### PR TITLE
fix(cli): recover sessions after workspace moves

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -18,6 +18,10 @@ describe('Maka CLI args', () => {
       [['--version'], { kind: 'version', text: '0.1.0' }],
       [['headless'], { kind: 'error', message: 'Unexpected argument: headless', exitCode: 2 }],
       [['--resume', 'abc'], { kind: 'tui', resumeSessionId: 'abc' }],
+      [
+        ['--resume', 'abc', '--cwd', '../moved repo'],
+        { kind: 'tui', resumeSessionId: 'abc', resumeCwd: '../moved repo' },
+      ],
       [['--resume'], { kind: 'error', message: '--resume requires a session id', exitCode: 2 }],
       [
         ['--resume', '--help'],
@@ -25,6 +29,14 @@ describe('Maka CLI args', () => {
       ],
       [
         ['--resume', 'abc', 'extra'],
+        { kind: 'error', message: 'Unexpected argument: extra', exitCode: 2 },
+      ],
+      [
+        ['--resume', 'abc', '--cwd'],
+        { kind: 'error', message: '--cwd requires a directory', exitCode: 2 },
+      ],
+      [
+        ['--resume', 'abc', '--cwd', '/repo', 'extra'],
         { kind: 'error', message: 'Unexpected argument: extra', exitCode: 2 },
       ],
     ];
@@ -35,6 +47,7 @@ describe('Maka CLI args', () => {
     const help = parseMakaCliArgs(['--help'], '0.1.0');
     assert.equal(help.kind, 'help');
     if (help.kind === 'help') assert.match(help.text, /Usage: maka/);
+    if (help.kind === 'help') assert.match(help.text, /--resume <id> --cwd <path>/);
   });
 
   test('preserves an established process exit code', () => {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -32,6 +32,7 @@ import type {
   MakaSessionMoveResult,
   MakaSessionDriver,
   MakaSessionRewindResult,
+  MakaSessionSwitchOptions,
   MakaSessionSwitchResult,
   RewindTarget,
   SessionResumeAvailability,
@@ -6340,6 +6341,56 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('relocates a moved session before resuming it at startup', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver([
+      fakeSessionSummary('session-2', '/repo/old', 'Moved chat'),
+    ]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo/current-shell',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+      resumeSessionId: 'session-2',
+      resumeCwd: '../new-worktree',
+    });
+
+    await waitFor(() => driver.sessionIds.length === 1);
+
+    assert.deepEqual(driver.sessionSwitchOptions, [{ relocateCwd: '../new-worktree' }]);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('points a missing-cwd resume failure at the explicit recovery command', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new MissingCwdSwitchSessionDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+      resumeSessionId: 'session-moved',
+    });
+
+    await waitFor(() => terminal.output().includes('--cwd <new-path>'));
+    const normalized = plainTerminalOutput(terminal.output()).replace(/\s+/g, ' ');
+    assert.match(
+      normalized,
+      /Retry with: maka --resume session-moved --cwd <new-path>\. Starting fresh\./,
+    );
+
+    exitMaka(terminal);
+    await run;
+  });
+
   test('resumes an active Host turn from its atomic transcript and continues live output', async () => {
     const terminal = new FakeTerminal();
     const driver = new ActiveResumeDriver();
@@ -7655,6 +7706,7 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly orchestrationModes: OrchestrationMode[] = [];
   readonly turnOrchestrations: Array<MakaPreparePromptOptions['turnOrchestration']> = [];
   readonly sessionIds: string[] = [];
+  readonly sessionSwitchOptions: Array<MakaSessionSwitchOptions | undefined> = [];
   readonly renames: string[] = [];
   readonly moves: string[] = [];
   startNewSessionCalls = 0;
@@ -7779,8 +7831,12 @@ class SlashCommandDriver implements MakaSessionDriver {
     this.orchestrationModes.push(mode);
     this.orchestrationMode = mode;
   }
-  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+  async switchSession(
+    sessionId: string,
+    options?: MakaSessionSwitchOptions,
+  ): Promise<MakaSessionSwitchResult> {
     this.sessionIds.push(sessionId);
+    this.sessionSwitchOptions.push(options);
     this.sessionId = sessionId;
     const summary = this.sessions.find((session) => session.id === sessionId);
     const nextSummary = summary ?? fakeSessionSummary(sessionId);
@@ -7830,6 +7886,12 @@ class HostSkillDriver extends SlashCommandDriver {
 class FailingSwitchSessionDriver extends SlashCommandDriver {
   async switchSession(_sessionId: string): Promise<MakaSessionSwitchResult> {
     throw new Error('session not found');
+  }
+}
+
+class MissingCwdSwitchSessionDriver extends SlashCommandDriver {
+  override async switchSession(_sessionId: string): Promise<MakaSessionSwitchResult> {
+    throw new Error('Session cwd no longer exists: /repo/old');
   }
 }
 

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { describe, test } from 'node:test';
 import type { StoredMessage } from '@maka/core';
@@ -22,6 +25,83 @@ import { SkillInvocationBlockedError, type MakaAttachedSessionTurn } from '../se
 import { WAIT_BUDGET_MS } from './tui-terminal-mock.js';
 
 describe('Runtime Host Maka Session driver', () => {
+  test('relocates a moved Session through Host authority before attaching', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-tui-resume-moved-cwd-'));
+    const target = join(root, 'new-worktree');
+    await mkdir(target);
+    try {
+      const oldCwd = join(root, 'old-worktree');
+      const connection = new FakeConnection([
+        new FakeSubscription(continuitySnapshot(), Promise.resolve([])),
+      ]);
+      connection.sessionQueries.push(
+        sessionProjection({ cwd: oldCwd }),
+        sessionProjection({ cwd: oldCwd }),
+      );
+      const inspected: string[] = [];
+      const driver = createRuntimeHostMakaSessionDriver({
+        connection: connection.value,
+        cwd: root,
+        llmConnectionSlug: 'openai-main',
+        model: 'gpt-5',
+        inspectCwdChanges: async (cwd) => {
+          inspected.push(cwd);
+          return undefined;
+        },
+      });
+
+      const switched = await driver.switchSession('session-1', {
+        relocateCwd: './new-worktree',
+      });
+      const canonicalTarget = await realpath(target);
+
+      assert.equal(switched.summary.cwd, canonicalTarget);
+      assert.deepEqual(switched.relocation, {
+        previousCwd: oldCwd,
+        cwd: canonicalTarget,
+        changed: true,
+        oldCwdDirty: undefined,
+      });
+      assert.deepEqual(inspected, [oldCwd]);
+      assert.deepEqual(
+        connection.requests.map(({ operation }) => operation),
+        [
+          'session.catalog.query',
+          'session.execution_boundary.query',
+          'session.catalog.query',
+          'session.cwd.relocate',
+        ],
+      );
+      assert.deepEqual(connection.requests.at(-1)?.input, {
+        sessionId: 'session-1',
+        expectedRevision: 1,
+        cwd: canonicalTarget,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('does not relocate an externally isolated Session during resume', async () => {
+    const connection = new FakeConnection([]);
+    connection.executionBoundary = { kind: 'external', harness: 'harbor', revision: 1 };
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: process.cwd(),
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+    });
+
+    await assert.rejects(
+      driver.switchSession('session-1', { relocateCwd: process.cwd() }),
+      /Cannot resume externally isolated session/,
+    );
+    assert.equal(
+      connection.requests.some(({ operation }) => operation === 'session.cwd.relocate'),
+      false,
+    );
+  });
+
   test('atomically joins an active turn without losing output produced during transcript load', async () => {
     const transcript = deferred<StoredMessage[]>();
     const subscription = new FakeSubscription(continuitySnapshot(), transcript.promise);
@@ -767,6 +847,7 @@ class FakeConnection {
   readonly sessionQueries: Array<SessionCatalogProjection | Promise<SessionCatalogProjection>> = [];
   openedSubscriptions = 0;
   interactionQuery: unknown;
+  executionBoundary: unknown = { kind: 'managed', access: 'read_write', revision: 1 };
   skillStartBlocked = false;
   readonly value: RuntimeHostMakaSessionDriverInput['connection'];
 
@@ -790,6 +871,15 @@ class FakeConnection {
     input: OperationInput<K>,
   ): Promise<OperationOutput<K>> {
     this.requests.push({ operation, input });
+    if (operation === 'session.cwd.relocate') {
+      return {
+        kind: 'committed',
+        session: sessionProjection({
+          revision: 2,
+          cwd: (input as OperationInput<'session.cwd.relocate'>).cwd,
+        }),
+      } as OperationOutput<K>;
+    }
     const turnInput = input as {
       sessionId?: string;
       turnId?: string;
@@ -802,7 +892,7 @@ class FakeConnection {
             session: await (this.sessionQueries.shift() ?? sessionProjection()),
           }
         : operation === 'session.execution_boundary.query'
-          ? { kind: 'managed', access: 'read_write', revision: 1 }
+          ? this.executionBoundary
           : operation === 'turn.message.submit'
             ? { disposition: 'queued', queueRevision: 2 }
             : operation === 'queue.retract'

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
 
 export type MakaCliCommand =
-  | { kind: 'tui'; resumeSessionId?: string }
+  | { kind: 'tui'; resumeSessionId?: string; resumeCwd?: string }
   | { kind: 'run'; args: string[] }
   | { kind: 'activate'; args: string[] }
   | { kind: 'eval'; args: string[] }
@@ -25,11 +25,19 @@ export function parseMakaCliArgs(argv: string[], version: string): MakaCliComman
     if (!sessionId || sessionId.startsWith('-')) {
       return { kind: 'error', message: '--resume requires a session id', exitCode: 2 };
     }
-    const extra = argv[2];
+    if (argv[2] === undefined) return { kind: 'tui', resumeSessionId: sessionId };
+    if (argv[2] !== '--cwd') {
+      return { kind: 'error', message: `Unexpected argument: ${argv[2]}`, exitCode: 2 };
+    }
+    const resumeCwd = argv[3];
+    if (!resumeCwd || resumeCwd.startsWith('-')) {
+      return { kind: 'error', message: '--cwd requires a directory', exitCode: 2 };
+    }
+    const extra = argv[4];
     if (extra !== undefined) {
       return { kind: 'error', message: `Unexpected argument: ${extra}`, exitCode: 2 };
     }
-    return { kind: 'tui', resumeSessionId: sessionId };
+    return { kind: 'tui', resumeSessionId: sessionId, resumeCwd };
   }
   if (first === 'run' || first === '-p') return { kind: 'run', args: argv.slice(1) };
   if (first === 'activate') return { kind: 'activate', args: argv.slice(1) };
@@ -93,6 +101,7 @@ function helpText(): string {
     '  -h, --help        Show help',
     '  -v, --version     Show version',
     '  --resume <session-id>  Reopen a previous session in the TUI',
+    '  --resume <id> --cwd <path>  Reopen a session after its directory moved',
   ].join('\n');
 }
 
@@ -138,6 +147,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
         cwd: process.cwd(),
         onProcessExit: handleMakaCliProcessExit,
         ...(command.resumeSessionId ? { resumeSessionId: command.resumeSessionId } : {}),
+        ...(command.resumeCwd ? { resumeCwd: command.resumeCwd } : {}),
       });
     }
   }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -176,6 +176,11 @@ export interface MakaPiTuiInput {
    */
   resumeSessionId?: string;
   /**
+   * Explicit replacement cwd used only while attaching `resumeSessionId`.
+   * The Session driver owns validation and durable relocation.
+   */
+  resumeCwd?: string;
+  /**
    * Read-only store of sessions from other coding agents (Claude Code,
    * Codex). When present, the session picker lists foreign sessions for the
    * current cwd; selecting one distills it into a handoff digest and opens a
@@ -1280,10 +1285,24 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // The driver validates the durable cwd before adopting the resumed session.
   // A failure leaves the active session untouched and the next prompt still
   // lands on the old one.
-  const switchSession = async (sessionId: string) => {
+  const switchSession = async (sessionId: string, relocateCwd?: string) => {
     resolvedInteractionIds.clear();
-    const result = await input.driver.switchSession(sessionId);
+    const result = await input.driver.switchSession(
+      sessionId,
+      relocateCwd === undefined ? undefined : { relocateCwd },
+    );
     await applySwitchResult(result);
+    if (result.relocation?.changed) {
+      const warning =
+        result.relocation.oldCwdDirty === true
+          ? ` Warning: the old directory "${result.relocation.previousCwd}" has uncommitted changes.`
+          : '';
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: `Session moved to "${result.relocation.cwd}".${warning}`,
+      });
+    }
     if (result.messages.length === 0) {
       state.entries.push({
         kind: 'notice',
@@ -2778,12 +2797,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   if (input.resumeSessionId) {
     void runControl(async () => {
       try {
-        await switchSession(input.resumeSessionId!);
+        await switchSession(input.resumeSessionId!, input.resumeCwd);
       } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        const recoveryHint =
+          input.resumeCwd === undefined && message.startsWith('Session cwd no longer exists:')
+            ? ` Retry with: maka --resume ${input.resumeSessionId} --cwd <new-path>.`
+            : '';
         state.entries.push({
           kind: 'notice',
           level: 'error',
-          text: `Could not resume session ${input.resumeSessionId}: ${error instanceof Error ? error.message : String(error)}. Starting fresh.`,
+          text: `Could not resume session ${input.resumeSessionId}: ${message}.${recoveryHint} Starting fresh.`,
         });
         requestRender();
       }

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -45,6 +45,7 @@ import type {
   MakaSessionDriver,
   MakaSessionMoveResult,
   MakaSessionRewindResult,
+  MakaSessionSwitchOptions,
   MakaSessionSwitchResult,
   RewindTarget,
   SessionResumeAvailability,
@@ -377,32 +378,40 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       return { previousCwd, cwd: nextCwd, changed: false, oldCwdDirty: false };
     }
     const oldCwdDirty = await this.#inspectCwdChanges(previousCwd).catch(() => undefined);
-    const session = await updateRuntimeHostSession(this.#connection, sessionId, (current) =>
-      this.#request('session.cwd.relocate', {
-        sessionId,
-        expectedRevision: current.revision,
-        cwd: nextCwd,
-      }),
-    );
+    const session = await this.#commitCwdRelocation(sessionId, nextCwd);
     this.#cwd = session.cwd;
     return { previousCwd, cwd: this.#cwd, changed: true, oldCwdDirty };
   }
 
-  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
-    const session = await getRuntimeHostSession(this.#connection, sessionId);
+  async switchSession(
+    sessionId: string,
+    options: MakaSessionSwitchOptions = {},
+  ): Promise<MakaSessionSwitchResult> {
+    let session = await getRuntimeHostSession(this.#connection, sessionId);
     if (!session) throw new Error(`Session not found: ${sessionId}`);
-    const summary = runtimeHostSessionSummary(session);
-    const availability = await inspectSessionResumeAvailability(summary);
-    if (!availability.available) {
-      throw new Error(
-        summary.cwd ? `Session cwd no longer exists: ${summary.cwd}` : availability.reason,
-      );
+    let summary = runtimeHostSessionSummary(session);
+    if (options.relocateCwd === undefined) {
+      await assertSessionResumeAvailable(summary);
     }
     const boundary = await this.#request('session.execution_boundary.query', { sessionId });
     if (boundary.kind === 'external') {
       throw new Error(
         `Cannot resume externally isolated session ${sessionId} outside its owning harness.`,
       );
+    }
+    let relocation: MakaSessionMoveResult | undefined;
+    if (options.relocateCwd !== undefined) {
+      const nextCwd = await resolveMoveCwd(options.relocateCwd, this.#cwd);
+      const previousCwd = session.cwd;
+      if (nextCwd === previousCwd) {
+        relocation = { previousCwd, cwd: nextCwd, changed: false, oldCwdDirty: false };
+      } else {
+        const oldCwdDirty = await this.#inspectCwdChanges(previousCwd).catch(() => undefined);
+        session = await this.#commitCwdRelocation(sessionId, nextCwd);
+        relocation = { previousCwd, cwd: session.cwd, changed: true, oldCwdDirty };
+      }
+      summary = runtimeHostSessionSummary(session);
+      await assertSessionResumeAvailable(summary);
     }
     const expectedChannelGeneration = this.#channelGeneration;
     const nextSessionGeneration = this.#sessionGeneration + 1;
@@ -424,6 +433,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     return {
       summary,
       messages: opened.messages,
+      ...(relocation === undefined ? {} : { relocation }),
       ...(attachedTurnId
         ? {
             activeTurn: {
@@ -437,6 +447,16 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
           }
         : {}),
     };
+  }
+
+  #commitCwdRelocation(sessionId: string, cwd: string): Promise<SessionCatalogProjection> {
+    return updateRuntimeHostSession(this.#connection, sessionId, (current) =>
+      this.#request('session.cwd.relocate', {
+        sessionId,
+        expectedRevision: current.revision,
+        cwd,
+      }),
+    );
   }
 
   async listRewindTargets(): Promise<RewindTarget[]> {
@@ -886,6 +906,15 @@ function representableSession(item: SessionCatalogItem): SessionCatalogProjectio
 function requireSession(item: SessionCatalogItem): SessionCatalogProjection {
   if (!('kind' in item)) return item;
   throw new Error(`Runtime Host Session is not representable by this CLI: ${item.id}`);
+}
+
+async function assertSessionResumeAvailable(summary: SessionSummary): Promise<void> {
+  const availability = await inspectSessionResumeAvailability(summary);
+  if (!availability.available) {
+    throw new Error(
+      summary.cwd ? `Session cwd no longer exists: ${summary.cwd}` : availability.reason,
+    );
+  }
 }
 
 async function updateRuntimeHostSession(

--- a/packages/cli/src/runtime-host-tui-command.ts
+++ b/packages/cli/src/runtime-host-tui-command.ts
@@ -13,6 +13,7 @@ export interface RunRuntimeHostTuiInput {
   readonly workspaceRoot: string;
   readonly cwd: string;
   readonly resumeSessionId?: string;
+  readonly resumeCwd?: string;
   readonly onProcessExit: (exitCode: number, error?: Error) => void;
 }
 
@@ -55,6 +56,7 @@ export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<
       listShellRunUpdates: (sessionId) => context.driver.listShellRunUpdates(sessionId),
       onProcessExit: input.onProcessExit,
       resumeSessionId: input.resumeSessionId,
+      resumeCwd: input.resumeCwd,
     });
     const sessionId = context.driver.getSessionId();
     if (sessionId)

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -17,6 +17,11 @@ export interface MakaSessionMoveResult {
   oldCwdDirty?: boolean;
 }
 
+export interface MakaSessionSwitchOptions {
+  /** Explicitly relocate the durable Session cwd before attaching to it. */
+  relocateCwd?: string;
+}
+
 export type InspectCwdChanges = (cwd: string) => Promise<boolean | undefined>;
 
 export interface RewindTarget {
@@ -28,6 +33,7 @@ export interface MakaSessionSwitchResult {
   summary: SessionSummary;
   messages: StoredMessage[];
   activeTurn?: MakaPreparedSessionTurn;
+  relocation?: MakaSessionMoveResult;
 }
 
 export interface MakaSessionRewindResult extends MakaSessionSwitchResult {
@@ -83,7 +89,10 @@ export interface MakaSessionDriver {
   setOrchestrationMode?(mode: OrchestrationMode): Promise<void>;
   renameSession(name: string): Promise<string | void>;
   moveSession?(cwd: string): Promise<MakaSessionMoveResult>;
-  switchSession(sessionId: string): Promise<MakaSessionSwitchResult>;
+  switchSession(
+    sessionId: string,
+    options?: MakaSessionSwitchOptions,
+  ): Promise<MakaSessionSwitchResult>;
   listRewindTargets(): Promise<RewindTarget[]>;
   rewindToTurn(turnId: string): Promise<MakaSessionRewindResult>;
   subscribeStartedTurns?(listener: (turn: MakaAttachedSessionTurn) => void): () => void;


### PR DESCRIPTION
## Summary

Add `maka --resume <session-id> --cwd <new-path>` so an interactive session can be recovered after its project directory moves.

The explicit path is canonicalized and committed through the existing Runtime Host relocation operation before the TUI attaches. Ordinary resume remains fail-closed, externally isolated sessions cannot be relocated, and the missing-cwd error now points to the recovery command.

Fixes #2529

## Verification

- `npm --workspace @maka/headless run build && npm --workspace maka-agent test` — 345 passed
- `npm run lint`
- `npm run format:check`
- `npm --workspace maka-agent run typecheck`
- Manual TUI check against a real session whose repository was renamed:

  ```text
  Note: Session moved to "/tmp/maka-dogfood-2026-08-09/workspace-a-moved".
  $ pwd
  /tmp/maka-dogfood-2026-08-09/workspace-a-moved
  ```

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

<details>
<summary>简体中文</summary>

## 概要

新增 `maka --resume <session-id> --cwd <new-path>`，让用户在项目目录被移动或重命名后仍能恢复原有交互式 Session。

新路径会先被规范化，并通过现有 Runtime Host relocation operation 提交，成功后 TUI 才会连接原 Session。普通恢复仍保持安全失败；externally isolated Session 不允许被该入口改写；cwd 失效时的提示会直接给出恢复命令。

## 验证

- CLI workspace 测试：345 项通过
- 全仓 lint 与 format check 通过
- CLI typecheck 通过
- 使用真实 Session 完成目录重命名、恢复和 Bash `pwd` 验证

</details>
