### PR TITLE
fix(runtime): harden CodeMode integration

### DIFF
--- a/packages/runtime/src/__tests__/code-mode-backend.test.ts
+++ b/packages/runtime/src/__tests__/code-mode-backend.test.ts
@@ -341,6 +341,43 @@ test('keeps direct-only tools out of the cell snapshot', async () => {
   assert.match(JSON.stringify(execResult?.content), /unknown_tool/);
 });
 
+test('keeps provider-native tools out of the cell snapshot', async () => {
+  let implementationCalls = 0;
+  const tools: MakaTool[] = [
+    {
+      name: 'native_search',
+      description: 'Search through the model provider',
+      parameters: z.object({}),
+      providerTool: { kind: 'openai-web-search' },
+      impl: () => {
+        implementationCalls += 1;
+        return { exposed: true };
+      },
+    },
+  ];
+  const events = await collect(
+    backend(execThenStopModel('return await tools.native_search({})'), [], undefined, {
+      tools,
+    }).send({
+      turnId: 'turn-code',
+      text: 'try native search',
+      context: [],
+      toolMode: 'code_mode',
+    }),
+  );
+
+  assert.equal(implementationCalls, 0);
+  assert.equal(
+    events.some((event) => event.type === 'tool_start' && event.toolName === 'native_search'),
+    false,
+  );
+  const execResult = events.find(
+    (event): event is Extract<SessionEvent, { type: 'tool_result' }> =>
+      event.type === 'tool_result' && event.toolUseId === 'exec-1',
+  );
+  assert.match(JSON.stringify(execResult?.content), /unknown_tool/);
+});
+
 test('validates nested arguments before ToolRuntime implementation dispatch', async () => {
   let implementationCalls = 0;
   const tools: MakaTool[] = [

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -24,7 +24,31 @@ import {
 import { applyRuntimeEventHistoryCompact } from '../history-compact.js';
 import { renderSynthesisCacheBlock, selectSynthesisCacheForReplay } from '../synthesis-cache.js';
 import { historyCompactBlockToCompactionBoundary } from '../compaction-boundary.js';
-import { estimateRuntimeEventChars } from '../context-budget-helpers.js';
+import {
+  estimateRuntimeEventChars,
+  estimateRuntimeEventsTokens,
+} from '../context-budget-helpers.js';
+
+test('estimates only model-visible provider context', () => {
+  const visible = textEvent('visible-user', 'turn-1', 'visible context');
+  const hiddenCall = {
+    ...toolCall('hidden-call', 'turn-1', 'nested-call'),
+    origin: 'code_mode' as const,
+    modelVisibility: 'hidden' as const,
+  };
+  const hiddenResult = {
+    ...toolResult('hidden-result', 'turn-1', 'nested-call', {
+      text: 'nested result must not consume provider context',
+    }),
+    origin: 'code_mode' as const,
+    modelVisibility: 'hidden' as const,
+  };
+
+  assert.equal(
+    estimateRuntimeEventsTokens([visible, hiddenCall, hiddenResult], 1),
+    estimateRuntimeEventsTokens([visible], 1),
+  );
+});
 
 describe('context-budget archive retrieval', () => {
   test('does not archive hidden nested tool results', () => {

--- a/packages/runtime/src/__tests__/tool-runtime-settlement.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-settlement.test.ts
@@ -341,24 +341,6 @@ describe('ToolRuntime settlement', () => {
     assert.deepEqual(settlement.modelOutput, { type: 'text', value: 'materialized image' });
   });
 
-  it('registers step admission synchronously before settlement awaits', async () => {
-    const runtime = makeRuntime();
-    const pending = runtime.settleToolCall({
-      tool: tool(() => ({ ok: true })),
-      turnId: 'turn-1',
-      stepId: 'step-1',
-      toolCallId: 'call-1',
-      input: {},
-      abortSignal: new AbortController().signal,
-      eventSink: {
-        push: () => {},
-        pushAndWaitUntilConsumed: async () => {},
-      },
-    });
-
-    await pending;
-  });
-
   it('rejects direct-only nested tools before permission argument projection or implementation', async () => {
     let permissionProjectionCalls = 0;
     let implementationCalls = 0;

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -495,6 +495,7 @@ function nestableToolSnapshot(
           active.has(tool.name) &&
           tool.name !== INVALID_TOOL_NAME &&
           tool.name !== 'exec' &&
+          tool.providerTool === undefined &&
           tool.nesting !== 'direct_only',
       )
       .map((tool) => [tool.name, tool] as const),

--- a/packages/runtime/src/context-budget-helpers.ts
+++ b/packages/runtime/src/context-budget-helpers.ts
@@ -46,7 +46,11 @@ export function estimateRuntimeEventsTokens(
   events: readonly RuntimeEvent[],
   charsPerToken = 4,
 ): number {
-  const chars = events.reduce((total, event) => total + estimateRuntimeEventChars(event), 0);
+  const chars = events.reduce(
+    (total, event) =>
+      event.modelVisibility === 'hidden' ? total : total + estimateRuntimeEventChars(event),
+    0,
+  );
   return estimateTokens(chars, charsPerToken);
 }
 


### PR DESCRIPTION
## Summary

- exclude provider-native tools from the nested CodeMode tool snapshot so their local invariant implementations cannot be dispatched
- exclude hidden RuntimeEvents, including nested CodeMode calls and results, from provider-context token estimates
- replace an assertion-free settlement test with focused regressions at the runtime behavior seams

Refs #2466

## Verification

- `npm --workspace @maka/runtime test` — 3290 tests, 3281 passed, 9 skipped, 0 failed
- `npm run lint`
- `npm run format:check`

## Review focus

This PR is intentionally limited to `packages/runtime` and its direct tests. It does not change the CodeMode evaluator, the Terminal-Bench 2.1 harness, or the AI SDK integration.