### PR TITLE
fix(desktop): restore slash command discovery

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -1,9 +1,21 @@
 import { expect, test, COMPOSER_INPUT } from './fixtures';
 
-test('groups commands before Skills and stages a command without running it', async ({
+test('shows only slash commands executable in the current session state', async ({
   invocableSkillsWindow: page,
 }) => {
   const composer = page.locator(COMPOSER_INPUT);
+  await composer.click();
+  await composer.pressSequentially('/');
+
+  const freshMenu = page.getByRole('listbox', { name: '命令和技能' });
+  const freshCommands = freshMenu.getByRole('group', { name: '命令' });
+  await expect(freshCommands.getByRole('option')).toHaveCount(2);
+  await expect(freshCommands.getByRole('option', { name: /使用 Graph.*\/graph/ })).toBeVisible();
+  await expect(freshCommands.getByRole('option', { name: /使用 Swarm.*\/swarm/ })).toBeVisible();
+  await expect(freshCommands.getByRole('option', { name: /\/compact/ })).toHaveCount(0);
+  await expect(freshCommands.getByRole('option', { name: /\/side/ })).toHaveCount(0);
+
+  await composer.press('Escape');
   await composer.fill('seed session');
   await composer.press('Enter');
   await expect(page.getByText('Fake backend received: seed session')).toBeVisible();
@@ -17,10 +29,60 @@ test('groups commands before Skills and stages a command without running it', as
   await expect(groups.nth(0)).toHaveAttribute('aria-label', '命令');
   await expect(groups.nth(1)).toHaveAttribute('aria-label', 'Skills');
 
-  const compact = groups.nth(0).getByRole('option', { name: /压缩上下文.*\/compact/ });
-  await expect(compact).toBeVisible();
-  await compact.click();
+  await expect(groups.nth(0).getByRole('option')).toHaveCount(4);
+});
 
-  await expect.poll(() => composer.textContent()).toBe('/compact ');
+test('stages a slash command without performing its action', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('seed session');
+  await composer.press('Enter');
+  await expect(page.getByText('Fake backend received: seed session')).toBeVisible();
+
+  await composer.click();
+  await composer.pressSequentially('/');
+
+  const menu = page.getByRole('listbox', { name: '命令和技能' });
+  const side = menu.getByRole('group', { name: '命令' }).getByRole('option', {
+    name: /打开侧聊.*\/side/,
+  });
+  await side.click();
+
+  await expect.poll(() => composer.textContent()).toBe('/side ');
+  await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(0);
   await expect(menu).not.toBeVisible();
+});
+
+test('offers commands only for the first token and keeps explicit Skill queries separate', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('seed session');
+  await composer.press('Enter');
+  await expect(page.getByText('Fake backend received: seed session')).toBeVisible();
+
+  await composer.fill('explain /');
+  const inlineMenu = page.getByRole('listbox', { name: '命令和技能' });
+  await expect(inlineMenu.getByRole('group', { name: '命令' })).toHaveCount(0);
+  await expect(inlineMenu.getByRole('group', { name: 'Skills' })).toBeVisible();
+
+  await composer.fill('/skill:compact');
+  await expect(inlineMenu.getByRole('option', { name: /\/compact/ })).toHaveCount(0);
+});
+
+test('dispatches a staged slash command instead of steering it into a running turn', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('keep streaming '.repeat(80));
+  await composer.press('Enter');
+  await expect(page.getByRole('button', { name: '停止' })).toBeVisible();
+
+  await composer.fill('/side discuss separately');
+  await expect(page.getByRole('button', { name: '插入消息' })).toBeVisible();
+  await composer.press('Enter');
+
+  await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(1);
+  await expect(page.getByText(/Acknowledged steering: \/side discuss separately/)).toHaveCount(0);
 });

--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -30,13 +30,27 @@ test('shows only slash commands executable in the current session state', async 
   await expect(groups.nth(0).getByRole('option')).toHaveCount(4);
 });
 
