### PR TITLE
test(cli): replace fixed waits in Pi TUI coverage with observable completion

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -61,8 +61,16 @@ import {
   inputSurfaceRows,
   latestPlainLineContaining,
   plainTerminalOutput,
+  WAIT_BUDGET_MS,
   waitFor,
+  waitForTuiPaint,
 } from './tui-terminal-mock.js';
+
+// Deadline for `Promise.race([run, …])` close watchdogs. A passing race
+// resolves the moment `run` settles, so this only bounds how long a FAILING
+// close takes to report — the same budget split as waitFor's WAIT_BUDGET_MS
+// (tight locally, generous on loaded CI runners).
+const CLOSE_BUDGET_MS = Math.max(WAIT_BUDGET_MS, 500);
 
 // Pin truecolor so the accent-chrome escape assertion ("uses logo blue") is
 // hermetic. Color level is detected from process.env.TERM/COLORTERM at module
@@ -214,7 +222,7 @@ describe('Maka Pi TUI runner', () => {
 
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -295,7 +303,7 @@ describe('Maka Pi TUI runner', () => {
       }),
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => {
@@ -333,7 +341,7 @@ describe('Maka Pi TUI runner', () => {
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -359,7 +367,7 @@ describe('Maka Pi TUI runner', () => {
       }),
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => {
@@ -381,16 +389,24 @@ describe('Maka Pi TUI runner', () => {
     // as the API key (otherwise /exit, /model, etc. become persisted secrets).
     terminal.input('/setup');
     terminal.input('\r');
-    await delay(60);
-    assert.equal(verifyCalls.length, 0);
+    // The wizard restarts at the provider step (closeWizard + re-route): the
+    // key field leaving the screen is the observable proof the input line was
+    // routed as a command instead of being consumed as key text.
+    await waitFor(() => {
+      const screen = plainTerminalOutput(terminal.screenOutput());
+      return screen.includes('Set Up Provider') && !screen.includes('API key');
+    });
 
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
+    // Anchored after close: every queued input has been fully processed, so a
+    // swallowed-as-key submit would have surfaced in verifyCalls by now.
+    assert.equal(verifyCalls.length, 0);
   });
 
   test('/setup without an onboarding surface reports unavailable in-frame instead of throwing', async () => {
@@ -408,7 +424,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => {
@@ -439,7 +455,7 @@ describe('Maka Pi TUI runner', () => {
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -465,18 +481,21 @@ describe('Maka Pi TUI runner', () => {
       },
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/setup');
     terminal.input('\r');
-    await delay(60);
-    const out = plainTerminalOutput(terminal.screenOutput());
-    assert.match(out, /storage read failed/);
-    assert.doesNotMatch(out, /没有可配置的 API key 类供应商/);
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('storage read failed'),
+    );
+    assert.doesNotMatch(
+      plainTerminalOutput(terminal.screenOutput()),
+      /没有可配置的 API key 类供应商/,
+    );
 
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -509,7 +528,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\x1b');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close on first-run picker cancel');
       }),
     ]);
@@ -541,7 +560,7 @@ describe('Maka Pi TUI runner', () => {
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -578,7 +597,7 @@ describe('Maka Pi TUI runner', () => {
       }),
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => {
@@ -606,7 +625,9 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('已启用 1 个模型'));
     assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /已配置/);
     terminal.input('\r'); // close the in-frame success
-    await delay(40);
+    // The success frame leaving the screen proves the wizard overlay released
+    // input focus, so the next line routes to the editor.
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('已启用 1 个模型'));
     // The refreshed ready model choices are immediately available from /model.
     terminal.input('/model');
     terminal.input('\r');
@@ -617,7 +638,7 @@ describe('Maka Pi TUI runner', () => {
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -669,7 +690,7 @@ describe('Maka Pi TUI runner', () => {
     // host re-resolves the now-configured default connection and relaunches.
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('first-run TUI did not close after save');
       }),
     ]);
@@ -700,7 +721,7 @@ describe('Maka Pi TUI runner', () => {
       }),
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => {
@@ -752,16 +773,18 @@ describe('Maka Pi TUI runner', () => {
     // A's verify now resolves with a failure. It must not clobber attempt B:
     // no failure status line, and the key being typed for B survives.
     resolveFirst({ kind: 'error', text: 'HTTP 401 Unauthorized' });
-    await delay(40);
+    // Sentinel render: one more typed key char forces a full repaint that lands
+    // after A's settled continuation, so a wrongly-applied failure line would be
+    // in this exact frame.
+    terminal.input('x');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('sk-bx'));
 
-    const out = plainTerminalOutput(terminal.screenOutput());
-    assert.doesNotMatch(out, /验证失败/);
-    assert.ok(out.includes('sk-b'));
+    assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /验证失败/);
 
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -792,7 +815,7 @@ describe('Maka Pi TUI runner', () => {
       }),
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => {
@@ -834,13 +857,17 @@ describe('Maka Pi TUI runner', () => {
     });
     // A's save now resolves ok. It must not show success or refresh choices.
     resolveFirstSave({ kind: 'ok', modelChoices: [] });
-    await delay(40);
+    // Sentinel render: typing into the key field forces a repaint that lands
+    // after A's settled save continuation, so a wrongly-shown success frame
+    // would be in this exact frame.
+    terminal.input('sk-z');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('sk-z'));
     assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /已启用/);
 
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -869,7 +896,7 @@ describe('Maka Pi TUI runner', () => {
       }),
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/setup');
     terminal.input('\r');
     await waitFor(() => {
@@ -903,7 +930,9 @@ describe('Maka Pi TUI runner', () => {
       }
     });
     terminal.input('\x03'); // Ctrl+C closes the wizard
-    await delay(30);
+    // The wizard frame leaving the screen proves the overlay released input
+    // focus, so the next line routes to the editor.
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('2/3'));
     // The save completes after the user left. The running TUI's ready model
     // choices are still authoritatively refreshed — abandoning the wizard only
     // drops the in-frame success UI, not the background state sync.
@@ -919,7 +948,10 @@ describe('Maka Pi TUI runner', () => {
         },
       ],
     });
-    await delay(40);
+    // The refresh (`modelChoices = result.modelChoices`) lands in the save
+    // promise's first continuation; one macrotask turn runs strictly after
+    // every queued microtask, so the choices are applied by the time it fires.
+    await delay(0);
     terminal.input('/model');
     terminal.input('\r');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('gpt-5.5-new'));
@@ -928,7 +960,7 @@ describe('Maka Pi TUI runner', () => {
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -986,15 +1018,15 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('hello');
     terminal.input('\r');
-    await delay(40);
+    // The wizard is back open as the only first-run surface; its frame is the
+    // observable proof the submit was intercepted before reaching the driver.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
     assert.equal(preparePromptCalls, 0);
-    // The wizard is back open as the only first-run surface.
-    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Set Up Provider'));
 
     process.emit('SIGTERM');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after SIGTERM');
       }),
     ]);
@@ -1036,7 +1068,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\x03');
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('Ctrl+C did not close the first-run wizard from the key phase');
       }),
     ]);
