### PR TITLE
test(storage): close agent run stores before cleanup

### DIFF
--- a/packages/storage/src/__tests__/agent-graph-supervisor-root-admission.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-supervisor-root-admission.test.ts
@@ -7,8 +7,8 @@ import type { RootExecutionDescriptor } from '@maka/core/agent-run';
 import { createSqliteAgentRunStore, type AdmitRootTurnInput } from '../agent-run-store.js';
 
 test('Agent Graph supervisor admission durably binds wake identity and Graph orchestration', async () => {
-  await withTempRoot(async (root) => {
-    const store = createSqliteAgentRunStore(root);
+  await withTempRoot(async (_root, openStore) => {
+    const store = openStore();
     const admitted = await store.admitRootTurn(admissionInput());
 
     assert.equal(admitted.kind, 'admitted');
@@ -18,7 +18,7 @@ test('Agent Graph supervisor admission durably binds wake identity and Graph orc
       source: 'host_api',
     });
 
-    const reopened = createSqliteAgentRunStore(root);
+    const reopened = openStore();
     assert.deepEqual(
       await reopened.readRootTurnAdmission('root-session', 'supervisor-turn'),
       admitted.admission,
@@ -27,8 +27,8 @@ test('Agent Graph supervisor admission durably binds wake identity and Graph orc
 });
 
 test('Agent Graph supervisor admission rejects malformed identity and non-Graph orchestration', async () => {
-  await withTempRoot(async (root) => {
-    const store = createSqliteAgentRunStore(root);
+  await withTempRoot(async (_root, openStore) => {
+    const store = openStore();
     await assert.rejects(
       () =>
         store.admitRootTurn(
@@ -95,11 +95,22 @@ function admissionInput(overrides: Partial<AdmitRootTurnInput> = {}): AdmitRootT
   };
 }
 
-async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
+async function withTempRoot(
+  run: (
+    root: string,
+    openStore: () => ReturnType<typeof createSqliteAgentRunStore>,
+  ) => Promise<void>,
+): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-graph-supervisor-admission-'));
+  const stores: ReturnType<typeof createSqliteAgentRunStore>[] = [];
   try {
-    await run(root);
+    await run(root, () => {
+      const store = createSqliteAgentRunStore(root);
+      stores.push(store);
+      return store;
+    });
   } finally {
+    for (const store of stores.reverse()) store.close?.();
     await rm(root, { recursive: true, force: true });
   }
 }

--- a/packages/storage/src/__tests__/claimed-agent-graph-root-admission.test.ts
+++ b/packages/storage/src/__tests__/claimed-agent-graph-root-admission.test.ts
@@ -9,8 +9,8 @@ import { createSqliteAgentRunStore, type AdmitRootTurnInput } from '../agent-run
 
 describe('claimed agent graph root admission', () => {
   test('round-trips an exact, deeply frozen durable descriptor', async () => {
-    await withTempRoot(async (root) => {
-      const store = createSqliteAgentRunStore(root);
+    await withTempRoot(async (_root, openStore) => {
+      const store = openStore();
       const result = await store.admitRootTurn(admissionInput());
       assert.equal(result.kind, 'admitted');
       assert.equal(result.admission.execution.kind, 'claimed_agent_graph_intent');
@@ -21,7 +21,7 @@ describe('claimed agent graph root admission', () => {
       assert.equal(Object.isFrozen(result.admission.execution), true);
       assert.equal(Object.isFrozen(result.admission.execution.claim), true);
 
-      const reopened = createSqliteAgentRunStore(root);
+      const reopened = openStore();
       const stored = await reopened.readRootTurnAdmission('session-child', 'turn-next');
       assert.deepEqual(stored, result.admission);
       assert.equal(Object.isFrozen(stored?.execution), true);
@@ -32,8 +32,8 @@ describe('claimed agent graph root admission', () => {
   });
 
   test('rejects descriptor unknown fields and malformed claims', async () => {
-    await withTempRoot(async (root) => {
-      const store = createSqliteAgentRunStore(root);
+    await withTempRoot(async (_root, openStore) => {
+      const store = openStore();
       await assert.rejects(
         () =>
           store.admitRootTurn(
@@ -78,8 +78,8 @@ describe('claimed agent graph root admission', () => {
   });
 
   test('rejects every claim target identity drift before writing admission', async () => {
-    await withTempRoot(async (root) => {
-      const store = createSqliteAgentRunStore(root);
+    await withTempRoot(async (root, openStore) => {
+      const store = openStore();
       for (const [field, value] of [
         ['targetSessionId', 'different-session'],
         ['targetTurnId', 'different-turn'],
@@ -118,8 +118,8 @@ describe('claimed agent graph root admission', () => {
   });
 
   test('rejects queue sources and a missing canonical UserMessage', async () => {
-    await withTempRoot(async (root) => {
-      const store = createSqliteAgentRunStore(root);
+    await withTempRoot(async (root, openStore) => {
+      const store = openStore();
       await assert.rejects(
         () =>
           store.admitRootTurn(
@@ -203,11 +203,22 @@ function baseClaim() {
   };
 }
 
-async function withTempRoot(run: (root: string) => Promise<void>): Promise<void> {
+async function withTempRoot(
+  run: (
+    root: string,
+    openStore: () => ReturnType<typeof createSqliteAgentRunStore>,
+  ) => Promise<void>,
+): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-claimed-graph-admission-'));
+  const stores: ReturnType<typeof createSqliteAgentRunStore>[] = [];
   try {
-    await run(root);
+    await run(root, () => {
+      const store = createSqliteAgentRunStore(root);
+      stores.push(store);
+      return store;
+    });
   } finally {
+    for (const store of stores.reverse()) store.close?.();
     await rm(root, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Summary

- make the two root-admission test fixtures own every SQLite AgentRun store they open
- close original and reopened stores in reverse order before removing each temporary root
- keep the change limited to test lifecycle cleanup with no filesystem retries or production behavior changes

Part of #2142 Phase 1.

## Why

The latest Windows baseline reports six cleanup failures across these two files after their assertions pass. Each test opens an AgentRun store, and two also open a second store, but the fixture removes the root without releasing the shared `runtime.sqlite` leases. Windows correctly rejects that unlink with `EBUSY`; POSIX hides the lifecycle omission.

## Validation

- `npm --workspace @maka/storage run build`
- `node --test packages/storage/dist/__tests__/agent-graph-supervisor-root-admission.test.js packages/storage/dist/__tests__/claimed-agent-graph-root-admission.test.js` (6 pass)
- `npx biome check packages/storage/src/__tests__/agent-graph-supervisor-root-admission.test.ts packages/storage/src/__tests__/claimed-agent-graph-root-admission.test.ts`
- `git diff --check`