### PR TITLE
test(desktop): poll animation landings instead of guessing their duration

### DIFF
--- a/apps/desktop/e2e/new-messages-indicator.spec.ts
+++ b/apps/desktop/e2e/new-messages-indicator.spec.ts
@@ -53,9 +53,16 @@ async function scrollToBottom(page: import('@playwright/test').Page) {
   // Astryx's synthetic-scroll guard bails out of the scroll handler while
   // scrollHeight is still changing, which a programmatic jump right after the
   // reply settles can trip; a real user's scroll keeps firing until the
-  // layout stops. Drive one more cycle after the layout settles so
+  // layout stops. Wait for the layout fact itself — scrollHeight stable across
+  // two consecutive animation frames — then drive one more cycle so
   // `isScrolledUp` follows the final position.
-  await page.waitForTimeout(250);
+  await page.waitForFunction(() => {
+    const el = document.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');
+    if (!el) return false;
+    const sampled = (window as { __scrollHeightSample?: number }).__scrollHeightSample;
+    (window as { __scrollHeightSample?: number }).__scrollHeightSample = el.scrollHeight;
+    return sampled === el.scrollHeight;
+  });
   await page.evaluate(() => {
     const el = document.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');
     el?.dispatchEvent(new Event('scroll'));

--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -403,14 +403,16 @@ test('the highlight travels with the prompt being read', async ({ longTranscript
   const seen: number[] = [];
   for (const ratio of [0, 0.35, 0.7]) {
     await scrollToRatio(page, ratio);
-    // The glide is a transition on `top`; wait for it to land before reading.
-    await page.waitForTimeout(600);
-    const highlight = await readHighlight();
-    const where = `at scroll ratio ${ratio}: ${JSON.stringify(highlight)}`;
-    expect(highlight, where).not.toBeNull();
-    expect(highlight!.centreDrift, where).toBeLessThanOrEqual(1);
-    expect(highlight!.rightDrift, where).toBeLessThanOrEqual(1);
-    seen.push(highlight!.activeIndex);
+    // The glide is a transition on `top`; poll for the landed geometry itself
+    // instead of guessing the transition's duration.
+    await expect(async () => {
+      const highlight = await readHighlight();
+      const where = `at scroll ratio ${ratio}: ${JSON.stringify(highlight)}`;
+      expect(highlight, where).not.toBeNull();
+      expect(highlight!.centreDrift, where).toBeLessThanOrEqual(1);
+      expect(highlight!.rightDrift, where).toBeLessThanOrEqual(1);
+    }).toPass();
+    seen.push((await readHighlight())!.activeIndex);
   }
   // And it actually moved, rather than agreeing with a highlight that never
   // left the first tick.
@@ -427,26 +429,31 @@ test('the highlight stays on the active tick while the rail scrolls itself', asy
   await settled(page, 90);
   await scrollToRatio(page, 1);
   await expect(page.locator('.maka-prompt-rail-tick').last()).toHaveAttribute('aria-current', 'true');
-  await page.waitForTimeout(600);
 
-  const reading = await page.evaluate(() => {
-    const rail = document.querySelector<HTMLElement>('.maka-prompt-rail')!;
-    const indicator = document.querySelector<HTMLElement>('.maka-prompt-rail-indicator')!;
-    const active = rail.querySelector<HTMLElement>('.maka-prompt-rail-tick[data-active="true"]')!;
-    const i = indicator.getBoundingClientRect();
-    const a = active.getBoundingClientRect();
-    const railBox = rail.getBoundingClientRect();
-    return {
-      railScrollTop: Math.round(rail.scrollTop),
-      centreDrift: Math.round(Math.abs(i.top + i.height / 2 - (a.top + a.height / 2))),
-      indicatorInsideRail: i.top >= railBox.top - 1 && i.bottom <= railBox.bottom + 1,
-    };
-  });
-  const where = JSON.stringify(reading);
-  // The rail really did scroll, so the highlight had something to keep up with.
-  expect(reading.railScrollTop, where).toBeGreaterThan(0);
-  expect(reading.centreDrift, where).toBeLessThanOrEqual(1);
-  expect(reading.indicatorInsideRail, where).toBe(true);
+  const readAlignment = () =>
+    page.evaluate(() => {
+      const rail = document.querySelector<HTMLElement>('.maka-prompt-rail')!;
+      const indicator = document.querySelector<HTMLElement>('.maka-prompt-rail-indicator')!;
+      const active = rail.querySelector<HTMLElement>('.maka-prompt-rail-tick[data-active="true"]')!;
+      const i = indicator.getBoundingClientRect();
+      const a = active.getBoundingClientRect();
+      const railBox = rail.getBoundingClientRect();
+      return {
+        railScrollTop: Math.round(rail.scrollTop),
+        centreDrift: Math.round(Math.abs(i.top + i.height / 2 - (a.top + a.height / 2))),
+        indicatorInsideRail: i.top >= railBox.top - 1 && i.bottom <= railBox.bottom + 1,
+      };
+    });
+  // The glide is a transition on `top`; poll for the landed geometry itself
+  // instead of guessing the transition's duration.
+  await expect(async () => {
+    const reading = await readAlignment();
+    const where = JSON.stringify(reading);
+    // The rail really did scroll, so the highlight had something to keep up with.
+    expect(reading.railScrollTop, where).toBeGreaterThan(0);
+    expect(reading.centreDrift, where).toBeLessThanOrEqual(1);
+    expect(reading.indicatorInsideRail, where).toBe(true);
+  }).toPass();
 });
 
 test('hovering a tick swells its neighbours and settles back', async ({ longTranscriptWindow: page }) => {
@@ -467,18 +474,20 @@ test('hovering a tick swells its neighbours and settles back', async ({ longTran
   // pointerover/pointerout, which do.
   const hovered = 12;
   await page.locator('.maka-prompt-rail-tick').nth(hovered).dispatchEvent('pointerover');
-  await page.waitForTimeout(500);
-
-  const swollen = await barWidths();
-  const note = JSON.stringify(swollen);
-  // A falloff, not a single fat tick: widest under the pointer, then stepping
-  // down on both sides until it meets the resting width.
-  expect(swollen[hovered], note).toBeGreaterThan(swollen[hovered - 1]!);
-  expect(swollen[hovered - 1], note).toBeGreaterThan(swollen[hovered - 2]!);
-  expect(swollen[hovered], note).toBeGreaterThan(swollen[hovered + 1]!);
-  expect(swollen[hovered + 1], note).toBeGreaterThan(swollen[hovered + 2]!);
-  expect(swollen[hovered - 3], note).toBe(rest[0]);
-  expect(swollen[hovered + 3], note).toBe(rest[0]);
+  // The swell is a width transition; poll for the settled falloff shape itself
+  // instead of guessing the transition's duration.
+  await expect(async () => {
+    const swollen = await barWidths();
+    const note = JSON.stringify(swollen);
+    // A falloff, not a single fat tick: widest under the pointer, then stepping
+    // down on both sides until it meets the resting width.
+    expect(swollen[hovered], note).toBeGreaterThan(swollen[hovered - 1]!);
+    expect(swollen[hovered - 1], note).toBeGreaterThan(swollen[hovered - 2]!);
+    expect(swollen[hovered], note).toBeGreaterThan(swollen[hovered + 1]!);
+    expect(swollen[hovered + 1], note).toBeGreaterThan(swollen[hovered + 2]!);
+    expect(swollen[hovered - 3], note).toBe(rest[0]);
+    expect(swollen[hovered + 3], note).toBe(rest[0]);
+  }).toPass();
 
   await page.evaluate((index) => {
     const tick = document.querySelectorAll('.maka-prompt-rail-tick')[index]!;
@@ -486,6 +495,7 @@ test('hovering a tick swells its neighbours and settles back', async ({ longTran
       new PointerEvent('pointerout', { bubbles: true, composed: true, relatedTarget: document.body }),
     );
   }, hovered);
-  await page.waitForTimeout(500);
-  expect(await barWidths()).toEqual(rest);
+  await expect(async () => {
+    expect(await barWidths()).toEqual(rest);
+  }).toPass();
 });

--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -158,11 +158,16 @@ test('the quote layer waits for the selection to settle, stays closed after Esca
   await page.keyboard.press('Escape');
   await expect(quoteLayer).toBeHidden();
   await page.keyboard.press('Shift');
+  // Real-timer negative window, derived from the hook's SELECTION_SETTLE_MS
+  // (350ms): a wrongly re-captured selection would surface the layer once that
+  // settle window elapses, so outliving it (with margin) proves the dismissal
+  // held.
   await page.waitForTimeout(500);
   await expect(quoteLayer).toBeHidden();
 
   // Selecting inside the composer must not surface a transcript affordance —
-  // and must not leave the previous selection's layer standing either.
+  // and must not leave the previous selection's layer standing either. Same
+  // SELECTION_SETTLE_MS-derived negative window as above.
   await composer.fill('drafted text to select');
   await selectContents(composer);
   await page.waitForTimeout(500);


### PR DESCRIPTION
Part of #2389 (desktop e2e workspace; Pi TUI landed as #2448, Runtime Host as #2450, the alignment audit follows separately).

## What changed

Five waits guessed at durations the page can be asked about directly:

| Spec | Was | Now |
|---|---|---|
| `prompt-rail` × 4 (indicator glide ×2, hover swell, hover settle) | `waitForTimeout(500-600)` then one-shot geometry read | `expect(...).toPass()` polling the asserted geometry itself (the repo's existing idiom, cf. `composer-skill-invocation.spec.ts`) — ends the moment the transition lands, and only a failing test pays the budget |
| `new-messages-indicator` pre-scroll settle | `waitForTimeout(250)` | `waitForFunction` on the observable layout fact: `scrollHeight` stable across two consecutive animation frames |

## Audited and preserved (each wait *is* the contract)

- **`quote-companion`'s two 500ms holds** — real-timer negative windows now documented with their derivation: they outlive the hook's `SELECTION_SETTLE_MS` (350ms) to prove a dismissed/composer selection *stays* hidden once the settle window has elapsed. The absence is the contract; there is no earlier observable.
- **The 90ms drag cadence** — deliberately paces mouse moves inside the 350ms settle window.
- **`titlebar-identity`'s 1s one-shot toast-absence read** — its comment already explains why a retrying matcher would mask the bug.
- **`bot-onboarding`'s 1.15s/1.3s waits** — synchronized against fixture-scheduled provider results, not animation guesses.

## Timing

The three touched suites run in the same ~20s wall locally (Playwright overlaps workers, so the removed sleeps were latency-hidden). The gain is load-tolerance, not wall time: the fixed 500/600ms reads lost races on loaded CI runners (the #2221/#2332 failure shape), while the polls track the asserted fact under any scheduler. 15/15 tests pass before and after.