### PR TITLE
feat: add Codex session adapter

### DIFF
--- a/packages/storage/src/__tests__/codex-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/codex-session-adapter.test.ts
@@ -1,0 +1,355 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { decodeStoredMessageForRecovery } from '@maka/core';
+import { CodexSessionAdapter } from '../codex-session-adapter.js';
+import { createExternalSessionAdapterRegistry } from '../external-session-adapters.js';
+
+const CURRENT_FIXTURE = fixturePath('codex-rollout-v0.144.jsonl');
+
+describe('CodexSessionAdapter', () => {
+  test('lists active and archived root Sessions from the newest Codex state database', async () => {
+    await withCodexHome(async (codexHome) => {
+      const activePath = await seedFixtureRollout(codexHome, 'codex-session-1', false);
+      const archivedPath = await seedMinimalRollout(
+        codexHome,
+        'codex-session-archived',
+        true,
+        '/workspace/archive',
+        'Archived task',
+      );
+      await seedStateDatabase(codexHome, [
+        {
+          id: 'codex-session-1',
+          rolloutPath: activePath,
+          cwd: '/workspace/project',
+          name: 'Named Codex thread',
+          createdAtMs: 1000,
+          updatedAtMs: 3000,
+          archived: false,
+          source: 'cli',
+        },
+        {
+          id: 'codex-session-archived',
+          rolloutPath: archivedPath,
+          cwd: '/workspace/archive',
+          name: 'Archived Codex thread',
+          createdAtMs: 1500,
+          updatedAtMs: 2000,
+          archived: true,
+          source: 'vscode',
+        },
+        {
+          id: 'codex-subagent',
+          rolloutPath: activePath,
+          cwd: '/workspace/project',
+          name: 'Internal child',
+          createdAtMs: 2000,
+          updatedAtMs: 4000,
+          archived: false,
+          source: '{"subagent":{"thread_spawn":{"parent_thread_id":"parent"}}}',
+        },
+      ]);
+
+      const adapter = new CodexSessionAdapter({ codexHome });
+      assert.equal(await adapter.detect(), true);
+      assert.deepEqual(await adapter.listSessions(), [
+        {
+          id: 'codex-session-1',
+          name: 'Named Codex thread',
+          cwd: '/workspace/project',
+          createdAt: 1_000_000,
+          updatedAt: 3_000_000,
+          archived: false,
+        },
+      ]);
+      assert.deepEqual(
+        (await adapter.listSessions({ includeArchived: true })).map((session) => session.id),
+        ['codex-session-1', 'codex-session-archived'],
+      );
+      assert.deepEqual(
+        await adapter.listSessions({ includeArchived: true, cwd: '/workspace/archive/' }),
+        [
+          {
+            id: 'codex-session-archived',
+            name: 'Archived Codex thread',
+            cwd: '/workspace/archive',
+            createdAt: 1_500_000,
+            updatedAt: 2_000_000,
+            archived: true,
+          },
+        ],
+      );
+    });
+  });
+
+  test('converts Codex presentation events and raw tool items without duplicates', async () => {
+    await withCodexHome(async (codexHome) => {
+      await seedFixtureRollout(codexHome, 'codex-session-1', false);
+      const adapter = new CodexSessionAdapter({ codexHome });
+
+      assert.deepEqual(await adapter.listSessions(), [
+        {
+          id: 'codex-session-1',
+          name: 'Fix the parser',
+          cwd: '/workspace/project',
+          createdAt: Date.parse('2026-08-08T00:00:00.000Z'),
+          updatedAt: await rolloutMtime(codexHome, 'codex-session-1', false),
+          archived: false,
+        },
+      ]);
+
+      const session = await adapter.readSession('codex-session-1');
+      assert.deepEqual(session.metadata, {
+        name: 'Fix the parser',
+        cwd: '/workspace/project',
+      });
+      assert.equal(session.messages.length, 9);
+      for (const message of session.messages) {
+        assert.deepEqual(decodeStoredMessageForRecovery(message), message);
+      }
+
+      assert.deepEqual(session.messages[0], {
+        type: 'user',
+        id: 'codex-user-1',
+        turnId: 'codex-turn-1',
+        ts: Date.parse('2026-08-08T00:00:02.000Z'),
+        text: 'Fix the parser',
+      });
+      assert.deepEqual(session.messages[1], {
+        type: 'assistant',
+        id: 'codex-codex-session-1-reasoning-7',
+        turnId: 'codex-turn-1',
+        ts: Date.parse('2026-08-08T00:00:03.000Z'),
+        text: '',
+        thinking: { text: 'Inspect the failing path.' },
+        contentOrder: ['thinking'],
+        modelId: 'gpt-codex-test',
+      });
+      assert.equal(session.messages[2]?.type, 'assistant');
+      assert.equal(session.messages[2]?.text, 'I found the issue.');
+      assert.deepEqual(session.messages[3], {
+        type: 'tool_call',
+        id: 'call-wait-1',
+        turnId: 'codex-turn-1',
+        ts: Date.parse('2026-08-08T00:00:05.000Z'),
+        toolName: 'wait',
+        args: { milliseconds: 25 },
+      });
+      assert.deepEqual(session.messages[4], {
+        type: 'tool_result',
+        id: 'function-output-1',
+        turnId: 'codex-turn-1',
+        ts: Date.parse('2026-08-08T00:00:06.000Z'),
+        toolUseId: 'call-wait-1',
+        isError: false,
+        content: { kind: 'text', text: 'waited' },
+      });
+      assert.equal(session.messages[5]?.type, 'tool_call');
+      assert.equal(session.messages[5]?.args, '*** Begin Patch');
+      assert.deepEqual(
+        session.messages[6]?.type === 'tool_result' ? session.messages[6].content : undefined,
+        { kind: 'text', text: 'Done\n1 file changed' },
+      );
+      assert.equal(session.messages[7]?.type, 'system_note');
+      assert.equal(session.messages[8]?.type, 'turn_state');
+      assert.equal(session.messages[8]?.status, 'completed');
+    });
+  });
+
+  test('rejects corrupt interior records, tolerates a torn tail, and bounds full reads', async () => {
+    await withCodexHome(async (codexHome) => {
+      const fixture = await readFile(CURRENT_FIXTURE, 'utf8');
+      const corruptId = 'codex-corrupt';
+      await seedRawRollout(
+        codexHome,
+        corruptId,
+        fixture
+          .replaceAll('codex-session-1', corruptId)
+          .replace(
+            '\n{"timestamp":"2026-08-08T00:00:01.000Z"',
+            '\nnot-json\n{"timestamp":"2026-08-08T00:00:01.000Z"',
+          ),
+      );
+      const tornId = 'codex-torn';
+      await seedRawRollout(
+        codexHome,
+        tornId,
+        `${fixture.replaceAll('codex-session-1', tornId)}{"timestamp"`,
+      );
+
+      const adapter = new CodexSessionAdapter({ codexHome });
+      await assert.rejects(adapter.readSession(corruptId), /Invalid Codex rollout.*line 2/);
+      assert.equal((await adapter.readSession(tornId)).messages.length, 9);
+
+      const bounded = new CodexSessionAdapter({ codexHome, maxRolloutBytes: 100 });
+      await assert.rejects(bounded.readSession(tornId), /exceeds 100 bytes/);
+    });
+  });
+
+  test('never follows a state database rollout path outside CODEX_HOME', async () => {
+    const outside = await mkdtemp(join(tmpdir(), 'maka-codex-outside-'));
+    try {
+      await withCodexHome(async (codexHome) => {
+        const id = 'codex-escaped';
+        const escapedPath = join(outside, `rollout-2026-08-08T00-00-00-${id}.jsonl`);
+        await writeFile(escapedPath, minimalRollout(id, '/outside', 'outside'));
+        await seedStateDatabase(codexHome, [
+          {
+            id,
+            rolloutPath: escapedPath,
+            cwd: '/outside',
+            name: 'Escaped',
+            createdAtMs: 1000,
+            updatedAtMs: 2000,
+            archived: false,
+            source: 'cli',
+          },
+        ]);
+
+        const adapter = new CodexSessionAdapter({ codexHome });
+        assert.deepEqual(await adapter.listSessions(), []);
+        await assert.rejects(adapter.readSession(id), /not found/);
+      });
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  test('is registered by the internal default registry', async () => {
+    await withCodexHome(async (codexHome) => {
+      const registry = createExternalSessionAdapterRegistry({ codex: { codexHome } });
+      assert.equal(registry.require('codex').id, 'codex');
+    });
+  });
+});
+
+function fixturePath(name: string): string {
+  return fileURLToPath(new URL(`../../src/__tests__/fixtures/${name}`, import.meta.url));
+}
+
+async function withCodexHome(run: (codexHome: string) => Promise<void>): Promise<void> {
+  const codexHome = await mkdtemp(join(tmpdir(), 'maka-codex-adapter-'));
+  try {
+    await run(codexHome);
+  } finally {
+    await rm(codexHome, { recursive: true, force: true });
+  }
+}
+
+async function seedFixtureRollout(
+  codexHome: string,
+  sessionId: string,
+  archived: boolean,
+): Promise<string> {
+  const fixture = (await readFile(CURRENT_FIXTURE, 'utf8')).replaceAll(
+    'codex-session-1',
+    sessionId,
+  );
+  return seedRawRollout(codexHome, sessionId, fixture, archived);
+}
+
+async function seedMinimalRollout(
+  codexHome: string,
+  sessionId: string,
+  archived: boolean,
+  cwd: string,
+  userText: string,
+): Promise<string> {
+  return seedRawRollout(codexHome, sessionId, minimalRollout(sessionId, cwd, userText), archived);
+}
+
+async function seedRawRollout(
+  codexHome: string,
+  sessionId: string,
+  content: string,
+  archived = false,
+): Promise<string> {
+  const directory = archived
+    ? join(codexHome, 'archived_sessions')
+    : join(codexHome, 'sessions', '2026', '08', '08');
+  await mkdir(directory, { recursive: true });
+  const path = join(directory, `rollout-2026-08-08T00-00-00-${sessionId}.jsonl`);
+  await writeFile(path, content);
+  return path;
+}
+
+function minimalRollout(sessionId: string, cwd: string, userText: string): string {
+  return [
+    JSON.stringify({
+      timestamp: '2026-08-08T00:00:00.000Z',
+      type: 'session_meta',
+      payload: { session_id: sessionId, id: sessionId, cwd, source: 'cli' },
+    }),
+    JSON.stringify({
+      timestamp: '2026-08-08T00:00:01.000Z',
+      type: 'event_msg',
+      payload: { type: 'user_message', message: userText },
+    }),
+    '',
+  ].join('\n');
+}
+
+interface StateRow {
+  id: string;
+  rolloutPath: string;
+  cwd: string;
+  name: string;
+  createdAtMs: number;
+  updatedAtMs: number;
+  archived: boolean;
+  source: string;
+}
+
+async function seedStateDatabase(codexHome: string, rows: readonly StateRow[]): Promise<void> {
+  const { DatabaseSync } = await import('node:sqlite');
+  const database = new DatabaseSync(join(codexHome, 'state_5.sqlite'));
+  try {
+    database.exec(`
+      CREATE TABLE threads (
+        id TEXT PRIMARY KEY,
+        rollout_path TEXT NOT NULL,
+        cwd TEXT,
+        name TEXT,
+        created_at_ms INTEGER,
+        updated_at_ms INTEGER,
+        archived INTEGER,
+        source TEXT
+      )
+    `);
+    const insert = database.prepare(`
+      INSERT INTO threads (
+        id, rollout_path, cwd, name, created_at_ms, updated_at_ms, archived, source
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    for (const row of rows) {
+      insert.run(
+        row.id,
+        row.rolloutPath,
+        row.cwd,
+        row.name,
+        row.createdAtMs,
+        row.updatedAtMs,
+        row.archived ? 1 : 0,
+        row.source,
+      );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function rolloutMtime(
+  codexHome: string,
+  sessionId: string,
+  archived: boolean,
+): Promise<number> {
+  const { stat } = await import('node:fs/promises');
+  const directory = archived
+    ? join(codexHome, 'archived_sessions')
+    : join(codexHome, 'sessions', '2026', '08', '08');
+  return (await stat(join(directory, `rollout-2026-08-08T00-00-00-${sessionId}.jsonl`))).mtimeMs;
+}

--- a/packages/storage/src/__tests__/codex-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/codex-session-adapter.test.ts
@@ -160,6 +160,54 @@ describe('CodexSessionAdapter', () => {
     });
   });
 
+  test('imports terminal errors as failed without failing turns on non-terminal errors', async () => {
+    await withCodexHome(async (codexHome) => {
+      const sessionId = 'codex-error-semantics';
+      await seedRawRollout(codexHome, sessionId, errorSemanticsRollout(sessionId));
+
+      const session = await new CodexSessionAdapter({ codexHome }).readSession(sessionId);
+      assert.deepEqual(
+        session.messages
+          .filter((message) => message.type === 'turn_state')
+          .map(({ turnId, status, errorClass }) => ({ turnId, status, errorClass })),
+        [
+          { turnId: 'turn-terminal', status: 'failed', errorClass: 'codex_error' },
+          { turnId: 'turn-rollback', status: 'completed', errorClass: undefined },
+          { turnId: 'turn-not-steerable', status: 'completed', errorClass: undefined },
+        ],
+      );
+    });
+  });
+
+  test('filesystem fallback excludes internal subagent rollouts', async () => {
+    await withCodexHome(async (codexHome) => {
+      await seedMinimalRollout(
+        codexHome,
+        'codex-root-fallback',
+        false,
+        '/workspace/root',
+        'Root task',
+      );
+      const subagentId = 'codex-subagent-fallback';
+      await seedRawRollout(
+        codexHome,
+        subagentId,
+        minimalRollout(subagentId, '/workspace/root', 'Internal task', {
+          subagent: {
+            thread_spawn: { parent_thread_id: 'parent', depth: 1 },
+          },
+        }),
+      );
+
+      const adapter = new CodexSessionAdapter({ codexHome });
+      assert.deepEqual(
+        (await adapter.listSessions()).map((session) => session.id),
+        ['codex-root-fallback'],
+      );
+      await assert.rejects(adapter.readSession(subagentId), /not found/);
+    });
+  });
+
   test('rejects corrupt interior records, tolerates a torn tail, and bounds full reads', async () => {
     await withCodexHome(async (codexHome) => {
       const fixture = await readFile(CURRENT_FIXTURE, 'utf8');
@@ -277,18 +325,63 @@ async function seedRawRollout(
   return path;
 }
 
-function minimalRollout(sessionId: string, cwd: string, userText: string): string {
+function minimalRollout(
+  sessionId: string,
+  cwd: string,
+  userText: string,
+  source: unknown = 'cli',
+): string {
   return [
     JSON.stringify({
       timestamp: '2026-08-08T00:00:00.000Z',
       type: 'session_meta',
-      payload: { session_id: sessionId, id: sessionId, cwd, source: 'cli' },
+      payload: { session_id: sessionId, id: sessionId, cwd, source },
     }),
     JSON.stringify({
       timestamp: '2026-08-08T00:00:01.000Z',
       type: 'event_msg',
       payload: { type: 'user_message', message: userText },
     }),
+    '',
+  ].join('\n');
+}
+
+function errorSemanticsRollout(sessionId: string): string {
+  const event = (second: number, payload: Record<string, unknown>): string =>
+    JSON.stringify({
+      timestamp: `2026-08-08T00:00:${String(second).padStart(2, '0')}.000Z`,
+      type: 'event_msg',
+      payload,
+    });
+  return [
+    JSON.stringify({
+      timestamp: '2026-08-08T00:00:00.000Z',
+      type: 'session_meta',
+      payload: { session_id: sessionId, id: sessionId, cwd: '/workspace', source: 'cli' },
+    }),
+    event(1, { type: 'task_started', turn_id: 'turn-terminal' }),
+    event(2, { type: 'user_message', message: 'Fail terminally' }),
+    event(3, {
+      type: 'task_complete',
+      turn_id: 'turn-terminal',
+      error: { message: 'capacity', codex_error_info: 'server_overloaded' },
+    }),
+    event(4, { type: 'task_started', turn_id: 'turn-rollback' }),
+    event(5, { type: 'user_message', message: 'Rollback warning' }),
+    event(6, {
+      type: 'error',
+      message: 'rollback failed',
+      codex_error_info: 'thread_rollback_failed',
+    }),
+    event(7, { type: 'task_complete', turn_id: 'turn-rollback' }),
+    event(8, { type: 'task_started', turn_id: 'turn-not-steerable' }),
+    event(9, { type: 'user_message', message: 'Steer review' }),
+    event(10, {
+      type: 'error',
+      message: 'cannot steer review',
+      codex_error_info: { active_turn_not_steerable: { turn_kind: 'review' } },
+    }),
+    event(11, { type: 'task_complete', turn_id: 'turn-not-steerable' }),
     '',
   ].join('\n');
 }

--- a/packages/storage/src/__tests__/fixtures/codex-rollout-v0.144.jsonl
+++ b/packages/storage/src/__tests__/fixtures/codex-rollout-v0.144.jsonl
@@ -1,0 +1,16 @@
+{"timestamp":"2026-08-08T00:00:00.000Z","type":"session_meta","payload":{"session_id":"codex-session-1","id":"codex-session-1","timestamp":"2026-08-08T00:00:00.000Z","cwd":"/workspace/project","originator":"codex_cli_rs","cli_version":"0.144.1","source":"cli","model_provider":"openai"}}
+{"timestamp":"2026-08-08T00:00:01.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"codex-turn-1","started_at":1786147201}}
+{"timestamp":"2026-08-08T00:00:01.100Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"synthetic developer context"}]}}
+{"timestamp":"2026-08-08T00:00:01.200Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"synthetic model input"}]}}
+{"timestamp":"2026-08-08T00:00:01.300Z","type":"turn_context","payload":{"turn_id":"codex-turn-1","cwd":"/workspace/project","model":"gpt-codex-test","approval_policy":"on-request","sandbox_policy":{"type":"workspace-write"}}}
+{"timestamp":"2026-08-08T00:00:02.000Z","type":"event_msg","payload":{"type":"user_message","client_id":"codex-user-1","message":"Fix the parser","images":[],"local_images":[],"text_elements":[]}}
+{"timestamp":"2026-08-08T00:00:03.000Z","type":"event_msg","payload":{"type":"agent_reasoning","text":"Inspect the failing path."}}
+{"timestamp":"2026-08-08T00:00:03.100Z","type":"response_item","payload":{"type":"reasoning","id":"reasoning-provider-1","summary":[{"type":"summary_text","text":"Inspect the failing path."}],"encrypted_content":"opaque"}}
+{"timestamp":"2026-08-08T00:00:04.000Z","type":"event_msg","payload":{"type":"agent_message","message":"I found the issue.","phase":"commentary"}}
+{"timestamp":"2026-08-08T00:00:04.100Z","type":"response_item","payload":{"type":"message","id":"assistant-provider-1","role":"assistant","content":[{"type":"output_text","text":"I found the issue."}],"phase":"commentary"}}
+{"timestamp":"2026-08-08T00:00:05.000Z","type":"response_item","payload":{"type":"function_call","id":"function-provider-1","name":"wait","arguments":"{\"milliseconds\":25}","call_id":"call-wait-1"}}
+{"timestamp":"2026-08-08T00:00:06.000Z","type":"response_item","payload":{"type":"function_call_output","id":"function-output-1","call_id":"call-wait-1","output":"waited"}}
+{"timestamp":"2026-08-08T00:00:07.000Z","type":"response_item","payload":{"type":"custom_tool_call","id":"custom-provider-1","name":"apply_patch","input":"*** Begin Patch","call_id":"call-patch-1"}}
+{"timestamp":"2026-08-08T00:00:08.000Z","type":"response_item","payload":{"type":"custom_tool_call_output","id":"custom-output-1","call_id":"call-patch-1","output":[{"type":"input_text","text":"Done"},{"type":"input_text","text":"1 file changed"}]}}
+{"timestamp":"2026-08-08T00:00:09.000Z","type":"event_msg","payload":{"type":"context_compacted"}}
+{"timestamp":"2026-08-08T00:00:10.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"codex-turn-1","last_agent_message":"I found the issue.","completed_at":1786147210}}

--- a/packages/storage/src/codex-session-adapter.ts
+++ b/packages/storage/src/codex-session-adapter.ts
@@ -338,7 +338,9 @@ function convertCodexRollout(
       }
 
       if (eventType === 'error') {
-        if (activeTurnId) failedTurnIds.add(activeTurnId);
+        if (activeTurnId && codexErrorAffectsTurnStatus(payload)) {
+          failedTurnIds.add(activeTurnId);
+        }
         messages.push({
           type: 'system_note',
           id: generatedCodexId(expectedSessionId, 'error', record.line),
@@ -352,15 +354,17 @@ function convertCodexRollout(
 
       if (eventType === 'task_complete' || eventType === 'turn_complete') {
         const turnId = stringField(payload, 'turn_id') ?? ensureTurnId(record.line);
+        const failed = failedTurnIds.has(turnId) || payload.error != null;
         messages.push({
           type: 'turn_state',
           id: generatedCodexId(expectedSessionId, 'turn-state', record.line),
           turnId,
           ts: timestampFor(record),
-          status: failedTurnIds.has(turnId) ? 'failed' : 'completed',
-          ...(failedTurnIds.has(turnId) ? { errorClass: 'codex_error' } : {}),
+          status: failed ? 'failed' : 'completed',
+          ...(failed ? { errorClass: 'codex_error' } : {}),
           partialOutputRetained: true,
         });
+        failedTurnIds.delete(turnId);
         if (activeTurnId === turnId) {
           activeTurnId = undefined;
           activeTurnIsExplicit = false;
@@ -485,6 +489,7 @@ function catalogEntryFromRolloutHead(
     const payload = asRecord(record.payload);
     if (!payload) continue;
     if (record.type === 'session_meta') {
+      if (!isRootCodexSource(payload.source)) return undefined;
       id = stringField(payload, 'session_id') ?? stringField(payload, 'id') ?? id;
       cwd = safeCodexCwd(payload.cwd) || cwd;
       createdAt =
@@ -696,16 +701,23 @@ function firstNonEmptyTitle(...values: unknown[]): string | undefined {
 
 function isRootCodexSource(value: unknown): boolean {
   if (value === undefined || value === null) return true;
-  if (typeof value !== 'string') return false;
-  if (CODEX_ROOT_SOURCE_TOKENS.has(value)) return true;
-  if (!value.startsWith('{')) return false;
-  try {
-    const parsed = JSON.parse(value) as unknown;
-    const custom = isRecord(parsed) ? parsed.custom : undefined;
-    return custom === 'atlas' || custom === 'chatgpt';
-  } catch {
-    return false;
+  if (typeof value === 'string') {
+    if (CODEX_ROOT_SOURCE_TOKENS.has(value)) return true;
+    if (!value.startsWith('{')) return false;
+    try {
+      return isRootCodexSource(JSON.parse(value) as unknown);
+    } catch {
+      return false;
+    }
   }
+  if (!isRecord(value)) return false;
+  return value.custom === 'atlas' || value.custom === 'chatgpt';
+}
+
+function codexErrorAffectsTurnStatus(payload: JsonRecord): boolean {
+  const info = payload.codex_error_info;
+  if (info === 'thread_rollback_failed' || info === 'active_turn_not_steerable') return false;
+  return !(isRecord(info) && Object.hasOwn(info, 'active_turn_not_steerable'));
 }
 
 function normalizeEpochMs(value: unknown): number | undefined {

--- a/packages/storage/src/codex-session-adapter.ts
+++ b/packages/storage/src/codex-session-adapter.ts
@@ -1,0 +1,808 @@
+import type { Dirent } from 'node:fs';
+import { open, readdir, realpath, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { basename, join, resolve, sep } from 'node:path';
+import type { StoredMessage } from '@maka/core';
+import { sanitizeForeignTitle } from '@maka/core/foreign-session';
+import type {
+  ExternalMakaSession,
+  ExternalSessionAdapter,
+  ExternalSessionQuery,
+  ExternalSessionSummary,
+} from '@maka/core/external-session';
+
+export const CODEX_SESSION_ADAPTER_ID = 'codex';
+export const CODEX_ROLLOUT_MAX_BYTES = 64 * 1024 * 1024;
+
+const CODEX_ROLLOUT_HEAD_BYTES = 512 * 1024;
+const CODEX_SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const CODEX_UNSAFE_PATH_CHARS =
+  /[\u0000-\u001F\u007F\u0080-\u009F\u061C\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u2069\uFEFF]/;
+const CODEX_ROOT_SOURCE_TOKENS = new Set(['cli', 'exec', 'vscode']);
+
+export interface CodexSessionAdapterOptions {
+  /** Codex's state root. Defaults to `$CODEX_HOME`, then `~/.codex`. */
+  codexHome?: string;
+  /** Test/host override for the bounded transcript read. */
+  maxRolloutBytes?: number;
+}
+
+interface CodexCatalogEntry extends ExternalSessionSummary {
+  rolloutPath: string;
+}
+
+interface CodexThreadRow {
+  id?: unknown;
+  rollout_path?: unknown;
+  cwd?: unknown;
+  name?: unknown;
+  title?: unknown;
+  preview?: unknown;
+  first_user_message?: unknown;
+  created_at_ms?: unknown;
+  created_at?: unknown;
+  updated_at_ms?: unknown;
+  updated_at?: unknown;
+  archived?: unknown;
+  source?: unknown;
+}
+
+type JsonRecord = Record<string, unknown>;
+
+/**
+ * Read-only adapter for Codex rollout JSONL.
+ *
+ * Codex persists presentation history as `event_msg` records and provider
+ * protocol facts as `response_item` records. User, assistant, and reasoning
+ * messages come from `event_msg` to avoid importing their response-item
+ * mirrors twice. Tool calls/results come from response items because they own
+ * the stable call identity and raw arguments/output.
+ */
+export class CodexSessionAdapter implements ExternalSessionAdapter {
+  readonly id = CODEX_SESSION_ADAPTER_ID;
+
+  private readonly codexHome: string;
+  private readonly maxRolloutBytes: number;
+
+  constructor(options: CodexSessionAdapterOptions = {}) {
+    this.codexHome = resolve(
+      options.codexHome ?? process.env.CODEX_HOME ?? join(homedir(), '.codex'),
+    );
+    this.maxRolloutBytes = options.maxRolloutBytes ?? CODEX_ROLLOUT_MAX_BYTES;
+    if (!Number.isSafeInteger(this.maxRolloutBytes) || this.maxRolloutBytes <= 0) {
+      throw new Error('Codex rollout byte limit must be a positive safe integer');
+    }
+  }
+
+  async detect(): Promise<boolean> {
+    return (
+      (await isDirectory(join(this.codexHome, 'sessions'))) ||
+      (await isDirectory(join(this.codexHome, 'archived_sessions'))) ||
+      (await codexStateDbsNewestFirst(this.codexHome)).length > 0
+    );
+  }
+
+  async listSessions(query: ExternalSessionQuery = {}): Promise<readonly ExternalSessionSummary[]> {
+    const entries = await this.listCatalog(query);
+    return entries.map(({ rolloutPath: _rolloutPath, ...summary }) => summary);
+  }
+
+  async readSession(sessionId: string): Promise<ExternalMakaSession> {
+    assertSafeCodexSessionId(sessionId);
+    const catalogEntry = await this.findCatalogEntry(sessionId);
+    if (!catalogEntry) throw new Error(`Codex Session not found: ${sessionId}`);
+
+    const rolloutPath = await this.resolveRolloutPath(catalogEntry.rolloutPath, sessionId);
+    if (!rolloutPath) throw new Error(`Codex rollout is unavailable: ${sessionId}`);
+    const text = await readBoundedUtf8File(rolloutPath, this.maxRolloutBytes);
+    const converted = convertCodexRollout(text, sessionId, catalogEntry.name, catalogEntry.cwd);
+
+    return {
+      sourceSessionId: sessionId,
+      metadata: converted.metadata,
+      messages: converted.messages,
+    };
+  }
+
+  private async listCatalog(query: ExternalSessionQuery): Promise<CodexCatalogEntry[]> {
+    for (const dbPath of await codexStateDbsNewestFirst(this.codexHome)) {
+      const rows = await readCodexThreadRows(dbPath, query);
+      if (rows === undefined) continue;
+      const entries = await Promise.all(rows.map((row) => this.entryFromRow(row)));
+      return entries
+        .filter((entry): entry is CodexCatalogEntry => entry !== undefined)
+        .filter((entry) => matchesQuery(entry, query))
+        .sort(compareCatalogEntries);
+    }
+
+    return this.scanRolloutCatalog(query);
+  }
+
+  private async findCatalogEntry(sessionId: string): Promise<CodexCatalogEntry | undefined> {
+    for (const dbPath of await codexStateDbsNewestFirst(this.codexHome)) {
+      const rows = await readCodexThreadRows(dbPath, { includeArchived: true }, sessionId);
+      if (rows === undefined) continue;
+      for (const row of rows) {
+        const entry = await this.entryFromRow(row);
+        if (entry?.id === sessionId) return entry;
+      }
+      break;
+    }
+
+    return this.findRolloutEntry(sessionId);
+  }
+
+  private async entryFromRow(row: CodexThreadRow): Promise<CodexCatalogEntry | undefined> {
+    if (!isSafeCodexSessionId(row.id)) return undefined;
+    if (typeof row.rollout_path !== 'string' || row.rollout_path.length === 0) return undefined;
+    if (!isRootCodexSource(row.source)) return undefined;
+
+    const rolloutPath = await this.resolveRolloutPath(row.rollout_path, row.id);
+    if (!rolloutPath) return undefined;
+    const name =
+      firstNonEmptyTitle(row.name, row.title, row.preview, row.first_user_message) ?? row.id;
+    const createdAt = normalizeEpochMs(row.created_at_ms) ?? normalizeEpochMs(row.created_at);
+    const updatedAt = normalizeEpochMs(row.updated_at_ms) ?? normalizeEpochMs(row.updated_at);
+
+    return {
+      id: row.id,
+      name,
+      cwd: safeCodexCwd(row.cwd),
+      ...(createdAt !== undefined ? { createdAt } : {}),
+      ...(updatedAt !== undefined ? { updatedAt } : {}),
+      archived: row.archived === true || row.archived === 1,
+      rolloutPath,
+    };
+  }
+
+  private async scanRolloutCatalog(query: ExternalSessionQuery): Promise<CodexCatalogEntry[]> {
+    const candidates = [
+      ...(await walkRolloutFiles(join(this.codexHome, 'sessions'), false)),
+      ...(query.includeArchived
+        ? await walkRolloutFiles(join(this.codexHome, 'archived_sessions'), true)
+        : []),
+    ].sort((a, b) => b.mtimeMs - a.mtimeMs);
+    const entries: CodexCatalogEntry[] = [];
+    for (const candidate of candidates) {
+      const head = await readUtf8Prefix(candidate.path, CODEX_ROLLOUT_HEAD_BYTES).catch(
+        () => undefined,
+      );
+      if (head === undefined) continue;
+      const entry = catalogEntryFromRolloutHead(head, candidate);
+      if (!entry || !matchesQuery(entry, query)) continue;
+      const rolloutPath = await this.resolveRolloutPath(candidate.path, entry.id);
+      if (rolloutPath) entries.push({ ...entry, rolloutPath });
+    }
+    return entries.sort(compareCatalogEntries);
+  }
+
+  private async findRolloutEntry(sessionId: string): Promise<CodexCatalogEntry | undefined> {
+    for (const [root, archived] of [
+      [join(this.codexHome, 'sessions'), false],
+      [join(this.codexHome, 'archived_sessions'), true],
+    ] as const) {
+      for (const candidate of await walkRolloutFiles(root, archived)) {
+        if (!rolloutFilenameMatchesId(basename(candidate.path), sessionId)) continue;
+        const head = await readUtf8Prefix(candidate.path, CODEX_ROLLOUT_HEAD_BYTES).catch(
+          () => undefined,
+        );
+        if (head === undefined) continue;
+        const entry = catalogEntryFromRolloutHead(head, candidate);
+        if (entry?.id !== sessionId) continue;
+        const rolloutPath = await this.resolveRolloutPath(candidate.path, sessionId);
+        if (rolloutPath) return { ...entry, rolloutPath };
+      }
+    }
+    return undefined;
+  }
+
+  private async resolveRolloutPath(
+    candidatePath: string,
+    expectedId: string,
+  ): Promise<string | undefined> {
+    try {
+      const root = await realpath(this.codexHome);
+      const candidate = await realpath(resolve(candidatePath));
+      if (candidate !== root && !candidate.startsWith(root + sep)) return undefined;
+      if (!rolloutFilenameMatchesId(basename(candidate), expectedId)) return undefined;
+      if (!(await stat(candidate)).isFile()) return undefined;
+      return candidate;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+interface RolloutCandidate {
+  path: string;
+  mtimeMs: number;
+  archived: boolean;
+}
+
+function convertCodexRollout(
+  text: string,
+  expectedSessionId: string,
+  fallbackName: string,
+  fallbackCwd: string,
+): ExternalMakaSession {
+  const records = parseRolloutRecords(text, expectedSessionId);
+  const sessionMeta = records.find((record) => record.value.type === 'session_meta')?.value;
+  const metaPayload = asRecord(sessionMeta?.payload);
+  const actualSessionId = stringField(metaPayload, 'session_id') ?? stringField(metaPayload, 'id');
+  if (actualSessionId !== expectedSessionId) {
+    throw new Error(`Codex rollout Session id mismatch: expected ${expectedSessionId}`);
+  }
+
+  const metaCwd = safeCodexCwd(metaPayload?.cwd);
+  const messages: StoredMessage[] = [];
+  let activeTurnId: string | undefined;
+  let activeTurnIsExplicit = false;
+  let activeModel = stringField(metaPayload, 'model_provider') ?? 'codex';
+  let lastTimestamp = normalizeEpochMs(sessionMeta?.timestamp) ?? 0;
+  let firstUserText: string | undefined;
+  const failedTurnIds = new Set<string>();
+
+  const timestampFor = (record: ParsedRolloutRecord): number => {
+    const parsed = normalizeEpochMs(record.value.timestamp);
+    if (parsed !== undefined) lastTimestamp = Math.max(lastTimestamp, parsed);
+    else lastTimestamp += 1;
+    return parsed ?? lastTimestamp;
+  };
+  const ensureTurnId = (line: number): string => {
+    activeTurnId ??= generatedCodexId(expectedSessionId, 'turn', line);
+    return activeTurnId;
+  };
+
+  for (const record of records) {
+    const envelope = record.value;
+    const payload = asRecord(envelope.payload);
+    if (!payload) continue;
+
+    if (envelope.type === 'turn_context') {
+      activeTurnId = stringField(payload, 'turn_id') ?? activeTurnId;
+      activeModel = stringField(payload, 'model') ?? activeModel;
+      continue;
+    }
+
+    if (envelope.type === 'event_msg') {
+      const eventType = stringField(payload, 'type');
+      if (eventType === 'task_started' || eventType === 'turn_started') {
+        const turnId = stringField(payload, 'turn_id');
+        if (turnId) {
+          activeTurnId = turnId;
+          activeTurnIsExplicit = true;
+        }
+        continue;
+      }
+
+      if (eventType === 'user_message') {
+        if (!activeTurnIsExplicit) {
+          activeTurnId = generatedCodexId(expectedSessionId, 'turn', record.line);
+        }
+        const text = stringField(payload, 'message') ?? mediaOnlyUserText(payload);
+        if (text.length === 0) continue;
+        firstUserText ??= text;
+        const turnId = ensureTurnId(record.line);
+        messages.push({
+          type: 'user',
+          id:
+            stringField(payload, 'client_id') ??
+            generatedCodexId(expectedSessionId, 'user', record.line),
+          turnId,
+          ts: timestampFor(record),
+          text,
+        });
+        continue;
+      }
+
+      if (eventType === 'agent_message') {
+        const text = stringField(payload, 'message');
+        if (!text) continue;
+        messages.push({
+          type: 'assistant',
+          id: generatedCodexId(expectedSessionId, 'assistant', record.line),
+          turnId: ensureTurnId(record.line),
+          ts: timestampFor(record),
+          text,
+          modelId: activeModel,
+          contentOrder: ['text'],
+        });
+        continue;
+      }
+
+      if (eventType === 'agent_reasoning') {
+        const reasoning = stringField(payload, 'text');
+        if (!reasoning) continue;
+        messages.push({
+          type: 'assistant',
+          id: generatedCodexId(expectedSessionId, 'reasoning', record.line),
+          turnId: ensureTurnId(record.line),
+          ts: timestampFor(record),
+          text: '',
+          thinking: { text: reasoning },
+          contentOrder: ['thinking'],
+          modelId: activeModel,
+        });
+        continue;
+      }
+
+      if (eventType === 'context_compacted') {
+        messages.push({
+          type: 'system_note',
+          id: generatedCodexId(expectedSessionId, 'compact', record.line),
+          turnId: activeTurnId,
+          ts: timestampFor(record),
+          kind: 'context_compacted',
+        });
+        continue;
+      }
+
+      if (eventType === 'error') {
+        if (activeTurnId) failedTurnIds.add(activeTurnId);
+        messages.push({
+          type: 'system_note',
+          id: generatedCodexId(expectedSessionId, 'error', record.line),
+          turnId: activeTurnId,
+          ts: timestampFor(record),
+          kind: 'error',
+          data: JSON.parse(JSON.stringify(payload)) as unknown,
+        });
+        continue;
+      }
+
+      if (eventType === 'task_complete' || eventType === 'turn_complete') {
+        const turnId = stringField(payload, 'turn_id') ?? ensureTurnId(record.line);
+        messages.push({
+          type: 'turn_state',
+          id: generatedCodexId(expectedSessionId, 'turn-state', record.line),
+          turnId,
+          ts: timestampFor(record),
+          status: failedTurnIds.has(turnId) ? 'failed' : 'completed',
+          ...(failedTurnIds.has(turnId) ? { errorClass: 'codex_error' } : {}),
+          partialOutputRetained: true,
+        });
+        if (activeTurnId === turnId) {
+          activeTurnId = undefined;
+          activeTurnIsExplicit = false;
+        }
+        continue;
+      }
+
+      if (eventType === 'turn_aborted') {
+        const turnId = stringField(payload, 'turn_id') ?? ensureTurnId(record.line);
+        const ts = timestampFor(record);
+        messages.push({
+          type: 'turn_state',
+          id: generatedCodexId(expectedSessionId, 'turn-state', record.line),
+          turnId,
+          ts,
+          status: 'aborted',
+          abortedAt: normalizeEpochMs(payload.completed_at) ?? ts,
+          abortSource: stringField(payload, 'reason') ?? 'codex',
+          partialOutputRetained: true,
+        });
+        if (activeTurnId === turnId) {
+          activeTurnId = undefined;
+          activeTurnIsExplicit = false;
+        }
+        continue;
+      }
+    }
+
+    if (envelope.type !== 'response_item') continue;
+    const itemType = stringField(payload, 'type');
+    if (itemType === 'function_call' || itemType === 'custom_tool_call') {
+      const callId = stringField(payload, 'call_id');
+      const toolName = namespacedToolName(payload);
+      if (!callId || !toolName) continue;
+      const rawArgs =
+        itemType === 'function_call'
+          ? stringField(payload, 'arguments')
+          : stringField(payload, 'input');
+      messages.push({
+        type: 'tool_call',
+        id: callId,
+        turnId: ensureTurnId(record.line),
+        ts: timestampFor(record),
+        toolName,
+        args: parseJsonString(rawArgs),
+      });
+      continue;
+    }
+
+    if (itemType === 'function_call_output' || itemType === 'custom_tool_call_output') {
+      const callId = stringField(payload, 'call_id');
+      if (!callId) continue;
+      messages.push({
+        type: 'tool_result',
+        id:
+          stringField(payload, 'id') ??
+          generatedCodexId(expectedSessionId, 'tool-result', record.line),
+        turnId: ensureTurnId(record.line),
+        ts: timestampFor(record),
+        toolUseId: callId,
+        // Codex persists the output body but not FunctionCallOutputPayload.success.
+        // Preserve the raw body and avoid guessing failure from its text.
+        isError: false,
+        content: { kind: 'text', text: codexToolOutputText(payload.output) },
+      });
+    }
+  }
+
+  const name =
+    sanitizeForeignTitle(fallbackName) || sanitizeForeignTitle(firstUserText) || expectedSessionId;
+  return {
+    sourceSessionId: expectedSessionId,
+    metadata: { name, cwd: metaCwd || fallbackCwd },
+    messages,
+  };
+}
+
+interface ParsedRolloutRecord {
+  line: number;
+  value: JsonRecord;
+}
+
+function parseRolloutRecords(text: string, sessionId: string): ParsedRolloutRecord[] {
+  const endsWithNewline = text.endsWith('\n');
+  const lines = text.split('\n');
+  if (endsWithNewline) lines.pop();
+  const records: ParsedRolloutRecord[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (line.trim().length === 0) continue;
+    try {
+      const value = JSON.parse(line) as unknown;
+      if (!isRecord(value)) throw new Error('record is not an object');
+      records.push({ line: index + 1, value });
+    } catch (error) {
+      if (!endsWithNewline && index === lines.length - 1) break;
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid Codex rollout ${sessionId} at line ${index + 1}: ${detail}`);
+    }
+  }
+  return records;
+}
+
+function catalogEntryFromRolloutHead(
+  text: string,
+  candidate: RolloutCandidate,
+): Omit<CodexCatalogEntry, 'rolloutPath'> | undefined {
+  const lines = text.split('\n');
+  let id: string | undefined;
+  let cwd = '';
+  let createdAt: number | undefined;
+  let firstUserText: string | undefined;
+  for (const line of lines) {
+    let record: JsonRecord;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!isRecord(parsed)) continue;
+      record = parsed;
+    } catch {
+      continue;
+    }
+    const payload = asRecord(record.payload);
+    if (!payload) continue;
+    if (record.type === 'session_meta') {
+      id = stringField(payload, 'session_id') ?? stringField(payload, 'id') ?? id;
+      cwd = safeCodexCwd(payload.cwd) || cwd;
+      createdAt =
+        normalizeEpochMs(record.timestamp) ?? normalizeEpochMs(payload.timestamp) ?? createdAt;
+    } else if (
+      record.type === 'event_msg' &&
+      payload.type === 'user_message' &&
+      firstUserText === undefined
+    ) {
+      firstUserText = stringField(payload, 'message');
+    }
+    if (id && firstUserText !== undefined) break;
+  }
+  if (!isSafeCodexSessionId(id)) return undefined;
+  if (!rolloutFilenameMatchesId(basename(candidate.path), id)) return undefined;
+  return {
+    id,
+    name: sanitizeForeignTitle(firstUserText) || id,
+    cwd,
+    ...(createdAt !== undefined ? { createdAt } : {}),
+    updatedAt: candidate.mtimeMs,
+    archived: candidate.archived,
+  };
+}
+
+async function readCodexThreadRows(
+  dbPath: string,
+  query: ExternalSessionQuery,
+  exactId?: string,
+): Promise<CodexThreadRow[] | undefined> {
+  try {
+    const sqlite = await import('node:sqlite');
+    const db = new sqlite.DatabaseSync(dbPath, { readOnly: true });
+    try {
+      const columns = new Set(
+        (db.prepare('PRAGMA table_info(threads)').all() as { name?: unknown }[])
+          .map((column) => (typeof column.name === 'string' ? column.name : ''))
+          .filter(Boolean),
+      );
+      if (!columns.has('id') || !columns.has('rollout_path')) return undefined;
+      const wanted = [
+        'id',
+        'rollout_path',
+        'cwd',
+        'name',
+        'title',
+        'preview',
+        'first_user_message',
+        'created_at_ms',
+        'created_at',
+        'updated_at_ms',
+        'updated_at',
+        'archived',
+        'source',
+      ].filter((column) => columns.has(column));
+      const where: string[] = [];
+      const params: Array<string | number> = [];
+      if (exactId !== undefined) {
+        where.push('id = ?');
+        params.push(exactId);
+      }
+      if (!query.includeArchived && columns.has('archived')) {
+        where.push('(archived IS NULL OR archived = 0)');
+      }
+      if (query.cwd !== undefined && columns.has('cwd')) {
+        const variants = cwdSqlVariants(query.cwd);
+        where.push(`cwd IN (${variants.map(() => '?').join(', ')})`);
+        params.push(...variants);
+      }
+      const orderColumn = columns.has('updated_at_ms')
+        ? 'updated_at_ms'
+        : columns.has('updated_at')
+          ? 'updated_at'
+          : 'id';
+      const sql =
+        `SELECT ${wanted.join(', ')} FROM threads` +
+        (where.length > 0 ? ` WHERE ${where.join(' AND ')}` : '') +
+        ` ORDER BY ${orderColumn} DESC`;
+      return db.prepare(sql).all(...params) as CodexThreadRow[];
+    } finally {
+      db.close();
+    }
+  } catch {
+    return undefined;
+  }
+}
+
+async function codexStateDbsNewestFirst(codexHome: string): Promise<string[]> {
+  try {
+    const root = await realpath(codexHome);
+    const candidates = (await readdir(codexHome))
+      .filter((name) => /^state_\d+\.sqlite$/.test(name))
+      .sort((a, b) => stateGeneration(b) - stateGeneration(a));
+    const databases: string[] = [];
+    for (const name of candidates) {
+      const candidate = await realpath(join(codexHome, name)).catch(() => undefined);
+      if (!candidate || (candidate !== root && !candidate.startsWith(root + sep))) continue;
+      if ((await stat(candidate).catch(() => undefined))?.isFile()) databases.push(candidate);
+    }
+    return databases;
+  } catch {
+    return [];
+  }
+}
+
+async function walkRolloutFiles(root: string, archived: boolean): Promise<RolloutCandidate[]> {
+  const files: RolloutCandidate[] = [];
+  const visit = async (directory: string): Promise<void> => {
+    let entries: Dirent<string>[];
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await visit(path);
+      } else if (
+        entry.isFile() &&
+        entry.name.startsWith('rollout-') &&
+        entry.name.endsWith('.jsonl')
+      ) {
+        try {
+          files.push({ path, mtimeMs: (await stat(path)).mtimeMs, archived });
+        } catch {
+          // The external store may change while it is being scanned.
+        }
+      }
+    }
+  };
+  await visit(root);
+  return files;
+}
+
+async function readBoundedUtf8File(path: string, maxBytes: number): Promise<string> {
+  const handle = await open(path, 'r');
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile()) throw new Error('Codex rollout is not a regular file');
+    if (metadata.size > maxBytes) throw new Error(`Codex rollout exceeds ${maxBytes} bytes`);
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for (;;) {
+      const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, maxBytes + 1 - total));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > maxBytes) throw new Error(`Codex rollout exceeds ${maxBytes} bytes`);
+      chunks.push(buffer.subarray(0, bytesRead));
+      if (total === maxBytes) {
+        const probe = Buffer.allocUnsafe(1);
+        if ((await handle.read(probe, 0, 1, total)).bytesRead > 0) {
+          throw new Error(`Codex rollout exceeds ${maxBytes} bytes`);
+        }
+        break;
+      }
+    }
+    return Buffer.concat(chunks, total).toString('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readUtf8Prefix(path: string, maxBytes: number): Promise<string> {
+  const handle = await open(path, 'r');
+  try {
+    if (!(await handle.stat()).isFile()) throw new Error('Codex rollout is not a regular file');
+    const buffer = Buffer.allocUnsafe(maxBytes);
+    const { bytesRead } = await handle.read(buffer, 0, maxBytes, 0);
+    return buffer.subarray(0, bytesRead).toString('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+function asRecord(value: unknown): JsonRecord | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: JsonRecord | undefined, field: string): string | undefined {
+  const value = record?.[field];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function isSafeCodexSessionId(value: unknown): value is string {
+  return typeof value === 'string' && CODEX_SESSION_ID_PATTERN.test(value);
+}
+
+function assertSafeCodexSessionId(value: string): void {
+  if (!isSafeCodexSessionId(value)) throw new Error(`Invalid Codex Session id: ${value}`);
+}
+
+function safeCodexCwd(value: unknown): string {
+  return typeof value === 'string' && !CODEX_UNSAFE_PATH_CHARS.test(value) ? value : '';
+}
+
+function firstNonEmptyTitle(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const title = sanitizeForeignTitle(value);
+    if (title.length > 0) return title;
+  }
+  return undefined;
+}
+
+function isRootCodexSource(value: unknown): boolean {
+  if (value === undefined || value === null) return true;
+  if (typeof value !== 'string') return false;
+  if (CODEX_ROOT_SOURCE_TOKENS.has(value)) return true;
+  if (!value.startsWith('{')) return false;
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    const custom = isRecord(parsed) ? parsed.custom : undefined;
+    return custom === 'atlas' || custom === 'chatgpt';
+  } catch {
+    return false;
+  }
+}
+
+function normalizeEpochMs(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value >= 1_000_000_000_000 ? value : value * 1000;
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) return normalizeEpochMs(numeric);
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function normalizePath(value: string): string {
+  const normalized = value.replaceAll('\\', '/').replace(/\/+$/, '');
+  return /^[A-Za-z]:\//.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function cwdSqlVariants(cwd: string): string[] {
+  const normalized = normalizePath(cwd);
+  const variants = new Set([cwd, normalized]);
+  if (/^[A-Za-z]:\//.test(normalized)) variants.add(normalized.replaceAll('/', '\\'));
+  if (normalized !== '/') {
+    variants.add(`${normalized}/`);
+    if (/^[A-Za-z]:\//.test(normalized)) variants.add(`${normalized.replaceAll('/', '\\')}\\`);
+  }
+  return [...variants];
+}
+
+function matchesQuery(entry: ExternalSessionSummary, query: ExternalSessionQuery): boolean {
+  if (!query.includeArchived && entry.archived) return false;
+  return query.cwd === undefined || normalizePath(entry.cwd) === normalizePath(query.cwd);
+}
+
+function compareCatalogEntries(a: CodexCatalogEntry, b: CodexCatalogEntry): number {
+  return (b.updatedAt ?? b.createdAt ?? 0) - (a.updatedAt ?? a.createdAt ?? 0);
+}
+
+function stateGeneration(path: string): number {
+  return Number(path.match(/\d+/)?.[0] ?? 0);
+}
+
+function rolloutFilenameMatchesId(filename: string, sessionId: string): boolean {
+  return filename.endsWith(`-${sessionId}.jsonl`);
+}
+
+function generatedCodexId(sessionId: string, kind: string, line: number): string {
+  return `codex-${sessionId}-${kind}-${line}`;
+}
+
+function namespacedToolName(payload: JsonRecord): string | undefined {
+  const name = stringField(payload, 'name');
+  if (!name) return undefined;
+  const namespace = stringField(payload, 'namespace');
+  return namespace ? `${namespace}.${name}` : name;
+}
+
+function parseJsonString(value: string | undefined): unknown {
+  if (value === undefined) return '';
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function codexToolOutputText(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    const texts = value.flatMap((item) => {
+      const record = asRecord(item);
+      return record?.type === 'input_text' && typeof record.text === 'string' ? [record.text] : [];
+    });
+    if (texts.length > 0) return texts.join('\n');
+  }
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function mediaOnlyUserText(payload: JsonRecord): string {
+  const images = Array.isArray(payload.images) ? payload.images : [];
+  const localImages = Array.isArray(payload.local_images) ? payload.local_images : [];
+  if (images.length > 0 || localImages.length > 0) return '[Image]';
+  const audio = Array.isArray(payload.audio) ? payload.audio : [];
+  const localAudio = Array.isArray(payload.local_audio) ? payload.local_audio : [];
+  return audio.length > 0 || localAudio.length > 0 ? '[Audio]' : '';
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/packages/storage/src/external-session-adapters.ts
+++ b/packages/storage/src/external-session-adapters.ts
@@ -1,0 +1,13 @@
+import { ExternalSessionAdapterRegistry } from '@maka/core/external-session';
+import { CodexSessionAdapter, type CodexSessionAdapterOptions } from './codex-session-adapter.js';
+
+export interface ExternalSessionAdapterOptions {
+  codex?: CodexSessionAdapterOptions;
+}
+
+/** Internal default registry. Product entry points are intentionally added later. */
+export function createExternalSessionAdapterRegistry(
+  options: ExternalSessionAdapterOptions = {},
+): ExternalSessionAdapterRegistry {
+  return new ExternalSessionAdapterRegistry([new CodexSessionAdapter(options.codex)]);
+}


### PR DESCRIPTION
## Summary

- add a read-only `CodexSessionAdapter` for discovering active and archived root Codex Sessions
- convert Codex rollout records directly into Maka `StoredMessage[]`, without a cleaner, external-message IR, or context synthesis layer
- use Codex presentation events for user, assistant, and reasoning messages while preserving tool calls/results from response items, avoiding mirrored-message duplication
- bound transcript reads, reject malformed interior records, tolerate a torn final JSONL record, and confine resolved rollout paths to `CODEX_HOME`
- register the adapter in the internal default registry; this PR adds no IPC, CLI, HTTP, or renderer entry point

Refs #2499

## Supported Codex data

- current and archived rollout files under `CODEX_HOME`
- catalog discovery through the newest usable Codex state SQLite database, with filesystem scan fallback
- root `cli`, `exec`, and `vscode` Sessions; internal subagent threads are excluded
- user/assistant text, reasoning, function/custom tool calls and results, compaction notes, and turn completion/abort/failure state

## Verification

- `npm exec -- biome check packages/storage/src/codex-session-adapter.ts packages/storage/src/external-session-adapters.ts packages/storage/src/__tests__/codex-session-adapter.test.ts`
- `npm --workspace @maka/core run typecheck`
- `npm --workspace @maka/storage run typecheck`
- focused Codex adapter/importer/SessionStore suite on Node 24: 12 passed, 0 failed
- Node 24 storage suite: 761 passed, 12 skipped; one unrelated `artifact-writer-lock` timing test timed out and passed when rerun alone
- read-only smoke test against real active and archived Codex Sessions; every converted record passed Maka's canonical stored-message decoder

## Review focus

This is Phase 2 of #2499. Codex format knowledge remains fully contained in the adapter:

```text
Codex state + rollout JSONL -> CodexSessionAdapter -> Maka StoredMessage[]
```

The generic importer and persistence path are unchanged. A user-facing import workflow remains a separate follow-up PR.
