### PR TITLE
feat: add external session import foundation

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -69,6 +69,7 @@
     "./agent-graph-supervisor-wake": "./dist/agent-graph-supervisor-wake.js",
     "./task-ledger": "./dist/task-ledger.js",
     "./foreign-session": "./dist/foreign-session.js",
+    "./external-session": "./dist/external-session.js",
     "./deep-research-run": "./dist/deep-research-run.js",
     "./deep-research-client-progress": "./dist/deep-research-client-progress.js",
     "./daily-review": "./dist/daily-review.js",

--- a/packages/core/src/__tests__/external-session.test.ts
+++ b/packages/core/src/__tests__/external-session.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  ExternalSessionAdapterRegistry,
+  type ExternalSessionAdapter,
+} from '../external-session.js';
+
+describe('ExternalSessionAdapterRegistry', () => {
+  test('registers and resolves adapters by their source id', () => {
+    const codex = fakeAdapter('codex');
+    const registry = new ExternalSessionAdapterRegistry([codex]);
+
+    assert.equal(registry.get('codex'), codex);
+    assert.equal(registry.require('codex'), codex);
+    assert.deepEqual(registry.list(), [codex]);
+  });
+
+  test('rejects duplicate and empty adapter ids', () => {
+    assert.throws(
+      () => new ExternalSessionAdapterRegistry([fakeAdapter('codex'), fakeAdapter('codex')]),
+      /already registered/,
+    );
+    assert.throws(
+      () => new ExternalSessionAdapterRegistry([fakeAdapter('  ')]),
+      /must not be empty/,
+    );
+  });
+
+  test('fails explicitly when an adapter is not registered', () => {
+    const registry = new ExternalSessionAdapterRegistry();
+    assert.throws(() => registry.require('codex'), /not registered/);
+  });
+});
+
+function fakeAdapter(id: string): ExternalSessionAdapter {
+  return {
+    id,
+    detect: async () => true,
+    listSessions: async () => [],
+    readSession: async (sourceSessionId) => ({
+      sourceSessionId,
+      metadata: { name: sourceSessionId, cwd: '/repo' },
+      messages: [],
+    }),
+  };
+}

