### PR TITLE
fix(runtime): preserve CJK PowerShell output on Windows

### DIFF
--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -168,6 +168,23 @@ jobs:
           }
           exit $exitCode
 
+      - id: runtime_powershell_encoding
+        name: Run Runtime PowerShell UTF-8 gates
+        if: always() && steps.build.outcome == 'success' && needs.changes.outputs.windows_runtime == 'true'
+        continue-on-error: true
+        timeout-minutes: 5
+        shell: pwsh
+        run: |
+          node.exe --test --test-force-exit --test-timeout=15000 --test-reporter=tap --test-concurrency=1 --test-name-pattern="preserves CJK PowerShell output through pipes|preserves CJK PowerShell output through a real PTY" packages/runtime/dist/__tests__/shell-run-manager.test.js 2>&1 |
+            Tee-Object -FilePath "$env:WINDOWS_BASELINE_LOG_DIR/runtime-powershell-utf8.log"
+          $exitCode = $LASTEXITCODE
+          $output = Get-Content "$env:WINDOWS_BASELINE_LOG_DIR/runtime-powershell-utf8.log"
+          if ($exitCode -eq 0 -and ($output -notcontains '# tests 2' -or $output -notcontains '# pass 2')) {
+            Write-Error 'Runtime PowerShell UTF-8 gate did not run exactly two passing tests'
+            exit 1
+          }
+          exit $exitCode
+
       # Full packages/storage test:dist is ~10 minutes on windows-latest and
       # mostly duplicates the Linux unit lane. Baseline keeps process/path/
       # lock-sensitive gates here. Release-blocking crash evidence belongs to
@@ -313,7 +330,12 @@ jobs:
           | CLI / Electron smoke | ${{ steps.smoke.outcome }} |
           | Storage path/lock gates | ${{ steps.storage.outcome }} |
           | Runtime PTY input | ${{ steps.runtime_pty_input.outcome }} |
+<<<<<<< HEAD
           | Full storage suite (nightly/manual) | ${{ steps.storage_full.outcome }} |
+=======
+          | Runtime PowerShell UTF-8 | ${{ steps.runtime_powershell_encoding.outcome }} |
+          | Managed workspace crash recovery | ${{ steps.managed_workspace_crash.outcome }} |
+>>>>>>> 107568745 (test(windows): gate PowerShell CJK shell output)
           | Residual processes | ${{ steps.processes.outcome }} |
 
           Download the `windows-baseline` artifact for complete logs.

--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -330,12 +330,8 @@ jobs:
           | CLI / Electron smoke | ${{ steps.smoke.outcome }} |
           | Storage path/lock gates | ${{ steps.storage.outcome }} |
           | Runtime PTY input | ${{ steps.runtime_pty_input.outcome }} |
-<<<<<<< HEAD
-          | Full storage suite (nightly/manual) | ${{ steps.storage_full.outcome }} |
-=======
           | Runtime PowerShell UTF-8 | ${{ steps.runtime_powershell_encoding.outcome }} |
