### PR TITLE
fix(desktop): keep readiness failures visible and recoverable

### DIFF
--- a/apps/desktop/src/main/__tests__/workspace-readiness-recovery.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-readiness-recovery.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { OnboardingState } from '@maka/core';
+import { deriveWorkspaceReadinessRecovery } from '../../renderer/workspace-readiness-recovery.js';
+
+function derive(state: OnboardingState | undefined, overrides = {}) {
+  return deriveWorkspaceReadinessRecovery({
+    state,
+    locale: 'zh',
+    activeSessionId: undefined,
+    showOnboardingHero: false,
+    ...overrides,
+  });
+}
+
+test('does not duplicate ready, onboarding, or active-session surfaces', () => {
+  assert.equal(derive(undefined), undefined);
+  assert.equal(
+    derive({ kind: 'ready_empty', connectionSlug: 'opencode-free', model: 'big-pickle' }),
+    undefined,
+  );
+  assert.equal(derive({ kind: 'needs_connection' }, { showOnboardingHero: true }), undefined);
+  assert.equal(derive({ kind: 'needs_connection' }, { activeSessionId: 'session-1' }), undefined);
+});
+
+test('routes a missing model back to the affected connection', () => {
+  const recovery = derive({ kind: 'needs_model', connectionSlug: 'opencode-free' });
+
+  assert.equal(recovery?.tone, 'warning');
+  assert.deepEqual(recovery?.target, {
+    kind: 'connection',
+    connectionSlug: 'opencode-free',
+  });
+  assert.ok(recovery?.title);
+  assert.ok(recovery?.description);
+  assert.ok(recovery?.actionLabel);
+});
+
+test('routes an unhealthy workspace to model settings as a hard block', () => {
+  const recovery = derive({ kind: 'blocked', reason: 'all_connections_unhealthy' });
+
+  assert.equal(recovery?.tone, 'destructive');
+  assert.deepEqual(recovery?.target, { kind: 'models' });
+});

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -55,6 +55,7 @@ import { MessageCircleQuestion } from '@maka/ui/icons';
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
 import { ChatMessageSurface } from './chat-message-surface';
+import { deriveWorkspaceReadinessRecovery } from './workspace-readiness-recovery';
 import { LiveTurnReconciler } from './live-turn-reconciler';
 import { useAppShellSessionUiReads } from './use-app-shell-session-ui-reads';
 import { AgentGraphPanel } from './agent-graph-panel';
