### PR TITLE
refactor(ui): name what a status means, in one place

### DIFF
--- a/apps/desktop/src/renderer/mcp-page.tsx
+++ b/apps/desktop/src/renderer/mcp-page.tsx
@@ -56,7 +56,10 @@ import {
   useToast,
   useUiLocale,
   type ModuleHubHeader,
+  dotForStatus,
+  type StatusSemantic,
 } from '@maka/ui';
+
 import {
   FileCode,
   Globe,
@@ -788,14 +791,25 @@ function McpServerInspector(props: {
   );
 }
 
-function mcpStatusDotVariant(state: { tone: 'neutral' | 'info' | 'success' | 'warning' | 'error' }): 'accent' | 'warning' | 'error' | 'neutral' {
-  // A failed connection is the one exceptional state; connected is the one
-  // live state worth the accent. Connecting is transient and indistinguishable
-  // from it by colour alone, so it stays neutral with the quiet states.
+function mcpStatusSemantic(state: { tone: 'neutral' | 'info' | 'success' | 'warning' | 'error' }): StatusSemantic {
   if (state.tone === 'error') return 'error';
-  if (state.tone === 'warning') return 'warning';
-  if (state.tone === 'success') return 'accent';
+  if (state.tone === 'warning') return 'attention';
+  // A connected server is healthy, not merely busy, so it takes success rather
+  // than the accent it used to borrow. That accent was a workaround from
+  // before this page had a word for "success" — accent means "live" everywhere
+  // else (a reminder waiting to fire wears it), and spending it on health made
+  // a connected server read as an in-flight one.
+  if (state.tone === 'success') return 'success';
+  // `info` here is genuinely quiet: 连接中 is transient and says nothing the
+  // user must act on, so it sits with the neutral states rather than claiming
+  // the eye. Other surfaces read their own `info` as "something is happening"
+  // and choose `active` — which is why the vocabulary has no `info` rung for
+  // them to disagree inside of.
   return 'neutral';
+}
+
+function mcpStatusDotVariant(state: { tone: 'neutral' | 'info' | 'success' | 'warning' | 'error' }) {
+  return dotForStatus(mcpStatusSemantic(state));
 }
 function McpEditorDialog(props: {
   state: Exclude<EditorState, null>;

--- a/apps/desktop/src/renderer/settings/memory-settings-labels.ts
+++ b/apps/desktop/src/renderer/settings/memory-settings-labels.ts
@@ -68,6 +68,12 @@ export function localMemoryPromptPreviewBlockedReason(state: LocalMemoryState, c
   return '';
 }
 
+// NOT migrated to the shared vocabulary yet, deliberately. This feeds the
+// settings surface's own `statusDotVariant` (settings-status-badge.ts, nine
+// files), and its `disabled` state is one of the nine `info` states awaiting a
+// batch semantic ruling: `info` renders as the accent dot there, so moving it
+// to `neutral` would be a visible colour change — exactly what this pass is
+// not allowed to make on its own. It migrates with the settings surface.
 export function memoryStatusTone(status: LocalMemoryState['status']): 'success' | 'info' | 'warning' | 'destructive' {
   switch (status) {
     case 'ok': return 'success';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -80,6 +80,9 @@ export type { PageHeaderProps } from './primitives/page-header.js';
 // incident-console archetype). Born in this package for 定时任务 / 每日回顾;
 // exported so the renderer-owned MCP page renders the same surface.
 export { ModulePage, type ModulePageProps } from './primitives/module-page.js';
+// One vocabulary for what a state MEANS, and one place deciding what each
+// word looks like — see status-vocabulary.ts for why there is no `info`.
+export { dotForStatus, type StatusSemantic } from './status-vocabulary.js';
 // One tab stop per module-page row list; the MCP page (renderer-owned) uses
 // the same hook the skills and plan-reminder panels do.
 export { useRovingRowFocus, type RovingRowFocusProps } from './use-roving-row-focus.js';

--- a/packages/ui/src/plan-reminder-status.ts
+++ b/packages/ui/src/plan-reminder-status.ts
@@ -1,30 +1,39 @@
 import type { PlanReminder, PlanReminderStatus } from '@maka/core';
+import { dotForStatus, type StatusSemantic } from './status-vocabulary.js';
 
 /**
- * Lifecycle tone for a reminder itself: paused is the only state that asks for
- * attention, completed is spent, everything else is simply live.
+ * Lifecycle meaning for a reminder itself: paused is the only state that asks
+ * for attention, completed is spent, everything else is simply live.
  *
  * Shared by the list page and the inspector so one reminder never reads as two
- * different severities depending on where it is shown.
+ * different severities depending on where it is shown. Says what the state
+ * MEANS and lets status-vocabulary decide the colour — the domain judgement
+ * (that paused deserves attention) is this file's, the palette is not.
  */
-export function planReminderStatusDotVariant(
-  status: PlanReminderStatus,
-): 'accent' | 'warning' | 'neutral' {
-  if (status === 'paused') return 'warning';
+export function planReminderStatusSemantic(status: PlanReminderStatus): StatusSemantic {
+  if (status === 'paused') return 'attention';
   if (status === 'completed') return 'neutral';
-  return 'accent';
+  return 'active';
+}
+
+export function planReminderStatusDotVariant(status: PlanReminderStatus) {
+  return dotForStatus(planReminderStatusSemantic(status));
 }
 
 /**
- * Run-history status tone. triggered = it fired (informational accent, not a
- * health signal), blocked = intentionally skipped (warning), failed =
- * delivery error. Exception-only: no success green for a plain "it ran"
- * record.
+ * Run-history meaning. `triggered` = it fired, which is a record rather than a
+ * health signal, so it reads as `active` and never earns success-green;
+ * `blocked` = intentionally skipped, which asks for attention; `failed` = a
+ * delivery error. Exception-only by design.
  */
-export function planRunStatusDotVariant(
+export function planRunStatusSemantic(
   status: NonNullable<PlanReminder['lastRun']>['status'],
-): 'accent' | 'warning' | 'error' {
-  if (status === 'blocked') return 'warning';
+): StatusSemantic {
+  if (status === 'blocked') return 'attention';
   if (status === 'failed') return 'error';
-  return 'accent';
+  return 'active';
+}
+
+export function planRunStatusDotVariant(status: NonNullable<PlanReminder['lastRun']>['status']) {
+  return dotForStatus(planRunStatusSemantic(status));
 }

--- a/packages/ui/src/skill-status.ts
+++ b/packages/ui/src/skill-status.ts
@@ -5,11 +5,14 @@
 // where it is shown — the same contract plan-reminder-status.ts keeps for
 // 定时任务.
 //
-// Tone rules: error is a broken state file or unreadable metadata; warning
-// is anything that asks for a decision (review, shadowed, budget-omitted, a
-// managed update); a deliberately disabled skill is neutral, not broken; an
-// enabled skill in context is simply live (accent), never success-green.
+// Meaning rules: `error` is a broken state file or unreadable metadata;
+// `attention` is anything that asks for a decision (review, shadowed,
+// budget-omitted, a managed update); a deliberately disabled skill is
+// `neutral`, not broken; an enabled skill in context is simply `active`,
+// never success-green. What those words look like is status-vocabulary's
+// call, not this file's.
 
+import { dotForStatus, type StatusSemantic } from './status-vocabulary.js';
 import type { SkillEntry } from './module-panel-types.js';
 import type { SkillsCopy } from './skills-copy.js';
 
@@ -24,20 +27,30 @@ function hasManagedUpdateAttention(skill: SkillEntry): boolean {
     && skill.managedUpdateStatus !== 'up_to_date';
 }
 
-export function skillStatusDotVariant(skill: SkillEntry): 'accent' | 'warning' | 'error' | 'neutral' {
+/**
+ * The ladder is the domain knowledge here: which of a skill's several
+ * independent problems wins the one dot it gets. Broken beats needs-looking-at
+ * beats off beats fine, and the order inside each rung is this file's business
+ * — status-vocabulary only decides what the words look like.
+ */
+export function skillStatusSemantic(skill: SkillEntry): StatusSemantic {
   const contextStatus = skillContextStatus(skill);
   if (skill.runtimeStatus === 'state_error' || skill.validationStatus === 'metadata_error' || contextStatus === 'invalid') {
     return 'error';
   }
-  if (skill.kind === 'discovery_diagnostic') return 'warning';
-  if (skill.needsReview) return 'warning';
-  if (skill.validationStatus && skill.validationStatus !== 'ok') return 'warning';
+  if (skill.kind === 'discovery_diagnostic') return 'attention';
+  if (skill.needsReview) return 'attention';
+  if (skill.validationStatus && skill.validationStatus !== 'ok') return 'attention';
   if (contextStatus === 'shadowed' || contextStatus === 'budget' || contextStatus === 'host_incompatible') {
-    return 'warning';
+    return 'attention';
   }
-  if (hasManagedUpdateAttention(skill)) return 'warning';
+  if (hasManagedUpdateAttention(skill)) return 'attention';
   if (!skill.enabled) return 'neutral';
-  return 'accent';
+  return 'active';
+}
+
+export function skillStatusDotVariant(skill: SkillEntry) {
+  return dotForStatus(skillStatusSemantic(skill));
 }
 
 /**

--- a/packages/ui/src/status-vocabulary.ts
+++ b/packages/ui/src/status-vocabulary.ts
@@ -1,0 +1,71 @@
+import type { StatusDotVariant } from '@astryxdesign/core/StatusDot';
+
+/**
+ * What a state MEANS, named once for the whole app.
+ *
+ * Seven places used to map their own domain states straight onto StatusDot
+ * variants, which made the app's status colours a matter of seven independent
+ * opinions: the same "success" was `accent` on the MCP page and `success` in
+ * session history, and the same "error" was called `destructive` in one file
+ * and `error` in five others.
+ *
+ * The fix is a layer, not a merge. Domain knowledge — that a blocked plan run
+ * is a warning, that a shadowed skill needs attention — stays with the surface
+ * that owns it, because only that surface knows it. What those surfaces now
+ * share is the vocabulary they express it in, and the single decision below
+ * about what each word looks like.
+ *
+ * There is deliberately no `info`. Two callers had one and meant opposite
+ * things by it: the MCP page meant "informational, do not draw the eye" and
+ * session history meant "something is happening here". One vague word standing
+ * for both is what let them drift apart unnoticed — they now pick `neutral` and
+ * `active` respectively, and the disagreement is visible in the call site
+ * rather than hidden in a shared name.
+ */
+export type StatusSemantic =
+  /** Healthy, connected, finished well. */
+  | 'success'
+  /** Live right now — running, scheduled, in flight. */
+  | 'active'
+  /** Needs a human eventually: paused, shadowed, degraded, review pending. */
+  | 'attention'
+  /** Broken now: failed delivery, invalid metadata, unreachable server. */
+  | 'error'
+  /** Present but not participating: disabled, completed-and-spent, off. */
+  | 'neutral';
+
+/**
+ * The one place a status word becomes a colour.
+ *
+ * `active` is `accent` because accent has always meant "live" here (a
+ * scheduled reminder waiting to fire wears it); it is not a second green.
+ * `attention` is `warning` rather than `error` because the state is "look at
+ * this when you can", not "this is broken".
+ */
+const SEMANTIC_TO_DOT: Record<StatusSemantic, StatusDotVariant> = {
+  success: 'success',
+  active: 'accent',
+  attention: 'warning',
+  error: 'error',
+  neutral: 'neutral',
+};
+
+/**
+ * Named `dotForStatus` rather than `statusDotVariant` only to avoid colliding
+ * with the settings surface's own `statusDotVariant`
+ * (`settings-status-badge.ts`), which nine files still import.
+ *
+ * That file is the eighth mapper and the largest — it predates this one and
+ * carries the settings surface's whole status language. The end state is that
+ * it becomes another adapter onto this vocabulary rather than a parallel
+ * system, at which point these two names collapse into one. It is not migrated
+ * here because its `info` states need a per-surface semantic decision (nine of
+ * them: does this mean "do not draw the eye" or "something is live?"), which is
+ * a design call and deserves its own pass rather than being guessed mid-refactor.
+ *
+ * Until then: new code uses this vocabulary; the settings surface keeps its
+ * own; neither grows a second opinion about what a state colour means.
+ */
+export function dotForStatus(semantic: StatusSemantic): StatusDotVariant {
+  return SEMANTIC_TO_DOT[semantic];
+}


### PR DESCRIPTION
## 改了什么
新增 `status-vocabulary.ts`：五类**语义**（`success` / `active` / `attention` / `error` / `neutral`）+ **唯一一处「语义 → 颜色」**。四个领域适配器改成回答"这个状态**是什么意思**"，颜色不再由它们各自决定。

## 为什么
全 app **八个文件**各自把领域状态直接映到 StatusDot variant，等于状态颜色有八份独立意见：同一个"成功"在 MCP 页是 `accent`、在会话历史是 `success`；同一个"错误"一处叫 `destructive`、另外七处叫 `error`。

**修法是加一层，不是合并。** 领域知识留在原地——只有定时任务知道 blocked 该警示，只有技能页知道一个技能同时有多个问题时哪个赢（那条**八级优先级阶梯原样保留**）。它们共享的只是**用什么词回答**，以及**每个词长什么样**这一个决定。

**故意没有 `info`。** 两个调用点都有 info 且含义相反：MCP 页指"信息性的、别抢注意力"，会话历史指"这里有事在进行"。一个模糊的词同时承载两种意思，正是它们悄悄跑偏的原因。现在各自说 `neutral` 和 `active`，**分歧显示在调用点，而不是藏在共享的名字里**。

## 唯一的颜色变化
**MCP 已连接：accent → success（绿点）。** accent 在我们体系里一贯是"活动中"（等待触发的提醒就是 accent），拿它表示"健康"会让已连接的服务器读起来像正在忙。那是这页还没有"成功"这个词时的将就。

## 故意不在本 PR 里的两件事
- **`settings-status-badge.ts`**：第八个也是最大的映射（**9 个文件在用**），它的 `info` 态需要逐个做语义判断——那是设计裁决不是重构，**单独一批迁移**。词汇表文件里写明了终态（它将退化为同一词汇表上的适配器、届时名字归一），锚住两者不各自演进。
- **`memoryStatusTone`**：喂的正是上面那个面，所以它的 `disabled → neutral` 归类和 `destructive → error` 改名**跟着设置面批次走**。两者都会重绘设置面的点，而本 PR 不允许重绘任何它没有命名的东西。

`dotForStatus` 而非 `statusDotVariant`，只是为了在两套并存期间不撞名；设置面迁完就归一。

## 验证
typecheck 0 错；`@maka/ui` **471 pass / 0 fail**。除 MCP 绿点外**零颜色变化**——其余映射收敛前后逐值相同。
