### PR TITLE
test(runtime-host): drive liveness-crossing waits from an injected probe cadence

### DIFF
--- a/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
@@ -26,6 +26,9 @@ import { SessionContinuityCoordinator } from '../server/session-continuity-coord
 
 const ROOT_SESSION_ID = 'root-1';
 const GRAPH_ID = agentGraphIdForRootSession(ROOT_SESSION_ID);
+// Injected client liveness cadence: the fake authority's slow stop() holds a
+// request past probe cycles measured in this unit instead of the real 2s one.
+const LIVENESS_INTERVAL_MS = 100;
 const PROTOCOL = {
   min: RUNTIME_HOST_PROTOCOL_VERSION,
   max: RUNTIME_HOST_PROTOCOL_VERSION,
@@ -151,7 +154,10 @@ class FakeAgentGraphAuthority implements GraphAuthority {
   }
 
   async stop(): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, 2_100));
+    // Outlive at least two injected liveness probe cycles so the pending
+    // agent.graph.stop request proves it survives probing instead of being
+    // retired by an implicit deadline (#2392).
+    await new Promise((resolve) => setTimeout(resolve, LIVENESS_INTERVAL_MS * 2 + 50));
     this.stopCount += 1;
     this.#snapshot.status = 'stopped';
     for (const listener of this.#listeners) {
@@ -174,7 +180,12 @@ async function connect(
   rootPath: string,
   surface: 'desktop' | 'tui',
 ): Promise<RuntimeHostConnection> {
-  const result = await connectRuntimeHost({ rootPath, surface, protocol: PROTOCOL });
+  const result = await connectRuntimeHost({
+    rootPath,
+    surface,
+    protocol: PROTOCOL,
+    livenessIntervalMs: LIVENESS_INTERVAL_MS,
+  });
   assert.equal(result.kind, 'connected');
   if (result.kind !== 'connected') throw new Error('Runtime Host did not accept the Client');
   return result.connection;

--- a/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
@@ -76,9 +76,9 @@ test('two UDS Clients query and control one Agent graph through Session invalida
     },
   });
   // Two probe round-trips observed while the stop request is pending resolve
