### PR TITLE
docs: add a contributing guide and extend the pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,12 @@
 ## Summary
 
 <!-- The problem this solves and the outcome it produces. If the approach
-is not the obvious one, say why. Link issues: "Closes #N" when this PR
-completes the issue, "Refs #N" for context only. -->
+is not the obvious one, say why. -->
+
+Fixes #
+
+<!-- Delete the line above if this PR closes no issue. Use "Refs #N" instead
+when an issue is context only. -->
 
 ## Verification
 
@@ -17,3 +21,13 @@ Breaking change, Migration, Rollout, Root cause, Security, Review focus.
 If work intentionally remains, open as a draft and track it with a
 task list under its own section.
 -->
+
+## Checklist
+
+- [ ] Tests cover the change and fail without it
+- [ ] Lint, format, typecheck and the affected suites pass locally
+
+Does this PR entail a change in behavior?
+
+- [ ] Yes — described under Summary above
+- [ ] No

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,179 @@
+# Contributing to Maka
+
+[![docs](https://img.shields.io/badge/docs-%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-blue?logo=googletranslate&logoColor=white)](./CONTRIBUTING.zh-CN.md)
+
+- [Where to start](#where-to-start)
+- [Quick start](#quick-start)
+- [Developing Maka](#developing-maka)
+- [Branch naming](#branch-naming)
+- [Pull requests](#pull-requests)
+- [License](#license)
+
+## Where to start
+
+These changes merge most readily:
+
+- Bug fixes
+- Model provider support — a new provider, or a fix to an existing one
+- Tests and stability work
+- Performance improvements
+- Documentation
+- Fixes for environment-specific problems
+
+Product and UI changes are different: open an issue and agree the direction
+before implementing. Maintainers land features directly because they set that
+direction; an outside contributor is better off confirming it first.
+
+Looking for something to pick up:
+
+- [`help wanted`](https://github.com/maka-agent/maka-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- [`good first issue`](https://github.com/maka-agent/maka-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+- [`bug`](https://github.com/maka-agent/maka-agent/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+- [`enhancement`](https://github.com/maka-agent/maka-agent/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+
+To claim one, say so in a comment and a maintainer may assign it to you.
+
+Prefer the **Bug report** or **Feature request** template when opening an issue —
+they ask for the context that makes one actionable. Report security problems through
+the private flow in [SECURITY.md](./SECURITY.md), never as a public issue.
+
+## Quick start
+
+| Requirement | Value |
+| --- | --- |
+| Node | `>=22.19.0` (`engines`, root `package.json`) |
+| npm | `11.12.1` (`packageManager`) |
+| Platform | macOS Apple Silicon for desktop work. Releases also ship an unsigned Windows x64 build and CI runs a non-blocking `windows_baseline` job, but Windows and Linux are not supported targets yet |
+
+```sh
+git clone https://github.com/maka-agent/maka-agent.git
+cd maka-agent
+npm install                 # root only — never inside a workspace
+npm run build               # builds every workspace in dependency order
+npm --workspace @maka/core test
+```
+
+Architecture is documented in [ARCHITECTURE.md](./ARCHITECTURE.md).
+
+## Developing Maka
+
+### Running
+
+```sh
+npm run dev          # desktop app with HMR
+npm run dev:full     # full build, then launch the desktop app
+
+npm --workspace maka-agent exec -- maka          # TUI
+npm --workspace maka-agent exec -- maka run "…"  # one non-interactive turn
+```
+
+Headless commands live in [`packages/headless/README.md`](./packages/headless/README.md).
+
+### Building
+
+`npm run build` builds workspaces in dependency order:
+
+```
+code-mode → core → storage → mcp → runtime → runtime-host
+          → computer-use → headless → maka-agent → ui → desktop
+```
+
+Building one workspace only succeeds when its dependencies are already built —
+`@maka/runtime` compiled against a stale `@maka/core` produces type errors that
+look like problems in the code you just wrote. When unsure, build from the root.
+
+The desktop app has four outputs; `build:test` covers the first three:
+
+```sh
+npm --workspace @maka/desktop run build:main      # main process
+npm --workspace @maka/desktop run build:preload   # preload bridge
+npm --workspace @maka/desktop run build:overlay   # overlay windows
+npm --workspace @maka/desktop run build:renderer  # renderer
+```
+
+### Testing
+
+Tests run against compiled output in `dist/`. Every workspace's `test` script
+cleans, builds, then runs `node --test`. **Always go through it** — calling
+`node --test` after a bare `build:*` executes orphaned artifacts from older
+trees, which fail on imports that no longer resolve.
+
+```sh
+npm test                                 # all workspaces
+npm --workspace @maka/core test          # one workspace
+npm run test:scripts                     # repository scripts
+npm --workspace @maka/desktop run e2e    # Playwright
+```
+
+### Before pushing
+
+CI runs these; matching them locally avoids a slow round trip.
+
+```sh
+npm run lint            # biome lint
+npm run format:check    # biome format — separate from lint; passing one proves nothing about the other
+npm run build
+npm run typecheck       # 4 tsconfig projects for desktop, including renderer and storybook
+npx knip --workspace apps/desktop
+npx knip --workspace packages/ui
+```
+
+The CI job named `typecheck` runs all of them under `bash -e`, so the first
+failure aborts the rest — read which step failed, not the job name.
+
+## Branch naming
+
+```
+<type>/<description>
+```
+
+`<description>` is lowercase and hyphen-separated. `<type>` must be one of:
+
+| Prefix | Meaning |
+| --- | --- |
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Behavior-preserving restructuring |
+| `test` | Test-only change |
+| `chore` | Build, dependency, and housekeeping work |
+| `perf` | Performance improvement |
+| `docs` | Documentation-only change |
+| `ci` | CI configuration and pipelines |
+| `build` | Build system and artifacts |
+
+## Pull requests
+
+Opening a pull request pre-fills
+[`pull_request_template.md`](./.github/pull_request_template.md), which carries
+the required sections and the checklist. Fill it in rather than replacing it.
+
+**Title.** The repository squash-merges, so the title becomes the commit on
+`main`. Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <summary>
+```
+
+`<type>` is the set in [branch naming](#branch-naming). `<scope>` is the
+workspace or area — `desktop`, `ui`, `runtime`, `headless`, `settings`,
+`runtime-host`, `storage`, `core`, `cli`, `deps`, `computer-use`, `scripts`,
+`release`, `windows`, `e2e`, `security`, and so on — `git log` shows the set
+in use.
+
+```
+fix(desktop): classify provider action errors from the unwrapped IPC message
+feat(runtime): decouple Swarm with asynchronous wakeups
+test(core): pin the shared validation corpus to every envelope value domain
+```
+
+**UI changes.** Include before/after screenshots or a recording. A visual change
+cannot be judged from a diff.
+
+**Keep the description short and your own.** Long generated write-ups slow
+review down. Say what changed and why in your own words; if that needs many
+paragraphs, the pull request is probably too large.
+
+## License
+
+By contributing you agree that your contributions are licensed under the
+[Apache License 2.0](./LICENSE).

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -1,0 +1,159 @@
+# 为 Maka 贡献代码
+
+[![docs](https://img.shields.io/badge/docs-English-blue?logo=googletranslate&logoColor=white)](./CONTRIBUTING.md)
+
+- [从哪里开始](#从哪里开始)
+- [快速开始](#快速开始)
+- [开发](#开发)
+- [分支命名](#分支命名)
+- [Pull Request](#pull-request)
+- [许可](#许可)
+
+## 从哪里开始
+
+下列类型的改动最容易被合并：
+
+- 缺陷修复
+- 模型供应商支持——新增一家，或修好已有的
+- 测试补强与稳定性改进
+- 性能优化
+- 文档
+- 环境相关问题的修复
+
+产品功能与界面改动不一样：请先开 issue 把方向谈定，再动手实现。维护者直接落地功能，是因为他们本身在设定方向；外部贡献者先确认可以避免白做。
+
+想找活干，可以从这些标签入手：
+
+- [`help wanted`](https://github.com/maka-agent/maka-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
+- [`good first issue`](https://github.com/maka-agent/maka-agent/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+- [`bug`](https://github.com/maka-agent/maka-agent/issues?q=is%3Aissue+is%3Aopen+label%3Abug)
+- [`enhancement`](https://github.com/maka-agent/maka-agent/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+
+想认领某个 issue，在下面留言，维护者可能会指派给你。
+
+提 issue 建议走 **Bug report** 或 **Feature request** 模板——它们会问出让一个 issue 可被处理所需的上下文。安全问题请走 [SECURITY.md](./SECURITY.md) 的私密流程，不要开公开 issue。
+
+## 快速开始
+
+| 要求 | 值 |
+| --- | --- |
+| Node | `>=22.19.0`（根 `package.json` 的 `engines`） |
+| npm | `11.12.1`（`packageManager`） |
+| 平台 | 桌面端开发需要 macOS Apple Silicon。发版也会产出未签名的 Windows x64 构建，CI 有非阻塞的 `windows_baseline` job，但 Windows 和 Linux 目前还不是受支持的目标平台 |
+
+```sh
+git clone https://github.com/maka-agent/maka-agent.git
+cd maka-agent
+npm install                 # 只在根目录装 —— 不要在某个 workspace 里跑
+npm run build               # 按依赖顺序构建全部 workspace
+npm --workspace @maka/core test
+```
+
+架构说明见 [ARCHITECTURE.zh-CN.md](./ARCHITECTURE.zh-CN.md)。
+
+## 开发
+
+### 运行
+
+```sh
+npm run dev          # 带 HMR 的桌面应用
+npm run dev:full     # 完整构建后启动桌面应用
+
+npm --workspace maka-agent exec -- maka          # TUI
+npm --workspace maka-agent exec -- maka run "…"  # 非交互地跑一个 Turn
+```
+
+Headless 的命令见 [`packages/headless/README.md`](./packages/headless/README.md)。
+
+### 构建
+
+`npm run build` 按依赖顺序构建各 workspace：
+
+```
+code-mode → core → storage → mcp → runtime → runtime-host
+          → computer-use → headless → maka-agent → ui → desktop
+```
+
+只有依赖都已构建好时，单独构建某个 workspace 才会成功——拿过期的 `@maka/core` 去编译 `@maka/runtime`，产生的类型错误看起来会像是你刚写的代码有问题。拿不准就从根目录构建。
+
+桌面应用有四个产物，`build:test` 覆盖前三个：
+
+```sh
+npm --workspace @maka/desktop run build:main      # 主进程
+npm --workspace @maka/desktop run build:preload   # preload 桥接层
+npm --workspace @maka/desktop run build:overlay   # overlay 窗口
+npm --workspace @maka/desktop run build:renderer  # 渲染层
+```
+
+### 测试
+
+测试跑的是 `dist/` 里的编译产物。每个 workspace 的 `test` 脚本都会先清理、再构建，然后执行 `node --test`。**务必走它**——在裸跑 `build:*` 之后直接 `node --test`，执行的会是旧代码留下的孤儿产物，它们会在早已不存在的 import 上失败。
+
+```sh
+npm test                                 # 全部 workspace
+npm --workspace @maka/core test          # 单个 workspace
+npm run test:scripts                     # 仓库脚本
+npm --workspace @maka/desktop run e2e    # Playwright
+```
+
+### 推送前
+
+CI 会跑这些；本地先对齐可以省掉一轮漫长往返。
+
+```sh
+npm run lint            # biome lint
+npm run format:check    # biome format —— 与 lint 相互独立，过了一个不代表另一个也过
+npm run build
+npm run typecheck       # desktop 有 4 个 tsconfig project，含 renderer 和 storybook
+npx knip --workspace apps/desktop
+npx knip --workspace packages/ui
+```
+
+CI 里名为 `typecheck` 的 job 会在 `bash -e` 下跑完上面全部命令，第一个失败会中止其余——要看是哪个 step 失败，别看 job 名字。
+
+## 分支命名
+
+```
+<type>/<描述>
+```
+
+`<描述>` 用小写，单词间以短横线分隔。`<type>` 只能是下列之一：
+
+| 前缀 | 含义 |
+| --- | --- |
+| `feat` | 新功能 |
+| `fix` | 缺陷修复 |
+| `refactor` | 不改变行为的重构 |
+| `test` | 仅测试改动 |
+| `chore` | 构建、依赖与杂项维护 |
+| `perf` | 性能优化 |
+| `docs` | 仅文档改动 |
+| `ci` | CI 配置与流水线 |
+| `build` | 构建系统与产物 |
+
+## Pull Request
+
+开 PR 时会自动填充 [`pull_request_template.md`](./.github/pull_request_template.md)，
+其中已包含必填小节和检查清单。请在它的基础上填写，不要整段替换。
+
+**标题。** 本仓库用 squash 合并，标题会成为落到 `main` 上的提交信息。遵循 [Conventional Commits](https://www.conventionalcommits.org/)：
+
+```
+<type>(<scope>): <summary>
+```
+
+`<type>` 就是[分支命名](#分支命名)那一套。`<scope>` 是改动的 workspace 或区域——`desktop`、`ui`、`runtime`、`headless`、`settings`、`runtime-host`、`storage`、`core`、`cli`、`deps`、`computer-use`、`scripts`、`release`、`windows`、`e2e`、`security` 等——`git log` 里能看到实际在用的集合。
+
+```
+fix(desktop): classify provider action errors from the unwrapped IPC message
+feat(runtime): decouple Swarm with asynchronous wakeups
+test(core): pin the shared validation corpus to every envelope value domain
+```
+
+**界面改动。** 请附改动前后的截图或录屏。视觉变化没法从 diff 判断。
+
+**描述写短，用你自己的话。** 长篇的生成式说明会拖慢评审。用自己的话说清改了什么、为什么；如果这需要很多段落，多半是这个 PR 太大了。
+
+## 许可
+
+提交贡献即表示你同意你的贡献以 [Apache License 2.0](./LICENSE) 授权。

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ Before submitting code, run typecheck, build, and focused tests proportionate to
 - [Documentation index and authority map](./docs/README.md)
 - [Backend architecture](./ARCHITECTURE.md)
 - [Product design](./DESIGN.md)
+- [Contributing guide](./CONTRIBUTING.md)
 - [Security policy](./SECURITY.md)
 
 ## License

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -241,6 +241,7 @@ npm --workspace @maka/desktop run smoke:real-window
 - [文档索引与权威来源说明](./docs/README.md)
 - [后端架构总览](./ARCHITECTURE.zh-CN.md)
 - [产品设计](./DESIGN.md)
+- [贡献指南](./CONTRIBUTING.zh-CN.md)
 - [安全政策](./SECURITY.md)
 
 ## 开源协议


### PR DESCRIPTION
## Summary

The repository has no CONTRIBUTING file, so a first contributor has to infer the branch prefix set, the commit format that becomes the squashed commit, and which build/test entry points are the real ones — or get them wrong in review.

This records what the repository already does. It does not propose new rules, and it deliberately avoids two that would not be true here: issue templates are recommended rather than required, since blank issues are enabled; and no PR title length is imposed, since 115 of the last 300 commit subjects exceed 72 characters.

The pull request template gains a `Fixes` line, an explicit behavior-change question, and a short checklist, so those expectations sit where a PR is actually written.

English and Chinese versions are structurally identical, and both READMEs link to it.

## Verification

- Every `npm` command and path in both documents checked against `package.json` and the filesystem.
- All internal anchors, cross-document links, and the four issue-label URLs resolve.
- `npm run lint` (2583 files) and `npm run format:check` (1594 files) pass.
- Documentation only — no code paths touched, so no test suites were run.

## Checklist

- [ ] Tests cover the change and fail without it — n/a, documentation only
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No