### PR TITLE
fix: preserve operational state across schema upgrades

### DIFF
--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -77,7 +77,6 @@ import {
   createMcpConfigStore,
   createSqliteModelCallLedger,
   createSqliteTelemetryRepo,
-  resetIncompatibleOperationalStateDatabase,
 } from '@maka/storage';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
@@ -223,10 +222,6 @@ if (e2eFixture) {
     app.exit(0);
     await new Promise<never>(() => {});
   }
-}
-
-if (resetIncompatibleOperationalStateDatabase(workspaceRoot)) {
-  console.warn('[startup] cleared incompatible operational state');
 }
 
 async function confirmDesktopStorageRootRepair(): Promise<boolean> {

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -5,11 +5,10 @@ import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { test } from 'node:test';
 import type { SessionHeader } from '@maka/core';
-import {
-  acquireOperationalStateDatabase,
-  resetIncompatibleOperationalStateDatabase,
-} from '../operational-state-store.js';
+import { acquireOperationalStateDatabase } from '../operational-state-store.js';
 import { SQLITE_RUNTIME_SCHEMA_VERSION } from '../sqlite-runtime-schema.js';
+import { SQLITE_SESSION_METADATA_SCHEMA_VERSION } from '../sqlite-session-metadata-schema.js';
+import { SQLITE_USAGE_SCHEMA_VERSION } from '../sqlite-usage-schema.js';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
 
 test('shares one operational database and produces an online backup', async () => {
@@ -55,7 +54,6 @@ test('preserves operational state when every schema is current', async () => {
     lease.database.exec("INSERT INTO compatibility_sentinel(value) VALUES ('preserved')");
     lease.close();
 
-    assert.equal(resetIncompatibleOperationalStateDatabase(root), false);
     const reopened = acquireOperationalStateDatabase(root);
     assert.equal(
       (
@@ -71,32 +69,189 @@ test('preserves operational state when every schema is current', async () => {
   }
 });
 
-test('clears operational state instead of migrating an incompatible schema', async (context) => {
-  for (const version of [SQLITE_RUNTIME_SCHEMA_VERSION - 1, SQLITE_RUNTIME_SCHEMA_VERSION + 1]) {
-    await context.test(`schema ${version}`, async () => {
-      const root = await mkdtemp(join(tmpdir(), 'maka-operational-incompatible-'));
-      const databasePath = join(root, 'runtime.sqlite');
-      try {
-        const lease = acquireOperationalStateDatabase(root);
-        lease.close();
-        const database = new DatabaseSync(databasePath);
-        database.exec(`PRAGMA user_version = ${version}`);
-        database.close();
+test('migrates older operational state without losing sessions or messages', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-upgrade-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    const lease = acquireOperationalStateDatabase(root);
+    const metadata = createSqliteSessionMetadataStore(databasePath, { databaseLease: lease });
+    await metadata.importSession(
+      sessionHeader(),
+      [{ type: 'user', id: 'message-1', turnId: 'turn-1', ts: 3, text: 'keep me' }],
+      { lastMessageAt: 3, lastMessagePreview: 'keep me' },
+    );
+    metadata.close();
 
-        assert.equal(resetIncompatibleOperationalStateDatabase(root), true);
-        const rebuilt = acquireOperationalStateDatabase(root);
-        assert.equal(
-          (rebuilt.database.prepare('PRAGMA user_version').get() as { user_version: number })
-            .user_version,
-          SQLITE_RUNTIME_SCHEMA_VERSION,
-        );
-        rebuilt.close();
-      } finally {
-        await rm(root, { recursive: true, force: true });
-      }
+    const database = new DatabaseSync(databasePath);
+    rewindRuntimeSchema(database);
+    database
+      .prepare(`UPDATE operational_schema_migrations SET version = ? WHERE scope = 'runtime'`)
+      .run(SQLITE_RUNTIME_SCHEMA_VERSION - 1);
+    database.close();
+
+    const reopenedLease = acquireOperationalStateDatabase(root);
+    assert.equal(
+      (reopenedLease.database.prepare('PRAGMA user_version').get() as { user_version: number })
+        .user_version,
+      SQLITE_RUNTIME_SCHEMA_VERSION,
+    );
+    const reopened = createSqliteSessionMetadataStore(databasePath, {
+      databaseLease: reopenedLease,
     });
+    try {
+      assert.equal((await reopened.read('session-1')).header.name, 'Session');
+      assert.deepEqual(await reopened.readMessages('session-1'), [
+        { type: 'user', id: 'message-1', turnId: 'turn-1', ts: 3, text: 'keep me' },
+      ]);
+    } finally {
+      reopened.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });
+
+test('rejects a newer scope before migrating an older scope', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-mixed-version-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    const lease = acquireOperationalStateDatabase(root);
+    lease.close();
+
+    const database = new DatabaseSync(databasePath);
+    rewindRuntimeSchema(database);
+    database
+      .prepare(`UPDATE operational_schema_migrations SET version = ? WHERE scope = 'usage'`)
+      .run(SQLITE_USAGE_SCHEMA_VERSION + 1);
+    database.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      /Operational schema usage is newer than supported/,
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      assert.equal(
+        (preserved.prepare('PRAGMA user_version').get() as { user_version: number }).user_version,
+        SQLITE_RUNTIME_SCHEMA_VERSION - 1,
+      );
+    } finally {
+      preserved.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects newer session metadata before migrating older runtime state', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-newer-metadata-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    const lease = acquireOperationalStateDatabase(root);
+    lease.close();
+
+    const database = new DatabaseSync(databasePath);
+    rewindRuntimeSchema(database);
+    database
+      .prepare(`UPDATE session_metadata_schema SET version = ? WHERE scope = 'session_metadata'`)
+      .run(SQLITE_SESSION_METADATA_SCHEMA_VERSION + 1);
+    database.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      /Operational schema session_metadata is newer than supported/,
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      assert.equal(
+        (preserved.prepare('PRAGMA user_version').get() as { user_version: number }).user_version,
+        SQLITE_RUNTIME_SCHEMA_VERSION - 1,
+      );
+    } finally {
+      preserved.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects an unknown operational schema without changing the database', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-unknown-scope-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    const lease = acquireOperationalStateDatabase(root);
+    lease.close();
+
+    const database = new DatabaseSync(databasePath);
+    database
+      .prepare(
+        `INSERT INTO operational_schema_migrations(scope, version, applied_at) VALUES (?, ?, ?)`,
+      )
+      .run('future_scope', 1, 1);
+    database.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      /Operational schema future_scope is unknown to this Maka build/,
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      const row = preserved
+        .prepare(
+          `SELECT scope, version, applied_at FROM operational_schema_migrations WHERE scope = ?`,
+        )
+        .get('future_scope') as { scope: string; version: number; applied_at: number };
+      assert.equal(row.scope, 'future_scope');
+      assert.equal(row.version, 1);
+      assert.equal(row.applied_at, 1);
+    } finally {
+      preserved.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects an invalid registered schema version before migrating', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-invalid-version-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    const lease = acquireOperationalStateDatabase(root);
+    lease.close();
+
+    const database = new DatabaseSync(databasePath);
+    rewindRuntimeSchema(database);
+    database
+      .prepare(`UPDATE operational_schema_migrations SET version = ? WHERE scope = 'usage'`)
+      .run(1.5);
+    database.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      /Operational schema usage has invalid version 1.5/,
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      assert.equal(
+        (preserved.prepare('PRAGMA user_version').get() as { user_version: number }).user_version,
+        SQLITE_RUNTIME_SCHEMA_VERSION - 1,
+      );
+    } finally {
+      preserved.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function rewindRuntimeSchema(database: DatabaseSync): void {
+  database.exec('DROP TABLE runtime_session_event_ordinals');
+  database.exec(`PRAGMA user_version = ${SQLITE_RUNTIME_SCHEMA_VERSION - 1}`);
+}
 
 function sessionHeader(): SessionHeader {
   return {

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -144,6 +144,46 @@ test('rejects a newer scope before migrating an older scope', async () => {
   }
 });
 
+test('rejects a newer runtime schema without changing the database', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-newer-runtime-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    const lease = acquireOperationalStateDatabase(root);
+    lease.close();
+
+    const database = new DatabaseSync(databasePath);
+    database.exec(`PRAGMA user_version = ${SQLITE_RUNTIME_SCHEMA_VERSION + 1}`);
+    database.exec('CREATE TABLE runtime_future_sentinel (value TEXT NOT NULL)');
+    database.exec("INSERT INTO runtime_future_sentinel(value) VALUES ('preserved')");
+    database.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      /Operational schema runtime is newer than supported/,
+    );
+
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      assert.equal(
+        (preserved.prepare('PRAGMA user_version').get() as { user_version: number }).user_version,
+        SQLITE_RUNTIME_SCHEMA_VERSION + 1,
+      );
+      assert.equal(
+        (
+          preserved.prepare('SELECT value FROM runtime_future_sentinel').get() as {
+            value: string;
+          }
+        ).value,
+        'preserved',
+      );
+    } finally {
+      preserved.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('rejects newer session metadata before migrating older runtime state', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-operational-newer-metadata-'));
   const databasePath = join(root, 'runtime.sqlite');

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -4,6 +4,7 @@ import { createRequire } from 'node:module';
 import type { DatabaseSync } from 'node:sqlite';
 import {
   configureSqliteRuntimeDatabase,
+  configureSqliteRuntimeLockWait,
   migrateSqliteRuntimeDatabase,
   readUserVersion,
   SQLITE_RUNTIME_SCHEMA_VERSION,
@@ -94,6 +95,9 @@ class OperationalStateDatabaseOwner {
     const Database = loadDatabaseSync();
     this.database = new Database(databasePath);
     try {
+      // Preflight reads must wait for another opener's WAL transition, but this
+      // connection-only pragma keeps rejected databases byte-for-byte intact.
+      configureSqliteRuntimeLockWait(this.database);
       // Reject every unsupported authority before the first migration commits,
       // so a newer later scope cannot leave an older earlier scope half-upgraded.
       assertOperationalSchemaCanMigrate(this.database);
@@ -262,13 +266,18 @@ function registerSchema(db: DatabaseSync, scope: string, version: number, applie
   const existing = db
     .prepare('SELECT version FROM operational_schema_migrations WHERE scope = ?')
     .get(scope) as { version?: unknown } | undefined;
-  if (
-    existing &&
-    (typeof existing.version !== 'number' ||
+  if (existing) {
+    if (
+      typeof existing.version !== 'number' ||
       !Number.isSafeInteger(existing.version) ||
-      existing.version > version)
-  ) {
-    throw new Error(`Operational schema ${scope} is newer than supported version ${version}`);
+      existing.version < 0
+    ) {
+      throw new Error(
+        `Operational schema ${scope} has invalid version ${String(existing.version)}; ` +
+          'Maka did not migrate or delete the database. Restore or repair this workspace before opening it.',
+      );
+    }
+    assertSupportedOperationalSchemaVersion(scope, existing.version, version);
   }
   db.prepare(`
     INSERT INTO operational_schema_migrations(scope, version, applied_at)

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { createRequire } from 'node:module';
 import type { DatabaseSync } from 'node:sqlite';
@@ -10,6 +10,7 @@ import {
 } from './sqlite-runtime-schema.js';
 import {
   migrateSqliteSessionMetadataDatabase,
+  readSqliteSessionMetadataSchemaVersion,
   SQLITE_SESSION_METADATA_SCHEMA_VERSION,
 } from './sqlite-session-metadata-schema.js';
 import {
@@ -60,55 +61,6 @@ export interface OperationalStateDatabaseLease {
 }
 
 /**
- * Operational state is disposable across incompatible app versions. Settings
- * and credentials live in dedicated stores, so rebuild this database instead
- * of migrating or downgrading its schema.
- */
-export function resetIncompatibleOperationalStateDatabase(workspaceRoot: string): boolean {
-  const databasePath = resolve(workspaceRoot, OPERATIONAL_STATE_DATABASE_NAME);
-  if (!existsSync(databasePath)) return false;
-  if (owners.has(databasePath)) {
-    throw new Error('Operational state compatibility must be checked before opening the database');
-  }
-
-  const Database = loadDatabaseSync();
-  const database = new Database(databasePath, { readOnly: true });
-  let compatible: boolean;
-  try {
-    compatible = hasCurrentOperationalSchema(database);
-  } finally {
-    database.close();
-  }
-  if (compatible) return false;
-
-  for (const suffix of ['', '-wal', '-shm']) {
-    rmSync(`${databasePath}${suffix}`, { force: true });
-  }
-  return true;
-}
-
-function hasCurrentOperationalSchema(database: DatabaseSync): boolean {
-  if (readUserVersion(database) !== SQLITE_RUNTIME_SCHEMA_VERSION) return false;
-  const table = database
-    .prepare(`
-      SELECT 1 AS present
-      FROM sqlite_master
-      WHERE type = 'table' AND name = 'operational_schema_migrations'
-    `)
-    .get() as { present?: unknown } | undefined;
-  if (table?.present !== 1) return false;
-
-  const rows = database
-    .prepare('SELECT scope, version FROM operational_schema_migrations')
-    .all() as Array<{ scope?: unknown; version?: unknown }>;
-  if (rows.length !== OPERATIONAL_SCHEMA_VERSIONS.size) return false;
-  return rows.every(
-    ({ scope, version }) =>
-      typeof scope === 'string' && OPERATIONAL_SCHEMA_VERSIONS.get(scope) === version,
-  );
-}
-
-/**
  * Acquire the process-local owner for the operational SQLite authority.
  *
  * Repositories receive leases instead of opening independent connections.
@@ -142,6 +94,9 @@ class OperationalStateDatabaseOwner {
     const Database = loadDatabaseSync();
     this.database = new Database(databasePath);
     try {
+      // Reject every unsupported authority before the first migration commits,
+      // so a newer later scope cannot leave an older earlier scope half-upgraded.
+      assertOperationalSchemaCanMigrate(this.database);
       configureSqliteRuntimeDatabase(this.database);
       migrateSqliteRuntimeDatabase(this.database);
       migrateSqliteSessionMetadataDatabase(this.database);
@@ -220,6 +175,66 @@ class OperationalStateDatabaseOwner {
       this.transactionDepth -= 1;
     }
   }
+}
+
+function assertOperationalSchemaCanMigrate(database: DatabaseSync): void {
+  assertSupportedOperationalSchemaVersion(
+    'runtime',
+    readUserVersion(database),
+    SQLITE_RUNTIME_SCHEMA_VERSION,
+  );
+  if (hasTable(database, 'session_metadata_schema')) {
+    assertSupportedOperationalSchemaVersion(
+      'session_metadata',
+      readSqliteSessionMetadataSchemaVersion(database),
+      SQLITE_SESSION_METADATA_SCHEMA_VERSION,
+    );
+  }
+
+  if (!hasTable(database, 'operational_schema_migrations')) return;
+  const rows = database
+    .prepare('SELECT scope, version FROM operational_schema_migrations')
+    .all() as Array<{ scope?: unknown; version?: unknown }>;
+  for (const { scope, version } of rows) {
+    if (typeof scope !== 'string') continue;
+    const supportedVersion = OPERATIONAL_SCHEMA_VERSIONS.get(scope);
+    if (supportedVersion === undefined) {
+      throw new Error(
+        `Operational schema ${scope} is unknown to this Maka build; ` +
+          'Maka did not migrate or delete the database. Upgrade Maka to open this workspace.',
+      );
+    }
+    if (typeof version !== 'number' || !Number.isSafeInteger(version) || version < 0) {
+      throw new Error(
+        `Operational schema ${scope} has invalid version ${String(version)}; ` +
+          'Maka did not migrate or delete the database. Restore or repair this workspace before opening it.',
+      );
+    }
+    assertSupportedOperationalSchemaVersion(scope, version, supportedVersion);
+  }
+}
+
+function assertSupportedOperationalSchemaVersion(
+  scope: string,
+  observedVersion: number,
+  supportedVersion: number,
+): void {
+  if (observedVersion <= supportedVersion) return;
+  throw new Error(
+    `Operational schema ${scope} is newer than supported version ${supportedVersion}; ` +
+      'Maka did not migrate or delete the database. Upgrade Maka to open this workspace.',
+  );
+}
+
+function hasTable(database: DatabaseSync, name: string): boolean {
+  const table = database
+    .prepare(`
+      SELECT 1 AS present
+      FROM sqlite_master
+      WHERE type = 'table' AND name = ?
+    `)
+    .get(name) as { present?: unknown } | undefined;
+  return table?.present === 1;
 }
 
 function migrateOperationalStateDatabase(db: DatabaseSync, now: () => number): void {

--- a/packages/storage/src/sqlite-runtime-schema.ts
+++ b/packages/storage/src/sqlite-runtime-schema.ts
@@ -307,10 +307,15 @@ export function configureSqliteRuntimeDatabase(db: DatabaseSync): void {
   // Bound lock acquisition before touching persistent journal state. WAL mode is
   // database-persistent, so established workspaces only need to verify it rather
   // than making every concurrent opener execute the setting form of the pragma.
-  db.exec(`PRAGMA busy_timeout = ${SQLITE_INITIALIZATION_BUSY_TIMEOUT_MS}`);
+  configureSqliteRuntimeLockWait(db);
   ensureWalJournalMode(db);
   db.exec('PRAGMA synchronous = FULL');
   db.exec('PRAGMA foreign_keys = ON');
+}
+
+/** Configure connection-local lock waiting without changing persistent database state. */
+export function configureSqliteRuntimeLockWait(db: DatabaseSync): void {
+  db.exec(`PRAGMA busy_timeout = ${SQLITE_INITIALIZATION_BUSY_TIMEOUT_MS}`);
 }
 
 export function migrateSqliteRuntimeDatabase(db: DatabaseSync): void {


### PR DESCRIPTION
## Summary

- remove Desktop's destructive `runtime.sqlite` reset so existing forward migrations preserve sessions, messages, and other operational state across upgrades
- preflight the runtime, session metadata, and registered operational schema authorities before any migration commits
- preserve the database and fail with an actionable error when a schema is newer, unknown, or invalid
- keep concurrent first-open behavior by configuring connection-local lock waiting before the read-only preflight
- replace the deletion contract with upgrade-preservation and fail-closed regression coverage

Closes #2357.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run build:workspace-deps --workspace @maka/desktop`
- `npm run build:main --workspace @maka/desktop`
- `node --test packages/storage/dist/__tests__/operational-state-store.test.js` — 8 passed
- `node --test packages/storage/dist/__tests__/sqlite-recovery-concurrency.test.js` — 8 consecutive runs passed
- `npm run test:dist --workspace=@maka/storage` — 734 passed, 0 failed, 12 skipped
- `npm test` — build and all affected tests passed; the command exited 1 on the existing `artifact-writer-lock` cleanup race (`ENOTEMPTY`). The same two cleanup failures reproduce on an unmodified `main` baseline.

## Review focus

The preflight intentionally lives in the storage owner rather than Desktop. This protects CLI, headless, runtime-host, and Desktop callers and prevents an unsupported later scope from being discovered only after an earlier scope has already migrated.

The preflight sets only the connection-local `busy_timeout` before reading schema authorities. Persistent WAL configuration and migrations still happen only after compatibility succeeds, so a rejected database remains unchanged.

Downgrade read/write compatibility is intentionally not introduced here. A follow-up will define an explicit global minimum-reader epoch and expand/contract migration rules from a new safe baseline; this PR only stops data loss and restores the existing forward-migration path.
