### PR TITLE
feat(desktop): consume task submission readiness

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-first-send-cleanup.test.ts
@@ -70,6 +70,7 @@ function createActionsDeps() {
       sessionId: undefined,
       navSection: 'sessions' as const,
     }),
+    checkTaskSubmissionReadiness: async () => true,
     clearPendingSessionAction: () => undefined,
     isNewChatSendSurfaceActive: () => true,
     isShellSurfaceOwnerActive: () => true,
@@ -95,6 +96,41 @@ function createActionsDeps() {
 }
 
 describe('composer first-send cleanup', () => {
+  it('cancels when the composer owner changes during the readiness check', async () => {
+    const readiness = deferred<boolean>();
+    const activeIdRef = { current: 'session-a' as string | undefined };
+    let sends = 0;
+    const restoreWindow = installWindow({
+      sessions: {
+        send: async () => {
+          sends += 1;
+          return { ok: true, attachments: [], skillInvocation: { loaded: [], failed: [] } };
+        },
+      },
+    });
+
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef,
+        captureComposerImportOwner: () => ({
+          sessionId: activeIdRef.current,
+          navSection: 'sessions',
+        }),
+        checkTaskSubmissionReadiness: () => readiness.promise,
+        isShellSurfaceOwnerActive: (owner) => owner.sessionId === activeIdRef.current,
+      });
+      const sending = actions.send('hello');
+      activeIdRef.current = 'session-b';
+      readiness.resolve(true);
+
+      assert.equal(await sending, false);
+      assert.equal(sends, 0, 'readiness for session A must never authorize a send to session B');
+    } finally {
+      restoreWindow();
+    }
+  });
+
   it('passes the effective offered model when creating the first session', async () => {
     let createInput: unknown;
     const restoreWindow = installWindow({
@@ -238,6 +274,14 @@ describe('composer first-send cleanup', () => {
     assert.deepEqual(removed, []);
   });
 });
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
 
 /**
  * #1433 round 5: the failure feedback for a send is addressed to the surface

--- a/apps/desktop/src/main/__tests__/task-readiness-notice.test.ts
+++ b/apps/desktop/src/main/__tests__/task-readiness-notice.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { TaskSubmissionReadinessSnapshot } from '@maka/core';
+import {
+  deriveTaskReadinessNotice,
+  isTaskSubmissionHardBlocked,
+} from '../../renderer/task-readiness-notice.js';
+
+test('confirmed repair and unavailable states block, while loading uncertainty does not', () => {
+  assert.equal(isTaskSubmissionHardBlocked(snapshot('repair_required', 'model_target')), true);
+  assert.equal(isTaskSubmissionHardBlocked(snapshot('unavailable', 'runtime')), true);
+  assert.equal(isTaskSubmissionHardBlocked(snapshot('unknown', 'runtime')), false);
+  assert.equal(isTaskSubmissionHardBlocked(undefined), false);
+});
+
+test('runtime and workspace blockers produce actionable localized notices', () => {
+  const runtime = deriveTaskReadinessNotice(snapshot('unavailable', 'runtime'), 'en');
+  assert.equal(runtime?.action, 'retry');
+  assert.match(runtime?.title ?? '', /runtime/i);
+
+  const workspace = deriveTaskReadinessNotice(snapshot('unavailable', 'workspace'), 'zh');
+  assert.equal(workspace?.action, 'new_task');
+  assert.match(workspace?.title ?? '', /工作区/);
+});
+
+test('model blockers stay owned by existing connection recovery surfaces', () => {
+  assert.equal(
+    deriveTaskReadinessNotice(snapshot('repair_required', 'model_target'), 'zh'),
+    undefined,
+  );
+});
+
+function snapshot(
+  state: TaskSubmissionReadinessSnapshot['state'],
+  id: 'runtime' | 'model_target' | 'workspace',
+): TaskSubmissionReadinessSnapshot {
+  const dimension = {
+    id,
+    state,
+    authority:
+      id === 'runtime'
+        ? ('runtime_host' as const)
+        : id === 'workspace'
+          ? ('workspace_execution' as const)
+          : ('connection_readiness' as const),
+    checkedAt: 1,
+  };
+  return {
+    checkedAt: 1,
+    state,
+    dimensions: [dimension],
+    blockers: state === 'ready' ? [] : [dimension],
+  };
+}

--- a/apps/desktop/src/main/__tests__/task-readiness-notice.test.ts
+++ b/apps/desktop/src/main/__tests__/task-readiness-notice.test.ts
@@ -4,11 +4,29 @@ import type { TaskSubmissionReadinessSnapshot } from '@maka/core';
 import {
   deriveTaskReadinessNotice,
   isTaskSubmissionHardBlocked,
+  resolveTaskReadinessModelTarget,
 } from '../../renderer/task-readiness-notice.js';
+
+test('an unlocked stale session checks the send projection rebind target', () => {
+  assert.deepEqual(
+    resolveTaskReadinessModelTarget(
+      { llmConnectionSlug: 'stale', model: 'removed-model' },
+      { kind: 'rebind', connectionSlug: 'healthy', model: 'ready-model' },
+      undefined,
+    ),
+    { connectionSlug: 'healthy', model: 'ready-model' },
+  );
+});
 
 test('confirmed repair and unavailable states block, while loading uncertainty does not', () => {
   assert.equal(isTaskSubmissionHardBlocked(snapshot('repair_required', 'model_target')), true);
   assert.equal(isTaskSubmissionHardBlocked(snapshot('unavailable', 'runtime')), true);
+  assert.equal(
+    isTaskSubmissionHardBlocked(snapshot('repair_required', 'model_target'), {
+      ignoreModelTarget: true,
+    }),
+    false,
+  );
   assert.equal(isTaskSubmissionHardBlocked(snapshot('unknown', 'runtime')), false);
   assert.equal(isTaskSubmissionHardBlocked(undefined), false);
 });
@@ -19,7 +37,7 @@ test('runtime and workspace blockers produce actionable localized notices', () =
   assert.match(runtime?.title ?? '', /runtime/i);
 
   const workspace = deriveTaskReadinessNotice(snapshot('unavailable', 'workspace'), 'zh');
-  assert.equal(workspace?.action, 'new_task');
+  assert.equal(workspace?.action, 'workspace_picker');
   assert.match(workspace?.title ?? '', /工作区/);
 });
 
@@ -44,6 +62,7 @@ function snapshot(
           ? ('workspace_execution' as const)
           : ('connection_readiness' as const),
     checkedAt: 1,
+    ...(id === 'workspace' ? { repairTarget: { kind: 'workspace_picker' as const } } : {}),
   };
   return {
     checkedAt: 1,

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -139,6 +139,7 @@ export function createAppShellChatActions(deps: {
     setPendingBySession: BooleanRecordUpdater,
   ) => boolean;
   captureComposerImportOwner: () => ComposerImportOwner;
+  checkTaskSubmissionReadiness: () => Promise<boolean>;
   clearPendingSessionAction: (
     sessionId: string,
     pendingRef: RefBox<Set<string>>,
@@ -178,6 +179,7 @@ export function createAppShellChatActions(deps: {
     activeIdRef,
     addPendingSessionAction,
     captureComposerImportOwner,
+    checkTaskSubmissionReadiness,
     clearPendingSessionAction,
     isNewChatSendSurfaceActive,
     isShellSurfaceOwnerActive,
@@ -305,6 +307,13 @@ export function createAppShellChatActions(deps: {
     const initialSessionId = activeIdRef.current;
     const sendOwner = captureComposerImportOwner();
     const newChatOwner = initialSessionId ? null : sendOwner;
+    if (!(await checkTaskSubmissionReadiness())) return false;
+    if (
+      (initialSessionId && !isShellSurfaceOwnerActive(sendOwner)) ||
+      (newChatOwner && !isNewChatSendSurfaceActive(newChatOwner))
+    ) {
+      return false;
+    }
     let optimisticSessionId: string | undefined;
     let optimisticTurnId: string | undefined;
     // #1433: the composer creates the session BEFORE it sends, so a first

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1854,6 +1854,7 @@ function AppShellContent({
     activeIdRef,
     addPendingSessionAction,
     captureComposerImportOwner,
+    checkTaskSubmissionReadiness: taskSubmissionReadyAtSend,
     clearPendingSessionAction,
     isNewChatSendSurfaceActive,
     isShellSurfaceOwnerActive,
@@ -2023,7 +2024,6 @@ function AppShellContent({
       }
       const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
       const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
-      if (!(await taskSubmissionReadyAtSend())) return false;
       const ok = await send(swarmCommand.task, pending, {
         turnOrchestration: { mode: 'swarm', source: 'slash_command' },
         ...(quotes ? { quotes } : {}),
@@ -2066,7 +2066,6 @@ function AppShellContent({
       }
       const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
       const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
-      if (!(await taskSubmissionReadyAtSend())) return false;
       const ok = await send(graphCommand.task, pending, {
         turnOrchestration: { mode: 'graph', source: 'slash_command' },
         ...(quotes ? { quotes } : {}),
@@ -2089,7 +2088,6 @@ function AppShellContent({
       ? revisionDraftRef.current
       : undefined;
     const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
-    if (!(await taskSubmissionReadyAtSend())) return false;
     const ok = await send(text, pending, {
       ...(quotes ? { quotes } : {}),
       ...(metadata?.workspaceFileReferences?.length

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -55,6 +55,11 @@ import { MessageCircleQuestion } from '@maka/ui/icons';
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
 import { ChatMessageSurface } from './chat-message-surface';
+import { useTaskSubmissionReadiness } from './use-task-submission-readiness';
+import {
+  deriveTaskReadinessNotice,
+  isTaskSubmissionHardBlocked,
+} from './task-readiness-notice';
 import { deriveWorkspaceReadinessRecovery } from './workspace-readiness-recovery';
 import { LiveTurnReconciler } from './live-turn-reconciler';
 import { useAppShellSessionUiReads } from './use-app-shell-session-ui-reads';
@@ -1753,6 +1758,17 @@ function AppShellContent({
     },
     onSelectNoProject: selectNoProject,
   };
+  const taskReadinessRequest = {
+    connectionSlug: activeSession?.llmConnectionSlug ?? newChatModel?.llmConnectionSlug,
+    model: activeSession?.model ?? newChatModel?.model,
+    cwd: activeSession?.cwd ?? projectInfo?.projectPath,
+  };
+  const taskReadiness = useTaskSubmissionReadiness(
+    taskReadinessRequest,
+    onboarding.snapshot,
+  );
+  const taskReadinessNotice = deriveTaskReadinessNotice(taskReadiness.snapshot, uiLocale);
+  const taskSubmissionHardBlocked = isTaskSubmissionHardBlocked(taskReadiness.snapshot);
   // The titlebar names the directory the ACTIVE session runs in, so it reads
   // the same projected project state the picker does — `projectInfo` already
   // resolves to the session's own cwd once a session owns it.
@@ -2777,7 +2793,9 @@ function AppShellContent({
                   onOpenModelSettings={() => openSettingsSection('models')}
                   noModelConnection={connections.length === 0}
                   sendBlocked={
-                    Boolean(workspaceReadinessRecovery) || sessionHealthNotice?.tone === 'destructive'
+                    Boolean(workspaceReadinessRecovery) ||
+                    sessionHealthNotice?.tone === 'destructive' ||
+                    taskSubmissionHardBlocked
                   }
                   permissionMode={activePermissionMode}
                   permissionModePending={activeId ? pendingPermissionModeBySession[activeId] === true : false}
@@ -2958,6 +2976,12 @@ function AppShellContent({
                 }}
                 sessionHealthNotice={sessionHealthNotice}
                 workspaceReadinessRecovery={workspaceReadinessRecovery}
+                taskReadinessNotice={taskReadinessNotice}
+                onTaskReadinessAction={
+                  taskReadinessNotice?.action === 'new_task'
+                    ? openNewTaskSurface
+                    : taskReadiness.refresh
+                }
                 showOnboardingHero={showOnboardingHero}
                 onboardingState={onboardingState}
                 isOnboardingLoading={isOnboardingLoading}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -59,6 +59,7 @@ import { useTaskSubmissionReadiness } from './use-task-submission-readiness';
 import {
   deriveTaskReadinessNotice,
   isTaskSubmissionHardBlocked,
+  resolveTaskReadinessModelTarget,
 } from './task-readiness-notice';
 import { deriveWorkspaceReadinessRecovery } from './workspace-readiness-recovery';
 import { LiveTurnReconciler } from './live-turn-reconciler';
@@ -720,6 +721,9 @@ function AppShellContent({
   // live in useShellChatModel (pure derivation of the snapshot + active session);
   // openSettingsSection is injected so the notice can wrap the derived click
   // target.
+  const activeSessionSendOutcome = activeSession
+    ? onboarding.snapshot?.sessionSendOutcomes[activeSession.id]
+    : undefined;
   const {
     chatModelChoices,
     activeConnection,
@@ -740,9 +744,7 @@ function AppShellContent({
     uiLocale,
     connections,
     snapshotChoices: onboarding.snapshot?.chatModelChoices,
-    sessionSendOutcome: activeSession
-      ? onboarding.snapshot?.sessionSendOutcomes[activeSession.id]
-      : undefined,
+    sessionSendOutcome: activeSessionSendOutcome,
     defaultConnection,
     activationCandidate: onboardingActivationCandidate,
     activeSession,
@@ -1759,8 +1761,7 @@ function AppShellContent({
     onSelectNoProject: selectNoProject,
   };
   const taskReadinessRequest = {
-    connectionSlug: activeSession?.llmConnectionSlug ?? newChatModel?.llmConnectionSlug,
-    model: activeSession?.model ?? newChatModel?.model,
+    ...resolveTaskReadinessModelTarget(activeSession, activeSessionSendOutcome, newChatModel),
     cwd: activeSession?.cwd ?? projectInfo?.projectPath,
   };
   const taskReadiness = useTaskSubmissionReadiness(
@@ -1768,7 +1769,11 @@ function AppShellContent({
     onboarding.snapshot,
   );
   const taskReadinessNotice = deriveTaskReadinessNotice(taskReadiness.snapshot, uiLocale);
-  const taskSubmissionHardBlocked = isTaskSubmissionHardBlocked(taskReadiness.snapshot);
+  const ignoreTaskReadinessModelTarget =
+    activeSession !== undefined && activeSessionSendOutcome?.kind !== 'blocked';
+  const taskSubmissionHardBlocked = isTaskSubmissionHardBlocked(taskReadiness.snapshot, {
+    ignoreModelTarget: ignoreTaskReadinessModelTarget,
+  });
   // The titlebar names the directory the ACTIVE session runs in, so it reads
   // the same projected project state the picker does — `projectInfo` already
   // resolves to the session's own cwd once a session owns it.
@@ -1912,6 +1917,13 @@ function AppShellContent({
     upsertSessionSummary,
   });
 
+  async function taskSubmissionReadyAtSend(): Promise<boolean> {
+    const snapshot = await taskReadiness.checkNow();
+    return !isTaskSubmissionHardBlocked(snapshot, {
+      ignoreModelTarget: ignoreTaskReadinessModelTarget,
+    });
+  }
+
   async function sendWithAttachments(
     text: string,
     metadata?: { workspaceFileReferences?: readonly WorkspaceFileReferencePosition[] },
@@ -2011,6 +2023,7 @@ function AppShellContent({
       }
       const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
       const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
+      if (!(await taskSubmissionReadyAtSend())) return false;
       const ok = await send(swarmCommand.task, pending, {
         turnOrchestration: { mode: 'swarm', source: 'slash_command' },
         ...(quotes ? { quotes } : {}),
@@ -2053,6 +2066,7 @@ function AppShellContent({
       }
       const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
       const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
+      if (!(await taskSubmissionReadyAtSend())) return false;
       const ok = await send(graphCommand.task, pending, {
         turnOrchestration: { mode: 'graph', source: 'slash_command' },
         ...(quotes ? { quotes } : {}),
@@ -2075,6 +2089,7 @@ function AppShellContent({
       ? revisionDraftRef.current
       : undefined;
     const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
+    if (!(await taskSubmissionReadyAtSend())) return false;
     const ok = await send(text, pending, {
       ...(quotes ? { quotes } : {}),
       ...(metadata?.workspaceFileReferences?.length
@@ -2978,8 +2993,12 @@ function AppShellContent({
                 workspaceReadinessRecovery={workspaceReadinessRecovery}
                 taskReadinessNotice={taskReadinessNotice}
                 onTaskReadinessAction={
-                  taskReadinessNotice?.action === 'new_task'
-                    ? openNewTaskSurface
+                  taskReadinessNotice?.action === 'workspace_picker'
+                    ? activeSession
+                      ? openNewTaskSurface
+                      : () => {
+                          void addProject();
+                        }
                     : taskReadiness.refresh
                 }
                 showOnboardingHero={showOnboardingHero}

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -11,6 +11,7 @@ import { OnboardingHero } from './onboarding-hero';
 import type { AppShellSessionUiState, AppShellSessionUiStateController } from './app-shell-session-ui-state';
 import type { SessionHealthNoticeView } from './use-shell-chat-model';
 import type { WorkspaceReadinessRecovery } from './workspace-readiness-recovery';
+import type { TaskReadinessNotice } from './task-readiness-notice';
 import { getShellCopy } from './locales/shell-copy';
 import { selectLiveTurn } from './use-app-shell-session-ui-reads';
 import { useAppShellSessionUiSelector } from './use-app-shell-session-ui-selector';
@@ -44,6 +45,8 @@ interface ChatMessageSurfaceProps extends Omit<
   activeSessionId: string | undefined;
   sessionHealthNotice?: SessionHealthNoticeView;
   workspaceReadinessRecovery?: WorkspaceReadinessRecovery;
+  taskReadinessNotice?: TaskReadinessNotice;
+  onTaskReadinessAction: () => void;
   showOnboardingHero: boolean;
   onboardingState: OnboardingState | undefined;
   isOnboardingLoading: boolean;
@@ -61,6 +64,8 @@ export function ChatMessageSurface({
   activeSessionId,
   sessionHealthNotice,
   workspaceReadinessRecovery,
+  taskReadinessNotice,
+  onTaskReadinessAction,
   showOnboardingHero,
   onboardingState,
   isOnboardingLoading,
@@ -147,6 +152,22 @@ export function ChatMessageSurface({
         deepResearchRun={deepResearchRun}
         emptyOverride={emptyOverride}
       />
+      {taskReadinessNotice && (
+        <div className="maka-workspace-readiness-notice">
+          <Banner
+            status={taskReadinessNotice.tone === 'destructive' ? 'error' : 'warning'}
+            className="maka-workspace-readiness-notice-alert"
+            role="status"
+            title={taskReadinessNotice.title}
+            description={taskReadinessNotice.description}
+            endContent={<Button
+              label={taskReadinessNotice.actionLabel}
+              variant="ghost"
+              size="sm"
+              onClick={onTaskReadinessAction}
+            />} />
+        </div>
+      )}
       {workspaceReadinessRecovery && (
         <div className="maka-workspace-readiness-notice">
           <Banner

--- a/apps/desktop/src/renderer/task-readiness-notice.ts
+++ b/apps/desktop/src/renderer/task-readiness-notice.ts
@@ -1,0 +1,72 @@
+import type {
+  TaskSubmissionReadinessDimension,
+  TaskSubmissionReadinessSnapshot,
+  UiLocale,
+} from '@maka/core';
+
+export interface TaskReadinessNotice {
+  tone: 'warning' | 'destructive';
+  title: string;
+  description: string;
+  actionLabel: string;
+  action: 'retry' | 'new_task';
+}
+
+export function isTaskSubmissionHardBlocked(
+  snapshot: TaskSubmissionReadinessSnapshot | undefined,
+): boolean {
+  return snapshot?.state === 'repair_required' || snapshot?.state === 'unavailable';
+}
+
+/** Model blockers already have connection-specific recovery surfaces. */
+export function deriveTaskReadinessNotice(
+  snapshot: TaskSubmissionReadinessSnapshot | undefined,
+  locale: UiLocale,
+): TaskReadinessNotice | undefined {
+  if (!snapshot) return undefined;
+  const blocker = snapshot.blockers.find(
+    (candidate) =>
+      candidate.state !== 'unknown' &&
+      (candidate.id === 'runtime' || candidate.id === 'workspace'),
+  );
+  if (!blocker) return undefined;
+  return noticeForBlocker(blocker, locale);
+}
+
+function noticeForBlocker(
+  blocker: TaskSubmissionReadinessDimension,
+  locale: UiLocale,
+): TaskReadinessNotice {
+  if (blocker.id === 'runtime') {
+    return locale === 'zh'
+      ? {
+          tone: 'destructive',
+          title: 'Maka 运行服务暂时不可用。',
+          description: '任务尚未提交。重新检测运行服务后再试。',
+          actionLabel: '重新检测',
+          action: 'retry',
+        }
+      : {
+          tone: 'destructive',
+          title: 'The Maka runtime is unavailable.',
+          description: 'The task was not submitted. Check the runtime again before retrying.',
+          actionLabel: 'Check again',
+          action: 'retry',
+        };
+  }
+  return locale === 'zh'
+    ? {
+        tone: 'destructive',
+        title: '当前任务的工作区不可用。',
+        description: '原目录可能已移动、删除或无法访问。请新建任务并选择可用工作区。',
+        actionLabel: '新建任务',
+        action: 'new_task',
+      }
+    : {
+        tone: 'destructive',
+        title: 'This task workspace is unavailable.',
+        description: 'The folder may have moved, been deleted, or become inaccessible. Start a new task with an available workspace.',
+        actionLabel: 'New task',
+        action: 'new_task',
+      };
+}

--- a/apps/desktop/src/renderer/task-readiness-notice.ts
+++ b/apps/desktop/src/renderer/task-readiness-notice.ts
@@ -1,21 +1,43 @@
 import type {
+  SessionSendProjection,
   TaskSubmissionReadinessDimension,
   TaskSubmissionReadinessSnapshot,
   UiLocale,
 } from '@maka/core';
+
+export function resolveTaskReadinessModelTarget(
+  session: { llmConnectionSlug: string; model: string } | undefined,
+  sendOutcome: SessionSendProjection | undefined,
+  newTaskTarget: { llmConnectionSlug: string; model: string } | undefined,
+): { connectionSlug?: string; model?: string } {
+  if (session && sendOutcome?.kind === 'rebind') {
+    return { connectionSlug: sendOutcome.connectionSlug, model: sendOutcome.model };
+  }
+  return {
+    connectionSlug: session?.llmConnectionSlug ?? newTaskTarget?.llmConnectionSlug,
+    model: session?.model ?? newTaskTarget?.model,
+  };
+}
 
 export interface TaskReadinessNotice {
   tone: 'warning' | 'destructive';
   title: string;
   description: string;
   actionLabel: string;
-  action: 'retry' | 'new_task';
+  action: 'retry' | 'workspace_picker';
 }
 
 export function isTaskSubmissionHardBlocked(
   snapshot: TaskSubmissionReadinessSnapshot | undefined,
+  options: { ignoreModelTarget?: boolean } = {},
 ): boolean {
-  return snapshot?.state === 'repair_required' || snapshot?.state === 'unavailable';
+  return (
+    snapshot?.blockers.some(
+      (blocker) =>
+        blocker.state !== 'unknown' &&
+        !(options.ignoreModelTarget === true && blocker.id === 'model_target'),
+    ) === true
+  );
 }
 
 /** Model blockers already have connection-specific recovery surfaces. */
@@ -54,19 +76,20 @@ function noticeForBlocker(
           action: 'retry',
         };
   }
+  const action = blocker.repairTarget?.kind === 'workspace_picker' ? 'workspace_picker' : 'retry';
   return locale === 'zh'
     ? {
         tone: 'destructive',
         title: '当前任务的工作区不可用。',
-        description: '原目录可能已移动、删除或无法访问。请新建任务并选择可用工作区。',
-        actionLabel: '新建任务',
-        action: 'new_task',
+        description: '原目录可能已移动、删除或无法访问。请选择可用工作区。',
+        actionLabel: action === 'workspace_picker' ? '选择工作区' : '重新检测',
+        action,
       }
     : {
         tone: 'destructive',
         title: 'This task workspace is unavailable.',
-        description: 'The folder may have moved, been deleted, or become inaccessible. Start a new task with an available workspace.',
-        actionLabel: 'New task',
-        action: 'new_task',
+        description: 'The folder may have moved, been deleted, or become inaccessible. Choose an available workspace.',
+        actionLabel: action === 'workspace_picker' ? 'Choose workspace' : 'Check again',
+        action,
       };
 }

