### PR TITLE
fix(cli): avoid Windows taskbar progress stalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Fixed
+
+- Disabled TUI taskbar-progress keepalives by default on native Windows and
+  Windows Terminal sessions, where repeated OSC 9;4 updates can make Explorer's
+  taskbar unresponsive. `MAKA_TASKBAR_PROGRESS=1` restores the prior behavior,
+  while `MAKA_TASKBAR_PROGRESS=0` disables it explicitly.
+
 ## 0.1.10 - 2026-08-10
 
 ### Highlights

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -48,7 +48,11 @@ import type {
   OnboardingVerifyResult,
 } from '../pi-tui-contracts.js';
 import type { ModelInfo, ProviderType } from '@maka/core/llm-connections';
-import { runMakaPiTui as runMakaPiTuiImpl, type MakaPiTuiInput } from '../pi-tui-runner.js';
+import {
+  resolveTaskbarProgress,
+  runMakaPiTui as runMakaPiTuiImpl,
+  type MakaPiTuiInput,
+} from '../pi-tui-runner.js';
 import { AUTO_RECAP_IDLE_MS } from '../session-recap.js';
 import { _setColorLevelForTesting } from '../tui-ansi.js';
 import { BUSY_SPINNER_FRAMES } from '../tui-attention.js';
@@ -84,6 +88,7 @@ function runMakaPiTui(input: TestMakaPiTuiInput): Promise<void> {
   return runMakaPiTuiImpl({
     ...rest,
     driver,
+    taskbarProgress: input.taskbarProgress ?? true,
     turnActivity: turnActivity ?? createTestTurnActivity(),
   });
 }
