### PR TITLE
test(desktop): stop exporting trimmed helpers

### DIFF
--- a/apps/desktop/src/main/__tests__/css-test-helpers.ts
+++ b/apps/desktop/src/main/__tests__/css-test-helpers.ts
@@ -210,7 +210,7 @@ const DYNAMIC_CLASS_NAME = /\bclassName\s*=\s*\{/;
  * they are reported by `findUnreadableBadgeCallSites` instead, so a call site
  * cannot leave this contract just by moving its class into an expression.
  */
-export async function findBadgeClassNames(roots: string[]): Promise<{ file: string; className: string }[]> {
+async function findBadgeClassNames(roots: string[]): Promise<{ file: string; className: string }[]> {
   const out: { file: string; className: string }[] = [];
   for (const root of roots) {
     for (const file of await readTsxTree(root)) {
@@ -237,7 +237,7 @@ export async function findBadgeClassNames(roots: string[]): Promise<{ file: stri
  * which is what a scan looking only for `className=` concludes about
  * `<Badge {...props} />`, silently and while green.
  */
-export async function findUnreadableBadgeCallSites(roots: string[]): Promise<string[]> {
+async function findUnreadableBadgeCallSites(roots: string[]): Promise<string[]> {
   const out: string[] = [];
   for (const root of roots) {
     for (const file of await readTsxTree(root)) {
@@ -297,7 +297,7 @@ export function cssRuleBody(css: string, selector: string): string | null {
  * Return the body of the first `@media <condition> { ... }` block.
  * `mediaCondition` is the part after `@media`, e.g. `(max-width: 620px)`.
  */
-export function cssMediaBody(css: string, mediaCondition: string): string | null {
+function cssMediaBody(css: string, mediaCondition: string): string | null {
   const stripped = stripCssComments(css);
   const cond = escapeCssSelector(mediaCondition);
   const re = new RegExp(`@media\\s*${cond}\\s*\\{`);
@@ -374,7 +374,7 @@ const TYPE_CUSTOM_PROP_RE =
  * rebinding the axis — it needs the longhand. See maka-tokens.css. */
 const FAMILY_ANCHOR = { selector: ':where(code, kbd, samp, pre)', prop: 'font-family' } as const;
 
-export function findTextRoleOffenders(css: string, tokensCss: string, label: string): string[] {
+function findTextRoleOffenders(css: string, tokensCss: string, label: string): string[] {
   const defined = new Set(parseCssCustomProps(tokensCss).keys());
   const offenders: string[] = [];
   /** Selectors that have already been given a role in this cascade context. */
@@ -577,7 +577,7 @@ const CONDITIONAL_AT = /^@(?:media|supports|container)\b/;
  *   - `!important` is not modelled. Nothing in this tree uses it on the
  *     properties these contracts read.
  */
-export function mergeBySelector(
+function mergeBySelector(
   css: string,
   options: { includeConditional?: boolean } = {},
 ): Map<string, string> {
@@ -688,7 +688,7 @@ export function parseCssCustomProps(css: string): Map<string, string[]> {
  * `--leading-normal: var(--leading-normal); --leading-normal: 1.55;`) still
  * passes because the first match satisfies `assert.match`. This helper fails
  * on duplicate declarations and on a single declaration with a drifted value. */
-export function assertCustomPropPinnedOnce(
+function assertCustomPropPinnedOnce(
   css: string,
   prop: string,
   expected: string,

--- a/packages/headless/src/__tests__/ab-run.test.ts
+++ b/packages/headless/src/__tests__/ab-run.test.ts
@@ -263,8 +263,6 @@ describe('runAbComparison', () => {
     assert.equal(result.stopReason, 'observed_cost_stop_reached');
   });
 
-  ;
-
   test('stops scheduling new pairs after a systemic provider failure', async () => {
     const calls: string[] = [];
     const result = await runAbComparison({

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1976,8 +1976,6 @@ describe('runHarborCell', () => {
     assert.equal(hostCellExitCode({ settledByDeadline: false }), 0);
   });
 
-  ;
-
   test('Harbor ai-sdk backend registration forwards the canonical metering sink', async () => {
     // The controller has always exposed `recordModelCallAttempt`; this
     // composition never passed it on, so Harbor produced diagnostic attempts

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -10,8 +10,6 @@ import { buildHarborJobConfig } from '../harbor-task-runner.js';
 
 const execFileAsync = promisify(execFile);
 
-;
-
 test('harness A/B CLI rejects an unsupported composition before creating a run root', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-harness-ab-composition-'));
   try {

--- a/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
+++ b/packages/headless/src/__tests__/prompt-candidate-loop.test.ts
@@ -669,8 +669,6 @@ describe('prompt candidate loop', () => {
     });
   });
 
-  ;
-
   test('requires an agent cwd when held-out artifact paths are provided', async () => {
     await withDir(async (dir) => {
       const programPath = join(dir, 'program.md');
@@ -847,8 +845,6 @@ describe('prompt candidate loop', () => {
       assert.equal(metaAgentCalled, false);
     });
   });
-
-  ;
 
   test('rejects agent-cwd directory symlinks that contain controller artifacts', async () => {
     await withDir(async (dir) => {
@@ -1858,10 +1854,6 @@ describe('prompt candidate loop', () => {
       assert.equal(await readFile(systemPromptPath, 'utf8'), 'original prompt\n');
     });
   });
-
-  ;
-
-  ;
 
   test('CLI git adapter rejects HEAD movement during a candidate round', async () => {
     await withDir(async (dir) => {

--- a/packages/headless/src/__tests__/prompt-optimization-loop-replay-decision.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-replay-decision.test.ts
@@ -137,8 +137,6 @@ describe('runPromptOptimizationLoop replay decision guards', () => {
     });
   });
 
-  ;
-
   test('fails closed when task evidence appears after its decision', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 20);

--- a/packages/headless/src/__tests__/prompt-optimization-loop-replay-identity.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-loop-replay-identity.test.ts
@@ -46,8 +46,6 @@ describe('runPromptOptimizationLoop replay identity guards', () => {
     });
   });
 
-  ;
-
   test('fails closed when replayed task evidence has no prompt hash', async () => {
     await withHarness(async (harness) => {
       const heldInTasks = makeTasks('hin', 20);


### PR DESCRIPTION
## Summary

- stop exporting six CSS test helpers whose consumers were removed by #2406
- restore the desktop knip check after #2410 fixed the preceding formatter failure

## Validation

- `biome format .` passes across 1620 files
- the six reported helper exports no longer appear in `knip --workspace apps/desktop` output
- #2410 CI passed TypeScript before reaching the knip failure