### PR TITLE
refactor(runtime): settle provider steps once

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { describe, test } from 'node:test';
-import type { ModelMessage } from '../model-protocol.js';
+import type { ModelMessage, ModelStreamResult } from '../model-protocol.js';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
 import { APICallError, type LanguageModelV4StreamPart } from '@ai-sdk/provider';
 import type { AgentRunHeader } from '@maka/core/agent-run';
@@ -9102,7 +9102,7 @@ describe('AiSdkBackend RunTrace', () => {
     };
     (
       backend as unknown as {
-        modelAdapter: { startStream: (input: FakeStreamInput) => Promise<unknown> };
+        modelAdapter: { startStream: (input: FakeStreamInput) => Promise<ModelStreamResult> };
       }
     ).modelAdapter.startStream = async (input: FakeStreamInput) => {
       calls += 1;
@@ -9117,8 +9117,12 @@ describe('AiSdkBackend RunTrace', () => {
             else input.abortSignal.addEventListener('abort', abort, { once: true });
           });
         })(),
-        usage: Promise.resolve(undefined),
-        finishReason: Promise.resolve('stop'),
+        outcome: Promise.resolve({
+          kind: 'completed',
+          finishReason: 'stop',
+          request: { messages: [] },
+          continuation: 'none',
+        }),
       };
     };
 
