### PR TITLE
fix(runtime-host): preserve provider failure diagnostics

### DIFF
--- a/apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts
@@ -23,6 +23,27 @@ const environment = {
   processUptimeSeconds: 41.9,
 };
 
+const runtimeHostDiagnostics = {
+  hostEpoch: 'epoch-1',
+  compositionId: 'maka.interactive',
+  compositionRevision: '1',
+  compositionModules: ['interactive', 'execution'],
+  state: 'ready' as const,
+  connections: 1,
+  activeOperations: 1,
+  activeResidencies: 0,
+  residencies: [],
+  protocolVersion: 0,
+  compatibilityEpoch: 16,
+  pid: 42,
+  processUptimeSeconds: 37,
+  nodeVersion: '22.0.0',
+  platform: 'linux' as const,
+  arch: 'x64',
+  osRelease: '6.6.0',
+  logs: ['host log'],
+};
+
 test('formats one redacted Desktop and Runtime Host diagnostic report', () => {
   const report = formatDesktopErrorDiagnosticReport(
     {
@@ -35,34 +56,16 @@ test('formats one redacted Desktop and Runtime Host diagnostic report', () => {
     ['main log'],
     {
       ok: true,
-      value: {
-        hostEpoch: 'epoch-1',
-        compositionId: 'maka.interactive',
-        compositionRevision: '1',
-        compositionModules: ['interactive', 'execution'],
-        state: 'ready',
-        connections: 1,
-        activeOperations: 1,
-        activeResidencies: 0,
-        residencies: [],
-        protocolVersion: 0,
-        compatibilityEpoch: 9,
-        pid: 42,
-        processUptimeSeconds: 37,
-        nodeVersion: '22.0.0',
-        platform: 'linux',
-        arch: 'x64',
-        osRelease: '6.6.0',
-        logs: ['host log'],
-      },
+      value: runtimeHostDiagnostics,
     },
+    undefined,
     new Date('2026-08-09T00:00:00Z'),
   );
 
   assert.match(report, /Recent main-process logs \(1\)\nmain log/);
   assert.match(report, /Build: dev @ a{12}/);
   assert.match(report, /Runtime Host[\s\S]*Recent Runtime Host logs \(1\)\nhost log/);
-  assert.match(report, /Protocol: v0 · compatibility 9/);
+  assert.match(report, /Protocol: v0 · compatibility 16/);
   assert.match(report, /Workspace: ~\/\.local\/share\/maka\/workspaces\/default/);
   assert.doesNotMatch(report, /sk-secretvalue123|\/home\/tester/);
 });
@@ -98,6 +101,7 @@ test('copies Desktop diagnostics while Runtime Host is unavailable', async () =>
     getRuntimeHostDiagnostics: async () => {
       throw new Error('Runtime Host disconnected');
     },
+    getRuntimeHostTurnTrace: async () => undefined,
     writeClipboard: (value) => {
       clipboard = value;
     },
@@ -110,4 +114,99 @@ test('copies Desktop diagnostics while Runtime Host is unavailable', async () =>
   assert.deepEqual(result, { ok: true });
   assert.match(clipboard, /Recent main-process logs \(1\)\nmain remained available/);
   assert.match(clipboard, /Diagnostics unavailable: Runtime Host disconnected/);
+});
+
+test('copies bounded evidence for the exact failed Turn', async () => {
+  type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
+  const handlers = new Map<string, IpcHandler>();
+  let clipboard = '';
+  registerDesktopDiagnosticsIpc({
+    ipcMain: {
+      handle(channel, handler) {
+        handlers.set(channel, handler);
+      },
+    },
+    environment: () => environment,
+    mainLogs: () => [],
+    getRuntimeHostDiagnostics: async () => runtimeHostDiagnostics,
+    getRuntimeHostTurnTrace: async (sessionId, turnId) => {
+      assert.equal(sessionId, 'session-1');
+      assert.equal(turnId, 'turn-1');
+      return {
+        turnId,
+        runId: 'run-1',
+        startedAt: 1_000,
+        endedAt: 4_501,
+        durationMs: 3_501,
+        steps: [
+          {
+            kind: 'model_call',
+            id: 'call-1',
+            turnId,
+            runId: 'run-1',
+            startedAt: 1_000,
+            endedAt: 4_501,
+            durationMs: 3_501,
+            callKind: 'main',
+            providerId: 'openrouter',
+            modelId: 'openrouter/free',
+            step: 0,
+            attempts: [
+              {
+                attemptId: 'attempt-1',
+                attempt: 0,
+                status: 'failed',
+                startedAt: 1_000,
+                completedAt: 4_501,
+                latencyMs: 3_501,
+                errorClass: 'unknown',
+                costBasis: 'unpriced',
+                usageBasis: 'missing',
+              },
+            ],
+            status: 'failed',
+          },
+          {
+            kind: 'error',
+            id: 'event-1',
+            turnId,
+            runId: 'run-1',
+            startedAt: 4_501,
+            message: 'No endpoints accepted the request',
+          },
+        ],
+        totals: {
+          durationMs: 3_501,
+          modelAttempts: 1,
+          retries: 0,
+          compactions: 0,
+          inputTokens: 0,
+          outputTokens: 0,
+          unpricedAttempts: 1,
+        },
+        failure: {
+          code: 'model_call_failed',
+          message: 'No endpoints accepted the request',
+          attributedToStepId: 'call-1',
+        },
+      };
+    },
+    writeClipboard: (value) => {
+      clipboard = value;
+    },
+  });
+
+  const handler = handlers.get('diagnostics:copyErrorReport');
+  assert.ok(handler);
+  const result = await handler({} as never, {
+    surface: 'toast',
+    title: 'Conversation error',
+    execution: { sessionId: 'session-1', turnId: 'turn-1', eventId: 'event-1' },
+  });
+
+  assert.deepEqual(result, { ok: true });
+  assert.match(clipboard, /Runtime Host execution[\s\S]*Run: run-1/);
+  assert.match(clipboard, /Failure message: No endpoints accepted the request/);
+  assert.match(clipboard, /openrouter\/openrouter\/free · failed · 3501ms/);
+  assert.match(clipboard, /attempt-1 · failed · 3501ms · unknown/);
 });

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -308,6 +308,9 @@ describe('single live-turn handoff', () => {
     const ref = { current: liveTurns.get() };
     const interactions = createStateSetter<InteractionQueues>({});
     let diagnosticDetails: string | undefined;
+    let diagnosticTarget:
+      | { sessionId: string; turnId: string; eventId: string }
+      | undefined;
     const handlers = createAppShellSessionEventHandlers({
       uiLocale: 'zh',
       activeIdRef: { current: 'session-1' },
@@ -321,8 +324,9 @@ describe('single live-turn handoff', () => {
       setInteractionBySession: interactions.set,
       showModelSetupToast: () => {},
       toastApi: {
-        error: (_title, _description, details) => {
+        error: (_title, _description, details, target) => {
           diagnosticDetails = details;
+          diagnosticTarget = target;
         },
       },
     });
@@ -340,6 +344,11 @@ describe('single live-turn handoff', () => {
     assert.match(diagnosticDetails ?? '', /Turn: turn-1/u);
     assert.match(diagnosticDetails ?? '', /Reason: tool_failed/u);
     assert.match(diagnosticDetails ?? '', /Code: TOOL_FAILED/u);
+    assert.deepEqual(diagnosticTarget, {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      eventId: 'event-1',
+    });
 
     handlers.reconcilePersistedMessages('session-1', [
       { type: 'tool_call', id: 'tool-1', turnId: 'turn-1', stepId: 'step-1', ts: 3, toolName: 'Bash', args: {} },

--- a/apps/desktop/src/main/desktop-diagnostics-ipc-main.ts
+++ b/apps/desktop/src/main/desktop-diagnostics-ipc-main.ts
@@ -1,6 +1,7 @@
 import type { IpcMain } from 'electron';
 import { truncateUtf8 } from '@maka/core/diagnostic-log';
 import { redactSecrets } from '@maka/core/redaction';
+import type { TurnTrace } from '@maka/core/session-trace';
 import type { HostDiagnosticsResult } from '@maka/runtime-host/protocol';
 import type { DesktopDiagnosticCopyResult } from '../preload/diagnostics-contract.js';
 import {
@@ -8,6 +9,7 @@ import {
   parseDesktopErrorDiagnosticInput,
   type DesktopDiagnosticEnvironment,
   type RuntimeHostDiagnosticRead,
+  type RuntimeHostExecutionDiagnosticRead,
 } from './main-process-diagnostics.js';
 
 export interface DesktopDiagnosticsIpcDeps {
@@ -15,6 +17,7 @@ export interface DesktopDiagnosticsIpcDeps {
   readonly environment: () => DesktopDiagnosticEnvironment;
   readonly mainLogs: () => readonly string[];
   readonly getRuntimeHostDiagnostics: () => Promise<HostDiagnosticsResult>;
+  readonly getRuntimeHostTurnTrace: (sessionId: string, turnId: string) => Promise<TurnTrace | undefined>;
   readonly writeClipboard: (value: string) => void;
 }
 
@@ -35,11 +38,32 @@ export function registerDesktopDiagnosticsIpc(deps: DesktopDiagnosticsIpcDeps): 
           ),
         };
       }
+      let runtimeExecution: RuntimeHostExecutionDiagnosticRead | undefined;
+      if (input.execution) {
+        try {
+          const turn = await deps.getRuntimeHostTurnTrace(
+            input.execution.sessionId,
+            input.execution.turnId,
+          );
+          runtimeExecution = turn
+            ? { ok: true, value: turn }
+            : { ok: false, error: 'Execution evidence was not found' };
+        } catch (error) {
+          runtimeExecution = {
+            ok: false,
+            error: truncateUtf8(
+              redactSecrets(error instanceof Error ? error.message : String(error)),
+              1024,
+            ),
+          };
+        }
+      }
       const report = formatDesktopErrorDiagnosticReport(
         input,
         deps.environment(),
         deps.mainLogs(),
         runtimeHost,
+        runtimeExecution,
       );
       try {
         deps.writeClipboard(report);

--- a/apps/desktop/src/main/main-process-diagnostics.ts
+++ b/apps/desktop/src/main/main-process-diagnostics.ts
@@ -1,8 +1,12 @@
 import { DiagnosticLogBuffer, truncateUtf8 } from '@maka/core/diagnostic-log';
 import { installConsoleDiagnosticLogCapture } from '@maka/core/node-diagnostic-log';
 import { redactSecrets } from '@maka/core/redaction';
+import type { TurnTrace } from '@maka/core/session-trace';
 import type { HostDiagnosticsResult } from '@maka/runtime-host/protocol';
-import type { DesktopErrorDiagnosticInput } from '../preload/diagnostics-contract.js';
+import type {
+  DesktopErrorDiagnosticInput,
+  DesktopExecutionDiagnosticTarget,
+} from '../preload/diagnostics-contract.js';
 
 const INPUT_LIMITS = {
   title: 512,
@@ -33,6 +37,10 @@ export type RuntimeHostDiagnosticRead =
   | { readonly ok: true; readonly value: HostDiagnosticsResult }
   | { readonly ok: false; readonly error: string };
 
+export type RuntimeHostExecutionDiagnosticRead =
+  | { readonly ok: true; readonly value: TurnTrace }
+  | { readonly ok: false; readonly error: string };
+
 export const mainProcessLogBuffer = new DiagnosticLogBuffer();
 
 let logCaptureInstalled = false;
@@ -53,6 +61,7 @@ export function parseDesktopErrorDiagnosticInput(input: unknown): DesktopErrorDi
     'title',
     'description',
     'details',
+    'execution',
     'rendererUserAgent',
     'rendererLocale',
   ]);
@@ -68,6 +77,9 @@ export function parseDesktopErrorDiagnosticInput(input: unknown): DesktopErrorDi
     title,
     ...optionalBoundedString(record, 'description', INPUT_LIMITS.description),
     ...optionalBoundedString(record, 'details', INPUT_LIMITS.details),
+    ...(record.execution !== undefined
+      ? { execution: parseExecutionDiagnosticTarget(record.execution) }
+      : {}),
     ...optionalBoundedString(record, 'rendererUserAgent', INPUT_LIMITS.rendererUserAgent),
     ...optionalBoundedString(record, 'rendererLocale', INPUT_LIMITS.rendererLocale),
   };
@@ -78,6 +90,7 @@ export function formatDesktopErrorDiagnosticReport(
   environment: DesktopDiagnosticEnvironment,
   mainLogs: readonly string[],
   runtimeHost: RuntimeHostDiagnosticRead,
+  runtimeExecution: RuntimeHostExecutionDiagnosticRead | undefined = undefined,
   capturedAt = new Date(),
 ): string {
   const lines = [
@@ -127,8 +140,93 @@ export function formatDesktopErrorDiagnosticReport(
     lines.push(`Diagnostics unavailable: ${runtimeHost.error}`);
   }
 
+  if (input.execution) {
+    lines.push('', 'Runtime Host execution');
+    if (!runtimeExecution?.ok) {
+      lines.push(`Execution evidence unavailable: ${runtimeExecution?.error ?? 'not queried'}`);
+    } else {
+      appendTurnTrace(lines, input.execution, runtimeExecution.value);
+    }
+  }
+
   const redacted = redactSecrets(lines.join('\n'));
   return collapseHomePath(redacted, environment.homePath, environment.platform);
+}
+
+function parseExecutionDiagnosticTarget(value: unknown): DesktopExecutionDiagnosticTarget {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('Invalid Desktop execution diagnostic target');
+  }
+  const record = value as Record<string, unknown>;
+  const keys = ['sessionId', 'turnId', 'eventId'] as const;
+  if (
+    Object.keys(record).length !== keys.length ||
+    keys.some((key) => !Object.hasOwn(record, key))
+  ) {
+    throw new TypeError('Invalid Desktop execution diagnostic target');
+  }
+  return {
+    sessionId: requireDiagnosticEntityId(record.sessionId, 'sessionId'),
+    turnId: requireDiagnosticEntityId(record.turnId, 'turnId'),
+    eventId: requireDiagnosticId(record.eventId, 'eventId'),
+  };
+}
+
+function requireDiagnosticEntityId(value: unknown, label: string): string {
+  if (typeof value !== 'string' || !/^[A-Za-z0-9_-]{1,128}$/.test(value)) {
+    throw new TypeError(`Invalid Desktop diagnostic ${label}`);
+  }
+  return value;
+}
+
+function requireDiagnosticId(value: unknown, label: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    /[\u0000-\u001f\u007f]/.test(value) ||
+    Buffer.byteLength(value, 'utf8') > 512
+  ) {
+    throw new TypeError(`Invalid Desktop diagnostic ${label}`);
+  }
+  return value;
+}
+
+function appendTurnTrace(
+  lines: string[],
+  target: DesktopExecutionDiagnosticTarget,
+  turn: TurnTrace,
+): void {
+  if (turn.turnId !== target.turnId) {
+    lines.push('Execution evidence unavailable: Turn identity did not match');
+    return;
+  }
+  lines.push(
+    `Session: ${target.sessionId}`,
+    `Turn: ${target.turnId}`,
+    `Run: ${turn.runId}`,
+    `Event: ${target.eventId}`,
+    `Duration: ${turn.durationMs}ms`,
+  );
+  if (turn.failure) {
+    lines.push(`Failure: ${turn.failure.code}`);
+    if (turn.failure.message) lines.push(`Failure message: ${turn.failure.message}`);
+  }
+  const calls = turn.steps.filter((step) => step.kind === 'model_call');
+  lines.push(`Model calls (${calls.length})`);
+  if (calls.length === 0) {
+    lines.push('<none recorded>');
+    return;
+  }
+  for (const call of calls) {
+    lines.push(
+      `- ${call.providerId}/${call.modelId} · ${call.status} · ${call.durationMs}ms · ${call.attempts.length} attempt(s)`,
+    );
+    for (const attempt of call.attempts) {
+      lines.push(
+        `  - ${attempt.attemptId} · ${attempt.status} · ${attempt.latencyMs}ms${attempt.errorClass ? ` · ${attempt.errorClass}` : ''}`,
+      );
+    }
+  }
 }
 
 function optionalBoundedString(

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -889,8 +889,12 @@ function registerPersistentClientIpc(): void {
     },
     getRuntimeHostTurnTrace: async (sessionId, turnId) => {
       if (!runtimePolicyClient) throw new Error("Runtime Host is unavailable");
-      const trace = await runtimePolicyClient.loadSessionTrace(sessionId);
-      return trace.turns.find((turn) => turn.turnId === turnId);
+      const result = await runtimePolicyClient.queryExecutionInspect({
+        kind: "turn_trace",
+        sessionId,
+        turnId,
+      });
+      return result.kind === "turn_trace" ? result.turn : undefined;
     },
     writeClipboard: (report) => clipboard.writeText(report),
   });

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -887,6 +887,11 @@ function registerPersistentClientIpc(): void {
       if (!runtimePolicyClient) throw new Error("Runtime Host is unavailable");
       return runtimePolicyClient.queryHostDiagnostics();
     },
+    getRuntimeHostTurnTrace: async (sessionId, turnId) => {
+      if (!runtimePolicyClient) throw new Error("Runtime Host is unavailable");
+      const trace = await runtimePolicyClient.loadSessionTrace(sessionId);
+      return trace.turns.find((turn) => turn.turnId === turnId);
+    },
     writeClipboard: (report) => clipboard.writeText(report),
   });
   ipcMain.handle("attachments:pickFiles", async (event) => {

--- a/apps/desktop/src/preload/diagnostics-contract.ts
+++ b/apps/desktop/src/preload/diagnostics-contract.ts
@@ -1,8 +1,15 @@
+export interface DesktopExecutionDiagnosticTarget {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly eventId: string;
+}
+
 export interface DesktopErrorDiagnosticInput {
   readonly surface: 'toast' | 'renderer_crash';
   readonly title: string;
   readonly description?: string;
   readonly details?: string;
+  readonly execution?: DesktopExecutionDiagnosticTarget;
   readonly rendererUserAgent?: string;
   readonly rendererLocale?: string;
 }

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -23,7 +23,12 @@ type RefBox<T> = { current: T };
 type StateUpdater<T> = (updater: (current: T) => T) => void;
 
 type ToastApi = {
-  error(title: string, description?: string, diagnosticDetails?: string): void;
+  error(
+    title: string,
+    description?: string,
+    diagnosticDetails?: string,
+    diagnosticTarget?: { sessionId: string; turnId: string; eventId: string },
+  ): void;
 };
 
 export interface AppShellSessionEventHandlers {
@@ -164,6 +169,7 @@ export function createAppShellSessionEventHandlers(options: {
               copy.conversationErrorTitle,
               sessionEventErrorMessage(event, uiLocale),
               sessionEventDiagnosticDetails(sessionId, event),
+              { sessionId, turnId: event.turnId, eventId: event.id },
             );
           }
         }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -249,6 +249,7 @@ export function AppShell({ initialOnboardingSnapshot = null }: AppShellProps = {
             title: input.title,
             ...(input.description ? { description: input.description } : {}),
             ...(input.diagnosticDetails ? { details: input.diagnosticDetails } : {}),
+            ...(input.diagnosticTarget ? { execution: input.diagnosticTarget } : {}),
             rendererUserAgent: navigator.userAgent,
             rendererLocale: navigator.language,
           })

--- a/packages/core/src/session-trace.ts
+++ b/packages/core/src/session-trace.ts
@@ -381,7 +381,7 @@ export function isSessionTrace(value: unknown): value is SessionTrace {
   );
 }
 
-function isTurnTrace(value: unknown): value is TurnTrace {
+export function isTurnTrace(value: unknown): value is TurnTrace {
   return (
     isRecord(value) &&
     hasExactShape(value, TURN_TRACE_SHAPE) &&

--- a/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
+++ b/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
@@ -11,7 +11,10 @@ import {
 import type { StoredInteractionRequest } from '@maka/storage/interaction-store';
 import { acquireOperationalStateDatabase } from '@maka/storage';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
-import { type SessionMessageQueueProjection } from '../protocol/index.js';
+import {
+  TURN_MESSAGE_TEXT_MAX_BYTES,
+  type SessionMessageQueueProjection,
+} from '../protocol/index.js';
 import {
   type CanonicalSessionProjection,
   CanonicalSessionProjectionReader,
@@ -21,6 +24,7 @@ import { type HostMessageRootPort, HostMessageCoordinator } from '../server/mess
 import { worstCaseGoalProjection } from '../server/goal-projection.js';
 import { RootAdmissionOwner } from '../server/root-admission-owner.js';
 import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+import { worstCaseFailedTurnSnapshot } from '../server/canonical-turn-snapshot.js';
 
 test('projects the canonical root lifecycle and the attachment queue from real Stores', async () => {
   await withStores(async (root, stores) => {
@@ -277,6 +281,95 @@ test('preflights queued steering at the exact in-flight snapshot boundary', asyn
   });
 });
 
+test('preflights the worst-case failed Turn before accepting more queued content', async () => {
+  await withStores(async (root, stores) => {
+    const { sessionId, rootAdmissions } = await createRunningRoot(root, stores);
+
+    let currentQueue: SessionMessageQueueProjection = {
+      hostEpoch: 'epoch-1',
+      queueRevision: 1,
+      steering: [],
+      followup: [],
+    };
+    const reader = new CanonicalSessionProjectionReader({
+      stores,
+      rootAdmissions,
+      messages: { projection: () => currentQueue },
+    });
+    const canonical = await reader.read(sessionId);
+    assert.ok(canonical?.rootTurn);
+    const capacityCanonical = {
+      ...canonical,
+      goal: worstCaseGoalProjection(sessionId),
+    };
+    currentQueue = largestFittingFollowupQueue(capacityCanonical);
+
+    assert.doesNotThrow(() =>
+      createSessionContinuitySnapshot(
+        { ...capacityCanonical, queue: currentQueue },
+        Number.MAX_SAFE_INTEGER,
+      ),
+    );
+    assert.throws(() =>
+      createSessionContinuitySnapshot(
+        {
+          ...capacityCanonical,
+          rootTurn: worstCaseFailedTurnSnapshot(capacityCanonical.rootTurn!),
+          queue: currentQueue,
+        },
+        Number.MAX_SAFE_INTEGER,
+      ),
+    );
+    assert.equal(await reader.fitsCandidate(sessionId, { queue: currentQueue }), false);
+  });
+});
+
+test('projects a failed Turn message from the canonical terminal event', async () => {
+  await withStores(async (root, stores) => {
+    const { sessionId, rootAdmissions } = await createRunningRoot(root, stores);
+    await stores.runtimeEventStore.appendRuntimeEvent(sessionId, 'run-1', {
+      id: 'terminal-failed-1',
+      invocationId: 'run-1',
+      sessionId,
+      turnId: 'turn-1',
+      runId: 'run-1',
+      ts: 12,
+      partial: false,
+      status: 'failed',
+      role: 'system',
+      author: 'system',
+      content: {
+        kind: 'error',
+        code: 'provider_error',
+        message: 'canonical provider failure api_key=sk-test-secret-value',
+      },
+    });
+    await stores.agentRunStore.updateRun(sessionId, 'run-1', {
+      status: 'failed',
+      updatedAt: 12,
+      completedAt: 12,
+      failureClass: 'provider_error',
+      failureMessage: 'stale Run header failure',
+    });
+
+    const reader = new CanonicalSessionProjectionReader({
+      stores,
+      rootAdmissions,
+      messages: {
+        projection: () => ({ hostEpoch: 'epoch-1', queueRevision: 0, steering: [], followup: [] }),
+      },
+    });
+    const canonical = await reader.read(sessionId);
+    assert.equal(canonical?.rootTurn?.status, 'failed');
+    if (canonical?.rootTurn?.status === 'failed') {
+      assert.equal(
+        canonical.rootTurn.failureMessage,
+        'canonical provider failure api_key=[redacted]',
+      );
+    }
+  });
+});
+
 test('propagates canonical Store read failures during candidate preflight', async () => {
   await withStores(async (root, stores) => {
     const session = await stores.sessionStore.create(sessionInput(root));
@@ -435,6 +528,39 @@ function runHeader(sessionId: string): AgentRunHeader {
   };
 }
 
+async function createRunningRoot(
+  root: string,
+  stores: ExecutionStoresWriter<'interactive'>,
+): Promise<{ sessionId: string; rootAdmissions: RootAdmissionOwner }> {
+  const session = await stores.sessionStore.create(sessionInput(root));
+  const rootAdmissions = new RootAdmissionOwner(stores.agentRunStore);
+  await rootAdmissions.recoverSession(session.id);
+  await rootAdmissions.admitRootTurn({
+    sessionId: session.id,
+    turnId: 'turn-1',
+    proposedRunId: 'run-1',
+    proposedUserMessageId: 'user-1',
+    execution: { kind: 'external_message' },
+    normalizedInput: { text: 'hello' },
+    sourceMessages: [],
+    admittedAt: 10,
+  });
+  await stores.agentRunStore.createRun(runHeader(session.id));
+  await stores.agentRunStore.appendEvent(session.id, 'run-1', {
+    type: 'run_started',
+    id: 'run-started-1',
+    sessionId: session.id,
+    turnId: 'turn-1',
+    runId: 'run-1',
+    ts: 11,
+  });
+  await stores.agentRunStore.updateRun(session.id, 'run-1', {
+    status: 'running',
+    updatedAt: 11,
+  });
+  return { sessionId: session.id, rootAdmissions };
+}
+
 function terminalEvent(sessionId: string): RuntimeEvent {
   return {
     id: 'terminal-1',
@@ -544,4 +670,49 @@ function largestFittingInFlightSteeringText(canonical: CanonicalSessionProjectio
     else upper = midpoint;
   }
   return lower;
+}
+
+function largestFittingFollowupQueue(
+  canonical: CanonicalSessionProjection,
+): SessionMessageQueueProjection {
+  const queue = (tailBytes: number): SessionMessageQueueProjection => ({
+    hostEpoch: 'epoch-1',
+    queueRevision: Number.MAX_SAFE_INTEGER,
+    steering: [],
+    followup: [
+      {
+        entryId: 'large-entry',
+        messageId: 'large-message',
+        content: { text: 'q'.repeat(TURN_MESSAGE_TEXT_MAX_BYTES) },
+        placement: 'next_turn',
+        state: 'queued',
+      },
+      {
+        entryId: 'tail-entry',
+        messageId: 'tail-message',
+        content: { text: 'q'.repeat(tailBytes) },
+        placement: 'next_turn',
+        state: 'queued',
+      },
+    ],
+  });
+  const fits = (tailBytes: number): boolean => {
+    try {
+      createSessionContinuitySnapshot(
+        { ...canonical, queue: queue(tailBytes) },
+        Number.MAX_SAFE_INTEGER,
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  let lower = 0;
+  let upper = TURN_MESSAGE_TEXT_MAX_BYTES;
+  while (lower + 1 < upper) {
+    const midpoint = Math.floor((lower + upper) / 2);
+    if (fits(midpoint)) lower = midpoint;
+    else upper = midpoint;
+  }
+  return queue(lower);
 }

--- a/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
+++ b/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@maka/storage/execution-stores';
 import type { StoredInteractionRequest } from '@maka/storage/interaction-store';
 import { acquireOperationalStateDatabase } from '@maka/storage';
+import { createSessionEventMapMemory, mapSessionEventToRuntimeEvent } from '@maka/runtime';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import {
   TURN_MESSAGE_TEXT_MAX_BYTES,
@@ -327,27 +328,55 @@ test('preflights the worst-case failed Turn before accepting more queued content
 test('projects a failed Turn message from the canonical terminal event', async () => {
   await withStores(async (root, stores) => {
     const { sessionId, rootAdmissions } = await createRunningRoot(root, stores);
-    await stores.runtimeEventStore.appendRuntimeEvent(sessionId, 'run-1', {
-      id: 'terminal-failed-1',
-      invocationId: 'run-1',
+    const memory = createSessionEventMapMemory();
+    const context = {
       sessionId,
-      turnId: 'turn-1',
+      invocationId: 'run-1',
       runId: 'run-1',
-      ts: 12,
-      partial: false,
-      status: 'failed',
-      role: 'system',
-      author: 'system',
-      content: {
-        kind: 'error',
+      turnId: 'turn-1',
+      source: 'test',
+      startedAt: 10,
+      request: {
+        sessionId,
+        invocationId: 'run-1',
+        runId: 'run-1',
+        turnId: 'turn-1',
+        text: 'hello',
+        source: 'test',
+      },
+      newId: () => 'unused',
+      now: () => 12,
+    } as const;
+    const errorEvent = mapSessionEventToRuntimeEvent(
+      {
+        type: 'error',
+        id: 'provider-error-1',
+        turnId: 'turn-1',
+        ts: 12,
+        recoverable: false,
         code: 'provider_error',
         message: 'canonical provider failure api_key=sk-test-secret-value',
       },
-    });
+      context,
+      memory,
+    );
+    const terminalEvent = mapSessionEventToRuntimeEvent(
+      {
+        type: 'complete',
+        id: 'terminal-failed-1',
+        turnId: 'turn-1',
+        ts: 13,
+        stopReason: 'error',
+      },
+      context,
+      memory,
+    );
+    await stores.runtimeEventStore.appendRuntimeEvent(sessionId, 'run-1', errorEvent);
+    await stores.runtimeEventStore.appendRuntimeEvent(sessionId, 'run-1', terminalEvent);
     await stores.agentRunStore.updateRun(sessionId, 'run-1', {
       status: 'failed',
-      updatedAt: 12,
-      completedAt: 12,
+      updatedAt: 13,
+      completedAt: 13,
       failureClass: 'provider_error',
       failureMessage: 'stale Run header failure',
     });

--- a/packages/runtime-host/src/__tests__/execution-inspect-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-inspect-coordinator.test.ts
@@ -141,6 +141,50 @@ describe('HostExecutionInspectCoordinator', () => {
     });
   });
 
+  test('reads one Turn trace without charging unrelated Session runs', async () => {
+    await withCoordinator(async ({ stores, coordinator }) => {
+      const session = await stores.sessionStore.create(sessionInput('Target Turn'));
+      for (let index = 0; index <= EXECUTION_INSPECT_SESSION_MAX_RUNS; index += 1) {
+        await stores.agentRunStore.createRun(runHeader(session.id, `unrelated-${index}`, index));
+      }
+      const runId = 'target-run';
+      const turnId = `turn-${runId}`;
+      await stores.agentRunStore.admitRootTurn({
+        sessionId: session.id,
+        turnId,
+        proposedRunId: runId,
+        proposedUserMessageId: 'target-user-message',
+        execution: { kind: 'external_message' },
+        previousRootTurnId: null,
+        normalizedInput: { text: 'diagnose this' },
+        sourceMessages: [],
+        admittedAt: 100,
+      });
+      await stores.agentRunStore.createRun(runHeader(session.id, runId, 100));
+      await stores.runtimeEventStore.appendRuntimeEvent(
+        session.id,
+        runId,
+        runtimeEvent(session.id, runId, 101),
+      );
+
+      const sessionTrace = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'session_trace_start', sessionId: session.id },
+        connectionContext(),
+      );
+      assert.equal(sessionTrace.ok, false);
+
+      const target = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'turn_trace', sessionId: session.id, turnId },
+        connectionContext(),
+      );
+      assert.equal(target.ok, true);
+      if (!target.ok || target.result.kind !== 'turn_trace') return;
+      assert.equal(target.result.turn.turnId, turnId);
+      assert.equal(target.result.turn.runId, runId);
+      assert.equal(target.result.turn.failure?.message, 'fixture failure');
+    });
+  });
+
   test('rejects oversized evidence at the bounded Store read boundary', async () => {
     await withCoordinator(async ({ stores, coordinator }) => {
       const session = await stores.sessionStore.create(sessionInput('Large evidence'));

--- a/packages/runtime-host/src/__tests__/execution-inspect-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-inspect-protocol.test.ts
@@ -37,6 +37,18 @@ describe('execution inspect protocol', () => {
       },
     );
     assert.deepEqual(
+      decodeClientFrame({
+        requestId: 'request-turn-trace',
+        operation: 'execution.inspect.query',
+        input: { kind: 'turn_trace', sessionId: 'session-1', turnId: 'turn-1' },
+      }),
+      {
+        requestId: 'request-turn-trace',
+        operation: 'execution.inspect.query',
+        input: { kind: 'turn_trace', sessionId: 'session-1', turnId: 'turn-1' },
+      },
+    );
+    assert.deepEqual(
       decodeHostFrame({
         requestId: 'request-query',
         operation: 'execution.inspect.query',
@@ -48,6 +60,20 @@ describe('execution inspect protocol', () => {
         operation: 'execution.inspect.query',
         ok: true,
         result: { kind: 'agent_run', document: agentRunDocument() },
+      },
+    );
+    assert.deepEqual(
+      decodeHostFrame({
+        requestId: 'request-turn-trace',
+        operation: 'execution.inspect.query',
+        ok: true,
+        result: { kind: 'turn_trace', sessionId: 'session-1', turn: turnTrace() },
+      }),
+      {
+        requestId: 'request-turn-trace',
+        operation: 'execution.inspect.query',
+        ok: true,
+        result: { kind: 'turn_trace', sessionId: 'session-1', turn: turnTrace() },
       },
     );
   });
@@ -142,6 +168,14 @@ describe('execution inspect protocol', () => {
     assert.throws(
       () =>
         HOST_OPERATION_SPECS['execution.inspect.query'].assertOutputForInput?.(
+          { kind: 'turn_trace', sessionId: 'session-1', turnId: 'turn-1' },
+          { kind: 'turn_trace', sessionId: 'session-1', turn: turnTrace('turn-2') },
+        ),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['execution.inspect.query'].assertOutputForInput?.(
           { kind: 'session', sessionId: 'session-1' },
           { kind: 'session', document: sessionDocument('different-session') },
         ),
@@ -202,6 +236,26 @@ function tracePage() {
       turnsWithFewerModelCallsThanSteps: [],
     },
     nextOffset: null,
+  };
+}
+
+function turnTrace(turnId = 'turn-1') {
+  return {
+    turnId,
+    runId: 'run-1',
+    startedAt: 1,
+    endedAt: 2,
+    durationMs: 1,
+    steps: [],
+    totals: {
+      durationMs: 1,
+      modelAttempts: 0,
+      retries: 0,
+      compactions: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      unpricedAttempts: 0,
+    },
   };
 }
 

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -33,6 +33,7 @@ import {
   TURN_MESSAGE_QUOTE_LABEL_MAX_LENGTH,
   TURN_MESSAGE_QUOTE_MAX_COUNT,
   TURN_MESSAGE_QUOTE_TEXT_MAX_LENGTH,
+  TURN_FAILURE_MESSAGE_MAX_BYTES,
   TURN_SKILL_ID_MAX_COUNT,
   TURN_SKILL_ID_MAX_LENGTH,
 } from '../protocol/turn.js';
@@ -47,7 +48,7 @@ describe('Runtime Host bootstrap protocol', () => {
 
   test('declares the current protocol and closed authority operation set', () => {
     assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
-    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 15);
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 16);
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
       'access.credential.issue',
       'access.credential.revoke',
@@ -1542,6 +1543,36 @@ describe('Runtime Host bootstrap protocol', () => {
             status: 'completed',
             terminalEventId: 'event-1',
             abortSource: 'user',
+          },
+        }),
+      isInvalidFrame,
+    );
+  });
+
+  test('carries a bounded failed Turn message without opening the snapshot shape', () => {
+    const response = {
+      requestId: 'request-failed-turn',
+      operation: 'turn.query' as const,
+      ok: true as const,
+      result: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        runId: 'run-1',
+        status: 'failed' as const,
+        terminalEventId: 'event-1',
+        failureClass: 'unknown',
+        failureMessage: 'Provider request failed',
+      },
+    };
+
+    assert.deepEqual(decodeHostFrame(response), response);
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          ...response,
+          result: {
+            ...response.result,
+            failureMessage: '界'.repeat(TURN_FAILURE_MESSAGE_MAX_BYTES),
           },
         }),
       isInvalidFrame,

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -4184,6 +4184,15 @@ test('post-start backend AggregateError is contained after its failed terminal t
     const terminal = classifyTerminalRuntimeLedger(run, events);
     assert.equal(terminal.kind, 'fact');
     if (terminal.kind === 'fact') assert.equal(terminal.fact.runStatus, 'failed');
+    const queried = await fixture.turnControl.handlers['turn.query'](
+      { sessionId: fixture.sessionId, turnId },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(queried.ok, true);
+    if (queried.ok && queried.result.status === 'failed') {
+      assert.equal(queried.result.failureMessage, run.failureMessage);
+      assert.ok(queried.result.failureMessage);
+    }
 
     await fixture.coordinator.close();
     await fixture.messages.close();

--- a/packages/runtime-host/src/adapter/session-projector.ts
+++ b/packages/runtime-host/src/adapter/session-projector.ts
@@ -272,7 +272,7 @@ export class RuntimeHostSessionProjector {
         ts: this.#now(),
         recoverable: false,
         reason: root.failureClass,
-        message: `Turn failed: ${root.failureClass}`,
+        message: root.failureMessage ?? `Turn failed: ${root.failureClass}`,
       });
     } else {
       events.push({

--- a/packages/runtime-host/src/protocol/execution-inspect.ts
+++ b/packages/runtime-host/src/protocol/execution-inspect.ts
@@ -6,6 +6,7 @@ import {
 } from '@maka/core/execution-inspect';
 import {
   isSessionTrace,
+  isTurnTrace,
   SESSION_TRACE_SCHEMA_VERSION,
   type SessionTraceCoverage,
   type TraceTotals,
@@ -64,6 +65,7 @@ export type ExecutionInspectQueryInput =
       readonly agentRunId: string;
     }
   | { readonly kind: 'session_trace_start'; readonly sessionId: string }
+  | { readonly kind: 'turn_trace'; readonly sessionId: string; readonly turnId: string }
   | {
       readonly kind: 'session_trace_continue';
       readonly sessionId: string;
@@ -74,6 +76,11 @@ export type ExecutionInspectQueryInput =
 export type ExecutionInspectQueryResult =
   | { readonly kind: 'session'; readonly document: SessionInspectDocument }
   | { readonly kind: 'agent_run'; readonly document: AgentRunInspectDocument }
+  | {
+      readonly kind: 'turn_trace';
+      readonly sessionId: string;
+      readonly turn: TurnTrace;
+    }
   | {
       readonly kind: 'session_trace_page';
       readonly schemaVersion: typeof SESSION_TRACE_SCHEMA_VERSION;
@@ -182,9 +189,17 @@ export function decodeExecutionInspectQueryInput(value: unknown): ExecutionInspe
     value,
     'execution.inspect.query input',
     ['kind', 'sessionId'],
-    ['agentRunId', 'revision', 'offset'],
+    ['agentRunId', 'turnId', 'revision', 'offset'],
   );
   const sessionId = requireEntityId(record.sessionId, 'inspect Session id');
+  if (record.kind === 'turn_trace') {
+    requireExactRecord(record, 'Turn trace query', ['kind', 'sessionId', 'turnId']);
+    return {
+      kind: 'turn_trace',
+      sessionId,
+      turnId: requireEntityId(record.turnId, 'trace Turn id'),
+    };
+  }
   if (record.kind === 'session_trace_start') {
     requireExactRecord(record, 'Session trace start query', ['kind', 'sessionId']);
     return { kind: 'session_trace_start', sessionId };
@@ -240,8 +255,17 @@ export function decodeExecutionInspectQueryResult(value: unknown): ExecutionInsp
       'nextOffset',
       'expectedRevision',
       'actualRevision',
+      'turn',
     ],
   );
+  if (shaped.kind === 'turn_trace') {
+    const record = requireExactRecord(shaped, 'Turn trace result', ['kind', 'sessionId', 'turn']);
+    const sessionId = requireEntityId(record.sessionId, 'trace Session id');
+    if (!isTurnTrace(record.turn)) {
+      throw invalidProtocolFrame('Invalid Turn trace');
+    }
+    return { kind: 'turn_trace', sessionId, turn: record.turn };
+  }
   if (shaped.kind === 'session_trace_revision_changed') {
     const record = requireExactRecord(shaped, 'Session trace revision changed result', [
       'kind',
@@ -370,6 +394,16 @@ function assertQueryOutputForInput(
   input: ExecutionInspectQueryInput,
   output: ExecutionInspectQueryResult,
 ): void {
+  if (input.kind === 'turn_trace') {
+    if (
+      output.kind !== 'turn_trace' ||
+      output.sessionId !== input.sessionId ||
+      output.turn.turnId !== input.turnId
+    ) {
+      throw invalidProtocolFrame('Turn trace result changed request identity');
+    }
+    return;
+  }
   if (input.kind === 'session_trace_start' || input.kind === 'session_trace_continue') {
     if (output.kind === 'session_trace_revision_changed') {
       if (input.kind !== 'session_trace_continue' || output.expectedRevision !== input.revision) {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -67,7 +67,7 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 15 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 16 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -89,6 +89,7 @@ export type {
   ArtifactTextPreview,
 } from './artifact.js';
 export {
+  TURN_FAILURE_MESSAGE_MAX_BYTES,
   TURN_MESSAGE_CONTENT_MAX_BYTES,
   TURN_MESSAGE_TEXT_MAX_BYTES,
   TURN_RESUME_PARK_REASONS,

--- a/packages/runtime-host/src/protocol/turn.ts
+++ b/packages/runtime-host/src/protocol/turn.ts
@@ -26,6 +26,8 @@ import {
 } from './codec.js';
 import { defineOperation } from './operation-spec.js';
 
+export const TURN_FAILURE_MESSAGE_MAX_BYTES = 256;
+
 export interface TurnStartInput {
   sessionId: string;
   turnId: string;
@@ -147,6 +149,7 @@ export type TurnSnapshot =
       status: 'failed';
       terminalEventId: string;
       failureClass: string;
+      failureMessage?: string;
     })
   | (TurnSnapshotBase & {
       status: 'cancelled';
@@ -604,19 +607,27 @@ export function decodeTurnSnapshot(value: unknown): TurnSnapshot {
     };
   }
   if (status === 'failed') {
-    assertExactKeys(record, 'failed Turn snapshot', [
-      'sessionId',
-      'turnId',
-      'runId',
-      'status',
-      'terminalEventId',
-      'failureClass',
-    ]);
+    requireShapedRecord(
+      record,
+      'failed Turn snapshot',
+      ['sessionId', 'turnId', 'runId', 'status', 'terminalEventId', 'failureClass'],
+      ['failureMessage'],
+    );
     return {
       ...base,
       status,
       terminalEventId: requireId(record.terminalEventId, 'terminalEventId'),
       failureClass: requireString(record.failureClass, 'failureClass', 128),
+      ...(record.failureMessage !== undefined
+        ? {
+            failureMessage: requireUtf8String(
+              record.failureMessage,
+              'failureMessage',
+              TURN_FAILURE_MESSAGE_MAX_BYTES,
+              false,
+            ),
+          }
+        : {}),
     };
   }
   if (status === 'cancelled') {

--- a/packages/runtime-host/src/server/canonical-session-projection.ts
+++ b/packages/runtime-host/src/server/canonical-session-projection.ts
@@ -13,7 +13,11 @@ import {
   SESSION_CONTINUITY_SCHEMA_VERSION,
   SESSION_CONTINUITY_SNAPSHOT_MAX_BYTES,
 } from '../protocol/index.js';
-import { isMissingFile, readCanonicalTurnSnapshot } from './canonical-turn-snapshot.js';
+import {
+  isMissingFile,
+  readCanonicalTurnSnapshot,
+  worstCaseFailedTurnSnapshot,
+} from './canonical-turn-snapshot.js';
 import type { HostMessageCoordinator } from './message-coordinator.js';
 import { worstCaseMessageQueueProjection } from './message-queue-capacity.js';
 import { projectSessionInteractions } from './interaction-projection.js';
@@ -115,6 +119,13 @@ export class CanonicalSessionProjectionReader {
     const candidateProjection = {
       ...canonical,
       ...candidate,
+      rootTurn:
+        canonical.rootTurn &&
+        canonical.rootTurn.status !== 'completed' &&
+        canonical.rootTurn.status !== 'failed' &&
+        canonical.rootTurn.status !== 'cancelled'
+          ? worstCaseFailedTurnSnapshot(canonical.rootTurn)
+          : canonical.rootTurn,
       goal: worstCaseGoalProjection(sessionId),
       queue: worstCaseMessageQueueProjection(candidate.queue ?? canonical.queue),
     };

--- a/packages/runtime-host/src/server/canonical-turn-snapshot.ts
+++ b/packages/runtime-host/src/server/canonical-turn-snapshot.ts
@@ -1,5 +1,6 @@
 import type { AgentRunHeader } from '@maka/core/agent-run';
 import { truncateUtf8 } from '@maka/core/diagnostic-log';
+import { redactSecrets } from '@maka/core/redaction';
 import { classifyTerminalRuntimeLedger } from '@maka/runtime';
 import type { ExecutionStoresWriter } from '@maka/storage/execution-stores';
 import { TURN_FAILURE_MESSAGE_MAX_BYTES, type TurnSnapshot } from '../protocol/index.js';
@@ -45,6 +46,14 @@ export async function readCanonicalTurnSnapshot(
     }
     if (fact.runStatus === 'failed') {
       if (!fact.failureClass) throw new Error('Failed terminal fact has no failure class');
+      const failureMessage =
+        fact.terminalEvent.content?.kind === 'error'
+          ? truncateUtf8(
+              redactSecrets(fact.terminalEvent.content.message),
+              TURN_FAILURE_MESSAGE_MAX_BYTES,
+              '…',
+            )
+          : undefined;
       return {
         sessionId,
         turnId,
@@ -52,11 +61,7 @@ export async function readCanonicalTurnSnapshot(
         status: 'failed',
         terminalEventId: fact.terminalEvent.id,
         failureClass: fact.failureClass,
-        ...(run.failureMessage
-          ? {
-              failureMessage: truncateUtf8(run.failureMessage, TURN_FAILURE_MESSAGE_MAX_BYTES, '…'),
-            }
-          : {}),
+        ...(failureMessage ? { failureMessage } : {}),
       };
     }
     if (!fact.abortSource) throw new Error('Cancelled terminal fact has no abort source');
@@ -79,6 +84,17 @@ export async function readCanonicalTurnSnapshot(
     throw new Error('Non-created Run has no durable start fact');
   }
   return { sessionId, turnId, runId, status: run.status };
+}
+
+/** Maximizes the encoded size of a protocol-valid failed Turn snapshot. */
+export function worstCaseFailedTurnSnapshot(identity: CanonicalTurnIdentity): TurnSnapshot {
+  return {
+    ...identity,
+    status: 'failed',
+    terminalEventId: 'x'.repeat(128),
+    failureClass: '\0'.repeat(128),
+    failureMessage: '\0'.repeat(TURN_FAILURE_MESSAGE_MAX_BYTES),
+  };
 }
 
 async function readRunIfPresent(

--- a/packages/runtime-host/src/server/canonical-turn-snapshot.ts
+++ b/packages/runtime-host/src/server/canonical-turn-snapshot.ts
@@ -1,7 +1,8 @@
 import type { AgentRunHeader } from '@maka/core/agent-run';
+import { truncateUtf8 } from '@maka/core/diagnostic-log';
 import { classifyTerminalRuntimeLedger } from '@maka/runtime';
 import type { ExecutionStoresWriter } from '@maka/storage/execution-stores';
-import type { TurnSnapshot } from '../protocol/index.js';
+import { TURN_FAILURE_MESSAGE_MAX_BYTES, type TurnSnapshot } from '../protocol/index.js';
 
 type CanonicalTurnStores = Pick<
   ExecutionStoresWriter<'interactive'>,
@@ -51,6 +52,11 @@ export async function readCanonicalTurnSnapshot(
         status: 'failed',
         terminalEventId: fact.terminalEvent.id,
         failureClass: fact.failureClass,
+        ...(run.failureMessage
+          ? {
+              failureMessage: truncateUtf8(run.failureMessage, TURN_FAILURE_MESSAGE_MAX_BYTES, '…'),
+            }
+          : {}),
       };
     }
     if (!fact.abortSource) throw new Error('Cancelled terminal fact has no abort source');

--- a/packages/runtime-host/src/server/execution-inspect-coordinator.ts
+++ b/packages/runtime-host/src/server/execution-inspect-coordinator.ts
@@ -45,6 +45,7 @@ interface InspectStores {
     | 'listSessionRunsBounded'
     | 'readEventsBounded'
     | 'readEventsByTypeBounded'
+    | 'readRootTurnAdmission'
   >;
   readonly runtimeEventStore: Pick<ExecutionRuntimeEventReader, 'readRuntimeEventsBounded'>;
 }
@@ -115,7 +116,9 @@ export class HostExecutionInspectCoordinator {
           ? await this.#inspectAgentRun(input.sessionId, input.agentRunId)
           : input.kind === 'session'
             ? await this.#inspectSession(input.sessionId)
-            : await this.#inspectSessionTracePage(input);
+            : input.kind === 'turn_trace'
+              ? await this.#inspectTurnTrace(input.sessionId, input.turnId)
+              : await this.#inspectSessionTracePage(input);
       if (result === undefined) {
         return failure('execution.inspect.query', 'not_found', 'Execution evidence was not found');
       }
@@ -125,7 +128,9 @@ export class HostExecutionInspectCoordinator {
           'invalid_request',
           input.kind === 'session'
             ? 'Session inspection exceeds the live Host result limit; inspect one AgentRun instead'
-            : 'AgentRun inspection exceeds the live Host result limit',
+            : input.kind === 'turn_trace'
+              ? 'Turn trace exceeds the live Host result limit'
+              : 'AgentRun inspection exceeds the live Host result limit',
         );
       }
       return { ok: true, result };
@@ -248,6 +253,43 @@ export class HostExecutionInspectCoordinator {
     return createTracePage(trace, revision, offset);
   }
 
+  async #inspectTurnTrace(
+    sessionId: string,
+    turnId: string,
+  ): Promise<ExecutionInspectQueryResult | undefined> {
+    try {
+      await this.#stores.sessionStore.readHeaderSnapshot(sessionId);
+    } catch (error) {
+      if (isMissing(error)) return undefined;
+      throw error;
+    }
+    const admission = await this.#stores.agentRunStore.readRootTurnAdmission(sessionId, turnId);
+    if (!admission) return undefined;
+    try {
+      const run = await this.#stores.agentRunStore.readRun(sessionId, admission.runId);
+      if (run.turnId !== turnId) {
+        throw new InspectQueryInvalidError('Turn trace admission does not match its AgentRun');
+      }
+    } catch (error) {
+      if (isMissing(error)) return undefined;
+      throw error;
+    }
+    const evidence = await this.#readRunTraceEvidence(
+      sessionId,
+      admission.runId,
+      new InspectEvidenceBudget('Turn'),
+    );
+    const turn = projectSessionTrace({
+      sessionId,
+      runtimeEvents: evidence.runtimeEvents,
+      modelCallAttempts: evidence.modelCallAttempts,
+      ...(evidence.unreadableRecords > 0 ? { unreadableRecords: evidence.unreadableRecords } : {}),
+    }).turns.find(
+      (candidate) => candidate.turnId === turnId && candidate.runId === admission.runId,
+    );
+    return turn ? { kind: 'turn_trace', sessionId, turn } : undefined;
+  }
+
   async #readSessionTrace(sessionId: string): Promise<SessionTrace | undefined> {
     try {
       await this.#stores.sessionStore.readHeaderSnapshot(sessionId);
@@ -267,33 +309,10 @@ export class HostExecutionInspectCoordinator {
     const modelCallAttempts: ModelCallAttempt[] = [];
     let unreadableRecords = 0;
     for (const run of runPage.runs) {
-      const runEvents = await budget
-        .read((remaining) =>
-          this.#stores.agentRunStore.readEventsByTypeBounded(
-            sessionId,
-            run.runId,
-            MODEL_CALL_ATTEMPT_EVENT_TYPE,
-            remaining,
-          ),
-        )
-        .catch((error) => {
-          if (isInspectQueryTooLargeError(error)) throw error;
-          unreadableRecords += 1;
-          return [];
-        });
-      for (const event of runEvents) {
-        if (event.type !== MODEL_CALL_ATTEMPT_EVENT_TYPE) continue;
-        try {
-          modelCallAttempts.push(decodeModelCallAttempt(event.data));
-        } catch {
-          unreadableRecords += 1;
-        }
-      }
-      runtimeEvents.push(
-        ...(await budget.read((remaining) =>
-          this.#stores.runtimeEventStore.readRuntimeEventsBounded(sessionId, run.runId, remaining),
-        )),
-      );
+      const evidence = await this.#readRunTraceEvidence(sessionId, run.runId, budget);
+      runtimeEvents.push(...evidence.runtimeEvents);
+      modelCallAttempts.push(...evidence.modelCallAttempts);
+      unreadableRecords += evidence.unreadableRecords;
     }
     return projectSessionTrace({
       sessionId,
@@ -301,6 +320,45 @@ export class HostExecutionInspectCoordinator {
       modelCallAttempts,
       ...(unreadableRecords > 0 ? { unreadableRecords } : {}),
     });
+  }
+
+  async #readRunTraceEvidence(
+    sessionId: string,
+    runId: string,
+    budget: InspectEvidenceBudget,
+  ): Promise<{
+    readonly runtimeEvents: RuntimeEvent[];
+    readonly modelCallAttempts: ModelCallAttempt[];
+    readonly unreadableRecords: number;
+  }> {
+    let unreadableRecords = 0;
+    const runEvents = await budget
+      .read((remaining) =>
+        this.#stores.agentRunStore.readEventsByTypeBounded(
+          sessionId,
+          runId,
+          MODEL_CALL_ATTEMPT_EVENT_TYPE,
+          remaining,
+        ),
+      )
+      .catch((error) => {
+        if (isInspectQueryTooLargeError(error)) throw error;
+        unreadableRecords += 1;
+        return [];
+      });
+    const modelCallAttempts: ModelCallAttempt[] = [];
+    for (const event of runEvents) {
+      if (event.type !== MODEL_CALL_ATTEMPT_EVENT_TYPE) continue;
+      try {
+        modelCallAttempts.push(decodeModelCallAttempt(event.data));
+      } catch {
+        unreadableRecords += 1;
+      }
+    }
+    const runtimeEvents = await budget.read((remaining) =>
+      this.#stores.runtimeEventStore.readRuntimeEventsBounded(sessionId, runId, remaining),
+    );
+    return { runtimeEvents, modelCallAttempts, unreadableRecords };
   }
 
   #budgetedReaders(label: 'AgentRun' | 'Session') {
@@ -336,7 +394,7 @@ class InspectEvidenceBudget {
   #remainingRecords = EXECUTION_INSPECT_EVIDENCE_MAX_RECORDS;
   #remainingBytes = EXECUTION_INSPECT_EVIDENCE_MAX_BYTES;
 
-  constructor(private readonly label: 'AgentRun' | 'Session') {}
+  constructor(private readonly label: 'AgentRun' | 'Session' | 'Turn') {}
 
   async read<T>(
     operation: (budget: EvidenceReadBudget) => Promise<BoundedEvidenceReadResult<T>>,

--- a/packages/runtime-host/src/server/hosted-execution-projection.ts
+++ b/packages/runtime-host/src/server/hosted-execution-projection.ts
@@ -3,11 +3,9 @@ import {
   type AgentRunHeader,
   type RootExecutionDescriptor,
 } from '@maka/core/agent-run';
-import {
-  classifyTerminalRuntimeLedger,
-  RuntimeMessageAuthorityInvariantError,
-} from '@maka/runtime';
+import { RuntimeMessageAuthorityInvariantError } from '@maka/runtime';
 import type { ExecutionStoresWriter } from '@maka/storage/execution-stores';
+import { readCanonicalTurnSnapshot } from './canonical-turn-snapshot.js';
 import type { HostedExecutionRef, HostedExecutionSnapshot } from './hosted-execution-authority.js';
 
 export class HostedExecutionProjectionReader {
@@ -18,57 +16,12 @@ export class HostedExecutionProjectionReader {
     knownRun?: AgentRunHeader,
   ): Promise<HostedExecutionSnapshot> {
     const run = knownRun ?? (await this.readRunIfPresent(execution.sessionId, execution.runId));
-    if (!run) return { ...execution, status: 'admitted' };
-    if (run.turnId !== execution.turnId) {
+    if (run && run.turnId !== execution.turnId) {
       throw new RuntimeMessageAuthorityInvariantError(
         `Hosted execution ${execution.turnId} does not match Run ${execution.runId}`,
       );
     }
-
-    const [runEvents, runtimeEvents] = await Promise.all([
-      this.stores.agentRunStore.readEvents(execution.sessionId, execution.runId),
-      this.stores.runtimeEventStore.readImmutableRuntimeEvents(
-        execution.sessionId,
-        execution.runId,
-      ),
-    ]);
-    const terminal = classifyTerminalRuntimeLedger(run, runtimeEvents);
-    if (terminal.kind === 'fact') {
-      const fact = terminal.fact;
-      if (fact.runStatus === 'completed') {
-        return {
-          ...execution,
-          status: 'completed',
-          terminalEventId: fact.terminalEvent.id,
-        };
-      }
-      if (fact.runStatus === 'failed') {
-        if (!fact.failureClass) throw new Error('Failed terminal fact has no failure class');
-        return {
-          ...execution,
-          status: 'failed',
-          terminalEventId: fact.terminalEvent.id,
-          failureClass: fact.failureClass,
-        };
-      }
-      if (!fact.abortSource) throw new Error('Cancelled terminal fact has no abort source');
-      return {
-        ...execution,
-        status: 'cancelled',
-        terminalEventId: fact.terminalEvent.id,
-        abortSource: fact.abortSource,
-      };
-    }
-    if (terminal.kind !== 'none') {
-      throw new Error('Runtime ledger does not contain one canonical terminal fact');
-    }
-    if (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled') {
-      throw new Error('Terminal Run header has no canonical terminal RuntimeEvent');
-    }
-    if (run.status !== 'created' && !runEvents.some((event) => event.type === 'run_started')) {
-      throw new Error('Non-created Run has no durable start fact');
-    }
-    return { ...execution, status: run.status };
+    return readCanonicalTurnSnapshot(this.stores, execution, run);
   }
 
   async readRunIfPresent(sessionId: string, runId: string): Promise<AgentRunHeader | undefined> {

--- a/packages/runtime-host/src/server/message-coordinator.ts
+++ b/packages/runtime-host/src/server/message-coordinator.ts
@@ -26,7 +26,6 @@ import {
   MESSAGE_QUEUE_PROJECTION_MAX_BYTES,
   MESSAGE_OPERATION_RESULT_MAX_BYTES,
   MESSAGE_OPERATION_SPECS,
-  TURN_FAILURE_MESSAGE_MAX_BYTES,
   type MessagePlacement,
   type QueueRetractInput,
   type QueueRetractResult,
@@ -42,6 +41,7 @@ import {
   type TurnSnapshot,
 } from '../protocol/index.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
+import { worstCaseFailedTurnSnapshot } from './canonical-turn-snapshot.js';
 import { worstCaseMessageQueueProjection } from './message-queue-capacity.js';
 import type { ConnectionContext, MessageOperationHandlerMap } from './operation-dispatcher.js';
 import { messageContentDigest } from './message-content-digest.js';
@@ -1592,14 +1592,7 @@ function interruptResultFits(
   const retracted = [...projection.steering, ...projection.followup]
     .filter((entry) => entry.state === 'queued')
     .map((entry): RetractedMessageSnapshot => ({ ...entry, state: 'retracted' }));
-  // Control characters maximize JSON expansion for the protocol-bounded string field.
-  const worstCaseTurn: TurnSnapshot = {
-    ...identity,
-    status: 'failed',
-    terminalEventId: 'x'.repeat(128),
-    failureClass: '\0'.repeat(128),
-    failureMessage: '\0'.repeat(TURN_FAILURE_MESSAGE_MAX_BYTES),
-  };
+  const worstCaseTurn = worstCaseFailedTurnSnapshot(identity);
   return fitsEncodedByteLimit(
     { queueRevision: Number.MAX_SAFE_INTEGER, retracted, turn: worstCaseTurn },
     MESSAGE_OPERATION_RESULT_MAX_BYTES,

--- a/packages/runtime-host/src/server/message-coordinator.ts
+++ b/packages/runtime-host/src/server/message-coordinator.ts
@@ -26,6 +26,7 @@ import {
   MESSAGE_QUEUE_PROJECTION_MAX_BYTES,
   MESSAGE_OPERATION_RESULT_MAX_BYTES,
   MESSAGE_OPERATION_SPECS,
+  TURN_FAILURE_MESSAGE_MAX_BYTES,
   type MessagePlacement,
   type QueueRetractInput,
   type QueueRetractResult,
@@ -1597,6 +1598,7 @@ function interruptResultFits(
     status: 'failed',
     terminalEventId: 'x'.repeat(128),
     failureClass: '\0'.repeat(128),
+    failureMessage: '\0'.repeat(TURN_FAILURE_MESSAGE_MAX_BYTES),
   };
   return fitsEncodedByteLimit(
     { queueRevision: Number.MAX_SAFE_INTEGER, retracted, turn: worstCaseTurn },

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -6043,12 +6043,9 @@ describe('AiSdkBackend model history', () => {
     );
   });
 
-  test('provider error mid-step still persists the streamed partial text (partialOutputRetained)', async () => {
-    // Codex P1: the non-abort error exit (provider failure / watchdog timeout)
-    // must flush the in-flight step's partial accumulators just like the abort
-    // exit does — the user already saw the streamed text, so it belongs in the
-    // ledger. The gate releases only after the backend has emitted the partial
-    // text_delta, so consumption-before-error is deterministic.
+  test('provider error mid-step persists partial text and its safe provider summary', async () => {
+    // The user already saw the streamed text, so it belongs in the ledger even
+    // when the provider fails. The gate makes consumption-before-error deterministic.
     const gate = makeGate();
     const model = new MockLanguageModelV4({
       doStream: {
@@ -6058,7 +6055,10 @@ describe('AiSdkBackend model history', () => {
             controller.enqueue({ type: 'text-start', id: 'text-1' });
             controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'partial answer' });
             await gate.promise;
-            controller.error(new Error('provider exploded mid-step'));
+            controller.error({
+              error: { code: 'provider_error', message: 'provider exploded mid-step' },
+              request_id: 'req-mid-step',
+            });
           },
         }),
       },
@@ -6089,9 +6089,10 @@ describe('AiSdkBackend model history', () => {
     assert.equal(assistants.length, 1);
     assert.equal(assistants[0]!.text, 'partial answer');
     // And the turn still closes as an error, not a false success.
+    const failure = events.find((event) => event.type === 'error');
     assert.equal(
-      events.some((event) => event.type === 'error'),
-      true,
+      failure?.message,
+      'provider exploded mid-step (code=provider_error, requestId=req-mid-step)',
     );
     const completes = events.filter((event) => event.type === 'complete');
     assert.equal(completes.length > 0, true);

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -11593,6 +11593,7 @@ describe('AiSdkBackend RunTrace', () => {
 
   test('does not retry an idle watchdog timeout after partial answer text', async () => {
     const timers = manualWatchdogTimer();
+    const traces: RunTraceEvent[] = [];
     let calls = 0;
     const model = new MockLanguageModelV4({
       doStream: async (options) => {
@@ -11622,6 +11623,7 @@ describe('AiSdkBackend RunTrace', () => {
       now: monotonicClock(),
       streamWatchdogTimer: timers.clock,
       providerRetrySleep: async () => {},
+      recordRunTrace: (event) => traces.push(event),
     });
 
     const events: SessionEvent[] = [];
@@ -11637,6 +11639,10 @@ describe('AiSdkBackend RunTrace', () => {
     );
     assert.equal(events.find((event) => event.type === 'error')?.reason, 'timeout');
     assert.equal(events.find((event) => event.type === 'complete')?.stopReason, 'error');
+    const failureTrace = traces.find((event) => event.type === 'model_stream_failed');
+    assert.equal(failureTrace?.data?.rawErrorName, 'Error');
+    assert.match(String(failureTrace?.data?.redactedErrorMessage), /stream idle timeout/);
+    assert.equal(typeof failureTrace?.data?.redactedErrorStackSha256, 'string');
   });
 
   test('does not retry an idle watchdog timeout after provider continuation metadata', async () => {

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -508,6 +508,7 @@ describe('AiSdkFlow seam', () => {
 
     assert.equal(out[1].status, 'failed');
     assert.equal(isTerminalRuntimeEvent(out[1]), true);
+    assert.deepEqual(out[1].content, err.content);
   });
 
   test('synthesizes a failed terminal event when the backend exhausts without one', async () => {

--- a/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
@@ -48,6 +48,7 @@ describe('ModelAdapter.startStream onError', () => {
       {
         type: 'model_failure',
         kind: 'rate_limit',
+        code: '429',
         message: 'Rate limit exceeded',
         retryable: true,
         retryAfterMs: 2500,

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -603,11 +603,24 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(event.message, 'Network error');
   });
 
-  test('keeps an unknown structured provider error generic', () => {
-    const event = newAdapter().makeErrorEvent('turn-1', { message: 'provider exploded' });
+  test('retains a safe bounded summary from an unknown structured provider error', () => {
+    const adapter = newAdapter();
+    const failure = adapter.normalizeFailure({
+      type: 'error',
+      error: {
+        code: 'provider_error',
+        message: `provider exploded api_key=sk-live-secret-token-value ${'x'.repeat(4_000)}`,
+      },
+      request_id: 'req-123',
+    });
+    const event = adapter.makeErrorEvent('turn-1', failure);
 
     assert.equal(event.reason, undefined);
-    assert.equal(event.message, 'Operation failed');
+    assert.equal(event.code, 'provider_error');
+    assert.match(event.message, /^provider exploded api_key=\[redacted\]/);
+    assert.match(event.message, /… \(code=provider_error, requestId=req-123\)$/);
+    assert.equal(Buffer.byteLength(event.message, 'utf8') <= 2 * 1024, true);
+    assert.equal(event.message.includes('sk-live-secret-token-value'), false);
   });
 
   test('normalizes cache and reasoning usage variants in the adapter module', () => {

--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -7,10 +7,47 @@ import { z } from 'zod/v4';
 import {
   classifyError,
   errorPresentationFromClass,
+  providerFailureSummary,
   providerRetryMetadata,
 } from '../provider-error-classification.js';
 
 describe('Provider error classification', () => {
+  test('extracts allowlisted fields from JSON string failures without copying the payload', () => {
+    const summary = providerFailureSummary(
+      JSON.stringify({
+        error: { message: 'provider rejected request', code: 'bad_request' },
+        request_id: 'req-123',
+        prompt: 'private customer text',
+        headers: { 'x-debug': 'internal' },
+      }),
+    );
+
+    assert.deepEqual(summary, {
+      message: 'provider rejected request (code=bad_request, requestId=req-123)',
+      code: 'bad_request',
+    });
+    assert.equal(JSON.stringify(summary).includes('private customer text'), false);
+    assert.equal(JSON.stringify(summary).includes('x-debug'), false);
+
+    assert.deepEqual(
+      providerFailureSummary({
+        error: JSON.stringify({
+          message: 'nested provider rejection',
+          code: 'nested_error',
+          prompt: 'another private prompt',
+        }),
+      }),
+      {
+        message: 'nested provider rejection (code=nested_error)',
+        code: 'nested_error',
+      },
+    );
+    assert.equal(
+      providerFailureSummary(JSON.stringify([{ prompt: 'private list payload' }])),
+      undefined,
+    );
+  });
+
   test('retries incremental Responses transport failures with stable classification', () => {
     const websocketFailure = Object.assign(new Error('closed before completion'), {
       name: 'OpenAiResponsesTransportError',

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2484,7 +2484,7 @@ export class AiSdkBackend implements AgentBackend {
               // Unrecoverable (not context-length, latch spent, no seam, or no
               // safe fold): surface the real provider error via the terminal
               // handler — never a fabricated success.
-              throw attemptFailure;
+              throw failure;
             }
             break;
           }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2484,7 +2484,7 @@ export class AiSdkBackend implements AgentBackend {
               // Unrecoverable (not context-length, latch spent, no seam, or no
               // safe fold): surface the real provider error via the terminal
               // handler — never a fabricated success.
-              throw failure;
+              throw attemptFailure;
             }
             break;
           }

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -82,6 +82,7 @@ export function mapCompleteStopReason(reason: CompleteStopReason): RuntimeEventS
 export interface SessionEventMapMemory {
   toolNameByUseId: Map<string, string>;
   failureClass?: string;
+  failureContent?: Extract<RuntimeEvent['content'], { kind: 'error' }>;
 }
 
 export function createSessionEventMapMemory(): SessionEventMapMemory {
@@ -549,23 +550,26 @@ function mapBackendSessionEvent(
       };
 
     // ── Error ─────────────────────────────────────────────────────────────
-    case 'error':
+    case 'error': {
       // No status here: the backend follows with a terminal `complete(error)`.
       // Keeping status off the error event avoids a double-terminal in the
       // error path; the trailing complete carries the terminal signal.
       memory.failureClass = event.reason ?? event.code ?? 'unknown';
+      const content = {
+        kind: 'error' as const,
+        ...(event.code !== undefined ? { code: event.code } : {}),
+        ...(event.reason !== undefined ? { reason: event.reason } : {}),
+        message: event.message,
+        ...(event.details !== undefined ? { details: event.details } : {}),
+      };
+      memory.failureContent = content;
       return {
         ...base,
         role: 'system',
         author: 'system',
-        content: {
-          kind: 'error',
-          ...(event.code !== undefined ? { code: event.code } : {}),
-          ...(event.reason !== undefined ? { reason: event.reason } : {}),
-          message: event.message,
-          ...(event.details !== undefined ? { details: event.details } : {}),
-        },
+        content,
       };
+    }
 
     // ── Terminal: abort + complete ────────────────────────────────────────
     case 'abort':
@@ -629,6 +633,7 @@ function completeRuntimeEvent(
     role: 'system',
     author: 'system',
     status,
+    ...(status === 'failed' && memory.failureContent ? { content: memory.failureContent } : {}),
     actions: { endInvocation: true, stateDelta },
   };
 }

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -38,6 +38,7 @@ import { resolveModelRuntime, type ResolvedModelRuntime } from './model-runtime.
 import {
   classifyError,
   errorPresentationFromClass,
+  providerFailureSummary,
   providerRetryMetadata,
 } from './provider-error-classification.js';
 import {
@@ -321,7 +322,7 @@ export class ModelAdapter {
           }
         } catch (error) {
           succeeded = false;
-          yield { kind: 'error', failure: normalizeModelFailure(error) };
+          yield { kind: 'error', failure: normalizeProviderFailure(error) };
         } finally {
           if (!continuation.lane) return;
           if (!succeeded) {
@@ -459,7 +460,7 @@ export class ModelAdapter {
   }
 
   normalizeFailure(error: unknown): ModelFailure {
-    return normalizeModelFailure(error);
+    return normalizeProviderFailure(error);
   }
 
   classifyError(error: unknown): string {
@@ -782,7 +783,7 @@ function translateChunk(
       return [{ kind: 'tool-call', toolCall }];
     }
     case 'error':
-      return [{ kind: 'error', failure: normalizeModelFailure(chunk.error) }];
+      return [{ kind: 'error', failure: normalizeProviderFailure(chunk.error) }];
     default:
       return [];
   }
@@ -848,6 +849,17 @@ function normalizeModelFailure(error: unknown): ModelFailure {
     ...(retry.retryAfterMs !== undefined ? { retryAfterMs: retry.retryAfterMs } : {}),
     ...(code !== undefined ? { code } : {}),
     message: presentation.message ?? generalizedErrorMessage(error),
+  };
+}
+
+function normalizeProviderFailure(error: unknown): ModelFailure {
+  if (isModelFailure(error)) return error;
+  const summary = providerFailureSummary(error);
+  const failure = normalizeModelFailure(error);
+  return {
+    ...failure,
+    ...(summary?.code !== undefined ? { code: summary.code } : {}),
+    ...(failure.kind === 'unknown' && summary !== undefined ? { message: summary.message } : {}),
   };
 }
 

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -1,5 +1,6 @@
 import { RetryError } from 'ai';
-import { isAuthenticationErrorText } from '@maka/core/redaction';
+import { truncateUtf8 } from '@maka/core/diagnostic-log';
+import { isAuthenticationErrorText, redactSecrets } from '@maka/core/redaction';
 
 /**
  * Structured provider error identifiers that mean the INPUT exceeded the
@@ -38,6 +39,14 @@ export interface ProviderRetryMetadata {
   retryable: boolean;
   retryAfterMs?: number;
 }
+
+interface ProviderFailureSummary {
+  message: string;
+  code?: string;
+}
+
+const PROVIDER_FAILURE_SUMMARY_MAX_BYTES = 2 * 1024;
+const PROVIDER_FAILURE_FIELD_MAX_BYTES = 256;
 
 const MAX_SAFE_TIMER_DELAY_MS = 2_147_483_647;
 const OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR = 'OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR';
@@ -190,6 +199,126 @@ function normalizeErrorEvidence(error: unknown): ProviderErrorEvidence | undefin
     };
   }
   return undefined;
+}
+
+/**
+ * Retains only allowlisted provider failure fields. The provider value may also
+ * contain request bodies, headers, or credentials, so it must never be copied
+ * or serialized as diagnostic output wholesale.
+ */
+export function providerFailureSummary(error: unknown): ProviderFailureSummary | undefined {
+  const target = providerErrorTarget(error);
+  const sources = providerFailureSources(target);
+  const message = firstProviderMessage(target, sources);
+  const code = firstProviderField(sources, ['code']) ?? firstProviderField(sources, ['type']);
+  const statusCode = firstProviderField(sources, ['statusCode', 'status']);
+  const requestId =
+    firstProviderField(sources, ['requestId', 'request_id']) ??
+    boundedProviderField(responseHeadersFromError(target)?.['x-request-id']);
+  const metadata = [
+    ...(code ? [`code=${code}`] : []),
+    ...(statusCode && statusCode !== code ? [`status=${statusCode}`] : []),
+    ...(requestId ? [`requestId=${requestId}`] : []),
+  ];
+  if (!message && metadata.length === 0) return undefined;
+  const suffix = metadata.length > 0 ? ` (${metadata.join(', ')})` : '';
+  const messageBudget = Math.max(
+    1,
+    PROVIDER_FAILURE_SUMMARY_MAX_BYTES - Buffer.byteLength(suffix, 'utf8'),
+  );
+  const summary = `${truncateUtf8(
+    redactSecrets(message ?? 'Provider request failed'),
+    messageBudget,
+    '…',
+  )}${suffix}`;
+  return {
+    message: truncateUtf8(summary, PROVIDER_FAILURE_SUMMARY_MAX_BYTES, '…'),
+    ...(code || statusCode ? { code: code ?? statusCode } : {}),
+  };
+}
+
+interface ProviderFailureSources {
+  records: readonly Record<string, unknown>[];
+  stringErrors: readonly unknown[];
+}
+
+function providerFailureSources(error: unknown): ProviderFailureSources {
+  const record = objectRecord(error);
+  if (!record) return { records: [], stringErrors: [] };
+  const data = objectRecord(safeField(record, 'data'));
+  const nestedError = objectRecord(safeField(record, 'error'));
+  const dataError = objectRecord(data ? safeField(data, 'error') : undefined);
+  const parsedBody = parsedProviderBody(safeField(record, 'responseBody'));
+  const parsedBodyError = objectRecord(parsedBody ? safeField(parsedBody, 'error') : undefined);
+  return {
+    records: [dataError, data, parsedBodyError, parsedBody, nestedError, record].filter(
+      (source): source is Record<string, unknown> => source !== undefined,
+    ),
+    stringErrors: [
+      data ? safeField(data, 'error') : undefined,
+      parsedBody ? safeField(parsedBody, 'error') : undefined,
+      safeField(record, 'error'),
+    ],
+  };
+}
+
+function firstProviderMessage(error: unknown, sources: ProviderFailureSources): string | undefined {
+  if (typeof error === 'string') return boundedProviderMessage(error);
+  const candidates = [
+    ...sources.records.map((source) => safeField(source, 'message')),
+    ...sources.stringErrors,
+  ];
+  return candidates.map(boundedProviderMessage).find((value) => value !== undefined);
+}
+
+function firstProviderField(
+  sources: ProviderFailureSources,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    for (const source of sources.records) {
+      const value = boundedProviderField(safeField(source, key));
+      if (value !== undefined) return value;
+    }
+  }
+  return undefined;
+}
+
+function parsedProviderBody(value: unknown): Record<string, unknown> | undefined {
+  if (typeof value !== 'string') return undefined;
+  try {
+    return objectRecord(JSON.parse(value));
+  } catch {
+    return undefined;
+  }
+}
+
+function objectRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function safeField(record: Record<string, unknown>, key: string): unknown {
+  try {
+    return record[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function boundedProviderField(value: unknown): string | undefined {
+  if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+  const normalized = String(value).trim();
+  if (!normalized) return undefined;
+  return truncateUtf8(redactSecrets(normalized), PROVIDER_FAILURE_FIELD_MAX_BYTES, '…');
+}
+
+function boundedProviderMessage(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  return truncateUtf8(redactSecrets(normalized), PROVIDER_FAILURE_SUMMARY_MAX_BYTES, '…');
 }
 
 /**

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -35,6 +35,14 @@ interface ProviderErrorEvidence {
   structuredCodes: string[];
 }
 
+interface ProviderErrorFacts {
+  target: unknown;
+  evidence: ProviderErrorEvidence;
+  summarySources: ProviderFailureSources;
+  bareMessage?: string;
+  responseHeaders?: Record<string, string>;
+}
+
 export interface ProviderRetryMetadata {
   retryable: boolean;
   retryAfterMs?: number;
@@ -93,14 +101,14 @@ function parseRetryAfterMs(headers: Record<string, string>): number | null | und
  * response headers across the ModelAdapter boundary.
  */
 export function providerRetryMetadata(error: unknown): ProviderRetryMetadata {
-  const target = providerErrorTarget(error);
-  const evidence = normalizeErrorEvidence(target);
-  if (!evidence) return { retryable: false };
+  const facts = normalizeProviderError(error);
+  if (!facts) return { retryable: false };
+  const { evidence } = facts;
 
   if (RUNTIME_RETRYABLE_ERROR_CODES.has(evidence.code)) return { retryable: true };
 
   const status = Number(evidence.statusCode || evidence.code);
-  const errorClass = classifyError(target);
+  const errorClass = classifyProviderFacts(facts);
   const retryable =
     errorClass === 'Network' ||
     status === 408 ||
@@ -109,7 +117,7 @@ export function providerRetryMetadata(error: unknown): ProviderRetryMetadata {
     (status >= 500 && status <= 599);
   if (!retryable) return { retryable: false };
 
-  const retryAfterMs = parseRetryAfterMs(responseHeadersFromError(target) ?? {});
+  const retryAfterMs = parseRetryAfterMs(facts.responseHeaders ?? {});
   if (retryAfterMs === null) return { retryable: false };
   return {
     retryable: true,
@@ -119,32 +127,33 @@ export function providerRetryMetadata(error: unknown): ProviderRetryMetadata {
 
 /** Collects `code`/`type` strings from a payload and from its `error` wrapper. */
 function collectStructuredCodes(payload: unknown, out: string[]): void {
-  const fromRecord = (record: unknown) => {
-    if (typeof record !== 'object' || record === null) return;
+  const fromRecord = (record: Record<string, unknown> | undefined) => {
+    if (!record) return;
     for (const key of ['code', 'type'] as const) {
-      const value = (record as Record<string, unknown>)[key];
+      const value = safeField(record, key);
       if (typeof value === 'string' && value) out.push(value.toLowerCase());
     }
   };
-  fromRecord(payload);
-  if (typeof payload === 'object' && payload !== null) {
-    fromRecord((payload as { error?: unknown }).error);
-  }
+  const record = providerRecord(payload);
+  fromRecord(record);
+  fromRecord(record ? providerRecord(safeField(record, 'error')) : undefined);
 }
 
-function normalizeErrorEvidence(error: unknown): ProviderErrorEvidence | undefined {
-  if (error instanceof Error) {
-    const code = 'code' in error ? String((error as { code?: unknown }).code) : '';
+function normalizeProviderError(error: unknown): ProviderErrorFacts | undefined {
+  const target = providerErrorTarget(error);
+  if (target instanceof Error) {
+    const responseHeaders = responseHeadersFromError(target);
+    const code = 'code' in target ? String((target as { code?: unknown }).code) : '';
     const statusCode =
-      'statusCode' in error
-        ? String((error as { statusCode?: unknown }).statusCode)
-        : 'status' in error
-          ? String((error as { status?: unknown }).status)
+      'statusCode' in target
+        ? String((target as { statusCode?: unknown }).statusCode)
+        : 'status' in target
+          ? String((target as { status?: unknown }).status)
           : '';
-    const rawBody = (error as { responseBody?: unknown }).responseBody;
+    const rawBody = (target as { responseBody?: unknown }).responseBody;
     const body = typeof rawBody === 'string' ? rawBody : '';
     const structuredCodes: string[] = [];
-    collectStructuredCodes((error as { data?: unknown }).data, structuredCodes);
+    collectStructuredCodes((target as { data?: unknown }).data, structuredCodes);
     if (structuredCodes.length === 0 && body) {
       // The failed-response handler keeps the raw body even when the provider
       // JSON failed the schema (which is exactly when `data` is absent).
@@ -155,28 +164,40 @@ function normalizeErrorEvidence(error: unknown): ProviderErrorEvidence | undefin
       }
     }
     return {
+      target,
       // The raw body joins the text evidence: when the provider JSON fails
       // the error schema, `message` degrades to the statusText and the body
       // is the ONLY carrier of the provider's wording (e.g. an
       // OpenAI-compatible `{error: string}` overflow). Positives and vetoes
       // both run over the same full text.
-      text: `${error.name} ${code} ${statusCode} ${error.message}${body ? ` ${body}` : ''}`.toLowerCase(),
-      statusCode,
-      code,
-      structuredCodes,
+      evidence: {
+        text: `${target.name} ${code} ${statusCode} ${target.message}${body ? ` ${body}` : ''}`.toLowerCase(),
+        statusCode,
+        code,
+        structuredCodes,
+      },
+      summarySources: providerFailureSources(target),
+      ...(responseHeaders ? { responseHeaders } : {}),
     };
   }
-  if (typeof error === 'string') {
+  if (typeof target === 'string') {
+    const parsed = parsedProviderValue(target);
     const structuredCodes: string[] = [];
-    try {
-      collectStructuredCodes(JSON.parse(error), structuredCodes);
-    } catch {
-      // A plain message string — text evidence only.
-    }
-    return { text: error.toLowerCase(), statusCode: '', code: '', structuredCodes };
+    if (parsed !== undefined) collectStructuredCodes(parsed, structuredCodes);
+    return {
+      target,
+      evidence: { text: target.toLowerCase(), statusCode: '', code: '', structuredCodes },
+      summarySources: providerFailureSources(parsed),
+      ...(parsed === undefined
+        ? { bareMessage: target }
+        : typeof parsed === 'string'
+          ? { bareMessage: parsed }
+          : {}),
+    };
   }
-  if (typeof error === 'object' && error !== null) {
-    const record = error as Record<string, unknown>;
+  if (typeof target === 'object' && target !== null) {
+    const record = target as Record<string, unknown>;
+    const responseHeaders = responseHeadersFromError(target);
     const field = (key: string): string => {
       const value = record[key];
       return typeof value === 'string' || typeof value === 'number' ? String(value) : '';
@@ -187,15 +208,20 @@ function normalizeErrorEvidence(error: unknown): ProviderErrorEvidence | undefin
     try {
       // Serialize the whole value so message/code text is evidence no matter
       // which of the known provider shapes carried it.
-      text = JSON.stringify(error).toLowerCase();
+      text = JSON.stringify(target).toLowerCase();
     } catch {
-      text = String(error).toLowerCase();
+      text = String(target).toLowerCase();
     }
     return {
-      text,
-      statusCode: field('statusCode') || field('status'),
-      code: field('code'),
-      structuredCodes,
+      target,
+      evidence: {
+        text,
+        statusCode: field('statusCode') || field('status'),
+        code: field('code'),
+        structuredCodes,
+      },
+      summarySources: providerFailureSources(target),
+      ...(responseHeaders ? { responseHeaders } : {}),
     };
   }
   return undefined;
@@ -207,14 +233,15 @@ function normalizeErrorEvidence(error: unknown): ProviderErrorEvidence | undefin
  * or serialized as diagnostic output wholesale.
  */
 export function providerFailureSummary(error: unknown): ProviderFailureSummary | undefined {
-  const target = providerErrorTarget(error);
-  const sources = providerFailureSources(target);
-  const message = firstProviderMessage(target, sources);
+  const facts = normalizeProviderError(error);
+  if (!facts) return undefined;
+  const sources = facts.summarySources;
+  const message = firstProviderMessage(facts);
   const code = firstProviderField(sources, ['code']) ?? firstProviderField(sources, ['type']);
   const statusCode = firstProviderField(sources, ['statusCode', 'status']);
   const requestId =
     firstProviderField(sources, ['requestId', 'request_id']) ??
-    boundedProviderField(responseHeadersFromError(target)?.['x-request-id']);
+    boundedProviderField(facts.responseHeaders?.['x-request-id']);
   const metadata = [
     ...(code ? [`code=${code}`] : []),
     ...(statusCode && statusCode !== code ? [`status=${statusCode}`] : []),
@@ -246,10 +273,10 @@ function providerFailureSources(error: unknown): ProviderFailureSources {
   const record = objectRecord(error);
   if (!record) return { records: [], stringErrors: [] };
   const data = objectRecord(safeField(record, 'data'));
-  const nestedError = objectRecord(safeField(record, 'error'));
-  const dataError = objectRecord(data ? safeField(data, 'error') : undefined);
+  const nestedError = providerRecord(safeField(record, 'error'));
+  const dataError = providerRecord(data ? safeField(data, 'error') : undefined);
   const parsedBody = parsedProviderBody(safeField(record, 'responseBody'));
-  const parsedBodyError = objectRecord(parsedBody ? safeField(parsedBody, 'error') : undefined);
+  const parsedBodyError = providerRecord(parsedBody ? safeField(parsedBody, 'error') : undefined);
   return {
     records: [dataError, data, parsedBodyError, parsedBody, nestedError, record].filter(
       (source): source is Record<string, unknown> => source !== undefined,
@@ -262,13 +289,20 @@ function providerFailureSources(error: unknown): ProviderFailureSources {
   };
 }
 
-function firstProviderMessage(error: unknown, sources: ProviderFailureSources): string | undefined {
-  if (typeof error === 'string') return boundedProviderMessage(error);
+function providerRecord(value: unknown): Record<string, unknown> | undefined {
+  return objectRecord(typeof value === 'string' ? (parsedProviderValue(value) ?? value) : value);
+}
+
+function firstProviderMessage(facts: ProviderErrorFacts): string | undefined {
+  if (facts.bareMessage !== undefined) return boundedProviderMessage(facts.bareMessage);
+  const sources = facts.summarySources;
   const candidates = [
     ...sources.records.map((source) => safeField(source, 'message')),
     ...sources.stringErrors,
   ];
-  return candidates.map(boundedProviderMessage).find((value) => value !== undefined);
+  return candidates
+    .map((candidate) => boundedProviderMessage(candidate))
+    .find((value) => value !== undefined);
 }
 
 function firstProviderField(
@@ -286,8 +320,12 @@ function firstProviderField(
 
 function parsedProviderBody(value: unknown): Record<string, unknown> | undefined {
   if (typeof value !== 'string') return undefined;
+  return objectRecord(parsedProviderValue(value));
+}
+
+function parsedProviderValue(value: string): unknown {
   try {
-    return objectRecord(JSON.parse(value));
+    return JSON.parse(value);
   } catch {
     return undefined;
   }
@@ -314,9 +352,27 @@ function boundedProviderField(value: unknown): string | undefined {
   return truncateUtf8(redactSecrets(normalized), PROVIDER_FAILURE_FIELD_MAX_BYTES, '…');
 }
 
-function boundedProviderMessage(value: unknown): string | undefined {
+function boundedProviderMessage(value: unknown, parseJson = true): string | undefined {
   if (typeof value !== 'string') return undefined;
-  const normalized = value.trim();
+  let normalized = value.trim();
+  if (!normalized) return undefined;
+  if (parseJson) {
+    const parsed = parsedProviderValue(normalized);
+    if (parsed !== undefined) {
+      if (typeof parsed === 'string') {
+        normalized = parsed.trim();
+      } else {
+        const sources = providerFailureSources(parsed);
+        const candidates = [
+          ...sources.records.map((source) => safeField(source, 'message')),
+          ...sources.stringErrors,
+        ];
+        return candidates
+          .map((candidate) => boundedProviderMessage(candidate, false))
+          .find((candidate) => candidate !== undefined);
+      }
+    }
+  }
   if (!normalized) return undefined;
   return truncateUtf8(redactSecrets(normalized), PROVIDER_FAILURE_SUMMARY_MAX_BYTES, '…');
 }
@@ -425,9 +481,12 @@ export function isContextOverflowErrorText(text: string): boolean {
  */
 export function classifyError(error: unknown): string {
   if (RetryError.isInstance(error) && error.reason === 'abort') return 'Abort';
-  const classificationTarget = providerErrorTarget(error);
-  const evidence = normalizeErrorEvidence(classificationTarget);
-  if (!evidence) return 'Other';
+  const facts = normalizeProviderError(error);
+  return facts ? classifyProviderFacts(facts) : 'Other';
+}
+
+function classifyProviderFacts(facts: ProviderErrorFacts): string {
+  const { target: classificationTarget, evidence } = facts;
   const { text, statusCode, code, structuredCodes } = evidence;
   if (text.includes('abort')) return 'Abort';
   if (code === OPENAI_RESPONSES_WEBSOCKET_TRANSPORT_ERROR) return 'Network';

--- a/packages/ui/src/toast.tsx
+++ b/packages/ui/src/toast.tsx
@@ -44,13 +44,22 @@ export interface ToastAction {
 
 export interface ToastErrorAction {
   label: string;
-  onClick(input: Pick<ToastInput, 'title' | 'description' | 'diagnosticDetails'>): void;
+  onClick(
+    input: Pick<ToastInput, 'title' | 'description' | 'diagnosticDetails' | 'diagnosticTarget'>,
+  ): void;
+}
+
+export interface ToastDiagnosticTarget {
+  sessionId: string;
+  turnId: string;
+  eventId: string;
 }
 
 export interface ToastInput {
   title: string;
   description?: string;
   diagnosticDetails?: string;
+  diagnosticTarget?: ToastDiagnosticTarget;
   variant?: ToastVariant;
   /** Auto-dismiss after this many ms. 0 disables the timer. Default 4000. */
   duration?: number;
@@ -68,7 +77,12 @@ export interface ConfirmInput {
 export interface ToastApi {
   toast(input: ToastInput): string;
   success(title: string, description?: string): string;
-  error(title: string, description?: string, diagnosticDetails?: string): string;
+  error(
+    title: string,
+    description?: string,
+    diagnosticDetails?: string,
+    diagnosticTarget?: ToastDiagnosticTarget,
+  ): string;
   info(title: string, description?: string): string;
   warning(title: string, description?: string): string;
   confirm(input: ConfirmInput): Promise<boolean>;
@@ -230,8 +244,15 @@ function ToastController(props: { children: ReactNode; errorAction?: ToastErrorA
     () => ({
       toast: push,
       success: (title, description) => push({ title, description, variant: 'success' }),
-      error: (title, description, diagnosticDetails) =>
-        push({ title, description, diagnosticDetails, variant: 'error', duration: 6000 }),
+      error: (title, description, diagnosticDetails, diagnosticTarget) =>
+        push({
+          title,
+          description,
+          diagnosticDetails,
+          diagnosticTarget,
+          variant: 'error',
+          duration: 6000,
+        }),
       info: (title, description) => push({ title, description, variant: 'info' }),
       warning: (title, description) => push({ title, description, variant: 'warning' }),
       confirm,


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Preserve an allowlisted, redacted, and bounded provider failure summary at the ModelAdapter boundary
- Project the canonical terminal RuntimeEvent failure message through Runtime Host Turn snapshots
- Attach the exact existing execution trace when Desktop copies an error report
- Reuse canonical Turn projection and existing execution inspection instead of adding a diagnostics authority

## Root cause

AI SDK provider failures may arrive as plain structured values rather than Error instances. Generic error normalization reduced unknown structured failures to `Operation failed`, and the Runtime Host Turn projection retained only `failureClass`, so Desktop diagnostics could not reconstruct the provider reason.

## Safety and correctness

JSON-shaped strings are parsed before allowlisted fields are selected; request bodies, prompts, arbitrary headers, and credentials are not copied into diagnostics. Session admission reserves the largest valid failed Turn snapshot, and the terminal RuntimeEvent remains the single failure-message fact across crash recovery.

Previously opaque structured provider failures now retain a safe provider message and available metadata. Historical provider details that were already discarded remain unrecoverable.

The Runtime Host compatibility epoch advances because failed Turn snapshots gain an optional bounded `failureMessage`.

## Validation

- Runtime build and typecheck; full suite: 3,315 passed, 9 skipped
- Runtime Host build and typecheck; full suite: 866 passed
- UI and Desktop build/typecheck; 33 targeted Desktop tests passed
- Biome and `git diff --check`

</details>

<details>
<summary>中文</summary>

## 概要

- 在 ModelAdapter 边界保留经过白名单筛选、脱敏和长度限制的 provider 错误摘要
- 通过 Runtime Host Turn snapshot 投影 canonical terminal RuntimeEvent 中的失败消息
- Desktop 复制错误报告时附加现有 execution trace 中的精确执行证据
- 复用 canonical Turn projection 和现有 execution inspection，不新增诊断 authority

## 根因

AI SDK 的 provider 错误可能是普通结构化值，而不是 Error 实例。通用错误归一化会将未知结构化错误压缩为 `Operation failed`，Runtime Host Turn 投影又只保留 `failureClass`，因此 Desktop 诊断无法还原 provider 原因。

## 安全性与正确性

JSON 形式的字符串会先解析，再选择白名单字段；请求体、prompt、任意 headers 和凭据不会被复制到诊断中。Session admission 会预留合法 failed Turn snapshot 的最大空间，terminal RuntimeEvent 在崩溃恢复前后始终是失败消息的唯一事实来源。

此前不透明的结构化 provider 错误现在会保留安全的 provider 消息和可用元数据。此前已经丢失的历史 provider 详情无法恢复。

由于 failed Turn snapshot 新增了可选且有界的 `failureMessage`，Runtime Host compatibility epoch 相应递增。

## 验证

- Runtime build、typecheck；完整测试 3,315 项通过、9 项跳过
- Runtime Host build、typecheck；完整测试 866 项通过
- UI 与 Desktop build/typecheck；33 项相关 Desktop 测试通过
- Biome 与 `git diff --check`

</details>