### PR TITLE
fix(storage): remove Windows worktrees outside their cwd

### DIFF
--- a/packages/storage/src/git-worktree-child-executor.ts
+++ b/packages/storage/src/git-worktree-child-executor.ts
@@ -170,7 +170,7 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
     if (!(await isDirectory(binding.worktreePath))) return;
     await this.ensure(binding);
     await this.withRepositoryAllocation(binding.gitCommonDir, () =>
-      this.removeOwnedWorktree(binding.worktreePath, binding.branch),
+      this.removeOwnedWorktree(binding.worktreePath, binding.branch, binding.gitCommonDir),
     );
   }
 
@@ -362,18 +362,23 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
       throw new Error(`Orphan subagent worktree ownership is unavailable: ${path}`);
     }
     await this.withRepositoryAllocation(inspected.gitCommonDir, () =>
-      this.removeOwnedWorktree(path, branch),
+      this.removeOwnedWorktree(path, branch, inspected.gitCommonDir),
     );
   }
 
-  private async removeOwnedWorktree(path: string, leaseBranch: string): Promise<void> {
+  private async removeOwnedWorktree(
+    path: string,
+    leaseBranch: string,
+    gitCommonDir: string,
+  ): Promise<void> {
     await runGit(path, ['clean', '-ffdx']);
     await runGit(path, ['checkout', '--detach', '--force', 'HEAD']);
     await runGit(path, ['clean', '-ffdx']);
     if (await gitRevParseOptional(path, leaseBranch)) {
       await runGit(path, ['branch', '-D', leaseBranch]);
     }
-    await runGit(path, ['worktree', 'remove', '--force', path]);
+    // Windows cannot remove a process's current directory, so run the final removal elsewhere.
+    await runGit(gitCommonDir, ['worktree', 'remove', '--force', path]);
   }
 }
 


### PR DESCRIPTION
## Summary

- execute the final `git worktree remove` from the stable Git common directory
- avoid asking a Windows Git process to delete its own current working directory
- preserve existing clean, detach, Host lease branch deletion, and repository allocation semantics

Closes two failures tracked by #2142:

- `retires only the Host lease branch after a child switches branches`
- `recovery preserves live bindings and retires orphaned worktrees`

## Validation

- `@maka/storage` build
- both affected tests pass in three consecutive Windows runs (`6/6`)
- Biome format check
- `git diff --check`

The complete test file separately observed a temp-root cleanup `EBUSY` in an unrelated availability test. This PR does not add broad filesystem retries or claim to address that independent cleanup failure.