### PR TITLE
fix(runtime): gate Responses replay on encrypted reasoning

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -79,6 +79,7 @@ import {
 import type { MemoryExtractionSourceSnapshot } from '../memory-extraction.js';
 import type { OpenAiResponsesSemanticBaseline } from '../openai-responses-continuation.js';
 import type { OpenAiResponsesTransportState } from '../openai-responses-websocket.js';
+import { getAIModel } from '../model-factory.js';
 
 describe('AiSdkBackend ApplyPatch routing', () => {
   test('advertises apply_patch only to supported native OpenAI models', async () => {
@@ -10809,88 +10810,176 @@ describe('AiSdkBackend thinking persistence', () => {
     assert.ok(prompt.indexOf('reasoning about the tool result') < prompt.indexOf('tool-1'));
   });
 
-  test('does not replay plaintext Responses reasoning through the encrypted OpenAI shape', async () => {
-    const ctx = {
-      sessionId: 'session-1',
-      invocationId: 'inv-1',
-      runId: 'run-prev',
-      turnId: 'turn-prev',
-      now: () => 7,
-      newId: idGenerator(),
-    } as unknown as InvocationContext;
-    const memory = createSessionEventMapMemory();
-    const priorEvents: SessionEvent[] = [
+  test('omits Responses reasoning without encrypted content from the wire request', async (t) => {
+    for (const replayCase of [
+      { name: 'missing', openai: { itemId: 'rs_deepseek' } },
       {
-        type: 'tool_start',
-        id: 'e1',
-        turnId: 'turn-prev',
-        ts: 1,
-        toolUseId: 'tool-1',
-        toolName: 'Read',
-        args: { path: 'package.json' },
-        stepId: 'm1',
+        name: 'null',
+        openai: { itemId: 'rs_deepseek', reasoningEncryptedContent: null },
       },
       {
-        type: 'tool_result',
-        id: 'e2',
-        turnId: 'turn-prev',
-        ts: 2,
-        toolUseId: 'tool-1',
-        isError: false,
-        content: { kind: 'text', text: 'file contents' },
+        name: 'empty string',
+        openai: { itemId: 'rs_deepseek', reasoningEncryptedContent: '' },
       },
-      {
-        type: 'thinking_complete',
-        id: 'e3',
-        turnId: 'turn-prev',
-        ts: 3,
-        messageId: 'm1',
-        text: 'plaintext reasoning from DeepSeek',
-        providerOptions: { openai: { itemId: 'rs_deepseek' } },
-      },
-      {
-        type: 'text_complete',
-        id: 'e4',
-        turnId: 'turn-prev',
-        ts: 4,
-        messageId: 'm1',
-        text: '',
-      },
-    ];
-    const runtimeContext = priorEvents.map((event) =>
-      mapSessionEventToRuntimeEvent(event, ctx, memory),
-    );
-    const secondModel = completionModel();
-    const secondBackend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
-      connection: {
-        slug: 'deepseek',
-        providerType: 'deepseek',
-        defaultModel: 'deepseek-v4-flash',
-      },
-      apiKey: 'deepseek-test-token',
-      modelId: 'deepseek-v4-flash',
-      modelFactory: () => secondModel,
-      tools: [],
-      newId: idGenerator(),
-      now: monotonicClock(),
-    });
+    ] as const) {
+      await t.test(replayCase.name, async () => {
+        const runtimeContext: RuntimeEvent[] = [
+          runtimeEvent({
+            id: 'e1',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            content: {
+              kind: 'thinking',
+              text: 'plaintext reasoning from DeepSeek',
+              providerOptions: { openai: replayCase.openai },
+            },
+            refs: { providerEventId: 'm1' },
+          }),
+          runtimeEvent({
+            id: 'e2',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'text', text: 'answer before the tool call' },
+            refs: { providerEventId: 'm1' },
+          }),
+          runtimeEvent({
+            id: 'e3',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            content: {
+              kind: 'function_call',
+              id: 'tool-1',
+              name: 'Read',
+              args: { path: 'package.json' },
+            },
+            refs: { toolCallId: 'tool-1', stepId: 'm1' },
+          }),
+          runtimeEvent({
+            id: 'e4',
+            turnId: 'turn-prev',
+            role: 'tool',
+            author: 'tool',
+            content: {
+              kind: 'function_response',
+              id: 'tool-1',
+              name: 'Read',
+              result: { kind: 'text', text: 'file contents' },
+            },
+            refs: { toolCallId: 'tool-1' },
+          }),
+        ];
+        let requestBody: Record<string, unknown> | undefined;
+        const fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+          requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+          const events = [
+            { type: 'response.created', response: { id: 'response-current' } },
+            {
+              type: 'response.completed',
+              response: {
+                id: 'response-current',
+                object: 'response',
+                created_at: 8,
+                model: 'deepseek-v4-flash',
+                status: 'completed',
+                output: [],
+                usage: { input_tokens: 1, output_tokens: 1 },
+              },
+            },
+          ];
+          const body = `${events
+            .map((event) => `data: ${JSON.stringify(event)}`)
+            .join('\n\n')}\n\ndata: [DONE]\n\n`;
+          return new Response(body, {
+            status: 200,
+            headers: { 'content-type': 'text/event-stream' },
+          });
+        }) as unknown as typeof globalThis.fetch;
+        const secondBackend = createTestAiSdkBackend({
+          sessionId: 'session-1',
+          header: header(),
+          appendMessage: async () => {},
+          connection: {
+            slug: 'deepseek',
+            providerType: 'deepseek',
+            defaultModel: 'deepseek-v4-flash',
+          },
+          apiKey: 'deepseek-test-token',
+          modelId: 'deepseek-v4-flash',
+          modelFactory: (input) => getAIModel({ ...input, fetch }),
+          tools: [],
+          newId: idGenerator(),
+          now: monotonicClock(),
+        });
 
-    await drain(
-      secondBackend.send({
-        turnId: 'turn-current',
-        text: 'follow up',
-        context: [],
-        runtimeContext,
-      }),
-    );
+        await drain(
+          secondBackend.send({
+            turnId: 'turn-current',
+            text: 'follow up',
+            context: [],
+            runtimeContext,
+          }),
+        );
 
-    const prompt = JSON.stringify(compactPrompt(secondModel));
-    assert.doesNotMatch(prompt, /plaintext reasoning from DeepSeek|rs_deepseek/);
-    assert.match(prompt, /"toolName":"Read"|"toolCallId":"tool-1"/);
-    assert.match(prompt, /file contents/);
+        const input = requestBody?.input;
+        assert.ok(Array.isArray(input));
+        assert.equal(
+          input.some((item) => item?.type === 'reasoning'),
+          false,
+        );
+        assert.deepEqual(
+          input.slice(0, 3).map((item) => {
+            assert.ok(item && typeof item === 'object' && !Array.isArray(item));
+            const record = item as Record<string, unknown>;
+            const content = Array.isArray(record.content) ? record.content : [];
+            const firstContent = content[0];
+            return {
+              type: record.type ?? (typeof record.role === 'string' ? 'message' : undefined),
+              role: record.role,
+              text:
+                firstContent && typeof firstContent === 'object' && !Array.isArray(firstContent)
+                  ? (firstContent as Record<string, unknown>).text
+                  : undefined,
+              callId: record.call_id,
+              name: record.name,
+              arguments: record.arguments,
+              output: record.output,
+            };
+          }),
+          [
+            {
+              type: 'message',
+              role: 'assistant',
+              text: 'answer before the tool call',
+              callId: undefined,
+              name: undefined,
+              arguments: undefined,
+              output: undefined,
+            },
+            {
+              type: 'function_call',
+              role: undefined,
+              text: undefined,
+              callId: 'tool-1',
+              name: 'Read',
+              arguments: '{"path":"package.json"}',
+              output: undefined,
+            },
+            {
+              type: 'function_call_output',
+              role: undefined,
+              text: undefined,
+              callId: 'tool-1',
+              name: undefined,
+              arguments: undefined,
+              output: '{"kind":"text","text":"file contents"}',
+            },
+          ],
+        );
+      });
+    }
   });
 
   test('OpenAI Responses reasoning from a tool step is replayed with its encrypted content', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10809,6 +10809,90 @@ describe('AiSdkBackend thinking persistence', () => {
     assert.ok(prompt.indexOf('reasoning about the tool result') < prompt.indexOf('tool-1'));
   });
 
+  test('does not replay plaintext Responses reasoning through the encrypted OpenAI shape', async () => {
+    const ctx = {
+      sessionId: 'session-1',
+      invocationId: 'inv-1',
+      runId: 'run-prev',
+      turnId: 'turn-prev',
+      now: () => 7,
+      newId: idGenerator(),
+    } as unknown as InvocationContext;
+    const memory = createSessionEventMapMemory();
+    const priorEvents: SessionEvent[] = [
+      {
+        type: 'tool_start',
+        id: 'e1',
+        turnId: 'turn-prev',
+        ts: 1,
+        toolUseId: 'tool-1',
+        toolName: 'Read',
+        args: { path: 'package.json' },
+        stepId: 'm1',
+      },
+      {
+        type: 'tool_result',
+        id: 'e2',
+        turnId: 'turn-prev',
+        ts: 2,
+        toolUseId: 'tool-1',
+        isError: false,
+        content: { kind: 'text', text: 'file contents' },
+      },
+      {
+        type: 'thinking_complete',
+        id: 'e3',
+        turnId: 'turn-prev',
+        ts: 3,
+        messageId: 'm1',
+        text: 'plaintext reasoning from DeepSeek',
+        providerOptions: { openai: { itemId: 'rs_deepseek' } },
+      },
+      {
+        type: 'text_complete',
+        id: 'e4',
+        turnId: 'turn-prev',
+        ts: 4,
+        messageId: 'm1',
+        text: '',
+      },
+    ];
+    const runtimeContext = priorEvents.map((event) =>
+      mapSessionEventToRuntimeEvent(event, ctx, memory),
+    );
+    const secondModel = completionModel();
+    const secondBackend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        slug: 'deepseek',
+        providerType: 'deepseek',
+        defaultModel: 'deepseek-v4-flash',
+      },
+      apiKey: 'deepseek-test-token',
+      modelId: 'deepseek-v4-flash',
+      modelFactory: () => secondModel,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(
+      secondBackend.send({
+        turnId: 'turn-current',
+        text: 'follow up',
+        context: [],
+        runtimeContext,
+      }),
+    );
+
+    const prompt = JSON.stringify(compactPrompt(secondModel));
+    assert.doesNotMatch(prompt, /plaintext reasoning from DeepSeek|rs_deepseek/);
+    assert.match(prompt, /"toolName":"Read"|"toolCallId":"tool-1"/);
+    assert.match(prompt, /file contents/);
+  });
+
   test('OpenAI Responses reasoning from a tool step is replayed with its encrypted content', async () => {
     const ctx = {
       sessionId: 'session-1',

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -67,7 +67,7 @@ describe('ModelAdapter stream and error normalization', () => {
       toolResults: true,
       signedThinking: false,
       unsignedThinking: true,
-      openAiResponsesThinking: false,
+      openAiResponsesEncryptedThinking: false,
     });
   });
 
@@ -121,7 +121,7 @@ describe('ModelAdapter stream and error normalization', () => {
       toolResults: true,
       signedThinking: false,
       unsignedThinking: false,
-      openAiResponsesThinking: true,
+      openAiResponsesEncryptedThinking: true,
     });
   });
 

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -3752,14 +3752,19 @@ export class AiSdkBackend implements AgentBackend {
             }
           : undefined;
       }
