### PR TITLE
feat: add nonblocking delegate orchestration mode

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2376,6 +2376,46 @@ describe('Maka Pi TUI runner', () => {
     assert.deepEqual(driver.permissionModes, []);
   });
 
+  test('shows, enables, disables, and runs Delegate Mode from the CLI', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/delegate');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Delegate Mode is off'));
+
+    terminal.input('/delegate on');
+    terminal.input('\r');
+    await waitFor(() => driver.orchestrationModes.length === 1);
+    await waitFor(() => terminal.output().includes('Delegate Mode enabled'));
+
+    terminal.input('/delegate off');
+    terminal.input('\r');
+    await waitFor(() => driver.orchestrationModes.length === 2);
+    await waitFor(() => terminal.output().includes('Delegate Mode disabled'));
+
+    terminal.input('/delegate investigate and report later');
+    terminal.input('\r');
+    await waitFor(() => driver.prompts.length === 1);
+    await waitFor(() => terminal.output().includes('Using Delegate Mode for this turn only'));
+
+    assert.deepEqual(driver.orchestrationModes, ['delegate', 'default']);
+    assert.deepEqual(driver.displayPrompts, ['investigate and report later']);
+    assert.deepEqual(driver.turnOrchestrations, [{ mode: 'delegate', source: 'slash_command' }]);
+
+    exitMaka(terminal);
+    await run;
+  });
+
   test('rejects Swarm commands during a running turn instead of steering them', async () => {
     const terminal = new FakeTerminal();
     const driver = new SteeringTurnDriver();

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -178,7 +178,7 @@ export interface MakaPiTranscriptMetadata {
   model: string;
   connectionSlug: string;
   permissionMode: string;
-  orchestrationMode?: 'default' | 'swarm' | 'graph';
+  orchestrationMode?: 'default' | 'swarm' | 'graph' | 'delegate';
   thinkingLevel?: ThinkingLevel;
   thinkingLevels?: readonly ThinkingLevel[];
   sessionId?: string | null;
@@ -1309,6 +1309,8 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
     parts.push(ansi.accent('swarm'));
   } else if (metadata.orchestrationMode === 'graph') {
     parts.push(ansi.accent('graph'));
+  } else if (metadata.orchestrationMode === 'delegate') {
+    parts.push(ansi.accent('delegate'));
   }
   const usage = metadata.usage;
   if (usage) {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -52,6 +52,7 @@ import type { InvocableSkillEntry } from '@maka/runtime/skill-invocation';
 import { MakaSkillHighlightEditor } from './skill-highlight-editor.js';
 import { parseGraphCommand, type ParsedGraphCommand } from '@maka/core/graph-command';
 import { parseSwarmCommand, type ParsedSwarmCommand } from '@maka/core/swarm-command';
+import { parseDelegateCommand, type ParsedDelegateCommand } from '@maka/core/delegate-command';
 import {
   inspectSessionResumeAvailability,
   type MakaAttachedSessionTurn,
@@ -2270,6 +2271,62 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     });
   };
 
+  const showDelegateStatus = () => {
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text:
+        orchestrationMode === 'delegate'
+          ? 'Delegate Mode is on for this session.'
+          : 'Delegate Mode is off.',
+    });
+    requestRender();
+  };
+
+  const setDelegateMode = async (mode: OrchestrationMode) => {
+    if (!input.driver.setOrchestrationMode) {
+      throw new Error('Delegate Mode is unavailable on this session driver.');
+    }
+    await input.driver.setOrchestrationMode(mode);
+    orchestrationMode = mode;
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text:
+        mode === 'delegate' ? 'Delegate Mode enabled for this session.' : 'Delegate Mode disabled.',
+    });
+    requestRender();
+  };
+
+  const runDelegateCommand = (command: ParsedDelegateCommand, idleMs: number) => {
+    if (command.kind === 'status') {
+      showDelegateStatus();
+      return;
+    }
+    if (command.kind === 'set_mode') {
+      void runControl(() => setDelegateMode(command.mode));
+      return;
+    }
+    if (input.firstRun) {
+      void showSetupWizard();
+      return;
+    }
+    lastActivityAt = Date.now();
+    promptSeq += 1;
+    maybeTriggerAutoRecap(idleMs);
+    state.entries.push({
+      kind: 'notice',
+      level: 'info',
+      text: 'Using Delegate Mode for this turn only.',
+    });
+    void runAgentTurn({
+      kind: 'external',
+      prompt: command.task,
+      sessionId: input.driver.getSessionId(),
+      turnOrchestration: { mode: 'delegate', source: 'slash_command' },
+    });
+  };
+
   const moveSession = async (targetCwd: string): Promise<void> => {
     if (!input.driver.moveSession) {
       state.entries.push({
@@ -2609,6 +2666,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
         const parsed = parseGraphCommand(`/graph${rawTail ? ` ${rawTail}` : ''}`);
         if (parsed) runGraphCommand(parsed, context.idleMs);
+      },
+    },
+    delegate: {
+      description: 'Show, enable, disable, or run one Delegate turn',
+      run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
+        const parsed = parseDelegateCommand(`/delegate${rawTail ? ` ${rawTail}` : ''}`);
+        if (parsed) runDelegateCommand(parsed, context.idleMs);
       },
     },
     swarm: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -112,6 +112,7 @@
     "./connection-error-copy": "./dist/connection-error-copy.js",
     "./git-review": "./dist/git-review.js",
     "./graph-command": "./dist/graph-command.js",
+    "./delegate-command": "./dist/delegate-command.js",
     "./project": "./dist/project.js",
     "./pty-output-view": "./dist/pty-output-view.js",
     "./relative-time": "./dist/relative-time.js",

--- a/packages/core/src/__tests__/delegate-command.test.ts
+++ b/packages/core/src/__tests__/delegate-command.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { parseDelegateCommand } from '../delegate-command.js';
+
+describe('/delegate parser', () => {
+  test('parses status, persistent mode changes, and one-turn work', () => {
+    assert.deepEqual(parseDelegateCommand('/delegate'), { kind: 'status' });
+    assert.deepEqual(parseDelegateCommand('/delegate status'), { kind: 'status' });
+    assert.deepEqual(parseDelegateCommand('/delegate on'), {
+      kind: 'set_mode',
+      mode: 'delegate',
+    });
+    assert.deepEqual(parseDelegateCommand('/delegate off'), {
+      kind: 'set_mode',
+      mode: 'default',
+    });
+    assert.deepEqual(parseDelegateCommand('/delegate investigate the regression'), {
+      kind: 'run_once',
+      task: 'investigate the regression',
+    });
+  });
+
+  test('does not claim lookalike slash commands', () => {
+    assert.equal(parseDelegateCommand('/delegated work'), null);
+  });
+});

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -20,6 +20,14 @@ describe('orchestration contract', () => {
     });
   });
 
