### PR TITLE
fix(runtime): classify expired probe budget as timeout

### DIFF
--- a/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
+++ b/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
@@ -241,7 +241,6 @@ describe('opencode-free anonymous runtime', () => {
   });
 
   test('bounds all fallback probes by one shared deadline', async () => {
-    const requestedModels: string[] = [];
     const connection: LlmConnection = {
       slug: 'opencode-free',
       name: 'OpenCode Free',
@@ -253,8 +252,6 @@ describe('opencode-free anonymous runtime', () => {
       updatedAt: 0,
     };
     const fakeFetch: typeof globalThis.fetch = async (_input, init) => {
-      const body = JSON.parse(String(init?.body)) as { model: string };
-      requestedModels.push(body.model);
       return await new Promise<Response>((_resolve, reject) => {
         const signal = init?.signal;
         assert.ok(signal);
@@ -273,6 +270,5 @@ describe('opencode-free anonymous runtime', () => {
     assert.equal(result.ok, false);
     assert.equal(result.errorClass, 'timeout');
     assert.ok(Date.now() - startedAt < 1_000);
-    assert.ok(requestedModels.length > 0);
   });
 });

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -148,7 +148,9 @@ async function testConnectionStrict(
     for (let index = 0; index < candidates.length; index += 1) {
       const candidate = candidates[index]!;
       const remainingMs = timeoutMs - (Date.now() - t0);
-      if (remainingMs <= 0) break;
+      if (remainingMs <= 0) {
+        return connectionTestFailure(new ConnectionEffectFetchError('timeout'), t0);
+      }
       const remainingCandidates = candidates.length - index;
       const attemptTimeoutMs = Math.max(1, Math.floor(remainingMs / remainingCandidates));
       try {
@@ -166,14 +168,7 @@ async function testConnectionStrict(
         lastFailure = connectionTestFailure(error, t0, true);
       }
     }
-    return (
-      lastFailure ?? {
-        ok: false,
-        errorMessage: 'No OpenCode Free model responded within the connection-test budget',
-        errorClass: 'provider_unavailable',
-        latencyMs: Date.now() - t0,
-      }
-    );
+    return lastFailure ?? connectionTestFailure(new ConnectionEffectFetchError('timeout'), t0);
   }
 
   return await testConnectionModel(connection, secret, testModel, fetchFn, t0, timeoutMs);


### PR DESCRIPTION
## Summary

- classify an already-exhausted shared OpenCode fallback budget as `timeout`
- avoid starting a provider request after the strict deadline has elapsed
- remove the test assumption that at least one probe must start before a shared deadline expires

## Why

If the process is descheduled for the full 40ms test budget before the first fallback iteration, no probe starts and `lastFailure` remains empty. The old fallback then reported `provider_unavailable`, even though the only known fact is that the shared deadline expired. This caused a CI flake and exposed an incorrect production edge classification.

## Validation

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/runtime run build`
- target deadline test repeated 30 times
- `node --test packages/runtime/dist/__tests__/opencode-free-anonymous.test.js` (7 pass)
- Biome and `git diff --check`