### PR TITLE
test(computer-use): order the stray-line check after an observable marker

### DIFF
--- a/packages/computer-use/src/__tests__/maka-cu-service.test.ts
+++ b/packages/computer-use/src/__tests__/maka-cu-service.test.ts
@@ -82,6 +82,9 @@ function handle(msg) {
     if (AFTER_HELLO) {
       setTimeout(function () {
         for (const line of AFTER_HELLO.split('|')) process.stdout.write(line + '\n');
+        // Observable marker: the stray lines are on stdout once this lands in
+        // the log, so a test can order its next round trip after them.
+        logRec({ kind: 'after-hello' });
       }, 30);
     }
     return;
@@ -216,13 +219,20 @@ describe('maka-cu supervisor: what the child may put on stdout', () => {
       // no caller is on the stack, and took the host process down. A Rust
       // executor serialising `Option::None` on an error path emits those five
       // bytes.
-      const { service } = makeService({ afterHello: 'null' });
+      const { service, logPath } = makeService({ afterHello: 'null' });
       const handshake = await service.ensureStarted();
       assert.equal(handshake.executor.name, 'maka-cu-mock');
-      // Still usable: one stray line is not a dead executor. The round-trip is
-      // also the ordering anchor for the uncaught check below: the stray line
-      // sits on stdout ahead of this response, so it was processed (and would
-      // have thrown in the data listener) before the call returned.
+      // The mock emits the stray line from a timer after the handshake, so
+      // first wait for its marker: once logged, `null` is on stdout ahead of
+      // the next response. The round trip below is then a true causal anchor —
+      // the stray line was processed (and would have thrown in the data
+      // listener) before the call returned.
+      await waitForRecord(
+        logPath,
+        (record) => record.kind === 'after-hello',
+        'the mock never emitted its post-hello stray line',
+      );
+      // Still usable: one stray line is not a dead executor.
       const envelope = await service.call('window.list', {});
       assert.equal(envelope.ok, true);
       assert.deepEqual(uncaught, [], 'a null stdout line must not reach uncaughtException');


### PR DESCRIPTION
Follow-up to the post-merge P3 on #2394 (cc @Astro-Han) — the review was right: the `window.list` round trip was not yet a causal barrier, because the mock emits `AFTER_HELLO` from a 30ms timer after the handshake. The round trip could be answered before the stray `null` was ever written, letting the assertion pass before the behavior under test occurred.

Exactly the suggested shape:

- the mock logs an `after-hello` marker once the stray lines are on stdout;
- the test waits for that marker (bounded `waitForRecord`), then does the round trip.

With the stray line provably ahead of the response on the same pipe, stream ordering makes the anchor real: the line was processed — and would have thrown in the stdout data listener — before the call returned. No fixed wait restored; test-only, production surface unchanged.

17/17 service tests green across 5 repeated runs after a clean build.