### PR TITLE
feat(opencode-free): enable Mimo and DeepSeek free models by default

### DIFF
--- a/apps/desktop/e2e/onboarding.spec.ts
+++ b/apps/desktop/e2e/onboarding.spec.ts
@@ -47,7 +47,11 @@ test('first run connects a provider and starts the first task without workspace 
     .toEqual({
       defaultSlug: null,
       defaultModel: '',
-      enabledModelIds: ['nemotron-3-ultra-free'],
+      enabledModelIds: [
+        'nemotron-3-ultra-free',
+        'mimo-v2.5-free',
+        'deepseek-v4-flash-free',
+      ],
     });
   await page.getByRole('button', { name: '返回应用', exact: true }).click();
 

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -239,6 +239,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
         name: seed.name,
         providerType: seed.providerType,
         defaultModel: seed.defaultModel,
+        ...(seed.enabledModelIds ? { enabledModelIds: [...seed.enabledModelIds] } : {}),
         extras: seed.extras,
       });
       const envApiKey =

--- a/packages/core/src/__tests__/bootstrap-connections.test.ts
+++ b/packages/core/src/__tests__/bootstrap-connections.test.ts
@@ -17,6 +17,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
   OPENCODE_FREE_BOOTSTRAP_VERSION,
+  OPENCODE_FREE_DEFAULT_ENABLED_MODELS,
   OPENCODE_FREE_DEFAULT_MODEL,
   OPENCODE_FREE_LEGACY_DEFAULT_MODEL,
   resolveBootstrapConnections,
@@ -37,6 +38,7 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
       const seeds = resolveBootstrapConnections(env);
       const free = seeds.find((seed) => seed.slug === 'opencode-free');
       assert.equal(free?.defaultModel, OPENCODE_FREE_DEFAULT_MODEL);
+      assert.deepEqual(free?.enabledModelIds, [...OPENCODE_FREE_DEFAULT_ENABLED_MODELS]);
       assert.deepEqual(free?.extras, {
         makaBootstrap: { id: 'opencode-free', version: OPENCODE_FREE_BOOTSTRAP_VERSION },
       });
@@ -51,8 +53,16 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
     }
   });
 