@@ -11467,7 +11471,7 @@ describe('AiSdkBackend thinking persistence', () => {
     };
     (
       backend as unknown as {
-        modelAdapter: { startStream: (input: FakeStreamInput) => Promise<unknown> };
+        modelAdapter: { startStream: (input: FakeStreamInput) => Promise<ModelStreamResult> };
       }
     ).modelAdapter.startStream = async (input: FakeStreamInput) => ({
       // The adapter boundary now exposes Maka-owned `ModelStreamEvent`s, not
@@ -11479,8 +11483,17 @@ describe('AiSdkBackend thinking persistence', () => {
         yield { kind: 'thinking', text: 'final thoughts' };
         yield { kind: 'thinking-signature', signature: 'sig-last' };
       })(),
-      usage: Promise.resolve(undefined),
-      finishReason: Promise.resolve('stop'),
+      outcome: Promise.resolve({
+        kind: 'truncated',
+        failure: {
+          type: 'model_failure',
+          kind: 'provider_unavailable',
+          message: 'Provider stream ended without finishing (unknown)',
+          retryable: false,
+        },
+        request: { messages: [] },
+        continuation: 'none',
+      }),
     });
 
     for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
@@ -11493,6 +11506,7 @@ describe('AiSdkBackend thinking persistence', () => {
     const thinkingOnly = assistants.find((m) => m.thinking?.signature === 'sig-last');
     assert.ok(thinkingOnly, 'thinking-only last step must persist');
     assert.equal(thinkingOnly.text, '');
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
     // No duplicate message ids anywhere in the ledger.
     const ids = appended.map((m) => (m as { id: string }).id);
     assert.equal(new Set(ids).size, ids.length, `duplicate ledger ids: ${ids.join(', ')}`);

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -5975,6 +5975,74 @@ describe('AiSdkBackend error surfaces', () => {
 });
 
 describe('AiSdkBackend usage telemetry', () => {
+  test('records provider-reported usage for a content-filter terminal', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: {
+        stream: simulateReadableStream({
+          chunks: [
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'finish',
+              finishReason: { unified: 'content-filter', raw: 'content_filter' },
+              usage: {
+                inputTokens: { total: 7, noCache: 7, cacheRead: 0, cacheWrite: 0 },
+                outputTokens: { total: 3, text: 3, reasoning: 0 },
+              },
+            },
+          ],
+          initialDelayInMs: null,
+          chunkDelayInMs: null,
+        }),
+      },
+    });
+    const appended: StoredMessage[] = [];
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => {
+        appended.push(message);
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({ turnId: 'turn-1', text: 'hi', context: [] })) {
+      events.push(event);
+    }
+
+    assert.equal(events.find((event) => event.type === 'token_usage')?.total, 10);
+    assert.equal(appended.find((message) => message.type === 'token_usage')?.total, 10);
+  });
+
+  test('lets an unconfigured turn continue past the former 50-step default', async () => {
+    const loop = countingToolLoopModel(51);
+    const durable = durableTurnHarness('turn-1', 'hi');
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => loop.model,
+      tools: [testTool('Read', z.object({ path: z.string() }))],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events = await drainDurably(backend.send(durable.input()), durable);
+
+    assert.equal(loop.callCount(), 52);
+    assert.equal(events.at(-1)?.type, 'complete');
+  });
+
   test('retries an output-free truncated provider stream once and recovers', async () => {
     const durable = durableTurnHarness('turn-truncated-retry', 'analyse the image');
     let calls = 0;
@@ -6167,107 +6235,6 @@ describe('AiSdkBackend usage telemetry', () => {
       (event): event is Extract<SessionEvent, { type: 'error' }> => event.type === 'error',
     );
     assert.equal(error?.reason, 'provider_unavailable');
-  });
-
-  test('says which failed terminal a content filter is', async () => {
-    // A named provider terminal, not a stream nobody closed. It reaches the
-    // same failed outcome and so must carry the same error event — on main it
-    // ended the turn failed while `lastError` stayed empty — but calling it
-    // "ended without finishing" would describe the wrong thing.
-    const durable = durableTurnHarness('turn-filtered', 'analyse the image');
-    const model = new MockLanguageModelV4({
-      doStream: async () => ({
-        stream: simulateReadableStream({
-          chunks: [
-            { type: 'stream-start', warnings: [] },
-            { type: 'text-start', id: 'text-1' },
-            { type: 'text-delta', id: 'text-1', delta: 'I cannot' },
-            { type: 'text-end', id: 'text-1' },
-            {
-              type: 'finish',
-              finishReason: { unified: 'content-filter' as const, raw: 'content_filter' },
-              usage: emptyUsage(),
-            },
-          ],
-          initialDelayInMs: null,
-          chunkDelayInMs: null,
-        }),
-      }),
-    });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
-      connection: connection(),
-      apiKey: 'sk-test',
-      modelId: 'mock-model-id',
-      modelFactory: () => model,
-      tools: [],
-      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
-    });
-
-    const events = await drainDurably(backend.send(durable.input()), durable);
-    const complete = events.find(
-      (event): event is Extract<SessionEvent, { type: 'complete' }> => event.type === 'complete',
-    );
-    const error = events.find(
-      (event): event is Extract<SessionEvent, { type: 'error' }> => event.type === 'error',
-    );
-
-    assert.equal(complete?.stopReason, 'error');
-    assert.ok(error, 'a failed terminal must be accompanied by an error event');
-  });
-
-  test('keeps a turn the provider named its own reason for', async () => {
-    // The SDK's `other` is not a reason, it is the SDK declining to name one:
-    // an unrecognized `finish_reason` from an OpenAI-compatible provider —
-    // llama.cpp's `eos_token`, DeepSeek's `insufficient_system_resource` —
-    // lands in the same bucket as a connection that died mid-answer. The
-    // provider's own spelling is the only thing that tells them apart, so
-    // treating the bucket itself as failure would fail complete answers.
-    const durable = durableTurnHarness('turn-unnamed', 'analyse the image');
-    const model = new MockLanguageModelV4({
-      doStream: async () => ({
-        stream: simulateReadableStream({
-          chunks: [
-            { type: 'stream-start', warnings: [] },
-            { type: 'text-start', id: 'text-1' },
-            { type: 'text-delta', id: 'text-1', delta: 'The top region is empty.' },
-            { type: 'text-end', id: 'text-1' },
-            {
-              type: 'finish',
-              finishReason: { unified: 'other' as const, raw: 'eos_token' },
-              usage: emptyUsage(),
-            },
-          ],
-          initialDelayInMs: null,
-          chunkDelayInMs: null,
-        }),
-      }),
-    });
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
-      connection: connection(),
-      apiKey: 'sk-test',
-      modelId: 'mock-model-id',
-      modelFactory: () => model,
-      tools: [],
-      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
-      newId: idGenerator(),
-      now: monotonicClock(),
-    });
-
-    const events = await drainDurably(backend.send(durable.input()), durable);
-    const complete = events.find(
-      (event): event is Extract<SessionEvent, { type: 'complete' }> => event.type === 'complete',
-    );
-
-    assert.equal(complete?.stopReason, 'end_turn');
-    assert.ok(!events.some((event) => event.type === 'error'));
   });
 
   test('rejects continuation-capable tools before side effects without a durable reader', async () => {

--- a/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
@@ -1,9 +1,18 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
-import { APICallError } from '@ai-sdk/provider';
+import {
+  APICallError,
+  type LanguageModelV4StreamPart,
+  type LanguageModelV4Usage,
+} from '@ai-sdk/provider';
 
-import { ModelAdapter } from '../model-adapter.js';
+import { ModelAdapter, settleModelStepOutcome } from '../model-adapter.js';
+
+const ZERO_USAGE: LanguageModelV4Usage = {
+  inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+  outputTokens: { total: 0, text: 0, reasoning: 0 },
+};
 
 function newAdapter(): ModelAdapter {
   return new ModelAdapter({
@@ -15,6 +24,29 @@ function newAdapter(): ModelAdapter {
     now: () => 0,
   });
 }
+
+describe('settleModelStepOutcome', () => {
+  test('explicit stream failure takes precedence over finish metadata', () => {
+    const failure = {
+      type: 'model_failure' as const,
+      kind: 'rate_limit' as const,
+      message: 'Rate limit exceeded',
+      retryable: true,
+    };
+
+    const outcome = settleModelStepOutcome({
+      aborted: false,
+      failure,
+      sawFinish: true,
+      finishReason: 'content-filter',
+      request: {},
+    });
+
+    assert.equal(outcome.kind, 'retryable-failure');
+    if (outcome.kind !== 'retryable-failure') return;
+    assert.equal(outcome.failure, failure);
+  });
+});
 
 describe('ModelAdapter.startStream onError', () => {
   test('normalizes provider retry eligibility and Retry-After at the adapter boundary', async () => {
@@ -54,6 +86,12 @@ describe('ModelAdapter.startStream onError', () => {
         retryAfterMs: 2500,
       },
     ]);
+    assert.deepEqual(await result.outcome, {
+      kind: 'retryable-failure',
+      failure: failures[0],
+      request: { messages: [{ role: 'user', content: 'hi' }] },
+      continuation: 'none',
+    });
   });
 
   test('does not hide provider retries inside one adapter call', async () => {
@@ -118,9 +156,88 @@ describe('ModelAdapter.startStream onError', () => {
       void _event;
     }
 
-    assert.deepEqual(await result.request, {
-      messages: [{ role: 'user', content: 'hi' }],
+    assert.deepEqual(await result.outcome, {
+      kind: 'completed',
+      finishReason: 'stop',
+      usage: {
+        inputTokens: 1,
+        outputTokens: 1,
+        cacheHitInputTokens: 0,
+        cacheMissInputTokens: 1,
+        cacheMissInputSource: 'explicit',
+        cachedInputTokens: 0,
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 0,
+        totalTokens: 2,
+        rawFinishReason: 'stop',
+      },
+      request: { messages: [{ role: 'user', content: 'hi' }] },
+      continuation: 'none',
     });
+  });
+
+  test('settles a stream without a finish frame as truncated', async () => {
+    const outcome = await settle([
+      { type: 'stream-start', warnings: [] },
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: 'partial' },
+    ]);
+
+    assert.equal(outcome.kind, 'truncated');
+    if (outcome.kind !== 'truncated') return;
+    assert.equal(outcome.failure.message, 'Provider stream ended without finishing (other)');
+    assert.equal(outcome.continuation, 'none');
+  });
+
+  test('preserves a provider reason hidden by the SDK other bucket', async () => {
+    const outcome = await settle([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'finish',
+        finishReason: { unified: 'other', raw: 'eos_token' },
+        usage: ZERO_USAGE,
+      },
+    ]);
+
+    assert.equal(outcome.kind, 'completed');
+    if (outcome.kind !== 'completed') return;
+    assert.equal(outcome.finishReason, 'eos_token');
+    assert.equal(outcome.usage?.rawFinishReason, 'eos_token');
+  });
+
+  test('settles a content filter as a terminal failure', async () => {
+    const outcome = await settle([
+      { type: 'stream-start', warnings: [] },
+      {
+        type: 'finish',
+        finishReason: { unified: 'content-filter', raw: 'content_filter' },
+        usage: ZERO_USAGE,
+      },
+    ]);
+
+    assert.equal(outcome.kind, 'terminal-failure');
+    if (outcome.kind !== 'terminal-failure') return;
+    assert.equal(outcome.failure.kind, 'unknown');
+    assert.equal(outcome.failure.message, 'Provider stopped the stream on a content filter');
+  });
+
+  test('settles an aborted request as aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const outcome = await settle(
+      [
+        { type: 'stream-start', warnings: [] },
+        {
+          type: 'finish',
+          finishReason: { unified: 'stop', raw: 'stop' },
+          usage: ZERO_USAGE,
+        },
+      ],
+      controller.signal,
+    );
+
+    assert.equal(outcome.kind, 'aborted');
   });
 
   // streamText's default onError is `console.error(error)`, which dumps the
@@ -176,3 +293,23 @@ describe('ModelAdapter.startStream onError', () => {
     );
   });
 });
