### PR TITLE
feat(desktop): animate custom pets from runtime state

### DIFF
--- a/apps/desktop/src/main/__tests__/custom-pet-companion-model.test.ts
+++ b/apps/desktop/src/main/__tests__/custom-pet-companion-model.test.ts
@@ -2,10 +2,12 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { PetPackManifestV1 } from '@maka/core';
 import {
+  derivePetActivityState,
   loadSelectedPetCompanion,
   petFrameSourceRect,
   samplePetAnimation,
   shouldReducePetMotion,
+  syncPetPlaybackState,
   type PetCompanionSource,
 } from '../../renderer/custom-pet-companion-model.js';
 
@@ -48,6 +50,64 @@ function source(overrides: Partial<PetCompanionSource> = {}): PetCompanionSource
 }
 
 describe('custom pet companion model', () => {
+  it('projects authoritative runtime signals onto pet activity states', () => {
+    const base = {
+      hasActiveSession: true,
+      hasActiveInteraction: false,
+      turnActive: false,
+      sessionStatus: 'active' as const,
+    };
+
+    assert.equal(derivePetActivityState(base), 'idle');
+    assert.equal(derivePetActivityState({ ...base, turnActive: true }), 'working');
+    assert.equal(derivePetActivityState({
+      ...base,
+      turnActive: true,
+      hasActiveInteraction: true,
+    }), 'needs-input');
+    assert.equal(derivePetActivityState({
+      ...base,
+      sessionStatus: 'waiting_for_user',
+    }), 'needs-input');
+    assert.equal(derivePetActivityState({
+      ...base,
+      turnActive: true,
+      sessionStatus: 'blocked',
+    }), 'blocked');
+    assert.equal(derivePetActivityState({
+      ...base,
+      hasActiveSession: false,
+      turnActive: true,
+    }), 'idle');
+  });
+
+  it('lets a completion pulse finish before ordinary idle takes over', () => {
+    assert.equal(syncPetPlaybackState({
+      currentState: 'working',
+      activityState: 'working',
+      completionArrived: true,
+      contextChanged: false,
+    }), 'ready');
+    assert.equal(syncPetPlaybackState({
+      currentState: 'ready',
+      activityState: 'idle',
+      completionArrived: false,
+      contextChanged: false,
+    }), 'ready');
+    assert.equal(syncPetPlaybackState({
+      currentState: 'ready',
+      activityState: 'blocked',
+      completionArrived: false,
+      contextChanged: false,
+    }), 'blocked');
+    assert.equal(syncPetPlaybackState({
+      currentState: 'ready',
+      activityState: 'idle',
+      completionArrived: false,
+      contextChanged: true,
+    }), 'idle');
+  });
+
   it('does not read the library when custom pets are disabled', async () => {
     let listCalls = 0;
     const result = await loadSelectedPetCompanion(source({

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -110,6 +110,7 @@ import { updateReminderFromStatus } from './app-shell-app-update';
 import { AppShellDetailPanel } from './app-shell-detail-panel';
 import { AppShellOverlays } from './app-shell-overlays';
 import { CustomPetCompanion } from './custom-pet-companion';
+import { derivePetActivityState } from './custom-pet-companion-model';
 import { createAppShellDailyReviewBridge } from './app-shell-daily-review-bridge';
 import { useAppShellModuleData } from './use-module-data';
 import { useKeepSystemAwake } from './use-keep-system-awake';
@@ -308,6 +309,7 @@ function AppShellContent({
   const [newChatSwarmModeActive, setNewChatSwarmModeActive] = useState(false);
   const [newChatGraphModeActive, setNewChatGraphModeActive] = useState(false);
   const [pendingOrchestrationModeBySession, setPendingOrchestrationModeBySession] = useState<Record<string, boolean>>({});
+  const [petCompletionNonce, setPetCompletionNonce] = useState(0);
   // P3: session ids with a live embedded-browser view. The right-side
   // BrowserPanel mounts only for these, so ordinary chats reserve no space.
   const [liveBrowserSessionIds, setLiveBrowserSessionIds] = useState<string[]>([]);
@@ -627,6 +629,12 @@ function AppShellContent({
   } = useShellLiveTurn({
     liveTurn: activeLiveTurnSnapshot,
     activeSession,
+  });
+  const petActivityState = derivePetActivityState({
+    hasActiveSession: activeSession !== undefined,
+    hasActiveInteraction: activeInteraction !== undefined,
+    turnActive,
+    sessionStatus: activeSession?.status,
   });
   // Surface a credential-lifecycle alert directly in the chat header when
   // the active session's connection is in `needs_reauth` / `error` or has
@@ -1653,6 +1661,9 @@ function AppShellContent({
     showModelSetupToast,
     toastApi,
     notifyRunEnded: ({ kind, sessionId, body }) => {
+      if (kind === 'completed' && activeIdRef.current === sessionId) {
+        setPetCompletionNonce((current) => current + 1);
+      }
       const title = sessionsRef.current.find((session) => session.id === sessionId)?.name;
       // Best-effort: swallow any main-side failure so a missed banner
       // never surfaces as an unhandled promise rejection.
@@ -2511,7 +2522,13 @@ function AppShellContent({
           </MakaUriContext.Provider>
         </AppShellDetailPanel>
       </AstryxAppShell>
-      {!hasModalOpen && !settingsOpen && <CustomPetCompanion />}
+      {!hasModalOpen && !settingsOpen && (
+        <CustomPetCompanion
+          activityState={petActivityState}
+          completionNonce={petCompletionNonce}
+          contextKey={activeId}
+        />
+      )}
       <AppShellOverlays
         settingsOpen={settingsOpen}
         connections={connections}

--- a/apps/desktop/src/renderer/custom-pet-companion-model.ts
+++ b/apps/desktop/src/renderer/custom-pet-companion-model.ts
@@ -1,7 +1,9 @@
 import type {
+  PetActivityState,
   PetAnimationV1,
   PetPackManifestV1,
   PetSpriteSheetV1,
+  SessionStatus,
 } from '@maka/core';
 
 export interface PetCompanionSource {
@@ -24,6 +26,43 @@ export type SelectedPetCompanion =
       readonly mimeType: 'image/png' | 'image/webp';
       readonly bytes: Uint8Array;
     };
+
+export interface PetRuntimeActivityInput {
+  readonly hasActiveSession: boolean;
+  readonly hasActiveInteraction: boolean;
+  readonly turnActive: boolean;
+  readonly sessionStatus: SessionStatus | undefined;
+}
+
+/**
+ * Project authoritative shell signals onto the pack contract. Completion is a
+ * separate edge-triggered pulse: normal turns return their session to `active`,
+ * so a durable status cannot distinguish "ready just now" from ordinary idle.
+ */
+export function derivePetActivityState(
+  input: PetRuntimeActivityInput,
+): PetActivityState {
+  if (!input.hasActiveSession) return 'idle';
+  if (input.hasActiveInteraction || input.sessionStatus === 'waiting_for_user') {
+    return 'needs-input';
+  }
+  if (input.sessionStatus === 'blocked') return 'blocked';
+  if (input.turnActive) return 'working';
+  return 'idle';
+}
+
+export function syncPetPlaybackState(input: {
+  readonly currentState: PetActivityState;
+  readonly activityState: PetActivityState;
+  readonly completionArrived: boolean;
+  readonly contextChanged: boolean;
+}): PetActivityState {
+  if (input.completionArrived) return 'ready';
+  if (input.contextChanged || input.activityState !== 'idle') return input.activityState;
+  // A completed turn can retire its running witness before its one-shot
+  // `ready` animation ends. Its manifest fallback owns that transition.
+  return input.currentState === 'ready' ? 'ready' : 'idle';
+}
 
 /**
  * Resolve the selection through the same public bridge available to Settings.

--- a/apps/desktop/src/renderer/custom-pet-companion.tsx
+++ b/apps/desktop/src/renderer/custom-pet-companion.tsx
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  resolvePetAnimationFallback,
+  resolvePetAnimationState,
+  type PetActivityState,
+} from '@maka/core';
 import { useMountedRef } from '@maka/ui';
 import {
   loadSelectedPetCompanion,
   petFrameSourceRect,
   samplePetAnimation,
   shouldReducePetMotion,
+  syncPetPlaybackState,
   type SelectedPetCompanion,
 } from './custom-pet-companion-model.js';
 
@@ -47,10 +53,16 @@ function usePetMotionPreference(): boolean {
 
 function PetSpriteCanvas(props: {
   companion: Extract<SelectedPetCompanion, { readonly kind: 'ready' }>;
+  activityState: PetActivityState;
+  onAnimationComplete: (
+    completedState: PetActivityState,
+    fallbackState: PetActivityState,
+  ) => void;
 }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const reducedMotion = usePetMotionPreference();
   const { manifest, mimeType, bytes } = props.companion;
+  const resolvedState = resolvePetAnimationState(manifest, props.activityState);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -58,7 +70,7 @@ function PetSpriteCanvas(props: {
     if (!canvas || !context) return;
 
     const sheet = manifest.spriteSheet;
-    const animation = manifest.animations.idle;
+    const animation = manifest.animations[resolvedState] ?? manifest.animations.idle;
     canvas.width = sheet.frameWidth;
     canvas.height = sheet.frameHeight;
     context.imageSmoothingEnabled = true;
@@ -103,7 +115,14 @@ function PetSpriteCanvas(props: {
           previousSequenceIndex = sample.sequenceIndex;
           draw(sample.frame);
         }
-        if (!sample.complete) animationFrame = window.requestAnimationFrame(tick);
+        if (sample.complete) {
+          props.onAnimationComplete(
+            resolvedState,
+            resolvePetAnimationFallback(manifest, resolvedState),
+          );
+          return;
+        }
+        animationFrame = window.requestAnimationFrame(tick);
       };
       animationFrame = window.requestAnimationFrame(tick);
     };
@@ -115,23 +134,49 @@ function PetSpriteCanvas(props: {
       if (animationFrame) window.cancelAnimationFrame(animationFrame);
       URL.revokeObjectURL(objectUrl);
     };
-  }, [bytes, manifest, mimeType, reducedMotion]);
+  }, [bytes, manifest, mimeType, props.onAnimationComplete, reducedMotion, resolvedState]);
 
   return (
     <canvas
       ref={canvasRef}
       className="maka-custom-pet-companion__canvas"
       data-pet-id={manifest.id}
-      data-pet-state="idle"
+      data-pet-state={resolvedState}
     />
   );
 }
 
-/** Decorative selected-pet layer. Runtime state projection follows separately. */
-export function CustomPetCompanion() {
+export function CustomPetCompanion(props: {
+  activityState: PetActivityState;
+  completionNonce: number;
+  contextKey: string | undefined;
+}) {
   const mountedRef = useMountedRef();
   const loadTicketRef = useRef(0);
+  const lastCompletionNonceRef = useRef(props.completionNonce);
+  const lastContextKeyRef = useRef(props.contextKey);
   const [companion, setCompanion] = useState<SelectedPetCompanion>(EMPTY_COMPANION);
+  const [playbackState, setPlaybackState] = useState(props.activityState);
+
+  useEffect(() => {
+    const completionArrived = props.completionNonce !== lastCompletionNonceRef.current;
+    const contextChanged = props.contextKey !== lastContextKeyRef.current;
+    lastCompletionNonceRef.current = props.completionNonce;
+    lastContextKeyRef.current = props.contextKey;
+    setPlaybackState((currentState) => syncPetPlaybackState({
+      currentState,
+      activityState: props.activityState,
+      completionArrived,
+      contextChanged,
+    }));
+  }, [props.activityState, props.completionNonce, props.contextKey]);
+
+  const handleAnimationComplete = useCallback((
+    completedState: PetActivityState,
+    fallbackState: PetActivityState,
+  ) => {
+    setPlaybackState((current) => current === completedState ? fallbackState : current);
+  }, []);
 
   const refresh = useCallback(async () => {
     const ticket = ++loadTicketRef.current;
@@ -165,7 +210,11 @@ export function CustomPetCompanion() {
   if (companion.kind !== 'ready') return null;
   return (
     <div className="maka-custom-pet-companion" aria-hidden="true">
-      <PetSpriteCanvas companion={companion} />
+      <PetSpriteCanvas
+        companion={companion}
+        activityState={playbackState}
+        onAnimationComplete={handleAnimationComplete}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- project authoritative AppShell signals onto custom pet `idle`, `working`, `needs-input`, and `blocked` animations
- pulse `ready` only for successfully completed active turns, allowing a one-shot completion animation to reach its manifest fallback before ordinary idle resumes
- resolve optional animation states and honor non-looping `fallback` transitions in the Canvas player while retaining reduced-motion freezing

Refs #2145

## Verification

- `npm run build`
- `npm run typecheck --workspace=@maka/desktop`
- `npm --workspace @maka/desktop run test:dist` — 1747 passed
- compiled custom pet model test — 9 passed
- `npx biome check` on the four changed files
- `npm test` reached unrelated host baseline failures: Node 22 SQLite warning assertions in storage/CLI, a macOS `/usr/local` sandbox-root assertion in runtime, and Python 3.9 compatibility/timeouts in headless; the desktop workspace passed independently