@@ -1061,7 +1093,11 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
 
     await waitFor(() => driver.boundaryRequests === 1);
-    await delay(20);
+    // The rendered prompt is the observable arming signal: only once it owns
+    // input does 'y' mean allow instead of editor text.
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Allow access outside the workspace?'),
+    );
     terminal.input('y');
     await waitFor(() => driver.boundaryResponses.length === 1);
 
@@ -1075,7 +1111,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1104,19 +1140,32 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('run');
     terminal.input('\r');
-    await delay(20);
+    // The submit clearing the editor is the observable signal the next typed
+    // text starts a fresh draft instead of appending to 'run'.
+    await waitFor(() => {
+      try {
+        return editorInputText(terminal) === '';
+      } catch {
+        return false; // the first frame has not painted an editor yet
+      }
+    });
     terminal.input('keep this draft');
     await waitFor(() => editorInputText(terminal) === 'keep this draft');
     releaseBoundaryRequest();
     await waitFor(() => driver.boundaryRequests === 1);
+    // The rendered prompt is the observable arming signal: only once it owns
+    // input is 'x' a (rejected) decision key instead of editor text.
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Allow access outside the workspace?'),
+    );
 
     terminal.input('x');
-    await delay(20);
-    assert.equal(editorInputText(terminal), 'keep this draft');
-    assert.deepEqual(driver.boundaryResponses, []);
-
     terminal.input('n');
     await waitFor(() => driver.boundaryResponses.length === 1);
+    // Input is processed in order, so a single deny response proves the armed
+    // prompt ignored 'x': an 'x'-triggered response would either add a second
+    // entry or change the first decision.
+    assert.deepEqual(driver.boundaryResponses, [{ requestId: 'boundary-1', decision: 'deny' }]);
     await waitFor(() => editorInputText(terminal) === 'keep this draft');
 
     exitMaka(terminal);
@@ -1139,14 +1188,17 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('run');
     terminal.input('\r');
     await waitFor(() => driver.boundaryRequests === 1);
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Allow access outside the workspace?'),
+    );
     terminal.input('\x1b[121;1:2u');
-    await delay(20);
-    assert.deepEqual(driver.boundaryResponses, []);
-
     terminal.input('y');
     await waitFor(() => driver.boundaryResponses.length === 1);
     exitMaka(terminal);
     await run;
