### PR TITLE
fix(desktop): keep generated files user-controlled

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-visibility.test.ts
@@ -32,10 +32,17 @@ describe('generated artifact visibility', () => {
     assert.deepEqual(filterUserVisibleArtifacts(hiddenSources.map(artifact)), []);
   });
 
-  it('preserves user-facing generated files and legacy records without a source', () => {
-    const visibleSources: Array<ArtifactSource | undefined> = [
+  it('excludes generic tool traces from generated files', () => {
+    const hiddenSources: ArtifactSource[] = [
       'tool_result',
       'tool_result_archive',
+    ];
+
+    assert.deepEqual(filterUserVisibleArtifacts(hiddenSources.map(artifact)), []);
+  });
+
+  it('preserves user-facing generated files and legacy records without a source', () => {
+    const visibleSources: Array<ArtifactSource | undefined> = [
       'subagent_writeback',
       'deep_research',
       'export',

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -71,7 +71,6 @@ import {
   findPreferredSideChatWorkbarTab,
   terminalRefFromWorkbarTab,
   terminalSessionWorkbarTabId,
-  staticSessionWorkbarTabId,
 } from './session-workbar-tabs';
 import {
   consumeCompanionInitialPrompt,
@@ -181,7 +180,6 @@ import { useShellChatModel } from './use-shell-chat-model';
 import { useShellLiveTurn } from './use-shell-live-turn';
 import { useShellLayout } from './use-shell-layout';
 import { useShellResume } from './use-shell-resume';
-import { filterUserVisibleArtifacts } from './artifact-visibility';
 import { recoverOrphanedCompanionCopies } from './quote-companion-core';
 import { useSideConversationWorkspace } from './use-side-conversation-workspace';
 
@@ -1324,9 +1322,6 @@ function AppShellContent({
     pinWorkbarTab,
     openWorkbarLauncher,
   } = useShellLayout();
-  const workbarPanelsStateRef = useRef(workbarPanelsState);
-  workbarPanelsStateRef.current = workbarPanelsState;
-
   const revealWorkbarLauncher = useCallback(() => {
     setWorkbarCollapsed(false);
     openWorkbarLauncher('right');
@@ -1389,55 +1384,6 @@ function AppShellContent({
         : [],
     [activeId, workbarCopy],
   );
-  useEffect(() => {
-    return window.maka.artifacts.subscribeChanges((event) => {
-      if (
-        event.reason !== 'created' ||
-        event.sessionId !== activeIdRef.current ||
-        navSelectionRef.current.section !== 'sessions'
-      ) {
-        return;
-      }
-      const expectedSessionId = event.sessionId;
-      void window.maka.artifacts
-        .get(expectedSessionId, event.artifactId)
-        .then((artifact) => {
-          if (
-            !artifact ||
-            activeIdRef.current !== expectedSessionId ||
-            navSelectionRef.current.section !== 'sessions' ||
-            filterUserVisibleArtifacts([artifact]).length === 0
-          ) {
-            return;
-          }
-          const filesTabId = staticSessionWorkbarTabId('files');
-          const current = workbarPanelsStateRef.current;
-          const placement = current.right.tabs.some(
-            (tab) => tab.id === filesTabId,
-          )
-            ? 'right'
-            : current.bottom.tabs.some((tab) => tab.id === filesTabId)
-              ? 'bottom'
-              : 'right';
-          openDynamicWorkbarTab(
-            {
-              id: filesTabId,
-              kind: 'files',
-              preview: true,
-            },
-            placement,
-          );
-          if (placement === 'right') setWorkbarCollapsed(false);
-          else setBottomPanelOpen(true);
-        })
-        .catch(() => {});
-    });
-  }, [
-    openDynamicWorkbarTab,
-    setBottomPanelOpen,
-    setWorkbarCollapsed,
-  ]);
-
   const openSideConversationWithQuote = useCallback(
     (quote: QuoteRef) => {
       if (!activeId) return;

--- a/apps/desktop/src/renderer/artifact-pane.tsx
+++ b/apps/desktop/src/renderer/artifact-pane.tsx
@@ -93,7 +93,6 @@ export function ArtifactPane(props: {
   const recordsSessionIdRef = useRef<string | undefined>(undefined);
   const pendingArtifactListRetryRef = useRef(false);
   const pendingArtifactActionRef = useRef<string | null>(null);
-  const pendingCreatedArtifactIdRef = useRef<string | null>(null);
 
   artifactPaneSessionIdRef.current = sessionId;
 
@@ -104,7 +103,6 @@ export function ArtifactPane(props: {
       artifactListRequestSeqRef.current += 1;
       pendingArtifactListRetryRef.current = false;
       pendingArtifactActionRef.current = null;
-      pendingCreatedArtifactIdRef.current = null;
     };
   }, []);
 
@@ -156,9 +154,6 @@ export function ArtifactPane(props: {
     // (one session's worth) and the metadata is already in memory on main.
     const unsubscribe = window.maka.artifacts.subscribeChanges((event) => {
       if (event.sessionId === sessionId) {
-        if (event.reason === 'created') {
-          pendingCreatedArtifactIdRef.current = event.artifactId;
-        }
         void refresh();
       }
     });
@@ -179,17 +174,6 @@ export function ArtifactPane(props: {
 
   // 已删除墓碑记录保持可选，用于展示明确失败态；只有选中 id 彻底消失时才回退到最新 live artifact。
   useEffect(() => {
-    const pendingId = pendingCreatedArtifactIdRef.current;
-    if (pendingId && recordsSessionId === sessionId) {
-      if (activeRecords.some((record) => record.id === pendingId)) {
-        pendingCreatedArtifactIdRef.current = null;
-        if (selectedId !== pendingId) setSelectedId(pendingId);
-        return;
-      }
-      if (records.some((record) => record.id === pendingId)) {
-        pendingCreatedArtifactIdRef.current = null;
-      }
-    }
     if (activeRecords.length === 0) {
       if (selectedId !== null) setSelectedId(null);
       return;
@@ -197,7 +181,7 @@ export function ArtifactPane(props: {
     if (!selectedId || !activeRecords.some((record) => record.id === selectedId)) {
       setSelectedId(preferredArtifactSelectionId(activeRecords));
     }
-  }, [activeRecords, records, recordsSessionId, selectedId, sessionId]);
+  }, [activeRecords, selectedId]);
 
   const previewRecord = useMemo(
     () => view.kind === 'preview'

--- a/apps/desktop/src/renderer/artifact-visibility.ts
+++ b/apps/desktop/src/renderer/artifact-visibility.ts
@@ -1,8 +1,8 @@
 import type { ArtifactDescriptor, ArtifactSource } from '@maka/core';
 
 const USER_VISIBLE_ARTIFACT_SOURCES = {
-  tool_result: true,
-  tool_result_archive: true,
+  tool_result: false,
+  tool_result_archive: false,
   synthesis_cache_block: false,
   history_compact_block: false,
   history_compact_source: false,


### PR DESCRIPTION
## Summary

- Keep the generated-files workbar closed until the user opens it.
- Preserve the current file selection when artifact events refresh an open pane.
- Exclude generic tool results and archived tool traces from the generated-files list.

The renderer previously treated any visible artifact event as navigation intent, while the visibility policy also classified internal tool traces as user-facing files. This change removes those two implicit behaviors without introducing a parallel component or state path.

## Verification

- Added a regression test that fails when `tool_result` or `tool_result_archive` appears in the user-visible artifact list; 3 focused visibility tests pass.
- CI passed after rebasing onto the latest `main`, including typecheck, affected workspace tests, Storybook smoke, alignment audit, both E2E shards, and the Windows baseline.
- Local renderer build, renderer typecheck, Biome lint and format checks, and `git diff --check` passed.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
