### PR TITLE
feat(desktop): render selected custom pet

### DIFF
--- a/apps/desktop/src/main/__tests__/custom-pet-companion-model.test.ts
+++ b/apps/desktop/src/main/__tests__/custom-pet-companion-model.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { PetPackManifestV1 } from '@maka/core';
+import {
+  loadSelectedPetCompanion,
+  petFrameSourceRect,
+  samplePetAnimation,
+  shouldReducePetMotion,
+  type PetCompanionSource,
+} from '../../renderer/custom-pet-companion-model.js';
+
+function manifest(id = 'likun.maodie'): PetPackManifestV1 {
+  return {
+    schema: 'maka.pet/v1',
+    id,
+    displayName: '耄耋',
+    spriteSheet: {
+      path: 'sprites.png',
+      format: 'png',
+      frameWidth: 64,
+      frameHeight: 48,
+      columns: 3,
+      rows: 2,
+      frameCount: 6,
+    },
+    animations: {
+      idle: { frames: [0, 2, 5], fps: 2, loop: true },
+      working: { frames: [1], fps: 1, loop: true },
+      'needs-input': { frames: [2], fps: 1, loop: true },
+      ready: { frames: [3], fps: 1, loop: true },
+      blocked: { frames: [4], fps: 1, loop: true },
+    },
+  };
+}
+
+function source(overrides: Partial<PetCompanionSource> = {}): PetCompanionSource {
+  const pet = manifest();
+  return {
+    getSelection: async () => pet.id,
+    list: async () => [pet],
+    readSpriteSheet: async () => ({
+      ok: true,
+      mimeType: 'image/png',
+      bytes: Uint8Array.of(1, 2, 3),
+    }),
+    ...overrides,
+  };
+}
+
+describe('custom pet companion model', () => {
+  it('does not read the library when custom pets are disabled', async () => {
+    let listCalls = 0;
+    const result = await loadSelectedPetCompanion(source({
+      getSelection: async () => null,
+      list: async () => {
+        listCalls += 1;
+        return [];
+      },
+    }));
+
+    assert.deepEqual(result, { kind: 'none' });
+    assert.equal(listCalls, 0);
+  });
+
+  it('loads the selected manifest and its local sprite bytes', async () => {
+    const result = await loadSelectedPetCompanion(source());
+
+    assert.equal(result.kind, 'ready');
+    if (result.kind !== 'ready') return;
+    assert.equal(result.manifest.id, 'likun.maodie');
+    assert.equal(result.mimeType, 'image/png');
+    assert.deepEqual([...result.bytes], [1, 2, 3]);
+  });
+
+  it('fails closed for stale selections and unreadable assets', async () => {
+    assert.deepEqual(await loadSelectedPetCompanion(source({ list: async () => [] })), {
+      kind: 'none',
+    });
+    assert.deepEqual(await loadSelectedPetCompanion(source({
+      readSpriteSheet: async () => ({ ok: false, reason: 'corrupt_pack' }),
+    })), { kind: 'none' });
+  });
+
+  it('samples sparse looping frames from elapsed time', () => {
+    const animation = manifest().animations.idle;
+
+    assert.deepEqual(samplePetAnimation(animation, 0), {
+      frame: 0, sequenceIndex: 0, complete: false,
+    });
+    assert.equal(samplePetAnimation(animation, 500).frame, 2);
+    assert.equal(samplePetAnimation(animation, 1_000).frame, 5);
+    assert.equal(samplePetAnimation(animation, 1_500).frame, 0);
+  });
+
+  it('holds the last frame and reports completion for one-shot animations', () => {
+    const animation = { frames: [3, 4], fps: 4, loop: false } as const;
+
+    assert.deepEqual(samplePetAnimation(animation, 500), {
+      frame: 4, sequenceIndex: 1, complete: true,
+    });
+  });
+
+  it('maps a frame index onto the declared sprite grid', () => {
+    assert.deepEqual(petFrameSourceRect(5, manifest().spriteSheet), {
+      x: 128,
+      y: 48,
+      width: 64,
+      height: 48,
+    });
+  });
+
+  it('freezes animation for either accessibility or deterministic fixtures', () => {
+    assert.equal(shouldReducePetMotion({
+      reducedMotionAttribute: false,
+      e2eFixtureAttribute: false,
+      systemPreference: false,
+    }), false);
+    assert.equal(shouldReducePetMotion({
+      reducedMotionAttribute: false,
+      e2eFixtureAttribute: true,
+      systemPreference: false,
+    }), true);
+    assert.equal(shouldReducePetMotion({
+      reducedMotionAttribute: true,
+      e2eFixtureAttribute: false,
+      systemPreference: false,
+    }), true);
+  });
+});

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -109,6 +109,7 @@ import { AppShellTopbarActions, AppShellWorkspaceTopActions } from './app-shell-
 import { updateReminderFromStatus } from './app-shell-app-update';
 import { AppShellDetailPanel } from './app-shell-detail-panel';
 import { AppShellOverlays } from './app-shell-overlays';
