### PR TITLE
fix(ui): show the selection quote layer only for a settled transcript selection

### DIFF
--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -192,6 +192,10 @@ test('the quote layer follows the selection while the transcript scrolls', async
     .getByText(/Fake backend received: scroll follow source 11/)
     .last()
     .evaluate((element) => {
+      // Centred first: the affordance is owed only to a selection inside the
+      // scroller's visible band, and where turn 11 lands depends on the host's
+      // font metrics. Without this the test asserts on layout luck.
+      element.scrollIntoView({ block: 'center' });
       const range = document.createRange();
       range.selectNodeContents(element);
       const selection = window.getSelection();
@@ -202,55 +206,64 @@ test('the quote layer follows the selection while the transcript scrolls', async
   const quoteLayer = page.locator('.maka-quote-actions');
   await expect(quoteLayer).toBeVisible();
 
-  // Both tops in one evaluate: read across two round-trips and a scroll still
-  // in flight would pair a fresh layer position with a stale selection one.
-  const geometry = () =>
-    page.evaluate(() => {
-      const layer = document.querySelector('.maka-quote-actions');
-      const selection = window.getSelection();
-      if (!layer || !selection || selection.rangeCount === 0) return null;
-      return {
-        layerTop: layer.getBoundingClientRect().top,
-        selectionTop: selection.getRangeAt(0).getBoundingClientRect().top,
-      };
-    });
-
   /**
-   * Drives the scroller directly instead of `mouse.wheel`: wheel delivery is a
+   * The whole measurement runs inside the page. Scrolling and reading across
+   * the driver interleaves round-trips with frames the renderer is still
+   * settling in, which pairs a fresh layer position with a stale selection one
+   * — the flake this test kept hitting. In here the scroll and both rects are
+   * one synchronous layout, and the wait for the layer to catch up is by frame.
+   *
+   * Writing `scrollTop` rather than sending a wheel: wheel delivery is a
    * host-level detail (it landed nowhere on CI's Linux runner), while what this
    * test is about is the `scroll` event the hook listens to, which a scrollTop
    * write raises just the same.
    */
-  const scrollTranscriptBy = (delta: number) =>
-    page.evaluate((by) => {
-      let node = document.querySelector('.maka-chat-message-list')?.parentElement ?? null;
-      while (node && node.scrollHeight <= node.clientHeight) node = node.parentElement;
-      if (!node) throw new Error('no scrollable transcript ancestor');
-      node.scrollTop += by;
-      return node.scrollTop;
-    }, delta);
+  const follow = await page.evaluate(async () => {
+    let scroller = document.querySelector('.maka-chat-message-list')?.parentElement ?? null;
+    while (scroller && scroller.scrollHeight <= scroller.clientHeight) {
+      scroller = scroller.parentElement;
+    }
+    if (!scroller) throw new Error('no scrollable transcript ancestor');
 
-  const before = await geometry();
-  expect(before).not.toBeNull();
-  await scrollTranscriptBy(-220);
+    const nextFrame = () => new Promise((resolve) => requestAnimationFrame(resolve));
+    const selectionTop = () =>
+      window.getSelection()?.getRangeAt(0).getBoundingClientRect().top ?? null;
+    const layerTop = () =>
+      document.querySelector('.maka-quote-actions')?.getBoundingClientRect().top ?? null;
 
+    const before = { selection: selectionTop(), layer: layerTop() };
+    scroller.scrollTop -= 220;
+    const selectionShift = selectionTop()! - before.selection!;
+
+    for (let frame = 0; frame < 120; frame += 1) {
+      await nextFrame();
+      const now = layerTop();
+      if (now !== null && Math.abs(now - before.layer! - selectionShift) <= 1) {
+        return { selectionShift, layerShift: now - before.layer! };
+      }
+    }
+    return { selectionShift, layerShift: layerTop() === null ? null : layerTop()! - before.layer! };
+  });
+
+  // A scroll that moved nothing would make the assertion below vacuous.
+  expect(follow.selectionShift).not.toBe(0);
   // The layer tracks the selection rather than merely surviving the scroll.
-  await expect
-    .poll(async () => {
-      const after = await geometry();
-      if (!after || !before) return null;
-      const selectionShift = after.selectionTop - before.selectionTop;
-      if (selectionShift === 0) return null;
-      return Math.abs(after.layerTop - before.layerTop - selectionShift) <= 1;
-    })
-    .toBe(true);
+  // Sub-pixel tolerance, not exactness: the layer is positioned in CSS pixels
+  // and rounded to the device grid, so it lands within a pixel of the anchor.
+  expect(Math.abs(follow.layerShift! - follow.selectionShift)).toBeLessThanOrEqual(1);
 
   // Following stops at the edge of the scroller. Once the anchor leaves the
   // visible band there is nothing to point at, and a bar clamped to the top of
   // the window pointing at off-screen text is the noise this feature exists to
   // avoid. `getBoundingClientRect()` still reports a full-size rect for an
   // off-screen range, so this cannot be left to the zero-size guard.
-  await scrollTranscriptBy(-6000);
+  await page.evaluate(() => {
+    let scroller = document.querySelector('.maka-chat-message-list')?.parentElement ?? null;
+    while (scroller && scroller.scrollHeight <= scroller.clientHeight) {
+      scroller = scroller.parentElement;
+    }
+    if (scroller) scroller.scrollTop = 0;
+  });
   await expect(quoteLayer).toBeHidden();
 });
 

--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -23,8 +23,9 @@ test('quote companion removes one staged quote, forks, answers, and cleans up on
   const [sourceSession] = await page.evaluate(() => window.maka.sessions.list());
   expect(sourceSession).toBeDefined();
 
-  // Create the same real DOM Range a drag selection would produce, then fire
-  // mouseup — the selection hook intentionally captures only finalized ranges.
+  // Create the same real DOM Range a drag selection would produce. Mutating
+  // the selection fires `selectionchange` on its own, which is the hook's only
+  // trigger; the click below absorbs the settle delay before the layer shows.
   const stageReply = async (reply: typeof firstSourceReply) => {
     await reply.evaluate((element) => {
       const range = document.createRange();
@@ -32,7 +33,6 @@ test('quote companion removes one staged quote, forks, answers, and cleans up on
       const selection = window.getSelection();
       selection?.removeAllRanges();
       selection?.addRange(range);
-      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
     });
     await page.getByRole('button', { name: '在侧栏追问' }).click();
   };
@@ -80,4 +80,125 @@ test('quote companion removes one staged quote, forks, answers, and cleans up on
   await expect
     .poll(async () => (await page.evaluate(() => window.maka.sessions.list())).length)
     .toBe(1);
+});
+
+/**
+ * The selection affordance's timing contract. Selecting text is not the same
+ * as wanting to quote it — most selections mean "copy" or are a reading habit
+ * — so the layer is owed to a settled selection inside a turn, and only that.
+ */
+test('the quote layer waits for the selection to settle, stays closed after Escape, and ignores the composer', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 1400, height: 900 });
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('selection timing source');
+  await composer.press('Enter');
+
+  const reply = page.getByText(/Fake backend received: selection timing source/);
+  await expect(reply).toBeVisible();
+
+  const quoteLayer = page.locator('.maka-quote-actions');
+  const selectContents = (locator: typeof reply) =>
+    locator.evaluate((element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+
+  // Timed inside the page: measuring across the driver would fold IPC latency
+  // into the delay and make the assertion depend on host load.
+  const appearedAfterMs = await reply.evaluate(async (element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    const startedAt = performance.now();
+    selection?.addRange(range);
+    await new Promise<void>((resolve, reject) => {
+      const deadline = startedAt + 3000;
+      const poll = () => {
+        if (document.querySelector('.maka-quote-actions')) resolve();
+        else if (performance.now() > deadline) reject(new Error('quote layer never appeared'));
+        else requestAnimationFrame(poll);
+      };
+      poll();
+    });
+    return performance.now() - startedAt;
+  });
+  // A selection that is still moving has not earned the layer yet: this delay
+  // is the whole fix for "it appears the instant I select something".
+  expect(appearedAfterMs).toBeGreaterThan(300);
+  await expect(quoteLayer).toBeVisible();
+
+  // Escape dismisses, and the dismissal holds: the layer used to come back on
+  // the next unrelated keystroke because any keyup re-captured the selection.
+  await page.keyboard.press('Escape');
+  await expect(quoteLayer).toBeHidden();
+  await page.keyboard.press('Shift');
+  await page.waitForTimeout(500);
+  await expect(quoteLayer).toBeHidden();
+
+  // Selecting inside the composer must not surface a transcript affordance —
+  // and must not leave the previous selection's layer standing either.
+  await composer.fill('drafted text to select');
+  await selectContents(composer);
+  await page.waitForTimeout(500);
+  await expect(quoteLayer).toBeHidden();
+});
+
+/**
+ * Scrolling moves the selection, so it must move the layer. The layer used to
+ * be cleared on scroll because its position was a snapshot; deriving the
+ * position from the live selection instead is what makes following possible.
+ */
+test('the quote layer follows the selection while the transcript scrolls', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 1400, height: 700 });
+  const composer = page.locator(COMPOSER_INPUT);
+  for (let i = 0; i < 6; i += 1) {
+    await composer.fill(`scroll follow source ${i}`);
+    await composer.press('Enter');
+    await expect(
+      page.getByText(new RegExp(`Fake backend received: scroll follow source ${i}`)).last(),
+    ).toBeVisible();
+  }
+
+  await page
+    .getByText(/Fake backend received: scroll follow source 4/)
+    .last()
+    .evaluate((element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+
+  const quoteLayer = page.locator('.maka-quote-actions');
+  await expect(quoteLayer).toBeVisible();
+  const selectionTop = () =>
+    page.evaluate(() => window.getSelection()?.getRangeAt(0).getBoundingClientRect().top ?? null);
+  const layerBefore = await quoteLayer.boundingBox();
+  const selectionBefore = await selectionTop();
+
+  await page.mouse.move(700, 350);
+  await page.mouse.wheel(0, -220);
+
+  // The layer tracks the selection rather than merely surviving the scroll.
+  await expect
+    .poll(async () => {
+      const layerAfter = await quoteLayer.boundingBox();
+      const selectionAfter = await selectionTop();
+      if (!layerAfter || !layerBefore || selectionAfter === null || selectionBefore === null) {
+        return null;
+      }
+      const selectionShift = selectionAfter - selectionBefore;
+      if (selectionShift === 0) return null;
+      return Math.abs(layerAfter.y - layerBefore.y - selectionShift) <= 1;
+    })
+    .toBe(true);
 });

--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -201,25 +201,47 @@ test('the quote layer follows the selection while the transcript scrolls', async
 
   const quoteLayer = page.locator('.maka-quote-actions');
   await expect(quoteLayer).toBeVisible();
-  const selectionTop = () =>
-    page.evaluate(() => window.getSelection()?.getRangeAt(0).getBoundingClientRect().top ?? null);
-  const layerBefore = await quoteLayer.boundingBox();
-  const selectionBefore = await selectionTop();
 
-  await page.mouse.move(700, 350);
-  await page.mouse.wheel(0, -220);
+  // Both tops in one evaluate: read across two round-trips and a scroll still
+  // in flight would pair a fresh layer position with a stale selection one.
+  const geometry = () =>
+    page.evaluate(() => {
+      const layer = document.querySelector('.maka-quote-actions');
+      const selection = window.getSelection();
+      if (!layer || !selection || selection.rangeCount === 0) return null;
+      return {
+        layerTop: layer.getBoundingClientRect().top,
+        selectionTop: selection.getRangeAt(0).getBoundingClientRect().top,
+      };
+    });
+
+  /**
+   * Drives the scroller directly instead of `mouse.wheel`: wheel delivery is a
+   * host-level detail (it landed nowhere on CI's Linux runner), while what this
+   * test is about is the `scroll` event the hook listens to, which a scrollTop
+   * write raises just the same.
+   */
+  const scrollTranscriptBy = (delta: number) =>
+    page.evaluate((by) => {
+      let node = document.querySelector('.maka-chat-message-list')?.parentElement ?? null;
+      while (node && node.scrollHeight <= node.clientHeight) node = node.parentElement;
+      if (!node) throw new Error('no scrollable transcript ancestor');
+      node.scrollTop += by;
+      return node.scrollTop;
+    }, delta);
+
+  const before = await geometry();
+  expect(before).not.toBeNull();
+  await scrollTranscriptBy(-220);
 
   // The layer tracks the selection rather than merely surviving the scroll.
   await expect
     .poll(async () => {
-      const layerAfter = await quoteLayer.boundingBox();
-      const selectionAfter = await selectionTop();
-      if (!layerAfter || !layerBefore || selectionAfter === null || selectionBefore === null) {
-        return null;
-      }
-      const selectionShift = selectionAfter - selectionBefore;
+      const after = await geometry();
+      if (!after || !before) return null;
+      const selectionShift = after.selectionTop - before.selectionTop;
       if (selectionShift === 0) return null;
-      return Math.abs(layerAfter.y - layerBefore.y - selectionShift) <= 1;
+      return Math.abs(after.layerTop - before.layerTop - selectionShift) <= 1;
     })
     .toBe(true);
 
@@ -228,7 +250,7 @@ test('the quote layer follows the selection while the transcript scrolls', async
   // the window pointing at off-screen text is the noise this feature exists to
   // avoid. `getBoundingClientRect()` still reports a full-size rect for an
   // off-screen range, so this cannot be left to the zero-size guard.
-  await page.mouse.wheel(0, -6000);
+  await scrollTranscriptBy(-6000);
   await expect(quoteLayer).toBeHidden();
 });
 

--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -179,7 +179,8 @@ test('the quote layer follows the selection while the transcript scrolls', async
 }) => {
   await page.setViewportSize({ width: 1400, height: 700 });
   const composer = page.locator(COMPOSER_INPUT);
-  for (let i = 0; i < 6; i += 1) {
+  // Long enough that the selected turn can be scrolled clear of the scroller.
+  for (let i = 0; i < 14; i += 1) {
     await composer.fill(`scroll follow source ${i}`);
     await composer.press('Enter');
     await expect(
@@ -188,7 +189,7 @@ test('the quote layer follows the selection while the transcript scrolls', async
   }
 
   await page
-    .getByText(/Fake backend received: scroll follow source 4/)
+    .getByText(/Fake backend received: scroll follow source 11/)
     .last()
     .evaluate((element) => {
       const range = document.createRange();
@@ -221,4 +222,59 @@ test('the quote layer follows the selection while the transcript scrolls', async
       return Math.abs(layerAfter.y - layerBefore.y - selectionShift) <= 1;
     })
     .toBe(true);
+
+  // Following stops at the edge of the scroller. Once the anchor leaves the
+  // visible band there is nothing to point at, and a bar clamped to the top of
+  // the window pointing at off-screen text is the noise this feature exists to
+  // avoid. `getBoundingClientRect()` still reports a full-size rect for an
+  // off-screen range, so this cannot be left to the zero-size guard.
+  await page.mouse.wheel(0, -6000);
+  await expect(quoteLayer).toBeHidden();
+});
+
+/**
+ * A new selection must not leave the layer standing on the previous one's
+ * anchor while the new one settles. Asserted within a frame: the settle timer
+ * would clear it ~350ms later anyway, so any auto-waiting assertion passes
+ * whether or not the code hides it up front.
+ */
+test('a new selection hides the layer immediately, not when the next one settles', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 1400, height: 900 });
+  const composer = page.locator(COMPOSER_INPUT);
+  for (const label of ['hide first alpha', 'hide first beta']) {
+    await composer.fill(label);
+    await composer.press('Enter');
+    await expect(page.getByText(new RegExp(`Fake backend received: ${label}`)).last()).toBeVisible();
+  }
+
+  const select = (pattern: RegExp) =>
+    page
+      .getByText(pattern)
+      .last()
+      .evaluate((element) => {
+        const range = document.createRange();
+        range.selectNodeContents(element);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      });
+
+  await select(/Fake backend received: hide first alpha/);
+  await expect(page.locator('.maka-quote-actions')).toBeVisible();
+
+  const stillVisibleNextFrame = await page
+    .getByText(/Fake backend received: hide first beta/)
+    .last()
+    .evaluate(async (element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      return !!document.querySelector('.maka-quote-actions');
+    });
+  expect(stillVisibleNextFrame).toBe(false);
 });

