### PR TITLE
fix(ui): expose archived conversations in the sidebar

### DIFF
--- a/packages/ui/src/__tests__/session-sidebar-import.test.tsx
+++ b/packages/ui/src/__tests__/session-sidebar-import.test.tsx
@@ -28,3 +28,31 @@ test('shows the localized external import action only when the shell enables it'
   assert.match(enabled, /Import conversation/);
   assert.doesNotMatch(disabled, /Import conversation/);
 });
+
+test('exposes active and archived conversation views in the session navigation', () => {
+  const active = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <SessionSidebarNav
+        selection={{ section: 'sessions', filter: 'chats' }}
+        onSelect={() => undefined}
+        onNew={() => undefined}
+      />
+    </LocaleProvider>,
+  );
+  const archived = renderToStaticMarkup(
+    <LocaleProvider locale="zh">
+      <SessionSidebarNav
+        selection={{ section: 'sessions', filter: 'archived' }}
+        onSelect={() => undefined}
+        onNew={() => undefined}
+      />
+    </LocaleProvider>,
+  );
+
+  assert.match(active, />Conversations</);
+  assert.match(active, />Archived</);
+  assert.match(active, /aria-current="page"[\s\S]*?>Conversations</);
+  assert.match(archived, />会话</);
+  assert.match(archived, />已归档</);
+  assert.match(archived, /aria-current="page"[\s\S]*?>已归档</);
+});

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -1,5 +1,15 @@
 import type { PlanReminder } from '@maka/core';
-import { AlertCircle, Blocks, Download, Settings, SquarePen, Timer, Upload } from './icons.js';
+import {
+  AlertCircle,
+  Archive,
+  Blocks,
+  Download,
+  MessageSquare,
+  Settings,
+  SquarePen,
+  Timer,
+  Upload,
+} from './icons.js';
 import type { NavModuleMemory, NavSelection } from './nav-selection.js';
 import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
