### PR TITLE
fix(runtime-host): stop agent graph supervisor wakes

### DIFF
--- a/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
@@ -32,21 +32,28 @@ describe('Host Agent Graph coordinator', () => {
     let listener: AgentGraphClientChangedListener | undefined;
     let unsubscribed = false;
     const invalidations: unknown[] = [];
+    const stopOrder: string[] = [];
+    const authority = {
+      getSnapshot: async () => snapshot,
+      inspectOperator: async () => inspection,
+      stop: async (rootSessionId: string) => {
+        stopOrder.push('graph');
+        stoppedRoot = rootSessionId;
+      },
+      subscribeAll: (candidate: AgentGraphClientChangedListener) => {
+        listener = candidate;
+        return () => {
+          unsubscribed = true;
+        };
+      },
+    } satisfies GraphAuthority;
     const coordinator = new HostAgentGraphCoordinator({
-      authority: {
-        getSnapshot: async () => snapshot,
-        inspectOperator: async () => inspection,
-        stop: async (rootSessionId) => {
-          stoppedRoot = rootSessionId;
-        },
-        subscribeAll: (candidate) => {
-          listener = candidate;
-          return () => {
-            unsubscribed = true;
-          };
-        },
-      } satisfies GraphAuthority,
+      authority,
       continuity: { enqueueAgentGraphChanged: (event) => invalidations.push(event) },
+      stopExecution: async (rootSessionId) => {
+        stopOrder.push('root');
+        await authority.stop(rootSessionId);
+      },
     });
 
     const queried = await coordinator.handlers['agent.graph.query'](
@@ -78,6 +85,7 @@ describe('Host Agent Graph coordinator', () => {
       result: { rootSessionId: 'root-1', graphId: snapshot.graphId },
     });
     assert.equal(stoppedRoot, 'root-1');
+    assert.deepEqual(stopOrder, ['root', 'graph']);
 
     await listener?.({
       schemaVersion: 1,

--- a/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
@@ -32,14 +32,9 @@ describe('Host Agent Graph coordinator', () => {
     let listener: AgentGraphClientChangedListener | undefined;
     let unsubscribed = false;
     const invalidations: unknown[] = [];
-    const stopOrder: string[] = [];
     const authority = {
       getSnapshot: async () => snapshot,
       inspectOperator: async () => inspection,
-      stop: async (rootSessionId: string) => {
-        stopOrder.push('graph');
-        stoppedRoot = rootSessionId;
-      },
       subscribeAll: (candidate: AgentGraphClientChangedListener) => {
         listener = candidate;
         return () => {
@@ -51,8 +46,7 @@ describe('Host Agent Graph coordinator', () => {
       authority,
       continuity: { enqueueAgentGraphChanged: (event) => invalidations.push(event) },
       stopExecution: async (rootSessionId) => {
-        stopOrder.push('root');
-        await authority.stop(rootSessionId);
+        stoppedRoot = rootSessionId;
       },
     });
 
@@ -85,7 +79,6 @@ describe('Host Agent Graph coordinator', () => {
       result: { rootSessionId: 'root-1', graphId: snapshot.graphId },
     });
     assert.equal(stoppedRoot, 'root-1');
-    assert.deepEqual(stopOrder, ['root', 'graph']);
 
     await listener?.({
       schemaVersion: 1,
@@ -118,18 +111,18 @@ describe('Host Agent Graph coordinator', () => {
       inspectOperator: async () => {
         throw new AgentGraphClientOperationError('not_found', 'Agent graph operator was not found');
       },
-      stop: async () => {
-        throw new AgentGraphClientOperationError(
-          'session_archived',
-          'Archived Sessions cannot supervise an agent graph',
-        );
-      },
       subscribeAll: () => () => undefined,
     } satisfies GraphAuthority;
 
     const child = new HostAgentGraphCoordinator({
       authority,
       continuity: { enqueueAgentGraphChanged: () => undefined },
+      stopExecution: async () => {
+        throw new AgentGraphClientOperationError(
+          'session_archived',
+          'Archived Sessions cannot supervise an agent graph',
+        );
+      },
     });
     const childQuery = await child.handlers['agent.graph.query'](
       { rootSessionId: 'root-1' },
@@ -278,7 +271,7 @@ describe('Host Agent Graph coordinator', () => {
 
 type GraphAuthority = Pick<
   AgentGraphCoordinator,
-  'getSnapshot' | 'inspectOperator' | 'stop' | 'subscribeAll'
+  'getSnapshot' | 'inspectOperator' | 'subscribeAll'
 >;
 
 function graphSnapshot(): RuntimeAgentGraphClientSnapshot {

--- a/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
@@ -57,6 +57,7 @@ test('two Clients query and control one Agent graph through Session invalidation
       const graph = new HostAgentGraphCoordinator({
         authority,
         continuity,
+        stopExecution: (rootSessionId) => authority.stopExecution(rootSessionId),
       });
       return {
         handlers: {
@@ -150,7 +151,7 @@ test('two Clients query and control one Agent graph through Session invalidation
 
 type GraphAuthority = Pick<
   AgentGraphCoordinator,
-  'getSnapshot' | 'inspectOperator' | 'stop' | 'subscribeAll'
+  'getSnapshot' | 'inspectOperator' | 'subscribeAll'
 >;
 
 class FakeAgentGraphAuthority implements GraphAuthority {
@@ -171,7 +172,8 @@ class FakeAgentGraphAuthority implements GraphAuthority {
    *  probe cycles — causal ordering, no fixed timing at all. */
   stopGate: Promise<void> = Promise.resolve();
 
-  async stop(): Promise<void> {
+  async stopExecution(rootSessionId: string): Promise<void> {
+    assert.equal(rootSessionId, ROOT_SESSION_ID);
     await this.stopGate;
     this.stopCount += 1;
     this.#snapshot.status = 'stopped';

--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -319,7 +319,7 @@ test('new Full Access Plan Skill previews use the mutating tool surface', async 
   });
 });
 
-test('production execution composition owns claimed graph activation retry and exact abort', async () => {
+test('production composition validates graph stop before aborting a claimed child', async () => {
   await withCompositionRoot(async ({ root, owner }) => {
     const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
     const claims = createAgentGraphControlStore(root);
@@ -416,6 +416,30 @@ test('production execution composition owns claimed graph activation retry and e
         onReady: ready,
       });
       await started;
+      const clientContext = {
+        hostEpoch: 'execution-composition-test',
+        connectionId: 'graph-stop-client',
+        surface: 'tui' as const,
+        principal: 'local_os_user' as const,
+        acquireResidency: () => ({ release() {} }),
+      };
+      const invalidStop = await composition.handlers['agent.graph.stop'](
+        { rootSessionId: abortedClaim.targetSessionId },
+        clientContext,
+      );
+      assert.equal(invalidStop.ok, false);
+      if (invalidStop.ok) return;
+      assert.equal(invalidStop.error.code, 'operation_conflict');
+      const stillActive = await composition.handlers['turn.query'](
+        {
+          sessionId: abortedClaim.targetSessionId,
+          turnId: abortedClaim.targetTurnId,
+        },
+        clientContext,
+      );
+      assert.equal(stillActive.ok, true);
+      if (!stillActive.ok) return;
+      assert.equal(['completed', 'failed', 'cancelled'].includes(stillActive.result.status), false);
       abort.abort();
       const aborted = await aborting;
       assert.equal(aborted.status, 'cancelled');

--- a/packages/runtime-host/src/server/agent-graph-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-coordinator.ts
@@ -70,13 +70,17 @@ export class HostAgentGraphCoordinator {
   };
 
   readonly #authority: AgentGraphAuthority;
+  readonly #stopExecution: (rootSessionId: string) => Promise<void>;
   #unsubscribe: (() => void) | undefined;
 
   constructor(options: {
     authority: AgentGraphAuthority;
     continuity: GraphContinuity;
+    stopExecution?: (rootSessionId: string) => Promise<void>;
   }) {
     this.#authority = options.authority;
+    this.#stopExecution =
+      options.stopExecution ?? ((rootSessionId) => this.#authority.stop(rootSessionId));
     this.#unsubscribe = options.authority.subscribeAll((event) =>
       options.continuity.enqueueAgentGraphChanged(projectChangedEvent(event)),
     );
@@ -114,7 +118,7 @@ export class HostAgentGraphCoordinator {
 
   async #stop(input: AgentGraphStopInput): Promise<OperationOutcome<'agent.graph.stop'>> {
     try {
-      await this.#authority.stop(input.rootSessionId);
+      await this.#stopExecution(input.rootSessionId);
       return {
         ok: true,
         result: {

--- a/packages/runtime-host/src/server/agent-graph-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-coordinator.ts
@@ -42,7 +42,7 @@ import type { SessionContinuityCoordinator } from './session-continuity-coordina
 
 type AgentGraphAuthority = Pick<
   AgentGraphCoordinator,
-  'getSnapshot' | 'inspectOperator' | 'stop' | 'subscribeAll'
+  'getSnapshot' | 'inspectOperator' | 'subscribeAll'
 >;
 
 type GraphContinuity = Pick<SessionContinuityCoordinator, 'enqueueAgentGraphChanged'>;
@@ -76,11 +76,10 @@ export class HostAgentGraphCoordinator {
   constructor(options: {
     authority: AgentGraphAuthority;
     continuity: GraphContinuity;
-    stopExecution?: (rootSessionId: string) => Promise<void>;
+    stopExecution: (rootSessionId: string) => Promise<void>;
   }) {
     this.#authority = options.authority;
-    this.#stopExecution =
-      options.stopExecution ?? ((rootSessionId) => this.#authority.stop(rootSessionId));
+    this.#stopExecution = options.stopExecution;
     this.#unsubscribe = options.authority.subscribeAll((event) =>
       options.continuity.enqueueAgentGraphChanged(projectChangedEvent(event)),
     );

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -884,15 +884,17 @@ export async function createExecutionRuntimeHostComposition(
       authority: graphCoordinator,
       continuity: continuityCoordinator,
       stopExecution: (rootSessionId) =>
-        requireGraphSupervisorWake(graphSupervisorWake).runWithSessionWakesSuppressed(
-          rootSessionId,
-          async () => {
-            await requireRootCoordinator(rootCoordinator).stopSession(rootSessionId, {
+        requireGraphCoordinator(graphCoordinator).stopExecution(rootSessionId, {
+          stopRoot: () =>
+            requireRootCoordinator(rootCoordinator).stopSession(rootSessionId, {
               source: 'stop_button',
-            });
-            await requireGraphCoordinator(graphCoordinator).stop(rootSessionId);
-          },
-        ),
+            }),
+          withSupervisorWakesSuppressed: (operation) =>
+            requireGraphSupervisorWake(graphSupervisorWake).runWithSessionWakesSuppressed(
+              rootSessionId,
+              operation,
+            ),
+        }),
     });
     const observeBackendInvalidation = (completion: Promise<void>) => {
       void completion.catch(() => {

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -883,6 +883,16 @@ export async function createExecutionRuntimeHostComposition(
     graphClient = new HostAgentGraphCoordinator({
       authority: graphCoordinator,
       continuity: continuityCoordinator,
+      stopExecution: (rootSessionId) =>
+        requireGraphSupervisorWake(graphSupervisorWake).runWithSessionWakesSuppressed(
+          rootSessionId,
+          async () => {
+            await requireRootCoordinator(rootCoordinator).stopSession(rootSessionId, {
+              source: 'stop_button',
+            });
+            await requireGraphCoordinator(graphCoordinator).stop(rootSessionId);
+          },
+        ),
     });
     const observeBackendInvalidation = (completion: Promise<void>) => {
       void completion.catch(() => {

--- a/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
@@ -704,9 +704,13 @@ describe('Agent Graph supervisor wake delivery', () => {
     }
   });
 
-  test('client stop aborts one Session wake without allowing an automatic retry', async () => {
+  test('overlapping client stops keep one Session wake suppressed until both settle', async () => {
     const store = createSqliteSessionMetadataStore(':memory:');
     const started = deferred();
+    const firstStopEntered = deferred();
+    const secondStopEntered = deferred();
+    const releaseFirstStop = deferred();
+    const releaseSecondStop = deferred();
     let snapshotVersion = 'snapshot-1';
     let turns = 0;
     const coordinator = new AgentGraphSupervisorWakeCoordinator({
@@ -731,7 +735,18 @@ describe('Agent Graph supervisor wake delivery', () => {
     try {
       coordinator.notify('root-session', reconciliation());
       await started.promise;
-      await coordinator.runWithSessionWakesSuppressed('root-session', async () => undefined);
+      const firstStop = coordinator.runWithSessionWakesSuppressed('root-session', async () => {
+        firstStopEntered.resolve();
+        await releaseFirstStop.promise;
+      });
+      await firstStopEntered.promise;
+      const secondStop = coordinator.runWithSessionWakesSuppressed('root-session', async () => {
+        secondStopEntered.resolve();
+        await releaseSecondStop.promise;
+      });
+      await secondStopEntered.promise;
+      releaseFirstStop.resolve();
+      await firstStop;
 
       const stopped = await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1');
       assert.equal(stopped?.status, 'superseded');
@@ -739,6 +754,9 @@ describe('Agent Graph supervisor wake delivery', () => {
       assert.equal(turns, 1);
 
       snapshotVersion = 'snapshot-2';
+      assert.equal(coordinator.notify('root-session', reconciliation()), undefined);
+      releaseSecondStop.resolve();
+      await secondStop;
       coordinator.notify('root-session', reconciliation());
       await coordinator.waitForIdle();
       assert.equal(turns, 2);

--- a/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
@@ -703,6 +703,54 @@ describe('Agent Graph supervisor wake delivery', () => {
       store.close();
     }
   });
+
+  test('client stop aborts one Session wake without allowing an automatic retry', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const started = deferred();
+    let snapshotVersion = 'snapshot-1';
+    let turns = 0;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot({ snapshotVersion }),
+      startTurn: async (_sessionId, input, _activity, abortSignal) => {
+        turns += 1;
+        if (turns === 1) {
+          started.resolve();
+          await new Promise<void>((resolve) => {
+            if (abortSignal.aborted) resolve();
+            else abortSignal.addEventListener('abort', () => resolve(), { once: true });
+          });
+          return { kind: 'aborted', turnId: input.turnId };
+        }
+        return { kind: 'completed', turnId: input.turnId };
+      },
+      inspectAttempt: async () => 'missing',
+      newId: sequentialIds(),
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await started.promise;
+      await coordinator.runWithSessionWakesSuppressed('root-session', async () => undefined);
+
+      const stopped = await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1');
+      assert.equal(stopped?.status, 'superseded');
+      assert.equal(stopped?.attemptCount, 1);
+      assert.equal(turns, 1);
+
+      snapshotVersion = 'snapshot-2';
+      coordinator.notify('root-session', reconciliation());
+      await coordinator.waitForIdle();
+      assert.equal(turns, 2);
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-2'))?.status,
+        'delivered',
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
 });
 
 async function createRunningAttempt(

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -325,6 +325,20 @@ describe('host-managed agent graph coordinator', () => {
         coordinator.toolsForSession(childSessions[0]!.id),
         /only to root Sessions/,
       );
+      let childStopEntered = false;
+      await assert.rejects(
+        coordinator.stopExecution(childSessions[0]!.id, {
+          stopRoot: async () => {
+            childStopEntered = true;
+          },
+          withSupervisorWakesSuppressed: async (operation) => {
+            childStopEntered = true;
+            await operation();
+          },
+        }),
+        /only to root Sessions/,
+      );
+      assert.equal(childStopEntered, false);
 
       const canonicalProjection = await controlStore.readAgentGraphClientProjection(graphId);
       assert.ok(canonicalProjection);
@@ -430,7 +444,16 @@ describe('host-managed agent graph coordinator', () => {
       );
       await gate.started;
       try {
-        await recovered.stop(rootSession.id);
+        const rootStopFailure = new Error('root stop failed');
+        await assert.rejects(
+          recovered.stopExecution(rootSession.id, {
+            stopRoot: async () => {
+              throw rootStopFailure;
+            },
+            withSupervisorWakesSuppressed: (operation) => operation(),
+          }),
+          (error: unknown) => error === rootStopFailure,
+        );
       } finally {
         gate.release();
       }

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -227,8 +227,11 @@ export interface AgentGraphSupervisorWakeInput {
 export class AgentGraphSupervisorWakeCoordinator {
   readonly #input: AgentGraphSupervisorWakeInput;
   readonly #tasks = new Set<Promise<void>>();
+  readonly #tasksBySession = new Map<string, Set<Promise<void>>>();
   readonly #pendingWakeIds = new Set<string>();
   readonly #abortController = new AbortController();
+  readonly #sessionAbortControllers = new Map<string, AbortController>();
+  readonly #sessionWakeSuppressions = new Map<string, number>();
   readonly #maxDeliveryAttempts: number;
   #closed = false;
 
@@ -246,13 +249,14 @@ export class AgentGraphSupervisorWakeCoordinator {
   ): Promise<void> | undefined {
     if (
       this.#closed ||
+      this.#sessionWakesSuppressed(rootSessionId) ||
       (!this.#input.shouldWake && (!result || !isAgentGraphSupervisorMilestone(result)))
     ) {
       return undefined;
     }
-    return this.#runTracked(rootSessionId, async () => {
+    return this.#runTracked(rootSessionId, async (abortSignal) => {
       try {
-        await this.#wake(rootSessionId, result);
+        await this.#wake(rootSessionId, abortSignal, result);
       } catch (error) {
         if (!this.#closed && !isAbortError(error)) {
           await notifyError(this.#input.onError, rootSessionId, error);
@@ -269,10 +273,10 @@ export class AgentGraphSupervisorWakeCoordinator {
    * proves that waiter is gone and makes the wake eligible for a fresh turn.
    */
   notifyPermissionResponse(rootSessionId: string): Promise<void> | undefined {
-    if (this.#closed) return undefined;
-    return this.#runTracked(rootSessionId, async () => {
+    if (this.#closed || this.#sessionWakesSuppressed(rootSessionId)) return undefined;
+    return this.#runTracked(rootSessionId, async (abortSignal) => {
       try {
-        await this.#settlePermissionResponse(rootSessionId);
+        await this.#settlePermissionResponse(rootSessionId, abortSignal);
       } catch (error) {
         if (!this.#closed && !isAbortError(error)) {
           await notifyError(this.#input.onError, rootSessionId, error);
@@ -300,6 +304,24 @@ export class AgentGraphSupervisorWakeCoordinator {
     while (this.#tasks.size > 0) await Promise.all([...this.#tasks]);
   }
 
+  /** Prevent supervisor retries while one client stop owns the root graph. */
+  async runWithSessionWakesSuppressed<T>(
+    rootSessionId: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    this.#beginSessionWakeSuppression(rootSessionId);
+    try {
+      return await operation();
+    } finally {
+      try {
+        await this.#waitForSessionIdle(rootSessionId);
+        await this.#supersedeSession(rootSessionId, 'agent_graph_stopped');
+      } finally {
+        this.#endSessionWakeSuppression(rootSessionId);
+      }
+    }
+  }
+
   hasLiveSessionState(rootSessionId: string): boolean {
     return this.#input.activityRegistry.whenIdle(rootSessionId) !== undefined;
   }
@@ -316,15 +338,21 @@ export class AgentGraphSupervisorWakeCoordinator {
     this.#closed = true;
     this.#abortController.abort();
     await this.waitForIdle();
+    this.#sessionAbortControllers.clear();
+    this.#tasksBySession.clear();
   }
 
   async #wake(
     rootSessionId: string,
+    abortSignal: AbortSignal,
     result?: AgentGraphScheduleReconciliationResult,
   ): Promise<void> {
+    abortSignal.throwIfAborted();
     if (!(await this.#isSessionDeliverable(rootSessionId))) return;
     const snapshot = await this.#input.readSnapshot(rootSessionId);
+    abortSignal.throwIfAborted();
     const wakeDecision = await this.#input.shouldWake?.(rootSessionId, result, snapshot);
+    abortSignal.throwIfAborted();
     if (
       wakeDecision === false ||
       (wakeDecision === undefined && (!result || !isAgentGraphSupervisorMilestone(result)))
@@ -344,7 +372,8 @@ export class AgentGraphSupervisorWakeCoordinator {
         rootSessionId,
       });
       if (this.#closed || claimed.wake.status === 'delivered') return;
-      await this.#deliverWake(claimed.wake, snapshot, result);
+      abortSignal.throwIfAborted();
+      await this.#deliverWake(claimed.wake, snapshot, abortSignal, result);
     } finally {
       this.#pendingWakeIds.delete(wakeId);
     }
@@ -353,9 +382,9 @@ export class AgentGraphSupervisorWakeCoordinator {
   #scheduleRecoveredWake(wake: AgentGraphSupervisorWakeRecord): void {
     if (this.#closed || this.#pendingWakeIds.has(wake.wakeId)) return;
     this.#pendingWakeIds.add(wake.wakeId);
-    void this.#runTracked(wake.rootSessionId, async () => {
+    void this.#runTracked(wake.rootSessionId, async (abortSignal) => {
       try {
-        await this.#resumeWake(wake);
+        await this.#resumeWake(wake, abortSignal);
       } catch (error) {
         if (!this.#closed && !isAbortError(error)) {
           await notifyError(this.#input.onError, wake.rootSessionId, error);
@@ -366,20 +395,28 @@ export class AgentGraphSupervisorWakeCoordinator {
     });
   }
 
-  #runTracked(rootSessionId: string, operation: () => Promise<void>): Promise<void> {
+  #runTracked(
+    rootSessionId: string,
+    operation: (abortSignal: AbortSignal) => Promise<void>,
+  ): Promise<void> {
     const residency = this.#input.acquireResidency?.(rootSessionId);
+    const abortSignal = this.#sessionAbortSignal(rootSessionId);
     const task = Promise.resolve()
-      .then(operation)
+      .then(() => operation(abortSignal))
       .finally(() => residency?.release());
     this.#tasks.add(task);
+    const sessionTasks = this.#tasksBySession.get(rootSessionId) ?? new Set<Promise<void>>();
+    sessionTasks.add(task);
+    this.#tasksBySession.set(rootSessionId, sessionTasks);
     void task.then(
-      () => this.#tasks.delete(task),
-      () => this.#tasks.delete(task),
+      () => this.#forgetTask(rootSessionId, task),
+      () => this.#forgetTask(rootSessionId, task),
     );
     return task;
   }
 
-  async #resumeWake(wake: AgentGraphSupervisorWakeRecord): Promise<void> {
+  async #resumeWake(wake: AgentGraphSupervisorWakeRecord, abortSignal: AbortSignal): Promise<void> {
+    abortSignal.throwIfAborted();
     if (!(await this.#isSessionDeliverable(wake.rootSessionId))) {
       await this.#supersedeSession(wake.rootSessionId, 'session_unavailable');
       return;
@@ -393,12 +430,14 @@ export class AgentGraphSupervisorWakeCoordinator {
     ) {
       return;
     }
-    await this.#deliverWake(wake, snapshot);
+    abortSignal.throwIfAborted();
+    await this.#deliverWake(wake, snapshot, abortSignal);
   }
 
   async #deliverWake(
     wake: AgentGraphSupervisorWakeRecord,
     snapshot: AgentGraphClientSnapshot,
+    abortSignal: AbortSignal,
     result?: AgentGraphScheduleReconciliationResult,
   ): Promise<void> {
     const presentation = (await this.#input.renderWake?.(wake.rootSessionId, snapshot, result)) ?? {
@@ -409,17 +448,15 @@ export class AgentGraphSupervisorWakeCoordinator {
     let lastFailure: string | undefined;
     let overflowRecoveryAttempted = false;
     for (let index = 0; index < this.#maxDeliveryAttempts; index += 1) {
+      abortSignal.throwIfAborted();
       if (!(await this.#isSessionDeliverable(wake.rootSessionId))) {
         await this.#supersedeSession(wake.rootSessionId, 'session_unavailable');
         return;
       }
       let overflowAttempt: { attemptId: string; turnId: string; failureReason: string } | undefined;
-      const activity = await this.#input.activityRegistry.acquire(
-        wake.rootSessionId,
-        this.#abortController.signal,
-      );
+      const activity = await this.#input.activityRegistry.acquire(wake.rootSessionId, abortSignal);
       try {
-        if (this.#closed) return;
+        if (this.#closed || this.#sessionWakesSuppressed(wake.rootSessionId)) return;
         const attemptId = this.#input.newId();
         const turnId = this.#input.newId();
         const admission = await this.#input.wakeStore.beginAgentGraphSupervisorWakeAttempt({
@@ -429,6 +466,7 @@ export class AgentGraphSupervisorWakeCoordinator {
           turnId,
         });
         if (!admission.acquired) return;
+        if (this.#sessionWakesSuppressed(wake.rootSessionId)) return;
         if (this.#closed) {
           await this.#markRetryable(wake.graphId, wake.wakeId, attemptId, 'host_shutdown');
           return;
@@ -450,9 +488,10 @@ export class AgentGraphSupervisorWakeCoordinator {
               },
             },
             activity,
-            this.#abortController.signal,
+            abortSignal,
             () => this.#isWakeCurrent(wake),
           );
+          if (this.#sessionWakesSuppressed(wake.rootSessionId)) return;
           if (outcome.kind === 'completed') {
             await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
               graphId: wake.graphId,
@@ -487,6 +526,7 @@ export class AgentGraphSupervisorWakeCoordinator {
             overflowAttempt = { attemptId, turnId, failureReason: lastFailure };
           }
         } catch (error) {
+          if (this.#sessionWakesSuppressed(wake.rootSessionId)) return;
           lastFailure = errorMessage(error);
           await this.#markRetryable(wake.graphId, wake.wakeId, attemptId, lastFailure);
           if (isSupervisorContextOverflow(lastFailure)) {
@@ -496,7 +536,7 @@ export class AgentGraphSupervisorWakeCoordinator {
       } finally {
         activity.release();
       }
-      if (this.#closed) return;
+      if (this.#closed || this.#sessionWakesSuppressed(wake.rootSessionId)) return;
       if (overflowAttempt) {
         const canRecover =
           !overflowRecoveryAttempted &&
@@ -528,7 +568,7 @@ export class AgentGraphSupervisorWakeCoordinator {
             graphId: wake.graphId,
             wakeId: wake.wakeId,
             ...overflowAttempt,
-            abortSignal: this.#abortController.signal,
+            abortSignal,
           });
           await emitWakeDiagnostic(this.#input.onDiagnostic, {
             event: 'context_overflow_recovery_completed',
@@ -604,6 +644,7 @@ export class AgentGraphSupervisorWakeCoordinator {
   }
 
   async #isWakeCurrent(wake: AgentGraphSupervisorWakeRecord): Promise<boolean> {
+    if (this.#sessionWakesSuppressed(wake.rootSessionId)) return false;
     if (!(await this.#isSessionDeliverable(wake.rootSessionId))) return false;
     const snapshot = await this.#input.readSnapshot(wake.rootSessionId);
     return (
@@ -649,14 +690,11 @@ export class AgentGraphSupervisorWakeCoordinator {
     return 1;
   }
 
-  async #settlePermissionResponse(rootSessionId: string): Promise<void> {
-    const activity = await this.#input.activityRegistry.acquire(
-      rootSessionId,
-      this.#abortController.signal,
-    );
+  async #settlePermissionResponse(rootSessionId: string, abortSignal: AbortSignal): Promise<void> {
+    const activity = await this.#input.activityRegistry.acquire(rootSessionId, abortSignal);
     const retryable: AgentGraphSupervisorWakeRecord[] = [];
     try {
-      if (this.#closed) return;
+      if (this.#closed || this.#sessionWakesSuppressed(rootSessionId)) return;
       const unsettled = (
         await this.#input.wakeStore.listUnsettledAgentGraphSupervisorWakes()
       ).filter((wake) => wake.rootSessionId === rootSessionId);
@@ -691,6 +729,58 @@ export class AgentGraphSupervisorWakeCoordinator {
       activity.release();
     }
     for (const wake of retryable) this.#scheduleRecoveredWake(wake);
+  }
+
+  #beginSessionWakeSuppression(rootSessionId: string): void {
+    const count = this.#sessionWakeSuppressions.get(rootSessionId) ?? 0;
+    this.#sessionWakeSuppressions.set(rootSessionId, count + 1);
+    if (count === 0) {
+      const controller = this.#sessionAbortControllers.get(rootSessionId) ?? new AbortController();
+      this.#sessionAbortControllers.set(rootSessionId, controller);
+      controller.abort();
+    }
+  }
+
+  #endSessionWakeSuppression(rootSessionId: string): void {
+    const count = this.#sessionWakeSuppressions.get(rootSessionId);
+    if (count === undefined) return;
+    if (count > 1) {
+      this.#sessionWakeSuppressions.set(rootSessionId, count - 1);
+      return;
+    }
+    this.#sessionWakeSuppressions.delete(rootSessionId);
+    if (!this.#tasksBySession.has(rootSessionId)) {
+      this.#sessionAbortControllers.delete(rootSessionId);
+    }
+  }
+
+  #sessionWakesSuppressed(rootSessionId: string): boolean {
+    return this.#sessionWakeSuppressions.has(rootSessionId);
+  }
+
+  #sessionAbortSignal(rootSessionId: string): AbortSignal {
+    let controller = this.#sessionAbortControllers.get(rootSessionId);
+    if (!controller) {
+      controller = new AbortController();
+      this.#sessionAbortControllers.set(rootSessionId, controller);
+    }
+    return AbortSignal.any([this.#abortController.signal, controller.signal]);
+  }
+
+  async #waitForSessionIdle(rootSessionId: string): Promise<void> {
+    while (this.#tasksBySession.has(rootSessionId)) {
+      await Promise.all([...this.#tasksBySession.get(rootSessionId)!]);
+    }
+  }
+
+  #forgetTask(rootSessionId: string, task: Promise<void>): void {
+    this.#tasks.delete(task);
+    const sessionTasks = this.#tasksBySession.get(rootSessionId);
+    sessionTasks?.delete(task);
+    if (sessionTasks?.size === 0) this.#tasksBySession.delete(rootSessionId);
+    if (!this.#sessionWakesSuppressed(rootSessionId) && !this.#tasksBySession.has(rootSessionId)) {
+      this.#sessionAbortControllers.delete(rootSessionId);
+    }
   }
 }
 

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -110,6 +110,11 @@ export interface AgentGraphCoordinatorInput {
   onError?(rootSessionId: string, error: unknown): void | Promise<void>;
 }
 
+export interface AgentGraphExecutionStopInput {
+  stopRoot(): Promise<void>;
+  withSupervisorWakesSuppressed(operation: () => Promise<void>): Promise<void>;
+}
+
 interface GraphDriver {
   rootSessionId: string;
   graphId: string;
@@ -501,6 +506,30 @@ export class AgentGraphCoordinator {
   async stop(rootSessionId: string): Promise<void> {
     await this.#assertRootSupervisor(rootSessionId);
     const driver = this.#driver(rootSessionId);
+    return this.#stopGraph(driver);
+  }
+
+  /** Stop the validated root supervisor and its graph under one wake fence. */
+  async stopExecution(rootSessionId: string, input: AgentGraphExecutionStopInput): Promise<void> {
+    await this.#assertRootSupervisor(rootSessionId);
+    const driver = this.#driver(rootSessionId);
+    await input.withSupervisorWakesSuppressed(async () => {
+      const failures: unknown[] = [];
+      try {
+        await input.stopRoot();
+      } catch (error) {
+        failures.push(error);
+      }
+      try {
+        await this.#stopGraph(driver);
+      } catch (error) {
+        failures.push(error);
+      }
+      throwCollectedFailures(`Failed to stop agent graph execution ${driver.graphId}`, failures);
+    });
+  }
+
+  #stopGraph(driver: GraphDriver): Promise<void> {
     if (driver.stopTask) return driver.stopTask;
     const stopTask = this.#stopDriver(driver).finally(() => {
       if (driver.stopTask === stopTask) driver.stopTask = undefined;


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Stopping an active Agent Graph now coordinates the complete root execution instead of pausing only the graph driver and its operator Sessions.

The Runtime Host suppresses and cancels pending supervisor wakes, stops the active root Turn, and then stops the graph driver. This ordering lets the existing graph generation fence reject schedule updates admitted before the stop, while terminally superseding the current wake so its retry policy cannot restart the graph. A later checkpoint can still start a new supervisor wake.

The previous behavior left the root supervisor wake outside the graph stop boundary. An active or retrying wake could therefore publish another schedule update and resume a graph after the user pressed Stop.

## Verification

- `npm run build --workspace @maka/runtime`
- `npm run build --workspace @maka/runtime-host`
- Runtime and Runtime Host Agent Graph coordinator suites: 41 passed
- Runtime Host complete compiled suite: 814 passed
- Biome and `git diff --check`

Manual Desktop reproduction was not rerun locally because the existing default data root uses a newer operational schema than this `main` checkout supports.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概述

停止正在运行的 Agent Graph 现在会协调完整的根执行流程，而不再只暂停 Graph driver 和它的 operator Sessions。

Runtime Host 会先抑制并取消待处理的 supervisor wakes，停止活跃的 root Turn，然后停止 Graph driver。这个顺序使已有的 Graph generation fence 能拒绝停止前获准的 schedule updates，同时将当前 wake 标记为终止，避免其重试策略重新启动 Graph。后续的新 checkpoint 仍然可以启动新的 supervisor wake。

此前 root supervisor wake 不在 Graph Stop 的边界内，因此活跃或正在重试的 wake 仍可能发布新的 schedule update，并在用户点击停止后重新唤醒 Graph。

## 验证

- `npm run build --workspace @maka/runtime`
- `npm run build --workspace @maka/runtime-host`
- Runtime 与 Runtime Host Agent Graph coordinator 测试：41 项通过
- Runtime Host 完整编译后测试：814 项通过
- Biome 与 `git diff --check`

由于本机默认 data root 的 operational schema 比当前 `main` 支持的版本更新，本地未重新执行 Desktop 手动复现。

## 检查清单

- [x] 测试覆盖此变更，并能在修复前失败
- [x] 本地 lint、format、typecheck 和受影响测试均通过

此 PR 是否包含行为变化？

- [x] 是——已在概述中说明
- [ ] 否

</details>

