### PR TITLE
feat(desktop): check for updates when the window regains focus

### DIFF
--- a/apps/desktop/src/main/__tests__/app-update-focus-check.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-focus-check.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AppUpdater } from 'electron-updater';
+import { createAppUpdateService } from '../app-update-service.js';
+
+/**
+ * Focus-triggered update checks (#162).
+ *
+ * The four-hour timer alone meant a version published while the window sat
+ * open went unnoticed until the next tick — the reported "the update never
+ * showed up". Focus is when the user is present, so it is when looking is
+ * worth it; the throttle is what keeps a frequent signal from becoming a
+ * request storm.
+ */
+function createHarness(options: { start: number }) {
+  const checks: number[] = [];
+  let now = options.start;
+
+  const updater = {
+    autoDownload: false,
+    autoInstallOnAppQuit: false,
+    on: () => updater,
+    setFeedURL: () => {},
+    checkForUpdates: async () => {
+      checks.push(now);
+      return null;
+    },
+  } as unknown as AppUpdater;
+
+  const service = createAppUpdateService({
+    currentVersion: '0.1.8',
+    isPackaged: true,
+    updater,
+    hasActiveTasks: () => false,
+    clock: {
+      // No scheduled checks in these tests: the timer is a separate trigger and
+      // firing it here would blur which path recorded the timestamp.
+      setTimeout: () => undefined,
+      clearTimeout: () => {},
+      now: () => now,
+    },
+  });
+
+  return {
+    service,
+    checks,
+    advance(ms: number) {
+      now += ms;
+    },
+  };
+}
+
+const FIFTEEN_MINUTES = 15 * 60 * 1000;
+
+describe('update check on window focus', () => {
+  test('checks when the window regains focus', async () => {
+    const harness = createHarness({ start: 1_000 });
+    harness.service.start();
+
+    await harness.service.checkForUpdatesOnFocus();
+
+    assert.equal(harness.checks.length, 1);
+  });
+
+  test('does not check again inside the throttle window', async () => {
+    const harness = createHarness({ start: 1_000 });
+    harness.service.start();
+
+    await harness.service.checkForUpdatesOnFocus();
+    harness.advance(FIFTEEN_MINUTES - 1);
+    await harness.service.checkForUpdatesOnFocus();
+
+    // Alt-tabbing repeatedly must not mean repeated update requests.
+    assert.equal(harness.checks.length, 1);
+  });
+
+  test('checks again once the throttle window has passed', async () => {
+    const harness = createHarness({ start: 1_000 });
+    harness.service.start();
+
+    await harness.service.checkForUpdatesOnFocus();
+    harness.advance(FIFTEEN_MINUTES);
+    await harness.service.checkForUpdatesOnFocus();
+
+    assert.equal(harness.checks.length, 2);
+  });
+
+  test('stays quiet until the service has started', async () => {
+    // Before start() the app has not decided it is in an updatable build at
+    // all; a focus event arriving first must not jump that gate.
+    const harness = createHarness({ start: 1_000 });
+
+    await harness.service.checkForUpdatesOnFocus();
+
+    assert.equal(harness.checks.length, 0);
+  });
+
+  test('stays quiet after dispose', async () => {
+    const harness = createHarness({ start: 1_000 });
+    harness.service.start();
+    harness.service.dispose();
+
+    await harness.service.checkForUpdatesOnFocus();
+
+    assert.equal(harness.checks.length, 0);
+  });
+});

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -261,6 +261,16 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
   app.whenReady().then(async () => {
     updateService.start();
 
+    // Check when the user comes back to the app, not only on the four-hour
+    // timer. A version published while the window sat open was otherwise
+    // invisible until the next tick, which is what "the update never showed
+    // up" actually was. The service throttles this to one check per 15
+    // minutes, so alt-tabbing does not turn into a request storm, and any
+    // extra Maka window firing the same app-level event is a no-op.
+    app.on('browser-window-focus', () => {
+      void updateService.checkForUpdatesOnFocus();
+    });
+
     // The renderer's first IPC calls (session enumeration, settings read,
     // connection listing)
     // all read from stores that are initialized synchronously at module load,

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -54,6 +54,8 @@ export interface AppUpdateService {
   getStatus(): AppUpdateStatus;
   retryUpdateDownload(): Promise<AppUpdateStatus>;
   installUpdate(input: AppUpdateInstallRequest): Promise<AppUpdateInstallResult>;
+  /** Check because the window regained focus, subject to a shared throttle. */
+  checkForUpdatesOnFocus(): Promise<void>;
 }
 
 interface AppUpdateServiceDeps {
@@ -67,11 +69,19 @@ interface AppUpdateServiceDeps {
   clock?: {
     setTimeout(callback: () => void, delayMs: number): unknown;
     clearTimeout(handle: unknown): void;
+    /** Time source for the focus-check throttle. */
+    now?(): number;
   };
 }
 
 const FIRST_UPDATE_CHECK_DELAY_MS = 10_000;
 const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+/**
+ * Focus is a cheap, frequent signal, so it is throttled rather than trusted:
+ * alt-tabbing ten times in a minute must not mean ten update requests. The
+ * four-hour timer stays as the floor for a window that is never refocused.
+ */
+const UPDATE_CHECK_ON_FOCUS_MIN_INTERVAL_MS = 15 * 60 * 1000;
 
 function normalizeVersion(version: string): string {
   return version.trim().replace(/^v/i, '');
@@ -158,6 +168,10 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     setTimeout: (callback: () => void, delayMs: number) => setTimeout(callback, delayMs),
     clearTimeout: (handle: unknown) => clearTimeout(handle as ReturnType<typeof setTimeout>),
   };
+  const now = (): number => clock.now?.() ?? Date.now();
+  // One record shared by both triggers. Keeping a separate timestamp per
+  // trigger would let a focus check fire seconds after a scheduled one.
+  let lastCheckStartedAt: number | undefined;
 
   const publish = (next: AppUpdateStatus): AppUpdateStatus => {
     status = next;
@@ -273,6 +287,7 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     if (status.state === 'downloading' && !allowDuringDownload) return status;
     if (activeDownload && !allowDuringDownload) return status;
     if (checkInFlight) return checkInFlight;
+    lastCheckStartedAt = now();
     checkInFlight = updater
       .checkForUpdates()
       .then((result) => {
@@ -365,11 +380,37 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     }
   }
 
+  /**
+   * Check because the user came back to the window.
+   *
+   * The four-hour timer alone means a version published while the app sat
+   * open is not noticed until the next tick — which is what "the update did
+   * not show up" actually was. Focus is when the user is present and a restart
+   * prompt is least disruptive, so it is the right moment to look.
+   *
+   * Deliberately does NOT reset the scheduled timer: the two triggers stay
+   * independent and the shared throttle is what keeps them from doubling up.
+   */
+  async function checkForUpdatesOnFocus(): Promise<void> {
+    if (disposed || !started) return;
+    if (
+      lastCheckStartedAt !== undefined &&
+      now() - lastCheckStartedAt < UPDATE_CHECK_ON_FOCUS_MIN_INTERVAL_MS
+    ) {
+      return;
+    }
+    // No `allowDuringDownload`: a download already in flight is the update
+    // arriving, and re-checking mid-download is exactly what that guard exists
+    // to prevent.
+    await checkForUpdates();
+  }
+
   return {
     start,
     dispose,
     getStatus: currentStatus,
     retryUpdateDownload,
     installUpdate,
+    checkForUpdatesOnFocus,
   };
 }


### PR DESCRIPTION
task #162。owner 反馈「自动升级不会及时出现」。

## 为什么

检查本身没坏，**节奏不对**：启动 10 秒查一次，之后每 4 小时一次。应用一直开着跨过一次发布，就得等下一个 4 小时刻度才发现——这就是「不及时」的真身。

窗口重新聚焦是个免费信号，而且含义正好：**用户回来了**。既是发现新版本最有价值的时刻，也是重启提示最不打扰的时刻。

## 规格六条的落法

1. **触发点**：`app.on('browser-window-focus')`（在 `app-lifecycle.ts` 里，紧挨 `updateService.start()`）。多窗口触发同一事件也无所谓，被节流吃掉。
2. **节流 15 分钟，且只有一处记录**：`lastCheckStartedAt` 由**真正发起检查的那条路径**写入，定时和聚焦共用。按触发路径各记各的会让聚焦检查在定时检查后几秒又发一次——这正是规格点名要避免的。
3. **4 小时兜底保留，聚焦不重置定时**：两条触发独立，靠共享节流去重（采纳规格里"不重置更简单"的判断）。
4. **重入保护沿用不绕开**：`checkForUpdatesOnFocus` 走既有 `checkForUpdates()`，**不传 `allowDuringDownload`**——正在下载就是更新已经在来的路上，此时重查正是那个守卫存在的理由。
5. **测试**：新增 5 条（`clock.now` 注入时间源）。
6. **无 UI、无 copy 变更，纯 main 侧。**

## 怎么验证的

- 新增 5 条单测：聚焦触发一次；节流窗口内（15min − 1ms）不重复；跨过窗口后再查；`start()` 之前不查；`dispose()` 之后不查。
- **故障注入**：把节流判断整段拆掉 → **恰好 1 条失败**（窗口内重复那条）→ 装回全绿。
- `@maka/desktop` **1804 passed / 0 failed**；typecheck / lint / format 全绿。
- 按范围化测试规矩，只跑了 desktop 这一个 workspace。

## 一处实现说明

`clock` 依赖原本只有 `setTimeout` / `clearTimeout`，节流需要时间源，所以加了可选的 `now?()`，默认 `Date.now`。沿用既有 DI 结构，没有引入新的注入机制。