### PR TITLE
test(computer-use): synchronize session cancellation

### DIFF
--- a/packages/computer-use/src/__tests__/maka-cu-service.test.ts
+++ b/packages/computer-use/src/__tests__/maka-cu-service.test.ts
@@ -346,14 +346,20 @@ describe('maka-cu supervisor: cancelling a delivered request (§7.2/§7.3)', () 
   it('clears one session without ending the others', async () => {
     // Before: any session with a delivered request in flight SIGKILLed the
     // child, which invalidated every other session's observations too.
-    const { service, logPath } = makeService({ silent: ['observe'], timeoutMs: 8000 });
+    const { service, logPath } = makeService({
+      silent: ['observe'],
+      answerCancel: true,
+      timeoutMs: 8000,
+    });
     await service.ensureStarted();
     const generation = service.snapshot().generation;
     const call = service.withSession('session-a', () => service.call('observe', {}));
-    void call.catch(() => {});
-    await delay(80);
+    const barrier = await service.call('window.list', {});
+    assert.equal(barrier.ok, true, 'the later round trip proves observe reached the executor');
     service.clearSession('session-a');
-    await delay(80);
+    const cancelled = await call;
+    assert.equal(cancelled.ok, false);
+    assert.equal(cancelled.ok === false && cancelled.error.code, 'aborted');
     assert.equal(service.snapshot().state, 'ready');
     assert.equal(service.snapshot().generation, generation, 'the generation must survive');
     const records = await readRecords(logPath);


### PR DESCRIPTION
## Summary

- make the session-clear test wait for a same-pipe round trip before cancelling the silent request
- have the mock executor acknowledge cancellation and await that causal response before reading its log
- remove two fixed 80ms sleeps while retaining state, generation, and cancel-log assertions

## Why

`clearSession()` synchronously sends `$/cancel`; the CI flake came from reading the child-process log after a fixed delay that did not guarantee the child had consumed stdin and appended the record. The mock records cancel before sending its response, so awaiting that response is a deterministic acknowledgement instead of a scheduling guess.

## Validation

- `npm --workspace @maka/computer-use run build`
- target test repeated 30 times
- `node --test packages/computer-use/dist/__tests__/maka-cu-service.test.js` (17 pass)
- Biome and `git diff --check`