### PR TITLE
chore(release): prepare 0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,53 @@
 
 ## Unreleased
 
+## 0.1.9 - 2026-08-09
+
+### Highlights
+
+- Completed the Runtime Host M5 production cutover (#2420), then established
+  the local standalone service (#2583), authenticated WebSocket access
+  (#2591), and Host-owned project catalog authority (#2603).
+- Added external session import end to end: the shared foundation (#2500), a
+  Codex session adapter (#2502), and the Desktop import flow (#2507).
+- Shipped Visual System 2.0 from its foundations through the full theme sweep
+  and detail polish (#2525, #2536, #2538), aligned high-traffic chrome with
+  Astryx primitives (#2580), and closed the remaining elevation, rhythm, and
+  primitive review debt (#2593).
+- Made task submission readiness a shared product contract (#2498), exposed it
+  in Desktop (#2519), added CLI preflight (#2524), and consumed the readiness
+  result at submission time (#2523).
+- Expanded implementation-agent capabilities with portable terminal input
+  (#2526), semantic terminal mouse input (#2533), interactive shell controls
+  (#2561), and OpenAI native ApplyPatch (#2532).
+- Replaced the CodeMode `Self` evaluator with QuickJS (#2549).
+
+### Reliability and developer experience
+
+- Runtime recovery now handles idle and incomplete provider streams (#2535,
+  #2604), preserves compaction projection after overflow (#2602), retains
+  imported session context (#2579), and keeps full access available in Plan
+  mode (#2581).
+- Stabilized Runtime Host session lifecycle races (#2548), added client request
+  backpressure (#2539), made task refusals actionable (#2527), recovered CLI
+  sessions after workspace moves (#2531), and kept renamed Claude model ids
+  stable across catalog refreshes (#2482).
+- Matured the generated-files workbar (#2506), kept generated files under user
+  control (#2585), restored composer drafts across remounts (#2584), exposed
+  diagnostics from error toasts (#2540), and added per-connection model request
+  customization (#2565).
+- Cut CI wall-clock time with impact gates and a single end-to-end job (#2589),
+  reduced Storybook to render smoke (#2582), and expanded Windows process,
+  named-pipe, artifact, workspace, and crash-recovery coverage.
+
+### Distribution
+
+- Ships for Apple Silicon macOS as a signed and notarized DMG and ZIP, and for
+  Windows x64 as an unsigned NSIS installer and ZIP, built and verified in the
+  same release run.
+- The bundled Computer Use skill ships with the app, but the Computer Use
+  executor remains excluded from this release.
+
 ## 0.1.8 - 2026-08-08
 
 ### Highlights

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@maka/desktop",
   "productName": "Maka",
   "description": "A local-first agent workspace built for real work.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "author": "The Maka Authors",
   "license": "Apache-2.0",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maka",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maka",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -38,7 +38,7 @@
     },
     "apps/desktop": {
       "name": "@maka/desktop",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@astryxdesign/core": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maka",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "license": "Apache-2.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Summary

Bumps the version to 0.1.9 and records the release in the changelog (99 commits since v0.1.8).

Highlights include Runtime Host M5 and standalone service foundations, authenticated WebSocket access, Host-owned project catalog authority, external session import with Codex support, Visual System 2.0 and Astryx alignment, task submission readiness, stronger runtime recovery, native ApplyPatch, terminal controls, and the QuickJS CodeMode evaluator.

PR #2592 is intentionally not included in this release.

After merge, dispatch the `Release desktop` workflow against `main`. It reads the version, reserves `v0.1.9`, builds and verifies macOS arm64 and Windows x64 artifacts, and creates one draft GitHub Release for acceptance and publication.

## Verification

Per release-owner direction, local tests were not rerun for this version-only prepare PR. CI does not need to be awaited before handing off the PR.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No