### PR TITLE
feat(runtime-host): recover clients across host restarts

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -315,6 +315,7 @@ test('drives the renderer Session execution facade through real UDS framing', as
       {
         client,
         observer,
+        observations: observer,
         attachmentApprovals: createAttachmentApprovalRegistry(),
         emitSessionsChanged() {},
         stat: async () => ({ size: 0 }),

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -63,9 +63,10 @@ test('tears down the whole candidate when the Host connection closes', async () 
   const candidate = await createDesktopRuntimeHostCandidate(host.connection, deps(ipc));
 
   host.disconnect();
+  await Promise.resolve();
+  assert.equal(ipc.size, 0);
   await candidate.closed;
 
-  assert.equal(ipc.size, 0);
   assert.equal(host.closeCalls, 1);
 });
 

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
@@ -14,13 +14,20 @@ test('replaces a disconnected generation without falling back to embedded Runtim
   const queue = [ready(first.candidate), ready(second.candidate)];
   let starts = 0;
   let resolveSecondStart!: () => void;
+  let releaseSecond!: () => void;
   const secondStarted = new Promise<void>((resolve) => {
     resolveSecondStart = resolve;
+  });
+  const secondReleased = new Promise<void>((resolve) => {
+    releaseSecond = resolve;
   });
   const owner = await startRuntimeHostDesktopOwner({} as DesktopRuntimeHostCandidateStartInput, {
     startCandidate: async () => {
       starts += 1;
-      if (starts === 2) resolveSecondStart();
+      if (starts === 2) {
+        resolveSecondStart();
+        await secondReleased;
+      }
       const result = queue.shift();
       assert.ok(result);
       return result;
@@ -29,9 +36,13 @@ test('replaces a disconnected generation without falling back to embedded Runtim
 
   first.disconnect();
   await secondStarted;
+  const botMessage = owner.handleBotIncomingMessage({ text: 'hello' } as BotIncomingMessage);
+  const stop = owner.stopSession('session-1');
   await new Promise<void>((resolve) => setImmediate(resolve));
-  await owner.handleBotIncomingMessage({ text: 'hello' } as BotIncomingMessage);
-  await owner.stopSession('session-1');
+  assert.equal(second.botMessages, 0);
+  assert.deepEqual(second.stoppedSessions, []);
+  releaseSecond();
+  await Promise.all([botMessage, stop]);
 
   assert.equal(first.botMessages, 0);
   assert.equal(second.botMessages, 1);

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
@@ -40,29 +40,71 @@ test('replaces a disconnected generation without falling back to embedded Runtim
   assert.equal(second.closeCalls, 1);
 });
 
-test('reports exhausted reconnect attempts as fatal and never starts a fallback', { timeout: 10_000 }, async () => {
+test('keeps reconnecting with bounded backoff until the Desktop adapter is restored', async () => {
   const first = candidateHarness();
+  const replacement = candidateHarness();
   let starts = 0;
+  const delays: number[] = [];
+  let resolveRestored!: () => void;
+  const restored = new Promise<void>((resolve) => {
+    resolveRestored = resolve;
+  });
+  const owner = await startRuntimeHostDesktopOwner({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (): Promise<DesktopRuntimeHostCandidateStartResult> => {
+      starts += 1;
+      if (starts === 1) return ready(first.candidate);
+      if (starts < 4) return { kind: 'failed', reason: 'host_unresponsive' };
+      resolveRestored();
+      return ready(replacement.candidate);
+    },
+    reconnectBackoff: {
+      minMs: 100,
+      maxMs: 150,
+      random: () => 0.5,
+      wait: async (delayMs) => {
+        delays.push(delayMs);
+      },
+    },
+  });
+
+  first.disconnect();
+  await restored;
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(starts, 4);
+  assert.deepEqual(delays, [100, 150]);
+  await owner.handleBotIncomingMessage({ text: 'restored' } as BotIncomingMessage);
+  assert.equal(replacement.botMessages, 1);
+  await owner.close();
+});
+
+test('stops reconnecting when the replacement Host is incompatible', async () => {
+  const first = candidateHarness();
   let reportFatal!: (error: Error) => void;
   const fatalReported = new Promise<Error>((resolve) => {
     reportFatal = resolve;
   });
   const owner = await startRuntimeHostDesktopOwner({} as DesktopRuntimeHostCandidateStartInput, {
-    startCandidate: async (): Promise<DesktopRuntimeHostCandidateStartResult> => {
-      starts += 1;
-      return starts === 1
+    startCandidate: async () =>
+      first.closeCalls === 0
         ? ready(first.candidate)
-        : { kind: 'failed', reason: 'host_unresponsive' };
-    },
-    onFatalError: (error) => {
-      reportFatal(error);
-    },
+        : {
+            kind: 'incompatible',
+            handshake: {
+              kind: 'incompatible',
+              hostEpoch: 'replacement-host',
+              protocolMin: 1,
+              protocolMax: 1,
+              compatibilityEpoch: 1,
+              state: 'ready',
+              replacement: 'wait_for_idle_exit',
+            },
+          },
+    onFatalError: reportFatal,
   });
 
-  first.disconnect();
+  await first.candidate.close();
   const fatal = await fatalReported;
-  assert.equal(starts, 4);
-  assert.match(fatal.message, /host_unresponsive/);
+  assert.match(fatal.message, /incompatible/);
   await owner.close();
 });
 

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
@@ -9,7 +9,7 @@ import type {
 import { startRuntimeHostDesktopOwner } from '../runtime-host-desktop-owner.js';
 
 test('replaces a disconnected generation without falling back to embedded Runtime', { timeout: 10_000 }, async () => {
-  const first = candidateHarness();
+  const first = candidateHarness({ delayDisconnect: true });
   const second = candidateHarness();
   const queue = [ready(first.candidate), ready(second.candidate)];
   let starts = 0;
@@ -35,10 +35,14 @@ test('replaces a disconnected generation without falling back to embedded Runtim
   });
 
   first.disconnect();
-  await secondStarted;
   const botMessage = owner.handleBotIncomingMessage({ text: 'hello' } as BotIncomingMessage);
   const stop = owner.stopSession('session-1');
   await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(starts, 1);
+  assert.equal(first.botMessages, 0);
+  assert.deepEqual(first.stoppedSessions, []);
+  first.finishDisconnect();
+  await secondStarted;
   assert.equal(second.botMessages, 0);
   assert.deepEqual(second.stoppedSessions, []);
   releaseSecond();
@@ -119,7 +123,7 @@ test('stops reconnecting when the replacement Host is incompatible', async () =>
   await owner.close();
 });
 
-function candidateHarness() {
+function candidateHarness(options: { delayDisconnect?: boolean } = {}) {
   let resolveClosed: (() => void) | undefined;
   const closed = new Promise<void>((resolve) => {
     resolveClosed = resolve;
@@ -127,9 +131,14 @@ function candidateHarness() {
   let closeCalls = 0;
   let botMessages = 0;
   const stoppedSessions: string[] = [];
+  let lifecycleState: 'ready' | 'unavailable' = 'ready';
   const candidate = {
     closed,
-    client: {},
+    client: {
+      get lifecycleState() {
+        return lifecycleState;
+      },
+    },
     botIncoming: {
       async handleBotIncomingMessage() {
         botMessages += 1;
@@ -137,6 +146,7 @@ function candidateHarness() {
     },
     async close() {
       closeCalls += 1;
+      lifecycleState = 'unavailable';
       resolveClosed?.();
     },
     async stopSession(sessionId: string) {
@@ -145,7 +155,11 @@ function candidateHarness() {
   } as unknown as DesktopRuntimeHostCandidate;
   return {
     candidate,
-    disconnect: () => resolveClosed?.(),
+    disconnect: () => {
+      lifecycleState = 'unavailable';
+      if (!options.delayDisconnect) resolveClosed?.();
+    },
+    finishDisconnect: () => resolveClosed?.(),
     get closeCalls() {
       return closeCalls;
     },

--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IpcMain } from "electron";
+import { RuntimeHostOperationError } from "@maka/runtime-host/client";
+import { RuntimeHostReconnectingIpcMain } from "../runtime-host-reconnecting-ipc-main.js";
+
+test("holds an invocation across a Runtime Host candidate replacement", async () => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc);
+  router.handle("sessions:list", async () => "first");
+  assert.equal(await ipc.invoke("sessions:list"), "first");
+
+  router.removeHandler("sessions:list");
+  const waiting = ipc.invoke("sessions:list");
+  let settled = false;
+  void waiting.finally(() => {
+    settled = true;
+  });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(settled, false);
+
+  router.handle("sessions:list", async () => "replacement");
+  assert.equal(await waiting, "replacement");
+
+  router.removeHandler("sessions:list");
+  const failed = deferred();
+  router.handle("sessions:list", async () => {
+    await failed.promise;
+    throw new RuntimeHostOperationError(
+      "session.catalog.query",
+      "host_draining",
+      "Runtime Host is draining",
+    );
+  });
+  const draining = ipc.invoke("sessions:list");
+  router.removeHandler("sessions:list");
+  router.handle("sessions:list", async () => "after-drain");
+  failed.resolve();
+  assert.equal(await draining, "after-drain");
+
+  router.close();
+  assert.equal(ipc.size, 0);
+});
+
+test("does not replay a command IPC handler after a draining rejection", async () => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc);
+  let calls = 0;
+  router.handle("sessions:send", async () => {
+    calls += 1;
+    throw new RuntimeHostOperationError(
+      "turn.start",
+      "host_draining",
+      "Runtime Host is draining",
+    );
+  });
+
+  await assert.rejects(() => ipc.invoke("sessions:send"), /draining/);
+  assert.equal(calls, 1);
+  router.close();
+});
+
+type IpcHandler = Parameters<IpcMain["handle"]>[1];
+
+function ipcHarness() {
+  const handlers = new Map<string, IpcHandler>();
+  return {
+    handle(channel: string, handler: IpcHandler): void {
+      if (handlers.has(channel)) throw new Error(`duplicate handler: ${channel}`);
+      handlers.set(channel, handler);
+    },
+    removeHandler(channel: string): void {
+      handlers.delete(channel);
+    },
+    async invoke(channel: string): Promise<unknown> {
+      const handler = handlers.get(channel);
+      assert.ok(handler);
+      return handler({} as never);
+    },
+    get size(): number {
+      return handlers.size;
+    },
+  };
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}

--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { IpcMain } from "electron";
-import { RuntimeHostOperationError } from "@maka/runtime-host/client";
+import {
+  RuntimeHostOperationError,
+  RuntimeHostRequestInterruptedError,
+} from "@maka/runtime-host/client";
 import { RuntimeHostReconnectingIpcMain } from "../runtime-host-reconnecting-ipc-main.js";
 
 test("holds an invocation across a Runtime Host candidate replacement", async () => {
   const ipc = ipcHarness();
   const router = new RuntimeHostReconnectingIpcMain(ipc);
-  router.handle("sessions:list", async () => "first");
+  router.handleReconnectableRead("sessions:list", async () => "first");
   assert.equal(await ipc.invoke("sessions:list"), "first");
 
   router.removeHandler("sessions:list");
@@ -19,12 +22,12 @@ test("holds an invocation across a Runtime Host candidate replacement", async ()
   await new Promise<void>((resolve) => setImmediate(resolve));
   assert.equal(settled, false);
 
-  router.handle("sessions:list", async () => "replacement");
+  router.handleReconnectableRead("sessions:list", async () => "replacement");
   assert.equal(await waiting, "replacement");
 
   router.removeHandler("sessions:list");
   const failed = deferred();
-  router.handle("sessions:list", async () => {
+  router.handleReconnectableRead("sessions:list", async () => {
     await failed.promise;
     throw new RuntimeHostOperationError(
       "session.catalog.query",
@@ -34,9 +37,20 @@ test("holds an invocation across a Runtime Host candidate replacement", async ()
   });
   const draining = ipc.invoke("sessions:list");
   router.removeHandler("sessions:list");
-  router.handle("sessions:list", async () => "after-drain");
+  router.handleReconnectableRead("sessions:list", async () => "after-drain");
   failed.resolve();
   assert.equal(await draining, "after-drain");
+
+  router.removeHandler("sessions:list");
+  router.handleReconnectableRead("sessions:list", async () => {
+    throw new RuntimeHostRequestInterruptedError(
+      "session.catalog.query",
+      "query",
+      "dispatched",
+      "timeout",
+    );
+  });
+  await assert.rejects(() => ipc.invoke("sessions:list"), /was interrupted/);
 
   router.close();
   assert.equal(ipc.size, 0);

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -742,15 +742,22 @@ function ipcHarness() {
 }
 
 function registerExecutionIpc(
-  deps: Omit<RuntimeHostSessionExecutionIpcDeps, 'sessionCopyCleanup' | 'onBackgroundError'> &
+  deps: Omit<
+    RuntimeHostSessionExecutionIpcDeps,
+    'sessionCopyCleanup' | 'onBackgroundError' | 'observations'
+  > &
     Partial<
-      Pick<RuntimeHostSessionExecutionIpcDeps, 'sessionCopyCleanup' | 'onBackgroundError'>
+      Pick<
+        RuntimeHostSessionExecutionIpcDeps,
+        'sessionCopyCleanup' | 'onBackgroundError' | 'observations'
+      >
     >,
   ipcMain: Pick<IpcMain, 'handle'>,
 ): (sessionId: string) => Promise<void> {
   return registerRuntimeHostSessionExecutionIpc(
     {
       ...deps,
+      observations: deps.observations ?? deps.observer,
       sessionCopyCleanup: deps.sessionCopyCleanup ?? unusedSessionCopyCleanup(),
       onBackgroundError: deps.onBackgroundError ?? (() => undefined),
     },

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -7,6 +7,7 @@ import type {
   SubscriptionFrame,
 } from "@maka/runtime-host/protocol";
 import type { DesktopRuntimeHostSession } from "../runtime-host-client.js";
+import { RuntimeHostSessionObservationRegistry } from "../runtime-host-session-observation-registry.js";
 import {
   RuntimeHostSessionObserver,
   type RuntimeHostSessionObserverTarget,
@@ -101,6 +102,92 @@ test("joins an active Turn without losing or replaying assistant text", async ()
 
   await observer.unobserve("observer-1");
   assert.equal(closeCount, 1);
+});
+
+test("restores renderer observation after the Host connection is replaced", async () => {
+  const firstEvents = new AsyncFrameQueue();
+  const secondEvents = new AsyncFrameQueue();
+  const firstObserver = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: Promise.resolve([]),
+        events: firstEvents,
+        async close() {
+          firstEvents.end();
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+  });
+  const secondObserver = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: Promise.resolve([
+          {
+            type: "assistant",
+            id: "message-1",
+            turnId: "turn-1",
+            ts: 10,
+            text: "Hello",
+            modelId: "test-model",
+          },
+        ]),
+        events: secondEvents,
+        async close() {
+          secondEvents.end();
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+    now: () => 50,
+  });
+  const observations = new RuntimeHostSessionObservationRegistry();
+  const target = eventTarget(10);
+
+  await observations.attach(firstObserver);
+  await observations.observe("session-1", "observer-1", target);
+  observations.detach(firstObserver);
+  await firstObserver.close();
+  await observations.attach(secondObserver);
+  await waitFor(() => target.events.length === 1);
+
+  secondEvents.push(deltaFrame(1, 5, " again"));
+  secondEvents.push({
+    kind: "subscription.session_projection",
+    hostEpoch: "host-2",
+    subscriptionId: "subscription-2",
+    sequence: 2,
+    snapshot: continuitySnapshot({
+      rootTurn: {
+        sessionId: "session-1",
+        turnId: "turn-1",
+        runId: "run-1",
+        status: "completed",
+        terminalEventId: "terminal-1",
+      },
+    }),
+  });
+  await waitFor(() =>
+    target.events.some((event) => event.type === "complete"),
+  );
+
+  assert.deepEqual(
+    target.events.map((event) => [
+      event.type,
+      "text" in event ? event.text : undefined,
+    ]),
+    [
+      ["text_delta", "Hello"],
+      ["text_delta", " again"],
+      ["text_complete", "Hello again"],
+      ["complete", undefined],
+    ],
+  );
+
+  await observations.close();
+  await secondObserver.close();
 });
 
 test("keeps a native Turn watched without a renderer and releases it at terminal", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -6,6 +6,7 @@ import type {
   SessionContinuitySnapshot,
   SubscriptionFrame,
 } from "@maka/runtime-host/protocol";
+import { RuntimeHostSubscriptionError } from "@maka/runtime-host/client";
 import type { DesktopRuntimeHostSession } from "../runtime-host-client.js";
 import { RuntimeHostSessionObservationRegistry } from "../runtime-host-session-observation-registry.js";
 import {
@@ -146,11 +147,11 @@ test("restores renderer observation after the Host connection is replaced", asyn
   const observations = new RuntimeHostSessionObservationRegistry();
   const target = eventTarget(10);
 
-  await observations.attach(firstObserver);
+  assert.deepEqual(await observations.attach(firstObserver), []);
   await observations.observe("session-1", "observer-1", target);
   observations.detach(firstObserver);
   await firstObserver.close();
-  await observations.attach(secondObserver);
+  assert.deepEqual(await observations.attach(secondObserver), ["session-1"]);
   await waitFor(() => target.events.length === 1);
 
   secondEvents.push(deltaFrame(1, 5, " again"));
@@ -188,6 +189,40 @@ test("restores renderer observation after the Host connection is replaced", asyn
 
   await observations.close();
   await secondObserver.close();
+});
+
+test("does not publish a terminal error while an owner-managed connection is replaced", async () => {
+  let rejectFrame!: (error: Error) => void;
+  let closeCount = 0;
+  const events: AsyncIterable<SubscriptionFrame> = {
+    [Symbol.asyncIterator]: () => ({
+      next: () =>
+        new Promise<IteratorResult<SubscriptionFrame>>((_resolve, reject) => {
+          rejectFrame = reject;
+        }),
+    }),
+  };
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => ({
+        snapshot: continuitySnapshot(),
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          closeCount += 1;
+        },
+      }),
+    },
+    emitSessionsChanged() {},
+    recoverConnectionClosed: true,
+  });
+  const target = eventTarget(11);
+  await observer.observe("session-1", "observer-1", target);
+
+  rejectFrame(new RuntimeHostSubscriptionError("connection_closed", "Host restarted"));
+  await waitFor(() => closeCount === 1);
+  assert.equal(target.events.some((event) => event.type === "error"), false);
+  await observer.close();
 });
 
 test("keeps a native Turn watched without a renderer and releases it at terminal", async () => {

--- a/apps/desktop/src/main/ipc-reconnect-policy.ts
+++ b/apps/desktop/src/main/ipc-reconnect-policy.ts
@@ -1,0 +1,19 @@
+import type { IpcMain } from "electron";
+
+export type IpcHandler = Parameters<IpcMain["handle"]>[1];
+
+export interface ReconnectableReadIpcMain extends Pick<IpcMain, "handle"> {
+  handleReconnectableRead?(channel: string, listener: IpcHandler): void;
+}
+
+export function handleReconnectableRead(
+  ipcMain: ReconnectableReadIpcMain,
+  channel: string,
+  listener: IpcHandler,
+): void {
+  if (ipcMain.handleReconnectableRead) {
+    ipcMain.handleReconnectableRead(channel, listener);
+  } else {
+    ipcMain.handle(channel, listener);
+  }
+}

--- a/apps/desktop/src/main/onboarding-ipc-main.ts
+++ b/apps/desktop/src/main/onboarding-ipc-main.ts
@@ -1,9 +1,13 @@
 import { ipcMain } from 'electron';
 import type { createOnboardingService } from './onboarding-service.js';
+import {
+  handleReconnectableRead,
+  type ReconnectableReadIpcMain,
+} from './ipc-reconnect-policy.js';
 
 export interface OnboardingIpcDeps {
   onboardingService: ReturnType<typeof createOnboardingService>;
-  ipcMain?: Pick<typeof ipcMain, 'handle'>;
+  ipcMain?: ReconnectableReadIpcMain;
 }
 
 export function registerOnboardingIpc(deps: OnboardingIpcDeps): void {
@@ -12,7 +16,9 @@ export function registerOnboardingIpc(deps: OnboardingIpcDeps): void {
   // these on app load and whenever `sessions:changed` /
   // `connections:changed` / settings change events fire. No push from
   // main.
-  target.handle('onboarding:getSnapshot', async () => deps.onboardingService.getSnapshot());
+  handleReconnectableRead(target, 'onboarding:getSnapshot', async () =>
+    deps.onboardingService.getSnapshot(),
+  );
   target.handle('onboarding:setMilestone', async (_event, id: unknown, status: unknown) => {
     // Service throws INVALID_MILESTONE_ID / INVALID_MILESTONE_STATUS
     // for bad inputs; let the error propagate so the renderer sees

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -258,7 +258,9 @@ const mcpCapabilityPublisher = createCapabilityRevisionPublisher(() =>
 let settingsBotsIpc: SettingsBotsIpcHandle | undefined;
 const botRegistry = new BotRegistry({
   onIncomingMessage: (message: BotIncomingMessage) => {
-    void owner?.handleBotIncomingMessage(message);
+    void owner
+      ?.handleBotIncomingMessage(message)
+      .catch((error) => console.error("[runtime-host] bot message failed:", error));
   },
   onStatusChange: (status) => {
     mainWindowController.send("settings:bots:statusChanged", status);

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -177,6 +177,8 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
   }
 
   async #close(): Promise<void> {
+    this.#ipc.close();
+    this.#detachSessionObservations();
     const domainResults = await Promise.allSettled([this.#closeSessionDomains()]);
     const results = await Promise.allSettled([
       this.#botIncoming.close(),
@@ -191,8 +193,6 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
   }
 
   async #closeConnection(): Promise<void> {
-    this.#ipc.close();
-    this.#detachSessionObservations();
     await this.#observer.close().catch(() => undefined);
     await this.#closeSessionObservations().catch(() => undefined);
     if (this.#hasRegisteredCapabilities()) {

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -39,6 +39,7 @@ import {
   registerRuntimeHostSessionExecutionIpc,
   type RuntimeHostSessionExecutionIpcDeps,
 } from "./runtime-host-session-execution-ipc-main.js";
+import { RuntimeHostSessionObservationRegistry } from "./runtime-host-session-observation-registry.js";
 import { RuntimeHostSessionObserver } from "./runtime-host-session-observer.js";
 
 type CandidateIpcMain = Pick<IpcMain, "handle" | "removeHandler">;
@@ -99,6 +100,7 @@ export interface DesktopRuntimeHostCandidateStartInput extends DesktopRuntimeHos
   readonly connectTimeoutMs?: number;
   readonly handshakeTimeoutMs?: number;
   readonly candidateEntrypoint?: string | URL;
+  readonly signal?: AbortSignal;
 }
 
 export type DesktopRuntimeHostCandidateStartResult =
@@ -127,6 +129,8 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
   readonly #closeNativeCapabilities: () => Promise<void>;
   readonly #closeSessionDomains: () => Promise<void>;
   readonly #disposeClientIpc: (() => void | Promise<void>) | undefined;
+  readonly #detachSessionObservations: () => void;
+  readonly #closeSessionObservations: () => Promise<void>;
   readonly #hasRegisteredCapabilities: () => boolean;
   readonly #stopSession: (sessionId: string) => Promise<void>;
   #closeTask: Promise<void> | undefined;
@@ -139,6 +143,8 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
     closeNativeCapabilities: () => Promise<void>;
     closeSessionDomains: () => Promise<void>;
     disposeClientIpc: (() => void | Promise<void>) | undefined;
+    detachSessionObservations: () => void;
+    closeSessionObservations: () => Promise<void>;
     connectionClosed: Promise<void>;
     hasRegisteredCapabilities: () => boolean;
     stopSession: (sessionId: string) => Promise<void>;
@@ -151,6 +157,8 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
     this.#closeNativeCapabilities = input.closeNativeCapabilities;
     this.#closeSessionDomains = input.closeSessionDomains;
     this.#disposeClientIpc = input.disposeClientIpc;
+    this.#detachSessionObservations = input.detachSessionObservations;
+    this.#closeSessionObservations = input.closeSessionObservations;
     this.#hasRegisteredCapabilities = input.hasRegisteredCapabilities;
     this.#stopSession = input.stopSession;
     this.botIncoming = input.botIncoming;
@@ -182,7 +190,9 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
 
   async #closeConnection(): Promise<void> {
     this.#ipc.close();
+    this.#detachSessionObservations();
     await this.#observer.close().catch(() => undefined);
+    await this.#closeSessionObservations().catch(() => undefined);
     if (this.#hasRegisteredCapabilities()) {
       await this.#client.unregisterClientCapabilities().catch(() => undefined);
     }
@@ -192,6 +202,7 @@ class DesktopRuntimeHostCandidateImpl implements DesktopRuntimeHostCandidate {
 
 export async function startDesktopRuntimeHostCandidate(
   input: DesktopRuntimeHostCandidateStartInput,
+  observationRegistry?: RuntimeHostSessionObservationRegistry,
 ): Promise<DesktopRuntimeHostCandidateStartResult> {
   const connection = await connectOrSpawnRuntimeHost(connectInput(input));
   if (connection.kind !== "connected") return connection;
@@ -205,6 +216,7 @@ export async function startDesktopRuntimeHostCandidate(
       candidate: await createDesktopRuntimeHostCandidate(
         connection.connection,
         input,
+        observationRegistry,
       ),
     };
   } catch (error) {
@@ -235,9 +247,14 @@ async function waitForRuntimeHostReady(
 export async function createDesktopRuntimeHostCandidate(
   connection: RuntimeHostConnection,
   deps: DesktopRuntimeHostCandidateDeps,
+  observationRegistry?: RuntimeHostSessionObservationRegistry,
 ): Promise<DesktopRuntimeHostCandidate> {
   const client = new DesktopRuntimeHostClient(connection);
   const ipc = new ScopedIpcMain(deps.ipcMain);
+  const sessionObservations =
+    observationRegistry ??
+    new RuntimeHostSessionObservationRegistry((error) => deps.onError?.(error));
+  const ownsSessionObservations = observationRegistry === undefined;
   const providers = new Set<DesktopNativeCapabilityProvider>();
   const nativeSessionIds = new Set<string>();
   const releaseNativeResources = async (
@@ -292,6 +309,7 @@ export async function createDesktopRuntimeHostCandidate(
   let observer: RuntimeHostSessionObserver | undefined;
   let closeSessionDomains: (() => Promise<void>) | undefined;
   let disposeClientIpc: (() => void | Promise<void>) | undefined;
+  let observationsAttached = false;
   let capabilitiesRegistered = false;
   try {
     let domains: RuntimeHostSessionDomainsIpcHandle | undefined;
@@ -309,6 +327,8 @@ export async function createDesktopRuntimeHostCandidate(
       ...(deps.now ? { now: deps.now } : {}),
     });
     observer = sessionObserver;
+    await sessionObservations.attach(sessionObserver);
+    observationsAttached = true;
     domains = registerRuntimeHostSessionDomainsIpc(
       {
         client,
@@ -410,6 +430,7 @@ export async function createDesktopRuntimeHostCandidate(
       {
         client,
         observer: sessionObserver,
+        observations: sessionObservations,
         attachmentApprovals: deps.attachmentApprovals,
         emitSessionsChanged: deps.emitSessionsChanged,
         stat: deps.stat,
@@ -441,15 +462,25 @@ export async function createDesktopRuntimeHostCandidate(
       closeNativeCapabilities,
       closeSessionDomains: domains.close,
       disposeClientIpc,
+      detachSessionObservations: () =>
+        sessionObservations.detach(sessionObserver),
+      closeSessionObservations: () =>
+        ownsSessionObservations
+          ? sessionObservations.close()
+          : Promise.resolve(),
       connectionClosed: connection.closed,
       hasRegisteredCapabilities: () => capabilitiesRegistered,
       stopSession,
     });
   } catch (error) {
     ipc.close();
+    if (observationsAttached && observer) sessionObservations.detach(observer);
     await Promise.resolve(disposeClientIpc?.()).catch(() => undefined);
     await closeSessionDomains?.().catch(() => undefined);
     await observer?.close().catch(() => undefined);
+    if (ownsSessionObservations) {
+      await sessionObservations.close().catch(() => undefined);
+    }
     await client.close().catch(() => undefined);
     await closeNativeCapabilities().catch(() => undefined);
     throw error;
@@ -481,6 +512,7 @@ function connectInput(
     ...(input.candidateEntrypoint === undefined
       ? {}
       : { candidateEntrypoint: input.candidateEntrypoint }),
+    ...(input.signal === undefined ? {} : { signal: input.signal }),
   };
 }
 

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -7,6 +7,7 @@ import type {
 import type { BotRegistry } from "@maka/runtime";
 import {
   connectOrSpawnRuntimeHost,
+  waitForRuntimeHostReady,
   type ConnectOrSpawnRuntimeHostInput,
   type ConnectOrSpawnRuntimeHostResult,
   type RuntimeHostConnection,
@@ -41,8 +42,9 @@ import {
 } from "./runtime-host-session-execution-ipc-main.js";
 import { RuntimeHostSessionObservationRegistry } from "./runtime-host-session-observation-registry.js";
 import { RuntimeHostSessionObserver } from "./runtime-host-session-observer.js";
+import type { IpcHandler, ReconnectableReadIpcMain } from "./ipc-reconnect-policy.js";
 
-type CandidateIpcMain = Pick<IpcMain, "handle" | "removeHandler">;
+type CandidateIpcMain = ReconnectableReadIpcMain & Pick<IpcMain, "removeHandler">;
 
 export interface DesktopRuntimeHostCandidateDeps {
   readonly ipcMain: CandidateIpcMain;
@@ -210,6 +212,7 @@ export async function startDesktopRuntimeHostCandidate(
     await waitForRuntimeHostReady(
       connection.connection,
       input.electionDeadlineMs ?? 45_000,
+      input.signal,
     );
     return {
       kind: "ready",
@@ -222,25 +225,6 @@ export async function startDesktopRuntimeHostCandidate(
   } catch (error) {
     await connection.connection.close().catch(() => undefined);
     throw error;
-  }
-}
-
-async function waitForRuntimeHostReady(
-  connection: RuntimeHostConnection,
-  timeoutMs: number,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (true) {
-    const status = await connection.status(Math.max(1, deadline - Date.now()));
-    if (status.state === "ready") return;
-    if (status.state === "draining")
-      throw new Error("Runtime Host drained before becoming ready");
-    const remaining = deadline - Date.now();
-    if (remaining <= 0)
-      throw new Error("Runtime Host did not become ready before the deadline");
-    await new Promise((resolve) =>
-      setTimeout(resolve, Math.min(25, remaining)),
-    );
   }
 }
 
@@ -324,11 +308,10 @@ export async function createDesktopRuntimeHostCandidate(
         outcome === "completed"
           ? deps.completeComputerUseTurn(sessionId)
           : deps.nativeCapabilities.releaseComputerUseSession(sessionId),
+      recoverConnectionClosed: observationRegistry !== undefined,
       ...(deps.now ? { now: deps.now } : {}),
     });
     observer = sessionObserver;
-    await sessionObservations.attach(sessionObserver);
-    observationsAttached = true;
     domains = registerRuntimeHostSessionDomainsIpc(
       {
         client,
@@ -342,6 +325,11 @@ export async function createDesktopRuntimeHostCandidate(
       ipc,
     );
     closeSessionDomains = domains.close;
+    const restoredSessionIds = await sessionObservations.attach(sessionObserver);
+    observationsAttached = true;
+    for (const sessionId of restoredSessionIds) {
+      deps.emitSessionsChanged("message-appended", sessionId);
+    }
     const watchComputerUseTurn = (sessionId: string, turnId: string): void => {
       void sessionObserver
         .watchTurn(sessionId, turnId)
@@ -516,7 +504,7 @@ function connectInput(
   };
 }
 
-class ScopedIpcMain implements Pick<IpcMain, "handle"> {
+class ScopedIpcMain implements ReconnectableReadIpcMain {
   readonly #ipcMain: CandidateIpcMain;
   readonly #channels = new Set<string>();
   #closed = false;
@@ -526,6 +514,14 @@ class ScopedIpcMain implements Pick<IpcMain, "handle"> {
   }
 
   handle(channel: string, listener: Parameters<IpcMain["handle"]>[1]): void {
+    this.#handle(channel, listener, false);
+  }
+
+  handleReconnectableRead(channel: string, listener: IpcHandler): void {
+    this.#handle(channel, listener, true);
+  }
+
+  #handle(channel: string, listener: IpcHandler, reconnectableRead: boolean): void {
     if (this.#closed)
       throw new Error("Desktop Runtime Host candidate IPC is closed");
     if (this.#channels.has(channel)) {
@@ -533,7 +529,11 @@ class ScopedIpcMain implements Pick<IpcMain, "handle"> {
         `Desktop Runtime Host candidate registered duplicate IPC: ${channel}`,
       );
     }
-    this.#ipcMain.handle(channel, listener);
+    if (reconnectableRead && this.#ipcMain.handleReconnectableRead) {
+      this.#ipcMain.handleReconnectableRead(channel, listener);
+    } else {
+      this.#ipcMain.handle(channel, listener);
+    }
     this.#channels.add(channel);
   }
 

--- a/apps/desktop/src/main/runtime-host-desktop-owner.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-owner.ts
@@ -1,13 +1,18 @@
 import type { BotIncomingMessage } from '@maka/runtime';
 import {
+  RuntimeHostPermanentReconnectError,
+  startRuntimeHostReconnectLifecycle,
+  type RuntimeHostReconnectBackoff,
+  type RuntimeHostReconnectLifecycle,
+} from '@maka/runtime-host/client';
+import {
   startDesktopRuntimeHostCandidate,
   type DesktopRuntimeHostCandidate,
   type DesktopRuntimeHostCandidateStartInput,
   type DesktopRuntimeHostCandidateStartResult,
 } from './runtime-host-desktop-candidate.js';
-
-const MAX_RECONNECT_ATTEMPTS = 3;
-const RECONNECT_DELAY_MS = 250;
+import { RuntimeHostReconnectingIpcMain } from './runtime-host-reconnecting-ipc-main.js';
+import { RuntimeHostSessionObservationRegistry } from './runtime-host-session-observation-registry.js';
 
 export interface RuntimeHostDesktopOwner {
   handleBotIncomingMessage(message: BotIncomingMessage): Promise<void>;
@@ -20,114 +25,87 @@ export async function startRuntimeHostDesktopOwner(
   options: {
     startCandidate?: (
       input: DesktopRuntimeHostCandidateStartInput,
+      observationRegistry: RuntimeHostSessionObservationRegistry,
     ) => Promise<DesktopRuntimeHostCandidateStartResult>;
     onFatalError?: (error: Error) => void;
+    reconnectBackoff?: RuntimeHostReconnectBackoff;
   } = {},
 ): Promise<RuntimeHostDesktopOwner> {
   const owner = new RuntimeHostDesktopOwnerImpl(
     input,
     options.startCandidate ?? startDesktopRuntimeHostCandidate,
     options.onFatalError ?? ((error) => console.error('[runtime-host] reconnect failed:', error)),
+    options.reconnectBackoff,
   );
   await owner.start();
   return owner;
 }
 
 class RuntimeHostDesktopOwnerImpl implements RuntimeHostDesktopOwner {
-  #candidate: DesktopRuntimeHostCandidate | undefined;
-  #generation = 0;
-  #closed = false;
-  #closeTask: Promise<void> | undefined;
+  readonly #ipcMain: RuntimeHostReconnectingIpcMain;
+  readonly #sessionObservations: RuntimeHostSessionObservationRegistry;
+  #lifecycle: RuntimeHostReconnectLifecycle<DesktopRuntimeHostCandidate> | undefined;
 
   constructor(
     private readonly input: DesktopRuntimeHostCandidateStartInput,
     private readonly startCandidate: (
       input: DesktopRuntimeHostCandidateStartInput,
+      observationRegistry: RuntimeHostSessionObservationRegistry,
     ) => Promise<DesktopRuntimeHostCandidateStartResult>,
     private readonly onFatalError: (error: Error) => void,
-  ) {}
-
-  async start(): Promise<void> {
-    const candidate = await this.connect();
-    this.install(candidate);
-  }
-
-  async handleBotIncomingMessage(message: BotIncomingMessage): Promise<void> {
-    const candidate = this.#candidate;
-    if (!candidate || this.#closed) return;
-    await candidate.botIncoming.handleBotIncomingMessage(message);
-  }
-
-  async stopSession(sessionId: string): Promise<void> {
-    const candidate = this.#candidate;
-    if (!candidate || this.#closed) return;
-    await candidate.stopSession(sessionId);
-  }
-
-  close(): Promise<void> {
-    this.#closeTask ??= this.closeOwner();
-    return this.#closeTask;
-  }
-
-  private async closeOwner(): Promise<void> {
-    this.#closed = true;
-    this.#generation += 1;
-    const candidate = this.#candidate;
-    this.#candidate = undefined;
-    await candidate?.close();
-  }
-
-  private install(candidate: DesktopRuntimeHostCandidate): void {
-    if (this.#closed) {
-      void candidate.close();
-      return;
-    }
-    this.#candidate = candidate;
-    const generation = ++this.#generation;
-    void candidate.closed.then(
-      () => this.reconnect(generation),
-      () => this.reconnect(generation),
+    private readonly reconnectBackoff: RuntimeHostReconnectBackoff | undefined,
+  ) {
+    this.#ipcMain = new RuntimeHostReconnectingIpcMain(this.input.ipcMain);
+    this.#sessionObservations = new RuntimeHostSessionObservationRegistry(
+      (error) => this.input.onError?.(error),
     );
   }
 
-  private async reconnect(generation: number): Promise<void> {
-    if (this.#closed || generation !== this.#generation) return;
-    this.#candidate = undefined;
-    for (let attempt = 0; attempt < MAX_RECONNECT_ATTEMPTS; attempt += 1) {
-      if (this.#closed || generation !== this.#generation) return;
-      if (attempt > 0) await delay(RECONNECT_DELAY_MS);
+  async start(): Promise<void> {
+    try {
+      this.#lifecycle = await startRuntimeHostReconnectLifecycle({
+        connect: (signal) => this.connect(signal),
+        onFatalError: this.onFatalError,
+        ...(this.reconnectBackoff ? { backoff: this.reconnectBackoff } : {}),
+      });
+    } catch (error) {
+      await this.#sessionObservations.close();
+      this.#ipcMain.close();
+      throw error;
+    }
+  }
+
+  async handleBotIncomingMessage(message: BotIncomingMessage): Promise<void> {
+    await this.#lifecycle?.current?.botIncoming.handleBotIncomingMessage(message);
+  }
+
+  async stopSession(sessionId: string): Promise<void> {
+    await this.#lifecycle?.current?.stopSession(sessionId);
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.#lifecycle?.close();
+    } finally {
       try {
-        const candidate = await this.connect();
-        if (this.#closed || generation !== this.#generation) {
-          await candidate.close();
-          return;
-        }
-        this.install(candidate);
-        return;
-      } catch (error) {
-        if (attempt + 1 === MAX_RECONNECT_ATTEMPTS) {
-          this.onFatalError(asError(error));
-        }
+        await this.#sessionObservations.close();
+      } finally {
+        this.#ipcMain.close();
       }
     }
   }
 
-  private async connect(): Promise<DesktopRuntimeHostCandidate> {
-    const result = await this.startCandidate(this.input);
+  private async connect(signal: AbortSignal): Promise<DesktopRuntimeHostCandidate> {
+    const result = await this.startCandidate(
+      { ...this.input, ipcMain: this.#ipcMain, signal },
+      this.#sessionObservations,
+    );
     if (result.kind === 'ready') return result.candidate;
     if (result.kind === 'incompatible') {
-      throw new Error(
+      throw new RuntimeHostPermanentReconnectError(
         `Runtime Host is incompatible (protocol ${result.handshake.protocolMin}-${result.handshake.protocolMax}; ${result.handshake.replacement})`,
       );
     }
     throw new Error(`Runtime Host startup failed: ${result.reason}`);
   }
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function asError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
 }

--- a/apps/desktop/src/main/runtime-host-desktop-owner.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-owner.ts
@@ -76,11 +76,13 @@ class RuntimeHostDesktopOwnerImpl implements RuntimeHostDesktopOwner {
   }
 
   async handleBotIncomingMessage(message: BotIncomingMessage): Promise<void> {
-    await this.#lifecycle?.current?.botIncoming.handleBotIncomingMessage(message);
+    const candidate = await this.#requireLifecycle().waitForCurrent();
+    await candidate.botIncoming.handleBotIncomingMessage(message);
   }
 
   async stopSession(sessionId: string): Promise<void> {
-    await this.#lifecycle?.current?.stopSession(sessionId);
+    const candidate = await this.#requireLifecycle().waitForCurrent();
+    await candidate.stopSession(sessionId);
   }
 
   async close(): Promise<void> {
@@ -107,5 +109,10 @@ class RuntimeHostDesktopOwnerImpl implements RuntimeHostDesktopOwner {
       );
     }
     throw new Error(`Runtime Host startup failed: ${result.reason}`);
+  }
+
+  #requireLifecycle(): RuntimeHostReconnectLifecycle<DesktopRuntimeHostCandidate> {
+    if (!this.#lifecycle) throw new Error('Desktop Runtime Host owner has not started');
+    return this.#lifecycle;
   }
 }

--- a/apps/desktop/src/main/runtime-host-desktop-owner.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-owner.ts
@@ -76,12 +76,12 @@ class RuntimeHostDesktopOwnerImpl implements RuntimeHostDesktopOwner {
   }
 
   async handleBotIncomingMessage(message: BotIncomingMessage): Promise<void> {
-    const candidate = await this.#requireLifecycle().waitForCurrent();
+    const candidate = await this.#waitForReadyCandidate();
     await candidate.botIncoming.handleBotIncomingMessage(message);
   }
 
   async stopSession(sessionId: string): Promise<void> {
-    const candidate = await this.#requireLifecycle().waitForCurrent();
+    const candidate = await this.#waitForReadyCandidate();
     await candidate.stopSession(sessionId);
   }
 
@@ -114,5 +114,14 @@ class RuntimeHostDesktopOwnerImpl implements RuntimeHostDesktopOwner {
   #requireLifecycle(): RuntimeHostReconnectLifecycle<DesktopRuntimeHostCandidate> {
     if (!this.#lifecycle) throw new Error('Desktop Runtime Host owner has not started');
     return this.#lifecycle;
+  }
+
+  async #waitForReadyCandidate(): Promise<DesktopRuntimeHostCandidate> {
+    const lifecycle = this.#requireLifecycle();
+    let candidate = await lifecycle.waitForCurrent();
+    while (candidate.client.lifecycleState !== 'ready') {
+      candidate = await lifecycle.waitForCurrent(candidate);
+    }
+    return candidate;
   }
 }

--- a/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
@@ -1,0 +1,121 @@
+import type { IpcMain } from "electron";
+import {
+  RuntimeHostOperationError,
+  RuntimeHostRequestInterruptedError,
+} from "@maka/runtime-host/client";
+
+const RECONNECTABLE_READ_CHANNELS = new Set([
+  "onboarding:getSnapshot",
+  "sessions:list",
+  "skills:listInvocable",
+]);
+
+type IpcHandler = Parameters<IpcMain["handle"]>[1];
+
+interface HandlerWaiter {
+  readonly resolve: (handler: IpcHandler) => void;
+  readonly reject: (error: Error) => void;
+}
+
+interface HandlerSlot {
+  readonly waiters: Set<HandlerWaiter>;
+  handler?: IpcHandler;
+}
+
+/**
+ * Keeps Electron IPC admission stable while a Runtime Host candidate is replaced.
+ */
+export class RuntimeHostReconnectingIpcMain
+  implements Pick<IpcMain, "handle" | "removeHandler">
+{
+  readonly #ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
+  readonly #slots = new Map<string, HandlerSlot>();
+  #closed = false;
+
+  constructor(ipcMain: Pick<IpcMain, "handle" | "removeHandler">) {
+    this.#ipcMain = ipcMain;
+  }
+
+  handle(channel: string, listener: IpcHandler): void {
+    if (this.#closed) {
+      throw new Error("Desktop Runtime Host IPC router is closed");
+    }
+    let slot = this.#slots.get(channel);
+    if (!slot) {
+      const created: HandlerSlot = { waiters: new Set() };
+      this.#ipcMain.handle(channel, (event, ...args) =>
+        this.#dispatch(channel, created, event, args),
+      );
+      this.#slots.set(channel, created);
+      slot = created;
+    }
+    if (slot.handler) {
+      throw new Error(`Desktop Runtime Host IPC handler already exists: ${channel}`);
+    }
+    slot.handler = listener;
+    for (const waiter of slot.waiters) waiter.resolve(listener);
+    slot.waiters.clear();
+  }
+
+  removeHandler(channel: string): void {
+    const slot = this.#slots.get(channel);
+    if (slot) slot.handler = undefined;
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    const error = new Error("Desktop Runtime Host IPC router is closed");
+    for (const [channel, slot] of this.#slots) {
+      for (const waiter of slot.waiters) waiter.reject(error);
+      slot.waiters.clear();
+      slot.handler = undefined;
+      this.#ipcMain.removeHandler(channel);
+    }
+    this.#slots.clear();
+  }
+
+  async #dispatch(
+    channel: string,
+    slot: HandlerSlot,
+    event: Parameters<IpcHandler>[0],
+    args: readonly unknown[],
+  ): Promise<unknown> {
+    let handler = slot.handler ?? (await this.#waitForHandler(slot));
+    while (true) {
+      try {
+        return await handler(event, ...args);
+      } catch (error) {
+        if (
+          !RECONNECTABLE_READ_CHANNELS.has(channel) ||
+          !isReconnectableReadFailure(error)
+        ) {
+          throw error;
+        }
+        handler = await this.#waitForHandler(slot, handler);
+      }
+    }
+  }
+
+  #waitForHandler(slot: HandlerSlot, previous?: IpcHandler): Promise<IpcHandler> {
+    if (this.#closed) {
+      return Promise.reject(
+        new Error("Desktop Runtime Host IPC router is closed"),
+      );
+    }
+    if (slot.handler && slot.handler !== previous) {
+      return Promise.resolve(slot.handler);
+    }
+    return new Promise((resolve, reject) => {
+      slot.waiters.add({ resolve, reject });
+    });
+  }
+}
+
+function isReconnectableReadFailure(error: unknown): boolean {
+  return (
+    (error instanceof RuntimeHostOperationError &&
+      error.code === "host_draining") ||
+    (error instanceof RuntimeHostRequestInterruptedError && error.retryable)
+  );
+}

--- a/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
@@ -3,14 +3,7 @@ import {
   RuntimeHostOperationError,
   RuntimeHostRequestInterruptedError,
 } from "@maka/runtime-host/client";
-
-const RECONNECTABLE_READ_CHANNELS = new Set([
-  "onboarding:getSnapshot",
-  "sessions:list",
-  "skills:listInvocable",
-]);
-
-type IpcHandler = Parameters<IpcMain["handle"]>[1];
+import type { IpcHandler, ReconnectableReadIpcMain } from "./ipc-reconnect-policy.js";
 
 interface HandlerWaiter {
   readonly resolve: (handler: IpcHandler) => void;
@@ -19,6 +12,7 @@ interface HandlerWaiter {
 
 interface HandlerSlot {
   readonly waiters: Set<HandlerWaiter>;
+  readonly reconnectableRead: boolean;
   handler?: IpcHandler;
 }
 
@@ -26,7 +20,7 @@ interface HandlerSlot {
  * Keeps Electron IPC admission stable while a Runtime Host candidate is replaced.
  */
 export class RuntimeHostReconnectingIpcMain
-  implements Pick<IpcMain, "handle" | "removeHandler">
+  implements ReconnectableReadIpcMain
 {
   readonly #ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
   readonly #slots = new Map<string, HandlerSlot>();
@@ -37,17 +31,28 @@ export class RuntimeHostReconnectingIpcMain
   }
 
   handle(channel: string, listener: IpcHandler): void {
+    this.#handle(channel, listener, false);
+  }
+
+  handleReconnectableRead(channel: string, listener: IpcHandler): void {
+    this.#handle(channel, listener, true);
+  }
+
+  #handle(channel: string, listener: IpcHandler, reconnectableRead: boolean): void {
     if (this.#closed) {
       throw new Error("Desktop Runtime Host IPC router is closed");
     }
     let slot = this.#slots.get(channel);
     if (!slot) {
-      const created: HandlerSlot = { waiters: new Set() };
+      const created: HandlerSlot = { waiters: new Set(), reconnectableRead };
       this.#ipcMain.handle(channel, (event, ...args) =>
-        this.#dispatch(channel, created, event, args),
+        this.#dispatch(created, event, args),
       );
       this.#slots.set(channel, created);
       slot = created;
+    }
+    if (slot.reconnectableRead !== reconnectableRead) {
+      throw new Error(`Desktop Runtime Host IPC policy changed: ${channel}`);
     }
     if (slot.handler) {
       throw new Error(`Desktop Runtime Host IPC handler already exists: ${channel}`);
@@ -76,7 +81,6 @@ export class RuntimeHostReconnectingIpcMain
   }
 
   async #dispatch(
-    channel: string,
     slot: HandlerSlot,
     event: Parameters<IpcHandler>[0],
     args: readonly unknown[],
@@ -87,7 +91,7 @@ export class RuntimeHostReconnectingIpcMain
         return await handler(event, ...args);
       } catch (error) {
         if (
-          !RECONNECTABLE_READ_CHANNELS.has(channel) ||
+          !slot.reconnectableRead ||
           !isReconnectableReadFailure(error)
         ) {
           throw error;
@@ -116,6 +120,7 @@ function isReconnectableReadFailure(error: unknown): boolean {
   return (
     (error instanceof RuntimeHostOperationError &&
       error.code === "host_draining") ||
-    (error instanceof RuntimeHostRequestInterruptedError && error.retryable)
+    (error instanceof RuntimeHostRequestInterruptedError &&
+      error.reason === "connection_lost")
   );
 }

--- a/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import type { IpcMain } from 'electron';
 import {
   isCollaborationMode,
   isOrchestrationMode,
@@ -28,6 +27,10 @@ import {
 } from './session-family-action.js';
 import { normalizeSessionModelSelection } from './session-model-input.js';
 import type { SessionCopyCleanupAuthority } from './quote-companion-cleanup.js';
+import {
+  handleReconnectableRead,
+  type ReconnectableReadIpcMain,
+} from './ipc-reconnect-policy.js';
 
 type RuntimeHostSessionCatalogClient = Pick<
   DesktopRuntimeHostClient,
@@ -60,7 +63,7 @@ export interface RuntimeHostSessionCatalogIpcDeps {
 
 export function registerRuntimeHostSessionCatalogIpc(
   deps: RuntimeHostSessionCatalogIpcDeps,
-  ipcMain: Pick<IpcMain, 'handle'>,
+  ipcMain: ReconnectableReadIpcMain,
 ): void {
   const newId = deps.newId ?? randomUUID;
   const listSessions = async (filter?: SessionListFilter): Promise<DesktopHostSessionSummary[]> => {
@@ -78,7 +81,9 @@ export function registerRuntimeHostSessionCatalogIpc(
   const actionIds = (sessionId: string, options: unknown) =>
     resolveSessionActionIds(() => listSessions(), sessionId, options);
 
-  ipcMain.handle('sessions:list', (_event, filter?: SessionListFilter) => listSessions(filter));
+  handleReconnectableRead(ipcMain, 'sessions:list', (_event, filter?: SessionListFilter) =>
+    listSessions(filter),
+  );
   ipcMain.handle('sessions:cleanupSessionCopy', async (_event, sessionId: string) => {
     await deps.sessionCopyCleanup.cleanup(sessionId);
   });

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -26,6 +26,7 @@ import {
 } from "./permission-response-guard.js";
 import type { DesktopRuntimeHostClient } from "./runtime-host-client.js";
 import type { SessionCopyCleanupAuthority } from './quote-companion-cleanup.js';
+import type { RuntimeHostSessionObservationRegistry } from "./runtime-host-session-observation-registry.js";
 import {
   RuntimeHostSessionObserver,
   type RuntimeHostSessionObserverTarget,
@@ -55,6 +56,10 @@ type RuntimeHostSessionExecutionClient = Pick<
 export interface RuntimeHostSessionExecutionIpcDeps {
   client: RuntimeHostSessionExecutionClient;
   observer: RuntimeHostSessionObserver;
+  observations: Pick<
+    RuntimeHostSessionObservationRegistry,
+    "observe" | "unobserve"
+  >;
   attachmentApprovals: AttachmentApprovalRegistry;
   emitSessionsChanged: (
     reason: SessionChangedReason,
@@ -112,7 +117,7 @@ export function registerRuntimeHostSessionExecutionIpc(
     async (event, sessionId: unknown, observerId: unknown) => {
       const normalizedSessionId = requiredId(sessionId, "Session");
       const normalizedObserverId = requiredId(observerId, "Session observer");
-      await deps.observer.observe(
+      await deps.observations.observe(
         normalizedSessionId,
         normalizedObserverId,
         event.sender as RuntimeHostSessionObserverTarget,
@@ -120,7 +125,9 @@ export function registerRuntimeHostSessionExecutionIpc(
     },
   );
   ipcMain.handle("sessions:unobserve", async (_event, observerId: unknown) => {
-    await deps.observer.unobserve(requiredId(observerId, "Session observer"));
+    await deps.observations.unobserve(
+      requiredId(observerId, "Session observer"),
+    );
   });
   ipcMain.handle("sessions:readMessages", async (_event, sessionId: string) => {
     const messages = await deps.observer.readMessages(sessionId);

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -30,13 +30,13 @@ export class RuntimeHostSessionObservationRegistry {
     this.#onError = onError;
   }
 
-  async attach(source: SessionObservationSource): Promise<void> {
+  async attach(source: SessionObservationSource): Promise<string[]> {
     this.#assertOpen();
     if (this.#source && this.#source !== source) {
       throw new Error("Runtime Host Session observations are already attached");
     }
     this.#source = source;
-    await Promise.all(
+    const restored = await Promise.all(
       [...this.#registrations].map(async ([observerId, registration]) => {
         try {
           await source.observe(
@@ -44,11 +44,14 @@ export class RuntimeHostSessionObservationRegistry {
             observerId,
             registration.target,
           );
+          return registration.sessionId;
         } catch (error) {
           if (this.#source === source) this.#onError(error);
+          return undefined;
         }
       }),
     );
+    return [...new Set(restored.filter((sessionId): sessionId is string => !!sessionId))];
   }
 
   detach(source: SessionObservationSource): void {

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -1,0 +1,136 @@
+import type {
+  RuntimeHostSessionObserver,
+  RuntimeHostSessionObserverTarget,
+} from "./runtime-host-session-observer.js";
+
+type SessionObservationSource = Pick<
+  RuntimeHostSessionObserver,
+  "observe" | "unobserve"
+>;
+
+interface SessionObservationRegistration {
+  readonly sessionId: string;
+  readonly target: RuntimeHostSessionObserverTarget;
+  readonly destroyedListener: () => void;
+}
+
+/**
+ * Keeps renderer observation intent alive while the Host connection is replaced.
+ */
+export class RuntimeHostSessionObservationRegistry {
+  readonly #registrations = new Map<
+    string,
+    SessionObservationRegistration
+  >();
+  readonly #onError: (error: unknown) => void;
+  #source: SessionObservationSource | undefined;
+  #closed = false;
+
+  constructor(onError: (error: unknown) => void = () => undefined) {
+    this.#onError = onError;
+  }
+
+  async attach(source: SessionObservationSource): Promise<void> {
+    this.#assertOpen();
+    if (this.#source && this.#source !== source) {
+      throw new Error("Runtime Host Session observations are already attached");
+    }
+    this.#source = source;
+    await Promise.all(
+      [...this.#registrations].map(async ([observerId, registration]) => {
+        try {
+          await source.observe(
+            registration.sessionId,
+            observerId,
+            registration.target,
+          );
+        } catch (error) {
+          if (this.#source === source) this.#onError(error);
+        }
+      }),
+    );
+  }
+
+  detach(source: SessionObservationSource): void {
+    if (this.#source === source) this.#source = undefined;
+  }
+
+  async observe(
+    sessionId: string,
+    observerId: string,
+    target: RuntimeHostSessionObserverTarget,
+  ): Promise<void> {
+    this.#assertOpen();
+    const previous = this.#registrations.get(observerId);
+    if (previous) {
+      if (previous.sessionId !== sessionId || previous.target.id !== target.id) {
+        throw new Error("Runtime Host Session observer identity was reused");
+      }
+      return;
+    }
+
+    const destroyedListener = () => {
+      void this.#remove(observerId).catch(this.#onError);
+    };
+    const registration = { sessionId, target, destroyedListener };
+    this.#registrations.set(observerId, registration);
+    target.once("destroyed", destroyedListener);
+
+    const source = this.#source;
+    if (!source) return;
+    try {
+      await source.observe(sessionId, observerId, target);
+    } catch (error) {
+      if (
+        this.#source === source &&
+        this.#registrations.get(observerId) === registration
+      ) {
+        this.#deleteRegistration(observerId, registration);
+      }
+      throw error;
+    }
+  }
+
+  async unobserve(observerId: string): Promise<void> {
+    await this.#remove(observerId);
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    const source = this.#source;
+    this.#source = undefined;
+    const registrations = [...this.#registrations];
+    this.#registrations.clear();
+    for (const [, registration] of registrations) {
+      registration.target.off("destroyed", registration.destroyedListener);
+    }
+    if (source) {
+      await Promise.allSettled(
+        registrations.map(([observerId]) => source.unobserve(observerId)),
+      );
+    }
+  }
+
+  async #remove(observerId: string): Promise<void> {
+    const registration = this.#registrations.get(observerId);
+    if (!registration) return;
+    this.#deleteRegistration(observerId, registration);
+    await this.#source?.unobserve(observerId);
+  }
+
+  #deleteRegistration(
+    observerId: string,
+    registration: SessionObservationRegistration,
+  ): void {
+    if (this.#registrations.get(observerId) !== registration) return;
+    this.#registrations.delete(observerId);
+    registration.target.off("destroyed", registration.destroyedListener);
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) {
+      throw new Error("Runtime Host Session observation registry is closed");
+    }
+  }
+}

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -24,6 +24,7 @@ import type {
   DesktopRuntimeHostClient,
   DesktopRuntimeHostSession,
 } from "./runtime-host-client.js";
+import { RuntimeHostSubscriptionError } from "@maka/runtime-host/client";
 
 const MAX_PENDING_FRAMES = 512;
 
@@ -50,6 +51,7 @@ export interface RuntimeHostSessionObserverDeps {
     sessionId: string,
     outcome: "completed" | "abandoned",
   ) => void | Promise<void>;
+  recoverConnectionClosed?: boolean;
   now?: () => number;
 }
 
@@ -103,6 +105,7 @@ export class RuntimeHostSessionObserver {
     sessionId: string,
     outcome: "completed" | "abandoned",
   ) => void | Promise<void>;
+  readonly #recoverConnectionClosed: boolean;
   readonly #now: () => number;
   #closed = false;
 
@@ -117,6 +120,7 @@ export class RuntimeHostSessionObserver {
       deps.emitAgentGraphChanged ?? (() => undefined);
     this.#onWatchedTurnFinished =
       deps.onWatchedTurnFinished ?? (() => undefined);
+    this.#recoverConnectionClosed = deps.recoverConnectionClosed ?? false;
     this.#now = deps.now ?? Date.now;
   }
 
@@ -369,7 +373,16 @@ export class RuntimeHostSessionObserver {
         );
       }
     } catch (error) {
-      if (!state.closing) this.#publishSubscriptionFailure(state, error);
+      if (state.closing) return;
+      if (
+        this.#recoverConnectionClosed &&
+        error instanceof RuntimeHostSubscriptionError &&
+        error.reason === "connection_closed"
+      ) {
+        void this.#closeState(state);
+        return;
+      }
+      this.#publishSubscriptionFailure(state, error);
     }
   }
 

--- a/apps/desktop/src/main/runtime-host-skills-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-skills-ipc-main.ts
@@ -1,4 +1,3 @@
-import type { ipcMain as electronIpcMain } from "electron";
 import type { ChatDefaultPermissionMode } from "@maka/core";
 import {
   resolveSkillDiscoveryPaths,
@@ -30,13 +29,17 @@ import type {
   DesktopSkillCatalogSnapshot,
 } from "./runtime-host-client.js";
 import { resolveSkillOpenPath } from "./skill-open-path.js";
+import {
+  handleReconnectableRead,
+  type ReconnectableReadIpcMain,
+} from "./ipc-reconnect-policy.js";
 
 const MAX_REVISION_ATTEMPTS = 3;
 
 type MainWindowController = ReturnType<typeof createMainWindowController>;
 
 interface RuntimeHostSkillsIpcDeps {
-  readonly ipcMain: Pick<typeof electronIpcMain, "handle">;
+  readonly ipcMain: ReconnectableReadIpcMain;
   readonly client: DesktopRuntimeHostClient;
   readonly workspaceRoot: string;
   readonly mainWindowController: MainWindowController;
@@ -75,7 +78,8 @@ export function registerRuntimeHostSkillsIpc(
     );
   });
 
-  deps.ipcMain.handle(
+  handleReconnectableRead(
+    deps.ipcMain,
     "skills:listInvocable",
     async (_event, sessionId?: unknown, newSessionContext?: unknown) => {
       const target =

--- a/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
@@ -8,9 +8,18 @@ import { connectRuntimeHostCli } from '../runtime-host-cli-context.js';
 test('CLI Runtime Host bootstrap launches the execution composition', async () => {
   let candidateEntrypoint: string | URL | undefined;
   let legacyConfigurationRoot: string | undefined;
+  let clientInstanceId: string | undefined;
   let closes = 0;
   const connection = {
+    rootId: 'root-id',
+    hostEpoch: 'host-epoch',
+    connectionId: 'connection-id',
+    selectedProtocol: 0,
+    closed: new Promise<void>(() => {}),
     status: async () => ({ state: 'ready' }),
+    subscribeConfigurationChanges: () => () => {},
+    subscribeProjectCatalogChanges: () => () => {},
+    subscribeSessionCatalogChanges: () => () => {},
     close: async () => {
       closes += 1;
     },
@@ -26,6 +35,7 @@ test('CLI Runtime Host bootstrap launches the execution composition', async () =
       connectOrSpawn: async (input) => {
         candidateEntrypoint = input.candidateEntrypoint;
         legacyConfigurationRoot = input.legacyConfigurationRoot;
+        clientInstanceId = input.clientInstanceId;
         return { kind: 'connected', connection };
       },
       readConnectionCatalog: async () => ({
@@ -39,6 +49,7 @@ test('CLI Runtime Host bootstrap launches the execution composition', async () =
   assert.ok(candidateEntrypoint instanceof URL);
   assert.equal(basename(fileURLToPath(candidateEntrypoint)), 'execution-candidate-main.js');
   assert.equal(legacyConfigurationRoot, '/legacy-configuration');
+  assert.ok(clientInstanceId);
   await context.close();
   assert.equal(closes, 1);
 });

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -9,6 +9,7 @@ import type {
   DirectRequestOperationKey,
   RuntimeHostSessionSubscription,
 } from '@maka/runtime-host/client';
+import { RuntimeHostSubscriptionError } from '@maka/runtime-host/client';
 import type {
   InteractionPendingSnapshot,
   OperationInput,
@@ -132,6 +133,37 @@ describe('Runtime Host Maka Session driver', () => {
       startOffset: 5,
       text: ' world',
     });
+  });
+
+  test('restarts initial hydration when the first connection closes during transcript load', async () => {
+    const transcript = deferred<StoredMessage[]>();
+    const initial = new FakeSubscription(continuitySnapshot(), transcript.promise);
+    const replacementMessages = [assistantMessage('turn-1', 'Canonical replacement')];
+    const replacement = new FakeSubscription(
+      continuitySnapshot({ projectionRevision: 2 }),
+      Promise.resolve(replacementMessages),
+      'subscription-2',
+    );
+    const connection = new FakeConnection([initial, replacement], true);
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/tmp',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+    });
+
+    const switching = driver.switchSession('session-1');
+    await waitFor(() => initial.nextCalls > 0);
+    const disconnected = new RuntimeHostSubscriptionError(
+      'connection_closed',
+      'connection closed during initial hydration',
+    );
+    initial.fail(disconnected);
+    transcript.reject(disconnected);
+
+    const switched = await switching;
+    assert.deepEqual(switched.messages, replacementMessages);
+    assert.equal(connection.openedSubscriptions, 2);
   });
 
   test('drains the active cut when its turn completes during transcript load', async () => {
@@ -840,6 +872,41 @@ describe('Runtime Host Maka Session driver', () => {
 
     assert.deepEqual(await replacement.promise, durableMessages);
   });
+
+  test('resnapshots an active Session after reconnect and continues its live stream', async () => {
+    const initial = new FakeSubscription(
+      continuitySnapshot(),
+      Promise.resolve([assistantMessage('turn-1', 'Hello')]),
+    );
+    const replacement = new FakeSubscription(
+      continuitySnapshot({ projectionRevision: 2 }),
+      Promise.resolve([assistantMessage('turn-1', 'Hello world')]),
+      'subscription-2',
+    );
+    const connection = new FakeConnection([initial, replacement], true);
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/tmp',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      now: () => 50,
+    });
+    const switched = await driver.switchSession('session-1');
+    assert.ok(switched.activeTurn);
+    const transcript = deferred<StoredMessage[]>();
+    driver.subscribeTranscriptReplacements!((_sessionId, _turnId, messages, reason) => {
+      assert.equal(reason, 'reconnect');
+      transcript.resolve(messages);
+    });
+
+    initial.fail(
+      new RuntimeHostSubscriptionError('connection_closed', 'connection lost during active Turn'),
+    );
+    assert.deepEqual(await transcript.promise, [assistantMessage('turn-1', 'Hello world')]);
+    assert.equal(connection.openedSubscriptions, 2);
+    replacement.push(deltaFrame(1, 'turn-1', 11, '!', 'subscription-2'));
+    assert.equal((await nextEvent(switched.activeTurn.events)).text, '!');
+  });
 });
 
 class FakeConnection {
@@ -851,8 +918,12 @@ class FakeConnection {
   skillStartBlocked = false;
   readonly value: RuntimeHostMakaSessionDriverInput['connection'];
 
-  constructor(private readonly subscriptions: FakeSubscription[]) {
+  constructor(
+    private readonly subscriptions: FakeSubscription[],
+    reconnecting = false,
+  ) {
     this.value = {
+      ...(reconnecting ? { reconnecting: true as const } : {}),
       hostEpoch: 'host-1',
       request: <K extends DirectRequestOperationKey>(operation: K, input: OperationInput<K>) =>
         this.request(operation, input),
@@ -953,9 +1024,13 @@ class FakeSubscription implements RuntimeHostSessionSubscription, AsyncIterator<
   readonly hostEpoch = 'host-1';
   readonly subscriptionId: string;
   readonly #frames: SubscriptionFrame[] = [];
-  readonly #waiters: Array<(result: IteratorResult<SubscriptionFrame>) => void> = [];
+  readonly #waiters: Array<{
+    resolve(result: IteratorResult<SubscriptionFrame>): void;
+    reject(error: Error): void;
+  }> = [];
   nextCalls = 0;
   #closed = false;
+  #failure: Error | undefined;
 
   constructor(
     readonly snapshot: SessionContinuitySnapshot,
@@ -973,14 +1048,20 @@ class FakeSubscription implements RuntimeHostSessionSubscription, AsyncIterator<
     this.nextCalls += 1;
     const frame = this.#frames.shift();
     if (frame) return Promise.resolve({ done: false, value: frame });
+    if (this.#failure) return Promise.reject(this.#failure);
     if (this.#closed) return Promise.resolve({ done: true, value: undefined });
-    return new Promise((resolve) => this.#waiters.push(resolve));
+    return new Promise((resolve, reject) => this.#waiters.push({ resolve, reject }));
   }
 
   push(frame: SubscriptionFrame): void {
     const waiter = this.#waiters.shift();
-    if (waiter) waiter({ done: false, value: frame });
+    if (waiter) waiter.resolve({ done: false, value: frame });
     else this.#frames.push(frame);
+  }
+
+  fail(error: Error): void {
+    this.#failure = error;
+    for (const waiter of this.#waiters.splice(0)) waiter.reject(error);
   }
 
   async loadTranscript<T>(decodeMessage: (value: unknown) => T): Promise<T[]> {
@@ -989,7 +1070,9 @@ class FakeSubscription implements RuntimeHostSessionSubscription, AsyncIterator<
 
   async close(): Promise<void> {
     this.#closed = true;
-    for (const waiter of this.#waiters.splice(0)) waiter({ done: true, value: undefined });
+    for (const waiter of this.#waiters.splice(0)) {
+      waiter.resolve({ done: true, value: undefined });
+    }
   }
 }
 
@@ -1170,12 +1253,18 @@ function sequenceIds(...ids: string[]): () => string {
   return () => ids[index++] ?? `id-${index}`;
 }
 
-function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((settle) => {
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((settle, fail) => {
     resolve = settle;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -333,6 +333,10 @@ describe('Runtime Host Maka Session driver', () => {
       userMessage('turn-2', 'Fast follow up'),
       assistantMessage('turn-2', 'Done'),
     ]);
+    const text = await nextEvent(attached.events);
+    assert.equal(text.type, 'text_complete');
+    if (text.type !== 'text_complete') assert.fail('Expected the durable assistant answer');
+    assert.equal(text.text, 'Done');
     assert.equal((await nextEvent(attached.events)).type, 'complete');
   });
 
@@ -907,6 +911,88 @@ describe('Runtime Host Maka Session driver', () => {
     replacement.push(deltaFrame(1, 'turn-1', 11, '!', 'subscription-2'));
     assert.equal((await nextEvent(switched.activeTurn.events)).text, '!');
   });
+
+  test('recovers the complete terminal answer when a Turn finishes during reconnect', async () => {
+    const initial = new FakeSubscription(
+      continuitySnapshot(),
+      Promise.resolve([assistantMessage('turn-1', 'Hello')]),
+    );
+    const replacement = new FakeSubscription(
+      continuitySnapshot({
+        projectionRevision: 2,
+        rootTurn: completedTurn('turn-1', 'run-1'),
+      }),
+      Promise.resolve([
+        assistantMessage('turn-1', 'Hello world'),
+        turnStateMessage('turn-1', 'completed'),
+      ]),
+      'subscription-2',
+    );
+    const connection = new FakeConnection([initial, replacement], true);
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/tmp',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      now: () => 50,
+    });
+    const switched = await driver.switchSession('session-1');
+    assert.ok(switched.activeTurn);
+
+    initial.fail(new RuntimeHostSubscriptionError('connection_closed', 'connection lost'));
+    const text = await nextEvent(switched.activeTurn.events);
+    assert.equal(text.type, 'text_complete');
+    assert.equal(text.text, 'Hello world');
+    assert.equal((await nextEvent(switched.activeTurn.events)).type, 'complete');
+    assert.equal((await switched.activeTurn.events[Symbol.asyncIterator]().next()).done, true);
+  });
+
+  test('settles an attached Turn before publishing its reconnect-gap successor', async () => {
+    const initial = new FakeSubscription(
+      continuitySnapshot(),
+      Promise.resolve([assistantMessage('turn-1', 'Working')]),
+    );
+    const replacementMessages = [
+      assistantMessage('turn-1', 'Finished'),
+      turnStateMessage('turn-1', 'completed'),
+      userMessage('turn-2', 'Continue'),
+      assistantMessage('turn-2', 'Continuing'),
+    ];
+    const replacement = new FakeSubscription(
+      continuitySnapshot({
+        projectionRevision: 3,
+        rootTurn: runningTurn('turn-2', 'run-2'),
+      }),
+      Promise.resolve(replacementMessages),
+      'subscription-2',
+    );
+    const successor = new FakeSubscription(
+      continuitySnapshot({
+        projectionRevision: 3,
+        rootTurn: runningTurn('turn-2', 'run-2'),
+      }),
+      Promise.resolve(replacementMessages),
+      'subscription-3',
+    );
+    const connection = new FakeConnection([initial, replacement, successor], true);
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/tmp',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      now: () => 50,
+    });
+    const switched = await driver.switchSession('session-1');
+    assert.ok(switched.activeTurn);
+    const started = deferred<MakaAttachedSessionTurn>();
+    driver.subscribeStartedTurns!((turn) => started.resolve(turn));
+
+    initial.fail(new RuntimeHostSubscriptionError('connection_closed', 'connection lost'));
+    assert.equal((await nextEvent(switched.activeTurn.events)).type, 'text_complete');
+    assert.equal((await nextEvent(switched.activeTurn.events)).type, 'complete');
+    assert.equal((await switched.activeTurn.events[Symbol.asyncIterator]().next()).done, true);
+    assert.equal((await started.promise).turnId, 'turn-2');
+  });
 });
 
 class FakeConnection {
@@ -1153,6 +1239,20 @@ function assistantMessage(turnId: string, text: string): StoredMessage {
 
 function userMessage(turnId: string, text: string): StoredMessage {
   return { type: 'user', id: `user-${turnId}`, turnId, ts: 9, text };
+}
+
+function turnStateMessage(
+  turnId: string,
+  status: 'completed' | 'failed' | 'aborted',
+): StoredMessage {
+  return {
+    type: 'turn_state',
+    id: `state-${turnId}`,
+    turnId,
+    ts: 80,
+    status,
+    partialOutputRetained: true,
+  };
 }
 
 function deltaFrame(

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -372,8 +372,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       requestRender();
     }) ?? (() => {});
   const unsubscribeTranscriptReplacements =
-    input.driver.subscribeTranscriptReplacements?.((sessionId, turnId, messages) => {
+    input.driver.subscribeTranscriptReplacements?.((sessionId, turnId, messages, reason) => {
       if (closed || input.driver.getSessionId() !== sessionId) return;
+      if (reason === 'reconnect') {
+        replaceTranscriptWithStoredMessages(state, messages);
+        shellRunElapsedTicker.sync();
+        requestRender();
+        return;
+      }
       if (reconcileToolsWithStoredMessages(state, turnId, messages)) {
         shellRunElapsedTicker.sync();
         requestRender();

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -6,6 +6,7 @@ import {
   createRuntimeHostReconnectingConnection,
   readRuntimeHostConnectionCatalog,
   RuntimeHostPermanentReconnectError,
+  waitForRuntimeHostReady,
   type RuntimeHostConnection,
 } from '@maka/runtime-host/client';
 import { RUNTIME_HOST_PROTOCOL_VERSION, type ClientSurface } from '@maka/runtime-host/protocol';
@@ -65,7 +66,7 @@ export async function connectRuntimeHostCli(
       throw new Error(`Runtime Host startup failed: ${connected.reason}`);
     }
     try {
-      await waitForReady(connected.connection);
+      await waitForRuntimeHostReady(connected.connection, 45_000, signal);
       return connected.connection;
     } catch (error) {
       await connected.connection.close().catch(() => undefined);
@@ -115,16 +116,4 @@ export function resolveRuntimeHostCliTarget(
     throw new Error(`Runtime Host model is unavailable for ${connection.slug}: ${model ?? ''}`);
   }
   return { connection, model };
-}
-
-async function waitForReady(connection: RuntimeHostConnection): Promise<void> {
-  const deadline = Date.now() + 45_000;
-  while (true) {
-    const status = await connection.status(Math.max(1, deadline - Date.now()));
-    if (status.state === 'ready') return;
-    if (status.state === 'draining') throw new Error('Runtime Host drained before becoming ready');
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) throw new Error('Runtime Host did not become ready before the deadline');
-    await new Promise((resolve) => setTimeout(resolve, Math.min(25, remaining)));
-  }
 }

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -1,8 +1,11 @@
+import { randomUUID } from 'node:crypto';
 import { NO_REAL_CONNECTION_CODE } from '@maka/core';
 import type { ConnectionCatalogEntry, ConnectionCatalogSnapshot } from '@maka/core/runtime-policy';
 import {
   connectOrSpawnRuntimeHost,
+  createRuntimeHostReconnectingConnection,
   readRuntimeHostConnectionCatalog,
+  RuntimeHostPermanentReconnectError,
   type RuntimeHostConnection,
 } from '@maka/runtime-host/client';
 import { RUNTIME_HOST_PROTOCOL_VERSION, type ClientSurface } from '@maka/runtime-host/protocol';
@@ -40,26 +43,41 @@ export async function connectRuntimeHostCli(
     ),
     ...overrides,
   };
-  const connected = await deps.connectOrSpawn({
+  const clientInstanceId = randomUUID();
+  const connectInput = {
     rootPath: input.rootPath,
     surface: input.surface,
     protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
+    clientInstanceId,
     candidateEntrypoint: deps.executionCandidateEntrypoint,
     ...(input.legacyConfigurationRoot
       ? { legacyConfigurationRoot: input.legacyConfigurationRoot }
       : {}),
+  } as const;
+  const connect = async (signal?: AbortSignal): Promise<RuntimeHostConnection> => {
+    const connected = await deps.connectOrSpawn({ ...connectInput, ...(signal ? { signal } : {}) });
+    if (connected.kind === 'incompatible') {
+      throw new RuntimeHostPermanentReconnectError(
+        `Runtime Host protocol is incompatible (Host ${connected.handshake.protocolMin}-${connected.handshake.protocolMax}, CLI ${RUNTIME_HOST_PROTOCOL_VERSION})`,
+      );
+    }
+    if (connected.kind === 'failed') {
+      throw new Error(`Runtime Host startup failed: ${connected.reason}`);
+    }
+    try {
+      await waitForReady(connected.connection);
+      return connected.connection;
+    } catch (error) {
+      await connected.connection.close().catch(() => undefined);
+      throw error;
+    }
+  };
+  const initialConnection = await connect();
+  const connection = await createRuntimeHostReconnectingConnection({
+    initialConnection,
+    connect,
   });
-  if (connected.kind === 'incompatible') {
-    throw new Error(
-      `Runtime Host protocol is incompatible (Host ${connected.handshake.protocolMin}-${connected.handshake.protocolMax}, CLI ${RUNTIME_HOST_PROTOCOL_VERSION})`,
-    );
-  }
-  if (connected.kind === 'failed') {
-    throw new Error(`Runtime Host startup failed: ${connected.reason}`);
-  }
-  const connection = connected.connection;
   try {
-    await waitForReady(connection);
     return {
       connection,
       catalog: await deps.readConnectionCatalog(connection),

--- a/packages/cli/src/runtime-host-session-channel.ts
+++ b/packages/cli/src/runtime-host-session-channel.ts
@@ -258,11 +258,12 @@ export class RuntimeHostSessionChannel {
         this.#failedSubscriptions.add(subscription);
         if (!this.#ready) return;
         if (this.#recoveryTask) {
-          void this.#recoveryTask.finally(() => {
+          const schedule = () => {
             if (this.#subscription === subscription && !this.#closing) {
               this.#scheduleRecovery(subscription);
             }
-          });
+          };
+          void this.#recoveryTask.then(schedule, schedule);
         } else {
           this.#scheduleRecovery(subscription);
         }
@@ -368,6 +369,22 @@ export class RuntimeHostSessionChannel {
       const copy = structuredClone(pending);
       if (this.#activated) this.#onInteractionPending(copy);
       else this.#pendingOpenedInteractions.push(copy);
+    }
+
+    if (
+      previousRoot &&
+      !isTerminalTurn(previousRoot) &&
+      (!root || root.runId !== previousRoot.runId)
+    ) {
+      const terminalEvents = this.#projector.seedStoredTerminal(previousRoot.turnId, this.messages);
+      if (terminalEvents.length === 0) {
+        throw new RuntimeHostSubscriptionError(
+          'projection_revision_invalid',
+          `Runtime Host replacement omitted the terminal record for Turn ${previousRoot.turnId}`,
+        );
+      }
+      for (const event of terminalEvents) this.#emit(event);
+      this.#queue(previousRoot.turnId).finish();
     }
 
     if (root && !isTerminalTurn(root)) {

--- a/packages/cli/src/runtime-host-session-channel.ts
+++ b/packages/cli/src/runtime-host-session-channel.ts
@@ -4,9 +4,12 @@ import {
   isRuntimeHostTerminalTurn as isTerminalTurn,
   type RuntimeHostTerminalTurn as TerminalTurnSnapshot,
 } from '@maka/runtime-host/adapter';
-import type {
-  RuntimeHostConnection,
-  RuntimeHostSessionSubscription,
+import {
+  isRuntimeHostReconnectingConnection,
+  RuntimeHostRequestInterruptedError,
+  RuntimeHostSubscriptionError,
+  type RuntimeHostConnection,
+  type RuntimeHostSessionSubscription,
 } from '@maka/runtime-host/client';
 import type {
   InteractionAnsweredSnapshot,
@@ -35,37 +38,46 @@ export interface RuntimeHostSessionChannelOptions {
   onInteractionPending: (pending: InteractionPendingSnapshot) => void;
   onInteractionResolved: (pending: InteractionPendingSnapshot) => void;
   onTurnTerminal: (turn: TerminalTurnSnapshot) => void;
+  onTranscriptReplaced: (turnId: string, messages: readonly StoredMessage[]) => void;
+  onRecovered: () => void;
 }
 
 export class RuntimeHostSessionChannel {
   readonly sessionId: string;
   readonly messages: StoredMessage[];
   snapshot: SessionContinuitySnapshot;
-  readonly #subscription: RuntimeHostSessionSubscription;
+  readonly #connection: Pick<RuntimeHostConnection, 'openSessionSubscription'>;
+  #subscription: RuntimeHostSessionSubscription;
   readonly #now: () => number;
   readonly #onTurnStarted: (turn: MakaPreparedSessionTurn) => void;
   readonly #onRuntimeResourceChanged: (sourceSessionId: string, ref: string) => void;
   readonly #onInteractionPending: (pending: InteractionPendingSnapshot) => void;
   readonly #onInteractionResolved: (pending: InteractionPendingSnapshot) => void;
   readonly #onTurnTerminal: (turn: TerminalTurnSnapshot) => void;
+  readonly #onTranscriptReplaced: (turnId: string, messages: readonly StoredMessage[]) => void;
+  readonly #onRecovered: () => void;
   readonly #turns = new Map<string, SessionEventQueue>();
   readonly #pendingFrames: SubscriptionFrame[] = [];
   readonly #pendingStartedTurns = new Map<string, MakaPreparedSessionTurn>();
   readonly #pendingOpenedInteractions: InteractionPendingSnapshot[] = [];
   readonly #pendingResolvedInteractions: InteractionPendingSnapshot[] = [];
   readonly #pendingTerminalTurns: TerminalTurnSnapshot[] = [];
+  readonly #failedSubscriptions = new WeakSet<RuntimeHostSessionSubscription>();
   #projector: RuntimeHostSessionProjector | undefined;
   #ready = false;
   #activated = false;
   #startedTurnBarrier: string | undefined;
   #closing = false;
   #failure: Error | undefined;
+  #recoveryTask: Promise<void> | undefined;
 
   private constructor(
     subscription: RuntimeHostSessionSubscription,
     messages: StoredMessage[],
     options: Omit<RuntimeHostSessionChannelOptions, 'connection' | 'sessionId'>,
+    connection: Pick<RuntimeHostConnection, 'openSessionSubscription'>,
   ) {
+    this.#connection = connection;
     this.#subscription = subscription;
     this.sessionId = subscription.snapshot.session.sessionId;
     this.snapshot = structuredClone(subscription.snapshot);
@@ -76,6 +88,8 @@ export class RuntimeHostSessionChannel {
     this.#onInteractionPending = options.onInteractionPending;
     this.#onInteractionResolved = options.onInteractionResolved;
     this.#onTurnTerminal = options.onTurnTerminal;
+    this.#onTranscriptReplaced = options.onTranscriptReplaced;
+    this.#onRecovered = options.onRecovered;
   }
 
   static async open(
@@ -85,31 +99,44 @@ export class RuntimeHostSessionChannel {
       sessionId: options.sessionId,
     });
     const initialRoot = structuredClone(subscription.snapshot.rootTurn);
-    const channel = new RuntimeHostSessionChannel(subscription, [], options);
-    void channel.#pump();
+    const channel = new RuntimeHostSessionChannel(subscription, [], options, options.connection);
+    void channel.#pump(subscription);
     try {
-      const messages = await subscription.loadTranscript(decodeStoredMessageForRead);
-      channel.messages.push(...messages.map((message) => structuredClone(message)));
-      channel.#projector = new RuntimeHostSessionProjector(
-        channel.snapshot,
-        channel.messages,
-        options.now,
-      );
-      for (const event of channel.#projector.seedActive(false)) channel.#emit(event);
-      channel.#ready = true;
-      for (const frame of channel.#pendingFrames.splice(0)) channel.#accept(frame);
+      const recovered = await channel.#hydrateInitial(subscription);
+      const root = recovered ? structuredClone(channel.snapshot.rootTurn) : initialRoot;
       return {
         channel,
         messages: channel.messages.map((message) => structuredClone(message)),
-        ...(initialRoot && !isTerminalTurn(initialRoot)
-          ? { attachedTurnId: initialRoot.turnId }
-          : {}),
-        ...(initialRoot && isTerminalTurn(initialRoot) ? { terminalTurn: initialRoot } : {}),
+        ...(root && !isTerminalTurn(root) ? { attachedTurnId: root.turnId } : {}),
+        ...(root && isTerminalTurn(root) ? { terminalTurn: root } : {}),
       };
     } catch (error) {
       await channel.close().catch(() => undefined);
       throw error;
     }
+  }
+
+  async #hydrateInitial(subscription: RuntimeHostSessionSubscription): Promise<boolean> {
+    let messages: StoredMessage[] | undefined;
+    try {
+      messages = await subscription.loadTranscript(decodeStoredMessageForRead);
+    } catch (error) {
+      if (!this.#canRecover(error)) throw error;
+      this.#failedSubscriptions.add(subscription);
+    }
+    if (this.#failedSubscriptions.has(subscription)) {
+      await this.#recover(subscription);
+      if (!this.#ready) {
+        throw this.#failure ?? new Error('Runtime Host Session recovery ended before hydration');
+      }
+      return true;
+    }
+    this.messages.push(...(messages ?? []).map((message) => structuredClone(message)));
+    this.#projector = new RuntimeHostSessionProjector(this.snapshot, this.messages, this.#now);
+    for (const event of this.#projector.seedActive(false)) this.#emit(event);
+    this.#ready = true;
+    for (const frame of this.#pendingFrames.splice(0)) this.#accept(frame);
+    return false;
   }
 
   async *eventsForTurn(turnId: string): AsyncIterable<SessionEvent> {
@@ -208,13 +235,16 @@ export class RuntimeHostSessionChannel {
     await this.#subscription.close();
   }
 
-  async #pump(): Promise<void> {
+  async #pump(subscription: RuntimeHostSessionSubscription): Promise<void> {
     try {
-      for await (const frame of this.#subscription) {
-        if (this.#closing) return;
+      for await (const frame of subscription) {
+        if (this.#closing || this.#subscription !== subscription) return;
         if (!this.#ready) {
           if (this.#pendingFrames.length >= MAX_PENDING_FRAMES) {
-            throw new Error('Runtime Host transcript could not keep up with live Session events');
+            throw new RuntimeHostSubscriptionError(
+              'slow_consumer',
+              'Runtime Host transcript could not keep up with live Session events',
+            );
           }
           this.#pendingFrames.push(frame);
         } else {
@@ -223,9 +253,157 @@ export class RuntimeHostSessionChannel {
       }
       if (!this.#closing) throw new Error('Runtime Host Session subscription ended unexpectedly');
     } catch (error) {
-      if (this.#closing) return;
+      if (this.#closing || this.#subscription !== subscription) return;
+      if (this.#canRecover(error)) {
+        this.#failedSubscriptions.add(subscription);
+        if (!this.#ready) return;
+        if (this.#recoveryTask) {
+          void this.#recoveryTask.finally(() => {
+            if (this.#subscription === subscription && !this.#closing) {
+              this.#scheduleRecovery(subscription);
+            }
+          });
+        } else {
+          this.#scheduleRecovery(subscription);
+        }
+        return;
+      }
       this.#fail(error);
     }
+  }
+
+  #scheduleRecovery(failed: RuntimeHostSessionSubscription): void {
+    if (this.#closing || this.#failure || this.#subscription !== failed || this.#recoveryTask)
+      return;
+    const task = this.#recover(failed);
+    this.#recoveryTask = task;
+    void task
+      .catch((error: unknown) => {
+        if (!this.#closing) this.#fail(error);
+      })
+      .finally(() => {
+        if (this.#recoveryTask === task) this.#recoveryTask = undefined;
+      });
+  }
+
+  async #recover(failed: RuntimeHostSessionSubscription): Promise<void> {
+    let previous = failed;
+    while (!this.#closing && !this.#failure && this.#subscription === previous) {
+      await previous.close().catch(() => undefined);
+      let replacement: RuntimeHostSessionSubscription;
+      try {
+        replacement = await this.#connection.openSessionSubscription({ sessionId: this.sessionId });
+      } catch (error) {
+        if (this.#canRecover(error)) continue;
+        throw error;
+      }
+      if (this.#closing || this.#failure || this.#subscription !== previous) {
+        await replacement.close().catch(() => undefined);
+        return;
+      }
+      this.#subscription = replacement;
+      this.#ready = false;
+      this.#pendingFrames.length = 0;
+      void this.#pump(replacement);
+      try {
+        const messages = await replacement.loadTranscript(decodeStoredMessageForRead);
+        if (this.#failedSubscriptions.has(replacement)) {
+          throw new RuntimeHostSubscriptionError(
+            'connection_closed',
+            'Runtime Host Session subscription closed during catch-up',
+          );
+        }
+        if (this.#closing || this.#failure || this.#subscription !== replacement) return;
+        const replacedLiveState = this.#acceptCanonicalReplacement(messages);
+        this.#ready = true;
+        for (const frame of this.#pendingFrames.splice(0)) this.#accept(frame);
+        if (replacedLiveState) this.#onRecovered();
+        return;
+      } catch (error) {
+        if (!this.#canRecover(error)) throw error;
+        previous = replacement;
+      }
+    }
+  }
+
+  #acceptCanonicalReplacement(messages: StoredMessage[]): boolean {
+    const replacedLiveState = this.#projector !== undefined;
+    const previousSnapshot = this.snapshot;
+    const nextSnapshot = structuredClone(this.#subscription.snapshot);
+    this.messages.splice(
+      0,
+      this.messages.length,
+      ...messages.map((message) => structuredClone(message)),
+    );
+    this.snapshot = nextSnapshot;
+    this.#projector = new RuntimeHostSessionProjector(nextSnapshot, this.messages, this.#now);
+    if (!replacedLiveState) {
+      for (const event of this.#projector.seedActive(false)) this.#emit(event);
+      return false;
+    }
+
+    const previousRoot = previousSnapshot.rootTurn;
+    const root = nextSnapshot.rootTurn;
+    const transcriptTurnId = root?.turnId ?? previousRoot?.turnId;
+    if (transcriptTurnId) {
+      this.#onTranscriptReplaced(
+        transcriptTurnId,
+        this.messages.map((message) => structuredClone(message)),
+      );
+    }
+
+    const previousPending = new Map(
+      previousSnapshot.interactions.pending.map((pending) => [pending.interactionId, pending]),
+    );
+    const nextPendingIds = new Set(
+      nextSnapshot.interactions.pending.map((pending) => pending.interactionId),
+    );
+    for (const pending of previousPending.values()) {
+      if (nextPendingIds.has(pending.interactionId)) continue;
+      if (this.#activated) this.#onInteractionResolved(structuredClone(pending));
+      else this.#pendingResolvedInteractions.push(structuredClone(pending));
+    }
+    for (const pending of nextSnapshot.interactions.pending) {
+      if (previousPending.has(pending.interactionId)) continue;
+      const copy = structuredClone(pending);
+      if (this.#activated) this.#onInteractionPending(copy);
+      else this.#pendingOpenedInteractions.push(copy);
+    }
+
+    if (root && !isTerminalTurn(root)) {
+      for (const event of this.#projector.seedActive(false)) this.#emit(event);
+      if (!previousRoot || previousRoot.runId !== root.runId) {
+        const turn = {
+          sessionId: this.sessionId,
+          turnId: root.turnId,
+          runId: root.runId,
+          events: this.eventsForTurn(root.turnId),
+        } satisfies MakaPreparedSessionTurn;
+        if (this.#activated && !this.#startedTurnBarrier) this.#onTurnStarted(turn);
+        else this.#pendingStartedTurns.set(turn.turnId, turn);
+      }
+    } else if (root && isTerminalTurn(root) && !sameTerminalTurn(previousRoot, root)) {
+      for (const event of this.#projector.seedTerminal(root)) this.#emit(event);
+      this.#queue(root.turnId).finish();
+      if (this.#activated) this.#onTurnTerminal(root);
+      else this.#pendingTerminalTurns.push(root);
+    }
+    return true;
+  }
+
+  #canRecover(error: unknown): boolean {
+    if (!isRuntimeHostReconnectingConnection(this.#connection)) return false;
+    if (error instanceof RuntimeHostRequestInterruptedError) {
+      return error.reason === 'connection_lost';
+    }
+    return (
+      error instanceof RuntimeHostSubscriptionError &&
+      (error.reason === 'connection_closed' ||
+        error.reason === 'sequence_gap' ||
+        error.reason === 'projection_revision_invalid' ||
+        error.reason === 'slow_consumer' ||
+        error.reason === 'transcript_expired')
+    );
   }
 
   #accept(frame: SubscriptionFrame): void {
@@ -238,6 +416,12 @@ export class RuntimeHostSessionChannel {
       return;
     }
     if (frame.kind === 'subscription.closed') {
+      if (frame.reason === 'slow_consumer') {
+        throw new RuntimeHostSubscriptionError(
+          'slow_consumer',
+          'Runtime Host Session subscription consumer fell behind',
+        );
+      }
       this.#fail(new Error(`Runtime Host Session subscription closed: ${frame.reason}`));
       return;
     }
@@ -356,4 +540,16 @@ class SessionEventQueue implements AsyncIterable<SessionEvent>, AsyncIterator<Se
     this.#waiting?.reject(error);
     this.#waiting = undefined;
   }
+}
+
+function sameTerminalTurn(
+  previous: SessionContinuitySnapshot['rootTurn'],
+  next: TerminalTurnSnapshot,
+): boolean {
+  return (
+    previous !== null &&
+    isTerminalTurn(previous) &&
+    previous.runId === next.runId &&
+    previous.terminalEventId === next.terminalEventId
+  );
 }

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -47,6 +47,7 @@ import type {
   MakaSessionRewindResult,
   MakaSessionSwitchOptions,
   MakaSessionSwitchResult,
+  MakaTranscriptReplacementReason,
   RewindTarget,
   SessionResumeAvailability,
 } from './session-driver.js';
@@ -87,7 +88,12 @@ export interface RuntimeHostMakaSessionDriver extends MakaSessionDriver {
     listener: (sessionId: string, requestId: string) => void,
   ): () => void;
   subscribeTranscriptReplacements(
-    listener: (sessionId: string, turnId: string, messages: StoredMessage[]) => void,
+    listener: (
+      sessionId: string,
+      turnId: string,
+      messages: StoredMessage[],
+      reason: MakaTranscriptReplacementReason,
+    ) => void,
   ): () => void;
   listShellRunUpdates(sessionId: string): Promise<ShellRunUpdate[]>;
   subscribeShellRunUpdates(listener: (update: ShellRunUpdate) => void): () => void;
@@ -125,7 +131,12 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     (sessionId: string, requestId: string) => void
   >();
   readonly #transcriptListeners = new Set<
-    (sessionId: string, turnId: string, messages: StoredMessage[]) => void
+    (
+      sessionId: string,
+      turnId: string,
+      messages: StoredMessage[],
+      reason: MakaTranscriptReplacementReason,
+    ) => void
   >();
 
   constructor(input: RuntimeHostMakaSessionDriverInput) {
@@ -531,7 +542,12 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   }
 
   subscribeTranscriptReplacements(
-    listener: (sessionId: string, turnId: string, messages: StoredMessage[]) => void,
+    listener: (
+      sessionId: string,
+      turnId: string,
+      messages: StoredMessage[],
+      reason: MakaTranscriptReplacementReason,
+    ) => void,
   ): () => void {
     this.#transcriptListeners.add(listener);
     return () => this.#transcriptListeners.delete(listener);
@@ -829,6 +845,9 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       },
       onInteractionResolved: (pending) => this.#resolveExternalInteraction(pending),
       onTurnTerminal: (turn) => this.#refreshTerminalTranscript(turn),
+      onTranscriptReplaced: (turnId, messages) =>
+        this.#publishTranscriptReplacement(sessionId, turnId, messages, 'reconnect'),
+      onRecovered: () => this.#refreshRuntimeResources(sessionId),
     });
   }
 
@@ -866,12 +885,34 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     void loadCurrentMessages(this.#connection, turn.sessionId)
       .then((messages) => {
         if (this.#sessionId !== turn.sessionId) return;
-        for (const listener of this.#transcriptListeners) {
-          listener(
-            turn.sessionId,
-            turn.turnId,
-            messages.map((message) => structuredClone(message)),
-          );
+        this.#publishTranscriptReplacement(turn.sessionId, turn.turnId, messages, 'terminal');
+      })
+      .catch(() => undefined);
+  }
+
+  #publishTranscriptReplacement(
+    sessionId: string,
+    turnId: string,
+    messages: readonly StoredMessage[],
+    reason: MakaTranscriptReplacementReason,
+  ): void {
+    if (this.#sessionId !== sessionId) return;
+    for (const listener of this.#transcriptListeners) {
+      listener(
+        sessionId,
+        turnId,
+        messages.map((message) => structuredClone(message)),
+        reason,
+      );
+    }
+  }
+
+  #refreshRuntimeResources(sessionId: string): void {
+    void readRuntimeHostResources(this.#connection, sessionId)
+      .then((resources) => {
+        if (this.#sessionId !== sessionId) return;
+        for (const resource of resources) {
+          for (const listener of this.#shellRunListeners) listener(resource);
         }
       })
       .catch(() => undefined);

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -100,7 +100,12 @@ export interface MakaSessionDriver {
     listener: (sessionId: string, requestId: string) => void,
   ): () => void;
   subscribeTranscriptReplacements?(
-    listener: (sessionId: string, turnId: string, messages: StoredMessage[]) => void,
+    listener: (
+      sessionId: string,
+      turnId: string,
+      messages: StoredMessage[],
+      reason: MakaTranscriptReplacementReason,
+    ) => void,
   ): () => void;
   startNewSession(): void;
   stop(): Promise<void>;
@@ -109,6 +114,8 @@ export interface MakaSessionDriver {
   getOrchestrationMode?(): OrchestrationMode;
   getPermissionMode?(): PermissionMode;
 }
+
+export type MakaTranscriptReplacementReason = 'terminal' | 'reconnect';
 
 export type SessionResumeAvailability = { available: true } | { available: false; reason: string };
 

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -10,7 +10,11 @@ import {
   tryAcquireInteractiveRootOwner,
 } from '@maka/storage/root-authority';
 import { readHostRegistration } from '../control/registration.js';
-import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
+import {
+  connectRuntimeHost,
+  RuntimeHostRequestInterruptedError,
+  type RuntimeHostConnection,
+} from '../client/index.js';
 import {
   decodeHostFrame,
   encodeProtocolMessage,
@@ -544,6 +548,55 @@ test('an admitted operation settles without connection or residency leakage afte
   );
 });
 
+test('an admitted command reports an unknown outcome when its connection closes', async () => {
+  const commandEntered = deferred();
+  const releaseCommand = deferred();
+  await withRuntimeHost(
+    async (input) => ({
+      ok: true,
+      result: runningSnapshot(input.sessionId, input.turnId),
+    }),
+    async ({ connectClient }) => {
+      const client = await connectClient();
+      const command = client.startTurn({
+        sessionId: 'session',
+        turnId: 'interrupted-command',
+        content: { text: 'start' },
+      });
+      try {
+        await withTimeout(commandEntered.promise, 1_000, 'command was not admitted');
+        await client.close();
+        await assert.rejects(
+          command,
+          (error: unknown) =>
+            error instanceof RuntimeHostRequestInterruptedError &&
+            error.mode === 'command' &&
+            error.dispatch === 'dispatched' &&
+            error.reason === 'connection_lost' &&
+            !error.retryable,
+        );
+      } finally {
+        releaseCommand.resolve();
+        await Promise.allSettled([command]);
+      }
+    },
+    {
+      'turn.start': async (input) => {
+        commandEntered.resolve();
+        await releaseCommand.promise;
+        return {
+          ok: true,
+          result: {
+            kind: 'started',
+            turn: runningSnapshot(input.sessionId, input.turnId),
+            skillInvocation: { loaded: [], failed: [], receipts: [] },
+          },
+        };
+      },
+    },
+  );
+});
+
 test('a duplicate active request id tears down only the offending connection', async () => {
   const handlerEntered = deferred();
   const releaseHandler = deferred();
@@ -879,6 +932,7 @@ interface RuntimeHostTestFixture {
 async function withRuntimeHost(
   queryTurn: TurnQueryHandler,
   run: (fixture: RuntimeHostTestFixture) => Promise<void>,
+  handlerOverrides: Partial<RuntimeHostComposition['handlers']> = {},
 ): Promise<void> {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-continuity-'));
   const root = join(base, 'root');
@@ -893,7 +947,7 @@ async function withRuntimeHost(
     owner,
     idleGraceMs: 10_000,
     compositionFactory: async () => ({
-      handlers: createHandlers(queryTurn),
+      handlers: { ...createHandlers(queryTurn), ...handlerOverrides },
       beginDrain() {},
       async recover() {},
       async close() {},

--- a/packages/runtime-host/src/__tests__/framed-transport.test.ts
+++ b/packages/runtime-host/src/__tests__/framed-transport.test.ts
@@ -33,6 +33,22 @@ test('drains clean half-open input before reporting typed read EOF', async () =>
   });
 });
 
+test('normalizes a native socket failure as a typed transport interruption', async () => {
+  await withSocketPair(async (transport) => {
+    const failure = Object.assign(new Error('connection reset'), { code: 'ECONNRESET' });
+    const pending = transport.read(1_000);
+    transport.socket.destroy(failure);
+    await assert.rejects(
+      pending,
+      (error: unknown) =>
+        error instanceof RuntimeHostTransportError &&
+        error.code === 'closed' &&
+        error.cause === failure,
+    );
+    await transport.closed;
+  });
+});
+
 test('drains a paused frame burst before reporting a terminal partial frame', async () => {
   await withSocketPair(async (transport, peer) => {
     const frames = Array.from({ length: 96 }, (_, index) => ({ index }));

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -22,6 +22,7 @@ import { promisify } from 'node:util';
 import {
   connectOrSpawnRuntimeHost,
   connectRuntimeHost,
+  RuntimeHostRequestInterruptedError,
   type RuntimeHostConnection,
 } from '../client/index.js';
 import { connectOrSpawnRuntimeHostWithDependencies } from '../client/connect-or-spawn.js';
@@ -910,7 +911,11 @@ describe('non-serving Runtime Host kernel', () => {
         await assert.rejects(
           locallyTimed,
           (error: unknown) =>
-            error instanceof RuntimeHostTransportError && error.code === 'read_timeout',
+            error instanceof RuntimeHostRequestInterruptedError &&
+            error.reason === 'timeout' &&
+            error.retryable &&
+            error.cause instanceof RuntimeHostTransportError &&
+            error.cause.code === 'read_timeout',
         );
         assert.equal(
           (await connected.connection.status()).hostEpoch,
@@ -957,9 +962,12 @@ describe('non-serving Runtime Host kernel', () => {
           assert.rejects(
             pending,
             (error: unknown) =>
-              error instanceof RuntimeHostTransportError &&
-              error.code === 'read_timeout' &&
-              error.message.includes('host.status'),
+              error instanceof RuntimeHostRequestInterruptedError &&
+              error.reason === 'connection_lost' &&
+              error.retryable &&
+              error.cause instanceof RuntimeHostTransportError &&
+              error.cause.code === 'read_timeout' &&
+              error.cause.message.includes('host.status'),
           ),
           5_000,
           'automatic Runtime Host liveness check did not reject pending work',

--- a/packages/runtime-host/src/__tests__/reconnecting-connection.test.ts
+++ b/packages/runtime-host/src/__tests__/reconnecting-connection.test.ts
@@ -1,0 +1,193 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  createRuntimeHostReconnectingConnection,
+  RuntimeHostOperationError,
+  RuntimeHostRequestInterruptedError,
+  type DirectRequestOperationKey,
+  type RuntimeHostConnection,
+} from '../client/index.js';
+import type { OperationInput, OperationKey, OperationOutput } from '../protocol/index.js';
+
+test('a reconnecting Client retries an interrupted query on the replacement connection', async () => {
+  const first = connectionHarness('first', (operation) => {
+    first.disconnect();
+    throw interrupted(operation, 'query', 'dispatched');
+  });
+  const unstable = connectionHarness('unstable', (operation) => {
+    throw interrupted(operation, 'query', 'dispatched');
+  });
+  unstable.disconnect();
+  const replacement = connectionHarness('replacement', (operation, input) => {
+    assert.equal(operation, 'goal.query');
+    const sessionId = (input as OperationInput<'goal.query'>).sessionId;
+    return { sessionId, goal: null } satisfies OperationOutput<'goal.query'>;
+  });
+  const reconnected = deferred();
+  let attempts = 0;
+  const connection = await createRuntimeHostReconnectingConnection({
+    initialConnection: first.connection,
+    connect: async () => {
+      attempts += 1;
+      if (attempts === 1) return unstable.connection;
+      reconnected.resolve();
+      return replacement.connection;
+    },
+  });
+  assert.deepEqual(await connection.request('goal.query', { sessionId: 'session-1' }), {
+    sessionId: 'session-1',
+    goal: null,
+  });
+  await reconnected.promise;
+  assert.deepEqual(first.operations, ['goal.query']);
+  assert.deepEqual(unstable.operations, ['goal.query']);
+  assert.deepEqual(replacement.operations, ['goal.query']);
+  await connection.close();
+});
+
+test('a reconnecting Client never replays an admitted command with an unknown outcome', async () => {
+  const first = connectionHarness('first', (operation) => {
+    first.disconnect();
+    throw interrupted(operation, 'command', 'dispatched');
+  });
+  const replacement = connectionHarness('replacement', () => {
+    throw new Error('command must not reach the replacement connection');
+  });
+  const reconnected = deferred();
+  const connection = await createRuntimeHostReconnectingConnection({
+    initialConnection: first.connection,
+    connect: async () => {
+      reconnected.resolve();
+      return replacement.connection;
+    },
+  });
+
+  await assert.rejects(
+    connection.request('turn.start', {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      content: { text: 'hello' },
+    }),
+    (error: unknown) =>
+      error instanceof RuntimeHostRequestInterruptedError &&
+      error.mode === 'command' &&
+      error.dispatch === 'dispatched' &&
+      error.retryable === false,
+  );
+  await reconnected.promise;
+  assert.deepEqual(first.operations, ['turn.start']);
+  assert.deepEqual(replacement.operations, []);
+  await connection.close();
+});
+
+test('a reconnecting Client waits for a replacement after a draining query rejection', async () => {
+  const first = connectionHarness('first', (operation) => {
+    first.disconnect();
+    throw new RuntimeHostOperationError(operation, 'host_draining', 'Runtime Host is draining');
+  });
+  const replacement = connectionHarness('replacement', (operation, input) => {
+    assert.equal(operation, 'goal.query');
+    const sessionId = (input as OperationInput<'goal.query'>).sessionId;
+    return { sessionId, goal: null } satisfies OperationOutput<'goal.query'>;
+  });
+  const connection = await createRuntimeHostReconnectingConnection({
+    initialConnection: first.connection,
+    connect: async () => replacement.connection,
+  });
+
+  assert.deepEqual(await connection.request('goal.query', { sessionId: 'session-1' }), {
+    sessionId: 'session-1',
+    goal: null,
+  });
+  assert.deepEqual(first.operations, ['goal.query']);
+  assert.deepEqual(replacement.operations, ['goal.query']);
+  await connection.close();
+});
+
+test('a Session observation reopens safely after its first connection starts draining', async () => {
+  const first = connectionHarness(
+    'first',
+    () => undefined,
+    async () => {
+      first.disconnect();
+      throw new RuntimeHostOperationError(
+        'subscription.open',
+        'host_draining',
+        'Runtime Host is draining',
+      );
+    },
+  );
+  const subscription = { subscriptionId: 'replacement-subscription' };
+  const replacement = connectionHarness(
+    'replacement',
+    () => undefined,
+    async () => subscription,
+  );
+  const connection = await createRuntimeHostReconnectingConnection({
+    initialConnection: first.connection,
+    connect: async () => replacement.connection,
+  });
+
+  assert.equal(await connection.openSessionSubscription({ sessionId: 'session-1' }), subscription);
+  assert.equal(first.openedSubscriptions, 1);
+  assert.equal(replacement.openedSubscriptions, 1);
+  await connection.close();
+});
+
+function connectionHarness(
+  id: string,
+  request: (operation: DirectRequestOperationKey, input: unknown) => unknown,
+  openSubscription: () => Promise<unknown> = async () => {
+    throw new Error('subscription is not available in this fixture');
+  },
+) {
+  let resolveClosed!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const operations: DirectRequestOperationKey[] = [];
+  let openedSubscriptions = 0;
+  const connection = {
+    rootId: 'root-id',
+    hostEpoch: `host-${id}`,
+    connectionId: id,
+    selectedProtocol: 0,
+    closed,
+    request: async (operation: DirectRequestOperationKey, input: unknown) => {
+      operations.push(operation);
+      return request(operation, input);
+    },
+    openSessionSubscription: async () => {
+      openedSubscriptions += 1;
+      return openSubscription();
+    },
+    subscribeConfigurationChanges: () => () => {},
+    subscribeProjectCatalogChanges: () => () => {},
+    subscribeSessionCatalogChanges: () => () => {},
+    close: async () => resolveClosed(),
+  } as unknown as RuntimeHostConnection;
+  return {
+    connection,
+    operations,
+    disconnect: resolveClosed,
+    get openedSubscriptions() {
+      return openedSubscriptions;
+    },
+  };
+}
+
+function interrupted(
+  operation: OperationKey,
+  mode: 'query' | 'command' | 'control',
+  dispatch: 'not_dispatched' | 'dispatched',
+): RuntimeHostRequestInterruptedError {
+  return new RuntimeHostRequestInterruptedError(operation, mode, dispatch, 'connection_lost');
+}
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}

--- a/packages/runtime-host/src/__tests__/wait-for-ready.test.ts
+++ b/packages/runtime-host/src/__tests__/wait-for-ready.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { waitForRuntimeHostReady } from '../client/index.js';
+
+test('stops a pending ready probe when its reconnect attempt is cancelled', async () => {
+  const started = deferred();
+  const never = new Promise<never>(() => undefined);
+  const controller = new AbortController();
+  const waiting = waitForRuntimeHostReady(
+    {
+      status: async () => {
+        started.resolve();
+        return never;
+      },
+    },
+    45_000,
+    controller.signal,
+  );
+  await started.promise;
+  const reason = new Error('closed');
+  controller.abort(reason);
+  await assert.rejects(waiting, (error: unknown) => error === reason);
+});
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}

--- a/packages/runtime-host/src/adapter/session-projector.ts
+++ b/packages/runtime-host/src/adapter/session-projector.ts
@@ -45,7 +45,7 @@ export class RuntimeHostSessionProjector {
     this.#now = now;
     this.#transcriptIds = new Set(transcript.map((message) => message.id));
     const root = snapshot.rootTurn;
-    if (!root || isRuntimeHostTerminalTurn(root)) return;
+    if (!root) return;
     for (const message of transcript) {
       if (message.type !== 'assistant' || message.turnId !== root.turnId) continue;
       if (message.thinking?.text) {
@@ -110,6 +110,71 @@ export class RuntimeHostSessionProjector {
 
   seedTerminal(turn: RuntimeHostTerminalTurn): SessionEvent[] {
     return this.#terminalEvents(turn);
+  }
+
+  seedStoredTerminal(turnId: string, transcript: readonly StoredMessage[]): SessionEvent[] {
+    const terminal = [...transcript]
+      .reverse()
+      .find(
+        (message): message is Extract<StoredMessage, { type: 'turn_state' }> =>
+          message.type === 'turn_state' &&
+          message.turnId === turnId &&
+          message.status !== 'running',
+      );
+    if (!terminal) return [];
+    const events: SessionEvent[] = [];
+    for (const message of transcript) {
+      if (message.type !== 'assistant' || message.turnId !== turnId) continue;
+      if (message.thinking?.text) {
+        events.push({
+          type: 'thinking_complete',
+          id: `${terminal.id}:thinking:${message.id}`,
+          turnId,
+          messageId: message.id,
+          ts: terminal.ts,
+          text: message.thinking.text,
+        });
+      }
+      if (message.text) {
+        events.push({
+          type: 'text_complete',
+          id: `${terminal.id}:text:${message.id}`,
+          turnId,
+          messageId: message.id,
+          ts: terminal.ts,
+          text: message.text,
+        });
+      }
+    }
+    if (terminal.status === 'completed') {
+      events.push({
+        type: 'complete',
+        id: terminal.id,
+        turnId,
+        ts: terminal.ts,
+        stopReason: 'end_turn',
+      });
+    } else if (terminal.status === 'failed') {
+      const reason = terminal.errorClass ?? 'runtime_error';
+      events.push({
+        type: 'error',
+        id: terminal.id,
+        turnId,
+        ts: terminal.ts,
+        recoverable: false,
+        reason,
+        message: `Turn failed: ${reason}`,
+      });
+    } else {
+      events.push({
+        type: 'abort',
+        id: terminal.id,
+        turnId,
+        ts: terminal.ts,
+        reason: abortReason(terminal.abortSource ?? ''),
+      });
+    }
+    return events;
   }
 
   accept(frame: SubscriptionFrame): RuntimeHostProjectionUpdate {

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -33,6 +33,7 @@ export interface ConnectOrSpawnRuntimeHostInput {
   handshakeTimeoutMs?: number;
   candidateEntrypoint?: string | URL;
   legacyConfigurationRoot?: string;
+  signal?: AbortSignal;
 }
 
 interface ConnectOrSpawnRuntimeHostDependencies {
@@ -67,6 +68,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
   validateProtocolRange(input.protocol);
   requireOptionalTimeout(input.connectTimeoutMs, 'connectTimeoutMs', 1);
   requireOptionalTimeout(input.handshakeTimeoutMs, 'handshakeTimeoutMs', 1);
+  input.signal?.throwIfAborted();
   const clientInstanceId = requireClientInstanceId(input.clientInstanceId ?? randomUUID());
   const capability = await resolveStorageRoot({ path: input.rootPath, kind: 'interactive' });
   const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
@@ -78,6 +80,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
   let sawUnresponsiveEndpoint = false;
 
   while (performance.now() < deadline) {
+    input.signal?.throwIfAborted();
     const result = await connectResolvedRuntimeHost({
       capability,
       controlDirectory,
@@ -115,7 +118,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
             ? {}
             : { legacyConfigurationRoot: input.legacyConfigurationRoot }),
         });
-        await settleBeforeDeadline(launch.spawned, deadline);
+        await settleBeforeDeadline(launch.spawned, deadline, input.signal);
       } catch {
         // A failed Candidate attempt is ordinary election evidence; discovery continues.
       }
@@ -126,7 +129,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
     if (remaining <= 0) break;
     const random = dependencies.random();
     const jitter = 0.75 + Math.min(1, Math.max(0, Number.isFinite(random) ? random : 0.5)) * 0.5;
-    await sleep(Math.min(remaining, Math.max(1, Math.round(backoffMs * jitter))));
+    await sleep(Math.min(remaining, Math.max(1, Math.round(backoffMs * jitter))), input.signal);
     backoffMs = Math.min(DEFAULT_BACKOFF_MAX_MS, backoffMs * 2);
   }
   return {
@@ -145,27 +148,43 @@ function shouldLaunchCandidate(result: ConnectRuntimeHostResult): boolean {
   return result.kind === 'unavailable' || result.kind === 'draining';
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) return Promise.reject(signal.reason);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
-function settleBeforeDeadline<T>(operation: Promise<T>, deadline: number): Promise<T> {
+function settleBeforeDeadline<T>(
+  operation: Promise<T>,
+  deadline: number,
+  signal?: AbortSignal,
+): Promise<T> {
   const remaining = deadline - performance.now();
   if (remaining <= 0) return Promise.reject(new Error('Runtime Host election deadline elapsed'));
+  if (signal?.aborted) return Promise.reject(signal.reason);
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(
-      () => reject(new Error('Runtime Host election deadline elapsed')),
-      remaining,
-    );
+    const settle = (operation: () => void) => {
+      clearTimeout(timer);
+      signal?.removeEventListener('abort', onAbort);
+      operation();
+    };
+    const timer = setTimeout(() => {
+      settle(() => reject(new Error('Runtime Host election deadline elapsed')));
+    }, remaining);
+    const onAbort = () => settle(() => reject(signal?.reason));
+    signal?.addEventListener('abort', onAbort, { once: true });
     operation.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (error: unknown) => {
-        clearTimeout(timer);
-        reject(error);
-      },
+      (value) => settle(() => resolve(value)),
+      (error: unknown) => settle(() => reject(error)),
     );
   });
 }

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -75,7 +75,7 @@ import {
 import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
 import type { RuntimeHostMessageTransport } from '../transport/message-transport.js';
 import { WebSocketTransport } from '../transport/websocket-transport.js';
-import type { OperationSpec } from '../protocol/operation-spec.js';
+import type { OperationMode, OperationSpec } from '../protocol/operation-spec.js';
 import {
   ClientSessionSubscription,
   RuntimeHostSubscriptionError,
@@ -265,6 +265,33 @@ export class RuntimeHostOperationError extends Error {
   }
 }
 
+export type RuntimeHostRequestDispatch = 'not_dispatched' | 'dispatched';
+export type RuntimeHostRequestInterruptionReason = 'connection_lost' | 'timeout';
+
+export class RuntimeHostRequestInterruptedError extends Error {
+  readonly retryable: boolean;
+
+  constructor(
+    readonly operation: OperationKey,
+    readonly mode: OperationMode,
+    readonly dispatch: RuntimeHostRequestDispatch,
+    readonly reason: RuntimeHostRequestInterruptionReason,
+    options: ErrorOptions = {},
+  ) {
+    const outcome =
+      mode === 'query'
+        ? reason === 'connection_lost'
+          ? 'the query may be retried on another connection'
+          : 'the query timed out and may be retried'
+        : dispatch === 'not_dispatched'
+          ? 'the operation was not dispatched'
+          : 'the operation outcome is unknown; do not retry it automatically';
+    super(`Runtime Host ${operation} was interrupted: ${outcome}`, options);
+    this.name = 'RuntimeHostRequestInterruptedError';
+    this.retryable = mode === 'query';
+  }
+}
+
 interface PendingRequest {
   operation: OperationKey;
   accept(value: unknown): unknown;
@@ -380,7 +407,6 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   ): Promise<Result> {
     const boundedTimeoutMs =
       timeoutMs === undefined ? undefined : requireTimeout(timeoutMs, 'timeoutMs');
-    if (this.#terminalError) return Promise.reject(this.#terminalError);
     const spec = HOST_OPERATION_SPECS[operation] as OperationSpec<
       OperationInput<K>,
       OperationOutput<K>,
@@ -391,6 +417,18 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       canonicalInput = spec.decodeInput(input);
     } catch (error) {
       return Promise.reject(asError(error));
+    }
+    if (this.#terminalError) {
+      return Promise.reject(
+        this.#terminalError instanceof RuntimeHostTransportError
+          ? interruptedRequestError(
+              operation,
+              'not_dispatched',
+              'connection_lost',
+              this.#terminalError,
+            )
+          : this.#terminalError,
+      );
     }
     const requestId = randomUUID();
     const isDomainRequest = operation !== 'host.status';
@@ -737,7 +775,9 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     if (pending.domainState === 'queued') {
       const index = this.#queuedDomainFrames.findIndex((queued) => queued.requestId === requestId);
       if (index !== -1) this.#queuedDomainFrames.splice(index, 1);
-      pending.reject(error);
+      pending.reject(
+        interruptedRequestError(pending.operation, 'not_dispatched', 'timeout', error),
+      );
       this.#scheduleLivenessCheck();
       return;
     }
@@ -745,7 +785,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       operation: pending.operation,
       ...(pending.domainState === 'in_flight' ? { domainState: pending.domainState } : {}),
     });
-    pending.reject(error);
+    pending.reject(interruptedRequestError(pending.operation, 'dispatched', 'timeout', error));
     this.#scheduleLivenessCheck();
   }
 
@@ -886,7 +926,16 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     this.#inFlightDomainRequests = 0;
     for (const pending of this.#pendingRequests.values()) {
       if (pending.timer) clearTimeout(pending.timer);
-      pending.reject(error);
+      pending.reject(
+        error instanceof RuntimeHostTransportError
+          ? interruptedRequestError(
+              pending.operation,
+              pending.domainState === 'queued' ? 'not_dispatched' : 'dispatched',
+              'connection_lost',
+              error,
+            )
+          : error,
+      );
     }
     this.#pendingRequests.clear();
     this.#retiredRequests.clear();
@@ -1384,5 +1433,20 @@ function requestTimeoutError(operation: OperationKey): RuntimeHostTransportError
   return new RuntimeHostTransportError(
     'read_timeout',
     `Timed out waiting for Runtime Host ${operation} response`,
+  );
+}
+
+function interruptedRequestError(
+  operation: OperationKey,
+  dispatch: RuntimeHostRequestDispatch,
+  reason: RuntimeHostRequestInterruptionReason,
+  cause: Error,
+): RuntimeHostRequestInterruptedError {
+  return new RuntimeHostRequestInterruptedError(
+    operation,
+    HOST_OPERATION_SPECS[operation].mode,
+    dispatch,
+    reason,
+    { cause },
   );
 }

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -31,6 +31,7 @@ export {
   type RuntimeHostSessionSubscription,
   type RuntimeHostSubscriptionFailureReason,
 } from './session-subscription.js';
+export { waitForRuntimeHostReady } from './wait-for-ready.js';
 export {
   RuntimeHostCatalogReadError,
   readRuntimeHostConnectionCatalog,

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -3,14 +3,29 @@ export {
   connectExistingRuntimeHost,
   connectRemoteRuntimeHost,
   RuntimeHostOperationError,
+  RuntimeHostRequestInterruptedError,
   type ConnectRuntimeHostInput,
   type ConnectRuntimeHostResult,
   type ConnectRemoteRuntimeHostInput,
   type ConnectRemoteRuntimeHostResult,
   type RuntimeHostConnection,
+  type RuntimeHostRequestDispatch,
+  type RuntimeHostRequestInterruptionReason,
   type RuntimeHostUnavailableReason,
   type DirectRequestOperationKey,
 } from './connection.js';
+export {
+  createRuntimeHostReconnectingConnection,
+  isRuntimeHostReconnectingConnection,
+  type RuntimeHostReconnectingConnection,
+} from './reconnecting-connection.js';
+export {
+  RuntimeHostPermanentReconnectError,
+  startRuntimeHostReconnectLifecycle,
+  type RuntimeHostReconnectBackoff,
+  type RuntimeHostReconnectLifecycle,
+  type RuntimeHostReconnectResource,
+} from './reconnect-lifecycle.js';
 export {
   RuntimeHostSubscriptionError,
   type RuntimeHostSessionSubscription,

--- a/packages/runtime-host/src/client/reconnect-lifecycle.ts
+++ b/packages/runtime-host/src/client/reconnect-lifecycle.ts
@@ -1,0 +1,306 @@
+const DEFAULT_BACKOFF_MIN_MS = 100;
+const DEFAULT_BACKOFF_MAX_MS = 5_000;
+const DEFAULT_STABLE_CONNECTION_MS = 10_000;
+
+export interface RuntimeHostReconnectResource {
+  readonly closed: Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface RuntimeHostReconnectBackoff {
+  readonly minMs?: number;
+  readonly maxMs?: number;
+  readonly stableConnectionMs?: number;
+  readonly random?: () => number;
+  readonly now?: () => number;
+  readonly wait?: (delayMs: number, signal: AbortSignal) => Promise<void>;
+}
+
+export interface RuntimeHostReconnectLifecycle<T extends RuntimeHostReconnectResource> {
+  readonly closed: Promise<void>;
+  readonly current: T | undefined;
+  waitForCurrent(previous?: T, signal?: AbortSignal): Promise<T>;
+  subscribe(listener: (current: T | undefined) => void): () => void;
+  close(): Promise<void>;
+}
+
+export class RuntimeHostPermanentReconnectError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'RuntimeHostPermanentReconnectError';
+  }
+}
+
+export async function startRuntimeHostReconnectLifecycle<
+  T extends RuntimeHostReconnectResource,
+>(input: {
+  readonly initial?: T;
+  readonly connect: (signal: AbortSignal) => Promise<T>;
+  readonly onReconnectError?: (error: Error) => void;
+  readonly onFatalError?: (error: Error) => void;
+  readonly backoff?: RuntimeHostReconnectBackoff;
+}): Promise<RuntimeHostReconnectLifecycle<T>> {
+  const lifecycle = new RuntimeHostReconnectLifecycleImpl(input);
+  await lifecycle.start();
+  return lifecycle;
+}
+
+interface CurrentWaiter<T> {
+  readonly previous: T | undefined;
+  readonly dispose: () => void;
+  resolve(value: T): void;
+  reject(error: Error): void;
+}
+
+class RuntimeHostReconnectLifecycleImpl<T extends RuntimeHostReconnectResource>
+  implements RuntimeHostReconnectLifecycle<T>
+{
+  readonly closed: Promise<void>;
+  readonly #initial: T | undefined;
+  readonly #connect: (signal: AbortSignal) => Promise<T>;
+  readonly #onReconnectError: ((error: Error) => void) | undefined;
+  readonly #onFatalError: ((error: Error) => void) | undefined;
+  readonly #minMs: number;
+  readonly #maxMs: number;
+  readonly #stableConnectionMs: number;
+  readonly #random: () => number;
+  readonly #now: () => number;
+  readonly #wait: (delayMs: number, signal: AbortSignal) => Promise<void>;
+  readonly #abort = new AbortController();
+  readonly #listeners = new Set<(current: T | undefined) => void>();
+  readonly #waiters = new Set<CurrentWaiter<T>>();
+  #current: T | undefined;
+  #installedAt = 0;
+  #failureCount = 0;
+  #closed = false;
+  #terminalError: Error | undefined;
+  #reconnectTask: Promise<void> | undefined;
+  #closeTask: Promise<void> | undefined;
+  #resolveClosed!: () => void;
+
+  constructor(input: {
+    readonly initial?: T;
+    readonly connect: (signal: AbortSignal) => Promise<T>;
+    readonly onReconnectError?: (error: Error) => void;
+    readonly onFatalError?: (error: Error) => void;
+    readonly backoff?: RuntimeHostReconnectBackoff;
+  }) {
+    this.#connect = input.connect;
+    this.#initial = input.initial;
+    this.#onReconnectError = input.onReconnectError;
+    this.#onFatalError = input.onFatalError;
+    this.#minMs = requireDelay(input.backoff?.minMs ?? DEFAULT_BACKOFF_MIN_MS, 'minMs');
+    this.#maxMs = requireDelay(input.backoff?.maxMs ?? DEFAULT_BACKOFF_MAX_MS, 'maxMs');
+    if (this.#maxMs < this.#minMs)
+      throw new RangeError('maxMs must be greater than or equal to minMs');
+    this.#stableConnectionMs = requireDelay(
+      input.backoff?.stableConnectionMs ?? DEFAULT_STABLE_CONNECTION_MS,
+      'stableConnectionMs',
+    );
+    this.#random = input.backoff?.random ?? Math.random;
+    this.#now = input.backoff?.now ?? Date.now;
+    this.#wait = input.backoff?.wait ?? waitForDelay;
+    this.closed = new Promise((resolve) => {
+      this.#resolveClosed = resolve;
+    });
+  }
+
+  get current(): T | undefined {
+    return this.#current;
+  }
+
+  async start(): Promise<void> {
+    try {
+      this.#install(this.#initial ?? (await this.#connect(this.#abort.signal)));
+    } catch (error) {
+      this.#failPermanently(asError(error));
+      throw error;
+    }
+  }
+
+  waitForCurrent(previous?: T, signal?: AbortSignal): Promise<T> {
+    if (this.#current && this.#current !== previous) return Promise.resolve(this.#current);
+    if (this.#terminalError) return Promise.reject(this.#terminalError);
+    if (this.#closed)
+      return Promise.reject(new Error('Runtime Host reconnect lifecycle is closed'));
+    if (signal?.aborted) return Promise.reject(signal.reason);
+    return new Promise((resolve, reject) => {
+      let waiter: CurrentWaiter<T>;
+      const onAbort = () => {
+        this.#waiters.delete(waiter);
+        reject(signal?.reason);
+      };
+      waiter = {
+        previous,
+        resolve,
+        reject,
+        dispose: () => signal?.removeEventListener('abort', onAbort),
+      };
+      this.#waiters.add(waiter);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  subscribe(listener: (current: T | undefined) => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  close(): Promise<void> {
+    this.#closeTask ??= this.#close();
+    return this.#closeTask;
+  }
+
+  async #close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#abort.abort();
+    const error = new Error('Runtime Host reconnect lifecycle is closed');
+    this.#rejectWaiters(error);
+    const current = this.#current;
+    this.#setCurrent(undefined);
+    await current?.close().catch(() => undefined);
+    await this.#reconnectTask?.catch(() => undefined);
+    this.#resolveClosed();
+  }
+
+  #install(resource: T): void {
+    if (this.#closed || this.#terminalError) {
+      void resource.close().catch(() => undefined);
+      return;
+    }
+    this.#installedAt = this.#now();
+    this.#setCurrent(resource);
+    void resource.closed.then(
+      () => this.#disconnected(resource),
+      () => this.#disconnected(resource),
+    );
+  }
+
+  #disconnected(resource: T): void {
+    if (this.#closed || this.#terminalError || this.#current !== resource) return;
+    if (this.#now() - this.#installedAt >= this.#stableConnectionMs) this.#failureCount = 0;
+    this.#failureCount += 1;
+    this.#setCurrent(undefined);
+    this.#scheduleReconnect();
+  }
+
+  #scheduleReconnect(): void {
+    if (this.#closed || this.#terminalError || this.#current || this.#reconnectTask) return;
+    const task = this.#reconnect();
+    this.#reconnectTask = task;
+    void task.finally(() => {
+      if (this.#reconnectTask === task) this.#reconnectTask = undefined;
+      this.#scheduleReconnect();
+    });
+  }
+
+  async #reconnect(): Promise<void> {
+    while (!this.#closed && !this.#terminalError && !this.#current) {
+      const delayMs = reconnectDelayMs(
+        this.#failureCount - 1,
+        this.#minMs,
+        this.#maxMs,
+        this.#random,
+      );
+      try {
+        if (delayMs > 0) await this.#wait(delayMs, this.#abort.signal);
+        const resource = await this.#connect(this.#abort.signal);
+        this.#install(resource);
+      } catch (error) {
+        if (this.#closed) return;
+        const failure = asError(error);
+        if (failure instanceof RuntimeHostPermanentReconnectError) {
+          this.#failPermanently(failure);
+          return;
+        }
+        this.#failureCount += 1;
+        notifyError(this.#onReconnectError, failure);
+      }
+    }
+  }
+
+  #setCurrent(current: T | undefined): void {
+    if (this.#current === current) return;
+    this.#current = current;
+    for (const listener of this.#listeners) {
+      try {
+        listener(current);
+      } catch {
+        // A lifecycle observer cannot invalidate the connection it observes.
+      }
+    }
+    if (current) {
+      for (const waiter of [...this.#waiters]) {
+        if (waiter.previous === current) continue;
+        this.#waiters.delete(waiter);
+        waiter.dispose();
+        waiter.resolve(current);
+      }
+    }
+  }
+
+  #failPermanently(error: Error): void {
+    if (this.#terminalError) return;
+    this.#terminalError = error;
+    this.#abort.abort();
+    this.#rejectWaiters(error);
+    notifyError(this.#onFatalError, error);
+    this.#resolveClosed();
+  }
+
+  #rejectWaiters(error: Error): void {
+    for (const waiter of this.#waiters) {
+      waiter.dispose();
+      waiter.reject(error);
+    }
+    this.#waiters.clear();
+  }
+}
+
+function notifyError(listener: ((error: Error) => void) | undefined, error: Error): void {
+  try {
+    listener?.(error);
+  } catch {
+    // Diagnostics cannot invalidate connection recovery.
+  }
+}
+
+function reconnectDelayMs(
+  attempt: number,
+  minMs: number,
+  maxMs: number,
+  random: () => number,
+): number {
+  if (attempt <= 0 || minMs === 0) return 0;
+  const exponential = Math.min(maxMs, minMs * 2 ** Math.min(attempt - 1, 30));
+  const sample = random();
+  const bounded = Number.isFinite(sample) ? Math.min(1, Math.max(0, sample)) : 0.5;
+  return Math.min(maxMs, Math.max(1, Math.round(exponential * (0.8 + bounded * 0.4))));
+}
+
+function waitForDelay(delayMs: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal.reason);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+function requireDelay(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 120_000) {
+    throw new RangeError(`${label} must be an integer between 0 and 120000`);
+  }
+  return value;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/runtime-host/src/client/reconnect-lifecycle.ts
+++ b/packages/runtime-host/src/client/reconnect-lifecycle.ts
@@ -189,10 +189,11 @@ class RuntimeHostReconnectLifecycleImpl<T extends RuntimeHostReconnectResource>
     if (this.#closed || this.#terminalError || this.#current || this.#reconnectTask) return;
     const task = this.#reconnect();
     this.#reconnectTask = task;
-    void task.finally(() => {
+    const finalize = () => {
       if (this.#reconnectTask === task) this.#reconnectTask = undefined;
       this.#scheduleReconnect();
-    });
+    };
+    void task.then(finalize, finalize);
   }
 
   async #reconnect(): Promise<void> {

--- a/packages/runtime-host/src/client/reconnecting-connection.ts
+++ b/packages/runtime-host/src/client/reconnecting-connection.ts
@@ -1,0 +1,433 @@
+import {
+  HOST_OPERATION_SPECS,
+  type ClientCapabilityReplaceResult,
+  type ClientCapabilityUnregisterResult,
+  type ContextCompactInput,
+  type ContextCompactResult,
+  type ContextDiagnosticsQueryInput,
+  type ContextDiagnosticsResult,
+  type DeepResearchQueryInput,
+  type DeepResearchQueryResult,
+  type DailyReviewMutateInput,
+  type DailyReviewMutateResult,
+  type DailyReviewQueryInput,
+  type DailyReviewQueryResult,
+  type HostDiagnosticsResult,
+  type HostStatusResult,
+  type OperationInput,
+  type OperationKey,
+  type OperationOutput,
+  type PlanControlInput,
+  type PlanControlResult,
+  type PlanQueryInput,
+  type PlanQueryResult,
+  type PlanTurnStartInput,
+  type PlanTurnStartResult,
+  type SessionCatalogChangedFrame,
+  type SessionCwdRelocateInput,
+  type SessionRecapGenerateInput,
+  type SessionRecapGenerateResult,
+  type SessionUpdateResult,
+  type SubscriptionOpenInput,
+  type TurnQueryInput,
+  type TurnRegenerateInput,
+  type TurnResumePlan,
+  type TurnResumeQueryInput,
+  type TurnResumeStartInput,
+  type TurnResumeStartResult,
+  type TurnSnapshot,
+  type TurnStartInput,
+  type TurnStartResult,
+  type TurnStopInput,
+} from '../protocol/index.js';
+import type { ClientCapabilityProvider } from './client-capability.js';
+import {
+  RuntimeHostOperationError,
+  RuntimeHostRequestInterruptedError,
+  type DirectRequestOperationKey,
+  type RuntimeHostConnection,
+} from './connection.js';
+import {
+  RuntimeHostPermanentReconnectError,
+  startRuntimeHostReconnectLifecycle,
+  type RuntimeHostReconnectBackoff,
+  type RuntimeHostReconnectLifecycle,
+} from './reconnect-lifecycle.js';
+import type { RuntimeHostSessionSubscription } from './session-subscription.js';
+
+export interface RuntimeHostReconnectingConnection extends RuntimeHostConnection {
+  readonly reconnecting: true;
+}
+
+export async function createRuntimeHostReconnectingConnection(input: {
+  readonly initialConnection: RuntimeHostConnection;
+  readonly connect: (signal: AbortSignal) => Promise<RuntimeHostConnection>;
+  readonly backoff?: RuntimeHostReconnectBackoff;
+  readonly onReconnectError?: (error: Error) => void;
+  readonly onFatalError?: (error: Error) => void;
+}): Promise<RuntimeHostReconnectingConnection> {
+  const expectedRootId = input.initialConnection.rootId;
+  const expectedProtocol = input.initialConnection.selectedProtocol;
+  const connect = async (signal: AbortSignal): Promise<RuntimeHostConnection> => {
+    const connection = await input.connect(signal);
+    if (connection.rootId !== expectedRootId) {
+      await connection.close().catch(() => undefined);
+      throw new RuntimeHostPermanentReconnectError(
+        `Runtime Host root changed from ${expectedRootId} to ${connection.rootId}`,
+      );
+    }
+    if (connection.selectedProtocol !== expectedProtocol) {
+      await connection.close().catch(() => undefined);
+      throw new RuntimeHostPermanentReconnectError(
+        `Runtime Host protocol changed from ${expectedProtocol} to ${connection.selectedProtocol}`,
+      );
+    }
+    return connection;
+  };
+  const lifecycle = await startRuntimeHostReconnectLifecycle({
+    initial: input.initialConnection,
+    connect,
+    ...(input.backoff ? { backoff: input.backoff } : {}),
+    ...(input.onReconnectError ? { onReconnectError: input.onReconnectError } : {}),
+    ...(input.onFatalError ? { onFatalError: input.onFatalError } : {}),
+  });
+  return new RuntimeHostReconnectingConnectionImpl(lifecycle);
+}
+
+export function isRuntimeHostReconnectingConnection(
+  connection: unknown,
+): connection is RuntimeHostReconnectingConnection {
+  return (connection as Partial<RuntimeHostReconnectingConnection>).reconnecting === true;
+}
+
+class RuntimeHostReconnectingConnectionImpl implements RuntimeHostReconnectingConnection {
+  readonly reconnecting = true as const;
+  readonly closed: Promise<void>;
+  readonly #configurationListeners = new Set<(revision: number) => void>();
+  readonly #projectListeners = new Set<(revision: number) => void>();
+  readonly #sessionListeners = new Set<(frame: SessionCatalogChangedFrame) => void>();
+  readonly #lifecycle: RuntimeHostReconnectLifecycle<RuntimeHostConnection>;
+  #lastConnection: RuntimeHostConnection;
+  #listenerDisposers: (() => void)[] = [];
+
+  constructor(lifecycle: RuntimeHostReconnectLifecycle<RuntimeHostConnection>) {
+    const initial = lifecycle.current;
+    if (!initial) throw new Error('Runtime Host reconnect lifecycle has no initial connection');
+    this.#lifecycle = lifecycle;
+    this.#lastConnection = initial;
+    this.closed = lifecycle.closed;
+    this.#bindListeners(initial);
+    lifecycle.subscribe((connection) => {
+      this.#unbindListeners();
+      if (!connection) return;
+      this.#lastConnection = connection;
+      this.#bindListeners(connection);
+    });
+  }
+
+  get rootId(): string {
+    return this.#lastConnection.rootId;
+  }
+
+  get hostEpoch(): string {
+    return this.#lastConnection.hostEpoch;
+  }
+
+  get connectionId(): string {
+    return this.#lastConnection.connectionId;
+  }
+
+  get selectedProtocol(): number {
+    return this.#lastConnection.selectedProtocol;
+  }
+
+  request<K extends DirectRequestOperationKey>(
+    operation: K,
+    input: OperationInput<K>,
+    timeoutMs?: number,
+  ): Promise<OperationOutput<K>> {
+    return this.#request(operation, input, timeoutMs);
+  }
+
+  status(timeoutMs?: number): Promise<HostStatusResult> {
+    return this.#request('host.status', {}, timeoutMs);
+  }
+
+  queryHostDiagnostics(timeoutMs?: number): Promise<HostDiagnosticsResult> {
+    return this.#request('host.diagnostics.query', {}, timeoutMs);
+  }
+
+  startTurn(input: TurnStartInput, timeoutMs?: number): Promise<TurnStartResult> {
+    return this.#request('turn.start', input, timeoutMs);
+  }
+
+  queryTurn(input: TurnQueryInput, timeoutMs?: number): Promise<TurnSnapshot> {
+    return this.#request('turn.query', input, timeoutMs);
+  }
+
+  stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot> {
+    return this.#request('turn.stop', input, timeoutMs);
+  }
+
+  regenerateTurn(input: TurnRegenerateInput, timeoutMs?: number): Promise<TurnSnapshot> {
+    return this.#request('turn.regenerate', input, timeoutMs);
+  }
+
+  queryContextDiagnostics(
+    input: ContextDiagnosticsQueryInput,
+    timeoutMs?: number,
+  ): Promise<ContextDiagnosticsResult> {
+    return this.#request('context.diagnostics.query', input, timeoutMs);
+  }
+
+  compactContext(input: ContextCompactInput, timeoutMs?: number): Promise<ContextCompactResult> {
+    return this.#request('context.compact', input, timeoutMs);
+  }
+
+  relocateSessionCwd(
+    input: SessionCwdRelocateInput,
+    timeoutMs?: number,
+  ): Promise<SessionUpdateResult> {
+    return this.#request('session.cwd.relocate', input, timeoutMs);
+  }
+
+  generateSessionRecap(
+    input: SessionRecapGenerateInput,
+    timeoutMs?: number,
+  ): Promise<SessionRecapGenerateResult> {
+    return this.#request('session.recap.generate', input, timeoutMs);
+  }
+
+  queryPlan(input: PlanQueryInput, timeoutMs?: number): Promise<PlanQueryResult> {
+    return this.#request('plan.query', input, timeoutMs);
+  }
+
+  controlPlan(input: PlanControlInput, timeoutMs?: number): Promise<PlanControlResult> {
+    return this.#request('plan.control', input, timeoutMs);
+  }
+
+  startPlanTurn(input: PlanTurnStartInput, timeoutMs?: number): Promise<PlanTurnStartResult> {
+    return this.#request('plan.turn.start', input, timeoutMs);
+  }
+
+  queryDeepResearch(
+    input: DeepResearchQueryInput,
+    timeoutMs?: number,
+  ): Promise<DeepResearchQueryResult> {
+    return this.#request('deep-research.query', input, timeoutMs);
+  }
+
+  queryDailyReview(
+    input: DailyReviewQueryInput,
+    timeoutMs?: number,
+  ): Promise<DailyReviewQueryResult> {
+    return this.#request('daily-review.query', input, timeoutMs);
+  }
+
+  mutateDailyReview(
+    input: DailyReviewMutateInput,
+    timeoutMs?: number,
+  ): Promise<DailyReviewMutateResult> {
+    return this.#request('daily-review.mutate', input, timeoutMs);
+  }
+
+  queryTurnResume(input: TurnResumeQueryInput, timeoutMs?: number): Promise<TurnResumePlan> {
+    return this.#request('turn.resume.query', input, timeoutMs);
+  }
+
+  startTurnResume(input: TurnResumeStartInput, timeoutMs?: number): Promise<TurnResumeStartResult> {
+    return this.#request('turn.resume.start', input, timeoutMs);
+  }
+
+  async openSessionSubscription(
+    input: SubscriptionOpenInput,
+    timeoutMs?: number,
+  ): Promise<RuntimeHostSessionSubscription> {
+    const deadline = requestDeadline(timeoutMs);
+    let previous: RuntimeHostConnection | undefined;
+    while (true) {
+      const connection = await this.#waitForConnection('subscription.open', previous, deadline);
+      const remaining = deadline === undefined ? undefined : Math.max(1, deadline - Date.now());
+      try {
+        return await connection.openSessionSubscription(input, remaining);
+      } catch (error) {
+        if (!isRetryableSubscriptionInterruption(error)) throw error;
+        previous = connection;
+      }
+    }
+  }
+
+  async replaceClientCapabilities(
+    provider: ClientCapabilityProvider,
+    timeoutMs?: number,
+  ): Promise<ClientCapabilityReplaceResult> {
+    const connection = this.#requireCurrent('client.capability.replace');
+    return connection.replaceClientCapabilities(provider, timeoutMs);
+  }
+
+  async unregisterClientCapabilities(
+    timeoutMs?: number,
+  ): Promise<ClientCapabilityUnregisterResult> {
+    const connection = this.#requireCurrent('client.capability.unregister');
+    return connection.unregisterClientCapabilities(timeoutMs);
+  }
+
+  subscribeConfigurationChanges(listener: (revision: number) => void): () => void {
+    this.#configurationListeners.add(listener);
+    return () => this.#configurationListeners.delete(listener);
+  }
+
+  subscribeProjectCatalogChanges(listener: (revision: number) => void): () => void {
+    this.#projectListeners.add(listener);
+    return () => this.#projectListeners.delete(listener);
+  }
+
+  subscribeSessionCatalogChanges(
+    listener: (frame: SessionCatalogChangedFrame) => void,
+  ): () => void {
+    this.#sessionListeners.add(listener);
+    return () => this.#sessionListeners.delete(listener);
+  }
+
+  close(): Promise<void> {
+    this.#unbindListeners();
+    return this.#lifecycle.close();
+  }
+
+  async #request<K extends OperationKey>(
+    operation: K,
+    input: OperationInput<K>,
+    timeoutMs?: number,
+  ): Promise<OperationOutput<K>> {
+    const spec = HOST_OPERATION_SPECS[operation];
+    const canonicalInput = spec.decodeInput(input) as OperationInput<K>;
+    const mode = spec.mode;
+    if (mode !== 'query') {
+      return this.#requireCurrent(operation).request(
+        operation as DirectRequestOperationKey,
+        canonicalInput as OperationInput<DirectRequestOperationKey>,
+        timeoutMs,
+      ) as Promise<OperationOutput<K>>;
+    }
+    const deadline = requestDeadline(timeoutMs);
+    let previous: RuntimeHostConnection | undefined;
+    while (true) {
+      const connection = await this.#waitForConnection(operation, previous, deadline);
+      const remaining = deadline === undefined ? undefined : Math.max(1, deadline - Date.now());
+      try {
+        return (await connection.request(
+          operation as DirectRequestOperationKey,
+          canonicalInput as OperationInput<DirectRequestOperationKey>,
+          remaining,
+        )) as OperationOutput<K>;
+      } catch (error) {
+        if (!isRetryableQueryInterruption(error)) throw error;
+        previous = connection;
+      }
+    }
+  }
+
+  async #waitForConnection(
+    operation: OperationKey,
+    previous: RuntimeHostConnection | undefined,
+    deadline: number | undefined,
+  ): Promise<RuntimeHostConnection> {
+    if (deadline === undefined) return this.#lifecycle.waitForCurrent(previous);
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) throw timeoutBeforeDispatch(operation);
+    const abort = new AbortController();
+    const timer = setTimeout(
+      () => abort.abort(new Error('Runtime Host request timed out')),
+      remaining,
+    );
+    try {
+      return await this.#lifecycle.waitForCurrent(previous, abort.signal);
+    } catch (error) {
+      if (abort.signal.aborted) throw timeoutBeforeDispatch(operation, asError(error));
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  #requireCurrent(operation: OperationKey): RuntimeHostConnection {
+    const connection = this.#lifecycle.current;
+    if (connection) return connection;
+    throw new RuntimeHostRequestInterruptedError(
+      operation,
+      HOST_OPERATION_SPECS[operation].mode,
+      'not_dispatched',
+      'connection_lost',
+      { cause: new Error('Runtime Host is reconnecting') },
+    );
+  }
+
+  #bindListeners(connection: RuntimeHostConnection): void {
+    this.#listenerDisposers = [
+      connection.subscribeConfigurationChanges((revision: number) => {
+        notify(this.#configurationListeners, revision);
+      }),
+      connection.subscribeProjectCatalogChanges((revision: number) => {
+        notify(this.#projectListeners, revision);
+      }),
+      connection.subscribeSessionCatalogChanges((frame: SessionCatalogChangedFrame) => {
+        notify(this.#sessionListeners, frame);
+      }),
+    ];
+  }
+
+  #unbindListeners(): void {
+    for (const dispose of this.#listenerDisposers.splice(0)) dispose();
+  }
+}
+
+function isConnectionLossInterruption(error: unknown): error is RuntimeHostRequestInterruptedError {
+  return error instanceof RuntimeHostRequestInterruptedError && error.reason === 'connection_lost';
+}
+
+function isHostDrainingOperation(error: unknown): error is RuntimeHostOperationError {
+  return error instanceof RuntimeHostOperationError && error.code === 'host_draining';
+}
+
+function isRetryableSubscriptionInterruption(error: unknown): boolean {
+  return isConnectionLossInterruption(error) || isHostDrainingOperation(error);
+}
+
+function isRetryableQueryInterruption(error: unknown): boolean {
+  return (isConnectionLossInterruption(error) && error.retryable) || isHostDrainingOperation(error);
+}
+
+function timeoutBeforeDispatch(
+  operation: OperationKey,
+  cause: Error = new Error('Runtime Host request timed out'),
+): RuntimeHostRequestInterruptedError {
+  return new RuntimeHostRequestInterruptedError(
+    operation,
+    HOST_OPERATION_SPECS[operation].mode,
+    'not_dispatched',
+    'timeout',
+    { cause },
+  );
+}
+
+function requestDeadline(timeoutMs: number | undefined): number | undefined {
+  if (timeoutMs === undefined) return undefined;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 120_000) {
+    throw new RangeError('timeoutMs must be an integer between 1 and 120000');
+  }
+  return Date.now() + timeoutMs;
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+function notify<T>(listeners: ReadonlySet<(value: T) => void>, value: T): void {
+  for (const listener of listeners) {
+    try {
+      listener(value);
+    } catch {
+      // A presentation listener cannot invalidate the Host connection.
+    }
+  }
+}

--- a/packages/runtime-host/src/client/wait-for-ready.ts
+++ b/packages/runtime-host/src/client/wait-for-ready.ts
@@ -1,0 +1,45 @@
+import type { RuntimeHostConnection } from './connection.js';
+
+export async function waitForRuntimeHostReady(
+  connection: Pick<RuntimeHostConnection, 'status'>,
+  timeoutMs = 45_000,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > 120_000) {
+    throw new RangeError('timeoutMs must be an integer between 1 and 120000');
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    signal?.throwIfAborted();
+    const status = await abortable(connection.status(Math.max(1, deadline - Date.now())), signal);
+    if (status.state === 'ready') return;
+    if (status.state === 'draining') {
+      throw new Error('Runtime Host drained before becoming ready');
+    }
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw new Error('Runtime Host did not become ready before the deadline');
+    }
+    await abortable(new Promise((resolve) => setTimeout(resolve, Math.min(25, remaining))), signal);
+  }
+}
+
+function abortable<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return operation;
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (callback: () => void) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener('abort', onAbort);
+      callback();
+    };
+    const onAbort = () => settle(() => reject(signal.reason));
+    signal.addEventListener('abort', onAbort, { once: true });
+    void operation.then(
+      (value) => settle(() => resolve(value)),
+      (error: unknown) => settle(() => reject(error)),
+    );
+  });
+}

--- a/packages/runtime-host/src/transport/framed-transport.ts
+++ b/packages/runtime-host/src/transport/framed-transport.ts
@@ -64,7 +64,7 @@ export class FramedTransport implements RuntimeHostMessageTransport {
       this.#ended = true;
       this.#drainInbound();
     });
-    socket.once('error', (error) => this.#fail(error));
+    socket.once('error', (error) => this.#fail(transportFailure(error)));
     socket.once('close', (hadError) => {
       if (!this.#readTerminal || hadError) {
         this.#fail(new RuntimeHostTransportError('closed', 'Runtime Host transport closed'));
@@ -111,8 +111,13 @@ export class FramedTransport implements RuntimeHostMessageTransport {
     const frame = frameLocalIpcProtocolMessage(message);
     return new Promise((resolve, reject) => {
       this.socket.write(frame, (error) => {
-        if (error) reject(error);
-        else resolve();
+        if (!error) {
+          resolve();
+          return;
+        }
+        const failure = transportFailure(error);
+        this.#fail(failure);
+        reject(failure);
       });
     });
   }
@@ -122,6 +127,7 @@ export class FramedTransport implements RuntimeHostMessageTransport {
   }
 
   abort(error?: Error): void {
+    if (error) this.#fail(error);
     this.socket.destroy(error);
   }
 
@@ -249,4 +255,17 @@ export class FramedTransport implements RuntimeHostMessageTransport {
 function asError(error: unknown): Error {
   if (error instanceof Error) return error;
   return new RuntimeHostProtocolError('invalid_frame', String(error));
+}
+
+function transportFailure(error: Error): Error {
+  if (error instanceof RuntimeHostTransportError || error instanceof RuntimeHostProtocolError) {
+    return error;
+  }
+  return new RuntimeHostTransportError(
+    'closed',
+    `Runtime Host transport failed: ${error.message}`,
+    {
+      cause: error,
+    },
+  );
 }

--- a/packages/runtime-host/src/transport/websocket-transport.ts
+++ b/packages/runtime-host/src/transport/websocket-transport.ts
@@ -42,7 +42,7 @@ export class WebSocketTransport implements RuntimeHostMessageTransport {
       this.#resolveClosed = resolve;
     });
     socket.on('message', (data, isBinary) => this.#receive(data, isBinary));
-    socket.once('error', (error) => this.#fail(error));
+    socket.once('error', (error) => this.#fail(transportFailure(error)));
     socket.once('close', () => {
       this.#endRead();
       this.#resolveClosed();
@@ -100,7 +100,7 @@ export class WebSocketTransport implements RuntimeHostMessageTransport {
       this.#socket.send(message, { binary: false, compress: false }, (error) => {
         this.#pendingWriteBytes -= message.byteLength;
         if (error) {
-          const failure = asError(error);
+          const failure = transportFailure(asError(error));
           this.#fail(failure);
           reject(failure);
           return;
@@ -220,4 +220,15 @@ function toBuffer(data: RawData): Buffer {
 
 function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function transportFailure(error: Error): Error {
+  if (error instanceof RuntimeHostTransportError || error instanceof RuntimeHostProtocolError) {
+    return error;
+  }
+  return new RuntimeHostTransportError(
+    'closed',
+    `Runtime Host WebSocket transport failed: ${error.message}`,
+    { cause: error },
+  );
 }


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Keep Runtime Host clients usable when the owning Host process restarts:

- add a shared reconnect lifecycle with bounded exponential backoff, stable client identity, and Host root/protocol validation
- distinguish safe read retries from commands whose outcome may be unknown, so reconnect never blindly repeats mutations
- resubscribe CLI/TUI sessions from a canonical transcript snapshot and continue live updates after recovery
- reconstruct the Desktop Host candidate while preserving renderer observation intent and a stable IPC admission surface

Refs #2522

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm --workspace @maka/runtime-host test` — 805 passed
- `npm --workspace maka-agent test` — 352 passed
- `npm --workspace @maka/desktop test` — 1140 passed
- Existing-profile Desktop, CLI, and TUI smoke tests with a real model
- Active and idle Host restart tests, including same-Session multi-client synchronization
- Agent Graph execution and child-session rendering across Desktop and CLI
- Automation persistence and Desktop rendering across a Host restart

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

让 Runtime Host 的宿主进程重启后，客户端仍可继续使用：

- 增加共享重连生命周期，采用有界指数退避，保持客户端身份稳定，并校验 Host 的数据根与协议身份
- 区分可安全重试的读取与结果可能不确定的命令，重连时绝不盲目重放修改操作
- CLI/TUI 从权威会话快照重新订阅，并在恢复后继续接收实时更新
- 重建 Desktop Host candidate，同时保留 renderer 的观察意图和稳定的 IPC 接入面

关联 #2522

## 验证

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm --workspace @maka/runtime-host test` — 805 项通过
- `npm --workspace maka-agent test` — 352 项通过
- `npm --workspace @maka/desktop test` — 1140 项通过
- 使用现有用户数据与真实模型验证 Desktop、CLI 和 TUI
- 验证空闲及活动任务中的 Host 重启，以及同一会话的多客户端同步
- 验证 Desktop 与 CLI 中的 Agent Graph 执行和子会话渲染
- 验证 Automation 在 Host 重启前后的持久化与 Desktop 展示

## 检查清单

- [x] 测试覆盖本次变更，且在缺少修复时会失败
- [x] 本地 lint、format、typecheck 与受影响测试套件全部通过

本 PR 是否包含行为变更？

- [x] 是 — 已在概要中说明
- [ ] 否

</details>
