### PR TITLE
fix(desktop): remove stale scrollbar fallback

### DIFF
--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1428,27 +1428,6 @@
     overflow: hidden;          /* main shell handles its own scrolling */
   }
 
-  /* Native fallback for raw browser scroll surfaces. Primary app scroll
-   * containers are mounted through OverlayScrollbars with the os-theme-maka
-   * theme in styles.css. */
-  * {
-    scrollbar-width: thin;
-    scrollbar-color: transparent transparent;
-  }
-  ::-webkit-scrollbar        { width: 6px; height: 6px; }
-  ::-webkit-scrollbar-track  { background: transparent; }
-  ::-webkit-scrollbar-thumb  {
-    background: transparent;
-    border-radius: var(--radius-control);
-    transition: background var(--duration-quick) var(--ease-out-strong);
-  }
-  *:hover {
-    scrollbar-color: oklch(from var(--foreground) l c h / 0.18) transparent;
-  }
-  *:hover::-webkit-scrollbar-thumb { background: oklch(from var(--foreground) l c h / 0.18); }
-  ::-webkit-scrollbar-thumb:hover { background: oklch(from var(--foreground) l c h / 0.28); }
-  ::-webkit-scrollbar-corner { background: transparent; }
-
   ::selection { background: var(--selection); }
 
   /* Subtle film-grain overlay. Per the taste-skill and frontend-design


### PR DESCRIPTION
## Summary

- remove the obsolete OverlayScrollbars fallback and its stale comment from `maka-tokens.css`
- leave `styles/base.css` as the single global scrollbar authority
- preserve the existing surface-specific scrollbar overrides

## Reproduction and validation

Before the change, the rendered scrollbar mixed both rule sets: `styles/base.css` supplied the 10 px hit area, 2 px inset, pill radius, and visible thumb, while the stale token block still supplied its background transition and hover rules.

After removing the block, I rebuilt Storybook and rendered `Product/Shell Official AppShell / Native Conversation` in local Chrome in both light and dark modes. The computed scrollbar remains 10 px with the 2 px transparent border, pill radius, and 16% thumb color; the stale transition is gone.

- `npm run lint`
- `npm run format:check`
- `npm run test:scripts` — 159 passed, 1 platform-specific skip
- `node scripts/check-dead-css.mjs --check`
- `npm --workspace @maka/desktop run build-storybook`
- `git diff --check`

Fixes #2571