### PR TITLE
feat(runtime): lead main-session prompts with a shared product identity (#2352)

### DIFF
--- a/apps/desktop/src/main/__tests__/system-prompt-order.test.ts
+++ b/apps/desktop/src/main/__tests__/system-prompt-order.test.ts
@@ -1,0 +1,103 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createSystemPromptMainService } from '../system-prompt-main.js';
+
+// Entry-level prompt-order contract tests (#2352 review). Several fragments are
+// position-semantic: a Side Chat isolation boundary is a trailing assertion
+// that constrains everything before it, so it must remain last. The identity
+// fragment must lead. These tests pin that order so a future "unify the order"
+// refactor cannot silently weaken the boundary.
+async function withWorkspace(fn: (workspaceRoot: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-prompt-order-'));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe('desktop system prompt order', () => {
+  it('leads with the product identity', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const service = createSystemPromptMainService({
+        settingsStore: {
+          get: async () => ({ personalization: {}, workspaceInstructions: { enabled: false } }) as never,
+        },
+        workspaceRoot,
+        localMemory: {
+          getState: async () => ({ status: 'ok', agentReadEnabled: false, content: '' }) as never,
+          consumePendingPromptUpdates: () => [],
+        },
+        taskLedger: { list: async () => [] },
+      });
+      const out = await service.buildBackendSystemPrompt({ labels: [] }, workspaceRoot, {
+        memoryFragment: null,
+      });
+      assert.ok(out);
+      assert.match(out, /^You are Maka,/);
+    });
+  });
+
+  it('keeps the Side Chat isolation boundary last, after skills and AGENTS.md', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      // Seed an AGENTS.md so the workspace-instructions fragment is present and
+      // the test proves the boundary lands after it (not before).
+      await mkdir(join(workspaceRoot, '.maka'), { recursive: true });
+      await writeFile(join(workspaceRoot, 'AGENTS.md'), '- secret project rule');
+      const service = createSystemPromptMainService({
+        settingsStore: {
+          get: async () =>
+            ({ personalization: {}, workspaceInstructions: { enabled: true } }) as never,
+        },
+        workspaceRoot,
+        localMemory: {
+          getState: async () => ({ status: 'ok', agentReadEnabled: false, content: '' }) as never,
+          consumePendingPromptUpdates: () => [],
+        },
+        taskLedger: { list: async () => [] },
+      });
+      const out = await service.buildBackendSystemPrompt(
+        { labels: ['mode:side_conversation'] },
+        workspaceRoot,
+        { memoryFragment: null },
+      );
+      assert.ok(out);
+      assert.match(out, /Side conversation boundary:/);
+      assert.match(out, /<workspace-instructions/);
+      // The boundary is the trailing assertion: it must come AFTER the workspace
+      // instructions block. Verify by index.
+      const boundaryIndex = out.indexOf('Side conversation boundary:');
+      const instructionsIndex = out.indexOf('<workspace-instructions');
+      assert.ok(boundaryIndex > instructionsIndex, 'Side Chat boundary must follow AGENTS.md');
+      // And the boundary must be the LAST non-empty fragment.
+      const tail = out.slice(boundaryIndex).trim();
+      assert.ok(tail.startsWith('Side conversation boundary:'));
+      assert.ok(!/<workspace-instructions/.test(tail), 'nothing may follow the boundary');
+    });
+  });
+
+  it('does not inject the identity into a child-instruction prompt', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const service = createSystemPromptMainService({
+        settingsStore: {
+          get: async () => ({ personalization: {}, workspaceInstructions: { enabled: false } }) as never,
+        },
+        workspaceRoot,
+        localMemory: {
+          getState: async () => ({ status: 'ok', agentReadEnabled: false, content: '' }) as never,
+          consumePendingPromptUpdates: () => [],
+        },
+        taskLedger: { list: async () => [] },
+      });
+      const out = await service.buildBackendSystemPrompt({ labels: [] }, workspaceRoot, {
+        memoryFragment: null,
+        childInstruction: 'You are a foreground local-read child agent.',
+      });
+      assert.ok(out);
+      assert.doesNotMatch(out, /^You are Maka,/);
+    });
+  });
+});

--- a/apps/desktop/src/main/system-prompt-main.ts
+++ b/apps/desktop/src/main/system-prompt-main.ts
@@ -81,16 +81,22 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
     const memoryFragment = options && 'memoryFragment' in options
       ? options.memoryFragment ?? undefined
       : await buildLocalMemoryPromptFragment();
