### PR TITLE
fix(runtime-host): preserve settled hosted outcomes

### DIFF
--- a/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { runHostedExecutionWithDependencies } from '../client/hosted-execution.js';
+
+test('diagnostics disconnect after settlement preserves the canonical result', async () => {
+  for (const status of ['completed', 'failed'] as const) {
+    const projection = settled(status);
+    const connected = ownedHost({
+      request: async () => projection,
+      queryHostDiagnostics: async () => {
+        throw new Error('connection closed');
+      },
+    });
+
+    const result = await runHostedExecutionWithDependencies(input(), {
+      connectOwnedRuntimeHost: async () => connected as never,
+    });
+
+    assert.deepEqual(result, projection);
+  }
+});
+
+test('abort observed with a completed response does not replace the result', async () => {
+  const abort = new AbortController();
+  const projection = settled('completed');
+  const connected = ownedHost({
+    request: async (operation: string) => {
+      if (operation === 'hosted.execution.start') {
+        abort.abort();
+        return projection;
+      }
+      return {
+        executionId: ID,
+        kind: 'indeterminate' as const,
+        failureReason: 'Hosted execution is not active',
+      };
+    },
+  });
+
+  const result = await runHostedExecutionWithDependencies(input(abort.signal), {
+    connectOwnedRuntimeHost: async () => connected as never,
+  });
+
+  assert.deepEqual(result, projection);
+});
+
+const ID = '00000000-0000-4000-8000-000000000001';
+
+function input(signal?: AbortSignal) {
+  return {
+    rootPath: '/runtime-host',
+    execution: {
+      executionId: ID,
+      session: {
+        workspace: { kind: 'host_path' as const, path: '/workspace' },
+        modelTarget: { kind: 'default' as const },
+      },
+      content: { text: 'solve' },
+    },
+    ...(signal ? { signal } : {}),
+  };
+}
+
+function settled(status: 'completed' | 'failed') {
+  return {
+    executionId: ID,
+    kind: 'settled' as const,
+    status,
+    ...(status === 'failed' ? { failureReason: 'subject failed' } : {}),
+    usage: {
+      inputTokens: 11,
+      outputTokens: 7,
+      cacheReadTokens: 3,
+      cacheWriteTokens: 2,
+      reasoningTokens: 1,
+      totalTokens: 18,
+    },
+    costUsd: 0.25,
+  };
+}
+
+function ownedHost(connection: Record<string, unknown>) {
+  return {
+    kind: 'connected' as const,
+    connection: { ...connection, close: async () => {} },
+    host: {
+      releaseToEnvironment: () => {},
+      settle: async () => false,
+    },
+  };
+}

--- a/packages/runtime-host/src/__tests__/hosted-execution-runner.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-runner.test.ts
@@ -42,6 +42,44 @@ test('hosted execution reads usage only after execution residencies settle', asy
   assert.equal(usageRead, true);
 });
 
