### PR TITLE
fix(storage): keep portable path tests stable on Windows

### DIFF
--- a/packages/storage/src/__tests__/foreign-session-store.test.ts
+++ b/packages/storage/src/__tests__/foreign-session-store.test.ts
@@ -2,13 +2,14 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, win32 } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import {
   FOREIGN_SESSION_SCAN_MAX_SESSIONS,
   type ForeignSessionSummary,
 } from '@maka/core/foreign-session';
 import {
+  codexCwdSqlVariants,
   createForeignSessionStore,
   isClaudeCodeImportEnabled,
   isCodexImportEnabled,
@@ -294,6 +295,13 @@ describe('foreign session store — Claude scan', () => {
 });
 
 describe('foreign session store — Codex scan', () => {
+  it('includes POSIX-shaped SQL variants for a native Windows cwd', () => {
+    const native = win32.join('C:\\', 'Users', 'me', 'project');
+    const variants = codexCwdSqlVariants(native);
+    assert.ok(variants.includes('C:/Users/me/project'));
+    assert.ok(variants.includes('C:/Users/me/project/'));
+  });
+
   it('lists threads from sqlite, dropping archived and foreign-source rows', async () => {
     const home = await tempHome();
     await seedCodexSqlite(home, [

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -536,7 +536,7 @@ describe('SqliteSessionMetadataStore', () => {
         turnId: 'turn-1',
         expansion: {
           filesystem: {
-            entries: [{ path: join(tmpdir(), 'maka-output'), access: 'write', scope: 'exact' }],
+            entries: [{ path: '/tmp/maka-output', access: 'write', scope: 'exact' }],
           },
         },
         justification: 'Write a temporary output.',

--- a/packages/storage/src/foreign-session-store.ts
+++ b/packages/storage/src/foreign-session-store.ts
@@ -574,9 +574,9 @@ async function readCodexThreadRows(
       // before the authoritative two-sided normalizePath() comparison in
       // codexRowsToSummaries(); SQL cannot run normalizePath on the stored side.
       if (cwdFilter !== undefined && columns.has('cwd')) {
-        const norm = normalizePath(cwdFilter);
-        where.push('(cwd = ? OR cwd = ?)');
-        params.push(norm, norm + sep);
+        const variants = coarseCwdVariants(cwdFilter);
+        where.push(`cwd IN (${variants.map(() => '?').join(', ')})`);
+        params.push(...variants);
       }
       const orderColumn = columns.has('updated_at_ms')
         ? 'updated_at_ms'
@@ -683,4 +683,15 @@ function rolloutFilenameMatchesId(base: string, id: string): boolean {
 function normalizePath(path: string): string {
   const resolved = resolve(path);
   return resolved.endsWith(sep) && resolved !== sep ? resolved.slice(0, -1) : resolved;
+}
+
+function coarseCwdVariants(path: string): string[] {
+  const variants = new Set<string>();
+  for (const candidate of [path, normalizePath(path)]) {
+    const withoutTrailingSeparator = candidate.replace(/[\\/]+$/, '') || candidate;
+    variants.add(withoutTrailingSeparator);
+    variants.add(`${withoutTrailingSeparator}/`);
+    variants.add(`${withoutTrailingSeparator}\\`);
+  }
+  return [...variants];
 }

--- a/packages/storage/src/foreign-session-store.ts
+++ b/packages/storage/src/foreign-session-store.ts
@@ -569,12 +569,11 @@ async function readCodexThreadRows(
       // Filter cwd IN SQL, before LIMIT: otherwise a multi-project store with
       // many newer threads from other directories fills the LIMIT window and
       // the target project's older thread never reaches the JS-side filter.
-      // This is a COARSE pre-filter — the exact normalized path or its
-      // trailing-separator variant — so a stored `/target/` isn't dropped
-      // before the authoritative two-sided normalizePath() comparison in
-      // codexRowsToSummaries(); SQL cannot run normalizePath on the stored side.
+      // This is a COARSE pre-filter across source-native and host-normalized
+      // separator forms. The authoritative two-sided normalizePath()
+      // comparison still runs in codexRowsToSummaries().
       if (cwdFilter !== undefined && columns.has('cwd')) {
-        const variants = coarseCwdVariants(cwdFilter);
+        const variants = codexCwdSqlVariants(cwdFilter);
         where.push(`cwd IN (${variants.map(() => '?').join(', ')})`);
         params.push(...variants);
       }
@@ -685,13 +684,19 @@ function normalizePath(path: string): string {
   return resolved.endsWith(sep) && resolved !== sep ? resolved.slice(0, -1) : resolved;
 }
 
-function coarseCwdVariants(path: string): string[] {
+export function codexCwdSqlVariants(path: string): string[] {
   const variants = new Set<string>();
   for (const candidate of [path, normalizePath(path)]) {
-    const withoutTrailingSeparator = candidate.replace(/[\\/]+$/, '') || candidate;
-    variants.add(withoutTrailingSeparator);
-    variants.add(`${withoutTrailingSeparator}/`);
-    variants.add(`${withoutTrailingSeparator}\\`);
+    for (const separatorForm of [
+      candidate,
+      candidate.replaceAll('\\', '/'),
+      candidate.replaceAll('/', '\\'),
+    ]) {
+      const withoutTrailingSeparator = separatorForm.replace(/[\\/]+$/, '') || separatorForm;
+      variants.add(withoutTrailingSeparator);
+      variants.add(`${withoutTrailingSeparator}/`);
+      variants.add(`${withoutTrailingSeparator}\\`);
+    }
   }
   return [...variants];
 }


### PR DESCRIPTION
## Summary

- preserve both source-native and host-normalized cwd variants in the Codex SQLite coarse filter
- keep the authoritative two-sided cwd comparison after the SQL `LIMIT`
- use a domain-valid POSIX sandbox path in the session-metadata test instead of the Windows host temp path

Part of #2142 Phase 1.

## Why

On Windows, `path.resolve('/target')` becomes a drive-qualified native path before the Codex thread query runs. The SQL pre-filter therefore discarded rows storing Codex's POSIX cwd before the existing JavaScript normalization could compare them. Separately, the sandbox-boundary fixture passed `tmpdir()` into a contract that intentionally accepts normalized absolute POSIX paths.

## Validation

- `npm --workspace @maka/storage run build`
- targeted Codex cwd tests: 3/3 pass on Windows
- targeted sandbox-boundary settlement test: pass on Windows
- `npx biome check` for changed files
- `git diff --check`
- combined local Windows storage baseline with #2365: `678 pass / 14 fail / 45 skip`, improved from `677 pass / 18 fail / 44 skip`