### PR TITLE
fix(desktop): show agent Automation crons on the scheduled-tasks page

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-automations-for-plans.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-automations-for-plans.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { AutomationProjection } from '@maka/runtime-host/protocol';
+import { listAgentAutomationsForScheduledTasks } from '../agent-automations-for-plans.js';
+
+function automation(
+  overrides: Partial<AutomationProjection> & Pick<AutomationProjection, 'id' | 'sessionId'>,
+): AutomationProjection {
+  return {
+    kind: 'cron',
+    name: overrides.name ?? overrides.id,
+    status: 'active',
+    prompt: 'do work',
+    schedule: { type: 'cron', expression: '0 9 * * *' },
+    createdAt: 100,
+    updatedAt: 100,
+    nextFireAt: 200,
+    lastFireAt: null,
+    lastRunId: null,
+    fireCount: 0,
+    maxFires: null,
+    expiresAt: null,
+    lastError: null,
+    consecutiveFailures: 0,
+    durable: true,
+    deferredFireCount: 0,
+    firePending: false,
+    waiting: null,
+    ...overrides,
+  };
+}
+
+describe('listAgentAutomationsForScheduledTasks', () => {
+  it('dedupes durable automations seen from multiple sessions and skips heartbeats', async () => {
+    const calls: string[] = [];
+    const client = {
+      async listSessions() {
+        return [
+          { id: 'live', isArchived: false },
+          { id: 'old', isArchived: true },
+        ] as never;
+      },
+      async listAutomations(sessionId: string) {
+        calls.push(sessionId);
+        if (sessionId === 'live') {
+          return [
+            automation({ id: 'cron-a', sessionId: 'live', createdAt: 20 }),
+            automation({
+              id: 'hb',
+              sessionId: 'live',
+              kind: 'heartbeat',
+              durable: false,
+            }),
+          ];
+        }
+        return [
+          automation({ id: 'cron-a', sessionId: 'creator', createdAt: 10 }),
+          automation({ id: 'cron-b', sessionId: 'creator', createdAt: 5 }),
+        ];
+      },
+    };
+
+    const listed = await listAgentAutomationsForScheduledTasks(client);
+    assert.deepEqual(calls, ['live', 'old']);
+    assert.deepEqual(
+      listed.map((entry) => entry.id),
+      ['cron-b', 'cron-a'],
+    );
+    // Live session is preferred when the same id is seen twice.
+    assert.equal(listed.find((entry) => entry.id === 'cron-a')?.sessionId, 'live');
+  });
+
+  it('survives a single session list failure', async () => {
+    const client = {
+      async listSessions() {
+        return [
+          { id: 'broken', isArchived: false },
+          { id: 'ok', isArchived: false },
+        ] as never;
+      },
+      async listAutomations(sessionId: string) {
+        if (sessionId === 'broken') throw new Error('session gone');
+        return [automation({ id: 'cron-ok', sessionId: 'ok' })];
+      },
+    };
+    const listed = await listAgentAutomationsForScheduledTasks(client);
+    assert.deepEqual(
+      listed.map((entry) => entry.id),
+      ['cron-ok'],
+    );
+  });
+});

