### PR TITLE
refactor(runtime-host): centralize workspace authority

### DIFF
--- a/apps/desktop/src/main/__tests__/new-session-project.test.ts
+++ b/apps/desktop/src/main/__tests__/new-session-project.test.ts
@@ -1,290 +1,100 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { test } from 'node:test';
-import { createProjectCatalog } from '@maka/storage';
-import {
-  resolveDesktopSessionSelection,
-  resolveNewSessionProjectInput,
-  type SessionProjectInput,
-} from '../new-session-project.js';
+import { resolveDesktopSessionWorkspace } from '../new-session-project.js';
 
-type CreateSessionInput = SessionProjectInput & {
-  cwd: string;
-  backend: string;
-  llmConnectionSlug: string;
-  model: string;
-  permissionMode: string;
-  name: string;
-  labels: string[];
-};
-type DesktopCreateSessionInput = Omit<CreateSessionInput, 'cwd'>;
-
-test('default sessions inherit and register the current Desktop project', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-new-session-project-'));
-  const cwd = join(base, 'project');
-  await mkdir(cwd);
-  const catalog = createProjectCatalog(join(base, 'storage'), {
-    createId: () => 'project-1',
-  });
-
-  try {
-    const selected = await resolveDesktopSessionSelection(
-      {},
-      {
-        current: async () => ({ projectId: undefined, path: cwd }),
-        select: async () => {
-          throw new Error('select must not be called');
-        },
-      },
-    );
-    const resolved = await resolveNewSessionProjectInput(selected, catalog);
-
-    assert.equal(resolved.cwd, await realpath(cwd));
-    assert.equal(resolved.projectId, 'project-1');
-    assert.equal((await catalog.list()).length, 1);
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
-});
-
-test('an explicit project selection resolves its path before Session creation', async () => {
-  const selected = await resolveDesktopSessionSelection(
-    { projectId: 'project-2' },
-    {
-      current: async () => {
-        throw new Error('current must not be called');
-      },
-      select: async (projectId) => ({
-        project: { id: projectId as string },
-        path: '/project-2/root',
-      }),
-    },
+test('registers an explicit unassociated Desktop directory as a Project target', async () => {
+  assert.deepEqual(
+    await resolveDesktopSessionWorkspace(
+      { cwd: '/workspace' },
+      selection(),
+      { register: async () => ({ id: 'project-1' }) as never },
+    ),
+    { kind: 'project', projectId: 'project-1' },
   );
-
-  assert.deepEqual(selected, {
-    cwd: '/project-2/root',
-    projectId: 'project-2',
-  });
 });
 
-test('an explicit no-project Session keeps its directory unassigned', async () => {
-  const input = { cwd: '/standalone', projectId: null } as const;
-  const resolved = await resolveNewSessionProjectInput(input, {
-    list: async () => {
-      throw new Error('list must not be called');
-    },
-    register: async () => {
-      throw new Error('register must not be called');
-    },
-    touch: async () => {
-      throw new Error('touch must not be called');
-    },
-  });
-
-  assert.equal(resolved, input);
+test('preserves an explicit no-Project directory as a Host-path target', async () => {
+  assert.deepEqual(
+    await resolveDesktopSessionWorkspace(
+      { cwd: '/standalone', projectId: null },
+      selection(),
+      { register: unexpected },
+    ),
+    { kind: 'host_path', path: '/standalone' },
+  );
 });
 
-test('a Session cannot associate a project with a different directory', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-new-session-project-mismatch-'));
-  const first = join(base, 'first');
-  const second = join(base, 'second');
-  await mkdir(first);
-  await mkdir(second);
-  const catalog = createProjectCatalog(join(base, 'storage'), {
-    createId: () => 'project-1',
-  });
-
-  try {
-    await catalog.register(first);
-    await assert.rejects(
-      () =>
-        resolveNewSessionProjectInput(
-          { cwd: second, projectId: 'project-1' },
-          catalog,
-        ),
-      /does not match/i,
-    );
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
-});
-test('new sessions preserve unexpected catalog failures', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-new-session-project-storage-failure-'));
-  const cwd = join(base, 'project');
-  await mkdir(cwd);
-  const catalog = createProjectCatalog(join(base, 'storage'), {
-    createId: () => 'project-1',
-  });
-
-  try {
-    await catalog.register(cwd);
-    const storageFailure = new Error('catalog write failed');
-    await assert.rejects(
-      () =>
-        resolveNewSessionProjectInput(makeInput(cwd, { projectId: 'project-1' }), {
-          list: () => catalog.list(),
-          register: (path) => catalog.register(path),
-          touch: async () => {
-            throw storageFailure;
-          },
-        }),
-      (error) => error === storageFailure,
-    );
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
+test('uses an explicit Project identity without trusting the Client directory', async () => {
+  assert.deepEqual(
+    await resolveDesktopSessionWorkspace(
+      { cwd: '/stale/client/path', projectId: 'project-1' },
+      selection(),
+      { register: unexpected },
+    ),
+    { kind: 'project', projectId: 'project-1' },
+  );
 });
 
-test('new sessions persist the catalog canonical path instead of a symlink alias', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-new-session-project-canonical-'));
-  const projectPath = join(base, 'project');
-  const aliasPath = join(base, 'project-alias');
-  await mkdir(projectPath);
-  await symlink(projectPath, aliasPath, 'dir');
-  const catalog = createProjectCatalog(join(base, 'storage'), {
-    createId: () => 'project-1',
-  });
-
-  try {
-    const project = await catalog.register(projectPath);
-    const resolved = await resolveNewSessionProjectInput(
-      makeInput(aliasPath, { projectId: project.id }),
-      catalog,
-    );
-
-    assert.equal(resolved.cwd, await realpath(projectPath));
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
+test('uses the configured default before the current Project preference', async () => {
+  assert.deepEqual(
+    await resolveDesktopSessionWorkspace(
+      {},
+      selection({
+        current: { projectId: 'current', path: '/current' },
+        defaultProjectId: 'default',
+      }),
+      { register: unexpected },
+    ),
+    { kind: 'project', projectId: 'default' },
+  );
 });
 
-test('new sessions resolve a merged project alias to the surviving project id', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-new-session-project-merged-alias-'));
-  const cwd = join(base, 'relocated');
-  await mkdir(cwd);
-  let id = 0;
-  const catalog = createProjectCatalog(join(base, 'storage'), {
-    createId: () => `project-${++id}`,
-  });
-
-  try {
-    const originalPath = join(base, 'original');
-    await mkdir(originalPath);
-    const original = await catalog.register(originalPath);
-    await rm(originalPath, { recursive: true, force: true });
-    const duplicate = await catalog.register(cwd);
-    await catalog.relinkWithSessions(original.id, cwd);
-
-    const resolved = await resolveNewSessionProjectInput(
-      makeInput(cwd, { projectId: duplicate.id }),
-      catalog,
-    );
-
-    assert.equal(resolved.projectId, original.id);
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
+test('falls back to the current preference when the configured default is stale', async () => {
+  assert.deepEqual(
+    await resolveDesktopSessionWorkspace(
+      {},
+      selection({
+        current: { projectId: 'current', path: '/current' },
+        defaultProjectId: 'missing',
+        unavailableIds: ['missing'],
+      }),
+      { register: unexpected },
+    ),
+    { kind: 'project', projectId: 'current' },
+  );
 });
 
-function makeInput(
-  cwd: string,
-  overrides: Partial<CreateSessionInput> = {},
-): CreateSessionInput {
+test('falls back to the current Host path when no Project preference exists', async () => {
+  assert.deepEqual(
+    await resolveDesktopSessionWorkspace(
+      {},
+      selection({ current: { projectId: null, path: '/standalone' } }),
+      { register: unexpected },
+    ),
+    { kind: 'host_path', path: '/standalone' },
+  );
+});
+
+function selection(
+  options: {
+    readonly current?: { readonly projectId: string | null | undefined; readonly path: string };
+    readonly defaultProjectId?: string;
+    readonly unavailableIds?: readonly string[];
+  } = {},
+) {
   return {
-    cwd,
-    backend: 'fake',
-    llmConnectionSlug: 'fake',
-    model: 'fake-model',
-    permissionMode: 'ask',
-    name: 'Session',
-    labels: [],
-    ...overrides,
+    current: async () => options.current ?? { projectId: undefined, path: '/workspace' },
+    select: async (projectId: unknown) => {
+      const id = String(projectId);
+      return {
+        project: options.unavailableIds?.includes(id) ? null : { id },
+        path: `/${id}`,
+      };
+    },
+    defaultProjectId: async () => options.defaultProjectId,
   };
 }
 
-const BASE_SESSION: DesktopCreateSessionInput = {
-  backend: 'fake',
-  llmConnectionSlug: 'fake',
-  model: 'fake-model',
-  permissionMode: 'ask',
-  name: 'Session',
-  labels: [],
-};
-
-test('the configured default project beats the last-used one', async () => {
-  // The point of the setting: something is almost always "last used", so a
-  // default that yielded to it would never apply.
-  const resolved = await resolveDesktopSessionSelection(
-    { ...BASE_SESSION },
-    {
-      current: async () => ({ projectId: 'last-used', path: '/last/used' }),
-      select: async (projectId) => ({
-        project: { id: projectId as string },
-        path: '/default/project',
-      }),
-      defaultProjectId: async () => 'default-project',
-    },
-  );
-
-  assert.equal(resolved.cwd, '/default/project');
-  assert.equal(resolved.projectId, 'default-project');
-});
-
-test('an explicit project id still overrides the configured default', async () => {
-  // The composer picker has to be able to take one conversation elsewhere,
-  // otherwise setting a default would trap every new chat in it.
-  const resolved = await resolveDesktopSessionSelection(
-    { ...BASE_SESSION, projectId: 'picked-for-this-chat' },
-    {
-      current: async () => {
-        throw new Error('current must not be called');
-      },
-      select: async (projectId) => ({
-        project: { id: projectId as string },
-        path: `/${projectId as string}`,
-      }),
-      defaultProjectId: async () => {
-        throw new Error('the default must not be consulted for an explicit pick');
-      },
-    },
-  );
-
-  assert.equal(resolved.projectId, 'picked-for-this-chat');
-});
-
-test('no configured default leaves the last-used behaviour untouched', async () => {
-  const resolved = await resolveDesktopSessionSelection(
-    { ...BASE_SESSION },
-    {
-      current: async () => ({ projectId: 'last-used', path: '/last/used' }),
-      select: async () => {
-        throw new Error('select must not be called');
-      },
-      defaultProjectId: async () => undefined,
-    },
-  );
-
-  assert.equal(resolved.cwd, '/last/used');
-  assert.equal(resolved.projectId, 'last-used');
-});
-
-test('a default project that no longer resolves falls back instead of failing the create', async () => {
-  // Archived, or its folder was deleted after it was chosen. Creating a
-  // session must still succeed — refusing to start a conversation because a
-  // preference went stale would be the worst possible reading of "default".
-  const resolved = await resolveDesktopSessionSelection(
-    { ...BASE_SESSION },
-    {
-      current: async () => ({ projectId: 'last-used', path: '/last/used' }),
-      select: async () => {
-        throw new Error('No such project: removed-project');
-      },
-      defaultProjectId: async () => 'removed-project',
-    },
-  );
-
-  assert.equal(resolved.cwd, '/last/used');
-  assert.equal(resolved.projectId, 'last-used');
-});
+async function unexpected(): Promise<never> {
+  throw new Error('Unexpected call');
+}

--- a/apps/desktop/src/main/__tests__/project-management-service.test.ts
+++ b/apps/desktop/src/main/__tests__/project-management-service.test.ts
@@ -3,15 +3,17 @@ import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { createProjectCatalog } from '@maka/storage';
-import { createProjectManagementService } from '../project-management-service.js';
+import { createProjectCatalog, type ProjectCatalog } from '@maka/storage';
+import {
+  createProjectManagementService,
+  type ProjectManagementCatalog,
+} from '../project-management-service.js';
 
-test('project management service owns selection and reversible lifecycle actions', async () => {
+test('owns Project selection and reversible lifecycle actions in Desktop', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-project-service-'));
   const firstPath = join(base, 'first');
   const relocatedPath = join(base, 'relocated');
-  await mkdir(firstPath);
-  await mkdir(relocatedPath);
+  await Promise.all([mkdir(firstPath), mkdir(relocatedPath)]);
   const selectedPaths: string[] = [];
   let nextDirectory: string | undefined = firstPath;
   const catalog = createProjectCatalog(join(base, 'storage'), {
@@ -19,7 +21,7 @@ test('project management service owns selection and reversible lifecycle actions
     createId: () => 'project-1',
   });
   const service = createProjectManagementService({
-    catalog,
+    catalog: managementCatalog(catalog),
     chooseDirectory: async () => nextDirectory,
     selection: {
       currentSelection: async () => ({
@@ -33,191 +35,102 @@ test('project management service owns selection and reversible lifecycle actions
   try {
     const added = await service.add();
     assert.equal(added.ok, true);
-    if (!added.ok) throw new Error('Expected an added project');
+    if (!added.ok) assert.fail('Expected an added Project');
     assert.equal(added.project.id, 'project-1');
     assert.equal(added.path, await realpath(firstPath));
-    assert.equal(selectedPaths.at(-1), added.project.preferredPath);
 
     assert.equal((await service.rename('project-1', '  Renamed  ')).name, 'Renamed');
     assert.equal((await service.archive('project-1')).archivedAt, 1_000);
-    await assert.rejects(() => service.select('project-1'), /archived/i);
-    assert.equal((await service.restore('project-1')).archivedAt, undefined);
+    assert.equal((await service.select('project-1')).project, null);
+    await service.restore('project-1');
 
     nextDirectory = relocatedPath;
-    const selectionCountBeforeRelink = selectedPaths.length;
     const relinked = await service.relink('project-1');
     assert.equal(relinked.ok, true);
-    if (!relinked.ok) throw new Error('Expected a relinked project');
-    assert.equal(relinked.project.id, 'project-1');
-    assert.equal(relinked.project.preferredPath, await realpath(relocatedPath));
-    assert.equal(
-      selectedPaths.length,
-      selectionCountBeforeRelink + 1,
-      'relinking the selected project keeps the current working directory usable',
-    );
     assert.equal(selectedPaths.at(-1), await realpath(relocatedPath));
-
-    const selected = await service.select('project-1');
-    assert.ok(selected.project);
-    assert.equal(selected.project.id, 'project-1');
-    assert.equal(selectedPaths.at(-1), await realpath(relocatedPath));
-
-    nextDirectory = undefined;
-    assert.deepEqual(await service.add(), { ok: false, reason: 'cancelled' });
-    assert.deepEqual(await service.relink('project-1'), { ok: false, reason: 'cancelled' });
   } finally {
     await rm(base, { recursive: true, force: true });
   }
 });
 
-test('project management service rejects malformed IPC identities before catalog access', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-project-service-input-'));
+test('rejects malformed Project identities before catalog access', async () => {
   const service = createProjectManagementService({
-    catalog: createProjectCatalog(join(base, 'storage')),
+    catalog: {
+      list: unexpected,
+      register: unexpected,
+      relink: unexpected,
+      rename: unexpected,
+      archive: unexpected,
+      restore: unexpected,
+    },
     chooseDirectory: async () => undefined,
     selection: {
-      currentSelection: async () => ({ projectId: undefined, path: base }),
-      setSelection: () => {},
+      currentSelection: async () => ({ projectId: undefined, path: '/workspace' }),
+      setSelection() {},
     },
   });
 
-  try {
-    await assert.rejects(() => service.select(''), /Invalid project id/);
-    assert.throws(() => service.rename('project-1', ''), /Invalid project name/);
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
+  await assert.rejects(() => service.select(''), /Invalid project id/);
+  assert.throws(() => service.rename('project-1', ''), /Invalid project name/);
 });
 
-test('project management service resolves a legacy path into one canonical selection', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-project-service-selection-'));
-  const projectPath = join(base, 'project');
-  await mkdir(projectPath);
-  const catalog = createProjectCatalog(join(base, 'storage'), {
-    createId: () => 'project-1',
-  });
-  await catalog.register(projectPath);
-  const savedSelections: Array<{ projectId: string | null; projectPath: string }> = [];
+test('keeps an explicit no-Project selection local to Desktop', async () => {
+  const selections: Array<{ projectId: string | null; path: string }> = [];
   const service = createProjectManagementService({
-    catalog,
+    catalog: {
+      list: unexpected,
+      register: unexpected,
+      relink: unexpected,
+      rename: unexpected,
+      archive: unexpected,
+      restore: unexpected,
+    },
     chooseDirectory: async () => undefined,
     selection: {
-      currentSelection: async () => ({
-        projectId: undefined,
-        path: await realpath(projectPath),
-      }),
-      setSelection: (projectId, path) => {
-        savedSelections.push({ projectId, projectPath: path });
-      },
+      currentSelection: async () => ({ projectId: undefined, path: '/workspace' }),
+      setSelection: (projectId, path) => selections.push({ projectId, path }),
     },
   });
 
-  try {
-    assert.deepEqual(await service.current(), {
-      projectId: 'project-1',
-      path: await realpath(projectPath),
-    });
-    assert.deepEqual(savedSelections, [
-      {
-        projectId: 'project-1',
-        projectPath: await realpath(projectPath),
-      },
-    ]);
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
+  assert.deepEqual(await service.select(null), { project: null, path: '/workspace' });
+  assert.deepEqual(selections, [{ projectId: null, path: '/workspace' }]);
 });
 
-test('project management service persists an explicit no-project selection in main', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-project-service-no-project-'));
-  const projectPath = join(base, 'project');
-  await mkdir(projectPath);
-  const savedSelections: Array<{ projectId: string | null; projectPath: string }> = [];
+test('does not silently replace a stale Project preference with another Project', async () => {
+  const selections: Array<{ projectId: string | null; path: string }> = [];
   const service = createProjectManagementService({
-    catalog: createProjectCatalog(join(base, 'storage')),
+    catalog: {
+      list: async () => [
+        { id: 'other', name: 'Other', locations: [], available: true },
+      ],
+      register: unexpected,
+      relink: unexpected,
+      rename: unexpected,
+      archive: unexpected,
+      restore: unexpected,
+    },
     chooseDirectory: async () => undefined,
     selection: {
-      currentSelection: async () => ({
-        projectId: undefined,
-        path: await realpath(projectPath),
-      }),
-      setSelection: (projectId, path) => {
-        savedSelections.push({ projectId, projectPath: path });
-      },
+      currentSelection: async () => ({ projectId: 'missing', path: '/last-known' }),
+      setSelection: (projectId, path) => selections.push({ projectId, path }),
     },
   });
 
-  try {
-    assert.deepEqual(await service.select(null), {
-      project: null,
-      path: await realpath(projectPath),
-    });
-    assert.deepEqual(savedSelections, [
-      {
-        projectId: null,
-        projectPath: await realpath(projectPath),
-      },
-    ]);
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
+  assert.deepEqual(await service.current(), { projectId: null, path: '/last-known' });
+  assert.deepEqual(selections, [{ projectId: null, path: '/last-known' }]);
 });
 
-test('archiving the current project resolves fallback or no-project inside main', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-project-service-archive-selection-'));
-  const firstPath = join(base, 'first');
-  const secondPath = join(base, 'second');
-  await mkdir(firstPath);
-  await mkdir(secondPath);
-  let now = 1_000;
-  let id = 0;
-  const catalog = createProjectCatalog(join(base, 'storage'), {
-    now: () => now,
-    createId: () => `project-${++id}`,
-  });
-  const first = await catalog.register(firstPath);
-  now = 2_000;
-  const second = await catalog.register(secondPath);
-  let selection = {
-    projectId: second.id as string | null | undefined,
-    path: await realpath(secondPath),
+function managementCatalog(catalog: ProjectCatalog): ProjectManagementCatalog {
+  return {
+    list: () => catalog.list(),
+    register: (path) => catalog.register(path),
+    relink: async (projectId, path) => (await catalog.relinkWithSessions(projectId, path)).project,
+    rename: (projectId, name) => catalog.rename(projectId, name),
+    archive: (projectId) => catalog.archive(projectId),
+    restore: (projectId) => catalog.restore(projectId),
   };
-  const service = createProjectManagementService({
-    catalog,
-    chooseDirectory: async () => undefined,
-    selection: {
-      currentSelection: async () => selection,
-      setSelection: (projectId, path) => {
-        selection = { projectId, path };
-      },
-    },
-  });
+}
 
-  try {
-    await service.archive(second.id);
-    assert.deepEqual(selection, {
-      projectId: first.id,
-      path: await realpath(firstPath),
-    });
-
-    selection = { projectId: second.id, path: await realpath(secondPath) };
-    assert.deepEqual(await service.current(), {
-      projectId: first.id,
-      path: await realpath(firstPath),
-    });
-
-    await service.archive(first.id);
-    assert.deepEqual(selection, {
-      projectId: null,
-      path: await realpath(firstPath),
-    });
-
-    selection = { projectId: first.id, path: await realpath(firstPath) };
-    assert.deepEqual(await service.current(), {
-      projectId: null,
-      path: await realpath(firstPath),
-    });
-  } finally {
-    await rm(base, { recursive: true, force: true });
-  }
-});
+async function unexpected(): Promise<never> {
+  throw new Error('Unexpected call');
+}

--- a/apps/desktop/src/main/__tests__/project-root-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/project-root-controller.test.ts
@@ -12,15 +12,35 @@ test('persists Project preferences by Runtime Host root identity', async () => {
   const preferenceFile = join(base, 'project-preferences.json');
   try {
     const first = controller(base, fallback, 'root-a');
-    first.setSelection('project-a', fallback);
-    await waitForPreference(preferenceFile, 'root-a', 'project-a');
+    await first.setSelection('project-a', fallback);
 
     const second = controller(base, fallback, 'root-b');
-    second.setSelection('project-b', fallback);
-    await waitForPreference(preferenceFile, 'root-b', 'project-b');
+    await second.setSelection('project-b', fallback);
 
     assert.equal((await controller(base, fallback, 'root-a').currentSelection()).projectId, 'project-a');
     assert.equal((await controller(base, fallback, 'root-b').currentSelection()).projectId, 'project-b');
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('serializes rapid selections without losing another Runtime Host root', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-preference-concurrency-'));
+  const fallback = join(base, 'fallback');
+  await mkdir(fallback);
+  const preferenceFile = join(base, 'project-preferences.json');
+  try {
+    const first = controller(base, fallback, 'root-a');
+    const second = controller(base, fallback, 'root-b');
+    await Promise.all([
+      first.setSelection('project-a-1', fallback),
+      second.setSelection('project-b', fallback),
+      first.setSelection('project-a-2', fallback),
+    ]);
+    assert.deepEqual(JSON.parse(await readFile(preferenceFile, 'utf8')).selections, {
+      'root-a': 'project-a-2',
+      'root-b': 'project-b',
+    });
   } finally {
     await rm(base, { recursive: true, force: true });
   }
@@ -37,7 +57,12 @@ test('migrates the legacy path selection once and removes the legacy file', asyn
     assert.equal(selection.projectId, 'project-1');
     assert.equal(selection.path, project);
     await assert.rejects(() => readFile(legacy), /ENOENT/);
-    await waitForPreference(join(base, 'project-preferences.json'), 'root-a', 'project-1');
+    assert.equal(
+      JSON.parse(await readFile(join(base, 'project-preferences.json'), 'utf8')).selections[
+        'root-a'
+      ],
+      'project-1',
+    );
   } finally {
     await rm(base, { recursive: true, force: true });
   }
@@ -89,23 +114,4 @@ function controller(base: string, fallback: string, rootId: string) {
     legacySelectionFile: join(base, 'last-project-path.json'),
     fallbackRoots: () => [fallback],
   });
-}
-
-async function waitForPreference(
-  file: string,
-  rootId: string,
-  projectId: string,
-): Promise<void> {
-  for (let attempt = 0; attempt < 50; attempt += 1) {
-    try {
-      const parsed = JSON.parse(await readFile(file, 'utf8')) as {
-        selections?: Record<string, string>;
-      };
-      if (parsed.selections?.[rootId] === projectId) return;
-    } catch {
-      // The best-effort write may still be pending.
-    }
-    await new Promise((resolve) => setImmediate(resolve));
-  }
-  assert.fail(`Preference was not persisted for ${rootId}`);
 }

--- a/apps/desktop/src/main/__tests__/project-root-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/project-root-controller.test.ts
@@ -2,211 +2,89 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, it } from 'node:test';
+import { test } from 'node:test';
 import { createProjectRootController } from '../project-root-controller.js';
 
-/**
- * Behavioral coverage for the shared project-root selection authority
- * (issue #1084 review follow-up): selected > persisted > fallback
- * precedence, explicit-path validation, and persistence on adoption.
- * The IPC modules only forward to this controller, so these unit tests
- * lock the state machine without needing an Electron ipcMain.
- */
-
-interface Fixture {
-  base: string;
-  lastProjectPathFile: string;
-  fallbackDir: string;
-  persistedDir: string;
-  selectedDir: string;
-}
-
-async function withFixture(fn: (fixture: Fixture) => Promise<void>): Promise<void> {
-  const base = await mkdtemp(join(tmpdir(), 'maka-project-root-controller-'));
+test('persists Project preferences by Runtime Host root identity', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-preference-'));
+  const fallback = join(base, 'fallback');
+  await mkdir(fallback);
+  const preferenceFile = join(base, 'project-preferences.json');
   try {
-    const fixture: Fixture = {
-      base,
-      lastProjectPathFile: join(base, 'last-project-path.json'),
-      fallbackDir: join(base, 'fallback'),
-      persistedDir: join(base, 'persisted'),
-      selectedDir: join(base, 'selected'),
-    };
-    await mkdir(fixture.fallbackDir, { recursive: true });
-    await mkdir(fixture.persistedDir, { recursive: true });
-    await mkdir(fixture.selectedDir, { recursive: true });
-    await fn(fixture);
+    const first = controller(base, fallback, 'root-a');
+    first.setSelection('project-a', fallback);
+    await waitForPreference(preferenceFile, 'root-a', 'project-a');
+
+    const second = controller(base, fallback, 'root-b');
+    second.setSelection('project-b', fallback);
+    await waitForPreference(preferenceFile, 'root-b', 'project-b');
+
+    assert.equal((await controller(base, fallback, 'root-a').currentSelection()).projectId, 'project-a');
+    assert.equal((await controller(base, fallback, 'root-b').currentSelection()).projectId, 'project-b');
   } finally {
     await rm(base, { recursive: true, force: true });
   }
-}
+});
 
-async function waitForPersistedPath(file: string, expected: string): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt++) {
-    try {
-      const parsed = JSON.parse(await readFile(file, 'utf8')) as { projectPath?: string };
-      if (parsed.projectPath === expected) return;
-    } catch {
-      // Not written yet (setSelection persists fire-and-forget).
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+test('migrates the legacy path selection once and removes the legacy file', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-preference-migration-'));
+  const project = join(base, 'project');
+  await mkdir(project);
+  const legacy = join(base, 'last-project-path.json');
+  await writeFile(legacy, JSON.stringify({ projectId: 'project-1', projectPath: project }));
+  try {
+    const selection = await controller(base, project, 'root-a').currentSelection();
+    assert.equal(selection.projectId, 'project-1');
+    assert.equal(selection.path, project);
+    await assert.rejects(() => readFile(legacy), /ENOENT/);
+    await waitForPreference(join(base, 'project-preferences.json'), 'root-a', 'project-1');
+  } finally {
+    await rm(base, { recursive: true, force: true });
   }
-  assert.fail(`setSelection must persist ${expected} to ${file}`);
+});
+
+test('does not reuse a preference from another Runtime Host root', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-preference-scope-'));
+  const fallback = join(base, 'fallback');
+  await mkdir(fallback);
+  await writeFile(
+    join(base, 'project-preferences.json'),
+    JSON.stringify({ version: 1, selections: { 'root-a': 'project-a' } }),
+  );
+  try {
+    assert.deepEqual(await controller(base, fallback, 'root-b').currentSelection(), {
+      projectId: undefined,
+      path: fallback,
+    });
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+function controller(base: string, fallback: string, rootId: string) {
+  return createProjectRootController({
+    rootId,
+    preferenceFile: join(base, 'project-preferences.json'),
+    legacySelectionFile: join(base, 'last-project-path.json'),
+    fallbackRoots: () => [fallback],
+  });
 }
 
-async function waitForPersistedSelection(
+async function waitForPreference(
   file: string,
-  expected: { projectId: string | null; projectPath: string },
+  rootId: string,
+  projectId: string,
 ): Promise<void> {
-  for (let attempt = 0; attempt < 100; attempt++) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
     try {
       const parsed = JSON.parse(await readFile(file, 'utf8')) as {
-        projectId?: string | null;
-        projectPath?: string;
+        selections?: Record<string, string>;
       };
-      if (
-        parsed.projectId === expected.projectId &&
-        parsed.projectPath === expected.projectPath
-      ) {
-        return;
-      }
+      if (parsed.selections?.[rootId] === projectId) return;
     } catch {
-      // Not written yet (setSelection persists fire-and-forget).
+      // The best-effort write may still be pending.
     }
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await new Promise((resolve) => setImmediate(resolve));
   }
-  assert.fail(`setSelection must persist ${JSON.stringify(expected)} to ${file}`);
+  assert.fail(`Preference was not persisted for ${rootId}`);
 }
-
-describe('project-root controller', () => {
-  it('falls back to the first resolvable fallback root when nothing is selected or persisted', async () => {
-    await withFixture(async (fixture) => {
-      const controller = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-      assert.equal(await controller.current(), fixture.fallbackDir);
-    });
-  });
-
-  it('prefers a validated persisted project over the fallback roots', async () => {
-    await withFixture(async (fixture) => {
-      await writeFile(
-        fixture.lastProjectPathFile,
-        JSON.stringify({ projectPath: fixture.persistedDir }),
-        'utf8',
-      );
-      const controller = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-      assert.equal(await controller.current(), fixture.persistedDir);
-    });
-  });
-
-  it('ignores a persisted project that no longer exists and falls back', async () => {
-    await withFixture(async (fixture) => {
-      await writeFile(
-        fixture.lastProjectPathFile,
-        JSON.stringify({ projectPath: join(fixture.base, 'deleted') }),
-        'utf8',
-      );
-      const controller = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-      assert.equal(await controller.current(), fixture.fallbackDir);
-    });
-  });
-
-  it('prefers the in-session selection over both persisted and fallback roots', async () => {
-    await withFixture(async (fixture) => {
-      await writeFile(
-        fixture.lastProjectPathFile,
-        JSON.stringify({ projectPath: fixture.persistedDir }),
-        'utf8',
-      );
-      const controller = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-      controller.setSelection('project-selected', fixture.selectedDir);
-      assert.equal(await controller.current(), fixture.selectedDir);
-    });
-  });
-
-  it('persists an adopted selection so a fresh controller restores it', async () => {
-    await withFixture(async (fixture) => {
-      const controller = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-      controller.setSelection('project-selected', fixture.selectedDir);
-      await waitForPersistedPath(fixture.lastProjectPathFile, fixture.selectedDir);
-
-      const restored = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-      assert.equal(await restored.current(), fixture.selectedDir);
-    });
-  });
-
-  it('persists the project id and path as one selection snapshot', async () => {
-    await withFixture(async (fixture) => {
-      const controller = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-      controller.setSelection('project-1', fixture.selectedDir);
-      await waitForPersistedSelection(fixture.lastProjectPathFile, {
-        projectId: 'project-1',
-        projectPath: fixture.selectedDir,
-      });
-
-      const restored = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-      assert.deepEqual(await restored.currentSelection(), {
-        projectId: 'project-1',
-        path: fixture.selectedDir,
-      });
-    });
-  });
-
-  it('validates explicit paths: rejects non-strings and missing directories, resolves real ones', async () => {
-    await withFixture(async (fixture) => {
-      const controller = createProjectRootController({
-        lastProjectPathFile: fixture.lastProjectPathFile,
-        fallbackRoots: () => [fixture.fallbackDir],
-      });
-
-      assert.deepEqual(await controller.resolveExplicit(undefined), { ok: false, reason: 'invalid-path' });
-      assert.deepEqual(await controller.resolveExplicit(''), { ok: false, reason: 'invalid-path' });
-      assert.deepEqual(await controller.resolveExplicit(42), { ok: false, reason: 'invalid-path' });
-      assert.deepEqual(
-        await controller.resolveExplicit(join(fixture.base, 'missing')),
-        { ok: false, reason: 'not-found' },
-      );
-      assert.deepEqual(
-        await controller.resolveExplicit(fixture.selectedDir),
-        { ok: true, projectPath: fixture.selectedDir },
-      );
-
-      // A nested path inside a git repo resolves to the repo root, matching
-      // the project-root walk the picker handlers rely on.
-      const repoRoot = join(fixture.base, 'repo');
-      const nested = join(repoRoot, 'apps', 'desktop');
-      await mkdir(join(repoRoot, '.git'), { recursive: true });
-      await writeFile(join(repoRoot, '.git', 'HEAD'), 'ref: refs/heads/main\n', 'utf8');
-      await mkdir(nested, { recursive: true });
-      assert.deepEqual(
-        await controller.resolveExplicit(nested),
-        { ok: true, projectPath: repoRoot },
-      );
-
-      // Validation must not adopt: the current root is untouched.
-      assert.equal(await controller.current(), fixture.fallbackDir);
-    });
-  });
-});

--- a/apps/desktop/src/main/__tests__/project-root-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/project-root-controller.test.ts
@@ -43,6 +43,27 @@ test('migrates the legacy path selection once and removes the legacy file', asyn
   }
 });
 
+test('keeps a legacy path selection until it can be represented by a Project id', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-preference-path-migration-'));
+  const fallback = join(base, 'fallback');
+  const project = join(base, 'project');
+  await mkdir(fallback);
+  await mkdir(project);
+  const legacy = join(base, 'last-project-path.json');
+  await writeFile(legacy, JSON.stringify({ projectPath: project }));
+  try {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      assert.deepEqual(await controller(base, fallback, 'root-a').currentSelection(), {
+        projectId: undefined,
+        path: project,
+      });
+    }
+    assert.equal(JSON.parse(await readFile(legacy, 'utf8')).projectPath, project);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 test('does not reuse a preference from another Runtime Host root', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-project-preference-scope-'));
   const fallback = join(base, 'fallback');

--- a/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
@@ -27,7 +27,9 @@ test('creates an explore Session through the Host-owned default model route', as
   });
   const adapter = createRuntimeHostBotSessionAdapter({
     client,
-    resolveCreateTarget: async () => ({ cwd: '/workspace', projectId: 'project-1' }),
+    resolveCreateTarget: async () => ({
+      workspace: { kind: 'project', projectId: 'project-1' },
+    }),
     emitSessionsChanged: (reason, sessionId, extra) =>
       changes.push({ reason, sessionId, extra }),
     newId: () => 'bot-session-1',
@@ -42,8 +44,7 @@ test('creates an explore Session through the Host-owned default model route', as
   assert.deepEqual(creates, [
     {
       sessionId: 'bot-session-1',
-      cwd: '/workspace',
-      projectId: 'project-1',
+      workspace: { kind: 'project', projectId: 'project-1' },
       name: 'Telegram conversation',
       labels: ['bot', 'telegram'],
       modelTarget: { kind: 'default' },
@@ -66,7 +67,7 @@ test('prepares a bound Session without exposing Host configuration revisions to 
   });
   const adapter = createRuntimeHostBotSessionAdapter({
     client,
-    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    resolveCreateTarget: hostPathCreateTarget,
     emitSessionsChanged() {},
   });
 
@@ -77,7 +78,7 @@ test('prepares a bound Session without exposing Host configuration revisions to 
 
   const unavailable = createRuntimeHostBotSessionAdapter({
     client: botClient({ getSession: async () => null }),
-    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    resolveCreateTarget: hostPathCreateTarget,
     emitSessionsChanged() {},
   });
   await assert.rejects(
@@ -98,7 +99,7 @@ test('reconciles an uncertain Host Session create with its stable Session identi
       },
       getSession: async (sessionId) => session(sessionId, { permissionMode: 'explore' }),
     }),
-    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    resolveCreateTarget: hostPathCreateTarget,
     emitSessionsChanged() {},
     newId: () => 'stable-session-id',
   });
@@ -141,7 +142,7 @@ test('subscribes before Turn start and settles a fast Host reply without losing 
   });
   const adapter = createRuntimeHostBotSessionAdapter({
     client,
-    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    resolveCreateTarget: hostPathCreateTarget,
     emitSessionsChanged: (reason, sessionId, extra) =>
       changes.push({ reason, sessionId, extra }),
   });
@@ -186,7 +187,7 @@ test('returns blocked Skill feedback without waiting for a Turn that was not cre
         },
       }),
     }),
-    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    resolveCreateTarget: hostPathCreateTarget,
     emitSessionsChanged() {},
   });
 
@@ -234,7 +235,7 @@ async function runProjectedTurn(rootTurn: TurnSnapshot) {
         return startedTurn(runningTurn(rootTurn.sessionId, rootTurn.turnId));
       },
     }),
-    resolveCreateTarget: async () => ({ cwd: '/workspace' }),
+    resolveCreateTarget: hostPathCreateTarget,
     emitSessionsChanged() {},
   });
   return adapter.runTurn({
@@ -265,7 +266,10 @@ function session(
   return {
     id,
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: id,
@@ -284,6 +288,10 @@ function session(
     orchestrationMode: 'default',
     ...overrides,
   };
+}
+
+async function hostPathCreateTarget() {
+  return { workspace: { kind: 'host_path' as const, path: '/workspace' } };
 }
 
 function runningTurn(sessionId: string, turnId: string): TurnSnapshot {

--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -846,7 +846,10 @@ function session(
   return {
     id,
     revision,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: id,

--- a/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-uds.test.ts
@@ -141,8 +141,10 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
           'session.create': async (input) => {
             assert.deepEqual(input.modelTarget, { kind: 'default' });
             assert.equal(input.permissionMode, undefined);
+            assert.equal(input.workspace.kind, 'host_path');
+            if (input.workspace.kind !== 'host_path') throw new Error('Expected Host path');
             projected = session(input.sessionId, {
-              cwd: input.cwd,
+              workspace: { target: input.workspace, hostCwd: input.workspace.path },
               name: input.name,
               connectionLocked: false,
             });
@@ -206,8 +208,10 @@ test('drives the renderer Session catalog facade through real UDS framing', asyn
         releaseComputerUseSession() {},
       },
       botRegistry: {} as BotRegistry,
-      resolveBotCreateTarget: async () => ({ cwd: base }),
-      resolveSessionCreateProject: async () => ({ cwd: base }),
+      resolveBotCreateTarget: async () => ({
+        workspace: { kind: 'host_path', path: base },
+      }),
+      resolveSessionCreateProject: async () => ({ kind: 'host_path', path: base }),
       emitSessionsChanged: (reason, sessionId) => changes.push({ reason, sessionId }),
       emitModeChanged() {},
       completeComputerUseTurn() {},
@@ -523,7 +527,10 @@ function session(
   return {
     id,
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: 'Desktop Host Session',

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -486,8 +486,10 @@ function deps(
     resizeImage: async (bytes) => bytes,
     nativeCapabilities,
     botRegistry: {} as BotRegistry,
-    resolveBotCreateTarget: async () => ({ cwd: '/workspace' }),
-    resolveSessionCreateProject: async () => ({ cwd: '/workspace' }),
+    resolveBotCreateTarget: async () => ({
+      workspace: { kind: 'host_path', path: '/workspace' },
+    }),
+    resolveSessionCreateProject: async () => ({ kind: 'host_path', path: '/workspace' }),
     emitSessionsChanged() {},
     emitModeChanged() {},
     completeComputerUseTurn() {},
@@ -824,7 +826,10 @@ function session(id: string): SessionCatalogProjection {
   return {
     id,
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: id,

--- a/apps/desktop/src/main/__tests__/runtime-host-external-sessions-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-external-sessions-ipc-main.test.ts
@@ -19,7 +19,7 @@ test('forwards bounded external Session requests and publishes imported Sessions
         listExternalSessions: async (input) => {
           requests.push(input);
           return {
-            sessions: [{ id: 'source-1', name: 'Source', cwd: '/external' }],
+            sessions: [{ id: 'source-1', name: 'Source', hostCwd: '/external' }],
             nextCursor: '16',
           };
         },
@@ -154,7 +154,10 @@ function session(id: string): SessionCatalogProjection {
   return {
     id,
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: 'Imported',

--- a/apps/desktop/src/main/__tests__/runtime-host-project-catalog.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-project-catalog.test.ts
@@ -1,24 +1,42 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { RuntimeHostOperationError } from '@maka/runtime-host/client';
-import { isProjectPathMismatchError } from '@maka/storage';
 import { createRuntimeHostProjectCatalog } from '../runtime-host-project-catalog.js';
 
-test('Host touch conflicts retain the Project path mismatch contract', async () => {
+test('adds Host-authorized paths only in the Desktop adapter', async () => {
+  const project = {
+    id: 'project-1',
+    aliases: [],
+    name: 'Project',
+    locationCount: 2,
+    archivedAt: null,
+    available: true,
+  } as const;
   const catalog = createRuntimeHostProjectCatalog(() =>
     ({
-      touchProject: async () => {
-        throw new RuntimeHostOperationError(
-          'project.catalog.mutate',
-          'operation_conflict',
-          'Path does not belong to project project-1',
-        );
-      },
+      listProjects: async () => [project],
+      registerProject: async () => project,
+      projectLocations: async () => ({
+        projectId: 'project-1',
+        locations: [
+          { path: '/workspace/project', isWorktree: false },
+          { path: '/workspace/worktree', isWorktree: true },
+        ],
+        preferredPath: '/workspace/project',
+      }),
     }) as never,
   );
 
-  await assert.rejects(
-    () => catalog.touch('project-1', '/workspace/other'),
-    (error: unknown) => isProjectPathMismatchError(error),
-  );
+  assert.deepEqual(await catalog.list(), [
+    {
+      id: 'project-1',
+      name: 'Project',
+      locations: [
+        { path: '/workspace/project', isWorktree: false },
+        { path: '/workspace/worktree', isWorktree: true },
+      ],
+      preferredPath: '/workspace/project',
+      available: true,
+    },
+  ]);
+  assert.deepEqual(await catalog.register('/workspace/project'), (await catalog.list())[0]);
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-project-catalog.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-project-catalog.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { createRuntimeHostProjectCatalog } from '../runtime-host-project-catalog.js';
 
-test('adds Host-authorized paths only in the Desktop adapter', async () => {
+test('reads every Project location through one stable Host catalog view', async () => {
   const project = {
     id: 'project-1',
     aliases: [],
@@ -10,33 +10,35 @@ test('adds Host-authorized paths only in the Desktop adapter', async () => {
     locationCount: 2,
     archivedAt: null,
     available: true,
+    locations: [
+      { path: '/workspace/project', isWorktree: false },
+      { path: '/workspace/worktree', isWorktree: true },
+    ],
+    preferredPath: '/workspace/project',
   } as const;
+  let listCalls = 0;
   const catalog = createRuntimeHostProjectCatalog(() =>
     ({
-      listProjects: async () => [project],
+      listProjects: async () => {
+        listCalls += 1;
+        return [project];
+      },
       registerProject: async () => project,
-      projectLocations: async () => ({
-        projectId: 'project-1',
-        locations: [
-          { path: '/workspace/project', isWorktree: false },
-          { path: '/workspace/worktree', isWorktree: true },
-        ],
-        preferredPath: '/workspace/project',
-      }),
     }) as never,
   );
 
-  assert.deepEqual(await catalog.list(), [
-    {
-      id: 'project-1',
-      name: 'Project',
-      locations: [
-        { path: '/workspace/project', isWorktree: false },
-        { path: '/workspace/worktree', isWorktree: true },
-      ],
-      preferredPath: '/workspace/project',
-      available: true,
-    },
-  ]);
-  assert.deepEqual(await catalog.register('/workspace/project'), (await catalog.list())[0]);
+  const expected = {
+    id: 'project-1',
+    name: 'Project',
+    locations: [
+      { path: '/workspace/project', isWorktree: false },
+      { path: '/workspace/worktree', isWorktree: true },
+    ],
+    preferredPath: '/workspace/project',
+    available: true,
+  };
+  assert.deepEqual(await catalog.list(), [expected]);
+  assert.equal(listCalls, 1);
+  assert.deepEqual(await catalog.register('/workspace/project'), expected);
+  assert.equal(listCalls, 2);
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-catalog-ipc-main.test.ts
@@ -24,7 +24,7 @@ test('leaves ordinary Session defaults to the Host while preserving product mode
   registerRuntimeHostSessionCatalogIpc(
     {
       client,
-      resolveCreateProject: async () => ({ cwd: '/project', projectId: 'project-1' }),
+      resolveCreateProject: async () => ({ kind: 'project', projectId: 'project-1' }),
       emitSessionsChanged: (reason, sessionId) => events.push({ reason, sessionId }),
       releaseSessionResources() {},
       sessionCopyCleanup: cleanupAuthority(),
@@ -44,8 +44,7 @@ test('leaves ordinary Session defaults to the Host while preserving product mode
   assert.deepEqual(creates, [
     {
       sessionId: 'session-1',
-      cwd: '/project',
-      projectId: 'project-1',
+      workspace: { kind: 'project', projectId: 'project-1' },
       name: DEFAULT_SESSION_NAME,
       modelTarget: { kind: 'default' },
       collaborationMode: 'agent',
@@ -53,8 +52,7 @@ test('leaves ordinary Session defaults to the Host while preserving product mode
     },
     {
       sessionId: 'session-2',
-      cwd: '/project',
-      projectId: 'project-1',
+      workspace: { kind: 'project', projectId: 'project-1' },
       mode: 'deep_research',
       labels: ['customer-label'],
       modelTarget: { kind: 'default' },
@@ -274,7 +272,8 @@ function cleanupAuthority(): RuntimeHostSessionCatalogIpcDeps['sessionCopyCleanu
 }
 
 const defaultCreateProject: RuntimeHostSessionCatalogIpcDeps['resolveCreateProject'] = async () => ({
-  cwd: '/workspace',
+  kind: 'host_path',
+  path: '/workspace',
 });
 
 function catalogClient(overrides: Partial<CatalogClient>): CatalogClient {
@@ -316,7 +315,10 @@ function session(
   return {
     id,
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: id,

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -779,7 +779,10 @@ function session(cwd = "/workspace"): SessionCatalogProjection {
   return {
     id: "session-1",
     revision: 1,
-    cwd,
+    workspace: {
+      target: { kind: 'host_path', path: cwd },
+      hostCwd: cwd,
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: "Session",

--- a/apps/desktop/src/main/__tests__/runtime-host-skills-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-skills-ipc-main.test.ts
@@ -4,9 +4,9 @@ import { registerRuntimeHostSkillsIpc } from '../runtime-host-skills-ipc-main.js
 
 test('keeps a resolved Skill mutation on one project root', async () => {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
-  const catalogContexts: string[] = [];
-  const mutationContexts: string[] = [];
-  let rootReads = 0;
+  const catalogContexts: unknown[] = [];
+  const mutationContexts: unknown[] = [];
+  let workspaceReads = 0;
   let mutationAttempts = 0;
   registerRuntimeHostSkillsIpc({
     ipcMain: {
@@ -15,16 +15,16 @@ test('keeps a resolved Skill mutation on one project root', async () => {
       },
     },
     client: {
-      loadSkillCatalog: async ({ projectRoot }: { projectRoot: string }) => {
-        catalogContexts.push(projectRoot);
+      loadSkillCatalog: async ({ workspace }: { workspace: unknown }) => {
+        catalogContexts.push(workspace);
         return {
           revision: `sha256:${'a'.repeat(64)}`,
           view: 'governance',
           items: [{ kind: 'skill', id: 'writer', ref: 'project:writer' }],
         };
       },
-      mutateSkillCatalog: async ({ context }: { context: { projectRoot: string } }) => {
-        mutationContexts.push(context.projectRoot);
+      mutateSkillCatalog: async ({ context }: { context: { workspace: unknown } }) => {
+        mutationContexts.push(context.workspace);
         mutationAttempts += 1;
         if (mutationAttempts === 1) return { kind: 'revision_conflict' };
         return { kind: 'rejected', reason: 'not_found' };
@@ -32,9 +32,13 @@ test('keeps a resolved Skill mutation on one project root', async () => {
     } as never,
     workspaceRoot: '/tmp/maka-runtime-host-skills-workspace',
     mainWindowController: {} as never,
-    getCurrentProjectRoot: async () => {
-      rootReads += 1;
-      return rootReads === 1 ? '/tmp/project-a' : '/tmp/project-b';
+    getCurrentWorkspace: async () => {
+      workspaceReads += 1;
+      const suffix = workspaceReads === 1 ? 'a' : 'b';
+      return {
+        target: { kind: 'project', projectId: `project-${suffix}` },
+        hostCwd: `/tmp/project-${suffix}`,
+      };
     },
     getDefaultPermissionMode: async () => 'ask',
     openPath: async () => '',
@@ -42,9 +46,12 @@ test('keeps a resolved Skill mutation on one project root', async () => {
 
   await handlers.get('skills:setEnabled')?.({}, 'writer', true);
 
-  assert.equal(rootReads, 1);
-  assert.deepEqual(catalogContexts, ['/tmp/project-a', '/tmp/project-a']);
-  assert.deepEqual(mutationContexts, ['/tmp/project-a', '/tmp/project-a']);
+  assert.equal(workspaceReads, 1);
+  assert.deepEqual(catalogContexts, [
+    { kind: 'project', projectId: 'project-a' },
+    { kind: 'project', projectId: 'project-a' },
+  ]);
+  assert.deepEqual(mutationContexts, catalogContexts);
 });
 
 test('requests the Host-owned invocable projection for existing and new Sessions', async () => {
@@ -64,7 +71,10 @@ test('requests the Host-owned invocable projection for existing and new Sessions
     } as never,
     workspaceRoot: '/tmp/maka-runtime-host-skills-workspace',
     mainWindowController: {} as never,
-    getCurrentProjectRoot: async () => '/tmp/project-a',
+    getCurrentWorkspace: async () => ({
+      target: { kind: 'project', projectId: 'project-a' },
+      hostCwd: '/tmp/project-a',
+    }),
     getDefaultPermissionMode: async () => 'bypass',
     openPath: async () => '',
   });
@@ -79,7 +89,7 @@ test('requests the Host-owned invocable projection for existing and new Sessions
     { kind: 'session', sessionId: 'session-1' },
     {
       kind: 'new_session',
-      context: { projectRoot: '/tmp/project-a' },
+      context: { workspace: { kind: 'project', projectId: 'project-a' } },
       collaborationMode: 'plan',
       permissionMode: 'bypass',
     },

--- a/apps/desktop/src/main/__tests__/runtime-host-skills-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-skills-ipc-main.test.ts
@@ -21,24 +21,32 @@ test('keeps a resolved Skill mutation on one project root', async () => {
           revision: `sha256:${'a'.repeat(64)}`,
           view: 'governance',
           items: [{ kind: 'skill', id: 'writer', ref: 'project:writer' }],
+          workspace: {
+            target: { kind: 'project', projectId: 'project-a' },
+            hostCwd: '/tmp/project-a',
+          },
         };
       },
       mutateSkillCatalog: async ({ context }: { context: { workspace: unknown } }) => {
         mutationContexts.push(context.workspace);
         mutationAttempts += 1;
         if (mutationAttempts === 1) return { kind: 'revision_conflict' };
-        return { kind: 'rejected', reason: 'not_found' };
+        return {
+          kind: 'rejected',
+          reason: 'not_found',
+          resolvedWorkspace: {
+            target: { kind: 'project', projectId: 'project-a' },
+            hostCwd: '/tmp/project-a',
+          },
+        };
       },
     } as never,
     workspaceRoot: '/tmp/maka-runtime-host-skills-workspace',
     mainWindowController: {} as never,
-    getCurrentWorkspace: async () => {
+    getCurrentWorkspaceTarget: async () => {
       workspaceReads += 1;
       const suffix = workspaceReads === 1 ? 'a' : 'b';
-      return {
-        target: { kind: 'project', projectId: `project-${suffix}` },
-        hostCwd: `/tmp/project-${suffix}`,
-      };
+      return { kind: 'project', projectId: `project-${suffix}` };
     },
     getDefaultPermissionMode: async () => 'ask',
     openPath: async () => '',
@@ -71,9 +79,9 @@ test('requests the Host-owned invocable projection for existing and new Sessions
     } as never,
     workspaceRoot: '/tmp/maka-runtime-host-skills-workspace',
     mainWindowController: {} as never,
-    getCurrentWorkspace: async () => ({
-      target: { kind: 'project', projectId: 'project-a' },
-      hostCwd: '/tmp/project-a',
+    getCurrentWorkspaceTarget: async () => ({
+      kind: 'project',
+      projectId: 'project-a',
     }),
     getDefaultPermissionMode: async () => 'bypass',
     openPath: async () => '',

--- a/apps/desktop/src/main/new-session-project.ts
+++ b/apps/desktop/src/main/new-session-project.ts
@@ -1,105 +1,47 @@
-import { isProjectPathMismatchError, type ProjectCatalog } from '@maka/storage';
+import type { ProjectCatalog } from '@maka/storage';
+import type { WorkspaceTarget } from '@maka/runtime-host/protocol';
 
-export type SessionProjectInput = {
+export interface DesktopSessionWorkspaceInput {
   readonly cwd?: string;
   readonly projectId?: string | null;
-};
+}
 
-export async function resolveDesktopSessionSelection<T extends SessionProjectInput>(
-  input: T,
-  selection: {
-    current(): Promise<{
-      projectId: string | null | undefined;
-      path: string;
-    }>;
-    select(
-      projectId: unknown,
-    ): Promise<{ project: { id: string } | null; path: string }>;
-    /**
-     * Settings -> 偏好 -> 项目 -> 默认项目, or undefined for "no preference".
-     * Optional so the pure-selection callers and tests that predate the
-     * setting keep their two-argument shape.
-     */
-    defaultProjectId?(): Promise<string | undefined>;
-  },
-): Promise<T & { cwd: string; projectId?: string | null }> {
-  if (input.cwd) return { ...input, cwd: input.cwd };
+interface DesktopSessionWorkspaceSelection {
+  current(): Promise<{ projectId: string | null | undefined; path: string }>;
+  select(projectId: unknown): Promise<{ project: { id: string } | null; path: string }>;
+  defaultProjectId?(): Promise<string | undefined>;
+}
 
-  // An explicit project id is this conversation's own choice (the composer
-  // picker) and outranks the configured default -- that override is the whole
-  // reason the picker still exists once a default is set.
-  if (input.projectId !== undefined) {
-    const selected = await selection.select(input.projectId);
-    return {
-      ...input,
-      cwd: selected.path,
-      projectId: selected.project?.id ?? null,
-    };
+export async function resolveDesktopSessionWorkspace(
+  input: DesktopSessionWorkspaceInput,
+  selection: DesktopSessionWorkspaceSelection,
+  catalog: Pick<ProjectCatalog, 'register'>,
+): Promise<WorkspaceTarget> {
+  if (input.cwd) {
+    if (input.projectId === null) return { kind: 'host_path', path: input.cwd };
+    if (typeof input.projectId === 'string') {
+      return { kind: 'project', projectId: input.projectId };
+    }
+    return { kind: 'project', projectId: (await catalog.register(input.cwd)).id };
   }
 
-  // No per-conversation choice: the configured default wins over the
-  // last-used project. A default that only applied when nothing was
-  // remembered would be a default in name only, since something is almost
-  // always remembered.
+  if (input.projectId !== undefined) {
+    if (input.projectId === null) {
+      return { kind: 'host_path', path: (await selection.current()).path };
+    }
+    const selected = await selection.select(input.projectId);
+    if (!selected.project) throw new Error(`Project does not exist: ${input.projectId}`);
+    return { kind: 'project', projectId: selected.project.id };
+  }
+
   const configuredDefault = await selection.defaultProjectId?.();
   if (configuredDefault !== undefined) {
-    try {
-      const selected = await selection.select(configuredDefault);
-      if (selected.project) {
-        return { ...input, cwd: selected.path, projectId: selected.project.id };
-      }
-    } catch {
-      // Archived, unavailable, or deleted since it was chosen. Creating the
-      // session still has to succeed, so fall through to the last-used
-      // project; the settings page is where that degradation is reported,
-      // because a toast at session-create time would blame the wrong action.
-    }
+    const selected = await selection.select(configuredDefault);
+    if (selected.project) return { kind: 'project', projectId: selected.project.id };
   }
 
-  const selected = await selection.current();
-  return {
-    ...input,
-    cwd: selected.path,
-    projectId: selected.projectId,
-  };
-}
-
-export async function resolveNewSessionProjectInput<T extends SessionProjectInput & { cwd: string }>(
-  input: T,
-  catalog: Pick<ProjectCatalog, 'list' | 'register' | 'touch'>,
-): Promise<T & { cwd: string; projectId?: string | null }> {
-  if (input.projectId === null) return input;
-
-  if (input.projectId) {
-    const requestedId = input.projectId;
-    const project = (await catalog.list()).find(
-      (candidate) => candidate.id === requestedId || candidate.aliases?.includes(requestedId),
-    );
-    if (!project) throw projectMismatch(requestedId);
-    if (project.archivedAt !== undefined) throw new Error(`Project is archived: ${requestedId}`);
-    if (!project.available) throw new Error(`Project is unavailable: ${requestedId}`);
-    try {
-      const touched = await catalog.touch(project.id, input.cwd);
-      return {
-        ...input,
-        cwd: touched.preferredPath ?? input.cwd,
-        projectId: touched.id,
-      };
-    } catch (error) {
-      if (!isProjectPathMismatchError(error)) throw error;
-      throw projectMismatch(requestedId);
-    }
-  }
-
-  const project = await catalog.register(input.cwd);
-  if (project.archivedAt !== undefined) throw new Error(`Project is archived: ${project.id}`);
-  return {
-    ...input,
-    cwd: project.preferredPath ?? input.cwd,
-    projectId: project.id,
-  };
-}
-
-function projectMismatch(projectId: string): Error {
-  return new Error(`Project does not match the selected directory: ${projectId}`);
+  const current = await selection.current();
+  return typeof current.projectId === 'string'
+    ? { kind: 'project', projectId: current.projectId }
+    : { kind: 'host_path', path: current.path };
 }

--- a/apps/desktop/src/main/project-management-service.ts
+++ b/apps/desktop/src/main/project-management-service.ts
@@ -32,7 +32,6 @@ export interface ProjectManagementService {
 export interface ProjectManagementCatalog {
   list(): Promise<ProjectRecord[]>;
   register(path: string): Promise<ProjectRecord>;
-  select(projectId: string): Promise<{ project: ProjectRecord; path: string }>;
   relink(projectId: string, path: string): Promise<ProjectRecord>;
   rename(projectId: string, name: string): Promise<ProjectRecord>;
   archive(projectId: string): Promise<ProjectRecord>;
@@ -56,31 +55,17 @@ export function createProjectManagementService(deps: {
     const selectedProjectId = selection.projectId;
     const requested =
       typeof selectedProjectId === 'string'
-        ? projects.find(
-            (project) =>
-              project.id === selectedProjectId ||
-              project.aliases?.includes(selectedProjectId),
-          )
-        : projects.find((project) =>
-            project.locations.some((location) => location.path === selection.path),
-          );
-    const isSelectable = (project: ProjectRecord | undefined) =>
-      project !== undefined &&
-      project.archivedAt === undefined &&
-      project.available &&
-      project.preferredPath;
-    const selected =
-      isSelectable(requested) ? requested : projects.find((project) => isSelectable(project));
-    const path = selected?.preferredPath;
-    if (!selected || !path) {
-      if (requested || typeof selectedProjectId === 'string') {
+        ? selectableProject(projects, selectedProjectId)
+        : undefined;
+    if (!requested) {
+      if (typeof selectedProjectId === 'string') {
         deps.selection.setSelection(null, selection.path);
         return { projectId: null, path: selection.path };
       }
       return { projectId: undefined, path: selection.path };
     }
-    deps.selection.setSelection(selected.id, path);
-    return { projectId: selected.id, path };
+    deps.selection.setSelection(requested.id, requested.preferredPath);
+    return { projectId: requested.id, path: requested.preferredPath };
   }
 
   return {
@@ -91,9 +76,9 @@ export function createProjectManagementService(deps: {
       const path = await deps.chooseDirectory();
       if (!path) return { ok: false, reason: 'cancelled' };
       const project = await deps.catalog.register(path);
-      const selected = await deps.catalog.select(project.id);
-      deps.selection.setSelection(selected.project.id, selected.path);
-      return { ok: true, project: selected.project, path: selected.path };
+      const selected = requireSelectableProject(project);
+      deps.selection.setSelection(selected.id, selected.preferredPath);
+      return { ok: true, project: selected, path: selected.preferredPath };
     },
 
     async select(projectId) {
@@ -102,39 +87,34 @@ export function createProjectManagementService(deps: {
         deps.selection.setSelection(null, selection.path);
         return { project: null, path: selection.path };
       }
-      const selected = await deps.catalog.select(requireProjectId(projectId));
-      deps.selection.setSelection(selected.project.id, selected.path);
-      return selected;
+      const id = requireProjectId(projectId);
+      const selection = await deps.selection.currentSelection();
+      const project = selectableProject(await deps.catalog.list(), id);
+      if (!project) {
+        return { project: null, path: selection.path };
+      }
+      deps.selection.setSelection(project.id, project.preferredPath);
+      return { project, path: project.preferredPath };
     },
 
     async relink(projectId) {
       const id = requireProjectId(projectId);
       const path = await deps.chooseDirectory();
       if (!path) return { ok: false, reason: 'cancelled' };
-      const [selection, projects] = await Promise.all([
-        deps.selection.currentSelection(),
-        deps.catalog.list(),
-      ]);
-      const previous = projects.find(
-        (project) => project.id === id || project.aliases?.includes(id),
-      );
-      const selectedProjectWasRelinked = previous?.locations.some(
-        (location) => location.path === selection.path,
-      );
+      const selection = await deps.selection.currentSelection();
+      const selectedProjectWasRelinked = selection.projectId === id;
       const project = await deps.catalog.relink(id, path);
-      if (selectedProjectWasRelinked && project.preferredPath) {
-        deps.selection.setSelection(project.id, project.preferredPath);
+      if (selectedProjectWasRelinked) {
+        const selected = requireSelectableProject(project);
+        deps.selection.setSelection(selected.id, selected.preferredPath);
       }
       return { ok: true, project };
     },
 
     async pathFor(projectId) {
       const id = requireProjectId(projectId);
-      const project = (await deps.catalog.list()).find(
-        (candidate) => candidate.id === id || candidate.aliases?.includes(id),
-      );
-      if (!project || project.archivedAt !== undefined || !project.available) return null;
-      return project.preferredPath ?? null;
+      const project = selectableProject(await deps.catalog.list(), id);
+      return project?.preferredPath ?? null;
     },
 
     rename(projectId, name) {
@@ -158,4 +138,28 @@ export function createProjectManagementService(deps: {
 function requireProjectId(value: unknown): string {
   if (typeof value !== 'string' || !value) throw new TypeError('Invalid project id.');
   return value;
+}
+
+function selectableProject(
+  projects: readonly ProjectRecord[],
+  id: string,
+): (ProjectRecord & { readonly preferredPath: string }) | undefined {
+  const project = projects.find(
+    (candidate) => candidate.id === id || candidate.aliases?.includes(id),
+  );
+  return isSelectableProject(project) ? project : undefined;
+}
+
+function requireSelectableProject(
+  project: ProjectRecord,
+): ProjectRecord & { readonly preferredPath: string } {
+  const selected = selectableProject([project], project.id);
+  if (!selected) throw new Error(`Project is unavailable: ${project.id}`);
+  return selected;
+}
+
+function isSelectableProject(
+  project: ProjectRecord | undefined,
+): project is ProjectRecord & { readonly preferredPath: string } {
+  return Boolean(project?.available && project.archivedAt === undefined && project.preferredPath);
 }

--- a/apps/desktop/src/main/project-root-controller.ts
+++ b/apps/desktop/src/main/project-root-controller.ts
@@ -1,4 +1,4 @@
-import { readFile, stat, writeFile } from 'node:fs/promises';
+import { readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { resolveProjectRoot } from '@maka/runtime';
 
 export interface CurrentProjectSelection {
@@ -6,94 +6,43 @@ export interface CurrentProjectSelection {
   path: string;
 }
 
-/**
- * Owns the "current project root" selection shared across the app/window,
- * git, workspace-search, and session-entry IPC surfaces. Project management
- * updates the project id and path together, and
- * every other surface reads that same selection snapshot.
- *
- * Extracted from the former `registerIpc()` closures so the state has one owner
- * once the handlers are split across modules.
- */
 export interface ProjectRootController {
-  /** Resolve the effective project root (selected → persisted → fallback). */
   current(): Promise<string>;
-  /** Resolve the selected project association and its effective root together. */
   currentSelection(): Promise<CurrentProjectSelection>;
-  /** Validate + resolve an explicit renderer-supplied path without selecting it. */
   resolveExplicit(
     projectPath: unknown,
   ): Promise<
     | { ok: true; projectPath: string }
     | { ok: false; reason: 'invalid-path' | 'not-found' }
   >;
-  /** Adopt a project association and resolved root as one persisted selection. */
   setSelection(projectId: string | null, projectPath: string): void;
 }
 
 export interface ProjectRootControllerDeps {
-  /** Absolute path of the JSON file that persists the last selected project. */
-  lastProjectPathFile: string;
-  /** Roots probed (in order) when nothing is selected or persisted. */
-  fallbackRoots: () => string[];
+  readonly rootId: string;
+  readonly preferenceFile: string;
+  readonly legacySelectionFile: string;
+  readonly fallbackRoots: () => string[];
+}
+
+interface ProjectPreferenceFile {
+  readonly version: 1;
+  readonly selections: Readonly<Record<string, string | null>>;
 }
 
 export function createProjectRootController(
   deps: ProjectRootControllerDeps,
 ): ProjectRootController {
   let selectedProject: CurrentProjectSelection | null = null;
+  const initialSelection = loadInitialSelection(deps);
 
-  async function loadPersistedProjectRoot(): Promise<CurrentProjectSelection | null> {
-    try {
-      const raw = await readFile(deps.lastProjectPathFile, 'utf8');
-      const parsed = JSON.parse(raw) as Record<string, unknown>;
-      if (typeof parsed.projectPath === 'string' && parsed.projectPath) {
-        await stat(parsed.projectPath);
-        return {
-          projectId:
-            typeof parsed.projectId === 'string' || parsed.projectId === null
-              ? parsed.projectId
-              : undefined,
-          path: await resolveProjectRoot([parsed.projectPath]),
-        };
-      }
-    } catch {
-      // File missing, invalid, or points at a deleted directory.
-    }
-    return null;
-  }
-  const persistedProjectRootPromise = loadPersistedProjectRoot();
-
-  async function saveLastProjectPath(
-    projectPath: string,
-    projectId: string | null | undefined,
-  ): Promise<void> {
-    try {
-      await writeFile(
-        deps.lastProjectPathFile,
-        JSON.stringify({
-          projectPath,
-          ...(projectId !== undefined ? { projectId } : {}),
-        }),
-        'utf8',
-      );
-    } catch {
-      // Best-effort; failure should not block the selection.
-    }
+  async function currentSelection(): Promise<CurrentProjectSelection> {
+    if (selectedProject) return selectedProject;
+    return (selectedProject = await initialSelection);
   }
 
   async function current(): Promise<string> {
     return (await currentSelection()).path;
-  }
-
-  async function currentSelection(): Promise<CurrentProjectSelection> {
-    if (selectedProject) return selectedProject;
-    const persistedProjectRoot = await persistedProjectRootPromise;
-    if (persistedProjectRoot) return (selectedProject = persistedProjectRoot);
-    return {
-      projectId: undefined,
-      path: await resolveProjectRoot(deps.fallbackRoots()),
-    };
   }
 
   async function resolveExplicit(projectPath: unknown): Promise<
@@ -113,8 +62,87 @@ export function createProjectRootController(
 
   function setSelection(projectId: string | null, projectPath: string): void {
     selectedProject = { projectId, path: projectPath };
-    void saveLastProjectPath(projectPath, projectId);
+    void savePreference(deps, projectId);
   }
 
   return { current, currentSelection, resolveExplicit, setSelection };
+}
+
+async function loadInitialSelection(
+  deps: ProjectRootControllerDeps,
+): Promise<CurrentProjectSelection> {
+  const fallbackPath = await resolveProjectRoot(deps.fallbackRoots());
+  const preference = await readPreference(deps.preferenceFile, deps.rootId);
+  if (preference !== undefined) return { projectId: preference, path: fallbackPath };
+
+  const legacy = await readLegacySelection(deps.legacySelectionFile);
+  if (!legacy) return { projectId: undefined, path: fallbackPath };
+  if (legacy.projectId !== undefined && !(await savePreference(deps, legacy.projectId))) {
+    return legacy;
+  }
+  await rm(deps.legacySelectionFile, { force: true }).catch(() => undefined);
+  return legacy;
+}
+
+async function readPreference(file: string, rootId: string): Promise<string | null | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(file, 'utf8')) as Partial<ProjectPreferenceFile>;
+    if (parsed.version !== 1 || !parsed.selections || typeof parsed.selections !== 'object') {
+      return undefined;
+    }
+    const value = parsed.selections[rootId];
+    return typeof value === 'string' || value === null ? value : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function readLegacySelection(file: string): Promise<CurrentProjectSelection | null> {
+  try {
+    const parsed = JSON.parse(await readFile(file, 'utf8')) as Record<string, unknown>;
+    if (typeof parsed.projectPath !== 'string' || !parsed.projectPath) return null;
+    await stat(parsed.projectPath);
+    return {
+      projectId:
+        typeof parsed.projectId === 'string' || parsed.projectId === null
+          ? parsed.projectId
+          : undefined,
+      path: await resolveProjectRoot([parsed.projectPath]),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function savePreference(
+  deps: ProjectRootControllerDeps,
+  projectId: string | null,
+): Promise<boolean> {
+  try {
+    const current = await readPreferenceFile(deps.preferenceFile);
+    await writeFile(
+      deps.preferenceFile,
+      JSON.stringify({
+        version: 1,
+        selections: { ...current.selections, [deps.rootId]: projectId },
+      } satisfies ProjectPreferenceFile),
+      'utf8',
+    );
+    return true;
+  } catch {
+    // Selection persistence is best-effort and never blocks the active window.
+    return false;
+  }
+}
+
+async function readPreferenceFile(file: string): Promise<ProjectPreferenceFile> {
+  try {
+    const parsed = JSON.parse(await readFile(file, 'utf8')) as Partial<ProjectPreferenceFile>;
+    if (parsed.version === 1 && parsed.selections && typeof parsed.selections === 'object') {
+      return { version: 1, selections: parsed.selections as Record<string, string | null> };
+    }
+  } catch {
+    // Start a new preference file below.
+  }
+  return { version: 1, selections: {} };
 }

--- a/apps/desktop/src/main/project-root-controller.ts
+++ b/apps/desktop/src/main/project-root-controller.ts
@@ -1,4 +1,5 @@
-import { readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { readFile, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { resolveProjectRoot } from '@maka/runtime';
 
 export interface CurrentProjectSelection {
@@ -15,7 +16,7 @@ export interface ProjectRootController {
     | { ok: true; projectPath: string }
     | { ok: false; reason: 'invalid-path' | 'not-found' }
   >;
-  setSelection(projectId: string | null, projectPath: string): void;
+  setSelection(projectId: string | null, projectPath: string): Promise<void>;
 }
 
 export interface ProjectRootControllerDeps {
@@ -29,6 +30,8 @@ interface ProjectPreferenceFile {
   readonly version: 1;
   readonly selections: Readonly<Record<string, string | null>>;
 }
+
+const preferenceWriteTails = new Map<string, Promise<void>>();
 
 export function createProjectRootController(
   deps: ProjectRootControllerDeps,
@@ -60,9 +63,9 @@ export function createProjectRootController(
     return { ok: true, projectPath: await resolveProjectRoot([projectPath]) };
   }
 
-  function setSelection(projectId: string | null, projectPath: string): void {
+  function setSelection(projectId: string | null, projectPath: string): Promise<void> {
     selectedProject = { projectId, path: projectPath };
-    void persistSelection(deps, projectId);
+    return persistSelection(deps, projectId);
   }
 
   return { current, currentSelection, resolveExplicit, setSelection };
@@ -127,20 +130,46 @@ async function savePreference(
   deps: ProjectRootControllerDeps,
   projectId: string | null,
 ): Promise<boolean> {
-  try {
-    const current = await readPreferenceFile(deps.preferenceFile);
-    await writeFile(
-      deps.preferenceFile,
-      JSON.stringify({
+  return enqueuePreferenceWrite(deps.preferenceFile, async () => {
+    try {
+      const current = await readPreferenceFile(deps.preferenceFile);
+      await writePreferenceFile(deps.preferenceFile, {
         version: 1,
         selections: { ...current.selections, [deps.rootId]: projectId },
-      } satisfies ProjectPreferenceFile),
-      'utf8',
-    );
-    return true;
-  } catch {
-    // Selection persistence is best-effort and never blocks the active window.
-    return false;
+      });
+      return true;
+    } catch {
+      // Selection persistence is best-effort and never blocks the active window.
+      return false;
+    }
+  });
+}
+
+function enqueuePreferenceWrite<Result>(
+  file: string,
+  operation: () => Promise<Result>,
+): Promise<Result> {
+  const previous = preferenceWriteTails.get(file) ?? Promise.resolve();
+  const result = previous.then(operation, operation);
+  const tail = result.then(
+    () => undefined,
+    () => undefined,
+  );
+  preferenceWriteTails.set(file, tail);
+  void tail.then(() => {
+    if (preferenceWriteTails.get(file) === tail) preferenceWriteTails.delete(file);
+  });
+  return result;
+}
+
+async function writePreferenceFile(file: string, value: ProjectPreferenceFile): Promise<void> {
+  const temporaryFile = `${file}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporaryFile, JSON.stringify(value), { encoding: 'utf8', flag: 'wx' });
+    await rename(temporaryFile, file);
+  } catch (error) {
+    await rm(temporaryFile, { force: true }).catch(() => undefined);
+    throw error;
   }
 }
 

--- a/apps/desktop/src/main/project-root-controller.ts
+++ b/apps/desktop/src/main/project-root-controller.ts
@@ -62,7 +62,7 @@ export function createProjectRootController(
 
   function setSelection(projectId: string | null, projectPath: string): void {
     selectedProject = { projectId, path: projectPath };
-    void savePreference(deps, projectId);
+    void persistSelection(deps, projectId);
   }
 
   return { current, currentSelection, resolveExplicit, setSelection };
@@ -77,11 +77,20 @@ async function loadInitialSelection(
 
   const legacy = await readLegacySelection(deps.legacySelectionFile);
   if (!legacy) return { projectId: undefined, path: fallbackPath };
-  if (legacy.projectId !== undefined && !(await savePreference(deps, legacy.projectId))) {
+  if (typeof legacy.projectId !== 'string') return legacy;
+  if (!(await savePreference(deps, legacy.projectId))) {
     return legacy;
   }
   await rm(deps.legacySelectionFile, { force: true }).catch(() => undefined);
   return legacy;
+}
+
+async function persistSelection(
+  deps: ProjectRootControllerDeps,
+  projectId: string | null,
+): Promise<void> {
+  if (!(await savePreference(deps, projectId))) return;
+  await rm(deps.legacySelectionFile, { force: true }).catch(() => undefined);
 }
 
 async function readPreference(file: string, rootId: string): Promise<string | null | undefined> {

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -20,7 +20,7 @@ import {
   type BotIncomingMessage,
 } from "@maka/runtime";
 import { loadOrCreateRuntimeHostClientInstanceId } from "@maka/runtime-host/client";
-import type { WorkspaceProjection } from "@maka/runtime-host/protocol";
+import type { WorkspaceTarget } from "@maka/runtime-host/protocol";
 import { McpClientManager } from "@maka/mcp";
 import {
   createSettingsStore,
@@ -262,15 +262,11 @@ const projectManagement: ProjectManagementService = createProjectManagementServi
   },
   selection: projectRoot,
 });
-const currentDesktopWorkspace = async (): Promise<WorkspaceProjection> => {
+const currentDesktopWorkspaceTarget = async (): Promise<WorkspaceTarget> => {
   const current = await projectManagement.current();
-  return {
-    target:
-      typeof current.projectId === "string"
-        ? { kind: "project", projectId: current.projectId }
-        : { kind: "host_path", path: current.path },
-    hostCwd: current.path,
-  };
+  return typeof current.projectId === "string"
+    ? { kind: "project", projectId: current.projectId }
+    : { kind: "host_path", path: current.path };
 };
 const mcpCapabilityPublisher = createCapabilityRevisionPublisher(() =>
   mcpManager.toolSnapshotRevision(),
@@ -445,7 +441,7 @@ owner = await startRuntimeHostDesktopOwner(
     },
     botRegistry,
     resolveBotCreateTarget: async () => ({
-      workspace: (await currentDesktopWorkspace()).target,
+      workspace: await currentDesktopWorkspaceTarget(),
     }),
     resolveSessionCreateProject: async (input) => {
       return resolveDesktopSessionWorkspace(
@@ -664,7 +660,7 @@ function registerHostClientIpc(
     client,
     workspaceRoot,
     mainWindowController,
-    getCurrentWorkspace: currentDesktopWorkspace,
+    getCurrentWorkspaceTarget: currentDesktopWorkspaceTarget,
     getDefaultPermissionMode: () =>
       resolveDefaultPermissionMode(() => loadRuntimeHostSettings(settingsIpcDeps)),
     openPath: (path) => shell.openPath(path),

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -20,12 +20,14 @@ import {
   type BotIncomingMessage,
 } from "@maka/runtime";
 import { loadOrCreateRuntimeHostClientInstanceId } from "@maka/runtime-host/client";
+import type { WorkspaceProjection } from "@maka/runtime-host/protocol";
 import { McpClientManager } from "@maka/mcp";
 import {
   createSettingsStore,
   createMcpConfigStore,
   createSqlitePlanReminderStore,
 } from "@maka/storage";
+import { resolveStorageRoot } from "@maka/storage/root-authority";
 import { registerAppIpc } from "./app-ipc-main.js";
 import { createAppQuitCoordinator } from "./app-quit-coordinator.js";
 import { createAppUpdateService } from "./app-update-service.js";
@@ -56,8 +58,7 @@ import {
 import { createMainWindowController } from "./main-window.js";
 import { mainProcessLogBuffer } from "./main-process-diagnostics.js";
 import {
-  resolveDesktopSessionSelection,
-  resolveNewSessionProjectInput,
+  resolveDesktopSessionWorkspace,
 } from "./new-session-project.js";
 import { registerMcpIpcMain } from "./mcp-ipc-main.js";
 import { createOnboardingService } from "./onboarding-service.js";
@@ -152,17 +153,19 @@ if (e2eFixture) {
     `[e2e-fixture] scenario=${e2eFixture.scenario} workspace=${workspaceRoot}`,
   );
   await seedE2eFixture({ workspaceRoot, fixture: e2eFixture });
-} else {
-  const storageRoot = await startupStep(
+}
+const storageRoot = e2eFixture
+  ? await resolveStorageRoot({ path: workspaceRoot, kind: "interactive" })
+  : await startupStep(
     "storage root",
     resolveDesktopStorageRoot(workspaceRoot, {
       confirmRepair: () => confirmDesktopStorageRootRepair(workspaceRoot),
     }),
   );
-  if (!storageRoot) {
-    app.exit(0);
-    await new Promise<never>(() => {});
-  }
+if (!storageRoot) {
+  app.exit(0);
+  await new Promise<never>(() => {});
+  throw new Error("Desktop storage root resolution did not complete");
 }
 const settingsStore = createSettingsStore(workspaceRoot);
 const mcpConfigStore = createMcpConfigStore(workspaceRoot);
@@ -231,7 +234,9 @@ onMainWindowClose = () => {
   native.computerUsePip.destroyAll();
 };
 const projectRoot = createProjectRootController({
-  lastProjectPathFile: join(workspaceRoot, "last-project-path.json"),
+  rootId: storageRoot.rootId,
+  preferenceFile: join(workspaceRoot, "project-preferences.json"),
+  legacySelectionFile: join(workspaceRoot, "last-project-path.json"),
   fallbackRoots: () => [process.cwd(), app.getAppPath()],
 });
 const attachmentApprovals = createAttachmentApprovalRegistry();
@@ -257,6 +262,16 @@ const projectManagement: ProjectManagementService = createProjectManagementServi
   },
   selection: projectRoot,
 });
+const currentDesktopWorkspace = async (): Promise<WorkspaceProjection> => {
+  const current = await projectManagement.current();
+  return {
+    target:
+      typeof current.projectId === "string"
+        ? { kind: "project", projectId: current.projectId }
+        : { kind: "host_path", path: current.path },
+    hostCwd: current.path,
+  };
+};
 const mcpCapabilityPublisher = createCapabilityRevisionPublisher(() =>
   mcpManager.toolSnapshotRevision(),
 );
@@ -429,14 +444,19 @@ owner = await startRuntimeHostDesktopOwner(
       releaseComputerUseSession,
     },
     botRegistry,
-    resolveBotCreateTarget: async () => ({ cwd: await projectRoot.current() }),
+    resolveBotCreateTarget: async () => ({
+      workspace: (await currentDesktopWorkspace()).target,
+    }),
     resolveSessionCreateProject: async (input) => {
-      const selected = await resolveDesktopSessionSelection(input, {
-        ...projectManagement,
-        defaultProjectId: async () =>
-          (await settingsStore.get()).projects.defaultProjectId,
-      });
-      return resolveNewSessionProjectInput(selected, projectCatalog);
+      return resolveDesktopSessionWorkspace(
+        input,
+        {
+          ...projectManagement,
+          defaultProjectId: async () =>
+            (await settingsStore.get()).projects.defaultProjectId,
+        },
+        projectCatalog,
+      );
     },
     emitSessionsChanged,
     emitModeChanged: (sessionId) =>
@@ -644,7 +664,7 @@ function registerHostClientIpc(
     client,
     workspaceRoot,
     mainWindowController,
-    getCurrentProjectRoot: () => projectRoot.current(),
+    getCurrentWorkspace: currentDesktopWorkspace,
     getDefaultPermissionMode: () =>
       resolveDefaultPermissionMode(() => loadRuntimeHostSettings(settingsIpcDeps)),
     openPath: (path) => shell.openPath(path),
@@ -674,7 +694,7 @@ function registerHostClientIpc(
       readSessionCwd: async (id) => {
         const session = await client.getSession(id);
         if (!session) throw new Error(`No such Session: ${id}`);
-        return session.cwd;
+        return session.workspace.hostCwd;
       },
     });
   registerAppIpc(

--- a/apps/desktop/src/main/runtime-host-bot-session-adapter.ts
+++ b/apps/desktop/src/main/runtime-host-bot-session-adapter.ts
@@ -3,6 +3,7 @@ import { RuntimeHostOperationError } from '@maka/runtime-host/client';
 import type {
   SessionCatalogProjection,
   SubscriptionFrame,
+  WorkspaceTarget,
 } from '@maka/runtime-host/protocol';
 import type {
   BotSessionAdapter,
@@ -25,8 +26,7 @@ type RuntimeHostBotSessionClient = Pick<
 >;
 
 export interface RuntimeHostBotSessionCreateTarget {
-  readonly cwd: string;
-  readonly projectId?: string | null;
+  readonly workspace: WorkspaceTarget;
 }
 
 export interface RuntimeHostBotSessionAdapterDeps {
@@ -53,8 +53,7 @@ export function createRuntimeHostBotSessionAdapter(
       try {
         session = await deps.client.createSession({
           sessionId,
-          cwd: target.cwd,
-          ...(target.projectId === undefined ? {} : { projectId: target.projectId }),
+          workspace: target.workspace,
           name: input.name,
           labels: [...input.labels],
           modelTarget: { kind: 'default' },

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -33,7 +33,7 @@ import {
   readRuntimeHostConnectionCatalog,
   readRuntimeHostInvocableSkills,
   readRuntimeHostResources,
-  readRuntimeHostProjects,
+  readRuntimeHostProjectDetails,
   readRuntimeHostSessions,
   readRuntimeHostSkillCatalog,
 } from "@maka/runtime-host/client";
@@ -66,8 +66,8 @@ import {
   type PricingQueryResult,
   type ProjectCatalogMutateInput,
   type ProjectCatalogMutateResult,
-  type ProjectCatalogLocationQueryResult,
   type ProjectCatalogProject,
+  type ProjectCatalogProjectDetails,
   type QueueRetractInput,
   type QueueRetractResult,
   type SessionCatalogFilter,
@@ -491,10 +491,10 @@ export class DesktopRuntimeHostClient {
     }
   }
 
-  async listProjects(): Promise<ProjectCatalogProject[]> {
+  async listProjects(): Promise<ProjectCatalogProjectDetails[]> {
     this.#assertOpen();
     try {
-      return await readRuntimeHostProjects(this.connection);
+      return await readRuntimeHostProjectDetails(this.connection);
     } catch (error) {
       if (!(error instanceof RuntimeHostCatalogReadError)) throw error;
       throw new DesktopRuntimeHostClientError(
@@ -507,10 +507,6 @@ export class DesktopRuntimeHostClient {
   async registerProject(path: string): Promise<ProjectCatalogProject> {
     const result = await this.#mutateProject({ kind: "register", path });
     return this.#projectForMutation(result);
-  }
-
-  projectLocations(projectId: string): Promise<ProjectCatalogLocationQueryResult> {
-    return this.#request("project.catalog.location.query", { projectId });
   }
 
   async relinkProject(projectId: string, path: string): Promise<ProjectCatalogProject> {

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -98,6 +98,7 @@ import {
   type TurnInterruptResult,
   type TurnMessageSubmitInput,
   type TurnMessageSubmitResult,
+  type WorkspaceProjection,
 } from "@maka/runtime-host/protocol";
 
 const MAX_OPTIMISTIC_ATTEMPTS = 3;
@@ -145,6 +146,7 @@ export interface DesktopSkillCatalogSnapshot {
   readonly revision: SkillCatalogRevision;
   readonly view: SkillCatalogView;
   readonly items: readonly SkillCatalogPageItem[];
+  readonly workspace: WorkspaceProjection;
 }
 
 export interface DesktopPricingMutationInput {
@@ -368,7 +370,17 @@ export class DesktopRuntimeHostClient {
   ): Promise<DesktopSkillCatalogSnapshot> {
     this.#assertOpen();
     try {
-      return await readRuntimeHostSkillCatalog(this.connection, context, view);
+      const snapshot = await readRuntimeHostSkillCatalog(
+        this.connection,
+        context,
+        view,
+      );
+      return {
+        revision: snapshot.revision,
+        view: snapshot.view,
+        items: snapshot.items,
+        workspace: snapshot.resolvedWorkspace,
+      };
     } catch (error) {
       if (!(error instanceof RuntimeHostCatalogReadError)) throw error;
       throw new DesktopRuntimeHostClientError(

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1,6 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
 import type { AttachmentRef, ShellRunUpdate } from "@maka/core/events";
-import type { ProjectRecord } from "@maka/core";
 import type { PlanSessionState, PlanUserControlInput } from "@maka/core/plan";
 import {
   decodeStoredMessageForRead,
@@ -67,6 +66,7 @@ import {
   type PricingQueryResult,
   type ProjectCatalogMutateInput,
   type ProjectCatalogMutateResult,
+  type ProjectCatalogLocationQueryResult,
   type ProjectCatalogProject,
   type QueueRetractInput,
   type QueueRetractResult,
@@ -83,7 +83,7 @@ import {
   type SessionLifecycleState,
   type SessionMetadataPatch,
   type SessionUpdateResult,
-  type SkillCatalogLocalContext,
+  type SkillCatalogWorkspaceContext,
   type SkillCatalogInvocableItem,
   type SkillCatalogInvocableTarget,
   type SkillCatalogMutateInput,
@@ -363,7 +363,7 @@ export class DesktopRuntimeHostClient {
   }
 
   async loadSkillCatalog(
-    context: SkillCatalogLocalContext,
+    context: SkillCatalogWorkspaceContext,
     view: SkillCatalogView,
   ): Promise<DesktopSkillCatalogSnapshot> {
     this.#assertOpen();
@@ -491,10 +491,10 @@ export class DesktopRuntimeHostClient {
     }
   }
 
-  async listProjects(): Promise<ProjectRecord[]> {
+  async listProjects(): Promise<ProjectCatalogProject[]> {
     this.#assertOpen();
     try {
-      return (await readRuntimeHostProjects(this.connection)).map(toProjectRecord);
+      return await readRuntimeHostProjects(this.connection);
     } catch (error) {
       if (!(error instanceof RuntimeHostCatalogReadError)) throw error;
       throw new DesktopRuntimeHostClientError(
@@ -504,42 +504,34 @@ export class DesktopRuntimeHostClient {
     }
   }
 
-  async registerProject(path: string): Promise<ProjectRecord> {
+  async registerProject(path: string): Promise<ProjectCatalogProject> {
     const result = await this.#mutateProject({ kind: "register", path });
     return this.#projectForMutation(result);
   }
 
-  async selectProject(projectId: string): Promise<{ project: ProjectRecord; path: string }> {
-    const result = await this.#mutateProject({ kind: "select", projectId });
-    if (result.kind !== "selection") throw invalidProjection("Project selection");
-    return { project: await this.#projectById(result.projectId), path: result.path };
+  projectLocations(projectId: string): Promise<ProjectCatalogLocationQueryResult> {
+    return this.#request("project.catalog.location.query", { projectId });
   }
 
-  async touchProject(projectId: string, path?: string): Promise<ProjectRecord> {
-    return this.#projectForMutation(
-      await this.#mutateProject({ kind: "touch", projectId, path: path ?? null }),
-    );
-  }
-
-  async relinkProject(projectId: string, path: string): Promise<ProjectRecord> {
+  async relinkProject(projectId: string, path: string): Promise<ProjectCatalogProject> {
     return this.#projectForMutation(
       await this.#mutateProject({ kind: "relink", projectId, path }),
     );
   }
 
-  async renameProject(projectId: string, name: string): Promise<ProjectRecord> {
+  async renameProject(projectId: string, name: string): Promise<ProjectCatalogProject> {
     return this.#projectForMutation(
       await this.#mutateProject({ kind: "rename", projectId, name }),
     );
   }
 
-  async archiveProject(projectId: string): Promise<ProjectRecord> {
+  async archiveProject(projectId: string): Promise<ProjectCatalogProject> {
     return this.#projectForMutation(
       await this.#mutateProject({ kind: "archive", projectId }),
     );
   }
 
-  async restoreProject(projectId: string): Promise<ProjectRecord> {
+  async restoreProject(projectId: string): Promise<ProjectCatalogProject> {
     return this.#projectForMutation(
       await this.#mutateProject({ kind: "restore", projectId }),
     );
@@ -550,17 +542,9 @@ export class DesktopRuntimeHostClient {
     return this.#request("project.catalog.mutate", input);
   }
 
-  async #projectForMutation(result: ProjectCatalogMutateResult): Promise<ProjectRecord> {
+  #projectForMutation(result: ProjectCatalogMutateResult): ProjectCatalogProject {
     if (result.kind !== "project") throw invalidProjection("Project mutation");
-    return this.#projectById(result.projectId);
-  }
-
-  async #projectById(projectId: string): Promise<ProjectRecord> {
-    const project = (await this.listProjects()).find(
-      (candidate) => candidate.id === projectId || candidate.aliases?.includes(projectId),
-    );
-    if (!project) throw invalidProjection("Project mutation");
-    return project;
+    return result.project;
   }
 
   async listArtifacts(sessionId: string): Promise<ArtifactProjection[]> {
@@ -780,21 +764,6 @@ export class DesktopRuntimeHostClient {
           orchestrationMode: current.orchestrationMode,
           ...definedPatch,
         },
-      }),
-    );
-  }
-
-  relocateSessionCwd(
-    sessionId: string,
-    cwd: string,
-    projectId?: string | null,
-  ): Promise<SessionCatalogProjection> {
-    return this.#updateSession(sessionId, (current) =>
-      this.#request("session.cwd.relocate", {
-        sessionId,
-        expectedRevision: current.revision,
-        cwd,
-        ...(projectId === undefined ? {} : { projectId }),
       }),
     );
   }
@@ -1535,18 +1504,6 @@ function requireSessionProjection(
     "unsupported_session",
     `Runtime Host Session is not representable by this Desktop Client: ${item.id}`,
   );
-}
-
-function toProjectRecord(project: ProjectCatalogProject): ProjectRecord {
-  return {
-    id: project.id,
-    ...(project.aliases.length === 0 ? {} : { aliases: [...project.aliases] }),
-    name: project.name,
-    locations: project.locations.map((location) => ({ ...location })),
-    ...(project.archivedAt === null ? {} : { archivedAt: project.archivedAt }),
-    available: project.available,
-    ...(project.preferredPath === null ? {} : { preferredPath: project.preferredPath }),
-  };
 }
 
 function clientClosed(): DesktopRuntimeHostClientError {

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -16,6 +16,7 @@ import {
 import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  type WorkspaceTarget,
 } from "@maka/runtime-host/protocol";
 import type { AttachmentApprovalRegistry } from "./attachment-approval.js";
 import {
@@ -58,13 +59,10 @@ export interface DesktopRuntimeHostCandidateDeps {
   readonly resizeImage: (bytes: Uint8Array) => Promise<Uint8Array>;
   readonly nativeCapabilities: DesktopNativeCapabilityProviderInput;
   readonly botRegistry: BotRegistry;
-  readonly resolveBotCreateTarget: () => Promise<{
-    readonly cwd: string;
-    readonly projectId?: string | null;
-  }>;
+  readonly resolveBotCreateTarget: () => Promise<{ readonly workspace: WorkspaceTarget }>;
   readonly resolveSessionCreateProject: (
     input: Pick<CreateSessionRequestInput, "cwd" | "projectId">,
-  ) => Promise<{ readonly cwd: string; readonly projectId?: string | null }>;
+  ) => Promise<WorkspaceTarget>;
   readonly emitSessionsChanged: (
     reason: SessionChangedReason,
     sessionId?: string,

--- a/apps/desktop/src/main/runtime-host-external-sessions-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-external-sessions-ipc-main.ts
@@ -40,9 +40,18 @@ export function registerRuntimeHostExternalSessionsIpc(
   handleReconnectableRead(ipcMain, 'external-sessions:listSources', () =>
     deps.client.listExternalSessionSources(),
   );
-  handleReconnectableRead(ipcMain, 'external-sessions:list', (_event, input: unknown) =>
-    deps.client.listExternalSessions(decodeExternalSessionCatalogQueryInput(input)),
-  );
+  handleReconnectableRead(ipcMain, 'external-sessions:list', async (_event, input: unknown) => {
+    const result = await deps.client.listExternalSessions(
+      decodeExternalSessionCatalogQueryInput(input),
+    );
+    return {
+      ...result,
+      sessions: result.sessions.map(({ hostCwd, ...session }) => ({
+        ...session,
+        cwd: hostCwd,
+      })),
+    };
+  });
   ipcMain.handle('external-sessions:import', async (_event, input: unknown) => {
     try {
       const session = await deps.client.importExternalSession(

--- a/apps/desktop/src/main/runtime-host-project-catalog.ts
+++ b/apps/desktop/src/main/runtime-host-project-catalog.ts
@@ -1,45 +1,71 @@
 import type { ProjectRecord } from "@maka/core";
-import { RuntimeHostOperationError } from "@maka/runtime-host/client";
-import { ProjectPathMismatchError } from "@maka/storage";
+import type { ProjectCatalogProject } from "@maka/runtime-host/protocol";
 import type { ProjectManagementCatalog } from "./project-management-service.js";
 import type { DesktopRuntimeHostClient } from "./runtime-host-client.js";
 
-export interface DesktopProjectCatalog extends ProjectManagementCatalog {
-  touch(projectId: string, path?: string): Promise<ProjectRecord>;
-}
+export interface DesktopProjectCatalog extends ProjectManagementCatalog {}
 
 type RuntimeHostProjectClient = Pick<
   DesktopRuntimeHostClient,
   | "archiveProject"
   | "listProjects"
+  | "projectLocations"
   | "registerProject"
   | "relinkProject"
   | "renameProject"
   | "restoreProject"
-  | "selectProject"
-  | "touchProject"
 >;
 
 export function createRuntimeHostProjectCatalog(
   resolveClient: () => RuntimeHostProjectClient,
 ): DesktopProjectCatalog {
   return {
-    list: () => resolveClient().listProjects(),
-    register: (path) => resolveClient().registerProject(path),
-    select: (projectId) => resolveClient().selectProject(projectId),
-    async touch(projectId, path) {
-      try {
-        return await resolveClient().touchProject(projectId, path);
-      } catch (error) {
-        if (error instanceof RuntimeHostOperationError && error.code === "operation_conflict") {
-          throw new ProjectPathMismatchError(projectId, path ?? "");
-        }
-        throw error;
-      }
+    list: async () => {
+      const client = resolveClient();
+      return Promise.all((await client.listProjects()).map((project) => projectRecord(client, project)));
     },
-    relink: (projectId, path) => resolveClient().relinkProject(projectId, path),
-    rename: (projectId, name) => resolveClient().renameProject(projectId, name),
-    archive: (projectId) => resolveClient().archiveProject(projectId),
-    restore: (projectId) => resolveClient().restoreProject(projectId),
+    register: async (path) => {
+      const client = resolveClient();
+      return projectRecord(client, await client.registerProject(path));
+    },
+    relink: async (projectId, path) => {
+      const client = resolveClient();
+      return projectRecord(client, await client.relinkProject(projectId, path));
+    },
+    rename: async (projectId, name) => {
+      const client = resolveClient();
+      return projectRecord(client, await client.renameProject(projectId, name));
+    },
+    archive: async (projectId) => {
+      const client = resolveClient();
+      return projectRecord(client, await client.archiveProject(projectId));
+    },
+    restore: async (projectId) => {
+      const client = resolveClient();
+      return projectRecord(client, await client.restoreProject(projectId));
+    },
+  };
+}
+
+async function projectRecord(
+  client: Pick<DesktopRuntimeHostClient, "projectLocations">,
+  project: ProjectCatalogProject,
+): Promise<ProjectRecord> {
+  if (!project.available || project.archivedAt !== null) return toProjectRecord(project);
+  return toProjectRecord(project, await client.projectLocations(project.id));
+}
+
+function toProjectRecord(
+  project: ProjectCatalogProject,
+  location?: Awaited<ReturnType<DesktopRuntimeHostClient["projectLocations"]>>,
+): ProjectRecord {
+  return {
+    id: project.id,
+    ...(project.aliases.length === 0 ? {} : { aliases: [...project.aliases] }),
+    name: project.name,
+    locations: location ? [...location.locations] : [],
+    ...(project.archivedAt === null ? {} : { archivedAt: project.archivedAt }),
+    available: project.available,
+    ...(location ? { preferredPath: location.preferredPath } : {}),
   };
 }

--- a/apps/desktop/src/main/runtime-host-project-catalog.ts
+++ b/apps/desktop/src/main/runtime-host-project-catalog.ts
@@ -1,5 +1,8 @@
 import type { ProjectRecord } from "@maka/core";
-import type { ProjectCatalogProject } from "@maka/runtime-host/protocol";
+import type {
+  ProjectCatalogProject,
+  ProjectCatalogProjectDetails,
+} from "@maka/runtime-host/protocol";
 import type { ProjectManagementCatalog } from "./project-management-service.js";
 import type { DesktopRuntimeHostClient } from "./runtime-host-client.js";
 
@@ -9,7 +12,6 @@ type RuntimeHostProjectClient = Pick<
   DesktopRuntimeHostClient,
   | "archiveProject"
   | "listProjects"
-  | "projectLocations"
   | "registerProject"
   | "relinkProject"
   | "renameProject"
@@ -22,7 +24,7 @@ export function createRuntimeHostProjectCatalog(
   return {
     list: async () => {
       const client = resolveClient();
-      return Promise.all((await client.listProjects()).map((project) => projectRecord(client, project)));
+      return (await client.listProjects()).map(toProjectRecord);
     },
     register: async (path) => {
       const client = resolveClient();
@@ -48,24 +50,24 @@ export function createRuntimeHostProjectCatalog(
 }
 
 async function projectRecord(
-  client: Pick<DesktopRuntimeHostClient, "projectLocations">,
+  client: Pick<DesktopRuntimeHostClient, "listProjects">,
   project: ProjectCatalogProject,
 ): Promise<ProjectRecord> {
-  if (!project.available || project.archivedAt !== null) return toProjectRecord(project);
-  return toProjectRecord(project, await client.projectLocations(project.id));
+  const details = (await client.listProjects()).find(
+    (candidate) => candidate.id === project.id || candidate.aliases.includes(project.id),
+  );
+  if (!details) throw new Error(`Project ${project.id} disappeared after mutation`);
+  return toProjectRecord(details);
 }
 
-function toProjectRecord(
-  project: ProjectCatalogProject,
-  location?: Awaited<ReturnType<DesktopRuntimeHostClient["projectLocations"]>>,
-): ProjectRecord {
+function toProjectRecord(project: ProjectCatalogProjectDetails): ProjectRecord {
   return {
     id: project.id,
     ...(project.aliases.length === 0 ? {} : { aliases: [...project.aliases] }),
     name: project.name,
-    locations: location ? [...location.locations] : [],
+    locations: [...project.locations],
     ...(project.archivedAt === null ? {} : { archivedAt: project.archivedAt }),
     available: project.available,
-    ...(location ? { preferredPath: location.preferredPath } : {}),
+    ...(project.preferredPath === null ? {} : { preferredPath: project.preferredPath }),
   };
 }

--- a/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
@@ -14,6 +14,7 @@ import type {
   SessionCatalogFilter,
   SessionCatalogProjection,
   SessionCreateInput,
+  WorkspaceTarget,
   SessionModelTarget,
 } from '@maka/runtime-host/protocol';
 import { resolveCreateSessionRequest } from './create-session-input.js';
@@ -50,7 +51,7 @@ export interface RuntimeHostSessionCatalogIpcDeps {
   client: RuntimeHostSessionCatalogClient;
   resolveCreateProject: (
     input: Pick<CreateSessionRequestInput, 'cwd' | 'projectId'>,
-  ) => Promise<{ readonly cwd: string; readonly projectId?: string | null }>;
+  ) => Promise<WorkspaceTarget>;
   emitSessionsChanged: (
     reason: SessionChangedReason,
     sessionId?: string,
@@ -101,15 +102,14 @@ export function registerRuntimeHostSessionCatalogIpc(
       throw new Error('Unsupported Runtime Host Session backend');
     }
     const request = resolveCreateSessionRequest(input);
-    const project = await deps.resolveCreateProject({
+    const workspace = await deps.resolveCreateProject({
       ...(input?.cwd === undefined ? {} : { cwd: input.cwd }),
       ...(input?.projectId === undefined ? {} : { projectId: input.projectId }),
     });
     const session = await deps.client.createSession({
       sessionId: newId(),
-      cwd: project.cwd,
+      workspace,
       ...(request.mode === undefined ? {} : { mode: request.mode }),
-      ...(project.projectId === undefined ? {} : { projectId: project.projectId }),
       ...(request.mode === undefined ? { name: request.name } : {}),
       ...(request.labels === undefined ? {} : { labels: request.labels }),
       modelTarget: normalizeModelTarget(input),
@@ -284,8 +284,10 @@ export function toDesktopHostSessionSummary(
 ): DesktopHostSessionSummary {
   return {
     id: session.id,
-    cwd: session.cwd,
-    ...(session.projectId === undefined ? {} : { projectId: session.projectId }),
+    cwd: session.workspace.hostCwd,
+    ...(session.workspace.target.kind === 'project'
+      ? { projectId: session.workspace.target.projectId }
+      : {}),
     name: session.name,
     isFlagged: session.isFlagged,
     isArchived: session.isArchived,

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -179,7 +179,7 @@ export function registerRuntimeHostSessionExecutionIpc(
         });
         attachments = await resolveAttachmentRefs({
           files,
-          cwd: session.cwd,
+          cwd: session.workspace.hostCwd,
           sessionId,
           workspaceFiles: "snapshot",
           resizeImage: deps.resizeImage,

--- a/apps/desktop/src/main/runtime-host-skills-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-skills-ipc-main.ts
@@ -11,6 +11,7 @@ import type {
   SkillCatalogMutation,
   SkillCatalogMutationRejectedReason,
   SkillCatalogPreviewUpdateResult,
+  WorkspaceProjection,
 } from "@maka/runtime-host/protocol";
 import type {
   BundledSkillCatalogEntry,
@@ -43,13 +44,13 @@ interface RuntimeHostSkillsIpcDeps {
   readonly client: DesktopRuntimeHostClient;
   readonly workspaceRoot: string;
   readonly mainWindowController: MainWindowController;
-  readonly getCurrentProjectRoot: () => Promise<string>;
+  readonly getCurrentWorkspace: () => Promise<WorkspaceProjection>;
   readonly getDefaultPermissionMode: () => Promise<ChatDefaultPermissionMode>;
   readonly openPath: (path: string) => Promise<string>;
 }
 
 interface GovernanceProjection {
-  readonly projectRoot: string;
+  readonly workspace: WorkspaceProjection;
   readonly snapshot: DesktopSkillCatalogSnapshot;
   readonly items: readonly SkillCatalogGovernanceItem[];
   readonly paths: ReadonlyMap<string, string>;
@@ -62,7 +63,7 @@ type StableSkillMutationResult = Exclude<
 
 interface StableSkillMutation {
   readonly result: StableSkillMutationResult;
-  readonly projectRoot: string;
+  readonly workspace: WorkspaceProjection;
 }
 
 export function registerRuntimeHostSkillsIpc(
@@ -71,7 +72,7 @@ export function registerRuntimeHostSkillsIpc(
   handleReconnectableRead(deps.ipcMain, "skills:list", async () => {
     const projection = await loadGovernance(
       deps,
-      await deps.getCurrentProjectRoot(),
+      await deps.getCurrentWorkspace(),
     );
     return projection.items.map((item) =>
       toSkillEntry(item, projection.paths.get(item.ref) ?? ""),
@@ -87,7 +88,7 @@ export function registerRuntimeHostSkillsIpc(
           ? { kind: "session" as const, sessionId }
           : {
               kind: "new_session" as const,
-              context: { projectRoot: await deps.getCurrentProjectRoot() },
+              context: { workspace: (await deps.getCurrentWorkspace()).target },
               collaborationMode:
                 normalizeNewSessionCollaborationMode(newSessionContext) ??
                 "agent",
@@ -100,9 +101,9 @@ export function registerRuntimeHostSkillsIpc(
   );
 
   handleReconnectableRead(deps.ipcMain, "skills:catalog:list", async () => {
-    const projectRoot = await deps.getCurrentProjectRoot();
+    const workspace = await deps.getCurrentWorkspace();
     const snapshot = await deps.client.loadSkillCatalog(
-      { projectRoot },
+      { workspace: workspace.target },
       "bundled",
     );
     return snapshot.items.flatMap((item): BundledSkillCatalogEntry[] =>
@@ -126,9 +127,9 @@ export function registerRuntimeHostSkillsIpc(
   });
 
   handleReconnectableRead(deps.ipcMain, "skills:sources:list", async () => {
-    const projectRoot = await deps.getCurrentProjectRoot();
+    const workspace = await deps.getCurrentWorkspace();
     const snapshot = await deps.client.loadSkillCatalog(
-      { projectRoot },
+      { workspace: workspace.target },
       "managed_sources",
     );
     return snapshot.items.flatMap((item): ManagedSkillSourceEntry[] =>
@@ -178,7 +179,7 @@ export function registerRuntimeHostSkillsIpc(
   handleReconnectableRead(deps.ipcMain, "skills:details", async (_event, idOrRef: string) => {
     const projection = await loadGovernance(
       deps,
-      await deps.getCurrentProjectRoot(),
+      await deps.getCurrentWorkspace(),
     );
     const resolved = resolveGovernanceItem(projection.items, idOrRef);
     if (!resolved.ok) return resolved;
@@ -195,13 +196,13 @@ export function registerRuntimeHostSkillsIpc(
     deps.ipcMain,
     "skills:previewUpdate",
     async (_event, idOrRef: string) => {
-      const projectRoot = await deps.getCurrentProjectRoot();
+      const workspace = await deps.getCurrentWorkspace();
       for (let attempt = 0; attempt < MAX_REVISION_ATTEMPTS; attempt += 1) {
-        const projection = await loadGovernance(deps, projectRoot);
+        const projection = await loadGovernance(deps, workspace);
         const resolved = resolveGovernanceItem(projection.items, idOrRef);
         if (!resolved.ok) return resolved;
         const result = await deps.client.previewSkillUpdate({
-          context: { projectRoot: projection.projectRoot },
+          context: { workspace: projection.workspace.target },
           expectedRevision: projection.snapshot.revision,
           ref: resolved.item.ref,
         });
@@ -282,7 +283,7 @@ export function registerRuntimeHostSkillsIpc(
   );
 
   deps.ipcMain.handle("skills:createStarter", async () => {
-    const { result, projectRoot } = await mutateSkill(deps, "governance", {
+    const { result, workspace } = await mutateSkill(deps, "governance", {
       kind: "create_starter",
     });
     if (result.kind === "rejected")
@@ -291,7 +292,7 @@ export function registerRuntimeHostSkillsIpc(
       throw new Error("Runtime Host did not project the starter Skill");
     const path = await resolveProjectedPath(
       deps.workspaceRoot,
-      projectRoot,
+      workspace.hostCwd,
       result.entry.ref,
     );
     return {
@@ -320,7 +321,7 @@ export function registerRuntimeHostSkillsIpc(
   deps.ipcMain.handle(
     "skills:open",
     async (_event, idOrRef: string, target: "file" | "directory" = "file") => {
-      const projectRoot = await deps.getCurrentProjectRoot();
+      const projectRoot = (await deps.getCurrentWorkspace()).hostCwd;
       const resolved = await resolveSkillOpenPath(
         deps.workspaceRoot,
         idOrRef,
@@ -338,17 +339,17 @@ export function registerRuntimeHostSkillsIpc(
 
 async function loadGovernance(
   deps: RuntimeHostSkillsIpcDeps,
-  projectRoot: string,
+  workspace: WorkspaceProjection,
 ): Promise<GovernanceProjection> {
   const snapshot = await deps.client.loadSkillCatalog(
-    { projectRoot },
+    { workspace: workspace.target },
     "governance",
   );
   return {
-    projectRoot,
+    workspace,
     snapshot,
     items: snapshot.items.filter(isGovernanceItem),
-    paths: await loadSkillPaths(deps.workspaceRoot, projectRoot),
+    paths: await loadSkillPaths(deps.workspaceRoot, workspace.hostCwd),
   };
 }
 
@@ -401,7 +402,7 @@ async function installSkill(
   sourceType: "bundled" | "managed",
   sourceId: string,
 ) {
-  const { result, projectRoot } = await mutateSkill(
+  const { result, workspace } = await mutateSkill(
     deps,
     sourceType === "bundled" ? "bundled" : "managed_sources",
     {
@@ -420,7 +421,7 @@ async function installSkill(
       result.entry,
       await resolveProjectedPath(
         deps.workspaceRoot,
-        projectRoot,
+        workspace.hostCwd,
         result.entry.ref,
       ),
     ),
@@ -432,7 +433,7 @@ async function mutateResolvedSkill(
   idOrRef: string,
   mutation: (ref: string) => SkillCatalogMutation,
 ) {
-  const { result, projectRoot } = await mutateResolvedSkillRaw(
+  const { result, workspace } = await mutateResolvedSkillRaw(
     deps,
     idOrRef,
     mutation,
@@ -447,7 +448,7 @@ async function mutateResolvedSkill(
       result.entry,
       await resolveProjectedPath(
         deps.workspaceRoot,
-        projectRoot,
+        workspace.hostCwd,
         result.entry.ref,
       ),
     ),
@@ -459,23 +460,23 @@ async function mutateResolvedSkillRaw(
   idOrRef: string,
   mutation: (ref: string) => SkillCatalogMutation,
 ): Promise<StableSkillMutation> {
-  const projectRoot = await deps.getCurrentProjectRoot();
+  const workspace = await deps.getCurrentWorkspace();
   for (let attempt = 0; attempt < MAX_REVISION_ATTEMPTS; attempt += 1) {
-    const projection = await loadGovernance(deps, projectRoot);
+    const projection = await loadGovernance(deps, workspace);
     const resolved = resolveGovernanceItem(projection.items, idOrRef);
     if (!resolved.ok) {
       return {
         result: { kind: "rejected", reason: "not_found" },
-        projectRoot: projection.projectRoot,
+        workspace: projection.workspace,
       };
     }
     const result = await deps.client.mutateSkillCatalog({
-      context: { projectRoot: projection.projectRoot },
+      context: { workspace: projection.workspace.target },
       expectedRevision: projection.snapshot.revision,
       mutation: mutation(resolved.item.ref),
     });
     if (result.kind !== "revision_conflict") {
-      return { result, projectRoot: projection.projectRoot };
+      return { result, workspace: projection.workspace };
     }
   }
   throw new Error(
@@ -488,15 +489,18 @@ async function mutateSkill(
   view: "governance" | "bundled" | "managed_sources",
   mutation: SkillCatalogMutation,
 ): Promise<StableSkillMutation> {
-  const projectRoot = await deps.getCurrentProjectRoot();
+  const workspace = await deps.getCurrentWorkspace();
   for (let attempt = 0; attempt < MAX_REVISION_ATTEMPTS; attempt += 1) {
-    const snapshot = await deps.client.loadSkillCatalog({ projectRoot }, view);
+    const snapshot = await deps.client.loadSkillCatalog(
+      { workspace: workspace.target },
+      view,
+    );
     const result = await deps.client.mutateSkillCatalog({
-      context: { projectRoot },
+      context: { workspace: workspace.target },
       expectedRevision: snapshot.revision,
       mutation,
     });
-    if (result.kind !== "revision_conflict") return { result, projectRoot };
+    if (result.kind !== "revision_conflict") return { result, workspace };
   }
   throw new Error(
     "Skill catalog kept changing while Desktop applied a mutation",

--- a/apps/desktop/src/main/runtime-host-skills-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-skills-ipc-main.ts
@@ -7,11 +7,12 @@ import {
 import type {
   SkillCatalogGovernanceItem,
   SkillCatalogManagedUpdateMutation,
-  SkillCatalogMutateResult,
   SkillCatalogMutation,
+  SkillCatalogMutationOutcome,
   SkillCatalogMutationRejectedReason,
   SkillCatalogPreviewUpdateResult,
   WorkspaceProjection,
+  WorkspaceTarget,
 } from "@maka/runtime-host/protocol";
 import type {
   BundledSkillCatalogEntry,
@@ -44,7 +45,7 @@ interface RuntimeHostSkillsIpcDeps {
   readonly client: DesktopRuntimeHostClient;
   readonly workspaceRoot: string;
   readonly mainWindowController: MainWindowController;
-  readonly getCurrentWorkspace: () => Promise<WorkspaceProjection>;
+  readonly getCurrentWorkspaceTarget: () => Promise<WorkspaceTarget>;
   readonly getDefaultPermissionMode: () => Promise<ChatDefaultPermissionMode>;
   readonly openPath: (path: string) => Promise<string>;
 }
@@ -57,7 +58,7 @@ interface GovernanceProjection {
 }
 
 type StableSkillMutationResult = Exclude<
-  SkillCatalogMutateResult,
+  SkillCatalogMutationOutcome,
   { readonly kind: 'revision_conflict' }
 >;
 
@@ -72,7 +73,7 @@ export function registerRuntimeHostSkillsIpc(
   handleReconnectableRead(deps.ipcMain, "skills:list", async () => {
     const projection = await loadGovernance(
       deps,
-      await deps.getCurrentWorkspace(),
+      await deps.getCurrentWorkspaceTarget(),
     );
     return projection.items.map((item) =>
       toSkillEntry(item, projection.paths.get(item.ref) ?? ""),
@@ -88,7 +89,7 @@ export function registerRuntimeHostSkillsIpc(
           ? { kind: "session" as const, sessionId }
           : {
               kind: "new_session" as const,
-              context: { workspace: (await deps.getCurrentWorkspace()).target },
+              context: { workspace: await deps.getCurrentWorkspaceTarget() },
               collaborationMode:
                 normalizeNewSessionCollaborationMode(newSessionContext) ??
                 "agent",
@@ -101,9 +102,9 @@ export function registerRuntimeHostSkillsIpc(
   );
 
   handleReconnectableRead(deps.ipcMain, "skills:catalog:list", async () => {
-    const workspace = await deps.getCurrentWorkspace();
+    const workspace = await deps.getCurrentWorkspaceTarget();
     const snapshot = await deps.client.loadSkillCatalog(
-      { workspace: workspace.target },
+      { workspace },
       "bundled",
     );
     return snapshot.items.flatMap((item): BundledSkillCatalogEntry[] =>
@@ -127,9 +128,9 @@ export function registerRuntimeHostSkillsIpc(
   });
 
   handleReconnectableRead(deps.ipcMain, "skills:sources:list", async () => {
-    const workspace = await deps.getCurrentWorkspace();
+    const workspace = await deps.getCurrentWorkspaceTarget();
     const snapshot = await deps.client.loadSkillCatalog(
-      { workspace: workspace.target },
+      { workspace },
       "managed_sources",
     );
     return snapshot.items.flatMap((item): ManagedSkillSourceEntry[] =>
@@ -179,7 +180,7 @@ export function registerRuntimeHostSkillsIpc(
   handleReconnectableRead(deps.ipcMain, "skills:details", async (_event, idOrRef: string) => {
     const projection = await loadGovernance(
       deps,
-      await deps.getCurrentWorkspace(),
+      await deps.getCurrentWorkspaceTarget(),
     );
     const resolved = resolveGovernanceItem(projection.items, idOrRef);
     if (!resolved.ok) return resolved;
@@ -196,9 +197,9 @@ export function registerRuntimeHostSkillsIpc(
     deps.ipcMain,
     "skills:previewUpdate",
     async (_event, idOrRef: string) => {
-      const workspace = await deps.getCurrentWorkspace();
+      const workspaceTarget = await deps.getCurrentWorkspaceTarget();
       for (let attempt = 0; attempt < MAX_REVISION_ATTEMPTS; attempt += 1) {
-        const projection = await loadGovernance(deps, workspace);
+        const projection = await loadGovernance(deps, workspaceTarget);
         const resolved = resolveGovernanceItem(projection.items, idOrRef);
         if (!resolved.ok) return resolved;
         const result = await deps.client.previewSkillUpdate({
@@ -207,10 +208,15 @@ export function registerRuntimeHostSkillsIpc(
           ref: resolved.item.ref,
         });
         if (result.kind === "revision_conflict") continue;
+        const workspace = result.resolvedWorkspace;
         return projectPreviewResult(
           result,
           resolved.item,
-          projection.paths.get(resolved.item.ref) ?? "",
+          await resolveProjectedPath(
+            deps.workspaceRoot,
+            workspace.hostCwd,
+            resolved.item.ref,
+          ),
         );
       }
       throw new Error(
@@ -321,12 +327,17 @@ export function registerRuntimeHostSkillsIpc(
   deps.ipcMain.handle(
     "skills:open",
     async (_event, idOrRef: string, target: "file" | "directory" = "file") => {
-      const projectRoot = (await deps.getCurrentWorkspace()).hostCwd;
+      const projection = await loadGovernance(
+        deps,
+        await deps.getCurrentWorkspaceTarget(),
+      );
+      const item = resolveGovernanceItem(projection.items, idOrRef);
+      if (!item.ok) return item;
       const resolved = await resolveSkillOpenPath(
         deps.workspaceRoot,
-        idOrRef,
+        item.item.ref,
         target,
-        projectRoot,
+        projection.workspace.hostCwd,
       );
       if (!resolved.ok) return resolved;
       const error = await deps.openPath(resolved.path);
@@ -339,17 +350,17 @@ export function registerRuntimeHostSkillsIpc(
 
 async function loadGovernance(
   deps: RuntimeHostSkillsIpcDeps,
-  workspace: WorkspaceProjection,
+  workspace: WorkspaceTarget,
 ): Promise<GovernanceProjection> {
   const snapshot = await deps.client.loadSkillCatalog(
-    { workspace: workspace.target },
+    { workspace },
     "governance",
   );
   return {
-    workspace,
+    workspace: snapshot.workspace,
     snapshot,
     items: snapshot.items.filter(isGovernanceItem),
-    paths: await loadSkillPaths(deps.workspaceRoot, workspace.hostCwd),
+    paths: await loadSkillPaths(deps.workspaceRoot, snapshot.workspace.hostCwd),
   };
 }
 
@@ -460,13 +471,16 @@ async function mutateResolvedSkillRaw(
   idOrRef: string,
   mutation: (ref: string) => SkillCatalogMutation,
 ): Promise<StableSkillMutation> {
-  const workspace = await deps.getCurrentWorkspace();
+  const workspace = await deps.getCurrentWorkspaceTarget();
   for (let attempt = 0; attempt < MAX_REVISION_ATTEMPTS; attempt += 1) {
     const projection = await loadGovernance(deps, workspace);
     const resolved = resolveGovernanceItem(projection.items, idOrRef);
     if (!resolved.ok) {
       return {
-        result: { kind: "rejected", reason: "not_found" },
+        result: {
+          kind: "rejected",
+          reason: "not_found",
+        },
         workspace: projection.workspace,
       };
     }
@@ -476,7 +490,7 @@ async function mutateResolvedSkillRaw(
       mutation: mutation(resolved.item.ref),
     });
     if (result.kind !== "revision_conflict") {
-      return { result, workspace: projection.workspace };
+      return { result, workspace: result.resolvedWorkspace };
     }
   }
   throw new Error(
@@ -489,18 +503,20 @@ async function mutateSkill(
   view: "governance" | "bundled" | "managed_sources",
   mutation: SkillCatalogMutation,
 ): Promise<StableSkillMutation> {
-  const workspace = await deps.getCurrentWorkspace();
+  const workspace = await deps.getCurrentWorkspaceTarget();
   for (let attempt = 0; attempt < MAX_REVISION_ATTEMPTS; attempt += 1) {
     const snapshot = await deps.client.loadSkillCatalog(
-      { workspace: workspace.target },
+      { workspace },
       view,
     );
     const result = await deps.client.mutateSkillCatalog({
-      context: { workspace: workspace.target },
+      context: { workspace: snapshot.workspace.target },
       expectedRevision: snapshot.revision,
       mutation,
     });
-    if (result.kind !== "revision_conflict") return { result, workspace };
+    if (result.kind !== "revision_conflict") {
+      return { result, workspace: result.resolvedWorkspace };
+    }
   }
   throw new Error(
     "Skill catalog kept changing while Desktop applied a mutation",

--- a/apps/desktop/src/main/runtime-host-workspace-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-workspace-ipc-main.ts
@@ -36,8 +36,8 @@ export function registerRuntimeHostWorkspaceIpc(
 async function sessionWorkspace(client: WorkspaceClient, sessionId: string): Promise<string | null> {
   const session = await client.getSession(sessionId);
   if (!session) throw new Error(`No such Session: ${sessionId}`);
-  const workspace = await stat(session.cwd).catch(() => null);
-  return workspace?.isDirectory() ? session.cwd : null;
+  const workspace = await stat(session.workspace.hostCwd).catch(() => null);
+  return workspace?.isDirectory() ? session.workspace.hostCwd : null;
 }
 
 function readRequest(value: unknown): {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -386,7 +386,6 @@ export interface MakaBridge {
     list(input: {
       adapterId: string;
       includeArchived?: boolean;
-      cwd?: string;
       cursor?: string;
     }): Promise<{ sessions: ExternalSessionSummary[]; nextCursor: string | null }>;
     import(input: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -433,7 +433,6 @@ const makaBridge = {
     list(input: {
       adapterId: string;
       includeArchived?: boolean;
-      cwd?: string;
       cursor?: string;
     }): Promise<{ sessions: ExternalSessionSummary[]; nextCursor: string | null }> {
       return ipcRenderer.invoke('external-sessions:list', input);

--- a/docs/architecture/runtime-host-architecture.md
+++ b/docs/architecture/runtime-host-architecture.md
@@ -123,7 +123,9 @@ type WorkspaceTarget =
 
 `project` is the portable form. Runtime Host resolves it through its Project Catalog and returns a projection containing the canonical target and `hostCwd`. `host_path` is for a Client that has explicit Host-path authority, such as a local CLI started in a checkout.
 
-Clients do not combine a path with a Project ID or resolve a Host path themselves. Desktop keeps its selected Project as a root-scoped Client preference; selecting a Project does not mutate global Host state. A Client without Host-path authority can use a registered Project, but cannot register, relink, reveal, or submit a Host path.
+The Project Catalog has revision-pinned, paginated summary and location views. The summary is path-free; reading locations requires Host-path authority.
+
+Clients do not combine a path with a Project ID or resolve a Host path themselves. Desktop keeps its selected Project as a root-scoped Client preference; selecting a Project does not mutate global Host state. A Client without Host-path authority can use a registered Project, but cannot register, relink, request a Host-side reveal, or submit a Host path.
 
 ## Lifecycle
 

--- a/docs/architecture/runtime-host-architecture.md
+++ b/docs/architecture/runtime-host-architecture.md
@@ -111,6 +111,20 @@ Before the first physical provider dispatch:
 
 A failed composition or commit fails closed. A Run that never dispatches does not invent a composition snapshot.
 
+### Runtime Host resolves workspaces
+
+Clients identify a workspace with one closed target:
+
+```ts
+type WorkspaceTarget =
+  | { kind: "project"; projectId: string }
+  | { kind: "host_path"; path: string };
+```
+
+`project` is the portable form. Runtime Host resolves it through its Project Catalog and returns a projection containing the canonical target and `hostCwd`. `host_path` is for a Client that has explicit Host-path authority, such as a local CLI started in a checkout.
+
+Clients do not combine a path with a Project ID or resolve a Host path themselves. Desktop keeps its selected Project as a root-scoped Client preference; selecting a Project does not mutate global Host state. A Client without Host-path authority can use a registered Project, but cannot register, relink, reveal, or submit a Host path.
+
 ## Lifecycle
 
 | Stage | Contract |
@@ -135,6 +149,7 @@ A Client disconnect releases only connection-scoped resources. It does not cance
 8. Provider dispatch waits for a durable Run Composition commit.
 9. Domain lifecycle and execution lifecycle remain separate.
 10. Shutdown continues closing other owners after one owner fails.
+11. Runtime Host is the only resolver from `WorkspaceTarget` to a canonical Host path.
 
 ## How failures converge
 
@@ -162,6 +177,7 @@ Runtime Host does not claim exactly-once behavior for arbitrary external side ef
 - [`host-kernel.ts`](../../packages/runtime-host/src/server/host-kernel.ts): process ownership, listeners, connection lifecycle, drain, and shutdown
 - [`host-composition.ts`](../../packages/runtime-host/src/server/host-composition.ts): composition identity, Module contract, recovery, and close order
 - [`hosted-execution-authority.ts`](../../packages/runtime-host/src/server/hosted-execution-authority.ts): root execution contract
+- [`workspace-resolver.ts`](../../packages/runtime-host/src/server/workspace-resolver.ts): Project and Host-path workspace resolution
 - [`run-composition.ts`](../../packages/core/src/run-composition.ts): durable Run Composition schema
 - [`state-root-composition.ts`](../../packages/storage/src/state-root-composition.ts): persistent Composition binding
 
@@ -175,6 +191,7 @@ Changes to these boundaries should preserve tests for:
 - Hosted Execution admission, stop, settlement, and restart recovery;
 - immutable Run Composition commit and pre-dispatch fail-closed behavior;
 - Client disconnect, drain, and crash recovery end to end.
+- Project-based workspace use without Host-path authority, and rejection of unauthorized Host paths.
 
 Repository-wide format, lint, typecheck, and test gates remain required for changes that cross these boundaries.
 

--- a/docs/architecture/runtime-host-architecture.md
+++ b/docs/architecture/runtime-host-architecture.md
@@ -127,6 +127,8 @@ The Project Catalog has revision-pinned, paginated summary and location views. T
 
 Clients do not combine a path with a Project ID or resolve a Host path themselves. Desktop keeps its selected Project as a root-scoped Client preference; selecting a Project does not mutate global Host state. A Client without Host-path authority can use a registered Project, but cannot register, relink, request a Host-side reveal, or submit a Host path.
 
+Skill catalog management is a Host-filesystem operation. It requires Host-path authority and returns the workspace resolved by that operation.
+
 ## Lifecycle
 
 | Stage | Contract |

--- a/docs/architecture/runtime-host-architecture.zh-CN.md
+++ b/docs/architecture/runtime-host-architecture.zh-CN.md
@@ -123,7 +123,9 @@ type WorkspaceTarget =
 
 `project` 是可跨机器传递的形式。Runtime Host 通过自己的 Project Catalog 解析它，并返回包含 canonical target 与 `hostCwd` 的 projection。`host_path` 只供拥有明确 Host-path authority 的 Client 使用，例如从本地 checkout 启动的 CLI。
 
-Client 不把 path 与 Project ID 拼在一起，也不自行解析 Host path。Desktop 将所选 Project 保存为按 root 隔离的 Client preference；选择 Project 不修改 Host 全局状态。没有 Host-path authority 的 Client 可以使用已注册 Project，但不能注册、relink、reveal 或提交 Host path。
+Project Catalog 提供 revision-pinned、paginated 的 summary 与 location view。Summary 不包含 path；读取 location 必须拥有 Host-path authority。
+
+Client 不把 path 与 Project ID 拼在一起，也不自行解析 Host path。Desktop 将所选 Project 保存为按 root 隔离的 Client preference；选择 Project 不修改 Host 全局状态。没有 Host-path authority 的 Client 可以使用已注册 Project，但不能注册、relink、请求 Host 侧 reveal 或提交 Host path。
 
 ## 生命周期
 

--- a/docs/architecture/runtime-host-architecture.zh-CN.md
+++ b/docs/architecture/runtime-host-architecture.zh-CN.md
@@ -111,6 +111,20 @@ Run Composer 冻结一次 Run 的 model-visible 基线：base system prompt、to
 
 Composition 或 commit 失败时必须 fail closed。没有发生 dispatch 的 Run 不伪造 composition snapshot。
 
+### Runtime Host 解析 workspace
+
+Client 只使用一种 closed target 表达 workspace：
+
+```ts
+type WorkspaceTarget =
+  | { kind: "project"; projectId: string }
+  | { kind: "host_path"; path: string };
+```
+
+`project` 是可跨机器传递的形式。Runtime Host 通过自己的 Project Catalog 解析它，并返回包含 canonical target 与 `hostCwd` 的 projection。`host_path` 只供拥有明确 Host-path authority 的 Client 使用，例如从本地 checkout 启动的 CLI。
+
+Client 不把 path 与 Project ID 拼在一起，也不自行解析 Host path。Desktop 将所选 Project 保存为按 root 隔离的 Client preference；选择 Project 不修改 Host 全局状态。没有 Host-path authority 的 Client 可以使用已注册 Project，但不能注册、relink、reveal 或提交 Host path。
+
 ## 生命周期
 
 | 阶段 | Contract |
@@ -135,6 +149,7 @@ Client disconnect 只释放 connection-scoped resources，不取消已经 admiss
 8. Provider dispatch 等待 Run Composition durable commit。
 9. Domain lifecycle 与 execution lifecycle 保持分离。
 10. 一个 owner 关闭失败时，shutdown 仍继续关闭其余 owner。
+11. 只有 Runtime Host 能把 `WorkspaceTarget` 解析为 canonical Host path。
 
 ## 失败如何收敛
 
@@ -162,6 +177,7 @@ Runtime Host 不承诺任意 external side effect 的 exactly-once。具体 Tool
 - [`host-kernel.ts`](../../packages/runtime-host/src/server/host-kernel.ts)：process ownership、listeners、connection lifecycle、drain 与 shutdown
 - [`host-composition.ts`](../../packages/runtime-host/src/server/host-composition.ts)：composition identity、Module contract、recovery 与 close order
 - [`hosted-execution-authority.ts`](../../packages/runtime-host/src/server/hosted-execution-authority.ts)：root execution contract
+- [`workspace-resolver.ts`](../../packages/runtime-host/src/server/workspace-resolver.ts)：Project 与 Host-path workspace resolution
 - [`run-composition.ts`](../../packages/core/src/run-composition.ts)：durable Run Composition schema
 - [`state-root-composition.ts`](../../packages/storage/src/state-root-composition.ts)：persistent Composition binding
 
@@ -175,6 +191,7 @@ Runtime Host 不承诺任意 external side effect 的 exactly-once。具体 Tool
 - Hosted Execution admission、stop、settlement 与 restart recovery；
 - immutable Run Composition commit 与 pre-dispatch fail-closed；
 - Client disconnect、drain 与 crash recovery 的端到端行为。
+- 无 Host-path authority 时使用 Project workspace，并拒绝未授权 Host path。
 
 跨越这些边界的改动仍须通过全仓 format、lint、typecheck 与 tests。
 

--- a/docs/architecture/runtime-host-architecture.zh-CN.md
+++ b/docs/architecture/runtime-host-architecture.zh-CN.md
@@ -127,6 +127,8 @@ Project Catalog 提供 revision-pinned、paginated 的 summary 与 location view
 
 Client 不把 path 与 Project ID 拼在一起，也不自行解析 Host path。Desktop 将所选 Project 保存为按 root 隔离的 Client preference；选择 Project 不修改 Host 全局状态。没有 Host-path authority 的 Client 可以使用已注册 Project，但不能注册、relink、请求 Host 侧 reveal 或提交 Host path。
 
+Skill Catalog 管理属于 Host 文件系统操作。它要求 Host-path authority，并返回该操作实际解析出的 workspace。
+
 ## 生命周期
 
 | 阶段 | Contract |

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -99,7 +99,10 @@ describe('Runtime Host maka run adapter', () => {
           sessions: [
             {
               ...sessionProjection('session-existing'),
-              cwd,
+              workspace: {
+                target: { kind: 'host_path', path: cwd },
+                hostCwd: cwd,
+              },
               lastUsedAt: 10,
               lastMessageAt: 10,
             },
@@ -1032,7 +1035,10 @@ function sessionProjection(id: string): SessionCatalogProjection {
   return {
     id,
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: 'Run once',

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -26,6 +26,62 @@ import { SkillInvocationBlockedError, type MakaAttachedSessionTurn } from '../se
 import { WAIT_BUDGET_MS } from './tui-terminal-mock.js';
 
 describe('Runtime Host Maka Session driver', () => {
+  test('honors explicit Project intent before inheriting the current workspace', async () => {
+    const cases = [
+      { cwd: '/repo', projectId: null, expected: { kind: 'host_path', path: '/repo' } },
+      {
+        cwd: '/repo',
+        projectId: 'project-b',
+        expected: { kind: 'project', projectId: 'project-b' },
+      },
+      {
+        cwd: '/other',
+        projectId: 'project-b',
+        expected: { kind: 'project', projectId: 'project-b' },
+      },
+      { cwd: '/repo', expected: { kind: 'project', projectId: 'project-a' } },
+      { cwd: '/other', expected: { kind: 'host_path', path: '/other' } },
+    ] as const;
+
+    for (const candidate of cases) {
+      const connection = new FakeConnection([
+        new FakeSubscription(continuitySnapshot(), Promise.resolve([])),
+      ]);
+      const driver = createRuntimeHostMakaSessionDriver({
+        connection: connection.value,
+        cwd: '/repo',
+        workspace: { kind: 'project', projectId: 'project-a' },
+        llmConnectionSlug: 'openai-main',
+        model: 'gpt-5',
+        newId: () => 'session-id',
+      });
+
+      await driver.createSession({
+        cwd: candidate.cwd,
+        ...('projectId' in candidate ? { projectId: candidate.projectId } : {}),
+        backend: 'ai-sdk',
+        llmConnectionSlug: 'openai-main',
+        model: 'gpt-5',
+        permissionMode: 'ask',
+      });
+
+      assert.deepEqual(
+        connection.requests.find(({ operation }) => operation === 'session.create')?.input,
+        {
+          sessionId: 'session-id',
+          workspace: candidate.expected,
+          name: 'New Chat',
+          modelTarget: {
+            kind: 'explicit',
+            connectionSlug: 'openai-main',
+            model: 'gpt-5',
+          },
+          permissionMode: 'ask',
+        },
+      );
+    }
+  });
+
   test('relocates a moved Session through Host authority before attaching', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-tui-resume-moved-cwd-'));
     const target = join(root, 'new-worktree');
@@ -1042,6 +1098,16 @@ class FakeConnection {
           workspace: { target: workspace, hostCwd: workspace.path },
         }),
       } as OperationOutput<K>;
+    }
+    if (operation === 'session.create') {
+      const create = input as OperationInput<'session.create'>;
+      return sessionProjection({
+        id: create.sessionId,
+        workspace: {
+          target: create.workspace,
+          hostCwd: create.workspace.kind === 'host_path' ? create.workspace.path : '/project',
+        },
+      }) as OperationOutput<K>;
     }
     const turnInput = input as {
       sessionId?: string;

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -36,8 +36,12 @@ describe('Runtime Host Maka Session driver', () => {
         new FakeSubscription(continuitySnapshot(), Promise.resolve([])),
       ]);
       connection.sessionQueries.push(
-        sessionProjection({ cwd: oldCwd }),
-        sessionProjection({ cwd: oldCwd }),
+        sessionProjection({
+          workspace: { target: { kind: 'host_path', path: oldCwd }, hostCwd: oldCwd },
+        }),
+        sessionProjection({
+          workspace: { target: { kind: 'host_path', path: oldCwd }, hostCwd: oldCwd },
+        }),
       );
       const inspected: string[] = [];
       const driver = createRuntimeHostMakaSessionDriver({
@@ -70,13 +74,13 @@ describe('Runtime Host Maka Session driver', () => {
           'session.catalog.query',
           'session.execution_boundary.query',
           'session.catalog.query',
-          'session.cwd.relocate',
+          'session.workspace.relocate',
         ],
       );
       assert.deepEqual(connection.requests.at(-1)?.input, {
         sessionId: 'session-1',
         expectedRevision: 1,
-        cwd: canonicalTarget,
+        workspace: { kind: 'host_path', path: canonicalTarget },
       });
     } finally {
       await rm(root, { recursive: true, force: true });
@@ -98,7 +102,7 @@ describe('Runtime Host Maka Session driver', () => {
       /Cannot resume externally isolated session/,
     );
     assert.equal(
-      connection.requests.some(({ operation }) => operation === 'session.cwd.relocate'),
+      connection.requests.some(({ operation }) => operation === 'session.workspace.relocate'),
       false,
     );
   });
@@ -1028,12 +1032,14 @@ class FakeConnection {
     input: OperationInput<K>,
   ): Promise<OperationOutput<K>> {
     this.requests.push({ operation, input });
-    if (operation === 'session.cwd.relocate') {
+    if (operation === 'session.workspace.relocate') {
+      const workspace = (input as OperationInput<'session.workspace.relocate'>).workspace;
+      if (workspace.kind !== 'host_path') throw new Error('Expected Host-path workspace');
       return {
         kind: 'committed',
         session: sessionProjection({
           revision: 2,
-          cwd: (input as OperationInput<'session.cwd.relocate'>).cwd,
+          workspace: { target: workspace, hostCwd: workspace.path },
         }),
       } as OperationOutput<K>;
     }
@@ -1205,7 +1211,10 @@ function sessionProjection(
   return {
     id: 'session-1',
     revision: 1,
-    cwd: '/tmp',
+    workspace: {
+      target: { kind: 'host_path', path: '/tmp' },
+      hostCwd: '/tmp',
+    },
     createdAt: 1,
     lastUsedAt: 2,
     name: 'Session',

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -32,6 +32,7 @@ import type {
   SessionCatalogItem,
   SessionCatalogProjection,
   SessionUpdateResult,
+  WorkspaceProjection,
   WorkspaceTarget,
 } from '@maka/runtime-host/protocol';
 import {
@@ -113,8 +114,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   readonly #now: () => number;
   readonly #inspectCwdChanges: InspectCwdChanges;
   #sessionId: string | null = null;
-  #cwd: string;
-  #workspace: WorkspaceTarget;
+  #workspace: WorkspaceProjection;
   #model: string;
   #llmConnectionSlug: string;
   #thinkingLevel: ThinkingLevel | undefined;
@@ -147,8 +147,10 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     this.#newId = input.newId ?? randomUUID;
     this.#now = input.now ?? Date.now;
     this.#inspectCwdChanges = input.inspectCwdChanges ?? inspectGitCwdChanges;
-    this.#cwd = input.cwd;
-    this.#workspace = input.workspace ?? { kind: 'host_path', path: input.cwd };
+    this.#workspace = {
+      target: input.workspace ?? { kind: 'host_path', path: input.cwd },
+      hostCwd: input.cwd,
+    };
     this.#model = input.model;
     this.#llmConnectionSlug = input.llmConnectionSlug;
     this.#permissionMode = input.permissionMode ?? 'ask';
@@ -162,10 +164,10 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   async createSession(input: CreateSessionInput): Promise<SessionSummary> {
     if (this.#sessionId) throw new Error('Cannot create a Session while another is active.');
     if (!input.model) throw new Error('Runtime Host Session creation requires an explicit model');
-    if (input.cwd !== this.#cwd) {
-      this.#workspace = { kind: 'host_path', path: input.cwd };
-    }
-    this.#cwd = input.cwd;
+    this.#workspace = {
+      target: workspaceTargetForCreate(this.#workspace, input),
+      hostCwd: input.cwd,
+    };
     this.#llmConnectionSlug = input.llmConnectionSlug;
     this.#model = input.model;
     this.#thinkingLevel = input.thinkingLevel;
@@ -181,7 +183,9 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     return sessions
       .map((session, index) => ({ session, index }))
       .sort((left, right) => {
-        const cwdDelta = cwdRank(left.session, this.#cwd) - cwdRank(right.session, this.#cwd);
+        const cwdDelta =
+          cwdRank(left.session, this.#workspace.hostCwd) -
+          cwdRank(right.session, this.#workspace.hostCwd);
         return cwdDelta !== 0 ? cwdDelta : left.index - right.index;
       })
       .map(({ session }) => session);
@@ -390,16 +394,15 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
 
   async moveSession(rawCwd: string): Promise<MakaSessionMoveResult> {
     const sessionId = this.#requireSession('move');
-    const nextCwd = await resolveMoveCwd(rawCwd, this.#cwd);
-    const previousCwd = this.#cwd;
+    const nextCwd = await resolveMoveCwd(rawCwd, this.#workspace.hostCwd);
+    const previousCwd = this.#workspace.hostCwd;
     if (nextCwd === previousCwd) {
       return { previousCwd, cwd: nextCwd, changed: false, oldCwdDirty: false };
     }
     const oldCwdDirty = await this.#inspectCwdChanges(previousCwd).catch(() => undefined);
     const session = await this.#commitCwdRelocation(sessionId, nextCwd);
-    this.#cwd = session.workspace.hostCwd;
-    this.#workspace = session.workspace.target;
-    return { previousCwd, cwd: this.#cwd, changed: true, oldCwdDirty };
+    this.#workspace = session.workspace;
+    return { previousCwd, cwd: this.#workspace.hostCwd, changed: true, oldCwdDirty };
   }
 
   async switchSession(
@@ -420,7 +423,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     }
     let relocation: MakaSessionMoveResult | undefined;
     if (options.relocateCwd !== undefined) {
-      const nextCwd = await resolveMoveCwd(options.relocateCwd, this.#cwd);
+      const nextCwd = await resolveMoveCwd(options.relocateCwd, this.#workspace.hostCwd);
       const previousCwd = session.workspace.hostCwd;
       if (nextCwd === previousCwd) {
         relocation = { previousCwd, cwd: nextCwd, changed: false, oldCwdDirty: false };
@@ -448,8 +451,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     this.#channelGeneration += 1;
     this.#sessionId = sessionId;
     await this.#replaceChannel(opened.channel);
-    this.#cwd = session.workspace.hostCwd;
-    this.#workspace = session.workspace.target;
+    this.#workspace = session.workspace;
     this.#adoptConfiguration(session);
     this.#activeBoundaryDisplayMode = executionBoundaryDisplayMode(boundary);
     this.#permissionMode = boundary.kind === 'bypass' ? 'bypass' : 'ask';
@@ -622,7 +624,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     const session = requireSession(
       await this.#request('session.create', {
         sessionId,
-        workspace: this.#workspace,
+        workspace: this.#workspace.target,
         name,
         modelTarget: {
           kind: 'explicit',
@@ -638,8 +640,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     );
     this.#sessionGeneration += 1;
     this.#sessionId = sessionId;
-    this.#cwd = session.workspace.hostCwd;
-    this.#workspace = session.workspace.target;
+    this.#workspace = session.workspace;
     this.#adoptConfiguration(session);
     await this.#ensureChannel(sessionId);
     return session;
@@ -940,6 +941,19 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   ): Promise<OperationOutput<K>> {
     return this.#connection.request(operation, input);
   }
+}
+
+function workspaceTargetForCreate(
+  current: WorkspaceProjection,
+  input: Pick<CreateSessionInput, 'cwd' | 'projectId'>,
+): WorkspaceTarget {
+  if (typeof input.projectId === 'string') {
+    return { kind: 'project', projectId: input.projectId };
+  }
+  if (input.projectId === null || input.cwd !== current.hostCwd) {
+    return { kind: 'host_path', path: input.cwd };
+  }
+  return current.target;
 }
 
 interface LoadedSessionConfiguration {

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -32,6 +32,7 @@ import type {
   SessionCatalogItem,
   SessionCatalogProjection,
   SessionUpdateResult,
+  WorkspaceTarget,
 } from '@maka/runtime-host/protocol';
 import {
   RuntimeHostSessionChannel,
@@ -63,6 +64,7 @@ const MAX_CATALOG_ATTEMPTS = 3;
 export interface RuntimeHostMakaSessionDriverInput {
   connection: RuntimeHostSessionDriverConnection;
   cwd: string;
+  workspace?: WorkspaceTarget;
   llmConnectionSlug: string;
   model: string;
   permissionMode?: PermissionMode;
@@ -112,6 +114,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   readonly #inspectCwdChanges: InspectCwdChanges;
   #sessionId: string | null = null;
   #cwd: string;
+  #workspace: WorkspaceTarget;
   #model: string;
   #llmConnectionSlug: string;
   #thinkingLevel: ThinkingLevel | undefined;
@@ -145,6 +148,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     this.#now = input.now ?? Date.now;
     this.#inspectCwdChanges = input.inspectCwdChanges ?? inspectGitCwdChanges;
     this.#cwd = input.cwd;
+    this.#workspace = input.workspace ?? { kind: 'host_path', path: input.cwd };
     this.#model = input.model;
     this.#llmConnectionSlug = input.llmConnectionSlug;
     this.#permissionMode = input.permissionMode ?? 'ask';
@@ -158,6 +162,9 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   async createSession(input: CreateSessionInput): Promise<SessionSummary> {
     if (this.#sessionId) throw new Error('Cannot create a Session while another is active.');
     if (!input.model) throw new Error('Runtime Host Session creation requires an explicit model');
+    if (input.cwd !== this.#cwd) {
+      this.#workspace = { kind: 'host_path', path: input.cwd };
+    }
     this.#cwd = input.cwd;
     this.#llmConnectionSlug = input.llmConnectionSlug;
     this.#model = input.model;
@@ -390,7 +397,8 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     }
     const oldCwdDirty = await this.#inspectCwdChanges(previousCwd).catch(() => undefined);
     const session = await this.#commitCwdRelocation(sessionId, nextCwd);
-    this.#cwd = session.cwd;
+    this.#cwd = session.workspace.hostCwd;
+    this.#workspace = session.workspace.target;
     return { previousCwd, cwd: this.#cwd, changed: true, oldCwdDirty };
   }
 
@@ -413,13 +421,18 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     let relocation: MakaSessionMoveResult | undefined;
     if (options.relocateCwd !== undefined) {
       const nextCwd = await resolveMoveCwd(options.relocateCwd, this.#cwd);
-      const previousCwd = session.cwd;
+      const previousCwd = session.workspace.hostCwd;
       if (nextCwd === previousCwd) {
         relocation = { previousCwd, cwd: nextCwd, changed: false, oldCwdDirty: false };
       } else {
         const oldCwdDirty = await this.#inspectCwdChanges(previousCwd).catch(() => undefined);
         session = await this.#commitCwdRelocation(sessionId, nextCwd);
-        relocation = { previousCwd, cwd: session.cwd, changed: true, oldCwdDirty };
+        relocation = {
+          previousCwd,
+          cwd: session.workspace.hostCwd,
+          changed: true,
+          oldCwdDirty,
+        };
       }
       summary = runtimeHostSessionSummary(session);
       await assertSessionResumeAvailable(summary);
@@ -435,7 +448,8 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     this.#channelGeneration += 1;
     this.#sessionId = sessionId;
     await this.#replaceChannel(opened.channel);
-    this.#cwd = session.cwd;
+    this.#cwd = session.workspace.hostCwd;
+    this.#workspace = session.workspace.target;
     this.#adoptConfiguration(session);
     this.#activeBoundaryDisplayMode = executionBoundaryDisplayMode(boundary);
     this.#permissionMode = boundary.kind === 'bypass' ? 'bypass' : 'ask';
@@ -462,10 +476,10 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
 
   #commitCwdRelocation(sessionId: string, cwd: string): Promise<SessionCatalogProjection> {
     return updateRuntimeHostSession(this.#connection, sessionId, (current) =>
-      this.#request('session.cwd.relocate', {
+      this.#request('session.workspace.relocate', {
         sessionId,
         expectedRevision: current.revision,
-        cwd,
+        workspace: { kind: 'host_path', path: cwd },
       }),
     );
   }
@@ -608,7 +622,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     const session = requireSession(
       await this.#request('session.create', {
         sessionId,
-        cwd: this.#cwd,
+        workspace: this.#workspace,
         name,
         modelTarget: {
           kind: 'explicit',
@@ -624,6 +638,8 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     );
     this.#sessionGeneration += 1;
     this.#sessionId = sessionId;
+    this.#cwd = session.workspace.hostCwd;
+    this.#workspace = session.workspace.target;
     this.#adoptConfiguration(session);
     await this.#ensureChannel(sessionId);
     return session;
@@ -994,8 +1010,10 @@ async function loadCurrentMessages(
 export function runtimeHostSessionSummary(session: SessionCatalogProjection): SessionSummary {
   return {
     id: session.id,
-    cwd: session.cwd,
-    ...(session.projectId === undefined ? {} : { projectId: session.projectId }),
+    cwd: session.workspace.hostCwd,
+    ...(session.workspace.target.kind === 'project'
+      ? { projectId: session.workspace.target.projectId }
+      : {}),
     name: session.name,
     isFlagged: session.isFlagged,
     isArchived: session.isArchived,

--- a/packages/cli/src/runtime-host-tui-context.ts
+++ b/packages/cli/src/runtime-host-tui-context.ts
@@ -117,7 +117,7 @@ async function listStablePresentedSkills(
   return [
     ...(await readRuntimeHostInvocableSkills(connection, {
       kind: 'new_session',
-      context: { projectRoot },
+      context: { workspace: { kind: 'host_path', path: projectRoot } },
       collaborationMode: 'agent',
       permissionMode,
     })),

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -152,14 +152,17 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
       (error: unknown) =>
         error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
     );
-    const remoteSkills = await remote.request('skill.catalog.query', {
-      kind: 'start',
-      context: {
-        workspace: { kind: 'project', projectId: registeredProjectId },
-      },
-      view: 'governance',
-    });
-    assert.equal(remoteSkills.kind, 'page');
+    await assert.rejects(
+      remote.request('skill.catalog.query', {
+        kind: 'start',
+        context: {
+          workspace: { kind: 'project', projectId: registeredProjectId },
+        },
+        view: 'governance',
+      }),
+      (error: unknown) =>
+        error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
+    );
     const remoteProjectSession = await remote.request('session.create', {
       sessionId: 'remote-project-session',
       workspace: { kind: 'project', projectId: registeredProjectId },

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -125,7 +125,10 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
       (error: unknown) =>
         error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
     );
-    const remoteProjects = await remote.request('project.catalog.query', { kind: 'list_start' });
+    const remoteProjects = await remote.request('project.catalog.query', {
+      kind: 'list_start',
+      view: 'summary',
+    });
     assert.equal(remoteProjects.kind, 'page');
     await assert.rejects(
       remote.request('project.catalog.mutate', {
@@ -145,7 +148,7 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
     const registeredProjectId = registered.project.id;
     const canonicalRoot = await realpath(root);
     await assert.rejects(
-      remote.request('project.catalog.location.query', { projectId: registeredProjectId }),
+      remote.request('project.catalog.query', { kind: 'list_start', view: 'locations' }),
       (error: unknown) =>
         error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
     );

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -51,6 +51,7 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
         'client.capability.replace',
         'project.catalog.query',
         'project.catalog.mutate',
+        'skill.catalog.query',
       ],
       canPublishClientCapabilities: false,
       canUseHostPaths: false,
@@ -124,23 +125,54 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
       (error: unknown) =>
         error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
     );
-    await assert.rejects(
-      remote.request('project.catalog.query', { kind: 'list_start' }),
-      (error: unknown) =>
-        error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
-    );
+    const remoteProjects = await remote.request('project.catalog.query', { kind: 'list_start' });
+    assert.equal(remoteProjects.kind, 'page');
     await assert.rejects(
       remote.request('project.catalog.mutate', {
-        kind: 'select',
-        projectId: 'project-1',
+        kind: 'register',
+        path: root,
       }),
       (error: unknown) =>
         error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
     );
 
+    const registered = await local.request('project.catalog.mutate', {
+      kind: 'register',
+      path: root,
+    });
+    assert.equal(registered.kind, 'project');
+    if (registered.kind !== 'project') assert.fail('Project registration did not commit');
+    const registeredProjectId = registered.project.id;
+    const canonicalRoot = await realpath(root);
+    await assert.rejects(
+      remote.request('project.catalog.location.query', { projectId: registeredProjectId }),
+      (error: unknown) =>
+        error instanceof RuntimeHostOperationError && error.code === 'unauthorized',
+    );
+    const remoteSkills = await remote.request('skill.catalog.query', {
+      kind: 'start',
+      context: {
+        workspace: { kind: 'project', projectId: registeredProjectId },
+      },
+      view: 'governance',
+    });
+    assert.equal(remoteSkills.kind, 'page');
+    const remoteProjectSession = await remote.request('session.create', {
+      sessionId: 'remote-project-session',
+      workspace: { kind: 'project', projectId: registeredProjectId },
+      modelTarget: { kind: 'default' },
+    });
+    assert.ok(!('kind' in remoteProjectSession));
+    if (!('kind' in remoteProjectSession)) {
+      assert.deepEqual(remoteProjectSession.workspace, {
+        target: { kind: 'project', projectId: registeredProjectId },
+        hostCwd: canonicalRoot,
+      });
+    }
+
     const created = await local.request('session.create', {
       sessionId: 'shared-session',
-      cwd: root,
+      workspace: { kind: 'host_path', path: root },
       name: 'Shared Session',
       modelTarget: { kind: 'default' },
     });
@@ -176,7 +208,7 @@ test('one Local IPC owner and one authenticated WebSocket Client control the sam
     await assert.rejects(
       remote.request('session.create', {
         sessionId: 'remote-path-session',
-        cwd: root,
+        workspace: { kind: 'host_path', path: root },
         modelTarget: { kind: 'default' },
       }),
       (error: unknown) =>

--- a/packages/runtime-host/src/__tests__/catalog-reader.test.ts
+++ b/packages/runtime-host/src/__tests__/catalog-reader.test.ts
@@ -4,6 +4,7 @@ import type { RuntimeHostConnection } from '../client/connection.js';
 import {
   RuntimeHostCatalogReadError,
   readRuntimeHostConnectionCatalog,
+  readRuntimeHostProjectDetails,
   readRuntimeHostProjects,
   readRuntimeHostSessions,
   readRuntimeHostSkillCatalog,
@@ -118,6 +119,7 @@ test('reassembles Project aliases without exposing Host locations', async () => 
       name: 'Project',
       aliasCount: aliases.length,
       locationCount,
+      preferredLocationIndex: 0,
       archivedAt: null,
       available: true,
     },
@@ -129,11 +131,13 @@ test('reassembles Project aliases without exposing Host locations', async () => 
     })),
   ];
   const connection = fakeConnection(async (_operation, input) => {
+    assert.equal(input.view, 'summary');
     const offset = input.kind === 'list_start' ? 0 : Number(input.cursor);
     const page = items.slice(offset, offset + 64);
     const nextOffset = offset + page.length;
     return {
       kind: 'page',
+      view: 'summary',
       revision: `sha256:${'a'.repeat(64)}`,
       projectCount: 1,
       items: page,
@@ -149,6 +153,59 @@ test('reassembles Project aliases without exposing Host locations', async () => 
       locationCount,
       archivedAt: null,
       available: true,
+    },
+  ]);
+});
+
+test('reassembles more Project locations than fit in one protocol page', async () => {
+  const locations = Array.from({ length: 70 }, (_, index) => ({
+    path: `/workspace/worktree-${index}`,
+    isWorktree: index !== 0,
+  }));
+  const items = [
+    {
+      kind: 'project' as const,
+      projectIndex: 0,
+      id: 'project-1',
+      name: 'Project',
+      aliasCount: 0,
+      locationCount: locations.length,
+      preferredLocationIndex: 0,
+      archivedAt: null,
+      available: true,
+    },
+    ...locations.map((location, itemIndex) => ({
+      kind: 'location' as const,
+      projectIndex: 0,
+      itemIndex,
+      location,
+    })),
+  ];
+  const connection = fakeConnection(async (_operation, input) => {
+    assert.equal(input.view, 'locations');
+    const offset = input.kind === 'list_start' ? 0 : Number(input.cursor);
+    const page = items.slice(offset, offset + 64);
+    const nextOffset = offset + page.length;
+    return {
+      kind: 'page',
+      view: 'locations',
+      revision: `sha256:${'b'.repeat(64)}`,
+      projectCount: 1,
+      items: page,
+      nextCursor: nextOffset < items.length ? String(nextOffset) : null,
+    };
+  });
+
+  assert.deepEqual(await readRuntimeHostProjectDetails(connection), [
+    {
+      id: 'project-1',
+      aliases: [],
+      name: 'Project',
+      locationCount: locations.length,
+      archivedAt: null,
+      available: true,
+      locations,
+      preferredPath: locations[0]?.path,
     },
   ]);
 });

--- a/packages/runtime-host/src/__tests__/catalog-reader.test.ts
+++ b/packages/runtime-host/src/__tests__/catalog-reader.test.ts
@@ -52,6 +52,10 @@ test('rejects a repeated Skill catalog cursor instead of looping forever', async
       revision: 'sha256:skills',
       items: [],
       nextCursor: 'repeated',
+      resolvedWorkspace: {
+        target: { kind: 'host_path', path: '/repo' },
+        hostCwd: '/repo',
+      },
     };
   });
 

--- a/packages/runtime-host/src/__tests__/catalog-reader.test.ts
+++ b/packages/runtime-host/src/__tests__/catalog-reader.test.ts
@@ -55,7 +55,12 @@ test('rejects a repeated Skill catalog cursor instead of looping forever', async
   });
 
   await assert.rejects(
-    () => readRuntimeHostSkillCatalog(connection, { projectRoot: '/repo' }, 'governance'),
+    () =>
+      readRuntimeHostSkillCatalog(
+        connection,
+        { workspace: { kind: 'host_path', path: '/repo' } },
+        'governance',
+      ),
     (error) =>
       error instanceof RuntimeHostCatalogReadError &&
       error.catalog === 'skill' &&
@@ -102,13 +107,9 @@ test('reassembles per-item relay profiles into the connection profile table', as
   ]);
 });
 
-test('reassembles Project aliases and locations across bounded pages without truncation', async () => {
+test('reassembles Project aliases without exposing Host locations', async () => {
   const aliases = Array.from({ length: 300 }, (_, index) => `project-alias-${index}`);
-  const root = process.platform === 'win32' ? 'C:\\workspace' : '/workspace';
-  const locations = Array.from({ length: 70 }, (_, index) => ({
-    path: `${root}${process.platform === 'win32' ? '\\' : '/'}location-${index}`,
-    isWorktree: index > 0,
-  }));
+  const locationCount = 70;
   const items = [
     {
       kind: 'project' as const,
@@ -116,22 +117,15 @@ test('reassembles Project aliases and locations across bounded pages without tru
       id: 'project-1',
       name: 'Project',
       aliasCount: aliases.length,
-      locationCount: locations.length,
+      locationCount,
       archivedAt: null,
       available: true,
-      preferredPath: locations[0]!.path,
     },
     ...aliases.map((alias, itemIndex) => ({
       kind: 'alias' as const,
       projectIndex: 0,
       itemIndex,
       alias,
-    })),
-    ...locations.map((location, itemIndex) => ({
-      kind: 'location' as const,
-      projectIndex: 0,
-      itemIndex,
-      location,
     })),
   ];
   const connection = fakeConnection(async (_operation, input) => {
@@ -152,10 +146,9 @@ test('reassembles Project aliases and locations across bounded pages without tru
       id: 'project-1',
       aliases,
       name: 'Project',
-      locations,
+      locationCount,
       archivedAt: null,
       available: true,
-      preferredPath: locations[0]!.path,
     },
   ]);
 });

--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -290,7 +290,7 @@ test('new Full Access Plan Skill previews use the mutating tool surface', async 
             kind: 'start',
             target: {
               kind: 'new_session',
-              context: { projectRoot: root },
+              context: { workspace: { kind: 'host_path', path: root } },
               collaborationMode: 'plan',
               permissionMode,
             },

--- a/packages/runtime-host/src/__tests__/external-session-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-coordinator.test.ts
@@ -51,6 +51,28 @@ test('discovers detected adapters and pages bounded source summaries', async () 
   assert.equal(second.result.nextCursor, null);
 });
 
+test('resolves a Project filter before calling the Host adapter', async () => {
+  const adapter = adapterFixture();
+  const filters: unknown[] = [];
+  adapter.listSessions = async (input) => {
+    filters.push(input);
+    return [];
+  };
+  const fixture = coordinatorFixture([adapter]);
+
+  const result = await fixture.coordinator.handlers['external-session.catalog.query'](
+    {
+      adapterId: 'codex',
+      workspace: { kind: 'project', projectId: 'project-1' },
+      includeArchived: true,
+    },
+    context,
+  );
+
+  assert.equal(result.ok, true);
+  assert.deepEqual(filters, [{ cwd: '/resolved-project', includeArchived: true }]);
+});
+
 test('stops catalog pages before the encoded result limit', async () => {
   const adapter = adapterFixture({ count: 20 });
   adapter.listSessions = async () =>
@@ -296,6 +318,23 @@ function coordinatorFixture(
       adapters: new ExternalSessionAdapterRegistry(adapters),
       admission,
       sessions: store,
+      workspaceResolver: {
+        resolve: async (target) =>
+          target.kind === 'host_path'
+            ? { target, cwd: target.path, projectId: null }
+            : {
+                target,
+                cwd: '/resolved-project',
+                projectId: target.projectId,
+                project: {
+                  id: target.projectId,
+                  name: 'Project',
+                  locations: [{ path: '/resolved-project', isWorktree: false }],
+                  available: true,
+                  preferredPath: '/resolved-project',
+                },
+              },
+      },
       resolveTarget: async () => ({
         backend: 'ai-sdk',
         llmConnectionSlug: 'default',

--- a/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
@@ -33,6 +33,20 @@ describe('external Session protocol', () => {
         'external-session.import': { mode: 'command', availability: 'ready' },
       },
     );
+    assert.equal(
+      HOST_OPERATION_SPECS['external-session.catalog.query'].usesHostPaths?.({
+        adapterId: 'codex',
+        workspace: { kind: 'project', projectId: 'project-1' },
+      }),
+      false,
+    );
+    assert.equal(
+      HOST_OPERATION_SPECS['external-session.catalog.query'].usesHostPaths?.({
+        adapterId: 'codex',
+        workspace: { kind: 'host_path', path: '/workspace' },
+      }),
+      true,
+    );
   });
 
   test('round-trips exact source, catalog, and import inputs', () => {
@@ -55,7 +69,7 @@ describe('external Session protocol', () => {
         input: {
           adapterId: 'codex',
           includeArchived: true,
-          cwd: '/workspace',
+          workspace: { kind: 'project', projectId: 'project-1' },
           cursor: '16',
         },
       }),
@@ -65,7 +79,7 @@ describe('external Session protocol', () => {
         input: {
           adapterId: 'codex',
           includeArchived: true,
-          cwd: '/workspace',
+          workspace: { kind: 'project', projectId: 'project-1' },
           cursor: '16',
         },
       },
@@ -118,7 +132,7 @@ describe('external Session protocol', () => {
           sessions: Array.from({ length: EXTERNAL_SESSION_PAGE_MAX_ITEMS + 1 }, (_, index) => ({
             id: `source-${index}`,
             name: `Session ${index}`,
-            cwd: '/workspace',
+            hostCwd: '/workspace',
           })),
           nextCursor: null,
         }),

--- a/packages/runtime-host/src/__tests__/project-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/project-catalog-coordinator.test.ts
@@ -9,6 +9,7 @@ import { HostProjectCatalogChangeService } from '../server/project-catalog-chang
 import { HostProjectCatalogCoordinator } from '../server/project-catalog-coordinator.js';
 import { HostProjectMembershipGate } from '../server/project-membership-gate.js';
 import { HostSessionCatalogChangeService } from '../server/session-catalog-change-service.js';
+import { HostWorkspaceResolver } from '../server/workspace-resolver.js';
 
 test('Host Project Catalog relink merges identities and reassigns every affected Session', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-project-catalog-'));
@@ -43,11 +44,13 @@ test('Host Project Catalog relink merges identities and reassigns every affected
       sessionFrames.push(frame);
     },
   });
+  const membership = new HostProjectMembershipGate();
   const coordinator = new HostProjectCatalogCoordinator(
     catalog,
     projectChanges,
     sessionChanges,
-    new HostProjectMembershipGate(),
+    membership,
+    new HostWorkspaceResolver(catalog, membership),
     () => assert.fail('ordinary project mutations must not drain the Host'),
   );
 
@@ -65,7 +68,7 @@ test('Host Project Catalog relink merges identities and reassigns every affected
     );
     assert.equal(relinked.ok, true);
     if (!relinked.ok || relinked.result.kind !== 'project') return;
-    assert.equal(relinked.result.projectId, original.id);
+    assert.equal(relinked.result.project.id, original.id);
     const [project] = await catalog.list();
     assert.deepEqual(project?.aliases, [duplicate.id]);
     assert.equal(project?.preferredPath, destinationPath);
@@ -99,6 +102,19 @@ test('Host Project Catalog relink merges identities and reassigns every affected
     assert.equal(listed.ok, true);
     assert.equal(listed.ok && listed.result.kind, 'page');
     assert.equal(listed.ok && listed.result.kind === 'page' && listed.result.projectCount, 1);
+
+    const location = await coordinator.handlers['project.catalog.location.query'](
+      { projectId: duplicate.id },
+      connection(),
+    );
+    assert.deepEqual(location, {
+      ok: true,
+      result: {
+        projectId: original.id,
+        locations: [{ path: destinationPath, isWorktree: false }],
+        preferredPath: destinationPath,
+      },
+    });
   } finally {
     catalog.close();
     await sessions.close?.();

--- a/packages/runtime-host/src/__tests__/project-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/project-catalog-coordinator.test.ts
@@ -9,7 +9,6 @@ import { HostProjectCatalogChangeService } from '../server/project-catalog-chang
 import { HostProjectCatalogCoordinator } from '../server/project-catalog-coordinator.js';
 import { HostProjectMembershipGate } from '../server/project-membership-gate.js';
 import { HostSessionCatalogChangeService } from '../server/session-catalog-change-service.js';
-import { HostWorkspaceResolver } from '../server/workspace-resolver.js';
 
 test('Host Project Catalog relink merges identities and reassigns every affected Session', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-project-catalog-'));
@@ -50,7 +49,6 @@ test('Host Project Catalog relink merges identities and reassigns every affected
     projectChanges,
     sessionChanges,
     membership,
-    new HostWorkspaceResolver(catalog, membership),
     () => assert.fail('ordinary project mutations must not drain the Host'),
   );
 
@@ -96,25 +94,30 @@ test('Host Project Catalog relink merges identities and reassigns every affected
     );
 
     const listed = await coordinator.handlers['project.catalog.query'](
-      { kind: 'list_start' },
+      { kind: 'list_start', view: 'summary' },
       connection(),
     );
     assert.equal(listed.ok, true);
     assert.equal(listed.ok && listed.result.kind, 'page');
     assert.equal(listed.ok && listed.result.kind === 'page' && listed.result.projectCount, 1);
 
-    const location = await coordinator.handlers['project.catalog.location.query'](
-      { projectId: duplicate.id },
+    const locations = await coordinator.handlers['project.catalog.query'](
+      { kind: 'list_start', view: 'locations' },
       connection(),
     );
-    assert.deepEqual(location, {
-      ok: true,
-      result: {
-        projectId: original.id,
-        locations: [{ path: destinationPath, isWorktree: false }],
-        preferredPath: destinationPath,
-      },
-    });
+    assert.equal(locations.ok, true);
+    if (!locations.ok || locations.result.kind !== 'page') return;
+    assert.deepEqual(
+      locations.result.items.filter((item) => item.kind === 'location'),
+      [
+        {
+          kind: 'location',
+          projectIndex: 0,
+          itemIndex: 0,
+          location: { path: destinationPath, isWorktree: false },
+        },
+      ],
+    );
   } finally {
     catalog.close();
     await sessions.close?.();

--- a/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
@@ -17,13 +17,7 @@ describe('Project catalog protocol', () => {
   test('declares bounded ready operations and exact invalidations', () => {
     assert.deepEqual(
       Object.fromEntries(
-        (
-          [
-            'project.catalog.query',
-            'project.catalog.location.query',
-            'project.catalog.mutate',
-          ] as const
-        ).map((operation) => [
+        (['project.catalog.query', 'project.catalog.mutate'] as const).map((operation) => [
           operation,
           {
             mode: HOST_OPERATION_SPECS[operation].mode,
@@ -33,7 +27,6 @@ describe('Project catalog protocol', () => {
       ),
       {
         'project.catalog.query': { mode: 'query', availability: 'ready' },
-        'project.catalog.location.query': { mode: 'query', availability: 'ready' },
         'project.catalog.mutate': { mode: 'command', availability: 'ready' },
       },
     );
@@ -76,12 +69,23 @@ describe('Project catalog protocol', () => {
     assert.deepEqual(decodeHostFrame(mutation), mutation);
     const location = {
       requestId: 'request-location',
-      operation: 'project.catalog.location.query' as const,
+      operation: 'project.catalog.query' as const,
       ok: true as const,
       result: {
-        projectId: 'project-1',
-        locations: [{ path: projectPath, isWorktree: false }],
-        preferredPath: projectPath,
+        kind: 'page' as const,
+        view: 'locations' as const,
+        revision,
+        projectCount: 1,
+        items: [
+          projectHeaderItem(),
+          {
+            kind: 'location' as const,
+            projectIndex: 0,
+            itemIndex: 0,
+            location: { path: projectPath, isWorktree: false },
+          },
+        ],
+        nextCursor: null,
       },
     };
     assert.deepEqual(decodeHostFrame(location), location);
@@ -89,11 +93,32 @@ describe('Project catalog protocol', () => {
       ...location,
       result: {
         ...location.result,
-        locations: [{ path: foreignHostPath, isWorktree: true }],
-        preferredPath: foreignHostPath,
+        items: [
+          projectHeaderItem(),
+          {
+            kind: 'location' as const,
+            projectIndex: 0,
+            itemIndex: 0,
+            location: { path: foreignHostPath, isWorktree: true },
+          },
+        ],
       },
     };
     assert.deepEqual(decodeHostFrame(foreignLocation), foreignLocation);
+    assert.equal(
+      HOST_OPERATION_SPECS['project.catalog.query'].usesHostPaths?.({
+        kind: 'list_start',
+        view: 'summary',
+      }),
+      false,
+    );
+    assert.equal(
+      HOST_OPERATION_SPECS['project.catalog.query'].usesHostPaths?.({
+        kind: 'list_start',
+        view: 'locations',
+      }),
+      true,
+    );
     assert.equal(
       HOST_OPERATION_SPECS['project.catalog.mutate'].usesHostPaths?.({
         kind: 'rename',
@@ -126,7 +151,7 @@ describe('Project catalog protocol', () => {
         decodeClientFrame({
           requestId: 'request-2',
           operation: 'project.catalog.query',
-          input: { kind: 'list_start', includeArchived: true },
+          input: { kind: 'list_start', view: 'summary', includeArchived: true },
         }),
       isProtocolError,
     );
@@ -134,6 +159,7 @@ describe('Project catalog protocol', () => {
       () =>
         decodeProjectCatalogQueryResult({
           kind: 'page',
+          view: 'summary',
           revision,
           projectCount: 1,
           items: Array.from({ length: PROJECT_CATALOG_PAGE_MAX_ITEMS + 1 }, projectHeaderItem),
@@ -145,6 +171,7 @@ describe('Project catalog protocol', () => {
       () =>
         decodeProjectCatalogQueryResult({
           kind: 'revision_changed',
+          view: 'summary',
           expected: revision,
           actual: revision,
           items: [],
@@ -172,6 +199,7 @@ function projectHeaderItem() {
     name: 'Project',
     aliasCount: 0,
     locationCount: 1,
+    preferredLocationIndex: 0,
     archivedAt: null,
     available: true,
   } as const;

--- a/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
@@ -10,13 +10,20 @@ import {
 } from '../protocol/index.js';
 
 const projectPath = process.platform === 'win32' ? 'C:\\workspace' : '/workspace';
+const foreignHostPath = process.platform === 'win32' ? '/workspace' : 'C:\\workspace';
 const revision = `sha256:${'a'.repeat(64)}` as const;
 
 describe('Project catalog protocol', () => {
   test('declares bounded ready operations and exact invalidations', () => {
     assert.deepEqual(
       Object.fromEntries(
-        (['project.catalog.query', 'project.catalog.mutate'] as const).map((operation) => [
+        (
+          [
+            'project.catalog.query',
+            'project.catalog.location.query',
+            'project.catalog.mutate',
+          ] as const
+        ).map((operation) => [
           operation,
           {
             mode: HOST_OPERATION_SPECS[operation].mode,
@@ -26,6 +33,7 @@ describe('Project catalog protocol', () => {
       ),
       {
         'project.catalog.query': { mode: 'query', availability: 'ready' },
+        'project.catalog.location.query': { mode: 'query', availability: 'ready' },
         'project.catalog.mutate': { mode: 'command', availability: 'ready' },
       },
     );
@@ -37,9 +45,6 @@ describe('Project catalog protocol', () => {
   test('round-trips every closed mutation shape and correlates its result', () => {
     for (const input of [
       { kind: 'register', path: projectPath },
-      { kind: 'select', projectId: 'project-1' },
-      { kind: 'touch', projectId: 'project-1', path: null },
-      { kind: 'touch', projectId: 'project-1', path: projectPath },
       { kind: 'relink', projectId: 'project-1', path: projectPath },
       { kind: 'rename', projectId: 'project-1', name: 'Project' },
       { kind: 'archive', projectId: 'project-1' },
@@ -52,27 +57,57 @@ describe('Project catalog protocol', () => {
       };
       assert.deepEqual(decodeClientFrame(request), request);
     }
-    assert.deepEqual(
-      decodeHostFrame({
-        requestId: 'request-select',
-        operation: 'project.catalog.mutate',
-        ok: true,
-        result: { kind: 'selection', projectId: 'project-1', path: projectPath },
-      }),
-      {
-        requestId: 'request-select',
-        operation: 'project.catalog.mutate',
-        ok: true,
-        result: { kind: 'selection', projectId: 'project-1', path: projectPath },
+    const mutation = {
+      requestId: 'request-register',
+      operation: 'project.catalog.mutate' as const,
+      ok: true as const,
+      result: {
+        kind: 'project' as const,
+        project: {
+          id: 'project-1',
+          aliases: [],
+          name: 'Project',
+          locationCount: 1,
+          archivedAt: null,
+          available: true,
+        },
       },
+    };
+    assert.deepEqual(decodeHostFrame(mutation), mutation);
+    const location = {
+      requestId: 'request-location',
+      operation: 'project.catalog.location.query' as const,
+      ok: true as const,
+      result: {
+        projectId: 'project-1',
+        locations: [{ path: projectPath, isWorktree: false }],
+        preferredPath: projectPath,
+      },
+    };
+    assert.deepEqual(decodeHostFrame(location), location);
+    const foreignLocation = {
+      ...location,
+      result: {
+        ...location.result,
+        locations: [{ path: foreignHostPath, isWorktree: true }],
+        preferredPath: foreignHostPath,
+      },
+    };
+    assert.deepEqual(decodeHostFrame(foreignLocation), foreignLocation);
+    assert.equal(
+      HOST_OPERATION_SPECS['project.catalog.mutate'].usesHostPaths?.({
+        kind: 'rename',
+        projectId: 'project-1',
+        name: 'Renamed',
+      }),
+      false,
     );
-    assert.throws(
-      () =>
-        HOST_OPERATION_SPECS['project.catalog.mutate'].assertOutputForInput?.(
-          { kind: 'select', projectId: 'project-1' },
-          { kind: 'project', projectId: 'project-1' },
-        ),
-      isProtocolError,
+    assert.equal(
+      HOST_OPERATION_SPECS['project.catalog.mutate'].usesHostPaths?.({
+        kind: 'register',
+        path: projectPath,
+      }),
+      true,
     );
   });
 
@@ -116,6 +151,16 @@ describe('Project catalog protocol', () => {
         }),
       isProtocolError,
     );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'request-stale-mutation',
+          operation: 'project.catalog.mutate',
+          ok: true,
+          result: { kind: 'project', projectId: 'project-1' },
+        }),
+      isProtocolError,
+    );
   });
 });
 
@@ -129,7 +174,6 @@ function projectHeaderItem() {
     locationCount: 1,
     archivedAt: null,
     available: true,
-    preferredPath: projectPath,
   } as const;
 }
 

--- a/packages/runtime-host/src/__tests__/project-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/project-catalog-two-client-uds.test.ts
@@ -81,8 +81,10 @@ test('two UDS clients converge on one Host-owned Project Catalog', {
       assert.ok(session);
       assert.equal(session && 'kind' in session, false);
       if (!session || 'kind' in session) continue;
-      assert.equal(session.projectId, seeded.originalProjectId);
-      assert.equal(session.cwd, seeded.destinationPath);
+      assert.deepEqual(session.workspace, {
+        target: { kind: 'project', projectId: seeded.originalProjectId },
+        hostCwd: seeded.destinationPath,
+      });
     }
   } finally {
     const cleanupErrors: unknown[] = [];

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -47,7 +47,7 @@ describe('Runtime Host bootstrap protocol', () => {
 
   test('declares the current protocol and closed authority operation set', () => {
     assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
-    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 14);
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 15);
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
       'access.credential.issue',
       'access.credential.revoke',
@@ -104,6 +104,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'plan.turn.start',
       'pricing.mutate',
       'pricing.query',
+      'project.catalog.location.query',
       'project.catalog.mutate',
       'project.catalog.query',
       'queue.retract',
@@ -119,7 +120,6 @@ describe('Runtime Host bootstrap protocol', () => {
       'session.catalog.query',
       'session.configuration.update',
       'session.create',
-      'session.cwd.relocate',
       'session.execution_boundary.query',
       'session.lifecycle.set',
       'session.metadata.update',
@@ -129,6 +129,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'session.revision.abandon',
       'session.revision.create',
       'session.transcript.query',
+      'session.workspace.relocate',
       'skill.catalog.invocable.query',
       'skill.catalog.mutate',
       'skill.catalog.preview-update',

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -104,7 +104,6 @@ describe('Runtime Host bootstrap protocol', () => {
       'plan.turn.start',
       'pricing.mutate',
       'pricing.query',
-      'project.catalog.location.query',
       'project.catalog.mutate',
       'project.catalog.query',
       'queue.retract',

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -12,6 +12,7 @@ import {
   type SessionHeader,
 } from '@maka/core';
 import { SessionConfigurationTransitionError, headerToSummary } from '@maka/runtime';
+import type { ProjectCatalog } from '@maka/storage';
 import {
   SessionMetadataVersionConflictError,
   type SessionCatalogRecord,
@@ -22,6 +23,7 @@ import {
 } from '../protocol/index.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 import { HostProjectMembershipGate } from '../server/project-membership-gate.js';
+import { HostWorkspaceResolver } from '../server/workspace-resolver.js';
 import {
   HostSessionCatalogCoordinator,
   type HostSessionCatalogCoordinatorOptions,
@@ -224,7 +226,7 @@ test('creation rejects reserved execution labels before claiming a Session ident
   const outcome = await fixture.coordinator.handlers['session.create'](
     {
       sessionId: fixture.sessionId,
-      cwd: process.cwd(),
+      workspace: { kind: 'host_path', path: process.cwd() },
       labels: [DEEP_RESEARCH_SESSION_LABEL],
       modelTarget: { kind: 'default' },
     },
@@ -269,7 +271,7 @@ test('creation on a relay connection honours declared levels via the catalog pro
   const outcome = await fixture.coordinator.handlers['session.create'](
     {
       sessionId: fixture.sessionId,
-      cwd: process.cwd(),
+      workspace: { kind: 'host_path', path: process.cwd() },
       modelTarget: { kind: 'explicit', connectionSlug: 'test', model: 'relay-model' },
       thinkingLevel: 'low',
     },
@@ -303,7 +305,7 @@ test('creation on a relay connection without declarations still fails closed on 
   const outcome = await fixture.coordinator.handlers['session.create'](
     {
       sessionId: fixture.sessionId,
-      cwd: process.cwd(),
+      workspace: { kind: 'host_path', path: process.cwd() },
       modelTarget: { kind: 'explicit', connectionSlug: 'test', model: 'relay-model' },
       thinkingLevel: 'low',
     },
@@ -334,7 +336,7 @@ test('creation rejects explore permission without a declared mode', async () => 
   const outcome = await fixture.coordinator.handlers['session.create'](
     {
       sessionId: fixture.sessionId,
-      cwd: process.cwd(),
+      workspace: { kind: 'host_path', path: process.cwd() },
       modelTarget: { kind: 'default' },
       permissionMode: 'explore',
     },
@@ -369,7 +371,7 @@ test('creation materializes Deep Research semantics inside the Host transaction'
   const outcome = await fixture.coordinator.handlers['session.create'](
     {
       sessionId: fixture.sessionId,
-      cwd: process.cwd(),
+      workspace: { kind: 'host_path', path: process.cwd() },
       mode: 'deep_research',
       name: 'Caller override',
       labels: ['customer-label'],
@@ -442,7 +444,7 @@ test('creation fingerprints and persists the canonical cwd behind a symlink', as
       const outcome = await fixture.coordinator.handlers['session.create'](
         {
           sessionId: fixture.sessionId,
-          cwd,
+          workspace: { kind: 'host_path', path: cwd },
           modelTarget: { kind: 'default' },
         },
         context,
@@ -459,13 +461,13 @@ test('creation fingerprints and persists the canonical cwd behind a symlink', as
   }
 });
 
-test('creation resolves a stale Client project path from current Host membership', async () => {
+test('creation resolves a Project alias and records Host-owned usage', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-session-create-project-'));
-  const stalePath = join(root, 'stale');
   const currentPath = join(root, 'current');
   await mkdir(currentPath);
   try {
     let created: Parameters<CatalogStores['createStableSession']>[0] | undefined;
+    const touches: Array<{ projectId: string; path?: string }> = [];
     const fixture = createFixture({
       projectCatalog: {
         list: async () => [
@@ -478,6 +480,10 @@ test('creation resolves a stale Client project path from current Host membership
             preferredPath: currentPath,
           },
         ],
+        touch: async (projectId: string, path?: string) => {
+          touches.push({ projectId, path });
+          return {} as never;
+        },
       } as never,
       stores: {
         createStableSession: async (request) => {
@@ -500,8 +506,7 @@ test('creation resolves a stale Client project path from current Host membership
     const outcome = await fixture.coordinator.handlers['session.create'](
       {
         sessionId: fixture.sessionId,
-        cwd: stalePath,
-        projectId: 'project-stale',
+        workspace: { kind: 'project', projectId: 'project-stale' },
         modelTarget: { kind: 'default' },
       },
       context,
@@ -510,12 +515,13 @@ test('creation resolves a stale Client project path from current Host membership
     assert.equal(outcome.ok, true);
     assert.equal(created?.input.cwd, currentPath);
     assert.equal(created?.input.projectId, 'project-current');
+    assert.deepEqual(touches, [{ projectId: 'project-current', path: currentPath }]);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test('cwd relocation canonicalizes once and commits through Runtime authority', async () => {
+test('Host-path relocation canonicalizes once and commits through Runtime authority', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-session-relocate-cwd-'));
   const target = join(root, 'target');
   const link = join(root, 'link');
@@ -524,12 +530,11 @@ test('cwd relocation canonicalizes once and commits through Runtime authority', 
   try {
     const fixture = createFixture();
     const expectedRevision = fixture.revision();
-    const outcome = await fixture.coordinator.handlers['session.cwd.relocate'](
+    const outcome = await fixture.coordinator.handlers['session.workspace.relocate'](
       {
         sessionId: fixture.sessionId,
         expectedRevision,
-        cwd: link,
-        projectId: 'project-2',
+        workspace: { kind: 'host_path', path: link },
       },
       context,
     );
@@ -539,9 +544,9 @@ test('cwd relocation canonicalizes once and commits through Runtime authority', 
     if ('kind' in outcome.result.session) {
       assert.fail('Relocated Session must remain wire-representable');
     }
-    assert.equal(outcome.result.session.cwd, await realpath(target));
+    assert.equal(outcome.result.session.workspace.hostCwd, await realpath(target));
     assert.equal(fixture.header().cwd, await realpath(target));
-    assert.equal(fixture.header().projectId, 'project-2');
+    assert.equal(fixture.header().projectId, null);
     assert.equal(fixture.revision(), expectedRevision + 1);
     assert.equal(fixture.drainRequests(), 0);
   } finally {
@@ -549,7 +554,7 @@ test('cwd relocation canonicalizes once and commits through Runtime authority', 
   }
 });
 
-test('cwd relocation reports a stale Session revision without mutating Runtime state', async () => {
+test('workspace relocation reports a stale Session revision without mutating Runtime state', async () => {
   let relocationAttempts = 0;
   const fixture = createFixture({
     manager: {
@@ -559,11 +564,11 @@ test('cwd relocation reports a stale Session revision without mutating Runtime s
       },
     },
   });
-  const outcome = await fixture.coordinator.handlers['session.cwd.relocate'](
+  const outcome = await fixture.coordinator.handlers['session.workspace.relocate'](
     {
       sessionId: fixture.sessionId,
       expectedRevision: fixture.revision() - 1,
-      cwd: process.cwd(),
+      workspace: { kind: 'host_path', path: process.cwd() },
     },
     context,
   );
@@ -580,7 +585,7 @@ test('cwd relocation reports a stale Session revision without mutating Runtime s
   assert.equal(fixture.drainRequests(), 0);
 });
 
-test('same-cwd relocation still enters Runtime eligibility authority', async () => {
+test('same-workspace relocation still enters Runtime eligibility authority', async () => {
   let relocationAttempts = 0;
   const cwd = await realpath(process.cwd());
   const fixture = createFixture({
@@ -596,11 +601,11 @@ test('same-cwd relocation still enters Runtime eligibility authority', async () 
     },
   });
 
-  const outcome = await fixture.coordinator.handlers['session.cwd.relocate'](
+  const outcome = await fixture.coordinator.handlers['session.workspace.relocate'](
     {
       sessionId: fixture.sessionId,
       expectedRevision: fixture.revision(),
-      cwd,
+      workspace: { kind: 'host_path', path: cwd },
     },
     context,
   );
@@ -662,7 +667,7 @@ function createFixture(
     readonly manager?: Partial<ConfigurationAuthority>;
     readonly continuity?: Partial<SessionContinuity>;
     readonly connection?: FixtureConnection;
-    readonly projectCatalog?: HostSessionCatalogCoordinatorOptions['projectCatalog'];
+    readonly projectCatalog?: ProjectCatalog;
   } = {},
 ) {
   const sessionId = 'session-1';
@@ -728,8 +733,10 @@ function createFixture(
     manager,
     admission: new SessionAdmissionGate(),
     continuity,
-    projectCatalog: options.projectCatalog ?? ({ list: async () => [] } as never),
-    projectMembership: new HostProjectMembershipGate(),
+    workspaceResolver: new HostWorkspaceResolver(
+      options.projectCatalog ?? ({ list: async () => [] } as never),
+      new HostProjectMembershipGate(),
+    ),
     requestDrain: () => {
       drains += 1;
     },

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -468,7 +468,11 @@ test('creation resolves a Project alias and records Host-owned usage', async () 
   try {
     let created: Parameters<CatalogStores['createStableSession']>[0] | undefined;
     const touches: Array<{ projectId: string; path?: string }> = [];
+    let projectChanges = 0;
     const fixture = createFixture({
+      onProjectChanged: () => {
+        projectChanges += 1;
+      },
       projectCatalog: {
         list: async () => [
           {
@@ -516,6 +520,7 @@ test('creation resolves a Project alias and records Host-owned usage', async () 
     assert.equal(created?.input.cwd, currentPath);
     assert.equal(created?.input.projectId, 'project-current');
     assert.deepEqual(touches, [{ projectId: 'project-current', path: currentPath }]);
+    assert.equal(projectChanges, 1);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
@@ -668,6 +673,7 @@ function createFixture(
     readonly continuity?: Partial<SessionContinuity>;
     readonly connection?: FixtureConnection;
     readonly projectCatalog?: ProjectCatalog;
+    readonly onProjectChanged?: () => void;
   } = {},
 ) {
   const sessionId = 'session-1';
@@ -736,6 +742,7 @@ function createFixture(
     workspaceResolver: new HostWorkspaceResolver(
       options.projectCatalog ?? ({ list: async () => [] } as never),
       new HostProjectMembershipGate(),
+      options.onProjectChanged ?? (() => undefined),
     ),
     requestDrain: () => {
       drains += 1;

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -12,7 +12,7 @@ import {
   type SessionHeader,
 } from '@maka/core';
 import { SessionConfigurationTransitionError, headerToSummary } from '@maka/runtime';
-import type { ProjectCatalog } from '@maka/storage';
+import { type ProjectCatalog, ProjectUnavailableError } from '@maka/storage';
 import {
   SessionMetadataVersionConflictError,
   type SessionCatalogRecord,
@@ -415,7 +415,7 @@ test('configuration update admits Plan mode through Runtime authority', async ()
   assert.equal(fixture.drainRequests(), 0);
 });
 
-test('creation fingerprints and persists the canonical cwd behind a symlink', async () => {
+test('creation persists a canonical cwd while fingerprints retain exact target intent', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-session-create-cwd-'));
   const target = join(root, 'target');
   const link = join(root, 'link');
@@ -455,10 +455,45 @@ test('creation fingerprints and persists the canonical cwd behind a symlink', as
     assert.equal(requests.length, 2);
     assert.equal(requests[0]?.input.cwd, await realpath(target));
     assert.equal(requests[1]?.input.cwd, await realpath(target));
-    assert.equal(requests[0]?.requestFingerprint, requests[1]?.requestFingerprint);
+    assert.notEqual(requests[0]?.requestFingerprint, requests[1]?.requestFingerprint);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test('exact Project creation retry succeeds after the Project becomes archived', async () => {
+  const fixture = createFixture({
+    projectCatalog: {
+      list: async () => [
+        {
+          id: 'project-1',
+          name: 'Project',
+          locations: [{ path: '/archived', isWorktree: false }],
+          archivedAt: 1,
+          available: true,
+          preferredPath: '/archived',
+        },
+      ],
+    } as never,
+    stores: {
+      probeStableSessionCreate: async () => ({
+        kind: 'existing',
+        record: headerSnapshot(sessionHeader('session-1', ['user-label']), 3),
+      }),
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.create'](
+    {
+      sessionId: fixture.sessionId,
+      workspace: { kind: 'project', projectId: 'project-1' },
+      modelTarget: { kind: 'default' },
+    },
+    context,
+  );
+
+  assert.equal(outcome.ok, true);
+  assert.equal(fixture.drainRequests(), 0);
 });
 
 test('creation resolves a Project alias and records Host-owned usage', async () => {
@@ -524,6 +559,40 @@ test('creation resolves a Project alias and records Host-owned usage', async () 
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test('creation reports a Project path lost before usage recording without draining', async () => {
+  const fixture = createFixture({
+    projectCatalog: {
+      list: async () => [
+        {
+          id: 'project-1',
+          name: 'Project',
+          locations: [{ path: '/missing', isWorktree: false }],
+          available: true,
+          preferredPath: '/missing',
+        },
+      ],
+      touch: async () => {
+        throw new ProjectUnavailableError('project-1');
+      },
+    } as never,
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.create'](
+    {
+      sessionId: fixture.sessionId,
+      workspace: { kind: 'project', projectId: 'project-1' },
+      modelTarget: { kind: 'default' },
+    },
+    context,
+  );
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    error: { code: 'operation_conflict', message: 'Project is unavailable: project-1' },
+  });
+  assert.equal(fixture.drainRequests(), 0);
 });
 
 test('Host-path relocation canonicalizes once and commits through Runtime authority', async () => {

--- a/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
@@ -21,7 +21,7 @@ describe('Session catalog protocol', () => {
             'session.create',
             'session.metadata.update',
             'session.configuration.update',
-            'session.cwd.relocate',
+            'session.workspace.relocate',
             'session.read_marker.set',
             'session.execution_boundary.query',
           ] as const
@@ -38,10 +38,26 @@ describe('Session catalog protocol', () => {
         'session.create': { mode: 'command', availability: 'ready' },
         'session.metadata.update': { mode: 'command', availability: 'ready' },
         'session.configuration.update': { mode: 'command', availability: 'ready' },
-        'session.cwd.relocate': { mode: 'command', availability: 'ready' },
+        'session.workspace.relocate': { mode: 'command', availability: 'ready' },
         'session.read_marker.set': { mode: 'command', availability: 'ready' },
         'session.execution_boundary.query': { mode: 'query', availability: 'ready' },
       },
+    );
+    assert.equal(
+      HOST_OPERATION_SPECS['session.create'].usesHostPaths?.({
+        sessionId: 'project-session',
+        workspace: { kind: 'project', projectId: 'project-1' },
+        modelTarget: { kind: 'default' },
+      }),
+      false,
+    );
+    assert.equal(
+      HOST_OPERATION_SPECS['session.create'].usesHostPaths?.({
+        sessionId: 'path-session',
+        workspace: { kind: 'host_path', path: '/workspace' },
+        modelTarget: { kind: 'default' },
+      }),
+      true,
     );
   });
 
@@ -111,8 +127,7 @@ describe('Session catalog protocol', () => {
         operation: 'session.create',
         input: {
           sessionId: 'session-1',
-          cwd: '/workspace',
-          projectId: null,
+          workspace: { kind: 'project', projectId: 'project-1' },
           name: 'Session',
           labels: ['catalog'],
           modelTarget: {
@@ -131,8 +146,7 @@ describe('Session catalog protocol', () => {
         operation: 'session.create',
         input: {
           sessionId: 'session-1',
-          cwd: '/workspace',
-          projectId: null,
+          workspace: { kind: 'project', projectId: 'project-1' },
           name: 'Session',
           labels: ['catalog'],
           modelTarget: {
@@ -151,22 +165,20 @@ describe('Session catalog protocol', () => {
     assert.deepEqual(
       decodeClientFrame({
         requestId: 'request-3',
-        operation: 'session.cwd.relocate',
+        operation: 'session.workspace.relocate',
         input: {
           sessionId: 'session-1',
           expectedRevision: 2,
-          cwd: '/workspace/next',
-          projectId: 'project-2',
+          workspace: { kind: 'host_path', path: '/workspace/next' },
         },
       }),
       {
         requestId: 'request-3',
-        operation: 'session.cwd.relocate',
+        operation: 'session.workspace.relocate',
         input: {
           sessionId: 'session-1',
           expectedRevision: 2,
-          cwd: '/workspace/next',
-          projectId: 'project-2',
+          workspace: { kind: 'host_path', path: '/workspace/next' },
         },
       },
     );
@@ -259,7 +271,7 @@ describe('Session catalog protocol', () => {
       operation: 'session.create',
       input: {
         sessionId: 'session-name',
-        cwd: '/workspace',
+        workspace: { kind: 'host_path', path: '/workspace' },
         name,
         modelTarget: { kind: 'default' },
       },
@@ -275,7 +287,7 @@ describe('Session catalog protocol', () => {
           operation: 'session.create',
           input: {
             sessionId: 'session-name-overflow',
-            cwd: '/workspace',
+            workspace: { kind: 'host_path', path: '/workspace' },
             name: '🦊'.repeat(81),
             modelTarget: { kind: 'default' },
           },
@@ -290,7 +302,7 @@ describe('Session catalog protocol', () => {
       operation: 'session.create',
       input: {
         sessionId: 'session-mode',
-        cwd: '/workspace',
+        workspace: { kind: 'host_path', path: '/workspace' },
         mode: 'deep_research',
         modelTarget: { kind: 'default' },
       },
@@ -306,7 +318,7 @@ describe('Session catalog protocol', () => {
           operation: 'session.create',
           input: {
             sessionId: 'session-invalid-mode',
-            cwd: '/workspace',
+            workspace: { kind: 'host_path', path: '/workspace' },
             mode: 'unknown',
             modelTarget: { kind: 'default' },
           },
@@ -416,7 +428,10 @@ function projection(overrides: Partial<SessionCatalogProjection> = {}): SessionC
   return {
     id: 'session-1',
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 2,
     name: 'Session',

--- a/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
@@ -382,6 +382,20 @@ describe('Session catalog protocol', () => {
     );
   });
 
+  test('rejects a Host path projection whose target and cwd disagree', () => {
+    assert.throws(
+      () =>
+        decodeSessionCatalogItem({
+          ...projection(),
+          workspace: {
+            target: { kind: 'host_path', path: '/workspace' },
+            hostCwd: '/different-workspace',
+          },
+        }),
+      isProtocolError,
+    );
+  });
+
   test('bounds pages and preserves revision-pinned continuation results', () => {
     const sessions = Array.from({ length: SESSION_CATALOG_PAGE_MAX_ITEMS }, (_, index) =>
       projection({ id: `session-${index}` }),

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -27,6 +27,7 @@ import {
   encodeProtocolMessage,
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  RuntimeHostProtocolError,
   type ClientFrame,
   type SessionCatalogItem,
   type SessionCatalogProjection,
@@ -70,7 +71,7 @@ test('two Clients share stable Session creation, CAS configuration, and catalog 
       });
       const createInput: SessionCreateInput = {
         sessionId: 'stable-session',
-        cwd: root,
+        workspace: { kind: 'host_path', path: root },
         name: 'Stable Session',
         labels: ['catalog'],
         modelTarget: { kind: 'default' },
@@ -172,14 +173,15 @@ test('two Clients share stable Session creation, CAS configuration, and catalog 
       await assert.rejects(
         desktop.request('session.create', {
           sessionId: 'relative-session',
-          cwd: '.',
+          workspace: { kind: 'host_path', path: '.' },
           modelTarget: { kind: 'default' },
         }),
-        operationError('invalid_request'),
+        (error: unknown) =>
+          error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame',
       );
       const planSession = await desktop.request('session.create', {
         sessionId: 'plan-session',
-        cwd: root,
+        workspace: { kind: 'host_path', path: root },
         modelTarget: { kind: 'default' },
         collaborationMode: 'plan',
       });
@@ -188,7 +190,7 @@ test('two Clients share stable Session creation, CAS configuration, and catalog 
       const researchSession = requireSessionProjection(
         await desktop.request('session.create', {
           sessionId: 'deep-research-session',
-          cwd: root,
+          workspace: { kind: 'host_path', path: root },
           mode: 'deep_research',
           name: 'Caller override',
           labels: ['customer-label'],
@@ -321,15 +323,15 @@ test('two Clients share stable Session creation, CAS configuration, and catalog 
       const secondCwd = join(base, 'workspace-second');
       await Promise.all([mkdir(firstCwd), mkdir(secondCwd)]);
       const relocationOutcomes = await Promise.all([
-        desktop.relocateSessionCwd({
+        desktop.relocateSessionWorkspace({
           sessionId: narrowedSession.id,
           expectedRevision: narrowedSession.revision,
-          cwd: firstCwd,
+          workspace: { kind: 'host_path', path: firstCwd },
         }),
-        tui.relocateSessionCwd({
+        tui.relocateSessionWorkspace({
           sessionId: narrowedSession.id,
           expectedRevision: narrowedSession.revision,
-          cwd: secondCwd,
+          workspace: { kind: 'host_path', path: secondCwd },
         }),
       ]);
       assert.deepEqual(relocationOutcomes.map((outcome) => outcome.kind).sort(), [
@@ -341,8 +343,8 @@ test('two Clients share stable Session creation, CAS configuration, and catalog 
       if (relocated?.kind !== 'committed') assert.fail('One Session relocation must commit');
       const relocatedSession = requireSessionProjection(relocated.session);
       assert.ok(
-        relocatedSession.cwd === (await realpath(firstCwd)) ||
-          relocatedSession.cwd === (await realpath(secondCwd)),
+        relocatedSession.workspace.hostCwd === (await realpath(firstCwd)) ||
+          relocatedSession.workspace.hostCwd === (await realpath(secondCwd)),
       );
       assert.deepEqual(await querySession(tui, narrowedSession.id), relocatedSession);
 
@@ -351,7 +353,7 @@ test('two Clients share stable Session creation, CAS configuration, and catalog 
       await assert.rejects(
         desktop.request('session.create', {
           sessionId: rejectedSessionId,
-          cwd: root,
+          workspace: { kind: 'host_path', path: root },
           modelTarget: { kind: 'default' },
         }),
         operationError('invalid_request'),
@@ -403,7 +405,7 @@ test('two Clients share stable Session creation, CAS configuration, and catalog 
           Array.from({ length: 34 }, (_, index) =>
             desktop.request('session.create', {
               sessionId: `bulk-${String(index).padStart(2, '0')}`,
-              cwd: root,
+              workspace: { kind: 'host_path', path: root },
               labels: ['paged'],
               modelTarget: { kind: 'default' },
             }),
@@ -687,7 +689,7 @@ test('stable Session creation survives response loss and Host restart', {
     host = await startHost(root, capability.rootId);
     const input: SessionCreateInput = {
       sessionId: 'response-loss-session',
-      cwd: root,
+      workspace: { kind: 'host_path', path: root },
       name: 'Response Loss Session',
       labels: ['catalog'],
       modelTarget: { kind: 'default' },

--- a/packages/runtime-host/src/__tests__/session-retirement-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-retirement-protocol.test.ts
@@ -146,7 +146,10 @@ function projection(overrides: Partial<SessionCatalogProjection> = {}): SessionC
   return {
     id: 'session-1',
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: 'Session',

--- a/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
@@ -149,7 +149,10 @@ function sessionProjection(id: string): SessionCatalogProjection {
   return {
     id,
     revision: 1,
-    cwd: '/workspace',
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
     createdAt: 1,
     lastUsedAt: 1,
     name: 'Session',

--- a/packages/runtime-host/src/__tests__/skill-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-coordinator.test.ts
@@ -11,6 +11,18 @@ import {
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 
 const roots = new Set<string>();
+const workspaceResolver = {
+  async run<T>(
+    target: { readonly kind: 'host_path'; readonly path: string },
+    operation: (workspace: {
+      readonly target: typeof target;
+      readonly cwd: string;
+      readonly projectId: null;
+    }) => Promise<T>,
+  ) {
+    return operation({ target, cwd: target.path, projectId: null });
+  },
+};
 
 afterEach(async () => {
   await Promise.all([...roots].map((root) => rm(root, { recursive: true, force: true })));
@@ -59,10 +71,10 @@ test('multi-caller operations share one lane and drain waits for admitted work',
       }
     },
   });
-  const coordinator = new HostSkillCatalogCoordinator(repository);
+  const coordinator = new HostSkillCatalogCoordinator(repository, workspaceResolver);
   const input = {
     kind: 'start' as const,
-    context: { projectRoot: project },
+    context: { workspace: { kind: 'host_path' as const, path: project } },
     view: 'governance' as const,
   };
 
@@ -118,7 +130,7 @@ test('lifecycle recovery remains queued during drain and close waits for it', as
       return operation(root);
     },
   });
-  const coordinator = new HostSkillCatalogCoordinator(repository);
+  const coordinator = new HostSkillCatalogCoordinator(repository, workspaceResolver);
 
   coordinator.beginDrain();
   const recovery = coordinator.recover();
@@ -138,7 +150,7 @@ test('lifecycle recovery remains queued during drain and close waits for it', as
 
   const rejected = await coordinator.query({
     kind: 'start',
-    context: { projectRoot: project },
+    context: { workspace: { kind: 'host_path', path: project } },
     view: 'governance',
   });
   assert.deepEqual(rejected, {
@@ -166,12 +178,12 @@ test('canonical model inventory uses the same revision and is deeply immutable',
     managedSourcesRoot: join(home, '.maka', 'skill-sources'),
     runWithRoot: async (operation) => operation(root),
   });
-  const coordinator = new HostSkillCatalogCoordinator(repository);
+  const coordinator = new HostSkillCatalogCoordinator(repository, workspaceResolver);
 
   await coordinator.recover();
   const query = await coordinator.query({
     kind: 'start',
-    context: { projectRoot: project },
+    context: { workspace: { kind: 'host_path', path: project } },
     view: 'governance',
   });
   assert.equal(query.ok, true);
@@ -216,6 +228,7 @@ test('invocable pages use the authoritative Host tool surface and invalidate on 
       managedSourcesRoot: join(home, '.maka', 'skill-sources'),
       runWithRoot: async (operation) => operation(root),
     }),
+    workspaceResolver,
     async () => ({ projectRoot: project, host: { toolNames } }),
   );
   const context: ConnectionContext = {
@@ -231,7 +244,7 @@ test('invocable pages use the authoritative Host tool surface and invalidate on 
       kind: 'start',
       target: {
         kind: 'new_session',
-        context: { projectRoot: project },
+        context: { workspace: { kind: 'host_path', path: project } },
         collaborationMode: 'agent',
         permissionMode: 'ask',
       },
@@ -251,7 +264,7 @@ test('invocable pages use the authoritative Host tool surface and invalidate on 
       kind: 'continue',
       target: {
         kind: 'new_session',
-        context: { projectRoot: project },
+        context: { workspace: { kind: 'host_path', path: project } },
         collaborationMode: 'agent',
         permissionMode: 'ask',
       },

--- a/packages/runtime-host/src/__tests__/skill-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-coordinator.test.ts
@@ -190,6 +190,10 @@ test('canonical model inventory uses the same revision and is deeply immutable',
   if (!query.ok) return;
   assert.equal(query.result.kind, 'page');
   if (query.result.kind !== 'page') return;
+  assert.deepEqual(query.result.resolvedWorkspace, {
+    target: { kind: 'host_path', path: project },
+    hostCwd: project,
+  });
   const model = await coordinator.readCanonicalModelInventory({ projectRoot: project });
   assert.equal(model.revision, query.result.revision);
   assert.equal(Object.isFrozen(model), true);

--- a/packages/runtime-host/src/__tests__/skill-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-protocol.test.ts
@@ -10,6 +10,7 @@ import {
   SKILL_CATALOG_PAGE_MAX_BYTES,
   SKILL_CATALOG_PAGE_MAX_ITEMS,
   SKILL_CATALOG_PREVIEW_RESULT_MAX_BYTES,
+  WORKSPACE_HOST_PATH_MAX_BYTES,
   type SkillCatalogBundledItem,
   type SkillCatalogGovernanceItem,
   type SkillCatalogMutation,
@@ -22,7 +23,10 @@ import { SkillCatalogRepository } from '../server/skill-catalog-repository.js';
 const REVISION = `sha256:${'a'.repeat(64)}` as SkillCatalogRevision;
 const NEXT_REVISION = `sha256:${'b'.repeat(64)}` as SkillCatalogRevision;
 const CONTEXT = {
-  projectRoot: process.platform === 'win32' ? 'C:\\workspace\\project' : '/workspace/project',
+  workspace: {
+    kind: 'host_path' as const,
+    path: process.platform === 'win32' ? 'C:\\workspace\\project' : '/workspace/project',
+  },
 };
 
 type IsAssignable<From, To> = [From] extends [To] ? true : false;
@@ -107,6 +111,22 @@ describe('Runtime Host Skill catalog protocol', () => {
         errors: [...queryErrors, 'commit_outcome_unknown'],
       },
     );
+    assert.equal(
+      SKILL_CATALOG_OPERATION_SPECS['skill.catalog.query'].usesHostPaths?.({
+        kind: 'start',
+        context: { workspace: { kind: 'project', projectId: 'project-1' } },
+        view: 'governance',
+      }),
+      false,
+    );
+    assert.equal(
+      SKILL_CATALOG_OPERATION_SPECS['skill.catalog.query'].usesHostPaths?.({
+        kind: 'start',
+        context: CONTEXT,
+        view: 'governance',
+      }),
+      true,
+    );
   });
 
   test('decodes bounded Session and new-Session invocable queries and pages', () => {
@@ -178,7 +198,7 @@ describe('Runtime Host Skill catalog protocol', () => {
     });
   });
 
-  test('decodes start and continuation queries with bounded typed local context', () => {
+  test('decodes start and continuation queries with bounded workspace context', () => {
     for (const input of [
       { kind: 'start', context: CONTEXT, view: 'governance' },
       { kind: 'start', context: CONTEXT, view: 'bundled' },
@@ -202,39 +222,40 @@ describe('Runtime Host Skill catalog protocol', () => {
     });
     assertInvalidRequest('skill.catalog.query', {
       kind: 'start',
-      context: { projectRoot: '界'.repeat(1366) },
+      context: {
+        workspace: {
+          kind: 'host_path',
+          path: '界'.repeat(Math.floor(WORKSPACE_HOST_PATH_MAX_BYTES / 3) + 1),
+        },
+      },
       view: 'governance',
     });
     for (const projectRoot of ['.', 'project', 'workspace/project']) {
       assertInvalidRequest('skill.catalog.query', {
         kind: 'start',
-        context: { projectRoot },
+        context: { workspace: { kind: 'host_path', path: projectRoot } },
         view: 'governance',
       });
     }
-    for (const [projectRoot, acceptedPlatform] of [
-      ['/workspace/project', 'posix'],
-      ['C:\\workspace\\project', 'win32'],
-      ['\\\\server\\share\\project', 'win32'],
-    ] as const) {
-      const input = { kind: 'start', context: { projectRoot }, view: 'governance' };
-      if (
-        process.platform === 'win32' ? acceptedPlatform === 'win32' : acceptedPlatform === 'posix'
-      ) {
-        const frame = request('skill.catalog.query', input);
-        assert.deepEqual(decodeClientFrame(frame), frame);
-      } else {
-        assertInvalidRequest('skill.catalog.query', input);
-      }
+    for (const projectRoot of [
+      '/workspace/project',
+      'C:\\workspace\\project',
+      '\\\\server\\share\\project',
+    ]) {
+      const input = {
+        kind: 'start',
+        context: { workspace: { kind: 'host_path', path: projectRoot } },
+        view: 'governance',
+      };
+      const frame = request('skill.catalog.query', input);
+      assert.deepEqual(decodeClientFrame(frame), frame);
     }
-    if (process.platform === 'win32') {
-      for (const projectRoot of ['\\workspace\\project', 'C:workspace\\project']) {
-        assertInvalidRequest('skill.catalog.query', {
-          kind: 'start',
-          context: { projectRoot },
-          view: 'governance',
-        });
-      }
+    for (const projectRoot of ['\\workspace\\project', 'C:workspace\\project']) {
+      assertInvalidRequest('skill.catalog.query', {
+        kind: 'start',
+        context: { workspace: { kind: 'host_path', path: projectRoot } },
+        view: 'governance',
+      });
     }
     assertInvalidRequest('skill.catalog.query', {
       kind: 'continue',
@@ -352,11 +373,13 @@ describe('Runtime Host Skill catalog protocol', () => {
         homeDirectory,
         managedSourcesRoot,
       });
-      const result = await repository.query({
-        kind: 'start',
-        context: { projectRoot },
-        view: 'bundled',
-      });
+      const result = await repository.query(
+        {
+          kind: 'start',
+          view: 'bundled',
+        },
+        { projectRoot },
+      );
       assert.equal(result.kind, 'page');
       if (result.kind !== 'page') return;
 

--- a/packages/runtime-host/src/__tests__/skill-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-protocol.test.ts
@@ -28,6 +28,10 @@ const CONTEXT = {
     path: process.platform === 'win32' ? 'C:\\workspace\\project' : '/workspace/project',
   },
 };
+const RESOLVED_WORKSPACE = {
+  target: CONTEXT.workspace,
+  hostCwd: CONTEXT.workspace.path,
+};
 
 type IsAssignable<From, To> = [From] extends [To] ? true : false;
 type AssertFalse<Value extends false> = Value;
@@ -117,7 +121,7 @@ describe('Runtime Host Skill catalog protocol', () => {
         context: { workspace: { kind: 'project', projectId: 'project-1' } },
         view: 'governance',
       }),
-      false,
+      true,
     );
     assert.equal(
       SKILL_CATALOG_OPERATION_SPECS['skill.catalog.query'].usesHostPaths?.({
@@ -200,9 +204,17 @@ describe('Runtime Host Skill catalog protocol', () => {
 
   test('decodes start and continuation queries with bounded workspace context', () => {
     for (const input of [
-      { kind: 'start', context: CONTEXT, view: 'governance' },
+      {
+        kind: 'start',
+        context: CONTEXT,
+        view: 'governance',
+      },
       { kind: 'start', context: CONTEXT, view: 'bundled' },
-      { kind: 'start', context: CONTEXT, view: 'managed_sources' },
+      {
+        kind: 'start',
+        context: CONTEXT,
+        view: 'managed_sources',
+      },
       {
         kind: 'continue',
         context: CONTEXT,
@@ -393,7 +405,13 @@ describe('Runtime Host Skill catalog protocol', () => {
         true,
       );
 
-      const frame = response('skill.catalog.query', result);
+      const frame = response('skill.catalog.query', {
+        ...result,
+        resolvedWorkspace: {
+          target: { kind: 'host_path', path: projectRoot },
+          hostCwd: projectRoot,
+        },
+      });
       assert.deepEqual(decodeHostFrame(frame), frame);
     } finally {
       await rm(base, { recursive: true, force: true });
@@ -523,15 +541,26 @@ describe('Runtime Host Skill catalog protocol', () => {
 
   test('decodes mutation outcomes, revision conflicts, and typed rejections', () => {
     for (const result of [
-      { kind: 'committed', revision: NEXT_REVISION, entry: governanceItem() },
-      { kind: 'unchanged', revision: REVISION, entry: null },
+      {
+        kind: 'committed',
+        revision: NEXT_REVISION,
+        entry: governanceItem(),
+        resolvedWorkspace: RESOLVED_WORKSPACE,
+      },
+      {
+        kind: 'unchanged',
+        revision: REVISION,
+        entry: null,
+        resolvedWorkspace: RESOLVED_WORKSPACE,
+      },
       {
         kind: 'revision_conflict',
         expectedRevision: REVISION,
         actualRevision: NEXT_REVISION,
+        resolvedWorkspace: RESOLVED_WORKSPACE,
       },
-      { kind: 'rejected', reason: 'blocked_scope' },
-      { kind: 'rejected', reason: 'metadata_error' },
+      { kind: 'rejected', reason: 'blocked_scope', resolvedWorkspace: RESOLVED_WORKSPACE },
+      { kind: 'rejected', reason: 'metadata_error', resolvedWorkspace: RESOLVED_WORKSPACE },
     ]) {
       const frame = response('skill.catalog.mutate', result);
       assert.deepEqual(decodeHostFrame(frame), frame);
@@ -562,6 +591,7 @@ describe('Runtime Host Skill catalog protocol', () => {
       },
       expectedCurrentSha256: REVISION,
       expectedSourceSha256: NEXT_REVISION,
+      resolvedWorkspace: RESOLVED_WORKSPACE,
     };
     const requestFrame = request('skill.catalog.preview-update', {
       context: CONTEXT,
@@ -574,6 +604,7 @@ describe('Runtime Host Skill catalog protocol', () => {
     const metadataErrorFrame = response('skill.catalog.preview-update', {
       kind: 'rejected',
       reason: 'metadata_error',
+      resolvedWorkspace: RESOLVED_WORKSPACE,
     });
     assert.deepEqual(decodeHostFrame(metadataErrorFrame), metadataErrorFrame);
 
@@ -670,6 +701,7 @@ function page(view: 'governance' | 'bundled' | 'managed_sources', items: readonl
     revision: REVISION,
     items,
     nextCursor: null,
+    resolvedWorkspace: RESOLVED_WORKSPACE,
   };
 }
 

--- a/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
@@ -22,6 +22,7 @@ import type {
 import {
   SkillCatalogRepository,
   SkillCatalogRepositoryError,
+  type SkillCatalogLocalContext,
   type SkillCatalogRepositoryOptions,
 } from '../server/skill-catalog-repository.js';
 import {
@@ -94,7 +95,6 @@ test('continuation pages are pinned to a freshly scanned revision', async () => 
   );
   const continued = await repository.query({
     kind: 'continue',
-    context: { projectRoot: fixture.project },
     view: 'governance',
     revision: first.revision,
     cursor: first.nextCursor,
@@ -125,7 +125,6 @@ test('continuation rejects a cursor at the exact end of the current view', async
   await assert.rejects(
     repository.query({
       kind: 'continue',
-      context: { projectRoot: fixture.project },
       view: 'governance',
       revision: page.revision,
       cursor: endCursor,
@@ -200,7 +199,6 @@ test('bounds oversized metadata with an explicit diagnostic and encodable mutati
   }
 
   const committed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'install', sourceType: 'managed', sourceId },
   });
@@ -235,7 +233,6 @@ test('external project sources are read-only while Data Root preferences use dur
   const external = governanceItem(first, 'project:agents:external');
 
   const rejected = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: first.revision,
     mutation: { kind: 'delete', ref: external.ref },
   });
@@ -243,7 +240,6 @@ test('external project sources are read-only while Data Root preferences use dur
   assert.match(await readFile(join(skillPath, 'SKILL.md'), 'utf8'), /External/);
 
   const committed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: first.revision,
     mutation: { kind: 'set_enabled', ref: external.ref, enabled: false },
   });
@@ -284,7 +280,6 @@ test('v1 snapshots use effective migration facts and same-value mutations persis
   await writeFile(statePath, v1);
   const migrationPage = await start(repository, fixture.project, 'governance');
   const migrated = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: migrationPage.revision,
     mutation: { kind: 'set_enabled', ref: 'project:maka:external', enabled: false },
   });
@@ -360,7 +355,6 @@ test('v1 case-only duplicates share legacy defaults and clear review through exp
   assert.equal(initialModel.inventory.find((skill) => skill.id === 'shared')?.enabled, false);
 
   const first = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'set_enabled', ref: projectSkill.ref, enabled: false },
   });
@@ -369,7 +363,6 @@ test('v1 case-only duplicates share legacy defaults and clear review through exp
   assert.equal(first.entry?.needsReview, true);
 
   const second = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: first.revision,
     mutation: { kind: 'set_enabled', ref: workspaceSkill.ref, enabled: false },
   });
@@ -406,7 +399,6 @@ test('a zero-match v1 preference persisted by Host enters review on future case-
   const repository = fixture.repository();
   const initial = await start(repository, fixture.project, 'governance');
   const persisted = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'set_pinned', ref: 'project:maka:anchor', pinned: true },
   });
@@ -470,7 +462,6 @@ test('noncanonical external ids remain wire-safe governance entries', async () =
 
   assert.deepEqual(
     await repository.mutate({
-      context: { projectRoot: fixture.project },
       expectedRevision: page.revision,
       mutation: { kind: 'set_enabled', ref: control.ref, enabled: false },
     }),
@@ -492,7 +483,6 @@ test('noncanonical external ids remain wire-safe governance entries', async () =
   );
 
   const disabled = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: page.revision,
     mutation: {
       kind: 'set_enabled',
@@ -553,7 +543,6 @@ test('repository preserves filesystem-safe ids and codec preserves the 256-byte 
   );
 
   const committed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: page.revision,
     mutation: { kind: 'set_enabled', ref: filesystemRef, enabled: false },
   });
@@ -623,7 +612,6 @@ test('starter creation uses the shared template and reuses the lowest valid star
   const repository = fixture.repository();
   const initial = await start(repository, fixture.project, 'governance');
   const created = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'create_starter' },
   });
@@ -636,7 +624,6 @@ test('starter creation uses the shared template and reuses the lowest valid star
   );
 
   const repeated = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: created.revision,
     mutation: { kind: 'create_starter' },
   });
@@ -652,7 +639,6 @@ test('invalid starter ids remain occupied when selecting the lowest available or
   const repository = fixture.repository();
   const initial = await start(repository, fixture.project, 'governance');
   const created = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'create_starter' },
   });
@@ -673,7 +659,6 @@ test('empty publication targets occupy starter ids and participate in revision',
   const occupied = await start(repository, fixture.project, 'governance');
 
   const created = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: occupied.revision,
     mutation: { kind: 'create_starter' },
   });
@@ -703,14 +688,12 @@ test('root-owned rejected and empty placeholders can be deleted and reinstalled'
   assert.equal(empty.manageable, true);
 
   const deletedRejected = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'delete', ref: rejected.ref },
   });
   assert.equal(deletedRejected.kind, 'committed');
   if (deletedRejected.kind !== 'committed') return;
   const deletedEmpty = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: deletedRejected.revision,
     mutation: { kind: 'delete', ref: empty.ref },
   });
@@ -718,7 +701,6 @@ test('root-owned rejected and empty placeholders can be deleted and reinstalled'
   if (deletedEmpty.kind !== 'committed') return;
 
   const installed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: deletedEmpty.revision,
     mutation: { kind: 'install', sourceType: 'bundled', sourceId: source.id },
   });
@@ -743,7 +725,6 @@ test('delete revision covers nested references, scripts, assets, and empty direc
 
   await writeFile(join(directory, 'assets', 'added.txt'), 'added\n');
   const addedConflict = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: snapshot.revision,
     mutation: { kind: 'delete', ref: 'workspace:legacy:tree-skill' },
   });
@@ -753,7 +734,6 @@ test('delete revision covers nested references, scripts, assets, and empty direc
   const changedSnapshot = await start(repository, fixture.project, 'governance');
   await writeFile(join(directory, 'scripts', 'run.sh'), 'echo changed\n');
   const changedConflict = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: changedSnapshot.revision,
     mutation: { kind: 'delete', ref: 'workspace:legacy:tree-skill' },
   });
@@ -763,7 +743,6 @@ test('delete revision covers nested references, scripts, assets, and empty direc
   const referenceSnapshot = await start(repository, fixture.project, 'governance');
   await writeFile(join(directory, 'references', 'notes.txt'), 'changed\n');
   const referenceConflict = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: referenceSnapshot.revision,
     mutation: { kind: 'delete', ref: 'workspace:legacy:tree-skill' },
   });
@@ -786,7 +765,6 @@ test('starter creation reuses the lowest ordinal valid Data Root starter', async
   const repository = fixture.repository();
   const initial = await start(repository, fixture.project, 'governance');
   const result = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'create_starter' },
   });
@@ -808,7 +786,6 @@ test('managed preview is bounded and hash-bound, then a force update commits the
 
   const initial = await start(repository, fixture.project, 'managed_sources');
   const installed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'install', sourceType: 'managed', sourceId },
   });
@@ -820,7 +797,6 @@ test('managed preview is bounded and hash-bound, then a force update commits the
   await writeFile(installedPath, localContent);
   const modified = await start(repository, fixture.project, 'governance');
   const preview = await repository.previewUpdate({
-    context: { projectRoot: fixture.project },
     expectedRevision: modified.revision,
     ref: `workspace:legacy:${sourceId}`,
   });
@@ -836,7 +812,6 @@ test('managed preview is bounded and hash-bound, then a force update commits the
   assert.ok(Buffer.byteLength(JSON.stringify(preview), 'utf8') <= 48 * 1024);
 
   const updated = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: preview.revision,
     mutation: {
       kind: 'update_managed',
@@ -876,7 +851,6 @@ test('Host previews, updates, and recovers the canonical Desktop managed-install
   });
   const snapshot = await start(repository, fixture.project, 'governance');
   const preview = await repository.previewUpdate({
-    context: { projectRoot: fixture.project },
     expectedRevision: snapshot.revision,
     ref: `workspace:legacy:${sourceId}`,
   });
@@ -884,7 +858,6 @@ test('Host previews, updates, and recovers the canonical Desktop managed-install
 
   await assert.rejects(
     repository.mutate({
-      context: { projectRoot: fixture.project },
       expectedRevision: snapshot.revision,
       mutation: {
         kind: 'update_managed',
@@ -927,7 +900,6 @@ test('managed install and update reject source changes after their revision snap
   const initial = await start(repository, fixture.project, 'managed_sources');
   replacement = versionTwo;
   const racedInstall = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'install', sourceType: 'managed', sourceId },
   });
@@ -938,7 +910,6 @@ test('managed install and update reject source changes after their revision snap
 
   const versionTwoSnapshot = await start(repository, fixture.project, 'managed_sources');
   const installed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: versionTwoSnapshot.revision,
     mutation: { kind: 'install', sourceType: 'managed', sourceId },
   });
@@ -950,7 +921,6 @@ test('managed install and update reject source changes after their revision snap
   const versionThreeSnapshot = await start(repository, fixture.project, 'governance');
   replacement = versionFour;
   const racedUpdate = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: versionThreeSnapshot.revision,
     mutation: {
       kind: 'update_managed',
@@ -978,7 +948,6 @@ test('managed install and update reject malformed UTF-8 sources before writing',
   const malformedInstallSnapshot = await start(repository, fixture.project, 'managed_sources');
   assert.deepEqual(
     await repository.mutate({
-      context: { projectRoot: fixture.project },
       expectedRevision: malformedInstallSnapshot.revision,
       mutation: { kind: 'install', sourceType: 'managed', sourceId },
     }),
@@ -989,7 +958,6 @@ test('managed install and update reject malformed UTF-8 sources before writing',
   await writeFile(sourcePath, versionOne);
   const validSnapshot = await start(repository, fixture.project, 'managed_sources');
   const installed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: validSnapshot.revision,
     mutation: { kind: 'install', sourceType: 'managed', sourceId },
   });
@@ -999,7 +967,6 @@ test('managed install and update reject malformed UTF-8 sources before writing',
   const malformedUpdateSnapshot = await start(repository, fixture.project, 'governance');
   assert.deepEqual(
     await repository.mutate({
-      context: { projectRoot: fixture.project },
       expectedRevision: malformedUpdateSnapshot.revision,
       mutation: {
         kind: 'update_managed',
@@ -1033,7 +1000,6 @@ test('non-force managed update preserves a local edit made after its snapshot', 
   });
   const initial = await start(repository, fixture.project, 'managed_sources');
   const installed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'install', sourceType: 'managed', sourceId },
   });
@@ -1043,7 +1009,6 @@ test('non-force managed update preserves a local edit made after its snapshot', 
   const snapshot = await start(repository, fixture.project, 'governance');
   editBeforeRead = true;
   const result = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: snapshot.revision,
     mutation: {
       kind: 'update_managed',
@@ -1077,7 +1042,6 @@ test('revision covers exact managed lock and baseline bytes and rejects post-sna
   });
   const initial = await start(repository, fixture.project, 'managed_sources');
   const installed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'install', sourceType: 'managed', sourceId },
   });
@@ -1103,7 +1067,6 @@ test('revision covers exact managed lock and baseline bytes and rejects post-sna
   const updateSnapshot = await start(repository, fixture.project, 'governance');
   editBaselineBeforeRead = true;
   const raced = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: updateSnapshot.revision,
     mutation: {
       kind: 'update_managed',
@@ -1130,7 +1093,6 @@ test('malformed installed artifacts retain raw revision hashes but cannot enter 
   const repository = fixture.repository();
   const initial = await start(repository, fixture.project, 'managed_sources');
   const installed = await repository.mutate({
-    context: { projectRoot: fixture.project },
     expectedRevision: initial.revision,
     mutation: { kind: 'install', sourceType: 'managed', sourceId },
   });
@@ -1156,14 +1118,12 @@ test('malformed installed artifacts retain raw revision hashes but cannot enter 
   await writeFile(installedPath, currentA);
   const skillA = await start(repository, fixture.project, 'governance');
   const previewA = await repository.previewUpdate({
-    context: { projectRoot: fixture.project },
     expectedRevision: skillA.revision,
     ref: `workspace:legacy:${sourceId}`,
   });
   assert.deepEqual(previewA, { kind: 'rejected', reason: 'metadata_error' });
   assert.deepEqual(
     await repository.mutate({
-      context: { projectRoot: fixture.project },
       expectedRevision: skillA.revision,
       mutation: {
         kind: 'update_managed',
@@ -1181,7 +1141,6 @@ test('malformed installed artifacts retain raw revision hashes but cannot enter 
   await writeFile(installedPath, currentB);
   const skillB = await start(repository, fixture.project, 'governance');
   const previewB = await repository.previewUpdate({
-    context: { projectRoot: fixture.project },
     expectedRevision: skillB.revision,
     ref: `workspace:legacy:${sourceId}`,
   });
@@ -1199,7 +1158,6 @@ test('install rejects invalid and case-only workspace occupants', async () => {
   const invalidSnapshot = await start(invalidRepository, invalidFixture.project, 'bundled');
   assert.deepEqual(
     await invalidRepository.mutate({
-      context: { projectRoot: invalidFixture.project },
       expectedRevision: invalidSnapshot.revision,
       mutation: { kind: 'install', sourceType: 'bundled', sourceId: source.id },
     }),
@@ -1212,7 +1170,6 @@ test('install rejects invalid and case-only workspace occupants', async () => {
   const emptySnapshot = await start(emptyRepository, emptyFixture.project, 'bundled');
   assert.deepEqual(
     await emptyRepository.mutate({
-      context: { projectRoot: emptyFixture.project },
       expectedRevision: emptySnapshot.revision,
       mutation: { kind: 'install', sourceType: 'bundled', sourceId: source.id },
     }),
@@ -1233,7 +1190,6 @@ test('install rejects invalid and case-only workspace occupants', async () => {
   assert.equal(caseProjection?.kind === 'bundled' && caseProjection.installed, true);
   assert.deepEqual(
     await caseRepository.mutate({
-      context: { projectRoot: caseFixture.project },
       expectedRevision: caseSnapshot.revision,
       mutation: { kind: 'install', sourceType: 'bundled', sourceId: source.id },
     }),
@@ -1291,7 +1247,6 @@ test('durable transaction uncertainty is not reported as success and the next sc
 
   await assert.rejects(
     repository.mutate({
-      context: { projectRoot: fixture.project },
       expectedRevision: initial.revision,
       mutation: { kind: 'install', sourceType: 'bundled', sourceId: source.id },
     }),
@@ -1319,7 +1274,37 @@ interface Fixture {
   repository(
     transactionOptions?: SkillCatalogTransactionOptions,
     testHooks?: SkillCatalogRepositoryOptions['testHooks'],
-  ): SkillCatalogRepository;
+  ): TestSkillCatalogRepository;
+}
+
+class TestSkillCatalogRepository extends SkillCatalogRepository {
+  constructor(
+    options: SkillCatalogRepositoryOptions,
+    private readonly context: SkillCatalogLocalContext,
+  ) {
+    super(options);
+  }
+
+  override query(
+    input: Parameters<SkillCatalogRepository['query']>[0],
+    context?: SkillCatalogLocalContext,
+  ) {
+    return super.query(input, context ?? this.context);
+  }
+
+  override mutate(
+    input: Parameters<SkillCatalogRepository['mutate']>[0],
+    context?: SkillCatalogLocalContext,
+  ) {
+    return super.mutate(input, context ?? this.context);
+  }
+
+  override previewUpdate(
+    input: Parameters<SkillCatalogRepository['previewUpdate']>[0],
+    context?: SkillCatalogLocalContext,
+  ) {
+    return super.previewUpdate(input, context ?? this.context);
+  }
 }
 
 async function createFixture(): Promise<Fixture> {
@@ -1341,13 +1326,16 @@ async function createFixture(): Promise<Fixture> {
     home,
     sources,
     repository(transactionOptions, testHooks) {
-      return new SkillCatalogRepository({
-        runWithRoot,
-        homeDirectory: home,
-        managedSourcesRoot: sources,
-        ...(transactionOptions ? { transactionOptions } : {}),
-        ...(testHooks ? { testHooks } : {}),
-      });
+      return new TestSkillCatalogRepository(
+        {
+          runWithRoot,
+          homeDirectory: home,
+          managedSourcesRoot: sources,
+          ...(transactionOptions ? { transactionOptions } : {}),
+          ...(testHooks ? { testHooks } : {}),
+        },
+        { projectRoot: project },
+      );
     },
   };
 }
@@ -1408,11 +1396,17 @@ function stateFile(ref: string, enabled: boolean, pinned: boolean, updatedAt: st
 }
 
 async function start(
-  repository: SkillCatalogRepository,
+  repository: TestSkillCatalogRepository,
   projectRoot: string,
   view: 'governance' | 'bundled' | 'managed_sources',
 ): Promise<Extract<SkillCatalogQueryResult, { kind: 'page' }>> {
-  const result = await repository.query({ kind: 'start', context: { projectRoot }, view });
+  const result = await repository.query(
+    {
+      kind: 'start',
+      view,
+    },
+    { projectRoot },
+  );
   assert.equal(result.kind, 'page');
   return result as Extract<SkillCatalogQueryResult, { kind: 'page' }>;
 }

--- a/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
@@ -212,7 +212,7 @@ test('bounds oversized metadata with an explicit diagnostic and encodable mutati
     requestId: 'metadata-projection',
     operation: 'skill.catalog.mutate' as const,
     ok: true as const,
-    result: committed,
+    result: { ...committed, resolvedWorkspace: workspaceProjection(fixture.project) },
   };
   assert.deepEqual(decodeHostFrame(frame), frame);
 
@@ -456,7 +456,7 @@ test('noncanonical external ids remain wire-safe governance entries', async () =
     requestId: 'noncanonical-external-id',
     operation: 'skill.catalog.query' as const,
     ok: true as const,
-    result: page,
+    result: { ...page, resolvedWorkspace: workspaceProjection(fixture.project) },
   };
   assert.deepEqual(decodeHostFrame(frame), frame);
 
@@ -521,6 +521,7 @@ test('repository preserves filesystem-safe ids and codec preserves the 256-byte 
   const boundaryPage = {
     ...page,
     items: [{ ...filesystemItem, id: boundaryId }],
+    resolvedWorkspace: workspaceProjection(fixture.project),
   };
   const queryFrame = {
     requestId: 'display-id-boundary-query',
@@ -553,7 +554,7 @@ test('repository preserves filesystem-safe ids and codec preserves the 256-byte 
     requestId: 'display-id-boundary-mutation',
     operation: 'skill.catalog.mutate' as const,
     ok: true as const,
-    result: committed,
+    result: { ...committed, resolvedWorkspace: workspaceProjection(fixture.project) },
   };
   assert.deepEqual(decodeHostFrame(mutationFrame), mutationFrame);
 
@@ -1393,6 +1394,13 @@ function stateFile(ref: string, enabled: boolean, pinned: boolean, updatedAt: st
     schemaVersion: 2,
     skills: { [ref]: { enabled, pinned, updatedAt } },
   })}\n`;
+}
+
+function workspaceProjection(projectRoot: string) {
+  return {
+    target: { kind: 'host_path' as const, path: projectRoot },
+    hostCwd: projectRoot,
+  };
 }
 
 async function start(

--- a/packages/runtime-host/src/__tests__/skill-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-two-client-uds.test.ts
@@ -1,7 +1,7 @@
 import { defineInteractiveRuntimeHostComposition } from '../server/host-composition.js';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { lstat, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { isAbsolute, join } from 'node:path';
 import { test } from 'node:test';
@@ -92,13 +92,22 @@ Keep ${privateMarker} inside the lazy-loaded body.
     const desktopPage = requirePage(desktopInitial);
     const tuiPage = requirePage(tuiInitial);
     assert.equal(desktopPage.revision, tuiPage.revision);
+    const canonicalProjectRoot = await realpath(projectRoot);
+    const expectedWorkspace = {
+      target: { kind: 'host_path' as const, path: canonicalProjectRoot },
+      hostCwd: canonicalProjectRoot,
+    };
+    assert.deepEqual(desktopPage.resolvedWorkspace, expectedWorkspace);
+    assert.deepEqual(tuiPage.resolvedWorkspace, expectedWorkspace);
     assert.ok(
       desktopPage.items.some(
         (item) => item.kind === 'skill' && item.ref === 'project:maka:private-project-skill',
       ),
     );
 
-    const wireJson = JSON.stringify([desktopInitial, tuiInitial]);
+    const { resolvedWorkspace: _desktopWorkspace, ...desktopMetadata } = desktopPage;
+    const { resolvedWorkspace: _tuiWorkspace, ...tuiMetadata } = tuiPage;
+    const wireJson = JSON.stringify([desktopMetadata, tuiMetadata]);
     for (const value of nestedStrings(JSON.parse(wireJson))) {
       assert.equal(isAbsolute(value), false, `wire projection leaked absolute path ${value}`);
     }
@@ -161,7 +170,11 @@ Keep ${privateMarker} inside the lazy-loaded body.
       },
       REQUEST_TIMEOUT_MS,
     );
-    assert.deepEqual(blockedDelete, { kind: 'rejected', reason: 'blocked_scope' });
+    assert.deepEqual(blockedDelete, {
+      kind: 'rejected',
+      reason: 'blocked_scope',
+      resolvedWorkspace: expectedWorkspace,
+    });
     assert.equal(await readFile(skillPath, 'utf8'), projectSkillBeforeDelete);
   } finally {
     const cleanupErrors: unknown[] = [];

--- a/packages/runtime-host/src/__tests__/skill-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-two-client-uds.test.ts
@@ -82,7 +82,7 @@ Keep ${privateMarker} inside the lazy-loaded body.
 
     const query = {
       kind: 'start',
-      context: { projectRoot },
+      context: { workspace: { kind: 'host_path', path: projectRoot } },
       view: 'governance',
     } as const;
     const [desktopInitial, tuiInitial] = await Promise.all([
@@ -116,7 +116,7 @@ Keep ${privateMarker} inside the lazy-loaded body.
 
     const expectedRevision = desktopPage.revision;
     const mutation = {
-      context: { projectRoot },
+      context: { workspace: { kind: 'host_path', path: projectRoot } },
       expectedRevision,
       mutation: { kind: 'create_starter' },
     } as const;
@@ -155,7 +155,7 @@ Keep ${privateMarker} inside the lazy-loaded body.
     const blockedDelete = await desktop.request(
       'skill.catalog.mutate',
       {
-        context: { projectRoot },
+        context: { workspace: { kind: 'host_path', path: projectRoot } },
         expectedRevision: finalPage.revision,
         mutation: { kind: 'delete', ref: 'project:maka:private-project-skill' },
       },

--- a/packages/runtime-host/src/client/catalog-reader.ts
+++ b/packages/runtime-host/src/client/catalog-reader.ts
@@ -7,7 +7,7 @@ import {
   type RelayModelProfiles,
   type SessionCatalogFilter,
   type SessionCatalogItem,
-  type SkillCatalogLocalContext,
+  type SkillCatalogWorkspaceContext,
   type SkillCatalogInvocableItem,
   type SkillCatalogInvocableTarget,
   type SkillCatalogPageItem,
@@ -82,7 +82,7 @@ export async function readRuntimeHostConnectionCatalog(
 
 export async function readRuntimeHostSkillCatalog(
   connection: RuntimeHostCatalogConnection,
-  context: SkillCatalogLocalContext,
+  context: SkillCatalogWorkspaceContext,
   view: SkillCatalogView,
 ): Promise<RuntimeHostSkillCatalogSnapshot> {
   const { first, pages } = await collectStablePages(
@@ -276,7 +276,6 @@ function assembleProjectCatalog(
     {
       header: Extract<ProjectCatalogPageItem, { kind: 'project' }>;
       aliases: Map<number, string>;
-      locations: Map<number, ProjectCatalogProject['locations'][number]>;
     }
   >();
   for (const item of items) {
@@ -284,38 +283,33 @@ function assembleProjectCatalog(
     if (projects.has(item.projectIndex)) {
       throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
     }
-    projects.set(item.projectIndex, { header: item, aliases: new Map(), locations: new Map() });
+    projects.set(item.projectIndex, { header: item, aliases: new Map() });
   }
   for (const item of items) {
     if (item.kind === 'project') continue;
     const project = projects.get(item.projectIndex);
     if (!project) throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
-    const values = item.kind === 'alias' ? project.aliases : project.locations;
-    const expectedCount =
-      item.kind === 'alias' ? project.header.aliasCount : project.header.locationCount;
-    if (item.itemIndex >= expectedCount || values.has(item.itemIndex)) {
+    if (item.itemIndex >= project.header.aliasCount || project.aliases.has(item.itemIndex)) {
       throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
     }
-    if (item.kind === 'alias') project.aliases.set(item.itemIndex, item.alias);
-    else project.locations.set(item.itemIndex, item.location);
+    project.aliases.set(item.itemIndex, item.alias);
   }
   if (projects.size !== first.projectCount) {
     throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
   }
   return [...projects.entries()]
     .sort(([left], [right]) => left - right)
-    .map(([, { header, aliases, locations }]) => {
-      if (aliases.size !== header.aliasCount || locations.size !== header.locationCount) {
+    .map(([, { header, aliases }]) => {
+      if (aliases.size !== header.aliasCount) {
         throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
       }
       return decodeProjectCatalogProject({
         id: header.id,
         aliases: orderedValues(aliases),
         name: header.name,
-        locations: orderedValues(locations),
+        locationCount: header.locationCount,
         archivedAt: header.archivedAt,
         available: header.available,
-        preferredPath: header.preferredPath,
       });
     });
 }

--- a/packages/runtime-host/src/client/catalog-reader.ts
+++ b/packages/runtime-host/src/client/catalog-reader.ts
@@ -14,6 +14,7 @@ import {
   type SkillCatalogPageItem,
   type SkillCatalogRevision,
   type SkillCatalogView,
+  type WorkspaceProjection,
   type OperationOutput,
   type ProjectCatalogPageItem,
   type ProjectCatalogProject,
@@ -32,6 +33,7 @@ export interface RuntimeHostSkillCatalogSnapshot {
   readonly revision: SkillCatalogRevision;
   readonly view: SkillCatalogView;
   readonly items: readonly SkillCatalogPageItem[];
+  readonly resolvedWorkspace: WorkspaceProjection;
 }
 
 export type RuntimeHostConnectionCatalogEntry = Omit<
@@ -88,6 +90,7 @@ export async function readRuntimeHostSkillCatalog(
   context: SkillCatalogWorkspaceContext,
   view: SkillCatalogView,
 ): Promise<RuntimeHostSkillCatalogSnapshot> {
+  let resolvedWorkspace: WorkspaceProjection | undefined;
   const { first, pages } = await collectStablePages(
     'skill',
     async () => {
@@ -96,7 +99,9 @@ export async function readRuntimeHostSkillCatalog(
         context,
         view,
       });
-      return result.kind === 'page' && result.view === view ? result : null;
+      if (result.kind !== 'page' || result.view !== view) return null;
+      resolvedWorkspace = result.resolvedWorkspace;
+      return result;
     },
     async (revision, cursor) => {
       const result = await connection.request('skill.catalog.query', {
@@ -106,10 +111,30 @@ export async function readRuntimeHostSkillCatalog(
         revision,
         cursor,
       });
-      return result.kind === 'page' && result.view === view ? result : null;
+      return result.kind === 'page' &&
+        result.view === view &&
+        workspaceProjectionsEqual(result.resolvedWorkspace, resolvedWorkspace)
+        ? result
+        : null;
     },
   );
-  return { revision: first.revision, view, items: pages.flatMap((page) => page.items) };
+  return {
+    revision: first.revision,
+    view,
+    items: pages.flatMap((page) => page.items),
+    resolvedWorkspace: first.resolvedWorkspace,
+  };
+}
+
+function workspaceProjectionsEqual(
+  left: WorkspaceProjection,
+  right: WorkspaceProjection | undefined,
+): boolean {
+  if (!right) return false;
+  if (left.hostCwd !== right.hostCwd || left.target.kind !== right.target.kind) return false;
+  return left.target.kind === 'project'
+    ? right.target.kind === 'project' && left.target.projectId === right.target.projectId
+    : right.target.kind === 'host_path' && left.target.path === right.target.path;
 }
 
 export async function readRuntimeHostInvocableSkills(

--- a/packages/runtime-host/src/client/catalog-reader.ts
+++ b/packages/runtime-host/src/client/catalog-reader.ts
@@ -1,5 +1,6 @@
 import {
   decodeProjectCatalogProject,
+  decodeProjectCatalogProjectDetails,
   type ConnectionCatalogCursor,
   type ConnectionCatalogPageItem,
   type ConnectionCatalogQueryResult,
@@ -16,7 +17,9 @@ import {
   type OperationOutput,
   type ProjectCatalogPageItem,
   type ProjectCatalogProject,
+  type ProjectCatalogProjectDetails,
   type ProjectCatalogQueryResult,
+  type ProjectCatalogView,
 } from '../protocol/index.js';
 import type { RuntimeHostConnection } from './connection.js';
 
@@ -164,19 +167,44 @@ export async function readRuntimeHostSessions(
 export async function readRuntimeHostProjects(
   connection: RuntimeHostCatalogConnection,
 ): Promise<ProjectCatalogProject[]> {
+  return readRuntimeHostProjectCatalog(connection, 'summary');
+}
+
+export async function readRuntimeHostProjectDetails(
+  connection: RuntimeHostCatalogConnection,
+): Promise<ProjectCatalogProjectDetails[]> {
+  return readRuntimeHostProjectCatalog(connection, 'locations');
+}
+
+function readRuntimeHostProjectCatalog(
+  connection: RuntimeHostCatalogConnection,
+  view: 'summary',
+): Promise<ProjectCatalogProject[]>;
+function readRuntimeHostProjectCatalog(
+  connection: RuntimeHostCatalogConnection,
+  view: 'locations',
+): Promise<ProjectCatalogProjectDetails[]>;
+async function readRuntimeHostProjectCatalog(
+  connection: RuntimeHostCatalogConnection,
+  view: ProjectCatalogView,
+): Promise<ProjectCatalogProject[] | ProjectCatalogProjectDetails[]> {
   const { first, pages } = await collectStablePages(
     'project',
     async () => {
-      const result = await connection.request('project.catalog.query', { kind: 'list_start' });
-      return result.kind === 'page' ? result : null;
+      const result = await connection.request('project.catalog.query', {
+        kind: 'list_start',
+        view,
+      });
+      return result.kind === 'page' && result.view === view ? result : null;
     },
     async (revision, cursor) => {
       const result = await connection.request('project.catalog.query', {
         kind: 'list_continue',
+        view,
         revision,
         cursor,
       });
-      return result.kind === 'page' ? result : null;
+      return result.kind === 'page' && result.view === view ? result : null;
     },
   );
   return assembleProjectCatalog(
@@ -276,6 +304,7 @@ function assembleProjectCatalog(
     {
       header: Extract<ProjectCatalogPageItem, { kind: 'project' }>;
       aliases: Map<number, string>;
+      locations: Map<number, Extract<ProjectCatalogPageItem, { kind: 'location' }>['location']>;
     }
   >();
   for (const item of items) {
@@ -283,33 +312,64 @@ function assembleProjectCatalog(
     if (projects.has(item.projectIndex)) {
       throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
     }
-    projects.set(item.projectIndex, { header: item, aliases: new Map() });
+    projects.set(item.projectIndex, { header: item, aliases: new Map(), locations: new Map() });
   }
   for (const item of items) {
     if (item.kind === 'project') continue;
     const project = projects.get(item.projectIndex);
     if (!project) throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
-    if (item.itemIndex >= project.header.aliasCount || project.aliases.has(item.itemIndex)) {
+    const values = item.kind === 'alias' ? project.aliases : project.locations;
+    const expectedCount =
+      item.kind === 'alias' ? project.header.aliasCount : project.header.locationCount;
+    if (item.itemIndex >= expectedCount || values.has(item.itemIndex)) {
       throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
     }
-    project.aliases.set(item.itemIndex, item.alias);
+    if (item.kind === 'alias') project.aliases.set(item.itemIndex, item.alias);
+    else project.locations.set(item.itemIndex, item.location);
   }
   if (projects.size !== first.projectCount) {
     throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
   }
   return [...projects.entries()]
     .sort(([left], [right]) => left - right)
-    .map(([, { header, aliases }]) => {
-      if (aliases.size !== header.aliasCount) {
+    .map(([, { header, aliases, locations }]) => {
+      if (
+        aliases.size !== header.aliasCount ||
+        header.available !== (header.preferredLocationIndex !== null) ||
+        (header.preferredLocationIndex !== null &&
+          header.preferredLocationIndex >= header.locationCount)
+      ) {
         throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
       }
-      return decodeProjectCatalogProject({
+      const project = decodeProjectCatalogProject({
         id: header.id,
         aliases: orderedValues(aliases),
         name: header.name,
         locationCount: header.locationCount,
         archivedAt: header.archivedAt,
         available: header.available,
+      });
+      if (first.view === 'summary') {
+        if (locations.size !== 0) {
+          throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
+        }
+        return project;
+      }
+      if (locations.size !== header.locationCount) {
+        throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
+      }
+      const orderedLocations = orderedValues(locations);
+      const preferredPath =
+        header.preferredLocationIndex === null
+          ? null
+          : orderedLocations[header.preferredLocationIndex]?.path;
+      if (preferredPath === undefined) {
+        throw new RuntimeHostCatalogReadError('project', 'invalid_projection');
+      }
+      return decodeProjectCatalogProjectDetails({
+        ...project,
+        locations: orderedLocations,
+        preferredPath,
       });
     });
 }

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -56,7 +56,7 @@ import {
   type SessionCatalogChangedFrame,
   type SubscriptionFrame,
   type SubscriptionOpenInput,
-  type SessionCwdRelocateInput,
+  type SessionWorkspaceRelocateInput,
   type SessionRecapGenerateInput,
   type SessionRecapGenerateResult,
   type SessionUpdateResult,
@@ -214,8 +214,8 @@ export interface RuntimeHostConnection {
     timeoutMs?: number,
   ): Promise<ContextDiagnosticsResult>;
   compactContext(input: ContextCompactInput, timeoutMs?: number): Promise<ContextCompactResult>;
-  relocateSessionCwd(
-    input: SessionCwdRelocateInput,
+  relocateSessionWorkspace(
+    input: SessionWorkspaceRelocateInput,
     timeoutMs?: number,
   ): Promise<SessionUpdateResult>;
   generateSessionRecap(
@@ -547,11 +547,11 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     return this.request('context.compact', input, timeoutMs);
   }
 
-  relocateSessionCwd(
-    input: SessionCwdRelocateInput,
+  relocateSessionWorkspace(
+    input: SessionWorkspaceRelocateInput,
     timeoutMs?: number,
   ): Promise<SessionUpdateResult> {
-    return this.request('session.cwd.relocate', input, timeoutMs);
+    return this.request('session.workspace.relocate', input, timeoutMs);
   }
 
   generateSessionRecap(

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -36,6 +36,7 @@ export {
   RuntimeHostCatalogReadError,
   readRuntimeHostConnectionCatalog,
   readRuntimeHostInvocableSkills,
+  readRuntimeHostProjectDetails,
   readRuntimeHostResources,
   readRuntimeHostProjects,
   readRuntimeHostSessions,

--- a/packages/runtime-host/src/client/reconnecting-connection.ts
+++ b/packages/runtime-host/src/client/reconnecting-connection.ts
@@ -24,7 +24,7 @@ import {
   type PlanTurnStartInput,
   type PlanTurnStartResult,
   type SessionCatalogChangedFrame,
-  type SessionCwdRelocateInput,
+  type SessionWorkspaceRelocateInput,
   type SessionRecapGenerateInput,
   type SessionRecapGenerateResult,
   type SessionUpdateResult,
@@ -203,11 +203,11 @@ class RuntimeHostReconnectingConnectionImpl implements RuntimeHostReconnectingCo
     return this.#request('context.compact', input, timeoutMs);
   }
 
-  relocateSessionCwd(
-    input: SessionCwdRelocateInput,
+  relocateSessionWorkspace(
+    input: SessionWorkspaceRelocateInput,
     timeoutMs?: number,
   ): Promise<SessionUpdateResult> {
-    return this.#request('session.cwd.relocate', input, timeoutMs);
+    return this.#request('session.workspace.relocate', input, timeoutMs);
   }
 
   generateSessionRecap(

--- a/packages/runtime-host/src/protocol/external-session.ts
+++ b/packages/runtime-host/src/protocol/external-session.ts
@@ -1,4 +1,3 @@
-import type { ExternalSessionSummary } from '@maka/core/external-session';
 import {
   requireCount,
   requireEncodedByteLimit,
@@ -10,6 +9,7 @@ import {
 import { invalidProtocolFrame } from './errors.js';
 import { defineHostPathOperation, defineOperation } from './operation-spec.js';
 import { decodeSessionCatalogItem, type SessionCatalogItem } from './session-catalog.js';
+import { decodeWorkspaceTarget, type WorkspaceTarget } from './workspace.js';
 
 export const EXTERNAL_SESSION_PAGE_MAX_ITEMS = 16;
 export const EXTERNAL_SESSION_RESULT_MAX_BYTES = 72 * 1024;
@@ -43,13 +43,22 @@ export interface ExternalSessionSourceQueryResult {
 export interface ExternalSessionCatalogQueryInput {
   readonly adapterId: string;
   readonly includeArchived?: boolean;
-  readonly cwd?: string;
+  readonly workspace?: WorkspaceTarget;
   readonly cursor?: string;
 }
 
 export interface ExternalSessionCatalogQueryResult {
-  readonly sessions: readonly ExternalSessionSummary[];
+  readonly sessions: readonly ExternalSessionCatalogItem[];
   readonly nextCursor: string | null;
+}
+
+export interface ExternalSessionCatalogItem {
+  readonly id: string;
+  readonly name: string;
+  readonly hostCwd: string;
+  readonly createdAt?: number;
+  readonly updatedAt?: number;
+  readonly archived?: boolean;
 }
 
 export interface ExternalSessionImportInput {
@@ -85,7 +94,7 @@ export const EXTERNAL_SESSION_OPERATION_SPECS = {
       decodeInput: decodeExternalSessionCatalogQueryInput,
       decodeOutput: decodeExternalSessionCatalogQueryResult,
     },
-    (input) => input.cwd !== undefined,
+    (input) => input.workspace?.kind === 'host_path',
   ),
   'external-session.import': defineOperation<
     ExternalSessionImportInput,
@@ -133,17 +142,15 @@ export function decodeExternalSessionCatalogQueryInput(
     value,
     'external Session catalog query input',
     ['adapterId'],
-    ['includeArchived', 'cwd', 'cursor'],
+    ['includeArchived', 'workspace', 'cursor'],
   );
   return {
     adapterId: adapterId(input.adapterId),
     ...(Object.hasOwn(input, 'includeArchived')
       ? { includeArchived: boolean(input.includeArchived, 'includeArchived') }
       : {}),
-    ...(Object.hasOwn(input, 'cwd')
-      ? {
-          cwd: requireUtf8String(input.cwd, 'external Session cwd', EXTERNAL_SESSION_CWD_MAX_BYTES),
-        }
+    ...(Object.hasOwn(input, 'workspace')
+      ? { workspace: decodeWorkspaceTarget(input.workspace) }
       : {}),
     ...(Object.hasOwn(input, 'cursor') ? { cursor: cursor(input.cursor) } : {}),
   };
@@ -198,11 +205,11 @@ export function decodeExternalSessionImportResult(value: unknown): ExternalSessi
   return decoded;
 }
 
-function decodeExternalSessionSummary(value: unknown): ExternalSessionSummary {
+function decodeExternalSessionSummary(value: unknown): ExternalSessionCatalogItem {
   const summary = requireShapedRecord(
     value,
     'external Session summary',
-    ['id', 'name', 'cwd'],
+    ['id', 'name', 'hostCwd'],
     ['createdAt', 'updatedAt', 'archived'],
   );
   const id = requireUtf8String(
@@ -215,9 +222,9 @@ function decodeExternalSessionSummary(value: unknown): ExternalSessionSummary {
   return {
     id,
     name: requireUtf8String(summary.name, 'external Session name', EXTERNAL_SESSION_NAME_MAX_BYTES),
-    cwd: boundedPossiblyEmptyText(
-      summary.cwd,
-      'external Session cwd',
+    hostCwd: boundedPossiblyEmptyText(
+      summary.hostCwd,
+      'external Session Host cwd',
       EXTERNAL_SESSION_CWD_MAX_BYTES,
     ),
     ...(Object.hasOwn(summary, 'createdAt')

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -56,12 +56,13 @@ export * from './session-catalog-change.js';
 export * from './session-retirement.js';
 export * from './session-transcript.js';
 export * from './task-ledger.js';
+export * from './workspace.js';
 
 export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 14 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 15 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -143,6 +143,7 @@ export * from './session-effects.js';
 export * from './skill-catalog.js';
 export * from './usage-pricing.js';
 export * from './web-search.js';
+export * from './workspace.js';
 
 export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   HOST_BOOTSTRAP_OPERATION_SPECS,

--- a/packages/runtime-host/src/protocol/project-catalog.ts
+++ b/packages/runtime-host/src/protocol/project-catalog.ts
@@ -7,7 +7,7 @@ import {
   requireUtf8String,
 } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
-import { defineHostPathOperation, defineOperation } from './operation-spec.js';
+import { defineHostPathOperation } from './operation-spec.js';
 import { decodeHostPath } from './workspace.js';
 
 export const PROJECT_CATALOG_PAGE_MAX_ITEMS = 64;
@@ -24,8 +24,6 @@ const QUERY_ERRORS = [
   'persistence_failed',
   'internal_failure',
 ] as const;
-const LOCATION_QUERY_ERRORS = [...QUERY_ERRORS, 'not_found', 'operation_conflict'] as const;
-
 const MUTATE_ERRORS = [
   'host_not_ready',
   'host_draining',
@@ -39,6 +37,8 @@ const MUTATE_ERRORS = [
 ] as const;
 
 export type ProjectCatalogRevision = `sha256:${string}`;
+
+export type ProjectCatalogView = 'summary' | 'locations';
 
 export interface ProjectCatalogLocation {
   readonly path: string;
@@ -54,6 +54,11 @@ export interface ProjectCatalogProject {
   readonly available: boolean;
 }
 
+export interface ProjectCatalogProjectDetails extends ProjectCatalogProject {
+  readonly locations: readonly ProjectCatalogLocation[];
+  readonly preferredPath: string | null;
+}
+
 export type ProjectCatalogPageItem =
   | {
       readonly kind: 'project';
@@ -62,6 +67,7 @@ export type ProjectCatalogPageItem =
       readonly name: string;
       readonly aliasCount: number;
       readonly locationCount: number;
+      readonly preferredLocationIndex: number | null;
       readonly archivedAt: number | null;
       readonly available: boolean;
     }
@@ -70,12 +76,19 @@ export type ProjectCatalogPageItem =
       readonly projectIndex: number;
       readonly itemIndex: number;
       readonly alias: string;
+    }
+  | {
+      readonly kind: 'location';
+      readonly projectIndex: number;
+      readonly itemIndex: number;
+      readonly location: ProjectCatalogLocation;
     };
 
 export type ProjectCatalogQueryInput =
-  | { readonly kind: 'list_start' }
+  | { readonly kind: 'list_start'; readonly view: ProjectCatalogView }
   | {
       readonly kind: 'list_continue';
+      readonly view: ProjectCatalogView;
       readonly revision: ProjectCatalogRevision;
       readonly cursor: string;
     };
@@ -83,6 +96,7 @@ export type ProjectCatalogQueryInput =
 export type ProjectCatalogQueryResult =
   | {
       readonly kind: 'page';
+      readonly view: ProjectCatalogView;
       readonly revision: ProjectCatalogRevision;
       readonly projectCount: number;
       readonly items: readonly ProjectCatalogPageItem[];
@@ -90,6 +104,7 @@ export type ProjectCatalogQueryResult =
     }
   | {
       readonly kind: 'revision_changed';
+      readonly view: ProjectCatalogView;
       readonly expected: ProjectCatalogRevision;
       readonly actual: ProjectCatalogRevision;
     };
@@ -106,39 +121,26 @@ export type ProjectCatalogMutateResult = {
   readonly project: ProjectCatalogProject;
 };
 
-export interface ProjectCatalogLocationQueryInput {
-  readonly projectId: string;
-}
-
-export interface ProjectCatalogLocationQueryResult {
-  readonly projectId: string;
-  readonly locations: readonly ProjectCatalogLocation[];
-  readonly preferredPath: string;
-}
-
 export const PROJECT_CATALOG_OPERATION_SPECS = {
-  'project.catalog.query': defineOperation<
+  'project.catalog.query': defineHostPathOperation<
     ProjectCatalogQueryInput,
     ProjectCatalogQueryResult,
     (typeof QUERY_ERRORS)[number]
-  >({
-    mode: 'query',
-    availability: 'ready',
-    errors: QUERY_ERRORS,
-    decodeInput: decodeProjectCatalogQueryInput,
-    decodeOutput: decodeProjectCatalogQueryResult,
-  }),
-  'project.catalog.location.query': defineHostPathOperation<
-    ProjectCatalogLocationQueryInput,
-    ProjectCatalogLocationQueryResult,
-    (typeof LOCATION_QUERY_ERRORS)[number]
-  >({
-    mode: 'query',
-    availability: 'ready',
-    errors: LOCATION_QUERY_ERRORS,
-    decodeInput: decodeProjectCatalogLocationQueryInput,
-    decodeOutput: decodeProjectCatalogLocationQueryResult,
-  }),
+  >(
+    {
+      mode: 'query',
+      availability: 'ready',
+      errors: QUERY_ERRORS,
+      decodeInput: decodeProjectCatalogQueryInput,
+      decodeOutput: decodeProjectCatalogQueryResult,
+      assertOutputForInput: (input, output) => {
+        if (input.view !== output.view) {
+          throw invalidProtocolFrame('Project catalog view changed');
+        }
+      },
+    },
+    (input) => input.view === 'locations',
+  ),
   'project.catalog.mutate': defineHostPathOperation<
     ProjectCatalogMutateInput,
     ProjectCatalogMutateResult,
@@ -155,62 +157,22 @@ export const PROJECT_CATALOG_OPERATION_SPECS = {
   ),
 } as const;
 
-export function decodeProjectCatalogLocationQueryInput(
-  value: unknown,
-): ProjectCatalogLocationQueryInput {
-  const input = requireExactRecord(value, 'project catalog location query input', ['projectId']);
-  return { projectId: projectId(input.projectId) };
-}
-
-export function decodeProjectCatalogLocationQueryResult(
-  value: unknown,
-): ProjectCatalogLocationQueryResult {
-  const result = requireExactRecord(value, 'project catalog location query result', [
-    'projectId',
-    'locations',
-    'preferredPath',
-  ]);
-  if (
-    !Array.isArray(result.locations) ||
-    result.locations.length > PROJECT_CATALOG_PAGE_MAX_ITEMS
-  ) {
-    throw invalidProtocolFrame('Invalid project locations');
-  }
-  const locations = result.locations.map(decodeProjectLocation);
-  const preferredPath = absolutePath(result.preferredPath, 'project preferred path');
-  if (
-    new Set(locations.map((location) => location.path)).size !== locations.length ||
-    !locations.some((location) => location.path === preferredPath)
-  ) {
-    throw invalidProtocolFrame('Invalid project locations');
-  }
-  const decoded: ProjectCatalogLocationQueryResult = {
-    projectId: projectId(result.projectId),
-    locations,
-    preferredPath,
-  };
-  requireEncodedByteLimit(
-    decoded,
-    'project catalog location query result',
-    PROJECT_CATALOG_PAGE_MAX_BYTES,
-  );
-  return decoded;
-}
-
 export function decodeProjectCatalogQueryInput(value: unknown): ProjectCatalogQueryInput {
   const record = requireRecord(value, 'project catalog query input');
   if (record.kind === 'list_start') {
-    requireExactRecord(record, 'project catalog list start input', ['kind']);
-    return { kind: 'list_start' };
+    const input = requireExactRecord(record, 'project catalog list start input', ['kind', 'view']);
+    return { kind: 'list_start', view: projectCatalogView(input.view) };
   }
   if (record.kind === 'list_continue') {
     const input = requireExactRecord(record, 'project catalog list continuation input', [
       'kind',
+      'view',
       'revision',
       'cursor',
     ]);
     return {
       kind: 'list_continue',
+      view: projectCatalogView(input.view),
       revision: revision(input.revision, 'project catalog revision'),
       cursor: requireUtf8String(
         input.cursor,
@@ -227,11 +189,13 @@ export function decodeProjectCatalogQueryResult(value: unknown): ProjectCatalogQ
   if (record.kind === 'revision_changed') {
     const result = requireExactRecord(record, 'project catalog revision changed result', [
       'kind',
+      'view',
       'expected',
       'actual',
     ]);
     return {
       kind: 'revision_changed',
+      view: projectCatalogView(result.view),
       expected: revision(result.expected, 'expected project catalog revision'),
       actual: revision(result.actual, 'actual project catalog revision'),
     };
@@ -239,6 +203,7 @@ export function decodeProjectCatalogQueryResult(value: unknown): ProjectCatalogQ
   if (record.kind !== 'page') throw invalidProtocolFrame('Invalid project catalog query result');
   const page = requireExactRecord(record, 'project catalog page result', [
     'kind',
+    'view',
     'revision',
     'projectCount',
     'items',
@@ -247,11 +212,13 @@ export function decodeProjectCatalogQueryResult(value: unknown): ProjectCatalogQ
   if (!Array.isArray(page.items) || page.items.length > PROJECT_CATALOG_PAGE_MAX_ITEMS) {
     throw invalidProtocolFrame('Invalid project catalog page items');
   }
+  const view = projectCatalogView(page.view);
   const decoded: ProjectCatalogQueryResult = {
     kind: 'page',
+    view,
     revision: revision(page.revision, 'project catalog revision'),
     projectCount: requireCount(page.projectCount, 'project catalog projectCount'),
-    items: page.items.map(decodeProjectCatalogPageItem),
+    items: page.items.map((item) => decodeProjectCatalogPageItem(item, view)),
     nextCursor:
       page.nextCursor === null
         ? null
@@ -318,7 +285,10 @@ export function decodeProjectCatalogMutateResult(value: unknown): ProjectCatalog
   throw invalidProtocolFrame('Invalid project catalog mutation result kind');
 }
 
-function decodeProjectCatalogPageItem(value: unknown): ProjectCatalogPageItem {
+function decodeProjectCatalogPageItem(
+  value: unknown,
+  view: ProjectCatalogView,
+): ProjectCatalogPageItem {
   const record = requireRecord(value, 'project catalog page item');
   if (record.kind === 'project') {
     const item = requireExactRecord(record, 'project catalog header item', [
@@ -328,6 +298,7 @@ function decodeProjectCatalogPageItem(value: unknown): ProjectCatalogPageItem {
       'name',
       'aliasCount',
       'locationCount',
+      'preferredLocationIndex',
       'archivedAt',
       'available',
     ]);
@@ -338,6 +309,10 @@ function decodeProjectCatalogPageItem(value: unknown): ProjectCatalogPageItem {
       name: requireUtf8String(item.name, 'project name', PROJECT_CATALOG_NAME_MAX_BYTES),
       aliasCount: requireCount(item.aliasCount, 'project alias count'),
       locationCount: requireCount(item.locationCount, 'project location count'),
+      preferredLocationIndex:
+        item.preferredLocationIndex === null
+          ? null
+          : requireCount(item.preferredLocationIndex, 'project preferred location index'),
       archivedAt:
         item.archivedAt === null ? null : requireCount(item.archivedAt, 'project archivedAt'),
       available: boolean(item.available, 'project available'),
@@ -355,6 +330,23 @@ function decodeProjectCatalogPageItem(value: unknown): ProjectCatalogPageItem {
       projectIndex: requireCount(item.projectIndex, 'project index'),
       itemIndex: requireCount(item.itemIndex, 'project alias index'),
       alias: projectId(item.alias),
+    };
+  }
+  if (record.kind === 'location') {
+    if (view !== 'locations') {
+      throw invalidProtocolFrame('Project summary contains a Host location');
+    }
+    const item = requireExactRecord(record, 'project catalog location item', [
+      'kind',
+      'projectIndex',
+      'itemIndex',
+      'location',
+    ]);
+    return {
+      kind: 'location',
+      projectIndex: requireCount(item.projectIndex, 'project index'),
+      itemIndex: requireCount(item.itemIndex, 'project location index'),
+      location: decodeProjectLocation(item.location),
     };
   }
   throw invalidProtocolFrame('Invalid project catalog page item kind');
@@ -386,6 +378,45 @@ export function decodeProjectCatalogProject(value: unknown): ProjectCatalogProje
   return project;
 }
 
+export function decodeProjectCatalogProjectDetails(value: unknown): ProjectCatalogProjectDetails {
+  const record = requireExactRecord(value, 'project catalog project details', [
+    'id',
+    'aliases',
+    'name',
+    'locationCount',
+    'archivedAt',
+    'available',
+    'locations',
+    'preferredPath',
+  ]);
+  const project = decodeProjectCatalogProject({
+    id: record.id,
+    aliases: record.aliases,
+    name: record.name,
+    locationCount: record.locationCount,
+    archivedAt: record.archivedAt,
+    available: record.available,
+  });
+  if (!Array.isArray(record.locations) || record.locations.length !== project.locationCount) {
+    throw invalidProtocolFrame('Invalid project locations');
+  }
+  const locations = record.locations.map(decodeProjectLocation);
+  if (new Set(locations.map((location) => location.path)).size !== locations.length) {
+    throw invalidProtocolFrame('Invalid project locations');
+  }
+  const preferredPath =
+    record.preferredPath === null
+      ? null
+      : absolutePath(record.preferredPath, 'project preferred path');
+  if (
+    project.available !== (preferredPath !== null) ||
+    (preferredPath !== null && !locations.some((location) => location.path === preferredPath))
+  ) {
+    throw invalidProtocolFrame('Invalid project preferred location');
+  }
+  return { ...project, locations, preferredPath };
+}
+
 function projectId(value: unknown): string {
   return requireEntityId(value, 'projectId');
 }
@@ -412,5 +443,12 @@ function revision(value: unknown, label: string): ProjectCatalogRevision {
 
 function boolean(value: unknown, label: string): boolean {
   if (typeof value !== 'boolean') throw invalidProtocolFrame(`Invalid ${label}`);
+  return value;
+}
+
+function projectCatalogView(value: unknown): ProjectCatalogView {
+  if (value !== 'summary' && value !== 'locations') {
+    throw invalidProtocolFrame('Invalid project catalog view');
+  }
   return value;
 }

--- a/packages/runtime-host/src/protocol/project-catalog.ts
+++ b/packages/runtime-host/src/protocol/project-catalog.ts
@@ -7,7 +7,8 @@ import {
   requireUtf8String,
 } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
-import { defineHostPathOperation } from './operation-spec.js';
+import { defineHostPathOperation, defineOperation } from './operation-spec.js';
+import { decodeHostPath } from './workspace.js';
 
 export const PROJECT_CATALOG_PAGE_MAX_ITEMS = 64;
 export const PROJECT_CATALOG_PAGE_MAX_BYTES = 48 * 1024;
@@ -23,6 +24,7 @@ const QUERY_ERRORS = [
   'persistence_failed',
   'internal_failure',
 ] as const;
+const LOCATION_QUERY_ERRORS = [...QUERY_ERRORS, 'not_found', 'operation_conflict'] as const;
 
 const MUTATE_ERRORS = [
   'host_not_ready',
@@ -47,10 +49,9 @@ export interface ProjectCatalogProject {
   readonly id: string;
   readonly aliases: readonly string[];
   readonly name: string;
-  readonly locations: readonly ProjectCatalogLocation[];
+  readonly locationCount: number;
   readonly archivedAt: number | null;
   readonly available: boolean;
-  readonly preferredPath: string | null;
 }
 
 export type ProjectCatalogPageItem =
@@ -63,19 +64,12 @@ export type ProjectCatalogPageItem =
       readonly locationCount: number;
       readonly archivedAt: number | null;
       readonly available: boolean;
-      readonly preferredPath: string | null;
     }
   | {
       readonly kind: 'alias';
       readonly projectIndex: number;
       readonly itemIndex: number;
       readonly alias: string;
-    }
-  | {
-      readonly kind: 'location';
-      readonly projectIndex: number;
-      readonly itemIndex: number;
-      readonly location: ProjectCatalogLocation;
     };
 
 export type ProjectCatalogQueryInput =
@@ -102,23 +96,28 @@ export type ProjectCatalogQueryResult =
 
 export type ProjectCatalogMutateInput =
   | { readonly kind: 'register'; readonly path: string }
-  | { readonly kind: 'select'; readonly projectId: string }
-  | { readonly kind: 'touch'; readonly projectId: string; readonly path: string | null }
   | { readonly kind: 'relink'; readonly projectId: string; readonly path: string }
   | { readonly kind: 'rename'; readonly projectId: string; readonly name: string }
   | { readonly kind: 'archive'; readonly projectId: string }
   | { readonly kind: 'restore'; readonly projectId: string };
 
-export type ProjectCatalogMutateResult =
-  | { readonly kind: 'project'; readonly projectId: string }
-  | {
-      readonly kind: 'selection';
-      readonly projectId: string;
-      readonly path: string;
-    };
+export type ProjectCatalogMutateResult = {
+  readonly kind: 'project';
+  readonly project: ProjectCatalogProject;
+};
+
+export interface ProjectCatalogLocationQueryInput {
+  readonly projectId: string;
+}
+
+export interface ProjectCatalogLocationQueryResult {
+  readonly projectId: string;
+  readonly locations: readonly ProjectCatalogLocation[];
+  readonly preferredPath: string;
+}
 
 export const PROJECT_CATALOG_OPERATION_SPECS = {
-  'project.catalog.query': defineHostPathOperation<
+  'project.catalog.query': defineOperation<
     ProjectCatalogQueryInput,
     ProjectCatalogQueryResult,
     (typeof QUERY_ERRORS)[number]
@@ -129,23 +128,74 @@ export const PROJECT_CATALOG_OPERATION_SPECS = {
     decodeInput: decodeProjectCatalogQueryInput,
     decodeOutput: decodeProjectCatalogQueryResult,
   }),
+  'project.catalog.location.query': defineHostPathOperation<
+    ProjectCatalogLocationQueryInput,
+    ProjectCatalogLocationQueryResult,
+    (typeof LOCATION_QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: LOCATION_QUERY_ERRORS,
+    decodeInput: decodeProjectCatalogLocationQueryInput,
+    decodeOutput: decodeProjectCatalogLocationQueryResult,
+  }),
   'project.catalog.mutate': defineHostPathOperation<
     ProjectCatalogMutateInput,
     ProjectCatalogMutateResult,
     (typeof MUTATE_ERRORS)[number]
-  >({
-    mode: 'command',
-    availability: 'ready',
-    errors: MUTATE_ERRORS,
-    decodeInput: decodeProjectCatalogMutateInput,
-    decodeOutput: decodeProjectCatalogMutateResult,
-    assertOutputForInput: (input, output) => {
-      if ((input.kind === 'select') !== (output.kind === 'selection')) {
-        throw invalidProtocolFrame('Project catalog mutation result kind does not match input');
-      }
+  >(
+    {
+      mode: 'command',
+      availability: 'ready',
+      errors: MUTATE_ERRORS,
+      decodeInput: decodeProjectCatalogMutateInput,
+      decodeOutput: decodeProjectCatalogMutateResult,
     },
-  }),
+    (input) => input.kind === 'register' || input.kind === 'relink',
+  ),
 } as const;
+
+export function decodeProjectCatalogLocationQueryInput(
+  value: unknown,
+): ProjectCatalogLocationQueryInput {
+  const input = requireExactRecord(value, 'project catalog location query input', ['projectId']);
+  return { projectId: projectId(input.projectId) };
+}
+
+export function decodeProjectCatalogLocationQueryResult(
+  value: unknown,
+): ProjectCatalogLocationQueryResult {
+  const result = requireExactRecord(value, 'project catalog location query result', [
+    'projectId',
+    'locations',
+    'preferredPath',
+  ]);
+  if (
+    !Array.isArray(result.locations) ||
+    result.locations.length > PROJECT_CATALOG_PAGE_MAX_ITEMS
+  ) {
+    throw invalidProtocolFrame('Invalid project locations');
+  }
+  const locations = result.locations.map(decodeProjectLocation);
+  const preferredPath = absolutePath(result.preferredPath, 'project preferred path');
+  if (
+    new Set(locations.map((location) => location.path)).size !== locations.length ||
+    !locations.some((location) => location.path === preferredPath)
+  ) {
+    throw invalidProtocolFrame('Invalid project locations');
+  }
+  const decoded: ProjectCatalogLocationQueryResult = {
+    projectId: projectId(result.projectId),
+    locations,
+    preferredPath,
+  };
+  requireEncodedByteLimit(
+    decoded,
+    'project catalog location query result',
+    PROJECT_CATALOG_PAGE_MAX_BYTES,
+  );
+  return decoded;
+}
 
 export function decodeProjectCatalogQueryInput(value: unknown): ProjectCatalogQueryInput {
   const record = requireRecord(value, 'project catalog query input');
@@ -222,7 +272,6 @@ export function decodeProjectCatalogMutateInput(value: unknown): ProjectCatalogM
       const input = requireExactRecord(record, 'project register input', ['kind', 'path']);
       return { kind: 'register', path: absolutePath(input.path, 'project path') };
     }
-    case 'select':
     case 'archive':
     case 'restore': {
       const input = requireExactRecord(record, `project ${record.kind} input`, [
@@ -230,18 +279,6 @@ export function decodeProjectCatalogMutateInput(value: unknown): ProjectCatalogM
         'projectId',
       ]);
       return { kind: record.kind, projectId: projectId(input.projectId) };
-    }
-    case 'touch': {
-      const input = requireExactRecord(record, 'project touch input', [
-        'kind',
-        'projectId',
-        'path',
-      ]);
-      return {
-        kind: 'touch',
-        projectId: projectId(input.projectId),
-        path: input.path === null ? null : absolutePath(input.path, 'project path'),
-      };
     }
     case 'relink': {
       const input = requireExactRecord(record, 'project relink input', [
@@ -275,20 +312,8 @@ export function decodeProjectCatalogMutateInput(value: unknown): ProjectCatalogM
 export function decodeProjectCatalogMutateResult(value: unknown): ProjectCatalogMutateResult {
   const record = requireRecord(value, 'project catalog mutation result');
   if (record.kind === 'project') {
-    const result = requireExactRecord(record, 'project mutation result', ['kind', 'projectId']);
-    return { kind: 'project', projectId: projectId(result.projectId) };
-  }
-  if (record.kind === 'selection') {
-    const result = requireExactRecord(record, 'project selection result', [
-      'kind',
-      'projectId',
-      'path',
-    ]);
-    return {
-      kind: 'selection',
-      projectId: projectId(result.projectId),
-      path: absolutePath(result.path, 'selected project path'),
-    };
+    const result = requireExactRecord(record, 'project mutation result', ['kind', 'project']);
+    return { kind: 'project', project: decodeProjectCatalogProject(result.project) };
   }
   throw invalidProtocolFrame('Invalid project catalog mutation result kind');
 }
@@ -305,7 +330,6 @@ function decodeProjectCatalogPageItem(value: unknown): ProjectCatalogPageItem {
       'locationCount',
       'archivedAt',
       'available',
-      'preferredPath',
     ]);
     return {
       kind: 'project',
@@ -317,10 +341,6 @@ function decodeProjectCatalogPageItem(value: unknown): ProjectCatalogPageItem {
       archivedAt:
         item.archivedAt === null ? null : requireCount(item.archivedAt, 'project archivedAt'),
       available: boolean(item.available, 'project available'),
-      preferredPath:
-        item.preferredPath === null
-          ? null
-          : absolutePath(item.preferredPath, 'project preferred path'),
     };
   }
   if (record.kind === 'alias') {
@@ -337,20 +357,6 @@ function decodeProjectCatalogPageItem(value: unknown): ProjectCatalogPageItem {
       alias: projectId(item.alias),
     };
   }
-  if (record.kind === 'location') {
-    const item = requireExactRecord(record, 'project catalog location item', [
-      'kind',
-      'projectIndex',
-      'itemIndex',
-      'location',
-    ]);
-    return {
-      kind: 'location',
-      projectIndex: requireCount(item.projectIndex, 'project index'),
-      itemIndex: requireCount(item.itemIndex, 'project location index'),
-      location: decodeProjectLocation(item.location),
-    };
-  }
   throw invalidProtocolFrame('Invalid project catalog page item kind');
 }
 
@@ -359,13 +365,11 @@ export function decodeProjectCatalogProject(value: unknown): ProjectCatalogProje
     'id',
     'aliases',
     'name',
-    'locations',
+    'locationCount',
     'archivedAt',
     'available',
-    'preferredPath',
   ]);
   if (!Array.isArray(record.aliases)) throw invalidProtocolFrame('Invalid project aliases');
-  if (!Array.isArray(record.locations)) throw invalidProtocolFrame('Invalid project locations');
   const aliases = record.aliases.map(projectId);
   if (new Set(aliases).size !== aliases.length) {
     throw invalidProtocolFrame('Duplicate project aliases');
@@ -374,24 +378,12 @@ export function decodeProjectCatalogProject(value: unknown): ProjectCatalogProje
     id: projectId(record.id),
     aliases,
     name: requireUtf8String(record.name, 'project name', PROJECT_CATALOG_NAME_MAX_BYTES),
-    locations: record.locations.map(decodeProjectLocation),
+    locationCount: requireCount(record.locationCount, 'project location count'),
     archivedAt:
       record.archivedAt === null ? null : requireCount(record.archivedAt, 'project archivedAt'),
     available: boolean(record.available, 'project available'),
-    preferredPath:
-      record.preferredPath === null
-        ? null
-        : absolutePath(record.preferredPath, 'project preferred path'),
   };
   return project;
-}
-
-function decodeProjectLocation(value: unknown): ProjectCatalogLocation {
-  const item = requireExactRecord(value, 'project location', ['path', 'isWorktree']);
-  return {
-    path: absolutePath(item.path, 'project location path'),
-    isWorktree: boolean(item.isWorktree, 'project location isWorktree'),
-  };
 }
 
 function projectId(value: unknown): string {
@@ -399,13 +391,15 @@ function projectId(value: unknown): string {
 }
 
 function absolutePath(value: unknown, label: string): string {
-  const path = requireUtf8String(value, label, PROJECT_CATALOG_PATH_MAX_BYTES);
-  const absolute =
-    process.platform === 'win32'
-      ? /^[A-Za-z]:[\\/]/.test(path) || /^[\\/]{2}[^\\/]+[\\/][^\\/]+(?:[\\/]|$)/.test(path)
-      : path.startsWith('/');
-  if (!absolute) throw invalidProtocolFrame(`${label} must be absolute`);
-  return path;
+  return decodeHostPath(value, label, PROJECT_CATALOG_PATH_MAX_BYTES);
+}
+
+function decodeProjectLocation(value: unknown): ProjectCatalogLocation {
+  const location = requireExactRecord(value, 'project location', ['path', 'isWorktree']);
+  return {
+    path: absolutePath(location.path, 'project location path'),
+    isWorktree: boolean(location.isWorktree, 'project worktree state'),
+  };
 }
 
 function revision(value: unknown, label: string): ProjectCatalogRevision {

--- a/packages/runtime-host/src/protocol/session-catalog.ts
+++ b/packages/runtime-host/src/protocol/session-catalog.ts
@@ -24,20 +24,26 @@ import {
 } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { defineHostPathOperation, defineOperation } from './operation-spec.js';
+import {
+  decodeWorkspaceProjection,
+  decodeWorkspaceTarget,
+  type WorkspaceProjection,
+  type WorkspaceTarget,
+  WORKSPACE_HOST_PATH_MAX_BYTES,
+} from './workspace.js';
 
 export type { SessionSubagentProjection } from '@maka/core/session';
 
 export const SESSION_CATALOG_PAGE_MAX_ITEMS = 32;
 export const SESSION_CATALOG_RESULT_MAX_BYTES = 48 * 1024;
 export const SESSION_CATALOG_CURSOR_MAX_BYTES = 512;
-export const SESSION_CATALOG_CWD_MAX_BYTES = 4 * 1024;
+export const SESSION_CATALOG_CWD_MAX_BYTES = WORKSPACE_HOST_PATH_MAX_BYTES;
 export const SESSION_CATALOG_NAME_MAX_BYTES = 320;
 export const SESSION_CATALOG_LABEL_MAX_ITEMS = 32;
 export const SESSION_CATALOG_LABEL_MAX_BYTES = 128;
 export const SESSION_CATALOG_PREVIEW_MAX_BYTES = 4 * 1024;
 export const SESSION_CATALOG_MODEL_MAX_BYTES = 512;
 export const SESSION_CATALOG_CONNECTION_SLUG_MAX_BYTES = 256;
-export const SESSION_CATALOG_PROJECT_ID_MAX_BYTES = 256;
 
 const QUERY_ERRORS = [
   'host_not_ready',
@@ -60,7 +66,7 @@ const EXECUTION_BOUNDARY_QUERY_ERRORS = [...QUERY_ERRORS, 'not_found'] as const;
 const PROJECTION_REQUIRED_FIELDS = [
   'id',
   'revision',
-  'cwd',
+  'workspace',
   'createdAt',
   'lastUsedAt',
   'name',
@@ -80,7 +86,6 @@ const PROJECTION_REQUIRED_FIELDS = [
 ] as const;
 const PROJECTION_FIELDS = [
   ...PROJECTION_REQUIRED_FIELDS,
-  'projectId',
   'lastMessageAt',
   'lastMessagePreview',
   'blockedReason',
@@ -125,9 +130,8 @@ export type SessionModelTarget =
 
 export interface SessionCreateInput {
   readonly sessionId: string;
-  readonly cwd: string;
+  readonly workspace: WorkspaceTarget;
   readonly mode?: SessionStartMode;
-  readonly projectId?: string | null;
   readonly name?: string;
   readonly labels?: readonly string[];
   readonly modelTarget: SessionModelTarget;
@@ -141,7 +145,6 @@ export interface SessionMetadataPatch {
   readonly name?: string;
   readonly labels?: readonly string[];
   readonly isFlagged?: boolean;
-  readonly projectId?: string | null;
 }
 
 export interface SessionMetadataUpdateInput {
@@ -164,11 +167,10 @@ export interface SessionConfigurationUpdateInput {
   readonly configuration: SessionConfiguration;
 }
 
-export interface SessionCwdRelocateInput {
+export interface SessionWorkspaceRelocateInput {
   readonly sessionId: string;
   readonly expectedRevision: number;
-  readonly cwd: string;
-  readonly projectId?: string | null;
+  readonly workspace: WorkspaceTarget;
 }
 
 export interface SessionReadMarkerSetInput {
@@ -183,8 +185,7 @@ export interface SessionExecutionBoundaryQueryInput {
 export interface SessionCatalogProjection {
   readonly id: string;
   readonly revision: number;
-  readonly cwd: string;
-  readonly projectId?: string | null;
+  readonly workspace: WorkspaceProjection;
   readonly createdAt: number;
   readonly lastUsedAt: number;
   readonly name: string;
@@ -267,14 +268,17 @@ export const SESSION_CATALOG_OPERATION_SPECS = {
     SessionCreateInput,
     SessionCatalogItem,
     (typeof CREATE_ERRORS)[number]
-  >({
-    mode: 'command',
-    availability: 'ready',
-    errors: CREATE_ERRORS,
-    decodeInput: decodeSessionCreateInput,
-    decodeOutput: decodeSessionCatalogItem,
-    assertOutputForInput: (input, output) => assertSessionIdentity(input.sessionId, output),
-  }),
+  >(
+    {
+      mode: 'command',
+      availability: 'ready',
+      errors: CREATE_ERRORS,
+      decodeInput: decodeSessionCreateInput,
+      decodeOutput: decodeSessionCatalogItem,
+      assertOutputForInput: (input, output) => assertSessionIdentity(input.sessionId, output),
+    },
+    (input) => input.workspace.kind === 'host_path',
+  ),
   'session.metadata.update': defineOperation<
     SessionMetadataUpdateInput,
     SessionUpdateResult,
@@ -299,18 +303,21 @@ export const SESSION_CATALOG_OPERATION_SPECS = {
     decodeOutput: decodeSessionUpdateResult,
     assertOutputForInput: assertUpdateOutputIdentity,
   }),
-  'session.cwd.relocate': defineHostPathOperation<
-    SessionCwdRelocateInput,
+  'session.workspace.relocate': defineHostPathOperation<
+    SessionWorkspaceRelocateInput,
     SessionUpdateResult,
     (typeof CONFIGURATION_UPDATE_ERRORS)[number]
-  >({
-    mode: 'command',
-    availability: 'ready',
-    errors: CONFIGURATION_UPDATE_ERRORS,
-    decodeInput: decodeSessionCwdRelocateInput,
-    decodeOutput: decodeSessionUpdateResult,
-    assertOutputForInput: assertUpdateOutputIdentity,
-  }),
+  >(
+    {
+      mode: 'command',
+      availability: 'ready',
+      errors: CONFIGURATION_UPDATE_ERRORS,
+      decodeInput: decodeSessionWorkspaceRelocateInput,
+      decodeOutput: decodeSessionUpdateResult,
+      assertOutputForInput: assertUpdateOutputIdentity,
+    },
+    (input) => input.workspace.kind === 'host_path',
+  ),
   'session.read_marker.set': defineOperation<
     SessionReadMarkerSetInput,
     SessionCatalogItem,
@@ -413,10 +420,9 @@ export function decodeSessionCreateInput(value: unknown): SessionCreateInput {
   const input = requireShapedRecord(
     value,
     'Session create input',
-    ['sessionId', 'cwd', 'modelTarget'],
+    ['sessionId', 'workspace', 'modelTarget'],
     [
       'mode',
-      'projectId',
       'name',
       'labels',
       'thinkingLevel',
@@ -427,20 +433,8 @@ export function decodeSessionCreateInput(value: unknown): SessionCreateInput {
   );
   return {
     sessionId: requireEntityId(input.sessionId, 'sessionId'),
-    cwd: requireUtf8String(input.cwd, 'Session cwd', SESSION_CATALOG_CWD_MAX_BYTES),
+    workspace: decodeWorkspaceTarget(input.workspace),
     ...(Object.hasOwn(input, 'mode') ? { mode: sessionStartMode(input.mode) } : {}),
-    ...(Object.hasOwn(input, 'projectId')
-      ? {
-          projectId:
-            input.projectId === null
-              ? null
-              : boundedText(
-                  input.projectId,
-                  'Session project id',
-                  SESSION_CATALOG_PROJECT_ID_MAX_BYTES,
-                ),
-        }
-      : {}),
     ...(Object.hasOwn(input, 'name') ? { name: sessionName(input.name) } : {}),
     ...(Object.hasOwn(input, 'labels') ? { labels: labels(input.labels) } : {}),
     modelTarget: modelTarget(input.modelTarget),
@@ -474,7 +468,7 @@ export function decodeSessionMetadataUpdateInput(value: unknown): SessionMetadat
     input.patch,
     'Session metadata patch',
     [],
-    ['name', 'labels', 'isFlagged', 'projectId'],
+    ['name', 'labels', 'isFlagged'],
   );
   if (Object.keys(patch).length === 0) {
     throw invalidProtocolFrame('Session metadata patch is empty');
@@ -487,18 +481,6 @@ export function decodeSessionMetadataUpdateInput(value: unknown): SessionMetadat
       ...(Object.hasOwn(patch, 'labels') ? { labels: labels(patch.labels) } : {}),
       ...(Object.hasOwn(patch, 'isFlagged')
         ? { isFlagged: boolean(patch.isFlagged, 'Session flagged state') }
-        : {}),
-      ...(Object.hasOwn(patch, 'projectId')
-        ? {
-            projectId:
-              patch.projectId === null
-                ? null
-                : boundedText(
-                    patch.projectId,
-                    'Session project id',
-                    SESSION_CATALOG_PROJECT_ID_MAX_BYTES,
-                  ),
-          }
         : {}),
     },
   };
@@ -533,29 +515,16 @@ export function decodeSessionConfigurationUpdateInput(
   };
 }
 
-export function decodeSessionCwdRelocateInput(value: unknown): SessionCwdRelocateInput {
-  const input = requireShapedRecord(
-    value,
-    'Session cwd relocate input',
-    ['sessionId', 'expectedRevision', 'cwd'],
-    ['projectId'],
-  );
+export function decodeSessionWorkspaceRelocateInput(value: unknown): SessionWorkspaceRelocateInput {
+  const input = requireExactRecord(value, 'Session workspace relocate input', [
+    'sessionId',
+    'expectedRevision',
+    'workspace',
+  ]);
   return {
     sessionId: requireEntityId(input.sessionId, 'sessionId'),
     expectedRevision: positiveRevision(input.expectedRevision, 'expected Session revision'),
-    cwd: requireUtf8String(input.cwd, 'Session cwd', SESSION_CATALOG_CWD_MAX_BYTES),
-    ...(Object.hasOwn(input, 'projectId')
-      ? {
-          projectId:
-            input.projectId === null
-              ? null
-              : boundedText(
-                  input.projectId,
-                  'Session project id',
-                  SESSION_CATALOG_PROJECT_ID_MAX_BYTES,
-                ),
-        }
-      : {}),
+    workspace: decodeWorkspaceTarget(input.workspace),
   };
 }
 
@@ -651,8 +620,7 @@ export function decodeSessionCatalogProjection(value: unknown): SessionCatalogPr
   const projection: SessionCatalogProjection = {
     id: requireEntityId(record.id, 'Session id'),
     revision: positiveRevision(record.revision, 'Session revision'),
-    cwd: requireUtf8String(record.cwd, 'Session cwd', SESSION_CATALOG_CWD_MAX_BYTES),
-    ...optionalProjectId(record),
+    workspace: decodeWorkspaceProjection(record.workspace),
     createdAt: timestamp(record.createdAt, 'Session createdAt'),
     lastUsedAt: timestamp(record.lastUsedAt, 'Session lastUsedAt'),
     name: sessionName(record.name),
@@ -780,18 +748,6 @@ function labels(value: unknown): readonly string[] {
     throw invalidProtocolFrame('Duplicate Session label');
   }
   return decoded;
-}
-
-function optionalProjectId(
-  record: Record<string, unknown>,
-): Pick<SessionCatalogProjection, 'projectId'> | Record<string, never> {
-  if (!Object.hasOwn(record, 'projectId')) return {};
-  return {
-    projectId:
-      record.projectId === null
-        ? null
-        : boundedText(record.projectId, 'Session project id', SESSION_CATALOG_PROJECT_ID_MAX_BYTES),
-  };
 }
 
 function optionalTimestamp<Field extends 'lastMessageAt' | 'statusUpdatedAt'>(
@@ -971,7 +927,10 @@ function boolean(value: unknown, label: string): boolean {
 }
 
 function assertUpdateOutputIdentity(
-  input: SessionMetadataUpdateInput | SessionConfigurationUpdateInput | SessionCwdRelocateInput,
+  input:
+    | SessionMetadataUpdateInput
+    | SessionConfigurationUpdateInput
+    | SessionWorkspaceRelocateInput,
   output: SessionUpdateResult,
 ): void {
   if (output.kind === 'committed') assertSessionIdentity(input.sessionId, output.session);

--- a/packages/runtime-host/src/protocol/skill-catalog.ts
+++ b/packages/runtime-host/src/protocol/skill-catalog.ts
@@ -2,6 +2,7 @@ import { isPermissionMode, type PermissionMode } from '@maka/core/permission';
 import { requireCount, requireEntityId, requireExactRecord, requireRecord } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { defineHostPathOperation } from './operation-spec.js';
+import { decodeWorkspaceTarget, type WorkspaceTarget } from './workspace.js';
 
 export const SKILL_CATALOG_PAGE_MAX_ITEMS = 128;
 export const SKILL_CATALOG_PAGE_MAX_BYTES = 48 * 1024;
@@ -9,7 +10,6 @@ export const SKILL_CATALOG_PREVIEW_RESULT_MAX_BYTES = 48 * 1024;
 export const SKILL_CATALOG_REF_MAX_BYTES = 512;
 export const SKILL_CATALOG_DISPLAY_ID_MAX_BYTES = 256;
 
-const PROJECT_ROOT_MAX_BYTES = 4096;
 const CURSOR_MAX_BYTES = 1024;
 const ID_MAX_BYTES = 81;
 export const SKILL_CATALOG_NAME_MAX_BYTES = 256;
@@ -86,15 +86,15 @@ export type SkillCatalogValidationCode =
   | 'read_failed'
   | 'projection_truncated';
 
-export interface SkillCatalogLocalContext {
-  readonly projectRoot: string;
+export interface SkillCatalogWorkspaceContext {
+  readonly workspace: WorkspaceTarget;
 }
 
 export type SkillCatalogInvocableTarget =
   | { readonly kind: 'session'; readonly sessionId: string }
   | {
       readonly kind: 'new_session';
-      readonly context: SkillCatalogLocalContext;
+      readonly context: SkillCatalogWorkspaceContext;
       readonly collaborationMode: 'agent' | 'plan';
       readonly permissionMode: PermissionMode;
     };
@@ -161,12 +161,12 @@ export type SkillCatalogPageItem =
 export type SkillCatalogQueryInput =
   | {
       readonly kind: 'start';
-      readonly context: SkillCatalogLocalContext;
+      readonly context: SkillCatalogWorkspaceContext;
       readonly view: SkillCatalogView;
     }
   | {
       readonly kind: 'continue';
-      readonly context: SkillCatalogLocalContext;
+      readonly context: SkillCatalogWorkspaceContext;
       readonly view: SkillCatalogView;
       readonly revision: SkillCatalogRevision;
       readonly cursor: string;
@@ -240,7 +240,7 @@ export type SkillCatalogManagedUpdateMutation =
     };
 
 export interface SkillCatalogMutateInput {
-  readonly context: SkillCatalogLocalContext;
+  readonly context: SkillCatalogWorkspaceContext;
   readonly expectedRevision: SkillCatalogRevision;
   readonly mutation: SkillCatalogMutation;
 }
@@ -269,7 +269,7 @@ export type SkillCatalogMutateResult =
   | { readonly kind: 'rejected'; readonly reason: SkillCatalogMutationRejectedReason };
 
 export interface SkillCatalogPreviewUpdateInput {
-  readonly context: SkillCatalogLocalContext;
+  readonly context: SkillCatalogWorkspaceContext;
   readonly expectedRevision: SkillCatalogRevision;
   readonly ref: string;
 }
@@ -314,13 +314,16 @@ export const SKILL_CATALOG_OPERATION_SPECS = {
     SkillCatalogQueryInput,
     SkillCatalogQueryResult,
     (typeof QUERY_ERRORS)[number]
-  >({
-    mode: 'query',
-    availability: 'ready',
-    errors: QUERY_ERRORS,
-    decodeInput: decodeQueryInput,
-    decodeOutput: decodeQueryResult,
-  }),
+  >(
+    {
+      mode: 'query',
+      availability: 'ready',
+      errors: QUERY_ERRORS,
+      decodeInput: decodeQueryInput,
+      decodeOutput: decodeQueryResult,
+    },
+    (input) => input.context.workspace.kind === 'host_path',
+  ),
   'skill.catalog.invocable.query': defineHostPathOperation<
     SkillCatalogInvocableQueryInput,
     SkillCatalogInvocableQueryResult,
@@ -333,30 +336,37 @@ export const SKILL_CATALOG_OPERATION_SPECS = {
       decodeInput: decodeInvocableQueryInput,
       decodeOutput: decodeInvocableQueryResult,
     },
-    (input) => input.target.kind === 'new_session',
+    (input) =>
+      input.target.kind === 'new_session' && input.target.context.workspace.kind === 'host_path',
   ),
   'skill.catalog.mutate': defineHostPathOperation<
     SkillCatalogMutateInput,
     SkillCatalogMutateResult,
     (typeof MUTATION_ERRORS)[number]
-  >({
-    mode: 'command',
-    availability: 'ready',
-    errors: MUTATION_ERRORS,
-    decodeInput: decodeMutateInput,
-    decodeOutput: decodeMutateResult,
-  }),
+  >(
+    {
+      mode: 'command',
+      availability: 'ready',
+      errors: MUTATION_ERRORS,
+      decodeInput: decodeMutateInput,
+      decodeOutput: decodeMutateResult,
+    },
+    (input) => input.context.workspace.kind === 'host_path',
+  ),
   'skill.catalog.preview-update': defineHostPathOperation<
     SkillCatalogPreviewUpdateInput,
     SkillCatalogPreviewUpdateResult,
     (typeof QUERY_ERRORS)[number]
-  >({
-    mode: 'query',
-    availability: 'ready',
-    errors: QUERY_ERRORS,
-    decodeInput: decodePreviewInput,
-    decodeOutput: decodePreviewResult,
-  }),
+  >(
+    {
+      mode: 'query',
+      availability: 'ready',
+      errors: QUERY_ERRORS,
+      decodeInput: decodePreviewInput,
+      decodeOutput: decodePreviewResult,
+    },
+    (input) => input.context.workspace.kind === 'host_path',
+  ),
 } as const;
 
 function decodeInvocableQueryInput(value: unknown): SkillCatalogInvocableQueryInput {
@@ -794,19 +804,9 @@ function decodePreviewResult(value: unknown): SkillCatalogPreviewUpdateResult {
   return decoded;
 }
 
-function localContext(value: unknown): SkillCatalogLocalContext {
-  const record = requireExactRecord(value, 'skill catalog local context', ['projectRoot']);
-  const projectRoot = utf8String(
-    record.projectRoot,
-    'skill catalog project root',
-    PROJECT_ROOT_MAX_BYTES,
-  );
-  if (!isSkillCatalogProjectRootLexicallyAbsolute(projectRoot)) {
-    throw invalidProtocolFrame('Skill catalog project root must be absolute');
-  }
-  return {
-    projectRoot,
-  };
+function localContext(value: unknown): SkillCatalogWorkspaceContext {
+  const record = requireExactRecord(value, 'skill catalog workspace context', ['workspace']);
+  return { workspace: decodeWorkspaceTarget(record.workspace) };
 }
 
 function invocableTarget(value: unknown): SkillCatalogInvocableTarget {

--- a/packages/runtime-host/src/protocol/skill-catalog.ts
+++ b/packages/runtime-host/src/protocol/skill-catalog.ts
@@ -2,7 +2,12 @@ import { isPermissionMode, type PermissionMode } from '@maka/core/permission';
 import { requireCount, requireEntityId, requireExactRecord, requireRecord } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { defineHostPathOperation } from './operation-spec.js';
-import { decodeWorkspaceTarget, type WorkspaceTarget } from './workspace.js';
+import {
+  decodeWorkspaceProjection,
+  decodeWorkspaceTarget,
+  type WorkspaceProjection,
+  type WorkspaceTarget,
+} from './workspace.js';
 
 export const SKILL_CATALOG_PAGE_MAX_ITEMS = 128;
 export const SKILL_CATALOG_PAGE_MAX_BYTES = 48 * 1024;
@@ -172,7 +177,7 @@ export type SkillCatalogQueryInput =
       readonly cursor: string;
     };
 
-export type SkillCatalogQueryResult =
+export type SkillCatalogQueryProjection =
   | {
       readonly kind: 'page';
       readonly view: SkillCatalogView;
@@ -180,11 +185,11 @@ export type SkillCatalogQueryResult =
       readonly items: readonly SkillCatalogPageItem[];
       readonly nextCursor: string | null;
     }
-  | {
-      readonly kind: 'revision_changed';
-      readonly expectedRevision: SkillCatalogRevision;
-      readonly actualRevision: SkillCatalogRevision;
-    };
+  | SkillCatalogRevisionChanged;
+
+export type SkillCatalogQueryResult = SkillCatalogQueryProjection & {
+  readonly resolvedWorkspace: WorkspaceProjection;
+};
 
 export type SkillCatalogInvocableQueryInput =
   | {
@@ -259,7 +264,7 @@ export type SkillCatalogMutationRejectedReason =
   | 'blocked_path'
   | 'state_error';
 
-export type SkillCatalogMutateResult =
+export type SkillCatalogMutationOutcome =
   | {
       readonly kind: 'committed' | 'unchanged';
       readonly revision: SkillCatalogRevision;
@@ -267,6 +272,10 @@ export type SkillCatalogMutateResult =
     }
   | SkillCatalogRevisionConflict
   | { readonly kind: 'rejected'; readonly reason: SkillCatalogMutationRejectedReason };
+
+export type SkillCatalogMutateResult = SkillCatalogMutationOutcome & {
+  readonly resolvedWorkspace: WorkspaceProjection;
+};
 
 export interface SkillCatalogPreviewUpdateInput {
   readonly context: SkillCatalogWorkspaceContext;
@@ -287,7 +296,7 @@ export type SkillCatalogPreviewRejectedReason =
   | 'source_invalid'
   | 'metadata_error';
 
-export type SkillCatalogPreviewUpdateResult =
+export type SkillCatalogPreviewUpdateOutcome =
   | {
       readonly kind: 'preview';
       readonly revision: SkillCatalogRevision;
@@ -303,6 +312,16 @@ export type SkillCatalogPreviewUpdateResult =
   | SkillCatalogRevisionConflict
   | { readonly kind: 'rejected'; readonly reason: SkillCatalogPreviewRejectedReason };
 
+export type SkillCatalogPreviewUpdateResult = SkillCatalogPreviewUpdateOutcome & {
+  readonly resolvedWorkspace: WorkspaceProjection;
+};
+
+export interface SkillCatalogRevisionChanged {
+  readonly kind: 'revision_changed';
+  readonly expectedRevision: SkillCatalogRevision;
+  readonly actualRevision: SkillCatalogRevision;
+}
+
 export interface SkillCatalogRevisionConflict {
   readonly kind: 'revision_conflict';
   readonly expectedRevision: SkillCatalogRevision;
@@ -314,16 +333,13 @@ export const SKILL_CATALOG_OPERATION_SPECS = {
     SkillCatalogQueryInput,
     SkillCatalogQueryResult,
     (typeof QUERY_ERRORS)[number]
-  >(
-    {
-      mode: 'query',
-      availability: 'ready',
-      errors: QUERY_ERRORS,
-      decodeInput: decodeQueryInput,
-      decodeOutput: decodeQueryResult,
-    },
-    (input) => input.context.workspace.kind === 'host_path',
-  ),
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeQueryInput,
+    decodeOutput: decodeQueryResult,
+  }),
   'skill.catalog.invocable.query': defineHostPathOperation<
     SkillCatalogInvocableQueryInput,
     SkillCatalogInvocableQueryResult,
@@ -343,30 +359,24 @@ export const SKILL_CATALOG_OPERATION_SPECS = {
     SkillCatalogMutateInput,
     SkillCatalogMutateResult,
     (typeof MUTATION_ERRORS)[number]
-  >(
-    {
-      mode: 'command',
-      availability: 'ready',
-      errors: MUTATION_ERRORS,
-      decodeInput: decodeMutateInput,
-      decodeOutput: decodeMutateResult,
-    },
-    (input) => input.context.workspace.kind === 'host_path',
-  ),
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeMutateInput,
+    decodeOutput: decodeMutateResult,
+  }),
   'skill.catalog.preview-update': defineHostPathOperation<
     SkillCatalogPreviewUpdateInput,
     SkillCatalogPreviewUpdateResult,
     (typeof QUERY_ERRORS)[number]
-  >(
-    {
-      mode: 'query',
-      availability: 'ready',
-      errors: QUERY_ERRORS,
-      decodeInput: decodePreviewInput,
-      decodeOutput: decodePreviewResult,
-    },
-    (input) => input.context.workspace.kind === 'host_path',
-  ),
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodePreviewInput,
+    decodeOutput: decodePreviewResult,
+  }),
 } as const;
 
 function decodeInvocableQueryInput(value: unknown): SkillCatalogInvocableQueryInput {
@@ -431,7 +441,11 @@ function decodeQueryInput(value: unknown): SkillCatalogQueryInput {
       'context',
       'view',
     ]);
-    return { kind: 'start', context: localContext(start.context), view: catalogView(start.view) };
+    return {
+      kind: 'start',
+      context: localContext(start.context),
+      view: catalogView(start.view),
+    };
   }
   if (record.kind === 'continue') {
     const continuation = requireExactRecord(record, 'skill catalog continuation query', [
@@ -454,13 +468,29 @@ function decodeQueryInput(value: unknown): SkillCatalogQueryInput {
 
 function decodeQueryResult(value: unknown): SkillCatalogQueryResult {
   const record = requireRecord(value, 'skill catalog query result');
-  if (record.kind === 'revision_changed') return revisionChanged(record);
+  if (record.kind === 'revision_changed') {
+    const changed = requireExactRecord(record, 'skill catalog revision changed result', [
+      'kind',
+      'expectedRevision',
+      'actualRevision',
+      'resolvedWorkspace',
+    ]);
+    return {
+      ...revisionChanged({
+        kind: changed.kind,
+        expectedRevision: changed.expectedRevision,
+        actualRevision: changed.actualRevision,
+      }),
+      resolvedWorkspace: decodeWorkspaceProjection(changed.resolvedWorkspace),
+    };
+  }
   const page = requireExactRecord(record, 'skill catalog page result', [
     'kind',
     'view',
     'revision',
     'items',
     'nextCursor',
+    'resolvedWorkspace',
   ]);
   if (page.kind !== 'page' || !Array.isArray(page.items)) {
     throw invalidProtocolFrame('Invalid skill catalog page result');
@@ -478,8 +508,13 @@ function decodeQueryResult(value: unknown): SkillCatalogQueryResult {
       page.nextCursor === null
         ? null
         : utf8String(page.nextCursor, 'skill catalog next cursor', CURSOR_MAX_BYTES),
+    resolvedWorkspace: decodeWorkspaceProjection(page.resolvedWorkspace),
   };
-  assertJsonByteLimit(decoded, SKILL_CATALOG_PAGE_MAX_BYTES, 'Skill catalog page');
+  assertJsonByteLimit(
+    decoded,
+    SKILL_CATALOG_PAGE_MAX_BYTES + resolvedWorkspaceByteOverhead(decoded.resolvedWorkspace),
+    'Skill catalog page',
+  );
   return decoded;
 }
 
@@ -715,18 +750,39 @@ function mutation(value: unknown): SkillCatalogMutation {
 
 function decodeMutateResult(value: unknown): SkillCatalogMutateResult {
   const record = requireRecord(value, 'skill catalog mutate result');
-  if (record.kind === 'revision_conflict') return revisionConflict(record);
+  if (record.kind === 'revision_conflict') {
+    const conflict = requireExactRecord(record, 'skill catalog revision conflict', [
+      'kind',
+      'expectedRevision',
+      'actualRevision',
+      'resolvedWorkspace',
+    ]);
+    return {
+      ...revisionConflict({
+        kind: conflict.kind,
+        expectedRevision: conflict.expectedRevision,
+        actualRevision: conflict.actualRevision,
+      }),
+      resolvedWorkspace: decodeWorkspaceProjection(conflict.resolvedWorkspace),
+    };
+  }
   if (record.kind === 'rejected') {
     const rejected = requireExactRecord(record, 'skill catalog mutation rejected result', [
       'kind',
       'reason',
+      'resolvedWorkspace',
     ]);
-    return { kind: 'rejected', reason: mutationRejectedReason(rejected.reason) };
+    return {
+      kind: 'rejected',
+      reason: mutationRejectedReason(rejected.reason),
+      resolvedWorkspace: decodeWorkspaceProjection(rejected.resolvedWorkspace),
+    };
   }
   const result = requireExactRecord(record, 'skill catalog mutation result', [
     'kind',
     'revision',
     'entry',
+    'resolvedWorkspace',
   ]);
   if (result.kind !== 'committed' && result.kind !== 'unchanged') {
     throw invalidProtocolFrame('Invalid skill catalog mutation result kind');
@@ -735,6 +791,7 @@ function decodeMutateResult(value: unknown): SkillCatalogMutateResult {
     kind: result.kind,
     revision: sha256(result.revision, 'skill catalog revision'),
     entry: result.entry === null ? null : governanceItem(result.entry),
+    resolvedWorkspace: decodeWorkspaceProjection(result.resolvedWorkspace),
   };
 }
 
@@ -753,13 +810,33 @@ function decodePreviewInput(value: unknown): SkillCatalogPreviewUpdateInput {
 
 function decodePreviewResult(value: unknown): SkillCatalogPreviewUpdateResult {
   const record = requireRecord(value, 'skill catalog preview result');
-  if (record.kind === 'revision_conflict') return revisionConflict(record);
+  if (record.kind === 'revision_conflict') {
+    const conflict = requireExactRecord(record, 'skill catalog revision conflict', [
+      'kind',
+      'expectedRevision',
+      'actualRevision',
+      'resolvedWorkspace',
+    ]);
+    return {
+      ...revisionConflict({
+        kind: conflict.kind,
+        expectedRevision: conflict.expectedRevision,
+        actualRevision: conflict.actualRevision,
+      }),
+      resolvedWorkspace: decodeWorkspaceProjection(conflict.resolvedWorkspace),
+    };
+  }
   if (record.kind === 'rejected') {
     const rejected = requireExactRecord(record, 'skill catalog preview rejected result', [
       'kind',
       'reason',
+      'resolvedWorkspace',
     ]);
-    return { kind: 'rejected', reason: previewRejectedReason(rejected.reason) };
+    return {
+      kind: 'rejected',
+      reason: previewRejectedReason(rejected.reason),
+      resolvedWorkspace: decodeWorkspaceProjection(rejected.resolvedWorkspace),
+    };
   }
   const preview = requireExactRecord(record, 'skill catalog preview result', [
     'kind',
@@ -772,6 +849,7 @@ function decodePreviewResult(value: unknown): SkillCatalogPreviewUpdateResult {
     'summary',
     'expectedCurrentSha256',
     'expectedSourceSha256',
+    'resolvedWorkspace',
   ]);
   if (preview.kind !== 'preview') throw invalidProtocolFrame('Invalid skill catalog preview kind');
   const decoded: SkillCatalogPreviewUpdateResult = {
@@ -795,10 +873,12 @@ function decodePreviewResult(value: unknown): SkillCatalogPreviewUpdateResult {
     summary: lineSummary(preview.summary),
     expectedCurrentSha256: sha256(preview.expectedCurrentSha256, 'expected current sha256'),
     expectedSourceSha256: sha256(preview.expectedSourceSha256, 'expected source sha256'),
+    resolvedWorkspace: decodeWorkspaceProjection(preview.resolvedWorkspace),
   };
   assertJsonByteLimit(
     decoded,
-    SKILL_CATALOG_PREVIEW_RESULT_MAX_BYTES,
+    SKILL_CATALOG_PREVIEW_RESULT_MAX_BYTES +
+      resolvedWorkspaceByteOverhead(decoded.resolvedWorkspace),
     'Skill catalog preview result',
   );
   return decoded;
@@ -868,9 +948,7 @@ export function isSkillCatalogProjectRootLexicallyAbsolute(
   return /^[A-Za-z]:[\\/]/.test(value) || /^[\\/]{2}[^\\/]+[\\/][^\\/]+(?:[\\/]|$)/.test(value);
 }
 
-function revisionChanged(
-  value: unknown,
-): Extract<SkillCatalogQueryResult, { kind: 'revision_changed' }> {
+function revisionChanged(value: unknown): SkillCatalogRevisionChanged {
   const record = requireExactRecord(value, 'skill catalog revision changed result', [
     'kind',
     'expectedRevision',
@@ -1130,6 +1208,10 @@ function previewRejectedReason(value: unknown): SkillCatalogPreviewRejectedReaso
     return value;
   }
   throw invalidProtocolFrame('Invalid skill catalog preview rejection reason');
+}
+
+function resolvedWorkspaceByteOverhead(workspace: WorkspaceProjection): number {
+  return Buffer.byteLength(`,"resolvedWorkspace":${JSON.stringify(workspace)}`, 'utf8');
 }
 
 function assertJsonByteLimit(value: unknown, maxBytes: number, label: string): void {

--- a/packages/runtime-host/src/protocol/workspace.ts
+++ b/packages/runtime-host/src/protocol/workspace.ts
@@ -53,8 +53,10 @@ function isLexicallyAbsoluteHostPath(path: string): boolean {
 
 export function decodeWorkspaceProjection(value: unknown): WorkspaceProjection {
   const projection = requireExactRecord(value, 'Workspace projection', ['target', 'hostCwd']);
-  return {
-    target: decodeWorkspaceTarget(projection.target),
-    hostCwd: decodeHostPath(projection.hostCwd, 'Workspace Host cwd'),
-  };
+  const target = decodeWorkspaceTarget(projection.target);
+  const hostCwd = decodeHostPath(projection.hostCwd, 'Workspace Host cwd');
+  if (target.kind === 'host_path' && target.path !== hostCwd) {
+    throw invalidProtocolFrame('Workspace Host path does not match its cwd');
+  }
+  return { target, hostCwd };
 }

--- a/packages/runtime-host/src/protocol/workspace.ts
+++ b/packages/runtime-host/src/protocol/workspace.ts
@@ -1,0 +1,60 @@
+import { requireEntityId, requireExactRecord, requireRecord, requireUtf8String } from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+
+export const WORKSPACE_HOST_PATH_MAX_BYTES = 4 * 1024;
+
+export type WorkspaceTarget =
+  | { readonly kind: 'project'; readonly projectId: string }
+  | { readonly kind: 'host_path'; readonly path: string };
+
+export interface WorkspaceProjection {
+  readonly target: WorkspaceTarget;
+  readonly hostCwd: string;
+}
+
+export function decodeHostPath(
+  value: unknown,
+  label: string,
+  maxBytes = WORKSPACE_HOST_PATH_MAX_BYTES,
+): string {
+  const path = requireUtf8String(value, label, maxBytes);
+  if (!isLexicallyAbsoluteHostPath(path)) {
+    throw invalidProtocolFrame(`${label} must be absolute`);
+  }
+  return path;
+}
+
+export function decodeWorkspaceTarget(value: unknown): WorkspaceTarget {
+  const target = requireRecord(value, 'Workspace target');
+  if (target.kind === 'project') {
+    const exact = requireExactRecord(target, 'Project workspace target', ['kind', 'projectId']);
+    return {
+      kind: 'project',
+      projectId: requireEntityId(exact.projectId, 'Workspace project id'),
+    };
+  }
+  if (target.kind === 'host_path') {
+    const exact = requireExactRecord(target, 'Host path workspace target', ['kind', 'path']);
+    return {
+      kind: 'host_path',
+      path: decodeHostPath(exact.path, 'Workspace Host path'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid Workspace target kind');
+}
+
+function isLexicallyAbsoluteHostPath(path: string): boolean {
+  return (
+    path.startsWith('/') ||
+    /^[A-Za-z]:[\\/]/.test(path) ||
+    /^[\\/]{2}[^\\/]+[\\/][^\\/]+(?:[\\/]|$)/.test(path)
+  );
+}
+
+export function decodeWorkspaceProjection(value: unknown): WorkspaceProjection {
+  const projection = requireExactRecord(value, 'Workspace projection', ['target', 'hostCwd']);
+  return {
+    target: decodeWorkspaceTarget(projection.target),
+    hostCwd: decodeHostPath(projection.hostCwd, 'Workspace Host cwd'),
+  };
+}

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -329,7 +329,6 @@ export class RuntimeHostConnectionSession {
 
   #attachProjectCatalogChanges(): void {
     if (
-      !this.#options.connection.authority.canUseHostPaths ||
       !hasRuntimeHostOperationGrant(this.#options.connection.authority, 'project.catalog.query')
     ) {
       return;

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -137,6 +137,7 @@ import { HostRuntimePolicyCoordinator } from './runtime-policy-coordinator.js';
 import { HostRuntimeResourceCoordinator } from './runtime-resource-coordinator.js';
 import { SessionAdmissionGate } from './session-admission-gate.js';
 import { HostSessionCatalogCoordinator } from './session-catalog-coordinator.js';
+import { HostWorkspaceResolver } from './workspace-resolver.js';
 import { HostSessionRetirementCoordinator } from './session-retirement-coordinator.js';
 import { HostSessionRevisionCoordinator } from './session-revision-coordinator.js';
 import { HostSessionEffectCoordinator } from './session-effect-coordinator.js';
@@ -404,12 +405,15 @@ export async function createExecutionRuntimeHostComposition(
           initiatingConnectionId: string,
         ) => Promise<string[]>)
       | undefined;
+    const projectMembership = new HostProjectMembershipGate();
+    const workspaceResolver = new HostWorkspaceResolver(openedProjectCatalog, projectMembership);
     const skills = new HostSkillCatalogCoordinator(
       new SkillCatalogRepository({
         runWithRoot: (operation) =>
           runWithStorageRootLease(context.owner.lease, 'interactive', 'write', operation),
         ...(options.skillHomeDirectory ? { homeDirectory: options.skillHomeDirectory } : {}),
       }),
+      workspaceResolver,
       async (input, connection) => {
         if (input.target.kind === 'session') {
           const sessionId = input.target.sessionId;
@@ -427,7 +431,7 @@ export async function createExecutionRuntimeHostComposition(
         }
         const previewSessionId = `skill-catalog-preview:${connection.connectionId}`;
         return {
-          projectRoot: input.target.context.projectRoot,
+          projectRoot: (await workspaceResolver.resolve(input.target.context.workspace)).cwd,
           host: buildHostCapabilitiesFromBinding(
             await requireNewSessionToolNameResolver(resolveNewSessionToolNames)(
               previewSessionId,
@@ -442,12 +446,12 @@ export async function createExecutionRuntimeHostComposition(
     const configurationChanges = new HostConfigurationChangeService();
     const sessionCatalogChanges = new HostSessionCatalogChangeService();
     const projectCatalogChanges = new HostProjectCatalogChangeService();
-    const projectMembership = new HostProjectMembershipGate();
     const projects = new HostProjectCatalogCoordinator(
       openedProjectCatalog,
       projectCatalogChanges,
       sessionCatalogChanges,
       projectMembership,
+      workspaceResolver,
       context.requestDrain,
     );
     let rootCoordinator: RootTurnCoordinator | undefined;
@@ -1119,14 +1123,14 @@ export async function createExecutionRuntimeHostComposition(
       manager,
       admission: sessionAdmission,
       continuity: continuityCoordinator,
-      projectCatalog: openedProjectCatalog,
-      projectMembership,
+      workspaceResolver,
       requestDrain: context.requestDrain,
     });
     const externalSessions = new HostExternalSessionCoordinator({
       adapters: createExternalSessionAdapterRegistry(),
       admission: sessionAdmission,
       sessions: stores.sessionStore,
+      workspaceResolver,
       resolveTarget: () => sessionCatalog.resolveExternalSessionImportTarget(),
       prepareImportedSessionHistory: (sessionId) =>
         requireSessionManager(manager).prepareImportedSessionHistory(sessionId),

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -405,8 +405,15 @@ export async function createExecutionRuntimeHostComposition(
           initiatingConnectionId: string,
         ) => Promise<string[]>)
       | undefined;
+    const configurationChanges = new HostConfigurationChangeService();
+    const sessionCatalogChanges = new HostSessionCatalogChangeService();
+    const projectCatalogChanges = new HostProjectCatalogChangeService();
     const projectMembership = new HostProjectMembershipGate();
-    const workspaceResolver = new HostWorkspaceResolver(openedProjectCatalog, projectMembership);
+    const workspaceResolver = new HostWorkspaceResolver(
+      openedProjectCatalog,
+      projectMembership,
+      () => projectCatalogChanges.publish(),
+    );
     const skills = new HostSkillCatalogCoordinator(
       new SkillCatalogRepository({
         runWithRoot: (operation) =>
@@ -443,15 +450,11 @@ export async function createExecutionRuntimeHostComposition(
         };
       },
     );
-    const configurationChanges = new HostConfigurationChangeService();
-    const sessionCatalogChanges = new HostSessionCatalogChangeService();
-    const projectCatalogChanges = new HostProjectCatalogChangeService();
     const projects = new HostProjectCatalogCoordinator(
       openedProjectCatalog,
       projectCatalogChanges,
       sessionCatalogChanges,
       projectMembership,
-      workspaceResolver,
       context.requestDrain,
     );
     let rootCoordinator: RootTurnCoordinator | undefined;

--- a/packages/runtime-host/src/server/external-session-coordinator.ts
+++ b/packages/runtime-host/src/server/external-session-coordinator.ts
@@ -13,6 +13,7 @@ import {
   EXTERNAL_SESSION_RESULT_MAX_BYTES,
   EXTERNAL_SESSION_SOURCE_MAX_ITEMS,
   EXTERNAL_SESSION_SOURCE_SESSION_ID_MAX_BYTES,
+  type ExternalSessionCatalogItem,
   type ExternalSessionCatalogQueryInput,
   type ExternalSessionImportInput,
   type OperationError,
@@ -24,6 +25,7 @@ import {
   SessionOperationFailure,
 } from './session-catalog-coordinator.js';
 import type { SessionAdmissionGate } from './session-admission-gate.js';
+import { type HostWorkspaceResolver, WorkspaceResolutionError } from './workspace-resolver.js';
 
 type ExternalSessionStore = {
   createImportedSession(
@@ -38,6 +40,7 @@ export interface HostExternalSessionCoordinatorOptions {
   readonly adapters: ExternalSessionAdapterRegistry;
   readonly admission: SessionAdmissionGate;
   readonly sessions: ExternalSessionStore;
+  readonly workspaceResolver: Pick<HostWorkspaceResolver, 'resolve'>;
   readonly resolveTarget: () => Promise<Omit<CreateSessionInput, 'cwd' | 'name'>>;
   readonly prepareImportedSessionHistory: (sessionId: string) => Promise<void>;
   readonly discardImportedSession: (sessionId: string) => Promise<void>;
@@ -55,6 +58,7 @@ export class HostExternalSessionCoordinator {
   readonly #adapters: ExternalSessionAdapterRegistry;
   readonly #admission: SessionAdmissionGate;
   readonly #sessions: ExternalSessionStore;
+  readonly #workspaceResolver: Pick<HostWorkspaceResolver, 'resolve'>;
   readonly #resolveTarget: HostExternalSessionCoordinatorOptions['resolveTarget'];
   readonly #prepareImportedSessionHistory: HostExternalSessionCoordinatorOptions['prepareImportedSessionHistory'];
   readonly #discardImportedSession: HostExternalSessionCoordinatorOptions['discardImportedSession'];
@@ -64,6 +68,7 @@ export class HostExternalSessionCoordinator {
     this.#adapters = options.adapters;
     this.#admission = options.admission;
     this.#sessions = options.sessions;
+    this.#workspaceResolver = options.workspaceResolver;
     this.#resolveTarget = options.resolveTarget;
     this.#prepareImportedSessionHistory = options.prepareImportedSessionHistory;
     this.#discardImportedSession = options.discardImportedSession;
@@ -108,17 +113,20 @@ export class HostExternalSessionCoordinator {
       return queryFailure('operation_unavailable', 'External Session source is unavailable');
     }
     try {
+      const cwd = input.workspace
+        ? (await this.#workspaceResolver.resolve(input.workspace)).cwd
+        : undefined;
       const offset = input.cursor === undefined ? 0 : Number(input.cursor);
       const sessions = (
         await adapter.listSessions({
-          ...(input.cwd === undefined ? {} : { cwd: input.cwd }),
+          ...(cwd === undefined ? {} : { cwd }),
           ...(input.includeArchived === undefined
             ? {}
             : { includeArchived: input.includeArchived }),
         })
       )
         .map(toWireSummary)
-        .filter((summary): summary is ExternalSessionSummary => summary !== undefined);
+        .filter((summary): summary is ExternalSessionCatalogItem => summary !== undefined);
       const page = boundedCatalogPage(sessions, offset);
       const nextOffset = offset + page.length;
       return {
@@ -128,7 +136,10 @@ export class HostExternalSessionCoordinator {
           nextCursor: nextOffset < sessions.length ? String(nextOffset) : null,
         },
       };
-    } catch {
+    } catch (error) {
+      if (error instanceof WorkspaceResolutionError) {
+        return queryFailure('invalid_request', error.message);
+      }
       return queryFailure('persistence_failed', 'External Session catalog could not be read');
     }
   }
@@ -229,7 +240,7 @@ export class HostExternalSessionCoordinator {
   }
 }
 
-function toWireSummary(summary: ExternalSessionSummary): ExternalSessionSummary | undefined {
+function toWireSummary(summary: ExternalSessionSummary): ExternalSessionCatalogItem | undefined {
   if (
     !wireSourceSessionId(summary.id) ||
     typeof summary.name !== 'string' ||
@@ -244,7 +255,7 @@ function toWireSummary(summary: ExternalSessionSummary): ExternalSessionSummary 
   return {
     id: summary.id,
     name,
-    cwd: truncateUtf8(summary.cwd, EXTERNAL_SESSION_CWD_MAX_BYTES),
+    hostCwd: truncateUtf8(summary.cwd, EXTERNAL_SESSION_CWD_MAX_BYTES),
     ...(createdAt === undefined ? {} : { createdAt }),
     ...(updatedAt === undefined ? {} : { updatedAt }),
     ...(typeof summary.archived === 'boolean' ? { archived: summary.archived } : {}),
@@ -252,10 +263,10 @@ function toWireSummary(summary: ExternalSessionSummary): ExternalSessionSummary 
 }
 
 function boundedCatalogPage(
-  sessions: readonly ExternalSessionSummary[],
+  sessions: readonly ExternalSessionCatalogItem[],
   offset: number,
-): ExternalSessionSummary[] {
-  const page: ExternalSessionSummary[] = [];
+): ExternalSessionCatalogItem[] {
+  const page: ExternalSessionCatalogItem[] = [];
   const end = Math.min(sessions.length, offset + EXTERNAL_SESSION_PAGE_MAX_ITEMS);
   for (let index = offset; index < end; index += 1) {
     const candidate = sessions[index];

--- a/packages/runtime-host/src/server/project-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/project-catalog-coordinator.ts
@@ -15,6 +15,7 @@ import {
   type OperationOutcome,
   type ProjectCatalogMutateInput,
   type ProjectCatalogMutateResult,
+  type ProjectCatalogLocationQueryInput,
   type ProjectCatalogPageItem,
   type ProjectCatalogProject,
   type ProjectCatalogQueryInput,
@@ -25,10 +26,12 @@ import type { ProjectCatalogOperationHandlerMap } from './operation-dispatcher.j
 import type { HostProjectCatalogChangeService } from './project-catalog-change-service.js';
 import type { HostProjectMembershipGate } from './project-membership-gate.js';
 import type { HostSessionCatalogChangeService } from './session-catalog-change-service.js';
+import { type HostWorkspaceResolver, WorkspaceResolutionError } from './workspace-resolver.js';
 
 export class HostProjectCatalogCoordinator {
   readonly handlers: ProjectCatalogOperationHandlerMap = {
     'project.catalog.query': (input) => this.#query(input),
+    'project.catalog.location.query': (input) => this.#queryLocation(input),
     'project.catalog.mutate': (input) => this.#mutate(input),
   };
 
@@ -37,6 +40,7 @@ export class HostProjectCatalogCoordinator {
     private readonly projectChanges: HostProjectCatalogChangeService,
     private readonly sessionChanges: HostSessionCatalogChangeService,
     private readonly membership: HostProjectMembershipGate,
+    private readonly workspaceResolver: Pick<HostWorkspaceResolver, 'run'>,
     private readonly requestDrain: () => void,
   ) {}
 
@@ -98,40 +102,61 @@ export class HostProjectCatalogCoordinator {
     }
   }
 
+  async #queryLocation(
+    input: ProjectCatalogLocationQueryInput,
+  ): Promise<OperationOutcome<'project.catalog.location.query'>> {
+    try {
+      return await this.workspaceResolver.run(
+        { kind: 'project', projectId: input.projectId },
+        async (workspace) => {
+          if (workspace.projectId === null) {
+            throw new Error('Project workspace resolution returned a Host path');
+          }
+          return {
+            ok: true,
+            result: {
+              projectId: workspace.projectId,
+              locations: workspace.project.locations.map(({ path, isWorktree }) => ({
+                path,
+                isWorktree,
+              })),
+              preferredPath: workspace.cwd,
+            },
+          };
+        },
+      );
+    } catch (error) {
+      if (error instanceof WorkspaceResolutionError) {
+        return locationFailure(
+          error.code === 'not_found' ? 'not_found' : 'operation_conflict',
+          error.message,
+        );
+      }
+      return locationFailure('persistence_failed', 'Project catalog is unavailable');
+    }
+  }
+
   async #applyMutation(input: ProjectCatalogMutateInput): Promise<ProjectCatalogMutateResult> {
     switch (input.kind) {
       case 'register':
-        return projectResult((await this.catalog.register(input.path)).id);
-      case 'select': {
-        const selected = await this.catalog.select(input.projectId);
-        return {
-          kind: 'selection',
-          projectId: selected.project.id,
-          path: selected.path,
-        };
-      }
-      case 'touch':
-        return projectResult(
-          (await this.catalog.touch(input.projectId, input.path === null ? undefined : input.path))
-            .id,
-        );
+        return projectResult(await this.catalog.register(input.path));
       case 'relink': {
         const result = await this.catalog.relinkWithSessions(input.projectId, input.path);
         for (const sessionId of result.updatedSessionIds) this.sessionChanges.publish(sessionId);
-        return projectResult(result.project.id);
+        return projectResult(result.project);
       }
       case 'rename':
-        return projectResult((await this.catalog.rename(input.projectId, input.name)).id);
+        return projectResult(await this.catalog.rename(input.projectId, input.name));
       case 'archive':
-        return projectResult((await this.catalog.archive(input.projectId)).id);
+        return projectResult(await this.catalog.archive(input.projectId));
       case 'restore':
-        return projectResult((await this.catalog.restore(input.projectId)).id);
+        return projectResult(await this.catalog.restore(input.projectId));
     }
   }
 }
 
-function projectResult(projectId: string): ProjectCatalogMutateResult {
-  return { kind: 'project', projectId };
+function projectResult(project: ProjectRecord): ProjectCatalogMutateResult {
+  return { kind: 'project', project: projectProject(project) };
 }
 
 function projectProject(project: ProjectRecord): ProjectCatalogProject {
@@ -139,10 +164,9 @@ function projectProject(project: ProjectRecord): ProjectCatalogProject {
     id: project.id,
     aliases: [...(project.aliases ?? [])],
     name: project.name,
-    locations: project.locations.map((location) => ({ ...location })),
+    locationCount: project.locations.length,
     archivedAt: project.archivedAt ?? null,
     available: project.available,
-    preferredPath: project.preferredPath ?? null,
   });
 }
 
@@ -154,22 +178,15 @@ function projectCatalogItems(projects: readonly ProjectCatalogProject[]): Projec
       id: project.id,
       name: project.name,
       aliasCount: project.aliases.length,
-      locationCount: project.locations.length,
+      locationCount: project.locationCount,
       archivedAt: project.archivedAt,
       available: project.available,
-      preferredPath: project.preferredPath,
     },
     ...project.aliases.map((alias, itemIndex) => ({
       kind: 'alias' as const,
       projectIndex,
       itemIndex,
       alias,
-    })),
-    ...project.locations.map((location, itemIndex) => ({
-      kind: 'location' as const,
-      projectIndex,
-      itemIndex,
-      location,
     })),
   ]);
 }
@@ -248,6 +265,13 @@ function queryFailure(
   code: 'invalid_request' | 'persistence_failed',
   message: string,
 ): OperationOutcome<'project.catalog.query'> {
+  return { ok: false, error: { code, message } };
+}
+
+function locationFailure(
+  code: 'not_found' | 'operation_conflict' | 'persistence_failed',
+  message: string,
+): OperationOutcome<'project.catalog.location.query'> {
   return { ok: false, error: { code, message } };
 }
 

--- a/packages/runtime-host/src/server/project-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/project-catalog-coordinator.ts
@@ -15,23 +15,21 @@ import {
   type OperationOutcome,
   type ProjectCatalogMutateInput,
   type ProjectCatalogMutateResult,
-  type ProjectCatalogLocationQueryInput,
   type ProjectCatalogPageItem,
   type ProjectCatalogProject,
   type ProjectCatalogQueryInput,
   type ProjectCatalogQueryResult,
   type ProjectCatalogRevision,
+  type ProjectCatalogView,
 } from '../protocol/index.js';
 import type { ProjectCatalogOperationHandlerMap } from './operation-dispatcher.js';
 import type { HostProjectCatalogChangeService } from './project-catalog-change-service.js';
 import type { HostProjectMembershipGate } from './project-membership-gate.js';
 import type { HostSessionCatalogChangeService } from './session-catalog-change-service.js';
-import { type HostWorkspaceResolver, WorkspaceResolutionError } from './workspace-resolver.js';
 
 export class HostProjectCatalogCoordinator {
   readonly handlers: ProjectCatalogOperationHandlerMap = {
     'project.catalog.query': (input) => this.#query(input),
-    'project.catalog.location.query': (input) => this.#queryLocation(input),
     'project.catalog.mutate': (input) => this.#mutate(input),
   };
 
@@ -40,7 +38,6 @@ export class HostProjectCatalogCoordinator {
     private readonly projectChanges: HostProjectCatalogChangeService,
     private readonly sessionChanges: HostSessionCatalogChangeService,
     private readonly membership: HostProjectMembershipGate,
-    private readonly workspaceResolver: Pick<HostWorkspaceResolver, 'run'>,
     private readonly requestDrain: () => void,
   ) {}
 
@@ -48,12 +45,13 @@ export class HostProjectCatalogCoordinator {
     input: ProjectCatalogQueryInput,
   ): Promise<OperationOutcome<'project.catalog.query'>> {
     try {
-      const projects = (await this.catalog.list()).map(projectProject);
-      const items = projectCatalogItems(projects);
+      const records = await this.catalog.list();
+      const items = projectCatalogItems(records, input.view);
       const revision = catalogRevision(items);
       if (input.kind === 'list_continue' && input.revision !== revision) {
         return successQuery({
           kind: 'revision_changed',
+          view: input.view,
           expected: input.revision,
           actual: revision,
         });
@@ -66,7 +64,7 @@ export class HostProjectCatalogCoordinator {
       ) {
         return queryFailure('invalid_request', 'Project catalog cursor is invalid');
       }
-      return successQuery(createPage(revision, projects.length, items, offset));
+      return successQuery(createPage(input.view, revision, records.length, items, offset));
     } catch {
       return queryFailure('persistence_failed', 'Project catalog is unavailable');
     }
@@ -99,40 +97,6 @@ export class HostProjectCatalogCoordinator {
         'commit_outcome_unknown',
         'Project catalog mutation outcome is unknown',
       );
-    }
-  }
-
-  async #queryLocation(
-    input: ProjectCatalogLocationQueryInput,
-  ): Promise<OperationOutcome<'project.catalog.location.query'>> {
-    try {
-      return await this.workspaceResolver.run(
-        { kind: 'project', projectId: input.projectId },
-        async (workspace) => {
-          if (workspace.projectId === null) {
-            throw new Error('Project workspace resolution returned a Host path');
-          }
-          return {
-            ok: true,
-            result: {
-              projectId: workspace.projectId,
-              locations: workspace.project.locations.map(({ path, isWorktree }) => ({
-                path,
-                isWorktree,
-              })),
-              preferredPath: workspace.cwd,
-            },
-          };
-        },
-      );
-    } catch (error) {
-      if (error instanceof WorkspaceResolutionError) {
-        return locationFailure(
-          error.code === 'not_found' ? 'not_found' : 'operation_conflict',
-          error.message,
-        );
-      }
-      return locationFailure('persistence_failed', 'Project catalog is unavailable');
     }
   }
 
@@ -170,25 +134,46 @@ function projectProject(project: ProjectRecord): ProjectCatalogProject {
   });
 }
 
-function projectCatalogItems(projects: readonly ProjectCatalogProject[]): ProjectCatalogPageItem[] {
-  return projects.flatMap((project, projectIndex): ProjectCatalogPageItem[] => [
-    {
-      kind: 'project',
-      projectIndex,
-      id: project.id,
-      name: project.name,
-      aliasCount: project.aliases.length,
-      locationCount: project.locationCount,
-      archivedAt: project.archivedAt,
-      available: project.available,
-    },
-    ...project.aliases.map((alias, itemIndex) => ({
-      kind: 'alias' as const,
-      projectIndex,
-      itemIndex,
-      alias,
-    })),
-  ]);
+function projectCatalogItems(
+  records: readonly ProjectRecord[],
+  view: ProjectCatalogView,
+): ProjectCatalogPageItem[] {
+  return records.flatMap((record, projectIndex): ProjectCatalogPageItem[] => {
+    const project = projectProject(record);
+    const preferredLocationIndex = record.preferredPath
+      ? record.locations.findIndex((location) => location.path === record.preferredPath)
+      : -1;
+    if (record.preferredPath && preferredLocationIndex < 0) {
+      throw new Error('Project preferred location is missing from its catalog record');
+    }
+    return [
+      {
+        kind: 'project',
+        projectIndex,
+        id: project.id,
+        name: project.name,
+        aliasCount: project.aliases.length,
+        locationCount: project.locationCount,
+        preferredLocationIndex: preferredLocationIndex < 0 ? null : preferredLocationIndex,
+        archivedAt: project.archivedAt,
+        available: project.available,
+      },
+      ...project.aliases.map((alias, itemIndex) => ({
+        kind: 'alias' as const,
+        projectIndex,
+        itemIndex,
+        alias,
+      })),
+      ...(view === 'summary'
+        ? []
+        : record.locations.map((location, itemIndex) => ({
+            kind: 'location' as const,
+            projectIndex,
+            itemIndex,
+            location: { path: location.path, isWorktree: location.isWorktree },
+          }))),
+    ];
+  });
 }
 
 function catalogRevision(items: readonly ProjectCatalogPageItem[]): ProjectCatalogRevision {
@@ -196,6 +181,7 @@ function catalogRevision(items: readonly ProjectCatalogPageItem[]): ProjectCatal
 }
 
 function createPage(
+  view: ProjectCatalogView,
   revision: ProjectCatalogRevision,
   projectCount: number,
   items: readonly ProjectCatalogPageItem[],
@@ -209,6 +195,7 @@ function createPage(
     const nextOffset = index + 1;
     const candidate: ProjectCatalogQueryResult = {
       kind: 'page',
+      view,
       revision,
       projectCount,
       items: [...pageItems, item],
@@ -223,6 +210,7 @@ function createPage(
   const nextOffset = offset + pageItems.length;
   return {
     kind: 'page',
+    view,
     revision,
     projectCount,
     items: pageItems,
@@ -265,13 +253,6 @@ function queryFailure(
   code: 'invalid_request' | 'persistence_failed',
   message: string,
 ): OperationOutcome<'project.catalog.query'> {
-  return { ok: false, error: { code, message } };
-}
-
-function locationFailure(
-  code: 'not_found' | 'operation_conflict' | 'persistence_failed',
-  message: string,
-): OperationOutcome<'project.catalog.location.query'> {
   return { ok: false, error: { code, message } };
 }
 

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -1,6 +1,4 @@
 import { createHash } from 'node:crypto';
-import { realpath, stat } from 'node:fs/promises';
-import { isAbsolute, resolve } from 'node:path';
 import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
 import { thinkingVariantsForConnection } from '@maka/core/model-thinking';
 import {
@@ -9,7 +7,6 @@ import {
   type ExecutionBoundarySummary,
 } from '@maka/core/sandbox-boundary';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
-import type { ProjectCatalog } from '@maka/storage';
 import { DEFAULT_SESSION_NAME, normalizeUserSessionName } from '@maka/core/session-name';
 import {
   isSessionStartModeLabel as isExecutionSemanticLabel,
@@ -49,7 +46,7 @@ import {
   type SessionCatalogRevision,
   type SessionConfigurationUpdateInput,
   type SessionCreateInput,
-  type SessionCwdRelocateInput,
+  type SessionWorkspaceRelocateInput,
   type SessionExecutionBoundaryQueryInput,
   type SessionMetadataUpdateInput,
   type SessionModelTarget,
@@ -57,9 +54,13 @@ import {
   type SessionUpdateResult,
 } from '../protocol/index.js';
 import type { SessionCatalogOperationHandlerMap } from './operation-dispatcher.js';
-import type { HostProjectMembershipGate } from './project-membership-gate.js';
 import { type SessionAdmissionLease, SessionAdmissionGate } from './session-admission-gate.js';
 import type { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
+import {
+  type HostWorkspaceResolver,
+  type ResolvedWorkspace,
+  WorkspaceResolutionError,
+} from './workspace-resolver.js';
 
 type SessionCatalogStores = Pick<
   ExecutionStoresWriter<'interactive'>['sessionStore'],
@@ -107,8 +108,7 @@ export interface HostSessionCatalogCoordinatorOptions {
   readonly manager: SessionConfigurationAuthority;
   readonly admission: SessionAdmissionGate;
   readonly continuity: SessionContinuity;
-  readonly projectCatalog: ProjectCatalog;
-  readonly projectMembership: HostProjectMembershipGate;
+  readonly workspaceResolver: HostWorkspaceResolver;
   readonly requestDrain: () => void;
 }
 
@@ -124,7 +124,7 @@ export class HostSessionCatalogCoordinator {
     'session.create': (input) => this.#create(input),
     'session.metadata.update': (input) => this.#updateMetadata(input),
     'session.configuration.update': (input) => this.#updateConfiguration(input),
-    'session.cwd.relocate': (input) => this.#relocateCwd(input),
+    'session.workspace.relocate': (input) => this.#relocateWorkspace(input),
     'session.read_marker.set': (input) => this.#setReadMarker(input),
     'session.execution_boundary.query': (input) => this.#queryExecutionBoundary(input),
   };
@@ -134,8 +134,7 @@ export class HostSessionCatalogCoordinator {
   readonly #manager: SessionConfigurationAuthority;
   readonly #admission: SessionAdmissionGate;
   readonly #continuity: SessionContinuity;
-  readonly #projectCatalog: ProjectCatalog;
-  readonly #projectMembership: HostProjectMembershipGate;
+  readonly #workspaceResolver: HostWorkspaceResolver;
   readonly #requestDrain: () => void;
 
   constructor(options: HostSessionCatalogCoordinatorOptions) {
@@ -144,8 +143,7 @@ export class HostSessionCatalogCoordinator {
     this.#manager = options.manager;
     this.#admission = options.admission;
     this.#continuity = options.continuity;
-    this.#projectCatalog = options.projectCatalog;
-    this.#projectMembership = options.projectMembership;
+    this.#workspaceResolver = options.workspaceResolver;
     this.#requestDrain = options.requestDrain;
   }
 
@@ -238,64 +236,66 @@ export class HostSessionCatalogCoordinator {
     return this.#admission.run(input.sessionId, async (lease) => {
       let commitAttempted = false;
       try {
-        const probe = await this.#stores.probeStableSessionCreate(
-          input.sessionId,
-          prepared.requestFingerprint,
-        );
-        if (probe.kind === 'existing') {
-          return createSuccess(
-            projectSessionCatalogRecord(await this.#stores.readCatalogRecord(input.sessionId)),
-          );
-        }
-        if (probe.kind === 'conflict') {
-          return createFailure(
-            'operation_conflict',
-            'Session identity belongs to a different create request',
-          );
-        }
-        const [model, policy] = await Promise.all([
-          this.#resolveModel(input.modelTarget, input.thinkingLevel),
-          this.#readRuntimePolicy(),
-        ]);
-        const result = await this.#projectMembership.run(async () => {
-          const workspace = await resolveSessionProjectWorkspace(
-            this.#projectCatalog,
-            prepared.cwd,
-            input.projectId,
-          );
-          const createInput: CreateSessionInput = {
-            cwd: workspace.cwd,
-            ...(workspace.projectId !== undefined ? { projectId: workspace.projectId } : {}),
-            name: prepared.name,
-            labels: [...prepared.labels],
-            backend: 'ai-sdk',
-            llmConnectionSlug: model.connectionSlug,
-            model: model.model,
-            ...(input.thinkingLevel === undefined ? {} : { thinkingLevel: input.thinkingLevel }),
-            permissionMode: prepared.permissionMode ?? policy.policy.chatDefaults.permissionMode,
-            collaborationMode: input.collaborationMode ?? 'agent',
-            orchestrationMode: input.orchestrationMode ?? 'default',
-          };
-          commitAttempted = true;
-          return this.#stores.createStableSession({
-            sessionId: input.sessionId,
-            requestFingerprint: prepared.requestFingerprint,
-            input: createInput,
-          });
-        });
-        if (result.kind === 'conflict') {
-          return createFailure(
-            'operation_conflict',
-            'Session identity belongs to a different create request',
-          );
-        }
-        await this.#continuity.refreshCanonical(input.sessionId, lease);
-        return createSuccess(
-          projectSessionCatalogRecord(await this.#stores.readCatalogRecord(input.sessionId)),
+        return await this.#workspaceResolver.runWithUsageRecorded(
+          input.workspace,
+          async (workspace) => {
+            const requestFingerprint = createRequestFingerprint(input, prepared, workspace);
+            const probe = await this.#stores.probeStableSessionCreate(
+              input.sessionId,
+              requestFingerprint,
+            );
+            if (probe.kind === 'existing') {
+              return createSuccess(
+                projectSessionCatalogRecord(await this.#stores.readCatalogRecord(input.sessionId)),
+              );
+            }
+            if (probe.kind === 'conflict') {
+              return createFailure(
+                'operation_conflict',
+                'Session identity belongs to a different create request',
+              );
+            }
+            const [model, policy] = await Promise.all([
+              this.#resolveModel(input.modelTarget, input.thinkingLevel),
+              this.#readRuntimePolicy(),
+            ]);
+            const createInput: CreateSessionInput = {
+              cwd: workspace.cwd,
+              ...(workspace.projectId === null ? {} : { projectId: workspace.projectId }),
+              name: prepared.name,
+              labels: [...prepared.labels],
+              backend: 'ai-sdk',
+              llmConnectionSlug: model.connectionSlug,
+              model: model.model,
+              ...(input.thinkingLevel === undefined ? {} : { thinkingLevel: input.thinkingLevel }),
+              permissionMode: prepared.permissionMode ?? policy.policy.chatDefaults.permissionMode,
+              collaborationMode: input.collaborationMode ?? 'agent',
+              orchestrationMode: input.orchestrationMode ?? 'default',
+            };
+            commitAttempted = true;
+            const result = await this.#stores.createStableSession({
+              sessionId: input.sessionId,
+              requestFingerprint,
+              input: createInput,
+            });
+            if (result.kind === 'conflict') {
+              return createFailure(
+                'operation_conflict',
+                'Session identity belongs to a different create request',
+              );
+            }
+            await this.#continuity.refreshCanonical(input.sessionId, lease);
+            return createSuccess(
+              projectSessionCatalogRecord(await this.#stores.readCatalogRecord(input.sessionId)),
+            );
+          },
         );
       } catch (error) {
-        if (error instanceof SessionOperationFailure) {
-          return createFailure(error.code, error.message);
+        if (error instanceof SessionOperationFailure || error instanceof WorkspaceResolutionError) {
+          return createFailure(
+            error.code === 'not_found' ? 'operation_conflict' : error.code,
+            error.message,
+          );
         }
         this.#requestDrain();
         if (!commitAttempted) {
@@ -323,7 +323,6 @@ export class HostSessionCatalogCoordinator {
           ...(input.patch.name === undefined ? {} : normalizeSessionNamePatch(input.patch.name)),
           ...(labels === undefined ? {} : { labels }),
           ...(input.patch.isFlagged === undefined ? {} : { isFlagged: input.patch.isFlagged }),
-          ...(input.patch.projectId === undefined ? {} : { projectId: input.patch.projectId }),
         };
         await this.#stores.updateHeaderVersioned(input.sessionId, patch, input.expectedRevision);
         return updateSuccess(await this.#committedUpdate(input.sessionId, lease));
@@ -422,49 +421,45 @@ export class HostSessionCatalogCoordinator {
     });
   }
 
-  async #relocateCwd(
-    input: SessionCwdRelocateInput,
-  ): Promise<OperationOutcome<'session.cwd.relocate'>> {
-    let cwd: string;
-    try {
-      if (!isAbsolute(input.cwd)) {
-        throw new SessionOperationFailure('invalid_request', 'Session cwd must be absolute');
-      }
-      cwd = await canonicalSessionDirectory(input.cwd);
-    } catch (error) {
-      return cwdFailure(
-        error instanceof SessionOperationFailure ? error.code : 'invalid_request',
-        error instanceof Error ? error.message : 'Session cwd is invalid',
-      );
-    }
+  async #relocateWorkspace(
+    input: SessionWorkspaceRelocateInput,
+  ): Promise<OperationOutcome<'session.workspace.relocate'>> {
     return this.#admission.run(input.sessionId, async (lease) => {
       let commitAttempted = false;
       try {
         const current = await this.#stores.readHeaderRecordSnapshot(input.sessionId);
         if (current.revision !== input.expectedRevision) {
-          return cwdSuccess(revisionConflict(input.expectedRevision, current.revision));
+          return workspaceSuccess(revisionConflict(input.expectedRevision, current.revision));
         }
-        commitAttempted = true;
-        await this.#manager.relocateSessionWorkspace(input.sessionId, {
-          expectedRevision: input.expectedRevision,
-          cwd,
-          ...(input.projectId === undefined ? {} : { projectId: input.projectId }),
+        await this.#workspaceResolver.run(input.workspace, async (workspace) => {
+          commitAttempted = true;
+          await this.#manager.relocateSessionWorkspace(input.sessionId, {
+            expectedRevision: input.expectedRevision,
+            cwd: workspace.cwd,
+            projectId: workspace.projectId,
+          });
         });
-        return cwdSuccess(await this.#committedUpdate(input.sessionId, lease));
+        return workspaceSuccess(await this.#committedUpdate(input.sessionId, lease));
       } catch (error) {
-        if (isNotFound(error)) return cwdFailure('not_found', 'Session does not exist');
+        if (isNotFound(error)) return workspaceFailure('not_found', 'Session does not exist');
         if (error instanceof SessionConfigurationRevisionConflictError) {
-          return cwdSuccess(revisionConflict(input.expectedRevision, error.actualRevision));
+          return workspaceSuccess(revisionConflict(input.expectedRevision, error.actualRevision));
         }
         if (error instanceof SessionConfigurationTransitionError) {
-          return cwdFailure(error.code, error.message);
+          return workspaceFailure(error.code, error.message);
+        }
+        if (error instanceof SessionOperationFailure || error instanceof WorkspaceResolutionError) {
+          return workspaceFailure(error.code, error.message);
         }
         if (!commitAttempted) {
           this.#requestDrain();
-          return cwdFailure('persistence_failed', 'Session workspace authority is unavailable');
+          return workspaceFailure(
+            'persistence_failed',
+            'Session workspace authority is unavailable',
+          );
         }
         this.#requestDrain();
-        return cwdFailure(
+        return workspaceFailure(
           'commit_outcome_unknown',
           'Session workspace relocation outcome is unknown',
         );
@@ -707,41 +702,12 @@ function sessionConfigurationMatches(
 }
 
 interface PreparedSessionCreate {
-  readonly cwd: string;
   readonly name: string;
   readonly labels: readonly string[];
   readonly permissionMode?: SessionCreateInput['permissionMode'];
-  readonly requestFingerprint: string;
-}
-
-async function resolveSessionProjectWorkspace(
-  catalog: Pick<ProjectCatalog, 'list'>,
-  cwd: string,
-  projectId: string | null | undefined,
-): Promise<{ readonly cwd: string; readonly projectId?: string | null }> {
-  if (typeof projectId !== 'string') {
-    return { cwd, ...(projectId === undefined ? {} : { projectId }) };
-  }
-  const project = (await catalog.list()).find(
-    (candidate) => candidate.id === projectId || candidate.aliases?.includes(projectId),
-  );
-  if (!project) {
-    throw new SessionOperationFailure('operation_conflict', `Project does not exist: ${projectId}`);
-  }
-  if (project.archivedAt !== undefined) {
-    throw new SessionOperationFailure('operation_conflict', `Project is archived: ${projectId}`);
-  }
-  const resolved = project.preferredPath;
-  if (!project.available || !resolved) {
-    throw new SessionOperationFailure('operation_conflict', `Project is unavailable: ${projectId}`);
-  }
-  return { cwd: resolved, projectId: project.id };
 }
 
 async function prepareCreate(input: SessionCreateInput): Promise<PreparedSessionCreate> {
-  if (!isAbsolute(input.cwd)) {
-    throw new SessionOperationFailure('invalid_request', 'Session cwd must be absolute');
-  }
   if (input.labels?.some(isExecutionSemanticLabel)) {
     throw new SessionOperationFailure(
       'invalid_request',
@@ -755,37 +721,38 @@ async function prepareCreate(input: SessionCreateInput): Promise<PreparedSession
       'Session creation requires a declared mode for explore permission',
     );
   }
-  const cwd =
-    typeof input.projectId === 'string'
-      ? resolve(input.cwd)
-      : await canonicalSessionDirectory(input.cwd);
   const name = normalizedSessionName(mode?.name ?? input.name ?? DEFAULT_SESSION_NAME);
   const labels = [...(input.labels ?? []), ...(mode?.labels ?? [])];
   const permissionMode = mode?.permissionMode ?? input.permissionMode;
-  const identity = [
-    'session.create.v1',
-    input.sessionId,
-    cwd,
-    Object.hasOwn(input, 'projectId') ? ['project', input.projectId] : ['omitted'],
+  return {
     name,
     labels,
+    ...(permissionMode === undefined ? {} : { permissionMode }),
+  };
+}
+
+function createRequestFingerprint(
+  input: SessionCreateInput,
+  prepared: PreparedSessionCreate,
+  workspace: ResolvedWorkspace,
+): string {
+  const identity = [
+    'session.create.v2',
+    input.sessionId,
+    workspace.target.kind === 'project'
+      ? ['project', workspace.target.projectId]
+      : ['host_path', workspace.target.path],
+    prepared.name,
+    prepared.labels,
     input.modelTarget.kind === 'default'
       ? ['default']
       : ['explicit', input.modelTarget.connectionSlug, input.modelTarget.model],
     input.thinkingLevel ?? null,
-    permissionMode ?? ['runtime_default'],
+    prepared.permissionMode ?? ['runtime_default'],
     input.collaborationMode ?? 'agent',
     input.orchestrationMode ?? 'default',
   ];
-  return {
-    cwd,
-    name,
-    labels,
-    ...(permissionMode === undefined ? {} : { permissionMode }),
-    requestFingerprint: `sha256:${createHash('sha256')
-      .update(JSON.stringify(identity))
-      .digest('hex')}`,
-  };
+  return `sha256:${createHash('sha256').update(JSON.stringify(identity)).digest('hex')}`;
 }
 
 export function projectSessionCatalogRecord(record: SessionCatalogRecord): SessionCatalogItem {
@@ -794,8 +761,13 @@ export function projectSessionCatalogRecord(record: SessionCatalogRecord): Sessi
   const projection: SessionCatalogProjection = {
     id: header.id,
     revision: record.revision,
-    cwd: header.cwd,
-    ...(header.projectId !== undefined ? { projectId: header.projectId } : {}),
+    workspace: {
+      target:
+        typeof header.projectId === 'string'
+          ? { kind: 'project', projectId: header.projectId }
+          : { kind: 'host_path', path: header.cwd },
+      hostCwd: header.cwd,
+    },
     createdAt: header.createdAt,
     lastUsedAt: header.lastUsedAt,
     name: header.name,
@@ -1027,16 +999,6 @@ function catalogActivityAt(header: SessionHeader): number {
   return header.lastMessageAt ?? header.lastUsedAt ?? header.createdAt;
 }
 
-async function canonicalSessionDirectory(path: string): Promise<string> {
-  try {
-    const canonical = await realpath(resolve(path));
-    if ((await stat(canonical)).isDirectory()) return canonical;
-  } catch {
-    // Project a stable request error below.
-  }
-  throw new SessionOperationFailure('invalid_request', 'Session cwd is not an existing directory');
-}
-
 function normalizedSessionName(name: string): string {
   const normalized = normalizeUserSessionName(name);
   if (!normalized.ok) throw new SessionOperationFailure('invalid_request', normalized.error);
@@ -1093,7 +1055,9 @@ function configurationSuccess(
   return { ok: true, result };
 }
 
-function cwdSuccess(result: SessionUpdateResult): OperationOutcome<'session.cwd.relocate'> {
+function workspaceSuccess(
+  result: SessionUpdateResult,
+): OperationOutcome<'session.workspace.relocate'> {
   return { ok: true, result };
 }
 
@@ -1141,10 +1105,10 @@ function configurationFailure(
   return { ok: false, error: { code, message } };
 }
 
-function cwdFailure(
-  code: OperationError<'session.cwd.relocate'>['code'],
+function workspaceFailure(
+  code: OperationError<'session.workspace.relocate'>['code'],
   message: string,
-): Extract<OperationOutcome<'session.cwd.relocate'>, { readonly ok: false }> {
+): Extract<OperationOutcome<'session.workspace.relocate'>, { readonly ok: false }> {
   return { ok: false, error: { code, message } };
 }
 

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -56,11 +56,7 @@ import {
 import type { SessionCatalogOperationHandlerMap } from './operation-dispatcher.js';
 import { type SessionAdmissionLease, SessionAdmissionGate } from './session-admission-gate.js';
 import type { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
-import {
-  type HostWorkspaceResolver,
-  type ResolvedWorkspace,
-  WorkspaceResolutionError,
-} from './workspace-resolver.js';
+import { type HostWorkspaceResolver, WorkspaceResolutionError } from './workspace-resolver.js';
 
 type SessionCatalogStores = Pick<
   ExecutionStoresWriter<'interactive'>['sessionStore'],
@@ -235,26 +231,26 @@ export class HostSessionCatalogCoordinator {
 
     return this.#admission.run(input.sessionId, async (lease) => {
       let commitAttempted = false;
+      const requestFingerprint = createRequestFingerprint(input, prepared);
       try {
+        const probe = await this.#stores.probeStableSessionCreate(
+          input.sessionId,
+          requestFingerprint,
+        );
+        if (probe.kind === 'existing') {
+          return createSuccess(
+            projectSessionCatalogRecord(await this.#stores.readCatalogRecord(input.sessionId)),
+          );
+        }
+        if (probe.kind === 'conflict') {
+          return createFailure(
+            'operation_conflict',
+            'Session identity belongs to a different create request',
+          );
+        }
         return await this.#workspaceResolver.runWithUsageRecorded(
           input.workspace,
           async (workspace) => {
-            const requestFingerprint = createRequestFingerprint(input, prepared, workspace);
-            const probe = await this.#stores.probeStableSessionCreate(
-              input.sessionId,
-              requestFingerprint,
-            );
-            if (probe.kind === 'existing') {
-              return createSuccess(
-                projectSessionCatalogRecord(await this.#stores.readCatalogRecord(input.sessionId)),
-              );
-            }
-            if (probe.kind === 'conflict') {
-              return createFailure(
-                'operation_conflict',
-                'Session identity belongs to a different create request',
-              );
-            }
             const [model, policy] = await Promise.all([
               this.#resolveModel(input.modelTarget, input.thinkingLevel),
               this.#readRuntimePolicy(),
@@ -734,14 +730,13 @@ async function prepareCreate(input: SessionCreateInput): Promise<PreparedSession
 function createRequestFingerprint(
   input: SessionCreateInput,
   prepared: PreparedSessionCreate,
-  workspace: ResolvedWorkspace,
 ): string {
   const identity = [
-    'session.create.v2',
+    'session.create.v3',
     input.sessionId,
-    workspace.target.kind === 'project'
-      ? ['project', workspace.target.projectId]
-      : ['host_path', workspace.target.path],
+    input.workspace.kind === 'project'
+      ? ['project', input.workspace.projectId]
+      : ['host_path', input.workspace.path],
     prepared.name,
     prepared.labels,
     input.modelTarget.kind === 'default'

--- a/packages/runtime-host/src/server/skill-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/skill-catalog-coordinator.ts
@@ -4,6 +4,7 @@ import type {
   SkillCatalogMutateInput,
   SkillCatalogPreviewUpdateInput,
   SkillCatalogQueryInput,
+  WorkspaceProjection,
 } from '../protocol/index.js';
 import type { ConnectionContext, SkillCatalogOperationHandlerMap } from './operation-dispatcher.js';
 import type { HostCapabilities } from '@maka/runtime';
@@ -17,7 +18,11 @@ import {
   type SkillCatalogRepositoryPreviewUpdateInput,
   type SkillCatalogRepositoryQueryInput,
 } from './skill-catalog-repository.js';
-import { type HostWorkspaceResolver, WorkspaceResolutionError } from './workspace-resolver.js';
+import {
+  type HostWorkspaceResolver,
+  type ResolvedWorkspace,
+  WorkspaceResolutionError,
+} from './workspace-resolver.js';
 
 type CatalogOperation =
   | 'skill.catalog.query'
@@ -67,8 +72,13 @@ export class HostSkillCatalogCoordinator {
 
   query(input: SkillCatalogQueryInput): Promise<OperationOutcome<'skill.catalog.query'>> {
     return this.#admitProtocolOperation('skill.catalog.query', () =>
-      this.#workspaceResolver.run(input.context.workspace, (workspace) =>
-        this.#repository.query(repositoryQueryInput(input), { projectRoot: workspace.cwd }),
+      this.#workspaceResolver.run(input.context.workspace, async (workspace) =>
+        withResolvedWorkspace(
+          await this.#repository.query(repositoryQueryInput(input), {
+            projectRoot: workspace.cwd,
+          }),
+          workspace,
+        ),
       ),
     );
   }
@@ -98,8 +108,13 @@ export class HostSkillCatalogCoordinator {
 
   mutate(input: SkillCatalogMutateInput): Promise<OperationOutcome<'skill.catalog.mutate'>> {
     return this.#admitProtocolOperation('skill.catalog.mutate', () =>
-      this.#workspaceResolver.run(input.context.workspace, (workspace) =>
-        this.#repository.mutate(repositoryMutateInput(input), { projectRoot: workspace.cwd }),
+      this.#workspaceResolver.run(input.context.workspace, async (workspace) =>
+        withResolvedWorkspace(
+          await this.#repository.mutate(repositoryMutateInput(input), {
+            projectRoot: workspace.cwd,
+          }),
+          workspace,
+        ),
       ),
     );
   }
@@ -108,10 +123,13 @@ export class HostSkillCatalogCoordinator {
     input: SkillCatalogPreviewUpdateInput,
   ): Promise<OperationOutcome<'skill.catalog.preview-update'>> {
     return this.#admitProtocolOperation('skill.catalog.preview-update', () =>
-      this.#workspaceResolver.run(input.context.workspace, (workspace) =>
-        this.#repository.previewUpdate(repositoryPreviewInput(input), {
-          projectRoot: workspace.cwd,
-        }),
+      this.#workspaceResolver.run(input.context.workspace, async (workspace) =>
+        withResolvedWorkspace(
+          await this.#repository.previewUpdate(repositoryPreviewInput(input), {
+            projectRoot: workspace.cwd,
+          }),
+          workspace,
+        ),
       ),
     );
   }
@@ -171,6 +189,16 @@ export class HostSkillCatalogCoordinator {
     );
     return pending;
   }
+}
+
+function withResolvedWorkspace<Result extends object>(
+  result: Result,
+  workspace: ResolvedWorkspace,
+): Result & { readonly resolvedWorkspace: WorkspaceProjection } {
+  return {
+    ...result,
+    resolvedWorkspace: { target: workspace.target, hostCwd: workspace.cwd },
+  };
 }
 
 function repositoryQueryInput(input: SkillCatalogQueryInput): SkillCatalogRepositoryQueryInput {

--- a/packages/runtime-host/src/server/skill-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/skill-catalog-coordinator.ts
@@ -1,7 +1,6 @@
 import type {
   OperationOutcome,
   SkillCatalogInvocableQueryInput,
-  SkillCatalogLocalContext,
   SkillCatalogMutateInput,
   SkillCatalogPreviewUpdateInput,
   SkillCatalogQueryInput,
@@ -12,7 +11,13 @@ import {
   SkillCatalogRepository,
   SkillCatalogRepositoryError,
   type CanonicalSkillInventorySnapshot,
+  type SkillCatalogLocalContext,
+  type SkillCatalogRepositoryInvocableQueryInput,
+  type SkillCatalogRepositoryMutateInput,
+  type SkillCatalogRepositoryPreviewUpdateInput,
+  type SkillCatalogRepositoryQueryInput,
 } from './skill-catalog-repository.js';
+import { type HostWorkspaceResolver, WorkspaceResolutionError } from './workspace-resolver.js';
 
 type CatalogOperation =
   | 'skill.catalog.query'
@@ -40,6 +45,7 @@ export class HostSkillCatalogCoordinator {
   };
 
   readonly #repository: SkillCatalogRepository;
+  readonly #workspaceResolver: Pick<HostWorkspaceResolver, 'run'>;
   readonly #resolveInvocableContext: SkillCatalogInvocableContextResolver | undefined;
   #accepting = true;
   #tail: Promise<void> = Promise.resolve();
@@ -47,9 +53,11 @@ export class HostSkillCatalogCoordinator {
 
   constructor(
     repository: SkillCatalogRepository,
+    workspaceResolver: Pick<HostWorkspaceResolver, 'run'>,
     resolveInvocableContext?: SkillCatalogInvocableContextResolver,
   ) {
     this.#repository = repository;
+    this.#workspaceResolver = workspaceResolver;
     this.#resolveInvocableContext = resolveInvocableContext;
   }
 
@@ -58,7 +66,11 @@ export class HostSkillCatalogCoordinator {
   }
 
   query(input: SkillCatalogQueryInput): Promise<OperationOutcome<'skill.catalog.query'>> {
-    return this.#admitProtocolOperation('skill.catalog.query', () => this.#repository.query(input));
+    return this.#admitProtocolOperation('skill.catalog.query', () =>
+      this.#workspaceResolver.run(input.context.workspace, (workspace) =>
+        this.#repository.query(repositoryQueryInput(input), { projectRoot: workspace.cwd }),
+      ),
+    );
   }
 
   queryInvocable(
@@ -77,7 +89,7 @@ export class HostSkillCatalogCoordinator {
     return this.#admitProtocolOperation('skill.catalog.invocable.query', async () => {
       const resolved = await this.#resolveInvocableContext!(input, context);
       return this.#repository.queryInvocable(
-        input,
+        repositoryInvocableQueryInput(input),
         { projectRoot: resolved.projectRoot },
         resolved.host,
       );
@@ -86,7 +98,9 @@ export class HostSkillCatalogCoordinator {
 
   mutate(input: SkillCatalogMutateInput): Promise<OperationOutcome<'skill.catalog.mutate'>> {
     return this.#admitProtocolOperation('skill.catalog.mutate', () =>
-      this.#repository.mutate(input),
+      this.#workspaceResolver.run(input.context.workspace, (workspace) =>
+        this.#repository.mutate(repositoryMutateInput(input), { projectRoot: workspace.cwd }),
+      ),
     );
   }
 
@@ -94,7 +108,11 @@ export class HostSkillCatalogCoordinator {
     input: SkillCatalogPreviewUpdateInput,
   ): Promise<OperationOutcome<'skill.catalog.preview-update'>> {
     return this.#admitProtocolOperation('skill.catalog.preview-update', () =>
-      this.#repository.previewUpdate(input),
+      this.#workspaceResolver.run(input.context.workspace, (workspace) =>
+        this.#repository.previewUpdate(repositoryPreviewInput(input), {
+          projectRoot: workspace.cwd,
+        }),
+      ),
     );
   }
 
@@ -155,11 +173,52 @@ export class HostSkillCatalogCoordinator {
   }
 }
 
+function repositoryQueryInput(input: SkillCatalogQueryInput): SkillCatalogRepositoryQueryInput {
+  return input.kind === 'start'
+    ? { kind: 'start', view: input.view }
+    : {
+        kind: 'continue',
+        view: input.view,
+        revision: input.revision,
+        cursor: input.cursor,
+      };
+}
+
+function repositoryInvocableQueryInput(
+  input: SkillCatalogInvocableQueryInput,
+): SkillCatalogRepositoryInvocableQueryInput {
+  return input.kind === 'start'
+    ? { kind: 'start' }
+    : { kind: 'continue', revision: input.revision, cursor: input.cursor };
+}
+
+function repositoryMutateInput(input: SkillCatalogMutateInput): SkillCatalogRepositoryMutateInput {
+  return {
+    expectedRevision: input.expectedRevision,
+    mutation: input.mutation,
+  };
+}
+
+function repositoryPreviewInput(
+  input: SkillCatalogPreviewUpdateInput,
+): SkillCatalogRepositoryPreviewUpdateInput {
+  return {
+    expectedRevision: input.expectedRevision,
+    ref: input.ref,
+  };
+}
+
 function repositoryFailure<K extends CatalogOperation>(
   operation: K,
   error: unknown,
 ): OperationOutcome<K> {
   if (!(error instanceof SkillCatalogRepositoryError)) {
+    if (error instanceof WorkspaceResolutionError) {
+      return {
+        ok: false,
+        error: { code: 'invalid_request', message: error.message },
+      } as OperationOutcome<K>;
+    }
     return {
       ok: false,
       error: { code: 'internal_failure', message: 'Skill catalog operation failed' },

--- a/packages/runtime-host/src/server/skill-catalog-repository.ts
+++ b/packages/runtime-host/src/server/skill-catalog-repository.ts
@@ -56,9 +56,7 @@ import {
   type SkillCatalogBundledItem,
   type SkillCatalogGovernanceItem,
   type SkillCatalogInvocableItem,
-  type SkillCatalogInvocableQueryInput,
   type SkillCatalogInvocableQueryResult,
-  type SkillCatalogLocalContext,
   type SkillCatalogManagedSourceItem,
   type SkillCatalogMutateInput,
   type SkillCatalogMutateResult,
@@ -67,12 +65,38 @@ import {
   type SkillCatalogPageItem,
   type SkillCatalogPreviewUpdateInput,
   type SkillCatalogPreviewUpdateResult,
-  type SkillCatalogQueryInput,
   type SkillCatalogQueryResult,
   type SkillCatalogRevision,
   type SkillCatalogValidationCode,
   type SkillCatalogView,
 } from '../protocol/index.js';
+
+export interface SkillCatalogLocalContext {
+  readonly projectRoot: string;
+}
+
+export type SkillCatalogRepositoryQueryInput =
+  | { readonly kind: 'start'; readonly view: SkillCatalogView }
+  | {
+      readonly kind: 'continue';
+      readonly view: SkillCatalogView;
+      readonly revision: SkillCatalogRevision;
+      readonly cursor: string;
+    };
+
+export type SkillCatalogRepositoryInvocableQueryInput =
+  | { readonly kind: 'start' }
+  | {
+      readonly kind: 'continue';
+      readonly revision: SkillCatalogRevision;
+      readonly cursor: string;
+    };
+
+export type SkillCatalogRepositoryMutateInput = Omit<SkillCatalogMutateInput, 'context'>;
+export type SkillCatalogRepositoryPreviewUpdateInput = Omit<
+  SkillCatalogPreviewUpdateInput,
+  'context'
+>;
 import {
   SkillCatalogTransactionError,
   SkillCatalogTransactionWriter,
@@ -217,8 +241,11 @@ export class SkillCatalogRepository {
     }
   }
 
-  async query(input: SkillCatalogQueryInput): Promise<SkillCatalogQueryResult> {
-    const snapshot = await this.#freshSnapshot(input.context);
+  async query(
+    input: SkillCatalogRepositoryQueryInput,
+    context: SkillCatalogLocalContext,
+  ): Promise<SkillCatalogQueryResult> {
+    const snapshot = await this.#freshSnapshot(context);
     if (input.kind === 'continue' && input.revision !== snapshot.revision) {
       return {
         kind: 'revision_changed',
@@ -239,7 +266,7 @@ export class SkillCatalogRepository {
   }
 
   async queryInvocable(
-    input: SkillCatalogInvocableQueryInput,
+    input: SkillCatalogRepositoryInvocableQueryInput,
     context: SkillCatalogLocalContext,
     host: HostCapabilities,
   ): Promise<SkillCatalogInvocableQueryResult> {
@@ -271,8 +298,11 @@ export class SkillCatalogRepository {
     return createInvocablePage(revision, items, offset);
   }
 
-  async mutate(input: SkillCatalogMutateInput): Promise<SkillCatalogMutateResult> {
-    const current = await this.#freshSnapshot(input.context);
+  async mutate(
+    input: SkillCatalogRepositoryMutateInput,
+    context: SkillCatalogLocalContext,
+  ): Promise<SkillCatalogMutateResult> {
+    const current = await this.#freshSnapshot(context);
     if (current.revision !== input.expectedRevision) {
       return revisionConflict(input.expectedRevision, current.revision);
     }
@@ -297,7 +327,7 @@ export class SkillCatalogRepository {
 
     let committed: RepositorySnapshot;
     try {
-      committed = await this.#freshSnapshot(input.context);
+      committed = await this.#freshSnapshot(context);
     } catch (error) {
       throw commitOutcomeUnknown(
         'Skill catalog committed but its new projection is unavailable',
@@ -315,9 +345,10 @@ export class SkillCatalogRepository {
   }
 
   async previewUpdate(
-    input: SkillCatalogPreviewUpdateInput,
+    input: SkillCatalogRepositoryPreviewUpdateInput,
+    context: SkillCatalogLocalContext,
   ): Promise<SkillCatalogPreviewUpdateResult> {
-    const snapshot = await this.#freshSnapshot(input.context);
+    const snapshot = await this.#freshSnapshot(context);
     if (snapshot.revision !== input.expectedRevision) {
       return revisionConflict(input.expectedRevision, snapshot.revision);
     }

--- a/packages/runtime-host/src/server/skill-catalog-repository.ts
+++ b/packages/runtime-host/src/server/skill-catalog-repository.ts
@@ -59,13 +59,13 @@ import {
   type SkillCatalogInvocableQueryResult,
   type SkillCatalogManagedSourceItem,
   type SkillCatalogMutateInput,
-  type SkillCatalogMutateResult,
+  type SkillCatalogMutationOutcome,
   type SkillCatalogMutation,
   type SkillCatalogMutationRejectedReason,
   type SkillCatalogPageItem,
   type SkillCatalogPreviewUpdateInput,
-  type SkillCatalogPreviewUpdateResult,
-  type SkillCatalogQueryResult,
+  type SkillCatalogPreviewUpdateOutcome,
+  type SkillCatalogQueryProjection,
   type SkillCatalogRevision,
   type SkillCatalogValidationCode,
   type SkillCatalogView,
@@ -244,7 +244,7 @@ export class SkillCatalogRepository {
   async query(
     input: SkillCatalogRepositoryQueryInput,
     context: SkillCatalogLocalContext,
-  ): Promise<SkillCatalogQueryResult> {
+  ): Promise<SkillCatalogQueryProjection> {
     const snapshot = await this.#freshSnapshot(context);
     if (input.kind === 'continue' && input.revision !== snapshot.revision) {
       return {
@@ -301,7 +301,7 @@ export class SkillCatalogRepository {
   async mutate(
     input: SkillCatalogRepositoryMutateInput,
     context: SkillCatalogLocalContext,
-  ): Promise<SkillCatalogMutateResult> {
+  ): Promise<SkillCatalogMutationOutcome> {
     const current = await this.#freshSnapshot(context);
     if (current.revision !== input.expectedRevision) {
       return revisionConflict(input.expectedRevision, current.revision);
@@ -347,7 +347,7 @@ export class SkillCatalogRepository {
   async previewUpdate(
     input: SkillCatalogRepositoryPreviewUpdateInput,
     context: SkillCatalogLocalContext,
-  ): Promise<SkillCatalogPreviewUpdateResult> {
+  ): Promise<SkillCatalogPreviewUpdateOutcome> {
     const snapshot = await this.#freshSnapshot(context);
     if (snapshot.revision !== input.expectedRevision) {
       return revisionConflict(input.expectedRevision, snapshot.revision);
@@ -389,7 +389,7 @@ export class SkillCatalogRepository {
 
     const currentSnippet = boundedSnippet(current.content);
     const sourceSnippet = boundedSnippet(source.content);
-    const result: SkillCatalogPreviewUpdateResult = {
+    const result: SkillCatalogPreviewUpdateOutcome = {
       kind: 'preview',
       revision: snapshot.revision,
       currentSnippet: currentSnippet.text,
@@ -1385,7 +1385,7 @@ function createPage(
   view: SkillCatalogView,
   items: readonly SkillCatalogPageItem[],
   offset: number,
-): SkillCatalogQueryResult {
+): SkillCatalogQueryProjection {
   const pageItems: SkillCatalogPageItem[] = [];
   let cursor = offset;
   while (cursor < items.length && pageItems.length < SKILL_CATALOG_PAGE_MAX_ITEMS) {
@@ -1897,8 +1897,8 @@ function boundedSnippet(content: string): { text: string; truncated: boolean } {
 }
 
 function shrinkPreview(
-  result: Extract<SkillCatalogPreviewUpdateResult, { kind: 'preview' }>,
-): SkillCatalogPreviewUpdateResult {
+  result: Extract<SkillCatalogPreviewUpdateOutcome, { kind: 'preview' }>,
+): SkillCatalogPreviewUpdateOutcome {
   let currentSnippet = result.currentSnippet;
   let sourceSnippet = result.sourceSnippet;
   while (
@@ -1962,7 +1962,7 @@ function canonicalJson(value: unknown): string {
 function revisionConflict(
   expectedRevision: SkillCatalogRevision,
   actualRevision: SkillCatalogRevision,
-): SkillCatalogMutateResult & SkillCatalogPreviewUpdateResult {
+): Extract<SkillCatalogMutationOutcome, { kind: 'revision_conflict' }> {
   return { kind: 'revision_conflict', expectedRevision, actualRevision };
 }
 

--- a/packages/runtime-host/src/server/workspace-resolver.ts
+++ b/packages/runtime-host/src/server/workspace-resolver.ts
@@ -34,6 +34,7 @@ export class HostWorkspaceResolver {
   constructor(
     private readonly catalog: Pick<ProjectCatalog, 'list' | 'touch'>,
     private readonly membership: HostProjectMembershipGate,
+    private readonly onProjectChanged: () => void,
   ) {}
 
   resolve(target: WorkspaceTarget): Promise<ResolvedWorkspace> {
@@ -55,6 +56,7 @@ export class HostWorkspaceResolver {
       const workspace = await this.#resolve(target);
       if (workspace.projectId !== null) {
         await this.catalog.touch(workspace.projectId, workspace.cwd);
+        this.onProjectChanged();
       }
       return operation(workspace);
     });

--- a/packages/runtime-host/src/server/workspace-resolver.ts
+++ b/packages/runtime-host/src/server/workspace-resolver.ts
@@ -1,7 +1,13 @@
 import { realpath, stat } from 'node:fs/promises';
 import { isAbsolute, resolve } from 'node:path';
 import type { ProjectRecord } from '@maka/core';
-import type { ProjectCatalog } from '@maka/storage';
+import {
+  type ProjectCatalog,
+  ProjectArchivedError,
+  ProjectNotFoundError,
+  ProjectPathMismatchError,
+  ProjectUnavailableError,
+} from '@maka/storage';
 import type { WorkspaceTarget } from '../protocol/index.js';
 import type { HostProjectMembershipGate } from './project-membership-gate.js';
 
@@ -55,7 +61,21 @@ export class HostWorkspaceResolver {
     return this.membership.run(async () => {
       const workspace = await this.#resolve(target);
       if (workspace.projectId !== null) {
-        await this.catalog.touch(workspace.projectId, workspace.cwd);
+        try {
+          await this.catalog.touch(workspace.projectId, workspace.cwd);
+        } catch (error) {
+          if (error instanceof ProjectNotFoundError) {
+            throw new WorkspaceResolutionError('not_found', error.message);
+          }
+          if (
+            error instanceof ProjectArchivedError ||
+            error instanceof ProjectUnavailableError ||
+            error instanceof ProjectPathMismatchError
+          ) {
+            throw new WorkspaceResolutionError('operation_conflict', error.message);
+          }
+          throw error;
+        }
         this.onProjectChanged();
       }
       return operation(workspace);

--- a/packages/runtime-host/src/server/workspace-resolver.ts
+++ b/packages/runtime-host/src/server/workspace-resolver.ts
@@ -1,0 +1,114 @@
+import { realpath, stat } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+import type { ProjectRecord } from '@maka/core';
+import type { ProjectCatalog } from '@maka/storage';
+import type { WorkspaceTarget } from '../protocol/index.js';
+import type { HostProjectMembershipGate } from './project-membership-gate.js';
+
+export type WorkspaceResolutionErrorCode = 'invalid_request' | 'not_found' | 'operation_conflict';
+
+export class WorkspaceResolutionError extends Error {
+  constructor(
+    readonly code: WorkspaceResolutionErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'WorkspaceResolutionError';
+  }
+}
+
+export type ResolvedWorkspace =
+  | {
+      readonly target: Extract<WorkspaceTarget, { readonly kind: 'host_path' }>;
+      readonly cwd: string;
+      readonly projectId: null;
+    }
+  | {
+      readonly target: Extract<WorkspaceTarget, { readonly kind: 'project' }>;
+      readonly cwd: string;
+      readonly projectId: string;
+      readonly project: ProjectRecord;
+    };
+
+export class HostWorkspaceResolver {
+  constructor(
+    private readonly catalog: Pick<ProjectCatalog, 'list' | 'touch'>,
+    private readonly membership: HostProjectMembershipGate,
+  ) {}
+
+  resolve(target: WorkspaceTarget): Promise<ResolvedWorkspace> {
+    return this.run(target, async (workspace) => workspace);
+  }
+
+  run<Result>(
+    target: WorkspaceTarget,
+    operation: (workspace: ResolvedWorkspace) => Promise<Result>,
+  ): Promise<Result> {
+    return this.membership.run(async () => operation(await this.#resolve(target)));
+  }
+
+  runWithUsageRecorded<Result>(
+    target: WorkspaceTarget,
+    operation: (workspace: ResolvedWorkspace) => Promise<Result>,
+  ): Promise<Result> {
+    return this.membership.run(async () => {
+      const workspace = await this.#resolve(target);
+      if (workspace.projectId !== null) {
+        await this.catalog.touch(workspace.projectId, workspace.cwd);
+      }
+      return operation(workspace);
+    });
+  }
+
+  async #resolve(target: WorkspaceTarget): Promise<ResolvedWorkspace> {
+    if (target.kind === 'host_path') {
+      const cwd = await canonicalHostDirectory(target.path);
+      return { target: { kind: 'host_path', path: cwd }, cwd, projectId: null };
+    }
+
+    const project = (await this.catalog.list()).find(
+      (candidate) =>
+        candidate.id === target.projectId || candidate.aliases?.includes(target.projectId),
+    );
+    if (!project) {
+      throw new WorkspaceResolutionError(
+        'not_found',
+        `Project does not exist: ${target.projectId}`,
+      );
+    }
+    if (project.archivedAt !== undefined) {
+      throw new WorkspaceResolutionError(
+        'operation_conflict',
+        `Project is archived: ${target.projectId}`,
+      );
+    }
+    if (!project.available || !project.preferredPath) {
+      throw new WorkspaceResolutionError(
+        'operation_conflict',
+        `Project is unavailable: ${target.projectId}`,
+      );
+    }
+    return {
+      target: { kind: 'project', projectId: project.id },
+      cwd: project.preferredPath,
+      projectId: project.id,
+      project,
+    };
+  }
+}
+
+async function canonicalHostDirectory(path: string): Promise<string> {
+  if (!isAbsolute(path)) {
+    throw new WorkspaceResolutionError('invalid_request', 'Workspace Host path must be absolute');
+  }
+  try {
+    const canonical = await realpath(resolve(path));
+    if ((await stat(canonical)).isDirectory()) return canonical;
+  } catch {
+    // Project a stable request error below.
+  }
+  throw new WorkspaceResolutionError(
+    'invalid_request',
+    'Workspace Host path is not an existing directory',
+  );
+}

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -9,6 +9,7 @@ import { promisify } from 'node:util';
 import {
   createProjectCatalog as createProjectCatalogBase,
   type ProjectCatalog,
+  ProjectUnavailableError,
   type ResolvedProjectLocation,
   resolveProjectLocation,
 } from '../project-catalog.js';
@@ -453,6 +454,24 @@ test('touching a project moves it to the front of the recent list', async () => 
     assert.deepEqual(
       (await catalog.list()).map((project) => project.id),
       [first.id, 'project-2'],
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('touch reports a Project that disappears before path resolution as unavailable', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-touch-missing-'));
+  try {
+    const path = join(base, 'project');
+    await mkdir(path);
+    const catalog = createProjectCatalog(join(base, 'storage'));
+    const project = await catalog.register(path);
+    await remove(path, { recursive: true });
+
+    await assert.rejects(
+      () => catalog.touch(project.id, path),
+      (error) => error instanceof ProjectUnavailableError && error.projectId === project.id,
     );
   } finally {
     await rm(base, { recursive: true, force: true });

--- a/packages/storage/src/project-catalog.ts
+++ b/packages/storage/src/project-catalog.ts
@@ -277,7 +277,12 @@ class SqliteProjectCatalog implements ProjectCatalog {
   }
 
   async touch(projectId: string, path?: string): Promise<ProjectRecord> {
-    const resolved = path ? await resolveProjectLocation({ path }) : undefined;
+    let resolved: Awaited<ReturnType<typeof resolveProjectLocation>> | undefined;
+    try {
+      resolved = path ? await resolveProjectLocation({ path }) : undefined;
+    } catch {
+      throw new ProjectUnavailableError(projectId);
+    }
     const resolvedPath = resolved
       ? resolved.kind === 'git'
         ? resolved.git!.worktreeRoot


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Introduce a closed `WorkspaceTarget` (`project` or `host_path`) and make Runtime Host the only resolver from workspace intent to a canonical Host path.
- Replace public Session `cwd + projectId` coupling with workspace targets across Session create/relocate, Skill Catalog, and External Session queries.
- Keep the generic Project Catalog path-free; expose locations only through Host-path-authorized queries, and return path-free Project summaries directly from mutations.
- Treat Skill Catalog management as one Host-filesystem contract: it requires Host-path authority and returns the workspace resolved by that operation.
- Move Desktop Project selection into a Runtime-Host-root-scoped Client preference while preserving native local directory selection.
- Preserve local CLI/TUI zero-configuration behavior while carrying canonical workspace identity through create, resume, move, continue, and Skill discovery.
- Bump the Runtime Host compatibility epoch and update the English and Chinese architecture documents.

## Impact and review focus

This is an intentional closed-schema change with no long-lived compatibility shim. Existing durable Sessions remain readable: Runtime Host projects their stored `projectId`/`cwd` into the new workspace shape.

Please focus review on:

- Host-path authorization for Project and `host_path` targets;
- Project membership fencing during Session and Skill operations;
- Desktop root-scoped Project preference migration;
- CLI/TUI local behavior and Session resume/move semantics.

## Verification

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -w @maka/runtime-host` — 843 passed
- `npm test -w @maka/desktop` — 1,150 passed
- `npm test -w maka-agent` — 357 passed
- `git diff --check`

## Checklist

- [x] Tests cover behavior and regression boundaries
- [x] Typecheck, lint, format, builds, and full affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

- 引入 closed `WorkspaceTarget`（`project` 或 `host_path`），由 Runtime Host 唯一负责将 workspace 意图解析为 canonical Host path。
- Session create/relocate、Skill Catalog 与 External Session query 不再公开组合 `cwd + projectId`，统一使用 workspace target。
- 普通 Project Catalog 保持 path-free；location 只通过 Host-path-authorized query 暴露，mutation 直接返回 path-free Project summary。
- Skill Catalog 管理统一为一种 Host 文件系统契约：要求 Host-path authority，并返回该操作实际解析出的 workspace。
- Desktop Project 选择改为按 Runtime Host root 隔离的 Client preference，同时保留本地原生目录选择体验。
- 保持 CLI/TUI 本地零配置行为，并让 create、resume、move、continue 与 Skill discovery 携带明确的 workspace identity。
- 推进 Runtime Host compatibility epoch，并更新中英文架构文档。

## 影响与审查重点

这是有意的 closed-schema 变更，不保留长期兼容双轨。既有 durable Session 无需批量迁移：Runtime Host 会把存储中的 `projectId`/`cwd` 投影为新的 workspace shape。

建议重点审查：

- Project target 与 `host_path` target 的 Host-path authorization；
- Session 与 Skill 操作期间的 Project membership fence；
- Desktop 按 root 隔离的 Project preference migration；
- CLI/TUI 本地行为以及 Session resume/move 语义。

## 验证

- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm test -w @maka/runtime-host` — 843 passed
- `npm test -w @maka/desktop` — 1,150 passed
- `npm test -w maka-agent` — 357 passed
- `git diff --check`

## Checklist

- [x] 测试覆盖行为与回归边界
- [x] typecheck、lint、format、build 与受影响的完整测试套件均在本地通过

这个 PR 是否包含行为变更？

- [x] 是——已在上方概要中说明
- [ ] 否

</details>
