### PR TITLE
feat(desktop): add Check for updates on the About page

### DIFF
--- a/apps/desktop/src/main/__tests__/about-update-status.test.ts
+++ b/apps/desktop/src/main/__tests__/about-update-status.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { getSettingsPreferencesCopy } from '../../renderer/locales/settings-preferences-copy.js';
+import { aboutUpdateStatusDetail } from '../../renderer/settings/about-update-status.js';
+
+const copy = getSettingsPreferencesCopy('zh').about;
+
+test('dev builds always show the development-build help line', () => {
+  assert.equal(
+    aboutUpdateStatusDetail(
+      { state: 'not-available', currentVersion: '0.1.9' },
+      copy,
+      { isDevBuild: true },
+    ),
+    copy.updateDevBuildHelp,
+  );
+});
+
+test('maps idle, latest, downloading, and error states for packaged builds', () => {
+  assert.equal(aboutUpdateStatusDetail(null, copy, { isDevBuild: false }), copy.updateIdle);
+  assert.equal(
+    aboutUpdateStatusDetail(
+      { state: 'not-available', currentVersion: '0.1.9', latestVersion: '0.1.9' },
+      copy,
+      { isDevBuild: false },
+    ),
+    copy.updateNotAvailable,
+  );
+  assert.equal(
+    aboutUpdateStatusDetail(
+      {
+        state: 'downloading',
+        currentVersion: '0.1.9',
+        latestVersion: '0.2.0',
+        progress: { percent: 42.4 },
+      },
+      copy,
+      { isDevBuild: false },
+    ),
+    copy.updateDownloading('0.2.0', 42),
+  );
+  assert.equal(
+    aboutUpdateStatusDetail(
+      {
+        state: 'error',
+        currentVersion: '0.1.9',
+        operation: 'check',
+        message: 'network down',
+      },
+      copy,
+      { isDevBuild: false },
+    ),
+    'network down',
+  );
+});

--- a/apps/desktop/src/main/__tests__/app-update-focus-check.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-focus-check.test.ts
@@ -104,4 +104,26 @@ describe('update check on window focus', () => {
 
     assert.equal(harness.checks.length, 0);
   });
+
+  test('manual checkForUpdatesNow ignores the focus throttle', async () => {
+    const harness = createHarness({ start: 1_000 });
+    harness.service.start();
+
+    await harness.service.checkForUpdatesOnFocus();
+    harness.advance(1_000);
+    await harness.service.checkForUpdatesNow();
+
+    // Focus is throttled for 15 minutes; the About button must still check.
+    assert.equal(harness.checks.length, 2);
+  });
+
+  test('manual checkForUpdatesNow works before start for packaged builds', async () => {
+    // The user can open Settings → About before the first scheduled check
+    // arms; a manual click must not depend on start().
+    const harness = createHarness({ start: 1_000 });
+
+    await harness.service.checkForUpdatesNow();
+
+    assert.equal(harness.checks.length, 1);
+  });
 });

--- a/apps/desktop/src/main/app-ipc-main.ts
+++ b/apps/desktop/src/main/app-ipc-main.ts
@@ -89,6 +89,7 @@ export function registerAppIpc(
     };
   });
   targetIpc.handle('app:updateStatus', (): AppUpdateStatus => updateService.getStatus());
