### PR TITLE
fix(desktop): bound settings selector menus

### DIFF
--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -128,6 +128,16 @@
   max-width: var(--settings-row-end-cap);
 }
 
+/* A Selector layer is min-width: anchor-size(width), but its intrinsic option
+   width may still make it wider than the right-aligned end slot. The selected
+   font decides that intrinsic width, so a label that fits on macOS can push
+   the left-aligned top-layer popover past the page edge on Linux. The setting
+   row owns the available inline space: cap its listbox layers to their anchor
+   and let the Selector's Item truncate long labels inside that stable width. */
+.settingsRowEnd [popover]:has([role="listbox"]) {
+  max-width: anchor-size(width);
+}
+
 @container settings-rows (max-width: 460px) {
   .settingsReadOnlyValue,
   .settingsRowEnd {

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -955,23 +955,47 @@ function assertDailyReviewSettingsBounds(
   const withinHorizontally = (inner: DOMRect, outer: DOMRect) =>
     inner.left >= outer.left - 1 && inner.right <= outer.right + 1;
   const timeRect = time.getBoundingClientRect();
+  const timeFormRect = timeForm.getBoundingClientRect();
   const selectorRect = selector.getBoundingClientRect();
+  const selectorFormRect = selectorForm.getBoundingClientRect();
   const popoverRect = popover.getBoundingClientRect();
   const pageRect = page.getBoundingClientRect();
   const doesNotCoverTrigger =
     popoverRect.top >= selectorRect.bottom - 1
     || popoverRect.bottom <= selectorRect.top + 1;
-  const valid =
-    withinHorizontally(timeRect, timeForm.getBoundingClientRect())
-    && withinHorizontally(selectorRect, selectorForm.getBoundingClientRect())
-    && popoverRect.width > 0
-    && popoverRect.height > 0
-    && withinHorizontally(popoverRect, pageRect)
-    && popoverRect.left >= -1
-    && popoverRect.right <= window.innerWidth + 1
-    && doesNotCoverTrigger;
-  if (!valid) {
-    throw new Error(`Daily Review controls overflow at ${window.innerWidth}px`);
+  const checks = {
+    timeWithinRow: withinHorizontally(timeRect, timeFormRect),
+    selectorWithinRow: withinHorizontally(selectorRect, selectorFormRect),
+    popoverHasSize: popoverRect.width > 0 && popoverRect.height > 0,
+    popoverWithinPage: withinHorizontally(popoverRect, pageRect),
+    popoverWithinViewport:
+      popoverRect.left >= -1 && popoverRect.right <= window.innerWidth + 1,
+    popoverDoesNotCoverTrigger: doesNotCoverTrigger,
+  };
+  const failedChecks = Object.entries(checks)
+    .filter(([, passed]) => !passed)
+    .map(([name]) => name);
+  if (failedChecks.length > 0) {
+    const rect = (value: DOMRect) => ({
+      left: value.left,
+      right: value.right,
+      top: value.top,
+      bottom: value.bottom,
+      width: value.width,
+      height: value.height,
+    });
+    throw new Error(`Daily Review controls overflow: ${JSON.stringify({
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      failedChecks,
+      rects: {
+        time: rect(timeRect),
+        timeForm: rect(timeFormRect),
+        selector: rect(selectorRect),
+        selectorForm: rect(selectorFormRect),
+        popover: rect(popoverRect),
+        page: rect(pageRect),
+      },
+    })}`);
   }
 }
 


### PR DESCRIPTION
## Summary

Keep Selector listbox layers inside settings rows by capping each popover to its anchor width. The existing narrow Daily Review story now reports named geometry failures and rectangles so future regressions remain actionable.

GitHub's Linux font metrics made the model option's intrinsic popover `144.1875px` wide while its anchor was `134px`. Because the layer aligns to the anchor's left edge, its right edge reached `454.1875px`, past the settings page boundary at `452px`. The same label measured narrower locally, which hid the overflow.

Refs #2541

## Verification

- GitHub Storybook RED: `popoverWithinPage`; popover right `454.1875`, page right `452`.
- Causal local probe with widened option text: disabling the new cap expands the popover from the `134px` anchor to `199.359375px`; enabling it keeps both at `134px`.
- `npx biome check apps/desktop/src/renderer/styles/settings/rows.css apps/desktop/stories/settings/settings-pages.stories.tsx`
- `npm --workspace @maka/desktop run typecheck:stories`
- `npm --workspace @maka/desktop run build-storybook`
- Full local Storybook smoke: both Daily Review floor checks pass; only the known icon catalog failure fixed by #2544 remains.

## Dependency

- [ ] #2544 must merge (or this branch must rebase onto it) before the complete Storybook job can be green.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
