### PR TITLE
fix(runtime): bound oversized prior turns before provider requests

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10332,7 +10332,7 @@ describe('AiSdkBackend context budget and prompt attribution', () => {
       turnTailPrompt: 'volatile tail',
       contextBudget: {
         name: 'test-budget',
-        maxHistoryEstimatedTokens: 1,
+        maxHistoryEstimatedTokens: 40,
         minRecentTurns: 1,
         charsPerToken: 1,
       },

--- a/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
+++ b/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core';
-import { buildDefaultContextBudgetPolicy } from '../context-budget-policy.js';
+import {
+  buildDefaultContextBudgetPolicy,
+  resolveContextBudgetCapacity,
+} from '../context-budget-policy.js';
 
 describe('mid-turn history compact policy env plumbing', () => {
   test('defaults on: the runtime derives midTurn with the shared reserve when history compaction is enabled', () => {
@@ -89,6 +92,18 @@ describe('window-bounded reserve derivation (issue #882 PR 3 review P2)', () => 
     // No window: the flat 32_000 fallback budget and the classic reserve.
     assert.equal(policy?.maxHistoryEstimatedTokens, 32_000);
     assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
+    assert.deepEqual(
+      resolveContextBudgetCapacity(
+        {
+          ...gpt4Connection(),
+          defaultModel: 'custom-model',
+          models: [{ id: 'custom-model' }],
+        } as LlmConnection,
+        'custom-model',
+        policy,
+      ),
+      { tokens: 48_384, source: 'policy_fallback' },
+    );
   });
 
   test('respects an explicit reserve override verbatim even on a small window', () => {

--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -73,6 +73,9 @@ interface MidTurnFixtureOptions {
    * instead of the hand-built one, so a test can exercise the shipped default.
    */
   useRuntimeDefaultPolicy?: boolean;
+  /** Exercise the supported explicit history-compaction escape hatch. */
+  historyCompactOff?: boolean;
+  historyBudgetTokens?: number;
   reserveTokens?: number;
   summarize?: () => Promise<string | undefined> | string | undefined;
   branch?: string;
@@ -90,8 +93,9 @@ interface MidTurnFixtureOptions {
   meteredSummarizer?: boolean;
   /** Override the checkpoint recorder (e.g. to simulate a write failure). */
   record?: (checkpoint: HistoryCompactCheckpoint) => void;
-  /** Make the prior turns large so folding them rescues an over-window turn. */
-  bigPriors?: boolean;
+  /** Payload size for each text prior, or for the tool result in a tool-heavy prior. */
+  priorChars?: number;
+  priorShape?: 'text' | 'tool_heavy';
   /** First tool result is huge (finding C: prune must be able to rescue it). */
   hugeFirstResult?: boolean;
   /** The model finishes on the second request instead of running three steps. */
@@ -106,10 +110,8 @@ interface MidTurnFixtureOptions {
   firstStepUsage?: { input: number; output: number } | 'missing';
   /** Volatile per-request turn tail (cwd/task state) appended to the user message. */
   volatileTurnTail?: boolean;
-  /** Very large prior turns (~20k chars) so a large summary still shrinks the fold. */
-  giantPriors?: boolean;
-  /** Large system prompt sent via the separate `system` field (finding: cold start). */
-  bigSystemPrompt?: boolean;
+  /** System prompt size sent through the provider's separate system field. */
+  systemPromptChars?: number;
 }
 
 /**
@@ -206,23 +208,49 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
       };
     },
   });
-  const priorChars = options.giantPriors ? 10_000 : options.bigPriors ? 2_000 : 120;
+  const priorChars = options.priorChars ?? 120;
   const priorEvents: RuntimeEvent[] = options.withoutPriorTurns
     ? []
-    : [
-        runtimeTextEvent(
-          'prior-user',
-          'turn-0',
-          'user',
-          `PRIOR_FACT question ${'p'.repeat(priorChars)}`,
-        ),
-        runtimeTextEvent(
-          'prior-model',
-          'turn-0',
-          'model',
-          `PRIOR_FACT answer ${'q'.repeat(priorChars)}`,
-        ),
-      ];
+    : options.priorShape === 'tool_heavy'
+      ? [
+          runtimeTextEvent('prior-user', 'turn-0', 'user', 'PRIOR_FACT inspect the artifact'),
+          {
+            ...runtimeTextEvent('prior-call', 'turn-0', 'model', ''),
+            content: {
+              kind: 'function_call' as const,
+              id: 'prior-tool-1',
+              name: 'Read',
+              args: { path: 'artifact.log' },
+            },
+          },
+          {
+            ...runtimeTextEvent('prior-result', 'turn-0', 'model', ''),
+            role: 'tool' as const,
+            author: 'tool' as const,
+            content: {
+              kind: 'function_response' as const,
+              id: 'prior-tool-1',
+              name: 'Read',
+              result: `OVERSIZED_TOOL_RESULT_${'r'.repeat(priorChars)}`,
+              isError: false,
+            },
+          },
+          runtimeTextEvent('prior-model', 'turn-0', 'model', 'PRIOR_FACT inspection complete'),
+        ]
+      : [
+          runtimeTextEvent(
+            'prior-user',
+            'turn-0',
+            'user',
+            `PRIOR_FACT question ${'p'.repeat(priorChars)}`,
+          ),
+          runtimeTextEvent(
+            'prior-model',
+            'turn-0',
+            'model',
+            `PRIOR_FACT answer ${'q'.repeat(priorChars)}`,
+          ),
+        ];
   const anchor: RuntimeEvent = {
     ...runtimeTextEvent('anchor-1', 'turn-1', 'user', ANCHOR_TEXT),
     ...(options.branch !== undefined ? { branch: options.branch } : {}),
@@ -317,10 +345,15 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
     ...(options.volatileTurnTail
       ? { turnTailPrompt: 'VOLATILE_TAIL_SENTINEL cwd=/tmp/maka task=keep-going' }
       : {}),
-    ...(options.bigSystemPrompt ? { systemPrompt: 'SYSTEM_CONTEXT '.repeat(400) } : {}),
+    ...(options.systemPromptChars ? { systemPrompt: 'S'.repeat(options.systemPromptChars) } : {}),
     contextBudget: options.useRuntimeDefaultPolicy
       ? buildDefaultContextBudgetPolicy(
-          { ...connection(), models: [{ id: 'mock-model-id', contextWindow }] },
+          {
+            ...connection(),
+            models: [
+              { id: 'mock-model-id', ...(options.withoutContextWindow ? {} : { contextWindow }) },
+            ],
+          },
           {
             name: 'runtime-default-mid-turn',
             modelId: 'mock-model-id',
@@ -328,10 +361,17 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
             // default-on midTurn derivation and the window-bounded reserve
             // under test); a test may still size the reserve to its toy window
             // through the first-class env knob by passing reserveTokens.
-            env:
-              options.reserveTokens !== undefined
-                ? { MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS: String(options.reserveTokens) }
-                : {},
+            env: {
+              ...(options.reserveTokens !== undefined
+                ? {
+                    MAKA_CONTEXT_HISTORY_COMPACT_RESERVE_TOKENS: String(options.reserveTokens),
+                  }
+                : {}),
+              ...(options.historyCompactOff ? { MAKA_CONTEXT_HISTORY_COMPACT: 'off' } : {}),
+              ...(options.historyBudgetTokens !== undefined
+                ? { MAKA_CONTEXT_HISTORY_BUDGET_TOKENS: String(options.historyBudgetTokens) }
+                : {}),
+            },
           },
         )
       : {
@@ -663,7 +703,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     const fixture = buildFixture({
       contextWindow: 150,
       reserveTokens: 100,
-      bigPriors: true,
+      priorChars: 2_000,
       firstStepUsage: { input: 1_400, output: 20 },
     });
     await runFixtureTurn(fixture, consumer);
@@ -754,7 +794,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     const fixture = buildFixture({
       contextWindow: 150,
       reserveTokens: 100,
-      bigPriors: true,
+      priorChars: 2_000,
       record: () => {
         throw new Error('disk full');
       },
@@ -846,7 +886,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     // real replacement projection instead: the third step's huge result makes
     // even [second block, anchor, tail] exceed the window, so the turn must
     // end with the explicit outcome — never send the over-window request.
-    const fixture = buildFixture({ bigPriors: true, rollingOverflow: true });
+    const fixture = buildFixture({ priorChars: 2_000, rollingOverflow: true });
     await runFixtureTurn(fixture, consumer);
 
     // The first fold happened and its projection was used (three requests ran).
@@ -875,7 +915,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     // verdict diagnostics ride this record and the completed steps' cost is
     // real. Three steps stream (100/20 + 150/30 + 150/30) before the step-4
     // verdict aborts the send.
-    const fixture = buildFixture({ bigPriors: true, rollingOverflow: true });
+    const fixture = buildFixture({ priorChars: 2_000, rollingOverflow: true });
     await runFixtureTurn(fixture, consumer);
 
     const complete = fixture.events.find((event) => event.type === 'complete');
@@ -883,9 +923,9 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
       complete?.type === 'complete' ? complete.stopReason : undefined,
       'context_budget_exhausted',
     );
-    // Three requests streamed; the fourth doStream call rejects immediately on
-    // the already-aborted signal and never reports usage.
-    assert.equal(fixture.model.doStreamCalls.length, 4);
+    // Three requests streamed; the fourth is rejected locally before the
+    // provider adapter is called and therefore reports no usage.
+    assert.equal(fixture.model.doStreamCalls.length, 3);
     const lastCall = fixture.llmCalls.at(-1);
     assert.equal(lastCall?.status, 'error');
     assert.equal(lastCall?.errorClass, 'ContextBudgetExhausted');
@@ -902,7 +942,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     // the whole call — so the truthful outcome is no record at all; the
     // terminal result stays observable on the durable CompleteEvent.
     const fixture = buildFixture({
-      bigPriors: true,
+      priorChars: 2_000,
       rollingOverflow: true,
       firstStepUsage: 'missing',
     });
@@ -1035,7 +1075,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     const fixture = buildFixture({
       contextWindow: 1_000,
       reserveTokens: 100,
-      bigPriors: true,
+      priorChars: 2_000,
       finalAtSecondCall: true,
       firstStepUsage: 'missing',
     });
@@ -1096,7 +1136,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
 
   test('persists a complete summary above the legacy block cap when the full replay shrinks and fits', async () => {
     const fixture = buildFixture({
-      giantPriors: true,
+      priorChars: 10_000,
       summarize: () => 'S'.repeat(5_000),
     });
     await runFixtureTurn(fixture, consumer);
@@ -1124,7 +1164,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
       hugeFirstResult: true,
       finalAtSecondCall: true,
       firstStepUsage: 'missing',
-      bigSystemPrompt: true,
+      systemPromptChars: 6_000,
     });
     await runFixtureTurn(fixture, consumer);
 
@@ -1251,12 +1291,10 @@ describe('mid-turn capacity compaction flow plumbing', () => {
 });
 
 describe('mid-turn capacity default-on safety guards (issue #882 PR 3)', () => {
-  test('does not fire when the selected model has no known context window (conservative default)', async () => {
-    // PR 3 sinks midTurn on by default, but the backend only activates it when
-    // resolveSelectedModelContextWindow yields a window. An unknown model (no
-    // metadata, no models[].contextWindow) must never compact. Durable replay
-    // remains active because it is the Runtime loop's independent source of
-    // truth.
+  test('keeps the fallback capacity guard inert below its unknown-model bound', async () => {
+    // The unknown model derives a 48,384-token capacity from the default
+    // 32,000-token history budget plus its 16,384-token reserve. This small
+    // turn stays below that bound, so no compaction runs.
     const fixture = buildFixture({ withoutContextWindow: true });
     await runFixtureTurn(fixture);
 
@@ -1267,6 +1305,178 @@ describe('mid-turn capacity default-on safety guards (issue #882 PR 3)', () => {
     assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
     // The raw span is never folded away, proving no compaction ran.
     assert.equal(promptJson(fixture, 2).includes('RAW_SPAN_ONE_'), true);
+  });
+
+  test('compacts one oversized prior turn before an unknown-model request', async () => {
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      withoutContextWindow: true,
+      priorChars: 180_000,
+      priorShape: 'tool_heavy',
+    });
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.summarizerCalls, 1);
+    assert.equal(fixture.recorded.length, 1);
+    assert.equal(fixture.recorded[0]?.coverage.eventCount, 4);
+    assert.match(fixture.summarizedSources[0] ?? '', /function_call/);
+    assert.match(fixture.summarizedSources[0] ?? '', /function_response/);
+    const firstPrompt = promptJson(fixture, 0);
+    assert.match(firstPrompt, /maka_history_compact_checkpoint/);
+    assert.match(firstPrompt, /MID_TURN_SUMMARY_SENTINEL/);
+    assert.equal(firstPrompt.includes('OVERSIZED_TOOL_RESULT_'), false);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+  });
+
+  test('rejects one oversized prior turn locally when its summary fails', async () => {
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      withoutContextWindow: true,
+      priorChars: 180_000,
+      priorShape: 'tool_heavy',
+      summarize: () => undefined,
+    });
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.summarizerCalls, 1);
+    assert.equal(fixture.model.doStreamCalls.length, 0);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'summarizer_failed');
+  });
+
+  test('compacts an oversized latest turn when an older turn is also retained', async () => {
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      withoutContextWindow: true,
+      priorChars: 180_000,
+      priorShape: 'tool_heavy',
+    });
+    fixture.priorEvents.unshift(
+      runtimeTextEvent('older-user', 'turn-older', 'user', 'older question'),
+      runtimeTextEvent('older-model', 'turn-older', 'model', 'older answer'),
+    );
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.summarizerCalls, 1);
+    assert.equal(fixture.recorded.length, 1);
+    assert.equal(promptJson(fixture, 0).includes('OVERSIZED_TOOL_RESULT_'), false);
+  });
+
+  test('rejects an oversized prior turn when history compaction is disabled', async () => {
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      withoutContextWindow: true,
+      historyCompactOff: true,
+      priorChars: 180_000,
+      priorShape: 'tool_heavy',
+    });
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.summarizerCalls, 0);
+    assert.equal(fixture.model.doStreamCalls.length, 0);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'no_safe_completed_span');
+  });
+
+  test('rejects an oversized penultimate turn when history compaction is disabled', async () => {
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      withoutContextWindow: true,
+      historyCompactOff: true,
+      priorChars: 180_000,
+      priorShape: 'tool_heavy',
+    });
+    fixture.priorEvents.push(
+      runtimeTextEvent('latest-user', 'turn-latest', 'user', 'small latest question'),
+      runtimeTextEvent('latest-model', 'turn-latest', 'model', 'small latest answer'),
+    );
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.model.doStreamCalls.length, 0);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'no_safe_completed_span');
+  });
+
+  test('keeps multiple bounded recent turns when only their aggregate exceeds the history budget', async () => {
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      contextWindow: 100_000,
+      historyCompactOff: true,
+      historyBudgetTokens: 32_000,
+      priorChars: 40_000,
+    });
+    fixture.priorEvents.push(
+      runtimeTextEvent('second-user', 'turn-second', 'user', `SECOND_USER_${'u'.repeat(40_000)}`),
+      runtimeTextEvent(
+        'second-model',
+        'turn-second',
+        'model',
+        `SECOND_MODEL_${'m'.repeat(40_000)}`,
+      ),
+    );
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+  });
+
+  test('rejects an oversized complete step-zero payload before provider dispatch', async () => {
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      withoutContextWindow: true,
+      systemPromptChars: 200_000,
+    });
+    await runFixtureTurn(fixture);
+
+    assert.equal(fixture.model.doStreamCalls.length, 0);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type, 'complete');
+    if (complete?.type !== 'complete') return;
+    assert.equal(complete.stopReason, 'context_budget_exhausted');
+    assert.equal(complete.contextBudgetExhaustedDetail, 'no_safe_completed_span');
+  });
+
+  test('keeps user_stop when stopping an oversized pre-turn summary', async () => {
+    let markSummaryStarted: (() => void) | undefined;
+    const summaryStarted = new Promise<void>((resolve) => {
+      markSummaryStarted = resolve;
+    });
+    let finishSummary: (() => void) | undefined;
+    const fixture = buildFixture({
+      useRuntimeDefaultPolicy: true,
+      withoutContextWindow: true,
+      priorChars: 180_000,
+      priorShape: 'tool_heavy',
+      summarize: () =>
+        new Promise<undefined>((resolve) => {
+          finishSummary = () => resolve(undefined);
+          markSummaryStarted?.();
+        }),
+    });
+    const turn = runFixtureTurn(fixture);
+    await summaryStarted;
+    await fixture.backend.stop('user_stop');
+    finishSummary?.();
+    await turn;
+
+    assert.equal(fixture.model.doStreamCalls.length, 0);
+    assert.equal(
+      fixture.events.some((event) => event.type === 'abort'),
+      true,
+    );
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'user_stop');
   });
 
   test('does not fire for a session without a persisted head anchor (child sessions have no seam)', async () => {
@@ -1324,7 +1534,7 @@ describe('the shipped runtime default drives the proactive long-turn journey (is
     const fixture = buildFixture({
       useRuntimeDefaultPolicy: true,
       contextWindow: 1_000,
-      bigPriors: true,
+      priorChars: 1_400,
       firstStepUsage: { input: 900, output: 20 },
     });
     await runFixtureTurn(fixture);

--- a/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
+++ b/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
@@ -1292,11 +1292,10 @@ describe('reactive overflow recovery in the streaming backend', () => {
     // The verdict measured the pinned, steering-inclusive payload and refused
     // it explicitly instead of completing on an unmeasured over-window request
     // (unpinned, the fold hides the first steer from the measurement and the
-    // turn ends happily on end_turn). The third doStream invocation is the
-    // verdict's own abort landing before the stream starts — the mock counts
-    // the call, but no request chunk was ever produced.
+    // turn ends happily on end_turn). The third request is rejected locally
+    // before the provider adapter is called.
     assert.equal(complete(fixture)?.stopReason, 'context_budget_exhausted');
-    assert.equal(fixture.model.doStreamCalls.length, 3);
+    assert.equal(fixture.model.doStreamCalls.length, 2);
     // Both steers were durably delivered to the ledger before the verdict —
     // they are owned by history, not lost.
     assert.equal(fixture.events.filter((event) => event.type === 'steering_message').length, 2);

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -37,6 +37,7 @@ import type {
   StorageRef,
   AttachmentRef,
   QuoteRef,
+  ContextBudgetExhaustedDetail,
 } from '@maka/core/events';
 import type {
   StoredMessage,
@@ -211,6 +212,7 @@ import {
   buildHistorySearchSource,
   buildPromptSegmentEstimates,
   estimateRuntimeEventsTokens,
+  hasOversizedRetainedHistoryTurn,
   mergeContextBudgetDiagnostic,
   mergeContextBudgetDiagnosticPatches,
   mergeRuntimeEventsInOriginalOrder,
@@ -919,6 +921,22 @@ class TurnScope {
   ) {}
 }
 
+type PriorReplayResult =
+  | {
+      status: 'ready';
+      messages: ModelMessage[];
+      gate: RuntimeEventReplayFallbackGate | 'stored_message_projection';
+      diagnostics: RuntimeEventModelReplayPlan['diagnostics'];
+      runtimeEventCount?: number;
+      contextBudget?: ContextBudgetDiagnostic;
+      latestHistoryCompactCheckpoint?: HistoryCompactCheckpoint;
+    }
+  | {
+      status: 'context_budget_exhausted';
+      detail: ContextBudgetExhaustedDetail;
+      contextBudget?: ContextBudgetDiagnostic;
+    };
+
 export class AiSdkBackend implements AgentBackend {
   readonly kind: BackendKind = 'ai-sdk';
   readonly sessionId: string;
@@ -1472,7 +1490,41 @@ export class AiSdkBackend implements AgentBackend {
     }
 
     // --- Build messages from RuntimeEvent history and its compatibility projection. ---
-    const priorReplay = await this.buildPriorMessages(scope, input);
+    const priorReplayResult = await this.buildPriorMessages(scope, input);
+    if (scope.aborted) {
+      queue.push({
+        type: 'abort',
+        id: this.newId(),
+        turnId,
+        ts: this.now(),
+        reason: 'user_stop',
+      } satisfies AbortEvent);
+      queue.push({
+        type: 'complete',
+        id: this.newId(),
+        turnId,
+        ts: this.now(),
+        stopReason: 'user_stop',
+      } satisfies CompleteEvent);
+      queue.close();
+      yield* this.drain(queue);
+      return;
+    }
+    if (priorReplayResult.status === 'context_budget_exhausted') {
+      trace.modelStreamCompleted('context_budget_exhausted');
+      queue.push({
+        type: 'complete',
+        id: this.newId(),
+        turnId,
+        ts: this.now(),
+        stopReason: 'context_budget_exhausted',
+        contextBudgetExhaustedDetail: priorReplayResult.detail,
+      } satisfies CompleteEvent);
+      queue.close();
+      yield* this.drain(queue);
+      return;
+    }
+    const priorReplay = priorReplayResult;
     if (input.continuation && priorReplay.messages.length === 0) {
       const replay = priorReplayFailureTrace(priorReplay);
       const error = new ContinuationReplayEmptyError(replay.gate, replay.diagnosticCodes);
@@ -1856,6 +1908,11 @@ export class AiSdkBackend implements AgentBackend {
                 messages: requestMessages,
               })
             : undefined;
+          if (midTurnState?.exhaustedDetail) {
+            throw new Error(
+              `context budget exhausted before provider dispatch: ${midTurnState.exhaustedDetail}`,
+            );
+          }
           const projectedMessages = shaped?.messages ?? requestMessages;
           const finalChildSummaryStep =
             this.input.header.collaborationMode === 'agent' &&
@@ -3002,18 +3059,11 @@ export class AiSdkBackend implements AgentBackend {
   private async buildPriorMessages(
     scope: TurnScope,
     input: BackendSendInput,
-  ): Promise<{
-    messages: ModelMessage[];
-    gate: RuntimeEventReplayFallbackGate | 'stored_message_projection';
-    diagnostics: RuntimeEventModelReplayPlan['diagnostics'];
-    runtimeEventCount?: number;
-    contextBudget?: ContextBudgetDiagnostic;
-    /** Latest durable checkpoint (loaded or written this turn) for mid-turn roll-forward. */
-    latestHistoryCompactCheckpoint?: HistoryCompactCheckpoint;
-  }> {
+  ): Promise<PriorReplayResult> {
     const priorStored = input.context.filter((message) => message.turnId !== input.turnId);
     if (!input.runtimeContext) {
       return {
+        status: 'ready',
         messages: await this.materializePriorMessages(scope.imageBudget, priorStored),
         gate: 'stored_message_projection',
         diagnostics: [],
@@ -3029,14 +3079,40 @@ export class AiSdkBackend implements AgentBackend {
     );
     const preparedContextBudget =
       await this.compaction.prepareContextBudgetPolicy(priorRuntimeContext);
-    const contextBudget = preparedContextBudget.policy;
-    const budgeted = applyRuntimeEventContextBudget(priorRuntimeContext, contextBudget, {
+    let contextBudget = preparedContextBudget.policy;
+    let budgeted = applyRuntimeEventContextBudget(priorRuntimeContext, contextBudget, {
       historyCompactProtocol:
         contextBudget?.historyCompact?.checkpoint ||
         this.compaction.hasHistoryCompactCheckpointWriter()
           ? 'checkpoint_v2'
           : 'legacy_v1',
     });
+    const oversizedRetainedTurn = hasOversizedRetainedHistoryTurn(
+      budgeted?.events ?? priorRuntimeContext,
+      contextBudget,
+    );
+    let contextBudgetExhaustedDetail: ContextBudgetExhaustedDetail | undefined =
+      oversizedRetainedTurn && contextBudget?.historyCompact?.enabled !== true
+        ? 'no_safe_completed_span'
+        : undefined;
+    if (oversizedRetainedTurn && contextBudget?.historyCompact?.enabled === true) {
+      const overflowRecoveryPolicy: ContextBudgetPolicy = {
+        ...contextBudget,
+        minRecentTurns: 0,
+        historyCompact: {
+          ...contextBudget.historyCompact,
+          minRecentTurns: 0,
+        },
+      };
+      contextBudget = overflowRecoveryPolicy;
+      budgeted = applyRuntimeEventContextBudget(priorRuntimeContext, overflowRecoveryPolicy, {
+        historyCompactProtocol:
+          overflowRecoveryPolicy.historyCompact?.checkpoint ||
+          this.compaction.hasHistoryCompactCheckpointWriter()
+            ? 'checkpoint_v2'
+            : 'legacy_v1',
+      });
+    }
     let runtimeContext = budgeted?.events ?? priorRuntimeContext;
     let contextBudgetDiagnostic = budgeted?.diagnostic;
     let latestHistoryCompactCheckpoint = contextBudget?.historyCompact?.checkpoint;
@@ -3078,6 +3154,9 @@ export class AiSdkBackend implements AgentBackend {
               ...runtimeContext.filter((event) => !event.id.startsWith('history-compact:')),
             ];
           } else {
+            if (oversizedRetainedTurn && !writePatch.fallbackCheckpoint) {
+              contextBudgetExhaustedDetail = 'summarizer_failed';
+            }
             runtimeContext = writePatch.fallbackCheckpoint
               ? buildHistoryCompactCheckpointFailOpenContext(
                   writePatch.fallbackCheckpoint,
@@ -3121,6 +3200,22 @@ export class AiSdkBackend implements AgentBackend {
           );
         }
       }
+    }
+
+    if (
+      oversizedRetainedTurn &&
+      contextBudget?.maxHistoryEstimatedTokens !== undefined &&
+      estimateRuntimeEventsTokens(runtimeContext, contextBudget.charsPerToken) >
+        contextBudget.maxHistoryEstimatedTokens
+    ) {
+      contextBudgetExhaustedDetail ??= 'no_safe_completed_span';
+    }
+    if (contextBudgetExhaustedDetail) {
+      return {
+        status: 'context_budget_exhausted',
+        detail: contextBudgetExhaustedDetail,
+        ...(contextBudgetDiagnostic ? { contextBudget: contextBudgetDiagnostic } : {}),
+      };
     }
 
     const historySearchSource = buildHistorySearchSource(priorRuntimeContext, contextBudget);
@@ -3258,6 +3353,7 @@ export class AiSdkBackend implements AgentBackend {
     );
     if (plan.items.length === 0) {
       return {
+        status: 'ready',
         messages: input.continuation
           ? await this.materializeRuntimeReplayTextOnly(scope.imageBudget, plan)
           : projectedMessages,
@@ -3271,6 +3367,7 @@ export class AiSdkBackend implements AgentBackend {
 
     if (hasBlockingReplayDiagnostics(plan)) {
       return {
+        status: 'ready',
         messages: input.continuation
           ? await this.materializeRuntimeReplayTextOnly(scope.imageBudget, plan)
           : projectedMessages,
@@ -3286,6 +3383,7 @@ export class AiSdkBackend implements AgentBackend {
 
     if (!plan.hasProviderNativeSemantics) {
       return {
+        status: 'ready',
         messages: await this.materializeRuntimeReplayPlan(plan, scope.imageBudget),
         gate: 'runtime_replay_text_only',
         diagnostics: plan.diagnostics,
@@ -3297,6 +3395,7 @@ export class AiSdkBackend implements AgentBackend {
 
     if (!this.canReplayProviderNative(plan)) {
       return {
+        status: 'ready',
         messages: input.continuation
           ? await this.materializeRuntimeReplayTextOnly(scope.imageBudget, plan)
           : projectedMessages,
@@ -3311,6 +3410,7 @@ export class AiSdkBackend implements AgentBackend {
     }
 
     return {
+      status: 'ready',
       messages: await this.materializeRuntimeReplayPlan(plan, scope.imageBudget),
       gate: 'runtime_replay_provider_native',
       diagnostics: plan.diagnostics,

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -89,7 +89,10 @@ import {
   exceedsHighWater,
   planMidTurnCapacityCompaction,
 } from './mid-turn-capacity-compact.js';
-import { resolveSelectedModelContextWindow } from './context-budget-policy.js';
+import {
+  resolveContextBudgetCapacity,
+  type ContextBudgetCapacity,
+} from './context-budget-policy.js';
 
 /**
  * Image byte allowance for one turn, accumulated across its provider steps.
@@ -1236,7 +1239,7 @@ export class AiSdkCompaction {
    * Mid-turn capacity compaction eligibility (issue #882 PR 1). Explicit
    * opt-in via `historyCompact.midTurn.enabled`; requires the checkpoint
    * writer seams plus the durable turn-ledger read, the persisted head anchor
-   * for this turn, and a known model context window.
+   * for this turn, and a bounded capacity window.
    */
   public buildMidTurnCapacityCompactState(
     input: BackendSendInput,
@@ -1267,15 +1270,16 @@ export class AiSdkCompaction {
     ) {
       return undefined;
     }
-    const contextWindow = resolveSelectedModelContextWindow(
+    const capacity = resolveContextBudgetCapacity(
       this.input.connection,
       this.input.modelId,
+      policy,
     );
-    if (contextWindow === undefined) return undefined;
+    if (capacity === undefined) return undefined;
     const priorContentEvents = (input.runtimeContext ?? [])
       .filter((event) => event.turnId !== input.turnId)
       .filter(isHistoryCompactContentEvent);
-    return new MidTurnCapacityCompactState(headAnchor, priorContentEvents, contextWindow);
+    return new MidTurnCapacityCompactState(headAnchor, priorContentEvents, capacity);
   }
 
   /**
@@ -1423,7 +1427,7 @@ export class AiSdkCompaction {
         });
       if (
         forcedEstimate === undefined &&
-        !exceedsHighWater(estimate, state.contextWindow, reserveTokens)
+        !exceedsHighWater(estimate, state.capacity.tokens, reserveTokens)
       ) {
         return keepProjection();
       }
@@ -1590,7 +1594,7 @@ export class AiSdkCompaction {
       orderedEvents,
       headAnchor: { runtimeEventId: state.headAnchor.id, turnId },
       estimatedNextRequestTokens: input.estimatedNextRequestTokens,
-      contextWindow: state.contextWindow,
+      contextWindow: state.capacity.tokens,
       reserveTokens,
       reserveTailEvents: midTurn.reserveTailEvents ?? 1,
       charsPerToken,
@@ -1774,7 +1778,7 @@ export class AiSdkCompaction {
       minFlushedSteps: state.flushedSteps,
       // The provider rejected the request outright, so force the fold past the
       // high water regardless of the (evidently under-counting) estimate.
-      estimatedNextRequestTokens: state.contextWindow + 1,
+      estimatedNextRequestTokens: state.capacity.tokens + 1,
       referencePayloadChars,
       providerTools: input.providerTools,
       activeToolsForStep: input.activeTools,
@@ -1851,7 +1855,8 @@ export class AiSdkCompaction {
    *    remainder exceeds capacity); a recorded shaping failure keeps its own
    *    detail and diagnostic reason.
    *
-   * Step 0 is shaped by the pre_turn path and only records the baseline here.
+   * Step 0 is shaped by the pre_turn path. It is still measured here so an
+   * unshapable first request cannot bypass the capacity invariant.
    */
   public buildMidTurnFinalRequestVerdict(input: {
     shaped: RequestProjectionStage;
@@ -1885,7 +1890,10 @@ export class AiSdkCompaction {
           systemPromptChars,
         );
       let payloadChars = finalPayloadChars();
-      if (options.stepNumber >= 1 && !state.exhaustedDetail) {
+      if (
+        (options.stepNumber >= 1 || state.capacity.source === 'policy_fallback') &&
+        !state.exhaustedDetail
+      ) {
         const estimateFinal = (): number =>
           estimateNextRequestTokens({
             ...(state.lastRequestInputTokens !== undefined
@@ -1899,7 +1907,11 @@ export class AiSdkCompaction {
         const capacityAttemptedThisStep =
           state.replacedStepNumber === options.stepNumber ||
           state.lastShapeFailure?.stepNumber === options.stepNumber;
-        if (estimate > state.contextWindow && !capacityAttemptedThisStep) {
+        if (
+          options.stepNumber >= 1 &&
+          estimate > state.capacity.tokens &&
+          !capacityAttemptedThisStep
+        ) {
           // One bounded capacity re-entry: the trigger threshold is
           // approximate on purpose (recoverable), so a miss must become a
           // rescue attempt before it can become a terminal verdict. Re-run
@@ -1926,7 +1938,7 @@ export class AiSdkCompaction {
           payloadChars = finalPayloadChars();
           estimate = estimateFinal();
         }
-        if (estimate > state.contextWindow) {
+        if (estimate > state.capacity.tokens) {
           const failure =
             state.lastShapeFailure?.stepNumber === options.stepNumber
               ? state.lastShapeFailure
@@ -2200,7 +2212,7 @@ export class MidTurnCapacityCompactState {
   constructor(
     readonly headAnchor: RuntimeEvent,
     readonly priorContentEvents: readonly RuntimeEvent[],
-    readonly contextWindow: number,
+    readonly capacity: ContextBudgetCapacity,
   ) {}
 }
 

--- a/packages/runtime/src/context-budget-policy.ts
+++ b/packages/runtime/src/context-budget-policy.ts
@@ -1,6 +1,7 @@
 import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
 import { lookupModelMetadata } from '@maka/core/model-metadata';
 import type { ContextBudgetPolicy } from './context-budget.js';
+import { finitePositive } from './context-budget-helpers.js';
 
 export interface BuildDefaultContextBudgetPolicyOptions {
   name?: string;
@@ -421,6 +422,27 @@ export function resolveSelectedModelContextWindow(
       ? lookupModelMetadata(connection.providerType, selectedModelId).contextWindow
       : undefined)
   );
+}
+
+export interface ContextBudgetCapacity {
+  tokens: number;
+  source: 'selected_model' | 'policy_fallback';
+}
+
+export function resolveContextBudgetCapacity(
+  connection: RuntimeExecutionConnection,
+  modelId: string | undefined,
+  policy: ContextBudgetPolicy | undefined,
+): ContextBudgetCapacity | undefined {
+  const selectedWindow = resolveSelectedModelContextWindow(connection, modelId);
+  if (selectedWindow !== undefined) {
+    return { tokens: selectedWindow, source: 'selected_model' };
+  }
+
+  const historyBudget = finitePositive(policy?.maxHistoryEstimatedTokens);
+  const reserveTokens = finitePositive(policy?.historyCompact?.midTurn?.reserveTokens);
+  if (historyBudget === undefined || reserveTokens === undefined) return undefined;
+  return { tokens: historyBudget + reserveTokens, source: 'policy_fallback' };
 }
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -304,6 +304,18 @@ export function applyRuntimeEventContextBudget(
   };
 }
 
+export function hasOversizedRetainedHistoryTurn(
+  events: readonly RuntimeEvent[],
+  policy: ContextBudgetPolicy | undefined,
+): boolean {
+  const maxTokens = finitePositive(policy?.maxHistoryEstimatedTokens);
+  if (maxTokens === undefined) return false;
+  const charsPerToken = policy?.charsPerToken ?? 4;
+  return groupEventsByTurn(events.filter(isHistoryCompactContentEvent), charsPerToken).some(
+    (turn) => turn.estimatedTokens > maxTokens,
+  );
+}
+
 export function buildPromptSegmentEstimates(input: PromptSegmentInput): PromptSegmentEstimate[] {
   const charsPerToken = input.charsPerToken ?? 4;
   return [


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- enforce the history budget on every retained RuntimeEvent turn instead of allowing one oversized recent turn to bypass the token bound
- reuse the existing durable checkpoint projection to fold an oversized completed turn before the next provider request
- derive a bounded capacity for metadata-less custom models from the history budget plus reserve
- stop an unshapable step-zero request locally before the provider adapter is called
- preserve aggregate `minRecentTurns` behavior when each retained turn is individually bounded
- preserve `user_stop` when cancellation races pre-turn summarization

## Root cause

The context-budget loop treated `minRecentTurns` as stronger than `maxHistoryEstimatedTokens`. A completed turn that exceeded the full history budget could therefore remain intact, especially when it was the only recent turn. The pre-turn history compactor then skipped that shape as `insufficient_turns`.

Metadata-less custom models had a second gap: the runtime had a bounded default history budget, but mid-turn capacity enforcement required declared model metadata. The final step-zero payload could therefore reach the provider without a usable capacity verdict.

This change checks the actual retained projection by turn. If any retained turn alone exceeds the history budget, the runtime retries the existing checkpoint path with no raw recent-turn tail. A valid checkpoint continues normally; an unavailable or failed safe projection ends locally as `context_budget_exhausted`. Unknown model metadata now uses the already configured history budget and reserve as an explicit fallback capacity, while known-window behavior remains unchanged.

## Validation

- `npm --workspace @maka/runtime test` — 3,364 passed, 0 failed, 3 skipped
- `npm --workspace @maka/runtime run typecheck`
- Biome format and lint on all changed files
- `git diff --check`

Closes #2371.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 对每个被保留的 RuntimeEvent turn 强制执行 history budget，不再允许单个超大 recent turn 绕过 token 上限
- 复用既有 durable checkpoint projection，在下一次 provider 请求前折叠已完成的超大 turn
- 对缺少模型 metadata 的自定义模型，通过 history budget 与 reserve 推导有界 capacity
- 当 step-zero 请求无法安全整形时，在调用 provider adapter 前本地终止
- 当每个 retained turn 都独立受限时，保留既有的 `minRecentTurns` 聚合行为
- 当取消与 pre-turn summarization 竞态时，继续保持 `user_stop`

## 根因

Context-budget 循环过去把 `minRecentTurns` 视为比 `maxHistoryEstimatedTokens` 更强的规则。因此，一个已完成 turn 即使单独超过整个 history budget，也可能被原样保留；只有一个 recent turn 时尤其如此。Pre-turn history compactor 随后又会把这种形状判定为 `insufficient_turns` 并跳过。

缺少 metadata 的自定义模型还存在第二条缺口：Runtime 虽然已有有界的默认 history budget，但 mid-turn capacity enforcement 要求模型声明 context window。最终的 step-zero payload 因而可能在没有 capacity verdict 的情况下进入 provider。

本次修改按 turn 检查实际 retained projection。只要任一 retained turn 单独超过 history budget，Runtime 就以不保留 raw recent-turn tail 的方式重试既有 checkpoint 路径。有效 checkpoint 会正常继续；若无法形成安全投影，则在本地以 `context_budget_exhausted` 结束。缺少模型 metadata 时，现在使用已配置的 history budget 与 reserve 作为显式 fallback capacity；已知窗口模型的既有行为保持不变。

## 验证

- `npm --workspace @maka/runtime test` — 3,364 项通过，0 项失败，3 项跳过
- `npm --workspace @maka/runtime run typecheck`
- 对全部改动文件运行 Biome format 与 lint
- `git diff --check`

关闭 #2371。

</details>