+  targetIpc.handle('app:checkForUpdates', () => updateService.checkForUpdatesNow());
   targetIpc.handle('app:retryUpdateDownload', () => updateService.retryUpdateDownload());
   targetIpc.handle('app:installUpdate', (_event, input: unknown) => {
     if (!isAppUpdateInstallRequest(input)) throw new TypeError('Invalid app update install request');

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -56,6 +56,11 @@ export interface AppUpdateService {
   installUpdate(input: AppUpdateInstallRequest): Promise<AppUpdateInstallResult>;
   /** Check because the window regained focus, subject to a shared throttle. */
   checkForUpdatesOnFocus(): Promise<void>;
+  /**
+   * User-initiated check from Settings → About. Skips the focus throttle so
+   * the button always runs a real check (or joins an in-flight one).
+   */
+  checkForUpdatesNow(): Promise<AppUpdateStatus>;
 }
 
 interface AppUpdateServiceDeps {
@@ -405,6 +410,13 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     await checkForUpdates();
   }
 
+  async function checkForUpdatesNow(): Promise<AppUpdateStatus> {
+    if (disposed) return currentStatus();
+    // Explicit user action: always attempt (or join) a check; do not apply the
+    // focus throttle. Still refuses to restart a mid-flight download.
+    return checkForUpdates();
+  }
+
   return {
     start,
     dispose,
@@ -412,5 +424,6 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
     retryUpdateDownload,
     installUpdate,
     checkForUpdatesOnFocus,
+    checkForUpdatesNow,
   };
 }

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -773,6 +773,7 @@ export interface MakaBridge {
     }>;
     subscribeUpdateStatus(handler: (status: AppUpdateStatus) => void): () => void;
     updateStatus(): Promise<AppUpdateStatus>;
+    checkForUpdates(): Promise<AppUpdateStatus>;
     retryUpdateDownload(): Promise<AppUpdateStatus>;
     installUpdate(input: AppUpdateInstallRequest): Promise<AppUpdateInstallResult>;
     sessionProjectInfo(sessionId: string): Promise<{

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1145,6 +1145,9 @@ const makaBridge = {
     updateStatus(): Promise<AppUpdateStatus> {
       return ipcRenderer.invoke('app:updateStatus');
     },
+    checkForUpdates(): Promise<AppUpdateStatus> {
+      return ipcRenderer.invoke('app:checkForUpdates');
+    },
     retryUpdateDownload(): Promise<AppUpdateStatus> {
       return ipcRenderer.invoke('app:retryUpdateDownload');
     },

--- a/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
@@ -162,6 +162,19 @@ export type SettingsPreferencesCopy = {
     keyboardShortcutsHelp: string;
     keyboardShortcutsOpen: string;
     reportIssueLabel: string;
+    updatesTitle: string;
+    checkForUpdates: string;
+    checkingForUpdates: string;
+    updateHelp: string;
+    updateDevBuildHelp: string;
+    updateIdle: string;
+    updateNotAvailable: string;
+    updateAvailable: (version: string) => string;
+    updateDownloading: (version: string, percent: number) => string;
+    updateDownloaded: (version: string) => string;
+    updateInstalling: (version: string) => string;
+    updateCheckFailed: string;
+    updateCheckFailedDetail: (message: string) => string;
   };
   password: {
     copyFailed: string;
@@ -216,6 +229,19 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
     },
     about: {
       loadFailed: '载入关于信息失败', loading: '正在加载关于页', unavailable: '无法载入关于信息', copied: '已复制环境信息', pasteHint: '可直接粘贴到问题报告', copyFailed: '复制失败', clipboardUnavailable: '剪贴板不可用或被系统拒绝。', devBuild: '本地开发版', packagedBuild: '正式版', subtitle: '本地优先的 AI 助手 · 桌面端运行环境', privacyLabel: '隐私与安全', privacyTitle: '本地优先 · 隐私默认', privacyPoints: ['所有会话、设置、凭据和 Skill 指令文件都保留在本机工作区。', '模型密钥保存在本机凭据文件内；订阅账号令牌使用系统安全存储。', 'Maka 不发送使用遥测；只在你显式启用时与所选模型供应商通信。', '高风险工具操作需要在对话内明示授权。', '每个会话都会在本机保留消息、工具调用、权限决策与模式变更记录。'], copying: '复制中…', copyEnvironment: '复制环境信息', copyHelp: '复制当前版本与平台信息以便定位问题；内容不包含工作区路径。', keyboardShortcuts: '键盘快捷键', keyboardShortcutsHelp: 'Maka 支持的全部快捷键一览。', keyboardShortcutsOpen: '查看', reportIssueLabel: '报告问题',
+      updatesTitle: '软件更新',
+      checkForUpdates: '检查更新',
+      checkingForUpdates: '检查中…',
+      updateHelp: '后台也会定期检查；需要重启安装时侧栏会提示。',
+      updateDevBuildHelp: '本地开发版不检查 GitHub 发布更新。请使用正式安装包。',
+      updateIdle: '尚未检查更新。',
+      updateNotAvailable: '已是最新版本。',
+      updateAvailable: (version) => `发现新版本 v${version}，正在准备下载…`,
+      updateDownloading: (version, percent) => `正在下载 v${version}（${percent}%）…`,
+      updateDownloaded: (version) => `v${version} 已下载，可在侧栏选择重启安装。`,
+      updateInstalling: (version) => `正在安装 v${version}…`,
+      updateCheckFailed: '检查更新失败',
+      updateCheckFailedDetail: (message) => message,
     },
     password: { copyFailed: '复制失败', clipboardUnavailable: '剪贴板不可用或被系统拒绝。', copying: '复制中', copied: '已复制', copy: '复制', hide: '隐藏', show: '显示', value: '凭据值' },
   },
@@ -251,6 +277,19 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
     },
     about: {
       loadFailed: 'Could not load About information', loading: 'Loading About', unavailable: 'About information is unavailable', copied: 'Environment info copied', pasteHint: 'Paste it directly into an issue report', copyFailed: 'Copy failed', clipboardUnavailable: 'The clipboard is unavailable or access was denied.', devBuild: 'Local development build', packagedBuild: 'Release build', subtitle: 'A local-first AI assistant · Desktop runtime', privacyLabel: 'Privacy and security', privacyTitle: 'Local first · Private by default', privacyPoints: ['Conversations, settings, credentials, and Skill instructions stay in the local workspace.', 'Model keys stay in a local credential file; subscription tokens use secure system storage.', 'Maka sends no usage telemetry and contacts a model provider only when you enable it.', 'High-risk tool operations require explicit permission in the conversation.', 'Messages, tool calls, permission decisions, and mode changes are retained locally for each session.'], copying: 'Copying…', copyEnvironment: 'Copy environment info', copyHelp: 'Copy version and platform details to help diagnose an issue. The workspace path is excluded.', keyboardShortcuts: 'Keyboard shortcuts', keyboardShortcutsHelp: 'Every shortcut Maka responds to.', keyboardShortcutsOpen: 'View', reportIssueLabel: 'Report an issue',
+      updatesTitle: 'Software updates',
+      checkForUpdates: 'Check for updates',
+      checkingForUpdates: 'Checking…',
+      updateHelp: 'Maka also checks in the background. When a restart is required, the sidebar will prompt you.',
+      updateDevBuildHelp: 'Development builds do not check GitHub releases. Use a packaged install.',
+      updateIdle: 'No update check has run yet.',
+      updateNotAvailable: 'You are on the latest version.',
+      updateAvailable: (version) => `Version v${version} is available and will download shortly…`,
+      updateDownloading: (version, percent) => `Downloading v${version} (${percent}%)…`,
+      updateDownloaded: (version) => `v${version} is ready. Restart from the sidebar to install.`,
+      updateInstalling: (version) => `Installing v${version}…`,
+      updateCheckFailed: 'Could not check for updates',
+      updateCheckFailedDetail: (message) => message,
     },
     password: { copyFailed: 'Copy failed', clipboardUnavailable: 'The clipboard is unavailable or access was denied.', copying: 'Copying', copied: 'Copied', copy: 'Copy', hide: 'Hide', show: 'Show', value: 'credential value' },
   },

