### PR TITLE
fix(runtime): make the Stop/timeout lifecycle race deterministic (#2514)

### DIFF
--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -2253,63 +2253,101 @@ describe('ShellRunProcessManager', () => {
     assert.equal(manager.livePtyCount(), 0);
   });
 
-  test('keeps the first committed lifecycle cause across Stop and timeout races', {
+  // The first-committed lifecycle cause must win the reported status across the
+  // Stop/timeout race. Each scenario pins one arrival ordering with the injected
+  // `scheduleTimeout` seam (see manualTimeoutScheduler) instead of betting on a
+  // wall-clock `timeoutMs`, so the focused race is deterministic and CI-stable.
+  // A far-future `timeoutMs` keeps the real timeout out of the way; `timeouts.fire()`
+  // decides exactly when the timeout commits. `trap "" TERM` + SIGKILL escalation
+  // stays real, but commit ownership is decided before the kill lands, so kill
+  // timing cannot flip the cause.
+  describe('keeps the first committed lifecycle cause across Stop and timeout races', {
     skip:
       process.platform === 'win32'
         ? 'Windows tree termination has no graceful SIGTERM phase'
         : false,
-  }, async () => {
-    const cancelledManager = await createTestManager(undefined, { killGraceMs: 500 });
-    const cancelledRun = await cancelledManager.runBackgroundBash(
-      shellInput({
-        cwd: await workspace(),
-        command: 'trap "" TERM; printf "READY\\n"; while :; do sleep 1; done',
-        pty: true,
-        timeoutMs: 350,
-      }),
-    );
-    assert.equal(cancelledRun.kind, 'shell_run');
-    const cancelled = await cancelledManager.stopBackgroundTask(
-      'session-1',
-      cancelledRun.ref,
-      NO_ABORT,
-    );
-    assertShellRun(cancelled);
-    assert.equal(cancelled.status, 'cancelled');
-    assert.deepEqual(cancelled.operation, { kind: 'stop', applied: true });
+  }, () => {
+    const stall = 'trap "" TERM; printf "READY\\n"; while :; do sleep 1; done';
 
-    const timedOutManager = await createTestManager(undefined, { killGraceMs: 500 });
-    const timedOutRun = await timedOutManager.runBackgroundBash(
-      shellInput({
-        cwd: await workspace(),
-        command: 'trap "" TERM; stty -echo; printf "READY\\n"; while :; do sleep 1; done',
-        pty: true,
-        timeoutMs: 350,
-      }),
-    );
-    assert.equal(timedOutRun.kind, 'shell_run');
-    await waitUntil(async () => {
-      try {
-        await timedOutManager.writeStdin({
-          sessionId: 'session-1',
-          ref: timedOutRun.ref,
-          input: 'x',
-          abortSignal: NO_ABORT,
-        });
-        return false;
-      } catch (error) {
-        if (error instanceof ShellRunPtyControlClosedError) return true;
-        throw error;
-      }
+    test('Stop commits first -> cancelled (Stop owns the termination)', async () => {
+      const timeouts = manualTimeoutScheduler();
+      const manager = await createTestManager(undefined, {
+        killGraceMs: 500,
+        scheduleTimeout: timeouts.schedule,
+      });
+      const run = await manager.runBackgroundBash(
+        shellInput({ cwd: await workspace(), command: stall, pty: true, timeoutMs: 60_000 }),
+      );
+      assert.equal(run.kind, 'shell_run');
+
+      const stopped = await manager.stopBackgroundTask('session-1', run.ref, NO_ABORT);
+      // Fire after Stop already committed: the timeout callback sees live.termination
+      // set and no-ops; on an empty pending set this is an explicit no-op anyway.
+      timeouts.fire();
+
+      assertShellRun(stopped);
+      assert.equal(stopped.status, 'cancelled');
+      assert.deepEqual(stopped.operation, { kind: 'stop', applied: true });
     });
-    const timedOut = await timedOutManager.stopBackgroundTask(
-      'session-1',
-      timedOutRun.ref,
-      NO_ABORT,
-    );
-    assertShellRun(timedOut);
-    assert.equal(timedOut.status, 'timed_out');
-    assert.deepEqual(timedOut.operation, { kind: 'stop', applied: false });
+
+    test('timeout kills, then Stop arrives -> timed_out (driverExit branch)', async () => {
+      const timeouts = manualTimeoutScheduler();
+      const manager = await createTestManager(undefined, {
+        killGraceMs: 500,
+        scheduleTimeout: timeouts.schedule,
+      });
+      const run = await manager.runBackgroundBash(
+        shellInput({ cwd: await workspace(), command: stall, pty: true, timeoutMs: 60_000 }),
+      );
+      assert.equal(run.kind, 'shell_run');
+
+      // Fire first: timeout commits 'timeout', SIGTERM is trapped, SIGKILL kills.
+      timeouts.fire();
+      await waitForTerminalShellRun(manager, run.ref);
+
+      const stopped = await manager.stopBackgroundTask('session-1', run.ref, NO_ABORT);
+      assertShellRun(stopped);
+      assert.equal(stopped.status, 'timed_out');
+      assert.deepEqual(stopped.operation, { kind: 'stop', applied: false });
+    });
+
+    test('timeout commits but process still alive, then Stop arrives -> timed_out (termination branch)', async () => {
+      const timeouts = manualTimeoutScheduler();
+      const manager = await createTestManager(undefined, {
+        killGraceMs: 500,
+        scheduleTimeout: timeouts.schedule,
+      });
+      const run = await manager.runBackgroundBash(
+        shellInput({ cwd: await workspace(), command: stall, pty: true, timeoutMs: 60_000 }),
+      );
+      assert.equal(run.kind, 'shell_run');
+
+      // Fire commits 'timeout' and sends SIGTERM, which `trap "" TERM` ignores, so
+      // the process stays alive while the termination is in flight. writeStdin
+      // refuses once termination is committed — that is exactly the in-flight state.
+      timeouts.fire();
+      await waitUntil(async () => {
+        try {
+          await manager.writeStdin({
+            sessionId: 'session-1',
+            ref: run.ref,
+            input: 'x',
+            abortSignal: NO_ABORT,
+          });
+          return false;
+        } catch (error) {
+          if (error instanceof ShellRunPtyControlClosedError) return true;
+          throw error;
+        }
+      });
+
+      // Stop arrives while the process is still alive but termination is committed:
+      // stopBackgroundTask joins via the live.termination branch without re-arbitrating.
+      const stopped = await manager.stopBackgroundTask('session-1', run.ref, NO_ABORT);
+      assertShellRun(stopped);
+      assert.equal(stopped.status, 'timed_out');
+      assert.deepEqual(stopped.operation, { kind: 'stop', applied: false });
+    });
   });
 
   test('releases failed startup slots and enforces total and PTY capacities independently', async () => {
@@ -2458,6 +2496,7 @@ function createManager(
     pipeOutputDrainMs?: number;
     onPtyData?: ShellRunProcessManagerInput['onPtyData'];
     scheduleFlush?: ShellRunProcessManagerInput['scheduleFlush'];
+    scheduleTimeout?: ShellRunProcessManagerInput['scheduleTimeout'];
   } = {},
 ): ShellRunProcessManager {
   let id = 0;
@@ -2496,6 +2535,25 @@ function manualFlushScheduler(): {
   };
 }
 
+/** Holds run timeouts until the test fires them, replacing wall-clock timeout timing. */
+function manualTimeoutScheduler(): {
+  schedule: (run: () => void, delayMs: number) => () => void;
+  fire: () => void;
+} {
+  const pending = new Set<() => void>();
+  return {
+    schedule: (run) => {
+      pending.add(run);
+      return () => pending.delete(run);
+    },
+    fire: () => {
+      const due = [...pending];
+      pending.clear();
+      for (const run of due) run();
+    },
+  };
+}
+
 async function createTestManager(
   onShellRunUpdate?: (update: ShellRunUpdate) => void,
   options?: {
@@ -2505,6 +2563,8 @@ async function createTestManager(
     flushIntervalMs?: number;
     pipeOutputDrainMs?: number;
     onPtyData?: ShellRunProcessManagerInput['onPtyData'];
+    scheduleFlush?: ShellRunProcessManagerInput['scheduleFlush'];
+    scheduleTimeout?: ShellRunProcessManagerInput['scheduleTimeout'];
   },
 ): Promise<ShellRunProcessManager> {
   return createManager(createSqliteShellRunStore(await workspace()), onShellRunUpdate, options);

--- a/packages/runtime/src/shell-run-contract.ts
+++ b/packages/runtime/src/shell-run-contract.ts
@@ -63,6 +63,8 @@ export interface ShellRunProcessManagerInput {
   pipeOutputDrainMs?: number;
   /** Schedules the automatic durable flush and returns its canceler; injected so tests can drive flush timing. */
   scheduleFlush?: (run: () => void, delayMs: number) => () => void;
+  /** Schedules the run timeout and returns its canceler; injected so tests can drive timeout timing. */
+  scheduleTimeout?: (run: () => void, delayMs: number) => () => void;
 }
 
 export interface ShellRunBashInput {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -162,7 +162,7 @@ interface LiveShellRunBase {
   integrityFailure?: Error;
   termination?: TerminationLifecycle;
   pendingStops: Set<PendingStop>;
-  timeoutTimer?: NodeJS.Timeout;
+  cancelTimeout?: () => void;
   cancelFlush?: () => void;
   flushInFlight?: Promise<ShellRunRecord>;
   persistChain: Promise<void>;
@@ -242,6 +242,7 @@ export class ShellRunProcessManager
   private readonly exitAcknowledgementMs: number;
   private readonly pipeOutputDrainMs: number;
   private readonly scheduleFlush: (run: () => void, delayMs: number) => () => void;
+  private readonly scheduleTimeout: (run: () => void, delayMs: number) => () => void;
   private reservedShellRuns = 0;
   private reservedPtyRuns = 0;
   private shuttingDown = false;
@@ -259,6 +260,12 @@ export class ShellRunProcessManager
     this.pipeOutputDrainMs = input.pipeOutputDrainMs ?? DEFAULT_PIPE_OUTPUT_DRAIN_MS;
     this.scheduleFlush =
       input.scheduleFlush ??
+      ((run, delayMs) => {
+        const timer = setTimeout(run, delayMs);
+        return () => clearTimeout(timer);
+      });
+    this.scheduleTimeout =
+      input.scheduleTimeout ??
       ((run, delayMs) => {
         const timer = setTimeout(run, delayMs);
         return () => clearTimeout(timer);
@@ -1775,7 +1782,7 @@ export class ShellRunProcessManager
 
   private armTimeout(live: LiveShellRun): void {
     if (live.timeoutMs === undefined) return;
-    live.timeoutTimer = setTimeout(() => {
+    live.cancelTimeout = this.scheduleTimeout(() => {
       if (live.rootExited || live.finalizeOnce || live.termination) return;
       live.lifecycleCause ??= 'timeout';
       this.requestForcedTermination(live, 'timeout');
@@ -1783,12 +1790,12 @@ export class ShellRunProcessManager
   }
 
   private clearLiveTimers(live: LiveShellRun): void {
-    if (live.timeoutTimer) clearTimeout(live.timeoutTimer);
+    live.cancelTimeout?.();
     if (live.mode === 'pty' && live.rawPublishTimer) {
       clearTimeout(live.rawPublishTimer);
     }
     live.cancelFlush?.();
-    live.timeoutTimer = undefined;
+    live.cancelTimeout = undefined;
     if (live.mode === 'pty') live.rawPublishTimer = undefined;
     live.cancelFlush = undefined;
   }


### PR DESCRIPTION
## Summary

Make the `keeps the first committed lifecycle cause across Stop and timeout races` test deterministic so the Runtime workspace stops flaking on CI (#2514).

### Root cause: a wall-clock bet, not a broken contract

Both scenarios differ only in **when Stop arrives relative to the timeout committing**, but that ordering was driven by a real `setTimeout(timeoutMs)` in `armTimeout`. The decisive detail is how `stopBackgroundTask` resolves — it **does not re-arbitrate** the cause once termination is underway:

```ts
if (live.driverExit)  { return ... { kind: 'stop', applied: false }; }   // process already dead
if (live.termination) { await waitForTerminationDecision(...); return ... { applied: false }; }  // timeout committed
// beginStopTermination also short-circuits: rootExited / live.termination -> finishPendingStop
```

So whichever side commits first "wins" the cause, and Stop just joins. Scenario 1 requires Stop to commit *before* the 350 ms timeout fires. Under CI load, event-loop scheduling can delay Stop past that boundary; once the timeout has set `live.termination` (or killed the process), `stopBackgroundTask` returns at its first guard → the run is reported `timed_out`. This matches the reported failure (`expected cancelled but received timed_out`).

A clarification on the PR #1776 cancel-override (`requestTermination` L1315): that branch is **not reachable from `stopBackgroundTask`** — Stop never calls `requestTermination`; it either starts its own termination via `beginStopTermination` or joins an existing one. The override's real callers are the run abort paths (`runBackgroundBash`/`runForegroundBash`) and session/runtime shutdown. So #1776 fixed the related race on those paths; #2514 is the different race the issue author flagged — wall-clock deciding whether Stop arrives before or after the timeout commits, with `stopBackgroundTask` simply joining whichever outcome is in flight. The lifecycle contract itself is intact; this is a test timing problem.

### Changes (3 files, +124 / −55)

**1. `shell-run-contract.ts` (+2)** — add an injectable `scheduleTimeout` seam, a twin of the existing `scheduleFlush`:
```ts
/** Schedules the run timeout and returns its canceler; injected so tests can drive timeout timing. */
scheduleTimeout?: (run: () => void, delayMs: number) => () => void;
```

**2. `shell-run-manager.ts` (+15 / −7)** — wire the seam. The `timeoutTimer?: NodeJS.Timeout` field becomes a generic `cancelTimeout?: () => void` (mirrors the existing `cancelFlush` field). The constructor binds `scheduleTimeout`, defaulting to real `setTimeout` when unset (**production behavior is unchanged**). `armTimeout` / `clearLiveTimers` use the seam. No arbitration logic (`requestTermination` / `runTermination` / `finalState` / cancel-override) is touched.

**3. `shell-run-manager.test.ts` (+101 / −48)** — add a `manualTimeoutScheduler()` helper (twin of `manualFlushScheduler()`, same `Set` + iterate semantics so `fire()` on an empty set is an explicit no-op) and rewrite the flaky two-scenario test into **three deterministic scenarios**. Each pins one arrival ordering via `timeouts.fire()` instead of betting on `timeoutMs: 350`; a far-future `timeoutMs: 60_000` keeps the real timeout out of the way. `trap "" TERM` + SIGKILL escalation stays real, but commit ownership is decided before the kill lands, so kill timing cannot flip the cause. Each scenario covers a distinct `stopBackgroundTask` branch:

| Scenario | Ordering | Expected | Branch |
|----------|----------|----------|--------|
| 1 | Stop commits first | `cancelled`, `applied: true` | Stop owns the termination |
| 2 | timeout kills, then Stop | `timed_out`, `applied: false` | `live.driverExit` (process gone) |
| 3 | timeout commits, process still alive, then Stop | `timed_out`, `applied: false` | `live.termination` (in-flight) |

Scenarios 2 and 3 are not redundant: `driverExit` and `live.termination` are different code paths in `stopBackgroundTask` with different join behavior, so pinning both gives independent regression coverage. **All original assertions (status and operation) are kept verbatim.**

### How this satisfies the issue's four goals

1. **Establish whether the contract is violated or Stop starts too close to the boundary.** — The contract is intact. The test started Stop too close to the `timeoutMs` boundary under CI load; `stopBackgroundTask` does not re-arbitrate once termination is in flight. Confirmed both by reading the code paths and empirically (see Verification).
2. **Replace wall-clock scheduling with a deterministic synchronization seam where practical.** — `scheduleTimeout` replaces the wall-clock timeout exactly where it decides the race. The `killGraceMs` latch and `rawPublishTimer` are left real — they don't decide commit ownership.
3. **Preserve the lifecycle contract; do not weaken the assertion or add retries.** — No change to arbitration logic; status **and** operation assertions kept unchanged; no retries.
4. **Verify the focused race repeatedly and keep the Runtime workspace CI stable.** — See Verification.

## Verification

**Tooling gates (all clean):**
- `npm run format:check` — 1643 files, no changes needed
- `npm run lint` — 2477 files, no issues
- `npm run typecheck` — all workspaces, zero type errors
- `npm --workspace @maka/runtime run build` — clean
- `npm --workspace @maka/runtime run test:dist`: 3390pass, 9 skipped. 

**Focused-race stability (the issue's core ask) — 200× loop, 0 failures:**

The rewritten scenarios were looped 200 times locally (125 + 75 batches), each run executing all three scenarios:

```
run 25: all pass    run 100: all pass
run 50: all pass    run 125: all pass
run 75: all pass    + 75-run batch: 0 failures
                    === 200-run total: 0 failures ===
```

**Before/after comparison (window elimination, per the issue's "verify" intent):**

| | Before (original test) | After (this PR) |
|---|---|---|
| Timeout trigger | real `setTimeout(350)` — OS decides when | `timeouts.fire()` — test decides when |
| Ordering control | none; bets Stop beats 350 ms | pinned per scenario via `fire()` placement |
| Local stability | 30/30 pass (light load) — window still present | 200/200 pass — window removed at the mechanism level |

An honest note on evidence strength: the 200× result is *statistical* support (the window is very likely gone), while the seam rewrite provides *mechanism-level* support (the wall-clock dependency that created the window is removed — `fire()` decides ordering explicitly). Together they support the conclusion that the focused race is now deterministic. This does not mathematically prove zero residual timing surface; e.g. scenario 3's `writeStdin`-throws barrier shares the same narrow shape as the original scenario 2's barrier (an in-flight-termination probe), but with ~25× timing margin (first poll ~20 ms vs `killGraceMs` 500 ms) and is not a regression.

Refs #2514.