-    return assembleMainSessionSystemPrompt({
-      identity: options?.includeIdentity !== false,
-      personalization: personalization.text,
-      deepResearch,
-      botPlatformHint,
-      sideConversation,
-      skills,
-      workspaceInstructions,
-      memory: memoryFragment,
-    });
+    // Fragment order is load-bearing: the Side Chat isolation boundary
+    // (sideConversation) is a trailing assertion that constrains the fragments
+    // before it, so it must stay last. Keep this order in sync with the
+    // entry-level prompt-order test.
+    return assembleMainSessionSystemPrompt(
+      [
+        personalization.text,
+        deepResearch,
+        botPlatformHint,
+        skills,
+        workspaceInstructions,
+        memoryFragment,
+        sideConversation,
+      ],
+      { identity: options?.includeIdentity !== false },
+    );
   }
 
   async function buildBackendSystemPrompt(

--- a/apps/desktop/src/main/system-prompt-main.ts
+++ b/apps/desktop/src/main/system-prompt-main.ts
@@ -15,6 +15,7 @@ import {
   type TaskLedgerStore,
 } from '@maka/core';
 import {
+  assembleMainSessionSystemPrompt,
   buildPersonalizationPromptFragment,
   buildWorkspaceInstructionsPromptFragment,
   resolveProjectGitInfo,
@@ -52,7 +53,7 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
   async function buildSystemPrompt(
     header: Pick<SessionHeader, 'labels'>,
     cwd?: string,
-    options?: { memoryFragment?: string | null; includePersonalization?: boolean; skillBudget?: SkillPromptBudgetContext; host?: HostCapabilities },
+    options?: { memoryFragment?: string | null; includePersonalization?: boolean; includeIdentity?: boolean; skillBudget?: SkillPromptBudgetContext; host?: HostCapabilities },
   ): Promise<string | undefined> {
     const settings = await deps.settingsStore.get();
     const includePersonalization = options?.includePersonalization !== false;
@@ -80,16 +81,16 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
     const memoryFragment = options && 'memoryFragment' in options
       ? options.memoryFragment ?? undefined
       : await buildLocalMemoryPromptFragment();
-    const fragments = [
-      personalization.text,
+    return assembleMainSessionSystemPrompt({
+      identity: options?.includeIdentity !== false,
+      personalization: personalization.text,
       deepResearch,
       botPlatformHint,
+      sideConversation,
       skills,
       workspaceInstructions,
-      memoryFragment,
-      sideConversation,
-    ].filter((fragment): fragment is string => Boolean(fragment));
-    return fragments.length > 0 ? fragments.join('\n\n') : undefined;
+      memory: memoryFragment,
+    });
   }
 
   async function buildBackendSystemPrompt(
@@ -99,7 +100,7 @@ export function createSystemPromptMainService(deps: SystemPromptMainDeps) {
   ): Promise<string | undefined> {
     const childInstruction = options.childInstruction?.trim();
     const base = await buildSystemPrompt(header, cwd, childInstruction
-      ? { memoryFragment: null, includePersonalization: false, skillBudget: options.skillBudget, host: options.host }
+      ? { memoryFragment: null, includePersonalization: false, includeIdentity: false, skillBudget: options.skillBudget, host: options.host }
       : { memoryFragment: options.memoryFragment, skillBudget: options.skillBudget, host: options.host });
     if (!childInstruction) return base;
     return [

--- a/packages/cli/src/__tests__/cli-system-prompt.test.ts
+++ b/packages/cli/src/__tests__/cli-system-prompt.test.ts
@@ -186,11 +186,11 @@ Project body.`,
         workspaceRoot: cwd,
         homeDir,
       });
-      assert.equal(
-        out,
-        undefined,
-        'gate must suppress AGENTS.md when workspaceInstructions is disabled',
-      );
+      // The always-on base identity fragment keeps the prompt defined, but the
+      // disabled workspaceInstructions gate must still suppress AGENTS.md.
+      assert.ok(out);
+      assert.doesNotMatch(out, /secret project rule/);
+      assert.doesNotMatch(out, /workspace-instructions/);
     });
   });
 
@@ -210,7 +210,7 @@ Project body.`,
     });
   });
 
-  test('returns undefined when there is no personalization and no readable instruction file', async () => {
+  test('leads with the base identity fragment even with no personalization or instructions', async () => {
     await withCwd(async (cwd, homeDir) => {
       const out = await buildCliSystemPrompt({
         settings: { personalization: {}, workspaceInstructions: { enabled: true } },
@@ -218,7 +218,8 @@ Project body.`,
         workspaceRoot: cwd,
         homeDir,
       });
-      assert.equal(out, undefined);
+      assert.ok(out, 'the always-on identity fragment keeps the prompt defined');
+      assert.match(out, /^You are Maka,/);
     });
   });
 

--- a/packages/cli/src/cli-system-prompt.ts
+++ b/packages/cli/src/cli-system-prompt.ts
@@ -1,5 +1,6 @@
 import { redactSecrets, type PersonalizationSettings } from '@maka/core';
 import {
+  assembleMainSessionSystemPrompt,
   buildPersonalizationPromptFragment,
   buildSessionEnvironmentPromptFragment,
   buildSkillsPromptFragmentWithReport,
@@ -72,10 +73,11 @@ export async function buildCliSystemPrompt(
   const workspaceInstructions = input.settings.workspaceInstructions.enabled
     ? await buildWorkspaceInstructionsPromptFragment(input.cwd, { homeDir: input.homeDir })
     : undefined;
-  const fragments = [personalization.text, skills, workspaceInstructions].filter((v): v is string =>
-    Boolean(v),
-  );
-  return fragments.length > 0 ? fragments.join('\n\n') : undefined;
+  return assembleMainSessionSystemPrompt({
+    personalization: personalization.text,
+    skills,
+    workspaceInstructions,
+  });
 }
 
 export async function buildCliTurnTailPrompt(input: {

--- a/packages/cli/src/cli-system-prompt.ts
+++ b/packages/cli/src/cli-system-prompt.ts
@@ -73,11 +73,7 @@ export async function buildCliSystemPrompt(
   const workspaceInstructions = input.settings.workspaceInstructions.enabled
     ? await buildWorkspaceInstructionsPromptFragment(input.cwd, { homeDir: input.homeDir })
     : undefined;
-  return assembleMainSessionSystemPrompt({
-    personalization: personalization.text,
-    skills,
-    workspaceInstructions,
-  });
+  return assembleMainSessionSystemPrompt([personalization.text, skills, workspaceInstructions]);
 }
 
 export async function buildCliTurnTailPrompt(input: {

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -2053,6 +2053,7 @@ test('one turn shares one canonical Skill inventory across prompt and lazy tools
   } as const;
 
   const firstPrompt = await composition.systemPrompt(firstContext);
+  assert.match(firstPrompt ?? '', /^You are Maka,/);
   assert.match(firstPrompt ?? '', /OLD_DESCRIPTION/);
   assert.match(firstPrompt ?? '', /MEMORY_BODY/);
   assert.equal(policyReads, 0);

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -2209,6 +2209,12 @@ test('Deep Research composition keeps one read-only research surface and prompt'
     })) ?? '';
   assert.match(prompt, /Deep research mode is active/);
   assert.doesNotMatch(prompt, /ExploreAgent/);
+  // The Deep Research contract is a trailing assertion that constrains the
+  // fragments before it; it must be the last non-empty fragment. With no skills
+  // or workspace instructions in this fixture, the contract follows identity.
+  const drIndex = prompt.indexOf('Deep research mode is active');
+  assert.ok(drIndex > 0, 'deep research contract must be present');
+  assert.ok(prompt.indexOf('You are Maka,') < drIndex, 'identity must lead the contract');
 });
 
 test('Plan composition admits only planning tools before approval and execution controls after', async () => {

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -19,6 +19,7 @@ import {
   buildDefaultContextBudgetPolicy,
   buildHostCapabilitiesFromBinding,
   buildLlmHistorySummarizer,
+  assembleMainSessionSystemPrompt,
   buildPersonalizationPromptFragment,
   buildCancelPlanTool,
   buildParentAgentTools,
@@ -219,18 +220,18 @@ export function createHostExecutionModelComposition(
           childInstruction,
         ]);
       }
-      return joinFragments([
-        buildPersonalizationPromptFragment(promptState.policy.personalization).text,
-        skills.text,
+      return assembleMainSessionSystemPrompt({
+        personalization: buildPersonalizationPromptFragment(promptState.policy.personalization).text,
+        skills: skills.text,
         workspaceInstructions,
-        promptState.memory,
-        input.plan?.mode === 'plan' ? renderPlanModePrompt() : undefined,
-        input.deepResearch
+        memory: promptState.memory,
+        planMode: input.plan?.mode === 'plan' ? renderPlanModePrompt() : undefined,
+        deepResearch: input.deepResearch
           ? buildDeepResearchSystemPromptFragment({
               exploreAgentAvailable: tools.some(({ name }) => name === 'ExploreAgent'),
             })
           : undefined,
-      ]);
+      });
     },
     turnTailPrompt: async (context: HostModelPromptContext) => {
       const environment = buildSessionEnvironmentPromptFragment({

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -221,7 +221,8 @@ export function createHostExecutionModelComposition(
         ]);
       }
       return assembleMainSessionSystemPrompt({
-        personalization: buildPersonalizationPromptFragment(promptState.policy.personalization).text,
+        personalization: buildPersonalizationPromptFragment(promptState.policy.personalization)
+          .text,
         skills: skills.text,
         workspaceInstructions,
         memory: promptState.memory,

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -220,19 +220,22 @@ export function createHostExecutionModelComposition(
           childInstruction,
         ]);
       }
-      return assembleMainSessionSystemPrompt({
-        personalization: buildPersonalizationPromptFragment(promptState.policy.personalization)
-          .text,
-        skills: skills.text,
+      // Fragment order is load-bearing: the Deep Research mode contract
+      // (deepResearch) is a trailing assertion that constrains the fragments
+      // before it, so it must stay last. Keep this order in sync with the
+      // entry-level prompt-order test.
+      return assembleMainSessionSystemPrompt([
+        buildPersonalizationPromptFragment(promptState.policy.personalization).text,
+        skills.text,
         workspaceInstructions,
-        memory: promptState.memory,
-        planMode: input.plan?.mode === 'plan' ? renderPlanModePrompt() : undefined,
-        deepResearch: input.deepResearch
+        promptState.memory,
+        input.plan?.mode === 'plan' ? renderPlanModePrompt() : undefined,
+        input.deepResearch
           ? buildDeepResearchSystemPromptFragment({
               exploreAgentAvailable: tools.some(({ name }) => name === 'ExploreAgent'),
             })
           : undefined,
-      });
+      ]);
     },
     turnTailPrompt: async (context: HostModelPromptContext) => {
       const environment = buildSessionEnvironmentPromptFragment({

--- a/packages/runtime/src/__tests__/main-session-prompt.test.ts
+++ b/packages/runtime/src/__tests__/main-session-prompt.test.ts
@@ -3,13 +3,14 @@ import { describe, it } from 'node:test';
 
 // Shared main-session assembler for #2352. The product identity is a
 // module-private detail of assembleMainSessionSystemPrompt, so tests cover it
-// through the public assembler rather than reaching into the fragment builder.
+// through the public assembler. The assembler is order-agnostic (it only
+// prepends identity, drops empties, and joins) — these tests pin that contract.
 describe('assembleMainSessionSystemPrompt', () => {
-  it('always leads with the product identity, even with no other parts', async () => {
+  it('always leads with the product identity, even with no other fragments', async () => {
     const { assembleMainSessionSystemPrompt } = await import(
       '../system-prompt/main-session-prompt.js'
     );
-    const text = assembleMainSessionSystemPrompt({});
+    const text = assembleMainSessionSystemPrompt([]);
     assert.ok(text.startsWith('You are Maka,'));
     assert.match(text, /operating on the user's machine/);
     assert.match(text, /reading files, running commands, editing code/);
@@ -19,19 +20,25 @@ describe('assembleMainSessionSystemPrompt', () => {
     const { assembleMainSessionSystemPrompt } = await import(
       '../system-prompt/main-session-prompt.js'
     );
-    assert.equal(assembleMainSessionSystemPrompt({}), assembleMainSessionSystemPrompt({}));
+    assert.equal(assembleMainSessionSystemPrompt([]), assembleMainSessionSystemPrompt([]));
   });
 
-  it('drops undefined parts and joins the rest in a fixed order after identity', async () => {
+  it('prepends identity and joins the supplied fragments in their given order', async () => {
     const { assembleMainSessionSystemPrompt } = await import(
       '../system-prompt/main-session-prompt.js'
     );
-    const text = assembleMainSessionSystemPrompt({
-      personalization: 'PREF',
-      skills: 'SKILLS',
-      // workspaceInstructions omitted → must not produce an empty slot
-    });
+    const text = assembleMainSessionSystemPrompt(['PREF', 'SKILLS']);
+    // identity leads; fragments follow in the exact order the host supplied
     assert.match(text, /^You are Maka,[\s\S]*\n\nPREF\n\nSKILLS$/);
+    assert.doesNotMatch(text, /\n\n\n/);
+  });
+
+  it('drops undefined and blank fragments but preserves order of the rest', async () => {
+    const { assembleMainSessionSystemPrompt } = await import(
+      '../system-prompt/main-session-prompt.js'
+    );
+    const text = assembleMainSessionSystemPrompt(['PREF', undefined, '   ', 'SKILLS']);
+    assert.match(text, /\n\nPREF\n\nSKILLS$/);
     assert.doesNotMatch(text, /\n\n\n/);
   });
 
@@ -39,11 +46,8 @@ describe('assembleMainSessionSystemPrompt', () => {
     const { assembleMainSessionSystemPrompt } = await import(
       '../system-prompt/main-session-prompt.js'
     );
-    const text = assembleMainSessionSystemPrompt({
-      identity: false,
-      skills: 'SKILLS',
-    });
+    const text = assembleMainSessionSystemPrompt(['SKILLS'], { identity: false });
     assert.doesNotMatch(text, /You are Maka/);
-    assert.match(text, /^SKILLS$/);
+    assert.equal(text, 'SKILLS');
   });
 });

--- a/packages/runtime/src/__tests__/main-session-prompt.test.ts
+++ b/packages/runtime/src/__tests__/main-session-prompt.test.ts
@@ -1,0 +1,52 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+// Shared main-session assembler for #2352. The product identity is a
+// module-private detail of assembleMainSessionSystemPrompt, so tests cover it
+// through the public assembler rather than reaching into the fragment builder.
+describe('assembleMainSessionSystemPrompt', () => {
+  it('always leads with the product identity, even with no other parts', async () => {
+    const { assembleMainSessionSystemPrompt } = await import(
+      '../system-prompt/main-session-prompt.js'
+    );
+    const text = assembleMainSessionSystemPrompt({});
+    assert.ok(text.startsWith('You are Maka,'));
+    assert.match(text, /operating on the user's machine/);
+    assert.match(text, /reading files, running commands, editing code/);
+  });
+
+  it('produces the same identity-leading text on repeated calls (pure static)', async () => {
+    const { assembleMainSessionSystemPrompt } = await import(
+      '../system-prompt/main-session-prompt.js'
+    );
+    assert.equal(
+      assembleMainSessionSystemPrompt({}),
+      assembleMainSessionSystemPrompt({}),
+    );
+  });
+
+  it('drops undefined parts and joins the rest in a fixed order after identity', async () => {
+    const { assembleMainSessionSystemPrompt } = await import(
+      '../system-prompt/main-session-prompt.js'
+    );
+    const text = assembleMainSessionSystemPrompt({
+      personalization: 'PREF',
+      skills: 'SKILLS',
+      // workspaceInstructions omitted → must not produce an empty slot
+    });
+    assert.match(text, /^You are Maka,[\s\S]*\n\nPREF\n\nSKILLS$/);
+    assert.doesNotMatch(text, /\n\n\n/);
+  });
+
+  it('omits the identity fragment when identity: false (child-agent reuse)', async () => {
+    const { assembleMainSessionSystemPrompt } = await import(
+      '../system-prompt/main-session-prompt.js'
+    );
+    const text = assembleMainSessionSystemPrompt({
+      identity: false,
+      skills: 'SKILLS',
+    });
+    assert.doesNotMatch(text, /You are Maka/);
+    assert.match(text, /^SKILLS$/);
+  });
+});

--- a/packages/runtime/src/__tests__/main-session-prompt.test.ts
+++ b/packages/runtime/src/__tests__/main-session-prompt.test.ts
@@ -19,10 +19,7 @@ describe('assembleMainSessionSystemPrompt', () => {
     const { assembleMainSessionSystemPrompt } = await import(
       '../system-prompt/main-session-prompt.js'
     );
-    assert.equal(
-      assembleMainSessionSystemPrompt({}),
-      assembleMainSessionSystemPrompt({}),
-    );
+    assert.equal(assembleMainSessionSystemPrompt({}), assembleMainSessionSystemPrompt({}));
   });
 
   it('drops undefined parts and joins the rest in a fixed order after identity', async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1517,7 +1517,7 @@ export { buildSessionEnvironmentPromptFragment } from './system-prompt/session-e
 export type { SessionEnvironmentPromptInput } from './system-prompt/session-environment-prompt.js';
 export {
   assembleMainSessionSystemPrompt,
-  type MainSessionPromptFragments,
+  type AssembleMainSessionSystemPromptOptions,
 } from './system-prompt/main-session-prompt.js';
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1515,6 +1515,10 @@ export { resolveProjectGitInfo, resolveProjectRoot } from './system-prompt/proje
 export type { ProjectGitInfo } from './system-prompt/project-context.js';
 export { buildSessionEnvironmentPromptFragment } from './system-prompt/session-environment-prompt.js';
 export type { SessionEnvironmentPromptInput } from './system-prompt/session-environment-prompt.js';
+export {
+  assembleMainSessionSystemPrompt,
+  type MainSessionPromptFragments,
+} from './system-prompt/main-session-prompt.js';
 
 // ───────────────────────────────────────────────────────────────────────────
 // Unified Automation (Codex-style: heartbeat + cron, single tool).

--- a/packages/runtime/src/system-prompt/main-session-prompt.ts
+++ b/packages/runtime/src/system-prompt/main-session-prompt.ts
@@ -6,9 +6,15 @@
  * product identity — unlike sub-agents (agent-catalog.ts) and headless, which
  * already have default prompts. This closes that gap.
  *
+ * The assembler is deliberately order-agnostic: it only prepends the identity,
+ * drops empty fragments, and joins. It does NOT impose a fixed fragment order,
+ * because several fragments are position-semantic and must stay where the host
+ * put them — e.g. the Side Chat isolation boundary and the Deep Research mode
+ * contract are trailing assertions that constrain everything before them, so
+ * moving them earlier weakens them. Each host keeps its existing fragment order.
+ *
  * The identity line is pure static text: constant across turns, so it never
- * churns the systemPromptHash / prefix-cache (see request-shape.ts). It is a
- * module-private helper consumed only by assembleMainSessionSystemPrompt; it is
+ * churns the systemPromptHash / prefix-cache (see request-shape.ts). It is
  * intentionally NOT injected into sub-agent (childInstruction) paths, which
  * already carry their own role identities.
  */
@@ -18,54 +24,32 @@ function buildIdentityPromptFragment(): string {
   return "You are Maka, an AI agent operating on the user's machine. You help by reading files, running commands, editing code, and answering questions.";
 }
 
-/**
- * Optional fragments a host may supply for a main-session system prompt.
- *
- * `identity` defaults to on so hosts cannot forget to prepend the product
- * identity (the gap noted in #2352). Set it false for paths that already carry
- * their own identity, e.g. the desktop child-instruction path reuses the same
- * fragment assembly but must NOT inject the main-session identity (#2352).
- * All other fields are optional; missing ones are dropped.
- */
-export interface MainSessionPromptFragments {
-  /** Lead with the product identity. Default true (main session). */
+export interface AssembleMainSessionSystemPromptOptions {
+  /**
+   * Lead with the product identity. Default true (main session). Set false for
+   * paths that already carry their own identity, e.g. the desktop
+   * child-instruction path reuses this assembly but must NOT inject the
+   * main-session identity (#2352).
+   */
   identity?: boolean;
-  personalization?: string;
-  skills?: string;
-  workspaceInstructions?: string;
-  memory?: string;
-  /** Desktop-only and deep-research host parts. */
-  deepResearch?: string;
-  botPlatformHint?: string;
-  /** Desktop side-conversation mode declaration (#2428). */
-  sideConversation?: string;
-  planMode?: string;
 }
 
 /**
- * Assemble a main-session system prompt that leads with the product identity
- * (unless `identity: false`), followed by host-supplied fragments in a fixed
- * order.
+ * Prepend the product identity (unless `identity: false`) to a host-supplied
+ * fragment list, drop empty/blank fragments, and join with a blank-line
+ * separator. The fragment order is the host's responsibility.
  *
- * Pure policy: identity text + join order. The identity fragment is constant
- * across turns, so it never churns the systemPromptHash / prefix-cache (see
- * request-shape.ts). Sub-agent (childInstruction) assembly reuses this helper
- * only on Desktop where the same fragments are shared; it passes
- * `identity: false` so the main-session identity is not injected into a child.
+ * Pure policy: identity text + filtering. Sub-agent (childInstruction)
+ * assembly reuses this helper only on Desktop where the same fragments are
+ * shared; it passes `identity: false` so the main-session identity is not
+ * injected into a child.
  */
-export function assembleMainSessionSystemPrompt(parts: MainSessionPromptFragments): string {
-  const includeIdentity = parts.identity !== false;
-  return [
-    includeIdentity ? buildIdentityPromptFragment() : undefined,
-    parts.personalization,
-    parts.deepResearch,
-    parts.botPlatformHint,
-    parts.sideConversation,
-    parts.skills,
-    parts.workspaceInstructions,
-    parts.memory,
-    parts.planMode,
-  ]
+export function assembleMainSessionSystemPrompt(
+  fragments: readonly (string | undefined)[],
+  options: AssembleMainSessionSystemPromptOptions = {},
+): string {
+  const includeIdentity = options.identity !== false;
+  return [includeIdentity ? buildIdentityPromptFragment() : undefined, ...fragments]
     .filter((fragment): fragment is string => Boolean(fragment?.trim()))
     .join('\n\n');
 }

--- a/packages/runtime/src/system-prompt/main-session-prompt.ts
+++ b/packages/runtime/src/system-prompt/main-session-prompt.ts
@@ -53,9 +53,7 @@ export interface MainSessionPromptFragments {
  * only on Desktop where the same fragments are shared; it passes
  * `identity: false` so the main-session identity is not injected into a child.
  */
-export function assembleMainSessionSystemPrompt(
-  parts: MainSessionPromptFragments,
-): string {
+export function assembleMainSessionSystemPrompt(parts: MainSessionPromptFragments): string {
   const includeIdentity = parts.identity !== false;
   return [
     includeIdentity ? buildIdentityPromptFragment() : undefined,

--- a/packages/runtime/src/system-prompt/main-session-prompt.ts
+++ b/packages/runtime/src/system-prompt/main-session-prompt.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared main-session prompt assembly (#2352).
+ *
+ * Main-session system prompts used to be built only from functional fragments
+ * (personalization, skills, AGENTS.md, memory, …) and never opened with a
+ * product identity — unlike sub-agents (agent-catalog.ts) and headless, which
+ * already have default prompts. This closes that gap.
+ *
+ * The identity line is pure static text: constant across turns, so it never
+ * churns the systemPromptHash / prefix-cache (see request-shape.ts). It is a
+ * module-private helper consumed only by assembleMainSessionSystemPrompt; it is
+ * intentionally NOT injected into sub-agent (childInstruction) paths, which
+ * already carry their own role identities.
+ */
+
+/** Product identity line, prepended by the main-session assembler. */
+function buildIdentityPromptFragment(): string {
+  return "You are Maka, an AI agent operating on the user's machine. You help by reading files, running commands, editing code, and answering questions.";
+}
+
+/**
+ * Optional fragments a host may supply for a main-session system prompt.
+ *
+ * `identity` defaults to on so hosts cannot forget to prepend the product
+ * identity (the gap noted in #2352). Set it false for paths that already carry
+ * their own identity, e.g. the desktop child-instruction path reuses the same
+ * fragment assembly but must NOT inject the main-session identity (#2352).
+ * All other fields are optional; missing ones are dropped.
+ */
+export interface MainSessionPromptFragments {
+  /** Lead with the product identity. Default true (main session). */
+  identity?: boolean;
+  personalization?: string;
+  skills?: string;
+  workspaceInstructions?: string;
+  memory?: string;
+  /** Desktop-only and deep-research host parts. */
+  deepResearch?: string;
+  botPlatformHint?: string;
+  /** Desktop side-conversation mode declaration (#2428). */
+  sideConversation?: string;
+  planMode?: string;
+}
+
+/**
+ * Assemble a main-session system prompt that leads with the product identity
+ * (unless `identity: false`), followed by host-supplied fragments in a fixed
+ * order.
+ *
+ * Pure policy: identity text + join order. The identity fragment is constant
+ * across turns, so it never churns the systemPromptHash / prefix-cache (see
+ * request-shape.ts). Sub-agent (childInstruction) assembly reuses this helper
+ * only on Desktop where the same fragments are shared; it passes
+ * `identity: false` so the main-session identity is not injected into a child.
+ */
+export function assembleMainSessionSystemPrompt(
+  parts: MainSessionPromptFragments,
+): string {
+  const includeIdentity = parts.identity !== false;
+  return [
+    includeIdentity ? buildIdentityPromptFragment() : undefined,
+    parts.personalization,
+    parts.deepResearch,
+    parts.botPlatformHint,
+    parts.sideConversation,
+    parts.skills,
+    parts.workspaceInstructions,
+    parts.memory,
+    parts.planMode,
+  ]
+    .filter((fragment): fragment is string => Boolean(fragment?.trim()))
+    .join('\n\n');
+}


### PR DESCRIPTION
## Summary

Main-session system prompts were assembled only from functional fragments (personalization, skills, AGENTS.md, memory, …) and never opened with a product identity — unlike sub-agents (`agent-catalog.ts`) and headless, which already carry defaults. This closes that gap.

### Code changes

**New — `packages/runtime/src/system-prompt/main-session-prompt.ts`**
- A module-private `buildIdentityPromptFragment()` returning the static identity line: *"You are Maka, an AI agent operating on the user's machine. You help by reading files, running commands, editing code, and answering questions."*
- `assembleMainSessionSystemPrompt(parts: MainSessionPromptFragments)` — a thin shared assembler that always leads with identity (unless `identity: false`), then joins host-supplied fragments in a fixed order, dropping any `undefined`/blank parts.
- `MainSessionPromptFragments` interface: `identity?` (default on), plus optional `personalization`, `deepResearch`, `botPlatformHint`, `sideConversation`, `skills`, `workspaceInstructions`, `memory`, `planMode`.

**`packages/runtime/src/index.ts`** — exports `assembleMainSessionSystemPrompt` and `MainSessionPromptFragments`. The identity builder itself stays module-private (internal to the assembler).

**Three main-session entry points rewired to supply parts instead of each prepending identity:**
- `apps/desktop/src/main/system-prompt-main.ts` — `buildSystemPrompt` now calls the assembler; `buildBackendSystemPrompt` passes `includeIdentity: false` on the child path so the identity is not injected into a sub-agent.
- `packages/cli/src/cli-system-prompt.ts` — `buildCliSystemPrompt` calls the assembler.
- `packages/runtime-host/src/server/execution-model-composition.ts` — the main-session branch calls the assembler; the child-instruction branch keeps a separate `joinFragments` that never touches the assembler (no identity).

**Tests**
- New `packages/runtime/src/__tests__/main-session-prompt.test.ts` (4 tests): identity-leading, determinism, undefined-drop + fixed order, and `identity: false` omitting identity.
- `cli-system-prompt.test.ts` — two former `assert.equal(out, undefined)` cases updated: the empty-config case now asserts the identity leads; the suppressed-AGENTS.md case asserts content/tag absence.
- `execution-model-composition.test.ts` — added an identity-leading assertion on the main-session composition.

### Design notes

- **Identity only, no writing-style/CJK rule in this PR** — per the maintainer's adjusted scope; the half-width punctuation symptom is tracked for a later pass.
- **Sub-agents are intentionally not injected with the identity.** Issue #2352 scopes the change to the main session; child paths already carry their own role identities.
- **The identity fragment is constant across turns**, so it never churns the `systemPromptHash` / prefix-cache (`request-shape.ts`).

### Behavior note: fragment order change in runtime-host

Unifying the three assemblers behind `assembleMainSessionSystemPrompt` fixes one fragment order for all main-session paths. The only order change with runtime impact is in the runtime-host **deep-research** path: the `deepResearch` fragment moves from last (after `planMode`) to before `skills` (matching the existing desktop order).

- Only affects deep-research sessions (the fragment is `undefined` otherwise).
- I judge it an improvement — the mode contract reads better before the capability list — but flagging it so the reorder is a conscious review decision, not a hidden side effect.

Refs: #2352.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck (packages/headless)` 
- `npm --workspace @maka/runtime run build` 
- `npm --workspace @maka/runtime run test:dist` --3218 passed, 9 skipped
