### PR TITLE
fix(runtime): preserve imported session context

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -252,6 +252,9 @@ export interface SessionHeader {
   /** Defaults to `default` when absent on legacy session records. */
   orchestrationMode?: OrchestrationMode;
 
+  /** Zero while an imported transcript is staging; one after materialization. */
+  transcriptLedgerVersion?: 0 | 1;
+
   /** Forward-compatible schema versioning. V0.1 only writes 1. */
   schemaVersion: 1;
 }

--- a/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
@@ -382,35 +382,43 @@ describe('Host Automation coordinator', () => {
   });
 
   test('rejects new Automations whose creator Session cannot execute hosted roots', async () => {
-    await withHarness(
-      async (harness) => {
-        await harness.coordinator.prepareRecovery();
-        const result = await harness.coordinator.handlers['automation.mutate'](
-          {
-            kind: 'create',
-            sessionId: 'creator-session',
-            automationKind: 'heartbeat',
-            name: 'unsupported heartbeat',
-            prompt: 'This cannot execute here.',
-            schedule: { type: 'interval', seconds: 60 },
-          },
-          CONNECTION_CONTEXT,
-        );
-        assert.deepEqual(result, {
-          ok: false,
-          error: {
-            code: 'operation_unavailable',
-            message: 'Automations cannot execute while the target Session is in Plan mode.',
-          },
-        });
-        assert.deepEqual(await harness.store.read(), {
-          revision: 0,
-          automations: [],
-          pendingFires: [],
-        });
+    for (const scenario of [
+      {
+        creatorHeader: { collaborationMode: 'plan' as const },
+        message: 'Automations cannot execute while the target Session is in Plan mode.',
       },
-      { creatorHeader: { collaborationMode: 'plan' } },
-    );
+      {
+        creatorHeader: { transcriptLedgerVersion: 0 as const },
+        message: 'Imported Session history is still being prepared.',
+      },
+    ]) {
+      await withHarness(
+        async (harness) => {
+          await harness.coordinator.prepareRecovery();
+          const result = await harness.coordinator.handlers['automation.mutate'](
+            {
+              kind: 'create',
+              sessionId: 'creator-session',
+              automationKind: 'heartbeat',
+              name: 'unsupported heartbeat',
+              prompt: 'This cannot execute here.',
+              schedule: { type: 'interval', seconds: 60 },
+            },
+            CONNECTION_CONTEXT,
+          );
+          assert.deepEqual(result, {
+            ok: false,
+            error: { code: 'operation_unavailable', message: scenario.message },
+          });
+          assert.deepEqual(await harness.store.read(), {
+            revision: 0,
+            automations: [],
+            pendingFires: [],
+          });
+        },
+        { creatorHeader: scenario.creatorHeader },
+      );
+    }
   });
 
   test('defers a due fire while incognito without admitting execution', async () => {

--- a/packages/runtime-host/src/__tests__/external-session-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-coordinator.test.ts
@@ -11,6 +11,7 @@ import type { SessionCatalogRecord } from '@maka/storage/execution-stores';
 import { EXTERNAL_SESSION_RESULT_MAX_BYTES } from '../protocol/index.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 import { HostExternalSessionCoordinator } from '../server/external-session-coordinator.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
 
 const context: ConnectionContext = {
   hostEpoch: 'external-session-test-epoch',
@@ -158,6 +159,95 @@ test('reports conversion errors before persistence and store uncertainty after e
   assert.equal(persistenceFailure.drainRequests(), 1);
 });
 
+test('removes an imported Session when its model history cannot be prepared', async () => {
+  const fixture = coordinatorFixture([adapterFixture()], {
+    prepareImportedSessionHistory: async () => {
+      throw new Error('ledger repair failed');
+    },
+  });
+
+  assert.deepEqual(
+    await fixture.coordinator.handlers['external-session.import'](
+      { adapterId: 'codex', sourceSessionId: 'source-0' },
+      context,
+    ),
+    {
+      ok: false,
+      error: {
+        code: 'persistence_failed',
+        message: 'External Session history could not be prepared',
+      },
+    },
+  );
+  assert.equal(fixture.hasRecord('imported-1'), false);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
+test('holds Session admission through failed history preparation and cleanup', async () => {
+  let markPreparationStarted!: () => void;
+  const preparationStarted = new Promise<void>((resolve) => {
+    markPreparationStarted = resolve;
+  });
+  let releasePreparation!: () => void;
+  const preparationRelease = new Promise<void>((resolve) => {
+    releasePreparation = resolve;
+  });
+  let discarded = false;
+  const fixture = coordinatorFixture([adapterFixture()], {
+    prepareImportedSessionHistory: async () => {
+      markPreparationStarted();
+      await preparationRelease;
+      throw new Error('ledger repair failed');
+    },
+    discardImportedSession: async () => {
+      discarded = true;
+    },
+  });
+
+  const importing = fixture.coordinator.handlers['external-session.import'](
+    { adapterId: 'codex', sourceSessionId: 'source-0' },
+    context,
+  );
+  await preparationStarted;
+  let competingAdmissionEntered = false;
+  const competingAdmission = fixture.admission.run('imported-1', () => {
+    competingAdmissionEntered = true;
+    assert.equal(discarded, true);
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(competingAdmissionEntered, false);
+
+  releasePreparation();
+  const outcome = await importing;
+  await competingAdmission;
+
+  assert.equal(outcome.ok, false);
+  assert.equal(competingAdmissionEntered, true);
+  assert.equal(fixture.drainRequests(), 0);
+});
+
+test('recovers or discards staged imported Sessions after restart', async () => {
+  const recovered = coordinatorFixture([adapterFixture()]);
+  await recovered.seedStagingSession();
+  assert.equal(recovered.readHeader('imported-1')?.transcriptLedgerVersion, 0);
+
+  await recovered.coordinator.recover();
+
+  assert.equal(recovered.readHeader('imported-1')?.transcriptLedgerVersion, 1);
+
+  const discarded = coordinatorFixture([adapterFixture()], {
+    prepareImportedSessionHistory: async () => {
+      throw new Error('ledger repair failed');
+    },
+  });
+  await discarded.seedStagingSession();
+
+  await discarded.coordinator.recover();
+
+  assert.equal(discarded.hasRecord('imported-1'), false);
+  assert.equal(discarded.drainRequests(), 0);
+});
+
 function coordinatorFixture(
   adapters: readonly ExternalSessionAdapter[],
   storeOverrides: Partial<{
@@ -165,10 +255,13 @@ function coordinatorFixture(
       input: Parameters<HostStore['createImportedSession']>[0],
       messages: readonly StoredMessage[],
     ): Promise<SessionHeader>;
+    prepareImportedSessionHistory(sessionId: string): Promise<void>;
+    discardImportedSession(sessionId: string): Promise<void>;
   }> = {},
 ) {
   let sequence = 0;
   let drains = 0;
+  const admission = new SessionAdmissionGate();
   const records = new Map<string, SessionCatalogRecord>();
   const creates: Array<{
     input: Parameters<HostStore['createImportedSession']>[0];
@@ -176,7 +269,10 @@ function coordinatorFixture(
   }> = [];
   const defaultCreate: HostStore['createImportedSession'] = async (input, messages) => {
     sequence += 1;
-    const header = sessionHeader(`imported-${sequence}`, input.cwd, input.name ?? 'Imported');
+    const header = {
+      ...sessionHeader(`imported-${sequence}`, input.cwd, input.name ?? 'Imported'),
+      transcriptLedgerVersion: 0 as const,
+    };
     creates.push({ input, messages });
     records.set(header.id, {
       header,
@@ -188,6 +284,7 @@ function coordinatorFixture(
   };
   const store: HostStore = {
     createImportedSession: storeOverrides.createImportedSession ?? defaultCreate,
+    listHeaders: async () => [...records.values()].map((record) => record.header),
     readCatalogRecord: async (sessionId) => {
       const record = records.get(sessionId);
       if (!record) throw new Error(`missing record: ${sessionId}`);
@@ -197,6 +294,7 @@ function coordinatorFixture(
   return {
     coordinator: new HostExternalSessionCoordinator({
       adapters: new ExternalSessionAdapterRegistry(adapters),
+      admission,
       sessions: store,
       resolveTarget: async () => ({
         backend: 'ai-sdk',
@@ -206,11 +304,43 @@ function coordinatorFixture(
         collaborationMode: 'agent',
         orchestrationMode: 'default',
       }),
+      prepareImportedSessionHistory:
+        storeOverrides.prepareImportedSessionHistory ??
+        (async (sessionId) => {
+          const record = records.get(sessionId);
+          if (!record) throw new Error(`missing record: ${sessionId}`);
+          const header = { ...record.header, transcriptLedgerVersion: 1 as const };
+          records.set(sessionId, {
+            ...record,
+            header,
+            revision: record.revision + 1,
+            summary: headerToSummary(header),
+          });
+        }),
+      discardImportedSession:
+        storeOverrides.discardImportedSession ??
+        (async (sessionId) => {
+          records.delete(sessionId);
+        }),
       requestDrain: () => {
         drains += 1;
       },
     }),
     creates,
+    admission,
+    seedStagingSession: () =>
+      defaultCreate(
+        {
+          cwd: '/external',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'default',
+          model: 'gpt-5',
+          permissionMode: 'ask',
+        },
+        [],
+      ),
+    readHeader: (sessionId: string) => records.get(sessionId)?.header,
+    hasRecord: (sessionId: string) => records.has(sessionId),
     drainRequests: () => drains,
   };
 }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1042,8 +1042,20 @@ export async function createExecutionRuntimeHostComposition(
     });
     const externalSessions = new HostExternalSessionCoordinator({
       adapters: createExternalSessionAdapterRegistry(),
+      admission: sessionAdmission,
       sessions: stores.sessionStore,
       resolveTarget: () => sessionCatalog.resolveExternalSessionImportTarget(),
+      prepareImportedSessionHistory: (sessionId) =>
+        requireSessionManager(manager).prepareImportedSessionHistory(sessionId),
+      discardImportedSession: async (sessionId) => {
+        const outcomes = await Promise.allSettled([
+          stores.purgeConversationOperationalState(sessionId),
+          stores.sessionStore.remove(sessionId),
+        ]);
+        for (const outcome of outcomes) {
+          if (outcome.status === 'rejected') throw outcome.reason;
+        }
+      },
       requestDrain: context.requestDrain,
     });
     const plans = new HostPlanCoordinator({
@@ -1139,6 +1151,7 @@ export async function createExecutionRuntimeHostComposition(
         await skills.recover();
         await openedArtifactStore.recover();
         await sessionRetirement.recover();
+        await externalSessions.recover();
         const sessions = await stores.sessionStore.listForRecovery();
         await worktreeChildExecutor.recover(
           sessions.flatMap((session) =>

--- a/packages/runtime-host/src/server/external-session-coordinator.ts
+++ b/packages/runtime-host/src/server/external-session-coordinator.ts
@@ -23,19 +23,24 @@ import {
   projectSessionCatalogRecord,
   SessionOperationFailure,
 } from './session-catalog-coordinator.js';
+import type { SessionAdmissionGate } from './session-admission-gate.js';
 
 type ExternalSessionStore = {
   createImportedSession(
     input: CreateSessionInput,
     messages: readonly StoredMessage[],
   ): Promise<SessionHeader>;
+  listHeaders(): Promise<SessionHeader[]>;
   readCatalogRecord(sessionId: string): Promise<SessionCatalogRecord>;
 };
 
 export interface HostExternalSessionCoordinatorOptions {
   readonly adapters: ExternalSessionAdapterRegistry;
+  readonly admission: SessionAdmissionGate;
   readonly sessions: ExternalSessionStore;
   readonly resolveTarget: () => Promise<Omit<CreateSessionInput, 'cwd' | 'name'>>;
+  readonly prepareImportedSessionHistory: (sessionId: string) => Promise<void>;
+  readonly discardImportedSession: (sessionId: string) => Promise<void>;
   readonly requestDrain: () => void;
 }
 
@@ -48,15 +53,30 @@ export class HostExternalSessionCoordinator {
   };
 
   readonly #adapters: ExternalSessionAdapterRegistry;
+  readonly #admission: SessionAdmissionGate;
   readonly #sessions: ExternalSessionStore;
   readonly #resolveTarget: HostExternalSessionCoordinatorOptions['resolveTarget'];
+  readonly #prepareImportedSessionHistory: HostExternalSessionCoordinatorOptions['prepareImportedSessionHistory'];
+  readonly #discardImportedSession: HostExternalSessionCoordinatorOptions['discardImportedSession'];
   readonly #requestDrain: () => void;
 
   constructor(options: HostExternalSessionCoordinatorOptions) {
     this.#adapters = options.adapters;
+    this.#admission = options.admission;
     this.#sessions = options.sessions;
     this.#resolveTarget = options.resolveTarget;
+    this.#prepareImportedSessionHistory = options.prepareImportedSessionHistory;
+    this.#discardImportedSession = options.discardImportedSession;
     this.#requestDrain = options.requestDrain;
+  }
+
+  async recover(): Promise<void> {
+    const headers = await this.#sessions.listHeaders();
+    for (const header of headers) {
+      if (header.transcriptLedgerVersion === 0) {
+        await this.#prepareStagedSession(header.id);
+      }
+    }
   }
 
   async listSources(): Promise<OperationOutcome<'external-session.source.query'>> {
@@ -139,14 +159,13 @@ export class HostExternalSessionCoordinator {
         return this.#sessions.createImportedSession(sessionInput, messages);
       },
     });
+    let header: SessionHeader;
     try {
-      const header = await importer.import({
+      header = await importer.import({
         adapterId: input.adapterId,
         sourceSessionId: input.sourceSessionId,
         target,
       });
-      const record = await this.#sessions.readCatalogRecord(header.id);
-      return { ok: true, result: { session: projectSessionCatalogRecord(record) } };
     } catch (error) {
       if (!commitAttempted) {
         return importFailure(
@@ -162,6 +181,31 @@ export class HostExternalSessionCoordinator {
         'External Session import outcome is unknown; check the Session list before retrying',
       );
     }
+
+    let prepared: boolean;
+    try {
+      prepared = await this.#prepareStagedSession(header.id);
+    } catch {
+      this.#requestDrain();
+      return importFailure(
+        'commit_outcome_unknown',
+        'External Session import outcome is unknown; check the Session list before retrying',
+      );
+    }
+    if (!prepared) {
+      return importFailure('persistence_failed', 'External Session history could not be prepared');
+    }
+
+    try {
+      const record = await this.#sessions.readCatalogRecord(header.id);
+      return { ok: true, result: { session: projectSessionCatalogRecord(record) } };
+    } catch {
+      this.#requestDrain();
+      return importFailure(
+        'commit_outcome_unknown',
+        'External Session import outcome is unknown; check the Session list before retrying',
+      );
+    }
   }
 
   async #isDetected(adapter: ExternalSessionAdapter): Promise<boolean> {
@@ -170,6 +214,18 @@ export class HostExternalSessionCoordinator {
     } catch {
       return false;
     }
+  }
+
+  async #prepareStagedSession(sessionId: string): Promise<boolean> {
+    return this.#admission.run(sessionId, async () => {
+      try {
+        await this.#prepareImportedSessionHistory(sessionId);
+        return true;
+      } catch {
+        await this.#discardImportedSession(sessionId);
+        return false;
+      }
+    });
   }
 }
 

--- a/packages/runtime-host/src/server/host-session-availability.ts
+++ b/packages/runtime-host/src/server/host-session-availability.ts
@@ -5,10 +5,12 @@ const WORKTREE_CHILD_UNAVAILABLE_REASON =
   'Worktree child Sessions must be continued through their parent agent.';
 const CHILD_CONTINUATION_UNAVAILABLE_REASON =
   'Child Sessions must be continued through their parent agent.';
+const IMPORT_STAGING_UNAVAILABLE_REASON = 'Imported Session history is still being prepared.';
 
 export function runtimeHostAutomationSessionUnavailableReason(
-  header: Pick<SessionHeader, 'collaborationMode'>,
+  header: Pick<SessionHeader, 'collaborationMode' | 'transcriptLedgerVersion'>,
 ): string | undefined {
+  if (header.transcriptLedgerVersion === 0) return IMPORT_STAGING_UNAVAILABLE_REASON;
   if (header.collaborationMode === 'plan') {
     return 'Automations cannot execute while the target Session is in Plan mode.';
   }
@@ -16,22 +18,33 @@ export function runtimeHostAutomationSessionUnavailableReason(
 }
 
 export function runtimeHostExternalTurnUnavailableReason(
-  header: Pick<SessionHeader, 'collaborationMode' | 'subagentWorkspace'>,
+  header: Pick<
+    SessionHeader,
+    'collaborationMode' | 'subagentWorkspace' | 'transcriptLedgerVersion'
+  >,
 ): string | undefined {
   return runtimeHostExecutionUnavailableReason(header, { kind: 'external_message' });
 }
 
 export function runtimeHostSafeBoundaryContinuationUnavailableReason(
-  header: Pick<SessionHeader, 'subagentParent'>,
+  header: Pick<SessionHeader, 'subagentParent' | 'transcriptLedgerVersion'>,
 ): string | undefined {
-  return header.subagentParent ? CHILD_CONTINUATION_UNAVAILABLE_REASON : undefined;
+  return header.transcriptLedgerVersion === 0
+    ? IMPORT_STAGING_UNAVAILABLE_REASON
+    : header.subagentParent
+      ? CHILD_CONTINUATION_UNAVAILABLE_REASON
+      : undefined;
 }
 
 export function runtimeHostExecutionUnavailableReason(
-  header: Pick<SessionHeader, 'collaborationMode' | 'subagentWorkspace'>,
+  header: Pick<
+    SessionHeader,
+    'collaborationMode' | 'subagentWorkspace' | 'transcriptLedgerVersion'
+  >,
   execution: RootExecutionDescriptor,
 ): string | undefined {
   return (
+    (header.transcriptLedgerVersion === 0 ? IMPORT_STAGING_UNAVAILABLE_REASON : undefined) ??
     (header.collaborationMode === 'plan' &&
     execution.kind !== 'external_message' &&
     execution.kind !== 'regenerate' &&

--- a/packages/runtime/src/__tests__/runtime-ledger-repair.test.ts
+++ b/packages/runtime/src/__tests__/runtime-ledger-repair.test.ts
@@ -1,0 +1,194 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { StoredMessage } from '@maka/core';
+import {
+  createSqliteAgentRunStore,
+  createSqliteRuntimeStore,
+  createSessionStore,
+} from '@maka/storage';
+import { buildRuntimeEventModelReplayPlan } from '../model-history.js';
+import { buildPriorRuntimeContext } from '../prior-run-context.js';
+import { backfillRuntimeEventsFromStoredMessages } from '../runtime-event-backfill.js';
+import { RuntimeLedgerRepair } from '../runtime-ledger-repair.js';
+
+test('repairs imported transcript turns into provider-neutral canonical history', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-transcript-ledger-repair-'));
+  const sessions = createSessionStore(root);
+  const runs = createSqliteAgentRunStore(root);
+  const runtimeEvents = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
+  let sequence = 0;
+  const newId = () => `repair-${++sequence}`;
+
+  try {
+    const externalTs = Date.now() + 86_400_000;
+    const messages: StoredMessage[] = [
+      {
+        type: 'user',
+        id: 'z-user',
+        turnId: 'turn-1',
+        ts: externalTs,
+        text: 'Fix the parser',
+      },
+      {
+        type: 'assistant',
+        id: 'a-assistant',
+        turnId: 'turn-1',
+        ts: externalTs,
+        text: 'I found the issue.',
+        thinking: { text: 'provider-specific reasoning' },
+        modelId: 'external-model',
+      },
+      {
+        type: 'tool_call',
+        id: 'tool-1',
+        turnId: 'turn-1',
+        ts: externalTs,
+        toolName: 'codex::exec',
+        args: { command: 'pwd' },
+      },
+      {
+        type: 'tool_result',
+        id: 'result-1',
+        turnId: 'turn-1',
+        ts: externalTs,
+        toolUseId: 'tool-1',
+        isError: false,
+        content: { kind: 'text', text: '/repo' },
+      },
+      {
+        type: 'turn_state',
+        id: 'state-1',
+        turnId: 'turn-1',
+        ts: externalTs,
+        status: 'completed',
+        partialOutputRetained: true,
+      },
+    ];
+    const session = await sessions.createImportedSession(
+      {
+        cwd: '/repo',
+        backend: 'fake',
+        llmConnectionSlug: 'deepseek',
+        model: 'deepseek-v4-flash',
+        permissionMode: 'ask',
+      },
+      messages,
+    );
+    assert.equal(session.transcriptLedgerVersion, 0);
+    const repair = new RuntimeLedgerRepair({
+      runStore: runs,
+      runtimeEventStore: runtimeEvents,
+      readMessages: (sessionId) => sessions.readMessages(sessionId),
+      appendMessage: (sessionId, message) => sessions.appendMessage(sessionId, message),
+      appendTurnState: async () => undefined,
+      newId,
+      now: () => 100,
+    });
+
+    await repair.materializeTranscriptLedger(session);
+    await repair.materializeTranscriptLedger(session);
+
+    const [importedRun] = await runs.listSessionRuns(session.id);
+    assert.ok(importedRun);
+    assert.equal(importedRun.turnId, 'turn-1');
+    assert.equal(importedRun.status, 'completed');
+    assert.ok(importedRun.createdAt < session.createdAt);
+
+    const importedEvents = await runtimeEvents.readRuntimeEvents(session.id, importedRun.runId);
+    assert.deepEqual(
+      buildRuntimeEventModelReplayPlan(importedEvents).items.map((item) =>
+        item.kind === 'text' ? [item.role, item.content] : item.kind,
+      ),
+      [
+        ['user', 'Fix the parser'],
+        ['assistant', 'I found the issue.'],
+      ],
+    );
+
+    const continuedMessages: StoredMessage[] = [
+      {
+        type: 'user',
+        id: 'continued-user',
+        turnId: 'turn-2',
+        ts: session.createdAt + 1,
+        text: 'What should I do next?',
+      },
+      {
+        type: 'assistant',
+        id: 'continued-assistant',
+        turnId: 'turn-2',
+        ts: session.createdAt + 2,
+        text: 'Add a regression test.',
+        modelId: 'continued-model',
+      },
+      {
+        type: 'turn_state',
+        id: 'continued-state',
+        turnId: 'turn-2',
+        ts: session.createdAt + 3,
+        status: 'completed',
+        partialOutputRetained: true,
+      },
+    ];
+    const continuedRun = await runs.createRun({
+      ...importedRun,
+      runId: 'continued-run',
+      invocationId: 'continued-invocation',
+      turnId: 'turn-2',
+      status: 'completed',
+      createdAt: session.createdAt + 1,
+      updatedAt: session.createdAt + 3,
+      completedAt: session.createdAt + 3,
+    });
+    for (const event of backfillRuntimeEventsFromStoredMessages({
+      run: continuedRun,
+      messages: continuedMessages,
+      newId,
+      now: () => session.createdAt + 3,
+    }).events) {
+      await runtimeEvents.appendRuntimeEvent(session.id, continuedRun.runId, event);
+    }
+
+    const currentRunId = 'current-run';
+    await runs.createRun({
+      ...continuedRun,
+      runId: currentRunId,
+      invocationId: 'current-invocation',
+      turnId: 'turn-3',
+      status: 'running',
+      createdAt: session.createdAt + 4,
+      updatedAt: session.createdAt + 4,
+      completedAt: undefined,
+    });
+    const prior = await buildPriorRuntimeContext({
+      sessionId: session.id,
+      currentRunId,
+      currentTurnId: 'turn-3',
+      linkedChildSession: false,
+      runStore: runs,
+      runtimeEventStore: runtimeEvents,
+      runStoreAvailable: true,
+      runtimeEventStoreAvailable: true,
+      readMessages: () => sessions.readMessages(session.id),
+    });
+    assert.deepEqual(
+      buildRuntimeEventModelReplayPlan(prior?.events ?? []).items.map((item) =>
+        item.kind === 'text' ? [item.role, item.content] : item.kind,
+      ),
+      [
+        ['user', 'Fix the parser'],
+        ['assistant', 'I found the issue.'],
+        ['user', 'What should I do next?'],
+        ['assistant', 'Add a regression test.'],
+      ],
+    );
+  } finally {
+    runtimeEvents.close();
+    runs.close?.();
+    await sessions.close?.();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -4694,6 +4694,7 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
 
   test('a claimed turn waits for an in-flight session mutation before reading its header', async () => {
     const store = new VersionedConfigurationMemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
     const updateStarted = makeGate();
     const releaseUpdate = makeGate();
     const activatedModels: string[] = [];
@@ -4704,6 +4705,8 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     });
     const manager = new SessionManager({
       store,
+      runStore,
+      runtimeEventStore: runStore,
       backends,
       newId: nextId(),
       now: nextNow(26_475),
@@ -4731,11 +4734,13 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     const turn = drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'start' }));
     await new Promise<void>((resolve) => setImmediate(resolve));
     assert.deepEqual(activatedModels, []);
+    assert.equal((await store.readHeader(session.id)).transcriptLedgerVersion, undefined);
 
     releaseUpdate.release();
     await transition;
     await turn;
     assert.deepEqual(activatedModels, ['new-model']);
+    assert.equal((await store.readHeader(session.id)).transcriptLedgerVersion, 1);
   });
 
   test('backend refresh propagates delayed disposal failure after an active turn settles', async () => {
@@ -7965,6 +7970,159 @@ describe('SessionManager permission mode updates', () => {
     expect(repairedRuntimeEvents.at(-1)?.status).toBe('completed');
   });
 
+  test('sendMessage completes interrupted imported history beside native runs', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore({ failRuntimeEventAppendAfter: 3 });
+    const backends = new BackendRegistry();
+    let backend: TestBackend | undefined;
+    backends.register('fake', (ctx) => {
+      backend = new TestBackend(ctx);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(7_025),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    await store.appendMessages(session.id, [
+      { type: 'user', id: 'imported-user-1', turnId: 'turn-1', ts: 101, text: 'First question' },
+      {
+        type: 'assistant',
+        id: 'imported-assistant-1',
+        turnId: 'turn-1',
+        ts: 102,
+        text: 'First answer',
+        modelId: 'external-model',
+      },
+      {
+        type: 'turn_state',
+        id: 'imported-state-1',
+        turnId: 'turn-1',
+        ts: 103,
+        status: 'completed',
+        partialOutputRetained: true,
+      },
+      { type: 'user', id: 'imported-user-2', turnId: 'turn-2', ts: 104, text: 'Second question' },
+      {
+        type: 'assistant',
+        id: 'imported-assistant-2',
+        turnId: 'turn-2',
+        ts: 105,
+        text: 'Second answer',
+        modelId: 'external-model',
+      },
+      {
+        type: 'turn_state',
+        id: 'imported-state-2',
+        turnId: 'turn-2',
+        ts: 106,
+        status: 'completed',
+        partialOutputRetained: true,
+      },
+    ]);
+
+    await expectRejects(
+      manager.prepareImportedSessionHistory(session.id),
+      /runtime event append failed/,
+    );
+    await seedRuntimeRun(
+      runStore,
+      makeRunHeader({
+        sessionId: session.id,
+        runId: 'native-run',
+        invocationId: 'native-invocation',
+        turnId: 'turn-3',
+        status: 'completed',
+        createdAt: 10,
+        updatedAt: 12,
+        completedAt: 12,
+      }),
+      [
+        runtimeEvent({
+          id: 'native-user',
+          invocationId: 'native-invocation',
+          sessionId: session.id,
+          runId: 'native-run',
+          turnId: 'turn-3',
+          ts: 10,
+          role: 'user',
+          author: 'user',
+          content: { kind: 'text', text: 'Native question' },
+        }),
+        runtimeEvent({
+          id: 'native-assistant',
+          invocationId: 'native-invocation',
+          sessionId: session.id,
+          runId: 'native-run',
+          turnId: 'turn-3',
+          ts: 11,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text: 'Native answer' },
+        }),
+        runtimeEvent({
+          id: 'native-complete',
+          invocationId: 'native-invocation',
+          sessionId: session.id,
+          runId: 'native-run',
+          turnId: 'turn-3',
+          ts: 12,
+          status: 'completed',
+          actions: { endInvocation: true },
+        }),
+      ],
+    );
+
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-4', text: 'Continue' }));
+
+    expect(
+      backend?.sendInputs[0]?.runtimeContext?.flatMap((event) =>
+        event.content?.kind === 'text' ? [event.content.text] : [],
+      ),
+    ).toEqual([
+      'First question',
+      'First answer',
+      'Second question',
+      'Second answer',
+      'Native question',
+      'Native answer',
+    ]);
+    expect((await store.readHeader(session.id)).transcriptLedgerVersion).toBe(1);
+    const repairedRuns = await runStore.listSessionRuns(session.id);
+    expect(repairedRuns.filter((run) => run.turnId === 'turn-1')).toHaveLength(1);
+    expect(repairedRuns.filter((run) => run.turnId === 'turn-2')).toHaveLength(1);
+  });
+
+  test('sendMessage rejects an imported Session while its history is staging', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(7_040),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    await store.updateHeader(session.id, { transcriptLedgerVersion: 0 });
+
+    await expectRejects(
+      drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'Too early' })),
+      /history is still being prepared/,
+    );
+
+    expect(await runStore.listSessionRuns(session.id)).toHaveLength(0);
+  });
+
   test('sendMessage rejects missing prior ledger when legacy message reads fail', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -7997,7 +8155,7 @@ describe('SessionManager permission mode updates', () => {
       collectSessionEvents(
         manager.sendMessage(session.id, { turnId: 'turn-2', text: 'follow up' }),
       ),
-      /RuntimeEvent ledger is missing for prior run run-1/,
+      /Cannot read messages/,
     );
   });
 

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -30,6 +30,7 @@ export interface RuntimeEventBackfillInput {
   run: AgentRunHeader;
   messages: readonly StoredMessage[];
   invocationId?: string;
+  modelHistory?: 'full' | 'conversation_text';
   now?: () => number;
   newId?: () => string;
 }
@@ -59,10 +60,11 @@ export function backfillRuntimeEventsFromStoredMessages(
     input.run.invocationId ?? input.invocationId ?? `backfill-${input.run.runId}`;
   const diagnostics: RuntimeEventBackfillDiagnostic[] = [];
   const events: RuntimeEvent[] = [];
+  const conversationTextOnly = input.modelHistory === 'conversation_text';
   const turnMessages = input.messages
     .filter((message) => messageTurnId(message) === input.run.turnId)
     .slice()
-    .sort((a, b) => a.ts - b.ts || messageId(a).localeCompare(messageId(b)));
+    .sort((a, b) => a.ts - b.ts);
   const toolCalls = new Map<string, ToolCallMessage>();
   const replayableProviderToolUseIds = new Set(
     turnMessages
@@ -119,16 +121,18 @@ export function backfillRuntimeEventsFromStoredMessages(
         break;
 
       case 'assistant':
-        events.push({
-          ...base,
-          id: newId(),
-          role: 'model',
-          author: 'agent',
-          content: { kind: 'text', text: message.text },
-          actions: { stateDelta: recoveryState(now, message) },
-          refs: { storedMessageId: message.id },
-        });
-        if (message.thinking) {
+        if (!conversationTextOnly || message.text.length > 0) {
+          events.push({
+            ...base,
+            id: newId(),
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'text', text: message.text },
+            actions: { stateDelta: recoveryState(now, message) },
+            refs: { storedMessageId: message.id },
+          });
+        }
+        if (!conversationTextOnly && message.thinking) {
           const parts = message.thinking.parts ?? [message.thinking];
           for (const part of parts) {
             events.push({
@@ -152,6 +156,7 @@ export function backfillRuntimeEventsFromStoredMessages(
         break;
 
       case 'tool_call': {
+        if (conversationTextOnly) break;
         if (message.providerExecuted === true && !replayableProviderToolUseIds.has(message.id)) {
           diagnostics.push({
             code: 'skipped_provider_native_replay_gap',
@@ -200,6 +205,7 @@ export function backfillRuntimeEventsFromStoredMessages(
       }
 
       case 'tool_result': {
+        if (conversationTextOnly) break;
         if (message.providerExecuted === true && message.providerOutput === undefined) {
           break;
         }
@@ -255,6 +261,7 @@ export function backfillRuntimeEventsFromStoredMessages(
       }
 
       case 'permission_decision': {
+        if (conversationTextOnly) break;
         const call = safePriorToolCall(toolCalls, message);
         if (!call) {
           diagnostics.push({
@@ -291,6 +298,7 @@ export function backfillRuntimeEventsFromStoredMessages(
       }
 
       case 'token_usage':
+        if (conversationTextOnly) break;
         events.push({
           ...base,
           id: newId(),
@@ -313,6 +321,7 @@ export function backfillRuntimeEventsFromStoredMessages(
         break;
 
       case 'system_note':
+        if (conversationTextOnly) break;
         diagnostics.push({
           code: 'skipped_high_risk_message',
           message:

--- a/packages/runtime/src/runtime-ledger-repair.ts
+++ b/packages/runtime/src/runtime-ledger-repair.ts
@@ -1,5 +1,12 @@
-import { isSessionInlineRun, isTerminalRuntimeEvent } from '@maka/core';
-import type { AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
+import { createHash } from 'node:crypto';
+import { deriveTurnRecords, isSessionInlineRun, isTerminalRuntimeEvent } from '@maka/core';
+import type {
+  AgentRunHeader,
+  AgentRunStore,
+  RuntimeEvent,
+  RuntimeEventStore,
+  SessionHeader,
+} from '@maka/core';
 import type { StoredMessage, TurnRecord } from '@maka/core/session';
 import type { AgentRunLineage } from './agent-run.js';
 import { backfillRuntimeEventsFromStoredMessages } from './runtime-event-backfill.js';
@@ -57,6 +64,54 @@ export class RuntimeLedgerRepair {
     return this.repairRunTerminalFact(sessionId, run);
   }
 
+  async materializeTranscriptLedger(header: SessionHeader): Promise<void> {
+    const sessionId = header.id;
+    return this.withRepairQueue(sessionId, 'transcript-runs', async () => {
+      const [messages, runs] = await Promise.all([
+        this.deps.readMessages(sessionId),
+        this.deps.runStore.listSessionRuns(sessionId),
+      ]);
+      const inlineRunsByTurn = new Map(
+        runs.filter(isSessionInlineRun).map((run) => [run.turnId, run] as const),
+      );
+      const messagesByTurn = groupMessagesByTurn(messages);
+      const turns = deriveTurnRecords(messages).filter((turn) =>
+        (messagesByTurn.get(turn.turnId) ?? []).some((message) => message.type === 'user'),
+      );
+      if (turns.length === 0) return;
+
+      const firstCreatedAt = Math.max(0, header.createdAt - turns.length);
+
+      for (const [index, turn] of turns.entries()) {
+        const turnMessages = messagesByTurn.get(turn.turnId) ?? [];
+        const runId = transcriptRunId(sessionId, turn.turnId);
+        const existing = inlineRunsByTurn.get(turn.turnId);
+        if (existing && existing.runId !== runId) continue;
+        const run =
+          existing ??
+          (await this.deps.runStore.createRun(
+            transcriptRunHeader({
+              header,
+              turn,
+              turnMessages,
+              runId,
+              createdAt: firstCreatedAt + index,
+            }),
+          ));
+        if (!(await this.materializeTranscriptRun(sessionId, run))) {
+          throw new Error(`Imported transcript Run ${run.runId} could not be materialized`);
+        }
+        const runtimeEvents = await this.deps.runtimeEventStore.readRuntimeEvents(
+          sessionId,
+          run.runId,
+        );
+        if (!runtimeEvents.some((event) => isMatchingTerminalRuntimeEvent(run, event))) {
+          throw new Error(`Imported transcript Run ${run.runId} has no terminal RuntimeEvent`);
+        }
+      }
+    });
+  }
+
   async repairSteeringMessagesOnce(sessionId: string): Promise<number> {
     return this.withRepairQueue(sessionId, 'steering-transcript', async () => {
       const messages = await this.deps.readMessages(sessionId);
@@ -86,66 +141,95 @@ export class RuntimeLedgerRepair {
     return this.withRepairQueue(sessionId, staleRun.runId, async () => {
       const run = await this.deps.runStore.readRun(sessionId, staleRun.runId).catch(() => staleRun);
       if (!isTerminalRunStatus(run.status)) return false;
-      let runtimeEvents: RuntimeEvent[];
-      try {
-        runtimeEvents = await this.deps.runtimeEventStore.readRuntimeEvents(sessionId, run.runId);
-      } catch {
-        return false;
-      }
-
-      let messages: StoredMessage[];
-      try {
-        messages = await this.deps.readMessages(sessionId);
-      } catch {
-        return false;
-      }
-      const recovered = backfillRuntimeEventsFromStoredMessages({
-        run,
-        messages,
-        invocationId: runtimeEvents[0]?.invocationId,
-        newId: this.deps.newId,
-        now: this.deps.now,
-      }).events;
-      const recoveredTerminal = recovered.find((event) =>
-        isMatchingTerminalRuntimeEvent(run, event),
-      );
-      const legacyTerminal = latestTurnState(messages, run.turnId);
-      const canTrustRecoveredTerminal = recoveredTerminal
-        ? isTrustworthyRecoveredTerminal(run, legacyTerminal, recoveredTerminal)
-        : false;
-      const recoveredEventsToPersist = canTrustRecoveredTerminal
-        ? recovered
-        : recovered.filter((event) => !isMatchingTerminalRuntimeEvent(run, event));
-      const eventsToAppend = missingRecoveredRuntimeEvents(
+      const runtimeEvents = await this.deps.runtimeEventStore
+        .readRuntimeEvents(sessionId, run.runId)
+        .catch(() => undefined);
+      if (!runtimeEvents) return false;
+      const messages = await this.deps.readMessages(sessionId).catch(() => undefined);
+      if (!messages) return false;
+      return this.repairRunTerminalFactFromSnapshot(
+        sessionId,
         run,
         runtimeEvents,
-        recoveredEventsToPersist,
+        messages,
+        'full',
       );
-      for (const event of eventsToAppend) {
-        await this.deps.runtimeEventStore.appendRuntimeEvent(sessionId, run.runId, event);
-      }
-
-      const existingTerminal = [...runtimeEvents, ...eventsToAppend].find((event) =>
-        isMatchingTerminalRuntimeEvent(run, event),
-      );
-      if (existingTerminal) {
-        return (
-          (await this.repairRunHeaderFromExistingTerminal(
-            sessionId,
-            run,
-            messages,
-            legacyTerminal,
-            existingTerminal,
-          )) || eventsToAppend.length > 0
-        );
-      }
-
-      await this.repairMissingTerminalAsFailed(sessionId, run, messages, [
-        ...runtimeEvents,
-        ...eventsToAppend,
-      ]);
-      return true;
     });
+  }
+
+  private async materializeTranscriptRun(
+    sessionId: string,
+    createdRun: AgentRunHeader,
+  ): Promise<boolean> {
+    return this.withRepairQueue(sessionId, createdRun.runId, async () => {
+      const run = await this.deps.runStore.readRun(sessionId, createdRun.runId);
+      if (!isTerminalRunStatus(run.status)) return false;
+      const [runtimeEvents, messages] = await Promise.all([
+        this.deps.runtimeEventStore.readRuntimeEvents(sessionId, run.runId),
+        this.deps.readMessages(sessionId),
+      ]);
+      return this.repairRunTerminalFactFromSnapshot(
+        sessionId,
+        run,
+        runtimeEvents,
+        messages,
+        'conversation_text',
+      );
+    });
+  }
+
+  private async repairRunTerminalFactFromSnapshot(
+    sessionId: string,
+    run: AgentRunHeader,
+    runtimeEvents: readonly RuntimeEvent[],
+    messages: readonly StoredMessage[],
+    modelHistory: 'full' | 'conversation_text',
+  ): Promise<boolean> {
+    const recovered = backfillRuntimeEventsFromStoredMessages({
+      run,
+      messages,
+      modelHistory,
+      invocationId: runtimeEvents[0]?.invocationId,
+      newId: this.deps.newId,
+      now: this.deps.now,
+    }).events;
+    const recoveredTerminal = recovered.find((event) => isMatchingTerminalRuntimeEvent(run, event));
+    const legacyTerminal = latestTurnState(messages, run.turnId);
+    const canTrustRecoveredTerminal = recoveredTerminal
+      ? isTrustworthyRecoveredTerminal(run, legacyTerminal, recoveredTerminal)
+      : false;
+    const recoveredEventsToPersist = canTrustRecoveredTerminal
+      ? recovered
+      : recovered.filter((event) => !isMatchingTerminalRuntimeEvent(run, event));
+    const eventsToAppend = missingRecoveredRuntimeEvents(
+      run,
+      runtimeEvents,
+      recoveredEventsToPersist,
+    );
+    for (const event of eventsToAppend) {
+      await this.deps.runtimeEventStore.appendRuntimeEvent(sessionId, run.runId, event);
+    }
+
+    const existingTerminal = [...runtimeEvents, ...eventsToAppend].find((event) =>
+      isMatchingTerminalRuntimeEvent(run, event),
+    );
+    if (existingTerminal) {
+      return (
+        (await this.repairRunHeaderFromExistingTerminal(
+          sessionId,
+          run,
+          messages,
+          legacyTerminal,
+          existingTerminal,
+        )) || eventsToAppend.length > 0
+      );
+    }
+
+    await this.repairMissingTerminalAsFailed(sessionId, run, messages, [
+      ...runtimeEvents,
+      ...eventsToAppend,
+    ]);
+    return true;
   }
 
   private async repairRunHeaderFromExistingTerminal(
@@ -302,6 +386,64 @@ export class RuntimeLedgerRepair {
     if (latest && isTerminalTurnStatus(latest.status) && latest.status === status) return;
     await this.deps.appendTurnState(sessionId, decision.turnId, status, decision.lineage, options);
   }
+}
+
+function transcriptRunId(sessionId: string, turnId: string): string {
+  const digest = createHash('sha256').update(sessionId).update('\0').update(turnId).digest('hex');
+  return `transcript-${digest.slice(0, 48)}`;
+}
+
+function transcriptRunHeader(input: {
+  header: SessionHeader;
+  turn: TurnRecord;
+  turnMessages: readonly StoredMessage[];
+  runId: string;
+  createdAt: number;
+}): AgentRunHeader {
+  const updatedAt = Math.max(input.createdAt, ...input.turnMessages.map((message) => message.ts));
+  const status = transcriptRunStatus(input.turn.status);
+  return {
+    runId: input.runId,
+    invocationId: `invocation-${input.runId}`,
+    sessionId: input.header.id,
+    turnId: input.turn.turnId,
+    status,
+    backendKind: input.header.backend,
+    llmConnectionSlug: input.header.llmConnectionSlug,
+    modelId: input.header.model,
+    cwd: input.header.cwd,
+    permissionMode: input.header.permissionMode,
+    collaborationMode: input.header.collaborationMode,
+    orchestrationMode: input.header.orchestrationMode,
+    createdAt: input.createdAt,
+    updatedAt,
+    completedAt: updatedAt,
+    ...(status === 'failed'
+      ? { failureClass: input.turn.errorClass ?? 'external_transcript_failed' }
+      : {}),
+    ...(status === 'cancelled'
+      ? { abortSource: input.turn.abortSource ?? 'external_session_snapshot' }
+      : {}),
+  };
+}
+
+function transcriptRunStatus(status: TurnRecord['status']): AgentRunHeader['status'] {
+  if (status === 'failed') return 'failed';
+  if (status === 'aborted') return 'cancelled';
+  if (status === 'completed') return 'completed';
+  return 'cancelled';
+}
+
+function groupMessagesByTurn(messages: readonly StoredMessage[]): Map<string, StoredMessage[]> {
+  const grouped = new Map<string, StoredMessage[]>();
+  for (const message of messages) {
+    const turnId = 'turnId' in message ? message.turnId : undefined;
+    if (!turnId) continue;
+    const bucket = grouped.get(turnId) ?? [];
+    bucket.push(message);
+    grouped.set(turnId, bucket);
+  }
+  return grouped;
 }
 
 interface RuntimeLedgerRepairDecision {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -894,6 +894,7 @@ export type RuntimeContinuationLifecycleEvent =
 export class SessionManager {
   private readonly runtimeKernel: RuntimeKernelLike;
   private readonly runtimeLedgerRepair?: RuntimeLedgerRepair;
+  private readonly preparedTranscriptLedgers = new Set<string>();
   private readonly runtimeCommitSink?: RuntimeCommitSink;
   private readonly activeHostedLinkedChildSessions = new Set<string>();
   private readonly childSessionSpawns = new Map<
@@ -2087,6 +2088,13 @@ export class SessionManager {
     input: UserMessageInput,
     options: TurnStartOptions = {},
   ): AsyncIterable<SessionEvent> {
+    const repair = input.agentId ? undefined : this.runtimeLedgerRepair;
+    const admitTurn = repair
+      ? async () => {
+          await this.ensureTranscriptLedger(sessionId, repair, 'compatibility');
+          return (await options.admitTurn?.()) ?? 'admitted';
+        }
+      : options.admitTurn;
     const sourceText = sessionTitleSource(input);
     const onRunStarted = this.deps.generateSessionTitle
       ? async (runId: string, header: SessionHeader) => {
@@ -2101,7 +2109,7 @@ export class SessionManager {
           }
         }
       : options.onRunStarted;
-    yield* this.runtimeKernel.startTurn(sessionId, input, { ...options, onRunStarted });
+    yield* this.runtimeKernel.startTurn(sessionId, input, { ...options, admitTurn, onRunStarted });
   }
 
   private async generateTitleInBackground(
@@ -5562,6 +5570,29 @@ export class SessionManager {
     return (
       (await this.runtimeLedgerRepair?.repairMissingTerminalFactOnce(sessionId, runId)) ?? false
     );
+  }
+
+  async prepareImportedSessionHistory(sessionId: string): Promise<void> {
+    const repair = this.runtimeLedgerRepair;
+    if (!repair) throw new Error('Imported Session history requires canonical Runtime stores');
+    await this.ensureTranscriptLedger(sessionId, repair, 'import');
+  }
+
+  private async ensureTranscriptLedger(
+    sessionId: string,
+    repair: RuntimeLedgerRepair,
+    source: 'compatibility' | 'import',
+  ): Promise<void> {
+    if (this.preparedTranscriptLedgers.has(sessionId)) return;
+    const header = await this.deps.store.readHeader(sessionId);
+    if (header.transcriptLedgerVersion === 0 && source !== 'import') {
+      throw new Error('Imported Session history is still being prepared');
+    }
+    if (header.transcriptLedgerVersion !== 1) {
+      await repair.materializeTranscriptLedger(header);
+      await this.updateHeader(sessionId, { transcriptLedgerVersion: 1 });
+    }
+    this.preparedTranscriptLedgers.add(sessionId);
   }
 
   private async prepareConversationRuntimeLedgerClone(

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -42,6 +42,35 @@ describe('SQLite SessionStore', () => {
     }
   });
 
+  test('keeps staging imports outside the catalog pagination domain', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-staging-catalog-'));
+    const store = createSessionStore(root);
+    try {
+      const visible = await store.create(makeInput({ name: 'Visible Session' }));
+      const staging = await Promise.all(
+        Array.from({ length: 32 }, (_, index) =>
+          store.createImportedSession(makeInput({ name: `Staging Session ${index}` }), []),
+        ),
+      );
+
+      const page = await store.listCatalogPage(undefined, undefined, 32);
+
+      assert.equal(page.kind, 'page');
+      if (page.kind !== 'page') assert.fail('expected a catalog page');
+      assert.deepEqual(
+        page.records.map((record) => record.header.id),
+        [visible.id],
+      );
+      assert.equal(page.hasMore, false);
+      await assert.rejects(store.readCatalogRecord(staging[0]!.id), (error) =>
+        isSessionNotFoundError(error),
+      );
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('appending the first user message locks the session before any read', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-lock-heal-'));
     const store = createSessionStore(root);

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -369,7 +369,10 @@ class SqliteSessionStore implements SessionAuthorityStore {
     const canonicalMessages = messages.map((message) =>
       decodeStoredMessageForRecovery(JSON.parse(JSON.stringify(message)) as unknown),
     );
-    const header = buildSessionHeader(this.workspaceRoot, input);
+    const header: SessionHeader = {
+      ...buildSessionHeader(this.workspaceRoot, input),
+      transcriptLedgerVersion: 0,
+    };
     const outcome = await this.metadata.importSession(
       header,
       canonicalMessages,
@@ -990,6 +993,9 @@ export function normalizeSessionHeader(
     isPermissionMode(header.permissionMode) &&
     isCollaborationMode(header.collaborationMode) &&
     isOrchestrationMode(header.orchestrationMode) &&
+    (header.transcriptLedgerVersion === undefined ||
+      header.transcriptLedgerVersion === 0 ||
+      header.transcriptLedgerVersion === 1) &&
     header.schemaVersion === 1;
   if (!valid) {
     throw new Error(`Invalid session header for session ${sessionId}: malformed fields`);

--- a/packages/storage/src/sqlite-session-catalog-query.ts
+++ b/packages/storage/src/sqlite-session-catalog-query.ts
@@ -21,6 +21,7 @@ export function buildSqliteSessionCatalogPageQuery(
   where.push(
     "COALESCE(json_extract(metadata.payload_json, '$.conversationCopy.state'), '') <> 'preparing'",
   );
+  where.push("COALESCE(json_extract(metadata.payload_json, '$.transcriptLedgerVersion'), 1) <> 0");
   if (filter.labelSlug !== undefined) {
     where.push('selected_label.label = ?');
     parameters.push(filter.labelSlug);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -976,6 +976,10 @@ export class SqliteSessionMetadataStore {
             json_extract(metadata.payload_json, '$.conversationCopy.state'),
             ''
           ) <> 'preparing'
+          AND COALESCE(
+            json_extract(metadata.payload_json, '$.transcriptLedgerVersion'),
+            1
+          ) <> 0
       `)
       .get(sessionId) as SessionMetadataCatalogRow | undefined;
     if (!row) throw new SessionNotFoundError(sessionId);


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Imported external Sessions now prepare canonical AgentRun and RuntimeEvent history before the import is reported as successful. Each imported transcript turn receives a synthetic Run, while provider-specific reasoning and tool records remain visible in the transcript but are excluded from cross-provider model replay.

The root cause was a split history model: external imports persisted StoredMessages for rendering, but prior model context is reconstructed exclusively from canonical AgentRun ledgers. The imported conversation therefore appeared complete in Desktop while the next model request received no historical context.

The repair is owned by the shared Runtime layer rather than Desktop. New imports remain outside the public Session catalog and cannot execute until canonical history preparation commits. Startup recovery resumes or discards interrupted imports, while pre-existing orphaned transcripts are materialized per turn at the shared root-turn boundary before a new Run is admitted. Materialization is resumable after partial writes, and a durable Session marker removes repeat transcript scans after completion. Desktop, CLI, and TUI therefore consume the same canonical history without a client-specific fallback.

## Verification

- Storage full suite: 774 passed, 12 skipped, 0 failed
- Runtime full suite: 3,272 passed, 9 skipped, 0 failed
- Runtime Host full suite: 780 passed, 0 failed
- Focused Runtime and Runtime Host regressions passed
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Checklist

- [x] Tests cover canonical model replay, transcript ordering, interrupted repair, and failed-import cleanup
- [x] Lint, format, build, and affected suites pass

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

导入外部会话时，现在会在返回成功前准备好规范的 AgentRun 与 RuntimeEvent 历史。每个导入的对话轮次都会获得合成 Run；提供商特定的思考与工具记录仍保留在可见转录中，但不会进入跨提供商的模型重放。

根因是历史数据存在两套口径：外部导入只持久化了用于界面渲染的 StoredMessage，而模型的上文只从规范 AgentRun ledger 重建。因此 Desktop 中看起来完整的导入会话，在下一次模型请求中却没有历史上下文。

修复归属共享 Runtime 层，而不是 Desktop。新导入在规范历史准备提交前不会进入公共 Session 目录，也不能执行；启动恢复会继续或清理被中断的导入。已有的孤立转录会在新 Run 获准前，于共享 root-turn 边界按轮次完成物化。物化在部分写入后可继续重试，完成后由持久 Session 标记避免重复扫描转录。因此 Desktop、CLI 与 TUI 都消费同一份规范历史，不需要 client 特定 fallback。

## 验证

- Storage 全量：774 通过，12 跳过，0 失败
- Runtime 全量：3,272 通过，9 跳过，0 失败
- Runtime Host 全量：780 通过，0 失败
- Runtime 与 Runtime Host 定点回归通过
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## 检查清单

- [x] 测试覆盖规范模型重放、转录顺序、中断后重试与导入失败清理
- [x] lint、format、build 与相关测试套件通过

此 PR 是否包含行为变化？

- [x] 是——已在概要中说明
- [ ] 否

</details>
