### PR TITLE
fix(dev): build runtime-host in the desktop library graph

### DIFF
--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -5,6 +5,7 @@
     { "path": "packages/storage" },
     { "path": "packages/mcp" },
     { "path": "packages/runtime" },
+    { "path": "packages/runtime-host" },
     { "path": "packages/computer-use" },
     { "path": "packages/ui" }
   ]


### PR DESCRIPTION
## Summary

`npm run dev` only runs `tsc --build tsconfig.lib.json`. After the Runtime Host cutover, desktop main imports `@maka/runtime-host/protocol` at runtime (esbuild leaves packages external), but that package was missing from the lib graph.

Stale/missing `packages/runtime-host/dist` then crashes Electron on load with errors such as:

```
SyntaxError: The requested module '@maka/runtime-host/protocol' does not provide an export named 'decodeExternalSessionCatalogQueryInput'
```

Add `packages/runtime-host` to `tsconfig.lib.json` so dev always rebuilds it.

## Verification

- `npm run dev` reaches `[startup] app ready` after the change
- Named export resolves: `import { decodeExternalSessionCatalogQueryInput } from '@maka/runtime-host/protocol'`