### PR TITLE
fix(oauth,desktop): recover stuck xAI login and stale connection deletes

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-connections-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-connections-ipc-main.test.ts
@@ -7,6 +7,51 @@ import {
   registerRuntimeHostConnectionsIpc,
 } from '../runtime-host-connections-ipc-main.js';
 
+test('retries connection delete after a stale revision instead of failing permanently', async () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  let revision = 1;
+  let removals = 0;
+  registerRuntimeHostConnectionsIpc({
+    ipcMain: {
+      handle: (channel, handler) => {
+        handlers.set(channel, handler as (...args: unknown[]) => unknown);
+      },
+    },
+    client: {
+      loadConnectionCatalog: async (): Promise<ConnectionCatalogSnapshot> => ({
+        revision,
+        defaultTarget: null,
+        connections: [
+          {
+            connectionId: 'connection-1',
+            revision,
+            slug: 'openrouter',
+            name: 'OpenRouter',
+            providerType: 'openai-compatible',
+            baseUrl: 'https://openrouter.ai/api/v1',
+            enabled: true,
+            enabledModelIds: ['model-1'],
+            models: [{ id: 'model-1' }],
+          },
+        ],
+      }),
+      removeConnection: async (expected: { connectionId: string; revision: number }) => {
+        removals += 1;
+        if (expected.revision === 1) {
+          revision = 2;
+          return { kind: 'connection_stale' };
+        }
+        assert.equal(expected.revision, 2);
+        return { kind: 'committed', catalogRevision: 3 };
+      },
+    } as never,
+    emitConnectionListChanged() {},
+  });
+
+  await handlers.get('connections:delete')?.({}, 'openrouter');
+  assert.equal(removals, 2);
+});
+
 test('reports an existing but unconfigured credential as missing', async () => {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
   registerRuntimeHostConnectionsIpc({

--- a/apps/desktop/src/main/__tests__/runtime-host-connections-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-connections-ipc-main.test.ts
@@ -52,6 +52,62 @@ test('retries connection delete after a stale revision instead of failing perman
   assert.equal(removals, 2);
 });
 
+test('treats a missing connection as a successful delete without calling remove', async () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  let removals = 0;
+  let listChanged = 0;
+  registerRuntimeHostConnectionsIpc({
+    ipcMain: {
+      handle: (channel, handler) => {
+        handlers.set(channel, handler as (...args: unknown[]) => unknown);
+      },
+    },
+    client: {
+      loadConnectionCatalog: async (): Promise<ConnectionCatalogSnapshot> => ({
+        revision: 1,
+        defaultTarget: null,
+        connections: [],
+      }),
+      removeConnection: async () => {
+        removals += 1;
+        return { kind: 'committed', catalogRevision: 2 };
+      },
+    } as never,
+    emitConnectionListChanged() {
+      listChanged += 1;
+    },
+  });
+
+  await handlers.get('connections:delete')?.({}, 'already-gone');
+  assert.equal(removals, 0);
+  assert.equal(listChanged, 1);
+});
+
+test('rejects invalid connection slug input instead of treating it as already deleted', async () => {
+  const handlers = new Map<string, (...args: unknown[]) => unknown>();
+  registerRuntimeHostConnectionsIpc({
+    ipcMain: {
+      handle: (channel, handler) => {
+        handlers.set(channel, handler as (...args: unknown[]) => unknown);
+      },
+    },
+    client: {
+      loadConnectionCatalog: async (): Promise<ConnectionCatalogSnapshot> => ({
+        revision: 1,
+        defaultTarget: null,
+        connections: [],
+      }),
+      removeConnection: async () => ({ kind: 'committed', catalogRevision: 2 }),
+    } as never,
+    emitConnectionListChanged() {},
+  });
+
+  await assert.rejects(
+    async () => handlers.get('connections:delete')?.({}, 42),
+    /Invalid connection slug|connection slug/i,
+  );
+});
+
 test('reports an existing but unconfigured credential as missing', async () => {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
   registerRuntimeHostConnectionsIpc({

--- a/apps/desktop/src/main/runtime-host-connections-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-connections-ipc-main.ts
@@ -219,26 +219,27 @@ export function registerRuntimeHostConnectionsIpc(
       let current: ReturnType<typeof requireConnection>;
       try {
         current = requireConnection(catalog, slug);
-      } catch {
-        // Already gone — treat as success for UX (list will refresh).
-        deps.emitConnectionListChanged();
-        return;
+      } catch (error) {
+        // Only treat a missing slug as success. Invalid input must still fail.
+        if (error instanceof Error && error.message.startsWith('No such Connection:')) {
+          deps.emitConnectionListChanged();
+          return;
+        }
+        throw error;
       }
       const result = await deps.client.removeConnection({
         connectionId: current.connectionId,
         revision: current.revision,
       });
+      // RemoveCatalogConnectionResult is only committed | connection_stale.
       if (result.kind === 'committed') {
         deps.emitConnectionListChanged();
         return;
       }
-      if (result.kind === 'connection_stale' && attempt < maxAttempts - 1) {
+      if (attempt < maxAttempts - 1) {
         continue;
       }
-      if (result.kind === 'connection_stale') {
-        throw new Error('连接状态已更新，请刷新列表后再删除');
-      }
-      throw new Error(`Unable to delete Connection: ${result.kind}`);
+      throw new Error('连接状态已更新，请刷新列表后再删除');
     }
   });
   deps.ipcMain.handle('connections:fetchModels', async (_event, slug: unknown) => {

--- a/apps/desktop/src/main/runtime-host-connections-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-connections-ipc-main.ts
@@ -239,7 +239,8 @@ export function registerRuntimeHostConnectionsIpc(
       if (attempt < maxAttempts - 1) {
         continue;
       }
-      throw new Error('连接状态已更新，请刷新列表后再删除');
+      // English so renderer locale mapping (provider-panel-shared) can choose zh/en.
+      throw new Error('Unable to delete Connection: connection_stale');
     }
   });
   deps.ipcMain.handle('connections:fetchModels', async (_event, slug: unknown) => {

--- a/apps/desktop/src/main/runtime-host-connections-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-connections-ipc-main.ts
@@ -210,16 +210,36 @@ export function registerRuntimeHostConnectionsIpc(
     return requireProjectedConnection(await snapshot(), current.slug);
   });
   deps.ipcMain.handle('connections:delete', async (_event, slug: unknown) => {
-    const catalog = await snapshot();
-    const current = requireConnection(catalog, slug);
-    requireCommitted(
-      await deps.client.removeConnection({
+    // OAuth/model-fetch can bump the connection revision under the UI. Retry
+    // on connection_stale with a fresh snapshot so delete does not fail with a
+    // opaque "service unavailable" after the user already confirmed.
+    const maxAttempts = 6;
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const catalog = await snapshot();
+      let current: ReturnType<typeof requireConnection>;
+      try {
+        current = requireConnection(catalog, slug);
+      } catch {
+        // Already gone — treat as success for UX (list will refresh).
+        deps.emitConnectionListChanged();
+        return;
+      }
+      const result = await deps.client.removeConnection({
         connectionId: current.connectionId,
         revision: current.revision,
-      }),
-      'delete Connection',
-    );
-    deps.emitConnectionListChanged();
+      });
+      if (result.kind === 'committed') {
+        deps.emitConnectionListChanged();
+        return;
+      }
+      if (result.kind === 'connection_stale' && attempt < maxAttempts - 1) {
+        continue;
+      }
+      if (result.kind === 'connection_stale') {
+        throw new Error('连接状态已更新，请刷新列表后再删除');
+      }
+      throw new Error(`Unable to delete Connection: ${result.kind}`);
+    }
   });
   deps.ipcMain.handle('connections:fetchModels', async (_event, slug: unknown) => {
     const current = requireConnection(await snapshot(), slug);

--- a/apps/desktop/src/main/runtime-host-oauth-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-oauth-ipc-main.ts
@@ -82,6 +82,9 @@ export function registerRuntimeHostOAuthIpc(deps: RuntimeHostOAuthIpcDeps): void
     }
     deps.ipcMain.handle(channel('get-auth-url'), async () => {
       if (!providerEnabled(provider)) return providerDisabled();
+      // Drop any Desktop-tracked attempt for this provider so a re-click does
+      // not race a stale completeAuthorization waiter against a new start.
+      await cancelProviderAttempts(deps, activeAttempts, provider);
       const connection = await ensureRuntimeHostAccountConnection(deps.client, {
         providerType: provider,
         slug: INTERACTIVE_OAUTH_CONNECTION_SLUGS[provider],
@@ -100,7 +103,13 @@ export function registerRuntimeHostOAuthIpc(deps: RuntimeHostOAuthIpcDeps): void
       } catch (error) {
         expectation.cancel(error);
         await deps.client.cancelOAuthLogin(attemptId).catch(() => undefined);
-        return actionFailure('Unable to start OAuth authorization');
+        // Prefer the host's message when present so "already in progress" is not
+        // flattened into a generic 鉴权失败 for the toast classifier.
+        const detail =
+          error instanceof Error && error.message.trim().length > 0
+            ? error.message
+            : 'Unable to start OAuth authorization';
+        return actionFailure(detail);
       }
     });
     deps.ipcMain.handle(channel('open-auth-url'), (_event, attemptId: unknown) => {

--- a/apps/desktop/src/main/runtime-host-oauth-presentation.ts
+++ b/apps/desktop/src/main/runtime-host-oauth-presentation.ts
@@ -29,6 +29,10 @@ export class RuntimeHostOAuthPresentation implements OAuthPresentationBackend {
       resolvePresented = accept;
       rejectPresented = decline;
     });
+    // If a later expect() supersedes this one before waitForPresentation
+    // attaches, Node would log UnhandledPromiseRejection. Keep a no-op
+    // handler; real waiters still observe the same rejection.
+    void presented.catch(() => undefined);
     const timer = setTimeout(() => {
       if (this.#pending?.attemptId !== attemptId) return;
       this.#pending = undefined;

--- a/apps/desktop/src/renderer/settings/provider-panel-shared.ts
+++ b/apps/desktop/src/renderer/settings/provider-panel-shared.ts
@@ -48,6 +48,11 @@ export function providerPanelActionErrorMessage(error: unknown, locale: UiLocale
   // Main-process handlers throw display-ready Chinese copy; keep it instead
   // of flattening it into a coarser classification or the generic fallback.
   if (/[\u3400-\u9fff]/.test(cleaned)) return cleaned;
+  if (/connection_stale|Unable to delete Connection: connection_stale/i.test(cleaned)) {
+    return locale === 'zh'
+      ? '连接状态已更新，请刷新列表后再删除。'
+      : 'The connection changed while deleting. Refresh the list and try again.';
+  }
   const classified = locale === 'zh'
     ? generalizedErrorMessageChinese(new Error(cleaned), '')
     : generalizedErrorMessage(new Error(cleaned), '');

--- a/apps/desktop/src/renderer/settings/use-oauth-login-flow.ts
+++ b/apps/desktop/src/renderer/settings/use-oauth-login-flow.ts
@@ -329,10 +329,11 @@ export function subscriptionResultMessage(message: string | undefined, fallback:
   if (!raw) return fallback;
   // Host conflict / supersede copy before the coarse keyword classifier turns
   // "authorization" into a generic 鉴权失败 that does not tell the user what to do.
+  // This is error-path copy: do not claim a new login already started.
   if (/already in progress|superseded by a new attempt/i.test(raw)) {
     return locale === 'zh'
-      ? '上一轮浏览器登录还在进行中，已为你重新发起；请在浏览器完成授权，或稍后再试。'
-      : 'A previous browser login was still running; a new attempt was started. Finish authorization in the browser, or try again shortly.';
+      ? '上一轮浏览器登录仍在进行或已切换，请再点一次登录，或稍后再试。'
+      : 'A previous browser login is still running or was superseded. Try logging in again shortly.';
   }
   if (/did not present OAuth|no matching OAuth presentation/i.test(raw)) {
     return locale === 'zh'

--- a/apps/desktop/src/renderer/settings/use-oauth-login-flow.ts
+++ b/apps/desktop/src/renderer/settings/use-oauth-login-flow.ts
@@ -327,6 +327,18 @@ export function subscriptionActionErrorMessage(error: unknown, locale: UiLocale 
 export function subscriptionResultMessage(message: string | undefined, fallback: string, locale: UiLocale = 'zh'): string {
   const raw = redactSecrets(message ?? '').trim();
   if (!raw) return fallback;
+  // Host conflict / supersede copy before the coarse keyword classifier turns
+  // "authorization" into a generic 鉴权失败 that does not tell the user what to do.
+  if (/already in progress|superseded by a new attempt/i.test(raw)) {
+    return locale === 'zh'
+      ? '上一轮浏览器登录还在进行中，已为你重新发起；请在浏览器完成授权，或稍后再试。'
+      : 'A previous browser login was still running; a new attempt was started. Finish authorization in the browser, or try again shortly.';
+  }
+  if (/did not present OAuth|no matching OAuth presentation/i.test(raw)) {
+    return locale === 'zh'
+      ? '无法打开系统浏览器完成登录，请检查是否拦截了弹窗后重试。'
+      : 'Could not open the system browser for login. Check popup blockers and try again.';
+  }
   const classified = locale === 'zh'
     ? generalizedErrorMessageChinese(new Error(raw), '')
     : generalizedErrorMessage(new Error(raw), '');

--- a/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
@@ -302,7 +302,9 @@ test('concurrent OAuth starts serialize and never dual-open active logins', asyn
     ]);
     // First is superseded while polling or still completing; second should authenticate.
     assert.ok(phases.some((phase) => phase.phase === 'authenticated'));
-    assert.ok(phases.every((phase) => phase.phase === 'authenticated' || phase.phase === 'cancelled'));
+    assert.ok(
+      phases.every((phase) => phase.phase === 'authenticated' || phase.phase === 'cancelled'),
+    );
     assert.equal(fixture.activeResidencies, 0);
     await coordinator.close();
     client.close();
@@ -311,7 +313,11 @@ test('concurrent OAuth starts serialize and never dual-open active logins', asyn
 
 test('supersede waits for an admitted token poll instead of dropping the granted token', async () => {
   await withFixture('xai-oauth', async (fixture) => {
-    const client = await attachPresentation(fixture.capabilities, 'client-xai-deferred-supersede', []);
+    const client = await attachPresentation(
+      fixture.capabilities,
+      'client-xai-deferred-supersede',
+      [],
+    );
     let markPollAdmitted!: () => void;
     const pollAdmitted = new Promise<void>((resolve) => {
       markPollAdmitted = resolve;
@@ -377,7 +383,10 @@ test('supersede waits for an admitted token poll instead of dropping the granted
     );
     const second = await secondPromise;
     assert.equal(second.ok, true);
-    assert.equal((await waitForTerminal(coordinator, 'attempt-deferred-second')).phase, 'authenticated');
+    assert.equal(
+      (await waitForTerminal(coordinator, 'attempt-deferred-second')).phase,
+      'authenticated',
+    );
     assert.equal(starts, 2);
     assert.equal(fixture.invalidations, 2);
     assert.equal(fixture.activeResidencies, 0);

--- a/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
@@ -239,6 +239,153 @@ test('a new OAuth start supersedes an in-progress login instead of failing with 
   });
 });
 
+test('concurrent OAuth starts serialize and never dual-open active logins', async () => {
+  await withFixture('xai-oauth', async (fixture) => {
+    const client = await attachPresentation(fixture.capabilities, 'client-xai-concurrent', []);
+    let concurrentActive = 0;
+    let maxConcurrentActive = 0;
+    let starts = 0;
+    const coordinator = new HostOAuthCoordinator({
+      runtimePolicy: fixture.stores,
+      activation: fixture.activation,
+      clientCapabilities: fixture.capabilities,
+      isProviderEnabled: () => true,
+      acquireResidency: fixture.acquireResidency,
+      invalidateBackends: async () => {
+        fixture.invalidations += 1;
+      },
+      onFatal: (error) => {
+        throw error;
+      },
+      now: () => NOW,
+      startXaiAuthorization: async () => {
+        starts += 1;
+        concurrentActive += 1;
+        maxConcurrentActive = Math.max(maxConcurrentActive, concurrentActive);
+        // Yield so a racing start would observe dual activity without a gate.
+        await new Promise((resolve) => setTimeout(resolve, 15));
+        concurrentActive -= 1;
+        return {
+          deviceCode: `device-${starts}`,
+          userCode: `CODE-${starts}`,
+          verificationUrl: 'https://accounts.x.ai/device',
+          expiresAt: NOW + 60_000,
+          intervalMs: 1_000,
+        };
+      },
+      pollXaiAuthorization: async (input) => {
+        if (input.signal.aborted) {
+          throw input.signal.reason ?? new DOMException('aborted', 'AbortError');
+        }
+        return tokenFixture(`xai-concurrent-${input.authorization.deviceCode}`);
+      },
+    });
+
+    const [first, second] = await Promise.all([
+      coordinator.handlers['oauth.login.start'](
+        { attemptId: 'attempt-concurrent-a', connectionId: fixture.connection.connectionId },
+        operationContext('client-xai-concurrent', fixture.acquireResidency),
+      ),
+      coordinator.handlers['oauth.login.start'](
+        { attemptId: 'attempt-concurrent-b', connectionId: fixture.connection.connectionId },
+        operationContext('client-xai-concurrent', fixture.acquireResidency),
+      ),
+    ]);
+    assert.equal(first.ok, true);
+    assert.equal(second.ok, true);
+    assert.equal(maxConcurrentActive, 1, 'device authorization must not run concurrently');
+    assert.equal(starts, 2);
+
+    const phases = await Promise.all([
+      waitForTerminal(coordinator, 'attempt-concurrent-a'),
+      waitForTerminal(coordinator, 'attempt-concurrent-b'),
+    ]);
+    // First is superseded while polling or still completing; second should authenticate.
+    assert.ok(phases.some((phase) => phase.phase === 'authenticated'));
+    assert.ok(phases.every((phase) => phase.phase === 'authenticated' || phase.phase === 'cancelled'));
+    assert.equal(fixture.activeResidencies, 0);
+    await coordinator.close();
+    client.close();
+  });
+});
+
+test('supersede waits for an admitted token poll instead of dropping the granted token', async () => {
+  await withFixture('xai-oauth', async (fixture) => {
+    const client = await attachPresentation(fixture.capabilities, 'client-xai-deferred-supersede', []);
+    let markPollAdmitted!: () => void;
+    const pollAdmitted = new Promise<void>((resolve) => {
+      markPollAdmitted = resolve;
+    });
+    let releasePoll!: () => void;
+    const pollRelease = new Promise<void>((resolve) => {
+      releasePoll = resolve;
+    });
+    let starts = 0;
+    const coordinator = new HostOAuthCoordinator({
+      runtimePolicy: fixture.stores,
+      activation: fixture.activation,
+      clientCapabilities: fixture.capabilities,
+      isProviderEnabled: () => true,
+      acquireResidency: fixture.acquireResidency,
+      invalidateBackends: async () => {
+        fixture.invalidations += 1;
+      },
+      onFatal: (error) => {
+        throw error;
+      },
+      now: () => NOW,
+      startXaiAuthorization: async () => {
+        starts += 1;
+        return {
+          deviceCode: `device-${starts}`,
+          userCode: `CODE-${starts}`,
+          verificationUrl: 'https://accounts.x.ai/device',
+          expiresAt: NOW + 60_000,
+          intervalMs: 1_000,
+        };
+      },
+      pollXaiAuthorization: async (input) => {
+        if (input.authorization.deviceCode === 'device-1') {
+          input.onPollAdmission?.();
+          markPollAdmitted();
+          await pollRelease;
+          return tokenFixture('xai-first-admitted');
+        }
+        return tokenFixture('xai-second-after-wait');
+      },
+    });
+
+    const first = await coordinator.handlers['oauth.login.start'](
+      { attemptId: 'attempt-deferred-first', connectionId: fixture.connection.connectionId },
+      operationContext('client-xai-deferred-supersede', fixture.acquireResidency),
+    );
+    assert.equal(first.ok, true);
+    await pollAdmitted;
+
+    const secondPromise = coordinator.handlers['oauth.login.start'](
+      { attemptId: 'attempt-deferred-second', connectionId: fixture.connection.connectionId },
+      operationContext('client-xai-deferred-supersede', fixture.acquireResidency),
+    );
+    // Give supersede time to observe cancellationDeferred and park on settlement.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    releasePoll();
+
+    assert.equal(
+      (await waitForTerminal(coordinator, 'attempt-deferred-first')).phase,
+      'authenticated',
+      'admitted poll must still commit under supersede',
+    );
+    const second = await secondPromise;
+    assert.equal(second.ok, true);
+    assert.equal((await waitForTerminal(coordinator, 'attempt-deferred-second')).phase, 'authenticated');
+    assert.equal(starts, 2);
+    assert.equal(fixture.invalidations, 2);
+    assert.equal(fixture.activeResidencies, 0);
+    await coordinator.close();
+    client.close();
+  });
+});
+
 test('xAI cancellation waits for an admitted token poll and commits its successful outcome', async () => {
   await withFixture('xai-oauth', async (fixture) => {
     const client = await attachPresentation(fixture.capabilities, 'client-xai-cut', []);

--- a/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-coordinator.test.ts
@@ -161,6 +161,84 @@ test('xAI enrollment keeps device polling and credential material in the Host', 
   });
 });
 
+test('a new OAuth start supersedes an in-progress login instead of failing with operation_conflict', async () => {
+  await withFixture('xai-oauth', async (fixture) => {
+    const client = await attachPresentation(fixture.capabilities, 'client-xai-supersede', []);
+    let firstPollEntered = false;
+    let starts = 0;
+    const coordinator = new HostOAuthCoordinator({
+      runtimePolicy: fixture.stores,
+      activation: fixture.activation,
+      clientCapabilities: fixture.capabilities,
+      isProviderEnabled: () => true,
+      acquireResidency: fixture.acquireResidency,
+      invalidateBackends: async () => {
+        fixture.invalidations += 1;
+      },
+      onFatal: (error) => {
+        throw error;
+      },
+      now: () => NOW,
+      startXaiAuthorization: async () => {
+        starts += 1;
+        return {
+          deviceCode: `device-${starts}`,
+          userCode: `CODE-${starts}`,
+          verificationUrl: 'https://accounts.x.ai/device',
+          expiresAt: NOW + 60_000,
+          intervalMs: 1_000,
+        };
+      },
+      pollXaiAuthorization: async (input) => {
+        if (input.authorization.deviceCode === 'device-1') {
+          firstPollEntered = true;
+          // Park until supersede aborts this attempt (no external deadlock).
+          await new Promise<never>((_resolve, reject) => {
+            if (input.signal.aborted) {
+              reject(input.signal.reason ?? new DOMException('aborted', 'AbortError'));
+              return;
+            }
+            input.signal.addEventListener(
+              'abort',
+              () => {
+                reject(input.signal.reason ?? new DOMException('aborted', 'AbortError'));
+              },
+              { once: true },
+            );
+          });
+        }
+        return tokenFixture('xai-second');
+      },
+    });
+
+    const first = await coordinator.handlers['oauth.login.start'](
+      { attemptId: 'attempt-first', connectionId: fixture.connection.connectionId },
+      operationContext('client-xai-supersede', fixture.acquireResidency),
+    );
+    assert.equal(first.ok, true);
+    // Wait until the first login has entered polling so #activeAttempt is set.
+    for (let i = 0; i < 50 && !firstPollEntered; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(firstPollEntered, true);
+
+    const second = await coordinator.handlers['oauth.login.start'](
+      { attemptId: 'attempt-second', connectionId: fixture.connection.connectionId },
+      operationContext('client-xai-supersede', fixture.acquireResidency),
+    );
+    assert.equal(second.ok, true, 'second start must supersede, not conflict');
+    if (second.ok) assert.equal(second.result.attemptId, 'attempt-second');
+
+    assert.equal((await waitForTerminal(coordinator, 'attempt-first')).phase, 'cancelled');
+    assert.equal((await waitForTerminal(coordinator, 'attempt-second')).phase, 'authenticated');
+    assert.equal(starts, 2);
+    assert.equal(fixture.invalidations, 1);
+    assert.equal(fixture.activeResidencies, 0);
+    await coordinator.close();
+    client.close();
+  });
+});
+
 test('xAI cancellation waits for an admitted token poll and commits its successful outcome', async () => {
   await withFixture('xai-oauth', async (fixture) => {
     const client = await attachPresentation(fixture.capabilities, 'client-xai-cut', []);

--- a/packages/runtime-host/src/server/oauth-coordinator.ts
+++ b/packages/runtime-host/src/server/oauth-coordinator.ts
@@ -283,9 +283,14 @@ export class HostOAuthCoordinator {
       ) {
         return this.#pendingStart.result;
       }
-      return authorizationInProgress();
+      // Another start is mid-admission. Wait for it so a double-click does not
+      // surface a permanent "already in progress" that only restart clears.
+      await this.#pendingStart.result.catch(() => undefined);
+      if (this.#activeAttempt) await this.#supersedeActiveLogin();
     }
-    if (this.#activeAttempt) return authorizationInProgress();
+    // User re-clicked 登录 after the browser already authorized (or abandoned)
+    // an earlier attempt. Supersede instead of blocking until process restart.
+    if (this.#activeAttempt) await this.#supersedeActiveLogin();
     if (this.#admissionClosed) return hostDraining();
 
     const result = this.#prepareStart(input, initiatingConnectionId);
@@ -295,6 +300,29 @@ export class HostOAuthCoordinator {
     } finally {
       if (this.#pendingStart?.result === result) this.#pendingStart = undefined;
     }
+  }
+
+  /**
+   * Cancel the active interactive login and wait until its residency is released.
+   * Used when the user starts a new login while a prior device-code poll is still open.
+   */
+  async #supersedeActiveLogin(): Promise<void> {
+    const previous = this.#activeAttempt;
+    if (!previous) return;
+    // Committing is the only phase that must finish — aborting mid-commit can
+    // leave credential write outcome unknown. Wait it out, then continue.
+    if (previous.phase === 'committing') {
+      await previous.settlement.catch(() => undefined);
+      return;
+    }
+    const reason = new DOMException('OAuth login superseded by a new attempt', 'AbortError');
+    previous.cancelRequested = true;
+    previous.cancellationDeferred = false;
+    if (previous.phase !== 'authenticated' && previous.phase !== 'failed') {
+      previous.phase = 'cancelled';
+    }
+    if (!previous.abort.signal.aborted) previous.abort.abort(reason);
+    await previous.settlement.catch(() => undefined);
   }
 
   async #prepareStart(

--- a/packages/runtime-host/src/server/oauth-coordinator.ts
+++ b/packages/runtime-host/src/server/oauth-coordinator.ts
@@ -136,13 +136,11 @@ export class HostOAuthCoordinator {
   readonly #authorizationTimeoutMs: number;
   readonly #attempts = new Map<string, LoginAttemptRecord>();
   #activeAttempt: ActiveLoginAttempt | undefined;
-  #pendingStart:
-    | {
-        readonly attemptId: string;
-        readonly connectionId: string;
-        readonly result: Promise<OperationOutcome<'oauth.login.start'>>;
-      }
-    | undefined;
+  /**
+   * Serializes oauth.login.start admissions so concurrent starts cannot dual-open
+   * interactive logins after supersede replaced operation_conflict.
+   */
+  #startGate: Promise<void> = Promise.resolve();
   #admissionClosed = false;
   #closeTask: Promise<void> | undefined;
 
@@ -276,29 +274,29 @@ export class HostOAuthCoordinator {
       }
       return { ok: true, result: projection(existing) };
     }
-    if (this.#pendingStart) {
-      if (
-        this.#pendingStart.attemptId === input.attemptId &&
-        this.#pendingStart.connectionId === input.connectionId
-      ) {
-        return this.#pendingStart.result;
-      }
-      // Another start is mid-admission. Wait for it so a double-click does not
-      // surface a permanent "already in progress" that only restart clears.
-      await this.#pendingStart.result.catch(() => undefined);
-      if (this.#activeAttempt) await this.#supersedeActiveLogin();
-    }
-    // User re-clicked 登录 after the browser already authorized (or abandoned)
-    // an earlier attempt. Supersede instead of blocking until process restart.
-    if (this.#activeAttempt) await this.#supersedeActiveLogin();
-    if (this.#admissionClosed) return hostDraining();
 
-    const result = this.#prepareStart(input, initiatingConnectionId);
-    this.#pendingStart = { ...input, result };
+    // Claim the start gate before any await so concurrent admissions queue.
+    let releaseGate!: () => void;
+    const previousGate = this.#startGate;
+    this.#startGate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    await previousGate.catch(() => undefined);
     try {
-      return await result;
+      const again = this.#attempts.get(input.attemptId);
+      if (again) {
+        if (projection(again).connectionId !== input.connectionId) {
+          return invalidRequest('OAuth attemptId is already bound to another connection');
+        }
+        return { ok: true, result: projection(again) };
+      }
+      // User re-clicked 登录 after the browser already authorized (or abandoned)
+      // an earlier attempt. Supersede instead of blocking until process restart.
+      if (this.#activeAttempt) await this.#supersedeActiveLogin();
+      if (this.#admissionClosed) return hostDraining();
+      return await this.#prepareStart(input, initiatingConnectionId);
     } finally {
-      if (this.#pendingStart?.result === result) this.#pendingStart = undefined;
+      releaseGate();
     }
   }
 
@@ -309,15 +307,14 @@ export class HostOAuthCoordinator {
   async #supersedeActiveLogin(): Promise<void> {
     const previous = this.#activeAttempt;
     if (!previous) return;
-    // Committing is the only phase that must finish — aborting mid-commit can
-    // leave credential write outcome unknown. Wait it out, then continue.
-    if (previous.phase === 'committing') {
+    // Align with cancel: once a token poll is admitted or credentials are
+    // committing, finish that path instead of aborting a browser-approved grant.
+    if (previous.phase === 'committing' || previous.cancellationDeferred) {
       await previous.settlement.catch(() => undefined);
       return;
     }
     const reason = new DOMException('OAuth login superseded by a new attempt', 'AbortError');
     previous.cancelRequested = true;
-    previous.cancellationDeferred = false;
     if (previous.phase !== 'authenticated' && previous.phase !== 'failed') {
       previous.phase = 'cancelled';
     }
@@ -685,16 +682,6 @@ function authorizationTimeout(value: number | undefined): number {
 
 function isCommitOutcomeUnknown(error: unknown): error is RuntimePolicyStoreError {
   return error instanceof RuntimePolicyStoreError && error.code === 'commit_outcome_unknown';
-}
-
-function authorizationInProgress(): OperationOutcome<'oauth.login.start'> {
-  return {
-    ok: false,
-    error: {
-      code: 'operation_conflict',
-      message: 'Another OAuth authorization is already in progress',
-    },
-  };
 }
 
 function invalidRequest(message: string) {


### PR DESCRIPTION
## Summary

Packaged desktop diagnostics showed three related model-connection UX failures:

1. **xAI OAuth**: browser shows authorized, Maka stays idle; re-click → toast 无法开始登录 / 鉴权失败 with `Another OAuth authorization is already in progress` and an **unhandled rejection**.
2. **Delete connection**: `connection_stale` → 删除模型连接失败 / 服务暂时不可用 (revision raced with OAuth/model fetch).
3. Coarse error classifier turned host conflict English into generic **鉴权失败**.

### Fixes

- **Host OAuth**: new login **supersedes** the active device-code poll instead of returning `operation_conflict`.
- **Desktop OAuth IPC**: cancel prior Desktop-tracked attempts before start; surface host error text; presentation `expect()` no longer leaves unhandled rejections when superseded.
- **Connection delete**: retry remove on `connection_stale` with a fresh catalog revision; Chinese copy when still stale.
- **Toast copy**: map “already in progress” / presentation failures to actionable zh/en strings (not 鉴权失败).

## Test plan

- [x] `node --test --test-name-pattern supersedes packages/runtime-host/dist/__tests__/oauth-coordinator.test.js`
- [x] `npx tsx --test apps/desktop/src/main/__tests__/runtime-host-connections-ipc-main.test.ts`
- [ ] Packaged: start xAI login → authorize in browser → Maka binds without re-click
- [ ] Packaged: start login twice → second supersedes first (no stuck “in progress”)
- [ ] Packaged: delete connection while status is updating → succeeds or clear refresh hint