### PR TITLE
feat(composer): stage attachments as Token chips with tooltip meta and lightbox

### DIFF
--- a/apps/desktop/e2e/attachment.spec.ts
+++ b/apps/desktop/e2e/attachment.spec.ts
@@ -67,16 +67,33 @@ test('a mixed attachment send has the Astryx message hierarchy', async ({ window
     );
   });
 
-  // Both attachment kinds appear in the composer before send: the file as a
-  // named two-line card, the image as a decoded Astryx Thumbnail — its
-  // filename lives in the accessible name (and hover tooltip), not visible
-  // text, once the preview probe passes.
-  await expect(page.getByText('note.txt')).toBeVisible();
-  const stagedThumbnail = page
-    .locator('.maka-composer-context-drawer')
-    .getByRole('group', { name: 'pixel.png' });
-  await expect(stagedThumbnail).toBeVisible();
-  await expect(stagedThumbnail.locator('img')).toBeVisible();
+  // Both attachment kinds stage as Token chips in the quote chips' rhythm,
+  // names visible on the chip itself (the full name + «EXT · size» meta ride
+  // the hover tooltip).
+  const chips = page.locator('.maka-composer-context-drawer .maka-composer-attachment-token');
+  await expect(chips.filter({ hasText: 'note.txt' })).toBeVisible();
+  const imageChip = chips.filter({ hasText: 'pixel.png' });
+  await expect(imageChip).toBeVisible();
+  // Once the preview decodes, the image chip becomes clickable (Token mounts
+  // its invisible button exactly then) and opens the Astryx Lightbox.
+  // exact: true — a bare name would also match the chip's remove button
+  // («移除 pixel.png»).
+  const imageChipButton = imageChip.getByRole('button', { name: 'pixel.png', exact: true });
+  await imageChipButton.click();
+  const stagedLightbox = page.getByRole('dialog');
+  await expect(stagedLightbox.getByRole('img', { name: 'pixel.png' })).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(stagedLightbox).not.toBeVisible();
+  // Native-dialog contract: closing hands focus back to the chip button that
+  // opened it — keyboard users must not be dropped on <body>. The Lightbox
+  // stays mounted through the close for exactly this.
+  await expect(imageChipButton).toBeFocused();
+  // Keyboard parity with hover: the focused chip surfaces the same
+  // «name · EXT · size» tooltip (focusTrigger="always" — Token's root span
+  // is not focusable, so focusin must bubble from the inner button).
+  await expect(
+    page.getByRole('tooltip').filter({ hasText: 'pixel.png · PNG' }),
+  ).toBeVisible();
 
   // Send the message carrying the attachment — the fake backend echoes the
   // attachment name, proving the ingest-on-send path delivered it (not just

--- a/apps/desktop/src/renderer/styles/astryx-mount.css
+++ b/apps/desktop/src/renderer/styles/astryx-mount.css
@@ -105,3 +105,16 @@
 .maka-window-titlebar [role="tooltip"] {
   pointer-events: none;
 }
+
+/* Lightbox media must breathe, not wallpaper: Astryx caps its <img> at 100%
+   of the dialog, and the dialog is the full viewport — a large screenshot
+   renders edge-to-edge with the close button sitting ON the image. Cap the
+   displayed box with a viewport margin instead; object-fit: contain keeps
+   the aspect ratio, zoom still scales via transform on top of this box, and
+   images smaller than the cap keep their natural size. One rule for every
+   Astryx lightbox (staged-attachment preview and the transcript's), so the
+   two viewers read identically. */
+.astryx-lightbox img {
+  max-width: min(100%, 86vw);
+  max-height: 80vh;
+}

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -98,107 +98,13 @@
   visibility: visible;
 }
 
