### PR TITLE
fix(ci): run Storybook for UI source changes

### DIFF
--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -31,11 +31,10 @@ const DEDICATED_WORKSPACE_LANES = new Set(['packages/runtime-host', 'packages/he
 // evidence that the run it drives still works.
 const E2E_DRIVING_SCRIPTS = new Set(['scripts/audit-alignment.mjs']);
 
-// Scripts / paths that can break Storybook without touching product ship
-// gates. Storybook is a catalog harness, not the product: typecheck already
-// typechecks stories and checks annotations, unit/e2e cover product behavior.
-// Running build+smoke on every desktop/ui PR taxes CI for almost no unique
-// signal — only the catalog and its wiring need this job.
+// Scripts / paths that can break the built Storybook catalog. Product stories
+// mount the UI package and desktop renderer, so runtime export/render changes
+// there belong to this surface even when no story file changes. Main-process
+// and e2e-only desktop changes stay outside it.
 const STORYBOOK_DRIVING_SCRIPTS = new Set(['scripts/storybook-visual-smoke.mjs']);
 
 // .storybook/preview.tsx imports THEME_PALETTES from this module. Narrower
@@ -44,10 +43,14 @@ const STORYBOOK_CORE_SETTINGS = 'packages/core/src/settings.ts';
 
 function isStorybookPath(path) {
   if (STORYBOOK_DRIVING_SCRIPTS.has(path) || path === STORYBOOK_CORE_SETTINGS) return true;
+  if (path === 'apps/desktop/src/renderer' || path.startsWith('apps/desktop/src/renderer/'))
+    return true;
   if (path === 'apps/desktop/.storybook' || path.startsWith('apps/desktop/.storybook/'))
     return true;
   if (path === 'apps/desktop/stories' || path.startsWith('apps/desktop/stories/')) return true;
-  // packages/ui also ships its own story tree (see .storybook/main.ts).
+  // packages/ui ships both the primitives mounted by product stories and its
+  // own story tree (see .storybook/main.ts).
+  if (path === 'packages/ui/src' || path.startsWith('packages/ui/src/')) return true;
   if (path === 'packages/ui/stories' || path.startsWith('packages/ui/stories/')) return true;
   return false;
 }

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -11,12 +11,19 @@ test('impact planning distinguishes docs, UI, and backend changes', () => {
 
   const ui = planTests(['packages/ui/src/button.tsx'], { graph });
   assert.equal(ui.e2e, true);
-  // Product UI work is not a Storybook catalog change — typecheck/unit/e2e own it.
-  assert.equal(ui.storybook, false);
+  // Product UI is mounted by the catalog. Runtime export and render changes can
+  // break Storybook even when its story files themselves are unchanged.
+  assert.equal(ui.storybook, true);
   assert.equal(ui.scriptMode, 'none');
   assert.deepEqual(ui.workspaces, ['packages/ui', 'apps/desktop']);
 
-  // Ordinary desktop product files must not drag Storybook Chromium.
+  // Renderer code is mounted by product stories; main-process and e2e files are not.
+  assert.equal(
+    planTests(['apps/desktop/src/renderer/settings/daily-review-settings-page.tsx'], {
+      graph,
+    }).storybook,
+    true,
+  );
   assert.equal(planTests(['apps/desktop/src/main/main.ts'], { graph }).storybook, false);
   assert.equal(planTests(['apps/desktop/e2e/settings.spec.ts'], { graph }).storybook, false);
 


### PR DESCRIPTION
## Summary

Run the Storybook build and smoke job when `packages/ui/src/**` or `apps/desktop/src/renderer/**` changes. Product stories mount both source surfaces, so runtime export and render regressions can break the catalog without touching a story file.

The previous catalog-only selector let #2538 add the non-component `ICON_SIZE` export without running the icon catalog, and let #2546 change the Daily Review selector geometry without running its narrow layout contract. A later unrelated full-suite change discovered both failures on `main`.

Refs #2541

## Verification

- RED: `node --test scripts/ci-test-plan.test.mjs` failed because UI and renderer source changes returned `storybook=false`.
- GREEN: `node --test scripts/ci-test-plan.test.mjs` — 6/6 pass.
- `npx biome check scripts/ci-test-plan.mjs scripts/ci-test-plan.test.mjs`

## Dependencies

This draft intentionally exposes the two Storybook failures already present on `main`:

- [ ] #2544 filters non-component icon exports.
- [ ] #2556 bounds settings Selector menus across font metrics.
- [ ] Rebase after both fixes merge and verify the newly selected Storybook job is green.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
