### PR TITLE
fix(ui): separate session row actions from navigation

### DIFF
--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -190,6 +190,7 @@
 }
 
 .maka-session-row {
+  position: relative;
   min-width: 0;
   -webkit-app-region: no-drag;
 }
@@ -265,6 +266,22 @@
   flex: 0 0 auto;
   width: var(--h-control-sm, 24px);
   min-height: var(--h-control-sm, 24px);
+}
+
+/* SideNavItem owns the row button and only supports non-interactive
+ * endContent. The action menu occupies the reserved trailing slot visually,
+ * but remains its sibling in the DOM so neither control contains the other. */
+.maka-session-row-action {
+  position: absolute;
+  inset-block-start: calc(
+    (var(--size-element-md) - var(--size-element-sm)) / 2
+  );
+  inset-inline-end: var(--space-2);
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--h-control-sm, 24px);
 }
 
 .maka-session-row-trailing-spacer {

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { SessionSummary } from '@maka/core';
+import { LocaleProvider } from '../locale-context.js';
+import { SessionHistoryList, type SessionRowActions } from '../session-history-list.js';
+
+const session: SessionSummary = {
+  id: 'session-1',
+  name: 'Release notes',
+  isFlagged: false,
+  isArchived: false,
+  labels: [],
+  hasUnread: false,
+  status: 'active',
+  backend: 'ai-sdk',
+  llmConnectionSlug: 'test-connection',
+  connectionLocked: true,
+  model: 'test-model',
+  permissionMode: 'ask',
+};
+
+const rowActions: SessionRowActions = {
+  onToggleFlag: () => undefined,
+  onArchive: () => undefined,
+  onUnarchive: () => undefined,
+  onRename: () => undefined,
+  onDelete: () => undefined,
+};
+
+test('renders session navigation and row actions as sibling controls', () => {
+  const markup = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <SessionHistoryList
+        sessions={[session]}
+        onSelectSession={() => undefined}
+        rowActions={rowActions}
+      />
+    </LocaleProvider>,
+  );
+
+  assert.equal((markup.match(/<button\b/g) ?? []).length, 2);
+  assert.match(markup, /class="maka-session-row-action"/);
+  assert.doesNotMatch(markup, /<button\b(?:(?!<\/button>)[\s\S])*<button\b/);
+});

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
-import type { SessionSummary } from '@maka/core';
+import type { SessionSummary } from '@maka/core/session';
 import { LocaleProvider } from '../locale-context.js';
 import { SessionHistoryList, type SessionRowActions } from '../session-history-list.js';
 

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -440,7 +440,11 @@ const SessionNavRow = memo(function SessionNavRow(props: {
         onClick={(event) => {
           if (event.detail > 1 && props.actions) {
             props.onStartRename(
-              { kind: 'session', id: props.session.id, name: props.session.name },
+              {
+                kind: 'session',
+                id: props.session.id,
+                name: props.session.name,
+              },
               // The row's own button: a double-click starts the rename from
               // the row itself, not from the actions menu.
               event.currentTarget as HTMLElement,
@@ -450,17 +454,23 @@ const SessionNavRow = memo(function SessionNavRow(props: {
           props.onSelectSession(props.session.id);
         }}
         endContent={
-          <SessionItemEndContent
+          <SessionItemMeta
             session={props.session}
             active={props.active}
             streaming={props.streaming}
             stale={props.stale}
             worktree={props.worktree}
-            actions={props.actions}
-            onStartRename={props.onStartRename}
+            reserveAction={props.actions !== undefined}
           />
         }
       />
+      {props.actions && (
+        <SessionItemActions
+          session={props.session}
+          actions={props.actions}
+          onStartRename={props.onStartRename}
+        />
+      )}
     </div>
   );
 });
@@ -578,48 +588,17 @@ function ProjectItemEndContent(props: {
   );
 }
 
-const SessionItemEndContent = memo(function SessionItemEndContent(props: {
+const SessionItemMeta = memo(function SessionItemMeta(props: {
   session: SessionSummary;
   active: boolean;
   streaming: boolean;
   stale: boolean;
   worktree: boolean;
-  actions?: SessionRowActions;
-  onStartRename(target: SessionRenameTarget, opener: HTMLElement | null): void;
+  reserveAction: boolean;
 }) {
   const locale = useUiLocale();
-  const trailingRef = useRef<HTMLSpanElement>(null);
   const copy = getConversationCopy(locale).sessions;
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [pendingAction, setPendingAction] = useState<SessionRowActionId | null>(null);
-  const mountedRef = useMountedRef();
-  const pendingActionRef = useRef<SessionRowActionId | null>(null);
-  const pendingMenuIntentRef = useRef<(() => void) | null>(null);
-  const actions = props.actions;
   const statusDot = resolveSessionStatusDot(props.session, props.streaming, props.active, locale);
-
-  useEffect(
-    () => () => {
-      pendingActionRef.current = null;
-    },
-    [],
-  );
-
-  function runRowAction(actionId: SessionRowActionId, action: () => void | Promise<void>) {
-    if (pendingActionRef.current) return;
-    pendingActionRef.current = actionId;
-    setPendingAction(actionId);
-    void (async () => {
-      try {
-        await action();
-      } catch {
-        // AppShell owns visible session-action failure feedback.
-      } finally {
-        pendingActionRef.current = null;
-        if (mountedRef.current) setPendingAction(null);
-      }
-    })();
-  }
 
   // Signal (status/unread) and action (MoreMenu) are orthogonal — same as
   // project rows (badge + menu). No hover XOR state machine.
@@ -636,7 +615,7 @@ const SessionItemEndContent = memo(function SessionItemEndContent(props: {
   ) : null;
 
   return (
-    <EndContentHitTarget className="maka-session-row-end">
+    <span className="maka-session-row-end">
       {props.stale && (
         <Tooltip content={copy.staleTitle}>
           {/* `yellow`, not `warning`. Astryx keeps two archives: the semantic
@@ -666,78 +645,120 @@ const SessionItemEndContent = memo(function SessionItemEndContent(props: {
         />
       )}
       {signal}
-      {actions ? (
-        <span className="maka-session-row-trailing" ref={trailingRef}>
-          <MoreMenu
-            size="sm"
-            label={copy.actionsAriaLabel}
-            isDisabled={pendingAction !== null}
-            isMenuOpen={menuOpen}
-            onOpenChange={(open) => {
-              setMenuOpen(open);
-              if (open) return;
-              const intent = pendingMenuIntentRef.current;
-              pendingMenuIntentRef.current = null;
-              if (intent) {
-                window.requestAnimationFrame(() => {
-                  intent();
-                });
-              }
-            }}
-            items={[
-              {
-                label: props.session.isFlagged ? copy.unpin : copy.pin,
-                icon: props.session.isFlagged ? PinOff : Pin,
-                onClick: () =>
-                  runRowAction('flag', () =>
-                    actions.onToggleFlag(props.session.id, !props.session.isFlagged),
-                  ),
-              },
-              {
-                label: copy.rename,
-                icon: Pencil,
-                onClick: () => {
-                  // Read now, while the trigger is still the thing the user is
-                  // on: by the time the intent runs the menu has closed and
-                  // focus is mid-handover.
-                  const opener = trailingRef.current?.querySelector<HTMLElement>('button') ?? null;
-                  pendingMenuIntentRef.current = () =>
-                    props.onStartRename(
-                      { kind: 'session', id: props.session.id, name: props.session.name },
-                      opener,
-                    );
-                },
-              },
-              {
-                label: props.session.isArchived ? copy.unarchive : copy.archive,
-                icon: props.session.isArchived ? ArchiveRestore : Archive,
-                onClick: () =>
-                  runRowAction('archive', () =>
-                    props.session.isArchived
-                      ? actions.onUnarchive(props.session.id)
-                      : actions.onArchive(props.session.id),
-                  ),
-              },
-              { type: 'divider' },
-              {
-                label: copy.delete,
-                icon: Trash2,
-                onClick: () => {
-                  pendingMenuIntentRef.current = () =>
-                    runRowAction('delete', () => actions.onDelete(props.session.id));
-                },
-              },
-            ]}
-          />
-        </span>
-      ) : (
-        <span className="maka-session-row-trailing">
-          {signal ? null : <span className="maka-session-row-trailing-spacer" aria-hidden="true" />}
-        </span>
-      )}
-    </EndContentHitTarget>
+      <span className="maka-session-row-trailing" aria-hidden="true">
+        {!props.reserveAction && !signal && <span className="maka-session-row-trailing-spacer" />}
+      </span>
+    </span>
   );
 });
+
+function SessionItemActions(props: {
+  session: SessionSummary;
+  actions: SessionRowActions;
+  onStartRename(target: SessionRenameTarget, opener: HTMLElement | null): void;
+}) {
+  const trailingRef = useRef<HTMLSpanElement>(null);
+  const copy = getConversationCopy(useUiLocale()).sessions;
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState<SessionRowActionId | null>(null);
+  const mountedRef = useMountedRef();
+  const pendingActionRef = useRef<SessionRowActionId | null>(null);
+  const pendingMenuIntentRef = useRef<(() => void) | null>(null);
+  const actions = props.actions;
+
+  useEffect(
+    () => () => {
+      pendingActionRef.current = null;
+    },
+    [],
+  );
+
+  function runRowAction(actionId: SessionRowActionId, action: () => void | Promise<void>) {
+    if (pendingActionRef.current) return;
+    pendingActionRef.current = actionId;
+    setPendingAction(actionId);
+    void (async () => {
+      try {
+        await action();
+      } catch {
+        // AppShell owns visible session-action failure feedback.
+      } finally {
+        pendingActionRef.current = null;
+        if (mountedRef.current) setPendingAction(null);
+      }
+    })();
+  }
+
+  return (
+    <span
+      className="maka-session-row-action"
+      ref={trailingRef}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      <MoreMenu
+        size="sm"
+        label={copy.actionsAriaLabel}
+        isDisabled={pendingAction !== null}
+        isMenuOpen={menuOpen}
+        onOpenChange={(open) => {
+          setMenuOpen(open);
+          if (open) return;
+          const intent = pendingMenuIntentRef.current;
+          pendingMenuIntentRef.current = null;
+          if (intent) window.requestAnimationFrame(intent);
+        }}
+        items={[
+          {
+            label: props.session.isFlagged ? copy.unpin : copy.pin,
+            icon: props.session.isFlagged ? PinOff : Pin,
+            onClick: () =>
+              runRowAction('flag', () =>
+                actions.onToggleFlag(props.session.id, !props.session.isFlagged),
+              ),
+          },
+          {
+            label: copy.rename,
+            icon: Pencil,
+            onClick: () => {
+              // Read now, while the trigger is still the thing the user is on:
+              // by the time the intent runs the menu has closed and focus is
+              // mid-handover.
+              const opener = trailingRef.current?.querySelector<HTMLElement>('button') ?? null;
+              pendingMenuIntentRef.current = () =>
+                props.onStartRename(
+                  {
+                    kind: 'session',
+                    id: props.session.id,
+                    name: props.session.name,
+                  },
+                  opener,
+                );
+            },
+          },
+          {
+            label: props.session.isArchived ? copy.unarchive : copy.archive,
+            icon: props.session.isArchived ? ArchiveRestore : Archive,
+            onClick: () =>
+              runRowAction('archive', () =>
+                props.session.isArchived
+                  ? actions.onUnarchive(props.session.id)
+                  : actions.onArchive(props.session.id),
+              ),
+          },
+          { type: 'divider' },
+          {
+            label: copy.delete,
+            icon: Trash2,
+            onClick: () => {
+              pendingMenuIntentRef.current = () =>
+                runRowAction('delete', () => actions.onDelete(props.session.id));
+            },
+          },
+        ]}
+      />
+    </span>
+  );
+}
 
 function resolveSessionStatusDot(
   session: SessionSummary,


### PR DESCRIPTION
## Summary

Session rows rendered their trailing action menu inside the row navigation button, producing invalid nested-button markup and a React hydration warning.

This keeps the row navigation and `MoreMenu` as sibling controls while preserving the existing trailing column, status indicators, rename focus handoff, and pending-action guard. The Storybook smoke contract now checks both that every populated row has its sibling action control and that no row contains nested buttons.

Fixes #2510

<details>
<summary>中文说明</summary>

会话侧栏此前把操作菜单按钮放在整行导航按钮内部，形成无效的嵌套 `button`，并在 Desktop 启动时触发 React hydration 警告。

本 PR 将行导航与 `MoreMenu` 调整为同级控件，同时保留原有的尾部列、状态提示、重命名焦点交接和异步操作防重入逻辑。Storybook smoke 也会验证每个会话行都使用同级操作控件，且不再出现嵌套按钮。

</details>

## Verification

- `npm --workspace @maka/ui test` — 263/263 pass
- `npm --workspace @maka/desktop run typecheck:stories`
- `node --test scripts/storybook-visual-smoke.test.mjs`
- `npx biome check` on the four changed files
- Rechecked the populated AppShell session sidebar in the Default Layout and Project Groups stories; row geometry and menu placement are unchanged.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
