### PR TITLE
perf(test): minimize the AgentSwarm progress-cap fixture

### DIFF
--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -513,13 +513,24 @@ describe('AgentSwarm adapter', () => {
     const output: Array<{ stream: string; chunk: string }> = [];
     const result = await buildAgentSwarmTool().impl(
       {
-        items: Array.from({ length: AGENT_SWARM_MAX_CONCURRENCY }, (_, index) => swarmItem(index)),
-        max_concurrency: AGENT_SWARM_MAX_CONCURRENCY,
+        // Four children, not the full 32. The cap under test is shared across
+        // the batch, so demonstrating it needs several children overflowing it
+        // together — not the maximum width, which 'composes local width with the
+        // shared child-run permit pool' already launches 32 children to cover.
+        //
+        // This fixture emitted 9,600 events (32 × 300) to prove a 128-event
+        // boundary and took ~19s. Measured, the time tracked the CHILD count,
+        // not the event count — about 0.6s per child, so cutting events alone
+        // changed nothing. Four children run in 0.4s.
+        items: Array.from({ length: 4 }, (_, index) => swarmItem(index)),
+        max_concurrency: 4,
       },
       context({
         emitOutput: (stream, chunk) => output.push({ stream, chunk }),
         spawnChildSession: async (input) => {
-          for (let index = 0; index < 300; index += 1) {
+          // 4 × 40 = 160: past the 128 cap, with every child contributing and
+          // none able to fill it alone.
+          for (let index = 0; index < 40; index += 1) {
             input.onEvent?.(
               childToolStart(
                 `${input.prompt}-tool-${index}`,


### PR DESCRIPTION
Closes #2386.

## 结果
| | 改前 | 改后 |
|---|---|---|
| 该条测试 | **19.4s** | **0.43s** |
| 整个文件（30 条） | **19.5s** | **0.53s** |

断言一条没动：completed 状态、**恰好 128** 条投影事件、16 KiB 上界、密钥不泄漏。

## Issue 的归因是错的，实测纠正
issue 说成本在"9,600 条事件"。**实测不是**：

- 把每个 child 的事件数 **300 → 5**（9,600 → 160）：**19.46s → 19.41s，毫无变化**
- 把 child 数 **32 → 4**：**立刻降到 0.43s**

**成本随 child 数走，不随事件数走**——这个 fixture 的 `spawnChildSession` 每个 child 约 0.6s，32 个就是那 19 秒。所以真正该减的是 child 数。

（顺带定位：文件启动开销只有 0.63s，19s 全在这一条测试里。）

## 为什么减 child 数不损失覆盖
被测的这个 cap 是**整批共享**的，"几个 child 一起把它挤爆"和"三十二个一起挤爆"证明力相同——**4 × 40 = 160**，过 128 线，每个 child 都有贡献且没有任何一个能单独填满。

**最大并发宽度不由这条测试覆盖**：`composes local width with the shared child-run permit pool` 会真正拉起 `AGENT_SWARM_MAX_CONCURRENCY` 个 child，那条没动。

## 验证
`@maka/runtime` 全套 **3367 pass / 0 fail**。