--- a/apps/desktop/src/main/agent-automations-for-plans.ts
+++ b/apps/desktop/src/main/agent-automations-for-plans.ts
@@ -1,0 +1,103 @@
+/**
+ * Collect agent Automations visible to the scheduled-tasks (plan-reminders)
+ * page. Durable crons outlive their creator session and are listed against
+ * every session that can still query the host; we dedupe by automation id.
+ *
+ * When the workspace has no sessions yet (or every list call fails), fall back
+ * to a read-only SQLite snapshot so durable crons still appear in the UI.
+ */
+
+import type { AutomationDefinition } from '@maka/core/automation';
+import type { AutomationProjection } from '@maka/runtime-host/protocol';
+import { createSqliteAutomationAuthority } from '@maka/storage';
+import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
+
+export type AgentAutomationListClient = Pick<
+  DesktopRuntimeHostClient,
+  'listSessions' | 'listAutomations'
+>;
+
+export async function listAgentAutomationsForScheduledTasks(
+  client: AgentAutomationListClient,
+  options: { workspaceRoot?: string } = {},
+): Promise<AutomationProjection[]> {
+  const sessions = await client.listSessions().catch(() => []);
+  // Prefer live sessions first so ownership/sessionId is as fresh as possible,
+  // then fall back to archived ones — durable crons remain queryable there.
+  const ordered = [...sessions].sort((a, b) => {
+    const aArchived = a.isArchived ? 1 : 0;
+    const bArchived = b.isArchived ? 1 : 0;
+    if (aArchived !== bArchived) return aArchived - bArchived;
+    return a.id.localeCompare(b.id);
+  });
+
+  const byId = new Map<string, AutomationProjection>();
+  for (const session of ordered) {
+    let automations: AutomationProjection[];
+    try {
+      automations = await client.listAutomations(session.id);
+    } catch {
+      // A single bad session must not hide the rest of the catalog.
+      continue;
+    }
+    for (const automation of automations) {
+      if (automation.kind !== 'cron' && automation.durable !== true) continue;
+      if (!byId.has(automation.id)) {
+        byId.set(automation.id, automation);
+      }
+    }
+  }
+
+  if (byId.size === 0 && options.workspaceRoot) {
+    for (const automation of readDurableAutomationsFromStore(options.workspaceRoot)) {
+      if (!byId.has(automation.id)) byId.set(automation.id, automation);
+    }
+  }
+
+  return [...byId.values()].sort((a, b) => {
+    if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function readDurableAutomationsFromStore(workspaceRoot: string): AutomationProjection[] {
+  try {
+    const authority = createSqliteAutomationAuthority(workspaceRoot);
+    try {
+      return authority
+        .read()
+        .automations.filter((automation) => automation.kind === 'cron' || automation.durable === true)
+        .map(projectDefinition);
+    } finally {
+      authority.close();
+    }
+  } catch {
+    return [];
+  }
+}
+
+function projectDefinition(automation: AutomationDefinition): AutomationProjection {
+  return {
+    id: automation.id,
+    kind: automation.kind,
+    name: automation.name,
+    status: automation.status,
+    prompt: automation.prompt,
+    sessionId: automation.sessionId,
+    schedule: automation.schedule,
+    createdAt: automation.createdAt,
+    updatedAt: automation.updatedAt,
+    nextFireAt: automation.nextFireAt,
+    lastFireAt: automation.lastFireAt,
+    lastRunId: automation.lastRunId,
+    fireCount: automation.fireCount,
+    maxFires: automation.maxFires,
+    expiresAt: automation.expiresAt,
+    lastError: automation.lastError,
+    consecutiveFailures: automation.consecutiveFailures,
+    durable: automation.durable === true,
+    deferredFireCount: automation.deferredFireCount ?? 0,
+    firePending: false,
+    waiting: automation.waiting ?? null,
+  };
+}

--- a/apps/desktop/src/main/plan-reminders-ipc-main.ts
+++ b/apps/desktop/src/main/plan-reminders-ipc-main.ts
@@ -1,16 +1,49 @@
 import { ipcMain } from "electron";
-import type { WorkspacePrivacyContext } from "@maka/core";
+import {
+  isAgentAutomationPlanReminder,
+  mergePlanRemindersWithAgentAutomations,
+  parseAgentAutomationReminderId,
+  type WorkspacePrivacyContext,
+} from "@maka/core";
+import type { AutomationProjection } from "@maka/runtime-host/protocol";
+import {
+  listAgentAutomationsForScheduledTasks,
+  type AgentAutomationListClient,
+} from "./agent-automations-for-plans.js";
 import type { PlanReminderMainService } from "./plan-reminders-main.js";
+import type { DesktopRuntimeHostClient } from "./runtime-host-client.js";
 
 interface PlanReminderIpcDeps {
   planReminders: PlanReminderMainService;
   getWorkspacePrivacyContext: () => Promise<WorkspacePrivacyContext>;
+  /**
+   * When present, `plans:list` merges durable agent Automations into the
+   * scheduled-tasks catalog so agent-created crons appear in the desktop UI.
+   */
+  runtimeHostClient?: AgentAutomationListClient &
+    Pick<DesktopRuntimeHostClient, "mutateAutomation">;
+  /** Workspace root for the SQLite fallback when no sessions can query the host. */
+  workspaceRoot?: string;
   ipcMain?: Pick<typeof ipcMain, "handle">;
 }
 
 export function registerPlanReminderIpc(deps: PlanReminderIpcDeps): void {
   const target = deps.ipcMain ?? ipcMain;
-  target.handle("plans:list", () => deps.planReminders.list());
+  target.handle("plans:list", async () => {
+    const planReminders = await deps.planReminders.list();
+    const client = deps.runtimeHostClient;
+    if (!client) return planReminders;
+    let automations: AutomationProjection[] = [];
+    try {
+      automations = await listAgentAutomationsForScheduledTasks(client, {
+        workspaceRoot: deps.workspaceRoot,
+      });
+    } catch {
+      // Host down / not ready: still return UI-created plan reminders.
+      return planReminders;
+    }
+    return mergePlanRemindersWithAgentAutomations(planReminders, automations);
+  });
   target.handle("plans:create", async (_event, input: unknown) => {
     const privacy = await deps.getWorkspacePrivacyContext();
     if (privacy.incognitoActive) {
@@ -18,22 +51,117 @@ export function registerPlanReminderIpc(deps: PlanReminderIpcDeps): void {
     }
     return deps.planReminders.create(input);
   });
-  target.handle("plans:update", (_event, id: string, patch: unknown) =>
-    deps.planReminders.update(id, patch),
-  );
-  target.handle("plans:setEnabled", (_event, id: string, enabled: boolean) =>
-    deps.planReminders.setEnabled(id, enabled),
-  );
-  target.handle("plans:triggerNow", (_event, id: string) =>
-    deps.planReminders.triggerNow(id),
-  );
-  target.handle("plans:snooze", (_event, id: string) =>
-    deps.planReminders.snooze(id),
-  );
-  target.handle("plans:clearRunHistory", (_event, id: string) =>
-    deps.planReminders.clearRunHistory(id),
-  );
+  target.handle("plans:update", async (_event, id: string, patch: unknown) => {
+    await rejectAgentAutomationMutation(id, "update", deps);
+    return deps.planReminders.update(id, patch);
+  });
+  target.handle("plans:setEnabled", async (_event, id: string, enabled: boolean) => {
+    const automationId = parseAgentAutomationReminderId(id);
+    if (automationId) {
+      return mutateAgentAutomationEnabled(deps, id, automationId, enabled);
+    }
+    return deps.planReminders.setEnabled(id, enabled);
+  });
+  target.handle("plans:triggerNow", async (_event, id: string) => {
+    await rejectAgentAutomationMutation(id, "trigger", deps);
+    return deps.planReminders.triggerNow(id);
+  });
+  target.handle("plans:snooze", async (_event, id: string) => {
+    await rejectAgentAutomationMutation(id, "snooze", deps);
+    return deps.planReminders.snooze(id);
+  });
+  target.handle("plans:clearRunHistory", async (_event, id: string) => {
+    await rejectAgentAutomationMutation(id, "clear history for", deps);
+    return deps.planReminders.clearRunHistory(id);
+  });
   target.handle("plans:delete", async (_event, id: string) => {
+    const automationId = parseAgentAutomationReminderId(id);
+    if (automationId) {
+      await deleteAgentAutomation(deps, id, automationId);
+      return;
+    }
     await deps.planReminders.delete(id);
   });
+}
+
+async function rejectAgentAutomationMutation(
+  id: string,
+  verb: string,
+  deps: PlanReminderIpcDeps,
+): Promise<void> {
+  if (!parseAgentAutomationReminderId(id)) return;
+  // Look up the live merged row so the error can mention the agent title.
+  const rows = await deps.planReminders.list().catch(() => []);
+  const row = rows.find((entry) => entry.id === id);
+  if (row && isAgentAutomationPlanReminder(row)) {
+    throw new Error(
+      `Cannot ${verb} agent automation "${row.title}" through the plan-reminder editor. Pause, resume, or delete it instead.`,
+    );
+  }
+  throw new Error(
+    `Cannot ${verb} an agent automation through the plan-reminder editor. Pause, resume, or delete it instead.`,
+  );
+}
+
+async function mutateAgentAutomationEnabled(
+  deps: PlanReminderIpcDeps,
+  reminderId: string,
+  automationId: string,
+  enabled: boolean,
+) {
+  const client = deps.runtimeHostClient;
+  if (!client) throw new Error("Runtime Host is not available for agent automations.");
+  const automations = await listAgentAutomationsForScheduledTasks(client, {
+    workspaceRoot: deps.workspaceRoot,
+  });
+  const automation = automations.find((entry) => entry.id === automationId);
+  if (!automation) throw new Error(`No such agent automation: ${automationId}`);
+  if (enabled && automation.status === "active") {
+    return mergePlanRemindersWithAgentAutomations([], [automation])[0]!;
+  }
+  if (!enabled && automation.status === "paused") {
+    return mergePlanRemindersWithAgentAutomations([], [automation])[0]!;
+  }
+  if (enabled && automation.status !== "paused") {
+    throw new Error("Only paused agent automations can be resumed.");
+  }
+  if (!enabled && automation.status !== "active") {
+    throw new Error("Only active agent automations can be paused.");
+  }
+  const result = await client.mutateAutomation({
+    kind: enabled ? "resume" : "pause",
+    sessionId: automation.sessionId,
+    automationId,
+  });
+  if (result.kind !== "committed" || !result.automation) {
+    throw new Error(
+      result.kind === "rejected"
+        ? `Agent automation ${enabled ? "resume" : "pause"} rejected: ${result.reason}`
+        : `Agent automation ${enabled ? "resume" : "pause"} failed.`,
+    );
+  }
+  return mergePlanRemindersWithAgentAutomations([], [result.automation])[0]!;
+}
+
+async function deleteAgentAutomation(
+  deps: PlanReminderIpcDeps,
+  reminderId: string,
+  automationId: string,
+): Promise<void> {
+  void reminderId;
+  const client = deps.runtimeHostClient;
+  if (!client) throw new Error("Runtime Host is not available for agent automations.");
+  const automations = await listAgentAutomationsForScheduledTasks(client, {
+    workspaceRoot: deps.workspaceRoot,
+  });
+  const automation = automations.find((entry) => entry.id === automationId);
+  if (!automation) throw new Error(`No such agent automation: ${automationId}`);
+  const result = await client.mutateAutomation({
+    kind: "delete",
+    sessionId: automation.sessionId,
+    automationId,
+  });
+  if (result.kind === "rejected") {
+    throw new Error(`Agent automation delete rejected: ${result.reason}`);
+  }
 }

--- a/apps/desktop/src/main/plan-reminders-ipc-main.ts
+++ b/apps/desktop/src/main/plan-reminders-ipc-main.ts
@@ -1,6 +1,5 @@
 import { ipcMain } from "electron";
 import {
-  isAgentAutomationPlanReminder,
   mergePlanRemindersWithAgentAutomations,
   parseAgentAutomationReminderId,
   type WorkspacePrivacyContext,
@@ -87,17 +86,11 @@ export function registerPlanReminderIpc(deps: PlanReminderIpcDeps): void {
 async function rejectAgentAutomationMutation(
   id: string,
   verb: string,
-  deps: PlanReminderIpcDeps,
+  _deps: PlanReminderIpcDeps,
 ): Promise<void> {
+  void _deps;
   if (!parseAgentAutomationReminderId(id)) return;
-  // Look up the live merged row so the error can mention the agent title.
-  const rows = await deps.planReminders.list().catch(() => []);
-  const row = rows.find((entry) => entry.id === id);
-  if (row && isAgentAutomationPlanReminder(row)) {
-    throw new Error(
-      `Cannot ${verb} agent automation "${row.title}" through the plan-reminder editor. Pause, resume, or delete it instead.`,
-    );
-  }
+  // Agent rows are never in the plan-reminder store — id prefix is enough.
   throw new Error(
     `Cannot ${verb} an agent automation through the plan-reminder editor. Pause, resume, or delete it instead.`,
   );
@@ -109,6 +102,7 @@ async function mutateAgentAutomationEnabled(
   automationId: string,
   enabled: boolean,
 ) {
+  void reminderId;
   const client = deps.runtimeHostClient;
   if (!client) throw new Error("Runtime Host is not available for agent automations.");
   const automations = await listAgentAutomationsForScheduledTasks(client, {
@@ -128,9 +122,10 @@ async function mutateAgentAutomationEnabled(
   if (!enabled && automation.status !== "active") {
     throw new Error("Only active agent automations can be paused.");
   }
+  const sessionId = await resolveAutomationManageSessionId(client, automation.sessionId);
   const result = await client.mutateAutomation({
     kind: enabled ? "resume" : "pause",
-    sessionId: automation.sessionId,
+    sessionId,
     automationId,
   });
   if (result.kind !== "committed" || !result.automation) {
@@ -156,12 +151,33 @@ async function deleteAgentAutomation(
   });
   const automation = automations.find((entry) => entry.id === automationId);
   if (!automation) throw new Error(`No such agent automation: ${automationId}`);
+  const sessionId = await resolveAutomationManageSessionId(client, automation.sessionId);
   const result = await client.mutateAutomation({
     kind: "delete",
-    sessionId: automation.sessionId,
+    sessionId,
     automationId,
   });
   if (result.kind === "rejected") {
     throw new Error(`Agent automation delete rejected: ${result.reason}`);
   }
+}
+
+/**
+ * Durable automations remain manageable from any session, but the host still
+ * requires a real session id on the mutate call. Prefer the creator when it
+ * still exists; otherwise any live session; otherwise any archived one.
+ */
+async function resolveAutomationManageSessionId(
+  client: AgentAutomationListClient,
+  preferredSessionId: string,
+): Promise<string> {
+  const sessions = await client.listSessions().catch(() => []);
+  if (sessions.some((session) => session.id === preferredSessionId)) {
+    return preferredSessionId;
+  }
+  const live = sessions.find((session) => !session.isArchived);
+  if (live) return live.id;
+  if (sessions[0]) return sessions[0].id;
+  // Last resort: creator id (host will surface not_found if it is truly gone).
+  return preferredSessionId;
 }

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -661,6 +661,8 @@ function registerHostClientIpc(
   registerPlanReminderIpc({
     ipcMain: scopedIpc,
     planReminders,
+    runtimeHostClient: client,
+    workspaceRoot,
     getWorkspacePrivacyContext: async () => ({
       incognitoActive: (await client.queryRuntimePolicy()).policy.privacy
         .incognitoActive,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1682,6 +1682,21 @@ function AppShellContent({
     toastApi,
   });
 
+  // Agent Automations (Automation tool) live in Runtime Host, not the plan
+  // store. Re-merge them whenever the scheduled-tasks page is open so a cron
+  // created in chat appears without a manual refresh. Poll while the page is
+  // foregrounded because the host does not yet push automation-catalog events.
+  const planRemindersSurfaceActive =
+    navSelection.section === 'automations' && navSelection.module === 'plan-reminders';
+  useEffect(() => {
+    if (!planRemindersSurfaceActive) return;
+    void refreshPlanReminders({ shouldShowError: isAutomationsSurfaceActive });
+    const timer = window.setInterval(() => {
+      void refreshPlanReminders({ shouldShowError: () => false });
+    }, 12_000);
+    return () => window.clearInterval(timer);
+  }, [planRemindersSurfaceActive, refreshPlanReminders]);
+
   // 保持系统唤醒 capability for the 定时任务 page: reads/writes
   // settings.system.keepSystemAwake over the existing settings bridge. When
   // the bridge is absent the panel hides the row (fail-soft).

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1686,16 +1686,22 @@ function AppShellContent({
   // store. Re-merge them whenever the scheduled-tasks page is open so a cron
   // created in chat appears without a manual refresh. Poll while the page is
   // foregrounded because the host does not yet push automation-catalog events.
+  //
+  // `refreshPlanReminders` is recreated every render (module-data helpers are
+  // not memoized). Hold it in a ref so this effect only re-runs when the
+  // surface becomes active — otherwise list → setState → re-render loops.
+  const refreshPlanRemindersRef = useRef(refreshPlanReminders);
+  refreshPlanRemindersRef.current = refreshPlanReminders;
   const planRemindersSurfaceActive =
     navSelection.section === 'automations' && navSelection.module === 'plan-reminders';
   useEffect(() => {
     if (!planRemindersSurfaceActive) return;
-    void refreshPlanReminders({ shouldShowError: isAutomationsSurfaceActive });
+    void refreshPlanRemindersRef.current({ shouldShowError: isAutomationsSurfaceActive });
     const timer = window.setInterval(() => {
-      void refreshPlanReminders({ shouldShowError: () => false });
+      void refreshPlanRemindersRef.current({ shouldShowError: () => false });
     }, 12_000);
     return () => window.clearInterval(timer);
-  }, [planRemindersSurfaceActive, refreshPlanReminders]);
+  }, [planRemindersSurfaceActive]);
 
   // 保持系统唤醒 capability for the 定时任务 page: reads/writes
   // settings.system.keepSystemAwake over the existing settings bridge. When

--- a/packages/core/src/__tests__/agent-automation-projection.test.ts
+++ b/packages/core/src/__tests__/agent-automation-projection.test.ts
@@ -57,7 +57,10 @@ describe('agent automation → plan-reminder projection', () => {
   });
 
   it('maps paused / completed / failed states', () => {
-    assert.equal(projectAgentAutomationAsPlanReminder(automation({ status: 'paused' })).status, 'paused');
+    assert.equal(
+      projectAgentAutomationAsPlanReminder(automation({ status: 'paused' })).status,
+      'paused',
+    );
     assert.equal(
       projectAgentAutomationAsPlanReminder(automation({ status: 'completed' })).status,
       'completed',

--- a/packages/core/src/__tests__/agent-automation-projection.test.ts
+++ b/packages/core/src/__tests__/agent-automation-projection.test.ts
@@ -1,0 +1,109 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  agentAutomationReminderId,
+  isAgentAutomationPlanReminder,
+  mergePlanRemindersWithAgentAutomations,
+  parseAgentAutomationReminderId,
+  projectAgentAutomationAsPlanReminder,
+  type AgentAutomationProjectionSource,
+} from '../agent-automation-projection.js';
+import type { PlanReminder } from '../plan-reminders.js';
+
+function automation(
+  overrides: Partial<AgentAutomationProjectionSource> = {},
+): AgentAutomationProjectionSource {
+  return {
+    id: 'auto-1',
+    kind: 'cron',
+    name: 'Morning brief',
+    status: 'active',
+    prompt: 'Summarize overnight PRs.',
+    sessionId: 'session-1',
+    schedule: { type: 'cron', expression: '0 9 * * 1-5' },
+    createdAt: 1_700_000_000_000,
+    updatedAt: 1_700_000_100_000,
+    nextFireAt: 1_700_086_400_000,
+    lastFireAt: 1_700_000_050_000,
+    lastRunId: 'run-1',
+    fireCount: 2,
+    lastError: null,
+    durable: true,
+    ...overrides,
+  };
+}
+
+describe('agent automation → plan-reminder projection', () => {
+  it('projects a durable cron into a scheduled-tasks row with agent origin', () => {
+    const row = projectAgentAutomationAsPlanReminder(automation());
+    assert.equal(row.id, agentAutomationReminderId('auto-1'));
+    assert.equal(row.title, 'Morning brief');
+    assert.equal(row.note, 'Summarize overnight PRs.');
+    assert.equal(row.status, 'scheduled');
+    assert.equal(row.enabled, true);
+    assert.equal(row.nextRunAt, 1_700_086_400_000);
+    assert.deepEqual(row.schedule, {
+      kind: 'cron',
+      startAt: 1_700_000_000_000,
+      expression: '0 9 * * 1-5',
+    });
+    assert.equal(row.agentOrigin?.automationId, 'auto-1');
+    assert.equal(row.agentOrigin?.sessionId, 'session-1');
+    assert.equal(row.agentOrigin?.kind, 'cron');
+    assert.equal(row.agentOrigin?.durable, true);
+    assert.equal(row.lastRun?.status, 'triggered');
+    assert.equal(row.runCount, 2);
+    assert.equal(isAgentAutomationPlanReminder(row), true);
+  });
+
+  it('maps paused / completed / failed states', () => {
+    assert.equal(projectAgentAutomationAsPlanReminder(automation({ status: 'paused' })).status, 'paused');
+    assert.equal(
+      projectAgentAutomationAsPlanReminder(automation({ status: 'completed' })).status,
+      'completed',
+    );
+    assert.equal(
+      projectAgentAutomationAsPlanReminder(automation({ status: 'expired' })).status,
+      'completed',
+    );
+    const failed = projectAgentAutomationAsPlanReminder(
+      automation({ lastError: 'model rate limited' }),
+    );
+    assert.equal(failed.lastRun?.status, 'failed');
+    assert.equal(failed.lastRun?.message, 'model rate limited');
+  });
+
+  it('parses the stable agent-automation reminder id prefix', () => {
+    assert.equal(parseAgentAutomationReminderId(agentAutomationReminderId('x')), 'x');
+    assert.equal(parseAgentAutomationReminderId('plain-uuid'), undefined);
+  });
+
+  it('merges agent automations into the plan-reminder list without clobbering real rows', () => {
+    const real: PlanReminder = {
+      id: 'plan-1',
+      title: 'UI reminder',
+      note: '',
+      schedule: { kind: 'once', runAt: 1_700_100_000_000 },
+      delivery: { channel: 'local' },
+      status: 'scheduled',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+      nextRunAt: 1_700_100_000_000,
+      runs: [],
+      runCount: 0,
+    };
+    const heartbeatOnly = automation({
+      id: 'hb-1',
+      kind: 'heartbeat',
+      durable: false,
+      name: 'private heartbeat',
+    });
+    const cron = automation({ id: 'cron-1', name: 'Agent cron' });
+    const merged = mergePlanRemindersWithAgentAutomations([real], [heartbeatOnly, cron]);
+    assert.equal(merged.length, 2);
+    assert.equal(merged[0]?.id, 'plan-1');
+    assert.equal(merged[1]?.title, 'Agent cron');
+    assert.equal(merged[1]?.agentOrigin?.automationId, 'cron-1');
+  });
+});

--- a/packages/core/src/agent-automation-projection.ts
+++ b/packages/core/src/agent-automation-projection.ts
@@ -1,0 +1,154 @@
+/**
+ * Project a Runtime Host agent Automation into the scheduled-tasks list shape
+ * (`PlanReminder`) so the desktop Automations page can show agent-created
+ * cron/heartbeat jobs next to UI-created plan reminders.
+ *
+ * Storage for plan reminders never sees these rows — they are assembled when
+ * the renderer refreshes the combined list.
+ */
+
+import type { AutomationKind, AutomationSchedule, AutomationStatus } from './automation.js';
+import type {
+  PlanReminder,
+  PlanReminderAgentOrigin,
+  PlanReminderRunRecord,
+  PlanReminderSchedule,
+  PlanReminderStatus,
+} from './plan-reminders.js';
+
+/** Minimal automation fields needed for the scheduled-tasks projection. */
+export interface AgentAutomationProjectionSource {
+  readonly id: string;
+  readonly kind: AutomationKind;
+  readonly name: string;
+  readonly status: AutomationStatus;
+  readonly prompt: string;
+  readonly sessionId: string;
+  readonly schedule: AutomationSchedule;
+  readonly createdAt: number;
+  readonly updatedAt: number;
+  readonly nextFireAt: number | null;
+  readonly lastFireAt: number | null;
+  readonly lastRunId: string | null;
+  readonly fireCount: number;
+  readonly lastError: string | null;
+  readonly durable: boolean;
+}
+
+const AGENT_REMINDER_ID_PREFIX = 'agent-automation:';
+
+export function agentAutomationReminderId(automationId: string): string {
+  return `${AGENT_REMINDER_ID_PREFIX}${automationId}`;
+}
+
+export function parseAgentAutomationReminderId(reminderId: string): string | undefined {
+  if (!reminderId.startsWith(AGENT_REMINDER_ID_PREFIX)) return undefined;
+  const automationId = reminderId.slice(AGENT_REMINDER_ID_PREFIX.length);
+  return automationId.length > 0 ? automationId : undefined;
+}
+
+export function isAgentAutomationPlanReminder(
+  reminder: Pick<PlanReminder, 'agentOrigin' | 'id'>,
+): boolean {
+  return Boolean(reminder.agentOrigin) || parseAgentAutomationReminderId(reminder.id) !== undefined;
+}
+
+export function projectAgentAutomationAsPlanReminder(
+  automation: AgentAutomationProjectionSource,
+): PlanReminder {
+  const status = mapAutomationStatus(automation.status);
+  const enabled = automation.status === 'active';
+  const schedule = mapAutomationSchedule(automation);
+  const lastRun = mapAutomationLastRun(automation);
+  const agentOrigin: PlanReminderAgentOrigin = {
+    automationId: automation.id,
+    sessionId: automation.sessionId,
+    kind: automation.kind,
+    durable: automation.durable === true,
+  };
+  return {
+    id: agentAutomationReminderId(automation.id),
+    title: automation.name,
+    note: automation.prompt,
+    schedule,
+    // Agent automations execute as Runtime Host turns; local delivery is only
+    // a list-row placeholder (there is no toast/bot payload for them here).
+    delivery: { channel: 'local' },
+    status,
+    enabled,
+    createdAt: automation.createdAt,
+    updatedAt: automation.updatedAt,
+    ...(typeof automation.nextFireAt === 'number' ? { nextRunAt: automation.nextFireAt } : {}),
+    ...(lastRun ? { lastRun, runs: [lastRun] } : { runs: [] }),
+    runCount: automation.fireCount,
+    agentOrigin,
+  };
+}
+
+/**
+ * Merge persisted plan reminders with agent-automation projections.
+ * Real plan-reminder rows win on id collision (should not happen in practice
+ * because agent rows use the `agent-automation:` id prefix).
+ */
+export function mergePlanRemindersWithAgentAutomations(
+  planReminders: readonly PlanReminder[],
+  automations: readonly AgentAutomationProjectionSource[],
+): PlanReminder[] {
+  const projected = automations
+    // Heartbeats are session-private polling; the scheduled-tasks page is for
+    // standalone work. Show cron always, and durable jobs of either kind so a
+    // future durable form still surfaces.
+    .filter((automation) => automation.kind === 'cron' || automation.durable === true)
+    .map(projectAgentAutomationAsPlanReminder);
+  const seen = new Set(planReminders.map((reminder) => reminder.id));
+  const merged = [...planReminders];
+  for (const row of projected) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    merged.push(row);
+  }
+  return merged;
+}
+
+function mapAutomationStatus(status: AutomationStatus): PlanReminderStatus {
+  if (status === 'active') return 'scheduled';
+  if (status === 'paused') return 'paused';
+  return 'completed';
+}
+
+function mapAutomationSchedule(automation: AgentAutomationProjectionSource): PlanReminderSchedule {
+  const schedule = automation.schedule;
+  if (schedule.type === 'cron') {
+    return {
+      kind: 'cron',
+      startAt: automation.createdAt,
+      expression: schedule.expression,
+    };
+  }
+  if (schedule.type === 'once') {
+    const runAt =
+      typeof automation.nextFireAt === 'number'
+        ? automation.nextFireAt
+        : automation.createdAt + schedule.delaySeconds * 1000;
+    return { kind: 'once', runAt };
+  }
+  // interval: the list only needs a countdown anchor — nextFireAt is authoritative.
+  const runAt =
+    typeof automation.nextFireAt === 'number'
+      ? automation.nextFireAt
+      : automation.createdAt + schedule.seconds * 1000;
+  return { kind: 'once', runAt };
+}
+
+function mapAutomationLastRun(
+  automation: AgentAutomationProjectionSource,
+): PlanReminderRunRecord | undefined {
+  if (typeof automation.lastFireAt !== 'number') return undefined;
+  const failed = typeof automation.lastError === 'string' && automation.lastError.length > 0;
+  return {
+    id: automation.lastRunId ?? `automation-fire-${automation.fireCount}`,
+    at: automation.lastFireAt,
+    status: failed ? 'failed' : 'triggered',
+    message: failed ? automation.lastError! : 'Agent automation ran.',
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1072,6 +1072,7 @@ export {
 export type {
   CreatePlanReminderInput,
   PlanReminder,
+  PlanReminderAgentOrigin,
   PlanReminderBlockReason,
   PlanReminderBotDeliveryTarget,
   PlanReminderCronSchedule,
@@ -1113,6 +1114,15 @@ export {
   normalizePlanReminderTitle,
   normalizeUpdatePlanReminderInput,
 } from './plan-reminders.js';
+// agent-automation-projection.ts — agent Automation → scheduled-tasks list rows
+export type { AgentAutomationProjectionSource } from './agent-automation-projection.js';
+export {
+  agentAutomationReminderId,
+  isAgentAutomationPlanReminder,
+  mergePlanRemindersWithAgentAutomations,
+  parseAgentAutomationReminderId,
+  projectAgentAutomationAsPlanReminder,
+} from './agent-automation-projection.js';
 // foreign-session.ts (#1057) — untrusted Claude Code / Codex session
 // contracts + defensive parsing. Subpath @maka/core/foreign-session preferred.
 export type {

--- a/packages/core/src/plan-reminders.ts
+++ b/packages/core/src/plan-reminders.ts
@@ -63,6 +63,19 @@ export interface PlanReminderRunRecord {
   blockReason?: PlanReminderBlockReason;
 }
 
+/**
+ * When present, this row is a *projection* of a Runtime Host agent Automation
+ * (the Automation tool's durable cron / heartbeat) into the scheduled-tasks UI.
+ * It is never written to the plan-reminder SQLite store — only assembled at
+ * list time so agent-created schedules appear next to UI-created reminders.
+ */
+export interface PlanReminderAgentOrigin {
+  automationId: string;
+  sessionId: string;
+  kind: 'heartbeat' | 'cron';
+  durable: boolean;
+}
+
 export interface PlanReminder {
   id: string;
   title: string;
@@ -77,6 +90,8 @@ export interface PlanReminder {
   lastRun?: PlanReminderRunRecord;
   runs: PlanReminderRunRecord[];
   runCount: number;
+  /** UI-only: agent Automation projection. Absent for real plan reminders. */
+  agentOrigin?: PlanReminderAgentOrigin;
 }
 
 export interface CreatePlanReminderInput {

--- a/packages/ui/src/plan-reminder-copy.ts
+++ b/packages/ui/src/plan-reminder-copy.ts
@@ -141,6 +141,11 @@ export interface PlanReminderCopy {
     created: string;
     runs: string;
     noRuns: string;
+    /** Badge for rows projected from the agent Automation tool. */
+    agentSource: string;
+    agentSourceHint: string;
+    /** Delivery column when the task runs as an agent session. */
+    agentDelivery: string;
   };
 }
 
@@ -166,7 +171,18 @@ const PLAN_REMINDER_COPY = {
       title: '定时任务', refreshing: '正在刷新定时任务', refresh: '刷新定时任务', create: '新建定时任务', keepAwake: '保持系统唤醒', pageSettings: '定时任务页面设置', keepAwakeErrorTitle: '无法更新保持系统唤醒', keepAwakeErrorFallback: '更新保持系统唤醒设置失败，请稍后重试。', viewsAriaLabel: '计划提醒视图', tasks: '我的定时任务', runs: '执行记录', filtersAriaLabel: '计划提醒筛选', sort: '排序', sortOptions: [['created-desc', '按创建时间倒序'], ['next-run-asc', '按下次触发升序'], ['updated-desc', '按更新时间倒序']], searchLabel: '搜索计划提醒', searchPlaceholder: '搜索标题、备注、投递或执行记录…', state: '状态', filterOption: (label, count) => `${label} ${count}`, active: '进行中', all: '全部', range: '范围', rangeOptions: [['day', '今天'], ['week', '近 7 天'], ['month', '近 30 天'], ['all', '全部记录']], searchMatches: (count) => `找到 ${count} 个匹配提醒`, clearSearch: '清除搜索', noSearchTitle: '没有匹配的提醒', noFilterTitle: '当前筛选没有提醒', noSearchBody: '调整搜索词，或切换状态筛选查看其他提醒。', noFilterBody: '切换筛选查看其他状态，或创建新的计划提醒。', emptyTitle: '还没有定时任务', emptyBody: '创建一个提醒，让 Maka 在指定时间继续这项工作。', listAriaLabel: '计划提醒列表', inspectorOpened: (title) => `已打开「${title}」的任务详情`, edit: '编辑', duplicate: '复制', triggering: '触发中…', triggerNow: '立即触发', snoozing: '延后中…', snooze: '延后 10 分钟', clearing: '清空中…', clearRuns: '清空记录', deleting: '删除中…', delete: '删除', nextRun: (time) => `下次触发：${time}`, recentRun: (time) => `最近 ${time}`, unscheduled: '未安排', noRunsTitle: '暂无执行记录', noRunsBody: '提醒触发、手动执行或投递失败后，会在这里保留最近记录。', showAllTime: '显示全部时间', runsAriaLabel: '计划提醒执行记录', activeCount: (count) => `${count} 个进行中`,
     },
     detail: {
-      label: '任务详情', enabled: '启用', recurrence: '重复', nextRun: '下次触发', lastRun: '最近触发', delivery: '投递', created: '创建于', runs: '执行记录', noRuns: '这个任务还没有执行记录。',
+      label: '任务详情',
+      enabled: '启用',
+      recurrence: '重复',
+      nextRun: '下次触发',
+      lastRun: '最近触发',
+      delivery: '投递',
+      created: '创建于',
+      runs: '执行记录',
+      noRuns: '这个任务还没有执行记录。',
+      agentSource: 'Agent 定时任务',
+      agentSourceHint: '由对话里的 Automation 工具创建。到点会新开会话执行提示词；可暂停、恢复或删除，不可用提醒表单编辑。',
+      agentDelivery: 'Agent 会话执行',
     },
   },
   en: {
@@ -190,7 +206,19 @@ const PLAN_REMINDER_COPY = {
       title: 'Scheduled tasks', refreshing: 'Refreshing scheduled tasks', refresh: 'Refresh scheduled tasks', create: 'New scheduled task', keepAwake: 'Keep system awake', pageSettings: 'Scheduled task page settings', keepAwakeErrorTitle: 'Could not update Keep system awake', keepAwakeErrorFallback: 'Could not update the Keep system awake setting. Try again later.', viewsAriaLabel: 'Scheduled task views', tasks: 'My scheduled tasks', runs: 'Run history', filtersAriaLabel: 'Scheduled task filters', sort: 'Sort', sortOptions: [['created-desc', 'Newest created first'], ['next-run-asc', 'Next run first'], ['updated-desc', 'Recently updated first']], searchLabel: 'Search scheduled tasks', searchPlaceholder: 'Search titles, notes, delivery, or run history…', state: 'Status', filterOption: (label, count) => `${label} ${count}`, active: 'Active', all: 'All', range: 'Range', rangeOptions: [['day', 'Today'], ['week', 'Last 7 days'], ['month', 'Last 30 days'], ['all', 'All runs']], searchMatches: (count) => `${count} matching ${count === 1 ? 'reminder' : 'reminders'}`, clearSearch: 'Clear search', noSearchTitle: 'No matching reminders', noFilterTitle: 'No reminders in this filter', noSearchBody: 'Change the search terms or status filter to find other reminders.', noFilterBody: 'Change the filter or create a new scheduled task.', emptyTitle: 'No scheduled tasks yet', emptyBody: 'Create a reminder so Maka can continue this work at the right time.', listAriaLabel: 'Scheduled task list', inspectorOpened: (title) => `Opened the task details for ${title}`, edit: 'Edit', duplicate: 'Duplicate', triggering: 'Triggering…', triggerNow: 'Trigger now', snoozing: 'Snoozing…', snooze: 'Snooze 10 minutes', clearing: 'Clearing…', clearRuns: 'Clear history', deleting: 'Deleting…', delete: 'Delete', nextRun: (time) => `Next run: ${time}`, recentRun: (time) => `Last run ${time}`, unscheduled: 'Not scheduled', noRunsTitle: 'No run history', noRunsBody: 'Triggered reminders, manual runs, and delivery failures appear here.', showAllTime: 'All time', runsAriaLabel: 'Scheduled task run history', activeCount: (count) => `${count} active`,
     },
     detail: {
-      label: 'Task details', enabled: 'Enabled', recurrence: 'Repeats', nextRun: 'Next run', lastRun: 'Last run', delivery: 'Delivery', created: 'Created', runs: 'Run history', noRuns: 'This task has not run yet.',
+      label: 'Task details',
+      enabled: 'Enabled',
+      recurrence: 'Repeats',
+      nextRun: 'Next run',
+      lastRun: 'Last run',
+      delivery: 'Delivery',
+      created: 'Created',
+      runs: 'Run history',
+      noRuns: 'This task has not run yet.',
+      agentSource: 'Agent scheduled task',
+      agentSourceHint:
+        'Created by the Automation tool in a chat. When due, Maka starts a fresh session with the prompt. You can pause, resume, or delete it here — the reminder form cannot edit it.',
+      agentDelivery: 'Agent session run',
     },
   },
 } satisfies UiCatalog<PlanReminderCopy>;

--- a/packages/ui/src/plan-reminder-inspector.tsx
+++ b/packages/ui/src/plan-reminder-inspector.tsx
@@ -11,7 +11,7 @@
 // delete controls all live here, where they are plain buttons with room for
 // real labels instead of six entries behind a per-row overflow menu.
 
-import type { PlanReminder } from '@maka/core';
+import { isAgentAutomationPlanReminder, type PlanReminder } from '@maka/core';
 import {
   Button,
   Divider,
@@ -51,6 +51,7 @@ export function PlanReminderInspector(props: {
   const locale = useUiLocale();
   const copy = getPlanReminderCopy(locale);
   const { reminder } = props;
+  const isAgentAutomation = isAgentAutomationPlanReminder(reminder);
   const isCompleted = reminder.status === 'completed';
   const pending = Array.from(props.pendingActionKeys).some((key) => key.startsWith(`${reminder.id}:`));
   const key = (action: string) => props.pendingActionKeys.has(`${reminder.id}:${action}`);
@@ -66,9 +67,17 @@ export function PlanReminderInspector(props: {
           <Text type="supporting" color="secondary">
             {planReminderStatusLabel(reminder.status, locale)}
           </Text>
+          {isAgentAutomation ? (
+            <Text type="supporting" color="secondary">
+              · {copy.detail.agentSource}
+            </Text>
+          ) : null}
         </HStack>
         <Heading level={2}>{reminder.title}</Heading>
         {reminder.note ? <Text type="body" color="secondary">{reminder.note}</Text> : null}
+        {isAgentAutomation ? (
+          <Text type="supporting" color="secondary">{copy.detail.agentSourceHint}</Text>
+        ) : null}
       </VStack>
 
       {!isCompleted && (
@@ -84,26 +93,28 @@ export function PlanReminderInspector(props: {
         </HStack>
       )}
 
-      <HStack gap={2} wrap="wrap">
-        <Button
-          size="sm"
-          label={key('trigger') ? copy.page.triggering : copy.page.triggerNow}
-          isDisabled={pending || !reminder.enabled}
-          onClick={props.onTriggerNow}
-        />
-        <Button
-          size="sm"
-          variant="secondary"
-          label={key('snooze') ? copy.page.snoozing : copy.page.snooze}
-          isDisabled={
-            pending
-            || !reminder.enabled
-            || reminder.status !== 'scheduled'
-            || typeof reminder.nextRunAt !== 'number'
-          }
-          onClick={props.onSnooze}
-        />
-      </HStack>
+      {!isAgentAutomation ? (
+        <HStack gap={2} wrap="wrap">
+          <Button
+            size="sm"
+            label={key('trigger') ? copy.page.triggering : copy.page.triggerNow}
+            isDisabled={pending || !reminder.enabled}
+            onClick={props.onTriggerNow}
+          />
+          <Button
+            size="sm"
+            variant="secondary"
+            label={key('snooze') ? copy.page.snoozing : copy.page.snooze}
+            isDisabled={
+              pending
+              || !reminder.enabled
+              || reminder.status !== 'scheduled'
+              || typeof reminder.nextRunAt !== 'number'
+            }
+            onClick={props.onSnooze}
+          />
+        </HStack>
+      ) : null}
 
       <Divider />
 
@@ -122,7 +133,11 @@ export function PlanReminderInspector(props: {
           </MetadataListItem>
         ) : null}
         <MetadataListItem label={copy.detail.delivery}>
-          <Text type="body">{formatPlanReminderDeliveryTargetLabel(reminder.delivery, locale)}</Text>
+          <Text type="body">
+            {isAgentAutomation
+              ? copy.detail.agentDelivery
+              : formatPlanReminderDeliveryTargetLabel(reminder.delivery, locale)}
+          </Text>
         </MetadataListItem>
         <MetadataListItem label={copy.detail.created}>
           <Text type="body">{formatReminderTime(reminder.createdAt, locale)}</Text>
@@ -136,7 +151,7 @@ export function PlanReminderInspector(props: {
           <StackItem size="fill">
             <Text type="label" color="secondary">{copy.detail.runs}</Text>
           </StackItem>
-          {reminder.runs.length > 0 && !isCompleted ? (
+          {reminder.runs.length > 0 && !isCompleted && !isAgentAutomation ? (
             <Button
               size="sm"
               variant="ghost"
@@ -172,14 +187,24 @@ export function PlanReminderInspector(props: {
       <Divider />
 
       <HStack gap={2} wrap="wrap">
-        <Button
-          size="sm"
-          variant="secondary"
-          label={copy.page.edit}
-          isDisabled={pending || isCompleted}
-          onClick={props.onEdit}
-        />
-        <Button size="sm" variant="secondary" label={copy.page.duplicate} isDisabled={pending} onClick={props.onDuplicate} />
+        {!isAgentAutomation ? (
+          <>
+            <Button
+              size="sm"
+              variant="secondary"
+              label={copy.page.edit}
+              isDisabled={pending || isCompleted}
+              onClick={props.onEdit}
+            />
+            <Button
+              size="sm"
+              variant="secondary"
+              label={copy.page.duplicate}
+              isDisabled={pending}
+              onClick={props.onDuplicate}
+            />
+          </>
+        ) : null}
         <StackItem size="fill" />
         <Button
           size="sm"

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -6,6 +6,7 @@ import type { PlanReminder, PlanReminderStatus } from '@maka/core';
 import {
   generalizedErrorMessage,
   generalizedErrorMessageChinese,
+  isAgentAutomationPlanReminder,
 } from '@maka/core';
 import {
   type PlanReminderFormSeed,
@@ -495,6 +496,7 @@ export function PlanReminderPanel(props: {
                        reminder and a healthy one identical on the row, so the
                        page could only be read by opening every entry. */
                     description={[
+                      isAgentAutomationPlanReminder(reminder) ? copy.detail.agentSource : null,
                       runException
                         ? runStatusLabel(runException.status, locale)
                         : reminder.status === 'scheduled'


### PR DESCRIPTION
## Summary

Agent-created scheduled tasks (the `Automation` tool, durable `cron`) were stored only in Runtime Host and never appeared on the desktop **定时任务** page, which only listed SQLite plan reminders.

This PR merges agent automations into `plans:list` as projected rows so they show up next to UI-created reminders, and wires pause / resume / delete through Runtime Host.

### Root cause
Two parallel systems:
1. **Plan reminders** — desktop UI + local toast/bot delivery  
2. **Agent Automations** — Runtime Host durable crons that fire real sessions  

The agent creates (2); the page only showed (1).

### Changes
- Project Automation → `PlanReminder` rows (`agent-automation:` id prefix + `agentOrigin`)
- `plans:list` merges durable/cron automations from the host (SQLite fallback when no sessions)
- Inspector: badge + hint for agent tasks; hide edit / duplicate / trigger-now / snooze; keep enable toggle + delete
- Refresh when opening the page + poll every 12s while open (no host catalog push events yet)

### Tests
- `packages/core` projection unit tests
- Desktop list/dedupe/failure unit tests
- UI / core builds + existing plan-reminder tests green

## Test plan
- [ ] Ask the agent to create a durable cron via Automation tool
- [ ] Open 定时任务 — the new task appears with **Agent 定时任务** badge
- [ ] Pause / resume from the inspector
- [ ] Delete from the inspector removes the host automation
- [ ] UI-created plan reminders still create/edit/trigger/snooze as before
- [ ] Empty workspace / host-not-ready still shows plan reminders only