### PR TITLE
fix(runtime-host): backpressure client request bursts

### DIFF
--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -14,6 +14,7 @@ import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.
 import {
   decodeHostFrame,
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
+  RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS,
   RUNTIME_HOST_PROTOCOL_VERSION,
   type HostFrame,
   type ResponseFrame,
@@ -82,6 +83,47 @@ test('concurrent responses remain framed and correlated in reverse completion or
         );
       } finally {
         for (const gate of release) gate.resolve();
+        await Promise.allSettled(requests);
+      }
+    },
+  );
+});
+
+test('the Client backpressures a healthy request burst at the Host connection limit', async () => {
+  const requestCount = 96;
+  const firstWaveEntered = deferred();
+  const releaseFirstWave = deferred();
+  let entered = 0;
+  let active = 0;
+  let maxActive = 0;
+
+  await withRuntimeHost(
+    async (input) => {
+      entered += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      if (entered === RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS) firstWaveEntered.resolve();
+      await releaseFirstWave.promise;
+      active -= 1;
+      return {
+        ok: true,
+        result: runningSnapshot(input.sessionId, input.turnId),
+      };
+    },
+    async ({ connectClient }) => {
+      const client = await connectClient();
+      const requests = Array.from({ length: requestCount }, (_, index) =>
+        client.queryTurn({ sessionId: 'session', turnId: `burst-${index}` }, 5_000),
+      );
+      try {
+        await withTimeout(firstWaveEntered.promise, 1_000, 'first request wave was not admitted');
+        assert.equal(maxActive, RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS);
+        releaseFirstWave.resolve();
+        const results = await Promise.all(requests);
+        assert.equal(results.length, requestCount);
+        assert.equal((await client.status(1_000)).state, 'ready');
+      } finally {
+        releaseFirstWave.resolve();
         await Promise.allSettled(requests);
       }
     },

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -33,6 +33,7 @@ import {
   type HostStatusResult,
   HOST_OPERATION_SPECS,
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
+  RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS,
   type OperationInput,
   type OperationKey,
   type OperationOutput,
@@ -234,7 +235,18 @@ interface PendingRequest {
   accept(value: unknown): unknown;
   resolve(value: unknown): void;
   reject(error: Error): void;
+  domainState?: 'queued' | 'in_flight';
   timer?: NodeJS.Timeout;
+}
+
+interface RetiredRequest {
+  operation: OperationKey;
+  domainState?: 'in_flight';
+}
+
+interface QueuedDomainFrame {
+  requestId: string;
+  frame: RequestFrame;
 }
 
 type RequestTimeoutScope = 'request' | 'connection';
@@ -246,7 +258,8 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   readonly closed: Promise<void>;
   readonly #transport: FramedTransport;
   readonly #pendingRequests = new Map<string, PendingRequest>();
-  readonly #retiredRequests = new Map<string, OperationKey>();
+  readonly #retiredRequests = new Map<string, RetiredRequest>();
+  readonly #queuedDomainFrames: QueuedDomainFrame[] = [];
   readonly #subscriptions = new Map<string, ClientSessionSubscription>();
   readonly #retiredSubscriptionIds = new Set<string>();
   readonly #clientCapabilities: ClientCapabilityChannel;
@@ -254,6 +267,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   readonly #sessionCatalogChangeListeners = new Set<(frame: SessionCatalogChangedFrame) => void>();
   #livenessTimer: NodeJS.Timeout | undefined;
   #livenessProbePending = false;
+  #inFlightDomainRequests = 0;
   #terminalError: Error | undefined;
   readonly #livenessIntervalMs: number;
   readonly #onLivenessProbe: (() => void) | undefined;
@@ -340,15 +354,13 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       return Promise.reject(asError(error));
     }
     const requestId = randomUUID();
+    const isDomainRequest = operation !== 'host.status';
     const result = new Promise<Result>((resolve, reject) => {
       const timer =
         boundedTimeoutMs === undefined
           ? undefined
           : setTimeout(() => {
-              const error = new RuntimeHostTransportError(
-                'read_timeout',
-                `Timed out waiting for Runtime Host ${operation} response`,
-              );
+              const error = requestTimeoutError(operation);
               if (timeoutScope === 'connection') this.#fail(error);
               else this.#retireRequest(requestId, error);
             }, boundedTimeoutMs);
@@ -361,6 +373,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
         },
         resolve: (value) => resolve(value as Result),
         reject,
+        ...(isDomainRequest ? { domainState: 'queued' as const } : {}),
         timer,
       });
       this.#scheduleLivenessCheck();
@@ -370,8 +383,30 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       operation,
       input: canonicalInput,
     } as RequestFrame;
-    void this.#transport.write(frame).catch((error: unknown) => this.#fail(asError(error)));
+    if (isDomainRequest) {
+      this.#queuedDomainFrames.push({ requestId, frame });
+      this.#drainDomainRequests();
+    } else {
+      void this.#transport.write(frame).catch((error: unknown) => this.#fail(asError(error)));
+    }
     return result;
+  }
+
+  #drainDomainRequests(): void {
+    while (
+      !this.#terminalError &&
+      this.#inFlightDomainRequests < RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS
+    ) {
+      const queued = this.#queuedDomainFrames.shift();
+      if (!queued) return;
+      const pending = this.#pendingRequests.get(queued.requestId);
+      if (!pending || pending.domainState !== 'queued') continue;
+      pending.domainState = 'in_flight';
+      this.#inFlightDomainRequests += 1;
+      void this.#transport
+        .write(queued.frame)
+        .catch((error: unknown) => this.#fail(asError(error)));
+    }
   }
 
   async status(timeoutMs?: number): Promise<HostStatusResult> {
@@ -577,9 +612,10 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #acceptResponse(frame: ResponseFrame): void {
     const pending = this.#pendingRequests.get(frame.requestId);
     if (!pending) {
-      const retiredOperation = this.#retiredRequests.get(frame.requestId);
-      if (retiredOperation === frame.operation) {
+      const retired = this.#retiredRequests.get(frame.requestId);
+      if (retired?.operation === frame.operation) {
         this.#retiredRequests.delete(frame.requestId);
+        this.#releaseDomainSlot(retired);
         this.#scheduleLivenessCheck();
         return;
       }
@@ -595,7 +631,9 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.#scheduleLivenessCheck();
     if (frame.ok) {
       try {
-        pending.resolve(pending.accept(frame.result));
+        const accepted = pending.accept(frame.result);
+        this.#releaseDomainSlot(pending);
+        pending.resolve(accepted);
       } catch (error) {
         const failure = asError(error);
         pending.reject(failure);
@@ -603,6 +641,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       }
       return;
     }
+    this.#releaseDomainSlot(pending);
     pending.reject(
       new RuntimeHostOperationError(frame.operation, frame.error.code, frame.error.message),
     );
@@ -632,9 +671,26 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     const pending = this.#pendingRequests.get(requestId);
     if (!pending) return;
     this.#pendingRequests.delete(requestId);
-    this.#retiredRequests.set(requestId, pending.operation);
+    if (pending.domainState === 'queued') {
+      const index = this.#queuedDomainFrames.findIndex((queued) => queued.requestId === requestId);
+      if (index !== -1) this.#queuedDomainFrames.splice(index, 1);
+      pending.reject(error);
+      this.#scheduleLivenessCheck();
+      return;
+    }
+    this.#retiredRequests.set(requestId, {
+      operation: pending.operation,
+      ...(pending.domainState === 'in_flight' ? { domainState: pending.domainState } : {}),
+    });
     pending.reject(error);
     this.#scheduleLivenessCheck();
+  }
+
+  #releaseDomainSlot(request: PendingRequest | RetiredRequest): void {
+    if (request.domainState !== 'in_flight') return;
+    request.domainState = undefined;
+    this.#inFlightDomainRequests -= 1;
+    this.#drainDomainRequests();
   }
 
   #resetLivenessCheck(): void {
