### PR TITLE
feat(desktop): persist custom pet selection

### DIFF
--- a/apps/desktop/src/main/__tests__/pet-pack-import.test.ts
+++ b/apps/desktop/src/main/__tests__/pet-pack-import.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import { PET_PACK_SCHEMA_V1 } from '@maka/core/pet';
+import { createSettingsStore } from '@maka/storage';
 import { createPetPackStore } from '@maka/storage/pet-pack-store';
 import {
   importPetPackFromDirectory,
@@ -153,6 +154,7 @@ test('IPC imports only the native picker result and returns stable envelopes', a
         showOpenDialog: async () => ({ canceled: false, filePaths: [source] }),
         send: (channel, payload) => events.push({ channel, payload }),
       },
+      settingsStore: createSettingsStore(stateRoot),
       now: () => 42,
     });
 
@@ -178,6 +180,7 @@ test('IPC returns sprite bytes, removes the pack, and emits only real mutations'
     await writeSourcePack(source);
     const handlers = new Map<string, (...args: unknown[]) => unknown>();
     const events: unknown[] = [];
+    const settingsStore = createSettingsStore(stateRoot);
     registerPetPackIpc({
       ipcMain: {
         handle: (channel, handler) => handlers.set(channel, handler as (...args: unknown[]) => unknown),
@@ -187,9 +190,40 @@ test('IPC returns sprite bytes, removes the pack, and emits only real mutations'
         showOpenDialog: async () => ({ canceled: false, filePaths: [source] }),
         send: (_channel, payload) => events.push(payload),
       },
+      settingsStore,
       now: () => 84,
     });
+    await settingsStore.update({ personalization: { selectedPetId: 'likun.missing' } });
+    assert.equal(await handlers.get('pets:getSelection')?.({}), null);
+    assert.equal((await settingsStore.get()).personalization.selectedPetId, null);
     await handlers.get('pets:importLocalDirectory')?.({});
+
+    assert.deepEqual(await handlers.get('pets:select')?.({}, 'likun.unknown'), {
+      ok: false,
+      reason: 'not_found',
+    });
+    assert.deepEqual(await handlers.get('pets:select')?.({}, '../escape'), {
+      ok: false,
+      reason: 'invalid_id',
+    });
+    assert.deepEqual(await handlers.get('pets:select')?.({}, 'likun.maodie'), {
+      ok: true,
+      selectedPetId: 'likun.maodie',
+    });
+    assert.equal(await handlers.get('pets:getSelection')?.({}), 'likun.maodie');
+    assert.deepEqual(await handlers.get('pets:select')?.({}, 'likun.maodie'), {
+      ok: true,
+      selectedPetId: 'likun.maodie',
+    });
+    assert.deepEqual(await handlers.get('pets:select')?.({}, null), {
+      ok: true,
+      selectedPetId: null,
+    });
+    assert.equal(await handlers.get('pets:getSelection')?.({}), null);
+    assert.deepEqual(await handlers.get('pets:select')?.({}, 'likun.maodie'), {
+      ok: true,
+      selectedPetId: 'likun.maodie',
+    });
 
     const asset = (await handlers.get('pets:readSpriteSheet')?.({}, 'likun.maodie')) as {
       ok: true;
@@ -221,10 +255,30 @@ test('IPC returns sprite bytes, removes the pack, and emits only real mutations'
       removed: false,
     });
     assert.deepEqual(await handlers.get('pets:list')?.(), []);
+    assert.equal(await handlers.get('pets:getSelection')?.({}), null);
+    assert.equal((await settingsStore.get()).personalization.selectedPetId, null);
     assert.deepEqual(events, [
       {
         type: 'pet_pack_changed',
         reason: 'installed',
+        petId: 'likun.maodie',
+        ts: 84,
+      },
+      {
+        type: 'pet_pack_changed',
+        reason: 'selected',
+        petId: 'likun.maodie',
+        ts: 84,
+      },
+      {
+        type: 'pet_pack_changed',
+        reason: 'selected',
+        petId: null,
+        ts: 84,
+      },
+      {
+        type: 'pet_pack_changed',
+        reason: 'selected',
         petId: 'likun.maodie',
         ts: 84,
       },
@@ -248,6 +302,14 @@ test('IPC reports picker cancellation without touching storage', async () => {
     mainWindowController: {
       showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
       send: () => {},
+    },
+    settingsStore: {
+      get: async () => {
+        throw new Error('settings get must not run');
+      },
+      update: async () => {
+        throw new Error('settings update must not run');
+      },
     },
     store: {
       list: async () => [],

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -1137,7 +1137,7 @@ function registerIpc(): void {
     getSkillSelectionReport: systemPromptService.getLastSkillSelectionReport,
     invalidateSkillSelectionReport: systemPromptService.invalidateSkillSelectionReport,
   });
-  registerPetPackIpc({ ipcMain, workspaceRoot, mainWindowController });
+  registerPetPackIpc({ ipcMain, workspaceRoot, mainWindowController, settingsStore });
   registerWorkspaceSearchIpc({ getProjectRoot: resolveProjectRootForContext });
   registerPlanReminderIpc({ planReminders, getWorkspacePrivacyContext });
   registerAgentGraphIpc({

--- a/apps/desktop/src/main/pet-pack-import.ts
+++ b/apps/desktop/src/main/pet-pack-import.ts
@@ -11,6 +11,7 @@ import {
   PetPackStoreError,
   type PetPackStore,
 } from '@maka/storage/pet-pack-store';
+import type { SettingsStore } from '@maka/storage';
 import type { createMainWindowController } from './main-window.js';
 
 type MainWindowController = Pick<
@@ -44,6 +45,13 @@ export type PetPackSpriteSheetResult =
 export type PetPackRemoveResult =
   | { readonly ok: true; readonly removed: boolean }
   | { readonly ok: false; readonly reason: 'invalid_id' | 'remove_failed' };
+
+export type PetPackSelectResult =
+  | { readonly ok: true; readonly selectedPetId: string | null }
+  | {
+      readonly ok: false;
+      readonly reason: 'invalid_id' | 'not_found' | 'read_failed' | 'write_failed';
+    };
 
 export class PetPackImportError extends Error {
   readonly reason: Exclude<PetPackImportFailureReason, 'cancelled'>;
@@ -93,6 +101,7 @@ export function registerPetPackIpc(input: {
   readonly ipcMain: Pick<IpcMain, 'handle'>;
   readonly workspaceRoot: string;
   readonly mainWindowController: MainWindowController;
+  readonly settingsStore: Pick<SettingsStore, 'get' | 'update'>;
   readonly store?: PetPackStore;
   readonly now?: () => number;
 }): void {
@@ -100,6 +109,44 @@ export function registerPetPackIpc(input: {
   const now = input.now ?? Date.now;
 
   input.ipcMain.handle('pets:list', () => store.list());
+  input.ipcMain.handle('pets:getSelection', () =>
+    resolveSelectedPetId(input.settingsStore, store),
+  );
+  input.ipcMain.handle(
+    'pets:select',
+    async (_event, petId: unknown): Promise<PetPackSelectResult> => {
+      if (petId !== null && typeof petId !== 'string') {
+        return { ok: false, reason: 'invalid_id' };
+      }
+      if (petId !== null) {
+        try {
+          if (!(await store.get(petId))) return { ok: false, reason: 'not_found' };
+        } catch (error) {
+          return {
+            ok: false,
+            reason:
+              error instanceof PetPackStoreError && error.code === 'invalid_id'
+                ? 'invalid_id'
+                : 'read_failed',
+          };
+        }
+      }
+      try {
+        const current = await input.settingsStore.get();
+        if (current.personalization.selectedPetId === petId) {
+          return { ok: true, selectedPetId: petId };
+        }
+        const settings = await input.settingsStore.update({
+          personalization: { selectedPetId: petId },
+        });
+        const selectedPetId = settings.personalization.selectedPetId;
+        emitChanged(input.mainWindowController, 'selected', selectedPetId, now());
+        return { ok: true, selectedPetId };
+      } catch {
+        return { ok: false, reason: 'write_failed' };
+      }
+    },
+  );
   input.ipcMain.handle(
     'pets:readSpriteSheet',
     async (_event, petId: unknown): Promise<PetPackSpriteSheetResult> => {
@@ -123,7 +170,10 @@ export function registerPetPackIpc(input: {
       if (typeof petId !== 'string') return { ok: false, reason: 'invalid_id' };
       try {
         const removed = await store.remove(petId);
-        if (removed) emitChanged(input.mainWindowController, 'removed', petId, now());
+        if (removed) {
+          await clearSelectedPetIfMatching(input.settingsStore, petId);
+          emitChanged(input.mainWindowController, 'removed', petId, now());
+        }
         return { ok: true, removed };
       } catch (error) {
         return {
@@ -161,6 +211,35 @@ export function registerPetPackIpc(input: {
   });
 }
 
+async function resolveSelectedPetId(
+  settingsStore: Pick<SettingsStore, 'get' | 'update'>,
+  store: PetPackStore,
+): Promise<string | null> {
+  const selectedPetId = (await settingsStore.get()).personalization.selectedPetId;
+  if (selectedPetId === null) return null;
+  try {
+    if (await store.get(selectedPetId)) return selectedPetId;
+  } catch {
+    return null;
+  }
+  await clearSelectedPetIfMatching(settingsStore, selectedPetId);
+  return null;
+}
+
+async function clearSelectedPetIfMatching(
+  settingsStore: Pick<SettingsStore, 'get' | 'update'>,
+  petId: string,
+): Promise<void> {
+  try {
+    const settings = await settingsStore.get();
+    if (settings.personalization.selectedPetId !== petId) return;
+    await settingsStore.update({ personalization: { selectedPetId: null } });
+  } catch {
+    // The library mutation already committed. Reads still fail closed while
+    // this stale selection points at a missing pack.
+  }
+}
+
 function spriteSheetFailureReason(
   error: unknown,
 ): Extract<PetPackSpriteSheetResult, { readonly ok: false }>['reason'] {
@@ -172,8 +251,8 @@ function spriteSheetFailureReason(
 
 function emitChanged(
   mainWindowController: MainWindowController,
-  reason: 'installed' | 'removed',
-  petId: string,
+  reason: 'installed' | 'removed' | 'selected',
+  petId: string | null,
   ts: number,
 ): void {
   mainWindowController.send('pets:changed', {

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -238,7 +238,7 @@ mcpManager.onChange(() => {
 });
 
 registerPersistentClientIpc();
-registerPetPackIpc({ ipcMain, workspaceRoot, mainWindowController });
+registerPetPackIpc({ ipcMain, workspaceRoot, mainWindowController, settingsStore });
 registerBrowserIpc({ mainWindowController });
 registerNotificationsIpc({
   ipcMain,

--- a/apps/desktop/src/main/runtime-host-settings-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-settings-ipc-main.ts
@@ -364,9 +364,17 @@ function toClientOwnedPatch(
   patch: UpdateAppSettingsInput,
 ): UpdateAppSettingsInput {
   const personalization =
-    patch.personalization?.uiLocale === undefined
+    patch.personalization?.uiLocale === undefined &&
+    patch.personalization?.selectedPetId === undefined
       ? undefined
-      : { uiLocale: patch.personalization.uiLocale };
+      : {
+          ...(patch.personalization.uiLocale === undefined
+            ? {}
+            : { uiLocale: patch.personalization.uiLocale }),
+          ...(patch.personalization.selectedPetId === undefined
+            ? {}
+            : { selectedPetId: patch.personalization.selectedPetId }),
+        };
   return {
     ...(patch.botChat ? { botChat: patch.botChat } : {}),
     ...(patch.usage ? { usage: patch.usage } : {}),

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -202,8 +202,8 @@ export type WindowCommand = { id: 'newTask' | 'openSettings' | 'openHelp' };
 
 export interface PetPackChangedEvent {
   readonly type: 'pet_pack_changed';
-  readonly reason: 'installed' | 'removed';
-  readonly petId: string;
+  readonly reason: 'installed' | 'removed' | 'selected';
+  readonly petId: string | null;
   readonly ts: number;
 }
 
@@ -211,6 +211,14 @@ export interface MakaBridge {
 
   pets: {
     list(): Promise<PetPackManifestV1[]>;
+    getSelection(): Promise<string | null>;
+    select(petId: string | null): Promise<
+      | { ok: true; selectedPetId: string | null }
+      | {
+          ok: false;
+          reason: 'invalid_id' | 'not_found' | 'read_failed' | 'write_failed';
+        }
+    >;
     readSpriteSheet(petId: string): Promise<
       | { ok: true; mimeType: 'image/png' | 'image/webp'; bytes: Uint8Array }
       | {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -124,6 +124,12 @@ const makaBridge = {
     list() {
       return ipcRenderer.invoke('pets:list');
     },
+    getSelection() {
+      return ipcRenderer.invoke('pets:getSelection');
+    },
+    select(petId: string | null) {
+      return ipcRenderer.invoke('pets:select', petId);
+    },
     readSpriteSheet(petId: string) {
       return ipcRenderer.invoke('pets:readSpriteSheet', petId);
     },

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -142,6 +142,33 @@ describe('appearance settings boundaries', () => {
   });
 });
 
+describe('custom pet selection settings', () => {
+  test('stays disabled by default and preserves a canonical user selection', () => {
+    const defaults = createDefaultSettings();
+    expect(defaults.personalization.selectedPetId).toBe(null);
+
+    const selected = mergeSettings(defaults, {
+      personalization: { selectedPetId: 'likun.maodie' },
+    });
+    expect(selected.personalization.selectedPetId).toBe('likun.maodie');
+    expect(normalizeSettings(selected).personalization.selectedPetId).toBe('likun.maodie');
+  });
+
+  test('fails closed for missing, unsafe, or malformed persisted selections', () => {
+    for (const selectedPetId of [undefined, '../maodie', 'MAODIE', '', 42, {}]) {
+      const normalized = normalizeSettings({
+        personalization: {
+          displayName: '',
+          assistantTone: '',
+          uiLocale: 'auto',
+          selectedPetId,
+        },
+      });
+      expect(normalized.personalization.selectedPetId).toBe(null);
+    }
+  });
+});
+
 test('boolean settings default, normalize, and merge through their shared boundary', () => {
   const defaults = createDefaultSettings();
   expect(defaults.notifications.runComplete).toBe(true);

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -22,6 +22,7 @@ import {
   type UiLocalePreference,
 } from './ui-locale.js';
 import { normalizeSubagentSettings, type SubagentSettings } from './subagent-settings.js';
+import { isPetPackId } from './pet.js';
 
 export { UI_LOCALE_PREFERENCES, isUiLocalePreference } from './ui-locale.js';
 export type { UiLocalePreference } from './ui-locale.js';
@@ -184,6 +185,8 @@ export interface PersonalizationSettings {
    * stays for fixture tests. Defaults to `'auto'`.
    */
   uiLocale: UiLocalePreference;
+  /** User-selected custom PetPack. `null` keeps the pet surface disabled. */
+  selectedPetId: string | null;
 }
 
 /**
@@ -448,6 +451,7 @@ export function createDefaultSettings(): AppSettings {
       displayName: '',
       assistantTone: '',
       uiLocale: 'auto',
+      selectedPetId: null,
     },
     onboarding: {
       milestones: [],
@@ -494,6 +498,11 @@ export function mergeSettings(current: AppSettings, patch: UpdateAppSettingsInpu
     personalization: {
       ...current.personalization,
       ...(patch.personalization ?? {}),
+      selectedPetId: normalizeSelectedPetId(
+        patch.personalization?.selectedPetId === undefined
+          ? current.personalization.selectedPetId
+          : patch.personalization.selectedPetId,
+      ),
     },
     onboarding: {
       ...current.onboarding,
@@ -602,6 +611,7 @@ export function normalizeSettings(input: unknown): AppSettings {
       uiLocale: isUiLocalePreference(base.personalization.uiLocale)
         ? base.personalization.uiLocale
         : 'auto',
+      selectedPetId: normalizeSelectedPetId(base.personalization.selectedPetId),
     },
     botChat: normalizeBotChatSettings(base.botChat, value.botChat),
     onboarding: {
@@ -633,6 +643,10 @@ export function normalizeSettings(input: unknown): AppSettings {
     },
     subagents: normalizeSubagentSettings(base.subagents),
   };
+}
+
+function normalizeSelectedPetId(value: unknown): string | null {
+  return isPetPackId(value) ? value : null;
 }
 
 function normalizeWorkspaceInstructionsSettings(


### PR DESCRIPTION
## Summary

- add a fail-closed selectedPetId user setting with a null default
- keep custom pets disabled until the user explicitly selects an installed pack
- expose getSelection and select through the PetPack preload boundary
- reject unsafe and missing pack IDs before persistence
- clear stale selections for missing or removed packs
- emit selection changes while suppressing no-op re-selections

## Testing

- core suite: 808 tests passed
- desktop compiled suite: 1735 tests passed
- desktop main TypeScript build
- preload TypeScript check
- focused settings and PetPack selection tests
- console, accessibility, and copy checks passed

## Product default

No pet is selected by default. The user-owned likun.maodie pack is never treated as an official or bundled Maka pet.

## Note

The broader local workspace dependency build still reaches the existing packages/ui/src/chat-surface-layout.tsx conversationKey type error; this PR does not touch that package.