### PR TITLE
fix(runtime): validate swarm resume by agent id

### DIFF
--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -634,6 +634,59 @@ describe('AgentSwarm adapter', () => {
     assert.equal(starts, 0);
   });
 
+  test('resumes a preset child when its display name differs from the built-in definition', async () => {
+    let resumed = false;
+    const result = await buildAgentSwarmTool().impl(
+      {
+        resume_run_ids: { 'preset-run': 'Continue the preset child.' },
+      },
+      context({
+        prepareChildAgentResume: async (sourceRunId) => ({
+          ...preparedResume(sourceRunId),
+          agentName: 'DeepSeek Flash Reader',
+        }),
+        resumeChildAgent: async (input) => {
+          resumed = true;
+          return {
+            ...childResult(0),
+            runId: 'resumed-preset-run',
+            resumedFromRunId: input.sourceRunId,
+          };
+        },
+      }),
+    );
+
+    assert.equal(resumed, true);
+    assert.equal(result.status, 'completed');
+    assert.equal(result.items[0]?.resumedFromRunId, 'preset-run');
+  });
+
+  test('rejects a resume when the durable agent id changed', async () => {
+    let resumed = false;
+    await assert.rejects(
+      Promise.resolve(
+        buildAgentSwarmTool().impl(
+          {
+            resume_run_ids: { 'changed-agent-run': 'Continue the child.' },
+          },
+          context({
+            prepareChildAgentResume: async (sourceRunId) => ({
+              ...preparedResume(sourceRunId),
+              agentId: 'implementation',
+            }),
+            resumeChildAgent: async () => {
+              resumed = true;
+              return childResult(0);
+            },
+          }),
+        ),
+      ),
+      /resume profile changed/,
+    );
+
+    assert.equal(resumed, false);
+  });
+
   test('rejects resume inputs that resolve to the same linked child Session before starting work', async () => {
     let starts = 0;
     const tool = buildAgentSwarmTool();

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -766,7 +766,8 @@ async function prepareAgentSwarmInput(
         throw new Error(`Child AgentRun resume identity changed for ${item.sourceRunId}`);
       }
       const definition = requireAgentDefinitionByProfile(definitions, prepared.profile);
-      if (definition.id !== prepared.agentId || definition.name !== prepared.agentName) {
+      // Resume identity is the durable agent key. Preset and display metadata may change.
+      if (definition.id !== prepared.agentId) {
         throw new Error(`Child AgentRun resume profile changed for ${item.sourceRunId}`);
       }
       return {


### PR DESCRIPTION
## Summary
- validate resumed swarm children by their durable agent ID only
- allow preset display names to differ from built-in agent definition names
- retain rejection when the durable agent ID actually changes

## Tests
- `node --test packages/runtime/dist/__tests__/agent-swarm-tools.test.js` (30 passed)
- `npx biome check packages/runtime/src/agent-swarm-tools.ts packages/runtime/src/__tests__/agent-swarm-tools.test.ts`