### PR TITLE
feat(cli): add task readiness preflight

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -30,7 +30,7 @@ describe('Runtime Host maka run adapter', () => {
       },
       {
         connect: async () => ({
-          connection: {} as RuntimeHostConnection,
+          connection: readinessConnection(),
           catalog: connectionCatalog(),
           close: async () => {
             closes += 1;
@@ -44,6 +44,43 @@ describe('Runtime Host maka run adapter', () => {
     assert.deepEqual(stdout, ['Host answer\n']);
     assert.deepEqual(stderr, []);
     assert.equal(closes, 1);
+  });
+
+  test('stops before context creation when CLI preflight finds a confirmed blocker', async () => {
+    const stderr: string[] = [];
+    let contextCreations = 0;
+    const blockedCatalog = connectionCatalog();
+    blockedCatalog.connections[0]!.enabled = false;
+
+    const exitCode = await runRuntimeHostTextCli(
+      ['answer once'],
+      {
+        workspaceRoot: () => '/runtime-host-data',
+        processCwd: () => process.cwd(),
+        stdinIsTTY: () => true,
+        readStdin: async () => '',
+        writeStdout: () => {},
+        writeStderr: (text) => stderr.push(text),
+        onSigint: () => () => {},
+        newId: () => 'turn-blocked',
+      },
+      {
+        connect: async () => ({
+          connection: {} as RuntimeHostConnection,
+          catalog: blockedCatalog,
+          close: async () => {},
+        }),
+        createContext: (_connection, _catalog, input) => {
+          contextCreations += 1;
+          return publicCommandContext(input);
+        },
+      },
+    );
+
+    assert.equal(exitCode, 2);
+    assert.equal(contextCreations, 0);
+    assert.match(stderr.join(''), /model_connection_disabled/);
+    assert.match(stderr.join(''), /repair connection "openai-main" in `maka`/);
   });
 
   test('continues the Host-owned cwd Session without creating another identity', async () => {
@@ -787,10 +824,30 @@ function connectionCatalog() {
         providerType: 'openai' as const,
         enabled: true,
         enabledModelIds: ['gpt-5'],
-        models: [],
+        models: [{ id: 'gpt-5' }],
       },
     ],
   };
+}
+
+function readinessConnection(): RuntimeHostConnection {
+  return {
+    request: async (operation: string) => {
+      if (operation !== 'credential.vault.query') {
+        throw new Error(`Unexpected readiness operation: ${operation}`);
+      }
+      return {
+        kind: 'status',
+        status: {
+          locator: { scope: 'connection', connectionId: 'connection-1', kind: 'api_key' },
+          configured: true,
+          credentialId: 'credential-1',
+          revision: 1,
+          updatedAt: 1,
+        },
+      };
+    },
+  } as unknown as RuntimeHostConnection;
 }
 
 async function* questionEvents(turnId: string): AsyncIterable<SessionEvent> {

--- a/packages/cli/src/__tests__/runtime-host-task-readiness.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-task-readiness.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { ConnectionCatalogSnapshot } from '@maka/core/runtime-policy';
+import type { RuntimeHostConnection } from '@maka/runtime-host/client';
+import {
+  formatRuntimeHostCliTaskBlockers,
+  isRuntimeHostCliTaskBlocked,
+  readRuntimeHostCliTaskReadiness,
+} from '../runtime-host-task-readiness.js';
+
+test('CLI preflight projects a ready first task from Host-owned authorities', async () => {
+  const snapshot = await readRuntimeHostCliTaskReadiness(
+    {
+      connection: credentialConnection(true),
+      catalog: catalog(),
+      cwd: process.cwd(),
+    },
+    () => 42,
+  );
+
+  assert.equal(snapshot.state, 'ready');
+  assert.equal(isRuntimeHostCliTaskBlocked(snapshot), false);
+  assert.deepEqual(
+    snapshot.dimensions.map((dimension) => dimension.id),
+    ['runtime', 'model_target', 'workspace'],
+  );
+});
+
+test('CLI preflight presents stable repair guidance before submission', async () => {
+  const snapshot = await readRuntimeHostCliTaskReadiness(
+    {
+      connection: credentialConnection(false),
+      catalog: catalog(),
+      cwd: process.cwd(),
+    },
+    () => 43,
+  );
+
+  assert.equal(snapshot.state, 'repair_required');
+  assert.equal(isRuntimeHostCliTaskBlocked(snapshot), true);
+  assert.equal(
+    formatRuntimeHostCliTaskBlockers(snapshot),
+    'model_missing_api_key: repair connection "openai-main" in `maka`',
+  );
+});
+
+test('CLI preflight keeps unavailable credential observations non-blocking', async () => {
+  const snapshot = await readRuntimeHostCliTaskReadiness(
+    {
+      connection: {
+        request: async () => {
+          throw new Error('credential store is temporarily unavailable');
+        },
+      } as unknown as RuntimeHostConnection,
+      catalog: catalog(),
+      cwd: process.cwd(),
+    },
+    () => 44,
+  );
+
+  assert.equal(snapshot.state, 'unknown');
+  assert.equal(snapshot.blockers[0]?.blockerCode, 'model_credentials_unknown');
+  assert.equal(isRuntimeHostCliTaskBlocked(snapshot), false);
+});
+
+function credentialConnection(configured: boolean): RuntimeHostConnection {
+  return {
+    request: async (operation: string) => {
+      assert.equal(operation, 'credential.vault.query');
+      return {
+        kind: 'status',
+        status: {
+          locator: { scope: 'connection', connectionId: 'connection-1', kind: 'api_key' },
+          configured,
+          credentialId: configured ? 'credential-1' : null,
+          revision: configured ? 1 : null,
+          updatedAt: configured ? 1 : null,
+        },
+      };
+    },
+  } as unknown as RuntimeHostConnection;
+}
+
+function catalog(): ConnectionCatalogSnapshot {
+  return {
+    revision: 1,
+    defaultTarget: { connectionId: 'connection-1', modelId: 'gpt-5' },
+    connections: [
+      {
+        connectionId: 'connection-1',
+        revision: 1,
+        slug: 'openai-main',
+        name: 'OpenAI',
+        providerType: 'openai',
+        enabled: true,
+        enabledModelIds: ['gpt-5'],
+        models: [{ id: 'gpt-5', capabilities: { chat: true } }],
+      },
+    ],
+  };
+}

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -28,6 +28,11 @@ import {
   type RuntimeHostMakaSessionDriver,
 } from './runtime-host-session-driver.js';
 import type { MakaPreparedSessionTurn } from './session-driver.js';
+import {
+  formatRuntimeHostCliTaskBlockers,
+  isRuntimeHostCliTaskBlocked,
+  readRuntimeHostCliTaskReadiness,
+} from './runtime-host-task-readiness.js';
 
 const GRAPH_POLL_INTERVAL_MS = 25;
 
@@ -37,7 +42,7 @@ export interface RuntimeHostRunCommandDeps {
     connection: RuntimeHostConnection,
     catalog: RuntimeHostCliConnectionContext['catalog'],
     input: Parameters<MakaRunDeps['createContext']>[0],
-  ): MakaRunContext;
+  ): MakaRunContext | Promise<MakaRunContext>;
   run: typeof runMakaTextCliCore;
 }
 
@@ -68,6 +73,7 @@ export async function runRuntimeHostTextCli(
           ),
         createContext: async (input) => {
           const context = await connect(input.workspaceRoot);
+          await assertRuntimeHostRunReady(context.connection, context.catalog, input);
           return commandDeps.createContext(context.connection, context.catalog, input);
         },
       },
@@ -128,6 +134,23 @@ export function createRuntimeHostRunContext(
       : {}),
     close: async () => runtime.close(),
   };
+}
+
+async function assertRuntimeHostRunReady(
+  connection: RuntimeHostConnection,
+  catalog: RuntimeHostCliConnectionContext['catalog'],
+  input: Parameters<MakaRunDeps['createContext']>[0],
+): Promise<void> {
+  const snapshot = await readRuntimeHostCliTaskReadiness({
+    connection,
+    catalog,
+    cwd: input.cwd,
+    ...(input.requestedConnectionSlug ? { connectionSlug: input.requestedConnectionSlug } : {}),
+    ...(input.requestedModel ? { model: input.requestedModel } : {}),
+  });
+  if (isRuntimeHostCliTaskBlocked(snapshot)) {
+    throw new Error(`Task is not ready:\n${formatRuntimeHostCliTaskBlockers(snapshot)}`);
+  }
 }
 
 class RuntimeHostRunRuntime implements MakaRunRuntime {

--- a/packages/cli/src/runtime-host-task-readiness.ts
+++ b/packages/cli/src/runtime-host-task-readiness.ts
@@ -1,0 +1,148 @@
+import { stat } from 'node:fs/promises';
+import {
+  deriveTaskSubmissionReadiness,
+  PROVIDER_DEFAULTS,
+  type LlmConnection,
+  type TaskSubmissionReadinessDimension,
+  type TaskSubmissionReadinessSnapshot,
+} from '@maka/core';
+import { providerAuthRequiresSecret } from '@maka/core/llm-connections';
+import type { ConnectionCatalogEntry, ConnectionCatalogSnapshot } from '@maka/core/runtime-policy';
+import type { RuntimeHostConnection } from '@maka/runtime-host/client';
+
+export interface RuntimeHostCliTaskReadinessInput {
+  readonly connection: RuntimeHostConnection;
+  readonly catalog: ConnectionCatalogSnapshot;
+  readonly cwd: string;
+  readonly connectionSlug?: string;
+  readonly model?: string;
+}
+
+export async function readRuntimeHostCliTaskReadiness(
+  input: RuntimeHostCliTaskReadinessInput,
+  now: () => number = Date.now,
+): Promise<TaskSubmissionReadinessSnapshot> {
+  const checkedAt = now();
+  const entry = resolveCatalogEntry(input.catalog, input.connectionSlug);
+  const modelTarget = entry
+    ? {
+        kind: 'resolved' as const,
+        connection: catalogEntryAsLlmConnection(entry, input.catalog),
+        hasSecret: await readHasSecret(input.connection, entry),
+        requestedModel: input.model,
+        checkedAt,
+      }
+    : input.connectionSlug
+      ? { kind: 'connection_missing' as const, connectionSlug: input.connectionSlug, checkedAt }
+      : { kind: 'missing_default' as const, checkedAt };
+
+  return deriveTaskSubmissionReadiness({
+    checkedAt,
+    runtime: { state: 'ready', checkedAt },
+    modelTarget,
+    workspace: { state: await inspectWorkspace(input.cwd), checkedAt },
+  });
+}
+
+export function isRuntimeHostCliTaskBlocked(snapshot: TaskSubmissionReadinessSnapshot): boolean {
+  return snapshot.state === 'repair_required' || snapshot.state === 'unavailable';
+}
+
+export function formatRuntimeHostCliTaskBlockers(
+  snapshot: TaskSubmissionReadinessSnapshot,
+): string {
+  return snapshot.blockers
+    .filter((blocker) => blocker.state !== 'unknown')
+    .map((blocker) => `${blocker.blockerCode ?? blocker.id}: ${repairHint(blocker)}`)
+    .join('\n');
+}
+
+function resolveCatalogEntry(
+  catalog: ConnectionCatalogSnapshot,
+  requestedSlug: string | undefined,
+): ConnectionCatalogEntry | undefined {
+  if (requestedSlug) {
+    return catalog.connections.find((candidate) => candidate.slug === requestedSlug);
+  }
+  return catalog.connections.find(
+    (candidate) => candidate.connectionId === catalog.defaultTarget?.connectionId,
+  );
+}
+
+function catalogEntryAsLlmConnection(
+  entry: ConnectionCatalogEntry,
+  catalog: ConnectionCatalogSnapshot,
+): LlmConnection {
+  const defaultModel =
+    entry.connectionId === catalog.defaultTarget?.connectionId
+      ? catalog.defaultTarget.modelId
+      : (entry.enabledModelIds[0] ?? '');
+  return {
+    slug: entry.slug,
+    name: entry.name,
+    providerType: entry.providerType,
+    ...(entry.baseUrl ? { baseUrl: entry.baseUrl } : {}),
+    enabled: entry.enabled,
+    defaultModel,
+    enabledModelIds: [...entry.enabledModelIds],
+    models: [...entry.models],
+    ...(entry.modelSource ? { modelSource: entry.modelSource } : {}),
+    ...(entry.modelsFetchedAt ? { modelsFetchedAt: entry.modelsFetchedAt } : {}),
+    ...(entry.lastTest
+      ? { lastTestStatus: entry.lastTest.status, lastTestAt: entry.lastTest.checkedAt }
+      : {}),
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+async function readHasSecret(
+  connection: RuntimeHostConnection,
+  entry: ConnectionCatalogEntry,
+): Promise<boolean | undefined> {
+  if (!providerAuthRequiresSecret(entry.providerType)) return false;
+  const authKind = PROVIDER_DEFAULTS[entry.providerType].authKind;
+  const kind = authKind === 'oauth_token' ? 'oauth_token' : 'api_key';
+  try {
+    const result = await connection.request('credential.vault.query', {
+      locator: { scope: 'connection', connectionId: entry.connectionId, kind },
+    });
+    return result.kind === 'status' ? result.status.configured : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function inspectWorkspace(
+  cwd: string,
+): Promise<'ready' | 'missing' | 'unavailable' | 'unknown'> {
+  try {
+    return (await stat(cwd)).isDirectory() ? 'ready' : 'unavailable';
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return 'missing';
+    if (code === 'EACCES') return 'unavailable';
+    return 'unknown';
+  }
+}
+
+function repairHint(blocker: TaskSubmissionReadinessDimension): string {
+  const target = blocker.repairTarget;
+  if (!target) return 'retry the command';
+  switch (target.kind) {
+    case 'provider_catalog':
+      return 'run `maka` to configure a model provider';
+    case 'connection':
+      return `repair connection "${target.connectionSlug}" in \`maka\``;
+    case 'models':
+      return 'choose an available connection with `--connection`';
+    case 'runtime_restart':
+      return 'restart Maka and retry';
+    case 'workspace_picker':
+      return 'choose an existing directory with `--cwd`';
+    case 'system_permission':
+      return `grant system permission "${target.permissionId}"`;
+    case 'capability_settings':
+      return `enable capability "${target.capabilityId}"`;
+  }
+}


### PR DESCRIPTION
## English

### What changed
- Add a `maka run` preflight that consumes the shared task-submission readiness projection before creating a runtime context or Session.
- Gather current authoritative inputs from the connected Runtime Host: connection catalog, credential status, and the selected workspace directory.
- Stop only for confirmed `repair_required` / `unavailable` states and print stable blocker codes with actionable CLI repair guidance.
- Keep `unknown` observations non-blocking so a temporary credential-status read failure does not invent a configuration failure.
- Preserve the existing interactive TUI onboarding flow; successful non-interactive runs remain quiet.

### First-success smoke journey
The public `maka run` adapter test now traverses a ready Host-owned catalog + credential preflight, creates the run context, completes one turn, prints only the final answer, and closes the shared Host connection.

### Validation
- `npm --workspace maka-agent test` — 344 passed
- Core, Storage, Runtime, and Runtime Host dependency builds
- Biome and diff checks for changed files

## 中文

### 改动内容
- 在创建 runtime context 或 Session 之前，为 `maka run` 增加共享 task-submission readiness preflight。
- 从已连接的 Runtime Host 读取当前权威输入：连接目录、凭据状态和选中的工作区目录。
- 仅在明确为 `repair_required` / `unavailable` 时停止，并输出稳定 blocker code 与可执行的 CLI 修复指引。
- `unknown` 状态保持不阻塞，credential status 暂时读取失败时不会虚构配置错误。
- 保留现有交互式 TUI 首次配置流程；成功的非交互调用仍然保持安静。

### 首次成功 smoke journey
公开 `maka run` 适配器测试现在会经过 Host 权威连接目录与 credential preflight，创建运行上下文，完成一次 turn，仅打印最终答案，并关闭共享 Host 连接。

### 验证
- `npm --workspace maka-agent test` — 344 个测试通过
- Core、Storage、Runtime、Runtime Host 依赖构建通过
- 变更文件 Biome 与 diff 检查通过

Completes the CLI delivery slice of #2497.
Related to #2469.