-          | Managed workspace crash recovery | ${{ steps.managed_workspace_crash.outcome }} |
->>>>>>> 107568745 (test(windows): gate PowerShell CJK shell output)
+          | Full storage suite (nightly/manual) | ${{ steps.storage_full.outcome }} |
           | Residual processes | ${{ steps.processes.outcome }} |
 
           Download the `windows-baseline` artifact for complete logs.

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -250,8 +250,8 @@ describe('builtin Bash projection and shell execution', () => {
 
   test('executor Bash executes with the same shell it declares', async () => {
     // /bin/echo stands in for pwsh.exe: if the shell reaches the local
-    // executor's spawn, stdout echoes the PowerShell flags back instead of a
-    // bare 'wired-marker' from the default POSIX shell.
+    // executor's spawn, stdout echoes the PowerShell flags and wrapper instead
+    // of a bare 'wired-marker' from the default POSIX shell.
     const tools = buildBuiltinTools({
       shell: { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: '/bin/echo' },
     });
@@ -269,7 +269,7 @@ describe('builtin Bash projection and shell execution', () => {
     )) as { output: { mode: string; stdout: string } };
     expect(
       result.output.stdout.startsWith(
-        '-NoLogo -NoProfile -NonInteractive -Command echo wired-marker\n',
+        '-NoLogo -NoProfile -NonInteractive -Command $__makaUtf8 = [System.Text.UTF8Encoding]::new($false)\n',
       ),
     ).toBe(true);
   });

--- a/packages/runtime/src/__tests__/shell-detect.test.ts
+++ b/packages/runtime/src/__tests__/shell-detect.test.ts
@@ -78,7 +78,7 @@ describe('buildShellSpawnPlan', () => {
     const script = spawnPlan.args[4] ?? '';
     assert.match(script, /\[Console\]::OutputEncoding = \$__makaUtf8/u);
     assert.equal(spawnPlan.env?.INHERITED, 'kept');
-    assert.equal(spawnPlan.env?.__MAKA_RUNTIME_POWERSHELL_COMMAND, command);
+    assert.ok(spawnPlan.env?.__MAKA_RUNTIME_POWERSHELL_COMMAND?.startsWith(`${command}\n`));
     assert.equal(spawnPlan.env?.__maka_runtime_powershell_command, undefined);
     assert.match(script, /SetEnvironmentVariable\('__MAKA_RUNTIME_POWERSHELL_COMMAND', \$null\)/u);
     assert.doesNotMatch(
@@ -98,6 +98,12 @@ describe('buildShellSpawnPlan', () => {
       'npm test',
     );
     assert.equal(
+      spawnPlan.env?.__MAKA_RUNTIME_POWERSHELL_COMMAND,
+      'npm test\n' +
+        '$__makaOk = $?\n' +
+        'if (-not $__makaOk) { if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) { exit $LASTEXITCODE } else { exit 1 } }',
+    );
+    assert.equal(
       spawnPlan.args[4],
       '$__makaUtf8 = [System.Text.UTF8Encoding]::new($false)\n' +
         '[Console]::OutputEncoding = $__makaUtf8\n' +
@@ -105,9 +111,7 @@ describe('buildShellSpawnPlan', () => {
         "$__makaCommandText = [Environment]::GetEnvironmentVariable('__MAKA_RUNTIME_POWERSHELL_COMMAND')\n" +
         "[Environment]::SetEnvironmentVariable('__MAKA_RUNTIME_POWERSHELL_COMMAND', $null)\n" +
         '$__makaCommand = [ScriptBlock]::Create($__makaCommandText)\n' +
-        '. $__makaCommand\n' +
-        '$__makaOk = $?\n' +
-        'if (-not $__makaOk) { if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) { exit $LASTEXITCODE } else { exit 1 } }',
+        '. $__makaCommand',
     );
   });
 
@@ -154,6 +158,8 @@ describe('buildPtyShellSpawnPlan', () => {
       /\$OutputEncoding = \$__makaUtf8\n\$__makaCommandText = \[Environment\]::GetEnvironmentVariable/u,
     );
     assert.equal(powershell.env?.INHERITED, 'kept');
-    assert.equal(powershell.env?.__MAKA_RUNTIME_POWERSHELL_COMMAND, 'Write-Output ready');
+    assert.ok(
+      powershell.env?.__MAKA_RUNTIME_POWERSHELL_COMMAND?.startsWith('Write-Output ready\n'),
+    );
   });
 });

--- a/packages/runtime/src/__tests__/shell-detect.test.ts
+++ b/packages/runtime/src/__tests__/shell-detect.test.ts
@@ -65,6 +65,7 @@ describe('buildShellSpawnPlan', () => {
     const spawnPlan = buildShellSpawnPlan(
       { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: 'C:\\Users\\u\\bin\\pwsh.exe' },
       command,
+      { INHERITED: 'kept', __maka_runtime_powershell_command: 'caller value' },
     );
     assert.equal(spawnPlan.file, 'C:\\Users\\u\\bin\\pwsh.exe');
     assert.equal(spawnPlan.useShellOption, false);
@@ -76,7 +77,10 @@ describe('buildShellSpawnPlan', () => {
     ]);
     const script = spawnPlan.args[4] ?? '';
     assert.match(script, /\[Console\]::OutputEncoding = \$__makaUtf8/u);
-    assert.equal(decodeWrappedPowerShellCommand(script), command);
+    assert.equal(spawnPlan.env?.INHERITED, 'kept');
+    assert.equal(spawnPlan.env?.__MAKA_RUNTIME_POWERSHELL_COMMAND, command);
+    assert.equal(spawnPlan.env?.__maka_runtime_powershell_command, undefined);
+    assert.match(script, /SetEnvironmentVariable\('__MAKA_RUNTIME_POWERSHELL_COMMAND', \$null\)/u);
     assert.doesNotMatch(
       script,
       /Write-Output/u,
@@ -98,7 +102,9 @@ describe('buildShellSpawnPlan', () => {
       '$__makaUtf8 = [System.Text.UTF8Encoding]::new($false)\n' +
         '[Console]::OutputEncoding = $__makaUtf8\n' +
         '$OutputEncoding = $__makaUtf8\n' +
-        "$__makaCommand = [ScriptBlock]::Create([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('bgBwAG0AIAB0AGUAcwB0AA==')))\n" +
+        "$__makaCommandText = [Environment]::GetEnvironmentVariable('__MAKA_RUNTIME_POWERSHELL_COMMAND')\n" +
+        "[Environment]::SetEnvironmentVariable('__MAKA_RUNTIME_POWERSHELL_COMMAND', $null)\n" +
+        '$__makaCommand = [ScriptBlock]::Create($__makaCommandText)\n' +
         '. $__makaCommand\n' +
         '$__makaOk = $?\n' +
         'if (-not $__makaOk) { if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) { exit $LASTEXITCODE } else { exit 1 } }',
@@ -138,20 +144,16 @@ describe('buildPtyShellSpawnPlan', () => {
     const powershell = buildPtyShellSpawnPlan(
       { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: 'C:\\pf\\pwsh.exe' },
       'Write-Output ready',
+      { INHERITED: 'kept' },
     );
     assert.equal(powershell.file, 'C:\\pf\\pwsh.exe');
     assert.deepEqual(powershell.args.slice(0, 3), ['-NoLogo', '-NoProfile', '-Command']);
     assert.doesNotMatch(powershell.args.join(' '), /-NonInteractive/);
     assert.match(
       powershell.args[3] ?? '',
-      /\$OutputEncoding = \$__makaUtf8\n\$__makaCommand = \[ScriptBlock\]::Create/u,
+      /\$OutputEncoding = \$__makaUtf8\n\$__makaCommandText = \[Environment\]::GetEnvironmentVariable/u,
     );
-    assert.equal(decodeWrappedPowerShellCommand(powershell.args[3] ?? ''), 'Write-Output ready');
+    assert.equal(powershell.env?.INHERITED, 'kept');
+    assert.equal(powershell.env?.__MAKA_RUNTIME_POWERSHELL_COMMAND, 'Write-Output ready');
   });
 });
-
-function decodeWrappedPowerShellCommand(script: string): string {
-  const encoded = /FromBase64String\('([^']+)'\)/u.exec(script)?.[1];
-  assert.ok(encoded, 'wrapper contains an encoded user command');
-  return Buffer.from(encoded, 'base64').toString('utf16le');
-}

--- a/packages/runtime/src/__tests__/shell-detect.test.ts
+++ b/packages/runtime/src/__tests__/shell-detect.test.ts
@@ -60,10 +60,11 @@ describe('detectShell', () => {
 });
 
 describe('buildShellSpawnPlan', () => {
-  test('spawns PowerShell explicitly with non-interactive flags and the command as one argument', () => {
+  test('spawns PowerShell explicitly and preserves the command in an isolated script block', () => {
+    const command = "using namespace System.Text\nWrite-Output '$HOME'";
     const spawnPlan = buildShellSpawnPlan(
       { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: 'C:\\Users\\u\\bin\\pwsh.exe' },
-      'Get-ChildItem -Name',
+      command,
     );
     assert.equal(spawnPlan.file, 'C:\\Users\\u\\bin\\pwsh.exe');
     assert.equal(spawnPlan.useShellOption, false);
@@ -73,9 +74,13 @@ describe('buildShellSpawnPlan', () => {
       '-NonInteractive',
       '-Command',
     ]);
-    assert.ok(
-      spawnPlan.args[4]!.startsWith('Get-ChildItem -Name\n'),
-      'command comes first, verbatim',
+    const script = spawnPlan.args[4] ?? '';
+    assert.match(script, /\[Console\]::OutputEncoding = \$__makaUtf8/u);
+    assert.equal(decodeWrappedPowerShellCommand(script), command);
+    assert.doesNotMatch(
+      script,
+      /Write-Output/u,
+      'user syntax is not interpolated into the wrapper',
     );
   });
 
@@ -90,7 +95,11 @@ describe('buildShellSpawnPlan', () => {
     );
     assert.equal(
       spawnPlan.args[4],
-      'npm test\n' +
+      '$__makaUtf8 = [System.Text.UTF8Encoding]::new($false)\n' +
+        '[Console]::OutputEncoding = $__makaUtf8\n' +
+        '$OutputEncoding = $__makaUtf8\n' +
+        "$__makaCommand = [ScriptBlock]::Create([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('bgBwAG0AIAB0AGUAcwB0AA==')))\n" +
+        '. $__makaCommand\n' +
         '$__makaOk = $?\n' +
         'if (-not $__makaOk) { if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) { exit $LASTEXITCODE } else { exit 1 } }',
     );
@@ -133,6 +142,16 @@ describe('buildPtyShellSpawnPlan', () => {
     assert.equal(powershell.file, 'C:\\pf\\pwsh.exe');
     assert.deepEqual(powershell.args.slice(0, 3), ['-NoLogo', '-NoProfile', '-Command']);
     assert.doesNotMatch(powershell.args.join(' '), /-NonInteractive/);
-    assert.match(powershell.args[3] ?? '', /^Write-Output ready\n/);
+    assert.match(
+      powershell.args[3] ?? '',
+      /\$OutputEncoding = \$__makaUtf8\n\$__makaCommand = \[ScriptBlock\]::Create/u,
+    );
+    assert.equal(decodeWrappedPowerShellCommand(powershell.args[3] ?? ''), 'Write-Output ready');
   });
 });
+
+function decodeWrappedPowerShellCommand(script: string): string {
+  const encoded = /FromBase64String\('([^']+)'\)/u.exec(script)?.[1];
+  assert.ok(encoded, 'wrapper contains an encoded user command');
+  return Buffer.from(encoded, 'base64').toString('utf16le');
+}

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -246,10 +246,7 @@ describe('runShellWithBoundedTail', () => {
       `flags then PowerShell wrapper, got: ${r.stdout}`,
     );
     assert.ok(r.stdout.includes("GetEnvironmentVariable('__MAKA_RUNTIME_POWERSHELL_COMMAND')"));
-    assert.ok(
-      r.stdout.includes('exit $LASTEXITCODE'),
-      'exit-code wrapper is part of the command argument',
-    );
+    assert.doesNotMatch(r.stdout, /wired-marker/u, 'user syntax stays outside argv');
   });
 
   test('a native command exit code survives the PowerShell -Command path (requires pwsh)', async (t) => {

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -229,7 +229,7 @@ describe('runShellWithBoundedTail', () => {
 
   test('spawns a detected PowerShell explicitly with non-interactive flags (not via shell:true)', async () => {
     // /bin/echo stands in for pwsh.exe: if the spawn plan is honoured, the
-    // "shell" receives the flags plus the command as argv and echoes them back.
+    // "shell" receives the flags plus the command wrapper as argv and echoes them back.
     // If the command were still run via shell:true, stdout would be plain
     // 'wired-marker' with no flags.
     const r = await runShellWithBoundedTail(
@@ -240,8 +240,13 @@ describe('runShellWithBoundedTail', () => {
     );
     assert.equal(r.exitCode, 0);
     assert.ok(
-      r.stdout.startsWith('-NoLogo -NoProfile -NonInteractive -Command echo wired-marker\n'),
-      `flags then verbatim command, got: ${r.stdout}`,
+      r.stdout.startsWith(
+        '-NoLogo -NoProfile -NonInteractive -Command $__makaUtf8 = [System.Text.UTF8Encoding]::new($false)\n',
+      ),
+      `flags then PowerShell wrapper, got: ${r.stdout}`,
+    );
+    assert.ok(
+      r.stdout.includes("FromBase64String('ZQBjAGgAbwAgAHcAaQByAGUAZAAtAG0AYQByAGsAZQByAA==')"),
     );
     assert.ok(
       r.stdout.includes('exit $LASTEXITCODE'),

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -245,9 +245,7 @@ describe('runShellWithBoundedTail', () => {
       ),
       `flags then PowerShell wrapper, got: ${r.stdout}`,
     );
-    assert.ok(
-      r.stdout.includes("FromBase64String('ZQBjAGgAbwAgAHcAaQByAGUAZAAtAG0AYQByAGsAZQByAA==')"),
-    );
+    assert.ok(r.stdout.includes("GetEnvironmentVariable('__MAKA_RUNTIME_POWERSHELL_COMMAND')"));
     assert.ok(
       r.stdout.includes('exit $LASTEXITCODE'),
       'exit-code wrapper is part of the command argument',

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -131,7 +131,7 @@ describe('ShellRunProcessManager', () => {
     if (result.output.mode !== 'pipes') throw new Error('expected pipes output');
     assert.match(result.output.stdout, /\$OutputEncoding = \$__makaUtf8/u);
     assert.match(result.output.stdout, /\$__makaCommand = \[ScriptBlock\]::Create/u);
-    assert.ok(result.output.stdout.includes('exit $LASTEXITCODE'));
+    assert.doesNotMatch(result.output.stdout, /wired-marker/u);
   });
 
   test('runs explicit argv and supplies inherited fd payloads on the pipe path', async () => {

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -101,7 +101,8 @@ describe('ShellRunProcessManager', () => {
     const result = await manager.runForegroundBash(
       shellInput({
         cwd: await workspace(),
-        command: "New-Item -ItemType File -Path '中文文件名.txt' | Out-Null; Get-ChildItem -Name",
+        command:
+          "if (Test-Path Env:__MAKA_RUNTIME_POWERSHELL_COMMAND) { throw 'internal command env leaked' }; New-Item -ItemType File -Path '中文文件名.txt' | Out-Null; Get-ChildItem -Name",
         shell,
       }),
     );
@@ -115,7 +116,7 @@ describe('ShellRunProcessManager', () => {
     assert.doesNotMatch(result.output.stdout, /\uFFFD/u);
   });
 
-  test('uses the existing explicit PowerShell pipe plan unchanged', async () => {
+  test('uses the shared explicit PowerShell pipe plan', async () => {
     const manager = await createTestManager();
     const result = await manager.runForegroundBash(
       shellInput({
@@ -1175,7 +1176,8 @@ describe('ShellRunProcessManager', () => {
     const initial = await manager.runBackgroundBash(
       shellInput({
         cwd: await workspace(),
-        command: "New-Item -ItemType File -Path '中文文件名.txt' | Out-Null; Get-ChildItem -Name",
+        command:
+          "if (Test-Path Env:__MAKA_RUNTIME_POWERSHELL_COMMAND) { throw 'internal command env leaked' }; New-Item -ItemType File -Path '中文文件名.txt' | Out-Null; Get-ChildItem -Name",
         pty: true,
         shell,
       }),

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -1195,6 +1195,42 @@ describe('ShellRunProcessManager', () => {
     assert.equal(manager.livePtyCount(), 0);
   });
 
+  test('preserves the caller environment through a PowerShell PTY', {
+    skip: process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression',
+  }, async () => {
+    const shell = windowsPowerShellPlan();
+    assert.ok(shell, 'Windows PowerShell 5.1 must exist on the Windows baseline runner');
+    const marker = 'maka-pty-caller-env';
+    const previousHostOnly = process.env.MAKA_PTY_HOST_ONLY;
+    process.env.MAKA_PTY_HOST_ONLY = 'must-not-leak';
+    try {
+      const manager = await createTestManager();
+      const initial = await manager.runBackgroundBash(
+        shellInput({
+          cwd: await workspace(),
+          command:
+            'Write-Output "marker=$env:MAKA_PTY_CALLER_MARKER"; Write-Output "host=$env:MAKA_PTY_HOST_ONLY"',
+          pty: true,
+          shell,
+          env: { MAKA_PTY_CALLER_MARKER: marker },
+        }),
+      );
+      const result = await waitForTerminalShellRun(manager, initial.ref);
+
+      assert.equal(result.status, 'completed');
+      assert.ok(result.output);
+      assert.equal(result.output.mode, 'pty');
+      if (result.output.mode !== 'pty') throw new Error('expected pty output');
+      const output = terminalText(result.output);
+      assert.match(output, new RegExp(`marker=${marker}`));
+      assert.match(output, /host=\r?\n/u);
+      assert.doesNotMatch(output, /must-not-leak/u);
+    } finally {
+      if (previousHostOnly === undefined) delete process.env.MAKA_PTY_HOST_ONLY;
+      else process.env.MAKA_PTY_HOST_ONLY = previousHostOnly;
+    }
+  });
+
   test('writes semantic text and Enter actions through a real PTY', async () => {
     const manager = await createTestManager();
     const initial = await manager.runBackgroundBash(

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -3,6 +3,7 @@ import childProcess, {
   type ExecFileException,
   type ExecFileOptionsWithStringEncoding,
 } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { syncBuiltinESMExports } from 'node:module';
 import { tmpdir } from 'node:os';
@@ -91,6 +92,29 @@ describe('ShellRunProcessManager', () => {
     assert.equal(manager.liveCount(), 0);
   });
 
+  test('preserves CJK PowerShell output through pipes', {
+    skip: process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression',
+  }, async () => {
+    const shell = windowsPowerShellPlan();
+    assert.ok(shell, 'Windows PowerShell 5.1 must exist on the Windows baseline runner');
+    const manager = await createTestManager();
+    const result = await manager.runForegroundBash(
+      shellInput({
+        cwd: await workspace(),
+        command: "New-Item -ItemType File -Path '中文文件名.txt' | Out-Null; Get-ChildItem -Name",
+        shell,
+      }),
+    );
+
+    assert.equal(result.kind, 'terminal');
+    assert.equal(result.status, 'completed');
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.output.mode, 'pipes');
+    if (result.output.mode !== 'pipes') throw new Error('expected pipes output');
+    assert.match(result.output.stdout, /中文文件名\.txt/u);
+    assert.doesNotMatch(result.output.stdout, /\uFFFD/u);
+  });
+
   test('uses the existing explicit PowerShell pipe plan unchanged', async () => {
     const manager = await createTestManager();
     const result = await manager.runForegroundBash(
@@ -104,11 +128,8 @@ describe('ShellRunProcessManager', () => {
     assert.equal(result.kind, 'terminal');
     assert.equal(result.output.mode, 'pipes');
     if (result.output.mode !== 'pipes') throw new Error('expected pipes output');
-    assert.ok(
-      result.output.stdout.startsWith(
-        '-NoLogo -NoProfile -NonInteractive -Command echo wired-marker\n',
-      ),
-    );
+    assert.match(result.output.stdout, /\$OutputEncoding = \$__makaUtf8/u);
+    assert.match(result.output.stdout, /\$__makaCommand = \[ScriptBlock\]::Create/u);
     assert.ok(result.output.stdout.includes('exit $LASTEXITCODE'));
   });
 
@@ -1142,6 +1163,33 @@ describe('ShellRunProcessManager', () => {
     assert.match(terminalText(result.output), /stdin=tty stdout=tty size=24 80/);
     assert.equal(result.output.cols, 80);
     assert.equal(result.output.rows, 24);
+    assert.equal(manager.livePtyCount(), 0);
+  });
+
+  test('preserves CJK PowerShell output through a real PTY', {
+    skip: process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression',
+  }, async () => {
+    const shell = windowsPowerShellPlan();
+    assert.ok(shell, 'Windows PowerShell 5.1 must exist on the Windows baseline runner');
+    const manager = await createTestManager();
+    const initial = await manager.runBackgroundBash(
+      shellInput({
+        cwd: await workspace(),
+        command: "New-Item -ItemType File -Path '中文文件名.txt' | Out-Null; Get-ChildItem -Name",
+        pty: true,
+        shell,
+      }),
+    );
+    const result = await waitForTerminalShellRun(manager, initial.ref);
+
+    assert.equal(result.status, 'completed');
+    assert.equal(result.exitCode, 0);
+    assert.ok(result.output);
+    assert.equal(result.output.mode, 'pty');
+    if (result.output.mode !== 'pty') throw new Error('expected pty output');
+    const output = terminalText(result.output);
+    assert.match(output, /中文文件名\.txt/u);
+    assert.doesNotMatch(output, /\uFFFD/u);
     assert.equal(manager.livePtyCount(), 0);
   });
 
@@ -2567,6 +2615,19 @@ function shellInput(input: {
     ...(input.onCompletion !== undefined ? { onCompletion: input.onCompletion } : {}),
     emitOutput: input.emitOutput ?? (() => undefined),
   };
+}
+
+function windowsPowerShellPlan(): ShellPlan | undefined {
+  if (process.platform !== 'win32') return undefined;
+  const executable = join(
+    process.env.SystemRoot ?? 'C:\\Windows',
+    'System32',
+    'WindowsPowerShell',
+    'v1.0',
+    'powershell.exe',
+  );
+  if (!existsSync(executable)) return undefined;
+  return { kind: 'powershell', displayName: 'Windows PowerShell 5.1', exe: executable };
 }
 
 function record(input: { shellRunId: string; status: ShellRunRecord['status'] }): ShellRunRecord {

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -17,7 +17,7 @@ const pwshPlan: ShellPlan = {
 describe('Bash tool shell is threaded through to execution, not just the description', () => {
   test('foreground tool executes with the same shell it declares', async () => {
     // /bin/echo stands in for pwsh.exe: if the tool's shell reaches the
-    // spawn, stdout echoes the PowerShell flags back. A shell that only
+    // spawn, stdout echoes the PowerShell flags and wrapper back. A shell that only
     // reached the description would run via the default POSIX shell and
     // print a bare 'wired-marker'.
     const tool = buildLocalForegroundBashTool({
@@ -28,7 +28,7 @@ describe('Bash tool shell is threaded through to execution, not just the descrip
     };
     assert.ok(
       result.output.stdout.startsWith(
-        '-NoLogo -NoProfile -NonInteractive -Command echo wired-marker\n',
+        '-NoLogo -NoProfile -NonInteractive -Command $__makaUtf8 = [System.Text.UTF8Encoding]::new($false)\n',
       ),
       `expected declared shell to execute, got: ${result.output.stdout}`,
     );

--- a/packages/runtime/src/shell-detect.ts
+++ b/packages/runtime/src/shell-detect.ts
@@ -94,6 +94,29 @@ const POWERSHELL_EXIT_CODE_TAIL =
   '$__makaOk = $?\n' +
   'if (-not $__makaOk) { if ($LASTEXITCODE -is [int] -and $LASTEXITCODE -ne 0) { exit $LASTEXITCODE } else { exit 1 } }';
 
+// Node decodes both pipe and PTY output as UTF-8. PowerShell 7 already defaults
+// to UTF-8, but Windows PowerShell 5.1 can inherit a legacy console code page
+// and corrupt non-ASCII output before Node sees it. Set both sides of the
+// PowerShell/native-program boundary: Console.OutputEncoding controls bytes
+// written by PowerShell, while $OutputEncoding controls text piped to native
+// commands. UTF8Encoding(false) avoids a BOM at the start of every shell run.
+const POWERSHELL_UTF8_BOOTSTRAP =
+  '$__makaUtf8 = [System.Text.UTF8Encoding]::new($false)\n' +
+  '[Console]::OutputEncoding = $__makaUtf8\n' +
+  '$OutputEncoding = $__makaUtf8';
+
+function buildPowerShellCommand(command: string): string {
+  // Keep the user command as its own parsed script. Prefixing statements
+  // directly would invalidate command text that begins with script-level
+  // syntax such as `using namespace`. Encoding also avoids interpolating any
+  // user quotes or PowerShell metacharacters into this bootstrap wrapper.
+  const encodedCommand = Buffer.from(command, 'utf16le').toString('base64');
+  const invokeCommand =
+    `$__makaCommand = [ScriptBlock]::Create([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('${encodedCommand}')))\n` +
+    '. $__makaCommand';
+  return `${POWERSHELL_UTF8_BOOTSTRAP}\n${invokeCommand}\n${POWERSHELL_EXIT_CODE_TAIL}`;
+}
+
 export function buildShellSpawnPlan(shell: ShellPlan, command: string): ShellSpawnPlan {
   if ((shell.kind === 'pwsh' || shell.kind === 'powershell') && shell.exe) {
     return {
@@ -103,7 +126,7 @@ export function buildShellSpawnPlan(shell: ShellPlan, command: string): ShellSpa
         '-NoProfile',
         '-NonInteractive',
         '-Command',
-        `${command}\n${POWERSHELL_EXIT_CODE_TAIL}`,
+        buildPowerShellCommand(command),
       ],
       useShellOption: false,
     };
@@ -119,7 +142,7 @@ export function buildPtyShellSpawnPlan(
   if ((shell.kind === 'pwsh' || shell.kind === 'powershell') && shell.exe) {
     return {
       file: shell.exe,
-      args: ['-NoLogo', '-NoProfile', '-Command', `${command}\n${POWERSHELL_EXIT_CODE_TAIL}`],
+      args: ['-NoLogo', '-NoProfile', '-Command', buildPowerShellCommand(command)],
     };
   }
   if (shell.kind === 'cmd') {

--- a/packages/runtime/src/shell-detect.ts
+++ b/packages/runtime/src/shell-detect.ts
@@ -129,8 +129,11 @@ function buildPowerShellCommand(
     Object.entries(env).filter(([key]) => key.toUpperCase() !== POWERSHELL_COMMAND_ENV),
   );
   return {
-    script: `${POWERSHELL_UTF8_BOOTSTRAP}\n${invokeCommand}\n${POWERSHELL_EXIT_CODE_TAIL}`,
-    env: { ...inheritedEnv, [POWERSHELL_COMMAND_ENV]: command },
+    script: `${POWERSHELL_UTF8_BOOTSTRAP}\n${invokeCommand}`,
+    env: {
+      ...inheritedEnv,
+      [POWERSHELL_COMMAND_ENV]: `${command}\n${POWERSHELL_EXIT_CODE_TAIL}`,
+    },
   };
 }
 

--- a/packages/runtime/src/shell-detect.ts
+++ b/packages/runtime/src/shell-detect.ts
@@ -68,11 +68,15 @@ export interface ShellSpawnPlan {
   file: string;
   args: string[];
   useShellOption: boolean;
+  /** Required environment snapshot; callers must pass it to spawn when present. */
+  env?: NodeJS.ProcessEnv;
 }
 
 export interface PtyShellSpawnPlan {
   file: string;
   args: string[];
+  /** Required environment snapshot; callers must pass it to the PTY when present. */
+  env?: NodeJS.ProcessEnv;
 }
 
 // PowerShell's -Command maps the process exit code to 0/1 from $? — a native
@@ -105,30 +109,43 @@ const POWERSHELL_UTF8_BOOTSTRAP =
   '[Console]::OutputEncoding = $__makaUtf8\n' +
   '$OutputEncoding = $__makaUtf8';
 
-function buildPowerShellCommand(command: string): string {
+const POWERSHELL_COMMAND_ENV = '__MAKA_RUNTIME_POWERSHELL_COMMAND';
+
+function buildPowerShellCommand(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): { script: string; env: NodeJS.ProcessEnv } {
   // Keep the user command as its own parsed script. Prefixing statements
   // directly would invalidate command text that begins with script-level
-  // syntax such as `using namespace`. Encoding also avoids interpolating any
-  // user quotes or PowerShell metacharacters into this bootstrap wrapper.
-  const encodedCommand = Buffer.from(command, 'utf16le').toString('base64');
+  // syntax such as `using namespace`. Carry it outside argv so wrapping does
+  // not shrink Windows' command-line budget, then remove the private slot
+  // before user code or any descendant process can inspect the environment.
   const invokeCommand =
-    `$__makaCommand = [ScriptBlock]::Create([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('${encodedCommand}')))\n` +
+    `$__makaCommandText = [Environment]::GetEnvironmentVariable('${POWERSHELL_COMMAND_ENV}')\n` +
+    `[Environment]::SetEnvironmentVariable('${POWERSHELL_COMMAND_ENV}', $null)\n` +
+    '$__makaCommand = [ScriptBlock]::Create($__makaCommandText)\n' +
     '. $__makaCommand';
-  return `${POWERSHELL_UTF8_BOOTSTRAP}\n${invokeCommand}\n${POWERSHELL_EXIT_CODE_TAIL}`;
+  const inheritedEnv = Object.fromEntries(
+    Object.entries(env).filter(([key]) => key.toUpperCase() !== POWERSHELL_COMMAND_ENV),
+  );
+  return {
+    script: `${POWERSHELL_UTF8_BOOTSTRAP}\n${invokeCommand}\n${POWERSHELL_EXIT_CODE_TAIL}`,
+    env: { ...inheritedEnv, [POWERSHELL_COMMAND_ENV]: command },
+  };
 }
 
-export function buildShellSpawnPlan(shell: ShellPlan, command: string): ShellSpawnPlan {
+export function buildShellSpawnPlan(
+  shell: ShellPlan,
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+): ShellSpawnPlan {
   if ((shell.kind === 'pwsh' || shell.kind === 'powershell') && shell.exe) {
+    const wrapped = buildPowerShellCommand(command, env);
     return {
       file: shell.exe,
-      args: [
-        '-NoLogo',
-        '-NoProfile',
-        '-NonInteractive',
-        '-Command',
-        buildPowerShellCommand(command),
-      ],
+      args: ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', wrapped.script],
       useShellOption: false,
+      env: wrapped.env,
     };
   }
   return { file: command, args: [], useShellOption: true };
@@ -140,9 +157,11 @@ export function buildPtyShellSpawnPlan(
   env: NodeJS.ProcessEnv = process.env,
 ): PtyShellSpawnPlan {
   if ((shell.kind === 'pwsh' || shell.kind === 'powershell') && shell.exe) {
+    const wrapped = buildPowerShellCommand(command, env);
     return {
       file: shell.exe,
-      args: ['-NoLogo', '-NoProfile', '-Command', buildPowerShellCommand(command)],
+      args: ['-NoLogo', '-NoProfile', '-Command', wrapped.script],
+      env: wrapped.env,
     };
   }
   if (shell.kind === 'cmd') {

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -112,8 +112,15 @@ export function runShellWithBoundedTail(
   command: string,
   options: BoundedShellOptions,
 ): Promise<BoundedShellResult> {
-  const plan = buildShellSpawnPlan(options.shell ?? defaultShellPlan(), command);
-  return runSpawnedProcessWithBoundedTail(plan.file, plan.args, plan.useShellOption, options);
+  const plan = buildShellSpawnPlan(
+    options.shell ?? defaultShellPlan(),
+    command,
+    options.env ?? process.env,
+  );
+  return runSpawnedProcessWithBoundedTail(plan.file, plan.args, plan.useShellOption, {
+    ...options,
+    ...(plan.env ? { env: plan.env } : {}),
+  });
 }
 
 /** Run an argv command directly, without a second shell parsing pass. */

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -741,7 +741,11 @@ export class ShellRunProcessManager
             args: [...input.argv.slice(1)],
             useShellOption: false,
           }
-        : buildShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command);
+        : buildShellSpawnPlan(
+            input.shell ?? defaultShellPlan(),
+            input.command,
+            input.env ?? process.env,
+          );
       startingRecord = await this.createStartingRecord(
         input,
         shellRunId,
@@ -753,7 +757,7 @@ export class ShellRunProcessManager
       const driver = new PipeProcessDriver({
         plan,
         cwd: input.cwd,
-        ...(input.env ? { env: input.env } : {}),
+        ...((plan.env ?? input.env) ? { env: plan.env ?? input.env } : {}),
         ...(input.fdInputs ? { fdInputs: input.fdInputs } : {}),
         outputDrainMs: this.pipeOutputDrainMs,
         onData: (stream, data) => dispatch((target) => this.onPipeData(target, stream, data)),
@@ -835,7 +839,7 @@ export class ShellRunProcessManager
         file: plan.file,
         args: plan.args,
         cwd: input.cwd,
-        env: input.env ?? process.env,
+        env: plan.env ?? input.env ?? process.env,
         cols: PTY_INITIAL_COLS,
         rows: PTY_INITIAL_ROWS,
         onData: (data) => dispatch((target) => this.onPtyData(target, data)),

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -826,7 +826,11 @@ export class ShellRunProcessManager
         onDirty: () => dispatch((target) => this.scheduleAutomaticFlush(target)),
         onFailure: (error) => dispatch((target) => this.handleIntegrityFailure(target, error)),
       });
-      const plan = buildPtyShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command);
+      const plan = buildPtyShellSpawnPlan(
+        input.shell ?? defaultShellPlan(),
+        input.command,
+        input.env ?? process.env,
+      );
       startingRecord = await this.createStartingRecord(
         input,
         shellRunId,


### PR DESCRIPTION
## Summary

Windows PowerShell 5.1 can emit redirected output in a legacy console code page while both Runtime shell collectors decode UTF-8. This sets the PowerShell and native-pipeline encoding at the shared spawn-plan seam, so CJK filenames survive both pipe and PTY execution.

The user command stays in an isolated script block so setup does not invalidate script-level syntax. It travels through a private process environment slot instead of an expanded command line, and the wrapper clears that slot before user code runs.

Fixes #2366

<details>
<summary>中文对照</summary>

Windows PowerShell 5.1 可能先按旧控制台代码页写出重定向输出，而 Runtime 的两种 shell 收集路径都会按 UTF-8 解码。本 PR 在共享 spawn plan 中同时设置 PowerShell 输出与 native pipeline 编码，使中文文件名在 pipe 和 PTY 两条路径中都能正确保留。

用户命令仍作为独立 ScriptBlock 解析，避免初始化语句破坏脚本级语法。命令通过进程私有环境槽传递，不放大 Windows 命令行；wrapper 会在执行用户代码前清理该槽。

</details>

## Verification

- `npm run build:test`
- `npm --workspace @maka/runtime run test:dist` — 3260 tests, 3255 passed, 5 platform skips
- `node --test scripts/windows-baseline-workflow.test.mjs` — 2 passed, 1 Windows-only skip
- `npx biome check` on all changed source, test, workflow, and script files
- Added Windows baseline gates that create and enumerate `中文文件名.txt` through both pipes and a real PTY; these require Windows PowerShell 5.1 and were not runnable on this Linux host

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
