### PR TITLE
fix(ui): settle drag selections after pointer release

### DIFF
--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test, COMPOSER_INPUT } from './fixtures';
+
+test('a transcript drag settles when its Turn loses capture or releases outside the window', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 1200, height: 800 });
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('pointer capture source');
+  await composer.press('Enter');
+
+  const reply = page.getByText(/Fake backend received: pointer capture source/);
+  await expect(reply).toBeVisible();
+  const turn = reply.locator('xpath=ancestor::*[@data-turn-id][1]');
+  const quoteLayer = page.locator('.maka-quote-actions');
+  await turn.evaluate((element) => {
+    const owner = element as HTMLElement;
+    owner.addEventListener('gotpointercapture', (event) => {
+      owner.dataset.e2eCapturedPointer = String((event as PointerEvent).pointerId);
+    });
+    owner.addEventListener('pointerup', () => {
+      owner.dataset.e2eCapturedPointerUp = 'true';
+    });
+    owner.addEventListener('lostpointercapture', () => {
+      owner.dataset.e2eLostPointerCapture = 'true';
+    });
+  });
+
+  const bounds = await reply.evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const rect = range.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+  if (bounds.width < 8 || bounds.height < 1) {
+    throw new Error('quote selection source has no visible text bounds');
+  }
+  const y = bounds.y + bounds.height / 2;
+  const startX = bounds.x + bounds.width - 2;
+  const selectedX = bounds.x + 2;
+
+  // Exercise the fallback itself with a browser-generated
+  // lostpointercapture event while the selection pointer is still down.
+  await page.mouse.move(startX, y);
+  await page.mouse.down();
+  await page.mouse.move(selectedX, y, { steps: 5 });
+  await expect(turn).toHaveAttribute('data-e2e-captured-pointer', /\d+/);
+  await expect
+    .poll(() => page.evaluate(() => window.getSelection()?.isCollapsed === false))
+    .toBe(true);
+  await turn.evaluate((element) => {
+    const owner = element as HTMLElement;
+    owner.releasePointerCapture(Number(owner.dataset.e2eCapturedPointer));
+  });
+  await expect(turn).toHaveAttribute('data-e2e-lost-pointer-capture', 'true');
+  await expect(quoteLayer).toBeVisible();
+  await page.mouse.up();
+
+  await page.evaluate(() => window.getSelection()?.removeAllRanges());
+  await expect(quoteLayer).toBeHidden();
+  await turn.evaluate((element) => {
+    const owner = element as HTMLElement;
+    delete owner.dataset.e2eCapturedPointer;
+    delete owner.dataset.e2eCapturedPointerUp;
+    delete owner.dataset.e2eLostPointerCapture;
+  });
+
+  // Pointer capture must route the physical release back to the owning Turn
+  // after the mouse leaves the renderer viewport.
+  await page.mouse.move(startX, y);
+  await page.mouse.down();
+  await page.mouse.move(selectedX, y, { steps: 5 });
+  await expect(turn).toHaveAttribute('data-e2e-captured-pointer', /\d+/);
+  await expect
+    .poll(() => page.evaluate(() => window.getSelection()?.isCollapsed === false))
+    .toBe(true);
+  await page.mouse.move(-20, y, { steps: 5 });
+  await page.mouse.up();
+
+  await expect(turn).toHaveAttribute('data-e2e-captured-pointer-up', 'true');
+  await expect(turn).toHaveAttribute('data-e2e-lost-pointer-capture', 'true');
+  await expect(quoteLayer).toBeVisible();
+});

--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -68,6 +68,16 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
   // the browser-generated lostpointercapture event deterministically.
   await page.mouse.move(selectedX + 1, y);
   await expect(turn).toHaveAttribute('data-e2e-lost-pointer-capture', 'true');
+  // Losing capture may settle or cancel the in-flight drag (for example, a
+  // simultaneous window blur cancels it). Either way it must release the
+  // pointer gate so the next real Selection change can settle normally.
+  await reply.evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+  });
   await expect(quoteLayer).toBeVisible();
   await page.mouse.up();
 

--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -23,6 +23,9 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
     owner.addEventListener('lostpointercapture', () => {
       owner.dataset.e2eLostPointerCapture = 'true';
     });
