### PR TITLE
fix(desktop): recover evicted Runtime Host session streams

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import test from 'node:test';
 import type { IpcMain } from 'electron';
 import type {
@@ -13,6 +14,8 @@ import type {
   OperationInput,
   OperationKey,
   SessionCatalogProjection,
+  SessionContinuitySnapshot,
+  SubscriptionFrame,
 } from '@maka/runtime-host/protocol';
 import { z } from 'zod';
 import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
@@ -21,6 +24,7 @@ import {
   type DesktopRuntimeHostCandidateControls,
   type DesktopRuntimeHostCandidateDeps,
 } from '../runtime-host-desktop-candidate.js';
+import { RuntimeHostSessionObservationRegistry } from '../runtime-host-session-observation-registry.js';
 
 test('owns one complete Desktop candidate generation and can restart cleanly', async () => {
   const ipc = ipcHarness();
@@ -312,10 +316,127 @@ test('does not release or report a Revision the Host retained during cleanup', a
   await candidate.close();
 });
 
+test('resyncs exact interaction and sidecar state after candidate replacement', async () => {
+  const ref = 'maka://runtime/background-tasks/shell-1';
+  const observations = new RuntimeHostSessionObservationRegistry();
+  const firstIpc = ipcHarness();
+  const firstHost = connectionHarness('first-observer', {
+    subscriptionSnapshot: continuitySnapshot({
+      interactions: { pending: [pendingQuestion()] },
+    }),
+    runtimeResourcePty: ptySnapshot(ref, 'before replacement'),
+  });
+  const firstCandidate = await createDesktopRuntimeHostCandidate(
+    firstHost.connection,
+    deps(firstIpc),
+    observations,
+  );
+  await firstIpc.invoke('sessions:observe', 'session-1', 'observer-1');
+  assert.ok(
+    firstIpc.sender.sent.some(
+      ({ payload }) =>
+        (payload as { type?: unknown }).type === 'user_question_request',
+    ),
+  );
+  assert.equal(
+    (
+      (await firstIpc.invoke('shell-runs:attach', {
+        sessionId: 'session-1',
+        ref,
+      })) as { buffer: string }
+    ).buffer,
+    'before replacement',
+  );
+  await firstCandidate.close();
+
+  const secondIpc = ipcHarness();
+  const resyncs: Array<{ channel: string; payload: unknown }> = [];
+  let terminalReattach: Promise<unknown> | undefined;
+  const secondHost = connectionHarness('second-observer', {
+    subscriptionSnapshot: continuitySnapshot({ interactions: { pending: [] } }),
+    runtimeResourcePty: ptySnapshot(ref, 'after replacement'),
+  });
+  const secondCandidate = await createDesktopRuntimeHostCandidate(
+    secondHost.connection,
+    {
+      ...deps(secondIpc),
+      sendToRenderer: (channel, payload) => {
+        resyncs.push({ channel, payload });
+        if (channel === 'shell-runs:resync') {
+          terminalReattach ??= secondIpc.invoke('shell-runs:attach', {
+            sessionId: 'session-1',
+            ref,
+          });
+        }
+      },
+    },
+    observations,
+  );
+
+  assert.ok(
+    resyncs.some(
+      ({ channel, payload }) =>
+        channel === 'graphs:resync' &&
+        (payload as { rootSessionId?: unknown }).rootSessionId === 'session-1',
+    ),
+  );
+  assert.ok(
+    resyncs.some(
+      ({ channel, payload }) =>
+        channel === 'shell-runs:resync' &&
+        (payload as { sessionId?: unknown }).sessionId === 'session-1',
+    ),
+  );
+  assert.ok(
+    resyncs.some(
+      ({ channel, payload }) =>
+        channel === 'sessions:active-interactions-changed' &&
+        (payload as { sessionId?: unknown }).sessionId === 'session-1' &&
+        Array.isArray((payload as { interactions?: unknown }).interactions) &&
+        (payload as { interactions: unknown[] }).interactions.length === 0,
+    ),
+  );
+  assert.ok(terminalReattach);
+  assert.equal(
+    ((await terminalReattach) as { buffer: string }).buffer,
+    'after replacement',
+  );
+  assert.equal(secondHost.runtimeResourceControllerAcquires, 1);
+
+  secondHost.pushSubscriptionFrame({
+    kind: 'subscription.runtime_resource_pty_data',
+    hostEpoch: 'host-second-observer',
+    subscriptionId: 'subscription-second-observer',
+    sequence: 1,
+    sessionId: 'session-1',
+    ref,
+    ptySequence: 5,
+    data: ' live',
+  });
+  await waitFor(() =>
+    resyncs.some(
+      ({ channel, payload }) =>
+        channel === 'shell-runs:pty-data' &&
+        (payload as { sequence?: unknown }).sequence === 5 &&
+        (payload as { data?: unknown }).data === ' live',
+    ),
+  );
+
+  await secondCandidate.close();
+  await observations.close();
+});
+
 type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
 
 function ipcHarness() {
   const handlers = new Map<string, IpcHandler>();
+  const sender = Object.assign(new EventEmitter(), {
+    id: 1,
+    sent: [] as Array<{ channel: string; payload: unknown }>,
+    send(channel: string, payload: unknown): void {
+      sender.sent.push({ channel, payload });
+    },
+  });
   return {
     handle(channel: string, handler: IpcHandler): void {
       if (handlers.has(channel)) throw new Error(`duplicate handler: ${channel}`);
@@ -327,7 +448,7 @@ function ipcHarness() {
     async invoke(channel: string, ...args: unknown[]): Promise<unknown> {
       const handler = handlers.get(channel);
       assert.ok(handler, `missing handler: ${channel}`);
-      return handler({ sender: { id: 1 } } as never, ...args);
+      return handler({ sender } as never, ...args);
     },
     get channels(): string[] {
       return [...handlers.keys()].sort();
@@ -335,6 +456,7 @@ function ipcHarness() {
     get size(): number {
       return handlers.size;
     },
+    sender,
   };
 }
 
@@ -386,7 +508,11 @@ function nativeTool(): MakaTool {
 
 function connectionHarness(
   label: string,
-  options: { revisionAbandon?: 'abandoned' | 'retained' } = {},
+  options: {
+    revisionAbandon?: 'abandoned' | 'retained';
+    subscriptionSnapshot?: SessionContinuitySnapshot;
+    runtimeResourcePty?: ReturnType<typeof ptySnapshot>;
+  } = {},
 ) {
   let resolveClosed: (() => void) | undefined;
   const closed = new Promise<void>((resolve) => {
@@ -402,6 +528,8 @@ function connectionHarness(
   let capabilityUnregistrations = 0;
   let closeCalls = 0;
   let startTurnCalls = 0;
+  let runtimeResourceControllerAcquires = 0;
+  let activeSubscriptionFrames: AsyncFrameQueue | undefined;
   const connection = {
     hostEpoch: `host-${label}`,
     connectionId: `connection-${label}`,
@@ -460,6 +588,23 @@ function connectionHarness(
           nextCursor: null,
         };
       }
+      if (
+        operation === 'runtime.resource.controller.acquire' &&
+        options.runtimeResourcePty
+      ) {
+        runtimeResourceControllerAcquires += 1;
+        return {
+          controllerId: (input as { controllerId: string }).controllerId,
+          nextSequence: options.runtimeResourcePty.sequence + 1,
+          pty: options.runtimeResourcePty,
+        };
+      }
+      if (operation === 'runtime.resource.controller.release') {
+        return {
+          controllerId: (input as { controllerId: string }).controllerId,
+          released: true,
+        };
+      }
       if (operation === 'session.execution_boundary.query') {
         return { kind: 'managed', access: 'read_only', revision: 1 };
       }
@@ -474,24 +619,19 @@ function connectionHarness(
       throw new Error(`Unexpected operation: ${operation}`);
     },
     openSessionSubscription: async ({ sessionId }: { sessionId: string }) => {
-      let resolveSubscriptionClosed: (() => void) | undefined;
-      const subscriptionClosed = new Promise<void>((resolve) => {
-        resolveSubscriptionClosed = resolve;
-      });
-      const closeSubscription = () => resolveSubscriptionClosed?.();
+      const subscriptionFrames = new AsyncFrameQueue();
+      activeSubscriptionFrames = subscriptionFrames;
+      const closeSubscription = () => subscriptionFrames.end();
       closeSubscriptions.add(closeSubscription);
       return {
         hostEpoch: `host-${label}`,
         subscriptionId: `subscription-${label}`,
-        snapshot: {
+        snapshot: options.subscriptionSnapshot ?? {
           projectionRevision: 1,
           session: { sessionId },
         },
         loadTranscript: async () => [],
-        async *[Symbol.asyncIterator]() {
-          await subscriptionClosed;
-          yield { kind: 'subscription.closed', reason: 'connection_closed' };
-        },
+        [Symbol.asyncIterator]: () => subscriptionFrames[Symbol.asyncIterator](),
         close: async () => closeSubscription(),
       };
     },
@@ -522,6 +662,10 @@ function connectionHarness(
       });
     },
     disconnect: () => resolveClosed?.(),
+    pushSubscriptionFrame: (frame: SubscriptionFrame) => {
+      assert.ok(activeSubscriptionFrames);
+      activeSubscriptionFrames.push(frame);
+    },
     get capabilityRegistrations() {
       return capabilityRegistrations;
     },
@@ -534,7 +678,117 @@ function connectionHarness(
     get startTurnCalls() {
       return startTurnCalls;
     },
+    get runtimeResourceControllerAcquires() {
+      return runtimeResourceControllerAcquires;
+    },
   };
+}
+
+function continuitySnapshot(
+  overrides: Partial<SessionContinuitySnapshot> = {},
+): SessionContinuitySnapshot {
+  return {
+    schemaVersion: 3,
+    session: {
+      sessionId: 'session-1',
+      metadataRevision: 1,
+      status: 'running',
+      createdAt: 1,
+      lastUsedAt: 1,
+      isArchived: false,
+    },
+    projectionRevision: 1,
+    rootTurn: {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      status: 'running',
+    },
+    goal: null,
+    queue: {
+      hostEpoch: 'host-1',
+      queueRevision: 0,
+      steering: [],
+      followup: [],
+    },
+    interactions: { pending: [] },
+    ...overrides,
+  };
+}
+
+function pendingQuestion() {
+  return {
+    schemaVersion: 1 as const,
+    interactionId: 'interaction-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    runId: 'run-1',
+    revision: 1 as const,
+    status: 'pending' as const,
+    outcome: null,
+    request: {
+      kind: 'question' as const,
+      toolUseId: 'tool-interaction-1',
+      questions: [
+        {
+          question: 'Proceed?',
+          options: [{ label: 'Yes', description: 'Continue.' }],
+        },
+      ],
+    },
+  };
+}
+
+function ptySnapshot(ref: string, buffer: string) {
+  return {
+    sessionId: 'session-1',
+    ref,
+    sequence: 4,
+    buffer,
+    size: { cols: 80, rows: 24 },
+  };
+}
+
+class AsyncFrameQueue implements AsyncIterable<SubscriptionFrame> {
+  readonly #frames: SubscriptionFrame[] = [];
+  readonly #waiters: Array<
+    (result: IteratorResult<SubscriptionFrame>) => void
+  > = [];
+  #ended = false;
+
+  push(frame: SubscriptionFrame): void {
+    const waiter = this.#waiters.shift();
+    if (waiter) waiter({ value: frame, done: false });
+    else this.#frames.push(frame);
+  }
+
+  end(): void {
+    this.#ended = true;
+    for (const waiter of this.#waiters.splice(0)) {
+      waiter({ value: undefined, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<SubscriptionFrame> {
+    return {
+      next: () => {
+        const frame = this.#frames.shift();
+        if (frame) return Promise.resolve({ value: frame, done: false });
+        if (this.#ended) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        return new Promise((resolve) => this.#waiters.push(resolve));
+      },
+    };
+  }
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.fail('Timed out waiting for candidate state');
 }
 
 function capabilityFrame(sessionId: string): ClientCapabilityCallFrame {

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -316,7 +316,7 @@ test('does not release or report a Revision the Host retained during cleanup', a
   await candidate.close();
 });
 
-test('resyncs exact interaction and sidecar state after candidate replacement', async () => {
+test('resyncs Goal, exact interaction, and sidecar state after candidate replacement', async () => {
   const ref = 'maka://runtime/background-tasks/shell-1';
   const observations = new RuntimeHostSessionObservationRegistry();
   const firstIpc = ipcHarness();
@@ -351,6 +351,7 @@ test('resyncs exact interaction and sidecar state after candidate replacement', 
 
   const secondIpc = ipcHarness();
   const resyncs: Array<{ channel: string; payload: unknown }> = [];
+  const sessionChanges: Array<{ reason: string; sessionId?: string }> = [];
   let terminalReattach: Promise<unknown> | undefined;
   const secondHost = connectionHarness('second-observer', {
     subscriptionSnapshot: continuitySnapshot({ interactions: { pending: [] } }),
@@ -360,6 +361,8 @@ test('resyncs exact interaction and sidecar state after candidate replacement', 
     secondHost.connection,
     {
       ...deps(secondIpc),
+      emitSessionsChanged: (reason, sessionId) =>
+        sessionChanges.push({ reason, sessionId }),
       sendToRenderer: (channel, payload) => {
         resyncs.push({ channel, payload });
         if (channel === 'shell-runs:resync') {
@@ -378,6 +381,12 @@ test('resyncs exact interaction and sidecar state after candidate replacement', 
       ({ channel, payload }) =>
         channel === 'graphs:resync' &&
         (payload as { rootSessionId?: unknown }).rootSessionId === 'session-1',
+    ),
+  );
+  assert.ok(
+    sessionChanges.some(
+      ({ reason, sessionId }) =>
+        reason === 'goal-change' && sessionId === 'session-1',
     ),
   );
   assert.ok(

--- a/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
@@ -577,6 +577,31 @@ test('publishes typed invalidations and refreshes only changed Runtime Resources
       payload: update,
     },
   ]);
+
+  sent.length = 0;
+  handle.sessionSubscriptionRecovered('session-1');
+  assert.deepEqual(sent, [
+    {
+      channel: 'tasks:changed',
+      payload: { sessionId: 'session-1', taskIds: [], at: 12 },
+    },
+    {
+      channel: 'deepResearch:changed',
+      payload: { sessionId: 'session-1', ts: 12 },
+    },
+    {
+      channel: 'plan-mode:changed',
+      payload: { sessionId: 'session-1' },
+    },
+    {
+      channel: 'graphs:resync',
+      payload: { rootSessionId: 'session-1' },
+    },
+    {
+      channel: 'shell-runs:resync',
+      payload: { sessionId: 'session-1' },
+    },
+  ]);
 });
 
 test('projects embedded and hosted Deep Research into one renderer contract', () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -535,6 +535,362 @@ test("reopens an evicted active subscription without a renderer resubscribe", as
   await observer.close();
 });
 
+test("retries an initial subscription closed before commit and resyncs once", async () => {
+  const firstEvents = new AsyncFrameQueue();
+  const secondEvents = new AsyncFrameQueue();
+  const firstTranscript = deferred<StoredMessage[]>();
+  const secondTranscript = deferred<StoredMessage[]>();
+  const recoveredSessions: string[] = [];
+  let openCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        openCount += 1;
+        const first = openCount === 1;
+        return {
+          snapshot: continuitySnapshot(),
+          transcript: first ? firstTranscript.promise : secondTranscript.promise,
+          events: first ? firstEvents : secondEvents,
+          async close() {
+            (first ? firstEvents : secondEvents).end();
+          },
+        };
+      },
+    },
+    emitSessionsChanged() {},
+    emitSubscriptionRecovered: (sessionId) => {
+      recoveredSessions.push(sessionId);
+    },
+  });
+  let observingSettled = false;
+  const observing = observer.observe("session-1", "observer-1", eventTarget(16));
+  void observing.then(
+    () => {
+      observingSettled = true;
+    },
+    () => {
+      observingSettled = true;
+    },
+  );
+  await waitFor(() => firstEvents.nextCount > 0);
+
+  firstTranscript.resolve([]);
+  queueMicrotask(() => {
+    queueMicrotask(() => {
+      firstEvents.push({
+        kind: "subscription.closed",
+        hostEpoch: "host-1",
+        subscriptionId: "subscription-1",
+        sequence: 1,
+        reason: "slow_consumer",
+      });
+    });
+  });
+  await waitFor(() => openCount === 2);
+  assert.equal(observingSettled, false);
+  assert.deepEqual(recoveredSessions, []);
+
+  secondTranscript.resolve([]);
+  await observing;
+  assert.deepEqual(recoveredSessions, ["session-1"]);
+  await observer.close();
+});
+
+test("finishes a watched predecessor after initial catch-up recovery", async () => {
+  const firstEvents = new AsyncFrameQueue();
+  const secondEvents = new AsyncFrameQueue();
+  const firstTranscript = deferred<StoredMessage[]>();
+  const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
+  let openCount = 0;
+  let replacementCloseCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        openCount += 1;
+        if (openCount === 1) {
+          return {
+            snapshot: continuitySnapshot(),
+            transcript: firstTranscript.promise,
+            events: firstEvents,
+            async close() {
+              firstEvents.end();
+            },
+          };
+        }
+        return {
+          snapshot: continuitySnapshot({
+            projectionRevision: 2,
+            rootTurn: {
+              sessionId: "session-1",
+              turnId: "turn-2",
+              runId: "run-2",
+              status: "running",
+            },
+          }),
+          transcript: Promise.resolve([
+            {
+              type: "turn_state" as const,
+              id: "terminal-1",
+              turnId: "turn-1",
+              ts: 20,
+              status: "completed" as const,
+              partialOutputRetained: true,
+            },
+          ]),
+          events: secondEvents,
+          async close() {
+            replacementCloseCount += 1;
+            secondEvents.end();
+          },
+        };
+      },
+    },
+    emitSessionsChanged() {},
+    onWatchedTurnFinished: (sessionId, outcome) => {
+      finishedTurns.push([sessionId, outcome]);
+    },
+  });
+  const watching = observer.watchTurn("session-1", "turn-1");
+  await waitFor(() => firstEvents.nextCount > 0);
+
+  firstEvents.push({
+    kind: "subscription.closed",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 1,
+    reason: "slow_consumer",
+  });
+  await watching;
+  await waitFor(() => replacementCloseCount === 1);
+
+  assert.deepEqual(finishedTurns, [["session-1", "completed"]]);
+  await observer.close();
+});
+
+test("keeps a joining observer pending across repeated catch-up eviction", async () => {
+  const firstEvents = new AsyncFrameQueue();
+  const replacementEvents = new AsyncFrameQueue();
+  const finalEvents = new AsyncFrameQueue();
+  const finalTranscript = deferred<StoredMessage[]>();
+  let openCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        openCount += 1;
+        if (openCount === 1) {
+          return {
+            snapshot: continuitySnapshot(),
+            transcript: Promise.resolve([]),
+            events: firstEvents,
+            async close() {
+              firstEvents.end();
+            },
+          };
+        }
+        if (openCount === 2) {
+          return {
+            snapshot: continuitySnapshot(),
+            transcript: deferred<StoredMessage[]>().promise,
+            events: replacementEvents,
+            async close() {
+              replacementEvents.end();
+            },
+          };
+        }
+        return {
+          snapshot: continuitySnapshot(),
+          transcript: finalTranscript.promise,
+          events: finalEvents,
+          async close() {
+            finalEvents.end();
+          },
+        };
+      },
+    },
+    emitSessionsChanged() {},
+  });
+  const firstTarget = eventTarget(13);
+  const joiningTarget = eventTarget(14);
+  await observer.observe("session-1", "observer-1", firstTarget);
+
+  firstEvents.push({
+    kind: "subscription.closed",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 1,
+    reason: "slow_consumer",
+  });
+  await waitFor(() => openCount === 2 && replacementEvents.nextCount > 0);
+
+  const joining = observer.observe(
+    "session-1",
+    "observer-2",
+    joiningTarget,
+  );
+  let joiningSettled = false;
+  void joining.then(
+    () => {
+      joiningSettled = true;
+    },
+    () => {
+      joiningSettled = true;
+    },
+  );
+  replacementEvents.push({
+    kind: "subscription.closed",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-2",
+    sequence: 1,
+    reason: "slow_consumer",
+  });
+  await waitFor(() => openCount === 3);
+  await Promise.resolve();
+  assert.equal(joiningSettled, false);
+  finalTranscript.resolve([
+    {
+      type: "assistant" as const,
+      id: "message-1",
+      turnId: "turn-1",
+      ts: 10,
+      text: "Hello",
+      modelId: "test-model",
+    },
+  ]);
+  await joining;
+
+  assert.equal(firstTarget.events.some((event) => event.type === "error"), false);
+  assert.equal(joiningTarget.events.some((event) => event.type === "error"), false);
+  assert.deepEqual(
+    joiningTarget.events.map((event) =>
+      event.type === "text_delta" ? event.text : event.type,
+    ),
+    ["Hello"],
+  );
+  await observer.close();
+});
+
+test("reconciles terminal, interaction, and sidecar state after subscription recovery", async () => {
+  const firstEvents = new AsyncFrameQueue();
+  const secondEvents = new AsyncFrameQueue();
+  const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
+  const interactionSnapshots: Array<readonly { requestId: string }[]> = [];
+  const recoveredSessions: string[] = [];
+  const firstInteraction = pendingQuestion("interaction-1", "turn-1", "run-1");
+  const secondInteraction = pendingQuestion("interaction-2", "turn-2", "run-2");
+  let openCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        openCount += 1;
+        if (openCount === 1) {
+          return {
+            snapshot: continuitySnapshot({
+              interactions: { pending: [firstInteraction] },
+            }),
+            transcript: Promise.resolve([]),
+            events: firstEvents,
+            async close() {
+              firstEvents.end();
+            },
+          };
+        }
+        return {
+          snapshot: continuitySnapshot({
+            projectionRevision: 3,
+            rootTurn: {
+              sessionId: "session-1",
+              turnId: "turn-2",
+              runId: "run-2",
+              status: "running",
+            },
+            interactions: { pending: [secondInteraction] },
+          }),
+          transcript: Promise.resolve([
+            {
+              type: "assistant" as const,
+              id: "message-1",
+              turnId: "turn-1",
+              ts: 10,
+              text: "First answer",
+              modelId: "test-model",
+            },
+            {
+              type: "turn_state" as const,
+              id: "terminal-1",
+              turnId: "turn-1",
+              ts: 20,
+              status: "completed" as const,
+              partialOutputRetained: true,
+            },
+            {
+              type: "assistant" as const,
+              id: "message-2",
+              turnId: "turn-2",
+              ts: 30,
+              text: "Second answer",
+              modelId: "test-model",
+            },
+          ]),
+          events: secondEvents,
+          async close() {
+            secondEvents.end();
+          },
+        };
+      },
+    },
+    emitSessionsChanged() {},
+    onWatchedTurnFinished: (sessionId, outcome) => {
+      finishedTurns.push([sessionId, outcome]);
+    },
+    emitActiveInteractionsChanged: (_sessionId, interactions) => {
+      interactionSnapshots.push(interactions);
+    },
+    emitSubscriptionRecovered: (sessionId) => {
+      recoveredSessions.push(sessionId);
+    },
+    now: () => 50,
+  });
+  const target = eventTarget(15);
+  await observer.observe("session-1", "observer-1", target);
+  await observer.watchTurn("session-1", "turn-1");
+
+  firstEvents.push({
+    kind: "subscription.closed",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 1,
+    reason: "slow_consumer",
+  });
+  await waitFor(() => recoveredSessions.length === 1);
+
+  assert.deepEqual(finishedTurns, [["session-1", "completed"]]);
+  assert.deepEqual(recoveredSessions, ["session-1"]);
+  assert.deepEqual(
+    interactionSnapshots.at(-1)?.map((interaction) => interaction.requestId),
+    ["interaction-2"],
+  );
+  assert.ok(
+    target.events.some(
+      (event) => event.type === "complete" && event.turnId === "turn-1",
+    ),
+  );
+  assert.ok(
+    target.events.some(
+      (event) =>
+        event.type === "text_delta" &&
+        event.turnId === "turn-2" &&
+        event.text === "Second answer",
+    ),
+  );
+  assert.ok(
+    target.events.some(
+      (event) =>
+        event.type === "user_question_request" && event.requestId === "interaction-2",
+    ),
+  );
+  await observer.close();
+});
+
 test("shares one Host subscription and one delivery per renderer target", async () => {
   const events = new AsyncFrameQueue();
   let openCount = 0;
@@ -957,6 +1313,29 @@ function deltaFrame(
       messageId: "message-1",
       startOffset,
       text,
+    },
+  };
+}
+
+function pendingQuestion(interactionId: string, turnId: string, runId: string) {
+  return {
+    schemaVersion: 1 as const,
+    interactionId,
+    sessionId: "session-1",
+    turnId,
+    runId,
+    revision: 1 as const,
+    status: "pending" as const,
+    outcome: null,
+    request: {
+      kind: "question" as const,
+      toolUseId: `tool-${interactionId}`,
+      questions: [
+        {
+          question: "Proceed?",
+          options: [{ label: "Yes", description: "Continue." }],
+        },
+      ],
     },
   };
 }

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -459,6 +459,82 @@ test("abandons a watched Turn when the Session is removed", async () => {
   await observer.close();
 });
 
+test("reopens an evicted active subscription without a renderer resubscribe", async () => {
+  const firstEvents = new AsyncFrameQueue();
+  const secondEvents = new AsyncFrameQueue();
+  const sessionChanges: Array<{ reason: string; sessionId: string }> = [];
+  let openCount = 0;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        openCount += 1;
+        const events = openCount === 1 ? firstEvents : secondEvents;
+        return {
+          snapshot: continuitySnapshot(),
+          transcript: Promise.resolve(
+            openCount === 1
+              ? []
+              : [
+                  {
+                    type: "assistant" as const,
+                    id: "message-1",
+                    turnId: "turn-1",
+                    ts: 10,
+                    text: "Hello",
+                    modelId: "test-model",
+                  },
+                ],
+          ),
+          events,
+          async close() {
+            events.end();
+          },
+        };
+      },
+    },
+    emitSessionsChanged: (reason, sessionId) =>
+      sessionChanges.push({ reason, sessionId }),
+  });
+  const target = eventTarget(12);
+  await observer.observe("session-1", "observer-1", target);
+
+  firstEvents.push(deltaFrame(1, 0, "Hel"));
+  firstEvents.push({
+    kind: "subscription.closed",
+    hostEpoch: "host-1",
+    subscriptionId: "subscription-1",
+    sequence: 2,
+    reason: "slow_consumer",
+  });
+  await waitFor(() => openCount === 2 && target.events.length === 2);
+
+  secondEvents.push(deltaFrame(1, 5, " world"));
+  await waitFor(() => target.events.length === 3);
+  assert.deepEqual(
+    target.events.map((event) => [
+      event.type,
+      "text" in event ? event.text : undefined,
+      "startOffset" in event ? event.startOffset : undefined,
+    ]),
+    [
+      ["text_delta", "Hel", 0],
+      ["text_delta", "Hello", 0],
+      ["text_delta", " world", 5],
+    ],
+  );
+  assert.equal(target.events.some((event) => event.type === "error"), false);
+  assert.ok(
+    sessionChanges.some(
+      (change) =>
+        change.reason === "message-appended" &&
+        change.sessionId === "session-1",
+    ),
+  );
+
+  await observer.unobserve("observer-1");
+  await observer.close();
+});
+
 test("shares one Host subscription and one delivery per renderer target", async () => {
   const events = new AsyncFrameQueue();
   let openCount = 0;

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -769,12 +769,13 @@ test("keeps a joining observer pending across repeated catch-up eviction", async
   await observer.close();
 });
 
-test("reconciles terminal, interaction, and sidecar state after subscription recovery", async () => {
+test("reconciles terminal, Goal, interaction, and sidecar state after subscription recovery", async () => {
   const firstEvents = new AsyncFrameQueue();
   const secondEvents = new AsyncFrameQueue();
   const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
   const interactionSnapshots: Array<readonly { requestId: string }[]> = [];
   const recoveredSessions: string[] = [];
+  const sessionChanges: string[] = [];
   const firstInteraction = pendingQuestion("interaction-1", "turn-1", "run-1");
   const secondInteraction = pendingQuestion("interaction-2", "turn-2", "run-2");
   let openCount = 0;
@@ -797,6 +798,7 @@ test("reconciles terminal, interaction, and sidecar state after subscription rec
         return {
           snapshot: continuitySnapshot({
             projectionRevision: 3,
+            goal: activeGoal(),
             rootTurn: {
               sessionId: "session-1",
               turnId: "turn-2",
@@ -838,7 +840,9 @@ test("reconciles terminal, interaction, and sidecar state after subscription rec
         };
       },
     },
-    emitSessionsChanged() {},
+    emitSessionsChanged(reason) {
+      sessionChanges.push(reason);
+    },
     onWatchedTurnFinished: (sessionId, outcome) => {
       finishedTurns.push([sessionId, outcome]);
     },
@@ -865,6 +869,7 @@ test("reconciles terminal, interaction, and sidecar state after subscription rec
 
   assert.deepEqual(finishedTurns, [["session-1", "completed"]]);
   assert.deepEqual(recoveredSessions, ["session-1"]);
+  assert.ok(sessionChanges.includes("goal-change"));
   assert.deepEqual(
     interactionSnapshots.at(-1)?.map((interaction) => interaction.requestId),
     ["interaction-2"],
@@ -1292,6 +1297,26 @@ function continuitySnapshot(
     },
     interactions: { pending: [] },
     ...overrides,
+  };
+}
+
+function activeGoal() {
+  return {
+    goalId: "goal-1",
+    revision: 1,
+    sessionId: "session-1",
+    condition: "Finish the recovery",
+    status: "active" as const,
+    setAt: 1,
+    iterations: 0,
+    maxIterations: 20,
+    consecutiveNoProgress: 0,
+    blockCap: 8,
+    tokenBudget: null,
+    tokensSpent: 0,
+    lastReason: null,
+    achievedAt: null,
+    pausedAt: null,
   };
 }
 

--- a/apps/desktop/src/main/__tests__/session-terminal-hydration.test.ts
+++ b/apps/desktop/src/main/__tests__/session-terminal-hydration.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { SessionTerminalHydration } from '../../renderer/session-terminal-hydration.js';
+
+test('terminal hydration ignores an old snapshot and replays only post-resync PTY data', () => {
+  const hydration = new SessionTerminalHydration();
+  const oldEpoch = hydration.begin();
+  hydration.accept({ sequence: 2, data: 'old' });
+
+  const currentEpoch = hydration.begin();
+  hydration.accept({ sequence: 6, data: ' after' });
+  const current = hydration.commit(currentEpoch, {
+    sequence: 5,
+    buffer: 'ready',
+  });
+
+  assert.deepEqual(current, {
+    snapshot: { sequence: 5, buffer: 'ready' },
+    replay: [{ sequence: 6, data: ' after' }],
+  });
+  assert.equal(
+    hydration.commit(oldEpoch, { sequence: 9, buffer: 'stale' }),
+    undefined,
+  );
+  assert.deepEqual(hydration.accept({ sequence: 7, data: ' now' }), {
+    sequence: 7,
+    data: ' now',
+  });
+});

--- a/apps/desktop/src/main/__tests__/shell-run-update-state.test.ts
+++ b/apps/desktop/src/main/__tests__/shell-run-update-state.test.ts
@@ -4,6 +4,7 @@ import type { ShellRunSnapshotResult, ShellRunUpdate } from '@maka/core';
 import {
   mergeShellRunNotification,
   mergeShellRunUpdates,
+  ShellRunHydration,
 } from '../../renderer/shell-run-update-state.js';
 
 test('ShellRun update state rejects a stale hydration result after a newer notification', () => {
@@ -75,6 +76,20 @@ test('ShellRun update state applies ownership changes at the same revision', () 
     sourceSessionId: 'parent',
   });
   assert.equal(next.branch?.bash?.result.revision, 3);
+});
+
+test('ShellRun hydration ignores an old read and replays updates after the resync boundary', () => {
+  const hydration = new ShellRunHydration();
+  const oldEpoch = hydration.begin();
+  hydration.accept(update(2));
+
+  const currentEpoch = hydration.begin();
+  hydration.accept(update(4));
+  const current = hydration.commit(currentEpoch);
+  assert.deepEqual(current?.updates.map((entry) => entry.result.revision), [4]);
+  assert.equal(hydration.commit(oldEpoch), undefined);
+
+  assert.equal(hydration.accept(update(5))?.result.revision, 5);
 });
 
 function update(revision: number): ShellRunUpdate {

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -307,6 +307,7 @@ describe('single live-turn handoff', () => {
     const liveTurns = createStateSetter<Record<string, LiveTurnProjection>>({ 'session-1': projection });
     const ref = { current: liveTurns.get() };
     const interactions = createStateSetter<InteractionQueues>({});
+    let diagnosticDetails: string | undefined;
     const handlers = createAppShellSessionEventHandlers({
       uiLocale: 'zh',
       activeIdRef: { current: 'session-1' },
@@ -319,7 +320,11 @@ describe('single live-turn handoff', () => {
       },
       setInteractionBySession: interactions.set,
       showModelSetupToast: () => {},
-      toastApi: { error: () => {} },
+      toastApi: {
+        error: (_title, _description, details) => {
+          diagnosticDetails = details;
+        },
+      },
     });
 
     handlers.handleEvent('session-1', {
@@ -331,6 +336,10 @@ describe('single live-turn handoff', () => {
     assert.equal(liveTurns.get()['session-1']?.terminal, true);
     assert.equal(liveTurns.get()['session-1']?.steps[0]?.tools[0]?.status, 'interrupted');
     assert.equal(liveTurns.get()['session-1']?.steps[0]?.tools[0]?.outputChunks?.[0]?.text, 'partial output');
+    assert.match(diagnosticDetails ?? '', /Session: session-1/u);
+    assert.match(diagnosticDetails ?? '', /Turn: turn-1/u);
+    assert.match(diagnosticDetails ?? '', /Reason: tool_failed/u);
+    assert.match(diagnosticDetails ?? '', /Code: TOOL_FAILED/u);
 
     handlers.reconcilePersistedMessages('session-1', [
       { type: 'tool_call', id: 'tool-1', turnId: 'turn-1', stepId: 'step-1', ts: 3, toolName: 'Bash', args: {} },

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -345,6 +345,7 @@ export async function createDesktopRuntimeHostCandidate(
     observationsAttached = true;
     for (const sessionId of restoredSessionIds) {
       deps.emitSessionsChanged("message-appended", sessionId);
+      deps.emitSessionsChanged("goal-change", sessionId);
       domains.sessionSubscriptionRecovered(sessionId);
       emitActiveInteractionsChanged(
         sessionId,

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -307,6 +307,13 @@ export async function createDesktopRuntimeHostCandidate(
       emitSessionDomainChanged: (change) => domains?.sessionDomainChanged(change),
       emitRuntimeResourcePtyData: (event) => domains?.runtimeResourcePtyData(event),
       emitAgentGraphChanged: (event) => domains?.agentGraphChanged(event),
+      emitActiveInteractionsChanged: (sessionId, interactions) =>
+        deps.sendToRenderer?.('sessions:active-interactions-changed', {
+          sessionId,
+          interactions,
+        }),
+      emitSubscriptionRecovered: (sessionId) =>
+        domains?.sessionSubscriptionRecovered(sessionId),
       onWatchedTurnFinished: (sessionId, outcome) =>
         outcome === "completed"
           ? deps.completeComputerUseTurn(sessionId)

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -1,5 +1,6 @@
 import type { IpcMain } from "electron";
 import type {
+  ActiveInteractionRequestEvent,
   CreateSessionRequestInput,
   SessionChangedEvent,
   SessionChangedReason,
@@ -300,6 +301,15 @@ export async function createDesktopRuntimeHostCandidate(
   let capabilitiesRegistered = false;
   try {
     let domains: RuntimeHostSessionDomainsIpcHandle | undefined;
+    const emitActiveInteractionsChanged = (
+      sessionId: string,
+      interactions: readonly ActiveInteractionRequestEvent[],
+    ): void => {
+      deps.sendToRenderer?.('sessions:active-interactions-changed', {
+        sessionId,
+        interactions,
+      });
+    };
     const sessionObserver = new RuntimeHostSessionObserver({
       client,
       emitSessionsChanged: (reason, sessionId, extra) =>
@@ -307,11 +317,7 @@ export async function createDesktopRuntimeHostCandidate(
       emitSessionDomainChanged: (change) => domains?.sessionDomainChanged(change),
       emitRuntimeResourcePtyData: (event) => domains?.runtimeResourcePtyData(event),
       emitAgentGraphChanged: (event) => domains?.agentGraphChanged(event),
-      emitActiveInteractionsChanged: (sessionId, interactions) =>
-        deps.sendToRenderer?.('sessions:active-interactions-changed', {
-          sessionId,
-          interactions,
-        }),
+      emitActiveInteractionsChanged,
       emitSubscriptionRecovered: (sessionId) =>
         domains?.sessionSubscriptionRecovered(sessionId),
       onWatchedTurnFinished: (sessionId, outcome) =>
@@ -339,6 +345,11 @@ export async function createDesktopRuntimeHostCandidate(
     observationsAttached = true;
     for (const sessionId of restoredSessionIds) {
       deps.emitSessionsChanged("message-appended", sessionId);
+      domains.sessionSubscriptionRecovered(sessionId);
+      emitActiveInteractionsChanged(
+        sessionId,
+        sessionObserver.listActiveInteractions(sessionId) ?? [],
+      );
     }
     const watchComputerUseTurn = (sessionId: string, turnId: string): void => {
       void sessionObserver

--- a/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
@@ -51,6 +51,7 @@ export interface RuntimeHostSessionDomainsIpcHandle {
   sessionDomainChanged(change: SessionDomainChange): void;
   runtimeResourcePtyData(event: ShellRunPtyDataEvent): void;
   agentGraphChanged(event: AgentGraphClientChangedEvent): void;
+  sessionSubscriptionRecovered(sessionId: string): void;
   close(): Promise<void>;
 }
 
@@ -206,35 +207,44 @@ export function registerRuntimeHostSessionDomainsIpc(
     });
   });
 
+  const sessionDomainChanged = (change: SessionDomainChange): void => {
+    switch (change.domain) {
+      case 'task':
+        deps.sendToRenderer?.('tasks:changed', {
+          sessionId: change.sessionId,
+          taskIds: [],
+          at: now(),
+        });
+        break;
+      case 'deep_research':
+        deps.sendToRenderer?.('deepResearch:changed', {
+          sessionId: change.sessionId,
+          ts: now(),
+        });
+        break;
+      case 'plan':
+        deps.sendToRenderer?.('plan-mode:changed', { sessionId: change.sessionId });
+        break;
+      case 'runtime_resource':
+        void refreshRuntimeResources(deps, change.sessionId, change.resources);
+        break;
+    }
+  };
+
   return {
-    sessionDomainChanged(change) {
-      switch (change.domain) {
-        case 'task':
-          deps.sendToRenderer?.('tasks:changed', {
-            sessionId: change.sessionId,
-            taskIds: [],
-            at: now(),
-          });
-          break;
-        case 'deep_research':
-          deps.sendToRenderer?.('deepResearch:changed', {
-            sessionId: change.sessionId,
-            ts: now(),
-          });
-          break;
-        case 'plan':
-          deps.sendToRenderer?.('plan-mode:changed', { sessionId: change.sessionId });
-          break;
-        case 'runtime_resource':
-          void refreshRuntimeResources(deps, change.sessionId, change.resources);
-          break;
-      }
-    },
+    sessionDomainChanged,
     runtimeResourcePtyData(event) {
       deps.sendToRenderer?.('shell-runs:pty-data', event);
     },
     agentGraphChanged(event) {
       deps.sendToRenderer?.('graphs:changed', event);
+    },
+    sessionSubscriptionRecovered(sessionId) {
+      sessionDomainChanged({ sessionId, domain: 'task' });
+      sessionDomainChanged({ sessionId, domain: 'deep_research' });
+      sessionDomainChanged({ sessionId, domain: 'plan' });
+      deps.sendToRenderer?.('graphs:resync', { rootSessionId: sessionId });
+      deps.sendToRenderer?.('shell-runs:resync', { sessionId });
     },
     close: () => shellRuns.close(),
   };

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -20,13 +20,13 @@ import type {
   SessionContinuitySnapshot,
   SubscriptionFrame,
 } from "@maka/runtime-host/protocol";
-import type {
-  DesktopRuntimeHostClient,
-  DesktopRuntimeHostSession,
-} from "./runtime-host-client.js";
+import type { DesktopRuntimeHostClient } from "./runtime-host-client.js";
 import { RuntimeHostSubscriptionError } from "@maka/runtime-host/client";
-
-const MAX_PENDING_FRAMES = 512;
+import {
+  type PreparedSessionSubscription,
+  RuntimeHostSessionSubscriptionOwner,
+  SessionRemovedSubscriptionError,
+} from "./runtime-host-session-subscription-owner.js";
 
 type SessionObserverClient = Pick<DesktopRuntimeHostClient, "openSession">;
 
@@ -71,9 +71,7 @@ interface ObservedSessionState {
   readonly sessionId: string;
   readonly targets: Map<number, ObserverTargetGroup>;
   readonly watchedTurnIds: Set<string>;
-  openTask: Promise<void>;
-  handle?: DesktopRuntimeHostSession;
-  attempt?: SessionSubscriptionAttempt;
+  readonly subscriptionOwner: RuntimeHostSessionSubscriptionOwner;
   transcript?: StoredMessage[];
   transcriptConsumed: boolean;
   snapshot?: SessionContinuitySnapshot;
@@ -94,32 +92,11 @@ interface SubscriptionFailureIdentity {
   readonly message: string;
 }
 
-interface SessionSubscriptionAttempt {
-  readonly handle: DesktopRuntimeHostSession;
-  readonly pendingFrames: SubscriptionFrame[];
-  readonly failed: Promise<Error>;
-  fail(error: Error): void;
-  failure?: Error;
-  committed: boolean;
-}
-
-interface AcquiredSessionSubscription {
-  readonly attempt: SessionSubscriptionAttempt;
-  readonly snapshot: SessionContinuitySnapshot;
-  readonly transcript: StoredMessage[];
-}
-
-class SessionRemovedSubscriptionError extends Error {
-  readonly name = "SessionRemovedSubscriptionError";
-}
-
 /**
- * Owns the Desktop-side lifetime of Host Session subscriptions.
+ * Projects an owned Host Session subscription into Desktop observers.
  *
- * The initial transcript and the following frames come from one atomic Host
- * subscription. The observer seeds the live projection from the active
- * transcript, then applies offset-bearing deltas, so joining mid-Turn neither
- * loses the already-generated prefix nor renders it twice.
+ * SessionSubscriptionOwner keeps replacement and catch-up atomic. This class
+ * owns only renderer targets and the resulting Desktop projection.
  */
 export class RuntimeHostSessionObserver {
   readonly #states = new Map<string, ObservedSessionState>();
@@ -168,7 +145,7 @@ export class RuntimeHostSessionObserver {
     this.#assertOpen();
     const existing = this.#states.get(sessionId);
     if (existing) {
-      await existing.openTask;
+      await existing.subscriptionOwner.waitUntilReady();
       if (!existing.transcriptConsumed) {
         existing.transcriptConsumed = true;
         return cloneMessages(existing.transcript ?? []);
@@ -176,7 +153,7 @@ export class RuntimeHostSessionObserver {
     }
     if (!existing) {
       const state = this.#state(sessionId);
-      await state.openTask;
+      await state.subscriptionOwner.waitUntilReady();
       state.transcriptConsumed = true;
       const transcript = cloneMessages(state.transcript ?? []);
       void this.#closeIfIdle(state);
@@ -189,7 +166,7 @@ export class RuntimeHostSessionObserver {
     this.#assertOpen();
     const existing = this.#states.get(sessionId);
     if (existing) {
-      await existing.openTask;
+      await existing.subscriptionOwner.waitUntilReady();
       if (existing.snapshot) return structuredClone(existing.snapshot);
     }
     const handle = await this.#client.openSession(sessionId);
@@ -234,7 +211,7 @@ export class RuntimeHostSessionObserver {
     group.observerIds.add(observerId);
     this.#observers.set(observerId, { state, group });
     try {
-      await state.openTask;
+      await state.subscriptionOwner.waitUntilReady();
       this.#seedTarget(state, group);
     } catch (error) {
       this.#detachObserver(observerId);
@@ -251,7 +228,7 @@ export class RuntimeHostSessionObserver {
     this.#assertOpen();
     const state = this.#state(sessionId);
     state.watchedTurnIds.add(turnId);
-    await state.openTask;
+    await state.subscriptionOwner.waitUntilReady();
     const root = state.snapshot?.rootTurn;
     if (root && root.turnId === turnId && isTerminalTurn(root)) {
       this.#finishWatchedTurn(state, turnId, "completed");
@@ -346,123 +323,49 @@ export class RuntimeHostSessionObserver {
   #state(sessionId: string): ObservedSessionState {
     const existing = this.#states.get(sessionId);
     if (existing) return existing;
-    const state: ObservedSessionState = {
+    let state!: ObservedSessionState;
+    const subscriptionOwner = new RuntimeHostSessionSubscriptionOwner({
+      client: this.#client,
+      sessionId,
+      now: this.#now,
+      commit: (subscription, recovered) =>
+        this.#commitSubscription(state, subscription, recovered),
+      acceptFrame: (frame) => this.#acceptFrame(state, frame),
+      recoveryStarted: (error) => {
+        console.warn(
+          "[runtime-host-session-observer] recovering subscription",
+          subscriptionFailureIdentity(state, error),
+        );
+      },
+      recoveryCompleted: (error) => {
+        console.info(
+          "[runtime-host-session-observer] subscription recovered",
+          subscriptionFailureIdentity(state, error),
+        );
+      },
+      recoveryFailed: (initialError, error) => {
+        console.error(
+          "[runtime-host-session-observer] subscription recovery failed",
+          {
+            failure: subscriptionFailureIdentity(state, initialError),
+            recovery: subscriptionFailureIdentity(state, error),
+          },
+        );
+      },
+      terminalFailure: (error) =>
+        this.#handleTerminalSubscriptionFailure(state, error),
+    });
+    state = {
       sessionId,
       targets: new Map(),
       watchedTurnIds: new Set(),
-      openTask: Promise.resolve(),
+      subscriptionOwner,
       transcriptConsumed: false,
       closing: false,
     };
     this.#states.set(sessionId, state);
-    state.openTask = this.#open(state);
+    subscriptionOwner.start();
     return state;
-  }
-
-  async #open(state: ObservedSessionState): Promise<void> {
-    try {
-      await this.#establishSubscription(state);
-    } catch (error) {
-      if (error instanceof SessionRemovedSubscriptionError) {
-        this.#emitSessionsChanged("deleted", state.sessionId);
-      }
-      await this.#closeState(state);
-      throw error;
-    }
-  }
-
-  async #acquireSubscription(
-    state: ObservedSessionState,
-  ): Promise<AcquiredSessionSubscription> {
-    const handle = await this.#client.openSession(state.sessionId);
-    if (state.closing) {
-      await handle.close();
-      throw new Error("Runtime Host Session observer closed while opening");
-    }
-    let fail!: (error: Error) => void;
-    const failed = new Promise<Error>((resolve) => {
-      fail = resolve;
-    });
-    const attempt: SessionSubscriptionAttempt = {
-      handle,
-      pendingFrames: [],
-      failed,
-      fail(error) {
-        if (attempt.failure) return;
-        attempt.failure = error;
-        fail(error);
-      },
-      committed: false,
-    };
-    state.attempt = attempt;
-    void this.#pump(state, attempt);
-    try {
-      const loaded = await Promise.race([
-        handle.transcript.then(
-          (transcript) => ({ kind: "transcript" as const, transcript }),
-          (error: unknown) => ({ kind: "failure" as const, error: asError(error) }),
-        ),
-        failed.then((error) => ({ kind: "failure" as const, error })),
-      ]);
-      if (loaded.kind === "failure") throw loaded.error;
-      if (attempt.failure) throw attempt.failure;
-      if (state.closing || state.attempt !== attempt) {
-        throw new Error("Runtime Host Session observer closed while opening");
-      }
-      validatePendingFrames(handle.snapshot, loaded.transcript, attempt.pendingFrames, this.#now);
-      return {
-        attempt,
-        snapshot: structuredClone(handle.snapshot),
-        transcript: loaded.transcript,
-      };
-    } catch (error) {
-      if (state.attempt === attempt) state.attempt = undefined;
-      await handle.close().catch(() => undefined);
-      throw error;
-    }
-  }
-
-  async #pump(
-    state: ObservedSessionState,
-    attempt: SessionSubscriptionAttempt,
-  ): Promise<void> {
-    const { handle } = attempt;
-    try {
-      for await (const frame of handle.events) {
-        if (state.closing) return;
-        if (frame.kind === "subscription.closed") {
-          throw subscriptionClosedError(frame.reason);
-        }
-        if (!attempt.committed) {
-          if (attempt.pendingFrames.length >= MAX_PENDING_FRAMES) {
-            throw new RuntimeHostSubscriptionError(
-              "slow_consumer",
-              "Runtime Host Session transcript could not keep up with live events",
-            );
-          }
-          attempt.pendingFrames.push(frame);
-        } else {
-          this.#acceptFrame(state, frame);
-        }
-      }
-      if (!state.closing)
-        throw new Error("Runtime Host Session subscription ended unexpectedly");
-    } catch (error) {
-      if (state.closing) return;
-      const failure = asError(error);
-      if (!attempt.committed) {
-        attempt.fail(failure);
-        return;
-      }
-      if (state.handle !== handle) return;
-      if (
-        isRecoverableSubscriptionFailure(failure)
-      ) {
-        this.#recoverSubscription(state, handle, failure);
-        return;
-      }
-      this.#handleTerminalSubscriptionFailure(state, failure);
-    }
   }
 
   #seedTarget(state: ObservedSessionState, group: ObserverTargetGroup): void {
@@ -617,85 +520,18 @@ export class RuntimeHostSessionObserver {
     this.#publishSubscriptionFailure(state, error);
   }
 
-  #recoverSubscription(
-    state: ObservedSessionState,
-    handle: DesktopRuntimeHostSession,
-    error: unknown,
-  ): void {
-    const identity = subscriptionFailureIdentity(state, error);
-    console.warn("[runtime-host-session-observer] recovering subscription", identity);
-    const recovery = this.#establishSubscription(state, handle, error);
-    state.openTask = recovery;
-    void recovery.catch((recoveryError: unknown) => {
-      if (state.closing || this.#states.get(state.sessionId) !== state) return;
-      const recovered = subscriptionFailureIdentity(state, recoveryError);
-      console.error(
-        "[runtime-host-session-observer] subscription recovery failed",
-        { failure: identity, recovery: recovered },
-      );
-      this.#handleTerminalSubscriptionFailure(state, asError(recoveryError));
-    });
-  }
-
-  async #establishSubscription(
-    state: ObservedSessionState,
-    failed?: DesktopRuntimeHostSession,
-    initialFailure?: unknown,
-  ): Promise<void> {
-    let failure =
-      initialFailure === undefined
-        ? undefined
-        : subscriptionFailureIdentity(state, initialFailure);
-    if (failed) await failed.close().catch(() => undefined);
-    while (true) {
-      if (state.closing || this.#states.get(state.sessionId) !== state) {
-        throw new Error("Runtime Host Session observer closed while opening");
-      }
-      let acquired: AcquiredSessionSubscription;
-      try {
-        acquired = await this.#acquireSubscription(state);
-      } catch (error) {
-        if (isRecoverableSubscriptionFailure(error)) {
-          failure ??= subscriptionFailureIdentity(state, error);
-          continue;
-        }
-        throw error;
-      }
-      try {
-        this.#commitSubscription(state, acquired, failure !== undefined);
-      } catch (error) {
-        if (state.attempt === acquired.attempt) state.attempt = undefined;
-        await acquired.attempt.handle.close().catch(() => undefined);
-        if (isRecoverableSubscriptionFailure(error)) {
-          failure ??= subscriptionFailureIdentity(state, error);
-          continue;
-        }
-        throw error;
-      }
-      if (failure) {
-        console.info("[runtime-host-session-observer] subscription recovered", failure);
-      }
-      return;
-    }
-  }
-
   #commitSubscription(
     state: ObservedSessionState,
-    acquired: AcquiredSessionSubscription,
+    subscription: PreparedSessionSubscription,
     recovered: boolean,
   ): void {
-    if (
-      state.closing ||
-      this.#states.get(state.sessionId) !== state ||
-      state.attempt !== acquired.attempt
-    ) {
+    if (state.closing || this.#states.get(state.sessionId) !== state) {
       throw new Error("Runtime Host Session observer closed before commit");
     }
-    if (acquired.attempt.failure) throw acquired.attempt.failure;
     const previousSnapshot = state.snapshot;
     const projector = new RuntimeHostSessionProjector(
-      acquired.snapshot,
-      acquired.transcript,
+      subscription.snapshot,
+      subscription.transcript,
       this.#now,
     );
     const replacement =
@@ -703,17 +539,17 @@ export class RuntimeHostSessionObserver {
         ? replacementProjection(
             previousSnapshot,
             projector,
-            acquired.transcript,
+            subscription.transcript,
           )
         : undefined;
+    const goalChanged = previousSnapshot
+      ? !sameGoal(previousSnapshot.goal, subscription.snapshot.goal)
+      : false;
 
-    state.attempt = undefined;
-    state.handle = acquired.attempt.handle;
-    state.snapshot = structuredClone(acquired.snapshot);
-    state.transcript = acquired.transcript;
+    state.snapshot = structuredClone(subscription.snapshot);
+    state.transcript = subscription.transcript;
     state.transcriptConsumed = false;
     state.projector = projector;
-    acquired.attempt.committed = true;
 
     if (replacement) {
       for (const event of replacement.terminalEvents) {
@@ -733,6 +569,9 @@ export class RuntimeHostSessionObserver {
         });
       }
       this.#emitActiveInteractions(state);
+      if (goalChanged) {
+        this.#emitSessionsChanged("goal-change", state.sessionId);
+      }
       const root = state.snapshot.rootTurn;
       this.#emitSessionsChanged(
         "status-change",
@@ -748,13 +587,13 @@ export class RuntimeHostSessionObserver {
       for (const group of state.targets.values()) this.#seedTarget(state, group);
     }
 
-    this.#finishPersistedWatchedTurns(state, projector, acquired.transcript);
+    this.#finishPersistedWatchedTurns(
+      state,
+      projector,
+      subscription.transcript,
+    );
 
     if (recovered) this.#emitSubscriptionRecovered(state.sessionId);
-
-    for (const frame of acquired.attempt.pendingFrames.splice(0)) {
-      this.#acceptFrame(state, frame);
-    }
     void this.#closeIfIdle(state);
   }
 
@@ -854,16 +693,7 @@ export class RuntimeHostSessionObserver {
       for (const group of state.targets.values())
         this.#detachTarget(state, group);
     }
-    const handle = state.handle;
-    const attempt = state.attempt;
-    state.handle = undefined;
-    state.attempt = undefined;
-    await Promise.all([
-      handle?.close().catch(() => undefined),
-      attempt && attempt.handle !== handle
-        ? attempt.handle.close().catch(() => undefined)
-        : undefined,
-    ]);
+    await state.subscriptionOwner.close();
   }
 
   async #removeTarget(
@@ -935,18 +765,6 @@ async function drainFrames(
     // A one-shot transcript read still owns a live Host subscription until it
     // closes. Drain bounded frames so transcript pagination cannot be evicted
     // as a slow consumer.
-  }
-}
-
-function validatePendingFrames(
-  snapshot: SessionContinuitySnapshot,
-  transcript: readonly StoredMessage[],
-  frames: readonly SubscriptionFrame[],
-  now: () => number,
-): void {
-  const projector = new RuntimeHostSessionProjector(snapshot, transcript, now);
-  for (const frame of frames) {
-    projector.accept(frame);
   }
 }
 
@@ -1023,33 +841,6 @@ function samePendingInteractions(
   return next.interactions.pending.every(
     (interaction) =>
       revisions.get(interaction.interactionId) === interaction.revision,
-  );
-}
-
-function subscriptionClosedError(
-  reason: "slow_consumer" | "session_removed",
-): Error {
-  return reason === "session_removed"
-    ? new SessionRemovedSubscriptionError(
-        "Runtime Host Session was removed while it was observed",
-      )
-    : new RuntimeHostSubscriptionError(
-        "slow_consumer",
-        "Runtime Host Session subscription closed for a slow consumer",
-      );
-}
-
-function asError(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error));
-}
-
-function isRecoverableSubscriptionFailure(error: unknown): boolean {
-  if (!(error instanceof RuntimeHostSubscriptionError)) return false;
-  return (
-    error.reason === "slow_consumer" ||
-    error.reason === "sequence_gap" ||
-    error.reason === "projection_revision_invalid" ||
-    error.reason === "transcript_expired"
   );
 }
 

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -82,6 +82,14 @@ interface ObserverRegistration {
   readonly group: ObserverTargetGroup;
 }
 
+interface SubscriptionFailureIdentity {
+  readonly sessionId: string;
+  readonly turnId?: string;
+  readonly runId?: string;
+  readonly reason: string;
+  readonly message: string;
+}
+
 /**
  * Owns the Desktop-side lifetime of Host Session subscriptions.
  *
@@ -321,31 +329,37 @@ export class RuntimeHostSessionObserver {
 
   async #open(state: ObservedSessionState): Promise<void> {
     try {
-      const handle = await this.#client.openSession(state.sessionId);
-      if (state.closing) {
-        await handle.close();
-        throw new Error("Runtime Host Session observer closed while opening");
-      }
-      state.handle = handle;
-      state.snapshot = structuredClone(handle.snapshot);
-      void this.#pump(state, handle);
-      state.transcript = await handle.transcript;
-      if (state.closing)
-        throw new Error("Runtime Host Session observer closed while opening");
-      state.projector = new RuntimeHostSessionProjector(
-        handle.snapshot,
-        state.transcript,
-        this.#now,
-      );
-      state.ready = true;
-      for (const group of state.targets.values())
-        this.#seedTarget(state, group);
-      for (const frame of state.pendingFrames.splice(0))
-        this.#acceptFrame(state, frame);
+      await this.#openHandle(state);
     } catch (error) {
       await this.#closeState(state);
       throw error;
     }
+  }
+
+  async #openHandle(state: ObservedSessionState): Promise<void> {
+    const handle = await this.#client.openSession(state.sessionId);
+    if (state.closing) {
+      await handle.close();
+      throw new Error("Runtime Host Session observer closed while opening");
+    }
+    state.handle = handle;
+    state.snapshot = structuredClone(handle.snapshot);
+    void this.#pump(state, handle);
+    state.transcript = await handle.transcript;
+    if (state.closing || state.handle !== handle) {
+      await handle.close();
+      throw new Error("Runtime Host Session observer closed while opening");
+    }
+    state.projector = new RuntimeHostSessionProjector(
+      handle.snapshot,
+      state.transcript,
+      this.#now,
+    );
+    state.ready = true;
+    for (const group of state.targets.values())
+      this.#seedTarget(state, group);
+    for (const frame of state.pendingFrames.splice(0))
+      this.#acceptFrame(state, frame);
   }
 
   async #pump(
@@ -374,6 +388,14 @@ export class RuntimeHostSessionObserver {
       }
     } catch (error) {
       if (state.closing) return;
+      if (
+        state.ready &&
+        state.handle === handle &&
+        isRecoverableSubscriptionFailure(error)
+      ) {
+        this.#recoverSubscription(state, handle, error);
+        return;
+      }
       if (
         this.#recoverConnectionClosed &&
         error instanceof RuntimeHostSubscriptionError &&
@@ -430,11 +452,9 @@ export class RuntimeHostSessionObserver {
         this.#emitSessionsChanged("deleted", state.sessionId);
         void this.#closeState(state);
       } else {
-        this.#publishSubscriptionFailure(
-          state,
-          new Error(
-            "Runtime Host Session subscription closed for a slow consumer",
-          ),
+        throw new RuntimeHostSubscriptionError(
+          "slow_consumer",
+          "Runtime Host Session subscription closed for a slow consumer",
         );
       }
       return;
@@ -503,6 +523,10 @@ export class RuntimeHostSessionObserver {
     error: unknown,
   ): void {
     const root = state.snapshot?.rootTurn;
+    const reason =
+      error instanceof RuntimeHostSubscriptionError
+        ? error.reason
+        : "subscription_closed";
     if (root && !isTerminalTurn(root)) {
       this.#broadcast(state.sessionId, {
         type: "error",
@@ -510,7 +534,7 @@ export class RuntimeHostSessionObserver {
         turnId: root.turnId,
         ts: this.#now(),
         recoverable: true,
-        reason: "subscription_closed",
+        reason,
         message:
           error instanceof Error
             ? error.message
@@ -523,6 +547,62 @@ export class RuntimeHostSessionObserver {
       root ? { turnId: root.turnId } : undefined,
     );
     void this.#closeState(state);
+  }
+
+  #recoverSubscription(
+    state: ObservedSessionState,
+    handle: DesktopRuntimeHostSession,
+    error: unknown,
+  ): void {
+    const identity = subscriptionFailureIdentity(state, error);
+    console.warn("[runtime-host-session-observer] recovering subscription", identity);
+    state.ready = false;
+    state.handle = undefined;
+    state.pendingFrames.length = 0;
+    state.transcript = undefined;
+    state.projector = undefined;
+    for (const group of state.targets.values()) group.seeded = false;
+
+    const recovery = this.#replaceSubscription(state, handle, identity);
+    state.openTask = recovery;
+    void recovery.catch(() => undefined);
+  }
+
+  async #replaceSubscription(
+    state: ObservedSessionState,
+    previous: DesktopRuntimeHostSession,
+    failure: SubscriptionFailureIdentity,
+  ): Promise<void> {
+    await previous.close().catch(() => undefined);
+    if (state.closing || this.#states.get(state.sessionId) !== state) return;
+    try {
+      await this.#openHandle(state);
+      console.info("[runtime-host-session-observer] subscription recovered", failure);
+      const root = state.snapshot?.rootTurn;
+      this.#emitSessionsChanged(
+        "status-change",
+        state.sessionId,
+        root ? { turnId: root.turnId } : undefined,
+      );
+      if (root) {
+        this.#emitSessionsChanged("message-appended", state.sessionId, {
+          turnId: root.turnId,
+        });
+        if (isTerminalTurn(root)) {
+          this.#finishWatchedTurn(state, root.turnId, "completed");
+          void this.#closeIfIdle(state);
+        }
+      }
+    } catch (error) {
+      if (state.closing || this.#states.get(state.sessionId) !== state) return;
+      const recovery = subscriptionFailureIdentity(state, error);
+      console.error(
+        "[runtime-host-session-observer] subscription recovery failed",
+        { failure, recovery },
+      );
+      this.#publishSubscriptionFailure(state, error);
+      throw error;
+    }
   }
 
   async #loadCurrentTranscript(sessionId: string): Promise<StoredMessage[]> {
@@ -674,4 +754,32 @@ async function drainFrames(
     // closes. Drain bounded frames so transcript pagination cannot be evicted
     // as a slow consumer.
   }
+}
+
+function isRecoverableSubscriptionFailure(error: unknown): boolean {
+  if (!(error instanceof RuntimeHostSubscriptionError)) return false;
+  return (
+    error.reason === "slow_consumer" ||
+    error.reason === "sequence_gap" ||
+    error.reason === "projection_revision_invalid"
+  );
+}
+
+function subscriptionFailureIdentity(
+  state: ObservedSessionState,
+  error: unknown,
+): SubscriptionFailureIdentity {
+  const root = state.snapshot?.rootTurn;
+  return {
+    sessionId: state.sessionId,
+    ...(root ? { turnId: root.turnId, runId: root.runId } : {}),
+    reason:
+      error instanceof RuntimeHostSubscriptionError
+        ? error.reason
+        : "subscription_closed",
+    message:
+      error instanceof Error
+        ? error.message
+        : "Runtime Host Session subscription closed",
+  };
 }

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -51,6 +51,11 @@ export interface RuntimeHostSessionObserverDeps {
     sessionId: string,
     outcome: "completed" | "abandoned",
   ) => void | Promise<void>;
+  emitActiveInteractionsChanged?: (
+    sessionId: string,
+    interactions: readonly ActiveInteractionRequestEvent[],
+  ) => void;
+  emitSubscriptionRecovered?: (sessionId: string) => void;
   recoverConnectionClosed?: boolean;
   now?: () => number;
 }
@@ -65,15 +70,14 @@ interface ObserverTargetGroup {
 interface ObservedSessionState {
   readonly sessionId: string;
   readonly targets: Map<number, ObserverTargetGroup>;
-  readonly pendingFrames: SubscriptionFrame[];
   readonly watchedTurnIds: Set<string>;
   openTask: Promise<void>;
   handle?: DesktopRuntimeHostSession;
+  attempt?: SessionSubscriptionAttempt;
   transcript?: StoredMessage[];
   transcriptConsumed: boolean;
   snapshot?: SessionContinuitySnapshot;
   projector?: RuntimeHostSessionProjector;
-  ready: boolean;
   closing: boolean;
 }
 
@@ -88,6 +92,25 @@ interface SubscriptionFailureIdentity {
   readonly runId?: string;
   readonly reason: string;
   readonly message: string;
+}
+
+interface SessionSubscriptionAttempt {
+  readonly handle: DesktopRuntimeHostSession;
+  readonly pendingFrames: SubscriptionFrame[];
+  readonly failed: Promise<Error>;
+  fail(error: Error): void;
+  failure?: Error;
+  committed: boolean;
+}
+
+interface AcquiredSessionSubscription {
+  readonly attempt: SessionSubscriptionAttempt;
+  readonly snapshot: SessionContinuitySnapshot;
+  readonly transcript: StoredMessage[];
+}
+
+class SessionRemovedSubscriptionError extends Error {
+  readonly name = "SessionRemovedSubscriptionError";
 }
 
 /**
@@ -113,6 +136,11 @@ export class RuntimeHostSessionObserver {
     sessionId: string,
     outcome: "completed" | "abandoned",
   ) => void | Promise<void>;
+  readonly #emitActiveInteractionsChanged: (
+    sessionId: string,
+    interactions: readonly ActiveInteractionRequestEvent[],
+  ) => void;
+  readonly #emitSubscriptionRecovered: (sessionId: string) => void;
   readonly #recoverConnectionClosed: boolean;
   readonly #now: () => number;
   #closed = false;
@@ -128,6 +156,10 @@ export class RuntimeHostSessionObserver {
       deps.emitAgentGraphChanged ?? (() => undefined);
     this.#onWatchedTurnFinished =
       deps.onWatchedTurnFinished ?? (() => undefined);
+    this.#emitActiveInteractionsChanged =
+      deps.emitActiveInteractionsChanged ?? (() => undefined);
+    this.#emitSubscriptionRecovered =
+      deps.emitSubscriptionRecovered ?? (() => undefined);
     this.#recoverConnectionClosed = deps.recoverConnectionClosed ?? false;
     this.#now = deps.now ?? Date.now;
   }
@@ -135,10 +167,12 @@ export class RuntimeHostSessionObserver {
   async readMessages(sessionId: string): Promise<StoredMessage[]> {
     this.#assertOpen();
     const existing = this.#states.get(sessionId);
-    if (existing && !existing.transcriptConsumed) {
+    if (existing) {
       await existing.openTask;
-      existing.transcriptConsumed = true;
-      return cloneMessages(existing.transcript ?? []);
+      if (!existing.transcriptConsumed) {
+        existing.transcriptConsumed = true;
+        return cloneMessages(existing.transcript ?? []);
+      }
     }
     if (!existing) {
       const state = this.#state(sessionId);
@@ -315,96 +349,119 @@ export class RuntimeHostSessionObserver {
     const state: ObservedSessionState = {
       sessionId,
       targets: new Map(),
-      pendingFrames: [],
       watchedTurnIds: new Set(),
       openTask: Promise.resolve(),
       transcriptConsumed: false,
-      ready: false,
       closing: false,
     };
-    state.openTask = this.#open(state);
     this.#states.set(sessionId, state);
+    state.openTask = this.#open(state);
     return state;
   }
 
   async #open(state: ObservedSessionState): Promise<void> {
     try {
-      await this.#openHandle(state);
+      await this.#establishSubscription(state);
     } catch (error) {
+      if (error instanceof SessionRemovedSubscriptionError) {
+        this.#emitSessionsChanged("deleted", state.sessionId);
+      }
       await this.#closeState(state);
       throw error;
     }
   }
 
-  async #openHandle(state: ObservedSessionState): Promise<void> {
+  async #acquireSubscription(
+    state: ObservedSessionState,
+  ): Promise<AcquiredSessionSubscription> {
     const handle = await this.#client.openSession(state.sessionId);
     if (state.closing) {
       await handle.close();
       throw new Error("Runtime Host Session observer closed while opening");
     }
-    state.handle = handle;
-    state.snapshot = structuredClone(handle.snapshot);
-    void this.#pump(state, handle);
-    state.transcript = await handle.transcript;
-    if (state.closing || state.handle !== handle) {
-      await handle.close();
-      throw new Error("Runtime Host Session observer closed while opening");
+    let fail!: (error: Error) => void;
+    const failed = new Promise<Error>((resolve) => {
+      fail = resolve;
+    });
+    const attempt: SessionSubscriptionAttempt = {
+      handle,
+      pendingFrames: [],
+      failed,
+      fail(error) {
+        if (attempt.failure) return;
+        attempt.failure = error;
+        fail(error);
+      },
+      committed: false,
+    };
+    state.attempt = attempt;
+    void this.#pump(state, attempt);
+    try {
+      const loaded = await Promise.race([
+        handle.transcript.then(
+          (transcript) => ({ kind: "transcript" as const, transcript }),
+          (error: unknown) => ({ kind: "failure" as const, error: asError(error) }),
+        ),
+        failed.then((error) => ({ kind: "failure" as const, error })),
+      ]);
+      if (loaded.kind === "failure") throw loaded.error;
+      if (attempt.failure) throw attempt.failure;
+      if (state.closing || state.attempt !== attempt) {
+        throw new Error("Runtime Host Session observer closed while opening");
+      }
+      validatePendingFrames(handle.snapshot, loaded.transcript, attempt.pendingFrames, this.#now);
+      return {
+        attempt,
+        snapshot: structuredClone(handle.snapshot),
+        transcript: loaded.transcript,
+      };
+    } catch (error) {
+      if (state.attempt === attempt) state.attempt = undefined;
+      await handle.close().catch(() => undefined);
+      throw error;
     }
-    state.projector = new RuntimeHostSessionProjector(
-      handle.snapshot,
-      state.transcript,
-      this.#now,
-    );
-    state.ready = true;
-    for (const group of state.targets.values())
-      this.#seedTarget(state, group);
-    for (const frame of state.pendingFrames.splice(0))
-      this.#acceptFrame(state, frame);
   }
 
   async #pump(
     state: ObservedSessionState,
-    handle: DesktopRuntimeHostSession,
+    attempt: SessionSubscriptionAttempt,
   ): Promise<void> {
+    const { handle } = attempt;
     try {
       for await (const frame of handle.events) {
         if (state.closing) return;
-        if (!state.ready) {
-          if (state.pendingFrames.length >= MAX_PENDING_FRAMES) {
-            throw new Error(
-              "Runtime Host Session initial transcript could not keep up with live events",
+        if (frame.kind === "subscription.closed") {
+          throw subscriptionClosedError(frame.reason);
+        }
+        if (!attempt.committed) {
+          if (attempt.pendingFrames.length >= MAX_PENDING_FRAMES) {
+            throw new RuntimeHostSubscriptionError(
+              "slow_consumer",
+              "Runtime Host Session transcript could not keep up with live events",
             );
           }
-          state.pendingFrames.push(frame);
+          attempt.pendingFrames.push(frame);
         } else {
           this.#acceptFrame(state, frame);
         }
       }
-      if (!state.closing) {
-        this.#publishSubscriptionFailure(
-          state,
-          new Error("Runtime Host Session subscription ended unexpectedly"),
-        );
-      }
+      if (!state.closing)
+        throw new Error("Runtime Host Session subscription ended unexpectedly");
     } catch (error) {
       if (state.closing) return;
-      if (
-        state.ready &&
-        state.handle === handle &&
-        isRecoverableSubscriptionFailure(error)
-      ) {
-        this.#recoverSubscription(state, handle, error);
+      const failure = asError(error);
+      if (!attempt.committed) {
+        attempt.fail(failure);
         return;
       }
+      if (state.handle !== handle) return;
       if (
-        this.#recoverConnectionClosed &&
-        error instanceof RuntimeHostSubscriptionError &&
-        error.reason === "connection_closed"
+        isRecoverableSubscriptionFailure(failure)
       ) {
-        void this.#closeState(state);
+        this.#recoverSubscription(state, handle, failure);
         return;
       }
-      this.#publishSubscriptionFailure(state, error);
+      this.#handleTerminalSubscriptionFailure(state, failure);
     }
   }
 
@@ -447,18 +504,6 @@ export class RuntimeHostSessionObserver {
       });
       return;
     }
-    if (frame.kind === "subscription.closed") {
-      if (frame.reason === "session_removed") {
-        this.#emitSessionsChanged("deleted", state.sessionId);
-        void this.#closeState(state);
-      } else {
-        throw new RuntimeHostSubscriptionError(
-          "slow_consumer",
-          "Runtime Host Session subscription closed for a slow consumer",
-        );
-      }
-      return;
-    }
     const update = state.projector?.accept(frame);
     if (!update || !state.projector) return;
     state.snapshot = state.projector.snapshot;
@@ -472,6 +517,9 @@ export class RuntimeHostSessionObserver {
     }
     const previous = update.previousSnapshot;
     if (!previous) return;
+    if (!samePendingInteractions(previous, state.snapshot)) {
+      this.#emitActiveInteractions(state);
+    }
     if (!sameGoal(previous.goal, state.snapshot.goal)) {
       this.#emitSessionsChanged("goal-change", state.sessionId);
     }
@@ -549,6 +597,26 @@ export class RuntimeHostSessionObserver {
     void this.#closeState(state);
   }
 
+  #handleTerminalSubscriptionFailure(
+    state: ObservedSessionState,
+    error: Error,
+  ): void {
+    if (error instanceof SessionRemovedSubscriptionError) {
+      this.#emitSessionsChanged("deleted", state.sessionId);
+      void this.#closeState(state);
+      return;
+    }
+    if (
+      this.#recoverConnectionClosed &&
+      error instanceof RuntimeHostSubscriptionError &&
+      error.reason === "connection_closed"
+    ) {
+      void this.#closeState(state);
+      return;
+    }
+    this.#publishSubscriptionFailure(state, error);
+  }
+
   #recoverSubscription(
     state: ObservedSessionState,
     handle: DesktopRuntimeHostSession,
@@ -556,52 +624,159 @@ export class RuntimeHostSessionObserver {
   ): void {
     const identity = subscriptionFailureIdentity(state, error);
     console.warn("[runtime-host-session-observer] recovering subscription", identity);
-    state.ready = false;
-    state.handle = undefined;
-    state.pendingFrames.length = 0;
-    state.transcript = undefined;
-    state.projector = undefined;
-    for (const group of state.targets.values()) group.seeded = false;
-
-    const recovery = this.#replaceSubscription(state, handle, identity);
+    const recovery = this.#establishSubscription(state, handle, error);
     state.openTask = recovery;
-    void recovery.catch(() => undefined);
+    void recovery.catch((recoveryError: unknown) => {
+      if (state.closing || this.#states.get(state.sessionId) !== state) return;
+      const recovered = subscriptionFailureIdentity(state, recoveryError);
+      console.error(
+        "[runtime-host-session-observer] subscription recovery failed",
+        { failure: identity, recovery: recovered },
+      );
+      this.#handleTerminalSubscriptionFailure(state, asError(recoveryError));
+    });
   }
 
-  async #replaceSubscription(
+  async #establishSubscription(
     state: ObservedSessionState,
-    previous: DesktopRuntimeHostSession,
-    failure: SubscriptionFailureIdentity,
+    failed?: DesktopRuntimeHostSession,
+    initialFailure?: unknown,
   ): Promise<void> {
-    await previous.close().catch(() => undefined);
-    if (state.closing || this.#states.get(state.sessionId) !== state) return;
-    try {
-      await this.#openHandle(state);
-      console.info("[runtime-host-session-observer] subscription recovered", failure);
-      const root = state.snapshot?.rootTurn;
+    let failure =
+      initialFailure === undefined
+        ? undefined
+        : subscriptionFailureIdentity(state, initialFailure);
+    if (failed) await failed.close().catch(() => undefined);
+    while (true) {
+      if (state.closing || this.#states.get(state.sessionId) !== state) {
+        throw new Error("Runtime Host Session observer closed while opening");
+      }
+      let acquired: AcquiredSessionSubscription;
+      try {
+        acquired = await this.#acquireSubscription(state);
+      } catch (error) {
+        if (isRecoverableSubscriptionFailure(error)) {
+          failure ??= subscriptionFailureIdentity(state, error);
+          continue;
+        }
+        throw error;
+      }
+      try {
+        this.#commitSubscription(state, acquired, failure !== undefined);
+      } catch (error) {
+        if (state.attempt === acquired.attempt) state.attempt = undefined;
+        await acquired.attempt.handle.close().catch(() => undefined);
+        if (isRecoverableSubscriptionFailure(error)) {
+          failure ??= subscriptionFailureIdentity(state, error);
+          continue;
+        }
+        throw error;
+      }
+      if (failure) {
+        console.info("[runtime-host-session-observer] subscription recovered", failure);
+      }
+      return;
+    }
+  }
+
+  #commitSubscription(
+    state: ObservedSessionState,
+    acquired: AcquiredSessionSubscription,
+    recovered: boolean,
+  ): void {
+    if (
+      state.closing ||
+      this.#states.get(state.sessionId) !== state ||
+      state.attempt !== acquired.attempt
+    ) {
+      throw new Error("Runtime Host Session observer closed before commit");
+    }
+    if (acquired.attempt.failure) throw acquired.attempt.failure;
+    const previousSnapshot = state.snapshot;
+    const projector = new RuntimeHostSessionProjector(
+      acquired.snapshot,
+      acquired.transcript,
+      this.#now,
+    );
+    const replacement =
+      previousSnapshot
+        ? replacementProjection(
+            previousSnapshot,
+            projector,
+            acquired.transcript,
+          )
+        : undefined;
+
+    state.attempt = undefined;
+    state.handle = acquired.attempt.handle;
+    state.snapshot = structuredClone(acquired.snapshot);
+    state.transcript = acquired.transcript;
+    state.transcriptConsumed = false;
+    state.projector = projector;
+    acquired.attempt.committed = true;
+
+    if (replacement) {
+      for (const event of replacement.terminalEvents) {
+        this.#broadcast(state.sessionId, event);
+      }
+      for (const event of replacement.activeEvents) {
+        this.#broadcast(state.sessionId, event);
+      }
+      for (const group of state.targets.values()) group.seeded = true;
+      for (const turnId of replacement.terminalTurnIds) {
+        this.#finishWatchedTurn(state, turnId, "completed");
+        this.#emitSessionsChanged("turn-status-change", state.sessionId, {
+          turnId,
+        });
+        this.#emitSessionsChanged("message-appended", state.sessionId, {
+          turnId,
+        });
+      }
+      this.#emitActiveInteractions(state);
+      const root = state.snapshot.rootTurn;
       this.#emitSessionsChanged(
         "status-change",
         state.sessionId,
         root ? { turnId: root.turnId } : undefined,
       );
-      if (root) {
+      if (root && !replacement.terminalTurnIds.has(root.turnId)) {
         this.#emitSessionsChanged("message-appended", state.sessionId, {
           turnId: root.turnId,
         });
-        if (isTerminalTurn(root)) {
-          this.#finishWatchedTurn(state, root.turnId, "completed");
-          void this.#closeIfIdle(state);
-        }
       }
-    } catch (error) {
-      if (state.closing || this.#states.get(state.sessionId) !== state) return;
-      const recovery = subscriptionFailureIdentity(state, error);
-      console.error(
-        "[runtime-host-session-observer] subscription recovery failed",
-        { failure, recovery },
-      );
-      this.#publishSubscriptionFailure(state, error);
-      throw error;
+    } else {
+      for (const group of state.targets.values()) this.#seedTarget(state, group);
+    }
+
+    this.#finishPersistedWatchedTurns(state, projector, acquired.transcript);
+
+    if (recovered) this.#emitSubscriptionRecovered(state.sessionId);
+
+    for (const frame of acquired.attempt.pendingFrames.splice(0)) {
+      this.#acceptFrame(state, frame);
+    }
+    void this.#closeIfIdle(state);
+  }
+
+  #emitActiveInteractions(state: ObservedSessionState): void {
+    const interactions = state.snapshot?.interactions.pending.flatMap(
+      (interaction) =>
+        projectRuntimeHostInteractionRequest(interaction, this.#now()),
+    );
+    if (interactions) {
+      this.#emitActiveInteractionsChanged(state.sessionId, interactions);
+    }
+  }
+
+  #finishPersistedWatchedTurns(
+    state: ObservedSessionState,
+    projector: RuntimeHostSessionProjector,
+    transcript: readonly StoredMessage[],
+  ): void {
+    for (const turnId of [...state.watchedTurnIds]) {
+      if (projector.seedStoredTerminal(turnId, transcript).length > 0) {
+        this.#finishWatchedTurn(state, turnId, "completed");
+      }
     }
   }
 
@@ -680,8 +855,15 @@ export class RuntimeHostSessionObserver {
         this.#detachTarget(state, group);
     }
     const handle = state.handle;
+    const attempt = state.attempt;
     state.handle = undefined;
-    await handle?.close().catch(() => undefined);
+    state.attempt = undefined;
+    await Promise.all([
+      handle?.close().catch(() => undefined),
+      attempt && attempt.handle !== handle
+        ? attempt.handle.close().catch(() => undefined)
+        : undefined,
+    ]);
   }
 
   async #removeTarget(
@@ -756,12 +938,118 @@ async function drainFrames(
   }
 }
 
+function validatePendingFrames(
+  snapshot: SessionContinuitySnapshot,
+  transcript: readonly StoredMessage[],
+  frames: readonly SubscriptionFrame[],
+  now: () => number,
+): void {
+  const projector = new RuntimeHostSessionProjector(snapshot, transcript, now);
+  for (const frame of frames) {
+    projector.accept(frame);
+  }
+}
+
+function replacementProjection(
+  previous: SessionContinuitySnapshot,
+  projector: RuntimeHostSessionProjector,
+  transcript: readonly StoredMessage[],
+): {
+  terminalEvents: SessionEvent[];
+  activeEvents: SessionEvent[];
+  terminalTurnIds: Set<string>;
+} {
+  const next = projector.snapshot;
+  const previousRoot = previous.rootTurn;
+  const root = next.rootTurn;
+  const terminalEvents: SessionEvent[] = [];
+  if (previousRoot && !isTerminalTurn(previousRoot)) {
+    if (!root || root.runId !== previousRoot.runId) {
+      const stored = projector.seedStoredTerminal(
+        previousRoot.turnId,
+        transcript,
+      );
+      if (!stored.some(isTerminalSessionEvent)) {
+        throw new RuntimeHostSubscriptionError(
+          "projection_revision_invalid",
+          `Runtime Host replacement omitted the terminal record for Turn ${previousRoot.turnId}`,
+        );
+      }
+      terminalEvents.push(...stored);
+    } else if (isTerminalTurn(root)) {
+      terminalEvents.push(...projector.seedTerminal(root));
+    }
+  }
+  if (
+    root &&
+    isTerminalTurn(root) &&
+    (!previousRoot || previousRoot.runId !== root.runId)
+  ) {
+    terminalEvents.push(...projector.seedTerminal(root));
+  }
+  return {
+    terminalEvents,
+    activeEvents:
+      root && !isTerminalTurn(root) ? projector.seedActive(true) : [],
+    terminalTurnIds: new Set(
+      terminalEvents.filter(isTerminalSessionEvent).map((event) => event.turnId),
+    ),
+  };
+}
+
+function isTerminalSessionEvent(
+  event: SessionEvent,
+): event is Extract<SessionEvent, { type: "complete" | "error" | "abort" }> {
+  return (
+    event.type === "complete" ||
+    event.type === "error" ||
+    event.type === "abort"
+  );
+}
+
+function samePendingInteractions(
+  previous: SessionContinuitySnapshot,
+  next: SessionContinuitySnapshot,
+): boolean {
+  if (previous.interactions.pending.length !== next.interactions.pending.length) {
+    return false;
+  }
+  const revisions = new Map(
+    previous.interactions.pending.map((interaction) => [
+      interaction.interactionId,
+      interaction.revision,
+    ]),
+  );
+  return next.interactions.pending.every(
+    (interaction) =>
+      revisions.get(interaction.interactionId) === interaction.revision,
+  );
+}
+
+function subscriptionClosedError(
+  reason: "slow_consumer" | "session_removed",
+): Error {
+  return reason === "session_removed"
+    ? new SessionRemovedSubscriptionError(
+        "Runtime Host Session was removed while it was observed",
+      )
+    : new RuntimeHostSubscriptionError(
+        "slow_consumer",
+        "Runtime Host Session subscription closed for a slow consumer",
+      );
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
 function isRecoverableSubscriptionFailure(error: unknown): boolean {
   if (!(error instanceof RuntimeHostSubscriptionError)) return false;
   return (
     error.reason === "slow_consumer" ||
     error.reason === "sequence_gap" ||
-    error.reason === "projection_revision_invalid"
+    error.reason === "projection_revision_invalid" ||
+    error.reason === "transcript_expired"
   );
 }
 

--- a/apps/desktop/src/main/runtime-host-session-subscription-owner.ts
+++ b/apps/desktop/src/main/runtime-host-session-subscription-owner.ts
@@ -1,0 +1,280 @@
+import type { StoredMessage } from "@maka/core";
+import { RuntimeHostSessionProjector } from "@maka/runtime-host/adapter";
+import { RuntimeHostSubscriptionError } from "@maka/runtime-host/client";
+import type {
+  SessionContinuitySnapshot,
+  SubscriptionFrame,
+} from "@maka/runtime-host/protocol";
+import type {
+  DesktopRuntimeHostClient,
+  DesktopRuntimeHostSession,
+} from "./runtime-host-client.js";
+
+const MAX_PENDING_FRAMES = 512;
+
+type SessionSubscriptionClient = Pick<DesktopRuntimeHostClient, "openSession">;
+
+export interface PreparedSessionSubscription {
+  readonly snapshot: SessionContinuitySnapshot;
+  readonly transcript: StoredMessage[];
+}
+
+export interface RuntimeHostSessionSubscriptionOwnerDeps {
+  readonly client: SessionSubscriptionClient;
+  readonly sessionId: string;
+  readonly now: () => number;
+  commit(subscription: PreparedSessionSubscription, recovered: boolean): void;
+  acceptFrame(frame: SubscriptionFrame): void;
+  recoveryStarted(error: Error): void;
+  recoveryCompleted(error: Error): void;
+  recoveryFailed(initialError: Error, error: Error): void;
+  terminalFailure(error: Error): void;
+}
+
+interface SubscriptionAttempt {
+  readonly handle: DesktopRuntimeHostSession;
+  readonly pendingFrames: SubscriptionFrame[];
+  readonly failed: Promise<Error>;
+  phase: "preparing" | "active";
+  failure?: Error;
+  fail(error: Error): void;
+}
+
+export class SessionRemovedSubscriptionError extends Error {
+  readonly name = "SessionRemovedSubscriptionError";
+}
+
+/** Owns exactly one replaceable Host subscription for one Desktop Session. */
+export class RuntimeHostSessionSubscriptionOwner {
+  readonly #deps: RuntimeHostSessionSubscriptionOwnerDeps;
+  #attempt?: SubscriptionAttempt;
+  #readyTask: Promise<void> = Promise.resolve();
+  #started = false;
+  #closed = false;
+
+  constructor(deps: RuntimeHostSessionSubscriptionOwnerDeps) {
+    this.#deps = deps;
+  }
+
+  start(): void {
+    if (this.#started) return;
+    this.#started = true;
+    this.#replaceReadyTask(this.#establish());
+  }
+
+  async waitUntilReady(): Promise<void> {
+    while (true) {
+      const task = this.#readyTask;
+      await task;
+      if (task === this.#readyTask) return;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    const attempt = this.#attempt;
+    this.#attempt = undefined;
+    attempt?.fail(ownerClosed());
+    await attempt?.handle.close().catch(() => undefined);
+  }
+
+  async #establish(failed?: SubscriptionAttempt, initialError?: Error): Promise<void> {
+    let recoveryError = initialError;
+    if (recoveryError) this.#deps.recoveryStarted(recoveryError);
+    if (failed) await failed.handle.close().catch(() => undefined);
+
+    while (true) {
+      this.#assertOpen();
+      let prepared: PreparedSessionSubscription;
+      let attempt: SubscriptionAttempt;
+      try {
+        ({ attempt, prepared } = await this.#prepare());
+      } catch (error) {
+        const failure = asError(error);
+        if (isRecoverableSubscriptionFailure(failure)) {
+          if (!recoveryError) {
+            recoveryError = failure;
+            this.#deps.recoveryStarted(failure);
+          }
+          continue;
+        }
+        if (recoveryError) this.#deps.recoveryFailed(recoveryError, failure);
+        throw failure;
+      }
+
+      try {
+        if (attempt.failure) throw attempt.failure;
+        this.#deps.commit(prepared, recoveryError !== undefined);
+        if (attempt.failure) throw attempt.failure;
+        attempt.phase = "active";
+        for (const frame of attempt.pendingFrames.splice(0)) {
+          this.#deps.acceptFrame(frame);
+        }
+      } catch (error) {
+        if (this.#attempt === attempt) this.#attempt = undefined;
+        await attempt.handle.close().catch(() => undefined);
+        const failure = asError(error);
+        if (isRecoverableSubscriptionFailure(failure)) {
+          if (!recoveryError) {
+            recoveryError = failure;
+            this.#deps.recoveryStarted(failure);
+          }
+          continue;
+        }
+        if (recoveryError) this.#deps.recoveryFailed(recoveryError, failure);
+        throw failure;
+      }
+
+      if (recoveryError) this.#deps.recoveryCompleted(recoveryError);
+      return;
+    }
+  }
+
+  async #prepare(): Promise<{
+    attempt: SubscriptionAttempt;
+    prepared: PreparedSessionSubscription;
+  }> {
+    const handle = await this.#deps.client.openSession(this.#deps.sessionId);
+    if (this.#closed) {
+      await handle.close().catch(() => undefined);
+      throw ownerClosed();
+    }
+
+    let fail!: (error: Error) => void;
+    const failed = new Promise<Error>((resolve) => {
+      fail = resolve;
+    });
+    const attempt: SubscriptionAttempt = {
+      handle,
+      pendingFrames: [],
+      failed,
+      phase: "preparing",
+      fail(error) {
+        if (attempt.failure) return;
+        attempt.failure = error;
+        fail(error);
+      },
+    };
+    this.#attempt = attempt;
+    void this.#pump(attempt);
+
+    try {
+      const loaded = await Promise.race([
+        handle.transcript.then(
+          (transcript) => ({ kind: "transcript" as const, transcript }),
+          (error: unknown) => ({ kind: "failure" as const, error: asError(error) }),
+        ),
+        failed.then((error) => ({ kind: "failure" as const, error })),
+      ]);
+      if (loaded.kind === "failure") throw loaded.error;
+      if (attempt.failure) throw attempt.failure;
+      if (this.#closed || this.#attempt !== attempt) throw ownerClosed();
+      validatePendingFrames(
+        handle.snapshot,
+        loaded.transcript,
+        attempt.pendingFrames,
+        this.#deps.now,
+      );
+      return {
+        attempt,
+        prepared: {
+          snapshot: structuredClone(handle.snapshot),
+          transcript: loaded.transcript,
+        },
+      };
+    } catch (error) {
+      if (this.#attempt === attempt) this.#attempt = undefined;
+      await handle.close().catch(() => undefined);
+      throw error;
+    }
+  }
+
+  async #pump(attempt: SubscriptionAttempt): Promise<void> {
+    try {
+      for await (const frame of attempt.handle.events) {
+        if (this.#closed || this.#attempt !== attempt) return;
+        if (frame.kind === "subscription.closed") {
+          throw subscriptionClosedError(frame.reason);
+        }
+        if (attempt.phase === "preparing") {
+          if (attempt.pendingFrames.length >= MAX_PENDING_FRAMES) {
+            throw new RuntimeHostSubscriptionError(
+              "slow_consumer",
+              "Runtime Host Session transcript could not keep up with live events",
+            );
+          }
+          attempt.pendingFrames.push(frame);
+        } else {
+          this.#deps.acceptFrame(frame);
+        }
+      }
+      if (!this.#closed) {
+        throw new Error("Runtime Host Session subscription ended unexpectedly");
+      }
+    } catch (error) {
+      if (this.#closed || this.#attempt !== attempt) return;
+      const failure = asError(error);
+      if (attempt.phase === "preparing") {
+        attempt.fail(failure);
+      } else if (isRecoverableSubscriptionFailure(failure)) {
+        this.#replaceReadyTask(this.#establish(attempt, failure));
+      } else {
+        this.#deps.terminalFailure(failure);
+      }
+    }
+  }
+
+  #replaceReadyTask(task: Promise<void>): void {
+    this.#readyTask = task;
+    void task.catch((error: unknown) => {
+      if (this.#closed || this.#readyTask !== task) return;
+      this.#deps.terminalFailure(asError(error));
+    });
+  }
+
+  #assertOpen(): void {
+    if (this.#closed) throw ownerClosed();
+  }
+}
+
+function validatePendingFrames(
+  snapshot: SessionContinuitySnapshot,
+  transcript: readonly StoredMessage[],
+  frames: readonly SubscriptionFrame[],
+  now: () => number,
+): void {
+  const projector = new RuntimeHostSessionProjector(snapshot, transcript, now);
+  for (const frame of frames) projector.accept(frame);
+}
+
+function subscriptionClosedError(
+  reason: "slow_consumer" | "session_removed",
+): Error {
+  return reason === "session_removed"
+    ? new SessionRemovedSubscriptionError(
+        "Runtime Host Session was removed while it was observed",
+      )
+    : new RuntimeHostSubscriptionError(
+        "slow_consumer",
+        "Runtime Host Session subscription closed for a slow consumer",
+      );
+}
+
+function isRecoverableSubscriptionFailure(error: unknown): boolean {
+  if (!(error instanceof RuntimeHostSubscriptionError)) return false;
+  return (
+    error.reason === "slow_consumer" ||
+    error.reason === "sequence_gap" ||
+    error.reason === "projection_revision_invalid" ||
+    error.reason === "transcript_expired"
+  );
+}
+
+function ownerClosed(): Error {
+  return new Error("Runtime Host Session observer closed while opening");
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -95,7 +95,6 @@ import type {
   McpTestResult,
 } from '@maka/core/mcp';
 import type {
-  AgentGraphClientChangedEvent,
   AgentGraphClientSnapshot,
   AgentGraphClientSnapshotOptions,
   AgentGraphOperatorInspection,
@@ -284,7 +283,7 @@ export interface MakaBridge {
     stop(rootSessionId: string): Promise<void>;
     subscribe(
       rootSessionId: string,
-      handler: (event: AgentGraphClientChangedEvent) => void,
+      handler: () => void,
     ): () => void;
   };
   sessions: {
@@ -326,6 +325,12 @@ export interface MakaBridge {
     readMessages(sessionId: string): Promise<StoredMessage[]>;
     readExecutionBoundary(sessionId: string): Promise<ExecutionBoundaryReadModel>;
     listActiveInteractions(sessionId: string): Promise<ActiveInteractionRequestEvent[]>;
+    subscribeActiveInteractions(
+      handler: (event: {
+        sessionId: string;
+        interactions: ActiveInteractionRequestEvent[];
+      }) => void,
+    ): () => void;
     listTurns(sessionId: string): Promise<TurnRecord[]>;
     compact(sessionId: string): Promise<void>;
     resumeLatest(sessionId: string): Promise<
@@ -427,6 +432,7 @@ export interface MakaBridge {
     }): Promise<ShellRunUpdate | null>;
     subscribeUpdates(handler: (update: ShellRunUpdate) => void): () => void;
     subscribePtyData(handler: (event: ShellRunPtyDataEvent) => void): () => void;
+    subscribeResync(handler: (event: { sessionId: string }) => void): () => void;
   };
   gitReview: {
     read(input: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -100,7 +100,6 @@ import type {
 } from '@maka/core';
 import type { SessionTrace } from '@maka/core/session-trace';
 import type {
-  AgentGraphClientChangedEvent,
   AgentGraphClientSnapshot,
   AgentGraphClientSnapshotOptions,
   AgentGraphOperatorInspection,
@@ -198,16 +197,26 @@ const makaBridge = {
     },
     subscribe(
       rootSessionId: string,
-      handler: (event: AgentGraphClientChangedEvent) => void,
+      handler: () => void,
     ): () => void {
-      const listener = (
+      const changedListener = (
         _event: Electron.IpcRendererEvent,
-        payload: AgentGraphClientChangedEvent,
+        payload: { rootSessionId: string },
       ) => {
-        if (payload.rootSessionId === rootSessionId) handler(payload);
+        if (payload.rootSessionId === rootSessionId) handler();
       };
-      ipcRenderer.on('graphs:changed', listener);
-      return () => ipcRenderer.off('graphs:changed', listener);
+      const resyncListener = (
+        _event: Electron.IpcRendererEvent,
+        payload: { rootSessionId: string },
+      ) => {
+        if (payload.rootSessionId === rootSessionId) handler();
+      };
+      ipcRenderer.on('graphs:changed', changedListener);
+      ipcRenderer.on('graphs:resync', resyncListener);
+      return () => {
+        ipcRenderer.off('graphs:changed', changedListener);
+        ipcRenderer.off('graphs:resync', resyncListener);
+      };
     },
   },
   sessions: {
@@ -281,6 +290,19 @@ const makaBridge = {
     },
     listActiveInteractions(sessionId: string): Promise<ActiveInteractionRequestEvent[]> {
       return ipcRenderer.invoke('sessions:listActiveInteractions', sessionId);
+    },
+    subscribeActiveInteractions(
+      handler: (event: {
+        sessionId: string;
+        interactions: ActiveInteractionRequestEvent[];
+      }) => void,
+    ): () => void {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        payload: { sessionId: string; interactions: ActiveInteractionRequestEvent[] },
+      ) => handler(payload);
+      ipcRenderer.on('sessions:active-interactions-changed', listener);
+      return () => ipcRenderer.off('sessions:active-interactions-changed', listener);
     },
     listTurns(sessionId: string): Promise<TurnRecord[]> {
       return ipcRenderer.invoke('sessions:listTurns', sessionId);
@@ -506,6 +528,12 @@ const makaBridge = {
         handler(payload);
       ipcRenderer.on('shell-runs:pty-data', listener);
       return () => ipcRenderer.off('shell-runs:pty-data', listener);
+    },
+    subscribeResync(handler: (event: { sessionId: string }) => void): () => void {
+      const listener = (_event: Electron.IpcRendererEvent, payload: { sessionId: string }) =>
+        handler(payload);
+      ipcRenderer.on('shell-runs:resync', listener);
+      return () => ipcRenderer.off('shell-runs:resync', listener);
     },
   },
   gitReview: {

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -13,7 +13,6 @@ import type {
   UiLocale,
 } from '@maka/core';
 import {
-  ShellRunUpdateBuffer,
   generalizedErrorMessageChinese,
   sessionExpectsEventStream,
   type ShellRunUpdate,
@@ -40,6 +39,7 @@ import type { WindowCommand } from '../preload/bridge-contract.js';
 import {
   mergeShellRunNotification,
   mergeShellRunUpdates,
+  ShellRunHydration,
   type ShellRunUpdatesBySession,
 } from './shell-run-update-state.js';
 
@@ -523,49 +523,57 @@ export function useShellRunUpdates(options: {
     if (!sessionId) return;
 
     let disposed = false;
-    let hydrated = false;
     let retryTimer: ReturnType<typeof globalThis.setTimeout> | undefined;
     let retryDelayMs = 250;
-    const pending = new ShellRunUpdateBuffer('desktop.shell-run-hydration-buffer');
+    const hydration = new ShellRunHydration();
     const unsubscribe = window.maka.shellRuns.subscribeUpdates((update) => {
       if (disposed) return;
-      if (!hydrated) {
-        pending.add(update);
-        return;
+      const live = hydration.accept(update);
+      if (live) {
+        options.setShellRunUpdatesBySession((current) =>
+          mergeShellRunNotification(current, sessionId, live),
+        );
       }
-      options.setShellRunUpdatesBySession((current) => mergeShellRunNotification(current, sessionId, update));
     });
-    const hydrate = () => {
+    const hydrate = (epoch: number) => {
       void window.maka.shellRuns
         .list(sessionId)
         .then((updates) => {
-        if (disposed) return;
-        applyUpdates(sessionId, updates);
-        retryDelayMs = 250;
-        const buffered = pending.drain();
-        for (const update of buffered.updates) {
+          if (disposed) return;
+          const buffered = hydration.commit(epoch);
+          if (!buffered) return;
+          applyUpdates(sessionId, updates);
+          retryDelayMs = 250;
+          for (const update of buffered.updates) {
             options.setShellRunUpdatesBySession((current) => mergeShellRunNotification(current, sessionId, update));
-        }
-        if (buffered.overflowed) {
-          hydrate();
-          return;
-        }
-        hydrated = true;
+          }
+          if (buffered.overflowed) hydrate(epoch);
         })
         .catch(() => {
-        if (disposed) return;
-        retryTimer = globalThis.setTimeout(() => {
-          retryTimer = undefined;
-          hydrate();
-        }, retryDelayMs);
-        retryDelayMs = Math.min(retryDelayMs * 2, 5_000);
-      });
+          if (disposed || !hydration.isCurrent(epoch)) return;
+          retryTimer = globalThis.setTimeout(() => {
+            retryTimer = undefined;
+            hydrate(epoch);
+          }, retryDelayMs);
+          retryDelayMs = Math.min(retryDelayMs * 2, 5_000);
+        });
     };
-    hydrate();
+    const unsubscribeResync = window.maka.shellRuns.subscribeResync((event) => {
+      if (disposed || event.sessionId !== sessionId) return;
+      const epoch = hydration.begin();
+      retryDelayMs = 250;
+      if (retryTimer !== undefined) {
+        globalThis.clearTimeout(retryTimer);
+        retryTimer = undefined;
+      }
+      hydrate(epoch);
+    });
+    hydrate(hydration.begin());
     return () => {
       disposed = true;
       if (retryTimer !== undefined) globalThis.clearTimeout(retryTimer);
       unsubscribe();
+      unsubscribeResync();
     };
   }, [options.activeId]);
 }

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -23,7 +23,7 @@ type RefBox<T> = { current: T };
 type StateUpdater<T> = (updater: (current: T) => T) => void;
 
 type ToastApi = {
-  error(title: string, description?: string): void;
+  error(title: string, description?: string, diagnosticDetails?: string): void;
 };
 
 export interface AppShellSessionEventHandlers {
@@ -160,7 +160,11 @@ export function createAppShellSessionEventHandlers(options: {
             showModelSetupToast(noRealConnectionSetupDescription(reason, uiLocale), reason);
           } else {
             const copy = getDesktopConversationCopy(uiLocale).actions;
-            toastApi.error(copy.conversationErrorTitle, sessionEventErrorMessage(event, uiLocale));
+            toastApi.error(
+              copy.conversationErrorTitle,
+              sessionEventErrorMessage(event, uiLocale),
+              sessionEventDiagnosticDetails(sessionId, event),
+            );
           }
         }
         notifyRunEnded?.({ kind: 'errored', sessionId, body: sessionEventErrorMessage(event, uiLocale) });
@@ -190,4 +194,22 @@ export function createAppShellSessionEventHandlers(options: {
   }
 
   return { handleEvent, reconcilePersistedMessages, settleAssistantStreaming };
+}
+
+function sessionEventDiagnosticDetails(
+  sessionId: string,
+  event: Extract<SessionEvent, { type: 'error' }>,
+): string {
+  return [
+    `Session: ${sessionId}`,
+    `Turn: ${event.turnId}`,
+    `Event: ${event.id}`,
+    `Reason: ${event.reason ?? '<none>'}`,
+    `Code: ${event.code ?? '<none>'}`,
+    `Recoverable: ${event.recoverable}`,
+    `Message: ${event.message}`,
+    ...(event.details === undefined
+      ? []
+      : [`Details: ${JSON.stringify(event.details)}`]),
+  ].join('\n');
 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -248,6 +248,7 @@ export function AppShell({ initialOnboardingSnapshot = null }: AppShellProps = {
             surface: 'toast',
             title: input.title,
             ...(input.description ? { description: input.description } : {}),
+            ...(input.diagnosticDetails ? { details: input.diagnosticDetails } : {}),
             rendererUserAgent: navigator.userAgent,
             rendererLocale: navigator.language,
           })

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1190,6 +1190,16 @@ function AppShellContent({
       cancelled = true;
     };
   }, [activeId, setInteractionBySession]);
+  useEffect(
+    () =>
+      window.maka.sessions.subscribeActiveInteractions(({ sessionId, interactions }) => {
+        markInteractionChanged(sessionId);
+        setInteractionBySession((current) =>
+          reconcileInteractions(current, sessionId, interactions),
+        );
+      }),
+    [markInteractionChanged, setInteractionBySession],
+  );
   const activeBoundarySurface = deriveDesktopExecutionBoundarySurface(
     activeId,
     activeExecutionBoundary,

--- a/apps/desktop/src/renderer/session-terminal-hydration.ts
+++ b/apps/desktop/src/renderer/session-terminal-hydration.ts
@@ -1,0 +1,54 @@
+export interface TerminalDataChunk {
+  readonly sequence: number;
+  readonly data: string;
+}
+
+export interface TerminalSnapshot {
+  readonly sequence: number;
+  readonly buffer: string;
+}
+
+export class SessionTerminalHydration {
+  readonly #pending: TerminalDataChunk[] = [];
+  #epoch = 0;
+  #attached = false;
+  #lastSequence = 0;
+
+  begin(): number {
+    this.#epoch += 1;
+    this.#attached = false;
+    this.#pending.length = 0;
+    return this.#epoch;
+  }
+
+  isCurrent(epoch: number): boolean {
+    return epoch === this.#epoch;
+  }
+
+  accept(event: TerminalDataChunk): TerminalDataChunk | undefined {
+    if (event.sequence <= this.#lastSequence) return undefined;
+    if (!this.#attached) {
+      this.#pending.push(event);
+      return undefined;
+    }
+    this.#lastSequence = event.sequence;
+    return event;
+  }
+
+  commit(
+    epoch: number,
+    snapshot: TerminalSnapshot,
+  ): { snapshot: TerminalSnapshot; replay: TerminalDataChunk[] } | undefined {
+    if (!this.isCurrent(epoch)) return undefined;
+    this.#lastSequence = snapshot.sequence;
+    this.#attached = true;
+    const replay: TerminalDataChunk[] = [];
+    for (const event of this.#pending.sort((left, right) => left.sequence - right.sequence)) {
+      if (event.sequence <= this.#lastSequence) continue;
+      this.#lastSequence = event.sequence;
+      replay.push(event);
+    }
+    this.#pending.length = 0;
+    return { snapshot, replay };
+  }
+}

--- a/apps/desktop/src/renderer/session-terminal-panel.tsx
+++ b/apps/desktop/src/renderer/session-terminal-panel.tsx
@@ -11,6 +11,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import '@xterm/xterm/css/xterm.css';
 import { getDesktopConversationCopy } from './locales/conversation-copy';
+import { SessionTerminalHydration } from './session-terminal-hydration';
 
 function terminalTheme(element: HTMLElement) {
   const styles = getComputedStyle(element);
@@ -58,9 +59,7 @@ export function SessionTerminalPanel(props: {
 
     lastSizeRef.current = '';
     let disposed = false;
-    let attached = false;
-    let lastSequence = 0;
-    const pending: Array<{ sequence: number; data: string }> = [];
+    const hydration = new SessionTerminalHydration();
     const terminal = new Terminal({
       allowTransparency: true,
       cursorBlink: true,
@@ -80,13 +79,8 @@ export function SessionTerminalPanel(props: {
     fitRef.current = fit;
 
     const writeEvent = (event: { sequence: number; data: string }) => {
-      if (event.sequence <= lastSequence) return;
-      if (!attached) {
-        pending.push(event);
-        return;
-      }
-      lastSequence = event.sequence;
-      terminal.write(event.data);
+      const live = hydration.accept(event);
+      if (live) terminal.write(live.data);
     };
     const unsubscribe = window.maka.shellRuns.subscribePtyData((event) => {
       if (
@@ -97,6 +91,39 @@ export function SessionTerminalPanel(props: {
         return;
       }
       writeEvent(event);
+    });
+    const hydrate = (epoch: number) => {
+      void window.maka.shellRuns
+        .attach({ sessionId: props.sessionId, ref: props.terminalRef! })
+        .then((snapshot) => {
+          if (disposed || !hydration.isCurrent(epoch)) return;
+          if (!snapshot) {
+            setError(copy.loadFailed);
+            return;
+          }
+          const committed = hydration.commit(epoch, snapshot);
+          if (!committed) return;
+          terminal.reset();
+          if (committed.snapshot.buffer) terminal.write(committed.snapshot.buffer);
+          for (const event of committed.replay) terminal.write(event.data);
+          setError(null);
+          requestAnimationFrame(() => {
+            resize();
+            if (activeRef.current) terminal.focus();
+          });
+        })
+        .catch((nextError) => {
+          if (disposed || !hydration.isCurrent(epoch)) return;
+          setError(
+            locale === 'zh'
+              ? generalizedErrorMessageChinese(nextError, copy.loadFailed)
+              : generalizedErrorMessage(nextError, copy.loadFailed),
+          );
+        });
+    };
+    const unsubscribeResync = window.maka.shellRuns.subscribeResync((event) => {
+      if (disposed || event.sessionId !== props.sessionId) return;
+      hydrate(hydration.begin());
     });
     const inputSubscription = terminal.onData((input) => {
       if (!input || disposed) return;
@@ -135,41 +162,13 @@ export function SessionTerminalPanel(props: {
     observer.observe(host);
 
     setError(null);
-    void window.maka.shellRuns
-      .attach({ sessionId: props.sessionId, ref: props.terminalRef })
-      .then((snapshot) => {
-        if (disposed) return;
-        if (!snapshot) {
-          setError(copy.loadFailed);
-          return;
-        }
-        terminal.reset();
-        if (snapshot.buffer) terminal.write(snapshot.buffer);
-        lastSequence = snapshot.sequence;
-        attached = true;
-        pending
-          .filter((event) => event.sequence > lastSequence)
-          .sort((left, right) => left.sequence - right.sequence)
-          .forEach(writeEvent);
-        pending.length = 0;
-        requestAnimationFrame(() => {
-          resize();
-          if (activeRef.current) terminal.focus();
-        });
-      })
-      .catch((nextError) => {
-        if (disposed) return;
-        setError(
-          locale === 'zh'
-            ? generalizedErrorMessageChinese(nextError, copy.loadFailed)
-            : generalizedErrorMessage(nextError, copy.loadFailed),
-        );
-      });
+    hydrate(hydration.begin());
 
     return () => {
       disposed = true;
       observer.disconnect();
       unsubscribe();
+      unsubscribeResync();
       inputSubscription.dispose();
       void window.maka.shellRuns
         .detach({ sessionId: props.sessionId, ref: props.terminalRef! })

--- a/apps/desktop/src/renderer/shell-run-update-state.ts
+++ b/apps/desktop/src/renderer/shell-run-update-state.ts
@@ -1,6 +1,7 @@
 import {
   mergeShellRunUpdate,
   projectShellRunUpdateForSession,
+  ShellRunUpdateBuffer,
   type ShellRunUpdate,
 } from '@maka/core';
 
@@ -42,4 +43,34 @@ export function mergeShellRunNotification(
       update,
     ),
   );
+}
+
+export class ShellRunHydration {
+  readonly #pending = new ShellRunUpdateBuffer('desktop.shell-run-hydration-buffer');
+  #epoch = 0;
+  #hydrated = false;
+
+  begin(): number {
+    this.#epoch += 1;
+    this.#hydrated = false;
+    this.#pending.clear();
+    return this.#epoch;
+  }
+
+  isCurrent(epoch: number): boolean {
+    return epoch === this.#epoch;
+  }
+
+  accept(update: ShellRunUpdate): ShellRunUpdate | undefined {
+    if (this.#hydrated) return update;
+    this.#pending.add(update);
+    return undefined;
+  }
+
+  commit(epoch: number): { updates: ShellRunUpdate[]; overflowed: boolean } | undefined {
+    if (!this.isCurrent(epoch)) return undefined;
+    const pending = this.#pending.drain();
+    this.#hydrated = !pending.overflowed;
+    return pending;
+  }
 }

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -44,12 +44,13 @@ export interface ToastAction {
 
 export interface ToastErrorAction {
   label: string;
-  onClick(input: Pick<ToastInput, 'title' | 'description'>): void;
+  onClick(input: Pick<ToastInput, 'title' | 'description' | 'diagnosticDetails'>): void;
 }
 
 export interface ToastInput {
   title: string;
   description?: string;
+  diagnosticDetails?: string;
   variant?: ToastVariant;
   /** Auto-dismiss after this many ms. 0 disables the timer. Default 4000. */
   duration?: number;
@@ -67,7 +68,7 @@ export interface ConfirmInput {
 export interface ToastApi {
   toast(input: ToastInput): string;
   success(title: string, description?: string): string;
-  error(title: string, description?: string): string;
+  error(title: string, description?: string, diagnosticDetails?: string): string;
   info(title: string, description?: string): string;
   warning(title: string, description?: string): string;
   confirm(input: ConfirmInput): Promise<boolean>;
@@ -229,7 +230,8 @@ function ToastController(props: { children: ReactNode; errorAction?: ToastErrorA
     () => ({
       toast: push,
       success: (title, description) => push({ title, description, variant: 'success' }),
-      error: (title, description) => push({ title, description, variant: 'error', duration: 6000 }),
+      error: (title, description, diagnosticDetails) =>
+        push({ title, description, diagnosticDetails, variant: 'error', duration: 6000 }),
       info: (title, description) => push({ title, description, variant: 'info' }),
       warning: (title, description) => push({ title, description, variant: 'warning' }),
       confirm,

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -47,6 +47,10 @@ const ALLOW = new Map([
     'Runtime Host reconnect exhaustion is fatal before the Desktop can present an in-app error; no credentials or provider payloads.',
   ],
   [
+    'apps/desktop/src/main/runtime-host-session-observer.ts',
+    'bounded Session subscription recovery diagnostics contain only Session/Turn/Run identities and internal failure metadata.',
+  ],
+  [
     'apps/desktop/src/main/startup-step.ts',
     'names a startup step that has not come back, before any window exists to show it in; a step name and no secrets.',
   ],


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Recover Desktop session streams when a bounded Runtime Host subscription is evicted while a turn is active.

Dense Agent Graph activity can overflow a client subscription queue within one scheduling window. Runtime Host correctly closes that subscription as a slow consumer, but Desktop previously stopped observing the session while the renderer still expected live updates. The stream then appeared frozen until the user changed sessions and returned.

Desktop now gives each observed Session one replaceable subscription owner. The owner validates and commits a replacement subscription atomically, restores the canonical transcript prefix, and continues offset-bearing deltas without a renderer resubscribe. The observer remains responsible only for Desktop projection and renderer targets.

After in-place recovery or Runtime Host candidate replacement, Desktop reconciles terminal and successor turns, Goal state, exact pending interactions, and Task, Deep Research, Plan, Graph, Shell Run, and PTY projections. A mounted terminal reacquires its controller snapshot and continues receiving live PTY data.

Copied Desktop diagnostic reports now include Session, Turn, event, stable reason/code, recoverability, and redacted internal details. Main-process logs also record subscription recovery attempts and outcomes.

## Verification

- `npm test --workspace @maka/desktop` — 1,157 tests passed
- `npm run typecheck --workspace @maka/desktop`
- `npm run build --workspace @maka/desktop`
- Biome and `git diff --check`
- Recovery regressions cover Goal invalidation, interaction clearing, Graph/Shell resync, PTY controller reacquisition, snapshot hydration, and subsequent live PTY data
- macOS Desktop smoke test with persisted Runtime Host state: the existing Graph transcript rendered and new thinking/tool updates continued streaming
- Windows Desktop was not available locally; the original report and follow-up verification target Windows

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — Desktop automatically recovers bounded Session subscriptions and reconciles dependent live state
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

当有界 Runtime Host 会话订阅在活跃 turn 期间被淘汰时，自动恢复 Desktop 会话流。

密集的 Agent Graph 活动可能在一个调度窗口内产生超过客户端订阅队列容量的帧。Runtime Host 会按设计以 slow consumer 原因关闭该订阅，但此前 Desktop 会停止观察该会话，而 renderer 仍在等待实时更新。结果是界面流式输出看似冻结，只有切换到其他会话再返回后才恢复。

Desktop 现在为每个被观察的 Session 设置一个可替换的订阅 owner。该 owner 原子地验证并提交替代订阅，恢复权威 transcript 前缀，并在无需 renderer 重新订阅的情况下继续接收带 offset 的 delta。observer 只负责 Desktop 投影与 renderer target。

无论是原订阅就地恢复，还是 Runtime Host candidate 替换，Desktop 都会协调已结束 turn、successor turn、Goal 状态、精确的待处理交互，以及 Task、Deep Research、Plan、Graph、Shell Run 和 PTY 投影。已挂载的终端会重新获取 controller snapshot，并继续接收实时 PTY 数据。

复制出的 Desktop 诊断报告现在还会包含 Session、Turn、事件标识、稳定的 reason/code、是否可恢复以及经过脱敏的内部详情。主进程日志也会记录订阅恢复的开始和结果。

## 验证

- `npm test --workspace @maka/desktop` — 1,157 项测试通过
- `npm run typecheck --workspace @maka/desktop`
- `npm run build --workspace @maka/desktop`
- Biome 与 `git diff --check`
- 恢复回归覆盖 Goal invalidation、交互清空、Graph/Shell resync、PTY controller 重新获取、snapshot 恢复及后续实时 PTY 数据
- macOS Desktop 持久化 Runtime Host 状态冒烟测试：既有 Graph transcript 正常渲染，新的 thinking/tool 更新可持续流式显示
- 本地没有 Windows Desktop 环境；原始报告与后续验证目标来自 Windows

## 检查清单

- [x] 测试覆盖本次行为，且在没有修复时会失败
- [x] lint、format、typecheck 与受影响测试均在本地通过

此 PR 是否包含行为变化？

- [x] 是 — Desktop 会自动恢复有界会话订阅，并协调依赖的实时状态
- [ ] 否

</details>