+
+async function settle(
+  chunks: LanguageModelV4StreamPart[],
+  abortSignal = new AbortController().signal,
+) {
+  const model = new MockLanguageModelV4({
+    doStream: async () => ({ stream: convertArrayToReadableStream(chunks) }),
+  });
+  const result = await newAdapter().startStream({
+    model,
+    messages: [{ role: 'user', content: 'hi' }],
+    tools: {},
+    activeTools: [],
+    onStreamActivity: () => {},
+    abortSignal,
+    repairToolCall: async () => null,
+  });
+  for await (const _event of result.events) void _event;
+  return await result.outcome;
+}

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -530,15 +530,8 @@ describe('ModelAdapter stream and error normalization', () => {
     );
     assert.equal(adapter.mapFinishReason('stop'), 'end_turn');
     assert.equal(adapter.mapFinishReason('length'), 'max_tokens');
-    assert.equal(adapter.mapFinishReason('content-filter'), 'error');
-    assert.equal(adapter.mapFinishReason('error'), 'error');
     assert.equal(adapter.mapFinishReason('tool-calls'), 'end_turn');
     assert.equal(adapter.mapFinishReason('provider-new-reason'), 'end_turn');
-    // Not the same as a new reason: these two are the SDK saying it cannot name
-    // why the stream stopped, which is what a dropped upstream connection looks
-    // like from here.
-    assert.equal(adapter.mapFinishReason('other'), 'error');
-    assert.equal(adapter.mapFinishReason('unknown'), 'error');
   });
 
   test('projects the final provider error inside an AI SDK retry wrapper', () => {

--- a/packages/runtime/src/__tests__/openai-responses-model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/openai-responses-model-adapter.test.ts
@@ -108,20 +108,26 @@ describe('OpenAI Responses ModelAdapter continuation', () => {
           stream: convertArrayToReadableStream<LanguageModelV4StreamPart>(
             providerCall === 1
               ? firstReasoningToolStep()
-              : [
-                  { type: 'stream-start', warnings: [] },
-                  {
-                    type: 'response-metadata',
-                    id: 'resp-2',
-                    modelId: 'gpt-5',
-                    timestamp: new Date(0),
-                  },
-                  {
-                    type: 'finish',
-                    finishReason: { unified: 'stop', raw: 'stop' },
-                    usage: ZERO_USAGE,
-                  },
-                ],
+              : providerCall === 2
+                ? [
+                    { type: 'stream-start', warnings: [] },
+                    {
+                      type: 'response-metadata',
+                      id: 'resp-2',
+                      modelId: 'gpt-5',
+                      timestamp: new Date(0),
+                    },
+                    {
+                      type: 'finish',
+                      finishReason: { unified: 'stop', raw: 'stop' },
+                      usage: ZERO_USAGE,
+                    },
+                  ]
+                : [
+                    { type: 'stream-start', warnings: [] },
+                    { type: 'text-start', id: 'text-3' },
+                    { type: 'text-delta', id: 'text-3', delta: 'partial' },
+                  ],
           ),
         };
       },
@@ -141,8 +147,10 @@ describe('OpenAI Responses ModelAdapter continuation', () => {
       openAiResponsesTransportState: transport,
     });
     const user: ModelMessage = { role: 'user', content: 'inspect it' };
-    await drain(adapter, model, [user], ['shell']);
+    const firstOutcome = await drain(adapter, model, [user], ['shell']);
 
+    assert.equal(firstOutcome.kind, 'completed');
+    assert.equal(firstOutcome.continuation, 'pending');
     assert.deepEqual(pending, {
       requestMessages: [user],
       responseId: 'resp-1',
@@ -184,6 +192,11 @@ describe('OpenAI Responses ModelAdapter continuation', () => {
       previousResponseId: 'resp-1',
     });
     assert.equal(calls[1]?.headers?.['x-maka-openai-responses-lane'], 'turn-1');
+
+    const truncated = await drain(adapter, model, [user], ['shell']);
+    assert.equal(truncated.kind, 'truncated');
+    assert.equal(pending, undefined);
+    assert.equal(baseline, undefined);
   });
 });
 
