### PR TITLE
feat(composer): preview thumbnails and file cards for staged attachments [ai-cross-reviewed]

### DIFF
--- a/apps/desktop/e2e/attachment.spec.ts
+++ b/apps/desktop/e2e/attachment.spec.ts
@@ -67,9 +67,16 @@ test('a mixed attachment send has the Astryx message hierarchy', async ({ window
     );
   });
 
-  // Both attachment kinds appear in the composer before send.
+  // Both attachment kinds appear in the composer before send: the file as a
+  // named two-line card, the image as a decoded Astryx Thumbnail — its
+  // filename lives in the accessible name (and hover tooltip), not visible
+  // text, once the preview probe passes.
   await expect(page.getByText('note.txt')).toBeVisible();
-  await expect(page.getByText('pixel.png')).toBeVisible();
+  const stagedThumbnail = page
+    .locator('.maka-composer-context-drawer')
+    .getByRole('group', { name: 'pixel.png' });
+  await expect(stagedThumbnail).toBeVisible();
+  await expect(stagedThumbnail.locator('img')).toBeVisible();
 
   // Send the message carrying the attachment — the fake backend echoes the
   // attachment name, proving the ingest-on-send path delivered it (not just

--- a/apps/desktop/src/main/__tests__/app-shell-pending-attachments.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-pending-attachments.test.ts
@@ -35,4 +35,17 @@ describe('pending attachments by draft key', () => {
 
     assert.deepEqual(selectPending(next, 'draft'), [addedWhileSending]);
   });
+
+  test('removes by caller identity even when the submitted snapshot was re-derived', () => {
+    // The composer hands back merged copies (e.g. with a late-arriving
+    // previewUrl), so reference equality would strand the staged originals.
+    const staged = { id: 'a', name: 'shot.png' };
+    const kept = { id: 'b', name: 'notes.md' };
+    const map = appendPending({}, 'draft', [staged, kept]);
+
+    const submittedCopy = { ...staged, previewUrl: 'data:image/png;base64,xyz' };
+    const next = removePendingItems(map, 'draft', [submittedCopy], (item) => item.id);
+
+    assert.deepEqual(selectPending(next, 'draft'), [kept]);
+  });
 });

--- a/apps/desktop/src/main/__tests__/attachment-ingest.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-ingest.test.ts
@@ -93,7 +93,7 @@ describe('ingestAttachments', () => {
         },
       });
       assert.equal(refs.length, 1);
-      assert.equal(refs[0].kind, 'other');
+      assert.equal(refs[0].kind, 'code');
       assert.equal(refs[0].ref.kind, 'workspace_file');
       assert.equal((refs[0].ref as { relativePath: string }).relativePath, 'main.ts');
       assert.equal(resizeCalls, 0);

--- a/apps/desktop/src/main/__tests__/attachment-preview.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-preview.test.ts
@@ -1,0 +1,184 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
+import {
+  loadApprovalPreview,
+  registerAttachmentPreviewIpc,
+  type AttachmentPreviewResult,
+} from '../attachment-preview.js';
+
+const PNG = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+
+function fakeRenderPreview(bytes: Uint8Array): Promise<{ bytes: Uint8Array; mimeType: string } | null> {
+  return Promise.resolve({ bytes, mimeType: 'image/png' });
+}
+
+describe('staged attachment preview (approval source)', () => {
+  it('returns thumbnail bytes for an approved image without consuming the approval', async () => {
+    const approvals = createAttachmentApprovalRegistry();
+    const [issued] = approvals.issueApprovals(1, [
+      { path: '/tmp/shot.png', name: 'shot.png', mimeType: 'image/png', size: PNG.byteLength },
+    ]);
+    let readCap = -1;
+    const result = await loadApprovalPreview({
+      senderId: 1,
+      approvalId: issued.approvalId,
+      approvals,
+      readFile: async (_path, maxBytes) => {
+        readCap = maxBytes;
+        return PNG;
+      },
+      renderPreview: fakeRenderPreview,
+    });
+    assert.deepEqual(result, {
+      ok: true,
+      base64: Buffer.from(PNG).toString('base64'),
+      mimeType: 'image/png',
+    });
+    // The read allocates by the approval's own stat size, never the global
+    // 50MB cap — a staged batch must not multiply flat 50MB buffers.
+    assert.equal(readCap, PNG.byteLength);
+    // The send must still be able to redeem the token afterwards.
+    assert.ok(approvals.consumeApproval(1, issued.approvalId));
+  });
+
+  it('refuses an approval whose stat size exceeds the cap without reading', async () => {
+    const approvals = createAttachmentApprovalRegistry();
+    const [issued] = approvals.issueApprovals(1, [
+      { path: '/tmp/huge.png', name: 'huge.png', mimeType: 'image/png', size: 100 },
+    ]);
+    let read = 0;
+    const result = await loadApprovalPreview({
+      senderId: 1,
+      approvalId: issued.approvalId,
+      approvals,
+      maxBytes: 99,
+      readFile: async () => {
+        read += 1;
+        return PNG;
+      },
+      renderPreview: fakeRenderPreview,
+    });
+    assert.deepEqual(result, { ok: false, reason: 'unreadable' });
+    assert.equal(read, 0);
+  });
+
+  it('guesses the image mime from the name when the approval has none', async () => {
+    const approvals = createAttachmentApprovalRegistry();
+    // pickFiles issues approvals without a mimeType — the common path.
+    const [issued] = approvals.issueApprovals(1, [{ path: '/tmp/shot.png', name: 'shot.png', size: 4 }]);
+    const result = await loadApprovalPreview({
+      senderId: 1,
+      approvalId: issued.approvalId,
+      approvals,
+      readFile: async () => PNG,
+      renderPreview: fakeRenderPreview,
+    });
+    assert.equal(result.ok, true);
+  });
+
+  it('refuses non-image approvals without touching the file', async () => {
+    const approvals = createAttachmentApprovalRegistry();
+    const [issued] = approvals.issueApprovals(1, [{ path: '/tmp/notes.md', name: 'notes.md', size: 4 }]);
+    let read = 0;
+    const result = await loadApprovalPreview({
+      senderId: 1,
+      approvalId: issued.approvalId,
+      approvals,
+      readFile: async () => {
+        read += 1;
+        return PNG;
+      },
+      renderPreview: fakeRenderPreview,
+    });
+    assert.deepEqual(result, { ok: false, reason: 'not_image' });
+    assert.equal(read, 0);
+  });
+
+  it('wires the shared IPC registration both execution modes reuse', async () => {
+    const approvals = createAttachmentApprovalRegistry();
+    const [issued] = approvals.issueApprovals(7, [
+      { path: '/tmp/shot.png', name: 'shot.png', mimeType: 'image/png', size: PNG.byteLength },
+    ]);
+    const handlers = new Map<
+      string,
+      (event: { sender: { id: number } }, approvalId: unknown) => Promise<AttachmentPreviewResult>
+    >();
+    registerAttachmentPreviewIpc({
+      ipcMain: { handle: (channel, listener) => handlers.set(channel, listener) },
+      approvals,
+      readFile: async () => PNG,
+      renderPreview: fakeRenderPreview,
+    });
+    const handler = handlers.get('attachments:previewApproval');
+    assert.ok(handler, 'handler registered on the expected channel');
+    const result = await handler({ sender: { id: 7 } }, issued.approvalId);
+    assert.equal(result.ok, true);
+    const foreign = await handler({ sender: { id: 8 } }, issued.approvalId);
+    assert.deepEqual(foreign, { ok: false, reason: 'not_found' });
+  });
+
+  it('rejects unknown, foreign-sender, and malformed approval ids', async () => {
+    const approvals = createAttachmentApprovalRegistry();
+    const [issued] = approvals.issueApprovals(1, [{ path: '/tmp/shot.png', name: 'shot.png', size: 4 }]);
+    const deps = { approvals, readFile: async () => PNG, renderPreview: fakeRenderPreview };
+    assert.deepEqual(
+      await loadApprovalPreview({ senderId: 1, approvalId: 42, ...deps }),
+      { ok: false, reason: 'invalid' },
+    );
+    assert.deepEqual(
+      await loadApprovalPreview({ senderId: 1, approvalId: 'nope', ...deps }),
+      { ok: false, reason: 'not_found' },
+    );
+    assert.deepEqual(
+      await loadApprovalPreview({ senderId: 2, approvalId: issued.approvalId, ...deps }),
+      { ok: false, reason: 'not_found' },
+    );
+  });
+
+  it('ships the original bytes when the thumbnailer cannot decode a small image (GIF path)', async () => {
+    const approvals = createAttachmentApprovalRegistry();
+    const [issued] = approvals.issueApprovals(1, [{ path: '/tmp/loop.gif', name: 'loop.gif', size: 4 }]);
+    const result = await loadApprovalPreview({
+      senderId: 1,
+      approvalId: issued.approvalId,
+      approvals,
+      readFile: async () => PNG,
+      // nativeImage has no GIF decoder — this is what it reports for one.
+      renderPreview: async () => null,
+    });
+    assert.deepEqual(result, {
+      ok: true,
+      base64: Buffer.from(PNG).toString('base64'),
+      mimeType: 'image/gif',
+    });
+  });
+
+  it('soft-fails when the bytes cannot be read, or cannot decode and exceed the inline cap', async () => {
+    const approvals = createAttachmentApprovalRegistry();
+    const issue = () => approvals.issueApprovals(1, [{ path: '/tmp/shot.png', name: 'shot.png', size: 4 }])[0];
+    assert.deepEqual(
+      await loadApprovalPreview({
+        senderId: 1,
+        approvalId: issue().approvalId,
+        approvals,
+        readFile: async () => {
+          throw new Error('too large');
+        },
+        renderPreview: fakeRenderPreview,
+      }),
+      { ok: false, reason: 'unreadable' },
+    );
+    assert.deepEqual(
+      await loadApprovalPreview({
+        senderId: 1,
+        approvalId: issue().approvalId,
+        approvals,
+        readFile: async () => PNG,
+        renderPreview: async () => null,
+        inlineFallbackMaxBytes: 2,
+      }),
+      { ok: false, reason: 'unreadable' },
+    );
+  });
+});