@@ -158,6 +163,72 @@ function fakeOnboardingSurface(opts: FakeOnboardingOpts = {}): MakaOnboardingSur
 }
 
 describe('Maka Pi TUI runner', () => {
+  test('disables taskbar progress on Windows and Windows Terminal by default', () => {
+    assert.equal(resolveTaskbarProgress(undefined, { platform: 'win32' }), false);
+    assert.equal(
+      resolveTaskbarProgress(undefined, {
+        platform: 'linux',
+        windowsTerminalSession: 'session-id',
+      }),
+      false,
+    );
+    assert.equal(resolveTaskbarProgress(undefined, { platform: 'linux' }), true);
+    assert.equal(resolveTaskbarProgress(undefined, { platform: 'darwin' }), true);
+  });
+
+  test('allows environment and explicit taskbar progress overrides', () => {
+    assert.equal(
+      resolveTaskbarProgress(undefined, { platform: 'win32', override: ' true ' }),
+      true,
+    );
+    assert.equal(resolveTaskbarProgress(undefined, { platform: 'linux', override: '0' }), false);
+    assert.equal(
+      resolveTaskbarProgress(undefined, { platform: 'win32', override: 'invalid' }),
+      false,
+    );
+    assert.equal(
+      resolveTaskbarProgress(false, {
+        platform: 'linux',
+        override: '1',
+      }),
+      false,
+    );
+    assert.equal(
+      resolveTaskbarProgress(true, {
+        platform: 'win32',
+        override: '0',
+      }),
+      true,
+    );
+  });
+
+  test('does not publish taskbar progress when the policy disables it', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new InterruptibleTurnDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+      taskbarProgress: false,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => driver.prompts.length === 1);
+    terminal.input('\x1b');
+    terminal.input('\x1b');
+    await waitFor(() => driver.stopCalls === 1);
+    terminal.input('/exit');
+    terminal.input('\r');
+    await run;
+
+    assert.deepEqual(terminal.progressStates, []);
+  });
+
   test('restores the terminal before exiting on SIGTERM', async () => {
     const { code, signal, stdout } = await runSignalExitProbe('SIGTERM');
 
@@ -6727,6 +6798,7 @@ class UserQuestionPromptDriver implements MakaSessionDriver {
 
 class InterruptibleTurnDriver implements MakaSessionDriver {
   stopCalls = 0;
+  readonly prompts: string[] = [];
   private releaseTurn: (() => void) | null = null;
 
   async listSessions(): Promise<SessionSummary[]> {
@@ -6734,6 +6806,7 @@ class InterruptibleTurnDriver implements MakaSessionDriver {
   }
 
   preparePrompt(prompt: string): Promise<MakaPreparedSessionTurn> {
+    this.prompts.push(prompt);
     return prepareTestPrompt(this, prompt);
   }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -131,6 +131,13 @@ export interface MakaPiTuiInput {
   /** Maximum context tokens for the active model, for the statusline ctx segment. */
   modelContextWindow?: number;
   terminal?: Terminal;
+  /**
+   * Whether turns and control actions publish terminal taskbar progress.
+   * Defaults off on native Windows and Windows Terminal sessions because its
+   * OSC 9;4 keepalive can make Explorer's taskbar unresponsive. Injectable so
+   * tests cross the same policy seam without depending on their host platform.
+   */
+  taskbarProgress?: boolean;
   /** Starts the CLI process-exit deadline after terminal restore, before outer cleanup. */
   onProcessExit?: (exitCode: number, error?: Error) => void;
   /**
@@ -191,8 +198,33 @@ export interface MakaPiTuiInput {
   foreignSessions?: MakaForeignSessionReader;
 }
 
+interface TaskbarProgressEnvironment {
+  readonly platform: NodeJS.Platform;
+  readonly override?: string;
+  readonly windowsTerminalSession?: string;
+}
+
+export function resolveTaskbarProgress(
+  setting: boolean | undefined,
+  environment: TaskbarProgressEnvironment = {
+    platform: process.platform,
+    override: process.env.MAKA_TASKBAR_PROGRESS,
+    windowsTerminalSession: process.env.WT_SESSION,
+  },
+): boolean {
+  if (setting !== undefined) return setting;
+  const forced = environment.override?.trim().toLowerCase();
+  if (forced === '1' || forced === 'true') return true;
+  if (forced === '0' || forced === 'false') return false;
+  return environment.platform !== 'win32' && environment.windowsTerminalSession === undefined;
+}
+
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const terminal = input.terminal ?? new ProcessTerminal();
+  const taskbarProgress = resolveTaskbarProgress(input.taskbarProgress);
+  const setTaskbarProgress = (active: boolean): void => {
+    if (taskbarProgress) terminal.setProgress(active);
+  };
   const tui = new TUI(terminal);
   const state = createMakaPiTranscriptState();
   let cwd = input.cwd;
@@ -517,7 +549,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     busy = true;
     const activity = beginActivity();
     editor.disableSubmit = true;
-    terminal.setProgress(true);
+    setTaskbarProgress(true);
     attention.controlStarted();
     requestRender();
     let sessionActivity: SessionActivityLease | undefined;
@@ -533,7 +565,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       busy = false;
       activity.finish();
       editor.disableSubmit = false;
-      terminal.setProgress(false);
+      setTaskbarProgress(false);
       attention.controlEnded();
       requestRender();
       startPendingAttachedTurn();
@@ -558,7 +590,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     shellRunElapsedTicker.dispose();
     stopTurnElapsedTicker();
     stopFallbackRetry();
-    terminal.setProgress(false);
+    setTaskbarProgress(false);
     // Drop the busy / attention title marker so the tab is not handed back to
     // the shell still marked busy when the session exits.
     attention.reset();
@@ -985,7 +1017,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     interruptRequested = false;
     lastTurnEscapeAt = 0;
     editor.disableSubmit = false;
-    terminal.setProgress(true);
+    setTaskbarProgress(true);
     attention.promptTurnStarted();
     requestRender();
 
@@ -997,7 +1029,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       stopTurnElapsedTicker();
       interruptRequested = false;
       editor.disableSubmit = false;
-      terminal.setProgress(false);
+      setTaskbarProgress(false);
       attention.promptTurnEnded();
       // A turn ending is activity too — resets the idle clock the next
       // submission's auto-recap check measures against.


### PR DESCRIPTION
## Summary

While using Maka in Windows Terminal, I found that an active TUI turn could make
the Windows taskbar visibly stutter. The TUI was keeping pi-tui's indeterminate
taskbar progress alive once per second; on the affected machine, those repeated
`OSC 9;4` updates kept Explorer near one full CPU core. The same behavior occurs
when Maka runs inside a WSL tab, where Node reports Linux.

This change disables taskbar-progress updates by default on native Windows and
inside Windows Terminal (`WT_SESSION`). Other terminals keep the existing
behavior. `MAKA_TASKBAR_PROGRESS=1` restores taskbar progress explicitly, and
`MAKA_TASKBAR_PROGRESS=0` can disable it elsewhere.

All turn, control-action, and cleanup paths now go through one small policy seam.
The in-TUI busy state and title spinner are unchanged.

Fixes #2647

## Verification

- `npm --workspace maka-agent test` — 360 tests passed
- `npm --workspace maka-agent run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

The Windows/WSL runtime A/B evidence is recorded in #2647. I did not execute this
branch on a Windows host from the current development environment.

## Review focus

- Precedence is explicit input, then `MAKA_TASKBAR_PROGRESS`, then the
  platform/Windows Terminal default.
- `WT_SESSION` intentionally covers WSL without treating every Linux terminal as
  Windows.
- No raw `terminal.setProgress(...)` call remains outside the policy seam in the
  TUI runner.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

<details>
<summary>中文对照</summary>

## 概要

我在 Windows Terminal 中实际使用 Maka 时发现，TUI 有活跃任务期间会让
Windows 任务栏明显卡顿。TUI 每秒维持一次 pi-tui 的不确定进度状态；在发生
问题的机器上，重复的 `OSC 9;4` 更新会让 Explorer 长时间接近占满一个 CPU
核心。在 Windows Terminal 的 WSL 标签页里运行 Maka 也会出现同样问题，
但此时 Node 报告的平台是 Linux。

这个改动默认关闭原生 Windows 以及 Windows Terminal 会话
（`WT_SESSION`）中的任务栏进度更新，其他终端保持原行为。
`MAKA_TASKBAR_PROGRESS=1` 可以显式恢复任务栏进度，
`MAKA_TASKBAR_PROGRESS=0` 可以在其他环境中显式关闭。

Turn、控制操作和终端清理路径现在统一经过一个很小的策略 Seam。TUI 内部的
忙碌状态和标题栏 spinner 不受影响。

修复 #2647。

## 验证

- `npm --workspace maka-agent test` — 360 项测试通过
- `npm --workspace maka-agent run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

Windows/WSL 的运行时 A/B 证据已记录在 #2647。本开发环境不是 Windows，
因此没有在这里直接运行该分支的 Windows 构建。

## 审查重点

- 优先级为：显式输入、`MAKA_TASKBAR_PROGRESS`、平台/Windows Terminal 默认值。
- 使用 `WT_SESSION` 是为了覆盖 WSL，同时不影响所有普通 Linux 终端。
- TUI runner 中所有 `terminal.setProgress(...)` 调用都经过同一个策略 Seam。

</details>
