### PR TITLE
fix(runtime-host): make active session joins replay-safe

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -56,10 +56,11 @@ test("joins an active Turn without losing or replaying assistant text", async ()
     target.events.map((event) => [
       event.type,
       "text" in event ? event.text : undefined,
+      "startOffset" in event ? event.startOffset : undefined,
     ]),
     [
-      ["text_delta", "Hello"],
-      ["text_delta", " world"],
+      ["text_delta", "Hello", 0],
+      ["text_delta", " world", 5],
     ],
   );
 

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -46,6 +46,7 @@ describe('Runtime Host Maka Session driver', () => {
       turnId: 'turn-1',
       messageId: 'message-turn-1',
       ts: 50,
+      startOffset: 5,
       text: ' world',
     });
   });

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -475,6 +475,8 @@ export type SessionEvent =
 export interface TextDeltaEvent extends BaseEvent {
   type: 'text_delta';
   messageId: string;
+  /** Absolute UTF-16 offset for replay-safe streams; absent for append-only backends. */
+  startOffset?: number;
   text: string;
 }
 
@@ -489,6 +491,8 @@ export interface TextCompleteEvent extends BaseEvent {
 export interface ThinkingDeltaEvent extends BaseEvent {
   type: 'thinking_delta';
   messageId: string;
+  /** Absolute UTF-16 offset for replay-safe streams; absent for append-only backends. */
+  startOffset?: number;
   text: string;
 }
 

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -522,6 +522,37 @@ test('a joining Client receives an immutable transcript and absolute overlapping
   coordinator.close();
 });
 
+test('a joining Client receives live assistant text that has not reached durable storage', async () => {
+  const durable = assistantMessage('chunk-1');
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+    undefined,
+    async () => [durable],
+  );
+
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(1));
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(2));
+  const connection = coordinator.attachConnection('connection-1', new RecordingSink());
+  const opened = await open(coordinator, 'connection-1');
+  connection.activate(opened.subscriptionId);
+
+  const snapshot = await coordinator.handlers['session.transcript.query'](
+    { kind: 'start', subscriptionId: opened.subscriptionId },
+    connectionContext('connection-1'),
+  );
+  assert.equal(snapshot.ok, true);
+  if (!snapshot.ok) assert.fail('expected the transcript snapshot');
+  assert.equal(snapshot.result.kind, 'chunk');
+  if (snapshot.result.kind !== 'chunk') assert.fail('expected a transcript chunk');
+  assert.deepEqual(
+    JSON.parse(Buffer.from(snapshot.result.data, 'base64').toString('utf8')),
+    assistantMessage('chunk-1chunk-2'),
+  );
+  coordinator.close();
+});
+
 test('transcript snapshots chunk one large message and remain subscription-owned', async () => {
   const message = assistantMessage('界'.repeat(20_000));
   const coordinator = new SessionContinuityCoordinator(

--- a/packages/runtime-host/src/adapter/session-projector.ts
+++ b/packages/runtime-host/src/adapter/session-projector.ts
@@ -83,6 +83,7 @@ export class RuntimeHostSessionProjector {
           turnId: accumulator.turnId,
           messageId: accumulator.messageId,
           ts: this.#now(),
+          startOffset: 0,
           text: accumulator.text,
         });
       }
@@ -131,6 +132,7 @@ export class RuntimeHostSessionProjector {
           turnId: delta.turnId,
           messageId: delta.messageId,
           ts: this.#now(),
+          startOffset: folded.text.length - folded.tail.length,
           text: folded.tail,
         });
       }

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -68,8 +68,15 @@ interface SessionProjectionState {
   canonical: CanonicalSessionProjection;
   revision: number;
   subscribers: Map<string, Subscriber>;
-  assistantOffsets: Map<string, number>;
+  assistantPrefixes: Map<string, ActiveAssistantPrefix>;
   terminalPublicationFence?: TerminalPublicationFence;
+}
+
+interface ActiveAssistantPrefix {
+  turnId: string;
+  messageId: string;
+  kind: SessionAssistantDelta['kind'];
+  text: string;
 }
 
 interface TerminalPublicationFence {
@@ -434,9 +441,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         state.canonical = canonical;
         state.revision = nextRevision;
         delete state.terminalPublicationFence;
-        for (const key of state.assistantOffsets.keys()) {
-          if (key.startsWith(`${runId}\0`)) state.assistantOffsets.delete(key);
-        }
+        state.assistantPrefixes.clear();
         this.#broadcastProjection(state, snapshot);
         if (state.subscribers.size === 0) this.#sessions.delete(sessionId);
       },
