### PR TITLE
ci: retry transient Electron downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,12 @@ jobs:
         with:
           node-version: '24'
           cache: npm
+      - name: Restore Electron artifact cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.cache/electron
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: electron-${{ runner.os }}-
       - run: npm ci
       - name: Ensure xvfb
         run: command -v xvfb-run >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y xvfb; }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "apps/desktop"
   ],
   "scripts": {
-    "postinstall": "node scripts/apply-dependency-patches.mjs && install-electron",
+    "postinstall": "node scripts/apply-dependency-patches.mjs && node scripts/install-electron-with-retry.mjs",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",
@@ -32,7 +32,7 @@
     "test:dist": "npm run test:scripts:full && node scripts/run-workspace-tests-parallel.mjs --concurrency=3",
     "test:dist:serial": "npm run test:scripts:full && node scripts/run-workspace-tests-parallel.mjs --serial",
     "test:fast": "npm run build:test && npm run test:scripts && node scripts/run-workspace-tests-parallel.mjs --concurrency=3",
-    "test:scripts": "node --test scripts/electron-builder-config.test.mjs scripts/sync-model-metadata.test.mjs scripts/fixture-env.test.mjs scripts/electron-lifecycle.test.mjs scripts/check-story-annotations.test.mjs scripts/check-dead-css.test.mjs scripts/check-astryx-alignment.test.mjs scripts/check-astryx-surface-inventory.test.mjs scripts/build-astryx-theme.test.mjs scripts/ci-test-plan.test.mjs scripts/run-headless-tests.test.mjs scripts/run-workspace-tests-parallel.test.mjs scripts/storybook-visual-smoke.test.mjs scripts/cu-e2e-scenarios.test.mjs scripts/cu-report-sanitize.test.mjs scripts/computer-use-provenance.test.mjs scripts/cu-trace-analyse.test.mjs scripts/prepare-bundled-git.test.mjs scripts/prepare-bundled-git-source.test.mjs scripts/bundled-skill-catalog.test.mjs scripts/windows-test-inventory.test.mjs scripts/windows-smoke.test.mjs scripts/windows-baseline-workflow.test.mjs scripts/code-mode-build-order.test.mjs scripts/dependency-audit-workflow.test.mjs apps/desktop/scripts/dev-app-runtime.test.mjs",
+    "test:scripts": "node --test scripts/electron-builder-config.test.mjs scripts/install-electron-with-retry.test.mjs scripts/sync-model-metadata.test.mjs scripts/fixture-env.test.mjs scripts/electron-lifecycle.test.mjs scripts/check-story-annotations.test.mjs scripts/check-dead-css.test.mjs scripts/check-astryx-alignment.test.mjs scripts/check-astryx-surface-inventory.test.mjs scripts/build-astryx-theme.test.mjs scripts/ci-test-plan.test.mjs scripts/run-headless-tests.test.mjs scripts/run-workspace-tests-parallel.test.mjs scripts/storybook-visual-smoke.test.mjs scripts/cu-e2e-scenarios.test.mjs scripts/cu-report-sanitize.test.mjs scripts/computer-use-provenance.test.mjs scripts/cu-trace-analyse.test.mjs scripts/prepare-bundled-git.test.mjs scripts/prepare-bundled-git-source.test.mjs scripts/bundled-skill-catalog.test.mjs scripts/windows-test-inventory.test.mjs scripts/windows-smoke.test.mjs scripts/windows-baseline-workflow.test.mjs scripts/code-mode-build-order.test.mjs scripts/dependency-audit-workflow.test.mjs apps/desktop/scripts/dev-app-runtime.test.mjs",
     "test:scripts:extended": "node --test scripts/cu-provider-matrix.test.mjs scripts/cu-process-restart-harness.test.mjs scripts/cu-real-model-launcher.test.mjs scripts/macos-arm64-release.test.mjs scripts/windows-x64-release.test.mjs scripts/measure-session-bundle.test.mjs",
     "test:scripts:full": "npm run test:scripts && npm run test:scripts:extended",
     "dev": "npm --workspace @maka/desktop run dev:hmr --",

--- a/scripts/install-electron-with-retry.mjs
+++ b/scripts/install-electron-with-retry.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { dirname } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 1_000;
+const transientFailurePattern =
+  /fetch failed|ECONNRESET|ECONNREFUSED|EHOSTUNREACH|ENETUNREACH|ENOTFOUND|EAI_AGAIN|ETIMEDOUT|socket hang up|Response code (?:408|425|429|5\d\d)\b/i;
+
+export function isTransientElectronInstallFailure(stderr) {
+  return transientFailurePattern.test(stderr);
+}
+
+export async function installWithRetry(
+  runAttempt,
+  {
+    maxAttempts = DEFAULT_MAX_ATTEMPTS,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    wait = sleep,
+    warn = console.warn,
+  } = {},
+) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = await runAttempt(attempt);
+    if (result.status === 0 || !isTransientElectronInstallFailure(result.stderr ?? '')) {
+      return result;
+    }
+    if (attempt === maxAttempts) {
+      return result;
+    }
+
+    const delayMs = baseDelayMs * 2 ** (attempt - 1);
+    warn(
+      `[install-electron] transient download failure on attempt ${attempt}/${maxAttempts}; retrying in ${delayMs}ms`,
+    );
+    await wait(delayMs);
+  }
+
+  throw new Error('Electron install retry loop ended unexpectedly');
+}
+
+function electronDebugNamespaces(existingDebug) {
+  return existingDebug ? `${existingDebug},@electron/get*` : '@electron/get*';
+}
+
+async function main() {
+  const require = createRequire(import.meta.url);
+  const installer = require.resolve('electron/install.js');
+  const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+
+  const result = await installWithRetry(() => {
+    const child = spawnSync(process.execPath, [installer], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DEBUG: electronDebugNamespaces(process.env.DEBUG),
+      },
+      stdio: ['inherit', 'inherit', 'pipe'],
+    });
+    if (child.stderr) {
+      process.stderr.write(child.stderr);
+    }
+    if (child.error) {
+      const message = child.error.stack ?? child.error.message;
+      process.stderr.write(`${message}\n`);
+      return { status: child.status ?? 1, stderr: `${child.stderr ?? ''}\n${message}` };
+    }
+    return { status: child.status ?? 1, stderr: child.stderr ?? '' };
+  });
+
+  process.exitCode = result.status ?? 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  await main();
+}

