### PR TITLE
fix: render subagent sessions as compact rows

### DIFF
--- a/apps/desktop/stories/subagent-sessions.stories.tsx
+++ b/apps/desktop/stories/subagent-sessions.stories.tsx
@@ -2,8 +2,8 @@
  * Subagent sessions — session presentation contract (design lock).
  *
  * - Sidebar lists only root/user sessions (no nested subagent tree).
- * - Multiple spawn_subagent calls in one turn render as one collapsible
- *   ToolTrow / ChatToolCalls group (product tool primitives).
+ * - Multiple spawn_subagent calls in one turn render as compact linked-session
+ *   rows in source order; ordinary tool evidence keeps its own ChatToolCalls.
  * - Opening a linked subagent switches the main chat column (option A);
  *   titlebar is project › parent › child.
  * - No composer drawer, strip, or parallel card system for subagents.
@@ -15,6 +15,7 @@
  */
 import { useState, type CSSProperties, type ReactNode } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { userEvent } from 'storybook/test';
 import {
   ChatComposer,
   ChatComposerInput,
@@ -382,8 +383,8 @@ function ParentShell() {
         <ProductTitlebar sessionName={PARENT_NAME} />
       </header>
       <Caption>
-        侧栏为 SessionListPanel + deriveSessionRail（仅 root）。流内一组可折叠
-        spawn_subagent；每个子会话是可直接打开的 Astryx 行。无 ComposerDrawer / strip。
+        侧栏为 SessionListPanel + deriveSessionRail（仅 root）。流内连续
+        spawn_subagent 保持为紧凑 Astryx 会话行。无 ComposerDrawer / strip。
       </Caption>
       <div style={shell.body}>
         <ProductRail activeSessionId={PARENT_SESSION_ID} />
@@ -397,7 +398,7 @@ function ParentShell() {
               </ChatMessage>
               <ChatMessage sender="assistant" name="Maka">
                 <ChatMessageBubble>
-                  当轮连续 spawn_subagent 合成一个工具组（与其它连续 tool run 相同）。点某行进对应子会话。
+                  当轮连续 spawn_subagent 保持原始顺序，每个子会话占一小行；点某行进入对应会话。
                 </ChatMessageBubble>
                 <ChatMessageMetadata timestamp="刚刚" />
                 <div style={{ marginTop: 10, width: '100%' }}>
@@ -469,7 +470,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Session presentation for subagents: flat sidebar, collapsible multi-spawn tool group, ' +
+          'Session presentation for subagents: flat sidebar, compact linked-session rows, ' +
           'main-column open with parent › child titlebar. No composer drawer.',
       },
     },
@@ -484,18 +485,27 @@ type Story = StoryObj<typeof meta>;
 export const ParentSession: Story = {
   name: '父会话 · 工具组 + 打开子会话',
   render: () => <ParentShell />,
+  play: async ({ canvasElement }) => {
+    const row = Array.from(canvasElement.querySelectorAll<HTMLButtonElement>('button'))
+      .find(candidate => candidate.textContent?.includes('explore · 读布局'));
+    if (!row) throw new Error('linked subagent row not found');
+    await userEvent.click(row);
+    if (!canvasElement.querySelector('[aria-label="子会话消息输入"]')) {
+      throw new Error('linked subagent session did not open');
+    }
+  },
 };
 
 // Real path: one native Astryx row per linked child session.
 export const ToolGroupFold: Story = {
-  name: '工具组 · 原生子会话行',
+  name: '多子代理 · 原生会话行',
   render: () => (
     <div style={shell.comparePane}>
       <Text type="body" style={{ fontWeight: 600 }}>
         {MULTI_SUBAGENT_ITEMS.length} 个子代理会话
       </Text>
       <Text type="supporting" color="secondary">
-        展开工具组后，每个子会话是一条原生工具行；点击该行直接打开会话。
+        每个子会话是一条紧凑的原生 Astryx 行；点击该行直接打开会话。
       </Text>
       <SubagentToolGroup
         items={MULTI_SUBAGENT_ITEMS}

--- a/packages/ui/src/__tests__/tool-trow-stability.test.tsx
+++ b/packages/ui/src/__tests__/tool-trow-stability.test.tsx
@@ -96,13 +96,29 @@ describe('linked subagent tool rows', () => {
     const html = renderTool(subagent('child-1'), () => undefined);
 
     assert.match(html, />Local Read</);
-    assert.match(html, /class="astryx-list\b/);
     assert.equal(html.match(/<button\b/g)?.length, 1);
-    assert.doesNotMatch(html, /data-variant="secondary"/);
-    assert.doesNotMatch(html, />打开子代理会话「Local Read」</);
+    assert.equal(renderTool(subagent(), () => undefined).match(/<button\b/g)?.length ?? 0, 0);
+    assert.equal(renderTool(subagent('child-1')).match(/<button\b/g)?.length ?? 0, 0);
+  });
 
-    assert.doesNotMatch(renderTool(subagent(), () => undefined), /打开子代理会话/);
-    assert.doesNotMatch(renderTool(subagent('child-1')), /打开子代理会话/);
+  it('preserves mixed tool and linked-agent order', () => {
+    const before = runningTool('tool-before', 'Read');
+    before.intent = 'before linked session';
+    const linked = subagent('child-1');
+    const after = runningTool('tool-after', 'Grep');
+    after.intent = 'after linked session';
+
+    const html = renderToStaticMarkup(createElement(ToolTrow, {
+      items: [before, linked, after],
+      onOpenLinkedSession: () => undefined,
+    }));
+    const beforeIndex = html.indexOf('before linked session');
+    const linkedIndex = html.indexOf('Inspect the runtime');
+    const afterIndex = html.indexOf('after linked session');
+
+    assert.ok(beforeIndex >= 0);
+    assert.ok(linkedIndex > beforeIndex);
+    assert.ok(afterIndex > linkedIndex);
   });
 
   it('uses the child result status instead of the settled transport status', () => {
@@ -176,15 +192,11 @@ describe('linked subagent tool rows', () => {
 
     assert.match(html, />Reader</);
     assert.match(html, />Worker</);
-    assert.equal(html.match(/<li\b/g)?.length, 2);
     assert.equal(html.match(/<button\b/g)?.length, 1);
-    assert.doesNotMatch(html, /data-variant="secondary"/);
-    assert.doesNotMatch(html, />打开子代理会话/);
     assert.match(html, /startup_failed/);
     assert.match(html, />失败</);
     assert.match(html, />已完成 · 只读<\/span>/);
     assert.doesNotMatch(html, />local_read<\/span>/);
-    assert.doesNotMatch(html, /aria-label="Loading"/);
   });
 
   it('keeps an empty swarm visible as its parent tool row', () => {

--- a/packages/ui/src/__tests__/tool-trow-stability.test.tsx
+++ b/packages/ui/src/__tests__/tool-trow-stability.test.tsx
@@ -92,11 +92,14 @@ describe('linked subagent tool rows', () => {
     onOpenLinkedSession?: (sessionId: string) => void,
   ) => renderToStaticMarkup(createElement(ToolTrow, { items: [item], onOpenLinkedSession }));
 
-  it('renders agent_spawn with an Astryx open-session control when linked', () => {
+  it('renders a linked agent as one compact clickable list row', () => {
     const html = renderTool(subagent('child-1'), () => undefined);
 
     assert.match(html, />Local Read</);
-    assert.match(html, /打开子代理会话「Local Read」/);
+    assert.match(html, /class="astryx-list\b/);
+    assert.equal(html.match(/<button\b/g)?.length, 1);
+    assert.doesNotMatch(html, /data-variant="secondary"/);
+    assert.doesNotMatch(html, />打开子代理会话「Local Read」</);
 
     assert.doesNotMatch(renderTool(subagent(), () => undefined), /打开子代理会话/);
     assert.doesNotMatch(renderTool(subagent('child-1')), /打开子代理会话/);
@@ -132,7 +135,7 @@ describe('linked subagent tool rows', () => {
     assert.match(withArtifacts, />已取消 · 只读<\/span>/);
   });
 
-  it('renders each swarm child as a native row and activates only linked sessions', () => {
+  it('links only swarm children that have a session', () => {
     const html = renderTool({
       toolUseId: 'swarm-1',
       toolName: 'agent_swarm',
@@ -173,7 +176,10 @@ describe('linked subagent tool rows', () => {
 
     assert.match(html, />Reader</);
     assert.match(html, />Worker</);
-    assert.equal(html.match(/>打开子代理会话/g)?.length, 1);
+    assert.equal(html.match(/<li\b/g)?.length, 2);
+    assert.equal(html.match(/<button\b/g)?.length, 1);
+    assert.doesNotMatch(html, /data-variant="secondary"/);
+    assert.doesNotMatch(html, />打开子代理会话/);
     assert.match(html, /startup_failed/);
     assert.match(html, />失败</);
     assert.match(html, />已完成 · 只读<\/span>/);

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -300,8 +300,9 @@ function mergeLiveOverPersisted(
  *   pre-merged with `\n\n`). Rendered as a collapsed "深度思考" disclosure.
  * - `text`: one assistant answer segment (a step's text). `ts` is the source
  *   step's wall-clock for hover meta.
- * - `tools`: one contiguous group of tool activity, rendered as a single
- *   Astryx tool group. Adjacent groups are pre-merged.
+ * - `tools`: one contiguous group of tool activity. Adjacent groups are
+ *   pre-merged; presentation may split ordinary evidence and linked-session
+ *   navigation into adjacent native Astryx segments without reordering them.
  *
  * The model stays FLAT: the collapsed "Processing" fold (#1307) is a render
  * concern applied by `foldTimeline` (timeline-fold.ts) at the component layer,

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -136,12 +136,10 @@
 .maka-subagent-session-label,
 .maka-subagent-session-end {
   display: flex;
-  min-width: 0;
   align-items: center;
   gap: var(--space-2);
 }
-.maka-subagent-session-label { width: 100%; }
-.maka-subagent-session-name { flex: 0 1 auto; }
+.maka-subagent-session-label { width: 100%; min-width: 0; }
 .maka-subagent-session-summary { min-width: 0; flex: 1 1 auto; }
 .maka-subagent-session-end { color: var(--muted-foreground); }
 .maka-live-turn-footer-placeholder { height: 32px; margin-top: 2px; }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -133,6 +133,17 @@
 }
 .maka-user-quotes { display: flex; max-width: 100%; flex-wrap: wrap; align-items: flex-start; gap: 4px; }
 .maka-assistant-answer-content { display: flex; width: 100%; min-width: 0; flex-direction: column; gap: 8px; }
+.maka-subagent-session-label,
+.maka-subagent-session-end {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+}
+.maka-subagent-session-label { width: 100%; }
+.maka-subagent-session-name { flex: 0 1 auto; }
+.maka-subagent-session-summary { min-width: 0; flex: 1 1 auto; }
+.maka-subagent-session-end { color: var(--muted-foreground); }
 .maka-live-turn-footer-placeholder { height: 32px; margin-top: 2px; }
 .maka-turn-processing,
 .maka-turn-status {

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -296,11 +296,10 @@ export function ToolCallDetail({
 }
 
 /**
- * Every tool row renders through Astryx `ChatToolCalls` — one component, one
- * visual language, whatever the status. The six product statuses fold into
- * Astryx's four: `interrupted` and sandbox denials are failures that carry
- * their own word in `errorMessage`, and the detail panel (banner, command,
- * output, previews) rides along in `resultDetail`.
+ * Ordinary tool evidence renders through Astryx `ChatToolCalls`; linked child
+ * sessions render through Astryx `ListItem` because their primary action is
+ * navigation, not inline evidence expansion. Adjacent segments preserve the
+ * source order without restoring a vendor activation patch.
  */
 export function ToolTrow({
   items,
@@ -358,7 +357,7 @@ function toolTrowSegments(items: ToolActivityItem[], locale: UiLocale): ToolTrow
     const previous = segments.at(-1);
     if (rows) {
       if (previous?.kind === 'agents') previous.rows.push(...rows);
-      else segments.push({ kind: 'agents', key: rows[0]!.key, rows });
+      else segments.push({ kind: 'agents', key: item.toolUseId, rows });
       continue;
     }
     const call = standardToolCall(item, locale);
@@ -375,7 +374,7 @@ function LinkedAgentList(props: {
 }) {
   const copy = getToolActivityCopy(props.locale).agent;
   return (
-    <List density="compact" className="maka-subagent-session-list">
+    <List density="compact">
       {props.rows.map((row) => {
         const childSessionId = row.childSessionId;
         const open = childSessionId && props.onOpenLinkedSession
@@ -385,7 +384,6 @@ function LinkedAgentList(props: {
         return (
           <ListItem
             key={row.key}
-            className="maka-subagent-session-row"
             startContent={(
               <StatusDot
                 variant={dotForStatus(linkedAgentStatusSemantic(row.status))}
@@ -395,7 +393,7 @@ function LinkedAgentList(props: {
             )}
             label={(
               <span className="maka-subagent-session-label">
-                <Text type="label" maxLines={1} className="maka-subagent-session-name">
+                <Text type="label" maxLines={1}>
                   {row.name}
                 </Text>
                 {row.target ? (
@@ -485,14 +483,18 @@ function linkedAgentRows(
   });
 }
 
-function linkedAgentStatusSemantic(
-  status: Extract<ToolResultContent, { kind: 'subagent' }>['status'],
-): StatusSemantic {
-  if (status === 'completed') return 'success';
-  if (status === 'running') return 'active';
-  if (status === 'waiting_for_user') return 'attention';
-  if (status === 'failed') return 'error';
-  return 'neutral';
+type LinkedAgentStatus = Extract<ToolResultContent, { kind: 'subagent' }>['status'];
+
+const LINKED_AGENT_STATUS_SEMANTIC = {
+  completed: 'success',
+  running: 'active',
+  waiting_for_user: 'attention',
+  failed: 'error',
+  cancelled: 'neutral',
+} satisfies Record<LinkedAgentStatus, StatusSemantic>;
+
+function linkedAgentStatusSemantic(status: LinkedAgentStatus): StatusSemantic {
+  return LINKED_AGENT_STATUS_SEMANTIC[status];
 }
 
 function subagentStats(
@@ -513,10 +515,9 @@ function boundedAgentSummary(summary: string): string | undefined {
 }
 
 /**
- * Green `+N` / red `-N`, from the shared structural parse. One diff for a row,
- * every diff in the run for the collapsed group header. Zero stays unpainted,
- * so a run that changed no file leaves the header as it was rather than
- * wearing a "0 changes" badge.
+ * Green `+N` / red `-N`, from the shared structural parse. Each visible call
+ * owns its diff counts. Zero stays unpainted so unchanged calls do not wear a
+ * misleading "0 changes" badge.
  */
 function diffStats(diffs: string[]): { additions?: number; deletions?: number } {
   let additions = 0;

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -8,6 +8,7 @@ import {
 import {
   ICON_SIZE,
   Check,
+  ChevronRight,
   Clock,
   Copy,
   Repeat,
@@ -34,7 +35,12 @@ import {
   Button as UiButton,
   Banner,
   ChatToolCalls,
+  List,
+  ListItem,
+  StatusDot,
+  Text,
   type ChatToolCallItem,
+  VisuallyHidden,
 } from '@astryxdesign/core';
 import { ToolCodeBlock, ToolDetailReveal } from './tool-activity/tool-code-block.js';
 import { cn } from './ui.js';
@@ -55,6 +61,7 @@ import {
   ToolResultPreview,
 } from './tool-activity/tool-result-preview.js';
 import { getToolActivityCopy } from './tool-activity/copy.js';
+import { dotForStatus, type StatusSemantic } from './status-vocabulary.js';
 
 /** Friendly card for a `load_tools` result; falls back to JSON on unexpected shapes. */
 function LoadToolResultPreview(props: { args: unknown; value: unknown }) {
@@ -304,20 +311,118 @@ export function ToolTrow({
 }) {
   const locale = useUiLocale();
   if (items.length === 0) return null;
-  const calls = items.flatMap((item) => linkedAgentCalls(item, locale)
-    ?? [standardToolCall(item, locale)]);
-  const openers = items.flatMap((item) => linkedSessionOpeners(item, locale, onOpenLinkedSession));
+  const segments = toolTrowSegments(items, locale);
 
-  // Stock ChatToolCalls only. Linked child sessions open via Astryx Button
-  // beside the row — no vendor onActivate patch.
+  // ChatToolCalls owns expandable tool evidence. Linked child sessions are
+  // navigation targets instead, so they render through Astryx's compact List:
+  // one native clickable row, with no parallel action button.
   return (
     <>
-      <ChatToolCalls
-        className="maka-tool-activity-card"
-        calls={calls}
-      />
-      {openers}
+      {segments.map((segment) => segment.kind === 'tools' ? (
+        <ChatToolCalls
+          key={segment.key}
+          className="maka-tool-activity-card"
+          calls={segment.calls}
+        />
+      ) : (
+        <LinkedAgentList
+          key={segment.key}
+          rows={segment.rows}
+          locale={locale}
+          onOpenLinkedSession={onOpenLinkedSession}
+        />
+      ))}
     </>
+  );
+}
+
+type LinkedAgentRow = {
+  key: string;
+  name: string;
+  status: Extract<ToolResultContent, { kind: 'subagent' }>['status'];
+  readOnly: boolean;
+  target?: string;
+  duration?: string;
+  failureClass?: string;
+  childSessionId?: string;
+};
+
+type ToolTrowSegment =
+  | { kind: 'tools'; key: string; calls: ChatToolCallItem[] }
+  | { kind: 'agents'; key: string; rows: LinkedAgentRow[] };
+
+function toolTrowSegments(items: ToolActivityItem[], locale: UiLocale): ToolTrowSegment[] {
+  const segments: ToolTrowSegment[] = [];
+  for (const item of items) {
+    const rows = linkedAgentRows(item, locale);
+    const previous = segments.at(-1);
+    if (rows) {
+      if (previous?.kind === 'agents') previous.rows.push(...rows);
+      else segments.push({ kind: 'agents', key: rows[0]!.key, rows });
+      continue;
+    }
+    const call = standardToolCall(item, locale);
+    if (previous?.kind === 'tools') previous.calls.push(call);
+    else segments.push({ kind: 'tools', key: item.toolUseId, calls: [call] });
+  }
+  return segments;
+}
+
+function LinkedAgentList(props: {
+  rows: LinkedAgentRow[];
+  locale: UiLocale;
+  onOpenLinkedSession?: (sessionId: string) => void;
+}) {
+  const copy = getToolActivityCopy(props.locale).agent;
+  return (
+    <List density="compact" className="maka-subagent-session-list">
+      {props.rows.map((row) => {
+        const childSessionId = row.childSessionId;
+        const open = childSessionId && props.onOpenLinkedSession
+          ? () => props.onOpenLinkedSession?.(childSessionId)
+          : undefined;
+        const status = copy.subagentStatus[row.status];
+        return (
+          <ListItem
+            key={row.key}
+            className="maka-subagent-session-row"
+            startContent={(
+              <StatusDot
+                variant={dotForStatus(linkedAgentStatusSemantic(row.status))}
+                label={status}
+                isPulsing={row.status === 'running'}
+              />
+            )}
+            label={(
+              <span className="maka-subagent-session-label">
+                <Text type="label" maxLines={1} className="maka-subagent-session-name">
+                  {row.name}
+                </Text>
+                {row.target ? (
+                  <Text type="body" color="secondary" maxLines={1} className="maka-subagent-session-summary">
+                    {row.target}
+                  </Text>
+                ) : null}
+                {row.failureClass ? (
+                  <VisuallyHidden>Error: {row.failureClass}</VisuallyHidden>
+                ) : null}
+              </span>
+            )}
+            endContent={(
+              <span className="maka-subagent-session-end">
+                <Text type="supporting" color="secondary">
+                  {[subagentStats(row.status, row.readOnly, props.locale), row.duration]
+                    .filter(Boolean)
+                    .join(' · ')}
+                </Text>
+                {open ? <ChevronRight size={ICON_SIZE.meta} aria-hidden="true" /> : null}
+              </span>
+            )}
+            onClick={open}
+          />
+        );
+      })}
+    </List>
   );
 }
 
@@ -343,25 +448,24 @@ function standardToolCall(item: ToolActivityItem, locale: UiLocale): ChatToolCal
   };
 }
 
-function linkedAgentCalls(
+function linkedAgentRows(
   item: ToolActivityItem,
   locale: UiLocale,
-): ChatToolCallItem[] | undefined {
+): LinkedAgentRow[] | undefined {
   const result = item.result;
   if (result?.kind === 'subagent') {
     const name = redactSecrets(result.agentName.trim()) || resolveToolDisplayName(item, locale);
     return [{
       key: item.toolUseId,
       name,
-      status: subagentToolStatus(result.status),
+      status: result.status,
+      readOnly: result.permissionMode === 'explore',
       target: item.intent
         ? formatToolIntent(item.intent)
         : boundedAgentSummary(result.summary),
       duration: formatDuration(item.durationMs ?? result.durationMs) ?? undefined,
-      errorMessage: result.failureClass
-        ? redactSecrets(result.failureClass)
-        : toolCallErrorMessage(item, locale),
-      stats: subagentStats(result.status, result.permissionMode === 'explore', locale),
+      failureClass: result.failureClass ? redactSecrets(result.failureClass) : undefined,
+      childSessionId: result.childSessionId,
     }];
   }
   if (result?.kind !== 'agent_swarm') return undefined;
@@ -371,22 +475,24 @@ function linkedAgentCalls(
     return {
       key: `${item.toolUseId}:${child.itemId}`,
       name,
-      status: child.status === 'completed' ? 'complete' : 'error',
+      status: child.status,
+      readOnly: child.profile === 'local_read',
       target: boundedAgentSummary(child.summary),
       duration: formatDuration(child.durationMs) ?? undefined,
-      errorMessage: child.failureClass ? redactSecrets(child.failureClass) : undefined,
-      stats: subagentStats(child.status, child.profile === 'local_read', locale),
-    } satisfies ChatToolCallItem;
+      failureClass: child.failureClass ? redactSecrets(child.failureClass) : undefined,
+      childSessionId: child.childSessionId,
+    } satisfies LinkedAgentRow;
   });
 }
 
-function subagentToolStatus(
+function linkedAgentStatusSemantic(
   status: Extract<ToolResultContent, { kind: 'subagent' }>['status'],
-): NonNullable<ChatToolCallItem['status']> {
-  if (status === 'completed') return 'complete';
-  if (status === 'running') return 'running';
-  if (status === 'waiting_for_user') return 'pending';
-  return 'error';
+): StatusSemantic {
+  if (status === 'completed') return 'success';
+  if (status === 'running') return 'active';
+  if (status === 'waiting_for_user') return 'attention';
+  if (status === 'failed') return 'error';
+  return 'neutral';
 }
 
 function subagentStats(
@@ -398,43 +504,6 @@ function subagentStats(
   return [copy.subagentStatus[status], readOnly ? copy.readOnly : undefined]
     .filter(Boolean)
     .join(' · ');
-}
-
-function linkedSessionOpeners(
-  item: ToolActivityItem,
-  locale: UiLocale,
-  onOpenLinkedSession: ((sessionId: string) => void) | undefined,
-) {
-  if (!onOpenLinkedSession) return [];
-  const result = item.result;
-  if (result?.kind === 'subagent') {
-    if (!result.childSessionId) return [];
-    const name = redactSecrets(result.agentName.trim()) || resolveToolDisplayName(item, locale);
-    return [linkedSessionButton(result.childSessionId, name, locale, onOpenLinkedSession)];
-  }
-  if (result?.kind !== 'agent_swarm') return [];
-  return result.items.flatMap((child) => {
-    if (!child.childSessionId) return [];
-    const name = redactSecrets((child.agentName || child.itemId).trim()) || child.profile;
-    return [linkedSessionButton(child.childSessionId, name, locale, onOpenLinkedSession)];
-  });
-}
-
-function linkedSessionButton(
-  childSessionId: string,
-  name: string,
-  locale: UiLocale,
-  onOpenLinkedSession: (sessionId: string) => void,
-) {
-  const label = getToolActivityCopy(locale).agent.openSessionAriaLabel(name);
-  return (
-    <UiButton
-      key={childSessionId}
-      variant="secondary"
-      label={label}
-      onClick={() => onOpenLinkedSession(childSessionId)}
-    />
-  );
 }
 
 function boundedAgentSummary(summary: string): string | undefined {

--- a/packages/ui/src/tool-activity/copy.ts
+++ b/packages/ui/src/tool-activity/copy.ts
@@ -121,7 +121,6 @@ export interface ToolActivityCopy {
     >;
     readOnly: string;
     duration: (value: string) => string;
-    openSessionAriaLabel: (name: string) => string;
     copyState: { pending: string; copied: string; failed: string; pendingAria: (label: string) => string; failedAria: (label: string) => string };
     copyButtons: Record<'summary' | 'continuation' | 'process' | 'evidence' | 'report' | 'candidate' | 'matches', { idle: string; copied: string }>;
     objectiveFallback: string;
@@ -208,7 +207,6 @@ const TOOL_ACTIVITY_COPY = {
     },
     agent: {
       subagentStatus: { completed: '已完成', failed: '失败', cancelled: '已取消', running: '运行中', waiting_for_user: '等待用户输入' }, readOnly: '只读', duration: (value) => `耗时 ${value}`,
-      openSessionAriaLabel: (name) => `打开子代理会话「${name}」`,
       copyState: { pending: '复制中…', copied: '已复制', failed: '复制失败', pendingAria: (label) => `${label}中`, failedAria: (label) => `${label}失败` },
       copyButtons: { summary: { idle: '复制摘要', copied: '已复制探索摘要' }, continuation: { idle: '复制续研提示', copied: '已复制续研提示' }, process: { idle: '复制过程', copied: '已复制探索过程' }, evidence: { idle: '复制证据', copied: '已复制证据锚点' }, report: { idle: '复制报告', copied: '已复制研究报告' }, candidate: { idle: '复制候选', copied: '已复制候选文件' }, matches: { idle: '复制片段', copied: '已复制命中片段' } },
       objectiveFallback: '只读探索', foundRead: (found, read) => `发现/读 ${found} / ${read} 个文件`, skipped: (count, sensitive) => sensitive ? `跳过 ${count} 个（含敏感 ${sensitive} 个）` : `跳过 ${count} 个`, budgetLimited: '受预算限制', continuationSuggested: (reason) => `建议续研：${reason}`, followupActionsAriaLabel: '只读探索后续操作', continuationTitle: '复制一段可继续只读探索的提示', incompleteFallback: '只读探索未完成。', detail: { terminal: '终态', foundRead: '发现/读', scope: '范围', queries: '查询', ignored: '忽略', stopping: '停止', boundary: '边界', next: '后续' }, files: (n) => `${n} 个文件`,
@@ -267,7 +265,6 @@ const TOOL_ACTIVITY_COPY = {
     },
     agent: {
       subagentStatus: { completed: 'Completed', failed: 'Failed', cancelled: 'Cancelled', running: 'Running', waiting_for_user: 'Waiting for user input' }, readOnly: 'Read only', duration: (value) => `Duration ${value}`,
-      openSessionAriaLabel: (name) => `Open subagent session “${name}”`,
       copyState: { pending: 'Copying…', copied: 'Copied', failed: 'Copy failed', pendingAria: (label) => `Copying ${label}`, failedAria: (label) => `Failed to copy ${label}` },
       copyButtons: { summary: { idle: 'Copy summary', copied: 'Exploration summary copied' }, continuation: { idle: 'Copy continuation prompt', copied: 'Continuation prompt copied' }, process: { idle: 'Copy process', copied: 'Exploration process copied' }, evidence: { idle: 'Copy evidence', copied: 'Evidence anchors copied' }, report: { idle: 'Copy report', copied: 'Research report copied' }, candidate: { idle: 'Copy candidates', copied: 'Candidate files copied' }, matches: { idle: 'Copy matches', copied: 'Matching excerpts copied' } },
       objectiveFallback: 'Read-only exploration', foundRead: (found, read) => `Discovered/read ${found} / ${read} files`, skipped: (count, sensitive) => sensitive ? `Skipped ${count} (${sensitive} sensitive)` : `Skipped ${count}`, budgetLimited: 'Budget limited', continuationSuggested: (reason) => `Continue: ${reason}`, followupActionsAriaLabel: 'Read-only exploration follow-up actions', continuationTitle: 'Copy a prompt that continues the read-only exploration', incompleteFallback: 'Read-only exploration did not complete.', detail: { terminal: 'Terminal state', foundRead: 'Discovered/read', scope: 'Scope', queries: 'Queries', ignored: 'Ignored', stopping: 'Stopped by', boundary: 'Limits', next: 'Next' }, files: (n) => `${n} ${n === 1 ? 'file' : 'files'}`,


### PR DESCRIPTION
## Summary

- Render linked subagent sessions through Astryx `List` / `ListItem` instead of appending standalone secondary buttons.
- Keep ordinary tool evidence in `ChatToolCalls` while presenting each linked subagent as one compact 14px navigation row.
- Preserve child status, read-only state, duration, summary, and failure semantics without restoring the removed Astryx vendor patch.

## Before / after

### Before — regressed rendering

<img width="900" alt="codex-clipboard-18840be8-47d3-43f4-ae0e-fde60a799102" src="https://github.com/user-attachments/assets/72b3e5ba-5afe-4368-bd9c-546422c61f14" />

### After — real Electron, compact Astryx rows

<img width="900" alt="subagent-compact-session-rows-electron" src="https://github.com/user-attachments/assets/2bf8111b-010f-48e1-b5b0-3d9048a13909" />

## Verification

- `npm run format:check`
- `npm run build --workspace=@maka/ui`
- `node --test packages/ui/dist/__tests__/tool-trow-stability.test.js` — 9 passed
- `npm --workspace @maka/desktop run typecheck:stories`
- `npm --workspace @maka/desktop run build:with-deps`
- Real Electron verification in dark mode: five persisted subagent sessions, 14px labels and summaries, one interaction per linked session, zero secondary buttons; linked-session navigation verified

## Review focus

- Is `ListItem` the narrowest existing Astryx seam for linked-session navigation?
- Can the segmenting or regression tests be simplified without losing behavior coverage?
- Does this remain the simplest ownership split between transcript tools and Graph/Swarm orchestration?

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
