### PR TITLE
fix(desktop): place daily review selector below trigger

### DIFF
--- a/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
@@ -146,6 +146,7 @@ export function DailyReviewSettingsPage(props: { connections: readonly LlmConnec
             label={copy.model}
             isLabelHidden
             options={modelOptions}
+            placement="below"
             isDisabled={formDisabled || modelOptions.length === 0}
             onChange={(value) => void patchConfig('modelKey', {
               modelKey: value === DAILY_REVIEW_DEFAULT_MODEL_VALUE ? '' : value,


### PR DESCRIPTION
## Summary

At the 480px window floor, the Daily Review analysis-model selector used Astryx Selector’s default selected-item overlay behavior, so the open popover could cover its trigger and violate the existing Storybook bounds contract.

Set the selector’s existing `placement` seam to `below`, matching the settings-row selector layout already used by the default permission control. This keeps the popup within the row/page bounds without shared CSS or parallel positioning logic.

## Verification

- Existing `product-settings-pages--daily-review-model-selector-open-narrow @ floor` geometry reproduced before the fix: trigger `446.98..466.98`, popover `442.98..580.98` (overlap)
- Focused built-Storybook smoke with the locked Playwright Chromium passed at 480px in light and dark: popup `472.98..610.98`, below trigger `446.98..466.98`
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run typecheck`
- `npm run format:check`
- Full `storybook-visual-smoke.mjs` run reached and passed both target floor jobs on the baseline build; the overall run still reports the unrelated pre-existing `design-system-icons--lucide-icons` catalog render failure

## Checklist

- [x] Tests cover the change and fail without it
- [x] Format, typecheck and the affected Storybook smoke pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
