### PR TITLE
fix(deps): bump dompurify past GHSA-55q2-fjhq-7xh7

### DIFF
--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -7072,7 +7072,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
-Package: dompurify@3.4.12
+Package: dompurify@3.4.13
 Declared license: (MPL-2.0 OR Apache-2.0)
 Selected license: Apache-2.0
 Repository: git://github.com/cure53/DOMPurify.git

--- a/package-lock.json
+++ b/package-lock.json
@@ -6966,9 +6966,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"


### PR DESCRIPTION
The 0.1.8 release run failed at the audit gate: DOMPurify moderate XSS advisory (GHSA-55q2-fjhq-7xh7), transitive via @maka/ui → mermaid. `npm audit fix` bumps the locked dompurify to 3.4.13; lockfile-only. `npm audit --omit=dev --audit-level=moderate` now exits clean. Unblocks re-dispatching the release.