### PR TITLE
fix(cli): format long-running turn durations

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -11,6 +11,7 @@ import {
   applyMakaSessionEventToTranscript,
   applyShellRunUpdateToTranscript,
   createMakaPiTranscriptState,
+  renderMakaPiActivityStrip,
   renderMakaPiTranscript,
   refreshRunningShellRunElapsed,
   reconcileToolsWithStoredMessages,
@@ -28,6 +29,30 @@ import {
 before(() => _setColorLevelForTesting(3));
 
 describe('Maka Pi TUI transcript', () => {
+  test('formats long-running turn durations with readable units', () => {
+    const metadata = (turnElapsedMs: number) => ({
+      title: 'Test session',
+      connectionSlug: 'test',
+      cwd: '/repo',
+      model: 'test-model',
+      permissionMode: 'ask',
+      turnElapsedMs,
+    });
+
+    assert.equal(stripAnsi(renderMakaPiActivityStrip(metadata(0), 80)), 'Working… 0s');
+    assert.equal(stripAnsi(renderMakaPiActivityStrip(metadata(59_999), 80)), 'Working… 59s');
+    assert.equal(stripAnsi(renderMakaPiActivityStrip(metadata(60_000), 80)), 'Working… 1m');
+    assert.equal(stripAnsi(renderMakaPiActivityStrip(metadata(83_000), 80)), 'Working… 1m 23s');
+    assert.equal(
+      stripAnsi(renderMakaPiActivityStrip(metadata(3_661_000), 80)),
+      'Working… 1h 1m 1s',
+    );
+    assert.equal(
+      stripAnsi(renderMakaPiActivityStrip(metadata(90_061_000), 80)),
+      'Working… 1d 1h 1m 1s',
+    );
+  });
+
   test('keeps assistant text after a tool call visible after the tool block', () => {
     const state = createMakaPiTranscriptState();
     appendUserPrompt(state, 'inspect the package');

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1354,7 +1354,7 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
 
 /**
  * One-line activity strip shown between the transcript and the editor.
- * Renders `Working… Ns` while a turn runs, or a blank reserved row when idle
+ * Renders `Working… <elapsed>` while a turn runs, or a blank reserved row when idle
  * so the layout does not jump when a turn starts or ends.
  */
 export function renderMakaPiActivityStrip(
@@ -1371,8 +1371,28 @@ export function renderMakaPiActivityStrip(
     return fitLine(ansi.dim(text), safeWidth);
   }
   if (metadata.turnElapsedMs === undefined) return '';
-  const seconds = Math.floor(metadata.turnElapsedMs / 1000);
-  return fitLine(ansi.dim(`Working… ${seconds}s`), safeWidth);
+  return fitLine(ansi.dim(`Working… ${formatElapsedDuration(metadata.turnElapsedMs)}`), safeWidth);
+}
+
+function formatElapsedDuration(elapsedMs: number): string {
+  let remainingSeconds = Math.max(0, Math.floor(elapsedMs / 1_000));
+  const units = [
+    ['d', 86_400],
+    ['h', 3_600],
+    ['m', 60],
+  ] as const;
+  const parts: string[] = [];
+
+  for (const [suffix, secondsPerUnit] of units) {
+    const value = Math.floor(remainingSeconds / secondsPerUnit);
+    if (value > 0) {
+      parts.push(`${value}${suffix}`);
+      remainingSeconds %= secondsPerUnit;
+    }
+  }
+
+  if (remainingSeconds > 0 || parts.length === 0) parts.push(`${remainingSeconds}s`);
+  return parts.join(' ');
 }
 
 /**


### PR DESCRIPTION
While using the TUI, I noticed that the activity strip keeps accumulating raw seconds for long-running turns. That makes durations such as `Working… 86400s` unnecessarily hard to scan.

This formats the elapsed time into compact day, hour, minute, and second units while keeping the existing one-second ticker and status-row layout unchanged. Examples are `59s`, `1m 23s`, `1h 1m 1s`, and `1d 1h 1m 1s`.

Tested with:
- `npm --workspace @maka/headless run build`
- `npm --workspace maka-agent run test` (461 tests)
- `npx biome check packages/cli/src/pi-transcript.ts packages/cli/src/__tests__/pi-transcript.test.ts`