### PR TITLE
feat: route DeepSeek V4 Flash through ApplyPatch

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1410,6 +1410,7 @@ export type {
   ModelDiscoveryResult,
   ModelDiscoverySource,
   ModelInfo,
+  ApplyPatchProtocol,
   ProviderCategory,
   ProviderCatalogGroup,
   ProviderDefaults,

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -22,6 +22,7 @@ import {
   RECOMMENDED_PROVIDER_TYPES,
   isWiredOAuthProvider,
   normalizeProviderType,
+  type ApplyPatchProtocol,
   type ProviderCatalogGroup,
   type ProviderCategory,
   type ProviderDefaults,
@@ -42,6 +43,7 @@ export {
   normalizeProviderType,
 };
 export type {
+  ApplyPatchProtocol,
   ProviderCatalogGroup,
   ProviderCategory,
   ProviderDefaults,

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -15,7 +15,9 @@ export const OPENCODE_FREE_DEFAULT_ENABLED_MODELS = [
 export type ProviderCategory = 'oauth' | 'domestic' | 'overseas' | 'local' | 'custom';
 export type ProviderCatalogGroup = 'recommended' | 'plans' | 'api' | 'aggregators' | 'local';
 
-export type ProviderRuntimeAdapter =
+export type ApplyPatchProtocol = 'openai-structured' | 'codex-v4a-freeform';
+
+type ProviderRuntimeAdapterDefinition =
   | { kind: 'anthropic'; auth: 'api-key' | 'bearer'; normalizeBaseUrl: boolean }
   | { kind: 'claude-subscription' }
   | { kind: 'openai'; apiProtocol?: 'openai-chat' | 'openai-responses' }
@@ -33,6 +35,11 @@ export type ProviderRuntimeAdapter =
       replayAssistantReasoningDetails?: true;
     }
   | { kind: 'unavailable' };
+
+export type ProviderRuntimeAdapter = ProviderRuntimeAdapterDefinition & {
+  /** Provider wire contract for ApplyPatch. Model support is resolved separately. */
+  readonly applyPatchProtocol?: ApplyPatchProtocol;
+};
 
 export type ProviderModelDiscovery =
   | {
@@ -784,7 +791,7 @@ const providerRegistry = {
     fallbackModels: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo', 'gpt-5'],
     status: 'ready',
     protocol: 'openai',
-    runtimeAdapter: { kind: 'openai' },
+    runtimeAdapter: { kind: 'openai', applyPatchProtocol: 'openai-structured' },
     modelDiscovery: { kind: 'protocol' },
     category: 'overseas',
     catalogGroup: 'api',
@@ -828,6 +835,7 @@ const providerRegistry = {
       kind: 'openai-compatible',
       name: 'provider',
       supportsOpenAiResponses: true,
+      applyPatchProtocol: 'codex-v4a-freeform',
     },
     modelDiscovery: { kind: 'protocol' },
     category: 'domestic',

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -390,6 +390,103 @@ describe('AiSdkBackend ApplyPatch routing', () => {
       false,
     );
   });
+
+  test('preserves every multi-file ApplyPatch fact from one provider step', async () => {
+    const model = completionModel();
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: { ...connection(), slug: 'openai', providerType: 'openai' },
+      apiKey: 'sk-test',
+      modelId: 'gpt-5.4',
+      modelFactory: () => model,
+      tools: [nativeApplyPatchTool()],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const firstPatch = [
+      '*** Begin Patch',
+      '*** Add File: first.txt',
+      '+first',
+      '*** Delete File: old-first.txt',
+      '*** End Patch',
+    ].join('\n');
+    const secondPatch = [
+      '*** Begin Patch',
+      '*** Add File: second.txt',
+      '+second',
+      '*** Delete File: old-second.txt',
+      '*** End Patch',
+    ].join('\n');
+    const call = (id: string, args: string) =>
+      runtimeEvent({
+        id: `rt-${id}`,
+        turnId: 'turn-previous',
+        role: 'model',
+        author: 'agent',
+        refs: { stepId: 'patch-step' },
+        content: { kind: 'function_call', id, name: 'apply_patch', args },
+      });
+    const result = (id: string, applied: Array<{ type: string; path: string }>) =>
+      runtimeEvent({
+        id: `rt-${id}-result`,
+        turnId: 'turn-previous',
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id,
+          name: 'apply_patch',
+          result: { status: 'completed', applied, output: 'Applied 2 file operations.' },
+        },
+      });
+
+    await drain(
+      backend.send({
+        turnId: 'turn-current',
+        text: 'continue',
+        context: [],
+        runtimeContext: [
+          runtimeTextEvent({
+            id: 'rt-user',
+            turnId: 'turn-previous',
+            role: 'user',
+            author: 'user',
+            text: 'patch both pairs',
+          }),
+          call('call-1', firstPatch),
+          call('call-2', secondPatch),
+          result('call-1', [
+            { type: 'create_file', path: 'first.txt' },
+            { type: 'delete_file', path: 'old-first.txt' },
+          ]),
+          result('call-2', [
+            { type: 'create_file', path: 'second.txt' },
+            { type: 'delete_file', path: 'old-second.txt' },
+          ]),
+          runtimeEvent({
+            id: 'rt-step-text',
+            turnId: 'turn-previous',
+            role: 'model',
+            author: 'agent',
+            refs: { providerEventId: 'patch-step' },
+            content: { kind: 'text', text: 'Both patches finished.' },
+          }),
+        ],
+      }),
+    );
+
+    const replayFacts = (compactPrompt(model) as Array<{ role: string; content: any[] }>)
+      .filter((message) => message.role === 'assistant')
+      .flatMap((message) => message.content)
+      .filter((part) => part.type === 'text' && part.text.startsWith('ApplyPatch completed'))
+      .map((part) => part.text);
+    assert.deepEqual(replayFacts, [
+      'ApplyPatch completed 2 file operations: create_file first.txt, delete_file old-first.txt.',
+      'ApplyPatch completed 2 file operations: create_file second.txt, delete_file old-second.txt.',
+    ]);
+  });
 });
 
 describe('AiSdkBackend Memory Extraction triggers', () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -86,7 +86,7 @@ import type { MemoryExtractionSourceSnapshot } from '../memory-extraction.js';
 import type { OpenAiResponsesSemanticBaseline } from '../openai-responses-continuation.js';
 import type { OpenAiResponsesTransportState } from '../openai-responses-websocket.js';
 
-describe('AiSdkBackend native ApplyPatch routing', () => {
+describe('AiSdkBackend ApplyPatch routing', () => {
   test('advertises apply_patch only to supported native OpenAI models', async () => {
     for (const [providerType, modelId, expected] of [
       ['openai', 'gpt-5.4', true],
@@ -105,14 +105,53 @@ describe('AiSdkBackend native ApplyPatch routing', () => {
         apiKey: 'sk-test',
         modelId,
         modelFactory: () => model,
-        tools: [nativeApplyPatchTool()],
+        tools: [
+          nativeApplyPatchTool(),
+          testTool('Write', z.object({})),
+          testTool('Edit', z.object({})),
+        ],
         newId: idGenerator(),
         now: monotonicClock(),
       });
 
       await drain(backend.send({ turnId: 'turn-1', text: 'edit', context: [] }));
-      assert.equal(modelToolNames(model).includes('apply_patch'), expected);
+      const names = modelToolNames(model);
+      assert.equal(names.includes('apply_patch'), expected);
+      assert.equal(names.includes('Write'), !expected);
+      assert.equal(names.includes('Edit'), !expected);
     }
+  });
+
+  test('replaces Write and Edit with freeform apply_patch for official DeepSeek V4 Flash', async () => {
+    const model = completionModel();
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        ...connection(),
+        slug: 'deepseek',
+        providerType: 'deepseek',
+        defaultModel: 'deepseek-v4-flash',
+      },
+      apiKey: 'sk-test',
+      modelId: 'deepseek-v4-flash',
+      modelFactory: () => model,
+      tools: [
+        nativeApplyPatchTool(),
+        testTool('Write', z.object({})),
+        testTool('Edit', z.object({})),
+      ],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(backend.send({ turnId: 'turn-1', text: 'edit', context: [] }));
+
+    const names = modelToolNames(model);
+    assert.equal(names.includes('apply_patch'), true);
+    assert.equal(names.includes('Write'), false);
+    assert.equal(names.includes('Edit'), false);
   });
 
   test('replays a durable apply_patch failure as native provider JSON', async () => {
@@ -181,6 +220,83 @@ describe('AiSdkBackend native ApplyPatch routing', () => {
     assert.deepEqual(toolResult?.output, {
       type: 'json',
       value: { status: 'failed', output: 'diff rejected' },
+    });
+  });
+
+  test('replays a durable DeepSeek freeform apply_patch result as plain text', async () => {
+    const model = completionModel();
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        ...connection(),
+        slug: 'deepseek',
+        providerType: 'deepseek',
+        defaultModel: 'deepseek-v4-flash',
+      },
+      apiKey: 'sk-test',
+      modelId: 'deepseek-v4-flash',
+      modelFactory: () => model,
+      tools: [nativeApplyPatchTool()],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(
+      backend.send({
+        turnId: 'turn-current',
+        text: 'continue',
+        context: [],
+        runtimeContext: [
+          runtimeTextEvent({
+            id: 'rt-user',
+            turnId: 'turn-previous',
+            role: 'user',
+            author: 'user',
+            text: 'patch it',
+          }),
+          runtimeEvent({
+            id: 'rt-call',
+            turnId: 'turn-previous',
+            role: 'model',
+            author: 'agent',
+            content: {
+              kind: 'function_call',
+              id: 'call-1',
+              name: 'apply_patch',
+              args: {
+                callId: 'call-1',
+                operation: { type: 'delete_file', path: 'file.txt' },
+              },
+            },
+          }),
+          runtimeEvent({
+            id: 'rt-result',
+            turnId: 'turn-previous',
+            role: 'tool',
+            author: 'tool',
+            content: {
+              kind: 'function_response',
+              id: 'call-1',
+              name: 'apply_patch',
+              result: { status: 'completed', output: 'Applied 1 file operation.' },
+            },
+          }),
+        ],
+      }),
+    );
+
+    const toolResult = (compactPrompt(model) as Array<{ role: string; content: any[] }>)
+      .find((message) => message.role === 'tool')
+      ?.content.find((part) => part.type === 'tool-result');
+    const toolCall = (compactPrompt(model) as Array<{ role: string; content: any[] }>)
+      .find((message) => message.role === 'assistant')
+      ?.content.find((part) => part.type === 'tool-call');
+    assert.equal(toolCall?.input, '*** Begin Patch\n*** Delete File: file.txt\n*** End Patch');
+    assert.deepEqual(toolResult?.output, {
+      type: 'text',
+      value: 'Applied 1 file operation.',
     });
   });
 });

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -299,6 +299,90 @@ describe('AiSdkBackend ApplyPatch routing', () => {
       value: 'Applied 1 file operation.',
     });
   });
+
+  test('preserves a multi-file ApplyPatch fact when structured replay cannot represent it', async () => {
+    const model = completionModel();
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: { ...connection(), slug: 'openai', providerType: 'openai' },
+      apiKey: 'sk-test',
+      modelId: 'gpt-5.4',
+      modelFactory: () => model,
+      tools: [nativeApplyPatchTool()],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const patch = [
+      '*** Begin Patch',
+      '*** Add File: added.txt',
+      '+hello',
+      '*** Delete File: removed.txt',
+      '*** End Patch',
+    ].join('\n');
+
+    await drain(
+      backend.send({
+        turnId: 'turn-current',
+        text: 'continue',
+        context: [],
+        runtimeContext: [
+          runtimeTextEvent({
+            id: 'rt-user',
+            turnId: 'turn-previous',
+            role: 'user',
+            author: 'user',
+            text: 'patch both files',
+          }),
+          runtimeEvent({
+            id: 'rt-call',
+            turnId: 'turn-previous',
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'function_call', id: 'call-1', name: 'apply_patch', args: patch },
+          }),
+          runtimeEvent({
+            id: 'rt-result',
+            turnId: 'turn-previous',
+            role: 'tool',
+            author: 'tool',
+            content: {
+              kind: 'function_response',
+              id: 'call-1',
+              name: 'apply_patch',
+              result: {
+                status: 'completed',
+                applied: [
+                  { type: 'create_file', path: 'added.txt' },
+                  { type: 'delete_file', path: 'removed.txt' },
+                ],
+                output: 'Applied 2 file operations.',
+              },
+            },
+          }),
+        ],
+      }),
+    );
+
+    const prompt = compactPrompt(model) as Array<{ role: string; content: any[] }>;
+    const replayText = prompt
+      .filter((message) => message.role === 'assistant')
+      .flatMap((message) => message.content)
+      .find((part) => part.type === 'text' && part.text.includes('added.txt'));
+    assert.equal(
+      replayText?.text,
+      'ApplyPatch completed 2 file operations: create_file added.txt, delete_file removed.txt.',
+    );
+    assert.equal(
+      prompt.some((message) =>
+        message.content.some(
+          (part) => part.type === 'tool-call' && part.toolName === 'apply_patch',
+        ),
+      ),
+      false,
+    );
+  });
 });
 
 describe('AiSdkBackend Memory Extraction triggers', () => {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -122,7 +122,7 @@ describe('AiSdkBackend ApplyPatch routing', () => {
     }
   });
 
-  test('replaces Write and Edit with freeform apply_patch for official DeepSeek V4 Flash', async () => {
+  test('replaces Write and Edit with freeform apply_patch for declared DeepSeek V4 Flash', async () => {
     const model = completionModel();
     const backend = createTestAiSdkBackend({
       sessionId: 'session-1',

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -267,7 +267,11 @@ describe('AiSdkBackend ApplyPatch routing', () => {
               name: 'apply_patch',
               args: {
                 callId: 'call-1',
-                operation: { type: 'delete_file', path: 'file.txt' },
+                operation: {
+                  type: 'update_file',
+                  path: 'file.txt',
+                  diff: '@@\n-before\n+after',
+                },
               },
             },
           }),
@@ -293,7 +297,10 @@ describe('AiSdkBackend ApplyPatch routing', () => {
     const toolCall = (compactPrompt(model) as Array<{ role: string; content: any[] }>)
       .find((message) => message.role === 'assistant')
       ?.content.find((part) => part.type === 'tool-call');
-    assert.equal(toolCall?.input, '*** Begin Patch\n*** Delete File: file.txt\n*** End Patch');
+    assert.equal(
+      toolCall?.input,
+      '*** Begin Patch\n*** Update File: file.txt\n@@\n-before\n+after\n*** End Patch',
+    );
     assert.deepEqual(toolResult?.output, {
       type: 'text',
       value: 'Applied 1 file operation.',

--- a/packages/runtime/src/__tests__/apply-patch-profile.test.ts
+++ b/packages/runtime/src/__tests__/apply-patch-profile.test.ts
@@ -74,7 +74,7 @@ describe('ApplyPatch profile routing', () => {
     assert.equal(resolveApplyPatchProfile({ wire: 'openai-responses' }, 'gpt-5.6'), null);
   });
 
-  test('normalizes portable history and drops an unrepresentable multi-file call', () => {
+  test('normalizes portable single-operation history', () => {
     assert.deepEqual(
       normalizeApplyPatchReplayInput(
         { kind: 'openai-structured' },
@@ -85,19 +85,6 @@ describe('ApplyPatch profile routing', () => {
         callId: 'call-1',
         operation: { type: 'delete_file', path: 'old.txt' },
       },
-    );
-    assert.equal(
-      normalizeApplyPatchReplayInput(
-        { kind: 'openai-structured' },
-        'call-1',
-        [
-          '*** Begin Patch',
-          '*** Delete File: one.txt',
-          '*** Delete File: two.txt',
-          '*** End Patch',
-        ].join('\n'),
-      ),
-      null,
     );
     assert.equal(
       normalizeApplyPatchReplayInput({ kind: 'codex-v4a-freeform' }, 'call-1', {

--- a/packages/runtime/src/__tests__/apply-patch-profile.test.ts
+++ b/packages/runtime/src/__tests__/apply-patch-profile.test.ts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  normalizeApplyPatchReplayInput,
+  resolveApplyPatchProfile,
+} from '../apply-patch-profile.js';
+
+describe('ApplyPatch profile routing', () => {
+  test('selects Codex V4A freeform only for official DeepSeek V4 Flash Responses', () => {
+    assert.deepEqual(
+      resolveApplyPatchProfile(
+        { providerType: 'deepseek', wire: 'openai-responses' },
+        'deepseek-v4-flash',
+      ),
+      { kind: 'codex-v4a-freeform' },
+    );
+    assert.equal(
+      resolveApplyPatchProfile(
+        { providerType: 'deepseek', wire: 'openai-chat' },
+        'deepseek-v4-flash',
+      ),
+      null,
+    );
+    assert.equal(
+      resolveApplyPatchProfile(
+        { providerType: 'deepseek', wire: 'openai-responses' },
+        'deepseek-v4-pro',
+      ),
+      null,
+    );
+    assert.equal(
+      resolveApplyPatchProfile(
+        { providerType: 'openrouter', wire: 'openai-responses' },
+        'deepseek/deepseek-v4-flash',
+      ),
+      null,
+    );
+    assert.equal(
+      resolveApplyPatchProfile(
+        {
+          providerType: 'deepseek',
+          wire: 'openai-responses',
+          baseUrl: 'https://gateway.example/v1',
+        },
+        'deepseek-v4-flash',
+      ),
+      null,
+    );
+  });
+
+  test('preserves structured routing for documented native OpenAI models', () => {
+    assert.deepEqual(
+      resolveApplyPatchProfile({ providerType: 'openai', wire: 'openai-responses' }, 'gpt-5.6'),
+      { kind: 'openai-structured' },
+    );
+    assert.equal(
+      resolveApplyPatchProfile({ providerType: 'openai', wire: 'openai-chat' }, 'gpt-5.6'),
+      null,
+    );
+    assert.equal(
+      resolveApplyPatchProfile({ providerType: 'openai', wire: 'openai-responses' }, 'gpt-5.5-pro'),
+      null,
+    );
+    assert.equal(
+      resolveApplyPatchProfile(
+        {
+          providerType: 'openai',
+          wire: 'openai-responses',
+          baseUrl: 'https://gateway.example/v1',
+        },
+        'gpt-5.6',
+      ),
+      null,
+    );
+  });
+
+  test('normalizes portable history and drops an unrepresentable multi-file call', () => {
+    assert.deepEqual(
+      normalizeApplyPatchReplayInput(
+        { kind: 'openai-structured' },
+        'call-1',
+        '*** Begin Patch\n*** Delete File: old.txt\n*** End Patch',
+      ),
+      {
+        callId: 'call-1',
+        operation: { type: 'delete_file', path: 'old.txt' },
+      },
+    );
+    assert.equal(
+      normalizeApplyPatchReplayInput(
+        { kind: 'openai-structured' },
+        'call-1',
+        [
+          '*** Begin Patch',
+          '*** Delete File: one.txt',
+          '*** Delete File: two.txt',
+          '*** End Patch',
+        ].join('\n'),
+      ),
+      null,
+    );
+    assert.equal(
+      normalizeApplyPatchReplayInput({ kind: 'codex-v4a-freeform' }, 'call-1', {
+        callId: 'call-1',
+        operation: { type: 'delete_file', path: 'old.txt' },
+      }),
+      '*** Begin Patch\n*** Delete File: old.txt\n*** End Patch',
+    );
+  });
+});

--- a/packages/runtime/src/__tests__/apply-patch-profile.test.ts
+++ b/packages/runtime/src/__tests__/apply-patch-profile.test.ts
@@ -4,74 +4,74 @@ import {
   normalizeApplyPatchReplayInput,
   resolveApplyPatchProfile,
 } from '../apply-patch-profile.js';
+import { resolveModelRuntime } from '../model-runtime.js';
 
 describe('ApplyPatch profile routing', () => {
-  test('selects Codex V4A freeform only for official DeepSeek V4 Flash Responses', () => {
+  test('derives the effective profile from the provider adapter contract', () => {
+    assert.deepEqual(
+      resolveModelRuntime(
+        {
+          providerType: 'deepseek',
+          baseUrl: 'https://gateway.example/v1',
+        },
+        'deepseek-v4-flash',
+      ).applyPatchProfile,
+      { kind: 'codex-v4a-freeform' },
+    );
+    assert.equal(
+      resolveModelRuntime({ providerType: 'xai' }, 'deepseek-v4-flash').applyPatchProfile,
+      null,
+    );
+  });
+
+  test('selects Codex V4A freeform only for declared V4 Flash Responses', () => {
     assert.deepEqual(
       resolveApplyPatchProfile(
-        { providerType: 'deepseek', wire: 'openai-responses' },
+        { wire: 'openai-responses', applyPatchProtocol: 'codex-v4a-freeform' },
         'deepseek-v4-flash',
       ),
       { kind: 'codex-v4a-freeform' },
     );
     assert.equal(
       resolveApplyPatchProfile(
-        { providerType: 'deepseek', wire: 'openai-chat' },
+        { wire: 'openai-chat', applyPatchProtocol: 'codex-v4a-freeform' },
         'deepseek-v4-flash',
       ),
       null,
     );
     assert.equal(
       resolveApplyPatchProfile(
-        { providerType: 'deepseek', wire: 'openai-responses' },
+        { wire: 'openai-responses', applyPatchProtocol: 'codex-v4a-freeform' },
         'deepseek-v4-pro',
       ),
       null,
     );
-    assert.equal(
-      resolveApplyPatchProfile(
-        { providerType: 'openrouter', wire: 'openai-responses' },
-        'deepseek/deepseek-v4-flash',
-      ),
-      null,
-    );
-    assert.equal(
-      resolveApplyPatchProfile(
-        {
-          providerType: 'deepseek',
-          wire: 'openai-responses',
-          baseUrl: 'https://gateway.example/v1',
-        },
-        'deepseek-v4-flash',
-      ),
-      null,
-    );
+    assert.equal(resolveApplyPatchProfile({ wire: 'openai-responses' }, 'deepseek-v4-flash'), null);
   });
 
   test('preserves structured routing for documented native OpenAI models', () => {
     assert.deepEqual(
-      resolveApplyPatchProfile({ providerType: 'openai', wire: 'openai-responses' }, 'gpt-5.6'),
+      resolveApplyPatchProfile(
+        { wire: 'openai-responses', applyPatchProtocol: 'openai-structured' },
+        'gpt-5.6',
+      ),
       { kind: 'openai-structured' },
     );
     assert.equal(
-      resolveApplyPatchProfile({ providerType: 'openai', wire: 'openai-chat' }, 'gpt-5.6'),
-      null,
-    );
-    assert.equal(
-      resolveApplyPatchProfile({ providerType: 'openai', wire: 'openai-responses' }, 'gpt-5.5-pro'),
-      null,
-    );
-    assert.equal(
       resolveApplyPatchProfile(
-        {
-          providerType: 'openai',
-          wire: 'openai-responses',
-          baseUrl: 'https://gateway.example/v1',
-        },
+        { wire: 'openai-chat', applyPatchProtocol: 'openai-structured' },
         'gpt-5.6',
       ),
       null,
     );
+    assert.equal(
+      resolveApplyPatchProfile(
+        { wire: 'openai-responses', applyPatchProtocol: 'openai-structured' },
+        'gpt-5.5-pro',
+      ),
+      null,
+    );
+    assert.equal(resolveApplyPatchProfile({ wire: 'openai-responses' }, 'gpt-5.6'), null);
   });
 
   test('normalizes portable history and drops an unrepresentable multi-file call', () => {

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -256,6 +256,47 @@ describe('builtin tool activity kinds', () => {
     assert.match(result.error, /target is missing/);
   });
 
+  test('does not start another V4A operation after the turn is stopped', async () => {
+    const abortController = new AbortController();
+    const paths: string[] = [];
+    const applyPatch = buildBuiltinTools({
+      executor: fakeExecutor({
+        applyPatch: async ({ path }) => {
+          paths.push(path);
+          abortController.abort();
+          return { ok: true, path };
+        },
+      }),
+    }).find((tool) => tool.name === 'apply_patch');
+    if (!applyPatch) throw new Error('apply_patch tool missing');
+
+    const result = (await runTool(
+      applyPatch,
+      [
+        '*** Begin Patch',
+        '*** Add File: first.txt',
+        '+first',
+        '*** Delete File: second.txt',
+        '*** Add File: third.txt',
+        '+third',
+        '*** End Patch',
+      ].join('\n'),
+      '/workspace',
+      abortController.signal,
+    )) as {
+      status: string;
+      applied: unknown;
+      stoppedBefore: unknown;
+      error: string;
+    };
+
+    assert.deepEqual(paths, ['first.txt']);
+    assert.equal(result.status, 'failed');
+    assert.deepEqual(result.applied, [{ type: 'create_file', path: 'first.txt' }]);
+    assert.deepEqual(result.stoppedBefore, { type: 'delete_file', path: 'second.txt' });
+    assert.match(result.error, /stopped before delete_file second\.txt/);
+  });
+
   test('applies freeform V4A contents to real files', async (t) => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-freeform-apply-patch-'));
     t.after(() => rm(cwd, { recursive: true, force: true }));
@@ -2832,6 +2873,7 @@ function runTool(
   tool: ReturnType<typeof buildBuiltinTools>[number],
   args: unknown,
   cwd: string,
+  abortSignal = new AbortController().signal,
 ): Promise<unknown> {
   return Promise.resolve(
     tool.impl(args as never, {
@@ -2839,7 +2881,7 @@ function runTool(
       turnId: 'turn-1',
       cwd,
       toolCallId: 'tool-1',
-      abortSignal: new AbortController().signal,
+      abortSignal,
       emitOutput: () => {},
     }),
   );

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -113,6 +113,129 @@ describe('builtin tool activity kinds', () => {
       true,
     );
   });
+
+  test('applies a freeform V4A patch through the existing filesystem authority', async () => {
+    const calls: Array<{
+      action: string;
+      path: string;
+      diff?: string;
+      cwd: string;
+      label: string;
+      scope: string;
+    }> = [];
+    const applyPatch = buildBuiltinTools({
+      executor: fakeExecutor({
+        applyPatch: async (input) => {
+          calls.push(input);
+          return { ok: true, path: input.path };
+        },
+      }),
+    }).find((tool) => tool.name === 'apply_patch');
+    if (!applyPatch) throw new Error('apply_patch tool missing');
+
+    const result = await runTool(
+      applyPatch,
+      [
+        '*** Begin Patch',
+        '*** Add File: added.txt',
+        '+hello',
+        '+world',
+        '*** Update File: changed.txt',
+        '@@',
+        '-before',
+        '+after',
+        '*** Delete File: removed.txt',
+        '*** End Patch',
+      ].join('\n'),
+      '/workspace',
+    );
+
+    assert.deepEqual(calls, [
+      {
+        cwd: '/workspace',
+        action: 'create',
+        path: 'added.txt',
+        diff: '+hello\n+world',
+        label: 'ApplyPatch',
+        scope: 'workspace',
+      },
+      {
+        cwd: '/workspace',
+        action: 'update',
+        path: 'changed.txt',
+        diff: '@@\n-before\n+after',
+        label: 'ApplyPatch',
+        scope: 'workspace',
+      },
+      {
+        cwd: '/workspace',
+        action: 'delete',
+        path: 'removed.txt',
+        label: 'ApplyPatch',
+        scope: 'workspace',
+      },
+    ]);
+    assert.deepEqual(result, { status: 'completed', output: 'Applied 3 file operations.' });
+  });
+
+  test('rejects unsupported V4A Move before applying any file operation', async () => {
+    let calls = 0;
+    const applyPatch = buildBuiltinTools({
+      executor: fakeExecutor({
+        applyPatch: async (input) => {
+          calls += 1;
+          return { ok: true, path: input.path };
+        },
+      }),
+    }).find((tool) => tool.name === 'apply_patch');
+    if (!applyPatch) throw new Error('apply_patch tool missing');
+
+    await assert.rejects(
+      runTool(
+        applyPatch,
+        [
+          '*** Begin Patch',
+          '*** Add File: first.txt',
+          '+first',
+          '*** Update File: old.txt',
+          '*** Move to: new.txt',
+          '@@',
+          '-old',
+          '+new',
+          '*** End Patch',
+        ].join('\n'),
+        '/workspace',
+      ),
+      /Move is not supported/,
+    );
+    assert.equal(calls, 0);
+  });
+
+  test('applies freeform V4A contents to real files', async (t) => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-freeform-apply-patch-'));
+    t.after(() => rm(cwd, { recursive: true, force: true }));
+    await writeFile(join(cwd, 'changed.txt'), 'before\n', 'utf8');
+    const applyPatch = buildBuiltinTools().find((tool) => tool.name === 'apply_patch');
+    if (!applyPatch) throw new Error('apply_patch tool missing');
+
+    await runTool(
+      applyPatch,
+      [
+        '*** Begin Patch',
+        '*** Add File: added.txt',
+        '+hello',
+        '*** Update File: changed.txt',
+        '@@',
+        '-before',
+        '+after',
+        '*** End Patch',
+      ].join('\n'),
+      cwd,
+    );
+
+    assert.equal(await readFile(join(cwd, 'added.txt'), 'utf8'), 'hello');
+    assert.equal(await readFile(join(cwd, 'changed.txt'), 'utf8'), 'after\n');
+  });
 });
 
 describe('builtin Read capabilities', () => {

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -155,7 +155,7 @@ describe('builtin tool activity kinds', () => {
         cwd: '/workspace',
         action: 'create',
         path: 'added.txt',
-        diff: '+hello\n+world',
+        diff: '+hello\n+world\n+',
         label: 'ApplyPatch',
         scope: 'workspace',
       },
@@ -175,7 +175,15 @@ describe('builtin tool activity kinds', () => {
         scope: 'workspace',
       },
     ]);
-    assert.deepEqual(result, { status: 'completed', output: 'Applied 3 file operations.' });
+    assert.deepEqual(result, {
+      status: 'completed',
+      applied: [
+        { type: 'create_file', path: 'added.txt' },
+        { type: 'update_file', path: 'changed.txt' },
+        { type: 'delete_file', path: 'removed.txt' },
+      ],
+      output: 'Applied 3 file operations.',
+    });
   });
 
   test('rejects unsupported V4A Move before applying any file operation', async () => {
@@ -211,6 +219,43 @@ describe('builtin tool activity kinds', () => {
     assert.equal(calls, 0);
   });
 
+  test('reports the applied prefix when a later V4A operation fails', async () => {
+    const applyPatch = buildBuiltinTools({
+      executor: fakeExecutor({
+        applyPatch: async ({ path }) => {
+          if (path === 'missing.txt') throw new Error('target is missing');
+          return { ok: true, path };
+        },
+      }),
+    }).find((tool) => tool.name === 'apply_patch');
+    if (!applyPatch) throw new Error('apply_patch tool missing');
+
+    const result = (await runTool(
+      applyPatch,
+      [
+        '*** Begin Patch',
+        '*** Add File: first.txt',
+        '+first',
+        '*** Update File: missing.txt',
+        '@@',
+        '-before',
+        '+after',
+        '*** End Patch',
+      ].join('\n'),
+      '/workspace',
+    )) as {
+      status: string;
+      applied: unknown;
+      failed: unknown;
+      error: string;
+    };
+
+    assert.equal(result.status, 'failed');
+    assert.deepEqual(result.applied, [{ type: 'create_file', path: 'first.txt' }]);
+    assert.deepEqual(result.failed, { type: 'update_file', path: 'missing.txt' });
+    assert.match(result.error, /target is missing/);
+  });
+
   test('applies freeform V4A contents to real files', async (t) => {
     const cwd = await mkdtemp(join(tmpdir(), 'maka-freeform-apply-patch-'));
     t.after(() => rm(cwd, { recursive: true, force: true }));
@@ -233,7 +278,7 @@ describe('builtin tool activity kinds', () => {
       cwd,
     );
 
-    assert.equal(await readFile(join(cwd, 'added.txt'), 'utf8'), 'hello');
+    assert.equal(await readFile(join(cwd, 'added.txt'), 'utf8'), 'hello\n');
     assert.equal(await readFile(join(cwd, 'changed.txt'), 'utf8'), 'after\n');
   });
 });

--- a/packages/runtime/src/__tests__/responses-wire-contract.test.ts
+++ b/packages/runtime/src/__tests__/responses-wire-contract.test.ts
@@ -142,6 +142,73 @@ describe('responses wire request body', () => {
     });
   });
 
+  test('sends DeepSeek-compatible freeform apply_patch calls and plain-text results', async () => {
+    let body: Record<string, unknown> | undefined;
+    const fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body));
+      return Response.json({
+        id: 'r',
+        object: 'response',
+        status: 'completed',
+        output: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    }) as unknown as typeof globalThis.fetch;
+    const connection = conn('deepseek');
+    const model = getAIModel({
+      connection,
+      apiKey: 'test-key',
+      modelId: 'deepseek-v4-flash',
+      fetch,
+    });
+    const tools = lowerModelTools({
+      apply_patch: { kind: 'provider', providerTool: { kind: 'openai-custom-apply-patch' } },
+    });
+    const patch = '*** Begin Patch\n*** Delete File: old.txt\n*** End Patch';
+
+    await model.doGenerate({
+      prompt: [
+        {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'apply_patch',
+              input: patch,
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [
+            {
+              type: 'tool-result',
+              toolCallId: 'call-1',
+              toolName: 'apply_patch',
+              output: { type: 'text', value: 'Applied 1 file operation.' },
+            },
+          ],
+        },
+      ],
+      tools: [{ ...(tools.apply_patch as object), name: 'apply_patch' } as never],
+      providerOptions: { openai: { store: false } },
+    });
+
+    assert.deepEqual((body?.tools as unknown[] | undefined)?.[0], {
+      type: 'custom',
+      name: 'apply_patch',
+    });
+    assert.deepEqual((body?.input as unknown[] | undefined)?.slice(-2), [
+      { type: 'custom_tool_call', call_id: 'call-1', name: 'apply_patch', input: patch },
+      {
+        type: 'custom_tool_call_output',
+        call_id: 'call-1',
+        output: 'Applied 1 file operation.',
+      },
+    ]);
+  });
+
   test('a non-OpenAI-named Responses model still asks for encrypted reasoning', async () => {
     // The options shape alone does not prove the wire: the SDK only adds the
     // include when it also believes the model reasons, and it decides that by

--- a/packages/runtime/src/__tests__/responses-wire-contract.test.ts
+++ b/packages/runtime/src/__tests__/responses-wire-contract.test.ts
@@ -7,6 +7,8 @@ import {
   thinkingVariantsForModel,
 } from '@maka/core';
 import { buildProviderOptions, getAIModel } from '@maka/runtime';
+import { z } from 'zod';
+import { routeApplyPatchTools } from '../apply-patch-profile.js';
 import { resolveModelRuntime } from '../model-runtime.js';
 import { lowerModelTools } from '../model-adapter.js';
 
@@ -161,10 +163,37 @@ describe('responses wire request body', () => {
       modelId: 'deepseek-v4-flash',
       fetch,
     });
-    const tools = lowerModelTools({
-      apply_patch: { kind: 'provider', providerTool: { kind: 'openai-custom-apply-patch' } },
-    });
     const patch = '*** Begin Patch\n*** Delete File: old.txt\n*** End Patch';
+    const runtime = resolveModelRuntime(connection, 'deepseek-v4-flash');
+    const [routedTool] = routeApplyPatchTools(
+      [
+        {
+          name: 'apply_patch',
+          description: 'Apply file changes',
+          parameters: z.object({}),
+          providerTool: { kind: 'openai-apply-patch' },
+          impl: async () => ({ status: 'completed' }),
+        },
+      ],
+      runtime.applyPatchProfile,
+    );
+    assert.ok(routedTool);
+    assert.ok(routedTool.providerTool);
+    assert.equal((routedTool.parameters as z.ZodType).safeParse(patch).success, true);
+    assert.deepEqual(
+      await routedTool.toModelOutput?.({
+        toolCallId: 'call-1',
+        input: patch,
+        output: { status: 'completed', output: 'Applied 1 file operation.' },
+      }),
+      { type: 'text', value: 'Applied 1 file operation.' },
+    );
+    const tools = lowerModelTools({
+      apply_patch: {
+        kind: 'provider',
+        providerTool: routedTool.providerTool,
+      },
+    });
 
     await model.doGenerate({
       prompt: [

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -940,7 +940,9 @@ describe('SessionManager graph operator provisioning', () => {
       runStore,
       runtimeEventStore: runStore,
       backends: new BackendRegistry(),
-      childTools: IMPLEMENTATION_AGENT_DEFINITION.tools.map(testTool),
+      childTools: IMPLEMENTATION_AGENT_DEFINITION.tools
+        .filter((name) => name !== 'Write' && name !== 'Edit')
+        .map(testTool),
       worktreeChildExecutor: {
         isAvailable: async () => true,
         provision: async (input) => {
@@ -1007,6 +1009,15 @@ describe('SessionManager graph operator provisioning', () => {
     expect(result.header.cwd).toBe(result.header.subagentWorkspace?.worktreePath);
     expect(result.header.subagentWorkspace?.kind).toBe('git_worktree');
     expect(result.header.subagentWorkspace?.branch).toMatch(/^maka\/subagent\//);
+    expect(result.header.subagentRuntime?.toolNames).toEqual([
+      'Read',
+      'Glob',
+      'Grep',
+      'apply_patch',
+      'Bash',
+      'WriteStdin',
+      'StopBackgroundTask',
+    ]);
     expect(headerToSummary(result.header).subagentWorkspace).toEqual(
       result.header.subagentWorkspace,
     );

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -274,12 +274,14 @@ describe('subagent tools', () => {
       supportedWriteBack: [AGENT_WRITE_BACK_PATCH],
     });
     expect(IMPLEMENTATION_AGENT_DEFINITION.permissionMode).toBe('execute');
+    expect(IMPLEMENTATION_AGENT_DEFINITION.toolGroups).toEqual(['file_edit']);
     expect([...IMPLEMENTATION_AGENT_DEFINITION.tools]).toEqual([
       'Read',
       'Glob',
       'Grep',
       'Write',
       'Edit',
+      'apply_patch',
       'Bash',
       'WriteStdin',
       'StopBackgroundTask',
@@ -381,6 +383,30 @@ describe('subagent tools', () => {
     });
   });
 
+  test('implementation remains available with the Write and Edit fallback', () => {
+    const tools = implementationCatalogTools().filter((tool) => tool.name !== 'apply_patch');
+    expect(
+      evaluateAgentDefinitionAvailability({
+        definition: IMPLEMENTATION_AGENT_DEFINITION,
+        tools,
+        worktreeChildExecutorAvailable: true,
+      }),
+    ).toEqual({ status: 'available' });
+  });
+
+  test('implementation remains available with the ApplyPatch alternative', () => {
+    const tools = implementationCatalogTools().filter(
+      (tool) => tool.name !== 'Write' && tool.name !== 'Edit',
+    );
+    expect(
+      evaluateAgentDefinitionAvailability({
+        definition: IMPLEMENTATION_AGENT_DEFINITION,
+        tools,
+        worktreeChildExecutorAvailable: true,
+      }),
+    ).toEqual({ status: 'available' });
+  });
+
   test('legacy parent mode does not override the authoritative child boundary and tool surface', () => {
     assertAgentDefinitionRunnable({
       definition: {
@@ -431,6 +457,7 @@ describe('subagent tools', () => {
       'WebSearch',
       'Write',
       'Edit',
+      'apply_patch',
       'Bash',
       'WriteStdin',
       'StopBackgroundTask',
@@ -442,6 +469,7 @@ describe('subagent tools', () => {
       'WebSearch',
       'Write',
       'Edit',
+      'apply_patch',
       'Bash',
       'WriteStdin',
       'StopBackgroundTask',

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -301,6 +301,25 @@ export function evaluateAgentDefinitionAvailability(input: {
     };
   }
 
+  const { missingTools } = resolveAgentDefinitionToolSet(tools, definition);
+  if (missingTools.length > 0) {
+    return { status: 'unavailable', reason: 'missing_tools', missingTools };
+  }
+
+  return { status: 'available' };
+}
+
+export function buildToolsForAgentDefinition(
+  tools: readonly MakaTool[],
+  definition: AgentRuntimeDefinition = LOCAL_READ_AGENT_DEFINITION,
+): MakaTool[] {
+  return resolveAgentDefinitionToolSet(tools, definition).tools;
+}
+
+function resolveAgentDefinitionToolSet(
+  tools: readonly MakaTool[],
+  definition: AgentRuntimeDefinition,
+): { tools: MakaTool[]; missingTools: string[] } {
   const byName = new Map(tools.map((tool) => [tool.name, tool]));
   const groupedToolNames = new Set<string>(
     (definition.toolGroups ?? []).flatMap((group) =>
@@ -317,25 +336,13 @@ export function evaluateAgentDefinitionAvailability(input: {
       if (!byName.has(name) && !missingTools.includes(name)) missingTools.push(name);
     }
   }
-  if (missingTools.length > 0) {
-    return { status: 'unavailable', reason: 'missing_tools', missingTools };
-  }
-
-  return { status: 'available' };
-}
-
-export function buildToolsForAgentDefinition(
-  tools: readonly MakaTool[],
-  definition: AgentRuntimeDefinition = LOCAL_READ_AGENT_DEFINITION,
-): MakaTool[] {
-  const byName = new Map(tools.map((tool) => [tool.name, tool]));
-  const out: MakaTool[] = [];
-  for (const name of definition.tools) {
-    const tool = byName.get(name);
-    if (!tool) continue;
-    out.push(tool);
-  }
-  return out;
+  return {
+    tools: definition.tools.flatMap((name) => {
+      const tool = byName.get(name);
+      return tool ? [tool] : [];
+    }),
+    missingTools,
+  };
 }
 
 export function assertAgentDefinitionRunnable(input: {

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -31,6 +31,11 @@ export type AgentWriteBackMode =
   | 'decision'
   | 'artifact'
   | 'patch';
+export type AgentToolGroup = 'file_edit';
+
+const AGENT_TOOL_GROUP_ALTERNATIVES = {
+  file_edit: [['Write', 'Edit'], ['apply_patch']],
+} as const satisfies Record<AgentToolGroup, readonly (readonly string[])[]>;
 
 export interface AgentProfileContract {
   capability: AgentCapability;
@@ -65,10 +70,14 @@ export interface AgentDefinition {
   contract: AgentProfileContract;
   permissionMode: PermissionMode;
   tools: readonly string[];
+  toolGroups?: readonly AgentToolGroup[];
   systemPrompt: string;
 }
 
-export type AgentRuntimeDefinition = Pick<AgentDefinition, 'id' | 'permissionMode' | 'tools'>;
+export type AgentRuntimeDefinition = Pick<
+  AgentDefinition,
+  'id' | 'permissionMode' | 'tools' | 'toolGroups'
+>;
 
 export interface AgentDefinitionListItem {
   id: string;
@@ -147,7 +156,7 @@ export const WEB_RESEARCH_AGENT_DEFINITION: AgentDefinition = {
 };
 
 export const IMPLEMENTATION_AGENT_DEFINITION: AgentDefinition = {
-  definitionVersion: 2,
+  definitionVersion: 3,
   id: IMPLEMENTATION_AGENT_ID,
   profile: IMPLEMENTATION_AGENT_PROFILE,
   name: 'Implementation',
@@ -161,7 +170,18 @@ export const IMPLEMENTATION_AGENT_DEFINITION: AgentDefinition = {
     supportedWriteBack: [AGENT_WRITE_BACK_PATCH],
   },
   permissionMode: 'execute',
-  tools: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash', 'WriteStdin', 'StopBackgroundTask'],
+  tools: [
+    'Read',
+    'Glob',
+    'Grep',
+    'Write',
+    'Edit',
+    'apply_patch',
+    'Bash',
+    'WriteStdin',
+    'StopBackgroundTask',
+  ],
+  toolGroups: ['file_edit'],
   systemPrompt: [
     'You are a foreground implementation child agent.',
     'Run only inside a dedicated worktree child executor when the host provides one.',
@@ -282,7 +302,21 @@ export function evaluateAgentDefinitionAvailability(input: {
   }
 
   const byName = new Map(tools.map((tool) => [tool.name, tool]));
-  const missingTools = definition.tools.filter((name) => !byName.has(name));
+  const groupedToolNames = new Set<string>(
+    (definition.toolGroups ?? []).flatMap((group) =>
+      AGENT_TOOL_GROUP_ALTERNATIVES[group].flatMap((alternative) => alternative),
+    ),
+  );
+  const missingTools = definition.tools.filter(
+    (name) => !groupedToolNames.has(name) && !byName.has(name),
+  );
+  for (const group of definition.toolGroups ?? []) {
+    const alternatives = AGENT_TOOL_GROUP_ALTERNATIVES[group];
+    if (alternatives.some((alternative) => alternative.every((name) => byName.has(name)))) continue;
+    for (const name of alternatives.flat()) {
+      if (!byName.has(name) && !missingTools.includes(name)) missingTools.push(name);
+    }
+  }
   if (missingTools.length > 0) {
     return { status: 'unavailable', reason: 'missing_tools', missingTools };
   }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -208,8 +208,14 @@ import {
   type MemoryExtractionSourceSnapshot,
   type MemoryExtractionTrigger,
 } from './memory-extraction.js';
-import { modelUsesNativeOpenAiResponses } from './model-runtime.js';
-import { openAiModelSupportsApplyPatch } from './openai-apply-patch.js';
+import { modelUsesNativeOpenAiResponses, resolveModelRuntime } from './model-runtime.js';
+import {
+  freeformApplyPatchResultText,
+  normalizeApplyPatchReplayInput,
+  resolveApplyPatchProfile,
+  routeApplyPatchTools,
+  type ApplyPatchProfile,
+} from './apply-patch-profile.js';
 import {
   applyRuntimeEventContextBudget,
   buildContextBudgetDiagnosticShell,
@@ -844,6 +850,16 @@ function nativeApplyPatchFailureOutput(output: ToolResultOutput): ToolResultOutp
   };
 }
 
+function freeformApplyPatchOutput(output: ToolResultOutput): ToolResultOutput {
+  if (output.type === 'text' || output.type === 'error-text') return output;
+  const value = output.type === 'json' || output.type === 'error-json' ? output.value : undefined;
+  const record = value && typeof value === 'object' && !Array.isArray(value) ? value : undefined;
+  const text = record ? freeformApplyPatchResultText(record) : freeformApplyPatchResultText(value);
+  return output.type === 'error-json'
+    ? { type: 'error-text', value: text }
+    : { type: 'text', value: text };
+}
+
 const MAX_PROVIDER_ATTEMPTS_PER_STEP = 10;
 const MAX_IDLE_WATCHDOG_RETRIES_PER_STEP = 1;
 const MAX_INCOMPLETE_STREAM_RETRIES_PER_STEP = 1;
@@ -992,6 +1008,7 @@ export class AiSdkBackend implements AgentBackend {
   private readonly providerRetrySleep: (delayMs: number, signal: AbortSignal) => Promise<void>;
   private readonly modelAdapter: ModelAdapter;
   private readonly toolAvailabilityRuntime: ToolAvailabilityRuntime;
+  private readonly applyPatchProfile: ApplyPatchProfile | null;
 
   /**
    * Every `send()` currently in flight on this backend.
@@ -1074,11 +1091,16 @@ export class AiSdkBackend implements AgentBackend {
             : {}),
         })
       : [];
-    const modelTools =
-      modelUsesNativeOpenAiResponses(input.connection, input.modelId) &&
-      openAiModelSupportsApplyPatch(input.modelId)
-        ? input.tools
-        : input.tools.filter((tool) => tool.providerTool?.kind !== 'openai-apply-patch');
+    const runtime = resolveModelRuntime(input.connection, input.modelId);
+    this.applyPatchProfile = resolveApplyPatchProfile(
+      {
+        providerType: input.connection.providerType,
+        wire: runtime.wire,
+        baseUrl: runtime.baseUrl,
+      },
+      input.modelId,
+    );
+    const modelTools = routeApplyPatchTools(input.tools, this.applyPatchProfile);
     this.toolAvailabilityRuntime = new ToolAvailabilityRuntime(
       // The archive decoder is a runtime protocol tool, not a host binding:
       // this session's placeholders name it, so this session advertises it.
@@ -3726,9 +3748,11 @@ export class AiSdkBackend implements AgentBackend {
           result.isError,
           `runtime-event:${result.eventId}:tool-result`,
         ));
-      return toolName === 'apply_patch' && result.isError
-        ? nativeApplyPatchFailureOutput(output)
-        : output;
+      if (toolName !== 'apply_patch') return output;
+      if (this.applyPatchProfile?.kind === 'codex-v4a-freeform') {
+        return freeformApplyPatchOutput(output);
+      }
+      return result.isError ? nativeApplyPatchFailureOutput(output) : output;
     };
     const pushClientToolResults = async (calls: readonly ToolCallItem[]) => {
       for (const call of calls) {
@@ -3880,7 +3904,24 @@ export class AiSdkBackend implements AgentBackend {
     for (const item of plan.items) {
       switch (item.kind) {
         case 'tool_call':
-          bufferedCalls.push(item);
+          if (item.toolName !== 'apply_patch') {
+            bufferedCalls.push(item);
+            break;
+          }
+          {
+            const replayInput = normalizeApplyPatchReplayInput(
+              this.applyPatchProfile,
+              item.toolCallId,
+              item.input,
+            );
+            if (replayInput !== null) {
+              bufferedCalls.push({
+                ...item,
+                input: replayInput,
+                ...(replayInput !== item.input ? { providerOptions: undefined } : {}),
+              });
+            }
+          }
           break;
         case 'tool_result':
           results.set(item.toolCallId, item);

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -210,6 +210,7 @@ import {
 } from './memory-extraction.js';
 import { modelUsesNativeOpenAiResponses, resolveModelRuntime } from './model-runtime.js';
 import {
+  applyPatchReplayFactText,
   freeformApplyPatchResultText,
   normalizeApplyPatchReplayInput,
   routeApplyPatchTools,
@@ -3669,6 +3670,11 @@ export class AiSdkBackend implements AgentBackend {
     };
     let bufferedCalls: ToolCallItem[] = [];
     const results = new Map<string, ToolResultItem>();
+    const downgradedApplyPatchCalls = new Map<string, ToolCallItem>();
+    const replayFactsByStep = new Map<
+      string,
+      { readonly text: string; readonly eventIds: readonly string[] }
+    >();
     const reasoningByStep = new Map<string, ThinkingItem[]>();
     const textByStep = new Map<string, TextItem>();
 
@@ -3779,6 +3785,7 @@ export class AiSdkBackend implements AgentBackend {
         ...(reasoning ?? []).map((item) => item.eventId),
         ...(text ? [text.eventId] : []),
         ...calls.map((call) => call.eventId),
+        ...(text?.stepId ? (replayFactsByStep.get(text.stepId)?.eventIds ?? []) : []),
       ];
       const replayReasoning = reasoning
         ?.map(reasoningReplay)
@@ -3817,6 +3824,11 @@ export class AiSdkBackend implements AgentBackend {
           text: text.content,
           ...(text.providerOptions !== undefined ? { providerOptions: text.providerOptions } : {}),
         });
+      }
+      const replayFact = text?.stepId ? replayFactsByStep.get(text.stepId) : undefined;
+      if (replayFact) {
+        content.push({ type: 'text', text: replayFact.text });
+        replayFactsByStep.delete(text!.stepId!);
       }
       for (const call of calls) {
         if (call.providerExecuted === true) continue;
@@ -3912,12 +3924,48 @@ export class AiSdkBackend implements AgentBackend {
                 input: replayInput,
                 ...(replayInput !== item.input ? { providerOptions: undefined } : {}),
               });
+            } else {
+              downgradedApplyPatchCalls.set(item.toolCallId, item);
             }
           }
           break;
-        case 'tool_result':
-          results.set(item.toolCallId, item);
+        case 'tool_result': {
+          const downgradedCall = downgradedApplyPatchCalls.get(item.toolCallId);
+          if (!downgradedCall) {
+            results.set(item.toolCallId, item);
+            break;
+          }
+          downgradedApplyPatchCalls.delete(item.toolCallId);
+          const replayFact = applyPatchReplayFactText(
+            downgradedCall.input,
+            item.output,
+            item.isError,
+          );
+          if (!replayFact) break;
+          if (downgradedCall.stepId) {
+            replayFactsByStep.set(downgradedCall.stepId, {
+              text: replayFact,
+              eventIds: [downgradedCall.eventId, item.eventId],
+            });
+            if (!textByStep.has(downgradedCall.stepId)) {
+              textByStep.set(downgradedCall.stepId, {
+                kind: 'text',
+                role: 'assistant',
+                content: '',
+                stepId: downgradedCall.stepId,
+                eventId: downgradedCall.eventId,
+                ts: downgradedCall.ts,
+              });
+            }
+          } else {
+            await flushPendingSteps();
+            push({ role: 'assistant', content: [{ type: 'text', text: replayFact }] }, [
+              downgradedCall.eventId,
+              item.eventId,
+            ]);
+          }
           break;
+        }
         case 'thinking':
           if (item.stepId !== undefined) {
             const stepReasoning = reasoningByStep.get(item.stepId) ?? [];

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -212,7 +212,6 @@ import { modelUsesNativeOpenAiResponses, resolveModelRuntime } from './model-run
 import {
   freeformApplyPatchResultText,
   normalizeApplyPatchReplayInput,
-  resolveApplyPatchProfile,
   routeApplyPatchTools,
   type ApplyPatchProfile,
 } from './apply-patch-profile.js';
@@ -1092,14 +1091,7 @@ export class AiSdkBackend implements AgentBackend {
         })
       : [];
     const runtime = resolveModelRuntime(input.connection, input.modelId);
-    this.applyPatchProfile = resolveApplyPatchProfile(
-      {
-        providerType: input.connection.providerType,
-        wire: runtime.wire,
-        baseUrl: runtime.baseUrl,
-      },
-      input.modelId,
-    );
+    this.applyPatchProfile = runtime.applyPatchProfile;
     const modelTools = routeApplyPatchTools(input.tools, this.applyPatchProfile);
     this.toolAvailabilityRuntime = new ToolAvailabilityRuntime(
       // The archive decoder is a runtime protocol tool, not a host binding:

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -3673,7 +3673,7 @@ export class AiSdkBackend implements AgentBackend {
     const downgradedApplyPatchCalls = new Map<string, ToolCallItem>();
     const replayFactsByStep = new Map<
       string,
-      { readonly text: string; readonly eventIds: readonly string[] }
+      Array<{ readonly text: string; readonly eventIds: readonly string[] }>
     >();
     const reasoningByStep = new Map<string, ThinkingItem[]>();
     const textByStep = new Map<string, TextItem>();
@@ -3785,7 +3785,9 @@ export class AiSdkBackend implements AgentBackend {
         ...(reasoning ?? []).map((item) => item.eventId),
         ...(text ? [text.eventId] : []),
         ...calls.map((call) => call.eventId),
-        ...(text?.stepId ? (replayFactsByStep.get(text.stepId)?.eventIds ?? []) : []),
+        ...(text?.stepId
+          ? (replayFactsByStep.get(text.stepId)?.flatMap((fact) => fact.eventIds) ?? [])
+          : []),
       ];
       const replayReasoning = reasoning
         ?.map(reasoningReplay)
@@ -3825,9 +3827,11 @@ export class AiSdkBackend implements AgentBackend {
           ...(text.providerOptions !== undefined ? { providerOptions: text.providerOptions } : {}),
         });
       }
-      const replayFact = text?.stepId ? replayFactsByStep.get(text.stepId) : undefined;
-      if (replayFact) {
-        content.push({ type: 'text', text: replayFact.text });
+      const replayFacts = text?.stepId ? replayFactsByStep.get(text.stepId) : undefined;
+      if (replayFacts) {
+        for (const replayFact of replayFacts) {
+          content.push({ type: 'text', text: replayFact.text });
+        }
         replayFactsByStep.delete(text!.stepId!);
       }
       for (const call of calls) {
@@ -3943,10 +3947,14 @@ export class AiSdkBackend implements AgentBackend {
           );
           if (!replayFact) break;
           if (downgradedCall.stepId) {
-            replayFactsByStep.set(downgradedCall.stepId, {
-              text: replayFact,
-              eventIds: [downgradedCall.eventId, item.eventId],
-            });
+            const stepFacts = replayFactsByStep.get(downgradedCall.stepId) ?? [];
+            replayFactsByStep.set(downgradedCall.stepId, [
+              ...stepFacts,
+              {
+                text: replayFact,
+                eventIds: [downgradedCall.eventId, item.eventId],
+              },
+            ]);
             if (!textByStep.has(downgradedCall.stepId)) {
               textByStep.set(downgradedCall.stepId, {
                 kind: 'text',

--- a/packages/runtime/src/apply-patch-batch.ts
+++ b/packages/runtime/src/apply-patch-batch.ts
@@ -1,0 +1,56 @@
+import type { ApplyPatchOperation } from './filesystem-executor.js';
+import { formatSyntheticToolErrorText } from './tool-runtime.js';
+
+export interface AppliedPatchOperationFact {
+  readonly type: ApplyPatchOperation['type'];
+  readonly path: string;
+}
+
+export type ApplyPatchBatchResult =
+  | {
+      readonly status: 'completed';
+      readonly applied: readonly AppliedPatchOperationFact[];
+      readonly output: string;
+    }
+  | {
+      readonly status: 'failed';
+      readonly applied: readonly AppliedPatchOperationFact[];
+      readonly failed: AppliedPatchOperationFact;
+      readonly error: string;
+    };
+
+function operationFact(operation: ApplyPatchOperation): AppliedPatchOperationFact {
+  return { type: operation.type, path: operation.path };
+}
+
+/** Execute one parsed patch in order while preserving the exact committed prefix. */
+export async function executeApplyPatchOperations(
+  operations: readonly ApplyPatchOperation[],
+  apply: (operation: ApplyPatchOperation) => Promise<void>,
+): Promise<ApplyPatchBatchResult> {
+  const applied: AppliedPatchOperationFact[] = [];
+  for (const operation of operations) {
+    try {
+      await apply(operation);
+      applied.push(operationFact(operation));
+    } catch (error) {
+      const failed = operationFact(operation);
+      const appliedText = applied.length
+        ? ` Applied before failure: ${applied.map((item) => `${item.type} ${item.path}`).join(', ')}.`
+        : ' No file operation was applied.';
+      return {
+        status: 'failed',
+        applied,
+        failed,
+        error: formatSyntheticToolErrorText(
+          `ApplyPatch failed on ${failed.type} ${failed.path} after ${applied.length} of ${operations.length} operations.${appliedText} ${error instanceof Error ? error.message : String(error)}`,
+        ),
+      };
+    }
+  }
+  return {
+    status: 'completed',
+    applied,
+    output: `Applied ${applied.length} file operation${applied.length === 1 ? '' : 's'}.`,
+  };
+}

--- a/packages/runtime/src/apply-patch-batch.ts
+++ b/packages/runtime/src/apply-patch-batch.ts
@@ -17,6 +17,12 @@ export type ApplyPatchBatchResult =
       readonly applied: readonly AppliedPatchOperationFact[];
       readonly failed: AppliedPatchOperationFact;
       readonly error: string;
+    }
+  | {
+      readonly status: 'failed';
+      readonly applied: readonly AppliedPatchOperationFact[];
+      readonly stoppedBefore: AppliedPatchOperationFact;
+      readonly error: string;
     };
 
 function operationFact(operation: ApplyPatchOperation): AppliedPatchOperationFact {
@@ -27,9 +33,24 @@ function operationFact(operation: ApplyPatchOperation): AppliedPatchOperationFac
 export async function executeApplyPatchOperations(
   operations: readonly ApplyPatchOperation[],
   apply: (operation: ApplyPatchOperation) => Promise<void>,
+  abortSignal?: AbortSignal,
 ): Promise<ApplyPatchBatchResult> {
   const applied: AppliedPatchOperationFact[] = [];
   for (const operation of operations) {
+    if (abortSignal?.aborted) {
+      const stoppedBefore = operationFact(operation);
+      const appliedText = applied.length
+        ? ` Applied before stop: ${applied.map((item) => `${item.type} ${item.path}`).join(', ')}.`
+        : ' No file operation was applied.';
+      return {
+        status: 'failed',
+        applied,
+        stoppedBefore,
+        error: formatSyntheticToolErrorText(
+          `ApplyPatch stopped before ${stoppedBefore.type} ${stoppedBefore.path} after ${applied.length} of ${operations.length} operations.${appliedText}`,
+        ),
+      };
+    }
     try {
       await apply(operation);
       applied.push(operationFact(operation));

--- a/packages/runtime/src/apply-patch-profile.ts
+++ b/packages/runtime/src/apply-patch-profile.ts
@@ -87,6 +87,67 @@ export function normalizeApplyPatchReplayInput(
   }
 }
 
+/** Preserve an executed multi-file patch when the target wire cannot replay one call for it. */
+export function applyPatchReplayFactText(
+  input: unknown,
+  output: unknown,
+  isError: boolean,
+): string | null {
+  if (typeof input !== 'string') return null;
+  let operations: ApplyPatchOperation[];
+  try {
+    operations = parseCodexV4aPatch(input);
+  } catch {
+    return null;
+  }
+  const recorded = recordedAppliedOperations(output);
+  const applied = recorded ?? (isError ? [] : operations.map(operationFact));
+  const facts = applied.map((item) => `${item.type} ${item.path}`).join(', ');
+  if (!isError) {
+    return `ApplyPatch completed ${applied.length} file operation${applied.length === 1 ? '' : 's'}: ${facts}.`;
+  }
+  const attempted = operations.map(operationFact);
+  const attemptedFacts = attempted.map((item) => `${item.type} ${item.path}`).join(', ');
+  return applied.length > 0
+    ? `ApplyPatch failed after applying ${applied.length} file operation${applied.length === 1 ? '' : 's'}: ${facts}.`
+    : `ApplyPatch failed while attempting ${attempted.length} file operation${attempted.length === 1 ? '' : 's'}: ${attemptedFacts}. No applied operation was recorded.`;
+}
+
+function operationFact(operation: ApplyPatchOperation): {
+  type: ApplyPatchOperation['type'];
+  path: string;
+} {
+  return { type: operation.type, path: operation.path };
+}
+
+function recordedAppliedOperations(
+  output: unknown,
+): Array<{ type: ApplyPatchOperation['type']; path: string }> | null {
+  const candidate = unwrapToolResultValue(output);
+  if (!candidate || typeof candidate !== 'object') return null;
+  const applied = (candidate as { applied?: unknown }).applied;
+  if (!Array.isArray(applied)) return null;
+  const facts: Array<{ type: ApplyPatchOperation['type']; path: string }> = [];
+  for (const item of applied) {
+    if (!item || typeof item !== 'object') return null;
+    const { type, path } = item as { type?: unknown; path?: unknown };
+    if (
+      (type !== 'create_file' && type !== 'update_file' && type !== 'delete_file') ||
+      typeof path !== 'string'
+    ) {
+      return null;
+    }
+    facts.push({ type, path });
+  }
+  return facts;
+}
+
+function unwrapToolResultValue(output: unknown): unknown {
+  if (!output || typeof output !== 'object') return output;
+  const record = output as { kind?: unknown; value?: unknown };
+  return record.kind === 'json' ? record.value : output;
+}
+
 function structuredApplyPatchOperation(input: unknown): ApplyPatchOperation | null {
   if (!input || typeof input !== 'object') return null;
   const operation = (input as { operation?: unknown }).operation;

--- a/packages/runtime/src/apply-patch-profile.ts
+++ b/packages/runtime/src/apply-patch-profile.ts
@@ -1,8 +1,8 @@
-import type { ProviderType } from '@maka/core/llm-connections';
+import type { ApplyPatchProtocol } from '@maka/core/llm-connections';
 import { z } from 'zod';
-import type { ModelRuntimeWire } from './model-runtime.js';
 import { parseCodexV4aPatch, serializeCodexV4aOperation } from './codex-v4a-patch.js';
 import type { ApplyPatchOperation } from './filesystem-executor.js';
+import type { ModelRuntimeWire } from './model-runtime.js';
 import { openAiModelSupportsApplyPatch } from './openai-apply-patch.js';
 import type { MakaTool } from './tool-runtime.js';
 
@@ -11,19 +11,8 @@ export type ApplyPatchProfile =
   | { readonly kind: 'codex-v4a-freeform' };
 
 export interface ApplyPatchProfileRuntime {
-  readonly providerType: ProviderType;
   readonly wire: ModelRuntimeWire;
-  /** Resolved endpoint. Omitted only by catalog-only callers that assume the provider default. */
-  readonly baseUrl?: string;
-}
-
-function usesOfficialEndpoint(baseUrl: string | undefined, hostname: string): boolean {
-  if (baseUrl === undefined) return true;
-  try {
-    return new URL(baseUrl).hostname.toLowerCase() === hostname;
-  } catch {
-    return false;
-  }
+  readonly applyPatchProtocol?: ApplyPatchProtocol;
 }
 
 /** Resolve the exact provider/model/wire contract; unknown combinations fail closed. */
@@ -31,20 +20,12 @@ export function resolveApplyPatchProfile(
   runtime: ApplyPatchProfileRuntime,
   modelId: string,
 ): ApplyPatchProfile | null {
-  if (runtime.wire !== 'openai-responses') return null;
+  if (runtime.wire !== 'openai-responses' || !runtime.applyPatchProtocol) return null;
   const id = modelId.trim().toLowerCase();
-  if (
-    runtime.providerType === 'openai' &&
-    usesOfficialEndpoint(runtime.baseUrl, 'api.openai.com') &&
-    openAiModelSupportsApplyPatch(id)
-  ) {
+  if (runtime.applyPatchProtocol === 'openai-structured' && openAiModelSupportsApplyPatch(id)) {
     return { kind: 'openai-structured' };
   }
-  if (
-    runtime.providerType === 'deepseek' &&
-    usesOfficialEndpoint(runtime.baseUrl, 'api.deepseek.com') &&
-    id === 'deepseek-v4-flash'
-  ) {
+  if (runtime.applyPatchProtocol === 'codex-v4a-freeform' && id === 'deepseek-v4-flash') {
     return { kind: 'codex-v4a-freeform' };
   }
   return null;

--- a/packages/runtime/src/apply-patch-profile.ts
+++ b/packages/runtime/src/apply-patch-profile.ts
@@ -1,0 +1,123 @@
+import type { ProviderType } from '@maka/core/llm-connections';
+import { z } from 'zod';
+import type { ModelRuntimeWire } from './model-runtime.js';
+import { parseCodexV4aPatch, serializeCodexV4aOperation } from './codex-v4a-patch.js';
+import type { ApplyPatchOperation } from './filesystem-executor.js';
+import { openAiModelSupportsApplyPatch } from './openai-apply-patch.js';
+import type { MakaTool } from './tool-runtime.js';
+
+export type ApplyPatchProfile =
+  | { readonly kind: 'openai-structured' }
+  | { readonly kind: 'codex-v4a-freeform' };
+
+export interface ApplyPatchProfileRuntime {
+  readonly providerType: ProviderType;
+  readonly wire: ModelRuntimeWire;
+  /** Resolved endpoint. Omitted only by catalog-only callers that assume the provider default. */
+  readonly baseUrl?: string;
+}
+
+function usesOfficialEndpoint(baseUrl: string | undefined, hostname: string): boolean {
+  if (baseUrl === undefined) return true;
+  try {
+    return new URL(baseUrl).hostname.toLowerCase() === hostname;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve the exact provider/model/wire contract; unknown combinations fail closed. */
+export function resolveApplyPatchProfile(
+  runtime: ApplyPatchProfileRuntime,
+  modelId: string,
+): ApplyPatchProfile | null {
+  if (runtime.wire !== 'openai-responses') return null;
+  const id = modelId.trim().toLowerCase();
+  if (
+    runtime.providerType === 'openai' &&
+    usesOfficialEndpoint(runtime.baseUrl, 'api.openai.com') &&
+    openAiModelSupportsApplyPatch(id)
+  ) {
+    return { kind: 'openai-structured' };
+  }
+  if (
+    runtime.providerType === 'deepseek' &&
+    usesOfficialEndpoint(runtime.baseUrl, 'api.deepseek.com') &&
+    id === 'deepseek-v4-flash'
+  ) {
+    return { kind: 'codex-v4a-freeform' };
+  }
+  return null;
+}
+
+/** Project one verified profile into an exclusive model-facing editing surface. */
+export function routeApplyPatchTools(
+  tools: readonly MakaTool[],
+  profile: ApplyPatchProfile | null,
+): MakaTool[] {
+  const applyPatchTool = tools.find((tool) => tool.providerTool?.kind === 'openai-apply-patch');
+  if (!applyPatchTool) return [...tools];
+  if (!profile) return tools.filter((tool) => tool !== applyPatchTool);
+
+  return tools
+    .filter((tool) => tool.name !== 'Write' && tool.name !== 'Edit')
+    .map((tool) => {
+      if (tool !== applyPatchTool || profile.kind !== 'codex-v4a-freeform') return tool;
+      return {
+        ...tool,
+        parameters: z.string(),
+        providerTool: { kind: 'openai-custom-apply-patch' as const },
+        toModelOutput: ({ output }) => ({
+          type: 'text' as const,
+          value: freeformApplyPatchResultText(output),
+        }),
+      };
+    });
+}
+
+export function freeformApplyPatchResultText(output: unknown): string {
+  if (typeof output === 'string') return output;
+  if (output && typeof output === 'object') {
+    const record = output as { output?: unknown; error?: unknown };
+    if (typeof record.output === 'string') return record.output;
+    if (typeof record.error === 'string') return record.error;
+  }
+  return 'ApplyPatch completed.';
+}
+
+/** Convert historical calls when a session switches between the two patch contracts. */
+export function normalizeApplyPatchReplayInput(
+  profile: ApplyPatchProfile | null,
+  toolCallId: string,
+  input: unknown,
+): unknown | null {
+  if (!profile) return input;
+  if (profile.kind === 'codex-v4a-freeform') {
+    if (typeof input === 'string') return input;
+    const operation = structuredApplyPatchOperation(input);
+    return operation ? serializeCodexV4aOperation(operation) : null;
+  }
+  if (typeof input !== 'string') return input;
+  try {
+    const operations = parseCodexV4aPatch(input);
+    return operations.length === 1 ? { callId: toolCallId, operation: operations[0] } : null;
+  } catch {
+    return null;
+  }
+}
+
+function structuredApplyPatchOperation(input: unknown): ApplyPatchOperation | null {
+  if (!input || typeof input !== 'object') return null;
+  const operation = (input as { operation?: unknown }).operation;
+  if (!operation || typeof operation !== 'object') return null;
+  const candidate = operation as { type?: unknown; path?: unknown; diff?: unknown };
+  if (typeof candidate.path !== 'string' || /[\r\n]/.test(candidate.path)) return null;
+  if (candidate.type === 'delete_file') return { type: candidate.type, path: candidate.path };
+  if (
+    (candidate.type === 'create_file' || candidate.type === 'update_file') &&
+    typeof candidate.diff === 'string'
+  ) {
+    return { type: candidate.type, path: candidate.path, diff: candidate.diff };
+  }
+  return null;
+}

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -29,6 +29,7 @@ import { bashToolResultToModelOutput } from './bash-model-output.js';
 import { fileWriteToolResultToModelOutput } from './file-tool-model-output.js';
 import { openAiApplyPatchInputSchema } from './openai-apply-patch.js';
 import { parseCodexV4aPatch } from './codex-v4a-patch.js';
+import { executeApplyPatchOperations } from './apply-patch-batch.js';
 import {
   buildManagedBashTool,
   buildStopBackgroundTaskTool,
@@ -314,13 +315,9 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         return await filesystem.applyPatch({ operation: input.operation, ...filesystemCall(ctx) });
       }
       const operations = parseCodexV4aPatch(input);
-      for (const operation of operations) {
+      return await executeApplyPatchOperations(operations, async (operation) => {
         await filesystem.applyPatch({ operation, ...filesystemCall(ctx) });
-      }
-      return {
-        status: 'completed' as const,
-        output: `Applied ${operations.length} file operation${operations.length === 1 ? '' : 's'}.`,
-      };
+      });
     },
   } satisfies MakaTool;
   const tools: MakaTool[] = [

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -315,9 +315,13 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         return await filesystem.applyPatch({ operation: input.operation, ...filesystemCall(ctx) });
       }
       const operations = parseCodexV4aPatch(input);
-      return await executeApplyPatchOperations(operations, async (operation) => {
-        await filesystem.applyPatch({ operation, ...filesystemCall(ctx) });
-      });
+      return await executeApplyPatchOperations(
+        operations,
+        async (operation) => {
+          await filesystem.applyPatch({ operation, ...filesystemCall(ctx) });
+        },
+        ctx.abortSignal,
+      );
     },
   } satisfies MakaTool;
   const tools: MakaTool[] = [

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -28,6 +28,7 @@ import {
 import { bashToolResultToModelOutput } from './bash-model-output.js';
 import { fileWriteToolResultToModelOutput } from './file-tool-model-output.js';
 import { openAiApplyPatchInputSchema } from './openai-apply-patch.js';
+import { parseCodexV4aPatch } from './codex-v4a-patch.js';
 import {
   buildManagedBashTool,
   buildStopBackgroundTaskTool,
@@ -304,12 +305,23 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
     name: 'apply_patch',
     activityKind: 'edit',
     categoryHint: 'file_write',
-    description: 'Apply one OpenAI V4A file operation.',
+    description: 'Apply one or more file changes using the selected provider patch protocol.',
     parameters: openAiApplyPatchInputSchema,
     providerTool: { kind: 'openai-apply-patch' },
     executionFacts,
-    impl: async ({ operation }, ctx) =>
-      await filesystem.applyPatch({ operation, ...filesystemCall(ctx) }),
+    impl: async (input, ctx) => {
+      if (typeof input !== 'string') {
+        return await filesystem.applyPatch({ operation: input.operation, ...filesystemCall(ctx) });
+      }
+      const operations = parseCodexV4aPatch(input);
+      for (const operation of operations) {
+        await filesystem.applyPatch({ operation, ...filesystemCall(ctx) });
+      }
+      return {
+        status: 'completed' as const,
+        output: `Applied ${operations.length} file operation${operations.length === 1 ? '' : 's'}.`,
+      };
+    },
   } satisfies MakaTool;
   const tools: MakaTool[] = [
     ...bashTools,

--- a/packages/runtime/src/codex-v4a-patch.ts
+++ b/packages/runtime/src/codex-v4a-patch.ts
@@ -58,7 +58,7 @@ export function parseCodexV4aPatch(input: string): ApplyPatchOperation[] {
       if (body.some((line) => !line.startsWith('+'))) {
         throw new CodexV4aPatchError(`ApplyPatch Add for ${path} must prefix every line with +.`);
       }
-      operations.push({ type: 'create_file', path, diff: body.join('\n') });
+      operations.push({ type: 'create_file', path, diff: [...body, '+'].join('\n') });
       continue;
     }
     if (body.some((line) => !isUpdateDiffLine(line))) {

--- a/packages/runtime/src/codex-v4a-patch.ts
+++ b/packages/runtime/src/codex-v4a-patch.ts
@@ -1,0 +1,85 @@
+import type { ApplyPatchOperation } from './filesystem-executor.js';
+
+export class CodexV4aPatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CodexV4aPatchError';
+  }
+}
+
+const FILE_HEADER = /^\*\*\* (Add|Delete|Update) File: (.+)$/;
+
+function isUpdateDiffLine(line: string): boolean {
+  return (
+    line === '@@' || line.startsWith('@@ ') || line === '*** End of File' || /^[ +\-]/.test(line)
+  );
+}
+
+/** Parse the client-executed subset of the Codex V4A envelope into existing operations. */
+export function parseCodexV4aPatch(input: string): ApplyPatchOperation[] {
+  const lines = input.replaceAll('\r\n', '\n').split('\n');
+  if (lines.at(-1) === '') lines.pop();
+  if (lines.shift() !== '*** Begin Patch' || lines.pop() !== '*** End Patch') {
+    throw new CodexV4aPatchError(
+      'ApplyPatch input must start with *** Begin Patch and end with *** End Patch.',
+    );
+  }
+
+  const operations: ApplyPatchOperation[] = [];
+  for (let index = 0; index < lines.length; ) {
+    const header = FILE_HEADER.exec(lines[index] ?? '');
+    if (!header) {
+      throw new CodexV4aPatchError(`Invalid ApplyPatch file header at line ${index + 2}.`);
+    }
+    const [, action, rawPath] = header;
+    const path = rawPath?.trim();
+    if (!path) throw new CodexV4aPatchError('ApplyPatch file paths cannot be empty.');
+    index += 1;
+
+    if (action === 'Delete') {
+      operations.push({ type: 'delete_file', path });
+      continue;
+    }
+    if (action === 'Update' && lines[index]?.startsWith('*** Move to:')) {
+      throw new CodexV4aPatchError(
+        'ApplyPatch Move is not supported; add the destination and delete the source instead.',
+      );
+    }
+
+    const body: string[] = [];
+    while (index < lines.length && !FILE_HEADER.test(lines[index] ?? '')) {
+      body.push(lines[index] ?? '');
+      index += 1;
+    }
+    if (body.length === 0) {
+      throw new CodexV4aPatchError(`ApplyPatch ${action} for ${path} has no diff.`);
+    }
+    if (action === 'Add') {
+      if (body.some((line) => !line.startsWith('+'))) {
+        throw new CodexV4aPatchError(`ApplyPatch Add for ${path} must prefix every line with +.`);
+      }
+      operations.push({ type: 'create_file', path, diff: body.join('\n') });
+      continue;
+    }
+    if (body.some((line) => !isUpdateDiffLine(line))) {
+      throw new CodexV4aPatchError(`ApplyPatch Update for ${path} contains an invalid diff line.`);
+    }
+    operations.push({ type: 'update_file', path, diff: body.join('\n') });
+  }
+
+  if (operations.length === 0) {
+    throw new CodexV4aPatchError('ApplyPatch input must contain at least one file operation.');
+  }
+  return operations;
+}
+
+export function serializeCodexV4aOperation(operation: ApplyPatchOperation): string {
+  const header =
+    operation.type === 'create_file'
+      ? `*** Add File: ${operation.path}`
+      : operation.type === 'delete_file'
+        ? `*** Delete File: ${operation.path}`
+        : `*** Update File: ${operation.path}`;
+  const body = operation.type === 'delete_file' ? '' : `\n${operation.diff.replace(/\n$/, '')}`;
+  return `*** Begin Patch\n${header}${body}\n*** End Patch`;
+}

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -60,7 +60,10 @@ import {
   OPENAI_RESPONSES_LANE_HEADER,
   type OpenAiResponsesTransportState,
 } from './openai-responses-websocket.js';
-import { openAiApplyPatchProviderTool } from './openai-apply-patch.js';
+import {
+  codexV4aApplyPatchProviderTool,
+  openAiApplyPatchProviderTool,
+} from './openai-apply-patch.js';
 
 /**
  * Build an ai-sdk LanguageModel from a single input object.
@@ -817,6 +820,8 @@ function compileProviderTool(
   switch (tool.kind) {
     case 'openai-apply-patch':
       return openAiApplyPatchProviderTool;
+    case 'openai-custom-apply-patch':
+      return codexV4aApplyPatchProviderTool;
     case 'openai-web-search':
       return openai.tools.webSearch({
         ...(tool.searchContextSize ? { searchContextSize: tool.searchContextSize } : {}),

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -6,6 +6,7 @@ import {
   type ProviderType,
 } from '@maka/core/llm-connections';
 import { lookupModelProviderOverride, openAiAdapterApiProtocol } from '@maka/core/model-metadata';
+import { resolveApplyPatchProfile, type ApplyPatchProfile } from './apply-patch-profile.js';
 
 export type ModelRuntimeWire =
   | 'anthropic-messages'
@@ -30,6 +31,8 @@ export interface ResolvedModelRuntime {
   wire: ModelRuntimeWire;
   /** Durable reasoning replay semantics carried by that wire. */
   reasoningReplay: ReasoningReplayContract;
+  /** Effective ApplyPatch contract after provider, model, and request wire are resolved. */
+  applyPatchProfile: ApplyPatchProfile | null;
 }
 
 export interface ModelRuntimeConnection {
@@ -63,7 +66,7 @@ export function resolveModelRuntime(
       `Kimi Coding Plan protocol must be openai-chat or anthropic-messages, received ${apiProtocol}`,
     );
   }
-  const adapter =
+  const adapter: ProviderRuntimeAdapter =
     connection.providerType === 'kimi-coding-plan' && apiProtocol === 'openai-chat'
       ? ({
           kind: 'openai-compatible',
@@ -87,6 +90,10 @@ export function resolveModelRuntime(
     ...(apiProtocol ? { apiProtocol } : {}),
     wire,
     reasoningReplay: reasoningReplayContract(adapter, wire),
+    applyPatchProfile: resolveApplyPatchProfile(
+      { wire, applyPatchProtocol: adapter.applyPatchProtocol },
+      modelId,
+    ),
   };
 }
 

--- a/packages/runtime/src/openai-apply-patch.ts
+++ b/packages/runtime/src/openai-apply-patch.ts
@@ -1,6 +1,7 @@
 import { openai } from '@ai-sdk/openai';
 
 export const openAiApplyPatchProviderTool = openai.tools.applyPatch({});
+export const codexV4aApplyPatchProviderTool = openai.tools.customTool({});
 const inputSchema = openAiApplyPatchProviderTool.inputSchema;
 export const openAiApplyPatchInputSchema =
   typeof inputSchema === 'function' ? inputSchema() : inputSchema;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -2514,11 +2514,15 @@ export class SessionManager {
     const definition = resolvedPreset
       ? requireBuiltinAgentDefinitionByProfile(resolvedPreset.profile)
       : requireBuiltinAgentDefinition(input.agentId!);
+    const availableChildTools = await this.childToolsForSession(input.source.sessionId);
     assertAgentDefinitionRunnable({
       definition,
-      tools: await this.childToolsForSession(input.source.sessionId),
+      tools: availableChildTools,
       worktreeChildExecutorAvailable: await this.isWorktreeChildExecutorAvailable(parentHeader),
     });
+    const resolvedToolNames = buildToolsForAgentDefinition(availableChildTools, definition).map(
+      (tool) => tool.name,
+    );
     const childPermissionMode =
       parentHeader.permissionMode === 'bypass' ? 'bypass' : definition.permissionMode;
 
@@ -2543,7 +2547,7 @@ export class SessionManager {
         profile: definition.profile,
         workspace: definition.contract.workspace,
         permissionMode: childPermissionMode,
-        toolNames: [...definition.tools],
+        toolNames: resolvedToolNames,
         categoryPolicy: {},
         systemPrompt: definition.systemPrompt,
         ...(resolvedPreset
@@ -2618,7 +2622,7 @@ export class SessionManager {
           profile: definition.profile,
           ...(resolvedPreset ? { presetId: resolvedPreset.id } : {}),
           systemPrompt: definition.systemPrompt,
-          toolNames: [...definition.tools],
+          toolNames: resolvedToolNames,
           categoryPolicy: {},
         },
         subagentSpawn: {
@@ -3105,6 +3109,9 @@ export class SessionManager {
       tools: availableChildTools,
       worktreeChildExecutorAvailable: await this.isWorktreeChildExecutorAvailable(parentHeader),
     });
+    const resolvedToolNames = buildToolsForAgentDefinition(availableChildTools, definition).map(
+      (tool) => tool.name,
+    );
 
     const proposedTurnId = input.turnId ?? this.deps.newId();
     const proposedRunId = input.runId ?? this.deps.newId();
@@ -3146,7 +3153,7 @@ export class SessionManager {
           profile: definition.profile,
           ...(input.resolvedPreset ? { presetId: input.resolvedPreset.id } : {}),
           systemPrompt: definition.systemPrompt,
-          toolNames: [...definition.tools],
+          toolNames: resolvedToolNames,
           categoryPolicy: {},
         },
         subagentSpawn: {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -129,7 +129,11 @@ export interface MakaTool<P = any, R = unknown> {
    * client-executed tools such as ApplyPatch still settle through ToolRuntime.
    */
   providerTool?: {
-    readonly kind: 'openai-apply-patch' | 'openai-web-search' | 'anthropic-web-search-20250305';
+    readonly kind:
+      | 'openai-apply-patch'
+      | 'openai-custom-apply-patch'
+      | 'openai-web-search'
+      | 'anthropic-web-search-20250305';
     readonly searchContextSize?: 'low' | 'medium' | 'high';
     readonly maxUses?: number;
   };


### PR DESCRIPTION
## Summary

- Select ApplyPatch from the resolved provider, model, and Responses wire contract without adding a user-facing setting.
- Preserve native structured ApplyPatch for documented OpenAI models and add DeepSeek V4 Flash custom/freeform ApplyPatch using the Codex V4A envelope.
- Keep the model-facing editing surface exclusive: supported profiles receive ApplyPatch, while all other models retain Write/Edit; child implementation agents persist the exact runtime tool inventory behind one `file_edit` alternative contract.
- Parse Add, Update, and Delete through the existing filesystem executor, preserve Add-file trailing newlines, reject unsupported Move before writes, report any applied prefix when a later operation fails, and stop before starting another operation after cancellation.
- Preserve every completed editing fact when session history crosses between structured and multi-file freeform profiles, including multiple patch calls from one provider step.
- Declare the wire protocol on provider adapters so compatible relays can opt in explicitly instead of being inferred from a hostname or generic Responses support.

Refs #2601

## Verification

- `npm run build --workspace @maka/core`
- `npm run build --workspace @maka/runtime`
- 591 focused tests passed across provider contracts, ApplyPatch routing/execution/replay, Responses wire contracts, child-agent tool resolution, durable snapshots, and SessionManager integration.
- Biome checks passed for all 20 changed TypeScript files.
- Full repository test suite not run locally; CI owns full coverage.

## Review focus

- Confirm the runtime-derived provider/model/wire contract remains the only authority and no UI/config toggle is introduced.
- Confirm OpenAI structured, DeepSeek custom/freeform, replay, and filesystem execution contracts remain separated at the wire boundary.
- Confirm truthful partial-failure and cancellation reporting preserve facts without claiming filesystem transactions.
- Confirm child availability, runtime tool inventory, durable snapshot, activation, and resume consume the same resolved tool set.
- Challenge whether every new abstraction and test is necessary for the issue-confirmed outcome.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
