### PR TITLE
feat(eval): add fair multi-arm execution infrastructure

### DIFF
--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -8,7 +8,7 @@ Experiment → Cells → Attempts → Results
        Runtime Host executes Maka subjects
 ```
 
-An Experiment combines one benchmark, one executor, all subjects, all tasks, a repetition count, one shared budget, and one verifier. Cells are the Cartesian product `task × repetition × subject`. A repetition is a new experimental sample; an infrastructure retry appends a replacement attempt to the same cell; continuation remains internal to Runtime Host. Each subject declares only the credential environment names its cells receive.
+An Experiment combines one benchmark, one executor, all subjects, all tasks, a repetition count, one shared budget, one verifier, and a frozen task-group concurrency limit. Cells are the Cartesian product `task × repetition × subject`. All subject arms in one task repetition start together; independent task groups run up to the declared limit. A repetition is a new experimental sample; an infrastructure retry appends a replacement attempt to the same cell; continuation remains internal to Runtime Host. Each subject declares only the credential environment names its cells receive.
 
 Run a fully expanded spec through the public CLI:
 

--- a/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-four-arm.json
+++ b/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-four-arm.json
@@ -45,6 +45,7 @@
       ]
     }
   },
+  "execution": { "maxConcurrentTaskGroups": 1 },
   "subjects": [
     {
       "id": "maka",

--- a/packages/eval/harbor/run_trial.py
+++ b/packages/eval/harbor/run_trial.py
@@ -1,11 +1,32 @@
 """Run exactly one pinned Harbor or Pier Trial."""
 
 import asyncio
+import contextlib
+import fcntl
+import hashlib
 import importlib
 import importlib.metadata
+import os
 import signal
 import sys
 from pathlib import Path
+from typing import Iterator
+
+
+@contextlib.contextmanager
+def task_cache_lock(cache_dir: Path, identity: str) -> Iterator[None]:
+    lock_dir = cache_dir / ".maka-locks"
+    lock_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path = lock_dir / f"{hashlib.sha256(identity.encode()).hexdigest()}.lock"
+    flags = os.O_CREAT | os.O_RDWR | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(lock_path, flags, 0o600)
+    try:
+        os.fchmod(descriptor, 0o600)
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
 
 
 async def main() -> None:
@@ -26,6 +47,18 @@ async def main() -> None:
         trial_type = importlib.import_module(f"{framework}.trial.trial").Trial
         config = config_type.model_validate_json(config_file.read_text())
         config_file.unlink()
+        if framework == "harbor":
+            from harbor.constants import TASK_CACHE_DIR
+            from harbor.tasks.client import TaskClient
+
+            task_identity = config.task.model_dump_json()
+            with task_cache_lock(TASK_CACHE_DIR, task_identity):
+                task_id = config.task.get_task_id()
+                await TaskClient().download_tasks(
+                    task_ids=[task_id],
+                    overwrite=config.task.overwrite,
+                    output_dir=config.task.download_dir,
+                )
         trial = await trial_type.create(config)
         await trial.run()
     finally:
@@ -34,4 +67,5 @@ async def main() -> None:
             loop.remove_signal_handler(host_signal)
 
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/eval/harbor/test_run_trial.py
+++ b/packages/eval/harbor/test_run_trial.py
@@ -1,0 +1,48 @@
+import multiprocessing
+import queue
+import tempfile
+import unittest
+from pathlib import Path
+
+from run_trial import task_cache_lock
+
+
+def acquire_lock(cache_dir: str, identity: str, acquired: multiprocessing.Queue) -> None:
+    with task_cache_lock(Path(cache_dir), identity):
+        acquired.put(identity)
+
+
+class TaskCacheLockTest(unittest.TestCase):
+    def test_same_task_waits_for_the_existing_process(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        acquired = context.Queue()
+        with tempfile.TemporaryDirectory() as cache_dir:
+            with task_cache_lock(Path(cache_dir), "same-task"):
+                process = context.Process(
+                    target=acquire_lock,
+                    args=(cache_dir, "same-task", acquired),
+                )
+                process.start()
+                with self.assertRaises(queue.Empty):
+                    acquired.get(timeout=0.2)
+            self.assertEqual(acquired.get(timeout=2), "same-task")
+            process.join(timeout=2)
+            self.assertEqual(process.exitcode, 0)
+
+    def test_different_task_does_not_wait(self) -> None:
+        context = multiprocessing.get_context("spawn")
+        acquired = context.Queue()
+        with tempfile.TemporaryDirectory() as cache_dir:
+            with task_cache_lock(Path(cache_dir), "first-task"):
+                process = context.Process(
+                    target=acquire_lock,
+                    args=(cache_dir, "second-task", acquired),
+                )
+                process.start()
+                self.assertEqual(acquired.get(timeout=2), "second-task")
+                process.join(timeout=2)
+                self.assertEqual(process.exitcode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -20,7 +20,7 @@
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run clean && npm run build && npm run test:dist",
-    "test:dist": "node --test \"dist/**/*.test.js\" && python3 harbor/test_relay_agent.py"
+    "test:dist": "node --test \"dist/**/*.test.js\" && python3 harbor/test_relay_agent.py && python3 harbor/test_run_trial.py"
   },
   "dependencies": {
     "@maka/runtime-host": "0.1.0"

--- a/packages/eval/src/__tests__/cli-cohort.test.ts
+++ b/packages/eval/src/__tests__/cli-cohort.test.ts
@@ -176,6 +176,7 @@ function spec() {
     id: 'cli-test',
     benchmark: { id: 'benchmark', version: 'version', config: {} },
     executor: { kind: 'harbor', config: {} },
+    execution: { maxConcurrentTaskGroups: 1 },
     subjects: [{ id: 'maka', kind: 'maka', credentials: [], config: {} }],
     tasks: [{ id: 'task', input: 'solve', config: {} }],
     repetitions: 1,

--- a/packages/eval/src/__tests__/harness-executor.test.ts
+++ b/packages/eval/src/__tests__/harness-executor.test.ts
@@ -40,10 +40,11 @@ test('harness spawn failure releases its relay listener and process', async () =
 test('preparation failure persists bounded redacted diagnostics on the attempt', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-eval-preparation-diagnostic-'));
   const executable = join(root, 'fake-python.mjs');
+  const boundarySecret = 's'.repeat(256);
   await writeFile(
     executable,
     `#!/usr/bin/env node