--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -108,6 +108,26 @@ test('the quote layer waits for the selection to settle, stays closed after Esca
       selection?.addRange(range);
     });
 
+  // Real drag-select with real mouse events. A drag emits a burst of
+  // `selectionchange`, and the gesture below lasts well past the settle delay,
+  // so a layer that appeared mid-drag — the original complaint — shows up here.
+  const replyBox = (await reply.boundingBox())!;
+  const dragY = replyBox.y + replyBox.height / 2;
+  await page.mouse.move(replyBox.x + 20, dragY);
+  await page.mouse.down();
+  for (const dx of [60, 120, 180, 240, 300]) {
+    await page.mouse.move(replyBox.x + 20 + dx, dragY);
+    await page.waitForTimeout(90);
+    await expect(quoteLayer).toBeHidden();
+  }
+  await page.mouse.up();
+  await expect(quoteLayer).toBeVisible();
+
+  // Back to no selection, so the measurement below times a fresh appearance
+  // rather than finding the layer this drag already raised.
+  await page.evaluate(() => window.getSelection()?.removeAllRanges());
+  await expect(quoteLayer).toBeHidden();
+
   // Timed inside the page: measuring across the driver would fold IPC latency
   // into the delay and make the assertion depend on host load.
   const appearedAfterMs = await reply.evaluate(async (element) => {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2541,7 +2541,7 @@ function AppShellContent({
                     ? (input) => {
                         const quote: QuoteRef = {
                           text: input.text,
-                          ...(input.turnId ? { sourceTurnId: input.turnId } : {}),
+                          sourceTurnId: input.turnId,
                         };
                         // Accumulate onto the open panel for this session rather
                         // than spawning a new one; otherwise start a fresh panel.

--- a/apps/desktop/src/renderer/styles/quote-side-panel.css
+++ b/apps/desktop/src/renderer/styles/quote-side-panel.css
@@ -14,6 +14,23 @@
   border-radius: var(--radius-element);
   background: var(--color-background-popover);
   -webkit-app-region: no-drag;
+  /* The hook already waits for the selection to settle before rendering this;
+     the fade keeps that arrival from reading as a pop. Short enough not to
+     add to the wait the user has already served. */
+  animation: maka-quote-actions-in 120ms var(--ease-standard, ease-out);
+}
+
+@keyframes maka-quote-actions-in {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .maka-quote-actions {
+    animation: none;
+  }
 }
 
 /* The quote lives as a transient tab inside the session workbar (not a second

--- a/packages/ui/src/__tests__/selection-quote-target.test.ts
+++ b/packages/ui/src/__tests__/selection-quote-target.test.ts
@@ -103,4 +103,15 @@ describe('resolveQuoteTarget', () => {
     assert.ok(root && leaf);
     assert.equal(resolveQuoteTarget('12:04 · 1.2k tokens', leaf, root), null);
   });
+
+  it('rejects a selection spanning two turns', () => {
+    // A cross-turn selection's common ancestor is the list that holds both
+    // turns, so the walk from it meets no turn id before reaching the root.
+    // Attributing the excerpt to either turn would misreport where it came
+    // from, so the affordance is withheld — deliberately, and asserted here so
+    // it is not later mistaken for an oversight.
+    const [root, turnList] = chain({}, {});
+    assert.ok(root && turnList);
+    assert.equal(resolveQuoteTarget('spans both replies', turnList, root), null);
+  });
 });

--- a/packages/ui/src/__tests__/selection-quote-target.test.ts
+++ b/packages/ui/src/__tests__/selection-quote-target.test.ts
@@ -1,0 +1,106 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  findEnclosingTurnId,
+  normalizeQuoteText,
+  resolveQuoteTarget,
+  type QuoteScopeNode,
+} from '../selection-quote-target.js';
+
+/**
+ * Builds a parent → child chain and returns its nodes, outermost first, so a
+ * test can hand any depth to the walker. `turnId` marks a node as a turn root.
+ */
+function chain(...levels: ReadonlyArray<{ turnId?: string }>): QuoteScopeNode[] {
+  const nodes: QuoteScopeNode[] = [];
+  let parent: QuoteScopeNode | null = null;
+  for (const level of levels) {
+    const node: QuoteScopeNode = {
+      parentNode: parent,
+      ...(level.turnId ? { dataset: { turnId: level.turnId } } : {}),
+    };
+    nodes.push(node);
+    parent = node;
+  }
+  return nodes;
+}
+
+describe('normalizeQuoteText', () => {
+  it('collapses the whitespace a selection picks up across elements', () => {
+    assert.equal(normalizeQuoteText('  the  runtime\n  assembles \t tools '), 'the runtime assembles tools');
+  });
+
+  it('rejects a selection that holds nothing but whitespace', () => {
+    assert.equal(normalizeQuoteText('   \n\t '), null);
+    assert.equal(normalizeQuoteText(''), null);
+  });
+});
+
+describe('findEnclosingTurnId', () => {
+  it('returns the nearest turn id on the way up', () => {
+    const [root, outerTurn, innerTurn, leaf] = chain(
+      {},
+      { turnId: 'turn-outer' },
+      { turnId: 'turn-inner' },
+      {},
+    );
+    assert.ok(root && leaf && outerTurn && innerTurn);
+    assert.equal(findEnclosingTurnId(leaf, root), 'turn-inner');
+  });
+
+  it('rejects a node that never meets the root — the composer case', () => {
+    const [, , composerLeaf] = chain({}, { turnId: 'turn-1' }, {});
+    const [detachedRoot] = chain({});
+    assert.ok(composerLeaf && detachedRoot);
+    // The leaf sits under a turn, but under a *different* tree than the
+    // transcript root, so it is out of scope even though a turn id is above it.
+    assert.equal(findEnclosingTurnId(composerLeaf, detachedRoot), null);
+  });
+
+  it('rejects transcript text that belongs to no turn', () => {
+    const [root, , leaf] = chain({}, {}, {});
+    assert.ok(root && leaf);
+    assert.equal(findEnclosingTurnId(leaf, root), null);
+  });
+
+  it('stops at the root rather than adopting a turn id above it', () => {
+    const [ancestorTurn, root, leaf] = chain({ turnId: 'turn-above-root' }, {}, {});
+    assert.ok(ancestorTurn && root && leaf);
+    assert.equal(findEnclosingTurnId(leaf, root), null);
+  });
+
+  it('treats the root itself as out of scope', () => {
+    const [root] = chain({});
+    assert.ok(root);
+    assert.equal(findEnclosingTurnId(root, root), null);
+  });
+
+  it('handles a null container', () => {
+    const [root] = chain({});
+    assert.ok(root);
+    assert.equal(findEnclosingTurnId(null, root), null);
+  });
+});
+
+describe('resolveQuoteTarget', () => {
+  it('resolves text plus the owning turn', () => {
+    const [root, , leaf] = chain({}, { turnId: 'turn-7' }, {});
+    assert.ok(root && leaf);
+    assert.deepEqual(resolveQuoteTarget('  assembles  tools ', leaf, root), {
+      text: 'assembles tools',
+      turnId: 'turn-7',
+    });
+  });
+
+  it('rejects a whitespace-only selection inside a turn', () => {
+    const [root, , leaf] = chain({}, { turnId: 'turn-7' }, {});
+    assert.ok(root && leaf);
+    assert.equal(resolveQuoteTarget('  \n ', leaf, root), null);
+  });
+
+  it('rejects real text that sits outside every turn', () => {
+    const [root, , leaf] = chain({}, {}, {});
+    assert.ok(root && leaf);
+    assert.equal(resolveQuoteTarget('12:04 · 1.2k tokens', leaf, root), null);
+  });
+});

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -2,7 +2,6 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type React
 import {
   AlertTriangle,
   ArrowRight,
-  TextQuote,
 } from './icons.js';
 import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
 import type { ChatModelChoice } from './chat-model-helpers.js';
@@ -210,16 +209,17 @@ export function ChatView(props: {
    * Codex/Cursor-style "quote this": when set, selecting text in the transcript
    * surfaces a floating action that hands the excerpt (+ its turn) to the host,
    * which stages it as a quote chip on the composer. Omitted by hosts that
-   * don't compose quotes.
+   * don't compose quotes. Only selections that resolve to a turn are offered,
+   * so `turnId` always arrives.
    */
-  onQuoteSelection?(input: { text: string; turnId?: string }): void;
+  onQuoteSelection?(input: { text: string; turnId: string }): void;
   /**
    * Codex/Cursor-style "ask in side panel": when set, selecting text in the
    * transcript surfaces a second floating action that hands the excerpt (+ its
    * turn) to the desktop app, which opens a read-only companion side panel
    * seeded with the quote. Omitted by hosts that don't support the side panel.
    */
-  onAskAboutSelection?(input: { text: string; turnId?: string }): void;
+  onAskAboutSelection?(input: { text: string; turnId: string }): void;
 }) {
   const conversationCopy = getConversationCopy(useUiLocale());
   const copy = conversationCopy.chat;
@@ -474,10 +474,12 @@ export function ChatView(props: {
     lightDismiss: true,
     onHide: clearSelectionQuote,
   });
+  // A quote with no anchor is scrolled out of view: keep it, hide the layer.
+  const selectionAnchor = selectionQuote?.anchor ?? null;
   useEffect(() => {
-    if (selectionQuote) selectionActionsLayer.show();
+    if (selectionAnchor) selectionActionsLayer.show();
     else selectionActionsLayer.hide();
-  }, [selectionQuote, selectionActionsLayer.show, selectionActionsLayer.hide]);
+  }, [selectionAnchor, selectionActionsLayer.show, selectionActionsLayer.hide]);
   const selectionActionsLabel = [
     props.onQuoteSelection ? copy.quoteSelection : null,
     props.onAskAboutSelection ? copy.askInSidePanel : null,
@@ -682,13 +684,16 @@ export function ChatView(props: {
             </>
           )}
         </ChatMessageList>
-        {selectionQuote && (props.onQuoteSelection || props.onAskAboutSelection) ? (
+        {selectionQuote && selectionAnchor && (props.onQuoteSelection || props.onAskAboutSelection) ? (
           selectionActionsLayer.render(
             <div
               className="maka-quote-actions"
               // Keep the live selection alive while clicking an action.
               onMouseDown={(event) => event.preventDefault()}
             >
+              {/* No icons: the labels already name the actions, so an icon
+                  beside each one encodes the same thing twice and buys the
+                  width back from the text the layer is covering. */}
               <ButtonGroup
                 label={selectionActionsLabel}
                 size="sm"
@@ -698,11 +703,10 @@ export function ChatView(props: {
                   <Button
                     type="button"
                     label={copy.quoteSelection}
-                    icon={<TextQuote aria-hidden="true" />}
                     onClick={() => {
                       props.onQuoteSelection?.({
                         text: selectionQuote.text,
-                        ...(selectionQuote.turnId ? { turnId: selectionQuote.turnId } : {}),
+                        turnId: selectionQuote.turnId,
                       });
                       clearSelectionQuote();
                       window.getSelection()?.removeAllRanges();
@@ -713,11 +717,10 @@ export function ChatView(props: {
                   <Button
                     type="button"
                     label={copy.askInSidePanel}
-                    icon={<TextQuote aria-hidden="true" />}
                     onClick={() => {
                       props.onAskAboutSelection?.({
                         text: selectionQuote.text,
-                        ...(selectionQuote.turnId ? { turnId: selectionQuote.turnId } : {}),
+                        turnId: selectionQuote.turnId,
                       });
                       clearSelectionQuote();
                       window.getSelection()?.removeAllRanges();
@@ -727,8 +730,8 @@ export function ChatView(props: {
               </ButtonGroup>
             </div>,
             {
-              x: selectionQuote.rect.left + selectionQuote.rect.width / 2,
-              y: Math.max(8, selectionQuote.rect.top - 42),
+              x: selectionAnchor.x,
+              y: Math.max(8, selectionAnchor.y - 42),
               style: { transform: 'translateX(-50%)' },
             },
           )

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -474,12 +474,10 @@ export function ChatView(props: {
     lightDismiss: true,
     onHide: clearSelectionQuote,
   });
-  // A quote with no anchor is scrolled out of view: keep it, hide the layer.
-  const selectionAnchor = selectionQuote?.anchor ?? null;
   useEffect(() => {
-    if (selectionAnchor) selectionActionsLayer.show();
+    if (selectionQuote) selectionActionsLayer.show();
     else selectionActionsLayer.hide();
-  }, [selectionAnchor, selectionActionsLayer.show, selectionActionsLayer.hide]);
+  }, [selectionQuote, selectionActionsLayer.show, selectionActionsLayer.hide]);
   const selectionActionsLabel = [
     props.onQuoteSelection ? copy.quoteSelection : null,
     props.onAskAboutSelection ? copy.askInSidePanel : null,
@@ -684,7 +682,7 @@ export function ChatView(props: {
             </>
           )}
         </ChatMessageList>
-        {selectionQuote && selectionAnchor && (props.onQuoteSelection || props.onAskAboutSelection) ? (
+        {selectionQuote && (props.onQuoteSelection || props.onAskAboutSelection) ? (
           selectionActionsLayer.render(
             <div
               className="maka-quote-actions"
@@ -730,8 +728,8 @@ export function ChatView(props: {
               </ButtonGroup>
             </div>,
             {
-              x: selectionAnchor.x,
-              y: Math.max(8, selectionAnchor.y - 42),
+              x: selectionQuote.anchor.x,
+              y: Math.max(8, selectionQuote.anchor.y - 42),
               style: { transform: 'translateX(-50%)' },
             },
           )

--- a/packages/ui/src/selection-quote-target.ts
+++ b/packages/ui/src/selection-quote-target.ts
@@ -58,6 +58,10 @@ export function findEnclosingTurnId(
  * only when it carries text and sits inside a turn. Metadata that lives in the
  * transcript but outside any turn — timestamps, progress panels, host-injected
  * cards — resolves to null, because quoting it back to the model says nothing.
+ *
+ * A selection spanning two turns resolves to null for the same reason: its
+ * common ancestor is above both turn roots, and attributing the excerpt to one
+ * turn id would be a lie about where it came from.
  */
 export function resolveQuoteTarget(
   rawText: string,

--- a/packages/ui/src/selection-quote-target.ts
+++ b/packages/ui/src/selection-quote-target.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure resolution of "what did the user select, and which turn does it belong
+ * to". Kept free of DOM globals (`HTMLElement`, `Node`) so it can be tested
+ * under plain Node, and so the hook that owns the listeners stays about timing
+ * rather than about parsing.
+ */
+
+/**
+ * The slice of a DOM node this module walks. Structural typing keeps real
+ * nodes assignable while letting tests build plain object trees.
+ */
+export interface QuoteScopeNode {
+  readonly parentNode: QuoteScopeNode | null;
+  readonly dataset?: { readonly turnId?: string | undefined } | undefined;
+}
+
+/** A selection that is quotable: non-empty text owned by a known turn. */
+export interface QuoteTarget {
+  readonly text: string;
+  readonly turnId: string;
+}
+
+/**
+ * Collapses the whitespace a DOM selection picks up across element
+ * boundaries. Returns null when nothing but whitespace was selected.
+ */
+export function normalizeQuoteText(raw: string): string | null {
+  const text = raw.replace(/\s+/g, ' ').trim();
+  return text === '' ? null : text;
+}
+
+/**
+ * Walks up from `from` to `root`, returning the nearest `data-turn-id` seen on
+ * the way. Reaching the top of the tree without meeting `root` returns null —
+ * that is how a selection outside the transcript is rejected, so callers need
+ * no separate containment check.
+ *
+ * The turn id is only honoured once `root` is actually reached. A turn id
+ * found on an out-of-scope branch (the composer's quote chip carries one) must
+ * not qualify that branch as quotable.
+ */
+export function findEnclosingTurnId(
+  from: QuoteScopeNode | null,
+  root: QuoteScopeNode,
+): string | null {
+  let node = from;
+  let nearest: string | null = null;
+  while (node) {
+    if (node === root) return nearest;
+    nearest ??= node.dataset?.turnId ?? null;
+    node = node.parentNode;
+  }
+  return null;
+}
+
+/**
+ * The single predicate behind the quote affordance: a selection is quotable
+ * only when it carries text and sits inside a turn. Metadata that lives in the
+ * transcript but outside any turn — timestamps, progress panels, host-injected
+ * cards — resolves to null, because quoting it back to the model says nothing.
+ */
+export function resolveQuoteTarget(
+  rawText: string,
+  container: QuoteScopeNode | null,
+  root: QuoteScopeNode,
+): QuoteTarget | null {
+  const text = normalizeQuoteText(rawText);
+  if (text === null) return null;
+  const turnId = findEnclosingTurnId(container, root);
+  if (turnId === null) return null;
+  return { text, turnId };
+}

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useState, type RefObject } from 'react';
-import { resolveQuoteTarget, type QuoteScopeNode } from './selection-quote-target.js';
+import {
+  resolveQuoteTarget,
+  type QuoteScopeNode,
+  type QuoteTarget,
+} from './selection-quote-target.js';
 
 /**
  * How long the selection must hold still before the affordance appears.
@@ -16,28 +20,32 @@ const SELECTION_SETTLE_MS = 350;
  * the selection's current viewport-space anchor point, re-measured while
  * scrolling so it can never describe a position the selection has left.
  */
-export interface MessageSelectionQuote {
-  text: string;
-  /** `data-turn-id` of the turn the selection sits in. */
-  turnId: string;
-  /**
-   * Top-centre of the selection in viewport coordinates, or null while the
-   * selection is scrolled out of view. Null means "nothing to point at right
-   * now", not "no longer quotable" — the quote survives so that scrolling back
-   * restores the affordance.
-   */
-  anchor: { x: number; y: number } | null;
+export interface MessageSelectionQuote extends QuoteTarget {
+  /** Top-centre of the selection, in viewport coordinates. */
+  anchor: { x: number; y: number };
 }
 
-function measureAnchor(): { x: number; y: number } | null {
+/**
+ * The point the layer hangs from, or null when there is nothing to point at.
+ *
+ * The visibility test is against `root`, not the window: the layer lives in
+ * the top layer and is never clipped by the scroller, so a selection scrolled
+ * above the transcript would otherwise be pointed at by a bar sitting over the
+ * header. An off-screen range still reports a full-size rect — only
+ * `display:none` yields a zero one — so being out of view has to be measured,
+ * not inferred from the rect collapsing.
+ */
+function measureAnchor(root: HTMLElement): { x: number; y: number } | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
   const box = selection.getRangeAt(0).getBoundingClientRect();
   if (box.width === 0 && box.height === 0) return null;
+  const band = root.getBoundingClientRect();
+  if (box.top < band.top || box.top > band.bottom) return null;
   return { x: box.left + box.width / 2, y: box.top };
 }
 
-function readSelection(root: HTMLElement): Omit<MessageSelectionQuote, 'anchor'> | null {
+function readSelection(root: HTMLElement): QuoteTarget | null {
   const selection = window.getSelection();
   if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
   const container = selection.getRangeAt(0).commonAncestorContainer as unknown as QuoteScopeNode;
@@ -70,6 +78,12 @@ export function useMessageSelectionQuote(
   // Dismissal needs no "stay dismissed" flag: `selectionchange` is the only
   // thing that can recompute the quote, and dismissing (Escape, light-dismiss,
   // consuming the action) does not change the selection. Clearing is enough.
+  //
+  // One acknowledged gap: Escape pressed inside the settle window does not
+  // cancel the pending show, because there is no layer yet for it to dismiss.
+  // Cancelling would take a keydown listener — the class of listener this hook
+  // exists to be rid of — to buy back a 350ms window in which the user has
+  // nothing on screen to dismiss.
   const clear = useCallback(() => setQuote(null), []);
 
   useEffect(() => {
@@ -81,7 +95,7 @@ export function useMessageSelectionQuote(
       const root = scrollRef.current;
       if (!root) return;
       const target = readSelection(root);
-      const anchor = target ? measureAnchor() : null;
+      const anchor = target ? measureAnchor(root) : null;
       setQuote(target && anchor ? { ...target, anchor } : null);
     }
 
@@ -94,15 +108,22 @@ export function useMessageSelectionQuote(
     }
 
     /**
-     * Scrolling moves the selection, not the quote. Re-measuring keeps the
-     * layer on it; a selection scrolled out of the viewport measures to
-     * nothing, so the layer hides until it scrolls back.
+     * Scrolling moves the selection, not the quote, so the layer follows it —
+     * up to the edge of the scroller. Past that the anchor is gone and so is
+     * the quote: keeping it to restore on the way back cannot work, because
+     * hiding the layer runs `onHide`, which clears the quote anyway.
+     *
+     * Measured before `setQuote` rather than inside the updater: an updater
+     * must be pure, and reading layout is not.
      */
     function onScroll(): void {
+      const root = scrollRef.current;
+      if (!root) return;
+      const anchor = measureAnchor(root);
       setQuote((current) => {
         if (!current) return current;
-        const anchor = measureAnchor();
-        if (anchor?.x === current.anchor?.x && anchor?.y === current.anchor?.y) return current;
+        if (!anchor) return null;
+        if (anchor.x === current.anchor.x && anchor.y === current.anchor.y) return current;
         return { ...current, anchor };
       });
     }

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -1,26 +1,60 @@
 import { useCallback, useEffect, useState, type RefObject } from 'react';
+import { resolveQuoteTarget, type QuoteScopeNode } from './selection-quote-target.js';
+
+/**
+ * How long the selection must hold still before the affordance appears.
+ * Selecting text usually means "copy this", or is just a reading habit; only a
+ * selection the user stops on carries enough intent to earn a floating action.
+ * The pause also covers drag-select and shift+arrow, which fire a burst of
+ * `selectionchange` events that would otherwise flash the layer mid-gesture.
+ */
+const SELECTION_SETTLE_MS = 350;
 
 /**
  * A live text selection inside the chat transcript, captured as a quotable
- * excerpt for the "quote this" affordance (Codex/Cursor-style). The `rect` is
- * the selection's viewport-space bounding box, used to position the floating
- * action near the selection.
+ * excerpt for the "quote this" affordance (Codex/Cursor-style). `anchor` is
+ * the selection's current viewport-space anchor point, re-measured while
+ * scrolling so it can never describe a position the selection has left.
  */
 export interface MessageSelectionQuote {
   text: string;
-  /** `data-turn-id` of the turn the selection sits in, when resolvable. */
-  turnId?: string;
-  rect: { top: number; left: number; bottom: number; right: number; width: number };
+  /** `data-turn-id` of the turn the selection sits in. */
+  turnId: string;
+  /**
+   * Top-centre of the selection in viewport coordinates, or null while the
+   * selection is scrolled out of view. Null means "nothing to point at right
+   * now", not "no longer quotable" — the quote survives so that scrolling back
+   * restores the affordance.
+   */
+  anchor: { x: number; y: number } | null;
+}
+
+function measureAnchor(): { x: number; y: number } | null {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
+  const box = selection.getRangeAt(0).getBoundingClientRect();
+  if (box.width === 0 && box.height === 0) return null;
+  return { x: box.left + box.width / 2, y: box.top };
+}
+
+function readSelection(root: HTMLElement): Omit<MessageSelectionQuote, 'anchor'> | null {
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
+  const container = selection.getRangeAt(0).commonAncestorContainer as unknown as QuoteScopeNode;
+  return resolveQuoteTarget(selection.toString(), container, root as unknown as QuoteScopeNode);
 }
 
 /**
- * Watches for a non-empty text selection within `scrollRef` (the messages
- * container) and exposes a captured snapshot as a
- * {@link MessageSelectionQuote}. The snapshot survives native selection
- * collapse so keyboard and accessibility activation can reach the action that
- * owns it; consumers explicitly clear it when that action is dismissed or
- * consumed. Scrolling still clears it because its rect would be stale.
- * Read-only: the hook never mutates the selection, so native copy still works.
+ * Watches for a settled text selection inside `scrollRef` (the messages
+ * container) and exposes it as a {@link MessageSelectionQuote}. Read-only: the
+ * hook never mutates the selection, so native copy still works.
+ *
+ * The selection is the single source of truth — the quote is derived from it
+ * on every relevant event rather than snapshotted, so there is no stale state
+ * to expire. `selectionchange` is the only trigger: it is the one event that
+ * means the selection actually became something else. Watching key or pointer
+ * events instead resurrects a dismissed layer on the next unrelated keystroke,
+ * which is why Escape could not close this before.
  *
  * Listeners live on `document` and resolve `scrollRef.current` at event time —
  * binding them to the element instead would capture whatever the ref held on
@@ -33,61 +67,55 @@ export function useMessageSelectionQuote(
   enabled: boolean,
 ): { quote: MessageSelectionQuote | null; clear: () => void } {
   const [quote, setQuote] = useState<MessageSelectionQuote | null>(null);
+  // Dismissal needs no "stay dismissed" flag: `selectionchange` is the only
+  // thing that can recompute the quote, and dismissing (Escape, light-dismiss,
+  // consuming the action) does not change the selection. Clearing is enough.
   const clear = useCallback(() => setQuote(null), []);
 
   useEffect(() => {
     if (!enabled) return;
 
-    function computeQuote(): MessageSelectionQuote | null {
+    let settleTimer = 0;
+
+    function settle(): void {
       const root = scrollRef.current;
-      if (!root) return null;
-      const selection = window.getSelection();
-      if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
-      const text = selection.toString().replace(/\s+/g, ' ').trim();
-      if (!text) return null;
-      const range = selection.getRangeAt(0);
-      if (!root.contains(range.commonAncestorContainer)) return null;
-      let node: Node | null = range.commonAncestorContainer;
-      let turnId: string | undefined;
-      while (node && node !== root) {
-        if (node instanceof HTMLElement && node.dataset.turnId) {
-          turnId = node.dataset.turnId;
-          break;
-        }
-        node = node.parentNode;
-      }
-      const box = range.getBoundingClientRect();
-      if (box.width === 0 && box.height === 0) return null;
-      return {
-        text,
-        ...(turnId ? { turnId } : {}),
-        rect: {
-          top: box.top,
-          left: box.left,
-          bottom: box.bottom,
-          right: box.right,
-          width: box.width,
-        },
-      };
+      if (!root) return;
+      const target = readSelection(root);
+      const anchor = target ? measureAnchor() : null;
+      setQuote(target && anchor ? { ...target, anchor } : null);
     }
 
-    function capture(): void {
-      const nextQuote = computeQuote();
-      if (nextQuote) setQuote(nextQuote);
+    function onSelectionChange(): void {
+      // Hide first, re-show only once the selection settles: a layer anchored
+      // to the previous selection is wrong the moment that selection changes.
+      setQuote(null);
+      window.clearTimeout(settleTimer);
+      settleTimer = window.setTimeout(settle, SELECTION_SETTLE_MS);
     }
 
-    // mouseup finalizes a drag-select; keyup covers keyboard (shift+arrow)
-    // selection. These events only capture; dismissal and consumption own
-    // clearing the snapshot. Scroll is capture-phase because it does not bubble.
-    document.addEventListener('mouseup', capture);
-    document.addEventListener('keyup', capture);
-    document.addEventListener('scroll', clear, { capture: true, passive: true });
+    /**
+     * Scrolling moves the selection, not the quote. Re-measuring keeps the
+     * layer on it; a selection scrolled out of the viewport measures to
+     * nothing, so the layer hides until it scrolls back.
+     */
+    function onScroll(): void {
+      setQuote((current) => {
+        if (!current) return current;
+        const anchor = measureAnchor();
+        if (anchor?.x === current.anchor?.x && anchor?.y === current.anchor?.y) return current;
+        return { ...current, anchor };
+      });
+    }
+
+    document.addEventListener('selectionchange', onSelectionChange);
+    // Capture-phase: scroll does not bubble.
+    document.addEventListener('scroll', onScroll, { capture: true, passive: true });
     return () => {
-      document.removeEventListener('mouseup', capture);
-      document.removeEventListener('keyup', capture);
-      document.removeEventListener('scroll', clear, { capture: true });
+      window.clearTimeout(settleTimer);
+      document.removeEventListener('selectionchange', onSelectionChange);
+      document.removeEventListener('scroll', onScroll, { capture: true });
     };
-  }, [scrollRef, enabled, clear]);
+  }, [scrollRef, enabled]);
 
   return { quote, clear };
 }


### PR DESCRIPTION
## Summary

The 引用 / 在侧栏追问 layer fired on almost every selection and could not be dismissed. Selecting text usually means "copy this", so treating any selection as intent to quote made the affordance noise.

Three defects shared one model error: the hook snapshotted the selection instead of deriving from it. It only ever *wrote* the snapshot, so an unresolvable selection left the previous one standing (selecting in the composer appeared to raise a transcript affordance). It captured on every `keyup`, so any keystroke resurrected a layer just closed with Escape. And it stored the rect, which goes stale on scroll — forcing a scroll listener that cleared the quote outright.

The fix derives from the live selection:

- `selectionchange` is the only trigger, and the selection must hold still 350ms. Drag-select no longer flashes the layer mid-gesture. Dismissal then needs no "stay dismissed" flag — nothing else recomputes the quote.
- Position is measured from the current selection and re-measured on scroll, so the layer follows it; once the anchor leaves the scroller's visible band the quote is dropped.
- A selection resolves only inside `[data-turn-id]`, and only after the walk reaches the transcript root — the composer's quote chip carries a turn id. `turnId` is now required on both callbacks.
- Icons dropped: the labels already name the actions. 187×28 → 147×28 over the covered text. Still Astryx `ButtonGroup size="sm"`, no size overrides.

Two external adversarial reviews independently found one real defect in the first version: a selection scrolled out of view left the layer clamped to the top of the window pointing at nothing. `getBoundingClientRect()` returns real negative coordinates for an off-screen range — only `display:none` yields a zero rect — so the zero-size guard never fired and the `anchor: null` path was dead. It could not have worked anyway: `useLayer`'s `hide()` calls `onHide` unconditionally (`Layer/useLayer.tsx:411`), and `onHide` clears the quote. So the state was deleted rather than guarded.

## Verification

- E2E `quote-companion`: 4 passed, run repeatedly for flake. Covers the settle delay (measured in-page so host load cannot skew it), a real mouse drag-select, Escape, the composer, scroll-follow, scroll-out, and hide-on-new-selection.
- `packages/ui`: 454 passed, incl. 12 unit tests for the resolution rules.
- `lint`, `format:check`, `apps/desktop typecheck` clean.
- Mutation-checked: settle delay → 0, band check removed, and hide-first removed each fail exactly the intended test and no other.

## Known gap

Escape pressed inside the 350ms settle window does not cancel the pending show. Cancelling needs a `keydown` listener — the class of listener this hook exists to remove — to cover a window in which nothing is on screen to dismiss. Recorded in the hook.