+    // After close every queued input has been drained: exactly one allow
+    // response proves the armed prompt ignored the 'y' key-release event.
+    assert.deepEqual(driver.boundaryResponses, [{ requestId: 'boundary-1', decision: 'allow' }]);
   });
 
   test('ignores the removed turn-wide approval key while a boundary request waits', async () => {
@@ -1167,12 +1219,15 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('n');
     terminal.input('\r');
     await waitFor(() => driver.boundaryRequests === 1);
-    await delay(20);
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Allow access outside the workspace?'),
+    );
     terminal.input('a');
-    await delay(20);
-    assert.equal(driver.boundaryResponses.length, 0);
     terminal.input('y');
     await waitFor(() => driver.boundaryResponses.length === 1);
+    // Input is processed in order, so a single allow response proves the armed
+    // prompt ignored the removed turn-wide 'a' key: an 'a'-triggered response
+    // would either add a second entry or change the first decision.
     assert.deepEqual(driver.boundaryResponses, [
       {
         requestId: 'boundary-1',
@@ -1183,7 +1238,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1208,7 +1263,11 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
 
     await waitFor(() => driver.boundaryRequests === 1);
-    await delay(20);
+    // The rendered prompt is the observable arming signal: only once it owns
+    // input does 'n' mean deny instead of editor text.
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Allow access outside the workspace?'),
+    );
     terminal.input('n');
     await waitFor(() => driver.boundaryResponses.length === 1);
 
@@ -1222,7 +1281,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1277,7 +1336,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1374,12 +1433,11 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Anything else'));
 
     // Q3: ↑ from the first option wraps to the (empty) Other row; Enter there is a
-    // no-op, so the question stays open until Escape leaves it unanswered.
+    // no-op, so the question stays open until Escape leaves it unanswered. Input
+    // is processed in order, so the null third answer below proves the Enter
+    // submitted nothing — a submit would have answered Q3 before the Escape.
     terminal.input('\x1b[A');
     terminal.input('\r');
-    await delay(20);
-    assert.equal(driver.responses.length, 0);
-    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('Anything else'));
     terminal.input('\x1b');
 
     await waitFor(() => driver.responses.length === 1);
@@ -1547,7 +1605,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1556,6 +1614,10 @@ describe('Maka Pi TUI runner', () => {
   test('off-screen running-Bash ticker never clears scrollback (#1135)', async () => {
     const terminal = new FakeTerminal();
     const driver = new OffscreenTickerDriver();
+    // Drive the 1s elapsed ticker manually instead of waiting wall-clock
+    // seconds: the injected clock advances and the captured callback fires.
+    let fakeNow = 10_000;
+    let tick: (() => void) | undefined;
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -1564,21 +1626,39 @@ describe('Maka Pi TUI runner', () => {
       connectionSlug: 'claude-subscription',
       permissionMode: 'ask',
       terminal,
+      shellRunTicker: {
+        now: () => fakeNow,
+        schedule: (callback) => {
+          tick = callback;
+          return () => {
+            tick = undefined;
+          };
+        },
+      },
     });
 
     terminal.input('r');
     terminal.input('\r');
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('late-build'));
 
-    // The ticker fires every 1s; wait past two ticks. The early running card
-    // is off-screen, so its elapsed update must not trigger a scrollback wipe.
-    await delay(2_500);
+    // Two elapsed ticks. The early running card is off-screen, so its elapsed
+    // update must not trigger a scrollback wipe.
+    await waitFor(() => tick !== undefined, 'the elapsed ticker to be scheduled');
+    fakeNow += 1_000;
+    tick!();
+    fakeNow += 1_000;
+    tick!();
+    // Sentinel render: the typed char repaints in the same coalesced pass as
+    // the tick-dirtied state, so a wrongful scrollback clear would have been
+    // written by the time it shows.
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal) === 'z');
     assert.equal(terminal.output().includes('\x1b[3J'), false);
 
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1629,14 +1709,18 @@ describe('Maka Pi TUI runner', () => {
         output: pipeOutput('early-build done'),
       },
     });
-    await delay(50);
+    // Sentinel render: the typed char repaints in the same coalesced pass as
+    // the settle-dirtied state, so a wrongful scrollback clear would have been
+    // written by the time it shows.
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal) === 'z');
 
     assert.equal(terminal.output().includes('\x1b[3J'), false);
 
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1666,7 +1750,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1694,7 +1778,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1779,13 +1863,16 @@ describe('Maka Pi TUI runner', () => {
     // The compact-only annotation leaving the screen proves the card is
     // still expanded after the release event.
     await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('(31 lines)'));
-    await delay(20);
+    // Sentinel render ordered after the release event: if the release had
+    // collapsed the card back, this frame would show the annotation again.
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal) === 'z');
     assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('(31 lines)'), false);
 
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1810,9 +1897,13 @@ describe('Maka Pi TUI runner', () => {
 
     // One physical Esc keypress arrives as a press + release pair under the
     // kitty protocol; it must count as a single Escape, not an interrupt.
+    // Escape handling runs synchronously off the input dispatch, so one
+    // macrotask turn (which drains every queued microtask first) is a
+    // deterministic settle — a wrongly-counted double Escape would have
+    // called stopSession by now.
     terminal.input('\x1b[27u');
     terminal.input('\x1b[27;1:3u');
-    await delay(20);
+    await delay(0);
     assert.equal(driver.stopCalls, 0);
 
     // A real second press still interrupts the running turn.
@@ -1823,7 +1914,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -1864,7 +1955,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -2137,7 +2228,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -2159,10 +2250,9 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('unsent draft');
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('unsent draft'));
     terminal.input('\x03');
-    await delay(20);
-
+    // The draft leaving the screen is the observable effect of the Ctrl-C.
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('unsent draft'));
     assert.equal(terminal.stopCalls, 0);
-    assert.doesNotMatch(plainTerminalOutput(terminal.screenOutput()), /unsent draft/);
     terminal.input('/exit');
     terminal.input('\r');
     await run;
@@ -2212,8 +2302,12 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() =>
       plainTerminalOutput(terminal.screenOutput()).includes('Press Ctrl+C again to exit.'),
     );
+    // Ctrl-C counting runs synchronously off the input dispatch, so one
+    // macrotask turn (which drains every queued microtask first) is a
+    // deterministic settle — a wrongly-counted second press would have begun
+    // closing the terminal by now.
     terminal.input('\x1b[99;5:2u');
-    await delay(20);
+    await delay(0);
 
     assert.equal(terminal.stopCalls, 0);
     terminal.input('\x1b[99;5u');