@@ -20,6 +30,8 @@ export function SessionSidebarNav(props: {
   const copy = getShellControlsCopy(locale).navigation;
   const extensionsActive = props.selection.section === 'extensions';
   const automationsActive = props.selection.section === 'automations';
+  const activeSessionFilter =
+    props.selection.section === 'sessions' ? props.selection.filter : undefined;
   const moduleMemory = props.moduleMemory ?? { extensions: 'skills', automations: 'plan-reminders' };
   const activePlanReminderCount = (props.planReminders ?? []).filter(
     (reminder) => reminder.status !== 'completed',
@@ -48,6 +60,20 @@ export function SessionSidebarNav(props: {
       {props.onImport && (
         <SideNavItem label={copy.importSession} icon={Upload} size="md" onClick={props.onImport} />
       )}
+      <SideNavItem
+        label={copy.conversations}
+        icon={MessageSquare}
+        size="md"
+        isSelected={activeSessionFilter === 'chats'}
+        onClick={() => props.onSelect({ section: 'sessions', filter: 'chats' })}
+      />
+      <SideNavItem
+        label={copy.archivedConversations}
+        icon={Archive}
+        size="md"
+        isSelected={activeSessionFilter === 'archived'}
+        onClick={() => props.onSelect({ section: 'sessions', filter: 'archived' })}
+      />
       <SideNavItem
         label={copy.extensions}
         icon={Blocks}

--- a/packages/ui/src/shell-controls-copy.ts
+++ b/packages/ui/src/shell-controls-copy.ts
@@ -8,6 +8,8 @@ type ShellControlsCopy = {
     mainLabel: string;
     newTask: string;
     importSession: string;
+    conversations: string;
+    archivedConversations: string;
     /**
      * Accessible name of the session-group header's new-task trigger
      * (session-history-list.tsx). Deliberately NOT `newTask`: that copy is
@@ -50,6 +52,8 @@ const SHELL_CONTROLS_COPY_BY_LOCALE = {
       mainLabel: '主导航',
       newTask: '新任务',
       importSession: '导入会话',
+      conversations: '会话',
+      archivedConversations: '已归档',
       groupNewTask: '新建任务',
       automations: '定时任务',
       extensions: '扩展',
@@ -83,6 +87,8 @@ const SHELL_CONTROLS_COPY_BY_LOCALE = {
       mainLabel: 'Main navigation',
       newTask: 'New task',
       importSession: 'Import conversation',
+      conversations: 'Conversations',
+      archivedConversations: 'Archived',
       groupNewTask: 'New task in group',
       automations: 'Scheduled tasks',
       extensions: 'Extensions',

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -69,6 +69,7 @@ const rowActions: NonNullable<SessionListPanelProps['rowActions']> = {
 
 function panelProps(input: {
   sessions: SessionSummary[];
+  selection?: SessionListPanelProps['selection'];
   activeId?: string;
   streamingSessionIds?: Set<string>;
   staleSessionIds?: Set<string>;
@@ -78,7 +79,7 @@ function panelProps(input: {
   worktreeSessionIds?: SessionListPanelProps['worktreeSessionIds'];
 }): SessionListPanelProps {
   return {
-    selection: { section: 'sessions', filter: 'chats' },
+    selection: input.selection ?? { section: 'sessions', filter: 'chats' },
     sessions: input.sessions,
     ...(input.activeId ? { activeId: input.activeId } : {}),
     ...(input.streamingSessionIds ? { streamingSessionIds: input.streamingSessionIds } : {}),
@@ -245,6 +246,29 @@ export const ConversationStates: Story = {
         streamingSessionIds: new Set(['status-running']),
         staleSessionIds: new Set(['status-blocked']),
       })} />
+    </StoryFrame>
+  ),
+};
+
+// Real path: after choosing Archived in the rail, an archived conversation
+// remains discoverable so its existing row-menu restore action is reachable.
+export const ArchivedConversations: Story = {
+  render: () => (
+    <StoryFrame>
+      <SessionListPanel
+        {...panelProps({
+          selection: { section: 'sessions', filter: 'archived' },
+          sessions: [
+            makeSession({
+              id: 'archived-release-notes',
+              name: '旧版本发布记录',
+              status: 'archived',
+              lastMessageAt: NOW - 8 * 24 * 60 * 60 * 1000,
+            }),
+          ],
+          activeId: 'archived-release-notes',
+        })}
+      />
     </StoryFrame>
   ),
 };


### PR DESCRIPTION
## Summary

Archived conversations already remain in the Desktop catalog and already have a Host-backed Unarchive row action, but the sidebar exposes no way to enter its existing `archived` filter. This adds explicit Conversations and Archived destinations to the session navigation, so an archived conversation stays discoverable and can be restored through the existing row menu.

The change does not add another catalog, storage, or IPC path. It only makes the existing navigation state reachable and adds localized, selected-state coverage plus an archived-list Storybook state.

Fixes #2317

<details>
<summary>中文对照</summary>

已归档会话本来就保留在 Desktop catalog 中，行菜单也已经具备由 Runtime Host 支持的“取消归档”动作；但侧栏没有任何入口能进入已有的 `archived` 筛选状态。本 PR 在会话导航中显式加入“会话”和“已归档”两个入口，使归档记录仍可发现，并能通过现有行菜单恢复。

本次修改不新增 catalog、存储或 IPC 路径，只让已有导航状态真正可达，并补充中英文选中态测试与归档列表 Storybook 场景。

</details>

## Verification

- `npm --workspace @maka/ui test` — 264 tests passed
- `npm --workspace @maka/desktop run typecheck:stories`
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook`
- `npx biome check` on all changed source, test, and story files
- Rendered the archived-list story in Chromium and checked the localized destinations, selected state, and archived row

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — archived conversations are reachable and restorable from the Desktop sidebar
- [ ] No
