### PR TITLE
fix(desktop): restore composer drafts after #2574 remount

### DIFF
--- a/apps/desktop/e2e/activity-card-sticky.spec.ts
+++ b/apps/desktop/e2e/activity-card-sticky.spec.ts
@@ -73,7 +73,10 @@ test('expanded activity headers stay reachable while their long details scroll',
   const groupHeader = toolGroup.locator(':scope > [role="button"]');
   await groupHeader.click();
 
-  const callHeader = toolGroup.locator('[data-slot="chat-tool-call-row"]').first();
+  // Stock ChatToolCalls marks expandable call rows with role=button only —
+  // data-slot="chat-tool-call-row" was a removed Astryx patch (#2574). Nested
+  // rows live under the group content; the group header is the direct child.
+  const callHeader = toolGroup.locator(':scope [role="button"]').nth(1);
   await callHeader.click();
   await toolGroup.locator('.maka-chat-tool-detail-inner').first().evaluate((element) => {
     element.style.minHeight = '720px';

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2685,10 +2685,10 @@ function AppShellContent({
                 />
               ) : null}
               <ChatSurfaceLayout
-                // Session switch remounts the layout so scroll / new-message
-                // state cannot leak. Composer draft is keyed by session id
-                // outside ChatLayout, so remount does not drop it.
-                key={activeId ?? 'no-session'}
+                // Stay mounted across session switches. Remounting would drop the
+                // Composer draft Map (drafts are not hosted outside this tree).
+                // Stock ChatLayout has no conversationKey; accept that scroll /
+                // new-message state is owned by content swaps, not a hard remount.
                 hidden={navSelection.section !== 'sessions'}
                 composer={
                   <>

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -93,8 +93,7 @@
 }
 
 .maka-turn .maka-activity-card-header[aria-expanded="true"],
-.maka-turn .maka-tool-activity-card > [role="button"][aria-expanded="true"],
-.maka-turn .maka-tool-activity-card [data-slot="chat-tool-call-row"][aria-expanded="true"] {
+.maka-turn .maka-tool-activity-card [role="button"][aria-expanded="true"] {
   position: sticky;
   top: var(--maka-activity-sticky-top);
   z-index: var(--z-sticky);
@@ -105,12 +104,13 @@
 
 /* A call detail inside an expanded tool group forms a second, bounded sticky
    tier. The group remains available to collapse the whole run; the lower row
-   collapses only the detail currently being read. */
+   collapses only the detail currently being read.
+   Stock ChatToolCalls uses role=button on call rows (no data-slot patch). */
 .maka-turn
   .maka-tool-activity-card
   > [role="button"][aria-expanded="true"]
   ~ div
-  [data-slot="chat-tool-call-row"][aria-expanded="true"] {
+  [role="button"][aria-expanded="true"] {
   top: calc(var(--maka-activity-sticky-top) + var(--maka-activity-header-height));
 }
 
@@ -124,7 +124,7 @@
 /* Cursor for tool/reasoning disclosure triggers is owned by
    styles/native-cursor.css (role=button + default !important). */
 
-.maka-turn .astryx-chat-tool-calls :is([role="button"], [data-slot="chat-tool-call-row"]) > span:nth-child(2) {
+.maka-turn .astryx-chat-tool-calls [role="button"] > span:nth-child(2) {
   font: var(--maka-text-label);
 }
 
@@ -151,7 +151,7 @@
    the rule enlarged the leading icon wrapper and left the reasoning text at
    supporting size — the one row the retune was for. */
 .maka-turn .astryx-chat-reasoning [role="button"],
-.maka-turn .astryx-chat-tool-calls :is([role="button"], [data-slot="chat-tool-call-row"]) {
+.maka-turn .astryx-chat-tool-calls [role="button"] {
   --text-supporting-size: var(--text-body-size);
   --text-supporting-leading: var(--maka-line-body);
 }

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -909,9 +909,12 @@ export const ExtensionsSkillsScrollContainment: Story = {
       canvasElement,
       '[aria-label="技能视图"]',
     );
+    // Stock Astryx List does not forward aria-label; this story only needs a
+    // stable handle on the installed rows to find the overflowing scroller
+    // (#2236 header containment), not a List a11y contract deleted in #2574.
     const rows = await waitForStorySelector<HTMLElement>(
       canvasElement,
-      '[aria-label="技能列表"]',
+      '.maka-module-page-rows',
     );
     // The scroller is whichever ancestor of the rows actually overflows —
     // asserting through the DOM, not through a class name the layout could


### PR DESCRIPTION
## Summary

- **#2574** remounted `ChatSurfaceLayout` with `key={activeId}` so scroll state would not leak. That also remounted the Composer and wiped its in-component draft Map. The PR comment claimed drafts lived outside the layout; they do not.
- Remove that remount so session switch / revision flows keep unsent drafts (composer skill leave-return, skill-draft-lifecycle).
- Align two **patch-era** selectors with stock Astryx (not product fixes):
  - activity-card e2e: `role=button` instead of `data-slot="chat-tool-call-row"`
  - skills scroll story: `.maka-module-page-rows` instead of `[aria-label="技能列表"]` (List does not forward `aria-label`)

## Test plan

- [ ] Desktop: type a draft with skill chips → 新任务 → return to previous session → draft and chips still present
- [ ] Revision + disable skill send failure: composer still shows the edited text / skill token
- [ ] Storybook smoke: `extensions-skills-scroll-containment` passes
- [ ] activity-card sticky e2e: expandable tool rows still sticky under group expand
- [ ] Optional: switch sessions and confirm no severe scroll/new-message bleed (accepted tradeoff vs draft loss)