@@ -2236,8 +2330,12 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('run');
     terminal.input('\r');
     await waitFor(() => terminal.progressStates.at(-1) === true);
+    // Ctrl-D handling runs synchronously off the input dispatch, so one
+    // macrotask turn (which drains every queued microtask first) is a
+    // deterministic settle — a wrongly-honored Ctrl-D would have begun
+    // closing the terminal or stopping the turn by now.
     terminal.input('\x04');
-    await delay(20);
+    await delay(0);
 
     assert.equal(terminal.stopCalls, 0);
     assert.equal(driver.stopCalls, 0);
@@ -2536,13 +2634,20 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('a draft to keep'));
 
     terminal.input('\x1b\r'); // Alt+Enter while a control action holds `busy`
-    await delay(20);
-
+    // The submit gate runs synchronously off the input dispatch; one macrotask
+    // turn (which drains every queued microtask first) is a deterministic
+    // settle for the prompt check.
+    await delay(0);
     assert.deepEqual(driver.prompts, []);
-    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('a draft to keep'));
+    // Sentinel render: the draft growing by the typed char proves the editor
+    // kept it — a wrongful submit would have cleared it first.
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal) === 'a draft to keepz');
 
     driver.releaseSetModel();
-    await delay(20);
+    // The control action settles through its promise continuations; one
+    // macrotask turn runs strictly after them, releasing `busy` for /exit.
+    await delay(0);
     terminal.input('\x03'); // clear the preserved draft
     terminal.input('/exit');
     terminal.input('\r');
@@ -2578,9 +2683,11 @@ describe('Maka Pi TUI runner', () => {
       );
     });
 
-    // The old bounded poll gave up after ~2s of busy and silently dropped the
-    // text; a normal turn easily outlives that budget.
-    await delay(2200);
+    // The old bounded poll gave up after ~2s of busy (about 20 attempts at the
+    // 100ms retry cadence) and silently dropped the text. Waiting for the
+    // driver to observe the retries crossing that budget — instead of guessing
+    // elapsed time — proves the CLI is still retrying under any scheduler load.
+    await waitForUpTo(() => driver.steerAttempts > 22 && driver.queueAttempts > 22, 30_000);
     const screen = plainTerminalOutput(terminal.screenOutput());
     assert.equal(screen.includes('Steering: second thought'), true);
     assert.equal(screen.includes('Queued: and afterwards'), true);
@@ -2765,19 +2872,25 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('after stop');
     terminal.input('\r'); // Enter: submits are disabled during convergence
     terminal.input('\x1b\r'); // Alt+Enter: gated before touching the editor
-    await delay(20);
+    // The convergence gates run synchronously off the input dispatch; one
+    // macrotask turn (which drains every queued microtask first) settles them.
+    await delay(0);
 
     driver.endTurn(); // the aborted turn finally terminates
     await waitFor(() => terminal.progressStates.at(-1) === false);
-    await delay(30);
-    // No second turn is prepared; the typed text is still in the editor as a draft.
-    assert.deepEqual(driver.prompts, ['start the work']);
-    assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('after stop'), true);
+    // The typed text is still in the editor as a draft, never a queued line.
+    await waitFor(() => {
+      const screen = plainTerminalOutput(terminal.screenOutput());
+      return screen.includes('after stop') && !screen.includes('Queued: after stop');
+    });
 
     terminal.input('\x03'); // clear the preserved draft
     terminal.input('/exit');
     terminal.input('\r');
     await run;
+    // Anchored after close: a wrongly-opened second turn would have landed in
+    // prompts by the time the TUI has fully shut down.
+    assert.deepEqual(driver.prompts, ['start the work']);
   });
 
   test('an aborted turn never auto-opens the flush turn; undelivered text becomes a draft', async () => {
@@ -2808,8 +2921,6 @@ describe('Maka Pi TUI runner', () => {
     driver.abortNextTurn = true;
     driver.endTurn();
     await waitFor(() => terminal.progressStates.at(-1) === false);
-    await delay(30);
-    assert.deepEqual(driver.prompts, ['start the work']);
     // The undelivered text is an editable draft, not a queued line.
     await waitFor(() => {
       const screen = plainTerminalOutput(terminal.screenOutput());
@@ -2820,6 +2931,9 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/exit');
     terminal.input('\r');
     await run;
+    // Anchored after close: a wrongly-opened flush turn would have landed in
+    // prompts by the time the TUI has fully shut down.
+    assert.deepEqual(driver.prompts, ['start the work']);
   });
 
   test('closes the main TUI on Ctrl-D', async () => {
@@ -2839,7 +2953,7 @@ describe('Maka Pi TUI runner', () => {
 
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close after Ctrl-D');
       }),
     ]);
@@ -2893,7 +3007,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -2919,14 +3033,18 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => driver.models.length === 1);
     terminal.input('\x03');
-    await delay(20);
+    // The rendered hint is the observable effect of the first Ctrl-C arming
+    // the exit gesture without closing anything.
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Press Ctrl+C again to exit.'),
+    );
 
     try {
       assert.equal(terminal.stopCalls, 0);
       terminal.input('\x03');
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close after the second Ctrl-C');
         }),
       ]);
