### PR TITLE
fix(runtime): make task refusals actionable

### DIFF
--- a/packages/core/src/__tests__/task-ledger.test.ts
+++ b/packages/core/src/__tests__/task-ledger.test.ts
@@ -314,6 +314,27 @@ describe('task lifecycle validators', () => {
     );
   });
 
+  test('names the recovery calls for pending tasks completed out of order', () => {
+    const result = validateTaskUpdate(
+      {
+        id: 't1',
+        key: 'T1',
+        subject: 'x',
+        status: 'pending',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      { status: 'completed', completionEvidence: 'test passed' },
+    );
+
+    assert.deepEqual(result, {
+      ok: false,
+      reason: 'invalid_transition',
+      message:
+        'Invalid task status transition from pending to completed. Call task_update with status "in_progress" first, then call task_update with status "completed" and completionEvidence.',
+    });
+  });
+
   test('normalizes explicit reopen as a one-shot update option', () => {
     assert.deepEqual(normalizeUpdateTaskInput({ explicitReopen: true }), {
       ok: true,

--- a/packages/core/src/task-ledger.ts
+++ b/packages/core/src/task-ledger.ts
@@ -455,9 +455,13 @@ export function validateTaskUpdate(
       explicitReopen,
     })
   ) {
+    const recovery =
+      previousTask.status === 'pending' && normalized.value.status === 'completed'
+        ? '. Call task_update with status "in_progress" first, then call task_update with status "completed" and completionEvidence.'
+        : '';
     return invalid(
       'invalid_transition',
-      `Invalid task status transition from ${previousTask.status} to ${normalized.value.status}`,
+      `Invalid task status transition from ${previousTask.status} to ${normalized.value.status}${recovery}`,
     );
   }
   const evidence = validateTaskEvidence(nextTask);

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -140,6 +140,23 @@ describe('subagent tools', () => {
     });
   });
 
+  test('agent_spawn names both recovery routes when no child selector is provided', () => {
+    const schema = buildSubagentSpawnTool({
+      definitions: [LOCAL_READ_AGENT_DEFINITION, WEB_RESEARCH_AGENT_DEFINITION],
+    }).parameters as {
+      safeParse(input: unknown): {
+        success: boolean;
+        error?: { issues: Array<{ message: string }> };
+      };
+    };
+
+    const parsed = schema.safeParse({ task: 'Inspect the repo.' });
+    expect(parsed.success).toBe(false);
+    expect(parsed.error?.issues.map((issue) => issue.message)).toContain(
+      'No child selector was provided. Call agent_list and pass a returned subagent_id to agent_spawn, or pass one legacy profile: local_read, web_research.',
+    );
+  });
+
   test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {
     expect(LOCAL_READ_AGENT_DEFINITION.id).toBe(LOCAL_READ_AGENT_ID);
     expect(LOCAL_READ_AGENT_DEFINITION.profile).toBe(LOCAL_READ_AGENT_PROFILE);

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -139,7 +139,9 @@ export function buildSubagentSpawnTool(
           if (!input.profile && !input.subagent_id) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
-              message: 'Provide subagent_id or legacy profile.',
+              message:
+                'No child selector was provided. Call agent_list and pass a returned subagent_id to agent_spawn, ' +
+                `or pass one legacy profile: ${profiles.join(', ')}.`,
             });
             return;
           }


### PR DESCRIPTION
Closes #2310.

## What changed

- The `pending -> completed` refusal now tells the model to mark the task `in_progress` first, then retry `completed` with `completionEvidence`.
- A selector-less `agent_spawn` call now points to `agent_list -> subagent_id` and lists the legacy profiles available in the current composition.

This keeps the current `subagent_id`-first behavior: when both selectors are present, `subagent_id` still wins and `profile` is ignored.

## Verification

- `npm --workspace @maka/core test` — 802 passed
- `node --test packages/runtime/dist/__tests__/subagent-tools.test.js` — 29 passed
- `node --test packages/runtime/dist/__tests__/task-ledger-tools.test.js` — 19 passed
- `npm --workspace @maka/core run typecheck`
- `npm --workspace @maka/runtime run typecheck`
- Biome check on the four changed files

The full runtime suite completed 3,251 tests locally: 3,221 passed, 3 skipped, and 27 failed in the untouched `model-factory-tool-call-index.test.js` on Node 26.3.0.
