### PR TITLE
fix(code-mode): harden evaluator boundaries

### DIFF
--- a/packages/code-mode/src/__tests__/code-mode.test.ts
+++ b/packages/code-mode/src/__tests__/code-mode.test.ts
@@ -195,6 +195,18 @@ test('rejects source that escapes the cell wrapper', async () => {
   assert.equal(result.ok ? undefined : result.error.kind, 'parse_error');
 });
 
+test('rejects wrapper escapes erased by TypeScript', async () => {
+  const result = await executeCodeCell({
+    code: `}
+      interface Escaped {`,
+    tools: [],
+    callTool: async () => null,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? undefined : result.error.kind, 'parse_error');
+});
+
 test('rejects unsupported operators before starting nested tool calls', async () => {
   let calls = 0;
   const result = await executeCodeCell({

--- a/packages/code-mode/src/__tests__/code-mode.test.ts
+++ b/packages/code-mode/src/__tests__/code-mode.test.ts
@@ -1,6 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { executeCodeCell, serializedByteLength } from '../index.js';
+import { type ExecuteCodeCellInput, executeCodeCell, serializedByteLength } from '../index.js';
+
+function executeToolResult(value: unknown, limits?: ExecuteCodeCellInput['limits']) {
+  return executeCodeCell({
+    code: 'return await tools.load({});',
+    tools: [{ name: 'load' }],
+    callTool: async () => value,
+    limits,
+  });
+}
 
 test('caps serialized-byte traversal before materializing an oversized representation', () => {
   const repeated = Array.from({ length: 1_024 }, () => '\0'.repeat(128));
@@ -183,28 +192,15 @@ test('rejects Promise.race before starting nested tool calls', async () => {
 });
 
 test('rejects source that escapes the cell wrapper', async () => {
-  const result = await executeCodeCell({
-    code: `}
-      const escaped = 1;
-    {`,
-    tools: [],
-    callTool: async () => null,
-  });
-
-  assert.equal(result.ok, false);
-  assert.equal(result.ok ? undefined : result.error.kind, 'parse_error');
-});
-
-test('rejects wrapper escapes erased by TypeScript', async () => {
-  const result = await executeCodeCell({
-    code: `}
-      interface Escaped {`,
-    tools: [],
-    callTool: async () => null,
-  });
-
-  assert.equal(result.ok, false);
-  assert.equal(result.ok ? undefined : result.error.kind, 'parse_error');
+  for (const code of [`}\nconst escaped = 1;\n{`, `}\ninterface Escaped {`]) {
+    const result = await executeCodeCell({
+      code,
+      tools: [],
+      callTool: async () => null,
+    });
+    assert.equal(result.ok, false, code);
+    assert.equal(result.ok ? undefined : result.error.kind, 'parse_error');
+  }
 });
 
 test('rejects unsupported operators before starting nested tool calls', async () => {
@@ -1055,16 +1051,173 @@ test('enforces the tool-result byte limit while materializing shared DAGs', asyn
   let value: unknown = [0];
   for (let index = 0; index < 18; index += 1) value = [value, value];
 
-  const result = await executeCodeCell({
-    code: 'return await tools.load({});',
-    tools: [{ name: 'load' }],
-    callTool: async () => value,
-    limits: { maxResultBytes: 64 },
-  });
+  const result = await executeToolResult(value, { maxResultBytes: 64 });
 
   assert.equal(result.ok, false);
   assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
   assert.match(result.ok ? '' : result.error.message, /result from load byte limit/i);
+});
+
+test('honors exact output byte boundaries', async () => {
+  const cases = [
+    { name: 'escaped string', code: 'return "\\0";', bytes: 8 },
+    { name: 'array', code: 'return [1, 2];', bytes: 5 },
+    { name: 'record', code: 'return { a: 1, b: 2 };', bytes: 13 },
+  ];
+  for (const testCase of cases) {
+    const atLimit = await executeCodeCell({
+      code: testCase.code,
+      tools: [],
+      callTool: async () => null,
+      limits: { maxOutputBytes: testCase.bytes },
+    });
+    assert.equal(atLimit.ok, true, testCase.name);
+
+    const belowLimit = await executeCodeCell({
+      code: testCase.code,
+      tools: [],
+      callTool: async () => null,
+      limits: { maxOutputBytes: testCase.bytes - 1 },
+    });
+    assert.equal(belowLimit.ok, false, testCase.name);
+    assert.equal(belowLimit.ok ? undefined : belowLimit.error.kind, 'limit_exceeded');
+  }
+});
+
+test('preserves sparse arrays returned by tools', async () => {
+  const result = await executeCodeCell({
+    code: `const value = await tools.load({});
+      return { isNull: value[0] === null, type: typeof value[0] };`,
+    tools: [{ name: 'load' }],
+    callTool: async () => new Array(1),
+  });
+
+  assert.deepEqual(result.ok ? result.value : undefined, { isNull: false, type: 'undefined' });
+});
+
+test('materializes the initial tool-result array length', async () => {
+  const value = new Array(1);
+  Object.defineProperty(value, 0, {
+    enumerable: true,
+    get: () => {
+      value.length = 100_001;
+      return 0;
+    },
+  });
+  const result = await executeCodeCell({
+    code: 'return (await tools.load({})).length;',
+    tools: [{ name: 'load' }],
+    callTool: async () => value,
+    limits: { maxCollectionItems: 1 },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.ok ? result.value : undefined, 1);
+});
+
+test('stops before reading tool-result values that cannot fit', async () => {
+  let reads = 0;
+  const array = new Array(1);
+  Object.defineProperty(array, 0, {
+    enumerable: true,
+    get: () => {
+      reads += 1;
+      return 0;
+    },
+  });
+  const record = {};
+  Object.defineProperty(record, 'a', {
+    enumerable: true,
+    get: () => {
+      reads += 1;
+      return 0;
+    },
+  });
+  for (const [value, maxResultBytes] of [
+    [array, 1],
+    [record, 5],
+  ] as const) {
+    const result = await executeToolResult(value, { maxResultBytes });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
+    assert.equal(reads, 0);
+  }
+});
+
+test('reserves remaining structure before reading tool-result values', async () => {
+  let siblingReads = 0;
+  const siblings = [0, 0];
+  for (const index of [0, 1]) {
+    Object.defineProperty(siblings, index, {
+      enumerable: true,
+      get: () => {
+        siblingReads += 1;
+        return index === 0 ? 'long' : 0;
+      },
+    });
+  }
+  const siblingResult = await executeToolResult(siblings, { maxResultBytes: 8 });
+  assert.equal(siblingResult.ok, false);
+  assert.equal(siblingReads, 1);
+
+  let nestedReads = 0;
+  const nested = new Array(1);
+  Object.defineProperty(nested, 0, {
+    enumerable: true,
+    get: () => {
+      nestedReads += 1;
+      return 0;
+    },
+  });
+  const nestedResult = await executeToolResult({ a: nested }, { maxResultBytes: 8 });
+  assert.equal(nestedResult.ok, false);
+  assert.equal(nestedReads, 0);
+});
+
+test('rejects unsafe tool-result keys before reading values', async () => {
+  let reads = 0;
+  const value = Object.create(null) as Record<string, unknown>;
+  Object.defineProperty(value, 'first', {
+    enumerable: true,
+    get: () => {
+      reads += 1;
+      return 0;
+    },
+  });
+  Object.defineProperty(value, '__proto__', { enumerable: true, value: null });
+  const result = await executeToolResult(value);
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? undefined : result.error.kind, 'invalid_data');
+  assert.equal(reads, 0);
+});
+
+test('omits tool-result properties deleted during materialization', async () => {
+  const value: Record<string, unknown> = {};
+  Object.defineProperty(value, 'a', {
+    enumerable: true,
+    get: () => {
+      delete value.b;
+      return 1;
+    },
+  });
+  value.b = 2;
+  const result = await executeToolResult(value);
+
+  assert.deepEqual(result.ok ? result.value : undefined, { a: 1 });
+});
+
+test('reads tool-result values through standard property access', async () => {
+  const value = new Proxy(
+    { a: 1 },
+    {
+      get: (target, key, receiver) => (key === 'a' ? 2 : Reflect.get(target, key, receiver)),
+    },
+  );
+  const result = await executeToolResult(value);
+
+  assert.deepEqual(result.ok ? result.value : undefined, { a: 2 });
 });
 
 test('keeps traversal budget independent from per-collection item limits', async () => {
@@ -1130,28 +1283,12 @@ test('bounds the values retained by Array.filter rather than its predicates', as
 });
 
 test('rejects oversized collections at the tool-result boundary', async () => {
-  const largeArray = Array.from({ length: 100_001 }, () => 0);
-  const arrayResult = await executeCodeCell({
-    code: 'return await tools.load({});',
-    tools: [{ name: 'load' }],
-    callTool: async () => largeArray,
-  });
-  assert.equal(arrayResult.ok, false);
-  assert.equal(arrayResult.ok ? undefined : arrayResult.error.kind, 'limit_exceeded');
-  assert.match(arrayResult.ok ? '' : arrayResult.error.message, /result from load item limit/i);
-
-  const largeRecord = Object.fromEntries(
-    Array.from({ length: 100_001 }, (_value, index) => [`key${index}`, index]),
-  );
-  const recordResult = await executeCodeCell({
-    code: 'return await tools.load({});',
-    tools: [{ name: 'load' }],
-    callTool: async () => largeRecord,
-    limits: { maxResultBytes: 8 * 1024 * 1024 },
-  });
-  assert.equal(recordResult.ok, false);
-  assert.equal(recordResult.ok ? undefined : recordResult.error.kind, 'limit_exceeded');
-  assert.match(recordResult.ok ? '' : recordResult.error.message, /result from load item limit/i);
+  for (const value of [[0, 0], { a: 1, b: 2 }]) {
+    const result = await executeToolResult(value, { maxCollectionItems: 1 });
+    assert.equal(result.ok, false);
+    assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
+    assert.match(result.ok ? '' : result.error.message, /result from load item limit/i);
+  }
 });
 
 test('enforces source, call, concurrency, result, and output byte limits', async (t) => {
@@ -1209,28 +1346,6 @@ test('enforces source, call, concurrency, result, and output byte limits', async
       limits: { maxResultBytes: 32 },
     });
     assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
-  });
-
-  await t.test('output bytes', async () => {
-    const result = await executeCodeCell({
-      code: 'return { text: "too large" };',
-      tools: [],
-      callTool: async () => null,
-      limits: { maxOutputBytes: 4 },
-    });
-    assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
-  });
-
-  await t.test('output bytes stop amplified serialization at the configured limit', async () => {
-    const repeated = Array.from({ length: 1_024 }, () => '\0'.repeat(128));
-    const result = await executeCodeCell({
-      code: 'return await tools.lookup({});',
-      tools: [{ name: 'lookup' }],
-      callTool: async () => repeated,
-      limits: { maxResultBytes: 1_024 * 1_024, maxOutputBytes: 64 },
-    });
-    assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
-    assert.match(result.ok ? '' : result.error.message, /output byte limit/i);
   });
 });
 

--- a/packages/code-mode/src/__tests__/code-mode.test.ts
+++ b/packages/code-mode/src/__tests__/code-mode.test.ts
@@ -1145,6 +1145,24 @@ test('stops before reading tool-result values that cannot fit', async () => {
   }
 });
 
+test('stops before inspecting tool-result containers that cannot fit', async () => {
+  let inspections = 0;
+  const value = new Proxy(
+    {},
+    {
+      ownKeys: (target) => {
+        inspections += 1;
+        return Reflect.ownKeys(target);
+      },
+    },
+  );
+  const result = await executeToolResult(value, { maxResultBytes: 1 });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
+  assert.equal(inspections, 0);
+});
+
 test('reserves remaining structure before reading tool-result values', async () => {
   let siblingReads = 0;
   const siblings = [0, 0];

--- a/packages/code-mode/src/__tests__/code-mode.test.ts
+++ b/packages/code-mode/src/__tests__/code-mode.test.ts
@@ -1117,35 +1117,29 @@ test('bounds the values retained by Array.filter rather than its predicates', as
   assert.match(result.ok ? '' : result.error.message, /Array\.filter byte limit/i);
 });
 
-test('bounds collection-producing array and object helpers', async () => {
+test('rejects oversized collections at the tool-result boundary', async () => {
   const largeArray = Array.from({ length: 100_001 }, () => 0);
-  const spreadResult = await executeCodeCell({
-    code: 'const values = await tools.load({}); return [...values].length;',
+  const arrayResult = await executeCodeCell({
+    code: 'return await tools.load({});',
     tools: [{ name: 'load' }],
     callTool: async () => largeArray,
   });
-  assert.equal(spreadResult.ok, false);
-  assert.equal(spreadResult.ok ? undefined : spreadResult.error.kind, 'limit_exceeded');
-
-  const mapResult = await executeCodeCell({
-    code: 'const values = await tools.load({}); return values.map((value) => value).length;',
-    tools: [{ name: 'load' }],
-    callTool: async () => largeArray,
-  });
-  assert.equal(mapResult.ok, false);
-  assert.equal(mapResult.ok ? undefined : mapResult.error.kind, 'limit_exceeded');
+  assert.equal(arrayResult.ok, false);
+  assert.equal(arrayResult.ok ? undefined : arrayResult.error.kind, 'limit_exceeded');
+  assert.match(arrayResult.ok ? '' : arrayResult.error.message, /result from load item limit/i);
 
   const largeRecord = Object.fromEntries(
     Array.from({ length: 100_001 }, (_value, index) => [`key${index}`, index]),
   );
-  const keysResult = await executeCodeCell({
-    code: 'return Object.keys(await tools.load({})).length;',
+  const recordResult = await executeCodeCell({
+    code: 'return await tools.load({});',
     tools: [{ name: 'load' }],
     callTool: async () => largeRecord,
     limits: { maxResultBytes: 8 * 1024 * 1024 },
   });
-  assert.equal(keysResult.ok, false);
-  assert.equal(keysResult.ok ? undefined : keysResult.error.kind, 'limit_exceeded');
+  assert.equal(recordResult.ok, false);
+  assert.equal(recordResult.ok ? undefined : recordResult.error.kind, 'limit_exceeded');
+  assert.match(recordResult.ok ? '' : recordResult.error.message, /result from load item limit/i);
 });
 
 test('enforces source, call, concurrency, result, and output byte limits', async (t) => {

--- a/packages/code-mode/src/__tests__/code-mode.test.ts
+++ b/packages/code-mode/src/__tests__/code-mode.test.ts
@@ -1022,7 +1022,7 @@ test('bounds collection amplification before splitting into too many items', asy
   assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
 });
 
-test('bounds cumulative output traversal for shared DAGs', async () => {
+test('enforces the output byte limit while materializing shared DAGs', async () => {
   const result = await executeCodeCell({
     code: `
       let value = [0];
@@ -1031,11 +1031,28 @@ test('bounds cumulative output traversal for shared DAGs', async () => {
     `,
     tools: [],
     callTool: async () => null,
+    limits: { maxOutputBytes: 64 },
   });
 
   assert.equal(result.ok, false);
   assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
-  assert.match(result.ok ? '' : result.error.message, /traversal/i);
+  assert.match(result.ok ? '' : result.error.message, /output byte limit/i);
+});
+
+test('enforces the tool-result byte limit while materializing shared DAGs', async () => {
+  let value: unknown = [0];
+  for (let index = 0; index < 18; index += 1) value = [value, value];
+
+  const result = await executeCodeCell({
+    code: 'return await tools.load({});',
+    tools: [{ name: 'load' }],
+    callTool: async () => value,
+    limits: { maxResultBytes: 64 },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? undefined : result.error.kind, 'limit_exceeded');
+  assert.match(result.ok ? '' : result.error.message, /result from load byte limit/i);
 });
 
 test('keeps traversal budget independent from per-collection item limits', async () => {

--- a/packages/code-mode/src/__tests__/code-mode.test.ts
+++ b/packages/code-mode/src/__tests__/code-mode.test.ts
@@ -182,6 +182,19 @@ test('rejects Promise.race before starting nested tool calls', async () => {
   assert.match(result.ok ? '' : result.error.message, /Promise\.race/);
 });
 
+test('rejects source that escapes the cell wrapper', async () => {
+  const result = await executeCodeCell({
+    code: `}
+      const escaped = 1;
+    {`,
+    tools: [],
+    callTool: async () => null,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.ok ? undefined : result.error.kind, 'parse_error');
+});
+
 test('rejects unsupported operators before starting nested tool calls', async () => {
   let calls = 0;
   const result = await executeCodeCell({

--- a/packages/code-mode/src/interpreter.ts
+++ b/packages/code-mode/src/interpreter.ts
@@ -235,11 +235,12 @@ const SUPPORTED_COLLECTION_METHODS = new Set([
   'substring',
 ]);
 
-interface CopyBudget {
-  nodes: number;
-  maxNodes: number;
-  serializedBytes: number;
-  maxSerializedBytes: number;
+interface MaterializationOptions {
+  label: string;
+  maxDepth: number;
+  maxCollectionItems: number;
+  preserveUndefined?: boolean;
+  maxBytes?: number;
   byteLimitLabel?: string;
 }
 
@@ -296,16 +297,13 @@ class Interpreter {
       this.throwIfTerminalFailure();
       await this.superviseUnobservedPromises();
       this.throwIfTerminalFailure();
-      const copied = copyPlainData(
-        value,
-        'execution result',
-        this.limits.maxDataDepth,
-        0,
-        new Set(),
-        this.limits.maxCollectionItems,
-        false,
-        createCopyBudget(this.limits.maxOutputBytes, 'output'),
-      );
+      const copied = materializePlainData(value, {
+        label: 'execution result',
+        maxDepth: this.limits.maxDataDepth,
+        maxCollectionItems: this.limits.maxCollectionItems,
+        maxBytes: this.limits.maxOutputBytes,
+        byteLimitLabel: 'output',
+      });
       return { ok: true, value: copied, toolCalls: [...this.toolCalls] };
     } catch (error) {
       if (!this.cellAbortController.signal.aborted) this.cellAbortController.abort(error);
@@ -1054,14 +1052,11 @@ class Interpreter {
           throw new InterpreterError('execution_error', 'JSON.parse expects one string', node);
         }
         try {
-          return copyPlainData(
-            JSON.parse(args[0]),
-            'JSON.parse result',
-            this.limits.maxDataDepth,
-            0,
-            new Set(),
-            this.limits.maxCollectionItems,
-          );
+          return materializePlainData(JSON.parse(args[0]), {
+            label: 'JSON.parse result',
+            maxDepth: this.limits.maxDataDepth,
+            maxCollectionItems: this.limits.maxCollectionItems,
+          });
         } catch (error) {
           if (error instanceof InterpreterError) throw error;
           throw new InterpreterError(
@@ -1074,15 +1069,12 @@ class Interpreter {
       if (args.length !== 1) {
         throw new InterpreterError('execution_error', 'JSON.stringify expects one value', node);
       }
-      const copied = copyPlainData(
-        args[0],
-        'JSON.stringify input',
-        this.limits.maxDataDepth,
-        0,
-        new Set(),
-        this.limits.maxCollectionItems,
-        true,
-      );
+      const copied = materializePlainData(args[0], {
+        label: 'JSON.stringify input',
+        maxDepth: this.limits.maxDataDepth,
+        maxCollectionItems: this.limits.maxCollectionItems,
+        preserveUndefined: true,
+      });
       assertByteLimit(copied, this.limits.maxIntermediateBytes, 'JSON.stringify');
       return JSON.stringify(copied);
     }
@@ -1493,14 +1485,11 @@ class Interpreter {
     if (this.activeToolCalls >= this.limits.maxConcurrency) {
       throw new InterpreterError('limit_exceeded', 'Tool concurrency limit exceeded', node);
     }
-    const input = copyPlainData(
-      value,
-      `arguments for ${name}`,
-      this.limits.maxDataDepth,
-      0,
-      new Set(),
-      this.limits.maxCollectionItems,
-    );
+    const input = materializePlainData(value, {
+      label: `arguments for ${name}`,
+      maxDepth: this.limits.maxDataDepth,
+      maxCollectionItems: this.limits.maxCollectionItems,
+    });
     assertByteLimit(input, this.limits.maxIntermediateBytes, 'tool arguments');
     const call = { index: this.toolCalls.length + 1, name };
     this.toolCalls.push(call);
@@ -1509,16 +1498,13 @@ class Interpreter {
       const operation = this.input.callTool(name, input, this.cellAbortController.signal);
       this.hostToolOperations.push(operation);
       const output = await awaitWithAbort(operation, this.cellAbortController.signal);
-      const copied = copyPlainData(
-        output,
-        `result from ${name}`,
-        this.limits.maxDataDepth,
-        0,
-        new Set(),
-        this.limits.maxCollectionItems,
-        false,
-        createCopyBudget(this.limits.maxResultBytes, `result from ${name}`),
-      );
+      const copied = materializePlainData(output, {
+        label: `result from ${name}`,
+        maxDepth: this.limits.maxDataDepth,
+        maxCollectionItems: this.limits.maxCollectionItems,
+        maxBytes: this.limits.maxResultBytes,
+        byteLimitLabel: `result from ${name}`,
+      });
       return copied;
     } catch (error) {
       if (this.input.signal?.aborted) throw abortReason(this.input.signal);
@@ -2083,122 +2069,116 @@ function parseCell(code: string): AstNode {
   return ast(wrapper, 'body');
 }
 
-function copyPlainData(
-  value: unknown,
-  label: string,
-  maxDepth: number,
-  depth = 0,
-  seen = new Set<object>(),
-  maxCollectionItems = Number.MAX_SAFE_INTEGER,
-  preserveUndefined = false,
-  budget: CopyBudget = createCopyBudget(),
-): unknown {
-  if (depth > maxDepth)
-    throw new InterpreterError('invalid_data', `${label} exceeds the data-depth limit`);
-  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
-    addCopySerializedBytes(budget, value);
-    return value;
-  }
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value))
-      throw new InterpreterError('invalid_data', `${label} contains a non-finite number`);
-    addCopySerializedBytes(budget, value);
-    return value;
-  }
-  if (value === undefined) {
-    const copied = preserveUndefined ? undefined : null;
-    addCopySerializedBytes(budget, copied);
-    return copied;
-  }
-  if (typeof value !== 'object')
-    throw new InterpreterError('invalid_data', `${label} contains a non-data value`);
-  budget.nodes += 1;
-  if (budget.nodes > budget.maxNodes) {
-    throw new InterpreterError('limit_exceeded', `${label} traversal limit exceeded`);
-  }
-  if (seen.has(value)) throw new InterpreterError('invalid_data', `${label} contains a cycle`);
-  seen.add(value);
-  try {
-    if (Array.isArray(value)) {
-      if (value.length > maxCollectionItems) {
-        throw new InterpreterError('limit_exceeded', `${label} item limit exceeded`);
-      }
-      addCopyBytes(budget, 1);
-      const output: unknown[] = [];
-      for (const [index, item] of value.entries()) {
-        if (index > 0) addCopyBytes(budget, 1);
-        output.push(
-          copyPlainData(
-            item,
-            label,
-            maxDepth,
-            depth + 1,
-            seen,
-            maxCollectionItems,
-            preserveUndefined,
-            budget,
-          ),
-        );
-      }
-      addCopyBytes(budget, 1);
-      return output;
-    }
-    if (!isPlainRecord(value))
-      throw new InterpreterError('invalid_data', `${label} contains a host object`);
-    if (Object.keys(value).length > maxCollectionItems) {
-      throw new InterpreterError('limit_exceeded', `${label} item limit exceeded`);
-    }
-    const output: Record<string, unknown> = {};
-    addCopyBytes(budget, 1);
-    for (const [index, [key, item]] of Object.entries(value).entries()) {
-      assertSafeKey(key);
-      if (index > 0) addCopyBytes(budget, 1);
-      addCopySerializedBytes(budget, key);
-      addCopyBytes(budget, 1);
-      output[key] = copyPlainData(
-        item,
-        label,
-        maxDepth,
-        depth + 1,
-        seen,
-        maxCollectionItems,
-        preserveUndefined,
-        budget,
+function materializePlainData(value: unknown, options: MaterializationOptions): unknown {
+  const seen = new Set<object>();
+  let nodes = 0;
+  let serializedBytes = 0;
+
+  const ensureBytes = (bytes: number): void => {
+    if (options.maxBytes === undefined) return;
+    if (bytes > options.maxBytes - serializedBytes) {
+      throw new InterpreterError(
+        'limit_exceeded',
+        `${options.byteLimitLabel ?? options.label} byte limit exceeded`,
       );
     }
-    addCopyBytes(budget, 1);
-    return output;
-  } finally {
-    seen.delete(value);
-  }
-}
-
-function createCopyBudget(
-  maxSerializedBytes = Number.POSITIVE_INFINITY,
-  byteLimitLabel?: string,
-): CopyBudget {
-  return {
-    nodes: 0,
-    maxNodes: MAX_COPY_NODES,
-    serializedBytes: 0,
-    maxSerializedBytes,
-    byteLimitLabel,
   };
-}
+  const addBytes = (bytes: number): void => {
+    ensureBytes(bytes);
+    if (options.maxBytes === undefined) return;
+    serializedBytes += bytes;
+  };
+  const addSerializedBytes = (item: unknown, requiredAfter = 0): void => {
+    if (options.maxBytes === undefined) return;
+    ensureBytes(requiredAfter);
+    const available = options.maxBytes - serializedBytes - requiredAfter;
+    const bytes = serializedByteLength(item, Math.max(0, available));
+    ensureBytes(bytes + requiredAfter);
+    addBytes(bytes);
+  };
 
-function addCopySerializedBytes(budget: CopyBudget, value: unknown): void {
-  if (!budget.byteLimitLabel) return;
-  const remaining = budget.maxSerializedBytes - budget.serializedBytes;
-  const bytes = serializedByteLength(value, Math.max(0, remaining));
-  addCopyBytes(budget, bytes);
-}
+  const copy = (current: unknown, depth: number, requiredAfter: number): unknown => {
+    if (depth > options.maxDepth) {
+      throw new InterpreterError('invalid_data', `${options.label} exceeds the data-depth limit`);
+    }
+    if (current === null || typeof current === 'string' || typeof current === 'boolean') {
+      addSerializedBytes(current, requiredAfter);
+      return current;
+    }
+    if (typeof current === 'number') {
+      if (!Number.isFinite(current)) {
+        throw new InterpreterError('invalid_data', `${options.label} contains a non-finite number`);
+      }
+      addSerializedBytes(current, requiredAfter);
+      return current;
+    }
+    if (current === undefined) {
+      const copied = options.preserveUndefined ? undefined : null;
+      addSerializedBytes(copied, requiredAfter);
+      return copied;
+    }
+    if (typeof current !== 'object') {
+      throw new InterpreterError('invalid_data', `${options.label} contains a non-data value`);
+    }
+    nodes += 1;
+    if (nodes > MAX_COPY_NODES) {
+      throw new InterpreterError('limit_exceeded', `${options.label} traversal limit exceeded`);
+    }
+    if (seen.has(current)) {
+      throw new InterpreterError('invalid_data', `${options.label} contains a cycle`);
+    }
+    seen.add(current);
+    try {
+      if (Array.isArray(current)) {
+        const length = current.length;
+        if (length > options.maxCollectionItems) {
+          throw new InterpreterError('limit_exceeded', `${options.label} item limit exceeded`);
+        }
+        ensureBytes((length === 0 ? 2 : length * 2 + 1) + requiredAfter);
+        addBytes(1);
+        const output = new Array<unknown>(length);
+        for (let index = 0; index < length; index += 1) {
+          if (index > 0) addBytes(1);
+          const requiredAfterItem = (length - index - 1) * 2 + 1 + requiredAfter;
+          if (index in current) {
+            ensureBytes(1 + requiredAfterItem);
+            output[index] = copy(current[index], depth + 1, requiredAfterItem);
+          } else addSerializedBytes(null, requiredAfterItem);
+        }
+        addBytes(1);
+        return output;
+      }
+      if (!isPlainRecord(current)) {
+        throw new InterpreterError('invalid_data', `${options.label} contains a host object`);
+      }
+      const keys = Object.keys(current);
+      if (keys.length > options.maxCollectionItems) {
+        throw new InterpreterError('limit_exceeded', `${options.label} item limit exceeded`);
+      }
+      for (const key of keys) assertSafeKey(key);
+      const output: Record<string, unknown> = {};
+      ensureBytes(2 + requiredAfter);
+      addBytes(1);
+      let emitted = 0;
+      for (const key of keys) {
+        const descriptor = Object.getOwnPropertyDescriptor(current, key);
+        if (!descriptor?.enumerable) continue;
+        if (emitted > 0) addBytes(1);
+        addSerializedBytes(key);
+        addBytes(1);
+        const requiredAfterItem = 1 + requiredAfter;
+        ensureBytes(1 + requiredAfterItem);
+        output[key] = copy(current[key], depth + 1, requiredAfterItem);
+        emitted += 1;
+      }
+      addBytes(1);
+      return output;
+    } finally {
+      seen.delete(current);
+    }
+  };
 
-function addCopyBytes(budget: CopyBudget, bytes: number): void {
-  if (!budget.byteLimitLabel) return;
-  if (bytes > budget.maxSerializedBytes - budget.serializedBytes) {
-    throw new InterpreterError('limit_exceeded', `${budget.byteLimitLabel} byte limit exceeded`);
-  }
-  budget.serializedBytes += bytes;
+  return copy(value, 0, 0);
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/code-mode/src/interpreter.ts
+++ b/packages/code-mode/src/interpreter.ts
@@ -2120,6 +2120,7 @@ function materializePlainData(value: unknown, options: MaterializationOptions): 
     if (typeof current !== 'object') {
       throw new InterpreterError('invalid_data', `${options.label} contains a non-data value`);
     }
+    ensureBytes(2 + requiredAfter);
     nodes += 1;
     if (nodes > MAX_COPY_NODES) {
       throw new InterpreterError('limit_exceeded', `${options.label} traversal limit exceeded`);
@@ -2157,7 +2158,6 @@ function materializePlainData(value: unknown, options: MaterializationOptions): 
       }
       for (const key of keys) assertSafeKey(key);
       const output: Record<string, unknown> = {};
-      ensureBytes(2 + requiredAfter);
       addBytes(1);
       let emitted = 0;
       for (const key of keys) {

--- a/packages/code-mode/src/interpreter.ts
+++ b/packages/code-mode/src/interpreter.ts
@@ -2052,11 +2052,15 @@ function parseCell(code: string): AstNode {
     );
   }
   const root = asAst(parsed);
-  const wrapper = nodes(root, 'body').find(
-    (node) =>
-      node.type === 'FunctionDeclaration' && optionalAst(node, 'id')?.name === '__maka_cell__',
-  );
-  if (!wrapper) throw new InterpreterError('parse_error', 'Cell wrapper could not be parsed');
+  const body = nodes(root, 'body');
+  const wrapper = body[0];
+  if (
+    body.length !== 1 ||
+    wrapper?.type !== 'FunctionDeclaration' ||
+    optionalAst(wrapper, 'id')?.name !== '__maka_cell__'
+  ) {
+    throw new InterpreterError('parse_error', 'Cell source escaped its wrapper');
+  }
   return ast(wrapper, 'body');
 }
 

--- a/packages/code-mode/src/interpreter.ts
+++ b/packages/code-mode/src/interpreter.ts
@@ -236,6 +236,9 @@ const SUPPORTED_COLLECTION_METHODS = new Set([
 interface CopyBudget {
   nodes: number;
   maxNodes: number;
+  serializedBytes: number;
+  maxSerializedBytes: number;
+  byteLimitLabel?: string;
 }
 
 const MAX_COPY_NODES = 100_000;
@@ -298,8 +301,9 @@ class Interpreter {
         0,
         new Set(),
         this.limits.maxCollectionItems,
+        false,
+        createCopyBudget(this.limits.maxOutputBytes, 'output'),
       );
-      assertByteLimit(copied, this.limits.maxOutputBytes, 'output');
       return { ok: true, value: copied, toolCalls: [...this.toolCalls] };
     } catch (error) {
       if (!this.cellAbortController.signal.aborted) this.cellAbortController.abort(error);
@@ -1510,8 +1514,9 @@ class Interpreter {
         0,
         new Set(),
         this.limits.maxCollectionItems,
+        false,
+        createCopyBudget(this.limits.maxResultBytes, `result from ${name}`),
       );
-      assertByteLimit(copied, this.limits.maxResultBytes, `result from ${name}`);
       return copied;
     } catch (error) {
       if (this.input.signal?.aborted) throw abortReason(this.input.signal);
@@ -2072,20 +2077,25 @@ function copyPlainData(
   seen = new Set<object>(),
   maxCollectionItems = Number.MAX_SAFE_INTEGER,
   preserveUndefined = false,
-  budget: CopyBudget = {
-    nodes: 0,
-    maxNodes: MAX_COPY_NODES,
-  },
+  budget: CopyBudget = createCopyBudget(),
 ): unknown {
   if (depth > maxDepth)
     throw new InterpreterError('invalid_data', `${label} exceeds the data-depth limit`);
-  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') {
+    addCopySerializedBytes(budget, value);
+    return value;
+  }
   if (typeof value === 'number') {
     if (!Number.isFinite(value))
       throw new InterpreterError('invalid_data', `${label} contains a non-finite number`);
+    addCopySerializedBytes(budget, value);
     return value;
   }
-  if (value === undefined) return preserveUndefined ? undefined : null;
+  if (value === undefined) {
+    const copied = preserveUndefined ? undefined : null;
+    addCopySerializedBytes(budget, copied);
+    return copied;
+  }
   if (typeof value !== 'object')
     throw new InterpreterError('invalid_data', `${label} contains a non-data value`);
   budget.nodes += 1;
@@ -2099,18 +2109,25 @@ function copyPlainData(
       if (value.length > maxCollectionItems) {
         throw new InterpreterError('limit_exceeded', `${label} item limit exceeded`);
       }
-      return value.map((item) =>
-        copyPlainData(
-          item,
-          label,
-          maxDepth,
-          depth + 1,
-          seen,
-          maxCollectionItems,
-          preserveUndefined,
-          budget,
-        ),
-      );
+      addCopyBytes(budget, 1);
+      const output: unknown[] = [];
+      for (const [index, item] of value.entries()) {
+        if (index > 0) addCopyBytes(budget, 1);
+        output.push(
+          copyPlainData(
+            item,
+            label,
+            maxDepth,
+            depth + 1,
+            seen,
+            maxCollectionItems,
+            preserveUndefined,
+            budget,
+          ),
+        );
+      }
+      addCopyBytes(budget, 1);
+      return output;
     }
     if (!isPlainRecord(value))
       throw new InterpreterError('invalid_data', `${label} contains a host object`);
@@ -2118,8 +2135,12 @@ function copyPlainData(
       throw new InterpreterError('limit_exceeded', `${label} item limit exceeded`);
     }
     const output: Record<string, unknown> = {};
-    for (const [key, item] of Object.entries(value)) {
+    addCopyBytes(budget, 1);
+    for (const [index, [key, item]] of Object.entries(value).entries()) {
       assertSafeKey(key);
+      if (index > 0) addCopyBytes(budget, 1);
+      addCopySerializedBytes(budget, key);
+      addCopyBytes(budget, 1);
       output[key] = copyPlainData(
         item,
         label,
@@ -2131,10 +2152,39 @@ function copyPlainData(
         budget,
       );
     }
+    addCopyBytes(budget, 1);
     return output;
   } finally {
     seen.delete(value);
   }
+}
+
+function createCopyBudget(
+  maxSerializedBytes = Number.POSITIVE_INFINITY,
+  byteLimitLabel?: string,
+): CopyBudget {
+  return {
+    nodes: 0,
+    maxNodes: MAX_COPY_NODES,
+    serializedBytes: 0,
+    maxSerializedBytes,
+    byteLimitLabel,
+  };
+}
+
+function addCopySerializedBytes(budget: CopyBudget, value: unknown): void {
+  if (!budget.byteLimitLabel) return;
+  const remaining = budget.maxSerializedBytes - budget.serializedBytes;
+  const bytes = serializedByteLength(value, Math.max(0, remaining));
+  addCopyBytes(budget, bytes);
+}
+
+function addCopyBytes(budget: CopyBudget, bytes: number): void {
+  if (!budget.byteLimitLabel) return;
+  if (bytes > budget.maxSerializedBytes - budget.serializedBytes) {
+    throw new InterpreterError('limit_exceeded', `${budget.byteLimitLabel} byte limit exceeded`);
+  }
+  budget.serializedBytes += bytes;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/code-mode/src/interpreter.ts
+++ b/packages/code-mode/src/interpreter.ts
@@ -1,6 +1,8 @@
 import { parse } from 'acorn';
 import {
+  createSourceFile,
   DiagnosticCategory,
+  isFunctionDeclaration,
   ModuleKind,
   ScriptTarget,
   flattenDiagnosticMessageText,
@@ -2030,7 +2032,19 @@ function isAstNode(value: unknown): value is AstNode {
 }
 
 function parseCell(code: string): AstNode {
-  const transpiled = transpileModule(`async function __maka_cell__() {\n${code}\n}`, {
+  const wrappedSource = `async function __maka_cell__() {\n${code}\n}`;
+  const sourceFile = createSourceFile('cell.ts', wrappedSource, ScriptTarget.ESNext, true);
+  const sourceWrapper = sourceFile.statements[0];
+  if (
+    sourceFile.statements.length !== 1 ||
+    !sourceWrapper ||
+    !isFunctionDeclaration(sourceWrapper) ||
+    sourceWrapper.name?.text !== '__maka_cell__' ||
+    !sourceWrapper.body
+  ) {
+    throw new InterpreterError('parse_error', 'Cell source escaped its wrapper');
+  }
+  const transpiled = transpileModule(wrappedSource, {
     reportDiagnostics: true,
     compilerOptions: { target: ScriptTarget.ESNext, module: ModuleKind.ESNext },
   });


### PR DESCRIPTION
## Summary

- validate the TypeScript source wrapper before transpilation and retain the post-transpile Acorn check, closing escapes that TypeScript would otherwise erase
- materialize tool results and final output through one bounded traversal that carries the remaining structural budget across nested values and rejects impossible containers before host inspection
- preserve sparse-array, mutation, and standard property-access semantics while replacing oversized or non-discriminating tests with small boundary cases

Refs #2466

## Verification

- `npm run test --workspace @maka/code-mode` (95 tests passed)
- `npm run typecheck --workspace @maka/code-mode`
- `npx biome check packages/code-mode/src/interpreter.ts packages/code-mode/src/__tests__/code-mode.test.ts`

## Review focus

`materializePlainData` owns traversal state in one closure. Its `requiredAfter` parameter reserves the minimum bytes required by remaining array items and every open ancestor before a value is read or recursively expanded; every composite value also proves that its minimum representation fits before container inspection.