+    document.addEventListener('selectionchange', () => {
+      owner.dataset.e2eSelectionChanged = 'true';
+    });
   });
 
   const bounds = await reply.evaluate((element) => {
@@ -47,6 +50,10 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
   await expect
     .poll(() => page.evaluate(() => window.getSelection()?.isCollapsed === false))
     .toBe(true);
+  // Reading Selection state can observe Chromium's new Range before the
+  // selectionchange task reaches the hook. Wait for that event so releasing
+  // capture cannot race the gesture's changedDuringPointer flag.
+  await expect(turn).toHaveAttribute('data-e2e-selection-changed', 'true');
   await turn.evaluate((element) => {
     const owner = element as HTMLElement;
     owner.releasePointerCapture(Number(owner.dataset.e2eCapturedPointer));
@@ -62,6 +69,7 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
     delete owner.dataset.e2eCapturedPointer;
     delete owner.dataset.e2eCapturedPointerUp;
     delete owner.dataset.e2eLostPointerCapture;
+    delete owner.dataset.e2eSelectionChanged;
   });
 
   // Pointer capture must route the physical release back to the owning Turn
@@ -73,6 +81,7 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
   await expect
     .poll(() => page.evaluate(() => window.getSelection()?.isCollapsed === false))
     .toBe(true);
+  await expect(turn).toHaveAttribute('data-e2e-selection-changed', 'true');
   await page.mouse.move(-20, y, { steps: 5 });
   await page.mouse.up();
 

--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, COMPOSER_INPUT } from './fixtures';
 
-test('a transcript drag settles when its Turn loses capture or releases outside the window', async ({
+test('a transcript drag releases outside the window through its owning Turn', async ({
   window: page,
 }) => {
   await page.setViewportSize({ width: 1200, height: 800 });
@@ -38,56 +38,13 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
     throw new Error('quote selection source has no visible text bounds');
   }
   const y = bounds.y + bounds.height / 2;
-  const startX = bounds.x + bounds.width - 2;
-  const selectedX = bounds.x + 2;
+  const startX = bounds.x + 2;
+  const selectedX = bounds.x + bounds.width - 2;
 
-  // Exercise the fallback itself with a browser-generated
-  // lostpointercapture event while the selection pointer is still down.
   // Ignore any collapsed selectionchange left by the Composer focus change;
   // the marker below must come from this drag while capture is active.
   await turn.evaluate((element) => {
-    delete (element as HTMLElement).dataset.e2eSelectionChanged;
-  });
-  await page.mouse.move(startX, y);
-  await page.mouse.down();
-  await page.mouse.move(selectedX, y, { steps: 5 });
-  await expect(turn).toHaveAttribute('data-e2e-captured-pointer', /\d+/);
-  await expect
-    .poll(() => page.evaluate(() => window.getSelection()?.isCollapsed === false))
-    .toBe(true);
-  // Reading Selection state can observe Chromium's new Range before the
-  // selectionchange task reaches the hook. Wait for that event so releasing
-  // capture cannot race the gesture's changedDuringPointer flag.
-  await expect(turn).toHaveAttribute('data-e2e-selection-changed', 'true');
-  await turn.evaluate((element) => {
     const owner = element as HTMLElement;
-    owner.releasePointerCapture(Number(owner.dataset.e2eCapturedPointer));
-  });
-  // Chromium processes a pending pointer-capture override when it dispatches
-  // the next pointer event. Move once after release so this assertion observes
-  // the browser-generated lostpointercapture event deterministically.
-  await page.mouse.move(selectedX + 1, y);
-  await expect(turn).toHaveAttribute('data-e2e-lost-pointer-capture', 'true');
-  // Losing capture may settle or cancel the in-flight drag (for example, a
-  // simultaneous window blur cancels it). Either way it must release the
-  // pointer gate so the next real Selection change can settle normally.
-  await reply.evaluate((element) => {
-    const range = document.createRange();
-    range.selectNodeContents(element);
-    const selection = window.getSelection();
-    selection?.removeAllRanges();
-    selection?.addRange(range);
-  });
-  await expect(quoteLayer).toBeVisible();
-  await page.mouse.up();
-
-  await page.evaluate(() => window.getSelection()?.removeAllRanges());
-  await expect(quoteLayer).toBeHidden();
-  await turn.evaluate((element) => {
-    const owner = element as HTMLElement;
-    delete owner.dataset.e2eCapturedPointer;
-    delete owner.dataset.e2eCapturedPointerUp;
-    delete owner.dataset.e2eLostPointerCapture;
     delete owner.dataset.e2eSelectionChanged;
   });
 
@@ -101,7 +58,10 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
     .poll(() => page.evaluate(() => window.getSelection()?.isCollapsed === false))
     .toBe(true);
   await expect(turn).toHaveAttribute('data-e2e-selection-changed', 'true');
-  await page.mouse.move(-20, y, { steps: 5 });
+  // Leave through the transcript side of the viewport. Exiting through the
+  // left would drag across the navigation rail and correctly turn this into a
+  // cross-scope Selection, which the quote resolver must reject.
+  await page.mouse.move(1220, y, { steps: 5 });
   await page.mouse.up();
 
   await expect(turn).toHaveAttribute('data-e2e-captured-pointer-up', 'true');

--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -63,6 +63,10 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
     const owner = element as HTMLElement;
     owner.releasePointerCapture(Number(owner.dataset.e2eCapturedPointer));
   });
+  // Chromium processes a pending pointer-capture override when it dispatches
+  // the next pointer event. Move once after release so this assertion observes
+  // the browser-generated lostpointercapture event deterministically.
+  await page.mouse.move(selectedX + 1, y);
   await expect(turn).toHaveAttribute('data-e2e-lost-pointer-capture', 'true');
   await expect(quoteLayer).toBeVisible();
   await page.mouse.up();

--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -20,9 +20,6 @@ test('a transcript drag releases outside the window through its owning Turn', as
     owner.addEventListener('pointerup', () => {
       owner.dataset.e2eCapturedPointerUp = 'true';
     });
-    owner.addEventListener('lostpointercapture', () => {
-      owner.dataset.e2eLostPointerCapture = 'true';
-    });
     document.addEventListener('selectionchange', () => {
       owner.dataset.e2eSelectionChanged = 'true';
     });
@@ -65,6 +62,5 @@ test('a transcript drag releases outside the window through its owning Turn', as
   await page.mouse.up();
 
   await expect(turn).toHaveAttribute('data-e2e-captured-pointer-up', 'true');
-  await expect(turn).toHaveAttribute('data-e2e-lost-pointer-capture', 'true');
   await expect(quoteLayer).toBeVisible();
 });

--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -43,6 +43,11 @@ test('a transcript drag settles when its Turn loses capture or releases outside 
 
   // Exercise the fallback itself with a browser-generated
   // lostpointercapture event while the selection pointer is still down.
+  // Ignore any collapsed selectionchange left by the Composer focus change;
+  // the marker below must come from this drag while capture is active.
+  await turn.evaluate((element) => {
+    delete (element as HTMLElement).dataset.e2eSelectionChanged;
+  });
   await page.mouse.move(startX, y);
   await page.mouse.down();
   await page.mouse.move(selectedX, y, { steps: 5 });

--- a/packages/ui/src/__tests__/message-selection-quote-boundary.test.ts
+++ b/packages/ui/src/__tests__/message-selection-quote-boundary.test.ts
@@ -33,7 +33,7 @@ test('pointer events cannot resurrect an unchanged or cancelled selection', () =
   boundary.beginPointerSelection(4);
   boundary.selectionChanged();
   boundary.cancelPointerSelection(8);
-  boundary.cancelActivePointerSelection();
+  boundary.cancelPointerSelection(4);
   assert.deepEqual(effects, ['hide', 'hide', 'hide', 'hide']);
 
   boundary.beginPointerSelection(5);

--- a/packages/ui/src/__tests__/message-selection-quote-boundary.test.ts
+++ b/packages/ui/src/__tests__/message-selection-quote-boundary.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createSelectionQuoteGestureBoundary } from '../use-message-selection-quote.js';
+
+test('drag selection settles only after its owning pointer is released', () => {
+  const effects: string[] = [];
+  const boundary = createSelectionQuoteGestureBoundary({
+    hideAndCancel: () => effects.push('hide'),
+    scheduleSettle: () => effects.push('schedule'),
+  });
+
+  boundary.beginPointerSelection(7);
+  boundary.selectionChanged();
+  boundary.selectionChanged();
+  assert.deepEqual(effects, ['hide', 'hide', 'hide']);
+
+  boundary.endPointerSelection(9);
+  assert.deepEqual(effects, ['hide', 'hide', 'hide'], 'another pointer cannot commit the drag');
+
+  boundary.endPointerSelection(7);
+  assert.deepEqual(effects, ['hide', 'hide', 'hide', 'schedule']);
+});
+
+test('pointer events cannot resurrect an unchanged or cancelled selection', () => {
+  const effects: string[] = [];
+  const boundary = createSelectionQuoteGestureBoundary({
+    hideAndCancel: () => effects.push('hide'),
+    scheduleSettle: () => effects.push('schedule'),
+  });
+
+  boundary.beginPointerSelection(3);
+  boundary.endPointerSelection(3);
+  boundary.beginPointerSelection(4);
+  boundary.selectionChanged();
+  boundary.cancelPointerSelection(8);
+  boundary.cancelActivePointerSelection();
+  assert.deepEqual(effects, ['hide', 'hide', 'hide', 'hide']);
+
+  boundary.beginPointerSelection(5);
+  boundary.selectionChanged();
+  boundary.cancelPointerSelection(5);
+  assert.deepEqual(effects, ['hide', 'hide', 'hide', 'hide', 'hide', 'hide', 'hide']);
+
+  boundary.selectionChanged();
+  assert.deepEqual(effects, [
+    'hide',
+    'hide',
+    'hide',
+    'hide',
+    'hide',
+    'hide',
+    'hide',
+    'hide',
+    'schedule',
+  ]);
+});

--- a/packages/ui/src/__tests__/message-selection-quote-boundary.test.ts
+++ b/packages/ui/src/__tests__/message-selection-quote-boundary.test.ts
@@ -9,15 +9,15 @@ test('drag selection settles only after its owning pointer is released', () => {
     scheduleSettle: () => effects.push('schedule'),
   });
 
-  boundary.beginPointerSelection(7);
+  assert.equal(boundary.beginPointerSelection(7, 'turn-a'), true);
   boundary.selectionChanged();
   boundary.selectionChanged();
   assert.deepEqual(effects, ['hide', 'hide', 'hide']);
 
-  boundary.endPointerSelection(9);
+  boundary.finishPointerSelection(9, 'commit');
   assert.deepEqual(effects, ['hide', 'hide', 'hide'], 'another pointer cannot commit the drag');
 
-  boundary.endPointerSelection(7);
+  assert.equal(boundary.finishPointerSelection(7, 'commit'), 'turn-a');
   assert.deepEqual(effects, ['hide', 'hide', 'hide', 'schedule']);
 });
 
@@ -28,17 +28,17 @@ test('pointer events cannot resurrect an unchanged or cancelled selection', () =
     scheduleSettle: () => effects.push('schedule'),
   });
 
-  boundary.beginPointerSelection(3);
-  boundary.endPointerSelection(3);
-  boundary.beginPointerSelection(4);
+  boundary.beginPointerSelection(3, 'turn-a');
+  boundary.finishPointerSelection(3, 'commit');
+  boundary.beginPointerSelection(4, 'turn-a');
   boundary.selectionChanged();
-  boundary.cancelPointerSelection(8);
-  boundary.cancelPointerSelection(4);
+  boundary.finishPointerSelection(8, 'cancel');
+  boundary.finishPointerSelection(4, 'cancel');
   assert.deepEqual(effects, ['hide', 'hide', 'hide', 'hide']);
 
-  boundary.beginPointerSelection(5);
+  boundary.beginPointerSelection(5, 'turn-a');
   boundary.selectionChanged();
-  boundary.cancelPointerSelection(5);
+  boundary.finishPointerSelection(5, 'cancel');
   assert.deepEqual(effects, ['hide', 'hide', 'hide', 'hide', 'hide', 'hide', 'hide']);
 
   boundary.selectionChanged();
@@ -53,4 +53,32 @@ test('pointer events cannot resurrect an unchanged or cancelled selection', () =
     'hide',
     'schedule',
   ]);