@@ -763,6 +819,8 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.#terminalError = error;
     if (this.#livenessTimer) clearTimeout(this.#livenessTimer);
     this.#livenessTimer = undefined;
+    this.#queuedDomainFrames.length = 0;
+    this.#inFlightDomainRequests = 0;
     for (const pending of this.#pendingRequests.values()) {
       if (pending.timer) clearTimeout(pending.timer);
       pending.reject(error);
@@ -1094,4 +1152,11 @@ function readRegistrationBeforeDeadline(
 
 function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function requestTimeoutError(operation: OperationKey): RuntimeHostTransportError {
+  return new RuntimeHostTransportError(
+    'read_timeout',
+    `Timed out waiting for Runtime Host ${operation} response`,
+  );
 }

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -63,6 +63,7 @@ export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 8 as const;
 // capacity large enough to represent that domain value; narrower surfaces such
 // as Session continuity retain their own limits.
 export const RUNTIME_HOST_MAX_FRAME_BYTES = 96 * 1024;
+export const RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS = 64;
 
 export type ClientSurface = 'desktop' | 'tui' | 'run' | 'activation' | 'bot' | 'inspect';
 

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -1,6 +1,7 @@
 import {
   decodeClientFrame,
   isClientCapabilityClientFrameKind,
+  RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS,
   type ClientCapabilityClientFrame,
   type HostOperationErrorCode,
   type RequestFrame,
@@ -31,8 +32,6 @@ import type {
   HostSessionCatalogChangeService,
   SessionCatalogChangeConnection,
 } from './session-catalog-change-service.js';
-
-const MAX_IN_FLIGHT_REQUESTS = 64;
 
 type AcceptedConnectionContext = Omit<ConnectionContext, 'acquireResidency'>;
 
@@ -125,11 +124,11 @@ export class RuntimeHostConnectionSession {
         throw new Error('Unexpected handshake frame after acceptance');
       }
       const usesLivenessReserve =
-        this.#requests.size === MAX_IN_FLIGHT_REQUESTS &&
+        this.#requests.size === RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS &&
         (frame.operation === 'host.status' || this.#inFlightStatusRequests > 0);
       if (
         this.#requests.has(frame.requestId) ||
-        (this.#requests.size >= MAX_IN_FLIGHT_REQUESTS && !usesLivenessReserve)
+        (this.#requests.size >= RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS && !usesLivenessReserve)
       ) {
         this.#teardown();
         return;


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Prevents healthy Runtime Host request bursts from closing a Desktop connection and surfacing as failures such as “Failed to refresh conversation.”

The Host intentionally enforces a per-connection request ceiling, but the official Client previously sent every request immediately. A burst above that ceiling therefore looked like a misbehaving Client, so the Host correctly tore down the connection and every Desktop IPC consumer on that connection failed together.

This change gives the Client the same shared capacity contract as the Host and queues excess domain requests locally. Request deadlines still begin at the API call boundary. A request that times out before transmission is removed from the queue, while a transmitted request retains its slot until its physical Host response arrives, preventing premature replacement from crossing the Host limit.

## Verification

- `npm run test:dist --workspace @maka/runtime-host` — 774 tests passed
- `npm run typecheck --workspace @maka/runtime-host`
- `npx biome check packages/runtime-host/src/client/connection.ts packages/runtime-host/src/protocol/index.ts packages/runtime-host/src/server/connection-session.ts packages/runtime-host/src/__tests__/connection-session.test.ts`
- `git diff --check`
- Real Desktop verification: 100 concurrent Skill catalog requests completed with 0 failures; Session listing and transcript reads remained usable; a real DeepSeek turn completed and refreshed without an error notification

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 摘要

防止正常的 Runtime Host 请求突发关闭 Desktop 连接，并最终表现为“刷新对话失败”等错误。

Host 会有意限制单条连接上的并发请求数量，但官方 Client 原先会立即发送所有请求。请求突发超过上限后，Host 会将其视为异常 Client 并正确断开连接，导致共享该连接的所有 Desktop IPC 调用同时失败。

本次修改让 Client 与 Host 共用同一容量契约，并在客户端本地排队超额的领域请求。请求超时仍从 API 调用时开始计算：尚未发送的请求超时后会从队列移除；已经发送的请求则继续占用槽位，直到收到真实的 Host 响应，避免过早补发请求再次越过 Host 上限。

## 验证

- `npm run test:dist --workspace @maka/runtime-host` — 774 项测试通过
- `npm run typecheck --workspace @maka/runtime-host`
- `npx biome check packages/runtime-host/src/client/connection.ts packages/runtime-host/src/protocol/index.ts packages/runtime-host/src/server/connection-session.ts packages/runtime-host/src/__tests__/connection-session.test.ts`
- `git diff --check`
- 真实 Desktop 验证：100 个并发 Skill catalog 请求全部成功；会话列表与消息读取保持可用；真实 DeepSeek 回合完成后正常刷新，没有错误通知

## 检查清单

- [x] 测试覆盖本次变更，并且在缺少修复时会失败
- [x] lint、format、typecheck 和受影响测试套件均在本地通过

此 PR 是否包含行为变化？

- [x] 是 — 已在上方摘要中说明
- [ ] 否

</details>