@@ -2968,7 +3086,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3022,7 +3140,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3047,11 +3165,12 @@ describe('Maka Pi TUI runner', () => {
     assert.deepEqual(driver.permissionModes, []);
 
     terminal.input('\r');
-    await delay(20);
-    assert.deepEqual(driver.permissionModes, []);
 
     exitMaka(terminal);
     await run;
+    // Anchored after close: every queued input has been drained, so a bare
+    // Enter that wrongly confirmed the switch would show in permissionModes.
+    assert.deepEqual(driver.permissionModes, []);
   });
 
   test('returns from Bypass to Auto without a confirmation', async () => {
@@ -3279,7 +3398,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3313,7 +3432,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3363,7 +3482,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3420,7 +3539,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3456,7 +3575,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/model');
     terminal.input('\r');
     await waitFor(() => terminal.output().includes('Select Model'));
@@ -3480,7 +3599,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3516,12 +3635,13 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/model');
     terminal.input('\r');
     await waitFor(() => terminal.output().includes('Select Model'));
     terminal.input('\x1b');
-    await delay(30);
+    // The picker leaving the screen is the observable effect of the cancel.
+    await waitFor(() => !plainTerminalOutput(terminal.screenOutput()).includes('Select Model'));
 
     // Esc closed the picker without rebinding: no setModel call, and the status
     // line still shows the original model + connection.
@@ -3534,7 +3654,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3570,7 +3690,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/model glm-5.2');
     terminal.input('\r');
     await waitFor(() => driver.models.length === 1);
@@ -3584,7 +3704,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3629,7 +3749,7 @@ describe('Maka Pi TUI runner', () => {
       terminal,
     });
 
-    await delay(20);
+    await waitForTuiPaint(terminal);
     terminal.input('/model');
     terminal.input('\r');
     await waitFor(() => terminal.output().includes('Select Model'));
@@ -3670,7 +3790,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(500).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3731,7 +3851,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3760,7 +3880,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3790,7 +3910,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -3905,7 +4025,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4027,7 +4147,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4066,7 +4186,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4132,7 +4252,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4186,7 +4306,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4227,9 +4347,12 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('go');
     terminal.input('\r');
     await waitFor(() => driver.prompts.length === 1);
-    // The driver's promptEvents completes near-instantly (no manual gating),
-    // so give the token_usage + complete events time to drain and render.
-    await delay(20);
+    // The turn ending is the observable drain point for the token_usage +
+    // complete events; the sentinel char then forces one more full frame, so a
+    // wrongly-rendered ctx segment would be in the cumulative output by now.
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal) === 'z');
 
     // Bug under test: the pre-switch session's 1_000 window must not survive
     // to render a (wrong) ctx total against the curated-out model's usage.
@@ -4238,7 +4361,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4447,7 +4570,10 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() =>
       plainTerminalOutput(terminal.output()).includes('Background task completed: build'),
     );
-    await delay(50);
+    // Sentinel render: a duplicate announcement from the same update would be
+    // in the cumulative output by the time the typed char paints.
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal) === 'z');
     const announcements =
       plainTerminalOutput(terminal.output()).split('Background task completed').length - 1;
     assert.equal(announcements, 1);
