### PR TITLE
fix(storage): serialize root marker repair on Windows

### DIFF
--- a/packages/storage/src/__tests__/root-authority.test.ts
+++ b/packages/storage/src/__tests__/root-authority.test.ts
@@ -6,7 +6,6 @@ import {
   lstat,
   mkdir,
   mkdtemp,
-  open,
   readdir,
   readFile,
   rename,
@@ -18,7 +17,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { unlock, waitForLock } from 'fs-native-extensions';
+import { withArtifactWriterLock } from '../artifact-writer-lock.js';
 import {
   adoptStorageRootOnImport,
   assertStorageRootCapability,
@@ -232,7 +231,7 @@ describe('storage root authority', () => {
     });
   });
 
-  test('reopens the current marker when a concurrent repair replaces the locked inode', async () => {
+  test('serializes concurrent repairs across marker replacement', async () => {
     await withRoots(async ({ root }) => {
       await resolveStorageRoot({ path: root, kind: 'interactive' });
       const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
@@ -249,17 +248,10 @@ describe('storage root authority', () => {
       assert.ok(first);
       assert.ok(second);
 
-      const gate = await open(markerPath, 'r+');
-      await waitForLock(gate.fd);
-      const repairs = Promise.allSettled([
+      const results = await Promise.allSettled([
         repairStorageRootIdentity(first),
         repairStorageRootIdentity(second),
       ]);
-      await new Promise((resolve) => setTimeout(resolve, 50));
-      unlock(gate.fd);
-      await gate.close();
-
-      const results = await repairs;
       assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
       const rejected = results.find((result) => result.status === 'rejected');
       assert.ok(rejected);
@@ -269,6 +261,49 @@ describe('storage root authority', () => {
         rejected.reason.code === 'root_identity_changed' ||
           rejected.reason.code === 'root_identity_collision',
       );
+      await resolveStorageRoot({ path: root, kind: 'interactive' });
+    });
+  });
+
+  test('serializes identity repair behind the Artifact bootstrap writer lock', async () => {
+    await withRoots(async ({ root }) => {
+      await resolveStorageRoot({ path: root, kind: 'interactive' });
+      let releaseWriter!: () => void;
+      const writerBlocked = new Promise<void>((resolve) => {
+        releaseWriter = resolve;
+      });
+      let writerAdmitted!: () => void;
+      const admitted = new Promise<void>((resolve) => {
+        writerAdmitted = resolve;
+      });
+      const writer = withArtifactWriterLock(root, async () => {
+        writerAdmitted();
+        await writerBlocked;
+      });
+      await admitted;
+
+      const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+      const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+        rootIdentity: { dev: string };
+      };
+      marker.rootIdentity.dev = (BigInt(marker.rootIdentity.dev) + 1n).toString();
+      await writeFile(markerPath, `${JSON.stringify(marker)}\n`);
+      const candidate = await prepareStorageRootIdentityRepair({
+        path: root,
+        kind: 'interactive',
+      });
+      assert.ok(candidate);
+
+      let repairSettled = false;
+      const repair = repairStorageRootIdentity(candidate).finally(() => {
+        repairSettled = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      assert.equal(repairSettled, false);
+
+      releaseWriter();
+      await writer;
+      await repair;
       await resolveStorageRoot({ path: root, kind: 'interactive' });
     });
   });
@@ -683,7 +718,7 @@ describe('storage root authority', () => {
     });
   });
 
-  test('normalizes native lock setup failures at the public authority boundary', async () => {
+  test('rejects a directory at the owner lock path', async () => {
     await withRoots(async ({ root }) => {
       const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
       const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
@@ -692,9 +727,7 @@ describe('storage root authority', () => {
       await assert.rejects(
         () => tryAcquireInteractiveRootOwner(capability),
         (error: unknown) =>
-          error instanceof StorageRootAuthorityError &&
-          error.code === 'lock_failed' &&
-          error.cause instanceof Error,
+          error instanceof StorageRootAuthorityError && error.code === 'invalid_lock_artifact',
       );
     });
   });

--- a/packages/storage/src/artifact-writer-bootstrap-lock.ts
+++ b/packages/storage/src/artifact-writer-bootstrap-lock.ts
@@ -1,0 +1,65 @@
+/// <reference path="./fs-native-extensions.d.ts" />
+
+import { constants as fsConstants } from 'node:fs';
+import { lstat, open, type FileHandle } from 'node:fs/promises';
+import { unlock, waitForLock } from 'fs-native-extensions';
+
+const lockGates = new Map<string, Promise<void>>();
+
+export async function withArtifactWriterBootstrapLock<T>(
+  lockPath: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = lockGates.get(lockPath);
+  let releaseGate!: () => void;
+  const current = new Promise<void>((resolve) => {
+    releaseGate = resolve;
+  });
+  lockGates.set(lockPath, current);
+  await previous?.catch(() => {});
+  try {
+    const handle = await open(
+      lockPath,
+      fsConstants.O_CREAT | fsConstants.O_RDWR | fsConstants.O_NOFOLLOW,
+      0o600,
+    );
+    let locked = false;
+    try {
+      await assertStableRegularFile(handle, lockPath);
+      if (process.platform !== 'win32') await handle.chmod(0o600);
+      await waitForLock(handle.fd);
+      locked = true;
+      await assertStableRegularFile(handle, lockPath);
+      return await operation();
+    } finally {
+      if (locked) releaseLock(handle);
+      await handle.close();
+    }
+  } finally {
+    releaseGate();
+    if (lockGates.get(lockPath) === current) lockGates.delete(lockPath);
+  }
+}
+
+async function assertStableRegularFile(handle: FileHandle, lockPath: string): Promise<void> {
+  const [handleStat, pathStat] = await Promise.all([
+    handle.stat({ bigint: true }),
+    lstat(lockPath, { bigint: true }),
+  ]);
+  if (
+    !handleStat.isFile() ||
+    !pathStat.isFile() ||
+    handleStat.dev !== pathStat.dev ||
+    handleStat.ino !== pathStat.ino
+  ) {
+    throw new Error(`Artifact writer bootstrap lock is not one stable file: ${lockPath}`);
+  }
+}
+
+function releaseLock(handle: FileHandle): void {
+  try {
+    unlock(handle.fd);
+  } catch {
+    // Closing the OS handle is the authoritative release path.
+  }
+}

--- a/packages/storage/src/artifact-writer-lock.ts
+++ b/packages/storage/src/artifact-writer-lock.ts
@@ -5,6 +5,7 @@ import { lstat, mkdir, open, realpath, type FileHandle } from 'node:fs/promises'
 import { join } from 'node:path';
 import { unlock, waitForLock } from 'fs-native-extensions';
 import { ARTIFACT_WRITER_LOCK_FILE } from './artifact-storage-layout.js';
+import { withArtifactWriterBootstrapLock } from './artifact-writer-bootstrap-lock.js';
 import {
   prepareArtifactWriterBootstrapAuthority,
   prepareArtifactWriterLockAuthorityForMarkedRoot,
@@ -21,7 +22,7 @@ export async function withArtifactWriterLock<T>(
   await mkdir(workspaceRoot, { recursive: true });
   const requestedCanonicalRoot = await realpath(workspaceRoot);
   const bootstrap = await prepareArtifactWriterBootstrapAuthority(requestedCanonicalRoot);
-  return withBootstrapArtifactWriterLock(bootstrap.lockPath, async () => {
+  return withArtifactWriterBootstrapLock(bootstrap.lockPath, async () => {
     await bootstrap.assertCurrentRoot();
     const authority = await prepareArtifactWriterLockAuthorityForMarkedRoot(
       bootstrap.canonicalPath,
@@ -38,16 +39,9 @@ export async function withLeaseBoundArtifactWriterLock<T>(
   authority: ArtifactWriterLockAuthority,
   operation: () => Promise<T>,
 ): Promise<T> {
-  return withBootstrapArtifactWriterLock(authority.bootstrapLockPath, () =>
+  return withArtifactWriterBootstrapLock(authority.bootstrapLockPath, () =>
     withAuthorityArtifactWriterLock(authority, operation),
   );
-}
-
-async function withBootstrapArtifactWriterLock<T>(
-  lockPath: string,
-  operation: () => Promise<T>,
-): Promise<T> {
-  return withArtifactWriterLockPath(lockPath, operation);
 }
 
 async function withAuthorityArtifactWriterLock<T>(

--- a/packages/storage/src/root-authority.ts
+++ b/packages/storage/src/root-authority.ts
@@ -1,16 +1,16 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { type BigIntStats, constants as fsConstants } from 'node:fs';
+import type { BigIntStats } from 'node:fs';
 import { chmod, lstat, mkdir, open, realpath, stat, type FileHandle } from 'node:fs/promises';
 import { userInfo } from 'node:os';
 import { isAbsolute, join, normalize, parse, resolve } from 'node:path';
 import { tryLock, unlock, waitForLock } from 'fs-native-extensions';
 
+import { withArtifactWriterBootstrapLock } from './artifact-writer-bootstrap-lock.js';
 import { publishMarkerFile, readBoundedMarkerFile } from './marker-file.js';
 
 export const STORAGE_ROOT_MARKER_FILE = '.maka-storage-root.json';
 export const STORAGE_ROOT_MARKER_SCHEMA_VERSION = 1 as const;
 const MAX_STORAGE_ROOT_MARKER_BYTES = 1_024;
-const MAX_ROOT_MARKER_LOCK_ATTEMPTS = 2;
 const ARTIFACT_WRITER_BOOTSTRAP_DIRECTORY = 'artifact-writer-bootstrap';
 
 export type StorageRootKind = 'interactive' | 'headless';
@@ -691,6 +691,10 @@ async function acquireInteractiveRootLock(
   const capabilityRecord = requireCapability(capability, 'interactive');
   const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
   const lockPath = join(controlDirectory, 'owner.lock');
+  const existingLock = await lstatPathIfPresent(lockPath);
+  if (existingLock && !existingLock.isFile()) {
+    throw invalidLockArtifact(lockPath);
+  }
   const handle = await open(lockPath, 'a+', 0o600);
   try {
     await assertStableLockArtifact(handle, lockPath);
@@ -997,7 +1001,7 @@ async function replaceRootMarkerIdentity(
   identity: RootIdentity,
   sourceMarker: RootMarker,
 ): Promise<RootMarker> {
-  return withExclusiveRootMarker(root, sourceMarker.kind, async (current) => {
+  return withExclusiveRootMarker(root, identity, sourceMarker.kind, async (current) => {
     assertRootMarkerUnchanged(root, current, sourceMarker);
     const marker: RootMarker = {
       ...current,
@@ -1049,68 +1053,21 @@ async function replaceRootMarkerIdentity(
 
 async function withExclusiveRootMarker<T>(
   root: string,
+  identity: RootIdentity,
   expectedKind: StorageRootKind,
   operation: (marker: RootMarker) => Promise<T>,
 ): Promise<T> {
-  const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
-  for (let attempt = 0; attempt < MAX_ROOT_MARKER_LOCK_ATTEMPTS; attempt += 1) {
-    const handle = await openRootMarkerForWrite(root, markerPath);
-    let locked = false;
-    try {
-      await waitForLock(handle.fd);
-      locked = true;
-      const [handleStat, pathStat] = await Promise.all([
-        handle.stat({ bigint: true }),
-        lstat(markerPath, { bigint: true }),
-      ]);
-      if (
-        !handleStat.isFile() ||
-        !pathStat.isFile() ||
-        handleStat.size > BigInt(MAX_STORAGE_ROOT_MARKER_BYTES)
-      ) {
-        throw new StorageRootAuthorityError(
-          'invalid_marker',
-          `Storage root marker must be one bounded regular file: ${markerPath}`,
-        );
-      }
-      if (handleStat.dev !== pathStat.dev || handleStat.ino !== pathStat.ino) {
-        if (attempt + 1 < MAX_ROOT_MARKER_LOCK_ATTEMPTS) continue;
-        throw new StorageRootAuthorityError(
-          'root_identity_changed',
-          `Storage root marker changed while acquiring its lock: ${root}`,
-        );
-      }
-      const marker = parseRootMarker(await handle.readFile('utf8'), markerPath);
-      if (marker.kind !== expectedKind) {
-        throw new StorageRootAuthorityError(
-          'root_kind_mismatch',
-          `Storage root ${root} is ${marker.kind}, not ${expectedKind}`,
-        );
-      }
-      return await operation(marker);
-    } finally {
-      if (locked) unlock(handle.fd);
-      await handle.close();
-    }
-  }
-  throw new StorageRootAuthorityError(
-    'root_identity_changed',
-    `Storage root marker changed while acquiring its lock: ${root}`,
-  );
-}
-
-async function openRootMarkerForWrite(root: string, markerPath: string): Promise<FileHandle> {
-  try {
-    return await open(markerPath, markerWriteFlags());
-  } catch (error) {
-    if (isNodeError(error, 'ENOENT')) {
-      throw new StorageRootAuthorityError('root_unmarked', `Storage root is not marked: ${root}`);
-    }
-    if (isInvalidMarkerPathError(error)) {
-      throw invalidRootMarker(markerPath, error);
-    }
-    throw error;
-  }
+  const controlRoot = await preparePrivateControlRoot();
+  const lockPath = await prepareArtifactWriterBootstrapLockPathForIdentity(controlRoot, identity);
+  return withArtifactWriterBootstrapLock(lockPath, async () => {
+    await assertRootPathIdentity(
+      root,
+      identity,
+      `Storage root identity changed while acquiring its marker publication lock: ${root}`,
+    );
+    const marker = await readAndValidateRootMarker(root, expectedKind);
+    return operation(marker);
+  });
 }
 
 function assertRootMarkerUnchanged(root: string, current: RootMarker, expected: RootMarker): void {
@@ -1120,10 +1077,6 @@ function assertRootMarkerUnchanged(root: string, current: RootMarker, expected: 
       `Storage root marker changed while updating its identity: ${root}`,
     );
   }
-}
-
-function markerWriteFlags(): number {
-  return fsConstants.O_RDWR | (fsConstants.O_NONBLOCK ?? 0) | (fsConstants.O_NOFOLLOW ?? 0);
 }
 
 function invalidRootMarker(markerPath: string, cause?: unknown): StorageRootAuthorityError {
@@ -1315,11 +1268,15 @@ async function assertStableLockArtifact(handle: FileHandle, path: string): Promi
     if (!isMissingPathError(error)) throw error;
   }
   if (!stable) {
-    throw new StorageRootAuthorityError(
-      'invalid_lock_artifact',
-      `Storage root lock path is not one stable regular file: ${path}`,
-    );
+    throw invalidLockArtifact(path);
   }
+}
+
+function invalidLockArtifact(path: string): StorageRootAuthorityError {
+  return new StorageRootAuthorityError(
+    'invalid_lock_artifact',
+    `Storage root lock path is not one stable regular file: ${path}`,
+  );
 }
 
 function releaseLock(handle: FileHandle): void {
@@ -1353,6 +1310,15 @@ function isInvalidMarkerPathError(error: unknown): boolean {
 async function statRootIfPresent(path: string): Promise<BigIntStats | undefined> {
   try {
     return await stat(path, { bigint: true });
+  } catch (error) {
+    if (isMissingPathError(error)) return undefined;
+    throw error;
+  }
+}
+
+async function lstatPathIfPresent(path: string): Promise<BigIntStats | undefined> {
+  try {
+    return await lstat(path, { bigint: true });
   } catch (error) {
     if (isMissingPathError(error)) return undefined;
     throw error;


### PR DESCRIPTION
## Summary

- serialize root marker identity repair with the stable Artifact writer bootstrap lock
- revalidate root identity and marker state before atomic marker publication
- reject non-file interactive owner lock artifacts consistently across platforms
- cover concurrent repair, writer-lock coordination, and invalid owner-lock artifacts

## Root cause

Windows cannot reliably reread or atomically replace the marker while the marker file itself is exclusively locked. Reads can fail with `EBUSY`, and replacement can fail with `EPERM`. A stable external lock keyed by the real root identity provides serialization without locking the file being replaced.

## Validation

- root-authority test file, three consecutive runs: `24 pass / 0 fail / 7 skip`
- root-authority + marker-file + artifact-writer-lock: `38 pass / 0 fail / 10 skip`
- `npm run build`
- `npm run typecheck`
- Biome format and lint checks
- `git diff --check`
- full Storage suite: `692 pass / 9 fail / 47 skip`; no failures in the root-authority, marker, or artifact-writer groups

The remaining full-suite failures are existing Windows/environment backlog and are not presented as green by this PR.

Relates to #2142.