@@ -1253,6 +1254,12 @@ function AppShellContent({
     onboardingState !== undefined &&
     onboardingState.kind !== 'ready_with_history' &&
     onboardingState.kind !== 'ready_empty';
+  const workspaceReadinessRecovery = deriveWorkspaceReadinessRecovery({
+    state: onboardingState,
+    locale: uiLocale,
+    activeSessionId: activeId,
+    showOnboardingHero,
+  });
   const onboardingComposerHidden = isOnboardingLoading || (showOnboardingHero && onboardingState !== undefined);
   // #1629: hiding the composer because the boundary is unknown is right, but
   // hiding it silently and forever is not. Once the read has spent its retries
@@ -2809,6 +2816,9 @@ function AppShellContent({
                   onNewChatThinkingLevelChange={(level) => setPendingNewChatThinkingLevel(level ?? null)}
                   onOpenModelSettings={() => openSettingsSection('models')}
                   noModelConnection={connections.length === 0}
+                  disabled={
+                    Boolean(workspaceReadinessRecovery) || sessionHealthNotice?.tone === 'destructive'
+                  }
                   permissionMode={activePermissionMode}
                   permissionModePending={activeId ? pendingPermissionModeBySession[activeId] === true : false}
                   // Every "cannot change this mid-turn" gate reads `turnActive`,
@@ -2987,6 +2997,7 @@ function AppShellContent({
                   });
                 }}
                 sessionHealthNotice={sessionHealthNotice}
+                workspaceReadinessRecovery={workspaceReadinessRecovery}
                 showOnboardingHero={showOnboardingHero}
                 onboardingState={onboardingState}
                 isOnboardingLoading={isOnboardingLoading}

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -10,6 +10,7 @@ import { Banner, Button, ChatView, useUiLocale } from '@maka/ui';
 import { OnboardingHero } from './onboarding-hero';
 import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state';
 import type { SessionHealthNoticeView } from './use-shell-chat-model';
+import type { WorkspaceReadinessRecovery } from './workspace-readiness-recovery';
 import { getShellCopy } from './locales/shell-copy';
 import { selectLiveTurn } from './use-app-shell-session-ui-reads';
 import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
@@ -42,6 +43,7 @@ interface ChatMessageSurfaceProps extends Omit<
   /** The shell's selected session. Not derived from `activeSession`, which the shell substitutes for an unsaved chat. */
   activeSessionId: string | undefined;
   sessionHealthNotice?: SessionHealthNoticeView;
+  workspaceReadinessRecovery?: WorkspaceReadinessRecovery;
   showOnboardingHero: boolean;
   onboardingState: OnboardingState | undefined;
   isOnboardingLoading: boolean;
@@ -58,6 +60,7 @@ export function ChatMessageSurface({
   sessionUiController,
   activeSessionId,
   sessionHealthNotice,
+  workspaceReadinessRecovery,
   showOnboardingHero,
   onboardingState,
   isOnboardingLoading,
@@ -74,6 +77,21 @@ export function ChatMessageSurface({
   // Every session-health-notice CTA routes to 设置 · 模型 (U1); this is the
   // action button's visible label.
   const goToModelsLabel = copy.goToModels;
+  const handleWorkspaceRecovery = () => {
+    const target = workspaceReadinessRecovery?.target;
+    if (!target) return;
+    switch (target.kind) {
+      case 'provider_catalog':
+        onBrowseProviders();
+        return;
+      case 'models':
+        onOpenSettings('models');
+        return;
+      case 'connection':
+        onOpenConnectionDetail(target.connectionSlug);
+        return;
+    }
+  };
   const activeSession = chatViewRest.activeSession;
   const deepResearchRun = useDeepResearchRun(
     activeSession?.id,
@@ -129,6 +147,22 @@ export function ChatMessageSurface({
         deepResearchRun={deepResearchRun}
         emptyOverride={emptyOverride}
       />
+      {workspaceReadinessRecovery && (
+        <div className="maka-workspace-readiness-notice">
+          <Banner
+            status={workspaceReadinessRecovery.tone === 'destructive' ? 'error' : 'warning'}
+            className="maka-workspace-readiness-notice-alert"
+            role="status"
+            title={workspaceReadinessRecovery.title}
+            description={workspaceReadinessRecovery.description}
+            endContent={<Button
+              label={workspaceReadinessRecovery.actionLabel}
+              variant="ghost"
+              size="sm"
+              onClick={handleWorkspaceRecovery}
+            />} />
+        </div>
+      )}
       {sessionHealthNotice && (
         <div className="maka-session-health-notice">
           <Banner

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -26,6 +26,7 @@
    session-health-notice layout contract reads its rule body by matching the
    selector immediately before the brace. */
 .maka-boundary-unreadable-notice,
+.maka-workspace-readiness-notice,
 .maka-session-health-notice {
   width: min(
     var(--maka-chat-measure),
@@ -37,6 +38,7 @@
 }
 
 .maka-boundary-unreadable-notice-alert,
+.maka-workspace-readiness-notice-alert,
 .maka-session-health-notice-alert {
   width: 100%;
   box-sizing: border-box;

--- a/apps/desktop/src/renderer/workspace-readiness-recovery.ts
+++ b/apps/desktop/src/renderer/workspace-readiness-recovery.ts
@@ -1,0 +1,38 @@
+import type { OnboardingState, UiLocale } from '@maka/core';
+import {
+  getOnboardingHeroCopy,
+  type OnboardingActionTarget,
+} from './onboarding-hero-copy.js';
+
+export interface WorkspaceReadinessRecovery {
+  tone: 'warning' | 'destructive';
+  title: string;
+  description: string;
+  actionLabel: string;
+  target: OnboardingActionTarget;
+}
+
+/**
+ * Keeps setup failures recoverable after the one-time onboarding surface has
+ * been dismissed. Active sessions have their own, more specific health
+ * projection, so this notice only owns the new-task workspace state.
+ */
+export function deriveWorkspaceReadinessRecovery(input: {
+  state: OnboardingState | undefined;
+  locale: UiLocale;
+  activeSessionId: string | undefined;
+  showOnboardingHero: boolean;
+}): WorkspaceReadinessRecovery | undefined {
+  if (!input.state || input.activeSessionId || input.showOnboardingHero) return undefined;
+
+  const copy = getOnboardingHeroCopy(input.state, input.locale);
+  if (!copy) return undefined;
+
+  return {
+    tone: copy.tone === 'destructive' ? 'destructive' : 'warning',
+    title: copy.title,
+    description: copy.body,
+    actionLabel: copy.cta.label,
+    target: copy.cta.target,
+  };
+}


### PR DESCRIPTION
## English

### Summary

After initial onboarding is completed or skipped, a new-task workspace can still become unable to send because its connection or model configuration is no longer ready. Previously, users could reach the composer and only discover the problem after sending, through a late runtime or IPC error.

This PR:

- derives a persistent workspace recovery notice from the existing main-process `OnboardingState`;
- shows the failure reason above the composer with a direct action to the provider catalog, affected connection, or Settings → Models;
- blocks submission when the workspace or active session is already known to be hard-blocked, while keeping the model picker and other recovery controls available;
- keeps active-session health notices and first-run onboarding as the owners of their existing surfaces, avoiding duplicate warnings;
- adds focused coverage for ready, onboarding-owned, active-session, missing-model, and unhealthy-workspace states.

No new readiness model is introduced. The renderer reuses the existing onboarding and session-health projections.

Refs #2469

### Verification

- `npx biome check` on all changed files — passed
- `npm --workspace @maka/desktop run build:workspace-deps` — passed
- `npm --workspace @maka/desktop run build:main` — passed
- `node --test apps/desktop/dist/main/__tests__/workspace-readiness-recovery.test.js` — 3/3 passed
- `npm --workspace @maka/desktop run build:renderer` — passed
- `npm --workspace @maka/desktop run build:preload` — passed
- `npm --workspace @maka/desktop run build:overlay` — passed
- launched with `npm run dev` for desktop verification

## 中文

### 概要

用户完成或跳过首次引导后，新任务工作区仍可能因为连接或模型配置失效而无法发送。此前用户仍能操作输入框，直到发送后才通过 runtime 或 IPC 错误发现问题。

本 PR：

- 复用主进程现有的 `OnboardingState`，派生持续显示的工作区恢复提示；
- 在输入框上方说明不可用原因，并提供直达服务商目录、对应连接或“设置 → 模型”的修复入口；
- 当工作区或当前会话已确定被硬阻塞时只禁止提交，同时保留模型切换和其他自救入口；
- 保留首次引导和会话级健康提示原有的界面职责，避免重复警告；
- 为已就绪、首次引导占用、活动会话、缺少模型和全部连接异常等状态补充针对性测试。

本次没有引入新的就绪状态模型，Renderer 继续使用现有 onboarding 和 session-health 投影。

关联 #2469

### 验证

- 对全部改动文件运行 `npx biome check`——通过
- `npm --workspace @maka/desktop run build:workspace-deps`——通过
- `npm --workspace @maka/desktop run build:main`——通过
- `node --test apps/desktop/dist/main/__tests__/workspace-readiness-recovery.test.js`——3/3 通过
- `npm --workspace @maka/desktop run build:renderer`——通过
- `npm --workspace @maka/desktop run build:preload`——通过
- `npm --workspace @maka/desktop run build:overlay`——通过
- 已通过 `npm run dev` 启动桌面端检查