### PR TITLE
test(windows): verify installer upgrades

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -135,9 +135,23 @@ jobs:
         if: matrix.platform == 'windows'
         run: npm run verify:windows-x64 -- "${{ steps.release.outputs.exe }}"
 
-      - name: Exercise clean Windows install and uninstall
+      - name: Download and verify the pinned Windows upgrade baseline
+        id: previous
         if: matrix.platform == 'windows'
-        run: npm run verify:windows-installer -- "${{ steps.release.outputs.exe }}"
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version="$(node -p "require('./apps/desktop/package.json').version")"
+          previous_exe="$(node scripts/prepare-windows-upgrade-baseline.mjs \
+            "$version" artifacts/windows-upgrade-baseline)"
+          echo "exe=$previous_exe" >> "$GITHUB_OUTPUT"
+
+      - name: Exercise pinned Windows upgrade and uninstall
+        if: matrix.platform == 'windows'
+        run: |
+          npm run verify:windows-installer -- \
+            "${{ steps.release.outputs.exe }}" \
+            "${{ steps.previous.outputs.exe }}"
 
       - name: Upload the verified release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -19,6 +19,8 @@ on:
       - 'scripts/prepare-bundled-git.mjs'
       - 'scripts/verify-windows-x64.mjs'
       - 'scripts/verify-windows-installer-lifecycle.mjs'
+      - 'scripts/prepare-windows-upgrade-baseline.mjs'
+      - 'scripts/windows-upgrade-baseline.json'
       - 'scripts/verify-packaged-app.mjs'
       - 'scripts/npm-spawn.mjs'
       - 'scripts/generate-third-party-notices.mjs'
@@ -65,7 +67,19 @@ jobs:
           version="$(node -p "require('./apps/desktop/package.json').version")"
           npm run verify:windows-x64 -- "apps/desktop/release/Maka-${version}-win-x64.exe"
 
-      - name: Exercise clean install and uninstall
+      - name: Download and verify the pinned Windows upgrade baseline
+        id: previous
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           version="$(node -p "require('./apps/desktop/package.json').version")"
-          npm run verify:windows-installer -- "apps/desktop/release/Maka-${version}-win-x64.exe"
+          previous_exe="$(node scripts/prepare-windows-upgrade-baseline.mjs \
+            "$version" artifacts/windows-upgrade-baseline)"
+          echo "exe=$previous_exe" >> "$GITHUB_OUTPUT"
+
+      - name: Exercise pinned-version upgrade and uninstall
+        run: |
+          version="$(node -p "require('./apps/desktop/package.json').version")"
+          npm run verify:windows-installer -- \
+            "apps/desktop/release/Maka-${version}-win-x64.exe" \
+            "${{ steps.previous.outputs.exe }}"