@@ -4488,7 +4614,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4595,9 +4721,10 @@ describe('Maka Pi TUI runner', () => {
     );
     terminal.input('\x1b[B');
     terminal.input('\r');
-    await delay(10);
+    // Selection handling runs synchronously off the input dispatch; one
+    // macrotask turn (which drains every queued microtask first) settles it.
+    await delay(0);
 
-    assert.deepEqual(driver.sessionIds, []);
     assert.match(
       plainTerminalOutput(terminal.screenOutput()),
       /Legacy chat.*Missing working directory/,
@@ -4606,6 +4733,8 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\x1b');
     exitMaka(terminal);
     await run;
+    // Anchored after close: a wrongly-honored resume would show in sessionIds.
+    assert.deepEqual(driver.sessionIds, []);
   });
 
   test('/context renders persisted request diagnostics without preparing a model turn', async () => {
@@ -4671,7 +4800,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4715,7 +4844,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -4765,7 +4894,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4801,6 +4930,9 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => driver.startNewSessionCalls === 1);
     const attemptsAfterReset = hydrationAttempts;
+    // Real-timer negative window, derived from the hydration retry schedule
+    // (first retry arms at 250ms): outliving that slot with no new attempt
+    // proves /new's reset cleared the timer rather than letting it fire.
     await delay(300);
     assert.equal(hydrationAttempts, attemptsAfterReset);
 
@@ -4842,10 +4974,12 @@ describe('Maka Pi TUI runner', () => {
     await new Promise<void>((resolve) => setImmediate(resolve));
     assert.equal(automationAcquired, false);
 
-    // While the model switch is in flight, typing + Enter must not send a prompt.
+    // While the model switch is in flight, typing + Enter must not send a
+    // prompt. The submit gate runs synchronously off the input dispatch; one
+    // macrotask turn (which drains every queued microtask first) settles it.
     terminal.input('blocked');
     terminal.input('\r');
-    await delay(20);
+    await delay(0);
     assert.deepEqual(driver.prompts, []);
 
     // After the switch completes, the previously typed prompt goes through.
@@ -4853,7 +4987,9 @@ describe('Maka Pi TUI runner', () => {
     await admission.whenIdle;
     const automationLease = await automationActivity;
     automationLease.release();
-    await delay(20);
+    // The control action's busy release settles through its promise
+    // continuations; one macrotask turn runs strictly after them.
+    await delay(0);
     terminal.input('\r');
     await waitFor(() => driver.prompts.length === 1);
     assert.deepEqual(driver.prompts, ['blocked']);
@@ -4861,7 +4997,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4886,20 +5022,17 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('y');
     await waitFor(() => driver.responses.length === 1);
-    await delay(20);
 
-    // Response rejected: error shows, but the boundary prompt stays and can be retried.
-    assert.ok(
-      plainTerminalOutput(terminal.output()).includes('Allow access outside the workspace?'),
-    );
-
+    // Response rejected: the boundary prompt stays armed and can be retried.
+    // The second response landing is the observable proof — an unarmed prompt
+    // would swallow the 'n' instead of responding.
     terminal.input('n');
     await waitFor(() => driver.responses.length === 2);
 
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4923,19 +5056,22 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => driver.listCalls === 1);
 
     // While the list is still loading, a submitted prompt must not go through.
+    // The submit gate runs synchronously off the input dispatch; one macrotask
+    // turn (which drains every queued microtask first) settles it.
     terminal.input('hello');
     terminal.input('\r');
-    await delay(20);
+    await delay(0);
     assert.deepEqual(driver.prompts, []);
 
     driver.releaseList();
-    await delay(30);
+    // The rendered picker is the observable arming signal for the Escape.
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Existing chat'));
 
     terminal.input('\x1b');
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -4958,8 +5094,11 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => terminal.progressStates.at(-1) === true);
 
+    // Escape handling runs synchronously off the input dispatch; one macrotask
+    // turn (which drains every queued microtask first) is a deterministic
+    // settle for the single-Escape-does-not-stop check.
     terminal.input('\x1b');
-    await delay(20);
+    await delay(0);
     assert.equal(driver.stopCalls, 0);
 
     terminal.input('\x1b');
@@ -4972,13 +5111,13 @@ describe('Maka Pi TUI runner', () => {
     // notice, but the contract under test is that stopSession is not fired again.
     terminal.input('\x1b');
     terminal.input('\x1b');
-    await delay(20);
+    await delay(0);
     assert.equal(driver.stopCalls, 1);
 
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5025,7 +5164,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5398,7 +5537,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5423,12 +5562,19 @@ describe('Maka Pi TUI runner', () => {
       ),
     );
 
-    // A single Escape falls through to the editor: no picker yet.
+    // A single Escape falls through to the editor: no picker yet. Sentinel
+    // render: a wrongly-opened picker would be in the cumulative output by the
+    // time the typed char paints. The char resets the gesture either way, so
+    // it is removed before the real double Escape below.
     terminal.input('\x1b');
-    await delay(40);
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal) === 'z');
     assert.equal(plainTerminalOutput(terminal.output()).includes('回到选定轮次'), false);
+    terminal.input('\x7f');
+    await waitFor(() => editorInputText(terminal) === '');
 
-    // A second Escape within the window completes the gesture and opens the picker.
+    // A consecutive Escape pair completes the gesture and opens the picker.
+    terminal.input('\x1b');
     terminal.input('\x1b');
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('回到选定轮次'));
 
@@ -5439,7 +5585,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5464,24 +5610,28 @@ describe('Maka Pi TUI runner', () => {
       ),
     );
 
-    // While a draft is present, Escape belongs to the editor (clear input), not
-    // the rewind gesture. Two Escapes must not open the picker.
+    // While a draft is present, Escape belongs to the editor, not the rewind
+    // gesture. Two Escapes must not open the picker. Input dispatch is
+    // synchronous, so no settling is needed between keys.
     terminal.input('draft in progress');
-    await delay(20);
+    await waitFor(() => editorInputText(terminal) === 'draft in progress');
     terminal.input('\x1b');
-    await delay(20);
     terminal.input('\x1b');
-    await delay(40);
+    // Sentinel render: a wrongly-opened picker would be on screen by the time
+    // the typed char paints.
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal).endsWith('z'));
     assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('回到选定轮次'), false);
