### PR TITLE
fix(ui): keep model recovery controls enabled

### DIFF
--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2816,7 +2816,7 @@ function AppShellContent({
                   onNewChatThinkingLevelChange={(level) => setPendingNewChatThinkingLevel(level ?? null)}
                   onOpenModelSettings={() => openSettingsSection('models')}
                   noModelConnection={connections.length === 0}
-                  disabled={
+                  sendBlocked={
                     Boolean(workspaceReadinessRecovery) || sessionHealthNotice?.tone === 'destructive'
                   }
                   permissionMode={activePermissionMode}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -182,6 +182,11 @@ export const Composer = forwardRef<
   ComposerHandle,
   {
     disabled?: boolean;
+    /**
+     * Prevent submission while leaving the draft and recovery controls usable.
+     * Hosts use this for configuration failures that the model picker can fix.
+     */
+    sendBlocked?: boolean;
     hidden?: boolean;
     /**
      * When true, a turn is in flight — live output OR the pre-first-token wait.
@@ -982,7 +987,12 @@ export const Composer = forwardRef<
   );
 
   async function sendCurrent() {
-    if (props.disabled || sendPendingRef.current || importActionOwnerRef.current?.pending) return;
+    if (
+      props.disabled
+      || props.sendBlocked
+      || sendPendingRef.current
+      || importActionOwnerRef.current?.pending
+    ) return;
     // There is one authoritative draft: staged Skills and files serialize into
     // `text`. The optional metadata below is a send-time rendering snapshot of
     // file chips that still exist in the editor, not a second draft state.
@@ -1164,6 +1174,7 @@ export const Composer = forwardRef<
   const noModelConnection = props.noModelConnection === true;
   const sendDisabled =
     props.disabled ||
+    props.sendBlocked ||
     sendPending ||
     importActionBusy ||
     !text.trim() ||


### PR DESCRIPTION
## English

### Summary

Follow-up to #2490. The readiness hard-block was passed to the Composer through its broad `disabled` prop, which also disabled the model picker. An affected existing session therefore could not switch away from its invalid model.

This PR adds a narrow `sendBlocked` Composer state that:

- disables the Send button and guards keyboard/form submission;
- keeps draft editing, the model picker, and other recovery controls available;
- lets users switch an affected existing session to a valid model and recover without restarting.

### Verification

- `npm --workspace @maka/ui run build` — passed
- `npm --workspace @maka/desktop run build:main` — passed
- `npx biome check packages/ui/src/composer.tsx apps/desktop/src/renderer/app-shell.tsx` — passed
- `git diff --check upstream/main...HEAD` — passed
- rebuilt and launched the desktop app for manual verification

## 中文

### 概要

这是 #2490 的后续修复。就绪状态的硬阻塞此前通过 Composer 的通用 `disabled` 属性传入，导致模型选择器也被禁用。受影响的旧任务因此无法切换掉已经失效的模型。

本 PR 新增窄语义的 `sendBlocked` 状态：

- 禁用发送按钮，并拦截键盘/表单提交；
- 保留草稿编辑、模型选择器和其他自救入口；
- 用户可以在受影响的旧任务中切换到有效模型，无需重启即可恢复。

### 验证

- `npm --workspace @maka/ui run build`——通过
- `npm --workspace @maka/desktop run build:main`——通过
- `npx biome check packages/ui/src/composer.tsx apps/desktop/src/renderer/app-shell.tsx`——通过
- `git diff --check upstream/main...HEAD`——通过
- 已重新编译并启动桌面端进行人工验证