### PR TITLE
refactor(ui): hand the chat meta row back to Astryx primitives

### DIFF
--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -175,35 +175,41 @@
    Markdown; PR 8 owns the remaining streaming and scroll-anchoring boundary. */
 
 /* --- User-turn meta row (relocated from tool-output.css) ----------------- */
-/* PR-CHAT-CHROME-FOLLOWUP-0 / PR5 CHAT-MESSAGE-TIME-0: the relative time is
-   always visible now (it was `opacity: 0` until hover, which hid it on
-   touch + from assistive tech). It stays quiet — caption tier at
-   normal weight, muted — and rides in the user turn's meta row beneath
-   the block. Aligned to the same tier the footer-action cva uses (text-xs). */
-/* #1879: height off the control ruler, not off the line box. `inline-block`
-   let the leading decide the box — measured, bumping this element's own
-   leading to 40px took the box from 20px to 40px and carried the meta row
-   with it. `--h-control-xs` is 20px, the value the supporting leading
-   already resolves to, so the pin is pixel-neutral today and load-bearing
-   the next time a leading moves. Safe to pin because `white-space: nowrap`
-   below makes single-line a property of this box rather than an assumption. */
+/* The time is an Astryx `Timestamp`, so the quiet register (supporting tier,
+   secondary colour) is the component's own default and is not restated here.
+   What stays is what the component does not decide:
+
+   - #1879: height off the control ruler, not off the line box. Measured then,
+     bumping this element's leading to 40px took the box from 20px to 40px and
+     carried the meta row with it. `--h-control-xs` is 20px, what the supporting
+     leading already resolves to, so the pin is pixel-neutral today and
+     load-bearing the next time a leading moves. Safe to pin because `nowrap`
+     makes single-line a property of this box rather than an assumption.
+   - `tabular-nums`, because `Timestamp`'s `time` format renders the hour with
+     `hour: 'numeric'` — no leading zero, so `9:05` and `14:32` differ by a
+     digit. The row is right-aligned, so that difference shows up on the left
+     edge; equal-width digits keep it to the one character it really is. */
 .maka-message-time-inline {
-  font: var(--maka-text-supporting);
   height: var(--h-control-xs);
   display: inline-flex;
   align-items: center;
-  color: var(--muted-foreground);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
 /* User turn meta row: quiet time + a copy affordance, right-aligned
    beneath the message block (the parent `Message role="user"` aligns its
-   items to flex-end, so this row shrink-wraps and hugs the right edge). */
+   items to flex-end, so this row shrink-wraps and hugs the right edge).
+
+   The row's own box is 28px — the height of the action buttons, not of the
+   12px time beside them — so it reads tighter against the bubble than its
+   4px top margin suggests. Astryx's default is nudged one step to 6px to give
+   the row back some air without opening a visible gap. */
 .maka-message-meta {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1-5);