--- a/apps/desktop/src/main/attachment-ingest.ts
+++ b/apps/desktop/src/main/attachment-ingest.ts
@@ -141,7 +141,7 @@ function isPathAttachment(file: AttachmentIngestFile): file is Extract<Attachmen
 /** Read at most maxBytes+1 bytes; reject if the file is larger. Guards against a
  * TOCTOU where the file grows between stat (size pre-check) and read, so main
  * never loads an oversized file into memory. */
-async function readFileCapped(path: string, maxBytes: number): Promise<Uint8Array> {
+export async function readFileCapped(path: string, maxBytes: number): Promise<Uint8Array> {
   const fh = await open(path, 'r');
   try {
     const buf = Buffer.alloc(maxBytes + 1);

--- a/apps/desktop/src/main/attachment-preview.ts
+++ b/apps/desktop/src/main/attachment-preview.ts
@@ -1,0 +1,101 @@
+import { Buffer } from 'node:buffer';
+import { attachmentKindFromMimeType, guessMimeFromName, MAX_ATTACHMENT_BYTES } from '@maka/core';
+import type { AttachmentApprovalRegistry } from './attachment-approval.js';
+
+export type AttachmentPreviewResult =
+  | { ok: true; base64: string; mimeType: string }
+  | { ok: false; reason: 'invalid' | 'not_found' | 'not_image' | 'unreadable' };
+
+/**
+ * When the thumbnail renderer can't decode the format (nativeImage has no
+ * GIF/WebP support), the original bytes ship as the preview instead — the
+ * renderer's <img> decodes those natively (and keeps GIFs animated). Only up
+ * to this size, so a huge original never rides the IPC as a data URL.
+ */
+export const INLINE_PREVIEW_FALLBACK_MAX_BYTES = 12 * 1024 * 1024;
+
+export interface AttachmentPreviewDeps {
+  readFile: (path: string, maxBytes: number) => Promise<Uint8Array>;
+  renderPreview: (bytes: Uint8Array) => Promise<{ bytes: Uint8Array; mimeType: string } | null>;
+}
+
+/**
+ * Resolve a staged (not yet sent) approval attachment into thumbnail bytes
+ * for the composer drawer. The approval is only PEEKED — the token must stay
+ * redeemable for the eventual send — and the path never leaves main; only
+ * the rendered preview does. Preview failures are soft by design: the
+ * renderer falls back to the named file card and the attachment still sends.
+ *
+ * The read is capped at the approval's own stat size, not the global
+ * attachment cap: `readFileCapped` allocates its cap up front, and a flat
+ * 50MB per call turns a multi-image staging into an instant memory spike
+ * (the renderer additionally serializes preview requests).
+ *
+ * `readFile`/`renderPreview` are injected because they depend on fs and
+ * Electron's nativeImage respectively; tests pass fakes.
+ */
+export async function loadApprovalPreview(input: {
+  senderId: number;
+  approvalId: unknown;
+  approvals: AttachmentApprovalRegistry;
+  maxBytes?: number;
+  inlineFallbackMaxBytes?: number;
+} & AttachmentPreviewDeps): Promise<AttachmentPreviewResult> {
+  if (typeof input.approvalId !== 'string' || input.approvalId.length === 0) {
+    return { ok: false, reason: 'invalid' };
+  }
+  const approved = input.approvals.peekApproval(input.senderId, input.approvalId);
+  if (!approved) return { ok: false, reason: 'not_found' };
+  const mimeType =
+    approved.mimeType && approved.mimeType.length > 0
+      ? approved.mimeType
+      : guessMimeFromName(approved.name);
+  if (attachmentKindFromMimeType(mimeType, approved.name) !== 'image') {
+    return { ok: false, reason: 'not_image' };
+  }
+  const maxBytes = input.maxBytes ?? MAX_ATTACHMENT_BYTES;
+  if (approved.size > maxBytes) return { ok: false, reason: 'unreadable' };
+  try {
+    const bytes = await input.readFile(approved.path, approved.size);
+    const preview = await input.renderPreview(bytes);
+    if (preview) {
+      return {
+        ok: true,
+        base64: Buffer.from(preview.bytes).toString('base64'),
+        mimeType: preview.mimeType,
+      };
+    }
+    const fallbackCap = input.inlineFallbackMaxBytes ?? INLINE_PREVIEW_FALLBACK_MAX_BYTES;
+    if (bytes.byteLength <= fallbackCap) {
+      return { ok: true, base64: Buffer.from(bytes).toString('base64'), mimeType };
+    }
+    return { ok: false, reason: 'unreadable' };
+  } catch {
+    return { ok: false, reason: 'unreadable' };
+  }
+}
+
+/**
+ * One registration for both execution modes (embedded sessions IPC and the
+ * Runtime Host boot path), so the channel's validation and wiring cannot
+ * drift between them.
+ */
+export function registerAttachmentPreviewIpc(input: {
+  ipcMain: {
+    handle(
+      channel: string,
+      listener: (event: { sender: { id: number } }, approvalId: unknown) => Promise<AttachmentPreviewResult>,
+    ): void;
+  };
+  approvals: AttachmentApprovalRegistry;
+} & AttachmentPreviewDeps): void {
+  input.ipcMain.handle('attachments:previewApproval', (event, approvalId) =>
+    loadApprovalPreview({
+      senderId: event.sender.id,
+      approvalId,
+      approvals: input.approvals,
+      readFile: input.readFile,
+      renderPreview: input.renderPreview,
+    }),
+  );
+}

--- a/apps/desktop/src/main/attachment-resize-native.ts
+++ b/apps/desktop/src/main/attachment-resize-native.ts
@@ -17,3 +17,27 @@ export async function resizeImageForAttachment(bytes: Uint8Array): Promise<Uint8
   const resized = img.resize({ width: target.width, height: target.height });
   return resized.toPNG();
 }
+
+/** Longest edge for composer-drawer preview thumbnails. The drawer renders a
+ * 64px square; 512 keeps it crisp on retina + drawer zoom while the data URL
+ * handed to the renderer stays small. */
+export const ATTACHMENT_PREVIEW_MAX_EDGE = 512;
+
+/**
+ * Render a staged attachment's preview thumbnail: decode, scale the longest
+ * edge down to {@link ATTACHMENT_PREVIEW_MAX_EDGE}, re-encode as PNG (always
+ * PNG so the renderer never sees the original container format). Returns
+ * null when the bytes don't decode as an image (corrupt file or a spoofed
+ * extension), so the caller can fall back to the placeholder glyph. Same
+ * nativeImage caveats as {@link resizeImageForAttachment}.
+ */
+export async function renderAttachmentPreview(
+  bytes: Uint8Array,
+): Promise<{ bytes: Uint8Array; mimeType: string } | null> {
+  const img = nativeImage.createFromBuffer(Buffer.from(bytes));
+  if (img.isEmpty()) return null;
+  const size = img.getSize();
+  const target = computeResizeDimensions(size.width, size.height, ATTACHMENT_PREVIEW_MAX_EDGE);
+  const scaled = target ? img.resize({ width: target.width, height: target.height }) : img;
+  return { bytes: scaled.toPNG(), mimeType: 'image/png' };
+}

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -28,7 +28,9 @@ import { registerAppIpc } from "./app-ipc-main.js";
 import { createAppQuitCoordinator } from "./app-quit-coordinator.js";
 import { createAppUpdateService } from "./app-update-service.js";
 import { createAttachmentApprovalRegistry } from "./attachment-approval.js";
-import { resizeImageForAttachment } from "./attachment-resize-native.js";
+import { renderAttachmentPreview, resizeImageForAttachment } from "./attachment-resize-native.js";
+import { registerAttachmentPreviewIpc } from "./attachment-preview.js";
+import { readFileCapped } from "./attachment-ingest.js";
 import { registerBrowserIpc } from "./browser-ipc-main.js";
 import { releaseBrowserSession } from "./browser/session.js";
 import { resolveBuildInfo } from "./build-info.js";
@@ -563,6 +565,12 @@ function registerPersistentClientIpc(): void {
       ok: true,
       files: attachmentApprovals.issueApprovals(event.sender.id, chosen),
     };
+  });
+  registerAttachmentPreviewIpc({
+    ipcMain,
+    approvals: attachmentApprovals,
+    readFile: readFileCapped,
+    renderPreview: renderAttachmentPreview,
   });
 }
 

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -29,7 +29,9 @@ import type { ArtifactStore, createSessionStore } from '@maka/storage';
 import type { ConnectionStore, SettingsStore } from '@maka/storage';
 import { runThreadSearch } from './search/thread-search.js';
 import { createRunStartedHook, resolveSessionSend, stoppedTurnBroadcasts } from './session-send-resolve.js';
