### PR TITLE
test(cli): tolerate transient incomplete TUI frames

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -55,7 +55,7 @@ import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
 import {
   assertBottomPickerPlacement,
   FakeTerminal,
-  inputSurfaceRows,
+  findInputSurfaceRows,
   latestPlainLineContaining,
   plainTerminalOutput,
   WAIT_BUDGET_MS,
@@ -5476,7 +5476,7 @@ describe('Maka Pi TUI runner', () => {
     // Sentinel render: a wrongly-opened picker would be on screen by the time
     // the typed char paints.
     terminal.input('z');
-    await waitFor(() => editorInputText(terminal).endsWith('z'));
+    await waitFor(() => editorInputText(terminal)?.endsWith('z') === true);
     assert.equal(plainTerminalOutput(terminal.screenOutput()).includes('回到选定轮次'), false);
 
     exitMaka(terminal);
@@ -6489,9 +6489,11 @@ function bellCount(terminal: FakeTerminal): number {
   return terminal.writes.filter((write) => write === '\x07').length;
 }
 
-function editorInputText(terminal: FakeTerminal): string {
+function editorInputText(terminal: FakeTerminal): string | undefined {
   const lines = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
-  const [topEditorBorderIndex, bottomEditorBorderIndex] = inputSurfaceRows(lines);
+  const inputRows = findInputSurfaceRows(lines);
+  if (!inputRows) return undefined;
+  const [topEditorBorderIndex, bottomEditorBorderIndex] = inputRows;
   return lines
     .slice(topEditorBorderIndex + 1, bottomEditorBorderIndex)
     .join('\n')

--- a/packages/cli/src/__tests__/tui-terminal-mock.test.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { findInputSurfaceRows, inputSurfaceRows } from './tui-terminal-mock.js';
+
+test('input surface lookup distinguishes an intermediate frame from a settled frame', () => {
+  const intermediate = ['────────────────'];
+  const settled = ['────────────────', 'draft', '────────────────'];
+
+  assert.equal(findInputSurfaceRows(intermediate), undefined);
+  assert.deepEqual(findInputSurfaceRows(settled), [0, 2]);
+  assert.throws(() => inputSurfaceRows(intermediate));
+});

--- a/packages/cli/src/__tests__/tui-terminal-mock.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.ts
@@ -67,15 +67,21 @@ export function plainTerminalOutput(output: string): string {
     .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, '');
 }
 
-export function inputSurfaceRows(lines: readonly string[]): [number, number] {
+export function findInputSurfaceRows(lines: readonly string[]): [number, number] | undefined {
   const editorBorderIndexes = lines
     .map((line, index) => (/^─+$/.test(line) ? index : -1))
     .filter((index) => index >= 0);
-  assert.ok(editorBorderIndexes.length >= 2);
+  if (editorBorderIndexes.length < 2) return undefined;
   return [
     editorBorderIndexes[editorBorderIndexes.length - 2]!,
     editorBorderIndexes[editorBorderIndexes.length - 1]!,
   ];
+}
+
+export function inputSurfaceRows(lines: readonly string[]): [number, number] {
+  const rows = findInputSurfaceRows(lines);
+  assert.ok(rows, 'expected a settled input surface with top and bottom editor borders');
+  return rows;
 }
 
 /**
@@ -89,11 +95,9 @@ export function inputSurfaceRows(lines: readonly string[]): [number, number] {
  */
 export function autocompleteSuggestionLines(lines: readonly string[]): readonly string[] {
   if (!lines.some((line) => line.includes('→'))) return [];
-  const editorBorders = lines
-    .map((line, index) => (/^─+$/.test(line) ? index : -1))
-    .filter((index) => index >= 0);
-  if (editorBorders.length < 2) return [];
-  const editorTopBorder = editorBorders[editorBorders.length - 2]!;
+  const inputRows = findInputSurfaceRows(lines);
+  if (!inputRows) return [];
+  const [editorTopBorder] = inputRows;
   let start = editorTopBorder;
   while (start > 0 && /\/\w/.test(lines[start - 1]!)) start -= 1;
   return lines.slice(start, editorTopBorder);


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Fixes #2563

CLI TUI polling could fail on a valid intermediate render because `editorInputText()` called a helper that asserted both editor borders were already present. The assertion escaped the polling predicate immediately instead of allowing it to observe the next settled frame.

This change separates the two contracts:

- `findInputSurfaceRows()` returns `undefined` while the input surface is incomplete, so polling remains pending.
- `inputSurfaceRows()` retains strict assertions for checks that require a settled layout.

The slash-autocomplete query now reuses the same non-throwing lookup, and a focused regression preserves the intermediate-versus-settled frame contract.

## Verification

- CLI test suite: 350 passed, 0 failed
- Affected `/recap` test: 20 consecutive passes
- CLI TypeScript typecheck
- Biome
- `git diff --check`

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

</details>

<details>
<summary>中文</summary>

## 概要

修复 #2563

CLI TUI 的轮询可能在合法的中间渲染 frame 上失败，因为 `editorInputText()` 调用了一个要求输入框上下边框已经完整存在的断言 helper。该断言会立即逃出轮询 predicate，使其无法继续观察下一个稳定 frame。

本次变更将两种契约分开：

- `findInputSurfaceRows()` 在输入区域尚不完整时返回 `undefined`，让轮询继续等待。
- `inputSurfaceRows()` 为要求稳定布局的检查保留严格断言。

Slash autocomplete 查询也复用了同一个非抛错 lookup，并添加一项聚焦回归，固定中间 frame 与稳定 frame 的契约。

## 验证

- CLI 测试套件：350 通过，0 失败
- 受影响的 `/recap` 测试：连续 20 次通过
- CLI TypeScript typecheck
- Biome
- `git diff --check`

## 检查清单

- [x] 测试覆盖该变更，且修复前会失败
- [x] lint、format、typecheck 与受影响测试套件均已在本地通过

此 PR 是否改变行为？

- [ ] 是——已在概要中说明
- [x] 否

</details>
