### PR TITLE
fix(runtime): recover idle provider streams

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10653,6 +10653,272 @@ describe('AiSdkBackend RunTrace', () => {
     );
   });
 
+  test('retries one idle watchdog timeout after preserving partial thinking', async () => {
+    const timers = manualWatchdogTimer();
+    const assistants: AssistantMessage[] = [];
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        if (calls === 1) {
+          return {
+            stream: hangingProviderStream(
+              [
+                { type: 'stream-start', warnings: [] },
+                { type: 'reasoning-start', id: 'reasoning-1' },
+                {
+                  type: 'reasoning-delta',
+                  id: 'reasoning-1',
+                  delta: 'partial thought',
+                },
+              ],
+              options.abortSignal,
+              'close',
+            ),
+          };
+        }
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: 'stream-start', warnings: [] },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'recovered' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: emptyUsage(),
+              },
+            ],
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => {
+        if (message.type === 'assistant') assistants.push(message);
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+      if (event.type === 'thinking_delta' && event.text === 'partial thought') timers.fire();
+    }
+
+    assert.equal(calls, 2);
+    assert.deepEqual(
+      events
+        .filter((event) => event.type === 'provider_retry')
+        .map(({ phase, attempt, maxAttempts, reason }) => ({
+          phase,
+          attempt,
+          maxAttempts,
+          reason,
+        })),
+      [
+        { phase: 'scheduled', attempt: 2, maxAttempts: 2, reason: 'timeout' },
+        { phase: 'started', attempt: 2, maxAttempts: 2, reason: 'timeout' },
+      ],
+    );
+    assert.equal(
+      events.some((event) => event.type === 'error'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
+    assert.equal(assistants.length, 2);
+    assert.equal(assistants[0]?.thinking?.text, 'partial thought');
+    assert.equal(assistants[0]?.text, '');
+    assert.equal(assistants[1]?.text, 'recovered');
+    assert.notEqual(assistants[0]?.id, assistants[1]?.id);
+  });
+
+  test('does not retry an idle watchdog timeout after partial answer text', async () => {
+    const timers = manualWatchdogTimer();
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        return {
+          stream: hangingProviderStream(
+            [
+              { type: 'stream-start', warnings: [] },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'partial answer' },
+            ],
+            options.abortSignal,
+          ),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+      if (event.type === 'text_delta' && event.text === 'partial answer') timers.fire();
+    }
+
+    assert.equal(calls, 1);
+    assert.equal(
+      events.some((event) => event.type === 'provider_retry'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'error')?.reason, 'timeout');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
+  test('does not retry an idle watchdog timeout after provider continuation metadata', async () => {
+    const timers = manualWatchdogTimer();
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        return {
+          stream: hangingProviderStream(
+            [
+              { type: 'stream-start', warnings: [] },
+              { type: 'reasoning-start', id: 'reasoning-1' },
+              {
+                type: 'reasoning-delta',
+                id: 'reasoning-1',
+                delta: 'completed provider reasoning',
+              },
+              {
+                type: 'reasoning-end',
+                id: 'reasoning-1',
+                providerMetadata: {
+                  openai: {
+                    itemId: 'reasoning-item-1',
+                    reasoningEncryptedContent: 'encrypted-reasoning',
+                  },
+                },
+              },
+            ],
+            options.abortSignal,
+          ),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    const eventsPromise = collectEvents(
+      backend.send({ turnId: 'turn-1', text: 'hi', context: [] }),
+      events,
+    );
+    await waitFor(() => timers.armCount() >= 5);
+    timers.fire();
+    await eventsPromise;
+
+    assert.equal(calls, 1);
+    assert.equal(
+      events.some((event) => event.type === 'provider_retry'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'error')?.reason, 'timeout');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
+  test('Stop aborts the turn while an idle-timeout retry is waiting', async () => {
+    const timers = manualWatchdogTimer();
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        return {
+          stream: hangingProviderStream(
+            [
+              { type: 'stream-start', warnings: [] },
+              { type: 'reasoning-start', id: 'reasoning-1' },
+              {
+                type: 'reasoning-delta',
+                id: 'reasoning-1',
+                delta: 'partial thought',
+              },
+            ],
+            options.abortSignal,
+          ),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async (_delayMs, signal) =>
+        await new Promise<void>((_resolve, reject) => {
+          const abort = () =>
+            reject(signal.reason ?? Object.assign(new Error('aborted'), { name: 'AbortError' }));
+          if (signal.aborted) abort();
+          else signal.addEventListener('abort', abort, { once: true });
+        }),
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+      if (event.type === 'thinking_delta' && event.text === 'partial thought') timers.fire();
+      if (event.type === 'provider_retry' && event.phase === 'scheduled') {
+        await backend.stop('user_stop');
+      }
+    }
+
+    assert.equal(calls, 1);
+    assert.equal(
+      events.some((event) => event.type === 'provider_retry' && event.phase === 'started'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'user_stop');
+  });
+
   test('records the continuation replay gate and blocking diagnostics on stream failure', async () => {
     const trace: RunTraceEvent[] = [];
     const model = new MockLanguageModelV4({
@@ -15096,6 +15362,53 @@ function makeGate(): { promise: Promise<void>; release: () => void } {
     release = resolve;
   });
   return { promise, release };
+}
+
+function manualWatchdogTimer(): {
+  clock: NonNullable<AiSdkBackendInput['streamWatchdogTimer']>;
+  fire: () => void;
+  armCount: () => number;
+} {
+  let pending: { readonly token: object; readonly callback: () => void } | undefined;
+  let armCount = 0;
+  return {
+    clock: {
+      setTimer: (callback) => {
+        armCount += 1;
+        const token = {};
+        pending = { token, callback };
+        return token;
+      },
+      clearTimer: (token) => {
+        if (pending?.token === token) pending = undefined;
+      },
+    },
+    fire: () => {
+      assert.ok(pending, 'watchdog timer must be armed');
+      const callback = pending.callback;
+      pending = undefined;
+      callback();
+    },
+    armCount: () => armCount,
+  };
+}
+
+function hangingProviderStream(
+  chunks: readonly LanguageModelV4StreamPart[],
+  signal: AbortSignal | undefined,
+  abortMode: 'error' | 'close' = 'error',
+): ReadableStream<LanguageModelV4StreamPart> {
+  return new ReadableStream<LanguageModelV4StreamPart>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      const abort = () => {
+        if (abortMode === 'close') controller.close();
+        else controller.error(signal?.reason ?? new Error('aborted'));
+      };
+      if (signal?.aborted) abort();
+      else signal?.addEventListener('abort', abort, { once: true });
+    },
+  });
 }
 
 function header(permissionMode: SessionHeader['permissionMode'] = 'ask'): SessionHeader {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10746,6 +10746,61 @@ describe('AiSdkBackend RunTrace', () => {
     assert.notEqual(assistants[0]?.id, assistants[1]?.id);
   });
 
+  test('stops after one recovered idle watchdog timeout in the same provider step', async () => {
+    const timers = manualWatchdogTimer();
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        return {
+          stream: hangingProviderStream(
+            [
+              { type: 'stream-start', warnings: [] },
+              { type: 'reasoning-start', id: `reasoning-${calls}` },
+              {
+                type: 'reasoning-delta',
+                id: `reasoning-${calls}`,
+                delta: `partial thought ${calls}`,
+              },
+            ],
+            options.abortSignal,
+          ),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+      if (event.type === 'thinking_delta' && event.text.startsWith('partial thought')) {
+        timers.fire();
+      }
+    }
+
+    assert.equal(calls, 2);
+    assert.equal(
+      events.filter((event) => event.type === 'provider_retry' && event.phase === 'scheduled')
+        .length,
+      1,
+    );
+    assert.equal(events.find((event) => event.type === 'error')?.reason, 'timeout');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
   test('does not retry an idle watchdog timeout after partial answer text', async () => {
     const timers = manualWatchdogTimer();
     let calls = 0;

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10746,6 +10746,141 @@ describe('AiSdkBackend RunTrace', () => {
     assert.notEqual(assistants[0]?.id, assistants[1]?.id);
   });
 
+  test('retries DeepSeek OpenAI Chat reasoning marked only for field replay', async () => {
+    const timers = manualWatchdogTimer();
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        if (calls === 1) {
+          return {
+            stream: hangingProviderStream(
+              [
+                { type: 'stream-start', warnings: [] },
+                { type: 'reasoning-start', id: 'reasoning-1' },
+                {
+                  type: 'reasoning-delta',
+                  id: 'reasoning-1',
+                  delta: 'ordinary DeepSeek reasoning',
+                },
+              ],
+              options.abortSignal,
+            ),
+          };
+        }
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: 'stream-start', warnings: [] },
+              { type: 'text-start', id: 'text-1' },
+              { type: 'text-delta', id: 'text-1', delta: 'recovered' },
+              { type: 'text-end', id: 'text-1' },
+              {
+                type: 'finish',
+                finishReason: { unified: 'stop', raw: 'stop' },
+                usage: emptyUsage(),
+              },
+            ],
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        ...connection(),
+        slug: 'deepseek',
+        providerType: 'deepseek',
+        defaultModel: 'deepseek-v4-pro',
+        models: [{ id: 'deepseek-v4-pro', apiProtocol: 'openai-chat' }],
+      },
+      apiKey: 'deepseek-token',
+      modelId: 'deepseek-v4-pro',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+      if (event.type === 'thinking_delta' && event.text === 'ordinary DeepSeek reasoning') {
+        timers.fire();
+      }
+    }
+
+    assert.equal(calls, 2);
+    assert.equal(
+      events.some((event) => event.type === 'provider_retry' && event.phase === 'started'),
+      true,
+    );
+    assert.equal(
+      events.some((event) => event.type === 'error'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
+  });
+
+  test('does not report a consumed idle timeout for a later assistant append failure', async () => {
+    const timers = manualWatchdogTimer();
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        return {
+          stream: hangingProviderStream(
+            [
+              { type: 'stream-start', warnings: [] },
+              { type: 'reasoning-start', id: 'reasoning-1' },
+              {
+                type: 'reasoning-delta',
+                id: 'reasoning-1',
+                delta: 'partial thought',
+              },
+            ],
+            options.abortSignal,
+          ),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {
+        throw new Error('assistant append failed');
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+      if (event.type === 'thinking_delta' && event.text === 'partial thought') timers.fire();
+    }
+
+    assert.equal(calls, 1);
+    const error = events.find((event) => event.type === 'error');
+    assert.equal(error?.type, 'error');
+    assert.notEqual(error?.type === 'error' ? error.reason : undefined, 'timeout');
+    assert.equal(error?.type === 'error' ? error.message : undefined, 'Operation failed');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
   test('links a recovered tool call to the retry assistant step', async () => {
     const timers = manualWatchdogTimer();
     const durable = durableTurnHarness('turn-1', 'read notes');
@@ -11016,6 +11151,66 @@ describe('AiSdkBackend RunTrace', () => {
       events,
     );
     await waitFor(() => timers.armCount() >= 5);
+    timers.fire();
+    await eventsPromise;
+
+    assert.equal(calls, 1);
+    assert.equal(
+      events.some((event) => event.type === 'provider_retry'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'error')?.reason, 'timeout');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
+  test('does not retry after provider-executed tool input starts', async () => {
+    const timers = manualWatchdogTimer();
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        return {
+          stream: hangingProviderStream(
+            [
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'tool-input-start',
+                id: 'provider-tool-1',
+                toolName: 'web_search',
+                providerExecuted: true,
+              },
+              {
+                type: 'tool-input-delta',
+                id: 'provider-tool-1',
+                delta: '{"query":"release notes"}',
+              },
+            ],
+            options.abortSignal,
+          ),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    const eventsPromise = collectEvents(
+      backend.send({ turnId: 'turn-1', text: 'hi', context: [] }),
+      events,
+    );
+    await waitFor(() => timers.armCount() >= 4);
     timers.fire();
     await eventsPromise;
 

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10746,6 +10746,120 @@ describe('AiSdkBackend RunTrace', () => {
     assert.notEqual(assistants[0]?.id, assistants[1]?.id);
   });
 
+  test('links a recovered tool call to the retry assistant step', async () => {
+    const timers = manualWatchdogTimer();
+    const durable = durableTurnHarness('turn-1', 'read notes');
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        if (calls === 1) {
+          return {
+            stream: hangingProviderStream(
+              [
+                { type: 'stream-start', warnings: [] },
+                { type: 'reasoning-start', id: 'reasoning-timeout' },
+                {
+                  type: 'reasoning-delta',
+                  id: 'reasoning-timeout',
+                  delta: 'timed-out thought',
+                },
+              ],
+              options.abortSignal,
+            ),
+          };
+        }
+        const chunks: LanguageModelV4StreamPart[] =
+          calls === 2
+            ? [
+                { type: 'stream-start', warnings: [] },
+                { type: 'reasoning-start', id: 'reasoning-retry' },
+                {
+                  type: 'reasoning-delta',
+                  id: 'reasoning-retry',
+                  delta: 'recovered thought',
+                },
+                {
+                  type: 'reasoning-delta',
+                  id: 'reasoning-retry',
+                  delta: '',
+                  providerMetadata: { anthropic: { signature: 'sig-retry' } },
+                },
+                { type: 'reasoning-end', id: 'reasoning-retry' },
+                {
+                  type: 'tool-call',
+                  toolCallId: 'read-1',
+                  toolName: 'Read',
+                  input: JSON.stringify({ path: 'notes.md' }),
+                },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                  usage: emptyUsage(),
+                },
+              ]
+            : [
+                { type: 'stream-start', warnings: [] },
+                { type: 'text-start', id: 'text-final' },
+                { type: 'text-delta', id: 'text-final', delta: 'done' },
+                { type: 'text-end', id: 'text-final' },
+                {
+                  type: 'finish',
+                  finishReason: { unified: 'stop', raw: 'stop' },
+                  usage: emptyUsage(),
+                },
+              ];
+        return {
+          stream: simulateReadableStream({
+            chunks,
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send(durable.input())) {
+      durable.record(event);
+      events.push(event);
+      if (event.type === 'thinking_delta' && event.text === 'timed-out thought') timers.fire();
+    }
+
+    const timeoutThinking = events.find(
+      (event) => event.type === 'thinking_complete' && event.text === 'timed-out thought',
+    );
+    const recoveredThinking = events.find(
+      (event) => event.type === 'thinking_complete' && event.text === 'recovered thought',
+    );
+    const toolStart = events.find(
+      (event): event is Extract<SessionEvent, { type: 'tool_start' }> =>
+        event.type === 'tool_start' && event.toolUseId === 'read-1',
+    );
+
+    assert.equal(calls, 3);
+    assert.equal(timeoutThinking?.type, 'thinking_complete');
+    assert.equal(recoveredThinking?.type, 'thinking_complete');
+    assert.equal(toolStart?.stepId, recoveredThinking?.messageId);
+    assert.notEqual(toolStart?.stepId, timeoutThinking?.messageId);
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
+  });
+
   test('stops after one recovered idle watchdog timeout in the same provider step', async () => {
     const timers = manualWatchdogTimer();
     let calls = 0;

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -11028,6 +11028,123 @@ describe('AiSdkBackend RunTrace', () => {
     assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
   });
 
+  test('does not retry an idle watchdog timeout after text continuation metadata', async () => {
+    const timers = manualWatchdogTimer();
+    let calls = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async (options) => {
+        calls += 1;
+        return {
+          stream: hangingProviderStream(
+            [
+              { type: 'stream-start', warnings: [] },
+              { type: 'text-start', id: 'text-1' },
+              {
+                type: 'text-end',
+                id: 'text-1',
+                providerMetadata: { openai: { itemId: 'message-item-1' } },
+              },
+            ],
+            options.abortSignal,
+          ),
+        };
+      },
+    });
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+
+    const events: SessionEvent[] = [];
+    const eventsPromise = collectEvents(
+      backend.send({ turnId: 'turn-1', text: 'hi', context: [] }),
+      events,
+    );
+    await waitFor(() => timers.armCount() >= 4);
+    timers.fire();
+    await eventsPromise;
+
+    assert.equal(calls, 1);
+    assert.equal(
+      events.some((event) => event.type === 'provider_retry'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'error')?.reason, 'timeout');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
+  test('does not retry an idle watchdog timeout after a terminal finish boundary', async () => {
+    const timers = manualWatchdogTimer();
+    const finishConsumed = makeGate();
+    let calls = 0;
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => completionModel(),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      streamWatchdogTimer: timers.clock,
+      providerRetrySleep: async () => {},
+    });
+    type FakeStreamInput = {
+      abortSignal: AbortSignal;
+      onStreamActivity: () => void;
+    };
+    (
+      backend as unknown as {
+        modelAdapter: { startStream: (input: FakeStreamInput) => Promise<unknown> };
+      }
+    ).modelAdapter.startStream = async (input: FakeStreamInput) => {
+      calls += 1;
+      return {
+        events: (async function* () {
+          input.onStreamActivity();
+          yield { kind: 'finish' as const, finishReason: 'stop' };
+          finishConsumed.release();
+          await new Promise<void>((_resolve, reject) => {
+            const abort = () => reject(input.abortSignal.reason ?? new Error('aborted'));
+            if (input.abortSignal.aborted) abort();
+            else input.abortSignal.addEventListener('abort', abort, { once: true });
+          });
+        })(),
+        usage: Promise.resolve(undefined),
+        finishReason: Promise.resolve('stop'),
+      };
+    };
+
+    const events: SessionEvent[] = [];
+    const eventsPromise = collectEvents(
+      backend.send({ turnId: 'turn-1', text: 'hi', context: [] }),
+      events,
+    );
+    await finishConsumed.promise;
+    timers.fire();
+    await eventsPromise;
+
+    assert.equal(calls, 1);
+    assert.equal(
+      events.some((event) => event.type === 'provider_retry'),
+      false,
+    );
+    assert.equal(events.find((event) => event.type === 'error')?.reason, 'timeout');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+  });
+
   test('Stop aborts the turn while an idle-timeout retry is waiting', async () => {
     const timers = manualWatchdogTimer();
     let calls = 0;

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -196,6 +196,56 @@ describe('ModelAdapter stream and error normalization', () => {
     );
   });
 
+  test('marks OpenAI Chat field metadata as a Maka transport hint', () => {
+    const adapter = new ModelAdapter({
+      connection: {
+        slug: 'deepseek',
+        providerType: 'deepseek',
+        defaultModel: 'deepseek-v4-pro',
+        models: [{ id: 'deepseek-v4-pro', apiProtocol: 'openai-chat' }],
+      },
+      apiKey: 'deepseek-token',
+      modelId: 'deepseek-v4-pro',
+      modelFactory: () => ({}),
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
+
+    assert.deepEqual(adapter.translateChunk({ type: 'reasoning-delta', text: 'think' } as Chunk), [
+      {
+        kind: 'thinking',
+        text: 'think',
+        providerOptions: { maka: { openAiChatReasoningField: 'reasoning_content' } },
+        providerOptionsOrigin: 'maka_transport',
+      },
+    ]);
+  });
+
+  test('surfaces provider-executed tool input as replay-unsafe activity', () => {
+    const adapter = newAdapter();
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
+
+    assert.deepEqual(
+      adapter.translateChunk({
+        type: 'tool-input-start',
+        toolCallId: 'search-1',
+        toolName: 'WebSearch',
+        providerExecuted: true,
+      } as Chunk),
+      [{ kind: 'provider-tool-input' }],
+    );
+    assert.deepEqual(
+      adapter.translateChunk({
+        type: 'tool-input-start',
+        toolCallId: 'read-1',
+        toolName: 'Read',
+        providerExecuted: false,
+      } as Chunk),
+      [],
+    );
+  });
+
   test('returns a Maka-owned tool call event from one provider step', () => {
     const adapter = newAdapter();
     type Chunk = Parameters<typeof adapter.translateChunk>[0];

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -689,7 +689,7 @@ export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {
   /** Timeout between SDK/tool events; paused while a tool is active. Default 120s. */
   streamIdleTimeoutMs?: number;
   /** Test seam for the Runtime-owned stream watchdog clock. */
-  streamWatchdogTimer?: Pick<StreamWatchdogInput, 'setTimer' | 'clearTimer'>;
+  streamWatchdogTimer?: Pick<Required<StreamWatchdogInput>, 'setTimer' | 'clearTimer'>;
   /** Test seam for the Runtime-owned provider retry clock. */
   providerRetrySleep?: (delayMs: number, signal: AbortSignal) => Promise<void>;
   /** Optional system prompt (skills + workspace AGENTS.md merged upstream). */
@@ -1948,7 +1948,6 @@ export class AiSdkBackend implements AgentBackend {
           const returnedToolCalls: ToolCallPart[] = [];
           let providerToolActivityCount = 0;
           const providerToolInputs = new Map<string, unknown>();
-          const providerStepId = currentStepMessageId;
           let providerStepUsage: NormalizedUsage | undefined;
           for (;;) {
             providerRequestAbortController = new AbortController();
@@ -2142,7 +2141,7 @@ export class AiSdkBackend implements AgentBackend {
                       providerExecuted: true,
                       activityKind: 'websearch',
                       displayName: 'Web search',
-                      stepId: providerStepId,
+                      stepId: currentStepMessageId,
                       ...(event.toolCall.providerOptions !== undefined
                         ? {
                             providerOptions: stripUndefinedDeep(event.toolCall.providerOptions),
@@ -2324,6 +2323,7 @@ export class AiSdkBackend implements AgentBackend {
 
           // Catch-all: flush any residual step content if the provider closed the
           // stream without a trailing `finish-step` for the last step.
+          const providerStepId = currentStepMessageId;
           await flushStep();
 
           // The settled promise reports only the SDK's unified enum; the stream

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -107,7 +107,12 @@ import Ajv2020 from 'ajv/dist/2020.js';
 import { z } from 'zod';
 
 import { AsyncEventQueue } from './async-queue.js';
-import { StreamWatchdog, formatStreamWatchdogError } from './stream-watchdog.js';
+import {
+  StreamWatchdog,
+  formatStreamWatchdogError,
+  type StreamWatchdogInput,
+  type StreamWatchdogPhase,
+} from './stream-watchdog.js';
 import {
   MAX_ACTIVE_CHILD_AGENT_RUNS_PER_TURN,
   MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN,
@@ -683,6 +688,8 @@ export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {
   streamConnectTimeoutMs?: number;
   /** Timeout between SDK/tool events; paused while a tool is active. Default 120s. */
   streamIdleTimeoutMs?: number;
+  /** Test seam for the Runtime-owned stream watchdog clock. */
+  streamWatchdogTimer?: Pick<StreamWatchdogInput, 'setTimer' | 'clearTimer'>;
   /** Test seam for the Runtime-owned provider retry clock. */
   providerRetrySleep?: (delayMs: number, signal: AbortSignal) => Promise<void>;
   /** Optional system prompt (skills + workspace AGENTS.md merged upstream). */
@@ -816,6 +823,7 @@ function toolResultText(text: string): ToolResultOutput {
 }
 
 const MAX_PROVIDER_ATTEMPTS_PER_STEP = 10;
+const MAX_IDLE_WATCHDOG_RETRIES_PER_STEP = 1;
 const PROVIDER_RETRY_BASE_DELAY_MS = 1_000;
 const PROVIDER_RETRY_MAX_DELAY_MS = 32_000;
 const PROVIDER_RETRY_JITTER_FACTOR = 0.25;
@@ -1565,28 +1573,30 @@ export class AiSdkBackend implements AgentBackend {
 
     // --- Background pump: streamText → stream → normalize → queue ---
     const pumpDone: Promise<void> = (async () => {
-      let watchdog: StreamWatchdog | null = null;
-      let watchdogTimeoutError: Error | null = null;
+      const watchdogState: { current: StreamWatchdog | null } = { current: null };
+      let providerRequestAbortController = new AbortController();
+      const watchdogTimeoutState: {
+        current: { readonly phase: StreamWatchdogPhase; readonly error: Error } | null;
+      } = { current: null };
+      const currentWatchdogTimeout = () => watchdogTimeoutState.current;
       try {
-        const streamWatchdog = new StreamWatchdog({
-          now: this.now,
-          connectTimeoutMs: this.input.streamConnectTimeoutMs,
-          idleTimeoutMs: this.input.streamIdleTimeoutMs,
-          onTimeout: (timeout) => {
-            const message = formatStreamWatchdogError(timeout);
-            watchdogTimeoutError = new Error(message);
-            queue.push(this.makeErrorEvent(turnId, watchdogTimeoutError));
-            trace.modelStreamFailed(
-              'Timeout',
-              watchdogTimeoutError,
-              priorReplayFailureTrace(priorReplay),
-            );
-            turnAbortController.abort(watchdogTimeoutError);
-          },
-        });
-        watchdog = streamWatchdog;
-        scope.watchdog = watchdog;
-        watchdog.start();
+        const startWatchdog = (): void => {
+          watchdogState.current?.stop();
+          const next = new StreamWatchdog({
+            now: this.now,
+            connectTimeoutMs: this.input.streamConnectTimeoutMs,
+            idleTimeoutMs: this.input.streamIdleTimeoutMs,
+            ...this.input.streamWatchdogTimer,
+            onTimeout: (timeout) => {
+              const error = new Error(formatStreamWatchdogError(timeout));
+              watchdogTimeoutState.current = { phase: timeout.phase, error };
+              providerRequestAbortController.abort(error);
+            },
+          });
+          watchdogState.current = next;
+          scope.watchdog = next;
+          next.start();
+        };
         const activeTools = plan.activeTools;
         const systemPrompt = joinPromptFragments([
           await this.resolveSystemPrompt(scope),
@@ -1934,18 +1944,35 @@ export class AiSdkBackend implements AgentBackend {
           providerRequestTracker?.setStep(runtimeSteps);
           let attemptMessages = projectedMessages;
           let providerAttempt = 1;
+          let idleWatchdogRetryCount = 0;
           const returnedToolCalls: ToolCallPart[] = [];
           let providerToolActivityCount = 0;
           const providerToolInputs = new Map<string, unknown>();
           const providerStepId = currentStepMessageId;
           let providerStepUsage: NormalizedUsage | undefined;
-          const attemptHasNoObservableOutput = () =>
-            returnedToolCalls.length === 0 &&
-            providerToolActivityCount === 0 &&
-            stepText.length === 0 &&
-            stepThinking.length === 0 &&
-            stepSignature === undefined;
           for (;;) {
+            providerRequestAbortController = new AbortController();
+            watchdogTimeoutState.current = null;
+            startWatchdog();
+            // Monotonic facts for this physical request. The step accumulators
+            // are cleared after flushStep(), so they cannot decide whether a
+            // later stream failure is safe to retry.
+            let attemptSawText = false;
+            let attemptSawThinking = false;
+            let attemptSawToolActivity = false;
+            let attemptSawContinuationMetadata = false;
+            let attemptReachedStepBoundary = false;
+            const attemptHasNoObservableOutput = () =>
+              !attemptSawText &&
+              !attemptSawThinking &&
+              !attemptSawToolActivity &&
+              !attemptSawContinuationMetadata &&
+              !attemptReachedStepBoundary;
+            const attemptCanRecoverFromIdleTimeout = () =>
+              !attemptSawText &&
+              !attemptSawToolActivity &&
+              !attemptSawContinuationMetadata &&
+              !attemptReachedStepBoundary;
             scope.memorySourceMessages = [...attemptMessages];
             scope.memorySourceEventMessagePositions =
               this.memoryEventMessagePositions(attemptMessages);
@@ -1957,12 +1984,13 @@ export class AiSdkBackend implements AgentBackend {
               toolMode === 'code_mode'
                 ? nestableToolSnapshot(providerTools, activeToolsForRequest)
                 : undefined;
+            const requestWatchdog = watchdogState.current;
             result = await this.modelAdapter.startStream({
               model,
               messages: attemptMessages,
               tools: modelTools,
               activeTools: activeToolsForRequest,
-              onStreamActivity: () => streamWatchdog.markActivity(),
+              onStreamActivity: () => requestWatchdog?.markActivity(),
               repairToolCall: async ({
                 toolCall,
                 error,
@@ -1981,7 +2009,10 @@ export class AiSdkBackend implements AgentBackend {
                 });
               },
               system: requestSystemPrompt,
-              abortSignal: turnAbortController.signal,
+              abortSignal: AbortSignal.any([
+                turnAbortController.signal,
+                providerRequestAbortController.signal,
+              ]),
               ...(providerRequestTracker ? { providerRequestTracker } : {}),
               continuationKey: scope.turnId,
             });
@@ -2000,6 +2031,7 @@ export class AiSdkBackend implements AgentBackend {
                   break;
                 }
                 if (event.kind === 'step-finish') {
+                  attemptReachedStepBoundary = true;
                   // Step boundary: AI SDK 7 delimits steps with `finish-step`
                   // (and `step-finish` for legacy replay fixtures); the adapter
                   // reduces both to this event. A duplicate boundary is harmless:
@@ -2031,6 +2063,7 @@ export class AiSdkBackend implements AgentBackend {
                   stepTextPartStartOffset = stepText.length;
                 } else if (event.kind === 'text') {
                   stepText += event.text;
+                  if (event.text.length > 0) attemptSawText = true;
                   queue.push({
                     type: 'text_delta',
                     id: this.newId(),
@@ -2050,7 +2083,9 @@ export class AiSdkBackend implements AgentBackend {
                 } else if (event.kind === 'thinking') {
                   sawStepThinking = true;
                   stepThinking += event.text;
+                  if (event.text.length > 0) attemptSawThinking = true;
                   if (event.providerOptions !== undefined) {
+                    attemptSawContinuationMetadata = true;
                     stepThinkingProviderOptions = event.providerOptions;
                   }
                   const openai = event.providerOptions?.openai;
@@ -2089,8 +2124,10 @@ export class AiSdkBackend implements AgentBackend {
                     text: event.text,
                   } satisfies ThinkingDeltaEvent);
                 } else if (event.kind === 'thinking-signature') {
+                  attemptSawContinuationMetadata = true;
                   stepSignature = event.signature;
                 } else if (event.kind === 'tool-call') {
+                  attemptSawToolActivity = true;
                   if (event.toolCall.providerExecuted) {
                     providerToolActivityCount += 1;
                     providerToolInputs.set(event.toolCall.toolCallId, event.toolCall.input);
@@ -2116,6 +2153,7 @@ export class AiSdkBackend implements AgentBackend {
                     returnedToolCalls.push(event.toolCall);
                   }
                 } else if (event.kind === 'provider-tool-result') {
+                  attemptSawToolActivity = true;
                   providerToolActivityCount += 1;
                   const providerOutput = stripUndefinedDeep(event.output);
                   queue.push({
@@ -2156,9 +2194,16 @@ export class AiSdkBackend implements AgentBackend {
               streamFailure = error;
               sawStreamError = true;
             }
+            watchdogState.current?.stop();
+            const settledWatchdogTimeout = currentWatchdogTimeout();
+            if (!sawStreamError && settledWatchdogTimeout) {
+              streamFailure = settledWatchdogTimeout.error;
+              sawStreamError = true;
+            }
 
             if (sawStreamError && !scope.aborted) {
-              if (scope.loopStopRequested) throw streamFailure;
+              const attemptFailure = settledWatchdogTimeout?.error ?? streamFailure;
+              if (scope.loopStopRequested) throw attemptFailure;
               // A retry is a fresh provider request that would run at least one
               // more step; with the send-level budget already spent there is
               // nothing left to grant it, so the error is terminal.
@@ -2166,7 +2211,7 @@ export class AiSdkBackend implements AgentBackend {
               const recovered =
                 stepBudgetRemains && attemptHasNoObservableOutput()
                   ? await this.compaction.recoverFromOverflowError({
-                      error: streamFailure,
+                      error: attemptFailure,
                       retryAlreadyUsed: overflowRetryUsed,
                       midTurnState,
                       turnId,
@@ -2199,18 +2244,32 @@ export class AiSdkBackend implements AgentBackend {
                 attemptMessages = recoveredProjection?.messages ?? recovered.messages;
                 continue;
               }
-              const failure = this.modelAdapter.normalizeFailure(streamFailure);
+              const failure = this.modelAdapter.normalizeFailure(attemptFailure);
+              const idleWatchdogRecovery =
+                settledWatchdogTimeout?.phase === 'idle' &&
+                idleWatchdogRetryCount < MAX_IDLE_WATCHDOG_RETRIES_PER_STEP &&
+                attemptCanRecoverFromIdleTimeout();
               if (
-                failure.retryable &&
+                (failure.retryable || idleWatchdogRecovery) &&
                 providerAttempt < MAX_PROVIDER_ATTEMPTS_PER_STEP &&
                 stepBudgetRemains &&
-                attemptHasNoObservableOutput()
+                (attemptHasNoObservableOutput() || idleWatchdogRecovery)
               ) {
+                if (idleWatchdogRecovery) {
+                  idleWatchdogRetryCount += 1;
+                  if (stepThinking.length > 0) {
+                    await flushStep();
+                    currentStepMessageId = this.newId();
+                  }
+                }
                 // The failed request did not return authoritative usage. Keep
                 // effectiveness recoverable, but fail final metering closed.
                 sawUnusableStepUsage = true;
                 const delayMs = providerRetryDelayMs(providerAttempt, failure.retryAfterMs);
                 const nextAttempt = providerAttempt + 1;
+                const maxAttempts = idleWatchdogRecovery
+                  ? nextAttempt
+                  : MAX_PROVIDER_ATTEMPTS_PER_STEP;
                 const reason = providerRetryReason(failure.kind);
                 queue.push({
                   type: 'provider_retry',
@@ -2219,16 +2278,11 @@ export class AiSdkBackend implements AgentBackend {
                   ts: this.now(),
                   phase: 'scheduled',
                   attempt: nextAttempt,
-                  maxAttempts: MAX_PROVIDER_ATTEMPTS_PER_STEP,
+                  maxAttempts,
                   delayMs,
                   reason,
                 } satisfies ProviderRetryEvent);
-                watchdog.pause();
-                try {
-                  await this.providerRetrySleep(delayMs, turnAbortController.signal);
-                } finally {
-                  watchdog.resume();
-                }
+                await this.providerRetrySleep(delayMs, turnAbortController.signal);
                 providerAttempt = nextAttempt;
                 queue.push({
                   type: 'provider_retry',
@@ -2237,7 +2291,7 @@ export class AiSdkBackend implements AgentBackend {
                   ts: this.now(),
                   phase: 'started',
                   attempt: providerAttempt,
-                  maxAttempts: MAX_PROVIDER_ATTEMPTS_PER_STEP,
+                  maxAttempts,
                   reason,
                 } satisfies ProviderRetryEvent);
                 continue;
@@ -2245,7 +2299,7 @@ export class AiSdkBackend implements AgentBackend {
               // Unrecoverable (not context-length, latch spent, no seam, or no
               // safe fold): surface the real provider error via the terminal
               // handler — never a fabricated success.
-              throw streamFailure;
+              throw attemptFailure;
             }
             break;
           }
@@ -2594,7 +2648,7 @@ export class AiSdkBackend implements AgentBackend {
         }
       } catch (err) {
         streamStatus = scope.aborted ? 'aborted' : 'error';
-        streamErrorClass = this.modelAdapter.classifyError(watchdogTimeoutError ?? err);
+        streamErrorClass = this.modelAdapter.classifyError(currentWatchdogTimeout()?.error ?? err);
         // Flush the in-flight step's partial text/thinking before the terminal
         // abort/error events. Earlier steps already flushed at their
         // `finish-step`; this keeps their and this step's streamed-out output on
@@ -2630,10 +2684,13 @@ export class AiSdkBackend implements AgentBackend {
             stopReason: 'user_stop',
           } satisfies CompleteEvent);
         } else {
-          if (!watchdogTimeoutError) {
-            queue.push(this.makeErrorEvent(turnId, err));
-            trace.modelStreamFailed(streamErrorClass, err, priorReplayFailureTrace(priorReplay));
-          }
+          const terminalError = currentWatchdogTimeout()?.error ?? err;
+          queue.push(this.makeErrorEvent(turnId, terminalError));
+          trace.modelStreamFailed(
+            streamErrorClass,
+            terminalError,
+            priorReplayFailureTrace(priorReplay),
+          );
           queue.push({
             type: 'complete',
             id: this.newId(),
@@ -2643,8 +2700,8 @@ export class AiSdkBackend implements AgentBackend {
           } satisfies CompleteEvent);
         }
       } finally {
-        watchdog?.stop();
-        if (scope.watchdog === watchdog) scope.watchdog = null;
+        watchdogState.current?.stop();
+        if (scope.watchdog === watchdogState.current) scope.watchdog = null;
         contextBudgetForTelemetry = contextBudgetWithActiveProjectionDiagnostics(
           contextBudgetForTelemetry,
           activeToolResultPruneDiagnosticPatch,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -1579,6 +1579,11 @@ export class AiSdkBackend implements AgentBackend {
         current: { readonly phase: StreamWatchdogPhase; readonly error: Error } | null;
       } = { current: null };
       const currentWatchdogTimeout = () => watchdogTimeoutState.current;
+      const consumeWatchdogTimeout = () => {
+        const timeout = watchdogTimeoutState.current;
+        watchdogTimeoutState.current = null;
+        return timeout;
+      };
       try {
         const startWatchdog = (): void => {
           watchdogState.current?.stop();
@@ -2087,7 +2092,9 @@ export class AiSdkBackend implements AgentBackend {
                   stepThinking += event.text;
                   if (event.text.length > 0) attemptSawThinking = true;
                   if (event.providerOptions !== undefined) {
-                    attemptSawContinuationMetadata = true;
+                    if (event.providerOptionsOrigin !== 'maka_transport') {
+                      attemptSawContinuationMetadata = true;
+                    }
                     stepThinkingProviderOptions = event.providerOptions;
                   }
                   const openai = event.providerOptions?.openai;
@@ -2128,6 +2135,11 @@ export class AiSdkBackend implements AgentBackend {
                 } else if (event.kind === 'thinking-signature') {
                   attemptSawContinuationMetadata = true;
                   stepSignature = event.signature;
+                } else if (event.kind === 'provider-tool-input') {
+                  // The provider has started its own tool. Even without a
+                  // final tool-call/result event, retrying can repeat external
+                  // work that the Runtime cannot observe or reconcile.
+                  attemptSawToolActivity = true;
                 } else if (event.kind === 'tool-call') {
                   attemptSawToolActivity = true;
                   if (event.toolCall.providerExecuted) {
@@ -2197,7 +2209,10 @@ export class AiSdkBackend implements AgentBackend {
               sawStreamError = true;
             }
             watchdogState.current?.stop();
-            const settledWatchdogTimeout = currentWatchdogTimeout();
+            // This timeout belongs to the physical request that just settled.
+            // Consume it before recovery/flush work: a later persistence error
+            // must not be reported as the already-handled watchdog timeout.
+            const settledWatchdogTimeout = consumeWatchdogTimeout();
             if (!sawStreamError && settledWatchdogTimeout) {
               streamFailure = settledWatchdogTimeout.error;
               sawStreamError = true;

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2029,8 +2029,10 @@ export class AiSdkBackend implements AgentBackend {
                   sawStreamError = true;
                   break;
                 }
-                if (event.kind === 'step-finish') {
+                if (event.kind === 'finish' || event.kind === 'step-finish') {
                   attemptReachedStepBoundary = true;
+                }
+                if (event.kind === 'step-finish') {
                   // Step boundary: AI SDK 7 delimits steps with `finish-step`
                   // (and `step-finish` for legacy replay fixtures); the adapter
                   // reduces both to this event. A duplicate boundary is harmless:
@@ -2072,6 +2074,7 @@ export class AiSdkBackend implements AgentBackend {
                     text: event.text,
                   } satisfies TextDeltaEvent);
                 } else if (event.kind === 'text-metadata') {
+                  attemptSawContinuationMetadata = true;
                   stepTextProviderOptions = mergeTextProviderOptions(
                     stepTextProviderOptions,
                     stripUndefinedDeep(event.providerOptions) as NonNullable<

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -694,6 +694,7 @@ function translateChunk(
                   providerOptions: openAiChatReasoningFieldProviderOptions(
                     openAiChatReasoningTransportState.reasoningField,
                   ),
+                  providerOptionsOrigin: 'maka_transport' as const,
                 }
               : {}),
         });
@@ -710,6 +711,10 @@ function translateChunk(
           : []),
       ];
     }
+    case 'tool-input-start':
+    case 'tool-input-delta':
+    case 'tool-input-end':
+      return chunk.providerExecuted === true ? [{ kind: 'provider-tool-input' }] : [];
     // Step boundaries (`start-step` / `finish-step`) and the terminal `finish`
     // carry no text/thinking to stream. The backend owns step accounting: it
     // counts and flushes one AssistantMessage per step and rotates the

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -430,8 +430,16 @@ export type ModelStreamEvent =
   | { kind: 'text-start' }
   | { kind: 'text'; text: string }
   | { kind: 'text-metadata'; providerOptions: ProviderOptions }
-  | { kind: 'thinking'; text: string; providerOptions?: ProviderOptions }
+  | {
+      kind: 'thinking';
+      text: string;
+      providerOptions?: ProviderOptions;
+      /** Maka-authored replay hint; absent provider metadata stays fail-closed. */
+      providerOptionsOrigin?: 'maka_transport';
+    }
   | { kind: 'thinking-signature'; signature: string }
+  /** Provider-side tool execution has begun, but no replayable call exists yet. */
+  | { kind: 'provider-tool-input' }
   | { kind: 'tool-call'; toolCall: ToolCallPart }
   | {
       kind: 'provider-tool-result';


### PR DESCRIPTION
## Summary

- retry one idle provider stream when it has produced only replay-unsafe partial thinking
- abort only the physical provider request, keeping user Stop as the turn-level authority
- preserve partial thinking under its own assistant step and keep text, tool activity, completed steps, and provider continuation metadata fail-closed
- scope each watchdog to one provider request so retry backoff, tool execution, and post-stream persistence are not mistaken for model silence

Fixes #2487

<details>
<summary>中文说明</summary>

- provider stream 只输出了无法安全续接的部分思考后进入 idle timeout 时，最多自动重试一次
- watchdog 只取消当前物理 provider 请求；用户 Stop 仍然拥有整个 Turn 的取消权
- 已展示的部分思考以独立 assistant step 保留；一旦出现正文、工具活动、已完成 step 或 provider continuation metadata，仍按原行为失败关闭
- 每个物理请求独立持有 watchdog，retry backoff、工具执行和请求后的持久化不会被误判为模型无响应

</details>

## Verification

- `npm --workspace @maka/runtime test` (3256 passed, 3 skipped)
- `npm --workspace @maka/runtime run typecheck`
- `npm run lint`
- `npm run format:check`
- deterministic coverage for reasoning-only recovery, the one-retry cap, recovered tool step identity, partial-text, text/reasoning continuation metadata and completed-boundary refusal, graceful stream close, and Stop during retry backoff

## Review focus

- the retry eligibility boundary in `AiSdkBackend`
- request-scoped watchdog cancellation versus turn-scoped Stop
- partial-thinking persistence and `stepId` ownership after recovery

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
