### PR TITLE
test(runtime): validate Windows process lifecycle

### DIFF
--- a/packages/runtime/src/__tests__/pty-process-driver.test.ts
+++ b/packages/runtime/src/__tests__/pty-process-driver.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { PtyProcessDriver, type PtyProcessExit } from '../pty-process-driver.js';
+import { loadPtyStack } from '../pty-stack.js';
+
+const TEST_TIMEOUT_MS = 5_000;
+
+test('PTY driver exposes the live child PID and acknowledges forced exit', async () => {
+  const stack = await loadPtyStack();
+  let resolveReady!: () => void;
+  let resolveExit!: (exit: PtyProcessExit) => void;
+  let rejectInvariant!: (error: Error) => void;
+  const ready = new Promise<void>((resolve) => {
+    resolveReady = resolve;
+  });
+  const invariantFailure = new Promise<never>((_, reject) => {
+    rejectInvariant = reject;
+  });
+  const exited = new Promise<PtyProcessExit>((resolve) => {
+    resolveExit = resolve;
+  });
+  const driver = new PtyProcessDriver({
+    stack,
+    file: process.execPath,
+    args: ['-e', "process.stdout.write('READY\\n'); setInterval(() => {}, 1000)"],
+    cwd: process.cwd(),
+    env: process.env,
+    cols: 80,
+    rows: 24,
+    onData: (data) => {
+      if (data.includes('READY')) resolveReady();
+    },
+    onExit: resolveExit,
+    onInvariantFailure: rejectInvariant,
+  });
+
+  try {
+    await withTimeout(Promise.race([ready, invariantFailure]), 'PTY child did not become ready');
+    assert.ok(Number.isSafeInteger(driver.pid) && driver.pid > 0);
+    driver.kill('SIGKILL');
+    await withTimeout(
+      Promise.race([exited, invariantFailure]),
+      'PTY child did not acknowledge exit',
+    );
+  } finally {
+    try {
+      driver.kill('SIGKILL');
+    } catch {
+      // The PTY may already have closed after acknowledging exit.
+    }
+    driver.dispose();
+  }
+});
+
+function withTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) => {
+      const timer = setTimeout(() => reject(new Error(message)), TEST_TIMEOUT_MS);
+      timer.unref();
+    }),
+  ]);
+}

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -180,11 +180,10 @@ describe('runShellWithBoundedTail', () => {
     }
   });
 
-  test('on abort, kills descendants that detach from the shell process group', async () => {
+  test('on abort, kills detached descendants of a directly spawned process', async () => {
     const dir = await fs.mkdtemp(join(tmpdir(), 'shell-exec-tree-'));
     const pidFile = join(dir, 'child.pid');
     const parentFile = join(dir, 'parent.cjs');
-    const runtime = JSON.stringify(process.execPath);
     const childScript = 'setInterval(() => {}, 1000)';
     await fs.writeFile(
       parentFile,
@@ -200,10 +199,10 @@ describe('runShellWithBoundedTail', () => {
       setInterval(() => {}, 1000);
     `,
     );
-    const cmd = `${runtime} ${JSON.stringify(parentFile)}`;
     const abort = new AbortController();
-    const running = runShellWithBoundedTail(
-      cmd,
+    const running = runProcessWithBoundedTail(
+      process.execPath,
+      [parentFile],
       base({
         timeoutMs: 10_000,
         killGraceMs: 150,


### PR DESCRIPTION
## Summary

- add a database-free PTY driver test that validates live PID publication, output readiness, forced termination, and exit acknowledgement on Windows ConPTY
- make detached-descendant abort coverage shell-independent so Windows exercises the real `taskkill /T /F` path
- retain the same direct-process test on POSIX for process-group and topology cleanup coverage

## Validation

- `npm --workspace @maka/runtime run build`
- `node --test --test-reporter=spec packages/runtime/dist/__tests__/child-process-lifecycle.test.js packages/runtime/dist/__tests__/pty-process-driver.test.js` (4 pass)
- focused `shell-exec` timeout, abort tree cleanup, and taskkill failure tests (3 pass)
- `npm --workspace @maka/runtime run typecheck`
- `npx biome check packages/runtime/src/__tests__/pty-process-driver.test.ts packages/runtime/src/__tests__/shell-exec.test.ts`
- `git diff --check`
- `npm run windows:inventory`

## Baseline note

The existing ShellRun ConPTY descendant assertion also passes on Windows, but its test file exits non-zero during temporary SQLite cleanup with the separately tracked `EBUSY` lifecycle issue. This PR does not mix that database cleanup work into process lifecycle validation.

Closes the process-lifecycle validation item in #2142.