### PR TITLE
fix(ui): expose Regenerate for failed turns with no assistant output

### DIFF
--- a/packages/ui/src/__tests__/empty-terminal-turn-recovery.test.tsx
+++ b/packages/ui/src/__tests__/empty-terminal-turn-recovery.test.tsx
@@ -1,0 +1,134 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { StoredMessage } from '@maka/core';
+import { createElement, type ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TurnView, type TurnFooterActionMeta } from '../chat-turn.js';
+import { LocaleProvider } from '../locale-context.js';
+import { materializeTurns, type TurnViewModel } from '../materialize.js';
+
+const USER_MESSAGE = {
+  type: 'user',
+  id: 'user-1',
+  turnId: 'turn-1',
+  ts: 1,
+  text: 'Continue',
+} satisfies StoredMessage;
+
+const FOOTER_ACTIONS = [
+  {
+    id: 'regenerate',
+    label: 'Regenerate',
+    enabled: true,
+    tooltip: 'Generate another response to this turn',
+  },
+  {
+    id: 'branch',
+    label: 'Branch',
+    enabled: true,
+    tooltip: 'Branch a new conversation from this response',
+  },
+  {
+    id: 'copy',
+    label: 'Copy',
+    enabled: false,
+    tooltip: 'This response has no content to copy',
+  },
+] satisfies ReadonlyArray<TurnFooterActionMeta>;
+
+function conversationalTurnWithState(status: 'running' | 'failed'): TurnViewModel {
+  const messages: StoredMessage[] = [
+    USER_MESSAGE,
+    {
+      type: 'turn_state',
+      id: `state-${status}`,
+      turnId: 'turn-1',
+      ts: 2,
+      status,
+      ...(status === 'failed' ? { errorClass: 'timeout' } : {}),
+      partialOutputRetained: false,
+    },
+  ];
+  const turn = materializeTurns(messages)[0];
+  assert.ok(turn);
+  assert.equal(turn.timeline.length, 0);
+  return turn;
+}
+
+function render(node: ReactNode): string {
+  return renderToStaticMarkup(
+    createElement(LocaleProvider, { locale: 'en', children: node }),
+  );
+}
+
+describe('empty terminal turn recovery', () => {
+  it('mounts failure state and Regenerate after a turn fails before assistant output', () => {
+    const markup = render(
+      createElement(TurnView, {
+        turn: conversationalTurnWithState('failed'),
+        failedReasonLabel: 'Request timed out',
+        footerActions: FOOTER_ACTIONS,
+        onFooterAction: () => {},
+      }),
+    );
+
+    assert.match(markup, /role="alert"/);
+    assert.match(markup, /Request timed out/);
+    const regenerate = markup.match(/<button\b[^>]*data-action="regenerate"[^>]*>/)?.[0];
+    assert.ok(regenerate);
+    assert.match(regenerate, /aria-label="Regenerate"/);
+    assert.doesNotMatch(regenerate, /aria-disabled="true"/);
+  });
+
+  it('keeps recovery actions out of an empty turn while it is still running', () => {
+    const markup = render(
+      createElement(TurnView, {
+        turn: conversationalTurnWithState('running'),
+        footerActions: FOOTER_ACTIONS,
+      }),
+    );
+
+    assert.doesNotMatch(markup, /data-action="(?:regenerate|branch)"/);
+    assert.doesNotMatch(markup, /role="toolbar"/);
+  });
+
+  it('does not invent recovery actions for an inferred legacy turn', () => {
+    const turn = materializeTurns([USER_MESSAGE])[0];
+    assert.ok(turn);
+    assert.equal(turn.statusSource, 'inferred');
+
+    const markup = render(
+      createElement(TurnView, {
+        turn,
+        footerActions: FOOTER_ACTIONS,
+      }),
+    );
+
+    assert.doesNotMatch(markup, /data-action="(?:regenerate|branch)"/);
+  });
+
+  it('does not offer conversational recovery for an internal terminal record', () => {
+    const turn = materializeTurns([
+      {
+        type: 'turn_state',
+        id: 'state-internal',
+        turnId: 'turn-internal',
+        ts: 1,
+        status: 'completed',
+        partialOutputRetained: false,
+      },
+    ])[0];
+    assert.ok(turn);
+    assert.equal(turn.statusSource, 'recorded');
+    assert.equal(turn.user, undefined);
+
+    const markup = render(
+      createElement(TurnView, {
+        turn,
+        footerActions: FOOTER_ACTIONS,
+      }),
+    );
+
+    assert.doesNotMatch(markup, /data-action="(?:regenerate|branch)"/);
+  });
+});

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -398,10 +398,14 @@ export const TurnView = memo(function TurnView(props: {
   const { turn } = props;
   const forwardBadges = props.lineageBadges?.filter((b) => b.direction === 'forward') ?? [];
   const reverseBadges = props.lineageBadges?.filter((b) => b.direction === 'reverse') ?? [];
-  // The assistant `ChatMessage` mounts once the turn has any timeline content OR
-  // this is the live streaming tail (a thinking-only / textless streaming turn
-  // has an empty committed timeline but must still show its live answer block).
-  const showAssistantMessage = turn.timeline.length > 0 || !!props.liveStreaming;
+  // A recorded conversational terminal turn owns presentation beyond its
+  // timeline: failure/abort state and recovery actions must remain visible even
+  // when the provider produced no assistant event. Inferred legacy turns and
+  // internal operations do not carry enough evidence for a recovery action.
+  const showAssistantMessage =
+    turn.timeline.length > 0 ||
+    !!props.liveStreaming ||
+    (turn.user !== undefined && turn.statusSource === 'recorded' && turn.status !== 'running');
   // #1307: the collapsed "Processing" fold is derived at render time from the
   // flat timeline. Settled turn identities are stable (memoized projections),
   // so this only recomputes for the turn whose timeline actually changed.


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- render the assistant recovery surface for recorded terminal conversational turns even when no assistant event was produced
- keep inferred legacy turns and internal operations from exposing invalid Regenerate or Branch actions
- keep empty running turns free of actionable recovery controls

## Root cause

`TurnView` mounted the assistant message only when the turn had timeline content or an active live-streaming projection. A request that failed before producing text, thinking, or tool events therefore lost both its failure banner and the footer that owns Regenerate.

The recovery surface now follows the durable turn model instead of timeline presence alone. A turn with a real user prompt and a recorded terminal state can render failure or abort presentation plus its recovery actions without assistant output. The evidence and ownership checks deliberately exclude inferred legacy completion and internal operations such as compaction, which do not have a valid conversational regeneration source.

## Validation

- `npm --workspace @maka/ui test` — 475 passed, 0 failed
- Desktop turn presentation and footer action tests — 22 passed, 0 failed
- Biome format and lint on all changed files
- `git diff --check`

Closes #2372.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 即使没有产生任何 assistant event，也为具有持久化终态证据的对话 turn 渲染 assistant 恢复区域
- 避免 inferred legacy turn 与内部 operation 暴露无效的“重新生成”或“分支”操作
- 继续保证空的 running turn 不出现可执行的恢复控件

## 根因

`TurnView` 过去只在 turn 包含 timeline 内容或存在活跃 live-streaming projection 时挂载 assistant message。请求若在产生 text、thinking 或 tool event 之前失败，failure banner 与承载“重新生成”的 footer 就会一起消失。

现在，恢复区域不再只依据 timeline 是否存在，而是遵循持久化 turn 模型。只要 turn 具有真实 user prompt 和已记录的终态，即使 assistant 输出为空，也能渲染失败或中止信息以及恢复操作。证据与所有权检查会明确排除 inferred legacy completion 和 compaction 等内部 operation，因为它们没有有效的对话 regeneration source。

## 验证

- `npm --workspace @maka/ui test` — 475 项通过，0 项失败
- Desktop turn presentation 与 footer action 测试 — 22 项通过，0 项失败
- 对全部改动文件运行 Biome format 与 lint
- `git diff --check`

关闭 #2372。

</details>
