### PR TITLE
feat(runtime-host): add authenticated WebSocket access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13555,9 +13555,11 @@
         "@maka/core": "0.1.0",
         "@maka/runtime": "0.1.0",
         "@maka/storage": "0.1.0",
+        "ws": "^8.21.1",
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@types/ws": "^8.18.1",
         "electron": "^43.2.0"
       }
     },

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -20,11 +20,46 @@ describe('Maka CLI args', () => {
       ],
       [
         ['runtime-host'],
-        { kind: 'error', message: 'runtime-host requires the serve command', exitCode: 2 },
+        {
+          kind: 'error',
+          message: 'runtime-host requires the serve or access command',
+          exitCode: 2,
+        },
       ],
       [
         ['runtime-host', 'serve', '--root'],
-        { kind: 'error', message: '--root requires a directory', exitCode: 2 },
+        { kind: 'error', message: '--root requires a value', exitCode: 2 },
+      ],
+      [
+        ['runtime-host', 'serve', '--websocket-port', '43120', '--websocket-host', '::1'],
+        {
+          kind: 'runtime-host-serve',
+          websocket: { host: '::1', port: 43120 },
+        },
+      ],
+      [
+        [
+          'runtime-host',
+          'access',
+          'issue',
+          '--principal',
+          'device-1',
+          '--grant',
+          'session.catalog.query',
+          '--grant',
+          'subscription.open',
+        ],
+        {
+          kind: 'runtime-host-access-issue',
+          principalId: 'device-1',
+          operationGrants: ['session.catalog.query', 'subscription.open'],
+          canPublishClientCapabilities: false,
+          canUseHostPaths: false,
+        },
+      ],
+      [
+        ['runtime-host', 'access', 'revoke', '--credential', 'credential-1'],
+        { kind: 'runtime-host-access-revoke', credentialId: 'credential-1' },
       ],
       [['run', 'hello', '--max-steps', '3'], { kind: 'run', args: ['hello', '--max-steps', '3'] }],
       [['-p', 'hello', '--max-steps', '3'], { kind: 'run', args: ['hello', '--max-steps', '3'] }],

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
+import { parseRuntimeHostCommand, type RuntimeHostCliCommand } from './runtime-host-cli.js';
 
 export type MakaCliCommand =
   | { kind: 'tui'; resumeSessionId?: string; resumeCwd?: string }
@@ -11,7 +12,7 @@ export type MakaCliCommand =
   | { kind: 'activate'; args: string[] }
   | { kind: 'eval'; args: string[] }
   | { kind: 'inspect'; args: string[] }
-  | { kind: 'runtime-host-serve'; rootPath?: string }
+  | RuntimeHostCliCommand
   | { kind: 'help'; text: string }
   | { kind: 'version'; text: string }
   | { kind: 'error'; message: string; exitCode: number };
@@ -98,13 +99,31 @@ function helpText(): string {
     '  maka -p ...       Alias for maka run',
     '  maka eval ...     Run evaluation and autonomous task commands',
     '  maka inspect ...  Inspect Session, AgentRun, or TaskRun evidence',
-    '  maka runtime-host serve [--root <path>]  Run a local Runtime Host service',
+    '  maka runtime-host serve [options]  Run a Runtime Host service',
+    '  maka runtime-host access issue --principal <id> --grant <operation>',
+    '  maka runtime-host access revoke --credential <id>',
     '',
     'Options:',
     '  -h, --help        Show help',
     '  -v, --version     Show version',
     '  --resume <session-id>  Reopen a previous session in the TUI',
     '  --resume <id> --cwd <path>  Reopen a session after its directory moved',
+    '',
+    'Runtime Host service options:',
+    '  --root <path>                 Select the canonical data root',
+    '  --websocket-port <port>       Enable an authenticated WebSocket listener',
+    '  --websocket-host <host>       Bind host (default: 127.0.0.1)',
+    '  --websocket-path <path>       Upgrade path (default: /runtime-host)',
+    '  --tls-certificate <path>      TLS certificate for WSS',
+    '  --tls-private-key <path>      TLS private key for WSS',
+    '  --allow-origin <origin>       Allow one browser Origin (repeatable)',
+    '',
+    'Runtime Host access issue options:',
+    '  --root <path>                 Select the canonical data root',
+    '  --principal <id>              Name the authenticated Client principal',
+    '  --grant <operation>           Grant one exact operation (repeatable)',
+    '  --publish-client-capabilities Allow Client Capability publication',
+    '  --allow-host-paths            Allow operations that submit Host paths',
   ].join('\n');
 }
 
@@ -135,7 +154,27 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
     }
     case 'runtime-host-serve': {
       const { runRuntimeHostServiceCli } = await import('./runtime-host-service-command.js');
-      return runRuntimeHostServiceCli(command.rootPath ?? resolveMakaWorkspaceRoot());
+      return runRuntimeHostServiceCli({
+        rootPath: command.rootPath ?? resolveMakaWorkspaceRoot(),
+        ...(command.websocket ? { websocket: command.websocket } : {}),
+      });
+    }
+    case 'runtime-host-access-issue': {
+      const { runRuntimeHostAccessIssueCli } = await import('./runtime-host-access-command.js');
+      return runRuntimeHostAccessIssueCli({
+        rootPath: command.rootPath ?? resolveMakaWorkspaceRoot(),
+        principalId: command.principalId,
+        operationGrants: command.operationGrants,
+        canPublishClientCapabilities: command.canPublishClientCapabilities,
+        canUseHostPaths: command.canUseHostPaths,
+      });
+    }
+    case 'runtime-host-access-revoke': {
+      const { runRuntimeHostAccessRevokeCli } = await import('./runtime-host-access-command.js');
+      return runRuntimeHostAccessRevokeCli({
+        rootPath: command.rootPath ?? resolveMakaWorkspaceRoot(),
+        credentialId: command.credentialId,
+      });
     }
     case 'help':
       process.stdout.write(`${command.text}\n`);
@@ -158,30 +197,6 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
       });
     }
   }
-}
-
-function parseRuntimeHostCommand(argv: string[]): MakaCliCommand {
-  if (argv[0] !== 'serve') {
-    return {
-      kind: 'error',
-      message: argv[0]
-        ? `Unexpected runtime-host command: ${argv[0]}`
-        : 'runtime-host requires the serve command',
-      exitCode: 2,
-    };
-  }
-  if (argv[1] === undefined) return { kind: 'runtime-host-serve' };
-  if (argv[1] !== '--root') {
-    return { kind: 'error', message: `Unexpected argument: ${argv[1]}`, exitCode: 2 };
-  }
-  const rootPath = argv[2];
-  if (!rootPath || rootPath.startsWith('-')) {
-    return { kind: 'error', message: '--root requires a directory', exitCode: 2 };
-  }
-  if (argv[3] !== undefined) {
-    return { kind: 'error', message: `Unexpected argument: ${argv[3]}`, exitCode: 2 };
-  }
-  return { kind: 'runtime-host-serve', rootPath };
 }
 
 async function readPackageVersion(): Promise<string> {

--- a/packages/cli/src/runtime-host-access-command.ts
+++ b/packages/cli/src/runtime-host-access-command.ts
@@ -1,0 +1,88 @@
+import {
+  connectExistingRuntimeHost,
+  consumeAccessCredentialDelivery,
+} from '@maka/runtime-host/client';
+import {
+  isOperationKey,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type OperationKey,
+} from '@maka/runtime-host/protocol';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+export interface RuntimeHostAccessIssueOptions {
+  readonly rootPath: string;
+  readonly principalId: string;
+  readonly operationGrants: readonly string[];
+  readonly canPublishClientCapabilities: boolean;
+  readonly canUseHostPaths: boolean;
+}
+
+export interface RuntimeHostAccessRevokeOptions {
+  readonly rootPath: string;
+  readonly credentialId: string;
+}
+
+export async function runRuntimeHostAccessIssueCli(
+  options: RuntimeHostAccessIssueOptions,
+): Promise<number> {
+  const operationGrants = requireOperationGrants(options.operationGrants);
+  const connection = await connectLocalOwner(options.rootPath);
+  try {
+    const result = await connection.request('access.credential.issue', {
+      principalId: options.principalId,
+      operationGrants,
+      canPublishClientCapabilities: options.canPublishClientCapabilities,
+      canUseHostPaths: options.canUseHostPaths,
+    });
+    const credential = await consumeAccessCredentialDelivery(
+      options.rootPath,
+      result.deliveryId,
+      result.credentialId,
+    );
+    const { deliveryId: _deliveryId, ...metadata } = result;
+    process.stdout.write(`${JSON.stringify({ ...metadata, credential }, null, 2)}\n`);
+    return 0;
+  } finally {
+    await connection.close();
+  }
+}
+
+export async function runRuntimeHostAccessRevokeCli(
+  options: RuntimeHostAccessRevokeOptions,
+): Promise<number> {
+  const connection = await connectLocalOwner(options.rootPath);
+  try {
+    const result = await connection.request('access.credential.revoke', {
+      credentialId: options.credentialId,
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return result.revoked ? 0 : 1;
+  } finally {
+    await connection.close();
+  }
+}
+
+async function connectLocalOwner(rootPath: string) {
+  const result = await connectExistingRuntimeHost({
+    rootPath,
+    surface: 'run',
+    protocol: PROTOCOL,
+  });
+  if (result.kind !== 'connected') {
+    throw new Error(`Runtime Host service is not available (${result.kind})`);
+  }
+  return result.connection;
+}
+
+function requireOperationGrants(values: readonly string[]): readonly OperationKey[] {
+  const grants = values.flatMap((value) => value.split(',')).filter((value) => value.length > 0);
+  if (grants.length === 0) throw new Error('At least one --grant is required');
+  for (const grant of grants) {
+    if (!isOperationKey(grant)) throw new Error(`Unknown Runtime Host operation grant: ${grant}`);
+  }
+  return [...new Set(grants)] as OperationKey[];
+}

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -1,0 +1,203 @@
+type RuntimeHostCliError = { kind: 'error'; message: string; exitCode: number };
+
+export type RuntimeHostCliCommand =
+  | {
+      kind: 'runtime-host-serve';
+      rootPath?: string;
+      websocket?: {
+        host: string;
+        port: number;
+        path?: string;
+        tlsCertificatePath?: string;
+        tlsPrivateKeyPath?: string;
+        allowedOrigins?: string[];
+      };
+    }
+  | {
+      kind: 'runtime-host-access-issue';
+      rootPath?: string;
+      principalId: string;
+      operationGrants: string[];
+      canPublishClientCapabilities: boolean;
+      canUseHostPaths: boolean;
+    }
+  | { kind: 'runtime-host-access-revoke'; rootPath?: string; credentialId: string }
+  | RuntimeHostCliError;
+
+export function parseRuntimeHostCommand(argv: string[]): RuntimeHostCliCommand {
+  if (argv[0] === 'serve') return parseServeCommand(argv.slice(1));
+  if (argv[0] === 'access') return parseAccessCommand(argv.slice(1));
+  return error(
+    argv[0]
+      ? `Unexpected runtime-host command: ${argv[0]}`
+      : 'runtime-host requires the serve or access command',
+  );
+}
+
+function parseServeCommand(argv: string[]): RuntimeHostCliCommand {
+  let rootPath: string | undefined;
+  let websocketHost = '127.0.0.1';
+  let websocketConfigured = false;
+  let websocketPort: number | undefined;
+  let websocketPath: string | undefined;
+  let tlsCertificatePath: string | undefined;
+  let tlsPrivateKeyPath: string | undefined;
+  const allowedOrigins: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--root') {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      rootPath = parsed;
+      index += 1;
+      continue;
+    }
+    if (argument === '--websocket-host') {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      websocketHost = parsed;
+      websocketConfigured = true;
+      index += 1;
+      continue;
+    }
+    if (argument === '--websocket-port') {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      websocketPort = Number(parsed);
+      websocketConfigured = true;
+      if (!Number.isInteger(websocketPort) || websocketPort < 1 || websocketPort > 65_535) {
+        return error('--websocket-port must be an integer between 1 and 65535');
+      }
+      index += 1;
+      continue;
+    }
+    if (argument === '--websocket-path') {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      websocketPath = parsed;
+      websocketConfigured = true;
+      index += 1;
+      continue;
+    }
+    if (argument === '--tls-certificate' || argument === '--tls-private-key') {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      if (argument === '--tls-certificate') tlsCertificatePath = parsed;
+      else tlsPrivateKeyPath = parsed;
+      websocketConfigured = true;
+      index += 1;
+      continue;
+    }
+    if (argument === '--allow-origin') {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      allowedOrigins.push(parsed);
+      websocketConfigured = true;
+      index += 1;
+      continue;
+    }
+    return error(`Unexpected argument: ${argument ?? ''}`);
+  }
+  if ((tlsCertificatePath === undefined) !== (tlsPrivateKeyPath === undefined)) {
+    return error('--tls-certificate and --tls-private-key must be provided together');
+  }
+  if (websocketConfigured && websocketPort === undefined) {
+    return error('--websocket-port is required for WebSocket options');
+  }
+  return {
+    kind: 'runtime-host-serve',
+    ...(rootPath ? { rootPath } : {}),
+    ...(websocketPort === undefined
+      ? {}
+      : {
+          websocket: {
+            host: websocketHost,
+            port: websocketPort,
+            ...(websocketPath ? { path: websocketPath } : {}),
+            ...(tlsCertificatePath ? { tlsCertificatePath } : {}),
+            ...(tlsPrivateKeyPath ? { tlsPrivateKeyPath } : {}),
+            ...(allowedOrigins.length > 0 ? { allowedOrigins } : {}),
+          },
+        }),
+  };
+}
+
+function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
+  const action = argv[0];
+  if (action !== 'issue' && action !== 'revoke') {
+    return error(
+      action
+        ? `Unexpected runtime-host access command: ${action}`
+        : 'runtime-host access requires the issue or revoke command',
+    );
+  }
+  let rootPath: string | undefined;
+  let principalId: string | undefined;
+  let credentialId: string | undefined;
+  const operationGrants: string[] = [];
+  let canPublishClientCapabilities = false;
+  let canUseHostPaths = false;
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--publish-client-capabilities') {
+      canPublishClientCapabilities = true;
+      continue;
+    }
+    if (argument === '--allow-host-paths') {
+      canUseHostPaths = true;
+      continue;
+    }
+    if (
+      argument === '--root' ||
+      argument === '--principal' ||
+      argument === '--grant' ||
+      argument === '--credential'
+    ) {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      if (argument === '--root') rootPath = parsed;
+      if (argument === '--principal') principalId = parsed;
+      if (argument === '--grant') operationGrants.push(parsed);
+      if (argument === '--credential') credentialId = parsed;
+      index += 1;
+      continue;
+    }
+    return error(`Unexpected argument: ${argument ?? ''}`);
+  }
+  if (action === 'issue') {
+    if (!principalId) return error('--principal is required');
+    if (operationGrants.length === 0) return error('At least one --grant is required');
+    if (credentialId) return error('--credential is only valid for access revoke');
+    return {
+      kind: 'runtime-host-access-issue',
+      ...(rootPath ? { rootPath } : {}),
+      principalId,
+      operationGrants,
+      canPublishClientCapabilities,
+      canUseHostPaths,
+    };
+  }
+  if (!credentialId) return error('--credential is required');
+  if (
+    principalId ||
+    operationGrants.length > 0 ||
+    canPublishClientCapabilities ||
+    canUseHostPaths
+  ) {
+    return error('Issue-only access options are not valid for revoke');
+  }
+  return {
+    kind: 'runtime-host-access-revoke',
+    ...(rootPath ? { rootPath } : {}),
+    credentialId,
+  };
+}
+
+function optionValue(argv: string[], index: number, option: string): string | RuntimeHostCliError {
+  const value = argv[index + 1];
+  return !value || value.startsWith('-') ? error(`${option} requires a value`) : value;
+}
+
+function error(message: string): RuntimeHostCliError {
+  return { kind: 'error', message, exitCode: 2 };
+}

--- a/packages/cli/src/runtime-host-service-command.ts
+++ b/packages/cli/src/runtime-host-service-command.ts
@@ -3,12 +3,53 @@ import {
   runRuntimeHostProcessLifecycle,
   startExecutionRuntimeHostService,
 } from '@maka/runtime-host/server';
+import { readFile } from 'node:fs/promises';
 