--- a/scripts/install-electron-with-retry.mjs
+++ b/scripts/install-electron-with-retry.mjs
@@ -7,11 +7,30 @@ import { fileURLToPath } from 'node:url';
 
 const DEFAULT_MAX_ATTEMPTS = 3;
 const DEFAULT_BASE_DELAY_MS = 1_000;
-const transientFailurePattern =
-  /fetch failed|ECONNRESET|ECONNREFUSED|EHOSTUNREACH|ENETUNREACH|ENOTFOUND|EAI_AGAIN|ETIMEDOUT|socket hang up|Response code (?:408|425|429|5\d\d)\b/i;
+const transientCodes = new Set([
+  'ECONNRESET',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+const transientHttpStatuses = new Set([408, 425, 429, 500, 502, 503, 504]);
 
-export function isTransientElectronInstallFailure(stderr) {
-  return transientFailurePattern.test(stderr);
+export function isTransientElectronInstallFailure(contextOutput) {
+  return contextOutput.split(/\r?\n/).some((line) => {
+    if (!line) return false;
+    try {
+      const context = JSON.parse(line);
+      return (
+        (context.kind === 'fetch' && transientCodes.has(context.code)) ||
+        (context.kind === 'http' && transientHttpStatuses.has(context.status))
+      );
+    } catch {
+      return false;
+    }
+  });
 }
 
 export async function installWithRetry(
@@ -25,7 +44,13 @@ export async function installWithRetry(
 ) {
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const result = await runAttempt(attempt);
-    if (result.status === 0 || !isTransientElectronInstallFailure(result.stderr ?? '')) {
+    if (
+      result.status === 0 ||
+      typeof result.status !== 'number' ||
+      result.signal ||
+      result.spawnError ||
+      !isTransientElectronInstallFailure(result.context ?? '')
+    ) {
       return result;
     }
     if (attempt === maxAttempts) {
@@ -42,37 +67,53 @@ export async function installWithRetry(
   throw new Error('Electron install retry loop ended unexpectedly');
 }
 
-function electronDebugNamespaces(existingDebug) {
-  return existingDebug ? `${existingDebug},@electron/get*` : '@electron/get*';
+export function electronInstallerSpawnOptions(repositoryRoot) {
+  return {
+    cwd: repositoryRoot,
+    encoding: 'utf8',
+    stdio: ['inherit', 'inherit', 'pipe', 'pipe'],
+  };
 }
 
 async function main() {
   const require = createRequire(import.meta.url);
   const installer = require.resolve('electron/install.js');
+  const launcher = fileURLToPath(new URL('./run-electron-installer.cjs', import.meta.url));
   const repositoryRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 
   const result = await installWithRetry(() => {
-    const child = spawnSync(process.execPath, [installer], {
-      cwd: repositoryRoot,
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        DEBUG: electronDebugNamespaces(process.env.DEBUG),
-      },
-      stdio: ['inherit', 'inherit', 'pipe'],
-    });
+    const child = spawnSync(
+      process.execPath,
+      [launcher, installer],
+      electronInstallerSpawnOptions(repositoryRoot),
+    );
     if (child.stderr) {
       process.stderr.write(child.stderr);
     }
     if (child.error) {
       const message = child.error.stack ?? child.error.message;
       process.stderr.write(`${message}\n`);
-      return { status: child.status ?? 1, stderr: `${child.stderr ?? ''}\n${message}` };
+      return {
+        status: child.status,
+        signal: child.signal,
+        spawnError: true,
+        context: child.output?.[3] ?? '',
+        stderr: `${child.stderr ?? ''}\n${message}`,
+      };
     }
-    return { status: child.status ?? 1, stderr: child.stderr ?? '' };
+    return {
+      status: child.status,
+      signal: child.signal,
+      context: child.output?.[3] ?? '',
+      stderr: child.stderr ?? '',
+    };
   });
 
-  process.exitCode = result.status ?? 1;
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+  } else {
+    process.exitCode = result.status ?? 1;
+  }
 }
 
 if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {

--- a/scripts/install-electron-with-retry.test.mjs
+++ b/scripts/install-electron-with-retry.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  installWithRetry,
+  isTransientElectronInstallFailure,
+} from './install-electron-with-retry.mjs';
+
+test('classifies transport and retryable HTTP failures as transient', () => {
+  assert.equal(isTransientElectronInstallFailure('TypeError: fetch failed'), true);
+  assert.equal(isTransientElectronInstallFailure('cause: ETIMEDOUT'), true);
+  assert.equal(
+    isTransientElectronInstallFailure(
+      'Response code 503 (Service Unavailable) for https://example.invalid/electron.zip',
+    ),
+    true,
+  );
+  assert.equal(
+    isTransientElectronInstallFailure(
+      'Response code 404 (Not Found) for https://example.invalid/electron.zip',
+    ),
+    false,
+  );
+});
+
+test('retries transient failures with bounded exponential backoff', async () => {
+  const attempts = [];
+  const delays = [];
+  const warnings = [];
+
+  const result = await installWithRetry(
+    async (attempt) => {
+      attempts.push(attempt);
+      return attempt < 3 ? { status: 1, stderr: 'fetch failed' } : { status: 0, stderr: '' };
+    },
+    {
+      wait: async (delay) => delays.push(delay),
+      warn: (message) => warnings.push(message),
+    },
+  );
+
+  assert.equal(result.status, 0);
+  assert.deepEqual(attempts, [1, 2, 3]);
+  assert.deepEqual(delays, [1_000, 2_000]);
+  assert.equal(warnings.length, 2);
+});
+
+test('does not retry permanent failures', async () => {
+  let attempts = 0;
+  const result = await installWithRetry(async () => {
+    attempts += 1;
+    return { status: 1, stderr: 'Response code 404 (Not Found)' };
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(attempts, 1);
+});
+
+test('stops after the configured number of attempts', async () => {
+  let attempts = 0;
+  const result = await installWithRetry(
+    async () => {
+      attempts += 1;
+      return { status: 1, stderr: 'ECONNRESET' };
+    },
+    { maxAttempts: 2, baseDelayMs: 0, wait: async () => {}, warn: () => {} },
+  );
+
+  assert.equal(result.status, 1);
+  assert.equal(attempts, 2);
+});

--- a/scripts/install-electron-with-retry.test.mjs
+++ b/scripts/install-electron-with-retry.test.mjs
@@ -1,26 +1,132 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
+  electronInstallerSpawnOptions,
   installWithRetry,
   isTransientElectronInstallFailure,
 } from './install-electron-with-retry.mjs';
 
+const require = createRequire(import.meta.url);
+const { contextAwareFetch, findErrorCode } = require('./run-electron-installer.cjs');
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+
+function fetchContext(code) {
+  return JSON.stringify({ kind: 'fetch', code });
+}
+
+function httpContext(status) {
+  return JSON.stringify({ kind: 'http', status });
+}
+
 test('classifies transport and retryable HTTP failures as transient', () => {
-  assert.equal(isTransientElectronInstallFailure('TypeError: fetch failed'), true);
-  assert.equal(isTransientElectronInstallFailure('cause: ETIMEDOUT'), true);
+  assert.equal(isTransientElectronInstallFailure(fetchContext('ETIMEDOUT')), true);
+  assert.equal(isTransientElectronInstallFailure(fetchContext('UND_ERR_SOCKET')), true);
+  assert.equal(isTransientElectronInstallFailure(httpContext(503)), true);
+  assert.equal(isTransientElectronInstallFailure(httpContext(404)), false);
+});
+
+test('does not trust unstructured errors or permanent failure markers', () => {
+  assert.equal(isTransientElectronInstallFailure('TypeError: fetch failed'), false);
+  assert.equal(isTransientElectronInstallFailure('cause: ETIMEDOUT'), false);
+  assert.equal(isTransientElectronInstallFailure(fetchContext('CERT_HAS_EXPIRED')), false);
   assert.equal(
-    isTransientElectronInstallFailure(
-      'Response code 503 (Service Unavailable) for https://example.invalid/electron.zip',
-    ),
-    true,
-  );
-  assert.equal(
-    isTransientElectronInstallFailure(
-      'Response code 404 (Not Found) for https://example.invalid/electron.zip',
-    ),
+    isTransientElectronInstallFailure(fetchContext('ERR_TLS_CERT_ALTNAME_INVALID')),
     false,
   );
+  assert.equal(isTransientElectronInstallFailure(fetchContext('ENOTFOUND')), false);
+  assert.equal(isTransientElectronInstallFailure(httpContext(501)), false);
+  assert.equal(isTransientElectronInstallFailure(JSON.stringify({ kind: 'fetch' })), false);
+  assert.equal(isTransientElectronInstallFailure('not-json'), false);
+});
+
+test('captures only a safe code from a nested fetch error', () => {
+  const error = new TypeError('fetch failed', {
+    cause: Object.assign(new Error('certificate details and private URL'), {
+      code: 'CERT_HAS_EXPIRED',
+    }),
+  });
+
+  assert.equal(findErrorCode(error), 'CERT_HAS_EXPIRED');
+  assert.equal(findErrorCode({ code: 'unsafe code https://secret.invalid/?token=x' }), undefined);
+});
+
+test('fetch wrapper emits sanitized context without URLs or error messages', async () => {
+  const emitted = [];
+  const privateUrl = 'https://user:secret@example.invalid/electron.zip?token=private';
+  const wrappedFetch = contextAwareFetch(
+    async () => {
+      throw new TypeError(`fetch failed for ${privateUrl}`, {
+        cause: Object.assign(new Error(`connect ${privateUrl}`), { code: 'ETIMEDOUT' }),
+      });
+    },
+    (context) => emitted.push(context),
+  );
+
+  await assert.rejects(wrappedFetch(privateUrl), /fetch failed/);
+  assert.deepEqual(emitted, [{ kind: 'fetch', code: 'ETIMEDOUT' }]);
+  assert.equal(JSON.stringify(emitted[0]).includes('secret'), false);
+  assert.equal(JSON.stringify(emitted[0]).includes('token'), false);
+});
+
+test('fetch wrapper records retryable HTTP status without the response URL', async () => {
+  const emitted = [];
+  const response = { ok: false, status: 503 };
+  const wrappedFetch = contextAwareFetch(
+    async () => response,
+    (context) => emitted.push(context),
+  );
+
+  assert.equal(await wrappedFetch('https://example.invalid/private?token=x'), response);
+  assert.deepEqual(emitted, [{ kind: 'http', status: 503 }]);
+});
+
+test('launcher sends HTTP context over the private fd without writing it to stderr', (t) => {
+  const fixtureDirectory = mkdtempSync(join(tmpdir(), 'electron-installer-context-'));
+  t.after(() => rmSync(fixtureDirectory, { force: true, recursive: true }));
+  const fixture = join(fixtureDirectory, 'http-503.cjs');
+  writeFileSync(
+    fixture,
+    `const http = require('node:http');
+const server = http.createServer((_request, response) => {
+  response.writeHead(503);
+  response.end('unavailable');
+});
+server.listen(0, '127.0.0.1', async () => {
+  try {
+    const { port } = server.address();
+    await fetch(\`http://127.0.0.1:\${port}/private?token=secret\`);
+  } finally {
+    server.close();
+  }
+});
+`,
+  );
+
+  const child = spawnSync(
+    process.execPath,
+    [join(scriptDirectory, 'run-electron-installer.cjs'), fixture],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe', 'pipe'] },
+  );
+
+  assert.equal(child.status, 0);
+  assert.equal(child.stderr, '');
+  assert.equal(child.output[3].trim(), httpContext(503));
+  assert.equal(child.output[3].includes('token'), false);
+  assert.equal(child.output[3].includes('secret'), false);
+});
+
+test('installer spawn options inherit the caller environment without forcing DEBUG', () => {
+  const options = electronInstallerSpawnOptions('/repo');
+
+  assert.equal(Object.hasOwn(options, 'env'), false);
+  assert.deepEqual(options.stdio, ['inherit', 'inherit', 'pipe', 'pipe']);
 });
 
 test('retries transient failures with bounded exponential backoff', async () => {
@@ -31,7 +137,9 @@ test('retries transient failures with bounded exponential backoff', async () => 
   const result = await installWithRetry(
     async (attempt) => {
       attempts.push(attempt);
-      return attempt < 3 ? { status: 1, stderr: 'fetch failed' } : { status: 0, stderr: '' };
+      return attempt < 3
+        ? { status: 1, context: fetchContext('ETIMEDOUT'), stderr: 'TypeError: fetch failed' }
+        : { status: 0, context: '', stderr: '' };
     },
     {
       wait: async (delay) => delays.push(delay),
@@ -49,7 +157,22 @@ test('does not retry permanent failures', async () => {
   let attempts = 0;
   const result = await installWithRetry(async () => {
     attempts += 1;
-    return { status: 1, stderr: 'Response code 404 (Not Found)' };
+    return { status: 1, context: httpContext(404), stderr: 'HTTPError' };
+  });
+
+  assert.equal(result.status, 1);
+  assert.equal(attempts, 1);
+});
+
+test('never classifies transient-looking stderr without structured context', async () => {
+  let attempts = 0;
+  const result = await installWithRetry(async () => {
+    attempts += 1;
+    return {
+      status: 1,
+      context: '',
+      stderr: 'ECONNRESET https://user:secret@example.invalid/file?token=private',
+    };
   });
 
   assert.equal(result.status, 1);
@@ -61,11 +184,59 @@ test('stops after the configured number of attempts', async () => {
   const result = await installWithRetry(
     async () => {
       attempts += 1;
-      return { status: 1, stderr: 'ECONNRESET' };
+      return { status: 1, context: fetchContext('ECONNRESET'), stderr: 'fetch failed' };
     },
     { maxAttempts: 2, baseDelayMs: 0, wait: async () => {}, warn: () => {} },
   );
 
   assert.equal(result.status, 1);
   assert.equal(attempts, 2);
+});
+
+test('returns a signal termination unchanged without retrying', async () => {
+  let attempts = 0;
+  const result = await installWithRetry(async () => {
+    attempts += 1;
+    return {
+      status: null,
+      signal: 'SIGTERM',
+      context: fetchContext('ECONNRESET'),
+      stderr: 'fetch failed',
+    };
+  });
+
+  assert.equal(attempts, 1);
+  assert.equal(result.status, null);
+  assert.equal(result.signal, 'SIGTERM');
+});
+
+test('returns a spawn error unchanged without retrying', async () => {
+  let attempts = 0;
+  const result = await installWithRetry(async () => {
+    attempts += 1;
+    return {
+      status: null,
+      spawnError: true,
+      context: fetchContext('ETIMEDOUT'),
+      stderr: 'spawn failed',
+    };
+  });
+
+  assert.equal(attempts, 1);
+  assert.equal(result.spawnError, true);
+});
+
+test('does not retry when the child has no numeric exit status', async () => {
+  let attempts = 0;
+  const result = await installWithRetry(async () => {
+    attempts += 1;
+    return {
+      status: null,
+      context: fetchContext('ETIMEDOUT'),
+      stderr: 'fetch failed',
+    };
+  });
+
+  assert.equal(attempts, 1);
+  assert.equal(result.status, null);
 });

--- a/scripts/run-electron-installer.cjs
+++ b/scripts/run-electron-installer.cjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+
+const safeCodePattern = /^[A-Z0-9_]{1,64}$/;
+
+function findErrorCode(error) {
+  const seen = new Set();
+  let current = error;
+
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current);
+    for (const value of [current.code, current.errno]) {
+      if (typeof value === 'string' && safeCodePattern.test(value)) {
+        return value;
+      }
+    }
+    current = current.cause;
+  }
+
+  return undefined;
+}
+
+function contextAwareFetch(fetchImplementation, emit) {
+  return async (...args) => {
+    try {
+      const response = await Reflect.apply(fetchImplementation, globalThis, args);
+      if (!response.ok) {
+        emit({ kind: 'http', status: response.status });
+      }
+      return response;
+    } catch (error) {
+      const code = findErrorCode(error);
+      emit(code ? { kind: 'fetch', code } : { kind: 'fetch' });
+      throw error;
+    }
+  };
+}
+
+function writeContext(context) {
+  try {
+    fs.writeSync(3, `${JSON.stringify(context)}\n`);
+  } catch {
+    // Context is best-effort. The installer must retain its original failure when fd 3 is unavailable.
+  }
+}
+
+if (require.main === module) {
+  const installer = process.argv[2];
+  if (!installer) {
+    throw new Error('Electron installer path is required');
+  }
+  if (typeof globalThis.fetch !== 'function') {
+    throw new Error('This Electron installer requires the built-in Fetch API');
+  }
+
+  globalThis.fetch = contextAwareFetch(globalThis.fetch, writeContext);
+  require(installer);
+}
+
+module.exports = { contextAwareFetch, findErrorCode };


### PR DESCRIPTION
## Summary

Wrap Electron's installer with bounded retries for transient fetch, network, rate-limit, and 5xx failures. The wrapper keeps permanent failures immediate, enables `@electron/get` diagnostics so the failing URL/status stays visible, and the E2E lane now restores Electron's artifact cache separately from npm's cache.

Fixes #2402

## Verification

- `node --test scripts/install-electron-with-retry.test.mjs` — 4/4 passed
- `npx --yes @biomejs/biome@2.5.6 check scripts/install-electron-with-retry.mjs scripts/install-electron-with-retry.test.mjs package.json` — passed
- `git diff --check` — passed
- Full `npm ci` did not complete locally: the package download phase itself ended with `ECONNRESET` before postinstall, and the available Node 22.15.1 is below the repository's >=22.19.0 requirement.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — transient Electron downloads are retried at most three times; permanent failures remain immediate
- [ ] No