### PR TITLE
feat(desktop): import custom pet packs safely

### DIFF
--- a/apps/desktop/src/main/__tests__/pet-pack-import.test.ts
+++ b/apps/desktop/src/main/__tests__/pet-pack-import.test.ts
@@ -1,0 +1,212 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { PET_PACK_SCHEMA_V1 } from '@maka/core/pet';
+import { createPetPackStore } from '@maka/storage/pet-pack-store';
+import {
+  importPetPackFromDirectory,
+  PetPackImportError,
+  registerPetPackIpc,
+} from '../pet-pack-import.js';
+
+function manifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema: PET_PACK_SCHEMA_V1,
+    id: 'likun.maodie',
+    displayName: '我的耄耋',
+    spriteSheet: {
+      path: 'assets/maodie.png',
+      format: 'png',
+      frameWidth: 32,
+      frameHeight: 32,
+      columns: 2,
+      rows: 2,
+      frameCount: 4,
+    },
+    animations: {
+      idle: { frames: [0], fps: 2, loop: true },
+      working: { frames: [1], fps: 4, loop: true },
+      'needs-input': { frames: [2], fps: 2, loop: true },
+      ready: { frames: [3], fps: 4, loop: false, fallback: 'idle' },
+      blocked: { frames: [2], fps: 2, loop: true },
+    },
+    ...overrides,
+  };
+}
+
+function pngHeader(width: number, height: number): Buffer {
+  const bytes = Buffer.alloc(33);
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(bytes);
+  bytes.writeUInt32BE(13, 8);
+  bytes.write('IHDR', 12, 'ascii');
+  bytes.writeUInt32BE(width, 16);
+  bytes.writeUInt32BE(height, 20);
+  return bytes;
+}
+
+test('imports only the manifest-selected sprite into the atomic store', async () => {
+  await withFixture(async ({ source, stateRoot }) => {
+    await writeSourcePack(source);
+    const store = createPetPackStore(stateRoot);
+
+    const installed = await importPetPackFromDirectory({ sourceDirectory: source, store });
+
+    assert.equal(installed.id, 'likun.maodie');
+    assert.deepEqual((await store.list()).map(({ id }) => id), ['likun.maodie']);
+    assert.deepEqual(
+      Buffer.from((await store.readSpriteSheet('likun.maodie'))?.bytes ?? []),
+      pngHeader(64, 64),
+    );
+  });
+});
+
+test('rejects malformed manifests and leaves the store empty', async () => {
+  await withFixture(async ({ source, stateRoot }) => {
+    await mkdir(join(source, 'assets'), { recursive: true });
+    await writeFile(join(source, 'pet.json'), '{"schema":');
+    await writeFile(join(source, 'assets', 'maodie.png'), pngHeader(64, 64));
+    const store = createPetPackStore(stateRoot);
+
+    await assert.rejects(
+      importPetPackFromDirectory({ sourceDirectory: source, store }),
+      isImportError('invalid_manifest'),
+    );
+    assert.deepEqual(await store.list(), []);
+  });
+});
+
+test('rejects a sprite symlink that redirects outside the selected directory', async (context) => {
+  if (process.platform === 'win32') {
+    context.skip('symlink creation is not reliably available on Windows CI');
+    return;
+  }
+  await withFixture(async ({ root, source, stateRoot }) => {
+    const outside = join(root, 'outside.png');
+    await mkdir(join(source, 'assets'), { recursive: true });
+    await writeFile(join(source, 'pet.json'), JSON.stringify(manifest()));
+    await writeFile(outside, pngHeader(64, 64));
+    await symlink(outside, join(source, 'assets', 'maodie.png'));
+
+    await assert.rejects(
+      importPetPackFromDirectory({
+        sourceDirectory: source,
+        store: createPetPackStore(stateRoot),
+      }),
+      isImportError('invalid_asset'),
+    );
+  });
+});
+
+test('rejects a symlinked asset directory even when it points back inside the source', async (context) => {
+  if (process.platform === 'win32') {
+    context.skip('symlink creation is not reliably available on Windows CI');
+    return;
+  }
+  await withFixture(async ({ source, stateRoot }) => {
+    const realAssets = join(source, 'real-assets');
+    await mkdir(realAssets);
+    await writeFile(join(source, 'pet.json'), JSON.stringify(manifest()));
+    await writeFile(join(realAssets, 'maodie.png'), pngHeader(64, 64));
+    await symlink(realAssets, join(source, 'assets'));
+
+    await assert.rejects(
+      importPetPackFromDirectory({
+        sourceDirectory: source,
+        store: createPetPackStore(stateRoot),
+      }),
+      isImportError('invalid_asset'),
+    );
+  });
+});
+
+test('maps a duplicate id without replacing the installed pet', async () => {
+  await withFixture(async ({ source, stateRoot }) => {
+    await writeSourcePack(source);
+    const store = createPetPackStore(stateRoot);
+    await importPetPackFromDirectory({ sourceDirectory: source, store });
+    await writeFile(
+      join(source, 'pet.json'),
+      JSON.stringify(manifest({ displayName: 'Replacement' })),
+    );
+
+    await assert.rejects(
+      importPetPackFromDirectory({ sourceDirectory: source, store }),
+      isImportError('already_installed'),
+    );
+    assert.equal((await store.get('likun.maodie'))?.displayName, '我的耄耋');
+  });
+});
+
+test('IPC imports only the native picker result and returns stable envelopes', async () => {
+  await withFixture(async ({ source, stateRoot }) => {
+    await writeSourcePack(source);
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    registerPetPackIpc({
+      ipcMain: {
+        handle: (channel, handler) => handlers.set(channel, handler as (...args: unknown[]) => unknown),
+      },
+      workspaceRoot: stateRoot,
+      mainWindowController: {
+        showOpenDialog: async () => ({ canceled: false, filePaths: [source] }),
+      },
+    });
+
+    const result = await handlers.get('pets:importLocalDirectory')?.({}, '/untrusted/path');
+    assert.deepEqual(result, { ok: true, manifest: manifest() });
+    assert.deepEqual(await handlers.get('pets:list')?.(), [manifest()]);
+  });
+});
+
+test('IPC reports picker cancellation without touching storage', async () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  registerPetPackIpc({
+    ipcMain: {
+      handle: (channel, handler) => handlers.set(channel, handler as (...args: unknown[]) => unknown),
+    },
+    workspaceRoot: '/unused',
+    mainWindowController: {
+      showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
+    },
+    store: {
+      list: async () => [],
+      get: async () => undefined,
+      install: async () => {
+        throw new Error('install must not run');
+      },
+      readSpriteSheet: async () => undefined,
+      remove: async () => false,
+    },
+  });
+
+  assert.deepEqual(await handlers.get('pets:importLocalDirectory')?.({}), {
+    ok: false,
+    reason: 'cancelled',
+  });
+});
+
+async function writeSourcePack(source: string): Promise<void> {
+  await mkdir(join(source, 'assets'), { recursive: true });
+  await writeFile(join(source, 'pet.json'), JSON.stringify(manifest()));
+  await writeFile(join(source, 'assets', 'maodie.png'), pngHeader(64, 64));
+  await writeFile(join(source, 'ignored.js'), 'throw new Error("must never execute")');
+}
+
+function isImportError(reason: PetPackImportError['reason']): (error: unknown) => boolean {
+  return (error) => error instanceof PetPackImportError && error.reason === reason;
+}
+
+async function withFixture(
+  run: (fixture: { root: string; source: string; stateRoot: string }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-pet-import-'));
+  const source = join(root, 'source');
+  const stateRoot = join(root, 'state');
+  await mkdir(source);
+  try {
+    await run({ root, source, stateRoot });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -116,6 +116,7 @@ import { registerBrowserIpc } from './browser-ipc-main.js';
 import { registerConnectionsIpc } from './connections-ipc-main.js';
 import { registerConfigIpc } from './config-ipc-main.js';
 import { registerPlanReminderIpc } from './plan-reminders-ipc-main.js';
+import { registerPetPackIpc } from './pet-pack-import.js';
 import { registerWorkspaceResourcesIpc } from './workspace-resources-ipc-main.js';
 import type { NewSessionSkillContext } from './workspace-resources-ipc-main.js';
 import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
@@ -1143,6 +1144,7 @@ function registerIpc(): void {
     getSkillSelectionReport: systemPromptService.getLastSkillSelectionReport,
     invalidateSkillSelectionReport: systemPromptService.invalidateSkillSelectionReport,
   });
+  registerPetPackIpc({ ipcMain, workspaceRoot, mainWindowController });
   registerWorkspaceSearchIpc({ getProjectRoot: resolveProjectRootForContext });
   registerPlanReminderIpc({ planReminders, getWorkspacePrivacyContext });
   registerAgentGraphIpc({

--- a/apps/desktop/src/main/pet-pack-import.ts
+++ b/apps/desktop/src/main/pet-pack-import.ts
@@ -1,0 +1,204 @@
+import { Buffer } from 'node:buffer';
+import { lstat, open, realpath } from 'node:fs/promises';
+import { join, relative, sep } from 'node:path';
+import type { IpcMain } from 'electron';
+import { decodePetPackManifest, type PetPackManifestV1 } from '@maka/core/pet';
+import {
+  createPetPackStore,
+  PET_PACK_MANIFEST_FILE,
+  PET_PACK_MANIFEST_MAX_BYTES,
+  PET_PACK_SPRITE_SHEET_MAX_BYTES,
+  PetPackStoreError,
+  type PetPackStore,
+} from '@maka/storage/pet-pack-store';
+import type { createMainWindowController } from './main-window.js';
+
+type MainWindowController = Pick<
+  ReturnType<typeof createMainWindowController>,
+  'showOpenDialog'
+>;
+
+export type PetPackImportFailureReason =
+  | 'cancelled'
+  | 'invalid_directory'
+  | 'invalid_manifest'
+  | 'invalid_asset'
+  | 'already_installed'
+  | 'read_failed';
+
+export type PetPackImportResult =
+  | { readonly ok: true; readonly manifest: PetPackManifestV1 }
+  | { readonly ok: false; readonly reason: PetPackImportFailureReason };
+
+export class PetPackImportError extends Error {
+  readonly reason: Exclude<PetPackImportFailureReason, 'cancelled'>;
+
+  constructor(
+    reason: Exclude<PetPackImportFailureReason, 'cancelled'>,
+    message: string,
+    options: { readonly cause?: unknown } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'PetPackImportError';
+    this.reason = reason;
+  }
+}
+
+/**
+ * Snapshot one code-free PetPack directory selected by the native file picker.
+ * The manifest decides which single sprite asset is read; neither path is ever
+ * accepted from the renderer.
+ */
+export async function importPetPackFromDirectory(input: {
+  readonly sourceDirectory: string;
+  readonly store: PetPackStore;
+}): Promise<PetPackManifestV1> {
+  const sourceRoot = await admitSourceDirectory(input.sourceDirectory);
+  const manifest = await readSourceManifest(sourceRoot);
+  const spriteSheet = await readSourceAsset(sourceRoot, manifest);
+
+  try {
+    return await input.store.install({ manifest, spriteSheet });
+  } catch (error) {
+    if (error instanceof PetPackStoreError) {
+      if (error.code === 'already_installed') {
+        throw new PetPackImportError('already_installed', error.message, { cause: error });
+      }
+      if (error.code === 'invalid_asset') {
+        throw new PetPackImportError('invalid_asset', error.message, { cause: error });
+      }
+    }
+    throw new PetPackImportError('read_failed', 'Unable to install the selected pet pack', {
+      cause: error,
+    });
+  }
+}
+
+export function registerPetPackIpc(input: {
+  readonly ipcMain: Pick<IpcMain, 'handle'>;
+  readonly workspaceRoot: string;
+  readonly mainWindowController: MainWindowController;
+  readonly store?: PetPackStore;
+}): void {
+  const store = input.store ?? createPetPackStore(input.workspaceRoot);
+
+  input.ipcMain.handle('pets:list', () => store.list());
+  input.ipcMain.handle('pets:importLocalDirectory', async (): Promise<PetPackImportResult> => {
+    const selection = await input.mainWindowController.showOpenDialog({
+      title: 'Import custom pet',
+      properties: ['openDirectory'],
+    });
+    if (selection.canceled || selection.filePaths.length === 0) {
+      return { ok: false, reason: 'cancelled' };
+    }
+
+    try {
+      const manifest = await importPetPackFromDirectory({
+        sourceDirectory: selection.filePaths[0],
+        store,
+      });
+      return { ok: true, manifest };
+    } catch (error) {
+      return {
+        ok: false,
+        reason: error instanceof PetPackImportError ? error.reason : 'read_failed',
+      };
+    }
+  });
+}
+
+async function admitSourceDirectory(sourceDirectory: string): Promise<string> {
+  try {
+    const metadata = await lstat(sourceDirectory);
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new Error('Selected pet pack source is not a plain directory');
+    }
+    return await realpath(sourceDirectory);
+  } catch (error) {
+    throw new PetPackImportError(
+      'invalid_directory',
+      'Selected pet pack source is not a readable directory',
+      { cause: error },
+    );
+  }
+}
+
+async function readSourceManifest(sourceRoot: string): Promise<PetPackManifestV1> {
+  try {
+    const bytes = await readBoundedSourceFile(
+      sourceRoot,
+      PET_PACK_MANIFEST_FILE,
+      PET_PACK_MANIFEST_MAX_BYTES,
+    );
+    const text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    return decodePetPackManifest(JSON.parse(text));
+  } catch (error) {
+    throw new PetPackImportError('invalid_manifest', 'Selected pet manifest is invalid', {
+      cause: error,
+    });
+  }
+}
+
+async function readSourceAsset(
+  sourceRoot: string,
+  manifest: PetPackManifestV1,
+): Promise<Uint8Array> {
+  try {
+    return await readBoundedSourceFile(
+      sourceRoot,
+      manifest.spriteSheet.path,
+      PET_PACK_SPRITE_SHEET_MAX_BYTES,
+    );
+  } catch (error) {
+    throw new PetPackImportError('invalid_asset', 'Selected pet sprite sheet is invalid', {
+      cause: error,
+    });
+  }
+}
+
+async function readBoundedSourceFile(
+  sourceRoot: string,
+  relativePath: string,
+  maxBytes: number,
+): Promise<Uint8Array> {
+  const segments = relativePath.split('/');
+  const candidate = join(sourceRoot, ...segments);
+  const canonicalPath = await realpath(candidate);
+  const fromRoot = relative(sourceRoot, canonicalPath);
+  if (fromRoot === '' || fromRoot === '..' || fromRoot.startsWith(`..${sep}`)) {
+    throw new Error('Pet pack source file escapes the selected directory');
+  }
+
+  let parent = sourceRoot;
+  for (const segment of segments.slice(0, -1)) {
+    parent = join(parent, segment);
+    const metadata = await lstat(parent);
+    if (!metadata.isDirectory() || metadata.isSymbolicLink()) {
+      throw new Error('Pet pack source path contains a redirected directory');
+    }
+  }
+
+  const before = await lstat(candidate, { bigint: true });
+  if (!before.isFile() || before.isSymbolicLink() || before.size > BigInt(maxBytes)) {
+    throw new Error(`Pet pack source file must be a regular file no larger than ${maxBytes} bytes`);
+  }
+
+  const handle = await open(candidate, 'r');
+  try {
+    const opened = await handle.stat({ bigint: true });
+    if (!opened.isFile() || opened.dev !== before.dev || opened.ino !== before.ino) {
+      throw new Error('Pet pack source file changed while opening');
+    }
+    const output = Buffer.alloc(maxBytes + 1);
+    let offset = 0;
+    while (offset < output.length) {
+      const { bytesRead } = await handle.read(output, offset, output.length - offset, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset > maxBytes) throw new Error(`Pet pack source file exceeds ${maxBytes} bytes`);
+    return output.subarray(0, offset);
+  } finally {
+    await handle.close();
+  }
+}

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -45,6 +45,7 @@ import { registerOnboardingIpc } from "./onboarding-ipc-main.js";
 import { registerNotificationsIpc } from "./notifications-ipc-main.js";
 import { registerPlanReminderIpc } from "./plan-reminders-ipc-main.js";
 import { createPlanReminderMainService } from "./plan-reminders-main.js";
+import { registerPetPackIpc } from "./pet-pack-import.js";
 import {
   createPermissionOverlayMain,
   registerPermissionOverlayIpc,
@@ -238,6 +239,7 @@ mcpManager.onChange(() => {
 });
 
 registerPersistentClientIpc();
+registerPetPackIpc({ ipcMain, workspaceRoot, mainWindowController });
 registerBrowserIpc({ mainWindowController });
 registerNotificationsIpc({
   ipcMain,

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -78,6 +78,7 @@ import type {
   DeepResearchChangedEvent,
   DeepResearchClientProgress,
   LocalMemoryEntryPreview,
+  PetPackManifestV1,
 } from '@maka/core';
 import type { SessionTrace } from '@maka/core/session-trace';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
@@ -206,6 +207,23 @@ export type AppUpdateInstallResult =
 export type WindowCommand = { id: 'newTask' | 'openSettings' | 'openHelp' };
 
 export interface MakaBridge {
+
+  pets: {
+    list(): Promise<PetPackManifestV1[]>;
+    importLocalDirectory(): Promise<
+      | { ok: true; manifest: PetPackManifestV1 }
+      | {
+          ok: false;
+          reason:
+            | 'cancelled'
+            | 'invalid_directory'
+            | 'invalid_manifest'
+            | 'invalid_asset'
+            | 'already_installed'
+            | 'read_failed';
+        }
+    >;
+  };
 
   tasks: {
     list(sessionId: string): Promise<Task[]>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -125,6 +125,14 @@ type LocalMemoryMutationResult =
   | { ok: false; state: LocalMemoryState; reason: string; message: string };
 
 const makaBridge = {
+  pets: {
+    list() {
+      return ipcRenderer.invoke('pets:list');
+    },
+    importLocalDirectory() {
+      return ipcRenderer.invoke('pets:importLocalDirectory');
+    },
+  },
   tasks: {
     list(sessionId: string): Promise<Task[]> {
       return ipcRenderer.invoke('tasks:list', sessionId);


### PR DESCRIPTION
## Summary

- import a code-free PetPack from a user-selected directory
- keep source paths in the Electron main process and expose only a no-argument preload method
- validate bounded manifest and sprite reads, containment, regular files, and symlink-free path components
- register the bridge for both embedded and Runtime Host desktop owners

## Testing

- desktop main TypeScript build
- preload TypeScript check
- full compiled desktop test suite and console, accessibility, and copy checks
- 7 focused PetPack import tests

## Note

The broader workspace dependency build currently reaches an unrelated existing type error in packages/ui/src/chat-surface-layout.tsx: ChatLayoutProps does not expose conversationKey.