--- a/apps/desktop/src/renderer/use-task-submission-readiness.ts
+++ b/apps/desktop/src/renderer/use-task-submission-readiness.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { TaskSubmissionReadinessSnapshot } from '@maka/core';
 import type { DesktopTaskSubmissionReadinessRequest } from '../preload/bridge-contract.js';
 
@@ -8,23 +8,26 @@ export function useTaskSubmissionReadiness(
 ) {
   const [snapshot, setSnapshot] = useState<TaskSubmissionReadinessSnapshot>();
   const [revision, setRevision] = useState(0);
+  const requestSequence = useRef(0);
   const refresh = useCallback(() => setRevision((value) => value + 1), []);
 
-  useEffect(() => {
-    let current = true;
-    setSnapshot(undefined);
-    void window.maka.taskReadiness
-      .getSnapshot(request)
-      .then((next) => {
-        if (current) setSnapshot(next);
-      })
-      .catch(() => {
-        if (current) setSnapshot(undefined);
-      });
-    return () => {
-      current = false;
-    };
-  }, [request.connectionSlug, request.model, request.cwd, refreshKey, revision]);
+  const checkNow = useCallback(async () => {
+    const sequence = ++requestSequence.current;
+    try {
+      const next = await window.maka.taskReadiness.getSnapshot(request);
+      if (requestSequence.current === sequence) setSnapshot(next);
+      return next;
+    } catch {
+      if (requestSequence.current === sequence) setSnapshot(undefined);
+      return undefined;
+    }
+  }, [request.connectionSlug, request.model, request.cwd]);
 
-  return { snapshot, refresh };
+  useEffect(() => {
+    requestSequence.current += 1;
+    setSnapshot(undefined);
+    void checkNow();
+  }, [checkNow, refreshKey, revision]);
+
+  return { snapshot, refresh, checkNow };
 }

