### PR TITLE
fix(desktop): hide session chrome behind settings

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -25,6 +25,7 @@ test('settings owns the window chrome while a session remains active', async ({
 
   const titlebar = page.locator('.maka-window-titlebar');
   await expect(titlebar).toHaveCount(1);
+  await expect(titlebar).toHaveAttribute('aria-hidden', 'true');
   await expect(titlebar).not.toHaveAttribute('inert');
   await expect
     .poll(() =>
@@ -37,6 +38,26 @@ test('settings owns the window chrome while a session remains active', async ({
       }),
     )
     .toEqual({ appRegion: 'drag', hasArea: true });
+});
+
+test('opening settings commits an active titlebar rename', async ({ window: page }) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('create a session for settings rename');
+  await composer.press('Enter');
+
+  const identity = page.locator('[data-maka-contract="titlebar-identity"]');
+  await expect(identity).toBeVisible();
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await identity.getByRole('button', { name: /重命名对话/ }).click();
+  await page.getByRole('textbox', { name: '重命名对话' }).fill('renamed before settings');
+
+  // Programmatic activation preserves input focus, matching the macOS
+  // application-menu command that opens Settings before Chromium can blur it.
+  await page.getByRole('button', { name: '设置' }).evaluate((button) => button.click());
+  await expect(page.getByRole('main', { name: '设置内容' })).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  await expect(identity).toContainText('renamed before settings');
 });
 
 // Appearance and channel surface in one window. The channel seed runs before

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -1,9 +1,43 @@
 import type { Page } from '@playwright/test';
-import { test, expect } from './fixtures';
+import { test, expect, COMPOSER_INPUT } from './fixtures';
 
 function settingsNavigation(page: Page) {
   return page.getByRole('navigation', { name: /^(设置分组|Settings sections)$/ });
 }
+
+test('settings owns the window chrome while a session remains active', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('create a session for settings');
+  await composer.press('Enter');
+
+  const identity = page.locator('[data-maka-contract="titlebar-identity"]');
+  await expect(identity).toBeVisible();
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await page.getByRole('button', { name: '设置' }).click();
+  await expect(page.getByRole('main', { name: '设置内容' })).toBeVisible();
+
+  await expect(identity).toHaveCount(0);
+  await expect(page.getByRole('button', { name: '搜索对话' })).toHaveCount(0);
+  await expect(page.getByRole('toolbar', { name: '工作区辅助操作' })).toHaveCount(0);
+  await expect(page.locator('.maka-shell-astryx')).toHaveAttribute('inert', '');
+
+  const titlebar = page.locator('.maka-window-titlebar');
+  await expect(titlebar).toHaveCount(1);
+  await expect(titlebar).not.toHaveAttribute('inert');
+  await expect
+    .poll(() =>
+      titlebar.evaluate((element) => {
+        const rect = element.getBoundingClientRect();
+        return {
+          appRegion: getComputedStyle(element).getPropertyValue('-webkit-app-region'),
+          hasArea: rect.width > 0 && rect.height > 0,
+        };
+      }),
+    )
+    .toEqual({ appRegion: 'drag', hasArea: true });
+});
 
 // Appearance and channel surface in one window. The channel seed runs before
 // settings opens (the shell snapshots the store on open). Back-icon rail

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -65,9 +65,6 @@ function ChromeColumnToggle(props: {
 export function AppShellTopbarActions(props: {
   sidebarCollapsed: boolean;
   onToggleSidebar(): void;
-  /* Settings has its own navigation column; the session-sidebar toggle is
-     meaningless there. */
-  sidebarToggleHidden?: boolean;
   onOpenSearchModal(): void;
 }) {
   const locale = useUiLocale();
@@ -85,16 +82,14 @@ export function AppShellTopbarActions(props: {
           onClick={props.onOpenSearchModal}
         />
       </Tooltip>
-      {!props.sidebarToggleHidden && (
-        <ChromeColumnToggle
-          collapsed={props.sidebarCollapsed}
-          expandLabel={copy.expandSidebar}
-          collapseLabel={copy.collapseSidebar}
-          expandIcon={PanelLeftOpen}
-          collapseIcon={PanelLeftClose}
-          onToggle={props.onToggleSidebar}
-        />
-      )}
+      <ChromeColumnToggle
+        collapsed={props.sidebarCollapsed}
+        expandLabel={copy.expandSidebar}
+        collapseLabel={copy.collapseSidebar}
+        expandIcon={PanelLeftOpen}
+        collapseIcon={PanelLeftClose}
+        onToggle={props.onToggleSidebar}
+      />
       {/* Collapsed "new task" lives on the SideNav rail (SessionSidebarNav),
           not here — a third titlebar button duplicated the rail icon and made
           left-cluster width state-dependent for drag-region math. */}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2168,11 +2168,12 @@ function AppShellContent({
   }, [activeId, activeStreamingMessageId, messages, settleAssistantStreaming]);
 
   const hasModalOpen = helpOpen || paletteOpen || searchModalOpen || externalImportOpen;
+  const shellObscured = hasModalOpen || settingsOpen;
 
   useEffect(() => {
     const handleWorkbarShortcut = (event: KeyboardEvent) => {
       if (
-        hasModalOpen ||
+        shellObscured ||
         navSelectionRef.current.section !== 'sessions' ||
         !activeId
       ) {
@@ -2206,7 +2207,7 @@ function AppShellContent({
     };
     window.addEventListener('keydown', handleWorkbarShortcut, true);
     return () => window.removeEventListener('keydown', handleWorkbarShortcut, true);
-  }, [activeId, hasModalOpen, requestOpenWorkbarTab]);
+  }, [activeId, requestOpenWorkbarTab, shellObscured]);
 
   useAppShellNavRefSync({
     navSelection,
@@ -2522,48 +2523,54 @@ function AppShellContent({
         aria-hidden={hasModalOpen ? 'true' : undefined}
         inert={hasModalOpen ? true : undefined}
       >
-        <AppShellTopbarActions
-          sidebarCollapsed={sessionListCollapsed}
-          onToggleSidebar={() => sessionSideNavHandleRef.current?.getCollapseState()?.toggle()}
-          sidebarToggleHidden={settingsOpen}
-          onOpenSearchModal={() => setSearchModalOpen(true)}
-        />
-        {/* Only a session has an identity to state. The other views name
-            themselves in the nav column they are selected from, and the
-            new-task surface still shows its project in the composer's
-            WorkspacePicker — which stops rendering at the exact moment this
-            takes over, when the first message creates the session. */}
-        {/* `activeSessionForView`, not `activeSession`: opening or creating a
-            session runs a few hundred ms on a placeholder record while the real
-            summary loads, and the name this replaced (the context layer's) was
-            showing through that window. Hung on the real record alone, 新任务
-            was named nowhere for the length of it. */}
-        {navSelection.section === 'sessions' && activeSessionForView && (
-          <TitlebarSessionIdentity
-            /* Keyed by session: the open rename is local state and the field is
-               uncontrolled, so a switch that left the instance mounted would
-               carry one session's half-typed name — and its commit — onto the
-               next one. A remount ties the edit to the session it belongs to. */
-            key={activeSessionForView.id}
-            sessionName={activeSessionForView.name}
-            onRenameSession={(name) => {
-              void sessionRowActionHandlers.renameSession(activeSessionForView.id, name);
-            }}
-            project={
-              titlebarProjectName
-                ? { name: titlebarProjectName, onOpenFolder: () => void openProjectFolder() }
-                : undefined
-            }
-            parentSession={titlebarParentSession}
-          />
-        )}
-        {!VIEWS_WITHOUT_WORKSPACE_ACTIONS.has(agentsView) && (
-          <AppShellWorkspaceTopActions
-            workbarAvailable={navSelection.section === 'sessions' && Boolean(activeId)}
-            workbarCollapsed={workbarCollapsed}
-            onOpenWorkbarLauncher={revealWorkbarLauncher}
-            onToggleWorkbar={toggleWorkbar}
-          />
+        {/* Settings owns the full window chrome. Keep this empty header mounted
+            as the frameless window's drag authority, but remove every control
+            and identity belonging to the obscured session shell. */}
+        {!settingsOpen && (
+          <>
+            <AppShellTopbarActions
+              sidebarCollapsed={sessionListCollapsed}
+              onToggleSidebar={() => sessionSideNavHandleRef.current?.getCollapseState()?.toggle()}
+              onOpenSearchModal={() => setSearchModalOpen(true)}
+            />
+            {/* Only a session has an identity to state. The other views name
+                themselves in the nav column they are selected from, and the
+                new-task surface still shows its project in the composer's
+                WorkspacePicker — which stops rendering at the exact moment this
+                takes over, when the first message creates the session. */}
+            {/* `activeSessionForView`, not `activeSession`: opening or creating a
+                session runs a few hundred ms on a placeholder record while the real
+                summary loads, and the name this replaced (the context layer's) was
+                showing through that window. Hung on the real record alone, 新任务
+                was named nowhere for the length of it. */}
+            {navSelection.section === 'sessions' && activeSessionForView && (
+              <TitlebarSessionIdentity
+                /* Keyed by session: the open rename is local state and the field is
+                   uncontrolled, so a switch that left the instance mounted would
+                   carry one session's half-typed name — and its commit — onto the
+                   next one. A remount ties the edit to the session it belongs to. */
+                key={activeSessionForView.id}
+                sessionName={activeSessionForView.name}
+                onRenameSession={(name) => {
+                  void sessionRowActionHandlers.renameSession(activeSessionForView.id, name);
+                }}
+                project={
+                  titlebarProjectName
+                    ? { name: titlebarProjectName, onOpenFolder: () => void openProjectFolder() }
+                    : undefined
+                }
+                parentSession={titlebarParentSession}
+              />
+            )}
+            {!VIEWS_WITHOUT_WORKSPACE_ACTIONS.has(agentsView) && (
+              <AppShellWorkspaceTopActions
+                workbarAvailable={navSelection.section === 'sessions' && Boolean(activeId)}
+                workbarCollapsed={workbarCollapsed}
+                onOpenWorkbarLauncher={revealWorkbarLauncher}
+                onToggleWorkbar={toggleWorkbar}
+              />
+            )}
+          </>
         )}
       </header>
       <AstryxAppShell
@@ -2576,8 +2583,8 @@ function AppShellContent({
         height="fill"
         contentPadding={0}
         mobileNav={{ breakpoint: 'none', hasToggle: false }}
-        aria-hidden={hasModalOpen ? 'true' : undefined}
-        inert={hasModalOpen ? true : undefined}
+        aria-hidden={shellObscured ? 'true' : undefined}
+        inert={shellObscured ? true : undefined}
         sideNav={
           <SessionListPanel
             collapseHandleRef={sessionSideNavHandleRef}
@@ -3022,7 +3029,7 @@ function AppShellContent({
                 activeId={activeId}
                 rightCollapsed={workbarCollapsed}
                 bottomOpen={bottomPanelOpen}
-                hidden={hasModalOpen}
+                hidden={shellObscured}
                 rightWidth={workbarWidth}
                 bottomHeight={bottomPanelHeight}
                 onDismissPanel={(placement) => {
@@ -3085,7 +3092,7 @@ function AppShellContent({
           </MakaUriContext.Provider>
         </AppShellDetailPanel>
       </AstryxAppShell>
-      {!hasModalOpen && !settingsOpen && (
+      {!shellObscured && (
         <CustomPetCompanion
           activityState={petActivityState}
           completionNonce={petCompletionNonce}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2520,7 +2520,7 @@ function AppShellContent({
           one frame-level hit-test surface. */}
       <header
         className="maka-window-titlebar"
-        aria-hidden={hasModalOpen ? 'true' : undefined}
+        aria-hidden={shellObscured ? 'true' : undefined}
         inert={hasModalOpen ? true : undefined}
       >
         {/* Settings owns the full window chrome. Keep this empty header mounted

--- a/apps/desktop/src/renderer/use-settings-modal.ts
+++ b/apps/desktop/src/renderer/use-settings-modal.ts
@@ -20,11 +20,20 @@ export function useSettingsModal() {
   const [settingsConnectionDetailSlug, setSettingsConnectionDetailSlug] = useState<string | undefined>(undefined);
   const [settingsCreateProviderType, setSettingsCreateProviderType] = useState<ProviderType | undefined>(undefined);
 
+  function showSettings() {
+    // macOS menu commands do not move DOM focus before opening Settings.
+    // Settle blur-owned edits before the obscured shell unmounts them.
+    if (!settingsOpen && document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+    setSettingsOpen(true);
+  }
+
   function openSettings() {
     setSettingsProviderCatalogOpen(false);
     setSettingsConnectionDetailSlug(undefined);
     setSettingsCreateProviderType(undefined);
-    setSettingsOpen(true);
+    showSettings();
   }
 
   function openSettingsSection(section: SettingsSection) {
@@ -33,7 +42,7 @@ export function useSettingsModal() {
     setSettingsProviderCatalogOpen(false);
     setSettingsConnectionDetailSlug(undefined);
     setSettingsCreateProviderType(undefined);
-    setSettingsOpen(true);
+    showSettings();
   }
 
   function openProviderCatalog() {
@@ -42,7 +51,7 @@ export function useSettingsModal() {
     setSettingsProviderCatalogOpen(true);
     setSettingsConnectionDetailSlug(undefined);
     setSettingsCreateProviderType(undefined);
-    setSettingsOpen(true);
+    showSettings();
   }
 
   /** Open Settings → 模型 with a specific connection's detail sheet expanded. */
@@ -52,7 +61,7 @@ export function useSettingsModal() {
     setSettingsProviderCatalogOpen(false);
     setSettingsConnectionDetailSlug(slug);
     setSettingsCreateProviderType(undefined);
-    setSettingsOpen(true);
+    showSettings();
   }
 
   /** Open Settings → 模型 with the create-connection dialog for this provider expanded. */
@@ -62,7 +71,7 @@ export function useSettingsModal() {
     setSettingsProviderCatalogOpen(false);
     setSettingsConnectionDetailSlug(undefined);
     setSettingsCreateProviderType(providerType);
-    setSettingsOpen(true);
+    showSettings();
   }
 
   return {


### PR DESCRIPTION
## Summary

Make Settings the sole owner of the full-window chrome while it is open. The obscured session shell becomes inert and its titlebar identity, search, and workbar controls unmount, while the empty frameless titlebar remains the window drag authority.

## Verification

- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:renderer`
- `npm run format:check`
- `npx playwright test --config e2e/playwright.config.ts e2e/settings.spec.ts` — 3 passed
- Reverse-injected the original titlebar rendering condition; the regression test failed on the still-mounted session identity, then passed after restoring the fix.

## Visual evidence

| Before — session chrome leaks above Settings | After — Settings owns the window chrome |
| --- | --- |
| <img width="1224" alt="Before: session and project chrome remains visible above Settings" src="https://github.com/user-attachments/assets/61989c8c-7a3e-43fb-bbb5-c8310a449305" /> | <img width="1171" alt="After: Settings cleanly covers session and project chrome" src="https://github.com/user-attachments/assets/ee894a97-bc01-4a68-9dbf-02eb9b07398a" /> |

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