+  test('delegate mode preserves its identity without granting swarm authority', () => {
+    assert.deepEqual(resolveEffectiveOrchestration('delegate', undefined), {
+      mode: 'delegate',
+      source: 'session',
+      agentSwarmAuthorization: 'none',
+    });
+  });
+
   test('a trusted turn override wins without changing the persisted session mode', () => {
     assert.deepEqual(
       resolveEffectiveOrchestration('default', { mode: 'swarm', source: 'host_api' }),

--- a/packages/core/src/agent-graph-schedule.ts
+++ b/packages/core/src/agent-graph-schedule.ts
@@ -263,7 +263,8 @@ function isScheduleSource(value: unknown): value is AgentGraphScheduleUpdateSour
     (value.orchestrationMode === undefined ||
       value.orchestrationMode === 'default' ||
       value.orchestrationMode === 'graph' ||
-      value.orchestrationMode === 'swarm')
+      value.orchestrationMode === 'swarm' ||
+      value.orchestrationMode === 'delegate')
   );
 }
 

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -311,7 +311,7 @@ function hostedRootAuthorityMatches(
         execution.wakeId.startsWith(`${execution.graphId}:`) &&
         run.agentGraphWakeId === execution.wakeId &&
         run.agentGraphWakeAttemptId === execution.attemptId &&
-        run.orchestrationMode === 'graph' &&
+        (run.orchestrationMode === 'graph' || run.orchestrationMode === 'delegate') &&
         run.orchestrationSource === 'turn_override' &&
         run.agentSwarmAuthorization === 'none' &&
         run.scheduledTaskId === undefined &&

--- a/packages/core/src/delegate-command.ts
+++ b/packages/core/src/delegate-command.ts
@@ -1,0 +1,19 @@
+import type { OrchestrationMode } from './orchestration.js';
+
+export type ParsedDelegateCommand =
+  | { kind: 'status' }
+  | { kind: 'set_mode'; mode: OrchestrationMode }
+  | { kind: 'run_once'; task: string };
+
+/** Parse the exact `/delegate` command without treating lookalike prompts as commands. */
+export function parseDelegateCommand(input: string): ParsedDelegateCommand | null {
+  const trimmed = input.trim();
+  const commandToken = trimmed.split(/\s+/, 1)[0] ?? '';
+  if (commandToken !== '/delegate') return null;
+
+  const tail = trimmed.slice(commandToken.length).trim();
+  if (!tail || tail === 'status') return { kind: 'status' };
+  if (tail === 'on') return { kind: 'set_mode', mode: 'delegate' };
+  if (tail === 'off') return { kind: 'set_mode', mode: 'default' };
+  return { kind: 'run_once', task: tail };
+}

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -1,4 +1,4 @@
-export const ORCHESTRATION_MODES = ['default', 'swarm', 'graph'] as const;
+export const ORCHESTRATION_MODES = ['default', 'swarm', 'graph', 'delegate'] as const;
 
 export type OrchestrationMode = (typeof ORCHESTRATION_MODES)[number];
 

--- a/packages/core/src/slash-command-catalog.ts
+++ b/packages/core/src/slash-command-catalog.ts
@@ -11,6 +11,7 @@ export interface SlashCommandSpec {
 export const SLASH_COMMAND_CATALOG = [
   { id: 'compact', session: 'required', surfaces: ['desktop', 'tui'] },
   { id: 'context', session: 'required', surfaces: ['tui'] },
+  { id: 'delegate', session: 'none', surfaces: ['tui'] },
   { id: 'exit', aliases: ['quit'], session: 'none', surfaces: ['tui'] },
   { id: 'graph', session: 'none', surfaces: ['desktop', 'tui'] },
   { id: 'help', session: 'none', surfaces: ['tui'] },

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -983,6 +983,158 @@ test('production Host executes a canonical ai-sdk Session against a real provide
   }
 });
 
+test('Delegate Mode returns the main turn normally while durable child work continues', {
+  timeout: 20_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-delegate-'));
+  const root = join(base, 'interactive');
+  const project = join(base, 'project');
+  const provider = await startProvider();
+  provider.configureDelegateFlow();
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  const context: ConnectionContext = {
+    hostEpoch: 'delegate-test-epoch',
+    connectionId: 'delegate-test-client',
+    surface: 'tui',
+    principal: 'local_os_user',
+    acquireResidency: () => ({ release() {} }),
+  };
+  let composition: Awaited<ReturnType<typeof createExecutionRuntimeHostComposition>> | undefined;
+  let graphStore: ReturnType<typeof createAgentGraphControlStore> | undefined;
+  try {
+    await mkdir(project);
+    await writeFile(join(project, 'README.md'), '# Delegate fixture\n');
+    const policy = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const created = await policy.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: 'delegate-provider',
+        name: 'Delegate provider',
+        providerType: 'moonshot',
+        baseUrl: provider.baseUrl,
+        enabled: true,
+        enabledModelIds: [MODEL_ID],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+    assert.equal(
+      (
+        await policy.credentialVault.set({
+          locator: {
+            scope: 'connection',
+            connectionId: connection.connectionId,
+            kind: 'api_key',
+          },
+          expected: null,
+          secret: API_KEY,
+        })
+      ).kind,
+      'committed',
+    );
+    await publishConnectionModel(policy, connection.connectionId, MODEL_ID, 32_768);
+
+    const execution = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await execution.sessionStore.create({
+      cwd: project,
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'delegate-provider',
+      model: MODEL_ID,
+      permissionMode: 'bypass',
+    });
+    composition = await createExecutionRuntimeHostComposition({
+      owner,
+      hostEpoch: context.hostEpoch,
+      acquireResidency: context.acquireResidency,
+      retainUntilProcessExit: () => undefined,
+      requestDrain: () => assert.fail('The healthy Delegate flow must not drain the Host'),
+    });
+    await composition.recover();
+
+    const turnId = 'hosted-delegate-turn';
+    const started = await composition.handlers['turn.start'](
+      {
+        sessionId: session.id,
+        turnId,
+        content: { text: 'Delegate this task and remain responsive.' },
+        turnOrchestration: { mode: 'delegate', source: 'host_api' },
+      },
+      context,
+    );
+    assert.equal(started.ok, true);
+    if (!started.ok || started.result.kind !== 'started') return;
+    const initialTerminal = await waitForTerminal(
+      composition,
+      session.id,
+      turnId,
+      started.result.turn,
+      context,
+    );
+    assert.equal(initialTerminal.status, 'completed');
+
+    const initialRun = await execution.agentRunStore.readRun(session.id, initialTerminal.runId);
+    assert.equal(initialRun.orchestrationMode, 'delegate');
+
+    graphStore = createAgentGraphControlStore(root);
+    const graphId = agentGraphIdForRootSession(session.id);
+    let updates = await graphStore.listAgentGraphScheduleUpdates(graphId);
+    let runs = await execution.agentRunStore.listSessionRuns(session.id);
+    for (let attempt = 0; attempt < 400; attempt += 1) {
+      const wakeRuns = runs.filter((run) => run.agentGraphWakeAttemptId !== undefined);
+      if (
+        wakeRuns.length > 0 &&
+        wakeRuns.every((run) => ['completed', 'failed', 'cancelled'].includes(run.status))
+      ) {
+        break;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+      updates = await graphStore.listAgentGraphScheduleUpdates(graphId);
+      runs = await execution.agentRunStore.listSessionRuns(session.id);
+    }
+
+    assert.equal(updates[0]?.source.orchestrationMode, 'delegate');
+    assert.equal(updates.length, 1);
+    assert.equal(updates[0]?.finish, undefined);
+    const wakeRuns = runs.filter((run) => run.agentGraphWakeAttemptId !== undefined);
+    assert.ok(wakeRuns.length > 0);
+    assert.ok(wakeRuns.every((run) => run.orchestrationMode === 'delegate'));
+    assert.ok(wakeRuns.some((run) => run.status === 'completed'));
+    assert.ok(wakeRuns.every((run) => ['completed', 'failed', 'cancelled'].includes(run.status)));
+
+    const supervisorRequests = provider.requests.filter(
+      (request) =>
+        request.body.stream === true && toolNames(request.body).includes('update_agent_graph'),
+    );
+    assert.ok(supervisorRequests.length >= 4);
+    assert.ok(
+      supervisorRequests.every((request) => !toolNames(request.body).includes('yield_agent_graph')),
+    );
+    assert.ok(
+      provider.requests.some((request) =>
+        JSON.stringify(request.body).includes('Background task accepted; I remain available.'),
+      ),
+    );
+  } finally {
+    graphStore?.close();
+    try {
+      await composition?.close();
+    } finally {
+      try {
+        await owner.close();
+      } finally {
+        await provider.close();
+        await rm(base, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
 test('production Host executes and durably supervises an Agent Graph over a real provider wire', {
   timeout: 20_000,
 }, async () => {
@@ -2869,6 +3021,7 @@ async function startProvider(): Promise<{
   configureChildAgentFlow(): void;
   configureImplementationChildAgentFlow(): void;
   configureAgentGraphFlow(): void;
+  configureDelegateFlow(): void;
   close(): Promise<void>;
 }> {
   const requests: ProviderRequest[] = [];
@@ -2901,6 +3054,13 @@ async function startProvider(): Promise<{
       flow = {
         kind: 'agent_graph',
         scenario: new AgentGraphProviderScenario(CHILD_AGENT_RESULT_TEXT),
+      };
+    },
+    configureDelegateFlow: () => {
+      if (flow.kind !== 'default') throw new Error('Provider flow is already configured');
+      flow = {
+        kind: 'agent_graph',
+        scenario: new AgentGraphProviderScenario(CHILD_AGENT_RESULT_TEXT, 'delegate'),
       };
     },
     close: () => closeServer(server),

--- a/packages/runtime-host/src/__tests__/fixtures/agent-graph-provider-scenario.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/agent-graph-provider-scenario.ts
@@ -80,7 +80,7 @@ export class AgentGraphProviderScenario {
         assert.match(
           latestUserText(body),
           this.orchestrationMode === 'delegate'
-            ? /Background task set .* reached settled\./
+            ? /Background task set .* reached a durable checkpoint\.[\s\S]*Checkpoint projection status: settled\./
             : /reached a durable supervisor checkpoint\./,
         );
         this.#phase = 'await_view_result';

--- a/packages/runtime-host/src/__tests__/fixtures/agent-graph-provider-scenario.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/agent-graph-provider-scenario.ts
@@ -19,7 +19,10 @@ export class AgentGraphProviderScenario {
   #childCompleted = false;
   #resultRecordId: string | undefined;
 
-  constructor(private readonly childResultText: string) {}
+  constructor(
+    private readonly childResultText: string,
+    private readonly orchestrationMode: 'graph' | 'delegate' = 'graph',
+  ) {}
 
   respond(body: Record<string, unknown>, reply: AgentGraphProviderReply): void {
     const names = toolNames(body);
@@ -31,14 +34,14 @@ export class AgentGraphProviderScenario {
       reply.text(this.childResultText);
       return;
     }
-    for (const required of [
-      'agent_output',
-      'update_agent_graph',
-      'view_agent_graph',
-      'yield_agent_graph',
-    ]) {
+    for (const required of ['agent_output', 'update_agent_graph', 'view_agent_graph']) {
       assert.ok(names.includes(required), `Graph provider request omitted ${required}`);
     }
+    assert.equal(
+      names.includes('yield_agent_graph'),
+      this.orchestrationMode === 'graph',
+      `Unexpected yield_agent_graph visibility in ${this.orchestrationMode} mode`,
+    );
 
     const toolResult = latestToolResultAfterCurrentUser(body);
     switch (this.#phase) {
@@ -63,6 +66,10 @@ export class AgentGraphProviderScenario {
         assert.equal(updated.kind, 'agent_graph_updated');
         assert.equal(requireRecord(updated.schedule, 'add-work schedule').closed, false);
         this.#phase = 'await_checkpoint';
+        if (this.orchestrationMode === 'delegate') {
+          reply.text('Background task accepted; I remain available.');
+          return;
+        }
         reply.toolCall('yield_agent_graph', {
           reason: 'Wait for the hosted operator checkpoint.',
         });
@@ -70,7 +77,12 @@ export class AgentGraphProviderScenario {
       }
       case 'await_checkpoint':
         assert.equal(toolResult, undefined);
-        assert.match(latestUserText(body), /reached a durable supervisor checkpoint\./);
+        assert.match(
+          latestUserText(body),
+          this.orchestrationMode === 'delegate'
+            ? /Background task set .* reached settled\./
+            : /reached a durable supervisor checkpoint\./,
+        );
         this.#phase = 'await_view_result';
         reply.toolCall('view_agent_graph', { mode: 'latest' });
         return;
@@ -91,6 +103,11 @@ export class AgentGraphProviderScenario {
         }
         const operator = requireRecord(operators[0], 'graph view operator');
         if (operator.status !== 'completed') {
+          assert.equal(
+            this.orchestrationMode,
+            'graph',
+            'Delegate checkpoint must not wake before background work settles',
+          );
           assert.ok(
             ['not_started', 'waiting', 'runnable', 'running', 'blocked'].includes(
               requireString(operator.status, 'Graph operator status'),
@@ -126,6 +143,11 @@ export class AgentGraphProviderScenario {
         assert.equal(result.status, 'completed');
         assert.equal(result.text, this.childResultText);
         this.#resultRecordId = requireString(result.resultRecordId, 'Graph result record id');
+        if (this.orchestrationMode === 'delegate') {
+          this.#phase = 'completed';
+          reply.text(`Delegated task completed: ${this.childResultText}`);
+          return;
+        }
         this.#phase = 'await_finish_result';
         reply.toolCall('update_agent_graph', {
           operation: 'finish',

--- a/packages/runtime-host/src/protocol/agent-graph.ts
+++ b/packages/runtime-host/src/protocol/agent-graph.ts
@@ -236,7 +236,7 @@ export interface AgentGraphClientSnapshot {
   readonly schemaVersion: typeof AGENT_GRAPH_CLIENT_SCHEMA_VERSION;
   readonly rootSessionId: string;
   readonly graphId: string;
-  readonly orchestrationMode: 'graph' | 'swarm';
+  readonly orchestrationMode: 'graph' | 'swarm' | 'delegate';
   readonly snapshotVersion: `sha256:${string}`;
   readonly status: AgentGraphClientStatus;
   readonly scheduleRevision: number;
@@ -1201,8 +1201,8 @@ function requireGraphStatus(value: unknown): AgentGraphClientStatus {
   throw invalidProtocolFrame('Invalid agent graph status');
 }
 
-function requireGraphOrchestrationMode(value: unknown): 'graph' | 'swarm' {
-  if (value === 'graph' || value === 'swarm') return value;
+function requireGraphOrchestrationMode(value: unknown): 'graph' | 'swarm' | 'delegate' {
+  if (value === 'graph' || value === 'swarm' || value === 'delegate') return value;
   throw invalidProtocolFrame('Invalid agent graph orchestration mode');
 }
 

--- a/packages/runtime-host/src/server/agent-graph-execution-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-execution-coordinator.ts
@@ -176,11 +176,11 @@ function assertAgentGraphInput(sessionId: string, input: UserMessageInput): void
   if (
     input.origin?.kind !== 'agent_graph' ||
     input.origin.graphId !== agentGraphIdForRootSession(sessionId) ||
-    input.turnOrchestration?.mode !== 'graph' ||
+    (input.turnOrchestration?.mode !== 'graph' && input.turnOrchestration?.mode !== 'delegate') ||
     input.turnOrchestration.source !== 'host_api'
   ) {
     throw new RuntimeMessageAuthorityInvariantError(
-      'Agent Graph supervisor execution requires the Session graph origin and Host Graph orchestration',
+      'Agent Graph supervisor execution requires the Session graph origin and Host Graph orchestration or Host Delegate orchestration',
     );
   }
 }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -36,6 +36,10 @@ import {
   renderAgentSwarmSupervisorWake,
   shouldWakeAgentSwarmSupervisor,
 } from '@maka/runtime/agent-swarm-status-tool';
+import {
+  renderDelegateSupervisorWake,
+  shouldWakeDelegateSupervisor,
+} from '@maka/runtime/delegate-mode';
 import { SessionActivityRegistry } from '@maka/runtime/goal-turn-lifecycle';
 import { ShellRunProcessManager } from '@maka/runtime/shell-run-manager';
 import { type MakaTool } from '@maka/runtime/tool-runtime';
@@ -1046,8 +1050,12 @@ export async function createExecutionRuntimeHostComposition(
       },
       recoverContextOverflow: (rootSessionId, { abortSignal }) =>
         graphExecutions.recoverContextOverflow(rootSessionId, randomUUID(), abortSignal),
-      shouldWake: shouldWakeAgentSwarmSupervisor,
-      renderWake: renderAgentSwarmSupervisorWake,
+      shouldWake: (rootSessionId, result, snapshot) =>
+        shouldWakeDelegateSupervisor(rootSessionId, result, snapshot) ??
+        shouldWakeAgentSwarmSupervisor(rootSessionId, result, snapshot),
+      renderWake: (rootSessionId, snapshot, result) =>
+        renderDelegateSupervisorWake(rootSessionId, snapshot, result) ??
+        renderAgentSwarmSupervisorWake(rootSessionId, snapshot, result),
       newId: randomUUID,
       isSessionDeliverable: async (sessionId) => {
         try {

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -2346,7 +2346,7 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
           resolveEffectiveOrchestration(session.orchestrationMode, undefined).mode)
         : resolveEffectiveOrchestration(session.orchestrationMode, admission.turnOrchestration)
             .mode;
-    return mode === 'graph' || mode === 'swarm'
+    return mode === 'graph' || mode === 'swarm' || mode === 'delegate'
       ? agentGraphIdForRootSession(admission.sessionId)
       : undefined;
   }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -40,6 +40,7 @@
     "./agent-catalog": "./dist/agent-catalog.js",
     "./agent-graph-supervisor-wake": "./dist/agent-graph-supervisor-wake.js",
     "./agent-swarm-status-tool": "./dist/agent-swarm-status-tool.js",
+    "./delegate-mode": "./dist/delegate-mode.js",
     "./ai-sdk-compaction-contract": "./dist/ai-sdk-compaction-contract.js",
     "./claude-subscription-usage": "./dist/claude-subscription-usage.js",
     "./codex-oauth-enrollment": "./dist/codex-oauth-enrollment.js",

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -6421,6 +6421,52 @@ describe('AiSdkBackend usage telemetry', () => {
     );
   });
 
+  test('keeps graph controls but removes yield from the Delegate provider surface', async () => {
+    const durable = durableTurnHarness('turn-delegate-tools', 'delegate a background task');
+    const model = textCompletionModel('Task accepted; I remain available.');
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [
+        testTool('agent_list', z.object({})),
+        testTool('view_agent_graph', z.object({})),
+        testTool('update_agent_graph', z.object({})),
+        testTool('yield_agent_graph', z.object({ reason: z.string() })),
+        testTool('agent_swarm_status', z.object({})),
+        testTool('agent_output', z.object({})),
+      ],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events = await drainDurably(
+      backend.send(
+        durable.input({
+          orchestration: {
+            mode: 'delegate',
+            source: 'turn_override',
+            agentSwarmAuthorization: 'none',
+          },
+        }),
+      ),
+      durable,
+    );
+
+    const call = model.doStreamCalls[0];
+    const toolNames = (call?.tools ?? []).map((tool) => tool.name);
+    assert.ok(toolNames.includes('update_agent_graph'));
+    assert.ok(toolNames.includes('view_agent_graph'));
+    assert.equal(toolNames.includes('yield_agent_graph'), false);
+    assert.match(JSON.stringify(call?.prompt), /Orchestration Mode: Delegate/);
+    assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
+  });
+
   test('ends the tool loop cooperatively when the graph supervisor yields', async () => {
     const durable = durableTurnHarness('turn-graph-yield', 'coordinate the graph');
     let streamCalls = 0;

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -6421,7 +6421,7 @@ describe('AiSdkBackend usage telemetry', () => {
     );
   });
 
-  test('keeps graph controls but removes yield from the Delegate provider surface', async () => {
+  test('restricts the Delegate main agent to durable task orchestration tools', async () => {
     const durable = durableTurnHarness('turn-delegate-tools', 'delegate a background task');
     const model = textCompletionModel('Task accepted; I remain available.');
     const backend = createTestAiSdkBackend({
@@ -6433,6 +6433,11 @@ describe('AiSdkBackend usage telemetry', () => {
       modelId: 'mock-model-id',
       modelFactory: () => model,
       tools: [
+        testTool('Read', z.object({ path: z.string() })),
+        testTool('Bash', z.object({ command: z.string() })),
+        testTool('load_tools', z.object({ group: z.string() })),
+        testTool('agent_spawn', z.object({ prompt: z.string() })),
+        testTool('ArchiveRead', z.object({ ref: z.string() })),
         testTool('agent_list', z.object({})),
         testTool('view_agent_graph', z.object({})),
         testTool('update_agent_graph', z.object({})),
@@ -6448,6 +6453,7 @@ describe('AiSdkBackend usage telemetry', () => {
     const events = await drainDurably(
       backend.send(
         durable.input({
+          toolMode: 'code_mode',
           orchestration: {
             mode: 'delegate',
             source: 'turn_override',
@@ -6462,8 +6468,16 @@ describe('AiSdkBackend usage telemetry', () => {
     const toolNames = (call?.tools ?? []).map((tool) => tool.name);
     assert.ok(toolNames.includes('update_agent_graph'));
     assert.ok(toolNames.includes('view_agent_graph'));
+    assert.ok(toolNames.includes('ArchiveRead'));
     assert.equal(toolNames.includes('yield_agent_graph'), false);
+    assert.equal(toolNames.includes('Read'), false);
+    assert.equal(toolNames.includes('Bash'), false);
+    assert.equal(toolNames.includes('load_tools'), false);
+    assert.equal(toolNames.includes('agent_spawn'), false);
+    assert.equal(toolNames.includes('exec'), false);
     assert.match(JSON.stringify(call?.prompt), /Orchestration Mode: Delegate/);
+    assert.match(JSON.stringify(call?.prompt), /exactly one structured decision/);
+    assert.match(JSON.stringify(call?.prompt), /requires any tool/);
     assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'end_turn');
   });
 

--- a/packages/runtime/src/__tests__/delegate-mode.test.ts
+++ b/packages/runtime/src/__tests__/delegate-mode.test.ts
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  renderDelegateModePrompt,
+  renderDelegateSupervisorWake,
+  shouldWakeDelegateSupervisor,
+} from '../delegate-mode.js';
+import type { AgentGraphClientSnapshot } from '../stream-graph-read-model.js';
+
+describe('Delegate Mode', () => {
+  test('instructs the main agent to acknowledge and end normally without yielding', () => {
+    const prompt = renderDelegateModePrompt();
+    assert.match(prompt, /remain responsive/);
+    assert.match(prompt, /end this turn normally/);
+    assert.match(prompt, /Do not poll, sleep/);
+  });
+
+  test('wakes only at durable attention or settled checkpoints', () => {
+    const running = snapshot('running');
+    assert.equal(shouldWakeDelegateSupervisor('root', undefined, running), false);
+
+    const completed = snapshot('completed');
+    assert.equal(shouldWakeDelegateSupervisor('root', undefined, completed), true);
+    const wake = renderDelegateSupervisorWake('root', completed);
+    assert.equal(wake?.orchestrationMode, 'delegate');
+    assert.match(wake?.text ?? '', /end this turn normally/);
+    assert.match(wake?.text ?? '', /Do not poll, sleep/);
+  });
+
+  test('does not claim ordinary Graph checkpoints', () => {
+    const graph = snapshot('completed');
+    graph.orchestrationMode = 'graph';
+    assert.equal(shouldWakeDelegateSupervisor('root', undefined, graph), undefined);
+    assert.equal(renderDelegateSupervisorWake('root', graph), undefined);
+  });
+});
+
+function snapshot(status: 'running' | 'completed'): AgentGraphClientSnapshot {
+  return {
+    schemaVersion: 1,
+    rootSessionId: 'root',
+    graphId: 'graph-root',
+    orchestrationMode: 'delegate',
+    snapshotVersion: 'snapshot-1',
+    status: 'active',
+    scheduleRevision: 1,
+    topologyFingerprint: 'fingerprint',
+    closed: false,
+    operators: [
+      {
+        operatorId: 'operator-1',
+        childSessionId: 'child-1',
+        provisionId: 'provision-1',
+        agentId: 'worker',
+        provisionedAt: 1,
+        status,
+        inboundEdgeIds: [],
+        outboundEdgeIds: [],
+        scheduledWorkIds: ['work-1'],
+        readiness: [],
+        omitted: {
+          inboundEdgeIds: 0,
+          outboundEdgeIds: 0,
+          scheduledWorkIds: 0,
+          readiness: 0,
+          readinessWaits: 0,
+        },
+        currentActivation: {
+          activationId: 'activation-1',
+          status,
+          recordCount: 1,
+          firstEventTime: 1,
+          lastEventTime: 2,
+          run: { sessionId: 'child-1', agentRunId: 'run-1' },
+        },
+      },
+    ],
+    edges: [],
+    work: [
+      {
+        workId: 'work-1',
+        target: { kind: 'preset', presetId: 'worker' },
+        inputIds: [],
+        status: 'requested',
+        instructionPreview: 'Do bounded work.',
+        instructionTruncated: false,
+        revision: 1,
+        committedAt: 1,
+      },
+    ],
+    reconciliationFailures: [],
+    stoppedTargets: [],
+    claims: [],
+    recentControlDecisions: [],
+    recentActivity: [],
+    terminalHistory: { records: [] },
+    omitted: {
+      operators: 0,
+      edges: 0,
+      work: 0,
+      reconciliationFailures: 0,
+      stoppedTargets: 0,
+      claims: 0,
+      controlDecisions: 0,
+      recentActivity: 0,
+    },
+  };
+}

--- a/packages/runtime/src/__tests__/delegate-mode.test.ts
+++ b/packages/runtime/src/__tests__/delegate-mode.test.ts
@@ -11,6 +11,9 @@ describe('Delegate Mode', () => {
   test('instructs the main agent to acknowledge and end normally without yielding', () => {
     const prompt = renderDelegateModePrompt();
     assert.match(prompt, /remain responsive/);
+    assert.match(prompt, /exactly one structured decision/);
+    assert.match(prompt, /zero tool calls/);
+    assert.match(prompt, /requires any tool/);
     assert.match(prompt, /end this turn normally/);
     assert.match(prompt, /Do not poll, sleep/);
   });
@@ -23,8 +26,31 @@ describe('Delegate Mode', () => {
     assert.equal(shouldWakeDelegateSupervisor('root', undefined, completed), true);
     const wake = renderDelegateSupervisorWake('root', completed);
     assert.equal(wake?.orchestrationMode, 'delegate');
+    assert.equal(wake?.displayText, 'Delegated task checkpoint.');
     assert.match(wake?.text ?? '', /end this turn normally/);
     assert.match(wake?.text ?? '', /Do not poll, sleep/);
+  });
+
+  test('does not wake again for reconciliation after a runtime checkpoint', () => {
+    const completed = snapshot('completed');
+    assert.equal(
+      shouldWakeDelegateSupervisor(
+        'root',
+        {
+          status: 'reconciled',
+          newActivationCount: 0,
+          observedExistingActivationCount: 1,
+          dispatches: [],
+          stops: [],
+          deferredWork: [],
+          failures: [],
+          schedule: {} as never,
+          observation: {} as never,
+        },
+        completed,
+      ),
+      false,
+    );
   });
 
   test('does not claim ordinary Graph checkpoints', () => {

--- a/packages/runtime/src/__tests__/delegate-mode.test.ts
+++ b/packages/runtime/src/__tests__/delegate-mode.test.ts
@@ -5,6 +5,7 @@ import {
   renderDelegateSupervisorWake,
   shouldWakeDelegateSupervisor,
 } from '../delegate-mode.js';
+import { isAgentGraphAsyncCheckpointTransition } from '../stream-graph-coordinator.js';
 import type { AgentGraphClientSnapshot } from '../stream-graph-read-model.js';
 
 describe('Delegate Mode', () => {
@@ -31,7 +32,7 @@ describe('Delegate Mode', () => {
     assert.match(wake?.text ?? '', /Do not poll, sleep/);
   });
 
-  test('does not wake again for reconciliation after a runtime checkpoint', () => {
+  test('lets recovery reconciliation recreate a terminal wake not yet persisted', () => {
     const completed = snapshot('completed');
     assert.equal(
       shouldWakeDelegateSupervisor(
@@ -49,8 +50,40 @@ describe('Delegate Mode', () => {
         },
         completed,
       ),
-      false,
+      true,
     );
+  });
+
+  test('checkpoints a completed later batch while an older failure still needs attention', () => {
+    const failedA = snapshot('failed');
+    failedA.work[0]!.workId = 'work-a';
+    failedA.operators[0]!.scheduledWorkIds = ['work-a'];
+
+    const runningB = structuredClone(failedA);
+    runningB.work.push({
+      ...runningB.work[0]!,
+      workId: 'work-b',
+      instructionPreview: 'Run independent batch B.',
+    });
+    runningB.operators.push({
+      ...runningB.operators[0]!,
+      operatorId: 'operator-2',
+      childSessionId: 'child-2',
+      provisionId: 'provision-2',
+      scheduledWorkIds: ['work-b'],
+      currentActivation: {
+        ...runningB.operators[0]!.currentActivation!,
+        activationId: 'activation-2',
+        status: 'running',
+        run: { sessionId: 'child-2', agentRunId: 'run-2' },
+      },
+    });
+    const completedB = structuredClone(runningB);
+    completedB.operators[1]!.status = 'completed';
+    completedB.operators[1]!.currentActivation!.status = 'completed';
+
+    assert.equal(isAgentGraphAsyncCheckpointTransition(failedA, runningB), false);
+    assert.equal(isAgentGraphAsyncCheckpointTransition(runningB, completedB), true);
   });
 
   test('does not claim ordinary Graph checkpoints', () => {
@@ -61,7 +94,7 @@ describe('Delegate Mode', () => {
   });
 });
 
-function snapshot(status: 'running' | 'completed'): AgentGraphClientSnapshot {
+function snapshot(status: 'running' | 'completed' | 'failed'): AgentGraphClientSnapshot {
   return {
     schemaVersion: 1,
     rootSessionId: 'root',

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -184,14 +184,14 @@ export interface AgentGraphSupervisorWakeInput {
     | {
         text: string;
         displayText: string;
-        orchestrationMode: 'graph' | 'swarm';
+        orchestrationMode: 'graph' | 'swarm' | 'delegate';
       }
     | undefined
     | Promise<
         | {
             text: string;
             displayText: string;
-            orchestrationMode: 'graph' | 'swarm';
+            orchestrationMode: 'graph' | 'swarm' | 'delegate';
           }
         | undefined
       >;

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -69,6 +69,7 @@ import {
 } from '@maka/core/orchestration';
 import type { PlanToolResult } from './plan-tools.js';
 import {
+  ARCHIVE_READ_TOOL_NAME,
   bindToolResultArchiveDecoder,
   type ToolResultArchiveCapability,
 } from './tool-result-archive-capability.js';
@@ -525,15 +526,15 @@ function projectToolModePlan(
   };
 }
 
-function omitToolsFromPlan(
+function restrictToolsInPlan(
   plan: ToolAvailabilityPlan,
-  omittedToolNames: ReadonlySet<string>,
+  allowedToolNames: ReadonlySet<string>,
 ): ToolAvailabilityPlan {
   const visible = (names: readonly string[]): string[] =>
-    names.filter((name) => !omittedToolNames.has(name));
+    names.filter((name) => allowedToolNames.has(name));
   return {
     ...plan,
-    providerTools: plan.providerTools.filter((tool) => !omittedToolNames.has(tool.name)),
+    providerTools: plan.providerTools.filter((tool) => allowedToolNames.has(tool.name)),
     activeTools: visible(plan.activeTools),
     ...(plan.projectActiveTools
       ? {
@@ -545,6 +546,16 @@ function omitToolsFromPlan(
     currentRepairToolNames: () => visible(plan.currentRepairToolNames()),
   };
 }
+
+const DELEGATE_MAIN_TOOL_NAMES = new Set([
+  INVALID_TOOL_NAME,
+  ARCHIVE_READ_TOOL_NAME,
+  'agent_list',
+  'view_agent_graph',
+  'update_agent_graph',
+  'agent_swarm_status',
+  'agent_output',
+]);
 
 function nestableToolSnapshot(
   providerTools: readonly MakaTool[],
@@ -1590,12 +1601,12 @@ export class AiSdkBackend implements AgentBackend {
         (input.runtimeContext ?? []).filter((event) => event.turnId !== turnId),
         requiredOrchestrationTools,
       ),
-      toolMode,
+      scope.orchestration.mode === 'delegate' ? 'direct' : toolMode,
       codeModeExecTool,
     );
     const plan =
       scope.orchestration.mode === 'delegate'
-        ? omitToolsFromPlan(toolModePlan, new Set(['yield_agent_graph']))
+        ? restrictToolsInPlan(toolModePlan, DELEGATE_MAIN_TOOL_NAMES)
         : toolModePlan;
     const providerTools = plan.providerTools;
     let activeToolResultPruneDiagnosticPatch: ActiveToolResultPruneDiagnosticPatch = {};

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -201,6 +201,7 @@ import {
 } from './tool-availability.js';
 import { renderSwarmModePrompt } from './swarm-mode.js';
 import { renderGraphModePrompt } from './graph-mode.js';
+import { renderDelegateModePrompt } from './delegate-mode.js';
 import {
   MEMORY_EXTRACT_TOOL_NAME,
   MEMORY_REMEMBER_TOOL_NAME,
@@ -521,6 +522,27 @@ function projectToolModePlan(
             baseChars + (diagnostic.toolSchemaCharReduction ?? 0)) + execSchemaChars,
       };
     },
+  };
+}
+
+function omitToolsFromPlan(
+  plan: ToolAvailabilityPlan,
+  omittedToolNames: ReadonlySet<string>,
+): ToolAvailabilityPlan {
+  const visible = (names: readonly string[]): string[] =>
+    names.filter((name) => !omittedToolNames.has(name));
+  return {
+    ...plan,
+    providerTools: plan.providerTools.filter((tool) => !omittedToolNames.has(tool.name)),
+    activeTools: visible(plan.activeTools),
+    ...(plan.projectActiveTools
+      ? {
+          projectActiveTools: (options) => ({
+            activeTools: visible(plan.projectActiveTools?.(options).activeTools ?? []),
+          }),
+        }
+      : {}),
+    currentRepairToolNames: () => visible(plan.currentRepairToolNames()),
   };
 }
 
@@ -1544,14 +1566,14 @@ export class AiSdkBackend implements AgentBackend {
             'agent_swarm_status',
             'agent_output',
           ])
-        : scope.orchestration.mode === 'graph'
+        : scope.orchestration.mode === 'graph' || scope.orchestration.mode === 'delegate'
           ? new Set([
               'agent_list',
               'view_agent_graph',
               'update_agent_graph',
-              'yield_agent_graph',
               'agent_swarm_status',
               'agent_output',
+              ...(scope.orchestration.mode === 'graph' ? ['yield_agent_graph'] : []),
             ])
           : new Set<string>();
     const requestedToolMode: unknown =
@@ -1563,7 +1585,7 @@ export class AiSdkBackend implements AgentBackend {
     if (toolMode === 'code_mode' && this.input.tools.some((tool) => tool.name === 'exec')) {
       throw new Error('Tool name "exec" is reserved for Code Mode.');
     }
-    const plan = projectToolModePlan(
+    const toolModePlan = projectToolModePlan(
       this.toolAvailabilityRuntime.prepare(
         (input.runtimeContext ?? []).filter((event) => event.turnId !== turnId),
         requiredOrchestrationTools,
@@ -1571,6 +1593,10 @@ export class AiSdkBackend implements AgentBackend {
       toolMode,
       codeModeExecTool,
     );
+    const plan =
+      scope.orchestration.mode === 'delegate'
+        ? omitToolsFromPlan(toolModePlan, new Set(['yield_agent_graph']))
+        : toolModePlan;
     const providerTools = plan.providerTools;
     let activeToolResultPruneDiagnosticPatch: ActiveToolResultPruneDiagnosticPatch = {};
     let activeCompactDiagnosticPatch: Partial<ContextBudgetDiagnostic> | undefined;
@@ -1692,6 +1718,7 @@ export class AiSdkBackend implements AgentBackend {
           await this.resolveSystemPrompt(scope),
           scope.orchestration?.mode === 'swarm' ? renderSwarmModePrompt() : undefined,
           scope.orchestration?.mode === 'graph' ? renderGraphModePrompt() : undefined,
+          scope.orchestration?.mode === 'delegate' ? renderDelegateModePrompt() : undefined,
         ]);
         const turnTailPrompt = input.continuation
           ? undefined

--- a/packages/runtime/src/delegate-mode.ts
+++ b/packages/runtime/src/delegate-mode.ts
@@ -32,10 +32,10 @@ export function shouldWakeDelegateSupervisor(
   snapshot: AgentGraphClientSnapshot,
 ): boolean | undefined {
   if (snapshot.orchestrationMode !== 'delegate') return undefined;
-  // Runtime events own Delegate checkpoint wakeups. The following reconciliation
-  // of the same terminal snapshot is a control-plane confirmation, not a second
-  // user-visible completion event.
-  if (_result !== undefined) return false;
+  // Checkpoint and reconciliation callbacks intentionally share the same
+  // snapshot-version wake identity. The durable wake store deduplicates the
+  // ordinary pair, while a recovery reconciliation can recreate a wake if the
+  // Host stopped before the checkpoint callback persisted its claim.
   return snapshot.reconciliationFailures.length > 0 || isAgentSwarmSupervisorCheckpoint(snapshot);
 }
 

--- a/packages/runtime/src/delegate-mode.ts
+++ b/packages/runtime/src/delegate-mode.ts
@@ -10,7 +10,13 @@ export function renderDelegateModePrompt(): string {
     '<orchestration_mode>',
     '# Orchestration Mode: Delegate',
     'Delegate Mode is active. You are the conversation-facing main agent and remain responsive while durable worker tasks execute in background child Sessions.',
-    'For work that is more than a quick conversational response, call agent_list, then submit bounded work with update_agent_graph. Treat each graph work item as a durable background task with an explicit objective, scope, constraints, and expected result.',
+    '<delegate_decision_contract>',
+    'For every user turn, make exactly one structured decision: respond or delegate.',
+    'Choose respond only when you can answer completely from the conversation and your existing model knowledge with zero tool calls. In that branch, emit the answer as plain text and do not call any tool.',
+    'Choose delegate whenever fulfilling the request requires any tool, external or workspace state, file access, shell command, code execution, browser, search, mutation, or other side effect. Never guess that state and never perform the work yourself.',
+    'In the delegate branch, call agent_list when worker selection is needed, then submit bounded work with update_agent_graph. Treat each graph work item as a durable background task with an explicit objective, scope, constraints, and expected result.',
+    'Task status, result reading, replacement, and cancellation are main-agent orchestration rather than worker execution; use only the exposed graph status, result, and control tools for those requests.',
+    '</delegate_decision_contract>',
     'After scheduling work, acknowledge what was delegated and end this turn normally. Do not poll, sleep, wait for child output, or call yield_agent_graph. The host will wake you at a durable task checkpoint.',
     'You may keep accepting user messages while workers run. Use view_agent_graph or agent_swarm_status when the user asks for status, update_agent_graph to add, replace, or stop work, and agent_output view=result only for committed worker results.',
     'On a host checkpoint, inspect task state, read committed results, decide whether follow-up work is needed, and either schedule it or report the result. If more work is scheduled, report the decision and end normally; never wait synchronously.',
@@ -26,6 +32,10 @@ export function shouldWakeDelegateSupervisor(
   snapshot: AgentGraphClientSnapshot,
 ): boolean | undefined {
   if (snapshot.orchestrationMode !== 'delegate') return undefined;
+  // Runtime events own Delegate checkpoint wakeups. The following reconciliation
+  // of the same terminal snapshot is a control-plane confirmation, not a second
+  // user-visible completion event.
+  if (_result !== undefined) return false;
   return snapshot.reconciliationFailures.length > 0 || isAgentSwarmSupervisorCheckpoint(snapshot);
 }
 
@@ -48,7 +58,8 @@ export function renderDelegateSupervisorWake(
   return {
     text: [
       '<delegate-task-checkpoint>',
-      `Background task set ${status.swarmId} reached ${status.status}.`,
+      `Background task set ${status.swarmId} reached a durable checkpoint.`,
+      `Checkpoint projection status: ${status.status}.`,
       `Reconciliation status: ${result?.status ?? 'checkpoint'}.`,
       ...(attentionWorkIds.length > 0
         ? [`Attention work ids: ${attentionWorkIds.join(', ')}.`]
@@ -60,7 +71,7 @@ export function renderDelegateSupervisorWake(
       'When the useful work is complete, synthesize the result for the user and end normally.',
       '</delegate-task-checkpoint>',
     ].join('\n'),
-    displayText: `Delegated tasks ${status.status.replace('_', ' ')}.`,
+    displayText: 'Delegated task checkpoint.',
     orchestrationMode: 'delegate',
   };
 }

--- a/packages/runtime/src/delegate-mode.ts
+++ b/packages/runtime/src/delegate-mode.ts
@@ -1,0 +1,66 @@
+import type { AgentGraphScheduleReconciliationResult } from './stream-graph-schedule-reconcile.js';
+import type { AgentGraphClientSnapshot } from './stream-graph-read-model.js';
+import {
+  isAgentSwarmSupervisorCheckpoint,
+  projectAgentSwarmStatus,
+} from './agent-swarm-status-tool.js';
+
+export function renderDelegateModePrompt(): string {
+  return [
+    '<orchestration_mode>',
+    '# Orchestration Mode: Delegate',
+    'Delegate Mode is active. You are the conversation-facing main agent and remain responsive while durable worker tasks execute in background child Sessions.',
+    'For work that is more than a quick conversational response, call agent_list, then submit bounded work with update_agent_graph. Treat each graph work item as a durable background task with an explicit objective, scope, constraints, and expected result.',
+    'After scheduling work, acknowledge what was delegated and end this turn normally. Do not poll, sleep, wait for child output, or call yield_agent_graph. The host will wake you at a durable task checkpoint.',
+    'You may keep accepting user messages while workers run. Use view_agent_graph or agent_swarm_status when the user asks for status, update_agent_graph to add, replace, or stop work, and agent_output view=result only for committed worker results.',
+    'On a host checkpoint, inspect task state, read committed results, decide whether follow-up work is needed, and either schedule it or report the result. If more work is scheduled, report the decision and end normally; never wait synchronously.',
+    'Keep the delegate graph open across task batches so later user messages can submit more work. Do not finish the graph merely because the current batch settled; finish it only when the user explicitly ends the delegate workflow or the host is retiring the session.',
+    'Use new_preset with an exact subagent_id when possible. Keep worker tasks non-overlapping and avoid delegating trivial chat.',
+    '</orchestration_mode>',
+  ].join('\n');
+}
+
+export function shouldWakeDelegateSupervisor(
+  _rootSessionId: string,
+  _result: AgentGraphScheduleReconciliationResult | undefined,
+  snapshot: AgentGraphClientSnapshot,
+): boolean | undefined {
+  if (snapshot.orchestrationMode !== 'delegate') return undefined;
+  return snapshot.reconciliationFailures.length > 0 || isAgentSwarmSupervisorCheckpoint(snapshot);
+}
+
+export function renderDelegateSupervisorWake(
+  _rootSessionId: string,
+  snapshot: AgentGraphClientSnapshot,
+  result?: AgentGraphScheduleReconciliationResult,
+):
+  | {
+      text: string;
+      displayText: string;
+      orchestrationMode: 'delegate';
+    }
+  | undefined {
+  if (snapshot.orchestrationMode !== 'delegate') return undefined;
+  const status = projectAgentSwarmStatus(snapshot);
+  const attentionWorkIds = status.items
+    .filter((item) => ['blocked', 'failed', 'aborted', 'cancelled'].includes(item.status))
+    .map((item) => item.workId);
+  return {
+    text: [
+      '<delegate-task-checkpoint>',
+      `Background task set ${status.swarmId} reached ${status.status}.`,
+      `Reconciliation status: ${result?.status ?? 'checkpoint'}.`,
+      ...(attentionWorkIds.length > 0
+        ? [`Attention work ids: ${attentionWorkIds.join(', ')}.`]
+        : []),
+      'Call agent_swarm_status for compact task status. Read committed completed results with agent_output view=result.',
+      'Replace or stop failed work when useful. Otherwise report the committed result and keep the delegate graph open for later task batches.',
+      'If you schedule more background work, report that decision and end this turn normally. Do not poll, sleep, wait synchronously, or call yield_agent_graph.',
+      'Do not finish the graph merely because this task batch settled; finish it only when the user explicitly ends the delegate workflow or the host is retiring the session.',
+      'When the useful work is complete, synthesize the result for the user and end normally.',
+      '</delegate-task-checkpoint>',
+    ].join('\n'),
+    displayText: `Delegated tasks ${status.status.replace('_', ' ')}.`,
+    orchestrationMode: 'delegate',
+  };
+}

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -728,7 +728,7 @@ export class AgentGraphCoordinator {
               );
               if (
                 advancement &&
-                isAsyncCheckpointTransition(advancement.before, advancement.after)
+                isAgentGraphAsyncCheckpointTransition(advancement.before, advancement.after)
               ) {
                 await notify(this.#input.onCheckpoint, driver.rootSessionId);
               }
@@ -1357,13 +1357,28 @@ function isMaterializedGraphClientEvent(
   ].includes(type);
 }
 
-function isAsyncCheckpointTransition(
+export function isAgentGraphAsyncCheckpointTransition(
   before: AgentGraphClientSnapshot,
   after: AgentGraphClientSnapshot,
 ): boolean {
   if (after.orchestrationMode !== 'swarm' && after.orchestrationMode !== 'delegate') return false;
   const previous = projectAgentSwarmStatus(before);
   const current = projectAgentSwarmStatus(after);
+  if (after.orchestrationMode === 'delegate') {
+    const terminals = (snapshot: ReturnType<typeof projectAgentSwarmStatus>): string[] =>
+      snapshot.items
+        .filter((item) =>
+          ['completed', 'blocked', 'failed', 'aborted', 'cancelled'].includes(item.status),
+        )
+        .map((item) => `${item.workId}:${item.status}`)
+        .sort();
+    const previousTerminals = terminals(previous);
+    const currentTerminals = terminals(current);
+    return (
+      previousTerminals.length !== currentTerminals.length ||
+      currentTerminals.some((entry, index) => entry !== previousTerminals[index])
+    );
+  }
   if (current.status === 'settled' && previous.status !== 'settled') return true;
   const attention = (snapshot: ReturnType<typeof projectAgentSwarmStatus>): string[] =>
     snapshot.items

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -728,7 +728,7 @@ export class AgentGraphCoordinator {
               );
               if (
                 advancement &&
-                isSwarmCheckpointTransition(advancement.before, advancement.after)
+                isAsyncCheckpointTransition(advancement.before, advancement.after)
               ) {
                 await notify(this.#input.onCheckpoint, driver.rootSessionId);
               }
@@ -1357,11 +1357,11 @@ function isMaterializedGraphClientEvent(
   ].includes(type);
 }
 
-function isSwarmCheckpointTransition(
+function isAsyncCheckpointTransition(
   before: AgentGraphClientSnapshot,
   after: AgentGraphClientSnapshot,
 ): boolean {
-  if (after.orchestrationMode !== 'swarm') return false;
+  if (after.orchestrationMode !== 'swarm' && after.orchestrationMode !== 'delegate') return false;
   const previous = projectAgentSwarmStatus(before);
   const current = projectAgentSwarmStatus(after);
   if (current.status === 'settled' && previous.status !== 'settled') return true;
@@ -1445,18 +1445,22 @@ function assertUniqueClaims(graphId: string, claims: readonly AgentGraphIntentCl
 function graphOrchestrationMode(
   updates: readonly AgentGraphScheduleUpdate[],
   header: SessionHeader,
-): 'graph' | 'swarm' {
+): 'graph' | 'swarm' | 'delegate' {
   const first = [...updates].sort((a, b) => a.revision - b.revision)[0];
   if (first?.source.orchestrationMode === 'swarm') return 'swarm';
   if (first?.source.orchestrationMode === 'graph') return 'graph';
-  return header.orchestrationMode === 'swarm' ? 'swarm' : 'graph';
+  if (first?.source.orchestrationMode === 'delegate') return 'delegate';
+  if (header.orchestrationMode === 'swarm') return 'swarm';
+  return header.orchestrationMode === 'delegate' ? 'delegate' : 'graph';
 }
 
 function isCurrentClientProjectionPayload(value: unknown): boolean {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const snapshot = value as Partial<AgentGraphClientSnapshot>;
   return (
-    (snapshot.orchestrationMode === 'graph' || snapshot.orchestrationMode === 'swarm') &&
+    (snapshot.orchestrationMode === 'graph' ||
+      snapshot.orchestrationMode === 'swarm' ||
+      snapshot.orchestrationMode === 'delegate') &&
     Array.isArray(snapshot.reconciliationFailures) &&
     typeof snapshot.omitted?.reconciliationFailures === 'number'
   );

--- a/packages/runtime/src/stream-graph-read-model.ts
+++ b/packages/runtime/src/stream-graph-read-model.ts
@@ -190,7 +190,7 @@ export interface AgentGraphClientSnapshot {
   schemaVersion: typeof AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION;
   rootSessionId: string;
   graphId: string;
-  orchestrationMode: 'graph' | 'swarm';
+  orchestrationMode: 'graph' | 'swarm' | 'delegate';
   snapshotVersion: string;
   status: AgentGraphClientStatus;
   scheduleRevision: number;
@@ -256,7 +256,7 @@ export interface BuildAgentGraphClientReadModelInput {
   provisions: readonly AgentGraphOperatorProvision[];
   scheduleUpdates: readonly AgentGraphScheduleUpdate[];
   schedule?: AgentGraphScheduleProjection;
-  orchestrationMode?: 'graph' | 'swarm';
+  orchestrationMode?: 'graph' | 'swarm' | 'delegate';
   reconciliationFailures?: readonly AgentGraphClientReconciliationFailure[];
   claimAdmissions?: readonly AgentGraphClientClaimAdmission[];
   observation: AgentGraphSupervisorObservation;
@@ -1279,7 +1279,9 @@ export function decodeMaterializedAgentGraphClientSnapshot(
     snapshot.schemaVersion !== AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION ||
     snapshot.rootSessionId !== expected.rootSessionId ||
     snapshot.graphId !== expected.graphId ||
-    (snapshot.orchestrationMode !== 'graph' && snapshot.orchestrationMode !== 'swarm') ||
+    (snapshot.orchestrationMode !== 'graph' &&
+      snapshot.orchestrationMode !== 'swarm' &&
+      snapshot.orchestrationMode !== 'delegate') ||
     snapshot.snapshotVersion !== expected.snapshotVersion ||
     !Array.isArray(snapshot.operators) ||
     !Array.isArray(snapshot.edges) ||

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -587,7 +587,11 @@ export function compileAgentGraphScheduleUpdate(input: {
     turnId: requireIdentity(input.context.turnId, 'source turn id'),
     toolCallId: requireIdentity(input.context.toolCallId, 'source tool call id'),
     orchestrationMode:
-      input.context.orchestrationMode === 'swarm' ? ('swarm' as const) : ('graph' as const),
+      input.context.orchestrationMode === 'swarm'
+        ? ('swarm' as const)
+        : input.context.orchestrationMode === 'delegate'
+          ? ('delegate' as const)
+          : ('graph' as const),
   };
   const addWorkInput =
     parsed.operation === undefined || parsed.operation === 'add_work'

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -1514,11 +1514,12 @@ function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
   const messageLessExecution = inputlessExecution || providerRetry;
   if (execution.kind === 'agent_graph_supervisor_wake') {
     if (
-      admission.turnOrchestration?.mode !== 'graph' ||
+      (admission.turnOrchestration?.mode !== 'graph' &&
+        admission.turnOrchestration?.mode !== 'delegate') ||
       admission.turnOrchestration.source !== 'host_api'
     ) {
       throw new Error(
-        'Invalid root turn admission contract: Agent Graph supervisor wake requires Host Graph orchestration',
+        'Invalid root turn admission contract: Agent Graph supervisor wake requires Host Graph orchestration or Host Delegate orchestration',
       );
     }
   } else if (admission.turnOrchestration && execution.kind !== 'external_message') {


### PR DESCRIPTION
## Summary

Add a CLI-only Delegate Mode for nonblocking main-agent, task, and sub-agent orchestration.

- Add `/delegate`, `/delegate on`, `/delegate off`, and `/delegate <task>` flows.
- Keep the conversation-facing main agent responsive while durable background work runs in child sessions.
- Reuse the existing durable Graph execution, persistence, recovery, and checkpoint infrastructure while keeping the graph open across task batches.
- Enforce a runtime boundary: the main agent may either answer from conversation/model knowledge with zero tools, or delegate work through task orchestration tools. It cannot access file, shell, code, browser, search, or other execution tools, including when code mode is requested.
- Wake the main agent when background work reaches a durable checkpoint and suppress the duplicate reconciliation wake for the same settled batch.

This changes user-visible CLI behavior by adding the `delegate` orchestration mode. It does not add external channel integrations or a separate first-class Task data model in this phase.

## Verification

- Full workspace build passed.
- Full workspace typecheck passed.
- Biome checks passed.
- CLI, Runtime, Runtime Host, Core, and Storage affected tests passed.
- Real TUI E2E passed: simple questions stayed on the main agent without creating tasks; tool-requiring work created durable background tasks; the main agent continued answering while a worker ran; completed task results woke the main agent and were reported to the caller; `/delegate off` restored default mode.
- Regression verified: a settled task batch now produces one completion wake instead of separate checkpoint and reconciled replies.

## Review focus

The implementation intentionally maps Delegate tasks onto Graph work items for the MVP. Please focus on the restricted main-agent tool surface, background checkpoint wake semantics, and keeping Delegate graphs open for later task batches.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No