--- a/apps/desktop/src/renderer/use-task-submission-readiness.ts
+++ b/apps/desktop/src/renderer/use-task-submission-readiness.ts
@@ -1,0 +1,30 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { TaskSubmissionReadinessSnapshot } from '@maka/core';
+import type { DesktopTaskSubmissionReadinessRequest } from '../preload/bridge-contract.js';
+
+export function useTaskSubmissionReadiness(
+  request: DesktopTaskSubmissionReadinessRequest,
+  refreshKey: unknown,
+) {
+  const [snapshot, setSnapshot] = useState<TaskSubmissionReadinessSnapshot>();
+  const [revision, setRevision] = useState(0);
+  const refresh = useCallback(() => setRevision((value) => value + 1), []);
+
+  useEffect(() => {
+    let current = true;
+    setSnapshot(undefined);
+    void window.maka.taskReadiness
+      .getSnapshot(request)
+      .then((next) => {
+        if (current) setSnapshot(next);
+      })
+      .catch(() => {
+        if (current) setSnapshot(undefined);
+      });
+    return () => {
+      current = false;
+    };
+  }, [request.connectionSlug, request.model, request.cwd, refreshKey, revision]);
+
+  return { snapshot, refresh };
+}


### PR DESCRIPTION
## English

### What changed
- Query the authoritative task-submission readiness snapshot for the active session or new-task target.
- Disable submission only for confirmed `repair_required` or `unavailable` states; `unknown` and loading states remain non-blocking.
- Show actionable runtime/workspace recovery notices above the composer, with retry or new-task actions.
- Keep model recovery owned by the existing model/connection surfaces to avoid duplicate guidance and preserve model switching.
- Clear stale readiness immediately when the model or workspace target changes.