-import { resizeImageForAttachment } from './attachment-resize-native.js';
+import { renderAttachmentPreview, resizeImageForAttachment } from './attachment-resize-native.js';
+import { registerAttachmentPreviewIpc } from './attachment-preview.js';
+import { readFileCapped } from './attachment-ingest.js';
 import { releaseBrowserSession } from './browser/session.js';
 import { sessionReadMessagesFailureMessage } from './session-read-error-copy.js';
 import { resolveCreateSessionInput } from './create-session-input.js';
@@ -558,6 +560,12 @@ export function registerSessionsIpc(
       return { ok: true, files: attachmentApprovals.issueApprovals(event.sender.id, chosen) };
     },
   );
+  registerAttachmentPreviewIpc({
+    ipcMain,
+    approvals: attachmentApprovals,
+    readFile: readFileCapped,
+    renderPreview: renderAttachmentPreview,
+  });
   ipcMain.handle(
     'attachments:readBytes',
     async (_event, sessionId: string, relativePath: string): Promise<

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -452,6 +452,10 @@ export interface MakaBridge {
       | { ok: true; files: { approvalId: string; name: string; mimeType?: string; size: number }[] }
       | { ok: false; reason: 'cancelled' }
     >;
+    previewApproval(approvalId: string): Promise<
+      | { ok: true; base64: string; mimeType: string }
+      | { ok: false; reason: string }
+    >;
     readBytes(sessionId: string, relativePath: string): Promise<
       | { ok: true; base64: string; mimeType: string }
       | { ok: false; reason: string }

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -589,6 +589,14 @@ const makaBridge = {
     > {
       return ipcRenderer.invoke('attachments:pickFiles');
     },
+    // Staged-attachment thumbnail for the composer drawer. Peeks the approval
+    // (never consumes it) so the token stays redeemable for the actual send.
+    previewApproval(approvalId: string): Promise<
+      | { ok: true; base64: string; mimeType: string }
+      | { ok: false; reason: string }
+    > {
+      return ipcRenderer.invoke('attachments:previewApproval', approvalId);
+    },
     readBytes(sessionId: string, relativePath: string): Promise<
       | { ok: true; base64: string; mimeType: string }
       | { ok: false; reason: string }

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -33,12 +33,28 @@ import {
 } from './skill-invocation-feedback.js';
 
 export type PendingAttachment = {
+  /** Unique per staged item; keys the preview cache and its cleanup, so a
+   *  preview resolving after its item left the list can never strand an
+   *  orphan entry. */
+  stagingKey: string;
   displayName: string;
   mimeType?: string;
   kind: import('@maka/core').AttachmentRef['kind'];
   size: number;
+  /** Composer drawer thumbnail source for image attachments. Merged in from
+   *  the preview cache only after the URL has actually decoded as an image,
+   *  so a set previewUrl always means "renderable" — anything else keeps the
+   *  named file card. */
+  previewUrl?: string;
   source: { type: 'approval'; approvalId: string; name: string } | { type: 'file'; file: File };
 };
+
+/** Stable identity for a staged attachment across preview-URL merges. The
+ *  drawer list is re-derived when a preview lands, so submitted items must
+ *  be matched by their source — never by object reference. */
+export function pendingAttachmentSourceKey(attachment: PendingAttachment): unknown {
+  return attachment.source.type === 'approval' ? `approval:${attachment.source.approvalId}` : attachment.source.file;
+}
 
 export interface WorkspaceFileReferencePosition {
   value: string;

--- a/apps/desktop/src/renderer/app-shell-pending-attachments.ts
+++ b/apps/desktop/src/renderer/app-shell-pending-attachments.ts
@@ -21,9 +21,10 @@ export function removePendingItems<T>(
   map: PendingByKey<T>,
   key: string,
   items: readonly T[],
+  identityOf: (item: T) => unknown = (item) => item,
 ): PendingByKey<T> {
-  const submitted = new Set(items);
-  const remaining = (map[key] ?? []).filter((item) => !submitted.has(item));
+  const submitted = new Set(items.map(identityOf));
+  const remaining = (map[key] ?? []).filter((item) => !submitted.has(identityOf(item)));
   if (remaining.length === 0) return clearPending(map, key);
   return { ...map, [key]: remaining };
 }

--- a/apps/desktop/src/renderer/index.html
+++ b/apps/desktop/src/renderer/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self'"
     />
     <title>Maka</title>
     <style>

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -21,14 +21,134 @@
   max-width: var(--maka-chat-measure);
 }
 
+/* Row-flow, not the old stacked column: image thumbnails and file/quote
+   chips share one wrapping row. `width: 100%` is what makes the wrap real:
+   as a flex item of Astryx's drawer content this group would otherwise size
+   to max-content, run past the drawer edge, and get clipped by the drawer
+   root's overflow:hidden — the drawer must grow DOWN, never rightward. */
 .maka-composer-context-drawer {
   display: flex;
+  width: 100%;
   min-width: 0;
   flex-wrap: wrap;
-  align-items: flex-start;
+  align-items: center;
   gap: var(--space-1-5);
-  flex-direction: column;
+  flex-direction: row;
   padding: var(--space-1) var(--space-3) var(--space-2);
+}
+
+/* Astryx ChatComposerDrawer wraps its content in a display:grid whose single
+   implicit column sizes to the content's max-content contribution — with a
+   long chip row that resolves WIDER than the grid (measured: 896px column in
+   a 648px grid), so the row wrapped against a phantom width and everything
+   past the drawer's right edge was clipped. Pin the column to the grid's own
+   width; the group above then wraps against the real edge. The content region
+   is the child carrying the disclosure id (aria-controls target). */
+.maka-composer-astryx .astryx-chat-composer-drawer > div[id] {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+/* Staged non-image file — a two-line card in the idiom of contemporary agent
+   composers: kind icon on a tinted tile, filename, "EXT · size" meta. Fixed
+   64px height so cards and image thumbnails read as one row, not a staggered
+   pile; capped width + ellipsis so a full z-library book title cannot span
+   the card. */
+.maka-composer-attachment-card {
+  display: inline-flex;
+  align-items: center;
+  box-sizing: border-box;
+  height: 56px;
+  gap: var(--space-1-5);
+  max-width: min(280px, 100%);
+  padding: 0 var(--space-1-5);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-modal);
+  background: var(--background);
+}
+
+.maka-composer-attachment-card-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 auto;
+  border-radius: var(--radius-surface);
+  background: var(--muted);
+  color: var(--foreground-secondary);
+}
+
+/* Kind accents keep to existing semantic tokens (no new hues): documents that
+   read as "PDF red" everywhere else, code as the accent. */
+.maka-composer-attachment-card[data-kind="pdf"] .maka-composer-attachment-card-icon {
+  background: color-mix(in oklch, var(--status-danger, var(--destructive)) 12%, var(--background));
+  color: var(--status-danger, var(--destructive));
+}
+
+.maka-composer-attachment-card[data-kind="code"] .maka-composer-attachment-card-icon {
+  background: color-mix(in oklch, var(--accent) 12%, var(--background));
+  color: var(--accent);
+}
+
+.maka-composer-attachment-card-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 2px;
+}
+
+.maka-composer-attachment-card-name {
+  font-size: 13px;
+  font-weight: var(--font-weight-medium);
+  line-height: 1.25;
+  color: var(--foreground);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-composer-attachment-card-meta {
+  font-size: 11px;
+  line-height: 1.2;
+  color: var(--muted-foreground);
+  white-space: nowrap;
+}
+
+.maka-composer-attachment-card-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  flex: 0 0 auto;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background-color: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+}
+
+.maka-composer-attachment-card-remove:hover,
+.maka-composer-attachment-card-remove:focus-visible {
+  background-color: var(--muted);
+  color: var(--foreground);
+}
+
+/* Image thumbnails: hairline border + the same 12px radius as the file card,
+   so a mostly-white screenshot doesn't melt into the drawer surface.
+   `--radius-element` feeds Astryx Thumbnail's inner image container; 11px
+   (outer 12 − 1px border) nests the image corners flush against the border
+   instead of leaving a sliver of background in each corner. */
+.maka-composer-attachment-thumbnail {
+  /* local: --radius-element — Astryx Thumbnail's inner image radius; outer
+     radius minus the 1px border nests the image flush in the frame. */
+  --radius-element: calc(var(--radius-modal) - 1px);
+  width: 56px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-modal);
+  overflow: hidden;
+  background: var(--background);
 }
 
 .maka-composer-input {

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -48,6 +48,56 @@
   grid-template-columns: minmax(0, 1fr);
 }
 
