### PR TITLE
fix(desktop): treat a blank UA-CH platform as absent in Astryx's mod-key probe

### DIFF
--- a/apps/desktop/e2e/keyboard-help.spec.ts
+++ b/apps/desktop/e2e/keyboard-help.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, COMPOSER_INPUT } from './fixtures';
+
+const MOD_SLASH = process.platform === 'darwin' ? 'Meta+/' : 'Control+/';
+
+/**
+ * #1689 regression pins: the cheat sheet must render as a structured grid
+ * with keycap chrome — not the stacked plain text the issue reported — and
+ * every documented entry point must reach it.
+ */
+test('the help modal opens from its entry points and keeps its styled layout', async ({ window: page }) => {
+  // Entry point 1: bare `?` with no input focused. The composer autofocuses,
+  // so park focus somewhere non-typing first.
+  await page.locator('body').click({ position: { x: 4, y: 200 } });
+  await page.keyboard.press('?');
+  const body = page.locator('dialog[open] .maka-help-body');
+  await expect(body).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(body).not.toBeVisible();
+
+  // Entry point 2: the platform mod combo — allowed even while typing.
+  await page.locator(COMPOSER_INPUT).click();
+  await page.keyboard.press(MOD_SLASH);
+  await expect(body).toBeVisible();
+
+  // Description/keys resolve into a two-column grid…
+  const rows = page.locator('.maka-help-section dl').first();
+  await expect(rows).toHaveCSS('display', 'grid');
+  const columns = await rows.evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(' ').length);
+  expect(columns).toBe(2);
+  // …headings carry the caption typography, not default heading bulk…
+  const heading = page.locator('.maka-help-section h3').first();
+  await expect(heading).toHaveCSS('font-size', '12px');
+  await expect(heading).toHaveCSS('font-weight', '600');
+  // …multi-key combos keep their distinct separator…
+  const plus = page.locator('.maka-help-plus').first();
+  await expect(plus).toBeVisible();
+  await expect(plus).toHaveText('+');
+  // …and Kbd chips carry real keycap chrome.
+  const keycap = page.locator('.maka-help-section .astryx-kbd kbd').first();
+  await expect(keycap).not.toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+  await expect(keycap).not.toHaveCSS('border-radius', '0px');
+
+  // The platform's own modifier is what the sheet documents — ⌘ on macOS,
+  // Ctrl elsewhere. (This harness boots with healthy UA-CH; the blank-UA-CH
+  // environment is pinned by the dedicated test below.)
+  const firstCombo = page.locator('.maka-help-section dd').first();
+  await expect(firstCombo).toContainText(process.platform === 'darwin' ? '⌘' : 'Ctrl');
+
+  // The same combo toggles it closed again.
+  await page.keyboard.press(MOD_SLASH);
+  await expect(body).not.toBeVisible();
+});
+
+/**
+ * Guard for the `@astryxdesign/core` blank-UA-CH patch (patches/README.md).
+ *
+ * Electron bundles with a rewritten identity (the ad-hoc-signed dev app)
+ * ship `userAgentData.platform: ''`, and Astryx's probe read the blank as
+ * "not Apple" — mod hotkeys bound Ctrl on macOS and keycaps drew Ctrl. This
+ * harness boots with healthy UA-CH, so the broken environment is
+ * reconstructed explicitly: blank UA-CH plus a Mac `navigator.platform`,
+ * installed before the app boots. Patched Astryx must fall through the
+ * blank to navigator.platform and land on ⌘ — on every host OS, which is
+ * what makes this test discriminating in CI (unpatched, the blank decides
+ * "not Apple" and the keycap reads Ctrl).
+ */
+test('a blank UA-CH platform falls through to navigator.platform', async ({ window: page }) => {
+  await page.context().addInitScript(() => {
+    const original = (navigator as { userAgentData?: unknown }).userAgentData ?? {};
+    Object.defineProperty(Navigator.prototype, 'userAgentData', {
+      configurable: true,
+      get: () => ({ ...(original as object), platform: '', brands: [] }),
+    });
+    Object.defineProperty(Navigator.prototype, 'platform', {
+      configurable: true,
+      get: () => 'MacIntel',
+    });
+  });
+  await page.reload();
+  await page.locator(COMPOSER_INPUT).waitFor();
+
+  // With the fake Mac platform installed, the mod hotkey must bind ⌘ — so
+  // Meta+/ opens the modal regardless of the host OS.
+  await page.keyboard.press('Meta+/');
+  const body = page.locator('dialog[open] .maka-help-body');
+  await expect(body).toBeVisible();
+  await expect(page.locator('.maka-help-section dd').first()).toContainText('⌘');
+});

