### PR TITLE
test(runtime-host): validate Windows named-pipe clients

### DIFF
--- a/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
@@ -31,8 +31,7 @@ const PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 
-test('two UDS Clients query and control one Agent graph through Session invalidation', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+test('two Clients query and control one Agent graph through Session invalidation', {
   timeout: 10_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-agent-graph-two-client-'));

--- a/packages/runtime-host/src/__tests__/automation-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-two-client-uds.test.ts
@@ -24,9 +24,7 @@ const PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 
-test('two UDS Clients share one revision-pinned Automation authority', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
-}, async () => {
+test('two Clients share one revision-pinned Automation authority', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-automation-uds-'));
   const root = join(base, 'interactive');
   const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });

--- a/packages/runtime-host/src/__tests__/control-endpoint.test.ts
+++ b/packages/runtime-host/src/__tests__/control-endpoint.test.ts
@@ -21,6 +21,24 @@ function legacyPrefix(): string {
   return `m-${process.getuid?.()}-${rootTag()}-`;
 }
 
+describe('runtime host Windows named-pipe endpoint', { skip: process.platform !== 'win32' }, () => {
+  test('derives a stable pipe name and has idempotent lifecycle hooks', async () => {
+    const endpoint = await prepareRuntimeHostEndpoint({ rootId: ROOT_ID, hostEpoch: 'epoch-1' });
+    assert.equal(endpoint.path, `\\\\.\\pipe\\maka-runtime-host-${ROOT_ID.slice(0, 16)}-epoch-1`);
+    await endpoint.prepareAfterListen();
+    await endpoint.cleanup();
+    await endpoint.cleanup();
+  });
+
+  test('rejects an invalid storage root identity', async () => {
+    await assert.rejects(
+      prepareRuntimeHostEndpoint({ rootId: 'not-a-root-id', hostEpoch: '1' }),
+      (error: unknown) =>
+        error instanceof RuntimeHostEndpointError && error.code === 'insecure_endpoint_directory',
+    );
+  });
+});
+
 describe('runtime host control endpoint', { skip: process.platform === 'win32' }, () => {
   const originalTmpdir = process.env.TMPDIR;
 

--- a/packages/runtime-host/src/__tests__/daily-review-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/daily-review-two-client-uds.test.ts
@@ -16,9 +16,7 @@ const PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 
-test('two UDS Clients share Daily Review config, generation, and restart recovery', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
-}, async () => {
+test('two Clients share Daily Review config, generation, and restart recovery', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-daily-review-uds-'));
   const root = join(base, 'interactive');
   const capability = await resolveStorageRoot({

--- a/packages/runtime-host/src/__tests__/deep-research-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/deep-research-two-client-uds.test.ts
@@ -20,9 +20,7 @@ const PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 
-test('two UDS Clients and a restarted production Host share one Deep Research projection', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
-}, async () => {
+test('two Clients and a restarted production Host share one Deep Research projection', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-deep-research-uds-'));
   const root = join(base, 'interactive');
   const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });

--- a/packages/runtime-host/src/__tests__/execution-inspect-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-inspect-uds.test.ts
@@ -17,8 +17,8 @@ import { removePosixEndpointDirectories } from './fixtures/endpoint-hygiene.js';
 
 const PROCESS_TIMEOUT_MS = 10_000;
 
-test('a live Host serves Interactive inspection over its real UDS while retaining exclusive ownership', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+test('a live Host serves Interactive inspection over its real endpoint while retaining exclusive ownership', {
+  skip: process.platform === 'win32' ? 'Windows execution Host startup lifecycle' : false,
   timeout: 60_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-inspect-'));

--- a/packages/runtime-host/src/__tests__/oauth-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-two-client-uds.test.ts
@@ -22,8 +22,7 @@ import {
 } from '../server/operation-dispatcher.js';
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
 
-test('OAuth enrollment presents only on the initiating Client over real UDS', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+test('OAuth enrollment presents only on the initiating Client over the real endpoint', {
   timeout: 30_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-oauth-two-client-'));
@@ -153,8 +152,7 @@ test('OAuth enrollment presents only on the initiating Client over real UDS', {
   }
 });
 
-test('OAuth enrollment honors Claude and Codex opt-out flags over real UDS', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+test('OAuth enrollment honors Claude and Codex opt-out flags over the real endpoint', {
   timeout: 30_000,
 }, async () => {
   const cases = [

--- a/packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts
@@ -20,9 +20,7 @@ const PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 
-test('two UDS Clients and a restarted production Host share one retry-safe Plan authority', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
-}, async () => {
+test('two Clients and a restarted production Host share one retry-safe Plan authority', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-plan-uds-'));
   const root = join(base, 'interactive');
   const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -41,8 +41,8 @@ const CURRENT_PROTOCOL = {
 const PROCESS_TIMEOUT_MS = 10_000;
 const WIRE_OVERSIZED_MODEL_ID = '😀'.repeat(256);
 
-test('two UDS Clients share stable Session creation, CAS configuration, and catalog continuity', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+test('two Clients share stable Session creation, CAS configuration, and catalog continuity', {
+  skip: process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false,
   timeout: 120_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-session-catalog-'));
@@ -665,7 +665,7 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
 });
 
 test('stable Session creation survives response loss and Host restart', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+  skip: process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false,
   timeout: 120_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-session-create-retry-'));

--- a/packages/runtime-host/src/__tests__/session-effect-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-effect-two-client-uds.test.ts
@@ -19,9 +19,7 @@ const PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 
-test('two UDS Clients share one durable Session recap effect', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
-}, async () => {
+test('two Clients share one durable Session recap effect', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-session-effect-uds-'));
   const root = join(base, 'interactive');
   const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -45,8 +45,8 @@ const LINEAGE_REVISION_TARGET_ID = 'lineage-revision-target';
 const LINEAGE_BRANCH_TARGET_ID = 'lineage-branch-target';
 const GRAPH_REVISION_TARGET_ID = 'graph-revision-target';
 
-test('two UDS Clients share exact retryable Session branch and revision authority', {
-  skip: process.platform === 'win32' ? 'POSIX UDS integration' : false,
+test('two Clients share exact retryable Session branch and revision authority', {
+  skip: process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false,
   timeout: 120_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-session-revision-'));

--- a/packages/runtime-host/src/control/endpoint.ts
+++ b/packages/runtime-host/src/control/endpoint.ts
@@ -31,6 +31,7 @@ export class RuntimeHostEndpointError extends Error {
 export async function prepareRuntimeHostEndpoint(
   input: RuntimeHostEndpointInput,
 ): Promise<RuntimeHostEndpoint> {
+  assertValidRootId(input.rootId);
   if (process.platform === 'win32') {
     const path = `\\\\.\\pipe\\maka-runtime-host-${input.rootId.slice(0, 16)}-${input.hostEpoch}`;
     return {
@@ -115,13 +116,16 @@ function endpointDirectoryPrefix(rootPrefix: string, pid: number): string {
 }
 
 function endpointRootTag(rootId: string): string {
+  return Buffer.from(rootId, 'hex').toString('base64url');
+}
+
+function assertValidRootId(rootId: string): void {
   if (!/^[a-f0-9]{64}$/.test(rootId)) {
     throw new RuntimeHostEndpointError(
       'insecure_endpoint_directory',
       'Runtime Host endpoint requires a valid storage root identity',
     );
   }
-  return Buffer.from(rootId, 'hex').toString('base64url');
 }
 
 // Reclaims same-rootId endpoint directories whose owning process is gone,


### PR DESCRIPTION
## Summary

- validate Windows named-pipe endpoint naming and lifecycle hooks
- enforce the storage root identity invariant before selecting either endpoint transport
- run transport-neutral two-client Agent Graph, Automation, Daily Review, Deep Research, OAuth, Plan, and Session effect flows on Windows
- replace misleading POSIX UDS skip reasons with the actual remaining Windows lifecycle blockers

## Root cause

The runtime host already selected a Windows named pipe, but its endpoint contract and most transport-neutral two-client flows were skipped under a generic `POSIX UDS integration` label. The Windows branch also returned before validating the 64-hex-character storage root identity required by the POSIX path.

The tests that still fail because of execution-host startup or SQLite shutdown remain skipped with explicit reasons; this PR does not present those lifecycle guarantees as complete.

## Validation

- Windows named-pipe and two-client group: `10 pass / 0 fail / 4 skip`
- full repository build
- full repository typecheck
- Biome check
- `git diff --check`

The current full runtime-host Windows baseline remains `578 pass / 116 fail / 25 skip`; the failures are existing SQLite, filesystem replacement, and process-lifecycle backlog. All tests enabled by this PR pass in the full run.

Relates to #2142.