### PR TITLE
test(windows): exercise installer lifecycle

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -135,6 +135,10 @@ jobs:
         if: matrix.platform == 'windows'
         run: npm run verify:windows-x64 -- "${{ steps.release.outputs.exe }}"
 
+      - name: Exercise clean Windows install and uninstall
+        if: matrix.platform == 'windows'
+        run: npm run verify:windows-installer -- "${{ steps.release.outputs.exe }}"
+
       - name: Upload the verified release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -19,6 +19,7 @@ on:
       - 'scripts/prepare-bundled-git.mjs'
       - 'scripts/prepare-bundled-git.test.mjs'
       - 'scripts/verify-windows-x64.mjs'
+      - 'scripts/verify-windows-installer-lifecycle.mjs'
       - 'scripts/verify-packaged-app.mjs'
       - 'scripts/npm-spawn.mjs'
       - 'scripts/generate-third-party-notices.mjs'
@@ -64,3 +65,8 @@ jobs:
         run: |
           version="$(node -p "require('./apps/desktop/package.json').version")"
           npm run verify:windows-x64 -- "apps/desktop/release/Maka-${version}-win-x64.exe"
+
+      - name: Exercise clean install and uninstall
+        run: |
+          version="$(node -p "require('./apps/desktop/package.json').version")"
+          npm run verify:windows-installer -- "apps/desktop/release/Maka-${version}-win-x64.exe"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "verify:macos-arm64": "node scripts/verify-macos-arm64-dmg.mjs",
     "package:windows-x64": "node scripts/package-windows-x64.mjs",
     "verify:windows-x64": "node scripts/verify-windows-x64.mjs",