-    assert.deepEqual(driver.rewound, []);
 
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
+    // Anchored after close: a wrongly-opened picker selection would show here.
+    assert.deepEqual(driver.rewound, []);
   });
 
   test('a non-Escape key between two Escapes does not open the rewind picker', async () => {
@@ -5505,18 +5655,20 @@ describe('Maka Pi TUI runner', () => {
 
     // The editor stays neutral (empty) throughout, but a left-arrow between the
     // two Escapes breaks the gesture: the two Escapes must be consecutive.
+    // Input dispatch is synchronous, so no settling is needed between keys.
     terminal.input('\x1b');
-    await delay(20);
     terminal.input('\x1b[D');
-    await delay(20);
     terminal.input('\x1b');
-    await delay(40);
+    // Sentinel render: a wrongly-opened picker would be on screen by the time
+    // the typed char paints.
+    terminal.input('z');
+    await waitFor(() => editorInputText(terminal) === 'z');
     assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('回到选定轮次'), false);
 
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5545,10 +5697,12 @@ describe('Maka Pi TUI runner', () => {
 
     // The turn has not ended yet (runtime stop is still settling). Further
     // double-Escapes must be swallowed, not fire a second stopSession that
-    // would append a duplicate abort note to the session log.
+    // would append a duplicate abort note to the session log. Escape handling
+    // runs synchronously off the input dispatch; one macrotask turn (which
+    // drains every queued microtask first) is a deterministic settle.
     terminal.input('\x1b');
     terminal.input('\x1b');
-    await delay(30);
+    await delay(0);
     assert.equal(driver.stopCalls, 1);
 
     driver.endTurn();
@@ -5557,7 +5711,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5615,7 +5769,7 @@ describe('Maka Pi TUI runner', () => {
     try {
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close after a second Ctrl-C');
         }),
       ]);
@@ -5644,7 +5798,11 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('run');
     terminal.input('\r');
     await waitFor(() => driver.boundaryRequests === 1);
-    await delay(20);
+    // The rendered prompt is the observable arming signal: only once it owns
+    // input do the Escapes mean deny instead of an interrupt gesture.
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Allow access outside the workspace?'),
+    );
 
     terminal.input('\x1b');
     terminal.input('\x1b');
@@ -5657,7 +5815,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5690,16 +5848,17 @@ describe('Maka Pi TUI runner', () => {
 
     // y must not trigger a response for the now-dead request.
     terminal.input('y');
-    await delay(20);
-    assert.equal(driver.respondCalls, 0);
 
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
+    // Anchored after close: every queued input has been drained, so a response
+    // for the dead request would show in respondCalls by now.
+    assert.equal(driver.respondCalls, 0);
   });
 
   test('enables focus reporting only after raw mode, so no stray ^[[I leaks on launch', async () => {
@@ -5731,7 +5890,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5765,7 +5924,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -5811,7 +5970,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -5872,7 +6031,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -5911,7 +6070,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -5948,7 +6107,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -5995,7 +6154,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -6062,7 +6221,11 @@ describe('Maka Pi TUI runner', () => {
       await submit('a later prompt', 2);
 
       gate.resolve();
-      await delay(50);
+      // Sentinel render: a wrongly-rendered recap would be in the cumulative
+      // output by the time the typed char paints (the recap continuation
+      // settles on microtasks before that render lands).
+      terminal.input('z');
+      await waitFor(() => editorInputText(terminal) === 'z');
       assert.equal(
         plainTerminalOutput(terminal.output()).includes('Recap: stale recap result'),
         false,
@@ -6072,7 +6235,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -6127,7 +6290,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -6169,7 +6332,11 @@ describe('Maka Pi TUI runner', () => {
       await driver.switchSession('session-2');
 
       gate.resolve();
-      await delay(50);
+      // Sentinel render: a wrongly-rendered recap would be in the cumulative
+      // output by the time the typed char paints (the recap continuation
+      // settles on microtasks before that render lands).
+      terminal.input('z');
+      await waitFor(() => editorInputText(terminal) === 'z');
       assert.equal(
         plainTerminalOutput(terminal.output()).includes('Recap:'),
         false,
@@ -6179,7 +6346,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -6240,7 +6407,7 @@ describe('Maka Pi TUI runner', () => {
       exitMaka(terminal);
       await Promise.race([
         run,
-        delay(50).then(() => {
+        delay(CLOSE_BUDGET_MS).then(() => {
           throw new Error('TUI did not close during test cleanup');
         }),
       ]);
@@ -6265,7 +6432,7 @@ describe('Maka Pi TUI runner', () => {
 
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close on a bare "quit" line');
       }),
     ]);
@@ -6300,7 +6467,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -6336,7 +6503,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -6428,7 +6595,7 @@ describe('Maka Pi TUI runner', () => {
     exitMaka(terminal);
     await Promise.race([
       run,
-      delay(50).then(() => {
+      delay(CLOSE_BUDGET_MS).then(() => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
@@ -6874,6 +7041,9 @@ class FallbackSteeringDriver implements MakaSessionDriver {
   /** Enqueue calls that report `fallback` before the owner "appears". */
   steerFallbacks = Number.POSITIVE_INFINITY;
   queueFallbacks = Number.POSITIVE_INFINITY;
+  /** Total enqueue attempts, including rejected ones — the observable retry count. */
+  steerAttempts = 0;
+  queueAttempts = 0;
   private steering: string[] = [];
   private followup: string[] = [];
   private pendingEvents: SessionEvent[] = [];
@@ -6965,6 +7135,7 @@ class FallbackSteeringDriver implements MakaSessionDriver {
   abortNextTurn = false;
 
   async steer(text: string): Promise<QueueEnqueueOutcome> {
+    this.steerAttempts += 1;
     if (this.steerFallbacks > 0) {
       this.steerFallbacks -= 1;
       return { kind: 'fallback' };
@@ -6976,6 +7147,7 @@ class FallbackSteeringDriver implements MakaSessionDriver {
   }
 
   async queueMessage(text: string): Promise<QueueEnqueueOutcome> {
+    this.queueAttempts += 1;
     if (this.queueFallbacks > 0) {
       this.queueFallbacks -= 1;
       return { kind: 'fallback' };

--- a/packages/cli/src/__tests__/tui-terminal-mock.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.ts
@@ -133,6 +133,15 @@ export function latestPlainLineContaining(output: string, text: string): string 
 export const WAIT_BUDGET_MS =
   Number(process.env.MAKA_TEST_WAIT_BUDGET_MS ?? '') || (process.env.CI ? 5_000 : 250);
 
+/** Resolves once the TUI is in raw mode and has painted its first frame, so
+ *  typed input reaches a mounted editor instead of racing runner startup. */
+export async function waitForTuiPaint(terminal: FakeTerminal): Promise<void> {
+  await waitFor(
+    () => terminal.startWriteIndex !== null && terminal.writes.length > terminal.startWriteIndex,
+    'the first TUI paint after raw-mode start',
+  );
+}
+
 export async function waitFor(predicate: () => boolean, description?: string): Promise<void> {
   const deadline = Date.now() + WAIT_BUDGET_MS;
   while (Date.now() < deadline) {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -149,6 +149,16 @@ export interface MakaPiTuiInput {
    * without waiting real seconds; defaults to the attention layer's own value.
    */
   attentionLongTurnThresholdMs?: number;
+  /**
+   * Clock + interval scheduling for the running shell-run elapsed ticker
+   * (1s cadence). Injectable so tests drive ticks deterministically instead
+   * of waiting wall-clock seconds; defaults to Date.now + a real unref'd
+   * setInterval.
+   */
+  shellRunTicker?: {
+    now?: () => number;
+    schedule?: (callback: () => void, intervalMs: number) => () => void;
+  };
   subscribeSessionTitleChanges?: (listener: (sessionId: string) => void) => () => void;
   subscribeShellRunUpdates?: (listener: (update: ShellRunUpdate) => void) => () => void;
   listShellRunUpdates?: (sessionId: string) => Promise<ShellRunUpdate[]>;
@@ -380,6 +390,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const shellRunElapsedTicker = createShellRunElapsedTicker({
     state,
     onTick: requestRender,
+    now: input.shellRunTicker?.now,
+    schedule: input.shellRunTicker?.schedule,
   });
 
   // ── Explicit skill invocation (#1148) ────────────────────────────────────


### PR DESCRIPTION
Part of #2389 (Pi TUI workspace; Runtime Host, desktop e2e, and alignment audit follow in separate PRs per the issue).

## What changed

Three fixed-wait patterns in `pi-tui-runner.test.ts` (plus one helper in `tui-terminal-mock.ts`), replaced with the closest deterministic mechanism:

| Pattern | Count | Replacement |
|---|---|---|
| Unconditional `await delay(20..2500)` | 55 | `waitFor` on the actual observable fact: first TUI paint (`waitForTuiPaint`), prompt arming ("Allow access outside the workspace?" on screen), wizard frames opening/closing, drafts appearing, driver retry counts |
| `Promise.race([run, delay(50/500).then(throw)])` close watchdogs | 81 | `CLOSE_BUDGET_MS = max(WAIT_BUDGET_MS, 500)` — a passing race still resolves the moment `run` settles; only failure reporting pays the budget (same split as `waitFor`, #2221) |
| Off-screen ticker test sleeping 2.5s for two real 1s ticks | 1 | The shell-run elapsed ticker's `now` + `schedule` are now injectable via `MakaPiTuiInput.shellRunTicker` (same test-injection pattern as `attentionLongTurnThresholdMs`); the test fires both ticks deterministically |

For must-NOT-happen assertions, the suite now uses three deterministic idioms instead of sleeping and hoping:

- **Sentinel render**: type one char and wait for it to paint — any wrongly-scheduled UI change (stale wizard failure line, dropped-recap render, rewind picker, scrollback wipe) would be in that same coalesced frame.
- **Close-anchored asserts**: for driver-level negatives (no prompt sent, no response for a dead request, no rewind), assert after `await run` — every queued input has provably drained.
- **`delay(0)` macrotask barrier**: for gates that run synchronously off input dispatch (double-Escape counting, Ctrl-C/Ctrl-D, submit gates) — one macrotask turn runs strictly after every queued microtask, independent of machine load.

The never-dropped fallback-enqueue test no longer sleeps 2.2s blind: the fake driver counts enqueue attempts, and the test waits for the retries to *observably* cross the old ~20-attempt give-up budget (the exact regression #1135-era bug shape), still at the real 100ms cadence so a reintroduced time-based budget would also trip it.

## Retained real-boundary contracts (unchanged by design)

- `runSignalExitProbe` / `runFatalExitProbe`: real child processes, real signals, and the real 3s `PROCESS_EXIT_GRACE_MS` deadline (3.5s + 2×0.5s of the remaining wall time).
- The 100ms fallback retry cadence (retry-budget test above).
- The 250ms hydration-retry cancellation window — a real-timer negative; now documented as derived from the retry schedule rather than an arbitrary sleep.

## Production surface

One additive, optional injection point: `MakaPiTuiInput.shellRunTicker?: { now?, schedule? }`, threaded into `createShellRunElapsedTicker` (which already accepted both). Defaults unchanged.

## Timing (local, `node --test dist/__tests__/pi-tui-runner.test.js`, 142 tests)

| | Before | After |
|---|---|---|
| Wall | 15.5s | 12.1s |
| CPU (user) | 4.2s | 4.1s |

The remaining wall time is dominated by the preserved real-boundary tests listed above; every other test now completes the moment its observed condition holds, and no assertion in the suite races scheduler timing anymore. Full `packages/cli` suite: 492/494 pass — the 2 failures are pre-existing local noise (`run-command.test.ts` expects empty stderr; Node 22.17 emits a SQLite ExperimentalWarning) on paths this PR does not touch.