### PR TITLE
feat(desktop): manage custom pets in settings

### DIFF
--- a/apps/desktop/src/main/__tests__/custom-pet-library-model.test.ts
+++ b/apps/desktop/src/main/__tests__/custom-pet-library-model.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { PetPackManifestV1 } from '@maka/core';
+import {
+  reconcileCustomPetLibrary,
+  removeCustomPet,
+  upsertCustomPet,
+} from '../../renderer/settings/custom-pet-library-model.js';
+
+function manifest(id: string, displayName = id): PetPackManifestV1 {
+  return {
+    schema: 'maka.pet/v1',
+    id,
+    displayName,
+    spriteSheet: {
+      path: 'sprites.png',
+      format: 'png',
+      frameWidth: 32,
+      frameHeight: 32,
+      columns: 5,
+      rows: 1,
+      frameCount: 5,
+    },
+    animations: {
+      idle: { frames: [0], fps: 1, loop: true },
+      working: { frames: [1], fps: 1, loop: true },
+      'needs-input': { frames: [2], fps: 1, loop: true },
+      ready: { frames: [3], fps: 1, loop: true },
+      blocked: { frames: [4], fps: 1, loop: true },
+    },
+  };
+}
+
+describe('custom pet library settings model', () => {
+  it('fails closed when selection and installed packs are observed across a remove event', () => {
+    const snapshot = reconcileCustomPetLibrary(
+      [manifest('likun.other')],
+      'likun.maodie',
+    );
+
+    assert.equal(snapshot.selectedPetId, null);
+    assert.deepEqual(snapshot.pets.map((pet) => pet.id), ['likun.other']);
+  });
+
+  it('keeps one actionable row per id while preserving store order', () => {
+    const first = manifest('likun.maodie', '耄耋');
+    const duplicate = manifest('likun.maodie', 'duplicate');
+    const other = manifest('likun.other');
+
+    const snapshot = reconcileCustomPetLibrary([first, duplicate, other], first.id);
+
+    assert.deepEqual(snapshot.pets, [first, other]);
+    assert.equal(snapshot.selectedPetId, first.id);
+  });
+
+  it('reconciles import and removal without leaving a removed pack selected', () => {
+    const maodie = manifest('likun.maodie', '耄耋');
+    const imported = upsertCustomPet(
+      { pets: [], selectedPetId: null },
+      maodie,
+    );
+    const selected = { ...imported, selectedPetId: maodie.id };
+
+    assert.deepEqual(imported.pets, [maodie]);
+    assert.deepEqual(removeCustomPet(selected, maodie.id), {
+      pets: [],
+      selectedPetId: null,
+    });
+  });
+});