--- a/apps/desktop/src/renderer/settings/about-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/about-settings-page.tsx
@@ -9,11 +9,13 @@ import {
   useToast,
   useUiLocale,
 } from '@maka/ui';
+import type { AppUpdateStatus } from '../../preload/bridge-contract.js';
 import { SettingsActions, SettingsPage, SettingsSection } from './settings-section';
 import { SettingRow } from './settings-rows';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { SettingsSkeletonStack } from './settings-skeleton';
 import { useActionGuard } from './use-action-guard';
+import { aboutUpdateStatusDetail } from './about-update-status.js';
 import { getSettingsPreferencesCopy } from '../locales/settings-preferences-copy.js';
 import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';
 
@@ -35,10 +37,14 @@ export function AboutSettingsPage(props: { onOpenKeyboardHelp?(): void }) {
   const [info, setInfo] = useState<AppInfo | null>(null);
   const [infoError, setInfoError] = useState<string | null>(null);
   const [copyingEnvSummary, setCopyingEnvSummary] = useState(false);
+  const [updateStatus, setUpdateStatus] = useState<AppUpdateStatus | null>(null);
+  const [checkingUpdate, setCheckingUpdate] = useState(false);
   const envSummaryCopyGuard = useActionGuard<'copy'>();
+  const checkUpdateGuard = useActionGuard<'check'>();
   const aboutPageMountedRef = useMountedRef();
   const toast = useToast();
   const envSummaryHelpId = useId();
+  const updateHelpId = useId();
 
   useEffect(() => {
     let cancelled = false;
@@ -60,6 +66,23 @@ export function AboutSettingsPage(props: { onOpenKeyboardHelp?(): void }) {
       cancelled = true;
     };
   }, [copy.loadFailed, locale, toast]);
+
+  useEffect(() => {
+    let cancelled = false;
+    window.maka.app
+      .updateStatus()
+      .then((status) => {
+        if (!cancelled) setUpdateStatus(status);
+      })
+      .catch(() => undefined);
+    const unsubscribe = window.maka.app.subscribeUpdateStatus((status) => {
+      if (!cancelled) setUpdateStatus(status);
+    });
+    return () => {
+      cancelled = true;
+      unsubscribe();
+    };
+  }, []);
 
   if (!info && !infoError) {
     return (
@@ -87,6 +110,25 @@ export function AboutSettingsPage(props: { onOpenKeyboardHelp?(): void }) {
   }
 
   const platformPretty = PLATFORM_LABEL[info.platform] ?? info.platform;
+
+  async function checkForUpdates() {
+    if (!checkUpdateGuard.begin('check')) return;
+    setCheckingUpdate(true);
+    try {
+      const status = await window.maka.app.checkForUpdates();
+      if (aboutPageMountedRef.current) setUpdateStatus(status);
+      if (status.state === 'error') {
+        toast.error(copy.updateCheckFailed, copy.updateCheckFailedDetail(status.message));
+      }
+    } catch (error) {
+      if (aboutPageMountedRef.current) {
+        toast.error(copy.updateCheckFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      checkUpdateGuard.finish();
+      if (aboutPageMountedRef.current) setCheckingUpdate(false);
+    }
+  }
 
   async function copyEnvSummary() {
     if (!info) return;
@@ -192,6 +234,29 @@ export function AboutSettingsPage(props: { onOpenKeyboardHelp?(): void }) {
           />
         </SettingsSection>
       )}
+      <SettingsSection title={copy.updatesTitle}>
+        <SettingRow
+          title={copy.checkForUpdates}
+          detail={aboutUpdateStatusDetail(updateStatus, copy, {
+            isDevBuild: info.buildMode === 'dev',
+          })}
+          action={(
+            <Button
+              variant="secondary"
+              size="sm"
+              isDisabled={checkingUpdate || info.buildMode === 'dev'}
+              aria-describedby={updateHelpId}
+              onClick={() => void checkForUpdates()}
+              label={checkingUpdate || updateStatus?.state === 'checking'
+                ? copy.checkingForUpdates
+                : copy.checkForUpdates}
+            />
+          )}
+        />
+        <p id={updateHelpId}>
+          {info.buildMode === 'dev' ? copy.updateDevBuildHelp : copy.updateHelp}
+        </p>
+      </SettingsSection>
       <SettingsSection title={sharedCopy.groups.buildInfo}>
         <SettingsActions>
           <Button variant="primary" isDisabled={copyingEnvSummary} aria-describedby={envSummaryHelpId} onClick={() => void copyEnvSummary()} label={copyingEnvSummary ? copy.copying : copy.copyEnvironment} />

--- a/apps/desktop/src/renderer/settings/about-update-status.ts
+++ b/apps/desktop/src/renderer/settings/about-update-status.ts
@@ -1,0 +1,23 @@
+import type { AppUpdateStatus } from '../../preload/bridge-contract.js';
+import type { SettingsPreferencesCopy } from '../locales/settings-preferences-copy.js';
+
+type AboutCopy = SettingsPreferencesCopy['about'];
+
+/** Map updater state to About-page detail copy (pure for unit tests). */
+export function aboutUpdateStatusDetail(
+  status: AppUpdateStatus | null,
+  copy: AboutCopy,
+  options: { readonly isDevBuild: boolean },
+): string {
+  if (options.isDevBuild) return copy.updateDevBuildHelp;
+  if (!status || status.state === 'idle') return copy.updateIdle;
+  if (status.state === 'checking') return copy.checkingForUpdates;
+  if (status.state === 'not-available') return copy.updateNotAvailable;
+  if (status.state === 'available') return copy.updateAvailable(status.latestVersion);
+  if (status.state === 'downloading') {
+    return copy.updateDownloading(status.latestVersion, Math.round(status.progress.percent));
+  }
+  if (status.state === 'downloaded') return copy.updateDownloaded(status.latestVersion);
+  if (status.state === 'installing') return copy.updateInstalling(status.latestVersion);
+  return copy.updateCheckFailedDetail(status.message);
+}

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -619,6 +619,10 @@ const makaBridge = {
         '/Users/storybook-fixture-user/Library/Application Support/Maka/workspaces/infra-observability-platform-desktop',
     }),
     openPath: async () => ({ ok: true as const, opened: '/Users/storybook' }),
+    // About mounts update status + subscribe on open (Settings → 关于).
+    updateStatus: async () => ({ state: 'idle' as const, currentVersion: '0.9.0-dev' }),
+    subscribeUpdateStatus: () => () => undefined,
+    checkForUpdates: async () => ({ state: 'not-available' as const, currentVersion: '0.9.0-dev' }),
   },
   ...makeMemoryBridgeChannels(emptyMemoryState),
   webSearch: {


### PR DESCRIPTION
## Summary
- Add `checkForUpdatesNow()` on the update service (bypasses the 15m focus throttle; still joins in-flight checks / refuses mid-download restarts).
- IPC + preload: `app:checkForUpdates`.
- Settings → **关于** new **软件更新** row with live status (idle / latest / downloading / ready to restart / error).
- Dev builds show a clear “development builds don’t check releases” message and disable the button.

## Test plan
- [x] Unit: focus throttle vs manual check; About status copy mapping
- [ ] Packaged app: 关于 → 检查更新 → see latest / download progress
- [ ] Dev app: button disabled, help text explains why
- [ ] After download: About shows ready message; sidebar install still works