### PR TITLE
fix(ui): harden quote layer scroll-follow against CI flake

### DIFF
--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -213,6 +213,12 @@ test('the quote layer follows the selection while the transcript scrolls', async
    * — the flake this test kept hitting. In here the scroll and both rects are
    * one synchronous layout, and the wait for the layer to catch up is by frame.
    *
+   * Each frame re-reads both tops: freezing selectionShift at the scroll write
+   * used to compare a settled layer against a selection that had not finished
+   * layout, and a residual of ~2 CSS px looked like product drift (#2379). The
+   * entry animation must not add a Y transform either (#2377); that path is
+   * locked by the CSS contract test.
+   *
    * Writing `scrollTop` rather than sending a wheel: wheel delivery is a
    * host-level detail (it landed nowhere on CI's Linux runner), while what this
    * test is about is the `scroll` event the hook listens to, which a scrollTop
@@ -232,17 +238,33 @@ test('the quote layer follows the selection while the transcript scrolls', async
       document.querySelector('.maka-quote-actions')?.getBoundingClientRect().top ?? null;
 
     const before = { selection: selectionTop(), layer: layerTop() };
+    if (before.selection === null || before.layer === null) {
+      return { selectionShift: 0, layerShift: null as number | null, residual: null as number | null };
+    }
     scroller.scrollTop -= 220;
-    const selectionShift = selectionTop()! - before.selection!;
 
     for (let frame = 0; frame < 120; frame += 1) {
       await nextFrame();
-      const now = layerTop();
-      if (now !== null && Math.abs(now - before.layer! - selectionShift) <= 1) {
-        return { selectionShift, layerShift: now - before.layer! };
+      const selection = selectionTop();
+      const layer = layerTop();
+      if (selection === null || layer === null) continue;
+      const selectionShift = selection - before.selection;
+      const layerShift = layer - before.layer;
+      // Vacuous until the selection has actually moved with the scroll.
+      if (selectionShift === 0) continue;
+      const residual = Math.abs(layerShift - selectionShift);
+      if (residual <= 1) {
+        return { selectionShift, layerShift, residual };
       }
     }
-    return { selectionShift, layerShift: layerTop() === null ? null : layerTop()! - before.layer! };
+    const selection = selectionTop();
+    const layer = layerTop();
+    const selectionShift =
+      selection === null ? 0 : selection - before.selection;
+    const layerShift = layer === null ? null : layer - before.layer;
+    const residual =
+      layerShift === null ? null : Math.abs(layerShift - selectionShift);
+    return { selectionShift, layerShift, residual };
   });
 
   // A scroll that moved nothing would make the assertion below vacuous.
@@ -250,7 +272,10 @@ test('the quote layer follows the selection while the transcript scrolls', async
   // The layer tracks the selection rather than merely surviving the scroll.
   // Sub-pixel tolerance, not exactness: the layer is positioned in CSS pixels
   // and rounded to the device grid, so it lands within a pixel of the anchor.
-  expect(Math.abs(follow.layerShift! - follow.selectionShift)).toBeLessThanOrEqual(1);
+  expect(
+    follow.residual,
+    `quote layer did not track selection (selectionShift=${follow.selectionShift}, layerShift=${follow.layerShift}, residual=${follow.residual})`,
+  ).toBeLessThanOrEqual(1);
 
   // Following stops at the edge of the scroller. Once the anchor leaves the
   // visible band there is nothing to point at, and a bar clamped to the top of

--- a/apps/desktop/src/renderer/styles/quote-side-panel.css
+++ b/apps/desktop/src/renderer/styles/quote-side-panel.css
@@ -16,7 +16,9 @@
   -webkit-app-region: no-drag;
   /* The hook already waits for the selection to settle before rendering this;
      the fade keeps that arrival from reading as a pop. Short enough not to
-     add to the wait the user has already served. */
+     add to the wait the user has already served. Opacity only: a Y transform
+     here offsets getBoundingClientRect from the live selection anchor and
+     fails scroll-follow E2E by that residual (#2377, #2379). */
   animation: maka-quote-actions-in 120ms var(--ease-standard, ease-out);
 }
 

--- a/packages/ui/src/__tests__/quote-actions-geometry.test.ts
+++ b/packages/ui/src/__tests__/quote-actions-geometry.test.ts
@@ -1,0 +1,25 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  QUOTE_ACTIONS_MIN_TOP,
+  QUOTE_ACTIONS_OFFSET_Y,
+  quoteActionsFixedTop,
+} from '../quote-actions-geometry.js';
+
+describe('quoteActionsFixedTop', () => {
+  it('tracks a selection that stays clear of the top clamp by the same delta', () => {
+    const before = 400;
+    const delta = -220;
+    assert.equal(
+      quoteActionsFixedTop(before + delta) - quoteActionsFixedTop(before),
+      delta,
+      'scroll-follow is only correct when the fixed top moves with the selection',
+    );
+    assert.equal(quoteActionsFixedTop(before), before - QUOTE_ACTIONS_OFFSET_Y);
+  });
+
+  it('clamps to the min top instead of following an off-screen selection into the chrome', () => {
+    assert.equal(quoteActionsFixedTop(10), QUOTE_ACTIONS_MIN_TOP);
+    assert.equal(quoteActionsFixedTop(QUOTE_ACTIONS_OFFSET_Y + QUOTE_ACTIONS_MIN_TOP), QUOTE_ACTIONS_MIN_TOP);
+  });
+});

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -7,6 +7,7 @@ import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
 import type { ChatModelChoice } from './chat-model-helpers.js';
 import { PromptAnchorRail } from './prompt-anchor-rail.js';
 import { useMessageSelectionQuote } from './use-message-selection-quote.js';
+import { quoteActionsFixedTop } from './quote-actions-geometry.js';
 import type {
   DeepResearchClientProgress,
   ProviderType,
@@ -722,7 +723,7 @@ export function ChatView(props: {
             </div>,
             {
               x: selectionQuote.anchor.x,
-              y: Math.max(8, selectionQuote.anchor.y - 42),
+              y: quoteActionsFixedTop(selectionQuote.anchor.y),
               style: { transform: 'translateX(-50%)' },
             },
           )

--- a/packages/ui/src/quote-actions-geometry.ts
+++ b/packages/ui/src/quote-actions-geometry.ts
@@ -1,0 +1,14 @@
+/**
+ * Fixed-mode placement for the selection quote actions layer.
+ *
+ * The layer hangs just above the selection's top edge. Keeping the offset in
+ * one place makes the scroll-follow contract checkable: when the selection
+ * moves by `d` and stays clear of the min clamp, the layer must move by `d`
+ * too (#2379).
+ */
+export const QUOTE_ACTIONS_OFFSET_Y = 42;
+export const QUOTE_ACTIONS_MIN_TOP = 8;
+
+export function quoteActionsFixedTop(selectionTop: number): number {
+  return Math.max(QUOTE_ACTIONS_MIN_TOP, selectionTop - QUOTE_ACTIONS_OFFSET_Y);
+}


### PR DESCRIPTION
## Summary

Closes #2379.

Root cause for the observed 2 CSS-px residual was the entry animation's `translateY(2px)` — already removed in #2377. This PR hardens the remaining edges so the scroll-follow contract stays stable and failures are self-explaining.

- Re-measure selection and layer tops **on the same frame** in the scroll-follow E2E (no frozen pre-layout `selectionShift`)
- Include `selectionShift` / `layerShift` / `residual` in the assertion message
- Extract `quoteActionsFixedTop` with a unit test that the layer moves by the same delta as the selection when clear of the top clamp
- Document in CSS that the entry animation must stay opacity-only (paired with the existing contract test from #2377)

## Verification

- `node --test packages/ui/dist/__tests__/quote-actions-geometry.test.js` — 2 passed
- `npm --workspace @maka/ui run test` — 473 passed
- `npm --workspace @maka/ui run typecheck` — passed
- `npm run lint` — passed
- Desktop full typecheck still fails on main for pre-existing `runningStatus` / `ChatMessageSurfaceProps` mismatch (reproduced with our changes stashed); not introduced here
- Focused quote-companion E2E: deferred to Linux CI (Electron window fixture flaky locally on this Mac, same as #2377)