### PR TITLE
feat(mcp): support remote dual-era negotiation

### DIFF
--- a/apps/desktop/src/main/__tests__/mcp-import.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-import.test.ts
@@ -12,6 +12,10 @@ test('MCP import migrates version 1 and unwrapped server maps to version 2', () 
     version: MCP_CONFIG_VERSION,
     mcpServers: { remote: { url: 'https://example.com/mcp' } },
   });
+  assert.deepEqual(parseMcpImport('{"version":{"command":"node"}}'), {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: { version: { command: 'node' } },
+  });
 });
 
 test('MCP import preserves remote protocol preferences from a version 2 wrapper', () => {

--- a/apps/desktop/src/main/__tests__/mcp-import.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-import.test.ts
@@ -16,6 +16,10 @@ test('MCP import migrates version 1 and unwrapped server maps to version 2', () 
     version: MCP_CONFIG_VERSION,
     mcpServers: { version: { command: 'node' } },
   });
+  assert.deepEqual(parseMcpImport('{"mcpServers":{"command":"node"}}'), {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: { mcpServers: { command: 'node' } },
+  });
 });
 
 test('MCP import preserves remote protocol preferences from a version 2 wrapper', () => {

--- a/apps/desktop/src/main/__tests__/mcp-import.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-import.test.ts
@@ -1,11 +1,47 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { MCP_CONFIG_VERSION } from '@maka/core/mcp';
 import { parseMcpImport } from '../../renderer/mcp-import.js';
+
+test('MCP import migrates version 1 and unwrapped server maps to version 2', () => {
+  assert.deepEqual(parseMcpImport('{"version":1,"mcpServers":{"local":{"command":"node"}}}'), {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: { local: { command: 'node' } },
+  });
+  assert.deepEqual(parseMcpImport('{"remote":{"url":"https://example.com/mcp"}}'), {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: { remote: { url: 'https://example.com/mcp' } },
+  });
+});
+
+test('MCP import preserves remote protocol preferences from a version 2 wrapper', () => {
+  assert.deepEqual(
+    parseMcpImport(
+      '{"version":2,"mcpServers":{"remote":{"url":"https://example.com/mcp","protocol":"2026-07-28"}}}',
+    ),
+    {
+      version: MCP_CONFIG_VERSION,
+      mcpServers: {
+        remote: { url: 'https://example.com/mcp', protocol: '2026-07-28' },
+      },
+    },
+  );
+});
+
+test('MCP import rejects protocol under a version 1 or missing wrapper', () => {
+  for (const source of [
+    '{"version":1,"mcpServers":{"remote":{"url":"https://example.com/mcp","protocol":"auto"}}}',
+    '{"mcpServers":{"remote":{"url":"https://example.com/mcp","protocol":"auto"}}}',
+    '{"remote":{"url":"https://example.com/mcp","protocol":"auto"}}',
+  ]) {
+    assert.throws(() => parseMcpImport(source), /protocol.*version 2/u);
+  }
+});
 
 test('MCP import rejects unsupported versions and malformed full configs', () => {
   assert.throws(
-    () => parseMcpImport('{"version":2,"mcpServers":{}}'),
-    /当前仅支持 version 1/u,
+    () => parseMcpImport('{"version":3,"mcpServers":{}}'),
+    /当前支持 version 1 和 2/u,
   );
-  assert.throws(() => parseMcpImport('{"version":1}'), /mcpServers 必须是 object/u);
+  assert.throws(() => parseMcpImport('{"version":2}'), /mcpServers 必须是 object/u);
 });

--- a/apps/desktop/src/main/__tests__/mcp-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-ipc-main.test.ts
@@ -1,11 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { McpConfigFile, McpServerStatus } from '@maka/core/mcp';
+import { MCP_CONFIG_VERSION, type McpConfigFile, type McpServerStatus } from '@maka/core/mcp';
 import { registerMcpIpcMain } from '../mcp-ipc-main.js';
 
 test('MCP IPC commits config before publishing capabilities and emitting status', async () => {
   const handlers = new Map<string, (...args: any[]) => Promise<any>>();
-  let config: McpConfigFile = { version: 1, mcpServers: {} };
+  let config: McpConfigFile = { version: MCP_CONFIG_VERSION, mcpServers: {} };
   const calls: string[] = [];
   const connected: McpServerStatus = {
     serverId: 'fixture', state: 'connected', transport: 'stdio', toolCount: 1,
@@ -18,12 +18,12 @@ test('MCP IPC commits config before publishing capabilities and emitting status'
       set: async (next) => { calls.push('store'); config = next; return next; },
       upsert: async (serverId, server) => {
         calls.push('store');
-        config = { version: 1, mcpServers: { ...config.mcpServers, [serverId]: server } };
+        config = { version: MCP_CONFIG_VERSION, mcpServers: { ...config.mcpServers, [serverId]: server } };
         return config;
       },
       remove: async (serverId) => {
         const { [serverId]: _removed, ...mcpServers } = config.mcpServers;
-        config = { version: 1, mcpServers };
+        config = { version: MCP_CONFIG_VERSION, mcpServers };
         return config;
       },
     },
@@ -49,7 +49,7 @@ test('MCP IPC commits config before publishing capabilities and emitting status'
   const setConfig = handlers.get('mcp:setConfig');
   assert.ok(setConfig);
   const imported = await setConfig({}, {
-    version: 1,
+    version: MCP_CONFIG_VERSION,
     mcpServers: { remote: { url: 'https://example.com/mcp', enabled: false } },
   });
   assert.deepEqual(imported.mcpServers, {
@@ -64,7 +64,7 @@ test('MCP IPC commits config before publishing capabilities and emitting status'
   assert.deepEqual(calls, ['ready', 'emit']);
 
   calls.length = 0;
-  config = { version: 1, mcpServers: { fixture: { command: 'node' } } };
+  config = { version: MCP_CONFIG_VERSION, mcpServers: { fixture: { command: 'node' } } };
   const cancelInstall = handlers.get('mcp:cancelInstall');
   assert.ok(cancelInstall);
   const cancelled = await cancelInstall({}, 'fixture');
@@ -74,7 +74,7 @@ test('MCP IPC commits config before publishing capabilities and emitting status'
 
 test('MCP market cancellation waits for an in-flight config write before rolling it back', async () => {
   const handlers = new Map<string, (...args: any[]) => Promise<any>>();
-  let config: McpConfigFile = { version: 1, mcpServers: {} };
+  let config: McpConfigFile = { version: MCP_CONFIG_VERSION, mcpServers: {} };
   let releaseWrite!: () => void;
   let markWriteStarted!: () => void;
   const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve; });
@@ -90,14 +90,14 @@ test('MCP market cancellation waits for an in-flight config write before rolling
         calls.push('write:start');
         markWriteStarted();
         await writeGate;
-        config = { version: 1, mcpServers: { ...config.mcpServers, [serverId]: server } };
+        config = { version: MCP_CONFIG_VERSION, mcpServers: { ...config.mcpServers, [serverId]: server } };
         calls.push('write:end');
         return config;
       },
       remove: async (serverId) => {
         calls.push('remove');
         const { [serverId]: _removed, ...mcpServers } = config.mcpServers;
-        config = { version: 1, mcpServers };
+        config = { version: MCP_CONFIG_VERSION, mcpServers };
         return config;
       },
     },
@@ -131,7 +131,7 @@ test('MCP market cancellation waits for an in-flight config write before rolling
 
 test('MCP config commit is not rolled back by a capability publication failure', async () => {
   const handlers = new Map<string, (...args: any[]) => Promise<any>>();
-  let config: McpConfigFile = { version: 1, mcpServers: {} };
+  let config: McpConfigFile = { version: MCP_CONFIG_VERSION, mcpServers: {} };
   const publicationErrors: unknown[] = [];
   registerMcpIpcMain({
     ipcMain: {
@@ -146,7 +146,10 @@ test('MCP config commit is not rolled back by a capability publication failure',
         return next;
       },
       upsert: async (serverId, server) => {
-        config = { version: 1, mcpServers: { ...config.mcpServers, [serverId]: server } };
+        config = {
+          version: MCP_CONFIG_VERSION,
+          mcpServers: { ...config.mcpServers, [serverId]: server },
+        };
         return config;
       },
       remove: async () => config,

--- a/apps/desktop/src/main/__tests__/mcp-page-model.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-page-model.test.ts
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isMcpStdioConfig, type McpServerStatus } from '@maka/core/mcp';
+import { MCP_CATALOG } from '../../renderer/mcp-catalog.js';
+import { getMcpCopy } from '../../renderer/locales/mcp-copy.js';
+import {
+  createEmptyMcpDraft,
+  mcpConfigFromDraft,
+  mcpDraftFromConfig,
+  presentMcpNegotiatedProtocol,
+  withMcpDraftTransport,
+} from '../../renderer/mcp-page-model.js';
+
+const copy = getMcpCopy('en');
+
+test('a newly-authored remote MCP persists an explicit auto preference', () => {
+  const config = mcpConfigFromDraft(
+    {
+      ...createEmptyMcpDraft(),
+      id: 'remote',
+      kind: 'remote',
+      url: ' https://example.com/mcp ',
+    },
+    copy,
+  );
+
+  assert.deepEqual(config, {
+    enabled: true,
+    url: 'https://example.com/mcp',
+    transport: 'auto',
+    protocol: 'auto',
+    headers: {},
+  });
+});
+
+test('editing an omitted remote preference presents and preserves legacy semantics', () => {
+  const draft = mcpDraftFromConfig('existing', {
+    url: 'https://example.com/mcp',
+    transport: 'streamable-http',
+  });
+
+  assert.equal(draft.protocol, 'legacy');
+  assert.deepEqual(mcpConfigFromDraft(draft, copy), {
+    enabled: true,
+    url: 'https://example.com/mcp',
+    transport: 'streamable-http',
+    protocol: 'legacy',
+    headers: {},
+  });
+});
+
+test('editing a remote MCP round-trips auto and exact modern preferences', () => {
+  for (const protocol of ['auto', '2026-07-28'] as const) {
+    const draft = mcpDraftFromConfig('remote', {
+      url: 'https://example.com/mcp',
+      transport: 'streamable-http',
+      protocol,
+    });
+
+    const saved = mcpConfigFromDraft(draft, copy);
+    assert.equal(!isMcpStdioConfig(saved) && saved.protocol, protocol);
+  }
+});
+
+test('selecting legacy SSE converges and persists the legacy preference', () => {
+  const modern = {
+    ...createEmptyMcpDraft(),
+    kind: 'remote' as const,
+    url: 'https://example.com/sse',
+    protocol: '2026-07-28' as const,
+  };
+  const sse = withMcpDraftTransport(modern, 'sse');
+
+  assert.equal(sse.protocol, 'legacy');
+  assert.deepEqual(mcpConfigFromDraft(sse, copy), {
+    enabled: true,
+    url: 'https://example.com/sse',
+    transport: 'sse',
+    protocol: 'legacy',
+    headers: {},
+  });
+
+  // The serializer also protects against an inconsistent draft supplied by a
+  // stale renderer event.
+  const forged = mcpConfigFromDraft({ ...sse, protocol: 'auto' }, copy);
+  assert.equal(!isMcpStdioConfig(forged) && forged.protocol, 'legacy');
+});
+
+test('stdio editing never adds a protocol preference in config version 2', () => {
+  const saved = mcpConfigFromDraft(
+    { ...createEmptyMcpDraft(), id: 'local', command: ' node ' },
+    copy,
+  );
+
+  assert.equal(isMcpStdioConfig(saved), true);
+  assert.equal(Object.hasOwn(saved, 'protocol'), false);
+});
+
+test('the MCP catalog opts every bundled remote entry into auto negotiation', () => {
+  const remoteEntries = MCP_CATALOG.filter((entry) => !isMcpStdioConfig(entry.config));
+
+  assert.deepEqual(
+    remoteEntries.map((entry) => entry.id),
+    ['notion', 'vercel', 'supabase'],
+  );
+  for (const entry of remoteEntries) {
+    assert.equal(!isMcpStdioConfig(entry.config) && entry.config.protocol, 'auto');
+  }
+});
+
+test('status copy presents only a live connected negotiated protocol', () => {
+  const status: McpServerStatus = {
+    serverId: 'remote',
+    state: 'connected',
+    transport: 'streamable-http',
+    negotiatedProtocol: { era: 'modern', revision: '2026-07-28' },
+    toolCount: 0,
+    tools: [],
+    updatedAt: 1,
+  };
+
+  assert.equal(
+    presentMcpNegotiatedProtocol(status, copy),
+    'Modern · 2026-07-28',
+  );
+  assert.equal(
+    presentMcpNegotiatedProtocol({ ...status, state: 'disconnected' }, copy),
+    undefined,
+  );
+});

--- a/apps/desktop/src/main/__tests__/mcp-page-model.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-page-model.test.ts
@@ -88,7 +88,7 @@ test('selecting legacy SSE converges and persists the legacy preference', () => 
 
 test('stdio editing never adds a protocol preference in config version 2', () => {
   const saved = mcpConfigFromDraft(
-    { ...createEmptyMcpDraft(), id: 'local', command: ' node ' },
+    { ...createEmptyMcpDraft(), id: 'local', commandLine: ' node ' },
     copy,
   );
 

--- a/apps/desktop/src/main/__tests__/mcp-runtime-e2e.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-runtime-e2e.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { fileURLToPath } from 'node:url';
 import { test } from 'node:test';
+import { MCP_CONFIG_VERSION } from '@maka/core/mcp';
 import { McpClientManager } from '@maka/mcp';
 import { buildMcpTools } from '@maka/runtime/mcp-tools';
 
@@ -12,7 +13,7 @@ test('MCP tools stay bound to the connection generation that advertised them', a
   });
   try {
     await manager.sync({
-      version: 1,
+      version: MCP_CONFIG_VERSION,
       mcpServers: {
         fixture: { command: process.execPath, args: [fixturePath] },
       },

--- a/apps/desktop/src/main/e2e-fixture/scenarios-modules.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-modules.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { MCP_CONFIG_VERSION } from '@maka/core/mcp';
 import { writeJson } from './seed-helpers.js';
 
 /**
@@ -13,7 +14,7 @@ import { writeJson } from './seed-helpers.js';
  */
 export async function seedMcpFixture(workspaceRoot: string): Promise<void> {
   const config = {
-    version: 1,
+    version: MCP_CONFIG_VERSION,
     mcpServers: {
       filesystem: {
         enabled: false,

--- a/apps/desktop/src/renderer/locales/mcp-copy.ts
+++ b/apps/desktop/src/renderer/locales/mcp-copy.ts
@@ -4,7 +4,7 @@ export type McpCopy = {
   errors: {
     load: string; install(name: string): string; cancelInstall(name: string): string; save: string; import: string;
     update: string; test: string; remove: string; unavailableStatus: string; mapLine(line: number): string;
-    importObject: string; importVersion(version: string): string; importServersObject: string;
+    importObject: string; importVersion(version: string): string; importServersObject: string; importProtocolVersion: string;
   };
   toast: {
     templateInstalled(name: string): string; templateInstalledDetail: string; installed(name: string): string;
@@ -24,7 +24,9 @@ export type McpCopy = {
   };
   detail: {
     label: string; enabled: string; transport: string; endpoint: string;
-    toolsLabel: string; statusLabel: string; inspectorOpened(id: string): string;
+    toolsLabel: string; statusLabel: string; protocolLabel: string;
+    negotiatedProtocol(era: 'legacy' | 'modern', revision: string): string;
+    inspectorOpened(id: string): string;
   };
   card: {
     macOnly: string; manage: string; cancellingAria(name: string): string; cancelAria(name: string): string; installAria(name: string): string;
@@ -44,6 +46,8 @@ export type McpCopy = {
     url: string; headers: string; headersHelp: string; saveConnect: string;
     required: string; invalidUrl: string; unbalancedQuote: string;
     transportLabel: string; transportAuto: string; transportStreamableHttp: string; transportLegacySse: string;
+    protocolLabel: string; protocolLegacy: string; protocolAuto: string; protocolModern: string;
+    protocolHelp: string; sseProtocolHelp: string;
   };
 };
 
@@ -53,7 +57,8 @@ const MCP_COPY = {
       load: '载入 MCP 失败', install: (name) => `安装 ${name} 失败`, cancelInstall: (name) => `取消安装 ${name} 失败`, save: '保存 MCP 失败',
       import: '导入 MCP 失败', update: '更新 MCP 失败', test: 'MCP 测试失败', remove: '删除 MCP 失败', unavailableStatus: 'Server 没有返回可用状态。',
       mapLine: (line) => `第 ${line} 行应为 KEY=value`, importObject: 'MCP JSON 必须是 object',
-      importVersion: (version) => `不支持 MCP 配置版本 ${version}，当前仅支持 version 1`, importServersObject: 'mcpServers 必须是 object',
+      importVersion: (version) => `不支持 MCP 配置版本 ${version}，当前支持 version 1 和 2`, importServersObject: 'mcpServers 必须是 object',
+      importProtocolVersion: '含 protocol 的 MCP 配置必须显式使用 version 2',
     },
     toast: {
       templateInstalled: (name) => `${name} 模板已安装`, templateInstalledDetail: '请在「已安装」中完成凭据配置，再启用连接。',
@@ -75,7 +80,9 @@ const MCP_COPY = {
     },
     detail: {
       label: '服务器详情', enabled: '启用', transport: '传输方式', endpoint: '端点',
-      toolsLabel: '工具', statusLabel: '状态', inspectorOpened: (id) => `已打开 ${id} 的详情`,
+      toolsLabel: '工具', statusLabel: '状态', protocolLabel: 'MCP 协议',
+      negotiatedProtocol: (era, revision) => `${era === 'modern' ? '现代' : '传统'} · ${revision}`,
+      inspectorOpened: (id) => `已打开 ${id} 的详情`,
     },
     card: {
       macOnly: '仅 macOS', manage: '管理', cancellingAria: (name) => `正在取消安装 ${name}`, cancelAria: (name) => `取消安装 ${name}`, installAria: (name) => `安装 ${name}`,
@@ -99,6 +106,8 @@ const MCP_COPY = {
       saveConnect: '保存并连接',
       required: '此字段为必填项。', invalidUrl: '请输入有效的 HTTP 或 HTTPS URL。', unbalancedQuote: '引号未闭合。',
       transportLabel: '传输协议', transportAuto: '自动回退', transportStreamableHttp: 'Streamable HTTP', transportLegacySse: '旧版 SSE',
+      protocolLabel: '协议偏好', protocolLegacy: '传统', protocolAuto: '自动协商', protocolModern: '仅 2026-07-28',
+      protocolHelp: '旧配置默认使用传统协议；自动协商会根据 server 能力选择协议。', sseProtocolHelp: '旧版 SSE 仅支持传统协议。',
     },
   },
   en: {
@@ -106,7 +115,8 @@ const MCP_COPY = {
       load: 'Failed to load MCP', install: (name) => `Failed to install ${name}`, cancelInstall: (name) => `Failed to cancel installation of ${name}`, save: 'Failed to save MCP',
       import: 'Failed to import MCP', update: 'Failed to update MCP', test: 'MCP test failed', remove: 'Failed to delete MCP', unavailableStatus: 'The server did not return an available status.',
       mapLine: (line) => `Line ${line} must use KEY=value`, importObject: 'MCP JSON must be an object',
-      importVersion: (version) => `Unsupported MCP config version ${version}; only version 1 is supported`, importServersObject: 'mcpServers must be an object',
+      importVersion: (version) => `Unsupported MCP config version ${version}; versions 1 and 2 are supported`, importServersObject: 'mcpServers must be an object',
+      importProtocolVersion: 'MCP configurations containing protocol must explicitly use version 2',
     },
     toast: {
       templateInstalled: (name) => `${name} template installed`, templateInstalledDetail: 'Finish configuring credentials under Installed before enabling the connection.',
@@ -128,7 +138,9 @@ const MCP_COPY = {
     },
     detail: {
       label: 'Server details', enabled: 'Enabled', transport: 'Transport', endpoint: 'Endpoint',
-      toolsLabel: 'Tools', statusLabel: 'Status', inspectorOpened: (id) => `${id} details opened`,
+      toolsLabel: 'Tools', statusLabel: 'Status', protocolLabel: 'MCP protocol',
+      negotiatedProtocol: (era, revision) => `${era === 'modern' ? 'Modern' : 'Legacy'} · ${revision}`,
+      inspectorOpened: (id) => `${id} details opened`,
     },
     card: {
       macOnly: 'macOS only', manage: 'Manage', cancellingAria: (name) => `Cancelling installation of ${name}`, cancelAria: (name) => `Cancel installation of ${name}`, installAria: (name) => `Install ${name}`,
@@ -152,6 +164,8 @@ const MCP_COPY = {
       saveConnect: 'Save and connect',
       required: 'This field is required.', invalidUrl: 'Enter a valid HTTP or HTTPS URL.', unbalancedQuote: 'Unclosed quote.',
       transportLabel: 'Transport', transportAuto: 'Auto fallback', transportStreamableHttp: 'Streamable HTTP', transportLegacySse: 'Legacy SSE',
+      protocolLabel: 'Protocol preference', protocolLegacy: 'Legacy', protocolAuto: 'Auto-negotiate', protocolModern: '2026-07-28 only',
+      protocolHelp: 'Existing configurations default to legacy; auto-negotiation selects an era from the server response.', sseProtocolHelp: 'Legacy SSE supports only the legacy protocol era.',
     },
   },
 } satisfies UiCatalog<McpCopy>;

--- a/apps/desktop/src/renderer/mcp-catalog.ts
+++ b/apps/desktop/src/renderer/mcp-catalog.ts
@@ -94,7 +94,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     mark: 'N',
     setupRequired: true,
     setupLabel: '需要登录授权',
-    config: { enabled: false, url: 'https://mcp.notion.com/mcp', transport: 'streamable-http' },
+    config: { enabled: false, url: 'https://mcp.notion.com/mcp', transport: 'streamable-http', protocol: 'auto' },
   },
   {
     id: 'macos-apps',
@@ -144,7 +144,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     mark: '▲',
     setupRequired: true,
     setupLabel: '需要登录授权',
-    config: { enabled: false, url: 'https://mcp.vercel.com', transport: 'streamable-http' },
+    config: { enabled: false, url: 'https://mcp.vercel.com', transport: 'streamable-http', protocol: 'auto' },
   },
   {
     id: 'supabase',
@@ -154,7 +154,7 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
     mark: 'S',
     setupRequired: true,
     setupLabel: '需要登录授权',
-    config: { enabled: false, url: 'https://mcp.supabase.com/mcp', transport: 'streamable-http' },
+    config: { enabled: false, url: 'https://mcp.supabase.com/mcp', transport: 'streamable-http', protocol: 'auto' },
   },
   {
     id: 'filesystem',

--- a/apps/desktop/src/renderer/mcp-import.ts
+++ b/apps/desktop/src/renderer/mcp-import.ts
@@ -8,7 +8,9 @@ export function parseMcpImport(source: string, locale: UiLocale = 'zh'): McpConf
   const value: unknown = JSON.parse(source);
   if (!isRecord(value)) throw new Error(copy.errors.importObject);
 
-  const wrapped = Object.hasOwn(value, 'mcpServers') || Object.hasOwn(value, 'version');
+  const wrapped =
+    Object.hasOwn(value, 'mcpServers') ||
+    (Object.hasOwn(value, 'version') && !isRecord(value.version));
   const sourceVersion = wrapped && Object.hasOwn(value, 'version') ? value.version : 1;
   let mcpServers: Record<string, unknown>;
 

--- a/apps/desktop/src/renderer/mcp-import.ts
+++ b/apps/desktop/src/renderer/mcp-import.ts
@@ -1,5 +1,6 @@
 import type { UiLocale } from '@maka/core/ui-locale';
 import type { McpConfigFile, McpServerConfig } from '@maka/core/mcp';
+import { MCP_CONFIG_VERSION } from '@maka/core/mcp';
 import { getMcpCopy } from './locales/mcp-copy.js';
 
 export function parseMcpImport(source: string, locale: UiLocale = 'zh'): McpConfigFile {
@@ -7,15 +8,34 @@ export function parseMcpImport(source: string, locale: UiLocale = 'zh'): McpConf
   const value: unknown = JSON.parse(source);
   if (!isRecord(value)) throw new Error(copy.errors.importObject);
 
-  if ('mcpServers' in value || 'version' in value) {
-    if ('version' in value && value.version !== 1) {
+  const wrapped = Object.hasOwn(value, 'mcpServers') || Object.hasOwn(value, 'version');
+  const sourceVersion = wrapped && Object.hasOwn(value, 'version') ? value.version : 1;
+  let mcpServers: Record<string, unknown>;
+
+  if (wrapped) {
+    if (sourceVersion !== 1 && sourceVersion !== MCP_CONFIG_VERSION) {
       throw new Error(copy.errors.importVersion(String(value.version)));
     }
     if (!isRecord(value.mcpServers)) throw new Error(copy.errors.importServersObject);
-    return { version: 1, mcpServers: value.mcpServers as Record<string, McpServerConfig> };
+    mcpServers = value.mcpServers;
+  } else {
+    mcpServers = value;
   }
 
-  return { version: 1, mcpServers: value as Record<string, McpServerConfig> };
+  if (sourceVersion === 1 && hasOwnProtocol(mcpServers)) {
+    throw new Error(copy.errors.importProtocolVersion);
+  }
+
+  return {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: mcpServers as Record<string, McpServerConfig>,
+  };
+}
+
+function hasOwnProtocol(mcpServers: Record<string, unknown>): boolean {
+  return Object.values(mcpServers).some(
+    (server) => isRecord(server) && Object.hasOwn(server, 'protocol'),
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/renderer/mcp-import.ts
+++ b/apps/desktop/src/renderer/mcp-import.ts
@@ -9,8 +9,9 @@ export function parseMcpImport(source: string, locale: UiLocale = 'zh'): McpConf
   if (!isRecord(value)) throw new Error(copy.errors.importObject);
 
   const wrapped =
-    Object.hasOwn(value, 'mcpServers') ||
-    (Object.hasOwn(value, 'version') && !isRecord(value.version));
+    (Object.hasOwn(value, 'version') && !isRecord(value.version)) ||
+    (Object.hasOwn(value, 'mcpServers') &&
+      (!isRecord(value.mcpServers) || !isMcpServerConfigShape(value.mcpServers)));
   const sourceVersion = wrapped && Object.hasOwn(value, 'version') ? value.version : 1;
   let mcpServers: Record<string, unknown>;
 
@@ -38,6 +39,10 @@ function hasOwnProtocol(mcpServers: Record<string, unknown>): boolean {
   return Object.values(mcpServers).some(
     (server) => isRecord(server) && Object.hasOwn(server, 'protocol'),
   );
+}
+
+function isMcpServerConfigShape(value: Record<string, unknown>): boolean {
+  return typeof value.command === 'string' || typeof value.url === 'string';
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/renderer/mcp-page-model.ts
+++ b/apps/desktop/src/renderer/mcp-page-model.ts
@@ -1,0 +1,126 @@
+import type {
+  McpProtocolPreference,
+  McpServerConfig,
+  McpServerStatus,
+} from '@maka/core/mcp';
+import { isMcpStdioConfig, resolveMcpRemoteProtocolPreference } from '@maka/core/mcp';
+import type { McpCopy } from './locales/mcp-copy.js';
+
+export type McpEditorDraft = {
+  id: string;
+  kind: 'stdio' | 'remote';
+  enabled: boolean;
+  command: string;
+  args: string;
+  cwd: string;
+  env: string;
+  url: string;
+  transport: 'auto' | 'streamable-http' | 'sse';
+  protocol: McpProtocolPreference;
+  headers: string;
+};
+
+export function createEmptyMcpDraft(): McpEditorDraft {
+  return {
+    id: '',
+    kind: 'stdio',
+    enabled: true,
+    command: '',
+    args: '',
+    cwd: '',
+    env: '',
+    url: '',
+    transport: 'auto',
+    protocol: 'auto',
+    headers: '',
+  };
+}
+
+export function mcpDraftFromConfig(id: string, config: McpServerConfig): McpEditorDraft {
+  if (isMcpStdioConfig(config)) {
+    return {
+      ...createEmptyMcpDraft(),
+      id,
+      enabled: config.enabled !== false,
+      command: config.command,
+      args: (config.args ?? []).join('\n'),
+      cwd: config.cwd ?? '',
+      env: formatMap(config.env),
+    };
+  }
+  return {
+    ...createEmptyMcpDraft(),
+    id,
+    kind: 'remote',
+    enabled: config.enabled !== false,
+    url: config.url,
+    transport: config.transport ?? 'auto',
+    // An omitted preference is the compatibility-preserving legacy posture,
+    // not the default for a newly-authored remote entry.
+    protocol: resolveMcpRemoteProtocolPreference(config),
+    headers: formatMap(config.headers),
+  };
+}
+
+export function withMcpDraftTransport(
+  draft: McpEditorDraft,
+  transport: McpEditorDraft['transport'],
+): McpEditorDraft {
+  return {
+    ...draft,
+    transport,
+    // Legacy HTTP+SSE is not a modern negotiation transport. Converge the
+    // draft as soon as the transport changes so the disabled protocol picker
+    // always describes the value that will be persisted.
+    ...(transport === 'sse' ? { protocol: 'legacy' as const } : {}),
+  };
+}
+
+export function mcpConfigFromDraft(draft: McpEditorDraft, copy: McpCopy): McpServerConfig {
+  if (draft.kind === 'stdio') {
+    return {
+      enabled: draft.enabled,
+      command: draft.command.trim(),
+      args: draft.args.split(/\r?\n/u).filter((line) => line.length > 0),
+      ...(draft.cwd.trim() ? { cwd: draft.cwd.trim() } : {}),
+      env: parseMap(draft.env, copy),
+    };
+  }
+  return {
+    enabled: draft.enabled,
+    url: draft.url.trim(),
+    transport: draft.transport,
+    protocol: draft.transport === 'sse' ? 'legacy' : draft.protocol,
+    headers: parseMap(draft.headers, copy),
+  };
+}
+
+export function presentMcpNegotiatedProtocol(
+  status: McpServerStatus | undefined,
+  copy: McpCopy,
+): string | undefined {
+  if (status?.state !== 'connected' || !status.negotiatedProtocol) return undefined;
+  return copy.detail.negotiatedProtocol(
+    status.negotiatedProtocol.era,
+    status.negotiatedProtocol.revision,
+  );
+}
+
+function parseMap(value: string, copy: McpCopy): Record<string, string> {
+  return Object.fromEntries(
+    value
+      .split(/\r?\n/u)
+      .filter((line) => line.trim())
+      .map((line, index) => {
+        const separator = line.indexOf('=');
+        if (separator <= 0) throw new Error(copy.errors.mapLine(index + 1));
+        return [line.slice(0, separator).trim(), line.slice(separator + 1)];
+      }),
+  );
+}
+
+function formatMap(value?: Record<string, string>): string {
+  return Object.entries(value ?? {})
+    .map(([key, item]) => `${key}=${item}`)
+    .join('\n');
+}

--- a/apps/desktop/src/renderer/mcp-page-model.ts
+++ b/apps/desktop/src/renderer/mcp-page-model.ts
@@ -5,13 +5,13 @@ import type {
 } from '@maka/core/mcp';
 import { isMcpStdioConfig, resolveMcpRemoteProtocolPreference } from '@maka/core/mcp';
 import type { McpCopy } from './locales/mcp-copy.js';
+import { formatCommandLine, parseCommandLine } from './mcp-command-line.js';
 
 export type McpEditorDraft = {
   id: string;
   kind: 'stdio' | 'remote';
   enabled: boolean;
-  command: string;
-  args: string;
+  commandLine: string;
   cwd: string;
   env: string;
   url: string;
@@ -25,8 +25,7 @@ export function createEmptyMcpDraft(): McpEditorDraft {
     id: '',
     kind: 'stdio',
     enabled: true,
-    command: '',
-    args: '',
+    commandLine: '',
     cwd: '',
     env: '',
     url: '',
@@ -42,8 +41,7 @@ export function mcpDraftFromConfig(id: string, config: McpServerConfig): McpEdit
       ...createEmptyMcpDraft(),
       id,
       enabled: config.enabled !== false,
-      command: config.command,
-      args: (config.args ?? []).join('\n'),
+      commandLine: formatCommandLine(config.command, config.args ?? []),
       cwd: config.cwd ?? '',
       env: formatMap(config.env),
     };
@@ -78,10 +76,14 @@ export function withMcpDraftTransport(
 
 export function mcpConfigFromDraft(draft: McpEditorDraft, copy: McpCopy): McpServerConfig {
   if (draft.kind === 'stdio') {
+    const parsed = parseCommandLine(draft.commandLine);
+    // Validation runs before save, so an unbalanced quote cannot reach here
+    // through the dialog; the throw keeps other callers honest.
+    if (!parsed.ok) throw new Error(copy.editor.unbalancedQuote);
     return {
       enabled: draft.enabled,
-      command: draft.command.trim(),
-      args: draft.args.split(/\r?\n/u).filter((line) => line.length > 0),
+      command: parsed.command,
+      args: parsed.args,
       ...(draft.cwd.trim() ? { cwd: draft.cwd.trim() } : {}),
       env: parseMap(draft.env, copy),
     };

--- a/apps/desktop/src/renderer/mcp-page.tsx
+++ b/apps/desktop/src/renderer/mcp-page.tsx
@@ -18,7 +18,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { McpConfigFile, McpServerConfig, McpServerStatus } from '@maka/core/mcp';
-import { isMcpStdioConfig } from '@maka/core/mcp';
+import { MCP_CONFIG_VERSION, isMcpStdioConfig } from '@maka/core/mcp';
 import {
   Banner,
   Button,
@@ -76,6 +76,14 @@ import {
 import { getMcpCatalog, catalogEntryMatches, type McpCatalogEntry } from './mcp-catalog';
 import { McpBrandMark, hasMcpBrandMark } from './mcp-brand-marks';
 import { parseMcpImport } from './mcp-import';
+import {
+  createEmptyMcpDraft,
+  mcpConfigFromDraft,
+  mcpDraftFromConfig,
+  presentMcpNegotiatedProtocol,
+  withMcpDraftTransport,
+  type McpEditorDraft,
+} from './mcp-page-model';
 import { settingsActionErrorMessage } from './settings/settings-error-copy';
 import { getMcpCopy, type McpCopy } from './locales/mcp-copy';
 import { formatCommandLine, parseCommandLine } from './mcp-command-line';
@@ -84,24 +92,12 @@ import {
   type McpEditorErrors,
 } from './mcp-editor-validation';
 
-type Draft = {
-  id: string;
-  kind: 'stdio' | 'remote';
-  enabled: boolean;
-  commandLine: string;
-  cwd: string;
-  env: string;
-  url: string;
-  transport: 'auto' | 'streamable-http' | 'sse';
-  headers: string;
-};
-
 type EditorState =
-  | { mode: 'manual'; draft: Draft; editingId: string | null }
+  | { mode: 'manual'; draft: McpEditorDraft; editingId: string | null }
   | { mode: 'json'; source: string }
   | null;
 
-const EMPTY_CONFIG: McpConfigFile = { version: 1, mcpServers: {} };
+const EMPTY_CONFIG: McpConfigFile = { version: MCP_CONFIG_VERSION, mcpServers: {} };
 const MIN_INSTALL_INDICATOR_MS = 500;
 
 type InstallPhase = 'installing' | 'cancelling';
@@ -224,14 +220,14 @@ export function McpPage(props: { hubHeader?: ModuleHubHeader }) {
     });
   }
 
-  function openManual(draft: Draft = emptyDraft()) {
+  function openManual(draft: McpEditorDraft = createEmptyMcpDraft()) {
     openEditor({ mode: 'manual', draft: { ...draft }, editingId: null });
   }
 
   function openEdit(serverId: string, server: McpServerConfig) {
     openEditor({
       mode: 'manual',
-      draft: draftFromConfig(serverId, server),
+      draft: mcpDraftFromConfig(serverId, server),
       editingId: serverId,
     });
   }
@@ -295,7 +291,7 @@ export function McpPage(props: { hubHeader?: ModuleHubHeader }) {
     setEditorErrors({});
     setBusy('save');
     try {
-      const next = await window.maka.mcp.upsert(editor.draft.id.trim(), configFromDraft(editor.draft, copy));
+      const next = await window.maka.mcp.upsert(editor.draft.id.trim(), mcpConfigFromDraft(editor.draft, copy));
       if (!mounted.current) return;
       setConfig(next);
       closeEditor();
@@ -315,7 +311,7 @@ export function McpPage(props: { hubHeader?: ModuleHubHeader }) {
     try {
       const imported = parseMcpImport(editor.source, locale);
       const next = await window.maka.mcp.setConfig({
-        version: 1,
+        version: MCP_CONFIG_VERSION,
         mcpServers: { ...config.mcpServers, ...imported.mcpServers },
       });
       if (!mounted.current) return;
@@ -719,6 +715,7 @@ function McpServerInspector(props: {
   const transportLabel = isMcpStdioConfig(server)
     ? copy.page.localStdio
     : server.transport ?? 'auto';
+  const negotiatedProtocol = presentMcpNegotiatedProtocol(status, copy);
   return (
     <VStack className="maka-mcp-inspector" gap={4}>
       <VStack gap={2}>
@@ -787,6 +784,11 @@ function McpServerInspector(props: {
         <MetadataListItem label={copy.detail.statusLabel}>
           <Text type="body">{state.label}</Text>
         </MetadataListItem>
+        {negotiatedProtocol ? (
+          <MetadataListItem label={copy.detail.protocolLabel}>
+            <Text type="body">{negotiatedProtocol}</Text>
+          </MetadataListItem>
+        ) : null}
       </MetadataList>
 
       {status?.tools.length ? (
@@ -835,7 +837,7 @@ function McpEditorDialog(props: {
   saving: boolean;
   onChange(
     next: Exclude<EditorState, null>,
-    changedKey?: keyof Draft,
+    changedKey?: keyof McpEditorDraft,
   ): void;
   onOpenChange(isOpen: boolean): void;
   onSave(event: React.FormEvent): void;
@@ -843,12 +845,19 @@ function McpEditorDialog(props: {
 }) {
   const editing = props.state.mode === 'manual' && Boolean(props.state.editingId);
 
-  const updateDraft = <K extends keyof Draft>(key: K, value: Draft[K]) => {
+  const updateDraft = <K extends keyof McpEditorDraft>(key: K, value: McpEditorDraft[K]) => {
     if (props.state.mode !== 'manual') return;
     props.onChange(
       { ...props.state, draft: { ...props.state.draft, [key]: value } },
       key,
     );
+  };
+  const updateTransport = (transport: McpEditorDraft['transport']) => {
+    if (props.state.mode !== 'manual') return;
+    props.onChange({
+      ...props.state,
+      draft: withMcpDraftTransport(props.state.draft, transport),
+    });
   };
   return (
     <Dialog
@@ -882,7 +891,7 @@ function McpEditorDialog(props: {
                   ? { mode: 'json', source: exampleJson() }
                   : {
                       mode: 'manual',
-                      draft: emptyDraft(),
+                      draft: createEmptyMcpDraft(),
                       editingId: null,
                     },
               );
@@ -920,7 +929,7 @@ function McpEditorDialog(props: {
               label={props.copy.editor.transportAria}
               value={props.state.draft.kind}
               orientation="horizontal"
-              onChange={(kind) => updateDraft('kind', kind as Draft['kind'])}
+              onChange={(kind) => updateDraft('kind', kind as McpEditorDraft['kind'])}
             >
               <RadioListItem
                 value="stdio"
@@ -956,8 +965,23 @@ function McpEditorDialog(props: {
                       { value: 'streamable-http', label: props.copy.editor.transportStreamableHttp },
                       { value: 'sse', label: props.copy.editor.transportLegacySse },
                     ]}
-                    onChange={(value) => updateDraft('transport', value as Draft['transport'])}
+                    onChange={(value) => updateTransport(value as McpEditorDraft['transport'])}
                     label={props.copy.editor.transportLabel}
+                    width="100%"
+                  />
+                  <Selector
+                    value={props.state.draft.protocol}
+                    options={[
+                      { value: 'legacy', label: props.copy.editor.protocolLegacy },
+                      { value: 'auto', label: props.copy.editor.protocolAuto },
+                      { value: '2026-07-28', label: props.copy.editor.protocolModern },
+                    ]}
+                    onChange={(value) => updateDraft('protocol', value as McpEditorDraft['protocol'])}
+                    label={props.copy.editor.protocolLabel}
+                    description={props.state.draft.transport === 'sse'
+                      ? props.copy.editor.sseProtocolHelp
+                      : props.copy.editor.protocolHelp}
+                    isDisabled={props.state.draft.transport === 'sse'}
                     width="100%"
                   />
                   <TextArea label={props.copy.editor.headers} description={props.copy.editor.headersHelp} value={props.state.draft.headers} onChange={(value) => updateDraft('headers', value)} placeholder={'Authorization=Bearer …\nX-Workspace=…'} />
@@ -974,46 +998,6 @@ function McpEditorDialog(props: {
       />
     </Dialog>
   );
-}
-
-function emptyDraft(): Draft {
-  return { id: '', kind: 'stdio', enabled: true, commandLine: '', cwd: '', env: '', url: '', transport: 'auto', headers: '' };
-}
-
-function draftFromConfig(id: string, config: McpServerConfig): Draft {
-  if (isMcpStdioConfig(config)) {
-    return { ...emptyDraft(), id, enabled: config.enabled !== false, commandLine: formatCommandLine(config.command, config.args ?? []), cwd: config.cwd ?? '', env: formatMap(config.env) };
-  }
-  return { ...emptyDraft(), id, kind: 'remote', enabled: config.enabled !== false, url: config.url, transport: config.transport ?? 'auto', headers: formatMap(config.headers) };
-}
-
-function configFromDraft(draft: Draft, copy: McpCopy): McpServerConfig {
-  if (draft.kind === 'stdio') {
-    const parsed = parseCommandLine(draft.commandLine);
-    // Validation runs before save, so an unbalanced quote cannot reach here
-    // through the dialog; the throw keeps other callers honest.
-    if (!parsed.ok) throw new Error(copy.editor.unbalancedQuote);
-    return {
-      enabled: draft.enabled,
-      command: parsed.command,
-      args: parsed.args,
-      ...(draft.cwd.trim() ? { cwd: draft.cwd.trim() } : {}),
-      env: parseMap(draft.env, copy),
-    };
-  }
-  return { enabled: draft.enabled, url: draft.url.trim(), transport: draft.transport, headers: parseMap(draft.headers, copy) };
-}
-
-function parseMap(value: string, copy: McpCopy): Record<string, string> {
-  return Object.fromEntries(value.split(/\r?\n/u).filter((line) => line.trim()).map((line, index) => {
-    const separator = line.indexOf('=');
-    if (separator <= 0) throw new Error(copy.errors.mapLine(index + 1));
-    return [line.slice(0, separator).trim(), line.slice(separator + 1)];
-  }));
-}
-
-function formatMap(value?: Record<string, string>): string {
-  return Object.entries(value ?? {}).map(([key, item]) => `${key}=${item}`).join('\n');
 }
 
 function endpointFor(server: McpServerConfig): string {
@@ -1046,6 +1030,7 @@ function presentStatus(status: McpServerStatus | undefined, enabled: boolean, co
 
 function exampleJson(): string {
   return JSON.stringify({
+    version: MCP_CONFIG_VERSION,
     mcpServers: {
       filesystem: {
         command: 'npx',

--- a/apps/desktop/src/renderer/mcp-page.tsx
+++ b/apps/desktop/src/renderer/mcp-page.tsx
@@ -854,10 +854,13 @@ function McpEditorDialog(props: {
   };
   const updateTransport = (transport: McpEditorDraft['transport']) => {
     if (props.state.mode !== 'manual') return;
-    props.onChange({
-      ...props.state,
-      draft: withMcpDraftTransport(props.state.draft, transport),
-    });
+    props.onChange(
+      {
+        ...props.state,
+        draft: withMcpDraftTransport(props.state.draft, transport),
+      },
+      'transport',
+    );
   };
   return (
     <Dialog

--- a/apps/desktop/stories/module-hubs.stories.tsx
+++ b/apps/desktop/stories/module-hubs.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { DailyReviewArchive, DailyReviewSummary } from '@maka/core/daily-review';
 import type { ScheduledTask, ScheduledTaskRun } from '@maka/core/scheduled-task';
 import type { McpConfigFile, McpServerStatus } from '@maka/core/mcp';
+import { MCP_CONFIG_VERSION } from '@maka/core/mcp';
 import {
   ScheduledTasksPage,
   DailyReviewPage,
@@ -420,7 +421,7 @@ const DAILY_REVIEW_ARCHIVE: DailyReviewArchive = {
 type DailyReviewBridge = NonNullable<ComponentProps<typeof DailyReviewPage>['bridge']>;
 
 const configuredMcpConfig: McpConfigFile = {
-  version: 1,
+  version: MCP_CONFIG_VERSION,
   mcpServers: {
     filesystem: {
       enabled: true,
@@ -436,7 +437,7 @@ const configuredMcpConfig: McpConfigFile = {
 };
 
 const editorMcpConfig: McpConfigFile = {
-  version: 1,
+  version: MCP_CONFIG_VERSION,
   mcpServers: {
     slack: {
       enabled: false,
@@ -479,7 +480,7 @@ const configuredMcpStatuses: McpServerStatus[] = [
 ];
 
 const failedMcpConfig: McpConfigFile = {
-  version: 1,
+  version: MCP_CONFIG_VERSION,
   mcpServers: {
     'team-tools': {
       enabled: true,
@@ -532,13 +533,13 @@ const withEditorMcpBridge = withScopedMakaBridge({
 
 const withEmptyMcpBridge = withScopedMakaBridge({
   mcp: {
-    getConfig: async () => ({ version: 1, mcpServers: {} }),
+    getConfig: async () => ({ version: MCP_CONFIG_VERSION, mcpServers: {} }),
     listStatuses: async () => [],
-    setConfig: async () => ({ version: 1, mcpServers: {} }),
-    upsert: async () => ({ version: 1, mcpServers: {} }),
-    install: async () => ({ version: 1, mcpServers: {} }),
-    remove: async () => ({ version: 1, mcpServers: {} }),
-    cancelInstall: async () => ({ version: 1, mcpServers: {} }),
+    setConfig: async () => ({ version: MCP_CONFIG_VERSION, mcpServers: {} }),
+    upsert: async () => ({ version: MCP_CONFIG_VERSION, mcpServers: {} }),
+    install: async () => ({ version: MCP_CONFIG_VERSION, mcpServers: {} }),
+    remove: async () => ({ version: MCP_CONFIG_VERSION, mcpServers: {} }),
+    cancelInstall: async () => ({ version: MCP_CONFIG_VERSION, mcpServers: {} }),
     test: async () => ({ ok: true, status: configuredMcpStatuses[0], latencyMs: 42 }),
     subscribeChanges: () => () => {},
   },

--- a/docs/architecture/mcp-runtime-architecture-draft.zh-CN.md
+++ b/docs/architecture/mcp-runtime-architecture-draft.zh-CN.md
@@ -1,22 +1,27 @@
 # Maka MCP runtime architecture
 
-状态：V1 implemented and verified（2026-07-18）
+状态：remote dual-era V2 implemented（2026-08-11）
+
+跟踪：[MCP 2026-07-28 dual-era rollout #1650](https://github.com/Maka-Agent/maka-agent/issues/1650)
 
 ## 1. 目标与边界
 
-Maka 的 MCP 接入必须复用现有 `MakaTool` execution boundary，而不是建立第二套 agent loop。MCP manager 负责连接、发现和调用；runtime adapter 把远端 tool 投影成动态 `MakaTool[]`。因此 MCP tool 自动获得现有 permission gating、runtime event log、telemetry、result persistence、abort 和 loop gate。
+Maka 的 MCP 接入必须复用现有 `MakaTool` execution boundary，而不是建立第二套 agent loop。MCP manager 负责连接、发现和调用；runtime adapter 把远端 tool 投影成动态 `MakaTool[]`。因此 MCP tool 复用 ToolRuntime 的 pre-implementation recording、abort、telemetry、result normalization 和 loop gate；这不代表当前普通路径存在 per-call PermissionEngine，也不代表每次调用都具有 durable T1/T2。
 
-V1 支持：
+当前支持：
 
-- local `stdio`、remote Streamable HTTP、legacy SSE；Streamable HTTP 可显式或自动 fallback 到 SSE。
-- `tools/list` pagination、`notifications/tools/list_changed`、tool call timeout 和 abort。
+- local `stdio` 仍固定 legacy；remote Streamable HTTP 可选择 legacy、自动协商或精确 pin `2026-07-28`；legacy SSE 只允许 legacy。
+- 自动 transport 仅在 Streamable HTTP 尚未产生协议证据、SDK 返回精确 404/405 not-implemented 分类且调用未 abort 时，才 fallback 到 legacy SSE。
+- `tools/list` pagination、tool call timeout 和 abort；legacy 使用 unsolicited `notifications/tools/list_changed`，modern 使用经 server acknowledgement 的 `subscriptions/listen`。
+- modern server 未声明 tools capability 时不发送 `tools/list`；list-change 由 Maka 做 bounded/coalesced refresh，不把 SDK auto-refresh 作为第二份 snapshot authority。
+- modern Streamable HTTP 对 SEP-2243 `x-mcp-header` 做 bounded validation；非法定义只排除对应 Tool，unsafe integer argument 在发送前本地失败。
 - text、image、audio、embedded resource、resource link content；MCP `isError` 进入 Maka error path。
-- workspace-scoped `mcp.json`，采用通用的 `mcpServers` 配置结构。
+- workspace-scoped `mcp.json` 使用 version 2；旧 wrapper 读取时保持 legacy 语义，只有显式 mutation 才迁移落盘。
 - 首页侧边栏「扩展 > MCP」模块，提供市场模板、搜索、JSON import、CRUD、test、status/tool list，以及配置变化后的 backend cache invalidation。
 - bundled catalog 对 executable package 固定已核验版本；需要 credential、OAuth 或路径选择的模板默认 `enabled: false`，setup 完成前不启动 server。
 - market install 是可取消 transaction：renderer 展示明确的 installing/cancelling 状态，main process abort 对应 connect、等待未完成的 config write settle，再 rollback config 并 reconcile tool snapshot。
 
-V1 不包含 OAuth browser flow、resources UI、resource subscription 和给 subprocess 使用的 loopback proxy。它们属于 V2；协议层保留 transport 和 content contracts，避免返工。
+当前 remote rollout 不包含 modern stdio、OAuth browser flow、resources UI、resource subscription 和给 subprocess 使用的 loopback proxy。协议层保留 transport 和 content contracts，后续按独立 PR 扩展。
 
 ## 2. 调研结论
 
@@ -37,7 +42,7 @@ flowchart LR
   Manager --> Transport["stdio / Streamable HTTP / SSE"]
   Manager --> Adapter["buildMcpTools"]
   Adapter --> Backend["AiSdkBackend"]
-  Backend --> Runtime["ToolRuntime permission + events + telemetry"]
+  Backend --> Runtime["ToolRuntime recording + telemetry + optional T1/T2"]
   Runtime --> Manager
 ```
 
@@ -51,7 +56,7 @@ flowchart LR
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "mcpServers": {
     "filesystem": {
       "enabled": true,
@@ -64,49 +69,61 @@ flowchart LR
       "enabled": true,
       "url": "https://mcp.example.com/mcp",
       "transport": "streamable-http",
+      "protocol": "auto",
       "headers": {}
     }
   }
 }
 ```
 
-Server id 是稳定 identity。配置 reconciliation 使用完整 normalized config fingerprint；新增/删除/修改只影响对应连接。remote headers 在 V1 仍位于 `mcp.json`，文件和目录分别强制 `0600`/`0700`；后续迁移到 Keychain-backed credential store。
+Server id 是稳定 identity。配置 reconciliation 使用完整 normalized config fingerprint；新增/删除/修改只影响对应连接。`protocol` 只允许出现在 remote config；省略表示兼容旧配置的 legacy，新建 Desktop remote 和 bundled remote catalog 显式写 `auto`。SSE 会收敛为 legacy，version 2 stdio 拒绝 `protocol`，避免给尚未实现的 modern stdio 制造虚假配置。
+
+version 1 或缺失 version 的 wrapper 可单向读取为 version 2 projection，但 `get()` 不静默改写文件；`set`、`upsert` 或 `remove` 才持久化 version 2。当前客户端遇到显式未知/未来 wrapper 必须拒绝，并且 full replacement 也不得覆盖其原始字节；malformed JSON 仍可通过用户主动的完整导入修复。remote headers 仍位于 `mcp.json`，文件和目录分别强制 `0600`/`0700`；后续迁移到 Keychain-backed credential store。
 
 Bundled catalog 不是第二份 runtime truth：点击安装只把选中的模板写入同一个 `mcpServers` map。需要 setup 的模板以 disabled snapshot 落盘，用户补齐配置并主动启用后才参与连接；不允许用“已写入配置”冒充“已授权”或“已连接”。
 
 ## 5. 安全与权限
 
 - stdio 默认只继承运行所需 allowlist：`PATH`、`HOME`、`USER`、`SHELL`、`LANG`、`LC_*`、`TMPDIR`、`XDG_*` 和 Windows system variables。配置中的显式 `env` 最后覆盖。
-- 所有 MCP tool 都按 mutation 处理：`categoryHint: network_send`。`readOnlyHint` 是不可信的 server advisory，不能用于降低 permission policy；未来若支持 trusted-server policy，必须由 Maka 侧配置明确授权。
-- MCP tools 不设置 `permissionRequired: false`，明确 deny rule 始终优先。
+- 普通配置型 MCP tool 默认为 `categoryHint: network_send`，用于 trace 分类和 Plan-mode exclusion；它本身不是用户审批机制。`readOnlyHint` 是不可信的 server advisory，不能降低这个分类。受信任的 host composition 可以显式选择更严格的 category/recovery policy，但该 authority 来自 Maka composition，而不是 server annotation。
+- Direct/Code Mode 的 managed execution 在 provider dispatch 前由 runtime adapter 检查 `ExecutionBoundary`；network 尚未启用时必须先通过 `requestSandboxBoundary`。协议协商只改变 manager 内部 wire codec，不能绕过这条授权路径。
+- manager 只提供 generation-bound tool snapshot 和远端调用。ToolRuntime 总是在 implementation 前投影 `tool_call` / `tool_start`；只有 host 配置 `runtimeCommitSink` 时，才要求 durable T1 在 provider side effect 前成功，并在结果后写 T2。没有 sink 的路径不得声称拥有 durable operation id 或 T1/T2 recovery authority。
 - main-process store boundary 对 IPC payload 做 runtime validation，不接受 prototype keys、空 command、非 HTTP(S) URL、非法 headers/env。
-- catalog 中的 executable package 必须 pin 到 reviewed version；stdio credential 优先走显式 env，不进入 process args。V1 的显式 env 仍受 owner-only 文件边界保护，不能等同于 encrypted secret storage。
+- catalog 中的 executable package 必须 pin 到 reviewed version；stdio credential 优先走显式 env，不进入 process args。当前显式 env 仍受 owner-only 文件边界保护，不能等同于 encrypted secret storage。
 - tool 名为 `mcp__{serverId}__{toolName}`；仅允许 provider-safe characters，超过 64 chars 时使用 stable hash suffix，并检测 collision。
 - rich output 对 model text、image count/总 base64 大小和 summary block 数量做 aggregate bounds；audio、resource blob 和 unknown payload 不直接注入 model context。
 
 ## 6. Lifecycle 与错误语义
 
-每个 server 只有一个 active connection promise，避免并发重复 spawn。connect 失败必须关闭半连接 client/transport；disconnect 取消 notification handler 并释放 child process/network stream。manager cache tools；list-changed notification 只刷新对应 server。
+每个 server 只有一个 active connection promise，避免并发重复 spawn。manager 在 remote candidate 创建时就持有取消权：即使 SDK 的 `server/discover` probe 尚未消费 caller signal，abort 也会关闭 candidate transport，不允许迟到握手继续产生网络行为。connect 失败必须关闭半连接 client/transport；disconnect 并发启动 subscription、client 和 transport teardown，不能先等待一个可能永不返回的远端 cancellation response。
+
+modern tool-list subscription 只有在 server 声明 capability 且 acknowledgement honor 对应 filter 时才成为 live refresh source。missing、rejected、unhonored 或 non-local close 会进入独立 subscription diagnostic，但不会伪装成 transport disconnect，也不会丢弃上一份可调用 tool snapshot。普通 client/tool 错误不能冒充 subscription 错误；refresh 与 subscription diagnostics 使用独立生命周期槽，成功 refresh 只清除 refresh failure，reconnect 才重建两者。
+
+每个 connection generation 只有一个 `ToolDiscoveryState`。initial discovery、显式 refresh、legacy notification 与 modern subscription signal 都推进同一个 change epoch，并共享同一个 in-flight promise；只有仍拥有当前 client、generation、discovery state 和最新 epoch 的 transaction 才能发布。发布结果仍是唯一的 immutable `ToolSnapshot { revision, tools }`，subscription、status 和 renderer 都不维护第二份 callable registry 或 revision。
 
 install operation 以 server id 串行化。取消时先标记 operation 并 abort active connect，再等待已经开始的 store write 完成；只有随后执行 remove + manager reconcile，才能避免迟到的 upsert 让已取消条目“复活”。renderer 也保留 cancellation marker，防止旧 install promise 覆盖 rollback 后的新 UI state。
 
-timeout 默认值：remote connect 30s、stdio connect 60s、list 15s、call 10min。caller abort 优先于 timeout。协议 `isError` 转为带 server/tool context 的异常；transport/timeout/validation 分别保留可诊断 message，stdio error 附带最多十行经过 redaction/truncation 的 stderr tail。
+timeout 默认值：remote connect 30s、stdio connect 60s、list 15s、call 10min。caller abort 优先于 timeout。协议 `isError` 转为带 server/tool context 的异常；modern `input_required` 不由 manager 自动满足或重试；transport/timeout/validation 分别保留可诊断 message，stdio error 附带最多十行经过 redaction/truncation 的 stderr tail。
 
-配置变更或 `notifications/tools/list_changed` 后 manager 先 reconcile，再使 cached backends 失效；正在执行的 turn 不被强杀，invalidation 会在最后一个 active run 完成时释放旧 backend，确保下个 turn 创建包含新 tool snapshot 的 backend。
+配置变更或任一 era 的 tool-list change 后 manager 先 reconcile，再使 cached backends 失效；正在执行的 turn 不被强杀，invalidation 会在最后一个 active run 完成时释放旧 backend，确保下个 turn 创建包含新 tool snapshot 的 backend。connected status 只展示本次 SDK 实际协商出的 era/revision；connecting、error 和 disconnected 不复用过期协商结果。
 
-## 7. V1 验收标准
+## 7. 当前验收标准
 
 1. stdio fixture 可完成 connect → paginated discovery → call → structured content projection → disconnect。
 2. `isError`、timeout、abort、startup failure 和经过 secret redaction 的 stderr diagnostics 有自动化覆盖。
 3. config store 能拒绝非法输入、并发写不损坏、POSIX mode 为 `0600`。
-4. tool name 在 64 chars 内稳定、无 collision；不可信 annotations 无法降低权限，model output aggregate bounds 有测试。
+4. tool name 在 64 chars 内稳定、无 collision；不可信 annotations 无法降低普通 MCP tool 的 `network_send` 分类或让它进入 Plan mode，model output aggregate bounds 有测试。
 5. Desktop 首页侧边栏仅在「扩展」分组下提供「技能」和「MCP」；MCP 模块可搜索市场模板、JSON import、添加、编辑、启停、测试和删除 server，状态与 tools 可见。
 6. market `+` 在安装中变为 progress indicator，hover/focus 变为可访问的取消操作；取消后 config 不复活、server 不残留、tools 不可见。
 7. 更新配置后新 turn 看见新 tools，删除后 tools 消失。
 8. targeted tests、workspace typecheck/build、full tests 和 Electron smoke 均通过。
+9. remote legacy/auto/exact pin、modern missing-tools、structured JSON、`input_required`、窄 SSE fallback 和无响应 probe cancellation 有真实 HTTP fixture 覆盖。
+10. modern subscription acknowledgement、initial-list race、burst coalescing、独立 diagnostics、non-local close 和无响应 cancellation teardown 有真实 SDK/event-bus fixture 覆盖。
+11. SEP-2243 定义 partition、bounded warning、safe integer 和 wire 前失败有自动化覆盖；legacy 路径不误启用 modern header 语义。
 
-## 8. V2 backlog
+## 8. 后续 backlog
 
+- stdio modern `2026-07-28` negotiation；在实现前 stdio config 不接受 `protocol`。
 - OAuth 2.1 authorization server metadata、PKCE、dynamic client registration 和 Keychain token persistence。
 - resources/templates browse、read、subscribe/unsubscribe 及 host UI。
 - authenticated loopback MCP proxy，供受控 subprocess client 共享 pool。

--- a/docs/architecture/mcp-runtime-architecture-draft.zh-CN.md
+++ b/docs/architecture/mcp-runtime-architecture-draft.zh-CN.md
@@ -116,7 +116,7 @@ timeout 默认值：remote connect 30s、stdio connect 60s、list 15s、call 10m
 5. Desktop 首页侧边栏仅在「扩展」分组下提供「技能」和「MCP」；MCP 模块可搜索市场模板、JSON import、添加、编辑、启停、测试和删除 server，状态与 tools 可见。
 6. market `+` 在安装中变为 progress indicator，hover/focus 变为可访问的取消操作；取消后 config 不复活、server 不残留、tools 不可见。
 7. 更新配置后新 turn 看见新 tools，删除后 tools 消失。
-8. targeted tests、workspace typecheck/build、full tests 和 Electron smoke 均通过。
+8. targeted tests、workspace typecheck/build、full tests 和 Electron smoke 必须通过。
 9. remote legacy/auto/exact pin、modern missing-tools、structured JSON、`input_required`、窄 SSE fallback 和无响应 probe cancellation 有真实 HTTP fixture 覆盖。
 10. modern subscription acknowledgement、initial-list race、burst coalescing、独立 diagnostics、non-local close 和无响应 cancellation teardown 有真实 SDK/event-bus fixture 覆盖。
 11. SEP-2243 定义 partition、bounded warning、safe integer 和 wire 前失败有自动化覆盖；legacy 路径不误启用 modern header 语义。

--- a/packages/core/src/mcp.ts
+++ b/packages/core/src/mcp.ts
@@ -1,6 +1,8 @@
-export const MCP_CONFIG_VERSION = 1 as const;
+export const MCP_CONFIG_VERSION = 2 as const;
 
 export type McpTransportKind = 'stdio' | 'streamable-http' | 'sse' | 'auto';
+
+export type McpProtocolPreference = 'legacy' | 'auto' | '2026-07-28';
 
 export interface McpStdioServerConfig {
   enabled?: boolean;
@@ -15,6 +17,7 @@ export interface McpRemoteServerConfig {
   url: string;
   transport?: 'streamable-http' | 'sse' | 'auto';
   headers?: Record<string, string>;
+  protocol?: McpProtocolPreference;
 }
 
 export type McpServerConfig = McpStdioServerConfig | McpRemoteServerConfig;
@@ -25,6 +28,11 @@ export interface McpConfigFile {
 }
 
 export type McpConnectionState = 'disabled' | 'disconnected' | 'connecting' | 'connected' | 'error';
+
+export interface McpNegotiatedProtocol {
+  era: 'legacy' | 'modern';
+  revision: string;
+}
 
 export interface McpToolAnnotations {
   title?: string;
@@ -67,6 +75,7 @@ export interface McpServerStatus {
   serverId: string;
   state: McpConnectionState;
   transport?: Exclude<McpTransportKind, 'auto'>;
+  negotiatedProtocol?: McpNegotiatedProtocol;
   toolCount: number;
   tools: McpToolDescriptor[];
   error?: string;
@@ -95,6 +104,12 @@ export interface McpTestResult {
 
 export function isMcpStdioConfig(config: McpServerConfig): config is McpStdioServerConfig {
   return 'command' in config;
+}
+
+export function resolveMcpRemoteProtocolPreference(
+  config: McpRemoteServerConfig,
+): McpProtocolPreference {
+  return config.protocol ?? 'legacy';
 }
 
 export function createDefaultMcpConfig(): McpConfigFile {

--- a/packages/mcp/src/__tests__/manager-fallback.test.ts
+++ b/packages/mcp/src/__tests__/manager-fallback.test.ts
@@ -92,18 +92,26 @@ describe('McpClientManager Streamable HTTP fallback contract', () => {
     assert.equal(fixture.sseGets, 0);
   });
 
-  test('does not fall back after the caller aborts the Streamable HTTP attempt', async () => {
-    const fixture = await createFallbackFixture({ streamable: { kind: 'hang' } });
-    const manager = createManager();
+  test('aborts a hanging auto or pinned probe without waiting for the server', async () => {
+    for (const protocol of ['auto', '2026-07-28'] as const) {
+      const fixture = await createFallbackFixture({ streamable: { kind: 'hang' } });
+      const manager = createManager();
 
-    const sync = manager.sync(remoteConfig(fixture.url, 'auto'));
-    await waitFor(() => fixture.streamablePosts === 1);
-    assert.equal(manager.cancelConnect('remote'), true);
-    fixture.releaseStreamable();
-    await sync;
+      const sync = manager.sync(remoteConfig(fixture.url, protocol));
+      await waitFor(() => fixture.streamablePosts === 1);
+      assert.equal(manager.cancelConnect('remote'), true);
+      try {
+        await settlesWithin(sync);
+      } finally {
+        fixture.releaseStreamable();
+      }
 
-    assert.equal(manager.status('remote')?.state, 'disconnected');
-    assert.equal(fixture.sseGets, 0);
+      assert.equal(manager.status('remote')?.state, 'disconnected');
+      assert.equal(fixture.sseGets, 0);
+
+      await manager.close();
+      await fixture.close();
+    }
   });
 
   test('does not fall back after the Streamable HTTP probe times out', async () => {
@@ -438,5 +446,22 @@ async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<voi
   while (!predicate()) {
     if (Date.now() >= deadline) throw new Error('condition was not reached');
     await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+async function settlesWithin<T>(promise: Promise<T>, timeoutMs = 500): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('operation did not settle after abort')),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }

--- a/packages/mcp/src/__tests__/manager-fallback.test.ts
+++ b/packages/mcp/src/__tests__/manager-fallback.test.ts
@@ -40,6 +40,17 @@ describe('McpClientManager Streamable HTTP fallback contract', () => {
       assert.ok(fixture.sseMethods.includes('initialize'));
       assert.ok(fixture.sseMethods.includes('tools/list'));
       assert.deepEqual(
+        manager.status('remote')?.tools.find((tool) => tool.name === 'echo')?.inputSchema,
+        {
+          type: 'object',
+          properties: {
+            value: { type: 'string' },
+            ratio: { type: 'number', 'x-mcp-header': 'Ratio' },
+          },
+        },
+        'legacy discovery must not apply modern x-mcp-header exclusion',
+      );
+      assert.deepEqual(
         await manager.callTool(bindingFor(manager, 'echo'), { value: `fallback-${status}` }),
         {
           content: [{ type: 'text', text: `fallback-${status}` }],
@@ -255,8 +266,9 @@ function remoteConfig(
 function bindingFor(manager: McpClientManager, toolName: string): McpToolBinding {
   const match = manager
     .toolSnapshot()
-    .tools
-    .find(({ descriptor }) => descriptor.serverId === 'remote' && descriptor.name === toolName);
+    .tools.find(
+      ({ descriptor }) => descriptor.serverId === 'remote' && descriptor.name === toolName,
+    );
   assert.ok(match, `missing bound MCP tool remote/${toolName}`);
   return match.binding;
 }
@@ -425,7 +437,10 @@ function createLegacyServer(): McpServer {
         description: 'Echo text',
         inputSchema: {
           type: 'object',
-          properties: { value: { type: 'string' } },
+          properties: {
+            value: { type: 'string' },
+            ratio: { type: 'number', 'x-mcp-header': 'Ratio' },
+          },
         },
       },
     ],

--- a/packages/mcp/src/__tests__/manager-fallback.test.ts
+++ b/packages/mcp/src/__tests__/manager-fallback.test.ts
@@ -1,0 +1,442 @@
+import assert from 'node:assert/strict';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
+import { afterEach, describe, test } from 'node:test';
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { Server as McpServer } from '@modelcontextprotocol/server';
+import { SSEServerTransport } from '@modelcontextprotocol/server-legacy/sse';
+import {
+  MCP_CONFIG_VERSION,
+  type McpConfigFile,
+  type McpProtocolPreference,
+  type McpToolBinding,
+} from '@maka/core/mcp';
+import { McpClientManager } from '../index.js';
+
+const managers: McpClientManager[] = [];
+const fixtures: FallbackFixture[] = [];
+
+afterEach(async () => {
+  await Promise.all(managers.splice(0).map((manager) => manager.close()));
+  await Promise.all(fixtures.splice(0).map((fixture) => fixture.close()));
+});
+
+describe('McpClientManager Streamable HTTP fallback contract', () => {
+  test('falls back from a pre-handshake 404 or 405 to a real legacy SSE server', async () => {
+    for (const status of [404, 405] as const) {
+      const fixture = await createFallbackFixture({ streamable: { kind: 'status', status } });
+      const manager = createManager();
+
+      await manager.sync(remoteConfig(fixture.url, 'auto'));
+
+      assert.equal(manager.status('remote')?.state, 'connected');
+      assert.equal(manager.status('remote')?.transport, 'sse');
+      assert.deepEqual(manager.status('remote')?.negotiatedProtocol, {
+        era: 'legacy',
+        revision: '2025-11-25',
+      });
+      assert.equal(fixture.sseGets, 1);
+      assert.deepEqual(fixture.streamableMethods, ['server/discover', 'initialize']);
+      assert.ok(fixture.sseMethods.includes('initialize'));
+      assert.ok(fixture.sseMethods.includes('tools/list'));
+      assert.deepEqual(
+        await manager.callTool(bindingFor(manager, 'echo'), { value: `fallback-${status}` }),
+        {
+          content: [{ type: 'text', text: `fallback-${status}` }],
+          structuredContent: undefined,
+        },
+      );
+
+      await manager.close();
+      await fixture.close();
+    }
+  });
+
+  test('does not fall back for non-404/405 HTTP responses', async () => {
+    const statuses = [400, 401, 403, 408, 409, 415, 429, 500] as const;
+    for (const status of statuses) {
+      const fixture = await createFallbackFixture({ streamable: { kind: 'status', status } });
+      const manager = createManager();
+
+      await manager.sync(remoteConfig(fixture.url, 'auto'));
+
+      assert.equal(manager.status('remote')?.state, 'error', `HTTP ${status}`);
+      assert.equal(fixture.streamableMethods[0], 'server/discover', `HTTP ${status}`);
+      assert.ok(fixture.streamablePosts >= 1, `HTTP ${status}`);
+      assert.equal(fixture.sseGets, 0, `HTTP ${status}`);
+
+      await manager.close();
+      await fixture.close();
+    }
+  });
+
+  test('does not fall back from an unexpected successful response body', async () => {
+    const fixture = await createFallbackFixture({ streamable: { kind: 'unexpected-success' } });
+    const manager = createManager();
+
+    await manager.sync(remoteConfig(fixture.url, 'auto'));
+
+    assert.equal(manager.status('remote')?.state, 'error');
+    assert.equal(fixture.streamablePosts, 1);
+    assert.equal(fixture.sseGets, 0);
+  });
+
+  test('does not fall back from a network failure', async () => {
+    const fixture = await createFallbackFixture({ streamable: { kind: 'network-error' } });
+    const manager = createManager();
+
+    await manager.sync(remoteConfig(fixture.url, 'auto'));
+
+    assert.equal(manager.status('remote')?.state, 'error');
+    assert.equal(fixture.streamablePosts, 1);
+    assert.equal(fixture.sseGets, 0);
+  });
+
+  test('does not fall back after the caller aborts the Streamable HTTP attempt', async () => {
+    const fixture = await createFallbackFixture({ streamable: { kind: 'hang' } });
+    const manager = createManager();
+
+    const sync = manager.sync(remoteConfig(fixture.url, 'auto'));
+    await waitFor(() => fixture.streamablePosts === 1);
+    assert.equal(manager.cancelConnect('remote'), true);
+    fixture.releaseStreamable();
+    await sync;
+
+    assert.equal(manager.status('remote')?.state, 'disconnected');
+    assert.equal(fixture.sseGets, 0);
+  });
+
+  test('does not fall back after the Streamable HTTP probe times out', async () => {
+    const fixture = await createFallbackFixture({ streamable: { kind: 'hang' } });
+    const manager = createManager(50);
+
+    await manager.sync(remoteConfig(fixture.url, 'auto'));
+    fixture.releaseStreamable();
+
+    assert.equal(manager.status('remote')?.state, 'error');
+    assert.equal(fixture.streamablePosts, 1);
+    assert.equal(fixture.sseGets, 0);
+  });
+
+  test('does not fall back after legacy initialize succeeded but initialized returned 404 or 405', async () => {
+    for (const status of [404, 405] as const) {
+      const fixture = await createFallbackFixture({
+        streamable: { kind: 'initialized-status', status },
+      });
+      const manager = createManager();
+
+      await manager.sync(remoteConfig(fixture.url, 'auto'));
+
+      assert.equal(manager.status('remote')?.state, 'error', `HTTP ${status}`);
+      assert.deepEqual(
+        fixture.streamableMethods.slice(0, 3),
+        ['server/discover', 'initialize', 'notifications/initialized'],
+        `HTTP ${status}`,
+      );
+      assert.equal(fixture.sseGets, 0, `HTTP ${status}`);
+
+      await manager.close();
+      await fixture.close();
+    }
+  });
+
+  test('an exact modern pin never attempts legacy SSE', async () => {
+    const fixture = await createFallbackFixture({ streamable: { kind: 'status', status: 404 } });
+    const manager = createManager();
+
+    await manager.sync(remoteConfig(fixture.url, '2026-07-28'));
+
+    assert.equal(manager.status('remote')?.state, 'error');
+    assert.equal(fixture.streamablePosts, 1);
+    assert.equal(fixture.sseGets, 0);
+  });
+
+  test('an explicit Streamable HTTP transport never attempts legacy SSE', async () => {
+    const fixture = await createFallbackFixture({ streamable: { kind: 'status', status: 404 } });
+    const manager = createManager();
+
+    await manager.sync(remoteConfig(fixture.url, 'legacy', 'streamable-http'));
+
+    assert.equal(manager.status('remote')?.state, 'error');
+    assert.equal(fixture.streamablePosts, 1);
+    assert.equal(fixture.sseGets, 0);
+  });
+
+  test('preserves both failures behind one stable public error when SSE also fails', async () => {
+    for (const status of [404, 405] as const) {
+      const fixture = await createFallbackFixture({
+        streamable: { kind: 'status', status },
+        sse: 'fail',
+      });
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url, 'auto'));
+      const postsBefore = fixture.streamablePosts;
+      const getsBefore = fixture.sseGets;
+
+      let rejection: unknown;
+      try {
+        await manager.connect('remote');
+      } catch (error) {
+        rejection = error;
+      }
+
+      assert.ok(rejection instanceof Error);
+      assert.equal(
+        rejection.message,
+        'MCP server "remote" connection failed: Streamable HTTP and legacy SSE connection attempts failed',
+      );
+      assert.ok(rejection.cause instanceof AggregateError);
+      assert.equal(rejection.cause.errors.length, 2);
+      assert.ok(rejection.cause.errors.every((error) => error instanceof Error));
+      assert.equal(fixture.streamablePosts, postsBefore + 2);
+      assert.equal(fixture.sseGets, getsBefore + 1);
+
+      await manager.close();
+      await fixture.close();
+    }
+  });
+});
+
+function createManager(remoteConnectMs = 5_000): McpClientManager {
+  const manager = new McpClientManager({
+    timeouts: { remoteConnectMs, listToolsMs: 5_000, callToolMs: 5_000 },
+  });
+  managers.push(manager);
+  return manager;
+}
+
+function remoteConfig(
+  url: string,
+  protocol: McpProtocolPreference,
+  transport: 'auto' | 'streamable-http' = 'auto',
+): McpConfigFile {
+  return {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: {
+      remote: {
+        url,
+        transport,
+        protocol,
+      },
+    },
+  };
+}
+
+function bindingFor(manager: McpClientManager, toolName: string): McpToolBinding {
+  const match = manager
+    .toolSnapshot()
+    .tools
+    .find(({ descriptor }) => descriptor.serverId === 'remote' && descriptor.name === toolName);
+  assert.ok(match, `missing bound MCP tool remote/${toolName}`);
+  return match.binding;
+}
+
+type StreamableBehavior =
+  | { kind: 'status'; status: number }
+  | { kind: 'unexpected-success' }
+  | { kind: 'network-error' }
+  | { kind: 'hang' }
+  | { kind: 'initialized-status'; status: 404 | 405 };
+
+interface FallbackFixture {
+  url: string;
+  streamablePosts: number;
+  sseGets: number;
+  streamableMethods: string[];
+  sseMethods: string[];
+  releaseStreamable(): void;
+  close(): Promise<void>;
+}
+
+async function createFallbackFixture(options: {
+  streamable: StreamableBehavior;
+  sse?: 'valid' | 'fail';
+}): Promise<FallbackFixture> {
+  let streamablePosts = 0;
+  let sseGets = 0;
+  const streamableMethods: string[] = [];
+  const sseMethods: string[] = [];
+  let releaseStreamable = () => {};
+  const streamableRelease = new Promise<void>((resolve) => {
+    releaseStreamable = resolve;
+  });
+  const sockets = new Set<Socket>();
+  const sseTransports = new Map<string, { transport: SSEServerTransport; server: McpServer }>();
+  const httpServer = createServer(async (req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    try {
+      if (url.pathname === '/mcp' && req.method === 'POST') {
+        streamablePosts += 1;
+        const body = await readJsonBody(req);
+        const methods = readProtocolMethods(body);
+        streamableMethods.push(...methods);
+        const behavior = options.streamable;
+        if (behavior.kind === 'network-error') {
+          req.socket.destroy();
+          return;
+        }
+        if (behavior.kind === 'hang') {
+          await streamableRelease;
+          writeHttpFailure(res, 404);
+          return;
+        }
+        if (behavior.kind === 'unexpected-success') {
+          res
+            .writeHead(200, { 'content-type': 'text/html; charset=utf-8' })
+            .end('<!doctype html><title>not MCP</title>');
+          return;
+        }
+        if (behavior.kind === 'status') {
+          writeHttpFailure(res, behavior.status);
+          return;
+        }
+        if (methods.includes('notifications/initialized')) {
+          writeHttpFailure(res, behavior.status);
+          return;
+        }
+        await handleLegacyStreamableRequest(req, res, body);
+        return;
+      }
+      if (url.pathname === '/mcp' && req.method === 'GET') {
+        sseGets += 1;
+        if (options.sse === 'fail') {
+          res.writeHead(503, { 'content-type': 'text/plain; charset=utf-8' }).end('unavailable');
+          return;
+        }
+        const transport = new SSEServerTransport('/messages', res);
+        const server = createLegacyServer();
+        sseTransports.set(transport.sessionId, { transport, server });
+        res.once('close', () => sseTransports.delete(transport.sessionId));
+        await server.connect(transport);
+        return;
+      }
+      if (url.pathname === '/messages' && req.method === 'POST') {
+        const body = await readJsonBody(req);
+        sseMethods.push(...readProtocolMethods(body));
+        const entry = sseTransports.get(url.searchParams.get('sessionId') ?? '');
+        if (!entry) {
+          res.writeHead(400).end('unknown SSE session');
+          return;
+        }
+        await entry.transport.handlePostMessage(req, res, body);
+        return;
+      }
+      res.writeHead(404).end('not found');
+    } catch (error) {
+      if (!res.headersSent) res.writeHead(500);
+      res.end(error instanceof Error ? error.message : String(error));
+    }
+  });
+  httpServer.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(0, '127.0.0.1', resolve);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === 'string') throw new Error('fallback fixture did not bind TCP');
+  let closed = false;
+  const fixture: FallbackFixture = {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    get streamablePosts() {
+      return streamablePosts;
+    },
+    get sseGets() {
+      return sseGets;
+    },
+    streamableMethods,
+    sseMethods,
+    releaseStreamable,
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      await Promise.all(
+        [...sseTransports.values()].map(async ({ transport, server }) => {
+          await transport.close().catch(() => {});
+          await server.close().catch(() => {});
+        }),
+      );
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve, reject) =>
+        httpServer.close((error) => (error ? reject(error) : resolve())),
+      );
+    },
+  };
+  fixtures.push(fixture);
+  return fixture;
+}
+
+async function handleLegacyStreamableRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  body: unknown,
+): Promise<void> {
+  const transport = new NodeStreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  const server = createLegacyServer();
+  await server.connect(transport);
+  res.once('close', () => {
+    void transport.close();
+    void server.close();
+  });
+  await transport.handleRequest(req, res, body);
+}
+
+function createLegacyServer(): McpServer {
+  const server = new McpServer(
+    { name: 'maka-fallback-fixture', version: '1.0.0' },
+    { capabilities: { tools: {} } },
+  );
+  server.setRequestHandler('tools/list', async () => ({
+    tools: [
+      {
+        name: 'echo',
+        description: 'Echo text',
+        inputSchema: {
+          type: 'object',
+          properties: { value: { type: 'string' } },
+        },
+      },
+    ],
+  }));
+  server.setRequestHandler('tools/call', async ({ params }) => ({
+    content: [{ type: 'text', text: String(params.arguments?.value ?? '') }],
+  }));
+  return server;
+}
+
+function writeHttpFailure(res: ServerResponse, status: number): void {
+  res
+    .writeHead(status, { 'content-type': 'application/json; charset=utf-8' })
+    .end(JSON.stringify({ error: `HTTP ${status}` }));
+}
+
+function readProtocolMethods(body: unknown): string[] {
+  return (Array.isArray(body) ? body : [body]).flatMap((message) => {
+    if (
+      typeof message === 'object' &&
+      message !== null &&
+      'method' in message &&
+      typeof message.method === 'string'
+    ) {
+      return [message.method];
+    }
+    return [];
+  });
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  const text = Buffer.concat(chunks).toString('utf8');
+  return text ? JSON.parse(text) : undefined;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('condition was not reached');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}

--- a/packages/mcp/src/__tests__/manager-fallback.test.ts
+++ b/packages/mcp/src/__tests__/manager-fallback.test.ts
@@ -114,6 +114,28 @@ describe('McpClientManager Streamable HTTP fallback contract', () => {
     }
   });
 
+  test('does not start a remote probe after a connecting listener cancels synchronously', async () => {
+    const fixture = await createFallbackFixture({ streamable: { kind: 'hang' } });
+    const manager = createManager();
+    let cancelResult: boolean | undefined;
+    manager.onChange((status) => {
+      if (status.serverId === 'remote' && status.state === 'connecting') {
+        cancelResult = manager.cancelConnect('remote');
+      }
+    });
+
+    try {
+      await settlesWithin(manager.sync(remoteConfig(fixture.url, 'auto')));
+    } finally {
+      fixture.releaseStreamable();
+    }
+
+    assert.equal(cancelResult, true);
+    assert.equal(fixture.streamablePosts, 0);
+    assert.equal(fixture.sseGets, 0);
+    assert.equal(manager.status('remote')?.state, 'disconnected');
+  });
+
   test('does not fall back after the Streamable HTTP probe times out', async () => {
     const fixture = await createFallbackFixture({ streamable: { kind: 'hang' } });
     const manager = createManager(50);

--- a/packages/mcp/src/__tests__/manager-subscription.test.ts
+++ b/packages/mcp/src/__tests__/manager-subscription.test.ts
@@ -158,10 +158,20 @@ describe('McpClientManager modern tool-list subscriptions', () => {
     await manager.sync(modernConfig(fixture.url));
     const original = manager.toolSnapshot().tools[0];
     assert.ok(original);
+    const snapshotBeforeFailure = manager.toolSnapshot();
+    let refreshDiagnosticUpdates = 0;
+    const unsubscribe = manager.onChange((status) => {
+      if (/tool refresh failed/u.test(status.error ?? '')) refreshDiagnosticUpdates += 1;
+    });
 
     fixture.failToolLists(true);
     fixture.notifyToolsChanged();
     await waitFor(() => /tool refresh failed/u.test(manager.status('remote')?.error ?? ''));
+    await settleEventLoop();
+
+    assert.equal(refreshDiagnosticUpdates, 1);
+    assert.strictEqual(manager.toolSnapshot(), snapshotBeforeFailure);
+    unsubscribe();
 
     fixture.failToolLists(false);
     await fixture.rotateHandler();

--- a/packages/mcp/src/__tests__/manager-subscription.test.ts
+++ b/packages/mcp/src/__tests__/manager-subscription.test.ts
@@ -1,0 +1,402 @@
+import assert from 'node:assert/strict';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { afterEach, describe, test } from 'node:test';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { createMcpHandler, InMemoryServerEventBus, Server } from '@modelcontextprotocol/server';
+import { MCP_CONFIG_VERSION, type McpConfigFile, type McpServerStatus } from '@maka/core/mcp';
+import { McpClientManager } from '../index.js';
+
+const managers: McpClientManager[] = [];
+const fixtures: SubscriptionFixture[] = [];
+
+afterEach(async () => {
+  await Promise.all(managers.splice(0).map((manager) => manager.close()));
+  await Promise.all(fixtures.splice(0).map((fixture) => fixture.close()));
+});
+
+describe('McpClientManager modern tool-list subscriptions', () => {
+  test('coalesces an honored notification burst into one bounded trailing refresh', async () => {
+    const fixture = await createSubscriptionFixture();
+    const manager = createManager();
+    const connectedSnapshots: string[][] = [];
+    manager.onChange((status) => {
+      if (status.state === 'connected') connectedSnapshots.push(toolNames(status));
+    });
+    await manager.sync(modernConfig(fixture.url));
+
+    fixture.setTools(['middle']);
+    const gate = fixture.blockNextToolList();
+    fixture.notifyToolsChanged();
+    await gate.entered;
+
+    fixture.setTools(['final']);
+    for (let index = 0; index < 20; index += 1) fixture.notifyToolsChanged();
+    await settleEventLoop();
+    gate.release();
+
+    await waitFor(
+      () => fixture.toolListCalls === 3 && toolNames(manager.status('remote'))[0] === 'final',
+    );
+
+    assert.equal(fixture.toolListCalls, 3);
+    assert.deepEqual(connectedSnapshots, [['initial'], ['final']]);
+    assert.equal(manager.status('remote')?.error, undefined);
+  });
+
+  test('coalesces a change received during initial discovery before publishing connected state', async () => {
+    const fixture = await createSubscriptionFixture();
+    const initialList = fixture.blockNextToolList();
+    const manager = createManager();
+    const connectedSnapshots: string[][] = [];
+    manager.onChange((status) => {
+      if (status.state === 'connected') connectedSnapshots.push(toolNames(status));
+    });
+
+    const syncing = manager.sync(modernConfig(fixture.url));
+    await initialList.entered;
+    await waitFor(() => fixture.subscriptionListeners === 1);
+    fixture.setTools(['changed-during-connect']);
+    fixture.notifyToolsChanged();
+    await settleEventLoop();
+    initialList.release();
+    await syncing;
+
+    assert.equal(fixture.toolListCalls, 2);
+    assert.deepEqual(connectedSnapshots, [['changed-during-connect']]);
+    assert.deepEqual(toolNames(manager.status('remote')), ['changed-during-connect']);
+  });
+
+  for (const mode of ['missing', 'unhonored', 'rejected'] as const) {
+    test(`keeps the connection usable when the subscription acknowledgement is ${mode}`, async () => {
+      const fixture = await createSubscriptionFixture({ subscriptionMode: mode });
+      const manager = createManager(mode === 'missing' ? 150 : 2_000);
+
+      await manager.sync(modernConfig(fixture.url));
+
+      const status = manager.status('remote');
+      assert.equal(status?.state, 'connected');
+      assert.deepEqual(status?.negotiatedProtocol, {
+        era: 'modern',
+        revision: '2026-07-28',
+      });
+      assert.deepEqual(toolNames(status), ['initial']);
+      assert.deepEqual(
+        manager.toolSnapshot().tools.map(({ descriptor }) => descriptor.name),
+        ['initial'],
+      );
+      assert.match(status?.error ?? '', /tool-list subscription/u);
+      if (mode === 'unhonored') {
+        assert.match(status?.error ?? '', /did not honor/u);
+      } else {
+        assert.match(status?.error ?? '', /unavailable/u);
+      }
+    });
+  }
+
+  test('keeps subscription and refresh diagnostics in separate lifecycle slots', async () => {
+    const fixture = await createSubscriptionFixture();
+    const manager = createManager();
+    await manager.sync(modernConfig(fixture.url));
+    const original = manager.toolSnapshot().tools[0];
+    assert.ok(original);
+
+    fixture.failToolLists(true);
+    fixture.notifyToolsChanged();
+    await waitFor(() => /tool refresh failed/u.test(manager.status('remote')?.error ?? ''));
+
+    fixture.failToolLists(false);
+    await fixture.rotateHandler();
+    await waitFor(() =>
+      /tool-list subscription closed (?:graceful|remote)/u.test(
+        manager.status('remote')?.error ?? '',
+      ),
+    );
+
+    const degraded = manager.status('remote');
+    assert.equal(degraded?.state, 'connected');
+    assert.deepEqual(degraded?.negotiatedProtocol, {
+      era: 'modern',
+      revision: '2026-07-28',
+    });
+    assert.deepEqual(toolNames(degraded), ['initial']);
+    assert.equal(manager.toolSnapshot().tools[0]?.binding, original.binding);
+    assert.match(degraded?.error ?? '', /tool refresh failed/u);
+    assert.match(degraded?.error ?? '', /tool-list subscription closed/u);
+
+    fixture.setTools(['after-recovery']);
+    await manager.refreshTools('remote');
+
+    const refreshed = manager.status('remote');
+    assert.deepEqual(toolNames(refreshed), ['after-recovery']);
+    assert.doesNotMatch(refreshed?.error ?? '', /tool refresh failed/u);
+    assert.match(refreshed?.error ?? '', /tool-list subscription closed/u);
+
+    await manager.reconnect('remote');
+
+    const reconnected = manager.status('remote');
+    assert.equal(reconnected?.state, 'connected');
+    assert.deepEqual(toolNames(reconnected), ['after-recovery']);
+    assert.deepEqual(reconnected?.negotiatedProtocol, {
+      era: 'modern',
+      revision: '2026-07-28',
+    });
+    assert.equal(reconnected?.error, undefined);
+  });
+});
+
+function createManager(remoteConnectMs = 2_000): McpClientManager {
+  const manager = new McpClientManager({
+    timeouts: { remoteConnectMs, listToolsMs: 2_000, callToolMs: 2_000 },
+  });
+  managers.push(manager);
+  return manager;
+}
+
+function modernConfig(url: string): McpConfigFile {
+  return {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: {
+      remote: {
+        url,
+        transport: 'streamable-http',
+        protocol: 'auto',
+      },
+    },
+  };
+}
+
+function toolNames(status: McpServerStatus | undefined): string[] {
+  return status?.tools.map((tool) => tool.name) ?? [];
+}
+
+type SubscriptionMode = 'honored' | 'missing' | 'unhonored' | 'rejected';
+
+interface ToolListGate {
+  entered: Promise<void>;
+  release(): void;
+}
+
+interface SubscriptionFixture {
+  readonly url: string;
+  readonly toolListCalls: number;
+  readonly subscriptionListeners: number;
+  setTools(names: string[]): void;
+  failToolLists(value: boolean): void;
+  blockNextToolList(): ToolListGate;
+  notifyToolsChanged(): void;
+  rotateHandler(): Promise<void>;
+  close(): Promise<void>;
+}
+
+async function createSubscriptionFixture(
+  options: { subscriptionMode?: SubscriptionMode } = {},
+): Promise<SubscriptionFixture> {
+  const subscriptionMode = options.subscriptionMode ?? 'honored';
+  let tools = ['initial'];
+  let shouldFailToolLists = false;
+  let toolListCalls = 0;
+  let nextToolListGate: InternalGate | undefined;
+  const toolListGates = new Set<InternalGate>();
+  const rawSubscriptions = new Set<ServerResponse>();
+  const handlers = new Set<ReturnType<typeof createMcpHandler>>();
+
+  const createHandlerGeneration = () => {
+    const bus = new InMemoryServerEventBus();
+    const handler = createMcpHandler(
+      () => {
+        const server = new Server(
+          { name: 'maka-subscription-fixture', version: '1.0.0' },
+          { capabilities: { tools: { listChanged: true } } },
+        );
+        server.setRequestHandler('tools/list', async () => {
+          toolListCalls += 1;
+          const result = tools.map((name) => ({
+            name,
+            inputSchema: { type: 'object' as const },
+          }));
+          const gate = nextToolListGate;
+          nextToolListGate = undefined;
+          if (gate) {
+            gate.markEntered();
+            try {
+              await gate.wait;
+            } finally {
+              toolListGates.delete(gate);
+            }
+          }
+          if (shouldFailToolLists) throw new Error('fixture tool list failed');
+          return { tools: result };
+        });
+        return server;
+      },
+      {
+        legacy: 'reject',
+        keepAliveMs: 0,
+        bus,
+        ...(subscriptionMode === 'rejected' ? { maxSubscriptions: 0 } : {}),
+      },
+    );
+    handlers.add(handler);
+    return { bus, handler, nodeHandler: toNodeHandler(handler) };
+  };
+
+  let current = createHandlerGeneration();
+  const httpServer = createServer(async (req, res) => {
+    try {
+      if (new URL(req.url ?? '/', 'http://127.0.0.1').pathname !== '/mcp') {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      const body = await readJsonBody(req);
+      if (
+        (subscriptionMode === 'missing' || subscriptionMode === 'unhonored') &&
+        requestMethod(body) === 'subscriptions/listen'
+      ) {
+        serveRawSubscription(res, body, subscriptionMode, rawSubscriptions);
+        return;
+      }
+      await current.nodeHandler(req, res, body);
+    } catch (error) {
+      if (!res.headersSent) res.writeHead(500);
+      res.end(error instanceof Error ? error.message : String(error));
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(0, '127.0.0.1', resolve);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === 'string') throw new Error('subscription fixture did not bind');
+
+  const fixture: SubscriptionFixture = {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    get toolListCalls() {
+      return toolListCalls;
+    },
+    get subscriptionListeners() {
+      return current.bus.listenerCount;
+    },
+    setTools(names) {
+      tools = [...names];
+    },
+    failToolLists(value) {
+      shouldFailToolLists = value;
+    },
+    blockNextToolList() {
+      if (nextToolListGate) throw new Error('a tool-list gate is already pending');
+      const gate = createGate();
+      toolListGates.add(gate);
+      nextToolListGate = gate;
+      return { entered: gate.entered, release: gate.release };
+    },
+    notifyToolsChanged() {
+      current.handler.notify.toolsChanged();
+    },
+    async rotateHandler() {
+      const previous = current;
+      current = createHandlerGeneration();
+      await previous.handler.close();
+    },
+    async close() {
+      for (const gate of toolListGates) gate.release();
+      toolListGates.clear();
+      for (const response of rawSubscriptions) response.end();
+      rawSubscriptions.clear();
+      await Promise.all([...handlers].map((handler) => handler.close()));
+      const closed = new Promise<void>((resolve, reject) =>
+        httpServer.close((error) => (error ? reject(error) : resolve())),
+      );
+      httpServer.closeAllConnections();
+      await closed;
+    },
+  };
+  fixtures.push(fixture);
+  return fixture;
+}
+
+interface InternalGate {
+  entered: Promise<void>;
+  wait: Promise<void>;
+  markEntered(): void;
+  release(): void;
+}
+
+function createGate(): InternalGate {
+  let markEntered = () => {};
+  let release = () => {};
+  const entered = new Promise<void>((resolve) => {
+    markEntered = resolve;
+  });
+  const wait = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { entered, wait, markEntered, release };
+}
+
+function serveRawSubscription(
+  response: ServerResponse,
+  body: unknown,
+  mode: 'missing' | 'unhonored',
+  open: Set<ServerResponse>,
+): void {
+  response.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache, no-transform',
+    connection: 'keep-alive',
+  });
+  open.add(response);
+  response.once('close', () => open.delete(response));
+  if (mode === 'missing') {
+    response.write(': acknowledgement intentionally withheld\n\n');
+    return;
+  }
+  const id = requestId(body);
+  response.write(
+    `event: message\ndata: ${JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'notifications/subscriptions/acknowledged',
+      params: {
+        notifications: {},
+        _meta: { 'io.modelcontextprotocol/subscriptionId': id },
+      },
+    })}\n\n`,
+  );
+}
+
+function requestMethod(body: unknown): string | undefined {
+  if (typeof body !== 'object' || body === null || !('method' in body)) return undefined;
+  return typeof body.method === 'string' ? body.method : undefined;
+}
+
+function requestId(body: unknown): string | number {
+  if (typeof body !== 'object' || body === null || !('id' in body)) {
+    throw new Error('subscription request did not include an id');
+  }
+  if (typeof body.id !== 'string' && typeof body.id !== 'number') {
+    throw new Error('subscription request had an invalid id');
+  }
+  return body.id;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  const text = Buffer.concat(chunks).toString('utf8');
+  return text ? JSON.parse(text) : undefined;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.ok(predicate(), 'condition was not met before timeout');
+}
+
+async function settleEventLoop(): Promise<void> {
+  for (let index = 0; index < 4; index += 1) {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+  await new Promise((resolve) => setTimeout(resolve, 150));
+}

--- a/packages/mcp/src/__tests__/manager-subscription.test.ts
+++ b/packages/mcp/src/__tests__/manager-subscription.test.ts
@@ -93,6 +93,65 @@ describe('McpClientManager modern tool-list subscriptions', () => {
     });
   }
 
+  test('does not wait for an unhonored subscription cancellation response during setup', async () => {
+    const fixture = await createSubscriptionFixture({
+      subscriptionMode: 'unhonored',
+      hangCancellation: true,
+    });
+    const manager = createManager();
+
+    try {
+      await settlesWithin(manager.sync(modernConfig(fixture.url)));
+    } finally {
+      fixture.releaseCancellation();
+    }
+
+    assert.equal(manager.status('remote')?.state, 'connected');
+    assert.match(manager.status('remote')?.error ?? '', /did not honor/u);
+  });
+
+  for (const operation of ['disconnect', 'close'] as const) {
+    test(`${operation} aborts an unanswered subscription cancellation request`, async () => {
+      const fixture = await createSubscriptionFixture({ hangCancellation: true });
+      const manager = createManager();
+      await manager.sync(modernConfig(fixture.url));
+
+      try {
+        await settlesWithin(
+          operation === 'disconnect' ? manager.disconnect('remote') : manager.close(),
+        );
+      } finally {
+        fixture.releaseCancellation();
+      }
+
+      if (operation === 'disconnect') {
+        assert.equal(manager.status('remote')?.state, 'disconnected');
+      }
+    });
+  }
+
+  test('does not attribute a normal tool transport failure to the subscription', async () => {
+    const fixture = await createSubscriptionFixture();
+    const manager = createManager();
+    await manager.sync(modernConfig(fixture.url));
+    const tool = manager.toolSnapshot().tools[0];
+    assert.ok(tool);
+
+    fixture.failToolCalls(true);
+    await assert.rejects(manager.callTool(tool.binding, {}));
+
+    assert.equal(manager.status('remote')?.state, 'connected');
+    assert.equal(manager.status('remote')?.error, undefined);
+    assert.equal(fixture.subscriptionListeners, 1);
+
+    fixture.failToolCalls(false);
+    assert.deepEqual(await manager.callTool(tool.binding, {}), {
+      content: [{ type: 'text', text: 'ok' }],
+      structuredContent: undefined,
+    });
+    assert.equal(manager.status('remote')?.error, undefined);
+  });
+
   test('keeps subscription and refresh diagnostics in separate lifecycle slots', async () => {
     const fixture = await createSubscriptionFixture();
     const manager = createManager();
@@ -182,23 +241,30 @@ interface SubscriptionFixture {
   readonly subscriptionListeners: number;
   setTools(names: string[]): void;
   failToolLists(value: boolean): void;
+  failToolCalls(value: boolean): void;
   blockNextToolList(): ToolListGate;
   notifyToolsChanged(): void;
   rotateHandler(): Promise<void>;
+  releaseCancellation(): void;
   close(): Promise<void>;
 }
 
 async function createSubscriptionFixture(
-  options: { subscriptionMode?: SubscriptionMode } = {},
+  options: { subscriptionMode?: SubscriptionMode; hangCancellation?: boolean } = {},
 ): Promise<SubscriptionFixture> {
   const subscriptionMode = options.subscriptionMode ?? 'honored';
   let tools = ['initial'];
   let shouldFailToolLists = false;
+  let shouldFailToolCalls = false;
   let toolListCalls = 0;
   let nextToolListGate: InternalGate | undefined;
   const toolListGates = new Set<InternalGate>();
   const rawSubscriptions = new Set<ServerResponse>();
   const handlers = new Set<ReturnType<typeof createMcpHandler>>();
+  let releaseCancellation = () => {};
+  const cancellationRelease = new Promise<void>((resolve) => {
+    releaseCancellation = resolve;
+  });
 
   const createHandlerGeneration = () => {
     const bus = new InMemoryServerEventBus();
@@ -227,6 +293,9 @@ async function createSubscriptionFixture(
           if (shouldFailToolLists) throw new Error('fixture tool list failed');
           return { tools: result };
         });
+        server.setRequestHandler('tools/call', async () => ({
+          content: [{ type: 'text', text: 'ok' }],
+        }));
         return server;
       },
       {
@@ -248,9 +317,21 @@ async function createSubscriptionFixture(
         return;
       }
       const body = await readJsonBody(req);
+      const method = requestMethod(body);
+      if (options.hangCancellation && method === 'notifications/cancelled') {
+        await cancellationRelease;
+        res.writeHead(204).end();
+        return;
+      }
+      if (shouldFailToolCalls && method === 'tools/call') {
+        res
+          .writeHead(500, { 'content-type': 'text/plain; charset=utf-8' })
+          .end('tool failed upstream');
+        return;
+      }
       if (
         (subscriptionMode === 'missing' || subscriptionMode === 'unhonored') &&
-        requestMethod(body) === 'subscriptions/listen'
+        method === 'subscriptions/listen'
       ) {
         serveRawSubscription(res, body, subscriptionMode, rawSubscriptions);
         return;
@@ -282,6 +363,9 @@ async function createSubscriptionFixture(
     failToolLists(value) {
       shouldFailToolLists = value;
     },
+    failToolCalls(value) {
+      shouldFailToolCalls = value;
+    },
     blockNextToolList() {
       if (nextToolListGate) throw new Error('a tool-list gate is already pending');
       const gate = createGate();
@@ -297,7 +381,9 @@ async function createSubscriptionFixture(
       current = createHandlerGeneration();
       await previous.handler.close();
     },
+    releaseCancellation,
     async close() {
+      releaseCancellation();
       for (const gate of toolListGates) gate.release();
       toolListGates.clear();
       for (const response of rawSubscriptions) response.end();
@@ -399,4 +485,21 @@ async function settleEventLoop(): Promise<void> {
     await new Promise<void>((resolve) => setImmediate(resolve));
   }
   await new Promise((resolve) => setTimeout(resolve, 150));
+}
+
+async function settlesWithin<T>(promise: Promise<T>, timeoutMs = 500): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error('subscription lifecycle did not settle')),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -618,6 +618,55 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       assert.equal(manager.status('remote'), undefined);
     });
 
+    test('retries when a synchronous diagnostic listener requests another refresh', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const snapshotBefore = manager.toolSnapshot();
+      const listsBefore = countProtocolMethod(fixture, 'tools/list');
+      let retry: Promise<unknown> | undefined;
+      let failureDiagnostics = 0;
+      const unsubscribe = manager.onChange((status) => {
+        if (status.serverId !== 'remote' || status.state !== 'connected' || !status.error) return;
+        failureDiagnostics += 1;
+        retry ??= manager.refreshTools('remote');
+      });
+
+      fixture.failNextHttpRequest('tools/list', 'temporary list failure');
+      const first = manager.refreshTools('remote');
+      await first;
+      assert.ok(retry);
+      await retry;
+      unsubscribe();
+
+      assert.equal(countProtocolMethod(fixture, 'tools/list') - listsBefore, 2);
+      assert.equal(failureDiagnostics, 1);
+      assert.strictEqual(manager.toolSnapshot(), snapshotBefore);
+      assert.equal(manager.status('remote')?.error, undefined);
+    });
+
+    test('does not leave a connected status after a synchronous listener retires the generation', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      const states: string[] = [];
+      let retiring: Promise<void> | undefined;
+      const unsubscribe = manager.onChange((status) => {
+        if (status.serverId !== 'remote') return;
+        states.push(status.state);
+        if (status.state === 'connected' && retiring === undefined) {
+          retiring = manager.disconnect('remote');
+        }
+      });
+
+      await manager.sync(remoteConfig(fixture.url));
+      unsubscribe();
+      await retiring;
+
+      assert.equal(manager.status('remote')?.state, 'disconnected');
+      assert.deepEqual(manager.toolSnapshot().tools, []);
+      assert.deepEqual(states, ['connecting', 'connected', 'disconnected']);
+    });
+
     test('does not let an old client refresh overwrite a replacement connection', async () => {
       const fixture = await createRemoteFixture('streamable-http');
       const manager = createManager();
@@ -1082,6 +1131,7 @@ interface RemoteFixture {
   requests: RemoteRequest[];
   setToolListMode(mode: ToolListMode): void;
   setHttpFailure(method: string, body: string): void;
+  failNextHttpRequest(method: string, body: string): void;
   holdNextToolList(): { started: Promise<void>; release(): void };
   setNotifyBeforeEveryToolListResponse(enabled: boolean): void;
   setNotifyOnEveryToolList(enabled: boolean): void;
@@ -1107,6 +1157,7 @@ async function createRemoteFixture(
   const requests: RemoteRequest[] = [];
   let toolListMode: ToolListMode = 'valid';
   let httpFailure: { method: string; body: string } | undefined;
+  let nextHttpFailure: { method: string; body: string } | undefined;
   let nextToolListGate: InternalToolListGate | undefined;
   let notifyBeforeEveryToolListResponse = false;
   let notifyOnEveryToolList = false;
@@ -1137,6 +1188,17 @@ async function createRemoteFixture(
       if (kind === 'streamable-http' && url.pathname === '/mcp' && req.method === 'POST') {
         const body = await readJsonBody(req);
         request.protocolMethods.push(...readProtocolMethods(body));
+        const oneShotFailure = nextHttpFailure;
+        if (
+          oneShotFailure &&
+          request.protocolMethods.some((method) => method === oneShotFailure.method)
+        ) {
+          nextHttpFailure = undefined;
+          res
+            .writeHead(500, { 'content-type': 'text/plain; charset=utf-8' })
+            .end(oneShotFailure.body);
+          return;
+        }
         if (
           httpFailure &&
           request.protocolMethods.some((method) => method === httpFailure?.method)
@@ -1221,6 +1283,9 @@ async function createRemoteFixture(
     },
     setHttpFailure: (method, body) => {
       httpFailure = { method, body };
+    },
+    failNextHttpRequest: (method, body) => {
+      nextHttpFailure = { method, body };
     },
     holdNextToolList: () => {
       if (nextToolListGate) throw new Error('a tools/list gate is already pending');

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, test } from 'node:test';
 import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
 import { Server as McpServer } from '@modelcontextprotocol/server';
 import { SSEServerTransport } from '@modelcontextprotocol/server-legacy/sse';
-import type { McpConfigFile, McpToolBinding } from '@maka/core/mcp';
+import { MCP_CONFIG_VERSION, type McpConfigFile, type McpToolBinding } from '@maka/core/mcp';
 import { buildStdioEnvironment, McpClientManager, McpToolCallError } from '../index.js';
 
 const fixturePath = fileURLToPath(new URL('../__fixtures__/stdio-server.js', import.meta.url));
@@ -50,7 +50,7 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       const manager = createManager();
 
       await manager.sync({
-        version: 1,
+        version: MCP_CONFIG_VERSION,
         mcpServers: {
           [serverId]: { url: fixture.url, transport: 'streamable-http' },
         },
@@ -351,7 +351,7 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       const fixture = await createRemoteFixture('streamable-http');
       const manager = createManager();
       await manager.sync({
-        version: 1,
+        version: MCP_CONFIG_VERSION,
         mcpServers: {
           first: { url: fixture.url, transport: 'streamable-http' },
           second: { url: fixture.url, transport: 'streamable-http' },
@@ -565,7 +565,7 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       await fixture.notifyToolListChanged();
       await gate.started;
 
-      const removal = manager.sync({ version: 1, mcpServers: {} });
+      const removal = manager.sync({ version: MCP_CONFIG_VERSION, mcpServers: {} });
       let removedBeforeRelease: boolean;
       try {
         removedBeforeRelease = await settlesWithin(removal, 1_000);
@@ -814,7 +814,7 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       await waitFor(() => manager.status('fixture')?.state === 'connecting');
       assert.equal(manager.cancelConnect('fixture'), true);
       await sync;
-      await manager.sync({ version: 1, mcpServers: {} });
+      await manager.sync({ version: MCP_CONFIG_VERSION, mcpServers: {} });
       assert.equal(manager.status('fixture'), undefined);
       assert.deepEqual(manager.toolSnapshot().tools, []);
     });
@@ -920,7 +920,7 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       const manager = createManager();
       await manager.sync(fixtureConfig());
       await manager.sync({
-        version: 1,
+        version: MCP_CONFIG_VERSION,
         mcpServers: {
           fixture: { ...fixtureConfig().mcpServers.fixture, enabled: false },
         },
@@ -928,7 +928,7 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       assert.equal(manager.status('fixture')?.state, 'disabled');
       assert.deepEqual(manager.toolSnapshot().tools, []);
       assert.equal((await manager.test('fixture')).ok, false);
-      await manager.sync({ version: 1, mcpServers: {} });
+      await manager.sync({ version: MCP_CONFIG_VERSION, mcpServers: {} });
       assert.equal(manager.status('fixture'), undefined);
     });
   });
@@ -979,7 +979,7 @@ function bindingFor(manager: McpClientManager, serverId: string, toolName: strin
 
 function fixtureConfig(extraArgs: string[] = []): McpConfigFile {
   return {
-    version: 1,
+    version: MCP_CONFIG_VERSION,
     mcpServers: {
       fixture: {
         command: process.execPath,
@@ -994,7 +994,7 @@ function remoteConfig(
   transport: 'auto' | 'streamable-http' = 'streamable-http',
 ): McpConfigFile {
   return {
-    version: 1,
+    version: MCP_CONFIG_VERSION,
     mcpServers: {
       remote: {
         url,

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -5,7 +5,12 @@ import { afterEach, describe, test } from 'node:test';
 import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
 import { Server as McpServer } from '@modelcontextprotocol/server';
 import { SSEServerTransport } from '@modelcontextprotocol/server-legacy/sse';
-import { MCP_CONFIG_VERSION, type McpConfigFile, type McpToolBinding } from '@maka/core/mcp';
+import {
+  MCP_CONFIG_VERSION,
+  type McpConfigFile,
+  type McpProtocolPreference,
+  type McpToolBinding,
+} from '@maka/core/mcp';
 import { buildStdioEnvironment, McpClientManager, McpToolCallError } from '../index.js';
 
 const fixturePath = fileURLToPath(new URL('../__fixtures__/stdio-server.js', import.meta.url));
@@ -25,6 +30,10 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       await manager.sync(remoteConfig(fixture.url));
 
       assert.equal(manager.status('remote')?.transport, 'streamable-http');
+      assert.deepEqual(manager.status('remote')?.negotiatedProtocol, {
+        era: 'legacy',
+        revision: '2025-11-25',
+      });
       assert.doesNotMatch(JSON.stringify(manager.status('remote')), /mcpb1\./u);
       assert.deepEqual(
         await manager.callTool(bindingFor(manager, 'remote', 'echo'), {
@@ -41,6 +50,37 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
         ),
       );
       assertLegacyHandshake(fixture);
+    });
+
+    test('auto probes before negotiating a legacy Streamable HTTP server', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+
+      await manager.sync(remoteConfig(fixture.url, 'streamable-http', 'auto'));
+
+      assert.equal(manager.status('remote')?.state, 'connected');
+      assert.deepEqual(manager.status('remote')?.negotiatedProtocol, {
+        era: 'legacy',
+        revision: '2025-11-25',
+      });
+      const methods = fixture.requests.flatMap((request) => request.protocolMethods);
+      assert.equal(methods[0], 'server/discover');
+      assert.ok(methods.indexOf('initialize') > 0);
+      assert.ok(methods.indexOf('tools/list') > methods.indexOf('initialize'));
+    });
+
+    test('does not downgrade an exact modern pin to a legacy Streamable HTTP server', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+
+      await manager.sync(remoteConfig(fixture.url, 'streamable-http', '2026-07-28'));
+
+      assert.equal(manager.status('remote')?.state, 'error');
+      assert.equal(manager.status('remote')?.negotiatedProtocol, undefined);
+      assert.deepEqual(manager.toolSnapshot().tools, []);
+      const methods = fixture.requests.flatMap((request) => request.protocolMethods);
+      assert.equal(methods[0], 'server/discover');
+      assert.equal(methods.includes('initialize'), false);
     });
 
     test('bounds and sanitizes connection errors before publishing status', async () => {
@@ -992,6 +1032,7 @@ function fixtureConfig(extraArgs: string[] = []): McpConfigFile {
 function remoteConfig(
   url: string,
   transport: 'auto' | 'streamable-http' = 'streamable-http',
+  protocol?: McpProtocolPreference,
 ): McpConfigFile {
   return {
     version: MCP_CONFIG_VERSION,
@@ -999,6 +1040,7 @@ function remoteConfig(
       remote: {
         url,
         transport,
+        ...(protocol === undefined ? {} : { protocol }),
         headers: { Authorization: 'Bearer remote-test' },
       },
     },

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -173,6 +173,21 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       );
     });
 
+    test('refreshes for legacy list-changed notifications without an advertised flag', async () => {
+      const fixture = await createRemoteFixture('sse', { advertiseToolListChanges: false });
+      const manager = createManager();
+      await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto', 'legacy'));
+
+      fixture.setToolListMode('replacement');
+      await fixture.notifyToolListChanged();
+      await waitFor(() => manager.toolSnapshot().tools[0]?.descriptor.name === 'replacement');
+
+      assert.deepEqual(
+        manager.status('remote')?.tools.map((tool) => tool.name),
+        ['replacement'],
+      );
+    });
+
     test('routes initial discovery through the refresh owner when list-changed precedes the first response', async () => {
       const fixture = await createRemoteFixture('sse');
       const gate = fixture.holdNextToolList();
@@ -1152,7 +1167,11 @@ type ToolListMode =
 
 async function createRemoteFixture(
   kind: 'streamable-http' | 'sse',
-  options: { advertiseTools?: boolean; legacyToolCallResult?: unknown } = {},
+  options: {
+    advertiseTools?: boolean;
+    advertiseToolListChanges?: boolean;
+    legacyToolCallResult?: unknown;
+  } = {},
 ): Promise<RemoteFixture> {
   const requests: RemoteRequest[] = [];
   let toolListMode: ToolListMode = 'valid';
@@ -1239,6 +1258,7 @@ async function createRemoteFixture(
         const transport = new SSEServerTransport('/messages', res);
         const server = createProtocolServer({
           advertiseTools: options.advertiseTools !== false,
+          advertiseToolListChanges: options.advertiseToolListChanges !== false,
           toolListMode: () => toolListMode,
           beforeToolList,
           afterToolList: () => toolListResponseClockAdvance(),
@@ -1335,6 +1355,7 @@ async function createRemoteFixture(
 
 function createProtocolServer(options: {
   advertiseTools: boolean;
+  advertiseToolListChanges?: boolean;
   toolListMode: () => ToolListMode;
   beforeToolList: () => Promise<void>;
   afterToolList: () => void;
@@ -1343,7 +1364,11 @@ function createProtocolServer(options: {
 }): McpServer {
   const server = new McpServer(
     { name: 'maka-remote-fixture', version: '1.0.0' },
-    { capabilities: options.advertiseTools ? { tools: { listChanged: true } } : {} },
+    {
+      capabilities: options.advertiseTools
+        ? { tools: options.advertiseToolListChanges === false ? {} : { listChanged: true } }
+        : {},
+    },
   );
   server.setRequestHandler('tools/list', async () => {
     const mode = options.toolListMode();

--- a/packages/mcp/src/__tests__/modern-manager.test.ts
+++ b/packages/mcp/src/__tests__/modern-manager.test.ts
@@ -1,0 +1,280 @@
+import assert from 'node:assert/strict';
+import { createServer, type IncomingMessage } from 'node:http';
+import { afterEach, describe, test } from 'node:test';
+import { SdkError, SdkErrorCode } from '@modelcontextprotocol/client';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import { createMcpHandler, inputRequired, Server } from '@modelcontextprotocol/server';
+import {
+  MCP_CONFIG_VERSION,
+  type McpConfigFile,
+  type McpProtocolPreference,
+  type McpToolBinding,
+} from '@maka/core/mcp';
+import { McpClientManager, McpToolCallError } from '../index.js';
+
+const managers: McpClientManager[] = [];
+const fixtures: ModernRemoteFixture[] = [];
+
+afterEach(async () => {
+  await Promise.all(managers.splice(0).map((manager) => manager.close()));
+  await Promise.all(fixtures.splice(0).map((fixture) => fixture.close()));
+});
+
+describe('McpClientManager modern Streamable HTTP E2E', () => {
+  test('auto negotiates 2026-07-28 and clears live protocol status on disconnect', async () => {
+    const fixture = await createModernRemoteFixture();
+    const manager = createManager();
+
+    await manager.sync(modernConfig(fixture.url, 'auto'));
+
+    assert.equal(fixture.protocolMethods[0], 'server/discover');
+    assert.deepEqual(manager.status('remote')?.negotiatedProtocol, {
+      era: 'modern',
+      revision: '2026-07-28',
+    });
+    assert.equal(manager.status('remote')?.transport, 'streamable-http');
+    assert.deepEqual(
+      manager.status('remote')?.tools.map((tool) => tool.name),
+      ['echo', 'structured', 'needs-input'],
+    );
+
+    await manager.disconnect('remote');
+
+    assert.equal(manager.status('remote')?.state, 'disconnected');
+    assert.equal(manager.status('remote')?.negotiatedProtocol, undefined);
+    assert.deepEqual(manager.status('remote')?.tools, []);
+  });
+
+  test('pins the exact 2026-07-28 revision', async () => {
+    const fixture = await createModernRemoteFixture();
+    const manager = createManager();
+
+    await manager.sync(modernConfig(fixture.url, '2026-07-28'));
+
+    assert.deepEqual(manager.status('remote')?.negotiatedProtocol, {
+      era: 'modern',
+      revision: '2026-07-28',
+    });
+    assert.equal(fixture.protocolMethods[0], 'server/discover');
+  });
+
+  test('does not issue tools/list when a modern server omits the tools capability', async () => {
+    const fixture = await createModernRemoteFixture({ advertiseTools: false });
+    const manager = createManager();
+
+    await manager.sync(modernConfig(fixture.url, 'auto'));
+
+    assert.deepEqual(manager.status('remote')?.negotiatedProtocol, {
+      era: 'modern',
+      revision: '2026-07-28',
+    });
+    assert.equal(manager.status('remote')?.toolCount, 0);
+    assert.deepEqual(manager.toolSnapshot().tools, []);
+    assert.equal(fixture.protocolMethods.includes('tools/list'), false);
+
+    assert.deepEqual(await manager.refreshTools('remote'), []);
+    assert.equal(fixture.protocolMethods.includes('tools/list'), false);
+  });
+
+  test('preserves every modern structuredContent JSON shape', async () => {
+    const fixture = await createModernRemoteFixture();
+    const manager = createManager();
+    await manager.sync(modernConfig(fixture.url, 'auto'));
+    const binding = bindingFor(manager, 'structured');
+
+    const cases = [
+      ['object', { ok: true }],
+      ['array', [1, 'two']],
+      ['scalar', 'ready'],
+      ['null', null],
+    ] as const;
+    for (const [kind, expected] of cases) {
+      const result = await manager.callTool(binding, { kind });
+      assert.deepEqual(result.structuredContent, expected);
+      assert.deepEqual(result.content, [{ type: 'text', text: kind }]);
+    }
+  });
+
+  test('surfaces input_required without silently retrying the tool', async () => {
+    const fixture = await createModernRemoteFixture();
+    const manager = createManager();
+    await manager.sync(modernConfig(fixture.url, 'auto'));
+
+    await assert.rejects(
+      manager.callTool(bindingFor(manager, 'needs-input'), {}),
+      (error: unknown) =>
+        error instanceof McpToolCallError &&
+        error.serverId === 'remote' &&
+        error.toolName === 'needs-input' &&
+        SdkError.isInstance(error.cause) &&
+        error.cause.code === SdkErrorCode.UnsupportedResultType &&
+        /unsupported deferred tool result/u.test(error.message),
+    );
+    assert.equal(fixture.toolCalls.get('needs-input'), 1);
+    assert.equal(fixture.protocolMethods.filter((method) => method === 'tools/call').length, 1);
+  });
+});
+
+function createManager(): McpClientManager {
+  const manager = new McpClientManager({
+    timeouts: { remoteConnectMs: 5_000, listToolsMs: 5_000, callToolMs: 5_000 },
+  });
+  managers.push(manager);
+  return manager;
+}
+
+function bindingFor(manager: McpClientManager, toolName: string): McpToolBinding {
+  const match = manager
+    .toolSnapshot()
+    .tools.find(
+      ({ descriptor }) => descriptor.serverId === 'remote' && descriptor.name === toolName,
+    );
+  assert.ok(match, `missing bound MCP tool remote/${toolName}`);
+  return match.binding;
+}
+
+function modernConfig(url: string, protocol: McpProtocolPreference): McpConfigFile {
+  return {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: {
+      remote: {
+        url,
+        transport: 'streamable-http',
+        protocol,
+      },
+    },
+  };
+}
+
+interface ModernRemoteFixture {
+  url: string;
+  protocolMethods: string[];
+  toolCalls: Map<string, number>;
+  close(): Promise<void>;
+}
+
+async function createModernRemoteFixture(
+  options: { advertiseTools?: boolean } = {},
+): Promise<ModernRemoteFixture> {
+  const advertiseTools = options.advertiseTools !== false;
+  const protocolMethods: string[] = [];
+  const toolCalls = new Map<string, number>();
+  const errors: Error[] = [];
+  const handler = createMcpHandler(
+    () => {
+      const server = new Server(
+        { name: 'maka-modern-fixture', version: '1.0.0' },
+        { capabilities: advertiseTools ? { tools: {} } : {} },
+      );
+      if (advertiseTools) {
+        server.setRequestHandler('tools/list', async () => ({
+          tools: [modernTool('echo'), modernTool('structured', {}), modernTool('needs-input')],
+        }));
+        server.setRequestHandler('tools/call', async ({ params }) => {
+          toolCalls.set(params.name, (toolCalls.get(params.name) ?? 0) + 1);
+          const args = params.arguments ?? {};
+          if (params.name === 'needs-input') {
+            return inputRequired({ requestState: 'awaiting-confirmation' });
+          }
+          if (params.name === 'structured') {
+            const kind = args.kind;
+            return {
+              content: [{ type: 'text', text: String(kind) }],
+              structuredContent:
+                kind === 'object'
+                  ? { ok: true }
+                  : kind === 'array'
+                    ? [1, 'two']
+                    : kind === 'scalar'
+                      ? 'ready'
+                      : null,
+            };
+          }
+          return {
+            content: [{ type: 'text', text: String(args.value ?? '') }],
+          };
+        });
+      }
+      return server;
+    },
+    {
+      legacy: 'reject',
+      keepAliveMs: 0,
+      onerror: (error) => errors.push(error),
+    },
+  );
+  const nodeHandler = toNodeHandler(handler, { onerror: (error) => errors.push(error) });
+  const httpServer = createServer(async (req, res) => {
+    try {
+      if (new URL(req.url ?? '/', 'http://127.0.0.1').pathname !== '/mcp') {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      const body = await readJsonBody(req);
+      protocolMethods.push(...readProtocolMethods(body));
+      await nodeHandler(req, res, body);
+    } catch (error) {
+      errors.push(error instanceof Error ? error : new Error(String(error)));
+      if (!res.headersSent) res.writeHead(500);
+      res.end('modern fixture failed');
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(0, '127.0.0.1', resolve);
+  });
+  const address = httpServer.address();
+  if (!address || typeof address === 'string') throw new Error('modern fixture did not bind TCP');
+  const fixture: ModernRemoteFixture = {
+    url: `http://127.0.0.1:${address.port}/mcp`,
+    protocolMethods,
+    toolCalls,
+    close: async () => {
+      await handler.close();
+      await new Promise<void>((resolve, reject) =>
+        httpServer.close((error) => (error ? reject(error) : resolve())),
+      );
+      assert.deepEqual(errors, []);
+    },
+  };
+  fixtures.push(fixture);
+  return fixture;
+}
+
+function modernTool(name: string, outputSchema?: Record<string, unknown>) {
+  return {
+    name,
+    inputSchema:
+      name === 'structured'
+        ? {
+            type: 'object' as const,
+            properties: {
+              kind: { enum: ['object', 'array', 'scalar', 'null'] },
+            },
+            required: ['kind'],
+          }
+        : { type: 'object' as const },
+    ...(outputSchema === undefined ? {} : { outputSchema }),
+  };
+}
+
+function readProtocolMethods(body: unknown): string[] {
+  return (Array.isArray(body) ? body : [body]).flatMap((message) => {
+    if (
+      typeof message === 'object' &&
+      message !== null &&
+      'method' in message &&
+      typeof message.method === 'string'
+    ) {
+      return [message.method];
+    }
+    return [];
+  });
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  const text = Buffer.concat(chunks).toString('utf8');
+  return text ? JSON.parse(text) : undefined;
+}

--- a/packages/mcp/src/__tests__/modern-manager.test.ts
+++ b/packages/mcp/src/__tests__/modern-manager.test.ts
@@ -14,6 +14,7 @@ import { McpClientManager, McpToolCallError } from '../index.js';
 
 const managers: McpClientManager[] = [];
 const fixtures: ModernRemoteFixture[] = [];
+const HOSTILE_HEADER_PATH = `token=sk-live-secret-token-value\r\n${'x'.repeat(1_000)}`;
 
 afterEach(async () => {
   await Promise.all(managers.splice(0).map((manager) => manager.close()));
@@ -152,6 +153,13 @@ describe('McpClientManager modern Streamable HTTP E2E', () => {
         error.toolName === 'header-echo' &&
         /unsafe integer argument at shard/u.test(error.message),
     );
+    await assert.rejects(
+      manager.callTool(binding, { [HOSTILE_HEADER_PATH]: Number.MAX_SAFE_INTEGER + 1 }),
+      (error: unknown) =>
+        error instanceof McpToolCallError &&
+        error.message.length <= 600 &&
+        !/[\r\n]|sk-live|secret-token/u.test(error.message),
+    );
     assert.equal(fixture.protocolMethods.length, methodsBeforeUnsafeCall);
     assert.equal(fixture.toolCalls.get('header-echo'), 1);
   });
@@ -234,6 +242,7 @@ async function createModernRemoteFixture(
                   properties: {
                     shard: { type: 'integer', 'x-mcp-header': 'Shard' },
                     value: { type: 'string' },
+                    [HOSTILE_HEADER_PATH]: { type: 'integer', 'x-mcp-header': 'Hostile' },
                   },
                 },
               },

--- a/packages/mcp/src/__tests__/modern-manager.test.ts
+++ b/packages/mcp/src/__tests__/modern-manager.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { createServer, type IncomingMessage } from 'node:http';
 import { afterEach, describe, test } from 'node:test';
-import { SdkError, SdkErrorCode } from '@modelcontextprotocol/client';
+import { SdkError, SdkErrorCode, type Tool } from '@modelcontextprotocol/client';
 import { toNodeHandler } from '@modelcontextprotocol/node';
 import { createMcpHandler, inputRequired, Server } from '@modelcontextprotocol/server';
 import {
@@ -113,6 +113,42 @@ describe('McpClientManager modern Streamable HTTP E2E', () => {
     assert.equal(fixture.toolCalls.get('needs-input'), 1);
     assert.equal(fixture.protocolMethods.filter((method) => method === 'tools/call').length, 1);
   });
+
+  test('partitions SEP-2243 definitions and mirrors safe arguments on the wire', async () => {
+    const fixture = await createModernRemoteFixture({ includeHeaderTools: true });
+    const manager = createManager();
+
+    await manager.sync(modernConfig(fixture.url, 'auto'));
+
+    assert.deepEqual(
+      manager
+        .toolSnapshot()
+        .tools.map(({ descriptor }) => descriptor.name)
+        .sort(),
+      ['echo', 'header-echo', 'needs-input', 'structured'],
+    );
+    assert.equal(bindingForOptional(manager, 'invalid-header'), undefined);
+
+    const binding = bindingFor(manager, 'header-echo');
+    assert.deepEqual(await manager.callTool(binding, { shard: 42, value: 'safe' }), {
+      content: [{ type: 'text', text: 'safe' }],
+      structuredContent: undefined,
+    });
+    assert.equal(fixture.toolCallHeaders.get('header-echo'), '42');
+    assert.equal(fixture.toolCalls.get('header-echo'), 1);
+
+    const methodsBeforeUnsafeCall = fixture.protocolMethods.length;
+    await assert.rejects(
+      manager.callTool(binding, { shard: Number.MAX_SAFE_INTEGER + 1, value: 'unsafe' }),
+      (error: unknown) =>
+        error instanceof McpToolCallError &&
+        error.serverId === 'remote' &&
+        error.toolName === 'header-echo' &&
+        /unsafe integer argument at shard/u.test(error.message),
+    );
+    assert.equal(fixture.protocolMethods.length, methodsBeforeUnsafeCall);
+    assert.equal(fixture.toolCalls.get('header-echo'), 1);
+  });
 });
 
 function createManager(): McpClientManager {
@@ -124,13 +160,20 @@ function createManager(): McpClientManager {
 }
 
 function bindingFor(manager: McpClientManager, toolName: string): McpToolBinding {
-  const match = manager
+  const binding = bindingForOptional(manager, toolName);
+  assert.ok(binding, `missing bound MCP tool remote/${toolName}`);
+  return binding;
+}
+
+function bindingForOptional(
+  manager: McpClientManager,
+  toolName: string,
+): McpToolBinding | undefined {
+  return manager
     .toolSnapshot()
     .tools.find(
       ({ descriptor }) => descriptor.serverId === 'remote' && descriptor.name === toolName,
-    );
-  assert.ok(match, `missing bound MCP tool remote/${toolName}`);
-  return match.binding;
+    )?.binding;
 }
 
 function modernConfig(url: string, protocol: McpProtocolPreference): McpConfigFile {
@@ -150,15 +193,17 @@ interface ModernRemoteFixture {
   url: string;
   protocolMethods: string[];
   toolCalls: Map<string, number>;
+  toolCallHeaders: Map<string, string | undefined>;
   close(): Promise<void>;
 }
 
 async function createModernRemoteFixture(
-  options: { advertiseTools?: boolean } = {},
+  options: { advertiseTools?: boolean; includeHeaderTools?: boolean } = {},
 ): Promise<ModernRemoteFixture> {
   const advertiseTools = options.advertiseTools !== false;
   const protocolMethods: string[] = [];
   const toolCalls = new Map<string, number>();
+  const toolCallHeaders = new Map<string, string | undefined>();
   const errors: Error[] = [];
   const handler = createMcpHandler(
     () => {
@@ -167,9 +212,37 @@ async function createModernRemoteFixture(
         { capabilities: advertiseTools ? { tools: {} } : {} },
       );
       if (advertiseTools) {
-        server.setRequestHandler('tools/list', async () => ({
-          tools: [modernTool('echo'), modernTool('structured', {}), modernTool('needs-input')],
-        }));
+        server.setRequestHandler('tools/list', async () => {
+          const tools: Tool[] = [
+            modernTool('echo'),
+            modernTool('structured', {}),
+            modernTool('needs-input'),
+          ];
+          if (options.includeHeaderTools) {
+            tools.push(
+              {
+                name: 'header-echo',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    shard: { type: 'integer', 'x-mcp-header': 'Shard' },
+                    value: { type: 'string' },
+                  },
+                },
+              },
+              {
+                name: 'invalid-header',
+                inputSchema: {
+                  type: 'object',
+                  properties: {
+                    ratio: { type: 'number', 'x-mcp-header': 'Ratio' },
+                  },
+                },
+              },
+            );
+          }
+          return { tools };
+        });
         server.setRequestHandler('tools/call', async ({ params }) => {
           toolCalls.set(params.name, (toolCalls.get(params.name) ?? 0) + 1);
           const args = params.arguments ?? {};
@@ -211,7 +284,11 @@ async function createModernRemoteFixture(
         return;
       }
       const body = await readJsonBody(req);
-      protocolMethods.push(...readProtocolMethods(body));
+      const methods = readProtocolMethods(body);
+      protocolMethods.push(...methods);
+      for (const toolName of readToolCallNames(body)) {
+        toolCallHeaders.set(toolName, headerValue(req, 'mcp-param-shard'));
+      }
       await nodeHandler(req, res, body);
     } catch (error) {
       errors.push(error instanceof Error ? error : new Error(String(error)));
@@ -229,6 +306,7 @@ async function createModernRemoteFixture(
     url: `http://127.0.0.1:${address.port}/mcp`,
     protocolMethods,
     toolCalls,
+    toolCallHeaders,
     close: async () => {
       await handler.close();
       await new Promise<void>((resolve, reject) =>
@@ -241,7 +319,7 @@ async function createModernRemoteFixture(
   return fixture;
 }
 
-function modernTool(name: string, outputSchema?: Record<string, unknown>) {
+function modernTool(name: string, outputSchema?: Record<string, unknown>): Tool {
   return {
     name,
     inputSchema:
@@ -270,6 +348,30 @@ function readProtocolMethods(body: unknown): string[] {
     }
     return [];
   });
+}
+
+function readToolCallNames(body: unknown): string[] {
+  return (Array.isArray(body) ? body : [body]).flatMap((message) => {
+    if (
+      typeof message === 'object' &&
+      message !== null &&
+      'method' in message &&
+      message.method === 'tools/call' &&
+      'params' in message &&
+      typeof message.params === 'object' &&
+      message.params !== null &&
+      'name' in message.params &&
+      typeof message.params.name === 'string'
+    ) {
+      return [message.params.name];
+    }
+    return [];
+  });
+}
+
+function headerValue(req: IncomingMessage, name: string): string | undefined {
+  const value = req.headers[name];
+  return Array.isArray(value) ? value.join(', ') : value;
 }
 
 async function readJsonBody(req: IncomingMessage): Promise<unknown> {

--- a/packages/mcp/src/__tests__/modern-manager.test.ts
+++ b/packages/mcp/src/__tests__/modern-manager.test.ts
@@ -60,7 +60,8 @@ describe('McpClientManager modern Streamable HTTP E2E', () => {
 
   test('does not issue tools/list when a modern server omits the tools capability', async () => {
     const fixture = await createModernRemoteFixture({ advertiseTools: false });
-    const manager = createManager();
+    let now = 1;
+    const manager = createManager({ now: () => now });
 
     await manager.sync(modernConfig(fixture.url, 'auto'));
 
@@ -72,7 +73,12 @@ describe('McpClientManager modern Streamable HTTP E2E', () => {
     assert.deepEqual(manager.toolSnapshot().tools, []);
     assert.equal(fixture.protocolMethods.includes('tools/list'), false);
 
+    now = 2;
     assert.deepEqual(await manager.refreshTools('remote'), []);
+    assert.equal(manager.status('remote')?.updatedAt, 2);
+    now = 3;
+    assert.deepEqual(await manager.refreshTools('remote'), []);
+    assert.equal(manager.status('remote')?.updatedAt, 3);
     assert.equal(fixture.protocolMethods.includes('tools/list'), false);
   });
 
@@ -151,8 +157,9 @@ describe('McpClientManager modern Streamable HTTP E2E', () => {
   });
 });
 
-function createManager(): McpClientManager {
+function createManager(options: { now?: () => number } = {}): McpClientManager {
   const manager = new McpClientManager({
+    ...options,
     timeouts: { remoteConnectMs: 5_000, listToolsMs: 5_000, callToolMs: 5_000 },
   });
   managers.push(manager);

--- a/packages/mcp/src/__tests__/sep-2243.test.ts
+++ b/packages/mcp/src/__tests__/sep-2243.test.ts
@@ -1,0 +1,264 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  formatMcpHeaderExclusionWarning,
+  MCP_HEADER_WARNING_LENGTH_LIMIT,
+  partitionMcpHeaderToolDefinitions,
+  validateMcpHeaderArguments,
+  validateMcpHeaderDefinition,
+  type McpHeaderToolRejection,
+} from '../sep-2243.js';
+
+describe('SEP-2243 definition validation', () => {
+  test('collects nested string, integer, and boolean properties', () => {
+    const result = validateMcpHeaderDefinition({
+      type: 'object',
+      properties: {
+        region: { type: 'string', 'x-mcp-header': 'Region' },
+        options: {
+          type: 'object',
+          properties: {
+            attempt: { type: 'integer', 'x-mcp-header': 'Attempt' },
+            dryRun: { type: 'boolean', 'x-mcp-header': 'Dry-Run' },
+          },
+        },
+      },
+    });
+
+    assert.equal(result.valid, true);
+    if (!result.valid) return;
+    assert.deepEqual(result.declarations, [
+      { path: ['region'], headerName: 'Region', type: 'string' },
+      { path: ['options', 'attempt'], headerName: 'Attempt', type: 'integer' },
+      { path: ['options', 'dryRun'], headerName: 'Dry-Run', type: 'boolean' },
+    ]);
+  });
+
+  test('rejects number even though the pinned SDK accepts it', () => {
+    assertInvalid(
+      {
+        type: 'object',
+        properties: {
+          ratio: { type: 'number', 'x-mcp-header': 'Ratio' },
+        },
+      },
+      'property_type_unsupported',
+      ['ratio'],
+    );
+  });
+
+  test('uses stable codes for malformed annotation values and property types', () => {
+    assertInvalid(schemaFor({ type: 'string', 'x-mcp-header': 42 }), 'annotation_not_string', [
+      'value',
+    ]);
+    assertInvalid(schemaFor({ type: 'string', 'x-mcp-header': '' }), 'header_name_empty', [
+      'value',
+    ]);
+    assertInvalid(
+      schemaFor({ type: ['string', 'null'], 'x-mcp-header': 'Value' }),
+      'property_type_unsupported',
+      ['value'],
+    );
+  });
+
+  test('requires an RFC 9110 token for the header name', () => {
+    for (const headerName of ['My Region', 'Region:Primary', 'Région', 'Region\t1']) {
+      assertInvalid(
+        schemaFor({ type: 'string', 'x-mcp-header': headerName }),
+        'header_name_invalid',
+        ['value'],
+      );
+    }
+
+    const allowed = validateMcpHeaderDefinition(
+      schemaFor({ type: 'string', 'x-mcp-header': "!#$%&'*+-.^_`|~09Az" }),
+    );
+    assert.equal(allowed.valid, true);
+  });
+
+  test('requires case-insensitively unique header names across nesting levels', () => {
+    assertInvalid(
+      {
+        type: 'object',
+        properties: {
+          first: { type: 'string', 'x-mcp-header': 'Region' },
+          nested: {
+            type: 'object',
+            properties: {
+              second: { type: 'string', 'x-mcp-header': 'rEgIoN' },
+            },
+          },
+        },
+      },
+      'header_name_duplicate',
+      ['nested', 'second'],
+    );
+  });
+
+  test('rejects annotations outside a properties-only static path', () => {
+    assertInvalid({ type: 'object', 'x-mcp-header': 'Root' }, 'not_statically_reachable', []);
+
+    const unreachableSchemas: Array<[string, unknown]> = [
+      ['items', { type: 'string', 'x-mcp-header': 'Item' }],
+      ['additionalProperties', { type: 'string', 'x-mcp-header': 'Additional' }],
+      ['oneOf', [{ type: 'string', 'x-mcp-header': 'Choice' }]],
+      ['$defs', { declared: { type: 'string', 'x-mcp-header': 'Definition' } }],
+      ['patternProperties', { '^dynamic': { type: 'string', 'x-mcp-header': 'Pattern' } }],
+    ];
+
+    for (const [keyword, subschema] of unreachableSchemas) {
+      assertInvalid({ type: 'object', [keyword]: subschema }, 'not_statically_reachable', [
+        `<${keyword}>`,
+      ]);
+    }
+  });
+});
+
+test('partitioning excludes only malformed Tools and preserves valid references', () => {
+  const valid = {
+    name: 'search',
+    inputSchema: schemaFor({ type: 'string', 'x-mcp-header': 'Region' }),
+  };
+  const invalid = {
+    name: 'calculate',
+    inputSchema: schemaFor({ type: 'number', 'x-mcp-header': 'Ratio' }),
+  };
+  const plain = { name: 'echo', inputSchema: { type: 'object' } };
+
+  const result = partitionMcpHeaderToolDefinitions([valid, invalid, plain]);
+
+  assert.deepEqual(
+    result.valid.map(({ tool }) => tool),
+    [valid, plain],
+  );
+  assert.deepEqual(result.rejected, [
+    {
+      toolName: 'calculate',
+      issue: { code: 'property_type_unsupported', path: ['value'] },
+    },
+  ]);
+});
+
+describe('SEP-2243 exclusion warning', () => {
+  test('reports the total and a capped sample using stable reason codes', () => {
+    const rejections = Array.from({ length: 8 }, (_, index) =>
+      rejection(
+        `tool-${index}`,
+        index % 2 === 0 ? 'header_name_invalid' : 'property_type_unsupported',
+      ),
+    );
+
+    const warning = formatMcpHeaderExclusionWarning(rejections);
+
+    assert.ok(warning);
+    assert.match(warning, /excluded 8 Tool definition/u);
+    assert.match(warning, /\[header_name_invalid\]/u);
+    assert.match(warning, /\[property_type_unsupported\]/u);
+    assert.match(warning, /3 more not shown/u);
+    assert.doesNotMatch(warning, /tool-5-/u);
+    assert.ok(warning.length <= MCP_HEADER_WARNING_LENGTH_LIMIT);
+  });
+
+  test('sanitizes control characters and always honors the rendered-length cap', () => {
+    const warning = formatMcpHeaderExclusionWarning([
+      rejection(`line\r\n\u2028\u2029${'😀\\'.repeat(200)}`, 'header_name_invalid'),
+      rejection('second', 'header_name_duplicate'),
+      rejection('third', 'annotation_not_string'),
+      rejection('fourth', 'header_name_empty'),
+      rejection('fifth', 'not_statically_reachable'),
+    ]);
+
+    assert.ok(warning);
+    assert.doesNotMatch(warning, /[\r\n\u2028\u2029]/u);
+    assert.match(warning, /…/u);
+    assert.ok(warning.length <= MCP_HEADER_WARNING_LENGTH_LIMIT);
+  });
+
+  test('redacts secret-shaped Tool names before logging them', () => {
+    const secret = 'sk-ant-1234567890abcdef';
+    const warning = formatMcpHeaderExclusionWarning([
+      rejection(`tool-${secret}`, 'header_name_invalid'),
+    ]);
+
+    assert.ok(warning);
+    assert.doesNotMatch(warning, new RegExp(secret, 'u'));
+    assert.match(warning, /\[redacted\]/u);
+  });
+
+  test('returns undefined when no Tool was excluded', () => {
+    assert.equal(formatMcpHeaderExclusionWarning([]), undefined);
+  });
+});
+
+describe('SEP-2243 call-time integer validation', () => {
+  const definition = validateMcpHeaderDefinition({
+    type: 'object',
+    properties: {
+      routing: {
+        type: 'object',
+        properties: {
+          shard: { type: 'integer', 'x-mcp-header': 'Shard' },
+        },
+      },
+    },
+  });
+  assert.equal(definition.valid, true);
+  if (!definition.valid) throw new Error('test setup is invalid');
+
+  test('accepts safe boundaries and leaves other schema validation to the caller', () => {
+    for (const value of [
+      Number.MIN_SAFE_INTEGER,
+      Number.MAX_SAFE_INTEGER,
+      undefined,
+      null,
+      'not-a-number',
+      1.5,
+      Number.POSITIVE_INFINITY,
+    ]) {
+      assert.deepEqual(
+        validateMcpHeaderArguments(definition.declarations, {
+          routing: { shard: value },
+        }),
+        { valid: true },
+      );
+    }
+  });
+
+  test('returns a stable local failure for unsafe integer arguments', () => {
+    assert.deepEqual(
+      validateMcpHeaderArguments(definition.declarations, {
+        routing: { shard: Number.MAX_SAFE_INTEGER + 1 },
+      }),
+      {
+        valid: false,
+        code: 'unsafe_integer_argument',
+        path: ['routing', 'shard'],
+      },
+    );
+  });
+});
+
+function schemaFor(property: Record<string, unknown>): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: { value: property },
+  };
+}
+
+function assertInvalid(
+  schema: unknown,
+  code: McpHeaderToolRejection['issue']['code'],
+  path: readonly string[],
+): void {
+  const result = validateMcpHeaderDefinition(schema);
+  assert.equal(result.valid, false);
+  if (result.valid) return;
+  assert.deepEqual(result.issue, { code, path });
+}
+
+function rejection(
+  toolName: string,
+  code: McpHeaderToolRejection['issue']['code'],
+): McpHeaderToolRejection {
+  return { toolName, issue: { code, path: ['value'] } };
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -651,13 +651,23 @@ export class McpClientManager {
       // owner with explicit refreshes and live change signals. A notification
       // arriving while the first tools/list is in flight therefore joins that
       // pass instead of publishing a snapshot the server already marked stale.
-      const initialRefresh = await this.startToolRefresh(
+      const initialRefreshPromise = this.startToolRefresh(
         serverId,
         entry,
         connectedClient,
         connectionGeneration,
         { initial: true, signal },
       );
+      if (bufferedEvents.pendingToolsChanged) {
+        this.handleToolsChanged(
+          serverId,
+          entry,
+          connectedClient,
+          connectionGeneration,
+          bufferedEvents.pendingToolsChanged.error,
+        );
+      }
+      const initialRefresh = await initialRefreshPromise;
       if (
         signal.aborted ||
         entry.closing ||
@@ -703,7 +713,6 @@ export class McpClientManager {
           undefined,
         );
       }
-      publishMcpHeaderExclusionWarning(snapshot.warning);
       if (subscription) {
         this.observeSubscriptionClose(
           serverId,
@@ -711,15 +720,6 @@ export class McpClientManager {
           connectedClient,
           connectionGeneration,
           subscription,
-        );
-      }
-      if (bufferedEvents.pendingToolsChanged) {
-        this.handleToolsChanged(
-          serverId,
-          entry,
-          connectedClient,
-          connectionGeneration,
-          bufferedEvents.pendingToolsChanged.error,
         );
       }
       return cloneStatus(entry.status);
@@ -1048,6 +1048,12 @@ export class McpClientManager {
         if (!this.ownsToolRefresh(serverId, entry, state)) {
           throw safeMcpOperationError(serverId, 'connection changed during tool refresh', failure);
         }
+        // A notification that arrived while this list was in flight supersedes
+        // its result: skip the stale publish and let the trailing notification
+        // pass own the snapshot. A manual refresh queued during the list is
+        // different: its result is still a valid latest snapshot, so publish it
+        // below and only then run the trailing pass.
+        if (state.pendingNotification) continue;
         const notificationState = entry.refreshNotificationState;
         const notificationStateMatches =
           notificationState?.client === state.client &&
@@ -1055,22 +1061,17 @@ export class McpClientManager {
         const refreshSuppressed = notificationStateMatches && notificationState.suppressed;
         if (failure !== undefined) {
           if (refreshSuppressed) throw this.toolRefreshFrequencyError(serverId);
-          if (state.pending) continue;
           const exposed = safeMcpOperationError(serverId, 'tool refresh failed', failure);
           entry.refreshDiagnostic = errorMessage(exposed);
           this.publishConnectionDiagnostics(entry);
-          if (
-            this.connections.get(serverId) !== entry ||
-            entry.client !== state.client ||
-            entry.connectionGeneration !== state.connectionGeneration ||
-            entry.status.state !== 'connected'
-          ) {
+          if (!this.ownsToolRefresh(serverId, entry, state)) {
             throw safeMcpOperationError(
               serverId,
               'connection changed during tool refresh',
               failure,
             );
           }
+          if (state.pending) continue;
           throw exposed;
         }
         if (!definitions) {
@@ -1105,6 +1106,9 @@ export class McpClientManager {
             error: projectConnectionDiagnostics(entry),
             updatedAt: this.now(),
           });
+          // A synchronous status listener can retire this generation during
+          // publication. Never hand descriptors for that retired snapshot
+          // back to the caller.
           if (!this.ownsToolRefresh(serverId, entry, state)) {
             throw safeMcpOperationError(
               serverId,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,18 +1,27 @@
 import { randomBytes } from 'node:crypto';
 import {
   Client,
+  SdkErrorCode,
+  SdkHttpError,
   SSEClientTransport,
   StreamableHTTPClientTransport,
+  type FetchLike,
+  type McpSubscription,
   type Tool,
   type Transport,
+  type VersionNegotiationOptions,
 } from '@modelcontextprotocol/client';
 import { StdioClientTransport } from '@modelcontextprotocol/client/stdio';
 import {
   isMcpStdioConfig,
+  resolveMcpRemoteProtocolPreference,
   type McpBoundTool,
   type McpCallResult,
   type McpConfigFile,
   type McpContentBlock,
+  type McpNegotiatedProtocol,
+  type McpProtocolPreference,
+  type McpRemoteServerConfig,
   type McpServerConfig,
   type McpServerStatus,
   type McpTestResult,
@@ -25,6 +34,12 @@ import {
   MCP_DIAGNOSTIC_INPUT_CODE_UNITS,
   MCP_ERROR_DIAGNOSTIC_CODE_POINTS,
 } from './diagnostic-text.js';
+import {
+  formatMcpHeaderExclusionWarning,
+  partitionMcpHeaderToolDefinitions,
+  validateMcpHeaderArguments,
+  type McpHeaderDeclaration,
+} from './sep-2243.js';
 import { createMcpToolBinding, parseMcpToolBinding } from './tool-binding.js';
 import { McpToolCallError, normalizeToolCallError } from './tool-call-error.js';
 import { discoverMcpTools, type McpDiscoveredTool } from './tool-discovery.js';
@@ -65,6 +80,7 @@ interface ToolSnapshotEntry {
   descriptor: McpToolDescriptor;
   binding: McpToolBinding;
   connectionGeneration: number;
+  headerDeclarations: readonly McpHeaderDeclaration[];
   callPreparation?: McpToolCallPreparationState;
 }
 
@@ -122,6 +138,10 @@ interface Connection {
   connectionGeneration?: number;
   refreshState?: ToolRefreshState;
   refreshNotificationState?: ToolRefreshNotificationState;
+  enforceMcpHeaders: boolean;
+  refreshDiagnostic?: string;
+  subscription?: McpSubscription;
+  subscriptionDiagnostic?: string;
   closing: boolean;
 }
 
@@ -132,10 +152,21 @@ interface ToolBindingTarget {
 
 interface OpenedMcpClient {
   client: Client;
+  events: McpClientEventBridge;
   transport: Transport;
   stdioTransport?: StdioClientTransport;
   kind: 'stdio' | 'streamable-http' | 'sse';
   isClosed(): boolean;
+}
+
+interface McpClientEventBridge {
+  activate(handlers: {
+    onClientError(error: Error): void;
+    onToolsChanged(error: Error | null): void;
+  }): {
+    clientErrors: Error[];
+    pendingToolsChanged?: { error: Error | null };
+  };
 }
 
 export class McpClientManager {
@@ -196,6 +227,7 @@ export class McpClientManager {
           fingerprint,
           closing: false,
           toolSnapshot: new Map(),
+          enforceMcpHeaders: false,
           status: this.makeStatus(
             serverId,
             serverConfig.enabled === false ? 'disabled' : 'disconnected',
@@ -259,14 +291,19 @@ export class McpClientManager {
     const connectPromise = entry.connectPromise;
     const client = entry.client;
     const transport = entry.transport;
+    const subscription = entry.subscription;
     entry.client = undefined;
     entry.transport = undefined;
     entry.stdioTransport = undefined;
+    entry.subscription = undefined;
     this.replaceToolSnapshot(entry, new Map());
     entry.connectionGeneration = undefined;
     entry.refreshState = undefined;
     entry.refreshNotificationState = undefined;
-    await safeClose(client, transport);
+    entry.enforceMcpHeaders = false;
+    entry.refreshDiagnostic = undefined;
+    entry.subscriptionDiagnostic = undefined;
+    await safeClose(client, transport, subscription);
     await connectPromise?.catch(() => {});
     if (remove) {
       this.connections.delete(serverId);
@@ -290,7 +327,12 @@ export class McpClientManager {
       entry.connectionGeneration = undefined;
       entry.refreshState = undefined;
       entry.refreshNotificationState = undefined;
-      return safeClose(entry.client, entry.transport);
+      entry.enforceMcpHeaders = false;
+      const subscription = entry.subscription;
+      entry.subscription = undefined;
+      entry.refreshDiagnostic = undefined;
+      entry.subscriptionDiagnostic = undefined;
+      return safeClose(entry.client, entry.transport, subscription);
     });
     await Promise.all(closing);
     await this.syncQueue.catch(() => {});
@@ -446,6 +488,14 @@ export class McpClientManager {
       throw new McpToolCallError(serverId, toolName, 'tool binding is stale');
     }
     const client = entry.client;
+    const headerArguments = validateMcpHeaderArguments(snapshot.headerDeclarations, args);
+    if (!headerArguments.valid) {
+      throw new McpToolCallError(
+        serverId,
+        toolName,
+        `unsafe integer argument at ${headerArguments.path.join('.')}`,
+      );
+    }
     const preparation =
       snapshot.callPreparation ??
       (snapshot.callPreparation = this.toolCallPreparer.prepare(snapshot.definition));
@@ -543,60 +593,74 @@ export class McpClientManager {
   ): Promise<McpServerStatus> {
     let connected: OpenedMcpClient | undefined;
     entry.closing = false;
+    entry.refreshDiagnostic = undefined;
+    entry.subscription = undefined;
+    entry.subscriptionDiagnostic = undefined;
     this.update(entry, {
-      ...entry.status,
-      state: 'connecting',
-      error: undefined,
-      updatedAt: this.now(),
+      ...this.makeStatus(serverId, 'connecting'),
+      stderrTail: entry.status.stderrTail,
     });
     try {
       connected = await this.openClient(serverId, entry, signal);
       if (signal.aborted || entry.closing || connected.isClosed()) {
         throw new Error(`MCP server "${serverId}" connection closed during setup`);
       }
-      entry.client = connected.client;
+      const connectedClient = connected.client;
+      const negotiatedProtocol = readNegotiatedProtocol(connectedClient);
+      const serverCapabilities = connectedClient.getServerCapabilities();
+      const expectsToolListSubscription =
+        negotiatedProtocol.era === 'modern' && serverCapabilities?.tools?.listChanged === true;
+      let subscription = expectsToolListSubscription
+        ? connectedClient.autoOpenedSubscription
+        : undefined;
+      let subscriptionFailure:
+        | { reason: 'missing'; cause?: Error }
+        | { reason: 'unhonored' }
+        | undefined;
+      if (subscription && subscription.honoredFilter.toolsListChanged !== true) {
+        await subscription.close().catch(() => {});
+        subscription = undefined;
+        subscriptionFailure = { reason: 'unhonored' };
+      }
+      entry.client = connectedClient;
       entry.transport = connected.transport;
       entry.stdioTransport = connected.stdioTransport;
+      entry.subscription = subscription;
       const connectionGeneration = this.allocateConnectionGeneration();
       entry.connectionGeneration = connectionGeneration;
-      const connectedClient = connected.client;
-      // Install the generation-fenced handler BEFORE initial discovery, and
-      // run that first discovery through the same single-flight refresh owner
-      // as explicit refreshes and notifications. A tools/list_changed that
-      // arrives while the first tools/list response is in flight then joins
-      // the active pass instead of being dropped, so the published snapshot
-      // cannot settle on a list the server already declared stale.
-      connectedClient.setNotificationHandler('notifications/tools/list_changed', async () => {
-        if (
-          this.connections.get(serverId) !== entry ||
-          entry.client !== connectedClient ||
-          entry.connectionGeneration !== connectionGeneration
-        ) {
-          return;
-        }
-        await this.refreshToolsAfterNotification(
-          serverId,
-          entry,
-          connectedClient,
-          connectionGeneration,
-        ).catch((error) => {
-          if (
-            this.connections.get(serverId) !== entry ||
-            entry.client !== connectedClient ||
-            entry.connectionGeneration !== connectionGeneration
-          ) {
-            return;
-          }
-          // Discovery refresh failure does not mean the transport closed. Keep
-          // the previous tool snapshot callable and avoid opening a second
-          // client over a still-live connection.
-          this.update(entry, {
-            ...entry.status,
-            error: errorMessage(error),
-            updatedAt: this.now(),
-          });
-        });
+      entry.enforceMcpHeaders =
+        connected.kind === 'streamable-http' && negotiatedProtocol.era === 'modern';
+
+      const bufferedEvents = connected.events.activate({
+        onClientError: (error) => {
+          if (!expectsToolListSubscription) return;
+          this.recordSubscriptionDiagnostic(
+            serverId,
+            entry,
+            connectedClient,
+            connectionGeneration,
+            formatSubscriptionDiagnostic(serverId, 'reported an error', error),
+          );
+        },
+        onToolsChanged: (error) => {
+          this.handleToolsChanged(serverId, entry, connectedClient, connectionGeneration, error);
+        },
       });
+      if (expectsToolListSubscription && !subscription && !subscriptionFailure) {
+        subscriptionFailure = {
+          reason: 'missing',
+          cause: bufferedEvents.clientErrors.at(-1),
+        };
+      }
+      entry.subscriptionDiagnostic = subscriptionFailure
+        ? subscriptionFailure.reason === 'unhonored'
+          ? formatSubscriptionDiagnostic(serverId, 'did not honor tool-list changes')
+          : formatSubscriptionDiagnostic(serverId, 'is unavailable', subscriptionFailure.cause)
+        : undefined;
+      // Initial discovery shares the generation-fenced, single-flight refresh
+      // owner with explicit refreshes and live change signals. A notification
+      // arriving while the first tools/list is in flight therefore joins that
+      // pass instead of publishing a snapshot the server already marked stale.
       const initialRefresh = await this.startToolRefresh(
         serverId,
         entry,
@@ -608,7 +672,7 @@ export class McpClientManager {
         signal.aborted ||
         entry.closing ||
         connected.isClosed() ||
-        entry.client !== connected.client ||
+        entry.client !== connectedClient ||
         entry.connectionGeneration !== connectionGeneration
       ) {
         throw new Error(`MCP server "${serverId}" connection changed during tool discovery`);
@@ -622,18 +686,38 @@ export class McpClientManager {
       // in one synchronous commit. Observers can therefore never advertise a
       // binding that callTool still rejects as not connected.
       this.replaceToolSnapshot(entry, initialSnapshot);
+      if (initialRefresh.suppressed) {
+        entry.refreshDiagnostic = errorMessage(this.toolRefreshFrequencyError(serverId));
+      }
       this.update(entry, {
         serverId,
         state: 'connected',
         transport: connected.kind,
+        negotiatedProtocol,
         toolCount: initialRefresh.descriptors.length,
         tools: initialRefresh.descriptors,
-        error: initialRefresh.suppressed
-          ? errorMessage(this.toolRefreshFrequencyError(serverId))
-          : undefined,
+        error: projectConnectionDiagnostics(entry),
         stderrTail: entry.status.stderrTail,
         updatedAt: this.now(),
       });
+      if (subscription) {
+        this.observeSubscriptionClose(
+          serverId,
+          entry,
+          connectedClient,
+          connectionGeneration,
+          subscription,
+        );
+      }
+      if (bufferedEvents.pendingToolsChanged) {
+        this.handleToolsChanged(
+          serverId,
+          entry,
+          connectedClient,
+          connectionGeneration,
+          bufferedEvents.pendingToolsChanged.error,
+        );
+      }
       return cloneStatus(entry.status);
     } catch (error) {
       const exposedError = safeMcpOperationError(
@@ -642,15 +726,23 @@ export class McpClientManager {
         error,
         !signal.aborted,
       );
-      await safeClose(connected?.client ?? entry.client, connected?.transport ?? entry.transport);
+      await safeClose(
+        connected?.client ?? entry.client,
+        connected?.transport ?? entry.transport,
+        connected?.client.autoOpenedSubscription ?? entry.subscription,
+      );
       if (!connected || !entry.client || entry.client === connected.client) {
         entry.client = undefined;
         entry.transport = undefined;
         entry.stdioTransport = undefined;
+        entry.subscription = undefined;
         this.replaceToolSnapshot(entry, new Map());
         entry.connectionGeneration = undefined;
         entry.refreshState = undefined;
         entry.refreshNotificationState = undefined;
+        entry.enforceMcpHeaders = false;
+        entry.refreshDiagnostic = undefined;
+        entry.subscriptionDiagnostic = undefined;
       }
       if (signal.aborted) {
         if (!entry.closing && this.connections.get(serverId) === entry) {
@@ -686,54 +778,213 @@ export class McpClientManager {
       attachStderrTail(transport, entry, () => {
         if (this.connections.get(serverId) === entry) this.emit(entry.status);
       });
-      const client = this.createClient();
+      const { client, events } = this.createClient('legacy');
       const isClosed = this.watchClientClose(serverId, entry, client);
       try {
         await client.connect(transport, { timeout: this.timeouts.stdioConnectMs, signal });
-        return { client, transport, stdioTransport: transport, kind: 'stdio', isClosed };
+        return {
+          client,
+          events,
+          transport,
+          stdioTransport: transport,
+          kind: 'stdio',
+          isClosed,
+        };
       } catch (error) {
         await safeClose(client, transport);
         throw enrichStdioError(error, entry.status.stderrTail);
       }
     }
-    const remoteConfig = entry.config;
+    const remoteConfig: McpRemoteServerConfig = entry.config;
     const requested = remoteConfig.transport ?? 'auto';
+    const preference = resolveMcpRemoteProtocolPreference(remoteConfig);
+    if (requested === 'sse' && preference !== 'legacy') {
+      throw new Error(`MCP legacy SSE transport does not support protocol ${preference}`);
+    }
+    let streamableFailure: unknown;
     if (requested !== 'sse') {
-      const client = this.createClient();
+      const evidence = createStreamableHandshakeEvidence();
+      const { client, events } = this.createClient(preference);
       const transport = new StreamableHTTPClientTransport(new URL(remoteConfig.url), {
         requestInit: { headers: remoteConfig.headers },
+        fetch: evidence.fetch,
       });
       const isClosed = this.watchClientClose(serverId, entry, client);
       try {
         await client.connect(transport, { timeout: this.timeouts.remoteConnectMs, signal });
-        return { client, transport, kind: 'streamable-http', isClosed };
+        return { client, events, transport, kind: 'streamable-http', isClosed };
       } catch (error) {
+        const producedProtocolEvidence =
+          evidence.hasAcceptedInitialize() ||
+          client.getProtocolEra() !== undefined ||
+          client.getNegotiatedProtocolVersion() !== undefined;
         await safeClose(client, transport);
-        if (requested === 'streamable-http') throw error;
+        if (
+          !shouldFallbackToLegacySse({
+            remoteConfig,
+            error,
+            signal,
+            producedProtocolEvidence,
+          })
+        ) {
+          throw error;
+        }
+        streamableFailure = error;
       }
     }
-    const client = this.createClient();
+    const { client, events } = this.createClient('legacy');
     const transport = new SSEClientTransport(new URL(remoteConfig.url), {
       requestInit: { headers: remoteConfig.headers },
     });
     const isClosed = this.watchClientClose(serverId, entry, client);
     try {
       await client.connect(transport, { timeout: this.timeouts.remoteConnectMs, signal });
-      return { client, transport, kind: 'sse', isClosed };
+      return { client, events, transport, kind: 'sse', isClosed };
     } catch (error) {
       await safeClose(client, transport);
+      if (streamableFailure !== undefined) {
+        throw new AggregateError(
+          [streamableFailure, error],
+          'Streamable HTTP and legacy SSE connection attempts failed',
+        );
+      }
       throw error;
     }
   }
 
-  private createClient(): Client {
-    return new Client(
+  private createClient(preference: McpProtocolPreference): {
+    client: Client;
+    events: McpClientEventBridge;
+  } {
+    let bufferedClientError: Error | undefined;
+    let pendingToolsChanged: { error: Error | null } | undefined;
+    let liveHandlers:
+      | {
+          onClientError(error: Error): void;
+          onToolsChanged(error: Error | null): void;
+        }
+      | undefined;
+    const client = new Client(
       { name: this.clientName, version: this.clientVersion },
       {
         capabilities: {},
-        versionNegotiation: { mode: 'legacy' },
+        versionNegotiation: versionNegotiationFor(preference),
+        inputRequired: { autoFulfill: false },
         enforceStrictCapabilities: false,
+        listChanged: {
+          tools: {
+            autoRefresh: false,
+            debounceMs: 0,
+            onChanged: (error) => {
+              if (liveHandlers) {
+                liveHandlers.onToolsChanged(error);
+              } else {
+                pendingToolsChanged = { error };
+              }
+            },
+          },
+        },
       },
+    );
+    client.onerror = (error) => {
+      if (liveHandlers) {
+        liveHandlers.onClientError(error);
+      } else {
+        bufferedClientError = error;
+      }
+    };
+    return {
+      client,
+      events: {
+        activate: (handlers) => {
+          if (liveHandlers) throw new Error('MCP client event bridge is already active');
+          liveHandlers = handlers;
+          const result = {
+            clientErrors: bufferedClientError ? [bufferedClientError] : [],
+            ...(pendingToolsChanged ? { pendingToolsChanged } : {}),
+          };
+          bufferedClientError = undefined;
+          pendingToolsChanged = undefined;
+          return result;
+        },
+      },
+    };
+  }
+
+  private handleToolsChanged(
+    serverId: string,
+    entry: Connection,
+    client: Client,
+    connectionGeneration: number,
+    error: Error | null,
+  ): void {
+    if (!this.isCurrentClient(serverId, entry, client, connectionGeneration)) return;
+    if (error) {
+      const exposed = safeMcpOperationError(serverId, 'tool-list change signal failed', error);
+      entry.refreshDiagnostic = errorMessage(exposed);
+      this.publishConnectionDiagnostics(entry);
+      return;
+    }
+    void this.refreshToolsAfterNotification(serverId, entry, client, connectionGeneration).catch(
+      (failure) => {
+        if (!this.isCurrentClient(serverId, entry, client, connectionGeneration)) return;
+        entry.refreshDiagnostic = errorMessage(failure);
+        this.publishConnectionDiagnostics(entry);
+      },
+    );
+  }
+
+  private observeSubscriptionClose(
+    serverId: string,
+    entry: Connection,
+    client: Client,
+    connectionGeneration: number,
+    subscription: McpSubscription,
+  ): void {
+    void subscription.closed.then((reason) => {
+      if (reason === 'local' || entry.subscription !== subscription) return;
+      this.recordSubscriptionDiagnostic(
+        serverId,
+        entry,
+        client,
+        connectionGeneration,
+        formatSubscriptionDiagnostic(serverId, `closed ${reason}`),
+      );
+    });
+  }
+
+  private recordSubscriptionDiagnostic(
+    serverId: string,
+    entry: Connection,
+    client: Client,
+    connectionGeneration: number,
+    diagnostic: string,
+  ): void {
+    if (!this.isCurrentClient(serverId, entry, client, connectionGeneration)) return;
+    entry.subscriptionDiagnostic = diagnostic;
+    if (entry.status.state === 'connected') this.publishConnectionDiagnostics(entry);
+  }
+
+  private publishConnectionDiagnostics(entry: Connection): void {
+    if (entry.status.state !== 'connected') return;
+    this.update(entry, {
+      ...entry.status,
+      error: projectConnectionDiagnostics(entry),
+      updatedAt: this.now(),
+    });
+  }
+
+  private isCurrentClient(
+    serverId: string,
+    entry: Connection,
+    client: Client,
+    connectionGeneration: number,
+  ): boolean {
+    return (
+      this.connections.get(serverId) === entry &&
+      entry.client === client &&
+      entry.connectionGeneration === connectionGeneration &&
+      !entry.closing
     );
   }
 
@@ -784,12 +1035,9 @@ export class McpClientManager {
         let definitions: McpDiscoveredTool[] | undefined;
         let failure: unknown;
         try {
-          definitions = await listAllTools(
-            state.client,
-            serverId,
-            this.timeouts.listToolsMs,
-            state.signal,
-          );
+          definitions = shouldDiscoverTools(state.client)
+            ? await listAllTools(state.client, serverId, this.timeouts.listToolsMs, state.signal)
+            : [];
         } catch (error) {
           failure = error;
         }
@@ -804,7 +1052,10 @@ export class McpClientManager {
         if (failure !== undefined) {
           if (refreshSuppressed) throw this.toolRefreshFrequencyError(serverId);
           if (state.pending) continue;
-          throw safeMcpOperationError(serverId, 'tool refresh failed', failure);
+          const exposed = safeMcpOperationError(serverId, 'tool refresh failed', failure);
+          entry.refreshDiagnostic = errorMessage(exposed);
+          this.publishConnectionDiagnostics(entry);
+          throw exposed;
         }
         if (!definitions) {
           if (refreshSuppressed) throw this.toolRefreshFrequencyError(serverId);
@@ -815,6 +1066,7 @@ export class McpClientManager {
         const snapshot = createToolSnapshot(
           serverId,
           definitions,
+          entry.enforceMcpHeaders,
           this.bindingManagerId,
           state.connectionGeneration,
           entry.toolSnapshot,
@@ -826,13 +1078,14 @@ export class McpClientManager {
           throw this.toolRefreshFrequencyError(serverId);
         }
         if (state.pending) continue;
+        entry.refreshDiagnostic = undefined;
         if (!state.initial) {
           this.replaceToolSnapshot(entry, snapshot.entries);
           this.update(entry, {
             ...entry.status,
             tools: snapshot.descriptors,
             toolCount: snapshot.descriptors.length,
-            error: undefined,
+            error: projectConnectionDiagnostics(entry),
             updatedAt: this.now(),
           });
           if (!this.ownsToolRefresh(serverId, entry, state)) {
@@ -886,28 +1139,30 @@ export class McpClientManager {
     if (entry.closing || this.connections.get(serverId) !== entry || entry.client !== client) {
       return;
     }
+    const subscription = entry.subscription;
     entry.client = undefined;
     entry.transport = undefined;
     entry.stdioTransport = undefined;
+    entry.subscription = undefined;
     this.replaceToolSnapshot(entry, new Map());
     entry.connectionGeneration = undefined;
     entry.refreshState = undefined;
     entry.refreshNotificationState = undefined;
+    entry.enforceMcpHeaders = false;
+    entry.refreshDiagnostic = undefined;
+    entry.subscriptionDiagnostic = undefined;
+    void subscription?.close().catch(() => {});
     this.update(entry, {
-      ...entry.status,
-      state: 'disconnected',
-      toolCount: 0,
-      tools: [],
-      updatedAt: this.now(),
+      ...this.makeStatus(serverId, 'disconnected'),
+      stderrTail: entry.status.stderrTail,
     });
   }
 
   private markError(entry: Connection, error: unknown): void {
     this.update(entry, {
-      ...entry.status,
-      state: 'error',
+      ...this.makeStatus(entry.status.serverId, 'error'),
       error: errorMessage(error),
-      updatedAt: this.now(),
+      stderrTail: entry.status.stderrTail,
     });
   }
 
@@ -1022,16 +1277,125 @@ async function listAllTools(
   );
 }
 
+function versionNegotiationFor(preference: McpProtocolPreference): VersionNegotiationOptions {
+  switch (preference) {
+    case 'legacy':
+      return { mode: 'legacy' };
+    case 'auto':
+      return { mode: 'auto' };
+    case '2026-07-28':
+      return { mode: { pin: '2026-07-28' } };
+  }
+}
+
+function readNegotiatedProtocol(client: Client): McpNegotiatedProtocol {
+  const era = client.getProtocolEra();
+  const revision = client.getNegotiatedProtocolVersion();
+  if (!era || !revision) {
+    throw new Error('MCP SDK connected without a negotiated protocol');
+  }
+  return { era, revision };
+}
+
+function shouldDiscoverTools(client: Client): boolean {
+  return !(
+    client.getProtocolEra() === 'modern' && client.getServerCapabilities()?.tools === undefined
+  );
+}
+
+function shouldFallbackToLegacySse(options: {
+  remoteConfig: McpRemoteServerConfig;
+  error: unknown;
+  signal: AbortSignal;
+  producedProtocolEvidence: boolean;
+}): boolean {
+  const { remoteConfig, error, signal, producedProtocolEvidence } = options;
+  return (
+    (remoteConfig.transport ?? 'auto') === 'auto' &&
+    resolveMcpRemoteProtocolPreference(remoteConfig) !== '2026-07-28' &&
+    !producedProtocolEvidence &&
+    !signal.aborted &&
+    SdkHttpError.isInstance(error) &&
+    error.code === SdkErrorCode.ClientHttpNotImplemented &&
+    (error.status === 404 || error.status === 405)
+  );
+}
+
+function createStreamableHandshakeEvidence(): {
+  fetch: FetchLike;
+  hasAcceptedInitialize(): boolean;
+} {
+  let acceptedInitialize = false;
+  return {
+    fetch: async (url, init) => {
+      // SDK v2 emits notifications/initialized only after the initialize result
+      // has passed wire validation and its server identity/capabilities have
+      // been accepted. The SDK clears those getters when this notification's
+      // HTTP request fails, so retain this one bit outside the Client lifecycle.
+      if (readJsonRpcMethods(init?.body).includes('notifications/initialized')) {
+        acceptedInitialize = true;
+      }
+      return globalThis.fetch(url, init);
+    },
+    hasAcceptedInitialize: () => acceptedInitialize,
+  };
+}
+
+function readJsonRpcMethods(body: BodyInit | null | undefined): string[] {
+  if (typeof body !== 'string') return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return [];
+  }
+  return (Array.isArray(parsed) ? parsed : [parsed]).flatMap((message) =>
+    isRecord(message) && typeof message.method === 'string' ? [message.method] : [],
+  );
+}
+
+function formatSubscriptionDiagnostic(serverId: string, detail: string, cause?: unknown): string {
+  return errorMessage(
+    safeMcpOperationError(serverId, `tool-list subscription ${detail}`, cause, cause !== undefined),
+  );
+}
+
+function projectConnectionDiagnostics(entry: Connection): string | undefined {
+  const diagnostics = [entry.subscriptionDiagnostic, entry.refreshDiagnostic].filter(
+    (value): value is string => Boolean(value),
+  );
+  if (diagnostics.length === 0) return undefined;
+  return formatMcpDiagnosticText(diagnostics.join('\n'), MCP_ERROR_DIAGNOSTIC_CODE_POINTS);
+}
+
 function createToolSnapshot(
   serverId: string,
   definitions: readonly McpDiscoveredTool[],
+  enforceMcpHeaders: boolean,
   managerId: string,
   connectionGeneration: number,
   previousEntries?: ReadonlyMap<string, ToolSnapshotEntry>,
 ): { entries: Map<string, ToolSnapshotEntry>; descriptors: McpToolDescriptor[] } {
+  const tools = definitions.map(({ definition }) => definition);
+  const partition = enforceMcpHeaders
+    ? partitionMcpHeaderToolDefinitions(tools)
+    : {
+        valid: tools.map((tool) => ({ tool, declarations: [] })),
+        rejected: [],
+      };
+  const warning = formatMcpHeaderExclusionWarning(partition.rejected);
+  if (warning) console.warn(warning);
+
   const entries = new Map<string, ToolSnapshotEntry>();
   const descriptors: McpToolDescriptor[] = [];
-  for (const discovered of definitions) {
+  const discoveredByName = new Map(
+    definitions.map((definition) => [definition.definition.name, definition]),
+  );
+  for (const { tool, declarations } of partition.valid) {
+    const discovered = discoveredByName.get(tool.name);
+    if (!discovered) {
+      throw new Error(`MCP server "${serverId}" lost Tool "${tool.name}" during validation`);
+    }
     const definition = discovered.definition;
     const descriptor = descriptorFromTool(serverId, definition);
     const definitionFingerprint = discovered.definitionFingerprint;
@@ -1053,6 +1417,10 @@ function createToolSnapshot(
       descriptor,
       binding,
       connectionGeneration,
+      headerDeclarations: declarations.map((declaration) => ({
+        ...declaration,
+        path: [...declaration.path],
+      })),
       ...(previous?.connectionGeneration === connectionGeneration &&
       previous.definitionFingerprint === definitionFingerprint &&
       previous.callPreparation
@@ -1259,7 +1627,12 @@ function enrichStdioError(error: unknown, stderrTail?: string[]): Error {
   return new Error(`${errorMessage(error)}${suffix}`, { cause: error });
 }
 
-async function safeClose(client?: Client, transport?: Transport): Promise<void> {
+async function safeClose(
+  client?: Client,
+  transport?: Transport,
+  subscription?: McpSubscription,
+): Promise<void> {
+  await subscription?.close().catch(() => {});
   await client?.close().catch(() => {});
   await transport?.close().catch(() => {});
 }
@@ -1279,7 +1652,12 @@ function sortValue(value: unknown): unknown {
 }
 
 function cloneStatus(status: McpServerStatus): McpServerStatus {
-  return { ...status, tools: status.tools.map(cloneTool), stderrTail: status.stderrTail?.slice() };
+  return {
+    ...status,
+    negotiatedProtocol: status.negotiatedProtocol ? { ...status.negotiatedProtocol } : undefined,
+    tools: status.tools.map(cloneTool),
+    stderrTail: status.stderrTail?.slice(),
+  };
 }
 
 function cloneTool(tool: McpToolDescriptor): McpToolDescriptor {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -492,7 +492,7 @@ export class McpClientManager {
       throw new McpToolCallError(
         serverId,
         toolName,
-        `unsafe integer argument at ${headerArguments.path.join('.')}`,
+        `unsafe integer argument at ${formatMcpDiagnosticText(headerArguments.path.join('.'))}`,
       );
     }
     const preparation =

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -633,6 +633,15 @@ export class McpClientManager {
       entry.enforceMcpHeaders =
         connected.kind === 'streamable-http' && negotiatedProtocol.era === 'modern';
 
+      if (negotiatedProtocol.era === 'legacy') {
+        // Legacy servers commonly emit this notification without advertising
+        // the optional listChanged flag. Keep that compatibility at the
+        // manager boundary; modern connections use the SDK subscription path.
+        connectedClient.setNotificationHandler('notifications/tools/list_changed', async () => {
+          this.handleToolsChanged(serverId, entry, connectedClient, connectionGeneration, null);
+        });
+      }
+
       const bufferedEvents = connected.events.activate({
         onToolsChanged: (error) => {
           this.handleToolsChanged(serverId, entry, connectedClient, connectionGeneration, error);

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -160,10 +160,7 @@ interface OpenedMcpClient {
 }
 
 interface McpClientEventBridge {
-  activate(handlers: {
-    onClientError(error: Error): void;
-    onToolsChanged(error: Error | null): void;
-  }): {
+  activate(handlers: { onToolsChanged(error: Error | null): void }): {
     clientErrors: Error[];
     pendingToolsChanged?: { error: Error | null };
   };
@@ -618,7 +615,10 @@ export class McpClientManager {
         | { reason: 'unhonored' }
         | undefined;
       if (subscription && subscription.honoredFilter.toolsListChanged !== true) {
-        await subscription.close().catch(() => {});
+        // close() settles the handle locally before sending its cancellation
+        // notification. Do not let an uncooperative server hold setup open by
+        // never answering that best-effort notification.
+        void subscription.close().catch(() => {});
         subscription = undefined;
         subscriptionFailure = { reason: 'unhonored' };
       }
@@ -632,16 +632,6 @@ export class McpClientManager {
         connected.kind === 'streamable-http' && negotiatedProtocol.era === 'modern';
 
       const bufferedEvents = connected.events.activate({
-        onClientError: (error) => {
-          if (!expectsToolListSubscription) return;
-          this.recordSubscriptionDiagnostic(
-            serverId,
-            entry,
-            connectedClient,
-            connectionGeneration,
-            formatSubscriptionDiagnostic(serverId, 'reported an error', error),
-          );
-        },
         onToolsChanged: (error) => {
           this.handleToolsChanged(serverId, entry, connectedClient, connectionGeneration, error);
         },
@@ -811,7 +801,7 @@ export class McpClientManager {
       });
       const isClosed = this.watchClientClose(serverId, entry, client);
       try {
-        await client.connect(transport, { timeout: this.timeouts.remoteConnectMs, signal });
+        await connectRemoteCandidate(client, transport, this.timeouts.remoteConnectMs, signal);
         return { client, events, transport, kind: 'streamable-http', isClosed };
       } catch (error) {
         const producedProtocolEvidence =
@@ -838,7 +828,7 @@ export class McpClientManager {
     });
     const isClosed = this.watchClientClose(serverId, entry, client);
     try {
-      await client.connect(transport, { timeout: this.timeouts.remoteConnectMs, signal });
+      await connectRemoteCandidate(client, transport, this.timeouts.remoteConnectMs, signal);
       return { client, events, transport, kind: 'sse', isClosed };
     } catch (error) {
       await safeClose(client, transport);
@@ -860,7 +850,6 @@ export class McpClientManager {
     let pendingToolsChanged: { error: Error | null } | undefined;
     let liveHandlers:
       | {
-          onClientError(error: Error): void;
           onToolsChanged(error: Error | null): void;
         }
       | undefined;
@@ -887,11 +876,10 @@ export class McpClientManager {
       },
     );
     client.onerror = (error) => {
-      if (liveHandlers) {
-        liveHandlers.onClientError(error);
-      } else {
-        bufferedClientError = error;
-      }
+      // client.onerror is a client-wide transport channel. It can explain why
+      // the SDK failed to auto-open a subscription during connect, but after
+      // activation it cannot safely be attributed to that subscription.
+      if (!liveHandlers) bufferedClientError = error;
     };
     return {
       client,
@@ -1632,9 +1620,33 @@ async function safeClose(
   transport?: Transport,
   subscription?: McpSubscription,
 ): Promise<void> {
-  await subscription?.close().catch(() => {});
-  await client?.close().catch(() => {});
-  await transport?.close().catch(() => {});
+  const subscriptionClose = subscription?.close().catch(() => {});
+  await Promise.all([
+    subscriptionClose,
+    client?.close().catch(() => {}),
+    transport?.close().catch(() => {}),
+  ]);
+}
+
+async function connectRemoteCandidate(
+  client: Client,
+  transport: Transport,
+  timeout: number,
+  signal: AbortSignal,
+): Promise<void> {
+  const closeOnAbort = () => {
+    // SDK v2's server/discover probe currently uses its timeout but not the
+    // Client.connect signal. Closing the candidate transport aborts that probe
+    // instead of leaving a late handshake running after manager cancellation.
+    void transport.close().catch(() => {});
+  };
+  if (signal.aborted) closeOnAbort();
+  else signal.addEventListener('abort', closeOnAbort, { once: true });
+  try {
+    await client.connect(transport, { timeout, signal });
+  } finally {
+    signal.removeEventListener('abort', closeOnAbort);
+  }
 }
 
 function stableConfigFingerprint(config: McpServerConfig): string {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -690,6 +690,20 @@ export class McpClientManager {
         stderrTail: entry.status.stderrTail,
         updatedAt: this.now(),
       });
+      if (
+        signal.aborted ||
+        entry.closing ||
+        connected.isClosed() ||
+        entry.client !== connectedClient ||
+        entry.connectionGeneration !== connectionGeneration
+      ) {
+        throw safeMcpOperationError(
+          serverId,
+          'connection changed during tool discovery',
+          undefined,
+        );
+      }
+      publishMcpHeaderExclusionWarning(snapshot.warning);
       if (subscription) {
         this.observeSubscriptionClose(
           serverId,
@@ -916,7 +930,9 @@ export class McpClientManager {
     void this.refreshToolsAfterNotification(serverId, entry, client, connectionGeneration).catch(
       (failure) => {
         if (!this.isCurrentClient(serverId, entry, client, connectionGeneration)) return;
-        entry.refreshDiagnostic = errorMessage(failure);
+        const diagnostic = errorMessage(failure);
+        if (entry.refreshDiagnostic === diagnostic) return;
+        entry.refreshDiagnostic = diagnostic;
         this.publishConnectionDiagnostics(entry);
       },
     );
@@ -1043,6 +1059,18 @@ export class McpClientManager {
           const exposed = safeMcpOperationError(serverId, 'tool refresh failed', failure);
           entry.refreshDiagnostic = errorMessage(exposed);
           this.publishConnectionDiagnostics(entry);
+          if (
+            this.connections.get(serverId) !== entry ||
+            entry.client !== state.client ||
+            entry.connectionGeneration !== state.connectionGeneration ||
+            entry.status.state !== 'connected'
+          ) {
+            throw safeMcpOperationError(
+              serverId,
+              'connection changed during tool refresh',
+              failure,
+            );
+          }
           throw exposed;
         }
         if (!definitions) {
@@ -1066,6 +1094,7 @@ export class McpClientManager {
           throw this.toolRefreshFrequencyError(serverId);
         }
         if (state.pending) continue;
+        publishMcpHeaderExclusionWarning(snapshot.warning);
         entry.refreshDiagnostic = undefined;
         if (!state.initial) {
           this.replaceToolSnapshot(entry, snapshot.entries);
@@ -1356,6 +1385,15 @@ function projectConnectionDiagnostics(entry: Connection): string | undefined {
   return formatMcpDiagnosticText(diagnostics.join('\n'), MCP_ERROR_DIAGNOSTIC_CODE_POINTS);
 }
 
+function publishMcpHeaderExclusionWarning(warning: string | undefined): void {
+  if (!warning) return;
+  try {
+    console.warn(warning);
+  } catch {
+    // A diagnostic sink cannot roll back an already-published Tool snapshot.
+  }
+}
+
 function createToolSnapshot(
   serverId: string,
   definitions: readonly McpDiscoveredTool[],
@@ -1363,7 +1401,11 @@ function createToolSnapshot(
   managerId: string,
   connectionGeneration: number,
   previousEntries?: ReadonlyMap<string, ToolSnapshotEntry>,
-): { entries: Map<string, ToolSnapshotEntry>; descriptors: McpToolDescriptor[] } {
+): {
+  entries: Map<string, ToolSnapshotEntry>;
+  descriptors: McpToolDescriptor[];
+  warning?: string;
+} {
   const tools = definitions.map(({ definition }) => definition);
   const partition = enforceMcpHeaders
     ? partitionMcpHeaderToolDefinitions(tools)
@@ -1372,7 +1414,6 @@ function createToolSnapshot(
         rejected: [],
       };
   const warning = formatMcpHeaderExclusionWarning(partition.rejected);
-  if (warning) console.warn(warning);
 
   const entries = new Map<string, ToolSnapshotEntry>();
   const descriptors: McpToolDescriptor[] = [];
@@ -1417,7 +1458,7 @@ function createToolSnapshot(
     });
     descriptors.push(descriptor);
   }
-  return { entries, descriptors };
+  return { entries, descriptors, ...(warning ? { warning } : {}) };
 }
 
 function descriptorFromTool(serverId: string, tool: Tool): McpToolDescriptor {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1048,12 +1048,6 @@ export class McpClientManager {
         if (!this.ownsToolRefresh(serverId, entry, state)) {
           throw safeMcpOperationError(serverId, 'connection changed during tool refresh', failure);
         }
-        // A notification that arrived while this list was in flight supersedes
-        // its result: skip the stale publish and let the trailing notification
-        // pass own the snapshot. A manual refresh queued during the list is
-        // different: its result is still a valid latest snapshot, so publish it
-        // below and only then run the trailing pass.
-        if (state.pendingNotification) continue;
         const notificationState = entry.refreshNotificationState;
         const notificationStateMatches =
           notificationState?.client === state.client &&

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1640,8 +1640,13 @@ async function connectRemoteCandidate(
     // instead of leaving a late handshake running after manager cancellation.
     void transport.close().catch(() => {});
   };
-  if (signal.aborted) closeOnAbort();
-  else signal.addEventListener('abort', closeOnAbort, { once: true });
+  if (signal.aborted) {
+    await transport.close().catch(() => {});
+    throw signal.reason instanceof Error
+      ? signal.reason
+      : new Error(String(signal.reason ?? 'MCP connection aborted'));
+  }
+  signal.addEventListener('abort', closeOnAbort, { once: true });
   try {
     await client.connect(transport, { timeout, signal });
   } finally {

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -399,8 +399,10 @@ export class McpClientManager {
       pendingNotification: notification,
       promise: Promise.resolve({ descriptors: [], suppressed: false }),
     };
-    state.promise = this.refreshToolLoop(serverId, entry, state);
     entry.refreshState = state;
+    // Start on the next microtask so the generation-owned gate is installed
+    // before even a synchronous no-capability refresh can settle and release it.
+    state.promise = Promise.resolve().then(() => this.refreshToolLoop(serverId, entry, state));
     return state.promise;
   }
 

--- a/packages/mcp/src/sep-2243.ts
+++ b/packages/mcp/src/sep-2243.ts
@@ -1,0 +1,272 @@
+import { formatMcpDiagnosticText } from './diagnostic-text.js';
+
+const X_MCP_HEADER = 'x-mcp-header';
+const RFC_9110_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/u;
+
+const UNREACHABLE_SCHEMA_KEYWORDS = [
+  'items',
+  'prefixItems',
+  'contains',
+  'additionalProperties',
+  'unevaluatedProperties',
+  'unevaluatedItems',
+  'propertyNames',
+  'patternProperties',
+  'dependentSchemas',
+  'oneOf',
+  'anyOf',
+  'allOf',
+  'not',
+  'if',
+  'then',
+  'else',
+  '$defs',
+  'definitions',
+] as const;
+
+const SCHEMA_MAP_KEYWORDS = new Set([
+  'patternProperties',
+  'dependentSchemas',
+  '$defs',
+  'definitions',
+]);
+
+const WARNING_SAMPLE_LIMIT = 5;
+export const MCP_HEADER_WARNING_LENGTH_LIMIT = 512;
+
+export type McpHeaderPrimitiveType = 'string' | 'integer' | 'boolean';
+
+export type McpHeaderDefinitionReasonCode =
+  | 'not_statically_reachable'
+  | 'annotation_not_string'
+  | 'header_name_empty'
+  | 'header_name_invalid'
+  | 'property_type_unsupported'
+  | 'header_name_duplicate';
+
+export interface McpHeaderDeclaration {
+  readonly path: readonly string[];
+  readonly headerName: string;
+  readonly type: McpHeaderPrimitiveType;
+}
+
+export interface McpHeaderDefinitionIssue {
+  readonly code: McpHeaderDefinitionReasonCode;
+  readonly path: readonly string[];
+}
+
+export type McpHeaderDefinitionValidation =
+  | {
+      readonly valid: true;
+      readonly declarations: readonly McpHeaderDeclaration[];
+    }
+  | {
+      readonly valid: false;
+      readonly issue: McpHeaderDefinitionIssue;
+    };
+
+export interface McpHeaderToolDefinitionLike {
+  readonly name: string;
+  readonly inputSchema: unknown;
+}
+
+export interface ValidMcpHeaderTool<T extends McpHeaderToolDefinitionLike> {
+  readonly tool: T;
+  readonly declarations: readonly McpHeaderDeclaration[];
+}
+
+export interface McpHeaderToolRejection {
+  readonly toolName: string;
+  readonly issue: McpHeaderDefinitionIssue;
+}
+
+export interface McpHeaderToolPartition<T extends McpHeaderToolDefinitionLike> {
+  readonly valid: readonly ValidMcpHeaderTool<T>[];
+  readonly rejected: readonly McpHeaderToolRejection[];
+}
+
+export type McpHeaderArgumentValidation =
+  | { readonly valid: true }
+  | {
+      readonly valid: false;
+      readonly code: 'unsafe_integer_argument';
+      readonly path: readonly string[];
+    };
+
+/**
+ * Validate the narrow SEP-2243 schema extension without becoming a general
+ * JSON Schema evaluator. A declaration is reachable only through `properties`
+ * keys; finding one in a dynamic or composed subschema invalidates the Tool.
+ */
+export function validateMcpHeaderDefinition(inputSchema: unknown): McpHeaderDefinitionValidation {
+  const declarations: McpHeaderDeclaration[] = [];
+  const headerPaths = new Map<string, readonly string[]>();
+
+  const visit = (
+    value: unknown,
+    path: readonly string[],
+    staticallyReachable: boolean,
+  ): McpHeaderDefinitionIssue | undefined => {
+    if (!isRecord(value)) return undefined;
+
+    if (X_MCP_HEADER in value) {
+      if (!staticallyReachable || path.length === 0) {
+        return { code: 'not_statically_reachable', path };
+      }
+
+      const headerName = value[X_MCP_HEADER];
+      if (typeof headerName !== 'string') {
+        return { code: 'annotation_not_string', path };
+      }
+      if (headerName.length === 0) {
+        return { code: 'header_name_empty', path };
+      }
+      if (!RFC_9110_TOKEN.test(headerName)) {
+        return { code: 'header_name_invalid', path };
+      }
+
+      const type = value.type;
+      if (!isMcpHeaderPrimitiveType(type)) {
+        return { code: 'property_type_unsupported', path };
+      }
+
+      const normalizedHeaderName = headerName.toLowerCase();
+      if (headerPaths.has(normalizedHeaderName)) {
+        return { code: 'header_name_duplicate', path };
+      }
+      headerPaths.set(normalizedHeaderName, path);
+      declarations.push({ path, headerName, type });
+    }
+
+    if (isRecord(value.properties)) {
+      for (const [propertyName, propertySchema] of Object.entries(value.properties)) {
+        const issue = visit(propertySchema, [...path, propertyName], staticallyReachable);
+        if (issue) return issue;
+      }
+    }
+
+    for (const keyword of UNREACHABLE_SCHEMA_KEYWORDS) {
+      const subschema = value[keyword];
+      if (subschema === undefined) continue;
+      const branches =
+        Array.isArray(subschema) || !SCHEMA_MAP_KEYWORDS.has(keyword) || !isRecord(subschema)
+          ? asArray(subschema)
+          : Object.values(subschema);
+      for (const branch of branches) {
+        const issue = visit(branch, [...path, `<${keyword}>`], false);
+        if (issue) return issue;
+      }
+    }
+
+    return undefined;
+  };
+
+  const issue = visit(inputSchema, [], true);
+  return issue ? { valid: false, issue } : { valid: true, declarations };
+}
+
+/**
+ * Partition independently so one malformed server Tool cannot hide valid
+ * siblings. The returned Tool references are unchanged.
+ */
+export function partitionMcpHeaderToolDefinitions<T extends McpHeaderToolDefinitionLike>(
+  tools: readonly T[],
+): McpHeaderToolPartition<T> {
+  const valid: ValidMcpHeaderTool<T>[] = [];
+  const rejected: McpHeaderToolRejection[] = [];
+
+  for (const tool of tools) {
+    const validation = validateMcpHeaderDefinition(tool.inputSchema);
+    if (validation.valid) {
+      valid.push({ tool, declarations: validation.declarations });
+    } else {
+      rejected.push({ toolName: tool.name, issue: validation.issue });
+    }
+  }
+
+  return { valid, rejected };
+}
+
+/**
+ * Produce one log-safe diagnostic per refresh. It exposes stable reason codes,
+ * never raw schemas or arguments, and remains bounded even for hostile names.
+ */
+export function formatMcpHeaderExclusionWarning(
+  rejections: readonly McpHeaderToolRejection[],
+): string | undefined {
+  if (rejections.length === 0) return undefined;
+
+  const candidates = rejections
+    .slice(0, WARNING_SAMPLE_LIMIT)
+    .map(
+      ({ toolName, issue }) =>
+        `${JSON.stringify(formatMcpDiagnosticText(toolName))} [${issue.code}]`,
+    );
+  const prefix =
+    `MCP tool discovery excluded ${rejections.length} Tool definition(s) with invalid ` +
+    'x-mcp-header annotations';
+
+  // Reserve room for the omitted count and prefer fewer complete samples over
+  // slicing through a Tool name or stable reason code.
+  for (let sampleCount = candidates.length; sampleCount >= 0; sampleCount -= 1) {
+    const omitted = rejections.length - sampleCount;
+    const sample = candidates.slice(0, sampleCount).join(', ');
+    const detail = sample ? `: ${sample}` : '';
+    const suffix = omitted > 0 ? `; ${omitted} more not shown` : '';
+    const warning = `${prefix}${detail}${suffix}`;
+    if (warning.length <= MCP_HEADER_WARNING_LENGTH_LIMIT) return warning;
+  }
+
+  return truncateRenderedWarning(prefix);
+}
+
+/**
+ * Enforce the SEP-2243 safe-integer rule after arguments exist but before the
+ * caller enters the HTTP transport.
+ */
+export function validateMcpHeaderArguments(
+  declarations: readonly McpHeaderDeclaration[],
+  args: Readonly<Record<string, unknown>>,
+): McpHeaderArgumentValidation {
+  for (const declaration of declarations) {
+    if (declaration.type !== 'integer') continue;
+    const value = valueAtPath(args, declaration.path);
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'number' && Number.isInteger(value) && !Number.isSafeInteger(value)) {
+      return {
+        valid: false,
+        code: 'unsafe_integer_argument',
+        path: declaration.path,
+      };
+    }
+  }
+  return { valid: true };
+}
+
+function isMcpHeaderPrimitiveType(value: unknown): value is McpHeaderPrimitiveType {
+  return value === 'string' || value === 'integer' || value === 'boolean';
+}
+
+function asArray(value: unknown): readonly unknown[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+function valueAtPath(root: unknown, path: readonly string[]): unknown {
+  let value = root;
+  for (const segment of path) {
+    if (!isRecord(value)) return undefined;
+    value = value[segment];
+  }
+  return value;
+}
+
+function truncateRenderedWarning(value: string): string {
+  if (value.length <= MCP_HEADER_WARNING_LENGTH_LIMIT) return value;
+  const end = MCP_HEADER_WARNING_LENGTH_LIMIT - 1;
+  const safeEnd = end > 0 && /[\uD800-\uDBFF]/u.test(value[end - 1] ?? '') ? end - 1 : end;
+  return `${value.slice(0, safeEnd)}\u2026`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/__tests__/mcp-tools.test.ts
+++ b/packages/runtime/src/__tests__/mcp-tools.test.ts
@@ -9,6 +9,7 @@ import type {
   McpToolDescriptor,
 } from '@maka/core/mcp';
 import { buildMcpTools, mcpProxyToolName, type McpToolProvider } from '../mcp-tools.js';
+import { selectCollaborationTools } from '../plan-mode.js';
 
 test('buildMcpTools projects discovery, abort, and rich model output', async () => {
   const readBinding = binding('internal-read-binding');
@@ -166,6 +167,21 @@ test('MCP annotations cannot lower permissions and model output has aggregate bo
   assert.ok(text.length <= 200_000);
   assert.equal(images.length, 4);
   assert.doesNotMatch(text, /secretBlob/u);
+});
+
+test('MCP tools stay network sends and are excluded from Plan mode', () => {
+  const tools = buildMcpTools(
+    fakeProvider(
+      [boundTool(descriptor('untrusted', 'claims-read-only', true), binding('plan-binding'))],
+      async () => ({ content: [{ type: 'text', text: 'unused' }] }),
+    ),
+  );
+
+  assert.equal(tools[0]?.categoryHint, 'network_send');
+  assert.deepEqual(
+    selectCollaborationTools({ mode: 'plan', tools, hasActiveExecution: false }),
+    [],
+  );
 });
 
 test('a trusted composition can apply the Client Capability permission floor and context', async () => {

--- a/packages/storage/src/__tests__/mcp-config-store.test.ts
+++ b/packages/storage/src/__tests__/mcp-config-store.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, test } from 'node:test';
+import { MCP_CONFIG_VERSION, resolveMcpRemoteProtocolPreference } from '@maka/core/mcp';
 import { createMcpConfigStore, normalizeMcpConfig } from '../mcp-config-store.js';
 
 const roots: string[] = [];
@@ -13,7 +14,7 @@ afterEach(async () =>
 test('creates and atomically updates a Claude-compatible mcp.json', async () => {
   const root = await tempRoot();
   const store = createMcpConfigStore(root);
-  assert.deepEqual(await store.get(), { version: 1, mcpServers: {} });
+  assert.deepEqual(await store.get(), { version: 2, mcpServers: {} });
   const next = await store.upsert('filesystem', {
     command: 'npx',
     args: ['-y', 'server'],
@@ -31,6 +32,144 @@ test('creates and atomically updates a Claude-compatible mcp.json', async () => 
     assert.equal((await stat(join(root, 'mcp.json'))).mode & 0o777, 0o600);
   await store.remove('filesystem');
   assert.deepEqual((await store.get()).mcpServers, {});
+});
+
+test('reads version 1 without rewriting and persists version 2 on the next mutation', async () => {
+  const root = await tempRoot();
+  const path = join(root, 'mcp.json');
+  const legacyText = `${JSON.stringify(
+    {
+      version: 1,
+      mcpServers: {
+        remote: { enabled: false, url: 'https://example.com/mcp' },
+      },
+    },
+    null,
+    2,
+  )}\n`;
+  await writeFile(path, legacyText, 'utf8');
+
+  const store = createMcpConfigStore(root);
+  const migrated = await store.get();
+  assert.equal(migrated.version, 2);
+  assert.deepEqual(migrated.mcpServers.remote, {
+    enabled: false,
+    url: 'https://example.com/mcp',
+    transport: 'auto',
+  });
+  assert.equal(await readFile(path, 'utf8'), legacyText);
+
+  await store.upsert('local', { command: 'node' });
+  const persisted = JSON.parse(await readFile(path, 'utf8')) as {
+    version: number;
+    mcpServers: Record<string, Record<string, unknown>>;
+  };
+  assert.equal(persisted.version, 2);
+  assert.equal(Object.hasOwn(persisted.mcpServers.remote, 'protocol'), false);
+});
+
+test('reads a missing wrapper version as version 1 without rewriting it', async () => {
+  const root = await tempRoot();
+  const path = join(root, 'mcp.json');
+  const legacyText = '{"mcpServers":{"remote":{"url":"https://example.com/mcp"}}}\n';
+  await writeFile(path, legacyText, 'utf8');
+
+  const migrated = await createMcpConfigStore(root).get();
+  const remote = migrated.mcpServers.remote;
+  assert.ok(remote && 'url' in remote);
+  assert.equal(migrated.version, 2);
+  assert.equal(Object.hasOwn(remote, 'protocol'), false);
+  assert.equal(resolveMcpRemoteProtocolPreference(remote), 'legacy');
+  assert.equal(await readFile(path, 'utf8'), legacyText);
+});
+
+test('round-trips every version 2 remote protocol preference', () => {
+  for (const protocol of ['legacy', 'auto', '2026-07-28'] as const) {
+    const normalized = normalizeMcpConfig({
+      version: 2,
+      mcpServers: {
+        remote: {
+          url: 'https://example.com/mcp',
+          transport: 'streamable-http',
+          protocol,
+        },
+      },
+    });
+    assert.deepEqual(normalized.mcpServers.remote, {
+      enabled: true,
+      url: 'https://example.com/mcp',
+      transport: 'streamable-http',
+      protocol,
+    });
+  }
+  assert.throws(
+    () =>
+      normalizeMcpConfig({
+        version: 2,
+        mcpServers: {
+          remote: { url: 'https://example.com/mcp', protocol: 'future' },
+        },
+      }),
+    /remote\.protocol is invalid/u,
+  );
+});
+
+test('rejects protocol fields under missing or version 1 wrappers', () => {
+  assert.throws(
+    () =>
+      normalizeMcpConfig({
+        version: 1,
+        mcpServers: {
+          remote: { url: 'https://example.com/mcp', protocol: 'legacy' },
+        },
+      }),
+    /version 1 must not contain "protocol"/u,
+  );
+  assert.throws(
+    () =>
+      normalizeMcpConfig({
+        mcpServers: {
+          remote: { url: 'https://example.com/mcp', protocol: undefined },
+        },
+      }),
+    /without a version must not contain "protocol"/u,
+  );
+});
+
+test('rejects protocol on version 2 stdio servers', () => {
+  assert.throws(
+    () =>
+      normalizeMcpConfig({
+        version: 2,
+        mcpServers: { local: { command: 'node', protocol: 'legacy' } },
+      }),
+    /protocol is not supported for stdio in version 2/u,
+  );
+});
+
+test('allows SSE only with an omitted or explicit legacy protocol', () => {
+  for (const config of [
+    { url: 'https://example.com/sse', transport: 'sse' },
+    { url: 'https://example.com/sse', transport: 'sse', protocol: 'legacy' },
+  ] as const) {
+    assert.doesNotThrow(() => normalizeMcpConfig({ version: 2, mcpServers: { remote: config } }));
+  }
+  for (const protocol of ['auto', '2026-07-28'] as const) {
+    assert.throws(
+      () =>
+        normalizeMcpConfig({
+          version: 2,
+          mcpServers: {
+            remote: {
+              url: 'https://example.com/sse',
+              transport: 'sse',
+              protocol,
+            },
+          },
+        }),
+      /transport "sse" requires protocol "legacy"/u,
+    );
+  }
 });
 
 test('serializes concurrent updates without corrupting the file', async () => {
@@ -60,22 +199,97 @@ test('rejects corrupt files and unsafe or invalid configs', async () => {
   await writeFile(join(root, 'mcp.json'), '{bad', 'utf8');
   await assert.rejects(createMcpConfigStore(root).get(), /JSON/u);
   assert.throws(
-    () => normalizeMcpConfig({ version: 1, mcpServers: { constructor: { command: 'x' } } }),
+    () =>
+      normalizeMcpConfig({
+        version: 2,
+        mcpServers: { constructor: { command: 'x' } },
+      }),
     /Invalid server id/u,
   );
   assert.throws(
-    () => normalizeMcpConfig({ version: 1, mcpServers: { bad: { url: 'file:///tmp/x' } } }),
+    () =>
+      normalizeMcpConfig({
+        version: 2,
+        mcpServers: { bad: { url: 'file:///tmp/x' } },
+      }),
     /http or https/u,
   );
   assert.throws(
     () =>
       normalizeMcpConfig({
-        version: 1,
+        version: 2,
         mcpServers: { bad: { url: 'https://user:secret@example.com/mcp' } },
       }),
     /embedded credentials/u,
   );
-  assert.throws(() => normalizeMcpConfig({ version: 2, mcpServers: {} }), /Unsupported/u);
+  assert.throws(() => normalizeMcpConfig({ version: 3, mcpServers: {} }), /Unsupported/u);
+});
+
+test('leaves a higher-version file untouched when it is rejected', async () => {
+  const root = await tempRoot();
+  const path = join(root, 'mcp.json');
+  const futureText = '{"version":3,"mcpServers":{}}\n';
+  await writeFile(path, futureText, 'utf8');
+
+  const store = createMcpConfigStore(root);
+  await assert.rejects(store.get(), /Unsupported MCP config version: 3/u);
+  await assert.rejects(
+    store.set({ version: MCP_CONFIG_VERSION, mcpServers: {} }),
+    /Unsupported MCP config version: 3/u,
+  );
+  assert.equal(await readFile(path, 'utf8'), futureText);
+});
+
+test('full replacement preserves future wrappers but can repair malformed current data', async () => {
+  const root = await tempRoot();
+  const path = join(root, 'mcp.json');
+  const store = createMcpConfigStore(root);
+
+  for (const futureText of [
+    '{"version":"future","mcpServers":{}}\n',
+    '{"version":0,"mcpServers":{}}\n',
+  ]) {
+    await writeFile(path, futureText, 'utf8');
+    await assert.rejects(
+      store.set({ version: MCP_CONFIG_VERSION, mcpServers: {} }),
+      /Unsupported MCP config version/u,
+    );
+    assert.equal(await readFile(path, 'utf8'), futureText);
+  }
+
+  await writeFile(path, '{malformed', 'utf8');
+  await store.set({
+    version: MCP_CONFIG_VERSION,
+    mcpServers: { repaired: { command: 'node' } },
+  });
+  assert.deepEqual(await store.get(), {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: { repaired: { enabled: true, command: 'node' } },
+  });
+});
+
+test('full replacement can migrate an existing version 1 wrapper to version 2', async () => {
+  const root = await tempRoot();
+  const path = join(root, 'mcp.json');
+  await writeFile(path, '{"version":1,"mcpServers":{"old":{"command":"node"}}}\n', 'utf8');
+
+  const store = createMcpConfigStore(root);
+  await store.set({
+    version: MCP_CONFIG_VERSION,
+    mcpServers: { remote: { url: 'https://example.com/mcp', protocol: 'auto' } },
+  });
+
+  assert.deepEqual(JSON.parse(await readFile(path, 'utf8')), {
+    version: MCP_CONFIG_VERSION,
+    mcpServers: {
+      remote: {
+        enabled: true,
+        url: 'https://example.com/mcp',
+        transport: 'auto',
+        protocol: 'auto',
+      },
+    },
+  });
 });
 
 async function tempRoot(): Promise<string> {

--- a/packages/storage/src/mcp-config-store.ts
+++ b/packages/storage/src/mcp-config-store.ts
@@ -5,6 +5,7 @@ import {
   MCP_CONFIG_VERSION,
   createDefaultMcpConfig,
   type McpConfigFile,
+  type McpProtocolPreference,
   type McpRemoteServerConfig,
   type McpServerConfig,
   type McpStdioServerConfig,
@@ -29,16 +30,19 @@ export function createMcpConfigStore(workspaceRoot: string): McpConfigStore {
 
 export function normalizeMcpConfig(value: unknown): McpConfigFile {
   if (!isRecord(value)) throw new Error('MCP config must be an object');
-  if (value.version !== undefined && value.version !== MCP_CONFIG_VERSION) {
-    throw new Error(`Unsupported MCP config version: ${String(value.version)}`);
-  }
+  const sourceVersion = supportedSourceVersion(value);
   if (!isRecord(value.mcpServers)) throw new Error('mcpServers must be an object');
   const entries = Object.entries(value.mcpServers);
   if (entries.length > MAX_SERVERS) throw new Error(`mcpServers exceeds ${MAX_SERVERS} entries`);
   const mcpServers: Record<string, McpServerConfig> = Object.create(null);
   for (const [serverId, raw] of entries) {
     assertSafeKey(serverId, 'server id');
-    mcpServers[serverId] = normalizeServer(raw, serverId);
+    mcpServers[serverId] = normalizeServer(
+      raw,
+      serverId,
+      sourceVersion,
+      value.version === undefined,
+    );
   }
   return { version: MCP_CONFIG_VERSION, mcpServers: { ...mcpServers } };
 }
@@ -55,6 +59,7 @@ class FileMcpConfigStore implements McpConfigStore {
   async set(config: McpConfigFile): Promise<McpConfigFile> {
     const normalized = normalizeMcpConfig(config);
     return this.serial(async () => {
+      await this.assertCurrentVersionCanBeReplaced();
       await this.write(normalized);
       return normalized;
     });
@@ -117,6 +122,27 @@ class FileMcpConfigStore implements McpConfigStore {
     }
   }
 
+  private async assertCurrentVersionCanBeReplaced(): Promise<void> {
+    let text: string;
+    try {
+      text = await readFile(this.path, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
+      throw error;
+    }
+    let current: unknown;
+    try {
+      current = JSON.parse(text);
+    } catch {
+      // Full replacement is the explicit recovery path for malformed files.
+      return;
+    }
+    if (!isRecord(current)) return;
+    // A client that does not understand a future wrapper must not erase it.
+    // Reuse the normal read boundary so this guard advances with the schema.
+    supportedSourceVersion(current);
+  }
+
   private async serial<T>(operation: () => Promise<T>): Promise<T> {
     const previous = this.queue;
     let release!: () => void;
@@ -132,10 +158,23 @@ class FileMcpConfigStore implements McpConfigStore {
   }
 }
 
-function normalizeServer(value: unknown, serverId: string): McpServerConfig {
+function normalizeServer(
+  value: unknown,
+  serverId: string,
+  sourceVersion: 1 | typeof MCP_CONFIG_VERSION,
+  versionMissing: boolean,
+): McpServerConfig {
   if (!isRecord(value)) throw new Error(`MCP server "${serverId}" must be an object`);
+  const hasProtocol = Object.hasOwn(value, 'protocol');
+  if (sourceVersion === 1 && hasProtocol) {
+    const source = versionMissing ? 'without a version' : 'version 1';
+    throw new Error(`MCP config ${source} must not contain "protocol"`);
+  }
   const enabled = value.enabled === undefined ? true : bool(value.enabled, `${serverId}.enabled`);
   if (typeof value.command === 'string') {
+    if (hasProtocol) {
+      throw new Error(`${serverId}.protocol is not supported for stdio in version 2`);
+    }
     const result: McpStdioServerConfig = {
       enabled,
       command: nonEmptyString(value.command, `${serverId}.command`),
@@ -162,13 +201,30 @@ function normalizeServer(value: unknown, serverId: string): McpServerConfig {
   if (transport !== 'auto' && transport !== 'streamable-http' && transport !== 'sse') {
     throw new Error(`${serverId}.transport is invalid`);
   }
-  const result: McpRemoteServerConfig = { enabled, url: parsed.toString(), transport };
+  const protocol = protocolPreference(value.protocol, `${serverId}.protocol`);
+  if (transport === 'sse' && protocol !== undefined && protocol !== 'legacy') {
+    throw new Error(`${serverId}.transport "sse" requires protocol "legacy"`);
+  }
+  const result: McpRemoteServerConfig = {
+    enabled,
+    url: parsed.toString(),
+    transport,
+  };
   if (value.headers !== undefined) result.headers = stringMap(value.headers, `${serverId}.headers`);
+  if (protocol !== undefined) result.protocol = protocol;
   return result;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function supportedSourceVersion(value: Record<string, unknown>): 1 | typeof MCP_CONFIG_VERSION {
+  const sourceVersion = value.version === undefined ? 1 : value.version;
+  if (sourceVersion !== 1 && sourceVersion !== MCP_CONFIG_VERSION) {
+    throw new Error(`Unsupported MCP config version: ${String(value.version)}`);
+  }
+  return sourceVersion;
 }
 
 function assertSafeKey(value: string, label: string): void {
@@ -187,6 +243,14 @@ function nonEmptyString(value: unknown, label: string): string {
 
 function bool(value: unknown, label: string): boolean {
   if (typeof value !== 'boolean') throw new Error(`${label} must be boolean`);
+  return value;
+}
+
+function protocolPreference(value: unknown, label: string): McpProtocolPreference | undefined {
+  if (value === undefined) return undefined;
+  if (value !== 'legacy' && value !== 'auto' && value !== '2026-07-28') {
+    throw new Error(`${label} is invalid`);
+  }
   return value;
 }
 


### PR DESCRIPTION
## Summary

- Add a versioned remote MCP protocol preference while preserving omitted v1 config as legacy and writing new remote entries as explicit `auto`.
- Negotiate legacy or `2026-07-28` Streamable HTTP sessions, keep SSE fallback limited to typed pre-identity 404/405 failures, and expose the negotiated protocol in Desktop status.
- Route initial discovery, manual refresh, legacy notifications, and modern subscriptions through the existing generation-owned discovery transaction and immutable Tool snapshot.
- Apply bounded SEP-2243 Tool partitioning and call-time integer checks without creating a second callable registry or bypassing Runtime execution boundaries.

Refs #1650

Depends on #2663. This is a cross-fork follow-up, so it remains a draft against `main`; until #2663 lands, the PR 2-only diff is:

https://github.com/me2seeks/maka-agent/compare/fix/1650-mcp-discovery-transaction...feat/1650-mcp-remote-dual-era-v2

## Verification

- Rebased onto the current `main` through the updated #2663 stack
- `npm --workspace @maka/mcp test` — 104/104
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- GitHub CI — all checks passed on the rebased head

I did not run a live public MCP endpoint or an Electron click-through smoke test.

## Review focus

`replaceToolSnapshot()` remains the only callable publication transaction. Protocol status, subscription diagnostics, and renderer state are projections; they do not own Tool bindings or a separate revision. Every refresh signal advances the same connection-generation epoch, and publication is fenced before and after synchronous listeners.

Modern stdio and config v3 remain the next RFC slice rather than being enabled here.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No


## Visual evidence

The real Desktop Storybook surfaces cover both requested states. SSE fixes the protocol preference to Legacy; the installed-server inspector projects the protocol actually negotiated by the MCP manager.

| Remote add/edit — SSE forces Legacy | Installed server — negotiated protocol |
| --- | --- |
| ![Remote MCP editor with SSE-forced Legacy protocol preference](https://raw.githubusercontent.com/me2seeks/maka-agent/8b84de3275b35f0db7fb6ee367a9bf164538b772/pr-2670-sse-editor.png) | ![Installed MCP server details with negotiated protocol](https://raw.githubusercontent.com/me2seeks/maka-agent/8b84de3275b35f0db7fb6ee367a9bf164538b772/pr-2670-negotiated-protocol.png) |

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka authored the existing dual-era MCP implementation, tests, verification, documentation, and visual evidence. OpenAI Codex authored the latest direct-map import ambiguity review remediation and its regression test.

Final squash trailers:

`Generated-by: Maka`
`Generated-by: Codex`
