### PR TITLE
fix(release): align filesystem worker smoke protocol

### DIFF
--- a/scripts/macos-arm64-release.test.mjs
+++ b/scripts/macos-arm64-release.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
+import { FILESYSTEM_WORKER_PROTOCOL_VERSION } from '../packages/runtime/dist/filesystem-worker/protocol.js';
 
 const signingEnvironment = {
   CSC_LINK: 'base64-certificate',
@@ -9,6 +12,35 @@ const signingEnvironment = {
   APPLE_API_KEY_ID: 'TESTKEY',
   APPLE_API_ISSUER: '00000000-0000-0000-0000-000000000000',
 };
+
+test('the packaged filesystem worker smoke uses the runtime protocol version', async () => {
+  const { smokePackagedFilesystemWorker } = await import(
+    new URL('verify-macos-arm64-dmg.mjs', import.meta.url)
+  );
+  const workingDirectory = await mkdtemp(join(tmpdir(), 'maka-filesystem-worker-smoke-'));
+
+  try {
+    await smokePackagedFilesystemWorker('/tmp/Maka', '/tmp/filesystem-worker.js', {
+      workingDirectory,
+      run: async (_command, _args, options) => {
+        const request = JSON.parse(options.input);
+        assert.equal(request.version, FILESYSTEM_WORKER_PROTOCOL_VERSION);
+        await writeFile(request.operation.path, request.operation.content, 'utf8');
+        return {
+          stdout: JSON.stringify({
+            version: FILESYSTEM_WORKER_PROTOCOL_VERSION,
+            requestId: request.requestId,
+            ok: true,
+            result: { kind: 'write', ok: true, path: request.operation.path, bytes: 25 },
+          }),
+          stderr: '',
+        };
+      },
+    });
+  } finally {
+    await rm(workingDirectory, { recursive: true, force: true });
+  }
+});
 
 test('release tooling fails closed on unsupported hosts, signing, and architecture', async () => {
   const desktopManifest = JSON.parse(

--- a/scripts/verify-macos-arm64-dmg.mjs
+++ b/scripts/verify-macos-arm64-dmg.mjs
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { FILESYSTEM_WORKER_PROTOCOL_VERSION } from '../packages/runtime/dist/filesystem-worker/protocol.js';
 import {
   assertMissing,
   assertPackagedResources,
@@ -32,7 +33,7 @@ function runCommandFromRepo(command, args, options = {}) {
 
 // macOS-only: the worker exists to enforce a sandbox profile, and Windows has no
 // implementation of one, so the app there runs file tools in-process instead.
-async function smokePackagedFilesystemWorker(
+export async function smokePackagedFilesystemWorker(
   executable,
   worker,
   { workingDirectory, run = runCommand } = {},
@@ -46,7 +47,7 @@ async function smokePackagedFilesystemWorker(
     },
   };
   const request = {
-    version: 4,
+    version: FILESYSTEM_WORKER_PROTOCOL_VERSION,
     requestId: 'release-filesystem-worker-smoke',
     operation: { kind: 'write', cwd: workspace, path: target, content },
     operationBoundary,


### PR DESCRIPTION
## Summary

- make the packaged macOS filesystem-worker smoke use the protocol version exported by the built runtime instead of a duplicated hardcoded value
- add a regression test that captures the packaged-worker request and verifies it stays aligned with the runtime protocol

This fixes the `Verify the final DMG` failure in release run #31318321465, where the verifier sent protocol v4 after #2532 upgraded the worker to v5.

After merge, rerun the `Release desktop` workflow from `main` for v0.1.9.

## Verification

- `node --test scripts/macos-arm64-release.test.mjs` (3/3 passed)
- `git diff --check`

A clean `npm ci --ignore-scripts` was attempted but the registry connection reset while fetching dependencies. The focused test was run against the built protocol module after TypeScript emitted it.