### PR TITLE
fix(ui): only show the previous-question button when a previous question exists

### DIFF
--- a/apps/desktop/e2e/ask-user-question.spec.ts
+++ b/apps/desktop/e2e/ask-user-question.spec.ts
@@ -40,11 +40,23 @@ test('answers three questions and continues the same fake-backend turn', async (
   await selectedOption.click();
   await expect(selectedOption).toBeChecked();
   await expect(unselectedOption).not.toBeChecked();
+  // The first question has nothing to go back to: no previous button at all,
+  // not a disabled one.
+  const previous = prompt.getByRole('button', { name: '上一题' });
+  await expect(previous).toHaveCount(0);
   const next = prompt.getByRole('button', { name: '下一题' });
   await next.click();
 
   await expect(prompt.getByText('2 / 3', { exact: true })).toBeVisible();
   await expect(next).toBeFocused();
+  // Going back keeps the answer already chosen on the first question.
+  await expect(previous).toBeVisible();
+  await previous.click();
+  await expect(prompt.getByText('1 / 3', { exact: true })).toBeVisible();
+  await expect(selectedOption).toBeChecked();
+  await expect(previous).toHaveCount(0);
+  await next.click();
+  await expect(prompt.getByText('2 / 3', { exact: true })).toBeVisible();
   const thisWeek = prompt.getByRole('radio', { name: '本周' });
   const nextWeek = prompt.getByRole('radio', { name: '下周' });
   await thisWeek.focus();

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -355,6 +355,29 @@ describe('localized conversation journey', () => {
     }
   });
 
+  it('does not render the previous-question button on the first of several questions', () => {
+    const multiQuestionRequest = {
+      ...questionRequest,
+      questions: [
+        { question: 'First?', options: [{ label: 'A' }] },
+        { question: 'Second?', options: [{ label: 'B' }] },
+      ],
+    } satisfies UserQuestionRequestEvent;
+    const surface = (
+      <UserQuestionPrompt request={multiQuestionRequest} onRespond={() => {}} onStop={() => {}} />
+    );
+    assert.doesNotMatch(render('zh', surface), /上一题/);
+    assert.doesNotMatch(render('en', surface), /Previous/);
+  });
+
+  it('does not render the previous-question button for a single-question prompt', () => {
+    const surface = (
+      <UserQuestionPrompt request={questionRequest} onRespond={() => {}} onStop={() => {}} />
+    );
+    assert.doesNotMatch(render('zh', surface), /上一题/);
+    assert.doesNotMatch(render('en', surface), /Previous/);
+  });
+
   it('localizes sandbox boundary chrome while preserving exact requested scopes', () => {
     const surface = <SandboxBoundaryPrompt request={sandboxBoundaryRequest} onRespond={() => {}} />;
     const zh = render('zh', surface);

--- a/packages/ui/src/user-question-prompt.tsx
+++ b/packages/ui/src/user-question-prompt.tsx
@@ -129,12 +129,14 @@ export function UserQuestionPrompt(props: {
             onClick={() => void props.onStop()}
             label={props.stopPending ? copy.stopping : copy.stop}
           />
-          <Button
-            variant="ghost"
-            isDisabled={questionIndex === 0 || interactionDisabled}
-            onClick={() => setQuestionIndex((current) => current - 1)}
-            label={copy.previous}
-          />
+          {questionIndex > 0 ? (
+            <Button
+              variant="ghost"
+              isDisabled={interactionDisabled}
+              onClick={() => setQuestionIndex((current) => current - 1)}
+              label={copy.previous}
+            />
+          ) : null}
           <Button
             variant="primary"
             className="maka-question-submit"


### PR DESCRIPTION
Closes #2354

## 问题

AskUserQuestion 弹窗底部操作区**始终渲染**"上一题"按钮，只用 `isDisabled` 在 `questionIndex === 0` 时禁用：

- 单问题模式：`questionIndex` 恒为 0，按钮永远禁用但一直占据 UI
- 多问题模式第一题：同样显示一个禁用的"上一题"，第一题没有可回的上一题

期望：第一题（含单问题场景）不显示"上一题"；从第二题开始才显示。

## 修复

`packages/ui/src/user-question-prompt.tsx`：将无条件渲染 + `isDisabled` 改为按 `questionIndex > 0` **条件渲染**，并去掉冗余的 `questionIndex === 0` 禁用判断（渲染条件已保证"有题可回"）。

## 测试

- **SSR 单测**（`conversation-localization.test.tsx`，+2）：单问题不渲染 `上一题`/`Previous`；多问题首题不渲染
- **e2e**（`ask-user-question.spec.ts`，扩展三题流程）：首题按钮 `toHaveCount(0)`；次题出现"上一题"，点击回退后已选答案保留、按钮消失，再前进继续原流程
- 本地验证：`packages/ui` 444/444 通过；`ask-user-question.spec.ts` 2/2 通过（Playwright + Electron）；biome 干净

## 行为对照

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 单个问题 | 禁用"上一题"常驻 | 不显示 |
| 多问题·第一题 | 禁用"上一题"常驻 | 不显示 |
| 多问题·第二题起 | 可用"上一题" | 可用"上一题"（不变） |