### PR TITLE
fix(cli): keep autocomplete inside short terminals

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -258,7 +258,9 @@ describe('Maka Pi TUI runner', () => {
       const currentInputRows = findInputSurfaceRows(current);
       if (!currentInputRows) return false;
       const [currentTopBorder] = currentInputRows;
-      return current[currentTopBorder - 1]?.includes(`(${totalCommands}/${totalCommands})`) === true;
+      return (
+        current[currentTopBorder - 1]?.includes(`(${totalCommands}/${totalCommands})`) === true
+      );
     });
     screen = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
     const selectedInputRows = findInputSurfaceRows(screen);

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -53,6 +53,7 @@ import {
 import { AUTO_RECAP_IDLE_MS } from '../session-recap.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
 import {
+  autocompleteSuggestionLines,
   assertBottomPickerPlacement,
   FakeTerminal,
   findInputSurfaceRows,
@@ -218,6 +219,80 @@ describe('Maka Pi TUI runner', () => {
     await run;
 
     assert.deepEqual(terminal.progressStates, []);
+  });
+
+  test('keeps slash autocomplete visible while a short terminal resizes', async () => {
+    const terminal = new FakeTerminal(40, 20);
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitForTuiPaint(terminal);
+    terminal.input('/');
+    await waitFor(() => {
+      const screen = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+      return autocompleteSuggestionLines(screen).some((line) => line.includes('→ /compact'));
+    });
+
+    let screen = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+    const initialInputRows = findInputSurfaceRows(screen);
+    assert.ok(initialInputRows);
+    let [topBorder, bottomBorder] = initialInputRows;
+    const firstCounter = /^\s*\((\d+)\/(\d+)\)\s*$/.exec(screen[topBorder - 1] ?? '');
+    assert.ok(firstCounter);
+    const totalCommands = Number(firstCounter[2]);
+    assert.ok(totalCommands > autocompleteSuggestionLines(screen).length);
+    assert.equal(bottomBorder, terminal.rows - 2);
+    assert.ok(autocompleteSuggestionLines(screen).some((line) => line.includes('→ /compact')));
+
+    terminal.input('\x1b[A');
+    await waitFor(() => {
+      const current = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+      const currentInputRows = findInputSurfaceRows(current);
+      if (!currentInputRows) return false;
+      const [currentTopBorder] = currentInputRows;
+      return current[currentTopBorder - 1]?.includes(`(${totalCommands}/${totalCommands})`) === true;
+    });
+    screen = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+    const selectedInputRows = findInputSurfaceRows(screen);
+    assert.ok(selectedInputRows);
+    [topBorder, bottomBorder] = selectedInputRows;
+    assert.ok(autocompleteSuggestionLines(screen).some((line) => line.includes('→ /')));
+    assert.equal(bottomBorder, terminal.rows - 2);
+
+    terminal.resize(80, 40);
+    await waitFor(() => {
+      const current = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+      return autocompleteSuggestionLines(current).length === totalCommands;
+    });
+    screen = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+    assert.equal(
+      screen.some((line) => /^\s*\(\d+\/\d+\)\s*$/.test(line)),
+      false,
+    );
+    assert.ok(autocompleteSuggestionLines(screen).some((line) => line.includes('→ /')));
+
+    terminal.resize(40, 20);
+    await waitFor(() => {
+      const current = plainTerminalOutput(terminal.screenOutput()).split(/\r?\n/);
+      const currentInputRows = findInputSurfaceRows(current);
+      if (!currentInputRows) return false;
+      const [currentTopBorder, currentBottomBorder] = currentInputRows;
+      return (
+        currentBottomBorder === terminal.rows - 2 &&
+        current[currentTopBorder - 1]?.includes(`(${totalCommands}/${totalCommands})`) === true
+      );
+    });
+
+    exitMaka(terminal);
+    await run;
   });
 
   test('restores the terminal before exiting on SIGTERM', async () => {

--- a/packages/cli/src/__tests__/tui-autocomplete-layout.test.ts
+++ b/packages/cli/src/__tests__/tui-autocomplete-layout.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { fitAutocompleteLines } from '../tui-autocomplete-layout.js';
+
+describe('fitAutocompleteLines', () => {
+  test('keeps the selected item visible and reports the full command count', () => {
+    const commands = Array.from(
+      { length: 18 },
+      (_, index) => `${index === 0 ? '→' : ' '} /command-${index + 1}`,
+    );
+
+    assert.deepEqual(fitAutocompleteLines(commands, 16), [...commands.slice(0, 15), '  (1/18)']);
+  });
+
+  test('moves the fitted window with a selection near the end', () => {
+    const commands = Array.from(
+      { length: 18 },
+      (_, index) => `${index === 17 ? '→' : ' '} /command-${index + 1}`,
+    );
+
+    assert.deepEqual(fitAutocompleteLines(commands, 6), [...commands.slice(13), '  (18/18)']);
+  });
+
+  test('preserves an upstream picker position when fitting an already-windowed list', () => {
+    const window = [
+      '  /command-18',
+      '  /command-19',
+      '→ /command-20',
+      '  /command-21',
+      '  /command-22',
+      '  (20/30)',
+    ];
+
+    assert.deepEqual(fitAutocompleteLines(window, 4), [
+      '  /command-19',
+      '→ /command-20',
+      '  /command-21',
+      '  (20/30)',
+    ]);
+  });
+
+  test('uses the selected row when only one autocomplete row fits', () => {
+    assert.deepEqual(fitAutocompleteLines(['  /one', '→ /two', '  /three'], 1), ['→ /two']);
+  });
+});

--- a/packages/cli/src/__tests__/tui-autocomplete-layout.test.ts
+++ b/packages/cli/src/__tests__/tui-autocomplete-layout.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { fitAutocompleteLines } from '../tui-autocomplete-layout.js';
+import { fitPendingQueueLines } from '../pi-tui-layout.js';
 
 describe('fitAutocompleteLines', () => {
   test('keeps the selected item visible and reports the full command count', () => {
@@ -41,5 +42,21 @@ describe('fitAutocompleteLines', () => {
 
   test('uses the selected row when only one autocomplete row fits', () => {
     assert.deepEqual(fitAutocompleteLines(['  /one', '→ /two', '  /three'], 1), ['→ /two']);
+  });
+});
+
+describe('fitPendingQueueLines', () => {
+  test('summarizes overflow after preserving the visible pending rows', () => {
+    const pending = Array.from({ length: 15 }, (_, index) => `Queued: message ${index + 1}`);
+
+    assert.deepEqual(fitPendingQueueLines(pending, 3), [
+      'Queued: message 1',
+      'Queued: message 2',
+      '… 13 more',
+    ]);
+  });
+
+  test('uses the only available row as an overflow summary', () => {
+    assert.deepEqual(fitPendingQueueLines(['Queued: one', 'Queued: two'], 1), ['… 2 more']);
   });
 });

--- a/packages/cli/src/__tests__/tui-terminal-mock.ts
+++ b/packages/cli/src/__tests__/tui-terminal-mock.ts
@@ -3,8 +3,8 @@ import { setTimeout as delay } from 'node:timers/promises';
 import type { Terminal } from '@earendil-works/pi-tui';
 
 export class FakeTerminal implements Terminal {
-  readonly columns = 80;
-  readonly rows = 24;
+  columns: number;
+  rows: number;
   readonly kittyProtocolActive = false;
   readonly progressStates: boolean[] = [];
   readonly writes: string[] = [];
@@ -15,10 +15,17 @@ export class FakeTerminal implements Terminal {
   // start() is called.
   startWriteIndex: number | null = null;
   private onInput: ((data: string) => void) | null = null;
+  private onResize: (() => void) | null = null;
 
-  start(onInput: (data: string) => void, _onResize: () => void): void {
+  constructor(columns = 80, rows = 24) {
+    this.columns = columns;
+    this.rows = rows;
+  }
+
+  start(onInput: (data: string) => void, onResize: () => void): void {
     this.startWriteIndex = this.writes.length;
     this.onInput = onInput;
+    this.onResize = onResize;
   }
 
   stop(): void {
@@ -49,6 +56,12 @@ export class FakeTerminal implements Terminal {
 
   input(data: string): void {
     this.onInput?.(data);
+  }
+
+  resize(columns: number, rows: number): void {
+    this.columns = columns;
+    this.rows = rows;
+    this.onResize?.();
   }
 
   output(): string {
@@ -98,9 +111,12 @@ export function autocompleteSuggestionLines(lines: readonly string[]): readonly 
   const inputRows = findInputSurfaceRows(lines);
   if (!inputRows) return [];
   const [editorTopBorder] = inputRows;
-  let start = editorTopBorder;
+  const end = /^\s*\(\d+\/\d+\)\s*$/.test(lines[editorTopBorder - 1] ?? '')
+    ? editorTopBorder - 1
+    : editorTopBorder;
+  let start = end;
   while (start > 0 && /\/\w/.test(lines[start - 1]!)) start -= 1;
-  return lines.slice(start, editorTopBorder);
+  return lines.slice(start, end);
 }
 
 export function assertBottomPickerPlacement(

--- a/packages/cli/src/pi-tui-layout.ts
+++ b/packages/cli/src/pi-tui-layout.ts
@@ -14,6 +14,16 @@ import {
 
 interface ViewportAwareEditor extends Component {
   setViewportRows(rows: number): void;
+  isShowingAutocomplete(): boolean;
+  minimumViewportRows(): number;
+}
+
+export function fitPendingQueueLines(lines: readonly string[], maxRows: number): string[] {
+  const rowBudget = Math.max(0, Math.floor(maxRows));
+  if (lines.length <= rowBudget) return [...lines];
+  if (rowBudget === 0) return [];
+  if (rowBudget === 1) return [`… ${lines.length} more`];
+  return [...lines.slice(0, rowBudget - 1), `… ${lines.length - rowBudget + 1} more`];
 }
 
 export class MakaTranscriptComponent implements Component {
@@ -98,8 +108,18 @@ export class MakaPiLayoutComponent extends Container {
   render(width: number): string[] {
     const transcriptLines = this.transcript.render(width);
     const activityLines = this.activityStrip.render(width);
-    const pendingLines = this.pendingQueue.render(width);
+    const allPendingLines = this.pendingQueue.render(width);
     const statusLines = this.statusLine.render(width);
+    const pendingRowsAvailable = this.editor.isShowingAutocomplete()
+      ? Math.max(
+          0,
+          this.terminal.rows -
+            activityLines.length -
+            statusLines.length -
+            this.editor.minimumViewportRows(),
+        )
+      : allPendingLines.length;
+    const pendingLines = fitPendingQueueLines(allPendingLines, pendingRowsAvailable);
     this.editor.setViewportRows(
       this.terminal.rows - activityLines.length - pendingLines.length - statusLines.length,
     );

--- a/packages/cli/src/pi-tui-layout.ts
+++ b/packages/cli/src/pi-tui-layout.ts
@@ -12,6 +12,10 @@ import {
   type MakaPiTranscriptState,
 } from './pi-transcript.js';
 
+interface ViewportAwareEditor extends Component {
+  setViewportRows(rows: number): void;
+}
+
 export class MakaTranscriptComponent implements Component {
   constructor(
     private readonly state: MakaPiTranscriptState,
@@ -79,7 +83,7 @@ export class MakaPiLayoutComponent extends Container {
     private readonly transcript: MakaTranscriptComponent,
     private readonly activityStrip: MakaActivityStripComponent,
     private readonly pendingQueue: MakaPendingQueueComponent,
-    private readonly editor: Component,
+    private readonly editor: ViewportAwareEditor,
     private readonly statusLine: Component,
     private readonly terminal: Terminal,
   ) {
@@ -95,8 +99,11 @@ export class MakaPiLayoutComponent extends Container {
     const transcriptLines = this.transcript.render(width);
     const activityLines = this.activityStrip.render(width);
     const pendingLines = this.pendingQueue.render(width);
-    const editorLines = this.editor.render(width);
     const statusLines = this.statusLine.render(width);
+    this.editor.setViewportRows(
+      this.terminal.rows - activityLines.length - pendingLines.length - statusLines.length,
+    );
+    const editorLines = this.editor.render(width);
     // #1064: when the activity strip is showing (a turn is running), separate
     // it from the last transcript line with a blank row. Without this, a
     // thinking or tool row (the agent-work stack, which has no internal blank

--- a/packages/cli/src/tui-autocomplete-layout.ts
+++ b/packages/cli/src/tui-autocomplete-layout.ts
@@ -28,17 +28,22 @@ export interface MakaAutocompleteArrangementInput {
 export interface MakaAutocompleteArrangementResult {
   lines: string[];
   autocompleteSlotRows: number;
+  editorRows: number;
 }
 
 export function arrangeAutocompleteAboveEditor(
   input: MakaAutocompleteArrangementInput,
 ): MakaAutocompleteArrangementResult {
   if (!input.autocompleteShowing) {
-    return { lines: input.lines, autocompleteSlotRows: 0 };
+    return { lines: input.lines, autocompleteSlotRows: 0, editorRows: input.lines.length };
   }
   const sections = splitTrailingAutocomplete(input.lines);
   if (sections.autocompleteLines.length === 0) {
-    return { lines: sections.editorLines, autocompleteSlotRows: 0 };
+    return {
+      lines: sections.editorLines,
+      autocompleteSlotRows: 0,
+      editorRows: sections.editorLines.length,
+    };
   }
   const autocompleteRowsAvailable = Math.max(
     0,
@@ -60,12 +65,14 @@ export function arrangeAutocompleteAboveEditor(
       ...sections.editorLines,
     ],
     autocompleteSlotRows,
+    editorRows: sections.editorLines.length,
   };
 }
 
 export class MakaAutocompleteAboveEditorComponent implements Component {
   private autocompleteSlotRows = 0;
   private viewportRows = Number.POSITIVE_INFINITY;
+  private editorRows = 3;
 
   constructor(private readonly editor: Editor) {}
 
@@ -85,6 +92,14 @@ export class MakaAutocompleteAboveEditorComponent implements Component {
     this.viewportRows = Math.max(0, Math.floor(rows));
   }
 
+  isShowingAutocomplete(): boolean {
+    return this.editor.isShowingAutocomplete();
+  }
+
+  minimumViewportRows(): number {
+    return this.editorRows + (this.editor.isShowingAutocomplete() ? 1 : 0);
+  }
+
   handleInput(data: string): void {
     this.editor.handleInput(data);
   }
@@ -98,6 +113,7 @@ export class MakaAutocompleteAboveEditorComponent implements Component {
       viewportRows: this.viewportRows,
     });
     this.autocompleteSlotRows = result.autocompleteSlotRows;
+    this.editorRows = result.editorRows;
     return result.lines;
   }
 }

--- a/packages/cli/src/tui-autocomplete-layout.ts
+++ b/packages/cli/src/tui-autocomplete-layout.ts
@@ -1,5 +1,5 @@
 import type { Component, Editor } from '@earendil-works/pi-tui';
-import { stripAnsi } from './tui-ansi.js';
+import { selectListTheme, stripAnsi } from './tui-ansi.js';
 
 // The pi-tui Editor renders its autocomplete menu at the tail of its render
 // output, i.e. below the input box. The Maka TUI pins the input at the bottom
@@ -8,6 +8,10 @@ import { stripAnsi } from './tui-ansi.js';
 // Editor exposes no way to render the menu on its own (only isShowingAutocomplete()),
 // so this module post-processes the lines Editor.render() returns: it locates the
 // editor's chrome borders and moves the trailing suggestion block above them.
+// The same adapter owns the viewport fit. The vendor SelectList captures its
+// max height when it opens, so changing Editor's option during a terminal resize
+// cannot resize the active list; fitting the rendered rows here preserves its
+// selected index while keeping that selected row inside Maka's live viewport.
 //
 // Fragile by necessity: isEditorChromeLine pattern-matches the editor's border
 // lines (all-dash) and scroll hint ("--- UP/DOWN N more ---"). If pi-tui changes
@@ -18,6 +22,7 @@ export interface MakaAutocompleteArrangementInput {
   lines: string[];
   autocompleteShowing: boolean;
   autocompleteSlotRows: number;
+  viewportRows: number;
 }
 
 export interface MakaAutocompleteArrangementResult {
@@ -35,14 +40,23 @@ export function arrangeAutocompleteAboveEditor(
   if (sections.autocompleteLines.length === 0) {
     return { lines: sections.editorLines, autocompleteSlotRows: 0 };
   }
-  const autocompleteSlotRows = Math.max(
-    input.autocompleteSlotRows,
-    sections.autocompleteLines.length,
+  const autocompleteRowsAvailable = Math.max(
+    0,
+    Math.floor(input.viewportRows) - sections.editorLines.length,
+  );
+  const autocompleteLines = fitAutocompleteLines(
+    sections.autocompleteLines,
+    autocompleteRowsAvailable,
+    selectListTheme().scrollInfo,
+  );
+  const autocompleteSlotRows = Math.min(
+    autocompleteRowsAvailable,
+    Math.max(input.autocompleteSlotRows, autocompleteLines.length),
   );
   return {
     lines: [
-      ...Array.from({ length: autocompleteSlotRows - sections.autocompleteLines.length }, () => ''),
-      ...sections.autocompleteLines,
+      ...Array.from({ length: autocompleteSlotRows - autocompleteLines.length }, () => ''),
+      ...autocompleteLines,
       ...sections.editorLines,
     ],
     autocompleteSlotRows,
@@ -51,6 +65,7 @@ export function arrangeAutocompleteAboveEditor(
 
 export class MakaAutocompleteAboveEditorComponent implements Component {
   private autocompleteSlotRows = 0;
+  private viewportRows = Number.POSITIVE_INFINITY;
 
   constructor(private readonly editor: Editor) {}
 
@@ -66,6 +81,10 @@ export class MakaAutocompleteAboveEditorComponent implements Component {
     this.editor.invalidate();
   }
 
+  setViewportRows(rows: number): void {
+    this.viewportRows = Math.max(0, Math.floor(rows));
+  }
+
   handleInput(data: string): void {
     this.editor.handleInput(data);
   }
@@ -76,10 +95,41 @@ export class MakaAutocompleteAboveEditorComponent implements Component {
       lines,
       autocompleteShowing: this.editor.isShowingAutocomplete(),
       autocompleteSlotRows: this.autocompleteSlotRows,
+      viewportRows: this.viewportRows,
     });
     this.autocompleteSlotRows = result.autocompleteSlotRows;
     return result.lines;
   }
+}
+
+export function fitAutocompleteLines(
+  lines: readonly string[],
+  maxRows: number,
+  formatScrollInfo: (text: string) => string = (text) => text,
+): string[] {
+  const rowBudget = Math.max(0, Math.floor(maxRows));
+  if (lines.length <= rowBudget) return [...lines];
+  if (rowBudget === 0) return [];
+
+  const trailingScrollInfo = parseScrollInfo(lines.at(-1));
+  const itemLines = trailingScrollInfo ? lines.slice(0, -1) : lines;
+  const selectedIndex = Math.max(
+    0,
+    itemLines.findIndex((line) => /^\s*→/.test(stripAnsi(line))),
+  );
+  if (rowBudget === 1) return [itemLines[selectedIndex] ?? itemLines[0] ?? ''];
+
+  const itemBudget = rowBudget - 1;
+  const startIndex = Math.max(
+    0,
+    Math.min(selectedIndex - Math.floor(itemBudget / 2), itemLines.length - itemBudget),
+  );
+  const selectedPosition = trailingScrollInfo?.position ?? selectedIndex + 1;
+  const total = trailingScrollInfo?.total ?? itemLines.length;
+  return [
+    ...itemLines.slice(startIndex, startIndex + itemBudget),
+    formatScrollInfo(`  (${selectedPosition}/${total})`),
+  ];
 }
 
 interface MakaAutocompleteSections {
@@ -104,6 +154,13 @@ function splitTrailingAutocomplete(lines: string[]): MakaAutocompleteSections {
 function isEditorChromeLine(line: string): boolean {
   const text = stripAnsi(line);
   return /^─+$/.test(text) || /^─── [↑↓] \d+ more ─*$/.test(text);
+}
+
+function parseScrollInfo(line: string | undefined): { position: number; total: number } | null {
+  if (!line) return null;
+  const match = /^\s*\((\d+)\/(\d+)\)\s*$/.exec(stripAnsi(line));
+  if (!match) return null;
+  return { position: Number(match[1]), total: Number(match[2]) };
 }
 
 function findLastIndex<T>(items: readonly T[], predicate: (item: T) => boolean): number {


### PR DESCRIPTION
## Summary

Slash autocomplete always rendered its full command list, so a short terminal could scroll the selected command above the live viewport while Enter still targeted that invisible item.

The TUI layout now gives autocomplete the rows left after activity, pending input, editor, and status chrome. The existing adapter crops the rendered suggestions around the current selection and preserves the upstream position counter, without rebuilding the picker or losing its selected index during resize.

Fixes #2555

<details>
<summary>中文说明</summary>

斜杠命令补全此前始终渲染完整列表。在较矮的终端中，当前选中项可能被推到可视区域上方，但按 Enter 仍会执行这个不可见的命令。

现在 TUI 会先扣除活动提示、待发送输入、编辑器和状态栏所占行数，再把剩余高度交给补全列表。现有 adapter 会围绕当前选中项裁剪渲染结果并保留位置计数；终端尺寸变化时不会重建 picker，也不会丢失选择位置。

</details>

## Verification

- `npm --workspace @maka/headless run build && npm --workspace maka-agent test` — 354/354 pass
- `npm --workspace maka-agent run typecheck`
- `npx biome check` on the five changed files
- Real 40 x 20 PTY: `/compact` and `(1/18)` remain visible on open; wrapping upward shows `/thinking` and `(18/18)`.
- Exercised live resize from 40 x 20 to 80 x 40 and back with autocomplete open; the selected item, editor borders, and status line remain visible.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
