### PR TITLE
feat(runtime): enable interactive shell controls for implementation agents

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -82,6 +82,10 @@ const SUMMARY_TEXT = '## Goal\nContinue hosted real-model execution.';
 const CLIENT_CAPABILITY_RESULT_TEXT = 'HOSTED_CLIENT_CAPABILITY_RESULT_SENTINEL';
 const CHILD_AGENT_RESULT_TEXT = 'HOSTED_CHILD_AGENT_RESULT_SENTINEL';
 const WEB_RESEARCH_CHILD_RESULT_TEXT = 'HOSTED_WEB_RESEARCH_RESULT_SENTINEL';
+const MAX_IMPLEMENTATION_CHILD_PTY_READS = 5;
+const MIN_IMPLEMENTATION_CHILD_REQUESTS = 6;
+const MAX_IMPLEMENTATION_CHILD_REQUESTS =
+  MIN_IMPLEMENTATION_CHILD_REQUESTS + MAX_IMPLEMENTATION_CHILD_PTY_READS - 1;
 const execFileAsync = promisify(execFile);
 
 test('backend creation aborts a stalled canonical connection read', async () => {
@@ -1326,8 +1330,20 @@ test('production Host publishes and retires an implementation child patch', asyn
   try {
     await mkdir(project);
     await writeFile(join(project, 'README.md'), '# Hosted child fixture\n');
+    await writeFile(
+      join(project, 'pty-child.mjs'),
+      [
+        "process.stdin.setEncoding('utf8');",
+        "process.stdout.write('READY\\n');",
+        "process.stdin.once('data', (data) => {",
+        '  process.stdout.write(`CHILD_PTY_OK:${data.trim()}\\n`);',
+        '  setTimeout(() => {}, 30_000);',
+        '});',
+        '',
+      ].join('\n'),
+    );
     await git(project, 'init', '--initial-branch=main');
-    await git(project, 'add', 'README.md');
+    await git(project, 'add', 'README.md', 'pty-child.mjs');
     await git(
       project,
       '-c',
@@ -1419,7 +1435,11 @@ test('production Host publishes and retires an implementation child patch', asyn
     );
 
     const requests = provider.requests.filter((request) => request.body.stream === true);
-    assert.equal(requests.length, 5);
+    assert.ok(
+      requests.length >= MIN_IMPLEMENTATION_CHILD_REQUESTS + 3 &&
+        requests.length <= MAX_IMPLEMENTATION_CHILD_REQUESTS + 3,
+      JSON.stringify(providerRequestTrace(requests)),
+    );
     assert.ok(toolNames(requests[0]?.body).includes('load_tools'));
     assert.equal(toolNames(requests[0]?.body).includes('agent_spawn'), false);
     assert.ok(toolNames(requests[1]?.body).includes('agent_spawn'));
@@ -1427,17 +1447,26 @@ test('production Host publishes and retires an implementation child patch', asyn
       'local_read',
       'implementation',
     ]);
-    assert.deepEqual(toolNames(requests[2]?.body), [
+    const childToolNames = [
       'ArchiveRead',
       'Bash',
       'Edit',
       'Glob',
       'Grep',
       'Read',
+      'StopBackgroundTask',
       'Write',
-    ]);
-    assert.deepEqual(toolNames(requests[3]?.body), toolNames(requests[2]?.body));
-    assert.ok(toolNames(requests[4]?.body).includes('agent_spawn'));
+      'WriteStdin',
+    ];
+    const childRequests = requests.slice(2, -1);
+    assert.ok(
+      childRequests.length >= MIN_IMPLEMENTATION_CHILD_REQUESTS &&
+        childRequests.length <= MAX_IMPLEMENTATION_CHILD_REQUESTS,
+    );
+    for (const request of childRequests) {
+      assert.deepEqual(toolNames(request.body), childToolNames);
+    }
+    assert.ok(toolNames(requests.at(-1)?.body).includes('agent_spawn'));
 
     const sessions = await execution.sessionStore.listForRecovery();
     const child = sessions.find((session) => session.id !== parent.id);
@@ -1460,10 +1489,10 @@ test('production Host publishes and retires an implementation child patch', asyn
     );
     const artifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
     const childArtifacts = await artifacts.listTurnArtifacts(child.id, childRuns[0]!.turnId);
-    assert.equal(childArtifacts.length, 4);
+    assert.equal(childArtifacts.length, childRequests.length + 2);
     assert.equal(
       childArtifacts.filter((artifact) => artifact.source === 'provider_request_capture').length,
-      2,
+      childRequests.length,
     );
     assert.ok(
       childArtifacts.some(
@@ -2876,21 +2905,35 @@ function toolNames(body: Record<string, unknown> | undefined): string[] {
 
 function providerRequestTrace(requests: readonly ProviderRequest[]): readonly unknown[] {
   return requests.map((request) => {
-    const messages = Array.isArray(request.body.messages) ? request.body.messages : [];
-    const lastToolResult = messages
-      .filter(
-        (message): message is Record<string, unknown> =>
-          Boolean(message) && typeof message === 'object' && message.role === 'tool',
-      )
-      .at(-1)?.content;
-    const serializedToolResult =
-      typeof lastToolResult === 'string' ? lastToolResult : JSON.stringify(lastToolResult);
     return {
       stream: request.body.stream,
       tools: toolNames(request.body),
-      lastToolResult: serializedToolResult?.slice(0, 1_000),
+      lastToolResult: latestToolResultText(request.body)?.slice(0, 1_000),
     };
   });
+}
+
+function latestToolResultText(body: Record<string, unknown>): string | undefined {
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  const content = messages
+    .filter(
+      (message): message is Record<string, unknown> =>
+        Boolean(message) && typeof message === 'object' && message.role === 'tool',
+    )
+    .at(-1)?.content;
+  return typeof content === 'string'
+    ? content
+    : content === undefined
+      ? undefined
+      : JSON.stringify(content);
+}
+
+function requireLatestToolResult(body: Record<string, unknown>): Record<string, unknown> {
+  const serialized = latestToolResultText(body);
+  assert.ok(serialized, 'provider fixture expected a tool result in model history');
+  const result: unknown = JSON.parse(serialized);
+  assert.ok(result && typeof result === 'object' && !Array.isArray(result));
+  return result as Record<string, unknown>;
 }
 
 function toolParameterEnum(
@@ -2906,6 +2949,12 @@ function toolParameterEnum(
   }) as { function?: { parameters?: { properties?: Record<string, unknown> } } } | undefined;
   const schema = tool?.function?.parameters?.properties?.[property];
   return schema && typeof schema === 'object' ? (schema as { enum?: unknown }).enum : undefined;
+}
+
+function requireRuntimeResourceRef(body: Record<string, unknown>): string {
+  const ref = JSON.stringify(body).match(/maka:\/\/runtime\/background-tasks\/[A-Za-z0-9_-]+/)?.[0];
+  assert.ok(ref, 'provider fixture expected a background-task ref in model history');
+  return ref;
 }
 
 async function git(cwd: string, ...args: string[]): Promise<string> {
@@ -2936,7 +2985,12 @@ type ProviderFlow =
       readonly groupId: string;
       readonly toolName: string;
     }
-  | { readonly kind: 'child_agent' | 'implementation_child_agent' }
+  | { readonly kind: 'child_agent' }
+  | {
+      readonly kind: 'implementation_child_agent';
+      ptyReadCount: number;
+      stopRequested: boolean;
+    }
   | { readonly kind: 'agent_graph'; readonly scenario: AgentGraphProviderScenario };
 
 async function startProvider(): Promise<{
@@ -2971,7 +3025,7 @@ async function startProvider(): Promise<{
     },
     configureImplementationChildAgentFlow: () => {
       if (flow.kind !== 'default') throw new Error('Provider flow is already configured');
-      flow = { kind: 'implementation_child_agent' };
+      flow = { kind: 'implementation_child_agent', ptyReadCount: 0, stopRequested: false };
     },
     configureAgentGraphFlow: () => {
       if (flow.kind !== 'default') throw new Error('Provider flow is already configured');
@@ -3087,7 +3141,9 @@ async function handleProviderRequest(
       'Glob',
       'Grep',
       'Read',
+      'StopBackgroundTask',
       'Write',
+      'WriteStdin',
     ]);
     respondProviderToolCall(response, streamRequestIndex, 'Write', {
       path: 'implementation.txt',
@@ -3096,6 +3152,57 @@ async function handleProviderRequest(
     return;
   }
   if (flow.kind === 'implementation_child_agent' && streamRequestIndex === 4) {
+    respondProviderToolCall(response, streamRequestIndex, 'Bash', {
+      command: 'node pty-child.mjs',
+      run_in_background: true,
+      pty: true,
+    });
+    return;
+  }
+  if (flow.kind === 'implementation_child_agent' && streamRequestIndex === 5) {
+    respondProviderToolCall(response, streamRequestIndex, 'WriteStdin', {
+      ref: requireRuntimeResourceRef(body),
+      actions: [
+        { type: 'text', text: 'ping' },
+        { type: 'key', key: 'enter' },
+      ],
+    });
+    return;
+  }
+  if (flow.kind === 'implementation_child_agent' && streamRequestIndex === 6) {
+    flow.ptyReadCount = 1;
+    respondProviderToolCall(response, streamRequestIndex, 'Read', {
+      ref: requireRuntimeResourceRef(body),
+    });
+    return;
+  }
+  if (
+    flow.kind === 'implementation_child_agent' &&
+    streamRequestIndex >= 7 &&
+    !toolNames(body).includes('agent_spawn')
+  ) {
+    const latestResult = latestToolResultText(body) ?? '';
+    if (!flow.stopRequested) {
+      if (!latestResult.includes('CHILD_PTY_OK:ping')) {
+        assert.ok(
+          flow.ptyReadCount < MAX_IMPLEMENTATION_CHILD_PTY_READS,
+          'PTY child did not publish its input response',
+        );
+        flow.ptyReadCount += 1;
+        respondProviderToolCall(response, streamRequestIndex, 'Read', {
+          ref: requireRuntimeResourceRef(body),
+        });
+        return;
+      }
+      flow.stopRequested = true;
+      respondProviderToolCall(response, streamRequestIndex, 'StopBackgroundTask', {
+        ref: requireRuntimeResourceRef(body),
+      });
+      return;
+    }
+    const stopResult = requireLatestToolResult(body);
+    assert.equal(stopResult.status, 'cancelled');
+    assert.deepEqual(stopResult.operation, { kind: 'stop', applied: true });
     respondProviderText(response, CHILD_AGENT_RESULT_TEXT);
     return;
   }

--- a/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
+++ b/packages/runtime/src/__tests__/non-cu-tool-refusal-text.test.ts
@@ -21,7 +21,6 @@ import {
   AGENT_LIST_TOOL_NAME,
   AGENT_OUTPUT_TOOL_NAME,
   AGENT_SPAWN_TOOL_NAME,
-  buildChildAgentTools,
   buildSubagentOutputTool,
   buildSubagentProjectionTools,
   buildSubagentSpawnTool,
@@ -617,43 +616,7 @@ describe('E5 — background task refs and capacity', () => {
     assert.ok(!text.includes('task-3-secret-value'), `must not echo the rejected ref: ${text}`);
   });
 
-  /**
-   * The seam the earlier version of these tests could not see.
-   *
-   * A refusal is read by whichever agent made the call, and `Bash` is on the
-   * `implementation` child list, so a child agent reaches the manager-wide cap
-   * exactly like a parent does. `buildToolsForAgentDefinition` is a strict name
-   * allowlist, so the child's schema is decided here and nowhere else. Asserting
-   * against a hand-written list of names would restate the message; asking the
-   * real builder which names a child never receives is what catches the next
-   * refusal that reaches for one.
-   */
-  const parentTools = buildBuiltinTools({
-    backgroundTasks: { stopBackgroundTask: async () => ({}) } as never,
-    ptyControls: { writeStdin: async () => ({}) } as never,
-  });
-  const childToolNames = new Set(buildChildAgentTools(parentTools).map((tool) => tool.name));
-  const parentOnlyToolNames = parentTools
-    .map((tool) => tool.name)
-    .filter((name) => !childToolNames.has(name));
-
-  function assertNamesNoToolAChildLacks(text: string): void {
-    // Guards the guard: if `Bash` ever leaves the child lists, a child can no
-    // longer reach this refusal and the assertion below stops meaning anything.
-    assert.ok(childToolNames.has('Bash'), 'a child agent must still be able to run Bash');
-    assert.ok(
-      parentOnlyToolNames.includes('StopBackgroundTask'),
-      'StopBackgroundTask must still be a parent-only tool for this test to bite',
-    );
-    for (const name of parentOnlyToolNames) {
-      assert.ok(
-        !text.includes(name),
-        `refusal names ${name}, which no child agent receives: ${text}`,
-      );
-    }
-  }
-
-  test('a full shell slot does not send the caller to a tool it may not have', async () => {
+  test('a full shell slot gives a session-independent recovery action', async () => {
     const cwd = await workspace();
     const manager = new ShellRunProcessManager({
       store: createSqliteShellRunStore(cwd),
@@ -673,14 +636,13 @@ describe('E5 — background task refs and capacity', () => {
         abortSignal: NO_ABORT,
       } as never),
     );
-    assertNamesNoToolAChildLacks(text);
     // The counters are manager-wide, so the session that hits the cap may own
     // none of the runs holding it: the move that always exists is waiting.
     assert.ok(/shared across sessions/.test(text), `must not promise an unavailable move: ${text}`);
     assert.ok(/Wait for a running background task to finish/.test(text), text);
   });
 
-  test('a full PTY slot does not send the caller to a tool it may not have', async () => {
+  test('a full PTY slot offers a non-interactive fallback', async () => {
     const cwd = await workspace();
     const manager = new ShellRunProcessManager({
       store: createSqliteShellRunStore(cwd),
@@ -701,7 +663,6 @@ describe('E5 — background task refs and capacity', () => {
         abortSignal: NO_ABORT,
       } as never),
     );
-    assertNamesNoToolAChildLacks(text);
     assert.ok(/PTY/.test(text), text);
     assert.ok(/shared across sessions/.test(text), text);
     // The one move that is both available and immediate: the same command

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -886,7 +886,7 @@ describe('SessionManager graph operator provisioning', () => {
     const manager = new SessionManager({
       store,
       backends: new BackendRegistry(),
-      childTools: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'].map(testTool),
+      childTools: IMPLEMENTATION_AGENT_DEFINITION.tools.map(testTool),
       worktreeChildExecutor: {
         isAvailable: async (input) => {
           checkedSources.push(input);
@@ -940,7 +940,7 @@ describe('SessionManager graph operator provisioning', () => {
       runStore,
       runtimeEventStore: runStore,
       backends: new BackendRegistry(),
-      childTools: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'].map(testTool),
+      childTools: IMPLEMENTATION_AGENT_DEFINITION.tools.map(testTool),
       worktreeChildExecutor: {
         isAvailable: async () => true,
         provision: async (input) => {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -281,19 +281,14 @@ describe('subagent tools', () => {
       'Write',
       'Edit',
       'Bash',
+      'WriteStdin',
+      'StopBackgroundTask',
     ]);
     expect(IMPLEMENTATION_AGENT_DEFINITION.tools.includes('WebSearch')).toBe(false);
     expect(IMPLEMENTATION_AGENT_DEFINITION.tools.includes('ExploreAgent')).toBe(false);
 
     const availability = listBuiltinAgentDefinitions({
-      tools: [
-        testCatalogTool('Read', 'read'),
-        testCatalogTool('Glob', 'read'),
-        testCatalogTool('Grep', 'read'),
-        testCatalogTool('Write', 'file_write'),
-        testCatalogTool('Edit', 'file_write'),
-        testCatalogTool('Bash', 'shell_unsafe'),
-      ],
+      tools: implementationCatalogTools(),
     }).find((definition) => definition.id === IMPLEMENTATION_AGENT_ID)?.availability;
     expect(availability).toEqual({
       status: 'unavailable',
@@ -306,14 +301,7 @@ describe('subagent tools', () => {
       Promise.resolve().then(() =>
         assertAgentDefinitionRunnable({
           definition: IMPLEMENTATION_AGENT_DEFINITION,
-          tools: [
-            testCatalogTool('Read', 'read'),
-            testCatalogTool('Glob', 'read'),
-            testCatalogTool('Grep', 'read'),
-            testCatalogTool('Write', 'file_write'),
-            testCatalogTool('Edit', 'file_write'),
-            testCatalogTool('Bash', 'shell_unsafe'),
-          ],
+          tools: implementationCatalogTools(),
         }),
       ),
       /worktree child executor/,
@@ -321,27 +309,13 @@ describe('subagent tools', () => {
 
     const runnableAvailability = listBuiltinAgentDefinitions({
       worktreeChildExecutorAvailable: true,
-      tools: [
-        testCatalogTool('Read', 'read'),
-        testCatalogTool('Glob', 'read'),
-        testCatalogTool('Grep', 'read'),
-        testCatalogTool('Write', 'file_write'),
-        testCatalogTool('Edit', 'file_write'),
-        testCatalogTool('Bash', 'shell_unsafe'),
-      ],
+      tools: implementationCatalogTools(),
     }).find((definition) => definition.id === IMPLEMENTATION_AGENT_ID)?.availability;
     expect(runnableAvailability).toEqual({ status: 'available' });
     assertAgentDefinitionRunnable({
       worktreeChildExecutorAvailable: true,
       definition: IMPLEMENTATION_AGENT_DEFINITION,
-      tools: [
-        testCatalogTool('Read', 'read'),
-        testCatalogTool('Glob', 'read'),
-        testCatalogTool('Grep', 'read'),
-        testCatalogTool('Write', 'file_write'),
-        testCatalogTool('Edit', 'file_write'),
-        testCatalogTool('Bash', 'shell_unsafe'),
-      ],
+      tools: implementationCatalogTools(),
     });
   });
 
@@ -425,6 +399,8 @@ describe('subagent tools', () => {
   test('child agent toolset keeps only built-in profile allowlisted tools', () => {
     const tools = buildChildAgentTools([
       ...buildBuiltinTools(),
+      testCatalogTool('WriteStdin', 'shell_unsafe'),
+      testCatalogTool('StopBackgroundTask', 'shell_unsafe'),
       {
         name: AGENT_SPAWN_TOOL_NAME,
         description: 'spawn',
@@ -456,6 +432,8 @@ describe('subagent tools', () => {
       'Write',
       'Edit',
       'Bash',
+      'WriteStdin',
+      'StopBackgroundTask',
     ]);
     expect([...CHILD_AGENT_TOOL_NAMES]).toEqual([
       'Read',
@@ -465,6 +443,8 @@ describe('subagent tools', () => {
       'Write',
       'Edit',
       'Bash',
+      'WriteStdin',
+      'StopBackgroundTask',
     ]);
   });
 
@@ -1470,6 +1450,10 @@ function testCatalogTool(name: string, categoryHint: MakaTool['categoryHint']): 
     categoryHint,
     impl: async () => ({}),
   };
+}
+
+function implementationCatalogTools(): MakaTool[] {
+  return IMPLEMENTATION_AGENT_DEFINITION.tools.map((name) => testCatalogTool(name, undefined));
 }
 
 async function expectRejects(promise: Promise<unknown>, pattern: RegExp): Promise<void> {

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -147,7 +147,7 @@ export const WEB_RESEARCH_AGENT_DEFINITION: AgentDefinition = {
 };
 
 export const IMPLEMENTATION_AGENT_DEFINITION: AgentDefinition = {
-  definitionVersion: 1,
+  definitionVersion: 2,
   id: IMPLEMENTATION_AGENT_ID,
   profile: IMPLEMENTATION_AGENT_PROFILE,
   name: 'Implementation',
@@ -161,7 +161,7 @@ export const IMPLEMENTATION_AGENT_DEFINITION: AgentDefinition = {
     supportedWriteBack: [AGENT_WRITE_BACK_PATCH],
   },
   permissionMode: 'execute',
-  tools: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'],
+  tools: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash', 'WriteStdin', 'StopBackgroundTask'],
   systemPrompt: [
     'You are a foreground implementation child agent.',
     'Run only inside a dedicated worktree child executor when the host provides one.',

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -1864,16 +1864,9 @@ export class ShellRunProcessManager
 
   private reserveSlot(mode: ShellMode): ShellRunSlotReservation {
     // The counters are manager-wide, so the session that hits the cap may own
-    // none of the runs holding it. Hedging on ownership — "stop one of yours
-    // if you started any" — is the wrong hedge, because the caller that most
-    // often hits this cap does not have the tool either. `Bash` reaches this
-    // path from a child agent, and `buildToolsForAgentDefinition` is a strict
-    // name allowlist: the `implementation` definition is granted Read, Glob,
-    // Grep, Write, Edit and Bash, and neither StopBackgroundTask nor
-    // WriteStdin is on any child list. Naming the tool would send that caller
-    // to look for a schema entry it does not have. So the refusal describes
-    // the action instead of naming the tool, and leads with waiting, which is
-    // the one move available to every caller.
+    // none of the runs holding it. Waiting is therefore the only recovery
+    // action available to every caller; stopping one of its own tasks is a
+    // conditional alternative.
     if (this.reservedShellRuns >= this.maxLiveShellRuns) {
       throw new Error(
         `No free background task slot: the runtime is at its limit of ${this.maxLiveShellRuns} ` +


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Implementation subagents can start background and PTY shell tasks, but their durable tool profile did not include the companion controls needed to interact with or stop those tasks. This change adds `WriteStdin` and `StopBackgroundTask` to the implementation profile and increments its definition version.

The Runtime Host integration coverage now exercises the complete public path: a real implementation child Session starts a PTY, writes input, reads the resulting screen, stops the task, and completes with a quiescent patch artifact. Existing durable child Sessions retain their stored tool snapshot and are not implicitly upgraded.

## Verification

- Runtime: 3,252 passed, 9 skipped, 0 failed
- Runtime Host: 775 passed, 0 failed
- Headless: 1,352 passed, 5 skipped, 0 failed
- Runtime Host implementation-child PTY integration: 10 consecutive passes
- TypeScript typecheck
- Biome
- `git diff --check`

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

实现型子 Agent 已经能够启动后台任务和 PTY，但其持久化工具配置缺少继续交互和停止任务所需的配套工具。本次变更为该配置加入 `WriteStdin` 与 `StopBackgroundTask`，并递增定义版本。

Runtime Host 集成测试现在覆盖完整的公开路径：真实的实现型子 Session 启动 PTY、写入输入、读取终端画面、停止任务，并在资源静默后产出 patch artifact。已有持久化子 Session 继续使用其存储的工具快照，不会被隐式升级。

## 验证

- Runtime：3,252 通过，9 跳过，0 失败
- Runtime Host：775 通过，0 失败
- Headless：1,352 通过，5 跳过，0 失败
- Runtime Host 实现型子 Session PTY 集成测试：连续 10 次通过
- TypeScript typecheck
- Biome
- `git diff --check`

## 检查清单

- [x] 测试覆盖该变更，且修复前会失败
- [x] lint、format、typecheck 与受影响测试套件均已在本地通过

此 PR 是否改变行为？

- [x] 是——已在概要中说明
- [ ] 否

</details>
