### PR TITLE
fix(ui): keep quote layer geometry stable during entry

### DIFF
--- a/apps/desktop/src/main/__tests__/quote-layer-geometry-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-layer-geometry-contract.test.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import postcss from 'postcss';
+import { readRendererContractCss } from './contract-css-helpers.js';
+
+describe('quote layer geometry', () => {
+  it('keeps the positioning transform stable during entry', async () => {
+    const root = postcss.parse(await readRendererContractCss());
+    const entry = root.nodes.find(
+      (node) => node.type === 'atrule' && node.name === 'keyframes' && node.params === 'maka-quote-actions-in',
+    );
+
+    assert.ok(entry && entry.type === 'atrule', 'the quote layer has an entry animation');
+    assert.equal(
+      entry.nodes?.some(
+        (node) => node.type === 'rule' && node.nodes.some((child) => child.type === 'decl' && child.prop === 'transform'),
+      ),
+      false,
+      'the entry animation must not override the transform used to position the layer',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/styles/quote-side-panel.css
+++ b/apps/desktop/src/renderer/styles/quote-side-panel.css
@@ -23,7 +23,6 @@
 @keyframes maka-quote-actions-in {
   from {
     opacity: 0;
-    transform: translateY(2px);
   }
 }
 


### PR DESCRIPTION
## Summary

Remove the quote layer entry animation's vertical transform so it cannot contaminate the scroll-follow geometry or temporarily override the layer's centering transform. The opacity fade remains unchanged.

Add a deterministic CSS contract that keeps positioning transforms out of the entry animation. This closes the timing race that failed the post-merge CI run for #2350.

## Verification

- RED/GREEN: quote-layer-geometry-contract.test.ts failed before the CSS change and passes after it.
- npm --workspace @maka/desktop run test:dist — 1780 passed.
- npm --workspace @maka/desktop run typecheck — passed.
- npm run lint — passed.
- npm run format:check — passed.
- npm --workspace @maka/desktop run build:with-deps — passed.
- Focused quote-companion E2E could not start its Electron window fixture on this Mac and timed out before the test body; the draft PR CI provides the original Linux verification environment.