### PR TITLE
test(runtime-host): validate Windows crash recovery

### DIFF
--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -15,11 +15,11 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 
 | Classification | Count |
 |---|---:|
-| windows-backend-gap | 30 |
+| windows-backend-gap | 21 |
 | portable-candidate | 0 |
 | platform-contract | 35 |
 
-Total Windows-excluded declarations: **65**
+Total Windows-excluded declarations: **56**
 
 ## Inventory
 
@@ -32,30 +32,21 @@ Total Windows-excluded declarations: **65**
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` kills login-shell descendants when capture times out | `process.platform === 'win32'` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` bounds shell output instead of buffering until the global timeout | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/headless/src/__tests__/sandbox.test.ts` copies portable workspace evidence while skipping process-local special files | `process.platform === 'win32'` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts` two UDS Clients query and control one Agent graph through Session invalidation | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/artifact-two-client-uds.test.ts` production Host recovers Artifact publication and preserves deletes across owner death | `process.platform === 'win32' ? 'POSIX process death gate' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/automation-two-client-uds.test.ts` two UDS Clients share one revision-pinned Automation authority | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/control-endpoint.test.ts` runtime host control endpoint | `process.platform === 'win32'` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/daily-review-two-client-uds.test.ts` two UDS Clients share Daily Review config, generation, and restart recovery | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/deep-research-two-client-uds.test.ts` two UDS Clients and a restarted production Host share one Deep Research projection | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/execution-host-queue.test.ts` a killed Host is recovered exactly once before its successor becomes ready | `process.platform === 'win32' ? 'POSIX process death gate' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/execution-inspect-uds.test.ts` a live Host serves Interactive inspection over its real UDS while retaining exclusive ownership | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
+| windows-backend-gap | `packages/runtime-host/src/__tests__/execution-inspect-uds.test.ts` a live Host serves Interactive inspection over its real endpoint while retaining exclusive ownership | `process.platform === 'win32' ? 'Windows execution Host startup lifecycle' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` an automatic failed liveness check is connection-fatal and Client close stays local | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` bounded election does not launch a Candidate after handshake exhausts the deadline | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` a non-reading Client overload is isolated to its connection | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` reports one shutdown failure through close and closed while releasing ownership | `process.platform === 'win32'` |
 | platform-contract | `packages/runtime-host/src/__tests__/host-kernel.test.ts` publishes private POSIX endpoint and registration permissions | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/memory-two-client-uds.test.ts` two UDS clients share one recoverable Memory authority across Host death | `process.platform === 'win32' ? 'POSIX process death gate' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/oauth-two-client-uds.test.ts` OAuth enrollment presents only on the initiating Client over real UDS | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/oauth-two-client-uds.test.ts` OAuth enrollment honors Claude and Codex opt-out flags over real UDS | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/plan-two-client-uds.test.ts` two UDS Clients and a restarted production Host share one retry-safe Plan authority | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts` invalidates when a real published mutation loses its commit reply | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/runtime-resource-process.test.ts` real Host Runtime Resource process lifecycle | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/runtime-resource-two-client-uds.test.ts` a Host-owned PTY survives Desktop disconnect and transfers control to TUI | `process.platform === 'win32' ? 'POSIX UDS and shell integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts` two UDS Clients share stable Session creation, CAS configuration, and catalog continuity | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts` stable Session creation survives response loss and Host restart | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/session-effect-two-client-uds.test.ts` two UDS Clients share one durable Session recap effect | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts` two UDS Clients share exact retryable Session branch and revision authority | `process.platform === 'win32' ? 'POSIX UDS integration' : false` |
+| windows-backend-gap | `packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts` two Clients share stable Session creation, CAS configuration, and catalog continuity | `process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false` |
+| windows-backend-gap | `packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts` stable Session creation survives response loss and Host restart | `process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false` |
+| windows-backend-gap | `packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts` two Clients share exact retryable Session branch and revision authority | `process.platform === 'win32' ? 'Windows SQLite shutdown lifecycle' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/skill-catalog-two-client-uds.test.ts` two UDS clients converge on one lease-bound Skill catalog authority | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts` fails the connection for a canonical response with mismatched ${mismatch.name} | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts` rejects local invalid input without poisoning transport and correlates a private canonical copy | `process.platform === 'win32'` |

--- a/packages/runtime-host/src/__tests__/execution-host-queue.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host-queue.test.ts
@@ -262,9 +262,7 @@ test('an archived Session rejects a new Turn before durable admission', async ()
   });
 });
 
-test('a killed Host is recovered exactly once before its successor becomes ready', {
-  skip: process.platform === 'win32' ? 'POSIX process death gate' : false,
-}, async () => {
+test('a killed Host is recovered exactly once before its successor becomes ready', async () => {
   await withExecutionRoot(async (fixture) => {
     const firstHost = await fixture.startHost();
     const first = await connectClient(fixture.root, 'desktop');
@@ -519,8 +517,9 @@ test('startup recovery canonically closes pending linked child admissions withou
     const reader = await tryAcquireInteractiveRootReader(fixture.capability);
     assert.ok(reader);
     if (!reader) throw new Error('Unable to acquire recovery result reader');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForRead>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForRead(reader.lease);
+      stores = await openInteractiveExecutionStoresForRead(reader.lease);
       for (const recovered of [initial, resume, retry, graph]) {
         const run = await stores.agentRunStore.readRun(recovered.sessionId, recovered.runId);
         assert.equal(run.status, 'failed');
@@ -548,15 +547,16 @@ test('startup recovery canonically closes pending linked child admissions withou
           assert.equal(terminal.fact.runStatus, 'failed');
           assert.equal(terminal.fact.failureClass, 'app_restarted');
         }
-        const userMessages = (await stores.sessionStore.readMessages(recovered.sessionId)).filter(
-          (message) => message.type === 'user' && message.turnId === recovered.turnId,
-        );
+        const userMessages: StoredMessage[] = (
+          await stores.sessionStore.readMessages(recovered.sessionId)
+        ).filter((message) => message.type === 'user' && message.turnId === recovered.turnId);
         assert.equal(userMessages.length, recovered.kind === 'linked_child_provider_retry' ? 0 : 1);
         if (recovered.kind !== 'linked_child_provider_retry') {
           assert.equal(userMessages[0]?.id, recovered.userMessageId);
         }
       }
     } finally {
+      await stores?.sessionStore.close?.();
       await reader.close();
     }
   });

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -349,8 +349,9 @@ async function seedDispatchedClientCapability(
   const owner = await tryAcquireInteractiveRootOwner(fixture.capability);
   assert.ok(owner);
   if (!owner) throw new Error('Unable to acquire execution root for Client Capability setup');
+  let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
   try {
-    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    stores = await openInteractiveExecutionStoresForWrite(owner.lease);
     const operationId = 'client-capability-before-ready';
     const invocationId = `${operationId}-invocation`;
     const runId = `${operationId}-run`;
@@ -412,6 +413,7 @@ async function seedDispatchedClientCapability(
     });
     return { runId, toolName };
   } finally {
+    await stores?.sessionStore.close?.();
     await owner.close();
   }
 }
@@ -1088,13 +1090,15 @@ async function withOwnedTaskLedgerToolPort<T>(
   const owner = await tryAcquireInteractiveRootOwner(fixture.capability);
   assert.ok(owner);
   if (!owner) throw new Error('Unable to acquire the interactive Task Ledger tool port');
+  let writer: Awaited<ReturnType<typeof openInteractiveTaskLedgerStoreForWrite>> | undefined;
   try {
-    const writer = await openInteractiveTaskLedgerStoreForWrite(owner.lease);
+    writer = await openInteractiveTaskLedgerStoreForWrite(owner.lease);
     const coordinator = new HostTaskLedgerCoordinator(writer, new SessionAdmissionGate(), {
       probeSessionRemoval: async () => ({ kind: 'present' }),
     });
     return await run(coordinator, buildTaskLedgerTools({ store: coordinator }));
   } finally {
+    writer?.close();
     await owner.close();
   }
 }

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host-suite.ts
@@ -116,8 +116,9 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for Session setup');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const session = await stores.sessionStore.create({
         cwd: this.root,
         backend: 'fake',
@@ -127,6 +128,7 @@ export class ExecutionFixture {
       });
       return session.id;
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -140,8 +142,9 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for continuation setup');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const sourceInvocationId = randomUUID();
       const sourceRunId = randomUUID();
       const sourceTurnId = randomUUID();
@@ -239,6 +242,7 @@ export class ExecutionFixture {
         sourceRuntimeEventHighWater: requiredToolName ? 4 : 2,
       };
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -258,8 +262,9 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for continuation crash setup');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const backends = new BackendRegistry();
       backends.register(
         'fake',
@@ -346,6 +351,7 @@ export class ExecutionFixture {
         targetTurnId,
       };
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -360,8 +366,9 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for continuation setup');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const workspace = await resolveWorkspaceIdentity({ path: this.root });
       const manager = new SessionManager({
         store: stores.sessionStore,
@@ -422,6 +429,7 @@ export class ExecutionFixture {
         targetTurnId,
       };
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -449,8 +457,9 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for child admission setup');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const turnId = randomUUID();
       const runId = randomUUID();
       const sourceRunId =
@@ -597,6 +606,7 @@ export class ExecutionFixture {
         agentName,
       };
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -606,8 +616,9 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for graph lineage setup');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const ts = Date.now();
       await stores.agentRunStore.createRun(
         {
@@ -631,6 +642,7 @@ export class ExecutionFixture {
         { durable: true },
       );
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -646,10 +658,12 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for archive');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       await stores.sessionStore.archive(this.sessionId);
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -718,8 +732,9 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for regenerate admission setup');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const messages = await stores.sessionStore.readMessages(this.sessionId);
       const source = messages.find(
         (message): message is Extract<StoredMessage, { type: 'user' }> =>
@@ -746,6 +761,7 @@ export class ExecutionFixture {
         userMessageId: result.admission.userMessageId,
       };
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -759,8 +775,9 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for admission setup');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const admittedAt = Date.now();
       const content = typeof input === 'string' ? { text: input } : input;
       const result = await stores.agentRunStore.admitRootTurn({
@@ -806,6 +823,7 @@ export class ExecutionFixture {
         userMessageId: result.admission.userMessageId,
       };
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -839,7 +857,7 @@ export class ExecutionFixture {
     host: ExecutionHostHandle,
   ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
     if (host.child.exitCode === null && host.child.signalCode === null) {
-      host.child.kill('SIGTERM');
+      host.child.send({ type: 'shutdown' });
     }
     const exit = await withTimeout(
       waitForExitResult(host.child),
@@ -856,12 +874,9 @@ export class ExecutionFixture {
   }
 
   async killHost(host: ExecutionHostHandle): Promise<void> {
+    const closed = waitForCloseResult(host.child);
     host.child.kill('SIGKILL');
-    await withTimeout(
-      waitForExit(host.child),
-      PROCESS_TIMEOUT_MS,
-      'execution Host survived SIGKILL',
-    );
+    await withTimeout(closed, PROCESS_TIMEOUT_MS, 'execution Host survived SIGKILL');
     this.#children.delete(host.child);
   }
 
@@ -876,8 +891,9 @@ export class ExecutionFixture {
 
   async readTurn(turnId: string): Promise<TurnLedger> {
     const reader = await acquireReader(this.capability);
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForRead>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForRead(reader.lease);
+      stores = await openInteractiveExecutionStoresForRead(reader.lease);
       const admission = await stores.agentRunStore.readRootTurnAdmission(this.sessionId, turnId);
       assert.ok(admission);
       const runs = (await stores.agentRunStore.listSessionRuns(this.sessionId)).filter(
@@ -900,6 +916,7 @@ export class ExecutionFixture {
         classification: classifyTerminalRuntimeLedger(run, runtimeEvents),
       };
     } finally {
+      await stores?.sessionStore.close?.();
       await reader.close();
     }
   }
@@ -908,10 +925,12 @@ export class ExecutionFixture {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
     if (!owner) throw new Error('Unable to acquire execution root for admission inspection');
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
-      return stores.agentRunStore.listRootTurnAdmissionsForRecovery(this.sessionId);
+      stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      return await stores.agentRunStore.listRootTurnAdmissionsForRecovery(this.sessionId);
     } finally {
+      await stores?.sessionStore.close?.();
       await owner.close();
     }
   }
@@ -922,8 +941,9 @@ export class ExecutionFixture {
     userMessageCount: number;
   }> {
     const reader = await acquireReader(this.capability);
+    let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForRead>> | undefined;
     try {
-      const stores = await openInteractiveExecutionStoresForRead(reader.lease);
+      stores = await openInteractiveExecutionStoresForRead(reader.lease);
       const [admission, runs, messages] = await Promise.all([
         stores.agentRunStore.readRootTurnAdmission(this.sessionId, turnId),
         stores.agentRunStore.listSessionRuns(this.sessionId),
@@ -937,6 +957,7 @@ export class ExecutionFixture {
         ).length,
       };
     } finally {
+      await stores?.sessionStore.close?.();
       await reader.close();
     }
   }
@@ -991,8 +1012,9 @@ export async function withExecutionRoot(
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner);
   let sessionId: string;
+  let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
   try {
-    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    stores = await openInteractiveExecutionStoresForWrite(owner.lease);
     const session = await stores.sessionStore.create({
       cwd: root,
       backend: 'fake',
@@ -1002,6 +1024,7 @@ export async function withExecutionRoot(
     });
     sessionId = session.id;
   } finally {
+    await stores?.sessionStore.close?.();
     await owner.close();
   }
   const fixture = new ExecutionFixture(base, root, capability, sessionId);
@@ -1403,6 +1426,27 @@ function waitForExitResult(
     };
     child.once('error', onError);
     child.once('exit', onExit);
+  });
+}
+
+function waitForCloseResult(
+  child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      child.off('error', onError);
+      child.off('close', onClose);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onClose = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    child.once('error', onError);
+    child.once('close', onClose);
   });
 }
 

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
@@ -37,6 +37,16 @@ if (recoverySessionId && recoveryRunId) {
   }
 }
 
+process.on('message', (message: unknown) => {
+  if (
+    message &&
+    typeof message === 'object' &&
+    (message as { type?: unknown }).type === 'shutdown'
+  ) {
+    void result.host.close();
+  }
+});
+
 try {
   await runRuntimeHostProcessLifecycle(result.host, {
     closeOnDisconnect: true,


### PR DESCRIPTION
## Summary

- enable the killed Runtime Host recovery gate on Windows
- use an explicit fixture IPC shutdown request for portable graceful Host teardown
- close execution and task-ledger stores before releasing root leases so Windows can remove SQLite files
- refresh the Windows skip inventory

## Validation

- `npm --workspace @maka/runtime-host run build`
- `npm --workspace @maka/runtime-host run typecheck`
- `node --test packages/runtime-host/dist/__tests__/execution-host-queue.test.js` (9/9 passed)
- shared execution-host fixture suites run serially (36/38 passed before the two remaining same-root-cause lease leaks were fixed)
- the two corrected execution-host cases passed after the fix
- final post-rebase Windows gate set passed (3/3)
- `npm run windows:inventory`
- `git diff --check`

The full runtime-host suite still exposes pre-existing Windows baseline failures outside this change, primarily SQLite file removal and live-root rename semantics tracked by #2142.

Part of #2142