### PR TITLE
refactor(settings): carry projects on the entity-list components

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-effect-stability-contract.test.ts
@@ -613,6 +613,7 @@ describe('AppShell effect stability contract', () => {
       arch: 'arm64',
       osRelease: 'test',
       workspacePath: '/workspace',
+      homePath: '/home/tester',
       projectId: project.id,
       projectPath: '/workspace/available',
       projectGit: { isGitRepo: false },

--- a/apps/desktop/src/main/__tests__/project-path-display.test.ts
+++ b/apps/desktop/src/main/__tests__/project-path-display.test.ts
@@ -1,0 +1,81 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  collapseHomePath,
+  projectPathDisplay,
+  truncatePathHead,
+} from '../../renderer/project-path-display.js';
+
+describe('collapseHomePath', () => {
+  it('collapses the home prefix', () => {
+    assert.equal(collapseHomePath('/Users/maka/Developer/app', '/Users/maka'), '~/Developer/app');
+  });
+
+  it('collapses the home directory itself to a bare ~', () => {
+    assert.equal(collapseHomePath('/Users/maka', '/Users/maka'), '~');
+  });
+
+  it('only matches on a path boundary', () => {
+    // The bug this pins: a prefix match would rewrite `/Users/maka-agent` to
+    // `~-agent`, quietly renaming a different user's directory.
+    assert.equal(
+      collapseHomePath('/Users/maka-agent/app', '/Users/maka'),
+      '/Users/maka-agent/app',
+    );
+  });
+
+  it('leaves paths outside home alone', () => {
+    assert.equal(collapseHomePath('/opt/work/app', '/Users/maka'), '/opt/work/app');
+  });
+
+  it('is a no-op when the home path is unknown', () => {
+    // The renderer learns home asynchronously; before it arrives the path must
+    // still render, just unabbreviated.
+    assert.equal(collapseHomePath('/Users/maka/app', undefined), '/Users/maka/app');
+  });
+
+  it('ignores a trailing separator on the home path', () => {
+    assert.equal(collapseHomePath('/Users/maka/app', '/Users/maka/'), '~/app');
+  });
+});
+
+describe('truncatePathHead', () => {
+  it('keeps the tail, which is the identifying end', () => {
+    const result = truncatePathHead('/Users/maka/Developer/experiments/astryx-design-system', 24);
+    assert.equal(result.length, 24);
+    assert.ok(result.endsWith('astryx-design-system'), result);
+    assert.ok(result.startsWith('…'), result);
+  });
+
+  it('leaves a path that already fits untouched', () => {
+    // No decorative ellipsis on a path that never needed shortening.
+    assert.equal(truncatePathHead('~/app', 24), '~/app');
+  });
+
+  it('leaves a path of exactly the budget untouched', () => {
+    const exact = 'a'.repeat(24);
+    assert.equal(truncatePathHead(exact, 24), exact);
+  });
+});
+
+describe('projectPathDisplay', () => {
+  it('collapses then truncates, and keeps the full path for the tooltip', () => {
+    const display = projectPathDisplay(
+      '/Users/maka/Developer/experiments/astryx-design-system',
+      { homePath: '/Users/maka', maxLength: 20 },
+    );
+
+    // 20 is a tight budget on purpose: the folder name is itself 20 chars, so
+    // the ellipsis has to eat into it. The tail is still what survives.
+    assert.equal(display.text, '…stryx-design-system');
+    assert.equal(display.text.length, 20);
+    // The tooltip is the unabbreviated original — `~` is exactly what a user
+    // consults the tooltip to expand.
+    assert.equal(display.title, '/Users/maka/Developer/experiments/astryx-design-system');
+  });
+
+  it('shows a short home path whole', () => {
+    const display = projectPathDisplay('/Users/maka/app', { homePath: '/Users/maka' });
+    assert.equal(display.text, '~/app');
+  });
+});

--- a/apps/desktop/src/main/app-ipc-main.ts
+++ b/apps/desktop/src/main/app-ipc-main.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { arch as osArch, release as osRelease } from 'node:os';
+import { arch as osArch, homedir, release as osRelease } from 'node:os';
 import { app, ipcMain, shell, type IpcMain } from 'electron';
 import { resolveProjectGitInfo } from '@maka/runtime';
 import type { createMainWindowController } from './main-window.js';
@@ -71,6 +71,9 @@ export function registerAppIpc(
       arch: osArch(),
       osRelease: osRelease(),
       workspacePath: workspaceRoot,
+      // Lets the renderer collapse a home prefix to `~` in displayed paths;
+      // it has no other way to learn this.
+      homePath: homedir(),
       projectId: selection.projectId,
       projectPath,
       projectGit: await resolveProjectGitInfo(projectPath),

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -688,6 +688,8 @@ export interface MakaBridge {
       arch: string;
       osRelease: string;
       workspacePath: string;
+      /** The OS home directory, for collapsing displayed paths to `~`. */
+      homePath: string;
       projectId?: string | null;
       projectPath: string;
       projectGit: { isGitRepo: boolean; branch?: string };

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1026,6 +1026,7 @@ const makaBridge = {
       arch: string;
       osRelease: string;
       workspacePath: string;
+      homePath: string;
       projectId?: string | null;
       projectPath: string;
       projectGit: { isGitRepo: boolean; branch?: string };

--- a/apps/desktop/src/renderer/project-path-display.ts
+++ b/apps/desktop/src/renderer/project-path-display.ts
@@ -1,0 +1,70 @@
+/**
+ * How a project's absolute path is shown next to its name.
+ *
+ * The path is machine data and stays mono, but on the projects list it was
+ * outweighing the thing it belongs to: a full absolute path wrapped to two
+ * lines under a one-line project name, so the row read as a path with a title
+ * rather than a project with a location.
+ *
+ * Two rules, in this order:
+ *
+ * 1. Collapse the home directory to `~`. It is the single longest constant
+ *    prefix in a personal machine's paths and carries no information — every
+ *    project under it shares it.
+ * 2. Keep the TAIL when it still does not fit. A path's identity lives at its
+ *    end: `.../experiments/astryx-design-system` says which project this is,
+ *    while `/Users/someone/Developer/exp...` says which machine it is on. Head
+ *    truncation is the opposite of what `text-overflow: ellipsis` does by
+ *    default, which is why it needs saying here rather than in CSS alone.
+ *
+ * The full path always remains available as the element's tooltip, so nothing
+ * is actually hidden — only de-emphasised.
+ */
+
+/** Collapse a home-directory prefix to `~`. */
+export function collapseHomePath(path: string, homePath: string | undefined): string {
+  if (!homePath) return path;
+  // Trailing separators would otherwise leave `~/` for the home dir itself.
+  const home = homePath.replace(/[/\\]+$/, '');
+  if (home === '') return path;
+  if (path === home) return '~';
+  // Only a real path boundary counts: `/Users/mak` must not match inside
+  // `/Users/maka-agent`.
+  if (path.startsWith(`${home}/`) || path.startsWith(`${home}\\`)) {
+    return `~${path.slice(home.length)}`;
+  }
+  return path;
+}
+
+/**
+ * Shorten from the head, keeping the last `maxLength` characters.
+ *
+ * Returns the path unchanged when it already fits, so short paths never gain
+ * a leading ellipsis they did not need.
+ */
+export function truncatePathHead(path: string, maxLength: number): string {
+  if (maxLength <= 1 || path.length <= maxLength) return path;
+  // The ellipsis costs one character of the budget, so the kept tail is
+  // maxLength - 1 and the result is exactly maxLength wide.
+  return `…${path.slice(path.length - (maxLength - 1))}`;
+}
+
+export interface ProjectPathDisplay {
+  /** What the row renders. */
+  text: string;
+  /** What the tooltip carries — the unabbreviated path, always. */
+  title: string;
+}
+
+export function projectPathDisplay(
+  path: string,
+  options: { homePath?: string; maxLength?: number } = {},
+): ProjectPathDisplay {
+  const collapsed = collapseHomePath(path, options.homePath);
+  return {
+    text: truncatePathHead(collapsed, options.maxLength ?? 52),
+    // The ORIGINAL path, not the `~` form: a tooltip exists to answer "where
+    // exactly is this", and `~` is precisely the part that was elided.
+    title: path,
+  };
+}

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -10,10 +10,12 @@ import {
   useToast,
   useUiLocale,
 } from '@maka/ui';
+import { HStack, List, ListItem } from '@astryxdesign/core';
+import { FolderOpen } from '@maka/ui/icons';
 import { getSettingsProjectsCopy } from '../locales/settings-projects-copy.js';
+import { projectPathDisplay } from '../project-path-display.js';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsPage, SettingsSection } from './settings-section';
-import { SettingsExpandableRow } from './settings-expandable-row';
 import { useKeyedActionGuard } from './use-action-guard';
 
 /**
@@ -42,6 +44,7 @@ export function ProjectsSettingsPage(props: {
   const mountedRef = useMountedRef();
   const actionGuard = useKeyedActionGuard<string>();
   const [projects, setProjects] = useState<ProjectRecord[]>([]);
+  const [homePath, setHomePath] = useState<string | undefined>(undefined);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [draftName, setDraftName] = useState('');
 
@@ -52,7 +55,12 @@ export function ProjectsSettingsPage(props: {
 
   useEffect(() => {
     void reload();
-  }, [reload]);
+    // Paths render unabbreviated until this lands, which is why
+    // `collapseHomePath` treats an unknown home as a no-op rather than a bug.
+    void window.maka.app.info().then((info) => {
+      if (mountedRef.current) setHomePath(info.homePath);
+    });
+  }, [reload, mountedRef]);
 
   // Archived projects are removed-from-Maka, not deleted; they belong to the
   // restore path, not to a list whose whole purpose is "what can I open".
@@ -110,7 +118,13 @@ export function ProjectsSettingsPage(props: {
         {listed.length === 0 ? (
           <EmptyState title={copy.emptyTitle} description={copy.emptyBody} />
         ) : (
-          listed.map((project) => {
+          // A project is an entity, not a preference, so it belongs in the
+          // entity-list carrier the MCP and skills pages already use — real
+          // list semantics, real dividers, and a leading slot for the icon
+          // that gives each row something to hang on. Built out of settings
+          // rows first, the page was four paragraphs of text in a column.
+          <List density="balanced" hasDividers aria-label={copy.section}>
+          {listed.map((project) => {
             const isDefault = project.id === defaultProjectId;
             const endCluster = (
                   <>
@@ -206,53 +220,88 @@ export function ProjectsSettingsPage(props: {
                   </>
             );
 
-            // Renaming swaps the row for the shared expandable editor, which
-            // owns the focus move in and back out. The end cluster rides along
-            // so the row keeps its default state and menu while collapsed —
-            // rename is reached from that menu, not from a competing button.
+            const isRenaming = renamingId === project.id;
+            const canSave =
+              draftName.trim() !== '' && draftName.trim() !== project.name;
+
+            async function saveRename() {
+              const next = draftName.trim();
+              if (next === '' || next === project.name) return;
+              await runRowAction(
+                `rename:${project.id}`,
+                async () => {
+                  await window.maka.projects.rename(project.id, next);
+                  setRenamingId(null);
+                },
+                copy.renameFailed,
+              );
+            }
+
+            const path = project.preferredPath
+              ? projectPathDisplay(project.preferredPath, { homePath })
+              : undefined;
+
             return (
-              <SettingsExpandableRow
+              <ListItem
                 key={project.id}
-                label={project.name}
-                value={
-                  <code className="settingsReadOnlyValue" data-mono="true">
-                    {project.preferredPath ?? copy.unavailable}
+                // While renaming, the field and its save/cancel pair share ONE
+                // flex container. Split across label and endContent they
+                // overlapped: the field claims the label slot's full width and
+                // the buttons render on top of its right edge.
+                label={isRenaming ? (
+                  <HStack gap={2} align="center">
+                  <TextInput
+                    type="text"
+                    value={draftName}
+                    onChange={(value) => setDraftName(value.slice(0, 80))}
+                    // Enter saves and Escape backs out: a field that can only
+                    // be dismissed by mousing to a button is a trap for anyone
+                    // who opened it from the keyboard.
+                    onEnter={() => {
+                      if (canSave) void saveRename();
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Escape') setRenamingId(null);
+                    }}
+                    label={copy.renameLabel}
+                    isLabelHidden
+                    hasAutoFocus
+                  />
+                    <Button
+                      variant="primary"
+                      size="sm"
+                      isDisabled={!canSave}
+                      clickAction={() => saveRename()}
+                      label={copy.save}
+                    />
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setRenamingId(null)}
+                      label={copy.cancel}
+                    />
+                  </HStack>
+                ) : project.name}
+                description={isRenaming ? undefined : (
+                  <code
+                    className="settingsReadOnlyValue"
+                    data-mono="true"
+                    // The abbreviated form is what the row shows; the whole
+                    // path stays one hover away rather than being lost.
+                    title={path?.title}
+                  >
+                    {path?.text ?? copy.unavailable}
                   </code>
-                }
-                end={endCluster}
-                isEditing={renamingId === project.id}
-                canSave={draftName.trim() !== '' && draftName.trim() !== project.name}
-                saveLabel={copy.save}
-                cancelLabel={copy.cancel}
-                onEdit={() => {
-                  setDraftName(project.name);
-                  setRenamingId(project.id);
-                }}
-                onCancel={() => setRenamingId(null)}
-                onSave={async () => {
-                  const next = draftName.trim();
-                  if (next === '' || next === project.name) return;
-                  await runRowAction(
-                    `rename:${project.id}`,
-                    async () => {
-                      await window.maka.projects.rename(project.id, next);
-                      setRenamingId(null);
-                    },
-                    copy.renameFailed,
-                  );
-                }}
-              >
-                <TextInput
-                  type="text"
-                  value={draftName}
-                  onChange={(value) => setDraftName(value.slice(0, 80))}
-                  label={copy.renameLabel}
-                  isLabelHidden
-                  width="100%"
-                />
-              </SettingsExpandableRow>
+                )}
+                // No wrapper class: `startContent` already owns the slot's
+                // layout, and the anchor's weight comes from the icon's size
+                // rather than a plate or a second glyph family.
+                startContent={<FolderOpen size={18} aria-hidden="true" />}
+                endContent={isRenaming ? undefined : endCluster}
+              />
             );
-          })
+          })}
+          </List>
         )}
       </SettingsSection>
     </SettingsPage>


### PR DESCRIPTION
## 改了什么

项目页的承载组件从「设置行」换成 Astryx `List` + `ListItem`，并落实路径显示规则与图标锚点。owner 反馈「目前不够好看」。

## 为什么：选错了承载组件，不是缺装饰

原来用的是 `SettingsSection` + 设置行——那是给「一个标签 + 一个控件」的**偏好项**用的。项目是**实体**。错配直接导致三件事：

- 每行没有前置槽可以放锚点，四行下来是一片文字
- 整条绝对路径 mono 折成两行，视觉重量压过它所属的项目名
- **列表语义是假的**：只是长得像列表。写 e2e 时 `getByRole('listitem')` 匹配不到，就是这个原因。

MCP 页和技能页的实体行早就用的是 `List` + `ListItem`：真列表语义、真分隔线、`startContent` 锚点槽。这次是回到既有做法，不是发明。

## 三条细节

**路径保尾段**：家目录缩 `~`，**从头部截断**——路径的辨识度在尾巴上，`…/experiments/astryx-design-system` 说明这是哪个项目，而 `/Users/someone/Developer/exp…` 只说明它在谁的机器上。完整路径留在 tooltip，信息没有丢失，只是降权。

用纯函数而不是 CSS `direction` 方向 trick：那招在混合方向文本里会把标点甩到错位，而路径里带中文目录名并不罕见。

**图标锚点**：我们自己的 Lucide `FolderOpen`（就是导航里项目页那枚），大一档尺寸。不引第二种字形族、不用实心变体——锚点的分量靠尺寸。**没有 wrapper class**：初版写的 `settingsProjectIcon` 在 CSS 里根本不存在，是个装饰性死类，删掉；`startContent` 槽本身就管布局。

**重命名态共容器**：输入框和「保存/取消」原本分处 label 槽和 endContent 槽，前者撑满槽宽、后者压在它右边框上，**视觉重叠**。改成共用一个 flex 容器，结构上不可能再叠。

## 怎么验证的

- 新增 **11 个路径规则单测**。边界条款：`~` 只在路径分隔处匹配，所以 `/Users/maka` 不会把 `/Users/maka-agent` 改写成 `~-agent`；已经够短的路径不加装饰性省略号；tooltip 存**原始**路径而不是 `~` 形式（`~` 正是用户查 tooltip 想展开的那部分）。
- **原有 3 个项目页 e2e 零改断言通过** —— 承载组件换了、行为契约没动，这本身就是回归证据。
- typecheck / lint / format / build / knip 全绿；desktop **1762 passed / 0 failed**。
- 视觉两态预览已过审。

重叠和死类两处都是**截图发现的，不是断言发现的**。