### PR TITLE
test(storage): enable long paths for bare Git fixtures

### DIFF
--- a/packages/storage/src/__tests__/git-workspace-service.test.ts
+++ b/packages/storage/src/__tests__/git-workspace-service.test.ts
@@ -818,11 +818,15 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
 }
 
 async function gitBare(repositoryPath: string, ...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync('git', ['--git-dir', repositoryPath, ...args], {
-    cwd: dirname(repositoryPath),
-    encoding: 'utf8',
-    maxBuffer: 8 * 1024 * 1024,
-  });
+  const { stdout } = await execFileAsync(
+    'git',
+    ['-c', 'core.longpaths=true', '--git-dir', repositoryPath, ...args],
+    {
+      cwd: dirname(repositoryPath),
+      encoding: 'utf8',
+      maxBuffer: 8 * 1024 * 1024,
+    },
+  );
   return stdout.trim();
 }
 


### PR DESCRIPTION
## Summary

- run bare-repository test Git commands with `core.longpaths=true`
- match the fixed Git runtime used by the managed workspace implementation
- keep the conflicting managed head-ref fixture valid under deeply nested Windows CI temp roots

Closes the remaining Git workspace failure tracked by #2142.

## Validation

- Core and Storage builds
- managed head-ref conflict test passes with `TEMP`/`TMP` nested to match the failing Actions path depth
- Biome format check
- `git diff --check`