@@ -483,9 +488,15 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       if (event.type === 'text_delta' || event.type === 'thinking_delta') {
         const kind: SessionAssistantDelta['kind'] =
           event.type === 'text_delta' ? 'text' : 'thinking';
-        const offsetKey = assistantOffsetKey(runId, kind, event.messageId);
-        const startOffset = state.assistantOffsets.get(offsetKey) ?? 0;
-        state.assistantOffsets.set(offsetKey, startOffset + event.text.length);
+        const prefixKey = assistantPrefixKey(kind, event.messageId);
+        const current = state.assistantPrefixes.get(prefixKey);
+        const startOffset = current?.text.length ?? 0;
+        state.assistantPrefixes.set(prefixKey, {
+          turnId: event.turnId,
+          messageId: event.messageId,
+          kind,
+          text: (current?.text ?? '') + event.text,
+        });
         for (const subscriber of state.subscribers.values()) {
           this.#enqueueAssistantDelta(subscriber, sessionId, runId, event, kind, startOffset);
         }
@@ -647,9 +658,10 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         return transcriptSubscriptionNotFound();
       }
       try {
+        const state = this.#sessions.get(subscriber.sessionId);
         const messages = await readTranscript(
           subscriber.sessionId,
-          this.#sessions.get(subscriber.sessionId)?.canonical.rootTurn ?? null,
+          state?.canonical.rootTurn ?? null,
         );
         if (this.#ownedSubscriber(connectionId, input.subscriptionId) !== subscriber) {
           return transcriptSubscriptionNotFound();
@@ -658,7 +670,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
           connectionId,
           subscriptionId: subscriber.subscriptionId,
           sessionId: subscriber.sessionId,
-          messages,
+          messages: mergeActiveAssistantPrefixes(messages, state?.assistantPrefixes.values()),
         });
       } catch {
         return {
@@ -928,7 +940,12 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     }
     if (!state) {
       const value = createSessionContinuitySnapshot(canonical, 1);
-      state = { canonical, revision: 1, subscribers: new Map(), assistantOffsets: new Map() };
+      state = {
+        canonical,
+        revision: 1,
+        subscribers: new Map(),
+        assistantPrefixes: new Map(),
+      };
       this.#sessions.set(sessionId, state);
       return { changed: true, state, value };
     }
@@ -980,12 +997,50 @@ function slowConsumerFrameBytes(subscriber: Subscriber, hostEpoch: string): numb
   }).byteLength;
 }
 
