### PR TITLE
chore(release): prepare 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 ## Unreleased
 
+## 0.1.7 - 2026-08-07
+
+### Highlights
+
+- Rebuilt the composer attachment experience: staged attachments are Token
+  chips with tooltip metadata and a lightbox (#2393), with preview thumbnails
+  and file cards (#2367).
+- Unified the app's status language: what a status means is now named in one
+  place (#2397), the Settings surfaces state semantics instead of colours
+  (#2401), and the migration finished by deleting its own bridge (#2403) —
+  every status dot draws from a single definition, and five formerly
+  "active-blue" informational dots settled into their true quiet states.
+- Added bounded long-term memory extraction (#2117) and a runtime `WebFetch`
+  tool (#2362).
+- Moved the CLI onto Runtime Host: `maka run` (#2337) and TUI sessions
+  (#2308), and scanned finished runs' trajectories for retrieval (#2319).
+- Kept a running status line up for the whole live turn (#2356), opened linked
+  subagents from stream tools instead of the sidebar (#2383), restored the
+  transcript's markdown rhythm (#2348), handed the chat meta row back to
+  Astryx primitives (#2358), and exposed recovery for empty failed turns
+  (#2381).
+- Rebuilt the extension module pages on the shared ModulePage shell (#2266),
+  led the session trace with an Astryx-native overview (#2289), and unified
+  the workspace picker onto the composer's ghost-menu family (#2287).
+- The window titlebar states the session's project and name (#2327), and the
+  Pinned and Recent group headers carry a new-task trigger (#2364).
+- Upgraded Astryx 0.2.0 → 0.3.0 (#2288), unified lucide-react onto one major
+  (#2275), added a dependency audit lane (#2223), and published the bundled
+  Git runtime's source materials (#2235).
+
+### Reliability and developer experience
+
+- Provider transport: hardened incremental OpenAI Responses (#2247), stopped
+  reporting a truncated provider stream as a finished turn (#2297), sent the
+  Responses wire the options it reads and read the reasoning it returns
+  (#2328), settled stop cleanly when it aborts a pending question (#2257), and
+  bounded oversized prior turns (#2378).
+- Sessions and storage: made session copy retries idempotent (#2398),
+  preserved operational state across schema upgrades (#2361), imported legacy
+  JSONL session transcripts into SQLite (#2263), closed usage stores after
+  lease revocation (#2365), made active session joins replay-safe (#2368), and
+  validated swarm resume by agent id (#2375).
+- Chat and UI details: kept quote layer geometry stable during entry (#2377)
+  and shown only for settled selections (#2350), made the tool diff readable
+  with its counts on a collapsed group (#2300), kept the prompt rail clickable
+  on macOS (#2338), used standard tab order in the provider catalog (#2306),
+  and served Claude OAuth models from the curated catalog with real error
+  causes (#2336).
+- Desktop platform: isolated the dev build's userData root from release
+  (#2292), closed xAI OAuth callback connections and retried a busy port
+  (#2302), enforced a metadata-free renderer startup boundary (#2176), and
+  dropped the consumer-less update-download bridge (#2326) while giving the
+  update action a slot instead of a row (#2320).
+- Runtime and headless: compacted and sanitized agent tool contracts (#2349),
+  classified an expired probe budget as timeout (#2344), decided the tool call
+  event's ledger lane at push time (#2240), separated request latency from
+  liveness (#2392), measured the wire the Maka runtime actually dials (#2286),
+  and mounted build outputs into the task container rather than the repo root
+  (#2298).
+- Trimmed low-value and redundant tests across suites (#2404, #2406), and made
+  ordering assertions independent of fixed wall-clock budgets (#2304).
+
+### Distribution
+
+- Ships for Apple Silicon macOS as a signed and notarized DMG and ZIP, and for
+  Windows x64 as an unsigned NSIS installer and ZIP, built and verified in the
+  same release run.
+- The bundled Computer Use skill ships with the app, but the Computer Use
+  executor remains excluded from this release.
+
 ## 0.1.6 - 2026-08-06
 
 ### Highlights

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@maka/desktop",
   "productName": "Maka",
   "description": "A local-first agent workspace built for real work.",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "author": "The Maka Authors",
   "license": "Apache-2.0",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maka",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maka",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -38,7 +38,7 @@
     },
     "apps/desktop": {
       "name": "@maka/desktop",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@astryxdesign/core": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maka",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "license": "Apache-2.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
Bumps the version to 0.1.7 and records the release in the changelog, following the 0.1.5/0.1.6 prepare convention (version fields in both package.json files and the lockfile, plus the CHANGELOG section).

## What 0.1.7 carries (85 commits since v0.1.6)

Highlights follow the changelog: the composer attachment experience (Token chips, previews, lightbox), the unified status vocabulary (one definition source for every status dot), bounded long-term memory extraction, the runtime WebFetch tool, Runtime Host-backed CLI run/TUI, live-turn status line and subagent stream links, the ModulePage extension rebuild, Astryx 0.3.0, and the lucide major unification.

## Process

- Changelog curated from the full v0.1.6..HEAD log by 审美专家 (release assessment in Slock thread 67633d48; owner approved the version and delegated preparation).
- After merge: dispatch the release-desktop workflow, which reads the version, creates tag v0.1.7, and builds/verifies both platforms into one draft release.