### PR TITLE
fix(runtime): compact and sanitize agent tool contracts

### DIFF
--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -168,36 +168,62 @@ describe('AgentSwarm adapter', () => {
     assert.match(refusal, /profile to one of: [^.]*\blocal_read\b/);
   });
 
-  test('rejects an item that sets both selectors, and says which mistake it is', async () => {
-    let starts = 0;
-    const runtime = buildRuntime(async () => {
-      starts += 1;
-      return childResult(starts);
+  test('prefers subagent_id when an item also carries a redundant legacy profile', async () => {
+    const parsed = (
+      buildAgentSwarmTool().parameters as {
+        safeParse(input: unknown): { success: boolean; data?: Record<string, unknown> };
+      }
+    ).safeParse({
+      items: [
+        {
+          item_id: 'both-selectors',
+          task: 'Inspect runtime validation.',
+          profile: 'not-a-real-profile',
+          subagent_id: 'reviewer',
+          ignored: true,
+        },
+      ],
     });
+    assert.equal(parsed.success, true);
+    assert.deepEqual(parsed.data?.items, [
+      {
+        item_id: 'both-selectors',
+        task: 'Inspect runtime validation.',
+        subagent_id: 'reviewer',
+      },
+    ]);
 
-    const result = await executeTool(
-      runtime,
-      buildAgentSwarmTool(),
+    const selectors: Array<{ profile: string; subagentId?: string }> = [];
+    const result = await buildAgentSwarmTool().impl(
       {
         items: [
           {
             item_id: 'both-selectors',
             task: 'Inspect runtime validation.',
-            profile: LOCAL_READ_AGENT_PROFILE,
+            profile: IMPLEMENTATION_AGENT_PROFILE,
             subagent_id: 'reviewer',
           },
         ],
       },
-      new AbortController(),
+      context({
+        listChildAgents: async () => ({
+          presets: [
+            {
+              id: 'reviewer',
+              profile: LOCAL_READ_AGENT_PROFILE,
+              availability: { status: 'available' },
+            },
+          ],
+        }),
+        spawnChildSession: async (input) => {
+          selectors.push({ profile: input.agentProfile, subagentId: input.subagentId });
+          return childResult(1);
+        },
+      }),
     );
 
-    assert.equal(starts, 0);
-    const refusal = String((result as { error?: unknown }).error);
-    // The opposite mistake must not read as the same sentence — a model told
-    // "neither is set" while it set both learns nothing it can act on.
-    assert.match(refusal, /subagent_id and profile are both set/);
-    assert.doesNotMatch(refusal, /Neither subagent_id nor profile is set/);
-    assert.match(refusal, /a user-approved preset id from agent_list/);
+    assert.deepEqual(selectors, [{ profile: LOCAL_READ_AGENT_PROFILE, subagentId: 'reviewer' }]);
+    assert.equal(result.status, 'completed');
   });
 
   test('accepts prompt_template with string items and rejects ambiguous template input', () => {
@@ -326,11 +352,26 @@ describe('AgentSwarm adapter', () => {
   });
 
   test('routes every configured template item through the selected subagent_id', async () => {
+    const parsed = (
+      buildAgentSwarmTool().parameters as {
+        safeParse(input: unknown): { success: boolean; data?: Record<string, unknown> };
+      }
+    ).safeParse({
+      prompt_template: `Review ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER}.`,
+      profile: 'not-a-real-profile',
+      subagent_id: 'fast-reader',
+      items: ['runtime'],
+    });
+    assert.equal(parsed.success, true);
+    assert.equal(parsed.data?.profile, undefined);
+    assert.equal(parsed.data?.subagent_id, 'fast-reader');
+
     const selectors: Array<{ profile: string; subagentId?: string }> = [];
     const tool = buildAgentSwarmTool();
     const result = await tool.impl(
       {
         prompt_template: `Review ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER}.`,
+        profile: IMPLEMENTATION_AGENT_PROFILE,
         subagent_id: 'fast-reader',
         items: ['runtime', 'desktop'],
         max_concurrency: 2,

--- a/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
@@ -180,7 +180,7 @@ describe('stream graph supervisor tools', () => {
     });
     try {
       const schema = updateTool.parameters as {
-        safeParse(value: unknown): { success: boolean };
+        safeParse(value: unknown): { success: boolean; data?: Record<string, unknown> };
       };
       assert.equal(schema.safeParse({}).success, false);
       assert.equal(
@@ -202,19 +202,18 @@ describe('stream graph supervisor tools', () => {
         }).success,
         false,
       );
-      assert.equal(
-        schema.safeParse({
-          graph_id: 'forged-graph',
-          add_work: [
-            {
-              agent_id: 'researcher',
-              instruction: 'Try to escape the bound graph.',
-              input_ids: [],
-            },
-          ],
-        }).success,
-        false,
-      );
+      const forgedIdentity = schema.safeParse({
+        graph_id: 'forged-graph',
+        add_work: [
+          {
+            agent_id: 'researcher',
+            instruction: 'Try to escape the bound graph.',
+            input_ids: [],
+          },
+        ],
+      });
+      assert.equal(forgedIdentity.success, true);
+      assert.equal(forgedIdentity.data?.graph_id, undefined);
       assert.equal(
         schema.safeParse({
           add_work: [
@@ -344,6 +343,41 @@ describe('stream graph supervisor tools', () => {
       observeGraph: async () => observationWithRecords('graph-provider-filled'),
     });
     try {
+      const parsed = (
+        updateTool.parameters as {
+          safeParse(input: unknown): { success: boolean; data?: Record<string, unknown> };
+        }
+      ).safeParse({
+        operation: 'add_work',
+        add_work: [
+          {
+            target_kind: 'new_agent',
+            agent_id: 'implementation',
+            operator_id: { malformed: true },
+            instruction: 'Implement node A.',
+            replacement_mode: 'none',
+            replaces: { malformed: true },
+            ignored: true,
+          },
+        ],
+        stop: 'not-an-array',
+        finish: { malformed: true },
+        ignored: true,
+      });
+      assert.equal(parsed.success, true);
+      assert.deepEqual(parsed.data, {
+        operation: 'add_work',
+        add_work: [
+          {
+            target_kind: 'new_agent',
+            agent_id: 'implementation',
+            instruction: 'Implement node A.',
+            input_ids: [],
+            replacement_mode: 'none',
+          },
+        ],
+      });
+
       const result = await updateTool.impl(
         {
           operation: 'add_work',

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -129,18 +129,34 @@ describe('subagent tools', () => {
     ).toEqual(['profile', 'subagent_id', 'task', 'write_back', 'isolation', 'task_id']);
   });
 
-  test('agent_spawn rejects task_id when task binding is unavailable', () => {
+  test('agent_spawn strips task_id when task binding is unavailable', () => {
     const schema = buildSubagentSpawnTool().parameters as {
-      safeParse(input: unknown): { success: boolean };
+      safeParse(input: unknown): { success: boolean; data?: Record<string, unknown> };
     };
 
-    expect(
-      schema.safeParse({
-        profile: LOCAL_READ_AGENT_PROFILE,
-        task: 'Inspect the repo.',
-        task_id: 'T1',
-      }).success,
-    ).toBe(false);
+    const parsed = schema.safeParse({
+      profile: LOCAL_READ_AGENT_PROFILE,
+      task: 'Inspect the repo.',
+      task_id: 'T1',
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toEqual({
+      profile: LOCAL_READ_AGENT_PROFILE,
+      task: 'Inspect the repo.',
+    });
+
+    const presetParsed = schema.safeParse({
+      profile: 'not-a-real-profile',
+      subagent_id: 'fast-reader',
+      task: 'Inspect the repo.',
+      task_id: { malformed: true },
+      ignored: true,
+    });
+    expect(presetParsed.success).toBe(true);
+    expect(presetParsed.data).toEqual({
+      subagent_id: 'fast-reader',
+      task: 'Inspect the repo.',
+    });
   });
 
   test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {
@@ -501,6 +517,7 @@ describe('subagent tools', () => {
       {
         profile: LOCAL_READ_AGENT_PROFILE,
         task: 'Inspect the runtime tests.',
+        task_id: 'ignored-without-task-binding',
       },
       {
         sessionId: 'session-1',
@@ -580,11 +597,15 @@ describe('subagent tools', () => {
     });
   });
 
-  test('agent_spawn resolves a configured subagent_id and never accepts a raw model target', async () => {
+  test('agent_spawn prefers a configured subagent_id over a redundant legacy profile', async () => {
     const tool = buildSubagentSpawnTool();
     const calls: Array<{ agentProfile: string; subagentId?: string; prompt?: string }> = [];
     await tool.impl(
-      { subagent_id: 'fast-reader', task: 'Inspect the runtime tests.' },
+      {
+        profile: IMPLEMENTATION_AGENT_PROFILE,
+        subagent_id: 'fast-reader',
+        task: 'Inspect the runtime tests.',
+      },
       {
         sessionId: 'session-1',
         turnId: 'parent-turn',
@@ -1130,7 +1151,28 @@ describe('subagent tools', () => {
         abortSignal: new AbortController().signal,
         emitOutput: () => {},
         listChildAgents: async () => ({
-          definitions: [{ id: LOCAL_READ_AGENT_ID }],
+          definitions: [
+            {
+              id: LOCAL_READ_AGENT_ID,
+              profile: LOCAL_READ_AGENT_PROFILE,
+              name: 'Local Read',
+              description: 'Read-only repository exploration.',
+              contract: { workspace: 'same_workspace', defaultWriteBack: 'summary' },
+              availability: { status: 'available' },
+            },
+          ],
+          presets: [
+            {
+              id: 'fast-reader',
+              name: 'Fast reader',
+              description: 'Cheap repository inspection.',
+              profile: LOCAL_READ_AGENT_PROFILE,
+              model: 'deepseek-v4-flash',
+              thinkingLevel: 'low',
+              availability: { status: 'available' },
+            },
+          ],
+          executions: [{ execution: { kind: 'legacy_child_run', runId: 'child-run' } }],
           runs: [{ runId: 'child-run', turnId: 'child-turn' }],
         }),
       },
@@ -1163,8 +1205,29 @@ describe('subagent tools', () => {
     expect(listTool.name).toBe(AGENT_LIST_TOOL_NAME);
     expect(outputTool.name).toBe(AGENT_OUTPUT_TOOL_NAME);
     expect(list).toEqual({
-      definitions: [{ id: LOCAL_READ_AGENT_ID }],
-      runs: [{ runId: 'child-run', turnId: 'child-turn' }],
+      presets: [
+        {
+          subagent_id: 'fast-reader',
+          name: 'Fast reader',
+          description: 'Cheap repository inspection.',
+          profile: LOCAL_READ_AGENT_PROFILE,
+          model: 'deepseek-v4-flash',
+          thinking_level: 'low',
+          status: 'available',
+        },
+      ],
+      legacy_profiles: [
+        {
+          profile: LOCAL_READ_AGENT_PROFILE,
+          name: 'Local Read',
+          description: 'Read-only repository exploration.',
+          workspace: 'same_workspace',
+          write_back: 'summary',
+          status: 'available',
+        },
+      ],
+      page: { returned: 1, total: 1 },
+      view: 'selection',
     });
     expect(output).toEqual({
       requested: {
@@ -1184,6 +1247,95 @@ describe('subagent tools', () => {
         },
       },
     });
+  });
+
+  test('agent_list keeps discovery compact, paginated, and free of execution history', async () => {
+    const listTool = buildSubagentListTool();
+    const schema = listTool.parameters as {
+      safeParse(input: unknown): {
+        success: boolean;
+        data?: { view?: string; cursor?: string };
+      };
+    };
+    expect(schema.safeParse({ ignored: true }).data).toEqual({ view: 'selection' });
+    expect(schema.safeParse({ cursor: 'not-a-cursor' }).success).toBe(false);
+
+    const catalog = {
+      definitions: [
+        {
+          profile: LOCAL_READ_AGENT_PROFILE,
+          name: 'Local Read',
+          description: 'Read-only repository exploration.',
+          contract: { workspace: 'same_workspace', defaultWriteBack: 'summary' },
+          availability: { status: 'available' },
+        },
+      ],
+      presets: Array.from({ length: 11 }, (_, index) => ({
+        id: `reader-${index}`,
+        name: `Reader ${index}`,
+        description: 'x'.repeat(1_000),
+        profile: LOCAL_READ_AGENT_PROFILE,
+        model: 'deepseek-v4-flash',
+        availability:
+          index === 10
+            ? { status: 'unavailable', reason: 'connection_disabled' }
+            : { status: 'available' },
+      })),
+      executions: Array.from({ length: 100 }, (_, index) => ({ runId: `run-${index}` })),
+      runs: Array.from({ length: 100 }, (_, index) => ({ runId: `legacy-run-${index}` })),
+    };
+    const call = async (
+      input: { view?: 'selection' | 'catalog'; cursor?: string },
+      source = catalog,
+    ) =>
+      (await listTool.impl(input, {
+        sessionId: 'session-1',
+        turnId: 'parent-turn',
+        cwd: '/tmp/cwd',
+        toolCallId: 'tool-list-compact',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+        listChildAgents: async () => source,
+      })) as Record<string, unknown>;
+
+    const first = await call({});
+    expect((first.presets as unknown[]).length).toBe(8);
+    expect(first.page).toEqual({ returned: 8, total: 10, next_cursor: '8' });
+    expect('definitions' in first).toBe(false);
+    expect('executions' in first).toBe(false);
+    expect('runs' in first).toBe(false);
+    expect(JSON.stringify(first).length < 8_192).toBe(true);
+
+    const second = await call({ cursor: '8' });
+    expect((second.presets as unknown[]).length).toBe(2);
+    expect(second.page).toEqual({ returned: 2, total: 10 });
+
+    const diagnosticTail = await call({ view: 'catalog', cursor: '8' });
+    expect(diagnosticTail.page).toEqual({ returned: 3, total: 11 });
+    expect((diagnosticTail.presets as Array<Record<string, unknown>>)[2]).toMatchObject({
+      subagent_id: 'reader-10',
+      status: 'unavailable',
+      reason: 'connection_disabled',
+    });
+
+    const worstCase = await call(
+      {},
+      {
+        ...catalog,
+        definitions: catalog.definitions.map((definition) => ({
+          ...definition,
+          name: 'n'.repeat(128),
+          description: 'd'.repeat(1_000),
+        })),
+        presets: catalog.presets.map((preset, index) => ({
+          ...preset,
+          id: `reader-${index}`.padEnd(128, 'x'),
+          name: 'n'.repeat(128),
+          model: 'm'.repeat(500),
+        })),
+      },
+    );
+    expect(JSON.stringify(worstCase).length <= 7_000).toBe(true);
   });
 
   test('agent_output accepts linked child-session and legacy run locators', () => {
@@ -1214,6 +1366,24 @@ describe('subagent tools', () => {
 
   test('agent_output uses an explicit locator when a provider fills unrelated fields', async () => {
     const outputTool = buildSubagentOutputTool();
+    const parsed = (
+      outputTool.parameters as {
+        safeParse(input: unknown): { success: boolean; data?: Record<string, unknown> };
+      }
+    ).safeParse({
+      locator: 'child_session_run',
+      child_session_id: 'child-session',
+      run_id: 'child-run',
+      turn_id: { malformed: true },
+      ignored: true,
+    });
+    expect(parsed.success).toBe(true);
+    expect(parsed.data).toEqual({
+      locator: 'child_session_run',
+      child_session_id: 'child-session',
+      run_id: 'child-run',
+    });
+
     const output = await outputTool.impl(
       {
         locator: 'child_session_run',

--- a/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-capability-backend.test.ts
@@ -145,6 +145,47 @@ describe('AiSdkBackend tool-result archive capability', () => {
 
     assert.equal(seen[0]?.sessionId, 'session-invoking');
   });
+
+  test('the decoder ignores itemId outside query instead of refusing the call', async () => {
+    const archive = createToolResultArchiveCapability({
+      archiveToolResult: async () => ({ artifactId: 'artifact-1' }),
+      readToolResultArchive: async () => ({ ok: false, reason: 'not_found' }),
+      readArchivedToolResultResource: async () => ({
+        ok: true,
+        serializedResult: JSON.stringify({ presets: [{ id: 'fast-reader' }] }),
+      }),
+    });
+    const parameters = archive.archiveReadTool.parameters as {
+      validate(
+        input: unknown,
+      ): Promise<{ success: true; value: unknown } | { success: false; error: unknown }>;
+    };
+    const parsed = await parameters.validate({
+      ref: buildToolResultArchiveResourceRef({
+        artifactId: `tool-result-archive-${'a'.repeat(32)}`,
+        bodySha256: 'b'.repeat(64),
+        originalBytes: 128,
+      }),
+      operation: 'inspect',
+      itemId: { malformed: true },
+      offset: 'not-a-number',
+      limit: -1,
+      ignored: true,
+    });
+
+    assert.equal(parsed.success, true);
+
+    const missingQueryItem = await parameters.validate({
+      ref: buildToolResultArchiveResourceRef({
+        artifactId: `tool-result-archive-${'a'.repeat(32)}`,
+        bodySha256: 'b'.repeat(64),
+        originalBytes: 128,
+      }),
+      operation: 'query',
+      ignored: true,
+    });
+    assert.equal(missingQueryItem.success, false, 'required branch fields still fail closed');
+  });
 });
 
 function toolContext(): MakaToolContext {

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -473,71 +473,67 @@ function traceAgentSwarm(
 }
 
 /**
- * Why a call was refused for its child selector, and what would work instead.
- *
- * The two failures read very differently to a model and shared one sentence:
- * "Provide exactly one of subagent_id or legacy profile." It named neither which
- * mistake this was, nor a single value that would have been accepted. A model
- * that got two of three items right and slipped on the third was told only that
- * — and the field list `formatToolArgsViolationText` appends is the *top-level*
- * one, which is not where the violation was (`path: ["items", 2]`). So name the
- * mistake, and name both ways out: the preset ids live behind `agent_list`, and
- * the legacy profiles are a closed set this schema already knows.
+ * Explain the one selector error that remains after redundant fields are
+ * cleaned: neither the preferred preset nor a legacy profile was provided.
  */
-function childSelectorIssueMessage(bothSet: boolean, profiles: readonly string[]): string {
-  const waysOut =
+function missingChildSelectorMessage(profiles: readonly string[]): string {
+  return (
+    'Neither subagent_id nor profile is set, so no child is selected. ' +
     `Set subagent_id to a user-approved preset id from agent_list, ` +
-    `or profile to one of: ${profiles.join(', ')}.`;
-  return bothSet
-    ? `subagent_id and profile are both set; exactly one of them selects the child. ${waysOut}`
-    : `Neither subagent_id nor profile is set, so no child is selected. ${waysOut}`;
+    `or profile to one of: ${profiles.join(', ')}.`
+  );
 }
 
 function agentSwarmInputSchema(
   definitions: readonly AgentDefinition[],
   profiles: ReturnType<typeof agentProfilesForDefinitions>,
 ) {
-  const itemSchema = z
-    .object({
-      item_id: z
-        .string()
-        .min(1)
-        .max(TASK_ID_MAX_CHARS)
-        .refine(isSafeTaskId)
-        .describe('Stable item id (letters, digits, dot, underscore, colon, or dash).'),
-      profile: z.enum(profiles).optional().describe('Legacy child capability profile.'),
-      subagent_id: z
-        .string()
-        .min(1)
-        .max(128)
-        .refine(isSafeSubagentPresetId)
-        .optional()
-        .describe('User-approved subagent preset id from agent_list.'),
-      task: z
-        .string()
-        .min(1)
-        .max(AGENT_SWARM_TASK_MAX_CHARS)
-        .describe('Bounded, self-contained task for this item.'),
-      write_back: z
-        .enum(AGENT_SWARM_WRITE_BACK_MODES)
-        .optional()
-        .describe('Requested child write-back mode.'),
-      isolation: z
-        .enum(AGENT_SWARM_ISOLATION_MODES)
-        .optional()
-        .describe('Requested child workspace isolation.'),
-    })
-    .superRefine((input, ctx) => {
-      if (Boolean(input.profile) === Boolean(input.subagent_id)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: childSelectorIssueMessage(Boolean(input.profile), profiles),
-        });
-        return;
-      }
-      if (!input.profile) return;
-      addAgentContractIssues(input, ctx, definitions);
-    });
+  const itemSchema = z.preprocess(
+    cleanPreferredSubagentSelector,
+    z
+      .object({
+        item_id: z
+          .string()
+          .min(1)
+          .max(TASK_ID_MAX_CHARS)
+          .refine(isSafeTaskId)
+          .describe('Stable item id (letters, digits, dot, underscore, colon, or dash).'),
+        profile: z.enum(profiles).optional().describe('Legacy child capability profile.'),
+        subagent_id: z
+          .string()
+          .min(1)
+          .max(128)
+          .refine(isSafeSubagentPresetId)
+          .optional()
+          .describe('User-approved subagent preset id from agent_list.'),
+        task: z
+          .string()
+          .min(1)
+          .max(AGENT_SWARM_TASK_MAX_CHARS)
+          .describe('Bounded, self-contained task for this item.'),
+        write_back: z
+          .enum(AGENT_SWARM_WRITE_BACK_MODES)
+          .optional()
+          .describe('Requested child write-back mode.'),
+        isolation: z
+          .enum(AGENT_SWARM_ISOLATION_MODES)
+          .optional()
+          .describe('Requested child workspace isolation.'),
+      })
+      .strip()
+      .superRefine((input, ctx) => {
+        if (!input.profile && !input.subagent_id) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: missingChildSelectorMessage(profiles),
+          });
+          return;
+        }
+        if (input.subagent_id) return;
+        if (!input.profile) return;
+        addAgentContractIssues(input, ctx, definitions);
+      }),
+  );
 
   const explicitItemsSchema = z
     .array(itemSchema)
@@ -559,156 +555,167 @@ function agentSwarmInputSchema(
     });
   const templateItemsSchema = z.array(z.string().trim().min(1)).min(1).max(AGENT_SWARM_MAX_ITEMS);
 
-  return z
-    .object({
-      items: z.union([explicitItemsSchema, templateItemsSchema]).optional(),
-      prompt_template: z
-        .string()
-        .trim()
-        .min(1)
-        .max(AGENT_SWARM_TASK_MAX_CHARS)
-        .optional()
-        .describe(
-          `Shared task template for string items; every ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER} occurrence is replaced.`,
-        ),
-      profile: z
-        .enum(profiles)
-        .optional()
-        .describe('Shared child profile for prompt_template string items.'),
-      subagent_id: z
-        .string()
-        .min(1)
-        .max(128)
-        .refine(isSafeSubagentPresetId)
-        .optional()
-        .describe('Shared user-approved subagent preset id for string items.'),
-      resume_run_ids: z
-        .record(z.string().trim().min(1), z.string().trim().min(1).max(AGENT_SWARM_TASK_MAX_CHARS))
-        .optional()
-        .describe('Map of terminal child AgentRun runId to its continuation prompt.'),
-      max_concurrency: z
-        .number()
-        .int()
-        .min(1)
-        .max(AGENT_SWARM_MAX_CONCURRENCY)
-        .default(AGENT_SWARM_DEFAULT_CONCURRENCY)
-        .describe('Maximum number of child items active inside this batch.'),
-    })
-    .superRefine((input, ctx) => {
-      const resumeCount = Object.keys(input.resume_run_ids ?? {}).length;
-      const itemCount = input.items?.length ?? 0;
-      if (resumeCount + itemCount < 1) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: 'Agent swarm requires at least one item or resume_run_ids entry.',
-        });
-      }
-      if (resumeCount + itemCount > AGENT_SWARM_MAX_ITEMS) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Agent swarm supports at most ${AGENT_SWARM_MAX_ITEMS} total items.`,
-        });
-      }
+  return z.preprocess(
+    cleanPreferredSubagentSelector,
+    z
+      .object({
+        items: z.union([explicitItemsSchema, templateItemsSchema]).optional(),
+        prompt_template: z
+          .string()
+          .trim()
+          .min(1)
+          .max(AGENT_SWARM_TASK_MAX_CHARS)
+          .optional()
+          .describe(
+            `Shared task template for string items; every ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER} occurrence is replaced.`,
+          ),
+        profile: z
+          .enum(profiles)
+          .optional()
+          .describe('Shared child profile for prompt_template string items.'),
+        subagent_id: z
+          .string()
+          .min(1)
+          .max(128)
+          .refine(isSafeSubagentPresetId)
+          .optional()
+          .describe('Shared user-approved subagent preset id for string items.'),
+        resume_run_ids: z
+          .record(
+            z.string().trim().min(1),
+            z.string().trim().min(1).max(AGENT_SWARM_TASK_MAX_CHARS),
+          )
+          .optional()
+          .describe('Map of terminal child AgentRun runId to its continuation prompt.'),
+        max_concurrency: z
+          .number()
+          .int()
+          .min(1)
+          .max(AGENT_SWARM_MAX_CONCURRENCY)
+          .default(AGENT_SWARM_DEFAULT_CONCURRENCY)
+          .describe('Maximum number of child items active inside this batch.'),
+      })
+      .strip()
+      .superRefine((input, ctx) => {
+        const resumeCount = Object.keys(input.resume_run_ids ?? {}).length;
+        const itemCount = input.items?.length ?? 0;
+        if (resumeCount + itemCount < 1) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Agent swarm requires at least one item or resume_run_ids entry.',
+          });
+        }
+        if (resumeCount + itemCount > AGENT_SWARM_MAX_ITEMS) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `Agent swarm supports at most ${AGENT_SWARM_MAX_ITEMS} total items.`,
+          });
+        }
 
-      if (!input.items) {
-        if (input.prompt_template !== undefined) {
+        if (!input.items) {
+          if (input.prompt_template !== undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['prompt_template'],
+              message: 'prompt_template requires string items.',
+            });
+          }
+          if (input.profile !== undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['profile'],
+              message: 'profile requires string items.',
+            });
+          }
+          if (input.subagent_id !== undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['subagent_id'],
+              message: 'subagent_id requires string items.',
+            });
+          }
+          return;
+        }
+
+        const templateItems = input.items.every((item) => typeof item === 'string');
+        if (!templateItems) {
+          if (input.prompt_template !== undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['prompt_template'],
+              message: 'prompt_template is only valid when items are strings.',
+            });
+          }
+          if (input.profile !== undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['profile'],
+              message: 'profile is specified per item when items are structured.',
+            });
+          }
+          if (input.subagent_id !== undefined) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['subagent_id'],
+              message: 'subagent_id is specified per item when items are structured.',
+            });
+          }
+          return;
+        }
+
+        if (input.prompt_template === undefined) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ['prompt_template'],
-            message: 'prompt_template requires string items.',
+            message: 'prompt_template is required when items are strings.',
           });
+          return;
         }
-        if (input.profile !== undefined) {
+        if (!input.profile && !input.subagent_id) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            path: ['profile'],
-            message: 'profile requires string items.',
+            message: `String items share one selector for the whole batch. ${missingChildSelectorMessage(profiles)}`,
           });
         }
-        if (input.subagent_id !== undefined) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['subagent_id'],
-            message: 'subagent_id requires string items.',
-          });
-        }
-        return;
-      }
-
-      const templateItems = input.items.every((item) => typeof item === 'string');
-      if (!templateItems) {
-        if (input.prompt_template !== undefined) {
+        if (!input.prompt_template.includes(AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: ['prompt_template'],
-            message: 'prompt_template is only valid when items are strings.',
+            message: `prompt_template must include ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER}.`,
           });
+          return;
         }
-        if (input.profile !== undefined) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['profile'],
-            message: 'profile is specified per item when items are structured.',
-          });
-        }
-        if (input.subagent_id !== undefined) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['subagent_id'],
-            message: 'subagent_id is specified per item when items are structured.',
-          });
-        }
-        return;
-      }
 
-      if (input.prompt_template === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['prompt_template'],
-          message: 'prompt_template is required when items are strings.',
-        });
-        return;
-      }
-      if (Boolean(input.profile) === Boolean(input.subagent_id)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `String items share one selector for the whole batch. ${childSelectorIssueMessage(
-            Boolean(input.profile),
-            profiles,
-          )}`,
-        });
-      }
-      if (!input.prompt_template.includes(AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['prompt_template'],
-          message: `prompt_template must include ${AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER}.`,
-        });
-        return;
-      }
+        const seenTasks = new Set<string>();
+        for (let index = 0; index < input.items.length; index += 1) {
+          const item = input.items[index];
+          if (typeof item !== 'string') continue;
+          const task = expandAgentSwarmPromptTemplate(input.prompt_template, item);
+          if (task.length > AGENT_SWARM_TASK_MAX_CHARS) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['items', index],
+              message: `Expanded agent swarm task exceeds ${AGENT_SWARM_TASK_MAX_CHARS} characters.`,
+            });
+          }
+          if (seenTasks.has(task)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['items', index],
+              message: 'Template items must produce distinct agent swarm tasks.',
+            });
+          }
+          seenTasks.add(task);
+        }
+      }),
+  );
+}
 
-      const seenTasks = new Set<string>();
-      for (let index = 0; index < input.items.length; index += 1) {
-        const item = input.items[index];
-        if (typeof item !== 'string') continue;
-        const task = expandAgentSwarmPromptTemplate(input.prompt_template, item);
-        if (task.length > AGENT_SWARM_TASK_MAX_CHARS) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['items', index],
-            message: `Expanded agent swarm task exceeds ${AGENT_SWARM_TASK_MAX_CHARS} characters.`,
-          });
-        }
-        if (seenTasks.has(task)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['items', index],
-            message: 'Template items must produce distinct agent swarm tasks.',
-          });
-        }
-        seenTasks.add(task);
-      }
-    });
+function cleanPreferredSubagentSelector(input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const cleaned = { ...(input as Record<string, unknown>) };
+  if (cleaned.subagent_id !== undefined) delete cleaned.profile;
+  return cleaned;
 }
 
 function addAgentContractIssues(
@@ -854,7 +861,7 @@ function preflightAgentSwarmInput(
       throw new Error(`Agent swarm item "${item.item_id}" has an invalid task.`);
     }
 
-    const profile = item.profile ?? presetProfiles.get(item.subagent_id!);
+    const profile = item.subagent_id ? presetProfiles.get(item.subagent_id) : item.profile;
     if (!profile) {
       throw new Error(
         `Unknown or unavailable subagent_id "${item.subagent_id}". Call agent_list first.`,
@@ -906,8 +913,8 @@ function normalizeAgentSwarmItems(input: AgentSwarmToolInput): AgentSwarmExplici
   if (!('prompt_template' in input) || typeof input.prompt_template !== 'string') {
     throw new Error('prompt_template is required when agent swarm items are strings.');
   }
-  if (Boolean(input.profile) === Boolean(input.subagent_id)) {
-    throw new Error('String items require exactly one of subagent_id or legacy profile.');
+  if (!input.profile && !input.subagent_id) {
+    throw new Error('String items require subagent_id or legacy profile.');
   }
 
   const promptTemplate = input.prompt_template.trim();

--- a/packages/runtime/src/archive-read-tool.ts
+++ b/packages/runtime/src/archive-read-tool.ts
@@ -10,54 +10,50 @@ import {
 export const ARCHIVE_READ_TOOL_NAME = 'ArchiveRead';
 
 export function buildArchiveReadTool(reader: ToolResultArchiveResourceReader): MakaTool {
-  const parameters = z
-    .object({
-      ref: z
-        .string()
-        .describe('A maka://archive/... ref returned in an archived tool-result placeholder'),
-      operation: z
-        .enum(['inspect', 'read', 'query'])
-        .default('inspect')
-        .describe(
-          'inspect lists archive metadata/items; query reads one structured item; read returns one bounded raw page',
-        ),
-      offset: z
-        .number()
-        .int()
-        .nonnegative()
-        .optional()
-        .describe('Zero-based character offset for read/query pagination'),
-      limit: z
-        .number()
-        .int()
-        .positive()
-        .max(TOOL_RESULT_ARCHIVE_MAX_LIMIT)
-        .optional()
-        .describe(`Maximum returned characters, capped at ${TOOL_RESULT_ARCHIVE_MAX_LIMIT}`),
-      itemId: z
-        .string()
-        .min(1)
-        .max(256)
-        .optional()
-        .describe('Structured item id returned by inspect; required for query'),
-    })
-    .strict()
-    .superRefine((value, ctx) => {
-      if (value.operation === 'query' && !value.itemId) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['itemId'],
-          message: 'itemId is required for query',
-        });
-      }
-      if (value.operation !== 'query' && value.itemId !== undefined) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['itemId'],
-          message: 'itemId is only valid for query',
-        });
-      }
-    });
+  const parameters = z.preprocess(
+    cleanArchiveReadInput,
+    z
+      .object({
+        ref: z
+          .string()
+          .describe('A maka://archive/... ref returned in an archived tool-result placeholder'),
+        operation: z
+          .enum(['inspect', 'read', 'query'])
+          .default('inspect')
+          .describe(
+            'inspect lists archive metadata/items; query reads one structured item; read returns one bounded raw page',
+          ),
+        offset: z
+          .number()
+          .int()
+          .nonnegative()
+          .optional()
+          .describe('Zero-based character offset for read/query pagination'),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .max(TOOL_RESULT_ARCHIVE_MAX_LIMIT)
+          .optional()
+          .describe(`Maximum returned characters, capped at ${TOOL_RESULT_ARCHIVE_MAX_LIMIT}`),
+        itemId: z
+          .string()
+          .min(1)
+          .max(256)
+          .optional()
+          .describe('Structured item id returned by inspect; required for query'),
+      })
+      .strip()
+      .superRefine((value, ctx) => {
+        if (value.operation === 'query' && !value.itemId) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['itemId'],
+            message: 'itemId is required for query',
+          });
+        }
+      }),
+  );
   const providerSchema = zodSchema(parameters);
   return {
     name: ARCHIVE_READ_TOOL_NAME,
@@ -76,4 +72,16 @@ export function buildArchiveReadTool(reader: ToolResultArchiveResourceReader): M
     impl: async (input, ctx) =>
       readToolResultArchiveResource(reader, ctx.sessionId, input, ctx.abortSignal),
   };
+}
+
+function cleanArchiveReadInput(input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const cleaned = { ...(input as Record<string, unknown>) };
+  const operation = cleaned.operation ?? 'inspect';
+  if (operation !== 'query') delete cleaned.itemId;
+  if (operation === 'inspect') {
+    delete cleaned.offset;
+    delete cleaned.limit;
+  }
+  return cleaned;
 }

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -56,69 +56,72 @@ const cursorSchema = z
   .max(512)
   .refine((value) => !/[\u0000-\u001f\u007f]/.test(value), 'Cursor contains control characters');
 
-const addWorkSchema = z
-  .object({
-    target_kind: z
-      .enum(['new_agent', 'existing_operator'])
-      .optional()
-      .describe(
-        'Explicit target discriminator. Use new_agent with agent_id, or existing_operator with operator_id. When present, unrelated optional identity fields are ignored.',
-      ),
-    agent_id: identitySchema
-      .optional()
-      .describe(
-        'Catalog agent id for NEW graph work (for example "implementation"). Set agent_id OR operator_id, never both.',
-      ),
-    operator_id: identitySchema
-      .optional()
-      .describe(
-        'Runtime id of an EXISTING graph operator returned by view_agent_graph. Use only for follow-up work; set operator_id OR agent_id, never both.',
-      ),
-    instruction: z.string().trim().min(1).max(AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS),
-    input_ids: z
-      .array(identitySchema)
-      .max(AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS)
-      .default([])
-      .describe('Durable record or result ids that form this work item input frontier.'),
-    replaces: identitySchema
-      .optional()
-      .describe('Existing work or activation superseded by this request.'),
-    replacement_mode: z
-      .enum(['none', 'replace'])
-      .optional()
-      .describe(
-        'Use none for normal work. Use replace only with a real replaces id. When none, any provider-filled replaces placeholder is ignored.',
-      ),
-  })
-  .strict()
-  .superRefine((value, ctx) => {
-    const validTarget = value.target_kind
-      ? value.target_kind === 'new_agent'
-        ? Boolean(value.agent_id)
-        : Boolean(value.operator_id)
-      : (value.agent_id ? 1 : 0) + (value.operator_id ? 1 : 0) === 1;
-    if (!validTarget) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'Set target_kind=new_agent with agent_id, target_kind=existing_operator with operator_id, or omit target_kind and provide exactly one identity',
-      });
-    }
-    if (value.replacement_mode === 'replace' && !value.replaces) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'replacement_mode=replace requires replaces',
-      });
-    }
-    addDuplicateIssue(ctx, value.input_ids, ['input_ids']);
-  });
+const addWorkSchema = z.preprocess(
+  cleanAddWorkInput,
+  z
+    .object({
+      target_kind: z
+        .enum(['new_agent', 'existing_operator'])
+        .optional()
+        .describe(
+          'Explicit target discriminator. Use new_agent with agent_id, or existing_operator with operator_id. When present, unrelated optional identity fields are ignored.',
+        ),
+      agent_id: identitySchema
+        .optional()
+        .describe(
+          'Catalog agent id for NEW graph work (for example "implementation"). Set agent_id OR operator_id, never both.',
+        ),
+      operator_id: identitySchema
+        .optional()
+        .describe(
+          'Runtime id of an EXISTING graph operator returned by view_agent_graph. Use only for follow-up work; set operator_id OR agent_id, never both.',
+        ),
+      instruction: z.string().trim().min(1).max(AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS),
+      input_ids: z
+        .array(identitySchema)
+        .max(AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS)
+        .default([])
+        .describe('Durable record or result ids that form this work item input frontier.'),
+      replaces: identitySchema
+        .optional()
+        .describe('Existing work or activation superseded by this request.'),
+      replacement_mode: z
+        .enum(['none', 'replace'])
+        .optional()
+        .describe(
+          'Use none for normal work. Use replace only with a real replaces id. When none, any provider-filled replaces placeholder is ignored.',
+        ),
+    })
+    .strip()
+    .superRefine((value, ctx) => {
+      const validTarget = value.target_kind
+        ? value.target_kind === 'new_agent'
+          ? Boolean(value.agent_id)
+          : Boolean(value.operator_id)
+        : (value.agent_id ? 1 : 0) + (value.operator_id ? 1 : 0) === 1;
+      if (!validTarget) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'Set target_kind=new_agent with agent_id, target_kind=existing_operator with operator_id, or omit target_kind and provide exactly one identity',
+        });
+      }
+      if (value.replacement_mode === 'replace' && !value.replaces) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'replacement_mode=replace requires replaces',
+        });
+      }
+      addDuplicateIssue(ctx, value.input_ids, ['input_ids']);
+    }),
+);
 
 const stopSchema = z
   .object({
     target_id: identitySchema,
     reason: z.string().trim().min(1).max(AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS),
   })
-  .strict();
+  .strip();
 
 const finishSchema = z
   .object({
@@ -129,44 +132,65 @@ const finishSchema = z
       .describe('Committed graph record ids selected as the final result.'),
     reason: z.string().trim().min(1).max(AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS),
   })
-  .strict()
+  .strip()
   .superRefine((value, ctx) => addDuplicateIssue(ctx, value.result_ids, ['result_ids']));
 
-const updateSchema = z
-  .object({
-    operation: z
-      .enum(['add_work', 'stop', 'finish'])
-      .optional()
-      .describe(
-        'Explicit operation discriminator. Only the matching payload is applied; unrelated provider-filled optional payloads are ignored.',
-      ),
-    add_work: z
-      .array(addWorkSchema)
-      .max(AGENT_GRAPH_SCHEDULE_MAX_ADD_WORK)
-      .optional()
-      .describe(
-        'Schedule work. For a new operator, provide agent_id only. Omit finish whenever add_work is present.',
-      ),
-    stop: z.array(stopSchema).max(AGENT_GRAPH_SCHEDULE_MAX_STOP).optional(),
-    finish: finishSchema
-      .optional()
-      .describe(
-        'Terminal operation selecting committed result ids. Use only after all work is done; never combine with add_work.',
-      ),
-  })
-  .strict()
-  .superRefine((value, ctx) => {
-    const addWork = value.add_work ?? [];
-    const stop = value.stop ?? [];
-    if (value.operation) {
-      const hasSelectedPayload =
-        (value.operation === 'add_work' && addWork.length > 0) ||
-        (value.operation === 'stop' && stop.length > 0) ||
-        (value.operation === 'finish' && value.finish !== undefined);
-      if (!hasSelectedPayload) {
+const updateSchema = z.preprocess(
+  cleanUpdateInput,
+  z
+    .object({
+      operation: z
+        .enum(['add_work', 'stop', 'finish'])
+        .optional()
+        .describe(
+          'Explicit operation discriminator. Only the matching payload is applied; unrelated provider-filled optional payloads are ignored.',
+        ),
+      add_work: z
+        .array(addWorkSchema)
+        .max(AGENT_GRAPH_SCHEDULE_MAX_ADD_WORK)
+        .optional()
+        .describe(
+          'Schedule work. For a new operator, provide agent_id only. Omit finish whenever add_work is present.',
+        ),
+      stop: z.array(stopSchema).max(AGENT_GRAPH_SCHEDULE_MAX_STOP).optional(),
+      finish: finishSchema
+        .optional()
+        .describe(
+          'Terminal operation selecting committed result ids. Use only after all work is done; never combine with add_work.',
+        ),
+    })
+    .strip()
+    .superRefine((value, ctx) => {
+      const addWork = value.add_work ?? [];
+      const stop = value.stop ?? [];
+      if (value.operation) {
+        const hasSelectedPayload =
+          (value.operation === 'add_work' && addWork.length > 0) ||
+          (value.operation === 'stop' && stop.length > 0) ||
+          (value.operation === 'finish' && value.finish !== undefined);
+        if (!hasSelectedPayload) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `operation=${value.operation} requires its matching payload`,
+          });
+        }
+        addDuplicateIssue(
+          ctx,
+          stop.map((entry) => entry.target_id),
+          ['stop'],
+        );
+        return;
+      }
+      if (addWork.length + stop.length + (value.finish ? 1 : 0) === 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `operation=${value.operation} requires its matching payload`,
+          message: 'At least one add_work, stop, or finish operation is required',
+        });
+      }
+      if (value.finish && addWork.length > 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'finish cannot be combined with add_work',
         });
       }
       addDuplicateIssue(
@@ -174,50 +198,35 @@ const updateSchema = z
         stop.map((entry) => entry.target_id),
         ['stop'],
       );
-      return;
-    }
-    if (addWork.length + stop.length + (value.finish ? 1 : 0) === 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'At least one add_work, stop, or finish operation is required',
-      });
-    }
-    if (value.finish && addWork.length > 0) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'finish cannot be combined with add_work',
-      });
-    }
-    addDuplicateIssue(
-      ctx,
-      stop.map((entry) => entry.target_id),
-      ['stop'],
-    );
-  });
+    }),
+);
 
-const viewSchema = z
-  .object({
-    mode: z
-      .enum(['latest', 'page'])
-      .optional()
-      .describe(
-        'Use latest for the current graph view. Use page only with an opaque cursor returned by a previous view.',
-      ),
-    cursor: cursorSchema
-      .optional()
-      .describe(
-        'Opaque cursor returned by an earlier view_agent_graph call. Ignored when mode=latest.',
-      ),
-  })
-  .strict()
-  .superRefine((value, ctx) => {
-    if (value.mode === 'page' && !value.cursor) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'mode=page requires cursor',
-      });
-    }
-  });
+const viewSchema = z.preprocess(
+  cleanViewInput,
+  z
+    .object({
+      mode: z
+        .enum(['latest', 'page'])
+        .optional()
+        .describe(
+          'Use latest for the current graph view. Use page only with an opaque cursor returned by a previous view.',
+        ),
+      cursor: cursorSchema
+        .optional()
+        .describe(
+          'Opaque cursor returned by an earlier view_agent_graph call. Ignored when mode=latest.',
+        ),
+    })
+    .strip()
+    .superRefine((value, ctx) => {
+      if (value.mode === 'page' && !value.cursor) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'mode=page requires cursor',
+        });
+      }
+    }),
+);
 
 const yieldSchema = z
   .object({
@@ -228,7 +237,39 @@ const yieldSchema = z
       .max(AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS)
       .describe('Why the supervisor has no immediate decision until the graph changes.'),
   })
-  .strict();
+  .strip();
+
+function cleanAddWorkInput(input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const cleaned = { ...(input as Record<string, unknown>) };
+  if (cleaned.target_kind === 'new_agent') delete cleaned.operator_id;
+  if (cleaned.target_kind === 'existing_operator') delete cleaned.agent_id;
+  if (cleaned.replacement_mode === 'none') delete cleaned.replaces;
+  return cleaned;
+}
+
+function cleanUpdateInput(input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const cleaned = { ...(input as Record<string, unknown>) };
+  if (cleaned.operation === 'add_work') {
+    delete cleaned.stop;
+    delete cleaned.finish;
+  } else if (cleaned.operation === 'stop') {
+    delete cleaned.add_work;
+    delete cleaned.finish;
+  } else if (cleaned.operation === 'finish') {
+    delete cleaned.add_work;
+    delete cleaned.stop;
+  }
+  return cleaned;
+}
+
+function cleanViewInput(input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const cleaned = { ...(input as Record<string, unknown>) };
+  if (cleaned.mode === undefined || cleaned.mode === 'latest') delete cleaned.cursor;
+  return cleaned;
+}
 
 export interface ViewAgentGraphToolInput {
   mode?: 'latest' | 'page';

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -41,6 +41,12 @@ const AGENT_SPAWN_ISOLATION_MODES = [
   AGENT_WORKSPACE_WORKTREE,
 ] as const;
 const CHILD_PROGRESS_ERROR_MAX_CHARS = 1_000;
+const AGENT_LIST_PAGE_SIZE = 8;
+// Active tool-result archival starts at roughly 8k characters with the default
+// token estimate. Keep discovery safely below it even with maximal catalog text.
+const AGENT_LIST_MAX_RESPONSE_CHARS = 7_000;
+const AGENT_LIST_DESCRIPTION_MAX_CHARS = 240;
+const AGENT_LIST_MODEL_MAX_CHARS = 160;
 
 /**
  * Which schema fields each `agent_output` locator needs. A rejection that only
@@ -88,76 +94,84 @@ export function buildSubagentSpawnTool(
     name: AGENT_SPAWN_TOOL_NAME,
     displayName: 'Agent',
     description:
-      'Run one bounded foreground child task. Prefer agent_list, then select the user-approved subagent_id whose description fits the task; profile is retained for legacy callers.',
-    parameters: z
-      .object({
-        profile: z.enum(profiles).optional().describe('Legacy child capability profile.'),
-        subagent_id: z
-          .string()
-          .min(1)
-          .max(128)
-          .refine(isSafeSubagentPresetId)
-          .optional()
-          .describe('User-approved subagent preset id from agent_list.'),
-        task: z.string().min(1).max(60_000).describe('Bounded task for the selected child agent.'),
-        write_back: z
-          .enum(AGENT_SPAWN_WRITE_BACK_MODES)
-          .optional()
-          .describe(
-            'Requested child write-back mode. Each built-in profile declares its supported modes.',
-          ),
-        isolation: z
-          .enum(AGENT_SPAWN_ISOLATION_MODES)
-          .optional()
-          .describe(
-            'Requested child workspace isolation. Worktree profiles fail closed until a worktree child executor is available.',
-          ),
-        ...(deps.taskLedger
-          ? {
-              task_id: z
-                .string()
-                .min(1)
-                .max(TASK_ID_MAX_CHARS)
-                .refine(isSafeTaskId)
-                .optional()
-                .describe('Existing task UUID or short key to bind to this child run.'),
-            }
-          : {}),
-      })
-      .strict()
-      .superRefine((input, ctx) => {
-        if (Boolean(input.profile) === Boolean(input.subagent_id)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Provide exactly one of subagent_id or legacy profile.',
-          });
-          return;
-        }
-        if (!input.profile) return;
-        const definition = requireAgentDefinitionByProfile(definitions, input.profile);
-        const requestedWriteBack = input.write_back ?? definition.contract.defaultWriteBack;
-        if (!definition.contract.supportedWriteBack.some((mode) => mode === requestedWriteBack)) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['write_back'],
-            message: `Agent profile "${definition.profile}" does not support write_back "${requestedWriteBack}".`,
-          });
-        }
-        const requestedIsolation = input.isolation ?? definition.contract.workspace;
-        if (requestedIsolation !== definition.contract.workspace) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ['isolation'],
-            message: `Agent profile "${definition.profile}" requires isolation "${definition.contract.workspace}", not "${requestedIsolation}".`,
-          });
-        }
-      }),
+      'Run one bounded foreground child task. Prefer agent_list, then select the user-approved subagent_id whose description fits the task; profile is retained for legacy callers. If both selectors are present, subagent_id wins and profile is ignored.',
+    parameters: z.preprocess(
+      (input) => cleanSubagentSpawnInput(input, deps.taskLedger !== undefined),
+      z
+        .object({
+          profile: z.enum(profiles).optional().describe('Legacy child capability profile.'),
+          subagent_id: z
+            .string()
+            .min(1)
+            .max(128)
+            .refine(isSafeSubagentPresetId)
+            .optional()
+            .describe('User-approved subagent preset id from agent_list.'),
+          task: z
+            .string()
+            .min(1)
+            .max(60_000)
+            .describe('Bounded task for the selected child agent.'),
+          write_back: z
+            .enum(AGENT_SPAWN_WRITE_BACK_MODES)
+            .optional()
+            .describe(
+              'Requested child write-back mode. Each built-in profile declares its supported modes.',
+            ),
+          isolation: z
+            .enum(AGENT_SPAWN_ISOLATION_MODES)
+            .optional()
+            .describe(
+              'Requested child workspace isolation. Worktree profiles fail closed until a worktree child executor is available.',
+            ),
+          ...(deps.taskLedger
+            ? {
+                task_id: z
+                  .string()
+                  .min(1)
+                  .max(TASK_ID_MAX_CHARS)
+                  .refine(isSafeTaskId)
+                  .optional()
+                  .describe('Existing task UUID or short key to bind to this child run.'),
+              }
+            : {}),
+        })
+        .strip()
+        .superRefine((input, ctx) => {
+          if (!input.profile && !input.subagent_id) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Provide subagent_id or legacy profile.',
+            });
+            return;
+          }
+          if (input.subagent_id) return;
+          if (!input.profile) return;
+          const definition = requireAgentDefinitionByProfile(definitions, input.profile);
+          const requestedWriteBack = input.write_back ?? definition.contract.defaultWriteBack;
+          if (!definition.contract.supportedWriteBack.some((mode) => mode === requestedWriteBack)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['write_back'],
+              message: `Agent profile "${definition.profile}" does not support write_back "${requestedWriteBack}".`,
+            });
+          }
+          const requestedIsolation = input.isolation ?? definition.contract.workspace;
+          if (requestedIsolation !== definition.contract.workspace) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['isolation'],
+              message: `Agent profile "${definition.profile}" requires isolation "${definition.contract.workspace}", not "${requestedIsolation}".`,
+            });
+          }
+        }),
+    ),
     categoryHint: 'subagent',
     nesting: 'direct_only',
     impl: async (input, ctx) => {
-      const definition = input.profile
-        ? requireAgentDefinitionByProfile(definitions, input.profile)
-        : await resolvePresetDefinition(input.subagent_id!, ctx, definitions);
+      const definition = input.subagent_id
+        ? await resolvePresetDefinition(input.subagent_id, ctx, definitions)
+        : requireAgentDefinitionByProfile(definitions, input.profile!);
       const requestedWriteBack = input.write_back ?? definition.contract.defaultWriteBack;
       if (!definition.contract.supportedWriteBack.some((mode) => mode === requestedWriteBack)) {
         throw new Error(
@@ -179,13 +193,12 @@ export function buildSubagentSpawnTool(
           },
         );
       }
-      const boundTask = input.task_id
-        ? await deps.taskLedger?.get(ctx.sessionId, input.task_id)
-        : undefined;
-      if (input.task_id && !deps.taskLedger)
-        throw new Error('Task binding is unavailable in this runtime');
-      if (input.task_id && !boundTask)
-        throw new Error(`No such task in this session: ${input.task_id}`);
+      // task_id is meaningful only in compositions that advertise task
+      // binding. Older or over-eager callers may still send it elsewhere;
+      // ignore it instead of turning an optional integration into a refusal.
+      const taskId = deps.taskLedger ? input.task_id : undefined;
+      const boundTask = taskId ? await deps.taskLedger!.get(ctx.sessionId, taskId) : undefined;
+      if (taskId && !boundTask) throw new Error(`No such task in this session: ${taskId}`);
       let claimedOwner:
         | {
             actor: 'child_agent';
@@ -286,6 +299,14 @@ export function buildSubagentSpawnTool(
   };
 }
 
+function cleanSubagentSpawnInput(input: unknown, taskBindingAvailable: boolean): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const cleaned = { ...(input as Record<string, unknown>) };
+  if (cleaned.subagent_id !== undefined) delete cleaned.profile;
+  if (!taskBindingAvailable) delete cleaned.task_id;
+  return cleaned;
+}
+
 async function resolvePresetDefinition(
   subagentId: string,
   ctx: MakaToolContext,
@@ -349,16 +370,33 @@ function boundedChildError(error: unknown): string {
     : `${message.slice(0, CHILD_PROGRESS_ERROR_MAX_CHARS - 1)}…`;
 }
 
-export function buildSubagentListTool(): MakaTool<Record<string, never>, unknown> {
+export function buildSubagentListTool(): MakaTool<
+  { view?: 'selection' | 'catalog'; cursor?: string },
+  unknown
+> {
   return {
     name: AGENT_LIST_TOOL_NAME,
     displayName: 'Agent List',
     description:
-      'List user-approved subagent presets (including task descriptions, model routes, and availability), capability definitions, and child runs for this session.',
-    parameters: z.object({}),
+      'List a compact page of subagents to select. The default selection view returns runnable user-approved subagent_id values first, followed by runnable legacy profiles. Use view=catalog only to diagnose unavailable routes. Child execution history is intentionally excluded; use refs returned by agent_spawn/agent_swarm with agent_output.',
+    parameters: z
+      .object({
+        view: z
+          .enum(['selection', 'catalog'])
+          .default('selection')
+          .describe(
+            'selection lists runnable choices; catalog also includes unavailable choices and reasons.',
+          ),
+        cursor: z
+          .string()
+          .regex(/^\d+$/)
+          .optional()
+          .describe('next_cursor returned by the previous agent_list page.'),
+      })
+      .strip(),
     categoryHint: 'read',
     nesting: 'direct_only',
-    impl: async (_input, ctx) => {
+    impl: async (input, ctx) => {
       // Not reachable from the desktop app or the CLI: both pass
       // `listChildAgents` to ToolRuntime unconditionally
       // (`session-stream.ts`, `runtime-bootstrap.ts`), and ToolRuntime hands
@@ -367,14 +405,164 @@ export function buildSubagentListTool(): MakaTool<Record<string, never>, unknown
       // here — which is why this stays a sentence rather than being deleted.
       if (!ctx.listChildAgents) {
         throw new Error(
-          'agent_list is not available in this session, so no agent catalog or child run list could be read. ' +
+          'agent_list is not available in this session, so no agent catalog could be read. ' +
             'Retrying agent_list will fail the same way — pick a child agent profile from the agent_spawn schema instead.',
           { cause: new Error('listChildAgents capability is unavailable in this runtime context') },
         );
       }
-      return await ctx.listChildAgents();
+      return projectAgentList(await ctx.listChildAgents(), input);
     },
   };
+}
+
+function projectAgentList(
+  catalog: unknown,
+  input: { view?: 'selection' | 'catalog'; cursor?: string },
+): unknown {
+  // The host capability remains a rich control-plane projection because spawn
+  // and swarm resolve presets through it. Only the model-facing list is narrowed.
+  if (!catalog || typeof catalog !== 'object' || Array.isArray(catalog)) {
+    throw new Error('agent_list returned an invalid catalog');
+  }
+  const raw = catalog as Record<string, unknown>;
+  const definitions = Array.isArray(raw.definitions) ? raw.definitions : [];
+  const definitionByProfile = new Map<string, Record<string, unknown>>();
+  for (const candidate of definitions) {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) continue;
+    const definition = candidate as Record<string, unknown>;
+    if (typeof definition.profile === 'string') {
+      definitionByProfile.set(definition.profile, definition);
+    }
+  }
+
+  const view = input.view ?? 'selection';
+  const presets = (Array.isArray(raw.presets) ? raw.presets : [])
+    .flatMap((candidate) => {
+      if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return [];
+      const preset = candidate as Record<string, unknown>;
+      if (
+        typeof preset.id !== 'string' ||
+        typeof preset.name !== 'string' ||
+        typeof preset.description !== 'string' ||
+        typeof preset.profile !== 'string' ||
+        typeof preset.model !== 'string'
+      ) {
+        return [];
+      }
+      const availability = effectivePresetAvailability(
+        preset,
+        definitionByProfile.get(preset.profile),
+      );
+      return [
+        {
+          subagent_id: preset.id,
+          name: boundedCatalogText(preset.name, 128),
+          description: boundedCatalogText(preset.description, AGENT_LIST_DESCRIPTION_MAX_CHARS),
+          profile: preset.profile,
+          model: boundedCatalogText(preset.model, AGENT_LIST_MODEL_MAX_CHARS),
+          ...(typeof preset.thinkingLevel === 'string'
+            ? { thinking_level: boundedCatalogText(preset.thinkingLevel, 32) }
+            : {}),
+          ...availability,
+        },
+      ];
+    })
+    .filter((preset) => view === 'catalog' || preset.status === 'available');
+
+  const offset = Math.min(Number.parseInt(input.cursor ?? '0', 10), presets.length);
+  const pagePresets = presets.slice(offset, offset + AGENT_LIST_PAGE_SIZE);
+  const legacyProfiles = definitions.flatMap((candidate) => {
+    if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return [];
+    const definition = candidate as Record<string, unknown>;
+    if (
+      typeof definition.profile !== 'string' ||
+      typeof definition.name !== 'string' ||
+      typeof definition.description !== 'string'
+    ) {
+      return [];
+    }
+    const availability = catalogAvailability(definition.availability);
+    if (view === 'selection' && availability.status !== 'available') return [];
+    const contract =
+      definition.contract &&
+      typeof definition.contract === 'object' &&
+      !Array.isArray(definition.contract)
+        ? (definition.contract as Record<string, unknown>)
+        : undefined;
+    return [
+      {
+        profile: definition.profile,
+        name: boundedCatalogText(definition.name, 128),
+        description: boundedCatalogText(definition.description, AGENT_LIST_DESCRIPTION_MAX_CHARS),
+        ...(typeof contract?.workspace === 'string'
+          ? { workspace: boundedCatalogText(contract.workspace, 32) }
+          : {}),
+        ...(typeof contract?.defaultWriteBack === 'string'
+          ? { write_back: boundedCatalogText(contract.defaultWriteBack, 32) }
+          : {}),
+        ...availability,
+      },
+    ];
+  });
+
+  const buildPage = () => {
+    const nextOffset = offset + pagePresets.length;
+    return {
+      presets: pagePresets,
+      legacy_profiles: legacyProfiles,
+      page: {
+        returned: pagePresets.length,
+        total: presets.length,
+        ...(nextOffset < presets.length ? { next_cursor: String(nextOffset) } : {}),
+      },
+      view,
+    };
+  };
+  while (
+    pagePresets.length > 1 &&
+    JSON.stringify(buildPage()).length > AGENT_LIST_MAX_RESPONSE_CHARS
+  ) {
+    pagePresets.pop();
+  }
+  return buildPage();
+}
+
+function effectivePresetAvailability(
+  preset: Record<string, unknown>,
+  definition: Record<string, unknown> | undefined,
+): { status: 'available' } | { status: 'unavailable'; reason: string } {
+  const presetAvailability = catalogAvailability(preset.availability);
+  if (presetAvailability.status === 'unavailable') return presetAvailability;
+  if (!definition) return { status: 'unavailable', reason: 'unknown_profile' };
+  const definitionAvailability = catalogAvailability(definition.availability);
+  if (definitionAvailability.status === 'unavailable') {
+    return {
+      status: 'unavailable',
+      reason: `profile_${definitionAvailability.reason}`,
+    };
+  }
+  return { status: 'available' };
+}
+
+function catalogAvailability(
+  value: unknown,
+): { status: 'available' } | { status: 'unavailable'; reason: string } {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { status: 'unavailable', reason: 'availability_unknown' };
+  }
+  const availability = value as Record<string, unknown>;
+  if (availability.status === 'available') return { status: 'available' };
+  return {
+    status: 'unavailable',
+    reason:
+      typeof availability.reason === 'string'
+        ? boundedCatalogText(availability.reason, 120)
+        : 'availability_unknown',
+  };
+}
+
+function boundedCatalogText(value: string, maxChars: number): string {
+  return value.length <= maxChars ? value : `${value.slice(0, maxChars - 1)}…`;
 }
 
 export function buildSubagentOutputTool(): MakaTool<
@@ -394,64 +582,68 @@ export function buildSubagentOutputTool(): MakaTool<
     displayName: 'Agent Output',
     description:
       'Inspect bounded child output. Use view=result for the final committed model text plus its Graph result record id; runtime_events is the default compatibility view. Always set locator: child_session_run for a graph childSessionId/currentRunId, child_session_latest for its latest run, or a legacy locator. Use view=all only for targeted diagnostics.',
-    parameters: z
-      .object({
-        locator: z
-          .enum(['child_session_latest', 'child_session_run', 'legacy_run', 'legacy_turn'])
-          .optional()
-          .describe(
-            'Explicit locator discriminator. The runtime applies only fields selected by this value.',
-          ),
-        child_session_id: z
-          .string()
-          .min(1)
-          .optional()
-          .describe('Linked child Session id. Without run_id, inspects its latest AgentRun.'),
-        run_id: z.string().min(1).optional(),
-        turn_id: z.string().min(1).optional(),
-        max_events: z.number().int().min(1).max(100).optional(),
-        max_bytes: z
-          .number()
-          .int()
-          .min(1024)
-          .max(128 * 1024)
-          .optional(),
-        view: z.enum(['result', 'events', 'runtime_events', 'all']).optional(),
-      })
-      .superRefine((input, ctx) => {
-        if (input.locator) {
-          const valid =
-            (input.locator === 'child_session_latest' && Boolean(input.child_session_id)) ||
-            (input.locator === 'child_session_run' &&
-              Boolean(input.child_session_id) &&
-              Boolean(input.run_id)) ||
-            (input.locator === 'legacy_run' && Boolean(input.run_id)) ||
-            (input.locator === 'legacy_turn' && Boolean(input.turn_id));
-          if (!valid) {
+    parameters: z.preprocess(
+      cleanSubagentOutputInput,
+      z
+        .object({
+          locator: z
+            .enum(['child_session_latest', 'child_session_run', 'legacy_run', 'legacy_turn'])
+            .optional()
+            .describe(
+              'Explicit locator discriminator. The runtime applies only fields selected by this value.',
+            ),
+          child_session_id: z
+            .string()
+            .min(1)
+            .optional()
+            .describe('Linked child Session id. Without run_id, inspects its latest AgentRun.'),
+          run_id: z.string().min(1).optional(),
+          turn_id: z.string().min(1).optional(),
+          max_events: z.number().int().min(1).max(100).optional(),
+          max_bytes: z
+            .number()
+            .int()
+            .min(1024)
+            .max(128 * 1024)
+            .optional(),
+          view: z.enum(['result', 'events', 'runtime_events', 'all']).optional(),
+        })
+        .strip()
+        .superRefine((input, ctx) => {
+          if (input.locator) {
+            const valid =
+              (input.locator === 'child_session_latest' && Boolean(input.child_session_id)) ||
+              (input.locator === 'child_session_run' &&
+                Boolean(input.child_session_id) &&
+                Boolean(input.run_id)) ||
+              (input.locator === 'legacy_run' && Boolean(input.run_id)) ||
+              (input.locator === 'legacy_turn' && Boolean(input.turn_id));
+            if (!valid) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                message: `locator=${input.locator} requires ${LOCATOR_REQUIRED_FIELDS[input.locator]}.`,
+              });
+            }
+            return;
+          }
+          if (input.child_session_id) {
+            if (input.turn_id) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ['turn_id'],
+                message: 'turn_id cannot be combined with child_session_id',
+              });
+            }
+            return;
+          }
+          if (Number(!!input.run_id) + Number(!!input.turn_id) !== 1) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              message: `locator=${input.locator} requires ${LOCATOR_REQUIRED_FIELDS[input.locator]}.`,
+              message: 'Provide child_session_id, or exactly one legacy run_id/turn_id',
             });
           }
-          return;
-        }
-        if (input.child_session_id) {
-          if (input.turn_id) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ['turn_id'],
-              message: 'turn_id cannot be combined with child_session_id',
-            });
-          }
-          return;
-        }
-        if (Number(!!input.run_id) + Number(!!input.turn_id) !== 1) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: 'Provide child_session_id, or exactly one legacy run_id/turn_id',
-          });
-        }
-      }),
+        }),
+    ),
     categoryHint: 'read',
     nesting: 'direct_only',
     impl: async (input, ctx) => {
@@ -520,6 +712,27 @@ export function buildSubagentOutputTool(): MakaTool<
       });
     },
   };
+}
+
+function cleanSubagentOutputInput(input: unknown): unknown {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return input;
+  const cleaned = { ...(input as Record<string, unknown>) };
+  switch (cleaned.locator) {
+    case 'child_session_latest':
+      delete cleaned.run_id;
+      delete cleaned.turn_id;
+      break;
+    case 'child_session_run':
+    case 'legacy_run':
+      delete cleaned.turn_id;
+      if (cleaned.locator === 'legacy_run') delete cleaned.child_session_id;
+      break;
+    case 'legacy_turn':
+      delete cleaned.child_session_id;
+      delete cleaned.run_id;
+      break;
+  }
+  return cleaned;
 }
 
 export function buildSubagentProjectionTools(): MakaTool[] {


### PR DESCRIPTION
## Summary

- make `agent_list` a compact selection API: runnable `subagent_id` presets come first, legacy profiles are reduced to selection metadata, and execution history is excluded
- add bounded pagination plus a 7,000-character response ceiling so catalog discovery stays below active tool-result archival thresholds
- sanitize provider-filled fields before validating discriminated agent tool branches; preferred selectors and explicit operations win while required active-branch fields still fail closed
- apply the same branch-aware cleanup to `agent_spawn`, `agent_swarm`, `agent_output`, `ArchiveRead`, and graph supervisor tools

## Verification

- `npm run build` — passed for the complete workspace
- targeted runtime regression suite — 127/127 passed
- `npm --workspace @maka/runtime test` — 3319 passed, 9 skipped, 1 unrelated environment-sensitive failure: `builtin-tools.test` expects macOS executable root `/usr/local`, which is not present in this machine generated sandbox argv
- rebuilt and locally installed the macOS arm64 desktop app; smoke launch remained running

## Review focus

- `agent_list` intentionally no longer exposes `definitions`, `executions`, or `runs` to the model. The host-side `listChildAgents` control-plane result remains unchanged for spawn/swarm preset resolution.
- redundant or unknown fields are ignored only before active-branch validation; missing selectors, invalid selected presets, and missing operation-specific required fields still reject.