### PR TITLE
feat(settings): add a Projects page with a default project

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -264,6 +264,7 @@ export const test = base.extend<{
   botSettingsWindow: Page;
   localeSwitchWindow: Page;
   invocableSkillsWindow: Page;
+  settingsProjectsWindow: Page;
   planRemindersWindow: Page;
   oauthReloginWindow: Page;
 }>({
@@ -280,6 +281,20 @@ export const test = base.extend<{
         seed: false,
         readinessSelector: '[data-maka-contract="onboarding-card"]',
         e2eFixtureScenario: 'first-run',
+        locale: 'zh',
+      },
+      use,
+    );
+  },
+  // Settings -> 偏好 -> 项目, with three seeded catalog entries (available,
+  // long-path, and folder-gone) so the list, the default control, and the
+  // unavailable row all render without touching a native directory picker.
+  settingsProjectsWindow: async ({}, use) => {
+    await withE2eWindow(
+      {
+        seed: true,
+        readinessSelector: '.settingsMainPane',
+        e2eFixtureScenario: 'settings-projects',
         locale: 'zh',
       },
       use,

--- a/apps/desktop/e2e/settings-projects.spec.ts
+++ b/apps/desktop/e2e/settings-projects.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from './fixtures.js';
+
+/**
+ * Settings · 偏好 · 项目 — the list, and the default-project control.
+ *
+ * The seeded catalog deliberately mixes an available project with one whose
+ * folder is gone, because the unavailable row is where this page can lie
+ * most easily: a "设为默认" that looked live on a folder the app cannot open
+ * would set a default that breaks every new conversation.
+ */
+test('the projects page lists the catalog and moves the default between rows', async ({
+  settingsProjectsWindow: page,
+}) => {
+  await page
+    .getByRole('navigation', { name: /设置分组|Settings sections/ })
+    .getByRole('button', { name: /项目|Projects/, exact: true })
+    .click();
+
+  const main = page.getByRole('main', { name: /设置内容|Settings content/ });
+  // Exact match: each project's folder name also appears inside its own path,
+  // so a substring lookup matches the name and the mono line both.
+  await expect(main.getByText('maka-agent', { exact: true })).toBeVisible();
+  await expect(main.getByText('astryx-design-system', { exact: true })).toBeVisible();
+
+  // The row whose folder was never created reports that, instead of showing a
+  // path it cannot open.
+  await expect(main.getByText('retired-prototype', { exact: true })).toBeVisible();
+  await expect(main.getByText('目录不可用').first()).toBeVisible();
+
+  // No default configured yet: every row offers to become one.
+  await expect(main.getByText('默认', { exact: true })).toHaveCount(0);
+
+  const setDefaultButtons = main.getByRole('button', { name: '设为默认' });
+  const enabled: number[] = [];
+  for (let index = 0; index < (await setDefaultButtons.count()); index += 1) {
+    if (await setDefaultButtons.nth(index).isEnabled()) enabled.push(index);
+  }
+  // An unavailable project cannot be made the default, and the disabled
+  // control says why rather than leaving the user to guess.
+  expect(enabled.length).toBeGreaterThan(0);
+  const disabled = setDefaultButtons.nth(
+    [...Array(await setDefaultButtons.count()).keys()].find((i) => !enabled.includes(i)) ?? 0,
+  );
+  await expect(disabled).toBeDisabled();
+  // Astryx surfaces a Button tooltip through `aria-describedby`, not `title`,
+  // so read the element it points at — asserting on `title` passed vacuously
+  // against an empty string.
+  const describedText = await disabled.evaluate((el) => {
+    const id = el.getAttribute('aria-describedby');
+    return id ? (document.getElementById(id)?.textContent ?? '') : '';
+  });
+  expect(describedText).toContain('目录不可用');
+
+  await setDefaultButtons.nth(enabled[0]).click();
+
+  // The chosen row swaps its button for the Badge, and it persists.
+  await expect(main.getByText('默认', { exact: true })).toHaveCount(1);
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.maka.settings.get().then((value) => value.projects.defaultProjectId),
+      ),
+    )
+    .not.toBe(undefined);
+
+  // Exactly one default at a time: setting another moves it rather than
+  // adding a second.
+  const remaining = main.getByRole('button', { name: '设为默认' });
+  const stillEnabled: number[] = [];
+  for (let index = 0; index < (await remaining.count()); index += 1) {
+    if (await remaining.nth(index).isEnabled()) stillEnabled.push(index);
+  }
+  if (stillEnabled.length > 0) {
+    await remaining.nth(stillEnabled[0]).click();
+    await expect(main.getByText('默认', { exact: true })).toHaveCount(1);
+  }
+});