+test('abort after terminal completion preserves the completed result', async () => {
+  const result = await runWithAbortAfterTerminal();
+  assert.equal(result.kind, 'settled');
+  if (result.kind === 'settled') assert.equal(result.status, 'completed');
+});
+
+test('abort after terminal failure preserves the failure reason', async () => {
+  const result = await runWithAbortAfterTerminal(() => terminalTurn('failed'));
+  assert.equal(result.kind, 'settled');
+  if (result.kind !== 'settled') return;
+  assert.equal(result.status, 'failed');
+  assert.equal(result.failureReason, 'subject failed');
+});
+
+async function runWithAbortAfterTerminal(query?: () => unknown) {
+  const abort = new AbortController();
+  const residency = deferred();
+  const settling = deferred();
+  const runner = new HostHostedExecutionRunner({
+    handlers: handlers(query ? { query } : {}),
+    context: context(),
+    requestDrain: () => {},
+    waitForExecutionResidencies: () => {
+      settling.resolve();
+      return residency.promise;
+    },
+    waitForAllResidencies: () => residency.promise,
+    now: sequence(100, 200),
+  });
+
+  const execution = runner.run(input(), abort.signal);
+  await settling.promise;
+  abort.abort();
+  residency.resolve();
+
+  return execution;
+}
+
 test('hosted execution cancellation drains the Host and waits for canonical stop', async () => {
   const abort = new AbortController();
   const started = deferred();
@@ -210,8 +248,13 @@ function runningTurn() {
   };
 }
 
-function terminalTurn(status: 'completed' | 'cancelled') {
-  return { ...runningTurn(), status, completedAt: 150 };
+function terminalTurn(status: 'completed' | 'failed' | 'cancelled') {
+  return {
+    ...runningTurn(),
+    status,
+    completedAt: 150,
+    ...(status === 'failed' ? { failureClass: 'subject failed' } : {}),
+  };
 }
 
 function usageSummary() {

--- a/packages/runtime-host/src/client/hosted-execution.ts
+++ b/packages/runtime-host/src/client/hosted-execution.ts
@@ -17,13 +17,26 @@ export interface RunHostedExecutionInput {
   readonly hostSettlementTimeoutMs?: number;
 }
 
+interface RunHostedExecutionDependencies {
+  readonly connectOwnedRuntimeHost: typeof connectOwnedRuntimeHost;
+}
+
+const defaultDependencies: RunHostedExecutionDependencies = { connectOwnedRuntimeHost };
+
 export async function runHostedExecution(
   input: RunHostedExecutionInput,
+): Promise<HostedExecutionProjection> {
+  return runHostedExecutionWithDependencies(input, defaultDependencies);
+}
+
+export async function runHostedExecutionWithDependencies(
+  input: RunHostedExecutionInput,
+  dependencies: RunHostedExecutionDependencies,
 ): Promise<HostedExecutionProjection> {
   if (input.signal?.aborted) {
     return indeterminate(input.execution.executionId, 'Hosted execution was cancelled');
   }
-  const connected = await connectOwnedRuntimeHost({
+  const connected = await dependencies.connectOwnedRuntimeHost({
     rootPath: input.rootPath,
     surface: 'run',
     protocol: {
@@ -37,7 +50,6 @@ export async function runHostedExecution(
   }
 
   let projection: HostedExecutionProjection;
-  let environmentResourcesRemain = false;
   try {
     const target = input.execution.session.modelTarget;
     if (target.kind === 'explicit') {
@@ -49,17 +61,6 @@ export async function runHostedExecution(
       });
     }
     projection = await executeHostedExecution(connected.connection, input.execution, input.signal);
-    if (preservesHostedExecutionEnvironment(projection) && input.signal?.aborted) {
-      projection = await connected.connection.request('hosted.execution.cancel', {
-        executionId: input.execution.executionId,
-      });
-    }
-    if (preservesHostedExecutionEnvironment(projection)) {
-      const diagnostics = await connected.connection.queryHostDiagnostics();
-      environmentResourcesRemain = diagnostics.residencies.some(
-        ({ label, count }) => label === 'runtime-resource' && count > 0,
-      );
-    }
   } catch {
     projection = indeterminate(
       input.execution.executionId,
@@ -69,7 +70,7 @@ export async function runHostedExecution(
     await connected.connection.close().catch(() => undefined);
   }
 
-  if (preservesHostedExecutionEnvironment(projection) && environmentResourcesRemain) {
+  if (preservesHostedExecutionEnvironment(projection)) {
     connected.host.releaseToEnvironment();
     return projection;
   }

--- a/packages/runtime-host/src/server/hosted-execution-runner.ts
+++ b/packages/runtime-host/src/server/hosted-execution-runner.ts
@@ -70,10 +70,8 @@ export class HostHostedExecutionRunner {
       return {
         executionId: input.executionId,
         kind: 'settled',
-        status: signal.aborted ? 'cancelled' : terminalStatus(terminal),
-        ...(!signal.aborted && terminal.status === 'failed'
-          ? { failureReason: terminal.failureClass }
-          : {}),
+        status: terminalStatus(terminal),
+        ...(terminal.status === 'failed' ? { failureReason: terminal.failureClass } : {}),
         usage: {
           inputTokens: usage.summary.totalTokens.input,
           outputTokens: usage.summary.totalTokens.output,


### PR DESCRIPTION
## Summary

Preserve Runtime Host canonical `completed` and `failed` outcomes once hosted execution reaches a terminal snapshot.

The server now derives the returned status and failure reason from that terminal snapshot instead of a later abort signal. The client no longer re-cancels an already settled response or performs post-settlement diagnostics and runtime-resource label inspection. Settled environments are released to the enclosing Trial environment; cancelled and indeterminate paths still settle the owned Host before returning.

Fixes #2662

## Verification

- `node --test --test-concurrency=1 dist/__tests__/hosted-execution-client.test.js dist/__tests__/hosted-execution-runner.test.js` — 8 passed
- `node --test --test-concurrency=1 dist/__tests__/owned-candidate.test.js` — 4 passed
- `node --test --test-name-pattern="hosted execution settles while its tracked environment resource remains verifiable" dist/__tests__/execution-composition.test.js` — passed
- `node --test --test-name-pattern="elects one owner, serves status and diagnostics, and releases ownership after true-idle shutdown" dist/__tests__/host-kernel.test.js` — passed
- `npm --workspace @maka/runtime-host run typecheck` — passed
- `npx biome check packages/runtime-host/src/client/hosted-execution.ts packages/runtime-host/src/server/hosted-execution-runner.ts packages/runtime-host/src/__tests__/hosted-execution-client.test.ts packages/runtime-host/src/__tests__/hosted-execution-runner.test.ts` — passed

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

AI disclosure: OpenAI Codex materially assisted with the implementation, tests, and PR draft. The human contributor reviewed the scope and owns the merge decision.

## Review and merge path

Fast-path rationale: this is a low-impact, easily reversible correction to the internal Runtime Host/Eval handoff. It restores the existing terminal-outcome invariant without changing a public API, protocol schema, CLI, user workflow, or another protected area. The required checks pass.

AI-assisted review: OpenAI Codex performed an adversarial review of terminal-outcome monotonicity, cancellation/drain semantics, Runtime Host lifecycle handoff, test quality, and possible simplifications. It found no blocking correctness issue; the human contributor reviewed the final diff and commit message and owns the merge decision.