-await new Promise((resolve) => process.stderr.write('x'.repeat(70_000), resolve));
+await new Promise((resolve) => process.stderr.write('x'.repeat(4_450) + '${boundarySecret}' + 'x'.repeat(65_294), resolve));
 await new Promise((resolve) => process.stderr.write('\\nAuthorization: Bearer test-bearer-secret\\nOPENAI_API_KEY=test-env-secret\\n', resolve));
 process.exitCode = 9;
 `,
@@ -54,7 +55,7 @@ process.exitCode = 9;
   const previousSecret = process.env.MAKA_TEST_SECRET;
   process.env.MAKA_TEST_PYTHON = executable;
   process.env.MAKA_TEST_TRIALS = root;
-  process.env.MAKA_TEST_SECRET = 'test-env-secret';
+  process.env.MAKA_TEST_SECRET = boundarySecret;
   try {
     const spec: ExperimentSpec = {
       schemaVersion: 'maka.eval.v1',
@@ -100,6 +101,7 @@ process.exitCode = 9;
     assert.equal(diagnostic.truncated, true);
     assert.ok(Buffer.byteLength(diagnostic.stderr) <= 65_536);
     assert.doesNotMatch(diagnostic.stderr, /test-bearer-secret|test-env-secret/u);
+    assert.doesNotMatch(diagnostic.stderr, /s{32}/u);
   } finally {
     if (previousPython === undefined) delete process.env.MAKA_TEST_PYTHON;
     else process.env.MAKA_TEST_PYTHON = previousPython;

--- a/packages/eval/src/__tests__/harness-executor.test.ts
+++ b/packages/eval/src/__tests__/harness-executor.test.ts
@@ -1,10 +1,13 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { FileAttemptStore } from '../attempt-store.js';
 import { createHarborExecutor } from '../harness-executor.js';
+import type { ExperimentSpec } from '../experiment.js';
+import { runExperiment, type SubjectAdapter } from '../runner.js';
 
 test('harness spawn failure releases its relay listener and process', async () => {
   const child = spawn(
@@ -32,6 +35,80 @@ test('harness spawn failure releases its relay listener and process', async () =
 
   assert.equal(exited, true);
   assert.equal(output, 'SETTLED\n');
+});
+
+test('preparation failure persists bounded redacted diagnostics on the attempt', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-eval-preparation-diagnostic-'));
+  const executable = join(root, 'fake-python.mjs');
+  await writeFile(
+    executable,
+    `#!/usr/bin/env node
+await new Promise((resolve) => process.stderr.write('x'.repeat(70_000), resolve));
+await new Promise((resolve) => process.stderr.write('\\nAuthorization: Bearer test-bearer-secret\\nOPENAI_API_KEY=test-env-secret\\n', resolve));
+process.exitCode = 9;
+`,
+  );
+  await chmod(executable, 0o755);
+  const previousPython = process.env.MAKA_TEST_PYTHON;
+  const previousTrials = process.env.MAKA_TEST_TRIALS;
+  const previousSecret = process.env.MAKA_TEST_SECRET;
+  process.env.MAKA_TEST_PYTHON = executable;
+  process.env.MAKA_TEST_TRIALS = root;
+  process.env.MAKA_TEST_SECRET = 'test-env-secret';
+  try {
+    const spec: ExperimentSpec = {
+      schemaVersion: 'maka.eval.v1',
+      id: 'experiment',
+      benchmark: { id: 'benchmark', version: 'version', config: { repository: 'repo' } },
+      executor: { kind: 'harbor', config: {} },
+      execution: { maxConcurrentTaskGroups: 1 },
+      subjects: [
+        { id: 'subject', kind: 'external', credentials: ['MAKA_TEST_SECRET'], config: {} },
+      ],
+      tasks: [{ id: 'task', input: 'solve', config: { harbor: { path: 'tasks/task' } } }],
+      repetitions: 1,
+      budget: { timeoutMultiplier: 1 },
+      verifier: { reward: 'reward' },
+    };
+    const executor = createHarborExecutor(
+      {
+        frameworkVersion: '0.20.0',
+        pythonPathEnv: 'MAKA_TEST_PYTHON',
+        trialsRootEnv: 'MAKA_TEST_TRIALS',
+        containerCwd: '/app',
+        environment: {},
+        mounts: [],
+      },
+      join(root, 'spec.json'),
+    );
+    const subject: SubjectAdapter = {
+      kind: 'external',
+      execute: async () => assert.fail('subject must not run'),
+    };
+    const store = new FileAttemptStore(join(root, 'attempts'));
+
+    await runExperiment({ spec, store, executor, subjects: [subject] });
+
+    const attempt = (await store.list('task::1::subject'))[0]!;
+    assert.equal(attempt.result.failureReason, 'executor preparation failed');
+    const artifact = attempt.result.artifacts[0]!;
+    assert.equal(artifact.kind, 'executor-preparation');
+    const diagnostic = JSON.parse(
+      await readFile(join(root, String(artifact.trialName), String(artifact.path)), 'utf8'),
+    ) as { stderr: string; truncated: boolean; exitCode: number | null };
+    assert.equal(diagnostic.exitCode, 9);
+    assert.equal(diagnostic.truncated, true);
+    assert.ok(Buffer.byteLength(diagnostic.stderr) <= 65_536);
+    assert.doesNotMatch(diagnostic.stderr, /test-bearer-secret|test-env-secret/u);
+  } finally {
+    if (previousPython === undefined) delete process.env.MAKA_TEST_PYTHON;
+    else process.env.MAKA_TEST_PYTHON = previousPython;
+    if (previousTrials === undefined) delete process.env.MAKA_TEST_TRIALS;
+    else process.env.MAKA_TEST_TRIALS = previousTrials;
+    if (previousSecret === undefined) delete process.env.MAKA_TEST_SECRET;
+    else process.env.MAKA_TEST_SECRET = previousSecret;
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 test('unknown Trial exception stays replaceable after subject failure', async () => {

--- a/packages/eval/src/__tests__/kernel.test.ts
+++ b/packages/eval/src/__tests__/kernel.test.ts
@@ -21,6 +21,133 @@ test('experiment expands task by repetition by subject', () => {
   );
 });
 
+test('all arms of one task repetition start together', async () => {
+  const store = new MemoryStore();
+  let started = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const threeArms: ExperimentSpec = {
+    ...spec(),
+    subjects: ['a', 'b', 'c'].map((id) => ({
+      id,
+      kind: 'maka' as const,
+      credentials: [],
+      config: {},
+    })),
+  };
+  const executor: ExperimentExecutor = {
+    kind: 'executor',
+    runAttempt: async (_input, operation) => {
+      started += 1;
+      await gate;
+      return {
+        kind: 'settled',
+        value: await operation({
+          context: {
+            cwd: '/workspace',
+            taskInput: 'solve',
+            metadata: {},
+            execute: async () => ({ termination: 'exited', exitCode: 0, stdout: '' }),
+          },
+          verify: async () => ({
+            status: 'completed',
+            score: 1,
+            failureReason: null,
+            artifacts: [],
+          }),
+        }),
+      };
+    },
+  };
+  const subject: SubjectAdapter = {
+    kind: 'maka',
+    execute: async () => ({
+      usage: null,
+      costUsd: null,
+      durationMs: 1,
+      status: 'completed',
+      failureReason: null,
+      artifacts: [],
+    }),
+  };
+
+  const running = runExperiment({ spec: threeArms, store, executor, subjects: [subject] });
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  try {
+    assert.equal(started, 3);
+  } finally {
+    release();
+    await running;
+  }
+});
+
+test('task-group concurrency never exceeds the frozen limit', async () => {
+  const store = new MemoryStore();
+  let active = 0;
+  let peak = 0;
+  let release!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const threeTasks: ExperimentSpec = {
+    ...spec(),
+    execution: { maxConcurrentTaskGroups: 2 },
+    subjects: [spec().subjects[0]!],
+    tasks: ['one', 'two', 'three'].map((id) => ({ id, input: 'solve', config: {} })),
+    repetitions: 1,
+  };
+  const executor: ExperimentExecutor = {
+    kind: 'executor',
+    runAttempt: async (_input, operation) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      if (active === 2) release();
+      await gate;
+      active -= 1;
+      return {
+        kind: 'settled',
+        value: await operation({
+          context: {
+            cwd: '/workspace',
+            taskInput: 'solve',
+            metadata: {},
+            execute: async () => ({ termination: 'exited', exitCode: 0, stdout: '' }),
+          },
+          verify: async () => ({
+            status: 'completed',
+            score: 1,
+            failureReason: null,
+            artifacts: [],
+          }),
+        }),
+      };
+    },
+  };
+  const subject: SubjectAdapter = {
+    kind: 'maka',
+    execute: async () => ({
+      usage: null,
+      costUsd: null,
+      durationMs: 1,
+      status: 'completed',
+      failureReason: null,
+      artifacts: [],
+    }),
+  };
+
+  const results = await runExperiment({
+    spec: threeTasks,
+    store,
+    executor,
+    subjects: [subject],
+  });
+
+  assert.equal(peak, 2);
+  assert.equal(results.size, 3);
+});
+
 test('cell result is the earliest valid attempt, never a hand-picked replacement', () => {
   assert.equal(
     selectCellResult([attempt(1, 'infra_failed'), attempt(2, 'completed'), attempt(3, 'completed')])
@@ -292,6 +419,7 @@ function spec(): ExperimentSpec {
     id: 'experiment',
     benchmark: { id: 'benchmark', version: 'version', config: {} },
     executor: { kind: 'executor', config: {} },
+    execution: { maxConcurrentTaskGroups: 1 },
     subjects: [
       { id: 'a', kind: 'maka', credentials: [], config: {} },
       { id: 'b', kind: 'external', credentials: [], config: {} },

--- a/packages/eval/src/experiment.ts
+++ b/packages/eval/src/experiment.ts
@@ -33,6 +33,7 @@ export interface ExperimentSpec {
     readonly config: JsonObject;
   };
   readonly executor: { readonly kind: string; readonly config: JsonObject };
+  readonly execution: { readonly maxConcurrentTaskGroups: number };
   readonly subjects: readonly {
     readonly id: string;
     readonly kind: 'maka' | 'external';

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -7,14 +7,17 @@ import { dirname, join, relative, resolve, sep } from 'node:path';
 import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { decodeJsonObject, type ExperimentCell, type JsonObject } from './experiment.js';
-import type {
-  ExperimentExecutor,
-  ExecutorVerification,
-  SubjectExecutionContext,
+import {
+  ExecutorPreparationFailure,
+  type ExperimentExecutor,
+  type ExecutorVerification,
+  type SubjectExecutionContext,
 } from './runner.js';
 import type { EvalResult } from './result.js';
 
 type Framework = 'harbor' | 'pier';
+
+const PREPARATION_STDERR_LIMIT = 64 * 1024;
 
 interface RelayState {
   readonly child: ChildProcess;
@@ -179,6 +182,7 @@ async function startTrial(
   await chmod(trialsRoot, 0o700);
   const trialName = `${safeName(cell.id)}-${randomBytes(6).toString('hex')}`;
   const configPath = join(trialsRoot, `${trialName}.json`);
+  const trialPath = join(trialsRoot, trialName);
   const task = decodeTask(framework, options, cell);
   const timeoutMultiplier = positive(cell.budget.timeoutMultiplier, 'budget.timeoutMultiplier');
   const environmentConfig = { ...options.environment, mounts: resolveMounts(options.mounts) };
@@ -190,6 +194,8 @@ async function startTrial(
   let child: ChildProcess | undefined;
   let connectedSocket: Socket | undefined;
   let abort: (() => void) | undefined;
+  const stderr = new BoundedCapture(PREPARATION_STDERR_LIMIT);
+  let stderrClosed: Promise<unknown> | undefined;
   try {
     server.listen(0, '127.0.0.1');
     await once(server, 'listening');
@@ -213,8 +219,10 @@ async function startTrial(
     child = spawn(
       process.env[options.pythonPathEnv]!,
       [join(relayPath, 'run_trial.py'), framework, options.frameworkVersion, configPath],
-      { cwd: dirname(specPath), env: environment, stdio: 'ignore' },
+      { cwd: dirname(specPath), env: environment, stdio: ['ignore', 'ignore', 'pipe'] },
     );
+    child.stderr!.on('data', (chunk: Buffer) => stderr.append(chunk));
+    stderrClosed = once(child.stderr!, 'close');
     abort = () => child?.kill('SIGTERM');
     signal?.addEventListener('abort', abort, { once: true });
     if (signal?.aborted) abort();
@@ -239,7 +247,7 @@ async function startTrial(
       lines,
       token,
       trialName,
-      trialPath: join(trialsRoot, trialName),
+      trialPath,
       taskInput: ready.instruction,
       credentials,
       containerCwd: options.containerCwd,
@@ -250,12 +258,81 @@ async function startTrial(
       child.kill('SIGTERM');
       await waitForTrial(child);
     }
+    await stderrClosed?.catch(() => undefined);
     connectedSocket?.destroy();
     await closeServer(server);
-    throw error;
+    await mkdir(trialPath, { recursive: true, mode: 0o700 });
+    const diagnosticPath = 'preparation-error.json';
+    const diagnostic = sanitizeDiagnostic(
+      stderr.text(),
+      [token, ...Object.values(credentials)],
+      PREPARATION_STDERR_LIMIT,
+    );
+    await writeFile(
+      join(trialPath, diagnosticPath),
+      `${JSON.stringify({
+        stage: 'executor-preparation',
+        framework,
+        exitCode: child?.exitCode ?? null,
+        signal: child?.signalCode ?? null,
+        stderr: diagnostic.text,
+        truncated: stderr.truncated || diagnostic.truncated,
+      })}\n`,
+      { flag: 'wx', mode: 0o600 },
+    );
+    throw new ExecutorPreparationFailure(
+      [{ kind: 'executor-preparation', framework, trialName, path: diagnosticPath }],
+      { cause: error },
+    );
   } finally {
     if (abort) signal?.removeEventListener('abort', abort);
   }
+}
+
+class BoundedCapture {
+  #value = Buffer.alloc(0);
+  #total = 0;
+
+  constructor(readonly limit: number) {}
+
+  append(chunk: Buffer): void {
+    this.#total += chunk.length;
+    this.#value = Buffer.concat([this.#value, chunk]).subarray(-this.limit);
+  }
+
+  get truncated(): boolean {
+    return this.#total > this.limit;
+  }
+
+  text(): string {
+    return this.#value.toString('utf8');
+  }
+}
+
+function sanitizeDiagnostic(
+  value: string,
+  exactSecrets: readonly string[],
+  limit: number,
+): { readonly text: string; readonly truncated: boolean } {
+  let redacted = value;
+  for (const secret of exactSecrets) {
+    if (secret) redacted = redacted.replaceAll(secret, '[REDACTED]');
+  }
+  redacted = redacted
+    .replace(/(authorization\s*:\s*(?:bearer|basic)\s+)[^\s]+/giu, '$1[REDACTED]')
+    .replace(
+      /((?:api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password)\s*[:=]\s*)[^\s]+/giu,
+      '$1[REDACTED]',
+    )
+    .replace(
+      /(--(?:api[_-]?key|access[_-]?token|refresh[_-]?token|secret|password)\s+)[^\s]+/giu,
+      '$1[REDACTED]',
+    )
+    .replace(/(https?:\/\/)[^\s/@:]+:[^\s/@]+@/giu, '$1[REDACTED]@')
+    .replace(/\bcommand\b[^\r\n]*/giu, 'command [REDACTED]');
+  const bytes = Buffer.from(redacted);
+  if (bytes.length <= limit) return { text: redacted, truncated: false };
+  return { text: bytes.subarray(-limit).toString('utf8'), truncated: true };
 }
 
 async function closeServer(server: Server): Promise<void> {

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -18,6 +18,7 @@ import type { EvalResult } from './result.js';
 type Framework = 'harbor' | 'pier';
 
 const PREPARATION_STDERR_LIMIT = 64 * 1024;
+const PREPARATION_REDACTION_OVERLAP = 8 * 1024;
 
 interface RelayState {
   readonly child: ChildProcess;
@@ -194,7 +195,14 @@ async function startTrial(
   let child: ChildProcess | undefined;
   let connectedSocket: Socket | undefined;
   let abort: (() => void) | undefined;
-  const stderr = new BoundedCapture(PREPARATION_STDERR_LIMIT);
+  const exactSecrets = [token, ...Object.values(credentials)];
+  const stderr = new BoundedCapture(
+    PREPARATION_STDERR_LIMIT +
+      Math.max(
+        PREPARATION_REDACTION_OVERLAP,
+        ...exactSecrets.map((secret) => Buffer.byteLength(secret)),
+      ),
+  );
   let stderrClosed: Promise<unknown> | undefined;
   try {
     server.listen(0, '127.0.0.1');
@@ -263,11 +271,7 @@ async function startTrial(
     await closeServer(server);
     await mkdir(trialPath, { recursive: true, mode: 0o700 });
     const diagnosticPath = 'preparation-error.json';
-    const diagnostic = sanitizeDiagnostic(
-      stderr.text(),
-      [token, ...Object.values(credentials)],
-      PREPARATION_STDERR_LIMIT,
-    );
+    const diagnostic = sanitizeDiagnostic(stderr.text(), exactSecrets, PREPARATION_STDERR_LIMIT);
     await writeFile(
       join(trialPath, diagnosticPath),
       `${JSON.stringify({

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -94,19 +94,35 @@ export async function runExperiment(input: {
       const subject = subjects.get(cell.subject.kind);
       if (!subject) throw new Error(`missing subject adapter: ${cell.subject.kind}`);
       subject.validate?.(cell);
-      if (input.signal?.aborted) break;
-      const attempts = await input.store.list(cell.id);
-      if (selectCellResult(attempts)) continue;
-      const startedAt = (input.now ?? Date.now)();
-      const result = await executeCell(input.executor, subject, cell, input.signal);
-      await input.store.append({
-        cellId: cell.id,
-        sequence: (attempts.at(-1)?.sequence ?? 0) + 1,
-        startedAt,
-        completedAt: (input.now ?? Date.now)(),
-        result,
-      });
     }
+    await runTaskGroups(
+      groupTaskCells(selected),
+      input.spec.execution.maxConcurrentTaskGroups,
+      async (group) => {
+        if (input.signal?.aborted) return;
+        await Promise.all(
+          group.map(async (cell) => {
+            if (input.signal?.aborted) return;
+            const attempts = await input.store.list(cell.id);
+            if (selectCellResult(attempts)) return;
+            const startedAt = (input.now ?? Date.now)();
+            const result = await executeCell(
+              input.executor,
+              subjects.get(cell.subject.kind)!,
+              cell,
+              input.signal,
+            );
+            await input.store.append({
+              cellId: cell.id,
+              sequence: (attempts.at(-1)?.sequence ?? 0) + 1,
+              startedAt,
+              completedAt: (input.now ?? Date.now)(),
+              result,
+            });
+          }),
+        );
+      },
+    );
 
     return new Map(
       (
@@ -118,6 +134,36 @@ export async function runExperiment(input: {
       ).flatMap(([cellId, result]) => (result ? [[cellId, result] as const] : [])),
     );
   });
+}
+
+function groupTaskCells(cells: readonly ExperimentCell[]): ExperimentCell[][] {
+  const groups = new Map<string, ExperimentCell[]>();
+  for (const cell of cells) {
+    const key = `${cell.task.id}\u0000${cell.repetition}`;
+    const group = groups.get(key);
+    if (group) group.push(cell);
+    else groups.set(key, [cell]);
+  }
+  return [...groups.values()];
+}
+
+async function runTaskGroups<T>(
+  groups: readonly T[],
+  maximum: number,
+  run: (group: T) => Promise<void>,
+): Promise<void> {
+  let next = 0;
+  const worker = async () => {
+    for (;;) {
+      const group = groups[next];
+      next += 1;
+      if (group === undefined) return;
+      await run(group);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(maximum, groups.length) }, async () => await worker()),
+  );
 }
 
 async function executeCell(

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -75,6 +75,16 @@ export interface AttemptStore {
   runExclusive<T>(operation: () => Promise<T>): Promise<T>;
 }
 
+export class ExecutorPreparationFailure extends Error {
+  constructor(
+    readonly artifacts: readonly JsonObject[],
+    options?: ErrorOptions,
+  ) {
+    super('executor preparation failed', options);
+    this.name = 'ExecutorPreparationFailure';
+  }
+}
+
 export async function runExperiment(input: {
   readonly spec: ExperimentSpec;
   readonly store: AttemptStore;
@@ -222,8 +232,13 @@ async function executeCell(
       status: 'indeterminate',
       failureReason: 'executor cleanup did not settle',
     };
-  } catch {
-    return failure('infra_failed', 'executor preparation failed');
+  } catch (error) {
+    return failure(
+      'infra_failed',
+      'executor preparation failed',
+      undefined,
+      error instanceof ExecutorPreparationFailure ? error.artifacts : [],
+    );
   }
 }
 
@@ -338,6 +353,7 @@ function failure(
   status: 'infra_failed' | 'indeterminate',
   failureReason: string,
   subject?: SubjectExecutionResult,
+  artifacts: readonly JsonObject[] = subject?.artifacts ?? [],
 ): EvalResult {
   return {
     score: null,
@@ -346,7 +362,7 @@ function failure(
     durationMs: subject?.durationMs ?? 0,
     status,
     failureReason,
-    artifacts: subject?.artifacts ?? [],
+    artifacts,
   };
 }
 

--- a/packages/eval/src/spec.ts
+++ b/packages/eval/src/spec.ts
@@ -6,6 +6,7 @@ export function parseExperimentSpec(value: unknown): ExperimentSpec {
     'id',
     'benchmark',
     'executor',
+    'execution',
     'subjects',
     'tasks',
     'repetitions',
@@ -15,6 +16,7 @@ export function parseExperimentSpec(value: unknown): ExperimentSpec {
   if (root.schemaVersion !== 'maka.eval.v1') throw new Error('unsupported experiment schema');
   const benchmark = exact(root.benchmark, 'benchmark', ['id', 'version', 'config']);
   const executor = exact(root.executor, 'executor', ['kind', 'config']);
+  const execution = exact(root.execution, 'execution', ['maxConcurrentTaskGroups']);
   const subjects: ExperimentSpec['subjects'][number][] = array(root.subjects, 'subjects').map(
     (value, index) => {
       const subject = exact(value, `subjects[${index}]`, ['id', 'kind', 'credentials', 'config']);
@@ -51,6 +53,12 @@ export function parseExperimentSpec(value: unknown): ExperimentSpec {
     executor: {
       kind: identifier(executor.kind, 'executor.kind'),
       config: decodeJsonObject(executor.config, 'executor.config'),
+    },
+    execution: {
+      maxConcurrentTaskGroups: positiveInteger(
+        execution.maxConcurrentTaskGroups,
+        'execution.maxConcurrentTaskGroups',
+      ),
     },
     subjects,
     tasks,


### PR DESCRIPTION
## Summary

- run every subject arm for one task/repetition concurrently while bounding independent task-group concurrency in the frozen experiment spec
- serialize Harbor Git task-cache preparation per task across processes without serializing trial execution
- persist bounded, redacted executor-preparation diagnostics as attempt artifacts
- prevent secrets crossing the diagnostic truncation boundary from leaking

This is experiment-agnostic infrastructure. It does not add an editing surface, a DeepSeek-specific cohort, a VM canary, or any automatic evaluation launch.

## Verification

- `npm --workspace @maka/eval test`
- `npm --workspace @maka/eval run typecheck`
- `python3 -m py_compile packages/eval/harbor/run_trial.py packages/eval/harbor/test_run_trial.py`
- `npx biome lint packages/eval`