### PR TITLE
feat(desktop): expose task submission readiness

### DIFF
--- a/apps/desktop/src/main/__tests__/task-submission-readiness-main.test.ts
+++ b/apps/desktop/src/main/__tests__/task-submission-readiness-main.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { LlmConnection } from '@maka/core';
+import { createDesktopTaskSubmissionReadinessService } from '../task-submission-readiness-main.js';
+
+test('resolves defaults and projects authoritative model and workspace readiness', async () => {
+  const service = createDesktopTaskSubmissionReadinessService({
+    workspaceRoot: '/workspace',
+    runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
+    listConnections: async () => [connection()],
+    getDefaultSlug: async () => 'provider',
+    hasCredential: async () => true,
+    inspectWorkspace: async () => 'ready',
+    now: () => 100,
+  });
+
+  const snapshot = await service.getSnapshot(undefined);
+  assert.equal(snapshot.state, 'ready');
+  assert.deepEqual(snapshot.dimensions.map(({ id }) => id), [
+    'runtime',
+    'model_target',
+    'workspace',
+  ]);
+});
+
+test('keeps credential lookup failure unknown instead of inventing a repair failure', async () => {
+  const service = createDesktopTaskSubmissionReadinessService({
+    workspaceRoot: '/workspace',
+    runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
+    listConnections: async () => [connection()],
+    getDefaultSlug: async () => 'provider',
+    hasCredential: async () => { throw new Error('vault unavailable'); },
+    inspectWorkspace: async () => 'ready',
+    now: () => 100,
+  });
+
+  const snapshot = await service.getSnapshot({ model: 'model-a' });
+  assert.equal(snapshot.state, 'unknown');
+  assert.equal(snapshot.blockers[0]?.blockerCode, 'model_credentials_unknown');
+});
+
+test('reports a closed runtime and unavailable requested workspace', async () => {
+  const service = createDesktopTaskSubmissionReadinessService({
+    workspaceRoot: '/workspace',
+    runtimeState: () => ({ state: 'unavailable', checkedAt: 90 }),
+    listConnections: async () => [connection()],
+    getDefaultSlug: async () => 'provider',
+    hasCredential: async () => true,
+    inspectWorkspace: async (cwd) => cwd === '/missing' ? 'unavailable' : 'ready',
+    now: () => 100,
+  });
+
+  const snapshot = await service.getSnapshot({ cwd: '/missing' });
+  assert.equal(snapshot.state, 'unavailable');
+  assert.deepEqual(snapshot.blockers.map(({ blockerCode }) => blockerCode), [
+    'runtime_unavailable',
+    'workspace_unavailable',
+  ]);
+});
+
+test('rejects malformed renderer input before reading stores', async () => {
+  let reads = 0;
+  const service = createDesktopTaskSubmissionReadinessService({
+    workspaceRoot: '/workspace',
+    runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
+    listConnections: async () => { reads += 1; return []; },
+    getDefaultSlug: async () => null,
+    hasCredential: async () => false,
+  });
+
+  await assert.rejects(service.getSnapshot({ cwd: '', extra: true }), /INVALID_TASK_READINESS_REQUEST/);
+  assert.equal(reads, 0);
+});
+
+function connection(): LlmConnection {
+  return {
+    slug: 'provider',
+    name: 'Provider',
+    providerType: 'openai-compatible',
+    enabled: true,
+    defaultModel: 'model-a',
+    enabledModelIds: ['model-a'],
+    models: [{ id: 'model-a' }],
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/apps/desktop/src/main/__tests__/task-submission-readiness-main.test.ts
+++ b/apps/desktop/src/main/__tests__/task-submission-readiness-main.test.ts
@@ -108,6 +108,22 @@ test('rejects malformed renderer input before reading stores', async () => {
   assert.equal(reads, 0);
 });
 
+
+test('maps a missing cwd to repairable workspace_missing', async () => {
+  const service = createDesktopTaskSubmissionReadinessService({
+    workspaceRoot: '/workspace',
+    runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
+    resolveModelTarget: async () => ({ kind: 'resolved', connection: connection(), hasSecret: true }),
+    inspectWorkspace: async () => 'missing',
+    now: () => 100,
+  });
+
+  const snapshot = await service.getSnapshot({ cwd: '/gone' });
+  assert.equal(snapshot.state, 'repair_required');
+  assert.equal(snapshot.blockers[0]?.blockerCode, 'workspace_missing');
+  assert.deepEqual(snapshot.blockers[0]?.repairTarget, { kind: 'workspace_picker' });
+});
+
 function connection(): LlmConnection {
   return {
     slug: 'provider',

--- a/apps/desktop/src/main/__tests__/task-submission-readiness-main.test.ts
+++ b/apps/desktop/src/main/__tests__/task-submission-readiness-main.test.ts
@@ -1,15 +1,16 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { LlmConnection } from '@maka/core';
-import { createDesktopTaskSubmissionReadinessService } from '../task-submission-readiness-main.js';
+import {
+  createDesktopTaskSubmissionReadinessService,
+  resolveStoredModelTarget,
+} from '../task-submission-readiness-main.js';
 
 test('resolves defaults and projects authoritative model and workspace readiness', async () => {
   const service = createDesktopTaskSubmissionReadinessService({
     workspaceRoot: '/workspace',
     runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
-    listConnections: async () => [connection()],
-    getDefaultSlug: async () => 'provider',
-    hasCredential: async () => true,
+    resolveModelTarget: async () => ({ kind: 'resolved', connection: connection(), hasSecret: true }),
     inspectWorkspace: async () => 'ready',
     now: () => 100,
   });
@@ -27,9 +28,11 @@ test('keeps credential lookup failure unknown instead of inventing a repair fail
   const service = createDesktopTaskSubmissionReadinessService({
     workspaceRoot: '/workspace',
     runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
-    listConnections: async () => [connection()],
-    getDefaultSlug: async () => 'provider',
-    hasCredential: async () => { throw new Error('vault unavailable'); },
+    resolveModelTarget: async () => ({
+      kind: 'resolved',
+      connection: connection(),
+      hasSecret: undefined,
+    }),
     inspectWorkspace: async () => 'ready',
     now: () => 100,
   });
@@ -39,13 +42,11 @@ test('keeps credential lookup failure unknown instead of inventing a repair fail
   assert.equal(snapshot.blockers[0]?.blockerCode, 'model_credentials_unknown');
 });
 
-test('reports a closed runtime and unavailable requested workspace', async () => {
+test('reports a closed runtime even when model catalog resolution rejects', async () => {
   const service = createDesktopTaskSubmissionReadinessService({
     workspaceRoot: '/workspace',
     runtimeState: () => ({ state: 'unavailable', checkedAt: 90 }),
-    listConnections: async () => [connection()],
-    getDefaultSlug: async () => 'provider',
-    hasCredential: async () => true,
+    resolveModelTarget: async () => { throw new Error('catalog closed'); },
     inspectWorkspace: async (cwd) => cwd === '/missing' ? 'unavailable' : 'ready',
     now: () => 100,
   });
@@ -54,8 +55,45 @@ test('reports a closed runtime and unavailable requested workspace', async () =>
   assert.equal(snapshot.state, 'unavailable');
   assert.deepEqual(snapshot.blockers.map(({ blockerCode }) => blockerCode), [
     'runtime_unavailable',
+    'model_target_unknown',
     'workspace_unavailable',
   ]);
+});
+
+test('passes an explicit slug to one model-target resolution without requiring a default read', async () => {
+  const requestedSlugs: Array<string | undefined> = [];
+  const service = createDesktopTaskSubmissionReadinessService({
+    workspaceRoot: '/workspace',
+    runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
+    resolveModelTarget: async (requestedSlug) => {
+      requestedSlugs.push(requestedSlug);
+      return { kind: 'connection_missing', connectionSlug: requestedSlug ?? 'unexpected' };
+    },
+    inspectWorkspace: async () => 'ready',
+    now: () => 100,
+  });
+
+  const snapshot = await service.getSnapshot({ connectionSlug: 'deleted' });
+  assert.deepEqual(requestedSlugs, ['deleted']);
+  assert.equal(snapshot.blockers[0]?.blockerCode, 'model_connection_missing');
+});
+
+test('resolves connection and default from one immutable catalog snapshot', async () => {
+  let reads = 0;
+  const resolution = await resolveStoredModelTarget(undefined, {
+    getSnapshot: async () => {
+      reads += 1;
+      return { defaultSlug: 'provider', connections: [connection()] };
+    },
+    hasCredential: async (candidate) => candidate.slug === 'provider',
+  });
+
+  assert.equal(reads, 1);
+  assert.equal(resolution.kind, 'resolved');
+  if (resolution.kind === 'resolved') {
+    assert.equal(resolution.connection.slug, 'provider');
+    assert.equal(resolution.hasSecret, true);
+  }
 });
 
 test('rejects malformed renderer input before reading stores', async () => {
@@ -63,9 +101,7 @@ test('rejects malformed renderer input before reading stores', async () => {
   const service = createDesktopTaskSubmissionReadinessService({
     workspaceRoot: '/workspace',
     runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
-    listConnections: async () => { reads += 1; return []; },
-    getDefaultSlug: async () => null,
-    hasCredential: async () => false,
+    resolveModelTarget: async () => { reads += 1; return { kind: 'missing_default' }; },
   });
 
   await assert.rejects(service.getSnapshot({ cwd: '', extra: true }), /INVALID_TASK_READINESS_REQUEST/);

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -55,6 +55,10 @@ import {
 import { registerMcpIpcMain } from "./mcp-ipc-main.js";
 import { createOnboardingService } from "./onboarding-service.js";
 import { registerOnboardingIpc } from "./onboarding-ipc-main.js";
+import {
+  createDesktopTaskSubmissionReadinessService,
+  registerTaskSubmissionReadinessIpc,
+} from "./task-submission-readiness-main.js";
 import { registerNotificationsIpc } from "./notifications-ipc-main.js";
 import { registerPlanReminderIpc } from "./plan-reminders-ipc-main.js";
 import { createPlanReminderMainService } from "./plan-reminders-main.js";
@@ -714,7 +718,36 @@ function registerHostClientIpc(
       return status?.configured === true;
     },
   });
+  const taskSubmissionReadinessService = createDesktopTaskSubmissionReadinessService({
+    workspaceRoot,
+    runtimeState: () => ({ state: client.lifecycleState, checkedAt: Date.now() }),
+    listConnections: async () =>
+      projectHostConnections(await client.loadConnectionCatalog()),
+    getDefaultSlug: async () => {
+      const catalog = await client.loadConnectionCatalog();
+      const target = catalog.defaultTarget;
+      return target === null
+        ? null
+        : (catalog.connections.find(
+            ({ connectionId }) => connectionId === target.connectionId,
+          )?.slug ?? null);
+    },
+    hasCredential: async (connection) => {
+      if (!providerAuthRequiresSecret(connection.providerType)) return true;
+      const catalog = await client.loadConnectionCatalog();
+      const entry = catalog.connections.find(({ slug }) => slug === connection.slug);
+      if (!entry) return false;
+      const authKind = PROVIDER_DEFAULTS[entry.providerType].authKind;
+      const status = await client.queryCredential({
+        scope: "connection",
+        connectionId: entry.connectionId,
+        kind: authKind === "oauth_token" ? "oauth_token" : "api_key",
+      });
+      return status?.configured === true;
+    },
+  });
   registerOnboardingIpc({ onboardingService, ipcMain: scopedIpc });
+  registerTaskSubmissionReadinessIpc(taskSubmissionReadinessService, scopedIpc);
   return async () => {
     unsubscribeConfigurationChanges();
     unsubscribeSessionCatalogChanges();

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -721,29 +721,31 @@ function registerHostClientIpc(
   const taskSubmissionReadinessService = createDesktopTaskSubmissionReadinessService({
     workspaceRoot,
     runtimeState: () => ({ state: client.lifecycleState, checkedAt: Date.now() }),
-    listConnections: async () =>
-      projectHostConnections(await client.loadConnectionCatalog()),
-    getDefaultSlug: async () => {
+    resolveModelTarget: async (requestedSlug) => {
       const catalog = await client.loadConnectionCatalog();
-      const target = catalog.defaultTarget;
-      return target === null
-        ? null
-        : (catalog.connections.find(
-            ({ connectionId }) => connectionId === target.connectionId,
-          )?.slug ?? null);
-    },
-    hasCredential: async (connection) => {
-      if (!providerAuthRequiresSecret(connection.providerType)) return true;
-      const catalog = await client.loadConnectionCatalog();
+      const connections = projectHostConnections(catalog);
+      const connectionSlug = requestedSlug ?? (catalog.defaultTarget === null
+        ? undefined
+        : catalog.connections.find(
+            ({ connectionId }) => connectionId === catalog.defaultTarget?.connectionId,
+          )?.slug);
+      if (!connectionSlug) return { kind: "missing_default" };
+      const connection = connections.find(({ slug }) => slug === connectionSlug);
+      if (!connection) return { kind: "connection_missing", connectionSlug };
+      if (!providerAuthRequiresSecret(connection.providerType)) {
+        return { kind: "resolved", connection, hasSecret: true };
+      }
       const entry = catalog.connections.find(({ slug }) => slug === connection.slug);
-      if (!entry) return false;
+      if (!entry) return { kind: "connection_missing", connectionSlug };
       const authKind = PROVIDER_DEFAULTS[entry.providerType].authKind;
-      const status = await client.queryCredential({
-        scope: "connection",
-        connectionId: entry.connectionId,
-        kind: authKind === "oauth_token" ? "oauth_token" : "api_key",
-      });
-      return status?.configured === true;
+      const hasSecret = await client.queryCredential({
+          scope: "connection",
+          connectionId: entry.connectionId,
+          kind: authKind === "oauth_token" ? "oauth_token" : "api_key",
+        })
+        .then((status) => status?.configured === true)
+        .catch(() => undefined);
+      return { kind: "resolved", connection, hasSecret };
     },
   });
   registerOnboardingIpc({ onboardingService, ipcMain: scopedIpc });

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -178,11 +178,20 @@ type PricingReconciliationTarget =
 export class DesktopRuntimeHostClient {
   readonly #sessions = new Set<DesktopSessionHandle>();
   #closeTask: Promise<void> | undefined;
+  #connectionClosed = false;
 
-  constructor(private readonly connection: RuntimeHostConnection) {}
+  constructor(private readonly connection: RuntimeHostConnection) {
+    void connection.closed?.then(() => {
+      this.#connectionClosed = true;
+    });
+  }
 
   get hostEpoch(): string {
     return this.connection.hostEpoch;
+  }
+
+  get lifecycleState(): 'ready' | 'unavailable' {
+    return this.#connectionClosed || this.#closeTask ? 'unavailable' : 'ready';
   }
 
   subscribeConfigurationChanges(listener: (revision: number) => void): () => void {

--- a/apps/desktop/src/main/task-submission-readiness-main.ts
+++ b/apps/desktop/src/main/task-submission-readiness-main.ts
@@ -1,0 +1,113 @@
+import { stat } from 'node:fs/promises';
+import type { ipcMain as electronIpcMain } from 'electron';
+import {
+  deriveTaskSubmissionReadiness,
+  type LlmConnection,
+  type TaskSubmissionReadinessSnapshot,
+} from '@maka/core';
+
+export interface DesktopTaskSubmissionReadinessRequest {
+  connectionSlug?: string;
+  model?: string;
+  cwd?: string;
+}
+
+export interface DesktopTaskSubmissionReadinessDeps {
+  workspaceRoot: string;
+  runtimeState(): { state: 'ready' | 'starting' | 'unavailable' | 'unknown'; checkedAt: number };
+  listConnections(): Promise<LlmConnection[]>;
+  getDefaultSlug(): Promise<string | null>;
+  hasCredential(connection: LlmConnection): Promise<boolean>;
+  inspectWorkspace?(cwd: string): Promise<'ready' | 'unavailable' | 'unknown'>;
+  now?(): number;
+}
+
+export function createDesktopTaskSubmissionReadinessService(
+  deps: DesktopTaskSubmissionReadinessDeps,
+) {
+  return {
+    async getSnapshot(input: unknown): Promise<TaskSubmissionReadinessSnapshot> {
+      const request = normalizeRequest(input);
+      const checkedAt = deps.now?.() ?? Date.now();
+      const [connections, defaultSlug] = await Promise.all([
+        deps.listConnections(),
+        deps.getDefaultSlug(),
+      ]);
+      const connectionSlug = request.connectionSlug ?? defaultSlug ?? undefined;
+      const connection = connectionSlug
+        ? connections.find((candidate) => candidate.slug === connectionSlug)
+        : undefined;
+      const hasSecret = connection
+        ? await deps.hasCredential(connection).catch(() => undefined)
+        : undefined;
+      const cwd = request.cwd ?? deps.workspaceRoot;
+      const workspaceState = await (deps.inspectWorkspace ?? inspectWorkspace)(cwd);
+
+      return deriveTaskSubmissionReadiness({
+        checkedAt,
+        runtime: deps.runtimeState(),
+        modelTarget: {
+          connection,
+          hasSecret,
+          requestedModel: request.model,
+          checkedAt,
+        },
+        workspace: { state: workspaceState, checkedAt },
+      });
+    },
+  };
+}
+
+export function registerTaskSubmissionReadinessIpc(
+  service: ReturnType<typeof createDesktopTaskSubmissionReadinessService>,
+  target: Pick<typeof electronIpcMain, 'handle'>,
+): void {
+  target.handle('taskReadiness:getSnapshot', (_event, input: unknown) =>
+    service.getSnapshot(input),
+  );
+}
+
+async function inspectWorkspace(cwd: string): Promise<'ready' | 'unavailable' | 'unknown'> {
+  try {
+    return (await stat(cwd)).isDirectory() ? 'ready' : 'unavailable';
+  } catch (error) {
+    return isConfirmedMissingWorkspace(error) ? 'unavailable' : 'unknown';
+  }
+}
+
+function isConfirmedMissingWorkspace(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code;
+  return code === 'ENOENT' || code === 'ENOTDIR' || code === 'EACCES';
+}
+
+function normalizeRequest(input: unknown): DesktopTaskSubmissionReadinessRequest {
+  if (input === undefined) return {};
+  if (!isPlainObject(input)) throw new TypeError('INVALID_TASK_READINESS_REQUEST');
+  const allowed = new Set(['connectionSlug', 'model', 'cwd']);
+  if (Object.keys(input).some((key) => !allowed.has(key))) {
+    throw new TypeError('INVALID_TASK_READINESS_REQUEST');
+  }
+  return {
+    ...optionalNonEmptyString(input, 'connectionSlug'),
+    ...optionalNonEmptyString(input, 'model'),
+    ...optionalNonEmptyString(input, 'cwd'),
+  };
+}
+
+function optionalNonEmptyString(
+  input: Record<string, unknown>,
+  key: 'connectionSlug' | 'model' | 'cwd',
+): Partial<DesktopTaskSubmissionReadinessRequest> {
+  const value = input[key];
+  if (value === undefined) return {};
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new TypeError('INVALID_TASK_READINESS_REQUEST');
+  }
+  return { [key]: value.trim() };
+}
+
+function isPlainObject(input: unknown): input is Record<string, unknown> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) return false;
+  const prototype = Object.getPrototypeOf(input);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/apps/desktop/src/main/task-submission-readiness-main.ts
+++ b/apps/desktop/src/main/task-submission-readiness-main.ts
@@ -16,7 +16,7 @@ export interface DesktopTaskSubmissionReadinessDeps {
   workspaceRoot: string;
   runtimeState(): { state: 'ready' | 'starting' | 'unavailable' | 'unknown'; checkedAt: number };
   resolveModelTarget(requestedSlug: string | undefined): Promise<DesktopModelTargetResolution>;
-  inspectWorkspace?(cwd: string): Promise<'ready' | 'unavailable' | 'unknown'>;
+  inspectWorkspace?(cwd: string): Promise<'ready' | 'missing' | 'unavailable' | 'unknown'>;
   now?(): number;
 }
 
@@ -77,17 +77,19 @@ export function registerTaskSubmissionReadinessIpc(
   );
 }
 
-async function inspectWorkspace(cwd: string): Promise<'ready' | 'unavailable' | 'unknown'> {
+async function inspectWorkspace(
+  cwd: string,
+): Promise<'ready' | 'missing' | 'unavailable' | 'unknown'> {
   try {
     return (await stat(cwd)).isDirectory() ? 'ready' : 'unavailable';
   } catch (error) {
-    return isConfirmedMissingWorkspace(error) ? 'unavailable' : 'unknown';
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    // Missing path is repairable (pick a workspace). Access failures stay
+    // unavailable; everything else is an unknown observation.
+    if (code === 'ENOENT' || code === 'ENOTDIR') return 'missing';
+    if (code === 'EACCES') return 'unavailable';
+    return 'unknown';
   }
-}
-
-function isConfirmedMissingWorkspace(error: unknown): boolean {
-  const code = (error as NodeJS.ErrnoException | undefined)?.code;
-  return code === 'ENOENT' || code === 'ENOTDIR' || code === 'EACCES';
 }
 
 function normalizeRequest(input: unknown): DesktopTaskSubmissionReadinessRequest {

--- a/apps/desktop/src/main/task-submission-readiness-main.ts
+++ b/apps/desktop/src/main/task-submission-readiness-main.ts
@@ -15,11 +15,31 @@ export interface DesktopTaskSubmissionReadinessRequest {
 export interface DesktopTaskSubmissionReadinessDeps {
   workspaceRoot: string;
   runtimeState(): { state: 'ready' | 'starting' | 'unavailable' | 'unknown'; checkedAt: number };
-  listConnections(): Promise<LlmConnection[]>;
-  getDefaultSlug(): Promise<string | null>;
-  hasCredential(connection: LlmConnection): Promise<boolean>;
+  resolveModelTarget(requestedSlug: string | undefined): Promise<DesktopModelTargetResolution>;
   inspectWorkspace?(cwd: string): Promise<'ready' | 'unavailable' | 'unknown'>;
   now?(): number;
+}
+
+export type DesktopModelTargetResolution =
+  | { kind: 'resolved'; connection: LlmConnection; hasSecret?: boolean }
+  | { kind: 'missing_default' }
+  | { kind: 'connection_missing'; connectionSlug: string }
+  | { kind: 'unknown' };
+
+export async function resolveStoredModelTarget(
+  requestedSlug: string | undefined,
+  deps: {
+    getSnapshot(): Promise<{ defaultSlug: string | null; connections: LlmConnection[] }>;
+    hasCredential(connection: LlmConnection): Promise<boolean>;
+  },
+): Promise<DesktopModelTargetResolution> {
+  const catalog = await deps.getSnapshot();
+  const connectionSlug = requestedSlug ?? catalog.defaultSlug ?? undefined;
+  if (!connectionSlug) return { kind: 'missing_default' };
+  const connection = catalog.connections.find((candidate) => candidate.slug === connectionSlug);
+  if (!connection) return { kind: 'connection_missing', connectionSlug };
+  const hasSecret = await deps.hasCredential(connection).catch(() => undefined);
+  return { kind: 'resolved', connection, hasSecret };
 }
 
 export function createDesktopTaskSubmissionReadinessService(
@@ -29,29 +49,19 @@ export function createDesktopTaskSubmissionReadinessService(
     async getSnapshot(input: unknown): Promise<TaskSubmissionReadinessSnapshot> {
       const request = normalizeRequest(input);
       const checkedAt = deps.now?.() ?? Date.now();
-      const [connections, defaultSlug] = await Promise.all([
-        deps.listConnections(),
-        deps.getDefaultSlug(),
-      ]);
-      const connectionSlug = request.connectionSlug ?? defaultSlug ?? undefined;
-      const connection = connectionSlug
-        ? connections.find((candidate) => candidate.slug === connectionSlug)
-        : undefined;
-      const hasSecret = connection
-        ? await deps.hasCredential(connection).catch(() => undefined)
-        : undefined;
+      const modelTarget = await deps.resolveModelTarget(request.connectionSlug).catch(
+        (): DesktopModelTargetResolution => ({ kind: 'unknown' }),
+      );
       const cwd = request.cwd ?? deps.workspaceRoot;
       const workspaceState = await (deps.inspectWorkspace ?? inspectWorkspace)(cwd);
 
       return deriveTaskSubmissionReadiness({
         checkedAt,
         runtime: deps.runtimeState(),
-        modelTarget: {
-          connection,
-          hasSecret,
-          requestedModel: request.model,
-          checkedAt,
-        },
+        modelTarget:
+          modelTarget.kind === 'resolved'
+            ? { ...modelTarget, requestedModel: request.model, checkedAt }
+            : { ...modelTarget, checkedAt },
         workspace: { state: workspaceState, checkedAt },
       });
     },

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -118,6 +118,12 @@ export interface OnboardingSnapshot {
   sessionSendOutcomes: Record<string, import('@maka/core').SessionSendProjection>;
 }
 
+export interface DesktopTaskSubmissionReadinessRequest {
+  connectionSlug?: string;
+  model?: string;
+  cwd?: string;
+}
+
 export type RendererIngestInput =
   | { approvalId: string; name: string; mimeType?: string }
   | { file: File };
@@ -501,6 +507,11 @@ export interface MakaBridge {
       status: 'completed' | 'skipped',
     ): Promise<OnboardingSnapshot>;
     clearMilestone(id: OnboardingMilestoneId): Promise<OnboardingSnapshot>;
+  };
+  taskReadiness: {
+    getSnapshot(
+      input?: DesktopTaskSubmissionReadinessRequest,
+    ): Promise<import('@maka/core').TaskSubmissionReadinessSnapshot>;
   };
   permissions: {
     getSnapshot(): Promise<PermissionSnapshot>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3,6 +3,7 @@ import { encodeIngestItems } from './attachment-ingest-payload.js';
 import type {
   MakaBridge,
   OnboardingSnapshot,
+  DesktopTaskSubmissionReadinessRequest,
   PermissionActionResult,
   PermissionOverlayStartResult,
   RendererIngestInput,
@@ -612,6 +613,11 @@ const makaBridge = {
     },
     clearMilestone(id: OnboardingMilestoneId): Promise<OnboardingSnapshot> {
       return ipcRenderer.invoke('onboarding:clearMilestone', id);
+    },
+  },
+  taskReadiness: {
+    getSnapshot(input?: DesktopTaskSubmissionReadinessRequest) {
+      return ipcRenderer.invoke('taskReadiness:getSnapshot', input);
     },
   },
   permissions: {

--- a/packages/core/src/__tests__/task-submission-readiness.test.ts
+++ b/packages/core/src/__tests__/task-submission-readiness.test.ts
@@ -21,6 +21,7 @@ describe('task submission readiness', () => {
 
   test('reuses connection readiness and routes an invalid model to its connection', () => {
     const input = readyInput();
+    if (input.modelTarget.kind !== 'resolved') throw new Error('expected resolved model target');
     input.modelTarget.requestedModel = 'removed-model';
     const snapshot = deriveTaskSubmissionReadiness(input);
 
@@ -37,12 +38,33 @@ describe('task submission readiness', () => {
 
   test('does not turn unresolved credentials into a confirmed repair failure', () => {
     const input = readyInput();
+    if (input.modelTarget.kind !== 'resolved') throw new Error('expected resolved model target');
     input.modelTarget.hasSecret = undefined;
     const snapshot = deriveTaskSubmissionReadiness(input);
 
     expect(snapshot.state).toBe('unknown');
     expect(snapshot.blockers[0]?.blockerCode).toBe('model_credentials_unknown');
     expect(snapshot.blockers[0]?.repairTarget).toBe(undefined);
+  });
+
+  test('normalizes a legacy Codex session model exactly like the send path', () => {
+    const input = readyInput();
+    input.modelTarget = {
+      kind: 'resolved',
+      connection: {
+        ...connection(),
+        slug: 'codex-sub',
+        providerType: 'openai-codex',
+        defaultModel: 'gpt-5.6-sol',
+        enabledModelIds: ['gpt-5.6-sol'],
+        models: [{ id: 'gpt-5.6-sol' }],
+      },
+      hasSecret: true,
+      requestedModel: 'gpt-5-codex',
+      checkedAt: 90,
+    };
+
+    expect(deriveTaskSubmissionReadiness(input).state).toBe('ready');
   });
 
   test('distinguishes unavailable runtime and workspace from repairable setup', () => {
@@ -90,6 +112,7 @@ function readyInput(): DeriveTaskSubmissionReadinessInput {
     checkedAt: 100,
     runtime: { state: 'ready', checkedAt: 95 },
     modelTarget: {
+      kind: 'resolved',
       connection: connection(),
       hasSecret: true,
       requestedModel: 'model-a',

--- a/packages/core/src/task-submission-readiness.ts
+++ b/packages/core/src/task-submission-readiness.ts
@@ -1,4 +1,9 @@
-import { isConnectionReady, type ChatConfigurationReason } from './connection-readiness.js';
+import {
+  isConnectionReady,
+  normalizeOpenAiCodexConnection,
+  normalizeRequestedModelForReadiness,
+  type ChatConfigurationReason,
+} from './connection-readiness.js';
 import type { LlmConnection } from './llm-connections.js';
 
 export const TASK_SUBMISSION_READINESS_STATES = [
@@ -22,6 +27,7 @@ export type TaskSubmissionReadinessRepairTarget =
 export type TaskSubmissionReadinessBlockerCode =
   | `model_${ChatConfigurationReason}`
   | 'model_credentials_unknown'
+  | 'model_target_unknown'
   | 'runtime_unavailable'
   | 'runtime_unknown'
   | 'workspace_missing'
@@ -63,12 +69,17 @@ export interface DeriveTaskSubmissionReadinessInput {
     state: 'ready' | 'starting' | 'unavailable' | 'unknown';
     checkedAt: number;
   };
-  modelTarget: {
-    connection?: LlmConnection;
-    hasSecret?: boolean;
-    requestedModel?: string;
-    checkedAt: number;
-  };
+  modelTarget:
+    | {
+        kind: 'resolved';
+        connection: LlmConnection;
+        hasSecret?: boolean;
+        requestedModel?: string;
+        checkedAt: number;
+      }
+    | { kind: 'missing_default'; checkedAt: number }
+    | { kind: 'connection_missing'; connectionSlug: string; checkedAt: number }
+    | { kind: 'unknown'; checkedAt: number };
   workspace: {
     state: 'ready' | 'missing' | 'unavailable' | 'unknown';
     checkedAt: number;
@@ -124,17 +135,29 @@ function runtimeDimension(
 function modelTargetDimension(
   target: DeriveTaskSubmissionReadinessInput['modelTarget'],
 ): TaskSubmissionReadinessDimension {
-  if (!target.connection) {
+  if (target.kind === 'unknown') {
+    return dimension('model_target', 'unknown', 'connection_readiness', target.checkedAt, {
+      blockerCode: 'model_target_unknown',
+    });
+  }
+  if (target.kind === 'missing_default') {
     return dimension('model_target', 'repair_required', 'connection_readiness', target.checkedAt, {
       blockerCode: 'model_missing_default_connection',
       repairTarget: { kind: 'provider_catalog' },
     });
   }
+  if (target.kind === 'connection_missing') {
+    return dimension('model_target', 'repair_required', 'connection_readiness', target.checkedAt, {
+      blockerCode: 'model_connection_missing',
+      repairTarget: { kind: 'models' },
+    });
+  }
 
+  const normalizedConnection = normalizeOpenAiCodexConnection(target.connection);
   const verdict = isConnectionReady({
-    connection: target.connection,
+    connection: normalizedConnection,
     hasSecret: target.hasSecret === true,
-    requestedModel: target.requestedModel,
+    requestedModel: normalizeRequestedModelForReadiness(target.connection, target.requestedModel),
   });
   if (verdict.ready) {
     return dimension('model_target', 'ready', 'connection_readiness', target.checkedAt);
@@ -146,7 +169,7 @@ function modelTargetDimension(
   }
   return dimension('model_target', 'repair_required', 'connection_readiness', target.checkedAt, {
     blockerCode: `model_${verdict.reason}`,
-    repairTarget: modelRepairTarget(verdict.reason, target.connection.slug),
+    repairTarget: modelRepairTarget(verdict.reason, normalizedConnection.slug),
   });
 }
 

--- a/packages/storage/src/connection-store.ts
+++ b/packages/storage/src/connection-store.ts
@@ -17,6 +17,7 @@ import { pruneRelayModelProfiles } from '@maka/core/model-thinking';
 import { relayProfilesForStorage } from './relay-profile-store.js';
 
 export interface ConnectionStore {
+  getSnapshot(): Promise<ConnectionStoreSnapshot>;
   list(): Promise<LlmConnection[]>;
   get(slug: string): Promise<LlmConnection | null>;
   create(input: CreateConnectionInput): Promise<LlmConnection>;
@@ -39,6 +40,11 @@ export interface ConnectionStore {
    * when there is no default, or when the default entry itself is unusable.
    */
   getDefaultConnection(): Promise<LlmConnection | null>;
+}
+
+export interface ConnectionStoreSnapshot {
+  defaultSlug: string | null;
+  connections: LlmConnection[];
 }
 
 interface ConnectionsFile {
@@ -69,6 +75,10 @@ class FileConnectionStore implements ConnectionStore {
 
   constructor(workspaceRoot: string, explicitPath?: string) {
     this.path = explicitPath ?? join(workspaceRoot, 'llm-connections.json');
+  }
+
+  async getSnapshot(): Promise<ConnectionStoreSnapshot> {
+    return await this.read();
   }
 
   async list(): Promise<LlmConnection[]> {


### PR DESCRIPTION
## Summary

Rebased landing of #2501 onto current main (post M5 Runtime Host cutover).

Second slice of #2497: Desktop Main adapter + typed preload IPC for the core projection from #2498.

- Resolves connection/model from a single catalog snapshot (atomic, no list/default race)
- Credential presence is read-only; failures stay `unknown`, not invented repair
- Workspace inspect maps `ENOENT`/`ENOTDIR` → `missing` (repair_required + workspace_picker); `EACCES` → unavailable
- Runtime Host tracks connection close → `lifecycleState: unavailable`
- IPC: `window.maka.taskReadiness.getSnapshot(...)` with strict input validation
- No Composer UI yet (explicit scope)

## Rebase notes vs upstream #2501

Main no longer has embedded `boot.ts` (M5 cutover). **Dropped the embedded boot wiring entirely** — only Runtime Host owner registers the IPC contract.

Also kept `DesktopRuntimeHostClient` subscribe helpers from main alongside the new `lifecycleState` getter.

## Validation

- `task-submission-readiness` core tests: 7/7
- Prior CI on the fork PR was green (including workspaces/typecheck)

Refs #2497 #2469

Closes #2501.

## Credits

@liugddx
