### PR TITLE
test(desktop): trim stale permission boundary journey

### DIFF
--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -1,32 +1,6 @@
 import { expect, test, COMPOSER_INPUT } from './fixtures';
 
-/**
- * #1611 + #1616: cross-boundary permission journeys only.
- * Quiet chrome shape (icon menu, option set) is unit-covered — do not re-lock
- * tooltip copy or menu structure here.
- *
- * Auto transition from a live boundary is covered by the sandbox-expansion
- * test below; this case only locks the full-access confirm cancel path.
- */
-test('full access from a read-only session requires confirm; cancel keeps the boundary', async ({
-  readOnlyBoundaryWindow: page,
-}) => {
-  const trigger = page
-    .locator('.maka-composer-left-controls .permissionModeIcon')
-    .getByRole('button');
-  await expect(trigger).toHaveAccessibleName('权限模式：只读');
-
-  await trigger.click();
-  const menu = page.getByRole('menu');
-  await expect(menu).toBeVisible();
-  await menu.getByRole('menuitemradio', { name: /完全权限/ }).click();
-
-  await expect(page.locator('.maka-confirm-modal')).toHaveCount(1);
-  await page.getByRole('button', { name: '保持自动' }).click();
-  await expect(page.locator('.maka-confirm-modal')).toHaveCount(0);
-  await expect(trigger).toHaveAccessibleName('权限模式：只读');
-});
-
+/** #1611: the live boundary update must cross main/renderer and survive reload. */
 test('approving an expansion updates the permission label at once and after a reload', async ({
   sandboxBoundaryWindow: page,
 }) => {

--- a/apps/desktop/src/main/__tests__/app-shell-session-settings-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-session-settings-actions.test.ts
@@ -30,13 +30,14 @@ function session(id: string): SessionSummary {
   };
 }
 
-function createHarness() {
+function createHarness(options: { confirm?: () => Promise<boolean> } = {}) {
   const activeIdRef = { current: 'session-a' as string | undefined };
   const sessions = [session('session-a'), session('session-b')];
   const sessionsRef = { current: sessions };
   const pending = new Set<string>();
   const pendingBySession: Record<string, boolean> = {};
   const modelCalls: string[] = [];
+  const permissionCalls: string[] = [];
   const thinkingCalls: string[] = [];
   const errors: string[] = [];
   const modelResult = deferred<SessionSummary>();
@@ -47,6 +48,10 @@ function createHarness() {
     value: {
       maka: {
         sessions: {
+          setPermissionMode: async (sessionId: string, mode: 'ask' | 'bypass') => {
+            permissionCalls.push(`${sessionId}:${mode}`);
+            return { ...session(sessionId), permissionMode: mode };
+          },
           setModel: async (sessionId: string) => {
             modelCalls.push(sessionId);
             return modelResult.promise;
@@ -82,7 +87,7 @@ function createHarness() {
     toastApi: {
       success: () => undefined,
       error: (title) => errors.push(title),
-      confirm: async () => true,
+      confirm: options.confirm ?? (async () => true),
     },
   });
 
@@ -94,12 +99,28 @@ function createHarness() {
     modelResult,
     pending,
     pendingBySession,
+    permissionCalls,
     thinkingCalls,
     thinkingResult,
   };
 }
 
-describe('AppShell session model configuration actions', () => {
+describe('AppShell session settings actions', () => {
+  it('does not grant full access when its confirmation is cancelled', async () => {
+    let confirmations = 0;
+    const harness = createHarness({
+      confirm: async () => {
+        confirmations += 1;
+        return false;
+      },
+    });
+
+    await harness.actions.setPermissionMode('bypass');
+
+    assert.equal(confirmations, 1);
+    assert.deepEqual(harness.permissionCalls, []);
+  });
+
   it('blocks a thinking-level mutation while the same session model mutation is pending', async () => {
     const harness = createHarness();
 


### PR DESCRIPTION
## Summary

Remove the stale E2E journey that opens the composer permission menu from a read-only boundary. The current shell hides the composer when local interaction is unavailable, so that fixture no longer represents a reachable product path.

Keep the live boundary-expansion E2E, and move the full-access cancellation invariant to the deterministic session-settings action test.

## Verification

- `npm run format:check`
- `npm --workspace @maka/desktop run build:with-deps`
- `node --test apps/desktop/dist/main/__tests__/app-shell-session-settings-actions.test.js` (5 passed)
- Remaining `permission-mode-surface` E2E: current `main` CI passes; local run timed out while setting up `sandboxBoundaryWindow` before entering the unchanged test body