### PR TITLE
refactor(settings): finish the status vocabulary, and delete the bridge

### DIFF
--- a/apps/desktop/src/renderer/locales/permission-center-copy.ts
+++ b/apps/desktop/src/renderer/locales/permission-center-copy.ts
@@ -1,3 +1,4 @@
+import type { StatusSemantic } from '@maka/ui';
 import type {
   CapabilityReadinessState,
   CapabilitySnapshot,
@@ -7,7 +8,7 @@ import type {
   UiLocale,
 } from '@maka/core';
 
-type Tone = 'neutral' | 'info' | 'success' | 'warning' | 'destructive';
+type Tone = StatusSemantic;
 type StatusCopy = { label: string; tone: Tone };
 
 export type PermissionCenterCopy = {
@@ -79,10 +80,10 @@ const PERMISSION_CENTER_COPY = {
   zh: {
     readiness: {
       not_configured: { label: '等待配置', detail: '需要先打开开关或补齐配置才能启用。', tone: 'neutral' },
-      denied: { label: '系统拒绝', detail: '所需系统权限被拒绝或当前平台不支持。', tone: 'destructive' },
+      denied: { label: '系统拒绝', detail: '所需系统权限被拒绝或当前平台不支持。', tone: 'error' },
       enabled: { label: '运行可用', detail: '当前快照标记为可用，具体层级见下方。', tone: 'success' },
-      degraded: { label: '部分可用', detail: '已有一部分能力可用，但仍有运行态、权限或子功能需要处理。', tone: 'warning' },
-      paused: { label: '已暂停', detail: '功能开关被显式关闭，但配置仍保留。', tone: 'info' },
+      degraded: { label: '部分可用', detail: '已有一部分能力可用，但仍有运行态、权限或子功能需要处理。', tone: 'attention' },
+      paused: { label: '已暂停', detail: '功能开关被显式关闭，但配置仍保留。', tone: 'neutral' },
     },
     osPermissions: {
       accessibility: { label: '辅助功能', purpose: 'Computer Use 需要它来读取窗口焦点 / 模拟键盘鼠标。', impact: 'Computer Use · 自动化键鼠操作' },
@@ -93,7 +94,7 @@ const PERMISSION_CENTER_COPY = {
     },
     osStates: {
       unsupported: { label: '当前平台不支持', tone: 'neutral' }, unknown: { label: '无法读取状态', tone: 'neutral' },
-      not_determined: { label: '等待授权', tone: 'warning' }, denied: { label: '已拒绝', tone: 'destructive' }, granted: { label: '已授权', tone: 'neutral' },
+      not_determined: { label: '等待授权', tone: 'attention' }, denied: { label: '已拒绝', tone: 'error' }, granted: { label: '已授权', tone: 'neutral' },
     },
     loading: '正在加载权限快照', readFailed: '无法读取权限快照', noData: '权限服务未返回数据。', readAgain: '重新读取',
     actionFailed: '权限操作失败',
@@ -127,10 +128,10 @@ const PERMISSION_CENTER_COPY = {
   en: {
     readiness: {
       not_configured: { label: 'Needs setup', detail: 'Enable the feature or complete its configuration first.', tone: 'neutral' },
-      denied: { label: 'Denied by system', detail: 'A required system permission was denied or is unsupported on this platform.', tone: 'destructive' },
+      denied: { label: 'Denied by system', detail: 'A required system permission was denied or is unsupported on this platform.', tone: 'error' },
       enabled: { label: 'Available', detail: 'The current snapshot is available; see the layers below for details.', tone: 'success' },
-      degraded: { label: 'Partially available', detail: 'Some functionality is available, but runtime, permission, or sub-feature work remains.', tone: 'warning' },
-      paused: { label: 'Paused', detail: 'The feature was explicitly disabled while its configuration remains saved.', tone: 'info' },
+      degraded: { label: 'Partially available', detail: 'Some functionality is available, but runtime, permission, or sub-feature work remains.', tone: 'attention' },
+      paused: { label: 'Paused', detail: 'The feature was explicitly disabled while its configuration remains saved.', tone: 'neutral' },
     },
     osPermissions: {
       accessibility: { label: 'Accessibility', purpose: 'Computer Use needs it to read window focus and simulate keyboard or mouse input.', impact: 'Computer Use · automated keyboard and mouse input' },
@@ -141,7 +142,7 @@ const PERMISSION_CENTER_COPY = {
     },
     osStates: {
       unsupported: { label: 'Unsupported on this platform', tone: 'neutral' }, unknown: { label: 'Status unavailable', tone: 'neutral' },
-      not_determined: { label: 'Waiting for permission', tone: 'warning' }, denied: { label: 'Denied', tone: 'destructive' }, granted: { label: 'Granted', tone: 'neutral' },
+      not_determined: { label: 'Waiting for permission', tone: 'attention' }, denied: { label: 'Denied', tone: 'error' }, granted: { label: 'Granted', tone: 'neutral' },
     },
     loading: 'Loading permission snapshot', readFailed: 'Could not read permission snapshot', noData: 'The permission service returned no data.', readAgain: 'Read again',
     actionFailed: 'Permission action failed',

--- a/apps/desktop/src/renderer/locales/settings-bot-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-bot-copy.ts
@@ -1,3 +1,4 @@
+import type { StatusSemantic } from '@maka/ui';
 import type { BotProvider, BotReadinessState, UiCatalog, UiLocale } from '@maka/core';
 
 type WidenCopy<T> = T extends string
@@ -20,11 +21,11 @@ const zhCopy = {
   readiness: {
     unscaffolded: { label: '未开放', detail: '该平台当前不可作为远程接入渠道。', tone: 'neutral' },
     scaffolded: { label: '待配置', detail: '等待补齐这个平台需要的凭据配置。', tone: 'neutral' },
-    configured: { label: '已配置', detail: '已填写配置；等待完成凭据或运行态验证。', tone: 'info' },
-    credentials_valid: { label: '凭据有效', detail: '凭据探测通过；这不代表已能收发消息。', tone: 'warning' },
+    configured: { label: '已配置', detail: '已填写配置；等待完成凭据或运行态验证。', tone: 'attention' },
+    credentials_valid: { label: '凭据有效', detail: '凭据探测通过；这不代表已能收发消息。', tone: 'attention' },
     operational: { label: '运行可用', detail: '最近一次真实运行探测成功。', tone: 'success' },
-    degraded: { label: '运行降级', detail: '之前可用，但最近运行态探测失败。', tone: 'destructive' },
-  } satisfies Record<BotReadinessState, { label: string; detail: string; tone: 'neutral' | 'info' | 'success' | 'warning' | 'destructive' }>,
+    degraded: { label: '运行降级', detail: '之前可用，但最近运行态探测失败。', tone: 'error' },
+  } satisfies Record<BotReadinessState, { label: string; detail: string; tone: StatusSemantic }>,
   planned: { label: '未开放', detail: '该平台当前不会保存为远程接入渠道或计划提醒投递目标。', tone: 'neutral' as const },
   status: {
     disabled: '开关关闭', noToken: '等待填写 Bot Token', missingFeishuCredentials: '等待填写飞书 App ID 或 App Secret',
@@ -104,8 +105,8 @@ const enCopy: BotSettingsCopy = {
   },
   readiness: {
     unscaffolded: { label: 'Unavailable', detail: 'This platform cannot currently be used for remote access.', tone: 'neutral' }, scaffolded: { label: 'Setup required', detail: 'Add the credentials required by this platform.', tone: 'neutral' },
-    configured: { label: 'Configured', detail: 'Configuration is saved; credential or runtime validation is still required.', tone: 'info' }, credentials_valid: { label: 'Credentials valid', detail: 'The credential check passed; this does not prove messages can be sent or received.', tone: 'warning' },
-    operational: { label: 'Operational', detail: 'The latest live runtime check succeeded.', tone: 'success' }, degraded: { label: 'Degraded', detail: 'This channel worked before, but the latest runtime check failed.', tone: 'destructive' },
+    configured: { label: 'Configured', detail: 'Configuration is saved; credential or runtime validation is still required.', tone: 'attention' }, credentials_valid: { label: 'Credentials valid', detail: 'The credential check passed; this does not prove messages can be sent or received.', tone: 'attention' },
+    operational: { label: 'Operational', detail: 'The latest live runtime check succeeded.', tone: 'success' }, degraded: { label: 'Degraded', detail: 'This channel worked before, but the latest runtime check failed.', tone: 'error' },
   },
   planned: { label: 'Unavailable', detail: 'This platform is not saved as a remote-access channel or scheduled-task delivery target.', tone: 'neutral' },
   status: { disabled: 'Turned off', noToken: 'Waiting for Bot Token', missingFeishuCredentials: 'Waiting for Feishu App ID or App Secret', feishuDomainRequired: 'Feishu credentials are valid; add the event subscription domain', feishuEventsNotConnected: 'Feishu credentials are valid; connect the event callback', unavailable: 'This platform cannot currently be used for remote access', stopped: 'Listener stopped', detailsInLogs: 'See logs for runtime details', polling: 'Long polling', gateway: 'Event channel', webhook: 'Webhook', none: 'None' },

--- a/apps/desktop/src/renderer/locales/settings-health-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-health-copy.ts
@@ -1,3 +1,4 @@
+import type { StatusSemantic } from '@maka/ui';
 import type {
   HealthSignal,
   HealthSignalLayer,
@@ -7,7 +8,16 @@ import type {
   UiLocale,
 } from '@maka/core';
 
-type HealthTone = 'neutral' | 'info' | 'success' | 'warning' | 'destructive';
+/**
+ * Health signals carry their own severity ladder — error > warning > info > ok
+ * — and the colours have to stay monotonic with it. That is why `info` maps to
+ * neutral rather than to attention: amber would collide with `warning` and
+ * collapse five rungs into four, leaving 提示 and 警告 visually identical. Grey
+ * keeps the ladder ordered (red > amber > grey > green); 提示 and 未知 share
+ * grey and are told apart by their labels, which is fine because neither asks
+ * for action.
+ */
+type HealthTone = StatusSemantic;
 
 export type HealthCenterCopy = {
   loading: string;
@@ -67,7 +77,7 @@ const SETTINGS_HEALTH_COPY = {
     layerAria: (label) => `${label}健康信号`, layerListAria: (label) => `${label}健康信号列表`,
     footnote: '本页不直接执行测试、修复或权限变更；它只汇总当前已记录的健康信号。需要处理问题时，请进入对应设置页或重新触发相关功能。',
     layers: layersZh,
-    statuses: { ok: { label: '正常', tone: 'neutral' }, info: { label: '提示', tone: 'info' }, warning: { label: '警告', tone: 'warning' }, error: { label: '错误', tone: 'destructive' }, unknown: { label: '未知', tone: 'neutral' } },
+    statuses: { ok: { label: '正常', tone: 'neutral' }, info: { label: '提示', tone: 'neutral' }, warning: { label: '警告', tone: 'attention' }, error: { label: '错误', tone: 'error' }, unknown: { label: '未知', tone: 'neutral' } },
     scopes: { app: '应用', llm_connection: 'LLM 连接', bot: '机器人', capability: '能力', storage: '存储' },
     sources: { connection_test: '连接测试', capability_snapshot: '能力快照', permission_snapshot: '权限快照', runtime_probe: '运行态探测', settings: '设置', storage: '本地存储' },
     source: '来源：', blocksSend: '阻塞发送', blocksCapability: '阻塞能力',
@@ -83,7 +93,7 @@ const SETTINGS_HEALTH_COPY = {
     layerAria: (label) => `${label} health signals`, layerListAria: (label) => `${label} health signal list`,
     footnote: 'This page does not run tests, repairs, or permission changes. It only summarizes recorded health signals. Open the relevant settings page or retry the related feature to address an issue.',
     layers: layersEn,
-    statuses: { ok: { label: 'Healthy', tone: 'neutral' }, info: { label: 'Info', tone: 'info' }, warning: { label: 'Warning', tone: 'warning' }, error: { label: 'Error', tone: 'destructive' }, unknown: { label: 'Unknown', tone: 'neutral' } },
+    statuses: { ok: { label: 'Healthy', tone: 'neutral' }, info: { label: 'Info', tone: 'neutral' }, warning: { label: 'Warning', tone: 'attention' }, error: { label: 'Error', tone: 'error' }, unknown: { label: 'Unknown', tone: 'neutral' } },
     scopes: { app: 'App', llm_connection: 'LLM connection', bot: 'Bot', capability: 'Capability', storage: 'Storage' },
     sources: { connection_test: 'Connection test', capability_snapshot: 'Capability snapshot', permission_snapshot: 'Permission snapshot', runtime_probe: 'Runtime probe', settings: 'Settings', storage: 'Local storage' },
     source: 'Source: ', blocksSend: 'Blocks sending', blocksCapability: 'Blocks capability',

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -20,7 +20,6 @@ import {
 } from '@maka/core';
 import { useMountedRef, useUiLocale, useToast , dotForStatus } from '@maka/ui';
 import { connectionChipStatus } from './provider-connection-status';
-import { statusDotVariant } from './settings-status-badge';
 import {
   CATALOG_INITIAL_FILTER,
   ProviderCatalogPage,

--- a/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-detail.tsx
@@ -38,7 +38,7 @@ import {
 } from './bot-chat-shared';
 import { getBotSettingsCopy, type BotSettingsCopy } from '../locales/settings-bot-copy';
 import { SettingsPage, SettingsSection } from './settings-section';
-import { statusDotVariant } from './settings-status-badge';
+import { dotForStatus } from '@maka/ui';
 
 function canEnableBotChannel(readiness: BotReadinessState): boolean {
   return readiness === 'credentials_valid' || readiness === 'operational' || readiness === 'degraded';
@@ -184,7 +184,7 @@ export function BotChatChannelDetail(props: {
               {/* Astryx convergence: readiness reads as the shared StatusDot +
                   text idiom — "no decorative Badge" (astryx docs principles). */}
               <span className="settingsStatus">
-                <StatusDot variant={statusDotVariant(readinessCopy.tone)} label={readinessCopy.label} />
+                <StatusDot variant={dotForStatus(readinessCopy.tone)} label={readinessCopy.label} />
                 <span>{readinessCopy.label}</span>
               </span>
             </h3>

--- a/apps/desktop/src/renderer/settings/bot-chat-overview.tsx
+++ b/apps/desktop/src/renderer/settings/bot-chat-overview.tsx
@@ -9,7 +9,7 @@ import { deriveBotChannelViewState } from './bot-settings-view-model';
 import { BOT_LABELS, BotBrandLogo, botReadinessCopyForSupport, botStatusDetail } from './bot-chat-shared';
 import { getBotSettingsCopy } from '../locales/settings-bot-copy';
 import { SettingsPage, SettingsSection } from './settings-section';
-import { statusDotVariant } from './settings-status-badge';
+import { dotForStatus } from '@maka/ui';
 
 /**
  * Remote-access overview: the "正在使用" list of configured channels plus
@@ -91,7 +91,7 @@ export function BotChatOverview(props: {
                 <span className="settingsRemoteAccessItemTitle" aria-label={copy.manageAria(botCopy.providers[entry.provider].label, entry.copy.label)}>
                   {botCopy.providers[entry.provider].label}
                   <span className="settingsStatus">
-                    <StatusDot variant={statusDotVariant(entry.copy.tone)} label={entry.copy.label} />
+                    <StatusDot variant={dotForStatus(entry.copy.tone)} label={entry.copy.label} />
                     <span>{entry.copy.label}</span>
                   </span>
                 </span>

--- a/apps/desktop/src/renderer/settings/claude-subscription-card.tsx
+++ b/apps/desktop/src/renderer/settings/claude-subscription-card.tsx
@@ -15,7 +15,7 @@ import {
   useUiLocale,
 } from '@maka/ui';
 import { getProviderSettingsCopy } from '../locales/settings-provider-copy';
-import { statusDotVariant, type StatusTone } from './settings-status-badge';
+import { dotForStatus, type StatusSemantic } from '@maka/ui';
 import {
   subscriptionActionErrorMessage,
   subscriptionResultMessage,
@@ -317,7 +317,7 @@ export function ClaudeSubscriptionCard() {
     <VStack gap={3}>
       <HStack gap={3} vAlign="center" hAlign="between" wrap="wrap">
         <span className="settingsStatus">
-          <StatusDot variant={statusDotVariant(presentation.tone)} label={presentation.label} />
+          <StatusDot variant={dotForStatus(presentation.tone)} label={presentation.label} />
           <span>{presentation.label}</span>
         </span>
         {state?.profile?.email ? (
@@ -439,7 +439,7 @@ type ClaudeSubscriptionPendingAction = 'login' | 'submit' | 'cancel' | 'logout' 
 
 interface SubscriptionStatePresentation {
   label: string;
-  tone: StatusTone;
+  tone: StatusSemantic;
   detail: string;
 }
 
@@ -449,7 +449,9 @@ function presentSubscriptionState(state: SubscriptionAccountState, locale: UiLoc
     case 'not_logged_in':
       return { label: copy.signedOut, tone: 'neutral', detail: copy.signedOutDetail };
     case 'authorizing':
-      return { label: copy.authorizing, tone: 'info', detail: copy.authorizingDetail };
+      // The system is working right now — one of only two genuine `active` states
+      // on this whole surface.
+      return { label: copy.authorizing, tone: 'active', detail: copy.authorizingDetail };
     case 'authenticated':
       return {
         label: copy.signedIn,
@@ -457,29 +459,29 @@ function presentSubscriptionState(state: SubscriptionAccountState, locale: UiLoc
         detail: copy.signedInDetail,
       };
     case 'refreshing':
-      return { label: copy.tokenRefreshing, tone: 'info', detail: copy.tokenRefreshingDetail };
+      return { label: copy.tokenRefreshing, tone: 'active', detail: copy.tokenRefreshingDetail };
     case 'refresh_failed':
       return {
         label: copy.tokenRefreshFailed,
-        tone: 'warning',
+        tone: 'attention',
         detail: subscriptionResultMessage(state.errorMessage, copy.tokenRefreshFailedDetail, locale),
       };
     case 'storage_failed':
       return {
         label: copy.storageFailed,
-        tone: 'warning',
+        tone: 'attention',
         detail: subscriptionResultMessage(state.errorMessage, copy.storageFailedDetail, locale),
       };
     case 'quota_unavailable':
       return {
         label: copy.quotaUnavailable,
-        tone: 'warning',
+        tone: 'attention',
         detail: subscriptionResultMessage(state.errorMessage, copy.quotaUnavailableDetail, locale),
       };
     case 'provider_rejected':
       return {
         label: copy.providerRejected,
-        tone: 'destructive',
+        tone: 'error',
         detail: subscriptionResultMessage(state.errorMessage, copy.providerRejectedDetail, locale),
       };
     default:

--- a/apps/desktop/src/renderer/settings/health-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/health-center-page.tsx
@@ -11,7 +11,7 @@ import { getHealthCenterCopy, type HealthCenterCopy } from '../locales/settings-
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsPage, SettingsRow, SettingsSection } from './settings-section';
 import { SettingsSkeletonStack } from './settings-skeleton';
-import { statusDotVariant } from './settings-status-badge';
+import { dotForStatus } from '@maka/ui';
 
 /**
  * PR-UI-9 — Health Center read-only page. Consumes `window.maka.health.getSnapshot()`
@@ -201,7 +201,7 @@ function HealthSignalRow(props: { signal: HealthSignal; copy: HealthCenterCopy }
       )}
       end={(
         <span className="settingsStatus">
-          <StatusDot variant={statusDotVariant(statusCopy.tone)} label={statusCopy.label} />
+          <StatusDot variant={dotForStatus(statusCopy.tone)} label={statusCopy.label} />
           <span>{statusCopy.label}</span>
         </span>
       )}

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -35,7 +35,7 @@ import { RelativeTime, StatusDot, useMountedRef, useToast, useUiLocale } from '@
 import { SettingsPage, SettingsSection } from './settings-section';
 import { getPermissionCenterCopy, type PermissionCenterCopy } from '../locales/permission-center-copy';
 import { settingsActionErrorMessage } from './settings-error-copy';
-import { statusDotVariant } from './settings-status-badge';
+import { dotForStatus } from '@maka/ui';
 import { SettingsSkeletonStack } from './settings-skeleton';
 import { useActionGuard } from './use-action-guard';
 
@@ -394,7 +394,7 @@ function CapabilityRow(props: {
           <HStack gap={2} align="center">
             <Text type="label" size="sm">{capabilityLabel}</Text>
             <span className="settingsStatus">
-              <StatusDot variant={statusDotVariant(readinessCopy.tone)} label={readinessCopy.label} />
+              <StatusDot variant={dotForStatus(readinessCopy.tone)} label={readinessCopy.label} />
               <span>{readinessCopy.label}</span>
             </span>
           </HStack>
@@ -445,7 +445,7 @@ function CapabilityRow(props: {
               {capability.osPermissions.map((req) => (
                 <MetadataListItem key={req.id} label={copy.osPermissions[req.id]?.label ?? req.id}>
                   <span className="settingsStatus">
-                    <StatusDot variant={statusDotVariant(copy.osStates[req.status].tone)} label={copy.osStates[req.status].label} />
+                    <StatusDot variant={dotForStatus(copy.osStates[req.status].tone)} label={copy.osStates[req.status].label} />
                     <span>{copy.osStates[req.status].label}</span>
                   </span>
                 </MetadataListItem>
@@ -599,7 +599,7 @@ function OsPermissionRow(props: {
         <HStack gap={2} align="center">
           <Text type="label" size="sm">{label}</Text>
           <span className="settingsStatus">
-            <StatusDot variant={statusDotVariant(stateCopy.tone)} label={stateCopy.label} />
+            <StatusDot variant={dotForStatus(stateCopy.tone)} label={stateCopy.label} />
             <span>{stateCopy.label}</span>
           </span>
         </HStack>

--- a/apps/desktop/src/renderer/settings/settings-status-badge.ts
+++ b/apps/desktop/src/renderer/settings/settings-status-badge.ts
@@ -1,5 +1,3 @@
-import { dotForStatus, type StatusSemantic } from '@maka/ui';
-
 /**
  * Badge tones. Still its own vocabulary because Astryx's Badge has an `info`
  * pill and its own idea of `neutral`, so a Badge can express a shade the dot
@@ -20,31 +18,5 @@ export function statusBadgeVariant(tone: StatusTone): 'success' | 'warning' | 'e
     case 'destructive': return 'error';
     case 'info': return 'info';
     case 'neutral': return 'neutral';
-  }
-}
-
-/**
- * Legacy tone → dot, on its way out.
- *
- * It used to take a `StatusTone` and map `info` onto the accent dot, because
- * Astryx's StatusDot has no `info` rung. That workaround was load-bearing in
- * the wrong direction: nine states across this surface said `info`, and only
- * ONE of them was actually in progress. The other eight — a disabled feature,
- * a configured approval policy, an expired credential waiting on the user —
- * all rendered as the same live accent dot, which is why settings read busier
- * than it was. Each of those nine now names what it means and the colour
- * follows.
- */
-export function statusDotVariant(tone: StatusTone) {
-  switch (tone) {
-    case 'success': return dotForStatus('success');
-    case 'warning': return dotForStatus('attention');
-    case 'destructive': return dotForStatus('error');
-    // The workaround this whole pass exists to remove, kept alive only while
-    // surfaces still emit `info`. Every migrated surface names what it means
-    // and calls `dotForStatus` directly; this branch shrinks to nothing as the
-    // last few move over, and then so does this function.
-    case 'info': return dotForStatus('active');
-    case 'neutral': return dotForStatus('neutral');
   }
 }

--- a/packages/ui/src/status-vocabulary.ts
+++ b/packages/ui/src/status-vocabulary.ts
@@ -66,20 +66,17 @@ const SEMANTIC_TO_DOT: Record<StatusSemantic, StatusDotVariant> = {
 };
 
 /**
- * Named `dotForStatus` rather than `statusDotVariant` only to avoid colliding
- * with the settings surface's own `statusDotVariant`
- * (`settings-status-badge.ts`), which nine files still import.
+ * Every status dot in the app now comes through here.
  *
- * That file is the eighth mapper and the largest — it predates this one and
- * carries the settings surface's whole status language. The end state is that
- * it becomes another adapter onto this vocabulary rather than a parallel
- * system, at which point these two names collapse into one. It is not migrated
- * here because its `info` states need a per-surface semantic decision (nine of
- * them: does this mean "do not draw the eye" or "something is live?"), which is
- * a design call and deserves its own pass rather than being guessed mid-refactor.
+ * The name was chosen to avoid colliding with the settings surface's own
+ * `statusDotVariant` while both existed; that one is gone, so the collision is
+ * too. Kept as `dotForStatus` because it reads as what it does and renaming it
+ * back would churn a dozen call sites for nothing.
  *
- * Until then: new code uses this vocabulary; the settings surface keeps its
- * own; neither grows a second opinion about what a state colour means.
+ * `StatusTone` still exists next to it, and deliberately: Astryx's Badge has an
+ * `info` pill and its own `neutral`, so a Badge can express a shade a dot
+ * cannot. One surface still renders those. Two vocabularies, because there are
+ * genuinely two — not because nobody cleaned up.
  */
 export function dotForStatus(semantic: StatusSemantic): StatusDotVariant {
   return SEMANTIC_TO_DOT[semantic];


### PR DESCRIPTION
轮二：剩下四个面迁完，**桥接的最后一个调用点消失，桥接本身随之删除**。

## 又五处状态被命名

| 状态 | 裁定 | 为什么 |
|---|---|---|
| bot `configured`「已配置」 | **attention** | 设置没走完；验证过才转 success/error，neutral 会读成"已妥" |
| 权限 `paused`「已暂停」 | **neutral** | 显式关闭但保留配置——陈述现状，不是事件 |
| 订阅 `authorizing`「授权中」 | **active** | 系统正在做 |
| 订阅 `tokenRefreshing` | **active** | 同类，做轮二时新发现的 |
| 健康信号 `info`「提示」 | **neutral** | 见下 |

## 健康信号那处最值得说
它的 `info` **不是"某个状态碰巧叫 info"，而是该面严重度阶梯里的真实一档**（error > warning > info > ok）。**颜色必须与阶梯保持单调**：映成 attention 就会和 `warning` 撞成同一个琥珀，**五档在视觉上塌成四档**，「提示」和「警告」不可分。灰色保住顺序：红 > 琥珀 > 灰 > 绿。「提示」和「未知」同为灰、靠文字区分，可以接受——两者都不要求行动。

## 一处刻意不动
`credentials_valid` **保持琥珀**。它自己的注释写着「凭据探测通过；这不代表已能收发消息」——**故意不给绿**，因为凭据通过不等于运行可用。这和词汇表里「success 只给经过验证的健康」是同一条法则被**独立发现了两次**。

## 桥接删除
`statusDotVariant` **直接删掉而不是迁移**：所有面都改调 `dotForStatus` 后它已无调用点。

`StatusTone` 和 `statusBadgeVariant` **保留，且不是遗留**——Astryx Badge 有 `info` 药丸和自己的 `neutral`，能表达点表达不了的层次，还有一个面在用。**两套词汇是因为真的有两套**，不是没清干净。

## 验证
typecheck：我的改动 0 错（`runtime-host-client` 那 2 条**在干净基线上同样存在**，与本改动无交集，diff 里零 runtime 文件）；`@maka/ui` **483 pass / 0 fail**；lint 0；format:check 0。
