### PR TITLE
fix(desktop): stabilize Runtime Host Session lifecycle races

### DIFF
--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -709,10 +709,6 @@ test('side chat recovers from failures and preserves its draft', async ({
     failPanel.getByText(/Fake backend received: retry after deterministic network failure/),
   ).toBeVisible();
 
-  await failComposer.fill('__e2e_error__:auth');
-  await failComposer.press('Enter');
-  await expect(failPanel.locator('.maka-quote-companion-error')).toHaveText('鉴权失败');
-
   await failComposer.fill('__e2e_wait_for_steering__');
   await failComposer.press('Enter');
   const activeSideTab = page.locator(
@@ -726,7 +722,6 @@ test('side chat recovers from failures and preserves its draft', async ({
   await expect
     .poll(async () => (await page.evaluate(() => window.maka.sessions.list())).length)
     .toBe(1);
-  await expect(page.getByText('鉴权失败')).toHaveCount(0);
 
   // Draft survival across collapse and launcher navigation.
   await waitForSourceSessionToSettle(page);

--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -711,6 +711,10 @@ test('side chat recovers from failures and preserves its draft', async ({
 
   await failComposer.fill('__e2e_error__:auth');
   await failComposer.press('Enter');
+  await expect(failPanel.locator('.maka-quote-companion-error')).toHaveText('鉴权失败');
+
+  await failComposer.fill('__e2e_wait_for_steering__');
+  await failComposer.press('Enter');
   const activeSideTab = page.locator(
     '.maka-workbar-tab[data-running][data-workbar-tab-id^="side-chat:"]',
   );

--- a/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
@@ -17,6 +17,7 @@ import {
   applyCompanionInteractionEvent,
   cleanupCompanionCopy,
   createCompanionDismissalGuard,
+  dismissCompanionCopy,
   companionRunEventEffect,
   deriveCompanionComposerState,
   isCompanionTurnTerminal,
@@ -58,6 +59,7 @@ interface FakeControl {
 
 function makeApi(control: FakeControl = {}) {
   const calls = {
+    lifecycle: [] as string[],
     removed: [] as string[],
     sent: [] as {
       id: string;
@@ -95,12 +97,16 @@ function makeApi(control: FakeControl = {}) {
       return forked;
     },
     cleanupSessionCopy: async (id) => {
+      calls.lifecycle.push(`cleanup:${id}`);
       calls.removed.push(id);
       if (control.cleanupThrows) throw new Error('cleanup failed');
     },
     abandonSessionCopy: async (id) => {
       calls.abandoned.push(id);
       if (control.abandonThrows) throw new Error('abandon acknowledgement lost');
+    },
+    stop: async (id) => {
+      calls.lifecycle.push(`stop:${id}`);
     },
     send: async (id, cmd) => {
       calls.sent.push({ id, cmd });
@@ -171,6 +177,19 @@ describe('companion dismissal guard', () => {
 
     assert.equal(replayedCleanup(), false);
     assert.equal(activeCleanup(), true);
+  });
+
+  it('stops a live companion before dismissing its durable copy', async () => {
+    const { api, calls } = makeApi();
+
+    assert.equal(
+      await dismissCompanionCopy(api, 'source-session', 'panel-1', 'companion-session'),
+      true,
+    );
+    assert.deepEqual(calls.lifecycle, [
+      'stop:companion-session',
+      'cleanup:companion-session',
+    ]);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -211,6 +211,35 @@ test('merges a configuration patch into each fresh CAS projection', async () => 
   );
 });
 
+test('retries a Session update through transient revision churn', async () => {
+  const responses: unknown[] = [];
+  for (let revision = 10; revision < 14; revision += 1) {
+    responses.push(
+      { kind: 'session', session: session('session-1', revision) },
+      {
+        kind: 'revision_conflict',
+        expectedRevision: revision,
+        actualRevision: revision + 1,
+      },
+    );
+  }
+  responses.push(
+    { kind: 'session', session: session('session-1', 14) },
+    {
+      kind: 'committed',
+      session: session('session-1', 15, { collaborationMode: 'plan' }),
+    },
+  );
+  const { client } = clientWithResponses(responses);
+
+  const updated = await client.updateSessionConfiguration('session-1', {
+    collaborationMode: 'plan',
+  });
+
+  assert.equal(updated.revision, 15);
+  assert.equal(updated.collaborationMode, 'plan');
+});
+
 test('rebuilds a Runtime Policy mutation from each fresh CAS projection', async () => {
   const initial = createDefaultRuntimePolicy();
   const concurrent = {

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -97,6 +97,7 @@ import {
 } from "@maka/runtime-host/protocol";
 
 const MAX_OPTIMISTIC_ATTEMPTS = 3;
+const MAX_SESSION_REVISION_ATTEMPTS = 8;
 const MAX_PRICING_SNAPSHOT_ATTEMPTS = 3;
 
 export type DesktopSessionConfigurationPatch = Partial<SessionConfiguration>;
@@ -730,7 +731,7 @@ export class DesktopRuntimeHostClient {
   }
 
   async removeSession(sessionId: string): Promise<void> {
-    for (let attempt = 0; attempt < MAX_OPTIMISTIC_ATTEMPTS; attempt += 1) {
+    for (let attempt = 0; attempt < MAX_SESSION_REVISION_ATTEMPTS; attempt += 1) {
       const current = await this.#requireSession(sessionId);
       const result = await this.#request("session.remove", {
         sessionId,
@@ -1379,7 +1380,7 @@ export class DesktopRuntimeHostClient {
     sessionId: string,
     update: (current: SessionCatalogProjection) => Promise<SessionUpdateResult>,
   ): Promise<SessionCatalogProjection> {
-    for (let attempt = 0; attempt < MAX_OPTIMISTIC_ATTEMPTS; attempt += 1) {
+    for (let attempt = 0; attempt < MAX_SESSION_REVISION_ATTEMPTS; attempt += 1) {
       const current = await this.#requireSession(sessionId);
       const result = await update(current);
       if (result.kind === "committed")

--- a/apps/desktop/src/renderer/quote-companion-core.ts
+++ b/apps/desktop/src/renderer/quote-companion-core.ts
@@ -48,6 +48,7 @@ export interface CompanionSessionApi {
   ): Promise<SessionSummary>;
   cleanupSessionCopy(sessionId: string): Promise<void>;
   abandonSessionCopy(sessionId: string): Promise<void>;
+  stop(sessionId: string): Promise<void>;
   send(
     sessionId: string,
     command: {
@@ -168,6 +169,16 @@ export async function cleanupCompanionCopy(
   } catch {
     return false;
   }
+}
+
+export async function dismissCompanionCopy(
+  api: CompanionSessionApi,
+  sourceSessionId: string,
+  panelId: string,
+  companionSessionId: string,
+): Promise<boolean> {
+  await api.stop(companionSessionId).catch(() => undefined);
+  return cleanupCompanionCopy(api, sourceSessionId, panelId, companionSessionId);
 }
 
 /**

--- a/apps/desktop/src/renderer/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/use-quote-companion.ts
@@ -24,8 +24,8 @@ import type { RendererIngestInput } from '../preload/bridge-contract.js';
 import {
   abandonPendingCompanionCopy,
   applyCompanionInteractionEvent,
-  cleanupCompanionCopy,
   createCompanionDismissalGuard,
+  dismissCompanionCopy,
   companionRunEventEffect,
   deriveCompanionComposerState,
   ensureCompanionFork,
@@ -307,7 +307,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         const sourceSessionId = sourceSessionIdRef.current;
         const id = companionIdRef.current ?? pendingForkIdRef.current;
         if (id && sourceSessionId) {
-          void cleanupCompanionCopy(
+          void dismissCompanionCopy(
             window.maka.sessions,
             sourceSessionId,
             panelId,


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Stabilize two Desktop lifecycle paths that could race with Runtime Host Session revision changes:

- stop an active side-conversation Turn before retiring its durable Session copy, instead of relying on later catalog reads to recover cleanup;
- allow Session updates and removals a larger but still bounded CAS resynchronization window, rebuilding each request from a fresh Host projection.

The side-chat E2E now dismisses a Turn that deliberately remains active, so it verifies the production stop-before-retire contract. The Session client regression crosses four consecutive revision conflicts before committing, which reproduces the window that exceeded the previous three-attempt bound.

Fixes #2543
Fixes #2545

## Verification

- `npx biome check` on all changed files
- `npm run typecheck --workspace @maka/desktop --if-present`
- `npm run build:test`
- focused Desktop unit tests: 50 passed
- complete Desktop unit suite: 1,131 passed
- affected Desktop E2E tests: 20/20 repeated runs passed, then 2/2 passed after rebasing onto current `main`

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 摘要

修复两条会与 Runtime Host Session revision 变化发生竞态的 Desktop 生命周期路径：

- 关闭侧边对话时，先停止仍在运行的 Turn，再退休其持久化 Session 副本，不再依赖后续 catalog 读取碰巧驱动清理；
- 为 Session 更新与删除提供更大的、但仍有界的 CAS 重同步窗口，并在每次重试时从 Host 的最新投影重建请求。

侧边对话 E2E 现在会关闭一个刻意保持运行的 Turn，因此能验证生产路径的“先停止、后退休”契约。Session client 回归测试则会连续经历四次 revision conflict 后再提交，覆盖原三次尝试上限不足的窗口。

修复 #2543
修复 #2545

## 验证

- 对全部改动文件运行 `npx biome check`
- `npm run typecheck --workspace @maka/desktop --if-present`
- `npm run build:test`
- Desktop 定点单测：50 项通过
- Desktop 完整单测：1,131 项通过
- 相关 Desktop E2E：重复运行 20/20 通过；rebase 到最新 `main` 后再次运行 2/2 通过

## 检查清单

- [x] 测试覆盖改动，并会在缺少修复时失败
- [x] lint、format、typecheck 与相关测试套件均已在本地通过

此 PR 是否包含行为变化？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