--- a/packages/core/src/external-session.ts
+++ b/packages/core/src/external-session.ts
@@ -1,0 +1,78 @@
+import type { StoredMessage } from './session.js';
+
+/** Stable identifier for one external Agent integration, for example `codex`. */
+export type ExternalAgentId = string;
+
+export interface ExternalSessionQuery {
+  cwd?: string;
+  includeArchived?: boolean;
+}
+
+/** Lightweight source-native identity used by session pickers and import commands. */
+export interface ExternalSessionSummary {
+  id: string;
+  name: string;
+  cwd: string;
+  createdAt?: number;
+  updatedAt?: number;
+  archived?: boolean;
+}
+
+/**
+ * An external session after its source-specific format has been converted to
+ * Maka's existing raw Session representation.
+ *
+ * There is intentionally no intermediate external-message model here. Each
+ * adapter owns its source format and emits canonical Maka StoredMessages.
+ */
+export interface ExternalMakaSession {
+  sourceSessionId: string;
+  metadata: {
+    name: string;
+    cwd: string;
+  };
+  messages: readonly StoredMessage[];
+}
+
+/** Read-only, source-specific conversion boundary for one external Agent. */
+export interface ExternalSessionAdapter {
+  readonly id: ExternalAgentId;
+
+  detect(): Promise<boolean>;
+
+  listSessions(query?: ExternalSessionQuery): Promise<readonly ExternalSessionSummary[]>;
+
+  readSession(sessionId: string): Promise<ExternalMakaSession>;
+}
+
+export class ExternalSessionAdapterRegistry {
+  private readonly adapters = new Map<ExternalAgentId, ExternalSessionAdapter>();
+
+  constructor(adapters: readonly ExternalSessionAdapter[] = []) {
+    for (const adapter of adapters) this.register(adapter);
+  }
+
+  register(adapter: ExternalSessionAdapter): void {
+    if (adapter.id.trim().length === 0) {
+      throw new Error('External Session adapter id must not be empty');
+    }
+    if (this.adapters.has(adapter.id)) {
+      throw new Error(`External Session adapter is already registered: ${adapter.id}`);
+    }
+    this.adapters.set(adapter.id, adapter);
+  }
+
+  get(adapterId: ExternalAgentId): ExternalSessionAdapter | undefined {
+    return this.adapters.get(adapterId);
+  }
+
+  require(adapterId: ExternalAgentId): ExternalSessionAdapter {
+    const adapter = this.get(adapterId);
+    if (!adapter) throw new Error(`External Session adapter is not registered: ${adapterId}`);
+    return adapter;
+  }
+
+  list(): readonly ExternalSessionAdapter[] {
+    return [...this.adapters.values()];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,7 @@ export * from './interaction.js';
 export * from './project.js';
 export * from './subagent-workspace.js';
 export * from './pet.js';
+export * from './external-session.js';
 
 // events.ts
 export type {

--- a/packages/storage/src/__tests__/external-session-importer.test.ts
+++ b/packages/storage/src/__tests__/external-session-importer.test.ts
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { StoredMessage } from '@maka/core';
+import {
+  ExternalSessionAdapterRegistry,
+  type ExternalSessionAdapter,
+} from '@maka/core/external-session';
+import {
+  ExternalSessionImporter,
+  type ExternalSessionImportTarget,
+} from '../external-session-importer.js';
+import { createSessionStore } from '../session-store.js';
+
+describe('ExternalSessionImporter', () => {
+  test('persists adapter output as native Maka StoredMessages', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-external-session-import-'));
+    const sessions = createSessionStore(root);
+    const messages: StoredMessage[] = [
+      { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 10, text: 'fix the parser' },
+      {
+        type: 'assistant',
+        id: 'assistant-1',
+        turnId: 'turn-1',
+        ts: 20,
+        text: 'done',
+        modelId: 'external-model',
+      },
+    ];
+    const adapter = fakeAdapter({
+      metadata: { name: 'Imported parser work', cwd: '/external/repo' },
+      messages,
+    });
+    const importer = new ExternalSessionImporter(
+      new ExternalSessionAdapterRegistry([adapter]),
+      sessions,
+    );
+
+    try {
+      const header = await importer.import({
+        adapterId: 'fake',
+        sourceSessionId: 'source-1',
+        target: target(),
+      });
+
+      assert.equal(header.name, 'Imported parser work');
+      assert.equal(header.cwd, '/external/repo');
+      assert.equal(header.model, 'maka-model');
+      assert.equal(header.connectionLocked, true);
+      assert.deepEqual(await sessions.readMessages(header.id), messages);
+    } finally {
+      await sessions.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('allows the Maka target to override imported name and cwd', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-external-session-target-'));
+    const sessions = createSessionStore(root);
+    const importer = new ExternalSessionImporter(
+      new ExternalSessionAdapterRegistry([
+        fakeAdapter({ metadata: { name: 'Source name', cwd: '/source' }, messages: [] }),
+      ]),
+      sessions,
+    );
+
+    try {
+      const header = await importer.import({
+        adapterId: 'fake',
+        sourceSessionId: 'source-1',
+        target: target({ name: 'Maka name', cwd: '/target' }),
+      });
+
+      assert.equal(header.name, 'Maka name');
+      assert.equal(header.cwd, '/target');
+    } finally {
+      await sessions.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects invalid adapter messages without exposing a partial Session', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-external-session-invalid-'));
+    const sessions = createSessionStore(root);
+    const adapter = fakeAdapter({
+      metadata: { name: 'Invalid import', cwd: '/repo' },
+      messages: [{ type: 'assistant' } as unknown as StoredMessage],
+    });
+    const importer = new ExternalSessionImporter(
+      new ExternalSessionAdapterRegistry([adapter]),
+      sessions,
+    );
+
+    try {
+      await assert.rejects(
+        importer.import({
+          adapterId: 'fake',
+          sourceSessionId: 'source-1',
+          target: target(),
+        }),
+        /Invalid stored message schema/,
+      );
+      assert.deepEqual(await sessions.listHeaders(), []);
+    } finally {
+      await sessions.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function target(overrides: Partial<ExternalSessionImportTarget> = {}): ExternalSessionImportTarget {
+  return {
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    model: 'maka-model',
+    permissionMode: 'ask',
+    ...overrides,
+  };
+}
+
+function fakeAdapter(
+  session: Pick<
+    Awaited<ReturnType<ExternalSessionAdapter['readSession']>>,
+    'metadata' | 'messages'
+  >,
+): ExternalSessionAdapter {
+  return {
+    id: 'fake',
+    detect: async () => true,
+    listSessions: async () => [],
+    readSession: async (sourceSessionId) => ({ sourceSessionId, ...session }),
+  };
+}

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -316,6 +316,8 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
       run(() => conversationOperationalStateStore.purge(sessionId)),
     sessionStore: {
       create: (input, initialBoundary) => run(() => sessionStore.create(input, initialBoundary)),
+      createImportedSession: (input, messages) =>
+        run(() => sessionStore.createImportedSession(input, messages)),
       probeStableSessionCreate: (sessionId, requestFingerprint) =>
         run(() => sessionStore.probeStableSessionCreate(sessionId, requestFingerprint)),
       createStableSession: (request, initialBoundary) =>

--- a/packages/storage/src/external-session-importer.ts
+++ b/packages/storage/src/external-session-importer.ts
@@ -1,0 +1,39 @@
+import type { CreateSessionInput, SessionHeader } from '@maka/core';
+import type { ExternalAgentId, ExternalSessionAdapterRegistry } from '@maka/core/external-session';
+import type { SessionAuthorityStore } from './session-store.js';
+
+export type ExternalSessionImportTarget = Omit<CreateSessionInput, 'cwd' | 'name'> & {
+  cwd?: string;
+  name?: string;
+};
+
+export interface ExternalSessionImportRequest {
+  adapterId: ExternalAgentId;
+  sourceSessionId: string;
+  target: ExternalSessionImportTarget;
+}
+
+/**
+ * Converts no formats itself. The selected adapter returns Maka StoredMessages;
+ * the importer only chooses target Session settings and commits them atomically.
+ */
+export class ExternalSessionImporter {
+  constructor(
+    private readonly adapters: ExternalSessionAdapterRegistry,
+    private readonly sessions: Pick<SessionAuthorityStore, 'createImportedSession'>,
+  ) {}
+
+  async import(request: ExternalSessionImportRequest): Promise<SessionHeader> {
+    const adapter = this.adapters.require(request.adapterId);
+    const external = await adapter.readSession(request.sourceSessionId);
+
+    return this.sessions.createImportedSession(
+      {
+        ...request.target,
+        cwd: request.target.cwd ?? external.metadata.cwd,
+        name: request.target.name ?? external.metadata.name,
+      },
+      external.messages,
+    );
+  }
+}

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -20,6 +20,7 @@ import {
 } from './operational-state-store.js';
 import {
   DEFAULT_SESSION_NAME,
+  decodeStoredMessageForRecovery,
   deriveTurnRecords,
   isCollaborationMode,
   isOrchestrationMode,
@@ -181,6 +182,11 @@ export interface SessionStore {
 }
 
 export interface SessionAuthorityStore extends SessionStore {
+  /** Atomically create a Session from already-converted Maka raw messages. */
+  createImportedSession(
+    input: CreateSessionInput,
+    messages: readonly StoredMessage[],
+  ): Promise<SessionHeader>;
   createSubagent(
     input: CreateSessionInput,
     initialBoundary?: ExecutionBoundary,
@@ -349,6 +355,30 @@ class SqliteSessionStore implements SessionAuthorityStore {
     return (
       await this.metadata.create(buildSessionHeader(this.workspaceRoot, input), initialBoundary)
     ).header;
+  }
+
+  async createImportedSession(
+    input: CreateSessionInput,
+    messages: readonly StoredMessage[],
+  ): Promise<SessionHeader> {
+    await this.ensureReady();
+    assertNoConversationCopyMetadata(input);
+    if (input.subagentSpawn) {
+      throw new Error('Subagent spawn metadata requires createSubagent()');
+    }
+    const canonicalMessages = messages.map((message) =>
+      decodeStoredMessageForRecovery(JSON.parse(JSON.stringify(message)) as unknown),
+    );
+    const header = buildSessionHeader(this.workspaceRoot, input);
+    const outcome = await this.metadata.importSession(
+      header,
+      canonicalMessages,
+      projectSessionCatalogMessages(canonicalMessages),
+    );
+    if (outcome !== 'imported') {
+      throw new Error(`Generated Session id already exists: ${header.id}`);
+    }
+    return (await this.metadata.read(header.id)).header;
   }
 
   async probeStableSessionCreate(


### PR DESCRIPTION
## Summary

- define a source-specific `ExternalSessionAdapter` contract that converts native records directly to Maka `StoredMessage[]`
- add an adapter registry and source-agnostic importer without introducing a cleaner, external-message IR, or context synthesis layer
- validate converted messages and atomically persist the Session header, raw messages, and catalog projection
- keep the importer internal for now; this PR adds no IPC, CLI, HTTP, or renderer entry point

Refs #2499

## Verification

- `npx biome check <changed TypeScript files>`
- `npm --workspace @maka/core run typecheck`
- `npm --workspace @maka/storage run typecheck`
- Node 24 core suite: 788 passed, 0 failed
- focused adapter/importer/SessionStore suite: 10 passed, 0 failed
- Node 24 storage suite: 756 passed, 12 skipped; one unrelated `artifact-writer-lock` concurrency test timed out while waiting for its lock-holder fixture and passed when rerun alone

## Review focus

This is Phase 1 of #2499. The intended boundary is deliberately small:

```text
external source -> source adapter -> Maka StoredMessage[] -> generic importer -> SessionStore
```

Source-format parsing belongs entirely to adapters. Codex format support and a user-facing import workflow remain separate follow-up PRs.