-      if (replaySupport.openAiResponsesThinking) {
+      if (replaySupport.openAiResponsesEncryptedThinking) {
         const openai = item.providerOptions?.openai;
         if (openai && typeof openai === 'object' && !Array.isArray(openai)) {
           const { itemId, reasoningEncryptedContent } = openai as {
             itemId?: unknown;
             reasoningEncryptedContent?: unknown;
           };
-          if (typeof itemId === 'string' && itemId.length > 0) {
+          if (
+            typeof itemId === 'string' &&
+            itemId.length > 0 &&
+            typeof reasoningEncryptedContent === 'string' &&
+            reasoningEncryptedContent.length > 0
+          ) {
             return {
               part: {
                 type: 'reasoning' as const,
@@ -3767,10 +3772,7 @@ export class AiSdkBackend implements AgentBackend {
                 providerOptions: {
                   openai: {
                     itemId,
-                    ...(typeof reasoningEncryptedContent === 'string' ||
-                    reasoningEncryptedContent === null
-                      ? { reasoningEncryptedContent }
-                      : {}),
+                    reasoningEncryptedContent,
                   },
                 },
               },

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -185,7 +185,8 @@ export class ModelAdapter {
       // relays that don't need the field ignore it. Reasoning is still
       // recorded to the event log and rendered regardless.
       unsignedThinking: this.runtime.reasoningReplay.kind === 'openai-chat-plaintext',
-      openAiResponsesThinking: this.runtime.reasoningReplay.kind === 'openai-responses-item',
+      openAiResponsesEncryptedThinking:
+        this.runtime.reasoningReplay.kind === 'openai-responses-encrypted',
     };
   }
 
@@ -634,7 +635,7 @@ export interface ModelAdapterRuntimeEventReplaySupport {
   toolResults: boolean;
   signedThinking: boolean;
   unsignedThinking: boolean;
-  openAiResponsesThinking: boolean;
+  openAiResponsesEncryptedThinking: boolean;
 }
 
 /**

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -20,7 +20,7 @@ export type ReasoningReplayContract =
   | { kind: 'none' }
   | { kind: 'anthropic-signed' }
   | { kind: 'openai-chat-plaintext'; requestField: 'observed' | 'reasoning' }
-  | { kind: 'openai-responses-item' };
+  | { kind: 'openai-responses-encrypted' };
 
 export interface ResolvedModelRuntime {
   adapter: ProviderRuntimeAdapter;
@@ -161,7 +161,10 @@ function reasoningReplayContract(
     case 'anthropic-messages':
       return { kind: 'anthropic-signed' };
     case 'openai-responses':
-      return { kind: 'openai-responses-item' };
+      // The native OpenAI serializer can replay only provider-issued encrypted
+      // reasoning when store=false. Open Responses plaintext reasoning is read
+      // by a separate response transport, but has no request codec here yet.
+      return { kind: 'openai-responses-encrypted' };
     case 'openai-chat':
       return adapter.kind === 'openai-compatible'
         ? {

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -163,7 +163,8 @@ function reasoningReplayContract(
     case 'openai-responses':
       // The native OpenAI serializer can replay only provider-issued encrypted
       // reasoning when store=false. Open Responses plaintext reasoning is read
-      // by a separate response transport, but has no request codec here yet.
+      // by a separate response transport, but has no request codec here yet;
+      // @ai-sdk/open-responses unlocks an open-responses-plaintext sibling.
       return { kind: 'openai-responses-encrypted' };
     case 'openai-chat':
       return adapter.kind === 'openai-compatible'


### PR DESCRIPTION
## Summary

Make the current Responses replay boundary explicit: Maka projects a reasoning item into the native OpenAI Responses shape only when it carries non-empty provider-issued encrypted content. Plaintext reasoning remains stored and visible, but is no longer misrepresented as an OpenAI encrypted item that the SDK warns about and drops.

Genuine encrypted OpenAI Responses reasoning and its tool ordering remain unchanged.

Part of #2513. The complete plaintext reasoning round trip remains tracked by Draft #2972.

## Boundary and scope

The plaintext reasoning serializer fix landed upstream through [vercel/ai#18515](https://github.com/vercel/ai/pull/18515) in `@ai-sdk/open-responses`. This PR does not make `reasoningReplayContract` dialect-aware: every model on the current `openai-responses` wire still has the same encrypted replay contract, and the data guard in `ai-sdk-backend.ts` decides whether a stored item is safe to project.

That guard conservatively reaches every model currently using this wire, including `volcengine-agent-plan`, `openai-responses-compatible`, `gpt-5*`, and `grok-4.5`. It only removes reasoning items that the native OpenAI serializer cannot replay with `store: false`; non-empty encrypted OpenAI reasoning continues unchanged.

The full plaintext path belongs in an `open-responses-plaintext` sibling backed by `@ai-sdk/open-responses`, as proposed in Draft #2972, rather than in a parallel serializer here.

## Verification

- Fake-fetch integration asserts the actual Responses request body, not only Maka intermediate messages.
- Missing, `null`, and empty `reasoningEncryptedContent` cases omit the reasoning item while preserving `message → function_call → function_call_output` structure and values.
- Encrypted OpenAI reasoning replay remains covered.
- `npm --workspace @maka/runtime test` — 2,788 passed, 6 skipped, 0 failed
- `npm run build:test`
- `npm run format:check`
- `npm run lint`

## Checklist

- [x] Wire-level tests cover the encrypted-only projection boundary
- [x] Plaintext reasoning remains available without entering an incompatible wire shape
- [x] Encrypted OpenAI reasoning replay remains unchanged
- [x] No global warning suppression

Does this PR entail a change in behavior?

- [x] Yes — unsupported plaintext reasoning is no longer projected into an encrypted-only wire shape
- [ ] No