-function assistantOffsetKey(
-  runId: string,
-  kind: SessionAssistantDelta['kind'],
-  messageId: string,
-): string {
-  return `${runId}\0${kind}\0${messageId}`;
+function assistantPrefixKey(kind: SessionAssistantDelta['kind'], messageId: string): string {
+  return `${kind}\0${messageId}`;
+}
+
+function mergeActiveAssistantPrefixes(
+  messages: readonly StoredMessage[],
+  prefixes: Iterable<ActiveAssistantPrefix> | undefined,
+): readonly StoredMessage[] {
+  const activePrefixes = prefixes ? [...prefixes] : [];
+  if (activePrefixes.length === 0) return messages;
+  const messageIndexById = new Map(messages.map((message, index) => [message.id, index]));
+  let merged: StoredMessage[] | undefined;
+  for (const prefix of activePrefixes) {
+    const messageIndex = messageIndexById.get(prefix.messageId);
+    if (messageIndex === undefined) {
+      throw new Error('Active assistant prefix has no matching transcript message');
+    }
+    const message = merged?.[messageIndex] ?? messages[messageIndex];
+    if (message?.type !== 'assistant' || message.turnId !== prefix.turnId) {
+      throw new Error('Active assistant prefix has no matching transcript message');
+    }
+    let nextMessage: StoredMessage;
+    if (prefix.kind === 'text') {
+      const text = mergeAssistantPrefix(message.text, prefix.text);
+      if (text === message.text) continue;
+      nextMessage = { ...message, text };
+    } else {
+      if (!message.thinking) {
+        throw new Error('Active thinking prefix has no matching transcript content');
+      }
+      const text = mergeAssistantPrefix(message.thinking.text, prefix.text);
+      if (text === message.thinking.text) continue;
+      nextMessage = { ...message, thinking: { ...message.thinking, text } };
+    }
+    if (!merged) merged = [...messages];
+    merged[messageIndex] = nextMessage;
+  }
+  return merged ?? messages;
+}
+
+function mergeAssistantPrefix(durable: string, active: string): string {
+  if (active.startsWith(durable)) return active;
+  if (durable.startsWith(active)) return durable;
+  throw new Error('Active assistant prefix conflicts with the durable transcript');
 }
 
 function transcriptSubscriptionNotFound(): OperationOutcome<'session.transcript.query'> {

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -86,6 +86,58 @@ describe('the unconfirmed claim an arm carries', () => {
 });
 
 describe('applyLiveTurnEvent', () => {
+  it('folds replayed absolute deltas instead of appending a resubscription seed', () => {
+    const seed = {
+      type: 'text_delta' as const,
+      id: 'seed-1',
+      turnId: 'turn-1',
+      messageId: 'step-1',
+      ts: 100,
+      startOffset: 0,
+      text: 'Hello',
+    };
+    const first = applyLiveTurnEvent(undefined, seed);
+    const replayed = applyLiveTurnEvent(first, { ...seed, id: 'seed-2', ts: 200 });
+    const extended = applyLiveTurnEvent(replayed, {
+      ...seed,
+      id: 'delta-3',
+      ts: 300,
+      startOffset: 5,
+      text: ' world',
+    });
+
+    assert.equal(replayed.steps[0]?.text?.text, 'Hello');
+    assert.equal(extended.steps[0]?.text?.text, 'Hello world');
+    assert.equal(extended.steps[0]?.text?.sourceEndOffset, 11);
+  });
+
+  it('tracks absolute thinking offsets independently from redacted display text', () => {
+    const first = applyLiveTurnEvent(undefined, {
+      type: 'thinking_delta',
+      id: 'thinking-1',
+      turnId: 'turn-1',
+      messageId: 'step-1',
+      ts: 100,
+      startOffset: 0,
+      text: 'Authorization: Bearer secret-value',
+    });
+    const replayed = applyLiveTurnEvent(first, {
+      type: 'thinking_delta',
+      id: 'thinking-2',
+      turnId: 'turn-1',
+      messageId: 'step-1',
+      ts: 200,
+      startOffset: 0,
+      text: 'Authorization: Bearer secret-value',
+    });
+
+    assert.equal(replayed.steps[0]?.thinking?.text, first.steps[0]?.thinking?.text);
+    assert.equal(
+      replayed.steps[0]?.thinking?.sourceEndOffset,
+      'Authorization: Bearer secret-value'.length,
+    );
+  });
+
   it('moves an armed turn from waiting to streamed on its first content event', () => {
     const waiting = armLiveTurn('turn-1');
     assert.equal(waiting.phase, 'waiting');

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -12,6 +12,8 @@ export interface LiveThinkingProjection {
   text: string;
   truncated: boolean;
   complete: boolean;
+  /** Raw source length, independent of redaction and display truncation. */
+  sourceEndOffset?: number;
 }
 
 export interface LiveTurnStepProjection {
@@ -28,6 +30,8 @@ export interface LiveTextProjection {
   text: string;
   truncated: boolean;
   complete: boolean;
+  /** Raw source length, independent of redaction and display truncation. */
+  sourceEndOffset?: number;
 }
 
 export interface LiveTurnProjection {
@@ -189,13 +193,17 @@ export function applyLiveTurnEvent(
   const step = stepIndex >= 0 ? prior.steps[stepIndex]! : { stepId, tools: [] };
   let nextStep: LiveTurnStepProjection;
   if (event.type === 'thinking_delta') {
-    const applied = applyThinkingDelta(step.thinking?.text ?? '', event.text, { locale });
+    const delta = replaySafeDelta(step.thinking?.sourceEndOffset, event);
+    const applied = applyThinkingDelta(step.thinking?.text ?? '', delta.text, { locale });
     nextStep = {
       ...step,
       thinking: {
         text: applied.text,
         truncated: (step.thinking?.truncated ?? false) || applied.truncated,
         complete: false,
+        ...(delta.sourceEndOffset === undefined
+          ? {}
+          : { sourceEndOffset: delta.sourceEndOffset }),
       },
     };
   } else if (event.type === 'thinking_complete') {
@@ -206,16 +214,23 @@ export function applyLiveTurnEvent(
         text: applied.text,
         truncated: applied.truncated,
         complete: true,
+        ...(step.thinking?.sourceEndOffset === undefined
+          ? {}
+          : { sourceEndOffset: event.text.length }),
       },
     };
   } else if (event.type === 'text_delta') {
-    const applied = applyAssistantDelta(step.text?.text ?? '', event.text, { locale });
+    const delta = replaySafeDelta(step.text?.sourceEndOffset, event);
+    const applied = applyAssistantDelta(step.text?.text ?? '', delta.text, { locale });
     nextStep = {
       ...step,
       text: {
         text: applied.text,
         truncated: (step.text?.truncated ?? false) || applied.truncated,
         complete: false,
+        ...(delta.sourceEndOffset === undefined
+          ? {}
+          : { sourceEndOffset: delta.sourceEndOffset }),
       },
     };
   } else if (event.type === 'text_complete') {
@@ -226,6 +241,9 @@ export function applyLiveTurnEvent(
         text: applied.text,
         truncated: applied.truncated,
         complete: true,
+        ...(step.text?.sourceEndOffset === undefined
+          ? {}
+          : { sourceEndOffset: event.text.length }),
       },
     };
   } else if (event.type === 'tool_start') {
@@ -332,6 +350,29 @@ export function applyLiveTurnEvent(
       : [...prior.steps, nextStep];
   }
   return { ...priorWithoutRetry, phase: 'streamed', steps };
+}
+
+function replaySafeDelta(
+  currentEndOffset: number | undefined,
+  event: Extract<SessionEvent, { type: 'text_delta' | 'thinking_delta' }>,
+): { text: string; sourceEndOffset?: number } {
+  if (event.startOffset === undefined) {
+    return {
+      text: event.text,
+      ...(currentEndOffset === undefined
+        ? {}
+        : { sourceEndOffset: currentEndOffset + event.text.length }),
+    };
+  }
+  const endOffset = event.startOffset + event.text.length;
+  if (currentEndOffset === undefined || event.startOffset > currentEndOffset) {
+    return { text: event.text, sourceEndOffset: endOffset };
+  }
+  const overlapLength = Math.min(currentEndOffset - event.startOffset, event.text.length);
+  return {
+    text: event.text.slice(overlapLength),
+    sourceEndOffset: Math.max(currentEndOffset, endOffset),
+  };
 }
 
 /**


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- make Runtime Host text and thinking deltas replay-safe with absolute UTF-16 offsets
- keep the renderer's raw stream cursor independent from redacted or truncated display text
- merge active assistant prefixes into transcript snapshots when partial persistence is still buffered
- reduce continuity state to the single active Run and copy only transcript messages that actually need an overlay
- add regressions for repeated active-Session joins, overlapping seed replay, thinking redaction, and transcript persistence lag

## Root cause

When Desktop switched away from a running Session and later subscribed again, the Runtime Host projector emitted the accumulated assistant content as a normal delta. The renderer retained that Session's live Turn projection and appended the replayed seed, so each switch could duplicate the same text again.

A separate race existed between live continuity and durable transcript batching. Runtime events advanced the Host's absolute assistant offset before later partial chunks reached SQLite. A Client joining during that window received an older transcript prefix followed by a newer live offset, which the projector correctly rejected as `Runtime Host assistant delta has a gap`.

This change gives Runtime Host deltas an absolute source offset and folds overlap at the renderer boundary. The continuity coordinator now derives offsets and active content from one in-memory prefix, and overlays that prefix onto a transcript snapshot under the same Session admission lane. Replayed seeds become idempotent, while joining Clients receive one contiguous transcript even when durable partial writes are still buffered.

## Validation

- `npm run build:test`
- `npm run typecheck --workspaces --if-present`
- `npm --workspace @maka/runtime-host run test:dist` — 733 passed
- `npm --workspace maka-agent run test:dist` — 494 passed
- `npm --workspace @maka/ui run test:dist`
- `npm --workspace @maka/desktop run test:dist`
- Biome check on all changed files
- `git diff --check`

</details>

<details>
<summary>中文</summary>

## 概要

- 使用绝对 UTF-16 offset 让 Runtime Host 的文本与思考 delta 可安全重放
- 让 renderer 的原始流 cursor 与脱敏、截断后的展示文本保持独立
- 当 partial persistence 仍在缓冲时，把活动 assistant prefix 合并进 transcript snapshot
- 将 continuity 状态收敛为单个 active Run，并只复制真正需要 overlay 的 transcript message
- 增加回归测试，覆盖重复加入活动 Session、重叠 seed 重放、思考内容脱敏和 transcript 持久化延迟

## 根因

Desktop 从一个运行中的 Session 切走并再次订阅时，Runtime Host projector 会把已经累计的 assistant 内容作为普通 delta 重新发送。Renderer 同时保留了该 Session 的 live Turn projection，于是把重放 seed 再次追加；每切换一次，同一段文本都可能继续重复。

Live continuity 与 durable transcript batching 之间还存在另一条竞态。Runtime event 会先推进 Host 的绝对 assistant offset，后续 partial chunk 则稍后才写入 SQLite。Client 在这个窗口加入时，会收到较旧的 transcript prefix 和较新的 live offset，projector 因而正确拒绝并报告 `Runtime Host assistant delta has a gap`。

本次修改为 Runtime Host delta 增加绝对 source offset，并在 renderer 边界折叠重叠内容。Continuity coordinator 现在从同一份内存 prefix 推导 offset 与活动内容，并在同一个 Session admission lane 内将它 overlay 到 transcript snapshot。重放 seed 因而具备幂等性；即使 durable partial write 仍在缓冲，新加入的 Client 也会收到连续 transcript。

## 验证

- `npm run build:test`
- `npm run typecheck --workspaces --if-present`
- `npm --workspace @maka/runtime-host run test:dist` — 733 项通过
- `npm --workspace maka-agent run test:dist` — 494 项通过
- `npm --workspace @maka/ui run test:dist`
- `npm --workspace @maka/desktop run test:dist`
- 对全部改动文件运行 Biome check
- `git diff --check`

</details>