+    "verify:windows-installer": "node scripts/verify-windows-installer-lifecycle.mjs",
     "measure:session-bundle": "node scripts/measure-session-bundle.mjs",
     "astryx:theme": "node scripts/build-astryx-theme.mjs",
     "sync:model-metadata": "node scripts/sync-model-metadata.mjs",

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -136,6 +136,7 @@ const EXTENDED_SCRIPT_FILES = new Set([
   // release path even when nothing macOS-specific was touched.
   'scripts/verify-packaged-app.mjs',
   'scripts/verify-macos-arm64-dmg.mjs',
+  'scripts/verify-windows-installer-lifecycle.mjs',
   'scripts/verify-windows-x64.mjs',
   'scripts/windows-x64-release.test.mjs',
 ]);

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -214,6 +214,7 @@ test('release tooling and the release config select the checks that cover them',
   for (const path of [
     'scripts/npm-spawn.mjs',
     'scripts/package-windows-x64.mjs',
+    'scripts/verify-windows-installer-lifecycle.mjs',
     'scripts/verify-windows-x64.mjs',
     'scripts/windows-x64-release.test.mjs',
     'scripts/verify-packaged-app.mjs',

--- a/scripts/verify-windows-installer-lifecycle.mjs
+++ b/scripts/verify-windows-installer-lifecycle.mjs
@@ -1,0 +1,175 @@
+import { access, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { runCommand } from './verify-packaged-app.mjs';
+import { powerShellLiteral, verifyPackagedWindowsApp } from './verify-windows-x64.mjs';
+
+const uninstallExecutableName = 'Uninstall Maka.exe';
+const temporaryCleanupRetries = 20;
+const temporaryCleanupRetryDelayMs = 250;
+
+function delay(milliseconds) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+}
+
+export async function listInstalledProcesses(installDirectory, { run = runCommand } = {}) {
+  const root = `${resolve(installDirectory)}${sep}`;
+  const script = String.raw`
+$root = [IO.Path]::GetFullPath(${powerShellLiteral(root)})
+$matches = @(
+  Get-CimInstance Win32_Process | ForEach-Object {
+    if ($_.ExecutablePath) {
+      $path = [IO.Path]::GetFullPath($_.ExecutablePath)
+      if ($path.StartsWith($root, [StringComparison]::OrdinalIgnoreCase)) {
+        [PSCustomObject]@{ processId = $_.ProcessId; name = $_.Name; path = $path }
+      }
+    }
+  }
+)
+$matches | ConvertTo-Json -Compress
+`;
+  const { stdout } = await run('powershell', ['-NoProfile', '-NonInteractive', '-Command', script]);
+  if (!stdout.trim()) return [];
+  const parsed = JSON.parse(stdout);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+export async function waitForInstalledProcessesToExit(
+  installDirectory,
+  {
+    listProcesses = listInstalledProcesses,
+    timeoutMs = 60_000,
+    pollIntervalMs = 1_000,
+    sleep = delay,
+  } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  let processes = await listProcesses(installDirectory);
+  while (processes.length > 0) {
+    if (Date.now() >= deadline) {
+      const summary = processes.map(({ processId, name }) => `${name} (${processId})`).join(', ');
+      throw new Error(
+        `Installed Maka processes did not exit within ${timeoutMs}ms: ${summary || '<unknown>'}.`,
+      );
+    }
+    await sleep(pollIntervalMs);
+    processes = await listProcesses(installDirectory);
+  }
+}
+
+export async function waitUntilMissing(
+  path,
+  { probe = access, timeoutMs = 30_000, pollIntervalMs = 250 } = {},
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (true) {
+    try {
+      await probe(path);
+    } catch (error) {
+      if (error?.code === 'ENOENT') return;
+      throw error;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`Installer cleanup did not remove ${path} within ${timeoutMs}ms.`);
+    }
+    await delay(pollIntervalMs);
+  }
+}
+
+export async function verifyWindowsInstallerLifecycle(
+  inputPath,
+  {
+    platform = process.platform,
+    makeTemporaryDirectory = () => mkdtemp(join(tmpdir(), 'maka-installer-lifecycle-')),
+    run = runCommand,
+    verifyApp = verifyPackagedWindowsApp,
+    requirePath = access,
+    waitForMissing = waitUntilMissing,
+    waitForProcessesToExit = waitForInstalledProcessesToExit,
+    remove = rm,
+    resolvePath = resolve,
+  } = {},
+) {
+  if (platform !== 'win32') {
+    throw new Error('Windows installer lifecycle verification requires Windows.');
+  }
+  if (!inputPath) {
+    throw new Error('Usage: npm run verify:windows-installer -- <path-to-exe>');
+  }
+
+  const installer = resolvePath(inputPath);
+  if (!installer.endsWith('.exe')) {
+    throw new Error(`Expected the NSIS installer .exe, found ${basename(installer)}.`);
+  }
+  await requirePath(installer);
+
+  const temporaryDirectory = await makeTemporaryDirectory();
+  const installDirectory = join(temporaryDirectory, 'installed');
+  const smokeDirectory = join(temporaryDirectory, 'smoke');
+  const uninstaller = join(installDirectory, uninstallExecutableName);
+  let installationStarted = false;
+  let uninstallCompleted = false;
+  let primaryError;
+
+  try {
+    console.log(`[verify-windows-installer] installing into ${installDirectory}`);
+    installationStarted = true;
+    // NSIS requires /D to be the final argument. spawn passes it directly, so
+    // spaces in a runner path do not need shell quoting.
+    await run(installer, ['/S', `/D=${installDirectory}`], { timeoutMs: 120_000 });
+    await requirePath(uninstaller);
+
+    console.log('[verify-windows-installer] verifying the installed application');
+    await verifyApp(installDirectory, { workingDirectory: smokeDirectory });
+
+    console.log('[verify-windows-installer] waiting for installed processes to exit');
+    await waitForProcessesToExit(installDirectory);
+
+    console.log('[verify-windows-installer] uninstalling');
+    await run(uninstaller, ['/S'], { timeoutMs: 120_000 });
+    await waitForMissing(installDirectory);
+    uninstallCompleted = true;
+    console.log('[verify-windows-installer] lifecycle verified');
+
+    return { installer, installDirectory };
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    const cleanupErrors = [];
+    if (installationStarted && !uninstallCompleted) {
+      try {
+        await requirePath(uninstaller);
+        await run(uninstaller, ['/S'], { timeoutMs: 120_000 });
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+    try {
+      await remove(temporaryDirectory, {
+        recursive: true,
+        force: true,
+        maxRetries: temporaryCleanupRetries,
+        retryDelay: temporaryCleanupRetryDelayMs,
+      });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (cleanupErrors.length > 0) {
+      const cleanupFailure = new AggregateError(
+        cleanupErrors,
+        'Installer verifier cleanup failed.',
+      );
+      if (!primaryError) throw cleanupFailure;
+      if (primaryError instanceof Error && primaryError.cause === undefined) {
+        primaryError.cause = cleanupFailure;
+      }
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await verifyWindowsInstallerLifecycle(process.argv[2]);
+  console.log(`Verified installer lifecycle for ${result.installer}`);
+}

--- a/scripts/windows-x64-release.test.mjs
+++ b/scripts/windows-x64-release.test.mjs
@@ -15,6 +15,9 @@ const {
   verifyPackagedWindowsApp,
   verifyWindowsX64Release,
 } = await import(new URL('verify-windows-x64.mjs', import.meta.url));
+const { verifyWindowsInstallerLifecycle, waitForInstalledProcessesToExit } = await import(
+  new URL('verify-windows-installer-lifecycle.mjs', import.meta.url)
+);
 
 const desktopManifest = JSON.parse(
   await readFile(new URL('../apps/desktop/package.json', import.meta.url), 'utf8'),
@@ -198,4 +201,80 @@ test('the PE machine is read from the executable header', async () => {
   } finally {
     await rm(directory, { recursive: true, force: true });
   }
+});
+
+test('the final NSIS artifact waits for installed processes before uninstalling', async () => {
+  const calls = [];
+
+  await verifyWindowsInstallerLifecycle('C:/release/Maka.exe', {
+    platform: 'win32',
+    makeTemporaryDirectory: async () => 'C:/runner-temp/lifecycle',
+    requirePath: async () => {},
+    run: async (command, args, options) => calls.push({ command, args, options }),
+    verifyApp: async (path) => calls.push({ verified: path }),
+    waitForProcessesToExit: async (path) => calls.push({ processesExited: path }),
+    waitForMissing: async (path) => calls.push({ missing: path }),
+    resolvePath: (path) => path,
+    remove: async () => {},
+  });
+
+  assert.deepEqual(calls[0].args, ['/S', '/D=C:/runner-temp/lifecycle/installed']);
+  assert.deepEqual(calls.slice(1, 4), [
+    { verified: 'C:/runner-temp/lifecycle/installed' },
+    { processesExited: 'C:/runner-temp/lifecycle/installed' },
+    {
+      command: 'C:/runner-temp/lifecycle/installed/Uninstall Maka.exe',
+      args: ['/S'],
+      options: { timeoutMs: 120_000 },
+    },
+  ]);
+  assert.deepEqual(calls[4], { missing: 'C:/runner-temp/lifecycle/installed' });
+});
+
+test('installed processes must exit before the lifecycle can continue', async () => {
+  const observations = [
+    [{ processId: 42, name: 'Maka.exe' }],
+    [{ processId: 43, name: 'Maka.exe' }],
+    [],
+  ];
+  const sleeps = [];
+  await waitForInstalledProcessesToExit('C:/Maka', {
+    listProcesses: async () => observations.shift(),
+    sleep: async (milliseconds) => sleeps.push(milliseconds),
+  });
+  assert.deepEqual(sleeps, [1_000, 1_000]);
+});
+
+test('a final cleanup failure does not replace the primary verification error', async () => {
+  const primary = new Error('installed app verification failed');
+  const cleanup = Object.assign(new Error('temporary directory is locked'), { code: 'EBUSY' });
+
+  await assert.rejects(
+    verifyWindowsInstallerLifecycle('C:/release/Maka.exe', {
+      platform: 'win32',
+      makeTemporaryDirectory: async () => 'C:/runner-temp/lifecycle',
+      requirePath: async () => {},
+      run: async () => {},
+      verifyApp: async () => {
+        throw primary;
+      },
+      resolvePath: (path) => path,
+      remove: async () => {
+        throw cleanup;
+      },
+    }),
+    (error) => error === primary && error.cause instanceof AggregateError,
+  );
+});
+
+test('installer lifecycle verification fails closed before touching a host', async () => {
+  await assert.rejects(
+    verifyWindowsInstallerLifecycle('C:/Maka.exe', { platform: 'darwin' }),
+    /requires Windows/,
+  );
+  await assert.rejects(verifyWindowsInstallerLifecycle('', { platform: 'win32' }), /Usage:/);
+  await assert.rejects(
+    verifyWindowsInstallerLifecycle('C:/Maka.zip', { platform: 'win32' }),
+    /NSIS installer/,
+  );
 });


### PR DESCRIPTION
## Summary

- install the final NSIS artifact silently into an isolated Windows directory
- verify the installed application from that directory, including resources, version, ConPTY, and renderer startup
- run the shipped uninstaller and require the install directory to disappear
- exercise the same lifecycle in pull-request packaging checks and the release workflow

## Validation

- `node --test scripts/windows-x64-release.test.mjs scripts/electron-builder-config.test.mjs scripts/ci-test-plan.test.mjs` (19 pass)
- `npm run test:scripts` (128 pass)
- Biome, workflow YAML parsing, and `git diff --check`

## Scope

This closes clean install/start/uninstall evidence. Version-to-version upgrade, failed-upgrade rollback, Authenticode, and automatic updates remain separate Phase 3 work in #2142.

<details>
<summary>中文说明</summary>

## 内容

- 将最终 NSIS 安装器静默安装到隔离的 Windows 目录；
- 从真实安装目录校验应用资源、版本、ConPTY 和桌面渲染器启动；
- 运行随安装包提供的卸载器，并要求安装目录最终消失；
- PR 打包检查和正式发布工作流复用同一套生命周期验证。

## 验证

- 相关单测 19 项通过；
- 完整脚本测试 128 项通过；
- Biome、workflow YAML 和 diff 检查通过。

## 边界

本 PR 完成干净安装、启动和卸载证据。跨版本升级、升级失败回滚、Authenticode 和自动更新仍作为 #2142 Phase 3 的后续独立工作。

</details>

Part of #2142.