### PR TITLE
feat(desktop): expose custom pet pack library

### DIFF
--- a/apps/desktop/src/main/__tests__/pet-pack-import.test.ts
+++ b/apps/desktop/src/main/__tests__/pet-pack-import.test.ts
@@ -143,6 +143,7 @@ test('IPC imports only the native picker result and returns stable envelopes', a
   await withFixture(async ({ source, stateRoot }) => {
     await writeSourcePack(source);
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const events: Array<{ channel: string; payload: unknown }> = [];
     registerPetPackIpc({
       ipcMain: {
         handle: (channel, handler) => handlers.set(channel, handler as (...args: unknown[]) => unknown),
@@ -150,12 +151,90 @@ test('IPC imports only the native picker result and returns stable envelopes', a
       workspaceRoot: stateRoot,
       mainWindowController: {
         showOpenDialog: async () => ({ canceled: false, filePaths: [source] }),
+        send: (channel, payload) => events.push({ channel, payload }),
       },
+      now: () => 42,
     });
 
     const result = await handlers.get('pets:importLocalDirectory')?.({}, '/untrusted/path');
     assert.deepEqual(result, { ok: true, manifest: manifest() });
     assert.deepEqual(await handlers.get('pets:list')?.(), [manifest()]);
+    assert.deepEqual(events, [
+      {
+        channel: 'pets:changed',
+        payload: {
+          type: 'pet_pack_changed',
+          reason: 'installed',
+          petId: 'likun.maodie',
+          ts: 42,
+        },
+      },
+    ]);
+  });
+});
+
+test('IPC returns sprite bytes, removes the pack, and emits only real mutations', async () => {
+  await withFixture(async ({ source, stateRoot }) => {
+    await writeSourcePack(source);
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const events: unknown[] = [];
+    registerPetPackIpc({
+      ipcMain: {
+        handle: (channel, handler) => handlers.set(channel, handler as (...args: unknown[]) => unknown),
+      },
+      workspaceRoot: stateRoot,
+      mainWindowController: {
+        showOpenDialog: async () => ({ canceled: false, filePaths: [source] }),
+        send: (_channel, payload) => events.push(payload),
+      },
+      now: () => 84,
+    });
+    await handlers.get('pets:importLocalDirectory')?.({});
+
+    const asset = (await handlers.get('pets:readSpriteSheet')?.({}, 'likun.maodie')) as {
+      ok: true;
+      mimeType: string;
+      bytes: Uint8Array;
+    };
+    assert.equal(asset.ok, true);
+    assert.equal(asset.mimeType, 'image/png');
+    assert.deepEqual(Buffer.from(asset.bytes), pngHeader(64, 64));
+    assert.deepEqual(await handlers.get('pets:readSpriteSheet')?.({}, '../escape'), {
+      ok: false,
+      reason: 'invalid_id',
+    });
+    assert.deepEqual(await handlers.get('pets:readSpriteSheet')?.({}, 'likun.unknown'), {
+      ok: false,
+      reason: 'not_found',
+    });
+    assert.deepEqual(await handlers.get('pets:remove')?.({}, '../escape'), {
+      ok: false,
+      reason: 'invalid_id',
+    });
+
+    assert.deepEqual(await handlers.get('pets:remove')?.({}, 'likun.maodie'), {
+      ok: true,
+      removed: true,
+    });
+    assert.deepEqual(await handlers.get('pets:remove')?.({}, 'likun.maodie'), {
+      ok: true,
+      removed: false,
+    });
+    assert.deepEqual(await handlers.get('pets:list')?.(), []);
+    assert.deepEqual(events, [
+      {
+        type: 'pet_pack_changed',
+        reason: 'installed',
+        petId: 'likun.maodie',
+        ts: 84,
+      },
+      {
+        type: 'pet_pack_changed',
+        reason: 'removed',
+        petId: 'likun.maodie',
+        ts: 84,
+      },
+    ]);
   });
 });
 
@@ -168,6 +247,7 @@ test('IPC reports picker cancellation without touching storage', async () => {
     workspaceRoot: '/unused',
     mainWindowController: {
       showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
+      send: () => {},
     },
     store: {
       list: async () => [],

--- a/apps/desktop/src/main/pet-pack-import.ts
+++ b/apps/desktop/src/main/pet-pack-import.ts
@@ -15,7 +15,7 @@ import type { createMainWindowController } from './main-window.js';
 
 type MainWindowController = Pick<
   ReturnType<typeof createMainWindowController>,
-  'showOpenDialog'
+  'send' | 'showOpenDialog'
 >;
 
 export type PetPackImportFailureReason =
@@ -29,6 +29,21 @@ export type PetPackImportFailureReason =
 export type PetPackImportResult =
   | { readonly ok: true; readonly manifest: PetPackManifestV1 }
   | { readonly ok: false; readonly reason: PetPackImportFailureReason };
+
+export type PetPackSpriteSheetResult =
+  | {
+      readonly ok: true;
+      readonly mimeType: 'image/png' | 'image/webp';
+      readonly bytes: Uint8Array;
+    }
+  | {
+      readonly ok: false;
+      readonly reason: 'invalid_id' | 'not_found' | 'corrupt_pack' | 'read_failed';
+    };
+
+export type PetPackRemoveResult =
+  | { readonly ok: true; readonly removed: boolean }
+  | { readonly ok: false; readonly reason: 'invalid_id' | 'remove_failed' };
 
 export class PetPackImportError extends Error {
   readonly reason: Exclude<PetPackImportFailureReason, 'cancelled'>;
@@ -79,10 +94,48 @@ export function registerPetPackIpc(input: {
   readonly workspaceRoot: string;
   readonly mainWindowController: MainWindowController;
   readonly store?: PetPackStore;
+  readonly now?: () => number;
 }): void {
   const store = input.store ?? createPetPackStore(input.workspaceRoot);
+  const now = input.now ?? Date.now;
 
   input.ipcMain.handle('pets:list', () => store.list());
+  input.ipcMain.handle(
+    'pets:readSpriteSheet',
+    async (_event, petId: unknown): Promise<PetPackSpriteSheetResult> => {
+      if (typeof petId !== 'string') return { ok: false, reason: 'invalid_id' };
+      try {
+        const asset = await store.readSpriteSheet(petId);
+        if (!asset) return { ok: false, reason: 'not_found' };
+        return {
+          ok: true,
+          mimeType: asset.format === 'png' ? 'image/png' : 'image/webp',
+          bytes: asset.bytes,
+        };
+      } catch (error) {
+        return { ok: false, reason: spriteSheetFailureReason(error) };
+      }
+    },
+  );
+  input.ipcMain.handle(
+    'pets:remove',
+    async (_event, petId: unknown): Promise<PetPackRemoveResult> => {
+      if (typeof petId !== 'string') return { ok: false, reason: 'invalid_id' };
+      try {
+        const removed = await store.remove(petId);
+        if (removed) emitChanged(input.mainWindowController, 'removed', petId, now());
+        return { ok: true, removed };
+      } catch (error) {
+        return {
+          ok: false,
+          reason:
+            error instanceof PetPackStoreError && error.code === 'invalid_id'
+              ? 'invalid_id'
+              : 'remove_failed',
+        };
+      }
+    },
+  );
   input.ipcMain.handle('pets:importLocalDirectory', async (): Promise<PetPackImportResult> => {
     const selection = await input.mainWindowController.showOpenDialog({
       title: 'Import custom pet',
@@ -97,6 +150,7 @@ export function registerPetPackIpc(input: {
         sourceDirectory: selection.filePaths[0],
         store,
       });
+      emitChanged(input.mainWindowController, 'installed', manifest.id, now());
       return { ok: true, manifest };
     } catch (error) {
       return {
@@ -104,6 +158,29 @@ export function registerPetPackIpc(input: {
         reason: error instanceof PetPackImportError ? error.reason : 'read_failed',
       };
     }
+  });
+}
+
+function spriteSheetFailureReason(
+  error: unknown,
+): Extract<PetPackSpriteSheetResult, { readonly ok: false }>['reason'] {
+  if (!(error instanceof PetPackStoreError)) return 'read_failed';
+  if (error.code === 'invalid_id') return 'invalid_id';
+  if (error.code === 'corrupt_pack') return 'corrupt_pack';
+  return 'read_failed';
+}
+
+function emitChanged(
+  mainWindowController: MainWindowController,
+  reason: 'installed' | 'removed',
+  petId: string,
+  ts: number,
+): void {
+  mainWindowController.send('pets:changed', {
+    type: 'pet_pack_changed',
+    reason,
+    petId,
+    ts,
   });
 }
 

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -206,10 +206,28 @@ export type AppUpdateInstallResult =
  */
 export type WindowCommand = { id: 'newTask' | 'openSettings' | 'openHelp' };
 
+export interface PetPackChangedEvent {
+  readonly type: 'pet_pack_changed';
+  readonly reason: 'installed' | 'removed';
+  readonly petId: string;
+  readonly ts: number;
+}
+
 export interface MakaBridge {
 
   pets: {
     list(): Promise<PetPackManifestV1[]>;
+    readSpriteSheet(petId: string): Promise<
+      | { ok: true; mimeType: 'image/png' | 'image/webp'; bytes: Uint8Array }
+      | {
+          ok: false;
+          reason: 'invalid_id' | 'not_found' | 'corrupt_pack' | 'read_failed';
+        }
+    >;
+    remove(petId: string): Promise<
+      | { ok: true; removed: boolean }
+      | { ok: false; reason: 'invalid_id' | 'remove_failed' }
+    >;
     importLocalDirectory(): Promise<
       | { ok: true; manifest: PetPackManifestV1 }
       | {
@@ -223,6 +241,7 @@ export interface MakaBridge {
             | 'read_failed';
         }
     >;
+    subscribeChanges(handler: (event: PetPackChangedEvent) => void): () => void;
   };
 
   tasks: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -12,6 +12,7 @@ import type {
   AppUpdateInstallResult,
   AppUpdateStatus,
   WindowCommand,
+  PetPackChangedEvent,
 } from './bridge-contract.js';
 import type {
   ConnectionEvent,
@@ -129,8 +130,20 @@ const makaBridge = {
     list() {
       return ipcRenderer.invoke('pets:list');
     },
+    readSpriteSheet(petId: string) {
+      return ipcRenderer.invoke('pets:readSpriteSheet', petId);
+    },
+    remove(petId: string) {
+      return ipcRenderer.invoke('pets:remove', petId);
+    },
     importLocalDirectory() {
       return ipcRenderer.invoke('pets:importLocalDirectory');
+    },
+    subscribeChanges(handler: (event: PetPackChangedEvent) => void): () => void {
+      const listener = (_event: Electron.IpcRendererEvent, payload: PetPackChangedEvent) =>
+        handler(payload);
+      ipcRenderer.on('pets:changed', listener);
+      return () => ipcRenderer.off('pets:changed', listener);
     },
   },
   tasks: {


### PR DESCRIPTION
## Summary

- expose bounded sprite-sheet bytes to the renderer without base64 expansion
- add stable not-found, invalid-id, corrupt-pack, read, and remove result envelopes
- let users remove installed custom pets
- publish install and remove events, suppressing events for no-op removals
- add preload methods and a lifecycle-safe change subscription

## Testing

- desktop main TypeScript build
- preload TypeScript check
- 8 focused PetPack import and library tests
- full compiled desktop suite: 1766 tests passed
- console, accessibility, and copy checks passed

## Note

The broader local workspace dependency build still reaches the existing packages/ui/src/chat-surface-layout.tsx conversationKey type error; this PR does not touch that package.