### PR TITLE
feat(runtime-host): add trusted capability provider service

### DIFF
--- a/apps/desktop/src/main/runtime-host-native-capabilities.ts
+++ b/apps/desktop/src/main/runtime-host-native-capabilities.ts
@@ -226,6 +226,9 @@ async function invokeNativeTool(
   invocation: AbortController,
   usedSessionIds: Set<string>,
 ): Promise<ClientCapabilityCallResult> {
+  if (frame.cwd === undefined) {
+    throw new Error("Desktop native capability requires Host cwd context");
+  }
   const signal = AbortSignal.any([options.signal, invocation.signal]);
   signal.throwIfAborted();
   const parameters = requireZodSchema(binding.tool);
@@ -270,6 +273,7 @@ function capabilityOffer(group: DesktopCapabilityGroup): ClientCapabilityOffer {
     offerId: group.offerId,
     version: CAPABILITY_VERSION,
     affinity: "session",
+    hostPathAccess: "cwd",
     label: group.label,
     description: group.description,
     tools: Object.freeze(

--- a/package-lock.json
+++ b/package-lock.json
@@ -13491,6 +13491,7 @@
         "@earendil-works/pi-tui": "0.83.0",
         "@maka/core": "0.1.0",
         "@maka/headless": "0.1.0",
+        "@maka/mcp": "0.1.0",
         "@maka/runtime": "0.1.0",
         "@maka/runtime-host": "0.1.0",
         "@maka/storage": "0.1.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,7 +14,7 @@
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",
     "build": "tsc -p tsconfig.json && node scripts/chmod-bin.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "pretest": "npm --workspace @maka/code-mode run build && npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/runtime-host run build",
+    "pretest": "npm --workspace @maka/code-mode run build && npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/mcp run build && npm --workspace @maka/runtime run build && npm --workspace @maka/runtime-host run build",
     "test": "npm run clean && npm run build && npm run test:dist",
     "test:dist": "node --test \"dist/**/*.test.js\""
   },
@@ -22,6 +22,7 @@
     "@earendil-works/pi-tui": "0.83.0",
     "@maka/core": "0.1.0",
     "@maka/headless": "0.1.0",
+    "@maka/mcp": "0.1.0",
     "@maka/runtime": "0.1.0",
     "@maka/runtime-host": "0.1.0",
     "@maka/storage": "0.1.0"

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -22,8 +22,24 @@ describe('Maka CLI args', () => {
         ['runtime-host'],
         {
           kind: 'error',
-          message: 'runtime-host requires the serve or access command',
+          message: 'runtime-host requires the serve, access, or capability-provider command',
           exitCode: 2,
+        },
+      ],
+      [
+        [
+          'runtime-host',
+          'capability-provider',
+          'serve',
+          '--url',
+          'ws://127.0.0.1:43120',
+          '--mcp-config',
+          '/srv/maka/mcp.json',
+        ],
+        {
+          kind: 'runtime-host-capability-provider-serve',
+          url: 'ws://127.0.0.1:43120',
+          mcpConfigPath: '/srv/maka/mcp.json',
         },
       ],
       [
@@ -51,9 +67,29 @@ describe('Maka CLI args', () => {
         ],
         {
           kind: 'runtime-host-access-issue',
+          principalKind: 'remote_owner',
           principalId: 'device-1',
           operationGrants: ['session.catalog.query', 'subscription.open'],
           canPublishClientCapabilities: false,
+          canUseHostPaths: false,
+        },
+      ],
+      [
+        [
+          'runtime-host',
+          'access',
+          'issue',
+          '--kind',
+          'capability-provider',
+          '--principal',
+          'automation-provider',
+        ],
+        {
+          kind: 'runtime-host-access-issue',
+          principalKind: 'capability_provider',
+          principalId: 'automation-provider',
+          operationGrants: ['client.capability.replace', 'client.capability.unregister'],
+          canPublishClientCapabilities: true,
           canUseHostPaths: false,
         },
       ],

--- a/packages/cli/src/__tests__/runtime-host-capability-provider-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-capability-provider-command.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { McpClientManager } from '@maka/mcp';
+import { createMcpCapabilityProvider } from '../runtime-host-capability-provider-command.js';
+
+test('MCP capability publication freezes an accepted callable tool snapshot', async () => {
+  let accepted = false;
+  const manager = {
+    statuses: () => [
+      {
+        serverId: 'workspace.remote',
+        state: 'connected' as const,
+        toolCount: 1,
+        tools: [
+          {
+            serverId: 'workspace.remote',
+            name: 'inspect/file',
+            description: 'Inspect the workspace.',
+            inputSchema: { type: 'object', additionalProperties: false },
+          },
+        ],
+        updatedAt: 1,
+      },
+    ],
+    bindTool:
+      (serverId: string, toolName: string) => async (arguments_: Record<string, unknown>) => {
+        assert.equal(accepted, true);
+        assert.equal(serverId, 'workspace.remote');
+        assert.equal(toolName, 'inspect/file');
+        return { content: [{ type: 'text' as const, text: JSON.stringify(arguments_) }] };
+      },
+  } satisfies Pick<McpClientManager, 'statuses' | 'bindTool'>;
+  const provider = createMcpCapabilityProvider(manager);
+  assert.ok(provider?.call);
+  const offer = provider.offers()[0];
+  assert.equal(offer?.affinity, 'session');
+  const tool = offer?.tools[0] ?? assert.fail('Expected a projected tool');
+  assert.match(tool.serverId, /^[A-Za-z0-9_-]+$/u);
+  assert.match(tool.name, /^[A-Za-z0-9_-]+$/u);
+
+  const result = await provider.call(
+    {
+      kind: 'client.capability.call',
+      invocationId: 'invocation-1',
+      registrationId: 'registration-1',
+      offerId: offer?.offerId ?? assert.fail('Expected an offer'),
+      serverId: tool.serverId,
+      toolName: tool.name,
+      arguments: { path: 'README.md' },
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      toolCallId: 'tool-call-1',
+    },
+    {
+      signal: new AbortController().signal,
+      accept: async () => {
+        accepted = true;
+      },
+    },
+  );
+  assert.deepEqual(result, { content: [{ type: 'text', text: '{"path":"README.md"}' }] });
+});
+
+test('MCP capability publication packs tools across server boundaries', () => {
+  const manager = {
+    statuses: () =>
+      Array.from({ length: 33 }, (_, index) => ({
+        serverId: `server-${index}`,
+        state: 'connected' as const,
+        toolCount: 1,
+        tools: [
+          {
+            serverId: `server-${index}`,
+            name: 'echo',
+            inputSchema: { type: 'object' as const },
+          },
+        ],
+        updatedAt: 1,
+      })),
+    bindTool: () => async () => ({ content: [] }),
+  } satisfies Pick<McpClientManager, 'statuses' | 'bindTool'>;
+
+  const offers = createMcpCapabilityProvider(manager)?.offers() ?? [];
+  assert.equal(offers.length, 1);
+  assert.equal(offers[0]?.tools.length, 33);
+  assert.equal(new Set(offers[0]?.tools.map((tool) => tool.serverId)).size, 33);
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -101,7 +101,9 @@ function helpText(): string {
     '  maka inspect ...  Inspect Session, AgentRun, or TaskRun evidence',
     '  maka runtime-host serve [options]  Run a Runtime Host service',
     '  maka runtime-host access issue --principal <id> --grant <operation>',
+    '  maka runtime-host access issue --kind capability-provider --principal <id>',
     '  maka runtime-host access revoke --credential <id>',
+    '  maka runtime-host capability-provider serve --url <ws-url> --mcp-config <path>',
     '',
     'Options:',
     '  -h, --help        Show help',
@@ -120,10 +122,18 @@ function helpText(): string {
     '',
     'Runtime Host access issue options:',
     '  --root <path>                 Select the canonical data root',
+    '  --kind <kind>                 remote-owner or capability-provider',
     '  --principal <id>              Name the authenticated Client principal',
     '  --grant <operation>           Grant one exact operation (repeatable)',
     '  --publish-client-capabilities Allow Client Capability publication',
     '  --allow-host-paths            Allow operations that submit Host paths',
+    '',
+    'Runtime Host capability provider options:',
+    '  --url <ws-url>                Connect to an authenticated Runtime Host WebSocket',
+    '  --mcp-config <path>           Publish tools from an MCP configuration file',
+    '  --expected-root <root-id>     Pin the canonical Runtime Host root identity',
+    '  --credential-env <name>       Read the access credential from this environment variable',
+    '  --client-identity <path>      Persist the provider Client instance identity here',
   ].join('\n');
 }
 
@@ -163,6 +173,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
       const { runRuntimeHostAccessIssueCli } = await import('./runtime-host-access-command.js');
       return runRuntimeHostAccessIssueCli({
         rootPath: command.rootPath ?? resolveMakaWorkspaceRoot(),
+        principalKind: command.principalKind,
         principalId: command.principalId,
         operationGrants: command.operationGrants,
         canPublishClientCapabilities: command.canPublishClientCapabilities,
@@ -174,6 +185,18 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
       return runRuntimeHostAccessRevokeCli({
         rootPath: command.rootPath ?? resolveMakaWorkspaceRoot(),
         credentialId: command.credentialId,
+      });
+    }
+    case 'runtime-host-capability-provider-serve': {
+      const { runRuntimeHostCapabilityProviderCli } = await import(
+        './runtime-host-capability-provider-command.js'
+      );
+      return runRuntimeHostCapabilityProviderCli({
+        url: command.url,
+        mcpConfigPath: command.mcpConfigPath,
+        ...(command.expectedRootId ? { expectedRootId: command.expectedRootId } : {}),
+        ...(command.credentialEnv ? { credentialEnv: command.credentialEnv } : {}),
+        ...(command.clientIdentityPath ? { clientIdentityPath: command.clientIdentityPath } : {}),
       });
     }
     case 'help':

--- a/packages/cli/src/runtime-host-access-command.ts
+++ b/packages/cli/src/runtime-host-access-command.ts
@@ -5,6 +5,7 @@ import {
 import {
   isOperationKey,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  type AccessCredentialPrincipalKind,
   type OperationKey,
 } from '@maka/runtime-host/protocol';
 
@@ -15,6 +16,7 @@ const PROTOCOL = {
 
 export interface RuntimeHostAccessIssueOptions {
   readonly rootPath: string;
+  readonly principalKind: AccessCredentialPrincipalKind;
   readonly principalId: string;
   readonly operationGrants: readonly string[];
   readonly canPublishClientCapabilities: boolean;
@@ -33,6 +35,7 @@ export async function runRuntimeHostAccessIssueCli(
   const connection = await connectLocalOwner(options.rootPath);
   try {
     const result = await connection.request('access.credential.issue', {
+      principalKind: options.principalKind,
       principalId: options.principalId,
       operationGrants,
       canPublishClientCapabilities: options.canPublishClientCapabilities,

--- a/packages/cli/src/runtime-host-capability-provider-command.ts
+++ b/packages/cli/src/runtime-host-capability-provider-command.ts
@@ -1,0 +1,280 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import type { McpCallResult, McpToolDescriptor } from '@maka/core/mcp';
+import { McpClientManager } from '@maka/mcp';
+import { normalizeMcpConfig } from '@maka/storage';
+import {
+  connectRemoteRuntimeHost,
+  loadOrCreateRuntimeHostClientInstanceId,
+  RuntimeHostPermanentReconnectError,
+  startRuntimeHostCapabilityProviderService,
+  type ClientCapabilityProvider,
+  type RuntimeHostConnection,
+} from '@maka/runtime-host/client';
+import {
+  CLIENT_CAPABILITY_MAX_TOOLS,
+  CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER,
+  decodeClientCapabilityReplaceInput,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type ClientCapabilityCallResult,
+  type ClientCapabilityOffer,
+} from '@maka/runtime-host/protocol';
+import { runRuntimeHostProcessLifecycle } from '@maka/runtime-host/server';
+
+const DEFAULT_CREDENTIAL_ENV = 'MAKA_RUNTIME_HOST_ACCESS_CREDENTIAL';
+const CAPABILITY_VERSION = '0';
+const MAX_MCP_CONFIG_BYTES = 1_048_576;
+const MCP_RECONNECT_INTERVAL_MS = 5_000;
+
+export interface RuntimeHostCapabilityProviderCliOptions {
+  readonly url: string;
+  readonly mcpConfigPath: string;
+  readonly expectedRootId?: string;
+  readonly credentialEnv?: string;
+  readonly clientIdentityPath?: string;
+}
+
+export async function runRuntimeHostCapabilityProviderCli(
+  options: RuntimeHostCapabilityProviderCliOptions,
+): Promise<number> {
+  const configPath = resolve(options.mcpConfigPath);
+  const identityPath = resolve(
+    options.clientIdentityPath ?? defaultProviderClientIdentityPath(options.url, configPath),
+  );
+  const credentialEnv = options.credentialEnv ?? DEFAULT_CREDENTIAL_ENV;
+  const credential = process.env[credentialEnv];
+  if (!credential)
+    throw new Error(`Runtime Host access credential is missing from ${credentialEnv}`);
+
+  const configText = await readFile(configPath, 'utf8');
+  if (Buffer.byteLength(configText, 'utf8') > MAX_MCP_CONFIG_BYTES) {
+    throw new Error('MCP config exceeds 1 MiB');
+  }
+  const config = normalizeMcpConfig(JSON.parse(configText));
+  const clientInstanceId = await loadOrCreateRuntimeHostClientInstanceId(identityPath);
+  const manager = new McpClientManager({
+    clientName: 'maka-capability-provider',
+    excludedStdioEnvironmentKeys: [credentialEnv],
+  });
+  await manager.sync(config);
+
+  let service: Awaited<ReturnType<typeof startRuntimeHostCapabilityProviderService>> | undefined;
+  let publishedRevision = manager.toolSnapshotRevision();
+  const disposeChanges = manager.onChange(() => {
+    const revision = manager.toolSnapshotRevision();
+    if (revision === publishedRevision) return;
+    publishedRevision = revision;
+    void service?.refresh().catch(reportRefreshFailure);
+  });
+  const reconnectTimer = setInterval(() => {
+    for (const status of manager.statuses()) {
+      if (status.state !== 'disconnected' && status.state !== 'error') continue;
+      void manager.connect(status.serverId).catch(() => undefined);
+    }
+  }, MCP_RECONNECT_INTERVAL_MS);
+  reconnectTimer.unref();
+  try {
+    service = await startRuntimeHostCapabilityProviderService({
+      connect: (signal) =>
+        connectRemoteCapabilityProvider({
+          url: options.url,
+          credential,
+          clientInstanceId,
+          signal,
+          ...(options.expectedRootId ? { expectedRootId: options.expectedRootId } : {}),
+        }),
+      createProvider: () => createMcpCapabilityProvider(manager),
+      onReconnectError: (error) => {
+        process.stderr.write(
+          `Runtime Host capability provider reconnect failed: ${error.message}\n`,
+        );
+      },
+      onPublicationError: reportRefreshFailure,
+      onFatalError: (error) => {
+        process.exitCode = 1;
+        process.stderr.write(`Runtime Host capability provider stopped: ${error.message}\n`);
+      },
+    });
+    await runRuntimeHostProcessLifecycle(service, {
+      onReady: () => {
+        process.stdout.write(
+          `Runtime Host capability provider is connected (${manager.tools().length} MCP tools)\n`,
+        );
+      },
+    });
+    return 0;
+  } finally {
+    clearInterval(reconnectTimer);
+    disposeChanges();
+    await service?.close().catch(() => undefined);
+    await manager.close();
+  }
+}
+
+function defaultProviderClientIdentityPath(url: string, configPath: string): string {
+  const identity = createHash('sha256')
+    .update(`runtime-host-capability-provider\0${url}\0${configPath}`)
+    .digest('hex')
+    .slice(0, 24);
+  return join(homedir(), '.maka', 'runtime-host-capability-providers', `${identity}.json`);
+}
+
+async function connectRemoteCapabilityProvider(input: {
+  readonly url: string;
+  readonly credential: string;
+  readonly clientInstanceId: string;
+  readonly expectedRootId?: string;
+  readonly signal: AbortSignal;
+}): Promise<RuntimeHostConnection> {
+  input.signal.throwIfAborted();
+  const connected = await connectRemoteRuntimeHost({
+    url: input.url,
+    credential: input.credential,
+    surface: 'capability-provider',
+    protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
+    clientInstanceId: input.clientInstanceId,
+    ...(input.expectedRootId ? { expectedRootId: input.expectedRootId } : {}),
+  });
+  if (input.signal.aborted) {
+    if (connected.kind === 'connected') await connected.connection.close();
+    input.signal.throwIfAborted();
+  }
+  if (connected.kind === 'connected') return connected.connection;
+  if (connected.kind === 'incompatible') {
+    throw new RuntimeHostPermanentReconnectError(
+      `Runtime Host protocol is incompatible (Host ${connected.handshake.protocolMin}-${connected.handshake.protocolMax})`,
+    );
+  }
+  if (connected.kind === 'unavailable' && connected.reason === 'root_mismatch') {
+    throw new RuntimeHostPermanentReconnectError('Runtime Host root identity does not match');
+  }
+  throw new Error(
+    connected.kind === 'unavailable'
+      ? `Runtime Host is unavailable (${connected.reason})`
+      : 'Runtime Host is draining',
+  );
+}
+
+export function createMcpCapabilityProvider(
+  manager: Pick<McpClientManager, 'statuses' | 'bindTool'>,
+): ClientCapabilityProvider | undefined {
+  const connected = manager
+    .statuses()
+    .filter((status) => status.state === 'connected' && status.tools.length > 0)
+    .sort((left, right) => left.serverId.localeCompare(right.serverId));
+  const toolCount = connected.reduce((sum, status) => sum + status.tools.length, 0);
+  if (toolCount === 0) return undefined;
+  if (toolCount > CLIENT_CAPABILITY_MAX_TOOLS) {
+    throw new Error(
+      `MCP capability provider exposes ${toolCount} tools; the limit is ${CLIENT_CAPABILITY_MAX_TOOLS}`,
+    );
+  }
+
+  const projectedIdentities = new Set<string>();
+  const projected: Array<{
+    readonly source: McpToolDescriptor;
+    readonly descriptor: ReturnType<typeof projectMcpTool>;
+  }> = [];
+  for (const status of connected) {
+    const tools = [...status.tools].sort((left, right) => left.name.localeCompare(right.name));
+    const wireServerId = capabilityEntityId(status.serverId);
+    for (const tool of tools) {
+      const descriptor = projectMcpTool(tool, wireServerId);
+      const identity = `${descriptor.serverId}\0${descriptor.name}`;
+      if (projectedIdentities.has(identity)) {
+        throw new Error('MCP tools collide after Client Capability identity normalization');
+      }
+      projectedIdentities.add(identity);
+      projected.push({ source: tool, descriptor });
+    }
+  }
+
+  const bindings = new Map<string, ReturnType<Pick<McpClientManager, 'bindTool'>['bindTool']>>();
+  const offers: ClientCapabilityOffer[] = [];
+  for (let offset = 0; offset < projected.length; offset += CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER) {
+    const chunk = projected.slice(offset, offset + CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER);
+    const offerId = mcpOfferId(chunk, offset / CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER);
+    const servers = new Set(chunk.map(({ source }) => source.serverId));
+    offers.push({
+      offerId,
+      version: CAPABILITY_VERSION,
+      affinity: 'session',
+      hostPathAccess: 'none',
+      label:
+        servers.size === 1
+          ? `MCP: ${chunk[0]?.source.serverId ?? 'tools'}`.slice(0, 128)
+          : `MCP tools (${servers.size} servers)`,
+      description: 'Use tools provided by connected MCP servers.',
+      tools: chunk.map(({ descriptor }) => descriptor),
+    });
+    for (const { source, descriptor } of chunk) {
+      bindings.set(
+        capabilityBindingKey(offerId, descriptor.serverId, descriptor.name),
+        manager.bindTool(source.serverId, source.name),
+      );
+    }
+  }
+  const canonical = decodeClientCapabilityReplaceInput({
+    registrationId: '00000000-0000-4000-8000-000000000000',
+    offers,
+  });
+
+  return {
+    offers: () => canonical.offers,
+    call: async (frame, options) => {
+      const call = bindings.get(
+        capabilityBindingKey(frame.offerId, frame.serverId, frame.toolName),
+      );
+      if (!call) throw new Error('MCP capability is not part of the published snapshot');
+      await options.accept();
+      return projectMcpResult(await call(frame.arguments, { signal: options.signal }));
+    },
+  };
+}
+
+function projectMcpTool(tool: McpToolDescriptor, wireServerId: string) {
+  return {
+    serverId: wireServerId,
+    name: capabilityEntityId(tool.name),
+    ...(tool.description ? { description: tool.description } : {}),
+    inputSchema: structuredClone(tool.inputSchema),
+    ...(tool.annotations ? { annotations: { ...tool.annotations } } : {}),
+  };
+}
+
+function capabilityEntityId(value: string): string {
+  if (/^[A-Za-z0-9_-]{1,128}$/u.test(value)) return value;
+  const label = value.replace(/[^A-Za-z0-9_-]+/gu, '_').slice(0, 103) || 'mcp';
+  const digest = createHash('sha256').update(value).digest('hex').slice(0, 24);
+  return `${label}_${digest}`;
+}
+
+function projectMcpResult(result: McpCallResult): ClientCapabilityCallResult {
+  return {
+    content: result.content.map((block) => structuredClone(block)),
+    ...(result.structuredContent === undefined
+      ? {}
+      : { structuredContent: structuredClone(result.structuredContent) }),
+  };
+}
+
+function mcpOfferId(
+  tools: readonly { readonly source: McpToolDescriptor }[],
+  chunk: number,
+): string {
+  const hash = createHash('sha256').update(`mcp-capability-offer-v0\0${chunk}`);
+  for (const { source } of tools)
+    hash.update('\0').update(source.serverId).update('\0').update(source.name);
+  return `mcp_${hash.digest('hex').slice(0, 24)}_${chunk}`;
+}
+
+function capabilityBindingKey(offerId: string, serverId: string, toolName: string): string {
+  return `${offerId}\0${serverId}\0${toolName}`;
+}
+
+function reportRefreshFailure(error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`Runtime Host capability publication refresh failed: ${message}\n`);
+}

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -16,22 +16,80 @@ export type RuntimeHostCliCommand =
   | {
       kind: 'runtime-host-access-issue';
       rootPath?: string;
+      principalKind: 'remote_owner' | 'capability_provider';
       principalId: string;
       operationGrants: string[];
       canPublishClientCapabilities: boolean;
       canUseHostPaths: boolean;
     }
   | { kind: 'runtime-host-access-revoke'; rootPath?: string; credentialId: string }
+  | {
+      kind: 'runtime-host-capability-provider-serve';
+      url: string;
+      mcpConfigPath: string;
+      expectedRootId?: string;
+      credentialEnv?: string;
+      clientIdentityPath?: string;
+    }
   | RuntimeHostCliError;
 
 export function parseRuntimeHostCommand(argv: string[]): RuntimeHostCliCommand {
   if (argv[0] === 'serve') return parseServeCommand(argv.slice(1));
   if (argv[0] === 'access') return parseAccessCommand(argv.slice(1));
+  if (argv[0] === 'capability-provider') {
+    return parseCapabilityProviderCommand(argv.slice(1));
+  }
   return error(
     argv[0]
       ? `Unexpected runtime-host command: ${argv[0]}`
-      : 'runtime-host requires the serve or access command',
+      : 'runtime-host requires the serve, access, or capability-provider command',
   );
+}
+
+function parseCapabilityProviderCommand(argv: string[]): RuntimeHostCliCommand {
+  if (argv[0] !== 'serve') {
+    return error(
+      argv[0]
+        ? `Unexpected runtime-host capability-provider command: ${argv[0]}`
+        : 'runtime-host capability-provider requires the serve command',
+    );
+  }
+  let url: string | undefined;
+  let mcpConfigPath: string | undefined;
+  let expectedRootId: string | undefined;
+  let credentialEnv: string | undefined;
+  let clientIdentityPath: string | undefined;
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (
+      argument === '--url' ||
+      argument === '--mcp-config' ||
+      argument === '--expected-root' ||
+      argument === '--credential-env' ||
+      argument === '--client-identity'
+    ) {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      if (argument === '--url') url = parsed;
+      if (argument === '--mcp-config') mcpConfigPath = parsed;
+      if (argument === '--expected-root') expectedRootId = parsed;
+      if (argument === '--credential-env') credentialEnv = parsed;
+      if (argument === '--client-identity') clientIdentityPath = parsed;
+      index += 1;
+      continue;
+    }
+    return error(`Unexpected argument: ${argument ?? ''}`);
+  }
+  if (!url) return error('--url is required');
+  if (!mcpConfigPath) return error('--mcp-config is required');
+  return {
+    kind: 'runtime-host-capability-provider-serve',
+    url,
+    mcpConfigPath,
+    ...(expectedRootId ? { expectedRootId } : {}),
+    ...(credentialEnv ? { credentialEnv } : {}),
+    ...(clientIdentityPath ? { clientIdentityPath } : {}),
+  };
 }
 
 function parseServeCommand(argv: string[]): RuntimeHostCliCommand {
@@ -133,6 +191,8 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
   }
   let rootPath: string | undefined;
   let principalId: string | undefined;
+  let principalKind: 'remote_owner' | 'capability_provider' = 'remote_owner';
+  let principalKindSpecified = false;
   let credentialId: string | undefined;
   const operationGrants: string[] = [];
   let canPublishClientCapabilities = false;
@@ -149,6 +209,7 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
     }
     if (
       argument === '--root' ||
+      argument === '--kind' ||
       argument === '--principal' ||
       argument === '--grant' ||
       argument === '--credential'
@@ -156,6 +217,13 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
       const parsed = optionValue(argv, index, argument);
       if (typeof parsed !== 'string') return parsed;
       if (argument === '--root') rootPath = parsed;
+      if (argument === '--kind') {
+        if (parsed !== 'remote-owner' && parsed !== 'capability-provider') {
+          return error('--kind must be remote-owner or capability-provider');
+        }
+        principalKind = parsed === 'remote-owner' ? 'remote_owner' : 'capability_provider';
+        principalKindSpecified = true;
+      }
       if (argument === '--principal') principalId = parsed;
       if (argument === '--grant') operationGrants.push(parsed);
       if (argument === '--credential') credentialId = parsed;
@@ -166,11 +234,25 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
   }
   if (action === 'issue') {
     if (!principalId) return error('--principal is required');
-    if (operationGrants.length === 0) return error('At least one --grant is required');
     if (credentialId) return error('--credential is only valid for access revoke');
+    if (principalKind === 'capability_provider') {
+      const requiredGrants = ['client.capability.replace', 'client.capability.unregister'];
+      if (canUseHostPaths) return error('A capability provider cannot use Host paths');
+      if (operationGrants.length === 0) operationGrants.push(...requiredGrants);
+      if (
+        operationGrants.length !== requiredGrants.length ||
+        requiredGrants.some((grant) => !operationGrants.includes(grant))
+      ) {
+        return error('A capability provider may grant only Client Capability publication');
+      }
+      canPublishClientCapabilities = true;
+    } else if (operationGrants.length === 0) {
+      return error('At least one --grant is required');
+    }
     return {
       kind: 'runtime-host-access-issue',
       ...(rootPath ? { rootPath } : {}),
+      principalKind,
       principalId,
       operationGrants,
       canPublishClientCapabilities,
@@ -180,6 +262,7 @@ function parseAccessCommand(argv: string[]): RuntimeHostCliCommand {
   if (!credentialId) return error('--credential is required');
   if (
     principalId ||
+    principalKindSpecified ||
     operationGrants.length > 0 ||
     canPublishClientCapabilities ||
     canUseHostPaths

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -16,6 +16,7 @@ export const AUTOMATION_CRON_EXPRESSION_MAX_CODE_UNITS = 100;
 export const AUTOMATION_CRON_EXPRESSION_MAX_BYTES = 300;
 export const AUTOMATION_LAST_ERROR_MAX_CODE_UNITS = 2_000;
 export const AUTOMATION_LAST_ERROR_MAX_BYTES = 6_000;
+export const AUTOMATION_MAX_CLIENT_CAPABILITY_REQUIREMENTS = 32;
 
 export interface AutomationTextLimit {
   readonly maxCodeUnits: number;
@@ -93,6 +94,18 @@ export interface AutomationExecutionTemplate {
   readonly orchestrationMode: OrchestrationMode;
 }
 
+export interface AutomationClientCapabilityRequirement {
+  readonly principalId: string;
+  readonly clientInstanceId: string;
+  readonly contractId: string;
+}
+
+export interface AutomationWaitingState {
+  readonly reason: 'client_capability_provider_unavailable';
+  readonly since: number;
+  readonly message: string;
+}
+
 export interface AutomationDefinition {
   id: string;
   kind: AutomationKind;
@@ -114,6 +127,10 @@ export interface AutomationDefinition {
   /** Cron definitions are globally visible and survive the creating Client. */
   durable?: boolean;
   deferredFireCount?: number;
+  /** Session-affine Client Capability contracts frozen when the Automation is created. */
+  capabilityRequirements?: readonly AutomationClientCapabilityRequirement[];
+  /** A transient prerequisite that must recover before the next fire can enter Runtime. */
+  waiting?: AutomationWaitingState;
   /** Present for Host-created cron definitions; legacy definitions acquire it before firing. */
   execution?: AutomationExecutionTemplate;
 }
@@ -133,7 +150,9 @@ export interface AutomationPendingFire {
   readonly status: 'admitted' | 'running';
   readonly admittedAt: number;
   readonly updatedAt: number;
+  readonly transientDeferredSince?: number;
   readonly startedAt?: number;
+  readonly capabilityRequirements?: readonly AutomationClientCapabilityRequirement[];
   readonly execution?: AutomationExecutionTemplate;
 }
 

--- a/packages/mcp/src/__fixtures__/stdio-server.ts
+++ b/packages/mcp/src/__fixtures__/stdio-server.ts
@@ -22,7 +22,13 @@ const server = new Server(
 server.setRequestHandler(ListToolsRequestSchema, async ({ params }) => {
   if (!params?.cursor) {
     return {
-      tools: [tool('echo', 'Echo text', true), tool('rich', 'Return rich content', true)],
+      tools: [
+        tool('echo', 'Echo text', true),
+        tool('rich', 'Return rich content', true),
+        ...(process.argv.includes('--environment')
+          ? [tool('environment', 'Read selected environment variables', true)]
+          : []),
+      ],
       nextCursor: 'page-2',
     };
   }
@@ -66,6 +72,23 @@ server.setRequestHandler(CallToolRequestSchema, async ({ params }) => {
   if (params.name === 'slow') {
     await new Promise((resolve) => setTimeout(resolve, 30_000));
     return { content: [{ type: 'text', text: 'too late' }] };
+  }
+  if (params.name === 'environment') {
+    const names = Array.isArray(params.arguments?.names) ? params.arguments.names : [];
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            Object.fromEntries(
+              names
+                .filter((name): name is string => typeof name === 'string')
+                .map((name) => [name, process.env[name] ?? null]),
+            ),
+          ),
+        },
+      ],
+    };
   }
   return { isError: true, content: [{ type: 'text', text: 'unknown tool' }] };
 });

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -123,6 +123,27 @@ describe('McpClientManager stdio E2E', () => {
     assert.deepEqual(status?.stderrTail, ['fixture startup failed: deliberate diagnostic']);
   });
 
+  test('excludes credential keys case-insensitively from a real stdio child', async () => {
+    const key = 'XDG_MAKA_PROVIDER_CREDENTIAL';
+    const previous = process.env[key];
+    process.env[key] = 'provider-secret';
+    const manager = new McpClientManager({
+      excludedStdioEnvironmentKeys: ['xdg_maka_provider_credential'],
+    });
+    managers.push(manager);
+    try {
+      await manager.sync(fixtureConfig(['--environment']));
+      const result = await manager.callTool('fixture', 'environment', { names: [key] });
+      assert.deepEqual(
+        JSON.parse(result.content[0]?.type === 'text' ? result.content[0].text : ''),
+        { [key]: null },
+      );
+    } finally {
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+  });
+
   test('cancels an in-flight installation connect without leaving tools visible', async () => {
     const manager = createManager();
     const sync = manager.sync(fixtureConfig(['--slow-start']));

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -33,6 +33,7 @@ export interface McpClientManagerOptions {
   clientVersion?: string;
   timeouts?: Partial<McpTimeouts>;
   now?: () => number;
+  excludedStdioEnvironmentKeys?: readonly string[];
 }
 
 export type McpManagerChangeListener = (status: McpServerStatus) => void;
@@ -72,6 +73,7 @@ export class McpClientManager {
   private readonly now: () => number;
   private readonly clientName: string;
   private readonly clientVersion: string;
+  private readonly excludedStdioEnvironmentKeys: readonly string[];
   private toolSnapshotRevisionValue = 0;
 
   constructor(options: McpClientManagerOptions = {}) {
@@ -79,6 +81,7 @@ export class McpClientManager {
     this.now = options.now ?? Date.now;
     this.clientName = options.clientName ?? 'maka';
     this.clientVersion = options.clientVersion ?? '0.1.0';
+    this.excludedStdioEnvironmentKeys = [...(options.excludedStdioEnvironmentKeys ?? [])];
   }
 
   onChange(listener: McpManagerChangeListener): () => void {
@@ -376,7 +379,11 @@ export class McpClientManager {
         command: entry.config.command,
         args: entry.config.args,
         cwd: entry.config.cwd,
-        env: buildStdioEnvironment(entry.config.env),
+        env: buildStdioEnvironment(
+          entry.config.env,
+          process.env,
+          this.excludedStdioEnvironmentKeys,
+        ),
         stderr: 'pipe',
       });
       attachStderrTail(transport, entry, () => {
@@ -563,6 +570,7 @@ function summarizeErrorContent(content: unknown[]): string {
 export function buildStdioEnvironment(
   explicit: Record<string, string> = {},
   source = process.env,
+  excludedKeys: readonly string[] = [],
 ): Record<string, string> {
   const result: Record<string, string> = {};
   const exact = new Set([
@@ -586,7 +594,12 @@ export function buildStdioEnvironment(
     if (value !== undefined && (exact.has(key) || key.startsWith('LC_') || key.startsWith('XDG_')))
       result[key] = value;
   }
-  return { ...result, ...explicit };
+  const environment = { ...result, ...explicit };
+  const excluded = new Set(excludedKeys.map((key) => key.toLowerCase()));
+  for (const key of Object.keys(environment)) {
+    if (excluded.has(key.toLowerCase())) delete environment[key];
+  }
+  return environment;
 }
 
 function attachStderrTail(

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -39,6 +39,7 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
       await connectRuntimeHost({ rootPath: root, surface: 'desktop', protocol: PROTOCOL }),
     );
     const issued = await local.request('access.credential.issue', {
+      principalKind: 'remote_owner',
       principalId: 'remote-device',
       operationGrants: [
         'session.catalog.query',
@@ -159,6 +160,7 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
             offerId: 'test',
             version: '1',
             affinity: 'call',
+            hostPathAccess: 'cwd',
             label: 'Test',
             tools: [
               {
@@ -173,6 +175,72 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
       (error: unknown) =>
         error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
     );
+    const providerIssued = await local.request('access.credential.issue', {
+      principalKind: 'capability_provider',
+      principalId: 'remote-provider',
+      operationGrants: ['client.capability.replace', 'client.capability.unregister'],
+      canPublishClientCapabilities: true,
+      canUseHostPaths: false,
+    });
+    const providerCredential = await consumeAccessCredentialDelivery(
+      root,
+      providerIssued.deliveryId,
+      providerIssued.credentialId,
+    );
+    const providerConnected = await connectRemoteRuntimeHost({
+      url,
+      credential: providerCredential,
+      expectedRootId: capability.rootId,
+      surface: 'capability-provider',
+      protocol: PROTOCOL,
+      clientInstanceId: 'remote-provider-instance',
+    });
+    assert.equal(providerConnected.kind, 'connected');
+    if (providerConnected.kind !== 'connected') assert.fail('Capability provider did not connect');
+    try {
+      await providerConnected.connection.replaceClientCapabilities({
+        offers: () => [
+          {
+            offerId: 'path-independent',
+            version: '1',
+            affinity: 'session',
+            hostPathAccess: 'none',
+            label: 'Path independent',
+            tools: [
+              {
+                serverId: 'remote',
+                name: 'inspect',
+                inputSchema: { type: 'object' },
+              },
+            ],
+          },
+        ],
+      });
+      await assert.rejects(
+        providerConnected.connection.replaceClientCapabilities({
+          offers: () => [
+            {
+              offerId: 'host-path',
+              version: '1',
+              affinity: 'session',
+              hostPathAccess: 'cwd',
+              label: 'Host path',
+              tools: [
+                {
+                  serverId: 'remote',
+                  name: 'inspect_path',
+                  inputSchema: { type: 'object' },
+                },
+              ],
+            },
+          ],
+        }),
+        (error: unknown) =>
+          error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
+      );
+    } finally {
+      await providerConnected.connection.close();
+    }
     assert.equal(
       (
         await remote.request('session.catalog.query', {
@@ -218,6 +286,7 @@ test('access credentials persist only as hashes and stay revoked after reload', 
     );
     const authority = await openRuntimeHostAccessAuthority(directory);
     const issued = await authority.issue({
+      principalKind: 'remote_owner',
       principalId: 'device-1',
       operationGrants: ['session.catalog.query'],
       canPublishClientCapabilities: false,
@@ -229,6 +298,17 @@ test('access credentials persist only as hashes and stay revoked after reload', 
       issued.credentialId,
     );
     assert.equal(authority.authenticate(credential)?.principalId, 'device-1');
+    assert.equal(authority.authenticate(credential)?.principalKind, 'remote_owner');
+    await assert.rejects(
+      authority.issue({
+        principalKind: 'capability_provider',
+        principalId: 'overprivileged-provider',
+        operationGrants: ['session.catalog.query'],
+        canPublishClientCapabilities: true,
+        canUseHostPaths: false,
+      }),
+      /may grant only Client Capability publication/u,
+    );
     assert.doesNotMatch(
       await readFile(join(directory, 'runtime-host-access.json'), 'utf8'),
       new RegExp(credential, 'u'),

--- a/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-coordinator.test.ts
@@ -28,6 +28,7 @@ import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-sto
 import {
   HostAutomationCoordinator,
   HostAutomationSessionBusyError,
+  type HostAutomationCoordinatorInput,
 } from '../server/automation-coordinator.js';
 import { HostAutomationFireCoordinator } from '../server/automation-fire-coordinator.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
@@ -246,7 +247,8 @@ describe('Host Automation coordinator', () => {
     await withHarness(
       async (harness) => {
         const automation = startedDefinition();
-        const fire = pendingFire();
+        const pending = pendingFire();
+        const fire = { ...pending, transientDeferredSince: pending.admittedAt };
         await harness.store.commit({
           expectedRevision: 0,
           automations: [automation],
@@ -291,7 +293,8 @@ describe('Host Automation coordinator', () => {
     await withHarness(
       async (harness) => {
         const automation = startedDefinition();
-        const fire = pendingFire();
+        const pending = pendingFire();
+        const fire = { ...pending, transientDeferredSince: pending.admittedAt };
         await harness.store.commit({
           expectedRevision: 0,
           automations: [automation],
@@ -331,7 +334,10 @@ describe('Host Automation coordinator', () => {
         await harness.coordinator.prepareRecovery();
         await harness.coordinator.recover();
         assert.equal(harness.rootInputs.length, 1);
-        assert.deepEqual((await harness.store.read()).pendingFires, [fire]);
+        const deferred = (await harness.store.read()).pendingFires[0];
+        assert.equal(deferred?.id, fire.id);
+        assert.equal(deferred?.runId, fire.runId);
+        assert.equal(deferred?.turnId, fire.turnId);
 
         harness.coordinator.start();
         harness.fireTimer();
@@ -448,6 +454,152 @@ describe('Host Automation coordinator', () => {
         assert.equal(harness.rootInputs.length, 0);
       },
       { readIncognito: async () => true },
+    );
+  });
+
+  test('persists provider waiting state and resumes with the frozen capability contract', async () => {
+    const requirement = {
+      principalId: 'automation-provider',
+      clientInstanceId: 'provider-instance',
+      contractId: 'provider-contract',
+    } as const;
+    let available = false;
+    await withHarness(
+      async (harness) => {
+        await harness.coordinator.prepareRecovery();
+        await harness.coordinator.recover();
+        harness.coordinator.start();
+        const created = await harness.coordinator.create({
+          kind: 'heartbeat',
+          name: 'provider task',
+          prompt: 'Use the provider.',
+          sessionId: 'creator-session',
+          schedule: { type: 'once', delaySeconds: 5 },
+          requiredCapabilityGroups: ['provider-contract'],
+        });
+        assert.ok(!('error' in created));
+        if ('error' in created) return;
+        assert.deepEqual(created.capabilityRequirements, [requirement]);
+        harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+
+        harness.fireTimer();
+        await waitFor('provider waiting state', async () => {
+          const automation = (await harness.store.read()).automations[0];
+          return automation?.waiting?.reason === 'client_capability_provider_unavailable';
+        });
+        assert.equal(harness.rootInputs.length, 0);
+
+        harness.now += DEFER_WINDOW_MS + 1;
+        harness.fireTimer();
+        await waitFor('persistent provider waiting state', async () => {
+          const automation = (await harness.store.read()).automations[0];
+          return automation?.status === 'active' && automation.waiting !== undefined;
+        });
+
+        available = true;
+        harness.fireTimer();
+        await waitFor(
+          'provider-backed Automation admission',
+          () => harness.rootInputs.length === 1,
+        );
+        harness.finishRun();
+        await waitFor('provider-backed Automation settlement', async () => {
+          const automation = (await harness.store.read()).automations[0];
+          return automation?.status === 'completed' && automation.waiting === undefined;
+        });
+      },
+      {
+        clientCapabilities: {
+          requirementsForAutomation: async (_sessionId, groups) => {
+            assert.deepEqual(groups, ['provider-contract']);
+            return { ok: true, requirements: [requirement] };
+          },
+          checkAutomationRequirements: async (requirements) => {
+            assert.deepEqual(requirements, [requirement]);
+            return available
+              ? { ok: true }
+              : { ok: false, message: 'Capability provider is offline' };
+          },
+          bindAutomationSession: async (_sessionId, requirements) => {
+            assert.deepEqual(requirements, [requirement]);
+            return available
+              ? { ok: true }
+              : { ok: false, message: 'Capability provider is offline' };
+          },
+        },
+      },
+    );
+  });
+
+  test('keeps an admitted fire pending beyond the retry window while its provider is offline', async () => {
+    const requirement = {
+      principalId: 'automation-provider',
+      clientInstanceId: 'provider-instance',
+      contractId: 'provider-contract',
+    } as const;
+    let available = false;
+    await withHarness(
+      async (harness) => {
+        await harness.coordinator.prepareRecovery();
+        await harness.coordinator.recover();
+        harness.coordinator.start();
+        const created = await harness.coordinator.create({
+          kind: 'heartbeat',
+          name: 'provider task',
+          prompt: 'Use the provider.',
+          sessionId: 'creator-session',
+          schedule: { type: 'once', delaySeconds: 5 },
+          requiredCapabilityGroups: ['provider-contract'],
+        });
+        assert.ok(!('error' in created));
+        if ('error' in created) return;
+        harness.now = created.nextFireAt ?? assert.fail('Expected a scheduled fire');
+
+        harness.fireTimer();
+        await waitFor('admitted provider waiting state', async () => {
+          const snapshot = await harness.store.read();
+          return (
+            snapshot.pendingFires.length === 1 &&
+            snapshot.automations[0]?.waiting?.reason === 'client_capability_provider_unavailable'
+          );
+        });
+        harness.now += DEFER_WINDOW_MS + 1;
+        harness.fireTimer();
+        await waitFor('durable admitted provider waiting state', async () => {
+          const snapshot = await harness.store.read();
+          return snapshot.pendingFires.length === 1 && snapshot.automations[0]?.status === 'active';
+        });
+
+        available = true;
+        harness.rootMode = 'busy';
+        harness.fireTimer();
+        await waitFor('post-provider transient deferral', async () => {
+          const snapshot = await harness.store.read();
+          return (
+            harness.rootInputs.length === 1 &&
+            snapshot.pendingFires[0]?.transientDeferredSince === harness.now
+          );
+        });
+        assert.equal((await harness.store.read()).automations[0]?.status, 'active');
+
+        harness.rootMode = 'run';
+        harness.fireTimer();
+        await waitFor('provider-backed admitted fire', () => harness.rootInputs.length === 2);
+        harness.finishRun();
+        await waitFor(
+          'provider-backed admitted fire settlement',
+          async () => (await harness.store.read()).automations[0]?.status === 'completed',
+        );
+        assert.equal((await harness.store.read()).automations[0]?.fireCount, 1);
+      },
+      {
+        clientCapabilities: {
+          requirementsForAutomation: async () => ({ ok: true, requirements: [requirement] }),
+          checkAutomationRequirements: async () => ({ ok: true }),
+          bindAutomationSession: async () =>
+            available ? { ok: true } : { ok: false, message: 'Capability provider is offline' },
+        },
+      },
     );
   });
 
@@ -650,6 +802,7 @@ describe('Host Automation coordinator', () => {
         listPendingFires: async () => [],
         listDueAutomations: async () => [due],
         recordDeferredFire: async () => false,
+        recordPrerequisiteWaiting: async () => false,
         admitFire: async () => {
           admitEntered.resolve();
           await releaseAdmission.promise;
@@ -657,6 +810,7 @@ describe('Host Automation coordinator', () => {
         },
         assertPendingFire: async () => undefined,
         recordFireDeferred: async () => undefined,
+        recordFirePrerequisiteWaiting: async () => undefined,
         failFire: async () => undefined,
         markFireRunning: async () => undefined,
         settleFire: async () => undefined,
@@ -683,6 +837,7 @@ describe('Host Automation coordinator', () => {
         },
       },
       runtimePolicy: runtimePolicyStores(),
+      clientCapabilities: availableClientCapabilities(),
       isSessionActive: () => false,
       acquireResidency: () => ({ release() {} }),
       requestDrain: () => undefined,
@@ -895,6 +1050,7 @@ async function withHarness(
     rootMode?: Harness['rootMode'];
     readIncognito?: () => Promise<boolean>;
     creatorHeader?: Partial<SessionHeader>;
+    clientCapabilities?: HostAutomationCoordinatorInput['clientCapabilities'];
   } = {},
 ): Promise<void> {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-automation-'));
@@ -1011,6 +1167,7 @@ async function withHarness(
     runtime,
     root,
     runtimePolicy: runtimePolicyStores(options.readIncognito),
+    clientCapabilities: options.clientCapabilities ?? availableClientCapabilities(),
     isSessionActive: () => false,
     sessionAdmission: new SessionAdmissionGate(),
     acquireResidency: () => {
@@ -1050,6 +1207,14 @@ async function withHarness(
     if (!owner.closed) await owner.close();
     await rm(base, { recursive: true, force: true });
   }
+}
+
+function availableClientCapabilities() {
+  return {
+    requirementsForAutomation: async () => ({ ok: true as const, requirements: [] }),
+    checkAutomationRequirements: async () => ({ ok: true as const }),
+    bindAutomationSession: async () => ({ ok: true as const }),
+  };
 }
 
 function sessionHeader(id: string, input: Partial<SessionHeader> = {}): SessionHeader {

--- a/packages/runtime-host/src/__tests__/automation-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-protocol.test.ts
@@ -63,6 +63,7 @@ describe('Automation protocol', () => {
       schedule: { type: 'once' as const, delaySeconds: 30 },
       maxFires: 1,
       durable: true,
+      requiredCapabilityGroups: ['client_contract'],
     };
     assert.deepEqual(decodeAutomationMutateInput(create), create);
     for (const kind of ['delete', 'pause', 'resume'] as const) {
@@ -96,6 +97,8 @@ describe('Automation protocol', () => {
       createInput({ schedule: { type: 'interval', seconds: 9 } }),
       createInput({ schedule: { type: 'once', delaySeconds: 86_401 } }),
       createInput({ schedule: { type: 'cron', expression: '*'.repeat(101) } }),
+      createInput({ requiredCapabilityGroups: ['client_contract', 'client_contract'] }),
+      createInput({ requiredCapabilityGroups: Array.from({ length: 33 }, (_, i) => `group_${i}`) }),
     ]) {
       assertInvalid(() => decodeAutomationMutateInput(input));
     }
@@ -194,6 +197,11 @@ function projection(): AutomationProjection {
     durable: true,
     deferredFireCount: 0,
     firePending: false,
+    waiting: {
+      reason: 'client_capability_provider_unavailable',
+      since: 2,
+      message: 'Capability provider is offline',
+    },
   };
 }
 

--- a/packages/runtime-host/src/__tests__/automation-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/automation-two-client-uds.test.ts
@@ -64,6 +64,11 @@ test('two Clients share one revision-pinned Automation authority', async () => {
           executeRoot: async () => assert.fail('No Automation fire is expected in this test'),
         },
         runtimePolicy: runtimePolicyStores(),
+        clientCapabilities: {
+          requirementsForAutomation: async () => ({ ok: true, requirements: [] }),
+          checkAutomationRequirements: async () => ({ ok: true }),
+          bindAutomationSession: async () => ({ ok: true }),
+        },
         isSessionActive: () => false,
         sessionAdmission: new SessionAdmissionGate(),
         acquireResidency: context.acquireResidency,

--- a/packages/runtime-host/src/__tests__/capability-provider-service.test.ts
+++ b/packages/runtime-host/src/__tests__/capability-provider-service.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { ClientCapabilityChannel } from '../client/client-capability-channel.js';
+import type { ClientCapabilityProvider } from '../client/client-capability.js';
+import { startRuntimeHostCapabilityProviderService } from '../client/capability-provider-service.js';
+import type { ClientCapabilityReplaceInput } from '../protocol/index.js';
+
+test('capability publication degrades in place and recovers from an invalid snapshot', async () => {
+  const connections: FakeConnection[] = [];
+  let provider: ClientCapabilityProvider | undefined = providerWithOffers(1);
+  const service = await startRuntimeHostCapabilityProviderService({
+    connect: async () => {
+      const connection = new FakeConnection();
+      connections.push(connection);
+      return connection;
+    },
+    createProvider: () => provider,
+    backoff: { minMs: 0, maxMs: 0, stableConnectionMs: 0 },
+  });
+
+  assert.equal(connections[0]?.replacements.length, 1);
+  assert.equal(connections[0]?.replacements[0]?.offers[0]?.offerId, 'offer-0');
+
+  provider = providerWithOffers(33);
+  await assert.rejects(service.refresh(), /Invalid Client Capability offers/u);
+  assert.equal(connections.length, 1);
+  assert.equal(connections[0]?.unregistrations, 1);
+
+  provider = providerWithOffers(1);
+  await service.refresh();
+  assert.equal(connections[0]?.replacements.length, 2);
+
+  connections[0]?.disconnect();
+  await waitFor(() => connections.length === 2);
+  assert.equal(connections[1]?.replacements.length, 1);
+
+  await service.close();
+  assert.equal(connections[1]?.closeCalls, 1);
+});
+
+test('capability provider startup rejects an invalid initial snapshot', async () => {
+  const connection = new FakeConnection();
+  await assert.rejects(
+    startRuntimeHostCapabilityProviderService({
+      connect: async () => connection,
+      createProvider: () => providerWithOffers(33),
+    }),
+    /Invalid Client Capability offers/u,
+  );
+  assert.equal(connection.closeCalls, 1);
+});
+
+class FakeConnection {
+  readonly #closed = deferred();
+  readonly #channel: ClientCapabilityChannel;
+  readonly replacements: ClientCapabilityReplaceInput[] = [];
+  unregistrations = 0;
+  closeCalls = 0;
+
+  constructor() {
+    this.#channel = new ClientCapabilityChannel({
+      write: async () => undefined,
+      replace: async (input) => {
+        this.replacements.push(input);
+        return { registrationId: input.registrationId, revision: this.replacements.length };
+      },
+      unregister: async (input) => {
+        this.unregistrations += 1;
+        return { registrationId: input.registrationId, revision: this.unregistrations };
+      },
+      onFailure: (error) => {
+        throw error;
+      },
+    });
+  }
+
+  readonly closed = this.#closed.promise;
+
+  replaceClientCapabilities(provider: ClientCapabilityProvider, timeoutMs = 1_000) {
+    return this.#channel.replace(provider, timeoutMs);
+  }
+
+  unregisterClientCapabilities(timeoutMs = 1_000) {
+    return this.#channel.unregister(timeoutMs);
+  }
+
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    this.#channel.close(new Error('Connection closed'));
+    this.#closed.resolve();
+  }
+
+  disconnect(): void {
+    this.#channel.close(new Error('Connection lost'));
+    this.#closed.resolve();
+  }
+}
+
+function providerWithOffers(count: number): ClientCapabilityProvider {
+  return {
+    offers: () =>
+      Array.from({ length: count }, (_, index) => ({
+        offerId: `offer-${index}`,
+        version: '0',
+        affinity: 'session' as const,
+        hostPathAccess: 'none' as const,
+        label: `Offer ${index}`,
+        tools: [
+          {
+            serverId: `server-${index}`,
+            name: 'echo',
+            inputSchema: { type: 'object' },
+          },
+        ],
+      })),
+  };
+}
+
+function deferred(): { readonly promise: Promise<void>; resolve(): void } {
+  let resolvePromise!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+  return { promise, resolve: resolvePromise };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 1));
+  }
+  assert.fail('Timed out waiting for reconnect');
+}

--- a/packages/runtime-host/src/__tests__/client-capability-channel.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-channel.test.ts
@@ -12,6 +12,7 @@ test('Client Capability channel closes a provider after its final registration i
         offerId: 'fixture',
         version: '0',
         affinity: 'call',
+        hostPathAccess: 'cwd',
         label: 'Fixture',
         tools: [
           {

--- a/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
+import { createManagedExecutionBoundary, createWorkspaceWritePermissionProfile } from '@maka/core';
 import { ToolOutcomeUnknownError } from '@maka/core/events';
 import type { McpCallResult } from '@maka/core/mcp';
 import type { ClientCapabilityReplaceInput } from '../protocol/index.js';
@@ -72,6 +73,147 @@ describe('Host Client Capability coordinator', () => {
     assert.equal(unregistered.ok, true);
     assert.equal(coordinator.snapshotForSession('session-a'), undefined);
     connection.close();
+    await coordinator.close();
+  });
+
+  test('does not trust a self-declared provider or disclose Host cwd', async () => {
+    const coordinator = createCoordinator();
+    let observedCall: unknown;
+    let connection!: ClientCapabilityConnection;
+    connection = coordinator.attachConnection(clientCapabilityConnectionIdentity('connection-a'), {
+      send: async (frame) => {
+        if (frame.kind !== 'client.capability.call') return;
+        observedCall = frame;
+        connection.accept({
+          kind: 'client.capability.accepted',
+          invocationId: frame.invocationId,
+        });
+        connection.accept({
+          kind: 'client.capability.result',
+          invocationId: frame.invocationId,
+          result: textResult('path independent'),
+        });
+      },
+    });
+    const replaced = await coordinator.handlers['client.capability.replace'](
+      {
+        registrationId: 'registration-a',
+        offers: [
+          {
+            offerId: 'path-independent',
+            version: '0',
+            affinity: 'session',
+            hostPathAccess: 'none',
+            label: 'Path independent',
+            tools: [
+              {
+                serverId: 'remote',
+                name: 'inspect',
+                inputSchema: { type: 'object' },
+              },
+            ],
+          },
+        ],
+      },
+      { ...connectionContext('connection-a'), surface: 'capability-provider' },
+    );
+    assert.equal(replaced.ok, true);
+    assert.deepEqual(await coordinator.bindSession('session-a', 'connection-a'), { ok: true });
+    const snapshot = coordinator.snapshotForSession('session-a');
+    assert.ok(snapshot);
+    assert.equal(snapshot.tools[0]?.categoryHint, 'client_capability');
+    await invoke(snapshot.tools[0]);
+    assert.ok(isRecord(observedCall));
+    assert.equal(Object.hasOwn(observedCall, 'cwd'), false);
+    snapshot.release();
+    await connection.close();
+    await coordinator.close();
+  });
+
+  test('trusted provider tools execute remotely without inheriting Host authority', async () => {
+    const coordinator = createCoordinator();
+    let observedCall: unknown;
+    let connection!: ClientCapabilityConnection;
+    connection = coordinator.attachConnection(
+      clientCapabilityConnectionIdentity('connection-a', 'connection-a', 'test-principal', true),
+      {
+        send: async (frame) => {
+          if (frame.kind !== 'client.capability.call') return;
+          observedCall = frame;
+          connection.accept({
+            kind: 'client.capability.accepted',
+            invocationId: frame.invocationId,
+          });
+          connection.accept({
+            kind: 'client.capability.result',
+            invocationId: frame.invocationId,
+            result: textResult('remote result'),
+          });
+        },
+      },
+    );
+    const input: ClientCapabilityReplaceInput = {
+      registrationId: 'registration-a',
+      offers: [
+        {
+          offerId: 'remote-provider',
+          version: '0',
+          affinity: 'session',
+          hostPathAccess: 'none',
+          label: 'Remote provider',
+          tools: [
+            {
+              serverId: 'remote',
+              name: 'inspect',
+              inputSchema: { type: 'object' },
+            },
+          ],
+        },
+      ],
+    };
+    const providerContext = {
+      ...connectionContext('connection-a'),
+      surface: 'capability-provider' as const,
+    };
+    assert.equal(
+      (await coordinator.handlers['client.capability.replace'](input, providerContext)).ok,
+      true,
+    );
+    assert.deepEqual(await coordinator.bindSession('session-a', 'connection-a'), { ok: true });
+    const snapshot = coordinator.snapshotForSession('session-a');
+    assert.ok(snapshot);
+    const tool = snapshot.tools[0] ?? assert.fail('Expected trusted provider tool');
+    assert.equal(tool.categoryHint, 'custom_tool');
+    const result = await tool.impl(
+      {},
+      {
+        sessionId: 'session-a',
+        turnId: 'turn-a',
+        cwd: '/host/workspace',
+        toolCallId: 'tool-call-a',
+        executionBoundary: createManagedExecutionBoundary(
+          createWorkspaceWritePermissionProfile(),
+          0,
+        ),
+        abortSignal: new AbortController().signal,
+        emitOutput: () => undefined,
+      },
+    );
+    assert.deepEqual(result, textResult('remote result'));
+    assert.ok(isRecord(observedCall));
+    assert.equal(Object.hasOwn(observedCall, 'cwd'), false);
+
+    const rejected = await coordinator.handlers['client.capability.replace'](
+      {
+        ...input,
+        registrationId: 'registration-b',
+        offers: input.offers.map((offer) => ({ ...offer, affinity: 'call' as const })),
+      },
+      providerContext,
+    );
+    assert.equal(rejected.ok, false);
+    snapshot.release();
+    await connection.close();
     await coordinator.close();
   });
 
@@ -918,6 +1060,53 @@ describe('Host Client Capability coordinator', () => {
       }
     }
   });
+
+  test('restores frozen Automation requirements only from the same provider contract', async () => {
+    const coordinator = createCoordinator();
+    const identity = (connectionId: string) =>
+      clientCapabilityConnectionIdentity(connectionId, 'stable-provider');
+    const first = coordinator.attachConnection(identity('connection-a'), { send: async () => {} });
+    await replace(coordinator, 'connection-a', 'registration-a', 'inspect');
+    assert.deepEqual(await coordinator.bindSession('creator-session', 'connection-a'), {
+      ok: true,
+    });
+    const creatorSnapshot = coordinator.snapshotForSession('creator-session');
+    assert.ok(creatorSnapshot);
+    const contractId = creatorSnapshot?.groups[0]?.id ?? assert.fail('Expected capability group');
+    creatorSnapshot.release();
+    const resolved = await coordinator.requirementsForAutomation('creator-session', [contractId]);
+    assert.equal(resolved.ok, true);
+    if (!resolved.ok) return;
+    const requirements = resolved.requirements;
+    assert.equal(requirements.length, 1);
+    assert.equal(requirements[0]?.clientInstanceId, 'stable-provider');
+    assert.deepEqual(await coordinator.requirementsForAutomation('creator-session', []), {
+      ok: true,
+      requirements: [],
+    });
+    assert.equal(
+      (await coordinator.requirementsForAutomation('creator-session', ['client_missing'])).ok,
+      false,
+    );
+
+    await first.close();
+    assert.equal((await coordinator.checkAutomationRequirements(requirements)).ok, false);
+
+    const second = coordinator.attachConnection(identity('connection-b'), { send: async () => {} });
+    await replace(coordinator, 'connection-b', 'registration-b', 'inspect');
+    assert.deepEqual(await coordinator.checkAutomationRequirements(requirements), { ok: true });
+    assert.deepEqual(await coordinator.bindAutomationSession('automation-session', requirements), {
+      ok: true,
+    });
+    const restored = coordinator.snapshotForSession('automation-session');
+    assert.deepEqual(restored?.registrationIds, ['registration-b']);
+    restored?.release();
+
+    await replace(coordinator, 'connection-b', 'registration-c', 'inspect', '1');
+    assert.equal((await coordinator.checkAutomationRequirements(requirements)).ok, false);
+    await second.close();
+    await coordinator.close();
+  });
 });
 
 async function assertLossClassification(
@@ -994,6 +1183,7 @@ function replacementInput(
         offerId,
         version,
         affinity,
+        hostPathAccess: 'cwd',
         label: 'Opaque capability',
         description: 'Known only to the provider.',
         tools: [

--- a/packages/runtime-host/src/__tests__/client-capability-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-protocol.test.ts
@@ -23,6 +23,7 @@ describe('Client Capability protocol', () => {
               offerId: 'not_known_by_host',
               version: 'vendor-v3',
               affinity: 'call',
+              hostPathAccess: 'none',
               label: 'Vendor-defined capability',
               tools: [
                 {
@@ -49,6 +50,7 @@ describe('Client Capability protocol', () => {
               offerId: 'not_known_by_host',
               version: 'vendor-v3',
               affinity: 'call',
+              hostPathAccess: 'none',
               label: 'Vendor-defined capability',
               tools: [
                 {
@@ -78,7 +80,6 @@ describe('Client Capability protocol', () => {
         sessionId: 'session',
         turnId: 'turn',
         toolCallId: 'tool-call',
-        cwd: '/workspace',
       }),
       {
         kind: 'client.capability.call',
@@ -91,7 +92,6 @@ describe('Client Capability protocol', () => {
         sessionId: 'session',
         turnId: 'turn',
         toolCallId: 'tool-call',
-        cwd: '/workspace',
       },
     );
     assert.deepEqual(
@@ -355,11 +355,17 @@ describe('Client Capability protocol', () => {
     );
   });
 
-  test('requires explicit affinity and rejects prototype-backed schema types', () => {
+  test('requires explicit affinity and Host path access', () => {
     const missingAffinity = offer('fixture', 'inspect') as Record<string, unknown>;
     delete missingAffinity.affinity;
     assert.throws(
       () => decodeClientFrame(replaceFrame([missingAffinity])),
+      (error: unknown) => error instanceof RuntimeHostProtocolError,
+    );
+    const missingHostPathAccess = offer('fixture', 'inspect') as Record<string, unknown>;
+    delete missingHostPathAccess.hostPathAccess;
+    assert.throws(
+      () => decodeClientFrame(replaceFrame([missingHostPathAccess])),
       (error: unknown) => error instanceof RuntimeHostProtocolError,
     );
     assert.throws(
@@ -443,6 +449,7 @@ function offer(offerId: string, toolName: string) {
     offerId,
     version: '0',
     affinity: 'call',
+    hostPathAccess: 'cwd',
     label: offerId,
     tools: [
       {

--- a/packages/runtime-host/src/__tests__/client-capability-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-uds.test.ts
@@ -91,6 +91,7 @@ test('unknown Client Capability loads, invokes, and rebinds after UDS reconnect'
             offerId: 'bypassed',
             version: '0',
             affinity: 'call',
+            hostPathAccess: 'cwd',
             label: 'Bypassed',
             tools: [
               {
@@ -114,6 +115,7 @@ test('unknown Client Capability loads, invokes, and rebinds after UDS reconnect'
           offerId: 'fixture_unknown',
           version: '0',
           affinity: 'session',
+          hostPathAccess: 'cwd',
           label: 'Unknown fixture',
           description: 'A capability the Host source does not enumerate.',
           tools: [

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -485,6 +485,7 @@ test('a ready composition attaches the authenticated Client identity once', asyn
         connectionId: 'stable-provider-connection',
         principalId: 'local_os_user',
         clientInstanceId: 'test-client',
+        unattended: false,
       },
     ]);
   } finally {

--- a/packages/runtime-host/src/__tests__/execution-host-continuation.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host-continuation.test.ts
@@ -447,6 +447,7 @@ function resumeFixtureProvider(
         offerId: 'resume_fixture',
         version: '0',
         affinity: 'session',
+        hostPathAccess: 'cwd',
         label: 'Resume fixture',
         tools: toolNames.map((name) => ({
           serverId,

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -395,6 +395,7 @@ test('production backend creation continues after a Session Client Capability is
           offerId: 'browser',
           version: '0',
           affinity: 'session',
+          hostPathAccess: 'cwd',
           label: 'Browser',
           tools: [
             {
@@ -482,6 +483,7 @@ test('production backend preserves coordinator Client Capability semantics acros
             offerId: 'hosted-browser',
             version: '0',
             affinity: 'session',
+            hostPathAccess: 'cwd',
             label: 'Hosted Browser',
             tools: [
               {

--- a/packages/runtime-host/src/__tests__/fixtures/client-capability.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/client-capability.ts
@@ -4,6 +4,7 @@ export function clientCapabilityConnectionIdentity(
   connectionId: string,
   clientInstanceId = connectionId,
   principalId = 'test-principal',
+  unattended = false,
 ): ClientCapabilityConnectionIdentity {
-  return { connectionId, principalId, clientInstanceId };
+  return { connectionId, principalId, clientInstanceId, unattended };
 }

--- a/packages/runtime-host/src/__tests__/fixtures/connect-client.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/connect-client.ts
@@ -59,5 +59,5 @@ process.on('message', (message) => {
 process.once('disconnect', close);
 
 function isClientSurface(value: string | undefined): value is ClientSurface {
-  return value === 'desktop' || value === 'tui';
+  return value === 'desktop' || value === 'tui' || value === 'capability-provider';
 }

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -47,7 +47,7 @@ describe('Runtime Host bootstrap protocol', () => {
 
   test('keeps the experimental protocol at v0 with the declared authority operations', () => {
     assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
-    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 12);
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 13);
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
       'access.credential.issue',
       'access.credential.revoke',

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -2839,6 +2839,7 @@ test('Client Capability ambiguity fails before durable root admission', async ()
               offerId: 'opaque',
               version: '0',
               affinity: 'session',
+              hostPathAccess: 'cwd',
               label: 'Opaque',
               tools: [
                 {
@@ -2921,6 +2922,7 @@ test('an exact active retry preserves the Client Capability admission binding', 
               offerId: 'browser',
               version: '0',
               affinity: 'turn',
+              hostPathAccess: 'cwd',
               label: 'Browser',
               tools: [
                 {
@@ -3015,6 +3017,7 @@ test('mixed-Client queued follow-ups preserve each submitting connection through
               offerId: 'browser',
               version: '0',
               affinity: 'turn',
+              hostPathAccess: 'cwd',
               label: 'Browser',
               tools: [
                 {
@@ -3188,6 +3191,7 @@ async function assertFollowupCapabilityRebinding(affinity: 'call' | 'turn'): Pro
             offerId: 'session-browser',
             version: '0',
             affinity: 'session',
+            hostPathAccess: 'cwd',
             label: 'Session browser',
             tools: [
               {
@@ -3214,6 +3218,7 @@ async function assertFollowupCapabilityRebinding(affinity: 'call' | 'turn'): Pro
               offerId: 'ephemeral-browser',
               version: '0',
               affinity,
+              hostPathAccess: 'cwd',
               label: 'Ephemeral browser',
               tools: [
                 {
@@ -3335,6 +3340,7 @@ test('an exact terminal retry does not require a live Client Capability binding'
             offerId: 'opaque',
             version: '0',
             affinity: 'session',
+            hostPathAccess: 'cwd',
             label: 'Opaque',
             tools: [
               {
@@ -4411,6 +4417,7 @@ async function registerSessionCapability(
           offerId: 'resume_fixture',
           version: '0',
           affinity: 'session',
+          hostPathAccess: 'cwd',
           label: 'Resume fixture',
           tools: toolNames.map((name) => ({
             serverId: 'resume_fixture',

--- a/packages/runtime-host/src/__tests__/websocket-listener.test.ts
+++ b/packages/runtime-host/src/__tests__/websocket-listener.test.ts
@@ -22,6 +22,7 @@ test('WebSocket admission, health, Origin, and message policy fail closed', {
   const directory = await mkdtemp(join(tmpdir(), 'maka-websocket-listener-'));
   const authority = await openRuntimeHostAccessAuthority(directory);
   const issued = await authority.issue({
+    principalKind: 'remote_owner',
     principalId: 'native-client',
     operationGrants: ['session.catalog.query'],
     canPublishClientCapabilities: false,

--- a/packages/runtime-host/src/client/capability-provider-service.ts
+++ b/packages/runtime-host/src/client/capability-provider-service.ts
@@ -1,0 +1,181 @@
+import type { ClientCapabilityProvider } from './client-capability.js';
+import type { RuntimeHostConnection } from './connection.js';
+import { decodeClientCapabilityReplaceInput } from '../protocol/index.js';
+import {
+  startRuntimeHostReconnectLifecycle,
+  type RuntimeHostReconnectBackoff,
+  type RuntimeHostReconnectLifecycle,
+  type RuntimeHostReconnectResource,
+} from './reconnect-lifecycle.js';
+
+interface PublishedCapabilityConnection extends RuntimeHostReconnectResource {
+  refresh(): Promise<void>;
+}
+
+type CapabilityProviderConnection = Pick<
+  RuntimeHostConnection,
+  'closed' | 'replaceClientCapabilities' | 'unregisterClientCapabilities' | 'close'
+>;
+
+class CapabilityProviderPublicationError extends Error {
+  readonly name = 'CapabilityProviderPublicationError';
+
+  constructor(cause: unknown) {
+    super(cause instanceof Error ? cause.message : String(cause), { cause });
+  }
+}
+
+export interface RuntimeHostCapabilityProviderService {
+  readonly closed: Promise<void>;
+  refresh(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export async function startRuntimeHostCapabilityProviderService(input: {
+  readonly connect: (signal: AbortSignal) => Promise<CapabilityProviderConnection>;
+  readonly createProvider: () => ClientCapabilityProvider | undefined;
+  readonly backoff?: RuntimeHostReconnectBackoff;
+  readonly onReconnectError?: (error: Error) => void;
+  readonly onPublicationError?: (error: Error) => void;
+  readonly onFatalError?: (error: Error) => void;
+}): Promise<RuntimeHostCapabilityProviderService> {
+  let established = false;
+  const lifecycle = await startRuntimeHostReconnectLifecycle({
+    connect: async (signal) => {
+      const connection = await input.connect(signal);
+      const published = new PublishedCapabilityConnectionImpl(connection, input.createProvider);
+      try {
+        signal.throwIfAborted();
+        await published.refresh();
+        signal.throwIfAborted();
+        return published;
+      } catch (error) {
+        if (error instanceof CapabilityProviderPublicationError) {
+          if (!established) {
+            await published.close().catch(() => undefined);
+            throw error;
+          }
+          input.onPublicationError?.(error);
+          return published;
+        }
+        await published.close().catch(() => undefined);
+        throw error;
+      }
+    },
+    ...(input.backoff ? { backoff: input.backoff } : {}),
+    ...(input.onReconnectError ? { onReconnectError: input.onReconnectError } : {}),
+    ...(input.onFatalError ? { onFatalError: input.onFatalError } : {}),
+  });
+  established = true;
+  return new RuntimeHostCapabilityProviderServiceImpl(lifecycle);
+}
+
+class RuntimeHostCapabilityProviderServiceImpl implements RuntimeHostCapabilityProviderService {
+  readonly closed: Promise<void>;
+  readonly #lifecycle: RuntimeHostReconnectLifecycle<PublishedCapabilityConnection>;
+  #refreshQueue = Promise.resolve();
+
+  constructor(lifecycle: RuntimeHostReconnectLifecycle<PublishedCapabilityConnection>) {
+    this.#lifecycle = lifecycle;
+    this.closed = lifecycle.closed;
+  }
+
+  refresh(): Promise<void> {
+    const refresh = this.#refreshQueue
+      .catch(() => undefined)
+      .then(async () => {
+        await this.#lifecycle.current?.refresh();
+      });
+    this.#refreshQueue = refresh;
+    return refresh;
+  }
+
+  async close(): Promise<void> {
+    await this.#lifecycle.close();
+    await this.#refreshQueue.catch(() => undefined);
+  }
+}
+
+class PublishedCapabilityConnectionImpl implements PublishedCapabilityConnection {
+  readonly closed: Promise<void>;
+  readonly #connection: CapabilityProviderConnection;
+  readonly #createProvider: () => ClientCapabilityProvider | undefined;
+  #registered = false;
+
+  constructor(
+    connection: CapabilityProviderConnection,
+    createProvider: () => ClientCapabilityProvider | undefined,
+  ) {
+    this.#connection = connection;
+    this.#createProvider = createProvider;
+    this.closed = connection.closed;
+  }
+
+  async refresh(): Promise<void> {
+    let candidate: ClientCapabilityProvider | undefined;
+    let provider: ClientCapabilityProvider | undefined;
+    try {
+      candidate = this.#createProvider();
+      provider = candidate ? snapshotProvider(candidate) : undefined;
+    } catch (error) {
+      await closeProvider(candidate);
+      await this.#clearRegistration();
+      throw new CapabilityProviderPublicationError(error);
+    }
+    if (!provider) {
+      await this.#clearRegistration();
+      return;
+    }
+    try {
+      await this.#connection.replaceClientCapabilities(provider);
+      this.#registered = true;
+    } catch (error) {
+      await closeProvider(provider);
+      await this.#connection.close().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  close(): Promise<void> {
+    return this.#connection.close();
+  }
+
+  async #clearRegistration(): Promise<void> {
+    if (!this.#registered) return;
+    try {
+      await this.#connection.unregisterClientCapabilities();
+      this.#registered = false;
+    } catch (error) {
+      await this.#connection.close().catch(() => undefined);
+      throw error;
+    }
+  }
+}
+
+function snapshotProvider(provider: ClientCapabilityProvider): ClientCapabilityProvider {
+  const services = provider.services?.() ?? [];
+  const canonical = decodeClientCapabilityReplaceInput({
+    registrationId: '00000000-0000-4000-8000-000000000000',
+    offers: provider.offers(),
+    ...(services.length === 0 ? {} : { services }),
+  });
+  const call = provider.call?.bind(provider);
+  const callService = provider.callService?.bind(provider);
+  const close = provider.close?.bind(provider);
+  return {
+    offers: () => canonical.offers,
+    ...(canonical.services === undefined ? {} : { services: () => canonical.services ?? [] }),
+    ...(call ? { call } : {}),
+    ...(callService ? { callService } : {}),
+    ...(close ? { close } : {}),
+  };
+}
+
+async function closeProvider(provider: ClientCapabilityProvider | undefined): Promise<void> {
+  if (!provider) return;
+  try {
+    await provider.close?.();
+  } catch {
+    // The registration failed before the Host could own provider teardown.
+  }
+}

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -50,6 +50,10 @@ export {
   type ConnectOrSpawnRuntimeHostResult,
 } from './connect-or-spawn.js';
 export { type ClientCapabilityProvider } from './client-capability.js';
+export {
+  startRuntimeHostCapabilityProviderService,
+  type RuntimeHostCapabilityProviderService,
+} from './capability-provider-service.js';
 export { loadOrCreateRuntimeHostClientInstanceId } from './client-instance-identity.js';
 export { consumeAccessCredentialDelivery } from '../control/access-credential-delivery.js';
 export {

--- a/packages/runtime-host/src/protocol/access-authority.ts
+++ b/packages/runtime-host/src/protocol/access-authority.ts
@@ -5,6 +5,8 @@ import type { OperationKey } from './operations.js';
 
 export const ACCESS_CREDENTIAL_MAX_GRANTS = 256;
 
+export type AccessCredentialPrincipalKind = 'remote_owner' | 'capability_provider';
+
 const ACCESS_ERRORS = [
   'host_not_ready',
   'host_draining',
@@ -15,6 +17,7 @@ const ACCESS_ERRORS = [
 ] as const;
 
 export interface AccessCredentialIssueInput {
+  readonly principalKind: AccessCredentialPrincipalKind;
   readonly principalId: string;
   readonly operationGrants: readonly OperationKey[];
   readonly canPublishClientCapabilities: boolean;
@@ -24,6 +27,7 @@ export interface AccessCredentialIssueInput {
 export interface AccessCredentialIssueResult {
   readonly credentialId: string;
   readonly deliveryId: string;
+  readonly principalKind: AccessCredentialPrincipalKind;
   readonly principalId: string;
   readonly operationGrants: readonly OperationKey[];
   readonly canPublishClientCapabilities: boolean;
@@ -66,12 +70,14 @@ export const ACCESS_AUTHORITY_OPERATION_SPECS = {
 
 export function decodeAccessCredentialIssueInput(value: unknown): AccessCredentialIssueInput {
   const record = requireExactRecord(value, 'access credential issue input', [
+    'principalKind',
     'principalId',
     'operationGrants',
     'canPublishClientCapabilities',
     'canUseHostPaths',
   ]);
   return {
+    principalKind: principalKind(record.principalKind),
     principalId: principalId(record.principalId),
     operationGrants: operationGrants(record.operationGrants),
     canPublishClientCapabilities: boolean(
@@ -86,6 +92,7 @@ export function decodeAccessCredentialIssueResult(value: unknown): AccessCredent
   const record = requireExactRecord(value, 'access credential issue result', [
     'credentialId',
     'deliveryId',
+    'principalKind',
     'principalId',
     'operationGrants',
     'canPublishClientCapabilities',
@@ -94,6 +101,7 @@ export function decodeAccessCredentialIssueResult(value: unknown): AccessCredent
   return {
     credentialId: requireId(record.credentialId, 'credentialId'),
     deliveryId: requireId(record.deliveryId, 'deliveryId'),
+    principalKind: principalKind(record.principalKind),
     principalId: principalId(record.principalId),
     operationGrants: operationGrants(record.operationGrants),
     canPublishClientCapabilities: boolean(
@@ -102,6 +110,13 @@ export function decodeAccessCredentialIssueResult(value: unknown): AccessCredent
     ),
     canUseHostPaths: boolean(record.canUseHostPaths, 'canUseHostPaths'),
   };
+}
+
+function principalKind(value: unknown): AccessCredentialPrincipalKind {
+  if (value !== 'remote_owner' && value !== 'capability_provider') {
+    throw invalidProtocolFrame('Invalid access credential principalKind');
+  }
+  return value;
 }
 
 export function decodeAccessCredentialRevokeInput(value: unknown): AccessCredentialRevokeInput {

--- a/packages/runtime-host/src/protocol/automation.ts
+++ b/packages/runtime-host/src/protocol/automation.ts
@@ -2,6 +2,7 @@ import {
   AUTOMATION_CRON_EXPRESSION_LIMIT,
   AUTOMATION_CRON_EXPRESSION_MAX_BYTES as CORE_AUTOMATION_CRON_EXPRESSION_MAX_BYTES,
   AUTOMATION_LAST_ERROR_LIMIT,
+  AUTOMATION_MAX_CLIENT_CAPABILITY_REQUIREMENTS,
   AUTOMATION_NAME_LIMIT,
   AUTOMATION_NAME_MAX_BYTES as CORE_AUTOMATION_NAME_MAX_BYTES,
   AUTOMATION_PROMPT_LIMIT,
@@ -10,6 +11,7 @@ import {
   type AutomationKind,
   type AutomationSchedule,
   type AutomationStatus,
+  type AutomationWaitingState,
 } from '@maka/core/automation';
 import {
   requireCount,
@@ -29,6 +31,7 @@ export const AUTOMATION_NAME_MAX_BYTES = CORE_AUTOMATION_NAME_MAX_BYTES;
 export const AUTOMATION_PROMPT_MAX_BYTES = CORE_AUTOMATION_PROMPT_MAX_BYTES;
 export const AUTOMATION_CRON_EXPRESSION_MAX_BYTES = CORE_AUTOMATION_CRON_EXPRESSION_MAX_BYTES;
 export const AUTOMATION_MAX_FIRES = 10_000;
+export const AUTOMATION_MAX_CAPABILITY_REQUIREMENTS = AUTOMATION_MAX_CLIENT_CAPABILITY_REQUIREMENTS;
 
 const QUERY_ERRORS = [
   'host_not_ready',
@@ -67,6 +70,7 @@ export interface AutomationProjection {
   readonly durable: boolean;
   readonly deferredFireCount: number;
   readonly firePending: boolean;
+  readonly waiting: AutomationWaitingState | null;
 }
 
 export type AutomationQueryInput =
@@ -109,6 +113,7 @@ export type AutomationMutateInput =
       readonly schedule: AutomationSchedule;
       readonly maxFires?: number;
       readonly durable?: boolean;
+      readonly requiredCapabilityGroups?: readonly string[];
     }
   | {
       readonly kind: 'delete' | 'pause' | 'resume';
@@ -255,7 +260,7 @@ export function decodeAutomationMutateInput(value: unknown): AutomationMutateInp
       record,
       'Automation create input',
       ['kind', 'sessionId', 'automationKind', 'name', 'prompt', 'schedule'],
-      ['maxFires', 'durable'],
+      ['maxFires', 'durable', 'requiredCapabilityGroups'],
     );
     if (input.automationKind !== 'heartbeat' && input.automationKind !== 'cron') {
       throw invalidProtocolFrame('Invalid Automation kind');
@@ -268,6 +273,7 @@ export function decodeAutomationMutateInput(value: unknown): AutomationMutateInp
     if (!(input.durable === undefined || typeof input.durable === 'boolean')) {
       throw invalidProtocolFrame('Invalid durable flag');
     }
+    const requiredCapabilityGroups = decodeRequiredCapabilityGroups(input.requiredCapabilityGroups);
     return {
       kind: 'create',
       sessionId: requireEntityId(input.sessionId, 'sessionId'),
@@ -282,6 +288,7 @@ export function decodeAutomationMutateInput(value: unknown): AutomationMutateInp
       schedule: decodeAutomationSchedule(input.schedule),
       ...(maxFires === undefined ? {} : { maxFires }),
       ...(input.durable === undefined ? {} : { durable: input.durable }),
+      ...(requiredCapabilityGroups === undefined ? {} : { requiredCapabilityGroups }),
     };
   }
   if (record.kind === 'delete' || record.kind === 'pause' || record.kind === 'resume') {
@@ -297,6 +304,18 @@ export function decodeAutomationMutateInput(value: unknown): AutomationMutateInp
     };
   }
   throw invalidProtocolFrame('Invalid Automation mutation kind');
+}
+
+function decodeRequiredCapabilityGroups(value: unknown): readonly string[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length > AUTOMATION_MAX_CAPABILITY_REQUIREMENTS) {
+    throw invalidProtocolFrame('Invalid Automation required capability groups');
+  }
+  const groups = value.map((group) => requireEntityId(group, 'capability group id'));
+  if (new Set(groups).size !== groups.length) {
+    throw invalidProtocolFrame('Duplicate Automation required capability group');
+  }
+  return groups;
 }
 
 export function decodeAutomationMutateResult(value: unknown): AutomationMutateResult {
@@ -347,6 +366,7 @@ export function decodeAutomationProjection(value: unknown): AutomationProjection
     'durable',
     'deferredFireCount',
     'firePending',
+    'waiting',
   ]);
   if (record.kind !== 'heartbeat' && record.kind !== 'cron') {
     throw invalidProtocolFrame('Invalid Automation projection kind');
@@ -386,6 +406,27 @@ export function decodeAutomationProjection(value: unknown): AutomationProjection
     durable: record.durable,
     deferredFireCount: requireCount(record.deferredFireCount, 'deferredFireCount'),
     firePending: record.firePending,
+    waiting: record.waiting === null ? null : decodeAutomationWaitingState(record.waiting),
+  };
+}
+
+function decodeAutomationWaitingState(value: unknown): AutomationWaitingState {
+  const record = requireExactRecord(value, 'Automation waiting state', [
+    'reason',
+    'since',
+    'message',
+  ]);
+  if (record.reason !== 'client_capability_provider_unavailable') {
+    throw invalidProtocolFrame('Invalid Automation waiting reason');
+  }
+  return {
+    reason: record.reason,
+    since: requireCount(record.since, 'Automation waiting since'),
+    message: requireAutomationText(
+      record.message,
+      'Automation waiting message',
+      AUTOMATION_LAST_ERROR_LIMIT,
+    ),
   };
 }
 

--- a/packages/runtime-host/src/protocol/client-capability.ts
+++ b/packages/runtime-host/src/protocol/client-capability.ts
@@ -51,6 +51,7 @@ export interface ClientCapabilityCallResult {
 }
 
 export type ClientCapabilityAffinity = 'call' | 'turn' | 'session';
+export type ClientCapabilityHostPathAccess = 'none' | 'cwd';
 
 export const CLIENT_CAPABILITY_MAX_OFFERS = 32;
 export const CLIENT_CAPABILITY_MAX_SERVICES = 32;
@@ -79,6 +80,7 @@ export interface ClientCapabilityOffer {
   readonly offerId: string;
   readonly version: string;
   readonly affinity: ClientCapabilityAffinity;
+  readonly hostPathAccess: ClientCapabilityHostPathAccess;
   readonly label: string;
   readonly description?: string;
   readonly tools: readonly ClientCapabilityToolDescriptor[];
@@ -120,7 +122,7 @@ export interface ClientCapabilityCallFrame {
   readonly sessionId: string;
   readonly turnId: string;
   readonly toolCallId: string;
-  readonly cwd: string;
+  readonly cwd?: string;
 }
 
 export interface ClientCapabilityServiceCallFrame {
@@ -430,19 +432,23 @@ export function decodeClientCapabilityHostFrame(value: unknown): ClientCapabilit
   const frame = requireRecord(value, 'Client Capability Host frame');
   switch (frame.kind) {
     case 'client.capability.call': {
-      assertExactKeys(frame, 'Client Capability call frame', [
-        'kind',
-        'invocationId',
-        'registrationId',
-        'offerId',
-        'serverId',
-        'toolName',
-        'arguments',
-        'sessionId',
-        'turnId',
-        'toolCallId',
-        'cwd',
-      ]);
+      assertOptionalExactKeys(
+        frame,
+        'Client Capability call frame',
+        [
+          'kind',
+          'invocationId',
+          'registrationId',
+          'offerId',
+          'serverId',
+          'toolName',
+          'arguments',
+          'sessionId',
+          'turnId',
+          'toolCallId',
+        ],
+        ['cwd'],
+      );
       const argumentsValue = decodeJsonRecord(frame.arguments, 'arguments');
       if (jsonByteLength(argumentsValue) > 40 * 1024) {
         throw invalidProtocolFrame('Client Capability arguments are too large');
@@ -458,7 +464,7 @@ export function decodeClientCapabilityHostFrame(value: unknown): ClientCapabilit
         sessionId: requireEntityId(frame.sessionId, 'sessionId'),
         turnId: requireEntityId(frame.turnId, 'turnId'),
         toolCallId: requireEntityId(frame.toolCallId, 'toolCallId'),
-        cwd: requireString(frame.cwd, 'cwd', 4_096),
+        ...(frame.cwd === undefined ? {} : { cwd: requireString(frame.cwd, 'cwd', 4_096) }),
       };
     }
     case 'client.capability.service_call': {
@@ -532,7 +538,7 @@ function decodeClientCapabilityOffer(value: unknown): ClientCapabilityOffer {
   assertOptionalExactKeys(
     record,
     'Client Capability offer',
-    ['offerId', 'version', 'affinity', 'label', 'tools'],
+    ['offerId', 'version', 'affinity', 'hostPathAccess', 'label', 'tools'],
     ['description'],
   );
   if (
@@ -546,6 +552,7 @@ function decodeClientCapabilityOffer(value: unknown): ClientCapabilityOffer {
     offerId: requireEntityId(record.offerId, 'offerId'),
     version: requireString(record.version, 'version', 64),
     affinity: decodeClientCapabilityAffinity(record.affinity),
+    hostPathAccess: decodeClientCapabilityHostPathAccess(record.hostPathAccess),
     label: requireString(record.label, 'label', 128),
     ...(record.description === undefined
       ? {}
@@ -570,6 +577,11 @@ function decodeClientCapabilityServiceOffer(value: unknown): ClientCapabilitySer
 function decodeClientCapabilityAffinity(value: unknown): ClientCapabilityAffinity {
   if (value === 'call' || value === 'turn' || value === 'session') return value;
   throw invalidProtocolFrame('Invalid Client Capability affinity');
+}
+
+function decodeClientCapabilityHostPathAccess(value: unknown): ClientCapabilityHostPathAccess {
+  if (value === 'none' || value === 'cwd') return value;
+  throw invalidProtocolFrame('Invalid Client Capability Host path access');
 }
 
 function decodeToolDescriptor(value: unknown): ClientCapabilityToolDescriptor {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -35,6 +35,7 @@ import {
 } from './operations.js';
 
 export { RuntimeHostProtocolError } from './errors.js';
+export * from './access-authority.js';
 export * from './agent-graph.js';
 export * from './interaction.js';
 export * from './automation.js';
@@ -61,8 +62,8 @@ export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // The wire version remains v0 before the first release. This independent epoch
 // lets a new Client retire a stale same-version Host whose closed schema is no
 // longer safe to use.
-// 12: Host-owned Project Catalog operations and invalidation changed the closed schema.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 12 as const;
+// 13: trusted capability-provider Clients and Automation waiting state changed the closed schema.
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 13 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such
@@ -76,7 +77,14 @@ export type EncodedProtocolMessage = Buffer & {
   readonly [encodedProtocolMessageBrand]: true;
 };
 
-export type ClientSurface = 'desktop' | 'tui' | 'run' | 'activation' | 'bot' | 'inspect';
+export type ClientSurface =
+  | 'desktop'
+  | 'tui'
+  | 'run'
+  | 'activation'
+  | 'bot'
+  | 'inspect'
+  | 'capability-provider';
 
 export interface ProtocolRange {
   min: number;
@@ -301,7 +309,8 @@ function requireSurface(value: unknown): ClientSurface {
     value === 'run' ||
     value === 'activation' ||
     value === 'bot' ||
-    value === 'inspect'
+    value === 'inspect' ||
+    value === 'capability-provider'
   )
     return value;
   throw invalidProtocolFrame('Invalid surface');

--- a/packages/runtime-host/src/server/access-authority.ts
+++ b/packages/runtime-host/src/server/access-authority.ts
@@ -29,6 +29,11 @@ import {
 } from './access-credential-store.js';
 
 const ACCESS_CREDENTIAL_PREFIX = 'maka_rh_';
+const CAPABILITY_PROVIDER_GRANTS = new Set([
+  'host.status',
+  'client.capability.replace',
+  'client.capability.unregister',
+]);
 
 export interface RuntimeHostAccessAuthority {
   authenticate(credential: string): RuntimeHostConnectionAuthority | undefined;
@@ -73,7 +78,7 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
     }
     return match
       ? createRuntimeHostConnectionAuthority({
-          principalKind: 'access_credential',
+          principalKind: match.principalKind,
           principalId: match.principalId,
           credentialId: match.credentialId,
           operationGrants: match.operationGrants,
@@ -86,25 +91,22 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
   issue(input: AccessCredentialIssueInput): Promise<AccessCredentialIssueResult> {
     return this.#mutate(async () => {
       const operationGrants = issuedAccessGrants(input.operationGrants);
+      assertCredentialAuthority(input, operationGrants);
       const credentialId = randomUUID();
       createRuntimeHostConnectionAuthority({
-        principalKind: 'access_credential',
+        principalKind: input.principalKind,
         principalId: input.principalId,
         credentialId,
         operationGrants,
         canPublishClientCapabilities: input.canPublishClientCapabilities,
         canUseHostPaths: input.canUseHostPaths,
       });
-      if (input.canPublishClientCapabilities && !input.canUseHostPaths) {
-        throw new RuntimeHostAccessInputError(
-          'Client Capability publication requires Host path authority until path-independent offers are declared',
-        );
-      }
       const credential = `${ACCESS_CREDENTIAL_PREFIX}${randomBytes(32).toString('base64url')}`;
       const stored: StoredAccessCredential = {
         credentialId,
         credentialHash: hashCredential(credential).toString('hex'),
         principalId: input.principalId,
+        principalKind: input.principalKind,
         status: 'active',
         operationGrants,
         canPublishClientCapabilities: input.canPublishClientCapabilities,
@@ -128,6 +130,7 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
         credentialId,
         deliveryId,
         principalId: stored.principalId,
+        principalKind: stored.principalKind,
         operationGrants,
         canPublishClientCapabilities: stored.canPublishClientCapabilities,
         canUseHostPaths: stored.canUseHostPaths,
@@ -178,6 +181,26 @@ class FileRuntimeHostAccessAuthority implements RuntimeHostAccessAuthority {
   async #commit(file: AccessCredentialFile): Promise<void> {
     await writeAccessCredentialFile(this.#path, file);
     this.#file = file;
+  }
+}
+
+function assertCredentialAuthority(
+  input: AccessCredentialIssueInput,
+  operationGrants: readonly string[],
+): void {
+  if (input.principalKind !== 'capability_provider') return;
+  if (!input.canPublishClientCapabilities || input.canUseHostPaths) {
+    throw new RuntimeHostAccessInputError(
+      'A capability provider must publish Client Capabilities without Host path authority',
+    );
+  }
+  if (
+    operationGrants.length !== CAPABILITY_PROVIDER_GRANTS.size ||
+    operationGrants.some((grant) => !CAPABILITY_PROVIDER_GRANTS.has(grant))
+  ) {
+    throw new RuntimeHostAccessInputError(
+      'A capability provider credential may grant only Client Capability publication operations',
+    );
   }
 }
 

--- a/packages/runtime-host/src/server/access-credential-store.ts
+++ b/packages/runtime-host/src/server/access-credential-store.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import { chmod, open, rename, rm, type FileHandle } from 'node:fs/promises';
 import { dirname } from 'node:path';
-import { HOST_OPERATION_SPECS, type OperationKey } from '../protocol/index.js';
+import {
+  type AccessCredentialPrincipalKind,
+  HOST_OPERATION_SPECS,
+  type OperationKey,
+} from '../protocol/index.js';
 
 const ACCESS_FILE_SCHEMA_VERSION = 1;
 const ACCESS_FILE_MAX_BYTES = 512 * 1024;
@@ -12,6 +16,7 @@ export interface StoredAccessCredential {
   readonly credentialId: string;
   readonly credentialHash: string;
   readonly principalId: string;
+  readonly principalKind: AccessCredentialPrincipalKind;
   readonly status: 'active' | 'revoked';
   readonly operationGrants: readonly OperationKey[];
   readonly canPublishClientCapabilities: boolean;
@@ -138,6 +143,10 @@ function decodeStoredCredential(value: unknown): StoredAccessCredential {
   if (!/^[a-f0-9]{64}$/u.test(credentialHash)) throw new Error('Invalid credentialHash');
   const principalId = requireStoredString(value.principalId, 'principalId');
   if (!/^[A-Za-z0-9_.:-]{1,128}$/u.test(principalId)) throw new Error('Invalid principalId');
+  const principalKind = value.principalKind === undefined ? 'remote_owner' : value.principalKind;
+  if (principalKind !== 'remote_owner' && principalKind !== 'capability_provider') {
+    throw new Error('Invalid principalKind');
+  }
   if (value.status !== 'active' && value.status !== 'revoked') throw new Error('Invalid status');
   if (!Array.isArray(value.operationGrants)) throw new Error('Invalid operationGrants');
   const rawOperationGrants = value.operationGrants.map((grant) =>
@@ -165,6 +174,7 @@ function decodeStoredCredential(value: unknown): StoredAccessCredential {
     credentialId,
     credentialHash,
     principalId,
+    principalKind,
     status: value.status,
     operationGrants,
     canPublishClientCapabilities: value.canPublishClientCapabilities,

--- a/packages/runtime-host/src/server/automation-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-coordinator.ts
@@ -39,6 +39,7 @@ import {
 } from '../protocol/index.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
 import type { AutomationOperationHandlerMap } from './operation-dispatcher.js';
+import type { HostClientCapabilityCoordinator } from './client-capability-coordinator.js';
 import { AutomationAuthorityInvariantError } from './automation-errors.js';
 import {
   assertFireRunIdentity,
@@ -64,6 +65,10 @@ export interface HostAutomationCoordinatorInput {
   readonly runtime: AutomationRuntime;
   readonly root: AutomationRoot;
   readonly runtimePolicy: RuntimePolicyStoresWriter;
+  readonly clientCapabilities: Pick<
+    HostClientCapabilityCoordinator,
+    'requirementsForAutomation' | 'checkAutomationRequirements' | 'bindAutomationSession'
+  >;
   readonly isSessionActive: (sessionId: string) => boolean;
   readonly sessionAdmission: SessionAdmissionGate;
   readonly acquireResidency: () => RuntimeHostResidency;
@@ -112,6 +117,7 @@ class AutomationMutationFailure extends Error {
       | 'session_archived'
       | 'session_busy'
       | 'session_unavailable'
+      | 'capability_unavailable'
       | 'host_not_ready'
       | 'host_draining',
     message: string,
@@ -135,6 +141,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
   readonly #sessions: AutomationSessions;
   readonly #requestDrain: () => void;
   readonly #sessionAdmission: SessionAdmissionGate;
+  readonly #clientCapabilities: HostAutomationCoordinatorInput['clientCapabilities'];
   readonly #newId: () => string;
   readonly #now: () => number;
   readonly #manager: AutomationManager;
@@ -152,6 +159,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     this.#sessions = input.sessions;
     this.#requestDrain = input.requestDrain;
     this.#sessionAdmission = input.sessionAdmission;
+    this.#clientCapabilities = input.clientCapabilities;
     this.#newId = input.newId ?? randomUUID;
     this.#now = input.now ?? Date.now;
     this.#manager = new AutomationManager({
@@ -166,10 +174,15 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
         listDueAutomations: (now) => this.#listDueAutomations(now),
         recordDeferredFire: (automationId, expectedSchedule, skip) =>
           this.#recordDeferredFire(automationId, expectedSchedule, skip),
+        recordPrerequisiteWaiting: (automationId, expectedSchedule, waiting) =>
+          this.#recordPrerequisiteWaiting(automationId, expectedSchedule, waiting),
         admitFire: (automationId, expectedSchedule) =>
           this.#admitFire(automationId, expectedSchedule),
         assertPendingFire: (fire) => this.#assertPendingFire(fire),
-        recordFireDeferred: (fire) => this.#recordFireDeferred(fire),
+        recordFireDeferred: (fire, transientDeferredSince) =>
+          this.#recordFireDeferred(fire, transientDeferredSince),
+        recordFirePrerequisiteWaiting: (fire, waiting) =>
+          this.#recordFirePrerequisiteWaiting(fire, waiting),
         failFire: (fire, error) => this.#failFire(fire, error),
         markFireRunning: (fire) => this.#markFireRunning(fire),
         settleFire: (fire, run) => this.#settleFire(fire, run),
@@ -185,6 +198,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
       runtime: input.runtime,
       root: input.root,
       runtimePolicy: input.runtimePolicy,
+      clientCapabilities: input.clientCapabilities,
       isSessionActive: input.isSessionActive,
       acquireResidency: input.acquireResidency,
       requestDrain: input.requestDrain,
@@ -283,6 +297,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     schedule: AutomationDefinition['schedule'];
     maxFires?: number;
     durable?: boolean;
+    requiredCapabilityGroups?: readonly string[];
   }): Promise<AutomationDefinition | { error: string }> {
     try {
       return (await this.#create(input)).automation;
@@ -401,6 +416,9 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
             schedule: input.schedule,
             ...(input.maxFires === undefined ? {} : { maxFires: input.maxFires }),
             ...(input.durable === undefined ? {} : { durable: input.durable }),
+            ...(input.requiredCapabilityGroups === undefined
+              ? {}
+              : { requiredCapabilityGroups: input.requiredCapabilityGroups }),
           });
           revision = committed.revision;
           automation = projectAutomation(committed.automation, committed.firePending);
@@ -445,7 +463,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
         if (failure.kind === 'session_busy') {
           return mutationFailure('session_busy', failure.message);
         }
-        if (failure.kind === 'session_unavailable') {
+        if (failure.kind === 'session_unavailable' || failure.kind === 'capability_unavailable') {
           return mutationFailure('operation_unavailable', failure.message);
         }
         return mutationSuccess({ kind: 'rejected', reason: failure.kind });
@@ -462,6 +480,7 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     schedule: AutomationDefinition['schedule'];
     maxFires?: number;
     durable?: boolean;
+    requiredCapabilityGroups?: readonly string[];
   }): Promise<CommittedAutomation> {
     return this.#exclusive(async () => {
       this.#assertWritable();
@@ -470,9 +489,27 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
       if (unavailableReason) {
         throw new AutomationMutationFailure('session_unavailable', unavailableReason);
       }
+      const resolvedRequirements = await this.#clientCapabilities.requirementsForAutomation(
+        input.sessionId,
+        input.requiredCapabilityGroups ?? [],
+      );
+      if (!resolvedRequirements.ok) {
+        throw new AutomationMutationFailure('capability_unavailable', resolvedRequirements.message);
+      }
+      const capabilityRequirements = resolvedRequirements.requirements;
       const execution = input.kind === 'cron' ? executionTemplateFromHeader(header) : undefined;
       const before = this.#snapshot();
-      const result = this.#manager.create({ ...input, ...(execution ? { execution } : {}) });
+      const result = this.#manager.create({
+        kind: input.kind,
+        name: input.name,
+        prompt: input.prompt,
+        sessionId: input.sessionId,
+        schedule: input.schedule,
+        ...(input.maxFires === undefined ? {} : { maxFires: input.maxFires }),
+        ...(input.durable === undefined ? {} : { durable: input.durable }),
+        ...(execution ? { execution } : {}),
+        ...(capabilityRequirements.length > 0 ? { capabilityRequirements } : {}),
+      });
       if ('error' in result) {
         const kind = result.error.includes('Invalid cron') ? 'invalid_schedule' : 'limit_reached';
         throw new AutomationMutationFailure(kind, result.error);
@@ -649,6 +686,29 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     });
   }
 
+  #recordPrerequisiteWaiting(
+    automationId: string,
+    expectedSchedule: number | null,
+    waiting: NonNullable<AutomationDefinition['waiting']>,
+  ): Promise<boolean> {
+    return this.#exclusive(async () => {
+      const automation = this.#manager.get(automationId);
+      if (
+        !automation ||
+        automation.status !== 'active' ||
+        automation.nextFireAt !== expectedSchedule ||
+        this.#pendingFires.has(automationId)
+      ) {
+        return false;
+      }
+      const before = this.#snapshot();
+      if (this.#manager.recordPrerequisiteWaiting(automationId, waiting)) {
+        await this.#commitOrRestore(before);
+      }
+      return true;
+    });
+  }
+
   async #admitFire(
     automationId: string,
     expectedSchedule: number | null,
@@ -725,6 +785,9 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
         status: 'admitted',
         admittedAt,
         updatedAt: admittedAt,
+        ...(started.capabilityRequirements && started.capabilityRequirements.length > 0
+          ? { capabilityRequirements: structuredClone(started.capabilityRequirements) }
+          : {}),
         ...(started.execution ? { execution: structuredClone(started.execution) } : {}),
       };
       this.#pendingFires.set(automationId, fire);
@@ -742,7 +805,10 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
     });
   }
 
-  async #recordFireDeferred(fire: AutomationPendingFire): Promise<void> {
+  async #recordFireDeferred(
+    fire: AutomationPendingFire,
+    transientDeferredSince: number,
+  ): Promise<void> {
     await this.#exclusive(async () => {
       const current = this.#pendingFires.get(fire.automationId);
       if (!current || current.id !== fire.id) return;
@@ -750,6 +816,26 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
       this.#manager.recordAdmittedFireDeferred(fire.automationId);
       this.#pendingFires.set(fire.automationId, {
         ...current,
+        transientDeferredSince: current.transientDeferredSince ?? transientDeferredSince,
+        updatedAt: Math.max(current.updatedAt, this.#now()),
+      });
+      await this.#commitOrRestore(before);
+    });
+  }
+
+  async #recordFirePrerequisiteWaiting(
+    fire: AutomationPendingFire,
+    waiting: NonNullable<AutomationDefinition['waiting']>,
+  ): Promise<void> {
+    await this.#exclusive(async () => {
+      const current = this.#pendingFires.get(fire.automationId);
+      if (!current || current.id !== fire.id) return;
+      const before = this.#snapshot();
+      const waitingChanged = this.#manager.recordPrerequisiteWaiting(fire.automationId, waiting);
+      if (!waitingChanged && current.transientDeferredSince === undefined) return;
+      this.#pendingFires.set(fire.automationId, {
+        ...current,
+        transientDeferredSince: undefined,
         updatedAt: Math.max(current.updatedAt, this.#now()),
       });
       await this.#commitOrRestore(before);
@@ -782,8 +868,10 @@ export class HostAutomationCoordinator implements AutomationToolAuthority {
       if (current.status === 'running') return;
       const before = this.#snapshot();
       const now = this.#now();
+      this.#manager.clearWaiting(fire.automationId);
       this.#pendingFires.set(fire.automationId, {
         ...current,
+        transientDeferredSince: undefined,
         status: 'running',
         startedAt: now,
         updatedAt: now,
@@ -928,6 +1016,7 @@ function projectAutomation(
     durable: automation.durable === true,
     deferredFireCount: automation.deferredFireCount ?? 0,
     firePending,
+    waiting: automation.waiting ? structuredClone(automation.waiting) : null,
   };
 }
 

--- a/packages/runtime-host/src/server/automation-fire-coordinator.ts
+++ b/packages/runtime-host/src/server/automation-fire-coordinator.ts
@@ -1,6 +1,11 @@
 import { createHash } from 'node:crypto';
 import { agentRunMatchesHostedRootExecution, type AgentRunHeader } from '@maka/core/agent-run';
-import type { AutomationDefinition, AutomationPendingFire } from '@maka/core/automation';
+import type {
+  AutomationClientCapabilityRequirement,
+  AutomationDefinition,
+  AutomationPendingFire,
+  AutomationWaitingState,
+} from '@maka/core/automation';
 import type { MessageContent } from '@maka/core/events';
 import type { SessionHeader } from '@maka/core/session';
 import {
@@ -39,16 +44,35 @@ export interface AutomationFireStateAuthority {
     expectedSchedule: number | null,
     skip: boolean,
   ): Promise<boolean>;
+  recordPrerequisiteWaiting(
+    automationId: string,
+    expectedSchedule: number | null,
+    waiting: AutomationWaitingState,
+  ): Promise<boolean>;
   admitFire(
     automationId: string,
     expectedSchedule: number | null,
   ): Promise<AutomationPendingFire | undefined>;
   assertPendingFire(fire: AutomationPendingFire): Promise<void>;
-  recordFireDeferred(fire: AutomationPendingFire): Promise<void>;
+  recordFireDeferred(fire: AutomationPendingFire, transientDeferredSince: number): Promise<void>;
+  recordFirePrerequisiteWaiting(
+    fire: AutomationPendingFire,
+    waiting: AutomationWaitingState,
+  ): Promise<void>;
   failFire(fire: AutomationPendingFire, error: string): Promise<void>;
   markFireRunning(fire: AutomationPendingFire): Promise<void>;
   settleFire(fire: AutomationPendingFire, run: AgentRunHeader): Promise<void>;
   residencyState(): { readonly pending: boolean; readonly scheduled: boolean };
+}
+
+export interface AutomationClientCapabilityAuthority {
+  checkAutomationRequirements(
+    requirements: readonly AutomationClientCapabilityRequirement[],
+  ): Promise<{ readonly ok: true } | { readonly ok: false; readonly message: string }>;
+  bindAutomationSession(
+    sessionId: string,
+    requirements: readonly AutomationClientCapabilityRequirement[],
+  ): Promise<{ readonly ok: true } | { readonly ok: false; readonly message: string }>;
 }
 
 export interface HostAutomationFireCoordinatorInput {
@@ -58,6 +82,7 @@ export interface HostAutomationFireCoordinatorInput {
   readonly runtime: AutomationRuntime;
   readonly root: AutomationRoot;
   readonly runtimePolicy: RuntimePolicyStoresWriter;
+  readonly clientCapabilities: AutomationClientCapabilityAuthority;
   readonly isSessionActive: (sessionId: string) => boolean;
   readonly acquireResidency: () => RuntimeHostResidency;
   readonly requestDrain: () => void;
@@ -86,6 +111,26 @@ class AutomationFireDeferredError extends Error {
   readonly name = 'AutomationFireDeferredError';
 }
 
+class AutomationFirePrerequisiteError extends Error {
+  readonly name = 'AutomationFirePrerequisiteError';
+
+  constructor(
+    message: string,
+    readonly waiting: AutomationWaitingState,
+  ) {
+    super(message);
+  }
+}
+
+type AutomationFireReadiness =
+  | { readonly ready: true }
+  | { readonly ready: false; readonly reason: 'transient_gate' }
+  | {
+      readonly ready: false;
+      readonly reason: 'prerequisite_unavailable';
+      readonly waiting: AutomationWaitingState;
+    };
+
 /** Owns timers and execution side effects; canonical state stays behind its narrow port. */
 export class HostAutomationFireCoordinator {
   readonly #state: AutomationFireStateAuthority;
@@ -94,6 +139,7 @@ export class HostAutomationFireCoordinator {
   readonly #runtime: AutomationRuntime;
   readonly #root: AutomationRoot;
   readonly #runtimePolicy: RuntimePolicyStoresWriter;
+  readonly #clientCapabilities: AutomationClientCapabilityAuthority;
   readonly #isSessionActive: (sessionId: string) => boolean;
   readonly #acquireResidency: () => RuntimeHostResidency;
   readonly #requestDrain: () => void;
@@ -118,6 +164,7 @@ export class HostAutomationFireCoordinator {
     this.#runtime = input.runtime;
     this.#root = input.root;
     this.#runtimePolicy = input.runtimePolicy;
+    this.#clientCapabilities = input.clientCapabilities;
     this.#isSessionActive = input.isSessionActive;
     this.#acquireResidency = input.acquireResidency;
     this.#requestDrain = input.requestDrain;
@@ -208,15 +255,24 @@ export class HostAutomationFireCoordinator {
     }
     for (const automation of await this.#state.listDueAutomations(this.#now())) {
       if (this.isDraining) return;
-      let allowed: boolean;
+      let readiness: AutomationFireReadiness;
       try {
-        allowed = await this.#canFire(automation);
+        readiness = await this.#canFire(automation);
       } catch (error) {
         this.#requestDrain();
         throw error;
       }
-      if (!allowed) {
-        await this.#recordDeferred(automation);
+      if (!readiness.ready) {
+        if (readiness.reason === 'prerequisite_unavailable') {
+          this.#deferredFires.delete(automation.id);
+          await this.#state.recordPrerequisiteWaiting(
+            automation.id,
+            automation.nextFireAt,
+            readiness.waiting,
+          );
+        } else {
+          await this.#recordDeferred(automation);
+        }
         continue;
       }
       const fire = await this.#state.admitFire(automation.id, automation.nextFireAt);
@@ -227,11 +283,13 @@ export class HostAutomationFireCoordinator {
     }
   }
 
-  async #canFire(automation: Pick<AutomationDefinition, 'kind' | 'sessionId'>): Promise<boolean> {
-    if (this.isDraining) return false;
+  async #canFire(
+    automation: Pick<AutomationDefinition, 'kind' | 'sessionId' | 'capabilityRequirements'>,
+  ): Promise<AutomationFireReadiness> {
+    if (this.isDraining) return { ready: false, reason: 'transient_gate' };
     if (automation.kind === 'heartbeat' && this.#isSessionActive(automation.sessionId))
-      return false;
-    return evaluateAutomationCanFire(automation, {
+      return { ready: false, reason: 'transient_gate' };
+    const allowed = await evaluateAutomationCanFire(automation, {
       isIncognitoActive: async () =>
         (await this.#runtimePolicy.runtimePolicy.getSnapshot()).policy.privacy.incognitoActive,
       readSessionHeader: async (sessionId) => {
@@ -248,6 +306,17 @@ export class HostAutomationFireCoordinator {
         }
       },
     });
+    if (!allowed) return { ready: false, reason: 'transient_gate' };
+    const availability = await this.#clientCapabilities.checkAutomationRequirements(
+      automation.capabilityRequirements ?? [],
+    );
+    return availability.ok
+      ? { ready: true }
+      : {
+          ready: false,
+          reason: 'prerequisite_unavailable',
+          waiting: capabilityWaiting(availability.message, this.#now()),
+        };
   }
 
   async #recordDeferred(
@@ -303,6 +372,7 @@ export class HostAutomationFireCoordinator {
         }
         established.resolve();
       }
+      await this.#assertFireCapabilityRequirements(fire);
       await this.#root.executeRoot({
         sessionId: fire.targetSessionId,
         turnId: fire.turnId,
@@ -375,6 +445,7 @@ export class HostAutomationFireCoordinator {
       }
       if (
         error instanceof AutomationFireDeferredError ||
+        error instanceof AutomationFirePrerequisiteError ||
         error instanceof RuntimeHostedRootConflictError ||
         error instanceof RuntimeHostedRootUnavailableError
       ) {
@@ -383,10 +454,17 @@ export class HostAutomationFireCoordinator {
           return;
         }
         try {
-          if (this.#now() - fire.admittedAt >= DEFER_WINDOW_MS) {
-            await this.#state.failFire(fire, automationAdmissionFailure(error));
+          if (error instanceof AutomationFirePrerequisiteError) {
+            await this.#state.recordFirePrerequisiteWaiting(fire, error.waiting);
           } else {
-            await this.#state.recordFireDeferred(fire);
+            const now = this.#now();
+            const transientDeferredSince =
+              fire.transientDeferredSince ?? Math.max(fire.admittedAt, now);
+            if (now - transientDeferredSince >= DEFER_WINDOW_MS) {
+              await this.#state.failFire(fire, automationAdmissionFailure(error));
+            } else {
+              await this.#state.recordFireDeferred(fire, transientDeferredSince);
+            }
           }
         } catch (stateError) {
           established.reject(stateError);
@@ -457,6 +535,20 @@ export class HostAutomationFireCoordinator {
     if (fire.automationKind === 'heartbeat' && !HEARTBEAT_IDLE_STATUSES.has(header.status)) {
       throw new AutomationFireDeferredError('Automation target Session is not idle');
     }
+    await this.#assertFireCapabilityRequirements(fire);
+  }
+
+  async #assertFireCapabilityRequirements(fire: AutomationPendingFire): Promise<void> {
+    const availability = await this.#clientCapabilities.bindAutomationSession(
+      fire.targetSessionId,
+      fire.capabilityRequirements ?? [],
+    );
+    if (!availability.ok) {
+      throw new AutomationFirePrerequisiteError(
+        availability.message,
+        capabilityWaiting(availability.message, this.#now()),
+      );
+    }
   }
 
   async #readRun(fire: AutomationPendingFire): Promise<AgentRunHeader | undefined> {
@@ -467,6 +559,14 @@ export class HostAutomationFireCoordinator {
       throw error;
     }
   }
+}
+
+function capabilityWaiting(message: string, since: number): AutomationWaitingState {
+  return {
+    reason: 'client_capability_provider_unavailable',
+    since,
+    message,
+  };
 }
 
 function automationAdmissionFailure(error: Error): string {

--- a/packages/runtime-host/src/server/client-capability-coordinator.ts
+++ b/packages/runtime-host/src/server/client-capability-coordinator.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
+import type { AutomationClientCapabilityRequirement } from '@maka/core/automation';
 import {
   buildMcpTools,
   mcpProxyToolName,
@@ -47,6 +48,9 @@ export interface ClientCapabilitySnapshot {
 
 interface ClientProviderState {
   readonly providerId: string;
+  readonly principalId: string;
+  readonly clientInstanceId: string;
+  readonly unattended: boolean;
   activeConnectionId?: string;
   current?: CapabilityRegistration;
   readonly registrations: Map<string, CapabilityRegistration>;
@@ -63,6 +67,7 @@ interface CapabilityRegistration {
   readonly providerId: string;
   readonly connectionId: string;
   readonly registrationId: string;
+  readonly unattended: boolean;
   readonly offersByContract: ReadonlyMap<string, FrozenOfferBinding>;
   readonly servicesByContract: ReadonlyMap<string, ClientCapabilityServiceOffer>;
   snapshotRefs: number;
@@ -76,6 +81,7 @@ interface FrozenOfferBinding {
 
 interface FrozenToolBinding {
   readonly offerId: string;
+  readonly hostPathAccess: ClientCapabilityOffer['hostPathAccess'];
   readonly descriptor: ClientCapabilityToolDescriptor;
 }
 
@@ -115,6 +121,10 @@ interface SelectedOfferBinding {
   readonly offer: FrozenOfferBinding;
 }
 
+interface RequiredOfferBinding extends SelectedOfferBinding {
+  readonly requirement: AutomationClientCapabilityRequirement;
+}
+
 interface SnapshotOfferBinding {
   readonly offer: FrozenOfferBinding;
   readonly registration?: CapabilityRegistration;
@@ -134,6 +144,17 @@ export interface ClientCapabilityServiceInvocationInput {
   readonly signal?: AbortSignal;
   readonly timeoutMs?: number;
 }
+
+export type AutomationClientCapabilityAvailability =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly message: string };
+
+export type AutomationClientCapabilityRequirements =
+  | {
+      readonly ok: true;
+      readonly requirements: readonly AutomationClientCapabilityRequirement[];
+    }
+  | { readonly ok: false; readonly message: string };
 
 /**
  * Host-owned registry, selection authority, and reverse-call lifecycle for
@@ -210,6 +231,89 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     if (!result.ok) {
       throw new Error(`Confirmed follow-up capability binding failed: ${result.message}`);
     }
+  }
+
+  requirementsForAutomation(
+    sessionId: string,
+    contractIds: readonly string[],
+  ): Promise<AutomationClientCapabilityRequirements> {
+    return this.#activation.runReadActivation(async () => {
+      if (contractIds.length === 0) return { ok: true, requirements: [] };
+      const state =
+        this.#previewSessions.getStore()?.get(sessionId) ?? this.#sessions.get(sessionId);
+      if (!state) {
+        return { ok: false, message: 'Required Client Capability groups are not loaded' };
+      }
+      const requirements: AutomationClientCapabilityRequirement[] = [];
+      for (const contractId of contractIds) {
+        const binding = state.sessionBindings.get(contractId);
+        if (!binding) {
+          return {
+            ok: false,
+            message: `Client Capability group ${contractId} is unavailable in this Session`,
+          };
+        }
+        const provider = this.#providers.get(binding.providerId);
+        if (!provider) {
+          throw new Error('Client Capability Session binding lost its provider identity');
+        }
+        requirements.push(
+          Object.freeze({
+            principalId: provider.principalId,
+            clientInstanceId: provider.clientInstanceId,
+            contractId,
+          }),
+        );
+      }
+      return { ok: true, requirements };
+    });
+  }
+
+  checkAutomationRequirements(
+    requirements: readonly AutomationClientCapabilityRequirement[],
+  ): Promise<AutomationClientCapabilityAvailability> {
+    return this.#activation.runReadActivation(async () => {
+      const resolved = this.#resolveAutomationRequirements(requirements);
+      return resolved.ok ? { ok: true } : resolved;
+    });
+  }
+
+  bindAutomationSession(
+    sessionId: string,
+    requirements: readonly AutomationClientCapabilityRequirement[],
+  ): Promise<AutomationClientCapabilityAvailability> {
+    return this.#activation.runMutation(async () => {
+      const resolved = this.#resolveAutomationRequirements(requirements);
+      if (!resolved.ok) return resolved;
+      const previous = this.#sessions.get(sessionId);
+      const previousBindings = previous?.sessionBindings ?? new Map();
+      const sessionBindings = new Map(previousBindings);
+      for (const binding of resolved.bindings) {
+        const current = sessionBindings.get(binding.requirement.contractId);
+        if (current && current.providerId !== binding.registration.providerId) {
+          return {
+            ok: false,
+            message:
+              'Automation Client Capability requirement conflicts with the target Session binding',
+          };
+        }
+        sessionBindings.set(binding.requirement.contractId, {
+          kind: 'bound',
+          providerId: binding.registration.providerId,
+        });
+      }
+      const next: SessionCapabilityState = {
+        ...(previous?.initiatingProviderId
+          ? { initiatingProviderId: previous.initiatingProviderId }
+          : {}),
+        sessionBindings,
+        turnBindings: new Map(previous?.turnBindings ?? []),
+      };
+      const changed = !bindingMapsEqual(previousBindings, sessionBindings);
+      this.#storeSessionState(sessionId, next);
+      if (changed) this.#onModelToolsChanged();
+      return { ok: true };
+    });
   }
 
   async #bindSession(
@@ -464,12 +568,22 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       rememberOfferProxyNames(offer, proxyNames);
     }
     if (selected.length === 0) return;
-    const proxyProvider = this.#snapshotProvider(state?.initiatingProviderId, selected);
-    const tools = buildMcpTools(proxyProvider, {
-      callTimeoutMs: DEFAULT_CALL_TIMEOUT_MS,
-      categoryHint: 'client_capability',
-      recoveryMode: 'outcome_unknown',
-    });
+    const unattended = selected.filter((binding) => binding.registration?.unattended === true);
+    const interactive = selected.filter((binding) => binding.registration?.unattended !== true);
+    assertUniqueSnapshotToolIdentities(selected);
+    const tools = [
+      ...buildMcpTools(this.#snapshotProvider(state?.initiatingProviderId, interactive), {
+        callTimeoutMs: DEFAULT_CALL_TIMEOUT_MS,
+        categoryHint: 'client_capability',
+        recoveryMode: 'outcome_unknown',
+      }),
+      ...buildMcpTools(this.#snapshotProvider(state?.initiatingProviderId, unattended), {
+        callTimeoutMs: DEFAULT_CALL_TIMEOUT_MS,
+        categoryHint: 'custom_tool',
+        recoveryMode: 'outcome_unknown',
+        executionLocation: 'remote',
+      }),
+    ];
     const groups = selected.map(({ offer: binding }) => ({
       id: binding.contractId,
       toolNames: binding.offer.tools.map((tool) => mcpProxyToolName(tool.serverId, tool.name)),
@@ -657,7 +771,23 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       }
       let registration: CapabilityRegistration;
       try {
-        registration = freezeRegistration(provider.providerId, context.connectionId, input);
+        if (
+          provider.unattended &&
+          (input.services?.length ||
+            input.offers.some(
+              (offer) => offer.affinity !== 'session' || offer.hostPathAccess !== 'none',
+            ))
+        ) {
+          throw new Error(
+            'A trusted capability provider may publish only path-independent session capabilities',
+          );
+        }
+        registration = freezeRegistration(
+          provider.providerId,
+          context.connectionId,
+          input,
+          provider.unattended,
+        );
       } catch (error) {
         return {
           ok: false,
@@ -814,9 +944,14 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     if (!provider) {
       provider = {
         providerId,
+        principalId: identity.principalId,
+        clientInstanceId: identity.clientInstanceId,
+        unattended: identity.unattended,
         registrations: new Map(),
       };
       this.#providers.set(providerId, provider);
+    } else if (provider.unattended !== identity.unattended) {
+      throw new Error('Client Capability provider authority changed across connections');
     }
     return provider;
   }
@@ -840,6 +975,35 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
       );
     }
     return eligible;
+  }
+
+  #resolveAutomationRequirements(
+    requirements: readonly AutomationClientCapabilityRequirement[],
+  ):
+    | { readonly ok: true; readonly bindings: readonly RequiredOfferBinding[] }
+    | { readonly ok: false; readonly message: string } {
+    const bindings: RequiredOfferBinding[] = [];
+    for (const requirement of requirements) {
+      const provider = this.#providers.get(
+        clientProviderId(requirement.principalId, requirement.clientInstanceId),
+      );
+      const registration = provider?.current;
+      const offer = registration?.offersByContract.get(requirement.contractId);
+      if (
+        !provider ||
+        !this.#activeConnection(provider) ||
+        !registration ||
+        !offer ||
+        offer.offer.affinity !== 'session'
+      ) {
+        return {
+          ok: false,
+          message: 'A required Client Capability provider is unavailable for this Automation',
+        };
+      }
+      bindings.push({ requirement, registration, offer });
+    }
+    return { ok: true, bindings };
   }
 
   #selectCallBinding(
@@ -1022,6 +1186,7 @@ function freezeRegistration(
   providerId: string,
   connectionId: string,
   input: ClientCapabilityReplaceInput,
+  unattended: boolean,
 ): CapabilityRegistration {
   const offers = input.offers.map((offer) =>
     Object.freeze({
@@ -1052,6 +1217,7 @@ function freezeRegistration(
       proxyNames.set(proxyName, identity);
       toolsByIdentity.set(identity, {
         offerId: offer.offerId,
+        hostPathAccess: offer.hostPathAccess,
         descriptor,
       });
     }
@@ -1075,6 +1241,7 @@ function freezeRegistration(
     providerId,
     connectionId,
     registrationId: input.registrationId,
+    unattended,
     offersByContract,
     servicesByContract,
     snapshotRefs: 0,
@@ -1107,6 +1274,7 @@ function capabilityGroupId(offer: ClientCapabilityOffer): string {
         offerId: offer.offerId,
         version: offer.version,
         affinity: offer.affinity,
+        hostPathAccess: offer.hostPathAccess,
         tools,
       }),
     )
@@ -1114,6 +1282,19 @@ function capabilityGroupId(offer: ClientCapabilityOffer): string {
     .slice(0, 16);
   const label = offer.offerId.replace(/[^A-Za-z0-9_-]+/g, '_').slice(0, 96);
   return `client_${hash}_${label}`;
+}
+
+function assertUniqueSnapshotToolIdentities(selected: readonly SnapshotOfferBinding[]): void {
+  const identities = new Set<string>();
+  for (const { offer } of selected) {
+    for (const descriptor of offer.offer.tools) {
+      const identity = toolIdentity(descriptor.serverId, descriptor.name);
+      if (identities.has(identity)) {
+        throw new Error('Client Capability snapshot contains a duplicate tool identity');
+      }
+      identities.add(identity);
+    }
+  }
 }
 
 function offerConflictsWithProxyNames(

--- a/packages/runtime-host/src/server/client-capability-invocation-broker.ts
+++ b/packages/runtime-host/src/server/client-capability-invocation-broker.ts
@@ -7,6 +7,7 @@ import {
   type ClientCapabilityCallResult,
   type ClientCapabilityClientFrame,
   type ClientCapabilityHostFrame,
+  type ClientCapabilityHostPathAccess,
   type ClientCapabilityToolDescriptor,
 } from '../protocol/index.js';
 import type { ClientCapabilityConnectionSender } from './client-capability-service.js';
@@ -39,6 +40,7 @@ export interface ClientCapabilityInvocationRegistration {
 
 export interface ClientCapabilityInvocationBinding {
   readonly offerId: string;
+  readonly hostPathAccess: ClientCapabilityHostPathAccess;
   readonly descriptor: ClientCapabilityToolDescriptor;
 }
 
@@ -105,7 +107,7 @@ export class ClientCapabilityInvocationBroker<
       sessionId: context.sessionId,
       turnId: context.turnId,
       toolCallId: context.toolCallId,
-      cwd: context.cwd,
+      ...(binding.hostPathAccess === 'cwd' ? { cwd: context.cwd } : {}),
     }));
   }
 

--- a/packages/runtime-host/src/server/client-capability-service.ts
+++ b/packages/runtime-host/src/server/client-capability-service.ts
@@ -8,6 +8,7 @@ export interface ClientCapabilityConnectionIdentity {
   readonly connectionId: string;
   readonly principalId: string;
   readonly clientInstanceId: string;
+  readonly unattended: boolean;
 }
 
 export interface ClientCapabilityConnection {

--- a/packages/runtime-host/src/server/connection-authority.ts
+++ b/packages/runtime-host/src/server/connection-authority.ts
@@ -1,12 +1,13 @@
 import {
   HOST_OPERATION_SPECS,
+  type AccessCredentialPrincipalKind,
   type ClientCapabilityClientFrame,
   type OperationKey,
   type RequestFrame,
 } from '../protocol/index.js';
 
 export interface RuntimeHostConnectionAuthority {
-  readonly principalKind: 'local_owner' | 'access_credential';
+  readonly principalKind: 'local_owner' | AccessCredentialPrincipalKind;
   readonly principalId: string;
   readonly credentialId?: string;
   readonly operationGrants: 'all' | readonly OperationKey[];
@@ -29,7 +30,7 @@ export function createRuntimeHostConnectionAuthority(
     throw new Error('Runtime Host connection principal is invalid');
   }
   if (
-    input.principalKind === 'access_credential' &&
+    input.principalKind !== 'local_owner' &&
     !/^[A-Za-z0-9_.:-]{1,128}$/.test(input.credentialId ?? '')
   ) {
     throw new Error('Runtime Host access credential identity is invalid');
@@ -96,6 +97,8 @@ function operationUsesHostPath(frame: RequestFrame): boolean {
     case 'project.catalog.query':
     case 'project.catalog.mutate':
       return true;
+    case 'client.capability.replace':
+      return frame.input.offers.some((offer) => offer.hostPathAccess === 'cwd');
     case 'skill.catalog.invocable.query':
       return frame.input.target.kind === 'new_session';
     case 'external-session.catalog.query':

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -268,6 +268,7 @@ export class RuntimeHostConnectionSession {
           connectionId: this.#options.connection.connectionId,
           principalId: this.#options.connection.authority.principalId,
           clientInstanceId: this.#options.connection.clientInstanceId,
+          unattended: this.#options.connection.authority.principalKind === 'capability_provider',
         },
         {
           send: (frame) => {

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1015,6 +1015,7 @@ export async function createExecutionRuntimeHostComposition(
       runtime: manager,
       root: { executeRoot: (input) => coordinator.executeRoot(input) },
       runtimePolicy: runtimePolicyStores,
+      clientCapabilities,
       isSessionActive: (sessionId) => coordinator.readRootState(sessionId).kind !== 'idle',
       sessionAdmission,
       acquireResidency: context.acquireResidency,

--- a/packages/runtime/src/automation-state.ts
+++ b/packages/runtime/src/automation-state.ts
@@ -8,9 +8,11 @@
 
 import type {
   AutomationDefinition,
+  AutomationClientCapabilityRequirement,
   AutomationExecutionTemplate,
   AutomationKind,
   AutomationSchedule,
+  AutomationWaitingState,
 } from '@maka/core/automation';
 import { AUTOMATION_LAST_ERROR_LIMIT, truncateAutomationText } from '@maka/core/automation';
 import { compileCronExpression } from '@maka/core/cron-expression';
@@ -83,6 +85,7 @@ export class AutomationManager {
     expiresAt?: number;
     durable?: boolean;
     execution?: AutomationExecutionTemplate;
+    capabilityRequirements?: readonly AutomationClientCapabilityRequirement[];
   }): AutomationDefinition | { error: string } {
     // Only count active/paused automations toward the limit (not completed/expired).
     const activeCount = this.listForSession(input.sessionId).filter(
@@ -142,6 +145,9 @@ export class AutomationManager {
       lastError: null,
       consecutiveFailures: 0,
       ...(durable ? { durable: true } : {}),
+      ...(input.capabilityRequirements && input.capabilityRequirements.length > 0
+        ? { capabilityRequirements: structuredClone(input.capabilityRequirements) }
+        : {}),
       ...(input.kind === 'cron' && input.execution ? { execution: input.execution } : {}),
     };
 
@@ -168,6 +174,7 @@ export class AutomationManager {
     if (automation.status !== 'active') return undefined;
     automation.status = 'paused';
     automation.updatedAt = this.deps.now();
+    automation.waiting = undefined;
     return automation;
   }
 
@@ -190,6 +197,7 @@ export class AutomationManager {
     // count toward re-pausing it after a single fresh failure.
     automation.consecutiveFailures = 0;
     automation.lastError = null;
+    automation.waiting = undefined;
     automation.nextFireAt = this.computeNextFire(automation.schedule, this.deps.now());
     return automation;
   }
@@ -232,6 +240,7 @@ export class AutomationManager {
       automation.status = 'expired';
       automation.nextFireAt = null;
       automation.updatedAt = now;
+      automation.waiting = undefined;
       return true;
     }
     return false;
@@ -247,6 +256,7 @@ export class AutomationManager {
     if (!automation || automation.status !== 'active') return undefined;
 
     const now = this.deps.now();
+    automation.waiting = undefined;
     // Check expiry BEFORE firing — don't execute expired automations.
     if (automation.expiresAt && now >= automation.expiresAt) {
       automation.status = 'expired';
@@ -278,21 +288,34 @@ export class AutomationManager {
     return automation;
   }
 
-  /**
-   * Record a fire attempt deferred by the idle-gate (target busy). Pure
-   * observability — surfaced in the model-facing list output.
-   */
+  /** Record a transient scheduler deferral. */
   recordDeferredFire(id: string): void {
     const automation = this.automations.get(id);
     if (!automation || automation.status !== 'active') return;
     automation.deferredFireCount = (automation.deferredFireCount ?? 0) + 1;
+    automation.waiting = undefined;
+    automation.updatedAt = this.deps.now();
   }
 
-  /** Record a retry for a fire that was admitted while the definition was active. */
+  /** Record a transient retry for a fire that was admitted while the definition was active. */
   recordAdmittedFireDeferred(id: string): void {
     const automation = this.automations.get(id);
     if (!automation) return;
     automation.deferredFireCount = (automation.deferredFireCount ?? 0) + 1;
+    automation.waiting = undefined;
+    automation.updatedAt = this.deps.now();
+  }
+
+  /** Persist a missing execution prerequisite without consuming the transient retry window. */
+  recordPrerequisiteWaiting(id: string, waiting: AutomationWaitingState): boolean {
+    const automation = this.automations.get(id);
+    if (!automation || automation.status !== 'active') return false;
+    const current = automation.waiting;
+    if (current?.reason === waiting.reason && current.message === waiting.message) return false;
+    automation.deferredFireCount = (automation.deferredFireCount ?? 0) + 1;
+    automation.waiting = mergeWaitingState(current, waiting);
+    automation.updatedAt = this.deps.now();
+    return true;
   }
 
   /**
@@ -313,7 +336,9 @@ export class AutomationManager {
     if (automation.schedule.type === 'once') {
       automation.nextFireAt = null;
       automation.status = 'expired';
-      automation.lastError = 'Fire window skipped (session busy or privacy mode)';
+      automation.lastError =
+        automation.waiting?.message ?? 'Fire window skipped (session busy or privacy mode)';
+      automation.waiting = undefined;
       return;
     }
     automation.nextFireAt = this.computeNextFire(automation.schedule, now);
@@ -338,6 +363,11 @@ export class AutomationManager {
     const automation = this.automations.get(id);
     if (!automation) return;
     settleAutomationAttempt(automation, { status: 'failed', error }, this.deps.now());
+  }
+
+  clearWaiting(id: string): void {
+    const automation = this.automations.get(id);
+    if (automation) automation.waiting = undefined;
   }
 
   removeAllForSession(sessionId: string): number {
@@ -459,6 +489,7 @@ export function settleAutomationAttempt(
   if (automation.status === 'completed' || automation.status === 'expired') return;
   if (outcome.runId) automation.lastRunId = outcome.runId;
   automation.updatedAt = now;
+  automation.waiting = undefined;
   if (outcome.status === 'completed') {
     automation.consecutiveFailures = 0;
     automation.lastError = null;
@@ -481,6 +512,15 @@ export function settleAutomationAttempt(
   ) {
     automation.status = 'paused';
   }
+}
+
+function mergeWaitingState(
+  current: AutomationWaitingState | undefined,
+  next: AutomationWaitingState,
+): AutomationWaitingState {
+  return current?.reason === next.reason
+    ? { ...next, since: current.since }
+    : structuredClone(next);
 }
 
 /**

--- a/packages/runtime/src/automation-tools.ts
+++ b/packages/runtime/src/automation-tools.ts
@@ -13,6 +13,7 @@ import {
   AUTOMATION_CRON_EXPRESSION_MAX_CODE_UNITS,
   AUTOMATION_NAME_LIMIT,
   AUTOMATION_NAME_MAX_CODE_UNITS,
+  AUTOMATION_MAX_CLIENT_CAPABILITY_REQUIREMENTS,
   AUTOMATION_PROMPT_LIMIT,
   AUTOMATION_PROMPT_MAX_CODE_UNITS,
   isAutomationTextWithinLimit,
@@ -33,6 +34,7 @@ export interface AutomationToolAuthority {
     schedule: AutomationDefinition['schedule'];
     maxFires?: number;
     durable?: boolean;
+    requiredCapabilityGroups?: readonly string[];
   }): AutomationDefinition | { error: string } | Promise<AutomationDefinition | { error: string }>;
   delete(id: string, sessionId: string): boolean | Promise<boolean>;
   pause(
@@ -144,6 +146,16 @@ function makeAutomationSchema(kindSchema: z.ZodType) {
       .optional()
       .describe(
         '[create] When true, persists across app restarts. Cron defaults to true (standalone scheduled task); heartbeat defaults to false (bound to this session).',
+      ),
+    required_capability_groups: z
+      .array(z.string().regex(/^[A-Za-z0-9_-]{1,128}$/))
+      .max(AUTOMATION_MAX_CLIENT_CAPABILITY_REQUIREMENTS)
+      .refine((values) => new Set(values).size === values.length, {
+        message: 'Capability group ids must be unique.',
+      })
+      .optional()
+      .describe(
+        '[create] Client Capability group ids returned by load_tools that every fire requires. Omit for Host-native automations.',
       ),
     id: z.string().min(1).max(64).optional().describe('[delete/pause/resume] Automation id.'),
   });
@@ -330,6 +342,7 @@ async function handleCreate(
     schedule,
     maxFires: input.max_fires,
     durable: input.durable,
+    requiredCapabilityGroups: input.required_capability_groups,
   });
 
   if ('error' in result) {
@@ -375,6 +388,7 @@ function formatAutomation(a: AutomationDefinition): string {
   if (a.nextFireAt) lines.push(`  Next: ${new Date(a.nextFireAt).toLocaleString()}`);
   if (a.lastFireAt) lines.push(`  Last: ${new Date(a.lastFireAt).toLocaleString()}`);
   if (a.lastError) lines.push(`  Error: ${a.lastError}`);
+  if (a.waiting) lines.push(`  Waiting: ${a.waiting.message}`);
   if (a.consecutiveFailures > 0) lines.push(`  Consecutive failures: ${a.consecutiveFailures}`);
   return lines.join('\n');
 }

--- a/packages/runtime/src/mcp-tools.ts
+++ b/packages/runtime/src/mcp-tools.ts
@@ -45,6 +45,7 @@ export interface BuildMcpToolsOptions {
   callTimeoutMs?: number;
   categoryHint?: ToolCategory;
   recoveryMode?: ToolRecoveryMode;
+  executionLocation?: 'host' | 'remote';
 }
 
 export function buildMcpTools(
@@ -80,6 +81,7 @@ export function buildMcpTools(
       impl: async (args: unknown, context) => {
         // Managed network authority applies equally to Direct and nested CodeMode dispatch.
         if (
+          options.executionLocation !== 'remote' &&
           context.executionBoundary?.kind === 'managed' &&
           context.executionBoundary.profile.network.kind !== 'enabled'
         ) {

--- a/packages/storage/src/__tests__/automation-authority.test.ts
+++ b/packages/storage/src/__tests__/automation-authority.test.ts
@@ -42,7 +42,10 @@ describe('interactive Automation authority', () => {
         assert.equal(committed.snapshot.revision, 1);
 
         automation.name = 'mutated after commit';
-        assert.equal((await second.read()).automations[0]?.name, 'daily summary');
+        const persisted = (await second.read()).automations[0];
+        assert.equal(persisted?.name, 'daily summary');
+        assert.deepEqual(persisted?.capabilityRequirements, [capabilityRequirement()]);
+        assert.equal(persisted?.waiting?.reason, 'client_capability_provider_unavailable');
 
         assert.deepEqual(
           await second.commit({ expectedRevision: 0, automations: [], pendingFires: [] }),
@@ -220,6 +223,12 @@ function definitionWithPendingFire(): AutomationDefinition {
     nextFireAt: 120_002,
     lastFireAt: 60_002,
     fireCount: 1,
+    capabilityRequirements: [capabilityRequirement()],
+    waiting: {
+      reason: 'client_capability_provider_unavailable',
+      since: 60_002,
+      message: 'Capability provider is offline',
+    },
   };
 }
 
@@ -238,6 +247,7 @@ function pendingFire(): AutomationPendingFire {
     status: 'admitted',
     admittedAt: 60_002,
     updatedAt: 60_002,
+    capabilityRequirements: [capabilityRequirement()],
     execution: {
       cwd: '/workspace',
       backend: 'ai-sdk',
@@ -247,6 +257,14 @@ function pendingFire(): AutomationPendingFire {
       orchestrationMode: 'default',
     },
   };
+}
+
+function capabilityRequirement() {
+  return {
+    principalId: 'automation-provider',
+    clientInstanceId: 'provider-instance',
+    contractId: 'provider-contract',
+  } as const;
 }
 
 async function withWriter(

--- a/packages/storage/src/automation-authority.ts
+++ b/packages/storage/src/automation-authority.ts
@@ -4,14 +4,17 @@ import { isThinkingLevel } from '@maka/core/model-thinking';
 import {
   AUTOMATION_CRON_EXPRESSION_LIMIT,
   AUTOMATION_LAST_ERROR_LIMIT,
+  AUTOMATION_MAX_CLIENT_CAPABILITY_REQUIREMENTS,
   AUTOMATION_NAME_LIMIT,
   AUTOMATION_PROMPT_LIMIT,
   isAutomationTextWithinLimit,
   type AutomationAuthoritySnapshot,
+  type AutomationClientCapabilityRequirement,
   type AutomationDefinition,
   type AutomationExecutionTemplate,
   type AutomationPendingFire,
   type AutomationSchedule,
+  type AutomationWaitingState,
 } from '@maka/core/automation';
 import {
   acquireOperationalStateDatabase,
@@ -47,6 +50,8 @@ const DEFINITION_KEYS = new Set([
   'consecutiveFailures',
   'durable',
   'deferredFireCount',
+  'capabilityRequirements',
+  'waiting',
   'execution',
 ]);
 const PENDING_FIRE_KEYS = new Set([
@@ -63,7 +68,9 @@ const PENDING_FIRE_KEYS = new Set([
   'status',
   'admittedAt',
   'updatedAt',
+  'transientDeferredSince',
   'startedAt',
+  'capabilityRequirements',
   'execution',
 ]);
 
@@ -363,7 +370,9 @@ function assertSnapshotRelationships(
       automation.lastFireAt > fire.admittedAt ||
       (automation.kind === 'heartbeat' && automation.sessionId !== fire.targetSessionId) ||
       (automation.kind === 'cron' &&
-        JSON.stringify(automation.execution) !== JSON.stringify(fire.execution))
+        JSON.stringify(automation.execution) !== JSON.stringify(fire.execution)) ||
+      JSON.stringify(automation.capabilityRequirements ?? []) !==
+        JSON.stringify(fire.capabilityRequirements ?? [])
     ) {
       throw new Error(`Pending Automation fire contradicts its definition: ${fire.id}`);
     }
@@ -377,6 +386,8 @@ function normalizeAutomationDefinition(value: unknown): AutomationDefinition {
   const schedule = normalizeSchedule(value.schedule);
   const execution =
     value.execution === undefined ? undefined : normalizeExecutionTemplate(value.execution);
+  const capabilityRequirements = normalizeCapabilityRequirements(value.capabilityRequirements);
+  const waiting = value.waiting === undefined ? undefined : normalizeWaitingState(value.waiting);
   if (!isId(value.id) || !isId(value.sessionId)) throw new Error('Invalid Automation identity');
   if (value.kind !== 'heartbeat' && value.kind !== 'cron') {
     throw new Error('Invalid Automation kind');
@@ -433,6 +444,8 @@ function normalizeAutomationDefinition(value: unknown): AutomationDefinition {
     ...(value.deferredFireCount === undefined
       ? {}
       : { deferredFireCount: value.deferredFireCount }),
+    ...(capabilityRequirements.length === 0 ? {} : { capabilityRequirements }),
+    ...(waiting ? { waiting } : {}),
     ...(execution ? { execution } : {}),
   } satisfies AutomationDefinition);
 }
@@ -462,11 +475,24 @@ function normalizePendingFire(value: unknown): AutomationPendingFire {
   }
   const startedAt =
     value.startedAt === undefined ? undefined : requireNonnegativeInteger(value.startedAt);
+  const transientDeferredSince =
+    value.transientDeferredSince === undefined
+      ? undefined
+      : requireNonnegativeInteger(value.transientDeferredSince);
   if ((value.status === 'running') !== (startedAt !== undefined)) {
     throw new Error('Pending Automation fire start state is inconsistent');
   }
+  if (
+    transientDeferredSince !== undefined &&
+    (value.status === 'running' ||
+      transientDeferredSince < value.admittedAt ||
+      transientDeferredSince > value.updatedAt)
+  ) {
+    throw new Error('Pending Automation fire deferral state is inconsistent');
+  }
   const execution =
     value.execution === undefined ? undefined : normalizeExecutionTemplate(value.execution);
+  const capabilityRequirements = normalizeCapabilityRequirements(value.capabilityRequirements);
   if ((value.automationKind === 'cron') !== (execution !== undefined)) {
     throw new Error('Pending cron fire must freeze its execution template');
   }
@@ -484,9 +510,60 @@ function normalizePendingFire(value: unknown): AutomationPendingFire {
     status: value.status,
     admittedAt: value.admittedAt,
     updatedAt: value.updatedAt,
+    ...(transientDeferredSince === undefined ? {} : { transientDeferredSince }),
     ...(startedAt === undefined ? {} : { startedAt }),
+    ...(capabilityRequirements.length === 0 ? {} : { capabilityRequirements }),
     ...(execution ? { execution } : {}),
   } satisfies AutomationPendingFire);
+}
+
+function normalizeCapabilityRequirements(value: unknown): AutomationClientCapabilityRequirement[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.length > AUTOMATION_MAX_CLIENT_CAPABILITY_REQUIREMENTS) {
+    throw new Error('Invalid Automation Client Capability requirements');
+  }
+  const requirements = value.map((entry) => {
+    if (
+      !isRecord(entry) ||
+      !hasOnlyKeys(entry, new Set(['principalId', 'clientInstanceId', 'contractId'])) ||
+      typeof entry.principalId !== 'string' ||
+      !/^[A-Za-z0-9_.:-]{1,128}$/.test(entry.principalId) ||
+      !isId(entry.clientInstanceId) ||
+      !isId(entry.contractId)
+    ) {
+      throw new Error('Invalid Automation Client Capability requirement');
+    }
+    return {
+      principalId: entry.principalId,
+      clientInstanceId: entry.clientInstanceId,
+      contractId: entry.contractId,
+    };
+  });
+  const identities = requirements.map(
+    (requirement) =>
+      `${requirement.principalId}\0${requirement.clientInstanceId}\0${requirement.contractId}`,
+  );
+  if (new Set(identities).size !== identities.length) {
+    throw new Error('Duplicate Automation Client Capability requirement');
+  }
+  return requirements;
+}
+
+function normalizeWaitingState(value: unknown): AutomationWaitingState {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, new Set(['reason', 'since', 'message'])) ||
+    value.reason !== 'client_capability_provider_unavailable' ||
+    !isNonnegativeInteger(value.since) ||
+    !isAutomationTextWithinLimit(value.message, AUTOMATION_LAST_ERROR_LIMIT)
+  ) {
+    throw new Error('Invalid Automation waiting state');
+  }
+  return {
+    reason: value.reason,
+    since: value.since,
+    message: value.message,
+  };
 }
 
 function normalizeSchedule(value: unknown): AutomationSchedule {


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

This adds the trusted capability-provider vertical slice for standalone Runtime Host deployments:

- add `maka runtime-host capability-provider serve` to publish MCP-backed tools over an authenticated Runtime Host connection, with bounded reconnect and publication recovery;
- issue a narrowly scoped capability-provider credential that can publish and serve capabilities without unrelated remote-owner or Host-path authority;
- keep remote capability manifests path-free by default and explicitly declare whether an offer may receive the Host session cwd;
- let Automations durably require one exact provider identity, report provider-unavailable waiting state, and resume without consuming the transient deferral window while the provider is offline;
- bound and validate projected manifests before publication, pack tools within protocol offer limits, and prevent the Runtime Host credential from reaching MCP child-process environments.

Refs #2522

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run test:dist` in `packages/runtime-host`
- `npm run test:dist` in `packages/runtime`
- `npm run test:dist` in `packages/storage`
- `npm run test:dist` in `packages/cli`
- `npm run test:dist` in `packages/mcp`

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

本 PR 为独立部署的 Runtime Host 增加可信 capability provider 的纵向能力闭环：

- 增加 `maka runtime-host capability-provider serve`，通过经过认证的 Runtime Host 连接发布并提供 MCP 工具，同时支持有界重连与 publication 恢复；
- 签发最小权限的 capability-provider credential，使 provider 可以发布和提供能力，但不获得无关的 remote-owner 权限或 Host 路径权限；
- 远程 capability manifest 默认不包含路径，并由 offer 显式声明是否可以接收 Host Session cwd；
- Automation 可以持久要求一个精确 provider 身份，在 provider 不可用时进入明确的等待状态，并在 provider 离线期间不消耗 transient deferral 时间窗口；
- publication 前对 manifest 做有界校验，将工具打包在 protocol offer 上限内，并防止 Runtime Host credential 进入 MCP 子进程环境。

Refs #2522

## 验证

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- 在 `packages/runtime-host` 中运行 `npm run test:dist`
- 在 `packages/runtime` 中运行 `npm run test:dist`
- 在 `packages/storage` 中运行 `npm run test:dist`
- 在 `packages/cli` 中运行 `npm run test:dist`
- 在 `packages/mcp` 中运行 `npm run test:dist`

## 检查清单

- [x] 测试覆盖本次变更，并会在缺少实现时失败
- [x] lint、format、typecheck 与受影响测试套件均已在本地通过

本 PR 是否改变行为？

- [x] 是——已在上方“概要”中说明
- [ ] 否

</details>