### PR TITLE
test(windows): support PowerShell fallback in process identity test

### DIFF
--- a/scripts/windows-baseline-workflow.test.mjs
+++ b/scripts/windows-baseline-workflow.test.mjs
@@ -7,18 +7,49 @@ import { fileURLToPath } from 'node:url';
 const workflowUrl = new URL('../.github/workflows/windows-baseline.yml', import.meta.url);
 const processIdentityScriptUrl = new URL('./windows-process-identity.ps1', import.meta.url);
 
-function resolvePowerShellExecutable() {
+function powerShellArgs(command) {
+  return ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-Command', command];
+}
+
+function resolvePowerShellExecutable(spawn = spawnSync) {
+  const failures = [];
   for (const executable of ['pwsh.exe', 'powershell.exe']) {
-    const probe = spawnSync(executable, ['-NoProfile', '-NonInteractive', '-Command', 'exit 0'], {
+    const probe = spawn(executable, powerShellArgs('exit 0'), {
       encoding: 'utf8',
     });
     if (probe.status === 0) return executable;
-    if (probe.error?.code !== 'ENOENT') {
-      assert.fail(probe.error?.message || probe.stderr || probe.stdout);
-    }
+    failures.push(
+      `${executable}: ${probe.error?.message || probe.stderr || probe.stdout || `exit ${probe.status}`}`,
+    );
   }
-  assert.fail('Neither pwsh.exe nor powershell.exe is available');
+  assert.fail(`No usable PowerShell executable (${failures.join('; ')})`);
 }
+
+test('PowerShell resolution covers the documented Windows PowerShell fallback', () => {
+  for (const pwshFailure of [
+    {
+      status: null,
+      error: Object.assign(new Error('spawnSync pwsh.exe ENOENT'), { code: 'ENOENT' }),
+    },
+    { status: 1, error: undefined },
+  ]) {
+    const calls = [];
+    const executable = resolvePowerShellExecutable((command, args, options) => {
+      calls.push({ command, args, options });
+      return command === 'pwsh.exe'
+        ? { ...pwshFailure, stdout: '', stderr: '' }
+        : { status: 0, error: undefined, stdout: '', stderr: '' };
+    });
+
+    assert.equal(executable, 'powershell.exe');
+    assert.deepEqual(
+      calls.map(({ command }) => command),
+      ['pwsh.exe', 'powershell.exe'],
+    );
+    assert.deepEqual(calls[0].args, powerShellArgs('exit 0'));
+    assert.equal(calls[0].options.encoding, 'utf8');
+  }
+});
 
 test('Windows baseline workflow keeps its non-blocking evidence contract', async () => {
   const workflow = await readFile(workflowUrl, 'utf8');
@@ -100,12 +131,8 @@ test('Windows process identity matches a non-empty JSON baseline to a live proce
         exit 1
       }
     `;
-  const result = spawnSync(
-    resolvePowerShellExecutable(),
-    ['-NoProfile', '-NonInteractive', '-Command', fixture],
-    {
-      encoding: 'utf8',
-    },
-  );
+  const result = spawnSync(resolvePowerShellExecutable(), powerShellArgs(fixture), {
+    encoding: 'utf8',
+  });
   assert.equal(result.status, 0, result.error?.message || result.stderr || result.stdout);
 });

--- a/scripts/windows-baseline-workflow.test.mjs
+++ b/scripts/windows-baseline-workflow.test.mjs
@@ -7,6 +7,19 @@ import { fileURLToPath } from 'node:url';
 const workflowUrl = new URL('../.github/workflows/windows-baseline.yml', import.meta.url);
 const processIdentityScriptUrl = new URL('./windows-process-identity.ps1', import.meta.url);
 
+function resolvePowerShellExecutable() {
+  for (const executable of ['pwsh.exe', 'powershell.exe']) {
+    const probe = spawnSync(executable, ['-NoProfile', '-NonInteractive', '-Command', 'exit 0'], {
+      encoding: 'utf8',
+    });
+    if (probe.status === 0) return executable;
+    if (probe.error?.code !== 'ENOENT') {
+      assert.fail(probe.error?.message || probe.stderr || probe.stdout);
+    }
+  }
+  assert.fail('Neither pwsh.exe nor powershell.exe is available');
+}
+
 test('Windows baseline workflow keeps its non-blocking evidence contract', async () => {
   const workflow = await readFile(workflowUrl, 'utf8');
 
@@ -76,7 +89,7 @@ test('Windows process identity matches a non-empty JSON baseline to a live proce
       $captured = [pscustomobject]@{
         Processes = @([pscustomobject]@{
           ProcessId = 4242
-          CreationDate = [DateTimeOffset]::Parse('2026-08-05T08:09:10.1234567+08:00')
+          CreationDate = [DateTimeOffset]::Parse('2026-08-05T08:09:10.1234567+08:00').ToUniversalTime().ToString('o')
         })
       } | ConvertTo-Json -Depth 3 | ConvertFrom-Json
       $live = [pscustomobject]@{
@@ -87,8 +100,12 @@ test('Windows process identity matches a non-empty JSON baseline to a live proce
         exit 1
       }
     `;
-  const result = spawnSync('pwsh.exe', ['-NoProfile', '-NonInteractive', '-Command', fixture], {
-    encoding: 'utf8',
-  });
-  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const result = spawnSync(
+    resolvePowerShellExecutable(),
+    ['-NoProfile', '-NonInteractive', '-Command', fixture],
+    {
+      encoding: 'utf8',
+    },
+  );
+  assert.equal(result.status, 0, result.error?.message || result.stderr || result.stdout);
 });


### PR DESCRIPTION
## Summary

- prefer PowerShell 7 for the Windows process identity test and fall back to Windows PowerShell 5.1 when `pwsh.exe` is unavailable or unusable
- make shell probing injectable so CI covers both a missing and a broken `pwsh.exe` before selecting `powershell.exe`
- run both probe and fixture commands with `-ExecutionPolicy Bypass`
- serialize the fixture's creation time as the same UTC ISO string written by the Windows baseline workflow
- surface diagnostics from every failed shell candidate instead of reporting only a `null` exit status

## Root cause

The Windows support baseline documents PowerShell 7 as preferred and Windows PowerShell 5.1 as a supported fallback, but this Windows-only script test unconditionally spawned `pwsh.exe`. On a fallback-only development environment, `spawnSync` returned `ENOENT` and `status: null`, so both `npm run test:scripts` and `npm run test:fast` stopped before workspace tests.

The fixture also serialized a `DateTimeOffset` object directly, unlike the workflow, which serializes an ISO string. Windows PowerShell 5.1 rounds that object during JSON conversion, so changing only the executable would introduce an artificial process identity mismatch.

## Impact

Windows contributors can run the repository script suite with either documented PowerShell option, including machines whose execution policy would otherwise block the dot-sourced helper. The injected resolver regression test exercises the fallback path on every platform, the local Windows PowerShell 5.1 run validates the real fallback shell, and GitHub Actions exercises the preferred `pwsh` path.

Fixes #2454
Part of #2142

## Validation

- reproduced the original targeted failure twice without `pwsh.exe`: `status: null`, `error.code: ENOENT`
- injected resolver regression covers both missing and unusable `pwsh.exe` candidates before selecting `powershell.exe`
- `node --test --test-name-pattern="PowerShell resolution|Windows process identity" scripts/windows-baseline-workflow.test.mjs` (2 pass)
- `npm run test:scripts` (129 pass, 0 fail, 1 existing skip)
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `git diff --check`

An earlier local `npm run test:fast` passed the repaired script stage, then encountered existing Windows workspace failures involving symlink privileges and locked temporary SQLite files (`EPERM`/`EBUSY`) and did not settle within 10 minutes. Those failures are outside this test-only change and remain under the broader Windows baseline tracked in #2142. The PR's required CI and non-blocking Windows baseline passed before the review follow-up; the updated checks run again after this commit.
