### PR TITLE
test(windows): run managed workspace crash gates

### DIFF
--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -121,6 +121,18 @@ jobs:
           Get-Content "$env:WINDOWS_BASELINE_LOG_DIR/storage.log"
           exit $exitCode
 
+      - id: managed_workspace_crash
+        name: Run managed workspace crash recovery gates
+        if: always() && steps.build.outcome == 'success'
+        continue-on-error: true
+        shell: pwsh
+        run: |
+          $env:MAKA_STORAGE_STRESS = '1'
+          node.exe --test --test-concurrency=1 --test-name-pattern="real process crash|real crash|real-process crash|crash after baseline ref publication" packages/storage/dist/__tests__/managed-workspace-baseline.test.js packages/storage/dist/__tests__/git-workspace-service.test.js *> "$env:WINDOWS_BASELINE_LOG_DIR/managed-workspace-crash.log"
+          $exitCode = $LASTEXITCODE
+          Get-Content "$env:WINDOWS_BASELINE_LOG_DIR/managed-workspace-crash.log"
+          exit $exitCode
+
       - id: processes
         name: Audit residual job processes
         if: always()
@@ -223,6 +235,7 @@ jobs:
           | Script tests | ${{ steps.scripts.outcome }} |
           | CLI / Electron smoke | ${{ steps.smoke.outcome }} |
           | Storage suite | ${{ steps.storage.outcome }} |
+          | Managed workspace crash recovery | ${{ steps.managed_workspace_crash.outcome }} |
           | Residual processes | ${{ steps.processes.outcome }} |
 
           Download the `windows-baseline` artifact for complete logs.

--- a/scripts/windows-baseline-workflow.test.mjs
+++ b/scripts/windows-baseline-workflow.test.mjs
@@ -58,7 +58,7 @@ test('Windows baseline workflow keeps its non-blocking evidence contract', async
   assert.match(workflow, /^\s+continue-on-error: true$/mu);
   assert.match(workflow, /^\s+timeout-minutes: 45$/mu);
 
-  const stepIds = [...workflow.matchAll(/^\s+- id: ([a-z]+)$/gmu)].map((match) => match[1]);
+  const stepIds = [...workflow.matchAll(/^\s+- id: ([a-z_]+)$/gmu)].map((match) => match[1]);
   assert.deepEqual(stepIds, [
     'install',
     'build',
@@ -66,6 +66,7 @@ test('Windows baseline workflow keeps its non-blocking evidence contract', async
     'scripts',
     'smoke',
     'storage',
+    'managed_workspace_crash',
     'processes',
   ]);
   for (const stepId of stepIds) {
@@ -79,6 +80,7 @@ test('Windows baseline workflow keeps its non-blocking evidence contract', async
     'npm.cmd run test:scripts',
     'npm.cmd run smoke:windows',
     'node.exe scripts/run-workspace-tests-parallel.mjs --concurrency=1 --workspaces=packages/storage',
+    'node.exe --test --test-concurrency=1 --test-name-pattern="real process crash|real crash|real-process crash|crash after baseline ref publication" packages/storage/dist/__tests__/managed-workspace-baseline.test.js packages/storage/dist/__tests__/git-workspace-service.test.js',
   ]) {
     assert.ok(workflow.includes(command), command);
   }
@@ -103,6 +105,8 @@ test('Windows baseline workflow keeps its non-blocking evidence contract', async
     /--workspaces=packages\/storage \*> "\$env:WINDOWS_BASELINE_LOG_DIR\/storage\.log"/u,
   );
   assert.match(workflow, /Get-Content "\$env:WINDOWS_BASELINE_LOG_DIR\/storage\.log"/u);
+  assert.match(workflow, /\$env:MAKA_STORAGE_STRESS = '1'/u);
+  assert.match(workflow, /managed-workspace-crash\.log/u);
   // Pin-short-comment contract: the workflow must pin upload-artifact to a
   // full SHA and annotate it with the exact version it resolves to. The major
   // is intentionally not asserted — dependabot may bump it — but the


### PR DESCRIPTION
## Summary

- add a dedicated managed-workspace crash-recovery step to the non-blocking Windows baseline
- run the 12 existing real-process baseline, worktree, and quarantine crash gates with storage stress enabled
- serialize the focused gate to avoid process and Git workspace contention
- retain a dedicated log artifact and surface the result in the workflow summary

## Validation

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/runtime run build`
- focused Windows managed-workspace crash command (12/12 passed)
- `node --test scripts/windows-baseline-workflow.test.mjs` (3/3 passed)
- `npm run test:scripts` (127 passed, 1 platform skip)
- `git diff --check`
- no residual managed-workspace crash child processes

Part of #2142