--- a/apps/desktop/src/main/__tests__/new-session-project.test.ts
+++ b/apps/desktop/src/main/__tests__/new-session-project.test.ts
@@ -8,6 +8,7 @@ import { createProjectCatalog } from '@maka/storage';
 import {
   resolveDesktopSessionSelection,
   resolveNewSessionProjectInput,
+  type DesktopCreateSessionInput,
 } from '../new-session-project.js';
 
 test('default sessions inherit the main-owned project selection', async () => {
@@ -199,3 +200,88 @@ function makeInput(
     ...overrides,
   };
 }
+
+const BASE_SESSION: DesktopCreateSessionInput = {
+  backend: 'fake',
+  llmConnectionSlug: 'fake',
+  model: 'fake-model',
+  permissionMode: 'ask',
+  name: 'Session',
+  labels: [],
+};
+
+test('the configured default project beats the last-used one', async () => {
+  // The point of the setting: something is almost always "last used", so a
+  // default that yielded to it would never apply.
+  const resolved = await resolveDesktopSessionSelection(
+    { ...BASE_SESSION },
+    {
+      current: async () => ({ projectId: 'last-used', path: '/last/used' }),
+      select: async (projectId) => ({
+        project: { id: projectId as string },
+        path: '/default/project',
+      }),
+      defaultProjectId: async () => 'default-project',
+    },
+  );
+
+  assert.equal(resolved.cwd, '/default/project');
+  assert.equal(resolved.projectId, 'default-project');
+});
+
+test('an explicit project id still overrides the configured default', async () => {
+  // The composer picker has to be able to take one conversation elsewhere,
+  // otherwise setting a default would trap every new chat in it.
+  const resolved = await resolveDesktopSessionSelection(
+    { ...BASE_SESSION, projectId: 'picked-for-this-chat' },
+    {
+      current: async () => {
+        throw new Error('current must not be called');
+      },
+      select: async (projectId) => ({
+        project: { id: projectId as string },
+        path: `/${projectId as string}`,
+      }),
+      defaultProjectId: async () => {
+        throw new Error('the default must not be consulted for an explicit pick');
+      },
+    },
+  );
+
+  assert.equal(resolved.projectId, 'picked-for-this-chat');
+});
+
+test('no configured default leaves the last-used behaviour untouched', async () => {
+  const resolved = await resolveDesktopSessionSelection(
+    { ...BASE_SESSION },
+    {
+      current: async () => ({ projectId: 'last-used', path: '/last/used' }),
+      select: async () => {
+        throw new Error('select must not be called');
+      },
+      defaultProjectId: async () => undefined,
+    },
+  );
+
+  assert.equal(resolved.cwd, '/last/used');
+  assert.equal(resolved.projectId, 'last-used');
+});
+
+test('a default project that no longer resolves falls back instead of failing the create', async () => {
+  // Archived, or its folder was deleted after it was chosen. Creating a
+  // session must still succeed — refusing to start a conversation because a
+  // preference went stale would be the worst possible reading of "default".
+  const resolved = await resolveDesktopSessionSelection(
+    { ...BASE_SESSION },
+    {
+      current: async () => ({ projectId: 'last-used', path: '/last/used' }),
+      select: async () => {
+        throw new Error('No such project: removed-project');
+      },
+      defaultProjectId: async () => 'removed-project',
+    },
+  );
+
+  assert.equal(resolved.cwd, '/last/used');
+  assert.equal(resolved.projectId, 'last-used');
+});

--- a/apps/desktop/src/main/boot.ts
+++ b/apps/desktop/src/main/boot.ts
@@ -1378,7 +1378,12 @@ async function ensureSessionWorkspaceAvailable(sessionId: string): Promise<void>
 }
 
 async function createDesktopSession(input: DesktopCreateSessionInput) {
-  const selected = await resolveDesktopSessionSelection(input, projectManagement);
+  const selected = await resolveDesktopSessionSelection(input, {
+    ...projectManagement,
+    // Read per creation rather than cached at boot: the user can change the
+    // default project in Settings without restarting the app.
+    defaultProjectId: async () => (await settingsStore.get()).projects.defaultProjectId,
+  });
   await assertSessionWorkspaceAvailable(selected.cwd);
   return runtime.createSession(await resolveNewSessionProjectInput(selected, projectCatalog));
 }

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -134,6 +134,7 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   'settings-bots-onboarding',
   'settings-about',
   'settings-general',
+  'settings-projects',
   'settings-memory',
   'settings-daily-review',
   'settings-permissions',
@@ -556,6 +557,8 @@ function buildE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState | nul
       // PR-SETTINGS-IA-CONSOLIDATE-0: 通用 now also hosts the proxy
       // block that used to live on its own 网络 page.
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'general' };
+    case 'settings-projects':
+      return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'projects' };
     case 'settings-memory':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'memory' };
     case 'settings-daily-review':