--- a/patches/@astryxdesign+core+0.3.0.patch
+++ b/patches/@astryxdesign+core+0.3.0.patch
@@ -161,6 +161,25 @@ index 8c509bc..f108f3b 100644
    };
  }
 \ No newline at end of file
+diff --git a/node_modules/@astryxdesign/core/dist/Kbd/Kbd.js b/node_modules/@astryxdesign/core/dist/Kbd/Kbd.js
+index 33ed78d..195a427 100644
+--- a/node_modules/@astryxdesign/core/dist/Kbd/Kbd.js
++++ b/node_modules/@astryxdesign/core/dist/Kbd/Kbd.js
+@@ -111,7 +111,13 @@ function detectMac() {
+   // Prefer User-Agent Client Hints API (not deprecated)
+   const uaData = 'userAgentData' in navigator ? navigator.userAgentData : null;
+   if (uaData && typeof uaData === 'object' && 'platform' in uaData) {
+-    return /mac/i.test(uaData.platform ?? '');
++    const uaPlatform = typeof uaData.platform === 'string' ? uaData.platform : '';
++    if (uaPlatform.trim().length > 0) {
++      return /mac/i.test(uaPlatform);
++    }
++    // Blank UA-CH platform: Electron bundles with a rewritten identity ship
++    // '' (and empty brands). Treat it as absent and fall through to
++    // navigator.platform instead of reading it as "not Apple".
+   }
+   // Fallback: navigator.platform (deprecated but still shipped everywhere)
+   return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');
 diff --git a/node_modules/@astryxdesign/core/dist/List/List.js b/node_modules/@astryxdesign/core/dist/List/List.js
 index 08b5f7d..94c623b 100644
 --- a/node_modules/@astryxdesign/core/dist/List/List.js
@@ -181,3 +200,22 @@ index 08b5f7d..94c623b 100644
      "aria-labelledby": header != null ? headerId : undefined,
      ...(isOrdered && start != null && start !== 1 ? {
        start
+diff --git a/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js b/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js
+index 65f9278..c2e72d1 100644
+--- a/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js
++++ b/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js
+@@ -54,7 +54,13 @@ function isApplePlatform() {
+   }
+   const uaData = 'userAgentData' in navigator ? navigator.userAgentData : null;
+   if (uaData && typeof uaData === 'object' && 'platform' in uaData) {
+-    return /mac/i.test(uaData.platform ?? '');
++    const uaPlatform = typeof uaData.platform === 'string' ? uaData.platform : '';
++    if (uaPlatform.trim().length > 0) {
++      return /mac/i.test(uaPlatform);
++    }
++    // Blank UA-CH platform: Electron bundles with a rewritten identity ship
++    // '' (and empty brands). Treat it as absent and fall through to
++    // navigator.platform instead of reading it as "not Apple".
+   }
+   return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');
+ }

--- a/patches/README.md
+++ b/patches/README.md
@@ -37,3 +37,20 @@ A contiguous run of tool calls is one group, and a group collapses by default. T
 The patch adds group-level `additions` / `deletions` and renders them beside the wrench count on the collapsed header. `ToolTrow` passes the run's total; the per-call counts stay on the rows inside.
 
 **Delete it when `packages/ui/src/__tests__/tool-trow-stability.test.tsx` passes without the patch** — its grouped-diff case asserts the summed `+N` / `-N` on a collapsed run.
+
+## `@astryxdesign/core`: a blank UA-CH platform must not decide "not Apple"
+
+`Kbd`'s ⌘/Ctrl display and `useHotkeys`' `mod` binding share one platform
+probe that prefers `navigator.userAgentData.platform` over the deprecated
+`navigator.platform`. Electron bundles whose identity was rewritten after
+copy (the ad-hoc-signed `Maka Dev.app` the TCC workflow builds) ship UA-CH
+**empty** — `platform: ''`, `brands: []` — and the probe read the blank as
+"not Apple": on macOS every `mod` hotkey listened for Ctrl (⌘+/ stopped
+opening the keyboard help) and every keycap drew Ctrl. The patch treats a
+blank `uaData.platform` as absent and falls through to `navigator.platform`;
+a non-blank value keeps deciding exactly as before.
+
+**Delete it when** the guard in `apps/desktop/e2e/keyboard-help.spec.ts`
+(the "blank UA-CH" test, which fakes `platform: ''` + `MacIntel` via an init
+script) passes without the patch — that means Astryx's own probe learned to
+distrust the blank.


### PR DESCRIPTION
Fixes #2429. Related: #1689 (investigation origin — its reported layout regression no longer reproduces on main; the new e2e pins that contract).

## What changed since the last review

All five findings addressed by rebuilding the fix:

| Finding | Resolution |
|---|---|
| global UA-CH façade inconsistency (Hard) | **Shim deleted.** The fix now rides the repo's dependency-patch mechanism at Astryx's two detection points (`Kbd.js` `detectMac`, `useHotkeys.js` `isApplePlatform`): a blank `uaData.platform` is treated as absent and falls through to `navigator.platform`. The page's `userAgentData` object, its prototype identity, `toJSON()` and `getHighEntropyValues()` stay untouched — verified live: `platform` still reads `""` in the dev bundle, keycaps draw ⌘. |
| core path untested (Hard) | The new e2e "blank UA-CH" test reconstructs the broken environment (init script installs `platform:''` + `brands:[]` + `navigator.platform: 'MacIntel'`, then reloads) and drives the REAL patched probe end to end. **Proven discriminating**: red without the patch, green with it — on every host OS including Linux CI, because the fake Mac platform makes the fall-through observable as a ⌘ keycap. |
| over-generalization (Judgment) | The patch only changes what a *blank* platform means at the probe; non-blank values decide exactly as before, and on Windows/Linux the blank already fell back to the correct Ctrl answer. No global shadow anywhere. |
| P1 issue mismatch | Split done: **#2429** now tracks the dev-bundle UA-CH defect and this PR fixes it. #1689's layout symptom is verified fixed on main and pinned here. |
| P2 layout pins incomplete | The entry-point/layout e2e now covers: bare `?` and `mod+/` entry points, two-column `grid-template-columns`, heading caption typography (12px/600), the `+` separator, keycap chrome, platform-correct modifier, and close-toggle. |

## Root cause (unchanged)

Rewritten-identity Electron bundles (the ad-hoc-signed `Maka Dev.app` from `dev-app-runtime.mjs`'s TCC workflow) ship `navigator.userAgentData` empty. Astryx's probe prefers UA-CH over `navigator.platform` and reads the blank as "not Apple" — on macOS `mod` hotkeys bound Ctrl (⌘+/ dead) and keycaps drew Ctrl. Bare `electron .` and release `Maka.app` populate UA-CH correctly (release user-verified on 0.1.6).

## Patch governance

`patches/README.md` gains the required section: reason, scope (only the blank-value branch), and deletion condition (the guard e2e passing unpatched means upstream learned to distrust the blank).

## Tests

- e2e ×2 (entry points + layout contract; blank-UA-CH guard) — the guard proven red-without/green-with the patch
- desktop suite 1758/1758, typecheck clean, biome/format/console/a11y/copy clean
- live-verified in the actual dev bundle via CDP: `uaData.platform` still `""`, Meta+/ opens, keycaps ⌘

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Ac5rv6WUKWtMZgQb5QPN16