@@ -224,7 +237,7 @@ async function drain(
   model: MockLanguageModelV4,
   messages: ModelMessage[],
   activeTools: string[],
-): Promise<void> {
+) {
   const result = await adapter.startStream({
     model,
     messages,
@@ -236,4 +249,5 @@ async function drain(
     continuationKey: 'turn-1',
   });
   for await (const event of result.events) void event;
+  return await result.outcome;
 }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -93,6 +93,7 @@ import type {
   JSONValue,
   ModelFinishReason,
   ModelMessage,
+  ModelStepOutcome,
   ReasoningPart,
   ModelFailure,
   ModelToolSet,
@@ -925,15 +926,6 @@ function isIncompleteProviderFinishReason(reason: ModelFinishReason | undefined)
   return reason === undefined || reason === 'other' || reason === 'unknown';
 }
 
-function incompleteProviderStreamFailure(reason: ModelFinishReason | undefined): ModelFailure {
-  return {
-    type: 'model_failure',
-    kind: 'provider_unavailable',
-    retryable: false,
-    message: `Provider stream ended without finishing (${reason ?? 'missing'})`,
-  };
-}
-
 function sleepForProviderRetry(delayMs: number, signal: AbortSignal): Promise<void> {
   if (signal.aborted) {
     return Promise.reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
@@ -1472,7 +1464,6 @@ export class AiSdkBackend implements AgentBackend {
     let lastStepInputTokens: number | undefined;
     let streamStatus: LlmCallRecord['status'] = 'success';
     let streamErrorClass: string | undefined;
-    let streamedFinishReason: string | undefined;
     let runtimeSteps = 0;
     let requestShapeForTelemetry: RequestShapeDiagnostic | undefined;
     let promptSegmentsForTelemetry: PromptSegmentEstimate[] = [];
@@ -2035,7 +2026,9 @@ export class AiSdkBackend implements AgentBackend {
         let requestMessages: ModelMessage[] = messages;
         let overflowRetryUsed = false;
         let result: ModelStreamResult;
+        let providerOutcome: ModelStepOutcome;
         let finishReason: ModelFinishReason = 'stop';
+        let terminalProviderError: unknown;
         agentLoop: for (;;) {
           await this.drainSteeringInto(scope, input, queue);
           if (this.input.loadTurnRuntimeEvents) {
@@ -2095,7 +2088,6 @@ export class AiSdkBackend implements AgentBackend {
             let attemptSawToolActivity = false;
             let attemptSawContinuationMetadata = false;
             let attemptReachedStepBoundary = false;
-            let attemptStreamedFinishReason: ModelFinishReason | undefined;
             const attemptHasNoObservableOutput = () =>
               !attemptSawText &&
               !attemptSawThinking &&
@@ -2151,237 +2143,215 @@ export class AiSdkBackend implements AgentBackend {
               continuationKey: scope.turnId,
             });
 
-            let streamFailure: unknown;
-            let sawStreamError = false;
-            try {
-              for await (const event of result.events) {
-                if (scope.aborted) break;
-                if (event.kind === 'error') {
-                  // A request-level error ends this stream; capture it and stop
-                  // consuming (the synthesized trailer carries no real step) so
-                  // the recovery decision runs on the outcome, not the trailer.
-                  streamFailure = event.failure;
-                  sawStreamError = true;
-                  break;
-                }
-                const incompleteFinish =
-                  (event.kind === 'finish' || event.kind === 'step-finish') &&
-                  isIncompleteProviderFinishReason(event.finishReason);
-                if (
-                  (event.kind === 'finish' || event.kind === 'step-finish') &&
-                  !incompleteFinish
-                ) {
-                  attemptReachedStepBoundary = true;
-                }
-                if (event.kind === 'step-finish') {
-                  // AI SDK can synthesize `finish-step(other)` when the provider
-                  // stream reaches EOF without a terminal frame. That is not a
-                  // completed model step and must not consume the step budget or
-                  // checkpoint imaginary usage before the safe retry below.
-                  if (!incompleteFinish) {
-                    // Step boundary: AI SDK 7 delimits steps with `finish-step`
-                    // (and `step-finish` for legacy replay fixtures); the adapter
-                    // reduces both to this event. A duplicate boundary is harmless:
-                    // the second flush no-ops (accumulators already cleared) and one
-                    // extra id rotation just discards an unused id.
-                    runtimeSteps += 1;
-                    const stepUsage = event.usage;
-                    providerStepUsage = stepUsage;
-                    if (!stepUsage) sawUnusableStepUsage = true;
-                    // Fail closed: reset on every step boundary so a missing final
-                    // step's usage does not leave a stale value from an earlier step.
-                    lastStepInputTokens = stepUsage?.inputTokens;
-                    if (stepUsage) {
-                      completedStepUsage = mergeNormalizedUsage(completedStepUsage, stepUsage);
-                      this.cumulativeUsageCheckpoint = mergeNormalizedUsage(
-                        this.cumulativeUsageCheckpoint,
-                        stepUsage,
-                      );
-                      await this.input.recordUsageCheckpoint?.({
-                        ...this.cumulativeUsageCheckpoint,
-                        costUsd: this.computeTokenUsageCostUsd(this.cumulativeUsageCheckpoint),
-                      });
-                    }
-                  }
-                }
-                if (event.kind === 'finish' || event.kind === 'step-finish') {
-                  attemptStreamedFinishReason = event.finishReason ?? attemptStreamedFinishReason;
-                }
-                if (event.kind === 'text-start') {
-                  stepTextPartStartOffset = stepText.length;
-                } else if (event.kind === 'text') {
-                  stepText += event.text;
-                  if (event.text.length > 0) attemptSawText = true;
-                  queue.push({
-                    type: 'text_delta',
-                    id: this.newId(),
-                    turnId,
-                    ts: this.now(),
-                    messageId: currentStepMessageId,
-                    text: event.text,
-                  } satisfies TextDeltaEvent);
-                } else if (event.kind === 'text-metadata') {
-                  attemptSawContinuationMetadata = true;
-                  stepTextProviderOptions = mergeTextProviderOptions(
-                    stepTextProviderOptions,
-                    stripUndefinedDeep(event.providerOptions) as NonNullable<
-                      ModelMessage['providerOptions']
-                    >,
-                    stepTextPartStartOffset,
-                  );
-                } else if (event.kind === 'thinking') {
-                  sawStepThinking = true;
-                  stepThinking += event.text;
-                  if (event.text.length > 0) attemptSawThinking = true;
-                  if (event.providerOptions !== undefined) {
-                    if (event.providerOptionsOrigin !== 'maka_transport') {
-                      attemptSawContinuationMetadata = true;
-                    }
-                    stepThinkingProviderOptions = event.providerOptions;
-                  }
-                  const openai = event.providerOptions?.openai;
-                  const itemId =
-                    openai && typeof openai === 'object' && !Array.isArray(openai)
-                      ? (openai as { itemId?: unknown }).itemId
-                      : undefined;
-                  if (typeof itemId === 'string' && itemId.length > 0) {
-                    let part = stepResponsesThinkingParts.find(
-                      (candidate) =>
-                        (candidate.providerOptions?.openai as { itemId?: unknown } | undefined)
-                          ?.itemId === itemId,
+            for await (const event of result.events) {
+              if (scope.aborted) break;
+              if (event.kind === 'error') {
+                // Settlement owns the failure; stop before any synthesized
+                // trailer and consume the one authoritative outcome below.
+                break;
+              }
+              const incompleteFinish =
+                (event.kind === 'finish' || event.kind === 'step-finish') &&
+                isIncompleteProviderFinishReason(event.finishReason);
+              if ((event.kind === 'finish' || event.kind === 'step-finish') && !incompleteFinish) {
+                attemptReachedStepBoundary = true;
+              }
+              if (event.kind === 'step-finish') {
+                // AI SDK can synthesize `finish-step(other)` when the provider
+                // stream reaches EOF without a terminal frame. That is not a
+                // completed model step and must not consume the step budget or
+                // checkpoint imaginary usage before the safe retry below.
+                if (!incompleteFinish) {
+                  // Step boundary: AI SDK 7 delimits steps with `finish-step`
+                  // (and `step-finish` for legacy replay fixtures); the adapter
+                  // reduces both to this event. A duplicate boundary is harmless:
+                  // the second flush no-ops (accumulators already cleared) and one
+                  // extra id rotation just discards an unused id.
+                  runtimeSteps += 1;
+                  const stepUsage = event.usage;
+                  providerStepUsage = stepUsage;
+                  if (!stepUsage) sawUnusableStepUsage = true;
+                  // Fail closed: reset on every step boundary so a missing final
+                  // step's usage does not leave a stale value from an earlier step.
+                  lastStepInputTokens = stepUsage?.inputTokens;
+                  if (stepUsage) {
+                    completedStepUsage = mergeNormalizedUsage(completedStepUsage, stepUsage);
+                    this.cumulativeUsageCheckpoint = mergeNormalizedUsage(
+                      this.cumulativeUsageCheckpoint,
+                      stepUsage,
                     );
-                    if (!part) {
-                      part = {
-                        text:
-                          stepResponsesThinkingParts.length === 0 && event.text.length === 0
-                            ? stepThinking
-                            : '',
-                        providerOptions: event.providerOptions,
-                      };
-                      stepResponsesThinkingParts.push(part);
-                    } else {
-                      part.providerOptions = event.providerOptions;
-                    }
-                    part.text += event.text;
-                  } else if (stepResponsesThinkingParts.length > 0) {
-                    stepResponsesThinkingParts.at(-1)!.text += event.text;
-                  }
-                  queue.push({
-                    type: 'thinking_delta',
-                    id: this.newId(),
-                    turnId,
-                    ts: this.now(),
-                    messageId: currentStepMessageId,
-                    text: event.text,
-                  } satisfies ThinkingDeltaEvent);
-                } else if (event.kind === 'thinking-signature') {
-                  attemptSawContinuationMetadata = true;
-                  stepSignature = event.signature;
-                } else if (event.kind === 'provider-tool-input') {
-                  // The provider has started its own tool. Even without a
-                  // final tool-call/result event, retrying can repeat external
-                  // work that the Runtime cannot observe or reconcile.
-                  attemptSawToolActivity = true;
-                } else if (event.kind === 'tool-call') {
-                  attemptSawToolActivity = true;
-                  if (event.toolCall.providerExecuted) {
-                    providerToolActivityCount += 1;
-                    providerToolInputs.set(event.toolCall.toolCallId, event.toolCall.input);
-                    queue.push({
-                      type: 'tool_start',
-                      id: this.newId(),
-                      turnId,
-                      ts: this.now(),
-                      toolUseId: event.toolCall.toolCallId,
-                      toolName: event.toolCall.toolName,
-                      args: event.toolCall.input,
-                      providerExecuted: true,
-                      activityKind: 'websearch',
-                      displayName: 'Web search',
-                      stepId: currentStepMessageId,
-                      ...(event.toolCall.providerOptions !== undefined
-                        ? {
-                            providerOptions: stripUndefinedDeep(event.toolCall.providerOptions),
-                          }
-                        : {}),
-                    } satisfies ToolStartEvent);
-                  } else {
-                    returnedToolCalls.push(event.toolCall);
-                  }
-                } else if (event.kind === 'provider-tool-result') {
-                  attemptSawToolActivity = true;
-                  providerToolActivityCount += 1;
-                  const providerOutput = stripUndefinedDeep(event.output);
-                  queue.push({
-                    type: 'tool_result',
-                    id: this.newId(),
-                    turnId,
-                    ts: this.now(),
-                    toolUseId: event.toolCallId,
-                    providerExecuted: true,
-                    ...(providerOutput !== undefined ? { providerOutput } : {}),
-                    isError: event.isError === true,
-                    content: providerToolResultContent(
-                      event.toolName,
-                      providerOutput,
-                      providerToolInputs.get(event.toolCallId),
-                    ),
-                  } satisfies ToolResultEvent);
-                  providerToolInputs.delete(event.toolCallId);
-                } else if (event.kind === 'step-finish' && !incompleteFinish) {
-                  // The step's text/thinking deltas are all in (the stream is
-                  // drained in order), so flush this step's AssistantMessage and
-                  // rotate to a fresh id for the next step. Tool settlement
-                  // below receives this step's pre-rotation id, so durable replay
-                  // can regroup calls with this reasoning/text.
-                  await flushStep();
-                  if (midTurnState) {
-                    // Durability clock: step N's thinking/text completion events
-                    // are enqueued by flushStep just above, so only after this
-                    // boundary can a seq-ack wait for step N mean anything. Wake
-                    // waiters AFTER the increment or they would re-check a stale
-                    // count and sleep.
-                    midTurnState.flushedSteps += 1;
-                    queue.wake();
+                    await this.input.recordUsageCheckpoint?.({
+                      ...this.cumulativeUsageCheckpoint,
+                      costUsd: this.computeTokenUsageCostUsd(this.cumulativeUsageCheckpoint),
+                    });
                   }
                 }
               }
-            } catch (error) {
-              streamFailure = error;
-              sawStreamError = true;
+              if (event.kind === 'text-start') {
+                stepTextPartStartOffset = stepText.length;
+              } else if (event.kind === 'text') {
+                stepText += event.text;
+                if (event.text.length > 0) attemptSawText = true;
+                queue.push({
+                  type: 'text_delta',
+                  id: this.newId(),
+                  turnId,
+                  ts: this.now(),
+                  messageId: currentStepMessageId,
+                  text: event.text,
+                } satisfies TextDeltaEvent);
+              } else if (event.kind === 'text-metadata') {
+                attemptSawContinuationMetadata = true;
+                stepTextProviderOptions = mergeTextProviderOptions(
+                  stepTextProviderOptions,
+                  stripUndefinedDeep(event.providerOptions) as NonNullable<
+                    ModelMessage['providerOptions']
+                  >,
+                  stepTextPartStartOffset,
+                );
+              } else if (event.kind === 'thinking') {
+                sawStepThinking = true;
+                stepThinking += event.text;
+                if (event.text.length > 0) attemptSawThinking = true;
+                if (event.providerOptions !== undefined) {
+                  if (event.providerOptionsOrigin !== 'maka_transport') {
+                    attemptSawContinuationMetadata = true;
+                  }
+                  stepThinkingProviderOptions = event.providerOptions;
+                }
+                const openai = event.providerOptions?.openai;
+                const itemId =
+                  openai && typeof openai === 'object' && !Array.isArray(openai)
+                    ? (openai as { itemId?: unknown }).itemId
+                    : undefined;
+                if (typeof itemId === 'string' && itemId.length > 0) {
+                  let part = stepResponsesThinkingParts.find(
+                    (candidate) =>
+                      (candidate.providerOptions?.openai as { itemId?: unknown } | undefined)
+                        ?.itemId === itemId,
+                  );
+                  if (!part) {
+                    part = {
+                      text:
+                        stepResponsesThinkingParts.length === 0 && event.text.length === 0
+                          ? stepThinking
+                          : '',
+                      providerOptions: event.providerOptions,
+                    };
+                    stepResponsesThinkingParts.push(part);
+                  } else {
+                    part.providerOptions = event.providerOptions;
+                  }
+                  part.text += event.text;
+                } else if (stepResponsesThinkingParts.length > 0) {
+                  stepResponsesThinkingParts.at(-1)!.text += event.text;
+                }
+                queue.push({
+                  type: 'thinking_delta',
+                  id: this.newId(),
+                  turnId,
+                  ts: this.now(),
+                  messageId: currentStepMessageId,
+                  text: event.text,
+                } satisfies ThinkingDeltaEvent);
+              } else if (event.kind === 'thinking-signature') {
+                attemptSawContinuationMetadata = true;
+                stepSignature = event.signature;
+              } else if (event.kind === 'provider-tool-input') {
+                // The provider has started its own tool. Even without a
+                // final tool-call/result event, retrying can repeat external
+                // work that the Runtime cannot observe or reconcile.
+                attemptSawToolActivity = true;
+              } else if (event.kind === 'tool-call') {
+                attemptSawToolActivity = true;
+                if (event.toolCall.providerExecuted) {
+                  providerToolActivityCount += 1;
+                  providerToolInputs.set(event.toolCall.toolCallId, event.toolCall.input);
+                  queue.push({
+                    type: 'tool_start',
+                    id: this.newId(),
+                    turnId,
+                    ts: this.now(),
+                    toolUseId: event.toolCall.toolCallId,
+                    toolName: event.toolCall.toolName,
+                    args: event.toolCall.input,
+                    providerExecuted: true,
+                    activityKind: 'websearch',
+                    displayName: 'Web search',
+                    stepId: currentStepMessageId,
+                    ...(event.toolCall.providerOptions !== undefined
+                      ? {
+                          providerOptions: stripUndefinedDeep(event.toolCall.providerOptions),
+                        }
+                      : {}),
+                  } satisfies ToolStartEvent);
+                } else {
+                  returnedToolCalls.push(event.toolCall);
+                }
+              } else if (event.kind === 'provider-tool-result') {
+                attemptSawToolActivity = true;
+                providerToolActivityCount += 1;
+                const providerOutput = stripUndefinedDeep(event.output);
+                queue.push({
+                  type: 'tool_result',
+                  id: this.newId(),
+                  turnId,
+                  ts: this.now(),
+                  toolUseId: event.toolCallId,
+                  providerExecuted: true,
+                  ...(providerOutput !== undefined ? { providerOutput } : {}),
+                  isError: event.isError === true,
+                  content: providerToolResultContent(
+                    event.toolName,
+                    providerOutput,
+                    providerToolInputs.get(event.toolCallId),
+                  ),
+                } satisfies ToolResultEvent);
+                providerToolInputs.delete(event.toolCallId);
+              } else if (event.kind === 'step-finish' && !incompleteFinish) {
+                // The step's text/thinking deltas are all in (the stream is
+                // drained in order), so flush this step's AssistantMessage and
+                // rotate to a fresh id for the next step. Tool settlement
+                // below receives this step's pre-rotation id, so durable replay
+                // can regroup calls with this reasoning/text.
+                await flushStep();
+                if (midTurnState) {
+                  // Durability clock: step N's thinking/text completion events
+                  // are enqueued by flushStep just above, so only after this
+                  // boundary can a seq-ack wait for step N mean anything. Wake
+                  // waiters AFTER the increment or they would re-check a stale
+                  // count and sleep.
+                  midTurnState.flushedSteps += 1;
+                  queue.wake();
+                }
+              }
             }
             watchdogState.current?.stop();
             // This timeout belongs to the physical request that just settled.
             // Consume it before recovery/flush work: a later persistence error
             // must not be reported as the already-handled watchdog timeout.
             const settledWatchdogTimeout = consumeWatchdogTimeout();
-            if (!sawStreamError && settledWatchdogTimeout) {
-              streamFailure = settledWatchdogTimeout.error;
-              sawStreamError = true;
-            }
+            providerOutcome = await result.outcome;
+            const incompleteStreamTerminal = providerOutcome.kind === 'truncated';
+            const incompleteStreamHasNoObservableOutput =
+              incompleteStreamTerminal &&
+              !attemptSawText &&
+              !attemptSawThinking &&
+              !attemptSawToolActivity &&
+              !attemptSawContinuationMetadata;
+            const attemptFailure =
+              settledWatchdogTimeout?.error ??
+              (providerOutcome.kind === 'completed' ? undefined : providerOutcome.failure);
 
-            let incompleteStreamTerminal = false;
-            let incompleteStreamHasNoObservableOutput = false;
-            if (!sawStreamError) {
-              const settledFinishReason =
-                attemptStreamedFinishReason ?? (await result.finishReason.catch(() => undefined));
-              if (isIncompleteProviderFinishReason(settledFinishReason)) {
-                streamFailure = incompleteProviderStreamFailure(settledFinishReason);
-                sawStreamError = true;
-                incompleteStreamTerminal = true;
-                incompleteStreamHasNoObservableOutput =
-                  !attemptSawText &&
-                  !attemptSawThinking &&
-                  !attemptSawToolActivity &&
-                  !attemptSawContinuationMetadata;
-              } else {
-                streamedFinishReason = settledFinishReason;
+            if (attemptFailure && !scope.aborted && !midTurnState?.exhaustedDetail) {
+              const failure =
+                settledWatchdogTimeout || providerOutcome.kind === 'completed'
+                  ? this.modelAdapter.normalizeFailure(attemptFailure)
+                  : providerOutcome.failure;
+              if (scope.loopStopRequested) {
+                terminalProviderError = settledWatchdogTimeout?.error ?? failure;
+                break agentLoop;
               }
-            }
-
-            if (sawStreamError && !scope.aborted) {
-              const attemptFailure = settledWatchdogTimeout?.error ?? streamFailure;
-              if (scope.loopStopRequested) throw attemptFailure;
               // A retry is a fresh provider request that would run at least one
               // more step; with the send-level budget already spent there is
               // nothing left to grant it, so the error is terminal.
@@ -2423,7 +2393,6 @@ export class AiSdkBackend implements AgentBackend {
                 attemptMessages = recoveredProjection?.messages ?? recovered.messages;
                 continue;
               }
-              const failure = this.modelAdapter.normalizeFailure(attemptFailure);
               const idleWatchdogRecovery =
                 settledWatchdogTimeout?.phase === 'idle' &&
                 idleWatchdogRetryCount < MAX_IDLE_WATCHDOG_RETRIES_PER_STEP &&
@@ -2483,8 +2452,10 @@ export class AiSdkBackend implements AgentBackend {
               }
               // Unrecoverable (not context-length, latch spent, no seam, or no
               // safe fold): surface the real provider error via the terminal
-              // handler — never a fabricated success.
-              throw attemptFailure;
+              // handler after settling any authoritative usage — never a
+              // fabricated success.
+              terminalProviderError = settledWatchdogTimeout?.error ?? failure;
+              break agentLoop;
             }
             break;
           }
@@ -2512,13 +2483,8 @@ export class AiSdkBackend implements AgentBackend {
           const providerStepId = currentStepMessageId;
           await flushStep();
 
-          // The settled promise reports only the SDK's unified enum; the stream
-          // events carry what the provider itself said, which is strictly more
-          // specific and is already what telemetry prefers below. Reading the
-          // same value here keeps the turn's outcome and its record from
-          // disagreeing about why the stream ended.
-          finishReason =
-            streamedFinishReason ?? (await result.finishReason.catch(() => 'stop')) ?? 'stop';
+          if (providerOutcome.kind !== 'completed') throw providerOutcome.failure;
+          finishReason = providerOutcome.finishReason;
           await queue.waitUntilConsumedThroughCurrent();
 
           if (returnedToolCalls.length > 0) {
@@ -2608,10 +2574,7 @@ export class AiSdkBackend implements AgentBackend {
               (maxSteps === undefined || runtimeSteps < maxSteps) &&
               !scope.loopStopRequested &&
               !scope.aborted;
-            if (
-              continuationWillRun &&
-              this.modelAdapter.continuationResponsePending(scope.turnId)
-            ) {
+            if (continuationWillRun && providerOutcome.continuation === 'pending') {
               const persistedProjection = await loadDurableTurnProjection();
               const responseMessages = persistedOpenAiResponsesStepMessages(
                 attemptMessages,
@@ -2660,7 +2623,7 @@ export class AiSdkBackend implements AgentBackend {
         // silently drop prior requests. An unusable sample in ANY request fails
         // the whole record closed (#972).
         try {
-          const attemptTotalUsage = await result.usage;
+          const attemptTotalUsage = providerOutcome.usage;
           tokenUsage = sawUnusableStepUsage ? undefined : (completedStepUsage ?? attemptTotalUsage);
           if (tokenUsage) {
             const systemPromptHash = turnDiagnostics.requestShape.componentHashes.systemPromptHash;
@@ -2786,33 +2749,13 @@ export class AiSdkBackend implements AgentBackend {
         // Nothing may await between this check and terminal emission: Stop must
         // win even when it arrives during post-stream usage persistence.
         if (scope.aborted) throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+        if (terminalProviderError) throw terminalProviderError;
         const stopReason =
           scope.loopStopReason ??
           (maxSteps !== undefined && finishReason === 'tool-calls'
             ? 'step_limit'
             : this.mapFinishReason(finishReason));
-        if (stopReason === 'error') {
-          // Reaching a failed terminal without anything having been thrown.
-          // Every other `stopReason: 'error'` here comes out of the catch below
-          // with an error event and a failed trace behind it, and the session's
-          // `lastError` and the request ledger are fed by exactly those. Ending
-          // the turn failed while the telemetry still reads `success` is the
-          // same blindness this branch exists to remove.
-          //
-          // Two different things arrive here and the message says which: the
-          // provider stopping the stream on its own policy, and a stop nothing
-          // named at all.
-          const err =
-            finishReason === 'content-filter'
-              ? new Error('Provider stopped the stream on a content filter')
-              : incompleteProviderStreamFailure(finishReason);
-          streamStatus = 'error';
-          streamErrorClass = this.modelAdapter.classifyError(err);
-          queue.push(this.makeErrorEvent(turnId, err));
-          trace.modelStreamFailed(streamErrorClass, err, priorReplayFailureTrace(priorReplay));
-        } else {
-          trace.modelStreamCompleted(stopReason);
-        }
+        trace.modelStreamCompleted(stopReason);
         const completeEvent = {
           type: 'complete',
           id: this.newId(),
@@ -3155,8 +3098,8 @@ export class AiSdkBackend implements AgentBackend {
     this.modelAdapter.dispose();
   }
 
-  /** Map ai-sdk finishReason → our CompleteEvent.stopReason. */
-  private mapFinishReason(reason: unknown): CompleteEvent['stopReason'] {
+  /** Map a completed provider finish reason → our CompleteEvent.stopReason. */
+  private mapFinishReason(reason: ModelFinishReason): CompleteEvent['stopReason'] {
     return this.modelAdapter.mapFinishReason(reason);
   }
 

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -15,6 +15,7 @@ import type {
   RawUsageFields,
   ModelStreamEvent,
   ModelStreamResult,
+  ModelStepOutcome,
   ModelFinishReason,
   ModelFailure,
   ModelFailureKind,
@@ -27,6 +28,7 @@ export type {
   RawUsageFields,
   ModelStreamEvent,
   ModelStreamResult,
+  ModelStepOutcome,
   ModelFinishReason,
   ModelFailure,
   ModelFailureKind,
@@ -290,6 +292,7 @@ export class ModelAdapter {
     return this.toModelStreamResult(sdkResult, input.onStreamActivity, {
       ...(responsesLane ? { lane: responsesLane } : {}),
       requestMessages: fullMessages,
+      abortSignal: input.abortSignal,
     });
   }
 
@@ -302,63 +305,82 @@ export class ModelAdapter {
   private toModelStreamResult(
     sdk: SdkStreamResult,
     onStreamActivity: () => void,
-    continuation: { lane?: string; requestMessages: ModelMessage[] },
+    continuation: { lane?: string; requestMessages: ModelMessage[]; abortSignal: AbortSignal },
   ): ModelStreamResult {
     const openAiChatReasoningTransportState =
       this.runtime.reasoningReplay.kind === 'openai-chat-plaintext'
         ? this.openAiChatReasoningTransportState
         : undefined;
     const openAiResponsesTransportState = this.openAiResponsesTransportState;
+    let settleOutcome!: (outcome: ModelStepOutcome) => void;
+    const outcome = new Promise<ModelStepOutcome>((resolve) => {
+      settleOutcome = resolve;
+    });
+    const request = { messages: continuation.requestMessages };
     const events: AsyncIterable<ModelStreamEvent> = {
       async *[Symbol.asyncIterator]() {
-        let succeeded = true;
+        let failure: ModelFailure | undefined;
+        let sawFinish = false;
+        let streamedFinishReason: string | undefined;
         try {
           for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
             onStreamActivity();
             for (const event of translateChunk(chunk, openAiChatReasoningTransportState)) {
-              if (event.kind === 'error') succeeded = false;
+              if (event.kind === 'error') failure = event.failure;
+              if (event.kind === 'finish') sawFinish = true;
+              if (event.kind === 'finish' || event.kind === 'step-finish') {
+                streamedFinishReason = event.finishReason ?? streamedFinishReason;
+              }
               yield event;
             }
           }
         } catch (error) {
-          succeeded = false;
-          yield { kind: 'error', failure: normalizeProviderFailure(error) };
+          failure = normalizeProviderFailure(error);
+          yield { kind: 'error', failure };
         } finally {
-          if (!continuation.lane) return;
-          if (!succeeded) {
-            openAiResponsesTransportState.clearSemantic(continuation.lane);
-            return;
-          }
-          const response = await Promise.resolve(sdk.response).catch(() => undefined);
-          if (
-            response?.id &&
-            openAiResponsesTransportState.canRecordSemantic(continuation.lane, response.id)
-          ) {
-            openAiResponsesTransportState.recordSemanticRequest(continuation.lane, {
-              requestMessages: structuredClone(continuation.requestMessages),
-              responseId: response.id,
-            });
-          } else {
-            openAiResponsesTransportState.clearSemantic(continuation.lane);
+          const [sdkUsage, sdkFinishReason] = await Promise.all([
+            sdk.usage.catch(() => undefined),
+            sdk.finishReason.catch(() => undefined),
+          ]);
+          const finishReason =
+            streamedFinishReason ?? rawFinishReasonString(sdkFinishReason) ?? 'unknown';
+          const usage = normalizeAiSdkUsage(sdkUsage, { rawFinishReason: finishReason });
+          let settled = settleModelStepOutcome({
+            aborted: continuation.abortSignal.aborted,
+            failure,
+            sawFinish,
+            finishReason,
+            usage,
+            request,
+          });
+
+          try {
+            if (continuation.lane) {
+              if (settled.kind === 'completed') {
+                const response = await Promise.resolve(sdk.response).catch(() => undefined);
+                if (
+                  response?.id &&
+                  openAiResponsesTransportState.canRecordSemantic(continuation.lane, response.id)
+                ) {
+                  openAiResponsesTransportState.recordSemanticRequest(continuation.lane, {
+                    requestMessages: structuredClone(continuation.requestMessages),
+                    responseId: response.id,
+                  });
+                  settled = { ...settled, continuation: 'pending' };
+                } else {
+                  openAiResponsesTransportState.clearSemantic(continuation.lane);
+                }
+              } else {
+                openAiResponsesTransportState.clearSemantic(continuation.lane);
+              }
+            }
+          } finally {
+            settleOutcome(settled);
           }
         }
       },
     };
-    const usage = (async () => {
-      const [sdkUsage, sdkFinishReason] = await Promise.all([
-        sdk.usage.catch(() => undefined),
-        sdk.finishReason.catch(() => undefined),
-      ]);
-      return normalizeAiSdkUsage(sdkUsage, { rawFinishReason: sdkFinishReason });
-    })();
-    const finishReason = (async () =>
-      rawFinishReasonString(await sdk.finishReason.catch(() => undefined)))();
-    // The SDK request contains only the wire delta during continuation. Keep
-    // Maka's public request metadata anchored to the complete durable
-    // projection so diagnostics and recovery never mistake an optimization for
-    // lost history.
-    const request = Promise.resolve({ messages: continuation.requestMessages });
-    return { events, usage, finishReason, request };
+    return { events, outcome };
   }
 
   endContinuation(lane: string): void {
@@ -367,10 +389,6 @@ export class ModelAdapter {
 
   recordContinuationResponse(lane: string, responseMessages: readonly ModelMessage[]): void {
     this.openAiResponsesTransportState.recordSemanticResponse(lane, responseMessages);
-  }
-
-  continuationResponsePending(lane: string): boolean {
-    return this.openAiResponsesTransportState.hasPendingSemantic(lane);
   }
 
   clearContinuation(lane: string): void {
@@ -468,40 +486,98 @@ export class ModelAdapter {
     return classifyError(error);
   }
 
-  mapFinishReason(reason: unknown): CompleteEvent['stopReason'] {
+  /** Map a successfully settled provider step to its runtime stop reason. */
+  mapFinishReason(reason: ModelFinishReason): CompleteEvent['stopReason'] {
     switch (reason) {
       case 'stop':
         return 'end_turn';
       case 'length':
         return 'max_tokens';
-      case 'content-filter':
-        return 'error';
-      case 'error':
-        return 'error';
       case 'tool-calls':
         return 'end_turn';
-      // The SDK's own two names for "the stream stopped and nothing named why".
-      // An upstream that drops the connection mid-answer lands here: it yields
-      // no error part and throws nothing, so these are the only signal that it
-      // happened. Calling them `end_turn` asserts the model said its piece —
-      // the one thing we know we cannot claim. A recorded run once reached
-      // `status: completed` on exactly this shape while its agent was still
-      // mid-task, caught only because the terminal SSE event never arrived.
-      //
-      // These are reached when nothing else named the stop: the SDK buckets
-      // every reason it does not recognize into `other` too, and
-      // `translateChunk` forwards the provider's own spelling in that case, so
-      // a genuinely new reason arrives here as itself and takes the tolerant
-      // default below. A provider spelling its reason `other` is
-      // indistinguishable from the bucket and lands here; the ambiguity is
-      // real and this resolves it toward the safe answer.
-      case 'other':
-      case 'unknown':
-        return 'error';
       default:
         return 'end_turn';
     }
   }
+}
+
+interface ModelStepSettlementEvidence {
+  aborted: boolean;
+  failure?: ModelFailure;
+  sawFinish: boolean;
+  finishReason: ModelFinishReason;
+  usage?: NormalizedUsage;
+  request: ModelRequestMetadata;
+}
+
+export function settleModelStepOutcome(evidence: ModelStepSettlementEvidence): ModelStepOutcome {
+  const { aborted, failure, sawFinish, finishReason, usage, request } = evidence;
+  if (aborted || failure?.kind === 'abort') {
+    return failedStepOutcome(
+      'aborted',
+      failure ?? normalizeModelFailure(Object.assign(new Error('aborted'), { name: 'AbortError' })),
+      request,
+      usage,
+    );
+  }
+  if (failure) {
+    return failedStepOutcome(
+      failure.retryable ? 'retryable-failure' : 'terminal-failure',
+      failure,
+      request,
+      usage,
+    );
+  }
+  if (!sawFinish || finishReason === 'other' || finishReason === 'unknown') {
+    return failedStepOutcome(
+      'truncated',
+      modelStepFailure(
+        'provider_unavailable',
+        `Provider stream ended without finishing (${finishReason})`,
+      ),
+      request,
+      usage,
+    );
+  }
+  if (finishReason === 'content-filter' || finishReason === 'error') {
+    return failedStepOutcome(
+      'terminal-failure',
+      modelStepFailure(
+        finishReason === 'content-filter' ? 'unknown' : 'provider_unavailable',
+        finishReason === 'content-filter'
+          ? 'Provider stopped the stream on a content filter'
+          : 'Provider stopped the stream with an error',
+      ),
+      request,
+      usage,
+    );
+  }
+  return {
+    kind: 'completed',
+    finishReason,
+    ...(usage ? { usage } : {}),
+    request,
+    continuation: 'none',
+  };
+}
+
+function modelStepFailure(kind: ModelFailureKind, message: string): ModelFailure {
+  return { type: 'model_failure', kind, message, retryable: false };
+}
+
+function failedStepOutcome(
+  kind: Exclude<ModelStepOutcome['kind'], 'completed'>,
+  failure: ModelFailure,
+  request: ModelRequestMetadata,
+  usage?: NormalizedUsage,
+): Exclude<ModelStepOutcome, { kind: 'completed' }> {
+  return {
+    kind,
+    failure,
+    ...(usage ? { usage } : {}),
+    request,
+    continuation: 'none',
+  };
 }
 
 function selectedModelMaxOutputTokens(

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -395,16 +395,24 @@ export type ModelStreamEvent =
   | { kind: 'finish'; finishReason?: ModelFinishReason }
   | { kind: 'error'; failure: ModelFailure };
 
-/**
- * Maka-owned result of a single `ModelAdapter.startStream` provider call. The
- * backend consumes `events` for streaming + step accounting, awaits `usage`
- * for the final billing-relevant token totals, `finishReason` for the terminal
- * stop reason, and `request` for the final Maka-owned message projection. All
- * four are normalized to Maka-owned types; no AI SDK type crosses this surface.
- */
+export type ModelStepOutcome =
+  | {
+      kind: 'completed';
+      finishReason: ModelFinishReason;
+      usage?: NormalizedUsage;
+      request: ModelRequestMetadata;
+      continuation: 'none' | 'pending';
+    }
+  | {
+      kind: 'truncated' | 'retryable-failure' | 'terminal-failure' | 'aborted';
+      failure: ModelFailure;
+      usage?: NormalizedUsage;
+      request: ModelRequestMetadata;
+      continuation: 'none';
+    };
+
+/** One physical provider request: live output plus one authoritative settlement. */
 export interface ModelStreamResult {
   events: AsyncIterable<ModelStreamEvent>;
-  usage: Promise<NormalizedUsage | undefined>;
-  finishReason: Promise<ModelFinishReason | undefined>;
-  request: Promise<ModelRequestMetadata | undefined>;
+  outcome: Promise<ModelStepOutcome>;
 }


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- replace split provider-step signals with one settled `ModelStepOutcome`
- classify every physical provider request as completed, truncated, retryable failure, terminal failure, or aborted
- preserve raw provider finish reasons and commit continuation only after successful settlement
- remove duplicated provider-outcome logic from `AiSdkBackend`, reducing the backend by about 54 lines

## Architecture

`ModelAdapter` now owns provider evidence interpretation. Each `ModelStreamResult` exposes two Maka-owned channels: normalized streaming `events` for live output and one `outcome` promise for authoritative settlement.

The outcome combines completion or failure, normalized usage, request metadata, and continuation viability. `AiSdkBackend` consumes it without reconstructing provider success from independent signals, while retaining ownership of turn-loop orchestration, retry policy, tool execution, persistence, telemetry emission, and terminal events.

Provider-specific continuation transport retains its protocol mechanics, but continuation state is committed only after a completed settlement and cleared for truncation, failure, or abort. This deepens the existing adapter boundary without adding another pass-through module.

## Behavior note

Mid-turn context exhaustion now follows the dedicated `context_budget_exhausted` completion path instead of entering generic provider-error recovery.

## Verification

- runtime build — passed
- backend, mid-turn capacity, and ModelAdapter tests — 314 passed
- git diff --check — passed

## Exclusions

This PR does not change retry limits or backoff policy, move turn-loop or persistence ownership into `ModelAdapter`, rewrite provider transports, or add provider adapters.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

- 将分散的 provider-step 信号收敛为唯一的 `ModelStepOutcome`
- 每个物理 provider request 只会被结算为 completed、truncated、retryable failure、terminal failure 或 aborted
- 保留原始 provider finish reason，且仅在 settlement 成功后提交 continuation
- 删除 `AiSdkBackend` 中重复的 provider-outcome 逻辑，使 backend 净减约 54 行

## 架构

`ModelAdapter` 现在负责解释完整的 provider evidence。每个 `ModelStreamResult` 对外提供两条 Maka 自有通道：用于实时输出的 normalized streaming `events`，以及用于权威结算的唯一 `outcome` promise。

Outcome 统一承载 completion 或 failure、normalized usage、request metadata 和 continuation viability。`AiSdkBackend` 直接消费 outcome，不再通过多组独立信号重新推断 provider request 是否成功；它继续负责 turn loop 编排、retry policy、tool execution、持久化、telemetry emission 和 terminal event。

Provider-specific continuation transport 仍负责协议细节，但 continuation state 仅在 completed settlement 后提交，在 truncated、failure 或 aborted 时清理。这一实现深化了现有 adapter 边界，没有新增仅负责转发的 module。

## 行为说明

Mid-turn context 耗尽现在确定走专用的 `context_budget_exhausted` 完成路径，不再进入通用 provider error recovery。

## 验证

- runtime build — 通过
- backend、mid-turn capacity 与 ModelAdapter 测试 — 314 项通过
- git diff --check — 通过

## 不在范围内

本 PR 不修改 retry 次数或 backoff policy，不将 turn loop 或持久化职责移入 `ModelAdapter`，不重写 provider transport，也不增加 provider adapter。

</details>

Closes #2416
