### PR TITLE
feat: add custom pet pack contract and atomic storage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,7 @@
     "./workspace": "./dist/workspace.js",
     "./attachments": "./dist/attachments.js",
     "./artifacts": "./dist/artifacts.js",
+    "./pet": "./dist/pet.js",
     "./runtime-inputs": "./dist/runtime-inputs.js",
     "./e2e-fixture": "./dist/e2e-fixture.js",
     "./capabilities": "./dist/capabilities.js",

--- a/packages/core/src/__tests__/pet.test.ts
+++ b/packages/core/src/__tests__/pet.test.ts
@@ -4,6 +4,7 @@ import {
   PET_PACK_SCHEMA_V1,
   PetManifestValidationError,
   decodePetPackManifest,
+  isPetPackId,
   isPetPackManifestV1,
   isSafePetAssetPath,
   resolvePetAnimationFallback,
@@ -45,6 +46,12 @@ describe('maka.pet/v1 manifest', () => {
     assert.equal(result.ok, true);
     assert.equal(isPetPackManifestV1(manifest), true);
     assert.equal(decodePetPackManifest(manifest), manifest);
+  });
+
+  test('exposes the canonical package id guard to storage boundaries', () => {
+    assert.equal(isPetPackId('likun.maodie'), true);
+    assert.equal(isPetPackId('../maodie'), false);
+    assert.equal(isPetPackId('MAODIE'), false);
   });
 
   test('requires the five task-semantic animations', () => {

--- a/packages/core/src/__tests__/pet.test.ts
+++ b/packages/core/src/__tests__/pet.test.ts
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  PET_PACK_SCHEMA_V1,
+  PetManifestValidationError,
+  decodePetPackManifest,
+  isPetPackManifestV1,
+  isSafePetAssetPath,
+  resolvePetAnimationFallback,
+  resolvePetAnimationState,
+  validatePetPackManifest,
+} from '../pet.js';
+
+function validManifest(): Record<string, unknown> {
+  return {
+    schema: PET_PACK_SCHEMA_V1,
+    id: 'likun.maodie',
+    displayName: '我的耄耋',
+    description: 'A user-installed custom pet.',
+    spriteSheet: {
+      path: 'assets/maodie.webp',
+      format: 'webp',
+      frameWidth: 128,
+      frameHeight: 128,
+      columns: 4,
+      rows: 4,
+      frameCount: 16,
+    },
+    animations: {
+      idle: { frames: [0, 1], fps: 4, loop: true },
+      working: { frames: [2, 3, 4, 5], fps: 8, loop: true },
+      'needs-input': { frames: [6, 7], fps: 4, loop: true },
+      ready: { frames: [8, 9], fps: 8, loop: false, fallback: 'idle' },
+      blocked: { frames: [10, 11], fps: 4, loop: true },
+      swarm: { frames: [12, 13], fps: 12, loop: true },
+      poke: { frames: [14, 15], fps: 10, loop: false, fallback: 'idle' },
+    },
+  };
+}
+
+describe('maka.pet/v1 manifest', () => {
+  test('accepts a declarative custom pet pack and decodes it unchanged', () => {
+    const manifest = validManifest();
+    const result = validatePetPackManifest(manifest);
+    assert.equal(result.ok, true);
+    assert.equal(isPetPackManifestV1(manifest), true);
+    assert.equal(decodePetPackManifest(manifest), manifest);
+  });
+
+  test('requires the five task-semantic animations', () => {
+    const manifest = validManifest();
+    const animations = manifest.animations as Record<string, unknown>;
+    delete animations.blocked;
+
+    const result = validatePetPackManifest(manifest);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.deepEqual(
+      result.issues.find((issue) => issue.path === '$.animations.blocked'),
+      {
+        code: 'missing_animation',
+        path: '$.animations.blocked',
+        message: 'missing required blocked animation',
+      },
+    );
+  });
+
+  test('rejects executable or unknown manifest fields', () => {
+    const manifest = validManifest();
+    manifest.script = 'pet.js';
+    (manifest.animations as Record<string, unknown>).onClick = { command: 'rm -rf .' };
+
+    const result = validatePetPackManifest(manifest);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.deepEqual(
+      result.issues.filter((issue) => issue.code === 'unknown_field').map((issue) => issue.path),
+      ['$.script', '$.animations.onClick'],
+    );
+  });
+
+  test('rejects traversal, absolute, Windows, and non-normalized asset paths', () => {
+    for (const path of [
+      '../maodie.webp',
+      '/tmp/maodie.webp',
+      'C:\\tmp\\maodie.webp',
+      'assets\\maodie.webp',
+      'assets//maodie.webp',
+      './assets/maodie.webp',
+    ]) {
+      assert.equal(isSafePetAssetPath(path), false, path);
+      const manifest = validManifest();
+      (manifest.spriteSheet as Record<string, unknown>).path = path;
+      const result = validatePetPackManifest(manifest);
+      assert.equal(result.ok, false, path);
+      if (!result.ok) assert.ok(result.issues.some((issue) => issue.code === 'unsafe_path'));
+    }
+  });
+
+  test('bounds sprite geometry, animation rate, and referenced frames', () => {
+    const manifest = validManifest();
+    const spriteSheet = manifest.spriteSheet as Record<string, unknown>;
+    spriteSheet.frameCount = 17;
+    const idle = (manifest.animations as Record<string, Record<string, unknown>>).idle;
+    idle.frames = [17];
+    idle.fps = 61;
+
+    const result = validatePetPackManifest(manifest);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.ok(result.issues.some((issue) => issue.path === '$.spriteSheet.frameCount'));
+    assert.ok(result.issues.some((issue) => issue.path === '$.animations.idle.frames[0]'));
+    assert.ok(result.issues.some((issue) => issue.path === '$.animations.idle.fps'));
+  });
+
+  test('requires explicit animation fallback targets to exist', () => {
+    const manifest = validManifest();
+    const ready = (manifest.animations as Record<string, Record<string, unknown>>).ready;
+    ready.fallback = 'sleep';
+
+    const result = validatePetPackManifest(manifest);
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.ok(
+      result.issues.some(
+        (issue) =>
+          issue.code === 'invalid_reference' && issue.path === '$.animations.ready.fallback',
+      ),
+    );
+  });
+
+  test('rejects a fallback on a looping animation', () => {
+    const manifest = validManifest();
+    const idle = (manifest.animations as Record<string, Record<string, unknown>>).idle;
+    idle.fallback = 'working';
+
+    assert.equal(isPetPackManifestV1(manifest), false);
+  });
+
+  test('throws a structured validation error from the strict decoder', () => {
+    const manifest = validManifest();
+    manifest.schema = 'maka.pet/v2';
+
+    assert.throws(
+      () => decodePetPackManifest(manifest),
+      (error: unknown) =>
+        error instanceof PetManifestValidationError && error.issues[0]?.path === '$.schema',
+    );
+  });
+});
+
+describe('pet activity fallback', () => {
+  test('maps absent optional states onto stable required-state animations', () => {
+    const manifest = decodePetPackManifest(validManifest());
+    assert.equal(resolvePetAnimationState(manifest, 'swarm'), 'swarm');
+    assert.equal(resolvePetAnimationState(manifest, 'sleep'), 'idle');
+    assert.equal(resolvePetAnimationState(manifest, 'cancelled'), 'idle');
+  });
+
+  test('keeps loops in place and returns one-shot animations to their fallback', () => {
+    const manifest = decodePetPackManifest(validManifest());
+    assert.equal(resolvePetAnimationFallback(manifest, 'working'), 'working');
+    assert.equal(resolvePetAnimationFallback(manifest, 'poke'), 'idle');
+    assert.equal(resolvePetAnimationFallback(manifest, 'ready'), 'idle');
+    assert.equal(resolvePetAnimationFallback(manifest, 'sleep'), 'idle');
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,7 @@ export * from './execution-inspect.js';
 export * from './interaction.js';
 export * from './project.js';
 export * from './subagent-workspace.js';
+export * from './pet.js';
 
 // events.ts
 export type {

--- a/packages/core/src/pet.ts
+++ b/packages/core/src/pet.ts
@@ -138,6 +138,10 @@ const PET_PACK_ID_PATTERN = new RegExp(
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
 const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 
+export function isPetPackId(value: unknown): value is string {
+  return typeof value === 'string' && PET_PACK_ID_PATTERN.test(value);
+}
+
 function addIssue(
   issues: PetManifestValidationIssue[],
   code: PetManifestValidationIssueCode,
@@ -473,7 +477,7 @@ export function validatePetPackManifest(value: unknown): PetManifestValidationRe
   }
 
   if (validateBoundedText(value.id, '$.id', PET_PACK_ID_MAX_CHARS, issues)) {
-    if (!PET_PACK_ID_PATTERN.test(value.id)) {
+    if (!isPetPackId(value.id)) {
       addIssue(
         issues,
         'invalid_value',

--- a/packages/core/src/pet.ts
+++ b/packages/core/src/pet.ts
@@ -1,0 +1,536 @@
+import { defineObjectShape, isRecord, type ExactObjectShape } from './record-schema.js';
+
+export const PET_PACK_SCHEMA_V1 = 'maka.pet/v1' as const;
+
+export const PET_REQUIRED_ACTIVITY_STATES = [
+  'idle',
+  'working',
+  'needs-input',
+  'ready',
+  'blocked',
+] as const;
+
+export const PET_OPTIONAL_ACTIVITY_STATES = [
+  'swarm',
+  'cancelled',
+  'poke',
+  'wake',
+  'sleep',
+] as const;
+
+export const PET_ACTIVITY_STATES = [
+  ...PET_REQUIRED_ACTIVITY_STATES,
+  ...PET_OPTIONAL_ACTIVITY_STATES,
+] as const;
+
+export type PetRequiredActivityState = (typeof PET_REQUIRED_ACTIVITY_STATES)[number];
+export type PetOptionalActivityState = (typeof PET_OPTIONAL_ACTIVITY_STATES)[number];
+export type PetActivityState = (typeof PET_ACTIVITY_STATES)[number];
+
+export const PET_ACTIVITY_STATE_FALLBACKS = {
+  idle: 'idle',
+  working: 'working',
+  'needs-input': 'needs-input',
+  ready: 'ready',
+  blocked: 'blocked',
+  swarm: 'working',
+  cancelled: 'idle',
+  poke: 'idle',
+  wake: 'idle',
+  sleep: 'idle',
+} as const satisfies Record<PetActivityState, PetRequiredActivityState>;
+
+export const PET_PACK_ID_MAX_CHARS = 64;
+export const PET_PACK_DISPLAY_NAME_MAX_CHARS = 80;
+export const PET_PACK_DESCRIPTION_MAX_CHARS = 500;
+export const PET_ASSET_PATH_MAX_CHARS = 256;
+export const PET_SPRITE_FRAME_MAX_DIMENSION = 2_048;
+export const PET_SPRITE_SHEET_MAX_DIMENSION = 8_192;
+export const PET_SPRITE_GRID_MAX_AXIS = 64;
+export const PET_SPRITE_FRAME_COUNT_MAX = 256;
+export const PET_ANIMATION_FPS_MAX = 60;
+
+export const PET_SPRITE_FORMATS = ['png', 'webp'] as const;
+export type PetSpriteFormat = (typeof PET_SPRITE_FORMATS)[number];
+
+export interface PetSpriteSheetV1 {
+  readonly path: string;
+  readonly format: PetSpriteFormat;
+  readonly frameWidth: number;
+  readonly frameHeight: number;
+  readonly columns: number;
+  readonly rows: number;
+  readonly frameCount: number;
+}
+
+export interface PetAnimationV1 {
+  readonly frames: readonly number[];
+  readonly fps: number;
+  readonly loop: boolean;
+  /** State selected after a non-looping animation finishes. Defaults to idle. */
+  readonly fallback?: PetActivityState;
+}
+
+export type PetAnimationsV1 = Readonly<Record<PetRequiredActivityState, PetAnimationV1>> &
+  Readonly<Partial<Record<PetOptionalActivityState, PetAnimationV1>>>;
+
+/**
+ * Declarative, code-free custom pet manifest. Assets live beside the manifest
+ * and are addressed only by safe package-relative paths.
+ */
+export interface PetPackManifestV1 {
+  readonly schema: typeof PET_PACK_SCHEMA_V1;
+  readonly id: string;
+  readonly displayName: string;
+  readonly description?: string;
+  readonly spriteSheet: PetSpriteSheetV1;
+  readonly animations: PetAnimationsV1;
+}
+
+export type PetManifestValidationIssueCode =
+  | 'invalid_type'
+  | 'missing_field'
+  | 'unknown_field'
+  | 'invalid_value'
+  | 'out_of_range'
+  | 'unsafe_path'
+  | 'missing_animation'
+  | 'invalid_reference';
+
+export interface PetManifestValidationIssue {
+  readonly code: PetManifestValidationIssueCode;
+  readonly path: string;
+  readonly message: string;
+}
+
+export type PetManifestValidationResult =
+  | { readonly ok: true; readonly value: PetPackManifestV1 }
+  | { readonly ok: false; readonly issues: readonly PetManifestValidationIssue[] };
+
+export class PetManifestValidationError extends Error {
+  readonly issues: readonly PetManifestValidationIssue[];
+
+  constructor(issues: readonly PetManifestValidationIssue[]) {
+    super(`Invalid ${PET_PACK_SCHEMA_V1} manifest: ${issues[0]?.message ?? 'unknown error'}`);
+    this.name = 'PetManifestValidationError';
+    this.issues = issues;
+  }
+}
+
+const MANIFEST_SHAPE = defineObjectShape<PetPackManifestV1>()(
+  ['schema', 'id', 'displayName', 'spriteSheet', 'animations'],
+  ['description'],
+);
+const SPRITE_SHEET_SHAPE = defineObjectShape<PetSpriteSheetV1>()(
+  ['path', 'format', 'frameWidth', 'frameHeight', 'columns', 'rows', 'frameCount'],
+  [],
+);
+const ANIMATION_SHAPE = defineObjectShape<PetAnimationV1>()(
+  ['frames', 'fps', 'loop'],
+  ['fallback'],
+);
+
+const PET_ACTIVITY_STATE_SET = new Set<string>(PET_ACTIVITY_STATES);
+const PET_SPRITE_FORMAT_SET = new Set<string>(PET_SPRITE_FORMATS);
+const PET_PACK_ID_PATTERN = new RegExp(
+  `^[a-z0-9](?:[a-z0-9._-]{0,${PET_PACK_ID_MAX_CHARS - 2}}[a-z0-9])?$`,
+);
+const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f-\u009f]/;
+const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
+
+function addIssue(
+  issues: PetManifestValidationIssue[],
+  code: PetManifestValidationIssueCode,
+  path: string,
+  message: string,
+): void {
+  issues.push({ code, path, message });
+}
+
+function validateExactShape(
+  value: Record<string, unknown>,
+  shape: ExactObjectShape,
+  path: string,
+  issues: PetManifestValidationIssue[],
+): void {
+  for (const field of shape.required) {
+    if (!Object.hasOwn(value, field)) {
+      addIssue(issues, 'missing_field', `${path}.${field}`, `missing required field ${field}`);
+    }
+  }
+  for (const field of Object.keys(value)) {
+    if (!shape.allowed.has(field)) {
+      addIssue(issues, 'unknown_field', `${path}.${field}`, `unknown field ${field}`);
+    }
+  }
+}
+
+function validateBoundedText(
+  value: unknown,
+  path: string,
+  maxChars: number,
+  issues: PetManifestValidationIssue[],
+): value is string {
+  if (typeof value !== 'string') {
+    addIssue(issues, 'invalid_type', path, 'must be a string');
+    return false;
+  }
+  if (value.length === 0 || value.trim() !== value || CONTROL_CHARACTER_PATTERN.test(value)) {
+    addIssue(
+      issues,
+      'invalid_value',
+      path,
+      'must be non-empty, trimmed, and free of control characters',
+    );
+    return false;
+  }
+  if (value.length > maxChars) {
+    addIssue(issues, 'out_of_range', path, `must be at most ${maxChars} characters`);
+    return false;
+  }
+  return true;
+}
+
+function validateBoundedInteger(
+  value: unknown,
+  path: string,
+  min: number,
+  max: number,
+  issues: PetManifestValidationIssue[],
+): value is number {
+  if (!Number.isInteger(value)) {
+    addIssue(issues, 'invalid_type', path, 'must be an integer');
+    return false;
+  }
+  const integer = value as number;
+  if (integer < min || integer > max) {
+    addIssue(issues, 'out_of_range', path, `must be between ${min} and ${max}`);
+    return false;
+  }
+  return true;
+}
+
+export function isSafePetAssetPath(value: unknown): value is string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > PET_ASSET_PATH_MAX_CHARS ||
+    value.trim() !== value ||
+    value.startsWith('/') ||
+    value.startsWith('\\') ||
+    WINDOWS_DRIVE_PATH_PATTERN.test(value) ||
+    value.includes('\\') ||
+    CONTROL_CHARACTER_PATTERN.test(value)
+  ) {
+    return false;
+  }
+  const segments = value.split('/');
+  return segments.every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+}
+
+function validateSpriteSheet(
+  value: unknown,
+  issues: PetManifestValidationIssue[],
+): value is PetSpriteSheetV1 {
+  const path = '$.spriteSheet';
+  if (!isRecord(value)) {
+    addIssue(issues, 'invalid_type', path, 'must be an object');
+    return false;
+  }
+  validateExactShape(value, SPRITE_SHEET_SHAPE, path, issues);
+
+  const spritePath = value.path;
+  const spriteFormat = value.format;
+  const frameWidth = value.frameWidth;
+  const frameHeight = value.frameHeight;
+  const columns = value.columns;
+  const rows = value.rows;
+  const frameCount = value.frameCount;
+
+  const safePath = isSafePetAssetPath(spritePath);
+  if (!safePath)
+    addIssue(issues, 'unsafe_path', `${path}.path`, 'must be a safe package-relative path');
+
+  const validFormat = typeof spriteFormat === 'string' && PET_SPRITE_FORMAT_SET.has(spriteFormat);
+  if (!validFormat) {
+    addIssue(issues, 'invalid_value', `${path}.format`, 'must be png or webp');
+  } else if (safePath && !spritePath.toLowerCase().endsWith(`.${spriteFormat}`)) {
+    addIssue(issues, 'invalid_value', `${path}.path`, `must end in .${spriteFormat}`);
+  }
+
+  const validFrameWidth = validateBoundedInteger(
+    frameWidth,
+    `${path}.frameWidth`,
+    1,
+    PET_SPRITE_FRAME_MAX_DIMENSION,
+    issues,
+  );
+  const validFrameHeight = validateBoundedInteger(
+    frameHeight,
+    `${path}.frameHeight`,
+    1,
+    PET_SPRITE_FRAME_MAX_DIMENSION,
+    issues,
+  );
+  const validColumns = validateBoundedInteger(
+    columns,
+    `${path}.columns`,
+    1,
+    PET_SPRITE_GRID_MAX_AXIS,
+    issues,
+  );
+  const validRows = validateBoundedInteger(
+    rows,
+    `${path}.rows`,
+    1,
+    PET_SPRITE_GRID_MAX_AXIS,
+    issues,
+  );
+  const validFrameCount = validateBoundedInteger(
+    frameCount,
+    `${path}.frameCount`,
+    1,
+    PET_SPRITE_FRAME_COUNT_MAX,
+    issues,
+  );
+
+  if (validFrameWidth && validColumns && frameWidth * columns > PET_SPRITE_SHEET_MAX_DIMENSION) {
+    addIssue(
+      issues,
+      'out_of_range',
+      path,
+      `sprite sheet width must be at most ${PET_SPRITE_SHEET_MAX_DIMENSION} pixels`,
+    );
+  }
+  if (validFrameHeight && validRows && frameHeight * rows > PET_SPRITE_SHEET_MAX_DIMENSION) {
+    addIssue(
+      issues,
+      'out_of_range',
+      path,
+      `sprite sheet height must be at most ${PET_SPRITE_SHEET_MAX_DIMENSION} pixels`,
+    );
+  }
+  if (validFrameCount && validColumns && validRows && frameCount > columns * rows) {
+    addIssue(
+      issues,
+      'out_of_range',
+      `${path}.frameCount`,
+      'cannot exceed the sprite grid capacity',
+    );
+  }
+
+  return (
+    safePath &&
+    validFormat &&
+    validFrameWidth &&
+    validFrameHeight &&
+    validColumns &&
+    validRows &&
+    validFrameCount
+  );
+}
+
+function validateAnimation(
+  value: unknown,
+  state: PetActivityState,
+  frameCount: number | undefined,
+  issues: PetManifestValidationIssue[],
+): value is PetAnimationV1 {
+  const path = `$.animations.${state}`;
+  if (!isRecord(value)) {
+    addIssue(issues, 'invalid_type', path, 'must be an object');
+    return false;
+  }
+  validateExactShape(value, ANIMATION_SHAPE, path, issues);
+
+  let validFrames = true;
+  if (!Array.isArray(value.frames) || value.frames.length === 0) {
+    addIssue(issues, 'invalid_value', `${path}.frames`, 'must be a non-empty array');
+    validFrames = false;
+  } else if (value.frames.length > PET_SPRITE_FRAME_COUNT_MAX) {
+    addIssue(
+      issues,
+      'out_of_range',
+      `${path}.frames`,
+      `must contain at most ${PET_SPRITE_FRAME_COUNT_MAX} frames`,
+    );
+    validFrames = false;
+  } else {
+    for (const [index, frame] of value.frames.entries()) {
+      if (
+        !Number.isInteger(frame) ||
+        frame < 0 ||
+        (frameCount !== undefined && frame >= frameCount)
+      ) {
+        addIssue(
+          issues,
+          'out_of_range',
+          `${path}.frames[${index}]`,
+          frameCount === undefined
+            ? 'must be a non-negative integer'
+            : `must be an integer between 0 and ${frameCount - 1}`,
+        );
+        validFrames = false;
+      }
+    }
+  }
+
+  const validFps = validateBoundedInteger(
+    value.fps,
+    `${path}.fps`,
+    1,
+    PET_ANIMATION_FPS_MAX,
+    issues,
+  );
+  const validLoop = typeof value.loop === 'boolean';
+  if (!validLoop) addIssue(issues, 'invalid_type', `${path}.loop`, 'must be a boolean');
+
+  let validFallback = true;
+  if (value.fallback !== undefined) {
+    if (typeof value.fallback !== 'string' || !PET_ACTIVITY_STATE_SET.has(value.fallback)) {
+      addIssue(issues, 'invalid_value', `${path}.fallback`, 'must name a supported activity state');
+      validFallback = false;
+    } else if (value.loop === true) {
+      addIssue(
+        issues,
+        'invalid_value',
+        `${path}.fallback`,
+        'is only valid for non-looping animations',
+      );
+      validFallback = false;
+    }
+  }
+
+  return validFrames && validFps && validLoop && validFallback;
+}
+
+function validateAnimations(
+  value: unknown,
+  frameCount: number | undefined,
+  issues: PetManifestValidationIssue[],
+): value is PetAnimationsV1 {
+  const path = '$.animations';
+  if (!isRecord(value)) {
+    addIssue(issues, 'invalid_type', path, 'must be an object');
+    return false;
+  }
+
+  let valid = true;
+  for (const state of PET_REQUIRED_ACTIVITY_STATES) {
+    if (!Object.hasOwn(value, state)) {
+      addIssue(
+        issues,
+        'missing_animation',
+        `${path}.${state}`,
+        `missing required ${state} animation`,
+      );
+      valid = false;
+    }
+  }
+  for (const state of Object.keys(value)) {
+    if (!PET_ACTIVITY_STATE_SET.has(state)) {
+      addIssue(issues, 'unknown_field', `${path}.${state}`, `unknown activity state ${state}`);
+      valid = false;
+      continue;
+    }
+    if (!validateAnimation(value[state], state as PetActivityState, frameCount, issues))
+      valid = false;
+  }
+
+  for (const [state, animation] of Object.entries(value)) {
+    if (
+      PET_ACTIVITY_STATE_SET.has(state) &&
+      isRecord(animation) &&
+      typeof animation.fallback === 'string' &&
+      PET_ACTIVITY_STATE_SET.has(animation.fallback) &&
+      !Object.hasOwn(value, animation.fallback)
+    ) {
+      addIssue(
+        issues,
+        'invalid_reference',
+        `${path}.${state}.fallback`,
+        `references missing ${animation.fallback} animation`,
+      );
+      valid = false;
+    }
+  }
+
+  return valid;
+}
+
+export function validatePetPackManifest(value: unknown): PetManifestValidationResult {
+  const issues: PetManifestValidationIssue[] = [];
+  if (!isRecord(value)) {
+    return {
+      ok: false,
+      issues: [{ code: 'invalid_type', path: '$', message: 'manifest must be an object' }],
+    };
+  }
+  validateExactShape(value, MANIFEST_SHAPE, '$', issues);
+
+  if (value.schema !== PET_PACK_SCHEMA_V1) {
+    addIssue(issues, 'invalid_value', '$.schema', `must equal ${PET_PACK_SCHEMA_V1}`);
+  }
+
+  if (validateBoundedText(value.id, '$.id', PET_PACK_ID_MAX_CHARS, issues)) {
+    if (!PET_PACK_ID_PATTERN.test(value.id)) {
+      addIssue(
+        issues,
+        'invalid_value',
+        '$.id',
+        'must use lowercase ASCII letters, digits, dots, underscores, or hyphens and start and end with a letter or digit',
+      );
+    }
+  }
+  validateBoundedText(value.displayName, '$.displayName', PET_PACK_DISPLAY_NAME_MAX_CHARS, issues);
+  if (value.description !== undefined) {
+    validateBoundedText(value.description, '$.description', PET_PACK_DESCRIPTION_MAX_CHARS, issues);
+  }
+
+  validateSpriteSheet(value.spriteSheet, issues);
+  const rawFrameCount = isRecord(value.spriteSheet) ? value.spriteSheet.frameCount : undefined;
+  const frameCount =
+    Number.isInteger(rawFrameCount) &&
+    (rawFrameCount as number) >= 1 &&
+    (rawFrameCount as number) <= PET_SPRITE_FRAME_COUNT_MAX
+      ? (rawFrameCount as number)
+      : undefined;
+  validateAnimations(
+    value.animations,
+    typeof frameCount === 'number' ? frameCount : undefined,
+    issues,
+  );
+
+  return issues.length === 0
+    ? { ok: true, value: value as unknown as PetPackManifestV1 }
+    : { ok: false, issues };
+}
+
+export function isPetPackManifestV1(value: unknown): value is PetPackManifestV1 {
+  return validatePetPackManifest(value).ok;
+}
+
+export function decodePetPackManifest(value: unknown): PetPackManifestV1 {
+  const result = validatePetPackManifest(value);
+  if (!result.ok) throw new PetManifestValidationError(result.issues);
+  return result.value;
+}
+
+export function resolvePetAnimationState(
+  manifest: Pick<PetPackManifestV1, 'animations'>,
+  requested: PetActivityState,
+): PetActivityState {
+  return Object.hasOwn(manifest.animations, requested)
+    ? requested
+    : PET_ACTIVITY_STATE_FALLBACKS[requested];
+}
+
+export function resolvePetAnimationFallback(
+  manifest: Pick<PetPackManifestV1, 'animations'>,
+  state: PetActivityState,
+): PetActivityState {
+  const resolvedState = resolvePetAnimationState(manifest, state);
+  const animation = manifest.animations[resolvedState] ?? manifest.animations.idle;
+  if (animation.loop) return resolvedState;
+  return resolvePetAnimationState(manifest, animation.fallback ?? 'idle');
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -20,6 +20,7 @@
     "./memory-bundle-store": "./dist/memory-bundle-store.js",
     "./managed-workspace-owner": "./dist/managed-workspace-owner.js",
     "./long-term-memory-store": "./dist/long-term-memory-store.js",
+    "./pet-pack-store": "./dist/pet-pack-store.js",
     "./root-authority": "./dist/root-authority.js",
     "./runtime-policy-stores": "./dist/runtime-policy-stores.js",
     "./shell-run-authority": "./dist/shell-run-authority.js",

--- a/packages/storage/src/__tests__/pet-pack-store.test.ts
+++ b/packages/storage/src/__tests__/pet-pack-store.test.ts
@@ -1,0 +1,250 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { PET_PACK_SCHEMA_V1 } from '@maka/core/pet';
+import {
+  PET_PACK_DIRECTORY,
+  PET_PACK_MANIFEST_FILE,
+  PET_PACK_SPRITE_SHEET_MAX_BYTES,
+  PetPackStoreError,
+  createPetPackStore,
+} from '../pet-pack-store.js';
+
+function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema: PET_PACK_SCHEMA_V1,
+    id: 'likun.maodie',
+    displayName: '我的耄耋',
+    description: 'A user-installed custom pet.',
+    spriteSheet: {
+      path: 'assets/maodie.png',
+      format: 'png',
+      frameWidth: 32,
+      frameHeight: 32,
+      columns: 2,
+      rows: 2,
+      frameCount: 4,
+    },
+    animations: {
+      idle: { frames: [0], fps: 2, loop: true },
+      working: { frames: [1], fps: 4, loop: true },
+      'needs-input': { frames: [2], fps: 2, loop: true },
+      ready: { frames: [3], fps: 4, loop: false, fallback: 'idle' },
+      blocked: { frames: [2], fps: 2, loop: true },
+    },
+    ...overrides,
+  };
+}
+
+function pngHeader(width: number, height: number): Buffer {
+  const bytes = Buffer.alloc(33);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes);
+  bytes.writeUInt32BE(13, 8);
+  bytes.write('IHDR', 12, 'ascii');
+  bytes.writeUInt32BE(width, 16);
+  bytes.writeUInt32BE(height, 20);
+  return bytes;
+}
+
+function webpExtendedHeader(width: number, height: number): Buffer {
+  const bytes = Buffer.alloc(30);
+  bytes.write('RIFF', 0, 'ascii');
+  bytes.writeUInt32LE(bytes.length - 8, 4);
+  bytes.write('WEBP', 8, 'ascii');
+  bytes.write('VP8X', 12, 'ascii');
+  bytes.writeUInt32LE(10, 16);
+  writeUInt24LE(bytes, 24, width - 1);
+  writeUInt24LE(bytes, 27, height - 1);
+  return bytes;
+}
+
+function writeUInt24LE(bytes: Buffer, offset: number, value: number): void {
+  bytes[offset] = value & 0xff;
+  bytes[offset + 1] = (value >>> 8) & 0xff;
+  bytes[offset + 2] = (value >>> 16) & 0xff;
+}
+
+describe('PetPackStore', () => {
+  test('atomically installs, lists, reads, and removes a custom pet', async () => {
+    await withStore(async ({ root, store }) => {
+      const installed = await store.install({
+        manifest: manifest(),
+        spriteSheet: pngHeader(64, 64),
+      });
+      assert.equal(installed.id, 'likun.maodie');
+      assert.deepEqual(
+        (await store.list()).map((item) => item.id),
+        ['likun.maodie'],
+      );
+      assert.equal((await store.get('likun.maodie'))?.displayName, '我的耄耋');
+
+      const asset = await store.readSpriteSheet('likun.maodie');
+      assert.equal(asset?.format, 'png');
+      assert.deepEqual(Buffer.from(asset?.bytes ?? []), pngHeader(64, 64));
+
+      const packRoot = join(root, ...PET_PACK_DIRECTORY.split('/'), 'likun.maodie');
+      assert.equal(
+        JSON.parse(await readFile(join(packRoot, PET_PACK_MANIFEST_FILE), 'utf8')).id,
+        'likun.maodie',
+      );
+      assert.deepEqual(
+        (await readdir(join(root, ...PET_PACK_DIRECTORY.split('/')))).filter((name) =>
+          name.startsWith('.install-'),
+        ),
+        [],
+      );
+
+      assert.equal(await store.remove('likun.maodie'), true);
+      assert.equal(await store.remove('likun.maodie'), false);
+      assert.deepEqual(await store.list(), []);
+    });
+  });
+
+  test('accepts a WebP sprite sheet whose header matches the manifest grid', async () => {
+    await withStore(async ({ store }) => {
+      const webpManifest = manifest({
+        id: 'likun.maodie-webp',
+        spriteSheet: {
+          path: 'maodie.webp',
+          format: 'webp',
+          frameWidth: 32,
+          frameHeight: 32,
+          columns: 2,
+          rows: 2,
+          frameCount: 4,
+        },
+      });
+      await store.install({
+        manifest: webpManifest,
+        spriteSheet: webpExtendedHeader(64, 64),
+      });
+      assert.equal((await store.readSpriteSheet('likun.maodie-webp'))?.format, 'webp');
+    });
+  });
+
+  test('rejects malformed manifests before publishing any directory', async () => {
+    await withStore(async ({ root, store }) => {
+      const invalid = manifest({ script: 'pet.js' });
+      await assert.rejects(store.install({ manifest: invalid, spriteSheet: pngHeader(64, 64) }));
+      await assert.rejects(readdir(join(root, ...PET_PACK_DIRECTORY.split('/'))), {
+        code: 'ENOENT',
+      });
+    });
+  });
+
+  test('rejects mismatched dimensions, invalid headers, and oversized assets', async () => {
+    await withStore(async ({ store }) => {
+      await assert.rejects(
+        store.install({ manifest: manifest(), spriteSheet: pngHeader(32, 64) }),
+        isStoreError('invalid_asset'),
+      );
+      await assert.rejects(
+        store.install({ manifest: manifest(), spriteSheet: Buffer.from('not an image') }),
+        isStoreError('invalid_asset'),
+      );
+      await assert.rejects(
+        store.install({
+          manifest: manifest(),
+          spriteSheet: new Uint8Array(PET_PACK_SPRITE_SHEET_MAX_BYTES + 1),
+        }),
+        isStoreError('invalid_asset'),
+      );
+      assert.deepEqual(await store.list(), []);
+    });
+  });
+
+  test('never replaces an installed pet with the same id', async () => {
+    await withStore(async ({ store }) => {
+      await store.install({ manifest: manifest(), spriteSheet: pngHeader(64, 64) });
+      await assert.rejects(
+        store.install({
+          manifest: manifest({ displayName: 'Replacement' }),
+          spriteSheet: pngHeader(64, 64),
+        }),
+        isStoreError('already_installed'),
+      );
+      assert.equal((await store.get('likun.maodie'))?.displayName, '我的耄耋');
+    });
+  });
+
+  test('snapshots caller-owned manifest and image bytes before waiting for publication', async () => {
+    await withStore(async ({ store }) => {
+      const mutableManifest = manifest({ id: 'likun.snapshot' });
+      const mutableSprite = pngHeader(64, 64);
+      const install = store.install({
+        manifest: mutableManifest,
+        spriteSheet: mutableSprite,
+      });
+      mutableManifest.displayName = 'Mutated after admission';
+      mutableSprite.fill(0);
+
+      await install;
+      assert.equal((await store.get('likun.snapshot'))?.displayName, '我的耄耋');
+      assert.deepEqual(
+        Buffer.from((await store.readSpriteSheet('likun.snapshot'))?.bytes ?? []),
+        pngHeader(64, 64),
+      );
+    });
+  });
+
+  test('rejects non-canonical ids at every direct lookup boundary', async () => {
+    await withStore(async ({ store }) => {
+      await assert.rejects(store.get('../maodie'), isStoreError('invalid_id'));
+      await assert.rejects(store.readSpriteSheet('/tmp/maodie'), isStoreError('invalid_id'));
+      await assert.rejects(store.remove('MAODIE'), isStoreError('invalid_id'));
+    });
+  });
+
+  test('detects sprite sheets redirected outside the installed pack', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withStore(async ({ root, store }) => {
+      await store.install({ manifest: manifest(), spriteSheet: pngHeader(64, 64) });
+      const packRoot = join(root, ...PET_PACK_DIRECTORY.split('/'), 'likun.maodie');
+      const assetPath = join(packRoot, 'assets', 'maodie.png');
+      const outsidePath = join(root, 'outside.png');
+      await writeFile(outsidePath, pngHeader(64, 64));
+      await rm(assetPath);
+      await symlink(outsidePath, assetPath);
+
+      await assert.rejects(store.readSpriteSheet('likun.maodie'), isStoreError('corrupt_pack'));
+    });
+  });
+
+  test('rejects a store root redirected outside the state root', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withStore(async ({ root, store }) => {
+      const outside = await mkdtemp(join(tmpdir(), 'maka-pet-pack-outside-'));
+      try {
+        await symlink(outside, join(root, 'pets'));
+        await assert.rejects(store.list(), isStoreError('corrupt_store'));
+        await assert.rejects(
+          store.install({ manifest: manifest(), spriteSheet: pngHeader(64, 64) }),
+          isStoreError('corrupt_store'),
+        );
+        assert.deepEqual(await readdir(outside), []);
+      } finally {
+        await rm(join(root, 'pets'), { force: true });
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+  });
+});
+
+function isStoreError(code: PetPackStoreError['code']): (error: unknown) => boolean {
+  return (error) => error instanceof PetPackStoreError && error.code === code;
+}
+
+async function withStore(
+  run: (input: { root: string; store: ReturnType<typeof createPetPackStore> }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-pet-pack-store-'));
+  try {
+    await run({ root, store: createPetPackStore(root) });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -134,6 +134,7 @@ export * from './project-catalog.js';
 export * from './project-session-backfill.js';
 export * from './git-worktree-child-executor.js';
 export * from './managed-workspace-owner.js';
+export * from './pet-pack-store.js';
 export * from './session-bundle-policy.js';
 export * from './session-bundle-contract.js';
 export * from './session-bundle-manifest.js';

--- a/packages/storage/src/pet-pack-store.ts
+++ b/packages/storage/src/pet-pack-store.ts
@@ -1,0 +1,530 @@
+import { randomUUID } from 'node:crypto';
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  open,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname, join, relative, sep } from 'node:path';
+import {
+  decodePetPackManifest,
+  isPetPackId,
+  PetManifestValidationError,
+  type PetPackManifestV1,
+  type PetSpriteFormat,
+} from '@maka/core/pet';
+
+export const PET_PACK_DIRECTORY = 'pets/v1';
+export const PET_PACK_MANIFEST_FILE = 'pet.json';
+export const PET_PACK_MANIFEST_MAX_BYTES = 64 * 1024;
+export const PET_PACK_SPRITE_SHEET_MAX_BYTES = 4 * 1024 * 1024;
+
+export type PetPackStoreErrorCode =
+  | 'invalid_id'
+  | 'invalid_asset'
+  | 'already_installed'
+  | 'corrupt_store'
+  | 'corrupt_pack'
+  | 'io_failed';
+
+export class PetPackStoreError extends Error {
+  readonly code: PetPackStoreErrorCode;
+  readonly petId?: string;
+
+  constructor(
+    code: PetPackStoreErrorCode,
+    message: string,
+    options: { readonly petId?: string; readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'PetPackStoreError';
+    this.code = code;
+    this.petId = options.petId;
+  }
+}
+
+export interface InstallPetPackInput {
+  /** Untrusted JSON value decoded at the caller boundary. */
+  readonly manifest: unknown;
+  /** Complete PNG or WebP sprite sheet bytes. */
+  readonly spriteSheet: Uint8Array;
+}
+
+export interface PetSpriteSheetAsset {
+  readonly format: PetSpriteFormat;
+  readonly bytes: Uint8Array;
+}
+
+export interface PetPackStore {
+  list(): Promise<readonly PetPackManifestV1[]>;
+  get(petId: string): Promise<PetPackManifestV1 | undefined>;
+  install(input: InstallPetPackInput): Promise<PetPackManifestV1>;
+  readSpriteSheet(petId: string): Promise<PetSpriteSheetAsset | undefined>;
+  remove(petId: string): Promise<boolean>;
+}
+
+export function createPetPackStore(stateRoot: string): PetPackStore {
+  return new FilePetPackStore(stateRoot);
+}
+
+class FilePetPackStore implements PetPackStore {
+  private mutationQueue: Promise<void> = Promise.resolve();
+  private readonly petsRoot: string;
+  private readonly root: string;
+
+  constructor(private readonly stateRoot: string) {
+    this.petsRoot = join(stateRoot, 'pets');
+    this.root = join(this.petsRoot, 'v1');
+  }
+
+  async list(): Promise<readonly PetPackManifestV1[]> {
+    if (!(await this.storeRootExists())) return [];
+    let entries;
+    try {
+      entries = await readdir(this.root, { withFileTypes: true });
+    } catch (error) {
+      if (hasErrorCode(error, 'ENOENT')) return [];
+      throw ioFailed('Unable to list installed pet packs', error);
+    }
+
+    const manifests: PetPackManifestV1[] = [];
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      if (entry.name.startsWith('.')) continue;
+      if (!isPetPackId(entry.name) || !entry.isDirectory() || entry.isSymbolicLink()) {
+        throw corruptPack(entry.name, 'Pet pack root contains an invalid entry');
+      }
+      manifests.push(await this.readInstalledManifest(entry.name));
+    }
+    return manifests;
+  }
+
+  async get(petId: string): Promise<PetPackManifestV1 | undefined> {
+    const admittedId = admitPetId(petId);
+    if (!(await this.storeRootExists())) return undefined;
+    const packRoot = join(this.root, admittedId);
+    try {
+      const metadata = await lstat(packRoot);
+      if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+        throw corruptPack(admittedId, 'Installed pet pack is not a regular directory');
+      }
+    } catch (error) {
+      if (hasErrorCode(error, 'ENOENT')) return undefined;
+      if (error instanceof PetPackStoreError) throw error;
+      throw ioFailed(`Unable to inspect pet pack ${admittedId}`, error, admittedId);
+    }
+    return this.readInstalledManifest(admittedId);
+  }
+
+  async install(input: InstallPetPackInput): Promise<PetPackManifestV1> {
+    const manifest = snapshotManifest(decodePetPackManifest(input.manifest));
+    const spriteSheet = Buffer.from(input.spriteSheet);
+    return await this.serial(async () => {
+      assertSpriteSheet(manifest, spriteSheet, 'invalid_asset');
+      await this.ensureRoot();
+
+      const destination = join(this.root, manifest.id);
+      if (await pathExists(destination)) {
+        throw new PetPackStoreError(
+          'already_installed',
+          `Pet pack ${manifest.id} is already installed`,
+          { petId: manifest.id },
+        );
+      }
+
+      const staging = await mkdtemp(join(this.root, '.install-'));
+      try {
+        if (process.platform !== 'win32') await chmod(staging, 0o700);
+        const manifestPath = join(staging, PET_PACK_MANIFEST_FILE);
+        await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+          encoding: 'utf8',
+          mode: 0o600,
+          flag: 'wx',
+        });
+
+        const assetPath = storedAssetPath(staging, manifest);
+        await mkdir(dirname(assetPath), { recursive: true, mode: 0o700 });
+        await writeFile(assetPath, spriteSheet, { mode: 0o600, flag: 'wx' });
+        if (process.platform !== 'win32') {
+          await chmod(manifestPath, 0o600);
+          await chmod(assetPath, 0o600);
+        }
+
+        try {
+          await rename(staging, destination);
+        } catch (error) {
+          if (hasErrorCode(error, 'EEXIST') || hasErrorCode(error, 'ENOTEMPTY')) {
+            throw new PetPackStoreError(
+              'already_installed',
+              `Pet pack ${manifest.id} is already installed`,
+              { petId: manifest.id, cause: error },
+            );
+          }
+          throw error;
+        }
+        return manifest;
+      } catch (error) {
+        if (error instanceof PetPackStoreError) throw error;
+        throw ioFailed(`Unable to install pet pack ${manifest.id}`, error, manifest.id);
+      } finally {
+        await rm(staging, { recursive: true, force: true }).catch(() => {});
+      }
+    });
+  }
+
+  async readSpriteSheet(petId: string): Promise<PetSpriteSheetAsset | undefined> {
+    const manifest = await this.get(petId);
+    if (!manifest) return undefined;
+    const packRoot = join(this.root, manifest.id);
+    try {
+      const bytes = await readBoundedRegularFile(
+        storedAssetPath(packRoot, manifest),
+        PET_PACK_SPRITE_SHEET_MAX_BYTES,
+        packRoot,
+      );
+      assertSpriteSheet(manifest, bytes, 'corrupt_pack');
+      return { format: manifest.spriteSheet.format, bytes: new Uint8Array(bytes) };
+    } catch (error) {
+      if (error instanceof PetPackStoreError) throw error;
+      throw corruptPack(manifest.id, 'Installed pet sprite sheet is unreadable', error);
+    }
+  }
+
+  remove(petId: string): Promise<boolean> {
+    return this.serial(async () => {
+      const admittedId = admitPetId(petId);
+      if (!(await this.storeRootExists())) return false;
+      const destination = join(this.root, admittedId);
+      const quarantine = join(this.root, `.remove-${admittedId}-${randomUUID()}`);
+      try {
+        await rename(destination, quarantine);
+      } catch (error) {
+        if (hasErrorCode(error, 'ENOENT')) return false;
+        throw ioFailed(`Unable to unpublish pet pack ${admittedId}`, error, admittedId);
+      }
+      try {
+        await rm(quarantine, { recursive: true });
+        return true;
+      } catch (error) {
+        throw ioFailed(`Unable to remove pet pack ${admittedId}`, error, admittedId);
+      }
+    });
+  }
+
+  private async readInstalledManifest(petId: string): Promise<PetPackManifestV1> {
+    const packRoot = join(this.root, petId);
+    try {
+      const bytes = await readBoundedRegularFile(
+        join(packRoot, PET_PACK_MANIFEST_FILE),
+        PET_PACK_MANIFEST_MAX_BYTES,
+        packRoot,
+      );
+      const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+      const manifest = decodePetPackManifest(JSON.parse(text));
+      if (manifest.id !== petId) {
+        throw corruptPack(petId, 'Installed pet manifest id does not match its directory');
+      }
+      return manifest;
+    } catch (error) {
+      if (error instanceof PetPackStoreError) throw error;
+      if (
+        error instanceof PetManifestValidationError ||
+        error instanceof SyntaxError ||
+        error instanceof TypeError
+      ) {
+        throw corruptPack(petId, 'Installed pet manifest is invalid', error);
+      }
+      throw corruptPack(petId, 'Installed pet manifest is unreadable', error);
+    }
+  }
+
+  private async ensureRoot(): Promise<void> {
+    try {
+      await mkdir(this.stateRoot, { recursive: true, mode: 0o700 });
+      await ensurePlainDirectory(this.petsRoot);
+      await ensurePlainDirectory(this.root);
+    } catch (error) {
+      if (error instanceof PetPackStoreError) throw error;
+      throw ioFailed('Unable to create the pet pack store', error);
+    }
+  }
+
+  private async storeRootExists(): Promise<boolean> {
+    for (const path of [this.petsRoot, this.root]) {
+      try {
+        const metadata = await lstat(path);
+        if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+          throw new PetPackStoreError(
+            'corrupt_store',
+            'Pet pack store contains a redirected or non-directory root',
+          );
+        }
+      } catch (error) {
+        if (hasErrorCode(error, 'ENOENT')) return false;
+        if (error instanceof PetPackStoreError) throw error;
+        throw ioFailed('Unable to inspect the pet pack store', error);
+      }
+    }
+    return true;
+  }
+
+  private async serial<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.mutationQueue;
+    let release!: () => void;
+    this.mutationQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
+function admitPetId(value: unknown): string {
+  if (!isPetPackId(value)) {
+    throw new PetPackStoreError('invalid_id', 'Pet pack id is not canonical');
+  }
+  return value;
+}
+
+function storedAssetPath(packRoot: string, manifest: PetPackManifestV1): string {
+  return join(packRoot, ...manifest.spriteSheet.path.split('/'));
+}
+
+async function ensurePlainDirectory(path: string): Promise<void> {
+  try {
+    await mkdir(path, { mode: 0o700 });
+  } catch (error) {
+    if (!hasErrorCode(error, 'EEXIST')) throw error;
+  }
+  const metadata = await lstat(path);
+  if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+    throw new PetPackStoreError(
+      'corrupt_store',
+      'Pet pack store contains a redirected or non-directory root',
+    );
+  }
+  if (process.platform !== 'win32') await chmod(path, 0o700);
+}
+
+function snapshotManifest(manifest: PetPackManifestV1): PetPackManifestV1 {
+  const animations: PetPackManifestV1['animations'] = {
+    idle: snapshotAnimation(manifest.animations.idle),
+    working: snapshotAnimation(manifest.animations.working),
+    'needs-input': snapshotAnimation(manifest.animations['needs-input']),
+    ready: snapshotAnimation(manifest.animations.ready),
+    blocked: snapshotAnimation(manifest.animations.blocked),
+    ...(manifest.animations.swarm === undefined
+      ? {}
+      : { swarm: snapshotAnimation(manifest.animations.swarm) }),
+    ...(manifest.animations.cancelled === undefined
+      ? {}
+      : { cancelled: snapshotAnimation(manifest.animations.cancelled) }),
+    ...(manifest.animations.poke === undefined
+      ? {}
+      : { poke: snapshotAnimation(manifest.animations.poke) }),
+    ...(manifest.animations.wake === undefined
+      ? {}
+      : { wake: snapshotAnimation(manifest.animations.wake) }),
+    ...(manifest.animations.sleep === undefined
+      ? {}
+      : { sleep: snapshotAnimation(manifest.animations.sleep) }),
+  };
+  return {
+    schema: manifest.schema,
+    id: manifest.id,
+    displayName: manifest.displayName,
+    ...(manifest.description === undefined ? {} : { description: manifest.description }),
+    spriteSheet: { ...manifest.spriteSheet },
+    animations,
+  };
+}
+
+function snapshotAnimation(
+  animation: PetPackManifestV1['animations']['idle'],
+): PetPackManifestV1['animations']['idle'] {
+  return {
+    frames: [...animation.frames],
+    fps: animation.fps,
+    loop: animation.loop,
+    ...(animation.fallback === undefined ? {} : { fallback: animation.fallback }),
+  };
+}
+
+async function readBoundedRegularFile(
+  path: string,
+  maxBytes: number,
+  containmentRoot: string,
+): Promise<Buffer> {
+  const [canonicalRoot, canonicalPath] = await Promise.all([
+    realpath(containmentRoot),
+    realpath(path),
+  ]);
+  const fromRoot = relative(canonicalRoot, canonicalPath);
+  if (fromRoot === '' || fromRoot === '..' || fromRoot.startsWith(`..${sep}`)) {
+    throw new Error('Pet pack file escapes its package root');
+  }
+
+  const before = await lstat(path, { bigint: true });
+  if (!before.isFile() || before.isSymbolicLink() || before.size > BigInt(maxBytes)) {
+    throw new Error(`Pet pack file must be a regular file no larger than ${maxBytes} bytes`);
+  }
+
+  const handle = await open(path, 'r');
+  try {
+    const opened = await handle.stat({ bigint: true });
+    if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error('Pet pack file changed while opening');
+    }
+    const initialSize = Number(opened.size);
+    const output = Buffer.allocUnsafe(Math.min(initialSize, maxBytes) + 1);
+    let offset = 0;
+    while (offset < output.length) {
+      const { bytesRead } = await handle.read(output, offset, output.length - offset, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset > maxBytes) throw new Error(`Pet pack file exceeds ${maxBytes} bytes`);
+    return output.subarray(0, offset);
+  } finally {
+    await handle.close();
+  }
+}
+
+function assertSpriteSheet(
+  manifest: PetPackManifestV1,
+  bytes: Uint8Array,
+  code: Extract<PetPackStoreErrorCode, 'invalid_asset' | 'corrupt_pack'>,
+): void {
+  if (bytes.byteLength === 0 || bytes.byteLength > PET_PACK_SPRITE_SHEET_MAX_BYTES) {
+    throw new PetPackStoreError(
+      code,
+      `Pet sprite sheet must be between 1 and ${PET_PACK_SPRITE_SHEET_MAX_BYTES} bytes`,
+      { petId: manifest.id },
+    );
+  }
+  let dimensions: { readonly width: number; readonly height: number };
+  try {
+    dimensions = readImageDimensions(Buffer.from(bytes), manifest.spriteSheet.format);
+  } catch (error) {
+    throw new PetPackStoreError(code, 'Pet sprite sheet has an invalid image header', {
+      petId: manifest.id,
+      cause: error,
+    });
+  }
+  const expectedWidth = manifest.spriteSheet.frameWidth * manifest.spriteSheet.columns;
+  const expectedHeight = manifest.spriteSheet.frameHeight * manifest.spriteSheet.rows;
+  if (dimensions.width !== expectedWidth || dimensions.height !== expectedHeight) {
+    throw new PetPackStoreError(
+      code,
+      `Pet sprite sheet must be ${expectedWidth}x${expectedHeight}, got ${dimensions.width}x${dimensions.height}`,
+      { petId: manifest.id },
+    );
+  }
+}
+
+function readImageDimensions(
+  bytes: Buffer,
+  format: PetSpriteFormat,
+): { readonly width: number; readonly height: number } {
+  return format === 'png' ? readPngDimensions(bytes) : readWebpDimensions(bytes);
+}
+
+function readPngDimensions(bytes: Buffer): { readonly width: number; readonly height: number } {
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  if (
+    bytes.length < 33 ||
+    !bytes.subarray(0, signature.length).equals(signature) ||
+    bytes.readUInt32BE(8) !== 13 ||
+    bytes.toString('ascii', 12, 16) !== 'IHDR'
+  ) {
+    throw new Error('Invalid PNG header');
+  }
+  const width = bytes.readUInt32BE(16);
+  const height = bytes.readUInt32BE(20);
+  if (width === 0 || height === 0) throw new Error('Invalid PNG dimensions');
+  return { width, height };
+}
+
+function readWebpDimensions(bytes: Buffer): { readonly width: number; readonly height: number } {
+  if (
+    bytes.length < 25 ||
+    bytes.toString('ascii', 0, 4) !== 'RIFF' ||
+    bytes.toString('ascii', 8, 12) !== 'WEBP'
+  ) {
+    throw new Error('Invalid WebP header');
+  }
+  const declaredSize = bytes.readUInt32LE(4) + 8;
+  if (declaredSize !== bytes.length) throw new Error('Invalid WebP container size');
+
+  const chunkType = bytes.toString('ascii', 12, 16);
+  const chunkSize = bytes.readUInt32LE(16);
+  if (20 + chunkSize > bytes.length) throw new Error('Truncated WebP image chunk');
+  if (chunkType === 'VP8X') {
+    if (chunkSize < 10 || bytes.length < 30) throw new Error('Invalid VP8X chunk');
+    return {
+      width: 1 + readUInt24LE(bytes, 24),
+      height: 1 + readUInt24LE(bytes, 27),
+    };
+  }
+  if (chunkType === 'VP8 ') {
+    if (
+      chunkSize < 10 ||
+      bytes.length < 30 ||
+      bytes[23] !== 0x9d ||
+      bytes[24] !== 0x01 ||
+      bytes[25] !== 0x2a
+    ) {
+      throw new Error('Invalid VP8 key frame');
+    }
+    return {
+      width: bytes.readUInt16LE(26) & 0x3fff,
+      height: bytes.readUInt16LE(28) & 0x3fff,
+    };
+  }
+  if (chunkType === 'VP8L') {
+    if (chunkSize < 5 || bytes.length < 25 || bytes[20] !== 0x2f) {
+      throw new Error('Invalid VP8L frame');
+    }
+    const bits = bytes.readUInt32LE(21);
+    return {
+      width: 1 + (bits & 0x3fff),
+      height: 1 + ((bits >>> 14) & 0x3fff),
+    };
+  }
+  throw new Error(`Unsupported WebP image chunk ${chunkType}`);
+}
+
+function readUInt24LE(bytes: Buffer, offset: number): number {
+  return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if (hasErrorCode(error, 'ENOENT')) return false;
+    throw error;
+  }
+}
+
+function corruptPack(petId: string, message: string, cause?: unknown): PetPackStoreError {
+  return new PetPackStoreError('corrupt_pack', message, { petId, cause });
+}
+
+function ioFailed(message: string, cause: unknown, petId?: string): PetPackStoreError {
+  return new PetPackStoreError('io_failed', message, { petId, cause });
+}
+
+function hasErrorCode(error: unknown, code: string): boolean {
+  return (error as NodeJS.ErrnoException | undefined)?.code === code;
+}


### PR DESCRIPTION
## Summary

- define the versioned custom pet pack v1 manifest contract in core
- add an atomic, bounded pet pack store with PNG/WebP validation
- reject traversal, symlinks, duplicate IDs, oversized sprites, and partial installs

## Testing

- core package: 812 tests passed
- targeted pet-pack suites: 20 tests passed
- storage package: 740 tests passed, 12 skipped, excluding 3 known environment-dependent failures in temporary dependency fixtures