### PR TITLE
refactor(settings): say what each status means, not what colour it is

### DIFF
--- a/apps/desktop/src/main/__tests__/provider-connection-status.test.ts
+++ b/apps/desktop/src/main/__tests__/provider-connection-status.test.ts
@@ -24,22 +24,22 @@ describe('connectionChipStatus', () => {
     > = [
       [
         { enabled: false, lastTestStatus: 'needs_reauth' },
-        { label: '需要重新登录', tone: 'info' },
+        { label: '需要重新登录', tone: 'attention' },
       ],
       [
         { enabled: true, lastTestStatus: 'needs_reauth' },
-        { label: '需要重新登录', tone: 'info' },
+        { label: '需要重新登录', tone: 'attention' },
       ],
       [
         { enabled: false, lastTestStatus: 'error' },
-        { label: '暂不可用 · 上次连接失败', tone: 'destructive' },
+        { label: '暂不可用 · 上次连接失败', tone: 'error' },
       ],
       [{ enabled: false, lastTestStatus: undefined }, { label: '暂不可用', tone: 'neutral' }],
       [{ enabled: false, lastTestStatus: 'verified' }, { label: '暂不可用', tone: 'neutral' }],
       [{ enabled: true, lastTestStatus: 'verified' }, null],
       [
         { enabled: true, lastTestStatus: 'error' },
-        { label: '上次连接失败', tone: 'destructive' },
+        { label: '上次连接失败', tone: 'error' },
       ],
       [{ enabled: true, lastTestStatus: undefined }, null],
     ];

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -18,7 +18,7 @@ import {
   type LlmConnection,
   type ProviderType,
 } from '@maka/core';
-import { useMountedRef, useUiLocale, useToast } from '@maka/ui';
+import { useMountedRef, useUiLocale, useToast , dotForStatus } from '@maka/ui';
 import { connectionChipStatus } from './provider-connection-status';
 import { statusDotVariant } from './settings-status-badge';
 import {
@@ -372,7 +372,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
                       <HStack gap={2} vAlign="center">
                         {status && (
                           <span className="settingsStatus">
-                            <StatusDot variant={statusDotVariant(status.tone)} label={status.label} />
+                            <StatusDot variant={dotForStatus(status.tone)} label={status.label} />
                             <span>{status.label}</span>
                           </span>
                         )}

--- a/apps/desktop/src/renderer/settings/memory-settings-labels.ts
+++ b/apps/desktop/src/renderer/settings/memory-settings-labels.ts
@@ -1,3 +1,4 @@
+import type { StatusSemantic } from '@maka/ui';
 import type { LocalMemoryState } from '@maka/core';
 import type { MemorySettingsCopy } from '../locales/settings-memory-copy';
 
@@ -68,18 +69,21 @@ export function localMemoryPromptPreviewBlockedReason(state: LocalMemoryState, c
   return '';
 }
 
-// NOT migrated to the shared vocabulary yet, deliberately. This feeds the
-// settings surface's own `statusDotVariant` (settings-status-badge.ts, nine
-// files), and its `disabled` state is one of the nine `info` states awaiting a
-// batch semantic ruling: `info` renders as the accent dot there, so moving it
-// to `neutral` would be a visible colour change — exactly what this pass is
-// not allowed to make on its own. It migrates with the settings surface.
-export function memoryStatusTone(status: LocalMemoryState['status']): 'success' | 'info' | 'warning' | 'destructive' {
+/**
+ * `disabled` is a settled fact the user chose, so it is `neutral`. It used to
+ * say `info`, which the settings surface painted as the accent dot — making a
+ * feature the user deliberately switched off look like one that was running.
+ *
+ * `error` replaces the old `destructive`: that word belongs to actions (a
+ * delete button), not to states, and this was the only place in the app naming
+ * this meaning differently from everywhere else.
+ */
+export function memoryStatusSemantic(status: LocalMemoryState['status']): StatusSemantic {
   switch (status) {
     case 'ok': return 'success';
-    case 'disabled': return 'info';
+    case 'disabled': return 'neutral';
     case 'safe_mode':
-    case 'incognito_blocked': return 'warning';
-    case 'error': return 'destructive';
+    case 'incognito_blocked': return 'attention';
+    case 'error': return 'error';
   }
 }

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -23,9 +23,9 @@ import {
   localMemoryBackupKindLabel,
   localMemoryBackupSummary,
   memoryStatusLabel,
-  memoryStatusTone,
+  memoryStatusSemantic,
 } from './memory-settings-labels';
-import { statusDotVariant } from './settings-status-badge';
+import { dotForStatus } from '@maka/ui';
 
 export function MemorySettingsPage(props: {
   settings: AppSettings;
@@ -102,7 +102,7 @@ export function MemorySettingsPage(props: {
             <span className="settingsFormRowControlCluster">
               <span className="settingsStatus">
                 <StatusDot
-                  variant={statusDotVariant(memoryStatusTone(effective.status))}
+                  variant={dotForStatus(memoryStatusSemantic(effective.status))}
                   label={memoryStatusLabel(effective.status, copy)}
                 />
                 <span>{memoryStatusLabel(effective.status, copy)}</span>

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -1,3 +1,4 @@
+import type { StatusSemantic } from '@maka/ui';
 import { useEffect, useState, type ComponentType } from 'react';
 import {
   Accessibility as AccessibilityIcon,
@@ -643,36 +644,39 @@ function localizedCapabilityGuidance(
   return capability.guidance.filter((item) => locale === 'zh' || !/[\u3400-\u9fff]/u.test(item));
 }
 
-function featureTone(state: CapabilitySnapshot['feature']['state']): 'neutral' | 'info' | 'success' | 'warning' | 'destructive' {
+function featureTone(state: CapabilitySnapshot['feature']['state']): StatusSemantic {
   if (state === 'enabled') return 'success';
-  if (state === 'partial') return 'warning';
-  if (state === 'disabled') return 'info';
+  if (state === 'partial') return 'attention';
+  // A capability the user turned off is a settled fact, not activity.
+  if (state === 'disabled') return 'neutral';
   return 'neutral';
 }
 
-function configurationTone(state: CapabilitySnapshot['configuration']['state']): 'neutral' | 'info' | 'success' | 'warning' | 'destructive' {
+function configurationTone(state: CapabilitySnapshot['configuration']['state']): StatusSemantic {
   if (state === 'present') return 'success';
-  if (state === 'missing') return 'warning';
+  if (state === 'missing') return 'attention';
   return 'neutral';
 }
 
-function actionApprovalTone(state: CapabilitySnapshot['actionApproval']['state']): 'neutral' | 'info' | 'success' | 'warning' | 'destructive' {
+function actionApprovalTone(state: CapabilitySnapshot['actionApproval']['state']): StatusSemantic {
   if (state === 'approved') return 'success';
-  if (state === 'denied') return 'destructive';
-  if (state === 'pending') return 'warning';
-  if (state === 'required_per_action' || state === 'required_scoped_lease') return 'info';
+  if (state === 'denied') return 'error';
+  if (state === 'pending') return 'attention';
+  // A configured approval policy describes how things will behave, not
+  // something happening now.
+  if (state === 'required_per_action' || state === 'required_scoped_lease') return 'neutral';
   return 'neutral';
 }
 
-function memoryAcceptanceTone(state: CapabilitySnapshot['memoryAcceptance']['state']): 'neutral' | 'info' | 'success' | 'warning' | 'destructive' {
+function memoryAcceptanceTone(state: CapabilitySnapshot['memoryAcceptance']['state']): StatusSemantic {
   if (state === 'accepted') return 'success';
-  if (state === 'draft_required') return 'warning';
+  if (state === 'draft_required') return 'attention';
   return 'neutral';
 }
 
-function runtimeProbeTone(state: CapabilitySnapshot['runtimeProbe']['state']): 'neutral' | 'info' | 'success' | 'warning' | 'destructive' {
+function runtimeProbeTone(state: CapabilitySnapshot['runtimeProbe']['state']): StatusSemantic {
   if (state === 'healthy') return 'success';
-  if (state === 'degraded') return 'destructive';
-  if (state === 'not_run') return 'warning';
+  if (state === 'degraded') return 'error';
+  if (state === 'not_run') return 'attention';
   return 'neutral';
 }

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -20,7 +20,7 @@ import {
   providerPanelActionErrorMessage,
   type CredentialPresenceStatus,
 } from './provider-panel-shared';
-import type { StatusTone } from './settings-status-badge';
+import type { StatusSemantic } from '@maka/ui';
 import {
   useConnectionDetail,
   type ConnectionDetailProps,
@@ -351,9 +351,12 @@ function DetailSection(props: { title: string; description: string; children: Re
 /** The list's three status tones against Banner's four; `neutral` has no
  * Banner equivalent, so it takes the quietest one rather than borrowing an
  * alarm color it does not mean. */
-function connectionIssueStatus(tone: StatusTone): 'error' | 'success' | 'info' {
-  if (tone === 'destructive') return 'error';
+function connectionIssueStatus(tone: StatusSemantic): 'error' | 'success' | 'info' {
+  if (tone === 'error') return 'error';
   if (tone === 'success') return 'success';
+  // Banner has a real `info` rung, unlike StatusDot — so this is the
+  // component's own quiet status, not the missing-rung workaround the dots
+  // had to fake with accent. Left as-is on that basis.
   return 'info';
 }
 

--- a/apps/desktop/src/renderer/settings/provider-connection-status.ts
+++ b/apps/desktop/src/renderer/settings/provider-connection-status.ts
@@ -5,11 +5,11 @@
 
 import type { LlmConnection, UiLocale } from '@maka/core';
 import { getProviderSettingsCopy } from '../locales/settings-provider-copy.js';
-import type { StatusTone } from './settings-status-badge';
+import type { StatusSemantic } from '@maka/ui';
 
 export interface ConnectionChipStatus {
   label: string;
-  tone: StatusTone;
+  tone: StatusSemantic;
 }
 
 /**
@@ -40,17 +40,20 @@ export interface ConnectionChipStatus {
  */
 export function connectionChipStatus(connection: LlmConnection, locale: UiLocale = 'zh'): ConnectionChipStatus | null {
   const copy = getProviderSettingsCopy(locale).shared.connectionStatuses;
-  if (connection.lastTestStatus === 'needs_reauth') return { label: copy.reauth, tone: 'info' };
+  // Waiting on the user, not on the system: an expired credential is a
+  // to-do, and it used to render as the live accent dot — reporting progress
+  // where nothing is progressing.
+  if (connection.lastTestStatus === 'needs_reauth') return { label: copy.reauth, tone: 'attention' };
   if (!connection.enabled) {
     return connection.lastTestStatus === 'error'
-      ? { label: copy.disabledFailed, tone: 'destructive' }
+      ? { label: copy.disabledFailed, tone: 'error' }
       : { label: copy.disabled, tone: 'neutral' };
   }
   switch (connection.lastTestStatus) {
     case 'verified':
       return null;
     case 'error':
-      return { label: copy.failed, tone: 'destructive' };
+      return { label: copy.failed, tone: 'error' };
     default:
       return null;
   }

--- a/apps/desktop/src/renderer/settings/settings-status-badge.ts
+++ b/apps/desktop/src/renderer/settings/settings-status-badge.ts
@@ -1,4 +1,16 @@
+import { dotForStatus, type StatusSemantic } from '@maka/ui';
+
+/**
+ * Badge tones. Still its own vocabulary because Astryx's Badge has an `info`
+ * pill and its own idea of `neutral`, so a Badge can express a shade the dot
+ * cannot — mapping it through the status vocabulary would flatten that.
+ *
+ * Only 一处 still renders these (the subagent settings page). Everything else
+ * on the settings surface is a dot plus plain text, per the "no decorative
+ * Badge" principle.
+ */
 export type StatusTone = 'neutral' | 'info' | 'success' | 'warning' | 'destructive';
+
 export function statusBadgeVariant(tone: StatusTone): 'success' | 'warning' | 'error' | 'info' | 'neutral' {
   switch (tone) {
     case 'success': return 'success';
@@ -12,17 +24,27 @@ export function statusBadgeVariant(tone: StatusTone): 'success' | 'warning' | 'e
 }
 
 /**
- * StatusDot variant for a tone. The settings surface's status language is a
- * dot + plain text ("no decorative Badge" — astryx docs principles); Astryx's
- * StatusDot has no `info` rung, so informational states ride the accent dot.
+ * Legacy tone → dot, on its way out.
+ *
+ * It used to take a `StatusTone` and map `info` onto the accent dot, because
+ * Astryx's StatusDot has no `info` rung. That workaround was load-bearing in
+ * the wrong direction: nine states across this surface said `info`, and only
+ * ONE of them was actually in progress. The other eight — a disabled feature,
+ * a configured approval policy, an expired credential waiting on the user —
+ * all rendered as the same live accent dot, which is why settings read busier
+ * than it was. Each of those nine now names what it means and the colour
+ * follows.
  */
-export function statusDotVariant(tone: StatusTone): 'success' | 'warning' | 'error' | 'accent' | 'neutral' {
+export function statusDotVariant(tone: StatusTone) {
   switch (tone) {
-    case 'success': return 'success';
-    case 'warning': return 'warning';
-    case 'destructive': return 'error';
-    case 'info': return 'accent';
-    case 'neutral': return 'neutral';
+    case 'success': return dotForStatus('success');
+    case 'warning': return dotForStatus('attention');
+    case 'destructive': return dotForStatus('error');
+    // The workaround this whole pass exists to remove, kept alive only while
+    // surfaces still emit `info`. Every migrated surface names what it means
+    // and calls `dotForStatus` directly; this branch shrinks to nothing as the
+    // last few move over, and then so does this function.
+    case 'info': return dotForStatus('active');
+    case 'neutral': return dotForStatus('neutral');
   }
 }
-

--- a/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/web-search-settings-page.tsx
@@ -8,7 +8,7 @@ import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';
 import { SettingsActions, SettingsField, SettingsPage, SettingsRow, SettingsSection } from './settings-section';
 import { PasswordInput } from './password-input';
 import { settingsActionErrorMessage } from './settings-error-copy';
-import { statusDotVariant } from './settings-status-badge';
+import { dotForStatus, type StatusSemantic } from '@maka/ui';
 import { useKeyedActionGuard } from './use-action-guard';
 
 /**
@@ -221,7 +221,10 @@ export function WebSearchSettingsPage(props: {
   const statusCopy = usingModelSearch
     ? {
         label: webSearch.enabled ? copy.statuses.modelEnabled : copy.statuses.modelDisabled,
-        tone: webSearch.enabled ? ('info' as const) : ('warning' as const),
+        // Verified-and-on is proven health, which is what success is for.
+        // Off stays amber (`attention`) exactly as before — it was never one of
+        // the ruled `info` states, and this pass repaints nothing it did not name.
+        tone: webSearch.enabled ? ('success' as const) : ('attention' as const),
       }
     : presentWebSearchCredentialStatus(
         credentialSource,
@@ -272,7 +275,7 @@ export function WebSearchSettingsPage(props: {
           end={<div className="settingsWebSearchControlCluster">
             <div className="settingsWebSearchStatusCluster" role="group" aria-label={copy.statusAria}>
               <span className="settingsStatus">
-                <StatusDot variant={statusDotVariant(statusCopy.tone)} label={statusCopy.label} />
+                <StatusDot variant={dotForStatus(statusCopy.tone)} label={statusCopy.label} />
                 <span>{statusCopy.label}</span>
               </span>
               {hasCheckedAt && (
@@ -449,21 +452,25 @@ function presentWebSearchCredentialStatus(
   enabled: boolean,
   status: WebSearchCredentialStatus,
   copy: WebSearchSettingsCopy,
-): { label: string; tone: 'success' | 'info' | 'warning' | 'destructive' } {
-  if (credentialSource === 'none') return { label: copy.statuses.not_configured, tone: 'warning' };
+): { label: string; tone: StatusSemantic } {
+  if (credentialSource === 'none') return { label: copy.statuses.not_configured, tone: 'attention' };
   if (status === 'valid') {
     return enabled
       ? { label: copy.statuses.validEnabled, tone: 'success' }
-      : { label: copy.statuses.validDisabled, tone: 'info' };
+      // Valid credentials, feature off: a fact the user set, not a problem.
+      : { label: copy.statuses.validDisabled, tone: 'neutral' };
   }
-  if (status === 'invalid_credentials') return { label: copy.statuses.invalid_credentials, tone: 'destructive' };
-  if (status === 'rate_limited') return { label: copy.statuses.rate_limited, tone: 'warning' };
-  if (status === 'timeout') return { label: copy.statuses.timeout, tone: 'warning' };
-  if (status === 'network_error') return { label: copy.statuses.network_error, tone: 'warning' };
-  if (status === 'not_configured') return { label: copy.statuses.not_configured, tone: 'warning' };
+  if (status === 'invalid_credentials') return { label: copy.statuses.invalid_credentials, tone: 'error' };
+  if (status === 'rate_limited') return { label: copy.statuses.rate_limited, tone: 'attention' };
+  if (status === 'timeout') return { label: copy.statuses.timeout, tone: 'attention' };
+  if (status === 'network_error') return { label: copy.statuses.network_error, tone: 'attention' };
+  if (status === 'not_configured') return { label: copy.statuses.not_configured, tone: 'attention' };
   return enabled
-    ? { label: copy.statuses.unknownEnabled, tone: 'warning' }
-    : { label: copy.statuses.untested, tone: 'info' };
+    ? { label: copy.statuses.unknownEnabled, tone: 'attention' }
+    // Configured but never tested: setup is unfinished, and the amber says so.
+    // Testing moves it to success or error, completing the narrative; neutral
+    // would read as "all set" and break that story.
+    : { label: copy.statuses.untested, tone: 'attention' };
 }
 
 function presentWebSearchCredentialSource(

--- a/packages/ui/src/status-vocabulary.ts
+++ b/packages/ui/src/status-vocabulary.ts
@@ -22,16 +22,31 @@ import type { StatusDotVariant } from '@astryxdesign/core/StatusDot';
  * `active` respectively, and the disagreement is visible in the call site
  * rather than hidden in a shared name.
  */
+/**
+ * Choosing between these turns on two questions, in order:
+ *
+ *   1. Is something happening, and if so who is doing it? The SYSTEM working
+ *      is `active`; waiting on the USER is `attention`. Collapsing those two
+ *      is the mistake that produced this vocabulary's worst case — an expired
+ *      credential reported as "in progress" when nothing is progressing.
+ *   2. If nothing is happening, is this a verified good outcome (`success`), a
+ *      broken one (`error`), or simply a fact (`neutral`)?
+ *
+ * `success` is reserved for a health that was PROVEN — a connection test that
+ * passed, a credential that validated. A switch merely being on is not proof
+ * of anything and reads as `active` (participating) or `neutral` (present),
+ * which is why an enabled skill is not green.
+ */
 export type StatusSemantic =
-  /** Healthy, connected, finished well. */
+  /** Proven healthy: a test passed, a credential validated, a server answered. */
   | 'success'
-  /** Live right now — running, scheduled, in flight. */
+  /** The system is working on it right now — running, authorizing, in flight. */
   | 'active'
-  /** Needs a human eventually: paused, shadowed, degraded, review pending. */
+  /** Waiting on a person: re-auth needed, review pending, paused, untested. */
   | 'attention'
   /** Broken now: failed delivery, invalid metadata, unreachable server. */
   | 'error'
-  /** Present but not participating: disabled, completed-and-spent, off. */
+  /** A settled fact, nothing to do: disabled, configured, completed-and-spent. */
   | 'neutral';
 
 /**


### PR DESCRIPTION
## 改了什么
设置面九处状态原本都叫 `info`，而 `info` 被画成 accent 点（Astryx StatusDot 没有 `info` 档，accent 是最接近的）。**九处里只有一处真的在进行中**——其余八处（关掉的功能、配置好的审批策略、有效但停用的凭证、等用户重新授权的过期 token）**全都渲染成同一个"活动中"的点**，这就是设置面此前微妙地"比实际热闹"的原因。

现在每处说自己是什么意思：

| 状态 | 裁定 | 为什么 |
|---|---|---|
| memory `disabled` | `neutral` | 用户自己关的，陈述现状 |
| capability `disabled` | `neutral` | 同上 |
| 审批策略 `required_*` | `neutral` | 描述行为方式，不是正在发生的事 |
| web search 有效但停用 | `neutral` | 用户设定的状态 |
| web search 已验证且开启 | **`success`** | **经过验证**的健康，不是"开关开着" |
| 凭证 `needs_reauth` | **`attention`** | 在等用户动手；判 active 会谎报"在进行" |
| 凭证 `untested` | **`attention`** | 设置没走完；测过转 success/error 完成叙事，neutral 会读成"已妥" |

`destructive` 全面改名 `error`——那个词属于动作不属于状态，这个面是最后一处叫法不同的。

## 分两轮的原因
`statusDotVariant` **故意保留 `StatusTone` 签名**：改签名会一次性打断全部 10 个消费点，所以它留作桥接（tone → semantic），已迁移的面直接调 `dotForStatus`。**桥接随剩余文件迁完而缩小、最后消失。**

**四个文件本轮不迁**：bot-chat 详情/概览、健康中心、Claude 订阅卡（**裁定 6 的 `authorizing → active` 在它里面**）。它们把 dot 色调和 Badge/Button variant 混用、而这些词名字相同，**必须逐个函数看消费者**——我试过批量字符串替换，结果刷中了无关的 Badge variant，已全部 revert。

## 一条裁定当场撤回
provider 连接的兜底原判 `neutral`，但细看**那处是 Banner 不是 StatusDot**，而 **Banner 真的有 `info` 档**——它的 `info` 是组件自己的安静语义，不是点缺档时的将就。**不动**。

## 验证
typecheck 0；`@maka/ui` **483 pass / 0 fail**。

desktop 测试有 2 条挂（`session-project-view-contract` / `stale-sessions`），**判定为并行负载下的既有 flake**，双证据：①**单跑 20 pass / 0 fail、exit 0**；②本 diff **grep 不到任何 session / attachment / lazy 字样**（全部是设置面状态色调）。另：干净 main 上同样有 1 条挂，但挂的是**另一条**（`attachment-ingest`），佐证这批是负载相关而非确定性损坏。