--- a/scripts/prepare-windows-upgrade-baseline.mjs
+++ b/scripts/prepare-windows-upgrade-baseline.mjs
@@ -1,0 +1,83 @@
+import { execFile } from 'node:child_process';
+import { mkdir, readFile, rm } from 'node:fs/promises';
+import { basename, dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+import { sha256File } from './verify-packaged-app.mjs';
+
+const runFile = promisify(execFile);
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const defaultManifestPath = join(repoRoot, 'scripts', 'windows-upgrade-baseline.json');
+
+function stableVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/u.exec(value);
+  return match ? match.slice(1).map(Number) : undefined;
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+export function validateWindowsUpgradeBaseline(manifest, candidateVersion) {
+  const baseline = stableVersion(manifest?.version);
+  const candidate = stableVersion(candidateVersion);
+  if (!baseline || !candidate) throw new Error('Windows upgrade versions must be stable x.y.z.');
+  if (manifest.tag !== `v${manifest.version}`)
+    throw new Error('Baseline tag must match its version.');
+  if (manifest.assetName !== `Maka-${manifest.version}-win-x64.exe`) {
+    throw new Error('Baseline asset name must exactly match its version and architecture.');
+  }
+  if (!/^[0-9a-f]{64}$/u.test(manifest.sha256)) {
+    throw new Error('Baseline SHA-256 must be a lowercase 64-character digest.');
+  }
+  if (compareVersions(baseline, candidate) >= 0) {
+    throw new Error('Windows upgrade baseline must be older than the candidate.');
+  }
+  return manifest;
+}
+
+export async function prepareWindowsUpgradeBaseline(
+  candidateVersion,
+  outputDirectory,
+  {
+    manifestPath = defaultManifestPath,
+    repository = process.env.GITHUB_REPOSITORY ?? 'maka-agent/maka-agent',
+    run = runFile,
+    checksum = sha256File,
+  } = {},
+) {
+  const manifest = validateWindowsUpgradeBaseline(
+    JSON.parse(await readFile(manifestPath, 'utf8')),
+    candidateVersion,
+  );
+  const directory = resolve(outputDirectory);
+  await rm(directory, { recursive: true, force: true });
+  await mkdir(directory, { recursive: true });
+  await run('gh', [
+    'release',
+    'download',
+    manifest.tag,
+    '--repo',
+    repository,
+    '--pattern',
+    manifest.assetName,
+    '--dir',
+    directory,
+  ]);
+  const installer = join(directory, manifest.assetName);
+  const actual = await checksum(installer);
+  if (actual !== manifest.sha256) {
+    throw new Error(
+      `Windows upgrade baseline checksum mismatch for ${basename(installer)}: expected ${manifest.sha256}, found ${actual}.`,
+    );
+  }
+  return installer;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const installer = await prepareWindowsUpgradeBaseline(process.argv[2], process.argv[3]);
+  process.stdout.write(installer);
+}

--- a/scripts/verify-windows-installer-lifecycle.mjs
+++ b/scripts/verify-windows-installer-lifecycle.mjs
@@ -9,6 +9,14 @@ const uninstallExecutableName = 'Uninstall Maka.exe';
 const temporaryCleanupRetries = 20;
 const temporaryCleanupRetryDelayMs = 250;
 
+export function installerVersion(path) {
+  const match = basename(path).match(/^Maka-(\d+\.\d+\.\d+)-win-x64\.exe$/u);
+  if (!match) {
+    throw new Error(`Cannot infer a release version from ${basename(path)}.`);
+  }
+  return match[1];
+}
+
 function delay(milliseconds) {
   return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
 }
@@ -79,6 +87,7 @@ export async function waitUntilMissing(
 
 export async function verifyWindowsInstallerLifecycle(
   inputPath,
+  previousInputPath,
   {
     platform = process.platform,
     makeTemporaryDirectory = () => mkdtemp(join(tmpdir(), 'maka-installer-lifecycle-')),
@@ -103,6 +112,11 @@ export async function verifyWindowsInstallerLifecycle(
     throw new Error(`Expected the NSIS installer .exe, found ${basename(installer)}.`);
   }
   await requirePath(installer);
+  const previousInstaller = previousInputPath ? resolvePath(previousInputPath) : undefined;
+  if (previousInstaller) {
+    installerVersion(previousInstaller);
+    await requirePath(previousInstaller);
+  }
 
   const temporaryDirectory = await makeTemporaryDirectory();
   const installDirectory = join(temporaryDirectory, 'installed');
@@ -113,8 +127,25 @@ export async function verifyWindowsInstallerLifecycle(
   let primaryError;
 
   try {
-    console.log(`[verify-windows-installer] installing into ${installDirectory}`);
     installationStarted = true;
+    if (previousInstaller) {
+      const previousVersion = installerVersion(previousInstaller);
+      console.log(
+        `[verify-windows-installer] installing previous version ${previousVersion} into ${installDirectory}`,
+      );
+      await run(previousInstaller, ['/S', `/D=${installDirectory}`], { timeoutMs: 120_000 });
+      await requirePath(uninstaller);
+      console.log('[verify-windows-installer] verifying the previous installed application');
+      await verifyApp(installDirectory, {
+        workingDirectory: smokeDirectory,
+        expectedVersion: previousVersion,
+      });
+      console.log('[verify-windows-installer] waiting for previous-version processes to exit');
+      await waitForProcessesToExit(installDirectory);
+      console.log(`[verify-windows-installer] upgrading to ${installerVersion(installer)}`);
+    } else {
+      console.log(`[verify-windows-installer] installing into ${installDirectory}`);
+    }
     // NSIS requires /D to be the final argument. spawn passes it directly, so
     // spaces in a runner path do not need shell quoting.
     await run(installer, ['/S', `/D=${installDirectory}`], { timeoutMs: 120_000 });
@@ -139,11 +170,20 @@ export async function verifyWindowsInstallerLifecycle(
   } finally {
     const cleanupErrors = [];
     if (installationStarted && !uninstallCompleted) {
+      let installedProcessesExited = false;
       try {
-        await requirePath(uninstaller);
-        await run(uninstaller, ['/S'], { timeoutMs: 120_000 });
+        await waitForProcessesToExit(installDirectory);
+        installedProcessesExited = true;
       } catch (error) {
         cleanupErrors.push(error);
+      }
+      if (installedProcessesExited) {
+        try {
+          await requirePath(uninstaller);
+          await run(uninstaller, ['/S'], { timeoutMs: 120_000 });
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
       }
     }
     try {
@@ -170,6 +210,6 @@ export async function verifyWindowsInstallerLifecycle(
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const result = await verifyWindowsInstallerLifecycle(process.argv[2]);
+  const result = await verifyWindowsInstallerLifecycle(process.argv[2], process.argv[3]);
   console.log(`Verified installer lifecycle for ${result.installer}`);
 }

--- a/scripts/verify-windows-x64.mjs
+++ b/scripts/verify-windows-x64.mjs
@@ -87,6 +87,7 @@ export async function verifyPackagedWindowsApp(
     readMachine = readPeMachine,
     smokeRenderer = smokePackagedRenderer,
     workingDirectory = appDirectory,
+    expectedVersion,
   } = {},
 ) {
   const desktopManifest = JSON.parse(await readFile(join(desktopRoot, 'package.json'), 'utf8'));
@@ -110,7 +111,7 @@ export async function verifyPackagedWindowsApp(
     run,
     `(Get-Item -LiteralPath ${powerShellLiteral(executable)}).VersionInfo.ProductVersion`,
   );
-  assertWindowsProductVersion(stdout, desktopManifest.version);
+  assertWindowsProductVersion(stdout, expectedVersion ?? desktopManifest.version);
 
   step('smoking node-pty through conpty');
   await run(executable, ['-e', ptyProbe, join(appAsar, 'package.json')], {

--- a/scripts/windows-upgrade-baseline.json
+++ b/scripts/windows-upgrade-baseline.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.1.9",
+  "tag": "v0.1.9",
+  "assetName": "Maka-0.1.9-win-x64.exe",
+  "sha256": "ebda293ab835ec8434df2f5bbeea21bb3ba9c82bc8348ab8ee8d4915e4b6fd4b"
+}


### PR DESCRIPTION
## Summary

- pin a reviewer-visible Windows upgrade baseline to the exact v0.1.9 tag, x64 installer asset, and repository-owned SHA-256
- install and fully smoke the previous release, including version, resources, ConPTY, and renderer startup
- drain previous-version Runtime Host processes, upgrade to the candidate with the same profile paths, and fully smoke the candidate
- retain the real NSIS uninstall and install-directory removal evidence from #2650

## Validation

- focused release/config tests pass
- Biome on changed files, workflow YAML parsing, and `git diff --check` pass

## Evidence boundary

This PR proves a closed-version package upgrade from the pinned v0.1.9 public release to the candidate. Old and candidate smokes reuse the same isolated profile paths, but this does not prove persisted business-state migration. Mid-install interruption recovery, rollback, running-app upgrades, shortcuts/registry cleanup, and automatic updates are explicitly deferred.

<details>
<summary>中文说明</summary>

## 内容

- 在仓库内固定可 review 的 Windows 升级基线：精确 v0.1.9 tag、x64 安装器资产和独立 SHA-256；
- 安装并完整验证旧版本，包括版本、资源、ConPTY 与桌面渲染器启动；
- 等待旧版 Runtime Host 退出，使用相同 profile 路径升级并完整验证候选版本；
- 保留 #2650 建立的真实 NSIS 卸载与安装目录移除证据。

## 证据边界

本 PR 证明固定 v0.1.9 公共发布版到候选版本的关闭状态升级。旧版和候选版复用相同隔离 profile 路径，但不证明持久业务数据迁移。安装中断恢复、rollback、运行中升级、快捷方式/注册表清理和自动更新均明确延期。

</details>

Part of #2142.