### PR TITLE
feat(settings): rename and reveal a project from its row menu

### DIFF
--- a/apps/desktop/e2e/settings-projects.spec.ts
+++ b/apps/desktop/e2e/settings-projects.spec.ts
@@ -75,3 +75,63 @@ test('the projects page lists the catalog and moves the default between rows', a
     await expect(main.getByText('默认', { exact: true })).toHaveCount(1);
   }
 });
+
+test('a project can be renamed in place from the row menu', async ({
+  settingsProjectsWindow: page,
+}) => {
+  await page
+    .getByRole('navigation', { name: /设置分组|Settings sections/ })
+    .getByRole('button', { name: /项目|Projects/, exact: true })
+    .click();
+
+  const main = page.getByRole('main', { name: /设置内容|Settings content/ });
+  await expect(main.getByText('astryx-design-system', { exact: true })).toBeVisible();
+
+  // Address the row by name, not by index: the app self-registers its own
+  // workspace as a project, so the seeded order is not the rendered order —
+  // an index here renamed the wrong project.
+  await main.getByRole('button', { name: '更多操作：astryx-design-system' }).click();
+  await page.getByRole('menuitem', { name: '重命名' }).click();
+
+  const field = main.getByRole('textbox');
+  await expect(field).toBeFocused();
+  await field.fill('astryx-renamed');
+  await main.getByRole('button', { name: '保存' }).click();
+
+  await expect(main.getByText('astryx-renamed', { exact: true })).toBeVisible();
+  await expect(main.getByText('astryx-design-system', { exact: true })).toHaveCount(0);
+
+  // It is the catalog that changed, not just the row.
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        window.maka.projects.list().then((all) => all.map((p) => p.name)),
+      ),
+    )
+    .toContain('astryx-renamed');
+});
+
+test('reveal is offered only for a project whose folder is still there', async ({
+  settingsProjectsWindow: page,
+}) => {
+  await page
+    .getByRole('navigation', { name: /设置分组|Settings sections/ })
+    .getByRole('button', { name: /项目|Projects/, exact: true })
+    .click();
+
+  const main = page.getByRole('main', { name: /设置内容|Settings content/ });
+  await expect(main.getByText('retired-prototype', { exact: true })).toBeVisible();
+
+  // The seeded `retired-prototype` folder was never created, so opening it
+  // could only fail; the entry is disabled rather than offered-and-broken.
+  await main.getByRole('button', { name: '更多操作：retired-prototype' }).click();
+  await expect(page.getByRole('menuitem', { name: '在访达中打开' })).toBeDisabled();
+  await page.keyboard.press('Escape');
+
+  // Main resolves the path from the catalog by id, so an available project
+  // reports a real directory rather than a renderer-supplied one.
+  const result = await page.evaluate(() =>
+    window.maka.projects.reveal('proj-fixture-gone'),
+  );
+  expect(result.ok).toBe(false);
+});

--- a/apps/desktop/src/main/app-ipc-main.ts
+++ b/apps/desktop/src/main/app-ipc-main.ts
@@ -90,6 +90,19 @@ export function registerAppIpc(
     deps.projectManagement.select(projectId));
   targetIpc.handle('projects:relink', (_event, projectId: unknown) =>
     deps.projectManagement.relink(projectId));
