### PR TITLE
test(headless): remove trim residue

### DIFF
--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -263,8 +263,6 @@ describe('runAbComparison', () => {
     assert.equal(result.stopReason, 'observed_cost_stop_reached');
   });
 
-  ;
-
   test('stops scheduling new pairs after a systemic provider failure', async () => {
     const calls: string[] = [];
     const result = await runAbComparison({

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1976,8 +1976,6 @@ describe('runHarborCell', () => {
     assert.equal(hostCellExitCode({ settledByDeadline: false }), 0);
   });
 
-  ;
-
   test('Harbor ai-sdk backend registration forwards the canonical metering sink', async () => {
     // The controller has always exposed `recordModelCallAttempt`; this
     // composition never passed it on, so Harbor produced diagnostic attempts

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -10,8 +10,6 @@ import { buildHarborJobConfig } from '../harbor-task-runner.js';
 
 const execFileAsync = promisify(execFile);
 
-;
-
 test('harness A/B CLI rejects an unsupported composition before creating a run root', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-composition-'));
   try {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -669,8 +669,6 @@ describe('prompt candidate loop', () => {
     });
   });
 
-  ;
-
   test('requires an agent cwd when held-out artifact paths are provided', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');
@@ -847,8 +845,6 @@ describe('prompt candidate loop', () => {
       assert.equal(metaAgentCalled, false);
     });
   });
-
-  ;
 
   test('rejects agent-cwd directory symlinks that contain controller artifacts', async () => {
     await withDir(async (dir) => {
@@ -1858,10 +1854,6 @@ describe('prompt candidate loop', () => {
       assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
     });
   });
-
-  ;
-
-  ;
 
   test('CLI git adapter rejects HEAD movement during a candidate round', async () => {
     await withDir(async (dir) => {

--- a/packages/headless/src/__tests__/prompt-optimization-loop-replay-decision.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-replay-decision.test.ts
@@ -137,8 +137,6 @@ describe('runPromptOptimizationLoop replay decision guards', () => {
     });
   });
 
-  ;
-
   test('fails closed when task evidence appears after its decision', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 20);

--- a/packages/headless/src/__tests__/prompt-optimization-loop-replay-identity.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-replay-identity.test.ts
@@ -46,8 +46,6 @@ describe('runPromptOptimizationLoop replay identity guards', () => {
     });
   });
 
-  ;
-
   test('fails closed when replayed task evidence has no prompt hash', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 20);


### PR DESCRIPTION
## Summary

- remove six orphan semicolon statements left after the low-value test deletion in #2406
- restore the repository-wide Biome format check

## Why

Every PR based on current `main` fails the required `typecheck` lane during `npm run format:check`, before typechecking begins. The formatter reports only these six headless test files.

## Validation

- `biome format --write` on the six reported files
- repository-wide `biome format .` (1620 files, no remaining changes)
- `git diff --check`

Follow-up to #2406.