-  it('migrates only the untouched historical OpenCode Free seed', () => {
-    const legacy: LlmConnection = {
+  it('migrates only the untouched historical OpenCode Free seed shapes', () => {
+    const currentPatch = {
+      defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
+      enabledModelIds: [...OPENCODE_FREE_DEFAULT_ENABLED_MODELS],
+      extras: {
+        makaBootstrap: { id: 'opencode-free', version: OPENCODE_FREE_BOOTSTRAP_VERSION },
+      },
+    };
+
+    const legacyV1: LlmConnection = {
       slug: 'opencode-free',
       name: 'OpenCode Free',
       providerType: 'opencode-free',
@@ -62,23 +72,44 @@ describe('resolveBootstrapConnections — zero-credential default seed', () => {
       createdAt: 1,
       updatedAt: 1,
     };
+    assert.deepEqual(resolveOpenCodeFreeBootstrapMigration(legacyV1), currentPatch);
 
-    const migration = resolveOpenCodeFreeBootstrapMigration(legacy);
-    assert.deepEqual(migration, {
+    const legacyV2: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
       defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
       enabledModelIds: [OPENCODE_FREE_DEFAULT_MODEL],
-      extras: {
-        makaBootstrap: { id: 'opencode-free', version: OPENCODE_FREE_BOOTSTRAP_VERSION },
-      },
-    });
-    assert.equal(resolveOpenCodeFreeBootstrapMigration({ ...legacy, ...migration }), undefined);
+      enabled: true,
+      extras: { makaBootstrap: { id: 'opencode-free', version: 2 } },
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    assert.deepEqual(resolveOpenCodeFreeBootstrapMigration(legacyV2), currentPatch);
+
+    // Already at the current bootstrap shape — no further migration.
+    assert.equal(
+      resolveOpenCodeFreeBootstrapMigration({
+        ...legacyV2,
+        ...currentPatch,
+      }),
+      undefined,
+    );
 
     for (const customized of [
-      { ...legacy, name: 'My free connection' },
-      { ...legacy, baseUrl: 'https://custom.example/v1' },
-      { ...legacy, enabledModelIds: [OPENCODE_FREE_LEGACY_DEFAULT_MODEL, 'custom-free'] },
-      { ...legacy, models: [{ id: OPENCODE_FREE_LEGACY_DEFAULT_MODEL }] },
-      { ...legacy, extras: { owner: 'user' } },
+      { ...legacyV1, name: 'My free connection' },
+      { ...legacyV1, baseUrl: 'https://custom.example/v1' },
+      { ...legacyV1, enabledModelIds: [OPENCODE_FREE_LEGACY_DEFAULT_MODEL, 'custom-free'] },
+      { ...legacyV1, models: [{ id: OPENCODE_FREE_LEGACY_DEFAULT_MODEL }] },
+      { ...legacyV1, extras: { owner: 'user' } },
+      {
+        ...legacyV2,
+        enabledModelIds: [OPENCODE_FREE_DEFAULT_MODEL, 'mimo-v2.5-free'],
+      },
+      {
+        ...legacyV2,
+        extras: { makaBootstrap: { id: 'opencode-free', version: 2 }, owner: 'user' },
+      },
     ]) {
       assert.equal(resolveOpenCodeFreeBootstrapMigration(customized), undefined);
     }

--- a/packages/core/src/bootstrap-connections.ts
+++ b/packages/core/src/bootstrap-connections.ts
@@ -16,8 +16,15 @@
 import type { LlmConnection, ProviderType, UpdateConnectionInput } from './llm-connections.js';
 
 export const OPENCODE_FREE_DEFAULT_MODEL = 'nemotron-3-ultra-free';
+/** Models enabled on a fresh OpenCode Free bootstrap (default first). */
+export const OPENCODE_FREE_DEFAULT_ENABLED_MODELS = [
+  OPENCODE_FREE_DEFAULT_MODEL,
+  'mimo-v2.5-free',
+  'deepseek-v4-flash-free',
+] as const;
 export const OPENCODE_FREE_LEGACY_DEFAULT_MODEL = 'big-pickle';
-export const OPENCODE_FREE_BOOTSTRAP_VERSION = 2;
+/** v1: big-pickle only; v2: nemotron only; v3: three free models enabled. */
+export const OPENCODE_FREE_BOOTSTRAP_VERSION = 3;
 
 const OPENCODE_FREE_BOOTSTRAP_EXTRAS = {
   makaBootstrap: { id: 'opencode-free', version: OPENCODE_FREE_BOOTSTRAP_VERSION },
@@ -28,6 +35,7 @@ export interface BootstrapConnectionSeed {
   readonly name: string;
   readonly providerType: ProviderType;
   readonly defaultModel: string;
+  readonly enabledModelIds?: readonly string[];
   readonly isDefault: boolean;
   readonly extras?: Record<string, unknown>;
 }
@@ -42,6 +50,7 @@ const OPENCODE_FREE_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
   name: 'OpenCode Free',
   providerType: 'opencode-free',
   defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
+  enabledModelIds: OPENCODE_FREE_DEFAULT_ENABLED_MODELS,
   extras: OPENCODE_FREE_BOOTSTRAP_EXTRAS,
 };
 
@@ -87,28 +96,59 @@ export function resolveBootstrapConnections(env: BootstrapEnv): readonly Bootstr
  * Migrate only the exact connection shape written by Maka's historical
  * OpenCode Free bootstrap. Any user-visible customization makes ownership
  * ambiguous and therefore fails closed.
+ *
+ * Recognized untouched shapes:
+ * - v1: `big-pickle` only, no extras
+ * - v2: `nemotron-3-ultra-free` only, bootstrap extras version 2
  */
 export function resolveOpenCodeFreeBootstrapMigration(
   connection: LlmConnection,
 ): UpdateConnectionInput | undefined {
-  if (
-    connection.slug !== 'opencode-free' ||
-    connection.name !== 'OpenCode Free' ||
-    connection.providerType !== 'opencode-free' ||
-    connection.baseUrl !== undefined ||
-    connection.defaultModel !== OPENCODE_FREE_LEGACY_DEFAULT_MODEL ||
-    connection.enabled !== true ||
-    connection.enabledModelIds?.length !== 1 ||
-    connection.enabledModelIds[0] !== OPENCODE_FREE_LEGACY_DEFAULT_MODEL ||
-    connection.models !== undefined ||
-    connection.extras !== undefined
-  ) {
-    return undefined;
-  }
+  if (!isUntouchedOpenCodeFreeBootstrapBase(connection)) return undefined;
+
+  const isLegacyV1 =
+    connection.defaultModel === OPENCODE_FREE_LEGACY_DEFAULT_MODEL &&
+    sameStringList(connection.enabledModelIds, [OPENCODE_FREE_LEGACY_DEFAULT_MODEL]) &&
+    connection.extras === undefined;
+
+  const isV2 =
+    connection.defaultModel === OPENCODE_FREE_DEFAULT_MODEL &&
+    sameStringList(connection.enabledModelIds, [OPENCODE_FREE_DEFAULT_MODEL]) &&
+    bootstrapVersion(connection) === 2;
+
+  if (!isLegacyV1 && !isV2) return undefined;
 
   return {
     defaultModel: OPENCODE_FREE_DEFAULT_MODEL,
-    enabledModelIds: [OPENCODE_FREE_DEFAULT_MODEL],
+    enabledModelIds: [...OPENCODE_FREE_DEFAULT_ENABLED_MODELS],
     extras: OPENCODE_FREE_BOOTSTRAP_EXTRAS,
   };
+}
+
+function isUntouchedOpenCodeFreeBootstrapBase(connection: LlmConnection): boolean {
+  return (
+    connection.slug === 'opencode-free' &&
+    connection.name === 'OpenCode Free' &&
+    connection.providerType === 'opencode-free' &&
+    connection.baseUrl === undefined &&
+    connection.enabled === true &&
+    connection.models === undefined
+  );
+}
+
+function bootstrapVersion(connection: LlmConnection): number | undefined {
+  const extras = connection.extras;
+  if (!extras || typeof extras !== 'object' || Array.isArray(extras)) return undefined;
+  const keys = Object.keys(extras);
+  if (keys.length !== 1 || keys[0] !== 'makaBootstrap') return undefined;
+  const bootstrap = extras.makaBootstrap;
+  if (!bootstrap || typeof bootstrap !== 'object' || Array.isArray(bootstrap)) return undefined;
+  const record = bootstrap as { id?: unknown; version?: unknown };
+  if (record.id !== 'opencode-free' || typeof record.version !== 'number') return undefined;
+  if (Object.keys(record).length !== 2) return undefined;
+  return record.version;
+}
+
+function sameStringList(actual: readonly string[] | undefined, expected: readonly string[]): boolean {
+  return actual?.length === expected.length && actual.every((id, index) => id === expected[index]);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1555,6 +1555,7 @@ export type {
 } from './bootstrap-connections.js';
 export {
   OPENCODE_FREE_BOOTSTRAP_VERSION,
+  OPENCODE_FREE_DEFAULT_ENABLED_MODELS,
   OPENCODE_FREE_DEFAULT_MODEL,
   OPENCODE_FREE_LEGACY_DEFAULT_MODEL,
   resolveBootstrapConnections,

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -505,6 +505,8 @@ export interface CreateConnectionInput {
   providerType: ProviderType;
   baseUrl?: string;
   defaultModel?: string;
+  /** When omitted, falls back to the default model alone. */
+  enabledModelIds?: string[];
   apiKey?: string;
   extras?: Record<string, unknown>;
 }

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -20,6 +20,28 @@ describe('FileConnectionStore', () => {
     });
   });
 
+  test('honors an explicit enabled model set on create', async () => {
+    await withConnectionStore(async (store) => {
+      const created = await store.create({
+        slug: 'opencode-free',
+        name: 'OpenCode Free',
+        providerType: 'opencode-free',
+        defaultModel: 'nemotron-3-ultra-free',
+        enabledModelIds: [
+          'nemotron-3-ultra-free',
+          'mimo-v2.5-free',
+          'deepseek-v4-flash-free',
+        ],
+      });
+
+      assert.deepEqual(created.enabledModelIds, [
+        'nemotron-3-ultra-free',
+        'mimo-v2.5-free',
+        'deepseek-v4-flash-free',
+      ]);
+    });
+  });
+
   test('migrates a legacy connection to only its default model enabled', async () => {
     await withConnectionStore(async (store, dir) => {
       await writeFile(
@@ -862,13 +884,21 @@ describe('FileConnectionStore', () => {
 
       const migrated = await store.updateIfUnchanged(created.slug, created.updatedAt, {
         defaultModel: 'nemotron-3-ultra-free',
-        enabledModelIds: ['nemotron-3-ultra-free'],
-        extras: { makaBootstrap: { id: 'opencode-free', version: 2 } },
+        enabledModelIds: [
+          'nemotron-3-ultra-free',
+          'mimo-v2.5-free',
+          'deepseek-v4-flash-free',
+        ],
+        extras: { makaBootstrap: { id: 'opencode-free', version: 3 } },
       });
       assert.equal(migrated?.defaultModel, 'nemotron-3-ultra-free');
-      assert.deepEqual(migrated?.enabledModelIds, ['nemotron-3-ultra-free']);
+      assert.deepEqual(migrated?.enabledModelIds, [
+        'nemotron-3-ultra-free',
+        'mimo-v2.5-free',
+        'deepseek-v4-flash-free',
+      ]);
       assert.deepEqual(migrated?.extras, {
-        makaBootstrap: { id: 'opencode-free', version: 2 },
+        makaBootstrap: { id: 'opencode-free', version: 3 },
       });
     });
   });

--- a/packages/storage/src/connection-store.ts
+++ b/packages/storage/src/connection-store.ts
@@ -81,7 +81,10 @@ class FileConnectionStore implements ConnectionStore {
         ...(baseUrl ? { baseUrl } : {}),
         defaultModel,
         enabled: true,
-        enabledModelIds: connectionEnabledModelIds({ defaultModel }),
+        enabledModelIds: connectionEnabledModelIds({
+          defaultModel,
+          enabledModelIds: input.enabledModelIds,
+        }),
         createdAt: now,
         updatedAt: now,
         ...(input.extras ? { extras: input.extras } : {}),


### PR DESCRIPTION
## Summary
- OpenCode Free bootstrap now enables three free models by default: `nemotron-3-ultra-free` (still the default), `mimo-v2.5-free`, and `deepseek-v4-flash-free`.
- Bootstrap version bumped to 3; untouched v1 (`big-pickle` only) and v2 (`nemotron` only) seeds migrate automatically. Any user customization fails closed.
- `CreateConnectionInput` / connection store `create` accept an explicit `enabledModelIds` set so the seed can write the multi-model inventory.

## Test plan
- [ ] Fresh install shows OpenCode Free with the three models enabled; default remains Nemotron 3 Ultra Free
- [ ] Existing untouched bootstrap (v1 or v2) upgrades to the three-model set on launch
- [ ] User-customized OpenCode Free connections are left alone