### PR TITLE
feat(desktop): copy diagnostics from error toasts

### DIFF
--- a/apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { IpcMain } from 'electron';
+import { registerDesktopDiagnosticsIpc } from '../desktop-diagnostics-ipc-main.js';
+import {
+  formatDesktopErrorDiagnosticReport,
+  parseDesktopErrorDiagnosticInput,
+} from '../main-process-diagnostics.js';
+
+const environment = {
+  appVersion: '0.1.8',
+  buildMode: 'dev' as const,
+  buildCommit: 'a'.repeat(40),
+  electronVersion: '38.0.0',
+  nodeVersion: '22.0.0',
+  chromeVersion: '140.0.0',
+  platform: 'linux' as const,
+  arch: 'x64',
+  osRelease: '6.6.0',
+  locale: 'en-US',
+  workspacePath: '/home/tester/.local/share/maka/workspaces/default',
+  homePath: '/home/tester',
+  processUptimeSeconds: 41.9,
+};
+
+test('formats one redacted Desktop and Runtime Host diagnostic report', () => {
+  const report = formatDesktopErrorDiagnosticReport(
+    {
+      surface: 'toast',
+      title: 'Connection failed',
+      description: 'api_key=sk-secretvalue123',
+      rendererLocale: 'en-US',
+    },
+    environment,
+    ['main log'],
+    {
+      ok: true,
+      value: {
+        hostEpoch: 'epoch-1',
+        state: 'ready',
+        connections: 1,
+        activeOperations: 1,
+        activeResidencies: 0,
+        protocolVersion: 0,
+        compatibilityEpoch: 9,
+        pid: 42,
+        processUptimeSeconds: 37,
+        nodeVersion: '22.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        osRelease: '6.6.0',
+        logs: ['host log'],
+      },
+    },
+    new Date('2026-08-09T00:00:00Z'),
+  );
+
+  assert.match(report, /Recent main-process logs \(1\)\nmain log/);
+  assert.match(report, /Build: dev @ a{12}/);
+  assert.match(report, /Runtime Host[\s\S]*Recent Runtime Host logs \(1\)\nhost log/);
+  assert.match(report, /Protocol: v0 · compatibility 9/);
+  assert.match(report, /Workspace: ~\/\.local\/share\/maka\/workspaces\/default/);
+  assert.doesNotMatch(report, /sk-secretvalue123|\/home\/tester/);
+});
+
+test('bounds renderer diagnostic text and rejects unknown fields', () => {
+  const input = parseDesktopErrorDiagnosticInput({
+    surface: 'toast',
+    title: '🚀'.repeat(513),
+    description: 'x'.repeat(30 * 1024),
+  });
+
+  assert.ok(Buffer.byteLength(input.title) <= 512);
+  assert.ok(Buffer.byteLength(input.description ?? '') <= 24 * 1024);
+  assert.match(input.title, /<diagnostic input truncated>$/);
+  assert.throws(
+    () => parseDesktopErrorDiagnosticInput({ surface: 'toast', title: 'error', extra: true }),
+    /Invalid Desktop diagnostic input/,
+  );
+});
+
+test('copies Desktop diagnostics while Runtime Host is unavailable', async () => {
+  type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
+  const handlers = new Map<string, IpcHandler>();
+  let clipboard = '';
+  registerDesktopDiagnosticsIpc({
+    ipcMain: {
+      handle(channel, handler) {
+        handlers.set(channel, handler);
+      },
+    },
+    environment: () => environment,
+    mainLogs: () => ['main remained available'],
+    getRuntimeHostDiagnostics: async () => {
+      throw new Error('Runtime Host disconnected');
+    },
+    writeClipboard: (value) => {
+      clipboard = value;
+    },
+  });
+
+  const handler = handlers.get('diagnostics:copyErrorReport');
+  assert.ok(handler);
+  const result = await handler({} as never, { surface: 'toast', title: 'Host failed' });
+
+  assert.deepEqual(result, { ok: true });
+  assert.match(clipboard, /Recent main-process logs \(1\)\nmain remained available/);
+  assert.match(clipboard, /Diagnostics unavailable: Runtime Host disconnected/);
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-client-pricing-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-pricing-uds.test.ts
@@ -5,12 +5,11 @@ import { join } from 'node:path';
 import test from 'node:test';
 import { connectRuntimeHost } from '@maka/runtime-host/client';
 import {
-  HOST_OPERATION_SPECS,
   RUNTIME_HOST_PROTOCOL_VERSION,
   type EffectivePricingEntry,
-  type OperationKey,
 } from '@maka/runtime-host/protocol';
 import {
+  createUnavailableDomainOperationHandlers,
   RuntimeHostKernel,
   type RuntimeHostComposition,
 } from '@maka/runtime-host/server';
@@ -170,21 +169,10 @@ test('drives the Desktop Pricing adapter through a real Runtime Host connection'
 type TestHandlers = Partial<RuntimeHostComposition['handlers']>;
 
 function handlers(overrides: TestHandlers): RuntimeHostComposition['handlers'] {
-  const unavailable = Object.fromEntries(
-    (Object.keys(HOST_OPERATION_SPECS) as OperationKey[])
-      .filter((operation) => operation !== 'host.status')
-      .map((operation) => [
-        operation,
-        async () => ({
-          ok: false,
-          error: {
-            code: 'operation_unavailable',
-            message: `${operation} is unavailable in the Desktop Pricing adapter fixture`,
-          },
-        }),
-      ]),
-  );
-  return { ...unavailable, ...overrides } as RuntimeHostComposition['handlers'];
+  return {
+    ...createUnavailableDomainOperationHandlers(),
+    ...overrides,
+  } as RuntimeHostComposition['handlers'];
 }
 
 function builtin(modelKey: string, inputUsdPer1M: number): EffectivePricingEntry {

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -7,12 +7,11 @@ import type { IpcMain } from 'electron';
 import type { BotRegistry, ComputerUseToolSet, MakaTool } from '@maka/runtime';
 import { connectRuntimeHost } from '@maka/runtime-host/client';
 import {
-  HOST_OPERATION_SPECS,
   RUNTIME_HOST_PROTOCOL_VERSION,
-  type OperationKey,
   type SessionCatalogProjection,
 } from '@maka/runtime-host/protocol';
 import {
+  createUnavailableDomainOperationHandlers,
   RuntimeHostKernel,
   type RuntimeHostComposition,
 } from '@maka/runtime-host/server';
@@ -465,21 +464,10 @@ test('drives bounded Session domain projections through real UDS framing', async
 type TestHandlers = Partial<RuntimeHostComposition['handlers']>;
 
 function handlers(overrides: TestHandlers): RuntimeHostComposition['handlers'] {
-  const unavailable = Object.fromEntries(
-    (Object.keys(HOST_OPERATION_SPECS) as OperationKey[])
-      .filter((operation) => operation !== 'host.status')
-      .map((operation) => [
-        operation,
-        async () => ({
-          ok: false,
-          error: {
-            code: 'operation_unavailable',
-            message: `${operation} is unavailable in the Desktop adapter fixture`,
-          },
-        }),
-      ]),
-  );
-  return { ...unavailable, ...overrides } as RuntimeHostComposition['handlers'];
+  return {
+    ...createUnavailableDomainOperationHandlers(),
+    ...overrides,
+  } as RuntimeHostComposition['handlers'];
 }
 
 function catalogRevision(seed: string): `sha256:${string}` {

--- a/apps/desktop/src/main/desktop-diagnostics-ipc-main.ts
+++ b/apps/desktop/src/main/desktop-diagnostics-ipc-main.ts
@@ -1,0 +1,52 @@
+import type { IpcMain } from 'electron';
+import { truncateUtf8 } from '@maka/core/diagnostic-log';
+import { redactSecrets } from '@maka/core/redaction';
+import type { HostDiagnosticsResult } from '@maka/runtime-host/protocol';
+import type { DesktopDiagnosticCopyResult } from '../preload/diagnostics-contract.js';
+import {
+  formatDesktopErrorDiagnosticReport,
+  parseDesktopErrorDiagnosticInput,
+  type DesktopDiagnosticEnvironment,
+  type RuntimeHostDiagnosticRead,
+} from './main-process-diagnostics.js';
+
+export interface DesktopDiagnosticsIpcDeps {
+  readonly ipcMain: Pick<IpcMain, 'handle'>;
+  readonly environment: () => DesktopDiagnosticEnvironment;
+  readonly mainLogs: () => readonly string[];
+  readonly getRuntimeHostDiagnostics: () => Promise<HostDiagnosticsResult>;
+  readonly writeClipboard: (value: string) => void;
+}
+
+export function registerDesktopDiagnosticsIpc(deps: DesktopDiagnosticsIpcDeps): void {
+  deps.ipcMain.handle(
+    'diagnostics:copyErrorReport',
+    async (_event, rawInput: unknown): Promise<DesktopDiagnosticCopyResult> => {
+      const input = parseDesktopErrorDiagnosticInput(rawInput);
+      let runtimeHost: RuntimeHostDiagnosticRead;
+      try {
+        runtimeHost = { ok: true, value: await deps.getRuntimeHostDiagnostics() };
+      } catch (error) {
+        runtimeHost = {
+          ok: false,
+          error: truncateUtf8(
+            redactSecrets(error instanceof Error ? error.message : String(error)),
+            1024,
+          ),
+        };
+      }
+      const report = formatDesktopErrorDiagnosticReport(
+        input,
+        deps.environment(),
+        deps.mainLogs(),
+        runtimeHost,
+      );
+      try {
+        deps.writeClipboard(report);
+        return { ok: true };
+      } catch {
+        return { ok: false, reason: 'clipboard_unavailable' };
+      }
+    },
+  );
+}

--- a/apps/desktop/src/main/main-process-diagnostics.ts
+++ b/apps/desktop/src/main/main-process-diagnostics.ts
@@ -1,0 +1,155 @@
+import { DiagnosticLogBuffer, truncateUtf8 } from '@maka/core/diagnostic-log';
+import { installConsoleDiagnosticLogCapture } from '@maka/core/node-diagnostic-log';
+import { redactSecrets } from '@maka/core/redaction';
+import type { HostDiagnosticsResult } from '@maka/runtime-host/protocol';
+import type { DesktopErrorDiagnosticInput } from '../preload/diagnostics-contract.js';
+
+const INPUT_LIMITS = {
+  title: 512,
+  description: 24 * 1024,
+  details: 24 * 1024,
+  rendererUserAgent: 2 * 1024,
+  rendererLocale: 64,
+} as const;
+const INPUT_TRUNCATION_MARKER = '\n<diagnostic input truncated>';
+
+export interface DesktopDiagnosticEnvironment {
+  readonly appVersion: string;
+  readonly buildMode: 'dev' | 'packaged';
+  readonly buildCommit: string | null;
+  readonly electronVersion: string;
+  readonly nodeVersion: string;
+  readonly chromeVersion: string;
+  readonly platform: NodeJS.Platform;
+  readonly arch: string;
+  readonly osRelease: string;
+  readonly locale: string;
+  readonly workspacePath: string;
+  readonly homePath: string;
+  readonly processUptimeSeconds: number;
+}
+
+export type RuntimeHostDiagnosticRead =
+  | { readonly ok: true; readonly value: HostDiagnosticsResult }
+  | { readonly ok: false; readonly error: string };
+
+export const mainProcessLogBuffer = new DiagnosticLogBuffer();
+
+let logCaptureInstalled = false;
+
+export function installMainProcessLogCapture(buffer: DiagnosticLogBuffer = mainProcessLogBuffer): void {
+  if (logCaptureInstalled) return;
+  logCaptureInstalled = true;
+  installConsoleDiagnosticLogCapture(buffer);
+}
+
+export function parseDesktopErrorDiagnosticInput(input: unknown): DesktopErrorDiagnosticInput {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new TypeError('Invalid Desktop diagnostic input');
+  }
+  const record = input as Record<string, unknown>;
+  const allowedKeys = new Set([
+    'surface',
+    'title',
+    'description',
+    'details',
+    'rendererUserAgent',
+    'rendererLocale',
+  ]);
+  if (Object.keys(record).some((key) => !allowedKeys.has(key))) {
+    throw new TypeError('Invalid Desktop diagnostic input');
+  }
+  if (record.surface !== 'toast' && record.surface !== 'renderer_crash') {
+    throw new TypeError('Invalid Desktop diagnostic surface');
+  }
+  const title = requireDiagnosticString(record.title, 'title', INPUT_LIMITS.title);
+  return {
+    surface: record.surface,
+    title,
+    ...optionalBoundedString(record, 'description', INPUT_LIMITS.description),
+    ...optionalBoundedString(record, 'details', INPUT_LIMITS.details),
+    ...optionalBoundedString(record, 'rendererUserAgent', INPUT_LIMITS.rendererUserAgent),
+    ...optionalBoundedString(record, 'rendererLocale', INPUT_LIMITS.rendererLocale),
+  };
+}
+
+export function formatDesktopErrorDiagnosticReport(
+  input: DesktopErrorDiagnosticInput,
+  environment: DesktopDiagnosticEnvironment,
+  mainLogs: readonly string[],
+  runtimeHost: RuntimeHostDiagnosticRead,
+  capturedAt = new Date(),
+): string {
+  const lines = [
+    'Maka Desktop diagnostic report',
+    `Captured at: ${capturedAt.toISOString()}`,
+    '',
+    'Error',
+    `Surface: ${input.surface}`,
+    `Title: ${input.title}`,
+  ];
+  if (input.description) lines.push(`Description: ${input.description}`);
+  if (input.details) lines.push('', 'Details:', input.details);
+
+  lines.push(
+    '',
+    'Environment',
+    `Maka: ${environment.appVersion}`,
+    `Build: ${environment.buildMode}${environment.buildCommit ? ` @ ${environment.buildCommit.slice(0, 12)}` : ''}`,
+    `Electron: ${environment.electronVersion}`,
+    `Chrome: ${environment.chromeVersion}`,
+    `Node: ${environment.nodeVersion}`,
+    `OS: ${environment.platform} ${environment.osRelease} (${environment.arch})`,
+    `Locale: ${environment.locale}`,
+    `Renderer locale: ${input.rendererLocale ?? '<unknown>'}`,
+    `Renderer user agent: ${input.rendererUserAgent ?? '<unknown>'}`,
+    `Workspace: ${environment.workspacePath}`,
+    `Main process uptime: ${Math.max(0, Math.floor(environment.processUptimeSeconds))}s`,
+    '',
+    `Recent main-process logs (${mainLogs.length})`,
+    ...(mainLogs.length > 0 ? mainLogs : ['<none captured>']),
+  );
+
+  lines.push('', 'Runtime Host');
+  if (runtimeHost.ok) {
+    const host = runtimeHost.value;
+    lines.push(
+      `Epoch: ${host.hostEpoch}`,
+      `Protocol: v${host.protocolVersion} · compatibility ${host.compatibilityEpoch}`,
+      `State: ${host.state}`,
+      `Process: ${host.pid} · uptime ${host.processUptimeSeconds}s`,
+      `Runtime: Node ${host.nodeVersion} · ${host.platform} ${host.osRelease} (${host.arch})`,
+      `Activity: ${host.connections} connections · ${host.activeOperations} operations · ${host.activeResidencies} residencies`,
+      `Recent Runtime Host logs (${host.logs.length})`,
+      ...(host.logs.length > 0 ? host.logs : ['<none captured>']),
+    );
+  } else {
+    lines.push(`Diagnostics unavailable: ${runtimeHost.error}`);
+  }
+
+  const redacted = redactSecrets(lines.join('\n'));
+  return collapseHomePath(redacted, environment.homePath, environment.platform);
+}
+
+function optionalBoundedString(
+  record: Record<string, unknown>,
+  key: keyof typeof INPUT_LIMITS,
+  maximum: number,
+): Partial<Record<typeof key, string>> {
+  const value = record[key];
+  if (value === undefined) return {};
+  return { [key]: requireDiagnosticString(value, key, maximum) };
+}
+
+function requireDiagnosticString(value: unknown, label: string, maximumBytes: number): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new TypeError(`Invalid Desktop diagnostic ${label}`);
+  }
+  return truncateUtf8(value, maximumBytes, INPUT_TRUNCATION_MARKER);
+}
+
+function collapseHomePath(value: string, homePath: string, platform: NodeJS.Platform): string {
+  if (!homePath) return value;
+  const escaped = homePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return value.replace(new RegExp(escaped, platform === 'win32' ? 'gi' : 'g'), '~');
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,5 +1,8 @@
 import { app, dialog } from 'electron';
+import { installMainProcessLogCapture } from './main-process-diagnostics.js';
 import { isIsolatedE2e } from './startup-context.js';
+
+installMainProcessLogCapture();
 
 // The macOS app menu title and app.getName() consumers read this name. Set it
 // before ready, unchanged from its historical pre-ready position.

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -1,5 +1,6 @@
-import { app, dialog, ipcMain, powerSaveBlocker, shell } from "electron";
+import { app, clipboard, dialog, ipcMain, powerSaveBlocker, shell } from "electron";
 import { randomUUID } from "node:crypto";
+import { arch as osArch, homedir, release as osRelease } from "node:os";
 import { basename, join } from "node:path";
 import {
   type ConnectionEvent,
@@ -37,6 +38,7 @@ import { releaseBrowserSession } from "./browser/session.js";
 import { createE2eFixtureBotOnboardingAdapters } from "./bot-onboarding-e2e-fixture.js";
 import { resolveBuildInfo } from "./build-info.js";
 import { computerUseServiceHealth } from "./computer-use-host.js";
+import { registerDesktopDiagnosticsIpc } from "./desktop-diagnostics-ipc-main.js";
 import { assembleDesktopNativeCapabilities } from "./desktop-native-capability-assembly.js";
 import { buildRiveWorkflowTool } from "./rive-workflow-tool.js";
 import { installDesktopShellPresentation } from "./desktop-shell-presentation.js";
@@ -48,6 +50,7 @@ import {
 } from "./e2e-fixture.js";
 import { createKeepSystemAwakeController } from "./keep-system-awake.js";
 import { createMainWindowController } from "./main-window.js";
+import { mainProcessLogBuffer } from "./main-process-diagnostics.js";
 import {
   resolveDesktopSessionSelection,
   resolveNewSessionProjectInput,
@@ -764,6 +767,30 @@ function registerHostClientIpc(
 }
 
 function registerPersistentClientIpc(): void {
+  registerDesktopDiagnosticsIpc({
+    ipcMain,
+    environment: () => ({
+      appVersion: app.getVersion(),
+      buildMode: buildInfo.mode,
+      buildCommit: buildInfo.commit,
+      electronVersion: process.versions.electron ?? "",
+      nodeVersion: process.versions.node,
+      chromeVersion: process.versions.chrome ?? "",
+      platform: process.platform,
+      arch: osArch(),
+      osRelease: osRelease(),
+      locale: app.getLocale(),
+      workspacePath: workspaceRoot,
+      homePath: homedir(),
+      processUptimeSeconds: process.uptime(),
+    }),
+    mainLogs: () => mainProcessLogBuffer.snapshot(),
+    getRuntimeHostDiagnostics: async () => {
+      if (!runtimePolicyClient) throw new Error("Runtime Host is unavailable");
+      return runtimePolicyClient.queryHostDiagnostics();
+    },
+    writeClipboard: (report) => clipboard.writeText(report),
+  });
   ipcMain.handle("attachments:pickFiles", async (event) => {
     const result = await mainWindowController.showOpenDialog({
       title: "Add attachments",

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -915,6 +915,10 @@ export class DesktopRuntimeHostClient {
     return this.#request("turn.query", input);
   }
 
+  queryHostDiagnostics(): Promise<OperationOutput<"host.diagnostics.query">> {
+    return this.connection.queryHostDiagnostics(2_000);
+  }
+
   stopTurn(
     input: OperationInput<"turn.stop">,
   ): Promise<OperationOutput<"turn.stop">> {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -82,6 +82,10 @@ import type {
 import type { SessionTrace } from '@maka/core/session-trace';
 import type { TestProxyInput } from '@maka/core/settings/network-settings';
 import type { ExternalSessionImportIpcResult } from './external-session-import-result.js';
+import type {
+  DesktopDiagnosticCopyResult,
+  DesktopErrorDiagnosticInput,
+} from './diagnostics-contract.js';
 import type { Result } from '@maka/core/result';
 import type { CreateSessionRequestInput } from '@maka/core';
 import type {
@@ -804,6 +808,9 @@ export interface MakaBridge {
         }
     >;
     saveArtifactAs(sessionId: string, artifactId: string): Promise<ArtifactSaveResult>;
+  };
+  diagnostics: {
+    copyErrorReport(input: DesktopErrorDiagnosticInput): Promise<DesktopDiagnosticCopyResult>;
   };
   workspace: {
     searchFiles(

--- a/apps/desktop/src/preload/diagnostics-contract.ts
+++ b/apps/desktop/src/preload/diagnostics-contract.ts
@@ -1,0 +1,12 @@
+export interface DesktopErrorDiagnosticInput {
+  readonly surface: 'toast' | 'renderer_crash';
+  readonly title: string;
+  readonly description?: string;
+  readonly details?: string;
+  readonly rendererUserAgent?: string;
+  readonly rendererLocale?: string;
+}
+
+export type DesktopDiagnosticCopyResult =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: 'clipboard_unavailable' };

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -17,6 +17,10 @@ import type {
 } from './bridge-contract.js';
 import type { ExternalSessionImportIpcResult } from './external-session-import-result.js';
 import type {
+  DesktopDiagnosticCopyResult,
+  DesktopErrorDiagnosticInput,
+} from './diagnostics-contract.js';
+import type {
   ConnectionEvent,
   ConnectionTestResult,
   CreateConnectionInput,
@@ -1171,6 +1175,11 @@ const makaBridge = {
     },
     saveArtifactAs(sessionId: string, artifactId: string): Promise<ArtifactSaveResult> {
       return ipcRenderer.invoke('app:saveArtifactAs', sessionId, artifactId);
+    },
+  },
+  diagnostics: {
+    copyErrorReport(input: DesktopErrorDiagnosticInput): Promise<DesktopDiagnosticCopyResult> {
+      return ipcRenderer.invoke('diagnostics:copyErrorReport', input);
     },
   },
   workspace: {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -36,6 +36,7 @@ import {
   LocaleProvider,
   ModuleHubSelector,
   ToastProvider,
+  type ToastErrorAction,
   type NavSelection,
   SessionListPanel,
   SkillsPage,
@@ -236,6 +237,22 @@ export function AppShell({ initialOnboardingSnapshot = null }: AppShellProps = {
   const [uiLocaleOverride, setUiLocaleOverride] = useState<UiLocale | null>(null);
   const systemUiLocale = useSystemUiLocale();
   const uiLocale = resolveUiLocale(uiLocalePreference, systemUiLocale, uiLocaleOverride);
+  const errorToastAction = useMemo<ToastErrorAction>(
+    () => ({
+      label: getShellCopy(uiLocale).errorBoundary.copyReport,
+      onClick: (input) => {
+        void window.maka.diagnostics.copyErrorReport({
+            surface: 'toast',
+            title: input.title,
+            ...(input.description ? { description: input.description } : {}),
+            rendererUserAgent: navigator.userAgent,
+            rendererLocale: navigator.language,
+          })
+          .catch(() => undefined);
+      },
+    }),
+    [uiLocale],
+  );
 
   return (
     <LocaleProvider locale={uiLocale} override={uiLocaleOverride}>
@@ -244,7 +261,7 @@ export function AppShell({ initialOnboardingSnapshot = null }: AppShellProps = {
           `useUiLocale()` throws before anything renders. Still above every
           Astryx subtree. */}
       <AstryxLocaleProvider>
-        <ToastProvider>
+        <ToastProvider errorAction={errorToastAction}>
           <ErrorBoundary locale={uiLocale}>
             <AppShellContent
               initialOnboardingSnapshot={initialOnboardingSnapshot}

--- a/apps/desktop/src/renderer/error-boundary.tsx
+++ b/apps/desktop/src/renderer/error-boundary.tsx
@@ -23,14 +23,8 @@ export function formatRendererErrorReport(error: Error, info?: ErrorInfo | null)
     'Maka renderer error report',
     `Captured at: ${new Date().toISOString()}`,
     '',
-    `${error.name}: ${error.message}`,
+    formatRendererErrorDetails(error, info),
   ];
-  if (error.stack) {
-    lines.push('', 'Stack:', error.stack);
-  }
-  if (info?.componentStack) {
-    lines.push('', 'React component stack:', info.componentStack.trim());
-  }
   if (typeof navigator !== 'undefined' && navigator.userAgent) {
     lines.push('', `User agent: ${navigator.userAgent}`);
   }
@@ -86,7 +80,19 @@ export class ErrorBoundary extends Component<{ children: ReactNode; locale: UiLo
     const copyRequestId = ++this.copyRequestSeq;
     this.setState({ copyState: 'pending' });
     try {
-      await navigator.clipboard.writeText(formatRendererErrorReport(error, errorInfo));
+      const diagnostics = window.maka?.diagnostics;
+      if (diagnostics) {
+        const result = await diagnostics.copyErrorReport({
+          surface: 'renderer_crash',
+          title: `${error.name}: ${error.message}`,
+          details: formatRendererErrorDetails(error, errorInfo),
+          rendererUserAgent: navigator.userAgent,
+          rendererLocale: navigator.language,
+        });
+        if (!result.ok) throw new Error('Desktop diagnostic clipboard write failed');
+      } else {
+        await navigator.clipboard.writeText(formatRendererErrorReport(error, errorInfo));
+      }
       if (this.isCurrentCopyRequest(copyRequestId, error)) this.setState({ copyState: 'copied' });
     } catch {
       if (this.isCurrentCopyRequest(copyRequestId, error)) this.setState({ copyState: 'failed' });
@@ -156,4 +162,13 @@ export class ErrorBoundary extends Component<{ children: ReactNode; locale: UiLo
       </div>
     );
   }
+}
+
+function formatRendererErrorDetails(error: Error, info?: ErrorInfo | null): string {
+  const lines = [`${error.name}: ${error.message}`];
+  if (error.stack) lines.push('', 'Stack:', error.stack);
+  if (info?.componentStack) {
+    lines.push('', 'React component stack:', info.componentStack.trim());
+  }
+  return redactSecrets(lines.join('\n'));
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -99,6 +99,8 @@
     "./text-file-import": "./dist/text-file-import.js",
     "./redaction": "./dist/redaction.js",
     "./display-redaction": "./dist/display-redaction.js",
+    "./diagnostic-log": "./dist/diagnostic-log.js",
+    "./node-diagnostic-log": "./dist/node-diagnostic-log.js",
     "./result": "./dist/result.js",
     "./settings": "./dist/settings.js",
     "./mcp": "./dist/mcp.js",

--- a/packages/core/src/__tests__/diagnostic-log.test.ts
+++ b/packages/core/src/__tests__/diagnostic-log.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { DiagnosticLogBuffer } from '../diagnostic-log.js';
+
+test('keeps a bounded redacted tail of diagnostic logs', () => {
+  const buffer = new DiagnosticLogBuffer({
+    maxBytes: 1024,
+    maxEntries: 2,
+    maxEntryCodePoints: 200,
+    maxEntryUtf8Bytes: 80,
+  });
+  buffer.append('info', 'api_key=sk-secretvalue123 first', new Date('2026-08-09T00:00:00Z'));
+  buffer.append('warn', '🚀'.repeat(100), new Date('2026-08-09T00:00:01Z'));
+  buffer.append('error', 'newest', new Date('2026-08-09T00:00:02Z'));
+
+  const logs = buffer.snapshot();
+  assert.equal(logs.length, 2);
+  assert.ok(Buffer.byteLength(JSON.stringify(logs)) <= 1024);
+  assert.ok(logs.every((entry) => Buffer.byteLength(entry) <= 80));
+  assert.doesNotMatch(logs.join('\n'), /sk-secretvalue123/);
+  assert.match(logs.at(-1) ?? '', /ERROR newest$/);
+});

--- a/packages/core/src/__tests__/redaction.test.ts
+++ b/packages/core/src/__tests__/redaction.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { formatWithOptions } from 'node:util';
 import { describe, test } from 'node:test';
 import {
   generalizedErrorMessage,
@@ -11,12 +12,28 @@ describe('redactSecrets', () => {
     const text = redactSecrets(
       'Authorization: Bearer sk-live-secret-token-value Proxy-Authorization: Basic opaque-proxy-value and ghp_abcdefghijklmnopqrstuvwxyz',
     );
+    const inspected = redactSecrets(
+      formatWithOptions(
+        { colors: false },
+        {
+          authorization: 'Bearer inspected-secret-value',
+          'Proxy-Authorization': 'Basic inspected-proxy-secret',
+          proxyAuthorization: 'Token inspected-camel-secret',
+        },
+      ),
+    );
 
     assert.equal(text.includes('sk-live-secret-token-value'), false);
     assert.equal(text.includes('opaque-proxy-value'), false);
     assert.equal(text.includes('ghp_abcdefghijklmnopqrstuvwxyz'), false);
     assert.match(text, /Authorization: Bearer \[redacted\]/);
     assert.match(text, /Proxy-Authorization: Basic \[redacted\]/);
+    assert.equal(inspected.includes('inspected-secret-value'), false);
+    assert.equal(inspected.includes('inspected-proxy-secret'), false);
+    assert.equal(inspected.includes('inspected-camel-secret'), false);
+    assert.match(inspected, /authorization: 'Bearer \[redacted\]'/);
+    assert.match(inspected, /'Proxy-Authorization': 'Basic \[redacted\]'/);
+    assert.match(inspected, /proxyAuthorization: 'Token \[redacted\]'/);
   });
 
   test('applies bounded text patterns to top-level JSON number primitives', () => {

--- a/packages/core/src/diagnostic-log.ts
+++ b/packages/core/src/diagnostic-log.ts
@@ -1,0 +1,123 @@
+import { redactSecrets } from './redaction.js';
+
+export type DiagnosticLogLevel = 'debug' | 'info' | 'log' | 'warn' | 'error';
+
+interface DiagnosticLogEntry {
+  readonly bytes: number;
+  readonly text: string;
+}
+
+export interface DiagnosticLogBufferOptions {
+  readonly maxBytes?: number;
+  readonly maxEntries?: number;
+  readonly maxEntryCodePoints?: number;
+  readonly maxEntryUtf8Bytes?: number;
+}
+
+export class DiagnosticLogBuffer {
+  readonly #entries: DiagnosticLogEntry[] = [];
+  readonly #maxBytes: number;
+  readonly #maxEntries: number | undefined;
+  readonly #maxEntryCodePoints: number;
+  readonly #maxEntryUtf8Bytes: number | undefined;
+  #bytes = 0;
+
+  constructor(options: DiagnosticLogBufferOptions = {}) {
+    this.#maxBytes = requireMinimumInteger(options.maxBytes ?? 64 * 1024, 'maxBytes', 4);
+    this.#maxEntries = optionalPositiveInteger(options.maxEntries, 'maxEntries');
+    this.#maxEntryCodePoints = requirePositiveInteger(
+      options.maxEntryCodePoints ?? 8 * 1024,
+      'maxEntryCodePoints',
+    );
+    this.#maxEntryUtf8Bytes = optionalPositiveInteger(
+      options.maxEntryUtf8Bytes,
+      'maxEntryUtf8Bytes',
+    );
+  }
+
+  append(level: DiagnosticLogLevel, message: string, capturedAt = new Date()): void {
+    const safe = truncateCodePoints(redactSecrets(message), this.#maxEntryCodePoints);
+    const prefixed = `[${capturedAt.toISOString()}] ${level.toUpperCase()} ${safe}`;
+    const entryBounded =
+      this.#maxEntryUtf8Bytes === undefined
+        ? prefixed
+        : truncateUtf8(prefixed, this.#maxEntryUtf8Bytes, '\n<log entry truncated>');
+    const text = truncateEncodedString(entryBounded, this.#maxBytes - 2);
+    const entry = { text, bytes: encodedStringBytes(text) };
+    this.#entries.push(entry);
+    this.#bytes += entry.bytes;
+    while (
+      (this.#snapshotBytes() > this.#maxBytes ||
+        (this.#maxEntries !== undefined && this.#entries.length > this.#maxEntries)) &&
+      this.#entries.length > 1
+    ) {
+      const removed = this.#entries.shift();
+      if (removed) this.#bytes -= removed.bytes;
+    }
+  }
+
+  snapshot(): readonly string[] {
+    return this.#entries.map(({ text }) => text);
+  }
+
+  #snapshotBytes(): number {
+    return 2 + this.#bytes + Math.max(0, this.#entries.length - 1);
+  }
+}
+
+function encodedStringBytes(value: string): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function requirePositiveInteger(value: number, label: string): number {
+  return requireMinimumInteger(value, label, 1);
+}
+
+function optionalPositiveInteger(value: number | undefined, label: string): number | undefined {
+  return value === undefined ? undefined : requirePositiveInteger(value, label);
+}
+
+function requireMinimumInteger(value: number, label: string, minimum: number): number {
+  if (!Number.isSafeInteger(value) || value < minimum) {
+    throw new RangeError(`${label} must be at least ${minimum}`);
+  }
+  return value;
+}
+
+function truncateCodePoints(value: string, maximum: number): string {
+  const codePoints = [...value];
+  if (codePoints.length <= maximum) return value;
+  return `${codePoints.slice(0, maximum).join('')}\n<log entry truncated>`;
+}
+
+function truncateEncodedString(value: string, maximumBytes: number): string {
+  if (encodedStringBytes(value) <= maximumBytes) return value;
+  const marker = '\n<log entry truncated>';
+  const suffix = encodedStringBytes(marker) <= maximumBytes ? marker : '';
+  const codePoints = [...value];
+  let low = 0;
+  let high = codePoints.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = `${codePoints.slice(0, middle).join('')}${suffix}`;
+    if (encodedStringBytes(candidate) <= maximumBytes) low = middle;
+    else high = middle - 1;
+  }
+  return `${codePoints.slice(0, low).join('')}${suffix}`;
+}
+
+export function truncateUtf8(value: string, maximumBytes: number, marker = ''): string {
+  requirePositiveInteger(maximumBytes, 'maximumBytes');
+  if (new TextEncoder().encode(value).byteLength <= maximumBytes) return value;
+  const suffix = new TextEncoder().encode(marker).byteLength <= maximumBytes ? marker : '';
+  const codePoints = [...value];
+  let low = 0;
+  let high = codePoints.length;
+  while (low < high) {
+    const middle = Math.ceil((low + high) / 2);
+    const candidate = `${codePoints.slice(0, middle).join('')}${suffix}`;
+    if (new TextEncoder().encode(candidate).byteLength <= maximumBytes) low = middle;
+    else high = middle - 1;
+  }
+  return `${codePoints.slice(0, low).join('')}${suffix}`;
+}

--- a/packages/core/src/node-diagnostic-log.ts
+++ b/packages/core/src/node-diagnostic-log.ts
@@ -1,0 +1,31 @@
+import { formatWithOptions } from 'node:util';
+import type { DiagnosticLogBuffer } from './diagnostic-log.js';
+
+const MAX_LOG_ENTRY_CODE_POINTS = 8 * 1024;
+
+export function installConsoleDiagnosticLogCapture(buffer: DiagnosticLogBuffer): void {
+  for (const level of ['debug', 'info', 'log', 'warn', 'error'] as const) {
+    const original = console[level].bind(console);
+    console[level] = (...args: unknown[]) => {
+      try {
+        buffer.append(
+          level,
+          formatWithOptions(
+            {
+              breakLength: 160,
+              colors: false,
+              compact: 3,
+              depth: 4,
+              maxArrayLength: 50,
+              maxStringLength: MAX_LOG_ENTRY_CODE_POINTS,
+            },
+            ...args,
+          ),
+        );
+      } catch {
+        // Diagnostic capture must not change console behavior.
+      }
+      original(...args);
+    };
+  }
+}

--- a/packages/core/src/redaction.ts
+++ b/packages/core/src/redaction.ts
@@ -24,7 +24,7 @@ const QUOTED_SECRET_KEY_VALUE_PATTERN = /((?:"([^"\\]+)"\s*:\s*"))(?:\\.|[^"\\])
 const ASSIGNED_SECRET_KEY_VALUE_PATTERN =
   /\b(([A-Za-z][A-Za-z0-9_-]*)(?:[ \t]|\\\r?\n)*[:=](?:[ \t]|\\\r?\n)*['"]?)(?:\\\r?\n|[^\s"'&<>])+/g;
 const AUTHORIZATION_HEADER_PATTERN =
-  /\b((?:proxy-)?authorization:\s*(?:bearer|basic|token)\s+)[^\s"'<>]+/gi;
+  /(^|[^A-Za-z0-9_])(['"]?(?:proxy[-_]?authorization|authorization)['"]?\s*:\s*['"]?(?:bearer|basic|token)\s+)[^\s"'<>]+/gim;
 const AWS_CLI_SPACE_SECRET_PATTERN = new RegExp(
   `(^|[\\s;&|()])((?:aws${SHELL_SEPARATOR_SOURCE}configure${SHELL_SEPARATOR_SOURCE}set${SHELL_SEPARATOR_SOURCE}${AWS_CONFIG_SECRET_KEY_SOURCE}|${AWS_SECRET_ACCESS_KEY_FLAG_SOURCE})${SHELL_SEPARATOR_SOURCE})${SHELL_SECRET_TOKEN_SOURCE}`,
   'gm',
@@ -55,7 +55,7 @@ function redactTextSecrets(value: string): string {
   );
   next = next.replace(
     AUTHORIZATION_HEADER_PATTERN,
-    (_match, prefix: string) => `${prefix}[redacted]`,
+    (_match, boundary: string, prefix: string) => `${boundary}${prefix}[redacted]`,
   );
   next = next.replace(
     AWS_CLI_SPACE_SECRET_PATTERN,

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -301,6 +301,7 @@ test('connection reset while operation admission is pending does not execute the
         activeResidencies: 0,
       },
     }),
+    ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
     ...createHandlers(async (input) => {
       handlerCalls += 1;
       return {
@@ -548,6 +549,7 @@ test('an in-flight status does not consume the final domain request slot', async
         },
       };
     },
+    ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
     ...createHandlers(async (input) => {
       const index = Number(input.turnId.slice('turn-'.length));
       domainEntered[index]?.resolve();
@@ -647,6 +649,7 @@ test('evicting one slow subscription keeps sibling subscriptions and requests us
         activeResidencies: 0,
       },
     }),
+    ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
     ...createHandlers(async (input) => ({
       ok: true,
       result: runningSnapshot(input.sessionId, input.turnId),
@@ -889,6 +892,7 @@ async function openHalfClosedDispatchedSession(
           activeResidencies: 0,
         },
       }),
+      ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
       ...createHandlers(async (input) => {
         handlerEntered.resolve();
         await releaseHandler.promise;
@@ -1030,6 +1034,13 @@ function statusResponse(requestId: string): ResponseFrame {
     },
   };
 }
+
+const UNUSED_HOST_DIAGNOSTICS_HANDLER: Pick<OperationHandlerMap, 'host.diagnostics.query'> = {
+  'host.diagnostics.query': async () => ({
+    ok: false,
+    error: { code: 'internal_failure', message: 'not used' },
+  }),
+};
 
 function largeFailureResponse(requestId: string): ResponseFrame {
   return {

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -73,7 +73,7 @@ const require = createRequire(import.meta.url);
 const execFileAsync = promisify(execFile);
 
 describe('non-serving Runtime Host kernel', () => {
-  test('elects one owner, serves status, and releases ownership after true-idle shutdown', async () => {
+  test('elects one owner, serves status and diagnostics, and releases ownership after true-idle shutdown', async () => {
     await withHostPaths(async (paths) => {
       const winner = await startTestRuntimeHostCandidate(paths, {
         rootPath: paths.root,
@@ -104,6 +104,14 @@ describe('non-serving Runtime Host kernel', () => {
         assert.equal(status.state, 'ready');
         assert.equal(status.connections, 1);
       }
+      const diagnostics = await connected.connection.queryHostDiagnostics();
+      assert.equal(diagnostics.hostEpoch, winner.host.hostEpoch);
+      assert.equal(diagnostics.state, 'ready');
+      assert.equal(diagnostics.pid, process.pid);
+      assert.equal(diagnostics.platform, process.platform);
+      assert.equal(diagnostics.protocolVersion, RUNTIME_HOST_PROTOCOL_VERSION);
+      assert.equal(diagnostics.compatibilityEpoch, RUNTIME_HOST_COMPATIBILITY_EPOCH);
+      assert.ok(Array.isArray(diagnostics.logs));
       await connected.connection.close();
       await winner.host.closed;
 

--- a/packages/runtime-host/src/__tests__/operation-dispatcher.test.ts
+++ b/packages/runtime-host/src/__tests__/operation-dispatcher.test.ts
@@ -162,6 +162,7 @@ function validHandlers(): OperationHandlerMap {
     }) as OperationOutcome<K>;
   return {
     'host.status': unavailable,
+    'host.diagnostics.query': unavailable,
     ...createUnavailableDomainOperationHandlers(),
   };
 }

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -27,8 +27,9 @@ import {
   RUNTIME_POLICY_OPERATION_SPECS,
   RuntimeHostProtocolError,
 } from '../protocol/index.js';
-import { HOST_STATUS_OPERATION_SPECS } from '../protocol/host-status.js';
+import { HOST_BOOTSTRAP_OPERATION_SPECS } from '../protocol/host-status.js';
 import { composeOperationSpecMaps } from '../protocol/operation-spec.js';
+import { runtimeHostLogBuffer } from '../process-diagnostics.js';
 import {
   TURN_MESSAGE_QUOTE_LABEL_MAX_LENGTH,
   TURN_MESSAGE_QUOTE_MAX_COUNT,
@@ -47,7 +48,7 @@ describe('Runtime Host bootstrap protocol', () => {
 
   test('keeps the experimental protocol at v0 with the declared authority operations', () => {
     assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
-    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 8);
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 9);
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
       'agent.graph.operator.query',
       'agent.graph.query',
@@ -84,6 +85,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'external-session.source.query',
       'goal.control',
       'goal.query',
+      'host.diagnostics.query',
       'host.status',
       'interaction.answer',
       'interaction.query',
@@ -1450,12 +1452,40 @@ describe('Runtime Host bootstrap protocol', () => {
 
   test('rejects duplicate operation keys while composing domain registries', () => {
     const composeUnchecked = composeOperationSpecMaps as (
-      left: typeof HOST_STATUS_OPERATION_SPECS,
-      right: typeof HOST_STATUS_OPERATION_SPECS,
+      left: typeof HOST_BOOTSTRAP_OPERATION_SPECS,
+      right: typeof HOST_BOOTSTRAP_OPERATION_SPECS,
     ) => unknown;
     assert.throws(
-      () => composeUnchecked(HOST_STATUS_OPERATION_SPECS, HOST_STATUS_OPERATION_SPECS),
+      () => composeUnchecked(HOST_BOOTSTRAP_OPERATION_SPECS, HOST_BOOTSTRAP_OPERATION_SPECS),
       /Duplicate Runtime Host operation key: host\.status/,
+    );
+  });
+
+  test('keeps Runtime Host logs within the diagnostics operation contract', () => {
+    for (let index = 0; index < 257; index += 1) {
+      runtimeHostLogBuffer.append('info', `entry ${index}`);
+    }
+    runtimeHostLogBuffer.append('error', '🚀'.repeat(3_000));
+    const logs = runtimeHostLogBuffer.snapshot();
+
+    assert.equal(logs.length, 256);
+    assert.doesNotThrow(() =>
+      HOST_BOOTSTRAP_OPERATION_SPECS['host.diagnostics.query'].decodeOutput({
+        hostEpoch: 'epoch-1',
+        state: 'ready',
+        connections: 1,
+        activeOperations: 0,
+        activeResidencies: 0,
+        protocolVersion: 0,
+        compatibilityEpoch: 9,
+        pid: 42,
+        processUptimeSeconds: 1,
+        nodeVersion: '22.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        osRelease: '6.6.0',
+        logs,
+      }),
     );
   });
 

--- a/packages/runtime-host/src/candidate-main.ts
+++ b/packages/runtime-host/src/candidate-main.ts
@@ -2,6 +2,9 @@
 import { startRuntimeHostCandidate } from './server/candidate.js';
 import { runRuntimeHostProcessLifecycle } from './server/process-lifecycle.js';
 import { parseRuntimeHostCandidateArguments } from './candidate-cli.js';
+import { installRuntimeHostLogCapture } from './process-diagnostics.js';
+
+installRuntimeHostLogCapture();
 
 const options = parseRuntimeHostCandidateArguments(process.argv.slice(2));
 const result = await startRuntimeHostCandidate(options);

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -27,6 +27,7 @@ import {
   type DailyReviewMutateResult,
   type DailyReviewQueryInput,
   type DailyReviewQueryResult,
+  type HostDiagnosticsResult,
   type HostOperationErrorCode,
   type HostIncompatible,
   type HostRegistration,
@@ -162,6 +163,7 @@ export interface RuntimeHostConnection {
     timeoutMs?: number,
   ): Promise<OperationOutput<K>>;
   status(timeoutMs?: number): Promise<HostStatusResult>;
+  queryHostDiagnostics(timeoutMs?: number): Promise<HostDiagnosticsResult>;
   startTurn(input: TurnStartInput, timeoutMs?: number): Promise<TurnStartResult>;
   queryTurn(input: TurnQueryInput, timeoutMs?: number): Promise<TurnSnapshot>;
   stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot>;
@@ -382,6 +384,10 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       throw error;
     }
     return status;
+  }
+
+  queryHostDiagnostics(timeoutMs?: number): Promise<HostDiagnosticsResult> {
+    return this.request('host.diagnostics.query', {}, timeoutMs);
   }
 
   startTurn(input: TurnStartInput, timeoutMs?: number): Promise<TurnStartResult> {

--- a/packages/runtime-host/src/desktop-e2e-execution-candidate-main.ts
+++ b/packages/runtime-host/src/desktop-e2e-execution-candidate-main.ts
@@ -4,6 +4,9 @@ import { parseRuntimeHostCandidateArguments } from './candidate-cli.js';
 import { startExecutionRuntimeHostCandidate } from './server/execution-candidate.js';
 import { createExecutionRuntimeHostComposition } from './server/execution-composition.js';
 import { runRuntimeHostProcessLifecycle } from './server/process-lifecycle.js';
+import { installRuntimeHostLogCapture } from './process-diagnostics.js';
+
+installRuntimeHostLogCapture();
 
 const options = parseRuntimeHostCandidateArguments(process.argv.slice(2));
 const result = await startExecutionRuntimeHostCandidate(

--- a/packages/runtime-host/src/execution-candidate-main.ts
+++ b/packages/runtime-host/src/execution-candidate-main.ts
@@ -2,6 +2,9 @@
 import { parseRuntimeHostCandidateArguments } from './candidate-cli.js';
 import { startExecutionRuntimeHostCandidate } from './server/execution-candidate.js';
 import { runRuntimeHostProcessLifecycle } from './server/process-lifecycle.js';
+import { installRuntimeHostLogCapture } from './process-diagnostics.js';
+
+installRuntimeHostLogCapture();
 
 const options = parseRuntimeHostCandidateArguments(process.argv.slice(2));
 const result = await startExecutionRuntimeHostCandidate(options);

--- a/packages/runtime-host/src/process-diagnostics.ts
+++ b/packages/runtime-host/src/process-diagnostics.ts
@@ -1,0 +1,20 @@
+import { DiagnosticLogBuffer } from '@maka/core/diagnostic-log';
+import { installConsoleDiagnosticLogCapture } from '@maka/core/node-diagnostic-log';
+import {
+  HOST_DIAGNOSTIC_LOG_MAX_ENTRIES,
+  HOST_DIAGNOSTIC_LOG_MAX_ENTRY_BYTES,
+} from './protocol/host-status.js';
+
+export const runtimeHostLogBuffer = new DiagnosticLogBuffer({
+  maxBytes: 48 * 1024,
+  maxEntries: HOST_DIAGNOSTIC_LOG_MAX_ENTRIES,
+  maxEntryUtf8Bytes: HOST_DIAGNOSTIC_LOG_MAX_ENTRY_BYTES,
+});
+
+let logCaptureInstalled = false;
+
+export function installRuntimeHostLogCapture(buffer = runtimeHostLogBuffer): void {
+  if (logCaptureInstalled) return;
+  logCaptureInstalled = true;
+  installConsoleDiagnosticLogCapture(buffer);
+}

--- a/packages/runtime-host/src/protocol/host-status.ts
+++ b/packages/runtime-host/src/protocol/host-status.ts
@@ -1,9 +1,21 @@
 import { invalidProtocolFrame } from './errors.js';
-import { requireCount, requireExactRecord, requireId } from './codec.js';
+import {
+  requireCount,
+  requireEncodedByteLimit,
+  requireExactRecord,
+  requireId,
+  requireString,
+  requireUtf8String,
+} from './codec.js';
 import { defineOperation } from './operation-spec.js';
 
 export type HostLifecycleState = 'starting' | 'containing' | 'recovering' | 'ready' | 'draining';
 export type HostStatusInput = Record<string, never>;
+export type HostDiagnosticsInput = Record<string, never>;
+
+export const HOST_DIAGNOSTICS_RESULT_MAX_BYTES = 72 * 1024;
+export const HOST_DIAGNOSTIC_LOG_MAX_ENTRIES = 256;
+export const HOST_DIAGNOSTIC_LOG_MAX_ENTRY_BYTES = 10 * 1024;
 
 export interface HostStatusResult {
   hostEpoch: string;
@@ -13,18 +25,37 @@ export interface HostStatusResult {
   activeResidencies: number;
 }
 
-export const HOST_STATUS_OPERATION_SPECS = {
+export interface HostDiagnosticsResult extends HostStatusResult {
+  protocolVersion: number;
+  compatibilityEpoch: number;
+  pid: number;
+  processUptimeSeconds: number;
+  nodeVersion: string;
+  platform: NodeJS.Platform;
+  arch: string;
+  osRelease: string;
+  logs: readonly string[];
+}
+
+export const HOST_BOOTSTRAP_OPERATION_SPECS = {
   'host.status': defineOperation({
     mode: 'query',
     availability: 'bootstrap',
     errors: ['host_draining', 'internal_failure'] as const,
-    decodeInput: decodeHostStatusInput,
+    decodeInput: (value) => decodeEmptyHostInput(value, 'host.status input'),
     decodeOutput: decodeHostStatusResult,
+  }),
+  'host.diagnostics.query': defineOperation({
+    mode: 'query',
+    availability: 'bootstrap',
+    errors: ['host_draining', 'internal_failure'] as const,
+    decodeInput: (value) => decodeEmptyHostInput(value, 'host.diagnostics.query input'),
+    decodeOutput: decodeHostDiagnosticsResult,
   }),
 } as const;
 
-function decodeHostStatusInput(value: unknown): HostStatusInput {
-  requireExactRecord(value, 'host.status input', []);
+function decodeEmptyHostInput(value: unknown, label: string): HostStatusInput {
+  requireExactRecord(value, label, []);
   return {};
 }
 
@@ -36,6 +67,55 @@ function decodeHostStatusResult(value: unknown): HostStatusResult {
     'activeOperations',
     'activeResidencies',
   ]);
+  return decodeHostStatusFields(record);
+}
+
+function decodeHostDiagnosticsResult(value: unknown): HostDiagnosticsResult {
+  requireEncodedByteLimit(
+    value,
+    'host.diagnostics.query result',
+    HOST_DIAGNOSTICS_RESULT_MAX_BYTES,
+  );
+  const record = requireExactRecord(value, 'host.diagnostics.query result', [
+    'hostEpoch',
+    'state',
+    'connections',
+    'activeOperations',
+    'activeResidencies',
+    'protocolVersion',
+    'compatibilityEpoch',
+    'pid',
+    'processUptimeSeconds',
+    'nodeVersion',
+    'platform',
+    'arch',
+    'osRelease',
+    'logs',
+  ]);
+  if (!Array.isArray(record.logs) || record.logs.length > HOST_DIAGNOSTIC_LOG_MAX_ENTRIES) {
+    throw invalidProtocolFrame('Invalid Runtime Host diagnostic logs');
+  }
+  return {
+    ...decodeHostStatusFields(record),
+    protocolVersion: requireCount(record.protocolVersion, 'Runtime Host protocol version'),
+    compatibilityEpoch: requireCount(record.compatibilityEpoch, 'Runtime Host compatibility epoch'),
+    pid: requireCount(record.pid, 'Runtime Host pid'),
+    processUptimeSeconds: requireCount(record.processUptimeSeconds, 'Runtime Host process uptime'),
+    nodeVersion: requireString(record.nodeVersion, 'Runtime Host Node version', 64),
+    platform: requirePlatform(record.platform),
+    arch: requireString(record.arch, 'Runtime Host architecture', 64),
+    osRelease: requireString(record.osRelease, 'Runtime Host OS release', 256),
+    logs: record.logs.map((entry) =>
+      requireUtf8String(
+        entry,
+        'Runtime Host diagnostic log entry',
+        HOST_DIAGNOSTIC_LOG_MAX_ENTRY_BYTES,
+      ),
+    ),
+  };
+}
+
+function decodeHostStatusFields(record: Record<string, unknown>): HostStatusResult {
   return {
     hostEpoch: requireId(record.hostEpoch, 'hostEpoch'),
     state: requireHostLifecycleState(record.state),
@@ -43,6 +123,25 @@ function decodeHostStatusResult(value: unknown): HostStatusResult {
     activeOperations: requireCount(record.activeOperations, 'activeOperations'),
     activeResidencies: requireCount(record.activeResidencies, 'activeResidencies'),
   };
+}
+
+function requirePlatform(value: unknown): NodeJS.Platform {
+  if (
+    value === 'aix' ||
+    value === 'android' ||
+    value === 'darwin' ||
+    value === 'freebsd' ||
+    value === 'haiku' ||
+    value === 'linux' ||
+    value === 'openbsd' ||
+    value === 'sunos' ||
+    value === 'win32' ||
+    value === 'cygwin' ||
+    value === 'netbsd'
+  ) {
+    return value;
+  }
+  throw invalidProtocolFrame('Invalid Runtime Host platform');
 }
 
 export function requireHostLifecycleState(value: unknown): HostLifecycleState {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -56,8 +56,8 @@ export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // The wire version remains v0 before the first release. This independent epoch
 // lets a new Client retire a stale same-version Host whose closed schema is no
 // longer safe to use.
-// 8: external Session discovery and import added three closed operation keys.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 8 as const;
+// 9: bounded Host process diagnostics added one closed operation key.
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 9 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -11,7 +11,7 @@ import { EXECUTION_INSPECT_OPERATION_SPECS } from './execution-inspect.js';
 import { EXTERNAL_SESSION_OPERATION_SPECS } from './external-session.js';
 import { CLIENT_CAPABILITY_OPERATION_SPECS } from './client-capability.js';
 import { invalidProtocolFrame } from './errors.js';
-import { HOST_STATUS_OPERATION_SPECS } from './host-status.js';
+import { HOST_BOOTSTRAP_OPERATION_SPECS } from './host-status.js';
 import { GOAL_OPERATION_SPECS } from './goal.js';
 import { INTERACTION_OPERATION_SPECS } from './interaction.js';
 import { MESSAGE_OPERATION_SPECS } from './message.js';
@@ -40,6 +40,8 @@ import { USAGE_PRICING_OPERATION_SPECS } from './usage-pricing.js';
 import { WEB_SEARCH_OPERATION_SPECS } from './web-search.js';
 
 export type {
+  HostDiagnosticsInput,
+  HostDiagnosticsResult,
   HostLifecycleState,
   HostStatusInput,
   HostStatusResult,
@@ -139,7 +141,7 @@ export * from './usage-pricing.js';
 export * from './web-search.js';
 
 export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
-  HOST_STATUS_OPERATION_SPECS,
+  HOST_BOOTSTRAP_OPERATION_SPECS,
   AGENT_GRAPH_OPERATION_SPECS,
   GOAL_OPERATION_SPECS,
   TURN_OPERATION_SPECS,

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { createServer, type Server, type Socket } from 'node:net';
+import { arch as osArch, release as osRelease } from 'node:os';
 import {
   assertInteractiveRootOwner,
   authenticateInteractiveRootOwner,
@@ -19,6 +20,7 @@ import {
   type HostHandshakeResult,
   type HostLifecycleState,
   type HostRegistration,
+  type HostStatusResult,
   type RequestFrame,
 } from '../protocol/index.js';
 import { FramedTransport } from '../transport/framed-transport.js';
@@ -36,6 +38,7 @@ import {
 import type { SessionContinuityService } from './session-continuity-service.js';
 import type { ClientCapabilityService } from './client-capability-service.js';
 import type { HostConfigurationChangeService } from './configuration-change-service.js';
+import { runtimeHostLogBuffer } from '../process-diagnostics.js';
 import type { HostSessionCatalogChangeService } from './session-catalog-change-service.js';
 
 const DEFAULT_IDLE_GRACE_MS = 30_000;
@@ -463,17 +466,36 @@ export class RuntimeHostKernel {
       {
         'host.status': async () => ({
           ok: true,
+          result: this.#statusSnapshot(),
+        }),
+        'host.diagnostics.query': async () => ({
+          ok: true,
           result: {
-            hostEpoch: this.hostEpoch,
-            state: this.#state,
-            connections: this.#acceptedTransports.size,
-            activeOperations: this.#activeOperations,
-            activeResidencies: this.#activeResidencies,
+            ...this.#statusSnapshot(),
+            protocolVersion: RUNTIME_HOST_PROTOCOL_VERSION,
+            compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+            pid: process.pid,
+            processUptimeSeconds: Math.max(0, Math.floor(process.uptime())),
+            nodeVersion: process.versions.node,
+            platform: process.platform,
+            arch: osArch(),
+            osRelease: osRelease(),
+            logs: runtimeHostLogBuffer.snapshot(),
           },
         }),
       },
       domainHandlers,
     );
+  }
+
+  #statusSnapshot(): HostStatusResult {
+    return {
+      hostEpoch: this.hostEpoch,
+      state: this.#state,
+      connections: this.#acceptedTransports.size,
+      activeOperations: this.#activeOperations,
+      activeResidencies: this.#activeResidencies,
+    };
   }
 
   #beginCompositionDrain(): void {

--- a/packages/runtime-host/src/server/index.ts
+++ b/packages/runtime-host/src/server/index.ts
@@ -12,3 +12,4 @@ export {
   type RuntimeHostCandidateOptions,
   type RuntimeHostCandidateResult,
 } from './candidate.js';
+export { createUnavailableDomainOperationHandlers } from './operation-dispatcher.js';

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -11,6 +11,7 @@ import {
   type ResponseFrame,
   type ResponseFrameFor,
 } from '../protocol/index.js';
+import { HOST_BOOTSTRAP_OPERATION_SPECS } from '../protocol/host-status.js';
 
 export interface ConnectionContext {
   hostEpoch: string;
@@ -33,7 +34,7 @@ export type OperationHandlerMap = {
   [K in OperationKey]: OperationHandler<K>;
 };
 
-export type DomainOperationKey = Exclude<OperationKey, 'host.status'>;
+export type DomainOperationKey = Exclude<OperationKey, keyof typeof HOST_BOOTSTRAP_OPERATION_SPECS>;
 export type TurnOperationKey = Extract<
   OperationKey,
   | 'turn.start'
@@ -187,7 +188,7 @@ export function composeOperationHandlers(
 export function createUnavailableDomainOperationHandlers(): DomainOperationHandlerMap {
   const handlers: Partial<DomainOperationHandlerMap> = {};
   for (const operation of Object.keys(HOST_OPERATION_SPECS) as OperationKey[]) {
-    if (operation === 'host.status') continue;
+    if (Object.hasOwn(HOST_BOOTSTRAP_OPERATION_SPECS, operation)) continue;
     const errors = HOST_OPERATION_SPECS[operation].errors as readonly HostOperationErrorCode[];
     if (!errors.includes('operation_unavailable')) {
       throw new Error(`${operation} does not declare operation_unavailable`);

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -42,6 +42,11 @@ export interface ToastAction {
   onClick(): void;
 }
 
+export interface ToastErrorAction {
+  label: string;
+  onClick(input: Pick<ToastInput, 'title' | 'description'>): void;
+}
+
 export interface ToastInput {
   title: string;
   description?: string;
@@ -83,15 +88,15 @@ interface ActiveConfirm {
 const DEFAULT_DURATION = 4000;
 const ToastContext = createContext<ToastApi | null>(null);
 
-export function ToastProvider(props: { children: ReactNode }) {
+export function ToastProvider(props: { children: ReactNode; errorAction?: ToastErrorAction }) {
   return (
     <LayerProvider toast={{ position: 'bottomEnd' }}>
-      <ToastController>{props.children}</ToastController>
+      <ToastController errorAction={props.errorAction}>{props.children}</ToastController>
     </LayerProvider>
   );
 }
 
-function ToastController(props: { children: ReactNode }) {
+function ToastController(props: { children: ReactNode; errorAction?: ToastErrorAction }) {
   const showToast = useAstryxToast();
   const [confirmState, setConfirmState] = useState<ActiveConfirm | null>(null);
   const activeConfirmRef = useRef<PendingConfirm | null>(null);
@@ -104,22 +109,37 @@ function ToastController(props: { children: ReactNode }) {
       const id = `t${++idSeed.current}`;
       let dismissCurrent: ToastDismissFn | undefined;
       const duration = input.duration ?? DEFAULT_DURATION;
+      const errorAction = props.errorAction;
+      const actions = [
+        input.action,
+        input.variant === 'error' && errorAction
+          ? {
+              label: errorAction.label,
+              onClick: () => errorAction.onClick(input),
+            }
+          : undefined,
+      ].filter((action): action is ToastAction => action !== undefined);
       dismissCurrent = showToast({
         uniqueID: id,
         body: <ToastBody input={input} />,
         type: input.variant === 'error' ? 'error' : 'info',
         isAutoHide: duration > 0,
         autoHideDuration: duration > 0 ? duration : DEFAULT_DURATION,
-        endContent: input.action ? (
-          <AstryxButton
-            variant="ghost"
-            size="sm"
-            label={input.action.label}
-            onClick={() => {
-              input.action?.onClick();
-              dismissCurrent?.();
-            }}
-          />
+        endContent: actions.length > 0 ? (
+          <HStack gap={1}>
+            {actions.map((action, index) => (
+              <AstryxButton
+                key={`${index}:${action.label}`}
+                variant="ghost"
+                size="sm"
+                label={action.label}
+                onClick={() => {
+                  action.onClick();
+                  dismissCurrent?.();
+                }}
+              />
+            ))}
+          </HStack>
         ) : undefined,
         onHide: () => {
           dismissByIdRef.current.delete(id);
@@ -128,7 +148,7 @@ function ToastController(props: { children: ReactNode }) {
       dismissByIdRef.current.set(id, dismissCurrent);
       return id;
     },
-    [showToast],
+    [props.errorAction, showToast],
   );
 
   const dismiss = useCallback((id: string) => {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- add a Copy diagnostics action to every Desktop error toast while preserving any existing product action
- route the top-level renderer crash surface through the same unified diagnostic report
- collect bounded, redacted Desktop main-process logs, application/build metadata, renderer context, and workspace information
- add a closed Runtime Host diagnostics operation for Host lifecycle, process environment, protocol compatibility, activity, and bounded logs
- keep the copy IPC owned by the Desktop process so client diagnostics remain available while Runtime Host is disconnected or reconnecting
- bound long error input instead of rejecting the report, and redact Node-inspected Authorization and Proxy-Authorization values before they reach the clipboard

## Verification

- `npm run test:dist --workspace @maka/core` — 808 tests passed
- `npm run test --workspace @maka/runtime-host` — 774 tests passed
- `npm run test:dist --workspace @maka/desktop` — 1,129 tests passed
- post-rebase focused diagnostics, redaction, and Runtime Host protocol regressions — 53 tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Checklist

- [x] Tests cover the user-visible and protocol boundaries without timeout-based waits
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — error surfaces can copy a unified Desktop and Runtime Host diagnostic report
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

- 为所有 Desktop 错误 Toast 增加“复制诊断信息”，并保留原有产品操作按钮
- 让顶层 Renderer 崩溃页面复用同一份统一诊断报告
- 收集经过边界限制和脱敏的 Desktop 主进程日志、应用与构建信息、Renderer 上下文及工作区信息
- 增加封闭的 Runtime Host 诊断操作，提供 Host 生命周期、进程环境、协议兼容性、活动状态与有界日志
- 让复制诊断 IPC 由 Desktop 进程长期持有，因此 Runtime Host 断线或重连期间仍可复制客户端诊断
- 对过长错误输入进行安全截断而不是拒绝整份报告，并在写入剪贴板前脱敏 Node inspect 形式的 Authorization 与 Proxy-Authorization

## 验证

- `npm run test:dist --workspace @maka/core` — 808 项测试通过
- `npm run test --workspace @maka/runtime-host` — 774 项测试通过
- `npm run test:dist --workspace @maka/desktop` — 1,129 项测试通过
- rebase 后诊断、脱敏与 Runtime Host 协议聚焦回归 — 53 项测试通过
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## 检查清单

- [x] 测试覆盖用户可见行为与协议边界，且不依赖 timeout wait
- [x] lint、format、typecheck 与受影响测试套件均在本地通过

此 PR 是否包含行为变化？

- [x] 是 — 错误界面现在可以复制统一的 Desktop 与 Runtime Host 诊断报告
- [ ] 否

</details>
