### PR TITLE
fix(runtime-host): close M4 readiness gaps

### DIFF
--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -15,11 +15,11 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 
 | Classification | Count |
 |---|---:|
-| windows-backend-gap | 29 |
-| portable-candidate | 21 |
+| windows-backend-gap | 30 |
+| portable-candidate | 22 |
 | platform-contract | 16 |
 
-Total Windows-excluded declarations: **66**
+Total Windows-excluded declarations: **68**
 
 ## Inventory
 
@@ -40,7 +40,7 @@ Total Windows-excluded declarations: **66**
 | windows-backend-gap | `packages/runtime-host/src/__tests__/deep-research-two-client-uds.test.ts` two UDS Clients and a restarted production Host share one Deep Research projection | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/execution-host-queue.test.ts` a killed Host is recovered exactly once before its successor becomes ready | `process.platform === 'win32' ? 'POSIX process death gate' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/execution-inspect-uds.test.ts` a live Host serves Interactive inspection over its real UDS while retaining exclusive ownership | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` a response timeout is connection-fatal and Client close stays local | `process.platform === 'win32'` |
+| windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` an automatic failed liveness check is connection-fatal and Client close stays local | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` bounded election does not launch a Candidate after handshake exhausts the deadline | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` a non-reading Client overload is isolated to its connection | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` reports one shutdown failure through close and closed while releasing ownership | `process.platform === 'win32'` |
@@ -51,6 +51,7 @@ Total Windows-excluded declarations: **66**
 | windows-backend-gap | `packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts` two UDS Clients and a restarted production Host share one retry-safe Plan authority | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts` invalidates when a real published mutation loses its commit reply | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/runtime-resource-process.test.ts` real Host Runtime Resource process lifecycle | `process.platform === 'win32'` |
