### PR TITLE
feat(ui): give skill rows the module page's browse dialect

### DIFF
--- a/apps/desktop/src/renderer/mcp-page.tsx
+++ b/apps/desktop/src/renderer/mcp-page.tsx
@@ -418,7 +418,7 @@ export function McpPage(props: { hubHeader?: ModuleHubHeader }) {
                 ].filter(Boolean).join(' · ')}
                 startContent={(
                   <span
-                    className="maka-mcp-market-icon"
+                    className="maka-module-market-icon"
                     data-brand={entry.id}
                     data-logo={hasMcpBrandMark(entry.id) ? 'true' : undefined}
                     aria-hidden="true"
@@ -495,7 +495,7 @@ export function McpPage(props: { hubHeader?: ModuleHubHeader }) {
                 key={serverId}
                 label={serverId}
                 description={(
-                  <span className="maka-mcp-row-description" data-maka-contract="mcp-server-description">
+                  <span className="maka-module-row-description" data-maka-contract="mcp-server-description">
                     {/* Exceptional state leads as TEXT; the healthy label
                         rides the dot's accessible name only. */}
                     {state.exception ? <span>{state.label} · </span> : null}

--- a/apps/desktop/src/renderer/styles/module-pages/mcp.css
+++ b/apps/desktop/src/renderer/styles/module-pages/mcp.css
@@ -1,40 +1,8 @@
-/* MCP page-specific bits.
-   The skeleton (Astryx Layout: header, toolbar, content, resizable inspector)
-   lives in the shared ModulePage primitive; rows are Astryx List/ListItem.
-   What is left here is the brand tiles, the install button's phase swap, the
-   row endpoint's truncation, the inspector's diagnostics, and the editor
-   dialog's own layout. */
-
-.maka-mcp-market-icon {
-  width: 28px;
-  height: 28px;
-  display: grid;
-  place-items: center;
-  border-radius: var(--radius-control);
-  background: var(--muted);
-  color: var(--foreground-secondary);
-}
-
-.maka-mcp-market-icon span {
-  font: var(--maka-text-heading-5);
-  letter-spacing: var(--tracking-normal);
-}
-
-/* Tiles that carry an official brand logo (mcp-brand-marks.tsx) drop the
-   per-brand tint and ride a quiet neutral plate — a colourful logo already
-   supplies the brand identity, so tinting the plate too would double up and
-   fight the mark. Mirrors provider-brand-marks' neutral `.providerLogo`. */
-.maka-mcp-market-icon[data-logo="true"] {
-  background: var(--foreground-5);
-  color: var(--foreground);
-  box-shadow: inset 0 0 0 1px oklch(from var(--foreground) l c h / 0.06);
-}
-
 /* Library brand marks (simple-icons) render as inline <svg>. Light theme fills
    each with its official brand hex, carried on the --mcp-brand-fill custom
    property set per-mark in mcp-brand-marks.tsx. Marks sit at the same 64% ratio
    as the provider plates. */
-.maka-mcp-market-icon .maka-mcp-brand-mark {
+.maka-module-market-icon .maka-mcp-brand-mark {
   width: 64%;
   height: 64%;
   display: block;
@@ -44,7 +12,7 @@
 /* Dark theme: near-black brand marks (Vercel ▲, Notion, Slack aubergine) are
    flagged data-contrast="low" by the luminance gate and inherit the plate's
    light foreground instead of vanishing on the dark neutral plate. */
-.dark .maka-mcp-market-icon .maka-mcp-brand-mark[data-contrast="low"] {
+.dark .maka-module-market-icon .maka-mcp-brand-mark[data-contrast="low"] {
   fill: currentColor;
 }
 
@@ -83,18 +51,11 @@
   opacity: 0;
 }
 
-/* The row description is one truncating line: transport, then the endpoint
-   in mono, then the live tool count. The title on the code keeps the full
-   endpoint one hover away. */
-.maka-mcp-row-description {
-  display: block;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
 
-.maka-mcp-row-description code {
+/* The endpoint <code> inside a browse row's supporting line. Follows the
+   description to the shared class; the rule is still live, it just lost its
+   old parent selector when the class moved. */
+.maka-module-row-description code {
   font: var(--maka-text-supporting);
 }
 

--- a/apps/desktop/src/renderer/styles/module-pages/module-shell.css
+++ b/apps/desktop/src/renderer/styles/module-pages/module-shell.css
@@ -108,6 +108,12 @@
 .maka-module-page-panel {
   min-height: 0;
   display: grid;
+  /* The column must be allowed to be narrower than its content. A grid track
+     sizes to max-content by default, so a panel holding SEVERAL row groups
+     stretched to the widest row and pushed each row's trailing action off
+     screen — a single group happened to collapse and hid this. `minmax(0, 1fr)`
+     is what makes "one column, never wider than the panel" explicit. */
+  grid-template-columns: minmax(0, 1fr);
   align-content: start;
   gap: var(--space-4);
   padding: var(--space-3) var(--space-5) var(--space-6);
@@ -152,4 +158,51 @@
     display: grid;
     align-items: stretch;
   }
+}
+
+/* Browse-row icon plate, shared by the MCP and Skills module pages.
+   Lifted out of mcp.css so the two pages cannot drift into two icon
+   languages: a skill row and an MCP row are the same kind of thing (a
+   browsable entity) and must read the same.
+
+   The tinting BOUNDARY moves with it, because it is the part that took
+   thinking: a tile carrying a colourful official logo drops the tint and
+   rides the quiet neutral plate, since the logo already supplies identity
+   and tinting the plate too would fight the mark. Skills ship no logos, so
+   they always take the neutral plate. */
+.maka-module-market-icon {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-control);
+  background: var(--muted);
+  color: var(--foreground-secondary);
+}
+
+.maka-module-market-icon span {
+  font: var(--maka-text-heading-5);
+  letter-spacing: var(--tracking-normal);
+}
+
+/* Tiles that carry an official brand logo (mcp-brand-marks.tsx) drop the
+   per-brand tint and ride a quiet neutral plate — a colourful logo already
+   supplies the brand identity, so tinting the plate too would double up and
+   fight the mark. Mirrors provider-brand-marks' neutral `.providerLogo`. */
+.maka-module-market-icon[data-logo="true"] {
+  background: var(--foreground-5);
+  color: var(--foreground);
+  box-shadow: inset 0 0 0 1px oklch(from var(--foreground) l c h / 0.06);
+}
+
+/* A browse row's supporting line is ONE truncating line, on both module
+   pages: metadata joined with `·`, clipped rather than wrapped, so rows keep
+   a predictable height and the column reads as a list instead of ragged
+   paragraphs. */
+.maka-module-row-description {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/packages/ui/src/skills-copy.ts
+++ b/packages/ui/src/skills-copy.ts
@@ -37,6 +37,8 @@ export interface SkillsCopy {
     noMatchTitle: string;
     noMatchBody: string;
     fallback: string;
+    /** How many tools a built-in skill declares, shown as row metadata. */
+    toolCount(count: number): string;
   };
   installed: {
     emptySearchTitle: string;
@@ -112,6 +114,8 @@ export interface SkillsCopy {
     toolbarAria: string;
     metaInstalled: (count: number) => string;
     metaUpdates: (count: number) => string;
+    /** How many skills the marketplace and built-in catalogs offer. */
+    metaAvailable: (count: number) => string;
     searchMatches: (count: number) => string;
     search: string;
     openFolder: string;
@@ -140,14 +144,14 @@ const SKILLS_COPY = {
     market: { categoryAll: '全部分类', sortName: '排序：名称', sortRecent: '排序：最近', controls: '市场筛选与排序', categoryFilter: '按分类筛选市场技能', sortAriaLabel: '市场技能排序方式', ariaLabel: '技能市场', importLocal: '导入本地 Skill', emptySearchTitle: '没有匹配的市场技能', emptyTitle: '来源库还是空的', emptySearchBody: '换一个关键词，或清空搜索查看全部来源。', emptyBody: '导入一个含 SKILL.md 的本地文件，它会作为可安装的来源出现在这里。', emptyFilterBody: '换一个分类或关键词，或清空筛选查看全部来源。', clearSearch: '清空搜索', clearFilters: '清空筛选', sourceFallback: '本地来源库 Skill。' },
     tabs: { ariaLabel: '技能视图', market: '市场', builtin: '内置', installed: '已安装' },
     install: { action: (name) => `安装 ${name}`, installedTitle: '已安装到当前工作区', installed: '已安装', notInstalled: '未安装' },
-    builtin: { ariaLabel: '内置技能', emptyTitle: '暂无内置技能', emptyBody: '应用自带的技能会出现在这里。', noMatchTitle: '没有匹配的内置技能', noMatchBody: '换一个关键词，或清空搜索查看全部内置技能。', fallback: '应用自带 Skill。' },
+    builtin: { ariaLabel: '内置技能', emptyTitle: '暂无内置技能', emptyBody: '应用自带的技能会出现在这里。', noMatchTitle: '没有匹配的内置技能', noMatchBody: '换一个关键词，或清空搜索查看全部内置技能。', fallback: '应用自带 Skill。', toolCount: (count: number) => `${count} 个工具` },
     installed: { emptySearchTitle: '没有匹配的 Skill', emptyTitle: '等待添加 Skill', emptySearchBody: '换一个关键词，或清空搜索查看全部本地技能。', emptyBodyBeforeCode: '把一个含', emptyBodyAfterCode: '的文件夹放到工作区的 skills/ 目录下，刷新后会出现在这里。', refreshPending: '刷新中…', refresh: '刷新技能', listAriaLabel: '技能列表' },
     context: { scope: { project: '项目', workspace: '工作区', user: '用户', custom: '自定义' }, decision: { advertised: '已进入上下文', disabled: '已停用', invalid: '元数据无效', host_incompatible: '主机不兼容', shadowed: '被高优先级覆盖', budget: '因预算省略' }, needsReview: '待确认', discoverySource: (scope, source) => `${scope}/${source} 发现源`, discoveryDiagnostic: { blocked_path: '路径被安全策略阻止', read_failed: '来源不可读取' } },
     row: { opening: '打开中…', reviewing: '审查中…', use: '使用', openTitle: '打开 SKILL.md', pinTitle: '固定到技能上下文', unpinTitle: '取消固定', viewDiff: '查看差异', viewUpdate: '查看更新', confirmDeleteAriaLabel: (name) => `确认删除 ${name}`, deleteDescription: '此操作会删除这个 Skill 的文件，且无法撤销。', cancel: '取消', delete: '删除' },
     review: { ariaLabel: 'Skill 更新审查', title: '更新审查', source: (id) => `来源 ${id}`, managedSource: '受管理来源', hasBaseline: '已有基线', missingBaseline: '缺少基线', lineTransition: (current, source) => `${current} → ${source} 行`, changedLines: (count) => `${count} 行不同`, warning: '工作区副本已有本地修改。继续更新会用来源库版本覆盖当前 SKILL.md。', workspace: '当前工作区', sourceVersion: '来源库版本', cancel: '取消', overwrite: '覆盖本地修改', update: '更新到来源版本' },
     description: { document: '创建、编辑、检查文档内容。', presentation: '创建、编辑、检查演示文稿。', spreadsheet: '创建、编辑、分析表格数据。', image: '生成或编辑图片素材。', browser: '打开、检查、操作网页界面。', macos: '辅助构建和调试 macOS 应用。', fallback: '打开技能文件查看适用场景。' },
     status: { metadataError: '元数据异常', managed: { source_missing: '来源缺失', update_available: '可更新', local_modified: '本地已修改', metadata_error: '元数据异常', up_to_date: '受管理', not_managed: '受管理' }, modified: '已修改', bundled: '内置', local: '本地', stateError: '状态异常', enabled: '已启用', disabled: '已停用' },
-    page: { title: '技能', toolbarAria: '技能筛选与视图', metaInstalled: (count) => `${count} 个已安装`, metaUpdates: (count) => `${count} 个可更新`, searchMatches: (count) => `${count} 个匹配`, search: '搜索技能', openFolder: '打开目录', moreActions: '更多技能操作', refreshing: '刷新中…', refresh: '刷新' },
+    page: { title: '技能', toolbarAria: '技能筛选与视图', metaInstalled: (count) => `${count} 个已安装`, metaUpdates: (count) => `${count} 个可更新`, metaAvailable: (count) => `${count} 个可安装`, searchMatches: (count) => `${count} 个匹配`, search: '搜索技能', openFolder: '打开目录', moreActions: '更多技能操作', refreshing: '刷新中…', refresh: '刷新' },
     detail: { label: '技能详情', enabled: '启用', pinned: '已固定', inspectorOpened: (name) => `已打开 ${name} 的详情`, idLabel: '标识', scopeLabel: '范围', sourceLabel: '来源', contextLabel: '上下文', runtimeLabel: '运行状态', toolsLabel: '声明工具', pathLabel: '路径' },
   },
   en: {
@@ -155,14 +159,14 @@ const SKILLS_COPY = {
     market: { categoryAll: 'All categories', sortName: 'Sort: Name', sortRecent: 'Sort: Recent', controls: 'Marketplace filters and sorting', categoryFilter: 'Filter marketplace skills by category', sortAriaLabel: 'Marketplace skill sort order', ariaLabel: 'Skill marketplace', importLocal: 'Import local Skill', emptySearchTitle: 'No matching marketplace skills', emptyTitle: 'The source library is empty', emptySearchBody: 'Try another keyword or clear search to see all sources.', emptyBody: 'Import a local file containing SKILL.md to make it available as an installable source.', emptyFilterBody: 'Try another category or keyword, or clear the filters.', clearSearch: 'Clear search', clearFilters: 'Clear filters', sourceFallback: 'Local source-library Skill.' },
     tabs: { ariaLabel: 'Skill views', market: 'Marketplace', builtin: 'Built in', installed: 'Installed' },
     install: { action: (name) => `Install ${name}`, installedTitle: 'Installed in this workspace', installed: 'Installed', notInstalled: 'Not installed' },
-    builtin: { ariaLabel: 'Built-in skills', emptyTitle: 'No built-in skills', emptyBody: 'Skills included with the app appear here.', noMatchTitle: 'No matching built-in skills', noMatchBody: 'Try another keyword or clear search to see all built-in skills.', fallback: 'Skill included with the app.' },
+    builtin: { ariaLabel: 'Built-in skills', emptyTitle: 'No built-in skills', emptyBody: 'Skills included with the app appear here.', noMatchTitle: 'No matching built-in skills', noMatchBody: 'Try another keyword or clear search to see all built-in skills.', fallback: 'Skill included with the app.', toolCount: (count: number) => (count === 1 ? '1 tool' : `${count} tools`) },
     installed: { emptySearchTitle: 'No matching Skills', emptyTitle: 'Waiting for a Skill', emptySearchBody: 'Try another keyword or clear search to see all local skills.', emptyBodyBeforeCode: 'Place a folder containing', emptyBodyAfterCode: 'in the workspace skills/ directory, then refresh to show it here.', refreshPending: 'Refreshing…', refresh: 'Refresh skills', listAriaLabel: 'Skill list' },
     context: { scope: { project: 'Project', workspace: 'Workspace', user: 'User', custom: 'Custom' }, decision: { advertised: 'In context', disabled: 'Disabled', invalid: 'Invalid metadata', host_incompatible: 'Host incompatible', shadowed: 'Shadowed', budget: 'Budget omitted' }, needsReview: 'Needs review', discoverySource: (scope, source) => `${scope}/${source} discovery source`, discoveryDiagnostic: { blocked_path: 'Path blocked by the safety policy', read_failed: 'Source could not be read' } },
     row: { opening: 'Opening…', reviewing: 'Reviewing…', use: 'Use', openTitle: 'Open SKILL.md', pinTitle: 'Pin to the skill context', unpinTitle: 'Unpin', viewDiff: 'View diff', viewUpdate: 'View update', confirmDeleteAriaLabel: (name) => `Delete ${name}?`, deleteDescription: 'This removes the Skill files and cannot be undone.', cancel: 'Cancel', delete: 'Delete' },
     review: { ariaLabel: 'Skill update review', title: 'Update review', source: (id) => `Source ${id}`, managedSource: 'Managed source', hasBaseline: 'Baseline available', missingBaseline: 'No baseline', lineTransition: (current, source) => `${current} → ${source} lines`, changedLines: (count) => `${count} ${count === 1 ? 'line differs' : 'lines differ'}`, warning: 'The workspace copy has local changes. Continuing will replace the current SKILL.md with the source version.', workspace: 'Current workspace', sourceVersion: 'Source version', cancel: 'Cancel', overwrite: 'Overwrite local changes', update: 'Update to source version' },
     description: { document: 'Create, edit, and inspect documents.', presentation: 'Create, edit, and inspect presentations.', spreadsheet: 'Create, edit, and analyze spreadsheet data.', image: 'Generate or edit images.', browser: 'Open, inspect, and operate web interfaces.', macos: 'Build and debug macOS apps.', fallback: 'Open the skill file to see when to use it.' },
     status: { metadataError: 'Metadata error', managed: { source_missing: 'Source missing', update_available: 'Update available', local_modified: 'Locally modified', metadata_error: 'Metadata error', up_to_date: 'Managed', not_managed: 'Managed' }, modified: 'Modified', bundled: 'Built in', local: 'Local', stateError: 'State error', enabled: 'Enabled', disabled: 'Disabled' },
-    page: { title: 'Skills', toolbarAria: 'Skill filters and views', metaInstalled: (count) => `${count} installed`, metaUpdates: (count) => count === 1 ? '1 update available' : `${count} updates available`, searchMatches: (count) => `${count} ${count === 1 ? 'match' : 'matches'}`, search: 'Search skills', openFolder: 'Open folder', moreActions: 'More Skill actions', refreshing: 'Refreshing…', refresh: 'Refresh' },
+    page: { title: 'Skills', toolbarAria: 'Skill filters and views', metaInstalled: (count) => `${count} installed`, metaUpdates: (count) => count === 1 ? '1 update available' : `${count} updates available`, metaAvailable: (count) => count === 1 ? '1 available to install' : `${count} available to install`, searchMatches: (count) => `${count} ${count === 1 ? 'match' : 'matches'}`, search: 'Search skills', openFolder: 'Open folder', moreActions: 'More Skill actions', refreshing: 'Refreshing…', refresh: 'Refresh' },
     detail: { label: 'Skill details', enabled: 'Enabled', pinned: 'Pinned', inspectorOpened: (name) => `${name} details opened`, idLabel: 'ID', scopeLabel: 'Scope', sourceLabel: 'Source', contextLabel: 'Context', runtimeLabel: 'Runtime', toolsLabel: 'Declared tools', pathLabel: 'Path' },
   },
 } satisfies UiCatalog<SkillsCopy>;

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -39,6 +39,7 @@ import {
   SegmentedControlItem,
   Selector,
   StatusDot,
+  Text,
   TextInput,
   Toolbar,
 } from '@astryxdesign/core';
@@ -66,6 +67,15 @@ import { useToast } from './toast.js';
 const MARKET_CATEGORY_ALL = '__all__';
 type MarketSort = 'name' | 'recent';
 type SkillTab = 'market' | 'builtin' | 'installed';
+
+/**
+ * Icon sizes by the role the glyph plays, not by call site. Eight hand-written
+ * numbers were scattered through this file; the values are unchanged, but a
+ * size is now a decision recorded once.
+ */
+const SKILL_ROW_ICON_SIZE = 18;
+const SKILL_INLINE_ICON_SIZE = 16;
+const SKILL_META_ICON_SIZE = 14;
 
 export function SkillsModuleMain(props: {
   skills?: SkillEntry[];
@@ -227,7 +237,39 @@ export function SkillsModuleMain(props: {
     if (!normalizedSkillQuery) return true;
     return `${entry.id} ${entry.name} ${entry.description} ${entry.category}`.toLowerCase().includes(normalizedSkillQuery);
   });
+  /**
+   * Built-in skills grouped by category.
+   *
+   * Structure, not colour, is how a browse surface gets richer: a reader
+   * scanning for "something that writes docs" is served by a heading, and no
+   * amount of tinting substitutes for one.
+   *
+   * Guarded twice, because grouping can make a list WORSE. With one category
+   * the headings are pure overhead, and while searching the user has already
+   * said what they want — splitting the few hits across headings buries them.
+   */
+  const bundledCatalogGroups = useMemo(() => {
+    const byCategory = new Map<ManagedSkillCategory, BundledSkillCatalogEntry[]>();
+    for (const entry of bundledCatalogFiltered) {
+      const group = byCategory.get(entry.category);
+      if (group) group.push(entry);
+      else byCategory.set(entry.category, [entry]);
+    }
+    return [...byCategory.entries()];
+  }, [bundledCatalogFiltered]);
+  const showBundledGroups = normalizedSkillQuery === '' && bundledCatalogGroups.length > 1;
+
   const allManagedSources = props.managedSkillSources ?? [];
+  // Distinct ids across both catalogs: a skill offered by the marketplace and
+  // shipped built-in is one thing you can install, not two.
+  const availableToInstallCount = useMemo(() => {
+    const ids = new Set<string>();
+    for (const entry of bundledCatalog) if (!entry.installed) ids.add(entry.id);
+    for (const source of allManagedSources) {
+      if (!skills.some((skill) => skill.id === source.id)) ids.add(source.id);
+    }
+    return ids.size;
+  }, [bundledCatalog, allManagedSources, skills]);
   const marketSources = useMemo(() => {
     const filtered = allManagedSources.filter((source) => {
       if (marketCategory !== MARKET_CATEGORY_ALL && source.category !== marketCategory) return false;
@@ -290,7 +332,7 @@ export function SkillsModuleMain(props: {
         isDisabled={installed || skillActionBusy || !onInstall}
         label={copy.install.action(name)}
         tooltip={installed ? copy.install.installedTitle : copy.install.action(name)}
-        icon={installing ? <Loader2 size={16} aria-hidden="true" /> : <Download size={16} aria-hidden="true" />}
+        icon={installing ? <Loader2 size={SKILL_INLINE_ICON_SIZE} aria-hidden="true" /> : <Download size={SKILL_INLINE_ICON_SIZE} aria-hidden="true" />}
       />
     );
   }
@@ -342,10 +384,18 @@ export function SkillsModuleMain(props: {
               <ListItem
                 key={source.id}
                 label={source.name}
-                description={[source.description || copy.market.sourceFallback, installed ? copy.install.installed : null]
+                description={[
+                  copy.categories[source.category],
+                  installed ? copy.install.installed : null,
+                  source.description || copy.market.sourceFallback,
+                ]
                   .filter(Boolean)
                   .join(' · ')}
-                startContent={<Blocks size={18} aria-hidden="true" />}
+                startContent={(
+                  <span className="maka-module-market-icon" aria-hidden="true">
+                    <Blocks size={SKILL_ROW_ICON_SIZE} />
+                  </span>
+                )}
                 endContent={catalogInstallButton(
                   source.id,
                   source.name,
@@ -378,13 +428,41 @@ export function SkillsModuleMain(props: {
           actions={<UiButton variant="ghost" size="sm" label={copy.market.clearSearch} onClick={() => setSkillSearchQuery('')} />}
         />
       ) : (
-        <List density="balanced" hasDividers className="maka-module-page-rows" aria-label={copy.builtin.ariaLabel}>
-          {bundledCatalogFiltered.map((entry) => (
+        // One List per category when grouping is on, each carrying its own
+        // heading; a single flat List otherwise. `header` is List's own slot,
+        // so the heading is associated with its rows rather than floating
+        // above them as loose text.
+        (showBundledGroups ? bundledCatalogGroups : [[null, bundledCatalogFiltered] as const]).map(
+          ([category, entries]) => (
+        <List
+          key={category ?? 'all'}
+          density="balanced"
+          hasDividers
+          className="maka-module-page-rows"
+          aria-label={category ? copy.categories[category] : copy.builtin.ariaLabel}
+          header={category ? <Text type="label" size="sm" color="secondary">{copy.categories[category]}</Text> : undefined}
+        >
+          {entries.map((entry) => (
             <ListItem
               key={entry.id}
               label={entry.name}
-              description={entry.description || copy.builtin.fallback}
-              startContent={<Blocks size={18} aria-hidden="true" />}
+              description={[
+                // The category is the group heading when grouping is on;
+                // repeating it on every row under that heading is the
+                // duplicate-count noise we removed from this page before.
+                showBundledGroups ? null : copy.categories[entry.category],
+                entry.declaredTools.length > 0
+                  ? copy.builtin.toolCount(entry.declaredTools.length)
+                  : null,
+                entry.description || copy.builtin.fallback,
+              ]
+                .filter(Boolean)
+                .join(' · ')}
+              startContent={(
+                <span className="maka-module-market-icon" aria-hidden="true">
+                  <Blocks size={SKILL_ROW_ICON_SIZE} />
+                </span>
+              )}
               endContent={catalogInstallButton(
                 entry.id,
                 entry.name,
@@ -395,6 +473,8 @@ export function SkillsModuleMain(props: {
             />
           ))}
         </List>
+          ),
+        )
       )}
     </div>
   );
@@ -498,9 +578,14 @@ export function SkillsModuleMain(props: {
     <main className="maka-main detailPane maka-module-main agents-chat-panel" data-page-shell="layout" data-module="skills" aria-label={props.hubHeader?.title ?? copy.page.title}>
       <ModulePage
         title={props.hubHeader?.title ?? copy.page.title}
+        // The page header said only how many skills are installed, which made
+        // a page whose other two tabs are catalogs look like it had nothing in
+        // them. Counting what is available to install is the number a browser
+        // is actually looking for.
         meta={[
           copy.page.metaInstalled(skills.length),
           updateAvailableCount > 0 ? copy.page.metaUpdates(updateAvailableCount) : null,
+          availableToInstallCount > 0 ? copy.page.metaAvailable(availableToInstallCount) : null,
         ].filter(Boolean).join(' · ')}
         inspectorLabel={copy.detail.label}
         inspectorAutoSaveId="maka-skill-inspector"
@@ -535,7 +620,7 @@ export function SkillsModuleMain(props: {
             <DropdownMenu
               button={{
                 label: copy.page.moreActions,
-                icon: <MoreHorizontal size={16} aria-hidden="true" />,
+                icon: <MoreHorizontal size={SKILL_INLINE_ICON_SIZE} aria-hidden="true" />,
                 isIconOnly: true,
                 variant: 'ghost',
                 isDisabled: skillActionBusy,
@@ -543,21 +628,21 @@ export function SkillsModuleMain(props: {
             >
               {props.onOpenSkillsFolder ? (
                 <DropdownMenuItem
-                  icon={<FolderOpen size={14} aria-hidden="true" />}
+                  icon={<FolderOpen size={SKILL_META_ICON_SIZE} aria-hidden="true" />}
                   label={copy.page.openFolder}
                   onClick={() => runPageActionAfterMenuClose('folder', props.onOpenSkillsFolder)}
                 />
               ) : null}
               {props.onImportManagedSkillSource ? (
                 <DropdownMenuItem
-                  icon={<Download size={14} aria-hidden="true" />}
+                  icon={<Download size={SKILL_META_ICON_SIZE} aria-hidden="true" />}
                   label={copy.market.importLocal}
                   onClick={() => runPageActionAfterMenuClose('source:import', props.onImportManagedSkillSource)}
                 />
               ) : null}
               {canRefreshSkillData ? (
                 <DropdownMenuItem
-                  icon={<RefreshCcw size={14} aria-hidden="true" />}
+                  icon={<RefreshCcw size={SKILL_META_ICON_SIZE} aria-hidden="true" />}
                   label={pendingSkillAction === 'refresh' ? copy.page.refreshing : copy.page.refresh}
                   onClick={() => runPageActionAfterMenuClose('refresh', refreshSkillData)}
                 />


### PR DESCRIPTION
task #163 波 1。owner 反馈技能页「太素了」。

## 为什么：不是缺装饰，是没跟上隔壁

技能行和 MCP 行是**同一种东西**——可浏览的实体——但只有一边被打扮成实体。技能行是全 app 唯一用裸图标字形的浏览行，而数据里现成的分类、工具数在送进行的路上被丢掉了。

## 四处改动，零新增颜色

**1 · 图标底共享化。** `.maka-mcp-market-icon` 从 mcp.css 提升为 module-shell.css 的 `.maka-module-market-icon`，技能行采用。**染色边界规则原样带走**——这是当初真正花了心思的部分：带彩色官方 logo 的 tile 主动放弃染底、走安静中性板，因为 logo 已经提供了识别，再染底会和图标打架。技能无 logo，恒走中性板。共享这个类，是为了两个模块页从此不会漂成两套图标语言。

**2 · 元数据回填，并且放在前面。** 分类与 `declaredTools.length` 本来就在数据里。**追加在描述末尾是错的**：技能描述是给模型看的长 prose，一截断最先丢的就是元数据，需要分类的行恰恰一个都看不到。现在是「3 个工具 · 描述」。

**3 · 内置按分类分组**，每组一个 List 带自己的 header——**结构才是浏览面变"富"的方式**，找"能写文档的"的人需要的是标题。**双守卫**：只有一个分类时标题是纯开销；搜索时用户已经说了要什么，再按标题拆散反而埋掉命中。分组态下行内不再带分类（组标题已经说了）。

**4 · 8 处手写图标尺寸 → 3 个角色常量**，数值不变。

页头原本只数已安装，让一个另外两个 tab 都是目录的页面看起来空空如也；现在也数可安装（两个目录去重）。

## 怎么验证的

- `@maka/ui` **251 passed / 0 failed**
- **skills 与 mcp 两个 e2e 都通过** —— MCP 的类名被指向了共享类，所以专门跑了它
- typecheck / lint / format / build 全绿
- 视觉两态截图已过审

## 已知遗留（不在本 PR，已批准单开）

长描述**没有省略号、被面板右缘直接切掉**——**改动前就存在**，非本次引入。根因：Astryx `Item` 只对**字符串** description 做截断，包 span 反而关掉它；真正的问题在 ModulePage 的 flex 链缺 `min-width: 0`，**MCP 页同病**。作为内容被切掉的 bug 单独修，两页截图为证。