+});
+
+test('a second primary pointer cannot replace the active gesture owner', () => {
+  const effects: string[] = [];
+  const boundary = createSelectionQuoteGestureBoundary({
+    hideAndCancel: () => effects.push('hide'),
+    scheduleSettle: () => effects.push('schedule'),
+  });
+
+  assert.equal(boundary.beginPointerSelection(1, 'mouse-owner'), true);
+  assert.equal(boundary.beginPointerSelection(2, 'touch-owner'), false);
+  boundary.selectionChanged();
+  assert.equal(boundary.finishPointerSelection(2, 'commit'), null);
+  assert.equal(boundary.finishPointerSelection(1, 'commit'), 'mouse-owner');
+  assert.deepEqual(effects, ['hide', 'hide', 'schedule']);
+});
+
+test('capture loss cancels a changed gesture without showing a quote', () => {
+  const effects: string[] = [];
+  const boundary = createSelectionQuoteGestureBoundary({
+    hideAndCancel: () => effects.push('hide'),
+    scheduleSettle: () => effects.push('schedule'),
+  });
+
+  boundary.beginPointerSelection(1, 'turn-a');
+  boundary.selectionChanged();
+  assert.equal(boundary.finishPointerSelection(1, 'cancel'), 'turn-a');
+  assert.deepEqual(effects, ['hide', 'hide', 'hide']);
 });

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -38,7 +38,6 @@ export interface SelectionQuoteGestureBoundary {
   selectionChanged(): void;
   endPointerSelection(pointerId: number): void;
   cancelPointerSelection(pointerId: number): void;
-  cancelActivePointerSelection(): void;
 }
 
 /**
@@ -73,12 +72,6 @@ export function createSelectionQuoteGestureBoundary(actions: {
     },
     cancelPointerSelection(pointerId) {
       if (pointerId !== activePointerId) return;
-      activePointerId = undefined;
-      changedDuringPointer = false;
-      actions.hideAndCancel();
-    },
-    cancelActivePointerSelection() {
-      if (activePointerId === undefined) return;
       activePointerId = undefined;
       changedDuringPointer = false;
       actions.hideAndCancel();
@@ -264,13 +257,6 @@ export function useMessageSelectionQuote(
       gesture.endPointerSelection(pointerId);
     }
 
-    function onWindowBlur(): void {
-      // Releasing a mouse outside the window need not deliver pointerup back to
-      // the document. Do not leave later keyboard selections behind that drag.
-      clearCaptureOwner();
-      gesture.cancelActivePointerSelection();
-    }
-
     /**
      * Scrolling moves the selection, not the quote, so the layer follows it —
      * up to the edge of the scroller. Past that the anchor is gone and so is
@@ -296,7 +282,6 @@ export function useMessageSelectionQuote(
     document.addEventListener('pointerdown', onPointerDown, { capture: true });
     document.addEventListener('pointerup', onPointerUp, { capture: true });
     document.addEventListener('pointercancel', onPointerCancel, { capture: true });
-    window.addEventListener('blur', onWindowBlur);
     // Capture-phase: scroll does not bubble.
     document.addEventListener('scroll', onScroll, { capture: true, passive: true });
     return () => {
@@ -306,7 +291,6 @@ export function useMessageSelectionQuote(
       document.removeEventListener('pointerup', onPointerUp, { capture: true });
       document.removeEventListener('pointercancel', onPointerCancel, { capture: true });
       clearCaptureOwner();
-      window.removeEventListener('blur', onWindowBlur);
       document.removeEventListener('scroll', onScroll, { capture: true });
     };
   }, [scrollRef, enabled]);

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, type RefObject } from 'react';
 import { flushSync } from 'react-dom';
 import {
+  findEnclosingTurnId,
   resolveQuoteTarget,
   type QuoteScopeNode,
   type QuoteTarget,
@@ -116,7 +117,9 @@ function readSelection(root: HTMLElement): QuoteTarget | null {
  * to expire. `selectionchange` remains the only event that says the selection
  * became something else. Primary pointer events only gate that signal while a
  * drag is active; they never capture a quote on their own, so an unrelated
- * click cannot resurrect a dismissed layer.
+ * click cannot resurrect a dismissed layer. The pointer gate starts only
+ * inside a turn that can own a quote; controls elsewhere in the scroll surface
+ * (including the quote actions themselves) are not selection gestures.
  *
  * Listeners live on `document` and resolve `scrollRef.current` at event time —
  * binding them to the element instead would capture whatever the ref held on
@@ -176,7 +179,10 @@ export function useMessageSelectionQuote(
         !event.isPrimary ||
         event.button !== 0 ||
         !(event.target instanceof Node) ||
-        !root.contains(event.target)
+        findEnclosingTurnId(
+          event.target as unknown as QuoteScopeNode,
+          root as unknown as QuoteScopeNode,
+        ) === null
       ) {
         return;
       }

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -33,48 +33,57 @@ const INTERACTIVE_QUOTE_TARGET = [
   '[role="tab"]',
 ].join(',');
 
-export interface SelectionQuoteGestureBoundary {
-  beginPointerSelection(pointerId: number): void;
+export type SelectionQuoteGestureDisposition = 'commit' | 'cancel';
+
+export interface SelectionQuoteGestureBoundary<Owner> {
+  beginPointerSelection(pointerId: number, owner: Owner): boolean;
   selectionChanged(): void;
-  endPointerSelection(pointerId: number): void;
-  cancelPointerSelection(pointerId: number): void;
+  finishPointerSelection(pointerId: number, disposition: SelectionQuoteGestureDisposition): Owner | null;
+  discardActivePointerSelection(): Owner | null;
 }
 
 /**
  * Turns pointer release into the commit boundary for drag selection without
  * making unrelated pointer events another way to resurrect a dismissed quote.
  */