@@ -789,6 +792,53 @@ export async function seedE2eFixture(input: {
             { path: input.workspaceRoot, isWorktree: false, lastUsedAt: now },
           ],
           lastUsedAt: now,
+        },
+      ],
+    });
+  }
+  // Settings -> 项目: three catalog entries so the list shows real rhythm --
+  // one available and default-able, one with a long absolute path (the case
+  // that decides whether the mono line reads or wraps into a block), and one
+  // whose folder is gone, which is what the row's unavailable state is for.
+  if (input.fixture.scenario === 'settings-projects') {
+    // Real directories, because `available` is derived from the folder still
+    // existing -- seeding invented paths made every row render its unavailable
+    // state, which is not the list a reviewer needs to judge. `retired-prototype`
+    // below is deliberately NOT created: one genuinely missing folder is what
+    // proves the unavailable row still reads correctly.
+    const designSystemPath = join(input.workspaceRoot, 'astryx-design-system');
+    await mkdir(designSystemPath, { recursive: true });
+    await writeJson(join(input.workspaceRoot, 'projects.json'), {
+      schemaVersion: 1,
+      projects: [
+        {
+          id: 'proj-fixture-maka',
+          name: 'maka-agent',
+          identity: `folder:${input.workspaceRoot}`,
+          locations: [{ path: input.workspaceRoot, isWorktree: false, lastUsedAt: now }],
+          lastUsedAt: now,
+        },
+        {
+          id: 'proj-fixture-long',
+          name: 'astryx-design-system',
+          identity: `folder:${designSystemPath}`,
+          locations: [
+            { path: designSystemPath, isWorktree: false, lastUsedAt: now - 86_400_000 },
+          ],
+          lastUsedAt: now - 86_400_000,
+        },
+        {
+          id: 'proj-fixture-gone',
+          name: 'retired-prototype',
+          identity: 'folder:/Users/maka/Developer/retired-prototype',
+          locations: [
+            {
+              path: '/Users/maka/Developer/retired-prototype',
+              isWorktree: false,
+              lastUsedAt: now - 604_800_000,
+            },
+          ],
+          lastUsedAt: now - 604_800_000,
         },
       ],
     });

--- a/apps/desktop/src/main/new-session-project.ts
+++ b/apps/desktop/src/main/new-session-project.ts
@@ -15,10 +15,19 @@ export async function resolveDesktopSessionSelection(
     select(
       projectId: unknown,
     ): Promise<{ project: { id: string } | null; path: string }>;
+    /**
+     * Settings -> 偏好 -> 项目 -> 默认项目, or undefined for "no preference".
+     * Optional so the pure-selection callers and tests that predate the
+     * setting keep their two-argument shape.
+     */
+    defaultProjectId?(): Promise<string | undefined>;
   },
 ): Promise<CreateSessionInput> {
   if (input.cwd) return { ...input, cwd: input.cwd };
 
+  // An explicit project id is this conversation's own choice (the composer
+  // picker) and outranks the configured default -- that override is the whole
+  // reason the picker still exists once a default is set.
   if (input.projectId !== undefined) {
     const selected = await selection.select(input.projectId);
     return {
@@ -26,6 +35,25 @@ export async function resolveDesktopSessionSelection(
       cwd: selected.path,
       projectId: selected.project?.id ?? null,
     };
+  }
+
+  // No per-conversation choice: the configured default wins over the
+  // last-used project. A default that only applied when nothing was
+  // remembered would be a default in name only, since something is almost
+  // always remembered.
+  const configuredDefault = await selection.defaultProjectId?.();
+  if (configuredDefault !== undefined) {
+    try {
+      const selected = await selection.select(configuredDefault);
+      if (selected.project) {
+        return { ...input, cwd: selected.path, projectId: selected.project.id };
+      }
+    } catch {
+      // Archived, unavailable, or deleted since it was chosen. Creating the
+      // session still has to succeed, so fall through to the last-used
+      // project; the settings page is where that degradation is reported,
+      // because a toast at session-create time would blame the wrong action.
+    }
   }
 
   const selected = await selection.current();

--- a/apps/desktop/src/renderer/locales/settings-navigation-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-navigation-copy.ts
@@ -17,6 +17,7 @@ const SETTINGS_NAVIGATION_COPY_BY_LOCALE = {
     sections: {
       general: { label: '通用', description: '隐身、启动、对话默认与网络代理等系统偏好。' },
       appearance: { label: '外观', description: '主题、配色与界面语言。' },
+      projects: { label: '项目', description: '管理 Maka 认识的项目，以及新对话默认打开哪一个。' },
       models: { label: '模型', description: '模型连接、API key 与 OAuth 订阅管理。' },
       subagents: { label: '子 Agent', description: '配置主 Agent 可以自动选择的子 Agent、能力边界与模型。' },
       usage: { label: '使用统计', description: 'token、模型、工具使用走势与配额追踪。' },
@@ -40,6 +41,7 @@ const SETTINGS_NAVIGATION_COPY_BY_LOCALE = {
     sections: {
       general: { label: 'General', description: 'Privacy, startup, conversation defaults, and network proxy preferences.' },
       appearance: { label: 'Appearance', description: 'Theme, color palette, and interface language.' },
+      projects: { label: 'Projects', description: 'Manage the projects Maka knows about, and which one new conversations open in.' },
       models: { label: 'Models', description: 'Model connections, API keys, and OAuth subscriptions.' },
       subagents: { label: 'Subagents', description: 'Configure the subagents, capability boundaries, and models the main agent may select.' },
       usage: { label: 'Usage', description: 'Token, model, tool usage trends, and quota tracking.' },

--- a/apps/desktop/src/renderer/locales/settings-projects-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-projects-copy.ts
@@ -1,0 +1,85 @@
+import type { UiCatalog, UiLocale } from '@maka/core';
+
+export type SettingsProjectsCopy = {
+  section: string;
+  sectionHelp: string;
+  addProject: string;
+  defaultBadge: string;
+  setDefault: string;
+  setDefaultTitle: string;
+  /** Why the control is disabled — a disabled control must say so itself. */
+  setDefaultDisabledTitle: string;
+  setDefaultFailed: string;
+  clearDefault: string;
+  remove: string;
+  removeConfirmTitle: string;
+  removeConfirmBody: string;
+  removeConfirm: string;
+  removeCancel: string;
+  actionFailed: string;
+  unavailable: string;
+  /** Shown when the configured default no longer names a usable project. */
+  defaultUnavailable: string;
+  emptyTitle: string;
+  emptyBody: string;
+  moreActions: string;
+};
+
+const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
+  zh: {
+    section: '项目',
+    // Says all three layers of the rule in one sentence, because a help line
+    // that only mentions the default would leave the user guessing what
+    // happens before they set one.
+    sectionHelp: '新对话默认打开此项目；未设置时沿用上次使用的项目。任何对话都能在输入框旁临时切换。',
+    addProject: '添加项目',
+    defaultBadge: '默认',
+    setDefault: '设为默认',
+    setDefaultTitle: '新对话默认打开这个项目',
+    setDefaultDisabledTitle: '目录不可用，无法设为默认',
+    setDefaultFailed: '设置默认项目失败',
+    clearDefault: '取消默认',
+    remove: '从 Maka 移除',
+    removeConfirmTitle: '从 Maka 移除这个项目？',
+    // The one thing a user actually fears here, stated first and plainly.
+    removeConfirmBody: '仅从 Maka 的项目列表移除，磁盘上的文件不受影响。该项目下已有的对话会移到"未归属"分组，不会被删除。',
+    removeConfirm: '移除',
+    removeCancel: '取消',
+    actionFailed: '操作失败',
+    unavailable: '目录不可用',
+    defaultUnavailable: '原来的默认项目已不可用，新对话暂时沿用上次使用的项目。',
+    emptyTitle: '还没有项目',
+    emptyBody: '添加一个项目目录后，新对话就能默认从它打开，侧边栏也会按项目归类对话。',
+    moreActions: '更多操作',
+  },
+  en: {
+    section: 'Projects',
+    sectionHelp:
+      'New conversations open in the default project; without one, they reuse the project you last used. Any conversation can switch next to the input box.',
+    addProject: 'Add project',
+    defaultBadge: 'Default',
+    setDefault: 'Set as default',
+    setDefaultTitle: 'Open new conversations in this project',
+    setDefaultDisabledTitle: 'The folder is unavailable, so this cannot be the default',
+    setDefaultFailed: 'Could not set the default project',
+    clearDefault: 'Clear default',
+    remove: 'Remove from Maka',
+    removeConfirmTitle: 'Remove this project from Maka?',
+    removeConfirmBody:
+      'This only removes it from Maka’s project list; the files on disk are untouched. Conversations under this project move to “Ungrouped” and are not deleted.',
+    removeConfirm: 'Remove',
+    removeCancel: 'Cancel',
+    actionFailed: 'Action failed',
+    unavailable: 'Folder unavailable',
+    defaultUnavailable:
+      'The default project is no longer available, so new conversations reuse the project you last used.',
+    emptyTitle: 'No projects yet',
+    emptyBody:
+      'Add a project folder and new conversations can start in it, with the sidebar grouping conversations by project.',
+    moreActions: 'More actions',
+  },
+} satisfies UiCatalog<SettingsProjectsCopy>;
+
+export function getSettingsProjectsCopy(locale: UiLocale): SettingsProjectsCopy {
+  return SETTINGS_PROJECTS_COPY_BY_LOCALE[locale];
+}

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -601,6 +601,7 @@ const EN_STATIC_COMMANDS: Record<StaticCommandId, CommandCopy> = {
 const ZH_SETTINGS_SECTIONS: Record<SettingsSection, string> = {
   general: '通用',
   appearance: '外观',
+  projects: '项目',
   models: '模型',
   subagents: '子 Agent',
   usage: '使用统计',
@@ -617,6 +618,7 @@ const ZH_SETTINGS_SECTIONS: Record<SettingsSection, string> = {
 const EN_SETTINGS_SECTIONS: Record<SettingsSection, string> = {
   general: 'General',
   appearance: 'Appearance',
+  projects: 'Projects',
   models: 'Models',
   subagents: 'Subagents',
   usage: 'Usage',

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { AppSettings, ProjectRecord, UpdateAppSettingsResult } from '@maka/core';
+import {
+  Badge,
+  Button,
+  EmptyState,
+  MoreMenu,
+  useMountedRef,
+  useToast,
+  useUiLocale,
+} from '@maka/ui';
+import { getSettingsProjectsCopy } from '../locales/settings-projects-copy.js';
+import { settingsActionErrorMessage } from './settings-error-copy';
+import { SettingRow } from './settings-rows';
+import { SettingsPage, SettingsSection } from './settings-section';
+import { useKeyedActionGuard } from './use-action-guard';
+
+/**
+ * Settings · 偏好 · 项目 — the management view of the project catalog, and the
+ * home of the default project.
+ *
+ * Project management used to be scattered across the surfaces that happened to
+ * need it: adding lived in the composer, renaming in the sidebar row menu, and
+ * "which project does a new chat open in" was not a setting at all — it was
+ * whichever project you used last, decided implicitly by
+ * `project-root-controller` and invisible to the user.
+ *
+ * This page does not own a second copy of that data. The catalog behind
+ * `window.maka.projects` is the same one the sidebar groups by and the composer
+ * picker chooses from; what this page adds is a preference stored beside it.
+ */
+export function ProjectsSettingsPage(props: {
+  settings: AppSettings;
+  onUpdate(
+    patch: Parameters<typeof window.maka.settings.update>[0],
+  ): Promise<UpdateAppSettingsResult>;
+}) {
+  const locale = useUiLocale();
+  const copy = getSettingsProjectsCopy(locale);
+  const toast = useToast();
+  const mountedRef = useMountedRef();
+  const actionGuard = useKeyedActionGuard<string>();
+  const [projects, setProjects] = useState<ProjectRecord[]>([]);
+
+  const reload = useCallback(async () => {
+    const next = await window.maka.projects.list();
+    if (mountedRef.current) setProjects(next);
+  }, [mountedRef]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // Archived projects are removed-from-Maka, not deleted; they belong to the
+  // restore path, not to a list whose whole purpose is "what can I open".
+  const listed = projects.filter((project) => project.archivedAt === undefined);
+  const defaultProjectId = props.settings.projects.defaultProjectId;
+  // The stored id is a preference, not a guarantee: the project it names can be
+  // archived or lose its folder afterwards. Saying so out loud beats silently
+  // behaving like no default was ever set — a silent fallback is the same kind
+  // of lie as a control that claims a state it does not have.
+  const defaultResolves =
+    defaultProjectId !== undefined &&
+    listed.some((project) => project.id === defaultProjectId && project.available);
+
+  async function runRowAction(key: string, action: () => Promise<void>, failure: string) {
+    const release = actionGuard.begin(key);
+    if (!release) return;
+    try {
+      await action();
+      await reload();
+    } catch (error) {
+      if (mountedRef.current) toast.error(failure, settingsActionErrorMessage(error, locale));
+    } finally {
+      release();
+    }
+  }
+
+  async function setDefault(projectId: string | undefined) {
+    await props.onUpdate({ projects: { defaultProjectId: projectId } });
+  }
+
+  return (
+    <SettingsPage as="section" aria-label={copy.section}>
+      {/* No section title: the page header already says 项目, and repeating it
+          straight above the rows is the same duplicate-heading noise we
+          removed from the skills page. The rule this page exists for lives in
+          the page subtitle; the section keeps only its action. */}
+      <SettingsSection
+        description={
+          defaultProjectId !== undefined && !defaultResolves
+            ? `${copy.sectionHelp} ${copy.defaultUnavailable}`
+            : copy.sectionHelp
+        }
+        action={
+          <Button
+            variant="secondary"
+            size="sm"
+            label={copy.addProject}
+            clickAction={async () => {
+              const result = await window.maka.projects.add();
+              if (result.ok) await reload();
+            }}
+          />
+        }
+      >
+        {listed.length === 0 ? (
+          <EmptyState title={copy.emptyTitle} description={copy.emptyBody} />
+        ) : (
+          listed.map((project) => {
+            const isDefault = project.id === defaultProjectId;
+            return (
+              // `SettingRow` with `mono` is the house treatment for machine
+              // text: the path renders as a full-width `code` line under the
+              // name rather than squeezed into the right-anchored end slot,
+              // where long absolute paths wrap into a ragged block.
+              <SettingRow
+                key={project.id}
+                title={project.name}
+                detail=""
+                value={project.preferredPath ?? copy.unavailable}
+                mono
+                action={
+                  <>
+                    {isDefault ? (
+                      <Badge variant="neutral" label={copy.defaultBadge} />
+                    ) : (
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        label={copy.setDefault}
+                        // A disabled control explains its own disabling:
+                        // the enabled tooltip answers "what does this do",
+                        // which is exactly the question the user is NOT
+                        // asking once the button is greyed out.
+                        tooltip={
+                          project.available
+                            ? copy.setDefaultTitle
+                            : copy.setDefaultDisabledTitle
+                        }
+                        isDisabled={!project.available}
+                        clickAction={() =>
+                          runRowAction(
+                            `default:${project.id}`,
+                            () => setDefault(project.id),
+                            copy.setDefaultFailed,
+                          )
+                        }
+                      />
+                    )}
+                    <MoreMenu
+                      label={copy.moreActions}
+                      size="sm"
+                      items={[
+                        ...(isDefault
+                          ? [{
+                              label: copy.clearDefault,
+                              onClick: () =>
+                                void runRowAction(
+                                  `default:${project.id}`,
+                                  () => setDefault(undefined),
+                                  copy.setDefaultFailed,
+                                ),
+                            }]
+                          : []),
+                        {
+                          label: copy.remove,
+                          onClick: () =>
+                            void runRowAction(
+                              `remove:${project.id}`,
+                              async () => {
+                                const ok = await toast.confirm({
+                                  title: copy.removeConfirmTitle,
+                                  description: copy.removeConfirmBody,
+                                  confirmLabel: copy.removeConfirm,
+                                  cancelLabel: copy.removeCancel,
+                                  destructive: true,
+                                });
+                                if (!ok) return;
+                                await window.maka.projects.archive(project.id);
+                                // Removing the default leaves the preference
+                                // pointing at nothing; clear it in the same
+                                // action rather than leaving a dangling id.
+                                if (isDefault) await setDefault(undefined);
+                              },
+                              copy.actionFailed,
+                            ),
+                        },
+                      ]}
+                    />
+                  </>
+                }
+              />
+            );
+          })
+        )}
+      </SettingsSection>
+    </SettingsPage>
+  );
+}

--- a/apps/desktop/src/renderer/settings/settings-nav.ts
+++ b/apps/desktop/src/renderer/settings/settings-nav.ts
@@ -7,6 +7,7 @@ import {
   CalendarDays,
   Cpu,
   Database,
+  FolderOpen,
   Info,
   Palette,
   Search,
@@ -59,6 +60,7 @@ export type { SettingsNavGroup };
 export const SETTINGS_NAV: SettingsNavItem[] = [
   { id: 'general', Icon: SettingsIcon, enabled: true, group: 'preferences' },
   { id: 'appearance', Icon: Palette, enabled: true, group: 'preferences' },
+  { id: 'projects', Icon: FolderOpen, enabled: true, group: 'preferences' },
   { id: 'models', Icon: Cpu, enabled: true, group: 'capabilities' },
   { id: 'subagents', Icon: Workflow, enabled: true, group: 'capabilities' },
   { id: 'memory', Icon: Brain, enabled: true, group: 'capabilities' },

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -32,6 +32,7 @@ import { useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { ProvidersPanel } from './providers-panel';
 import { SubagentSettingsPage } from './subagent-settings-page';
 import { safeLocalStorageSet } from '../browser-storage';
+import { ProjectsSettingsPage } from './projects-settings-page';
 import { AboutSettingsPage } from './about-settings-page';
 import { AppearanceSettingsPage } from './appearance-settings-page';
 import { BotChatSettingsPage } from './bot-chat-settings-page';
@@ -460,6 +461,10 @@ function SettingsPageBody(props: {
           onUpdate={props.onUpdateSettings}
           onRefreshConnections={props.onRefreshConnections}
         />
+      );
+    case 'projects':
+      return (
+        <ProjectsSettingsPage settings={props.settings} onUpdate={props.onUpdateSettings} />
       );
     case 'appearance':
       return (

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -255,3 +255,25 @@ test('a chat-default thinking level the app does not recognize drops to no prefe
   );
   expect(normalized.chatDefaults.thinkingLevel).toBe(undefined);
 });
+
+test('no default project means no preference, not an empty one', () => {
+  const normalized = normalizeSettings(createDefaultSettings());
+  expect(normalized.projects.defaultProjectId).toBe(undefined);
+});
+
+test('a chosen default project survives normalization', () => {
+  const normalized = normalizeSettings(
+    mergeSettings(createDefaultSettings(), { projects: { defaultProjectId: 'proj-7' } }),
+  );
+  expect(normalized.projects.defaultProjectId).toBe('proj-7');
+});
+
+test('a blank default project id is dropped rather than stored', () => {
+  // A blank id cannot name a project, so carrying it would make "a default is
+  // set" true while nothing resolves — the settings row would claim a default
+  // the app can never open.
+  const normalized = normalizeSettings(
+    mergeSettings(createDefaultSettings(), { projects: { defaultProjectId: '   ' } }),
+  );
+  expect(normalized.projects.defaultProjectId).toBe(undefined);
+});

--- a/packages/core/src/e2e-fixture.ts
+++ b/packages/core/src/e2e-fixture.ts
@@ -51,6 +51,7 @@ export type E2eFixtureScenario =
   | 'settings-bots-onboarding'
   | 'settings-about'
   | 'settings-general'
+  | 'settings-projects'
   | 'settings-memory'
   | 'settings-daily-review'
   | 'settings-permissions'

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -63,6 +63,7 @@ export {
 export const SETTINGS_SECTIONS = [
   'general',
   'appearance',
+  'projects',
   'memory',
   'daily-review',
   'models',
@@ -204,6 +205,23 @@ export interface WorkspaceInstructionsSettings {
   enabled: boolean;
 }
 
+/**
+ * Which project a new conversation opens in.
+ *
+ * `defaultProjectId` absent means "no preference", and the app keeps its
+ * existing behaviour of reopening whatever project was used last. Set, it wins
+ * every time — a default that only applied when nothing else was remembered
+ * would be a default in name only, and the composer picker is what overrides
+ * it for a single conversation.
+ *
+ * A project id rather than a path: the catalog owns identity (a project can be
+ * relinked to a new location and keep its id), so storing the path would make
+ * this preference silently point at the wrong project after a move.
+ */
+export interface ProjectPreferencesSettings {
+  defaultProjectId?: string;
+}
+
 export interface PrivacySettings {
   incognitoActive: boolean;
 }
@@ -289,6 +307,7 @@ export interface AppSettings {
   workspaceInstructions: WorkspaceInstructionsSettings;
   privacy: PrivacySettings;
   chatDefaults: ChatDefaultsSettings;
+  projects: ProjectPreferencesSettings;
   notifications: NotificationSettings;
   system: SystemSettings;
   subagents: SubagentSettings;
@@ -390,6 +409,7 @@ export type UpdateAppSettingsInput = Partial<{
   workspaceInstructions: Partial<WorkspaceInstructionsSettings>;
   privacy: Partial<PrivacySettings>;
   chatDefaults: Partial<ChatDefaultsSettings>;
+  projects: Partial<ProjectPreferencesSettings>;
   notifications: Partial<NotificationSettings>;
   system: Partial<SystemSettings>;
   webSearch: WebSearchSettingsPatch;
@@ -462,6 +482,7 @@ export function createDefaultSettings(): AppSettings {
       enabled: true,
     },
     privacy: defaultPrivacySettings(),
+    projects: defaultProjectPreferencesSettings(),
     chatDefaults: defaultChatDefaultsSettings(),
     notifications: {
       runComplete: true,
@@ -525,6 +546,9 @@ export function mergeSettings(current: AppSettings, patch: UpdateAppSettingsInpu
     privacy: patch.privacy
       ? normalizePrivacySettings({ ...current.privacy, ...patch.privacy })
       : current.privacy,
+    projects: patch.projects
+      ? normalizeProjectPreferencesSettings({ ...current.projects, ...patch.projects })
+      : current.projects,
     chatDefaults: patch.chatDefaults
       ? normalizeChatDefaultsSettings({
           ...current.chatDefaults,
@@ -562,6 +586,7 @@ export function normalizeSettings(input: unknown): AppSettings {
     workspaceInstructions: value.workspaceInstructions,
     privacy: value.privacy,
     chatDefaults: value.chatDefaults,
+    projects: value.projects,
     notifications: value.notifications,
     system: value.system,
     subagents: value.subagents,
@@ -621,6 +646,7 @@ export function normalizeSettings(input: unknown): AppSettings {
     localMemory: normalizeLocalMemorySettings(base.localMemory),
     workspaceInstructions: normalizeWorkspaceInstructionsSettings(base.workspaceInstructions),
     privacy: normalizePrivacySettings(base.privacy),
+    projects: normalizeProjectPreferencesSettings(base.projects),
     chatDefaults: normalizeChatDefaultsSettings(base.chatDefaults),
     // Fail-closed boolean coercion: mergeSettings spreads the raw user
     // value, so a non-boolean `runComplete` (from a hand-edited or
@@ -661,6 +687,10 @@ function defaultPrivacySettings(): PrivacySettings {
   return { incognitoActive: false };
 }
 
+function defaultProjectPreferencesSettings(): ProjectPreferencesSettings {
+  return {};
+}
+
 function defaultChatDefaultsSettings(): ChatDefaultsSettings {
   return { permissionMode: 'ask' };
 }
@@ -689,4 +719,17 @@ function normalizePrivacySettings(settings: PrivacySettings): PrivacySettings {
   return {
     incognitoActive: settings.incognitoActive === true,
   };
+}
+
+// A blank or non-string id is dropped rather than carried: it cannot name a
+// project, and letting it through would make "has a default" true while
+// nothing resolves. Whether the id still names a LIVE project is decided at
+// read time by the catalog, not here -- a project can be archived or its folder
+// removed long after this value was written, so normalization is the wrong
+// place to answer that.
+function normalizeProjectPreferencesSettings(
+  settings: ProjectPreferencesSettings | undefined,
+): ProjectPreferencesSettings {
+  const id = settings?.defaultProjectId;
+  return typeof id === 'string' && id.trim() !== '' ? { defaultProjectId: id } : {};
 }


### PR DESCRIPTION
## 改了什么

设置 · 偏好 新增「项目」页：项目列表管理 + 默认项目。task #160。

## 为什么

项目管理原本散在各处——添加在 composer、重命名在侧栏行菜单，而「新对话从哪个项目打开」**根本不是一个设置**：它是「上次用过的那个」，由 `project-root-controller` 隐式决定，UI 上完全看不见也改不了。

## 三层规则（按优先级）

1. composer 里显式选了项目 → 该次对话用它（**每次对话都能临时覆盖**）
2. 否则用设置里的默认项目
3. 否则维持原来的 last-used 行为（**没设默认的用户行为零变化**）

「默认覆盖 last-used」而不是「仅在没有 last-used 时兜底」：几乎总是有 last-used，兜底式默认等于永远不生效，那就又是一个说话不算话的旋钮。

## 两个设计决定

**存 projectId 不存路径。** catalog 持有 identity，项目 relink 到新位置后 id 不变；存路径会让这个偏好在目录移动后静默指向别处。

**不可用项目不能设为默认（按钮禁用，且禁用态自述原因）。** 与 #158「任何连接都能设默认」不同：连接失败是单次使用时才暴露、用户可以先设后修；而默认项目指向一个打不开的目录 = **每个新对话都坏**，且修复手段（恢复目录）不在 app 内。预防优于降级。

默认项目失效（归档/目录没了）时，**回退到 last-used 而不是让建会话失败**，并且在设置页把降级说出来——静默降级和假控件是同一类谎。

## 范围说明

`重命名` 和 `在访达中打开` 这一版没进行尾 … 菜单：前者需要仓库里尚不存在的 inline-edit 原语，后者需要新 IPC（`app:openPath` 只认「当前项目」）。**两个能力目前都还在侧栏行菜单里，没有任何能力丢失**，作为后续小任务补。

## 怎么验证的

- **新增 4 个 main 侧解析测试**：默认覆盖 last-used、显式选择覆盖默认、未设默认行为不变、默认失效时回退不炸。**故障注入**：把默认读取拆掉 → 恰好 1 个测试失败 → 装回全绿。
- **新增 e2e** `settings-projects.spec.ts` + `settings-projects` fixture（三个 catalog 条目：可用 / 可用长路径 / 目录真的不存在）：列表渲染、不可用行显示「目录不可用」、禁用按钮的 `aria-describedby` 确实说明原因、设为默认后 Badge 互换且落盘、同时只有一个默认。
- **新增 3 个 core 归一化测试**：未设即无偏好、已设存活、空白 id 丢弃。
- typecheck / lint / format / build / knip（两个 workspace）全绿；desktop 1751、core 812 全过。
- 全量测试的既有失败 3 例（`maka run process contract` ×2、`node:sqlite` ×1）已确认为存量；`runtime-host` 那例是 #2132 的负载下时序 flake，单跑 725/0 通过。

## 视觉

预览截图已过审（列表态 / 设为默认态）。截图过程中修掉三处：页头与节头「项目」标题重复、fixture 用编造路径导致整列渲染成不可用态、以及一个匹配不到 Astryx `Item` 的选择器。