### PR TITLE
fix(ui): copy only the turn's final reply, not every assistant step

### DIFF
--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import type { AttachmentRef, StoredMessage } from "@maka/core";
 import {
+  finalAssistantReplyText,
   materializeChat,
   materializeTools,
   materializeTurns,
@@ -767,5 +768,59 @@ describe("live tool status over persisted", () => {
       tools?.kind === "tools" ? tools.items[0]?.status : undefined,
       "interrupted",
     );
+  });
+});
+
+describe("final reply extraction for copy (#2407)", () => {
+  const multiStepTurn = (): StoredMessage[] => [
+    { type: "user", id: "ask", turnId: "t1", ts: 1, text: "do the thing" },
+    {
+      type: "assistant",
+      id: "step-1",
+      turnId: "t1",
+      ts: 2,
+      text: "Let me inspect the files first.",
+      modelId: "fixture",
+    },
+    {
+      type: "assistant",
+      id: "step-2",
+      turnId: "t1",
+      ts: 3,
+      text: "Found it — the flag was inverted.",
+      modelId: "fixture",
+    },
+    {
+      type: "assistant",
+      id: "step-3",
+      turnId: "t1",
+      ts: 4,
+      text: "Done: the fix is committed and the tests pass.",
+      modelId: "fixture",
+    },
+  ];
+
+  test("returns only the last answer step, not the intermediate narration", () => {
+    const [turn] = materializeTurns(multiStepTurn());
+    assert.ok(turn);
+    assert.equal(finalAssistantReplyText(turn), "Done: the fix is committed and the tests pass.");
+  });
+
+  test("leaves the legacy aggregate concatenation untouched for its other consumers", () => {
+    const [turn] = materializeTurns(multiStepTurn());
+    assert.equal(
+      turn?.assistant?.text,
+      "Let me inspect the files first.\n\nFound it — the flag was inverted.\n\nDone: the fix is committed and the tests pass.",
+    );
+  });
+
+  test("falls back to the aggregate when the timeline has no text entry", () => {
+    const [turn] = materializeTurns(multiStepTurn());
+    assert.ok(turn);
+    const withoutText = {
+      ...turn,
+      timeline: turn.timeline.filter((item) => item.kind !== "text"),
+    };
+    assert.equal(finalAssistantReplyText(withoutText), turn.assistant?.text);
   });
 });

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -772,6 +772,8 @@ describe("live tool status over persisted", () => {
 });
 
 describe("final reply extraction for copy (#2407)", () => {
+  // The issue's shape: the model narrates, calls tools, narrates again, then
+  // answers — one assistant row per step with tool calls interleaved.
   const multiStepTurn = (): StoredMessage[] => [
     { type: "user", id: "ask", turnId: "t1", ts: 1, text: "do the thing" },
     {
@@ -783,18 +785,36 @@ describe("final reply extraction for copy (#2407)", () => {
       modelId: "fixture",
     },
     {
+      type: "tool_call",
+      id: "tool-1",
+      turnId: "t1",
+      ts: 3,
+      toolName: "Read",
+      args: { path: "flag.ts" },
+      stepId: "step-2",
+    },
+    {
       type: "assistant",
       id: "step-2",
       turnId: "t1",
-      ts: 3,
+      ts: 4,
       text: "Found it — the flag was inverted.",
       modelId: "fixture",
+    },
+    {
+      type: "tool_call",
+      id: "tool-2",
+      turnId: "t1",
+      ts: 5,
+      toolName: "Edit",
+      args: { path: "flag.ts" },
+      stepId: "step-3",
     },
     {
       type: "assistant",
       id: "step-3",
       turnId: "t1",
-      ts: 4,
+      ts: 6,
       text: "Done: the fix is committed and the tests pass.",
       modelId: "fixture",
     },
@@ -804,6 +824,18 @@ describe("final reply extraction for copy (#2407)", () => {
     const [turn] = materializeTurns(multiStepTurn());
     assert.ok(turn);
     assert.equal(finalAssistantReplyText(turn), "Done: the fix is committed and the tests pass.");
+  });
+
+  test("keeps every narration step on the timeline in production order", () => {
+    const [turn] = materializeTurns(multiStepTurn());
+    assert.deepEqual(
+      turn?.timeline.flatMap((item) => (item.kind === "text" ? [item.text] : [])),
+      [
+        "Let me inspect the files first.",
+        "Found it — the flag was inverted.",
+        "Done: the fix is committed and the tests pass.",
+      ],
+    );
   });
 
   test("leaves the legacy aggregate concatenation untouched for its other consumers", () => {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -31,7 +31,11 @@ import {
   type ProviderRetryEvent,
   type QuoteRef,
 } from '@maka/core';
-import type { TurnTimelineItem, TurnViewModel } from './materialize.js';
+import {
+  finalAssistantReplyText,
+  type TurnTimelineItem,
+  type TurnViewModel,
+} from './materialize.js';
 import { foldTimeline, type FoldedTimelineChild } from './timeline-fold.js';
 import { AttachmentKindIcon } from './attachment-kinds.js';
 import { QuoteRefChip } from './quote-ref-chip.js';
@@ -647,7 +651,7 @@ export const TurnView = memo(function TurnView(props: {
               <TurnFooterActions
                 actions={props.footerActions}
                 onAction={props.onFooterAction ? (actionId) => props.onFooterAction?.(turn.turnId, actionId) : undefined}
-                assistantText={turn.assistant?.text ?? ''}
+                assistantText={finalAssistantReplyText(turn)}
               />
             )
           )}

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -764,6 +764,21 @@ export function materializeTurns(
 }
 
 /**
+ * The turn's final reply: the last answer step on the timeline. Intermediate
+ * steps (text emitted between tool calls) narrate the work in progress; the
+ * clipboard wants only the answer the turn settled on (#2407), not the
+ * `\n\n`-joined `assistant.text` aggregate. Falls back to the aggregate for
+ * turns with no timeline text entry.
+ */
+export function finalAssistantReplyText(turn: TurnViewModel): string {
+  for (let index = turn.timeline.length - 1; index >= 0; index -= 1) {
+    const item = turn.timeline[index];
+    if (item?.kind === "text" && item.text.length > 0) return item.text;
+  }
+  return turn.assistant?.text ?? "";
+}
+
+/**
  * Fold a background command's child tools (its `Read`s and `StopBackgroundTask`)
  * into the `Bash` that owns the run.
  *


### PR DESCRIPTION
Fixes #2407.

## Root cause

`TurnFooterActions`'s copy handler reads `turn.assistant.text` (`chat-turn.tsx`), which `materializeTurns` builds by `\n\n`-joining **every** assistant step of the turn (`materialize.ts` — one `AssistantMessage` row per model step, i.e. each burst of text between tool calls). On a multi-step turn, Copy Reply therefore copied all the intermediate narration concatenated with the final answer. The doc comment on the aggregate already flags it as a legacy field kept "for older consumers (copy, export, prompt rail)".

## Fix

New pure helper `finalAssistantReplyText(turn)` in `materialize.ts`: the last `kind: 'text'` entry on `turn.timeline` — the rendering source of truth — with a fallback to the aggregate for turns with no timeline text entry. The copy path is its only consumer.

Deliberately narrow:

- **The aggregate itself is unchanged.** Conversation export (`conversation-markdown.ts`) joins `StoredMessage`s independently and arguably wants the full narrative; the prompt rail keeps its preview semantics. Changing either is a separate product decision.
- Live streaming turns are unaffected: the live tail renders a footer placeholder, so the copy button only exists on settled turns, whose timeline text comes untruncated from storage.

## Tests

New `node:test` cases in `materialize.test.ts` over a three-step turn fixture:

- `finalAssistantReplyText` returns only the last answer step;
- the legacy aggregate still concatenates (pinning that this fix does not change other consumers);
- the fallback returns the aggregate when the timeline has no text entry.

`@maka/ui`: 254 pass / 0 fail. Full-repo typecheck and Biome: clean.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Ac5rv6WUKWtMZgQb5QPN16