### PR TITLE
fix(storybook): filter non-component icon exports

### DIFF
--- a/packages/ui/stories/icons.stories.tsx
+++ b/packages/ui/stories/icons.stories.tsx
@@ -17,8 +17,20 @@ interface IconEntry {
   Comp: ElementType<{ size?: number | string; strokeWidth?: number | string; 'aria-hidden'?: boolean }>;
 }
 
+// The icon seam also exports shared metadata such as ICON_SIZE. Keep the story
+// self-updating without assuming every runtime export can be rendered.
+function isIconComponent(value: unknown): value is IconEntry['Comp'] {
+  return (
+    typeof value === 'function' ||
+    (typeof value === 'object' &&
+      value !== null &&
+      'render' in value &&
+      typeof value.render === 'function')
+  );
+}
+
 const LUCIDE_ICONS: IconEntry[] = Object.entries(Icons)
-  .map(([name, value]) => ({ name, Comp: value as IconEntry['Comp'] }))
+  .flatMap(([name, value]) => (isIconComponent(value) ? [{ name, Comp: value }] : []))
   .sort((a, b) => a.name.localeCompare(b.name));
 
 // Derived from BOT_BRAND, the registry BotBrandLogo itself reads. A hand-kept


### PR DESCRIPTION
#2538 added `ICON_SIZE` to `@maka/ui/icons`, so that module is no longer component-only. The icon story still cast every namespace export to `ElementType`, and production Storybook tried to render the size object as a component.

This keeps the catalog self-updating, but filters the namespace to function and `forwardRef` component shapes before rendering it.

Tested with:

- Desktop Storybook typecheck
- production Storybook build
- full Storybook smoke: 48 manifest checks and 101 catalog stories

Fixes #2541

<details>
<summary>中文对照</summary>

#2538 在 `@maka/ui/icons` 中加入了 `ICON_SIZE`，因此这个模块不再只导出组件。图标 Story 仍把命名空间里的每个导出都强制当成 `ElementType`，导致生产 Storybook 把尺寸对象作为组件渲染。

本次修改保留图标目录的自动追踪，只在渲染前接收函数组件和 `forwardRef` 组件形态。

已验证 Desktop Storybook 类型检查、生产构建，以及完整 Storybook smoke（48 个 manifest 检查、101 个 catalog Story）。

</details>