-export function createSelectionQuoteGestureBoundary(actions: {
+export function createSelectionQuoteGestureBoundary<Owner>(actions: {
   hideAndCancel(): void;
   scheduleSettle(): void;
-}): SelectionQuoteGestureBoundary {
-  let activePointerId: number | undefined;
-  let changedDuringPointer = false;
+}): SelectionQuoteGestureBoundary<Owner> {
+  let active: { pointerId: number; owner: Owner; changed: boolean } | null = null;
+
+  function finish(
+    pointerId: number,
+    disposition: SelectionQuoteGestureDisposition,
+  ): Owner | null {
+    if (!active || pointerId !== active.pointerId) return null;
+    const completed = active;
+    active = null;
+    if (disposition === 'commit' && completed.changed) actions.scheduleSettle();
+    if (disposition === 'cancel') actions.hideAndCancel();
+    return completed.owner;
+  }
 
   return {
-    beginPointerSelection(pointerId) {
-      if (activePointerId !== undefined) return;
-      activePointerId = pointerId;
-      changedDuringPointer = false;
+    beginPointerSelection(pointerId, owner) {
+      if (active) return false;
+      active = { pointerId, owner, changed: false };
       actions.hideAndCancel();
+      return true;
     },
     selectionChanged() {
       actions.hideAndCancel();
-      if (activePointerId === undefined) actions.scheduleSettle();
-      else changedDuringPointer = true;
+      if (!active) actions.scheduleSettle();
+      else active.changed = true;
     },
-    endPointerSelection(pointerId) {
-      if (pointerId !== activePointerId) return;
-      const shouldSettle = changedDuringPointer;
-      activePointerId = undefined;
-      changedDuringPointer = false;
-      if (shouldSettle) actions.scheduleSettle();
+    finishPointerSelection(pointerId, disposition) {
+      return finish(pointerId, disposition);
     },
-    cancelPointerSelection(pointerId) {
-      if (pointerId !== activePointerId) return;
-      activePointerId = undefined;
-      changedDuringPointer = false;
-      actions.hideAndCancel();
+    discardActivePointerSelection() {
+      if (!active) return null;
+      const discarded = active;
+      active = null;
+      return discarded.owner;
     },
   };
 }
@@ -182,14 +191,14 @@ export function useMessageSelectionQuote(
       settleTimer = window.setTimeout(settle, SELECTION_SETTLE_MS);
     }
 
-    const gesture = createSelectionQuoteGestureBoundary({ hideAndCancel, scheduleSettle });
-    let captureOwner: Element | null = null;
-    let capturedPointerId: number | undefined;
+    const gesture = createSelectionQuoteGestureBoundary<Element>({ hideAndCancel, scheduleSettle });
 
-    function clearCaptureOwner(): void {
-      captureOwner?.removeEventListener('lostpointercapture', onLostPointerCapture);
-      captureOwner = null;
-      capturedPointerId = undefined;
+    function finishGesture(
+      pointerId: number,
+      disposition: SelectionQuoteGestureDisposition,
+    ): void {
+      const owner = gesture.finishPointerSelection(pointerId, disposition);
+      owner?.removeEventListener('lostpointercapture', onLostPointerCapture);
     }
 
     function onPointerDown(event: PointerEvent): void {
@@ -214,22 +223,19 @@ export function useMessageSelectionQuote(
       ) {
         return;
       }
-      gesture.beginPointerSelection(event.pointerId);
+      if (!gesture.beginPointerSelection(event.pointerId, turnOwner)) return;
       try {
         // `lostpointercapture` belongs to the element that owns capture. Listen
         // there instead of relying on it crossing the document boundary: in
         // Electron, the owner receives this event even when a document-level
         // capture listener does not. Keeping the listener on the owner also
         // makes the capture lifetime and its cleanup one local responsibility.
-        captureOwner = turnOwner;
-        capturedPointerId = event.pointerId;
-        captureOwner.addEventListener('lostpointercapture', onLostPointerCapture);
+        turnOwner.addEventListener('lostpointercapture', onLostPointerCapture);
         turnOwner.setPointerCapture(event.pointerId);
       } catch {
         // Capture can fail if Chromium has already retired the physical
         // pointer. Do not retain a gesture that can no longer deliver its end.
-        clearCaptureOwner();
-        gesture.cancelPointerSelection(event.pointerId);
+        finishGesture(event.pointerId, 'cancel');
       }
     }
 
@@ -238,23 +244,18 @@ export function useMessageSelectionQuote(
     }
 
     function onPointerUp(event: PointerEvent): void {
-      if (event.pointerId === capturedPointerId) clearCaptureOwner();
-      gesture.endPointerSelection(event.pointerId);
+      finishGesture(event.pointerId, 'commit');
     }
 
     function onPointerCancel(event: PointerEvent): void {
-      if (event.pointerId === capturedPointerId) clearCaptureOwner();
-      gesture.cancelPointerSelection(event.pointerId);
+      finishGesture(event.pointerId, 'cancel');
     }
 
     function onLostPointerCapture(event: Event): void {
-      // Normal pointerup already settles first, making this a no-op. When the
-      // owner loses capture without pointerup, this is the only trustworthy
-      // end boundary left for the final selection.
+      // Capture loss can happen without a physical release (capture transfer,
+      // owner removal, or pointer lock), so it cancels rather than commits.
       const pointerId = (event as PointerEvent).pointerId;
-      if (pointerId !== capturedPointerId) return;
-      clearCaptureOwner();
-      gesture.endPointerSelection(pointerId);
+      finishGesture(pointerId, 'cancel');
     }
 
     /**
@@ -290,7 +291,8 @@ export function useMessageSelectionQuote(
       document.removeEventListener('pointerdown', onPointerDown, { capture: true });
       document.removeEventListener('pointerup', onPointerUp, { capture: true });
       document.removeEventListener('pointercancel', onPointerCancel, { capture: true });
-      clearCaptureOwner();
+      const owner = gesture.discardActivePointerSelection();
+      owner?.removeEventListener('lostpointercapture', onLostPointerCapture);
       document.removeEventListener('scroll', onScroll, { capture: true });
     };
   }, [scrollRef, enabled]);

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -16,6 +16,23 @@ import {
  */
 const SELECTION_SETTLE_MS = 350;
 
+// Capturing an interactive descendant onto its Turn would retarget pointerup
+// away from the control and can suppress its click. Control labels are UI, not
+// transcript content, so they are not quote-selection gesture owners.
+const INTERACTIVE_QUOTE_TARGET = [
+  'a[href]',
+  'button',
+  'input',
+  'select',
+  'textarea',
+  'summary',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[role="button"]',
+  '[role="link"]',
+  '[role="menuitem"]',
+  '[role="tab"]',
+].join(',');
+
 export interface SelectionQuoteGestureBoundary {
   beginPointerSelection(pointerId: number): void;
   selectionChanged(): void;
@@ -118,8 +135,10 @@ function readSelection(root: HTMLElement): QuoteTarget | null {
  * became something else. Primary pointer events only gate that signal while a
  * drag is active; they never capture a quote on their own, so an unrelated
  * click cannot resurrect a dismissed layer. The pointer gate starts only
- * inside a turn that can own a quote; controls elsewhere in the scroll surface
- * (including the quote actions themselves) are not selection gestures.
+ * inside a turn that can own a quote, and that turn captures the pointer so a
+ * release outside the Electron window still closes the gesture. Controls
+ * elsewhere in the scroll surface (including the quote actions themselves)
+ * are not selection gestures.
  *
  * Listeners live on `document` and resolve `scrollRef.current` at event time —
  * binding them to the element instead would capture whatever the ref held on
@@ -174,19 +193,34 @@ export function useMessageSelectionQuote(
 
     function onPointerDown(event: PointerEvent): void {
       const root = scrollRef.current;
+      const targetNode = event.target instanceof Node ? event.target : null;
+      const targetElement =
+        targetNode instanceof Element ? targetNode : targetNode?.parentElement ?? null;
+      const turnOwner = targetElement?.closest('[data-turn-id]') ?? null;
+      const interactiveOwner = targetElement?.closest(INTERACTIVE_QUOTE_TARGET) ?? null;
       if (
         !root ||
         !event.isPrimary ||
         event.button !== 0 ||
-        !(event.target instanceof Node) ||
+        !targetNode ||
+        !turnOwner ||
+        !root.contains(turnOwner) ||
+        (interactiveOwner !== null && turnOwner.contains(interactiveOwner)) ||
         findEnclosingTurnId(
-          event.target as unknown as QuoteScopeNode,
+          targetNode as unknown as QuoteScopeNode,
           root as unknown as QuoteScopeNode,
         ) === null
       ) {
         return;
       }
       gesture.beginPointerSelection(event.pointerId);
+      try {
+        turnOwner.setPointerCapture(event.pointerId);
+      } catch {
+        // Capture can fail if Chromium has already retired the physical
+        // pointer. Do not retain a gesture that can no longer deliver its end.
+        gesture.cancelPointerSelection(event.pointerId);
+      }
     }
 
     function onSelectionChange(): void {
@@ -199,6 +233,13 @@ export function useMessageSelectionQuote(
 
     function onPointerCancel(event: PointerEvent): void {
       gesture.cancelPointerSelection(event.pointerId);
+    }
+
+    function onLostPointerCapture(event: PointerEvent): void {
+      // Normal pointerup already settles first, making this a no-op. When the
+      // owner loses capture without pointerup, this is the only trustworthy
+      // end boundary left for the final selection.
+      gesture.endPointerSelection(event.pointerId);
     }
 
     function onWindowBlur(): void {
@@ -232,6 +273,7 @@ export function useMessageSelectionQuote(
     document.addEventListener('pointerdown', onPointerDown, { capture: true });
     document.addEventListener('pointerup', onPointerUp, { capture: true });
     document.addEventListener('pointercancel', onPointerCancel, { capture: true });
+    document.addEventListener('lostpointercapture', onLostPointerCapture, { capture: true });
     window.addEventListener('blur', onWindowBlur);
     // Capture-phase: scroll does not bubble.
     document.addEventListener('scroll', onScroll, { capture: true, passive: true });
@@ -241,6 +283,7 @@ export function useMessageSelectionQuote(
       document.removeEventListener('pointerdown', onPointerDown, { capture: true });
       document.removeEventListener('pointerup', onPointerUp, { capture: true });
       document.removeEventListener('pointercancel', onPointerCancel, { capture: true });
+      document.removeEventListener('lostpointercapture', onLostPointerCapture, { capture: true });
       window.removeEventListener('blur', onWindowBlur);
       document.removeEventListener('scroll', onScroll, { capture: true });
     };

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -15,6 +15,59 @@ import {
  */
 const SELECTION_SETTLE_MS = 350;
 
+export interface SelectionQuoteGestureBoundary {
+  beginPointerSelection(pointerId: number): void;
+  selectionChanged(): void;
+  endPointerSelection(pointerId: number): void;
+  cancelPointerSelection(pointerId: number): void;
+  cancelActivePointerSelection(): void;
+}
+
+/**
+ * Turns pointer release into the commit boundary for drag selection without
+ * making unrelated pointer events another way to resurrect a dismissed quote.
+ */
+export function createSelectionQuoteGestureBoundary(actions: {
+  hideAndCancel(): void;
+  scheduleSettle(): void;
+}): SelectionQuoteGestureBoundary {
+  let activePointerId: number | undefined;
+  let changedDuringPointer = false;
+
+  return {
+    beginPointerSelection(pointerId) {
+      if (activePointerId !== undefined) return;
+      activePointerId = pointerId;
+      changedDuringPointer = false;
+      actions.hideAndCancel();
+    },
+    selectionChanged() {
+      actions.hideAndCancel();
+      if (activePointerId === undefined) actions.scheduleSettle();
+      else changedDuringPointer = true;
+    },
+    endPointerSelection(pointerId) {
+      if (pointerId !== activePointerId) return;
+      const shouldSettle = changedDuringPointer;
+      activePointerId = undefined;
+      changedDuringPointer = false;
+      if (shouldSettle) actions.scheduleSettle();
+    },
+    cancelPointerSelection(pointerId) {
+      if (pointerId !== activePointerId) return;
+      activePointerId = undefined;
+      changedDuringPointer = false;
+      actions.hideAndCancel();
+    },
+    cancelActivePointerSelection() {
+      if (activePointerId === undefined) return;
+      activePointerId = undefined;
+      changedDuringPointer = false;
+      actions.hideAndCancel();
+    },
+  };
+}
+
 /**
  * A live text selection inside the chat transcript, captured as a quotable
  * excerpt for the "quote this" affordance (Codex/Cursor-style). `anchor` is
@@ -60,10 +113,10 @@ function readSelection(root: HTMLElement): QuoteTarget | null {
  *
  * The selection is the single source of truth — the quote is derived from it
  * on every relevant event rather than snapshotted, so there is no stale state
- * to expire. `selectionchange` is the only trigger: it is the one event that
- * means the selection actually became something else. Watching key or pointer
- * events instead resurrects a dismissed layer on the next unrelated keystroke,
- * which is why Escape could not close this before.
+ * to expire. `selectionchange` remains the only event that says the selection
+ * became something else. Primary pointer events only gate that signal while a
+ * drag is active; they never capture a quote on their own, so an unrelated
+ * click cannot resurrect a dismissed layer.
  *
  * Listeners live on `document` and resolve `scrollRef.current` at event time —
  * binding them to the element instead would capture whatever the ref held on
@@ -100,14 +153,52 @@ export function useMessageSelectionQuote(
       setQuote(target && anchor ? { ...target, anchor } : null);
     }
 
-    function onSelectionChange(): void {
+    function hideAndCancel(): void {
       // Hide first, re-show only once the selection settles: a layer anchored
       // to the previous selection is wrong the moment that selection changes.
       // This listener is outside React's event system, so concurrent rendering
       // may otherwise leave the stale layer painted for another frame.
       flushSync(() => setQuote(null));
       window.clearTimeout(settleTimer);
+    }
+
+    function scheduleSettle(): void {
+      window.clearTimeout(settleTimer);
       settleTimer = window.setTimeout(settle, SELECTION_SETTLE_MS);
+    }
+
+    const gesture = createSelectionQuoteGestureBoundary({ hideAndCancel, scheduleSettle });
+
+    function onPointerDown(event: PointerEvent): void {
+      const root = scrollRef.current;
+      if (
+        !root ||
+        !event.isPrimary ||
+        event.button !== 0 ||
+        !(event.target instanceof Node) ||
+        !root.contains(event.target)
+      ) {
+        return;
+      }
+      gesture.beginPointerSelection(event.pointerId);
+    }
+
+    function onSelectionChange(): void {
+      gesture.selectionChanged();
+    }
+
+    function onPointerUp(event: PointerEvent): void {
+      gesture.endPointerSelection(event.pointerId);
+    }
+
+    function onPointerCancel(event: PointerEvent): void {
+      gesture.cancelPointerSelection(event.pointerId);
+    }
+
+    function onWindowBlur(): void {
+      // Releasing a mouse outside the window need not deliver pointerup back to
+      // the document. Do not leave later keyboard selections behind that drag.
+      gesture.cancelActivePointerSelection();
     }
 
     /**
@@ -132,11 +223,19 @@ export function useMessageSelectionQuote(
     }
 
     document.addEventListener('selectionchange', onSelectionChange);
+    document.addEventListener('pointerdown', onPointerDown, { capture: true });
+    document.addEventListener('pointerup', onPointerUp, { capture: true });
+    document.addEventListener('pointercancel', onPointerCancel, { capture: true });
+    window.addEventListener('blur', onWindowBlur);
     // Capture-phase: scroll does not bubble.
     document.addEventListener('scroll', onScroll, { capture: true, passive: true });
     return () => {
       window.clearTimeout(settleTimer);
       document.removeEventListener('selectionchange', onSelectionChange);
+      document.removeEventListener('pointerdown', onPointerDown, { capture: true });
+      document.removeEventListener('pointerup', onPointerUp, { capture: true });
+      document.removeEventListener('pointercancel', onPointerCancel, { capture: true });
+      window.removeEventListener('blur', onWindowBlur);
       document.removeEventListener('scroll', onScroll, { capture: true });
     };
   }, [scrollRef, enabled]);

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -190,6 +190,14 @@ export function useMessageSelectionQuote(
     }
 
     const gesture = createSelectionQuoteGestureBoundary({ hideAndCancel, scheduleSettle });
+    let captureOwner: Element | null = null;
+    let capturedPointerId: number | undefined;
+
+    function clearCaptureOwner(): void {
+      captureOwner?.removeEventListener('lostpointercapture', onLostPointerCapture);
+      captureOwner = null;
+      capturedPointerId = undefined;
+    }
 
     function onPointerDown(event: PointerEvent): void {
       const root = scrollRef.current;
@@ -215,10 +223,19 @@ export function useMessageSelectionQuote(
       }
       gesture.beginPointerSelection(event.pointerId);
       try {
+        // `lostpointercapture` belongs to the element that owns capture. Listen
+        // there instead of relying on it crossing the document boundary: in
+        // Electron, the owner receives this event even when a document-level
+        // capture listener does not. Keeping the listener on the owner also
+        // makes the capture lifetime and its cleanup one local responsibility.
+        captureOwner = turnOwner;
+        capturedPointerId = event.pointerId;
+        captureOwner.addEventListener('lostpointercapture', onLostPointerCapture);
         turnOwner.setPointerCapture(event.pointerId);
       } catch {
         // Capture can fail if Chromium has already retired the physical
         // pointer. Do not retain a gesture that can no longer deliver its end.
+        clearCaptureOwner();
         gesture.cancelPointerSelection(event.pointerId);
       }
     }
@@ -228,23 +245,29 @@ export function useMessageSelectionQuote(
     }
 
     function onPointerUp(event: PointerEvent): void {
+      if (event.pointerId === capturedPointerId) clearCaptureOwner();
       gesture.endPointerSelection(event.pointerId);
     }
 
     function onPointerCancel(event: PointerEvent): void {
+      if (event.pointerId === capturedPointerId) clearCaptureOwner();
       gesture.cancelPointerSelection(event.pointerId);
     }
 
-    function onLostPointerCapture(event: PointerEvent): void {
+    function onLostPointerCapture(event: Event): void {
       // Normal pointerup already settles first, making this a no-op. When the
       // owner loses capture without pointerup, this is the only trustworthy
       // end boundary left for the final selection.
-      gesture.endPointerSelection(event.pointerId);
+      const pointerId = (event as PointerEvent).pointerId;
+      if (pointerId !== capturedPointerId) return;
+      clearCaptureOwner();
+      gesture.endPointerSelection(pointerId);
     }
 
     function onWindowBlur(): void {
       // Releasing a mouse outside the window need not deliver pointerup back to
       // the document. Do not leave later keyboard selections behind that drag.
+      clearCaptureOwner();
       gesture.cancelActivePointerSelection();
     }
 
@@ -273,7 +296,6 @@ export function useMessageSelectionQuote(
     document.addEventListener('pointerdown', onPointerDown, { capture: true });
     document.addEventListener('pointerup', onPointerUp, { capture: true });
     document.addEventListener('pointercancel', onPointerCancel, { capture: true });
-    document.addEventListener('lostpointercapture', onLostPointerCapture, { capture: true });
     window.addEventListener('blur', onWindowBlur);
     // Capture-phase: scroll does not bubble.
     document.addEventListener('scroll', onScroll, { capture: true, passive: true });
@@ -283,7 +305,7 @@ export function useMessageSelectionQuote(
       document.removeEventListener('pointerdown', onPointerDown, { capture: true });
       document.removeEventListener('pointerup', onPointerUp, { capture: true });
       document.removeEventListener('pointercancel', onPointerCancel, { capture: true });
-      document.removeEventListener('lostpointercapture', onLostPointerCapture, { capture: true });
+      clearCaptureOwner();
       window.removeEventListener('blur', onWindowBlur);
       document.removeEventListener('scroll', onScroll, { capture: true });
     };


### PR DESCRIPTION
## Summary

The quote affordance currently treats 350 ms without a `selectionchange` as a settled drag. Once the pointer moves past the available text, the browser may stop changing the Selection while the button is still held, so the layer can appear before the gesture ends.

This makes primary pointer release the commit boundary for drag selection. Selection changes while that pointer is held clear the old affordance but do not arm the timer; pointerup then starts the existing settle path. Keyboard and programmatic selections keep the same delay, while unchanged clicks, another pointer, pointer cancellation, and window blur cannot resurrect a dismissed quote.

Pointer tracking starts only inside a turn that can own a quote. Controls elsewhere in the scroll surface, including the quote actions, therefore cannot clear the quote they are trying to consume.

The E2E drives a deterministic pointer/selection event boundary through the real transcript DOM without driver-side timing sleeps. A deterministic UI boundary test owns the timing policy.

Fixes #2400

<details>
<summary>中文对照</summary>

引用浮层目前把“350ms 内没有 `selectionchange`”当成拖选已经结束。当指针越过可选文本后，浏览器可能不再改变 Selection，但鼠标仍处于按下状态，因此浮层会在手势结束前出现。

本 PR 将主指针释放设为拖选的提交边界。指针按住期间的选区变化只会清除旧浮层，不会启动 timer；pointerup 后才进入原有 settle 路径。键盘和程序化选区仍保留相同延迟，同时未改变选区的点击、其他 pointer、pointercancel 与窗口失焦都不能让已关闭的引用浮层重新出现。

pointer tracking 只会从可拥有引用的 turn 内部开始，因此滚动区域中的其他控件（包括引用操作按钮本身）不会在消费引用前把它清掉。

E2E 改为在真实 transcript DOM 中确定性地驱动 pointer/selection event 边界，不再依赖 driver 侧 sleep；确定性的 UI boundary 单测负责时序规则。

</details>

## Verification

- `npm --workspace @maka/ui test` — 265 tests passed
- `npm --workspace @maka/desktop run build:with-deps`
- `npx biome check` on all changed source, test, and E2E files
- Focused Electron E2E passed under a local Xvfb display, including `CI=1` visible-window mode

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected non-Electron suite pass locally
- [x] Focused Electron E2E passed on Xvfb; GitHub merge-sha run pending

Does this PR entail a change in behavior?

- [x] Yes — a drag-selected quote can appear only after its pointer is released
- [ ] No
