### PR TITLE
fix(settings): govern the 外观 page structure, grouping, and copy

### DIFF
--- a/apps/desktop/src/main/__tests__/astryx-component-behavior.test.ts
+++ b/apps/desktop/src/main/__tests__/astryx-component-behavior.test.ts
@@ -17,7 +17,18 @@ const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 const LUCIDE_REACT_PACKAGE = ['lucide', 'react'].join('-');
 
 type RendererComponents = {
+  AppearanceSettingsPage(props: {
+    themePref: 'light' | 'dark' | 'auto';
+    themePalette: 'default';
+    onUpdate(): Promise<never>;
+    onThemeChange(): void;
+    onThemePaletteChange(): void;
+  }): ReactNode;
   ArtifactPreview(props: { record: ArtifactRecord }): ReactNode;
+  PersonalizationSettingsSection(props: {
+    settings: AppSettings;
+    onUpdate(): Promise<never>;
+  }): ReactNode;
   BotWeChatFields(props: {
     channel: BotChannelSettings;
     updateChannel(patch: Partial<BotChannelSettings>): Promise<boolean>;
@@ -224,6 +235,65 @@ describe('Astryx component behavior', () => {
     assert.match(markup, /class="astryx-table-scroll-wrapper/);
     assert.equal(markup.match(/<td\b[^>]*role="rowheader"/g)?.length, 1);
   });
+
+  it('files every appearance option tile under a named group', async () => {
+    const { AppearanceSettingsPage, LocaleProvider, ToastProvider } = await rendererComponents;
+    const markup = renderWithLocale(
+      LocaleProvider,
+      createElement(AppearanceSettingsPage, {
+        themePref: 'auto',
+        themePalette: 'default',
+        onUpdate: async () => { throw new Error('not called during render'); },
+        onThemeChange: () => undefined,
+        onThemePaletteChange: () => undefined,
+      }),
+      ToastProvider,
+    );
+
+    // One page root. The page used to wrap a second component that opened a
+    // `SettingsPage` of its own, so the page grid nested inside itself.
+    assert.equal(markup.match(/class="[^"]*settingsPageStack/g)?.length, 1);
+
+    // Each `<section>` is named by its own heading, and each option grid is a
+    // group named by the label the user can see above it — 主题 for the theme
+    // tiles, 编辑器主题 / 产品色调 for the two palette sets. Without this the
+    // page hands assistive tech 14 loose tiles with no statement of which set
+    // any of them belongs to.
+    for (const id of [
+      'settings-appearance-theme-heading',
+      'settings-appearance-palette-heading',
+      'settings-appearance-palette-editor-label',
+      'settings-appearance-palette-product-label',
+    ]) {
+      assert.match(markup, new RegExp(`id="${id}"`), `missing anchor id ${id}`);
+      assert.match(markup, new RegExp(`aria-labelledby="${id}"`), `nothing points at ${id}`);
+    }
+    assert.equal(markup.match(/role="group"/g)?.length, 3);
+    assert.equal(markup.match(/<section [^>]*aria-labelledby=/g)?.length, 2);
+
+    // 界面语言 lives on 通用 now; the 外观 page must not grow it back.
+    assert.doesNotMatch(markup, /界面语言/);
+  });
+
+  it('keeps the identity block a section of 通用, not a page of its own', async () => {
+    const { LocaleProvider, PersonalizationSettingsSection, ToastProvider } = await rendererComponents;
+    const settings = {
+      personalization: { displayName: '', assistantTone: '', uiLocale: 'zh' },
+    } as AppSettings;
+    const markup = renderWithLocale(
+      LocaleProvider,
+      createElement(PersonalizationSettingsSection, {
+        settings,
+        onUpdate: async () => { throw new Error('not called during render'); },
+      }),
+      ToastProvider,
+    );
+
+    // 通用 renders this inside its own page stack; a second one here nests the
+    // page grid in itself and doubles the section rhythm.
+    assert.doesNotMatch(markup, /settingsPageStack/);
+    assert.match(markup, /class="settingsSection"/);
+  });
 });
 
 async function importRendererComponents(): Promise<RendererComponents> {
@@ -234,10 +304,12 @@ async function importRendererComponents(): Promise<RendererComponents> {
   await build({
     stdin: {
       contents: [
+        "export { AppearanceSettingsPage } from './apps/desktop/src/renderer/settings/appearance-settings-page.tsx';",
         "export { ArtifactPreview } from './apps/desktop/src/renderer/artifact-preview.tsx';",
         "export { BotWeChatFields } from './apps/desktop/src/renderer/settings/bot-wechat-login.tsx';",
         "export { KeyboardHelpModal } from './apps/desktop/src/renderer/keyboard-help.tsx';",
         "export { OnboardingHero } from './apps/desktop/src/renderer/onboarding-hero.tsx';",
+        "export { PersonalizationSettingsSection } from './apps/desktop/src/renderer/settings/personalization-settings-section.tsx';",
         "export { ProviderCatalogPage } from './apps/desktop/src/renderer/settings/provider-catalog-page.tsx';",
         "export { UsageSettingsPage } from './apps/desktop/src/renderer/settings/usage-settings-page.tsx';",
         "export { LocaleProvider } from './packages/ui/dist/locale-context.js';",

--- a/apps/desktop/src/renderer/locales/settings-navigation-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-navigation-copy.ts
@@ -15,8 +15,8 @@ const SETTINGS_NAVIGATION_COPY_BY_LOCALE = {
       system: '系统',
     },
     sections: {
-      general: { label: '通用', description: '隐身、启动、对话默认与网络代理等系统偏好。' },
-      appearance: { label: '外观', description: '主题、配色与界面语言。' },
+      general: { label: '通用', description: '显示名称与界面语言、隐私与通知、对话默认与网络代理。' },
+      appearance: { label: '外观', description: '界面主题与调色板。' },
       projects: { label: '项目', description: '管理 Maka 认识的项目，以及新对话默认打开哪一个。' },
       models: { label: '模型', description: '模型连接、API key 与 OAuth 订阅管理。' },
       subagents: { label: '子 Agent', description: '配置主 Agent 可以自动选择的子 Agent、能力边界与模型。' },
@@ -39,8 +39,8 @@ const SETTINGS_NAVIGATION_COPY_BY_LOCALE = {
       system: 'System',
     },
     sections: {
-      general: { label: 'General', description: 'Privacy, startup, conversation defaults, and network proxy preferences.' },
-      appearance: { label: 'Appearance', description: 'Theme, color palette, and interface language.' },
+      general: { label: 'General', description: 'Display name and interface language, privacy and notifications, conversation defaults, and network proxy.' },
+      appearance: { label: 'Appearance', description: 'Interface theme and color palette.' },
       projects: { label: 'Projects', description: 'Manage the projects Maka knows about, and which one new conversations open in.' },
       models: { label: 'Models', description: 'Model connections, API keys, and OAuth subscriptions.' },
       subagents: { label: 'Subagents', description: 'Configure the subagents, capability boundaries, and models the main agent may select.' },

--- a/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
@@ -54,7 +54,6 @@ export type SettingsPreferencesCopy = {
     paletteLabels: Record<ThemePalette, string>;
     paletteHelp: Record<ThemePalette, string>;
     paletteGroups: { editor: string; product: string };
-    persistenceHelp: string;
   };
   pets: {
     import: string;
@@ -197,7 +196,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       themeOptions: { light: { label: '浅色', help: '始终使用浅色界面。' }, dark: { label: '深色', help: '始终使用深色界面。' }, auto: { label: '跟随系统', help: '匹配系统当前的浅色或深色偏好。' } },
       paletteLabels: { default: '默认', onedark: 'One Dark', 'catppuccin-mocha': 'Catppuccin Mocha', 'tokyo-night': 'Tokyo Night', nord: 'Nord', coral: '珊瑚', azure: '湖蓝', forest: '森林', dusk: '暮光', sand: '沙金', mono: '极简灰' },
       paletteHelp: { default: 'Maka 品牌蓝强调色', onedark: '编辑器经典深色', 'catppuccin-mocha': '紫调柔和深色', 'tokyo-night': '深蓝主题', nord: '北欧冷色', coral: '暖粉 / 珊瑚强调色', azure: '湖蓝强调色，干净冷静', forest: '深苔绿与暖蜂蜜强调色', dusk: '深紫罗兰与冷调画布', sand: '琥珀沙金与暖奶白', mono: '纯灰阶，无彩色干扰' },
-      paletteGroups: { editor: '编辑器主题', product: '产品色调' }, persistenceHelp: '切换会立即生效，并保存在本地外观设置里供下次启动使用。',
+      paletteGroups: { editor: '编辑器主题', product: '产品色调' },
     },
     pets: {
       import: '导入 PetPack', importing: '正在导入…', loading: '正在载入自定义宠物…',
@@ -234,7 +233,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       pets: 'Custom pets', petsHelp: 'Manage PetPacks you import yourself. Maka does not bundle or enable any pet by default.',
     },
     appearance: {
-      saveFailed: 'Could not save appearance settings', theme: 'Theme', palette: 'Color palette', themeOptions: { light: { label: 'Light', help: 'Always use the light interface.' }, dark: { label: 'Dark', help: 'Always use the dark interface.' }, auto: { label: 'Follow system', help: 'Match the current system appearance.' } }, paletteLabels: { default: 'Default', onedark: 'One Dark', 'catppuccin-mocha': 'Catppuccin Mocha', 'tokyo-night': 'Tokyo Night', nord: 'Nord', coral: 'Coral', azure: 'Azure', forest: 'Forest', dusk: 'Dusk', sand: 'Sand', mono: 'Monochrome' }, paletteHelp: { default: 'Maka brand-blue accent', onedark: 'Classic dark editor theme', 'catppuccin-mocha': 'Soft purple dark theme', 'tokyo-night': 'Deep-blue editor theme', nord: 'Cool Nordic colors', coral: 'Warm pink and coral accent', azure: 'Clean, calm blue accent', forest: 'Deep moss and warm honey', dusk: 'Deep violet on a cool canvas', sand: 'Amber sand and warm ivory', mono: 'Pure grayscale without color distraction' }, paletteGroups: { editor: 'Editor themes', product: 'Product colors' }, persistenceHelp: 'Changes apply immediately and are saved locally for the next launch.',
+      saveFailed: 'Could not save appearance settings', theme: 'Theme', palette: 'Color palette', themeOptions: { light: { label: 'Light', help: 'Always use the light interface.' }, dark: { label: 'Dark', help: 'Always use the dark interface.' }, auto: { label: 'Follow system', help: 'Match the current system appearance.' } }, paletteLabels: { default: 'Default', onedark: 'One Dark', 'catppuccin-mocha': 'Catppuccin Mocha', 'tokyo-night': 'Tokyo Night', nord: 'Nord', coral: 'Coral', azure: 'Azure', forest: 'Forest', dusk: 'Dusk', sand: 'Sand', mono: 'Monochrome' }, paletteHelp: { default: 'Maka brand-blue accent', onedark: 'Classic dark editor theme', 'catppuccin-mocha': 'Soft purple dark theme', 'tokyo-night': 'Deep-blue editor theme', nord: 'Cool Nordic colors', coral: 'Warm pink and coral accent', azure: 'Clean, calm blue accent', forest: 'Deep moss and warm honey', dusk: 'Deep violet on a cool canvas', sand: 'Amber sand and warm ivory', mono: 'Pure grayscale without color distraction' }, paletteGroups: { editor: 'Editor themes', product: 'Product colors' },
     },
     pets: {
       import: 'Import PetPack', importing: 'Importing…', loading: 'Loading custom pets…',

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -1,278 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
-import {
-  Grid,
-  HStack,
-  SegmentedControl,
-  SegmentedControlItem,
-  SelectableCard,
-  Text,
-  VStack,
-} from '@astryxdesign/core';
-import { SettingsField, SettingsPage, SettingsRow, SettingsSection } from './settings-section';
-import { SettingsExpandableRow } from './settings-expandable-row';
-import { getSettingsSharedCopy } from '../locales/settings-shared-copy';
-import type {
-  AppSettings,
-  PersonalizationSettings,
-  ThemePalette,
-  ThemePreference,
-  UiLocalePreference,
-  UpdateAppSettingsResult,
-} from '@maka/core';
-import {
-  TextArea,
-  TextInput,
-  useMountedRef,
-  useToast,
-  useUiLocale,
-} from '@maka/ui';
+import { useEffect, useRef } from 'react';
+import { Grid, HStack, SelectableCard, Text, VStack } from '@astryxdesign/core';
+import { SettingsPage, SettingsSection } from './settings-section';
+import type { ThemePalette, ThemePreference, UpdateAppSettingsResult } from '@maka/core';
+import { useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { getSettingsPreferencesCopy } from '../locales/settings-preferences-copy.js';
 import { CustomPetSettingsSection } from './custom-pet-settings-section.js';
-
-export function AppearanceSettingsPage(props: {
-  themePref: ThemePreference;
-  themePalette: ThemePalette;
-  settings: AppSettings;
-  onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
-  onThemeChange(pref: ThemePreference): void;
-  onThemePaletteChange(palette: ThemePalette): void;
-}) {
-  return (
-    <SettingsPage>
-      {/* Designer audit P2-13: 显示名称/界面语言/语气偏好 are identity, not
-          appearance — PersonalizationSettingsPage now renders on the 通用
-          page. The duplicated 主题 section heading is gone too: the page IS
-          the theme page now. */}
-      <ThemeSettingsPage
-        themePref={props.themePref}
-        themePalette={props.themePalette}
-        settings={props.settings}
-        onUpdate={props.onUpdate}
-        onThemeChange={props.onThemeChange}
-        onThemePaletteChange={props.onThemePaletteChange}
-      />
-    </SettingsPage>
-  );
-}
-
-// PR-TONE-AUTOSAVE-0: the personalization block used to be the page's ONLY
-// control with an explicit 保存 button + helper line — every neighboring row
-// (显示名称 / 界面语言 / 默认模型 / switches) persists silently on change or
-// blur. Two save models on one page. This block now autosaves like its
-// siblings: 显示名称 and 助手语气偏好 flush on blur (and the tone textarea
-// also debounces mid-typing), 界面语言 persists on change. No button, no
-// success toast — silence is the page's success language; only failures
-// surface (toast.error, like every sibling persist path).
-
-export function PersonalizationSettingsPage(props: {
-  settings: AppSettings;
-  onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
-}) {
-  const locale = useUiLocale();
-  const copy = getSettingsPreferencesCopy(locale).personalization;
-  const sections = getSettingsPreferencesCopy(locale).sections;
-  const sharedCopy = getSettingsSharedCopy(locale);
-  // At most one row in the group is open — the template's own rule.
-  const [expandedRow, setExpandedRow] = useState<string | null>(null);
-  // Persist the tone textarea this long after the user stops typing; blur
-  // flushes immediately regardless.
-  const TONE_AUTOSAVE_DEBOUNCE_MS = 800;
-  const value = props.settings.personalization;
-  const [displayName, setDisplayName] = useState(value.displayName);
-  const [assistantTone, setAssistantTone] = useState(value.assistantTone);
-  const [uiLocale, setUiLocale] = useState<UiLocalePreference>(value.uiLocale);
-  const toast = useToast();
-  const personalizationMountedRef = useMountedRef();
-  // The shared ticket limits stale failure feedback. Locale reconciliation
-  // has separate ownership because a later display-name or tone save must not
-  // suppress rollback of a failed language preference.
-  const persistTicketRef = useRef(0);
-  const localePersistTicketRef = useRef(0);
-  const persistPendingCountRef = useRef(0);
-  // Debounce timer for the tone textarea; flushed immediately on blur.
-  const toneDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      // Invalidate any in-flight save's late UI write, and drop the pending
-      // debounced flush so it can't fire after the panel closes.
-      persistTicketRef.current += 1;
-      localePersistTicketRef.current += 1;
-      if (toneDebounceRef.current) {
-        clearTimeout(toneDebounceRef.current);
-        toneDebounceRef.current = null;
-      }
-    };
-  }, []);
-
-  // PR-PERSONALIZATION-SYNC-0: sync form state when the persisted
-  // personalization changes externally. Two real scenarios:
-  //   1. Server-side sanitization (control chars, secret-shaped
-  //      patterns) rewrites the input on save — local state would
-  //      otherwise keep showing the raw typed value while the
-  //      persisted store has the sanitized version.
-  //   2. Another agent / background sync mutates settings while the
-  //      panel is open.
-  // Guarded on the pending-save count so an autosave that's still in
-  // flight doesn't get its optimistic local value reset out from under
-  // the user mid-edit — the sync only lands when nothing is in flight.
-  useEffect(() => {
-    if (persistPendingCountRef.current > 0) return;
-    setDisplayName(value.displayName);
-    setAssistantTone(value.assistantTone);
-    setUiLocale(value.uiLocale);
-  }, [value.displayName, value.assistantTone, value.uiLocale]);
-
-  // Shared persist path for every personalization field. Locale has its own
-  // last-write-wins lane so unrelated saves cannot steal rollback ownership.
-  // Returns whether the write landed. The autosaving fields ignore it — they
-  // have nowhere to put the answer — but a row that closes on save has to
-  // know, or a failed write collapses the row onto the old value and drops
-  // the draft with only a toast to show for it.
-  async function persistPersonalization(patch: Partial<PersonalizationSettings>): Promise<boolean> {
-    const ticket = ++persistTicketRef.current;
-    const localeTicket = patch.uiLocale === undefined ? null : ++localePersistTicketRef.current;
-    persistPendingCountRef.current += 1;
-    try {
-      const result = await props.onUpdate({ personalization: patch });
-      // Saved. An unmounted page just has nowhere left to reflect it.
-      if (!personalizationMountedRef.current) return true;
-      if (localeTicket !== null && localeTicket === localePersistTicketRef.current) {
-        setUiLocale(result.settings.personalization.uiLocale);
-      }
-      return true;
-    } catch (error) {
-      if (!personalizationMountedRef.current) return false;
-      if (localeTicket !== null && localeTicket === localePersistTicketRef.current) {
-        setUiLocale(value.uiLocale);
-      }
-      if (ticket === persistTicketRef.current) {
-        toast.error(copy.saveFailed, settingsActionErrorMessage(error, locale));
-      }
-      return false;
-    } finally {
-      persistPendingCountRef.current = Math.max(0, persistPendingCountRef.current - 1);
-    }
-  }
-
-  function persistLocale(next: UiLocalePreference) {
-    setUiLocale(next);
-    void persistPersonalization({ uiLocale: next });
-  }
-
-  // Tone autosave: debounce mid-typing so we don't hammer settings.update on
-  // every keystroke, then flush the pending value immediately on blur (blur
-  // wins — clears the timer and saves right away).
-  function scheduleToneSave(nextValue: string) {
-    if (toneDebounceRef.current) clearTimeout(toneDebounceRef.current);
-    toneDebounceRef.current = setTimeout(() => {
-      toneDebounceRef.current = null;
-      void persistPersonalization({ assistantTone: nextValue.trim().slice(0, 500) });
-    }, TONE_AUTOSAVE_DEBOUNCE_MS);
-  }
-
-  function flushTone(nextValue: string) {
-    if (toneDebounceRef.current) {
-      clearTimeout(toneDebounceRef.current);
-      toneDebounceRef.current = null;
-    }
-    void persistPersonalization({ assistantTone: nextValue.trim().slice(0, 500) });
-  }
-
-  return (
-    <SettingsPage>
-      {/* These editable values stay in the same grouped Settings card as the
-          neighboring preferences; the full-width tone field uses the vertical
-          row variant. */}
-      <SettingsSection title={sections.identity} description={sections.identityHelp}>
-        {/* A name you set once and then read. A permanently-open input asked
-            the user to fill in something already filled in, and its blur-save
-            gave them no way to back out of a change. The row reports the
-            settled value and opens on demand; Cancel puts the draft back. */}
-        <SettingsExpandableRow
-          label={copy.displayName}
-          value={value.displayName || copy.displayNameUnset}
-          actionLabel={value.displayName ? copy.displayNameChange : copy.displayNameSet}
-          isEditing={expandedRow === 'displayName'}
-          canSave={displayName.trim() !== value.displayName}
-          saveLabel={sharedCopy.save}
-          cancelLabel={sharedCopy.cancel}
-          onEdit={() => {
-            setDisplayName(value.displayName);
-            setExpandedRow('displayName');
-          }}
-          onCancel={() => {
-            setDisplayName(value.displayName);
-            setExpandedRow(null);
-          }}
-          onSave={async () => {
-            // Only close on a write that landed: a failed save leaves the row
-            // open with the draft intact, which is the promise explicit saving
-            // makes and blur-autosave could not keep.
-            if (await persistPersonalization({ displayName: displayName.trim().slice(0, 60) })) {
-              setExpandedRow(null);
-            }
-          }}
-        >
-          <TextInput
-            type="text"
-            value={displayName}
-            onChange={(value) => setDisplayName(value.slice(0, 60))}
-            placeholder={copy.displayNamePlaceholder}
-            label={copy.displayName}
-            description={copy.displayNameHelp}
-            isLabelHidden
-            width="100%"
-          />
-        </SettingsExpandableRow>
-
-        {/*
-          PR-LANG-PREF-0 (WAWQAQ msg `edc9cb41` + kenji `7e532892`
-          acceptance criteria): 自动 / 中文 / English. User explicit
-          choice wins over the temporary auto -> zh fallback;
-          e2e-fixture override wins over both (deterministic baselines).
-        */}
-        <SettingsRow
-          label={copy.interfaceLanguage}
-          description={copy.interfaceLanguageHelp}
-          end={<SegmentedControl
-            value={uiLocale}
-            onChange={(next) => persistLocale(next as UiLocalePreference)}
-            label={copy.interfaceLanguage}
-          >
-            {copy.localeOptions.map(([value, label]) => (
-              <SegmentedControlItem key={value} value={value} label={label} />
-            ))}
-          </SegmentedControl>}
-        />
-
-        <SettingsField>
-          {/* No fixed height style: it lands as inline style on the wrapper,
-              which pins the visible box while the inner textarea keeps its
-              native `resize: vertical` — dragging then moves only the grip.
-              `rows` owns the default height; the wrapper follows the
-              textarea, so user resizing works. */}
-          <TextArea
-            value={assistantTone}
-            onChange={(value) => {
-              const next = value.slice(0, 500);
-              setAssistantTone(next);
-              scheduleToneSave(next);
-            }}
-            onBlur={() => flushTone(assistantTone)}
-            placeholder={copy.assistantTonePlaceholder}
-            rows={4}
-            hasSpellCheck={false}
-            label={copy.assistantTone}
-            description={copy.assistantToneHelp}
-            width="100%"
-          />
-        </SettingsField>
-      </SettingsSection>
-    </SettingsPage>
-  );
-}
 
 /**
  * Mini chat-surface mockup rendered inside each theme radio tile. Replaces
@@ -330,10 +63,23 @@ const PALETTE_GROUPS: ReadonlyArray<{ id: 'editor' | 'product'; palettes: Readon
   { id: 'product', palettes: ['coral', 'azure', 'forest', 'dusk', 'sand', 'mono'] },
 ];
 
-function ThemeSettingsPage(props: {
+// The section headings and the palette sub-group labels are the page's only
+// landmarks, so they carry stable ids: `SettingsSection` wires each
+// `<section>` to its heading via aria-labelledby, and each option Grid is a
+// `role="group"` named by the label above it. Without them the page hands a
+// screen reader 14 loose option tiles with no statement of which set — 主题,
+// 编辑器主题, or 产品色调 — any one of them belongs to.
+const THEME_SECTION_HEADING_ID = 'settings-appearance-theme-heading';
+const PALETTE_SECTION_HEADING_ID = 'settings-appearance-palette-heading';
+const paletteGroupLabelId = (group: 'editor' | 'product') => `settings-appearance-palette-${group}-label`;
+
+export function AppearanceSettingsPage(props: {
   themePref: ThemePreference;
   themePalette: ThemePalette;
-  settings: AppSettings;
+  /* No `settings` prop: the page reads theme and palette from the two
+     dedicated props above and writes through `onUpdate`. It used to accept
+     the whole AppSettings object and pass it down one level, where nothing
+     ever read it. */
   onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
   onThemeChange(pref: ThemePreference): void;
   onThemePaletteChange(palette: ThemePalette): void;
@@ -384,6 +130,12 @@ function ThemeSettingsPage(props: {
   }
 
   return (
+    /* Designer audit P2-13: 显示名称/界面语言/语气偏好 are identity, not
+       appearance — they render on the 通用 page (see
+       personalization-settings-page.tsx). The page IS the theme page now, so
+       it owns the one `SettingsPage` root directly; it used to wrap a second
+       component that opened a `SettingsPage` of its own, nesting the page
+       grid inside itself. */
     <SettingsPage>
       {/* Both option grids are Astryx `Grid` + `SelectableCard`. SelectableCard
           is documented for exactly this ("plan pickers, filter chips, or option
@@ -397,8 +149,13 @@ function ThemeSettingsPage(props: {
           hand-written CSS: a border/radius/background recipe, a hover rule, a
           `:has(input:checked)` selected rule, and a stretched `label::after`
           overlay to make the tile clickable. All four are the library's job. */}
-      <SettingsSection variant="bare" title={sections.theme} description={sections.themeHelp}>
-        <Grid columns={{ minWidth: 180 }} gap={2}>
+      <SettingsSection
+        variant="bare"
+        titleId={THEME_SECTION_HEADING_ID}
+        title={sections.theme}
+        description={sections.themeHelp}
+      >
+        <Grid columns={{ minWidth: 180 }} gap={2} role="group" aria-labelledby={THEME_SECTION_HEADING_ID}>
           {(Object.entries(copy.themeOptions) as Array<[ThemePreference, { label: string; help: string }]>).map(([value, option]) => (
             <SelectableCard
               key={value}
@@ -419,20 +176,34 @@ function ThemeSettingsPage(props: {
         </Grid>
       </SettingsSection>
 
-      {/* persistenceHelp used to trail the page as a loose <p> with no owner.
-          It describes when a palette change lands, so it is the palette
-          group's description. */}
+      {/* The group description says what the palette governs AND when a switch
+          lands, the same two things `sections.themeHelp` says for the section
+          above — so both sections now take their lede from the same `sections`
+          namespace instead of one reaching into `appearance` for a loose
+          persistence line. */}
       <SettingsSection
         variant="bare"
+        titleId={PALETTE_SECTION_HEADING_ID}
         title={sections.palette}
-        description={copy.persistenceHelp}
+        description={sections.paletteHelp}
       >
         {PALETTE_GROUPS.map((group) => (
           <VStack key={group.id} gap={1.5}>
-            <Text type="supporting" size="sm" color="secondary" weight="medium">
+            <Text
+              id={paletteGroupLabelId(group.id)}
+              type="supporting"
+              size="sm"
+              color="secondary"
+              weight="medium"
+            >
               {copy.paletteGroups[group.id]}
             </Text>
-            <Grid columns={{ minWidth: 180 }} gap={2}>
+            <Grid
+              columns={{ minWidth: 180 }}
+              gap={2}
+              role="group"
+              aria-labelledby={paletteGroupLabelId(group.id)}
+            >
               {group.palettes.map((palette) => (
                 <SelectableCard
                   key={palette}

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { PersonalizationSettingsPage } from "./appearance-settings-page";
+import { PersonalizationSettingsSection } from "./personalization-settings-section";
 import {
   SettingsActions,
   SettingsField,
@@ -62,7 +62,7 @@ export function GeneralSettingsPage(props: {
       {/* Designer audit P2-13: identity fields (显示名称/界面语言/语气偏好)
           moved here from the 外观 page — they configure who you are to the
           app, not how the app looks. The component keeps its save flow. */}
-      <PersonalizationSettingsPage
+      <PersonalizationSettingsSection
         settings={props.settings}
         onUpdate={props.onUpdate}
       />

--- a/apps/desktop/src/renderer/settings/personalization-settings-section.tsx
+++ b/apps/desktop/src/renderer/settings/personalization-settings-section.tsx
@@ -1,0 +1,240 @@
+// The 身份 group of the 通用 page: how Maka addresses you, the interface
+// language, and the assistant tone.
+//
+// It used to live in appearance-settings-page.tsx as
+// `PersonalizationSettingsPage`, left behind when the designer audit (P2-13)
+// moved identity off 外观 and onto 通用 — so the only consumer,
+// general-settings-page.tsx, imported a *page* out of the *appearance* file
+// and rendered it inside its own `SettingsPage`, nesting one page stack in
+// another. It is one section of someone else's page: named, filed, and shaped
+// as one.
+import { useEffect, useRef, useState } from 'react';
+import { SegmentedControl, SegmentedControlItem } from '@astryxdesign/core';
+import { SettingsField, SettingsRow, SettingsSection } from './settings-section';
+import { SettingsExpandableRow } from './settings-expandable-row';
+import { getSettingsSharedCopy } from '../locales/settings-shared-copy';
+import type {
+  AppSettings,
+  PersonalizationSettings,
+  UiLocalePreference,
+  UpdateAppSettingsResult,
+} from '@maka/core';
+import { TextArea, TextInput, useMountedRef, useToast, useUiLocale } from '@maka/ui';
+import { settingsActionErrorMessage } from './settings-error-copy';
+import { getSettingsPreferencesCopy } from '../locales/settings-preferences-copy.js';
+
+// PR-TONE-AUTOSAVE-0: the personalization block used to be the page's ONLY
+// control with an explicit 保存 button + helper line — every neighboring row
+// (显示名称 / 界面语言 / 默认模型 / switches) persists silently on change or
+// blur. Two save models on one page. This block now autosaves like its
+// siblings: 显示名称 and 助手语气偏好 flush on blur (and the tone textarea
+// also debounces mid-typing), 界面语言 persists on change. No button, no
+// success toast — silence is the page's success language; only failures
+// surface (toast.error, like every sibling persist path).
+
+export function PersonalizationSettingsSection(props: {
+  settings: AppSettings;
+  onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
+}) {
+  const locale = useUiLocale();
+  const copy = getSettingsPreferencesCopy(locale).personalization;
+  const sections = getSettingsPreferencesCopy(locale).sections;
+  const sharedCopy = getSettingsSharedCopy(locale);
+  // At most one row in the group is open — the template's own rule.
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
+  // Persist the tone textarea this long after the user stops typing; blur
+  // flushes immediately regardless.
+  const TONE_AUTOSAVE_DEBOUNCE_MS = 800;
+  const value = props.settings.personalization;
+  const [displayName, setDisplayName] = useState(value.displayName);
+  const [assistantTone, setAssistantTone] = useState(value.assistantTone);
+  const [uiLocale, setUiLocale] = useState<UiLocalePreference>(value.uiLocale);
+  const toast = useToast();
+  const personalizationMountedRef = useMountedRef();
+  // The shared ticket limits stale failure feedback. Locale reconciliation
+  // has separate ownership because a later display-name or tone save must not
+  // suppress rollback of a failed language preference.
+  const persistTicketRef = useRef(0);
+  const localePersistTicketRef = useRef(0);
+  const persistPendingCountRef = useRef(0);
+  // Debounce timer for the tone textarea; flushed immediately on blur.
+  const toneDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      // Invalidate any in-flight save's late UI write, and drop the pending
+      // debounced flush so it can't fire after the panel closes.
+      persistTicketRef.current += 1;
+      localePersistTicketRef.current += 1;
+      if (toneDebounceRef.current) {
+        clearTimeout(toneDebounceRef.current);
+        toneDebounceRef.current = null;
+      }
+    };
+  }, []);
+
+  // PR-PERSONALIZATION-SYNC-0: sync form state when the persisted
+  // personalization changes externally. Two real scenarios:
+  //   1. Server-side sanitization (control chars, secret-shaped
+  //      patterns) rewrites the input on save — local state would
+  //      otherwise keep showing the raw typed value while the
+  //      persisted store has the sanitized version.
+  //   2. Another agent / background sync mutates settings while the
+  //      panel is open.
+  // Guarded on the pending-save count so an autosave that's still in
+  // flight doesn't get its optimistic local value reset out from under
+  // the user mid-edit — the sync only lands when nothing is in flight.
+  useEffect(() => {
+    if (persistPendingCountRef.current > 0) return;
+    setDisplayName(value.displayName);
+    setAssistantTone(value.assistantTone);
+    setUiLocale(value.uiLocale);
+  }, [value.displayName, value.assistantTone, value.uiLocale]);
+
+  // Shared persist path for every personalization field. Locale has its own
+  // last-write-wins lane so unrelated saves cannot steal rollback ownership.
+  // Returns whether the write landed. The autosaving fields ignore it — they
+  // have nowhere to put the answer — but a row that closes on save has to
+  // know, or a failed write collapses the row onto the old value and drops
+  // the draft with only a toast to show for it.
+  async function persistPersonalization(patch: Partial<PersonalizationSettings>): Promise<boolean> {
+    const ticket = ++persistTicketRef.current;
+    const localeTicket = patch.uiLocale === undefined ? null : ++localePersistTicketRef.current;
+    persistPendingCountRef.current += 1;
+    try {
+      const result = await props.onUpdate({ personalization: patch });
+      // Saved. An unmounted page just has nowhere left to reflect it.
+      if (!personalizationMountedRef.current) return true;
+      if (localeTicket !== null && localeTicket === localePersistTicketRef.current) {
+        setUiLocale(result.settings.personalization.uiLocale);
+      }
+      return true;
+    } catch (error) {
+      if (!personalizationMountedRef.current) return false;
+      if (localeTicket !== null && localeTicket === localePersistTicketRef.current) {
+        setUiLocale(value.uiLocale);
+      }
+      if (ticket === persistTicketRef.current) {
+        toast.error(copy.saveFailed, settingsActionErrorMessage(error, locale));
+      }
+      return false;
+    } finally {
+      persistPendingCountRef.current = Math.max(0, persistPendingCountRef.current - 1);
+    }
+  }
+
+  function persistLocale(next: UiLocalePreference) {
+    setUiLocale(next);
+    void persistPersonalization({ uiLocale: next });
+  }
+
+  // Tone autosave: debounce mid-typing so we don't hammer settings.update on
+  // every keystroke, then flush the pending value immediately on blur (blur
+  // wins — clears the timer and saves right away).
+  function scheduleToneSave(nextValue: string) {
+    if (toneDebounceRef.current) clearTimeout(toneDebounceRef.current);
+    toneDebounceRef.current = setTimeout(() => {
+      toneDebounceRef.current = null;
+      void persistPersonalization({ assistantTone: nextValue.trim().slice(0, 500) });
+    }, TONE_AUTOSAVE_DEBOUNCE_MS);
+  }
+
+  function flushTone(nextValue: string) {
+    if (toneDebounceRef.current) {
+      clearTimeout(toneDebounceRef.current);
+      toneDebounceRef.current = null;
+    }
+    void persistPersonalization({ assistantTone: nextValue.trim().slice(0, 500) });
+  }
+
+  return (
+    /* These editable values stay in the same grouped Settings card as the
+       neighboring preferences; the full-width tone field uses the vertical
+       row variant. The 通用 page owns the `SettingsPage` stack this sits in. */
+    <SettingsSection title={sections.identity} description={sections.identityHelp}>
+      {/* A name you set once and then read. A permanently-open input asked
+          the user to fill in something already filled in, and its blur-save
+          gave them no way to back out of a change. The row reports the
+          settled value and opens on demand; Cancel puts the draft back. */}
+      <SettingsExpandableRow
+        label={copy.displayName}
+        value={value.displayName || copy.displayNameUnset}
+        actionLabel={value.displayName ? copy.displayNameChange : copy.displayNameSet}
+        isEditing={expandedRow === 'displayName'}
+        canSave={displayName.trim() !== value.displayName}
+        saveLabel={sharedCopy.save}
+        cancelLabel={sharedCopy.cancel}
+        onEdit={() => {
+          setDisplayName(value.displayName);
+          setExpandedRow('displayName');
+        }}
+        onCancel={() => {
+          setDisplayName(value.displayName);
+          setExpandedRow(null);
+        }}
+        onSave={async () => {
+          // Only close on a write that landed: a failed save leaves the row
+          // open with the draft intact, which is the promise explicit saving
+          // makes and blur-autosave could not keep.
+          if (await persistPersonalization({ displayName: displayName.trim().slice(0, 60) })) {
+            setExpandedRow(null);
+          }
+        }}
+      >
+        <TextInput
+          type="text"
+          value={displayName}
+          onChange={(value) => setDisplayName(value.slice(0, 60))}
+          placeholder={copy.displayNamePlaceholder}
+          label={copy.displayName}
+          description={copy.displayNameHelp}
+          isLabelHidden
+          width="100%"
+        />
+      </SettingsExpandableRow>
+
+      {/*
+        PR-LANG-PREF-0 (WAWQAQ msg `edc9cb41` + kenji `7e532892`
+        acceptance criteria): 自动 / 中文 / English. User explicit
+        choice wins over the temporary auto -> zh fallback;
+        e2e-fixture override wins over both (deterministic baselines).
+      */}
+      <SettingsRow
+        label={copy.interfaceLanguage}
+        description={copy.interfaceLanguageHelp}
+        end={<SegmentedControl
+          value={uiLocale}
+          onChange={(next) => persistLocale(next as UiLocalePreference)}
+          label={copy.interfaceLanguage}
+        >
+          {copy.localeOptions.map(([value, label]) => (
+            <SegmentedControlItem key={value} value={value} label={label} />
+          ))}
+        </SegmentedControl>}
+      />
+
+      <SettingsField>
+        {/* No fixed height style: it lands as inline style on the wrapper,
+            which pins the visible box while the inner textarea keeps its
+            native `resize: vertical` — dragging then moves only the grip.
+            `rows` owns the default height; the wrapper follows the
+            textarea, so user resizing works. */}
+        <TextArea
+          value={assistantTone}
+          onChange={(value) => {
+            const next = value.slice(0, 500);
+            setAssistantTone(next);
+            scheduleToneSave(next);
+          }}
+          onBlur={() => flushTone(assistantTone)}
+          placeholder={copy.assistantTonePlaceholder}
+          rows={4}
+          hasSpellCheck={false}
+          label={copy.assistantTone}
+          description={copy.assistantToneHelp}
+          width="100%"
+        />
+      </SettingsField>
+    </SettingsSection>
+  );
+}

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -471,7 +471,6 @@ function SettingsPageBody(props: {
         <AppearanceSettingsPage
           themePref={props.themePref}
           themePalette={props.themePalette}
-          settings={props.settings}
           onUpdate={props.onUpdateSettings}
           onThemeChange={props.onThemeChange}
           onThemePaletteChange={props.onThemePaletteChange}


### PR DESCRIPTION
The 外观 page carries four leftovers from the moves that reshaped it — identity going to 通用 (P2-13), the Astryx open-group rebuild (#1972), and the settings-page kit (#1991). None of them change what the page looks like; all four change what it *is*.

### Page root

`AppearanceSettingsPage` wrapped a `ThemeSettingsPage` that opened a `SettingsPage` of its own, so the page grid nested inside itself — two `.settingsPageStack` in the rendered DOM. The page IS the theme page (its own comment says so), so it is now one component with one root.

通用 had the same defect from the other side: the identity block was exported as `PersonalizationSettingsPage` from `appearance-settings-page.tsx` and rendered inside `GeneralSettingsPage`'s own `SettingsPage`. It is one section of someone else's page, so it is now named, filed, and shaped as one — `personalization-settings-section.tsx`, returning a `SettingsSection`.

### Grouping

The 14 option tiles were loose in the accessibility tree: the two `<section>`s were unnamed landmarks (`SettingsSection` takes a `titleId` for exactly this and the page passed none), and the visible 编辑器主题 / 产品色调 labels had no programmatic relationship to the grids they head. Sections now carry `titleId`; each grid is a `role="group"` named by the label above it.

### Copy

The nav description still advertised 界面语言 on 外观 — a page that has not had it since P2-13 — while 通用, which does have it, never mentioned it. Both descriptions now say what their page holds, zh and en.

`sections.paletteHelp` was defined in both locales and read by nobody, while the palette section reached into `appearance.persistenceHelp` for its lede. The palette section now takes its lede from `sections`, the same namespace the theme section above it uses, and the unread key is gone.

`AppearanceSettingsPage` also stops taking a `settings` prop it only passed down one level to a component that never read it.

### Contract

`astryx-component-behavior.test.ts` pins one page stack, the four `aria-labelledby` anchors, three named groups, no 界面语言 on 外观, and that the identity block opens no page stack of its own.

### Verification

- `npm --workspace @maka/desktop run typecheck`
- `npm run format:check`
- `npm --workspace @maka/desktop run test:checks` (console / a11y / copy)
- `node scripts/check-dead-css.mjs --check`
- 1754 desktop tests, 0 failures
- Both pages re-rendered in a real Electron fixture window (`settings-appearance` / `settings-general`, light and dark): 外观 unchanged apart from the two copy lines, 通用 pixel identical, `.settingsPageStack` count 2 → 1 on each.

### Not in this PR

The palette picker's visual weaknesses are real but need a design conversation, so they are deliberately left alone: the swatches hardcode light-mode accents (`mono` is inverted in dark — `oklch(0.30 0 0)` previewed against a live dark accent of `oklch(0.92 0 0)`), the tiles preview the accent but never the canvas, the theme mock is palette-blind, and `columns={{minWidth:180}}` leaves orphan rows at 5 and 6 items. Happy to take any of them as a follow-up.