-/* Staged non-image file — a two-line card in the idiom of contemporary agent
-   composers: kind icon on a tinted tile, filename, "EXT · size" meta. Fixed
-   64px height so cards and image thumbnails read as one row, not a staggered
-   pile; capped width + ellipsis so a full z-library book title cannot span
-   the card. */
-.maka-composer-attachment-card {
-  display: inline-flex;
-  align-items: center;
-  box-sizing: border-box;
-  height: 56px;
-  gap: var(--space-1-5);
+/* Staged attachments share the quote chips' Token rhythm (maintainer
+   decision on the #2367 follow-up); the drawer stays a flat chip row. Cap
+   the chip and let Astryx Token's own ellipsis truncate, so a full
+   z-library book title cannot span the drawer — the full name rides the
+   chip's hover Tooltip instead. */
+.maka-composer-context-drawer .maka-composer-attachment-token {
   max-width: min(280px, 100%);
-  padding: 0 var(--space-1-5);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-modal);
-  background: var(--background);
-}
-
-.maka-composer-attachment-card-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  flex: 0 0 auto;
-  border-radius: var(--radius-surface);
-  background: var(--muted);
-  color: var(--foreground-secondary);
-}
-
-/* Kind accents keep to existing semantic tokens (no new hues): documents that
-   read as "PDF red" everywhere else, code as the accent. */
-.maka-composer-attachment-card[data-kind="pdf"] .maka-composer-attachment-card-icon {
-  background: color-mix(in oklch, var(--status-danger, var(--destructive)) 12%, var(--background));
-  color: var(--status-danger, var(--destructive));
-}
-
-.maka-composer-attachment-card[data-kind="code"] .maka-composer-attachment-card-icon {
-  background: color-mix(in oklch, var(--accent) 12%, var(--background));
-  color: var(--accent);
-}
-
-.maka-composer-attachment-card-text {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  gap: 2px;
-}
-
-.maka-composer-attachment-card-name {
-  font-size: 13px;
-  font-weight: var(--font-weight-medium);
-  line-height: 1.25;
-  color: var(--foreground);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.maka-composer-attachment-card-meta {
-  font-size: 11px;
-  line-height: 1.2;
-  color: var(--muted-foreground);
-  white-space: nowrap;
-}
-
-.maka-composer-attachment-card-remove {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  flex: 0 0 auto;
-  padding: 0;
-  border: 0;
-  border-radius: var(--radius-pill);
-  background-color: transparent;
-  color: var(--muted-foreground);
-  cursor: pointer;
-}
-
-.maka-composer-attachment-card-remove:hover,
-.maka-composer-attachment-card-remove:focus-visible {
-  background-color: var(--muted);
-  color: var(--foreground);
-}
-
-/* Image thumbnails: hairline border + the same 12px radius as the file card,
-   so a mostly-white screenshot doesn't melt into the drawer surface.
-   `--radius-element` feeds Astryx Thumbnail's inner image container; 11px
-   (outer 12 − 1px border) nests the image corners flush against the border
-   instead of leaving a sliver of background in each corner. */
-.maka-composer-attachment-thumbnail {
-  /* local: --radius-element — Astryx Thumbnail's inner image radius; outer
-     radius minus the 1px border nests the image flush in the frame. */
-  --radius-element: calc(var(--radius-modal) - 1px);
-  width: 56px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-modal);
-  overflow: hidden;
-  background: var(--background);
 }
 
 .maka-composer-input {

--- a/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
+++ b/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
@@ -264,7 +264,7 @@ describe('composer quiet chrome', () => {
     assert.doesNotMatch(drawer, /data-mode=/);
   });
 
-  it('stages an image as a thumbnail preview and a file as an iconized token', () => {
+  it('stages every attachment as a Token chip; a decoded image chip is clickable', () => {
     const markup = render(
       <Composer
         onSend={() => true}
@@ -282,23 +282,37 @@ describe('composer quiet chrome', () => {
       markup.indexOf('maka-composer-context-drawer'),
       markup.indexOf('maka-composer-left-controls'),
     );
-    // An image with a host-supplied preview is a real Astryx Thumbnail showing
-    // those pixels — not a filename chip.
-    assert.match(drawer, /maka-composer-attachment-thumbnail/);
-    assert.match(drawer, /<img[^>]*src="blob:app\/shot"/);
-    // An image whose preview hasn't landed (or failed) renders as a NAMED file
-    // card — never an anonymous placeholder square.
-    const thumbCount = drawer.split('maka-composer-attachment-thumbnail').length - 1;
-    assert.equal(thumbCount, 1, 'only the previewable image is a thumbnail');
-    assert.match(drawer, /data-kind="image"/);
-    assert.match(drawer, /pending\.png/);
-    // A non-image file is a two-line card: kind icon tile, name, "EXT · size"
-    // meta, and a localized remove control — not a bare filename chip.
-    assert.match(drawer, /maka-composer-attachment-card/);
-    assert.match(drawer, /data-kind="doc"/);
+    // Maintainer decision on the #2367 follow-up: attachments keep the quote
+    // chips' Token rhythm — no inline thumbnails, no two-line cards.
+    assert.doesNotMatch(drawer, /maka-composer-attachment-thumbnail/);
+    assert.doesNotMatch(drawer, /maka-composer-attachment-card/);
+    const chipCount = drawer.split('maka-composer-attachment-token').length - 1;
+    assert.equal(chipCount, 3, 'every attachment is one Token chip');
+    // Kind icons ride the chips (image + doc here), names stay visible text.
+    assert.match(drawer, /lucide-file-image/);
+    assert.match(drawer, /lucide-file-type/);
     assert.match(drawer, /premier-league-tactics\.epub/);
-    assert.match(drawer, /EPUB · 3\.0 MB/);
-    assert.match(drawer, /aria-label="移除 premier-league-tactics\.epub"/);
+    // Only the decoded image is interactive: Token renders its invisible
+    // button (real button semantics) exactly when onClick is wired, and the
+    // lightbox trigger exists only for a set previewUrl.
+    assert.match(
+      drawer,
+      /<button[^>]*type="button"[^>]*>(?:<span[^>]*>)?shot\.png/,
+      'the previewable image chip must be clickable',
+    );
+    assert.doesNotMatch(
+      drawer,
+      /<button[^>]*type="button"[^>]*>(?:<span[^>]*>)?pending\.png/,
+      'an image without a decoded preview stays inert',
+    );
+    // The full name and «EXT · size» meta ride the chip's Tooltip.
+    assert.match(drawer, /premier-league-tactics\.epub · EPUB · 3\.0 MB/);
+    // Astryx Token owns the remove affordance. English here because this
+    // render mounts no AstryxLocaleProvider — the zh catalog override
+    // (@astryx.token.remove) is covered by the localization suites.
+    assert.match(drawer, /aria-label="Remove premier-league-tactics\.epub"/);
+    // No lightbox mounts until a chip is actually clicked.
+    assert.doesNotMatch(markup, /astryx-lightbox/);
   });
 
   it('shows a single voice control only when the host wires capture', () => {

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -23,7 +23,6 @@ import {
   Sparkles,
   Upload,
   Workflow,
-  X,
 } from './icons.js';
 import {
   ChatModelSwitcher,
@@ -58,8 +57,9 @@ import {
   ChatComposerDrawer,
   ChatComposerInput,
   IconButton,
-  Thumbnail,
+  Lightbox,
   Token,
+  Tooltip,
   useChatPasteAsToken,
   type ChatComposerInputHandle,
   type ChatComposerToken,
@@ -206,8 +206,9 @@ export const Composer = forwardRef<
       mimeType?: string;
       size: number;
       /** Renderer-resolvable image source (object/data URL) for `kind: 'image'`
-       *  previews. While absent (still loading, or preview failed) the image
-       *  renders as a named file card instead of a thumbnail. */
+       *  previews. When set, the chip is clickable and opens the image in a
+       *  Lightbox; while absent (still loading, or preview failed) the chip is
+       *  inert like any other kind. */
       previewUrl?: string;
     }[];
     onRemoveAttachment?(index: number): void;
@@ -1131,6 +1132,24 @@ export const Composer = forwardRef<
    */
   const drawerTokenCount =
     (props.pendingQuotes?.length ?? 0) + (props.pendingAttachments?.length ?? 0);
+  /** The last staged image opened from a chip (Lightbox media shape). Kept
+   *  mounted after close — see the Lightbox render — so only the open flag
+   *  drives visibility. */
+  const [attachmentLightbox, setAttachmentLightbox] = useState<{
+    src: string;
+    alt: string;
+    caption: string;
+  } | null>(null);
+  const [attachmentLightboxOpen, setAttachmentLightboxOpen] = useState(false);
+  useEffect(() => {
+    if (attachmentLightboxOpen || !attachmentLightbox) return;
+    // Unmount one commit AFTER the closed render, never in it: child effects
+    // run first, so Astryx has already executed dialog.close() — the native
+    // hand-back of focus to the chip button — by the time this fires. The
+    // deferred unmount also keeps the DOM to a single .astryx-lightbox for
+    // the chat transcript's own lightbox.
+    setAttachmentLightbox(null);
+  }, [attachmentLightboxOpen, attachmentLightbox]);
   /**
    * The session modes that are currently on, in the order the ＋ menu lists
    * them. The menu stays the switch — it turns each mode on *and* off; these
@@ -1313,57 +1332,53 @@ export const Composer = forwardRef<
                   const onRemove = props.onRemoveAttachment
                     ? () => props.onRemoveAttachment?.(index)
                     : undefined;
-                  // Astryx-standard rendering (per maintainer guidance): images
-                  // with a resolved preview get a real Thumbnail; everything
-                  // else — other kinds, AND images whose preview failed or is
-                  // still loading — gets the two-line file card, so nothing
-                  // ever sits in the drawer as an anonymous placeholder square.
-                  if (attachment.kind === 'image' && attachment.previewUrl) {
-                    return (
-                      <Thumbnail
-                        key={`${attachment.displayName}-${index}`}
-                        className="maka-composer-attachment-thumbnail"
-                        src={attachment.previewUrl}
-                        label={attachment.displayName}
-                        onRemove={onRemove}
-                      />
-                    );
-                  }
+                  // Astryx-standard rendering (maintainer decision on #2367's
+                  // follow-up): every attachment is a Token in the same chip
+                  // rhythm as quotes — kind icon + truncated name. The full
+                  // name and «EXT · size» meta live in a hover/focus Tooltip,
+                  // and an image with a decoded preview opens it in a
+                  // Lightbox on click instead of rendering an inline
+                  // thumbnail.
                   const extension = attachmentExtensionLabel(attachment.displayName);
                   const sizeLabel = formatPreviewSize(attachment.size, locale);
+                  // One string for both surfaces (chip tooltip + lightbox
+                  // caption), so the wording cannot drift between them.
+                  const detail = `${attachment.displayName} · ${
+                    extension ? `${extension} · ${sizeLabel}` : sizeLabel
+                  }`;
+                  const previewUrl =
+                    attachment.kind === 'image' ? attachment.previewUrl : undefined;
                   return (
-                    <span
+                    <Tooltip
                       key={`${attachment.displayName}-${index}`}
-                      className="maka-composer-attachment-card"
-                      data-kind={attachment.kind}
+                      content={detail}
+                      // "always", not the default "auto": the tooltip anchors
+                      // Token's non-focusable root span, so auto would never
+                      // attach focus listeners. focusin bubbles from the
+                      // chip's inner buttons, giving keyboard users the same
+                      // metadata hover shows.
+                      focusTrigger="always"
                     >
-                      <span className="maka-composer-attachment-card-icon" aria-hidden="true">
-                        <AttachmentKindIcon kind={attachment.kind} />
-                      </span>
-                      <span className="maka-composer-attachment-card-text">
-                        <span
-                          className="maka-composer-attachment-card-name"
-                          title={attachment.displayName}
-                        >
-                          {attachment.displayName}
-                        </span>
-                        <span className="maka-composer-attachment-card-meta">
-                          {extension ? `${extension} · ${sizeLabel}` : sizeLabel}
-                        </span>
-                      </span>
-                      {onRemove && (
-                        <button
-                          type="button"
-                          className="maka-composer-attachment-card-remove"
-                          aria-label={getConversationCopy(locale).messages.removeAttachmentAriaLabel(
-                            attachment.displayName,
-                          )}
-                          onClick={onRemove}
-                        >
-                          <X size={13} aria-hidden="true" />
-                        </button>
-                      )}
-                    </span>
+                      <Token
+                        size="sm"
+                        className="maka-composer-attachment-token"
+                        icon={<AttachmentKindIcon kind={attachment.kind} />}
+                        label={attachment.displayName}
+                        onRemove={onRemove}
+                        onClick={
+                          previewUrl
+                            ? () => {
+                                setAttachmentLightbox({
+                                  src: previewUrl,
+                                  alt: attachment.displayName,
+                                  caption: detail,
+                                });
+                                setAttachmentLightboxOpen(true);
+                              }
+                            : undefined
+                        }
+                      />
+                    </Tooltip>
                   );
                 })}
               </div>
@@ -1679,6 +1694,20 @@ export const Composer = forwardRef<
           )}
         />
       </form>
+      {attachmentLightbox && (
+        <Lightbox
+          // Driven by the flag, never by unmounting: the component must
+          // survive the close so Astryx runs dialog.close(), which is what
+          // hands focus back to the chip button that opened it (the native
+          // <dialog> contract keyboard users rely on).
+          isOpen={attachmentLightboxOpen}
+          onOpenChange={(isOpen) => {
+            if (!isOpen) setAttachmentLightboxOpen(false);
+          }}
+          hasZoom
+          media={attachmentLightbox}
+        />
+      )}
     </>
   );
 });


### PR DESCRIPTION

<img width="736" height="271" alt="image" src="https://github.com/user-attachments/assets/f0993254-c2e2-48cb-b9c3-2bcc4c58557c" />
<img width="772" height="219" alt="image" src="https://github.com/user-attachments/assets/fa7f58e0-7350-4733-b2ac-bb31cd6fbba3" />


## What

Follow-up to #2367, implementing the maintainer's direction: staged attachments drop the inline thumbnails / two-line cards and keep the **quote chips' Astryx Token rhythm** —

- every attachment is one `Token`: kind icon + truncated name (280px cap, Token's own ellipsis)
- full name and `EXT · size` meta ride an Astryx `Tooltip` on **hover and keyboard focus** (`focusTrigger="always"` — the tooltip anchors Token's non-focusable root span, so the default `auto` would never attach focus listeners; `focusin` bubbles from the chip's inner buttons)
- an image whose preview has decoded is clickable and opens in an Astryx `Lightbox` (zoomable, native `<dialog>`); Token mounts its invisible button exactly when `onClick` is wired, so only previewable images read as interactive
- images still loading (or that failed the decode probe) stay inert chips like any other kind — never an anonymous placeholder

## Keyboard contracts

- **Focus restoration:** the Lightbox is driven by an open flag and unmounts one commit *after* the closed render (child effects run first), so Astryx always executes `dialog.close()` — the native hand-back of focus to the chip button — before the component goes away. The deferred unmount also keeps the DOM to a single `.astryx-lightbox` alongside the transcript's own viewer.
- Both paths are pinned by the attachment e2e: after Escape, focus lands back on the chip button, and the focused chip re-surfaces its metadata tooltip.

## Lightbox sizing

Astryx caps its lightbox `<img>` at 100% of the full-viewport dialog, so large screenshots rendered edge-to-edge with the close button on the image. One rule in `astryx-mount.css` caps the displayed box at `86vw × 80vh` for both viewers (staged preview + transcript): aspect kept, zoom unaffected, small images stay natural size. Verified via CDP: a 2512×1652 original displays at 998×656 in a 1240×820 window.

## How

Pure presentation swap in `composer.tsx` + CSS: the card/thumbnail styles are deleted (dead-CSS check clean), and the whole preview pipeline from #2367 is unchanged — sequential loads, stat-sized reads, `Image.decode()` probes, stagingKey lifecycle. `previewUrl` now feeds the lightbox instead of an inline thumbnail. The chip tooltip and lightbox caption share one composed string so the wording cannot drift.

## Tests

- ui 477 / desktop 1789 / e2e attachment spec — all green; console/a11y/copy/dead-CSS/format checks clean
- `composer-quiet-chrome` asserts the chip contract: three chips for three attachments, kind icons, SSR'd tooltip meta, clickable-only-when-decoded, no lightbox mounted until a chip is clicked
- e2e drives the full flow: drop txt+png → both chips visible by name → click the image chip → lightbox shows the image → Escape closes → **focus returns to the chip and the tooltip re-surfaces** → send delivers both attachments

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Ac5rv6WUKWtMZgQb5QPN16