-test('dispatches Compact without sending it as a prompt', async ({
+test('compacts the active session', async ({
   invocableSkillsWindow: page,
 }) => {
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill('seed session');
   await composer.press('Enter');
   await expect(page.getByText('Fake backend received: seed session')).toBeVisible();
+
+  const sessionId = await page.evaluate(async () => (await window.maka.sessions.list())[0]?.id);
+  expect(sessionId).toBeTruthy();
+  await page.evaluate((activeSessionId) => {
+    const testWindow = window as typeof window & {
+      __makaObservedCompactCompletion?: boolean;
+    };
+    testWindow.__makaObservedCompactCompletion = false;
+    window.maka.sessions.subscribeChanges((event) => {
+      if (event.reason === 'status-change' && event.sessionId === activeSessionId) {
+        testWindow.__makaObservedCompactCompletion = true;
+      }
+    });
+  }, sessionId!);
 
   await composer.click();
   await composer.pressSequentially('/');
@@ -50,6 +64,18 @@ test('dispatches Compact without sending it as a prompt', async ({
   await expect.poll(() => composer.textContent()).toBe('/compact ');
   await expect(menu).not.toBeVisible();
   await composer.press('Enter');
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { __makaObservedCompactCompletion?: boolean })
+            .__makaObservedCompactCompletion,
+      ),
+    )
+    .toBe(true);
+  await expect.poll(() => composer.textContent()).toBe('');
+  await expect(page.getByText('压缩失败')).toHaveCount(0);
 
   await composer.fill('after compact');
   await composer.press('Enter');

--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test, COMPOSER_INPUT } from './fixtures';
+
+test('groups commands before Skills and stages a command without running it', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('seed session');
+  await composer.press('Enter');
+  await expect(page.getByText('Fake backend received: seed session')).toBeVisible();
+
+  await composer.click();
+  await composer.pressSequentially('/');
+
+  const menu = page.getByRole('listbox', { name: '命令和技能' });
+  const groups = menu.getByRole('group');
+  await expect(groups).toHaveCount(2);
+  await expect(groups.nth(0)).toHaveAttribute('aria-label', '命令');
+  await expect(groups.nth(1)).toHaveAttribute('aria-label', 'Skills');
+
+  const compact = groups.nth(0).getByRole('option', { name: /压缩上下文.*\/compact/ });
+  await expect(compact).toBeVisible();
+  await compact.click();
+
+  await expect.poll(() => composer.textContent()).toBe('/compact ');
+  await expect(menu).not.toBeVisible();
+});

--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -12,8 +12,6 @@ test('shows only slash commands executable in the current session state', async 
   await expect(freshCommands.getByRole('option')).toHaveCount(2);
   await expect(freshCommands.getByRole('option', { name: /使用 Graph.*\/graph/ })).toBeVisible();
   await expect(freshCommands.getByRole('option', { name: /使用 Swarm.*\/swarm/ })).toBeVisible();
-  await expect(freshCommands.getByRole('option', { name: /\/compact/ })).toHaveCount(0);
-  await expect(freshCommands.getByRole('option', { name: /\/side/ })).toHaveCount(0);
 
   await composer.press('Escape');
   await composer.fill('seed session');
@@ -32,7 +30,7 @@ test('shows only slash commands executable in the current session state', async 
   await expect(groups.nth(0).getByRole('option')).toHaveCount(4);
 });
 
-test('stages a slash command without performing its action', async ({
+test('dispatches Compact without sending it as a prompt', async ({
   invocableSkillsWindow: page,
 }) => {
   const composer = page.locator(COMPOSER_INPUT);
@@ -44,14 +42,19 @@ test('stages a slash command without performing its action', async ({
   await composer.pressSequentially('/');
 
   const menu = page.getByRole('listbox', { name: '命令和技能' });
-  const side = menu.getByRole('group', { name: '命令' }).getByRole('option', {
-    name: /打开侧聊.*\/side/,
+  const compact = menu.getByRole('group', { name: '命令' }).getByRole('option', {
+    name: /压缩上下文.*\/compact/,
   });
-  await side.click();
+  await compact.click();
 
-  await expect.poll(() => composer.textContent()).toBe('/side ');
-  await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(0);
+  await expect.poll(() => composer.textContent()).toBe('/compact ');
   await expect(menu).not.toBeVisible();
+  await composer.press('Enter');
+
+  await composer.fill('after compact');
+  await composer.press('Enter');
+  await expect(page.getByText('Fake backend received: after compact')).toBeVisible();
+  await expect(page.getByText('Fake backend received: /compact')).toHaveCount(0);
 });
 
 test('offers commands only for the first token and keeps explicit Skill queries separate', async ({
@@ -69,6 +72,11 @@ test('offers commands only for the first token and keeps explicit Skill queries 
 
   await composer.fill('/skill:compact');
   await expect(inlineMenu.getByRole('option', { name: /\/compact/ })).toHaveCount(0);
+
+  await composer.fill('/side');
+  await composer.press('Home');
+  await composer.press('ArrowRight');
+  await expect(inlineMenu.getByRole('group', { name: '命令' })).toHaveCount(0);
 });
 
 test('dispatches a staged slash command instead of steering it into a running turn', async ({
@@ -79,10 +87,22 @@ test('dispatches a staged slash command instead of steering it into a running tu
   await composer.press('Enter');
   await expect(page.getByRole('button', { name: '停止' })).toBeVisible();
 
-  await composer.fill('/side discuss separately');
+  await composer.fill('/compact explain');
   await expect(page.getByRole('button', { name: '插入消息' })).toBeVisible();
   await composer.press('Enter');
 
+  await composer.fill('/');
+  const menu = page.getByRole('listbox', { name: '命令和技能' });
+  const commands = menu.getByRole('group', { name: '命令' });
+  await expect(commands.getByRole('option', { name: /\/compact/ })).toHaveCount(0);
+  const side = commands.getByRole('option', { name: /打开侧聊.*\/side/ });
+  await side.click();
+  await expect.poll(() => composer.textContent()).toBe('/side ');
+  await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(0);
+
+  await composer.fill('/side discuss separately');
+  await composer.press('Enter');
+
   await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(1);
-  await expect(page.getByText(/Acknowledged steering: \/side discuss separately/)).toHaveCount(0);
+  await expect(page.getByText(/Acknowledged steering: \/compact explain/)).toBeVisible();
 });

--- a/apps/desktop/src/main/__tests__/desktop-slash-command.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-slash-command.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseDesktopSlashCommand } from '../../renderer/desktop-slash-command.js';
+
+describe('Desktop slash command parsing', () => {
+  it('recognizes only input accepted by a Desktop command parser', () => {
+    assert.deepEqual(parseDesktopSlashCommand(' /compact '), { kind: 'compact' });
+    assert.equal(parseDesktopSlashCommand('/compact explain'), null);
+    assert.deepEqual(parseDesktopSlashCommand('/side discuss separately'), {
+      kind: 'side',
+      command: { prompt: 'discuss separately' },
+    });
+    assert.deepEqual(parseDesktopSlashCommand('/graph status'), {
+      kind: 'graph',
+      command: { kind: 'status' },
+    });
+    assert.deepEqual(parseDesktopSlashCommand('/swarm investigate'), {
+      kind: 'swarm',
+      command: { kind: 'run_once', task: 'investigate' },
+    });
+    assert.equal(parseDesktopSlashCommand('explain /side'), null);
+  });
+});

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -20,8 +20,6 @@ import type {
 import {
   collapseSessionRevisions,
   isLinkedSubagentSession,
-  parseGraphCommand,
-  parseSwarmCommand,
   resolveUiLocale,
   slashCommandsForSurface,
 } from '@maka/core';
@@ -31,6 +29,7 @@ import {
   DailyReviewPage,
   ChatSurfaceLayout,
   type ComposerHandle,
+  type ComposerSendMetadata,
   type ComposerSlashCommandOption,
   type MakaUriDest,
   MakaUriContext,
@@ -87,10 +86,8 @@ import {
   removeStagedCompanionQuote,
   stageCompanionQuote,
 } from './quote-companion-panel-state';
-import {
-  parseSideChatCommand,
-  sideChatTitleFromPrompt,
-} from './side-chat-command';
+import { sideChatTitleFromPrompt } from './side-chat-command';
+import { parseDesktopSlashCommand } from './desktop-slash-command';
 import {
   applyCompanionForkVisibilityEvent,
   reconcileCompanionForkVisibility,
@@ -1375,8 +1372,11 @@ function AppShellContent({
   );
   const desktopSlashCommands = useMemo<readonly ComposerSlashCommandOption[]>(
     () => {
+      const streaming = turnActive || activeStreamingLive;
       const availableCommands = slashCommandsForSurface('desktop').filter(
-        ({ session }) => session === 'none' || Boolean(activeId),
+        ({ id, session }) =>
+          (session === 'none' || Boolean(activeId))
+          && !(streaming && id === 'compact'),
       );
       const presentation: Record<
         SlashCommandIdForSurface<'desktop'>,
@@ -1405,7 +1405,7 @@ function AppShellContent({
       };
       return availableCommands.map(({ id }) => ({ id, ...presentation[id] }));
     },
-    [activeId, shellCopy.slashCommands],
+    [activeId, activeStreamingLive, shellCopy.slashCommands, turnActive],
   );
   const openSideConversationWithQuote = useCallback(
     (quote: QuoteRef) => {
@@ -1909,15 +1909,13 @@ function AppShellContent({
 
   async function sendWithAttachments(
     text: string,
-    metadata?: { workspaceFileReferences?: readonly WorkspaceFileReferencePosition[] },
+    metadata?: ComposerSendMetadata,
   ): Promise<boolean | void> {
     const revision = revisionDraftRef.current;
     const revisionSend = Boolean(
       revision && activeIdRef.current === revision.draftSessionId,
     );
-    const sideChatCommand = parseSideChatCommand(text);
-    const swarmCommand = parseSwarmCommand(text);
-    const graphCommand = parseGraphCommand(text);
+    const slashCommand = parseDesktopSlashCommand(text);
     if (
       revisionSend &&
       revision &&
@@ -1934,13 +1932,13 @@ function AppShellContent({
         toastApi.info(actionCopy.revisionUnavailableTitle, actionCopy.revisionAttachmentsUnsupported);
         return false;
       }
-      if (text.trim() === '/compact' || sideChatCommand || swarmCommand || graphCommand) {
+      if (slashCommand) {
         toastApi.info(actionCopy.revisionUnavailableTitle, actionCopy.revisionCommandUnsupported);
         return false;
       }
       if (!(await prepareRevisionSend(text))) return false;
     }
-    if (text.trim() === '/compact') {
+    if (slashCommand?.kind === 'compact') {
       const sessionId = activeIdRef.current;
       if (!sessionId) return true;
       try {
@@ -1959,7 +1957,7 @@ function AppShellContent({
         return false;
       }
     }
-    if (sideChatCommand) {
+    if (slashCommand?.kind === 'side') {
       if (!activeIdRef.current) {
         toastApi.info(
           shellCopy.sideChatUnavailableTitle,
@@ -1978,10 +1976,11 @@ function AppShellContent({
         );
         return false;
       }
-      openSideConversation(sideChatCommand.prompt || undefined);
+      openSideConversation(slashCommand.command.prompt || undefined);
       return true;
     }
-    if (swarmCommand) {
+    if (slashCommand?.kind === 'swarm') {
+      const swarmCommand = slashCommand.command;
       if (swarmCommand.kind === 'status') {
         const active = activeIdRef.current
           ? (activeSessionForView?.orchestrationMode ?? 'default') === 'swarm'
@@ -2023,7 +2022,8 @@ function AppShellContent({
       if (ok !== false && quotes) clearQuotes();
       return ok;
     }
-    if (graphCommand) {
+    if (slashCommand?.kind === 'graph') {
+      const graphCommand = slashCommand.command;
       if (graphCommand.kind === 'status') {
         const active = activeIdRef.current
           ? (activeSessionForView?.orchestrationMode ?? 'default') === 'graph'
@@ -2107,6 +2107,15 @@ function AppShellContent({
       }
       return false;
     }
+  }
+
+  function submitWhileStreaming(
+    text: string,
+    metadata?: ComposerSendMetadata,
+  ): Promise<boolean | void> {
+    return parseDesktopSlashCommand(text)
+      ? sendWithAttachments(text, metadata)
+      : steerWithText(text);
   }
 
   const stop = createAppShellStopAction({
@@ -2728,7 +2737,7 @@ function AppShellContent({
                   processing={showProcessingIndicator && !activeStreamingLive}
                   continuing={showContinuingIndicator && !activeStreamingLive}
                   onSend={sendWithAttachments}
-                  onSteer={steerWithText}
+                  onStreamingSubmit={submitWhileStreaming}
                   onStop={stop}
                   revisionNotice={
                     revisionDraft && activeId === revisionDraft.draftSessionId

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -13,6 +13,7 @@ import type {
   PlanReminder,
   QuoteRef,
   SessionSummary,
+  SlashCommandId,
   UiLocale,
   UiLocalePreference,
 } from '@maka/core';
@@ -22,6 +23,7 @@ import {
   parseGraphCommand,
   parseSwarmCommand,
   resolveUiLocale,
+  slashCommandsForSurface,
 } from '@maka/core';
 import { hasSettledInitialOnboarding } from '@maka/core/onboarding-milestone';
 import {
@@ -52,7 +54,7 @@ import {
   getSharedUiCopy,
   reconcileInteractions,
 } from '@maka/ui';
-import { MessageCircleQuestion } from '@maka/ui/icons';
+import { GitBranch, MessageCircleQuestion, Minimize2, Network } from '@maka/ui/icons';
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
 import { ChatMessageSurface } from './chat-message-surface';
@@ -1371,25 +1373,42 @@ function AppShellContent({
     (initialPrompt?: string) => openNewSideConversation('right', initialPrompt),
     [openNewSideConversation],
   );
-  const openSideConversationRef = useRef(openSideConversation);
-  openSideConversationRef.current = openSideConversation;
-  const sideChatSlashCommands = useMemo<
-    readonly ComposerSlashCommandOption[]
-  >(
-    () =>
-      activeId
-        ? [
-            {
-              id: 'side',
-              name: workbarCopy.sideChat,
-              description: workbarCopy.launcher.sideChat,
-              keywords: ['side', 'btw', '侧聊', '追问'],
-              Icon: MessageCircleQuestion,
-              onSelect: () => openSideConversationRef.current(),
-            },
-          ]
-        : [],
-    [activeId, workbarCopy],
+  const desktopSlashCommands = useMemo<readonly ComposerSlashCommandOption[]>(
+    () => {
+      const availableCommands = slashCommandsForSurface('desktop').filter(
+        ({ session }) => session === 'none' || Boolean(activeId),
+      );
+      const presentation: Partial<
+        Record<SlashCommandId, Omit<ComposerSlashCommandOption, 'id'>>
+      > = {
+        compact: {
+          ...shellCopy.slashCommands.compact,
+          keywords: ['compact', 'context', '压缩', '上下文'],
+          Icon: Minimize2,
+        },
+        side: {
+          ...shellCopy.slashCommands.side,
+          keywords: ['side', 'btw', '侧聊', '追问'],
+          Icon: MessageCircleQuestion,
+        },
+        swarm: {
+          ...shellCopy.slashCommands.swarm,
+          keywords: ['swarm', 'multi-agent', '多智能体'],
+          Icon: Network,
+        },
+        graph: {
+          ...shellCopy.slashCommands.graph,
+          keywords: ['graph', 'agent graph', '智能体图'],
+          Icon: GitBranch,
+        },
+      };
+      return availableCommands.map(({ id }) => {
+        const option = presentation[id];
+        if (!option) throw new Error(`Missing Desktop slash command presentation: /${id}`);
+        return { id, ...option };
+      });
+    },
+    [activeId, shellCopy.slashCommands],
   );
   const openSideConversationWithQuote = useCallback(
     (quote: QuoteRef) => {
@@ -2725,7 +2744,7 @@ function AppShellContent({
                       : undefined
                   }
                   mentionSkills={mentionSkills}
-                  slashCommands={sideChatSlashCommands}
+                  slashCommands={desktopSlashCommands}
                   onSearchMentionFiles={searchMentionFiles}
                   pendingAttachments={pendingAttachments}
                   onRemoveAttachment={removeAttachment}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -13,7 +13,7 @@ import type {
   PlanReminder,
   QuoteRef,
   SessionSummary,
-  SlashCommandId,
+  SlashCommandIdForSurface,
   UiLocale,
   UiLocalePreference,
 } from '@maka/core';
@@ -1378,8 +1378,9 @@ function AppShellContent({
       const availableCommands = slashCommandsForSurface('desktop').filter(
         ({ session }) => session === 'none' || Boolean(activeId),
       );
-      const presentation: Partial<
-        Record<SlashCommandId, Omit<ComposerSlashCommandOption, 'id'>>
+      const presentation: Record<
+        SlashCommandIdForSurface<'desktop'>,
+        Omit<ComposerSlashCommandOption, 'id'>
       > = {
         compact: {
           ...shellCopy.slashCommands.compact,
@@ -1402,11 +1403,7 @@ function AppShellContent({
           Icon: GitBranch,
         },
       };
-      return availableCommands.map(({ id }) => {
-        const option = presentation[id];
-        if (!option) throw new Error(`Missing Desktop slash command presentation: /${id}`);
-        return { id, ...option };
-      });
+      return availableCommands.map(({ id }) => ({ id, ...presentation[id] }));
     },
     [activeId, shellCopy.slashCommands],
   );

--- a/apps/desktop/src/renderer/desktop-slash-command.ts
+++ b/apps/desktop/src/renderer/desktop-slash-command.ts
@@ -1,0 +1,24 @@
+import {
+  parseGraphCommand,
+  parseSwarmCommand,
+  type ParsedGraphCommand,
+  type ParsedSwarmCommand,
+} from '@maka/core';
+import { parseSideChatCommand, type SideChatCommand } from './side-chat-command.js';
+
+export type DesktopSlashCommand =
+  | { kind: 'compact' }
+  | { kind: 'side'; command: SideChatCommand }
+  | { kind: 'graph'; command: ParsedGraphCommand }
+  | { kind: 'swarm'; command: ParsedSwarmCommand };
+
+/** Classify input with the same parsers that own Desktop command execution. */
+export function parseDesktopSlashCommand(input: string): DesktopSlashCommand | null {
+  if (input.trim() === '/compact') return { kind: 'compact' };
+  const side = parseSideChatCommand(input);
+  if (side) return { kind: 'side', command: side };
+  const graph = parseGraphCommand(input);
+  if (graph) return { kind: 'graph', command: graph };
+  const swarm = parseSwarmCommand(input);
+  return swarm ? { kind: 'swarm', command: swarm } : null;
+}

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -372,6 +372,10 @@ type ShellCopy = {
     newConversation: string;
     compactErrorTitle: string;
     compactErrorFallback: string;
+    slashCommands: Record<'compact' | 'graph' | 'side' | 'swarm', {
+      name: string;
+      description: string;
+    }>;
     sideChatUnavailableTitle: string;
     sideChatUnavailableDescription: string;
     sideChatContextPendingTitle: string;
@@ -1048,6 +1052,12 @@ const SHELL_COPY_BY_LOCALE = {
       newConversation: '新建对话',
       compactErrorTitle: '压缩失败',
       compactErrorFallback: '对话暂时无法压缩，请稍后重试。',
+      slashCommands: {
+        compact: { name: '压缩上下文', description: '压缩旧历史并保留当前任务' },
+        graph: { name: '使用 Graph', description: '查看、切换或单次运行 Graph' },
+        side: { name: '打开侧聊', description: '在右侧开始一个具体话题' },
+        swarm: { name: '使用 Swarm', description: '查看、切换或单次运行 Swarm' },
+      },
       sideChatUnavailableTitle: '暂时无法打开侧边对话',
       sideChatUnavailableDescription: '请先在主会话中发送一条消息，再使用 /side。',
       sideChatContextPendingTitle: '先处理待发送的上下文',
@@ -1553,6 +1563,12 @@ const SHELL_COPY_BY_LOCALE = {
       newConversation: 'New conversation',
       compactErrorTitle: 'Compaction failed',
       compactErrorFallback: 'The conversation could not be compacted. Try again later.',
+      slashCommands: {
+        compact: { name: 'Compact context', description: 'Compact older history while preserving the current task' },
+        graph: { name: 'Use Graph', description: 'Inspect, switch, or run Graph once' },
+        side: { name: 'Open side chat', description: 'Start a specific topic in the side panel' },
+        swarm: { name: 'Use Swarm', description: 'Inspect, switch, or run Swarm once' },
+      },
       sideChatUnavailableTitle: 'Side chat is not available yet',
       sideChatUnavailableDescription:
         'Send a message in the main conversation before using /side.',

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -6,6 +6,7 @@ import {
   type PermissionMode,
   type ChatDefaultPermissionMode,
   type SettingsSection,
+  type SlashCommandIdForSurface,
   type ThinkingLevel,
 } from '@maka/core';
 
@@ -372,7 +373,7 @@ type ShellCopy = {
     newConversation: string;
     compactErrorTitle: string;
     compactErrorFallback: string;
-    slashCommands: Record<'compact' | 'graph' | 'side' | 'swarm', {
+    slashCommands: Record<SlashCommandIdForSurface<'desktop'>, {
       name: string;
       description: string;
     }>;

--- a/apps/desktop/src/renderer/quote-companion-panel.tsx
+++ b/apps/desktop/src/renderer/quote-companion-panel.tsx
@@ -226,7 +226,7 @@ export function QuoteCompanionPanel(props: {
                 return accepted;
               }}
               onStop={() => void companion.stop()}
-              onSteer={(text: string) => companion.steer(text)}
+              onStreamingSubmit={(text: string) => companion.steer(text)}
               hidden={Boolean(activeInteraction)}
               streaming={companion.streaming}
               processing={companion.processing}

--- a/apps/desktop/src/renderer/styles/composer-mention.css
+++ b/apps/desktop/src/renderer/styles/composer-mention.css
@@ -47,6 +47,12 @@
   white-space: nowrap;
 }
 
+.maka-composer-command-token {
+  margin-inline-start: var(--space-2);
+  color: var(--muted-foreground);
+  font: var(--maka-text-code);
+}
+
 .maka-composer-mention-secondary {
   font: var(--maka-text-supporting);
   min-width: 0;

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -28,7 +28,7 @@ import {
   type QueueEnqueueOutcome,
   type SessionSummary,
   type ShellRunUpdate,
-  type SlashCommandId,
+  type SlashCommandIdForSurface,
 } from '@maka/core';
 import {
   buildForeignSessionHandoffMessage,
@@ -2307,7 +2307,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     );
   };
 
-  type TuiSlashCommandId = Exclude<SlashCommandId, 'side'>;
+  type TuiSlashCommandId = SlashCommandIdForSurface<'tui'>;
   type TuiSlashCommandHandler = Omit<MakaSlashCommand, 'name' | 'aliases'>;
 
   const slashCommandHandlers = {
@@ -2576,16 +2576,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
   } satisfies Record<TuiSlashCommandId, TuiSlashCommandHandler>;
 
-  const slashCommands: MakaSlashCommand[] = slashCommandsForSurface('tui').flatMap((spec) => {
-    if (spec.id === 'side') return [];
-    return [
-      {
-        name: spec.id,
-        ...('aliases' in spec ? { aliases: spec.aliases } : {}),
-        ...slashCommandHandlers[spec.id],
-      },
-    ];
-  });
+  const slashCommands: MakaSlashCommand[] = slashCommandsForSurface('tui').map((spec) => ({
+    name: spec.id,
+    ...('aliases' in spec ? { aliases: spec.aliases } : {}),
+    ...slashCommandHandlers[spec.id],
+  }));
 
   const handleSlashCommand = (prompt: string, idleMs: number): boolean => {
     const trimmed = prompt.trim();

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -24,9 +24,11 @@ import type { OrchestrationMode } from '@maka/core/orchestration';
 import type { SkillInvocationResult } from '@maka/core/skill-invocation';
 import {
   projectRevisionLinkedSessionTree,
+  slashCommandsForSurface,
   type QueueEnqueueOutcome,
   type SessionSummary,
   type ShellRunUpdate,
+  type SlashCommandId,
 } from '@maka/core';
 import {
   buildForeignSessionHandoffMessage,
@@ -2305,9 +2307,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     );
   };
 
-  const slashCommands: MakaSlashCommand[] = [
-    {
-      name: 'context',
+  type TuiSlashCommandId = Exclude<SlashCommandId, 'side'>;
+  type TuiSlashCommandHandler = Omit<MakaSlashCommand, 'name' | 'aliases'>;
+
+  const slashCommandHandlers = {
+    context: {
       description: 'Show latest request context usage',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
@@ -2332,8 +2336,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         });
       },
     },
-    {
-      name: 'compact',
+    compact: {
       description: 'Compact session context',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
@@ -2348,30 +2351,25 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void runControl(compactSession);
       },
     },
-    {
-      name: 'exit',
+    exit: {
       description: 'Exit Maka',
-      aliases: ['quit'],
       run: () => {
         beginGracefulClose();
       },
     },
-    {
-      name: 'help',
+    help: {
       description: 'Show commands and keybindings',
       run: () => {
         void runControl(async () => showHelp());
       },
     },
-    {
-      name: 'new',
+    new: {
       description: 'Start a new session',
       run: () => {
         void runControl(async () => newSession());
       },
     },
-    {
-      name: 'skill',
+    skill: {
       description: 'Invoke a skill (or type /skill:<name> inline)',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
@@ -2386,8 +2384,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void showSkillList();
       },
     },
-    {
-      name: 'setup',
+    setup: {
       description: 'Set up a model provider (API key)',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
@@ -2402,8 +2399,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void showSetupWizard();
       },
     },
-    {
-      name: 'model',
+    model: {
       description: 'Select model',
       run: (parts: string[]) => {
         if (parts.length === 1) {
@@ -2423,8 +2419,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void runControl(() => setModel(nextModel));
       },
     },
-    {
-      name: 'move',
+    move: {
       description: 'Move current session to another directory',
       run: (parts: string[], rawTail?: string) => {
         const targetCwd = (rawTail ?? parts.slice(1).join(' ')).trim();
@@ -2435,8 +2430,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         showMovePicker();
       },
     },
-    {
-      name: 'thinking',
+    thinking: {
       description: 'Set thinking level',
       run: (parts: string[]) => {
         if (parts.length === 1) {
@@ -2474,8 +2468,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void runControl(() => setThinkingLevel(level));
       },
     },
-    {
-      name: 'permissions',
+    permissions: {
       description: 'Set session permissions',
       run: (parts: string[]) => {
         if (parts.length === 1) {
@@ -2495,15 +2488,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         requestSandboxBoundaryMode(mode);
       },
     },
-    {
-      name: 'recap',
+    recap: {
       description: 'One-sentence recap of the session so far',
       run: () => {
         void runRecap('manual');
       },
     },
-    {
-      name: 'rename',
+    rename: {
       description: 'Rename current session',
       run: (parts: string[]) => {
         const name = parts.slice(1).join(' ').trim();
@@ -2528,8 +2519,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         });
       },
     },
-    {
-      name: 'resume',
+    resume: {
       description: 'Resume latest interrupted run at a safe boundary',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
@@ -2544,15 +2534,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void runControl(resumeSession);
       },
     },
-    {
-      name: 'rewind',
+    rewind: {
       description: 'Rewind to an earlier turn',
       run: () => {
         void runControl(showRewindPicker);
       },
     },
-    {
-      name: 'session',
+    session: {
       description: 'Resume session',
       run: (parts: string[]) => {
         if (parts.length === 1) {
@@ -2572,23 +2560,32 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         void runControl(() => switchSession(sessionId));
       },
     },
-    {
-      name: 'graph',
+    graph: {
       description: 'Show, enable, disable, or run one Graph turn',
       run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
         const parsed = parseGraphCommand(`/graph${rawTail ? ` ${rawTail}` : ''}`);
         if (parsed) runGraphCommand(parsed, context.idleMs);
       },
     },
-    {
-      name: 'swarm',
+    swarm: {
       description: 'Show, enable, disable, or run one Swarm turn',
       run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
         const parsed = parseSwarmCommand(`/swarm${rawTail ? ` ${rawTail}` : ''}`);
         if (parsed) runSwarmCommand(parsed, context.idleMs);
       },
     },
-  ].sort((left, right) => left.name.localeCompare(right.name));
+  } satisfies Record<TuiSlashCommandId, TuiSlashCommandHandler>;
+
+  const slashCommands: MakaSlashCommand[] = slashCommandsForSurface('tui').flatMap((spec) => {
+    if (spec.id === 'side') return [];
+    return [
+      {
+        name: spec.id,
+        ...('aliases' in spec ? { aliases: spec.aliases } : {}),
+        ...slashCommandHandlers[spec.id],
+      },
+    ];
+  });
 
   const handleSlashCommand = (prompt: string, idleMs: number): boolean => {
     const trimmed = prompt.trim();

--- a/packages/core/src/__tests__/slash-command-catalog.test.ts
+++ b/packages/core/src/__tests__/slash-command-catalog.test.ts
@@ -4,30 +4,6 @@ import { SLASH_COMMAND_CATALOG, slashCommandsForSurface } from '../slash-command
 
 describe('slash command catalog', () => {
   it('owns every built-in command identity and alias once', () => {
-    assert.deepEqual(
-      SLASH_COMMAND_CATALOG.map(({ id }) => id),
-      [
-        'compact',
-        'context',
-        'exit',
-        'graph',
-        'help',
-        'model',
-        'move',
-        'new',
-        'permissions',
-        'recap',
-        'rename',
-        'resume',
-        'rewind',
-        'session',
-        'setup',
-        'side',
-        'skill',
-        'swarm',
-        'thinking',
-      ],
-    );
     const identities = SLASH_COMMAND_CATALOG.flatMap((command) => [
       command.id,
       ...('aliases' in command ? command.aliases : []),
@@ -39,6 +15,7 @@ describe('slash command catalog', () => {
   });
 
   it('declares the commands each product surface can actually execute', () => {
+    assert.ok(SLASH_COMMAND_CATALOG.every(({ surfaces }) => surfaces.length > 0));
     assert.deepEqual(
       slashCommandsForSurface('desktop').map(({ id }) => id),
       ['compact', 'graph', 'side', 'swarm'],

--- a/packages/core/src/__tests__/slash-command-catalog.test.ts
+++ b/packages/core/src/__tests__/slash-command-catalog.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  SLASH_COMMAND_CATALOG,
+  slashCommandsForSurface,
+  slashCommandSpec,
+} from '../slash-command-catalog.js';
+
+describe('slash command catalog', () => {
+  it('owns every built-in command identity and alias once', () => {
+    assert.deepEqual(
+      SLASH_COMMAND_CATALOG.map(({ id }) => id),
+      [
+        'compact',
+        'context',
+        'exit',
+        'graph',
+        'help',
+        'model',
+        'move',
+        'new',
+        'permissions',
+        'recap',
+        'rename',
+        'resume',
+        'rewind',
+        'session',
+        'setup',
+        'side',
+        'skill',
+        'swarm',
+        'thinking',
+      ],
+    );
+    assert.deepEqual(slashCommandSpec('exit'), {
+      id: 'exit',
+      aliases: ['quit'],
+      tail: 'none',
+      session: 'none',
+      surfaces: ['tui'],
+    });
+  });
+
+  it('describes the shared tail grammar used by every surface', () => {
+    assert.equal(slashCommandSpec('compact').tail, 'none');
+    assert.equal(slashCommandSpec('rename').tail, 'required');
+    assert.equal(slashCommandSpec('side').tail, 'optional');
+    assert.equal(slashCommandSpec('skill').tail, 'none');
+    assert.equal(slashCommandSpec('swarm').tail, 'optional');
+  });
+
+  it('declares the commands each product surface can actually execute', () => {
+    assert.deepEqual(
+      slashCommandsForSurface('desktop').map(({ id }) => id),
+      ['compact', 'graph', 'side', 'swarm'],
+    );
+    assert.deepEqual(
+      slashCommandsForSurface('tui').map(({ id }) => id),
+      SLASH_COMMAND_CATALOG.filter(({ id }) => id !== 'side').map(({ id }) => id),
+    );
+  });
+});

--- a/packages/core/src/__tests__/slash-command-catalog.test.ts
+++ b/packages/core/src/__tests__/slash-command-catalog.test.ts
@@ -1,10 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import {
-  SLASH_COMMAND_CATALOG,
-  slashCommandsForSurface,
-  slashCommandSpec,
-} from '../slash-command-catalog.js';
+import { SLASH_COMMAND_CATALOG, slashCommandsForSurface } from '../slash-command-catalog.js';
 
 describe('slash command catalog', () => {
   it('owns every built-in command identity and alias once', () => {
@@ -32,21 +28,14 @@ describe('slash command catalog', () => {
         'thinking',
       ],
     );
-    assert.deepEqual(slashCommandSpec('exit'), {
-      id: 'exit',
-      aliases: ['quit'],
-      tail: 'none',
-      session: 'none',
-      surfaces: ['tui'],
-    });
-  });
-
-  it('describes the shared tail grammar used by every surface', () => {
-    assert.equal(slashCommandSpec('compact').tail, 'none');
-    assert.equal(slashCommandSpec('rename').tail, 'required');
-    assert.equal(slashCommandSpec('side').tail, 'optional');
-    assert.equal(slashCommandSpec('skill').tail, 'none');
-    assert.equal(slashCommandSpec('swarm').tail, 'optional');
+    const identities = SLASH_COMMAND_CATALOG.flatMap((command) => [
+      command.id,
+      ...('aliases' in command ? command.aliases : []),
+    ]);
+    assert.equal(new Set(identities).size, identities.length);
+    const exit = SLASH_COMMAND_CATALOG.find(({ id }) => id === 'exit');
+    assert.ok(exit && 'aliases' in exit);
+    assert.deepEqual(exit.aliases, ['quit']);
   });
 
   it('declares the commands each product surface can actually execute', () => {
@@ -56,7 +45,26 @@ describe('slash command catalog', () => {
     );
     assert.deepEqual(
       slashCommandsForSurface('tui').map(({ id }) => id),
-      SLASH_COMMAND_CATALOG.filter(({ id }) => id !== 'side').map(({ id }) => id),
+      [
+        'compact',
+        'context',
+        'exit',
+        'graph',
+        'help',
+        'model',
+        'move',
+        'new',
+        'permissions',
+        'recap',
+        'rename',
+        'resume',
+        'rewind',
+        'session',
+        'setup',
+        'skill',
+        'swarm',
+        'thinking',
+      ],
     );
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './orchestration.js';
 export * from './tool-mode.js';
 export * from './swarm-command.js';
 export * from './graph-command.js';
+export * from './slash-command-catalog.js';
 export * from './plan.js';
 export * from './agent-graph-control.js';
 export * from './agent-graph-schedule.js';

--- a/packages/core/src/slash-command-catalog.ts
+++ b/packages/core/src/slash-command-catalog.ts
@@ -1,0 +1,47 @@
+export type SlashCommandTail = 'none' | 'optional' | 'required';
+export type SlashCommandSessionRequirement = 'none' | 'required';
+export type SlashCommandSurface = 'desktop' | 'tui';
+
+export interface SlashCommandSpec {
+  readonly id: string;
+  readonly aliases?: readonly string[];
+  readonly tail: SlashCommandTail;
+  readonly session: SlashCommandSessionRequirement;
+  readonly surfaces: readonly SlashCommandSurface[];
+}
+
+export const SLASH_COMMAND_CATALOG = [
+  { id: 'compact', tail: 'none', session: 'required', surfaces: ['desktop', 'tui'] },
+  { id: 'context', tail: 'none', session: 'required', surfaces: ['tui'] },
+  { id: 'exit', aliases: ['quit'], tail: 'none', session: 'none', surfaces: ['tui'] },
+  { id: 'graph', tail: 'optional', session: 'required', surfaces: ['desktop', 'tui'] },
+  { id: 'help', tail: 'none', session: 'none', surfaces: ['tui'] },
+  { id: 'model', tail: 'optional', session: 'required', surfaces: ['tui'] },
+  { id: 'move', tail: 'optional', session: 'required', surfaces: ['tui'] },
+  { id: 'new', tail: 'none', session: 'none', surfaces: ['tui'] },
+  { id: 'permissions', tail: 'optional', session: 'required', surfaces: ['tui'] },
+  { id: 'recap', tail: 'none', session: 'required', surfaces: ['tui'] },
+  { id: 'rename', tail: 'required', session: 'required', surfaces: ['tui'] },
+  { id: 'resume', tail: 'none', session: 'required', surfaces: ['tui'] },
+  { id: 'rewind', tail: 'none', session: 'required', surfaces: ['tui'] },
+  { id: 'session', tail: 'optional', session: 'none', surfaces: ['tui'] },
+  { id: 'setup', tail: 'none', session: 'none', surfaces: ['tui'] },
+  { id: 'side', tail: 'optional', session: 'required', surfaces: ['desktop'] },
+  { id: 'skill', tail: 'none', session: 'required', surfaces: ['tui'] },
+  { id: 'swarm', tail: 'optional', session: 'required', surfaces: ['desktop', 'tui'] },
+  { id: 'thinking', tail: 'optional', session: 'required', surfaces: ['tui'] },
+] as const satisfies readonly SlashCommandSpec[];
+
+export type SlashCommandId = (typeof SLASH_COMMAND_CATALOG)[number]['id'];
+
+const SLASH_COMMAND_BY_ID = new Map(SLASH_COMMAND_CATALOG.map((command) => [command.id, command]));
+
+export function slashCommandSpec(id: SlashCommandId): SlashCommandSpec {
+  return SLASH_COMMAND_BY_ID.get(id)!;
+}
+
+export function slashCommandsForSurface(surface: SlashCommandSurface) {
+  return SLASH_COMMAND_CATALOG.filter((command) =>
+    (command.surfaces as readonly SlashCommandSurface[]).includes(surface),
+  );
+}

--- a/packages/core/src/slash-command-catalog.ts
+++ b/packages/core/src/slash-command-catalog.ts
@@ -1,47 +1,57 @@
-export type SlashCommandTail = 'none' | 'optional' | 'required';
 export type SlashCommandSessionRequirement = 'none' | 'required';
 export type SlashCommandSurface = 'desktop' | 'tui';
 
 export interface SlashCommandSpec {
   readonly id: string;
   readonly aliases?: readonly string[];
-  readonly tail: SlashCommandTail;
   readonly session: SlashCommandSessionRequirement;
   readonly surfaces: readonly SlashCommandSurface[];
 }
 
 export const SLASH_COMMAND_CATALOG = [
-  { id: 'compact', tail: 'none', session: 'required', surfaces: ['desktop', 'tui'] },
-  { id: 'context', tail: 'none', session: 'required', surfaces: ['tui'] },
-  { id: 'exit', aliases: ['quit'], tail: 'none', session: 'none', surfaces: ['tui'] },
-  { id: 'graph', tail: 'optional', session: 'required', surfaces: ['desktop', 'tui'] },
-  { id: 'help', tail: 'none', session: 'none', surfaces: ['tui'] },
-  { id: 'model', tail: 'optional', session: 'required', surfaces: ['tui'] },
-  { id: 'move', tail: 'optional', session: 'required', surfaces: ['tui'] },
-  { id: 'new', tail: 'none', session: 'none', surfaces: ['tui'] },
-  { id: 'permissions', tail: 'optional', session: 'required', surfaces: ['tui'] },
-  { id: 'recap', tail: 'none', session: 'required', surfaces: ['tui'] },
-  { id: 'rename', tail: 'required', session: 'required', surfaces: ['tui'] },
-  { id: 'resume', tail: 'none', session: 'required', surfaces: ['tui'] },
-  { id: 'rewind', tail: 'none', session: 'required', surfaces: ['tui'] },
-  { id: 'session', tail: 'optional', session: 'none', surfaces: ['tui'] },
-  { id: 'setup', tail: 'none', session: 'none', surfaces: ['tui'] },
-  { id: 'side', tail: 'optional', session: 'required', surfaces: ['desktop'] },
-  { id: 'skill', tail: 'none', session: 'required', surfaces: ['tui'] },
-  { id: 'swarm', tail: 'optional', session: 'required', surfaces: ['desktop', 'tui'] },
-  { id: 'thinking', tail: 'optional', session: 'required', surfaces: ['tui'] },
+  { id: 'compact', session: 'required', surfaces: ['desktop', 'tui'] },
+  { id: 'context', session: 'required', surfaces: ['tui'] },
+  { id: 'exit', aliases: ['quit'], session: 'none', surfaces: ['tui'] },
+  { id: 'graph', session: 'none', surfaces: ['desktop', 'tui'] },
+  { id: 'help', session: 'none', surfaces: ['tui'] },
+  { id: 'model', session: 'required', surfaces: ['tui'] },
+  { id: 'move', session: 'required', surfaces: ['tui'] },
+  { id: 'new', session: 'none', surfaces: ['tui'] },
+  { id: 'permissions', session: 'required', surfaces: ['tui'] },
+  { id: 'recap', session: 'required', surfaces: ['tui'] },
+  { id: 'rename', session: 'required', surfaces: ['tui'] },
+  { id: 'resume', session: 'required', surfaces: ['tui'] },
+  { id: 'rewind', session: 'required', surfaces: ['tui'] },
+  { id: 'session', session: 'none', surfaces: ['tui'] },
+  { id: 'setup', session: 'none', surfaces: ['tui'] },
+  { id: 'side', session: 'required', surfaces: ['desktop'] },
+  { id: 'skill', session: 'required', surfaces: ['tui'] },
+  { id: 'swarm', session: 'none', surfaces: ['desktop', 'tui'] },
+  { id: 'thinking', session: 'required', surfaces: ['tui'] },
 ] as const satisfies readonly SlashCommandSpec[];
 
 export type SlashCommandId = (typeof SLASH_COMMAND_CATALOG)[number]['id'];
 
-const SLASH_COMMAND_BY_ID = new Map(SLASH_COMMAND_CATALOG.map((command) => [command.id, command]));
-
-export function slashCommandSpec(id: SlashCommandId): SlashCommandSpec {
-  return SLASH_COMMAND_BY_ID.get(id)!;
+type CatalogCommand = (typeof SLASH_COMMAND_CATALOG)[number];
+type CatalogCommandForSurface<Command, Surface extends SlashCommandSurface> = Command extends {
+  readonly surfaces: readonly SlashCommandSurface[];
 }
+  ? Surface extends Command['surfaces'][number]
+    ? Command
+    : never
+  : never;
 
-export function slashCommandsForSurface(surface: SlashCommandSurface) {
+export type SlashCommandForSurface<Surface extends SlashCommandSurface> = CatalogCommandForSurface<
+  CatalogCommand,
+  Surface
+>;
+export type SlashCommandIdForSurface<Surface extends SlashCommandSurface> =
+  SlashCommandForSurface<Surface>['id'];
+
+export function slashCommandsForSurface<Surface extends SlashCommandSurface>(
+  surface: Surface,
+): readonly SlashCommandForSurface<Surface>[] {
   return SLASH_COMMAND_CATALOG.filter((command) =>
     (command.surfaces as readonly SlashCommandSurface[]).includes(surface),
-  );
+  ) as unknown as readonly SlashCommandForSurface<Surface>[];
 }

--- a/packages/runtime-host/src/desktop-e2e-execution-candidate-main.ts
+++ b/packages/runtime-host/src/desktop-e2e-execution-candidate-main.ts
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
-import { FakeBackend } from '@maka/runtime';
+import type { BackendCompactHistoryInput, BackendCompactHistoryResult } from '@maka/core';
+import {
+  buildHistoryCompactCheckpoint,
+  FakeBackend,
+  type BackendFactoryContext,
+} from '@maka/runtime';
 import { parseRuntimeHostCandidateArguments } from './candidate-cli.js';
 import { startExecutionRuntimeHostCandidate } from './server/execution-candidate.js';
 import { createExecutionRuntimeHostComposition } from './server/execution-composition.js';
@@ -7,6 +12,27 @@ import { runRuntimeHostProcessLifecycle } from './server/process-lifecycle.js';
 import { installRuntimeHostLogCapture } from './process-diagnostics.js';
 
 installRuntimeHostLogCapture();
+
+/** The desktop E2E backend mirrors the one control capability exercised by the slash menu. */
+class DesktopE2eBackend extends FakeBackend {
+  constructor(private readonly backendContext: BackendFactoryContext) {
+    super(backendContext);
+  }
+
+  async compactHistory(input: BackendCompactHistoryInput): Promise<BackendCompactHistoryResult> {
+    const recordCheckpoint = this.backendContext.recordHistoryCompactCheckpoint;
+    if (!recordCheckpoint) {
+      throw new Error('Desktop E2E compaction requires a checkpoint recorder');
+    }
+    const checkpoint = buildHistoryCompactCheckpoint({
+      sessionId: this.sessionId,
+      coveredRuntimeEvents: input.runtimeContext,
+      summary: 'Deterministic Desktop E2E context checkpoint.',
+    });
+    await recordCheckpoint(checkpoint, input.turnId);
+    return {};
+  }
+}
 
 const options = parseRuntimeHostCandidateArguments(process.argv.slice(2));
 const result = await startExecutionRuntimeHostCandidate(
@@ -26,7 +52,7 @@ const result = await startExecutionRuntimeHostCandidate(
           bootstrapRuntimePolicy: false,
         },
         {
-          primaryBackendFactory: (backendContext) => new FakeBackend(backendContext),
+          primaryBackendFactory: (backendContext) => new DesktopE2eBackend(backendContext),
           oauthAuthorization: {
             startCodexAuthorization: async () => ({
               deviceAuthId: 'desktop-e2e-device-authorization',

--- a/packages/ui/src/__tests__/chat-input-behavior.test.ts
+++ b/packages/ui/src/__tests__/chat-input-behavior.test.ts
@@ -122,10 +122,11 @@ describe('mention filtering', () => {
   });
 
   it('offers commands only for a leading token, outside explicit Skill syntax', () => {
-    assert.equal(slashCommandQuery('/', ''), '');
-    assert.equal(slashCommandQuery('  /comp', 'comp'), 'comp');
-    assert.equal(slashCommandQuery('explain /comp', 'comp'), null);
-    assert.equal(slashCommandQuery('/skill:compact', 'skill:compact'), null);
-    assert.equal(slashCommandQuery('/SKILL:compact', 'SKILL:compact'), null);
+    assert.equal(slashCommandQuery('/', '', ''), '');
+    assert.equal(slashCommandQuery('  /comp', '', 'comp'), 'comp');
+    assert.equal(slashCommandQuery('explain /comp', '', 'comp'), null);
+    assert.equal(slashCommandQuery('/comp', 'act', 'comp'), null);
+    assert.equal(slashCommandQuery('/skill:compact', '', 'skill:compact'), null);
+    assert.equal(slashCommandQuery('/SKILL:compact', '', 'SKILL:compact'), null);
   });
 });

--- a/packages/ui/src/__tests__/chat-input-behavior.test.ts
+++ b/packages/ui/src/__tests__/chat-input-behavior.test.ts
@@ -7,6 +7,7 @@ import {
   createTriggerSearchSource,
   isChatInputComposing,
   mentionQueryMatches,
+  slashCommandQuery,
   skillMentionQuery,
 } from '../chat-input-behavior.js';
 
@@ -118,5 +119,13 @@ describe('mention filtering', () => {
     assert.equal(skillMentionQuery('skill:wri'), 'wri');
     assert.equal(skillMentionQuery('SKILL:wri'), 'wri');
     assert.equal(skillMentionQuery('writer'), 'writer');
+  });
+
+  it('offers commands only for a leading token, outside explicit Skill syntax', () => {
+    assert.equal(slashCommandQuery('/', ''), '');
+    assert.equal(slashCommandQuery('  /comp', 'comp'), 'comp');
+    assert.equal(slashCommandQuery('explain /comp', 'comp'), null);
+    assert.equal(slashCommandQuery('/skill:compact', 'skill:compact'), null);
+    assert.equal(slashCommandQuery('/SKILL:compact', 'SKILL:compact'), null);
   });
 });

--- a/packages/ui/src/chat-input-behavior.ts
+++ b/packages/ui/src/chat-input-behavior.ts
@@ -102,6 +102,14 @@ export function skillMentionQuery(query: string): string {
   return query.toLowerCase().startsWith('skill:') ? query.slice('skill:'.length) : query;
 }
 
+/** Return the searchable command query only when `/` starts the draft's first token. */
+export function slashCommandQuery(textBeforeCaret: string, rawQuery: string): string | null {
+  if (rawQuery.toLowerCase().startsWith('skill:')) return null;
+  const triggerIndex = textBeforeCaret.length - rawQuery.length - 1;
+  if (triggerIndex < 0 || textBeforeCaret[triggerIndex] !== '/') return null;
+  return textBeforeCaret.slice(0, triggerIndex).trim() === '' ? rawQuery : null;
+}
+
 export interface ChatInputActionOwner<ActionId> {
   readonly pending: ActionId | null;
   run<Result>(actionId: ActionId, action: () => Promise<Result>): Promise<Result | undefined>;

--- a/packages/ui/src/chat-input-behavior.ts
+++ b/packages/ui/src/chat-input-behavior.ts
@@ -103,8 +103,13 @@ export function skillMentionQuery(query: string): string {
 }
 
 /** Return the searchable command query only when `/` starts the draft's first token. */
-export function slashCommandQuery(textBeforeCaret: string, rawQuery: string): string | null {
+export function slashCommandQuery(
+  textBeforeCaret: string,
+  textAfterCaret: string,
+  rawQuery: string,
+): string | null {
   if (rawQuery.toLowerCase().startsWith('skill:')) return null;
+  if (/^\S/.test(textAfterCaret)) return null;
   const triggerIndex = textBeforeCaret.length - rawQuery.length - 1;
   if (triggerIndex < 0 || textBeforeCaret[triggerIndex] !== '/') return null;
   return textBeforeCaret.slice(0, triggerIndex).trim() === '' ? rawQuery : null;

--- a/packages/ui/src/components.tsx
+++ b/packages/ui/src/components.tsx
@@ -40,6 +40,7 @@ export { AutomationsPage, DailyReviewPage, SkillsPage } from './module-pages.js'
 export { Composer } from './composer.js';
 export type {
   ComposerHandle,
+  ComposerSendMetadata,
   ComposerSlashCommandOption,
 } from './composer.js';
 export {

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -47,6 +47,7 @@ import {
   fileTransferContainsFiles,
   isChatInputComposing,
   mentionQueryMatches,
+  slashCommandQuery,
   skillMentionQuery,
   type ChatInputActionOwner,
   type ComposerTextPort,
@@ -683,14 +684,16 @@ export const Composer = forwardRef<
     mentionSkills: props.mentionSkills,
     slashCommands: props.slashCommands,
     onSearchMentionFiles: props.onSearchMentionFiles,
+    commandsGroup: mentionCopy.commandsGroup,
+    skillsGroup: mentionCopy.skillsGroup,
   });
-  useEffect(() => {
-    mentionSourceRef.current = {
-      mentionSkills: props.mentionSkills,
-      slashCommands: props.slashCommands,
-      onSearchMentionFiles: props.onSearchMentionFiles,
-    };
-  });
+  mentionSourceRef.current = {
+    mentionSkills: props.mentionSkills,
+    slashCommands: props.slashCommands,
+    onSearchMentionFiles: props.onSearchMentionFiles,
+    commandsGroup: mentionCopy.commandsGroup,
+    skillsGroup: mentionCopy.skillsGroup,
+  };
 
   const searchSourcesRef = useRef<{ files: SearchSource; skills: SearchSource }>(null);
   if (!searchSourcesRef.current) {
@@ -705,25 +708,41 @@ export const Composer = forwardRef<
     };
     const files = createTriggerSearchSource<SearchableItem>(runFileSearch);
     const listSlashSuggestions = (rawQuery: string): SearchableItem[] => {
-      const skills = mentionSourceRef.current.mentionSkills ?? [];
-      const commands = mentionSourceRef.current.slashCommands ?? [];
+      const source = mentionSourceRef.current;
+      const skills = source.mentionSkills ?? [];
+      const editable = editableNode();
+      const selection = document.getSelection();
+      let textBeforeCaret = textPort.getValue();
+      if (
+        editable &&
+        selection?.focusNode &&
+        editable.contains(selection.focusNode)
+      ) {
+        const range = document.createRange();
+        range.selectNodeContents(editable);
+        range.setEnd(selection.focusNode, selection.focusOffset);
+        textBeforeCaret = range.toString();
+      }
+      const commandQuery = slashCommandQuery(textBeforeCaret, rawQuery);
       const query = skillMentionQuery(rawQuery);
-      const commandItems = commands
-        .filter((command) =>
-          mentionQueryMatches(
-            query,
-            `${command.id} ${command.name} ${command.description ?? ''} ${(command.keywords ?? []).join(' ')}`,
-          ),
-        )
-        .map((command) => ({
-          id: `command:${command.id}`,
-          label: command.name,
-          auxiliaryData: {
-            kind: 'command',
-            command,
-            group: mentionCopy.commandsGroup,
-          } satisfies ComposerSlashSuggestion,
-        }));
+      const commandItems = commandQuery === null
+        ? []
+        : (source.slashCommands ?? [])
+            .filter((command) =>
+              mentionQueryMatches(
+                commandQuery,
+                `${command.id} ${command.name} ${command.description ?? ''} ${(command.keywords ?? []).join(' ')}`,
+              ),
+            )
+            .map((command) => ({
+              id: `command:${command.id}`,
+              label: command.name,
+              auxiliaryData: {
+                kind: 'command',
+                command,
+                group: source.commandsGroup,
+              } satisfies ComposerSlashSuggestion,
+            }));
       const skillItems = skills
         .filter((skill) =>
           mentionQueryMatches(query, `${skill.id} ${skill.name} ${skill.description ?? ''}`),
@@ -734,7 +753,7 @@ export const Composer = forwardRef<
           auxiliaryData: {
             kind: 'skill',
             skill,
-            group: mentionCopy.skillsGroup,
+            group: source.skillsGroup,
           } satisfies ComposerSlashSuggestion,
         }));
       return [...commandItems, ...skillItems].slice(0, 50);
@@ -1015,7 +1034,13 @@ export const Composer = forwardRef<
     setSendPending(true);
     let sent: boolean | void;
     try {
-      const submit = props.streaming && props.onSteer ? props.onSteer : props.onSend;
+      const commandToken = text.trimStart().split(/\s+/, 1)[0];
+      const isSlashCommand = props.slashCommands?.some(
+        (command) => commandToken === `/${command.id}`,
+      );
+      const submit = !isSlashCommand && props.streaming && props.onSteer
+        ? props.onSteer
+        : props.onSend;
       sent = await submit(
         text,
         workspaceFileReferences.length > 0 ? { workspaceFileReferences } : undefined,

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -217,8 +217,8 @@ export const Composer = forwardRef<
       text: string,
       metadata?: ComposerSendMetadata,
     ): boolean | void | Promise<boolean | void>;
-    /** Insert a text-only instruction into the active turn at its next step boundary. */
-    onSteer?(
+    /** Submit while a turn is active; the host owns control-command versus steering semantics. */
+    onStreamingSubmit?(
       text: string,
       metadata?: ComposerSendMetadata,
     ): boolean | void | Promise<boolean | void>;
@@ -713,6 +713,7 @@ export const Composer = forwardRef<
       const editable = editableNode();
       const selection = document.getSelection();
       let textBeforeCaret = textPort.getValue();
+      let textAfterCaret = '';
       if (
         editable &&
         selection?.focusNode &&
@@ -722,8 +723,11 @@ export const Composer = forwardRef<
         range.selectNodeContents(editable);
         range.setEnd(selection.focusNode, selection.focusOffset);
         textBeforeCaret = range.toString();
+        range.selectNodeContents(editable);
+        range.setStart(selection.focusNode, selection.focusOffset);
+        textAfterCaret = range.toString();
       }
-      const commandQuery = slashCommandQuery(textBeforeCaret, rawQuery);
+      const commandQuery = slashCommandQuery(textBeforeCaret, textAfterCaret, rawQuery);
       const query = skillMentionQuery(rawQuery);
       const commandItems = commandQuery === null
         ? []
@@ -918,7 +922,7 @@ export const Composer = forwardRef<
     const editable = editableNode();
     if (editable?.getAttribute('aria-expanded') !== 'true') return;
     editable.dispatchEvent(new Event('input', { bubbles: true }));
-  }, [props.mentionSkills, props.slashCommands]);
+  }, [locale, props.mentionSkills, props.slashCommands]);
 
   /**
    * An open menu must follow the caret, not just the text. `useTriggerMenu`
@@ -1034,12 +1038,8 @@ export const Composer = forwardRef<
     setSendPending(true);
     let sent: boolean | void;
     try {
-      const commandToken = text.trimStart().split(/\s+/, 1)[0];
-      const isSlashCommand = props.slashCommands?.some(
-        (command) => commandToken === `/${command.id}`,
-      );
-      const submit = !isSlashCommand && props.streaming && props.onSteer
-        ? props.onSteer
+      const submit = props.streaming && props.onStreamingSubmit
+        ? props.onStreamingSubmit
         : props.onSend;
       sent = await submit(
         text,
@@ -1766,7 +1766,7 @@ export const Composer = forwardRef<
           sendActions={(
             <div className="maka-composer-right-controls" />
           )}
-          sendButton={props.streaming && props.onSteer ? (
+          sendButton={props.streaming && props.onStreamingSubmit ? (
             <div className="maka-composer-running-actions">
               <IconButton
                 variant="ghost"

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -100,12 +100,11 @@ export interface ComposerSlashCommandOption {
   description?: string;
   keywords?: readonly string[];
   Icon?: LucideIcon;
-  onSelect(): void;
 }
 
 type ComposerSlashSuggestion =
-  | { kind: 'command'; command: ComposerSlashCommandOption }
-  | { kind: 'skill'; skill: ComposerSkillOption };
+  | { kind: 'command'; command: ComposerSlashCommandOption; group: string }
+  | { kind: 'skill'; skill: ComposerSkillOption; group: string };
 
 /**
  * The draft text a chosen Skill becomes. This is the product-wide invocation
@@ -719,7 +718,11 @@ export const Composer = forwardRef<
         .map((command) => ({
           id: `command:${command.id}`,
           label: command.name,
-          auxiliaryData: { kind: 'command', command } satisfies ComposerSlashSuggestion,
+          auxiliaryData: {
+            kind: 'command',
+            command,
+            group: mentionCopy.commandsGroup,
+          } satisfies ComposerSlashSuggestion,
         }));
       const skillItems = skills
         .filter((skill) =>
@@ -728,7 +731,11 @@ export const Composer = forwardRef<
         .map((skill) => ({
           id: `skill:${skill.id}`,
           label: skill.name,
-          auxiliaryData: { kind: 'skill', skill } satisfies ComposerSlashSuggestion,
+          auxiliaryData: {
+            kind: 'skill',
+            skill,
+            group: mentionCopy.skillsGroup,
+          } satisfies ComposerSlashSuggestion,
         }));
       return [...commandItems, ...skillItems].slice(0, 50);
     };
@@ -821,7 +828,10 @@ export const Composer = forwardRef<
                   />
                 ) : null}
                 <span className="maka-composer-mention-text">
-                  <span className="maka-composer-mention-name">{command.name}</span>
+                  <span className="maka-composer-mention-name">
+                    {command.name}
+                    <span className="maka-composer-command-token">/{command.id}</span>
+                  </span>
                   <span className="maka-composer-mention-secondary">
                     {command.description}
                   </span>
@@ -858,8 +868,7 @@ export const Composer = forwardRef<
         onSelect: (item): string | ChatComposerToken => {
           const suggestion = item.auxiliaryData as ComposerSlashSuggestion;
           if (suggestion.kind === 'command') {
-            suggestion.command.onSelect();
-            return '';
+            return `/${suggestion.command.id} `;
           }
           return inlineReferenceToken({
             kind: 'skill',

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -158,6 +158,8 @@ export interface ConversationCopy {
     filesAriaLabel: string;
     skillsAriaLabel: string;
     commandsAndSkillsAriaLabel: string;
+    commandsGroup: string;
+    skillsGroup: string;
     loading: string;
   };
   workspace: {
@@ -387,7 +389,7 @@ const CONVERSATION_COPY = {
       allowSession: '本会话允许',
     },
     questions: { other: '其他', otherDescription: '输入一个不同的答案。', otherAriaLabel: '其他答案', otherPlaceholder: '输入你的答案', stop: '停止', stopping: '停止中…', previous: '上一题', submitting: '正在提交…', submit: '提交答案', next: '下一题' },
-    mentions: { noFiles: '未找到文件', noSkills: '暂无技能', noCommandsOrSkills: '没有匹配的命令或技能', filesAriaLabel: '工作区文件', skillsAriaLabel: '技能', commandsAndSkillsAriaLabel: '命令和技能', loading: '加载中…' },
+    mentions: { noFiles: '未找到文件', noSkills: '暂无技能', noCommandsOrSkills: '没有匹配的命令或技能', filesAriaLabel: '工作区文件', skillsAriaLabel: '技能', commandsAndSkillsAriaLabel: '命令和技能', commandsGroup: '命令', skillsGroup: 'Skills', loading: '加载中…' },
     workspace: {
       choose: '选择项目', current: '当前项目', addProject: '添加项目', noProject: '无项目', relink: '重新定位',
       chooseTitle: (branch) => branch ? `选择项目 · ${branch}` : '选择项目',
@@ -526,7 +528,7 @@ const CONVERSATION_COPY = {
       allowSession: 'Allow for this session',
     },
     questions: { other: 'Other', otherDescription: 'Enter a different answer.', otherAriaLabel: 'Other answer', otherPlaceholder: 'Enter your answer', stop: 'Stop', stopping: 'Stopping…', previous: 'Previous', submitting: 'Submitting…', submit: 'Submit answers', next: 'Next' },
-    mentions: { noFiles: 'No files found', noSkills: 'No skills available', noCommandsOrSkills: 'No matching commands or skills', filesAriaLabel: 'Workspace files', skillsAriaLabel: 'Skills', commandsAndSkillsAriaLabel: 'Commands and skills', loading: 'Loading…' },
+    mentions: { noFiles: 'No files found', noSkills: 'No skills available', noCommandsOrSkills: 'No matching commands or skills', filesAriaLabel: 'Workspace files', skillsAriaLabel: 'Skills', commandsAndSkillsAriaLabel: 'Commands and skills', commandsGroup: 'Commands', skillsGroup: 'Skills', loading: 'Loading…' },
     workspace: {
       choose: 'Choose project', current: 'Current project', addProject: 'Add project', noProject: 'No project', relink: 'Relink',
       chooseTitle: (branch) => branch ? `Choose project · ${branch}` : 'Choose project',


### PR DESCRIPTION
## Summary

Restore discoverability of Desktop slash commands without adding a second execution path.

- Add a shared slash-command catalog for command identity, session requirement, and TUI/Desktop availability.
- Derive the TUI command registry and Desktop command suggestions from that catalog.
- Group Desktop commands before Skills in the existing Astryx trigger menu.
- Stage `/compact `, `/graph `, `/side `, or `/swarm ` in the composer so typed-command dispatch remains authoritative.
- Keep Desktop command parsing and streaming submit routing at the Desktop owner.
- Preserve Skill token insertion while giving commands localized action-first rows.

## Verification

- `node --test packages/core/dist/__tests__/slash-command-catalog.test.js`
- `node --test packages/ui/dist/__tests__/chat-input-behavior.test.js`
- `node --test apps/desktop/dist/main/__tests__/desktop-slash-command.test.js apps/desktop/dist/main/__tests__/side-chat-command.test.js`
- `npm --workspace maka-agent run typecheck`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:with-deps`
- `npm run format:check`
- `git diff --check`

Desktop Electron E2E is covered by CI. Full repository tests were not run locally.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No