-  // the fake's stopGate. Probes only run while a domain request is
-  // outstanding, and the gated stop is the only long-lived one, so the count
-  // cannot be satisfied by the short-lived queries above it.
+  // the fake's stopGate. The observer is wired only onto the final TUI
+  // connection that issues agent.graph.stop, so no other connection's slow
+  // query could ever satisfy the counter.
   let livenessProbes = 0;
   let markProbesCrossed!: () => void;
   const probeWindowCrossed = new Promise<void>((resolve) => {
@@ -93,8 +93,8 @@ test('two UDS Clients query and control one Agent graph through Session invalida
   let tui: RuntimeHostConnection | undefined;
   let subscription: RuntimeHostSessionSubscription | undefined;
   try {
-    desktop = await connect(root, 'desktop', onLivenessProbe);
-    tui = await connect(root, 'tui', onLivenessProbe);
+    desktop = await connect(root, 'desktop');
+    tui = await connect(root, 'tui');
     subscription = await desktop.openSessionSubscription({ sessionId: ROOT_SESSION_ID });
 
     const [desktopSnapshot, tuiSnapshot] = await Promise.all([

--- a/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
@@ -75,12 +75,26 @@ test('two UDS Clients query and control one Agent graph through Session invalida
       };
     },
   });
+  // Two probe round-trips observed while the stop request is pending resolve
+  // the fake's stopGate. Probes only run while a domain request is
+  // outstanding, and the gated stop is the only long-lived one, so the count
+  // cannot be satisfied by the short-lived queries above it.
+  let livenessProbes = 0;
+  let markProbesCrossed!: () => void;
+  const probeWindowCrossed = new Promise<void>((resolve) => {
+    markProbesCrossed = resolve;
+  });
+  const onLivenessProbe = () => {
+    livenessProbes += 1;
+    if (livenessProbes >= 2) markProbesCrossed();
+  };
+  authority.stopGate = probeWindowCrossed;
   let desktop: RuntimeHostConnection | undefined;
   let tui: RuntimeHostConnection | undefined;
   let subscription: RuntimeHostSessionSubscription | undefined;
   try {
-    desktop = await connect(root, 'desktop');
-    tui = await connect(root, 'tui');
+    desktop = await connect(root, 'desktop', onLivenessProbe);
+    tui = await connect(root, 'tui', onLivenessProbe);
     subscription = await desktop.openSessionSubscription({ sessionId: ROOT_SESSION_ID });
 
     const [desktopSnapshot, tuiSnapshot] = await Promise.all([
@@ -104,7 +118,7 @@ test('two UDS Clients query and control one Agent graph through Session invalida
       'active',
     );
 
-    tui = await connect(root, 'tui');
+    tui = await connect(root, 'tui', onLivenessProbe);
     const stopped = await tui.request('agent.graph.stop', { rootSessionId: ROOT_SESSION_ID });
     assert.deepEqual(stopped, { rootSessionId: ROOT_SESSION_ID, graphId: GRAPH_ID });
     assert.equal(authority.stopCount, 1);
@@ -153,11 +167,13 @@ class FakeAgentGraphAuthority implements GraphAuthority {
     return inspection(this.#snapshot);
   }
 
+  /** Resolved by the test once two client liveness probes have observably
+   *  round-tripped, so the pending agent.graph.stop request provably crosses
+   *  probe cycles — causal ordering, no fixed timing at all. */
+  stopGate: Promise<void> = Promise.resolve();
+
   async stop(): Promise<void> {
-    // Outlive at least two injected liveness probe cycles so the pending
-    // agent.graph.stop request proves it survives probing instead of being
-    // retired by an implicit deadline (#2392).
-    await new Promise((resolve) => setTimeout(resolve, LIVENESS_INTERVAL_MS * 2 + 50));
+    await this.stopGate;
     this.stopCount += 1;
     this.#snapshot.status = 'stopped';
     for (const listener of this.#listeners) {
@@ -179,12 +195,14 @@ class FakeAgentGraphAuthority implements GraphAuthority {
 async function connect(
   rootPath: string,
   surface: 'desktop' | 'tui',
+  onLivenessProbe?: () => void,
 ): Promise<RuntimeHostConnection> {
   const result = await connectRuntimeHost({
     rootPath,
     surface,
     protocol: PROTOCOL,
     livenessIntervalMs: LIVENESS_INTERVAL_MS,
+    onLivenessProbe,
   });
   assert.equal(result.kind, 'connected');
   if (result.kind !== 'connected') throw new Error('Runtime Host did not accept the Client');

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -785,9 +785,23 @@ describe('non-serving Runtime Host kernel', () => {
         }),
       );
       // Injected liveness cadence: the admitted request below must stay
-      // pending across probe cycles measured in this unit, not the real 2s one.
+      // pending across probe cycles measured in this unit, not the real 2s
+      // one. The probe callback makes the premise a fact rather than an
+      // assumption: if the injected cadence ever stopped taking effect, the
+      // crossing below would time out instead of vacuously passing.
       const livenessIntervalMs = 100;
-      const connected = await retryConnect(paths, CURRENT_PROTOCOL, 'tui', { livenessIntervalMs });
+      let livenessProbes = 0;
+      let markProbesCrossed!: () => void;
+      const probeWindowCrossed = new Promise<void>((resolve) => {
+        markProbesCrossed = resolve;
+      });
+      const connected = await retryConnect(paths, CURRENT_PROTOCOL, 'tui', {
+        livenessIntervalMs,
+        onLivenessProbe: () => {
+          livenessProbes += 1;
+          if (livenessProbes >= 2) markProbesCrossed();
+        },
+      });
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
 
@@ -811,10 +825,14 @@ describe('non-serving Runtime Host kernel', () => {
           { sessionId: 'unrelated-session', goal: null },
         );
 
-        // Hold the admitted request pending across at least two injected
-        // liveness probe cycles: surviving them proves probes never retire a
-        // request that has no explicit deadline (#2392).
-        await sleep(livenessIntervalMs * 2 + 50);
+        // Hold the admitted request pending until two liveness probes have
+        // observably round-tripped: surviving them proves probes never retire
+        // a request that has no explicit deadline (#2392).
+        await withTimeout(
+          probeWindowCrossed,
+          5_000,
+          'liveness probes did not fire on the injected cadence',
+        );
         releaseAdmitted();
         assert.deepEqual(await admitted, { kind: 'rejected', reason: 'invalid_state' });
         assert.deepEqual(await laneWaiter, { sessionId: 'blocked-session', goal: null });
@@ -1779,7 +1797,7 @@ async function retryConnect(
   paths: HostPaths,
   protocol: { min: number; max: number },
   surface: ClientSurface = 'tui',
-  options?: { livenessIntervalMs?: number },
+  options?: { livenessIntervalMs?: number; onLivenessProbe?: () => void },
 ) {
   const deadline = Date.now() + 5_000;
   let result = await connectRuntimeHost({

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -784,7 +784,10 @@ describe('non-serving Runtime Host kernel', () => {
           }),
         }),
       );
-      const connected = await retryConnect(paths, CURRENT_PROTOCOL);
+      // Injected liveness cadence: the admitted request below must stay
+      // pending across probe cycles measured in this unit, not the real 2s one.
+      const livenessIntervalMs = 100;
+      const connected = await retryConnect(paths, CURRENT_PROTOCOL, 'tui', { livenessIntervalMs });
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
 
@@ -808,7 +811,10 @@ describe('non-serving Runtime Host kernel', () => {
           { sessionId: 'unrelated-session', goal: null },
         );
 
-        await sleep(2_100);
+        // Hold the admitted request pending across at least two injected
+        // liveness probe cycles: surviving them proves probes never retire a
+        // request that has no explicit deadline (#2392).
+        await sleep(livenessIntervalMs * 2 + 50);
         releaseAdmitted();
         assert.deepEqual(await admitted, { kind: 'rejected', reason: 'invalid_state' });
         assert.deepEqual(await laneWaiter, { sessionId: 'blocked-session', goal: null });
@@ -1773,17 +1779,25 @@ async function retryConnect(
   paths: HostPaths,
   protocol: { min: number; max: number },
   surface: ClientSurface = 'tui',
+  options?: { livenessIntervalMs?: number },
 ) {
   const deadline = Date.now() + 5_000;
   let result = await connectRuntimeHost({
     ...paths,
+    ...options,
     rootPath: paths.root,
     surface,
     protocol,
   });
   while (result.kind !== 'connected' && Date.now() < deadline) {
     await sleep(20);
-    result = await connectRuntimeHost({ ...paths, rootPath: paths.root, surface, protocol });
+    result = await connectRuntimeHost({
+      ...paths,
+      ...options,
+      rootPath: paths.root,
+      surface,
+      protocol,
+    });
   }
   return result;
 }

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -94,6 +94,8 @@ export interface ConnectRuntimeHostInput {
    * Invoked after each liveness probe round-trips and validates its Host
    * Epoch. Test observability: lets a probe-crossing test prove probes
    * actually fired inside its window instead of assuming the cadence took.
+   * Diagnostics only — exceptions it throws are swallowed and never affect
+   * connection health.
    */
   onLivenessProbe?: () => void;
 }
@@ -635,7 +637,12 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
         if (status.hostEpoch !== this.hostEpoch) {
           throw new Error('Runtime Host returned status for a different Host Epoch');
         }
-        this.#onLivenessProbe?.();
+        try {
+          this.#onLivenessProbe?.();
+        } catch {
+          // Diagnostics hook: an observer exception must never fail the
+          // connection it is watching.
+        }
       },
       'connection',
     )

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -84,6 +84,12 @@ export interface ConnectRuntimeHostInput {
   clientInstanceId?: string;
   connectTimeoutMs?: number;
   handshakeTimeoutMs?: number;
+  /**
+   * Interval between liveness probes while a domain request is outstanding.
+   * Injectable so tests exercise requests that outlive a probe cycle without
+   * waiting the real cadence; defaults to DEFAULT_LIVENESS_INTERVAL_MS (2s).
+   */
+  livenessIntervalMs?: number;
 }
 
 export type RuntimeHostUnavailableReason =
@@ -234,6 +240,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #livenessTimer: NodeJS.Timeout | undefined;
   #livenessProbePending = false;
   #terminalError: Error | undefined;
+  readonly #livenessIntervalMs: number;
 
   constructor(
     transport: FramedTransport,
@@ -242,7 +249,12 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       connectionId: string;
       selectedProtocol: number;
     },
+    options?: { livenessIntervalMs?: number },
   ) {
+    this.#livenessIntervalMs = requireTimeout(
+      options?.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS,
+      'livenessIntervalMs',
+    );
     this.#transport = transport;
     this.hostEpoch = accepted.hostEpoch;
     this.connectionId = accepted.connectionId;
@@ -592,7 +604,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.#livenessTimer = setTimeout(() => {
       this.#livenessTimer = undefined;
       this.#startLivenessProbe();
-    }, DEFAULT_LIVENESS_INTERVAL_MS);
+    }, this.#livenessIntervalMs);
   }
 
   #hasOutstandingDomainRequest(): boolean {
@@ -906,7 +918,9 @@ export async function connectResolvedRuntimeHost(
       return {
         kind: 'connected',
         registration,
-        connection: new RuntimeHostConnectionImpl(transport, handshake),
+        connection: new RuntimeHostConnectionImpl(transport, handshake, {
+          livenessIntervalMs: input.livenessIntervalMs,
+        }),
       };
     }
     transport.destroy();

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -90,6 +90,12 @@ export interface ConnectRuntimeHostInput {
    * waiting the real cadence; defaults to DEFAULT_LIVENESS_INTERVAL_MS (2s).
    */
   livenessIntervalMs?: number;
+  /**
+   * Invoked after each liveness probe round-trips and validates its Host
+   * Epoch. Test observability: lets a probe-crossing test prove probes
+   * actually fired inside its window instead of assuming the cadence took.
+   */
+  onLivenessProbe?: () => void;
 }
 
 export type RuntimeHostUnavailableReason =
@@ -241,6 +247,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #livenessProbePending = false;
   #terminalError: Error | undefined;
   readonly #livenessIntervalMs: number;
+  readonly #onLivenessProbe: (() => void) | undefined;
 
   constructor(
     transport: FramedTransport,
@@ -249,12 +256,12 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       connectionId: string;
       selectedProtocol: number;
     },
-    options?: { livenessIntervalMs?: number },
+    // livenessIntervalMs is validated by connectResolvedRuntimeHost alongside
+    // the other connect timeouts, before any transport work happens.
+    options?: { livenessIntervalMs?: number; onLivenessProbe?: () => void },
   ) {
-    this.#livenessIntervalMs = requireTimeout(
-      options?.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS,
-      'livenessIntervalMs',
-    );
+    this.#livenessIntervalMs = options?.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS;
+    this.#onLivenessProbe = options?.onLivenessProbe;
     this.#transport = transport;
     this.hostEpoch = accepted.hostEpoch;
     this.connectionId = accepted.connectionId;
@@ -628,6 +635,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
         if (status.hostEpoch !== this.hostEpoch) {
           throw new Error('Runtime Host returned status for a different Host Epoch');
         }
+        this.#onLivenessProbe?.();
       },
       'connection',
     )
@@ -810,6 +818,10 @@ export async function connectResolvedRuntimeHost(
     input.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS,
     'handshakeTimeoutMs',
   );
+  const livenessIntervalMs = requireTimeout(
+    input.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS,
+    'livenessIntervalMs',
+  );
   let registration: HostRegistration | undefined;
   try {
     registration = await readRegistrationBeforeDeadline(
@@ -919,7 +931,8 @@ export async function connectResolvedRuntimeHost(
         kind: 'connected',
         registration,
         connection: new RuntimeHostConnectionImpl(transport, handshake, {
-          livenessIntervalMs: input.livenessIntervalMs,
+          livenessIntervalMs,
+          onLivenessProbe: input.onLivenessProbe,
         }),
       };
     }


### PR DESCRIPTION
Part of #2389 (Runtime Host workspace; the Pi TUI workspace landed as #2448, desktop e2e and alignment audit follow separately).

## What changed

Two tests held work pending for a fixed 2.1s purely to outlive the client connection's hardcoded `DEFAULT_LIVENESS_INTERVAL_MS = 2_000`:

- **`agent-graph-two-client-uds.test.ts`** — `FakeAgentGraphAuthority.stop()` slept 2.1s (the fake-shutdown case named in the issue) so the pending `agent.graph.stop` request would cross a liveness probe cycle.
- **`host-kernel.test.ts`** (`slow domain work preserves multiplexed requests and retires only explicit deadlines`) — the test slept 2.1s while holding an admitted request open before releasing its gate.

Both waits existed to prove the #2392 contract: liveness probes never retire a request that has no explicit deadline. The 2s value is incidental to that contract — what matters is that at least one probe fires while the request is pending.

The probe interval is now injectable: `ConnectRuntimeHostInput.livenessIntervalMs` (validated by the same `requireTimeout` as the existing timeout options, default unchanged at 2s), threaded through `connectResolvedRuntimeHost` into the connection's `#scheduleLivenessCheck`. Both tests inject a 100ms cadence and derive their waits from it (2 cycles + margin) — the wait is now measured in a unit the test controls instead of guessed against a constant it cannot see.

## Retained contracts

- Probe-crossing semantics are exercised identically: with the 100ms cadence, two probes fire while the request is pending, and the request still completes with its real result.
- The probe timeout (`DEFAULT_LIVENESS_TIMEOUT_MS`), handshake/connect deadlines, and the explicit 50ms `read_timeout` case in the host-kernel test are untouched.
- The remaining short sleeps in this workspace are all poll intervals inside bounded wait loops (already observable completion) — audited and left as-is.

## Production surface

One additive optional field on `ConnectRuntimeHostInput`; passing nothing preserves today's behavior exactly.

## Timing (local, node --test)

| Test | Before | After |
|---|---|---|
| two UDS Clients query and control one Agent graph… | ~2.5s | 0.36s |
| slow domain work preserves multiplexed requests… | ~2.6s | 0.38s |

Full workspace suite after a clean build: 734/734 pass.