+| windows-backend-gap | `packages/runtime-host/src/__tests__/runtime-resource-two-client-uds.test.ts` a Host-owned PTY survives Desktop disconnect and transfers control to TUI | `process.platform === 'win32' ? 'POSIX UDS and shell integration' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts` two UDS Clients share stable Session creation, CAS configuration, and catalog continuity | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts` stable Session creation survives response loss and Host restart | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/session-effect-two-client-uds.test.ts` two UDS Clients share one durable Session recap effect | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
@@ -88,6 +89,7 @@ Total Windows-excluded declarations: **66**
 | platform-contract | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` fails closed on final symlinks, FIFOs, and oversized documents without changing bytes | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/storage/src/__tests__/sqlite-long-term-memory-crash.test.ts` retains one committed Item and its receipt when killed between COMMIT and return | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/storage/src/__tests__/sqlite-runtime-crash.test.ts` SqliteRuntimeStore real-process crash boundaries | `process.platform === 'win32'` |
+| portable-candidate | `packages/storage/src/__tests__/usage-stores.test.ts` classifies a renamed or replaced live root as a draining persistence failure | `process.platform === 'win32' ? 'Windows does not permit renaming a directory with an open SQLite database' : false` |
 | portable-candidate | `packages/storage/src/__tests__/workspace-identity.test.ts` a non-Git workspace resolves when the Git executable is unavailable | `process.platform === 'win32'` |
 | portable-candidate | `packages/storage/src/__tests__/workspace-identity.test.ts` a Git workspace does not publish a marker when the Git executable is unavailable | `process.platform === 'win32'` |
 | portable-candidate | `packages/storage/src/__tests__/workspace-identity.test.ts` an unmarked read-only workspace fails without leaving marker state | `process.platform === 'win32'` |

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -2,8 +2,8 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { LlmConnection, ModelInfo, ProviderType } from '@maka/core/llm-connections';
 import type { ConnectionStore, CredentialStore } from '@maka/storage';
+import { listApiKeyOnboardableProviders } from '../onboarding-catalog.js';
 import {
-  listApiKeyOnboardableProviders,
   listOnboardingProviders,
   saveApiKeyConnection,
   verifyApiKeyConnection,

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -38,20 +38,17 @@ import type {
   SessionResumeAvailability,
 } from '../session-driver.js';
 import { CliGoalContinuation, type CliGoalTurnHost } from '../cli-goal-continuation.js';
-import type { ModelChoice } from '../connection-target.js';
-import {
-  listApiKeyOnboardableProviders,
-  type MakaOnboardingSurface,
-  type OnboardingProviderEntry,
-  type OnboardingSaveResult,
-  type OnboardingVerifyResult,
-} from '../onboarding.js';
+import { listApiKeyOnboardableProviders } from '../onboarding-catalog.js';
+import type {
+  MakaOnboardingSurface,
+  MakaPiTuiGoalLifecycle,
+  ModelChoice,
+  OnboardingProviderEntry,
+  OnboardingSaveResult,
+  OnboardingVerifyResult,
+} from '../pi-tui-contracts.js';
 import type { ModelInfo, ProviderType } from '@maka/core/llm-connections';
-import {
-  runMakaPiTui as runMakaPiTuiImpl,
-  type MakaPiTuiGoalLifecycle,
-  type MakaPiTuiInput,
-} from '../pi-tui-runner.js';
+import { runMakaPiTui as runMakaPiTuiImpl, type MakaPiTuiInput } from '../pi-tui-runner.js';
 import { AUTO_RECAP_IDLE_MS } from '../session-recap.js';
 import { _setColorLevelForTesting } from '../tui-ansi.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';

--- a/packages/cli/src/__tests__/runtime-host-run-dependency.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-dependency.test.ts
@@ -1,9 +1,22 @@
 import assert from 'node:assert/strict';
-import { dirname, join, relative, resolve } from 'node:path';
+import {
+  dirname,
+  isAbsolute as isAbsolutePath,
+  join,
+  posix,
+  relative,
+  resolve,
+  sep,
+  win32,
+} from 'node:path';
 import { after, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import type { SessionManager as EmbeddedSessionManagerFixture } from '@maka/runtime';
+import type { SessionManager as EmbeddedSubpathSessionManagerFixture } from '@maka/runtime/session-manager';
 import * as ts from 'typescript/unstable/ast';
 import { API } from 'typescript/unstable/sync';
+
+export { SessionManager as EmbeddedSessionManagerReexportFixture } from '@maka/runtime';
 
 const sourceRoot = fileURLToPath(new URL('../../src/', import.meta.url));
 const packageRoot = resolve(sourceRoot, '..');
@@ -11,6 +24,56 @@ const projectConfig = join(packageRoot, 'tsconfig.json');
 const compilerApi = new API({ cwd: packageRoot });
 const compilerSnapshot = compilerApi.updateSnapshot({ openProjects: [projectConfig] });
 const compilerProject = loadCompilerProject();
+let dependencyScannerRuntimeOwnerFixture: EmbeddedSessionManagerFixture | undefined;
+void dependencyScannerRuntimeOwnerFixture;
+let dependencyScannerRuntimeSubpathFixture: EmbeddedSubpathSessionManagerFixture | undefined;
+void dependencyScannerRuntimeSubpathFixture;
+type EmbeddedSessionManagerImportTypeFixture = import('@maka/runtime').SessionManager;
+let dependencyScannerRuntimeImportTypeFixture: EmbeddedSessionManagerImportTypeFixture | undefined;
+void dependencyScannerRuntimeImportTypeFixture;
+
+async function dependencyScannerFixture(target: string): Promise<void> {
+  await import('../run-command.js');
+  await import('@maka/storage');
+  await import('@maka/runtime');
+  await import('@maka/runtime-host/server');
+  await import(target);
+}
+void dependencyScannerFixture;
+
+function dependencyScannerLoaderFixture(): void {
+  const load = process.getBuiltinModule('node:module').createRequire(import.meta.url);
+  load('@maka/storage');
+}
+void dependencyScannerLoaderFixture;
+
+function dependencyScannerBracketLoaderFixture(): void {
+  const load = process['getBuiltinModule']('node:module').createRequire(import.meta.url);
+  load('@maka/storage');
+}
+void dependencyScannerBracketLoaderFixture;
+
+const { getBuiltinModule: dependencyScannerGetBuiltinModule } = process;
+function dependencyScannerAliasedLoaderFixture(): void {
+  const load = dependencyScannerGetBuiltinModule('node:module').createRequire(import.meta.url);
+  load('@maka/storage');
+}
+void dependencyScannerAliasedLoaderFixture;
+
+const dependencyScannerProcessAlias = process;
+function dependencyScannerProcessAliasFixture(): void {
+  const load = dependencyScannerProcessAlias
+    .getBuiltinModule('node:module')
+    .createRequire(import.meta.url);
+  load('@maka/storage');
+}
+void dependencyScannerProcessAliasFixture;
+
+function dependencyScannerGlobalProcessFixture(): void {
+  const load = globalThis.process.getBuiltinModule('node:module').createRequire(import.meta.url);
+  load('@maka/storage');
+}
+void dependencyScannerGlobalProcessFixture;
 
 after(() => {
   compilerSnapshot.dispose();
@@ -23,24 +86,109 @@ function loadCompilerProject() {
   return project;
 }
 
-test('the Runtime Host run entry cannot reach the embedded Runtime or writer Stores', () => {
-  const reached = reachableModules(join(sourceRoot, 'runtime-host-run-command.ts'));
+test('Runtime Host CLI entries cannot reach embedded Runtime owners or writer Stores', () => {
   const forbiddenModules = new Set([
     'embedded-tui-command.ts',
     'run-command.ts',
     'runtime-bootstrap.ts',
   ]);
   const violations: string[] = [];
-  for (const path of reached) {
-    const localPath = relative(sourceRoot, path);
-    if (forbiddenModules.has(localPath)) violations.push(localPath);
-    for (const specifier of runtimeModuleSpecifiers(path)) {
-      if (specifier === '@maka/storage' || specifier.startsWith('@maka/storage/')) {
-        violations.push(`${localPath}: ${specifier}`);
+  for (const entrypoint of [
+    'runtime-host-run-command.ts',
+    'runtime-host-tui-command.ts',
+    'live-inspect-backend.ts',
+  ]) {
+    for (const path of reachableModules(join(sourceRoot, entrypoint))) {
+      const localPath = relative(sourceRoot, path);
+      const references = moduleReferences(path);
+      if (forbiddenModules.has(localPath)) violations.push(`${entrypoint}: ${localPath}`);
+      for (const violation of workspaceBoundaryViolations(references)) {
+        violations.push(`${entrypoint}: ${localPath}: ${violation}`);
       }
     }
   }
   assert.deepEqual(violations, []);
+});
+
+test('the dependency gate rejects hidden loads and every workspace owner reference shape', () => {
+  const path = join(sourceRoot, '__tests__', 'runtime-host-run-dependency.test.ts');
+  const scan = scanModuleReferences(path);
+  assert.ok(scan.references.some((reference) => reference.specifier === '../run-command.js'));
+  assert.ok(scan.references.some((reference) => reference.specifier === '@maka/storage'));
+  assert.equal(scan.nonStaticLoads.length, 1);
+  assert.match(scan.nonStaticLoads[0] ?? '', /import\(\.\.\.\)/);
+  assert.ok(
+    scan.forbiddenLoaderCapabilities.some((violation) =>
+      violation.endsWith('getBuiltinModule: process.getBuiltinModule'),
+    ),
+  );
+  assert.ok(
+    scan.forbiddenLoaderCapabilities.some((violation) =>
+      violation.endsWith("getBuiltinModule: process['getBuiltinModule']"),
+    ),
+  );
+  assert.ok(
+    scan.forbiddenLoaderCapabilities.some((violation) =>
+      violation.endsWith('getBuiltinModule: getBuiltinModule'),
+    ),
+  );
+  assert.ok(
+    scan.forbiddenLoaderCapabilities.some((violation) =>
+      violation.endsWith('getBuiltinModule: dependencyScannerProcessAlias.getBuiltinModule'),
+    ),
+  );
+  assert.ok(
+    scan.forbiddenLoaderCapabilities.some((violation) =>
+      violation.endsWith('getBuiltinModule: globalThis.process.getBuiltinModule'),
+    ),
+  );
+  const runtimeViolations = workspaceBoundaryViolations(scan.references);
+  assert.ok(runtimeViolations.some((violation) => /import .*SessionManager/.test(violation)));
+  assert.ok(runtimeViolations.some((violation) => /export .*SessionManager/.test(violation)));
+  assert.ok(runtimeViolations.some((violation) => /import_type .*SessionManager/.test(violation)));
+  assert.ok(
+    runtimeViolations.some((violation) =>
+      /@maka\/runtime\/session-manager is not an allowed client module/.test(violation),
+    ),
+  );
+  assert.ok(runtimeViolations.some((violation) => /dynamic .*unbounded/.test(violation)));
+  assert.ok(
+    runtimeViolations.some((violation) =>
+      /@maka\/runtime-host\/server is not an allowed client module/.test(violation),
+    ),
+  );
+  assert.deepEqual(
+    workspaceBoundaryViolations([
+      {
+        specifier: 'maka-agent',
+        kind: 'import',
+        bindings: ['createMakaCliRuntimeContext'],
+      },
+      {
+        specifier: '@maka/runtime-host/execution-candidate-main',
+        kind: 'import',
+        bindings: ['startRuntimeHostCandidate'],
+      },
+    ]),
+    [
+      'import maka-agent is not an allowed client module',
+      'import @maka/runtime-host/execution-candidate-main is not an allowed client module',
+    ],
+  );
+  assert.deepEqual(
+    workspaceBoundaryViolations([
+      { specifier: 'file:///tmp/runtime-owner.js', kind: 'dynamic', bindings: null },
+      { specifier: 'data:text/javascript,export default 1', kind: 'dynamic', bindings: null },
+      { specifier: 'C:\\runtime-owner.js', kind: 'import', bindings: ['owner'] },
+      { specifier: '#runtime-owner', kind: 'import', bindings: ['owner'] },
+    ]),
+    [
+      'dynamic file:///tmp/runtime-owner.js is not a portable static module specifier',
+      'dynamic data:text/javascript,export default 1 is not a portable static module specifier',
+      'import C:\\runtime-owner.js is not a portable static module specifier',
+      'import #runtime-owner is not a portable static module specifier',
+    ],
+  );
 });
 
 function reachableModules(entrypoint: string): Set<string> {
@@ -50,30 +198,280 @@ function reachableModules(entrypoint: string): Set<string> {
     const path = pending.pop();
     if (!path || reached.has(path)) continue;
     reached.add(path);
-    for (const specifier of runtimeModuleSpecifiers(path)) {
+    for (const { specifier } of moduleReferences(path)) {
       if (!specifier.startsWith('.')) continue;
-      const target = resolve(dirname(path), specifier).replace(/\.js$/, '.ts');
-      if (target.startsWith(`${sourceRoot}/`)) pending.push(target);
+      const target = sourcePathForLocalSpecifier(path, specifier);
+      if (!isInside(sourceRoot, target)) {
+        throw new Error(
+          `Runtime Host CLI dependency escapes its source root: ${path}: ${specifier}`,
+        );
+      }
+      pending.push(target);
     }
   }
   return reached;
 }
 
-function runtimeModuleSpecifiers(path: string): string[] {
+function moduleReferences(path: string): readonly ModuleReference[] {
+  const scan = scanModuleReferences(path);
+  const violations = [...scan.nonStaticLoads, ...scan.forbiddenLoaderCapabilities];
+  if (violations.length > 0) {
+    throw new Error(
+      `Dependency boundary requires explicit module declarations:\n${violations.join('\n')}`,
+    );
+  }
+  return scan.references;
+}
+
+type ModuleReferenceKind = 'import' | 'export' | 'import_type' | 'dynamic' | 'require';
+
+interface ModuleReference {
+  readonly specifier: string;
+  readonly kind: ModuleReferenceKind;
+  readonly bindings: readonly string[] | null;
+}
+
+function scanModuleReferences(path: string): {
+  references: ModuleReference[];
+  nonStaticLoads: string[];
+  forbiddenLoaderCapabilities: string[];
+} {
   const source = compilerProject.program.getSourceFile(path);
   if (!source) throw new Error(`TypeScript did not load ${path}`);
-  const specifiers: string[] = [];
-  source.forEachChild((node: ts.Node) => {
+  const references: ModuleReference[] = [];
+  const nonStaticLoads: string[] = [];
+  const forbiddenLoaderCapabilities: string[] = [];
+  const visit = (node: ts.Node): void => {
+    const loaderCapability = loaderCapabilityName(node);
+    if (loaderCapability) {
+      const violation = `${path}: ${loaderCapability}: ${node.getText(source).replace(/\s+/g, '')}`;
+      if (!forbiddenLoaderCapabilities.includes(violation)) {
+        forbiddenLoaderCapabilities.push(violation);
+      }
+    }
     if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
-      specifiers.push(node.moduleSpecifier.text);
+      references.push({
+        specifier: node.moduleSpecifier.text,
+        kind: 'import',
+        bindings: importBindings(node),
+      });
     }
     if (
       ts.isExportDeclaration(node) &&
       node.moduleSpecifier &&
       ts.isStringLiteral(node.moduleSpecifier)
     ) {
-      specifiers.push(node.moduleSpecifier.text);
+      references.push({
+        specifier: node.moduleSpecifier.text,
+        kind: 'export',
+        bindings: exportBindings(node),
+      });
     }
-  });
-  return specifiers;
+    if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === 'require'))
+    ) {
+      const target = node.arguments[0];
+      if (target && ts.isStringLiteralLikeNode(target)) {
+        references.push({
+          specifier: target.text,
+          kind: node.expression.kind === ts.SyntaxKind.ImportKeyword ? 'dynamic' : 'require',
+          bindings: null,
+        });
+      } else {
+        nonStaticLoads.push(
+          `${path}: ${node.expression.kind === ts.SyntaxKind.ImportKeyword ? 'import' : 'require'}(...)`,
+        );
+      }
+    }
+    if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteral(node.argument.literal)
+    ) {
+      references.push({
+        specifier: node.argument.literal.text,
+        kind: 'import_type',
+        bindings: node.qualifier ? [leftmostEntityName(node.qualifier)] : null,
+      });
+    }
+    if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteralLikeNode(node.moduleReference.expression)
+    ) {
+      references.push({
+        specifier: node.moduleReference.expression.text,
+        kind: 'require',
+        bindings: null,
+      });
+    }
+    node.forEachChild(visit);
+  };
+  visit(source);
+  for (const reference of references) {
+    if (reference.specifier === 'node:module' || reference.specifier === 'module') {
+      forbiddenLoaderCapabilities.push(`${path}: ${reference.specifier}`);
+    }
+  }
+  return { references, nonStaticLoads, forbiddenLoaderCapabilities };
+}
+
+type WorkspaceImportPolicy = 'named' | ReadonlySet<string>;
+
+const workspacePresentationImports = new Map<string, WorkspaceImportPolicy>([
+  [
+    '@maka/runtime',
+    new Set([
+      'AgentRunInspectDocument',
+      'ChatItem',
+      'ContextDiagnostics',
+      'GoalObservedTurnSettler',
+      'GoalObservedTurnStart',
+      'GoalTurnAdmission',
+      'GoalTurnOutcome',
+      'HostCapabilities',
+      'InvocationResult',
+      'InvocableSkillEntry',
+      'RuntimeContinuation',
+      'SafeBoundaryContinuationPlan',
+      'SESSION_RECAP_INSTRUCTION',
+      'SessionActivityLease',
+      'SessionActivityRegistry',
+      'SessionInspectDocument',
+      'SkillSource',
+      'ToolActivityItem',
+      'cleanSessionRecapText',
+      'drainGoalTurn',
+      'listInvocableSkills',
+      'materializeSession',
+      'prepareSkillInvocationMessage',
+    ]),
+  ],
+  ['@maka/headless', new Set(['TaskRunInspectDocument'])],
+  ['@maka/runtime-host/adapter', 'named'],
+  ['@maka/runtime-host/client', 'named'],
+  ['@maka/runtime-host/protocol', 'named'],
+]);
+
+function workspaceBoundaryViolations(references: readonly ModuleReference[]): string[] {
+  const violations: string[] = [];
+  for (const reference of references) {
+    if (!isPortableStaticSpecifier(reference.specifier)) {
+      violations.push(
+        `${reference.kind} ${reference.specifier} is not a portable static module specifier`,
+      );
+      continue;
+    }
+    if (!isWorkspaceSpecifier(reference.specifier)) continue;
+    const allowed = workspaceImportPolicy(reference.specifier);
+    if (allowed === undefined) {
+      violations.push(`${reference.kind} ${reference.specifier} is not an allowed client module`);
+      continue;
+    }
+    if (!reference.bindings) {
+      violations.push(`${reference.kind} ${reference.specifier} is unbounded`);
+      continue;
+    }
+    for (const binding of reference.bindings) {
+      if (
+        binding === 'default' ||
+        binding === '*' ||
+        (allowed !== 'named' && !allowed.has(binding))
+      ) {
+        violations.push(`${reference.kind} ${reference.specifier} ${binding}`);
+      }
+    }
+  }
+  return violations;
+}
+
+function isPortableStaticSpecifier(specifier: string): boolean {
+  if (posix.isAbsolute(specifier) || win32.isAbsolute(specifier) || specifier.startsWith('#')) {
+    return false;
+  }
+  const scheme = /^[A-Za-z][A-Za-z0-9+.-]*:/.exec(specifier)?.[0];
+  return scheme === undefined || scheme === 'node:';
+}
+
+function isWorkspaceSpecifier(specifier: string): boolean {
+  return (
+    specifier === 'maka-agent' ||
+    specifier.startsWith('maka-agent/') ||
+    specifier.startsWith('@maka/')
+  );
+}
+
+function workspaceImportPolicy(specifier: string): WorkspaceImportPolicy | undefined {
+  if (specifier === '@maka/core' || specifier.startsWith('@maka/core/')) return 'named';
+  return workspacePresentationImports.get(specifier);
+}
+
+function importBindings(node: ts.ImportDeclaration): readonly string[] | null {
+  const clause = node.importClause;
+  if (!clause) return null;
+  const bindings: string[] = [];
+  if (clause.name) bindings.push('default');
+  if (!clause.namedBindings) return bindings.length > 0 ? bindings : null;
+  if (ts.isNamespaceImport(clause.namedBindings)) return [...bindings, '*'];
+  return [
+    ...bindings,
+    ...clause.namedBindings.elements.map((element) =>
+      element.propertyName ? element.propertyName.text : element.name.text,
+    ),
+  ];
+}
+
+function exportBindings(node: ts.ExportDeclaration): readonly string[] | null {
+  if (!node.exportClause || ts.isNamespaceExport(node.exportClause)) return null;
+  return node.exportClause.elements.map((element) =>
+    element.propertyName ? element.propertyName.text : element.name.text,
+  );
+}
+
+function leftmostEntityName(name: ts.EntityName): string {
+  let current = name;
+  while (ts.isQualifiedName(current)) current = current.left;
+  return current.text;
+}
+
+function loaderCapabilityName(node: ts.Node): string | undefined {
+  if (
+    ts.isElementAccessExpression(node) &&
+    ((ts.isIdentifier(node.expression) && node.expression.text === 'process') ||
+      (node.argumentExpression &&
+        ts.isStringLiteralLikeNode(node.argumentExpression) &&
+        node.argumentExpression.text === 'getBuiltinModule'))
+  ) {
+    return 'getBuiltinModule';
+  }
+  if (ts.isPropertyAccessExpression(node) && node.name.text === 'getBuiltinModule') {
+    return 'getBuiltinModule';
+  }
+  if (ts.isIdentifier(node) && node.text === 'getBuiltinModule') {
+    if (ts.isPropertyAccessExpression(node.parent) && node.parent.name === node) return undefined;
+    return 'getBuiltinModule';
+  }
+  if (!ts.isIdentifier(node) || node.text !== 'require') return undefined;
+  if (
+    (ts.isPropertyAccessExpression(node.parent) && node.parent.name === node) ||
+    (ts.isPropertyAssignment(node.parent) && node.parent.name === node) ||
+    (node.parent as { name?: ts.Node }).name === node
+  ) {
+    return undefined;
+  }
+  return 'require';
+}
+
+function sourcePathForLocalSpecifier(importer: string, specifier: string): string {
+  const target = resolve(dirname(importer), specifier);
+  if (target.endsWith('.js')) return `${target.slice(0, -3)}.ts`;
+  return target.endsWith('.ts') ? target : `${target}.ts`;
+}
+
+function isInside(root: string, path: string): boolean {
+  const child = relative(root, path);
+  return child !== '..' && !child.startsWith(`..${sep}`) && !isAbsolutePath(child);
 }

--- a/packages/cli/src/connection-target.ts
+++ b/packages/cli/src/connection-target.ts
@@ -8,23 +8,13 @@ import {
   type OAuthSubscriptionTokens,
 } from '@maka/runtime';
 import type { ConnectionStore, CredentialKind, CredentialStore } from '@maka/storage';
+import type { ModelChoice } from './pi-tui-contracts.js';
 
 export interface ReadySessionTarget {
   connection: LlmConnection;
   apiKey: string;
   model: string;
   oauthTokens?: OAuthSubscriptionTokens;
-}
-
-/** One selectable model in the `/model` picker, tagged with its owning connection. */
-export interface ModelChoice {
-  connectionSlug: string;
-  connectionName: string;
-  providerType: ProviderType;
-  model: string;
-  isDefaultConnection: boolean;
-  /** Maximum context tokens for this model, resolved from the connection or provider catalog. */
-  contextWindow?: number;
 }
 
 export function selectableModelIdsForTarget(

--- a/packages/cli/src/embedded-tui-command.ts
+++ b/packages/cli/src/embedded-tui-command.ts
@@ -11,7 +11,8 @@ import {
 } from '@maka/storage';
 import { selectableModelIdsForTarget } from './connection-target.js';
 import { createApiKeyOnboardingSurface } from './onboarding.js';
-import { runMakaPiTui, type MakaPiTuiGoalLifecycle } from './pi-tui-runner.js';
+import type { MakaPiTuiGoalLifecycle } from './pi-tui-contracts.js';
+import { runMakaPiTui } from './pi-tui-runner.js';
 import { createMakaCliRuntimeContext } from './runtime-bootstrap.js';
 import { createMakaSessionDriver, type MakaSessionDriver } from './session-driver.js';
 

--- a/packages/cli/src/onboarding-catalog.ts
+++ b/packages/cli/src/onboarding-catalog.ts
@@ -1,0 +1,21 @@
+import {
+  CATALOG_PROVIDER_TYPES,
+  PROVIDER_DEFAULTS,
+  providerAuthSupportsApiKey,
+} from '@maka/core/llm-connections';
+import type { OnboardableProvider } from './pi-tui-contracts.js';
+
+export function listApiKeyOnboardableProviders(): OnboardableProvider[] {
+  return CATALOG_PROVIDER_TYPES.filter((providerType) => providerAuthSupportsApiKey(providerType))
+    .map((providerType) => {
+      const definition = PROVIDER_DEFAULTS[providerType];
+      return {
+        providerType,
+        label: definition.label,
+        authKind: definition.authKind as 'api_key' | 'optional_api_key',
+        requiresBaseUrl: !definition.baseUrl,
+        fallbackModels: definition.fallbackModels,
+      };
+    })
+    .filter((provider) => !provider.requiresBaseUrl);
+}

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,5 +1,4 @@
 import {
-  CATALOG_PROVIDER_TYPES,
   PROVIDER_DEFAULTS,
   connectionEnabledModelIds,
   deriveConnectionSlug,
@@ -11,44 +10,17 @@ import {
   type ProviderType,
 } from '@maka/core/llm-connections';
 import type { ConnectionStore, CredentialStore } from '@maka/storage';
-import type { ModelChoice } from './connection-target.js';
 import { listReadyModelChoices } from './connection-target.js';
-
-export interface OnboardableProvider {
-  providerType: ProviderType;
-  label: string;
-  authKind: 'api_key' | 'optional_api_key';
-  /** True when the catalog ships no default baseUrl, so the wizard must prompt
-   *  for an endpoint (self-hosted / compatible gateways). */
-  requiresBaseUrl: boolean;
-  fallbackModels: readonly string[];
-}
-
-/** Host-supplied onboarding surface for the three-step `/setup` wizard. The
- *  wizard is UI-only: it calls `listProviders` to open, `verify` to check a
- *  supplied-or-stored key and discover models without persisting, and `save` to
- *  persist the curated enabled-model set + cache and refresh the running TUI's
- *  ready model choices. The host owns the connection/credential stores; the
- *  secret never crosses back into the wizard. */
-export interface MakaOnboardingSurface {
-  listProviders: () => Promise<OnboardingProviderEntry[]>;
-  verify: (input: OnboardingVerifyInput) => Promise<OnboardingVerifyResult>;
-  save: (input: OnboardingSaveInput) => Promise<OnboardingSaveResult>;
-}
-
-/** Wizard-facing verify input: a provider plus an optional key (blank reuses a
- *  stored secret for an existing connection). */
-export type OnboardingVerifyInput = Pick<VerifyApiKeyConnectionInput, 'providerType' | 'apiKey'>;
-export type OnboardingVerifyResult = VerifyApiKeyConnectionResult;
-
-/** Wizard-facing save input: the verified provider, an optional key (blank
- *  keeps the stored secret for an existing connection), the curated enabled
- *  set, and the discovered models to cache. */
-export type OnboardingSaveInput = Pick<
-  SaveApiKeyConnectionInput,
-  'providerType' | 'apiKey' | 'enabledModelIds' | 'models'
->;
-export type OnboardingSaveResult = SaveApiKeyConnectionResult;
+import { listApiKeyOnboardableProviders } from './onboarding-catalog.js';
+import type {
+  MakaOnboardingSurface,
+  ModelChoice,
+  OnboardingProviderEntry,
+  OnboardingSaveInput,
+  OnboardingSaveResult,
+  OnboardingVerifyInput,
+  OnboardingVerifyResult,
+} from './pi-tui-contracts.js';
 
 /** Build the onboarding surface the TUI wizard calls, owning the connection and
  *  credential stores plus the model probe so the first-run host (cli.ts) and
@@ -88,37 +60,6 @@ export function createApiKeyOnboardingSurface(deps: {
   };
 }
 
-/** Catalog providers that can be onboarded with an API key, in catalog order.
- *  The TUI wizard's first step picks from this list. */
-export function listApiKeyOnboardableProviders(): OnboardableProvider[] {
-  return (
-    CATALOG_PROVIDER_TYPES.filter((providerType) => providerAuthSupportsApiKey(providerType))
-      .map((providerType) => {
-        const def = PROVIDER_DEFAULTS[providerType];
-        return {
-          providerType,
-          label: def.label,
-          authKind: def.authKind as 'api_key' | 'optional_api_key',
-          requiresBaseUrl: !def.baseUrl,
-          fallbackModels: def.fallbackModels,
-        };
-      })
-      // Phase 1 collects only an API key; providers without a default baseUrl
-      // cannot be completed by this wizard and would wedge a fresh install, so
-      // exclude them until the base-URL prompt lands (phase 2).
-      .filter((provider) => !provider.requiresBaseUrl)
-  );
-}
-
-/** A catalog provider annotated with whether a connection already exists for
- *  it, plus that connection's curated enabled model ids. The wizard's provider
- *  search marks existing providers `已设置` and pre-selects their enabled set in
- *  the model step; new connections start with no models selected. */
-export interface OnboardingProviderEntry extends OnboardableProvider {
-  hasConnection: boolean;
-  enabledModelIds: readonly string[];
-}
-
 /** Catalog API-key providers (phase 1) annotated with the host's existing
  *  connection state. The wizard calls this when it opens so `已设置` and the
  *  preserved enabled set reflect live storage, not a startup snapshot. */
@@ -138,8 +79,7 @@ export async function listOnboardingProviders(input: {
   });
 }
 
-export interface VerifyApiKeyConnectionInput {
-  providerType: ProviderType;
+export interface VerifyApiKeyConnectionInput extends OnboardingVerifyInput {
   /** Supplied key. Blank for an existing connection reuses the stored secret;
    *  blank for a new required-key connection is rejected. Never returned to the
    *   wizard — verify is host-owned. */
@@ -149,9 +89,7 @@ export interface VerifyApiKeyConnectionInput {
   fetchModels: (connection: LlmConnection, apiKey: string) => Promise<ModelInfo[]>;
 }
 
-export type VerifyApiKeyConnectionResult =
-  | { kind: 'ok'; models: ModelInfo[] }
-  | { kind: 'error'; text: string };
+export type VerifyApiKeyConnectionResult = OnboardingVerifyResult;
 
 /** Probe a provider with a supplied or stored secret without persisting: the
  *  wizard's key step verifies the key works and discovers models, then defers
@@ -218,8 +156,7 @@ function transientOnboardingConnection(providerType: ProviderType): LlmConnectio
   };
 }
 
-export interface SaveApiKeyConnectionInput {
-  providerType: ProviderType;
+export interface SaveApiKeyConnectionInput extends OnboardingSaveInput {
   /** Supplied key. Blank for an existing connection leaves the stored secret
    *   untouched; a new connection must supply one (verify already enforced it). */
   apiKey?: string;
@@ -236,9 +173,7 @@ export interface SaveApiKeyConnectionInput {
   fetchModelChoices: () => Promise<ModelChoice[]>;
 }
 
-export type SaveApiKeyConnectionResult =
-  | { kind: 'ok'; modelChoices: ModelChoice[] }
-  | { kind: 'error'; text: string };
+export type SaveApiKeyConnectionResult = OnboardingSaveResult;
 
 /** Persist the verified connection with the curated enabled-model set, caching
  *  discovered models and normalizing the required compatibility `defaultModel`

--- a/packages/cli/src/pi-tui-contracts.ts
+++ b/packages/cli/src/pi-tui-contracts.ts
@@ -1,0 +1,73 @@
+import type { ForeignSessionDigest, ForeignSessionSummary } from '@maka/core/foreign-session';
+import type { ModelInfo, ProviderType } from '@maka/core/llm-connections';
+import type { GoalTurnAdmission, HostCapabilities, SkillSource } from '@maka/runtime';
+import type { MakaPiTuiTurnLifecycle } from './pi-tui-turn.js';
+
+export interface ModelChoice {
+  connectionSlug: string;
+  connectionName: string;
+  providerType: ProviderType;
+  model: string;
+  isDefaultConnection: boolean;
+  contextWindow?: number;
+}
+
+export interface OnboardableProvider {
+  providerType: ProviderType;
+  label: string;
+  authKind: 'api_key' | 'optional_api_key';
+  requiresBaseUrl: boolean;
+  fallbackModels: readonly string[];
+}
+
+export interface OnboardingProviderEntry extends OnboardableProvider {
+  hasConnection: boolean;
+  enabledModelIds: readonly string[];
+}
+
+export interface OnboardingVerifyInput {
+  providerType: ProviderType;
+  apiKey?: string;
+}
+
+export type OnboardingVerifyResult =
+  | { kind: 'ok'; models: ModelInfo[] }
+  | { kind: 'error'; text: string };
+
+export interface OnboardingSaveInput {
+  providerType: ProviderType;
+  apiKey?: string;
+  enabledModelIds: readonly string[];
+  models: readonly ModelInfo[];
+}
+
+export type OnboardingSaveResult =
+  | { kind: 'ok'; modelChoices: ModelChoice[] }
+  | { kind: 'error'; text: string };
+
+export interface MakaOnboardingSurface {
+  listProviders(): Promise<OnboardingProviderEntry[]>;
+  verify(input: OnboardingVerifyInput): Promise<OnboardingVerifyResult>;
+  save(input: OnboardingSaveInput): Promise<OnboardingSaveResult>;
+}
+
+export interface SessionRecapGenerator {
+  generate(
+    sessionId: string,
+    reason: 'manual' | 'idle',
+  ): Promise<{ ok: true; text: string; raw: string } | { ok: false; error: string }>;
+}
+
+export interface MakaCliSkillSurface {
+  source(cwd: string): SkillSource;
+  host: HostCapabilities;
+}
+
+export interface MakaForeignSessionReader {
+  listSessions(options?: { cwd?: string }): Promise<ForeignSessionSummary[]>;
+  readDigest(summary: ForeignSessionSummary): Promise<ForeignSessionDigest>;
+}
+
+export interface MakaPiTuiGoalLifecycle extends MakaPiTuiTurnLifecycle {
+  bindHost(host: { admitTurn(sessionId: string, text: string): GoalTurnAdmission }): () => void;
+}

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -20,8 +20,7 @@ import type { PermissionMode } from '@maka/core/permission';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { InvocableSkillEntry } from '@maka/runtime';
 import { PROVIDER_DEFAULTS, type ModelInfo, type ProviderType } from '@maka/core/llm-connections';
-import type { ModelChoice } from './connection-target.js';
-import type { OnboardingProviderEntry } from './onboarding.js';
+import type { ModelChoice, OnboardingProviderEntry } from './pi-tui-contracts.js';
 import { skillInvocationPrefixAt } from './skill-token.js';
 import { ansi, editorTheme, selectListTheme, stripAnsi } from './tui-ansi.js';
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -33,15 +33,17 @@ import {
   foreignSourceLabel,
   type ForeignSessionSummary,
 } from '@maka/core/foreign-session';
-import type { ForeignSessionStore } from '@maka/storage';
 import type { ContextDiagnostics, GoalTurnOutcome, SessionActivityLease } from '@maka/runtime';
-import type { ModelChoice } from './connection-target.js';
-import {
-  listApiKeyOnboardableProviders,
-  type MakaOnboardingSurface,
-  type OnboardingProviderEntry,
-} from './onboarding.js';
-import type { MakaCliSkillSurface, SessionRecapGenerator } from './runtime-bootstrap.js';
+import { listApiKeyOnboardableProviders } from './onboarding-catalog.js';
+import type {
+  MakaCliSkillSurface,
+  MakaForeignSessionReader,
+  MakaOnboardingSurface,
+  MakaPiTuiGoalLifecycle,
+  ModelChoice,
+  OnboardingProviderEntry,
+  SessionRecapGenerator,
+} from './pi-tui-contracts.js';
 import { AUTO_RECAP_DISPLAY_LIMIT_BYTES, shouldAutoRecap } from './session-recap.js';
 import {
   listInvocableSkills,
@@ -56,7 +58,6 @@ import {
   type ParsedGraphCommand,
   type ParsedSwarmCommand,
 } from '@maka/core';
-import type { CliGoalTurnHost } from './cli-goal-continuation.js';
 import {
   inspectSessionResumeAvailability,
   type MakaAttachedSessionTurn,
@@ -81,11 +82,7 @@ import {
   toggleAllToolExpansion,
   type MakaPiTranscriptMetadata,
 } from './pi-transcript.js';
-import {
-  runMakaPiTuiTurn,
-  type MakaPiTuiTurnLifecycle,
-  type MakaPiTuiTurnRequest,
-} from './pi-tui-turn.js';
+import { runMakaPiTuiTurn, type MakaPiTuiTurnRequest } from './pi-tui-turn.js';
 import { editorTheme, selectListTheme } from './tui-ansi.js';
 import { MakaAutocompleteAboveEditorComponent } from './tui-autocomplete-layout.js';
 import { createShellRunElapsedTicker } from './shell-run-elapsed-ticker.js';
@@ -117,10 +114,6 @@ import {
   thinkingLevelPickerItems,
   type MakaSlashCommand,
 } from './pi-tui-pickers.js';
-
-export interface MakaPiTuiGoalLifecycle extends MakaPiTuiTurnLifecycle {
-  bindHost: (host: CliGoalTurnHost) => () => void;
-}
 
 export interface MakaPiTuiInput {
   title: string;
@@ -190,7 +183,7 @@ export interface MakaPiTuiInput {
    * current cwd; selecting one distills it into a handoff digest and opens a
    * fresh Maka session seeded with it. Omitting it hides the feature.
    */
-  foreignSessions?: ForeignSessionStore;
+  foreignSessions?: MakaForeignSessionReader;
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -53,13 +53,11 @@ import {
   routeWebSearchTools,
   type AutomationDefinition,
   type EffectiveProductToolSurface,
-  type HostCapabilities,
   type HostCapabilitiesResolver,
   type MakaTool,
   type InvocationResult,
   type InvocationSource,
   type ShellRunUpdate,
-  type SkillSource,
   type ModelMessage,
 } from '@maka/runtime';
 import {
@@ -85,9 +83,9 @@ import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-
 import { resolveStorageRoot } from '@maka/storage/root-authority';
 import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import { fetchProviderModels } from '@maka/runtime';
-import { createApiKeyOnboardingSurface, type MakaOnboardingSurface } from './onboarding.js';
+import { createApiKeyOnboardingSurface } from './onboarding.js';
 import { isActiveShellRunStatus, resolveModelVisionSupport } from '@maka/core';
-import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
+import type { ReadySessionTarget } from './connection-target.js';
 import {
   listReadyModelChoices,
   resolveDefaultSessionTarget,
@@ -95,6 +93,12 @@ import {
 } from './connection-target.js';
 import { buildCliSystemPrompt, buildCliTurnTailPrompt } from './cli-system-prompt.js';
 import { CliGoalContinuation } from './cli-goal-continuation.js';
+import type {
+  MakaCliSkillSurface,
+  MakaOnboardingSurface,
+  ModelChoice,
+  SessionRecapGenerator,
+} from './pi-tui-contracts.js';
 import { cleanRecapText } from './session-recap.js';
 
 export interface MakaCliRuntimeContext {
@@ -159,13 +163,6 @@ export function resolveCliStreamConnectTimeoutMs(
  * throws — failures resolve to `{ ok: false }` so callers can surface them
  * without a try/catch.
  */
-export interface SessionRecapGenerator {
-  generate(
-    sessionId: string,
-    reason: 'manual' | 'idle',
-  ): Promise<{ ok: true; text: string; raw: string } | { ok: false; error: string }>;
-}
-
 export interface CreateMakaCliRuntimeContextInput {
   surface: 'tui' | 'run' | 'activation';
   /** Legacy root; both new roots default to this path. */
@@ -202,13 +199,6 @@ export interface CreateMakaCliRuntimeContextInput {
 
 export interface GetOrCreateCliClaudeDeviceIdDeps {
   newId?: () => string;
-}
-
-export interface MakaCliSkillSurface {
-  /** Five-path discovery source for a session cwd (project-level paths are cwd-relative). */
-  source(cwd: string): SkillSource;
-  /** This host's capability surface — the same gate the Skill tool loads through. */
-  host: HostCapabilities;
 }
 
 export function isMakaClaudeSubscriptionCloakEnabled(

--- a/packages/cli/src/runtime-host-tui-context.ts
+++ b/packages/cli/src/runtime-host-tui-context.ts
@@ -2,10 +2,12 @@ import { randomUUID } from 'node:crypto';
 import type { ConnectionCatalogEntry, ConnectionCatalogSnapshot } from '@maka/core/runtime-policy';
 import { SessionActivityRegistry, type InvocableSkillEntry } from '@maka/runtime';
 import { readRuntimeHostSkillCatalog, type RuntimeHostConnection } from '@maka/runtime-host/client';
-import type { ModelChoice } from './connection-target.js';
-import type { MakaPiTuiGoalLifecycle } from './pi-tui-runner.js';
-import type { SessionRecapGenerator } from './runtime-bootstrap.js';
 import { connectRuntimeHostCli, resolveRuntimeHostCliTarget } from './runtime-host-cli-context.js';
+import type {
+  MakaPiTuiGoalLifecycle,
+  ModelChoice,
+  SessionRecapGenerator,
+} from './pi-tui-contracts.js';
 import {
   createRuntimeHostMakaSessionDriver,
   type RuntimeHostMakaSessionDriverInput,

--- a/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
@@ -7,6 +7,7 @@ import { describe, test } from 'node:test';
 import type { AgentRunHeader, SessionHeader } from '@maka/core';
 import type { AutomationDefinition, AutomationPendingFire } from '@maka/core/automation';
 import {
+  DEFER_WINDOW_MS,
   RuntimeHostedRootConflictError,
   RuntimeHostedRootUnavailableError,
   type MakaToolContext,
@@ -266,7 +267,10 @@ describe('Host Automation coordinator', () => {
         await harness.coordinator.recover();
         assert.equal(harness.rootInputs.length, 1);
         assert.deepEqual((await harness.store.read()).pendingFires, [fire]);
+        assert.equal((await harness.store.read()).automations[0]?.deferredFireCount, 1);
 
+        const paused = await harness.coordinator.pause(automation.id, automation.sessionId);
+        assert.equal(paused?.status, 'paused');
         harness.coordinator.start();
         harness.fireTimer();
         await waitFor(
@@ -275,6 +279,39 @@ describe('Host Automation coordinator', () => {
         );
         assert.equal(harness.rootInputs[1]?.runId, fire.runId);
         assert.equal((await harness.store.read()).pendingFires[0]?.id, fire.id);
+        const retried = (await harness.store.read()).automations[0];
+        assert.equal(retried?.status, 'paused');
+        assert.equal(retried?.deferredFireCount, 2);
+      },
+      { rootMode: 'busy' },
+    );
+  });
+
+  test('fails a recovered admitted fire after its durable retry window expires', async () => {
+    await withHarness(
+      async (harness) => {
+        const automation = startedDefinition();
+        const fire = pendingFire();
+        await harness.store.commit({
+          expectedRevision: 0,
+          automations: [automation],
+          pendingFires: [fire],
+        });
+        harness.now = fire.admittedAt + DEFER_WINDOW_MS;
+
+        await harness.coordinator.prepareRecovery();
+        await harness.coordinator.recover();
+
+        const snapshot = await harness.store.read();
+        assert.deepEqual(snapshot.pendingFires, []);
+        assert.equal(snapshot.automations[0]?.status, 'paused');
+        assert.equal(snapshot.automations[0]?.consecutiveFailures, 1);
+        assert.equal(
+          snapshot.automations[0]?.lastError,
+          'Automation execution could not enter Runtime within its retry window: Session is busy',
+        );
+        assert.equal(harness.rootInputs.length, 1);
+        assert.equal(harness.drainCount, 0);
       },
       { rootMode: 'busy' },
     );
@@ -611,6 +648,8 @@ describe('Host Automation coordinator', () => {
           return fire;
         },
         assertPendingFire: async () => undefined,
+        recordFireDeferred: async () => undefined,
+        failFire: async () => undefined,
         markFireRunning: async () => undefined,
         settleFire: async () => undefined,
         residencyState: () => ({ pending: false, scheduled: false }),

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -59,6 +59,7 @@ import {
   decodeHostFrame,
   RUNTIME_HOST_PROTOCOL_VERSION,
   TASK_LEDGER_PAGE_MAX_ITEMS,
+  type AutomationProjection,
   type ConnectionCatalogQueryResult,
   type InteractionPendingSnapshot,
   type SubscriptionFrame,
@@ -92,6 +93,88 @@ import {
   withExecutionRoot,
   withTimeout,
 } from './fixtures/execution-host-suite.js';
+
+test('production Host executes admitted heartbeat and cron fires through one durable root authority', {
+  timeout: 30_000,
+}, async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const desktop = await connectClient(fixture.root, 'desktop');
+    const tui = await connectClient(fixture.root, 'tui');
+    try {
+      const heartbeat = await desktop.request('automation.mutate', {
+        kind: 'create',
+        sessionId: fixture.sessionId,
+        automationKind: 'heartbeat',
+        name: 'heartbeat execution proof',
+        prompt: 'Complete the heartbeat execution proof.',
+        schedule: { type: 'once', delaySeconds: 5 },
+      });
+      const cron = await tui.request('automation.mutate', {
+        kind: 'create',
+        sessionId: fixture.sessionId,
+        automationKind: 'cron',
+        name: 'cron execution proof',
+        prompt: 'Complete the cron execution proof.',
+        schedule: { type: 'once', delaySeconds: 5 },
+      });
+      assert.equal(heartbeat.kind, 'committed');
+      assert.equal(cron.kind, 'committed');
+      if (
+        heartbeat.kind !== 'committed' ||
+        !heartbeat.automation ||
+        cron.kind !== 'committed' ||
+        !cron.automation
+      ) {
+        return;
+      }
+
+      const [observedHeartbeat, observedCron] = await Promise.all([
+        waitForAutomationCompletion(tui, fixture.sessionId, heartbeat.automation.id),
+        waitForAutomationCompletion(desktop, fixture.sessionId, cron.automation.id),
+      ]);
+      assert.ok(observedHeartbeat.lastRunId);
+      assert.ok(observedCron.lastRunId);
+      assert.equal(observedHeartbeat.lastError, null);
+      assert.equal(observedCron.lastError, null);
+      assert.equal(observedHeartbeat.firePending, false);
+      assert.equal(observedCron.firePending, false);
+
+      const cronSessions = await desktop.request('session.catalog.query', {
+        kind: 'list_start',
+        filter: { labelSlug: 'cron' },
+      });
+      assert.equal(cronSessions.kind, 'page');
+      if (cronSessions.kind === 'page') {
+        assert.equal(cronSessions.sessions.length, 1);
+        const cronSession = cronSessions.sessions[0];
+        assert.ok(cronSession && !('kind' in cronSession));
+        if (cronSession && !('kind' in cronSession)) {
+          assert.deepEqual([...cronSession.labels].sort(), ['automation', 'cron']);
+          assert.ok(cronSession.lastMessageAt);
+        }
+      }
+
+      const deletedHeartbeat = await tui.request('automation.mutate', {
+        kind: 'delete',
+        sessionId: fixture.sessionId,
+        automationId: heartbeat.automation.id,
+      });
+      assert.equal(deletedHeartbeat.kind, 'committed');
+      assert.equal(deletedHeartbeat.kind === 'committed' && deletedHeartbeat.automation, null);
+      const deletedCron = await desktop.request('automation.mutate', {
+        kind: 'delete',
+        sessionId: fixture.sessionId,
+        automationId: cron.automation.id,
+      });
+      assert.equal(deletedCron.kind, 'committed');
+      assert.equal(deletedCron.kind === 'committed' && deletedCron.automation, null);
+    } finally {
+      await Promise.allSettled([desktop.close(), tui.close()]);
+      await fixture.stopHost(host);
+    }
+  });
+});
 
 test('production Host settles dispatched Client Capabilities before publishing Ready', async () => {
   await withExecutionRoot(async (fixture) => {
@@ -1077,4 +1160,40 @@ async function collectTaskLedgerProjection(
     pages,
     tasks: pages.flatMap((page) => page.tasks),
   };
+}
+
+async function waitForAutomationCompletion(
+  client: RuntimeHostConnection,
+  sessionId: string,
+  automationId: string,
+): Promise<AutomationProjection> {
+  const deadline = Date.now() + 20_000;
+  let last: AutomationProjection | null = null;
+  while (Date.now() < deadline) {
+    const result = await client.request('automation.query', {
+      kind: 'get',
+      sessionId,
+      automationId,
+    });
+    if (
+      result.kind === 'automation' &&
+      result.automation?.status === 'completed' &&
+      !result.automation.firePending
+    ) {
+      return result.automation;
+    }
+    if (result.kind === 'automation') last = result.automation;
+    if (
+      result.kind === 'automation' &&
+      result.automation &&
+      !result.automation.firePending &&
+      result.automation.lastError
+    ) {
+      throw new Error(`Automation execution failed: ${result.automation.lastError}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(
+    `Automation ${automationId} did not settle before the deadline: ${JSON.stringify(last)}`,
+  );
 }

