### PR TITLE
perf(test): shrink storage capacity and legacy Plan fixtures to minimal crossings

### DIFF
--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -478,6 +478,10 @@ describe('SqliteSessionMetadataStore', () => {
     let rejectedRequestId: string | undefined;
     try {
       await store.create(fullHeader());
+      // Each request stays near MAX_SANDBOX_BOUNDARY_SERIALIZED_BYTES so the
+      // cumulative boundary crosses capacity in the fewest settles, using few
+      // near-MAX_SANDBOX_BOUNDARY_PATH_CHARS entries to keep the per-settle
+      // boundary scans cheap.
       for (let request = 0; request < 30; request += 1) {
         const requestId = `capacity-${request}`;
         await store.createSandboxBoundaryRequest({
@@ -486,8 +490,8 @@ describe('SqliteSessionMetadataStore', () => {
           turnId: 'turn-1',
           expansion: {
             filesystem: {
-              entries: Array.from({ length: 32 }, (_, entry) => ({
-                path: `/outside/${request}/${entry}-${'x'.repeat(1_800)}`,
+              entries: Array.from({ length: 15 }, (_, entry) => ({
+                path: `/outside/${request}/${entry}-${'x'.repeat(4_000)}`,
                 access: 'read' as const,
                 scope: 'exact' as const,
               })),

--- a/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
@@ -414,11 +414,16 @@ describe('SQLite workflow stores', () => {
 function seedLegacyPlanLedger(root: string, eventCount = 3): void {
   const lease = acquireOperationalStateDatabase(root);
   try {
-    const steps = Array.from({ length: 50 }, (_, index) => ({
+    // Each dimension exceeds its projection bound by just enough to force
+    // truncation: 51 files > PLAN_MAX_FILES_PER_STEP, 21 risks >
+    // PLAN_MAX_RISKS, 31 title chars > PLAN_STEP_TITLE_MAX_CHARS, and four
+    // 4_000-byte descriptions oversubscribe PLAN_PROJECTION_ITEM_MAX_BYTES so
+    // the shared text budget must settle below 4_000 bytes.
+    const steps = Array.from({ length: 4 }, (_, index) => ({
       id: `legacy step ${index}`,
-      title: '"'.repeat(100),
+      title: '"'.repeat(31),
       description: '"'.repeat(4_000),
-      files: Array.from({ length: 60 }, () => '"'.repeat(100)),
+      files: Array.from({ length: 51 }, () => '"'.repeat(100)),
     }));
     const proposal = {
       planId: 'legacy-plan',
@@ -428,7 +433,7 @@ function seedLegacyPlanLedger(root: string, eventCount = 3): void {
       revision: 1,
       title: '"'.repeat(16 * 1024),
       steps,
-      risks: Array.from({ length: 25 }, (_, index) => `Legacy risk ${index}`),
+      risks: Array.from({ length: 21 }, (_, index) => `Legacy risk ${index}`),
       status: 'pending_approval',
       submittedAt: 1,
     };


### PR DESCRIPTION
Refs #2388 (fixture-reduction PR; the stress-policy change comes separately per the issue).

## What changed

**Sandbox-boundary capacity test** (`sqlite-session-metadata-store.test.ts`): each expansion request now carries 15 near-`MAX_SANDBOX_BOUNDARY_PATH_CHARS` paths instead of 32 shorter ones. Per-request serialized size stays near `MAX_SANDBOX_BOUNDARY_SERIALIZED_BYTES` (the fewest settles that can cross the 1 MiB execution-boundary cap), but each settle's boundary rescan now walks less than half the accumulated entries.

**Legacy Plan ledger fixture** (`sqlite-workflow-store.test.ts`): `seedLegacyPlanLedger` now exceeds each projection bound by just enough to force truncation — 4 steps (enough to push the shared text budget below the asserted 4,000 bytes), 51 files > `PLAN_MAX_FILES_PER_STEP`, 21 risks > `PLAN_MAX_RISKS`, 31-char titles > `PLAN_STEP_TITLE_MAX_CHARS` — instead of ~500KB of near-max fields per ledger event.

## What deliberately did not change

- **Assertions**: every truncation/atomicity/persisted-state assertion is untouched; the fixtures still cross every asserted boundary.
- **Catalog capacity test**: already minimal — each connection sits at `CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS` × `CONNECTION_MODEL_ID_MAX_LENGTH` (~262KB), so ~16 commits is the floor for crossing the 4 MiB document cap.
- **Vault capacity test**: already minimal — secrets are at `MAX_SECRET_LENGTH` (64 KiB), and the provider auth contract (`coordinator.ts`) requires one connection per stored secret (`oauth_token` is github-copilot-only), so 32 commits is the floor for the 2 MiB cap.
- All three capacity loops break on first rejection, so their loop caps were never a cost driver.

## Timing (Apple Silicon, node --test per file)

| Test | Before | After |
|---|---|---|
| rejects an expansion atomically before the complete boundary exceeds capacity | 2,495ms | 1,171ms |
| projects a pre-bound legacy Plan ledger into the bounded Host contract | 517ms | 118ms |
| requires a projected legacy proposal to be revised or abandoned | 114ms | 41ms |

Full `@maka/storage` suite: 766 tests, 754 pass / 12 skipped / 0 fail before and after. Suite wall time is bounded by the slowest test file, so the win shows up as ~3.8s less per-file CPU rather than lower end-to-end wall time.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Ac5rv6WUKWtMZgQb5QPN16