### PR TITLE
feat(core): define task submission readiness projection

### DIFF
--- a/packages/core/src/__tests__/task-submission-readiness.test.ts
+++ b/packages/core/src/__tests__/task-submission-readiness.test.ts
@@ -1,0 +1,114 @@
+import { describe, test } from 'node:test';
+import type { LlmConnection } from '../llm-connections.js';
+import {
+  deriveTaskSubmissionReadiness,
+  type DeriveTaskSubmissionReadinessInput,
+} from '../task-submission-readiness.js';
+import { expect } from '../test-helpers.js';
+
+describe('task submission readiness', () => {
+  test('projects a ready baseline from current authorities', () => {
+    const snapshot = deriveTaskSubmissionReadiness(readyInput());
+
+    expect(snapshot.state).toBe('ready');
+    expect(snapshot.blockers).toEqual([]);
+    expect(snapshot.dimensions.map((dimension) => dimension.id)).toEqual([
+      'runtime',
+      'model_target',
+      'workspace',
+    ]);
+  });
+
+  test('reuses connection readiness and routes an invalid model to its connection', () => {
+    const input = readyInput();
+    input.modelTarget.requestedModel = 'removed-model';
+    const snapshot = deriveTaskSubmissionReadiness(input);
+
+    expect(snapshot.state).toBe('repair_required');
+    expect(snapshot.blockers[0]).toEqual({
+      id: 'model_target',
+      state: 'repair_required',
+      authority: 'connection_readiness',
+      checkedAt: 90,
+      blockerCode: 'model_model_not_enabled',
+      repairTarget: { kind: 'connection', connectionSlug: 'provider' },
+    });
+  });
+
+  test('does not turn unresolved credentials into a confirmed repair failure', () => {
+    const input = readyInput();
+    input.modelTarget.hasSecret = undefined;
+    const snapshot = deriveTaskSubmissionReadiness(input);
+
+    expect(snapshot.state).toBe('unknown');
+    expect(snapshot.blockers[0]?.blockerCode).toBe('model_credentials_unknown');
+    expect(snapshot.blockers[0]?.repairTarget).toBe(undefined);
+  });
+
+  test('distinguishes unavailable runtime and workspace from repairable setup', () => {
+    const runtimeInput = readyInput();
+    runtimeInput.runtime.state = 'unavailable';
+    expect(deriveTaskSubmissionReadiness(runtimeInput).state).toBe('unavailable');
+
+    const workspaceInput = readyInput();
+    workspaceInput.workspace.state = 'missing';
+    const workspace = deriveTaskSubmissionReadiness(workspaceInput);
+    expect(workspace.state).toBe('repair_required');
+    expect(workspace.blockers[0]?.repairTarget).toEqual({ kind: 'workspace_picker' });
+  });
+
+  test('only requested capabilities participate in submission readiness', () => {
+    const input = readyInput();
+    input.capabilities = [
+      { id: 'computer_use', state: 'unavailable', checkedAt: 80 },
+      { id: 'git', state: 'ready', checkedAt: 81 },
+    ];
+
+    const ordinaryTask = deriveTaskSubmissionReadiness(input);
+    expect(ordinaryTask.state).toBe('ready');
+    expect(ordinaryTask.dimensions).toHaveLength(3);
+
+    input.requestedCapabilityIds = ['computer_use'];
+    const computerUseTask = deriveTaskSubmissionReadiness(input);
+    expect(computerUseTask.state).toBe('unavailable');
+    expect(computerUseTask.blockers[0]?.id).toBe('capability:computer_use');
+  });
+
+  test('treats a missing requested capability observation as unknown', () => {
+    const input = readyInput();
+    input.requestedCapabilityIds = ['git'];
+    const snapshot = deriveTaskSubmissionReadiness(input);
+
+    expect(snapshot.state).toBe('unknown');
+    expect(snapshot.blockers[0]?.blockerCode).toBe('capability_unknown');
+    expect(snapshot.blockers[0]?.repairTarget).toBe(undefined);
+  });
+});
+
+function readyInput(): DeriveTaskSubmissionReadinessInput {
+  return {
+    checkedAt: 100,
+    runtime: { state: 'ready', checkedAt: 95 },
+    modelTarget: {
+      connection: connection(),
+      hasSecret: true,
+      requestedModel: 'model-a',
+      checkedAt: 90,
+    },
+    workspace: { state: 'ready', checkedAt: 85 },
+  };
+}
+
+function connection(): LlmConnection {
+  return {
+    slug: 'provider',
+    name: 'Provider',
+    providerType: 'openai-compatible',
+    enabled: true,
+    defaultModel: 'model-a',
+    enabledModelIds: ['model-a'],
+    models: [{ id: 'model-a' }],
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -936,6 +936,21 @@ export {
   isHealthSignalStatus,
 } from './health.js';
 
+// task-submission-readiness.ts
+export type {
+  DeriveTaskSubmissionReadinessInput,
+  TaskSubmissionCapabilityReadinessInput,
+  TaskSubmissionReadinessBlockerCode,
+  TaskSubmissionReadinessDimension,
+  TaskSubmissionReadinessRepairTarget,
+  TaskSubmissionReadinessSnapshot,
+  TaskSubmissionReadinessState,
+} from './task-submission-readiness.js';
+export {
+  TASK_SUBMISSION_READINESS_STATES,
+  deriveTaskSubmissionReadiness,
+} from './task-submission-readiness.js';
+
 // search.ts (PR-SEARCH-0 + PR-SEARCH-1.5)
 export type {
   SearchError,

--- a/packages/core/src/task-submission-readiness.ts
+++ b/packages/core/src/task-submission-readiness.ts
@@ -1,0 +1,246 @@
+import { isConnectionReady, type ChatConfigurationReason } from './connection-readiness.js';
+import type { LlmConnection } from './llm-connections.js';
+
+export const TASK_SUBMISSION_READINESS_STATES = [
+  'ready',
+  'repair_required',
+  'unavailable',
+  'unknown',
+] as const;
+
+export type TaskSubmissionReadinessState = (typeof TASK_SUBMISSION_READINESS_STATES)[number];
+
+export type TaskSubmissionReadinessRepairTarget =
+  | { kind: 'provider_catalog' }
+  | { kind: 'connection'; connectionSlug: string }
+  | { kind: 'models' }
+  | { kind: 'runtime_restart' }
+  | { kind: 'workspace_picker' }
+  | { kind: 'system_permission'; permissionId: string }
+  | { kind: 'capability_settings'; capabilityId: string };
+
+export type TaskSubmissionReadinessBlockerCode =
+  | `model_${ChatConfigurationReason}`
+  | 'model_credentials_unknown'
+  | 'runtime_unavailable'
+  | 'runtime_unknown'
+  | 'workspace_missing'
+  | 'workspace_unavailable'
+  | 'workspace_unknown'
+  | 'capability_unavailable'
+  | 'capability_unknown';
+
+export interface TaskSubmissionReadinessDimension {
+  id: 'runtime' | 'model_target' | 'workspace' | `capability:${string}`;
+  state: TaskSubmissionReadinessState;
+  authority:
+    | 'runtime_host'
+    | 'connection_readiness'
+    | 'workspace_execution'
+    | 'capability_snapshot';
+  checkedAt: number;
+  blockerCode?: TaskSubmissionReadinessBlockerCode;
+  repairTarget?: TaskSubmissionReadinessRepairTarget;
+}
+
+export interface TaskSubmissionReadinessSnapshot {
+  checkedAt: number;
+  state: TaskSubmissionReadinessState;
+  dimensions: TaskSubmissionReadinessDimension[];
+  blockers: TaskSubmissionReadinessDimension[];
+}
+
+export interface TaskSubmissionCapabilityReadinessInput {
+  id: string;
+  state: 'ready' | 'unavailable' | 'unknown';
+  checkedAt: number;
+  repairTarget?: TaskSubmissionReadinessRepairTarget;
+}
+
+export interface DeriveTaskSubmissionReadinessInput {
+  checkedAt: number;
+  runtime: {
+    state: 'ready' | 'starting' | 'unavailable' | 'unknown';
+    checkedAt: number;
+  };
+  modelTarget: {
+    connection?: LlmConnection;
+    hasSecret?: boolean;
+    requestedModel?: string;
+    checkedAt: number;
+  };
+  workspace: {
+    state: 'ready' | 'missing' | 'unavailable' | 'unknown';
+    checkedAt: number;
+  };
+  capabilities?: ReadonlyArray<TaskSubmissionCapabilityReadinessInput>;
+  requestedCapabilityIds?: ReadonlyArray<string>;
+}
+
+/**
+ * Pure task-submission projection over current authorities. Historical health
+ * observations are deliberately not an input: callers must not turn an old
+ * runtime probe into a current send gate.
+ */
+export function deriveTaskSubmissionReadiness(
+  input: DeriveTaskSubmissionReadinessInput,
+): TaskSubmissionReadinessSnapshot {
+  const dimensions = [
+    runtimeDimension(input.runtime),
+    modelTargetDimension(input.modelTarget),
+    workspaceDimension(input.workspace),
+    ...requestedCapabilityDimensions(
+      input.capabilities ?? [],
+      input.requestedCapabilityIds ?? [],
+      input.checkedAt,
+    ),
+  ];
+  const blockers = dimensions.filter((dimension) => dimension.state !== 'ready');
+  return {
+    checkedAt: input.checkedAt,
+    state: aggregateReadinessState(blockers),
+    dimensions,
+    blockers,
+  };
+}
+
+function runtimeDimension(
+  runtime: DeriveTaskSubmissionReadinessInput['runtime'],
+): TaskSubmissionReadinessDimension {
+  if (runtime.state === 'ready') {
+    return dimension('runtime', 'ready', 'runtime_host', runtime.checkedAt);
+  }
+  if (runtime.state === 'unavailable') {
+    return dimension('runtime', 'unavailable', 'runtime_host', runtime.checkedAt, {
+      blockerCode: 'runtime_unavailable',
+      repairTarget: { kind: 'runtime_restart' },
+    });
+  }
+  return dimension('runtime', 'unknown', 'runtime_host', runtime.checkedAt, {
+    blockerCode: 'runtime_unknown',
+  });
+}
+
+function modelTargetDimension(
+  target: DeriveTaskSubmissionReadinessInput['modelTarget'],
+): TaskSubmissionReadinessDimension {
+  if (!target.connection) {
+    return dimension('model_target', 'repair_required', 'connection_readiness', target.checkedAt, {
+      blockerCode: 'model_missing_default_connection',
+      repairTarget: { kind: 'provider_catalog' },
+    });
+  }
+
+  const verdict = isConnectionReady({
+    connection: target.connection,
+    hasSecret: target.hasSecret === true,
+    requestedModel: target.requestedModel,
+  });
+  if (verdict.ready) {
+    return dimension('model_target', 'ready', 'connection_readiness', target.checkedAt);
+  }
+  if (verdict.reason === 'missing_api_key' && target.hasSecret === undefined) {
+    return dimension('model_target', 'unknown', 'connection_readiness', target.checkedAt, {
+      blockerCode: 'model_credentials_unknown',
+    });
+  }
+  return dimension('model_target', 'repair_required', 'connection_readiness', target.checkedAt, {
+    blockerCode: `model_${verdict.reason}`,
+    repairTarget: modelRepairTarget(verdict.reason, target.connection.slug),
+  });
+}
+
+function workspaceDimension(
+  workspace: DeriveTaskSubmissionReadinessInput['workspace'],
+): TaskSubmissionReadinessDimension {
+  if (workspace.state === 'ready') {
+    return dimension('workspace', 'ready', 'workspace_execution', workspace.checkedAt);
+  }
+  if (workspace.state === 'missing') {
+    return dimension('workspace', 'repair_required', 'workspace_execution', workspace.checkedAt, {
+      blockerCode: 'workspace_missing',
+      repairTarget: { kind: 'workspace_picker' },
+    });
+  }
+  if (workspace.state === 'unavailable') {
+    return dimension('workspace', 'unavailable', 'workspace_execution', workspace.checkedAt, {
+      blockerCode: 'workspace_unavailable',
+      repairTarget: { kind: 'workspace_picker' },
+    });
+  }
+  return dimension('workspace', 'unknown', 'workspace_execution', workspace.checkedAt, {
+    blockerCode: 'workspace_unknown',
+  });
+}
+
+function requestedCapabilityDimensions(
+  capabilities: ReadonlyArray<TaskSubmissionCapabilityReadinessInput>,
+  requestedIds: ReadonlyArray<string>,
+  checkedAt: number,
+): TaskSubmissionReadinessDimension[] {
+  const byId = new Map(capabilities.map((capability) => [capability.id, capability]));
+  return [...new Set(requestedIds)].map((id) => {
+    const capability = byId.get(id);
+    if (capability?.state === 'ready') {
+      return dimension(`capability:${id}`, 'ready', 'capability_snapshot', capability.checkedAt);
+    }
+    const state = capability?.state === 'unavailable' ? 'unavailable' : 'unknown';
+    return dimension(
+      `capability:${id}`,
+      state,
+      'capability_snapshot',
+      capability?.checkedAt ?? checkedAt,
+      {
+        blockerCode: state === 'unavailable' ? 'capability_unavailable' : 'capability_unknown',
+        ...(state === 'unavailable'
+          ? {
+              repairTarget: capability?.repairTarget ?? {
+                kind: 'capability_settings',
+                capabilityId: id,
+              },
+            }
+          : {}),
+      },
+    );
+  });
+}
+
+function aggregateReadinessState(
+  blockers: ReadonlyArray<TaskSubmissionReadinessDimension>,
+): TaskSubmissionReadinessState {
+  if (blockers.some((blocker) => blocker.state === 'unavailable')) return 'unavailable';
+  if (blockers.some((blocker) => blocker.state === 'repair_required')) return 'repair_required';
+  if (blockers.some((blocker) => blocker.state === 'unknown')) return 'unknown';
+  return 'ready';
+}
+
+function modelRepairTarget(
+  reason: ChatConfigurationReason,
+  connectionSlug: string,
+): TaskSubmissionReadinessRepairTarget {
+  switch (reason) {
+    case 'missing_default_connection':
+    case 'connection_missing':
+    case 'fake_backend':
+      return { kind: 'provider_catalog' };
+    case 'missing_model':
+    case 'empty_model_list':
+    case 'model_not_enabled':
+    case 'model_not_chat_capable':
+      return { kind: 'connection', connectionSlug };
+    case 'connection_disabled':
+    case 'missing_api_key':
+    case 'oauth_subscription_not_wired':
+      return { kind: 'connection', connectionSlug };
+  }
+}
+
+function dimension(
+  id: TaskSubmissionReadinessDimension['id'],
+  state: TaskSubmissionReadinessState,
+  authority: TaskSubmissionReadinessDimension['authority'],
+  checkedAt: number,
+  blocker?: Pick<TaskSubmissionReadinessDimension, 'blockerCode' | 'repairTarget'>,
+): TaskSubmissionReadinessDimension {
+  return { id, state, authority, checkedAt, ...blocker };
+}


### PR DESCRIPTION
## English

### Summary

First implementation slice of #2497 under the product roadmap #2469. This PR defines a shared, pure, scope-aware task-submission readiness contract in `@maka/core`.

It projects current authoritative inputs into:

- one overall state: `ready`, `repair_required`, `unavailable`, or `unknown`;
- ordered Runtime, model-target, workspace, and requested-capability dimensions;
- stable machine-readable blocker codes;
- non-localized repair targets for later Desktop and CLI consumers;
- authority and observation timestamps for each dimension.

Key behavior:

- model readiness delegates to the existing `isConnectionReady` authority;
- optional capabilities participate only when explicitly requested by the task;
- unrelated degraded capabilities do not block ordinary work;
- unknown/loading facts stay distinct from confirmed repair failures and do not invent repair actions;
- historical Health Snapshot observations are deliberately not accepted as inputs, so an old runtime probe cannot become a current send gate.

Refs #2497
Refs #2469

### Verification

- `npm --workspace @maka/core run clean` — passed
- `npm --workspace @maka/core run build` — passed
- `node --test packages/core/dist/__tests__/task-submission-readiness.test.js` — 6/6 passed
- `npx biome check` on all changed files — passed
- `git diff --check` — passed

### Scope

This PR does not add persistence, IPC adapters, Desktop/CLI UI, or a new Health Center. Those remain separate reversible slices in #2497.

## 中文

### 概要

这是产品路线 #2469 下子任务 #2497 的第一个实现切片。本 PR 在 `@maka/core` 中定义共享、纯函数、按任务能力范围判断的提交就绪契约。

投影结果包括：

- `ready`、`repair_required`、`unavailable`、`unknown` 四种整体状态；
- 有序的 Runtime、模型目标、工作区和按需能力维度；
- 稳定的机器可读 blocker code；
- 供后续 Desktop/CLI 消费的非本地化 repair target；
- 每个维度的权威来源和观察时间。

关键行为：

- 模型就绪判断复用现有 `isConnectionReady` 权威；
- 可选能力只有在任务明确请求时才参与判断；
- 无关能力降级不会阻塞普通任务；
- unknown/loading 与已确认的修复错误分开，未知状态不会虚构修复动作；
- 契约刻意不接受历史 Health Snapshot 观察，因此旧 runtime probe 不会变成当前发送门禁。

关联 #2497
关联 #2469

### 验证

- `npm --workspace @maka/core run clean`——通过
- `npm --workspace @maka/core run build`——通过
- `node --test packages/core/dist/__tests__/task-submission-readiness.test.js`——6/6 通过
- 对全部改动文件运行 `npx biome check`——通过
- `git diff --check`——通过

### 范围

本 PR 不包含持久化、IPC 适配、Desktop/CLI UI 或新的健康中心；这些将在 #2497 中以独立、可回退的切片继续交付。