+/* The collapse toggle is a full-width 20px band whose only visible affordance
+   is a 20×2px pill — its aria-label («收起附加内容» / «展开附加内容») was
+   unreadable for sighted users, and a native `title` needs a ~1s motionless
+   hover that a thin band rarely gets. Surface the label as an instant CSS
+   tooltip instead: `attr(aria-label)` tracks the live attribute, so the text
+   flips with the collapse state and stays localized with no JS.
+
+   Placement is the hard constraint: the drawer root clips its own box
+   (overflow:hidden for the collapse animation), so the bubble can't rise
+   above the band, and the input card paints ABOVE the drawer (body z-index 2
+   vs drawer 1 — that overlap is the card's design), so anything hanging
+   below the collapsed band gets covered. The one strip clear of both is the
+   band's own height — within it the bubble tracks the pointer horizontally
+   (--maka-drawer-tooltip-x, set by the drawer's onPointerMove in
+   composer.tsx), falling back to beside the pill for keyboard focus. */
+.maka-composer-astryx .astryx-chat-composer-drawer > [role='button'][aria-controls] {
+  position: relative;
+}
+
+.maka-composer-astryx .astryx-chat-composer-drawer > [role='button'][aria-controls]::after {
+  /* local: --maka-drawer-tooltip-x — bubble x within the band, written by
+     the drawer's onPointerMove in composer.tsx (cleared on pointer leave);
+     the fallback beside the pill serves keyboard focus. */
+  content: attr(aria-label);
+  position: absolute;
+  top: 50%;
+  left: var(--maka-drawer-tooltip-x, calc(50% + 20px));
+  transform: translateY(-50%);
+  padding: 3px 8px;
+  border-radius: var(--radius-control);
+  /* Astryx's fixed tooltip pair (same as Thumbnail's remove scrim): legible
+     in both themes without borrowing surface tokens for text. */
+  background-color: var(--color-overlay);
+  color: var(--color-on-dark);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--duration-fast, 120ms) var(--ease-standard, ease);
+  z-index: var(--z-tooltip);
+}
+
+.maka-composer-astryx .astryx-chat-composer-drawer > [role='button'][aria-controls]:hover::after,
+.maka-composer-astryx .astryx-chat-composer-drawer > [role='button'][aria-controls]:focus-visible::after {
+  opacity: 1;
+  visibility: visible;
+}
+
 /* Staged non-image file — a two-line card in the idiom of contemporary agent
    composers: kind icon on a tinted tile, filename, "EXT · size" meta. Fixed
    64px height so cards and image thumbnails read as one row, not a staggered

--- a/apps/desktop/src/renderer/use-app-shell-composer-attachments.ts
+++ b/apps/desktop/src/renderer/use-app-shell-composer-attachments.ts
@@ -1,7 +1,7 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { attachmentKindFromMimeType, guessMimeFromName } from '@maka/core';
 import { useUiLocale } from '@maka/ui';
-import type { PendingAttachment } from './app-shell-chat-actions';
+import { pendingAttachmentSourceKey, type PendingAttachment } from './app-shell-chat-actions';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import { localizedShellErrorMessage } from './locales/shell-copy.js';
 import {
@@ -24,6 +24,7 @@ function approvalToPending(file: {
 }): PendingAttachment {
   const mimeType = file.mimeType ?? guessMimeFromName(file.name);
   return {
+    stagingKey: crypto.randomUUID(),
     displayName: file.name,
     mimeType,
     kind: attachmentKindFromMimeType(mimeType, file.name),
@@ -35,12 +36,32 @@ function approvalToPending(file: {
 function fileToPending(file: File): PendingAttachment {
   const mimeType = file.type || undefined;
   return {
+    stagingKey: crypto.randomUUID(),
     displayName: file.name,
     mimeType,
     kind: attachmentKindFromMimeType(mimeType ?? '', file.name),
     size: file.size,
     source: { type: 'file', file },
   };
+}
+
+/** True once the URL has decoded as an image in this renderer. Gates every
+ * preview before it reaches the drawer, so a corrupt file or a spoofed
+ * extension falls back to the named file card instead of Astryx Thumbnail's
+ * anonymous placeholder. */
+async function probeImageUrl(url: string): Promise<boolean> {
+  try {
+    const image = new Image();
+    image.src = url;
+    await image.decode();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function releasePreviewUrl(url: string | undefined): void {
+  if (url?.startsWith('blob:')) URL.revokeObjectURL(url);
 }
 
 export function useAppShellComposerAttachments(options: {
@@ -50,14 +71,90 @@ export function useAppShellComposerAttachments(options: {
   const uiLocale = useUiLocale();
   const copy = getDesktopConversationCopy(uiLocale).actions;
   const [pendingByKey, setPendingByKey] = useState<PendingByKey<PendingAttachment>>({});
-  const pendingAttachments = selectPending(pendingByKey, options.draftKey);
+  // Preview URLs by stagingKey, kept beside — not inside — the staged items
+  // so a late-arriving preview never replaces an item object out from under
+  // an in-flight send. Entries only exist for staged items (see the cleanup
+  // effect); values are object URLs (file source) or data URLs (approval).
+  const [previewByStagingKey, setPreviewByStagingKey] = useState<Record<string, string>>({});
+  // Live mirror of every staged item's key, for async preview arrivals to
+  // check before writing: state snapshots inside a .then are stale by design.
+  const stagedKeysRef = useRef<Set<string>>(new Set());
+  const stagedAttachments = selectPending(pendingByKey, options.draftKey);
+  const pendingAttachments = useMemo(
+    () =>
+      stagedAttachments.map((item) => {
+        const previewUrl = previewByStagingKey[item.stagingKey];
+        return previewUrl ? { ...item, previewUrl } : item;
+      }),
+    [stagedAttachments, previewByStagingKey],
+  );
+
+  // Single owner of preview lifecycle: whenever the staged set changes,
+  // refresh the live-key mirror and drop (+ revoke) every preview whose item
+  // is gone — covering remove, submit, and any preview that raced past the
+  // write guard below.
+  useEffect(() => {
+    const liveKeys = new Set<string>();
+    for (const items of Object.values(pendingByKey)) {
+      for (const item of items) liveKeys.add(item.stagingKey);
+    }
+    stagedKeysRef.current = liveKeys;
+    setPreviewByStagingKey((current) => {
+      const deadKeys = Object.keys(current).filter((key) => !liveKeys.has(key));
+      if (deadKeys.length === 0) return current;
+      const next = { ...current };
+      for (const key of deadKeys) {
+        releasePreviewUrl(next[key]);
+        delete next[key];
+      }
+      return next;
+    });
+  }, [pendingByKey]);
+
+  function commitPreview(stagingKey: string, url: string): void {
+    if (!stagedKeysRef.current.has(stagingKey)) {
+      // The item was removed or sent while the preview was in flight.
+      releasePreviewUrl(url);
+      return;
+    }
+    setPreviewByStagingKey((current) => ({ ...current, [stagingKey]: url }));
+  }
+
+  /** SEQUENTIAL by design: each approval preview makes main read and decode
+   * the full original (bounded by the file's own stat size), so firing a
+   * whole picker batch concurrently multiplies peak memory by the batch
+   * size. One at a time keeps the ceiling at a single image; the drawer
+   * shows named file cards until each thumbnail lands. */
+  async function loadPreviewsSequentially(staged: readonly PendingAttachment[]): Promise<void> {
+    for (const item of staged) {
+      if (item.kind !== 'image') continue;
+      if (!stagedKeysRef.current.has(item.stagingKey)) continue;
+      try {
+        if (item.source.type === 'file') {
+          const url = URL.createObjectURL(item.source.file);
+          if (await probeImageUrl(url)) commitPreview(item.stagingKey, url);
+          else releasePreviewUrl(url);
+          continue;
+        }
+        const preview = await window.maka.attachments.previewApproval(item.source.approvalId);
+        if (!preview.ok) continue;
+        const url = `data:${preview.mimeType};base64,${preview.base64}`;
+        if (await probeImageUrl(url)) commitPreview(item.stagingKey, url);
+      } catch {
+        // Soft by design: a failed preview leaves the named file card.
+      }
+    }
+  }
 
   async function pickAttachments(): Promise<void> {
     const ownerKey = options.draftKey;
     try {
       const result = await window.maka.attachments.pickFiles();
       if (!result.ok) return;
-      setPendingByKey((map) => appendPending(map, ownerKey, result.files.map(approvalToPending)));
+      const staged = result.files.map(approvalToPending);
+      setPendingByKey((map) => appendPending(map, ownerKey, staged));
+      for (const item of staged) stagedKeysRef.current.add(item.stagingKey);
+      void loadPreviewsSequentially(staged);
     } catch (error) {
       options.toastApi.error(
         copy.attachmentFailedTitle,
@@ -69,7 +166,10 @@ export function useAppShellComposerAttachments(options: {
   async function attachFilePaths(files: File[]): Promise<void> {
     if (files.length === 0) return;
     const ownerKey = options.draftKey;
-    setPendingByKey((map) => appendPending(map, ownerKey, files.map(fileToPending)));
+    const staged = files.map(fileToPending);
+    setPendingByKey((map) => appendPending(map, ownerKey, staged));
+    for (const item of staged) stagedKeysRef.current.add(item.stagingKey);
+    void loadPreviewsSequentially(staged);
   }
 
   function removeAttachment(index: number): void {
@@ -79,7 +179,9 @@ export function useAppShellComposerAttachments(options: {
 
   function clearSubmittedAttachments(submitted: readonly PendingAttachment[]): void {
     const ownerKey = options.draftKey;
-    setPendingByKey((map) => removePendingItems(map, ownerKey, submitted));
+    setPendingByKey((map) =>
+      removePendingItems(map, ownerKey, submitted, pendingAttachmentSourceKey),
+    );
   }
 
   return {

--- a/packages/core/src/__tests__/attachments.test.ts
+++ b/packages/core/src/__tests__/attachments.test.ts
@@ -14,6 +14,10 @@ describe('attachment MIME routing', () => {
       ['application/pdf', undefined, 'pdf'],
       ['application/octet-stream', 'budget.xlsx', 'doc'],
       ['', 'slides.pptx', 'doc'],
+      ['text/plain', 'server.ts', 'code'],
+      ['application/octet-stream', 'MAIN.PY', 'code'],
+      ['text/markdown', 'notes.md', 'other'],
+      ['', 'archive.tar.gz', 'other'],
     ] as const) {
       assert.equal(attachmentKindFromMimeType(mime, name), kind);
     }

--- a/packages/core/src/attachments.ts
+++ b/packages/core/src/attachments.ts
@@ -98,6 +98,41 @@ export function guessMimeFromName(fileName: string): string {
  * `vnd.openxmlformats` string depending on the source); MIME still wins
  * when it is present and specific.
  */
+/** Extensions routed to the `code` kind. Consumption is identical to `other`
+ * (the model Reads them on demand); the kind only drives display — the
+ * FileCode icon in chat turns and the composer's staged-file card. */
+const CODE_FILE_EXTENSIONS = new Set([
+  'c',
+  'cc',
+  'cpp',
+  'cs',
+  'css',
+  'go',
+  'h',
+  'hpp',
+  'java',
+  'js',
+  'json',
+  'jsx',
+  'kt',
+  'mjs',
+  'cjs',
+  'php',
+  'py',
+  'rb',
+  'rs',
+  'sh',
+  'sql',
+  'svelte',
+  'swift',
+  'ts',
+  'tsx',
+  'vue',
+  'yaml',
+  'yml',
+  'zsh',
+]);
+
 export function attachmentKindFromMimeType(
   mimeType: string,
   fileName?: string,
@@ -116,6 +151,10 @@ export function attachmentKindFromMimeType(
       lowerName.endsWith('.ppt')
     ) {
       return 'doc';
+    }
+    const dot = lowerName.lastIndexOf('.');
+    if (dot >= 0 && CODE_FILE_EXTENSIONS.has(lowerName.slice(dot + 1))) {
+      return 'code';
     }
   }
   return 'other';

--- a/packages/ui/src/__tests__/astryx-form-controls-localization.test.tsx
+++ b/packages/ui/src/__tests__/astryx-form-controls-localization.test.tsx
@@ -17,6 +17,19 @@ function renderChineseControl(children: React.ReactNode): string {
 }
 
 describe('Astryx form-control localization', () => {
+  it('spells out the drawer toggle click affordance in both locales', () => {
+    // These strings double as the composer drawer's visible hover tooltip
+    // (composer.css renders attr(aria-label)), so both locales must carry the
+    // click affordance — en is otherwise override-free and must not regress
+    // to Astryx's bare "Collapse {label}".
+    const zh = astryxMessageOverrides('zh')?.zh;
+    assert.equal(zh?.['@astryx.chatComposerDrawer.collapse'], '点击收起{label}');
+    assert.equal(zh?.['@astryx.chatComposerDrawer.expand'], '点击展开{label}');
+    const en = astryxMessageOverrides('en')?.en;
+    assert.equal(en?.['@astryx.chatComposerDrawer.collapse'], 'Click to collapse {label}');
+    assert.equal(en?.['@astryx.chatComposerDrawer.expand'], 'Click to expand {label}');
+  });
+
   it('sources every rendered Slice 4 default message from the Maka copy catalog', () => {
     const messages = astryxMessageOverrides('zh')?.zh;
 

--- a/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
+++ b/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
@@ -264,6 +264,43 @@ describe('composer quiet chrome', () => {
     assert.doesNotMatch(drawer, /data-mode=/);
   });
 
+  it('stages an image as a thumbnail preview and a file as an iconized token', () => {
+    const markup = render(
+      <Composer
+        onSend={() => true}
+        onStop={() => {}}
+        pendingAttachments={[
+          { displayName: 'shot.png', kind: 'image', size: 2048, previewUrl: 'blob:app/shot' },
+          { displayName: 'pending.png', kind: 'image', size: 1024 },
+          { displayName: 'premier-league-tactics.epub', kind: 'doc', size: 3 * 1024 * 1024 },
+        ]}
+        onRemoveAttachment={() => {}}
+        modelLabel="demo"
+      />,
+    );
+    const drawer = markup.slice(
+      markup.indexOf('maka-composer-context-drawer'),
+      markup.indexOf('maka-composer-left-controls'),
+    );
+    // An image with a host-supplied preview is a real Astryx Thumbnail showing
+    // those pixels — not a filename chip.
+    assert.match(drawer, /maka-composer-attachment-thumbnail/);
+    assert.match(drawer, /<img[^>]*src="blob:app\/shot"/);
+    // An image whose preview hasn't landed (or failed) renders as a NAMED file
+    // card — never an anonymous placeholder square.
+    const thumbCount = drawer.split('maka-composer-attachment-thumbnail').length - 1;
+    assert.equal(thumbCount, 1, 'only the previewable image is a thumbnail');
+    assert.match(drawer, /data-kind="image"/);
+    assert.match(drawer, /pending\.png/);
+    // A non-image file is a two-line card: kind icon tile, name, "EXT · size"
+    // meta, and a localized remove control — not a bare filename chip.
+    assert.match(drawer, /maka-composer-attachment-card/);
+    assert.match(drawer, /data-kind="doc"/);
+    assert.match(drawer, /premier-league-tactics\.epub/);
+    assert.match(drawer, /EPUB · 3\.0 MB/);
+    assert.match(drawer, /aria-label="移除 premier-league-tactics\.epub"/);
+  });
+
   it('shows a single voice control only when the host wires capture', () => {
     const markup = render(
       <Composer

--- a/packages/ui/src/astryx-copy.ts
+++ b/packages/ui/src/astryx-copy.ts
@@ -109,8 +109,11 @@ export const ASTRYX_COPY_ZH: AstryxCopy = {
     statusRead: '已读',
     statusSending: '发送中',
     statusSent: '已发送',
-    drawerCollapse: '收起{label}',
-    drawerExpand: '展开{label}',
+    // «点击» is deliberate: the string doubles as the toggle band's visible
+    // hover tooltip (composer.css renders attr(aria-label)), where the click
+    // affordance is the whole point.
+    drawerCollapse: '点击收起{label}',
+    drawerExpand: '点击展开{label}',
     newMessages: '跳到最新消息',
     scrollToBottom: '滚动到底部',
     toolCallsError: '错误：{message}',

--- a/packages/ui/src/astryx-i18n.tsx
+++ b/packages/ui/src/astryx-i18n.tsx
@@ -54,7 +54,19 @@ export function AstryxLocaleProvider({
 }
 
 export function astryxMessageOverrides(locale: UiLocale): Overrides | undefined {
-  if (locale === 'en') return undefined;
+  if (locale === 'en') {
+    // en otherwise resolves to Astryx's shipped defaults. These two are the
+    // sole exceptions: the drawer toggle's aria-label doubles as its visible
+    // hover tooltip (composer.css renders attr(aria-label)), and the shipped
+    // "Collapse {label}" / "Expand {label}" read as state names there — the
+    // click affordance is the tooltip's whole point.
+    return {
+      en: {
+        '@astryx.chatComposerDrawer.collapse': 'Click to collapse {label}',
+        '@astryx.chatComposerDrawer.expand': 'Click to expand {label}',
+      },
+    };
+  }
   const shared = getSharedUiCopy(locale);
   const form = shared.formControls;
   // `locale` is narrowed to 'zh' past the early return; the catalogue lives

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -23,6 +23,7 @@ import {
   Sparkles,
   Upload,
   Workflow,
+  X,
 } from './icons.js';
 import {
   ChatModelSwitcher,
@@ -57,6 +58,7 @@ import {
   ChatComposerDrawer,
   ChatComposerInput,
   IconButton,
+  Thumbnail,
   Token,
   useChatPasteAsToken,
   type ChatComposerInputHandle,
@@ -71,6 +73,8 @@ import {
   DropdownMenuItem,
 } from '@astryxdesign/core/DropdownMenu';
 import { PermissionModeSelect } from './permission-mode-menu.js';
+import { AttachmentKindIcon } from './attachment-kinds.js';
+import { formatPreviewSize } from './artifact-preview-registry.js';
 import {
   inlineReferenceFileBasename,
   inlineReferenceToken,
@@ -119,6 +123,15 @@ function skillTokenValue(id: string): string {
  * rows before it scrolls; rows, not pixels, is the knob upstream exposes.
  */
 const COMPOSER_MAX_ROWS = 10;
+
+/** Uppercased extension for the staged-file card's meta line ("EPUB · 621.0 KB").
+ *  Null when the name has no usable extension, so the meta line is size-only. */
+function attachmentExtensionLabel(name: string): string | null {
+  const idx = name.lastIndexOf('.');
+  if (idx <= 0 || idx === name.length - 1) return null;
+  const ext = name.slice(idx + 1);
+  return ext.length > 8 ? null : ext.toUpperCase();
+}
 
 /**
  * PR-UI-15 (@yuejing 2026-05-22): Composer copy is locale-aware.
@@ -187,7 +200,16 @@ export const Composer = forwardRef<
     onStop(): void | Promise<void>;
     onPickAttachments?(): void | Promise<void>;
     onAttachFilePaths?(files: File[]): void | Promise<void>;
-    pendingAttachments?: readonly { displayName: string; kind: AttachmentRef['kind']; mimeType?: string; size: number }[];
+    pendingAttachments?: readonly {
+      displayName: string;
+      kind: AttachmentRef['kind'];
+      mimeType?: string;
+      size: number;
+      /** Renderer-resolvable image source (object/data URL) for `kind: 'image'`
+       *  previews. While absent (still loading, or preview failed) the image
+       *  renders as a named file card instead of a thumbnail. */
+      previewUrl?: string;
+    }[];
     onRemoveAttachment?(index: number): void;
     /** Quoted excerpts staged for the next send; rendered as removable chips. */
     pendingQuotes?: readonly QuoteRef[];
@@ -1250,14 +1272,63 @@ export const Composer = forwardRef<
                     onRemove={props.onRemoveQuote ? () => props.onRemoveQuote?.(index) : undefined}
                   />
                 ))}
-                {props.pendingAttachments?.map((attachment, index) => (
-                  <Token
-                    key={`${attachment.displayName}-${index}`}
-                    size="sm"
-                    label={attachment.displayName}
-                    onRemove={props.onRemoveAttachment ? () => props.onRemoveAttachment?.(index) : undefined}
-                  />
-                ))}
+                {props.pendingAttachments?.map((attachment, index) => {
+                  const onRemove = props.onRemoveAttachment
+                    ? () => props.onRemoveAttachment?.(index)
+                    : undefined;
+                  // Astryx-standard rendering (per maintainer guidance): images
+                  // with a resolved preview get a real Thumbnail; everything
+                  // else — other kinds, AND images whose preview failed or is
+                  // still loading — gets the two-line file card, so nothing
+                  // ever sits in the drawer as an anonymous placeholder square.
+                  if (attachment.kind === 'image' && attachment.previewUrl) {
+                    return (
+                      <Thumbnail
+                        key={`${attachment.displayName}-${index}`}
+                        className="maka-composer-attachment-thumbnail"
+                        src={attachment.previewUrl}
+                        label={attachment.displayName}
+                        onRemove={onRemove}
+                      />
+                    );
+                  }
+                  const extension = attachmentExtensionLabel(attachment.displayName);
+                  const sizeLabel = formatPreviewSize(attachment.size, locale);
+                  return (
+                    <span
+                      key={`${attachment.displayName}-${index}`}
+                      className="maka-composer-attachment-card"
+                      data-kind={attachment.kind}
+                    >
+                      <span className="maka-composer-attachment-card-icon" aria-hidden="true">
+                        <AttachmentKindIcon kind={attachment.kind} />
+                      </span>
+                      <span className="maka-composer-attachment-card-text">
+                        <span
+                          className="maka-composer-attachment-card-name"
+                          title={attachment.displayName}
+                        >
+                          {attachment.displayName}
+                        </span>
+                        <span className="maka-composer-attachment-card-meta">
+                          {extension ? `${extension} · ${sizeLabel}` : sizeLabel}
+                        </span>
+                      </span>
+                      {onRemove && (
+                        <button
+                          type="button"
+                          className="maka-composer-attachment-card-remove"
+                          aria-label={getConversationCopy(locale).messages.removeAttachmentAriaLabel(
+                            attachment.displayName,
+                          )}
+                          onClick={onRemove}
+                        >
+                          <X size={13} aria-hidden="true" />
+                        </button>
+                      )}
+                    </span>
+                  );
+                })}
               </div>
             </ChatComposerDrawer>
           ) : undefined}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -1262,8 +1262,45 @@ export const Composer = forwardRef<
           onSubmit={() => {}}
           isDisabled={props.disabled}
           drawer={drawerTokenCount > 0 ? (
-            <ChatComposerDrawer count={drawerTokenCount} label={copy.addContext}>
-              <div className="maka-composer-context-drawer" role="group" aria-label={copy.addContext}>
+            <ChatComposerDrawer
+              count={drawerTokenCount}
+              label={copy.stagedContext}
+              // The collapse band's tooltip (composer.css ::after) follows the
+              // pointer instead of sitting at a fixed offset — on a full-width
+              // band a fixed bubble can be half a window away from the cursor.
+              // The custom property feeds the ::after's `left`; clamped so the
+              // bubble never crosses the band's right edge.
+              onPointerMove={(event) => {
+                const toggle = event.currentTarget.querySelector<HTMLElement>(
+                  '[role="button"][aria-controls]',
+                );
+                if (!toggle) return;
+                const band = toggle.getBoundingClientRect();
+                if (event.clientY < band.top || event.clientY > band.bottom) return;
+                // Clamp against the bubble's border-box: computed width is
+                // content-box only, so the paddings must be priced in or the
+                // right edge overshoots by exactly their sum.
+                const bubbleStyle = getComputedStyle(toggle, '::after');
+                const bubbleWidth =
+                  (Number.parseFloat(bubbleStyle.width) || 124) +
+                  (Number.parseFloat(bubbleStyle.paddingLeft) || 0) +
+                  (Number.parseFloat(bubbleStyle.paddingRight) || 0);
+                const x = Math.min(
+                  Math.max(event.clientX - band.left + 14, 8),
+                  Math.max(8, band.width - bubbleWidth - 8),
+                );
+                toggle.style.setProperty('--maka-drawer-tooltip-x', `${x}px`);
+              }}
+              // Without this, keyboard focus after a hover would show the
+              // bubble at the last pointer position instead of the
+              // beside-the-pill fallback.
+              onPointerLeave={(event) => {
+                event.currentTarget
+                  .querySelector<HTMLElement>('[role="button"][aria-controls]')
+                  ?.style.removeProperty('--maka-drawer-tooltip-x');
+              }}
+            >
+              <div className="maka-composer-context-drawer" role="group" aria-label={copy.stagedContext}>
                 {props.pendingQuotes?.map((quote, index) => (
                   <Token
                     key={`${quote.sourceTurnId ?? 'quote'}-${index}`}

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -68,6 +68,12 @@ export interface ConversationCopy {
     continuing: string;
     interruptHint: string;
     addContext: string;
+    /** Noun label for the composer drawer's staged quotes/attachments — the
+     *  collapsed badge, the drawer group's accessible name, and the collapse
+     *  toggle's "收起{label}" interpolation. `addContext` stays the ＋ menu's
+     *  ACTION label; reusing the verb phrase here made the collapsed drawer
+     *  read like a button. */
+    stagedContext: string;
     selectModel: string;
     dropToImport: string;
     addingAttachment: string;
@@ -333,7 +339,7 @@ const CONVERSATION_COPY = {
       placeholder: '描述任务，@ 引用文件，/ 选择技能…', textareaAriaLabel: '消息输入框', pastedQuoteLabel: '粘贴的文本', selectedSkillsAriaLabel: '已选择的 Skill', removeSkillAriaLabel: (name) => `移除 Skill：${name}`, awaitingPermission: '等待你确认权限…',
       sending: '正在发送…', importing: '正在导入…', sendLabel: '发送', stopLabel: '停止', stopping: '停止中…',
       streaming: 'Maka 正在回答…', processing: 'Maka 正在处理…', continuing: 'Maka 继续中…',
-      interruptHint: '或点停止中断', addContext: '添加上下文',
+      interruptHint: '或点停止中断', addContext: '添加上下文', stagedContext: '附加内容',
       selectModel: '选择模型', dropToImport: '松开以导入文件内容', addingAttachment: '正在添加附件', addFileOrDirectory: '添加文件或目录',
       chooseSkill: '选择技能', noSkillsAvailable: '当前没有可用技能',
       switchDisabledStreaming: '当前对话正在流式输出，等结束后再切换模型。', switchDisabledRunning: '当前对话正在运行，等结束后再切换模型。', switchDisabledPermission: '当前有工具调用正在等待确认，处理后再切换模型。',
@@ -478,7 +484,7 @@ const CONVERSATION_COPY = {
       placeholder: 'Describe a task, @ to reference files, / for skills…', textareaAriaLabel: 'Message input', pastedQuoteLabel: 'Pasted text', selectedSkillsAriaLabel: 'Selected Skills', removeSkillAriaLabel: (name) => `Remove Skill: ${name}`, awaitingPermission: 'Waiting for your permission decision…',
       sending: 'Sending…', importing: 'Importing…', sendLabel: 'Send', stopLabel: 'Stop', stopping: 'Stopping…',
       streaming: 'Maka is responding…', processing: 'Maka is working…', continuing: 'Maka is continuing…',
-      interruptHint: 'or click Stop to interrupt', addContext: 'Add context',
+      interruptHint: 'or click Stop to interrupt', addContext: 'Add context', stagedContext: 'staged items',
       selectModel: 'Choose model', dropToImport: 'Drop to import file contents', addingAttachment: 'Adding attachment', addFileOrDirectory: 'Add file or directory',
       chooseSkill: 'Choose skills', noSkillsAvailable: 'No skills available',
       switchDisabledStreaming: 'Wait for the current response to finish before switching models.', switchDisabledRunning: 'Wait for the current run to finish before switching models.', switchDisabledPermission: 'Resolve the pending tool permission before switching models.',

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -126,6 +126,10 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   // Rendered by Astryx's own Collapsible; settings/permission.css targets it to
   // size the capability group's disclosure row.
   'astryx-collapsible-trigger',
+  // ChatComposerDrawer's root (themeProps). composer.css pins its content
+  // grid's implicit column to the grid's own width so the staged-attachment
+  // row wraps at the real drawer edge instead of a max-content phantom width.
+  'astryx-chat-composer-drawer',
   // Astryx's Item (themeProps class on every settings row). rows.css squares
   // its corners inside an open row group: Item ships a 10px radius for its
   // standalone chip use, and our hairline is a border on the Item itself, so


### PR DESCRIPTION
Before:
<img width="708" height="194" alt="image" src="https://github.com/user-attachments/assets/5660807a-a335-4a34-be5c-870bacfc5c28" />


After:
<img width="753" height="302" alt="image" src="https://github.com/user-attachments/assets/4f055ac1-4c03-41eb-bc31-0dccdb66297d" />

## What

Staged attachments in the composer drawer rendered as bare filename Tokens — no image preview, no kind icon, and long filenames spanned (and overflowed) the drawer row. Per maintainer guidance, this stays on the Astryx standard scheme (`ChatComposerDrawer` / `Thumbnail` / themeProps hooks) and patches on top of it.

| | Before | After |
|---|---|---|
| Images | filename chip | real `Thumbnail` preview (56px, hover remove); GIFs stay animated |
| Other files | filename chip | two-line card: tinted kind-icon tile, ellipsized name, `EXT · size`, remove |
| Many files | single row, clipped at the drawer edge | wrapping chip rows |
| Collapsed drawer | «3 添加上下文» (read like a button) | «3 附加内容» + instant pointer-tracking tooltip on the collapse handle |

## How

**Preview sourcing** — the file path never leaves main:
- drag/paste files mint an object URL (CSP gains `img-src blob:` — such URLs only resolve to blobs this renderer created)
- picker files resolve over a new `attachments:previewApproval` IPC, registered once and shared by both execution modes. The approval is only **peeked**, so the token stays redeemable for the send. Bytes return as a 512px PNG via nativeImage, or as the original bytes (≤12MB) when nativeImage can't decode the format (GIF/WebP)

**Memory-bounded by design:**
- the renderer requests previews **one at a time**; main reads at the approval's own stat size instead of allocating the flat 50MB attachment cap per call
- previews live in a cache keyed by per-item `stagingKey`; a single cleanup effect drops (and revokes) entries whose item left the list, and late arrivals check a live-key mirror before writing — a preview resolving after remove/send can neither strand an orphan entry nor leak its object URL

**Correct-by-probe:** every candidate URL passes an `Image.decode()` probe before reaching the drawer, so corrupt bytes or a spoofed extension fall back to the **named** file card, never an anonymous placeholder. `attachmentKindFromMimeType` now routes source extensions to `code` (display only), which was previously unreachable.

**Layout:** two independent bugs kept the chip row from wrapping — the group sized to max-content as a flex item (fixed: `width: 100%`), and `ChatComposerDrawer`'s content grid let its implicit column resolve wider than the grid itself (measured 896px in a 648px grid; fixed: `grid-template-columns: minmax(0, 1fr)`).

**Drawer copy + tooltip:** new `stagedContext` copy («附加内容» / "staged items") replaces the ＋ menu's action phrase on the collapsed badge; toggle labels gain the click affordance in both locales (en picks up its first two Astryx message overrides). The collapse handle gets an instant CSS tooltip driven by `attr(aria-label)` that tracks the pointer within the band — placement is constraint-driven (drawer root clips itself; the input card paints above the drawer), documented in `composer.css`.

## Known debt

The wrap fix and tooltip target Astryx-internal structure (`> div[id]`, the toggle's `[role="button"][aria-controls]`) from product CSS/JSX — there is no public seam for either today. Follow-up: propose a drawer API upstream (content-column contract + toggle slot or tooltip prop).

## Tests

- core 3 (kind routing incl. `code`), ui 444, desktop 1781 — all green; console/a11y/copy/dead-CSS checks clean
- new coverage: size-capped preview reads, over-cap rejection without I/O, shared IPC registration for both modes, GIF fallback bytes, decode-failure soft-fail, re-derived-snapshot removal identity, drawer toggle copy in both locales
- verified live via CDP: sequential previews, 7-file wrap with zero overflow, spoofed-`.png` falling back to a named card, pointer-tracked tooltip clamped at the band edge

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Ac5rv6WUKWtMZgQb5QPN16