### PR TITLE
feat(runtime-host): preserve capability providers across reconnect

### DIFF
--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -19,6 +19,7 @@ import {
   buildMcpTools,
   type BotIncomingMessage,
 } from "@maka/runtime";
+import { loadOrCreateRuntimeHostClientInstanceId } from "@maka/runtime-host/client";
 import { McpClientManager } from "@maka/mcp";
 import {
   createSettingsStore,
@@ -129,6 +130,9 @@ await resolveShellEnv();
 
 const buildInfo = resolveBuildInfo(app.isPackaged, app.getAppPath());
 const userDataDir = app.getPath("userData");
+const runtimeHostClientInstanceId = await loadOrCreateRuntimeHostClientInstanceId(
+  join(userDataDir, "runtime-host-client.json"),
+);
 const e2eFixture = resolveDesktopE2eFixture();
 const useBotOnboardingFixture =
   e2eFixture?.scenario === "settings-bots" ||
@@ -367,6 +371,7 @@ const sessionCopyOwnerProcessId = randomUUID();
 owner = await startRuntimeHostDesktopOwner(
   {
     rootPath: workspaceRoot,
+    clientInstanceId: runtimeHostClientInstanceId,
     candidateEntrypoint: new URL(
       import.meta.resolve(
         isE2e

--- a/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
@@ -8,13 +8,14 @@ import {
 } from '../server/client-capability-coordinator.js';
 import type { ClientCapabilityConnection } from '../server/client-capability-service.js';
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
+import { clientCapabilityConnectionIdentity } from './fixtures/client-capability.js';
 
 describe('Host Client Capability coordinator', () => {
   test('freezes active snapshots across replacement and releases stale registrations', async () => {
     const sent: unknown[] = [];
     const coordinator = createCoordinator();
     let connection!: ClientCapabilityConnection;
-    connection = coordinator.attachConnection('connection-a', {
+    connection = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
       send: async (frame) => {
         sent.push(frame);
         if (frame.kind !== 'client.capability.call') return;
@@ -80,8 +81,13 @@ describe('Host Client Capability coordinator', () => {
 
   test('prefers the initiating provider and reports otherwise ambiguous selection', async () => {
     const coordinator = createCoordinator();
-    const first = coordinator.attachConnection('connection-a', { send: async () => {} });
-    const second = coordinator.attachConnection('connection-b', { send: async () => {} });
+    const first = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
+      send: async () => {},
+    });
+    const second = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-b'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-a', 'registration-a', 'first');
     assert.deepEqual(await coordinator.bindSession('sole-session', 'observer'), { ok: true });
     const sole = coordinator.snapshotForSession('sole-session');
@@ -106,7 +112,10 @@ describe('Host Client Capability coordinator', () => {
 
   test('previews the initiating provider without persisting a Session binding', async () => {
     const coordinator = createCoordinator();
-    const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+    const connection = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-a'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
 
     assert.equal(coordinator.snapshotForSession('session-a'), undefined);
@@ -133,7 +142,10 @@ describe('Host Client Capability coordinator', () => {
 
   test('holds one registry view through preview and rejects a stale commit', async () => {
     const coordinator = createCoordinator();
-    const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+    const connection = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-a'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
     let markPreviewStarted!: () => void;
     const previewStarted = new Promise<void>((resolve) => {
@@ -189,7 +201,10 @@ describe('Host Client Capability coordinator', () => {
 
   test('serializes connection release behind an active binding preview', async () => {
     const coordinator = createCoordinator();
-    const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+    const connection = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-a'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
     let markPreviewStarted!: () => void;
     const previewStarted = new Promise<void>((resolve) => {
@@ -229,8 +244,13 @@ describe('Host Client Capability coordinator', () => {
 
   test('composes disjoint contracts from multiple providers', async () => {
     const coordinator = createCoordinator();
-    const first = coordinator.attachConnection('connection-a', { send: async () => {} });
-    const second = coordinator.attachConnection('connection-b', { send: async () => {} });
+    const first = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
+      send: async () => {},
+    });
+    const second = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-b'),
+      { send: async () => {} },
+    );
     await replace(
       coordinator,
       'connection-a',
@@ -267,28 +287,87 @@ describe('Host Client Capability coordinator', () => {
     await coordinator.close();
   });
 
-  test('rebinds a lost Session contract to the sole compatible provider', async () => {
+  test('rebinds a lost Session contract only to the same authenticated Client identity', async () => {
     const coordinator = createCoordinator();
-    const first = coordinator.attachConnection('connection-a', { send: async () => {} });
+    const first = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-a', 'client-a', 'principal-a'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
     assert.deepEqual(await coordinator.bindSession('session-a', 'connection-a'), { ok: true });
-    first.close();
+    await first.close();
 
-    const replacement = coordinator.attachConnection('connection-b', { send: async () => {} });
+    const wrong = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-wrong', 'client-a', 'principal-wrong'),
+      { send: async () => {} },
+    );
+    await replace(coordinator, 'connection-wrong', 'registration-wrong', 'inspect');
+    assert.deepEqual(await coordinator.bindSession('session-a', 'connection-wrong'), {
+      ok: false,
+      message: 'A Session-bound Client Capability provider has not reconnected',
+    });
+
+    const replacement = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-b', 'client-a', 'principal-a'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-b', 'registration-b', 'inspect');
-    assert.deepEqual(await coordinator.bindSession('session-a', 'connection-a'), { ok: true });
+    assert.deepEqual(await coordinator.bindSession('session-a', 'connection-b'), { ok: true });
     const snapshot = coordinator.snapshotForSession('session-a');
     assert.deepEqual(snapshot?.registrationIds, ['registration-b']);
     snapshot?.release();
-    replacement.close();
+    await Promise.all([wrong.close(), replacement.close()]);
+    await coordinator.close();
+  });
+
+  test('a reconnecting Client takes over its provider lease before the stale connection closes', async () => {
+    const coordinator = createCoordinator();
+    const first = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-a', 'client-a', 'principal-a'),
+      { send: async () => {} },
+    );
+    await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
+    assert.deepEqual(await coordinator.bindSession('session-a', 'connection-a'), { ok: true });
+
+    const replacement = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-b', 'client-a', 'principal-a'),
+      { send: async () => {} },
+    );
+    await replace(coordinator, 'connection-b', 'registration-b', 'inspect');
+    assert.deepEqual(
+      await coordinator.handlers['client.capability.unregister'](
+        { registrationId: 'registration-a' },
+        connectionContext('connection-a'),
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'invalid_request',
+          message: 'Client Capability registration is not current',
+        },
+      },
+    );
+
+    await first.close();
+    assert.deepEqual(await coordinator.bindSession('session-a', 'connection-b'), { ok: true });
+    const snapshot = coordinator.snapshotForSession('session-a');
+    assert.deepEqual(snapshot?.registrationIds, ['registration-b']);
+    snapshot?.release();
+    await replacement.close();
     await coordinator.close();
   });
 
   test('forgets initiating Clients when replacement or unregister removes all call-affine offers', async () => {
     for (const mutation of ['replace', 'unregister'] as const) {
       const coordinator = createCoordinator();
-      const first = coordinator.attachConnection('connection-a', { send: async () => {} });
-      const second = coordinator.attachConnection('connection-b', { send: async () => {} });
+      const first = coordinator.attachConnection(
+        clientCapabilityConnectionIdentity('connection-a'),
+        { send: async () => {} },
+      );
+      const second = coordinator.attachConnection(
+        clientCapabilityConnectionIdentity('connection-b'),
+        { send: async () => {} },
+      );
       await replace(
         coordinator,
         'connection-a',
@@ -354,8 +433,13 @@ describe('Host Client Capability coordinator', () => {
     const coordinator = createCoordinator();
     assert.deepEqual(await coordinator.bindSession('session-a', 'connection-a'), { ok: true });
 
-    const first = coordinator.attachConnection('connection-a', { send: async () => {} });
-    const second = coordinator.attachConnection('connection-b', { send: async () => {} });
+    const first = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
+      send: async () => {},
+    });
+    const second = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-b'),
+      { send: async () => {} },
+    );
     await replace(
       coordinator,
       'connection-a',
@@ -390,7 +474,10 @@ describe('Host Client Capability coordinator', () => {
 
   test('retires Session bindings after explicit replacement and unregister', async () => {
     const coordinator = createCoordinator();
-    const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+    const connection = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-a'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
     assert.deepEqual(await coordinator.bindSession('session-a', 'connection-a'), { ok: true });
 
@@ -414,7 +501,7 @@ describe('Host Client Capability coordinator', () => {
   test('isolates call-affine ambiguity and freezes the initiating provider in a snapshot', async () => {
     const coordinator = createCoordinator();
     let first!: ClientCapabilityConnection;
-    first = coordinator.attachConnection('connection-a', {
+    first = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
       send: async (frame) => {
         if (frame.kind !== 'client.capability.call') return;
         first.accept({
@@ -429,7 +516,7 @@ describe('Host Client Capability coordinator', () => {
       },
     });
     let second!: ClientCapabilityConnection;
-    second = coordinator.attachConnection('connection-b', {
+    second = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-b'), {
       send: async (frame) => {
         if (frame.kind !== 'client.capability.call') return;
         second.accept({
@@ -492,8 +579,13 @@ describe('Host Client Capability coordinator', () => {
 
   test('omits ambiguous turn-affine contracts without creating a Session tombstone', async () => {
     const coordinator = createCoordinator();
-    const first = coordinator.attachConnection('connection-a', { send: async () => {} });
-    const second = coordinator.attachConnection('connection-b', { send: async () => {} });
+    const first = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
+      send: async () => {},
+    });
+    const second = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-b'),
+      { send: async () => {} },
+    );
     await replace(
       coordinator,
       'connection-a',
@@ -531,8 +623,13 @@ describe('Host Client Capability coordinator', () => {
 
   test('keeps load_tools group identity provider-independent and contract-sensitive', async () => {
     const coordinator = createCoordinator();
-    const first = coordinator.attachConnection('connection-a', { send: async () => {} });
-    const second = coordinator.attachConnection('connection-b', { send: async () => {} });
+    const first = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
+      send: async () => {},
+    });
+    const second = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-b'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-a', 'registration-a', 'shared_tool');
     await replace(coordinator, 'connection-b', 'registration-b', 'shared_tool');
 
@@ -543,7 +640,10 @@ describe('Host Client Capability coordinator', () => {
     first.close();
     second.close();
 
-    const changed = coordinator.attachConnection('connection-c', { send: async () => {} });
+    const changed = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-c'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-c', 'registration-c', 'shared_tool', '1');
     await coordinator.bindSession('session-c', 'connection-c');
     const changedSnapshot = coordinator.snapshotForSession('session-c');
@@ -562,7 +662,10 @@ describe('Host Client Capability coordinator', () => {
 
   test('bounds concurrent invocations for one provider connection', async () => {
     const coordinator = createCoordinator();
-    const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+    const connection = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-a'),
+      { send: async () => {} },
+    );
     await replace(coordinator, 'connection-a', 'registration-a', 'opaque');
     await coordinator.bindSession('session-a', 'connection-a');
     const snapshot = coordinator.snapshotForSession('session-a');
@@ -619,7 +722,7 @@ describe('Host Client Capability coordinator', () => {
     const receivedCall = new Promise<void>((resolve) => {
       callArrived = resolve;
     });
-    connection = coordinator.attachConnection('connection-a', {
+    connection = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
       send: async (frame) => {
         sent.push(frame);
         if (frame.kind !== 'client.capability.call') return;
@@ -769,13 +872,16 @@ describe('Host Client Capability coordinator', () => {
       const invocationArrived = new Promise<string>((resolve) => {
         resolveInvocation = resolve;
       });
-      const connection = coordinator.attachConnection('connection-a', {
-        send: async (frame) => {
-          if (frame.kind === 'client.capability.call') {
-            resolveInvocation(frame.invocationId);
-          }
+      const connection = coordinator.attachConnection(
+        clientCapabilityConnectionIdentity('connection-a'),
+        {
+          send: async (frame) => {
+            if (frame.kind === 'client.capability.call') {
+              resolveInvocation(frame.invocationId);
+            }
+          },
         },
-      });
+      );
       await replace(coordinator, 'connection-a', 'registration-a', 'opaque');
       await coordinator.bindSession('session-a', 'connection-a');
       const snapshot = coordinator.snapshotForSession('session-a');
@@ -806,7 +912,7 @@ async function assertLossClassification(
 ): Promise<void> {
   const coordinator = createCoordinator();
   let connection!: ClientCapabilityConnection;
-  connection = coordinator.attachConnection('connection-a', {
+  connection = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
     send: async (frame) => {
       if (frame.kind !== 'client.capability.call') return;
       if (accept) {
@@ -894,7 +1000,7 @@ test('Host services stay bound to the explicitly initiating Client connection', 
   const calls: string[] = [];
   const attach = (connectionId: string) => {
     let connection!: ReturnType<HostClientCapabilityCoordinator['attachConnection']>;
-    connection = coordinator.attachConnection(connectionId, {
+    connection = coordinator.attachConnection(clientCapabilityConnectionIdentity(connectionId), {
       send: async (frame) => {
         if (frame.kind === 'client.capability.service_call') {
           calls.push(connectionId);
@@ -948,7 +1054,10 @@ test('service-only registration lifecycle does not invalidate model backends', a
   const coordinator = createCoordinator(() => {
     modelToolChanges += 1;
   });
-  const connection = coordinator.attachConnection('connection-a', { send: async () => {} });
+  const connection = coordinator.attachConnection(
+    clientCapabilityConnectionIdentity('connection-a'),
+    { send: async () => {} },
+  );
   for (const registrationId of ['service-a', 'service-b']) {
     const outcome = await coordinator.handlers['client.capability.replace'](
       {
@@ -967,7 +1076,10 @@ test('service-only registration lifecycle does not invalidate model backends', a
   assert.equal(unregistered.ok, true);
   assert.equal(modelToolChanges, 0);
 
-  const serviceConnection = coordinator.attachConnection('connection-b', { send: async () => {} });
+  const serviceConnection = coordinator.attachConnection(
+    clientCapabilityConnectionIdentity('connection-b'),
+    { send: async () => {} },
+  );
   const serviceRegistered = await coordinator.handlers['client.capability.replace'](
     {
       registrationId: 'service-disconnect',

--- a/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { ToolOutcomeUnknownError } from '@maka/core/events';
 import type { McpCallResult } from '@maka/core/mcp';
+import type { ClientCapabilityReplaceInput } from '../protocol/index.js';
 import {
   ClientCapabilityInvocationError,
   HostClientCapabilityCoordinator,
@@ -334,6 +335,19 @@ describe('Host Client Capability coordinator', () => {
       { send: async () => {} },
     );
     await replace(coordinator, 'connection-b', 'registration-b', 'inspect');
+    assert.deepEqual(
+      await coordinator.handlers['client.capability.replace'](
+        replacementInput('registration-a-late', 'inspect'),
+        connectionContext('connection-a'),
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'invalid_request',
+          message: 'Client Capability connection has been superseded',
+        },
+      },
+    );
     assert.deepEqual(
       await coordinator.handlers['client.capability.unregister'](
         { registrationId: 'registration-a' },
@@ -958,31 +972,41 @@ async function replace(
   affinity: 'call' | 'turn' | 'session' = 'session',
 ): Promise<void> {
   const outcome = await coordinator.handlers['client.capability.replace'](
-    {
-      registrationId,
-      offers: [
-        {
-          offerId,
-          version,
-          affinity,
-          label: 'Opaque capability',
-          description: 'Known only to the provider.',
-          tools: [
-            {
-              serverId: offerId,
-              name: toolName,
-              description: 'An open-world fixture tool.',
-              inputSchema: { type: 'object', additionalProperties: false },
-            },
-          ],
-        },
-      ],
-    },
+    replacementInput(registrationId, toolName, version, offerId, affinity),
     {
       ...connectionContext(connectionId),
     },
   );
   assert.equal(outcome.ok, true);
+}
+
+function replacementInput(
+  registrationId: string,
+  toolName: string,
+  version = '0',
+  offerId = 'opaque_offer',
+  affinity: 'call' | 'turn' | 'session' = 'session',
+): ClientCapabilityReplaceInput {
+  return {
+    registrationId,
+    offers: [
+      {
+        offerId,
+        version,
+        affinity,
+        label: 'Opaque capability',
+        description: 'Known only to the provider.',
+        tools: [
+          {
+            serverId: offerId,
+            name: toolName,
+            description: 'An open-world fixture tool.',
+            inputSchema: { type: 'object', additionalProperties: false },
+          },
+        ],
+      },
+    ],
+  };
 }
 
 function connectionContext(connectionId: string) {

--- a/packages/runtime-host/src/__tests__/client-capability-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-uds.test.ts
@@ -28,7 +28,7 @@ import {
 } from '../server/operation-dispatcher.js';
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
 
-test('unknown Client Capability loads, invokes, chunks, and disconnects over real UDS', async () => {
+test('unknown Client Capability loads, invokes, and rebinds after UDS reconnect', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-client-capability-'));
   const root = join(base, 'root');
   let host: RuntimeHostKernel | undefined;
@@ -68,6 +68,7 @@ test('unknown Client Capability loads, invokes, chunks, and disconnects over rea
     const connected = await connectRuntimeHost({
       rootPath: root,
       surface: 'desktop',
+      clientInstanceId: 'desktop-installation-a',
       protocol: {
         min: RUNTIME_HOST_PROTOCOL_VERSION,
         max: RUNTIME_HOST_PROTOCOL_VERSION,
@@ -230,6 +231,40 @@ test('unknown Client Capability loads, invokes, chunks, and disconnects over rea
       (error: unknown) =>
         error instanceof ClientCapabilityInvocationError && error.code === 'capability_lost',
     );
+
+    const reconnected = await connectRuntimeHost({
+      rootPath: root,
+      surface: 'desktop',
+      clientInstanceId: 'desktop-installation-a',
+      protocol: {
+        min: RUNTIME_HOST_PROTOCOL_VERSION,
+        max: RUNTIME_HOST_PROTOCOL_VERSION,
+      },
+    });
+    assert.equal(reconnected.kind, 'connected');
+    if (reconnected.kind !== 'connected') return;
+    client = reconnected.connection;
+    await client.replaceClientCapabilities({
+      offers: provider.offers,
+      call: async (frame, { accept }) => {
+        await accept();
+        return {
+          content: [{ type: 'text', text: `reconnected:${String(frame.arguments.prefix)}` }],
+        };
+      },
+    });
+    assert.deepEqual(await coordinator.bindSession('session-uds', client.connectionId), {
+      ok: true,
+    });
+    snapshot.release();
+    snapshot = coordinator.snapshotForSession('session-uds');
+    const reconnectedTool = snapshot?.tools.find(
+      (candidate) => candidate.name === mcpProxyToolName('fixture_unknown', 'make_unknown_payload'),
+    );
+    assert.ok(reconnectedTool);
+    assert.deepEqual(await reconnectedTool.impl({ prefix: 'from-uds' }, toolContext), {
+      content: [{ type: 'text', text: 'reconnected:from-uds' }],
+    });
   } finally {
     snapshot?.release();
     await client?.close().catch(() => undefined);

--- a/packages/runtime-host/src/__tests__/client-instance-identity.test.ts
+++ b/packages/runtime-host/src/__tests__/client-instance-identity.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { loadOrCreateRuntimeHostClientInstanceId } from '../client/index.js';
+
+test('Client instance identity converges across concurrent startup and survives restart', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-runtime-host-client-identity-'));
+  const path = join(root, 'profile', 'runtime-host-client.json');
+  try {
+    const identities = await Promise.all(
+      Array.from({ length: 8 }, () => loadOrCreateRuntimeHostClientInstanceId(path)),
+    );
+    assert.equal(new Set(identities).size, 1);
+    assert.equal(await loadOrCreateRuntimeHostClientInstanceId(path), identities[0]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('Client instance identity rejects an invalid persisted document', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-runtime-host-client-identity-invalid-'));
+  const path = join(root, 'runtime-host-client.json');
+  try {
+    await writeFile(path, '{"schemaVersion":1,"clientInstanceId":""}\n');
+    await assert.rejects(loadOrCreateRuntimeHostClientInstanceId(path), /Invalid clientInstanceId/);
+    assert.equal(await readFile(path, 'utf8'), '{"schemaVersion":1,"clientInstanceId":""}\n');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -24,6 +24,10 @@ import {
 } from '../protocol/index.js';
 import { RuntimeHostKernel, type RuntimeHostComposition } from '../server/index.js';
 import { LOCAL_OWNER_CONNECTION_AUTHORITY } from '../server/connection-authority.js';
+import type {
+  ClientCapabilityConnectionIdentity,
+  ClientCapabilityService,
+} from '../server/client-capability-service.js';
 import { RuntimeHostConnectionSession } from '../server/connection-session.js';
 import {
   createUnavailableAccessAuthorityOperationHandlers,
@@ -408,6 +412,82 @@ test('connection reset while operation admission is pending does not execute the
     pair.clientTransport.abort();
     await Promise.allSettled([run, pair.close()]);
   }
+});
+
+test('a ready composition attaches the authenticated Client identity once', async () => {
+  const pair = await openTransportPair();
+  const attached: ClientCapabilityConnectionIdentity[] = [];
+  let serviceAvailable = false;
+  let closeCalls = 0;
+  const service: ClientCapabilityService = {
+    attachConnection(identity) {
+      attached.push(identity);
+      return {
+        accept() {},
+        async close() {
+          closeCalls += 1;
+        },
+      };
+    },
+  };
+  const session = new RuntimeHostConnectionSession({
+    transport: pair.serverTransport,
+    connection: acceptedConnection('stable-provider-connection'),
+    resolveHandlers: () => ({
+      'host.status': async () => ({
+        ok: true,
+        result: {
+          hostEpoch: 'host-epoch',
+          state: 'ready',
+          connections: 1,
+          activeOperations: 1,
+          activeResidencies: 0,
+        },
+      }),
+      ...UNUSED_HOST_DIAGNOSTICS_HANDLER,
+      ...createUnavailableAccessAuthorityOperationHandlers(),
+      ...createUnavailableDomainOperationHandlers(),
+    }),
+    resolveContinuity: () => undefined,
+    resolveClientCapabilities: () => (serviceAvailable ? service : undefined),
+    beginOperation: async () => ({
+      acquireResidency: () => ({ release() {} }),
+      seal() {},
+      finish() {},
+    }),
+    onTeardown() {},
+  });
+  const run = session.run();
+  try {
+    await writeProtocolFrame(pair.clientTransport, {
+      requestId: 'before-composition',
+      operation: 'host.status',
+      input: {},
+    });
+    await pair.clientTransport.read(1_000);
+    assert.deepEqual(attached, []);
+
+    serviceAvailable = true;
+    for (const requestId of ['after-composition', 'still-attached']) {
+      await writeProtocolFrame(pair.clientTransport, {
+        requestId,
+        operation: 'host.status',
+        input: {},
+      });
+      await pair.clientTransport.read(1_000);
+    }
+    assert.deepEqual(attached, [
+      {
+        connectionId: 'stable-provider-connection',
+        principalId: 'local_os_user',
+        clientInstanceId: 'test-client',
+      },
+    ]);
+  } finally {
+    pair.clientTransport.abort();
+    await Promise.allSettled([run, pair.close()]);
+  }
+  assert.equal(closeCalls, 1);
 });
 
 test('an admitted operation settles without connection or residency leakage after disconnect', async () => {

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -8,6 +8,7 @@ import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { test } from 'node:test';
 import { z } from 'zod';
+import { clientCapabilityConnectionIdentity } from './fixtures/client-capability.js';
 import {
   createBypassExecutionBoundary,
   createManagedExecutionBoundary,
@@ -376,7 +377,9 @@ test('production backend creation continues after a Session Client Capability is
     activation: new RuntimePolicyActivationGate(),
     onModelToolsChanged: () => undefined,
   });
-  const provider = coordinator.attachConnection('provider-a', { send: async () => undefined });
+  const provider = coordinator.attachConnection(clientCapabilityConnectionIdentity('provider-a'), {
+    send: async () => undefined,
+  });
   const context: ConnectionContext = {
     hostEpoch: 'backend-creation-epoch',
     connectionId: 'provider-a',
@@ -442,25 +445,28 @@ test('production backend preserves coordinator Client Capability semantics acros
   let connection: ReturnType<HostClientCapabilityCoordinator['attachConnection']> | undefined;
   let backend: Awaited<ReturnType<typeof createHostAiSdkBackend>> | undefined;
   try {
-    connection = coordinator.attachConnection('client-capability-provider', {
-      send: async (frame) => {
-        if (frame.kind !== 'client.capability.call') return;
-        calls.push(frame);
-        queueMicrotask(() => {
-          connection?.accept({
-            kind: 'client.capability.accepted',
-            invocationId: frame.invocationId,
+    connection = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('client-capability-provider'),
+      {
+        send: async (frame) => {
+          if (frame.kind !== 'client.capability.call') return;
+          calls.push(frame);
+          queueMicrotask(() => {
+            connection?.accept({
+              kind: 'client.capability.accepted',
+              invocationId: frame.invocationId,
+            });
+            connection?.accept({
+              kind: 'client.capability.result',
+              invocationId: frame.invocationId,
+              result: {
+                content: [{ type: 'text', text: CLIENT_CAPABILITY_RESULT_TEXT }],
+              },
+            });
           });
-          connection?.accept({
-            kind: 'client.capability.result',
-            invocationId: frame.invocationId,
-            result: {
-              content: [{ type: 'text', text: CLIENT_CAPABILITY_RESULT_TEXT }],
-            },
-          });
-        });
+        },
       },
-    });
+    );
     const context = {
       hostEpoch: 'client-capability-host-epoch',
       connectionId: 'client-capability-provider',

--- a/packages/runtime-host/src/__tests__/fixtures/client-capability.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/client-capability.ts
@@ -1,0 +1,9 @@
+import type { ClientCapabilityConnectionIdentity } from '../../server/client-capability-service.js';
+
+export function clientCapabilityConnectionIdentity(
+  connectionId: string,
+  clientInstanceId = connectionId,
+  principalId = 'test-principal',
+): ClientCapabilityConnectionIdentity {
+  return { connectionId, principalId, clientInstanceId };
+}

--- a/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
@@ -26,6 +26,7 @@ import {
 import { HostClientCapabilityCoordinator } from '../server/client-capability-coordinator.js';
 import { HostOAuthCoordinator } from '../server/oauth-coordinator.js';
 import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
+import { clientCapabilityConnectionIdentity } from './fixtures/client-capability.js';
 
 const NOW = 1_800_000_000_000;
 
@@ -633,7 +634,7 @@ async function attachPresentation(
 ) {
   const serviceCalls = new Map<string, ClientCapabilityServiceCallFrame>();
   let connection!: ReturnType<HostClientCapabilityCoordinator['attachConnection']>;
-  connection = coordinator.attachConnection(connectionId, {
+  connection = coordinator.attachConnection(clientCapabilityConnectionIdentity(connectionId), {
     send: async (frame) => {
       if (frame.kind === 'client.capability.service_call') {
         calls.push(connectionId);

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -33,6 +33,7 @@ import type {
 } from '@maka/core/backend-types';
 import type { SessionEvent } from '@maka/core/events';
 import type { MakaTool } from '@maka/runtime';
+import { clientCapabilityConnectionIdentity } from './fixtures/client-capability.js';
 import {
   openInteractiveExecutionStoresForWrite,
   type RootTurnAdmission,
@@ -181,7 +182,10 @@ test('a failed exact Capability retry does not poison the parked continuation bi
     },
     registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
   });
-  const seedConnection = capabilities.attachConnection('provider-seed', { send: async () => {} });
+  const seedConnection = capabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-seed'),
+    { send: async () => {} },
+  );
   let wrongConnection: ReturnType<HostClientCapabilityCoordinator['attachConnection']> | undefined;
   let correctConnection:
     | ReturnType<HostClientCapabilityCoordinator['attachConnection']>
@@ -202,7 +206,10 @@ test('a failed exact Capability retry does not poison the parked continuation bi
     );
 
     await seedConnection.close();
-    wrongConnection = capabilities.attachConnection('provider-wrong', { send: async () => {} });
+    wrongConnection = capabilities.attachConnection(
+      clientCapabilityConnectionIdentity('provider-wrong'),
+      { send: async () => {} },
+    );
     await registerSessionCapability(fixture, capabilities, 'provider-wrong', 'registration-wrong', [
       'inspect',
       'unexpected',
@@ -237,7 +244,10 @@ test('a failed exact Capability retry does not poison the parked continuation bi
 
     await wrongConnection.close();
     wrongConnection = undefined;
-    correctConnection = capabilities.attachConnection('provider-correct', { send: async () => {} });
+    correctConnection = capabilities.attachConnection(
+      clientCapabilityConnectionIdentity('provider-correct'),
+      { send: async () => {} },
+    );
     await registerSessionCapability(
       fixture,
       capabilities,
@@ -313,9 +323,12 @@ test('resume query preserves Session-before-activation lock ordering', async () 
     },
     registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
   });
-  const connection = capabilities.attachConnection('provider-lock-order', {
-    send: async () => {},
-  });
+  const connection = capabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-lock-order'),
+    {
+      send: async () => {},
+    },
+  );
   const laneEntered = deferred<void>();
   const releaseLane = deferred<void>();
   let blocker: Promise<void> | undefined;
@@ -426,7 +439,10 @@ test('turn.start resolves explicit Skills once before durable admission and repl
     activation: new RuntimePolicyActivationGate(),
     onModelToolsChanged: () => undefined,
   });
-  const connection = capabilities.attachConnection('skill-provider', { send: async () => {} });
+  const connection = capabilities.attachConnection(
+    clientCapabilityConnectionIdentity('skill-provider'),
+    { send: async () => {} },
+  );
   const fixture = await createFailureFixture({
     registerBackend: (backends) => backends.register('fake', (context) => new FakeBackend(context)),
     clientCapabilities: capabilities,
@@ -2797,12 +2813,18 @@ test('Client Capability ambiguity fails before durable root admission', async ()
       backends.register('fake', (context) => new FakeBackend(context));
     },
   });
-  const first = clientCapabilities.attachConnection('provider-a', {
-    send: async () => {},
-  });
-  const second = clientCapabilities.attachConnection('provider-b', {
-    send: async () => {},
-  });
+  const first = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-a'),
+    {
+      send: async () => {},
+    },
+  );
+  const second = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-b'),
+    {
+      send: async () => {},
+    },
+  );
 
   try {
     for (const [connectionId, registrationId] of [
@@ -2873,12 +2895,18 @@ test('an exact active retry preserves the Client Capability admission binding', 
       });
     },
   });
-  const first = clientCapabilities.attachConnection('provider-a', {
-    send: async () => {},
-  });
-  const second = clientCapabilities.attachConnection('provider-b', {
-    send: async () => {},
-  });
+  const first = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-a'),
+    {
+      send: async () => {},
+    },
+  );
+  const second = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-b'),
+    {
+      send: async () => {},
+    },
+  );
 
   try {
     for (const [connectionId, registrationId] of [
@@ -2961,12 +2989,18 @@ test('mixed-Client queued follow-ups preserve each submitting connection through
       });
     },
   });
-  const first = clientCapabilities.attachConnection('provider-a', {
-    send: async () => {},
-  });
-  const second = clientCapabilities.attachConnection('provider-b', {
-    send: async () => {},
-  });
+  const first = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-a'),
+    {
+      send: async () => {},
+    },
+  );
+  const second = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-b'),
+    {
+      send: async () => {},
+    },
+  );
 
   try {
     for (const [connectionId, registrationId] of [
@@ -3099,42 +3133,51 @@ async function assertFollowupCapabilityRebinding(affinity: 'call' | 'turn'): Pro
       });
     },
   });
-  const sessionProvider = clientCapabilities.attachConnection('provider-session', {
-    send: async () => {},
-  });
+  const sessionProvider = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-session'),
+    {
+      send: async () => {},
+    },
+  );
   const calls: string[] = [];
   let previousProvider!: ReturnType<HostClientCapabilityCoordinator['attachConnection']>;
-  previousProvider = clientCapabilities.attachConnection('provider-previous', {
-    send: async (frame) => {
-      if (frame.kind !== 'client.capability.call') return;
-      calls.push('provider-previous');
-      previousProvider.accept({
-        kind: 'client.capability.accepted',
-        invocationId: frame.invocationId,
-      });
-      previousProvider.accept({
-        kind: 'client.capability.result',
-        invocationId: frame.invocationId,
-        result: { content: [{ type: 'text', text: 'previous' }] },
-      });
+  previousProvider = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-previous'),
+    {
+      send: async (frame) => {
+        if (frame.kind !== 'client.capability.call') return;
+        calls.push('provider-previous');
+        previousProvider.accept({
+          kind: 'client.capability.accepted',
+          invocationId: frame.invocationId,
+        });
+        previousProvider.accept({
+          kind: 'client.capability.result',
+          invocationId: frame.invocationId,
+          result: { content: [{ type: 'text', text: 'previous' }] },
+        });
+      },
     },
-  });
+  );
   let followupProvider!: ReturnType<HostClientCapabilityCoordinator['attachConnection']>;
-  followupProvider = clientCapabilities.attachConnection('provider-followup', {
-    send: async (frame) => {
-      if (frame.kind !== 'client.capability.call') return;
-      calls.push('provider-followup');
-      followupProvider.accept({
-        kind: 'client.capability.accepted',
-        invocationId: frame.invocationId,
-      });
-      followupProvider.accept({
-        kind: 'client.capability.result',
-        invocationId: frame.invocationId,
-        result: { content: [{ type: 'text', text: 'followup' }] },
-      });
+  followupProvider = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-followup'),
+    {
+      send: async (frame) => {
+        if (frame.kind !== 'client.capability.call') return;
+        calls.push('provider-followup');
+        followupProvider.accept({
+          kind: 'client.capability.accepted',
+          invocationId: frame.invocationId,
+        });
+        followupProvider.accept({
+          kind: 'client.capability.result',
+          invocationId: frame.invocationId,
+          result: { content: [{ type: 'text', text: 'followup' }] },
+        });
+      },
     },
-  });
+  );
 
   try {
     const sessionReplaced = await clientCapabilities.handlers['client.capability.replace'](
@@ -3276,9 +3319,12 @@ test('an exact terminal retry does not require a live Client Capability binding'
       backends.register('fake', (context) => new FakeBackend(context));
     },
   });
-  const provider = clientCapabilities.attachConnection('provider-a', {
-    send: async () => {},
-  });
+  const provider = clientCapabilities.attachConnection(
+    clientCapabilityConnectionIdentity('provider-a'),
+    {
+      send: async () => {},
+    },
+  );
 
   try {
     const replaced = await clientCapabilities.handlers['client.capability.replace'](

--- a/packages/runtime-host/src/client/client-instance-identity.ts
+++ b/packages/runtime-host/src/client/client-instance-identity.ts
@@ -24,13 +24,12 @@ export async function loadOrCreateRuntimeHostClientInstanceId(path: string): Pro
   const temporaryPath = join(directory, `.runtime-host-client-${randomUUID()}.tmp`);
   const handle = await open(temporaryPath, 'wx', 0o600);
   try {
-    await handle.writeFile(`${JSON.stringify(document)}\n`, 'utf8');
-    await handle.sync();
-  } finally {
-    await handle.close();
-  }
-
-  try {
+    try {
+      await handle.writeFile(`${JSON.stringify(document)}\n`, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
     await link(temporaryPath, path);
     await syncDirectory(directory);
     return document.clientInstanceId;

--- a/packages/runtime-host/src/client/client-instance-identity.ts
+++ b/packages/runtime-host/src/client/client-instance-identity.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+import { link, mkdir, open, readFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { requireClientInstanceId } from '../protocol/index.js';
+
+const CLIENT_IDENTITY_SCHEMA_VERSION = 1;
+const CLIENT_IDENTITY_MAX_BYTES = 512;
+
+interface ClientIdentityDocument {
+  readonly schemaVersion: typeof CLIENT_IDENTITY_SCHEMA_VERSION;
+  readonly clientInstanceId: string;
+}
+
+export async function loadOrCreateRuntimeHostClientInstanceId(path: string): Promise<string> {
+  const existing = await readClientIdentity(path);
+  if (existing !== undefined) return existing.clientInstanceId;
+
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const document: ClientIdentityDocument = {
+    schemaVersion: CLIENT_IDENTITY_SCHEMA_VERSION,
+    clientInstanceId: randomUUID(),
+  };
+  const temporaryPath = join(directory, `.runtime-host-client-${randomUUID()}.tmp`);
+  const handle = await open(temporaryPath, 'wx', 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(document)}\n`, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+
+  try {
+    await link(temporaryPath, path);
+    await syncDirectory(directory);
+    return document.clientInstanceId;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    const winner = await readClientIdentity(path);
+    if (winner === undefined) throw new Error('Runtime Host Client identity disappeared');
+    return winner.clientInstanceId;
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+async function readClientIdentity(path: string): Promise<ClientIdentityDocument | undefined> {
+  let bytes: Buffer;
+  try {
+    bytes = await readFile(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+  if (bytes.length > CLIENT_IDENTITY_MAX_BYTES) {
+    throw new Error('Runtime Host Client identity exceeds its size limit');
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes));
+  } catch (error) {
+    throw new Error('Runtime Host Client identity is not valid JSON', { cause: error });
+  }
+  if (!isRecord(value) || value.schemaVersion !== CLIENT_IDENTITY_SCHEMA_VERSION) {
+    throw new Error('Runtime Host Client identity has an unsupported schema');
+  }
+  if (Object.keys(value).some((key) => key !== 'schemaVersion' && key !== 'clientInstanceId')) {
+    throw new Error('Runtime Host Client identity contains unknown fields');
+  }
+  return {
+    schemaVersion: CLIENT_IDENTITY_SCHEMA_VERSION,
+    clientInstanceId: requireClientInstanceId(value.clientInstanceId),
+  };
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await open(path, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -34,6 +34,7 @@ export {
   type ConnectOrSpawnRuntimeHostResult,
 } from './connect-or-spawn.js';
 export { type ClientCapabilityProvider } from './client-capability.js';
+export { loadOrCreateRuntimeHostClientInstanceId } from './client-instance-identity.js';
 export { consumeAccessCredentialDelivery } from '../control/access-credential-delivery.js';
 export {
   createOAuthPresentationClientProvider,

--- a/packages/runtime-host/src/server/client-capability-coordinator.ts
+++ b/packages/runtime-host/src/server/client-capability-coordinator.ts
@@ -47,10 +47,7 @@ export interface ClientCapabilitySnapshot {
 
 interface ClientProviderState {
   readonly providerId: string;
-  readonly principalId: string;
-  readonly clientInstanceId: string;
   activeConnectionId?: string;
-  sender?: ClientCapabilityConnectionSender;
   current?: CapabilityRegistration;
   readonly registrations: Map<string, CapabilityRegistration>;
 }
@@ -59,6 +56,7 @@ interface ClientProviderConnection {
   readonly connectionId: string;
   readonly provider: ClientProviderState;
   readonly sender: ClientCapabilityConnectionSender;
+  superseded: boolean;
 }
 
 interface CapabilityRegistration {
@@ -67,7 +65,6 @@ interface CapabilityRegistration {
   readonly registrationId: string;
   readonly offersByContract: ReadonlyMap<string, FrozenOfferBinding>;
   readonly servicesByContract: ReadonlyMap<string, ClientCapabilityServiceOffer>;
-  current: boolean;
   snapshotRefs: number;
 }
 
@@ -165,7 +162,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     this.#invocations = new ClientCapabilityInvocationBroker({
       senderFor: (connectionId) => {
         const connection = this.#connections.get(connectionId);
-        return connection?.provider.activeConnectionId === connectionId
+        return connection && this.#activeConnection(connection.provider) === connection
           ? connection.sender
           : undefined;
       },
@@ -186,6 +183,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       connectionId: identity.connectionId,
       provider,
       sender,
+      superseded: false,
     });
     let closeTask: Promise<void> | undefined;
     return {
@@ -422,7 +420,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       const provider = this.#providers.get(binding.providerId);
       const registration = provider?.current;
       const offer = registration?.offersByContract.get(contractId);
-      if (!provider?.sender || !registration || !offer) {
+      if (!provider || !this.#activeConnection(provider) || !registration || !offer) {
         throw new ClientCapabilityInvocationError(
           'capability_lost',
           'A Session-bound Client Capability provider is unavailable',
@@ -439,7 +437,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       const registration = provider?.current;
       const offer = registration?.offersByContract.get(contractId);
       if (
-        !provider?.sender ||
+        !provider ||
+        !this.#activeConnection(provider) ||
         !registration ||
         !offer ||
         offerConflictsWithProxyNames(offer, proxyNames)
@@ -505,14 +504,16 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   async callService(
     input: ClientCapabilityServiceInvocationInput,
   ): Promise<Record<string, unknown>> {
-    const provider = this.#connections.get(input.connectionId)?.provider;
+    const connection = this.#connections.get(input.connectionId);
+    const provider = connection?.provider;
     const registration = provider?.current;
     const service = registration?.servicesByContract.get(
       serviceContract(input.serviceId, input.version),
     );
     if (
-      provider?.activeConnectionId !== input.connectionId ||
-      !provider.sender ||
+      !connection ||
+      !provider ||
+      this.#activeConnection(provider) !== connection ||
       !registration ||
       !service
     ) {
@@ -545,16 +546,19 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   }
 
   hasService(connectionId: string, serviceId: string, version: string): boolean {
-    const provider = this.#connections.get(connectionId)?.provider;
+    const connection = this.#connections.get(connectionId);
+    const provider = connection?.provider;
     return Boolean(
-      provider?.activeConnectionId === connectionId &&
-        provider.sender &&
+      connection &&
+        provider &&
+        this.#activeConnection(provider) === connection &&
         provider.current?.servicesByContract.has(serviceContract(serviceId, version)),
     );
   }
 
   retireSessions(sessionIds: readonly string[]): void {
     for (const sessionId of new Set(sessionIds)) this.#sessions.delete(sessionId);
+    for (const provider of this.#providers.values()) this.#deleteProviderIfUnused(provider);
   }
 
   releaseConnection(connectionId: string): Promise<void> {
@@ -579,10 +583,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       return;
     }
     provider.activeConnectionId = undefined;
-    provider.sender = undefined;
     if (provider.current) {
       const registration = provider.current;
-      registration.current = false;
       provider.current = undefined;
       this.#markBindingsLost(provider.providerId);
       this.#removeTurnBindings(provider.providerId);
@@ -635,6 +637,15 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
         };
       }
       const { provider } = connection;
+      if (connection.superseded) {
+        return {
+          ok: false,
+          error: {
+            code: 'invalid_request',
+            message: 'Client Capability connection has been superseded',
+          },
+        };
+      }
       if (provider.registrations.has(input.registrationId)) {
         return {
           ok: false,
@@ -659,11 +670,11 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       const previous = provider.current;
       const previousConnectionId = provider.activeConnectionId;
       if (previousConnectionId && previousConnectionId !== context.connectionId) {
+        const previousConnection = this.#connections.get(previousConnectionId);
+        if (previousConnection) previousConnection.superseded = true;
         this.#invocations.releaseConnection(previousConnectionId);
       }
-      if (previous) previous.current = false;
       provider.activeConnectionId = context.connectionId;
-      provider.sender = connection.sender;
       provider.current = registration;
       const currentContracts = new Set(registration.offersByContract.keys());
       if (previous) {
@@ -722,7 +733,6 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
         };
       }
       const registration = provider.current;
-      registration.current = false;
       provider.current = undefined;
       this.#retireBindings(provider.providerId, new Set(registration.offersByContract.keys()));
       this.#removeTurnBindings(provider.providerId, new Set(registration.offersByContract.keys()));
@@ -804,8 +814,6 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     if (!provider) {
       provider = {
         providerId,
-        principalId: identity.principalId,
-        clientInstanceId: identity.clientInstanceId,
         registrations: new Map(),
       };
       this.#providers.set(providerId, provider);
@@ -817,7 +825,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     const eligible = new Map<string, SelectedOfferBinding[]>();
     for (const provider of this.#providers.values()) {
       const registration = provider.current;
-      if (!provider.sender || !registration) continue;
+      if (!this.#activeConnection(provider) || !registration) continue;
       for (const offer of registration.offersByContract.values()) {
         const candidates = eligible.get(offer.contractId) ?? [];
         candidates.push({ registration, offer });
@@ -961,14 +969,14 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   }
 
   #releaseRegistrationIfUnused(registration: CapabilityRegistration): void {
+    const provider = this.#providers.get(registration.providerId);
     if (
-      registration.current ||
+      provider?.current === registration ||
       registration.snapshotRefs !== 0 ||
       this.#invocations.holdsRegistration(registration)
     ) {
       return;
     }
-    const provider = this.#providers.get(registration.providerId);
     if (!provider?.registrations.delete(registration.registrationId)) return;
     void this.#connections
       .get(registration.connectionId)
@@ -978,6 +986,13 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       })
       .catch(() => {});
     this.#deleteProviderIfUnused(provider);
+  }
+
+  #activeConnection(provider: ClientProviderState): ClientProviderConnection | undefined {
+    const connection = provider.activeConnectionId
+      ? this.#connections.get(provider.activeConnectionId)
+      : undefined;
+    return connection?.provider === provider && !connection.superseded ? connection : undefined;
   }
 
   #deleteProviderIfUnused(provider: ClientProviderState): void {
@@ -1062,7 +1077,6 @@ function freezeRegistration(
     registrationId: input.registrationId,
     offersByContract,
     servicesByContract,
-    current: true,
     snapshotRefs: 0,
   };
 }

--- a/packages/runtime-host/src/server/client-capability-coordinator.ts
+++ b/packages/runtime-host/src/server/client-capability-coordinator.ts
@@ -25,6 +25,7 @@ import type {
 } from './operation-dispatcher.js';
 import type { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
 import type {
+  ClientCapabilityConnectionIdentity,
   ClientCapabilityConnection,
   ClientCapabilityConnectionSender,
   ClientCapabilityService,
@@ -45,13 +46,23 @@ export interface ClientCapabilitySnapshot {
 }
 
 interface ClientProviderState {
-  readonly connectionId: string;
+  readonly providerId: string;
+  readonly principalId: string;
+  readonly clientInstanceId: string;
+  activeConnectionId?: string;
   sender?: ClientCapabilityConnectionSender;
   current?: CapabilityRegistration;
   readonly registrations: Map<string, CapabilityRegistration>;
 }
 
+interface ClientProviderConnection {
+  readonly connectionId: string;
+  readonly provider: ClientProviderState;
+  readonly sender: ClientCapabilityConnectionSender;
+}
+
 interface CapabilityRegistration {
+  readonly providerId: string;
   readonly connectionId: string;
   readonly registrationId: string;
   readonly offersByContract: ReadonlyMap<string, FrozenOfferBinding>;
@@ -72,12 +83,12 @@ interface FrozenToolBinding {
 }
 
 type SessionCapabilityBinding =
-  | { readonly kind: 'bound'; readonly connectionId: string }
-  | { readonly kind: 'lost' };
+  | { readonly kind: 'bound'; readonly providerId: string }
+  | { readonly kind: 'lost'; readonly providerId: string };
 type SessionBindingMode = 'strict' | 'degrade';
 
 interface SessionCapabilityState {
-  readonly initiatingConnectionId: string;
+  readonly initiatingProviderId?: string;
   readonly sessionBindings: ReadonlyMap<string, SessionCapabilityBinding>;
   readonly turnBindings: ReadonlyMap<string, SessionCapabilityBinding>;
 }
@@ -140,6 +151,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   readonly #activation: RuntimePolicyActivationGate;
   readonly #onModelToolsChanged: () => void;
   readonly #providers = new Map<string, ClientProviderState>();
+  readonly #connections = new Map<string, ClientProviderConnection>();
   readonly #sessions = new Map<string, SessionCapabilityState>();
   readonly #previewSessions = new AsyncLocalStorage<ReadonlyMap<string, SessionCapabilityState>>();
   readonly #pendingConnectionReleases = new Set<Promise<void>>();
@@ -151,29 +163,38 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     this.#activation = options.activation;
     this.#onModelToolsChanged = options.onModelToolsChanged;
     this.#invocations = new ClientCapabilityInvocationBroker({
-      senderFor: (connectionId) => this.#providers.get(connectionId)?.sender,
+      senderFor: (connectionId) => {
+        const connection = this.#connections.get(connectionId);
+        return connection?.provider.activeConnectionId === connectionId
+          ? connection.sender
+          : undefined;
+      },
       onRegistrationIdle: (registration) => this.#releaseRegistrationIfUnused(registration),
     });
   }
 
   attachConnection(
-    connectionId: string,
+    identity: ClientCapabilityConnectionIdentity,
     sender: ClientCapabilityConnectionSender,
   ): ClientCapabilityConnection {
     if (this.#draining) throw new Error('Client Capability registry is draining');
-    const provider = this.#provider(connectionId);
-    if (provider.sender && provider.sender !== sender) {
-      throw new Error('Client Capability connection already has a sender');
+    if (this.#connections.has(identity.connectionId)) {
+      throw new Error('Client Capability connection identity already exists');
     }
-    provider.sender = sender;
+    const provider = this.#provider(identity);
+    this.#connections.set(identity.connectionId, {
+      connectionId: identity.connectionId,
+      provider,
+      sender,
+    });
     let closeTask: Promise<void> | undefined;
     return {
       accept: (frame) => {
         if (closeTask) return;
-        this.#invocations.accept(connectionId, frame);
+        this.#invocations.accept(identity.connectionId, frame);
       },
       close: () => {
-        closeTask ??= this.releaseConnection(connectionId);
+        closeTask ??= this.releaseConnection(identity.connectionId);
         return closeTask;
       },
     };
@@ -265,6 +286,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     initiatingConnectionId: string,
     mode: SessionBindingMode,
   ): SessionBindingSelection {
+    const initiatingProviderId = this.#connections.get(initiatingConnectionId)?.provider.providerId;
     const previousState = this.#sessions.get(sessionId);
     const previous = previousState?.sessionBindings ?? new Map();
     const eligible = this.#eligibleOffersByContract();
@@ -283,11 +305,11 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       let candidate: SelectedOfferBinding | undefined;
       if (previousBinding?.kind === 'bound') {
         candidate = candidates.find(
-          (entry) => entry.registration.connectionId === previousBinding.connectionId,
+          (entry) => entry.registration.providerId === previousBinding.providerId,
         );
         if (!candidate) {
           if (mode === 'degrade') {
-            next.set(contractId, { kind: 'lost' });
+            next.set(contractId, { kind: 'lost', providerId: previousBinding.providerId });
             continue;
           }
           return {
@@ -297,9 +319,9 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
           };
         }
       } else if (previousBinding?.kind === 'lost') {
-        candidate =
-          candidates.find((entry) => entry.registration.connectionId === initiatingConnectionId) ??
-          (candidates.length === 1 ? candidates[0] : undefined);
+        candidate = candidates.find(
+          (entry) => entry.registration.providerId === previousBinding.providerId,
+        );
         if (!candidate) {
           if (mode === 'degrade') {
             next.set(contractId, previousBinding);
@@ -307,13 +329,12 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
           }
           return {
             ok: false,
-            message:
-              'A lost Client Capability binding requires a compatible initiating Client to rebind',
+            message: 'A Session-bound Client Capability provider has not reconnected',
           };
         }
       } else {
         candidate =
-          candidates.find((entry) => entry.registration.connectionId === initiatingConnectionId) ??
+          candidates.find((entry) => entry.registration.providerId === initiatingProviderId) ??
           (candidates.length === 1 ? candidates[0] : undefined);
         if (!candidate && candidates.length > 1) {
           if (mode === 'degrade') continue;
@@ -327,7 +348,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       if (!candidate) continue;
       next.set(contractId, {
         kind: 'bound',
-        connectionId: candidate.registration.connectionId,
+        providerId: candidate.registration.providerId,
       });
       selected.push(candidate);
     }
@@ -337,7 +358,10 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       if (offerConflictsWithProxyNames(candidate.offer, proxyNames)) {
         if (mode === 'degrade') {
           if (previous.has(candidate.offer.contractId)) {
-            next.set(candidate.offer.contractId, { kind: 'lost' });
+            next.set(candidate.offer.contractId, {
+              kind: 'lost',
+              providerId: candidate.registration.providerId,
+            });
           } else {
             next.delete(candidate.offer.contractId);
           }
@@ -358,12 +382,12 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     )) {
       if (candidates[0]?.offer.offer.affinity !== 'turn') continue;
       const candidate =
-        candidates.find((entry) => entry.registration.connectionId === initiatingConnectionId) ??
+        candidates.find((entry) => entry.registration.providerId === initiatingProviderId) ??
         (candidates.length === 1 ? candidates[0] : undefined);
       if (!candidate || offerConflictsWithProxyNames(candidate.offer, proxyNames)) continue;
       nextTurn.set(contractId, {
         kind: 'bound',
-        connectionId: candidate.registration.connectionId,
+        providerId: candidate.registration.providerId,
       });
       rememberOfferProxyNames(candidate.offer, proxyNames);
     }
@@ -371,14 +395,14 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     return {
       ok: true,
       state: {
-        initiatingConnectionId,
+        ...(initiatingProviderId ? { initiatingProviderId } : {}),
         sessionBindings: next,
         turnBindings: nextTurn,
       },
       modelToolsChanged:
         !bindingMapsEqual(previous, next) ||
         !bindingMapsEqual(previousTurn, nextTurn) ||
-        (previousState?.initiatingConnectionId !== initiatingConnectionId &&
+        (previousState?.initiatingProviderId !== initiatingProviderId &&
           [...eligible.values()].some(
             (candidates) => candidates[0]?.offer.offer.affinity === 'call',
           )),
@@ -395,7 +419,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       left.localeCompare(right),
     )) {
       if (binding.kind === 'lost') continue;
-      const provider = this.#providers.get(binding.connectionId);
+      const provider = this.#providers.get(binding.providerId);
       const registration = provider?.current;
       const offer = registration?.offersByContract.get(contractId);
       if (!provider?.sender || !registration || !offer) {
@@ -411,7 +435,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       left.localeCompare(right),
     )) {
       const provider =
-        binding.kind === 'bound' ? this.#providers.get(binding.connectionId) : undefined;
+        binding.kind === 'bound' ? this.#providers.get(binding.providerId) : undefined;
       const registration = provider?.current;
       const offer = registration?.offersByContract.get(contractId);
       if (
@@ -441,7 +465,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       rememberOfferProxyNames(offer, proxyNames);
     }
     if (selected.length === 0) return;
-    const proxyProvider = this.#snapshotProvider(state?.initiatingConnectionId, selected);
+    const proxyProvider = this.#snapshotProvider(state?.initiatingProviderId, selected);
     const tools = buildMcpTools(proxyProvider, {
       callTimeoutMs: DEFAULT_CALL_TIMEOUT_MS,
       categoryHint: 'client_capability',
@@ -481,12 +505,17 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   async callService(
     input: ClientCapabilityServiceInvocationInput,
   ): Promise<Record<string, unknown>> {
-    const provider = this.#providers.get(input.connectionId);
+    const provider = this.#connections.get(input.connectionId)?.provider;
     const registration = provider?.current;
     const service = registration?.servicesByContract.get(
       serviceContract(input.serviceId, input.version),
     );
-    if (!provider?.sender || !registration || !service) {
+    if (
+      provider?.activeConnectionId !== input.connectionId ||
+      !provider.sender ||
+      !registration ||
+      !service
+    ) {
       throw new ClientCapabilityInvocationError(
         'capability_lost',
         'Client Capability service is unavailable on the initiating connection',
@@ -516,9 +545,10 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   }
 
   hasService(connectionId: string, serviceId: string, version: string): boolean {
-    const provider = this.#providers.get(connectionId);
+    const provider = this.#connections.get(connectionId)?.provider;
     return Boolean(
-      provider?.sender &&
+      provider?.activeConnectionId === connectionId &&
+        provider.sender &&
         provider.current?.servicesByContract.has(serviceContract(serviceId, version)),
     );
   }
@@ -529,32 +559,40 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
 
   releaseConnection(connectionId: string): Promise<void> {
     this.#invocations.releaseConnection(connectionId);
+    const connection = this.#connections.get(connectionId);
+    if (!connection) return Promise.resolve();
     let task!: Promise<void>;
     task = this.#activation
-      .runMutation(() => this.#releaseConnectionState(connectionId))
+      .runMutation(() => this.#releaseConnectionState(connection))
       .finally(() => this.#pendingConnectionReleases.delete(task));
     this.#pendingConnectionReleases.add(task);
     void task.catch(() => undefined);
     return task;
   }
 
-  #releaseConnectionState(connectionId: string): void {
-    const provider = this.#providers.get(connectionId);
-    if (!provider) return;
+  #releaseConnectionState(connection: ClientProviderConnection): void {
+    if (this.#connections.get(connection.connectionId) !== connection) return;
+    const { provider } = connection;
+    this.#connections.delete(connection.connectionId);
+    if (provider.activeConnectionId !== connection.connectionId) {
+      this.#deleteProviderIfUnused(provider);
+      return;
+    }
+    provider.activeConnectionId = undefined;
     provider.sender = undefined;
     if (provider.current) {
       const registration = provider.current;
       registration.current = false;
       provider.current = undefined;
-      this.#markBindingsLost(connectionId);
-      this.#removeTurnBindings(connectionId);
+      this.#markBindingsLost(provider.providerId);
+      this.#removeTurnBindings(provider.providerId);
       this.#revision += 1;
       if (hasModelToolOffers(registration)) this.#onModelToolsChanged();
     }
     for (const registration of [...provider.registrations.values()]) {
       this.#releaseRegistrationIfUnused(registration);
     }
-    if (provider.registrations.size === 0) this.#providers.delete(connectionId);
+    this.#deleteProviderIfUnused(provider);
     this.#pruneEmptySessions();
   }
 
@@ -564,7 +602,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
 
   async close(): Promise<void> {
     this.beginDrain();
-    for (const connectionId of [...this.#providers.keys()]) {
+    for (const connectionId of [...this.#connections.keys()]) {
       this.releaseConnection(connectionId);
     }
     await Promise.allSettled([...this.#pendingConnectionReleases]);
@@ -586,8 +624,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
           },
         };
       }
-      const provider = this.#provider(context.connectionId);
-      if (!provider.sender) {
+      const connection = this.#connections.get(context.connectionId);
+      if (!connection) {
         return {
           ok: false,
           error: {
@@ -596,6 +634,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
           },
         };
       }
+      const { provider } = connection;
       if (provider.registrations.has(input.registrationId)) {
         return {
           ok: false,
@@ -607,7 +646,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       }
       let registration: CapabilityRegistration;
       try {
-        registration = freezeRegistration(context.connectionId, input);
+        registration = freezeRegistration(provider.providerId, context.connectionId, input);
       } catch (error) {
         return {
           ok: false,
@@ -618,12 +657,18 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
         };
       }
       const previous = provider.current;
+      const previousConnectionId = provider.activeConnectionId;
+      if (previousConnectionId && previousConnectionId !== context.connectionId) {
+        this.#invocations.releaseConnection(previousConnectionId);
+      }
       if (previous) previous.current = false;
+      provider.activeConnectionId = context.connectionId;
+      provider.sender = connection.sender;
       provider.current = registration;
+      const currentContracts = new Set(registration.offersByContract.keys());
       if (previous) {
-        const currentContracts = new Set(registration.offersByContract.keys());
         this.#retireBindings(
-          context.connectionId,
+          provider.providerId,
           new Set(
             [...previous.offersByContract.keys()].filter(
               (contractId) => !currentContracts.has(contractId),
@@ -631,7 +676,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
           ),
         );
         this.#removeTurnBindings(
-          context.connectionId,
+          provider.providerId,
           new Set(
             [...previous.offersByContract.keys()].filter(
               (contractId) => !currentContracts.has(contractId),
@@ -639,6 +684,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
           ),
         );
       }
+      this.#restoreBindings(provider.providerId, currentContracts);
       provider.registrations.set(registration.registrationId, registration);
       this.#revision += 1;
       if (hasModelToolOffers(previous) || hasModelToolOffers(registration)) {
@@ -661,8 +707,12 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     context: ConnectionContext,
   ): ReturnType<ClientCapabilityOperationHandlerMap['client.capability.unregister']> {
     return this.#activation.runMutation(async () => {
-      const provider = this.#providers.get(context.connectionId);
-      if (!provider?.current || provider.current.registrationId !== input.registrationId) {
+      const provider = this.#connections.get(context.connectionId)?.provider;
+      if (
+        provider?.activeConnectionId !== context.connectionId ||
+        !provider.current ||
+        provider.current.registrationId !== input.registrationId
+      ) {
         return {
           ok: false,
           error: {
@@ -674,8 +724,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       const registration = provider.current;
       registration.current = false;
       provider.current = undefined;
-      this.#retireBindings(context.connectionId, new Set(registration.offersByContract.keys()));
-      this.#removeTurnBindings(context.connectionId, new Set(registration.offersByContract.keys()));
+      this.#retireBindings(provider.providerId, new Set(registration.offersByContract.keys()));
+      this.#removeTurnBindings(provider.providerId, new Set(registration.offersByContract.keys()));
       this.#revision += 1;
       if (hasModelToolOffers(registration)) this.#onModelToolsChanged();
       this.#releaseRegistrationIfUnused(registration);
@@ -691,7 +741,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
   }
 
   #snapshotProvider(
-    initiatingConnectionId: string | undefined,
+    initiatingProviderId: string | undefined,
     selected: readonly SnapshotOfferBinding[],
   ): McpToolProvider {
     const tools = selected.flatMap(({ offer }) => offer.offer.tools);
@@ -733,7 +783,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
             }
           : this.#selectCallBinding(
               selectedBinding.contractId,
-              initiatingConnectionId,
+              initiatingProviderId,
               toolIdentity(serverId, toolName),
             );
         return this.#invocations.invoke(
@@ -748,14 +798,17 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     };
   }
 
-  #provider(connectionId: string): ClientProviderState {
-    let provider = this.#providers.get(connectionId);
+  #provider(identity: ClientCapabilityConnectionIdentity): ClientProviderState {
+    const providerId = clientProviderId(identity.principalId, identity.clientInstanceId);
+    let provider = this.#providers.get(providerId);
     if (!provider) {
       provider = {
-        connectionId,
+        providerId,
+        principalId: identity.principalId,
+        clientInstanceId: identity.clientInstanceId,
         registrations: new Map(),
       };
-      this.#providers.set(connectionId, provider);
+      this.#providers.set(providerId, provider);
     }
     return provider;
   }
@@ -773,8 +826,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     }
     for (const candidates of eligible.values()) {
       candidates.sort((left, right) =>
-        `${left.registration.connectionId}\0${left.registration.registrationId}`.localeCompare(
-          `${right.registration.connectionId}\0${right.registration.registrationId}`,
+        `${left.registration.providerId}\0${left.registration.registrationId}`.localeCompare(
+          `${right.registration.providerId}\0${right.registration.registrationId}`,
         ),
       );
     }
@@ -783,12 +836,12 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
 
   #selectCallBinding(
     contractId: string,
-    initiatingConnectionId: string | undefined,
+    initiatingProviderId: string | undefined,
     identity: string,
   ): { readonly registration: CapabilityRegistration; readonly tool: FrozenToolBinding } {
     const candidates = this.#eligibleOffersByContract().get(contractId) ?? [];
     const candidate =
-      candidates.find((entry) => entry.registration.connectionId === initiatingConnectionId) ??
+      candidates.find((entry) => entry.registration.providerId === initiatingProviderId) ??
       (candidates.length === 1 ? candidates[0] : undefined);
     if (!candidate) {
       throw new ClientCapabilityInvocationError(
@@ -808,33 +861,50 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     return { registration: candidate.registration, tool };
   }
 
-  #markBindingsLost(connectionId: string, contracts?: ReadonlySet<string>): void {
+  #markBindingsLost(providerId: string, contracts?: ReadonlySet<string>): void {
     for (const [sessionId, state] of this.#sessions) {
       const bindings = state.sessionBindings;
       let next: Map<string, SessionCapabilityBinding> | undefined;
       for (const [contractId, binding] of bindings) {
         if (
           binding.kind !== 'bound' ||
-          binding.connectionId !== connectionId ||
+          binding.providerId !== providerId ||
           (contracts && !contracts.has(contractId))
         ) {
           continue;
         }
         next ??= new Map(bindings);
-        next.set(contractId, { kind: 'lost' });
+        next.set(contractId, { kind: 'lost', providerId });
       }
       if (next) this.#storeSessionState(sessionId, { ...state, sessionBindings: next });
     }
   }
 
-  #retireBindings(connectionId: string, contracts: ReadonlySet<string>): void {
+  #restoreBindings(providerId: string, contracts: ReadonlySet<string>): void {
+    for (const [sessionId, state] of this.#sessions) {
+      const next = new Map(state.sessionBindings);
+      for (const [contractId, binding] of state.sessionBindings) {
+        if (
+          binding.kind === 'lost' &&
+          binding.providerId === providerId &&
+          contracts.has(contractId)
+        ) {
+          next.set(contractId, { kind: 'bound', providerId });
+        }
+      }
+      if (bindingMapsEqual(state.sessionBindings, next)) continue;
+      this.#storeSessionState(sessionId, { ...state, sessionBindings: next });
+    }
+  }
+
+  #retireBindings(providerId: string, contracts: ReadonlySet<string>): void {
     for (const [sessionId, state] of this.#sessions) {
       const bindings = state.sessionBindings;
       const next = new Map(bindings);
       for (const [contractId, binding] of bindings) {
         if (
           binding.kind === 'bound' &&
-          binding.connectionId === connectionId &&
+          binding.providerId === providerId &&
           contracts.has(contractId)
         ) {
           next.delete(contractId);
@@ -845,14 +915,14 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     }
   }
 
-  #removeTurnBindings(connectionId: string, contracts?: ReadonlySet<string>): void {
+  #removeTurnBindings(providerId: string, contracts?: ReadonlySet<string>): void {
     for (const [sessionId, state] of this.#sessions) {
       const bindings = state.turnBindings;
       const next = new Map(bindings);
       for (const [contractId, binding] of bindings) {
         if (
           binding.kind === 'bound' &&
-          binding.connectionId === connectionId &&
+          binding.providerId === providerId &&
           (!contracts || contracts.has(contractId))
         ) {
           next.delete(contractId);
@@ -898,21 +968,43 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     ) {
       return;
     }
-    const provider = this.#providers.get(registration.connectionId);
+    const provider = this.#providers.get(registration.providerId);
     if (!provider?.registrations.delete(registration.registrationId)) return;
-    void provider.sender
-      ?.send({
+    void this.#connections
+      .get(registration.connectionId)
+      ?.sender?.send({
         kind: 'client.capability.registration_release',
         registrationId: registration.registrationId,
       })
       .catch(() => {});
-    if (!provider.current && !provider.sender && provider.registrations.size === 0) {
-      this.#providers.delete(provider.connectionId);
+    this.#deleteProviderIfUnused(provider);
+  }
+
+  #deleteProviderIfUnused(provider: ClientProviderState): void {
+    if (
+      provider.current ||
+      provider.activeConnectionId ||
+      provider.registrations.size > 0 ||
+      [...this.#connections.values()].some((connection) => connection.provider === provider) ||
+      this.#providerHasBindings(provider.providerId)
+    ) {
+      return;
     }
+    this.#providers.delete(provider.providerId);
+  }
+
+  #providerHasBindings(providerId: string): boolean {
+    for (const state of this.#sessions.values()) {
+      for (const binding of [...state.sessionBindings.values(), ...state.turnBindings.values()]) {
+        if (binding.providerId === providerId) return true;
+      }
+    }
+    return false;
   }
 }
 
 function freezeRegistration(
+  providerId: string,
   connectionId: string,
   input: ClientCapabilityReplaceInput,
 ): CapabilityRegistration {
@@ -965,6 +1057,7 @@ function freezeRegistration(
     );
   }
   return {
+    providerId,
     connectionId,
     registrationId: input.registrationId,
     offersByContract,
@@ -972,6 +1065,10 @@ function freezeRegistration(
     current: true,
     snapshotRefs: 0,
   };
+}
+
+function clientProviderId(principalId: string, clientInstanceId: string): string {
+  return `${principalId}\0${clientInstanceId}`;
 }
 
 function serviceContract(serviceId: string, version: string): string {
@@ -1049,8 +1146,7 @@ function bindingMapsEqual(
     if (
       !candidate ||
       candidate.kind !== binding.kind ||
-      (binding.kind === 'bound' &&
-        (candidate.kind !== 'bound' || candidate.connectionId !== binding.connectionId))
+      candidate.providerId !== binding.providerId
     ) {
       return false;
     }
@@ -1063,7 +1159,7 @@ function sessionCapabilityStatesEqual(
   right: SessionCapabilityState,
 ): boolean {
   return (
-    left.initiatingConnectionId === right.initiatingConnectionId &&
+    left.initiatingProviderId === right.initiatingProviderId &&
     bindingMapsEqual(left.sessionBindings, right.sessionBindings) &&
     bindingMapsEqual(left.turnBindings, right.turnBindings)
   );

--- a/packages/runtime-host/src/server/client-capability-service.ts
+++ b/packages/runtime-host/src/server/client-capability-service.ts
@@ -4,6 +4,12 @@ export interface ClientCapabilityConnectionSender {
   send(frame: ClientCapabilityHostFrame): Promise<void>;
 }
 
+export interface ClientCapabilityConnectionIdentity {
+  readonly connectionId: string;
+  readonly principalId: string;
+  readonly clientInstanceId: string;
+}
+
 export interface ClientCapabilityConnection {
   accept(frame: ClientCapabilityClientFrame): void;
   close(): Promise<void>;
@@ -12,7 +18,7 @@ export interface ClientCapabilityConnection {
 /** Pure full-duplex seam kept outside the Runtime-backed execution composition. */
 export interface ClientCapabilityService {
   attachConnection(
-    connectionId: string,
+    identity: ClientCapabilityConnectionIdentity,
     sender: ClientCapabilityConnectionSender,
   ): ClientCapabilityConnection;
 }

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -196,18 +196,13 @@ export class RuntimeHostConnectionSession {
 
     try {
       if (this.#closed) return;
+      this.#ensureClientCapabilities();
       const continuity =
         frame.operation === 'subscription.open' ||
         frame.operation === 'subscription.close' ||
         frame.operation === 'session.transcript.query'
           ? this.#ensureContinuity()
           : undefined;
-      if (
-        frame.operation === 'client.capability.replace' ||
-        frame.operation === 'client.capability.unregister'
-      ) {
-        this.#ensureClientCapabilities();
-      }
       const response = await dispatchOperation(frame, this.#options.resolveHandlers(), {
         ...this.#options.connection,
         principal: this.#options.connection.authority.principalId,
@@ -268,15 +263,22 @@ export class RuntimeHostConnectionSession {
     }
     if (!this.#clientCapabilities) {
       this.#clientCapabilityService = service;
-      this.#clientCapabilities = service.attachConnection(this.#options.connection.connectionId, {
-        send: (frame) => {
-          try {
-            return this.#writer.enqueue(frame).flushed;
-          } catch (error) {
-            return Promise.reject(error);
-          }
+      this.#clientCapabilities = service.attachConnection(
+        {
+          connectionId: this.#options.connection.connectionId,
+          principalId: this.#options.connection.authority.principalId,
+          clientInstanceId: this.#options.connection.clientInstanceId,
         },
-      });
+        {
+          send: (frame) => {
+            try {
+              return this.#writer.enqueue(frame).flushed;
+            } catch (error) {
+              return Promise.reject(error);
+            }
+          },
+        },
+      );
     }
     return this.#clientCapabilities;
   }


### PR DESCRIPTION
## Summary

- persist one Desktop Runtime Host Client instance identity under the Electron `userData` profile;
- key Client Capability providers by the authenticated principal and persistent Client instance instead of an ephemeral connection;
- preserve Session affinity while a provider is disconnected and restore it only when that exact authenticated Client returns with an equivalent contract;
- let a reconnecting Client take over its provider lease before the stale connection finishes closing, without allowing stale unregister or teardown to invalidate the replacement.

The wire registration ID remains an immutable manifest-version identity. Reconnect affinity uses the stable provider identity, so in-flight snapshots can retain their original registration without mutating it in place.

Refs #2522

## Verification

- `npm --workspace @maka/runtime-host test` — 797 tests passed;
- `npm --workspace @maka/runtime-host run typecheck`;
- `npm exec -- tsc -p apps/desktop/tsconfig.main.json --noEmit`;
- focused real-UDS reconnect coverage verifies disconnect, unavailable state, authenticated rebind, and invocation over the replacement connection;
- Biome and `git diff --check` pass for the affected files.

## Remaining Phase 4 work

- shared reconnect and bounded-backoff lifecycle;
- subscription catch-up and operation-specific indeterminate-outcome handling;
- unattended capability-provider service mode and provider-unavailable Automation behavior;
- restart, partition, slow-consumer, revocation, and shutdown journeys.

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

- 在 Electron `userData` profile 下持久化 Desktop Runtime Host Client 实例身份；
- Client Capability provider 不再绑定临时连接，而是绑定认证主体与持久 Client 实例；
- provider 断开时保留 Session affinity；只有同一认证 Client 携带等价 contract 返回时才恢复；
- 新连接可在旧连接完成关闭前接管 provider lease，旧连接后续的 unregister 或 teardown 不会破坏替代连接。

wire registration ID 继续表示不可变的 manifest 版本。重连 affinity 使用稳定 provider 身份，因此正在使用的 snapshot 可以继续引用原 registration，不需要原地修改。

关联 #2522

## 验证

- `npm --workspace @maka/runtime-host test`：797 项测试通过；
- `npm --workspace @maka/runtime-host run typecheck`；
- `npm exec -- tsc -p apps/desktop/tsconfig.main.json --noEmit`；
- 真实 UDS 重连覆盖验证了断开、不可用状态、认证身份重绑定，以及替代连接上的工具调用；
- 受影响文件通过 Biome 与 `git diff --check`。

## Phase 4 剩余工作

- 共享重连与有界退避生命周期；
- subscription catch-up 与按 operation 区分的 indeterminate outcome 处理；
- 无人值守 capability-provider service mode 与 Automation provider unavailable 行为；
- restart、partition、slow consumer、revocation 与 shutdown 场景。

</details>

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
