### PR TITLE
ci: cut wall-clock via impact gates and single e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,38 +223,11 @@ jobs:
           require_lane "Runtime Host tests" "$RUNTIME_HOST_SELECTED" "$RUNTIME_HOST_RESULT"
           require_lane "Headless tests" "$HEADLESS_SELECTED" "$HEADLESS_RESULT"
 
-  e2e_shard:
-    needs: changes
-    if: needs.changes.outputs.e2e == 'true'
-    name: e2e_shard (${{ matrix.shard }}/2)
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-          cache: npm
-      - run: npm ci
-      # Each shard keeps one Playwright worker on its own runner and X display.
-      # This overlaps independent Electron cold starts without reintroducing
-      # the OS-focus races observed with multiple workers on one display.
-      - name: Ensure xvfb
-        run: command -v xvfb-run >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y xvfb; }
-      - name: E2E shard ${{ matrix.shard }}/2
-        run: xvfb-run -a npm --workspace @maka/desktop run e2e -- --shard=${{ matrix.shard }}/2
-
-  # Design governance: the CDP alignment auditor walks the e2e-fixture fixtures
-  # and fails on same-type height mismatches, mixed-type centerline drift, or
-  # radius-family splits. It shares the e2e selection gate and the built
-  # renderer, but not the suite's critical path: it has no data dependency on
-  # Playwright, and riding shard 1 made that shard ~51s longer than shard 2 for
-  # work the shard did not need. Its own runner pays one extra checkout and
-  # build in exchange for balanced shards.
-  alignment_audit:
+  # One Electron job: install once, run the (now small) e2e suite, then the
+  # CDP alignment audit against the same built renderer. Dual shards plus a
+  # separate audit job each paid full npm ci + cold build after the suite
+  # slash; that was pure wall-clock and runner waste.
+  e2e:
     needs: changes
     if: needs.changes.outputs.e2e == 'true'
     runs-on: ubuntu-latest
@@ -267,43 +240,10 @@ jobs:
       - run: npm ci
       - name: Ensure xvfb
         run: command -v xvfb-run >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y xvfb; }
-      - name: Build renderer
-        run: npm --workspace @maka/desktop run build:with-deps
+      - name: Desktop e2e
+        run: xvfb-run -a npm --workspace @maka/desktop run e2e
       - name: Alignment audit
         run: xvfb-run -a node scripts/audit-alignment.mjs
-
-  # Preserve the existing required check while every selected shard retains
-  # its own failure and diagnostic output. The audit lane joins the same gate
-  # so splitting it out does not drop it from the required check.
-  e2e:
-    needs: [changes, e2e_shard, alignment_audit]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require successful E2E shards
-        env:
-          CHANGES_RESULT: ${{ needs.changes.result }}
-          E2E_SELECTED: ${{ needs.changes.outputs.e2e }}
-          SHARDS_RESULT: ${{ needs.e2e_shard.result }}
-          AUDIT_RESULT: ${{ needs.alignment_audit.result }}
-        run: |
-          if [[ "$CHANGES_RESULT" != "success" ]]; then
-            echo "changes failed: $CHANGES_RESULT" >&2
-            exit 1
-          fi
-          expected="skipped"
-          if [[ "$E2E_SELECTED" == "true" ]]; then
-            expected="success"
-          fi
-          if [[ "$SHARDS_RESULT" != "$expected" ]]; then
-            echo "E2E shards expected $expected but were $SHARDS_RESULT" >&2
-            exit 1
-          fi
-          if [[ "$AUDIT_RESULT" != "$expected" ]]; then
-            echo "Alignment audit expected $expected but was $AUDIT_RESULT" >&2
-            exit 1
-          fi
-
   # Storybook build + initial render smoke. Embedded mode disables every play
   # function, so this lane never duplicates desktop interaction or layout E2E.
   # It launches Chromium only to catch catalog runtime errors. See FIDELITY.md.

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -49,14 +49,49 @@ function isStorybookCatalogPath(path) {
   return false;
 }
 
+/** Unit / contract tests under src — not the Storybook catalog mount surface. */
+function isPackageTestPath(path) {
+  if (path.includes('/__tests__/')) return true;
+  if (/\.test\.(ts|tsx|js|mjs)$/.test(path)) return true;
+  return false;
+}
+
+/**
+ * Product UI that product stories import. Test files under packages/ui/src
+ * only need the unit lane — forcing Storybook (~2m wall with Chromium +
+ * build-storybook) on every presentation unit edit was pure wall-clock waste.
+ */
+function isUiProductSourcePath(path) {
+  if (path === 'packages/ui/src' || path.startsWith('packages/ui/src/')) {
+    return !isPackageTestPath(path);
+  }
+  return false;
+}
+
 function isStorybookPath(path) {
   if (STORYBOOK_DRIVING_SCRIPTS.has(path) || path === STORYBOOK_CORE_SETTINGS) return true;
-  if (path === 'apps/desktop/src/renderer' || path.startsWith('apps/desktop/src/renderer/'))
-    return true;
+  if (path === 'apps/desktop/src/renderer' || path.startsWith('apps/desktop/src/renderer/')) {
+    // Renderer unit tests do not change Storybook mount code.
+    return !isPackageTestPath(path);
+  }
   if (isStorybookCatalogPath(path)) return true;
-  // packages/ui ships both the primitives mounted by product stories and its
-  // own story tree (see .storybook/main.ts).
-  if (path === 'packages/ui/src' || path.startsWith('packages/ui/src/')) return true;
+  // packages/ui product sources (not __tests__) ship into the catalog.
+  if (isUiProductSourcePath(path)) return true;
+  return false;
+}
+
+/**
+ * Electron e2e should pay cold install/boot only when the real window surface
+ * or e2e driver changed — not when only packages/ui unit tests changed.
+ */
+function isE2eProductPath(path) {
+  if (E2E_DRIVING_SCRIPTS.has(path)) return true;
+  if (path === 'apps/desktop' || path.startsWith('apps/desktop/')) {
+    // Storybook catalog under desktop never needs a real Electron window.
+    if (isStorybookCatalogPath(path)) return false;
+    return true;
+  }
+  if (isUiProductSourcePath(path)) return true;
   return false;
 }
 
