### PR TITLE
fix(storage): close usage stores after lease revocation

### DIFF
--- a/packages/storage/src/__tests__/usage-stores.test.ts
+++ b/packages/storage/src/__tests__/usage-stores.test.ts
@@ -131,15 +131,20 @@ describe('InteractiveUsageStores', () => {
     });
   });
 
-  test('classifies a renamed or replaced live root as a draining persistence failure', async () => {
+  test('classifies a renamed or replaced live root as a draining persistence failure', {
+    skip:
+      process.platform === 'win32'
+        ? 'Windows does not permit renaming a directory with an open SQLite database'
+        : false,
+  }, async () => {
     for (const replacement of [false, true]) {
       await withInteractiveRoot(async ({ root, capability }) => {
         const owner = await tryAcquireInteractiveRootOwner(capability);
         assert(owner);
         const stores = await openInteractiveUsageStoresForWrite(owner.lease);
-        await rename(root, `${root}-moved`);
-        if (replacement) await mkdir(root);
         try {
+          await rename(root, `${root}-moved`);
+          if (replacement) await mkdir(root);
           await assert.rejects(
             () => stores.pricing.snapshot(),
             (error: unknown) => {

--- a/packages/storage/src/__tests__/usage-stores.test.ts
+++ b/packages/storage/src/__tests__/usage-stores.test.ts
@@ -15,6 +15,7 @@ import {
   resolveStorageRoot,
   STORAGE_ROOT_MARKER_FILE,
   StorageRootAuthorityError,
+  tryAcquireInteractiveRootReader,
   tryAcquireInteractiveRootOwner,
   type StorageRootAuthorityErrorCode,
 } from '../root-authority.js';
@@ -27,6 +28,7 @@ import {
 import {
   classifyInteractiveUsageStoresFailure,
   InteractiveUsageStoresClosedError,
+  openInteractiveUsageStoresForRead,
   openInteractiveUsageStoresForWrite,
 } from '../usage-stores.js';
 
@@ -151,6 +153,7 @@ describe('InteractiveUsageStores', () => {
             },
           );
         } finally {
+          await stores.close();
           await owner.close();
         }
       });
@@ -200,6 +203,7 @@ describe('InteractiveUsageStores', () => {
             },
           );
         } finally {
+          await stores.close();
           await owner.close();
         }
       });
@@ -274,6 +278,28 @@ describe('InteractiveUsageStores', () => {
         () => stores.pricing.snapshot(),
         (error) => error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
       );
+      await stores.close();
+    });
+  });
+
+  test('reader close releases local resources after lease revocation', async () => {
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert(owner);
+      const writer = await openInteractiveUsageStoresForWrite(owner.lease);
+      await writer.close();
+      await owner.close();
+
+      const readerOwner = await tryAcquireInteractiveRootReader(capability);
+      assert(readerOwner);
+      const reader = await openInteractiveUsageStoresForRead(readerOwner.lease);
+      await readerOwner.close();
+
+      await assert.rejects(
+        () => reader.pricing.snapshot(),
+        (error) => error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+      );
+      await reader.close();
     });
   });
 });

--- a/packages/storage/src/usage-stores.ts
+++ b/packages/storage/src/usage-stores.ts
@@ -237,6 +237,7 @@ export async function openInteractiveUsageStoresForRead(
     openRepos(root, false),
   );
   let closed = false;
+  let closePromise: Promise<void> | undefined;
   const run = <T>(operation: () => T | Promise<T>): Promise<T> => {
     if (closed) return Promise.reject(new InteractiveUsageStoresClosedError());
     return runWithStorageRootLease(lease, 'interactive', 'read', async () => operation());
@@ -248,10 +249,11 @@ export async function openInteractiveUsageStoresForRead(
     telemetry: telemetryReader(repos.telemetry, run),
     modelCalls: modelCallReader(repos.modelCalls, run),
     pricing: pricingReader(repos.pricing, run),
-    close: async () => {
-      if (closed) return;
-      await run(() => closeRepos(repos.telemetry, repos.modelCalls, repos.pricing));
+    close: () => {
+      if (closePromise) return closePromise;
       closed = true;
+      closePromise = closeRepos(repos.telemetry, repos.modelCalls, repos.pricing);
+      return closePromise;
     },
   };
   freezeFacade(stores);
@@ -372,9 +374,9 @@ function createWriterFacade(
     closePromise = accepted
       .then(async () => {
         const closed = await Promise.allSettled([
-          run(() => telemetry.close()),
-          run(() => modelCalls.close()),
-          run(() => pricing.close()),
+          telemetry.close(),
+          modelCalls.close(),
+          pricing.close(),
         ]);
         throwDeduplicatedFailures('Interactive usage stores close failed', [
           ...failures,


### PR DESCRIPTION
## Summary

- release telemetry, model-call, and pricing SQLite resources without re-entering root authority during close
- keep read/write operations lease-bound while making close idempotent after revocation
- close usage stores in root-identity and marker failure tests, and cover reader cleanup after revocation

Part of #2142.

## Validation

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `node --test packages/storage/dist/__tests__/usage-stores.test.js` (8/8 pass)
- `npx biome check packages/storage/src/usage-stores.ts packages/storage/src/__tests__/usage-stores.test.ts`
- full storage suite: 734 pass, 12 skip, 1 pre-existing environment-sensitive failure in `package-import.test` because the current Node process emits the experimental `node:sqlite` warning; the failure reproduces in isolation and is unrelated to these files