### PR TITLE
fix(desktop): preserve Session copy idempotency across ambiguous outcomes

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-revision-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-revision-actions.test.ts
@@ -1,10 +1,26 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 import type { SessionSummary, StoredMessage } from '@maka/core';
 import {
+  abandonTurnRevisionCopyAttempt,
   createAppShellRevisionActions,
   type TurnRevisionDraft,
 } from '../../renderer/app-shell-revision-actions.js';
+import {
+  completeSessionCopyAttempt,
+  readSessionCopyAttempt,
+} from '../../renderer/session-copy-attempt.js';
+
+const revisionAttemptKey = {
+  scope: 'edit-and-resend:turn-1',
+  kind: 'revision' as const,
+  sourceSessionId: 'source',
+};
+
+afterEach(() => {
+  const attempt = readSessionCopyAttempt(revisionAttemptKey);
+  if (attempt) completeSessionCopyAttempt(revisionAttemptKey, attempt.copyId);
+});
 
 function session(id: string): SessionSummary {
   return {
@@ -39,9 +55,10 @@ function userMessage(
 function installWindow(
   reviseBeforeTurn: (
     sessionId: string,
-    input: { sourceTurnId: string },
+    input: { sourceTurnId: string; copyId?: string },
   ) => Promise<SessionSummary>,
-  remove: (sessionId: string) => Promise<void>,
+  cleanupSessionCopy: (sessionId: string) => Promise<void>,
+  abandonSessionCopy: (sessionId: string) => Promise<void>,
 ): () => void {
   const target = globalThis as unknown as { window?: unknown };
   const hadWindow = Object.prototype.hasOwnProperty.call(target, 'window');
@@ -49,7 +66,7 @@ function installWindow(
   Object.defineProperty(target, 'window', {
     configurable: true,
     value: {
-      maka: { sessions: { reviseBeforeTurn, remove } },
+      maka: { sessions: { reviseBeforeTurn, cleanupSessionCopy, abandonSessionCopy } },
     },
     writable: true,
   });
@@ -69,26 +86,31 @@ function installWindow(
 function createHarness(options: {
   reviseBeforeTurn: (
     sessionId: string,
-    input: { sourceTurnId: string },
+    input: { sourceTurnId: string; copyId?: string },
   ) => Promise<SessionSummary>;
   messages?: StoredMessage[];
   pendingAttachments?: boolean;
   previousComposerText?: string;
   refreshMessagesResult?: boolean;
+  abandonThrows?: boolean;
 }) {
   const activeIdRef: { current: string | undefined } = { current: 'source' };
   const revisionDraftRef: { current: TurnRevisionDraft | null } = { current: null };
   const composerCalls: string[] = [];
   const opened: string[] = [];
-  const revisionCalls: Array<[string, { sourceTurnId: string }]> = [];
-  const removed: string[] = [];
+  const revisionCalls: Array<[string, { sourceTurnId: string; copyId?: string }]> = [];
+  const abandoned: string[] = [];
   const infoToasts: Array<[string, string | undefined]> = [];
   const restoreWindow = installWindow(
     async (sessionId, input) => {
       revisionCalls.push([sessionId, input]);
       return options.reviseBeforeTurn(sessionId, input);
     },
-    async (sessionId) => { removed.push(sessionId); },
+    async () => undefined,
+    async (sessionId) => {
+      abandoned.push(sessionId);
+      if (options.abandonThrows) throw new Error('cleanup intent was not recorded');
+    },
   );
   const actions = createAppShellRevisionActions({
     uiLocale: 'en',
@@ -127,9 +149,10 @@ function createHarness(options: {
     composerCalls,
     infoToasts,
     opened,
-    removed,
+    abandoned,
     restoreWindow,
     revisionDraftRef,
+    getRevisionDraft: () => revisionDraftRef.current,
   };
 }
 
@@ -143,13 +166,43 @@ describe('app shell revision actions', () => {
       assert.deepEqual(harness.composerCalls, ['Human-facing prompt', '<focus>']);
 
       assert.equal(await harness.actions.prepareRevisionSend('Edited prompt'), true);
-      assert.deepEqual(harness.revisionCalls, [['source', { sourceTurnId: 'turn-1' }]]);
+      assert.deepEqual(harness.revisionCalls, [
+        [
+          'source',
+          {
+            sourceTurnId: 'turn-1',
+            copyId: harness.revisionDraftRef.current?.copyId,
+          },
+        ],
+      ]);
       assert.deepEqual(harness.opened, ['revision']);
       assert.equal(harness.revisionDraftRef.current?.draftSessionId, 'revision');
       assert.deepEqual(
         harness.composerCalls,
         ['Human-facing prompt', '<focus>', '<draft:revision:Edited prompt>', '<focus>'],
       );
+    } finally {
+      harness.restoreWindow();
+    }
+  });
+
+  it('keeps one copy identity when revision preparation has an ambiguous failure', async () => {
+    let attempts = 0;
+    const harness = createHarness({
+      reviseBeforeTurn: async (_sessionId, input) => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('response lost');
+        return session(input.copyId ?? 'missing-copy-id');
+      },
+    });
+    try {
+      harness.actions.beginEditUserMessage('turn-1');
+      assert.equal(await harness.actions.prepareRevisionSend('Edited prompt'), false);
+      assert.equal(await harness.actions.prepareRevisionSend('Edited prompt'), true);
+      const copyIds = harness.revisionCalls.map(([, input]) => input.copyId);
+      assert.equal(copyIds.length, 2);
+      assert.equal(copyIds[0], copyIds[1]);
+      assert.equal(harness.revisionDraftRef.current?.draftSessionId, copyIds[0]);
     } finally {
       harness.restoreWindow();
     }
@@ -216,7 +269,7 @@ describe('app shell revision actions', () => {
       resolveRevision?.(session('revision'));
       assert.equal(await pending, false);
       assert.deepEqual(harness.opened, []);
-      assert.deepEqual(harness.removed, ['revision']);
+      assert.deepEqual(harness.abandoned, ['revision']);
     } finally {
       harness.restoreWindow();
     }
@@ -229,14 +282,106 @@ describe('app shell revision actions', () => {
     });
     try {
       harness.actions.beginEditUserMessage('turn-1');
+      const abandonedCopyId = harness.revisionDraftRef.current?.copyId;
       assert.equal(await harness.actions.prepareRevisionSend('Edited prompt'), false);
       assert.equal(harness.activeIdRef.current, 'source');
       assert.equal(harness.revisionDraftRef.current?.draftSessionId, 'source');
-      assert.deepEqual(harness.removed, ['revision']);
+      assert.deepEqual(harness.abandoned, ['revision']);
+      assert.notEqual(harness.revisionDraftRef.current?.copyId, abandonedCopyId);
       assert.ok(harness.composerCalls.includes('<draft:source:Edited prompt>'));
       assert.deepEqual(harness.composerCalls.slice(-2), ['Edited prompt', '<focus>']);
     } finally {
       harness.restoreWindow();
+    }
+  });
+
+  it('does not replace a target until its cleanup intent is durable', async () => {
+    const control = {
+      reviseBeforeTurn: async () => session('revision'),
+      refreshMessagesResult: false,
+      abandonThrows: true,
+    };
+    const harness = createHarness(control);
+    try {
+      harness.actions.beginEditUserMessage('turn-1');
+      const copyId = harness.revisionDraftRef.current?.copyId;
+      assert.equal(await harness.actions.prepareRevisionSend('Edited prompt'), false);
+      assert.equal(harness.revisionDraftRef.current?.copyId, copyId);
+      assert.equal(harness.revisionDraftRef.current?.copyPhase, 'abandoning');
+      assert.deepEqual(harness.abandoned, ['revision']);
+    } finally {
+      control.abandonThrows = false;
+      await harness.actions.cancelRevisionDraft();
+      harness.restoreWindow();
+    }
+  });
+
+  it('durably abandons the target when a committed Revision response is lost', async () => {
+    const harness = createHarness({
+      reviseBeforeTurn: async () => {
+        throw new Error('Committed response was lost');
+      },
+    });
+    try {
+      harness.actions.beginEditUserMessage('turn-1');
+      const firstCopyId = harness.revisionDraftRef.current?.copyId;
+      assert.equal(await harness.actions.prepareRevisionSend('Edited prompt'), false);
+
+      await harness.actions.cancelRevisionDraft();
+      assert.deepEqual(harness.abandoned, [firstCopyId]);
+      assert.equal(harness.revisionDraftRef.current, null);
+
+      harness.actions.beginEditUserMessage('turn-1');
+      assert.notEqual(harness.getRevisionDraft()?.copyId, firstCopyId);
+    } finally {
+      harness.restoreWindow();
+    }
+  });
+
+  it('remembers an ambiguous Revision request across renderer state loss', async () => {
+    const first = createHarness({
+      reviseBeforeTurn: async () => {
+        throw new Error('Committed response was lost');
+      },
+    });
+    first.actions.beginEditUserMessage('turn-1');
+    const copyId = first.revisionDraftRef.current?.copyId;
+    assert.equal(await first.actions.prepareRevisionSend('Edited prompt'), false);
+    first.restoreWindow();
+
+    const reloaded = createHarness({ reviseBeforeTurn: async () => session('revision') });
+    try {
+      reloaded.actions.beginEditUserMessage('turn-1');
+      assert.equal(reloaded.revisionDraftRef.current?.copyId, copyId);
+      assert.equal(reloaded.revisionDraftRef.current?.copyPhase, 'started');
+      await reloaded.actions.cancelRevisionDraft();
+      assert.deepEqual(reloaded.abandoned, [copyId]);
+    } finally {
+      reloaded.restoreWindow();
+    }
+  });
+
+  it('keeps an archived draft cleanup handle until durable abandon is acknowledged', async () => {
+    const first = createHarness({
+      reviseBeforeTurn: async () => {
+        throw new Error('Committed response was lost');
+      },
+      abandonThrows: true,
+    });
+    first.actions.beginEditUserMessage('turn-1');
+    assert.equal(await first.actions.prepareRevisionSend('Edited prompt'), false);
+    const draft = first.revisionDraftRef.current;
+    assert.ok(draft);
+    assert.equal(await abandonTurnRevisionCopyAttempt(draft), false);
+    first.restoreWindow();
+
+    const reloaded = createHarness({ reviseBeforeTurn: async () => session('revision') });
+    try {
+      reloaded.actions.beginEditUserMessage('turn-1');
+      assert.equal(reloaded.revisionDraftRef.current?.copyPhase, 'abandoning');
+      await reloaded.actions.cancelRevisionDraft();
+    } finally {
+      reloaded.restoreWindow();
     }
   });
 
@@ -251,7 +396,7 @@ describe('app shell revision actions', () => {
       await harness.actions.cancelRevisionDraft();
       assert.equal(harness.revisionDraftRef.current, null);
       assert.deepEqual(harness.opened, ['revision', 'source']);
-      assert.deepEqual(harness.removed, ['revision']);
+      assert.deepEqual(harness.abandoned, ['revision']);
       assert.ok(harness.composerCalls.includes('<clear:revision>'));
       // One restore carries both the words and the staged Skill.
       assert.ok(

--- a/apps/desktop/src/main/__tests__/app-shell-turn-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-turn-actions.test.ts
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { SessionSummary } from '@maka/core';
+import { createAppShellTurnActions } from '../../renderer/app-shell-turn-actions.js';
+
+test('preserves a Branch copy identity after an ambiguous failure and completes it on success', async () => {
+  const calls: Array<{ sourceTurnId: string; copyId?: string }> = [];
+  let loseFirstResponse = true;
+  const restoreWindow = installWindow(async (_sessionId, input) => {
+    calls.push(input);
+    if (loseFirstResponse) {
+      loseFirstResponse = false;
+      throw new Error('Committed response was lost');
+    }
+    return session(input.copyId ?? 'missing-copy-id');
+  });
+  const pending = new Set<string>();
+  const opened: string[] = [];
+  const actions = createAppShellTurnActions({
+    uiLocale: 'en',
+    activeIdRef: { current: 'branch-action-source' },
+    addPendingTurnAction: (key) => {
+      if (pending.has(key)) return false;
+      pending.add(key);
+      return true;
+    },
+    clearPendingTurnAction: (key) => {
+      pending.delete(key);
+    },
+    openSessionInChat: (sessionId) => {
+      opened.push(sessionId);
+    },
+    pendingKeyOf: (sessionId, turnId, actionId) => `${sessionId}:${turnId}:${actionId}`,
+    refreshMessages: async () => true,
+    refreshSessions: async () => [],
+    setMessages: () => undefined,
+    toastApi: { info() {}, success() {}, error() {} },
+    upsertSessionSummary: () => undefined,
+  });
+
+  try {
+    await actions.handleTurnFooterAction('branch-action-turn', 'branch');
+    await actions.handleTurnFooterAction('branch-action-turn', 'branch');
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0]?.copyId, calls[1]?.copyId);
+    assert.deepEqual(opened, [calls[0]?.copyId]);
+
+    await actions.handleTurnFooterAction('branch-action-turn', 'branch');
+    assert.equal(calls.length, 3);
+    assert.notEqual(calls[2]?.copyId, calls[1]?.copyId);
+  } finally {
+    restoreWindow();
+  }
+});
+
+function installWindow(
+  branchFromTurn: (
+    sessionId: string,
+    input: { sourceTurnId: string; copyId?: string },
+  ) => Promise<SessionSummary>,
+): () => void {
+  const target = globalThis as unknown as { window?: unknown };
+  const hadWindow = Object.prototype.hasOwnProperty.call(target, 'window');
+  const previousWindow = target.window;
+  Object.defineProperty(target, 'window', {
+    configurable: true,
+    value: { maka: { sessions: { branchFromTurn } } },
+    writable: true,
+  });
+  return () => {
+    if (hadWindow) {
+      Object.defineProperty(target, 'window', {
+        configurable: true,
+        value: previousWindow,
+        writable: true,
+      });
+    } else {
+      delete target.window;
+    }
+  };
+}
+
+function session(id: string): SessionSummary {
+  return {
+    id,
+    name: id,
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'fake',
+    llmConnectionSlug: 'test',
+    connectionLocked: false,
+    model: 'test',
+    permissionMode: 'ask',
+  };
+}

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -5,6 +5,8 @@ import {
   normalizeBranchFromTurnInput,
   normalizeRegenerateTurnInput,
   normalizeReviseBeforeTurnInput,
+  normalizeRuntimeHostBranchFromTurnInput,
+  normalizeRuntimeHostReviseBeforeTurnInput,
   normalizeSandboxBoundaryResponse,
   normalizeSessionSendCommand,
   normalizeStopSessionInput,
@@ -57,18 +59,33 @@ describe('permission response IPC boundary', () => {
       turnId: 'turn-3',
     });
     assert.deepEqual(
-      normalizeBranchFromTurnInput({ sourceTurnId: 'turn-3', name: '  Branch name  ', ignored: 1 }),
-      { sourceTurnId: 'turn-3', name: 'Branch name' },
+      normalizeRuntimeHostBranchFromTurnInput({
+        sourceTurnId: 'turn-3',
+        name: '  Branch name  ',
+        copyId: 'branch-copy-1',
+        ignored: 1,
+      }),
+      { sourceTurnId: 'turn-3', name: 'Branch name', copyId: 'branch-copy-1' },
     );
-    assert.deepEqual(normalizeReviseBeforeTurnInput({ sourceTurnId: 'turn-4', ignored: true }), {
-      sourceTurnId: 'turn-4',
-    });
+    assert.deepEqual(
+      normalizeRuntimeHostReviseBeforeTurnInput({
+        sourceTurnId: 'turn-4',
+        copyId: 'revision-copy-1',
+        ignored: true,
+      }),
+      {
+        sourceTurnId: 'turn-4',
+        copyId: 'revision-copy-1',
+      },
+    );
 
     const invalidActions: Array<() => unknown> = [
       () => normalizeRegenerateTurnInput({ sourceTurnId: 'turn-1', turnId: 1 }),
       () => normalizeBranchFromTurnInput({ sourceTurnId: 'turn-1', name: 1 }),
       () => normalizeBranchFromTurnInput({ sourceTurnId: 'x'.repeat(129) }),
       () => normalizeReviseBeforeTurnInput({ sourceTurnId: 1 }),
+      () => normalizeRuntimeHostBranchFromTurnInput({ sourceTurnId: 'turn-1' }),
+      () => normalizeRuntimeHostReviseBeforeTurnInput({ sourceTurnId: 'turn-1', copyId: '' }),
     ];
     for (const action of invalidActions) assert.throws(action, /Invalid/);
   });

--- a/apps/desktop/src/main/__tests__/quote-companion-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-cleanup.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, it } from 'node:test';
 import { DatabaseSync } from 'node:sqlite';
-import { createQuoteCompanionCleanupAuthority } from '../quote-companion-cleanup.js';
+import { createSessionCopyCleanupAuthority } from '../quote-companion-cleanup.js';
 
 const roots: string[] = [];
 
@@ -19,9 +19,28 @@ afterEach(async () => {
 });
 
 describe('quote companion cleanup authority', () => {
+  it('acknowledges abandon after the intent is durable without waiting for removal', async () => {
+    const workspaceRoot = await createWorkspace();
+    let releaseRemoval: (() => void) | undefined;
+    const removal = new Promise<void>((resolve) => {
+      releaseRemoval = resolve;
+    });
+    const authority = createSessionCopyCleanupAuthority({
+      workspaceRoot,
+      removeSession: async () => removal,
+    });
+
+    await authority.schedule('fork-scheduled');
+    assert.deepEqual(await readPendingIds(workspaceRoot), ['fork-scheduled']);
+
+    releaseRemoval?.();
+    await authority.cleanup('fork-scheduled');
+    assert.deepEqual(await readPendingIds(workspaceRoot), []);
+  });
+
   it('persists a failed removal and recovers it through a new authority instance', async () => {
     const workspaceRoot = await createWorkspace();
-    const first = createQuoteCompanionCleanupAuthority({
+    const first = createSessionCopyCleanupAuthority({
       workspaceRoot,
       removeSession: async () => {
         throw new Error('temporary removal failure');
@@ -32,7 +51,7 @@ describe('quote companion cleanup authority', () => {
     assert.deepEqual(await readPendingIds(workspaceRoot), ['fork-1']);
 
     const removed: string[] = [];
-    const afterRestart = createQuoteCompanionCleanupAuthority({
+    const afterRestart = createSessionCopyCleanupAuthority({
       workspaceRoot,
       removeSession: async (sessionId) => {
         removed.push(sessionId);
@@ -48,7 +67,7 @@ describe('quote companion cleanup authority', () => {
   it('clears the durable intent only after the complete removal succeeds', async () => {
     const workspaceRoot = await createWorkspace();
     let pendingDuringRemoval: string[] = [];
-    const authority = createQuoteCompanionCleanupAuthority({
+    const authority = createSessionCopyCleanupAuthority({
       workspaceRoot,
       removeSession: async () => {
         pendingDuringRemoval = await readPendingIds(workspaceRoot);
@@ -63,7 +82,7 @@ describe('quote companion cleanup authority', () => {
 
   it('continues recovering other companions when one removal still fails', async () => {
     const workspaceRoot = await createWorkspace();
-    const seed = createQuoteCompanionCleanupAuthority({
+    const seed = createSessionCopyCleanupAuthority({
       workspaceRoot,
       removeSession: async () => {
         throw new Error('offline');
@@ -72,7 +91,7 @@ describe('quote companion cleanup authority', () => {
     await assert.rejects(seed.cleanup('fork-a'));
     await assert.rejects(seed.cleanup('fork-b'));
 
-    const authority = createQuoteCompanionCleanupAuthority({
+    const authority = createSessionCopyCleanupAuthority({
       workspaceRoot,
       removeSession: async (sessionId) => {
         if (sessionId === 'fork-a') throw new Error('still offline');
@@ -86,6 +105,24 @@ describe('quote companion cleanup authority', () => {
       ['fork-a'],
     );
     assert.deepEqual(await readPendingIds(workspaceRoot), ['fork-a']);
+  });
+
+  it('forgets a terminal retained Revision without reporting deletion', async () => {
+    const workspaceRoot = await createWorkspace();
+    const seed = createSessionCopyCleanupAuthority({
+      workspaceRoot,
+      removeSession: async () => {
+        throw new Error('offline');
+      },
+    });
+    await assert.rejects(seed.cleanup('retained-revision'));
+
+    const authority = createSessionCopyCleanupAuthority({
+      workspaceRoot,
+      removeSession: async () => 'retained',
+    });
+    assert.deepEqual(await authority.recover(), { removed: [], failed: [] });
+    assert.deepEqual(await readPendingIds(workspaceRoot), []);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
@@ -11,10 +11,13 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 import type { SessionEvent, SessionSummary, StoredMessage, TurnRecord, TurnStatus } from '@maka/core';
 import {
+  abandonPendingCompanionCopy,
   applyCompanionInteractionEvent,
+  cleanupCompanionCopy,
+  createCompanionDismissalGuard,
   deriveCompanionComposerState,
   isCompanionTurnTerminal,
   latestSettledTurnId,
@@ -42,11 +45,13 @@ interface FakeControl {
   turns?: TurnRecord[];
   listTurnsThrows?: boolean;
   branchThrows?: boolean;
-  createThrows?: boolean;
+  loseFirstBranchResponse?: boolean;
+  createdId?: string;
   /** permissionMode `setPermissionMode` returns (default = the requested mode). */
   afterSetMode?: string;
   setModeThrows?: boolean;
   cleanupThrows?: boolean;
+  abandonThrows?: boolean;
   sendThrows?: boolean;
   sendResult?: { ok: true } | { ok: false; reason?: string };
   /** Runs right after the fork is created (e.g. to flip `disposed`). */
@@ -58,14 +63,9 @@ function makeApi(control: FakeControl = {}) {
     removed: [] as string[],
     sent: [] as { id: string; cmd: { turnId: string; text: string; quotes?: unknown } }[],
     setMode: [] as [string, string][],
-    branchedFrom: [] as string[],
+    branchedFrom: [] as Array<{ sourceTurnId: string; copyId: string }>,
+    abandoned: [] as string[],
     created: 0,
-  };
-  const forge = (): SessionSummary => {
-    calls.created++;
-    const forked = summary('fork-1', 'execute'); // inherits the parent's elevated mode
-    control.afterCreate?.();
-    return forked;
   };
   const api: CompanionSessionApi = {
     readMessages: async () => [{ turnId: 'x' } as unknown as StoredMessage],
@@ -74,22 +74,29 @@ function makeApi(control: FakeControl = {}) {
       return control.turns ?? [turn('main-turn-1', 'completed')];
     },
     branchFromTurn: async (_id, input) => {
-      calls.branchedFrom.push(input.sourceTurnId);
+      calls.branchedFrom.push(input);
       if (control.branchThrows) throw new Error('branchFromTurn failed');
-      return forge();
-    },
-    create: async () => {
-      if (control.createThrows) throw new Error('create failed');
-      return forge();
+      const forked = summary(control.createdId ?? input.copyId, 'execute');
+      calls.created++;
+      control.afterCreate?.();
+      if (control.loseFirstBranchResponse) {
+        control.loseFirstBranchResponse = false;
+        throw new Error('Committed response was lost');
+      }
+      return forked;
     },
     setPermissionMode: async (id, mode) => {
       calls.setMode.push([id, mode]);
       if (control.setModeThrows) throw new Error('setPermissionMode failed');
       return summary(id, control.afterSetMode ?? mode);
     },
-    cleanupQuoteCompanion: async (id) => {
+    cleanupSessionCopy: async (id) => {
       calls.removed.push(id);
       if (control.cleanupThrows) throw new Error('cleanup failed');
+    },
+    abandonSessionCopy: async (id) => {
+      calls.abandoned.push(id);
+      if (control.abandonThrows) throw new Error('abandon acknowledgement lost');
     },
     send: async (id, cmd) => {
       calls.sent.push({ id, cmd });
@@ -120,6 +127,13 @@ const base = {
   existingForkId: null as string | null,
 };
 
+afterEach(async () => {
+  const { api } = makeApi();
+  for (const sourceSessionId of ['main', 'quote-retry-source', 'quote-abandon-source']) {
+    await abandonPendingCompanionCopy(api, sourceSessionId);
+  }
+});
+
 describe('latestSettledTurnId', () => {
   it('picks the latest non-running turn (skips a trailing running turn)', () => {
     assert.equal(
@@ -128,6 +142,17 @@ describe('latestSettledTurnId', () => {
     );
     assert.equal(latestSettledTurnId([turn('a', 'running')]), undefined);
     assert.equal(latestSettledTurnId([]), undefined);
+  });
+});
+
+describe('companion dismissal guard', () => {
+  it('ignores a StrictMode effect replay but accepts the current mount dismissal', () => {
+    const guard = createCompanionDismissalGuard();
+    const replayedCleanup = guard.beginMount();
+    const activeCleanup = guard.beginMount();
+
+    assert.equal(replayedCleanup(), false);
+    assert.equal(activeCleanup(), true);
   });
 });
 
@@ -179,17 +204,17 @@ describe('performCompanionTurn', () => {
     });
     const rec = recorder();
     const result = await performCompanionTurn({ api, isDisposed: () => false, ...base, ...rec });
-    assert.deepEqual(result, { status: 'sent', forkId: 'fork-1' });
-    assert.deepEqual(calls.branchedFrom, ['t-settled']); // NOT the running turn
-    assert.deepEqual(calls.setMode, [['fork-1', 'explore']]);
+    assert.equal(result.status, 'sent');
+    assert.deepEqual(calls.branchedFrom.map(({ sourceTurnId }) => sourceTurnId), ['t-settled']);
+    assert.deepEqual(calls.setMode, [[calls.branchedFrom[0]!.copyId, 'explore']]);
     assert.equal(calls.sent.length, 1);
     assert.deepEqual(calls.sent[0].cmd.quotes, [{ text: 'excerpt' }]);
     assert.deepEqual(calls.removed, []);
     // Quotes are consumed only AFTER the send is accepted.
     assert.deepEqual(rec.events, [
-      'created:fork-1',
-      'committed:fork-1',
-      'beforeSend:fork-1',
+      `created:${calls.branchedFrom[0]!.copyId}`,
+      `committed:${calls.branchedFrom[0]!.copyId}`,
+      `beforeSend:${calls.branchedFrom[0]!.copyId}`,
       'consumed',
     ]);
   });
@@ -213,9 +238,9 @@ describe('performCompanionTurn', () => {
     });
     assert.equal(result.status, 'sent');
     assert.deepEqual(events, [
-      'created:fork-1',
+      `created:${(result as { forkId: string }).forkId}`,
       'pin-started',
-      'committed:fork-1',
+      `committed:${(result as { forkId: string }).forkId}`,
       'send-started',
     ]);
   });
@@ -240,8 +265,116 @@ describe('performCompanionTurn', () => {
     assert.deepEqual(rec.events, []);
   });
 
-  it('structures fallback create rejection and never pins or sends', async () => {
-    const { api, calls } = makeApi({ turns: [], createThrows: true });
+  it('retries a lost companion Branch with its original target and settled boundary', async () => {
+    const control: FakeControl = {
+      turns: [turn('quote-boundary-1', 'completed')],
+      loseFirstBranchResponse: true,
+      afterSetMode: 'explore',
+    };
+    const { api, calls } = makeApi(control);
+    const input = {
+      ...base,
+      sourceSession: summary('quote-retry-source', 'execute'),
+    };
+
+    assert.deepEqual(
+      await performCompanionTurn({ api, isDisposed: () => false, ...input, ...recorder() }),
+      { status: 'error', code: 'fork_setup_failed' },
+    );
+    control.turns = [turn('quote-boundary-1', 'completed'), turn('quote-boundary-2', 'completed')];
+    const retried = await performCompanionTurn({
+      api,
+      isDisposed: () => false,
+      ...input,
+      ...recorder(),
+    });
+
+    assert.equal(retried.status, 'sent');
+    assert.equal(calls.branchedFrom.length, 2);
+    assert.deepEqual(calls.branchedFrom[1], calls.branchedFrom[0]);
+    assert.equal(calls.branchedFrom[1]?.sourceTurnId, 'quote-boundary-1');
+  });
+
+  it('durably abandons an unresolved companion target before a new action', async () => {
+    const control: FakeControl = {
+      turns: [turn('quote-abandon-boundary', 'completed')],
+      loseFirstBranchResponse: true,
+      afterSetMode: 'explore',
+    };
+    const { api, calls } = makeApi(control);
+    const sourceSession = summary('quote-abandon-source', 'execute');
+    const input = { ...base, sourceSession };
+
+    await performCompanionTurn({ api, isDisposed: () => false, ...input, ...recorder() });
+    const abandonedCopyId = calls.branchedFrom[0]!.copyId;
+    assert.equal(await abandonPendingCompanionCopy(api, sourceSession.id), true);
+    assert.deepEqual(calls.abandoned, [abandonedCopyId]);
+
+    const next = await performCompanionTurn({
+      api,
+      isDisposed: () => false,
+      ...input,
+      ...recorder(),
+    });
+    assert.equal(next.status, 'sent');
+    assert.notEqual(calls.branchedFrom[1]?.copyId, abandonedCopyId);
+  });
+
+  it('never reuses a target after its cleanup acknowledgement becomes ambiguous', async () => {
+    const control: FakeControl = {
+      turns: [turn('quote-ambiguous-abandon-boundary', 'completed')],
+      loseFirstBranchResponse: true,
+      abandonThrows: true,
+      afterSetMode: 'explore',
+    };
+    const { api, calls } = makeApi(control);
+    const sourceSession = summary('quote-ambiguous-abandon-source', 'execute');
+    const input = { ...base, sourceSession };
+
+    await performCompanionTurn({ api, isDisposed: () => false, ...input, ...recorder() });
+    const firstCopyId = calls.branchedFrom[0]?.copyId;
+    assert.equal(await abandonPendingCompanionCopy(api, sourceSession.id), false);
+
+    control.abandonThrows = false;
+    const retried = await performCompanionTurn({
+      api,
+      isDisposed: () => false,
+      ...input,
+      ...recorder(),
+    });
+    assert.equal(retried.status, 'sent');
+    assert.notEqual(calls.branchedFrom[1]?.copyId, firstCopyId);
+    await cleanupCompanionCopy(api, sourceSession.id, calls.branchedFrom[1]!.copyId);
+  });
+
+  it('completes the copy lease by copy id when an embedded fork has another id', async () => {
+    const control: FakeControl = {
+      createdId: 'embedded-fork',
+      afterSetMode: 'explore',
+    };
+    const { api, calls } = makeApi(control);
+    const sourceSession = summary('embedded-source', 'execute');
+    const input = { ...base, sourceSession };
+    const sent = await performCompanionTurn({
+      api,
+      isDisposed: () => false,
+      ...input,
+      ...recorder(),
+    });
+    assert.equal(sent.status, 'sent');
+    const firstCopyId = calls.branchedFrom[0]?.copyId;
+
+    assert.equal(await cleanupCompanionCopy(api, sourceSession.id, 'embedded-fork'), true);
+    assert.deepEqual(calls.removed, ['embedded-fork']);
+
+    control.createdId = 'embedded-fork-2';
+    await performCompanionTurn({ api, isDisposed: () => false, ...input, ...recorder() });
+    assert.notEqual(calls.branchedFrom[1]?.copyId, firstCopyId);
+    await cleanupCompanionCopy(api, sourceSession.id, 'embedded-fork-2');
+  });
+
+  it('does not create a companion before the source has a settled turn', async () => {
+    const { api, calls } = makeApi({ turns: [] });
     const rec = recorder();
     const result = await performCompanionTurn({ api, isDisposed: () => false, ...base, ...rec });
     assert.deepEqual(result, { status: 'error', code: 'fork_setup_failed' });
@@ -255,13 +388,13 @@ describe('performCompanionTurn', () => {
     const rec = recorder();
     const result = await performCompanionTurn({ api, isDisposed: () => false, ...base, ...rec });
     assert.deepEqual(result, { status: 'error', code: 'permission_pin_failed' });
-    assert.deepEqual(calls.removed, ['fork-1']);
+    assert.deepEqual(calls.removed, [calls.branchedFrom[0]!.copyId]);
     assert.equal(calls.sent.length, 0);
-    assert.deepEqual(rec.events, ['created:fork-1']);
+    assert.deepEqual(rec.events, [`created:${calls.branchedFrom[0]!.copyId}`]);
   });
 
   it('does not release a hidden fork when authoritative cleanup fails', async () => {
-    const { api } = makeApi({ setModeThrows: true, cleanupThrows: true });
+    const { api, calls } = makeApi({ setModeThrows: true, cleanupThrows: true });
     const events: string[] = [];
 
     const result = await performCompanionTurn({
@@ -277,7 +410,7 @@ describe('performCompanionTurn', () => {
     await Promise.resolve();
 
     assert.deepEqual(result, { status: 'error', code: 'permission_pin_failed' });
-    assert.deepEqual(events, ['created:fork-1']);
+    assert.deepEqual(events, [`created:${calls.branchedFrom[0]!.copyId}`]);
   });
 
   it('fail-closed: a fork not confirmed `explore` is removed and never sends', async () => {
@@ -285,7 +418,7 @@ describe('performCompanionTurn', () => {
     const rec = recorder();
     const result = await performCompanionTurn({ api, isDisposed: () => false, ...base, ...rec });
     assert.deepEqual(result, { status: 'error', code: 'permission_pin_failed' });
-    assert.deepEqual(calls.removed, ['fork-1']);
+    assert.deepEqual(calls.removed, [calls.branchedFrom[0]!.copyId]);
     assert.equal(calls.sent.length, 0);
   });
 
@@ -297,22 +430,22 @@ describe('performCompanionTurn', () => {
     const rec = recorder();
     const result = await performCompanionTurn({ api, isDisposed: () => disposed, ...base, ...rec });
     assert.equal(result.status, 'disposed');
-    assert.deepEqual(calls.removed, ['fork-1']);
+    assert.deepEqual(calls.removed, [calls.branchedFrom[0]!.copyId]);
     assert.deepEqual(calls.setMode, []); // bailed before pinning
     assert.equal(calls.sent.length, 0);
     assert.deepEqual(rec.events, []);
   });
 
   it('send rejection (thrown) is retryable: arms but does NOT consume the staged quotes', async () => {
-    const { api } = makeApi({ afterSetMode: 'explore', sendThrows: true });
+    const { api, calls } = makeApi({ afterSetMode: 'explore', sendThrows: true });
     const rec = recorder();
     const result = await performCompanionTurn({ api, isDisposed: () => false, ...base, ...rec });
     assert.deepEqual(result, { status: 'error', code: 'send_failed' });
     assert.equal(rec.events.includes('consumed'), false);
     assert.deepEqual(rec.events, [
-      'created:fork-1',
-      'committed:fork-1',
-      'beforeSend:fork-1',
+      `created:${calls.branchedFrom[0]!.copyId}`,
+      `committed:${calls.branchedFrom[0]!.copyId}`,
+      `beforeSend:${calls.branchedFrom[0]!.copyId}`,
     ]);
   });
 

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -209,6 +209,11 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
       emitSessionsChanged: (reason, sessionId) => changes.push({ reason, sessionId }),
       emitModeChanged() {},
       completeComputerUseTurn() {},
+      createSessionCopyCleanup: () => ({
+        cleanup: async () => undefined,
+        schedule: async () => undefined,
+        recover: async () => ({ removed: [], failed: [] }),
+      }),
       newId: () => 'session-ipc',
     });
     assert.equal(started.kind, 'ready');

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -271,6 +271,41 @@ test('closes the claimed Host connection when native capability construction fai
   assert.equal(host.closeCalls, 1);
 });
 
+test('does not release or report a Revision the Host retained during cleanup', async () => {
+  const ipc = ipcHarness();
+  const host = connectionHarness('retained-revision', { revisionAbandon: 'retained' });
+  const released: string[] = [];
+  const changes: Array<{ reason: string; sessionId?: string }> = [];
+  let removeSessionCopy: ((sessionId: string) => Promise<'removed' | 'retained'>) | undefined;
+  const candidate = await createDesktopRuntimeHostCandidate(host.connection, {
+    ...deps(ipc, {
+      browserTools: [],
+      releaseBrowserSession: (sessionId) => {
+        released.push(`browser:${sessionId}`);
+      },
+      computerUseTools: emptyComputerUseTools(),
+      releaseComputerUseSession: (sessionId) => {
+        released.push(`computer:${sessionId}`);
+      },
+    }),
+    emitSessionsChanged: (reason, sessionId) => changes.push({ reason, sessionId }),
+    createSessionCopyCleanup: ({ removeSession }) => {
+      removeSessionCopy = removeSession;
+      return {
+        cleanup: async () => undefined,
+        schedule: async () => undefined,
+        recover: async () => ({ removed: [], failed: [] }),
+      };
+    },
+  });
+
+  assert.ok(removeSessionCopy);
+  assert.equal(await removeSessionCopy('session-retained-revision'), 'retained');
+  assert.deepEqual(released, []);
+  assert.deepEqual(changes, []);
+  await candidate.close();
+});
+
 type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
 
 function ipcHarness() {
@@ -318,6 +353,11 @@ function deps(
     emitSessionsChanged() {},
     emitModeChanged() {},
     completeComputerUseTurn() {},
+    createSessionCopyCleanup: () => ({
+      cleanup: async () => undefined,
+      schedule: async () => undefined,
+      recover: async () => ({ removed: [], failed: [] }),
+    }),
     newId: () => 'candidate-id',
   };
 }
@@ -335,7 +375,10 @@ function nativeTool(): MakaTool {
   };
 }
 
-function connectionHarness(label: string) {
+function connectionHarness(
+  label: string,
+  options: { revisionAbandon?: 'abandoned' | 'retained' } = {},
+) {
   let resolveClosed: (() => void) | undefined;
   const closed = new Promise<void>((resolve) => {
     resolveClosed = resolve;
@@ -374,7 +417,27 @@ function connectionHarness(label: string) {
         operation === 'session.catalog.query' &&
         (input as { kind?: unknown }).kind === 'get'
       ) {
-        return { kind: 'session', session: session((input as { sessionId: string }).sessionId) };
+        const sessionId = (input as { sessionId: string }).sessionId;
+        return {
+          kind: 'session',
+          session:
+            options.revisionAbandon === undefined
+              ? session(sessionId)
+              : {
+                  ...session(sessionId),
+                  revisionRootSessionId: 'source-revision-root',
+                  revisionParentSessionId: 'source-revision-root',
+                  revisionOfTurnId: 'source-turn',
+                  revisionIndex: 2,
+                  revisionState: 'preparing',
+                },
+        };
+      }
+      if (operation === 'session.revision.abandon' && options.revisionAbandon) {
+        return {
+          kind: options.revisionAbandon,
+          sessionId: (input as { targetSessionId: string }).targetSessionId,
+        };
       }
       if (operation === 'runtime.resource.query') {
         return {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
@@ -27,6 +27,7 @@ test('leaves ordinary Session defaults to the Host while preserving product mode
       workspaceRoot: '/workspace',
       emitSessionsChanged: (reason, sessionId) => events.push({ reason, sessionId }),
       releaseSessionResources() {},
+      sessionCopyCleanup: cleanupAuthority(),
       newId: () => `session-${++sequence}`,
     },
     ipc,
@@ -83,6 +84,7 @@ test('filters linked subagents without exposing the filter to the Host protocol'
       workspaceRoot: '/workspace',
       emitSessionsChanged() {},
       releaseSessionResources() {},
+      sessionCopyCleanup: cleanupAuthority(),
     },
     ipc,
   );
@@ -99,6 +101,64 @@ test('filters linked subagents without exposing the filter to the Host protocol'
     agentName: 'Worker',
     profile: 'default',
   });
+});
+
+test('recovers and records Session copy cleanup through the Runtime Host catalog facade', async () => {
+  const cleanupCalls: string[] = [];
+  let recoveries = 0;
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionCatalogIpc(
+    {
+      client: catalogClient({ listSessions: async () => [] }),
+      workspaceRoot: '/workspace',
+      emitSessionsChanged() {},
+      releaseSessionResources() {},
+      sessionCopyCleanup: {
+        cleanup: async (sessionId) => { cleanupCalls.push(`cleanup:${sessionId}`); },
+        schedule: async (sessionId) => { cleanupCalls.push(`abandon:${sessionId}`); },
+        recover: async () => {
+          recoveries += 1;
+          return { removed: [], failed: [] };
+        },
+      },
+    },
+    ipc,
+  );
+
+  await ipc.invoke('sessions:list');
+  await ipc.invoke('sessions:cleanupSessionCopy', 'copy-cleanup');
+  await ipc.invoke('sessions:abandonSessionCopy', 'copy-abandon');
+
+  assert.equal(recoveries, 1);
+  assert.deepEqual(cleanupCalls, ['cleanup:copy-cleanup', 'abandon:copy-abandon']);
+});
+
+test('keeps abandoned copies hidden while durable cleanup is still pending', async () => {
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionCatalogIpc(
+    {
+      client: catalogClient({
+        listSessions: async () => [session('visible'), session('abandoned-copy')],
+      }),
+      workspaceRoot: '/workspace',
+      emitSessionsChanged() {},
+      releaseSessionResources() {},
+      sessionCopyCleanup: {
+        cleanup: async () => undefined,
+        schedule: async () => undefined,
+        recover: async () => ({
+          removed: [],
+          failed: [{ sessionId: 'abandoned-copy', error: new Error('remove failed') }],
+        }),
+      },
+    },
+    ipc,
+  );
+
+  assert.deepEqual(
+    (await ipc.invoke('sessions:list') as Array<{ id: string }>).map(({ id }) => id),
+    ['visible'],
+  );
 });
 
 test('applies family metadata and retirement actions through Host-owned operations', async () => {
@@ -131,6 +191,7 @@ test('applies family metadata and retirement actions through Host-owned operatio
       releaseSessionResources: async (sessionId) => {
         released.push(sessionId);
       },
+      sessionCopyCleanup: cleanupAuthority(),
     },
     ipc,
   );
@@ -163,6 +224,7 @@ test('normalizes renderer configuration actions into Host patches', async () => 
       workspaceRoot: '/workspace',
       emitSessionsChanged() {},
       releaseSessionResources() {},
+      sessionCopyCleanup: cleanupAuthority(),
     },
     ipc,
   );
@@ -192,6 +254,14 @@ test('normalizes renderer configuration actions into Host patches', async () => 
 });
 
 type CatalogClient = RuntimeHostSessionCatalogIpcDeps['client'];
+
+function cleanupAuthority(): RuntimeHostSessionCatalogIpcDeps['sessionCopyCleanup'] {
+  return {
+    cleanup: async () => undefined,
+    schedule: async () => undefined,
+    recover: async () => ({ removed: [], failed: [] }),
+  };
+}
 
 function catalogClient(overrides: Partial<CatalogClient>): CatalogClient {
   const unavailable = async (): Promise<never> => {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -70,6 +70,98 @@ test("advances the Host read marker through the last visible message", async () 
   await observer.close();
 });
 
+test("retries committed Branch and Revision copies with the renderer-owned identity", async () => {
+  const committed = new Map<string, SessionCatalogProjection>();
+  const lostResponses = new Set(["branch-copy-1", "revision-copy-1"]);
+  const calls: Array<{
+    kind: "branch" | "revision";
+    targetSessionId: string;
+    sourceTurnId: string;
+  }> = [];
+  let fallbackIds = 0;
+  const ipc = ipcHarness();
+  registerRuntimeHostSessionExecutionIpc(
+    {
+      client: executionClient({
+        copySession: async (kind, input) => {
+          calls.push({
+            kind,
+            targetSessionId: input.targetSessionId,
+            sourceTurnId: input.sourceTurnId,
+          });
+          let copy = committed.get(input.targetSessionId);
+          if (!copy) {
+            copy = { ...session(), id: input.targetSessionId, name: input.targetSessionId };
+            committed.set(input.targetSessionId, copy);
+          }
+          if (lostResponses.delete(input.targetSessionId)) {
+            throw new Error("Committed response was lost");
+          }
+          return copy;
+        },
+      }),
+      observer: unusedObserver(),
+      attachmentApprovals: createAttachmentApprovalRegistry(),
+      emitSessionsChanged() {},
+      stat: async () => ({ size: 0 }),
+      resizeImage: async (bytes) => bytes,
+      beforeStop() {},
+      newId: () => `fallback-${++fallbackIds}`,
+    },
+    ipc,
+  );
+
+  for (const input of [
+    {
+      channel: "sessions:branchFromTurn",
+      copyId: "branch-copy-1",
+      sourceTurnId: "branch-source-turn",
+    },
+    {
+      channel: "sessions:reviseBeforeTurn",
+      copyId: "revision-copy-1",
+      sourceTurnId: "revision-source-turn",
+    },
+  ] as const) {
+    await assert.rejects(
+      ipc.invoke(input.channel, "source-session", {
+        sourceTurnId: input.sourceTurnId,
+        copyId: input.copyId,
+      }),
+      /response was lost/,
+    );
+    const retried = (await ipc.invoke(input.channel, "source-session", {
+      sourceTurnId: input.sourceTurnId,
+      copyId: input.copyId,
+    })) as { id: string };
+    assert.equal(retried.id, input.copyId);
+  }
+
+  assert.deepEqual(calls, [
+    { kind: "branch", targetSessionId: "branch-copy-1", sourceTurnId: "branch-source-turn" },
+    { kind: "branch", targetSessionId: "branch-copy-1", sourceTurnId: "branch-source-turn" },
+    {
+      kind: "revision",
+      targetSessionId: "revision-copy-1",
+      sourceTurnId: "revision-source-turn",
+    },
+    {
+      kind: "revision",
+      targetSessionId: "revision-copy-1",
+      sourceTurnId: "revision-source-turn",
+    },
+  ]);
+  assert.equal(committed.size, 2);
+  assert.equal(fallbackIds, 0);
+
+  const newBranch = (await ipc.invoke("sessions:branchFromTurn", "source-session", {
+    sourceTurnId: "branch-source-turn",
+    copyId: "branch-copy-2",
+  })) as { id: string };
+  assert.equal(newBranch.id, "branch-copy-2");
+  assert.equal(committed.size, 3);
+});
+
 test("sends canonical content and uploads owned Attachment bytes through the Host", async () => {
   const starts: unknown[] = [];
   const uploads: unknown[] = [];

--- a/apps/desktop/src/main/__tests__/session-copy-attempt.test.ts
+++ b/apps/desktop/src/main/__tests__/session-copy-attempt.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type * as SessionCopyAttemptModule from '../../renderer/session-copy-attempt.js';
+
+test('one logical Session copy preserves its target and source boundary across renderer reload', async () => {
+  const storage = memoryStorage();
+  const key: SessionCopyAttemptModule.SessionCopyAttemptKey = {
+    scope: 'turn-footer:turn-reload',
+    kind: 'branch',
+    sourceSessionId: 'source-reload',
+  };
+  let sequence = 0;
+  const firstModule = await loadFreshModule('first');
+  const first = firstModule.acquireSessionCopyAttempt(
+    key,
+    'turn-before-reload',
+    storage,
+    () => `copy-${++sequence}`,
+  );
+
+  const reloadedModule = await loadFreshModule('reloaded');
+  assert.equal(first.phase, 'reserved');
+  assert.equal(firstModule.startSessionCopyAttempt(key, first.copyId, storage), true);
+  const retry = reloadedModule.acquireSessionCopyAttempt(
+    key,
+    'newer-settled-turn',
+    storage,
+    () => `copy-${++sequence}`,
+  );
+  assert.deepEqual(
+    { copyId: retry.copyId, sourceTurnId: retry.sourceTurnId, phase: retry.phase },
+    { copyId: first.copyId, sourceTurnId: 'turn-before-reload', phase: 'started' },
+  );
+  assert.equal(sequence, 1);
+
+  assert.equal(reloadedModule.abandonSessionCopyAttempt(key, retry.copyId, storage), true);
+  const abandoningModule = await loadFreshModule('abandoning');
+  const abandoning = abandoningModule.acquireSessionCopyAttempt(
+    key,
+    'newer-settled-turn',
+    storage,
+    () => `copy-${++sequence}`,
+  );
+  assert.equal(abandoning.phase, 'abandoning');
+  assert.equal(abandoningModule.startSessionCopyAttempt(key, abandoning.copyId, storage), false);
+
+  abandoning.complete();
+  const nextAction = abandoningModule.acquireSessionCopyAttempt(
+    key,
+    'newer-settled-turn',
+    storage,
+    () => `copy-${++sequence}`,
+  );
+  assert.notEqual(nextAction.copyId, first.copyId);
+  assert.equal(nextAction.sourceTurnId, 'newer-settled-turn');
+  assert.equal(sequence, 2);
+  nextAction.complete();
+});
+
+test('independent Branch and Revision actions never share a copy identity', async () => {
+  const storage = memoryStorage();
+  const module = await loadFreshModule('independent');
+  let sequence = 0;
+  const base = {
+    scope: 'conversation-actions:test-independent',
+    sourceSessionId: 'source-independent',
+  } as const;
+  const branch = module.acquireSessionCopyAttempt(
+    { ...base, kind: 'branch' },
+    'turn-independent',
+    storage,
+    () => `copy-${++sequence}`,
+  );
+  const revision = module.acquireSessionCopyAttempt(
+    { ...base, kind: 'revision' },
+    'turn-independent',
+    storage,
+    () => `copy-${++sequence}`,
+  );
+
+  assert.notEqual(branch.copyId, revision.copyId);
+  branch.complete();
+  revision.complete();
+});
+
+async function loadFreshModule(name: string): Promise<typeof SessionCopyAttemptModule> {
+  const url = new URL('../../renderer/session-copy-attempt.js', import.meta.url);
+  url.searchParams.set('instance', name);
+  return import(url.href) as Promise<typeof SessionCopyAttemptModule>;
+}
+
+function memoryStorage(): Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> {
+  const values = new Map<string, string>();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+  };
+}

--- a/apps/desktop/src/main/permission-response-guard.ts
+++ b/apps/desktop/src/main/permission-response-guard.ts
@@ -15,6 +15,7 @@ import {
 
 const MAX_PERMISSION_REQUEST_ID_LENGTH = 128;
 const MAX_TURN_ID_LENGTH = 128;
+const MAX_COPY_ID_LENGTH = 128;
 const MAX_BRANCH_NAME_LENGTH = 200;
 const MAX_SESSION_SEND_TEXT_LENGTH = 128_000;
 const MAX_QUOTE_COUNT = 16;
@@ -27,6 +28,9 @@ interface WorkspaceFileReferencePosition {
   value: string;
   start: number;
 }
+
+export type RuntimeHostBranchFromTurnInput = BranchFromTurnInput & { copyId: string };
+export type RuntimeHostReviseBeforeTurnInput = ReviseBeforeTurnInput & { copyId: string };
 
 interface NormalizedSendSessionCommand {
   type: 'send';
@@ -113,6 +117,26 @@ export function normalizeReviseBeforeTurnInput(input: unknown): ReviseBeforeTurn
       'Invalid revision sourceTurnId',
       MAX_TURN_ID_LENGTH,
     ),
+  };
+}
+
+export function normalizeRuntimeHostBranchFromTurnInput(
+  input: unknown,
+): RuntimeHostBranchFromTurnInput {
+  const value = requireObject(input, 'Invalid branch turn input');
+  return {
+    ...normalizeBranchFromTurnInput(value),
+    copyId: normalizeRequiredString(value.copyId, 'Invalid conversation copyId', MAX_COPY_ID_LENGTH),
+  };
+}
+
+export function normalizeRuntimeHostReviseBeforeTurnInput(
+  input: unknown,
+): RuntimeHostReviseBeforeTurnInput {
+  const value = requireObject(input, 'Invalid revision turn input');
+  return {
+    ...normalizeReviseBeforeTurnInput(value),
+    copyId: normalizeRequiredString(value.copyId, 'Invalid conversation copyId', MAX_COPY_ID_LENGTH),
   };
 }
 

--- a/apps/desktop/src/main/quote-companion-cleanup.ts
+++ b/apps/desktop/src/main/quote-companion-cleanup.ts
@@ -1,40 +1,49 @@
 import { acquireOperationalStateDatabase } from '@maka/storage';
 
-interface QuoteCompanionCleanupStore {
+interface SessionCopyCleanupStore {
   list(): Promise<string[]>;
   track(sessionId: string): Promise<void>;
   forget(sessionId: string): Promise<void>;
 }
 
-export interface QuoteCompanionCleanupRecovery {
+export type SessionCopyCleanupDisposition = 'removed' | 'retained';
+
+export interface SessionCopyCleanupRecovery {
   removed: string[];
   failed: Array<{ sessionId: string; error: unknown }>;
 }
 
-export interface QuoteCompanionCleanupAuthority {
+export interface SessionCopyCleanupAuthority {
   cleanup(sessionId: string): Promise<void>;
-  recover(): Promise<QuoteCompanionCleanupRecovery>;
+  schedule(sessionId: string): Promise<void>;
+  recover(): Promise<SessionCopyCleanupRecovery>;
 }
 
-export function createQuoteCompanionCleanupAuthority(input: {
+export function createSessionCopyCleanupAuthority(input: {
   workspaceRoot: string;
-  removeSession: (sessionId: string) => Promise<void>;
-}): QuoteCompanionCleanupAuthority {
-  return new QuoteCompanionCleanupAuthorityImpl(
-    new SqliteQuoteCompanionCleanupStore(input.workspaceRoot),
+  removeSession: (sessionId: string) => Promise<SessionCopyCleanupDisposition | void>;
+}): SessionCopyCleanupAuthority {
+  return new SessionCopyCleanupAuthorityImpl(
+    new SqliteSessionCopyCleanupStore(input.workspaceRoot),
     input.removeSession,
   );
 }
 
-class QuoteCompanionCleanupAuthorityImpl implements QuoteCompanionCleanupAuthority {
-  private readonly inFlight = new Map<string, Promise<void>>();
+class SessionCopyCleanupAuthorityImpl implements SessionCopyCleanupAuthority {
+  private readonly inFlight = new Map<string, Promise<SessionCopyCleanupDisposition>>();
 
   constructor(
-    private readonly store: QuoteCompanionCleanupStore,
-    private readonly removeSession: (sessionId: string) => Promise<void>,
+    private readonly store: SessionCopyCleanupStore,
+    private readonly removeSession: (
+      sessionId: string,
+    ) => Promise<SessionCopyCleanupDisposition | void>,
   ) {}
 
   cleanup(sessionId: string): Promise<void> {
+    return this.cleanupDisposition(sessionId).then(() => undefined);
+  }
+
+  private cleanupDisposition(sessionId: string): Promise<SessionCopyCleanupDisposition> {
     const normalized = normalizeSessionId(sessionId);
     const active = this.inFlight.get(normalized);
     if (active) return active;
@@ -45,13 +54,19 @@ class QuoteCompanionCleanupAuthorityImpl implements QuoteCompanionCleanupAuthori
     return operation;
   }
 
-  async recover(): Promise<QuoteCompanionCleanupRecovery> {
+  async schedule(sessionId: string): Promise<void> {
+    const normalized = normalizeSessionId(sessionId);
+    await this.store.track(normalized);
+    void this.cleanup(normalized).catch(() => undefined);
+  }
+
+  async recover(): Promise<SessionCopyCleanupRecovery> {
     const removed: string[] = [];
-    const failed: QuoteCompanionCleanupRecovery['failed'] = [];
+    const failed: SessionCopyCleanupRecovery['failed'] = [];
     for (const sessionId of await this.store.list()) {
       try {
-        await this.cleanup(sessionId);
-        removed.push(sessionId);
+        const disposition = await this.cleanupDisposition(sessionId);
+        if (disposition === 'removed') removed.push(sessionId);
       } catch (error) {
         failed.push({ sessionId, error });
       }
@@ -59,14 +74,15 @@ class QuoteCompanionCleanupAuthorityImpl implements QuoteCompanionCleanupAuthori
     return { removed, failed };
   }
 
-  private async cleanupOnce(sessionId: string): Promise<void> {
+  private async cleanupOnce(sessionId: string): Promise<SessionCopyCleanupDisposition> {
     await this.store.track(sessionId);
-    await this.removeSession(sessionId);
+    const disposition = (await this.removeSession(sessionId)) ?? 'removed';
     await this.store.forget(sessionId);
+    return disposition;
   }
 }
 
-class SqliteQuoteCompanionCleanupStore implements QuoteCompanionCleanupStore {
+class SqliteSessionCopyCleanupStore implements SessionCopyCleanupStore {
   constructor(private readonly workspaceRoot: string) {}
 
   async list(): Promise<string[]> {

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -52,6 +52,7 @@ import {
 import { resolveProjectContextRoot } from "./project-context-root.js";
 import { createProjectManagementService } from "./project-management-service.js";
 import { createProjectRootController } from "./project-root-controller.js";
+import { createSessionCopyCleanupAuthority } from "./quote-companion-cleanup.js";
 import {
   projectHostConnections,
   registerRuntimeHostConnectionsIpc,
@@ -282,6 +283,8 @@ owner = await startRuntimeHostDesktopOwner(
     emitModeChanged: (sessionId) =>
       emitSessionsChanged("mode-change", sessionId),
     completeComputerUseTurn,
+    createSessionCopyCleanup: ({ removeSession }) =>
+      createSessionCopyCleanupAuthority({ workspaceRoot, removeSession }),
     sendToRenderer: (channel, payload) =>
       mainWindowController.send(channel, payload),
     onError: (error) =>

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -680,6 +680,18 @@ export class DesktopRuntimeHostClient {
     throw revisionConflict("remove", sessionId);
   }
 
+  async removeSessionCopy(sessionId: string): Promise<'removed' | 'retained'> {
+    const current = await this.#requireSession(sessionId);
+    if (current.revisionOfTurnId !== undefined) {
+      const result = await this.#request('session.revision.abandon', {
+        targetSessionId: sessionId,
+      });
+      return result.kind === 'abandoned' ? 'removed' : 'retained';
+    }
+    await this.removeSession(sessionId);
+    return 'removed';
+  }
+
   async copySession(
     kind: "branch" | "revision",
     input: Omit<SessionConversationCopyInput, "expectedSourceRevision">,

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -15,6 +15,10 @@ import {
 } from "./bot-incoming-main.js";
 import { createRuntimeHostBotSessionAdapter } from "./runtime-host-bot-session-adapter.js";
 import { DesktopRuntimeHostClient } from "./runtime-host-client.js";
+import type {
+  SessionCopyCleanupAuthority,
+  SessionCopyCleanupDisposition,
+} from "./quote-companion-cleanup.js";
 import {
   createDesktopNativeCapabilityProvider,
   type DesktopNativeCapabilityProvider,
@@ -55,6 +59,9 @@ export interface DesktopRuntimeHostCandidateDeps {
   readonly onError?: RuntimeHostSessionDomainsIpcDeps["onError"];
   readonly newId?: () => string;
   readonly now?: () => number;
+  readonly createSessionCopyCleanup: (input: {
+    removeSession: (sessionId: string) => Promise<SessionCopyCleanupDisposition>;
+  }) => SessionCopyCleanupAuthority;
   readonly registerClientIpc?: (
     client: DesktopRuntimeHostClient,
     ipcMain: Pick<IpcMain, "handle">,
@@ -330,12 +337,22 @@ export async function createDesktopRuntimeHostCandidate(
         });
       return capabilityRefresh;
     };
+    const sessionCopyCleanup = deps.createSessionCopyCleanup({
+      removeSession: async (sessionId) => {
+        const disposition = await client.removeSessionCopy(sessionId);
+        if (disposition === "retained") return disposition;
+        await releaseNativeSession(sessionId).catch((error) => deps.onError?.(error));
+        deps.emitSessionsChanged("deleted", sessionId);
+        return disposition;
+      },
+    });
     registerRuntimeHostSessionCatalogIpc(
       {
         client,
         workspaceRoot: deps.workspaceRoot,
         emitSessionsChanged: deps.emitSessionsChanged,
         releaseSessionResources: releaseNativeSession,
+        sessionCopyCleanup,
         ...(deps.newId ? { newId: deps.newId } : {}),
       },
       ipc,

--- a/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
@@ -27,6 +27,7 @@ import {
   resolveSessionActionIds,
 } from './session-family-action.js';
 import { normalizeSessionModelSelection } from './session-model-input.js';
+import type { SessionCopyCleanupAuthority } from './quote-companion-cleanup.js';
 
 type RuntimeHostSessionCatalogClient = Pick<
   DesktopRuntimeHostClient,
@@ -51,6 +52,7 @@ export interface RuntimeHostSessionCatalogIpcDeps {
     extra?: Pick<SessionChangedEvent, 'connectionSlug' | 'modelId' | 'turnId'>,
   ) => void;
   releaseSessionResources: (sessionId: string) => void | Promise<void>;
+  sessionCopyCleanup: SessionCopyCleanupAuthority;
   newId?: () => string;
 }
 
@@ -60,9 +62,12 @@ export function registerRuntimeHostSessionCatalogIpc(
 ): void {
   const newId = deps.newId ?? randomUUID;
   const listSessions = async (filter?: SessionListFilter): Promise<DesktopHostSessionSummary[]> => {
+    const recovery = await deps.sessionCopyCleanup.recover();
+    const pendingCleanup = new Set(recovery.failed.map(({ sessionId }) => sessionId));
     const parentSessionId = normalizeParentSessionFilter(filter?.subagentParentSessionId);
     const sessions = await deps.client.listSessions(toHostCatalogFilter(filter));
     return sessions
+      .filter((session) => !pendingCleanup.has(session.id))
       .filter((session) =>
         parentSessionId === undefined ? true : session.subagent?.parentSessionId === parentSessionId,
       )
@@ -72,6 +77,12 @@ export function registerRuntimeHostSessionCatalogIpc(
     resolveSessionActionIds(() => listSessions(), sessionId, options);
 
   ipcMain.handle('sessions:list', (_event, filter?: SessionListFilter) => listSessions(filter));
+  ipcMain.handle('sessions:cleanupSessionCopy', async (_event, sessionId: string) => {
+    await deps.sessionCopyCleanup.cleanup(sessionId);
+  });
+  ipcMain.handle('sessions:abandonSessionCopy', async (_event, sessionId: string) => {
+    await deps.sessionCopyCleanup.schedule(sessionId);
+  });
   ipcMain.handle('sessions:create', async (_event, input?: CreateSessionRequestInput) => {
     if (input?.backend !== undefined && input.backend !== 'ai-sdk') {
       throw new Error('Unsupported Runtime Host Session backend');

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -14,9 +14,9 @@ import {
   resolveIngestItems,
 } from "./attachment-ingest.js";
 import {
-  normalizeBranchFromTurnInput,
+  normalizeRuntimeHostBranchFromTurnInput,
   normalizeRegenerateTurnInput,
-  normalizeReviseBeforeTurnInput,
+  normalizeRuntimeHostReviseBeforeTurnInput,
   normalizeSandboxBoundaryResponse,
   normalizeSessionSendCommand,
   normalizeUserQuestionResponse,
@@ -302,10 +302,10 @@ export function registerRuntimeHostSessionExecutionIpc(
   ipcMain.handle(
     "sessions:branchFromTurn",
     async (_event, sessionId: string, input: unknown) => {
-      const normalized = normalizeBranchFromTurnInput(input);
+      const normalized = normalizeRuntimeHostBranchFromTurnInput(input);
       let branch = await deps.client.copySession("branch", {
         sourceSessionId: sessionId,
-        targetSessionId: newId(),
+        targetSessionId: normalized.copyId,
         sourceTurnId: normalized.sourceTurnId,
       });
       if (normalized.name) {
@@ -320,10 +320,10 @@ export function registerRuntimeHostSessionExecutionIpc(
   ipcMain.handle(
     "sessions:reviseBeforeTurn",
     async (_event, sessionId: string, input: unknown) => {
-      const normalized = normalizeReviseBeforeTurnInput(input);
+      const normalized = normalizeRuntimeHostReviseBeforeTurnInput(input);
       const revision = await deps.client.copySession("revision", {
         sourceSessionId: sessionId,
-        targetSessionId: newId(),
+        targetSessionId: normalized.copyId,
         sourceTurnId: normalized.sourceTurnId,
       });
       deps.emitSessionsChanged("created", revision.id);

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -57,7 +57,7 @@ import { handleReviseBeforeTurn } from './session-revision.js';
 import { prepareSessionSendSkillPlan } from './session-send-skill-plan.js';
 import type { DesktopCreateSessionInput } from './new-session-project.js';
 import { registerSessionExecutionIpc } from './session-execution-ipc-main.js';
-import { createQuoteCompanionCleanupAuthority } from './quote-companion-cleanup.js';
+import { createSessionCopyCleanupAuthority } from './quote-companion-cleanup.js';
 import { mergeSentInlineReferences } from './session-send-inline-references.js';
 import { resolveSessionActionIds } from './session-family-action.js';
 import { normalizeSessionModelSelection } from './session-model-input.js';
@@ -234,7 +234,7 @@ export function registerSessionsIpc(
     automationManager.removeAllForSession(sessionId);
     emitSessionsChanged('deleted', sessionId);
   };
-  const quoteCompanionCleanup = createQuoteCompanionCleanupAuthority({
+  const sessionCopyCleanup = createSessionCopyCleanupAuthority({
     workspaceRoot,
     removeSession,
   });
@@ -252,7 +252,7 @@ export function registerSessionsIpc(
   ipcMain.handle('sessions:list', async (_event, filter?: SessionListFilter) => {
     // Listing is also a recovery trigger. Await it so an orphaned hidden
     // companion is removed before it can reappear in the sidebar after restart.
-    const recovery = await quoteCompanionCleanup.recover();
+    const recovery = await sessionCopyCleanup.recover();
     const pendingCleanup = new Set(recovery.failed.map(({ sessionId }) => sessionId));
     return (await runtime.listSessions(filter)).filter(
       ({ id }) => !pendingCleanup.has(id),
@@ -742,8 +742,13 @@ export function registerSessionsIpc(
       await removeSession(id);
     }
   });
-  ipcMain.handle('sessions:cleanupQuoteCompanion', async (_event, sessionId: string) => {
-    await quoteCompanionCleanup.cleanup(sessionId);
+  ipcMain.handle('sessions:cleanupSessionCopy', async (_event, sessionId: string) => {
+    if (!(await runtime.listSessions()).some((session) => session.id === sessionId)) return;
+    await sessionCopyCleanup.cleanup(sessionId);
+  });
+  ipcMain.handle('sessions:abandonSessionCopy', async (_event, sessionId: string) => {
+    if (!(await runtime.listSessions()).some((session) => session.id === sessionId)) return;
+    await sessionCopyCleanup.schedule(sessionId);
   });
 }
 

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -119,6 +119,16 @@ export type RendererIngestInput =
   | { approvalId: string; name: string; mimeType?: string }
   | { file: File };
 
+export type DesktopBranchFromTurnInput = BranchFromTurnInput & {
+  /** Stable target identity for retrying one Desktop copy action. */
+  copyId: string;
+};
+
+export type DesktopReviseBeforeTurnInput = ReviseBeforeTurnInput & {
+  /** Stable target identity for retrying one Desktop copy action. */
+  copyId: string;
+};
+
 export type LocalMemoryMutationResult =
   | { ok: true; state: LocalMemoryState; entry?: LocalMemoryEntryPreview; proposal?: LocalMemoryEntryPreview }
   | { ok: false; state: LocalMemoryState; reason: string; message: string };
@@ -267,8 +277,8 @@ export interface MakaBridge {
       | { disposition: 'park'; rejectionReasons: string[]; diagnostics: unknown[] }
     >;
     regenerateTurn(sessionId: string, input: RegenerateTurnInput): Promise<void>;
-    branchFromTurn(sessionId: string, input: BranchFromTurnInput): Promise<SessionSummary>;
-    reviseBeforeTurn(sessionId: string, input: ReviseBeforeTurnInput): Promise<SessionSummary>;
+    branchFromTurn(sessionId: string, input: DesktopBranchFromTurnInput): Promise<SessionSummary>;
+    reviseBeforeTurn(sessionId: string, input: DesktopReviseBeforeTurnInput): Promise<SessionSummary>;
     respondToSandboxBoundary(sessionId: string, response: SandboxBoundaryResponse): Promise<void>;
     respondToUserQuestion(sessionId: string, response: UserQuestionResponse): Promise<void>;
     saveConversationToFile(input: {
@@ -307,7 +317,8 @@ export interface MakaBridge {
     setModel(sessionId: string, input: { llmConnectionSlug: string; model: string }): Promise<SessionSummary>;
     setThinkingLevel(sessionId: string, level: ThinkingLevel | undefined | null): Promise<SessionSummary>;
     remove(sessionId: string, options?: { revisionFamily?: boolean }): Promise<void>;
-    cleanupQuoteCompanion(sessionId: string): Promise<void>;
+    cleanupSessionCopy(sessionId: string): Promise<void>;
+    abandonSessionCopy(sessionId: string): Promise<void>;
   };
   projects: {
     list(): Promise<ProjectRecord[]>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -6,6 +6,8 @@ import type {
   PermissionActionResult,
   PermissionOverlayStartResult,
   RendererIngestInput,
+  DesktopBranchFromTurnInput,
+  DesktopReviseBeforeTurnInput,
   AppUpdateInstallRequest,
   AppUpdateInstallResult,
   AppUpdateStatus,
@@ -55,10 +57,8 @@ import type {
   ArtifactDescriptor,
   ArtifactSaveResult,
   ArtifactTextReadResult,
-  BranchFromTurnInput,
   CapabilitySnapshotCollection,
   RegenerateTurnInput,
-  ReviseBeforeTurnInput,
   TurnRecord,
   PermissionSnapshot,
   LocalMemoryEntryPreview,
@@ -255,10 +255,10 @@ const makaBridge = {
     regenerateTurn(sessionId: string, input: RegenerateTurnInput): Promise<void> {
       return ipcRenderer.invoke('sessions:regenerateTurn', sessionId, input);
     },
-    branchFromTurn(sessionId: string, input: BranchFromTurnInput): Promise<SessionSummary> {
+    branchFromTurn(sessionId: string, input: DesktopBranchFromTurnInput): Promise<SessionSummary> {
       return ipcRenderer.invoke('sessions:branchFromTurn', sessionId, input);
     },
-    reviseBeforeTurn(sessionId: string, input: ReviseBeforeTurnInput): Promise<SessionSummary> {
+    reviseBeforeTurn(sessionId: string, input: DesktopReviseBeforeTurnInput): Promise<SessionSummary> {
       return ipcRenderer.invoke('sessions:reviseBeforeTurn', sessionId, input);
     },
     respondToSandboxBoundary(sessionId: string, response: SandboxBoundaryResponse): Promise<void> {
@@ -364,8 +364,11 @@ const makaBridge = {
     remove(sessionId: string, options?: { revisionFamily?: boolean }): Promise<void> {
       return ipcRenderer.invoke('sessions:remove', sessionId, options);
     },
-    cleanupQuoteCompanion(sessionId: string): Promise<void> {
-      return ipcRenderer.invoke('sessions:cleanupQuoteCompanion', sessionId);
+    cleanupSessionCopy(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('sessions:cleanupSessionCopy', sessionId);
+    },
+    abandonSessionCopy(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('sessions:abandonSessionCopy', sessionId);
     },
   },
   projects: {

--- a/apps/desktop/src/renderer/app-shell-revision-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-revision-actions.ts
@@ -7,6 +7,14 @@ import {
   isSessionWorkspaceUnavailableError,
   showSessionWorkspaceUnavailableToast,
 } from './session-workspace-errors.js';
+import {
+  acquireSessionCopyAttempt,
+  abandonSessionCopyAttempt,
+  completeSessionCopyAttempt,
+  startSessionCopyAttempt,
+  type SessionCopyAttemptPhase,
+  type SessionCopyAttemptKey,
+} from './session-copy-attempt.js';
 
 type RefBox<T> = { current: T };
 type MessageListUpdater = (
@@ -22,6 +30,8 @@ type ToastApi = {
 export type TurnRevisionDraft = {
   sourceSessionId: string;
   sourceTurnId: string;
+  copyId: string;
+  copyPhase: SessionCopyAttemptPhase;
   /** Active owner of the draft. Changes to the branch child after prepare. */
   draftSessionId: string;
   originalText: string;
@@ -81,6 +91,14 @@ export function createAppShellRevisionActions(deps: {
   } = deps;
   const copy = getDesktopConversationCopy(uiLocale).actions;
 
+  function revisionCopyKey(sourceSessionId: string, sourceTurnId: string): SessionCopyAttemptKey {
+    return {
+      scope: `edit-and-resend:${sourceTurnId}`,
+      kind: 'revision',
+      sourceSessionId,
+    };
+  }
+
   function beginEditUserMessage(turnId: string): void {
     const sessionId = activeIdRef.current;
     if (!sessionId) return;
@@ -136,9 +154,15 @@ export function createAppShellRevisionActions(deps: {
     }
 
     const prompt = userFacingText(userMessage);
+    const copyAttempt = acquireSessionCopyAttempt(
+      revisionCopyKey(sessionId, turnId),
+      turnId,
+    );
     commitRevisionDraft({
       sourceSessionId: sessionId,
-      sourceTurnId: turnId,
+      sourceTurnId: copyAttempt.sourceTurnId,
+      copyId: copyAttempt.copyId,
+      copyPhase: copyAttempt.phase,
       draftSessionId: sessionId,
       originalText: prompt,
       previousComposerText: composerRef.current?.getText() ?? '',
@@ -155,44 +179,128 @@ export function createAppShellRevisionActions(deps: {
   ): Promise<void> {
     composerRef.current?.clearDraft(revisionSessionId);
     const current = revisionDraftRef.current;
-    let restored: TurnRevisionDraft | undefined;
-    if (current?.draftSessionId === revisionSessionId) {
-      restored = { ...draft, draftSessionId: draft.sourceSessionId };
-      composerRef.current?.setDraft(draft.sourceSessionId, text);
-      commitRevisionDraft(restored);
-    }
     if (activeIdRef.current === revisionSessionId) {
       openSessionInChat(draft.sourceSessionId);
       setMessages([]);
       await refreshMessages(draft.sourceSessionId).catch(() => false);
-      if (activeIdRef.current === draft.sourceSessionId && revisionDraftRef.current === restored) {
-        composerRef.current?.setText(text);
-        composerRef.current?.focus();
-      }
     }
-    await window.maka.sessions.remove(revisionSessionId).catch(() => undefined);
+    const abandonment = await abandonRevisionCopy(draft, revisionSessionId);
+    const abandoningDraft = abandonment.draft;
+    let restored: TurnRevisionDraft | undefined;
+    if (current?.copyId === draft.copyId && revisionDraftRef.current === abandoningDraft) {
+      if (abandonment.acknowledged) {
+        const nextAttempt = acquireSessionCopyAttempt(
+          revisionCopyKey(draft.sourceSessionId, draft.sourceTurnId),
+          draft.sourceTurnId,
+        );
+        restored = {
+          ...draft,
+          sourceTurnId: nextAttempt.sourceTurnId,
+          copyId: nextAttempt.copyId,
+          copyPhase: nextAttempt.phase,
+          draftSessionId: draft.sourceSessionId,
+        };
+      } else {
+        restored = { ...abandoningDraft, draftSessionId: draft.sourceSessionId };
+      }
+      composerRef.current?.setDraft(draft.sourceSessionId, text);
+      commitRevisionDraft(restored);
+    }
+    if (activeIdRef.current === draft.sourceSessionId && revisionDraftRef.current === restored) {
+      composerRef.current?.setText(text);
+      composerRef.current?.focus();
+    }
     await refreshSessions().catch(() => []);
   }
 
+  function completeRevisionCopyAttempt(draft: TurnRevisionDraft): void {
+    completeTurnRevisionCopyAttempt(draft);
+  }
+
+  async function abandonRevisionCopy(
+    draft: TurnRevisionDraft,
+    revisionSessionId: string,
+  ): Promise<{ acknowledged: boolean; draft: TurnRevisionDraft }> {
+    const tracked = abandonSessionCopyAttempt(
+      revisionCopyKey(draft.sourceSessionId, draft.sourceTurnId),
+      draft.copyId,
+    );
+    const current = revisionDraftRef.current;
+    const trackedDraft = current?.copyId === draft.copyId ? current : draft;
+    const abandoningDraft =
+      tracked && trackedDraft.copyPhase !== 'abandoning'
+        ? { ...trackedDraft, copyPhase: 'abandoning' as const }
+        : trackedDraft;
+    if (revisionDraftRef.current === trackedDraft && abandoningDraft !== trackedDraft) {
+      commitRevisionDraft(abandoningDraft);
+    }
+    try {
+      // Main acknowledges only after the cleanup intent is durable; physical
+      // removal may finish after this renderer has closed the draft.
+      await window.maka.sessions.abandonSessionCopy(revisionSessionId);
+      completeRevisionCopyAttempt(draft);
+      return { acknowledged: true, draft: abandoningDraft };
+    } catch {
+      // An ambiguous cleanup acknowledgement stays in `abandoning`; this
+      // target may only retry cleanup and can never be copied into again.
+      return { acknowledged: false, draft: abandoningDraft };
+    }
+  }
+
   async function prepareRevisionSend(text: string): Promise<boolean> {
-    const draft = revisionDraftRef.current;
+    let draft = revisionDraftRef.current;
     if (!draft || activeIdRef.current !== draft.draftSessionId) return false;
     // A previous attempt already prepared the version; retry normal send there.
     if (draft.draftSessionId !== draft.sourceSessionId) return true;
 
-    const sourceSessionId = draft.sourceSessionId;
+    if (draft.copyPhase === 'abandoning') {
+      const abandonment = await abandonRevisionCopy(draft, draft.copyId);
+      if (
+        !abandonment.acknowledged ||
+        revisionDraftRef.current !== abandonment.draft ||
+        activeIdRef.current !== draft.sourceSessionId
+      ) {
+        return false;
+      }
+      const nextAttempt = acquireSessionCopyAttempt(
+        revisionCopyKey(draft.sourceSessionId, draft.sourceTurnId),
+        draft.sourceTurnId,
+      );
+      draft = {
+        ...draft,
+        copyId: nextAttempt.copyId,
+        copyPhase: nextAttempt.phase,
+      };
+      commitRevisionDraft(draft);
+    }
+
+    const startedDraft =
+      draft.copyPhase === 'started' ? draft : { ...draft, copyPhase: 'started' as const };
+    if (startedDraft !== draft) {
+      if (
+        !startSessionCopyAttempt(
+          revisionCopyKey(draft.sourceSessionId, draft.sourceTurnId),
+          draft.copyId,
+        )
+      ) {
+        return false;
+      }
+      commitRevisionDraft(startedDraft);
+    }
+    const sourceSessionId = startedDraft.sourceSessionId;
     let preparedSessionId: string | undefined;
     try {
       const newSession = await window.maka.sessions.reviseBeforeTurn(sourceSessionId, {
-        sourceTurnId: draft.sourceTurnId,
+        sourceTurnId: startedDraft.sourceTurnId,
+        copyId: startedDraft.copyId,
       });
       preparedSessionId = newSession.id;
-      if (activeIdRef.current !== sourceSessionId || revisionDraftRef.current !== draft) {
-        await rollbackPreparedRevision(draft, newSession.id, text);
+      if (activeIdRef.current !== sourceSessionId || revisionDraftRef.current !== startedDraft) {
+        await rollbackPreparedRevision(startedDraft, newSession.id, text);
         return false;
       }
 
-      const prepared = { ...draft, draftSessionId: newSession.id };
+      const prepared = { ...startedDraft, draftSessionId: newSession.id };
       composerRef.current?.setDraft(newSession.id, text);
       commitRevisionDraft(prepared);
       upsertSessionSummary(newSession);
@@ -204,7 +312,7 @@ export function createAppShellRevisionActions(deps: {
         activeIdRef.current !== newSession.id ||
         revisionDraftRef.current !== prepared
       ) {
-        await rollbackPreparedRevision(draft, newSession.id, text);
+        await rollbackPreparedRevision(startedDraft, newSession.id, text);
         return false;
       }
       composerRef.current?.focus();
@@ -213,7 +321,7 @@ export function createAppShellRevisionActions(deps: {
       return true;
     } catch (error) {
       if (preparedSessionId) {
-        await rollbackPreparedRevision(draft, preparedSessionId, text);
+        await rollbackPreparedRevision(startedDraft, preparedSessionId, text);
       }
       if (activeIdRef.current !== sourceSessionId) return false;
       if (isSessionWorkspaceUnavailableError(error)) {
@@ -231,18 +339,24 @@ export function createAppShellRevisionActions(deps: {
   async function cancelRevisionDraft(): Promise<void> {
     const draft = revisionDraftRef.current;
     if (!draft) return;
-    const preparedSessionId =
-      draft.draftSessionId !== draft.sourceSessionId ? draft.draftSessionId : undefined;
+    const cleanupSessionId = draft.copyPhase !== 'reserved'
+      ? draft.draftSessionId !== draft.sourceSessionId
+        ? draft.draftSessionId
+        : draft.copyId
+      : undefined;
+    if (cleanupSessionId) await abandonRevisionCopy(draft, cleanupSessionId);
+    else completeRevisionCopyAttempt(draft);
     commitRevisionDraft(null);
     composerRef.current?.setDraft(draft.sourceSessionId, draft.previousComposerText);
-    if (preparedSessionId) composerRef.current?.clearDraft(preparedSessionId);
+    if (draft.draftSessionId !== draft.sourceSessionId) {
+      composerRef.current?.clearDraft(draft.draftSessionId);
+    }
     if (activeIdRef.current !== draft.sourceSessionId) {
       openSessionInChat(draft.sourceSessionId);
       setMessages([]);
       await refreshMessages(draft.sourceSessionId).catch(() => false);
     }
-    if (preparedSessionId) {
-      await window.maka.sessions.remove(preparedSessionId).catch(() => undefined);
+    if (cleanupSessionId) {
       await refreshSessions().catch(() => []);
     }
     if (activeIdRef.current === draft.sourceSessionId) {
@@ -252,4 +366,35 @@ export function createAppShellRevisionActions(deps: {
   }
 
   return { beginEditUserMessage, prepareRevisionSend, cancelRevisionDraft };
+}
+
+export function completeTurnRevisionCopyAttempt(draft: TurnRevisionDraft): void {
+  completeSessionCopyAttempt(
+    {
+      scope: `edit-and-resend:${draft.sourceTurnId}`,
+      kind: 'revision',
+      sourceSessionId: draft.sourceSessionId,
+    },
+    draft.copyId,
+  );
+}
+
+export async function abandonTurnRevisionCopyAttempt(
+  draft: TurnRevisionDraft,
+): Promise<boolean> {
+  const key: SessionCopyAttemptKey = {
+    scope: `edit-and-resend:${draft.sourceTurnId}`,
+    kind: 'revision',
+    sourceSessionId: draft.sourceSessionId,
+  };
+  abandonSessionCopyAttempt(key, draft.copyId);
+  const targetSessionId =
+    draft.draftSessionId === draft.sourceSessionId ? draft.copyId : draft.draftSessionId;
+  try {
+    await window.maka.sessions.abandonSessionCopy(targetSessionId);
+    completeSessionCopyAttempt(key, draft.copyId);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/apps/desktop/src/renderer/app-shell-turn-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-actions.ts
@@ -6,6 +6,7 @@ import {
   isSessionWorkspaceUnavailableError,
   showSessionWorkspaceUnavailableToast,
 } from './session-workspace-errors.js';
+import { acquireSessionCopyAttempt } from './session-copy-attempt.js';
 
 type RefBox<T> = { current: T };
 type MessageListUpdater = (next: StoredMessage[] | ((current: StoredMessage[]) => StoredMessage[])) => void;
@@ -66,7 +67,19 @@ export function createAppShellTurnActions(deps: {
           toastApi.info(copy.regenerateStartedTitle, copy.regenerateStartedDescription);
         }
       } else if (actionId === 'branch') {
-        const newSession = await window.maka.sessions.branchFromTurn(sessionId, { sourceTurnId: turnId });
+        const copyAttempt = acquireSessionCopyAttempt(
+          {
+            scope: `turn-footer:${turnId}`,
+            kind: 'branch',
+            sourceSessionId: sessionId,
+          },
+          turnId,
+        );
+        const newSession = await window.maka.sessions.branchFromTurn(sessionId, {
+          sourceTurnId: copyAttempt.sourceTurnId,
+          copyId: copyAttempt.copyId,
+        });
+        copyAttempt.complete();
         upsertSessionSummary(newSession);
         if (activeIdRef.current === sessionId) {
           openSessionInChat(newSession.id);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -121,6 +121,8 @@ import {
 } from './app-shell-chat-actions';
 import { createAppShellTurnActions } from './app-shell-turn-actions';
 import {
+  abandonTurnRevisionCopyAttempt,
+  completeTurnRevisionCopyAttempt,
   createAppShellRevisionActions,
   type TurnRevisionDraft,
 } from './app-shell-revision-actions';
@@ -546,6 +548,8 @@ function AppShellContent({
     if (draft.sourceSessionId !== draft.draftSessionId) {
       composerRef.current?.clearDraft(draft.sourceSessionId);
     }
+    if (draft.copyPhase === 'reserved') completeTurnRevisionCopyAttempt(draft);
+    else void abandonTurnRevisionCopyAttempt(draft);
     commitRevisionDraft(null);
   }, [sessions, commitRevisionDraft]);
 
@@ -1740,6 +1744,7 @@ function AppShellContent({
     if (ok !== false && quotes) clearQuotes();
     if (ok !== false && revisionSend) {
       if (expectedRevisionDraft) {
+        completeTurnRevisionCopyAttempt(expectedRevisionDraft);
         composerRef.current?.clearDraft(expectedRevisionDraft.draftSessionId);
         if (expectedRevisionDraft.sourceSessionId !== expectedRevisionDraft.draftSessionId) {
           composerRef.current?.clearDraft(expectedRevisionDraft.sourceSessionId);

--- a/apps/desktop/src/renderer/quote-companion-core.ts
+++ b/apps/desktop/src/renderer/quote-companion-core.ts
@@ -7,7 +7,6 @@ import {
   type LiveTurnProjection,
 } from '@maka/ui';
 import type {
-  CreateSessionInput,
   PermissionMode,
   QuoteRef,
   SessionEvent,
@@ -15,6 +14,14 @@ import type {
   StoredMessage,
   TurnRecord,
 } from '@maka/core';
+import {
+  acquireSessionCopyAttempt,
+  abandonSessionCopyAttempt,
+  completeSessionCopyAttempt,
+  readSessionCopyAttempt,
+  startSessionCopyAttempt,
+  type SessionCopyAttemptKey,
+} from './session-copy-attempt.js';
 
 /** The companion is a read-only explanation surface: reads + local search are
  *  available and web/custom tools follow the normal permission path, while
@@ -33,10 +40,13 @@ type CompanionSendResult = { ok: true } | { ok: false; reason?: string };
 export interface CompanionSessionApi {
   readMessages(sessionId: string): Promise<StoredMessage[]>;
   listTurns(sessionId: string): Promise<TurnRecord[]>;
-  branchFromTurn(sessionId: string, input: { sourceTurnId: string; name?: string }): Promise<SessionSummary>;
-  create(input: Partial<CreateSessionInput>): Promise<SessionSummary>;
+  branchFromTurn(
+    sessionId: string,
+    input: { sourceTurnId: string; name?: string; copyId: string },
+  ): Promise<SessionSummary>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
-  cleanupQuoteCompanion(sessionId: string): Promise<void>;
+  cleanupSessionCopy(sessionId: string): Promise<void>;
+  abandonSessionCopy(sessionId: string): Promise<void>;
   send(
     sessionId: string,
     command: { type: 'send'; turnId: string; text: string; quotes?: QuoteRef[] },
@@ -58,6 +68,20 @@ export type EnsureCompanionForkResult =
   | { status: 'disposed' }
   | { status: 'error'; code: CompanionErrorCode };
 
+export interface CompanionDismissalGuard {
+  beginMount(): () => boolean;
+}
+
+export function createCompanionDismissalGuard(): CompanionDismissalGuard {
+  let generation = 0;
+  return {
+    beginMount: () => {
+      const mountedGeneration = ++generation;
+      return () => generation === mountedGeneration;
+    },
+  };
+}
+
 export interface EnsureCompanionForkDeps {
   api: CompanionSessionApi;
   sourceSession: SessionSummary;
@@ -76,6 +100,44 @@ export interface EnsureCompanionForkDeps {
  *  A `running` turn is skipped so a fork never branches mid-turn. */
 export function latestSettledTurnId(turns: readonly TurnRecord[]): string | undefined {
   return [...turns].reverse().find((turn) => turn.status !== 'running')?.turnId;
+}
+
+function companionCopyAttemptKey(sourceSessionId: string): SessionCopyAttemptKey {
+  return { scope: 'quote-companion', kind: 'branch', sourceSessionId };
+}
+
+export async function abandonPendingCompanionCopy(
+  api: CompanionSessionApi,
+  sourceSessionId: string,
+): Promise<boolean> {
+  const key = companionCopyAttemptKey(sourceSessionId);
+  const attempt = readSessionCopyAttempt(key);
+  if (!attempt) return true;
+  abandonSessionCopyAttempt(key, attempt.copyId);
+  try {
+    await api.abandonSessionCopy(attempt.copyId);
+    completeSessionCopyAttempt(key, attempt.copyId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function cleanupCompanionCopy(
+  api: CompanionSessionApi,
+  sourceSessionId: string,
+  companionSessionId: string,
+): Promise<boolean> {
+  const key = companionCopyAttemptKey(sourceSessionId);
+  const attempt = readSessionCopyAttempt(key);
+  if (attempt) abandonSessionCopyAttempt(key, attempt.copyId);
+  try {
+    await api.cleanupSessionCopy(companionSessionId);
+    if (attempt) completeSessionCopyAttempt(key, attempt.copyId);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -102,10 +164,9 @@ export function deriveCompanionComposerState(
  * lifecycle paths can remain fire-and-forget without losing recovery.
  */
 function scheduleCompanionCleanup(deps: EnsureCompanionForkDeps, sessionId: string): void {
-  void deps.api
-    .cleanupQuoteCompanion(sessionId)
-    .then(() => deps.onForkCleanupSucceeded?.(sessionId))
-    .catch(() => {});
+  void cleanupCompanionCopy(deps.api, deps.sourceSession.id, sessionId).then((cleaned) => {
+    if (cleaned) deps.onForkCleanupSucceeded?.(sessionId);
+  });
 }
 
 /**
@@ -136,23 +197,34 @@ export async function ensureCompanionFork(
   }
   if (isDisposed()) return { status: 'disposed' };
   const boundaryTurnId = latestSettledTurnId(turns);
-
-  let created: SessionSummary;
-  try {
-    created = boundaryTurnId
-      ? await api.branchFromTurn(sourceSession.id, { sourceTurnId: boundaryTurnId, name })
-      : await api.create({
-          ...(sourceSession.cwd ? { cwd: sourceSession.cwd } : {}),
-          backend: sourceSession.backend,
-          llmConnectionSlug: sourceSession.llmConnectionSlug,
-          model: sourceSession.model,
-          parentSessionId: sourceSession.id,
-          name,
-        });
-  } catch {
+  if (!boundaryTurnId) return { status: 'error', code: 'fork_setup_failed' };
+  let copyAttempt = acquireSessionCopyAttempt(
+    companionCopyAttemptKey(sourceSession.id),
+    boundaryTurnId,
+  );
+  if (copyAttempt.phase === 'abandoning') {
+    if (!(await abandonPendingCompanionCopy(api, sourceSession.id))) {
+      return { status: 'error', code: 'fork_setup_failed' };
+    }
+    copyAttempt = acquireSessionCopyAttempt(
+      companionCopyAttemptKey(sourceSession.id),
+      boundaryTurnId,
+    );
+  }
+  if (!startSessionCopyAttempt(companionCopyAttemptKey(sourceSession.id), copyAttempt.copyId)) {
     return { status: 'error', code: 'fork_setup_failed' };
   }
 
+  let created: SessionSummary;
+  try {
+    created = await api.branchFromTurn(sourceSession.id, {
+      sourceTurnId: copyAttempt.sourceTurnId,
+      name,
+      copyId: copyAttempt.copyId,
+    });
+  } catch {
+    return { status: 'error', code: 'fork_setup_failed' };
+  }
   if (isDisposed()) {
     scheduleCompanionCleanup(deps, created.id);
     return { status: 'disposed' };

--- a/apps/desktop/src/renderer/quote-companion-panel.tsx
+++ b/apps/desktop/src/renderer/quote-companion-panel.tsx
@@ -125,7 +125,9 @@ export function QuoteCompanionPanel(props: {
                   size="sm"
                   className="maka-quote-panel-clear"
                   label={copy.exit}
-                  onClick={props.onClear}
+                  onClick={() => {
+                    void companion.abandonPendingCopy().finally(() => props.onClear?.());
+                  }}
                 />
               </div>
             )}

--- a/apps/desktop/src/renderer/session-copy-attempt.ts
+++ b/apps/desktop/src/renderer/session-copy-attempt.ts
@@ -1,0 +1,176 @@
+const SESSION_COPY_ATTEMPTS_KEY = 'maka-session-copy-attempts-v3';
+
+type SessionStorageLike = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+export type SessionCopyAttemptKey = {
+  scope: string;
+  kind: 'branch' | 'revision';
+  sourceSessionId: string;
+};
+
+export type SessionCopyAttemptPhase = 'reserved' | 'started' | 'abandoning';
+
+export interface SessionCopyAttempt {
+  copyId: string;
+  sourceTurnId: string;
+  phase: SessionCopyAttemptPhase;
+  complete(): void;
+}
+
+type PersistedSessionCopyAttempt = Pick<SessionCopyAttempt, 'copyId' | 'sourceTurnId' | 'phase'>;
+
+const memoryAttempts = new Map<string, PersistedSessionCopyAttempt>();
+
+function rendererSessionStorage(): SessionStorageLike | undefined {
+  try {
+    return typeof sessionStorage === 'undefined' ? undefined : sessionStorage;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Acquire the stable target and source boundary for one logical Session copy.
+ * The lease survives renderer reload through sessionStorage, but ends with the
+ * window. Ambiguous failures deliberately leave it open; confirmed success or
+ * authoritative cleanup calls complete so the next user action starts fresh.
+ */
+export function acquireSessionCopyAttempt(
+  key: SessionCopyAttemptKey,
+  sourceTurnId: string,
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+  newId: () => string = () => crypto.randomUUID(),
+): SessionCopyAttempt {
+  const encodedKey = encodeAttemptKey(key);
+  const attempts = readAttempts(storage);
+  let attempt = attempts.get(encodedKey);
+  if (!attempt) {
+    attempt = { copyId: newId(), sourceTurnId, phase: 'reserved' };
+    attempts.set(encodedKey, attempt);
+    writeAttempts(storage, attempts);
+  }
+  memoryAttempts.set(encodedKey, attempt);
+  return {
+    ...attempt,
+    complete: () => completeSessionCopyAttempt(key, attempt.copyId, storage),
+  };
+}
+
+export function startSessionCopyAttempt(
+  key: SessionCopyAttemptKey,
+  copyId: string,
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): boolean {
+  const encodedKey = encodeAttemptKey(key);
+  const attempts = readAttempts(storage);
+  const current = attempts.get(encodedKey);
+  if (!current || current.copyId !== copyId) return false;
+  if (current.phase === 'abandoning') return false;
+  if (current.phase === 'reserved') {
+    const started = { ...current, phase: 'started' as const };
+    attempts.set(encodedKey, started);
+    memoryAttempts.set(encodedKey, started);
+    writeAttempts(storage, attempts);
+  }
+  return true;
+}
+
+export function abandonSessionCopyAttempt(
+  key: SessionCopyAttemptKey,
+  copyId: string,
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): boolean {
+  const encodedKey = encodeAttemptKey(key);
+  const attempts = readAttempts(storage);
+  const current = attempts.get(encodedKey);
+  if (!current || current.copyId !== copyId) return false;
+  if (current.phase !== 'abandoning') {
+    const abandoning = { ...current, phase: 'abandoning' as const };
+    attempts.set(encodedKey, abandoning);
+    memoryAttempts.set(encodedKey, abandoning);
+    writeAttempts(storage, attempts);
+  }
+  return true;
+}
+
+export function readSessionCopyAttempt(
+  key: SessionCopyAttemptKey,
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): PersistedSessionCopyAttempt | undefined {
+  return readAttempts(storage).get(encodeAttemptKey(key));
+}
+
+export function completeSessionCopyAttempt(
+  key: SessionCopyAttemptKey,
+  copyId: string,
+  storage: SessionStorageLike | undefined = rendererSessionStorage(),
+): void {
+  const encodedKey = encodeAttemptKey(key);
+  const current = readAttempts(storage);
+  if (current.get(encodedKey)?.copyId === copyId) {
+    current.delete(encodedKey);
+    writeAttempts(storage, current);
+  }
+  if (memoryAttempts.get(encodedKey)?.copyId === copyId) memoryAttempts.delete(encodedKey);
+}
+
+function encodeAttemptKey(key: SessionCopyAttemptKey): string {
+  return JSON.stringify([key.scope, key.kind, key.sourceSessionId]);
+}
+
+function readAttempts(
+  storage: SessionStorageLike | undefined,
+): Map<string, PersistedSessionCopyAttempt> {
+  try {
+    const raw = storage?.getItem(SESSION_COPY_ATTEMPTS_KEY);
+    if (!raw) return new Map(memoryAttempts);
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return new Map(memoryAttempts);
+    const attempts = new Map<string, PersistedSessionCopyAttempt>();
+    for (const entry of parsed) {
+      if (
+        Array.isArray(entry) &&
+        entry.length === 2 &&
+        typeof entry[0] === 'string' &&
+        entry[0].length <= 1_024 &&
+        isPersistedAttempt(entry[1])
+      ) {
+        attempts.set(entry[0], entry[1]);
+      }
+    }
+    for (const [key, attempt] of memoryAttempts) {
+      if (!attempts.has(key)) attempts.set(key, attempt);
+    }
+    return attempts;
+  } catch {
+    return new Map(memoryAttempts);
+  }
+}
+
+function writeAttempts(
+  storage: SessionStorageLike | undefined,
+  attempts: Map<string, PersistedSessionCopyAttempt>,
+): void {
+  try {
+    if (attempts.size === 0) storage?.removeItem(SESSION_COPY_ATTEMPTS_KEY);
+    else storage?.setItem(SESSION_COPY_ATTEMPTS_KEY, JSON.stringify([...attempts]));
+  } catch {
+    // Restricted renderer contexts keep the process-local lease until reload.
+  }
+}
+
+function isPersistedAttempt(value: unknown): value is PersistedSessionCopyAttempt {
+  if (!value || typeof value !== 'object') return false;
+  const attempt = value as { copyId?: unknown; sourceTurnId?: unknown; phase?: unknown };
+  return (
+    typeof attempt.copyId === 'string' &&
+    attempt.copyId.length > 0 &&
+    attempt.copyId.length <= 128 &&
+    typeof attempt.sourceTurnId === 'string' &&
+    attempt.sourceTurnId.length > 0 &&
+    attempt.sourceTurnId.length <= 128 &&
+    (attempt.phase === 'reserved' ||
+      attempt.phase === 'started' ||
+      attempt.phase === 'abandoning')
+  );
+}

--- a/apps/desktop/src/renderer/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/use-quote-companion.ts
@@ -20,7 +20,10 @@ import type {
   UserQuestionResponse,
 } from '@maka/core';
 import {
+  abandonPendingCompanionCopy,
   applyCompanionInteractionEvent,
+  cleanupCompanionCopy,
+  createCompanionDismissalGuard,
   deriveCompanionComposerState,
   isCompanionTurnTerminal,
   performCompanionTurn,
@@ -72,6 +75,7 @@ export interface UseQuoteCompanionResult {
   /** Returns whether the send was accepted; false leaves the draft + staged
    *  quotes in place so the user can retry. */
   send: (text: string) => Promise<boolean>;
+  abandonPendingCopy: () => Promise<void>;
   stop: () => Promise<void>;
   respondToSandboxBoundary: (response: SandboxBoundaryResponse) => Promise<void>;
   respondToUserQuestion: (response: UserQuestionResponse) => Promise<void>;
@@ -113,6 +117,8 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   // A created fork is hidden immediately, before its permission pin completes,
   // but is not considered usable until onForkCommitted promotes it.
   const pendingForkIdRef = useRef<string | null>(null);
+  const sourceSessionIdRef = useRef(sourceSession?.id);
+  sourceSessionIdRef.current = sourceSession?.id;
   const onForkVisibilityChangeRef = useRef(onForkVisibilityChange);
   onForkVisibilityChangeRef.current = onForkVisibilityChange;
   const localeRef = useRef(locale);
@@ -135,6 +141,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   // StrictMode-safe mounted guard (re-arms on the dev mount → unmount → remount
   // double-invoke; a hand-rolled disposed flag would stay tripped after replay).
   const mountedRef = useMountedRef();
+  const dismissalGuardRef = useRef(createCompanionDismissalGuard());
 
   // Subscribe to the fork's event stream + load its transcript. Called
   // synchronously the moment the fork is committed, BEFORE the run starts, so
@@ -176,22 +183,28 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   // switching source session, or collapsing the workbar — unsubscribe and remove
   // the fork so it never lingers in the session list. Runs only on unmount.
   useEffect(() => {
+    const shouldDismiss = dismissalGuardRef.current.beginMount();
     return () => {
-      unsubscribeRef.current?.();
-      const id = companionIdRef.current ?? pendingForkIdRef.current;
-      if (id) {
-        // The main-process authority records this intent before attempting the
-        // full removal, and retries it on a later session list / app restart.
-        void window.maka.sessions
-          .cleanupQuoteCompanion(id)
-          .then(() =>
-            onForkVisibilityChangeRef.current?.({
-              type: 'cleanup-succeeded',
-              sessionId: id,
-            }),
-          )
-          .catch(() => {});
-      }
+      queueMicrotask(() => {
+        // React StrictMode immediately replays mount effects in development.
+        // A later setup generation means this was not a real panel dismissal.
+        if (!shouldDismiss()) return;
+        unsubscribeRef.current?.();
+        const sourceSessionId = sourceSessionIdRef.current;
+        const id = companionIdRef.current ?? pendingForkIdRef.current;
+        if (id && sourceSessionId) {
+          void cleanupCompanionCopy(window.maka.sessions, sourceSessionId, id).then((cleaned) => {
+            if (cleaned) {
+              onForkVisibilityChangeRef.current?.({
+                type: 'cleanup-succeeded',
+                sessionId: id,
+              });
+            }
+          });
+        } else if (sourceSessionId) {
+          void abandonPendingCompanionCopy(window.maka.sessions, sourceSessionId);
+        }
+      });
     };
   }, []);
 
@@ -279,6 +292,11 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
     [turnInFlight, sourceSession, panelId, pendingQuotes, onQuotesConsumed, subscribeToFork, mountedRef],
   );
 
+  const abandonPendingCopy = useCallback(async (): Promise<void> => {
+    if (!sourceSession) return;
+    await abandonPendingCompanionCopy(window.maka.sessions, sourceSession.id);
+  }, [sourceSession]);
+
   const stop = useCallback(async (): Promise<void> => {
     const id = companionIdRef.current;
     if (!id) return;
@@ -346,6 +364,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
     activeSandboxBoundary,
     activeQuestion,
     send,
+    abandonPendingCopy,
     stop,
     respondToSandboxBoundary,
     respondToUserQuestion,

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -112,6 +112,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'session.read_marker.set',
       'session.recap.generate',
       'session.remove',
+      'session.revision.abandon',
       'session.revision.create',
       'session.transcript.query',
       'skill.catalog.mutate',

--- a/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
@@ -82,6 +82,20 @@ describe('Session revision protocol', () => {
         }),
       isInvalidFrame,
     );
+    assert.deepEqual(
+      decodeHostFrame({
+        requestId: 'request-abandon',
+        operation: 'session.revision.abandon',
+        ok: true,
+        result: { kind: 'retained', sessionId: 'revision-target' },
+      }),
+      {
+        requestId: 'request-abandon',
+        operation: 'session.revision.abandon',
+        ok: true,
+        result: { kind: 'retained', sessionId: 'revision-target' },
+      },
+    );
   });
 
   test('preserves optimistic source revision conflicts on the wire', () => {
@@ -106,6 +120,27 @@ describe('Session revision protocol', () => {
           actualRevision: 5,
         },
       },
+    );
+  });
+
+  test('keeps single-target Revision abandonment identity exact', () => {
+    const frame = decodeClientFrame({
+      requestId: 'request-abandon',
+      operation: 'session.revision.abandon',
+      input: { targetSessionId: 'revision-target' },
+    });
+    assert.deepEqual(frame, {
+      requestId: 'request-abandon',
+      operation: 'session.revision.abandon',
+      input: { targetSessionId: 'revision-target' },
+    });
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['session.revision.abandon'].assertOutputForInput?.(
+          { targetSessionId: 'revision-target' },
+          { kind: 'abandoned', sessionId: 'other-target' },
+        ),
+      isInvalidFrame,
     );
   });
 });

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -255,6 +255,13 @@ async function verifyConcurrentRevisionAuthority(
     if (renamed.kind !== 'committed') assert.fail('Source rename must commit');
     const renamedSource = requireSessionProjection(renamed.session);
     assert.deepEqual(await tui.request('session.branch.create', branchInput), desktopBranch);
+    assert.deepEqual(
+      await tui.request('session.branch.create', {
+        ...branchInput,
+        expectedSourceRevision: renamedSource.revision,
+      }),
+      desktopBranch,
+    );
 
     const revisionInput = {
       sourceSessionId,
@@ -271,6 +278,28 @@ async function verifyConcurrentRevisionAuthority(
     assert.equal(revision.revisionOfTurnId, 'turn-2');
     assert.equal(revision.revisionIndex, 2);
     assert.equal(revision.revisionState, 'preparing');
+
+    const abandonedTargetId = 'abandoned-revision-target';
+    const abandonedRevision = await desktop.request('session.revision.create', {
+      ...revisionInput,
+      targetSessionId: abandonedTargetId,
+    });
+    assert.equal(abandonedRevision.kind, 'committed');
+    assert.deepEqual(
+      await desktop.request('session.revision.abandon', {
+        targetSessionId: abandonedTargetId,
+      }),
+      { kind: 'abandoned', sessionId: abandonedTargetId },
+    );
+    assert.equal((await querySession(desktop, sourceSessionId)).id, sourceSessionId);
+    assert.equal((await querySession(desktop, REVISION_TARGET_ID)).id, REVISION_TARGET_ID);
+    assert.deepEqual(
+      await desktop.request('session.catalog.query', {
+        kind: 'get',
+        sessionId: abandonedTargetId,
+      }),
+      { kind: 'session', session: null },
+    );
 
     const sourceAfterRevision = await querySession(tui, sourceSessionId);
     const staleExpectedRevision = sourceAfterRevision.revision + 1;
@@ -354,6 +383,16 @@ async function verifyRestartRecoveryAndAdmission(
       (await querySession(restarted, ADMITTED_REVISION_TARGET_ID)).revisionState,
       'committed',
     );
+    assert.deepEqual(
+      await restarted.request('session.revision.abandon', {
+        targetSessionId: ADMITTED_REVISION_TARGET_ID,
+      }),
+      { kind: 'retained', sessionId: ADMITTED_REVISION_TARGET_ID },
+    );
+    assert.equal(
+      (await querySession(restarted, ADMITTED_REVISION_TARGET_ID)).id,
+      ADMITTED_REVISION_TARGET_ID,
+    );
 
     const lineageRevision = await restarted.request('session.revision.create', {
       sourceSessionId,
@@ -372,6 +411,20 @@ async function verifyRestartRecoveryAndAdmission(
       expectedSourceRevision: lineageSource.revision,
     });
     assert.equal(lineageBranch.kind, 'committed');
+    assert.deepEqual(
+      await restarted.request('session.revision.abandon', {
+        targetSessionId: LINEAGE_REVISION_TARGET_ID,
+      }),
+      { kind: 'retained', sessionId: LINEAGE_REVISION_TARGET_ID },
+    );
+    assert.equal(
+      (await querySession(restarted, LINEAGE_REVISION_TARGET_ID)).id,
+      LINEAGE_REVISION_TARGET_ID,
+    );
+    assert.equal(
+      (await querySession(restarted, LINEAGE_BRANCH_TARGET_ID)).id,
+      LINEAGE_BRANCH_TARGET_ID,
+    );
   } finally {
     await restarted.close();
   }

--- a/packages/runtime-host/src/protocol/session-revision.ts
+++ b/packages/runtime-host/src/protocol/session-revision.ts
@@ -34,6 +34,14 @@ export type SessionConversationCopyResult =
       readonly actualRevision: number;
     };
 
+export interface SessionRevisionAbandonInput {
+  readonly targetSessionId: string;
+}
+
+export type SessionRevisionAbandonResult =
+  | { readonly kind: 'abandoned'; readonly sessionId: string }
+  | { readonly kind: 'retained'; readonly sessionId: string };
+
 export const SESSION_REVISION_OPERATION_SPECS = {
   'session.branch.create': defineOperation<
     SessionConversationCopyInput,
@@ -59,7 +67,42 @@ export const SESSION_REVISION_OPERATION_SPECS = {
     decodeOutput: decodeSessionConversationCopyResult,
     assertOutputForInput: assertConversationCopyOutput,
   }),
+  'session.revision.abandon': defineOperation<
+    SessionRevisionAbandonInput,
+    SessionRevisionAbandonResult,
+    (typeof SESSION_COPY_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: SESSION_COPY_ERRORS,
+    decodeInput: decodeSessionRevisionAbandonInput,
+    decodeOutput: decodeSessionRevisionAbandonResult,
+    assertOutputForInput: (input, output) => {
+      if (output.sessionId !== input.targetSessionId) {
+        throw invalidProtocolFrame('Abandoned Session revision identity does not match request');
+      }
+    },
+  }),
 } as const;
+
+function decodeSessionRevisionAbandonInput(value: unknown): SessionRevisionAbandonInput {
+  const input = requireExactRecord(value, 'Session revision abandon input', ['targetSessionId']);
+  return { targetSessionId: requireEntityId(input.targetSessionId, 'targetSessionId') };
+}
+
+function decodeSessionRevisionAbandonResult(value: unknown): SessionRevisionAbandonResult {
+  const result = requireExactRecord(value, 'Session revision abandon result', [
+    'kind',
+    'sessionId',
+  ]);
+  if (result.kind !== 'abandoned' && result.kind !== 'retained') {
+    throw invalidProtocolFrame('Invalid Session revision abandon result kind');
+  }
+  return {
+    kind: result.kind,
+    sessionId: requireEntityId(result.sessionId, 'sessionId'),
+  };
+}
 
 export function decodeSessionConversationCopyInput(value: unknown): SessionConversationCopyInput {
   const input = requireExactRecord(value, 'Session conversation-copy input', [

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -66,7 +66,7 @@ export type SessionContinuityOperationKey = Extract<
 >;
 export type SessionRevisionOperationKey = Extract<
   OperationKey,
-  'session.branch.create' | 'session.revision.create'
+  'session.branch.create' | 'session.revision.create' | 'session.revision.abandon'
 >;
 export type SessionRetirementOperationKey = Extract<
   OperationKey,

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -35,6 +35,8 @@ import type {
   OperationOutcome,
   SessionConversationCopyInput,
   SessionConversationCopyResult,
+  SessionRevisionAbandonInput,
+  SessionRevisionAbandonResult,
 } from '../protocol/index.js';
 import type {
   SessionRevisionOperationHandlerMap,
@@ -50,7 +52,12 @@ import {
 import { purgeSessionSidecars } from './session-sidecar-purge.js';
 
 type ConversationCopyKind = 'branch' | 'revision';
-type ConversationCopyOutcome = OperationOutcome<SessionRevisionOperationKey>;
+type ConversationCopyOperationKey = Exclude<
+  SessionRevisionOperationKey,
+  'session.revision.abandon'
+>;
+type ConversationCopyOutcome = OperationOutcome<ConversationCopyOperationKey>;
+type RevisionAbandonOutcome = OperationOutcome<'session.revision.abandon'>;
 const CONVERSATION_COPY_ADMISSION_PASSES = 2;
 interface ConversationCopyAdmissionRetry {
   readonly kind: 'retry_admission';
@@ -77,6 +84,7 @@ export class HostSessionRevisionCoordinator {
   readonly handlers: SessionRevisionOperationHandlerMap = {
     'session.branch.create': (input) => this.#copy('branch', input),
     'session.revision.create': (input) => this.#copy('revision', input),
+    'session.revision.abandon': (input) => this.#abandonRevision(input),
   };
 
   readonly #stores: ExecutionStoresWriter<'interactive'>;
@@ -176,6 +184,42 @@ export class HostSessionRevisionCoordinator {
       for (const sessionId of result.sessionIds) admittedSessionIds.add(sessionId);
     }
     return copyFailure('session_busy', 'Agent Graph child ownership changed during copy');
+  }
+
+  async #abandonRevision(input: SessionRevisionAbandonInput): Promise<RevisionAbandonOutcome> {
+    return this.options.admission.run(input.targetSessionId, async () => {
+      let header: SessionHeader;
+      try {
+        header = await this.#stores.sessionStore.readHeaderSnapshot(input.targetSessionId);
+      } catch (error) {
+        return isSessionNotFoundError(error)
+          ? abandonFailure('not_found', 'Target Session revision does not exist')
+          : abandonFailure('persistence_failed', 'Target Session revision is unavailable');
+      }
+      if (header.conversationCopy?.kind !== 'revision') {
+        return abandonFailure('operation_conflict', 'Target is not a Session revision copy');
+      }
+      if (
+        header.revisionState !== 'preparing' ||
+        this.options.isSessionActive(input.targetSessionId) ||
+        (await this.#hasAdmittedRevisionTurn(input.targetSessionId)) ||
+        (await this.#hasCommittedConversationCopyDependent(input.targetSessionId))
+      ) {
+        return abandonSuccess({ kind: 'retained', sessionId: input.targetSessionId });
+      }
+      try {
+        await this.#discard(header);
+        return abandonSuccess({
+          kind: 'abandoned',
+          sessionId: input.targetSessionId,
+        });
+      } catch {
+        return abandonFailure(
+          'persistence_failed',
+          'Target Session revision could not be abandoned',
+        );
+      }
+    });
   }
 
   async #copyAdmitted(
@@ -687,6 +731,14 @@ export class HostSessionRevisionCoordinator {
     }
     return boundary >= 0 && messages.slice(boundary + 1).some((message) => message.type === 'user');
   }
+
+  async #hasCommittedConversationCopyDependent(sessionId: string): Promise<boolean> {
+    return (await this.#stores.sessionStore.listHeaders()).some(
+      (header) =>
+        header.conversationCopy?.state === 'committed' &&
+        header.conversationCopy.sourceSessionId === sessionId,
+    );
+  }
 }
 
 function isConversationRuntimeFactRewriteUnsupported(error: unknown): boolean {
@@ -701,15 +753,17 @@ function conversationCopyFingerprint(
   kind: ConversationCopyKind,
   input: SessionConversationCopyInput,
 ): `sha256:${string}` {
+  // The optimistic source revision guards only the initial create. Once this
+  // target exists, its stable identity must resolve the committed outcome even
+  // if a reconnecting Client observes a newer source revision.
   return `sha256:${createHash('sha256')
     .update(
       JSON.stringify([
-        'session.conversation-copy.v0',
+        'session.conversation-copy.v1',
         kind,
         input.sourceSessionId,
         input.targetSessionId,
         input.sourceTurnId,
-        input.expectedSourceRevision,
       ]),
     )
     .digest('hex')}`;
@@ -806,9 +860,20 @@ function copySuccess(result: SessionConversationCopyResult): ConversationCopyOut
   return { ok: true, result };
 }
 
+function abandonSuccess(result: SessionRevisionAbandonResult): RevisionAbandonOutcome {
+  return { ok: true, result };
+}
+
 function copyFailure(
   code: Extract<ConversationCopyOutcome, { ok: false }>['error']['code'],
   message: string,
 ): ConversationCopyOutcome {
+  return { ok: false, error: { code, message } };
+}
+
+function abandonFailure(
+  code: Extract<RevisionAbandonOutcome, { ok: false }>['error']['code'],
+  message: string,
+): RevisionAbandonOutcome {
   return { ok: false, error: { code, message } };
 }


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- persist one exact target and source-turn boundary for each logical Branch or Revision attempt across renderer retries and reloads
- model copy ownership as `reserved -> started -> abandoning`, so a target queued for cleanup can never be reused
- make committed Host copy retries independent of later source metadata revisions
- add exact-target Revision abandonment without deleting the source or sibling revision family
- keep admitted, committed, active, or lineage-owned Revisions through a terminal `retained` outcome
- durably recover abandoned Quote Companion and edit-and-resend copies while hiding cleanup-pending targets from the Session list

## Root cause

Desktop allocated copy identity inside each IPC invocation. If Runtime Host committed a Branch or Revision but its response was lost, the next renderer action used another target and could create a duplicate. Retries that did preserve the target still re-read the source revision, while the Host fingerprint included that mutable revision, so a later source update turned an exact retry into an identity conflict.

Cleanup had the same ambiguity in reverse: losing an abandonment acknowledgement could let the renderer reuse a target already queued for deletion. Revision cleanup also used the ordinary family-removal operation, which could retire the source and every sibling version instead of discarding only the empty target.

## Design

The renderer now owns a session-scoped copy lease containing the target, frozen source boundary, and lifecycle phase. Ambiguous copy failures remain `started`; cleanup begins by durably moving the lease to `abandoning`, which can only retry cleanup. A fresh target is allocated only after the cleanup intent is acknowledged.

Runtime Host uses the immutable copy identity for committed retry resolution; the optimistic source revision remains an initial-create precondition only. A dedicated `session.revision.abandon` operation serializes against the target and discards only an unused preparing Revision. Revisions with admitted work or committed dependents return `retained`, which terminates cleanup without releasing resources or broadcasting deletion.

Quote Companion keeps the same lease through its ephemeral lifetime, survives renderer reloads, avoids StrictMode effect replay cleanup, and handles embedded runtimes whose returned Session id differs from the requested copy id. Cleanup intents remain durable across Desktop reconnects, and pending targets stay out of the visible Session projection until cleanup reaches a terminal result.

## Validation

- `npm --workspace @maka/runtime-host test` — 735 passed, 0 failed
- `npm --workspace @maka/desktop test` — 1808 passed, 0 failed
- Runtime Host and Desktop typechecks
- real two-client UDS coverage for exact retry, single-target abandon, admitted Revision retention, sibling preservation, and dependent-lineage retention
- renderer reload, ambiguous copy/cleanup acknowledgement, rollback, archive, Quote dismissal, embedded-id, and retained-resource regression coverage
- candidate dependency boundary, Biome checks, and `git diff --check`

Closes #2374.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 为每次逻辑 Branch 或 Revision 操作持久化唯一 target 与 source-turn boundary，跨 renderer 重试和 reload 保持不变
- 用 `reserved -> started -> abandoning` 表达 copy 所有权，已经进入清理队列的 target 永远不能再次用于 copy
- 让 Host 已提交 copy 的精确重试不再受后续 source metadata revision 变化影响
- 新增精确 target 的 Revision abandon，不再删除 source 或 sibling revision family
- 通过 terminal `retained` outcome 保留已经 admitted、committed、active 或被 lineage 引用的 Revision
- 持久恢复 Quote Companion 与 edit-and-resend 的废弃副本，并从 Session 列表隐藏仍在清理的 target

## 根因

Desktop 过去在每次 IPC invocation 内部分配 copy identity。如果 Runtime Host 已经提交 Branch 或 Revision，但响应丢失，renderer 的下一次操作会使用另一个 target，从而可能创建重复副本。即使重试保留了 target，Desktop 仍会重新读取 source revision，而 Host fingerprint 又包含这个可变 revision；source 后续更新会把精确重试变成 identity conflict。

清理路径存在反向的同类歧义：abandon acknowledgement 丢失后，renderer 可能再次使用已经排队删除的 target。Revision cleanup 还误用了普通 family removal，可能删除 source 与全部 sibling version，而不是只丢弃空的 target。

## 设计

renderer 现在持有 session-scoped copy lease，其中包含 target、冻结的 source boundary 与 lifecycle phase。copy outcome 不明确时保持 `started`；清理开始前先持久进入 `abandoning`，该状态只能重试清理。只有 cleanup intent 得到确认后才会分配新 target。

Runtime Host 使用不可变 copy identity 解析已提交重试；optimistic source revision 只作为首次创建的 precondition。新的 `session.revision.abandon` operation 与 target admission 串行，只丢弃未使用的 preparing Revision。已经存在 admitted work 或 committed dependent 的 Revision 返回 `retained`，终止清理，同时不会释放资源或广播删除。

Quote Companion 在完整临时生命周期内保留同一 lease，可跨 renderer reload 恢复，避开 StrictMode effect replay 的伪清理，并兼容返回 Session id 与请求 copy id 不同的 embedded runtime。cleanup intent 可跨 Desktop reconnect 持久恢复；在清理得到 terminal result 前，pending target 不会出现在可见 Session projection 中。

## 验证

- `npm --workspace @maka/runtime-host test` — 735 项通过，0 项失败
- `npm --workspace @maka/desktop test` — 1808 项通过，0 项失败
- Runtime Host 与 Desktop typecheck
- 通过真实 two-client UDS 覆盖精确重试、单 target abandon、admitted Revision retention、sibling 保留与 dependent lineage retention
- 覆盖 renderer reload、copy/cleanup acknowledgement 歧义、rollback、archive、Quote dismiss、embedded id 与 retained resource 回归
- candidate dependency boundary、Biome 检查与 `git diff --check`

关闭 #2374。

</details>
