### PR TITLE
fix(desktop): align workbar picker with Astryx

### DIFF
--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -8,9 +8,11 @@ async function openGitChanges(page: Page) {
   await composer.fill('create review session');
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: create review session/)).toBeVisible();
+  const workspaceActions = page.getByRole('toolbar', { name: '工作区辅助操作' });
+  await expect(workspaceActions.getByRole('button')).toHaveCount(1);
   await page.getByRole('button', { name: '展开会话工作栏' }).click();
-  await page.getByRole('button', { name: '打开工作栏标签' }).first().click();
-  await page.getByRole('menuitem', { name: '变更' }).click();
+  await expect(page.getByRole('list', { name: '打开工具' })).toBeVisible();
+  await page.getByRole('button', { name: /变更.*查看当前 Git 工作区变化/ }).click();
   return page.getByRole('region', { name: 'Git 变更' });
 }
 

--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -8,13 +8,30 @@ async function openGitChanges(page: Page) {
   await composer.fill('create review session');
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: create review session/)).toBeVisible();
-  const workspaceActions = page.getByRole('toolbar', { name: '工作区辅助操作' });
-  await expect(workspaceActions.getByRole('button')).toHaveCount(1);
   await page.getByRole('button', { name: '展开会话工作栏' }).click();
   await expect(page.getByRole('list', { name: '打开工具' })).toBeVisible();
   await page.getByRole('button', { name: /变更.*查看当前 Git 工作区变化/ }).click();
   return page.getByRole('region', { name: 'Git 变更' });
 }