--- a/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
@@ -43,6 +43,8 @@ export type SettingsPreferencesCopy = {
     themeHelp: string;
     palette: string;
     paletteHelp: string;
+    pets: string;
+    petsHelp: string;
   };
   appearance: {
     saveFailed: string;
@@ -53,6 +55,48 @@ export type SettingsPreferencesCopy = {
     paletteHelp: Record<ThemePalette, string>;
     paletteGroups: { editor: string; product: string };
     persistenceHelp: string;
+  };
+  pets: {
+    import: string;
+    importing: string;
+    loading: string;
+    status: string;
+    activePet(name: string): string;
+    disabled: string;
+    disable: string;
+    disabling: string;
+    empty: string;
+    emptyHelp: string;
+    selected: string;
+    select: string;
+    selecting: string;
+    remove: string;
+    removing: string;
+    removeTitle(name: string): string;
+    removeDescription: string;
+    confirmRemove: string;
+    cancel: string;
+    loadFailed: string;
+    importFailed: string;
+    selectFailed: string;
+    removeFailed: string;
+    importErrors: {
+      invalid_directory: string;
+      invalid_manifest: string;
+      invalid_asset: string;
+      already_installed: string;
+      read_failed: string;
+    };
+    selectErrors: {
+      invalid_id: string;
+      not_found: string;
+      read_failed: string;
+      write_failed: string;
+    };
+    removeErrors: {
+      invalid_id: string;
+      remove_failed: string;
+    };
   };
   general: {
     incognito: string;
@@ -146,6 +190,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       network: '网络', networkHelp: 'AI 模型请求走的网络通道。',
       theme: '主题', themeHelp: '界面跟随系统，还是固定浅色或深色。',
       palette: '调色板', paletteHelp: '强调色与画布色调；切换会立即生效并保存在本地。',
+      pets: '自定义宠物', petsHelp: '管理你自己导入的 PetPack。Maka 不预装、也不默认启用任何宠物。',
     },
     appearance: {
       saveFailed: '保存外观设置失败', theme: '主题', palette: '调色板',
@@ -153,6 +198,17 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       paletteLabels: { default: '默认', onedark: 'One Dark', 'catppuccin-mocha': 'Catppuccin Mocha', 'tokyo-night': 'Tokyo Night', nord: 'Nord', coral: '珊瑚', azure: '湖蓝', forest: '森林', dusk: '暮光', sand: '沙金', mono: '极简灰' },
       paletteHelp: { default: 'Maka 品牌蓝强调色', onedark: '编辑器经典深色', 'catppuccin-mocha': '紫调柔和深色', 'tokyo-night': '深蓝主题', nord: '北欧冷色', coral: '暖粉 / 珊瑚强调色', azure: '湖蓝强调色，干净冷静', forest: '深苔绿与暖蜂蜜强调色', dusk: '深紫罗兰与冷调画布', sand: '琥珀沙金与暖奶白', mono: '纯灰阶，无彩色干扰' },
       paletteGroups: { editor: '编辑器主题', product: '产品色调' }, persistenceHelp: '切换会立即生效，并保存在本地外观设置里供下次启动使用。',
+    },
+    pets: {
+      import: '导入 PetPack', importing: '正在导入…', loading: '正在载入自定义宠物…',
+      status: '桌面宠物', activePet: (name) => `当前使用：${name}`, disabled: '已关闭', disable: '关闭宠物', disabling: '正在关闭…',
+      empty: '还没有导入宠物', emptyHelp: '选择一个包含 pet.json 和精灵图的本地文件夹。',
+      selected: '正在使用', select: '使用', selecting: '正在切换…', remove: '删除', removing: '正在删除…',
+      removeTitle: (name) => `删除“${name}”？`, removeDescription: '这会删除 Maka 本地保存的该宠物包，且无法撤销。原始文件夹不会受影响。', confirmRemove: '删除', cancel: '取消',
+      loadFailed: '无法载入自定义宠物', importFailed: '导入宠物失败', selectFailed: '切换宠物失败', removeFailed: '删除宠物失败',
+      importErrors: { invalid_directory: '所选文件夹无效。', invalid_manifest: 'pet.json 不符合 maka.pet/v1 格式。', invalid_asset: '精灵图缺失、无效或超出限制。', already_installed: '已经导入了相同 ID 的宠物。', read_failed: '无法读取所选文件夹。' },
+      selectErrors: { invalid_id: '宠物 ID 无效。', not_found: '该宠物已不在本地宠物库中。', read_failed: '无法读取宠物库。', write_failed: '无法保存宠物选择。' },
+      removeErrors: { invalid_id: '宠物 ID 无效。', remove_failed: '无法删除本地宠物包。' },
     },
     general: {
       incognito: '隐身模式', incognitoHelp: '开启后暂停本地记忆读写、联网搜索和计划提醒触发。', enableIncognito: '启用隐身模式', incognitoFailed: '隐身模式切换失败', notifications: '完成时发送系统通知', notificationsHelp: '窗口不在前台时，在回答完成或出错后发送桌面通知。', notificationsFailed: '通知设置切换失败', workspaceInstructions: '遵循项目指令', workspaceInstructionsHelp: '自动读取每个项目中已有的 AGENTS.md、CLAUDE.md 或 GEMINI.md；文件仍由各自项目管理。', workspaceInstructionsFailed: '项目指令设置切换失败', updateFailed: '设置未生效，请稍后重试。',
@@ -175,9 +231,21 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       network: 'Network', networkHelp: 'The network path AI model requests take.',
       theme: 'Theme', themeHelp: 'Follow the system appearance, or stay on light or dark.',
       palette: 'Color palette', paletteHelp: 'Accent and canvas colors. Changes apply immediately and are saved locally.',
+      pets: 'Custom pets', petsHelp: 'Manage PetPacks you import yourself. Maka does not bundle or enable any pet by default.',
     },
     appearance: {
       saveFailed: 'Could not save appearance settings', theme: 'Theme', palette: 'Color palette', themeOptions: { light: { label: 'Light', help: 'Always use the light interface.' }, dark: { label: 'Dark', help: 'Always use the dark interface.' }, auto: { label: 'Follow system', help: 'Match the current system appearance.' } }, paletteLabels: { default: 'Default', onedark: 'One Dark', 'catppuccin-mocha': 'Catppuccin Mocha', 'tokyo-night': 'Tokyo Night', nord: 'Nord', coral: 'Coral', azure: 'Azure', forest: 'Forest', dusk: 'Dusk', sand: 'Sand', mono: 'Monochrome' }, paletteHelp: { default: 'Maka brand-blue accent', onedark: 'Classic dark editor theme', 'catppuccin-mocha': 'Soft purple dark theme', 'tokyo-night': 'Deep-blue editor theme', nord: 'Cool Nordic colors', coral: 'Warm pink and coral accent', azure: 'Clean, calm blue accent', forest: 'Deep moss and warm honey', dusk: 'Deep violet on a cool canvas', sand: 'Amber sand and warm ivory', mono: 'Pure grayscale without color distraction' }, paletteGroups: { editor: 'Editor themes', product: 'Product colors' }, persistenceHelp: 'Changes apply immediately and are saved locally for the next launch.',
+    },
+    pets: {
+      import: 'Import PetPack', importing: 'Importing…', loading: 'Loading custom pets…',
+      status: 'Desktop pet', activePet: (name) => `Currently using: ${name}`, disabled: 'Off', disable: 'Turn off pet', disabling: 'Turning off…',
+      empty: 'No pets imported yet', emptyHelp: 'Choose a local folder containing pet.json and a sprite sheet.',
+      selected: 'In use', select: 'Use', selecting: 'Switching…', remove: 'Remove', removing: 'Removing…',
+      removeTitle: (name) => `Remove “${name}”?`, removeDescription: 'This removes Maka’s local copy of the pet pack and cannot be undone. The original folder is not affected.', confirmRemove: 'Remove', cancel: 'Cancel',
+      loadFailed: 'Could not load custom pets', importFailed: 'Could not import pet', selectFailed: 'Could not switch pet', removeFailed: 'Could not remove pet',
+      importErrors: { invalid_directory: 'The selected folder is invalid.', invalid_manifest: 'pet.json does not match the maka.pet/v1 format.', invalid_asset: 'The sprite sheet is missing, invalid, or outside the supported limits.', already_installed: 'A pet with the same ID is already installed.', read_failed: 'The selected folder could not be read.' },
+      selectErrors: { invalid_id: 'The pet ID is invalid.', not_found: 'That pet is no longer in the local library.', read_failed: 'The pet library could not be read.', write_failed: 'The pet selection could not be saved.' },
+      removeErrors: { invalid_id: 'The pet ID is invalid.', remove_failed: 'The local pet pack could not be removed.' },
     },
     general: {
       incognito: 'Incognito mode', incognitoHelp: 'Pause local memory, web search, and scheduled reminder triggers.', enableIncognito: 'Enable incognito mode', incognitoFailed: 'Could not change incognito mode', notifications: 'Send a system notification when finished', notificationsHelp: 'Notify when a response finishes or fails while the window is in the background.', notificationsFailed: 'Could not change notification settings', workspaceInstructions: 'Follow project instructions', workspaceInstructionsHelp: 'Automatically read existing AGENTS.md, CLAUDE.md, or GEMINI.md files in each project. Manage the files in their respective projects.', workspaceInstructionsFailed: 'Could not change project instruction settings', updateFailed: 'The setting was not applied. Try again later.', defaultModel: 'Default model', defaultModelHelp: 'Model used by new conversations.', notSet: 'Not set', saveDefaultModelFailed: 'Could not save the default model', defaultPermission: 'Default permission mode', defaultPermissionHelp: 'Initial permission mode for new conversations; it can be changed at any time.', saveDefaultPermissionFailed: 'Could not save the default permission mode', defaultThinking: 'Default thinking level', defaultThinkingHelp: 'Thinking level for new conversations; models that do not offer the chosen level use their own default.', followModelDefault: 'Follow model default', saveDefaultThinkingFailed: 'Could not save the default thinking level', proxy: 'Proxy server', proxyHelp: 'Configure a network proxy for AI model requests', enableProxy: 'Enable proxy server', saveNetworkFailed: 'Could not save network settings', proxyProtocol: 'Proxy protocol', serverAddress: 'Server address', port: 'Port', proxyAuth: 'Proxy authentication', proxyAuthHelp: 'Enable this when a username and password are required.', enableProxyAuth: 'Enable proxy authentication', username: 'Username', password: 'Password', bypassList: 'Proxy bypass list', bypassHelp: 'These domains connect directly. Separate multiple domains with commas.', autoBypass: (count) => `${count} ${count === 1 ? 'domain was' : 'domains were'} added automatically. The proxy applies to AI model requests only.`, testing: 'Testing…', testCurrent: 'Test current configuration', proxyReachable: 'Proxy is reachable', proxyTestFailed: 'Proxy test failed', proxyTestError: 'Could not test proxy',

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -28,6 +28,7 @@ import {
 } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { getSettingsPreferencesCopy } from '../locales/settings-preferences-copy.js';
+import { CustomPetSettingsSection } from './custom-pet-settings-section.js';
 
 export function AppearanceSettingsPage(props: {
   themePref: ThemePreference;
@@ -456,6 +457,8 @@ function ThemeSettingsPage(props: {
           </VStack>
         ))}
       </SettingsSection>
+
+      <CustomPetSettingsSection />
     </SettingsPage>
   );
 }

--- a/apps/desktop/src/renderer/settings/custom-pet-library-model.ts
+++ b/apps/desktop/src/renderer/settings/custom-pet-library-model.ts
@@ -1,0 +1,54 @@
+import type { PetPackManifestV1 } from '@maka/core';
+
+export interface CustomPetLibrarySnapshot {
+  readonly pets: readonly PetPackManifestV1[];
+  readonly selectedPetId: string | null;
+}
+
+/**
+ * Treat the installed pack list as the authority for selection. The settings
+ * store already repairs stale selections, but this renderer can observe the
+ * list and selection on opposite sides of a remove event. Failing closed here
+ * avoids briefly presenting a missing pack as active.
+ *
+ * Duplicate ids are also collapsed defensively. A healthy store cannot emit
+ * them, but one row per actionable id keeps the UI deterministic if a damaged
+ * library is recovered in place.
+ */
+export function reconcileCustomPetLibrary(
+  manifests: readonly PetPackManifestV1[],
+  selectedPetId: string | null,
+): CustomPetLibrarySnapshot {
+  const byId = new Map<string, PetPackManifestV1>();
+  for (const manifest of manifests) {
+    if (!byId.has(manifest.id)) byId.set(manifest.id, manifest);
+  }
+  const pets = [...byId.values()];
+  return {
+    pets,
+    selectedPetId: selectedPetId !== null && byId.has(selectedPetId)
+      ? selectedPetId
+      : null,
+  };
+}
+
+export function upsertCustomPet(
+  snapshot: CustomPetLibrarySnapshot,
+  manifest: PetPackManifestV1,
+): CustomPetLibrarySnapshot {
+  const existingIndex = snapshot.pets.findIndex((pet) => pet.id === manifest.id);
+  const pets = [...snapshot.pets];
+  if (existingIndex === -1) pets.push(manifest);
+  else pets[existingIndex] = manifest;
+  return reconcileCustomPetLibrary(pets, snapshot.selectedPetId);
+}
+
+export function removeCustomPet(
+  snapshot: CustomPetLibrarySnapshot,
+  petId: string,
+): CustomPetLibrarySnapshot {
+  return reconcileCustomPetLibrary(
+    snapshot.pets.filter((pet) => pet.id !== petId),
+    snapshot.selectedPetId,
+  );
+}

--- a/apps/desktop/src/renderer/settings/custom-pet-settings-section.tsx
+++ b/apps/desktop/src/renderer/settings/custom-pet-settings-section.tsx
@@ -1,0 +1,240 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Badge, Button, useMountedRef, useToast, useUiLocale } from '@maka/ui';
+import { SettingsRow, SettingsSection } from './settings-section';
+import { settingsActionErrorMessage } from './settings-error-copy';
+import { getSettingsPreferencesCopy } from '../locales/settings-preferences-copy.js';
+import {
+  reconcileCustomPetLibrary,
+  removeCustomPet,
+  upsertCustomPet,
+  type CustomPetLibrarySnapshot,
+} from './custom-pet-library-model.js';
+
+const EMPTY_LIBRARY: CustomPetLibrarySnapshot = {
+  pets: [],
+  selectedPetId: null,
+};
+
+type PetMutation =
+  | 'import'
+  | 'disable'
+  | `select:${string}`
+  | `remove:${string}`;
+
+export function CustomPetSettingsSection() {
+  const locale = useUiLocale();
+  const preferencesCopy = getSettingsPreferencesCopy(locale);
+  const copy = preferencesCopy.pets;
+  const sections = preferencesCopy.sections;
+  const toast = useToast();
+  const mountedRef = useMountedRef();
+  const refreshTicketRef = useRef(0);
+  const [library, setLibrary] = useState<CustomPetLibrarySnapshot>(EMPTY_LIBRARY);
+  const [loading, setLoading] = useState(true);
+  const [mutation, setMutation] = useState<PetMutation | null>(null);
+
+  const refreshLibrary = useCallback(async (options?: {
+    showLoading?: boolean;
+    reportError?: boolean;
+  }) => {
+    const ticket = ++refreshTicketRef.current;
+    if (options?.showLoading && mountedRef.current) setLoading(true);
+    try {
+      const [pets, selectedPetId] = await Promise.all([
+        window.maka.pets.list(),
+        window.maka.pets.getSelection(),
+      ]);
+      if (mountedRef.current && ticket === refreshTicketRef.current) {
+        setLibrary(reconcileCustomPetLibrary(pets, selectedPetId));
+      }
+    } catch (error) {
+      if (
+        options?.reportError
+        && mountedRef.current
+        && ticket === refreshTicketRef.current
+      ) {
+        toast.error(copy.loadFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      if (mountedRef.current && ticket === refreshTicketRef.current) {
+        setLoading(false);
+      }
+    }
+  }, [copy.loadFailed, locale, mountedRef, toast]);
+
+  useEffect(() => {
+    void refreshLibrary({ showLoading: true, reportError: true });
+    const unsubscribe = window.maka.pets.subscribeChanges(() => {
+      // The event is only an invalidation signal. Re-read both authorities so
+      // install/remove/select events from another window converge identically.
+      void refreshLibrary();
+    });
+    return () => {
+      refreshTicketRef.current += 1;
+      unsubscribe();
+    };
+  }, [refreshLibrary]);
+
+  async function importPet() {
+    refreshTicketRef.current += 1;
+    setMutation('import');
+    try {
+      const result = await window.maka.pets.importLocalDirectory();
+      if (!mountedRef.current) return;
+      if (!result.ok) {
+        if (result.reason !== 'cancelled') {
+          toast.error(copy.importFailed, copy.importErrors[result.reason]);
+        }
+        return;
+      }
+      // Import and enable remain separate user choices. Installing a pack must
+      // never silently replace the pet the user already selected.
+      setLibrary((current) => upsertCustomPet(current, result.manifest));
+      await refreshLibrary();
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(copy.importFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      if (mountedRef.current) setMutation(null);
+    }
+  }
+
+  async function selectPet(petId: string | null) {
+    refreshTicketRef.current += 1;
+    setMutation(petId === null ? 'disable' : `select:${petId}`);
+    try {
+      const result = await window.maka.pets.select(petId);
+      if (!mountedRef.current) return;
+      if (!result.ok) {
+        toast.error(copy.selectFailed, copy.selectErrors[result.reason]);
+        return;
+      }
+      setLibrary((current) => reconcileCustomPetLibrary(
+        current.pets,
+        result.selectedPetId,
+      ));
+      await refreshLibrary();
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(copy.selectFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      if (mountedRef.current) setMutation(null);
+    }
+  }
+
+  async function requestRemovePet(petId: string) {
+    const pet = library.pets.find((candidate) => candidate.id === petId);
+    if (!pet) return;
+    const confirmed = await toast.confirm({
+      title: copy.removeTitle(pet.displayName),
+      description: copy.removeDescription,
+      confirmLabel: copy.confirmRemove,
+      cancelLabel: copy.cancel,
+      destructive: true,
+    });
+    if (!confirmed || !mountedRef.current) return;
+
+    refreshTicketRef.current += 1;
+    setMutation(`remove:${petId}`);
+    try {
+      const result = await window.maka.pets.remove(petId);
+      if (!mountedRef.current) return;
+      if (!result.ok) {
+        toast.error(copy.removeFailed, copy.removeErrors[result.reason]);
+        return;
+      }
+      setLibrary((current) => removeCustomPet(current, petId));
+      await refreshLibrary();
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(copy.removeFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      if (mountedRef.current) setMutation(null);
+    }
+  }
+
+  const selectedPet = library.pets.find((pet) => pet.id === library.selectedPetId);
+  const actionDisabled = loading || mutation !== null;
+
+  return (
+    <SettingsSection
+      title={sections.pets}
+      description={sections.petsHelp}
+      action={(
+        <Button
+          variant="secondary"
+          size="sm"
+          isDisabled={actionDisabled}
+          onClick={() => void importPet()}
+          label={mutation === 'import' ? copy.importing : copy.import}
+        />
+      )}
+    >
+      <SettingsRow
+        label={copy.status}
+        description={loading
+          ? copy.loading
+          : selectedPet
+            ? copy.activePet(selectedPet.displayName)
+            : copy.disabled}
+        end={loading ? undefined : selectedPet ? (
+          <Button
+            variant="secondary"
+            size="sm"
+            isDisabled={actionDisabled}
+            onClick={() => void selectPet(null)}
+            label={mutation === 'disable' ? copy.disabling : copy.disable}
+          />
+        ) : (
+          <Badge variant="neutral" label={copy.disabled} />
+        )}
+      />
+
+      {loading && library.pets.length === 0 ? (
+        <SettingsRow label={copy.loading} />
+      ) : null}
+
+      {!loading && library.pets.length === 0 ? (
+        <SettingsRow label={copy.empty} description={copy.emptyHelp} />
+      ) : null}
+
+      {library.pets.map((pet) => {
+        const isSelected = pet.id === library.selectedPetId;
+        const isSelecting = mutation === `select:${pet.id}`;
+        const isRemoving = mutation === `remove:${pet.id}`;
+        return (
+          <SettingsRow
+            key={pet.id}
+            label={pet.displayName}
+            description={pet.description ? `${pet.description} · ${pet.id}` : pet.id}
+            end={(
+              <>
+                {isSelected ? (
+                  <Badge variant="neutral" label={copy.selected} />
+                ) : (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    isDisabled={actionDisabled}
+                    onClick={() => void selectPet(pet.id)}
+                    label={isSelecting ? copy.selecting : copy.select}
+                  />
+                )}
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  isDisabled={actionDisabled}
+                  onClick={() => void requestRemovePet(pet.id)}
+                  label={isRemoving ? copy.removing : copy.remove}
+                />
+              </>
+            )}
+          />
+        );
+      })}
+    </SettingsSection>
+  );
+}


### PR DESCRIPTION
## Summary

- add a Custom pets section to Appearance settings for importing, selecting, disabling, and removing user PetPacks
- keep import and activation as separate explicit choices; Maka still bundles and enables no pet by default
- reconcile library and selection updates across pet change events, with localized errors and destructive removal confirmation
- cover stale selection, duplicate ids, import, and removal reconciliation in the settings model

## Verification

- npm run build
- npm run typecheck --workspace @maka/desktop
- npm run test --workspace @maka/desktop (1738 tests passed)
- npx biome check on all changed files

Builds on #2437. Runtime pet animation/display remains a follow-up PR.