### PR TITLE
fix(ui): keep the icon gallery renderable when icons.tsx exports a non-component

### DIFF
--- a/packages/ui/stories/icons.stories.tsx
+++ b/packages/ui/stories/icons.stories.tsx
@@ -17,7 +17,25 @@ interface IconEntry {
   Comp: ElementType<{ size?: number | string; strokeWidth?: number | string; 'aria-hidden'?: boolean }>;
 }
 
+/**
+ * `icons.tsx` is not only components: it also owns `ICON_SIZE`, the sizing
+ * ladder every call site reads (#2538). Enumerating the module and rendering
+ * whatever comes back therefore mounts a plain object as an element, which
+ * React rejects outright ("element type is invalid", error #130) and which
+ * takes the whole story down with it.
+ *
+ * Keep the enumeration — a hand-kept list is what would let a newly added icon
+ * go unrendered — and filter on what can actually be mounted instead. Lucide's
+ * icons arrive as `forwardRef` objects rather than plain functions, so the test
+ * is React's own element-type marker, not `typeof value === 'function'`.
+ */
+function isRenderableIcon(value: unknown): boolean {
+  if (typeof value === 'function') return true;
+  return typeof value === 'object' && value !== null && '$$typeof' in value;
+}
+
 const LUCIDE_ICONS: IconEntry[] = Object.entries(Icons)
+  .filter(([, value]) => isRenderableIcon(value))
   .map(([name, value]) => ({ name, Comp: value as IconEntry['Comp'] }))
   .sort((a, b) => a.name.localeCompare(b.name));
 


### PR DESCRIPTION
## What

`Design System/Icons` currently throws on mount, which fails the Storybook smoke run.

The gallery enumerates `icons.tsx` and mounts every export:

```tsx
const LUCIDE_ICONS = Object.entries(Icons)
  .map(([name, value]) => ({ name, Comp: value as IconEntry['Comp'] }))
```

That held while the module was only components. #2538 added `ICON_SIZE` — the sizing ladder (`meta` / `control` / `chrome` / `empty` / `plate`) call sites read — so the story now mounts a plain object as an element. React rejects it outright:

```
[design-system-icons--lucide-icons @ catalog] console.error:
Error: Minified React error #130 (element type is invalid: got object)
```

Enumerated at runtime, it is the only one: **112 exports, 1 non-component**.

## The fix

Keep the enumeration and filter on what can actually be mounted. The enumeration is deliberate — the story's own comment on `BOT_BRAND_PROVIDERS` makes the argument, and it applies here too: a hand-kept list is satisfied by any subset, so a newly added icon would silently never render.

Lucide's icons arrive as `forwardRef` objects rather than plain functions, so the test is React's own element-type marker, not `typeof value === 'function'`.

## Why CI did not catch it

The `storybook` job is path-gated (`needs.changes.outputs.storybook == 'true'`). On the runs where it mattered it was `skipped`, so main is green with this story broken — I hit it from a branch that does trip the gate.

## Verification

`npm --workspace @maka/desktop run build-storybook && npm --workspace @maka/desktop run smoke:storybook`

- before: `✗ design-system-icons--lucide-icons` → `1 story check(s) failed`, exit 1
- after: `✓ design-system-icons--lucide-icons` → `Product Storybook smoke passed (48 manifest check(s), 101 catalog render(s))`, exit 0

Split out of [#1874](https://github.com/maka-agent/maka-agent/pull/1874) rather than folded into it — it is unrelated to that feature and shouldn't need its review.