+
+test('titlebar workbar action restores an existing tool instead of the picker', async ({
+  gitReviewWindow,
+}) => {
+  const page = gitReviewWindow.page;
+  const workspaceActions = page.getByRole('toolbar', { name: '工作区辅助操作' });
+  const panel = await openGitChanges(page);
+  await expect(workspaceActions.getByRole('button', { name: '收起会话工作栏' })).toBeVisible();
+  await expect(workspaceActions.getByRole('button', { name: '打开工作栏工具' })).toHaveCount(0);
+  await page.getByRole('button', { name: '打开工作栏标签' }).click();
+  const picker = page.getByRole('list', { name: '打开工具' });
+  await expect(picker).toBeVisible();
+
+  await workspaceActions.getByRole('button', { name: '收起会话工作栏' }).click();
+  await workspaceActions.getByRole('button', { name: '展开会话工作栏' }).click();
+
+  await expect(panel).toBeVisible();
+  await expect(picker).not.toBeVisible();
+});
 
 test('Git changes show branch files as a collapsed single-open list', async ({
   gitReviewWindow,

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -1,7 +1,6 @@
 import {
   PanelLeftClose,
   PanelLeftOpen,
-  ListFilter,
   PanelRightClose,
   PanelRightOpen,
   Search,
@@ -121,7 +120,6 @@ export function AppShellTopbarActions(props: {
 export function AppShellWorkspaceTopActions(props: {
   workbarAvailable: boolean;
   workbarCollapsed: boolean;
-  onOpenWorkbarLauncher(): void;
   onToggleWorkbar(): void;
 }) {
   const locale = useUiLocale();
@@ -132,16 +130,6 @@ export function AppShellWorkspaceTopActions(props: {
 
   return (
     <div className="maka-workspace-top-actions" role="toolbar" aria-label={copy.workspaceActions}>
-      <Tooltip content={copy.openWorkbarLauncher}>
-        <IconButton
-          label={copy.openWorkbarLauncher}
-          icon={<ChromeIcon icon={ListFilter} />}
-          variant="ghost"
-          size="md"
-          className="maka-titlebar-action"
-          onClick={props.onOpenWorkbarLauncher}
-        />
-      </Tooltip>
       <ChromeColumnToggle
         collapsed={props.workbarCollapsed}
         expandLabel={copy.expandWorkbar}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1596,17 +1596,17 @@ function AppShellContent({
   const toggleWorkbar = useCallback(() => {
     if (workbarCollapsed) {
       setWorkbarCollapsed(false);
-      if (workbarPanelsState.right.tabs.length === 0) {
-        openWorkbarLauncher('right');
+      if (workbarPanelsState.right.activeTabId) {
+        activateWorkbarTab('right', workbarPanelsState.right.activeTabId);
       }
       return;
     }
     setWorkbarCollapsed(true);
   }, [
-    openWorkbarLauncher,
+    activateWorkbarTab,
     setWorkbarCollapsed,
     workbarCollapsed,
-    workbarPanelsState.right.tabs.length,
+    workbarPanelsState.right.activeTabId,
   ]);
 
   // Side chats survive a panel collapse. They are cleaned up only when their

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1328,11 +1328,6 @@ function AppShellContent({
     pinWorkbarTab,
     openWorkbarLauncher,
   } = useShellLayout();
-  const revealWorkbarLauncher = useCallback(() => {
-    setWorkbarCollapsed(false);
-    openWorkbarLauncher('right');
-  }, [openWorkbarLauncher, setWorkbarCollapsed]);
-
   const openNewSideConversation = useCallback(
     (placement: SessionWorkbarPlacement, initialPrompt?: string) => {
       const sourceSessionId = activeIdRef.current;
@@ -2566,7 +2561,6 @@ function AppShellContent({
               <AppShellWorkspaceTopActions
                 workbarAvailable={navSelection.section === 'sessions' && Boolean(activeId)}
                 workbarCollapsed={workbarCollapsed}
-                onOpenWorkbarLauncher={revealWorkbarLauncher}
                 onToggleWorkbar={toggleWorkbar}
               />
             )}

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -73,6 +73,7 @@ export interface DesktopConversationCopy {
     sideChat: string;
     sideChatNumbered(index: number): string;
     openTab: string;
+    openTools: string;
     closeTab(label: string): string;
     tabMenu(label: string): string;
     moveLeft: string;
@@ -370,6 +371,7 @@ const COPY = {
       sideChat: '侧边对话',
       sideChatNumbered: (index) => `侧边对话 ${index}`,
       openTab: '打开工作栏标签',
+      openTools: '打开工具',
       closeTab: (label) => `关闭${label}`,
       tabMenu: (label) => `${label}标签菜单`,
       moveLeft: '向左移动',
@@ -552,6 +554,7 @@ const COPY = {
       sideChat: 'Side chat',
       sideChatNumbered: (index) => `Side chat ${index}`,
       openTab: 'Open workbar tab',
+      openTools: 'Open tools',
       closeTab: (label) => `Close ${label}`,
       tabMenu: (label) => `${label} tab menu`,
       moveLeft: 'Move left',

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -361,7 +361,6 @@ type ShellCopy = {
     expandSidebar: string;
     collapseSidebar: string;
     newTask: string;
-    openWorkbarLauncher: string;
     expandWorkbar: string;
     collapseWorkbar: string;
     workspaceActions: string;
@@ -1041,7 +1040,6 @@ const SHELL_COPY_BY_LOCALE = {
       expandSidebar: '展开侧边栏',
       collapseSidebar: '收起侧边栏',
       newTask: '新任务',
-      openWorkbarLauncher: '打开工作栏工具',
       expandWorkbar: '展开会话工作栏',
       collapseWorkbar: '收起会话工作栏',
       workspaceActions: '工作区辅助操作',
@@ -1552,7 +1550,6 @@ const SHELL_COPY_BY_LOCALE = {
       expandSidebar: 'Expand sidebar',
       collapseSidebar: 'Collapse sidebar',
       newTask: 'New task',
-      openWorkbarLauncher: 'Open workbar tools',
       expandWorkbar: 'Expand conversation workbar',
       collapseWorkbar: 'Collapse conversation workbar',
       workspaceActions: 'Workspace actions',

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -2,7 +2,6 @@ import {
   lazy,
   Suspense,
   useEffect,
-  useLayoutEffect,
   useRef,
   useState,
   type CSSProperties,
@@ -48,8 +47,10 @@ import { Badge } from '@astryxdesign/core/Badge';
 import { Button } from '@astryxdesign/core/Button';
 import { Card } from '@astryxdesign/core/Card';
 import { ContextMenu } from '@astryxdesign/core/ContextMenu';
-import { Item } from '@astryxdesign/core/Item';
+import { Heading } from '@astryxdesign/core/Heading';
+import { Icon } from '@astryxdesign/core/Icon';
 import { Kbd } from '@astryxdesign/core/Kbd';
+import { List, ListItem } from '@astryxdesign/core/List';
 import { Section } from '@astryxdesign/core/Section';
 import { Spinner } from '@astryxdesign/core/Spinner';
 import { Toolbar } from '@astryxdesign/core/Toolbar';
@@ -542,20 +543,15 @@ function SortableWorkbarTab(props: {
 }
 
 function WorkbarLauncher(props: {
-  active: boolean;
-  returnTabId: string | null;
   onOpen: (kind: SessionWorkbarTabKind) => void;
-  onDismiss: () => void;
   sideChatAvailable: boolean;
 }) {
   const copy = getDesktopConversationCopy(useUiLocale()).workbar;
-  const isMac = navigator.platform.toLowerCase().includes('mac');
-  const menuRef = useRef<HTMLDivElement>(null);
   const actions: Array<{
     kind: SessionWorkbarTabKind;
     label: string;
     description: string;
-    icon: ReactNode;
+    icon: typeof Activity;
     shortcut?: string;
     disabled?: boolean;
   }> = [
@@ -563,142 +559,74 @@ function WorkbarLauncher(props: {
       kind: 'side-chat',
       label: copy.sideChat,
       description: copy.launcher.sideChat,
-      icon: <MessageCircleQuestion aria-hidden />,
-      // Astryx Kbd tokens (+ separated); mod = Cmd on Mac / Ctrl elsewhere.
-      shortcut: isMac ? 'mod+alt+s' : 'ctrl+alt+s',
+      icon: MessageCircleQuestion,
+      shortcut: 'mod+alt+s',
       disabled: !props.sideChatAvailable,
     },
     {
       kind: 'review',
       label: copy.review,
       description: copy.launcher.review,
-      icon: <GitBranch aria-hidden />,
+      icon: GitBranch,
       shortcut: 'ctrl+shift+g',
     },
     {
       kind: 'terminal',
       label: copy.terminal,
       description: copy.launcher.terminal,
-      icon: <Terminal aria-hidden />,
+      icon: Terminal,
       shortcut: 'ctrl+`',
     },
     {
       kind: 'browser',
       label: copy.browser,
       description: copy.launcher.browser,
-      icon: <Globe aria-hidden />,
+      icon: Globe,
       shortcut: 'mod+t',
     },
     {
       kind: 'files',
       label: copy.files,
       description: copy.launcher.files,
-      icon: <FolderOpen aria-hidden />,
+      icon: FolderOpen,
       shortcut: 'mod+p',
     },
     {
       kind: 'tasks',
       label: copy.tasks,
       description: copy.launcher.tasks,
-      icon: <ListTodo aria-hidden />,
+      icon: ListTodo,
     },
     {
       kind: 'inspector',
       label: copy.inspector,
       description: copy.launcher.inspector,
-      icon: <Activity aria-hidden />,
+      icon: Activity,
     },
   ];
-  const firstEnabledActionIndex = actions.findIndex(
-    (action) => !action.disabled,
-  );
-  useLayoutEffect(() => {
-    if (!props.active) return;
-    menuRef.current
-      ?.querySelector<HTMLElement>('[role="menuitem"]:not([aria-disabled="true"])')
-      ?.focus();
-  }, [props.active]);
-  const handleMenuKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    const menu = menuRef.current;
-    if (!menu) return;
-    const items = Array.from(
-      menu.querySelectorAll<HTMLElement>(
-        '[role="menuitem"]:not([aria-disabled="true"])',
-      ),
-    );
-    const currentIndex = items.findIndex(
-      (item) => item === document.activeElement,
-    );
-    let targetIndex = -1;
-    if (event.key === 'ArrowDown') {
-      targetIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length;
-    } else if (event.key === 'ArrowUp') {
-      targetIndex =
-        currentIndex < 0
-          ? items.length - 1
-          : (currentIndex - 1 + items.length) % items.length;
-    } else if (event.key === 'Home') {
-      targetIndex = 0;
-    } else if (event.key === 'End') {
-      targetIndex = items.length - 1;
-    } else if (event.key === 'Escape' && props.returnTabId) {
-      event.preventDefault();
-      props.onDismiss();
-      window.requestAnimationFrame(() => {
-        document
-          .querySelector<HTMLElement>(
-            `[data-workbar-tab-id="${CSS.escape(props.returnTabId ?? '')}"] [role="tab"]`,
-          )
-          ?.focus();
-      });
-      return;
-    } else if (event.key === 'Enter' || event.key === ' ') {
-      // Item + role="menuitem" puts onClick on the row div (parent-role mode)
-      // and does not render a keyboard-activatable button — the menu parent
-      // must activate the focused item.
-      event.preventDefault();
-      const focused = items[currentIndex >= 0 ? currentIndex : 0];
-      focused?.click();
-      return;
-    }
-    const target = items[targetIndex];
-    if (!target) return;
-    event.preventDefault();
-    target.focus();
-  };
   return (
     <div className="maka-workbar-launcher">
-      <div
-        ref={menuRef}
+      <List
         className="maka-workbar-launcher-list"
-        role="menu"
-        aria-label={copy.openTab}
-        onKeyDown={handleMenuKeyDown}
+        density="compact"
+        header={<Heading level={4}>{copy.openTools}</Heading>}
       >
-        {actions.map((action, index) => (
-          <Item
+        {actions.map((action) => (
+          <ListItem
             key={action.kind}
-            role="menuitem"
-            className="maka-workbar-launcher-row"
-            data-secondary={
-              action.kind === 'tasks' || action.kind === 'inspector' || undefined
-            }
-            tabIndex={index === firstEnabledActionIndex ? 0 : -1}
-            startContent={<span className="maka-workbar-launcher-icon">{action.icon}</span>}
+            startContent={<Icon icon={action.icon} size="sm" color="secondary" />}
             label={action.label}
-            aria-description={action.description}
+            description={action.description}
             endContent={
               action.shortcut ? (
-                <span className="maka-workbar-launcher-shortcut">
-                  <Kbd keys={action.shortcut} />
-                </span>
+                <Kbd keys={action.shortcut} />
               ) : undefined
             }
             isDisabled={action.disabled}
             onClick={() => props.onOpen(action.kind)}
           />
         ))}
-      </div>
+      </List>
     </div>
   );
 }
@@ -809,14 +737,7 @@ export function SessionWorkbar(props: {
             />
             <WorkbarPanel active={visible && showingLauncher} placement={placement}>
               <WorkbarLauncher
-                active={visible && showingLauncher}
-                returnTabId={activeTab?.id ?? null}
                 onOpen={(kind) => props.onRequestOpenTab(placement, kind)}
-                onDismiss={() => {
-                  if (activeTab) {
-                    props.onActivateTab(placement, activeTab.id);
-                  }
-                }}
                 sideChatAvailable={props.sourceSession !== undefined}
               />
             </WorkbarPanel>

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -273,69 +273,7 @@
 }
 
 .maka-workbar-launcher-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
   width: min(100%, 360px);
-}
-
-.maka-workbar-launcher-row {
-  display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--space-3);
-  width: 100%;
-  min-height: 36px;
-  padding: var(--space-1) var(--space-3);
-  border: 0;
-  border-radius: var(--radius-element);
-  background: transparent;
-  color: var(--foreground);
-  cursor: pointer;
-  text-align: left;
-}
-
-.maka-workbar-launcher-row:hover,
-.maka-workbar-launcher-row:focus-visible {
-  background: var(--color-overlay-hover);
-  outline: none;
-  box-shadow: inset 0 0 0 var(--focus-ring-width) var(--focus-ring);
-}
-
-.maka-workbar-launcher-row:active {
-  transform: scale(0.98);
-}
-
-.maka-workbar-launcher-row[data-secondary]:first-of-type,
-.maka-workbar-launcher-row:not([data-secondary])
-  + .maka-workbar-launcher-row[data-secondary] {
-  margin-top: var(--space-2);
-  padding-top: calc(var(--space-2) + var(--space-1));
-  border-top: var(--border-width-hairline) solid var(--border);
-  border-radius: 0 0 var(--radius-element) var(--radius-element);
-}
-
-.maka-workbar-launcher-row[aria-disabled="true"] {
-  cursor: default;
-  opacity: 0.45;
-  pointer-events: none;
-}
-
-.maka-workbar-launcher-icon {
-  display: inline-grid;
-  place-items: center;
-  color: var(--foreground-secondary);
-}
-
-.maka-workbar-launcher-icon > svg {
-  width: var(--icon-chrome);
-  height: var(--icon-chrome);
-}
-
-/* Astryx Kbd owns keycap chrome; only mute the cluster. */
-.maka-workbar-launcher-shortcut {
-  color: var(--muted-foreground);
-  white-space: nowrap;
 }
 
 /* Session trace (#1625): a read-only causal timeline in the workbar.

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -364,7 +364,6 @@ function ComposedShell(props: {
         <AppShellWorkspaceTopActions
           workbarAvailable
           workbarCollapsed={false}
-          onOpenWorkbarLauncher={noop}
           onToggleWorkbar={noop}
         />
       </header>

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -591,7 +591,6 @@ function ModuleSurface(props: {
         <AppShellWorkspaceTopActions
           workbarAvailable={false}
           workbarCollapsed
-          onOpenWorkbarLauncher={noop}
           onToggleWorkbar={noop}
         />
         <ToastProvider>{props.children}</ToastProvider>

--- a/apps/desktop/stories/session-workbar.stories.tsx
+++ b/apps/desktop/stories/session-workbar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { ArtifactRecord, GitReviewSnapshot, Task } from '@maka/core';
+import type { ArtifactRecord, GitReviewSnapshot, SessionSummary, Task } from '@maka/core';
 import type { SessionTrace } from '@maka/core/session-trace';
 import { ToastProvider } from '@maka/ui';
 import { SessionWorkbar } from '../src/renderer/session-workbar';
@@ -34,6 +34,21 @@ import { withScopedMakaBridge } from './maka-bridge';
 
 const SESSION_ID = 'session-workbar';
 const NOW = Date.UTC(2026, 6, 31, 10, 30, 0);
+const TOOL_PICKER_SOURCE_SESSION: SessionSummary = {
+  id: SESSION_ID,
+  name: '工作栏组件审查',
+  isFlagged: false,
+  isArchived: false,
+  labels: [],
+  hasUnread: false,
+  status: 'active',
+  lastMessageAt: NOW,
+  backend: 'ai-sdk',
+  llmConnectionSlug: 'anthropic-main',
+  connectionLocked: false,
+  model: 'claude-sonnet-4-5',
+  permissionMode: 'ask',
+};
 
 // The record-file row reads `app:info`'s operationalStateDatabasePath (the
 // exact path main resolves). The short one is what a default workspace looks
@@ -501,7 +516,10 @@ function bridge(options: {
 }
 
 /** The column AppShell hands the workbar, at the width it restores by default. */
-function Workbar(props: { tab?: 'review' | 'tasks' | 'files' | 'inspector' }) {
+function Workbar(props: {
+  tab?: 'review' | 'tasks' | 'files' | 'inspector';
+  sourceSession?: SessionSummary;
+}) {
   const emptyTabsState = createSessionWorkbarTabsState();
   const tabsState = props.tab
     ? openStaticSessionWorkbarTab(emptyTabsState, props.tab)
@@ -525,21 +543,7 @@ function Workbar(props: { tab?: 'review' | 'tasks' | 'files' | 'inspector' }) {
           onPinTab={noop}
           onOpenLauncher={noop}
           onRequestOpenTab={noop}
-          sourceSession={{
-            id: SESSION_ID,
-            name: '工作栏组件审查',
-            isFlagged: false,
-            isArchived: false,
-            labels: [],
-            hasUnread: false,
-            status: 'active',
-            lastMessageAt: NOW,
-            backend: 'ai-sdk',
-            llmConnectionSlug: 'anthropic-main',
-            connectionLocked: false,
-            model: 'claude-sonnet-4-5',
-            permissionMode: 'ask',
-          }}
+          sourceSession={props.sourceSession}
         />
       </ToastProvider>
     </div>
@@ -559,7 +563,7 @@ type Story = StoryObj<typeof meta>;
 // workbar's empty content, composed entirely from Astryx List primitives.
 export const ToolPicker: Story = {
   decorators: [bridge()],
-  render: () => <Workbar />,
+  render: () => <Workbar sourceSession={TOOL_PICKER_SOURCE_SESSION} />,
 };
 
 // Real path: 会话工作栏 → 变更, showing the live branch comparison from the

--- a/apps/desktop/stories/session-workbar.stories.tsx
+++ b/apps/desktop/stories/session-workbar.stories.tsx
@@ -501,11 +501,11 @@ function bridge(options: {
 }
 
 /** The column AppShell hands the workbar, at the width it restores by default. */
-function Workbar(props: { tab: 'review' | 'tasks' | 'files' | 'inspector' }) {
-  const tabsState = openStaticSessionWorkbarTab(
-    createSessionWorkbarTabsState(),
-    props.tab,
-  );
+function Workbar(props: { tab?: 'review' | 'tasks' | 'files' | 'inspector' }) {
+  const emptyTabsState = createSessionWorkbarTabsState();
+  const tabsState = props.tab
+    ? openStaticSessionWorkbarTab(emptyTabsState, props.tab)
+    : emptyTabsState;
   return (
     <div style={{ height: 720, display: 'flex', justifyContent: 'flex-end' }}>
       <ToastProvider>
@@ -525,6 +525,21 @@ function Workbar(props: { tab: 'review' | 'tasks' | 'files' | 'inspector' }) {
           onPinTab={noop}
           onOpenLauncher={noop}
           onRequestOpenTab={noop}
+          sourceSession={{
+            id: SESSION_ID,
+            name: '工作栏组件审查',
+            isFlagged: false,
+            isArchived: false,
+            labels: [],
+            hasUnread: false,
+            status: 'active',
+            lastMessageAt: NOW,
+            backend: 'ai-sdk',
+            llmConnectionSlug: 'anthropic-main',
+            connectionLocked: false,
+            model: 'claude-sonnet-4-5',
+            permissionMode: 'ask',
+          }}
         />
       </ToastProvider>
     </div>
@@ -539,6 +554,13 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof meta>;
+
+// Real path: sidebar → a session → expand an empty workbar. The picker is the
+// workbar's empty content, composed entirely from Astryx List primitives.
+export const ToolPicker: Story = {
+  decorators: [bridge()],
+  render: () => <Workbar />,
+};
 
 // Real path: 会话工作栏 → 变更, showing the live branch comparison from the
 // session cwd. The panel is Git-backed; no message or tool-result fixture is

--- a/docs/astryx-alignment-inventory.md
+++ b/docs/astryx-alignment-inventory.md
@@ -46,7 +46,7 @@ exists / broken hierarchy) · **polish** (off-scale px, density).
 | App shell / session list | SideNav | intentional raw siblings where nested button forbidden |
 | Composer | Raw hint/cancel buttons | **fixed → Button** |
 | Workbar tabs | Raw `role=tab` + dnd-kit | intentional (dnd + tablist; close is IconButton) |
-| Workbar launcher menu | Raw menuitem buttons | **fixed → Item** |
+| Workbar tool picker | Product-authored menu semantics and row chrome | **fixed → List + ListItem** |
 | Inspector failed filter | Raw toggle | **fixed → ToggleButton** |
 | Plan execution panel | Raw expand toggle | **fixed → Collapsible** |
 | Titlebar identity | BreadcrumbItem | already aligned |
@@ -64,12 +64,12 @@ exists / broken hierarchy) · **polish** (off-scale px, density).
 | Quote / prompt rail chips | Raw expand/remove | polish (chip hit geometry) |
 
 ## Fixed in this pass
-- Control-height rhythm: task ledger rows/triggers, module list skeleton rows, workbar launcher rows.
+- Control-height rhythm: task ledger rows/triggers and module list skeleton rows.
 - Composer no-model / revision cancel → Astryx `Button`.
 - Inspector failed-only filter → Astryx `ToggleButton`.
 - External import source + session pick → `SegmentedControl` / `Item`.
 - Plan execution expand → Astryx `Collapsible`.
-- Workbar launcher rows → Astryx `Item` (`role=menuitem`).
+- Workbar tool picker → Astryx `List` + `ListItem`; visible descriptions and native row interaction.
 - `scripts/check-astryx-alignment.mjs` + unit test gate.
 
 ## Remaining polish (non-blocker)

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -54,9 +54,9 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/quote-companion-panel.tsx` | shell-chrome-or-panel | Banner, Spinner | aligned — uses Astryx (Banner, Spinner) | aligned |
 | `apps/desktop/src/renderer/reference-shell.css` | styles | n/a (css) | aligned — no off-rhythm control heights flagged | aligned |
 | `apps/desktop/src/renderer/session-inspector-panel.tsx` | shell-chrome-or-panel | Banner, Button, EmptyState, HStack, Heading, Section, Text, TextInput, ToggleButton, Tooltip, VStack | aligned — uses Astryx (Banner, Button, EmptyState, HStack, Heading, Section, Text, TextInput) | aligned |
-| `apps/desktop/src/renderer/session-review-panel.tsx` | shell-chrome-or-panel | Banner, Button, EmptyState, Section, SegmentedControl, SegmentedControlItem, Toolbar | aligned — uses Astryx (Banner, Button, EmptyState, Section, SegmentedControl, SegmentedControlItem, Toolbar) | aligned |
+| `apps/desktop/src/renderer/session-review-panel.tsx` | shell-chrome-or-panel | Banner, Button, Collapsible, EmptyState, HStack, Section, Text, VStack | aligned — uses Astryx (Banner, Button, Collapsible, EmptyState, HStack, Section, Text, VStack) | aligned |
 | `apps/desktop/src/renderer/session-terminal-panel.tsx` | shell-chrome-or-panel | Banner, EmptyState | aligned — uses Astryx (Banner, EmptyState) | aligned |
-| `apps/desktop/src/renderer/session-workbar.tsx` | shell-chrome-or-panel | Badge, Button, Card, ContextMenu, IconButton, Item, Section, Spinner, Toolbar, Tooltip | aligned — uses Astryx (Badge, Button, Card, ContextMenu, IconButton, Item, Section, Spinner) | aligned |
+| `apps/desktop/src/renderer/session-workbar.tsx` | shell-chrome-or-panel | Badge, Button, Card, ContextMenu, Heading, IconButton, List, ListItem, Section, Spinner, Toolbar, Tooltip | aligned — uses Astryx (Badge, Button, Card, ContextMenu, Heading, IconButton, List, ListItem) | aligned |
 | `apps/desktop/src/renderer/settings/about-settings-page.tsx` | settings-page | Badge, Banner, Button, List, ListItem | aligned — uses Astryx (Badge, Banner, Button, List, ListItem) | aligned |
 | `apps/desktop/src/renderer/settings/appearance-settings-page.tsx` | settings-page | HStack, Text, VStack | aligned — uses Astryx (HStack, Text, VStack) | aligned |
 | `apps/desktop/src/renderer/settings/bot-chat-detail.tsx` | settings-module | Banner, Button, Card, MetadataList, MetadataListItem, SegmentedControl, SegmentedControlItem, Text, VStack | aligned — uses Astryx (Banner, Button, Card, MetadataList, MetadataListItem, SegmentedControl, SegmentedControlItem, Text) | aligned |
@@ -201,7 +201,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `packages/ui/src/task-ledger-panel.tsx` | shell-chrome-or-panel | Banner, Collapsible, EmptyState, IconButton, Spinner | aligned — uses Astryx (Banner, Collapsible, EmptyState, IconButton, Spinner) | aligned |
 | `packages/ui/src/titlebar-session-identity.tsx` | shell-chrome-or-panel | BreadcrumbItem, Breadcrumbs | aligned — uses Astryx (BreadcrumbItem, Breadcrumbs) | aligned |
 | `packages/ui/src/toast.tsx` | ui-composition | Button, HStack, Text, VStack | aligned — uses Astryx (Button, HStack, Text, VStack) | aligned |
-| `packages/ui/src/tool-activity.tsx` | ui-composition | Banner, Button, ChatToolCalls | aligned — uses Astryx (Banner, Button, ChatToolCalls) | aligned |
+| `packages/ui/src/tool-activity.tsx` | ui-composition | Banner, Button, ChatToolCalls, List, ListItem, Text | aligned — uses Astryx (Banner, Button, ChatToolCalls, List, ListItem, Text) | aligned |
 | `packages/ui/src/tool-activity/agent-preview.tsx` | ui-composition | Button | aligned — uses Astryx (Button) | aligned |
 | `packages/ui/src/tool-activity/diff-code-preview.tsx` | ui-composition | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `packages/ui/src/tool-activity/tool-code-block.tsx` | ui-composition | none | aligned — no raw controls; no Astryx JSX usage | aligned |

--- a/scripts/check-astryx-alignment.mjs
+++ b/scripts/check-astryx-alignment.mjs
@@ -59,7 +59,6 @@ const controlBlocks = [
     /\.maka-module-list-skeleton-row\b[\s\S]{0,220}?min-height:\s*(\d+)px/,
     'module-list-skeleton-row',
   ],
-  [/\.maka-workbar-launcher-row\b[\s\S]{0,220}?min-height:\s*(\d+)px/, 'workbar-launcher-row'],
 ];
 
 for (const rel of HEIGHT_GUARD_FILES) {
@@ -98,7 +97,7 @@ const REQUIRED_IMPORTS = [
   ['apps/desktop/src/renderer/external-session-import-dialog.tsx', /SegmentedControl/],
   ['apps/desktop/src/renderer/external-session-import-dialog.tsx', /Item/],
   ['apps/desktop/src/renderer/plan-mode-panel.tsx', /Collapsible/],
-  ['apps/desktop/src/renderer/session-workbar.tsx', /from '@astryxdesign\/core\/Item'/],
+  ['apps/desktop/src/renderer/session-workbar.tsx', /from '@astryxdesign\/core\/List'/],
 ];
 for (const [rel, re] of REQUIRED_IMPORTS) {
   const text = readFileSync(join(root, rel), 'utf8');
@@ -109,30 +108,16 @@ for (const [rel, re] of REQUIRED_IMPORTS) {
 
 // Contracts that fixed a11y regressions after the first Astryx pass.
 const workbar = readFileSync(join(root, 'apps/desktop/src/renderer/session-workbar.tsx'), 'utf8');
-// Negative lookbehind: bare description= prop, not aria-description=
-if (/(?<![\w-])description=\{action\.description\}/.test(workbar)) {
+if (!/<List\b/.test(workbar) || !/<ListItem\b/.test(workbar)) {
+  failures.push('session-workbar.tsx: launcher should use Astryx List/ListItem');
+}
+if (!/(?<![\w-])description=\{action\.description\}/.test(workbar)) {
+  failures.push('session-workbar.tsx: launcher ListItem should show its action description');
+}
+if (/role=["']menuitem["']|aria-description=\{action\.description\}/.test(workbar)) {
   failures.push(
-    'session-workbar.tsx: launcher Item must not put action.description in visible description',
+    'session-workbar.tsx: launcher must not recreate ListItem semantics with menu roles or aria-only copy',
   );
-}
-if (!/aria-description=\{action\.description\}/.test(workbar)) {
-  failures.push(
-    'session-workbar.tsx: launcher Item should keep AT description via aria-description',
-  );
-}
-
-const launcherCss = readFileSync(
-  join(root, 'apps/desktop/src/renderer/styles/chat-detail.css'),
-  'utf8',
-);
-if (
-  /\.maka-workbar-launcher-row:disabled\b/.test(launcherCss) &&
-  !/\.maka-workbar-launcher-row\[aria-disabled/.test(launcherCss)
-) {
-  failures.push('chat-detail.css: launcher disabled style must target [aria-disabled]');
-}
-if (!/\.maka-workbar-launcher-row\[aria-disabled/.test(launcherCss)) {
-  failures.push('chat-detail.css: missing .maka-workbar-launcher-row[aria-disabled] rule');
 }
 
 const importTsx = readFileSync(

--- a/scripts/check-astryx-alignment.mjs
+++ b/scripts/check-astryx-alignment.mjs
@@ -97,27 +97,12 @@ const REQUIRED_IMPORTS = [
   ['apps/desktop/src/renderer/external-session-import-dialog.tsx', /SegmentedControl/],
   ['apps/desktop/src/renderer/external-session-import-dialog.tsx', /Item/],
   ['apps/desktop/src/renderer/plan-mode-panel.tsx', /Collapsible/],
-  ['apps/desktop/src/renderer/session-workbar.tsx', /from '@astryxdesign\/core\/List'/],
 ];
 for (const [rel, re] of REQUIRED_IMPORTS) {
   const text = readFileSync(join(root, rel), 'utf8');
   if (!re.test(text)) {
     failures.push(`${rel}: missing required Astryx import matching ${re}`);
   }
-}
-
-// Contracts that fixed a11y regressions after the first Astryx pass.
-const workbar = readFileSync(join(root, 'apps/desktop/src/renderer/session-workbar.tsx'), 'utf8');
-if (!/<List\b/.test(workbar) || !/<ListItem\b/.test(workbar)) {
-  failures.push('session-workbar.tsx: launcher should use Astryx List/ListItem');
-}
-if (!/(?<![\w-])description=\{action\.description\}/.test(workbar)) {
-  failures.push('session-workbar.tsx: launcher ListItem should show its action description');
-}
-if (/role=["']menuitem["']|aria-description=\{action\.description\}/.test(workbar)) {
-  failures.push(
-    'session-workbar.tsx: launcher must not recreate ListItem semantics with menu roles or aria-only copy',
-  );
 }
 
 const importTsx = readFileSync(

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -196,6 +196,7 @@ const RESERVED_SCALE_TOKENS = new Set([
   // tokens mirror ICON_SIZE in @maka/ui's icons.tsx for the CSS-clamped
   // sites; a rung with no clamp today (empty, plate) still names its gap.
   // --icon-size is the deprecated alias, kept one release.
+  '--icon-chrome',
   '--icon-empty',
   '--icon-plate',
   '--icon-size',


### PR DESCRIPTION
## Summary

- merge the two conversation-workbar titlebar actions into the existing expand/collapse control
- show the embedded tool picker only when an expanded workbar has no tabs; otherwise restore the existing tab
- replace product-authored launcher menu semantics and row chrome with published Astryx `Heading`, `List`, `ListItem`, `Icon`, and `Kbd` primitives
- update the Astryx alignment contract and focused E2E coverage to prevent the duplicate action or custom menu path from returning

Refs #2574

## Verification

- `npm run format`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run test:checks`
- `node --test scripts/check-astryx-alignment.test.mjs scripts/check-astryx-surface-inventory.test.mjs`
- `node scripts/check-dead-css.mjs --check`
- `npm --workspace @maka/desktop run build:renderer`
- `npx playwright test --config e2e/playwright.config.ts session-workbar.spec.ts` (4 passed)
- visually verified the empty-workbar picker in Electron and the `ToolPicker` Storybook story

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