+  // Reveal takes an id, not a path: main asks the catalog where that project
+  // lives, so a renderer cannot ask for an arbitrary directory to be opened.
+  // The existing `project` open-path guard then re-checks the resolved
+  // directory before it reaches the shell.
+  targetIpc.handle('projects:reveal', async (_event, projectId: unknown): Promise<OpenPathResult> => {
+    const projectPath = await deps.projectManagement.pathFor(projectId);
+    if (!projectPath) return { ok: false, reason: 'missing' };
+    const resolved = await resolveOpenPath({ key: 'project', workspaceRoot, projectRoot: projectPath });
+    if (!resolved.ok) return resolved;
+    const error = await shell.openPath(resolved.path);
+    if (error) return { ok: false, reason: 'open-failed' };
+    return { ok: true, opened: resolved.key };
+  });
   targetIpc.handle('projects:rename', (_event, projectId: unknown, name: unknown) =>
     deps.projectManagement.rename(projectId, name));
   targetIpc.handle('projects:archive', (_event, projectId: unknown) =>

--- a/apps/desktop/src/main/project-management-service.ts
+++ b/apps/desktop/src/main/project-management-service.ts
@@ -16,6 +16,14 @@ export interface ProjectManagementService {
     projectId: unknown,
   ): Promise<{ project: ProjectRecord | null; path: string }>;
   relink(projectId: unknown): Promise<DirectoryActionResult>;
+  /**
+   * The on-disk path of a catalogued project, for surfaces that need to open
+   * it. Returns null when the project is unknown, archived, or its folder is
+   * gone, so a caller cannot reveal something the catalog no longer vouches
+   * for. Deliberately takes an id rather than a path: the renderer never gets
+   * to name an arbitrary directory for the main process to open.
+   */
+  pathFor(projectId: unknown): Promise<string | null>;
   rename(projectId: unknown, name: unknown): Promise<ProjectRecord>;
   archive(projectId: unknown): Promise<ProjectRecord>;
   restore(projectId: unknown): Promise<ProjectRecord>;
@@ -140,6 +148,15 @@ export function createProjectManagementService(deps: {
         deps.selection.setSelection(project.id, project.preferredPath);
       }
       return { ok: true, project };
+    },
+
+    async pathFor(projectId) {
+      const id = requireProjectId(projectId);
+      const project = (await deps.catalog.list()).find(
+        (candidate) => candidate.id === id || candidate.aliases?.includes(id),
+      );
+      if (!project || project.archivedAt !== undefined || !project.available) return null;
+      return project.preferredPath ?? null;
     },
 
     rename(projectId, name) {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -369,6 +369,8 @@ export interface MakaBridge {
     relink(
       projectId: string,
     ): Promise<{ ok: true; project: ProjectRecord } | { ok: false; reason: 'cancelled' }>;
+    /** Open a catalogued project's folder in the OS file manager. */
+    reveal(projectId: string): Promise<OpenPathResult>;
     rename(projectId: string, name: string): Promise<ProjectRecord>;
     archive(projectId: string): Promise<ProjectRecord>;
     restore(projectId: string): Promise<ProjectRecord>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -410,6 +410,15 @@ const makaBridge = {
     > {
       return ipcRenderer.invoke('projects:relink', projectId);
     },
+    reveal(projectId: string): Promise<
+      | { ok: true; opened: string }
+      | {
+          ok: false;
+          reason: 'unknown-key' | 'not-allowed' | 'missing' | 'not-a-directory' | 'open-failed';
+        }
+    > {
+      return ipcRenderer.invoke('projects:reveal', projectId);
+    },
     rename(projectId: string, name: string): Promise<ProjectRecord> {
       return ipcRenderer.invoke('projects:rename', projectId, name);
     },

--- a/apps/desktop/src/renderer/locales/settings-projects-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-projects-copy.ts
@@ -10,6 +10,13 @@ export type SettingsProjectsCopy = {
   /** Why the control is disabled — a disabled control must say so itself. */
   setDefaultDisabledTitle: string;
   setDefaultFailed: string;
+  rename: string;
+  renameLabel: string;
+  renameFailed: string;
+  openFolder: string;
+  openFolderFailed: string;
+  save: string;
+  cancel: string;
   clearDefault: string;
   remove: string;
   removeConfirmTitle: string;
@@ -22,7 +29,12 @@ export type SettingsProjectsCopy = {
   defaultUnavailable: string;
   emptyTitle: string;
   emptyBody: string;
-  moreActions: string;
+  /**
+   * Names the row it belongs to. Four buttons all called 更多操作 are one
+   * button as far as assistive tech is concerned — and they were equally
+   * ambiguous to a test, which is how the ambiguity was noticed.
+   */
+  moreActions(projectName: string): string;
 };
 
 const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
@@ -38,6 +50,15 @@ const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
     setDefaultTitle: '新对话默认打开这个项目',
     setDefaultDisabledTitle: '目录不可用，无法设为默认',
     setDefaultFailed: '设置默认项目失败',
+    rename: '重命名',
+    renameLabel: '项目名称',
+    renameFailed: '重命名失败',
+    openFolder: '在访达中打开',
+    // Says which of the two things went wrong, because the fix differs: a
+    // missing folder is the user's to restore, a refusal to open is not.
+    openFolderFailed: '打不开这个目录，它可能已被移动或删除',
+    save: '保存',
+    cancel: '取消',
     clearDefault: '取消默认',
     remove: '从 Maka 移除',
     removeConfirmTitle: '从 Maka 移除这个项目？',
@@ -50,7 +71,7 @@ const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
     defaultUnavailable: '原来的默认项目已不可用，新对话暂时沿用上次使用的项目。',
     emptyTitle: '还没有项目',
     emptyBody: '添加一个项目目录后，新对话就能默认从它打开，侧边栏也会按项目归类对话。',
-    moreActions: '更多操作',
+    moreActions: (projectName: string) => `更多操作：${projectName}`,
   },
   en: {
     section: 'Projects',
@@ -62,6 +83,13 @@ const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
     setDefaultTitle: 'Open new conversations in this project',
     setDefaultDisabledTitle: 'The folder is unavailable, so this cannot be the default',
     setDefaultFailed: 'Could not set the default project',
+    rename: 'Rename',
+    renameLabel: 'Project name',
+    renameFailed: 'Could not rename the project',
+    openFolder: 'Reveal in Finder',
+    openFolderFailed: 'Could not open this folder — it may have been moved or deleted',
+    save: 'Save',
+    cancel: 'Cancel',
     clearDefault: 'Clear default',
     remove: 'Remove from Maka',
     removeConfirmTitle: 'Remove this project from Maka?',
@@ -76,7 +104,7 @@ const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
     emptyTitle: 'No projects yet',
     emptyBody:
       'Add a project folder and new conversations can start in it, with the sidebar grouping conversations by project.',
-    moreActions: 'More actions',
+    moreActions: (projectName: string) => `More actions for ${projectName}`,
   },
 } satisfies UiCatalog<SettingsProjectsCopy>;
 

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -5,14 +5,15 @@ import {
   Button,
   EmptyState,
   MoreMenu,
+  TextInput,
   useMountedRef,
   useToast,
   useUiLocale,
 } from '@maka/ui';
 import { getSettingsProjectsCopy } from '../locales/settings-projects-copy.js';
 import { settingsActionErrorMessage } from './settings-error-copy';
-import { SettingRow } from './settings-rows';
 import { SettingsPage, SettingsSection } from './settings-section';
+import { SettingsExpandableRow } from './settings-expandable-row';
 import { useKeyedActionGuard } from './use-action-guard';
 
 /**
@@ -41,6 +42,8 @@ export function ProjectsSettingsPage(props: {
   const mountedRef = useMountedRef();
   const actionGuard = useKeyedActionGuard<string>();
   const [projects, setProjects] = useState<ProjectRecord[]>([]);
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [draftName, setDraftName] = useState('');
 
   const reload = useCallback(async () => {
     const next = await window.maka.projects.list();
@@ -109,18 +112,7 @@ export function ProjectsSettingsPage(props: {
         ) : (
           listed.map((project) => {
             const isDefault = project.id === defaultProjectId;
-            return (
-              // `SettingRow` with `mono` is the house treatment for machine
-              // text: the path renders as a full-width `code` line under the
-              // name rather than squeezed into the right-anchored end slot,
-              // where long absolute paths wrap into a ragged block.
-              <SettingRow
-                key={project.id}
-                title={project.name}
-                detail=""
-                value={project.preferredPath ?? copy.unavailable}
-                mono
-                action={
+            const endCluster = (
                   <>
                     {isDefault ? (
                       <Badge variant="neutral" label={copy.defaultBadge} />
@@ -149,7 +141,7 @@ export function ProjectsSettingsPage(props: {
                       />
                     )}
                     <MoreMenu
-                      label={copy.moreActions}
+                      label={copy.moreActions(project.name)}
                       size="sm"
                       items={[
                         ...(isDefault
@@ -163,6 +155,29 @@ export function ProjectsSettingsPage(props: {
                                 ),
                             }]
                           : []),
+                        {
+                          label: copy.rename,
+                          onClick: () => {
+                            setDraftName(project.name);
+                            setRenamingId(project.id);
+                          },
+                        },
+                        {
+                          label: copy.openFolder,
+                          // Only offered when the catalog still vouches for the
+                          // folder; a menu entry that always fails is worse
+                          // than one that is not there.
+                          isDisabled: !project.available,
+                          onClick: () =>
+                            void runRowAction(
+                              `reveal:${project.id}`,
+                              async () => {
+                                const result = await window.maka.projects.reveal(project.id);
+                                if (!result.ok) throw new Error(result.reason);
+                              },
+                              copy.openFolderFailed,
+                            ),
+                        },
                         {
                           label: copy.remove,
                           onClick: () =>
@@ -189,8 +204,53 @@ export function ProjectsSettingsPage(props: {
                       ]}
                     />
                   </>
+            );
+
+            // Renaming swaps the row for the shared expandable editor, which
+            // owns the focus move in and back out. The end cluster rides along
+            // so the row keeps its default state and menu while collapsed —
+            // rename is reached from that menu, not from a competing button.
+            return (
+              <SettingsExpandableRow
+                key={project.id}
+                label={project.name}
+                value={
+                  <code className="settingsReadOnlyValue" data-mono="true">
+                    {project.preferredPath ?? copy.unavailable}
+                  </code>
                 }
-              />
+                end={endCluster}
+                isEditing={renamingId === project.id}
+                canSave={draftName.trim() !== '' && draftName.trim() !== project.name}
+                saveLabel={copy.save}
+                cancelLabel={copy.cancel}
+                onEdit={() => {
+                  setDraftName(project.name);
+                  setRenamingId(project.id);
+                }}
+                onCancel={() => setRenamingId(null)}
+                onSave={async () => {
+                  const next = draftName.trim();
+                  if (next === '' || next === project.name) return;
+                  await runRowAction(
+                    `rename:${project.id}`,
+                    async () => {
+                      await window.maka.projects.rename(project.id, next);
+                      setRenamingId(null);
+                    },
+                    copy.renameFailed,
+                  );
+                }}
+              >
+                <TextInput
+                  type="text"
+                  value={draftName}
+                  onChange={(value) => setDraftName(value.slice(0, 80))}
+                  label={copy.renameLabel}
+                  isLabelHidden
+                  width="100%"
+                />
+              </SettingsExpandableRow>
             );
           })
         )}

--- a/apps/desktop/src/renderer/settings/settings-expandable-row.tsx
+++ b/apps/desktop/src/renderer/settings/settings-expandable-row.tsx
@@ -37,8 +37,18 @@ export function SettingsExpandableRow(props: {
   label: string;
   /** The settled value, shown while collapsed. */
   value: ReactNode;
-  /** Label for the affordance that opens the editor (更改 / 设置 / 编辑). */
-  actionLabel: string;
+  /** Label for the affordance that opens the editor (更改 / 设置 / 编辑).
+   *  Unused when `end` supplies the row's own cluster. */
+  actionLabel?: string;
+  /**
+   * Replaces the built-in 更改 trigger for rows that already own their end
+   * slot — a project row carries a default Badge, a 设为默认 button and a …
+   * menu, and editing is reached from that menu rather than from a second
+   * button competing with them. The editor, its focus move, and the
+   * save/cancel pair stay identical either way, which is the whole reason
+   * this lives here instead of being hand-rolled per page.
+   */
+  end?: ReactNode;
   isEditing: boolean;
   isDisabled?: boolean;
   /** Save stays disabled until the draft actually differs from the value. */
@@ -85,14 +95,14 @@ export function SettingsExpandableRow(props: {
         label={props.label}
         description={props.value}
         align="start"
-        end={(
+        end={props.end ?? (
           <Button
             ref={triggerRef}
             variant="ghost"
             size="sm"
             isDisabled={props.isDisabled}
             onClick={props.onEdit}
-            label={props.actionLabel}
+            label={props.actionLabel ?? ''}
           />
         )}
       />


### PR DESCRIPTION
## 改了什么

补齐 #160 降级掉的两项，项目页从「只能选默认」变成「能管理项目」。task #161。

## 在访达中打开：传 id，不传路径

渲染层传 **projectId**，主进程向 catalog 问这个项目在哪，再交给已有的 `project` open-path 守卫复核解析后的目录。**渲染层没有机会指定任意目录让 shell 打开** —— 这比把 `app:openPath` 放开成「接受任意路径」安全，也不需要新的守卫逻辑。

只在 catalog 仍然认可该目录时才可点：一个必然失败的菜单项，比没有这个菜单项更糟。

## 重命名：复用既有原语，不是新造

`SettingsExpandableRow` **本来就存在**（外观页的显示名称在用），它已经封好了「打开时聚焦第一个控件、关闭时把焦点还给行」以及「为什么故意不挂 aria-expanded」这些判断。手写第二套编辑器等于把这些判断重做一遍还容易漏。

给它加了一个 `end` prop：本来就自带尾部控件簇的行（默认 Badge / 设为默认 / … 菜单）保留自己的簇，而不是再长出一个和它们抢位置的「更改」按钮。重命名从 … 菜单进。既有调用方不传 `end`，行为不变。

## 顺带修一个真问题

每行的 … 菜单现在带上项目名（`更多操作：astryx-design-system`）。**四个都叫「更多操作」的按钮，对辅助技术来说等于同一个按钮**；它们对测试也同样有歧义——我第一版 e2e 按下标定位，结果重命名了错误的那一行（app 会自注册一个工作区项目，导致渲染顺序和 fixture 种子顺序不一致）。是截图暴露的，不是断言。

## 怎么验证的

- e2e 从 1 个扩到 3 个：重命名（含焦点断言 + catalog 真的改了，不只是行变了）、不可用项目的「在访达中打开」为禁用、`reveal` 对目录不存在的项目返回 `ok:false`。
- typecheck / lint / format / build / knip 全绿；desktop **1751 passed / 0 failed**。
- 测试按名字定位行，不按下标——这次翻车的直接原因。