### PR TITLE
test(storybook): shrink the smoke matrix to its declared checks

### DIFF
--- a/apps/desktop/stories/product-smoke-manifest.json
+++ b/apps/desktop/stories/product-smoke-manifest.json
@@ -22,43 +22,67 @@
       "storyId": "product-onboarding--needs-connection",
       "productionHost": "ChatView > OnboardingHero",
       "state": "Fresh workspace choosing its first model provider",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent."
+      }
     },
     "settings": {
       "storyId": "product-settings-pages--general",
       "productionHost": "SettingsSurface",
       "state": "Dense general preferences form",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent."
+      }
     },
     "usage": {
       "storyId": "product-settings-pages--usage-long-tail",
       "productionHost": "SettingsSurface > UsageSettingsPage",
       "state": "Populated usage metrics, filters, tabs, and request table",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent."
+      }
     },
     "providers": {
       "storyId": "product-settings-providers--configured-providers",
       "productionHost": "ProvidersPanel",
       "state": "Configured provider rows, categories, OAuth status, and actions",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent."
+      }
     },
     "skills": {
       "storyId": "product-module-hubs--extensions-skills-installed",
       "productionHost": "AppShellDetailPanel > SkillsPage",
       "state": "Installed skills list",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent."
+      }
     },
     "mcp": {
       "storyId": "product-module-hubs--extensions-mcp-configured",
       "productionHost": "AppShellDetailPanel > McpPage",
       "state": "Connected and disabled configured MCP servers",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the dedicated narrow reference covers minimum-width server rows.",
+        "floor": "The dedicated narrow reference (mcpNarrow) covers the minimum-width server list."
+      }
     },
     "mcpSetupRequired": {
       "storyId": "product-module-hubs--extensions-mcp-setup-required",
@@ -75,15 +99,23 @@
       "storyId": "product-module-hubs--extensions-mcp-marketplace",
       "productionHost": "AppShellDetailPanel > McpPage",
       "state": "Marketplace with configured servers and no setup guidance",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "The dedicated narrow reference (mcpNarrow) covers minimum-width MCP geometry."
+      }
     },
     "mcpEditor": {
       "storyId": "product-module-hubs--extensions-mcp-editor",
       "productionHost": "AppShellDetailPanel > McpPage > McpEditorDialog",
       "state": "Credentialed stdio server editor with all required setup fields visible",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent."
+      }
     },
     "mcpConnectionFailed": {
       "storyId": "product-module-hubs--extensions-mcp-connection-failed",
@@ -111,17 +143,23 @@
       "storyId": "product-module-hubs--scheduled-plan-reminders-configured",
       "productionHost": "AppShellDetailPanel > AutomationsPage",
       "state": "Recurring, paused, completed and delivery-blocked reminders in one list",
-      "viewports": ["wide", "compact", "floor"],
+      "viewports": ["wide", "floor"],
       "colorSchemes": ["light", "dark"],
-      "checks": ["plan-reminder-row", "module-page-shell"]
+      "checks": ["plan-reminder-row", "module-page-shell"],
+      "viewportOptOuts": {
+        "compact": "Below the 1100px check threshold the floor contract is the stricter horizontal-containment case for the same checks."
+      }
     },
     "planRemindersInspector": {
       "storyId": "product-module-hubs--scheduled-plan-reminders-inspector",
       "productionHost": "AppShellDetailPanel > AutomationsPage",
       "state": "One reminder selected: the inspector beside the rows when wide, over them when narrow",
-      "viewports": ["wide", "compact", "floor"],
+      "viewports": ["wide", "floor"],
       "colorSchemes": ["light", "dark"],
-      "checks": ["module-page-inspector"]
+      "checks": ["module-page-inspector"],
+      "viewportOptOuts": {
+        "compact": "The inspector check branches at 1024px: wide proves the side panel, floor proves the dialog; compact takes the same dialog branch as floor."
+      }
     },
     "planRemindersEmpty": {
       "storyId": "product-module-hubs--scheduled-plan-reminders",
@@ -151,8 +189,12 @@
       "storyId": "product-module-hubs--scheduled-daily-review",
       "productionHost": "AppShellDetailPanel > DailyReviewPage",
       "state": "Loaded daily review summary",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light", "dark"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light", "dark"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "The settings-bounds reference (dailyReviewSettingsBounds) covers minimum-width daily-review geometry."
+      }
     },
     "dailyReviewSettingsBounds": {
       "storyId": "product-settings-pages--daily-review-model-selector-open-narrow",
@@ -169,9 +211,12 @@
       "storyId": "product-shell-official-appshell--session-context-layer",
       "productionHost": "AppShell > ChatView",
       "state": "Goal, branch, revision and memory metadata above the transcript",
-      "viewports": ["wide", "compact", "floor"],
+      "viewports": ["wide", "floor"],
       "colorSchemes": ["light", "dark"],
-      "checks": ["session-context-layer"]
+      "checks": ["session-context-layer"],
+      "viewportOptOuts": {
+        "compact": "The check runs one width-agnostic predicate; wide proves the full layer, floor proves the overflow-menu fallback at the stricter width."
+      }
     },
     "composer": {
       "storyId": "product-shell-official-appshell--new-chat-composer",
@@ -189,8 +234,12 @@
       "storyId": "product-ask-user-question--pending-decisions",
       "productionHost": "UserQuestionPrompt (the ChatComposerRegion takeover is out of scope)",
       "state": "First of three questions, at the composer's position",
-      "viewports": ["wide", "compact", "floor"],
-      "colorSchemes": ["light"]
+      "viewports": ["wide"],
+      "colorSchemes": ["light"],
+      "viewportOptOuts": {
+        "compact": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent.",
+        "floor": "No width-dependent check is declared; the mount, console, and scheme assertions are viewport-independent."
+      }
     },
     "toastConfirmQueue": {
       "storyId": "primitives-toast--confirm-queued",


### PR DESCRIPTION
Part of #2390 (Storybook half; the Electron E2E changes follow in a separate PR per the issue).

## Problem

The product smoke manifest expanded 22 surfaces into **92 serial page loads**, but the assertions do not justify the matrix:

- Every job runs the same baseline: mount succeeds, no console/page errors, root has content, and (dark jobs) the `.dark` class + computed color-scheme. Only a surface's declared `checks[]` add anything beyond that.
- **Nine surfaces declare no checks** (onboarding, settings, usage, providers, skills, mcp, mcpMarketplace, mcpEditor, dailyReview) — their compact and floor viewports re-ran exactly the baseline that wide already proves. Same for askUserQuestion.
- Three checked surfaces ran compact and floor through the **same check branch**: `module-page-inspector` branches at 1024px (both compact 820 and floor 480 take the dialog branch), `plan-reminder-row`'s right-alignment check gates on ≥1100px (both skip it), and `session-context-layer` is one width-agnostic predicate whose distinct narrow behavior (overflow-menu fallback) floor already exercises at the stricter width.

## Change

One file: `apps/desktop/stories/product-smoke-manifest.json`. Every removal goes through the runner's own declared mechanism — the validator fails unless each of the three product viewports is either covered or given a written opt-out reason — so nothing is silently skipped:

- 9 no-checks surfaces + askUserQuestion → **wide only** (both color schemes kept: the dark-scheme assertion is a real per-job check)
- planReminders / planRemindersInspector / sessionContext → **wide + floor**, compact opted out as the same check branch at a looser width

Untouched: `REQUIRED_PRODUCT_SURFACES` (all 22 surfaces still present), all `checks[]`, the runner itself, and the **full catalog mount sweep** — every story in the built index still renders once (100 renders before and after), so 'renders without throwing' coverage is not reduced for any story.

## Timing

Local, `smoke:storybook` after `build-storybook`, same machine:

| | manifest jobs (serial) | catalog renders | wall |
|---|---|---|---|
| before | 92 | 100 | 43.0s |
| after | **48** | 100 | **28.6s** (−33%) |

The manifest half runs at concurrency 1 (its geometry checks need a quiet page), so it dominates smoke wall time — and is exactly the half this shrinks.

## Judgment call for review

The three checked-surface compact opt-outs (planReminders, planRemindersInspector, sessionContext) are the interpretive part: the check *code* takes the same branch as floor, but the DOM under it differs at 820px. If you weigh 820px as an independent geometry worth mounting, say so and I'll restore those three (matrix 48 → 54; the nine no-checks surfaces are the unambiguous bulk of the win).

cc @Astro-Han