### PR TITLE
test: wait for active session in slash command e2e

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -109,8 +109,10 @@ test('dispatches a staged slash command instead of steering it into a running tu
   invocableSkillsWindow: page,
 }) => {
   const composer = page.locator(COMPOSER_INPUT);
-  await composer.fill('keep streaming '.repeat(80));
+  const runningPrompt = `running-turn-marker ${'keep streaming '.repeat(80)}`;
+  await composer.fill(runningPrompt);
   await composer.press('Enter');
+  await expect(page.locator('.maka-user-message', { hasText: 'running-turn-marker' })).toBeVisible();
   await expect(page.getByRole('button', { name: '停止' })).toBeVisible();
 
   await composer.fill('/compact explain');


### PR DESCRIPTION
## Summary

- wait for the optimistic user message before exercising slash commands during the first running turn
- use active-session transcript ownership as the readiness signal instead of treating the Stop button as a proxy
- prevent `/side` discovery from racing the first send's asynchronous `setActiveId`

## Verification

- `npx biome check apps/desktop/e2e/slash-command-menu.spec.ts`
- `npm --workspace @maka/desktop run build:with-deps`
- focused regression repeated 5 times: 5 passed
- `slash-command-menu.spec.ts`: 4 passed

## Root cause

The test continued as soon as the locally armed turn exposed the Stop button. The first-send path sets the active session only after `sessions.send` resolves, while `/side` is cataloged only when an active session exists. The test could therefore open the slash menu before the session-owning transcript was ready and wait forever on an option that was omitted from that menu instance.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
