### PR TITLE
fix(runtime-host): reject stale Hosts during startup

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type { BotIncomingMessage } from '@maka/runtime';
-import { INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID } from '@maka/runtime-host/protocol';
+import {
+  INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
+} from '@maka/runtime-host/protocol';
 import type {
   DesktopRuntimeHostCandidate,
   DesktopRuntimeHostCandidateStartInput,
@@ -103,20 +106,7 @@ test('stops reconnecting when the replacement Host is incompatible', async () =>
     startCandidate: async () =>
       first.closeCalls === 0
         ? ready(first.candidate)
-        : {
-            kind: 'incompatible',
-            handshake: {
-              kind: 'incompatible',
-              hostEpoch: 'replacement-host',
-              compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
-              compositionRevision: '2',
-              protocolMin: 1,
-              protocolMax: 1,
-              compatibilityEpoch: 1,
-              state: 'ready',
-              replacement: 'wait_for_idle_exit',
-            },
-          },
+        : incompatibleHost('wait_for_idle_exit'),
     onFatalError: reportFatal,
   });
 
@@ -125,6 +115,42 @@ test('stops reconnecting when the replacement Host is incompatible', async () =>
   assert.match(fatal.message, /incompatible/);
   await owner.close();
 });
+
+test('explains how to retire an older Host during startup', async () => {
+  await assert.rejects(
+    startRuntimeHostDesktopOwner({} as DesktopRuntimeHostCandidateStartInput, {
+      startCandidate: async () => incompatibleHost('blocked_by_residency'),
+      onFatalError: () => undefined,
+    }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.equal(
+        error.message,
+        'An older Maka process is still running and is incompatible with this build. Fully quit the previous Maka Desktop process, then start Maka again.',
+      );
+      return true;
+    },
+  );
+});
+
+function incompatibleHost(
+  replacement: 'wait_for_idle_exit' | 'blocked_by_residency',
+): DesktopRuntimeHostCandidateStartResult {
+  return {
+    kind: 'incompatible',
+    handshake: {
+      kind: 'incompatible',
+      hostEpoch: 'older-host',
+      compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+      compositionRevision: 'legacy',
+      protocolMin: 0,
+      protocolMax: 0,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH - 1,
+      state: 'ready',
+      replacement,
+    },
+  };
+}
 
 function candidateHarness(options: { delayDisconnect?: boolean } = {}) {
   let resolveClosed: (() => void) | undefined;

--- a/apps/desktop/src/main/runtime-host-desktop-owner.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-owner.ts
@@ -5,6 +5,7 @@ import {
   type RuntimeHostReconnectBackoff,
   type RuntimeHostReconnectLifecycle,
 } from '@maka/runtime-host/client';
+import { RUNTIME_HOST_COMPATIBILITY_EPOCH } from '@maka/runtime-host/protocol';
 import {
   startDesktopRuntimeHostCandidate,
   type DesktopRuntimeHostCandidate,
@@ -104,6 +105,11 @@ class RuntimeHostDesktopOwnerImpl implements RuntimeHostDesktopOwner {
     );
     if (result.kind === 'ready') return result.candidate;
     if (result.kind === 'incompatible') {
+      if (result.handshake.compatibilityEpoch < RUNTIME_HOST_COMPATIBILITY_EPOCH) {
+        throw new RuntimeHostPermanentReconnectError(
+          'An older Maka process is still running and is incompatible with this build. Fully quit the previous Maka Desktop process, then start Maka again.',
+        );
+      }
       throw new RuntimeHostPermanentReconnectError(
         `Runtime Host is incompatible (protocol ${result.handshake.protocolMin}-${result.handshake.protocolMax}; ${result.handshake.replacement})`,
       );

--- a/packages/cli/src/live-inspect-backend.ts
+++ b/packages/cli/src/live-inspect-backend.ts
@@ -4,6 +4,7 @@ import {
   type RuntimeHostConnection,
 } from '@maka/runtime-host/client';
 import {
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   type ExecutionInspectResolveInput,
 } from '@maka/runtime-host/protocol';
@@ -116,6 +117,9 @@ function liveHostUnavailableMessage(
   result: Exclude<ConnectRuntimeHostResult, { kind: 'connected' }>,
 ): string {
   if (result.kind === 'incompatible') {
+    if (result.handshake.compatibilityEpoch < RUNTIME_HOST_COMPATIBILITY_EPOCH) {
+      return 'Interactive storage is locked by an older Runtime Host. Stop its owning Maka process, then try again.';
+    }
     return 'Interactive storage is locked by an incompatible Runtime Host';
   }
   if (result.kind === 'draining') {

--- a/packages/cli/src/runtime-host-capability-provider-command.ts
+++ b/packages/cli/src/runtime-host-capability-provider-command.ts
@@ -18,6 +18,7 @@ import {
   CLIENT_CAPABILITY_MAX_TOOLS_PER_OFFER,
   decodeClientCapabilityReplaceInput,
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   type ClientCapabilityCallResult,
   type ClientCapabilityOffer,
@@ -145,6 +146,11 @@ async function connectRemoteCapabilityProvider(input: {
   }
   if (connected.kind === 'connected') return connected.connection;
   if (connected.kind === 'incompatible') {
+    if (connected.handshake.compatibilityEpoch < RUNTIME_HOST_COMPATIBILITY_EPOCH) {
+      throw new RuntimeHostPermanentReconnectError(
+        'The remote Runtime Host is older than this capability provider. Upgrade or restart the Runtime Host, then reconnect.',
+      );
+    }
     throw new RuntimeHostPermanentReconnectError(
       `Runtime Host protocol is incompatible (Host ${connected.handshake.protocolMin}-${connected.handshake.protocolMax})`,
     );

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -11,6 +11,7 @@ import {
 } from '@maka/runtime-host/client';
 import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   type ClientSurface,
 } from '@maka/runtime-host/protocol';
@@ -63,6 +64,11 @@ export async function connectRuntimeHostCli(
   const connect = async (signal?: AbortSignal): Promise<RuntimeHostConnection> => {
     const connected = await deps.connectOrSpawn({ ...connectInput, ...(signal ? { signal } : {}) });
     if (connected.kind === 'incompatible') {
+      if (connected.handshake.compatibilityEpoch < RUNTIME_HOST_COMPATIBILITY_EPOCH) {
+        throw new RuntimeHostPermanentReconnectError(
+          'An older Maka Runtime Host is still running and is incompatible with this build. Stop the previous Maka Desktop or CLI process, then try again.',
+        );
+      }
       throw new RuntimeHostPermanentReconnectError(
         `Runtime Host protocol is incompatible (Host ${connected.handshake.protocolMin}-${connected.handshake.protocolMax}, CLI ${RUNTIME_HOST_PROTOCOL_VERSION})`,
       );

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -47,7 +47,7 @@ describe('Runtime Host bootstrap protocol', () => {
 
   test('keeps the experimental protocol at v0 with the declared authority operations', () => {
     assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
-    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 13);
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 14);
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
       'access.credential.issue',
       'access.credential.revoke',

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -62,9 +62,10 @@ export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // The wire version remains v0 before the first release. This independent epoch
 // lets a new Client retire a stale same-version Host whose closed schema is no
 // longer safe to use.
-// 13: composition identity, trusted capability providers, and Automation waiting
-// state changed the closed schema.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 13 as const;
+// 13: trusted capability-provider Clients and Automation waiting state changed
+// the closed schema.
+// 14: composition identity became part of Host startup and handshake authority.
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 14 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- bump the Runtime Host compatibility epoch from 13 to 14
- reject stale Hosts during the startup handshake, before any domain command is dispatched
- provide actionable stale-Host guidance for Desktop, CLI, live inspect, and remote capability providers

## Root cause

The composition-aware Host startup contract changed while the compatibility epoch remained at 13. A new Client could therefore attach to a Runtime Host left behind by an older Maka process and fail only after dispatching `client.capability.replace`, where the operation outcome was unknown.

## Impact

Developers who update while an older Maka process is still running now receive an immediate instruction to stop that process and retry. This PR intentionally does not add automatic command replay, Host takeover, or a new reconnect state.

## Validation

- Biome check for all changed files
- Runtime Host, Desktop, and CLI type checks
- Runtime Host protocol tests
- Desktop Runtime Host owner tests
- CLI Runtime Host context test
- Runtime Host kernel and legacy subscription compatibility tests

</details>

<details>
<summary>中文</summary>

## 概要

- 将 Runtime Host compatibility epoch 从 13 提升到 14
- 在启动握手阶段拒绝旧 Host，避免发送任何领域命令后才失败
- 为 Desktop、CLI、live inspect 和远程 capability provider 提供可执行的旧 Host 处理提示

## 根因

Runtime Host 启动契约已经加入 composition 相关约束，但 compatibility epoch 仍停留在 13。新版 Client 因而可能连接由旧版 Maka 进程遗留的 Runtime Host，直到发送 `client.capability.replace` 后连接才中断，并留下命令结果未知的错误。

## 影响

开发者在旧 Maka 进程仍运行时更新代码，现在会立即看到停止旧进程并重试的明确提示。本 PR 不增加自动命令重放、Host 接管或新的重连状态。

## 验证

- 所有变更文件的 Biome 检查
- Runtime Host、Desktop 和 CLI 类型检查
- Runtime Host 协议测试
- Desktop Runtime Host owner 测试
- CLI Runtime Host context 测试
- Runtime Host kernel 与旧 subscription 兼容性测试

</details>
