### PR TITLE
feat(ui): add a new-task trigger to the Pinned and Recent group headers

### DIFF
--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -189,6 +189,29 @@
 }
 
 /*
+ * Group-header new-task trigger (session-history-list.tsx): the compact plus
+ * on the Pinned / Recent section titles.
+ *
+ * Size: Astryx IconButton ships sm/md/lg (28/32/40px) — there is no xs. The
+ * trigger deliberately takes the rail's compact control step instead
+ * (--h-control-sm, 24px — the same box the rows' trailing ⋯ column is
+ * measured in), so the section header gains almost no height; one product
+ * size override is the cost. !important for the same reason as every other
+ * StyleX override in this file.
+ *
+ * Column alignment needs no margin: the header's endContent and the rows'
+ * trailing column are both 24px boxes right-aligned to the SAME content edge
+ * (the SideNav scrollable zone's spacing-2 plus their own spacing-2
+ * paddingInline on each side), so the plus centre lands on the ⋯ column's
+ * centre by layout. Title entry, row actions — one vertical action column,
+ * one eye sweep.
+ */
+.maka-group-new-task-button {
+  width: var(--h-control-sm, 24px) !important;
+  height: var(--h-control-sm, 24px) !important;
+}
+
+/*
  * Dim only this row's SideNavItem. Child combinators stop before [role=group]
  * nests under project groups.
  * DOM: .maka-session-row > SideNavItem root > .astryx-side-nav-item

--- a/packages/ui/src/__tests__/session-group-new-task.test.tsx
+++ b/packages/ui/src/__tests__/session-group-new-task.test.tsx
@@ -53,12 +53,18 @@ describe('session group new-task trigger', () => {
 
     // One trigger per labeled group: Pinned + Recent.
     assert.equal(markup.match(/maka-group-new-task-button/g)?.length, 2);
-    assert.equal(markup.match(/aria-label="New task"/g)?.length, 2);
+    assert.equal(markup.match(/aria-label="New task in group"/g)?.length, 2);
+    // The trigger must NOT reuse the rail row's accessible name ("New task"):
+    // two same-named buttons are a strict-mode violation for
+    // getByRole('button', { name }) and an ambiguity for screen readers.
+    assert.doesNotMatch(markup, /aria-label="New task"/);
   });
 
-  it('localizes the accessible name with the shared new-task copy', () => {
+  it('localizes the accessible name with the group-specific new-task copy', () => {
     const zh = renderHistory({ locale: 'zh', sessions: MIXED, onNewTask: () => {} });
-    assert.equal(zh.match(/aria-label="新任务"/g)?.length, 2);
+    assert.equal(zh.match(/aria-label="新建任务"/g)?.length, 2);
+    // 新建任务 must stay distinct from the rail row's 新任务 (see above).
+    assert.doesNotMatch(zh, /aria-label="新任务"/);
   });
 
   it('stays absent without an onNewTask handler', () => {

--- a/packages/ui/src/__tests__/session-group-new-task.test.tsx
+++ b/packages/ui/src/__tests__/session-group-new-task.test.tsx
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { SessionSummary } from '@maka/core';
+import { LocaleProvider } from '../locale-context.js';
+import { SessionHistoryList } from '../session-history-list.js';
+
+function session(overrides: Partial<SessionSummary> & { id: string }): SessionSummary {
+  return {
+    name: overrides.id,
+    status: 'active',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    lastMessageAt: 1,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'anthropic-main',
+    connectionLocked: false,
+    model: 'claude-sonnet-4-5',
+    permissionMode: 'ask',
+    ...overrides,
+  };
+}
+
+function renderHistory(props: {
+  locale: 'zh' | 'en';
+  sessions: SessionSummary[];
+  onNewTask?: () => void;
+  groupVariant?: 'conversation' | 'project';
+}): string {
+  return renderToStaticMarkup(
+    <LocaleProvider locale={props.locale}>
+      <SessionHistoryList
+        sessions={props.sessions}
+        groupVariant={props.groupVariant}
+        onSelectSession={() => {}}
+        onNewTask={props.onNewTask}
+      />
+    </LocaleProvider>,
+  );
+}
+
+const MIXED = [
+  session({ id: 'pinned-1', name: 'cli-chat', isFlagged: true, lastMessageAt: 3 }),
+  session({ id: 'recent-1', name: '你好呀', lastMessageAt: 2 }),
+  session({ id: 'recent-2', name: 'Deep Research', lastMessageAt: 1 }),
+];
+
+describe('session group new-task trigger', () => {
+  it('puts one trigger on each labeled group in time view', () => {
+    const markup = renderHistory({ locale: 'en', sessions: MIXED, onNewTask: () => {} });
+
+    // One trigger per labeled group: Pinned + Recent.
+    assert.equal(markup.match(/maka-group-new-task-button/g)?.length, 2);
+    assert.equal(markup.match(/aria-label="New task"/g)?.length, 2);
+  });
+
+  it('localizes the accessible name with the shared new-task copy', () => {
+    const zh = renderHistory({ locale: 'zh', sessions: MIXED, onNewTask: () => {} });
+    assert.equal(zh.match(/aria-label="新任务"/g)?.length, 2);
+  });
+
+  it('stays absent without an onNewTask handler', () => {
+    const markup = renderHistory({ locale: 'en', sessions: MIXED });
+    assert.doesNotMatch(markup, /maka-group-new-task-button/);
+  });
+
+  it('stays out of the project grouping, whose rows carry their own new-task menu', () => {
+    const markup = renderHistory({
+      locale: 'en',
+      sessions: MIXED,
+      groupVariant: 'project',
+      onNewTask: () => {},
+    });
+    assert.doesNotMatch(markup, /maka-group-new-task-button/);
+  });
+
+  it('skips an unlabeled group, which has no title row to carry the trigger', () => {
+    const markup = renderToStaticMarkup(
+      <LocaleProvider locale="en">
+        <SessionHistoryList
+          sessions={MIXED}
+          groups={[{ id: 'plain', label: '', sessions: MIXED }]}
+          onSelectSession={() => {}}
+          onNewTask={() => {}}
+        />
+      </LocaleProvider>,
+    );
+    assert.doesNotMatch(markup, /maka-group-new-task-button/);
+  });
+});

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -21,12 +21,14 @@ import {
   Pin,
   PinOff,
   Plug,
+  Plus,
   SquarePen,
   Trash2,
 } from './icons.js';
 import { Badge } from '@astryxdesign/core/Badge';
 import { Tooltip } from '@astryxdesign/core/Tooltip';
 import { MoreMenu } from '@astryxdesign/core/MoreMenu';
+import { IconButton } from '@astryxdesign/core/IconButton';
 import {
   SideNavItem,
   SideNavSection,
@@ -37,6 +39,7 @@ import { describeBlockedReason, presentSessionStatus } from './session-status-pr
 import { SessionRenameDialog, type SessionRenameTarget } from './session-rename-dialog.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
+import { getShellControlsCopy } from './shell-controls-copy.js';
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
 type SessionHistoryGroupVariant = 'conversation' | 'project';
@@ -78,6 +81,13 @@ export function SessionHistoryList(props: {
   headingEnd?: ReactNode;
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
+  /**
+   * Creates a new task from a group header's trailing trigger (time grouping
+   * only). Same handler as the rail's top-level 新任务 row: a session created
+   * here lands where any new session lands; the trigger is a proximity entry,
+   * not a different creation path. Absent = no trigger.
+   */
+  onNewTask?(): void;
 }) {
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).sessions;
@@ -123,6 +133,7 @@ export function SessionHistoryList(props: {
       onSelectSession={props.onSelectSession}
       rowActions={props.rowActions}
       projectActions={props.projectActions}
+      onNewTask={props.onNewTask}
     />
   );
 
@@ -159,8 +170,10 @@ function SessionListGroups(props: {
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
   projectActions?: ProjectRowActions;
+  onNewTask?(): void;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
+  const newTaskCopy = getShellControlsCopy(useUiLocale()).navigation.newTask;
   const [renameTarget, setRenameTarget] = useState<SessionRenameTarget | null>(null);
   /**
    * The control the rename was started from, so focus can go back to it.
@@ -293,6 +306,24 @@ function SessionListGroups(props: {
     );
   }
 
+  // Group-header new-task trigger (time grouping). Same label and handler as
+  // the rail's top-level 新任务 SideNavItem — the header copy comes from the
+  // same shell-controls source so the two entries cannot drift. IconButton +
+  // Tooltip is the icon-only pattern SessionSidebarFooter already uses; the
+  // compact 24px box and column alignment belong to sidebar.css.
+  const newTaskAction = props.onNewTask ? (
+    <Tooltip content={newTaskCopy}>
+      <IconButton
+        className="maka-group-new-task-button"
+        variant="ghost"
+        size="sm"
+        label={newTaskCopy}
+        icon={<Plus size={14} aria-hidden="true" />}
+        onClick={() => void props.onNewTask?.()}
+      />
+    </Tooltip>
+  ) : undefined;
+
   return (
     <>
       {renameDialog}
@@ -306,7 +337,12 @@ function SessionListGroups(props: {
           );
         }
         return (
-          <SideNavSection key={group.key} title={group.label} className="maka-session-group">
+          <SideNavSection
+            key={group.key}
+            title={group.label}
+            endContent={newTaskAction}
+            className="maka-session-group"
+          >
             {items}
           </SideNavSection>
         );

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -173,7 +173,7 @@ function SessionListGroups(props: {
   onNewTask?(): void;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
-  const newTaskCopy = getShellControlsCopy(useUiLocale()).navigation.newTask;
+  const newTaskCopy = getShellControlsCopy(useUiLocale()).navigation.groupNewTask;
   const [renameTarget, setRenameTarget] = useState<SessionRenameTarget | null>(null);
   /**
    * The control the rename was started from, so focus can go back to it.
@@ -306,11 +306,14 @@ function SessionListGroups(props: {
     );
   }
 
-  // Group-header new-task trigger (time grouping). Same label and handler as
-  // the rail's top-level 新任务 SideNavItem — the header copy comes from the
-  // same shell-controls source so the two entries cannot drift. IconButton +
-  // Tooltip is the icon-only pattern SessionSidebarFooter already uses; the
-  // compact 24px box and column alignment belong to sidebar.css.
+  // Group-header new-task trigger (time grouping). Same HANDLER as the
+  // rail's top-level 新任务 SideNavItem, but a different NAME
+  // (navigation.groupNewTask): reusing copy.newTask would give two controls
+  // the same accessible name, a strict-mode collision for
+  // getByRole('button', { name: '新任务' }) and an ambiguity for screen
+  // readers. IconButton + Tooltip is the icon-only pattern
+  // SessionSidebarFooter already uses; the compact 24px box and column
+  // alignment belong to sidebar.css.
   const newTaskAction = props.onNewTask ? (
     <Tooltip content={newTaskCopy}>
       <IconButton

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -160,6 +160,11 @@ export function SessionListPanel(props: {
             projectActions={props.projectActions}
             onSelectSession={props.onSelectSession}
             rowActions={props.rowActions}
+            /* The group-header trigger is the SAME creation path as the rail's
+               新任务 row: one handler, two proximity entries (decision D1-a:
+               a session created from the Pinned header is an ordinary new
+               session, nothing auto-pinned). */
+            onNewTask={props.onNew}
             heading={onViewModeChange ? copy.title : undefined}
             headingEnd={groupingSwitch}
           />

--- a/packages/ui/src/shell-controls-copy.ts
+++ b/packages/ui/src/shell-controls-copy.ts
@@ -7,6 +7,14 @@ type ShellControlsCopy = {
   navigation: {
     mainLabel: string;
     newTask: string;
+    /**
+     * Accessible name of the session-group header's new-task trigger
+     * (session-history-list.tsx). Deliberately NOT `newTask`: that copy is
+     * the rail's top-level SideNavItem's name, and two controls sharing one
+     * accessible name collide for `getByRole('button', { name })` and screen
+     * readers alike. The two entries share the handler, not the name.
+     */
+    groupNewTask: string;
     automations: string;
     extensions: string;
     settings: string;
@@ -40,6 +48,7 @@ const SHELL_CONTROLS_COPY_BY_LOCALE = {
     navigation: {
       mainLabel: '主导航',
       newTask: '新任务',
+      groupNewTask: '新建任务',
       automations: '定时任务',
       extensions: '扩展',
       settings: '设置',
@@ -71,6 +80,7 @@ const SHELL_CONTROLS_COPY_BY_LOCALE = {
     navigation: {
       mainLabel: 'Main navigation',
       newTask: 'New task',
+      groupNewTask: 'New task in group',
       automations: 'Scheduled tasks',
       extensions: 'Extensions',
       settings: 'Settings',


### PR DESCRIPTION
## What

The session rail gains a compact **New task** trigger on the **Pinned** and **Recent** group headers (time grouping), so a new session can start right where the eye already is — one vertical action column shared with each row's trailing `⋯`.

| | |
|---|---|
| Slot | `SideNavSection.endContent` — the official Astryx seam the Conversations heading already uses for the grouping switch |
| Control | `IconButton variant="ghost"` + `Tooltip`, icon `Plus` (lucide), accessible name from `navigation.groupNewTask` (zh `新建任务` / en `New task in group`) — deliberately distinct from the rail row's `navigation.newTask`: two same-named controls are a strict-mode collision for `getByRole('button', { name })` and an ambiguity for screen readers. The two entries share the handler, not the name |
| Wiring | the same `onNew` handler `SessionListPanel` already feeds the top-level 新任务 row |
| Size | product CSS takes the rail's compact control step (`--h-control-sm`, 24px — the box the rows' trailing `⋯` column is measured in); Astryx ships no xs button, so one size override is the cost |

## Design decisions (settled before implementation)

- **D1 · Pinned header semantics** — a session created from the Pinned header is an **ordinary new session** (lands in Recent); nothing is auto-pinned. The trigger is a proximity entry, not a different creation path; behavior stays identical to `⌘N`.
- **D2 · Empty groups** — `groupSessionsForHistory` leaves a group unrendered when it has no sessions; the trigger only appears where a title row exists. No change to grouping logic.
- **D3 · Scope** — time grouping only. Project grouping already carries a per-project new-task item in its `MoreMenu`; a second entry there would duplicate it. Enforced structurally: the trigger lives in the conversation branch of `SessionListGroups`.

## Column alignment — zero margin by layout

The header's `endContent` and the rows' trailing column are both **24px boxes right-aligned to the same content edge** (the SideNav scrollable zone's `spacing-2` + their own `spacing-2` `paddingInline` on each side). The plus centre therefore lands on the `⋯` column's centre by construction — the alignment is a property of the layout, not a tuned offset (verified against the shipping sidebar: both centres sit at the same measured x).

## Testing

- New `packages/ui/src/__tests__/session-group-new-task.test.tsx` (5 cases): one trigger per labeled group in time view, group-specific accessible name (zh/en) with the rail row's name pinned as absent, absent without a handler, absent in project grouping, absent for unlabeled groups.
- `npm --workspace @maka/ui test` — 447 pass / 0 fail.
- Desktop e2e (real app build): `composer-skill-invocation`, `new-messages-indicator`, `new-task-reload`, `scroll-geometry` — 18 pass / 0 fail.
- `check-a11y` / `check-copy` / `check-console` clean; `biome check` clean on all touched files; `check-dead-css --check` clean.



