### PR TITLE
test(runtime-host): validate Windows artifact recovery

### DIFF
--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -15,11 +15,11 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 
 | Classification | Count |
 |---|---:|
-| windows-backend-gap | 19 |
+| windows-backend-gap | 18 |
 | portable-candidate | 0 |
 | platform-contract | 35 |
 
-Total Windows-excluded declarations: **54**
+Total Windows-excluded declarations: **53**
 
 ## Inventory
 
@@ -32,7 +32,6 @@ Total Windows-excluded declarations: **54**
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` kills login-shell descendants when capture times out | `process.platform === 'win32'` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` bounds shell output instead of buffering until the global timeout | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/headless/src/__tests__/sandbox.test.ts` copies portable workspace evidence while skipping process-local special files | `process.platform === 'win32'` |
-| windows-backend-gap | `packages/runtime-host/src/__tests__/artifact-two-client-uds.test.ts` production Host recovers Artifact publication and preserves deletes across owner death | `process.platform === 'win32' ? 'POSIX process death gate' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/control-endpoint.test.ts` runtime host control endpoint | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/execution-inspect-uds.test.ts` a live Host serves Interactive inspection over its real endpoint while retaining exclusive ownership | `process.platform === 'win32' ? 'Windows execution Host startup lifecycle' : false` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/host-kernel.test.ts` an automatic failed liveness check is connection-fatal and Client close stays local | `process.platform === 'win32'` |

--- a/packages/runtime-host/src/__tests__/artifact-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/artifact-two-client-uds.test.ts
@@ -26,7 +26,7 @@ const CURRENT_PROTOCOL = {
   min: RUNTIME_HOST_PROTOCOL_VERSION,
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
-const PROCESS_TIMEOUT_MS = 10_000;
+const PROCESS_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 10_000;
 const BULK_ARTIFACT_COUNT = 24;
 const BULK_ARTIFACT_SUMMARY = 's'.repeat(7 * 1024);
 const MAX_ARTIFACT_ID = 'a'.repeat(ARTIFACT_ENTITY_ID_MAX_CHARS);
@@ -36,7 +36,6 @@ const PROTECTED_ARTIFACTS = [
 ] as const;
 
 test('production Host recovers Artifact publication and preserves deletes across owner death', {
-  skip: process.platform === 'win32' ? 'POSIX process death gate' : false,
   timeout: 120_000,
 }, async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-artifacts-'));
@@ -268,8 +267,10 @@ async function seedExecutionRoot(
 ): Promise<{ readonly sessionId: string; readonly otherSessionId: string }> {
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner, 'Artifact test could not acquire the interactive root owner');
+  let stores: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>> | undefined;
+  let artifacts: Awaited<ReturnType<typeof openInteractiveArtifactStoreForWrite>> | undefined;
   try {
-    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    stores = await openInteractiveExecutionStoresForWrite(owner.lease);
     const session = await stores.sessionStore.create({
       cwd: root,
       backend: 'fake',
@@ -284,11 +285,12 @@ async function seedExecutionRoot(
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    const artifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
-    await artifacts.recover();
+    const openedArtifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
+    artifacts = openedArtifacts;
+    await openedArtifacts.recover();
     await Promise.all([
       ...Array.from({ length: 130 }, (_, index) =>
-        artifacts.create({
+        openedArtifacts.create({
           id: index === 2 ? MAX_ARTIFACT_ID : `artifact-${index.toString().padStart(3, '0')}`,
           sessionId: session.id,
           turnId: 'turn-1',
@@ -300,7 +302,7 @@ async function seedExecutionRoot(
           now: 10_000 - index,
         }),
       ),
-      artifacts.create({
+      openedArtifacts.create({
         id: 'small-text',
         sessionId: session.id,
         turnId: 'turn-1',
@@ -311,7 +313,7 @@ async function seedExecutionRoot(
         source: 'fixture',
         now: 20_000,
       }),
-      artifacts.create({
+      openedArtifacts.create({
         id: 'small-binary',
         sessionId: session.id,
         turnId: 'turn-1',
@@ -322,7 +324,7 @@ async function seedExecutionRoot(
         source: 'fixture',
         now: 19_999,
       }),
-      artifacts.create({
+      openedArtifacts.create({
         id: 'replacement-expanded-text',
         sessionId: session.id,
         turnId: 'turn-1',
@@ -334,7 +336,7 @@ async function seedExecutionRoot(
         now: 9_000,
       }),
       ...PROTECTED_ARTIFACTS.map((artifact, index) =>
-        artifacts.create({
+        openedArtifacts.create({
           id: artifact.id,
           sessionId: session.id,
           turnId: 'turn-1',
@@ -348,7 +350,7 @@ async function seedExecutionRoot(
       ),
       ...Array.from({ length: BULK_ARTIFACT_COUNT }, (_, index) => {
         const id = `bulk-${index.toString().padStart(3, '0')}`;
-        return artifacts.create({
+        return openedArtifacts.create({
           id,
           sessionId: session.id,
           turnId: 'turn-1',
@@ -364,6 +366,8 @@ async function seedExecutionRoot(
     ]);
     return { sessionId: session.id, otherSessionId: otherSession.id };
   } finally {
+    artifacts?.close();
+    await stores?.sessionStore.close?.();
     await owner.close();
   }
 }
@@ -402,7 +406,7 @@ async function startHost(root: string, rootId: string): Promise<ExecutionHostHan
 
 async function stopHost(host: ExecutionHostHandle): Promise<void> {
   if (host.child.exitCode === null && host.child.signalCode === null) {
-    host.child.kill('SIGTERM');
+    host.child.send({ type: 'shutdown' });
   }
   const exit = await withTimeout(
     waitForExitResult(host.child),


### PR DESCRIPTION
## Summary

- enable the production Artifact publication and owner-death recovery gate on Windows
- close fixture-owned Artifact and execution stores before releasing the root lease
- use the explicit Runtime Host fixture shutdown protocol for portable graceful teardown
- allow a larger Windows cold-start budget for recovery of the seeded Artifact catalog
- refresh the Windows skip inventory

## Validation

- `npm --workspace @maka/runtime run build`
- `npm --workspace @maka/runtime-host run build`
- `npm --workspace @maka/runtime-host run typecheck`
- `node --test packages/runtime-host/dist/__tests__/artifact-two-client-uds.test.js` (passed twice before rebase and once after rebase on Windows)
- `npm run windows:inventory`
- `git diff --check`

The prerequisite Runtime Host fixture shutdown and deterministic execution-store cleanup changes are available on `main` through #2492. This PR now contains only the Artifact recovery gate and inventory update.

Part of #2142