### PR TITLE
fix(desktop): disable scroll animation for reduced motion

### DIFF
--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -53,6 +53,7 @@ function renderLiveTurn(liveTurn: LiveTurnProjection): string {
       permissionMode: 'ask',
     },
     messages: [{ type: 'user', id: 'user-1', turnId: liveTurn.turnId, ts: 1, text: 'go' }],
+    scrollBehavior: 'smooth',
     liveTurn,
     onNew() {},
   } satisfies Parameters<typeof ChatView>[0]));
@@ -100,6 +101,7 @@ describe('single live-turn handoff', () => {
         { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
         { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text: finalText, modelId: 'model' },
       ],
+      scrollBehavior: 'smooth',
       liveTurn: {
         turnId: 'turn-1',
         phase: 'streamed',
@@ -129,6 +131,7 @@ describe('single live-turn handoff', () => {
         { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'go' },
         { type: 'assistant', id: 'assistant-1', turnId: 'turn-1', ts: 2, text, modelId: 'model' },
       ],
+      scrollBehavior: 'smooth',
       liveTurn: {
         turnId: 'turn-1',
         phase: 'streamed',

--- a/apps/desktop/src/renderer/quote-companion-panel.tsx
+++ b/apps/desktop/src/renderer/quote-companion-panel.tsx
@@ -25,6 +25,7 @@ import type {
   StagedCompanionQuote,
 } from './quote-companion-panel-state';
 import type { CompanionForkVisibilityEvent } from './quote-companion-visibility';
+import { readScrollMotionBehavior } from './scroll-motion-policy';
 
 /**
  * The side-conversation workbar tab: a transient read-only fork of the main session.
@@ -267,6 +268,7 @@ export function QuoteCompanionPanel(props: {
       >
         <ChatView
           messages={companion.messages}
+          scrollBehavior={readScrollMotionBehavior()}
           liveTurn={companion.liveTurn}
           runningStatus={companion.processing}
           activeSession={companion.companionSession}

--- a/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
+++ b/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
@@ -18,6 +18,7 @@ import {
 import { deriveMemorySettingsViewModel } from './memory-settings-view-model';
 import { useKeyedActionGuard } from './use-action-guard';
 import { getMemorySettingsCopy } from '../locales/settings-memory-copy';
+import { readScrollMotionBehavior } from '../scroll-motion-policy';
 
 export interface MemoryDocumentControllerProps {
   settings: AppSettings;
@@ -419,7 +420,7 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
       editorRef.current?.setSelectionRange(range.start, range.end);
       editorRef.current?.scrollIntoView({
         block: 'center',
-        behavior: 'smooth',
+        behavior: readScrollMotionBehavior(),
       });
     });
   }

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -163,6 +163,7 @@ const conversation: StoredMessage[] = [
 
 const baseChatProps: ChatViewProps = {
   messages: conversation,
+  scrollBehavior: 'smooth',
   activeSession,
   activeConnectionLabel: 'Anthropic',
   activeModel: 'claude-sonnet-4-5',

--- a/apps/desktop/stories/onboarding.stories.tsx
+++ b/apps/desktop/stories/onboarding.stories.tsx
@@ -65,7 +65,7 @@ function DetailPane(props: { children?: ReactNode }) {
         <div className="maka-detail-with-artifacts">
           <div className="mainColumn" data-home-surface="true">
             <ChatSurfaceLayout composer={null}>
-              <ChatView messages={[]} onNew={() => undefined} emptyOverride={emptyOverride} />
+              <ChatView messages={[]} scrollBehavior="smooth" onNew={() => undefined} emptyOverride={emptyOverride} />
             </ChatSurfaceLayout>
           </div>
         </div>

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -162,7 +162,7 @@ export function ChatView(props: {
    * chat view only scrolls/highlights the already-rendered turn.
    */
   scrollTargetTurn?: { turnId: string; nonce: number };
-  scrollBehavior?: ScrollBehavior;
+  scrollBehavior: ScrollBehavior;
   /**
    * PR109f: when the active session is a branched session
    * (`parentSessionId` set on its summary), show a banner above the
@@ -412,6 +412,7 @@ export function ChatView(props: {
     sessionId,
     turnIds: orderedTurnIds,
     scrollRef,
+    scrollBehavior: props.scrollBehavior,
     targetTurnId: props.scrollTargetTurn?.turnId,
     seededGeometry,
   });
@@ -596,6 +597,7 @@ export function ChatView(props: {
         <PromptAnchorRail
           turns={promptRailTurns}
           scrollRef={scrollRef}
+          scrollBehavior={props.scrollBehavior}
           onNavigateFallback={revealTurn}
           mountedTurnsRevision={mountStart}
         />

--- a/packages/ui/src/prompt-anchor-rail.tsx
+++ b/packages/ui/src/prompt-anchor-rail.tsx
@@ -18,6 +18,7 @@ export interface PromptAnchorRailTurn {
 export interface PromptAnchorRailProps {
   turns: readonly PromptAnchorRailTurn[];
   scrollRef: RefObject<HTMLElement | null>;
+  scrollBehavior: ScrollBehavior;
   /** When progressive mount has not yet placed the turn in the DOM. */
   onNavigateFallback?: (turnId: string) => void;
   /** Bumped when turn DOM membership changes without `turns` changing. */
@@ -25,7 +26,7 @@ export interface PromptAnchorRailProps {
 }
 
 /** Right-edge rail: one tick per user prompt, scrolls to `[data-turn-id]`. */
-export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRef, onNavigateFallback, mountedTurnsRevision }: PromptAnchorRailProps): React.ReactElement | null {
+export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRef, scrollBehavior, onNavigateFallback, mountedTurnsRevision }: PromptAnchorRailProps): React.ReactElement | null {
   const copy = getConversationCopy(useUiLocale()).sessions;
   const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
   const [safeArea, setSafeArea] = useState<{ scrollport: number; dock: number } | null>(null);
@@ -132,7 +133,7 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
   function jumpTo(turnId: string): void {
     const el = scrollRef.current?.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);
     if (el && 'scrollIntoView' in el) {
-      (el as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' });
+      (el as HTMLElement).scrollIntoView({ behavior: scrollBehavior, block: 'start' });
     } else if (!el) {
       onNavigateFallback?.(turnId);
     }

--- a/packages/ui/src/use-chat-scroll.ts
+++ b/packages/ui/src/use-chat-scroll.ts
@@ -9,7 +9,7 @@ export function useChatScroll(input: {
   hasTurns: boolean;
   messages: readonly StoredMessage[];
   target?: { turnId: string; nonce: number };
-  behavior?: ScrollBehavior;
+  behavior: ScrollBehavior;
   /**
    * #2052: false while the progressive mount is still filling the transcript.
    * The warm-up snapshots the `.maka-turn` NodeList once, so starting it
@@ -146,7 +146,7 @@ export function useChatScroll(input: {
       const targetElement = element as HTMLElement;
       targetElement.setAttribute('tabindex', '-1');
       targetElement.scrollIntoView({
-        behavior: input.behavior ?? 'smooth',
+        behavior: input.behavior,
         block: 'center',
       });
       targetElement.focus({ preventScroll: true });

--- a/packages/ui/src/use-progressive-turn-mount.ts
+++ b/packages/ui/src/use-progressive-turn-mount.ts
@@ -33,6 +33,7 @@ export function useProgressiveTurnMount(input: {
   sessionId: string | undefined;
   turnIds: readonly string[];
   scrollRef: RefObject<HTMLElement | null>;
+  scrollBehavior: ScrollBehavior;
   /** Search navigation target; mounted before use-chat-scroll queries it. */
   targetTurnId?: string;
   /**
@@ -118,10 +119,10 @@ export function useProgressiveTurnMount(input: {
     const root = input.scrollRef.current;
     const element = root?.querySelector(`[data-turn-id="${CSS.escape(pendingReveal)}"]`);
     if (element && 'scrollIntoView' in element) {
-      (element as HTMLElement).scrollIntoView({ behavior: 'smooth', block: 'start' });
+      (element as HTMLElement).scrollIntoView({ behavior: input.scrollBehavior, block: 'start' });
       setPendingReveal(undefined);
     }
-  }, [pendingReveal, reconciled.start, input.scrollRef]);
+  }, [pendingReveal, reconciled.start, input.scrollBehavior, input.scrollRef]);
 
   const revealTurn = useCallback((turnId: string) => {
     setPendingReveal(turnId);

--- a/packages/ui/stories/attachment.stories.tsx
+++ b/packages/ui/stories/attachment.stories.tsx
@@ -93,6 +93,7 @@ const baseComposer: ComposerProps = {
 
 const baseChat: ChatViewProps = {
   messages: [],
+  scrollBehavior: 'smooth',
   activeSession: session(),
   activeConnectionLabel: 'Anthropic',
   activeModel: 'claude-sonnet-4-5',


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Maka already has one Desktop policy for programmatic scroll motion. It follows the operating system’s reduced-motion preference and disables animation during deterministic E2E capture.

Several navigation paths bypassed this policy. They used a hard-coded `smooth` value or an implicit `smooth` fallback.

As a result, these interactions could still animate when the user requested reduced motion:

- jumping to a search result in the transcript
- navigating with the prompt anchor rail
- revealing a turn outside the progressively mounted transcript window
- locating an entry in the memory document editor

This PR routes these interactions through the existing motion policy. Programmatic scrolling now follows the same native desktop convention across the application.

Refs #2084

## Root cause

The main conversation already passed `readScrollMotionBehavior()` into `ChatView`, but this value did not reach every internal navigation path.

`PromptAnchorRail` and `useProgressiveTurnMount` used hard-coded smooth scrolling. `useChatScroll` also supplied its own smooth fallback.

The quote companion omitted the policy when rendering `ChatView`. Memory document navigation used another hard-coded smooth scroll.

These independent defaults made the shared policy optional in practice and allowed new call sites to bypass it silently.

## Changes

- make `ChatView.scrollBehavior` required so each host must choose the motion behavior explicitly
- pass the selected behavior to search-result navigation, prompt anchors, and progressive turn reveal
- use `readScrollMotionBehavior()` in the quote companion and memory document editor
- remove local hard-coded and fallback smooth behavior
- reuse the existing motion policy without adding another abstraction

## Behavior

When motion is allowed, programmatic navigation keeps its existing smooth animation.

When the operating system requests reduced motion, programmatic navigation moves without animation.

E2E fixture captures also move without animation, which preserves deterministic screenshots and interaction timing.

This PR does not change touchpad inertia, mouse-wheel scrolling, scrollbar dragging, or other user-driven scrolling.

## Verification

- `npm --workspace @maka/ui run typecheck` — passed
- `npm --workspace @maka/desktop run typecheck` — passed
- `npm --workspace @maka/desktop test -- --test-name-pattern="single live-turn handoff"` — 1,095 passed
- Biome check on all changed files — passed
- `git diff --check origin/main...HEAD` — passed
- Manual verification — passed

</details>

<details>
<summary>中文</summary>

## 概要

Maka 已有统一的 Desktop 程序化滚动策略。该策略遵守操作系统的 reduced-motion 偏好，并在确定性 E2E 截图期间关闭动画。

部分导航路径绕过了这项策略，直接使用硬编码的 `smooth`，或者在未指定行为时默认使用 `smooth`。

因此，即使用户已要求减少动态效果，以下交互仍可能播放平滑滚动动画：

- 跳转到会话中的搜索结果
- 使用 prompt 锚点栏导航
- 展开并定位渐进挂载窗口之外的 turn
- 在记忆文档编辑器中定位条目

本 PR 让这些交互复用现有滚动策略，使程序化滚动在整个应用中遵守一致的原生桌面交互规范。

关联 #2084

## 根因

主会话已经将 `readScrollMotionBehavior()` 传给 `ChatView`，但该值没有继续传递到所有内部导航路径。

`PromptAnchorRail` 和 `useProgressiveTurnMount` 使用了硬编码的平滑滚动。`useChatScroll` 也保留了自己的 `smooth` fallback。

引用侧栏渲染 `ChatView` 时没有提供这项策略。记忆文档导航则使用了另一处硬编码的平滑滚动。

这些独立默认值使共享策略在实际使用中仍是可选的，也让新增调用方可以无意间绕过它。

## 变更

- 将 `ChatView.scrollBehavior` 改为必填，要求每个宿主明确选择滚动行为
- 将选定行为传递给搜索结果导航、prompt 锚点和渐进式 turn 展开
- 在引用侧栏和记忆文档编辑器中使用 `readScrollMotionBehavior()`
- 删除局部硬编码和 fallback 的平滑滚动
- 复用现有 motion policy，不新增抽象层

## 行为变化

当系统允许动态效果时，程序化导航继续使用现有的平滑滚动动画。

当操作系统要求减少动态效果时，程序化导航不再播放滚动动画。

E2E fixture 截图也会关闭动画，以保持截图结果和交互时序稳定。

本 PR 不改变触控板惯性、鼠标滚轮、拖动滚动条或其他用户主动滚动行为。

## 验证

- `npm --workspace @maka/ui run typecheck` — 通过
- `npm --workspace @maka/desktop run typecheck` — 通过
- `npm --workspace @maka/desktop test -- --test-name-pattern="single live-turn handoff"` — 1,095 项通过
- 对所有变更文件运行 Biome check — 通过
- `git diff --check origin/main...HEAD` — 通过
- 手工验证 — 通过

</details>
