### PR TITLE
test(storage): keep hydration crash fixture alive

### DIFF
--- a/packages/storage/src/__tests__/fixtures/session-bundle-hydration-binding-crash.ts
+++ b/packages/storage/src/__tests__/fixtures/session-bundle-hydration-binding-crash.ts
@@ -34,12 +34,20 @@ fs.promises.open = async (...args) => {
 syncBuiltinESMExports();
 
 const { createSessionBundleFileService } = await import('../../index.js');
-await createSessionBundleFileService().hydrate({
-  source: {
-    path: archivePath,
-    expectedArchiveDigest: archiveDigest as `sha256:${string}`,
-  },
-  limits: JSON.parse(limitsJson),
-  expectedSessionId: 'cloud-session-1',
-  destinationRoot,
-});
+// Keep the deliberately wedged top-level await alive until the parent delivers
+// SIGKILL. Without a referenced handle, Node exits with code 13 as soon as the
+// event loop is empty and races the crash-state assertions in the parent test.
+const keepAlive = setInterval(() => undefined, 60_000);
+try {
+  await createSessionBundleFileService().hydrate({
+    source: {
+      path: archivePath,
+      expectedArchiveDigest: archiveDigest as `sha256:${string}`,
+    },
+    limits: JSON.parse(limitsJson),
+    expectedSessionId: 'cloud-session-1',
+    destinationRoot,
+  });
+} finally {
+  clearInterval(keepAlive);
+}


### PR DESCRIPTION
## Summary

The hydration crash fixture intentionally leaves its top-level `hydrate()` await pending after writing a partial ownership binding. Once the event loop became empty, Node could detect that unsettled top-level await and exit with code 13 before the parent test delivered SIGKILL.

Keep a referenced timer alive around the hydration call and clear it if the call ever settles normally. The fixture now stays alive until the parent kills it, so the existing signal and staging-state assertions remain strict instead of accepting Node's early exit.

Fixes #2537

<details>
<summary>中文对照</summary>

hydration crash fixture 会在写入部分 ownership binding 后，故意让顶层 `hydrate()` await 永久挂起。当事件循环变空时，Node 可能把它识别为未完成的 top-level await，并在父测试发送 SIGKILL 前以退出码 13 主动结束。

本 PR 在 hydration 调用期间保留一个 ref'ed timer，并在调用正常结束时清理。这样 fixture 会一直存活到父测试主动终止，原有的 signal 与 staging 状态断言仍保持严格，不会把 Node 的提前退出当作可接受结果。

</details>

## Verification

- `npm --workspace @maka/storage run test:dist` — 770 passed, 14 platform skips
- Target crash test repeated 50 times — 50/50 passed
- `npx biome check packages/storage/src/__tests__/fixtures/session-bundle-hydration-binding-crash.ts`

## Checklist

- [x] The existing test still requires `SIGKILL`
- [x] No production code or recovery semantics changed
- [x] Formatting and affected tests pass locally
