### PR TITLE
test(storage): relax bundle export lock timeout

### DIFF
--- a/packages/storage/src/__tests__/artifact-writer-lock.test.ts
+++ b/packages/storage/src/__tests__/artifact-writer-lock.test.ts
@@ -33,6 +33,7 @@ import { createSessionStore } from '../session-store.js';
 
 const TEST_TIMEOUT_MS = 15_000;
 const OPERATION_TIMEOUT_MS = 5_000;
+const BUNDLE_EXPORT_TIMEOUT_MS = 10_000;
 const COMPETING_PAYLOAD_BYTES = 4 * 1024 * 1024;
 // Windows does not permit replacing or deleting a directory while SQLite has files open in it.
 // These tests exercise POSIX root-replacement semantics; Windows coverage verifies cleanup after
@@ -383,7 +384,7 @@ test('bundle export excludes a mutation queued behind the same child-held writer
       await assertPending(mutation, 'Store mutation');
 
       await releaseHolder(holder);
-      await withTimeout(bundleExport, OPERATION_TIMEOUT_MS, 'bundle export');
+      await withTimeout(bundleExport, BUNDLE_EXPORT_TIMEOUT_MS, 'bundle export');
       await withTimeout(mutation, OPERATION_TIMEOUT_MS, 'Store mutation');
 
       const exportedStore = createSqliteArtifactStore(destinationRoot);
@@ -451,11 +452,15 @@ test('bundle export holds Artifact authority through selected-session projection
       await releaseHolder(holder);
       assert.equal(
         (
-          await withTimeout(projectedMessages, OPERATION_TIMEOUT_MS, 'selected-session projection')
+          await withTimeout(
+            projectedMessages,
+            BUNDLE_EXPORT_TIMEOUT_MS,
+            'selected-session projection',
+          )
         ).find((message) => message.type === 'user')?.text,
         'portable transcript',
       );
-      await withTimeout(bundleExport, OPERATION_TIMEOUT_MS, 'bundle export');
+      await withTimeout(bundleExport, BUNDLE_EXPORT_TIMEOUT_MS, 'bundle export');
     } finally {
       await stopHolder(holder);
     }


### PR DESCRIPTION
## Summary

- give bundle-export lock scenarios a dedicated 10-second watchdog
- keep the 5-second watchdog for ordinary Artifact writer-lock operations
- prevent a completed-but-slower SQLite backup from racing temporary-directory cleanup and surfacing a secondary `ENOTEMPTY`

## Root cause

On Node 26.5.1, `node:sqlite` online backup takes about 5.0 seconds after the test waits on a child-held Artifact writer lock. The test used the same 5-second operation timeout, so the timeout rejected while bundle export and the queued projection were still completing. Temporary-directory cleanup then raced those operations and often replaced the original timeout with `ENOTEMPTY`.

The same scenario completed in about 0.3 seconds on the repository's Node 24 CI runtime. Production code completed successfully on every observed Node 26 run, so this keeps the change at the test watchdog seam rather than changing lock, SQLite, or cleanup behavior.

## Verification

- before: Node 26.5.1 focused target, 50/50 failed (mostly `ENOTEMPTY`, some direct projection timeouts), about 5.4 seconds per run
- after: Node 26.5.1 focused target, 20/20 passed, about 5.44–5.50 seconds per run
- after: Node 24.18.1 focused target, 20/20 passed
- after: Node 26.5.1 `artifact-writer-lock.test`, 10/10 passed with `--test-concurrency=1`
- after: Node 24.18.1 `artifact-writer-lock.test`, 10/10 passed with `--test-concurrency=1`
- after: Node 24.18.1 `npm --workspace @maka/storage test`, 748 tests, 736 passed, 12 skipped, 0 failed
- `npx biome check packages/storage/src/__tests__/artifact-writer-lock.test.ts`