-export async function runRuntimeHostServiceCli(rootPath: string): Promise<number> {
+export interface RuntimeHostServiceCliOptions {
+  readonly rootPath: string;
+  readonly websocket?: {
+    readonly host: string;
+    readonly port: number;
+    readonly path?: string;
+    readonly tlsCertificatePath?: string;
+    readonly tlsPrivateKeyPath?: string;
+    readonly allowedOrigins?: readonly string[];
+  };
+}
+
+export async function runRuntimeHostServiceCli(
+  options: RuntimeHostServiceCliOptions,
+): Promise<number> {
   installRuntimeHostLogCapture();
-  const host = await startExecutionRuntimeHostService({ rootPath });
+  const websocket = options.websocket
+    ? {
+        host: options.websocket.host,
+        port: options.websocket.port,
+        ...(options.websocket.path ? { path: options.websocket.path } : {}),
+        ...(options.websocket.allowedOrigins
+          ? { allowedOrigins: options.websocket.allowedOrigins }
+          : {}),
+        ...(options.websocket.tlsCertificatePath && options.websocket.tlsPrivateKeyPath
+          ? {
+              tls: {
+                certificate: await readFile(options.websocket.tlsCertificatePath),
+                privateKey: await readFile(options.websocket.tlsPrivateKeyPath),
+              },
+            }
+          : {}),
+      }
+    : undefined;
+  const host = await startExecutionRuntimeHostService({
+    rootPath: options.rootPath,
+    ...(websocket ? { websocket } : {}),
+  });
   await runRuntimeHostProcessLifecycle(host, {
-    onReady: () => process.stdout.write(`Runtime Host service is ready at ${host.endpoint}\n`),
+    onReady: () => {
+      process.stdout.write(`Runtime Host service is ready at ${host.endpoint}\n`);
+      for (const endpoint of host.websocketEndpoints) {
+        process.stdout.write(`Runtime Host WebSocket is ready at ${endpoint}\n`);
+      }
+    },
   });
   return 0;
 }

--- a/packages/runtime-host/package.json
+++ b/packages/runtime-host/package.json
@@ -24,9 +24,11 @@
     "@maka/core": "0.1.0",
     "@maka/runtime": "0.1.0",
     "@maka/storage": "0.1.0",
+    "ws": "^8.21.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@types/ws": "^8.18.1",
     "electron": "^43.2.0"
   }
 }

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -1,0 +1,252 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { resolveRootControlNamespace, resolveStorageRoot } from '@maka/storage/root-authority';
+import {
+  connectRemoteRuntimeHost,
+  connectRuntimeHost,
+  consumeAccessCredentialDelivery,
+  RuntimeHostOperationError,
+  type RuntimeHostConnection,
+} from '../client/index.js';
+import { RUNTIME_HOST_PROTOCOL_VERSION } from '../protocol/index.js';
+import {
+  openRuntimeHostAccessAuthority,
+  startExecutionRuntimeHostService,
+} from '../server/index.js';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+test('one Local IPC owner and one authenticated WebSocket Client control the same Session', {
+  timeout: 120_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-authenticated-websocket-'));
+  const root = join(base, 'root');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const host = await startExecutionRuntimeHostService({
+    rootPath: root,
+    websocket: { host: '127.0.0.1', port: 0 },
+  });
+  let local: RuntimeHostConnection | undefined;
+  let remote: RuntimeHostConnection | undefined;
+  try {
+    local = requireConnection(
+      await connectRuntimeHost({ rootPath: root, surface: 'desktop', protocol: PROTOCOL }),
+    );
+    const issued = await local.request('access.credential.issue', {
+      principalId: 'remote-device',
+      operationGrants: [
+        'session.catalog.query',
+        'session.metadata.update',
+        'session.create',
+        'client.capability.replace',
+      ],
+      canPublishClientCapabilities: false,
+      canUseHostPaths: false,
+    });
+    const credential = await consumeAccessCredentialDelivery(
+      root,
+      issued.deliveryId,
+      issued.credentialId,
+    );
+    const url = host.websocketEndpoints[0];
+    assert.ok(url);
+
+    const wrongRoot = await connectRemoteRuntimeHost({
+      url,
+      credential,
+      expectedRootId: 'f'.repeat(64),
+      surface: 'tui',
+      protocol: PROTOCOL,
+    });
+    assert.deepEqual(wrongRoot, { kind: 'unavailable', reason: 'root_mismatch' });
+
+    const connected = await connectRemoteRuntimeHost({
+      url,
+      credential,
+      expectedRootId: capability.rootId,
+      surface: 'tui',
+      protocol: PROTOCOL,
+    });
+    assert.equal(connected.kind, 'connected');
+    if (connected.kind !== 'connected') assert.fail('WebSocket Client did not connect');
+    remote = connected.connection;
+    assert.equal(remote.rootId, local.rootId);
+    assert.equal(remote.hostEpoch, local.hostEpoch);
+
+    const created = await local.request('session.create', {
+      sessionId: 'shared-session',
+      cwd: root,
+      name: 'Shared Session',
+      modelTarget: { kind: 'default' },
+    });
+    assert.ok(!('kind' in created));
+    assert.deepEqual(
+      await remote.request('session.catalog.query', {
+        kind: 'get',
+        sessionId: 'shared-session',
+      }),
+      { kind: 'session', session: created },
+    );
+
+    const catalogChanged = new Promise<string>((resolve) => {
+      local?.subscribeSessionCatalogChanges((frame) => resolve(frame.sessionId));
+    });
+    const renamed = await remote.request('session.metadata.update', {
+      sessionId: 'shared-session',
+      expectedRevision: created.revision,
+      patch: { name: 'Renamed remotely' },
+    });
+    assert.equal(renamed.kind, 'committed');
+    assert.equal(await catalogChanged, 'shared-session');
+    assert.deepEqual(
+      await local.request('session.catalog.query', {
+        kind: 'get',
+        sessionId: 'shared-session',
+      }),
+      renamed.kind === 'committed'
+        ? { kind: 'session', session: renamed.session }
+        : assert.fail('Remote Session rename did not commit'),
+    );
+
+    await assert.rejects(
+      remote.request('session.create', {
+        sessionId: 'remote-path-session',
+        cwd: root,
+        modelTarget: { kind: 'default' },
+      }),
+      (error: unknown) =>
+        error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
+    );
+    await assert.rejects(
+      remote.replaceClientCapabilities({
+        offers: () => [
+          {
+            offerId: 'test',
+            version: '1',
+            affinity: 'call',
+            label: 'Test',
+            tools: [
+              {
+                serverId: 'test',
+                name: 'noop',
+                inputSchema: { type: 'object' },
+              },
+            ],
+          },
+        ],
+      }),
+      (error: unknown) =>
+        error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
+    );
+    assert.equal(
+      (
+        await remote.request('session.catalog.query', {
+          kind: 'get',
+          sessionId: 'shared-session',
+        })
+      ).kind,
+      'session',
+    );
+
+    assert.deepEqual(
+      await local.request('access.credential.revoke', { credentialId: issued.credentialId }),
+      { credentialId: issued.credentialId, revoked: true },
+    );
+    await remote.closed;
+    remote = undefined;
+    assert.deepEqual(
+      await connectRemoteRuntimeHost({
+        url,
+        credential,
+        expectedRootId: capability.rootId,
+        surface: 'tui',
+        protocol: PROTOCOL,
+      }),
+      { kind: 'unavailable', reason: 'connect_failed' },
+    );
+  } finally {
+    await Promise.allSettled([remote?.close(), local?.close()]);
+    await host.close().catch(() => undefined);
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('access credentials persist only as hashes and stay revoked after reload', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-access-authority-'));
+  try {
+    const { consumeAccessCredentialDeliveryFromControlDirectory } = await import(
+      '../control/access-credential-delivery.js'
+    );
+    const authority = await openRuntimeHostAccessAuthority(directory);
+    const issued = await authority.issue({
+      principalId: 'device-1',
+      operationGrants: ['session.catalog.query'],
+      canPublishClientCapabilities: false,
+      canUseHostPaths: false,
+    });
+    const credential = await consumeAccessCredentialDeliveryFromControlDirectory(
+      directory,
+      issued.deliveryId,
+      issued.credentialId,
+    );
+    assert.equal(authority.authenticate(credential)?.principalId, 'device-1');
+    assert.doesNotMatch(
+      await readFile(join(directory, 'runtime-host-access.json'), 'utf8'),
+      new RegExp(credential, 'u'),
+    );
+
+    const reopened = await openRuntimeHostAccessAuthority(directory);
+    assert.equal(reopened.authenticate(credential)?.credentialId, issued.credentialId);
+    assert.deepEqual(await reopened.revoke({ credentialId: issued.credentialId }), {
+      credentialId: issued.credentialId,
+      revoked: true,
+    });
+    assert.equal(reopened.authenticate(credential), undefined);
+    assert.equal(
+      (await openRuntimeHostAccessAuthority(directory)).authenticate(credential),
+      undefined,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('a rejected required WebSocket listener releases Local IPC and root ownership', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-websocket-startup-rollback-'));
+  const root = join(base, 'root');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  try {
+    await assert.rejects(
+      startExecutionRuntimeHostService({
+        rootPath: root,
+        websocket: { host: '0.0.0.0', port: 0 },
+      }),
+      /must bind to loopback/u,
+    );
+    const successor = await startExecutionRuntimeHostService({ rootPath: root });
+    await successor.close();
+  } finally {
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+function requireConnection(
+  result: Awaited<ReturnType<typeof connectRuntimeHost>>,
+): RuntimeHostConnection {
+  if (result.kind !== 'connected') throw new Error(`Local Client did not connect: ${result.kind}`);
+  return result.connection;
+}

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -56,6 +56,15 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
     );
     const url = host.websocketEndpoints[0];
     assert.ok(url);
+    await assert.rejects(
+      connectRemoteRuntimeHost({
+        url: `${url}?route=forbidden`,
+        credential,
+        surface: 'tui',
+        protocol: PROTOCOL,
+      }),
+      /must not contain credentials, a query, or a fragment/u,
+    );
 
     const wrongRoot = await connectRemoteRuntimeHost({
       url,
@@ -78,6 +87,11 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
     remote = connected.connection;
     assert.equal(remote.rootId, local.rootId);
     assert.equal(remote.hostEpoch, local.hostEpoch);
+    await assert.rejects(
+      remote.request('host.diagnostics.query', {}),
+      (error: unknown) =>
+        error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
+    );
 
     const created = await local.request('session.create', {
       sessionId: 'shared-session',

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -26,6 +26,7 @@ import { RuntimeHostKernel, type RuntimeHostComposition } from '../server/index.
 import { LOCAL_OWNER_CONNECTION_AUTHORITY } from '../server/connection-authority.js';
 import { RuntimeHostConnectionSession } from '../server/connection-session.js';
 import {
+  createUnavailableAccessAuthorityOperationHandlers,
   createUnavailableDomainOperationHandlers,
   type OperationHandlerMap,
 } from '../server/operation-dispatcher.js';
@@ -357,6 +358,7 @@ test('connection reset while operation admission is pending does not execute the
       },
     }),
     ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
+    ...createUnavailableAccessAuthorityOperationHandlers(),
     ...createHandlers(async (input) => {
       handlerCalls += 1;
       return {
@@ -600,6 +602,7 @@ test('an in-flight status does not consume the final domain request slot', async
       };
     },
     ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
+    ...createUnavailableAccessAuthorityOperationHandlers(),
     ...createHandlers(async (input) => {
       const index = Number(input.turnId.slice('turn-'.length));
       domainEntered[index]?.resolve();
@@ -695,6 +698,7 @@ test('evicting one slow subscription keeps sibling subscriptions and requests us
       },
     }),
     ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
+    ...createUnavailableAccessAuthorityOperationHandlers(),
     ...createHandlers(async (input) => ({
       ok: true,
       result: runningSnapshot(input.sessionId, input.turnId),
@@ -928,6 +932,7 @@ async function openHalfClosedDispatchedSession(
         },
       }),
       ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
+      ...createUnavailableAccessAuthorityOperationHandlers(),
       ...createHandlers(async (input) => {
         handlerEntered.resolve();
         await releaseHandler.promise;

--- a/packages/runtime-host/src/__tests__/operation-dispatcher.test.ts
+++ b/packages/runtime-host/src/__tests__/operation-dispatcher.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import type { OperationKey, OperationOutcome, RequestFrame } from '../protocol/index.js';
 import {
   composeOperationHandlers,
+  createUnavailableAccessAuthorityOperationHandlers,
   createUnavailableDomainOperationHandlers,
   dispatchOperation,
   type ConnectionContext,
@@ -163,6 +164,7 @@ function validHandlers(): OperationHandlerMap {
   return {
     'host.status': unavailable,
     'host.diagnostics.query': unavailable,
+    ...createUnavailableAccessAuthorityOperationHandlers(),
     ...createUnavailableDomainOperationHandlers(),
   };
 }

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -47,8 +47,10 @@ describe('Runtime Host bootstrap protocol', () => {
 
   test('keeps the experimental protocol at v0 with the declared authority operations', () => {
     assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
-    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 10);
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 11);
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
+      'access.credential.issue',
+      'access.credential.revoke',
       'agent.graph.operator.query',
       'agent.graph.query',
       'agent.graph.stop',
@@ -727,6 +729,7 @@ describe('Runtime Host bootstrap protocol', () => {
     );
     const accepted = {
       kind: 'accepted' as const,
+      rootId: 'a'.repeat(64),
       hostEpoch: 'epoch-1',
       connectionId: 'connection-1',
       selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -38,8 +38,8 @@ const PROTOCOL = {
 
 test('registers a subscription before receiving a coalesced first frame', async () => {
   await withProtocolPeer(
-    async (transport, hostEpoch) => {
-      const request = await acceptConnectionAndReadOpen(transport, hostEpoch);
+    async (transport, hostEpoch, rootId) => {
+      const request = await acceptConnectionAndReadOpen(transport, hostEpoch, rootId);
       const opened = openResult(hostEpoch, 'subscription-ordered');
       await writeRawLocalIpc(
         transport,
@@ -70,8 +70,8 @@ test('registers a subscription before receiving a coalesced first frame', async 
 
 test('delivers Runtime Resource PTY frames without closing the connection', async () => {
   await withProtocolPeer(
-    async (transport, hostEpoch) => {
-      const request = await acceptConnectionAndReadOpen(transport, hostEpoch);
+    async (transport, hostEpoch, rootId) => {
+      const request = await acceptConnectionAndReadOpen(transport, hostEpoch, rootId);
       const opened = openResult(hostEpoch, 'subscription-pty');
       const frame = {
         kind: 'subscription.runtime_resource_pty_data' as const,
@@ -119,8 +119,8 @@ test('delivers Runtime Resource PTY frames without closing the connection', asyn
 
 test('isolates a sequence gap and continues requests on the same connection', async () => {
   await withProtocolPeer(
-    async (transport, hostEpoch) => {
-      const request = await acceptConnectionAndReadOpen(transport, hostEpoch);
+    async (transport, hostEpoch, rootId) => {
+      const request = await acceptConnectionAndReadOpen(transport, hostEpoch, rootId);
       const opened = openResult(hostEpoch, 'subscription-gap');
       await writeRawLocalIpc(
         transport,
@@ -153,8 +153,8 @@ test('isolates a sequence gap and continues requests on the same connection', as
 test('rejects epoch and Session correlation changes per subscription', async () => {
   for (const changed of ['epoch', 'session', 'graph'] as const) {
     await withProtocolPeer(
-      async (transport, hostEpoch) => {
-        const request = await acceptConnectionAndReadOpen(transport, hostEpoch);
+      async (transport, hostEpoch, rootId) => {
+        const request = await acceptConnectionAndReadOpen(transport, hostEpoch, rootId);
         const opened = openResult(hostEpoch, `subscription-${changed}`);
         await writeProtocolFrame(transport, {
           requestId: request.requestId,
@@ -203,8 +203,8 @@ test('rejects epoch and Session correlation changes per subscription', async () 
 test('evicts a locally slow iterator and keeps the connection usable', async () => {
   const closeObserved = deferred<void>();
   await withProtocolPeer(
-    async (transport, hostEpoch) => {
-      const request = await acceptConnectionAndReadOpen(transport, hostEpoch);
+    async (transport, hostEpoch, rootId) => {
+      const request = await acceptConnectionAndReadOpen(transport, hostEpoch, rootId);
       const opened = openResult(hostEpoch, 'subscription-slow');
       const frames = [
         encodeLocalIpcTestFrame({
@@ -239,8 +239,8 @@ test('evicts a locally slow iterator and keeps the connection usable', async () 
 
 test('ends every active subscription with connection_closed on EOF', async () => {
   await withProtocolPeer(
-    async (transport, hostEpoch) => {
-      const request = await acceptConnectionAndReadOpen(transport, hostEpoch);
+    async (transport, hostEpoch, rootId) => {
+      const request = await acceptConnectionAndReadOpen(transport, hostEpoch, rootId);
       await writeProtocolFrame(transport, {
         requestId: request.requestId,
         operation: 'subscription.open',
@@ -271,8 +271,8 @@ test('loads a canonical transcript while live frames continue on the same connec
     modelId: 'test-model',
   };
   await withProtocolPeer(
-    async (transport, hostEpoch) => {
-      const openRequest = await acceptConnectionAndReadOpen(transport, hostEpoch);
+    async (transport, hostEpoch, rootId) => {
+      const openRequest = await acceptConnectionAndReadOpen(transport, hostEpoch, rootId);
       const opened = openResult(hostEpoch, 'subscription-transcript');
       await writeProtocolFrame(transport, {
         requestId: openRequest.requestId,
@@ -333,8 +333,8 @@ test('restarts transcript loading after an expired snapshot', async () => {
   const encoded = Buffer.from(JSON.stringify(message), 'utf8');
   const splitAt = Math.floor(encoded.byteLength / 2);
   await withProtocolPeer(
-    async (transport, hostEpoch) => {
-      const openRequest = await acceptConnectionAndReadOpen(transport, hostEpoch);
+    async (transport, hostEpoch, rootId) => {
+      const openRequest = await acceptConnectionAndReadOpen(transport, hostEpoch, rootId);
       const opened = openResult(hostEpoch, 'subscription-retry');
       await writeProtocolFrame(transport, {
         requestId: openRequest.requestId,
@@ -486,7 +486,7 @@ test('forces a same-v0 pre-epoch Host through its incompatible replacement path'
 });
 
 async function withProtocolPeer(
-  serve: (transport: FramedTransport, hostEpoch: string) => Promise<void>,
+  serve: (transport: FramedTransport, hostEpoch: string, rootId: string) => Promise<void>,
   run: (connection: RuntimeHostConnection) => Promise<void>,
 ): Promise<void> {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-subscription-'));
@@ -502,7 +502,10 @@ async function withProtocolPeer(
   });
   const serverTask = deferred<void>();
   const server = createServer((socket) => {
-    void serve(new FramedTransport(socket), hostEpoch).then(serverTask.resolve, serverTask.reject);
+    void serve(new FramedTransport(socket), hostEpoch, capability.rootId).then(
+      serverTask.resolve,
+      serverTask.reject,
+    );
   });
   try {
     await listen(server, endpoint.path);
@@ -544,11 +547,13 @@ async function withProtocolPeer(
 async function acceptConnectionAndReadOpen(
   transport: FramedTransport,
   hostEpoch: string,
+  rootId: string,
 ): Promise<Extract<RequestFrame, { operation: 'subscription.open' }>> {
   const hello = decodeClientFrame(await transport.read(1_000));
   assert.ok('kind' in hello && hello.kind === 'hello');
   await writeProtocolFrame(transport, {
     kind: 'accepted',
+    rootId,
     hostEpoch,
     connectionId: 'connection-1',
     selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,

--- a/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
@@ -153,8 +153,8 @@ describe('Usage/Pricing client response correlation', () => {
       skip: process.platform === 'win32',
     }, async () => {
       await withProtocolPeer(
-        async (transport, hostEpoch) => {
-          const request = await acceptConnectionAndReadRequest(transport, hostEpoch);
+        async (transport, hostEpoch, rootId) => {
+          const request = await acceptConnectionAndReadRequest(transport, hostEpoch, rootId);
           assert.equal(request.operation, mismatch.operation);
           await writeHostFrame(transport, {
             requestId: request.requestId,
@@ -178,8 +178,8 @@ describe('Usage/Pricing client response correlation', () => {
     skip: process.platform === 'win32',
   }, async () => {
     await withProtocolPeer(
-      async (transport, hostEpoch) => {
-        const request = await acceptConnectionAndReadRequest(transport, hostEpoch);
+      async (transport, hostEpoch, rootId) => {
+        const request = await acceptConnectionAndReadRequest(transport, hostEpoch, rootId);
         assert.equal(request.operation, 'usage.query');
         assert.deepEqual(request.input, {
           kind: 'logs',
@@ -251,7 +251,7 @@ function requestUnchecked(
 }
 
 async function withProtocolPeer(
-  serve: (transport: FramedTransport, hostEpoch: string) => Promise<void>,
+  serve: (transport: FramedTransport, hostEpoch: string, rootId: string) => Promise<void>,
   run: (connection: RuntimeHostConnection) => Promise<void>,
 ): Promise<void> {
   const base = await mkdtemp(join(tmpdir(), 'maka-usage-pricing-correlation-'));
@@ -270,7 +270,10 @@ async function withProtocolPeer(
     rejectServer = reject;
   });
   const server = createServer((socket) => {
-    void serve(new FramedTransport(socket), hostEpoch).then(resolveServer, rejectServer);
+    void serve(new FramedTransport(socket), hostEpoch, capability.rootId).then(
+      resolveServer,
+      rejectServer,
+    );
   });
   try {
     await listen(server, endpoint.path);
@@ -312,11 +315,13 @@ async function withProtocolPeer(
 async function acceptConnectionAndReadRequest(
   transport: FramedTransport,
   hostEpoch: string,
+  rootId: string,
 ): Promise<RequestFrame> {
   const hello = decodeClientFrame(await transport.read(REQUEST_TIMEOUT_MS));
   assert.ok('kind' in hello && hello.kind === 'hello');
   await writeHostFrame(transport, {
     kind: 'accepted',
+    rootId,
     hostEpoch,
     connectionId: 'usage-pricing-correlation',
     selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,

--- a/packages/runtime-host/src/__tests__/websocket-listener.test.ts
+++ b/packages/runtime-host/src/__tests__/websocket-listener.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import WebSocket from 'ws';
+import { consumeAccessCredentialDeliveryFromControlDirectory } from '../control/access-credential-delivery.js';
+import { encodeProtocolMessage, RuntimeHostProtocolError } from '../protocol/index.js';
+import { openRuntimeHostAccessAuthority } from '../server/access-authority.js';
+import { startRuntimeHostWebSocketListener } from '../server/websocket-listener.js';
+import type { RuntimeHostMessageTransport } from '../transport/message-transport.js';
+
+test('WebSocket admission, health, Origin, and message policy fail closed', async () => {
+  const directory = await mkdtemp(join(tmpdir(), 'maka-websocket-listener-'));
+  const authority = await openRuntimeHostAccessAuthority(directory);
+  const issued = await authority.issue({
+    principalId: 'native-client',
+    operationGrants: ['session.catalog.query'],
+    canPublishClientCapabilities: false,
+    canUseHostPaths: false,
+  });
+  const credential = await consumeAccessCredentialDeliveryFromControlDirectory(
+    directory,
+    issued.deliveryId,
+    issued.credentialId,
+  );
+  const accepted = deferred<RuntimeHostMessageTransport>();
+  let ready = false;
+  const listener = await startRuntimeHostWebSocketListener({
+    host: '127.0.0.1',
+    port: 0,
+    accessAuthority: authority,
+    isReady: () => ready,
+    accept: ({ transport }) => accepted.resolve(transport),
+  });
+  let client: WebSocket | undefined;
+  try {
+    const httpBase = listener.endpoint.replace('ws://', 'http://').replace('/runtime-host', '');
+    assert.equal((await fetch(`${httpBase}/healthz`)).status, 200);
+    assert.equal((await fetch(`${httpBase}/readyz`)).status, 503);
+    ready = true;
+    assert.equal((await fetch(`${httpBase}/readyz`)).status, 200);
+
+    await assert.rejects(openWebSocket(listener.endpoint));
+    await assert.rejects(openWebSocket(listener.endpoint, credential, 'https://browser.invalid'));
+
+    client = await openWebSocket(listener.endpoint, credential);
+    const transport = await accepted.promise;
+    client.send(JSON.stringify({ message: 'hello' }));
+    assert.deepEqual(await transport.read(1_000), { message: 'hello' });
+
+    const reply = onceMessage(client);
+    await transport.write(encodeProtocolMessage({ kind: 'draining', hostEpoch: 'host-1' }));
+    const received = await reply;
+    assert.equal(received.isBinary, false);
+    assert.deepEqual(JSON.parse(received.data.toString()), {
+      kind: 'draining',
+      hostEpoch: 'host-1',
+    });
+
+    client.send(JSON.stringify({ queued: true }));
+    client.send(Buffer.from('{}'));
+    await transport.closed;
+    await assert.rejects(
+      transport.read(1_000),
+      (error: unknown) =>
+        error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame',
+    );
+  } finally {
+    client?.terminate();
+    await listener.closeAdmission().catch(() => undefined);
+    await listener.cleanup().catch(() => undefined);
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+function openWebSocket(url: string, credential?: string, origin?: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url, {
+      ...(credential ? { headers: { authorization: `Bearer ${credential}` } } : {}),
+      ...(origin ? { origin } : {}),
+      perMessageDeflate: false,
+    });
+    socket.once('open', () => resolve(socket));
+    socket.once('error', reject);
+  });
+}
+
+function onceMessage(socket: WebSocket): Promise<{ data: WebSocket.RawData; isBinary: boolean }> {
+  return new Promise((resolve) => {
+    socket.once('message', (data, isBinary) => resolve({ data, isBinary }));
+  });
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/packages/runtime-host/src/__tests__/websocket-listener.test.ts
+++ b/packages/runtime-host/src/__tests__/websocket-listener.test.ts
@@ -1,16 +1,24 @@
 import assert from 'node:assert/strict';
+import { once } from 'node:events';
 import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import WebSocket from 'ws';
 import { consumeAccessCredentialDeliveryFromControlDirectory } from '../control/access-credential-delivery.js';
-import { encodeProtocolMessage, RuntimeHostProtocolError } from '../protocol/index.js';
+import {
+  encodeProtocolMessage,
+  RUNTIME_HOST_MAX_MESSAGE_BYTES,
+  RuntimeHostProtocolError,
+} from '../protocol/index.js';
 import { openRuntimeHostAccessAuthority } from '../server/access-authority.js';
 import { startRuntimeHostWebSocketListener } from '../server/websocket-listener.js';
 import type { RuntimeHostMessageTransport } from '../transport/message-transport.js';
 
-test('WebSocket admission, health, Origin, and message policy fail closed', async () => {
+test('WebSocket admission, health, Origin, and message policy fail closed', {
+  timeout: 5_000,
+}, async () => {
   const directory = await mkdtemp(join(tmpdir(), 'maka-websocket-listener-'));
   const authority = await openRuntimeHostAccessAuthority(directory);
   const issued = await authority.issue({
@@ -34,6 +42,8 @@ test('WebSocket admission, health, Origin, and message policy fail closed', asyn
     accept: ({ transport }) => accepted.resolve(transport),
   });
   let client: WebSocket | undefined;
+  let survivor: WebSocket | undefined;
+  let partial: Socket | undefined;
   try {
     const httpBase = listener.endpoint.replace('ws://', 'http://').replace('/runtime-host', '');
     assert.equal((await fetch(`${httpBase}/healthz`)).status, 200);
@@ -42,6 +52,7 @@ test('WebSocket admission, health, Origin, and message policy fail closed', asyn
     assert.equal((await fetch(`${httpBase}/readyz`)).status, 200);
 
     await assert.rejects(openWebSocket(listener.endpoint));
+    await assert.rejects(openWebSocket(`${listener.endpoint}?route=forbidden`, credential));
     await assert.rejects(openWebSocket(listener.endpoint, credential, 'https://browser.invalid'));
 
     client = await openWebSocket(listener.endpoint, credential);
@@ -66,8 +77,35 @@ test('WebSocket admission, health, Origin, and message policy fail closed', asyn
       (error: unknown) =>
         error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame',
     );
+
+    client = await openWebSocket(listener.endpoint, credential);
+    const invalidUtf8Closed = waitForClose(client, 'invalid UTF-8 Client');
+    client.send(Buffer.from([0xff]), { binary: false });
+    await invalidUtf8Closed;
+
+    client = await openWebSocket(listener.endpoint, credential);
+    const oversizedClosed = waitForClose(client, 'oversized Client');
+    client.send('x'.repeat(RUNTIME_HOST_MAX_MESSAGE_BYTES + 1));
+    await oversizedClosed;
+
+    survivor = await openWebSocket(listener.endpoint, credential);
+    const target = new URL(listener.endpoint);
+    partial = connect({ host: target.hostname, port: Number(target.port) });
+    await once(partial, 'connect');
+    partial.write(`GET ${target.pathname} HTTP/1.1\r\nHost: ${target.host}\r\n`);
+    const partialClosed = waitForClose(partial, 'partial HTTP Client');
+    await Promise.all([
+      withTimeout(listener.closeAdmission(), 'listener admission close'),
+      partialClosed,
+    ]);
+    assert.equal(survivor.readyState, WebSocket.OPEN);
+    const survivorClosed = waitForClose(survivor, 'upgraded Client');
+    await listener.cleanup();
+    await survivorClosed;
   } finally {
     client?.terminate();
+    survivor?.terminate();
+    partial?.destroy();
     await listener.closeAdmission().catch(() => undefined);
     await listener.cleanup().catch(() => undefined);
     await rm(directory, { recursive: true, force: true });
@@ -90,6 +128,27 @@ function onceMessage(socket: WebSocket): Promise<{ data: WebSocket.RawData; isBi
   return new Promise((resolve) => {
     socket.once('message', (data, isBinary) => resolve({ data, isBinary }));
   });
+}
+
+function waitForClose(socket: WebSocket | Socket, label: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} did not close`)), 1_000);
+    socket.once('error', () => undefined);
+    socket.once('close', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`${label} did not settle`)), 1_000);
+      timer.unref();
+    }),
+  ]);
 }
 
 function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -1208,8 +1208,8 @@ function requireRemoteWebSocketUrl(value: string): URL {
   if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
     throw new Error('Remote Runtime Host URL must use ws or wss');
   }
-  if (url.username || url.password || url.hash) {
-    throw new Error('Remote Runtime Host URL must not contain credentials or a fragment');
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error('Remote Runtime Host URL must not contain credentials, a query, or a fragment');
   }
   if (
     url.protocol === 'ws:' &&

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { connect } from 'node:net';
 import { performance } from 'node:perf_hooks';
+import WebSocket from 'ws';
 import {
   discoverMarkedStorageRoot,
   prepareStorageRootControlDirectory,
@@ -37,6 +38,7 @@ import {
   HOST_OPERATION_SPECS,
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_MAX_IN_FLIGHT_DOMAIN_REQUESTS,
+  RUNTIME_HOST_MAX_MESSAGE_BYTES,
   type OperationInput,
   type OperationKey,
   type OperationOutput,
@@ -71,6 +73,7 @@ import {
 } from '../protocol/index.js';
 import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
 import type { RuntimeHostMessageTransport } from '../transport/message-transport.js';
+import { WebSocketTransport } from '../transport/websocket-transport.js';
 import type { OperationSpec } from '../protocol/operation-spec.js';
 import {
   ClientSessionSubscription,
@@ -84,6 +87,8 @@ const DEFAULT_CONNECT_TIMEOUT_MS = 500;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 2_000;
 const DEFAULT_LIVENESS_INTERVAL_MS = 2_000;
 const DEFAULT_LIVENESS_TIMEOUT_MS = 2_000;
+const MAX_WEBSOCKET_FRAGMENTS = 256;
+const MAX_WEBSOCKET_BUFFERED_CHUNKS = 256;
 
 export interface ConnectRuntimeHostInput {
   rootPath: string;
@@ -134,6 +139,28 @@ export type ConnectRuntimeHostResult =
       registration?: HostRegistration;
     };
 
+export interface ConnectRemoteRuntimeHostInput {
+  readonly url: string;
+  readonly credential: string;
+  readonly expectedRootId?: string;
+  readonly surface: ClientSurface;
+  readonly protocol: ProtocolRange;
+  readonly clientInstanceId?: string;
+  readonly connectTimeoutMs?: number;
+  readonly handshakeTimeoutMs?: number;
+  readonly livenessIntervalMs?: number;
+  readonly onLivenessProbe?: () => void;
+}
+
+export type ConnectRemoteRuntimeHostResult =
+  | { kind: 'connected'; connection: RuntimeHostConnection }
+  | { kind: 'incompatible'; handshake: HostIncompatible }
+  | { kind: 'draining' }
+  | {
+      kind: 'unavailable';
+      reason: 'connect_failed' | 'handshake_failed' | 'root_mismatch';
+    };
+
 type ConnectResolvedRuntimeHostResult =
   | ConnectRuntimeHostResult
   | {
@@ -157,6 +184,7 @@ interface ConnectResolvedRuntimeHostInput
 }
 
 export interface RuntimeHostConnection {
+  readonly rootId: string;
   readonly hostEpoch: string;
   readonly connectionId: string;
   readonly selectedProtocol: number;
@@ -257,6 +285,7 @@ interface QueuedDomainFrame {
 type RequestTimeoutScope = 'request' | 'connection';
 
 class RuntimeHostConnectionImpl implements RuntimeHostConnection {
+  readonly rootId: string;
   readonly hostEpoch: string;
   readonly connectionId: string;
   readonly selectedProtocol: number;
@@ -280,6 +309,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   constructor(
     transport: RuntimeHostMessageTransport,
     accepted: {
+      rootId: string;
       hostEpoch: string;
       connectionId: string;
       selectedProtocol: number;
@@ -291,6 +321,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.#livenessIntervalMs = options?.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS;
     this.#onLivenessProbe = options?.onLivenessProbe;
     this.#transport = transport;
+    this.rootId = accepted.rootId;
     this.hostEpoch = accepted.hostEpoch;
     this.connectionId = accepted.connectionId;
     this.selectedProtocol = accepted.selectedProtocol;
@@ -898,10 +929,58 @@ export async function connectExistingRuntimeHost(
   );
 }
 
-function normalizeConnectRuntimeHostInput(input: ConnectRuntimeHostInput): {
+export async function connectRemoteRuntimeHost(
+  input: ConnectRemoteRuntimeHostInput,
+): Promise<ConnectRemoteRuntimeHostResult> {
+  const normalized = normalizeConnectRuntimeHostInput(input);
+  const url = requireRemoteWebSocketUrl(input.url);
+  let transport: WebSocketTransport;
+  try {
+    transport = await openWebSocketTransport(url, input.credential, normalized.connectTimeoutMs);
+  } catch {
+    return { kind: 'unavailable', reason: 'connect_failed' };
+  }
+  const timer = setTimeout(() => {
+    transport.abort(new Error('Timed out handshaking with Runtime Host'));
+  }, normalized.handshakeTimeoutMs);
+  try {
+    const result = await exchangeRuntimeHostHandshake({
+      transport,
+      surface: input.surface,
+      protocol: input.protocol,
+      clientInstanceId: normalized.clientInstanceId,
+      expectedRootId: input.expectedRootId,
+      livenessIntervalMs: normalized.livenessIntervalMs,
+      onLivenessProbe: input.onLivenessProbe,
+    });
+    if (result.kind === 'connected') return result;
+    transport.abort();
+    return result.kind === 'incompatible' ? result : { kind: 'draining' };
+  } catch (error) {
+    transport.abort();
+    if (error instanceof RuntimeHostRootMismatchError) {
+      return { kind: 'unavailable', reason: 'root_mismatch' };
+    }
+    return { kind: 'unavailable', reason: 'handshake_failed' };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function normalizeConnectRuntimeHostInput(
+  input: Pick<
+    ConnectRuntimeHostInput,
+    | 'protocol'
+    | 'clientInstanceId'
+    | 'connectTimeoutMs'
+    | 'handshakeTimeoutMs'
+    | 'livenessIntervalMs'
+  >,
+): {
   clientInstanceId: string;
   connectTimeoutMs: number;
   handshakeTimeoutMs: number;
+  livenessIntervalMs: number;
 } {
   validateProtocolRange(input.protocol);
   return {
@@ -913,6 +992,10 @@ function normalizeConnectRuntimeHostInput(input: ConnectRuntimeHostInput): {
     handshakeTimeoutMs: requireTimeout(
       input.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS,
       'handshakeTimeoutMs',
+    ),
+    livenessIntervalMs: requireTimeout(
+      input.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS,
+      'livenessIntervalMs',
     ),
   };
 }
@@ -1011,61 +1094,34 @@ export async function connectResolvedRuntimeHost(
           max: Math.min(Number.MAX_SAFE_INTEGER, registration.protocolMax + 1),
         }
       : input.protocol;
-    await writeClientFrame(transport, {
-      kind: 'hello',
-      clientInstanceId: input.clientInstanceId,
+    const result = await exchangeRuntimeHostHandshake({
+      transport,
       surface: input.surface,
-      protocolMin: helloProtocol.min,
-      protocolMax: helloProtocol.max,
-      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+      protocol: input.protocol,
+      helloProtocol,
+      clientInstanceId: input.clientInstanceId,
+      expectedHostEpoch: registration.hostEpoch,
+      expectedRootId: registration.rootId,
+      hostProtocol: { min: registration.protocolMin, max: registration.protocolMax },
+      livenessIntervalMs,
+      onLivenessProbe: input.onLivenessProbe,
     });
-    if (remainingTimeout(handshakeDeadline.at) === undefined) {
-      throw handshakeDeadline.exhaustsElection
-        ? new ElectionDeadlineElapsedError()
-        : new Error('Runtime Host handshake deadline elapsed');
-    }
-    // The phase timer owns the full hello write/read deadline and its timeout classification.
-    const handshake = decodeHostFrame(await transport.read(0));
-    if (!('kind' in handshake))
-      throw new Error('Runtime Host returned an operation response before handshake');
-    if (
-      handshake.kind !== 'accepted' &&
-      handshake.kind !== 'incompatible' &&
-      handshake.kind !== 'draining'
-    ) {
-      throw new Error('Runtime Host returned a non-handshake frame before acceptance');
-    }
-    if (handshake.hostEpoch !== registration.hostEpoch) {
-      transport.abort();
-      return { kind: 'unavailable', reason: 'epoch_mismatch', registration };
-    }
-    if (handshake.kind === 'accepted') {
-      if (staleCompatibility || handshake.compatibilityEpoch !== RUNTIME_HOST_COMPATIBILITY_EPOCH) {
-        throw new Error('Runtime Host accepted an incompatible schema epoch');
-      }
-      if (
-        handshake.selectedProtocol < input.protocol.min ||
-        handshake.selectedProtocol > input.protocol.max ||
-        handshake.selectedProtocol < registration.protocolMin ||
-        handshake.selectedProtocol > registration.protocolMax
-      ) {
-        throw new Error('Runtime Host selected a protocol outside the negotiated range');
-      }
-      return {
-        kind: 'connected',
-        registration,
-        connection: new RuntimeHostConnectionImpl(transport, handshake, {
-          livenessIntervalMs,
-          onLivenessProbe: input.onLivenessProbe,
-        }),
-      };
+    if (result.kind === 'connected') {
+      return { ...result, registration };
     }
     transport.abort();
-    if (handshake.kind === 'incompatible') return { kind: 'incompatible', handshake, registration };
-    return { kind: 'draining', registration };
+    return result.kind === 'incompatible'
+      ? { ...result, registration }
+      : { kind: 'draining', registration };
   } catch (error) {
     transport.abort();
     const failure = handshakeTimeoutError ?? error;
+    if (failure instanceof RuntimeHostEpochMismatchError) {
+      return { kind: 'unavailable', reason: 'epoch_mismatch', registration };
+    }
+    if (failure instanceof RuntimeHostRootMismatchError) {
+      return { kind: 'unavailable', reason: 'root_mismatch', registration };
+    }
     if (failure instanceof ElectionDeadlineElapsedError) {
       return { kind: 'election_deadline_elapsed', endpointConnected: true };
     }
@@ -1073,6 +1129,133 @@ export async function connectResolvedRuntimeHost(
   } finally {
     clearTimeout(handshakeTimer);
   }
+}
+
+interface ExchangeRuntimeHostHandshakeInput {
+  readonly transport: RuntimeHostMessageTransport;
+  readonly surface: ClientSurface;
+  readonly protocol: ProtocolRange;
+  readonly helloProtocol?: ProtocolRange;
+  readonly hostProtocol?: ProtocolRange;
+  readonly clientInstanceId: string;
+  readonly expectedHostEpoch?: string;
+  readonly expectedRootId?: string;
+  readonly livenessIntervalMs?: number;
+  readonly onLivenessProbe?: () => void;
+}
+
+async function exchangeRuntimeHostHandshake(
+  input: ExchangeRuntimeHostHandshakeInput,
+): Promise<
+  | { kind: 'connected'; connection: RuntimeHostConnection }
+  | { kind: 'incompatible'; handshake: HostIncompatible }
+  | { kind: 'draining' }
+> {
+  const helloProtocol = input.helloProtocol ?? input.protocol;
+  await writeClientFrame(input.transport, {
+    kind: 'hello',
+    clientInstanceId: input.clientInstanceId,
+    surface: input.surface,
+    protocolMin: helloProtocol.min,
+    protocolMax: helloProtocol.max,
+    compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+  });
+  const handshake = decodeHostFrame(await input.transport.read(0));
+  if (!('kind' in handshake)) {
+    throw new Error('Runtime Host returned an operation response before handshake');
+  }
+  if (
+    handshake.kind !== 'accepted' &&
+    handshake.kind !== 'incompatible' &&
+    handshake.kind !== 'draining'
+  ) {
+    throw new Error('Runtime Host returned a non-handshake frame before acceptance');
+  }
+  if (input.expectedHostEpoch && handshake.hostEpoch !== input.expectedHostEpoch) {
+    throw new RuntimeHostEpochMismatchError();
+  }
+  if (handshake.kind === 'incompatible') return { kind: 'incompatible', handshake };
+  if (handshake.kind === 'draining') return { kind: 'draining' };
+  if (input.expectedRootId && handshake.rootId !== input.expectedRootId) {
+    throw new RuntimeHostRootMismatchError();
+  }
+  if (handshake.compatibilityEpoch !== RUNTIME_HOST_COMPATIBILITY_EPOCH) {
+    throw new Error('Runtime Host accepted an incompatible schema epoch');
+  }
+  if (
+    handshake.selectedProtocol < input.protocol.min ||
+    handshake.selectedProtocol > input.protocol.max ||
+    (input.hostProtocol !== undefined &&
+      (handshake.selectedProtocol < input.hostProtocol.min ||
+        handshake.selectedProtocol > input.hostProtocol.max))
+  ) {
+    throw new Error('Runtime Host selected a protocol outside the negotiated range');
+  }
+  return {
+    kind: 'connected',
+    connection: new RuntimeHostConnectionImpl(input.transport, handshake, {
+      livenessIntervalMs: input.livenessIntervalMs,
+      onLivenessProbe: input.onLivenessProbe,
+    }),
+  };
+}
+
+class RuntimeHostEpochMismatchError extends Error {}
+class RuntimeHostRootMismatchError extends Error {}
+
+function requireRemoteWebSocketUrl(value: string): URL {
+  const url = new URL(value);
+  if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+    throw new Error('Remote Runtime Host URL must use ws or wss');
+  }
+  if (url.username || url.password || url.hash) {
+    throw new Error('Remote Runtime Host URL must not contain credentials or a fragment');
+  }
+  if (
+    url.protocol === 'ws:' &&
+    url.hostname !== '127.0.0.1' &&
+    url.hostname !== '[::1]' &&
+    url.hostname !== '::1'
+  ) {
+    throw new Error('Plain remote Runtime Host WebSocket URLs must use loopback');
+  }
+  return url;
+}
+
+function openWebSocketTransport(
+  url: URL,
+  credential: string,
+  timeoutMs: number,
+): Promise<WebSocketTransport> {
+  if (!credential || /\s/u.test(credential)) {
+    return Promise.reject(new Error('Runtime Host access credential is invalid'));
+  }
+  return new Promise((resolve, reject) => {
+    const webSocketOptions = {
+      headers: { authorization: `Bearer ${credential}` },
+      handshakeTimeout: timeoutMs,
+      maxPayload: RUNTIME_HOST_MAX_MESSAGE_BYTES,
+      maxFragments: MAX_WEBSOCKET_FRAGMENTS,
+      maxBufferedChunks: MAX_WEBSOCKET_BUFFERED_CHUNKS,
+      perMessageDeflate: false,
+    };
+    const socket = new WebSocket(url, webSocketOptions);
+    const onOpen = () => {
+      cleanup();
+      resolve(new WebSocketTransport(socket));
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      socket.terminate();
+      reject(error);
+    };
+    const cleanup = () => {
+      socket.off('open', onOpen);
+      socket.off('error', onError);
+    };
+    socket.once('open', onOpen);
+    socket.once('error', onError);
+  });
 }
 
 function openTransport(

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -1,9 +1,12 @@
 export {
   connectRuntimeHost,
   connectExistingRuntimeHost,
+  connectRemoteRuntimeHost,
   RuntimeHostOperationError,
   type ConnectRuntimeHostInput,
   type ConnectRuntimeHostResult,
+  type ConnectRemoteRuntimeHostInput,
+  type ConnectRemoteRuntimeHostResult,
   type RuntimeHostConnection,
   type RuntimeHostUnavailableReason,
   type DirectRequestOperationKey,
@@ -30,6 +33,7 @@ export {
   type ConnectOrSpawnRuntimeHostResult,
 } from './connect-or-spawn.js';
 export { type ClientCapabilityProvider } from './client-capability.js';
+export { consumeAccessCredentialDelivery } from '../control/access-credential-delivery.js';
 export {
   createOAuthPresentationClientProvider,
   OAUTH_PRESENTATION_SERVICE_ID,

--- a/packages/runtime-host/src/control/access-credential-delivery.ts
+++ b/packages/runtime-host/src/control/access-credential-delivery.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from 'node:crypto';
+import { chmod, open, readdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  resolveExistingStorageRootControlDirectory,
+  resolveStorageRoot,
+} from '@maka/storage/root-authority';
+
+const DELIVERY_FILE_PREFIX = 'runtime-host-access-delivery-';
+const DELIVERY_FILE_MAX_BYTES = 1024;
+const DELIVERY_LIFETIME_MS = 60_000;
+
+interface AccessCredentialDelivery {
+  readonly credentialId: string;
+  readonly credential: string;
+}
+
+export async function createAccessCredentialDelivery(
+  controlDirectory: string,
+  credentialId: string,
+  credential: string,
+): Promise<string> {
+  const deliveryId = randomUUID();
+  const path = deliveryPath(controlDirectory, deliveryId);
+  try {
+    await writeFile(path, `${JSON.stringify({ credentialId, credential })}\n`, {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    });
+    if (process.platform !== 'win32') await chmod(path, 0o600);
+    setTimeout(
+      () => void rm(path, { force: true }).catch(() => undefined),
+      DELIVERY_LIFETIME_MS,
+    ).unref();
+    return deliveryId;
+  } catch (error) {
+    await rm(path, { force: true });
+    throw error;
+  }
+}
+
+export async function purgeAccessCredentialDeliveries(controlDirectory: string): Promise<void> {
+  const entries = await readdir(controlDirectory);
+  await Promise.all(
+    entries
+      .filter((entry) => /^runtime-host-access-delivery-[0-9a-f-]{36}\.json$/u.test(entry))
+      .map((entry) => rm(join(controlDirectory, entry), { force: true })),
+  );
+}
+
+export async function consumeAccessCredentialDelivery(
+  rootPath: string,
+  deliveryId: string,
+  expectedCredentialId: string,
+): Promise<string> {
+  requireDeliveryId(deliveryId);
+  const capability = await resolveStorageRoot({ path: rootPath, kind: 'interactive' });
+  const { controlDirectory } = await resolveExistingStorageRootControlDirectory(capability);
+  return consumeAccessCredentialDeliveryFromControlDirectory(
+    controlDirectory,
+    deliveryId,
+    expectedCredentialId,
+  );
+}
+
+export async function consumeAccessCredentialDeliveryFromControlDirectory(
+  controlDirectory: string,
+  deliveryId: string,
+  expectedCredentialId: string,
+): Promise<string> {
+  const path = deliveryPath(controlDirectory, deliveryId);
+  try {
+    const handle = await open(path, 'r');
+    let raw: Buffer;
+    try {
+      const buffer = Buffer.alloc(DELIVERY_FILE_MAX_BYTES + 1);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, 0);
+      if (bytesRead > DELIVERY_FILE_MAX_BYTES) {
+        throw new Error('Runtime Host access credential delivery is too large');
+      }
+      raw = buffer.subarray(0, bytesRead);
+    } finally {
+      await handle.close();
+    }
+    const delivery = decodeDelivery(JSON.parse(raw.toString('utf8')) as unknown);
+    if (delivery.credentialId !== expectedCredentialId) {
+      throw new Error('Runtime Host access credential delivery identity does not match');
+    }
+    return delivery.credential;
+  } finally {
+    await rm(path, { force: true });
+  }
+}
+
+function deliveryPath(controlDirectory: string, deliveryId: string): string {
+  requireDeliveryId(deliveryId);
+  return join(controlDirectory, `${DELIVERY_FILE_PREFIX}${deliveryId}.json`);
+}
+
+function requireDeliveryId(deliveryId: string): void {
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u.test(deliveryId)) {
+    throw new Error('Invalid Runtime Host access credential delivery identity');
+  }
+}
+
+function decodeDelivery(value: unknown): AccessCredentialDelivery {
+  if (!isRecord(value) || Object.keys(value).length !== 2) {
+    throw new Error('Invalid Runtime Host access credential delivery');
+  }
+  if (typeof value.credentialId !== 'string' || typeof value.credential !== 'string') {
+    throw new Error('Invalid Runtime Host access credential delivery');
+  }
+  if (value.credential.length === 0 || value.credential.length > 512) {
+    throw new Error('Invalid Runtime Host access credential delivery');
+  }
+  return { credentialId: value.credentialId, credential: value.credential };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/runtime-host/src/control/access-credential-delivery.ts
+++ b/packages/runtime-host/src/control/access-credential-delivery.ts
@@ -49,6 +49,13 @@ export async function purgeAccessCredentialDeliveries(controlDirectory: string):
   );
 }
 
+export function discardAccessCredentialDelivery(
+  controlDirectory: string,
+  deliveryId: string,
+): Promise<void> {
+  return rm(deliveryPath(controlDirectory, deliveryId), { force: true });
+}
+
 export async function consumeAccessCredentialDelivery(
   rootPath: string,
   deliveryId: string,

--- a/packages/runtime-host/src/protocol/access-authority.ts
+++ b/packages/runtime-host/src/protocol/access-authority.ts
@@ -1,0 +1,147 @@
+import { invalidProtocolFrame } from './errors.js';
+import { requireExactRecord, requireId, requireString, requireUtf8String } from './codec.js';
+import { defineOperation } from './operation-spec.js';
+import type { OperationKey } from './operations.js';
+
+export const ACCESS_CREDENTIAL_MAX_GRANTS = 256;
+
+const ACCESS_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'invalid_request',
+  'persistence_failed',
+  'internal_failure',
+] as const;
+
+export interface AccessCredentialIssueInput {
+  readonly principalId: string;
+  readonly operationGrants: readonly OperationKey[];
+  readonly canPublishClientCapabilities: boolean;
+  readonly canUseHostPaths: boolean;
+}
+
+export interface AccessCredentialIssueResult {
+  readonly credentialId: string;
+  readonly deliveryId: string;
+  readonly principalId: string;
+  readonly operationGrants: readonly OperationKey[];
+  readonly canPublishClientCapabilities: boolean;
+  readonly canUseHostPaths: boolean;
+}
+
+export interface AccessCredentialRevokeInput {
+  readonly credentialId: string;
+}
+
+export interface AccessCredentialRevokeResult {
+  readonly credentialId: string;
+  readonly revoked: boolean;
+}
+
+export const ACCESS_AUTHORITY_OPERATION_SPECS = {
+  'access.credential.issue': defineOperation<
+    AccessCredentialIssueInput,
+    AccessCredentialIssueResult,
+    (typeof ACCESS_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: ACCESS_ERRORS,
+    decodeInput: decodeAccessCredentialIssueInput,
+    decodeOutput: decodeAccessCredentialIssueResult,
+  }),
+  'access.credential.revoke': defineOperation<
+    AccessCredentialRevokeInput,
+    AccessCredentialRevokeResult,
+    (typeof ACCESS_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: ACCESS_ERRORS,
+    decodeInput: decodeAccessCredentialRevokeInput,
+    decodeOutput: decodeAccessCredentialRevokeResult,
+  }),
+} as const;
+
+export function decodeAccessCredentialIssueInput(value: unknown): AccessCredentialIssueInput {
+  const record = requireExactRecord(value, 'access credential issue input', [
+    'principalId',
+    'operationGrants',
+    'canPublishClientCapabilities',
+    'canUseHostPaths',
+  ]);
+  return {
+    principalId: principalId(record.principalId),
+    operationGrants: operationGrants(record.operationGrants),
+    canPublishClientCapabilities: boolean(
+      record.canPublishClientCapabilities,
+      'canPublishClientCapabilities',
+    ),
+    canUseHostPaths: boolean(record.canUseHostPaths, 'canUseHostPaths'),
+  };
+}
+
+export function decodeAccessCredentialIssueResult(value: unknown): AccessCredentialIssueResult {
+  const record = requireExactRecord(value, 'access credential issue result', [
+    'credentialId',
+    'deliveryId',
+    'principalId',
+    'operationGrants',
+    'canPublishClientCapabilities',
+    'canUseHostPaths',
+  ]);
+  return {
+    credentialId: requireId(record.credentialId, 'credentialId'),
+    deliveryId: requireId(record.deliveryId, 'deliveryId'),
+    principalId: principalId(record.principalId),
+    operationGrants: operationGrants(record.operationGrants),
+    canPublishClientCapabilities: boolean(
+      record.canPublishClientCapabilities,
+      'canPublishClientCapabilities',
+    ),
+    canUseHostPaths: boolean(record.canUseHostPaths, 'canUseHostPaths'),
+  };
+}
+
+export function decodeAccessCredentialRevokeInput(value: unknown): AccessCredentialRevokeInput {
+  const record = requireExactRecord(value, 'access credential revoke input', ['credentialId']);
+  return { credentialId: requireId(record.credentialId, 'credentialId') };
+}
+
+export function decodeAccessCredentialRevokeResult(value: unknown): AccessCredentialRevokeResult {
+  const record = requireExactRecord(value, 'access credential revoke result', [
+    'credentialId',
+    'revoked',
+  ]);
+  return {
+    credentialId: requireId(record.credentialId, 'credentialId'),
+    revoked: boolean(record.revoked, 'revoked'),
+  };
+}
+
+function operationGrants(value: unknown): readonly OperationKey[] {
+  if (!Array.isArray(value) || value.length > ACCESS_CREDENTIAL_MAX_GRANTS) {
+    throw invalidProtocolFrame('Invalid access credential operation grants');
+  }
+  const grants = value.map((grant) =>
+    requireString(grant, 'access credential operation grant', 128),
+  );
+  if (new Set(grants).size !== grants.length) {
+    throw invalidProtocolFrame('Duplicate access credential operation grant');
+  }
+  return grants as OperationKey[];
+}
+
+function principalId(value: unknown): string {
+  const principal = requireUtf8String(value, 'access credential principalId', 128);
+  if (!/^[A-Za-z0-9_.:-]+$/u.test(principal)) {
+    throw invalidProtocolFrame('Invalid access credential principalId');
+  }
+  return principal;
+}
+
+function boolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') throw invalidProtocolFrame(`Invalid ${label}`);
+  return value;
+}

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -55,8 +55,8 @@ export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // The wire version remains v0 before the first release. This independent epoch
 // lets a new Client retire a stale same-version Host whose closed schema is no
 // longer safe to use.
-// 10: request header operations and transport-safe credential export changed the closed schema.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 10 as const;
+// 11: authenticated root identity and admission authorization changed the closed schema.
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 11 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such
@@ -89,6 +89,7 @@ export interface ClientHello {
 
 export interface HostAccepted {
   kind: 'accepted';
+  rootId: string;
   hostEpoch: string;
   connectionId: string;
   selectedProtocol: number;
@@ -187,6 +188,7 @@ export function decodeHostFrame(value: unknown): HostFrame {
   if (frame.kind === 'accepted') {
     return {
       kind: 'accepted',
+      rootId: requireId(frame.rootId, 'rootId'),
       hostEpoch: requireId(frame.hostEpoch, 'hostEpoch'),
       connectionId: requireId(frame.connectionId, 'connectionId'),
       selectedProtocol: requireProtocolVersion(frame.selectedProtocol, 'selectedProtocol'),

--- a/packages/runtime-host/src/protocol/operation-spec.ts
+++ b/packages/runtime-host/src/protocol/operation-spec.ts
@@ -4,6 +4,7 @@ export type OperationAvailability = 'bootstrap' | 'ready';
 export type HostOperationErrorCode =
   | 'host_not_ready'
   | 'host_draining'
+  | 'unauthorized'
   | 'operation_unavailable'
   | 'not_found'
   | 'session_archived'

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -1,4 +1,5 @@
 import { ARTIFACT_OPERATION_SPECS } from './artifact.js';
+import { ACCESS_AUTHORITY_OPERATION_SPECS } from './access-authority.js';
 import { AGENT_GRAPH_OPERATION_SPECS } from './agent-graph.js';
 import { AUTOMATION_OPERATION_SPECS } from './automation.js';
 import { requireExactRecord, requireId, requireRecord, requireString } from './codec.js';
@@ -117,6 +118,7 @@ export type {
   TurnStopInput,
 } from './turn.js';
 export * from './connection-effects.js';
+export * from './access-authority.js';
 export * from './configuration.js';
 export * from './deep-research.js';
 export * from './daily-review.js';
@@ -142,6 +144,7 @@ export * from './web-search.js';
 
 export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   HOST_BOOTSTRAP_OPERATION_SPECS,
+  ACCESS_AUTHORITY_OPERATION_SPECS,
   AGENT_GRAPH_OPERATION_SPECS,
   GOAL_OPERATION_SPECS,
   TURN_OPERATION_SPECS,
@@ -188,7 +191,7 @@ type InferErrorCode<Spec> =
 export type OperationInput<K extends OperationKey> = InferInput<OperationSpecMap[K]>;
 export type OperationOutput<K extends OperationKey> = InferOutput<OperationSpecMap[K]>;
 export type OperationError<K extends OperationKey> = HostOperationError<
-  InferErrorCode<OperationSpecMap[K]>
+  InferErrorCode<OperationSpecMap[K]> | 'unauthorized'
 >;
 
 export type RequestFrameFor<K extends OperationKey> = {
@@ -271,7 +274,10 @@ function decodeOperationError<C extends HostOperationErrorCode>(
   allowedCodes: readonly C[],
 ): HostOperationError<C> {
   const record = requireExactRecord(value, 'operation error', ['code', 'message']);
-  if (typeof record.code !== 'string' || !allowedCodes.includes(record.code as C)) {
+  if (
+    typeof record.code !== 'string' ||
+    (record.code !== 'unauthorized' && !allowedCodes.includes(record.code as C))
+  ) {
     throw invalidProtocolFrame('Operation returned an undeclared error code');
   }
   return {

--- a/packages/runtime-host/src/server/access-authority.ts
+++ b/packages/runtime-host/src/server/access-authority.ts
@@ -1,0 +1,224 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
+import { join } from 'node:path';
+import {
+  type AccessCredentialIssueInput,
+  type AccessCredentialIssueResult,
+  type AccessCredentialRevokeInput,
+  type AccessCredentialRevokeResult,
+} from '../protocol/index.js';
+import {
+  createRuntimeHostConnectionAuthority,
+  type RuntimeHostConnectionAuthority,
+} from './connection-authority.js';
+import type { OperationOutcome } from '../protocol/operations.js';
+import {
+  createAccessCredentialDelivery,
+  purgeAccessCredentialDeliveries,
+} from '../control/access-credential-delivery.js';
+import {
+  ACCESS_FILE_NAME,
+  createAccessCredentialFile,
+  issuedAccessGrants,
+  readAccessCredentialFile,
+  RuntimeHostAccessInputError,
+  type AccessCredentialFile,
+  type StoredAccessCredential,
+  writeAccessCredentialFile,
+} from './access-credential-store.js';
+
+const ACCESS_CREDENTIAL_PREFIX = 'maka_rh_';
+
+export interface RuntimeHostAccessAuthority {
+  authenticate(credential: string): RuntimeHostConnectionAuthority | undefined;
+  issue(input: AccessCredentialIssueInput): Promise<AccessCredentialIssueResult>;
+  revoke(input: AccessCredentialRevokeInput): Promise<AccessCredentialRevokeResult>;
+  subscribeRevocations(listener: (credentialId: string) => void): () => void;
+}
+
+export async function openRuntimeHostAccessAuthority(
+  controlDirectory: string,
+): Promise<RuntimeHostAccessAuthority> {
+  await purgeAccessCredentialDeliveries(controlDirectory);
+  const path = join(controlDirectory, ACCESS_FILE_NAME);
+  return new FileRuntimeHostAccessAuthority(
+    controlDirectory,
+    path,
+    await readAccessCredentialFile(path),
+  );
+}
+
+class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
+  readonly #controlDirectory: string;
+  readonly #path: string;
+  #file: AccessCredentialFile;
+  #mutation = Promise.resolve();
+  readonly #revocationListeners = new Set<(credentialId: string) => void>();
+
+  constructor(controlDirectory: string, path: string, file: AccessCredentialFile) {
+    this.#controlDirectory = controlDirectory;
+    this.#path = path;
+    this.#file = file;
+  }
+
+  authenticate(credential: string): RuntimeHostConnectionAuthority | undefined {
+    const candidate = hashCredential(credential);
+    let match: StoredAccessCredential | undefined;
+    for (const stored of this.#file.credentials) {
+      const storedHash = Buffer.from(stored.credentialHash, 'hex');
+      const equal =
+        storedHash.byteLength === candidate.byteLength && timingSafeEqual(storedHash, candidate);
+      if (equal && stored.status === 'active') match = stored;
+    }
+    return match
+      ? createRuntimeHostConnectionAuthority({
+          principalKind: 'access_credential',
+          principalId: match.principalId,
+          credentialId: match.credentialId,
+          operationGrants: match.operationGrants,
+          canPublishClientCapabilities: match.canPublishClientCapabilities,
+          canUseHostPaths: match.canUseHostPaths,
+        })
+      : undefined;
+  }
+
+  issue(input: AccessCredentialIssueInput): Promise<AccessCredentialIssueResult> {
+    return this.#mutate(async () => {
+      const operationGrants = issuedAccessGrants(input.operationGrants);
+      const credentialId = randomUUID();
+      createRuntimeHostConnectionAuthority({
+        principalKind: 'access_credential',
+        principalId: input.principalId,
+        credentialId,
+        operationGrants,
+        canPublishClientCapabilities: input.canPublishClientCapabilities,
+        canUseHostPaths: input.canUseHostPaths,
+      });
+      if (input.canPublishClientCapabilities && !input.canUseHostPaths) {
+        throw new RuntimeHostAccessInputError(
+          'Client Capability publication requires Host path authority until path-independent offers are declared',
+        );
+      }
+      const credential = `${ACCESS_CREDENTIAL_PREFIX}${randomBytes(32).toString('base64url')}`;
+      const stored: StoredAccessCredential = {
+        credentialId,
+        credentialHash: hashCredential(credential).toString('hex'),
+        principalId: input.principalId,
+        status: 'active',
+        operationGrants,
+        canPublishClientCapabilities: input.canPublishClientCapabilities,
+        canUseHostPaths: input.canUseHostPaths,
+        createdAt: new Date().toISOString(),
+      };
+      await this.#commit(createAccessCredentialFile([...this.#file.credentials, stored]));
+      const deliveryId = await createAccessCredentialDelivery(
+        this.#controlDirectory,
+        credentialId,
+        credential,
+      );
+      return {
+        credentialId,
+        deliveryId,
+        principalId: stored.principalId,
+        operationGrants,
+        canPublishClientCapabilities: stored.canPublishClientCapabilities,
+        canUseHostPaths: stored.canUseHostPaths,
+      };
+    });
+  }
+
+  revoke(input: AccessCredentialRevokeInput): Promise<AccessCredentialRevokeResult> {
+    return this.#mutate(async () => {
+      const index = this.#file.credentials.findIndex(
+        (credential) => credential.credentialId === input.credentialId,
+      );
+      if (index === -1 || this.#file.credentials[index]?.status === 'revoked') {
+        return { credentialId: input.credentialId, revoked: false };
+      }
+      const credentials = [...this.#file.credentials];
+      credentials[index] = {
+        ...credentials[index]!,
+        status: 'revoked',
+        revokedAt: new Date().toISOString(),
+      };
+      await this.#commit(createAccessCredentialFile(credentials));
+      for (const listener of this.#revocationListeners) {
+        try {
+          listener(input.credentialId);
+        } catch {
+          // Revocation is already durable; an observer cannot roll it back.
+        }
+      }
+      return { credentialId: input.credentialId, revoked: true };
+    });
+  }
+
+  subscribeRevocations(listener: (credentialId: string) => void): () => void {
+    this.#revocationListeners.add(listener);
+    return () => this.#revocationListeners.delete(listener);
+  }
+
+  #mutate<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#mutation.then(operation, operation);
+    this.#mutation = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  async #commit(file: AccessCredentialFile): Promise<void> {
+    await writeAccessCredentialFile(this.#path, file);
+    this.#file = file;
+  }
+}
+
+export async function issueAccessCredential(
+  authority: RuntimeHostAccessAuthority | undefined,
+  input: AccessCredentialIssueInput,
+): Promise<OperationOutcome<'access.credential.issue'>> {
+  if (!authority) return unavailable('issue');
+  try {
+    return { ok: true, result: await authority.issue(input) };
+  } catch (error) {
+    if (error instanceof RuntimeHostAccessInputError) {
+      return { ok: false, error: { code: 'invalid_request', message: error.message } };
+    }
+    return {
+      ok: false,
+      error: { code: 'persistence_failed', message: 'Access credential could not be issued' },
+    };
+  }
+}
+
+export async function revokeAccessCredential(
+  authority: RuntimeHostAccessAuthority | undefined,
+  input: AccessCredentialRevokeInput,
+): Promise<OperationOutcome<'access.credential.revoke'>> {
+  if (!authority) return unavailable('revoke');
+  try {
+    return { ok: true, result: await authority.revoke(input) };
+  } catch {
+    return {
+      ok: false,
+      error: { code: 'persistence_failed', message: 'Access credential could not be revoked' },
+    };
+  }
+}
+
+function unavailable(operation: 'issue'): OperationOutcome<'access.credential.issue'>;
+function unavailable(operation: 'revoke'): OperationOutcome<'access.credential.revoke'>;
+function unavailable(
+  _operation: 'issue' | 'revoke',
+): OperationOutcome<'access.credential.issue'> | OperationOutcome<'access.credential.revoke'> {
+  return {
+    ok: false,
+    error: {
+      code: 'operation_unavailable',
+      message: 'Runtime Host access credentials are unavailable in this composition',
+    },
+  };
+}
+
+function hashCredential(credential: string): Buffer {
+  return createHash('sha256').update(credential, 'utf8').digest();
+}

--- a/packages/runtime-host/src/server/access-authority.ts
+++ b/packages/runtime-host/src/server/access-authority.ts
@@ -13,10 +13,12 @@ import {
 import type { OperationOutcome } from '../protocol/operations.js';
 import {
   createAccessCredentialDelivery,
+  discardAccessCredentialDelivery,
   purgeAccessCredentialDeliveries,
 } from '../control/access-credential-delivery.js';
 import {
   ACCESS_FILE_NAME,
+  assertAccessCredentialFileCapacity,
   createAccessCredentialFile,
   issuedAccessGrants,
   readAccessCredentialFile,
@@ -109,12 +111,19 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
         canUseHostPaths: input.canUseHostPaths,
         createdAt: new Date().toISOString(),
       };
-      await this.#commit(createAccessCredentialFile([...this.#file.credentials, stored]));
+      const nextFile = createAccessCredentialFile([...this.#file.credentials, stored]);
+      assertAccessCredentialFileCapacity(nextFile);
       const deliveryId = await createAccessCredentialDelivery(
         this.#controlDirectory,
         credentialId,
         credential,
       );
+      try {
+        await this.#commit(nextFile);
+      } catch (error) {
+        await discardAccessCredentialDelivery(this.#controlDirectory, deliveryId);
+        throw error;
+      }
       return {
         credentialId,
         deliveryId,

--- a/packages/runtime-host/src/server/access-credential-store.ts
+++ b/packages/runtime-host/src/server/access-credential-store.ts
@@ -32,6 +32,13 @@ export class RuntimeHostAccessInputError extends Error {
   }
 }
 
+export class RuntimeHostAccessCapacityError extends Error {
+  constructor() {
+    super('Runtime Host access credential storage is full');
+    this.name = 'RuntimeHostAccessCapacityError';
+  }
+}
+
 export function createAccessCredentialFile(
   credentials: readonly StoredAccessCredential[],
 ): AccessCredentialFile {
@@ -40,6 +47,21 @@ export function createAccessCredentialFile(
 
 export function issuedAccessGrants(grants: readonly OperationKey[]): readonly OperationKey[] {
   return validateGrants([...new Set<OperationKey>(['host.status', ...grants])]);
+}
+
+export function assertAccessCredentialFileCapacity(file: AccessCredentialFile): void {
+  const fullyRevoked = createAccessCredentialFile(
+    file.credentials.map((credential) =>
+      credential.status === 'revoked'
+        ? credential
+        : {
+            ...credential,
+            status: 'revoked',
+            revokedAt: '9999-12-31T23:59:59.999Z',
+          },
+    ),
+  );
+  serializeAccessCredentialFile(fullyRevoked);
 }
 
 export async function readAccessCredentialFile(path: string): Promise<AccessCredentialFile> {
@@ -68,11 +90,12 @@ export async function writeAccessCredentialFile(
   path: string,
   file: AccessCredentialFile,
 ): Promise<void> {
+  const contents = serializeAccessCredentialFile(file);
   const tempPath = `${path}.${randomUUID()}.tmp`;
   try {
     const handle = await open(tempPath, 'wx', 0o600);
     try {
-      await handle.writeFile(`${JSON.stringify(file, null, 2)}\n`, 'utf8');
+      await handle.writeFile(contents, 'utf8');
       await handle.sync();
     } finally {
       await handle.close();
@@ -84,6 +107,14 @@ export async function writeAccessCredentialFile(
     await rm(tempPath, { force: true });
     throw error;
   }
+}
+
+function serializeAccessCredentialFile(file: AccessCredentialFile): string {
+  const contents = `${JSON.stringify(file, null, 2)}\n`;
+  if (Buffer.byteLength(contents) > ACCESS_FILE_MAX_BYTES) {
+    throw new RuntimeHostAccessCapacityError();
+  }
+  return contents;
 }
 
 function decodeAccessFile(value: unknown): AccessCredentialFile {

--- a/packages/runtime-host/src/server/access-credential-store.ts
+++ b/packages/runtime-host/src/server/access-credential-store.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from 'node:crypto';
+import { chmod, open, rename, rm, type FileHandle } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { HOST_OPERATION_SPECS, type OperationKey } from '../protocol/index.js';
+
+const ACCESS_FILE_SCHEMA_VERSION = 1;
+const ACCESS_FILE_MAX_BYTES = 512 * 1024;
+
+export const ACCESS_FILE_NAME = 'runtime-host-access.json';
+
+export interface StoredAccessCredential {
+  readonly credentialId: string;
+  readonly credentialHash: string;
+  readonly principalId: string;
+  readonly status: 'active' | 'revoked';
+  readonly operationGrants: readonly OperationKey[];
+  readonly canPublishClientCapabilities: boolean;
+  readonly canUseHostPaths: boolean;
+  readonly createdAt: string;
+  readonly revokedAt?: string;
+}
+
+export interface AccessCredentialFile {
+  readonly schemaVersion: typeof ACCESS_FILE_SCHEMA_VERSION;
+  readonly credentials: readonly StoredAccessCredential[];
+}
+
+export class RuntimeHostAccessInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RuntimeHostAccessInputError';
+  }
+}
+
+export function createAccessCredentialFile(
+  credentials: readonly StoredAccessCredential[],
+): AccessCredentialFile {
+  return { schemaVersion: ACCESS_FILE_SCHEMA_VERSION, credentials };
+}
+
+export function issuedAccessGrants(grants: readonly OperationKey[]): readonly OperationKey[] {
+  return validateGrants([...new Set<OperationKey>(['host.status', ...grants])]);
+}
+
+export async function readAccessCredentialFile(path: string): Promise<AccessCredentialFile> {
+  let handle: FileHandle;
+  try {
+    handle = await open(path, 'r');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return createAccessCredentialFile([]);
+    throw error;
+  }
+  let raw: Buffer;
+  try {
+    const buffer = Buffer.alloc(ACCESS_FILE_MAX_BYTES + 1);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, 0);
+    if (bytesRead > ACCESS_FILE_MAX_BYTES) {
+      throw new Error('Runtime Host access file is too large');
+    }
+    raw = buffer.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+  return decodeAccessFile(JSON.parse(raw.toString('utf8')) as unknown);
+}
+
+export async function writeAccessCredentialFile(
+  path: string,
+  file: AccessCredentialFile,
+): Promise<void> {
+  const tempPath = `${path}.${randomUUID()}.tmp`;
+  try {
+    const handle = await open(tempPath, 'wx', 0o600);
+    try {
+      await handle.writeFile(`${JSON.stringify(file, null, 2)}\n`, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    if (process.platform !== 'win32') await chmod(tempPath, 0o600);
+    await rename(tempPath, path);
+    await syncDirectory(dirname(path));
+  } catch (error) {
+    await rm(tempPath, { force: true });
+    throw error;
+  }
+}
+
+function decodeAccessFile(value: unknown): AccessCredentialFile {
+  if (!isRecord(value) || value.schemaVersion !== ACCESS_FILE_SCHEMA_VERSION) {
+    throw new Error('Unsupported Runtime Host access file');
+  }
+  if (!Array.isArray(value.credentials)) throw new Error('Invalid Runtime Host access file');
+  const credentials = value.credentials.map(decodeStoredCredential);
+  if (
+    new Set(credentials.map((credential) => credential.credentialId)).size !== credentials.length
+  ) {
+    throw new Error('Duplicate Runtime Host access credential identity');
+  }
+  return createAccessCredentialFile(credentials);
+}
+
+function decodeStoredCredential(value: unknown): StoredAccessCredential {
+  if (!isRecord(value)) throw new Error('Invalid Runtime Host access credential');
+  const credentialId = requireStoredString(value.credentialId, 'credentialId');
+  const credentialHash = requireStoredString(value.credentialHash, 'credentialHash');
+  if (!/^[a-f0-9]{64}$/u.test(credentialHash)) throw new Error('Invalid credentialHash');
+  const principalId = requireStoredString(value.principalId, 'principalId');
+  if (!/^[A-Za-z0-9_.:-]{1,128}$/u.test(principalId)) throw new Error('Invalid principalId');
+  if (value.status !== 'active' && value.status !== 'revoked') throw new Error('Invalid status');
+  if (!Array.isArray(value.operationGrants)) throw new Error('Invalid operationGrants');
+  const rawOperationGrants = value.operationGrants.map((grant) =>
+    requireStoredString(grant, 'operationGrant'),
+  ) as OperationKey[];
+  if (new Set(rawOperationGrants).size !== rawOperationGrants.length) {
+    throw new Error('Duplicate Runtime Host access operation grant');
+  }
+  const operationGrants = validateGrants(rawOperationGrants);
+  if (!operationGrants.includes('host.status')) {
+    throw new Error('Runtime Host access credential lacks its liveness grant');
+  }
+  if (
+    typeof value.canPublishClientCapabilities !== 'boolean' ||
+    typeof value.canUseHostPaths !== 'boolean'
+  ) {
+    throw new Error('Invalid access credential authority');
+  }
+  const createdAt = requireStoredString(value.createdAt, 'createdAt');
+  const revokedAt = value.revokedAt;
+  if (revokedAt !== undefined && typeof revokedAt !== 'string') {
+    throw new Error('Invalid revokedAt');
+  }
+  return {
+    credentialId,
+    credentialHash,
+    principalId,
+    status: value.status,
+    operationGrants,
+    canPublishClientCapabilities: value.canPublishClientCapabilities,
+    canUseHostPaths: value.canUseHostPaths,
+    createdAt,
+    ...(revokedAt === undefined ? {} : { revokedAt }),
+  };
+}
+
+function validateGrants(grants: readonly OperationKey[]): readonly OperationKey[] {
+  for (const grant of grants) {
+    if (!Object.hasOwn(HOST_OPERATION_SPECS, grant)) {
+      throw new RuntimeHostAccessInputError(`Unknown Runtime Host operation grant: ${grant}`);
+    }
+    if (grant === 'access.credential.issue' || grant === 'access.credential.revoke') {
+      throw new RuntimeHostAccessInputError('Access credential administration is local-owner only');
+    }
+  }
+  return Object.freeze([...grants]);
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await open(path, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function requireStoredString(value: unknown, label: string): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > 1024) {
+    throw new Error(`Invalid Runtime Host access ${label}`);
+  }
+  return value;
+}

--- a/packages/runtime-host/src/server/connection-authority.ts
+++ b/packages/runtime-host/src/server/connection-authority.ts
@@ -1,8 +1,14 @@
-import { HOST_OPERATION_SPECS, type OperationKey } from '../protocol/index.js';
+import {
+  HOST_OPERATION_SPECS,
+  type ClientCapabilityClientFrame,
+  type OperationKey,
+  type RequestFrame,
+} from '../protocol/index.js';
 
 export interface RuntimeHostConnectionAuthority {
   readonly principalKind: 'local_owner' | 'access_credential';
   readonly principalId: string;
+  readonly credentialId?: string;
   readonly operationGrants: 'all' | readonly OperationKey[];
   readonly canPublishClientCapabilities: boolean;
   readonly canUseHostPaths: boolean;
@@ -22,6 +28,12 @@ export function createRuntimeHostConnectionAuthority(
   if (!/^[A-Za-z0-9_.:-]{1,128}$/.test(input.principalId)) {
     throw new Error('Runtime Host connection principal is invalid');
   }
+  if (
+    input.principalKind === 'access_credential' &&
+    !/^[A-Za-z0-9_.:-]{1,128}$/.test(input.credentialId ?? '')
+  ) {
+    throw new Error('Runtime Host access credential identity is invalid');
+  }
   const operationGrants =
     input.operationGrants === 'all'
       ? 'all'
@@ -34,4 +46,59 @@ export function createRuntimeHostConnectionAuthority(
           }),
         );
   return Object.freeze({ ...input, operationGrants });
+}
+
+export function authorizeRuntimeHostOperation(
+  authority: RuntimeHostConnectionAuthority,
+  frame: RequestFrame,
+): boolean {
+  if (
+    (frame.operation === 'access.credential.issue' ||
+      frame.operation === 'access.credential.revoke') &&
+    authority.principalKind !== 'local_owner'
+  ) {
+    return false;
+  }
+  if (authority.operationGrants !== 'all' && !authority.operationGrants.includes(frame.operation)) {
+    return false;
+  }
+  if (
+    (frame.operation === 'client.capability.replace' ||
+      frame.operation === 'client.capability.unregister') &&
+    !authority.canPublishClientCapabilities
+  ) {
+    return false;
+  }
+  return authority.canUseHostPaths || !operationUsesHostPath(frame);
+}
+
+export function hasRuntimeHostOperationGrant(
+  authority: RuntimeHostConnectionAuthority,
+  operation: OperationKey,
+): boolean {
+  return authority.operationGrants === 'all' || authority.operationGrants.includes(operation);
+}
+
+export function authorizeClientCapabilityFrame(
+  authority: RuntimeHostConnectionAuthority,
+  _frame: ClientCapabilityClientFrame,
+): boolean {
+  return authority.canPublishClientCapabilities;
+}
+
+function operationUsesHostPath(frame: RequestFrame): boolean {
+  switch (frame.operation) {
+    case 'session.create':
+    case 'session.cwd.relocate':
+    case 'skill.catalog.query':
+    case 'skill.catalog.mutate':
+    case 'skill.catalog.preview-update':
+      return true;
+    case 'skill.catalog.invocable.query':
+      return frame.input.target.kind === 'new_session';
+    case 'external-session.catalog.query':
+      return frame.input.cwd !== undefined;
+    default:
+      return false;
+  }
 }

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -33,6 +33,11 @@ import type {
   SessionCatalogChangeConnection,
 } from './session-catalog-change-service.js';
 import type { RuntimeHostConnectionAuthority } from './connection-authority.js';
+import {
+  authorizeClientCapabilityFrame,
+  authorizeRuntimeHostOperation,
+  hasRuntimeHostOperationGrant,
+} from './connection-authority.js';
 
 type AcceptedConnectionContext = Omit<ConnectionContext, 'acquireResidency' | 'principal'> & {
   readonly clientInstanceId: string;
@@ -122,7 +127,14 @@ export class RuntimeHostConnectionSession {
       const frame = decodeClientFrame(await this.#options.transport.read(0));
       if ('kind' in frame) {
         if (isClientCapabilityClientFrameKind(frame.kind)) {
-          this.#ensureClientCapabilities()?.accept(frame as ClientCapabilityClientFrame);
+          const capabilityFrame = frame as ClientCapabilityClientFrame;
+          if (
+            !authorizeClientCapabilityFrame(this.#options.connection.authority, capabilityFrame)
+          ) {
+            this.#teardown();
+            return;
+          }
+          this.#ensureClientCapabilities()?.accept(capabilityFrame);
           continue;
         }
         throw new Error('Unexpected handshake frame after acceptance');
@@ -155,6 +167,13 @@ export class RuntimeHostConnectionSession {
   }
 
   async #handleRequest(frame: RequestFrame): Promise<void> {
+    if (!authorizeRuntimeHostOperation(this.#options.connection.authority, frame)) {
+      if (this.#closed) return;
+      await this.#writer.enqueue(
+        operationFailureResponse(frame, 'unauthorized', 'Runtime Host operation is not authorized'),
+      ).flushed;
+      return;
+    }
     const admission = await this.#options.beginOperation(frame);
     if (typeof admission === 'string') {
       if (this.#closed) return;
@@ -262,6 +281,9 @@ export class RuntimeHostConnectionSession {
   }
 
   #attachConfigurationChanges(): void {
+    if (!hasRuntimeHostOperationGrant(this.#options.connection.authority, 'runtime.policy.query')) {
+      return;
+    }
     const service = this.#options.resolveConfigurationChanges?.();
     if (!service || this.#configurationChanges) return;
     this.#configurationChanges = service.attachConnection(this.#options.connection.connectionId, {
@@ -287,6 +309,11 @@ export class RuntimeHostConnectionSession {
   }
 
   #attachSessionCatalogChanges(): void {
+    if (
+      !hasRuntimeHostOperationGrant(this.#options.connection.authority, 'session.catalog.query')
+    ) {
+      return;
+    }
     const service = this.#options.resolveSessionCatalogChanges?.();
     if (!service || this.#sessionCatalogChanges) return;
     this.#sessionCatalogChanges = service.attachConnection(this.#options.connection.connectionId, {

--- a/packages/runtime-host/src/server/execution-service.ts
+++ b/packages/runtime-host/src/server/execution-service.ts
@@ -5,6 +5,9 @@ import {
   type ExecutionRuntimeHostCompositionDependencies,
 } from './execution-composition-factory.js';
 import { RuntimeHostKernel } from './host-kernel.js';
+import { openRuntimeHostAccessAuthority } from './access-authority.js';
+import { startRuntimeHostServiceListenerSet } from './listener-set.js';
+import type { StartRuntimeHostWebSocketListenerOptions } from './websocket-listener.js';
 
 export interface ExecutionRuntimeHostServiceOptions {
   readonly rootPath: string;
@@ -13,6 +16,10 @@ export interface ExecutionRuntimeHostServiceOptions {
   readonly bundledGitResourcesRoot?: string;
   readonly handshakeTimeoutMs?: number;
   readonly shutdownGraceMs?: number;
+  readonly websocket?: Omit<
+    StartRuntimeHostWebSocketListenerOptions,
+    'accessAuthority' | 'accept' | 'isReady'
+  >;
 }
 
 export type ExecutionRuntimeHostServiceDependencies = ExecutionRuntimeHostCompositionDependencies;
@@ -37,11 +44,27 @@ export async function startExecutionRuntimeHostService(
   const capability = await resolveStorageRoot({ path: options.rootPath, kind: 'interactive' });
   const owner = await tryAcquireInteractiveRootOwner(capability);
   if (!owner) throw new RuntimeHostRootAlreadyOwnedError(capability.canonicalPath);
-  return RuntimeHostKernel.start({
-    owner,
-    lifecycleMode: 'service',
-    handshakeTimeoutMs: options.handshakeTimeoutMs,
-    shutdownGraceMs: options.shutdownGraceMs,
-    compositionFactory,
-  });
+  try {
+    const accessAuthority = await openRuntimeHostAccessAuthority(owner.controlDirectory);
+    return await RuntimeHostKernel.start({
+      owner,
+      lifecycleMode: 'service',
+      handshakeTimeoutMs: options.handshakeTimeoutMs,
+      shutdownGraceMs: options.shutdownGraceMs,
+      compositionFactory,
+      accessAuthority,
+      ...(options.websocket
+        ? {
+            listenerSetFactory: (input) =>
+              startRuntimeHostServiceListenerSet(input, {
+                ...options.websocket!,
+                accessAuthority,
+              }),
+          }
+        : {}),
+    });
+  } catch (error) {
+    if (!owner.closed) await owner.close();
+    throw error;
+  }
 }

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -34,6 +34,11 @@ import {
   type OperationResidency,
   type OperationHandlerMap,
 } from './operation-dispatcher.js';
+import {
+  issueAccessCredential,
+  revokeAccessCredential,
+  type RuntimeHostAccessAuthority,
+} from './access-authority.js';
 import type { SessionContinuityService } from './session-continuity-service.js';
 import type { ClientCapabilityService } from './client-capability-service.js';
 import type { HostConfigurationChangeService } from './configuration-change-service.js';
@@ -98,6 +103,7 @@ interface RuntimeHostKernelCommonOptions {
   shutdownGraceMs?: number;
   compositionFactory?: RuntimeHostCompositionFactory;
   listenerSetFactory?: RuntimeHostListenerSetFactory;
+  accessAuthority?: RuntimeHostAccessAuthority;
 }
 
 export type RuntimeHostLifecycleMode = 'ephemeral' | 'service';
@@ -120,6 +126,10 @@ export class RuntimeHostKernel {
   readonly #handshakingTransports = new Set<RuntimeHostMessageTransport>();
   readonly #acceptedTransports = new Set<RuntimeHostMessageTransport>();
   readonly #connectionSessions = new Set<RuntimeHostConnectionSession>();
+  readonly #transportAuthorities = new Map<
+    RuntimeHostMessageTransport,
+    RuntimeHostListenerConnection['authority']
+  >();
   readonly #operationDrainWaiters = new Set<() => void>();
   readonly #residencyDrainWaiters = new Set<() => void>();
   readonly #lifecycle: RuntimeHostLifecycle;
@@ -142,6 +152,7 @@ export class RuntimeHostKernel {
   #terminationRequired: RuntimeHostProcessTerminationRequiredError | undefined;
   #resolveClosed!: () => void;
   #rejectClosed!: (error: unknown) => void;
+  readonly #unsubscribeAccessRevocations: (() => void) | undefined;
 
   private constructor(options: RuntimeHostKernelOptions) {
     this.#lifecycle = normalizeLifecycle(options);
@@ -154,6 +165,9 @@ export class RuntimeHostKernel {
     this.#handshakeTimeoutMs = options.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
     this.#shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.#options = options;
+    this.#unsubscribeAccessRevocations = options.accessAuthority?.subscribeRevocations(
+      (credentialId) => this.#revokeCredentialConnections(credentialId),
+    );
     this.#operationHandlers = this.#createOperationHandlers(
       createUnavailableDomainOperationHandlers(),
     );
@@ -202,6 +216,10 @@ export class RuntimeHostKernel {
     return this.#acceptedTransports.size;
   }
 
+  get websocketEndpoints(): readonly string[] {
+    return this.#listeners?.websocketEndpoints ?? [];
+  }
+
   close(): Promise<void> {
     this.#requestDrain();
     return this.closed;
@@ -223,6 +241,7 @@ export class RuntimeHostKernel {
       rootId: this.#options.owner.capability.rootId,
       hostEpoch: this.hostEpoch,
       accept: (connection) => this.#accept(connection),
+      isReady: () => this.#state === 'ready' && !this.#shutdownRequested,
     });
     await this.#publishRegistration();
     const compositionFactory = this.#options.compositionFactory;
@@ -263,9 +282,11 @@ export class RuntimeHostKernel {
 
   #accept(connection: RuntimeHostListenerConnection): void {
     const { transport } = connection;
+    this.#transportAuthorities.set(transport, connection.authority);
     this.#handshakingTransports.add(transport);
     void this.#serveConnection(connection).finally(() => {
       this.#handshakingTransports.delete(transport);
+      this.#transportAuthorities.delete(transport);
     });
   }
 
@@ -358,6 +379,7 @@ export class RuntimeHostKernel {
     this.#cancelIdle();
     return {
       kind: 'accepted',
+      rootId: this.#options.owner.capability.rootId,
       hostEpoch: this.hostEpoch,
       connectionId: randomUUID(),
       selectedProtocol,
@@ -371,6 +393,12 @@ export class RuntimeHostKernel {
       throw new Error('Runtime Host connection residency underflow');
     }
     this.#settleLifecycleAfterWork();
+  }
+
+  #revokeCredentialConnections(credentialId: string): void {
+    for (const [transport, authority] of this.#transportAuthorities) {
+      if (authority.credentialId === credentialId) transport.abort();
+    }
   }
 
   async #beginOperation(
@@ -495,6 +523,10 @@ export class RuntimeHostKernel {
             logs: runtimeHostLogBuffer.snapshot(),
           },
         }),
+        'access.credential.issue': async (input) =>
+          issueAccessCredential(this.#options.accessAuthority, input),
+        'access.credential.revoke': async (input) =>
+          revokeAccessCredential(this.#options.accessAuthority, input),
       },
       domainHandlers,
     );
@@ -612,6 +644,7 @@ export class RuntimeHostKernel {
 
   async #closeResources(): Promise<void> {
     const errors: unknown[] = [];
+    this.#unsubscribeAccessRevocations?.();
     // Stop new admissions before any asynchronous shutdown bookkeeping. The
     // shutdown deadline may expire while publishing the draining registration;
     // leaving the listener open in that case strands an unreachable, ref'ed
@@ -662,6 +695,7 @@ export class RuntimeHostKernel {
 
   async #abortStartup(): Promise<void> {
     this.#state = 'draining';
+    this.#unsubscribeAccessRevocations?.();
     for (const transport of this.#handshakingTransports) transport.abort();
     for (const transport of this.#acceptedTransports) transport.abort();
     await this.#listeners?.closeAdmission().catch(() => undefined);

--- a/packages/runtime-host/src/server/index.ts
+++ b/packages/runtime-host/src/server/index.ts
@@ -27,6 +27,7 @@ export {
 export { installRuntimeHostLogCapture } from '../process-diagnostics.js';
 export {
   createRuntimeHostListenerSet,
+  startRuntimeHostServiceListenerSet,
   startLocalRuntimeHostListenerSet,
   type RuntimeHostListenerSet,
   type RuntimeHostListener,
@@ -35,6 +36,15 @@ export {
   type RuntimeHostListenerSetFactory,
   type RuntimeHostListenerSetFactoryInput,
 } from './listener-set.js';
+export {
+  startRuntimeHostWebSocketListener,
+  type RuntimeHostWebSocketTls,
+  type StartRuntimeHostWebSocketListenerOptions,
+} from './websocket-listener.js';
+export {
+  openRuntimeHostAccessAuthority,
+  type RuntimeHostAccessAuthority,
+} from './access-authority.js';
 export {
   createRuntimeHostConnectionAuthority,
   LOCAL_OWNER_CONNECTION_AUTHORITY,

--- a/packages/runtime-host/src/server/listener-set.ts
+++ b/packages/runtime-host/src/server/listener-set.ts
@@ -1,6 +1,10 @@
 import { startLocalIpcRuntimeHostListener } from './local-ipc-listener.js';
 import type { RuntimeHostMessageTransport } from '../transport/message-transport.js';
 import type { RuntimeHostConnectionAuthority } from './connection-authority.js';
+import {
+  startRuntimeHostWebSocketListener,
+  type StartRuntimeHostWebSocketListenerOptions,
+} from './websocket-listener.js';
 
 export interface RuntimeHostListenerConnection {
   readonly transport: RuntimeHostMessageTransport;
@@ -19,6 +23,7 @@ export type RuntimeHostListenerKind = 'local_ipc' | 'websocket';
 export interface RuntimeHostListenerSet {
   readonly listeners: readonly RuntimeHostListener[];
   readonly localEndpoint: string;
+  readonly websocketEndpoints: readonly string[];
   closeAdmission(): Promise<void>;
   cleanup(): Promise<void>;
 }
@@ -27,6 +32,7 @@ export interface RuntimeHostListenerSetFactoryInput {
   readonly rootId: string;
   readonly hostEpoch: string;
   readonly accept: (connection: RuntimeHostListenerConnection) => void;
+  readonly isReady: () => boolean;
 }
 
 export type RuntimeHostListenerSetFactory = (
@@ -40,6 +46,25 @@ export async function startLocalRuntimeHostListenerSet(
   return createRuntimeHostListenerSet(local);
 }
 
+export async function startRuntimeHostServiceListenerSet(
+  input: RuntimeHostListenerSetFactoryInput,
+  websocket: Omit<StartRuntimeHostWebSocketListenerOptions, 'accept' | 'isReady'>,
+): Promise<RuntimeHostListenerSet> {
+  const local = await startLocalIpcRuntimeHostListener(input);
+  try {
+    const remote = await startRuntimeHostWebSocketListener({
+      ...websocket,
+      accept: input.accept,
+      isReady: input.isReady,
+    });
+    return createRuntimeHostListenerSet(local, [remote]);
+  } catch (error) {
+    await local.closeAdmission().catch(() => undefined);
+    await local.cleanup().catch(() => undefined);
+    throw error;
+  }
+}
+
 export function createRuntimeHostListenerSet(
   local: RuntimeHostListener & { readonly kind: 'local_ipc' },
   additional: readonly RuntimeHostListener[] = [],
@@ -48,6 +73,11 @@ export function createRuntimeHostListenerSet(
   return {
     listeners,
     localEndpoint: local.endpoint,
+    websocketEndpoints: Object.freeze(
+      additional
+        .filter((listener) => listener.kind === 'websocket')
+        .map((listener) => listener.endpoint),
+    ),
     closeAdmission: () => settleListeners(listeners, (listener) => listener.closeAdmission()),
     cleanup: () => settleListeners([...listeners].reverse(), (listener) => listener.cleanup()),
   };

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -12,6 +12,7 @@ import {
   type ResponseFrameFor,
 } from '../protocol/index.js';
 import { HOST_BOOTSTRAP_OPERATION_SPECS } from '../protocol/host-status.js';
+import { ACCESS_AUTHORITY_OPERATION_SPECS } from '../protocol/access-authority.js';
 
 export interface ConnectionContext {
   hostEpoch: string;
@@ -34,7 +35,10 @@ export type OperationHandlerMap = {
   [K in OperationKey]: OperationHandler<K>;
 };
 
-export type DomainOperationKey = Exclude<OperationKey, keyof typeof HOST_BOOTSTRAP_OPERATION_SPECS>;
+export type HostCoreOperationKey =
+  | keyof typeof HOST_BOOTSTRAP_OPERATION_SPECS
+  | keyof typeof ACCESS_AUTHORITY_OPERATION_SPECS;
+export type DomainOperationKey = Exclude<OperationKey, HostCoreOperationKey>;
 export type TurnOperationKey = Extract<
   OperationKey,
   | 'turn.start'
@@ -161,6 +165,10 @@ export type DailyReviewOperationHandlerMap = Pick<OperationHandlerMap, DailyRevi
 export type WebSearchOperationHandlerMap = Pick<OperationHandlerMap, WebSearchOperationKey>;
 export type NetworkProxyOperationHandlerMap = Pick<OperationHandlerMap, NetworkProxyOperationKey>;
 export type ConfigurationOperationHandlerMap = Pick<OperationHandlerMap, ConfigurationOperationKey>;
+export type AccessAuthorityOperationHandlerMap = Pick<
+  OperationHandlerMap,
+  keyof typeof ACCESS_AUTHORITY_OPERATION_SPECS
+>;
 
 export function composeOperationHandlers(
   ...handlerMaps: readonly Partial<OperationHandlerMap>[]
@@ -191,7 +199,12 @@ export function composeOperationHandlers(
 export function createUnavailableDomainOperationHandlers(): DomainOperationHandlerMap {
   const handlers: Partial<DomainOperationHandlerMap> = {};
   for (const operation of Object.keys(HOST_OPERATION_SPECS) as OperationKey[]) {
-    if (Object.hasOwn(HOST_BOOTSTRAP_OPERATION_SPECS, operation)) continue;
+    if (
+      Object.hasOwn(HOST_BOOTSTRAP_OPERATION_SPECS, operation) ||
+      Object.hasOwn(ACCESS_AUTHORITY_OPERATION_SPECS, operation)
+    ) {
+      continue;
+    }
     const errors = HOST_OPERATION_SPECS[operation].errors as readonly HostOperationErrorCode[];
     if (!errors.includes('operation_unavailable')) {
       throw new Error(`${operation} does not declare operation_unavailable`);
@@ -207,6 +220,25 @@ export function createUnavailableDomainOperationHandlers(): DomainOperationHandl
     });
   }
   return handlers as DomainOperationHandlerMap;
+}
+
+export function createUnavailableAccessAuthorityOperationHandlers(): AccessAuthorityOperationHandlerMap {
+  return {
+    'access.credential.issue': async () => ({
+      ok: false,
+      error: {
+        code: 'operation_unavailable',
+        message: 'Runtime Host access credentials are unavailable',
+      },
+    }),
+    'access.credential.revoke': async () => ({
+      ok: false,
+      error: {
+        code: 'operation_unavailable',
+        message: 'Runtime Host access credentials are unavailable',
+      },
+    }),
+  };
 }
 
 export async function dispatchOperation(
@@ -228,7 +260,7 @@ export function operationFailureResponse(
 ): ResponseFrame {
   const declaredErrors = HOST_OPERATION_SPECS[request.operation]
     .errors as readonly HostOperationErrorCode[];
-  if (!declaredErrors.includes(code)) {
+  if (code !== 'unauthorized' && !declaredErrors.includes(code)) {
     throw new Error(`${request.operation} does not declare ${code}`);
   }
   return {

--- a/packages/runtime-host/src/server/websocket-listener.ts
+++ b/packages/runtime-host/src/server/websocket-listener.ts
@@ -1,0 +1,248 @@
+import { createServer as createHttpServer, type Server as HttpServer } from 'node:http';
+import { createServer as createHttpsServer, type Server as HttpsServer } from 'node:https';
+import type { Duplex } from 'node:stream';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { WebSocketServer } from 'ws';
+import { RUNTIME_HOST_MAX_MESSAGE_BYTES } from '../protocol/index.js';
+import { WebSocketTransport } from '../transport/websocket-transport.js';
+import type { RuntimeHostAccessAuthority } from './access-authority.js';
+import type { RuntimeHostListener, RuntimeHostListenerConnection } from './listener-set.js';
+
+const DEFAULT_WEBSOCKET_PATH = '/runtime-host';
+const MAX_WEBSOCKET_FRAGMENTS = 256;
+const MAX_WEBSOCKET_BUFFERED_CHUNKS = 256;
+
+export interface RuntimeHostWebSocketTls {
+  readonly certificate: string | Buffer;
+  readonly privateKey: string | Buffer;
+}
+
+export interface StartRuntimeHostWebSocketListenerOptions {
+  readonly host: string;
+  readonly port: number;
+  readonly path?: string;
+  readonly tls?: RuntimeHostWebSocketTls;
+  readonly allowedOrigins?: readonly string[];
+  readonly accessAuthority: RuntimeHostAccessAuthority;
+  readonly isReady: () => boolean;
+  readonly accept: (connection: RuntimeHostListenerConnection) => void;
+}
+
+export async function startRuntimeHostWebSocketListener(
+  options: StartRuntimeHostWebSocketListenerOptions,
+): Promise<RuntimeHostListener & { readonly kind: 'websocket' }> {
+  validateWebSocketListenerOptions(options);
+  const path = options.path ?? DEFAULT_WEBSOCKET_PATH;
+  const server = options.tls
+    ? createHttpsServer(
+        { cert: options.tls.certificate, key: options.tls.privateKey },
+        (request, response) => handleHttpRequest(request, response, options.isReady),
+      )
+    : createHttpServer((request, response) =>
+        handleHttpRequest(request, response, options.isReady),
+      );
+  const webSocketOptions = {
+    noServer: true,
+    clientTracking: true,
+    maxPayload: RUNTIME_HOST_MAX_MESSAGE_BYTES,
+    maxFragments: MAX_WEBSOCKET_FRAGMENTS,
+    maxBufferedChunks: MAX_WEBSOCKET_BUFFERED_CHUNKS,
+    perMessageDeflate: false,
+  };
+  const webSocketServer = new WebSocketServer(webSocketOptions);
+  const transports = new Set<WebSocketTransport>();
+  const onUpgrade = (request: IncomingMessage, socket: Duplex, head: Buffer) => {
+    if (!upgradeTargetsPath(request, path)) {
+      rejectUpgrade(socket, 404, 'Not Found');
+      return;
+    }
+    if (!originAccepted(request.headers.origin, options.allowedOrigins)) {
+      rejectUpgrade(socket, 403, 'Forbidden');
+      return;
+    }
+    const credential = readBearerCredential(request.headers.authorization);
+    const authority = credential ? options.accessAuthority.authenticate(credential) : undefined;
+    if (!authority) {
+      rejectUpgrade(socket, 401, 'Unauthorized');
+      return;
+    }
+    webSocketServer.handleUpgrade(request, socket, head, (webSocket) => {
+      const transport = new WebSocketTransport(webSocket);
+      transports.add(transport);
+      void transport.closed.then(() => transports.delete(transport));
+      try {
+        options.accept({ transport, authority });
+      } catch (error) {
+        transport.abort(asError(error));
+      }
+    });
+  };
+  server.on('upgrade', onUpgrade);
+  try {
+    await listen(server, options.host, options.port);
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('WebSocket listener has no address');
+    const scheme = options.tls ? 'wss' : 'ws';
+    const host = address.family === 'IPv6' ? `[${address.address}]` : address.address;
+    return new RuntimeHostWebSocketListener(
+      server,
+      webSocketServer,
+      transports,
+      `${scheme}://${host}:${address.port}${path}`,
+      onUpgrade,
+    );
+  } catch (error) {
+    server.off('upgrade', onUpgrade);
+    for (const transport of transports) transport.abort();
+    await closeWebSocketServer(webSocketServer).catch(() => undefined);
+    await closeServer(server).catch(() => undefined);
+    throw error;
+  }
+}
+
+class RuntimeHostWebSocketListener implements RuntimeHostListener {
+  readonly kind = 'websocket' as const;
+  readonly endpoint: string;
+  readonly #server: HttpServer | HttpsServer;
+  readonly #webSocketServer: WebSocketServer;
+  readonly #transports: Set<WebSocketTransport>;
+  readonly #onUpgrade: (request: IncomingMessage, socket: Duplex, head: Buffer) => void;
+  #closeTask: Promise<void> | undefined;
+  #cleanupTask: Promise<void> | undefined;
+
+  constructor(
+    server: HttpServer | HttpsServer,
+    webSocketServer: WebSocketServer,
+    transports: Set<WebSocketTransport>,
+    endpoint: string,
+    onUpgrade: (request: IncomingMessage, socket: Duplex, head: Buffer) => void,
+  ) {
+    this.#server = server;
+    this.#webSocketServer = webSocketServer;
+    this.#transports = transports;
+    this.endpoint = endpoint;
+    this.#onUpgrade = onUpgrade;
+  }
+
+  closeAdmission(): Promise<void> {
+    if (!this.#closeTask) {
+      this.#server.off('upgrade', this.#onUpgrade);
+      this.#closeTask = closeServer(this.#server);
+    }
+    return this.#closeTask;
+  }
+
+  cleanup(): Promise<void> {
+    this.#cleanupTask ??= (async () => {
+      for (const transport of this.#transports) transport.abort();
+      await closeWebSocketServer(this.#webSocketServer);
+      await this.closeAdmission();
+    })();
+    return this.#cleanupTask;
+  }
+}
+
+function handleHttpRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  isReady: () => boolean,
+): void {
+  if (request.method !== 'GET') {
+    respond(response, 405, 'Method Not Allowed');
+    return;
+  }
+  const pathname = request.url ? new URL(request.url, 'http://runtime-host.invalid').pathname : '';
+  if (pathname === '/healthz') {
+    respond(response, 200, 'ok');
+    return;
+  }
+  if (pathname === '/readyz') {
+    const ready = isReady();
+    respond(response, ready ? 200 : 503, ready ? 'ready' : 'not ready');
+    return;
+  }
+  respond(response, 404, 'Not Found');
+}
+
+function respond(response: ServerResponse, status: number, body: string): void {
+  response.writeHead(status, {
+    'cache-control': 'no-store',
+    'content-type': 'text/plain; charset=utf-8',
+    'content-length': Buffer.byteLength(body),
+  });
+  response.end(body);
+}
+
+function upgradeTargetsPath(request: IncomingMessage, expectedPath: string): boolean {
+  if (request.method !== 'GET' || !request.url) return false;
+  return new URL(request.url, 'http://runtime-host.invalid').pathname === expectedPath;
+}
+
+function originAccepted(origin: string | undefined, allowedOrigins: readonly string[] | undefined) {
+  if (origin === undefined) return true;
+  return allowedOrigins?.includes(origin) === true;
+}
+
+function readBearerCredential(value: string | undefined): string | undefined {
+  if (!value?.startsWith('Bearer ')) return;
+  const credential = value.slice('Bearer '.length);
+  return credential.length > 0 && !/\s/u.test(credential) ? credential : undefined;
+}
+
+function rejectUpgrade(socket: Duplex, status: number, message: string): void {
+  if (socket.destroyed) return;
+  socket.end(`HTTP/1.1 ${status} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`);
+}
+
+function validateWebSocketListenerOptions(options: StartRuntimeHostWebSocketListenerOptions): void {
+  if (!Number.isInteger(options.port) || options.port < 0 || options.port > 65_535) {
+    throw new RangeError('Runtime Host WebSocket port must be between 0 and 65535');
+  }
+  const path = options.path ?? DEFAULT_WEBSOCKET_PATH;
+  if (!path.startsWith('/') || path.includes('?') || path.includes('#')) {
+    throw new Error('Runtime Host WebSocket path must be an absolute URL path');
+  }
+  if (!options.tls && options.host !== '127.0.0.1' && options.host !== '::1') {
+    throw new Error('Plain Runtime Host WebSocket listeners must bind to loopback');
+  }
+  if (
+    options.allowedOrigins &&
+    new Set(options.allowedOrigins).size !== options.allowedOrigins.length
+  ) {
+    throw new Error('Runtime Host WebSocket Origin allowlist contains duplicates');
+  }
+}
+
+function listen(server: HttpServer | HttpsServer, host: string, port: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => {
+      server.off('listening', onListening);
+      reject(error);
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve();
+    };
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, host);
+  });
+}
+
+function closeServer(server: HttpServer | HttpsServer): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function closeWebSocketServer(server: WebSocketServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/runtime-host/src/server/websocket-listener.ts
+++ b/packages/runtime-host/src/server/websocket-listener.ts
@@ -109,6 +109,7 @@ class RuntimeHostWebSocketListener implements RuntimeHostListener {
   readonly #transports: Set<WebSocketTransport>;
   readonly #onUpgrade: (request: IncomingMessage, socket: Duplex, head: Buffer) => void;
   #closeTask: Promise<void> | undefined;
+  #serverCloseTask: Promise<void> | undefined;
   #cleanupTask: Promise<void> | undefined;
 
   constructor(
@@ -128,16 +129,20 @@ class RuntimeHostWebSocketListener implements RuntimeHostListener {
   closeAdmission(): Promise<void> {
     if (!this.#closeTask) {
       this.#server.off('upgrade', this.#onUpgrade);
-      this.#closeTask = closeServer(this.#server);
+      this.#serverCloseTask = closeServer(this.#server);
+      void this.#serverCloseTask.catch(() => undefined);
+      this.#server.closeAllConnections();
+      this.#closeTask = Promise.resolve();
     }
     return this.#closeTask;
   }
 
   cleanup(): Promise<void> {
     this.#cleanupTask ??= (async () => {
+      await this.closeAdmission();
       for (const transport of this.#transports) transport.abort();
       await closeWebSocketServer(this.#webSocketServer);
-      await this.closeAdmission();
+      await this.#serverCloseTask;
     })();
     return this.#cleanupTask;
   }
@@ -176,7 +181,8 @@ function respond(response: ServerResponse, status: number, body: string): void {
 
 function upgradeTargetsPath(request: IncomingMessage, expectedPath: string): boolean {
   if (request.method !== 'GET' || !request.url) return false;
-  return new URL(request.url, 'http://runtime-host.invalid').pathname === expectedPath;
+  const url = new URL(request.url, 'http://runtime-host.invalid');
+  return url.pathname === expectedPath && url.search === '';
 }
 
 function originAccepted(origin: string | undefined, allowedOrigins: readonly string[] | undefined) {

--- a/packages/runtime-host/src/transport/framed-transport.ts
+++ b/packages/runtime-host/src/transport/framed-transport.ts
@@ -29,7 +29,8 @@ export class RuntimeHostTransportError extends Error {
       | 'read_eof'
       | 'read_timeout'
       | 'concurrent_read'
-      | 'inbound_queue_full',
+      | 'inbound_queue_full'
+      | 'outbound_queue_full',
     message: string,
     options?: ErrorOptions,
   ) {

--- a/packages/runtime-host/src/transport/websocket-transport.ts
+++ b/packages/runtime-host/src/transport/websocket-transport.ts
@@ -1,0 +1,223 @@
+import { TextDecoder } from 'node:util';
+import WebSocket, { type RawData } from 'ws';
+import {
+  RUNTIME_HOST_MAX_MESSAGE_BYTES,
+  RuntimeHostProtocolError,
+  type EncodedProtocolMessage,
+} from '../protocol/index.js';
+import { RuntimeHostTransportError } from './framed-transport.js';
+import type { RuntimeHostMessageTransport } from './message-transport.js';
+
+const MAX_QUEUED_MESSAGES = 64;
+const MAX_QUEUED_BYTES = 2 * 1024 * 1024;
+const MAX_PENDING_WRITE_BYTES = 2 * 1024 * 1024;
+
+interface QueuedMessage {
+  readonly value: unknown;
+  readonly encodedBytes: number;
+}
+
+interface ReadWaiter {
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+  timer?: NodeJS.Timeout;
+}
+
+export class WebSocketTransport implements RuntimeHostMessageTransport {
+  readonly closed: Promise<void>;
+  readonly #socket: WebSocket;
+  readonly #decoder = new TextDecoder('utf-8', { fatal: true });
+  readonly #queue: QueuedMessage[] = [];
+  #queuedBytes = 0;
+  #pendingWriteBytes = 0;
+  #waiter: ReadWaiter | undefined;
+  #failure: Error | undefined;
+  #readTerminal: RuntimeHostTransportError | undefined;
+  #closeAfterFlush = false;
+  #resolveClosed!: () => void;
+
+  constructor(socket: WebSocket) {
+    this.#socket = socket;
+    this.closed = new Promise((resolve) => {
+      this.#resolveClosed = resolve;
+    });
+    socket.on('message', (data, isBinary) => this.#receive(data, isBinary));
+    socket.once('error', (error) => this.#fail(error));
+    socket.once('close', () => {
+      this.#endRead();
+      this.#resolveClosed();
+    });
+  }
+
+  read(timeoutMs: number): Promise<unknown> {
+    if (this.#failure) return Promise.reject(this.#failure);
+    const queued = this.#queue.shift();
+    if (queued) {
+      this.#queuedBytes -= queued.encodedBytes;
+      return Promise.resolve(queued.value);
+    }
+    if (this.#readTerminal) return Promise.reject(this.#readTerminal);
+    if (this.#waiter) {
+      return Promise.reject(
+        new RuntimeHostTransportError(
+          'concurrent_read',
+          'Only one Runtime Host message read may be pending',
+        ),
+      );
+    }
+    return new Promise((resolve, reject) => {
+      const waiter: ReadWaiter = { resolve, reject };
+      if (timeoutMs > 0) {
+        waiter.timer = setTimeout(() => {
+          if (this.#waiter !== waiter) return;
+          this.#fail(
+            new RuntimeHostTransportError(
+              'read_timeout',
+              'Timed out waiting for Runtime Host message',
+            ),
+          );
+        }, timeoutMs);
+      }
+      this.#waiter = waiter;
+    });
+  }
+
+  write(message: EncodedProtocolMessage): Promise<void> {
+    if (this.#failure) return Promise.reject(this.#failure);
+    if (this.#socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new RuntimeHostTransportError('closed', 'WebSocket is not open'));
+    }
+    if (this.#pendingWriteBytes + message.byteLength > MAX_PENDING_WRITE_BYTES) {
+      const error = new RuntimeHostTransportError(
+        'outbound_queue_full',
+        'Runtime Host WebSocket outbound queue is full',
+      );
+      this.#fail(error);
+      return Promise.reject(error);
+    }
+    this.#pendingWriteBytes += message.byteLength;
+    return new Promise((resolve, reject) => {
+      this.#socket.send(message, { binary: false, compress: false }, (error) => {
+        this.#pendingWriteBytes -= message.byteLength;
+        if (error) {
+          const failure = asError(error);
+          this.#fail(failure);
+          reject(failure);
+          return;
+        }
+        resolve();
+        if (this.#closeAfterFlush && this.#pendingWriteBytes === 0) this.#socket.close(1000);
+      });
+    });
+  }
+
+  closeAfterFlush(): void {
+    this.#closeAfterFlush = true;
+    if (this.#pendingWriteBytes === 0 && this.#socket.readyState === WebSocket.OPEN) {
+      this.#socket.close(1000);
+    }
+  }
+
+  abort(error?: Error): void {
+    if (error) this.#fail(error);
+    this.#socket.terminate();
+  }
+
+  #receive(data: RawData, isBinary: boolean): void {
+    try {
+      if (isBinary) {
+        throw new RuntimeHostProtocolError(
+          'invalid_frame',
+          'Runtime Host WebSocket messages must be text',
+        );
+      }
+      const encoded = toBuffer(data);
+      if (encoded.byteLength === 0) {
+        throw new RuntimeHostProtocolError('invalid_frame', 'Runtime Host message is empty');
+      }
+      if (encoded.byteLength > RUNTIME_HOST_MAX_MESSAGE_BYTES) {
+        throw new RuntimeHostProtocolError(
+          'frame_too_large',
+          'Runtime Host message exceeds the byte limit',
+        );
+      }
+      const value = decodeMessage(this.#decoder, encoded);
+      if (this.#waiter) {
+        const waiter = this.#waiter;
+        this.#waiter = undefined;
+        if (waiter.timer) clearTimeout(waiter.timer);
+        waiter.resolve(value);
+        return;
+      }
+      if (
+        this.#queue.length >= MAX_QUEUED_MESSAGES ||
+        this.#queuedBytes + encoded.byteLength > MAX_QUEUED_BYTES
+      ) {
+        throw new RuntimeHostTransportError(
+          'inbound_queue_full',
+          'Runtime Host WebSocket inbound queue is full',
+        );
+      }
+      this.#queue.push({ value, encodedBytes: encoded.byteLength });
+      this.#queuedBytes += encoded.byteLength;
+    } catch (error) {
+      this.#fail(asError(error));
+    }
+  }
+
+  #endRead(): void {
+    if (this.#failure || this.#readTerminal) return;
+    this.#readTerminal = new RuntimeHostTransportError(
+      'read_eof',
+      'Runtime Host WebSocket read side ended',
+    );
+    if (!this.#waiter) return;
+    const waiter = this.#waiter;
+    this.#waiter = undefined;
+    if (waiter.timer) clearTimeout(waiter.timer);
+    waiter.reject(this.#readTerminal);
+  }
+
+  #fail(error: Error): void {
+    if (this.#failure) return;
+    this.#failure = error;
+    this.#queue.length = 0;
+    this.#queuedBytes = 0;
+    if (this.#waiter) {
+      const waiter = this.#waiter;
+      this.#waiter = undefined;
+      if (waiter.timer) clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+    if (
+      this.#socket.readyState === WebSocket.OPEN ||
+      this.#socket.readyState === WebSocket.CONNECTING
+    ) {
+      this.#socket.terminate();
+    }
+  }
+}
+
+function decodeMessage(decoder: TextDecoder, encoded: Buffer): unknown {
+  let text: string;
+  try {
+    text = decoder.decode(encoded);
+  } catch {
+    throw new RuntimeHostProtocolError('invalid_utf8', 'Runtime Host message is not valid UTF-8');
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new RuntimeHostProtocolError('invalid_json', 'Runtime Host message is not valid JSON');
+  }
+}
+
+function toBuffer(data: RawData): Buffer {
+  if (Buffer.isBuffer(data)) return data;
+  if (Array.isArray(data)) return Buffer.concat(data);
+  return Buffer.from(data);
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

Add the authenticated WebSocket vertical slice for the standalone Runtime Host service.

- keep Local IPC and WebSocket/WSS connections on one root owner, kernel, dispatcher, and canonical state model;
- add root-owned opaque access credentials with hash-only durable storage, exact operation grants, explicit Host-path and Client Capability authority, one-time private local delivery, and immediate connection revocation;
- authenticate native Clients during HTTP Upgrade, reject browser Origin by default, require WSS off loopback, and expose minimal health/readiness endpoints;
- add a bounded one-message-per-WebSocket transport with strict text/UTF-8/JSON handling, queue limits, backpressure, and deterministic teardown;
- return `rootId` in the accepted handshake and add a remote connector that supports root pinning without local discovery, election, spawning, or fallback;
- add `maka runtime-host serve` WebSocket/TLS options and access credential issue/revoke commands.

Refs #2522

## Security

- Clear access credentials are never stored in the access database or sent in Runtime Host protocol frames. The local owner receives a short-lived delivery identity and consumes the clear credential once from the private root control directory.
- Plain WebSocket listeners and Clients are restricted to literal loopback addresses. Non-loopback listeners require TLS.
- Unauthorized operations are rejected before domain admission and dispatch. A credential revocation closes matching handshaking and active connections immediately.
- Existing credentials retain frozen operation sets when new protocol operations are added.

## Verification

- `npm --workspace @maka/runtime-host test` — 784 passed
- `npm --workspace maka-agent test` — 350 passed
- `npm run lint` — passed
- `npm run format:check` — passed

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

为独立 Runtime Host 服务增加经过认证的 WebSocket 纵向切片。

- Local IPC 与 WebSocket/WSS 连接共享同一个 root owner、kernel、dispatcher 和 canonical state model；
- 增加由 root 持有的 opaque access credential，持久层只保存 hash，并支持精确 operation grant、显式 Host path 与 Client Capability authority、一次性私有本地交付和即时断开吊销；
- 在 HTTP Upgrade 阶段认证原生 Client，默认拒绝 browser Origin，非 loopback 必须使用 WSS，并提供最小化 health/readiness endpoint；
- 增加每条 WebSocket message 承载一条 protocol message 的有界 transport，严格处理 text、UTF-8、JSON、queue、backpressure 与确定性 teardown；
- accepted handshake 返回 `rootId`，并增加支持 root pinning、但不参与本地 discovery、election、spawn 或 fallback 的 remote connector；
- 为 `maka runtime-host serve` 增加 WebSocket/TLS 参数，并增加 access credential issue/revoke 命令。

关联 #2522

## 安全边界

- 明文 access credential 不进入 access 数据库，也不进入 Runtime Host protocol frame。本地 owner 只收到短期 delivery identity，再从 root 私有控制目录一次性消费明文 credential；
- 明文 WebSocket listener 与 Client 仅允许 literal loopback 地址，非 loopback listener 必须使用 TLS；
- 未授权 operation 在领域 admission 和 dispatch 前被拒绝；credential 吊销会立即关闭匹配的 handshake 中连接与活动连接；
- 新增 protocol operation 不会扩张既有 credential 的冻结 operation set。

## 验证

- `npm --workspace @maka/runtime-host test` — 784 项通过
- `npm --workspace maka-agent test` — 350 项通过
- `npm run lint` — 通过
- `npm run format:check` — 通过

## 检查清单

- [x] 测试覆盖本次行为，且在缺少实现时会失败
- [x] lint、format、typecheck 与受影响测试套件均在本地通过

此 PR 是否改变行为？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
