### PR TITLE
feat(ui): open linked subagents from stream tools, not sidebar

### DIFF
--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -58,8 +58,6 @@ test('project mode nests sessions under collapsible project SideNav items', asyn
   await expect(projectToggle).toHaveAttribute('aria-expanded', 'true');
   const session = project.locator('[data-maka-contract="session-row"]').first();
   await expect(session).toBeVisible();
-  // Nested project sessions are ordinary nav rows, not subagent rows.
-  await expect(session).not.toHaveAttribute('data-subagent', 'true');
   // Product zero-nest: session left edge matches the project row (no 24px tree indent).
   const projectBox = await projectToggle.boundingBox();
   const sessionBox = await session.boundingBox();

--- a/apps/desktop/src/main/__tests__/session-list-render-helpers.ts
+++ b/apps/desktop/src/main/__tests__/session-list-render-helpers.ts
@@ -29,9 +29,6 @@ export function renderSessionListPanel(options: {
   groups?: Parameters<typeof SessionListPanel>[0]['groups'];
   projectActions?: Parameters<typeof SessionListPanel>[0]['projectActions'];
   worktreeSessionIds?: Parameters<typeof SessionListPanel>[0]['worktreeSessionIds'];
-  childSessionsByParentId?: Parameters<
-    typeof SessionListPanel
-  >[0]['childSessionsByParentId'];
   staleSessionIds?: Parameters<typeof SessionListPanel>[0]['staleSessionIds'];
   viewMode?: Parameters<typeof SessionListPanel>[0]['viewMode'];
 } = {}): string {
@@ -52,7 +49,6 @@ export function renderSessionListPanel(options: {
       groups: options.groups,
       projectActions: options.projectActions,
       worktreeSessionIds: options.worktreeSessionIds,
-      childSessionsByParentId: options.childSessionsByParentId,
       staleSessionIds: options.staleSessionIds,
       viewMode: options.viewMode,
       onViewModeChange: options.viewMode ? () => {} : undefined,

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -230,33 +230,22 @@ describe('sidebar project view mode', () => {
     assert.doesNotMatch(activeChunk, /data-session-status=/);
   });
 
-  it('lazy-mounts linked children and expands the active child ancestor chain', () => {
+  it('keeps the sidebar flat: linked children are not nested under parents', () => {
     const parent = makeSessionSummary({ id: 'parent', name: 'Parent task' });
     const child = makeSessionSummary({ id: 'child', name: 'Child agent' });
-    const collapsedMarkup = renderSessionListPanel({
-      sessions: [parent],
-      childSessionsByParentId: new Map([[parent.id, [child]]]),
-    });
-    assert.match(collapsedMarkup, /maka-session-lazy-children-sentinel/);
-    assert.doesNotMatch(collapsedMarkup, /data-session-id="child"/);
-
+    // Host passes only root sessions; child open state is titlebar + main column.
     const markup = renderSessionListPanel({
       sessions: [parent],
-      activeId: child.id,
-      childSessionsByParentId: new Map([[parent.id, [child]]]),
+      activeId: parent.id,
     });
 
-    assert.ok(markup.indexOf('Parent task') < markup.indexOf('Child agent'));
-    assert.match(markup, /data-subagent="true"/);
-    assert.match(markup, /data-session-id="child"/);
-    assert.match(markup, /data-maka-contract="session-row"/);
-    // Nested subagent rows use native SideNavItem Bot icon (lucide-bot).
-    const childChunk =
-      markup.match(/data-session-id="child"[\s\S]*?(?=data-session-id="|$)/)?.[0] ?? '';
-    assert.match(childChunk, /lucide-bot/);
-    const parentChunk =
-      markup.match(/data-session-id="parent"[\s\S]*?(?=data-session-id="child"|$)/)?.[0] ?? '';
-    assert.doesNotMatch(parentChunk, /lucide-bot/);
+    assert.match(markup, /data-session-id="parent"/);
+    assert.doesNotMatch(markup, /data-session-id="child"/);
+    assert.doesNotMatch(markup, /data-subagent="true"/);
+    assert.doesNotMatch(markup, /maka-session-lazy-children-sentinel/);
+    assert.doesNotMatch(markup, /lucide-bot/);
+    // Child is not a sidebar peer either — only the root list is rendered.
+    assert.doesNotMatch(markup, /Child agent/);
   });
 
   it('applies Chats, Flagged, and Archived filters independently to parents and children', () => {

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -1,15 +1,12 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import {
-  filterLinkedSessionTree,
-  isLinkedSubagentSession,
-  projectLinkedSessionTree,
-} from '@maka/core';
+import { filterLinkedSessionTree, projectLinkedSessionTree } from '@maka/core';
 import { sessionMatchesNavSelection } from '../../renderer/session-nav-filter.js';
 import {
   deriveProjectGroups,
   deriveWorktreeSessionIds,
 } from '../../renderer/session-project-grouping.js';
+import { deriveSessionRail } from '../../renderer/session-rail.js';
 import { makeSessionSummary, renderSessionListPanel } from './session-list-render-helpers.js';
 
 describe('sidebar project view mode', () => {
@@ -252,7 +249,7 @@ describe('sidebar project view mode', () => {
     assert.doesNotMatch(markup, /Child agent/);
   });
 
-  it('applies Chats, Flagged, and Archived filters independently to parents and children', () => {
+  it('applies Chats, Flagged, and Archived filters through the production rail projection', () => {
     const parent = makeSessionSummary({
       id: 'parent',
       name: 'Parent task',
@@ -284,51 +281,39 @@ describe('sidebar project view mode', () => {
       lastMessageAt: 50,
       subagentParent: childRelation(archivedParent.id),
     });
-    const tree = projectLinkedSessionTree([
+    const sessions = [
       parent,
       archivedChild,
       flaggedChild,
       archivedParent,
       activeChild,
-    ]);
-    const filter = (selection: 'chats' | 'flagged' | 'archived') =>
-      filterLinkedSessionTree(tree, (session) =>
-        sessionMatchesNavSelection(session, { section: 'sessions', filter: selection }),
-      );
-    // Desktop rail: tree filter may promote a matching linked child past a
-    // hidden ancestor, but the flat sidebar still drops every linked child.
-    const flatSidebarRoots = (selection: 'chats' | 'flagged' | 'archived') =>
-      filter(selection).roots.filter((session) => !isLinkedSubagentSession(session));
-
-    const chats = filter('chats');
+    ];
+    // Core tree filter still promotes matching linked descendants for CLI / nested
+    // UIs — assert that contract separately from the desktop flat rail.
+    const tree = projectLinkedSessionTree(sessions);
+    const chatsTree = filterLinkedSessionTree(tree, (session) =>
+      sessionMatchesNavSelection(session, { section: 'sessions', filter: 'chats' }),
+    );
     assert.deepEqual(
-      chats.roots.map((session) => session.id),
+      chatsTree.roots.map((session) => session.id),
       [parent.id, activeChild.id],
     );
+
+    const rail = (selection: 'chats' | 'flagged' | 'archived') =>
+      deriveSessionRail(sessions, parent.id, (session) =>
+        sessionMatchesNavSelection(session, { section: 'sessions', filter: selection }),
+      );
+
     assert.deepEqual(
-      chats.childrenByParentId.get(parent.id)?.map((session) => session.id),
-      [flaggedChild.id],
-    );
-    assert.deepEqual(
-      flatSidebarRoots('chats').map((session) => session.id),
+      rail('chats').sessions.map((session) => session.id),
       [parent.id],
     );
-
-    const flagged = filter('flagged');
     assert.deepEqual(
-      flagged.roots.map((session) => session.id),
-      [flaggedChild.id],
+      rail('flagged').sessions.map((session) => session.id),
+      [],
     );
-    assert.deepEqual(flatSidebarRoots('flagged').map((session) => session.id), []);
-
-    const archived = filter('archived');
     assert.deepEqual(
-      archived.roots.map((session) => session.id),
-      [archivedChild.id, archivedParent.id],
-    );
-    // Only the archived ordinary parent remains; linked children stay off the rail.
-    assert.deepEqual(
-      flatSidebarRoots('archived').map((session) => session.id),
+      rail('archived').sessions.map((session) => session.id),
       [archivedParent.id],
     );
   });

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -1,6 +1,5 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { filterLinkedSessionTree, projectLinkedSessionTree } from '@maka/core';
 import { sessionMatchesNavSelection } from '../../renderer/session-nav-filter.js';
 import {
   deriveProjectGroups,
@@ -288,16 +287,6 @@ describe('sidebar project view mode', () => {
       archivedParent,
       activeChild,
     ];
-    // Core tree filter still promotes matching linked descendants for CLI / nested
-    // UIs — assert that contract separately from the desktop flat rail.
-    const tree = projectLinkedSessionTree(sessions);
-    const chatsTree = filterLinkedSessionTree(tree, (session) =>
-      sessionMatchesNavSelection(session, { section: 'sessions', filter: 'chats' }),
-    );
-    assert.deepEqual(
-      chatsTree.roots.map((session) => session.id),
-      [parent.id, activeChild.id],
-    );
 
     const rail = (selection: 'chats' | 'flagged' | 'archived') =>
       deriveSessionRail(sessions, parent.id, (session) =>
@@ -318,7 +307,7 @@ describe('sidebar project view mode', () => {
     );
   });
 
-  it('keeps a running parent visible when preview metadata is temporarily unavailable', () => {
+  it('keeps a running parent on the rail when preview metadata is temporarily unavailable', () => {
     const parent = makeSessionSummary({
       id: 'running-parent',
       name: 'Running parent',
@@ -332,20 +321,15 @@ describe('sidebar project view mode', () => {
       lastMessageAt: 50,
       subagentParent: childRelation(parent.id),
     });
-    const tree = filterLinkedSessionTree(
-      projectLinkedSessionTree([parent, child]),
-      (session) =>
-        sessionMatchesNavSelection(session, { section: 'sessions', filter: 'chats' }),
+    const rail = deriveSessionRail([parent, child], parent.id, (session) =>
+      sessionMatchesNavSelection(session, { section: 'sessions', filter: 'chats' }),
     );
 
     assert.deepEqual(
-      tree.roots.map((session) => session.id),
+      rail.sessions.map((session) => session.id),
       [parent.id],
     );
-    assert.deepEqual(
-      tree.childrenByParentId.get(parent.id)?.map((session) => session.id),
-      [child.id],
-    );
+    assert.equal(rail.activeRowId, parent.id);
   });
 
   it('project group ids stay DOM-safe and distinct when the cwd has spaces or shared basenames', () => {

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -1,6 +1,10 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { filterLinkedSessionTree, projectLinkedSessionTree } from '@maka/core';
+import {
+  filterLinkedSessionTree,
+  isLinkedSubagentSession,
+  projectLinkedSessionTree,
+} from '@maka/core';
 import { sessionMatchesNavSelection } from '../../renderer/session-nav-filter.js';
 import {
   deriveProjectGroups,
@@ -291,6 +295,10 @@ describe('sidebar project view mode', () => {
       filterLinkedSessionTree(tree, (session) =>
         sessionMatchesNavSelection(session, { section: 'sessions', filter: selection }),
       );
+    // Desktop rail: tree filter may promote a matching linked child past a
+    // hidden ancestor, but the flat sidebar still drops every linked child.
+    const flatSidebarRoots = (selection: 'chats' | 'flagged' | 'archived') =>
+      filter(selection).roots.filter((session) => !isLinkedSubagentSession(session));
 
     const chats = filter('chats');
     assert.deepEqual(
@@ -301,17 +309,27 @@ describe('sidebar project view mode', () => {
       chats.childrenByParentId.get(parent.id)?.map((session) => session.id),
       [flaggedChild.id],
     );
+    assert.deepEqual(
+      flatSidebarRoots('chats').map((session) => session.id),
+      [parent.id],
+    );
 
     const flagged = filter('flagged');
     assert.deepEqual(
       flagged.roots.map((session) => session.id),
       [flaggedChild.id],
     );
+    assert.deepEqual(flatSidebarRoots('flagged').map((session) => session.id), []);
 
     const archived = filter('archived');
     assert.deepEqual(
       archived.roots.map((session) => session.id),
       [archivedChild.id, archivedParent.id],
+    );
+    // Only the archived ordinary parent remains; linked children stay off the rail.
+    assert.deepEqual(
+      flatSidebarRoots('archived').map((session) => session.id),
+      [archivedParent.id],
     );
   });
 

--- a/apps/desktop/src/main/__tests__/session-rail.test.ts
+++ b/apps/desktop/src/main/__tests__/session-rail.test.ts
@@ -1,0 +1,192 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { SessionSummary, SubagentSessionParent } from '@maka/core';
+import { deriveSessionRail } from '../../renderer/session-rail.js';
+import { sessionMatchesNavSelection } from '../../renderer/session-nav-filter.js';
+import { makeSessionSummary } from './session-list-render-helpers.js';
+
+function childRelation(parentSessionId: string): SubagentSessionParent {
+  return {
+    kind: 'subagent',
+    parentSessionId,
+    spawnedBy: {
+      parentRunId: 'run',
+      parentTurnId: 'turn',
+      toolCallId: 'tool',
+    },
+    lifecycle: 'foreground',
+  };
+}
+
+function chatsInclude(session: SessionSummary): boolean {
+  return sessionMatchesNavSelection(session, { section: 'sessions', filter: 'chats' });
+}
+
+describe('deriveSessionRail', () => {
+  it('lists only revision-tree roots and never nests linked children', () => {
+    const parent = makeSessionSummary({ id: 'parent', name: 'Parent', lastMessageAt: 10 });
+    const child = makeSessionSummary({
+      id: 'child',
+      name: 'Child',
+      lastMessageAt: 20,
+      subagentParent: childRelation(parent.id),
+    });
+    const peer = makeSessionSummary({ id: 'peer', name: 'Peer', lastMessageAt: 5 });
+
+    const rail = deriveSessionRail([parent, child, peer], child.id, chatsInclude);
+
+    assert.deepEqual(
+      rail.sessions.map((session) => session.id),
+      [parent.id, peer.id],
+    );
+    assert.equal(rail.activeRowId, parent.id);
+  });
+
+  it('keeps an orphan linked child on the rail when its parent is gone', () => {
+    const other = makeSessionSummary({ id: 'other', name: 'Other', lastMessageAt: 1 });
+    const orphan = makeSessionSummary({
+      id: 'orphan',
+      name: 'Orphan child',
+      lastMessageAt: 2,
+      subagentParent: childRelation('deleted-parent'),
+    });
+
+    const rail = deriveSessionRail([other, orphan], orphan.id, chatsInclude);
+
+    assert.deepEqual(
+      rail.sessions.map((session) => session.id),
+      [other.id, orphan.id],
+    );
+    assert.equal(rail.activeRowId, orphan.id);
+  });
+
+  it('does not promote a linked child when only the parent fails the nav filter', () => {
+    const archivedParent = makeSessionSummary({
+      id: 'archived-parent',
+      name: 'Archived parent',
+      isArchived: true,
+      lastMessageAt: 10,
+    });
+    const activeChild = makeSessionSummary({
+      id: 'active-child',
+      name: 'Active child',
+      lastMessageAt: 20,
+      subagentParent: childRelation(archivedParent.id),
+    });
+    const liveParent = makeSessionSummary({
+      id: 'live-parent',
+      name: 'Live parent',
+      lastMessageAt: 30,
+    });
+
+    const rail = deriveSessionRail(
+      [archivedParent, activeChild, liveParent],
+      activeChild.id,
+      chatsInclude,
+    );
+
+    assert.deepEqual(
+      rail.sessions.map((session) => session.id),
+      [liveParent.id],
+    );
+    // Parent is off the chats rail; no row can represent the open child.
+    assert.equal(rail.activeRowId, undefined);
+  });
+
+  it('highlights the revision representative when the physical parent was revised', () => {
+    const parentV1 = makeSessionSummary({
+      id: 'parent-v1',
+      name: 'Parent v1',
+      lastMessageAt: 1,
+    });
+    const parentV2 = makeSessionSummary({
+      id: 'parent-v2',
+      name: 'Parent v2',
+      lastMessageAt: 3,
+      revisionRootSessionId: 'parent-v1',
+      revisionParentSessionId: 'parent-v1',
+      revisionIndex: 2,
+      revisionState: 'committed',
+    });
+    const child = makeSessionSummary({
+      id: 'child',
+      name: 'Child',
+      lastMessageAt: 2,
+      subagentParent: childRelation(parentV1.id),
+    });
+
+    const rail = deriveSessionRail([parentV1, parentV2, child], child.id, chatsInclude);
+
+    assert.deepEqual(
+      rail.sessions.map((session) => session.id),
+      [parentV2.id],
+    );
+    assert.equal(rail.activeRowId, parentV2.id);
+  });
+
+  it('applies flagged and archived filters flat against rail roots only', () => {
+    const parent = makeSessionSummary({
+      id: 'parent',
+      name: 'Parent',
+      lastMessageAt: 10,
+    });
+    const archivedChild = makeSessionSummary({
+      id: 'archived-child',
+      name: 'Archived child',
+      isArchived: true,
+      lastMessageAt: 20,
+      subagentParent: childRelation(parent.id),
+    });
+    const flaggedChild = makeSessionSummary({
+      id: 'flagged-child',
+      name: 'Flagged child',
+      isFlagged: true,
+      lastMessageAt: 30,
+      subagentParent: childRelation(parent.id),
+    });
+    const archivedParent = makeSessionSummary({
+      id: 'archived-parent',
+      name: 'Archived parent',
+      isArchived: true,
+      lastMessageAt: 40,
+    });
+    const activeChildOfArchived = makeSessionSummary({
+      id: 'active-child',
+      name: 'Active child',
+      lastMessageAt: 50,
+      subagentParent: childRelation(archivedParent.id),
+    });
+    const sessions = [
+      parent,
+      archivedChild,
+      flaggedChild,
+      archivedParent,
+      activeChildOfArchived,
+    ];
+
+    const chats = deriveSessionRail(sessions, parent.id, (session) =>
+      sessionMatchesNavSelection(session, { section: 'sessions', filter: 'chats' }),
+    );
+    assert.deepEqual(
+      chats.sessions.map((session) => session.id),
+      [parent.id],
+    );
+
+    const flagged = deriveSessionRail(sessions, flaggedChild.id, (session) =>
+      sessionMatchesNavSelection(session, { section: 'sessions', filter: 'flagged' }),
+    );
+    assert.deepEqual(
+      flagged.sessions.map((session) => session.id),
+      [],
+    );
+    assert.equal(flagged.activeRowId, undefined);
+
+    const archived = deriveSessionRail(sessions, archivedParent.id, (session) =>
+      sessionMatchesNavSelection(session, { section: 'sessions', filter: 'archived' }),
+    );
+    assert.deepEqual(
+      archived.sessions.map((session) => session.id),
+      [archivedParent.id],
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-rail.test.ts
+++ b/apps/desktop/src/main/__tests__/session-rail.test.ts
@@ -122,6 +122,28 @@ describe('deriveSessionRail', () => {
       [parentV2.id],
     );
     assert.equal(rail.activeRowId, parentV2.id);
+    // Titlebar parent shares the same representative, not the physical parent-v1 name.
+    assert.equal(rail.activeParentSession?.id, parentV2.id);
+    assert.equal(rail.activeParentSession?.name, 'Parent v2');
+  });
+
+  it('surfaces no titlebar parent for ordinary roots or orphans', () => {
+    const root = makeSessionSummary({ id: 'root', name: 'Root', lastMessageAt: 1 });
+    const orphan = makeSessionSummary({
+      id: 'orphan',
+      name: 'Orphan',
+      lastMessageAt: 2,
+      subagentParent: childRelation('missing'),
+    });
+
+    assert.equal(
+      deriveSessionRail([root], root.id, chatsInclude).activeParentSession,
+      undefined,
+    );
+    assert.equal(
+      deriveSessionRail([orphan], orphan.id, chatsInclude).activeParentSession,
+      undefined,
+    );
   });
 
   it('applies flagged and archived filters flat against rail roots only', () => {

--- a/apps/desktop/src/main/__tests__/stale-sessions.test.ts
+++ b/apps/desktop/src/main/__tests__/stale-sessions.test.ts
@@ -161,36 +161,37 @@ describe('stale session CSS contract (@kenji review gate)', () => {
     const { makeSessionSummary, renderSessionListPanel } = await import(
       './session-list-render-helpers.js'
     );
-    const parent = makeSessionSummary({ id: 'parent', name: 'Parent' });
-    const child = makeSessionSummary({ id: 'child', name: 'Child' });
+    const stale = makeSessionSummary({ id: 'stale-session', name: 'Stale' });
+    const healthy = makeSessionSummary({ id: 'healthy-session', name: 'Healthy' });
     const html = renderSessionListPanel({
-      sessions: [parent],
-      activeId: child.id,
-      childSessionsByParentId: new Map([['parent', [child]]]),
-      staleSessionIds: new Set(['parent']),
+      sessions: [stale, healthy],
+      activeId: healthy.id,
+      staleSessionIds: new Set(['stale-session']),
     });
 
-    const parentChunk = html.match(
-      /data-session-id="parent"[\s\S]*?(?=data-session-id="child"|$)/,
+    const staleChunk = html.match(
+      /data-session-id="stale-session"[\s\S]*?(?=data-session-id="healthy-session"|$)/,
     )?.[0];
-    const childChunk = html.match(/data-session-id="child"[\s\S]*?(?=data-session-id=|$)/)?.[0];
-    assert.ok(parentChunk, 'expected parent session row markup');
-    assert.ok(childChunk, 'expected child session row markup');
-    assert.match(parentChunk, /data-stale="true"/, 'stale parent must set data-stale');
+    const healthyChunk = html.match(
+      /data-session-id="healthy-session"[\s\S]*?(?=data-session-id=|$)/,
+    )?.[0];
+    assert.ok(staleChunk, 'expected stale session row markup');
+    assert.ok(healthyChunk, 'expected healthy session row markup');
+    assert.match(staleChunk, /data-stale="true"/, 'stale session must set data-stale');
     assert.match(
-      parentChunk,
+      staleChunk,
       /maka-list-row-stale-pill/,
-      'stale parent must render the stale pill',
+      'stale session must render the stale pill',
     );
     assert.doesNotMatch(
-      childChunk,
+      healthyChunk,
       /data-stale="true"/,
-      'healthy child must not inherit data-stale from parent',
+      'healthy session must not inherit data-stale',
     );
     assert.doesNotMatch(
-      childChunk,
+      healthyChunk,
       /maka-list-row-stale-pill/,
-      'healthy child must not render a stale pill',
+      'healthy session must not render a stale pill',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/subagent-ui-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/subagent-ui-contract.test.ts
@@ -48,4 +48,66 @@ describe('subagent UI contract', () => {
     assert.doesNotMatch(markup, /42 个事件/);
   });
 
+  it('forwards onOpenLinkedSession through ToolCallDetail when childSessionId is present', () => {
+    const item: ToolActivityItem = {
+      toolUseId: 'subagent-open',
+      toolName: 'spawn_subagent',
+      status: 'completed',
+      args: {},
+      result: {
+        kind: 'subagent',
+        agentName: 'Explore layout',
+        turnId: 'turn-open',
+        runId: 'run-open',
+        childSessionId: 'child-session-open',
+        status: 'completed',
+        permissionMode: 'explore',
+        summary: 'Mapped the layout.',
+        artifactIds: [],
+        durationMs: 1_200,
+        eventCount: 4,
+      },
+    };
+    const markup = renderToStaticMarkup(createElement(LocaleProvider, {
+      locale: 'zh',
+      children: createElement(ToolCallDetail, {
+        item,
+        onOpenLinkedSession() {},
+      }),
+    }));
+
+    assert.match(markup, /data-kind="subagent"/);
+    assert.match(markup, /打开会话|Open session/);
+    assert.match(markup, /child-session-open|Explore layout/);
+  });
+
+  it('hides the open control when onOpenLinkedSession is not provided', () => {
+    const item: ToolActivityItem = {
+      toolUseId: 'subagent-no-host',
+      toolName: 'spawn_subagent',
+      status: 'completed',
+      args: {},
+      result: {
+        kind: 'subagent',
+        agentName: 'No host open',
+        turnId: 'turn-no-host',
+        runId: 'run-no-host',
+        childSessionId: 'child-session-no-host',
+        status: 'completed',
+        permissionMode: 'explore',
+        summary: 'Ready.',
+        artifactIds: [],
+        durationMs: 800,
+        eventCount: 2,
+      },
+    };
+    const markup = renderToStaticMarkup(createElement(LocaleProvider, {
+      locale: 'zh',
+      children: createElement(ToolCallDetail, { item }),
+    }));
+
+    assert.match(markup, /data-kind="subagent"/);
+    assert.doesNotMatch(markup, /打开会话|Open session/);
+  });
+
 });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -19,7 +19,6 @@ import type {
 import {
   collapseSessionRevisions,
   isLinkedSubagentSession,
-  linkedSubagentParentSessionId,
   parseGraphCommand,
   parseSwarmCommand,
   resolveUiLocale,
@@ -576,10 +575,14 @@ function AppShellContent({
   // Running → Waiting → Blocked → Active → Review → Done → Archived);
   // `aborted` is dropped. Pinned (flagged) sessions float to the top
   // in their own group, preserving the PR48 pin-floats behavior.
-  // One projection owns both rail membership and active highlight: revision-
-  // tree roots (orphans stay; linked children with a live parent leave), then
-  // a flat nav / companion filter — never promote children past ancestors.
-  const { sessions: visibleSessions, activeRowId: sidebarActiveId } = useMemo(
+  // One projection owns rail membership, active highlight, and titlebar parent:
+  // revision-tree roots (orphans stay; linked children with a live parent leave),
+  // flat nav / companion filter — never promote children past ancestors.
+  const {
+    sessions: visibleSessions,
+    activeRowId: sidebarActiveId,
+    activeParentSession: railParentSession,
+  } = useMemo(
     () =>
       deriveSessionRail(sessions, activeId, (session) =>
         !hiddenCompanionForkIds.has(session.id)
@@ -1021,17 +1024,15 @@ function AppShellContent({
     openSessionInChat(parentSessionId);
   }
 
+  // Same revision-aware parent row the rail uses — not a second physical-id walk.
   const titlebarParentSession = useMemo(() => {
-    if (!activeSession) return undefined;
-    const parentId = linkedSubagentParentSessionId(activeSession);
-    if (!parentId) return undefined;
-    const parent = sessions.find((session) => session.id === parentId);
-    if (!parent) return undefined;
+    if (!railParentSession) return undefined;
+    const parentId = railParentSession.id;
     return {
-      name: parent.name,
+      name: railParentSession.name,
       onOpen: () => openSessionInChatRef.current(parentId),
     };
-  }, [activeSession, sessions]);
+  }, [railParentSession]);
 
   const activeSessionForView: SessionSummary | undefined =
     activeSession ??

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -18,13 +18,10 @@ import type {
 } from '@maka/core';
 import {
   collapseSessionRevisions,
-  filterLinkedSessionTree,
   isLinkedSubagentSession,
   linkedSubagentParentSessionId,
   parseGraphCommand,
   parseSwarmCommand,
-  projectRevisionLinkedSessionTree,
-  resolveLinkedSessionRootId,
   resolveUiLocale,
 } from '@maka/core';
 import { hasSettledInitialOnboarding } from '@maka/core/onboarding-milestone';
@@ -94,6 +91,7 @@ import { useShellSearch } from './use-shell-search';
 import { useSessionGoal } from './use-session-goal';
 import { deriveStaleSessionIds } from './stale-sessions';
 import { deriveProjectGroups, deriveWorktreeSessionIds } from './session-project-grouping';
+import { deriveSessionRail } from './session-rail';
 import { useAppShellTurnPresentation } from './app-shell-turn-view-model';
 import { readScrollMotionBehavior } from './scroll-motion-policy';
 import { deriveBranchBanner } from './branch-banner';
@@ -578,34 +576,17 @@ function AppShellContent({
   // Running → Waiting → Blocked → Active → Review → Done → Archived);
   // `aborted` is dropped. Pinned (flagged) sessions float to the top
   // in their own group, preserving the PR48 pin-floats behavior.
-  const sidebarSessionTree = useMemo(
-    () => projectRevisionLinkedSessionTree(sessions, activeId),
-    [sessions, activeId],
-  );
-  const visibleSessionTree = useMemo(
+  // One projection owns both rail membership and active highlight: revision-
+  // tree roots (orphans stay; linked children with a live parent leave), then
+  // a flat nav / companion filter — never promote children past ancestors.
+  const { sessions: visibleSessions, activeRowId: sidebarActiveId } = useMemo(
     () =>
-      // Exclude the quote companion's ephemeral fork so it stays hidden from the
-      // main session list while its panel is open.
-      filterLinkedSessionTree(sidebarSessionTree, (session) =>
+      deriveSessionRail(sessions, activeId, (session) =>
         !hiddenCompanionForkIds.has(session.id)
           ? sessionMatchesNavSelection(session, navSelection)
           : false,
       ),
-    [sidebarSessionTree, navSelection, hiddenCompanionForkIds],
-  );
-  // Tree filter can promote a matching linked child to a root when its parent
-  // is filtered out (e.g. archived parent + active child under Chats). The
-  // rail never lists linked children — they open only from stream tools /
-  // titlebar — so drop them here rather than reintroducing nesting.
-  const visibleSessions = useMemo(
-    () => visibleSessionTree.roots.filter((session) => !isLinkedSubagentSession(session)),
-    [visibleSessionTree],
-  );
-  // While a child is active, highlight its root ancestor so the rail still
-  // answers "which conversation am I in?" without nesting rows.
-  const sidebarActiveId = useMemo(
-    () => resolveLinkedSessionRootId(activeId, sessions),
-    [activeId, sessions],
+    [sessions, activeId, navSelection, hiddenCompanionForkIds],
   );
   // PR-DAILY-REVIEW-MVP-0: bridge for the main Daily Review module.
   // Memoized so the panel's `useEffect` cleanup keys

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -20,9 +20,11 @@ import {
   collapseSessionRevisions,
   filterLinkedSessionTree,
   isLinkedSubagentSession,
+  linkedSubagentParentSessionId,
   parseGraphCommand,
   parseSwarmCommand,
   projectRevisionLinkedSessionTree,
+  resolveLinkedSessionRootId,
   resolveUiLocale,
 } from '@maka/core';
 import { hasSettledInitialOnboarding } from '@maka/core/onboarding-milestone';
@@ -592,6 +594,13 @@ function AppShellContent({
     [sidebarSessionTree, navSelection, hiddenCompanionForkIds],
   );
   const visibleSessions = visibleSessionTree.roots;
+  // Linked children open in the main column and stay out of the sidebar list.
+  // While a child is active, highlight its root ancestor so the rail still
+  // answers "which conversation am I in?" without nesting rows.
+  const sidebarActiveId = useMemo(
+    () => resolveLinkedSessionRootId(activeId, sessions) ?? activeId,
+    [activeId, sessions],
+  );
   // PR-DAILY-REVIEW-MVP-0: bridge for the main Daily Review module.
   // Memoized so the panel's `useEffect` cleanup keys
   // off a stable reference instead of refetching on every render.
@@ -1024,6 +1033,18 @@ function AppShellContent({
   function handleBranchBannerClick(parentSessionId: string): void {
     openSessionInChat(parentSessionId);
   }
+
+  const titlebarParentSession = useMemo(() => {
+    if (!activeSession) return undefined;
+    const parentId = linkedSubagentParentSessionId(activeSession);
+    if (!parentId) return undefined;
+    const parent = sessions.find((session) => session.id === parentId);
+    if (!parent) return undefined;
+    return {
+      name: parent.name,
+      onOpen: () => openSessionInChatRef.current(parentId),
+    };
+  }, [activeSession, sessions]);
 
   const activeSessionForView: SessionSummary | undefined =
     activeSession ??
@@ -2133,6 +2154,7 @@ function AppShellContent({
                 ? { name: titlebarProjectName, onOpenFolder: () => void openProjectFolder() }
                 : undefined
             }
+            parentSession={titlebarParentSession}
           />
         )}
         {!VIEWS_WITHOUT_WORKSPACE_ACTIONS.has(agentsView) && (
@@ -2168,14 +2190,13 @@ function AppShellContent({
             maxWidth={SESSION_LIST_EXPANDED_MAX_WIDTH}
             selection={navSelection}
             sessions={visibleSessions}
-            activeId={activeId}
+            activeId={sidebarActiveId}
             planReminders={planReminders}
             streamingSessionIds={streamingSessionIds}
             staleSessionIds={staleSessionIds}
             viewMode={viewMode}
             onViewModeChange={setViewMode}
             groups={viewMode === 'project' ? sessionProjectGroups : undefined}
-            childSessionsByParentId={visibleSessionTree.childrenByParentId}
             worktreeSessionIds={worktreeSessionIds}
             moduleMemory={navigationState.moduleMemory}
             onSelect={setNavSelection}
@@ -2517,6 +2538,7 @@ function AppShellContent({
                 } : undefined}
                 onLineageBadgeClick={handleLineageBadgeClick}
                 onReadAttachmentBytes={window.maka.attachments.readBytes}
+                onOpenLinkedSession={openSessionInChat}
                 scrollTargetTurn={
                   activeId && searchScrollTarget?.sessionId === activeId
                         ? {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -593,12 +593,18 @@ function AppShellContent({
       ),
     [sidebarSessionTree, navSelection, hiddenCompanionForkIds],
   );
-  const visibleSessions = visibleSessionTree.roots;
-  // Linked children open in the main column and stay out of the sidebar list.
+  // Tree filter can promote a matching linked child to a root when its parent
+  // is filtered out (e.g. archived parent + active child under Chats). The
+  // rail never lists linked children — they open only from stream tools /
+  // titlebar — so drop them here rather than reintroducing nesting.
+  const visibleSessions = useMemo(
+    () => visibleSessionTree.roots.filter((session) => !isLinkedSubagentSession(session)),
+    [visibleSessionTree],
+  );
   // While a child is active, highlight its root ancestor so the rail still
   // answers "which conversation am I in?" without nesting rows.
   const sidebarActiveId = useMemo(
-    () => resolveLinkedSessionRootId(activeId, sessions) ?? activeId,
+    () => resolveLinkedSessionRootId(activeId, sessions),
     [activeId, sessions],
   );
   // PR-DAILY-REVIEW-MVP-0: bridge for the main Daily Review module.

--- a/apps/desktop/src/renderer/session-rail.ts
+++ b/apps/desktop/src/renderer/session-rail.ts
@@ -1,0 +1,56 @@
+import type { SessionSummary } from '@maka/core';
+import { projectRevisionLinkedSessionTree } from '@maka/core';
+
+/**
+ * Desktop sidebar rail projection.
+ *
+ * Linked children leave the rail: membership is exactly the roots of the
+ * revision-aware linked tree (parent present → child nested off-rail; parent
+ * missing → orphan stays a root). Nav / companion filters are flat — never
+ * promote a linked child past a filtered ancestor.
+ *
+ * Active row shares that same tree: when a child is open, highlight the
+ * ancestor that actually appears as a rail row (revision representatives
+ * included via projectRevisionLinkedSessionTree aliases).
+ */
+export function deriveSessionRail(
+  sessions: readonly SessionSummary[],
+  activeId: string | undefined,
+  include: (session: SessionSummary) => boolean,
+): {
+  sessions: SessionSummary[];
+  activeRowId: string | undefined;
+} {
+  const tree = projectRevisionLinkedSessionTree(sessions, activeId);
+  const parentByChildId = new Map<string, string>();
+  for (const [parentId, children] of tree.childrenByParentId) {
+    for (const child of children) {
+      parentByChildId.set(child.id, parentId);
+    }
+  }
+
+  const railSessions = tree.roots.filter(include);
+  return {
+    sessions: railSessions,
+    activeRowId: resolveActiveRailRowId(activeId, railSessions, parentByChildId),
+  };
+}
+
+function resolveActiveRailRowId(
+  activeId: string | undefined,
+  railSessions: readonly SessionSummary[],
+  parentByChildId: ReadonlyMap<string, string>,
+): string | undefined {
+  if (!activeId) return undefined;
+  const rowIds = new Set(railSessions.map((session) => session.id));
+  let currentId = activeId;
+  const visited = new Set<string>();
+  while (!visited.has(currentId)) {
+    visited.add(currentId);
+    if (rowIds.has(currentId)) return currentId;
+    const parentId = parentByChildId.get(currentId);
+    if (!parentId) return undefined;
+    currentId = parentId;
+  }
+  return undefined;
+}

--- a/apps/desktop/src/renderer/session-rail.ts
+++ b/apps/desktop/src/renderer/session-rail.ts
@@ -1,6 +1,17 @@
 import type { SessionSummary } from '@maka/core';
 import { projectRevisionLinkedSessionTree } from '@maka/core';
 
+export type SessionRailProjection = {
+  sessions: SessionSummary[];
+  activeRowId: string | undefined;
+  /**
+   * Immediate linked parent of the active session, as the revision-aware tree
+   * sees it (physical parent id aliased to the family representative). Titlebar
+   * crumbs share this row with the rail so rename/revise cannot disagree.
+   */
+  activeParentSession: SessionSummary | undefined;
+};
+
 /**
  * Desktop sidebar rail projection.
  *
@@ -9,30 +20,34 @@ import { projectRevisionLinkedSessionTree } from '@maka/core';
  * missing → orphan stays a root). Nav / companion filters are flat — never
  * promote a linked child past a filtered ancestor.
  *
- * Active row shares that same tree: when a child is open, highlight the
- * ancestor that actually appears as a rail row (revision representatives
- * included via projectRevisionLinkedSessionTree aliases).
+ * Active row and titlebar parent share that same tree: when a child is open,
+ * highlight the ancestor that appears as a rail row and surface the immediate
+ * parent representative for breadcrumbs.
  */
 export function deriveSessionRail(
   sessions: readonly SessionSummary[],
   activeId: string | undefined,
   include: (session: SessionSummary) => boolean,
-): {
-  sessions: SessionSummary[];
-  activeRowId: string | undefined;
-} {
+): SessionRailProjection {
   const tree = projectRevisionLinkedSessionTree(sessions, activeId);
   const parentByChildId = new Map<string, string>();
+  const sessionsById = new Map<string, SessionSummary>();
+  for (const root of tree.roots) {
+    sessionsById.set(root.id, root);
+  }
   for (const [parentId, children] of tree.childrenByParentId) {
     for (const child of children) {
       parentByChildId.set(child.id, parentId);
+      sessionsById.set(child.id, child);
     }
   }
 
   const railSessions = tree.roots.filter(include);
+  const activeParentId = activeId ? parentByChildId.get(activeId) : undefined;
   return {
     sessions: railSessions,
     activeRowId: resolveActiveRailRowId(activeId, railSessions, parentByChildId),
+    activeParentSession: activeParentId ? sessionsById.get(activeParentId) : undefined,
   };
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -188,15 +188,9 @@
   -webkit-app-region: no-drag;
 }
 
-/* SideNavItem needs a truthy child to retain its disclosure control. Collapsed
- * session trees provide this sentinel instead of mounting every Swarm child. */
-.maka-session-lazy-children-sentinel {
-  display: none;
-}
-
 /*
  * Dim only this row's SideNavItem. Child combinators stop before [role=group]
- * nests, so a stale parent never mutes healthy subagent rows underneath.
+ * nests under project groups.
  * DOM: .maka-session-row > SideNavItem root > .astryx-side-nav-item
  * (leaf: button; collapsible parent: split-action row that may host the
  * primary control with aria-current).
@@ -210,17 +204,13 @@
   opacity: 1;
 }
 
-.maka-session-row[data-subagent="true"] .astryx-side-nav-item {
-  color: var(--foreground-secondary);
-}
-
 /*
  * Project groups are a section label + peer sessions, not a deep tree.
  * Astryx SideNavItem always pads children with spacing-6 (24px); that is the
  * shell-side-nav workspace pattern, but it wastes a full icon column in a
  * narrow session rail. Zero only the project item's own nest so sessions share
- * the time-sort left edge. Do not use a descendant selector — that would also
- * punch through subagent trees under session rows inside the project.
+ * the time-sort left edge. Child combinator only — do not use a descendant
+ * selector that would punch deeper nest levels if any appear later.
  * DOM: .maka-project-row > SideNavItem root > [role=group] > childrenInner
  */
 .maka-project-row > div > [role="group"] > div {

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -389,7 +389,6 @@ function ComposedShell(props: {
             maxWidth={480}
             selection={{ section: 'sessions', filter: 'chats' }}
             sessions={sidebarRows}
-            childSessionsByParentId={sessionTree.childrenByParentId}
             activeId={active?.id}
             groups={viewMode === 'project' ? projectGroups : undefined}
             streamingSessionIds={streamingIds}

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState, type CSSProperties, type ReactNode } from 'react';
 import type { ComponentProps } from 'react';
-import { projectRevisionLinkedSessionTree } from '@maka/core';
 import type { ProjectRecord, SessionSummary, StoredMessage } from '@maka/core';
 import {
   ChatSurfaceLayout,
@@ -17,6 +16,7 @@ import { AppShellDetailPanel } from '../src/renderer/app-shell-detail-panel';
 import { deriveAppShellTurnPresentation } from '../src/renderer/app-shell-turn-view-model';
 import { deriveBranchBanner } from '../src/renderer/branch-banner';
 import { deriveSessionRevisionNavigation } from '../src/renderer/session-revisions';
+import { deriveSessionRail } from '../src/renderer/session-rail';
 import { AppShell as AstryxAppShell } from '@astryxdesign/core/AppShell';
 
 const NOW = Date.UTC(2026, 6, 1, 9, 30, 0);
@@ -315,11 +315,9 @@ function ComposedShell(props: {
   // showing lineage the production rules would not produce for its sessions.
   const branchBanner = deriveBranchBanner(active, sessions);
   const revisionNavigation = deriveSessionRevisionNavigation(sessions, active?.id);
-  // The sidebar shows logical conversations, not physical revisions: production
-  // collapses each family to one row before rendering. Passing the raw list
-  // would put three rows where the app shows one.
-  const sessionTree = projectRevisionLinkedSessionTree(sessions, active?.id);
-  const sidebarRows = sessionTree.roots;
+  // Same rail projection as app-shell: revision-tree roots only (linked
+  // children stay off the list). Stories include every fixture row.
+  const { sessions: sidebarRows } = deriveSessionRail(sessions, active?.id, () => true);
   const messages = props.chat?.messages ?? baseChatProps.messages;
   // ChatView projects the transcript and calls this back with the turns, the
   // same seam production uses (app-shell.tsx), so a story cannot show footer

--- a/apps/desktop/stories/subagent-sessions.stories.tsx
+++ b/apps/desktop/stories/subagent-sessions.stories.tsx
@@ -1,0 +1,511 @@
+/**
+ * Subagent sessions — session presentation contract (design lock).
+ *
+ * - Sidebar lists only root/user sessions (no nested subagent tree).
+ * - Multiple spawn_subagent calls in one turn render as one collapsible
+ *   ToolTrow / ChatToolCalls group (product tool primitives).
+ * - Opening a linked subagent switches the main chat column (option A);
+ *   titlebar is project › parent › child.
+ * - No composer drawer, strip, or parallel card system for subagents.
+ *
+ * Review scaffold for the layout target; not yet the shipped shell path.
+ */
+import type { CSSProperties, ReactNode } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { BreadcrumbItem, Breadcrumbs } from '@astryxdesign/core/Breadcrumbs';
+import {
+  ChatComposer,
+  ChatComposerInput,
+  ChatMessage,
+  ChatMessageBubble,
+  ChatMessageList,
+  ChatMessageMetadata,
+  ChatToolCalls,
+  type ChatToolCallItem,
+} from '@astryxdesign/core/Chat';
+import { Icon } from '@astryxdesign/core/Icon';
+import { Text } from '@astryxdesign/core/Text';
+import type { ToolResultContent } from '@maka/core';
+import { formatDuration } from '../../../packages/ui/src/tool-activity/preview-utils.js';
+import { formatToolIntent } from '../../../packages/ui/src/tool-format.js';
+import { resolveToolDisplayName } from '../../../packages/ui/src/tool-activity/display-name.js';
+import { ToolCallDetail } from '../../../packages/ui/src/tool-activity.js';
+import type { ToolActivityItem } from '../../../packages/ui/src/materialize.js';
+import { useUiLocale } from '../../../packages/ui/src/locale-context.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures — multi-subagent contiguous tool run
+// ---------------------------------------------------------------------------
+
+const NOW = 1_735_689_600_000;
+const PARENT_NAME = '实现会话任务台账';
+const PROJECT_NAME = 'maka-agent';
+
+function subagentResult(
+  partial: Partial<Extract<ToolResultContent, { kind: 'subagent' }>> &
+    Pick<Extract<ToolResultContent, { kind: 'subagent' }>, 'agentName' | 'status'>,
+): Extract<ToolResultContent, { kind: 'subagent' }> {
+  return {
+    kind: 'subagent',
+    agentId: partial.agentId ?? `agent-${partial.agentName}`,
+    agentName: partial.agentName,
+    turnId: partial.turnId ?? `turn-${partial.agentName}`,
+    runId: partial.runId ?? `run-${partial.agentName}`,
+    status: partial.status,
+    permissionMode: partial.permissionMode ?? 'ask',
+    summary: partial.summary ?? '',
+    artifactIds: partial.artifactIds ?? [],
+    startedAt: partial.startedAt ?? NOW - 60_000,
+    completedAt: partial.completedAt,
+    durationMs: partial.durationMs ?? 12_000,
+    eventCount: partial.eventCount ?? 8,
+    ...(partial.failureClass ? { failureClass: partial.failureClass } : {}),
+  };
+}
+
+const MULTI_SUBAGENT_ITEMS: ToolActivityItem[] = [
+  {
+    toolUseId: 'sa-explore-layout',
+    toolName: 'spawn_subagent',
+    displayName: 'explore · 读布局',
+    intent: '扫 desktop session list 与 workbar 相关样式',
+    status: 'running',
+    args: { agentName: 'explore · 读布局', objective: '扫 desktop session list 与 workbar 相关样式' },
+    result: subagentResult({
+      agentName: 'explore · 读布局',
+      status: 'running',
+      permissionMode: 'explore',
+      durationMs: 72_000,
+      startedAt: NOW - 72_000,
+    }),
+    durationMs: 72_000,
+  },
+  {
+    toolUseId: 'sa-coder-draft',
+    toolName: 'spawn_subagent',
+    displayName: 'coder · 写草案',
+    intent: '起草 titlebar breadcrumb 扩展点',
+    status: 'running',
+    args: { agentName: 'coder · 写草案', objective: '起草 titlebar breadcrumb 扩展点' },
+    result: subagentResult({
+      agentName: 'coder · 写草案',
+      status: 'running',
+      durationMs: 48_000,
+      startedAt: NOW - 48_000,
+    }),
+    durationMs: 48_000,
+  },
+  {
+    toolUseId: 'sa-review-contract',
+    toolName: 'spawn_subagent',
+    displayName: 'review · 契约',
+    intent: '核对侧栏不再渲染 data-subagent 嵌套行',
+    status: 'completed',
+    args: { agentName: 'review · 契约', objective: '核对侧栏不再渲染 data-subagent 嵌套行' },
+    result: subagentResult({
+      agentName: 'review · 契约',
+      status: 'completed',
+      summary: '侧栏无嵌套；入口仅在流内工具组。',
+      durationMs: 125_000,
+      startedAt: NOW - 200_000,
+      completedAt: NOW - 75_000,
+    }),
+    durationMs: 125_000,
+  },
+  {
+    toolUseId: 'sa-explore-fail',
+    toolName: 'spawn_subagent',
+    displayName: 'explore · 失败样例',
+    intent: '演示失败态在分组工具行中的可读性',
+    status: 'errored',
+    args: { agentName: 'explore · 失败样例', objective: '演示失败态' },
+    result: subagentResult({
+      agentName: 'explore · 失败样例',
+      status: 'failed',
+      summary: '权限边界拒绝读取 .env。',
+      failureClass: 'permission_denied',
+      durationMs: 19_000,
+      startedAt: NOW - 40_000,
+      completedAt: NOW - 21_000,
+    }),
+    durationMs: 19_000,
+  },
+  {
+    toolUseId: 'sa-waiting',
+    toolName: 'spawn_subagent',
+    displayName: 'explore · 等用户',
+    intent: '等待批准后再读路径',
+    status: 'running',
+    args: { agentName: 'explore · 等用户', objective: '等待批准后再读路径', permissionMode: 'explore' },
+    result: subagentResult({
+      agentName: 'explore · 等用户',
+      status: 'waiting_for_user',
+      permissionMode: 'explore',
+      summary: 'Waiting for approval before reading the requested path.',
+      durationMs: 4_000,
+      startedAt: NOW - 4_000,
+    }),
+    durationMs: 4_000,
+  },
+];
+
+function childLabel(item: ToolActivityItem): string {
+  if (item.result?.kind === 'subagent' && item.result.agentName) return item.result.agentName;
+  return item.displayName || item.toolName;
+}
+
+function childObjective(item: ToolActivityItem): string {
+  if (typeof item.intent === 'string' && item.intent.trim()) return item.intent;
+  return childLabel(item);
+}
+
+function astryxToolStatus(item: ToolActivityItem): ChatToolCallItem['status'] {
+  switch (item.status) {
+    case 'completed':
+      return 'complete';
+    case 'errored':
+    case 'interrupted':
+      return 'error';
+    case 'running':
+      return 'running';
+    default:
+      return 'pending';
+  }
+}
+
+/**
+ * Same data mapping as product `ToolTrow`, with optional expand control for the
+ * fold story. Hosted under `.maka-turn` so product hover paint applies:
+ * `apps/desktop/src/renderer/styles/chat-message.css` scopes
+ * `.astryx-chat-tool-calls [role="button"]:hover` to that turn root.
+ * Bare ChatToolCalls outside a turn is the wrong frame, not a different component.
+ */
+function SubagentToolGroup(props: {
+  items: ToolActivityItem[];
+  defaultIsExpanded?: boolean;
+}) {
+  const locale = useUiLocale();
+  if (props.items.length === 0) return null;
+  const calls: ChatToolCallItem[] = props.items.map((item) => ({
+    key: item.toolUseId,
+    name: resolveToolDisplayName(item, locale),
+    status: astryxToolStatus(item),
+    target: item.intent ? formatToolIntent(item.intent) : undefined,
+    duration: formatDuration(item.durationMs) ?? undefined,
+    resultDetail: (
+      <div className="maka-tool-call-detail">
+        <ToolCallDetail item={item} />
+      </div>
+    ),
+  }));
+  return (
+    <div className="maka-turn">
+      <ChatToolCalls
+        calls={calls}
+        defaultIsExpanded={props.defaultIsExpanded}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shell
+// ---------------------------------------------------------------------------
+
+const shell: Record<string, CSSProperties> = {
+  root: {
+    height: 720,
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    background: 'var(--color-background-body, #f4f4f5)',
+    color: 'var(--color-text-primary)',
+    fontFamily: 'var(--font-sans, system-ui)',
+  },
+  titlebar: {
+    height: 44,
+    display: 'flex',
+    alignItems: 'center',
+    paddingInline: 16,
+    gap: 12,
+    borderBottom: '1px solid var(--color-border-muted, rgba(0,0,0,0.08))',
+    flex: '0 0 auto',
+  },
+  body: {
+    flex: 1,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'row',
+    gap: 12,
+    padding: 12,
+  },
+  plate: {
+    flex: 1,
+    minWidth: 0,
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    background: 'var(--color-background-surface, #fff)',
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  stream: {
+    flex: 1,
+    minHeight: 0,
+    overflow: 'auto',
+    padding: '16px 20px',
+  },
+  composerStack: {
+    flex: '0 0 auto',
+    padding: '0 16px 16px',
+  },
+  caption: {
+    padding: '6px 12px',
+    borderBottom: '1px solid var(--color-border-muted, rgba(0,0,0,0.06))',
+    background: 'var(--color-background-muted, rgba(0,0,0,0.03))',
+  },
+  sideNav: {
+    width: 220,
+    flex: '0 0 auto',
+    minHeight: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    padding: 10,
+    background: 'var(--color-background-surface, #fff)',
+    borderRadius: 12,
+    overflow: 'auto',
+  },
+  sideNavLabel: {
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.04em',
+    textTransform: 'uppercase' as const,
+    color: 'var(--color-text-secondary, #71717a)',
+    padding: '4px 8px',
+  },
+  sideNavRow: {
+    padding: '8px 10px',
+    borderRadius: 8,
+    fontSize: 13,
+    fontWeight: 500,
+  },
+  sideNavRowActive: {
+    background: 'var(--color-background-muted, rgba(0,0,0,0.06))',
+  },
+  compareRoot: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: 16,
+    padding: 16,
+    minHeight: 560,
+    boxSizing: 'border-box' as const,
+    background: 'var(--color-background-body, #f4f4f5)',
+  },
+  comparePane: {
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: 10,
+    padding: 14,
+    borderRadius: 12,
+    background: 'var(--color-background-surface, #fff)',
+    border: '1px solid var(--color-border-muted, rgba(0,0,0,0.1))',
+  },
+};
+
+function Caption(props: { children: ReactNode }) {
+  return (
+    <div style={shell.caption}>
+      <Text type="supporting" color="secondary">
+        {props.children}
+      </Text>
+    </div>
+  );
+}
+
+function TitlebarTrail(props: {
+  project?: string;
+  parent?: { name: string; onClick?: () => void };
+  sessionName: string;
+  sessionIsCurrent?: boolean;
+}) {
+  return (
+    <Breadcrumbs
+      label="会话位置"
+      separator={<Icon icon="chevronRight" size="xsm" />}
+    >
+      {props.project ? (
+        <BreadcrumbItem onClick={() => undefined}>{props.project}</BreadcrumbItem>
+      ) : null}
+      {props.parent ? (
+        <BreadcrumbItem onClick={props.parent.onClick}>{props.parent.name}</BreadcrumbItem>
+      ) : null}
+      <BreadcrumbItem isCurrent={props.sessionIsCurrent ?? !props.parent}>
+        {props.sessionName}
+      </BreadcrumbItem>
+    </Breadcrumbs>
+  );
+}
+
+function RootSidebar() {
+  return (
+    <aside style={shell.sideNav} aria-label="会话列表">
+      <div style={shell.sideNavLabel}>会话</div>
+      <div style={{ ...shell.sideNavRow, ...shell.sideNavRowActive }}>{PARENT_NAME}</div>
+      <div style={shell.sideNavRow}>修 CI 绿线</div>
+      <div style={shell.sideNavRow}>文档润色</div>
+      <div style={{ marginTop: 12, paddingInline: 8 }}>
+        <Text type="supporting" color="secondary">
+          仅 root 会话；无 data-subagent 嵌套。
+        </Text>
+      </div>
+    </aside>
+  );
+}
+
+function ParentShell() {
+  return (
+    <div style={shell.root} data-maka-contract="subagent-session-layout">
+      <header style={shell.titlebar}>
+        <TitlebarTrail project={PROJECT_NAME} sessionName={PARENT_NAME} />
+      </header>
+      <Caption>
+        侧栏无嵌套。流内一组可折叠 spawn_subagent（仅工具原语）。产品在 linked
+        工具行上挂打开；无第二套列表、无 ComposerDrawer / strip。
+      </Caption>
+      <div style={shell.body}>
+        <RootSidebar />
+        <div style={shell.plate}>
+          <div style={shell.stream}>
+            <ChatMessageList>
+              <ChatMessage sender="user">
+                <ChatMessageBubble>
+                  并行派多个子代理做布局扫描、草案与契约核对。
+                </ChatMessageBubble>
+              </ChatMessage>
+              <ChatMessage sender="assistant" name="Maka">
+                <ChatMessageBubble>
+                  当轮连续 spawn_subagent 合成一个工具组（与其它连续 tool run 相同）。点某行进对应子会话（产品接线，非下方平行列表）。
+                </ChatMessageBubble>
+                <ChatMessageMetadata timestamp="刚刚" />
+                <div style={{ marginTop: 10, width: '100%' }}>
+                  <SubagentToolGroup items={MULTI_SUBAGENT_ITEMS} defaultIsExpanded />
+                </div>
+              </ChatMessage>
+            </ChatMessageList>
+          </div>
+          <div style={shell.composerStack}>
+            <ChatComposer
+              onSubmit={() => undefined}
+              placeholder="继续编排父会话…"
+              input={<ChatComposerInput aria-label="消息输入" />}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stories — three locks, nothing else
+// ---------------------------------------------------------------------------
+
+const meta = {
+  title: 'Product/Subagent Sessions',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Session presentation for subagents: flat sidebar, collapsible multi-spawn tool group, ' +
+          'main-column open with parent › child titlebar. No composer drawer.',
+      },
+    },
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Real path: Review scaffold — parent session with multi-subagent tool group, flat sidebar, open child in main column; design lock, not yet shipped shell path.
+export const ParentSession: Story = {
+  name: '父会话 · 工具组 + 打开子会话',
+  render: () => <ParentShell />,
+};
+
+// Real path: Review scaffold — multi spawn_subagent group collapsed vs expanded using ChatToolCalls; side-by-side review aid, not a product screen.
+export const ToolGroupFold: Story = {
+  name: '工具组 · 折叠 vs 展开',
+  render: () => (
+    <div style={shell.compareRoot}>
+      <div style={shell.comparePane}>
+        <Text type="body" style={{ fontWeight: 600 }}>
+          折叠
+        </Text>
+        <Text type="supporting" color="secondary">
+          {MULTI_SUBAGENT_ITEMS.length} 个 spawn_subagent 一组；头上数量 + 最近行（同 ContiguousGroup）。
+        </Text>
+        <SubagentToolGroup items={MULTI_SUBAGENT_ITEMS} defaultIsExpanded={false} />
+      </div>
+      <div style={shell.comparePane}>
+        <Text type="body" style={{ fontWeight: 600 }}>
+          展开
+        </Text>
+        <Text type="supporting" color="secondary">
+          每行 + resultDetail = 现有 ToolCallDetail / SubagentPreview。
+        </Text>
+        <SubagentToolGroup items={MULTI_SUBAGENT_ITEMS} defaultIsExpanded />
+      </div>
+    </div>
+  ),
+};
+
+// Real path: Review scaffold — child session main column with project › parent › child breadcrumbs after open from tool group; design lock, not yet shipped.
+export const ChildSession: Story = {
+  name: '子会话 · 面包屑回父',
+  render: () => {
+    const item = MULTI_SUBAGENT_ITEMS[0]!;
+    return (
+      <div style={shell.root}>
+        <header style={shell.titlebar}>
+          <TitlebarTrail
+            project={PROJECT_NAME}
+            parent={{ name: PARENT_NAME }}
+            sessionName={childLabel(item)}
+            sessionIsCurrent
+          />
+        </header>
+        <Caption>
+          从工具组打开后的主区。侧栏仍是 root 列表，不嵌套该子代理。
+        </Caption>
+        <div style={shell.body}>
+          <RootSidebar />
+          <div style={shell.plate}>
+            <div style={shell.stream}>
+              <ChatMessageList>
+                <ChatMessage sender="user">
+                  <ChatMessageBubble>{childObjective(item)}</ChatMessageBubble>
+                </ChatMessage>
+                <ChatMessage sender="assistant" name={childLabel(item)}>
+                  <ChatMessageBubble>子代理完整会话流。</ChatMessageBubble>
+                  <ChatMessageMetadata timestamp="运行中" />
+                </ChatMessage>
+              </ChatMessageList>
+            </div>
+            <div style={shell.composerStack}>
+              <ChatComposer
+                onSubmit={() => undefined}
+                placeholder="向该子代理追问…"
+                input={<ChatComposerInput aria-label="子会话消息输入" />}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+

--- a/apps/desktop/stories/subagent-sessions.stories.tsx
+++ b/apps/desktop/stories/subagent-sessions.stories.tsx
@@ -51,6 +51,9 @@ function subagentResult(
     agentName: partial.agentName,
     turnId: partial.turnId ?? `turn-${partial.agentName}`,
     runId: partial.runId ?? `run-${partial.agentName}`,
+    // Linked child id is what product open wiring needs; stories seed it so
+    // expanded tool detail shows the same Open control as the shell.
+    childSessionId: partial.childSessionId ?? `session-${partial.agentName}`,
     status: partial.status,
     permissionMode: partial.permissionMode ?? 'ask',
     summary: partial.summary ?? '',
@@ -183,6 +186,7 @@ function astryxToolStatus(item: ToolActivityItem): ChatToolCallItem['status'] {
 function SubagentToolGroup(props: {
   items: ToolActivityItem[];
   defaultIsExpanded?: boolean;
+  onOpenLinkedSession?(sessionId: string): void;
 }) {
   const locale = useUiLocale();
   if (props.items.length === 0) return null;
@@ -194,7 +198,7 @@ function SubagentToolGroup(props: {
     duration: formatDuration(item.durationMs) ?? undefined,
     resultDetail: (
       <div className="maka-tool-call-detail">
-        <ToolCallDetail item={item} />
+        <ToolCallDetail item={item} onOpenLinkedSession={props.onOpenLinkedSession} />
       </div>
     ),
   }));
@@ -390,7 +394,11 @@ function ParentShell() {
                 </ChatMessageBubble>
                 <ChatMessageMetadata timestamp="刚刚" />
                 <div style={{ marginTop: 10, width: '100%' }}>
-                  <SubagentToolGroup items={MULTI_SUBAGENT_ITEMS} defaultIsExpanded />
+                  <SubagentToolGroup
+                    items={MULTI_SUBAGENT_ITEMS}
+                    defaultIsExpanded
+                    onOpenLinkedSession={() => undefined}
+                  />
                 </div>
               </ChatMessage>
             </ChatMessageList>
@@ -448,16 +456,24 @@ export const ToolGroupFold: Story = {
         <Text type="supporting" color="secondary">
           {MULTI_SUBAGENT_ITEMS.length} 个 spawn_subagent 一组；头上数量 + 最近行（同 ContiguousGroup）。
         </Text>
-        <SubagentToolGroup items={MULTI_SUBAGENT_ITEMS} defaultIsExpanded={false} />
+        <SubagentToolGroup
+          items={MULTI_SUBAGENT_ITEMS}
+          defaultIsExpanded={false}
+          onOpenLinkedSession={() => undefined}
+        />
       </div>
       <div style={shell.comparePane}>
         <Text type="body" style={{ fontWeight: 600 }}>
           展开
         </Text>
         <Text type="supporting" color="secondary">
-          每行 + resultDetail = 现有 ToolCallDetail / SubagentPreview。
+          每行 + resultDetail = 现有 ToolCallDetail / SubagentPreview（含打开会话）。
         </Text>
-        <SubagentToolGroup items={MULTI_SUBAGENT_ITEMS} defaultIsExpanded />
+        <SubagentToolGroup
+          items={MULTI_SUBAGENT_ITEMS}
+          defaultIsExpanded
+          onOpenLinkedSession={() => undefined}
+        />
       </div>
     </div>
   ),

--- a/apps/desktop/stories/subagent-sessions.stories.tsx
+++ b/apps/desktop/stories/subagent-sessions.stories.tsx
@@ -8,11 +8,13 @@
  *   titlebar is project › parent › child.
  * - No composer drawer, strip, or parallel card system for subagents.
  *
- * Review scaffold for the layout target; not yet the shipped shell path.
+ * Titlebar and sidebar use the same product components as app-shell
+ * (TitlebarSessionIdentity, SessionListPanel, deriveSessionRail). The
+ * multi-spawn tool group still maps through ChatToolCalls the way
+ * production ToolTrow does, with real ToolCallDetail for Open.
  */
 import type { CSSProperties, ReactNode } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { BreadcrumbItem, Breadcrumbs } from '@astryxdesign/core/Breadcrumbs';
 import {
   ChatComposer,
   ChatComposerInput,
@@ -23,15 +25,19 @@ import {
   ChatToolCalls,
   type ChatToolCallItem,
 } from '@astryxdesign/core/Chat';
-import { Icon } from '@astryxdesign/core/Icon';
 import { Text } from '@astryxdesign/core/Text';
-import type { ToolResultContent } from '@maka/core';
+import type { SessionSummary, ToolResultContent } from '@maka/core';
+import {
+  SessionListPanel,
+  TitlebarSessionIdentity,
+} from '@maka/ui';
 import { formatDuration } from '../../../packages/ui/src/tool-activity/preview-utils.js';
 import { formatToolIntent } from '../../../packages/ui/src/tool-format.js';
 import { resolveToolDisplayName } from '../../../packages/ui/src/tool-activity/display-name.js';
 import { ToolCallDetail } from '../../../packages/ui/src/tool-activity.js';
 import type { ToolActivityItem } from '../../../packages/ui/src/materialize.js';
 import { useUiLocale } from '../../../packages/ui/src/locale-context.js';
+import { deriveSessionRail } from '../src/renderer/session-rail.js';
 
 // ---------------------------------------------------------------------------
 // Fixtures — multi-subagent contiguous tool run
@@ -268,34 +274,11 @@ const shell: Record<string, CSSProperties> = {
     borderBottom: '1px solid var(--color-border-muted, rgba(0,0,0,0.06))',
     background: 'var(--color-background-muted, rgba(0,0,0,0.03))',
   },
-  sideNav: {
-    width: 220,
+  rail: {
+    width: 260,
     flex: '0 0 auto',
     minHeight: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 4,
-    padding: 10,
-    background: 'var(--color-background-surface, #fff)',
-    borderRadius: 12,
-    overflow: 'auto',
-  },
-  sideNavLabel: {
-    fontSize: 11,
-    fontWeight: 600,
-    letterSpacing: '0.04em',
-    textTransform: 'uppercase' as const,
-    color: 'var(--color-text-secondary, #71717a)',
-    padding: '4px 8px',
-  },
-  sideNavRow: {
-    padding: '8px 10px',
-    borderRadius: 8,
-    fontSize: 13,
-    fontWeight: 500,
-  },
-  sideNavRowActive: {
-    background: 'var(--color-background-muted, rgba(0,0,0,0.06))',
+    alignSelf: 'stretch',
   },
   compareRoot: {
     display: 'grid',
@@ -318,6 +301,57 @@ const shell: Record<string, CSSProperties> = {
   },
 };
 
+const NOOP_ROW_ACTIONS = {
+  onToggleFlag() {},
+  onArchive() {},
+  onUnarchive() {},
+  onRename() {},
+  onDelete() {},
+};
+
+function makeRailSession(
+  overrides: Partial<SessionSummary> & Pick<SessionSummary, 'id' | 'name'>,
+): SessionSummary {
+  return {
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'fake',
+    llmConnectionSlug: 'default',
+    connectionLocked: false,
+    model: 'fake',
+    permissionMode: 'ask',
+    ...overrides,
+  };
+}
+
+const PARENT_SESSION_ID = 'parent';
+const LINKED_CHILD_SESSION_ID = 'session-explore-layout';
+
+/** Full session catalog: roots plus one linked child (child stays off the rail). */
+const RAIL_FIXTURE_SESSIONS: SessionSummary[] = [
+  makeRailSession({ id: PARENT_SESSION_ID, name: PARENT_NAME, lastMessageAt: 30 }),
+  makeRailSession({ id: 'peer-ci', name: '修 CI 绿线', lastMessageAt: 20 }),
+  makeRailSession({ id: 'peer-docs', name: '文档润色', lastMessageAt: 10 }),
+  makeRailSession({
+    id: LINKED_CHILD_SESSION_ID,
+    name: 'explore · 读布局',
+    lastMessageAt: 25,
+    subagentParent: {
+      kind: 'subagent',
+      parentSessionId: PARENT_SESSION_ID,
+      spawnedBy: {
+        parentRunId: 'run',
+        parentTurnId: 'turn',
+        toolCallId: 'tool',
+      },
+      lifecycle: 'foreground',
+    },
+  }),
+];
+
 function Caption(props: { children: ReactNode }) {
   return (
     <div style={shell.caption}>
@@ -328,43 +362,50 @@ function Caption(props: { children: ReactNode }) {
   );
 }
 
-function TitlebarTrail(props: {
-  project?: string;
-  parent?: { name: string; onClick?: () => void };
+function ProductTitlebar(props: {
   sessionName: string;
-  sessionIsCurrent?: boolean;
+  parentName?: string;
 }) {
   return (
-    <Breadcrumbs
-      label="会话位置"
-      separator={<Icon icon="chevronRight" size="xsm" />}
-    >
-      {props.project ? (
-        <BreadcrumbItem onClick={() => undefined}>{props.project}</BreadcrumbItem>
-      ) : null}
-      {props.parent ? (
-        <BreadcrumbItem onClick={props.parent.onClick}>{props.parent.name}</BreadcrumbItem>
-      ) : null}
-      <BreadcrumbItem isCurrent={props.sessionIsCurrent ?? !props.parent}>
-        {props.sessionName}
-      </BreadcrumbItem>
-    </Breadcrumbs>
+    <TitlebarSessionIdentity
+      sessionName={props.sessionName}
+      onRenameSession={() => undefined}
+      project={{
+        name: PROJECT_NAME,
+        onOpenFolder: () => undefined,
+      }}
+      parentSession={
+        props.parentName
+          ? {
+              name: props.parentName,
+              onOpen: () => undefined,
+            }
+          : undefined
+      }
+    />
   );
 }
 
-function RootSidebar() {
+function ProductRail(props: { activeSessionId: string }) {
+  const { sessions, activeRowId } = deriveSessionRail(
+    RAIL_FIXTURE_SESSIONS,
+    props.activeSessionId,
+    () => true,
+  );
   return (
-    <aside style={shell.sideNav} aria-label="会话列表">
-      <div style={shell.sideNavLabel}>会话</div>
-      <div style={{ ...shell.sideNavRow, ...shell.sideNavRowActive }}>{PARENT_NAME}</div>
-      <div style={shell.sideNavRow}>修 CI 绿线</div>
-      <div style={shell.sideNavRow}>文档润色</div>
-      <div style={{ marginTop: 12, paddingInline: 8 }}>
-        <Text type="supporting" color="secondary">
-          仅 root 会话；无 data-subagent 嵌套。
-        </Text>
-      </div>
-    </aside>
+    <div style={shell.rail}>
+      <SessionListPanel
+        selection={{ section: 'sessions', filter: 'chats' }}
+        sessions={sessions}
+        activeId={activeRowId}
+        width={260}
+        onSelectSession={() => undefined}
+        onSelect={() => undefined}
+        onOpenSettings={() => undefined}
+        onNew={() => undefined}
+        rowActions={NOOP_ROW_ACTIONS}
+      />
+    </div>
   );
 }
 
@@ -372,14 +413,14 @@ function ParentShell() {
   return (
     <div style={shell.root} data-maka-contract="subagent-session-layout">
       <header style={shell.titlebar}>
-        <TitlebarTrail project={PROJECT_NAME} sessionName={PARENT_NAME} />
+        <ProductTitlebar sessionName={PARENT_NAME} />
       </header>
       <Caption>
-        侧栏无嵌套。流内一组可折叠 spawn_subagent（仅工具原语）。产品在 linked
-        工具行上挂打开；无第二套列表、无 ComposerDrawer / strip。
+        侧栏为 SessionListPanel + deriveSessionRail（仅 root）。流内一组可折叠
+        spawn_subagent；Open 走 ToolCallDetail。无 ComposerDrawer / strip。
       </Caption>
       <div style={shell.body}>
-        <RootSidebar />
+        <ProductRail activeSessionId={PARENT_SESSION_ID} />
         <div style={shell.plate}>
           <div style={shell.stream}>
             <ChatMessageList>
@@ -390,7 +431,7 @@ function ParentShell() {
               </ChatMessage>
               <ChatMessage sender="assistant" name="Maka">
                 <ChatMessageBubble>
-                  当轮连续 spawn_subagent 合成一个工具组（与其它连续 tool run 相同）。点某行进对应子会话（产品接线，非下方平行列表）。
+                  当轮连续 spawn_subagent 合成一个工具组（与其它连续 tool run 相同）。点某行进对应子会话。
                 </ChatMessageBubble>
                 <ChatMessageMetadata timestamp="刚刚" />
                 <div style={{ marginTop: 10, width: '100%' }}>
@@ -438,13 +479,13 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// Real path: Review scaffold — parent session with multi-subagent tool group, flat sidebar, open child in main column; design lock, not yet shipped shell path.
+// Real path: parent session with multi-subagent tool group; flat SessionListPanel rail + TitlebarSessionIdentity.
 export const ParentSession: Story = {
   name: '父会话 · 工具组 + 打开子会话',
   render: () => <ParentShell />,
 };
 
-// Real path: Review scaffold — multi spawn_subagent group collapsed vs expanded using ChatToolCalls; side-by-side review aid, not a product screen.
+// Real path: multi spawn_subagent group collapsed vs expanded via ChatToolCalls + ToolCallDetail Open.
 export const ToolGroupFold: Story = {
   name: '工具组 · 折叠 vs 展开',
   render: () => (
@@ -479,7 +520,7 @@ export const ToolGroupFold: Story = {
   ),
 };
 
-// Real path: Review scaffold — child session main column with project › parent › child breadcrumbs after open from tool group; design lock, not yet shipped.
+// Real path: child open — product titlebar parent crumb; rail still roots only (parent highlighted).
 export const ChildSession: Story = {
   name: '子会话 · 面包屑回父',
   render: () => {
@@ -487,18 +528,13 @@ export const ChildSession: Story = {
     return (
       <div style={shell.root}>
         <header style={shell.titlebar}>
-          <TitlebarTrail
-            project={PROJECT_NAME}
-            parent={{ name: PARENT_NAME }}
-            sessionName={childLabel(item)}
-            sessionIsCurrent
-          />
+          <ProductTitlebar sessionName={childLabel(item)} parentName={PARENT_NAME} />
         </header>
         <Caption>
-          从工具组打开后的主区。侧栏仍是 root 列表，不嵌套该子代理。
+          从工具组打开后的主区。侧栏仍是 deriveSessionRail 的 root 列表并高亮父会话。
         </Caption>
         <div style={shell.body}>
-          <RootSidebar />
+          <ProductRail activeSessionId={LINKED_CHILD_SESSION_ID} />
           <div style={shell.plate}>
             <div style={shell.stream}>
               <ChatMessageList>

--- a/apps/desktop/stories/subagent-sessions.stories.tsx
+++ b/apps/desktop/stories/subagent-sessions.stories.tsx
@@ -560,4 +560,3 @@ export const ChildSession: Story = {
     );
   },
 };
-

--- a/packages/core/src/__tests__/subagent-session-parent.test.ts
+++ b/packages/core/src/__tests__/subagent-session-parent.test.ts
@@ -15,7 +15,6 @@ import {
   isSubagentSessionSpawn,
   linkedSubagentParentSessionId,
   projectLinkedSessionTree,
-  resolveLinkedSessionRootId,
   subagentSessionRuntimeSummary,
 } from '../session.js';
 import { isPermissionModeWithinCeiling } from '../permission.js';
@@ -161,21 +160,6 @@ describe('subagent session parent relation', () => {
     assert.equal(linkedSubagentParentSessionId(childA), 'parent-session');
     assert.equal(linkedSubagentParentSessionId(hostChild), 'parent-session');
     assert.equal(linkedSubagentParentSessionId(branch), undefined);
-  });
-
-  test('resolveLinkedSessionRootId walks linked parents for sidebar selection', () => {
-    const parent = summary('parent');
-    const child = summary('child', {
-      subagentParent: { ...relation, parentSessionId: parent.id },
-    });
-    const grandchild = summary('grandchild', {
-      subagentParent: { ...relation, parentSessionId: child.id },
-    });
-    const sessions = [parent, child, grandchild];
-    assert.equal(resolveLinkedSessionRootId(grandchild.id, sessions), parent.id);
-    assert.equal(resolveLinkedSessionRootId(child.id, sessions), parent.id);
-    assert.equal(resolveLinkedSessionRootId(parent.id, sessions), parent.id);
-    assert.equal(resolveLinkedSessionRootId(undefined, sessions), undefined);
   });
 
   test('projects linked children beneath parents while preserving branches and orphans', () => {

--- a/packages/core/src/__tests__/subagent-session-parent.test.ts
+++ b/packages/core/src/__tests__/subagent-session-parent.test.ts
@@ -8,7 +8,6 @@ import type {
 } from '../session.js';
 import {
   childSessionsForParent,
-  filterLinkedSessionTree,
   isLinkedSubagentSession,
   isSubagentSessionParent,
   isSubagentSessionRuntime,
@@ -209,43 +208,6 @@ describe('subagent session parent relation', () => {
       ['child-a', 'child-b'],
     );
     assert.equal(tree.childrenByParentId.size, 0);
-  });
-
-  test('filters every tree level and promotes matching descendants past hidden ancestors', () => {
-    const parent = summary('parent', { isFlagged: false, isArchived: false });
-    const archivedChild = summary('archived-child', {
-      isArchived: true,
-      subagentParent: { ...relation, parentSessionId: parent.id },
-    });
-    const flaggedGrandchild = summary('flagged-grandchild', {
-      isFlagged: true,
-      subagentParent: { ...relation, parentSessionId: archivedChild.id },
-    });
-    const tree = projectLinkedSessionTree([parent, archivedChild, flaggedGrandchild]);
-
-    const chats = filterLinkedSessionTree(tree, (session) => !session.isArchived);
-    assert.deepEqual(
-      chats.roots.map((session) => session.id),
-      ['parent'],
-    );
-    assert.deepEqual(
-      chats.childrenByParentId.get(parent.id)?.map((session) => session.id),
-      ['flagged-grandchild'],
-    );
-
-    const archived = filterLinkedSessionTree(tree, (session) => session.isArchived);
-    assert.deepEqual(
-      archived.roots.map((session) => session.id),
-      ['archived-child'],
-    );
-    assert.equal(archived.childrenByParentId.size, 0);
-
-    const flagged = filterLinkedSessionTree(tree, (session) => session.isFlagged);
-    assert.deepEqual(
-      flagged.roots.map((session) => session.id),
-      ['flagged-grandchild'],
-    );
-    assert.equal(flagged.childrenByParentId.size, 0);
   });
 });
 

--- a/packages/core/src/__tests__/subagent-session-parent.test.ts
+++ b/packages/core/src/__tests__/subagent-session-parent.test.ts
@@ -13,7 +13,9 @@ import {
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,
+  linkedSubagentParentSessionId,
   projectLinkedSessionTree,
+  resolveLinkedSessionRootId,
   subagentSessionRuntimeSummary,
 } from '../session.js';
 import { isPermissionModeWithinCeiling } from '../permission.js';
@@ -156,6 +158,24 @@ describe('subagent session parent relation', () => {
     assert.equal(isLinkedSubagentSession(childA), true);
     assert.equal(isLinkedSubagentSession(hostChild), true);
     assert.equal(isLinkedSubagentSession(branch), false);
+    assert.equal(linkedSubagentParentSessionId(childA), 'parent-session');
+    assert.equal(linkedSubagentParentSessionId(hostChild), 'parent-session');
+    assert.equal(linkedSubagentParentSessionId(branch), undefined);
+  });
+
+  test('resolveLinkedSessionRootId walks linked parents for sidebar selection', () => {
+    const parent = summary('parent');
+    const child = summary('child', {
+      subagentParent: { ...relation, parentSessionId: parent.id },
+    });
+    const grandchild = summary('grandchild', {
+      subagentParent: { ...relation, parentSessionId: child.id },
+    });
+    const sessions = [parent, child, grandchild];
+    assert.equal(resolveLinkedSessionRootId(grandchild.id, sessions), parent.id);
+    assert.equal(resolveLinkedSessionRootId(child.id, sessions), parent.id);
+    assert.equal(resolveLinkedSessionRootId(parent.id, sessions), parent.id);
+    assert.equal(resolveLinkedSessionRootId(undefined, sessions), undefined);
   });
 
   test('projects linked children beneath parents while preserving branches and orphans', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -374,7 +374,6 @@ export {
   SUBAGENT_SESSION_SPAWN_SCHEMA_VERSION,
   TURN_STATUSES,
   childSessionsForParent,
-  filterLinkedSessionTree,
   projectLinkedSessionTree,
   STEP_LIMIT_NOTICE_TEXT,
   deriveTurnRecords,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -381,6 +381,8 @@ export {
   isSessionStatus,
   isSessionBlockedReason,
   isLinkedSubagentSession,
+  linkedSubagentParentSessionId,
+  resolveLinkedSessionRootId,
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -382,7 +382,6 @@ export {
   isSessionBlockedReason,
   isLinkedSubagentSession,
   linkedSubagentParentSessionId,
-  resolveLinkedSessionRootId,
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -505,6 +505,37 @@ export function isLinkedSubagentSession(
   return linkedSubagentParentId(session) !== undefined;
 }
 
+/** Immediate linked parent session id, if this session is a linked child. */
+export function linkedSubagentParentSessionId(
+  session: Pick<SessionSummary, 'subagent' | 'subagentParent'>,
+): string | undefined {
+  return linkedSubagentParentId(session);
+}
+
+/**
+ * Walk linked-subagent parent pointers to the root session id for sidebar
+ * selection. When a child is open in the main column, the sidebar still only
+ * lists roots, so the parent (or further ancestor) should appear selected.
+ */
+export function resolveLinkedSessionRootId(
+  sessionId: string | undefined,
+  sessions: readonly Pick<SessionSummary, 'id' | 'subagent' | 'subagentParent'>[],
+): string | undefined {
+  if (!sessionId) return undefined;
+  const byId = new Map(sessions.map((session) => [session.id, session]));
+  let currentId = sessionId;
+  const visited = new Set<string>();
+  while (!visited.has(currentId)) {
+    visited.add(currentId);
+    const session = byId.get(currentId);
+    if (!session) return currentId;
+    const parentId = linkedSubagentParentId(session);
+    if (!parentId || !byId.has(parentId)) return currentId;
+    currentId = parentId;
+  }
+  return currentId;
+}
+
 /** Read-model projection; input order is preserved at every tree level. */
 export function projectLinkedSessionTree(
   sessions: readonly SessionSummary[],

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -512,30 +512,6 @@ export function linkedSubagentParentSessionId(
   return linkedSubagentParentId(session);
 }
 
-/**
- * Walk linked-subagent parent pointers to the root session id for sidebar
- * selection. When a child is open in the main column, the sidebar still only
- * lists roots, so the parent (or further ancestor) should appear selected.
- */
-export function resolveLinkedSessionRootId(
-  sessionId: string | undefined,
-  sessions: readonly Pick<SessionSummary, 'id' | 'subagent' | 'subagentParent'>[],
-): string | undefined {
-  if (!sessionId) return undefined;
-  const byId = new Map(sessions.map((session) => [session.id, session]));
-  let currentId = sessionId;
-  const visited = new Set<string>();
-  while (!visited.has(currentId)) {
-    visited.add(currentId);
-    const session = byId.get(currentId);
-    if (!session) return currentId;
-    const parentId = linkedSubagentParentId(session);
-    if (!parentId || !byId.has(parentId)) return currentId;
-    currentId = parentId;
-  }
-  return currentId;
-}
-
 /** Read-model projection; input order is preserved at every tree level. */
 export function projectLinkedSessionTree(
   sessions: readonly SessionSummary[],

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -562,39 +562,6 @@ function linkedSubagentParentId(
   return session.subagent?.parentSessionId;
 }
 
-/**
- * Filter a linked tree without leaking non-matching descendants through a
- * matching parent. Matching descendants whose ancestors do not match are
- * promoted to the nearest matching ancestor, or to a root when none exists.
- */
-export function filterLinkedSessionTree(
-  tree: LinkedSessionTree,
-  include: (session: SessionSummary) => boolean,
-): LinkedSessionTree {
-  const roots: SessionSummary[] = [];
-  const mutableChildren = new Map<string, SessionSummary[]>();
-
-  const visit = (session: SessionSummary, visibleParentId?: string): void => {
-    const included = include(session);
-    const nextVisibleParentId = included ? session.id : visibleParentId;
-    if (included) {
-      if (visibleParentId) {
-        const children = mutableChildren.get(visibleParentId) ?? [];
-        children.push(session);
-        mutableChildren.set(visibleParentId, children);
-      } else {
-        roots.push(session);
-      }
-    }
-    for (const child of tree.childrenByParentId.get(session.id) ?? []) {
-      visit(child, nextVisibleParentId);
-    }
-  };
-
-  for (const root of tree.roots) visit(root);
-  return { roots, childrenByParentId: mutableChildren };
-}
-
 function linkedParentChainContainsCycle(
   startSessionId: string,
   sessionsById: ReadonlyMap<string, SessionSummary>,

--- a/packages/ui/src/__tests__/subagent-open-session.test.tsx
+++ b/packages/ui/src/__tests__/subagent-open-session.test.tsx
@@ -1,0 +1,42 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { ToolResultContent } from '@maka/core';
+import { LocaleProvider } from '../locale-context.js';
+import { SubagentPreview } from '../tool-activity/agent-preview.js';
+
+function subagentResult(
+  overrides: Partial<Extract<ToolResultContent, { kind: 'subagent' }>> = {},
+): Extract<ToolResultContent, { kind: 'subagent' }> {
+  return {
+    kind: 'subagent',
+    agentName: 'explore · layout',
+    turnId: 'turn-1',
+    status: 'running',
+    permissionMode: 'ask',
+    summary: '',
+    artifactIds: [],
+    ...overrides,
+  };
+}
+
+function render(result: Extract<ToolResultContent, { kind: 'subagent' }>): string {
+  return renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <SubagentPreview result={result} onOpenSession={() => undefined} />
+    </LocaleProvider>,
+  );
+}
+
+describe('SubagentPreview open session', () => {
+  it('renders an open control when childSessionId and onOpenSession are present', () => {
+    const html = render(subagentResult({ childSessionId: 'child-1' }));
+    assert.match(html, /data-maka-contract="open-subagent-session"/);
+    assert.match(html, /Open session/);
+  });
+
+  it('hides the open control when childSessionId is missing', () => {
+    const html = render(subagentResult());
+    assert.doesNotMatch(html, /data-maka-contract="open-subagent-session"/);
+  });
+});

--- a/packages/ui/src/__tests__/subagent-open-session.test.tsx
+++ b/packages/ui/src/__tests__/subagent-open-session.test.tsx
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { ToolResultContent } from '@maka/core';
 import { LocaleProvider } from '../locale-context.js';
-import { SubagentPreview } from '../tool-activity/agent-preview.js';
+import { AgentSwarmPreview, SubagentPreview } from '../tool-activity/agent-preview.js';
 
 function subagentResult(
   overrides: Partial<Extract<ToolResultContent, { kind: 'subagent' }>> = {},
@@ -20,23 +20,109 @@ function subagentResult(
   };
 }
 
-function render(result: Extract<ToolResultContent, { kind: 'subagent' }>): string {
-  return renderToStaticMarkup(
-    <LocaleProvider locale="en">
-      <SubagentPreview result={result} onOpenSession={() => undefined} />
-    </LocaleProvider>,
-  );
+function swarmResult(
+  items: Extract<ToolResultContent, { kind: 'agent_swarm' }>['items'],
+): Extract<ToolResultContent, { kind: 'agent_swarm' }> {
+  return {
+    kind: 'agent_swarm',
+    status: 'completed',
+    items,
+    startedAt: 0,
+    completedAt: 1,
+    durationMs: 1,
+  };
 }
 
 describe('SubagentPreview open session', () => {
   it('renders an open control when childSessionId and onOpenSession are present', () => {
-    const html = render(subagentResult({ childSessionId: 'child-1' }));
+    const html = renderToStaticMarkup(
+      <LocaleProvider locale="en">
+        <SubagentPreview
+          result={subagentResult({ childSessionId: 'child-1' })}
+          onOpenSession={() => undefined}
+        />
+      </LocaleProvider>,
+    );
     assert.match(html, /data-maka-contract="open-subagent-session"/);
     assert.match(html, /Open session/);
   });
 
   it('hides the open control when childSessionId is missing', () => {
-    const html = render(subagentResult());
+    const html = renderToStaticMarkup(
+      <LocaleProvider locale="en">
+        <SubagentPreview result={subagentResult()} onOpenSession={() => undefined} />
+      </LocaleProvider>,
+    );
+    assert.doesNotMatch(html, /data-maka-contract="open-subagent-session"/);
+  });
+
+  it('hides the open control when the host omits onOpenSession', () => {
+    const html = renderToStaticMarkup(
+      <LocaleProvider locale="en">
+        <SubagentPreview result={subagentResult({ childSessionId: 'child-1' })} />
+      </LocaleProvider>,
+    );
+    assert.doesNotMatch(html, /data-maka-contract="open-subagent-session"/);
+  });
+});
+
+describe('AgentSwarmPreview open session', () => {
+  it('renders an open control for items that carry childSessionId', () => {
+    const html = renderToStaticMarkup(
+      <LocaleProvider locale="en">
+        <AgentSwarmPreview
+          result={swarmResult([
+            {
+              itemId: 'item-1',
+              index: 0,
+              profile: 'local_read',
+              started: true,
+              childSessionId: 'child-swarm-1',
+              agentName: 'reader',
+              status: 'completed',
+              summary: 'done',
+              artifactIds: [],
+            },
+            {
+              itemId: 'item-2',
+              index: 1,
+              profile: 'local_read',
+              started: true,
+              status: 'completed',
+              summary: 'no session',
+              artifactIds: [],
+            },
+          ])}
+          onOpenSession={() => undefined}
+        />
+      </LocaleProvider>,
+    );
+    assert.equal(
+      html.match(/data-maka-contract="open-subagent-session"/g)?.length,
+      1,
+      'only the item with childSessionId opens',
+    );
+  });
+
+  it('hides open controls when the host omits onOpenSession', () => {
+    const html = renderToStaticMarkup(
+      <LocaleProvider locale="en">
+        <AgentSwarmPreview
+          result={swarmResult([
+            {
+              itemId: 'item-1',
+              index: 0,
+              profile: 'local_read',
+              started: true,
+              childSessionId: 'child-swarm-1',
+              status: 'completed',
+              summary: 'done',
+              artifactIds: [],
+            },
+          ])}
+        />
+      </LocaleProvider>,
+    );
     assert.doesNotMatch(html, /data-maka-contract="open-subagent-session"/);
   });
 });

--- a/packages/ui/src/__tests__/titlebar-session-identity.test.tsx
+++ b/packages/ui/src/__tests__/titlebar-session-identity.test.tsx
@@ -13,7 +13,11 @@ import {
  * and the project only in the composer's WorkspacePicker (gone the moment a
  * session exists). So these assertions are about presence, not decoration.
  */
-function render(props: { sessionName: string; projectName?: string }): string {
+function render(props: {
+  sessionName: string;
+  projectName?: string;
+  parentName?: string;
+}): string {
   return renderToStaticMarkup(
     <LocaleProvider locale="en">
       <TitlebarSessionIdentity
@@ -22,6 +26,11 @@ function render(props: { sessionName: string; projectName?: string }): string {
         project={
           props.projectName
             ? { name: props.projectName, onOpenFolder: () => undefined }
+            : undefined
+        }
+        parentSession={
+          props.parentName
+            ? { name: props.parentName, onOpen: () => undefined }
             : undefined
         }
       />
@@ -62,6 +71,27 @@ describe('TitlebarSessionIdentity', () => {
       'project and session segments must both be buttons',
     );
     assert.doesNotMatch(html, /aria-current/);
+  });
+
+  it('inserts the parent session between project and child when a linked child is open', () => {
+    const html = render({
+      sessionName: 'explore · layout',
+      projectName: 'maka-agent',
+      parentName: 'Implement session ledger',
+    });
+    assert.match(html, /maka-agent/);
+    assert.match(html, /Implement session ledger/);
+    assert.match(html, /explore · layout/);
+    assert.ok(
+      html.indexOf('maka-agent') < html.indexOf('Implement session ledger') &&
+        html.indexOf('Implement session ledger') < html.indexOf('explore · layout'),
+      'trail order is project › parent › child',
+    );
+    assert.equal(
+      html.match(/<button[^>]*type="button"/g)?.length,
+      3,
+      'project, parent, and session segments must all be buttons',
+    );
   });
 
   it('truncates each segment on its own rather than wrapping the strip', () => {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -392,6 +392,11 @@ export const TurnView = memo(function TurnView(props: {
    * reaching into the desktop preload directly.
    */
   onReadAttachmentBytes?: ReadAttachmentBytes;
+  /**
+   * Open a linked subagent child session in the main chat column. Threaded into
+   * tool-detail SubagentPreview; omitted when the host has no navigation.
+   */
+  onOpenLinkedSession?(sessionId: string): void;
 }) {
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).messages;
@@ -570,12 +575,17 @@ export const TurnView = memo(function TurnView(props: {
                 through the derived fold as collapsed Processing blocks. */}
             {foldedTimeline.map((item, index) =>
               item.kind === 'processing' ? (
-                <ProcessingBlock key={`processing-${item.id}`} entries={item.children} />
+                <ProcessingBlock
+                  key={`processing-${item.id}`}
+                  entries={item.children}
+                  onOpenLinkedSession={props.onOpenLinkedSession}
+                />
               ) : (
                 <TurnTimelineEntry
                   key={timelineEntryKey(item, index)}
                   item={item}
                   onStreamingSettled={props.liveStreaming?.onStreamingSettled}
+                  onOpenLinkedSession={props.onOpenLinkedSession}
                 />
               ),
             )}
@@ -957,12 +967,15 @@ function timelineEntryKey(item: TurnTimelineItem, index: number): string {
 function TurnTimelineEntry(props: {
   item: TurnTimelineItem;
   onStreamingSettled?: (messageId?: string) => void;
+  onOpenLinkedSession?(sessionId: string): void;
 }) {
   const { item } = props;
   if (item.kind === 'thinking') {
     return <DeepThinking text={item.text} live={item.live === true} truncated={item.truncated === true} />;
   }
-  if (item.kind === 'tools') return <ToolTrow items={item.items} />;
+  if (item.kind === 'tools') {
+    return <ToolTrow items={item.items} onOpenLinkedSession={props.onOpenLinkedSession} />;
+  }
   if (item.kind === 'text' && item.live) {
     return (
       <StreamingAssistantBubble
@@ -976,12 +989,19 @@ function TurnTimelineEntry(props: {
   return <MessageBody role="assistant" text={item.text} ts={item.ts} />;
 }
 
-function ProcessingBlock(props: { entries: FoldedTimelineChild[] }) {
+function ProcessingBlock(props: {
+  entries: FoldedTimelineChild[];
+  onOpenLinkedSession?(sessionId: string): void;
+}) {
   const { entries } = props;
   return (
     <div className="maka-processing-sequence">
       {entries.map((entry, index) => (
-        <TurnTimelineEntry key={timelineEntryKey(entry, index)} item={entry} />
+        <TurnTimelineEntry
+          key={timelineEntryKey(entry, index)}
+          item={entry}
+          onOpenLinkedSession={props.onOpenLinkedSession}
+        />
       ))}
     </div>
   );

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -199,6 +199,11 @@ export function ChatView(props: {
    * reconciliation on the hot streaming path.
    */
   onReadAttachmentBytes?: ReadAttachmentBytes;
+  /**
+   * Open a linked subagent child session in the main chat column (option A).
+   * Threaded into SubagentPreview inside tool detail.
+   */
+  onOpenLinkedSession?(sessionId: string): void;
   onNew(): void;
   onPromptSuggestion?(prompt: string): void;
   /**
@@ -626,6 +631,7 @@ export function ChatView(props: {
                       lineageBadges={turnPresentation?.lineageBadgesByTurn[turn.turnId]}
                       onLineageBadgeClick={stableLineageBadgeClick}
                       onReadAttachmentBytes={props.onReadAttachmentBytes}
+                      onOpenLinkedSession={props.onOpenLinkedSession}
                       searchHighlighted={highlightedTurnId === turn.turnId}
                       liveStreaming={
                         turn.turnId === tailTurnId

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -201,7 +201,9 @@ export function ChatView(props: {
   onReadAttachmentBytes?: ReadAttachmentBytes;
   /**
    * Open a linked subagent child session in the main chat column (option A).
-   * Threaded into SubagentPreview inside tool detail.
+   * Threaded into SubagentPreview / AgentSwarmPreview inside tool detail.
+   * Pass an identity-stable reference so memoized TurnViews keep skipping
+   * reconciliation on the hot streaming path (ChatView also ref-wraps this).
    */
   onOpenLinkedSession?(sessionId: string): void;
   onNew(): void;
@@ -353,6 +355,12 @@ export function ChatView(props: {
   onLineageBadgeClickRef.current = props.onLineageBadgeClick;
   const stableLineageBadgeClick = useCallback(
     (targetTurnId: string) => onLineageBadgeClickRef.current?.(targetTurnId),
+    [],
+  );
+  const onOpenLinkedSessionRef = useRef(props.onOpenLinkedSession);
+  onOpenLinkedSessionRef.current = props.onOpenLinkedSession;
+  const stableOpenLinkedSession = useCallback(
+    (sessionId: string) => onOpenLinkedSessionRef.current?.(sessionId),
     [],
   );
   const conversationItemsByTurn = useMemo(() => {
@@ -631,7 +639,9 @@ export function ChatView(props: {
                       lineageBadges={turnPresentation?.lineageBadgesByTurn[turn.turnId]}
                       onLineageBadgeClick={stableLineageBadgeClick}
                       onReadAttachmentBytes={props.onReadAttachmentBytes}
-                      onOpenLinkedSession={props.onOpenLinkedSession}
+                      onOpenLinkedSession={
+                        props.onOpenLinkedSession ? stableOpenLinkedSession : undefined
+                      }
                       searchHighlighted={highlightedTurnId === turn.turnId}
                       liveStreaming={
                         turn.turnId === tailTurnId

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -22,8 +22,14 @@ export type { ChatSurfaceLayoutProps } from './chat-surface-layout.js';
 export { ChatView } from './chat-view.js';
 export { WorkspacePicker } from './workspace-picker.js';
 export type { WorkspacePickerModel } from './workspace-picker.js';
-export { deriveTitlebarProjectName, TitlebarSessionIdentity } from './titlebar-session-identity.js';
-export type { TitlebarProject } from './titlebar-session-identity.js';
+export {
+  deriveTitlebarProjectName,
+  TitlebarSessionIdentity,
+} from './titlebar-session-identity.js';
+export type {
+  TitlebarParentSession,
+  TitlebarProject,
+} from './titlebar-session-identity.js';
 export type {
   TurnFooterActionMeta,
   TurnLineageBadge,

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -271,6 +271,10 @@ export interface ConversationCopy {
     openProjectFolder: (name: string) => string;
     /** Action phrase appended to the titlebar project crumb's accessible name. */
     openProjectFolderAction: string;
+    /** Tooltip / accessible name for the parent crumb when a linked child is open. */
+    openParentSession: (name: string) => string;
+    /** Action phrase appended to the titlebar parent crumb's accessible name. */
+    openParentSessionAction: string;
     sessionContextMore: (count: number) => string;
     revisionVersionsAriaLabel: string;
     revisionVersion: (current: number, total: number) => string;
@@ -437,6 +441,7 @@ const CONVERSATION_COPY = {
       loadFailed: '对话载入失败', loading: '载入中…', retryLoad: '重试载入', quoteSelection: '引用', askInSidePanel: '在侧栏追问', noMessages: '暂无消息',
       branchBeforeInterrupt: '从中断前分支', sessionContextAriaLabel: '会话上下文', sessionLineageAriaLabel: '会话来源', sessionContextMore: (count) => `更多会话上下文（${count}）`,
       titlebarIdentityAriaLabel: '当前会话', openProjectFolder: (name) => `在文件管理器中打开「${name}」`, openProjectFolderAction: '打开项目文件夹',
+      openParentSession: (name) => `返回父会话「${name}」`, openParentSessionAction: '打开父会话',
       revisionVersionsAriaLabel: '对话版本', revisionVersion: (current, total) => `版本 ${current} / ${total}`, previousRevision: '查看上一版本', nextRevision: '查看下一版本',
     },
     sessions: {
@@ -580,6 +585,7 @@ const CONVERSATION_COPY = {
       loadFailed: 'Conversation failed to load', loading: 'Loading…', retryLoad: 'Retry', quoteSelection: 'Quote', askInSidePanel: 'Ask in side panel', noMessages: 'No messages yet',
       branchBeforeInterrupt: 'Branched before interruption', sessionContextAriaLabel: 'Session context', sessionLineageAriaLabel: 'Session origin', sessionContextMore: (count) => `More session context (${count})`,
       titlebarIdentityAriaLabel: 'Current conversation', openProjectFolder: (name) => `Open “${name}” in the file manager`, openProjectFolderAction: 'Open project folder',
+      openParentSession: (name) => `Return to parent session “${name}”`, openParentSessionAction: 'Open parent session',
       revisionVersionsAriaLabel: 'Conversation versions', revisionVersion: (current, total) => `Version ${current} of ${total}`, previousRevision: 'View previous version', nextRevision: 'View next version',
     },
     sessions: {

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -2,7 +2,6 @@ import {
   memo,
   useCallback,
   useEffect,
-  useMemo,
   useRef,
   useState,
   type KeyboardEvent,
@@ -16,7 +15,6 @@ import {
   AlertTriangle,
   Archive,
   ArchiveRestore,
-  Bot,
   FolderGit2,
   FolderOpen,
   Pencil,
@@ -74,7 +72,6 @@ export function SessionHistoryList(props: {
   groups?: ReadonlyArray<SessionHistoryGroup>;
   worktreeSessionIds?: ReadonlySet<string>;
   projectActions?: ProjectRowActions;
-  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
   groupVariant?: SessionHistoryGroupVariant;
   /** Optional section chrome (title + end actions) wrapping the history. */
   heading?: string;
@@ -122,7 +119,6 @@ export function SessionHistoryList(props: {
       activeId={props.activeId}
       streamingSessionIds={props.streamingSessionIds}
       staleSessionIds={props.staleSessionIds}
-      childSessionsByParentId={props.childSessionsByParentId}
       worktreeSessionIds={props.worktreeSessionIds}
       onSelectSession={props.onSelectSession}
       rowActions={props.rowActions}
@@ -159,7 +155,6 @@ function SessionListGroups(props: {
   activeId?: string;
   streamingSessionIds?: Set<string>;
   staleSessionIds?: Set<string>;
-  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
   worktreeSessionIds?: ReadonlySet<string>;
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
@@ -184,10 +179,6 @@ function SessionListGroups(props: {
    */
   const renameOpenerRef = useRef<HTMLElement | null>(null);
   const [archivedExpanded, setArchivedExpanded] = useState(false);
-  const activeAncestorIds = useMemo(
-    () => resolveActiveSessionAncestorIds(props.activeId, props.childSessionsByParentId),
-    [props.activeId, props.childSessionsByParentId],
-  );
 
   const startRename = useCallback((target: SessionRenameTarget, opener: HTMLElement | null) => {
     renameOpenerRef.current = opener;
@@ -214,32 +205,25 @@ function SessionListGroups(props: {
     });
   }
 
-  const renderSessionTree = useCallback(
-    function renderSessionTree(session: SessionSummary, nested: boolean): ReactNode {
-      const childSessions = props.childSessionsByParentId?.get(session.id);
-      return (
-        <SessionNavRow
-          key={session.id}
-          session={session}
-          nested={nested}
-          active={session.id === props.activeId}
-          streaming={props.streamingSessionIds?.has(session.id) ?? false}
-          stale={props.staleSessionIds?.has(session.id) ?? false}
-          worktree={props.worktreeSessionIds?.has(session.id) ?? false}
-          onSelectSession={props.onSelectSession}
-          actions={props.rowActions}
-          onStartRename={startRename}
-          childSessions={childSessions}
-          expandedForActiveDescendant={activeAncestorIds.has(session.id)}
-          renderSessionTree={childSessions?.length ? renderSessionTree : undefined}
-        />
-      );
-    },
+  // Linked subagent sessions open in the main chat column, not as nested
+  // sidebar rows. The host passes only root/user sessions here.
+  const renderSessionRow = useCallback(
+    (session: SessionSummary): ReactNode => (
+      <SessionNavRow
+        key={session.id}
+        session={session}
+        active={session.id === props.activeId}
+        streaming={props.streamingSessionIds?.has(session.id) ?? false}
+        stale={props.staleSessionIds?.has(session.id) ?? false}
+        worktree={props.worktreeSessionIds?.has(session.id) ?? false}
+        onSelectSession={props.onSelectSession}
+        actions={props.rowActions}
+        onStartRename={startRename}
+      />
+    ),
     [
-      activeAncestorIds,
       startRename,
       props.activeId,
-      props.childSessionsByParentId,
       props.onSelectSession,
       props.rowActions,
       props.staleSessionIds,
@@ -282,7 +266,7 @@ function SessionListGroups(props: {
               startRename({ kind: 'project', id: project.id, name: project.name }, opener);
             }
           }}
-          renderSession={(session) => renderSessionTree(session, false)}
+          renderSession={renderSessionRow}
         />
       );
     }
@@ -313,7 +297,7 @@ function SessionListGroups(props: {
     <>
       {renameDialog}
       {props.groups.map((group) => {
-        const items = group.sessions.map((session) => renderSessionTree(session, false));
+        const items = group.sessions.map((session) => renderSessionRow(session));
         if (!group.label) {
           return (
             <div key={group.key} className="maka-session-group">
@@ -388,7 +372,6 @@ function EndContentHitTarget(props: {
 
 const SessionNavRow = memo(function SessionNavRow(props: {
   session: SessionSummary;
-  nested: boolean;
   active: boolean;
   streaming: boolean;
   stale: boolean;
@@ -396,45 +379,22 @@ const SessionNavRow = memo(function SessionNavRow(props: {
   onSelectSession(sessionId: string): void;
   actions?: SessionRowActions;
   onStartRename(target: SessionRenameTarget, opener: HTMLElement | null): void;
-  childSessions?: readonly SessionSummary[];
-  expandedForActiveDescendant: boolean;
-  renderSessionTree?(session: SessionSummary, nested: boolean): ReactNode;
 }) {
   const locale = useUiLocale();
   const metaTitle = formatSessionMeta(props.session, locale);
-  const hasChildren = Boolean(props.childSessions?.length);
-  const [userCollapsed, setUserCollapsed] = useState<boolean | null>(null);
-  // A tree should not pay to mount every descendant before the user opens it.
-  // Keep the active session visible by forcing only its ancestor chain open;
-  // the active node itself may stay collapsed when it owns a large Swarm.
-  const isCollapsed = props.expandedForActiveDescendant
-    ? false
-    : (userCollapsed ?? true);
 
   return (
     <div
       className="maka-session-row"
       data-maka-contract="session-row"
       data-session-id={props.session.id}
-      data-subagent={props.nested ? 'true' : undefined}
       data-stale={props.stale ? 'true' : undefined}
       title={metaTitle}
     >
       <SideNavItem
         label={props.session.name}
-        // Nested (subagent) rows: native leading Bot icon keeps hierarchy
-        // readable without CSS nest-padding overrides. Parent rows stay iconless.
-        icon={props.nested ? Bot : undefined}
         size="md"
         isSelected={props.active}
-        collapsible={
-          hasChildren
-            ? {
-                isCollapsed,
-                onCollapsedChange: setUserCollapsed,
-              }
-            : undefined
-        }
         onClick={(event) => {
           if (event.detail > 1 && props.actions) {
             props.onStartRename(
@@ -458,43 +418,10 @@ const SessionNavRow = memo(function SessionNavRow(props: {
             onStartRename={props.onStartRename}
           />
         }
-      >
-        {hasChildren ? (
-          isCollapsed ? (
-            // Astryx derives disclosure chrome from `Boolean(children)`.
-            // A zero-layout sentinel preserves the chevron without mounting
-            // the expensive descendant tree while this node is collapsed.
-            <span className="maka-session-lazy-children-sentinel" aria-hidden="true" />
-          ) : (
-            props.childSessions?.map((child) => props.renderSessionTree?.(child, true))
-          )
-        ) : undefined}
-      </SideNavItem>
+      />
     </div>
   );
 });
-
-function resolveActiveSessionAncestorIds(
-  activeId: string | undefined,
-  childSessionsByParentId: ReadonlyMap<string, readonly SessionSummary[]> | undefined,
-): ReadonlySet<string> {
-  const ancestors = new Set<string>();
-  if (!activeId || !childSessionsByParentId) return ancestors;
-
-  const parentByChildId = new Map<string, string>();
-  for (const [parentId, children] of childSessionsByParentId) {
-    for (const child of children) parentByChildId.set(child.id, parentId);
-  }
-
-  const visited = new Set<string>([activeId]);
-  let parentId = parentByChildId.get(activeId);
-  while (parentId && !visited.has(parentId)) {
-    ancestors.add(parentId);
-    visited.add(parentId);
-    parentId = parentByChildId.get(parentId);
-  }
-  return ancestors;
-}
 
 function ProjectItemEndContent(props: {
   project?: ProjectRecord;

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -42,7 +42,6 @@ export function SessionListPanel(props: {
   groups?: ReadonlyArray<SessionHistoryGroup>;
   worktreeSessionIds?: ReadonlySet<string>;
   projectActions?: ProjectRowActions;
-  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
   viewMode?: SessionViewMode;
   onViewModeChange?: (mode: SessionViewMode) => void;
   onSelectSession(sessionId: string): void;
@@ -159,7 +158,6 @@ export function SessionListPanel(props: {
             groups={groups}
             worktreeSessionIds={props.worktreeSessionIds}
             projectActions={props.projectActions}
-            childSessionsByParentId={props.childSessionsByParentId}
             onSelectSession={props.onSelectSession}
             rowActions={props.rowActions}
             heading={onViewModeChange ? copy.title : undefined}

--- a/packages/ui/src/titlebar-session-identity.tsx
+++ b/packages/ui/src/titlebar-session-identity.tsx
@@ -43,7 +43,17 @@ export function deriveTitlebarProjectName(options: {
 }
 
 /**
- * The session's identity in the window titlebar: `project › session name`.
+ * Parent session trail segment for a linked subagent open in the main column.
+ * Clicking returns to the parent; the child is never listed in the sidebar.
+ */
+export interface TitlebarParentSession {
+  name: string;
+  onOpen(): void;
+}
+
+/**
+ * The session's identity in the window titlebar: `project › session name`,
+ * or `project › parent › child` when a linked subagent is open.
  *
  * Before this, an open session showed neither. The name lived only in the
  * sidebar list — gone the moment the sidebar was collapsed — and the project
@@ -55,7 +65,7 @@ export function deriveTitlebarProjectName(options: {
  * project, it is the trail `SessionContextLayer` already speaks for session
  * lineage, and it degrades to a single item when there is no project.
  *
- * The two interactive segments carve `no-drag` rectangles out of the titlebar's
+ * The interactive segments carve `no-drag` rectangles out of the titlebar's
  * drag surface, the same way the left rail and the workspace actions do. Each
  * covers only its own text, so the strip stays draggable around them.
  */
@@ -63,6 +73,8 @@ export function TitlebarSessionIdentity(props: {
   sessionName: string;
   onRenameSession(name: string): void;
   project?: TitlebarProject;
+  /** Immediate linked parent when viewing a child subagent session. */
+  parentSession?: TitlebarParentSession;
 }) {
   const copy = getConversationCopy(useUiLocale());
   const [renaming, setRenaming] = useState(false);
@@ -125,6 +137,19 @@ export function TitlebarSessionIdentity(props: {
             </span>
             <span className="maka-visually-hidden">
               {copy.chat.openProjectFolderAction}
+            </span>
+          </BreadcrumbItem>
+        ) : null}
+        {props.parentSession ? (
+          <BreadcrumbItem onClick={props.parentSession.onOpen}>
+            <span
+              className="maka-titlebar-identity__segment"
+              title={copy.chat.openParentSession(props.parentSession.name)}
+            >
+              {props.parentSession.name}
+            </span>
+            <span className="maka-visually-hidden">
+              {copy.chat.openParentSessionAction}
             </span>
           </BreadcrumbItem>
         ) : null}

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -159,7 +159,13 @@ function AutomationResultPreview(props: { text: string }) {
  * row's expansion state internally — this panel is the seam where the product
  * decides what a result looks like, and it is asserted directly.
  */
-export function ToolCallDetail({ item }: { item: ToolActivityItem }) {
+export function ToolCallDetail({
+  item,
+  onOpenLinkedSession,
+}: {
+  item: ToolActivityItem;
+  onOpenLinkedSession?(sessionId: string): void;
+}) {
   const locale = useUiLocale();
   const cancelled = isCancelledToolResult(item.result);
   const sandboxBlocked = isSandboxDeniedTool(item);
@@ -223,6 +229,7 @@ export function ToolCallDetail({ item }: { item: ToolActivityItem }) {
             toolName={item.toolName}
             args={item.args}
             shellRunSource={item.shellRunSource}
+            onOpenLinkedSession={onOpenLinkedSession}
           />
         )
       )}
@@ -265,7 +272,13 @@ export function ToolCallDetail({ item }: { item: ToolActivityItem }) {
               return <ToolCodeBlock code={invocationLine} />;
             }
             if (showResult && !ownsPanel && displayResult) {
-              return <ToolResultPreview content={displayResult} toolName={item.toolName} />;
+              return (
+                <ToolResultPreview
+                  content={displayResult}
+                  toolName={item.toolName}
+                  onOpenLinkedSession={onOpenLinkedSession}
+                />
+              );
             }
             if (showInvocation && invocationLine) {
               return <ToolCodeBlock code={invocationLine} />;
@@ -285,7 +298,13 @@ export function ToolCallDetail({ item }: { item: ToolActivityItem }) {
  * their own word in `errorMessage`, and the detail panel (banner, command,
  * output, previews) rides along in `resultDetail`.
  */
-export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
+export function ToolTrow({
+  items,
+  onOpenLinkedSession,
+}: {
+  items: ToolActivityItem[];
+  onOpenLinkedSession?(sessionId: string): void;
+}) {
   const locale = useUiLocale();
   if (items.length === 0) return null;
   const calls: ChatToolCallItem[] = items.map((item) => ({
@@ -303,7 +322,7 @@ export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
     ...diffStats(itemDiffs(item)),
     resultDetail: (
       <ToolDetailReveal>
-        <ToolCallDetail item={item} />
+        <ToolCallDetail item={item} onOpenLinkedSession={onOpenLinkedSession} />
       </ToolDetailReveal>
     ),
   }));

--- a/packages/ui/src/tool-activity/agent-preview.tsx
+++ b/packages/ui/src/tool-activity/agent-preview.tsx
@@ -93,6 +93,8 @@ function boundedAgentSwarmSummary(summary: string): string {
 
 export function SubagentPreview(props: {
   result: SubagentResult;
+  /** Host switches the main chat column to this linked child session. */
+  onOpenSession?(sessionId: string): void;
 }) {
   const locale = useUiLocale();
   const copy = getToolActivityCopy(locale).agent;
@@ -101,6 +103,9 @@ export function SubagentPreview(props: {
   const status = presentSubagentStatus(result.status, locale);
   const summary = typeof result.summary === 'string' ? result.summary.trim() : '';
   const artifactCount = result.artifactIds.length;
+  const agentLabel = redactSecrets(result.agentName || 'Subagent');
+  const childSessionId = result.childSessionId;
+  const canOpen = Boolean(childSessionId && props.onOpenSession);
   const meta = [
     status,
     presentSubagentPermission(result.permissionMode, locale),
@@ -110,8 +115,21 @@ export function SubagentPreview(props: {
   return (
     <div className={cn(previewVariants({ part: 'overlay' }), previewVariants({ part: 'agent' }))} data-kind="subagent" data-status={result.status}>
       <header className={previewVariants({ part: 'agent-head' })}>
-        <strong>{redactSecrets(result.agentName || 'Subagent')}</strong>
+        <strong>{agentLabel}</strong>
         <small>{meta}</small>
+        {canOpen && childSessionId && props.onOpenSession ? (
+          <div className={previewVariants({ part: 'agent-actions' })} role="group">
+            <UiButton
+              variant="ghost"
+              size="sm"
+              className={previewVariants({ part: 'agent-copy' })}
+              data-maka-contract="open-subagent-session"
+              onClick={() => props.onOpenSession?.(childSessionId)}
+              aria-label={copy.openSessionAriaLabel(agentLabel)}
+              label={copy.openSession}
+            />
+          </div>
+        ) : null}
       </header>
       {summary.length > 0 && (
         <section className={previewVariants({ part: 'agent-section' })} aria-label={copy.resultSummaryAriaLabel}>

--- a/packages/ui/src/tool-activity/agent-preview.tsx
+++ b/packages/ui/src/tool-activity/agent-preview.tsx
@@ -18,6 +18,8 @@ const AGENT_SWARM_PREVIEW_MAX_ITEMS = 32;
 
 export function AgentSwarmPreview(props: {
   result: AgentSwarmResult;
+  /** Host switches the main chat column to a linked swarm child session. */
+  onOpenSession?(sessionId: string): void;
 }) {
   const locale = useUiLocale();
   const copy = getToolActivityCopy(locale).agent;
@@ -63,6 +65,9 @@ export function AgentSwarmPreview(props: {
               item.runId ? `run ${redactSecrets(item.runId)}` : '',
               item.turnId ? `turn ${redactSecrets(item.turnId)}` : '',
             ].filter(Boolean).join(' · ');
+            const agentLabel = redactSecrets(item.agentName || item.itemId);
+            const openSession = props.onOpenSession;
+            const openSessionId = item.childSessionId;
 
             return (
               <li key={`${item.index}:${item.itemId}`} data-status={item.status}>
@@ -75,6 +80,19 @@ export function AgentSwarmPreview(props: {
                   </span>
                 )}
                 {refs && <code title={refs}>{refs}</code>}
+                {openSessionId && openSession ? (
+                  <div className={previewVariants({ part: 'agent-actions' })} role="group">
+                    <UiButton
+                      variant="ghost"
+                      size="sm"
+                      className={previewVariants({ part: 'agent-copy' })}
+                      data-maka-contract="open-subagent-session"
+                      onClick={() => openSession(openSessionId)}
+                      aria-label={copy.openSessionAriaLabel(agentLabel)}
+                      label={copy.openSession}
+                    />
+                  </div>
+                ) : null}
               </li>
             );
           })}
@@ -104,8 +122,8 @@ export function SubagentPreview(props: {
   const summary = typeof result.summary === 'string' ? result.summary.trim() : '';
   const artifactCount = result.artifactIds.length;
   const agentLabel = redactSecrets(result.agentName || 'Subagent');
-  const childSessionId = result.childSessionId;
-  const canOpen = Boolean(childSessionId && props.onOpenSession);
+  const openSession = props.onOpenSession;
+  const openSessionId = result.childSessionId;
   const meta = [
     status,
     presentSubagentPermission(result.permissionMode, locale),
@@ -117,14 +135,14 @@ export function SubagentPreview(props: {
       <header className={previewVariants({ part: 'agent-head' })}>
         <strong>{agentLabel}</strong>
         <small>{meta}</small>
-        {canOpen && childSessionId && props.onOpenSession ? (
+        {openSessionId && openSession ? (
           <div className={previewVariants({ part: 'agent-actions' })} role="group">
             <UiButton
               variant="ghost"
               size="sm"
               className={previewVariants({ part: 'agent-copy' })}
               data-maka-contract="open-subagent-session"
-              onClick={() => props.onOpenSession?.(childSessionId)}
+              onClick={() => openSession(openSessionId)}
               aria-label={copy.openSessionAriaLabel(agentLabel)}
               label={copy.openSession}
             />

--- a/packages/ui/src/tool-activity/copy.ts
+++ b/packages/ui/src/tool-activity/copy.ts
@@ -136,6 +136,9 @@ export interface ToolActivityCopy {
     artifacts: string;
     artifactCount: (count: number) => string;
     readOnly: string;
+    /** Open the linked child session in the main chat column. */
+    openSession: string;
+    openSessionAriaLabel: (name: string) => string;
     copyState: { pending: string; copied: string; failed: string; pendingAria: (label: string) => string; failedAria: (label: string) => string };
     copyButtons: Record<'summary' | 'continuation' | 'process' | 'evidence' | 'report' | 'candidate' | 'matches', { idle: string; copied: string }>;
     objectiveFallback: string;
@@ -222,6 +225,7 @@ const TOOL_ACTIVITY_COPY = {
     },
     agent: {
       subagentStatus: { completed: '已完成', failed: '失败', cancelled: '已取消', running: '运行中', waiting_for_user: '等待用户输入' }, duration: (value) => `耗时 ${value}`, resultSummaryAriaLabel: '子代理结果摘要', resultSummary: '结果摘要', artifactsAriaLabel: '子代理产物', artifacts: '产物', artifactCount: (n) => `${n} 个`, readOnly: '只读',
+      openSession: '打开会话', openSessionAriaLabel: (name) => `打开子代理会话「${name}」`,
       swarm: { status: { completed: '已完成', partial: '部分完成', failed: '失败', cancelled: '已取消' }, taskCount: (n) => `${n} 个任务`, completedCount: (n) => `${n} 完成`, failedCount: (n) => `${n} 失败`, cancelledCount: (n) => `${n} 取消`, artifactCount: (n) => `${n} 个产物`, resultsAriaLabel: 'Agent Swarm 结果', hiddenTaskCount: (n) => `另有 ${n} 个任务未显示` },
       copyState: { pending: '复制中…', copied: '已复制', failed: '复制失败', pendingAria: (label) => `${label}中`, failedAria: (label) => `${label}失败` },
       copyButtons: { summary: { idle: '复制摘要', copied: '已复制探索摘要' }, continuation: { idle: '复制续研提示', copied: '已复制续研提示' }, process: { idle: '复制过程', copied: '已复制探索过程' }, evidence: { idle: '复制证据', copied: '已复制证据锚点' }, report: { idle: '复制报告', copied: '已复制研究报告' }, candidate: { idle: '复制候选', copied: '已复制候选文件' }, matches: { idle: '复制片段', copied: '已复制命中片段' } },
@@ -281,6 +285,7 @@ const TOOL_ACTIVITY_COPY = {
     },
     agent: {
       subagentStatus: { completed: 'Completed', failed: 'Failed', cancelled: 'Cancelled', running: 'Running', waiting_for_user: 'Waiting for user input' }, duration: (value) => `Duration ${value}`, resultSummaryAriaLabel: 'Subagent result summary', resultSummary: 'Result summary', artifactsAriaLabel: 'Subagent artifacts', artifacts: 'Artifacts', artifactCount: (n) => `${n}`, readOnly: 'Read only',
+      openSession: 'Open session', openSessionAriaLabel: (name) => `Open subagent session “${name}”`,
       swarm: { status: { completed: 'Completed', partial: 'Partially completed', failed: 'Failed', cancelled: 'Cancelled' }, taskCount: (n) => `${n} ${n === 1 ? 'task' : 'tasks'}`, completedCount: (n) => `${n} completed`, failedCount: (n) => `${n} failed`, cancelledCount: (n) => `${n} cancelled`, artifactCount: (n) => `${n} ${n === 1 ? 'artifact' : 'artifacts'}`, resultsAriaLabel: 'Agent Swarm results', hiddenTaskCount: (n) => `${n} more ${n === 1 ? 'task is' : 'tasks are'} not shown` },
       copyState: { pending: 'Copying…', copied: 'Copied', failed: 'Copy failed', pendingAria: (label) => `Copying ${label}`, failedAria: (label) => `Failed to copy ${label}` },
       copyButtons: { summary: { idle: 'Copy summary', copied: 'Exploration summary copied' }, continuation: { idle: 'Copy continuation prompt', copied: 'Continuation prompt copied' }, process: { idle: 'Copy process', copied: 'Exploration process copied' }, evidence: { idle: 'Copy evidence', copied: 'Evidence anchors copied' }, report: { idle: 'Copy report', copied: 'Research report copied' }, candidate: { idle: 'Copy candidates', copied: 'Candidate files copied' }, matches: { idle: 'Copy matches', copied: 'Matching excerpts copied' } },

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -129,6 +129,8 @@ export function ToolResultPreview(props: {
   toolName?: string;
   args?: unknown;
   shellRunSource?: 'owned' | 'unavailable';
+  /** Open a linked subagent child session in the main chat column. */
+  onOpenLinkedSession?(sessionId: string): void;
 }) {
   const { content } = props;
   const locale = useUiLocale();
@@ -179,7 +181,12 @@ export function ToolResultPreview(props: {
   }
 
   if (content.kind === 'subagent') {
-    return <SubagentPreview result={content} />;
+    return (
+      <SubagentPreview
+        result={content}
+        onOpenSession={props.onOpenLinkedSession}
+      />
+    );
   }
 
   if (content.kind === 'agent_swarm') {

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -190,7 +190,12 @@ export function ToolResultPreview(props: {
   }
 
   if (content.kind === 'agent_swarm') {
-    return <AgentSwarmPreview result={content} />;
+    return (
+      <AgentSwarmPreview
+        result={content}
+        onOpenSession={props.onOpenLinkedSession}
+      />
+    );
   }
 
   if (content.kind === 'rive_workflow') {

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -76,7 +76,6 @@ function panelProps(input: {
   groups?: SessionListPanelProps['groups'];
   projectActions?: SessionListPanelProps['projectActions'];
   worktreeSessionIds?: SessionListPanelProps['worktreeSessionIds'];
-  childSessionsByParentId?: SessionListPanelProps['childSessionsByParentId'];
 }): SessionListPanelProps {
   return {
     selection: { section: 'sessions', filter: 'chats' },
@@ -87,9 +86,6 @@ function panelProps(input: {
     ...(input.groups ? { groups: input.groups } : {}),
     ...(input.projectActions ? { projectActions: input.projectActions } : {}),
     ...(input.worktreeSessionIds ? { worktreeSessionIds: input.worktreeSessionIds } : {}),
-    ...(input.childSessionsByParentId
-      ? { childSessionsByParentId: input.childSessionsByParentId }
-      : {}),
     onSelectSession: noop,
     onSelect: noop,
     onOpenSettings: noop,
@@ -306,42 +302,6 @@ export const PinnedAndRecentSections: Story = {
       />
     </StoryFrame>
   ),
-};
-
-// Real path: a parent session that spawned a linked child agent — child sits
-// under the parent with data-subagent + native Bot leading icon.
-export const NestedSubagentSessions: Story = {
-  render: () => {
-    const parent = makeSession({
-      id: 'parent-main',
-      name: '重构侧栏会话树',
-      status: 'running',
-      lastMessageAt: NOW - 3 * 60 * 1000,
-    });
-    const child = makeSession({
-      id: 'child-agent',
-      name: 'explore: 扫描 SideNav 用法',
-      status: 'done',
-      lastMessageAt: NOW - 2 * 60 * 1000,
-    });
-    const sibling = makeSession({
-      id: 'peer-session',
-      name: '无子代理的普通会话',
-      lastMessageAt: NOW - 20 * 60 * 1000,
-    });
-    return (
-      <StoryFrame>
-        <SessionListPanel
-          {...panelProps({
-            sessions: [parent, sibling],
-            activeId: 'child-agent',
-            streamingSessionIds: new Set(['parent-main']),
-            childSessionsByParentId: new Map([[parent.id, [child]]]),
-          })}
-        />
-      </StoryFrame>
-    );
-  },
 };
 
 // Real path: group-by-project — collapsible project rows, sessions flush under


### PR DESCRIPTION
## Summary

Linked subagent sessions no longer appear as nested rows in the sidebar. The session rail lists only root/user sessions; opening a child switches the main chat column (option A) and the titlebar shows `project › parent › child` so the parent stays one click away.

Entry point is the existing collapsible spawn_subagent tool group: expand a row and use **Open session** in the subagent tool detail when `childSessionId` is present. No parallel roster, composer drawer, strip, or custom card system.

Refs design lock in Storybook `Product/Subagent Sessions`.

## Verification

- `npm run build -w @maka/core` and `@maka/ui`
- `npm run build:main` / `build:renderer` for `@maka/desktop`
- Focused tests (all pass):
  - `packages/core/dist/__tests__/subagent-session-parent.test.js`
  - `packages/ui/dist/__tests__/titlebar-session-identity.test.js`
  - `packages/ui/dist/__tests__/subagent-open-session.test.js`
  - `apps/desktop/dist/main/__tests__/session-project-view-contract.test.js`
  - `apps/desktop/dist/main/__tests__/stale-sessions.test.js`
- Biome check on touched TS sources
- Not run: full workspace test suite, Playwright E2E

## Review focus

- Sidebar no longer receives `childSessionsByParentId`; tree projection still produces roots so children do not leak as top-level rows.
- While a child is active, sidebar selection highlights the root ancestor via `resolveLinkedSessionRootId`.
- Open affordance lives in tool detail (`SubagentPreview`) to avoid fighting ChatToolCalls row expand.