### PR TITLE
fix(ui): keep the active prompt tick visible after resize

### DIFF
--- a/packages/ui/src/__tests__/prompt-anchor-rail.test.ts
+++ b/packages/ui/src/__tests__/prompt-anchor-rail.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { observeActivePromptRailVisibility } from '../prompt-anchor-rail.js';
+
+test('keeps the active tick visible when the rail viewport resizes', () => {
+  let railBox = box(0, 600);
+  let tickBox = box(570, 590);
+  let onResize: (() => void) | undefined;
+  let observed: Element | undefined;
+  let disconnected = false;
+  const tick = {
+    getBoundingClientRect: () => tickBox,
+  } as HTMLElement;
+  const rail = {
+    scrollTop: 384,
+    getBoundingClientRect: () => railBox,
+    querySelector: () => tick,
+  } as unknown as HTMLElement;
+
+  const cleanup = observeActivePromptRailVisibility(rail, (callback) => {
+    onResize = callback;
+    return {
+      observe: (target) => {
+        observed = target;
+      },
+      disconnect: () => {
+        disconnected = true;
+      },
+    };
+  });
+
+  assert.equal(observed, rail);
+  assert.equal(rail.scrollTop, 384, 'the initial visible tick does not move the rail');
+
+  railBox = box(0, 286);
+  onResize?.();
+  assert.equal(rail.scrollTop, 688, 'a shorter rail brings the active tick back from below');
+
+  tickBox = box(-30, -10);
+  onResize?.();
+  assert.equal(rail.scrollTop, 658, 'the same observer also restores a tick above the rail');
+
+  cleanup();
+  assert.equal(disconnected, true);
+});
+
+function box(top: number, bottom: number): DOMRect {
+  return { top, bottom } as DOMRect;
+}

--- a/packages/ui/src/prompt-anchor-rail.tsx
+++ b/packages/ui/src/prompt-anchor-rail.tsx
@@ -18,6 +18,39 @@ const SCROLL_END_EPSILON_PX = 2;
  */
 const HOVER_FALLOFF_TICKS = 3;
 
+interface PromptRailResizeObserver {
+  observe(target: Element): void;
+  disconnect(): void;
+}
+
+type PromptRailResizeObserverFactory = (
+  onResize: () => void,
+) => PromptRailResizeObserver;
+
+const createPromptRailResizeObserver: PromptRailResizeObserverFactory = (onResize) =>
+  new ResizeObserver(onResize);
+
+/** Keep the active tick reachable without scrolling the transcript ancestor. */
+export function keepActivePromptRailTickVisible(rail: HTMLElement): void {
+  const tick = rail.querySelector<HTMLElement>('.maka-prompt-rail-tick[data-active="true"]');
+  if (!tick) return;
+  const railBox = rail.getBoundingClientRect();
+  const tickBox = tick.getBoundingClientRect();
+  if (tickBox.top < railBox.top) rail.scrollTop -= railBox.top - tickBox.top;
+  else if (tickBox.bottom > railBox.bottom)
+    rail.scrollTop += tickBox.bottom - railBox.bottom;
+}
+
+export function observeActivePromptRailVisibility(
+  rail: HTMLElement,
+  createObserver: PromptRailResizeObserverFactory = createPromptRailResizeObserver,
+): () => void {
+  const observer = createObserver(() => keepActivePromptRailTickVisible(rail));
+  observer.observe(rail);
+  keepActivePromptRailTickVisible(rail);
+  return () => observer.disconnect();
+}
+
 export interface PromptAnchorRailTurn {
   turnId: string;
   /** The user prompt text for this turn; used as the hover preview + a11y label. */
@@ -182,13 +215,8 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
   useEffect(() => {
     const rail = railRef.current;
     if (!rail || activeTurnId === null) return;
-    const tick = rail.querySelector<HTMLElement>('.maka-prompt-rail-tick[data-active="true"]');
-    if (!tick) return;
-    const railBox = rail.getBoundingClientRect();
-    const tickBox = tick.getBoundingClientRect();
-    if (tickBox.top < railBox.top) rail.scrollTop -= railBox.top - tickBox.top;
-    else if (tickBox.bottom > railBox.bottom) rail.scrollTop += tickBox.bottom - railBox.bottom;
-  }, [activeTurnId]);
+    return observeActivePromptRailVisibility(rail);
+  }, [activeTurnId, turns]);
 
   function jumpTo(turnId: string): void {
     const el = scrollRef.current?.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);


### PR DESCRIPTION
## Summary

The prompt rail currently corrects its active tick only when the active turn changes. When the composer or window later reduces the rail viewport, that same tick can become hidden even though the active turn has not changed.

This keeps the existing rail-only scroll arithmetic and rechecks it whenever the rail's own box resizes. The observer is disconnected with the component effect, and focused coverage exercises both lower and upper overflow after a resize.

Fixes #2324

<details>
<summary>中文对照</summary>

Prompt rail 目前只在激活 turn 变化时校正激活刻度。如果 composer 或窗口随后压缩了 rail 的可视区域，激活 turn 虽未变化，对应刻度仍可能被遮住。

本 PR 保留现有只滚动 rail 的位置计算，并在 rail 自身尺寸变化时重新校正。observer 会随组件 effect 断开；聚焦测试覆盖了 resize 后刻度从下方和上方溢出的情况。

</details>

## Verification

- `npm --workspace @maka/ui test` — 264 tests passed
- `npx biome check packages/ui/src/prompt-anchor-rail.tsx packages/ui/src/__tests__/prompt-anchor-rail.test.ts`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — the active prompt tick remains visible when the rail viewport resizes
- [ ] No