+  margin-top: var(--space-1-5);
 }
 
 /* Turn summary / lineage rows / footer measure column folded into the

--- a/packages/ui/src/chat-display-helpers.ts
+++ b/packages/ui/src/chat-display-helpers.ts
@@ -38,20 +38,12 @@ export function formatAbsoluteTimestamp(ts: number, locale: UiLocale): string {
   return createAbsoluteTimeFormat(locale).format(new Date(ts));
 }
 
-function createClockTimeFormat(locale: UiLocale): Intl.DateTimeFormat {
-  if (typeof Intl === 'undefined' || typeof Intl.DateTimeFormat !== 'function') {
-    return { format: (d: Date) => d.toISOString().slice(11, 16) } as unknown as Intl.DateTimeFormat;
-  }
-  return new Intl.DateTimeFormat(
-    uiLocaleToIntlLocale(locale),
-    { hour: '2-digit', minute: '2-digit', hour12: false },
-  );
-}
-
-/** Wall-clock `HH:mm` (24-hour), for the always-absolute user-message time. */
-export function formatClockTime(ts: number, locale: UiLocale): string {
-  return createClockTimeFormat(locale).format(new Date(ts));
-}
+/* `formatClockTime` (a 24-hour `HH:mm` for the user-message time) lived here
+   until the meta row moved to Astryx's `Timestamp`. Locking the hour cycle was
+   the app overriding a preference that belongs to the reader's system, which is
+   why `Timestamp` formats against the host locale and offers no hour-cycle
+   knob. Absolute readings now come from that component, not from a local bag of
+   `Intl` options. */
 
 export function formatTurnDuration(ms: number): string {
   // Same shape as tool-activity's formatDuration — the turn meta chip

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -3,7 +3,7 @@ import { useMountedRef } from './use-mounted-ref.js';
 import { AlertOctagon, Ban, Check, Copy, GitBranch, Info, Loader2, Pencil, RefreshCcw, Timer } from './icons.js';
 import { type ClipboardCopyPhase, useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { Markdown } from './markdown.js';
-import { formatAbsoluteTimestamp, formatClockTime, turnAbortMarkerLabel } from './chat-display-helpers.js';
+import { turnAbortMarkerLabel } from './chat-display-helpers.js';
 import { redactSecrets } from './redact.js';
 import { isProgressiveStreamingEnabled } from './streaming-presentation.js';
 import {
@@ -17,6 +17,7 @@ import {
   HStack,
   IconButton as UiIconButton,
   Thumbnail,
+  Timestamp,
   Token,
   useLightbox,
 } from '@astryxdesign/core';
@@ -42,6 +43,17 @@ import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 import { AstryxLocaleProvider } from './astryx-i18n.js';
 import { InlineReferenceText } from './inline-reference.js';
+
+/* A size has to be passed: Astryx's `sm` button bounds the icon slot at 16px
+   (Button.tsx's `iconSizeStyles`) but does not resize the glyph inside it, so an
+   unsized lucide icon keeps its own 24px height and renders 16×24, squashed.
+
+   14 rather than the slot's own 16, because `--icon-size` (maka-tokens.css)
+   scopes that token to "nav + button icons" and sends "dense meta (12-14)" back
+   to the call site — this row is dense meta. 14 is also where the same position
+   already sits most often across the app. Named rather than repeated at four
+   call sites: one value, one place to read why. */
+const FOOTER_ICON_SIZE = 14;
 
 export function LocalizedChatMessage({
   accessibleLabel,
@@ -161,34 +173,30 @@ const MessageBody = memo(function MessageBody(props: {
         className="maka-message-meta"
         timestamp={
           props.ts !== undefined ? (
-            <small
-              className="maka-message-time-inline tabular-nums"
-              aria-hidden="true"
-              title={formatAbsoluteTimestamp(props.ts, locale)}
-            >
-              {formatClockTime(props.ts, locale)}
-            </small>
+            /* `value` takes ms directly: Timestamp's own parseValue reads
+               anything past 1e12 as milliseconds (2001-09-09 onward), and a
+               chat message never predates that. */
+            <Timestamp className="maka-message-time-inline" value={props.ts} format="time" />
           ) : undefined
         }
         footer={
           <>
             <MessageCopyButton text={props.text} />
             {props.onEditUserMessage ? (
-              <Tooltip content={editActionLabel}>
-                <UiIconButton
-                  label={editActionLabel}
-                  icon={<Pencil size={12} aria-hidden="true" />}
-                  variant="ghost"
-                  size="sm"
-                  className={markerVariants({ variant: 'footer-action' })}
-                  aria-disabled={props.editDisabled === true ? 'true' : undefined}
-                  data-action="edit"
-                  onClick={() => {
-                    if (props.editDisabled) return;
-                    props.onEditUserMessage?.();
-                  }}
-                />
-              </Tooltip>
+              <UiIconButton
+                label={editActionLabel}
+                tooltip={editActionLabel}
+                icon={<Pencil size={FOOTER_ICON_SIZE} aria-hidden="true" />}
+                variant="ghost"
+                size="sm"
+                className={markerVariants({ variant: 'footer-action' })}
+                aria-disabled={props.editDisabled === true ? 'true' : undefined}
+                data-action="edit"
+                onClick={() => {
+                  if (props.editDisabled) return;
+                  props.onEditUserMessage?.();
+                }}
+              />
             ) : null}
           </>
         }
@@ -270,25 +278,24 @@ function MessageCopyButton(props: { text: string }) {
         ? copyText.copyFailed
         : baseLabel;
   const icon = copied
-    ? <Check size={12} aria-hidden="true" />
-    : <Copy size={12} aria-hidden="true" />;
+    ? <Check size={FOOTER_ICON_SIZE} aria-hidden="true" />
+    : <Copy size={FOOTER_ICON_SIZE} aria-hidden="true" />;
 
   return (
-    <Tooltip content={actionLabel}>
-      <UiIconButton
-        label={baseLabel}
-        icon={icon}
-        variant="ghost"
-        size="sm"
-        className={markerVariants({ variant: 'footer-action' })}
-        aria-busy={copyPending ? 'true' : undefined}
-        isDisabled={copyPending}
-        data-copied={copied}
-        data-copy-feedback={copyPhase ?? undefined}
-        data-pending={copyPending ? 'true' : undefined}
-        onClick={() => void copy()}
-      />
-    </Tooltip>
+    <UiIconButton
+      label={baseLabel}
+      tooltip={actionLabel}
+      icon={icon}
+      variant="ghost"
+      size="sm"
+      className={markerVariants({ variant: 'footer-action' })}
+      aria-busy={copyPending ? 'true' : undefined}
+      isDisabled={copyPending}
+      data-copied={copied}
+      data-copy-feedback={copyPhase ?? undefined}
+      data-pending={copyPending ? 'true' : undefined}
+      onClick={() => void copy()}
+    />
   );
 }
 
@@ -749,24 +756,24 @@ function TurnFooterActions(props: {
               ? (copyPhase ? copyFeedbackLabel : (action.tooltip ?? action.label))
               : (action.tooltip ?? action.label);
             const icon = isCopyAction && copyPhase === 'copied'
-              ? <Check size={12} aria-hidden="true" />
+              ? <Check size={FOOTER_ICON_SIZE} aria-hidden="true" />
               : STATUS_FOOTER_ICON[action.id];
             return (
-              <Tooltip key={action.id} content={tooltipText}>
-                <UiIconButton
-                  label={action.label}
-                  icon={icon}
-                  variant="ghost"
-                  size="sm"
-                  className={markerVariants({ variant: 'footer-action' })}
-                  data-action={action.id}
-                  data-pending={isActionPending || undefined}
-                  data-copy-feedback={isCopyAction && copyPhase ? copyPhase : undefined}
-                  aria-disabled={!action.enabled || copyIsPending}
-                  aria-busy={isActionPending || undefined}
-                  onClick={() => void handleClick(action)}
-                />
-              </Tooltip>
+              <UiIconButton
+                key={action.id}
+                label={action.label}
+                tooltip={tooltipText}
+                icon={icon}
+                variant="ghost"
+                size="sm"
+                className={markerVariants({ variant: 'footer-action' })}
+                data-action={action.id}
+                data-pending={isActionPending || undefined}
+                data-copy-feedback={isCopyAction && copyPhase ? copyPhase : undefined}
+                aria-disabled={!action.enabled || copyIsPending}
+                aria-busy={isActionPending || undefined}
+                onClick={() => void handleClick(action)}
+              />
             );
           })}
         </>
@@ -776,10 +783,10 @@ function TurnFooterActions(props: {
 }
 
 const STATUS_FOOTER_ICON: Record<TurnFooterActionMeta['id'], ReactNode> = {
-  regenerate: <RefreshCcw size={12} aria-hidden="true" />,
-  branch: <GitBranch size={12} aria-hidden="true" />,
-  copy: <Copy size={12} aria-hidden="true" />,
-  info: <Info size={12} aria-hidden="true" />,
+  regenerate: <RefreshCcw size={FOOTER_ICON_SIZE} aria-hidden="true" />,
+  branch: <GitBranch size={FOOTER_ICON_SIZE} aria-hidden="true" />,
+  copy: <Copy size={FOOTER_ICON_SIZE} aria-hidden="true" />,
+  info: <Info size={FOOTER_ICON_SIZE} aria-hidden="true" />,
 };
 
 export function ModelProcessingIndicator() {

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -79,9 +79,39 @@
   font: var(--maka-text-body);
  margin: 0; color: var(--muted-foreground); }
 
-.maka-message-meta { opacity: 0; transition: opacity var(--duration-quick) var(--ease-out-strong); }
-.maka-user-message:hover .maka-message-meta,
-.maka-user-message:focus-within .maka-message-meta { opacity: 1; }
+/* The meta row holds two different kinds of thing, so it gets two different
+   rules. The time is content — a fact about the message — and stays put; gating
+   it on hover is what hid it from touch and from assistive tech. The actions are
+   chrome and only surface on hover or focus. Astryx already splits these into a
+   `timestamp` and a `footer` slot; the gate belongs on the slot, not on the row
+   that contains both.
+
+   The `· ` between the two slots is Astryx's own separator, rendered whenever
+   the timestamp has something to be separated FROM. It is dropped rather than
+   gated: the two slots already read as separate at rest, since one is text and
+   the other a row of controls that fades in beside it, so the bullet adds a mark
+   without adding a distinction. The slots carry no class of their own, so it is
+   addressed positionally — the timestamp is the first child span and the
+   separator the one right after it (the footer's own children are buttons).
+
+   A transparent action still takes clicks, here and on the assistant footer.
+   `pointer-events: none` looks like the fix and is not obviously safe: it makes
+   the pointer fall through to the ancestor whose `:hover` is what restores the
+   button, so being clickable again depends on the browser redoing hit-testing
+   on a later mouse event. Continuous movement gets there; a jump that lands and
+   stops was not something this surface could be made to reproduce. Left as-is
+   rather than traded for a failure mode that could not be demonstrated. */
+.maka-message-meta > span + span {
+  display: none;
+}
+.maka-message-meta .maka-turn-footer-action {
+  opacity: 0;
+  transition: opacity var(--duration-quick) var(--ease-out-strong);
+}
+.maka-user-message:hover .maka-message-meta .maka-turn-footer-action,
+.maka-user-message:focus-within .maka-message-meta .maka-turn-footer-action {
+  opacity: 1;
+}
 .maka-user-quotes { display: flex; max-width: 100%; flex-wrap: wrap; align-items: flex-start; gap: 4px; }
 .maka-assistant-answer-content { display: flex; width: 100%; min-width: 0; flex-direction: column; gap: 8px; }
 .maka-live-turn-footer-placeholder { height: 32px; margin-top: 2px; }


### PR DESCRIPTION
## Summary

The row under a chat message reimplemented parts Astryx already ships, and every visible defect in it traced back to one of those reimplementations.

- **Time.** A hand-rolled `<small>` carried a native `title` and `aria-hidden`, so the absolute reading was mouse-only and the visible one was hidden from assistive tech. It is now `Timestamp` — a semantic `<time datetime>` with a copyable hover card, and exactly what `ChatMessageMetadata`'s own docs put in that slot. `formatClockTime` had no other caller and is deleted.
- **Icons.** Four separate `12` literals became one named constant at `14`. `--icon-size` reserves 12–14 for "dense meta" and this row is dense meta; 14 is also where the same position already sits most often across the app. A size must be passed at all because Astryx's `sm` button bounds the icon slot at 16px without resizing the glyph — measured, an unsized lucide icon renders 16×24, squashed.
- **Tooltips.** Each button was wrapped in a `<Tooltip>` element. `Button` takes a `tooltip` prop and attaches the same behaviour through a hook, which is what its source recommends. The `display: contents` wrapper is gone and `aria-describedby` now resolves — previously it computed to nothing, which is why call sites carried hand-written `aria-label` fallbacks.
- **Hover gate.** It sat on the whole row and so covered the time too, contrary to what the comment directly above it claimed. It moves to the footer slot, so the time stays visible. Astryx's `·` separator is dropped rather than gated: with the time always present and the actions fading in beside it, the bullet added a mark without adding a distinction.
- **Spacing.** The row's top margin goes 4px → 6px. Its box is the 28px height of the buttons, not the 12px of the time, so it sat tighter against the bubble than its margin suggested.

**Behaviour change worth knowing:** the hour cycle now follows the host locale instead of a hardcoded `hour12: false`. Most locales are unaffected (`14:32` in zh / en-GB / ja / de / fr); en-US renders `2:32 PM`. The hour also loses its leading zero (`9:05`, not `09:05`), which is why `tabular-nums` stays on that element.

Refs #2359 — the icon sizing policy this lands against is unenforced repo-wide (145 hardcoded sizes across 11 values). This PR deliberately does not attempt that sweep.

## Verification

- `npm run -w @maka/ui test` — 442 passing
- `npm run -w @maka/ui typecheck`, `npm --workspace @maka/desktop run typecheck` — clean
- `npm run lint`, `npm run format:check` — clean
- `node scripts/check-dead-css.mjs --check`, `node scripts/check-a11y.mjs` — clean
- Not run: Playwright E2E and the desktop main-process suite — this change is renderer-only presentation with no journey or IPC surface.

Checked against computed styles in Storybook (`Product/Shell Official AppShell → Native Conversation`) rather than by eye:

| | result |
|---|---|
| time element | `<time datetime="…">`, no `aria-hidden`, opacity 1 at rest |
| separator | `display: none` |
| icon | 14×14 in a 16px slot, 28px button, stroke 1.75 (the globally governed value) |
| tooltip wiring | button is a direct child of the meta row, `aria-describedby` resolves |
| spacing | row `margin-top: 6px` |

## Review focus

`pointer-events: none` was tried on the transparent actions — a transparent button still takes clicks — and reverted. It makes the pointer fall through to the ancestor whose `:hover` is what restores the button, so being clickable again depends on the browser redoing hit-testing on a later mouse event. Continuous movement gets there; a pointer that jumps onto the button and stops could not be reproduced on this surface, so the fix could not be demonstrated safe. The pre-existing behaviour is left untouched and the reasoning is recorded in the CSS.