### Validation
- `npx biome check` (changed files)
- Desktop main, preload, and renderer builds
- Desktop renderer and preload TypeScript checks
- 17 targeted Core/Main/Renderer readiness tests

### Known baseline issue
- The aggregate workspace dependency build currently stops in `@maka/ui` at `src/tool-activity.tsx` because `ChatToolCallItem` does not expose `activateLabel` / `onActivate`. Desktop builds pass after rebuilding the other workspace dependencies; this PR does not touch that code.

## 中文

### 改动内容
- 针对当前会话或新任务目标，读取权威的任务提交 readiness 快照。
- 仅在状态明确为 `repair_required` 或 `unavailable` 时禁止提交；`unknown` 和加载中不会阻塞用户。
- 在输入区上方显示可操作的运行时/工作区恢复提示，并提供重试或新建任务操作。
- 模型问题继续由现有模型/连接恢复界面负责，避免重复提示，同时保留切换模型能力。
- 切换模型或工作区时立即清除旧 readiness，防止旧错误误锁新目标。

### 验证
- 变更文件 Biome 检查
- Desktop main、preload、renderer 构建
- Desktop renderer、preload TypeScript 检查
- 17 个 Core/Main/Renderer readiness 针对性测试

### 已知基线问题
- 当前聚合 workspace 依赖构建会在 `@maka/ui/src/tool-activity.tsx` 停止，因为 `ChatToolCallItem` 尚未暴露 `activateLabel` / `onActivate`。重建其余依赖后 Desktop 构建均通过；本 PR 未修改该处。

Refs #2497
Related to #2469