--- a/packages/runtime-host/src/__tests__/runtime-resource-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-two-client-uds.test.ts
@@ -1,0 +1,242 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { isActiveShellRunStatus } from '@maka/core/shell-run';
+import { ShellRunProcessManager } from '@maka/runtime';
+import {
+  resolveRootControlNamespace,
+  resolveStorageRoot,
+  tryAcquireInteractiveRootOwner,
+} from '@maka/storage/root-authority';
+import { openInteractiveShellRunStoreForWrite } from '@maka/storage/shell-run-authority';
+import {
+  connectRuntimeHost,
+  type RuntimeHostConnection,
+  RuntimeHostOperationError,
+} from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+import { RuntimeHostKernel } from '../server/host-kernel.js';
+import { createUnavailableDomainOperationHandlers } from '../server/operation-dispatcher.js';
+import { HostRuntimeResourceCoordinator } from '../server/runtime-resource-coordinator.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+
+const SESSION_ID = 'runtime-resource-continuity';
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+test('a Host-owned PTY survives Desktop disconnect and transfers control to TUI', {
+  skip: process.platform === 'win32' ? 'POSIX UDS and shell integration' : false,
+  timeout: 30_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-resource-two-client-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  let owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  let resources: HostRuntimeResourceCoordinator | undefined;
+  let host: RuntimeHostKernel | undefined;
+  let desktop: RuntimeHostConnection | undefined;
+  let tui: RuntimeHostConnection | undefined;
+
+  try {
+    host = await RuntimeHostKernel.start({
+      owner,
+      idleGraceMs: 30_000,
+      compositionFactory: async (context) => {
+        const writer = await openInteractiveShellRunStoreForWrite(context.owner.lease);
+        let coordinator: HostRuntimeResourceCoordinator;
+        const manager = new ShellRunProcessManager({
+          store: writer,
+          newId: randomUUID,
+          now: Date.now,
+          onShellRunUpdate: (update) => coordinator.observeShellRunUpdate(update),
+        });
+        coordinator = new HostRuntimeResourceCoordinator({
+          manager,
+          sessions: {
+            listShellRunUpdates: (sessionId) => manager.listSessionUpdates(sessionId),
+            getShellRunUpdate: (sessionId, ref) =>
+              manager.getSessionUpdate(sessionId, ref).then((update) => update ?? null),
+          },
+          sessionHeaders: {
+            readHeader: async () => ({ status: 'idle', isArchived: false }),
+          },
+          sessionAdmission: new SessionAdmissionGate(),
+          acquireResidency: context.acquireResidency,
+          requestDrain: context.requestDrain,
+        });
+        resources = coordinator;
+        return {
+          handlers: {
+            ...createUnavailableDomainOperationHandlers(),
+            ...coordinator.handlers,
+          },
+          releaseConnection: (connectionId) => coordinator.releaseConnection(connectionId),
+          beginDrain: () => coordinator.beginDrain(),
+          recover: async () => undefined,
+          close: async () => {
+            await coordinator.close();
+            writer.close();
+          },
+        };
+      },
+    });
+    owner = undefined;
+    assert.ok(resources);
+
+    const started = await resources.runBackgroundBash({
+      sessionId: SESSION_ID,
+      sourceTurnId: 'turn-1',
+      sourceToolCallId: 'tool.pty/continuity',
+      cwd: process.cwd(),
+      command:
+        'stty -echo; printf "READY\\n"; IFS= read -r first; printf "desktop:%s\\n" "$first"; IFS= read -r second; printf "tui:%s\\n" "$second"; while :; do sleep 1; done',
+      pty: true,
+      emitOutput: () => undefined,
+    });
+    assert.equal(started.status, 'running');
+
+    [desktop, tui] = await Promise.all([connect(root, 'desktop'), connect(root, 'tui')]);
+    const desktopList = await desktop.request('runtime.resource.query', {
+      kind: 'list_start',
+      sessionId: SESSION_ID,
+    });
+    const tuiList = await tui.request('runtime.resource.query', {
+      kind: 'list_start',
+      sessionId: SESSION_ID,
+    });
+    assert.deepEqual(tuiList, desktopList);
+
+    const desktopController = {
+      sessionId: SESSION_ID,
+      ref: started.ref,
+      controllerId: 'desktop-controller',
+    };
+    const acquiredByDesktop = await desktop.request(
+      'runtime.resource.controller.acquire',
+      desktopController,
+    );
+    assert.equal(acquiredByDesktop.controllerId, desktopController.controllerId);
+    await desktop.request('runtime.resource.controller.control', {
+      ...desktopController,
+      sequence: acquiredByDesktop.nextSequence,
+      control: { kind: 'input_and_resize', input: 'first\r', cols: 100, rows: 30 },
+    });
+    await waitForOutput(tui, started.ref, /desktop:first/);
+
+    await desktop.close();
+    desktop = undefined;
+
+    const tuiController = {
+      sessionId: SESSION_ID,
+      ref: started.ref,
+      controllerId: 'tui-controller',
+    };
+    const acquiredByTui = await waitForController(tui, tuiController);
+    await tui.request('runtime.resource.controller.control', {
+      ...tuiController,
+      sequence: acquiredByTui.nextSequence,
+      control: { kind: 'input_and_resize', input: 'second\r', cols: 120, rows: 40 },
+    });
+    const continued = await waitForOutput(tui, started.ref, /tui:second/);
+    const continuedOutput = continued.output;
+    assert.ok(continuedOutput);
+    assert.equal(continuedOutput?.mode, 'pty');
+    if (!continuedOutput || continuedOutput.mode !== 'pty') {
+      throw new Error('Runtime Resource did not retain PTY output');
+    }
+    assert.equal(continuedOutput.cols, 120);
+    assert.equal(continuedOutput.rows, 40);
+    const output = `${continuedOutput.scrollback}\n${continuedOutput.screen}`;
+    assert.equal(output.match(/desktop:first/g)?.length, 1);
+    assert.equal(output.match(/tui:second/g)?.length, 1);
+
+    const stopped = await tui.request('runtime.resource.stop', {
+      sessionId: SESSION_ID,
+      ref: started.ref,
+    });
+    assert.equal(stopped.resource.status, 'cancelled');
+    const terminal = await waitForTerminal(tui, started.ref);
+    assert.equal(terminal.status, 'cancelled');
+  } finally {
+    await Promise.allSettled([desktop?.close(), tui?.close()]);
+    await host?.close().catch(() => undefined);
+    await owner?.close().catch(() => undefined);
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+async function connect(
+  rootPath: string,
+  surface: 'desktop' | 'tui',
+): Promise<RuntimeHostConnection> {
+  const result = await connectRuntimeHost({ rootPath, surface, protocol: PROTOCOL });
+  assert.equal(result.kind, 'connected');
+  if (result.kind !== 'connected') throw new Error('Runtime Host Client did not connect');
+  return result.connection;
+}
+
+async function waitForController(
+  client: RuntimeHostConnection,
+  input: { sessionId: string; ref: string; controllerId: string },
+) {
+  const deadline = Date.now() + 10_000;
+  while (true) {
+    try {
+      return await client.request('runtime.resource.controller.acquire', input);
+    } catch (error) {
+      if (!(error instanceof RuntimeHostOperationError) || error.code !== 'operation_conflict') {
+        throw error;
+      }
+      if (Date.now() >= deadline) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+}
+
+async function waitForOutput(client: RuntimeHostConnection, ref: string, pattern: RegExp) {
+  const deadline = Date.now() + 10_000;
+  while (true) {
+    const resource = await queryResource(client, ref);
+    if (resource.output?.mode === 'pty') {
+      const output = `${resource.output.scrollback}\n${resource.output.screen}`;
+      if (pattern.test(output)) return resource;
+    }
+    if (Date.now() >= deadline) throw new Error(`PTY output did not match ${pattern}`);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function waitForTerminal(client: RuntimeHostConnection, ref: string) {
+  const deadline = Date.now() + 10_000;
+  while (true) {
+    const resource = await queryResource(client, ref);
+    if (!isActiveShellRunStatus(resource.status)) return resource;
+    if (Date.now() >= deadline) throw new Error('PTY did not stop before the deadline');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function queryResource(client: RuntimeHostConnection, ref: string) {
+  const result = await client.request('runtime.resource.query', {
+    kind: 'get',
+    sessionId: SESSION_ID,
+    ref,
+  });
+  assert.equal(result.kind, 'resource');
+  assert.ok(result.kind === 'resource' && result.resource);
+  if (result.kind !== 'resource' || !result.resource) {
+    throw new Error('Runtime Resource disappeared');
+  }
+  return result.resource.result;
+}

--- a/packages/runtime-host/src/server/automation-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-coordinator.ts
@@ -169,6 +169,8 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
         admitFire: (automationId, expectedSchedule) =>
           this.#admitFire(automationId, expectedSchedule),
         assertPendingFire: (fire) => this.#assertPendingFire(fire),
+        recordFireDeferred: (fire) => this.#recordFireDeferred(fire),
+        failFire: (fire, error) => this.#failFire(fire, error),
         markFireRunning: (fire) => this.#markFireRunning(fire),
         settleFire: (fire, run) => this.#settleFire(fire, run),
         residencyState: () => ({
@@ -737,6 +739,37 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
       if (!current || current.id !== fire.id) {
         throw new AutomationAuthorityInvariantError('Pending Automation fire disappeared');
       }
+    });
+  }
+
+  async #recordFireDeferred(fire: AutomationPendingFire): Promise<void> {
+    await this.#exclusive(async () => {
+      const current = this.#pendingFires.get(fire.automationId);
+      if (!current || current.id !== fire.id) return;
+      const before = this.#snapshot();
+      this.#manager.recordAdmittedFireDeferred(fire.automationId);
+      this.#pendingFires.set(fire.automationId, {
+        ...current,
+        updatedAt: Math.max(current.updatedAt, this.#now()),
+      });
+      await this.#commitOrRestore(before);
+    });
+  }
+
+  async #failFire(fire: AutomationPendingFire, error: string): Promise<void> {
+    await this.#exclusive(async () => {
+      const current = this.#pendingFires.get(fire.automationId);
+      if (!current || current.id !== fire.id) return;
+      const before = this.#snapshot();
+      const automation = this.#manager.get(fire.automationId);
+      if (!automation) {
+        throw new AutomationAuthorityInvariantError(
+          'Pending Automation fire has no canonical definition',
+        );
+      }
+      settleAutomationAttempt(automation, { status: 'failed', error }, this.#now());
+      this.#pendingFires.delete(fire.automationId);
+      await this.#commitOrRestore(before);
     });
   }
 

--- a/packages/runtime-host/src/server/automation-fire-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-fire-coordinator.ts
@@ -44,6 +44,8 @@ export interface AutomationFireStateAuthority {
     expectedSchedule: number | null,
   ): Promise<AutomationPendingFire | undefined>;
   assertPendingFire(fire: AutomationPendingFire): Promise<void>;
+  recordFireDeferred(fire: AutomationPendingFire): Promise<void>;
+  failFire(fire: AutomationPendingFire, error: string): Promise<void>;
   markFireRunning(fire: AutomationPendingFire): Promise<void>;
   settleFire(fire: AutomationPendingFire, run: AgentRunHeader): Promise<void>;
   residencyState(): { readonly pending: boolean; readonly scheduled: boolean };
@@ -376,6 +378,20 @@ export class HostAutomationFireCoordinator {
         error instanceof RuntimeHostedRootConflictError ||
         error instanceof RuntimeHostedRootUnavailableError
       ) {
+        if (this.isDraining) {
+          established.resolve();
+          return;
+        }
+        try {
+          if (this.#now() - fire.admittedAt >= DEFER_WINDOW_MS) {
+            await this.#state.failFire(fire, automationAdmissionFailure(error));
+          } else {
+            await this.#state.recordFireDeferred(fire);
+          }
+        } catch (stateError) {
+          established.reject(stateError);
+          throw stateError;
+        }
         established.resolve();
         return;
       }
@@ -420,9 +436,6 @@ export class HostAutomationFireCoordinator {
       throw new AutomationFireDeferredError('Automation authority is draining');
     }
     await this.#state.assertPendingFire(fire);
-    if (this.#isSessionActive(fire.targetSessionId)) {
-      throw new AutomationFireDeferredError('Automation target Session is busy');
-    }
     const incognito = (await this.#runtimePolicy.runtimePolicy.getSnapshot()).policy.privacy
       .incognitoActive;
     if (incognito) throw new AutomationFireDeferredError('Incognito mode is active');
@@ -454,6 +467,10 @@ export class HostAutomationFireCoordinator {
       throw error;
     }
   }
+}
+
+function automationAdmissionFailure(error: Error): string {
+  return `Automation execution could not enter Runtime within its retry window: ${error.message}`;
 }
 
 export function fireContent(fire: AutomationPendingFire): MessageContent {

--- a/packages/runtime/src/automation-state.ts
+++ b/packages/runtime/src/automation-state.ts
@@ -288,6 +288,13 @@ export class AutomationManager {
     automation.deferredFireCount = (automation.deferredFireCount ?? 0) + 1;
   }
 
+  /** Record a retry for a fire that was admitted while the definition was active. */
+  recordAdmittedFireDeferred(id: string): void {
+    const automation = this.automations.get(id);
+    if (!automation) return;
+    automation.deferredFireCount = (automation.deferredFireCount ?? 0) + 1;
+  }
+
   /**
    * Skip a fire without executing — advance to next schedule time.
    * Used only when the scheduler's defer/retry window (~45min, mirroring the


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- let admitted heartbeat and cron fires enter the Runtime Host root authority without conflicting with the coordinator's own reservation
- persist admitted-fire deferrals and settle fires as failed with a visible `lastError` after the durable retry window instead of retrying forever
- separate owner-neutral TUI presentation contracts and provider catalog data from embedded Runtime and writer Store composition
- enforce a default-deny dependency boundary for Runtime Host TUI, `maka run`, and live inspect across static, dynamic, re-exported, aliased, and workspace-package imports
- cover heartbeat and cron execution through a real production Host, plus Desktop-to-TUI PTY control transfer through two real UDS clients
- keep the Windows exclusion inventory current for the new POSIX integration coverage

## Compatibility boundaries

- M4 remains a pre-cutover adapter milestone: production ownership stays on the single embedded Runtime until the atomic M5 switch
- #2262 remains an independent Desktop presentation follow-up and is intentionally not part of this M4 closure
- no embedded fallback or second Runtime writer is introduced on any Runtime Host adapter path

## Validation

- `@maka/runtime`: 3306 passed, 3 platform skips
- `@maka/runtime-host`: 738 passed
- CLI: 516 passed
- full repository TypeScript typecheck
- full repository Biome lint and format check
- Windows test inventory check: 68 declarations
- real OpenRouter Free Runtime Host smoke for `maka run`
- real tmux/PTY Runtime Host TUI smoke using the active XDG home, with the model returning the exact expected response
- production Host heartbeat, cron, deletion, and two-client PTY continuity integration tests

Closes #2010.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 让已经接纳的 heartbeat 与 cron fire 正常进入 Runtime Host root authority，不再与 coordinator 自己持有的 reservation 冲突
- 持久化 admitted fire 的 defer；超过 durable retry window 后写入可见 `lastError` 并收敛为失败，不再无限静默重试
- 将 owner-neutral 的 TUI presentation contract 与 provider catalog 从 embedded Runtime、writer Store composition 中拆出
- 为 Runtime Host TUI、`maka run` 与 live inspect 建立默认拒绝的 dependency boundary，覆盖静态、动态、re-export、alias 与 workspace package import
- 通过真实 production Host 验证 heartbeat 与 cron，并通过两个真实 UDS client 验证 Desktop 到 TUI 的 PTY 控制权转移
- 为新增 POSIX 集成测试同步更新 Windows 排除清单

## 兼容边界

- M4 仍是 cutover 前的 adapter milestone：在 M5 原子切换前，production 继续只使用唯一 embedded Runtime owner
- #2262 继续作为独立的 Desktop presentation follow-up，不属于本次 M4 收口范围
- 所有 Runtime Host adapter path 均未引入 embedded fallback 或第二个 Runtime writer

## 验证

- `@maka/runtime`：3306 项通过，3 项平台跳过
- `@maka/runtime-host`：738 项通过
- CLI：516 项通过
- 全仓 TypeScript typecheck
- 全仓 Biome lint 与 format check
- Windows 测试清单检查：68 条声明
- 使用 OpenRouter Free 完成真实 Runtime Host `maka run` 冒烟测试
- 直接使用当前 XDG Home，通过真实 tmux/PTY 完成 Runtime Host TUI 冒烟测试，模型返回精确预期文本
- production Host heartbeat、cron、delete 与双 Client PTY continuity 集成测试

关闭 #2010。

</details>