@@ -246,16 +281,10 @@ export function planTests(changedFiles, options = {}) {
 
   return {
     code,
-    // Electron E2E + alignment audit. Direct desktop/ui only — a storage or
-    // runtime change must not drag cold Electron boots.
-    //
-    // Scripts that DRIVE the suite belong here too. `scripts/**` only sets
-    // scriptMode, so without this a change to the auditor itself was verified
-    // by its unit tests and never by the run it orchestrates.
-    e2e:
-      directWorkspaces.has('apps/desktop') ||
-      directWorkspaces.has('packages/ui') ||
-      files.some((path) => E2E_DRIVING_SCRIPTS.has(path)),
+    // Electron E2E + alignment audit (same job). Product desktop/ui sources and
+    // e2e drivers only — a storage/runtime change must not drag cold Electron
+    // boots, and packages/ui unit-test-only PRs must not either.
+    e2e: files.some((path) => isE2eProductPath(path)),
     full: false,
     // packages/cli/src/__tests__/runtime-host-session-driver.test.ts executes real sandboxed
     // shell tools, so the bubblewrap + user-namespace setup is required whenever

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -25,10 +25,7 @@ test('impact planning distinguishes docs, UI, and backend changes', () => {
   assert.equal(uiUnitOnly.e2e, false);
   assert.equal(uiUnitOnly.storybook, false);
   assert.ok(uiUnitOnly.workspaces.includes('packages/ui'));
-  assert.equal(
-    planTests(['packages/ui/src/composer.tsx'], { graph }).e2e,
-    true,
-  );
+  assert.equal(planTests(['packages/ui/src/composer.tsx'], { graph }).e2e, true);
 
   // Renderer code is mounted by product stories; main-process and e2e files are not.
   assert.equal(

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -17,6 +17,19 @@ test('impact planning distinguishes docs, UI, and backend changes', () => {
   assert.equal(ui.scriptMode, 'none');
   assert.deepEqual(ui.workspaces, ['packages/ui', 'apps/desktop']);
 
+  // Unit-only packages/ui edits still run workspace tests, but must not force
+  // cold Electron e2e or Storybook build+Chromium smoke.
+  const uiUnitOnly = planTests(['packages/ui/src/__tests__/tool-activity-presentation.test.ts'], {
+    graph,
+  });
+  assert.equal(uiUnitOnly.e2e, false);
+  assert.equal(uiUnitOnly.storybook, false);
+  assert.ok(uiUnitOnly.workspaces.includes('packages/ui'));
+  assert.equal(
+    planTests(['packages/ui/src/composer.tsx'], { graph }).e2e,
+    true,
+  );
+
   // Renderer code is mounted by product stories; main-process and e2e files are not.
   assert.equal(
     planTests(['apps/desktop/src/renderer/settings/daily-review-settings-page.tsx'], {
@@ -26,6 +39,7 @@ test('impact planning distinguishes docs, UI, and backend changes', () => {
   );
   assert.equal(planTests(['apps/desktop/src/main/main.ts'], { graph }).storybook, false);
   assert.equal(planTests(['apps/desktop/e2e/settings.spec.ts'], { graph }).storybook, false);
+  assert.equal(planTests(['apps/desktop/e2e/settings.spec.ts'], { graph }).e2e, true);
 
   // Catalog + harness changes build and render the catalog without paying for
   // workspace tests or real-window Electron E2E.


### PR DESCRIPTION
## Summary

CI wall-clock on recent main merges is ~3–3.5 minutes and is dominated by the **longest parallel lane**, not the sum of jobs. Measurement on #2580 / #2587 showed:

- `test_workspaces` ~177s often sets the critical path on large PRs
- **Storybook ~130s** was still selected for pure `packages/ui` **unit test** edits
- Electron paid **three** cold installs (`e2e`×2 + `alignment_audit`) after the e2e suite was already slim

### Changes

1. **Impact plan** (`scripts/ci-test-plan.mjs`): unit/test paths under `packages/ui/src` and renderer no longer force Storybook or Electron e2e; product sources still do.
2. **Workflow**: one `e2e` job runs desktop e2e then alignment audit (shared `npm ci` + built renderer). Removed shard matrix and standalone alignment job.

## Test plan

- [x] `node --test scripts/ci-test-plan.test.mjs`
- [ ] PR CI shows single `e2e` job when e2e selected (no `e2e_shard` / `alignment_audit`)
- [ ] A packages/ui `__tests__`-only commit does not start storybook or e2e