### PR TITLE
test(windows): resolve portable skip inventory

### DIFF
--- a/apps/desktop/src/main/__tests__/project-context-root.test.ts
+++ b/apps/desktop/src/main/__tests__/project-context-root.test.ts
@@ -73,7 +73,10 @@ describe('resolveProjectContextRoot', () => {
   });
 
   it('rejects a session cwd without read and traversal access', {
-    skip: process.platform === 'win32' || process.getuid?.() === 0,
+    skip:
+      process.platform === 'win32'
+        ? 'POSIX permissions are required to make the session cwd inaccessible'
+        : process.getuid?.() === 0,
   }, async () => {
     const sessionRoot = await mkdtemp(join(tmpdir(), 'maka-inaccessible-session-project-'));
     await chmod(sessionRoot, 0o000);

--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -16,17 +16,17 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 | Classification | Count |
 |---|---:|
 | windows-backend-gap | 30 |
-| portable-candidate | 24 |
-| platform-contract | 16 |
+| portable-candidate | 0 |
+| platform-contract | 35 |
 
-Total Windows-excluded declarations: **70**
+Total Windows-excluded declarations: **65**
 
 ## Inventory
 
 | Classification | Test | Skip expression |
 |---|---|---|
 | platform-contract | `apps/desktop/scripts/dev-app-runtime.test.mjs` the real probe survives a hostile bundle path | `process.platform !== 'darwin'` |
-| portable-candidate | `apps/desktop/src/main/__tests__/project-context-root.test.ts` rejects a session cwd without read and traversal access | `process.platform === 'win32' \|\| process.getuid?.() === 0` |
+| platform-contract | `apps/desktop/src/main/__tests__/project-context-root.test.ts` rejects a session cwd without read and traversal access | `process.platform === 'win32' ? 'POSIX permissions are required to make the session cwd inaccessible' : process.getuid?.() === 0` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` imports the login PATH without importing application control variables | `process.platform === 'win32'` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` keeps the inherited PATH and does not log shell stderr when capture fails | `process.platform === 'win32'` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` kills login-shell descendants when capture times out | `process.platform === 'win32'` |
@@ -65,33 +65,28 @@ Total Windows-excluded declarations: **70**
 | platform-contract | `packages/runtime/src/__tests__/shell-exec.test.ts` bounds output drain after the root exits while a detached descendant retains stdout | `process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` latches timeout when the root exits during POSIX process discovery | `process.platform === 'win32' ? 'POSIX process discovery only' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves cancellation when timeout fires during POSIX process discovery | `process.platform === 'win32' ? 'POSIX process discovery only' : false` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` ignores a Stop abort that occurs after another admitted Stop commits termination | `process.platform === 'win32' ? 'Windows termination has no asynchronous POSIX snapshot window' : false` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps a pipe task alive when Stop aborts during process-tree preparation | `process.platform === 'win32' ? 'Windows termination does not take a POSIX process snapshot' : false` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps a PTY task controllable when Stop aborts during process-tree preparation | `process.platform === 'win32' ? 'Windows termination does not take a POSIX process snapshot' : false` |
+| platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` ignores a Stop abort that occurs after another admitted Stop commits termination | `process.platform === 'win32' ? 'Windows termination has no asynchronous POSIX snapshot window' : false` |
+| platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps a pipe task alive when Stop aborts during process-tree preparation | `process.platform === 'win32' ? 'Windows termination does not take a POSIX process snapshot' : false` |
+| platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps a PTY task controllable when Stop aborts during process-tree preparation | `process.platform === 'win32' ? 'Windows termination does not take a POSIX process snapshot' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` settles after root exit when a detached descendant retains inherited stdout | `process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps the first committed lifecycle cause across Stop and timeout races | `process.platform === 'win32' ? 'Windows tree termination has no graceful SIGTERM phase' : false` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps SIGTERM final output and escalates an ignored SIGTERM without leaking slots | `process.platform === 'win32' ? 'Windows tree termination has no graceful SIGTERM phase' : false` |
-| portable-candidate | `packages/storage/src/__tests__/managed-workspace-baseline.test.ts` preserves the durable database root binding across formal whole-root import | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/managed-workspace-baseline.test.ts` rejects an authority database whose file identity changes after registration | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/managed-workspace-baseline.test.ts` does not return an accepted baseline when runtime.sqlite is replaced after the initial root check | `process.platform === 'win32'` |
+| platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps the first committed lifecycle cause across Stop and timeout races | `process.platform === 'win32' ? 'Windows tree termination has no graceful SIGTERM phase' : false` |
+| platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps SIGTERM final output and escalates an ignored SIGTERM without leaking slots | `process.platform === 'win32' ? 'Windows tree termination has no graceful SIGTERM phase' : false` |
+| platform-contract | `packages/storage/src/__tests__/managed-workspace-baseline.test.ts` rejects an authority database whose file identity changes after registration | `process.platform === 'win32' ? 'Windows cannot rename an open SQLite database to replace its file identity' : false` |
+| platform-contract | `packages/storage/src/__tests__/managed-workspace-baseline.test.ts` does not return an accepted baseline when runtime.sqlite is replaced after the initial root check | `process.platform === 'win32' ? 'Windows cannot rename an open SQLite database during the verification race' : false` |
 | platform-contract | `packages/storage/src/__tests__/managed-workspace-baseline.test.ts` rejects a source tree containing a non-UTF-8 Git path | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/managed-workspace-owner.test.ts` rejects execution when runtime.sqlite detaches from its canonical path after verification | `process.platform === 'win32' ? 'Open SQLite files cannot be renamed reliably on Windows' : false` |
-| portable-candidate | `packages/storage/src/__tests__/memory-bundle-store.test.ts` rejects a symbolic-link Memory parent without reading or writing outside the root | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/pet-pack-store.test.ts` detects sprite sheets redirected outside the installed pack | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/pet-pack-store.test.ts` rejects a store root redirected outside the state root | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/root-authority.test.ts` preserves unexpected marker I/O failures at the public authority boundary | `process.platform === 'win32' \|\| (typeof process.getuid === 'function' && process.getuid() === 0)` |
+| platform-contract | `packages/storage/src/__tests__/managed-workspace-owner.test.ts` rejects execution when runtime.sqlite detaches from its canonical path after verification | `process.platform === 'win32' ? 'Open SQLite files cannot be renamed reliably on Windows' : false` |
+| platform-contract | `packages/storage/src/__tests__/pet-pack-store.test.ts` detects sprite sheets redirected outside the installed pack | `process.platform === 'win32' ? 'Windows file-symlink permissions are not guaranteed in CI' : false` |
+| platform-contract | `packages/storage/src/__tests__/root-authority.test.ts` preserves unexpected marker I/O failures at the public authority boundary | `process.platform === 'win32' ? 'POSIX permissions are required to make the marker unreadable' : typeof process.getuid === 'function' && process.getuid() === 0` |
 | platform-contract | `packages/storage/src/__tests__/root-authority.test.ts` rejects FIFO marker paths without blocking root resolution | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/root-authority.test.ts` rejects a lock path that aliases another filesystem object | `process.platform === 'win32'` |
+| platform-contract | `packages/storage/src/__tests__/root-authority.test.ts` rejects a lock path that aliases another filesystem object | `process.platform === 'win32' ? 'Windows file-symlink permissions are not guaranteed in CI' : false` |
 | platform-contract | `packages/storage/src/__tests__/root-authority.test.ts` validates an existing control directory without repairing its permissions | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` reports unknown outcome when credential persistence fails after clearing verified state | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` validates proxy policy mutations before clearing and reports failed follow-up commits as unknown | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` reports unknown outcome when active proxy password persistence fails after clearing | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` preserves unknown commit semantics and consumes the completion ticket | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` successor recovery removes credentials orphaned by an interrupted connection removal | `process.platform === 'win32'` |
+| platform-contract | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` reports unknown outcome when credential persistence fails after clearing verified state | `process.platform === 'win32' ? 'POSIX permissions are required to inject a persistence failure' : false` |
+| platform-contract | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` validates proxy policy mutations before clearing and reports failed follow-up commits as unknown | `process.platform === 'win32' ? 'POSIX permissions are required to inject a persistence failure' : false` |
+| platform-contract | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` reports unknown outcome when active proxy password persistence fails after clearing | `process.platform === 'win32' ? 'POSIX permissions are required to inject a persistence failure' : false` |
+| platform-contract | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` preserves unknown commit semantics and consumes the completion ticket | `process.platform === 'win32' ? 'POSIX permissions are required to inject a persistence failure' : false` |
+| platform-contract | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` successor recovery removes credentials orphaned by an interrupted connection removal | `process.platform === 'win32' ? 'POSIX permissions are required to inject a persistence failure' : false` |
 | platform-contract | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` fails closed on final symlinks, FIFOs, and oversized documents without changing bytes | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/storage/src/__tests__/sqlite-long-term-memory-crash.test.ts` retains one committed Item and its receipt when killed between COMMIT and return | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/storage/src/__tests__/sqlite-runtime-crash.test.ts` SqliteRuntimeStore real-process crash boundaries | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/usage-stores.test.ts` classifies a renamed or replaced live root as a draining persistence failure | `process.platform === 'win32' ? 'Windows does not permit renaming a directory with an open SQLite database' : false` |
-| portable-candidate | `packages/storage/src/__tests__/workspace-identity.test.ts` a non-Git workspace resolves when the Git executable is unavailable | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/workspace-identity.test.ts` a Git workspace does not publish a marker when the Git executable is unavailable | `process.platform === 'win32'` |
-| portable-candidate | `packages/storage/src/__tests__/workspace-identity.test.ts` an unmarked read-only workspace fails without leaving marker state | `process.platform === 'win32'` |
+| platform-contract | `packages/storage/src/__tests__/usage-stores.test.ts` classifies a renamed or replaced live root as a draining persistence failure | `process.platform === 'win32' ? 'Windows does not permit renaming a directory with an open SQLite database' : false` |
+| platform-contract | `packages/storage/src/__tests__/workspace-identity.test.ts` an unmarked read-only workspace fails without leaving marker state | `process.platform === 'win32' ? 'POSIX permissions are required to create a read-only workspace fixture' : false` |

--- a/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
@@ -512,9 +512,7 @@ test('rejects a canonical SQLite database copied from a different durable storag
   }
 });
 
-test('preserves the durable database root binding across formal whole-root import', {
-  skip: process.platform === 'win32',
-}, async () => {
+test('preserves the durable database root binding across formal whole-root import', async () => {
   const root = await temporaryRoot();
   const sourceStorageRoot = join(root, 'storage-a');
   const importedStorageRoot = join(root, 'storage-imported');
@@ -652,7 +650,10 @@ test('rejects final admission when the root marker changes after post-commit art
 });
 
 test('rejects an authority database whose file identity changes after registration', {
-  skip: process.platform === 'win32',
+  skip:
+    process.platform === 'win32'
+      ? 'Windows cannot rename an open SQLite database to replace its file identity'
+      : false,
 }, async () => {
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
@@ -683,7 +684,10 @@ test('rejects an authority database whose file identity changes after registrati
 });
 
 test('does not return an accepted baseline when runtime.sqlite is replaced after the initial root check', {
-  skip: process.platform === 'win32',
+  skip:
+    process.platform === 'win32'
+      ? 'Windows cannot rename an open SQLite database during the verification race'
+      : false,
 }, async () => {
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');

--- a/packages/storage/src/__tests__/memory-bundle-store.test.ts
+++ b/packages/storage/src/__tests__/memory-bundle-store.test.ts
@@ -711,15 +711,17 @@ describe('interactive Memory bundle storage authority', () => {
     });
   });
 
-  test('rejects a symbolic-link Memory parent without reading or writing outside the root', {
-    skip: process.platform === 'win32',
-  }, async () => {
+  test('rejects a symbolic-link Memory parent without reading or writing outside the root', async () => {
     await withInteractiveOwner(async ({ root, owner }) => {
       const outside = await mkdtemp(join(tmpdir(), 'maka-memory-outside-'));
       try {
         const outsideMemory = join(outside, 'MEMORY.md');
         await writeFile(outsideMemory, '# Outside\n');
-        await symlink(outside, memoryDirectory(root));
+        await symlink(
+          outside,
+          memoryDirectory(root),
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
 
         await assert.rejects(
           openInteractiveMemoryBundleStoreForWrite(owner.lease),

--- a/packages/storage/src/__tests__/pet-pack-store.test.ts
+++ b/packages/storage/src/__tests__/pet-pack-store.test.ts
@@ -198,7 +198,10 @@ describe('PetPackStore', () => {
   });
 
   test('detects sprite sheets redirected outside the installed pack', {
-    skip: process.platform === 'win32',
+    skip:
+      process.platform === 'win32'
+        ? 'Windows file-symlink permissions are not guaranteed in CI'
+        : false,
   }, async () => {
     await withStore(async ({ root, store }) => {
       await store.install({ manifest: manifest(), spriteSheet: pngHeader(64, 64) });
@@ -213,13 +216,15 @@ describe('PetPackStore', () => {
     });
   });
 
-  test('rejects a store root redirected outside the state root', {
-    skip: process.platform === 'win32',
-  }, async () => {
+  test('rejects a store root redirected outside the state root', async () => {
     await withStore(async ({ root, store }) => {
       const outside = await mkdtemp(join(tmpdir(), 'maka-pet-pack-outside-'));
       try {
-        await symlink(outside, join(root, 'pets'));
+        await symlink(
+          outside,
+          join(root, 'pets'),
+          process.platform === 'win32' ? 'junction' : 'dir',
+        );
         await assert.rejects(store.list(), isStoreError('corrupt_store'));
         await assert.rejects(
           store.install({ manifest: manifest(), spriteSheet: pngHeader(64, 64) }),

--- a/packages/storage/src/__tests__/root-authority.test.ts
+++ b/packages/storage/src/__tests__/root-authority.test.ts
@@ -494,8 +494,9 @@ describe('storage root authority', () => {
 
   test('preserves unexpected marker I/O failures at the public authority boundary', {
     skip:
-      process.platform === 'win32' ||
-      (typeof process.getuid === 'function' && process.getuid() === 0),
+      process.platform === 'win32'
+        ? 'POSIX permissions are required to make the marker unreadable'
+        : typeof process.getuid === 'function' && process.getuid() === 0,
   }, async () => {
     await withRoots(async ({ root }) => {
       const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
@@ -701,7 +702,10 @@ describe('storage root authority', () => {
   });
 
   test('rejects a lock path that aliases another filesystem object', {
-    skip: process.platform === 'win32',
+    skip:
+      process.platform === 'win32'
+        ? 'Windows file-symlink permissions are not guaranteed in CI'
+        : false,
   }, async () => {
     await withRoots(async ({ base, root }) => {
       const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -1197,7 +1197,10 @@ describe('runtime policy stores', () => {
   });
 
   test('reports unknown outcome when credential persistence fails after clearing verified state', {
-    skip: process.platform === 'win32',
+    skip:
+      process.platform === 'win32'
+        ? 'POSIX permissions are required to inject a persistence failure'
+        : false,
   }, async () => {
     await withInteractiveOwner(async ({ root, stores }) => {
       const connection = await createConnection(
@@ -1337,7 +1340,10 @@ describe('runtime policy stores', () => {
   });
 
   test('validates proxy policy mutations before clearing and reports failed follow-up commits as unknown', {
-    skip: process.platform === 'win32',
+    skip:
+      process.platform === 'win32'
+        ? 'POSIX permissions are required to inject a persistence failure'
+        : false,
   }, async () => {
     await withInteractiveOwner(async ({ root, stores }) => {
       const connection = await createConnection(
@@ -1540,7 +1546,10 @@ describe('runtime policy stores', () => {
   });
 
   test('reports unknown outcome when active proxy password persistence fails after clearing', {
-    skip: process.platform === 'win32',
+    skip:
+      process.platform === 'win32'
+        ? 'POSIX permissions are required to inject a persistence failure'
+        : false,
   }, async () => {
     await withInteractiveOwner(async ({ root, stores }) => {
       const connection = await createConnection(
@@ -1864,7 +1873,10 @@ describe('runtime policy stores', () => {
   });
 
   test('preserves unknown commit semantics and consumes the completion ticket', {
-    skip: process.platform === 'win32',
+    skip:
+      process.platform === 'win32'
+        ? 'POSIX permissions are required to inject a persistence failure'
+        : false,
   }, async () => {
     await withInteractiveOwner(async ({ root, stores }) => {
       const connection = await createConnection(
@@ -2226,7 +2238,10 @@ describe('runtime policy stores', () => {
   });
 
   test('successor recovery removes credentials orphaned by an interrupted connection removal', {
-    skip: process.platform === 'win32',
+    skip:
+      process.platform === 'win32'
+        ? 'POSIX permissions are required to inject a persistence failure'
+        : false,
   }, async () => {
     await withInteractiveRoot(async ({ root, capability }) => {
       const firstOwner = await tryAcquireInteractiveRootOwner(capability);

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -197,9 +197,7 @@ test('a malformed enclosing Git repository prevents publishing a new marker', as
   }
 });
 
-test('a non-Git workspace resolves when the Git executable is unavailable', {
-  skip: process.platform === 'win32',
-}, async () => {
+test('a non-Git workspace resolves when the Git executable is unavailable', async () => {
   const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-no-git-required-'));
   try {
     await resolveWorkspaceIdentityWithoutGit(workspace);
@@ -210,9 +208,7 @@ test('a non-Git workspace resolves when the Git executable is unavailable', {
   }
 });
 
-test('a Git workspace does not publish a marker when the Git executable is unavailable', {
-  skip: process.platform === 'win32',
-}, async () => {
+test('a Git workspace does not publish a marker when the Git executable is unavailable', async () => {
   const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-unavailable-'));
   try {
     await execFileAsync('git', ['init', '--quiet'], { cwd: workspace });
@@ -225,7 +221,10 @@ test('a Git workspace does not publish a marker when the Git executable is unava
 });
 
 test('an unmarked read-only workspace fails without leaving marker state', {
-  skip: process.platform === 'win32',
+  skip:
+    process.platform === 'win32'
+      ? 'POSIX permissions are required to create a read-only workspace fixture'
+      : false,
 }, async () => {
   const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-read-only-'));
   try {

--- a/scripts/windows-test-inventory.mjs
+++ b/scripts/windows-test-inventory.mjs
@@ -198,7 +198,11 @@ function classifySkip(path, title, expression) {
     /process\.platform\s*!==\s*['"]darwin['"]/u.test(expression) ||
     value.includes('posix process discovery') ||
     value.includes('posix detached process-group') ||
+    value.includes('posix snapshot') ||
+    value.includes('posix process snapshot') ||
+    value.includes('graceful sigterm') ||
     value.includes('publishes private posix endpoint') ||
+    value.includes('open sqlite') ||
     value.includes('fifo') ||
     value.includes('non-utf-8 git path') ||
     value.includes('permissions') ||


### PR DESCRIPTION
## Summary

- enable five portable Windows storage tests covering Git-unavailable workspace identity, whole-root import, and junction escape rejection
- replace ambiguous Windows skips with concrete POSIX permission, file-symlink, open-SQLite replacement, process-snapshot, or graceful-signal contracts
- improve inventory classification so explicitly platform-specific tests are not reported as portable candidates
- regenerate the Windows skip inventory from 70 to 65 declarations and from 24 to 0 portable candidates

## Validation

- `npm --workspace @maka/storage run build`
- five newly enabled Windows tests: 5 pass / 0 fail / 0 skip
- `npm --workspace @maka/storage run typecheck`
- focused Biome checks for all changed source files
- `npm run windows:inventory`
- `node --test scripts/windows-test-inventory.test.mjs`
- `git diff --check`

## Coordination

#2464 and #2465 are currently green but not yet merged. If their skip changes land first, this branch will regenerate the inventory against the resulting `main` before merge.

Addresses the remaining portable-test inventory item in #2142.