### PR TITLE
feat(desktop): expose exact Pricing keys for unpriced calls

### DIFF
--- a/apps/desktop/src/main/__tests__/session-inspector-pricing-key.test.ts
+++ b/apps/desktop/src/main/__tests__/session-inspector-pricing-key.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  SESSION_TRACE_SCHEMA_VERSION,
+  type SessionTrace,
+  type TraceModelAttempt,
+  type TraceTotals,
+} from '@maka/core/session-trace';
+import { deriveInspectorPanelModel } from '../../renderer/session-inspector-panel-model.js';
+
+const TOTALS: TraceTotals = {
+  durationMs: 10,
+  modelAttempts: 1,
+  retries: 0,
+  compactions: 0,
+  inputTokens: 1,
+  outputTokens: 1,
+  unpricedAttempts: 1,
+};
+
+describe('Session Inspector Pricing key', () => {
+  test('uses the canonical provider rather than the connection slug for an unpriced call', () => {
+    const model = deriveInspectorPanelModel(traceWithAttempt(attempt('unpriced')));
+
+    assert.equal(model.turns[0]?.steps[0]?.unpricedPricingKey, 'DeepInfra:org/Model:Preview');
+  });
+
+  test('does not offer a Pricing key when the call was priced', () => {
+    const model = deriveInspectorPanelModel(traceWithAttempt(attempt('priced')));
+
+    assert.equal(model.turns[0]?.steps[0]?.unpricedPricingKey, undefined);
+  });
+});
+
+function attempt(costBasis: TraceModelAttempt['costBasis']): TraceModelAttempt {
+  return {
+    attemptId: 'attempt-1',
+    attempt: 0,
+    status: 'completed',
+    startedAt: 1,
+    completedAt: 11,
+    latencyMs: 10,
+    ...(costBasis === 'priced' ? { costUsd: 0.01 } : {}),
+    costBasis,
+    usageBasis: 'reported',
+  };
+}
+
+function traceWithAttempt(modelAttempt: TraceModelAttempt): SessionTrace {
+  return {
+    schemaVersion: SESSION_TRACE_SCHEMA_VERSION,
+    sessionId: 'session-1',
+    turns: [
+      {
+        turnId: 'turn-1',
+        runId: 'run-1',
+        startedAt: 1,
+        endedAt: 11,
+        durationMs: 10,
+        steps: [
+          {
+            kind: 'model_call',
+            id: 'call-1',
+            turnId: 'turn-1',
+            runId: 'run-1',
+            startedAt: 1,
+            endedAt: 11,
+            durationMs: 10,
+            callKind: 'main',
+            connectionSlug: 'my-deepinfra-account',
+            providerId: 'DeepInfra',
+            modelId: 'org/Model:Preview',
+            step: 0,
+            attempts: [modelAttempt],
+            status: 'completed',
+            ...(modelAttempt.costBasis === 'priced' ? { costUsd: 0.01 } : {}),
+          },
+        ],
+        totals: {
+          ...TOTALS,
+          ...(modelAttempt.costBasis === 'priced' ? { costUsd: 0.01, unpricedAttempts: 0 } : {}),
+        },
+      },
+    ],
+    totals: {
+      ...TOTALS,
+      ...(modelAttempt.costBasis === 'priced' ? { costUsd: 0.01, unpricedAttempts: 0 } : {}),
+    },
+    coverage: {
+      modelCalls: 'no_known_gap',
+      turnsMissingModelCalls: [],
+      unreadableRecords: 0,
+      turnsWithFewerModelCallsThanSteps: [],
+    },
+  };
+}

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -148,6 +148,10 @@ export interface DesktopConversationCopy {
     copyPath: string;
     /** Toast after a successful path copy. */
     pathCopied: string;
+    /** Copy action and success copy for an unpriced model call's exact Pricing key. */
+    copyPricingKey: string;
+    pricingKeyCopied: string;
+    unpricedPricingKey: string;
     /** Toast title when the clipboard write is denied or unavailable. */
     copyFailed: string;
     copyFailedDetail: string;
@@ -466,6 +470,9 @@ const COPY = {
       recordFile: '记录文件',
       copyPath: '复制文件路径',
       pathCopied: '已复制文件路径',
+      copyPricingKey: '复制定价键',
+      pricingKeyCopied: '已复制定价键',
+      unpricedPricingKey: '未计价的定价键',
       copyFailed: '复制失败',
       copyFailedDetail: '剪贴板不可用或被系统拒绝。',
       loadFailed: '追踪读取失败',
@@ -663,6 +670,9 @@ const COPY = {
       recordFile: 'Record file',
       copyPath: 'Copy file path',
       pathCopied: 'File path copied',
+      copyPricingKey: 'Copy pricing key',
+      pricingKeyCopied: 'Pricing key copied',
+      unpricedPricingKey: 'Unpriced pricing key',
       copyFailed: 'Copy failed',
       copyFailedDetail: 'The clipboard is unavailable or access was denied by the system.',
       loadFailed: 'Could not read the trace',

--- a/apps/desktop/src/renderer/session-inspector-panel-model.ts
+++ b/apps/desktop/src/renderer/session-inspector-panel-model.ts
@@ -5,7 +5,7 @@ import {
   type TraceStep,
   type TraceTotals,
 } from '@maka/core/session-trace';
-
+import { pricingModelKey } from '@maka/core/usage-stats/pricing';
 /**
  * View model for the Inspector panel (#1625).
  *
@@ -31,6 +31,8 @@ export interface InspectorStepRow {
   durationMs?: number;
   /** Retries beyond the first attempt of one logical call. */
   retries?: number;
+  /** Exact Runtime pricing lookup key, exposed only when an attempt was unpriced. */
+  unpricedPricingKey?: string;
   /**
    * The recovery decision that was actually recorded, structured rather than
    * pre-formatted so the panel owns the wording in the reader's language.
@@ -114,6 +116,9 @@ function toStepRow(step: TraceStep, attributedToStepId: string | undefined): Ins
       ...(detail !== undefined ? { detail } : {}),
       durationMs: step.durationMs,
       ...(step.attempts.length > 1 ? { retries: step.attempts.length - 1 } : {}),
+      ...(step.attempts.some((attempt) => attempt.costBasis === 'unpriced')
+        ? { unpricedPricingKey: pricingModelKey(step.providerId, step.modelId) }
+        : {}),
       failed,
     };
   }

--- a/apps/desktop/src/renderer/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/session-inspector-panel.tsx
@@ -122,6 +122,15 @@ export function SessionInspectorPanel(props: { sessionId: string; active: boolea
     }
   }
 
+  async function copyPricingKey(key: string) {
+    try {
+      await navigator.clipboard.writeText(key);
+      toast.success(copy.pricingKeyCopied, key);
+    } catch {
+      toast.error(copy.copyFailed, copy.copyFailedDetail);
+    }
+  }
+
   // The path is split for display only — the directory part truncates while
   // the filename never does, so a narrow panel still says which file the row
   // is about. The full path stays the tooltip and clipboard value, and the
@@ -300,7 +309,12 @@ export function SessionInspectorPanel(props: { sessionId: string; active: boolea
 
               <ol className="maka-inspector-turns">
                 {model.turns.map((turn) => (
-                  <TurnRow key={turn.turnId} turn={turn} copy={copy} />
+                  <TurnRow
+                    key={turn.turnId}
+                    turn={turn}
+                    copy={copy}
+                    onCopyPricingKey={copyPricingKey}
+                  />
                 ))}
               </ol>
             </VStack>
@@ -594,7 +608,11 @@ function formatPercent(ratio: number): string {
  * out-shouts the turn label it qualifies, and the red dot on the rail has
  * already flagged the row from the margin.
  */
-function TurnRow(props: { turn: InspectorTurnRow; copy: InspectorCopy }) {
+function TurnRow(props: {
+  turn: InspectorTurnRow;
+  copy: InspectorCopy;
+  onCopyPricingKey: (key: string) => void | Promise<void>;
+}) {
   const { copy, turn } = props;
   return (
     <li
@@ -629,7 +647,12 @@ function TurnRow(props: { turn: InspectorTurnRow; copy: InspectorCopy }) {
       </div>
       <ol className="maka-inspector-steps">
         {turn.steps.map((step) => (
-          <StepRow key={step.id} step={step} copy={copy} />
+          <StepRow
+            key={step.id}
+            step={step}
+            copy={copy}
+            onCopyPricingKey={props.onCopyPricingKey}
+          />
         ))}
       </ol>
     </li>
@@ -649,8 +672,13 @@ function TurnRow(props: { turn: InspectorTurnRow; copy: InspectorCopy }) {
  * rather than written `×2`, which is the attempts counter's own notation and
  * asks the reader to work out that one of them was a retry.
  */
-function StepRow(props: { step: InspectorStepRow; copy: InspectorCopy }) {
+function StepRow(props: {
+  step: InspectorStepRow;
+  copy: InspectorCopy;
+  onCopyPricingKey: (key: string) => void | Promise<void>;
+}) {
   const { copy, step } = props;
+  const pricingKey = step.unpricedPricingKey;
   // A row names itself with whatever identity it has: a model, a tool, or —
   // for a compaction, an error, a permission prompt with no tool — its kind.
   const label = step.label ?? inspectorStepKindLabel(copy, step.kind);
@@ -675,6 +703,21 @@ function StepRow(props: { step: InspectorStepRow; copy: InspectorCopy }) {
       <span className="maka-inspector-step-text">
         <span className="maka-inspector-step-label">{label}</span>
         {qualifier && <span className="maka-inspector-step-detail">{qualifier}</span>}
+        {pricingKey && (
+          <span className="maka-inspector-pricing-key">
+            <span>{copy.unpricedPricingKey}</span>
+            <code>{pricingKey}</code>
+            <Button
+              variant="ghost"
+              size="sm"
+              icon={<Copy size={14} aria-hidden="true" />}
+              label={copy.copyPricingKey}
+              onClick={() => {
+                void props.onCopyPricingKey(pricingKey);
+              }}
+            />
+          </span>
+        )}
         {step.recovered && (
           <span className="maka-inspector-step-recovered">{copy.recoveredAs(step.recovered)}</span>
         )}

--- a/apps/desktop/src/renderer/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/session-inspector-panel.tsx
@@ -711,11 +711,13 @@ function StepRow(props: {
               variant="ghost"
               size="sm"
               icon={<Copy size={14} aria-hidden="true" />}
-              label={copy.copyPricingKey}
+              label={`${copy.copyPricingKey}: ${pricingKey}`}
               onClick={() => {
                 void props.onCopyPricingKey(pricingKey);
               }}
-            />
+            >
+              {copy.copyPricingKey}
+            </Button>
           </span>
         )}
         {step.recovered && (

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -553,6 +553,19 @@
   overflow-wrap: anywhere;
 }
 
+.maka-inspector-pricing-key {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-1);
+  min-width: 0;
+  color: var(--warning-text);
+}
+
+.maka-inspector-pricing-key code {
+  overflow-wrap: anywhere;
+}
+
 /* A recovery is not trivia about the step, it is the reason the run survived,
    so it carries the exception tint rather than the qualifier grey. */
 .maka-inspector-step-recovered {

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -7,6 +7,7 @@ import type {
 import { PROVIDER_DEFAULTS, providerSupportsModelDiscovery } from './llm-connections.js';
 import type { PricingConfig } from './usage-stats/types.js';
 import { curatedCatalogFallbackModelsForProvider, lookupModelMetadata } from './model-metadata.js';
+import { pricingModelKey } from './usage-stats/pricing.js';
 
 export type ModelCapabilitySource = 'provider_api' | 'static_catalog' | 'user_override' | 'unknown';
 
@@ -313,7 +314,9 @@ function makeEntry(
     provenance: {
       modelSource,
       ...(input.modelsFetchedAt ? { modelsFetchedAt: input.modelsFetchedAt } : {}),
-      ...(pricing ? { pricingModelKey: `${input.providerType}:${normalizedModel.id}` } : {}),
+      ...(pricing
+        ? { pricingModelKey: pricingModelKey(input.providerType, normalizedModel.id) }
+        : {}),
       sources: provenanceSources(
         input,
         normalizedModel.id,
@@ -594,7 +597,7 @@ function savedChoiceSourcesById(
 
 function findPricing(input: BuildModelCatalogInput, id: string): ModelCatalogPricing | null {
   if (!input.pricing) return null;
-  const modelKey = `${input.providerType}:${id}`;
+  const modelKey = pricingModelKey(input.providerType, id);
   for (const item of input.pricing) {
     if (item.modelKey !== modelKey) continue;
     return {

--- a/packages/core/src/usage-stats/__tests__/pricing.test.ts
+++ b/packages/core/src/usage-stats/__tests__/pricing.test.ts
@@ -6,8 +6,13 @@ import {
   comparePricingModelKeys,
   normalizePricingConfig,
   normalizePricingModelKey,
+  pricingModelKey,
   validateCanonicalPricingConfig,
 } from '../pricing.js';
+
+test('pricing model key preserves the exact provider and model identifiers', () => {
+  assert.equal(pricingModelKey('DeepInfra', 'org/Model:Preview'), 'DeepInfra:org/Model:Preview');
+});
 
 test('pricing model keys use strict exact ordering', () => {
   const composed = '\u00e9';

--- a/packages/core/src/usage-stats/bucket-key.ts
+++ b/packages/core/src/usage-stats/bucket-key.ts
@@ -1,4 +1,5 @@
 import type { UsageGroupBy } from './types.js';
+import { pricingModelKey } from './pricing.js';
 
 /**
  * The bucket key for one model call, shared by every Usage source.
@@ -17,7 +18,7 @@ export function usageBucketKey(
     case 'provider':
       return call.providerId;
     case 'model':
-      return `${call.providerId}:${call.modelId}`;
+      return pricingModelKey(call.providerId, call.modelId);
     case 'day':
       return new Date(call.ts).toISOString().slice(0, 10);
     case 'hour':

--- a/packages/core/src/usage-stats/pricing.ts
+++ b/packages/core/src/usage-stats/pricing.ts
@@ -63,6 +63,15 @@ const CANONICAL_PRICING_CONFIG_KEY_SET = new Set<string>(CANONICAL_PRICING_CONFI
 export const PRICING_MODEL_KEY_MAX_CHARS = 128;
 
 /**
+ * Build the exact key shared by Runtime pricing lookup and user-facing call facts.
+ * Provider and model ids are already canonical facts at this seam, so do not
+ * trim, lowercase, or otherwise normalize either half here.
+ */
+export function pricingModelKey(providerId: string, modelId: string): string {
+  return `${providerId}:${modelId}`;
+}
+
+/**
  * Locale-independent strict total order for exact JavaScript strings.
  * Canonically equivalent Unicode spellings remain distinct keys.
  */

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -82,6 +82,7 @@ import {
   PROVIDER_IMAGE_BUDGET_EXCEEDED_MESSAGE,
 } from '@maka/core/attachments';
 import { stripUndefinedDeep } from '@maka/core/tool-args-identity';
+import { pricingModelKey } from '@maka/core/usage-stats/pricing';
 import type {
   LlmCallRecord,
   PricingConfig,
@@ -3264,7 +3265,7 @@ export class AiSdkBackend implements AgentBackend {
   private computeTokenUsageCostUsd(usage: NormalizedAiSdkUsage): number | undefined {
     try {
       const pricing = (this.input.lookupPricing ?? getBuiltinPricing)(
-        `${this.input.connection.providerType}:${this.input.modelId}`,
+        pricingModelKey(this.input.connection.providerType, this.input.modelId),
       );
       if (pricing === null) return undefined;
       return computeCost(
@@ -3399,7 +3400,7 @@ export class AiSdkBackend implements AgentBackend {
   ): ResolvedModelCallCost | undefined {
     try {
       const pricing = (this.input.lookupPricing ?? getBuiltinPricing)(
-        `${this.input.connection.providerType}:${modelId}`,
+        pricingModelKey(this.input.connection.providerType, modelId),
       );
       if (pricing === null) return undefined;
       const costUsd = computeCost(

--- a/packages/runtime/src/telemetry/record-llm-call.ts
+++ b/packages/runtime/src/telemetry/record-llm-call.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { generalizedErrorMessage } from '@maka/core/redaction';
+import { pricingModelKey } from '@maka/core/usage-stats/pricing';
 import type { LlmCallRecord, PricingConfig } from '@maka/core/usage-stats/types';
 import { computeCost } from './cost.js';
 import type { TelemetryRepoLite } from './types.js';
@@ -44,7 +45,7 @@ export async function recordLlmCallStrict(
         cacheMissInputTokens,
         cacheWriteInputTokens,
       },
-      deps.lookupPricing(`${record.providerId}:${record.modelId}`),
+      deps.lookupPricing(pricingModelKey(record.providerId, record.modelId)),
     ).totalCost;
   const ts = record.startedAt + record.latencyMs;
   const recordId = record.callId

--- a/scripts/deepseek-live-cost-baseline.mjs
+++ b/scripts/deepseek-live-cost-baseline.mjs
@@ -24,6 +24,7 @@ import {
   createSessionStore,
   openRuntimeEventPersistence,
 } from '../packages/storage/dist/index.js';
+import { pricingModelKey } from '../packages/core/dist/usage-stats/pricing.js';
 
 const apiKey = process.env.DEEPSEEK_API_KEY;
 if (!apiKey) {
@@ -676,7 +677,7 @@ async function runPhase7ToolScenario(input) {
     turn.assistantText.includes(input.sentinel),
   );
   const finalArchiveReads = archiveReads.filter((read) => read.requestTurnId === 'phase7-recover');
-  const pricingId = `${connection.providerType}:${input.model}`;
+  const pricingId = pricingModelKey(connection.providerType, input.model);
   return {
     matrixCase: input.matrixCase,
     mode: input.mode,
@@ -1345,7 +1346,7 @@ async function runPhase10HistoryCompactScenario(input) {
     'Recover the Phase 10 sentinel again from prior context. Do not explain. Answer only the sentinel.',
   );
 
-  const pricingId = `${connection.providerType}:${input.model}`;
+  const pricingId = pricingModelKey(connection.providerType, input.model);
   return {
     matrixCase: input.matrixCase,
     mode: input.mode,
@@ -1762,7 +1763,7 @@ async function runPhase8SynthesisScenario(input) {
   const rawEvidenceUsageEvent = rawEvidenceTurn?.events.find(
     (event) => event.type === 'token_usage',
   );
-  const pricingId = `${connection.providerType}:${input.model}`;
+  const pricingId = pricingModelKey(connection.providerType, input.model);
   const coveredRecordOffset =
     input.mode === 'synthesis_read_write'
       ? rawEvidenceTurn


### PR DESCRIPTION
## Summary

Pricing overrides use an exact `providerId:modelId` lookup key, but an observed unpriced call did not give users a reliable way to obtain that key. The connection slug shown elsewhere can be different, so reconstructing it in the renderer would be easy to get wrong.

- centralize Pricing model-key construction in Core and use it across Runtime lookup, catalog projection, Usage bucketing, Headless, and the cost-baseline script
- expose the exact key on unpriced Session Inspector model calls with localized copy feedback
- keep priced calls unchanged and verify that the canonical provider id wins over the connection slug
- cover the real Host-backed Inspector and clipboard journey with the Desktop fixture

Refs #2015

## Verification

- `npm --workspace @maka/core test` — 802 passed
- `npm --workspace @maka/desktop run test:dist` — 1,128 passed
- `npm --workspace @maka/desktop run typecheck`
- focused Runtime cost, AiSdkBackend, Headless Pricing, Inspector projection, and E2E-fixture tests
- Biome checks and `git diff --check`
- the focused Playwright build completed locally; Electron launch requires an X server that is not available in this environment, so the new journey is left for CI to execute

<details>
<summary><strong>简体中文</strong></summary>

### 概要

Pricing override 使用精确的 `providerId:modelId` 作为查找 key，但用户此前无法从实际出现的未计价调用中可靠地取得这个 key。界面其他位置展示的 connection slug 可能与 canonical provider id 不同，因此不应让 Renderer 自行推断。

- 在 Core 中统一 Pricing model key 的构造，并让 Runtime 查价、Model Catalog 投影、Usage 分桶、Headless 和成本基线脚本共同使用
- 在 Session Inspector 的未计价模型调用中展示精确 key，并提供本地化的复制反馈
- 已计价调用保持原样，并通过测试保证使用 canonical provider id，而不是 connection slug
- 使用 Desktop fixture 覆盖真实 Host-backed Inspector 与剪贴板操作路径

### 验证

- `npm --workspace @maka/core test` — 802 项通过
- `npm --workspace @maka/desktop run test:dist` — 1,128 项通过
- `npm --workspace @maka/desktop run typecheck`
- Runtime cost、AiSdkBackend、Headless Pricing、Inspector projection 与 E2E fixture 定向测试通过
- Biome 检查与 `git diff --check` 通过
- 本地已完成定向 Playwright 构建；当前环境没有 X Server，无法启动 Electron，因此新增的真实界面路径交由 CI 执行

</details>

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