+import { CustomPetCompanion } from './custom-pet-companion';
 import { createAppShellDailyReviewBridge } from './app-shell-daily-review-bridge';
 import { useAppShellModuleData } from './use-module-data';
 import { useKeepSystemAwake } from './use-keep-system-awake';
@@ -2510,6 +2511,7 @@ function AppShellContent({
           </MakaUriContext.Provider>
         </AppShellDetailPanel>
       </AstryxAppShell>
+      {!hasModalOpen && !settingsOpen && <CustomPetCompanion />}
       <AppShellOverlays
         settingsOpen={settingsOpen}
         connections={connections}

--- a/apps/desktop/src/renderer/custom-pet-companion-model.ts
+++ b/apps/desktop/src/renderer/custom-pet-companion-model.ts
@@ -1,0 +1,104 @@
+import type {
+  PetAnimationV1,
+  PetPackManifestV1,
+  PetSpriteSheetV1,
+} from '@maka/core';
+
+export interface PetCompanionSource {
+  getSelection(): Promise<string | null>;
+  list(): Promise<PetPackManifestV1[]>;
+  readSpriteSheet(petId: string): Promise<
+    | { ok: true; mimeType: 'image/png' | 'image/webp'; bytes: Uint8Array }
+    | {
+        ok: false;
+        reason: 'invalid_id' | 'not_found' | 'corrupt_pack' | 'read_failed';
+      }
+  >;
+}
+
+export type SelectedPetCompanion =
+  | { readonly kind: 'none' }
+  | {
+      readonly kind: 'ready';
+      readonly manifest: PetPackManifestV1;
+      readonly mimeType: 'image/png' | 'image/webp';
+      readonly bytes: Uint8Array;
+    };
+
+/**
+ * Resolve the selection through the same public bridge available to Settings.
+ * Every mismatch fails closed: a stale id, a removed manifest, or an unreadable
+ * sprite sheet means no decorative layer instead of a broken-image surface.
+ */
+export async function loadSelectedPetCompanion(
+  source: PetCompanionSource,
+): Promise<SelectedPetCompanion> {
+  const selectedPetId = await source.getSelection();
+  if (selectedPetId === null) return { kind: 'none' };
+
+  const manifests = await source.list();
+  const manifest = manifests.find((candidate) => candidate.id === selectedPetId);
+  if (!manifest) return { kind: 'none' };
+
+  const spriteSheet = await source.readSpriteSheet(selectedPetId);
+  if (!spriteSheet.ok) return { kind: 'none' };
+  return {
+    kind: 'ready',
+    manifest,
+    mimeType: spriteSheet.mimeType,
+    bytes: spriteSheet.bytes,
+  };
+}
+
+export interface PetAnimationSample {
+  readonly frame: number;
+  readonly sequenceIndex: number;
+  readonly complete: boolean;
+}
+
+/** Pure elapsed-time sampler so delayed frames do not slow the animation. */
+export function samplePetAnimation(
+  animation: PetAnimationV1,
+  elapsedMs: number,
+): PetAnimationSample {
+  const elapsed = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0;
+  const unboundedIndex = Math.floor((elapsed * animation.fps) / 1_000);
+  const complete = !animation.loop && unboundedIndex >= animation.frames.length;
+  const sequenceIndex = animation.loop
+    ? unboundedIndex % animation.frames.length
+    : Math.min(unboundedIndex, animation.frames.length - 1);
+  return {
+    frame: animation.frames[sequenceIndex],
+    sequenceIndex,
+    complete,
+  };
+}
+
+export interface PetFrameSourceRect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export function petFrameSourceRect(
+  frame: number,
+  sheet: PetSpriteSheetV1,
+): PetFrameSourceRect {
+  return {
+    x: (frame % sheet.columns) * sheet.frameWidth,
+    y: Math.floor(frame / sheet.columns) * sheet.frameHeight,
+    width: sheet.frameWidth,
+    height: sheet.frameHeight,
+  };
+}
+
+export function shouldReducePetMotion(input: {
+  readonly reducedMotionAttribute: boolean;
+  readonly e2eFixtureAttribute: boolean;
+  readonly systemPreference: boolean;
+}): boolean {
+  return input.reducedMotionAttribute
+    || input.e2eFixtureAttribute
+    || input.systemPreference;
+}

--- a/apps/desktop/src/renderer/custom-pet-companion.tsx
+++ b/apps/desktop/src/renderer/custom-pet-companion.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useMountedRef } from '@maka/ui';
+import {
+  loadSelectedPetCompanion,
+  petFrameSourceRect,
+  samplePetAnimation,
+  shouldReducePetMotion,
+  type SelectedPetCompanion,
+} from './custom-pet-companion-model.js';
+
+const EMPTY_COMPANION: SelectedPetCompanion = { kind: 'none' };
+
+function readPetMotionPreference(): boolean {
+  if (typeof document === 'undefined' || typeof window === 'undefined') return true;
+  const root = document.documentElement;
+  return shouldReducePetMotion({
+    reducedMotionAttribute: root.dataset.makaReducedMotion === 'true',
+    e2eFixtureAttribute: root.dataset.makaE2eFixture === 'true',
+    systemPreference:
+      typeof window.matchMedia === 'function'
+      && window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+  });
+}
+
+function usePetMotionPreference(): boolean {
+  const [reduced, setReduced] = useState(readPetMotionPreference);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => setReduced(readPetMotionPreference());
+    const observer = new MutationObserver(sync);
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ['data-maka-reduced-motion', 'data-maka-e2e-fixture'],
+    });
+    media.addEventListener('change', sync);
+    sync();
+    return () => {
+      observer.disconnect();
+      media.removeEventListener('change', sync);
+    };
+  }, []);
+
+  return reduced;
+}
+
+function PetSpriteCanvas(props: {
+  companion: Extract<SelectedPetCompanion, { readonly kind: 'ready' }>;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const reducedMotion = usePetMotionPreference();
+  const { manifest, mimeType, bytes } = props.companion;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext('2d');
+    if (!canvas || !context) return;
+
+    const sheet = manifest.spriteSheet;
+    const animation = manifest.animations.idle;
+    canvas.width = sheet.frameWidth;
+    canvas.height = sheet.frameHeight;
+    context.imageSmoothingEnabled = true;
+
+    // Copy into an owned ArrayBuffer. IPC may expose an ArrayBufferLike-backed
+    // view, while Blob requires a transferable browser-owned part.
+    const ownedBytes = new Uint8Array(bytes.length);
+    ownedBytes.set(bytes);
+    const objectUrl = URL.createObjectURL(new Blob([ownedBytes.buffer], { type: mimeType }));
+    const image = new Image();
+    let disposed = false;
+    let animationFrame = 0;
+
+    const draw = (frame: number) => {
+      const source = petFrameSourceRect(frame, sheet);
+      context.clearRect(0, 0, sheet.frameWidth, sheet.frameHeight);
+      context.drawImage(
+        image,
+        source.x,
+        source.y,
+        source.width,
+        source.height,
+        0,
+        0,
+        sheet.frameWidth,
+        sheet.frameHeight,
+      );
+    };
+
+    image.onload = () => {
+      if (disposed) return;
+      draw(animation.frames[0]);
+      if (reducedMotion) return;
+
+      let startedAt: number | undefined;
+      let previousSequenceIndex = 0;
+      const tick = (timestamp: number) => {
+        if (disposed) return;
+        startedAt ??= timestamp;
+        const sample = samplePetAnimation(animation, timestamp - startedAt);
+        if (sample.sequenceIndex !== previousSequenceIndex) {
+          previousSequenceIndex = sample.sequenceIndex;
+          draw(sample.frame);
+        }
+        if (!sample.complete) animationFrame = window.requestAnimationFrame(tick);
+      };
+      animationFrame = window.requestAnimationFrame(tick);
+    };
+    image.src = objectUrl;
+
+    return () => {
+      disposed = true;
+      image.onload = null;
+      if (animationFrame) window.cancelAnimationFrame(animationFrame);
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [bytes, manifest, mimeType, reducedMotion]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="maka-custom-pet-companion__canvas"
+      data-pet-id={manifest.id}
+      data-pet-state="idle"
+    />
+  );
+}
+
+/** Decorative selected-pet layer. Runtime state projection follows separately. */
+export function CustomPetCompanion() {
+  const mountedRef = useMountedRef();
+  const loadTicketRef = useRef(0);
+  const [companion, setCompanion] = useState<SelectedPetCompanion>(EMPTY_COMPANION);
+
+  const refresh = useCallback(async () => {
+    const ticket = ++loadTicketRef.current;
+    try {
+      const next = await loadSelectedPetCompanion(window.maka.pets);
+      if (mountedRef.current && ticket === loadTicketRef.current) setCompanion(next);
+    } catch {
+      // A pet is optional decoration. Bridge or asset failures remove it rather
+      // than destabilizing the application shell or surfacing startup noise.
+      if (mountedRef.current && ticket === loadTicketRef.current) {
+        setCompanion(EMPTY_COMPANION);
+      }
+    }
+  }, [mountedRef]);
+
+  useEffect(() => {
+    void refresh();
+    const unsubscribe = window.maka.pets.subscribeChanges((event) => {
+      // Selection/removal invalidates what is currently painted immediately;
+      // an install alone cannot affect the active pack and need not reload it.
+      if (event.reason === 'installed') return;
+      setCompanion(EMPTY_COMPANION);
+      void refresh();
+    });
+    return () => {
+      loadTicketRef.current += 1;
+      unsubscribe();
+    };
+  }, [refresh]);
+
+  if (companion.kind !== 'ready') return null;
+  return (
+    <div className="maka-custom-pet-companion" aria-hidden="true">
+      <PetSpriteCanvas companion={companion} />
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -44,4 +44,5 @@
 @import "./styles/theme-glass.css" layer(components);
 @import "./styles/prompt-rail.css" layer(components);
 @import "./styles/quote-side-panel.css" layer(components);
+@import "./styles/custom-pet-companion.css" layer(components);
 @import "./styles/astryx-mount.css" layer(components);

--- a/apps/desktop/src/renderer/styles/custom-pet-companion.css
+++ b/apps/desktop/src/renderer/styles/custom-pet-companion.css
@@ -1,0 +1,27 @@
+/* User-supplied desktop pet. It is decorative and never participates in hit
+   testing; the main shell remains the sole interaction surface beneath it. */
+.maka-custom-pet-companion {
+  position: absolute;
+  inset-inline-end: var(--space-5);
+  inset-block-end: var(--space-5);
+  z-index: var(--z-sticky);
+  display: grid;
+  place-items: end;
+  pointer-events: none;
+  filter: drop-shadow(0 var(--space-1) var(--space-2) oklch(0 0 0 / 0.18));
+}
+
+.maka-custom-pet-companion__canvas {
+  display: block;
+  inline-size: min(8rem, 22vw);
+  block-size: auto;
+  max-block-size: min(8rem, 22vh);
+  object-fit: contain;
+}
+
+@media (max-width: 640px), (max-height: 520px) {
+  .maka-custom-pet-companion__canvas {
+    inline-size: min(6rem, 22vw);
+    max-block-size: min(6rem, 22vh);
+  }
+}


### PR DESCRIPTION
## Summary

- load the user-selected PetPack and render its idle animation as a decorative desktop companion
- play arbitrary manifest frame sequences at their declared FPS on Canvas without assuming contiguous sprite frames
- refresh immediately when selection or removal changes, and fail closed for stale ids, missing manifests, or unreadable assets
- release Blob URLs and animation frames on every selection change or unmount
- freeze motion for reduced-motion users and deterministic E2E fixtures, and hide the companion behind Settings and other modal surfaces

## Verification

- npm run build
- npm run typecheck --workspace @maka/desktop
- npm run test --workspace @maka/desktop (1745 tests passed)
- npx biome check on all changed files

Builds on #2440. Mapping live task state to working / needs-input / ready / blocked remains the next focused PR.