### PR TITLE
fix(runtime-host): preserve assistant stream completion

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -1,3 +1,4 @@
+import { FAKE_HOLD_OPEN_PROMPT } from '@maka/runtime/fake-backend';
 import { expect, test, COMPOSER_INPUT } from './fixtures';
 
 test('shows only slash commands executable in the current session state', async ({
@@ -109,10 +110,10 @@ test('dispatches a staged slash command instead of steering it into a running tu
   invocableSkillsWindow: page,
 }) => {
   const composer = page.locator(COMPOSER_INPUT);
-  const runningPrompt = `running-turn-marker ${'keep streaming '.repeat(80)}`;
+  const runningPrompt = FAKE_HOLD_OPEN_PROMPT;
   await composer.fill(runningPrompt);
   await composer.press('Enter');
-  await expect(page.locator('.maka-user-message', { hasText: 'running-turn-marker' })).toBeVisible();
+  await expect(page.locator('.maka-user-message', { hasText: runningPrompt })).toBeVisible();
   await expect(page.getByRole('button', { name: '停止' })).toBeVisible();
 
   await composer.fill('/compact explain');
@@ -133,4 +134,5 @@ test('dispatches a staged slash command instead of steering it into a running tu
 
   await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(1);
   await expect(page.getByText(/Acknowledged steering: \/compact explain/)).toBeVisible();
+  await page.getByRole('button', { name: '停止' }).click();
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
@@ -131,8 +131,9 @@ test('subscribes before Turn start and settles a fast Host reply without losing 
       events.push(projectionFrame(1, runningTurn(input.sessionId, input.turnId)));
       events.push(deltaFrame(2, input.sessionId, input.turnId, 0, 'Hello'));
       events.push(deltaFrame(3, input.sessionId, input.turnId, 3, 'lo world'));
+      events.push(deltaFrame(4, input.sessionId, input.turnId, 0, 'Corrected reply', true));
       events.push(
-        projectionFrame(4, {
+        projectionFrame(5, {
           ...runningTurn(input.sessionId, input.turnId),
           status: 'completed',
           terminalEventId: 'terminal-1',
@@ -154,7 +155,7 @@ test('subscribes before Turn start and settles a fast Host reply without losing 
     text: 'hello',
   });
 
-  assert.deepEqual(result, { kind: 'completed', text: 'Hello world' });
+  assert.deepEqual(result, { kind: 'completed', text: 'Corrected reply' });
   assert.equal(closeCount, 1);
   assert.deepEqual(changes, [
     {
@@ -163,6 +164,46 @@ test('subscribes before Turn start and settles a fast Host reply without losing 
       extra: { turnId: 'turn-1' },
     },
   ]);
+});
+
+test('accepts an empty reset delta as the authoritative Bot reply', async () => {
+  const events = new AsyncFrameQueue();
+  const adapter = createRuntimeHostBotSessionAdapter({
+    client: botClient({
+      openSession: async () => ({
+        snapshot: continuitySnapshot(null),
+        activeAssistantStreams: [],
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          events.end();
+        },
+      }),
+      startTurn: async (input) => {
+        events.push(deltaFrame(1, input.sessionId, input.turnId, 0, 'Provisional reply'));
+        events.push(deltaFrame(2, input.sessionId, input.turnId, 0, '', true));
+        events.push(
+          projectionFrame(3, {
+            ...runningTurn(input.sessionId, input.turnId),
+            status: 'completed',
+            terminalEventId: 'terminal-1',
+          }),
+        );
+        return startedTurn(runningTurn(input.sessionId, input.turnId));
+      },
+    }),
+    resolveCreateTarget: hostPathCreateTarget,
+    emitSessionsChanged() {},
+  });
+
+  assert.deepEqual(
+    await adapter.runTurn({
+      sessionId: 'bot-session-1',
+      turnId: 'turn-1',
+      text: 'hello',
+    }),
+    { kind: 'completed', text: '' },
+  );
 });
 
 test('returns blocked Skill feedback without waiting for a Turn that was not created', async () => {
@@ -344,6 +385,7 @@ function deltaFrame(
   turnId: string,
   startOffset: number,
   text: string,
+  reset = false,
 ): SubscriptionFrame {
   return {
     kind: 'subscription.session_delta',
@@ -358,6 +400,7 @@ function deltaFrame(
       messageId: 'message-1',
       startOffset,
       text,
+      ...(reset ? { reset: true } : {}),
     },
   };
 }

--- a/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
@@ -116,6 +116,7 @@ test('subscribes before Turn start and settles a fast Host reply without losing 
   let closeCount = 0;
   const handle: DesktopRuntimeHostSession = {
     snapshot: continuitySnapshot(null),
+    activeAssistantStreams: [],
     transcript: Promise.resolve([]),
     events,
     async close() {
@@ -171,6 +172,7 @@ test('returns blocked Skill feedback without waiting for a Turn that was not cre
     client: botClient({
       openSession: async () => ({
         snapshot: continuitySnapshot(null),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -224,6 +226,7 @@ async function runProjectedTurn(rootTurn: TurnSnapshot) {
     client: botClient({
       openSession: async () => ({
         snapshot: continuitySnapshot(null),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {

--- a/apps/desktop/src/main/__tests__/runtime-host-client.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client.test.ts
@@ -51,6 +51,7 @@ function subscription(
   return {
     hostEpoch: 'host-1',
     subscriptionId: `subscription-${sessionId}`,
+    activeAssistantStreams: [],
     snapshot: {
       schemaVersion: SESSION_CONTINUITY_SCHEMA_VERSION,
       session: {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -696,6 +696,7 @@ function observerWithTranscript(
           },
           interactions: { pending: [] },
         },
+        activeAssistantStreams: [],
         transcript: Promise.resolve([...transcript]),
         events: waitForEnd(eventsFinished),
         async close() {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -21,6 +21,7 @@ test("joins an active Turn without losing or replaying assistant text", async ()
   let closeCount = 0;
   const handle: DesktopRuntimeHostSession = {
     snapshot: continuitySnapshot(),
+    activeAssistantStreams: [activeText('message-1')],
     transcript: transcript.promise,
     events,
     async close() {
@@ -112,6 +113,7 @@ test("restores renderer observation after the Host connection is replaced", asyn
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events: firstEvents,
         async close() {
@@ -125,6 +127,7 @@ test("restores renderer observation after the Host connection is replaced", asyn
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [activeText('message-1')],
         transcript: Promise.resolve([
           {
             type: "assistant",
@@ -206,6 +209,7 @@ test("does not publish a terminal error while an owner-managed connection is rep
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -233,6 +237,7 @@ test("keeps a native Turn watched without a renderer and releases it at terminal
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -277,6 +282,7 @@ test("does not let an older terminal projection finish a newer watched Turn", as
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [],
         transcript: transcript.promise,
         events,
         async close() {
@@ -365,6 +371,7 @@ test("invalidates the transcript when another client starts a Turn", async () =>
             terminalEventId: "terminal-1",
           },
         }),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -431,6 +438,7 @@ test("abandons a watched Turn when the Session is removed", async () => {
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -471,6 +479,8 @@ test("reopens an evicted active subscription without a renderer resubscribe", as
         const events = openCount === 1 ? firstEvents : secondEvents;
         return {
           snapshot: continuitySnapshot(),
+          activeAssistantStreams:
+            openCount === 1 ? [] : [activeText('message-1')],
           transcript: Promise.resolve(
             openCount === 1
               ? []
@@ -549,6 +559,7 @@ test("retries an initial subscription closed before commit and resyncs once", as
         const first = openCount === 1;
         return {
           snapshot: continuitySnapshot(),
+          activeAssistantStreams: [],
           transcript: first ? firstTranscript.promise : secondTranscript.promise,
           events: first ? firstEvents : secondEvents,
           async close() {
@@ -610,6 +621,7 @@ test("finishes a watched predecessor after initial catch-up recovery", async () 
         if (openCount === 1) {
           return {
             snapshot: continuitySnapshot(),
+            activeAssistantStreams: [],
             transcript: firstTranscript.promise,
             events: firstEvents,
             async close() {
@@ -627,6 +639,7 @@ test("finishes a watched predecessor after initial catch-up recovery", async () 
               status: "running",
             },
           }),
+          activeAssistantStreams: [],
           transcript: Promise.resolve([
             {
               type: "turn_state" as const,
@@ -680,6 +693,7 @@ test("keeps a joining observer pending across repeated catch-up eviction", async
         if (openCount === 1) {
           return {
             snapshot: continuitySnapshot(),
+            activeAssistantStreams: [],
             transcript: Promise.resolve([]),
             events: firstEvents,
             async close() {
@@ -690,6 +704,7 @@ test("keeps a joining observer pending across repeated catch-up eviction", async
         if (openCount === 2) {
           return {
             snapshot: continuitySnapshot(),
+            activeAssistantStreams: [],
             transcript: deferred<StoredMessage[]>().promise,
             events: replacementEvents,
             async close() {
@@ -699,6 +714,7 @@ test("keeps a joining observer pending across repeated catch-up eviction", async
         }
         return {
           snapshot: continuitySnapshot(),
+          activeAssistantStreams: [activeText('message-1')],
           transcript: finalTranscript.promise,
           events: finalEvents,
           async close() {
@@ -788,6 +804,7 @@ test("reconciles terminal, Goal, interaction, and sidecar state after subscripti
             snapshot: continuitySnapshot({
               interactions: { pending: [firstInteraction] },
             }),
+            activeAssistantStreams: [],
             transcript: Promise.resolve([]),
             events: firstEvents,
             async close() {
@@ -807,6 +824,7 @@ test("reconciles terminal, Goal, interaction, and sidecar state after subscripti
             },
             interactions: { pending: [secondInteraction] },
           }),
+          activeAssistantStreams: [activeText('message-2', 'turn-2')],
           transcript: Promise.resolve([
             {
               type: "assistant" as const,
@@ -906,6 +924,7 @@ test("shares one Host subscription and one delivery per renderer target", async 
         openCount += 1;
         return {
           snapshot: continuitySnapshot(),
+          activeAssistantStreams: [],
           transcript: Promise.resolve([]),
           events,
           async close() {
@@ -941,6 +960,7 @@ test("releases the renderer destroyed listener when its last observer leaves", a
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -975,6 +995,7 @@ test("closes a Host handle that arrives after the observer is closed", async () 
   await observer.close();
   opened.resolve({
     snapshot: continuitySnapshot(),
+    activeAssistantStreams: [],
     transcript: Promise.resolve([]),
     events: new AsyncFrameQueue(),
     async close() {
@@ -998,6 +1019,7 @@ test("drains live frames while refreshing the canonical transcript", async () =>
         if (openCount === 1) {
           return {
             snapshot: continuitySnapshot(),
+            activeAssistantStreams: [],
             transcript: Promise.resolve([]),
             events: initialEvents,
             async close() {
@@ -1007,6 +1029,7 @@ test("drains live frames while refreshing the canonical transcript", async () =>
         }
         return {
           snapshot: continuitySnapshot(),
+          activeAssistantStreams: [],
           transcript: refreshTranscript.promise,
           events: refreshEvents,
           async close() {
@@ -1059,6 +1082,7 @@ test("rehydrates pending interactions and publishes answer acknowledgements", as
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot({ interactions: { pending: [pending] } }),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -1096,6 +1120,7 @@ test("projects Host queue revisions and newly delivered steering messages", asyn
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -1174,6 +1199,7 @@ test("publishes Host sidecar and graph invalidations without inventing Session s
     client: {
       openSession: async () => ({
         snapshot: continuitySnapshot(),
+        activeAssistantStreams: [],
         transcript: Promise.resolve([]),
         events,
         async close() {
@@ -1298,6 +1324,10 @@ function continuitySnapshot(
     interactions: { pending: [] },
     ...overrides,
   };
+}
+
+function activeText(messageId: string, turnId = 'turn-1') {
+  return { kind: 'text' as const, turnId, messageId };
 }
 
 function activeGoal() {

--- a/apps/desktop/src/main/runtime-host-bot-session-adapter.ts
+++ b/apps/desktop/src/main/runtime-host-bot-session-adapter.ts
@@ -164,7 +164,7 @@ async function collectRuntimeHostBotTurn(
       if (frame.delta.turnId !== turnId || frame.delta.kind !== 'text') continue;
       latestMessageId = frame.delta.messageId;
       const folded = foldRuntimeHostAssistantDelta(
-        assistantText.get(latestMessageId) ?? '',
+        frame.delta.reset ? '' : (assistantText.get(latestMessageId) ?? ''),
         frame.delta,
       );
       assistantText.set(latestMessageId, folded.text);

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -79,6 +79,7 @@ import {
   type SessionCatalogItem,
   type SessionCatalogProjection,
   type SessionConfiguration,
+  type SessionAssistantStreamIdentity,
   type SessionContinuitySnapshot,
   type SessionConversationCopyInput,
   type SessionConversationCopyResult,
@@ -134,6 +135,7 @@ export class DesktopRuntimeHostClientError extends Error {
 
 export interface DesktopRuntimeHostSession {
   readonly snapshot: SessionContinuitySnapshot;
+  readonly activeAssistantStreams: readonly SessionAssistantStreamIdentity[];
   readonly transcript: Promise<StoredMessage[]>;
   readonly events: AsyncIterable<SubscriptionFrame>;
   close(): Promise<void>;
@@ -1545,6 +1547,7 @@ export class DesktopRuntimeHostClient {
 
 class DesktopSessionHandle implements DesktopRuntimeHostSession {
   readonly snapshot: SessionContinuitySnapshot;
+  readonly activeAssistantStreams: readonly SessionAssistantStreamIdentity[];
   readonly transcript: Promise<StoredMessage[]>;
   readonly events: AsyncIterable<SubscriptionFrame>;
   #closeTask: Promise<void> | undefined;
@@ -1554,6 +1557,7 @@ class DesktopSessionHandle implements DesktopRuntimeHostSession {
     private readonly onClose: () => void,
   ) {
     this.snapshot = subscription.snapshot;
+    this.activeAssistantStreams = subscription.activeAssistantStreams;
     this.events = subscription;
     this.transcript = subscription.loadTranscript(decodeStoredMessageForRead);
     void this.transcript.catch(() => undefined);

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -533,6 +533,7 @@ export class RuntimeHostSessionObserver {
       subscription.snapshot,
       subscription.transcript,
       this.#now,
+      subscription.activeAssistantStreams,
     );
     const replacement =
       previousSnapshot

--- a/apps/desktop/src/main/runtime-host-session-subscription-owner.ts
+++ b/apps/desktop/src/main/runtime-host-session-subscription-owner.ts
@@ -2,6 +2,7 @@ import type { StoredMessage } from "@maka/core";
 import { RuntimeHostSessionProjector } from "@maka/runtime-host/adapter";
 import { RuntimeHostSubscriptionError } from "@maka/runtime-host/client";
 import type {
+  SessionAssistantStreamIdentity,
   SessionContinuitySnapshot,
   SubscriptionFrame,
 } from "@maka/runtime-host/protocol";
@@ -16,6 +17,7 @@ type SessionSubscriptionClient = Pick<DesktopRuntimeHostClient, "openSession">;
 
 export interface PreparedSessionSubscription {
   readonly snapshot: SessionContinuitySnapshot;
+  readonly activeAssistantStreams: readonly SessionAssistantStreamIdentity[];
   readonly transcript: StoredMessage[];
 }
 
@@ -172,6 +174,7 @@ export class RuntimeHostSessionSubscriptionOwner {
       if (this.#closed || this.#attempt !== attempt) throw ownerClosed();
       validatePendingFrames(
         handle.snapshot,
+        handle.activeAssistantStreams,
         loaded.transcript,
         attempt.pendingFrames,
         this.#deps.now,
@@ -180,6 +183,7 @@ export class RuntimeHostSessionSubscriptionOwner {
         attempt,
         prepared: {
           snapshot: structuredClone(handle.snapshot),
+          activeAssistantStreams: structuredClone(handle.activeAssistantStreams),
           transcript: loaded.transcript,
         },
       };
@@ -240,11 +244,17 @@ export class RuntimeHostSessionSubscriptionOwner {
 
 function validatePendingFrames(
   snapshot: SessionContinuitySnapshot,
+  activeAssistantStreams: readonly SessionAssistantStreamIdentity[],
   transcript: readonly StoredMessage[],
   frames: readonly SubscriptionFrame[],
   now: () => number,
 ): void {
-  const projector = new RuntimeHostSessionProjector(snapshot, transcript, now);
+  const projector = new RuntimeHostSessionProjector(
+    snapshot,
+    transcript,
+    now,
+    activeAssistantStreams,
+  );
   for (const frame of frames) projector.accept(frame);
 }
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -113,6 +113,40 @@ describe('Maka Pi TUI transcript', () => {
     );
   });
 
+  test('treats text_complete as the authoritative assistant text', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(
+      state,
+      event({ type: 'text_delta', messageId: 'message-1', text: 'draft' }),
+    );
+
+    renderMakaPiTranscript(state, meta(), 80);
+    applyMakaSessionEventToTranscript(
+      state,
+      event({ type: 'text_complete', messageId: 'message-1', text: 'final' }),
+    );
+
+    assert.equal(
+      state.entries[0]?.kind === 'assistant' ? state.entries[0].text : undefined,
+      'final',
+    );
+    assert.match(renderMakaPiTranscript(state, meta(), 80).map(stripAnsi).join('\n'), /final/);
+  });
+
+  test('allows text_complete to replace streamed assistant text with empty text', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(
+      state,
+      event({ type: 'text_delta', messageId: 'message-1', text: 'discard me' }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({ type: 'text_complete', messageId: 'message-1', text: '' }),
+    );
+
+    assert.equal(state.entries[0]?.kind === 'assistant' ? state.entries[0].text : undefined, '');
+  });
+
   test('reconciles durable tool details without resetting live turn state', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -195,6 +195,40 @@ describe('Runtime Host Maka Session driver', () => {
     });
   });
 
+  test('delivers completed thinking while a later step remains active', async () => {
+    const subscription = new FakeSubscription(continuitySnapshot(), Promise.resolve([]));
+    const connection = new FakeConnection([subscription]);
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/tmp',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      now: () => 50,
+    });
+
+    const switched = await driver.switchSession('session-1');
+    assert.ok(switched.activeTurn);
+    subscription.push(thinkingFrame(1, 'step-1', 0, 'first'));
+    subscription.push(thinkingFrame(2, 'step-1', 5, '', true));
+    subscription.push(thinkingFrame(3, 'step-2', 0, 'second'));
+
+    assert.deepEqual(
+      [
+        await nextEvent(switched.activeTurn.events),
+        await nextEvent(switched.activeTurn.events),
+        await nextEvent(switched.activeTurn.events),
+      ].map((event) => ({
+        type: event.type,
+        messageId: 'messageId' in event ? event.messageId : undefined,
+      })),
+      [
+        { type: 'thinking_delta', messageId: 'step-1' },
+        { type: 'thinking_complete', messageId: 'step-1' },
+        { type: 'thinking_delta', messageId: 'step-2' },
+      ],
+    );
+  });
+
   test('restarts initial hydration when the first connection closes during transcript load', async () => {
     const transcript = deferred<StoredMessage[]>();
     const initial = new FakeSubscription(continuitySnapshot(), transcript.promise);
@@ -1180,6 +1214,7 @@ class FakeConnection {
 
 class FakeSubscription implements RuntimeHostSessionSubscription, AsyncIterator<SubscriptionFrame> {
   readonly hostEpoch = 'host-1';
+  readonly activeAssistantStreams = [];
   readonly subscriptionId: string;
   readonly #frames: SubscriptionFrame[] = [];
   readonly #waiters: Array<{
@@ -1351,6 +1386,31 @@ function deltaFrame(
       messageId: `message-${turnId}`,
       startOffset,
       text,
+    },
+  };
+}
+
+function thinkingFrame(
+  sequence: number,
+  messageId: string,
+  startOffset: number,
+  text: string,
+  complete = false,
+): SubscriptionFrame {
+  return {
+    kind: 'subscription.session_delta',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence,
+    sessionId: 'session-1',
+    delta: {
+      kind: 'thinking',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      messageId,
+      startOffset,
+      text,
+      ...(complete ? { complete: true } : {}),
     },
   };
 }

--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -342,7 +342,6 @@ describe('Runtime Host Maka Session driver', () => {
         rootTurn: completedTurn('turn-1', 'run-1'),
       }),
     });
-    assert.equal((await nextEvent(initial.activeTurn.events)).type, 'text_complete');
     assert.equal((await nextEvent(initial.activeTurn.events)).type, 'complete');
     assert.equal((await initial.activeTurn.events[Symbol.asyncIterator]().next()).done, true);
     await waitFor(() => refresh.nextCalls > 0);

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -48,7 +48,6 @@ export interface MakaPiUsageSummary {
 
 export interface MakaPiTranscriptState {
   entries: MakaPiTranscriptEntry[];
-  sawTextDeltaMessageIds: Set<string>;
   pendingInteraction?: MakaPiPendingInteraction;
   queuedInteractions: MakaPiPendingInteraction[];
   /**
@@ -193,7 +192,6 @@ export interface MakaPiTranscriptMetadata {
 export function createMakaPiTranscriptState(): MakaPiTranscriptState {
   return {
     entries: [],
-    sawTextDeltaMessageIds: new Set(),
     queuedInteractions: [],
     expandAllTools: false,
     expandAllThinking: false,
@@ -310,14 +308,6 @@ export function replaceTranscriptWithStoredMessages(
 ): void {
   const view = materializeSession(messages);
   state.entries = foldStoredShellRunChildren(view.items.flatMap(chatItemToTranscriptEntries));
-  state.sawTextDeltaMessageIds = new Set(
-    state.entries
-      .filter(
-        (entry): entry is Extract<MakaPiTranscriptEntry, { kind: 'assistant' }> =>
-          entry.kind === 'assistant',
-      )
-      .map((entry) => entry.messageId),
-  );
   clearPendingInteractions(state);
   state.pendingShellRunPolls.clear();
   state.expandAllTools = false;
@@ -529,12 +519,11 @@ export function applyMakaSessionEventToTranscript(
   }
   switch (event.type) {
     case 'text_delta':
-      state.sawTextDeltaMessageIds.add(event.messageId);
       appendAssistantText(state, event.messageId, event.text);
       break;
 
     case 'text_complete':
-      if (!state.sawTextDeltaMessageIds.has(event.messageId) && event.text) {
+      if (!setAssistantText(state, event.messageId, event.text) && event.text) {
         appendAssistantText(state, event.messageId, event.text);
       }
       break;
@@ -1253,14 +1242,13 @@ function renderTranscriptEntryBlock(entry: MakaPiTranscriptEntry, width: number)
 
 function transcriptEntrySignature(entry: MakaPiTranscriptEntry, width: number): string {
   switch (entry.kind) {
-    // user and assistant text is append-only (user is immutable; assistant only
-    // grows via appendAssistantText, and text_complete is guarded from replacing
-    // it), so length is a safe change key. If a path ever replaces their text in
-    // place, switch these to full-text keys like thinking below.
+    // User text is immutable, so length is a safe change key.
     case 'user':
       return `user|${width}|${entry.text.length}`;
     case 'assistant':
-      return `assistant|${width}|${entry.text.length}`;
+      // text_complete authoritatively replaces streamed text, including with a
+      // same-length final, so the full value must participate in the cache key.
+      return `assistant|${width}|${entry.text}`;
     case 'thinking':
       // Not just the length: `thinking_complete` can replace the streamed text
       // in place with a same-length final, which a length-only key would miss and
@@ -1476,6 +1464,17 @@ function appendAssistantText(state: MakaPiTranscriptState, messageId: string, te
     return;
   }
   state.entries.push({ kind: 'assistant', messageId, text });
+}
+
+function setAssistantText(state: MakaPiTranscriptState, messageId: string, text: string): boolean {
+  for (let index = state.entries.length - 1; index >= 0; index -= 1) {
+    const entry = state.entries[index];
+    if (entry?.kind === 'assistant' && entry.messageId === messageId) {
+      entry.text = text;
+      return true;
+    }
+  }
+  return false;
 }
 
 function appendThinking(state: MakaPiTranscriptState, messageId: string, text: string): void {

--- a/packages/cli/src/runtime-host-session-channel.ts
+++ b/packages/cli/src/runtime-host-session-channel.ts
@@ -132,7 +132,12 @@ export class RuntimeHostSessionChannel {
       return true;
     }
     this.messages.push(...(messages ?? []).map((message) => structuredClone(message)));
-    this.#projector = new RuntimeHostSessionProjector(this.snapshot, this.messages, this.#now);
+    this.#projector = new RuntimeHostSessionProjector(
+      this.snapshot,
+      this.messages,
+      this.#now,
+      subscription.activeAssistantStreams,
+    );
     for (const event of this.#projector.seedActive(false)) this.#emit(event);
     this.#ready = true;
     for (const frame of this.#pendingFrames.splice(0)) this.#accept(frame);
@@ -337,7 +342,12 @@ export class RuntimeHostSessionChannel {
       ...messages.map((message) => structuredClone(message)),
     );
     this.snapshot = nextSnapshot;
-    this.#projector = new RuntimeHostSessionProjector(nextSnapshot, this.messages, this.#now);
+    this.#projector = new RuntimeHostSessionProjector(
+      nextSnapshot,
+      this.messages,
+      this.#now,
+      this.#subscription.activeAssistantStreams,
+    );
     if (!replacedLiveState) {
       for (const event of this.#projector.seedActive(false)) this.#emit(event);
       return false;

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -48,7 +48,7 @@ describe('Runtime Host bootstrap protocol', () => {
 
   test('declares the current protocol and closed authority operation set', () => {
     assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
-    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 16);
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 17);
     assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
       'access.credential.issue',
       'access.credential.revoke',
@@ -230,10 +230,25 @@ describe('Runtime Host bootstrap protocol', () => {
         hostEpoch: 'epoch-1',
         subscriptionId: 'subscription-1',
         nextSequence: 1,
+        activeAssistantStreams: [{ kind: 'thinking', turnId: 'turn-1', messageId: 'message-1' }],
         snapshot: continuitySnapshot('epoch-1'),
       },
     };
     assert.deepEqual(decodeHostFrame(opened), opened);
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          ...opened,
+          result: {
+            ...opened.result,
+            activeAssistantStreams: [
+              ...opened.result.activeAssistantStreams,
+              ...opened.result.activeAssistantStreams,
+            ],
+          },
+        }),
+      isInvalidFrame,
+    );
     assert.throws(
       () =>
         decodeHostFrame({
@@ -369,6 +384,44 @@ describe('Runtime Host bootstrap protocol', () => {
             text: 'private reasoning',
             signature: 'provider-signature',
           },
+        }),
+      isInvalidFrame,
+    );
+    const completion = {
+      kind: 'subscription.session_delta' as const,
+      hostEpoch: 'epoch-1',
+      subscriptionId: 'subscription-1',
+      sequence: 1,
+      sessionId: 'session-1',
+      delta: {
+        kind: 'thinking' as const,
+        turnId: 'turn-1',
+        runId: 'run-1',
+        messageId: 'message-1',
+        startOffset: 7,
+        text: '',
+        complete: true as const,
+      },
+    };
+    assert.deepEqual(decodeHostFrame(completion), completion);
+    const replacement = {
+      ...completion,
+      delta: {
+        kind: completion.delta.kind,
+        turnId: completion.delta.turnId,
+        runId: completion.delta.runId,
+        messageId: completion.delta.messageId,
+        startOffset: 0,
+        text: 'final',
+        reset: true as const,
+      },
+    };
+    assert.deepEqual(decodeHostFrame(replacement), replacement);
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          ...replacement,
+          delta: { ...replacement.delta, startOffset: 1 },
         }),
       isInvalidFrame,
     );

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -79,6 +79,135 @@ test('open snapshot includes pending Interactions from the canonical projection'
   coordinator.close();
 });
 
+test('open identifies only assistant streams that are still active', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  coordinator.attachConnection('connection-1', new RecordingSink());
+  await open(coordinator, 'connection-1');
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(1));
+
+  coordinator.attachConnection('connection-2', new RecordingSink());
+  const active = await open(coordinator, 'connection-2');
+  assert.deepEqual(active.activeAssistantStreams, [
+    { kind: 'text', turnId: 'turn-1', messageId: 'message-1' },
+  ]);
+
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    textCompleteEvent('message-1', 'chunk-1'),
+  );
+  coordinator.attachConnection('connection-3', new RecordingSink());
+  const completed = await open(coordinator, 'connection-3');
+  assert.deepEqual(completed.activeAssistantStreams, []);
+  coordinator.close();
+});
+
+test('publishes a non-prefix final value as an authoritative replacement', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const sink = new RecordingSink();
+  const connection = coordinator.attachConnection('connection-1', sink);
+  const opened = await open(coordinator, 'connection-1');
+  connection.activate(opened.subscriptionId);
+
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', {
+    ...textEvent(1),
+    text: 'draft',
+  });
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    textCompleteEvent('message-1', 'final'),
+  );
+  await waitFor(() => sink.frames.length === 3);
+
+  assert.deepEqual(
+    sink.frames.map((frame) =>
+      frame.kind === 'subscription.session_delta'
+        ? {
+            startOffset: frame.delta.startOffset,
+            text: frame.delta.text,
+            reset: frame.delta.reset === true,
+            complete: frame.delta.complete === true,
+          }
+        : frame.kind,
+    ),
+    [
+      { startOffset: 0, text: 'draft', reset: false, complete: false },
+      { startOffset: 0, text: 'final', reset: true, complete: false },
+      { startOffset: 5, text: '', reset: false, complete: true },
+    ],
+  );
+  coordinator.close();
+});
+
+test('coalesces reasoning parts and completes the step before later steps continue', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const sink = new RecordingSink();
+  const connection = coordinator.attachConnection('connection-1', sink);
+  const opened = await open(coordinator, 'connection-1');
+  connection.activate(opened.subscriptionId);
+
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    thinkingEvent('thinking_delta', 'step-1', 'first'),
+  );
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    thinkingEvent('thinking_delta', 'step-1', 'second'),
+  );
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    thinkingEvent('thinking_complete', 'step-1', 'first'),
+  );
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    thinkingEvent('thinking_complete', 'step-1', 'second'),
+  );
+  assert.equal(sink.frames.length, 2);
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textCompleteEvent('step-1', ''));
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    thinkingEvent('thinking_delta', 'step-2', 'second'),
+  );
+  await waitFor(() => sink.frames.length === 4);
+
+  assert.deepEqual(
+    sink.frames.map((frame) =>
+      frame.kind === 'subscription.session_delta'
+        ? {
+            messageId: frame.delta.messageId,
+            text: frame.delta.text,
+            complete: frame.delta.complete === true,
+          }
+        : frame.kind,
+    ),
+    [
+      { messageId: 'step-1', text: 'first', complete: false },
+      { messageId: 'step-1', text: 'second', complete: false },
+      { messageId: 'step-1', text: '', complete: true },
+      { messageId: 'step-2', text: 'second', complete: false },
+    ],
+  );
+  coordinator.close();
+});
+
 test('terminal fence suppresses ordinary refresh until the exact terminal cut publishes', async () => {
   let projection = canonical({
     rootTurn: { sessionId: SESSION_ID, turnId: 'turn-1', runId: 'run-1', status: 'running' },
@@ -771,6 +900,17 @@ class RecordingSink implements SessionContinuityFrameSink {
   }
 }
 
+function textCompleteEvent(messageId: string, text: string) {
+  return {
+    type: 'text_complete' as const,
+    id: `text_complete-${messageId}`,
+    turnId: 'turn-1',
+    ts: 1,
+    messageId,
+    text,
+  };
+}
+
 async function open(coordinator: SessionContinuityCoordinator, connectionId: string) {
   const outcome = await coordinator.handlers['subscription.open'](
     { sessionId: SESSION_ID },
@@ -917,6 +1057,21 @@ function textEvent(index: number) {
     ts: index,
     messageId: 'message-1',
     text: `chunk-${index}`,
+  };
+}
+
+function thinkingEvent(
+  type: 'thinking_delta' | 'thinking_complete',
+  messageId: string,
+  text: string,
+) {
+  return {
+    type,
+    id: `${type}-${messageId}`,
+    turnId: 'turn-1',
+    ts: 1,
+    messageId,
+    text,
   };
 }
 

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -79,7 +79,7 @@ test('open snapshot includes pending Interactions from the canonical projection'
   coordinator.close();
 });
 
-test('open identifies only assistant streams that are still active', async () => {
+test('open identifies every assistant stream that is still active and round-trips its result', async () => {
   const coordinator = new SessionContinuityCoordinator(
     HOST_EPOCH,
     async () => canonical(),
@@ -88,12 +88,37 @@ test('open identifies only assistant streams that are still active', async () =>
   coordinator.attachConnection('connection-1', new RecordingSink());
   await open(coordinator, 'connection-1');
   await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(1));
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    thinkingEvent('thinking_delta', 'message-2', 'reasoning'),
+  );
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', {
+    ...textEvent(2),
+    messageId: 'message-3',
+  });
 
   coordinator.attachConnection('connection-2', new RecordingSink());
   const active = await open(coordinator, 'connection-2');
   assert.deepEqual(active.activeAssistantStreams, [
     { kind: 'text', turnId: 'turn-1', messageId: 'message-1' },
+    { kind: 'thinking', turnId: 'turn-1', messageId: 'message-2' },
+    { kind: 'text', turnId: 'turn-1', messageId: 'message-3' },
   ]);
+
+  const decoded = decodeHostFrame(
+    JSON.parse(
+      encodeProtocolMessage({
+        requestId: 'open-round-trip',
+        operation: 'subscription.open',
+        ok: true,
+        result: active,
+      }).toString('utf8'),
+    ),
+  );
+  assert.ok('ok' in decoded && decoded.ok);
+  if (!('ok' in decoded) || !decoded.ok || decoded.operation !== 'subscription.open') return;
+  assert.deepEqual(decoded.result.activeAssistantStreams, active.activeAssistantStreams);
 
   await coordinator.acceptRuntimeEvent(
     SESSION_ID,
@@ -101,7 +126,25 @@ test('open identifies only assistant streams that are still active', async () =>
     textCompleteEvent('message-1', 'chunk-1'),
   );
   coordinator.attachConnection('connection-3', new RecordingSink());
-  const completed = await open(coordinator, 'connection-3');
+  const remaining = await open(coordinator, 'connection-3');
+  assert.deepEqual(remaining.activeAssistantStreams, [
+    { kind: 'thinking', turnId: 'turn-1', messageId: 'message-2' },
+    { kind: 'text', turnId: 'turn-1', messageId: 'message-3' },
+  ]);
+
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    thinkingEvent('thinking_complete', 'message-2', 'reasoning'),
+  );
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textCompleteEvent('message-2', ''));
+  await coordinator.acceptRuntimeEvent(
+    SESSION_ID,
+    'run-1',
+    textCompleteEvent('message-3', 'chunk-2'),
+  );
+  coordinator.attachConnection('connection-4', new RecordingSink());
+  const completed = await open(coordinator, 'connection-4');
   assert.deepEqual(completed.activeAssistantStreams, []);
   coordinator.close();
 });
@@ -706,6 +749,42 @@ test('a joining Client receives live assistant text that has not reached durable
   assert.deepEqual(
     JSON.parse(Buffer.from(snapshot.result.data, 'base64').toString('utf8')),
     assistantMessage('chunk-1chunk-2'),
+  );
+  coordinator.close();
+});
+
+test('a durable final replaces a non-prefix live draft during transcript catch-up', async () => {
+  const transcript = deferred<readonly StoredMessage[]>();
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+    undefined,
+    () => transcript.promise,
+  );
+
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', {
+    ...textEvent(1),
+    text: 'draft',
+  });
+  const connection = coordinator.attachConnection('connection-1', new RecordingSink());
+  const opened = await open(coordinator, 'connection-1');
+  connection.activate(opened.subscriptionId);
+
+  const catchUp = coordinator.handlers['session.transcript.query'](
+    { kind: 'start', subscriptionId: opened.subscriptionId },
+    connectionContext('connection-1'),
+  );
+  transcript.resolve([assistantMessage('authoritative final')]);
+
+  const snapshot = await catchUp;
+  assert.equal(snapshot.ok, true);
+  if (!snapshot.ok) assert.fail('expected the transcript snapshot');
+  assert.equal(snapshot.result.kind, 'chunk');
+  if (snapshot.result.kind !== 'chunk') assert.fail('expected a transcript chunk');
+  assert.deepEqual(
+    JSON.parse(Buffer.from(snapshot.result.data, 'base64').toString('utf8')),
+    assistantMessage('authoritative final'),
   );
   coordinator.close();
 });

--- a/packages/runtime-host/src/__tests__/session-projector.test.ts
+++ b/packages/runtime-host/src/__tests__/session-projector.test.ts
@@ -66,6 +66,71 @@ test('seeds only streams identified as active by the Host catch-up state', () =>
   );
 });
 
+test('does not replay settled transcript steps when the active step reaches terminal', () => {
+  const transcript: StoredMessage[] = [
+    {
+      ...assistant('settled-step-1', 'first answer'),
+      thinking: { text: 'first thought' },
+    },
+    {
+      ...assistant('settled-step-2', 'second answer'),
+      thinking: { text: 'second thought' },
+    },
+    {
+      ...assistant('active-step', 'partial answer'),
+      thinking: { text: 'active thought' },
+    },
+  ];
+  const projector = new RuntimeHostSessionProjector(snapshot(), transcript, () => 10, [
+    { kind: 'text', turnId: 'turn-1', messageId: 'active-step' },
+    { kind: 'thinking', turnId: 'turn-1', messageId: 'active-step' },
+  ]);
+
+  assert.deepEqual(
+    projector
+      .seedActive(true)
+      .map((event) => [
+        event.type,
+        'messageId' in event && event.messageId,
+        'text' in event && event.text,
+      ]),
+    [
+      ['thinking_delta', 'active-step', 'active thought'],
+      ['text_delta', 'active-step', 'partial answer'],
+    ],
+  );
+
+  const terminal = projector.accept({
+    kind: 'subscription.session_projection',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 1,
+    snapshot: snapshot({
+      projectionRevision: 2,
+      rootTurn: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        runId: 'run-1',
+        status: 'completed',
+        terminalEventId: 'terminal-1',
+      },
+    }),
+  }).events;
+
+  assert.deepEqual(
+    terminal.map((event) => [
+      event.type,
+      'messageId' in event ? event.messageId : undefined,
+      'text' in event ? event.text : undefined,
+    ]),
+    [
+      ['thinking_complete', 'active-step', 'active thought'],
+      ['text_complete', 'active-step', 'partial answer'],
+      ['complete', undefined, undefined],
+    ],
+  );
+});
+
 function deltaFrame(
   sequence: number,
   startOffset: number,

--- a/packages/runtime-host/src/__tests__/session-projector.test.ts
+++ b/packages/runtime-host/src/__tests__/session-projector.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { StoredMessage } from '@maka/core';
+import { RuntimeHostSessionProjector } from '../adapter/session-projector.js';
+import type { SessionContinuitySnapshot, SubscriptionFrame } from '../protocol/index.js';
+
+test('applies authoritative replacement once and does not complete it again at Turn terminal', () => {
+  const projector = new RuntimeHostSessionProjector(
+    snapshot(),
+    [assistant('message-1', 'draft')],
+    () => 10,
+    [{ kind: 'text', turnId: 'turn-1', messageId: 'message-1' }],
+  );
+
+  assert.deepEqual(
+    projector.seedActive(true).map((event) => event.type),
+    ['text_delta'],
+  );
+  assert.deepEqual(projector.accept(deltaFrame(1, 0, 'final', { reset: true })).events, []);
+  const completed = projector.accept(deltaFrame(2, 5, '', { complete: true })).events;
+  assert.deepEqual(
+    completed.map((event) => [event.type, 'text' in event ? event.text : '']),
+    [['text_complete', 'final']],
+  );
+  assert.deepEqual(projector.seedActive(true), []);
+
+  const terminal = projector.accept({
+    kind: 'subscription.session_projection',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 3,
+    snapshot: snapshot({
+      projectionRevision: 2,
+      rootTurn: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        runId: 'run-1',
+        status: 'completed',
+        terminalEventId: 'terminal-1',
+      },
+    }),
+  }).events;
+  assert.deepEqual(
+    terminal.map((event) => event.type),
+    ['complete'],
+  );
+});
+
+test('seeds only streams identified as active by the Host catch-up state', () => {
+  const transcript: StoredMessage[] = [
+    assistant('completed-step', 'done'),
+    {
+      ...assistant('active-step', ''),
+      thinking: { text: 'still working' },
+    },
+  ];
+  const projector = new RuntimeHostSessionProjector(snapshot(), transcript, () => 10, [
+    { kind: 'thinking', turnId: 'turn-1', messageId: 'active-step' },
+  ]);
+
+  assert.deepEqual(
+    projector
+      .seedActive(true)
+      .map((event) => [event.type, 'messageId' in event && event.messageId]),
+    [['thinking_delta', 'active-step']],
+  );
+});
+
+function deltaFrame(
+  sequence: number,
+  startOffset: number,
+  text: string,
+  flags: { reset?: true; complete?: true } = {},
+): SubscriptionFrame {
+  return {
+    kind: 'subscription.session_delta',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence,
+    sessionId: 'session-1',
+    delta: {
+      kind: 'text',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      messageId: 'message-1',
+      startOffset,
+      text,
+      ...flags,
+    },
+  };
+}
+
+function snapshot(overrides: Partial<SessionContinuitySnapshot> = {}): SessionContinuitySnapshot {
+  return {
+    schemaVersion: 3,
+    session: {
+      sessionId: 'session-1',
+      metadataRevision: 1,
+      status: 'running',
+      createdAt: 1,
+      lastUsedAt: 1,
+      isArchived: false,
+    },
+    projectionRevision: 1,
+    rootTurn: {
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      runId: 'run-1',
+      status: 'running',
+    },
+    goal: null,
+    queue: { hostEpoch: 'host-1', queueRevision: 0, steering: [], followup: [] },
+    interactions: { pending: [] },
+    ...overrides,
+  };
+}
+
+function assistant(id: string, text: string): Extract<StoredMessage, { type: 'assistant' }> {
+  return {
+    type: 'assistant',
+    id,
+    turnId: 'turn-1',
+    ts: 1,
+    text,
+    modelId: 'gpt-5',
+  };
+}

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -617,6 +617,7 @@ function openResult(hostEpoch: string, subscriptionId: string) {
     hostEpoch,
     subscriptionId,
     nextSequence: 1,
+    activeAssistantStreams: [],
     snapshot: {
       schemaVersion: SESSION_CONTINUITY_SCHEMA_VERSION,
       session: {

--- a/packages/runtime-host/src/adapter/session-projector.ts
+++ b/packages/runtime-host/src/adapter/session-projector.ts
@@ -17,7 +17,6 @@ interface AssistantAccumulator {
   messageId: string;
   text: string;
   complete: boolean;
-  completionEmitted: boolean;
   replacing: boolean;
 }
 
@@ -60,7 +59,6 @@ export class RuntimeHostSessionProjector {
           messageId: message.id,
           text: message.thinking.text,
           complete: true,
-          completionEmitted: false,
           replacing: false,
         });
       }
@@ -71,7 +69,6 @@ export class RuntimeHostSessionProjector {
           messageId: message.id,
           text: message.text,
           complete: true,
-          completionEmitted: false,
           replacing: false,
         });
       }
@@ -86,7 +83,6 @@ export class RuntimeHostSessionProjector {
         messageId: stream.messageId,
         text: current?.text ?? '',
         complete: false,
-        completionEmitted: false,
         replacing: false,
       });
     }
@@ -135,7 +131,7 @@ export class RuntimeHostSessionProjector {
   }
 
   seedTerminal(turn: RuntimeHostTerminalTurn): SessionEvent[] {
-    return this.#terminalEvents(turn);
+    return this.#terminalEvents(turn, true);
   }
 
   seedStoredTerminal(turnId: string, transcript: readonly StoredMessage[]): SessionEvent[] {
@@ -217,7 +213,6 @@ export class RuntimeHostSessionProjector {
         messageId: delta.messageId,
         text: folded.text,
         complete: delta.complete === true,
-        completionEmitted: delta.complete === true,
         replacing: delta.complete === true ? false : replacing,
       });
       if (delta.complete === true) {
@@ -282,10 +277,10 @@ export class RuntimeHostSessionProjector {
     return { events, previousSnapshot, startedTurn, terminalTurn, resolvedInteractions };
   }
 
-  #terminalEvents(root: RuntimeHostTerminalTurn): SessionEvent[] {
+  #terminalEvents(root: RuntimeHostTerminalTurn, includeSettled = false): SessionEvent[] {
     const events: SessionEvent[] = [];
     for (const accumulator of this.#accumulators.values()) {
-      if (accumulator.turnId !== root.turnId || accumulator.completionEmitted) continue;
+      if (accumulator.turnId !== root.turnId || (!includeSettled && accumulator.complete)) continue;
       events.push({
         type: accumulator.kind === 'text' ? 'text_complete' : 'thinking_complete',
         id: `${root.terminalEventId}:${accumulator.kind}:${accumulator.messageId}`,

--- a/packages/runtime-host/src/adapter/session-projector.ts
+++ b/packages/runtime-host/src/adapter/session-projector.ts
@@ -4,6 +4,7 @@ import type {
   InteractionPendingSnapshot,
   SessionContinuitySnapshot,
   SessionAssistantDelta,
+  SessionAssistantStreamIdentity,
   SessionMessageQueueProjection,
   SteeringMessageSnapshot,
   SubscriptionFrame,
@@ -15,6 +16,9 @@ interface AssistantAccumulator {
   turnId: string;
   messageId: string;
   text: string;
+  complete: boolean;
+  completionEmitted: boolean;
+  replacing: boolean;
 }
 
 export type RuntimeHostTerminalTurn = Extract<
@@ -40,6 +44,7 @@ export class RuntimeHostSessionProjector {
     snapshot: SessionContinuitySnapshot,
     transcript: readonly StoredMessage[],
     now: () => number = Date.now,
+    activeAssistantStreams: readonly SessionAssistantStreamIdentity[] = [],
   ) {
     this.#snapshot = structuredClone(snapshot);
     this.#now = now;
@@ -54,6 +59,9 @@ export class RuntimeHostSessionProjector {
           turnId: root.turnId,
           messageId: message.id,
           text: message.thinking.text,
+          complete: true,
+          completionEmitted: false,
+          replacing: false,
         });
       }
       if (message.text) {
@@ -62,8 +70,25 @@ export class RuntimeHostSessionProjector {
           turnId: root.turnId,
           messageId: message.id,
           text: message.text,
+          complete: true,
+          completionEmitted: false,
+          replacing: false,
         });
       }
+    }
+    for (const stream of activeAssistantStreams) {
+      if (stream.turnId !== root.turnId) continue;
+      const key = accumulatorKey(stream.kind, stream.messageId);
+      const current = this.#accumulators.get(key);
+      this.#accumulators.set(key, {
+        kind: stream.kind,
+        turnId: stream.turnId,
+        messageId: stream.messageId,
+        text: current?.text ?? '',
+        complete: false,
+        completionEmitted: false,
+        replacing: false,
+      });
     }
   }
 
@@ -77,6 +102,7 @@ export class RuntimeHostSessionProjector {
     const events: SessionEvent[] = [];
     if (includeAssistantText) {
       for (const accumulator of this.#accumulators.values()) {
+        if (accumulator.complete) continue;
         events.push({
           type: accumulator.kind === 'text' ? 'text_delta' : 'thinking_delta',
           id: `host-seed:${root.runId}:${accumulator.kind}:${accumulator.messageId}`,
@@ -183,14 +209,27 @@ export class RuntimeHostSessionProjector {
       const delta = frame.delta;
       const key = accumulatorKey(delta.kind, delta.messageId);
       const current = this.#accumulators.get(key);
-      const folded = foldRuntimeHostAssistantDelta(current?.text ?? '', delta);
+      const folded = foldRuntimeHostAssistantDelta(delta.reset ? '' : (current?.text ?? ''), delta);
+      const replacing = delta.reset === true || (current?.replacing ?? false);
       this.#accumulators.set(key, {
         kind: delta.kind,
         turnId: delta.turnId,
         messageId: delta.messageId,
         text: folded.text,
+        complete: delta.complete === true,
+        completionEmitted: delta.complete === true,
+        replacing: delta.complete === true ? false : replacing,
       });
-      if (folded.tail) {
+      if (delta.complete === true) {
+        events.push({
+          type: delta.kind === 'text' ? 'text_complete' : 'thinking_complete',
+          id: frameIdentity(frame),
+          turnId: delta.turnId,
+          messageId: delta.messageId,
+          ts: this.#now(),
+          text: folded.text,
+        });
+      } else if (folded.tail && !replacing) {
         events.push({
           type: delta.kind === 'text' ? 'text_delta' : 'thinking_delta',
           id: frameIdentity(frame),
@@ -246,7 +285,7 @@ export class RuntimeHostSessionProjector {
   #terminalEvents(root: RuntimeHostTerminalTurn): SessionEvent[] {
     const events: SessionEvent[] = [];
     for (const accumulator of this.#accumulators.values()) {
-      if (accumulator.turnId !== root.turnId) continue;
+      if (accumulator.turnId !== root.turnId || accumulator.completionEmitted) continue;
       events.push({
         type: accumulator.kind === 'text' ? 'text_complete' : 'thinking_complete',
         id: `${root.terminalEventId}:${accumulator.kind}:${accumulator.messageId}`,

--- a/packages/runtime-host/src/client/session-subscription.ts
+++ b/packages/runtime-host/src/client/session-subscription.ts
@@ -1,5 +1,6 @@
 import {
   encodeProtocolMessage,
+  type SessionAssistantStreamIdentity,
   type SessionContinuitySnapshot,
   type SubscriptionFrame,
   type SubscriptionOpenResult,
@@ -41,6 +42,7 @@ export interface RuntimeHostSessionSubscription extends AsyncIterable<Subscripti
   readonly hostEpoch: string;
   readonly subscriptionId: string;
   readonly snapshot: SessionContinuitySnapshot;
+  readonly activeAssistantStreams: readonly SessionAssistantStreamIdentity[];
   loadTranscript<T>(decodeMessage: (value: unknown) => T): Promise<T[]>;
   close(): Promise<void>;
 }
@@ -56,6 +58,7 @@ export class ClientSessionSubscription
   readonly hostEpoch: string;
   readonly subscriptionId: string;
   readonly snapshot: SessionContinuitySnapshot;
+  readonly activeAssistantStreams: readonly SessionAssistantStreamIdentity[];
   readonly #requestClose: () => Promise<void>;
   readonly #queryTranscript: (
     input: SessionTranscriptQueryInput,
@@ -85,6 +88,7 @@ export class ClientSessionSubscription
     this.hostEpoch = result.hostEpoch;
     this.subscriptionId = result.subscriptionId;
     this.snapshot = result.snapshot;
+    this.activeAssistantStreams = result.activeAssistantStreams;
     this.#expectedSessionId = result.snapshot.session.sessionId;
     this.#expectedSequence = result.nextSequence;
     this.#latestProjectionRevision = result.snapshot.projectionRevision;

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -72,7 +72,7 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 16 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 17 as const;
 // A legal sandbox-boundary expansion can consume 64 KiB before its Interaction
 // envelope and independently bounded justification are added. Keep transport
 // capacity large enough to represent that domain value; narrower surfaces such

--- a/packages/runtime-host/src/protocol/session-continuity.ts
+++ b/packages/runtime-host/src/protocol/session-continuity.ts
@@ -73,6 +73,13 @@ export interface SubscriptionOpenResult {
   subscriptionId: string;
   nextSequence: number;
   snapshot: SessionContinuitySnapshot;
+  activeAssistantStreams: SessionAssistantStreamIdentity[];
+}
+
+export interface SessionAssistantStreamIdentity {
+  kind: 'text' | 'thinking';
+  turnId: string;
+  messageId: string;
 }
 
 export interface SubscriptionCloseInput {
@@ -101,6 +108,8 @@ export interface SessionAssistantDelta {
   messageId: string;
   startOffset: number;
   text: string;
+  reset?: true;
+  complete?: true;
 }
 
 export interface SessionDeltaFrame extends SubscriptionEnvelope {
@@ -473,6 +482,7 @@ function decodeSubscriptionOpenResult(value: unknown): SubscriptionOpenResult {
     'subscriptionId',
     'nextSequence',
     'snapshot',
+    'activeAssistantStreams',
   ]);
   const hostEpoch = requireId(record.hostEpoch, 'hostEpoch');
   const snapshot = decodeSessionContinuitySnapshot(record.snapshot);
@@ -482,7 +492,49 @@ function decodeSubscriptionOpenResult(value: unknown): SubscriptionOpenResult {
     subscriptionId: requireId(record.subscriptionId, 'subscriptionId'),
     nextSequence: requirePositiveCount(record.nextSequence, 'nextSequence'),
     snapshot,
+    activeAssistantStreams: decodeActiveAssistantStreams(record.activeAssistantStreams, snapshot),
   };
+}
+
+function decodeActiveAssistantStreams(
+  value: unknown,
+  snapshot: SessionContinuitySnapshot,
+): SessionAssistantStreamIdentity[] {
+  if (!Array.isArray(value) || value.length > 2) {
+    throw invalidProtocolFrame('Invalid active Session assistant streams');
+  }
+  const root = snapshot.rootTurn;
+  const identities = value.map((candidate): SessionAssistantStreamIdentity => {
+    const record = requireExactRecord(candidate, 'active Session assistant stream', [
+      'kind',
+      'turnId',
+      'messageId',
+    ]);
+    if (record.kind !== 'text' && record.kind !== 'thinking') {
+      throw invalidProtocolFrame('Invalid active Session assistant stream kind');
+    }
+    const kind = record.kind;
+    const identity: SessionAssistantStreamIdentity = {
+      kind,
+      turnId: requireEntityId(record.turnId, 'turnId'),
+      messageId: requireEntityId(record.messageId, 'messageId'),
+    };
+    if (
+      !root ||
+      root.status === 'completed' ||
+      root.status === 'failed' ||
+      root.status === 'cancelled' ||
+      identity.turnId !== root.turnId
+    ) {
+      throw invalidProtocolFrame('Active Session assistant stream has no active root Turn');
+    }
+    return identity;
+  });
+  const keys = identities.map(({ kind, messageId }) => `${kind}\0${messageId}`);
+  if (new Set(keys).size !== keys.length) {
+    throw invalidProtocolFrame('Duplicate active Session assistant stream');
+  }
+  return identities;
 }
 
 function decodeSubscriptionCloseInput(value: unknown): SubscriptionCloseInput {
@@ -504,7 +556,18 @@ function decodeEnvelope(record: Record<string, unknown>): SubscriptionEnvelope {
 }
 
 function decodeAssistantDelta(value: unknown): SessionAssistantDelta {
-  const record = requireExactRecord(value, 'Session assistant delta', [
+  const record = requireRecord(value, 'Session assistant delta');
+  assertAllowedKeys(record, 'Session assistant delta', [
+    'kind',
+    'turnId',
+    'runId',
+    'messageId',
+    'startOffset',
+    'text',
+    'reset',
+    'complete',
+  ]);
+  assertRequiredKeys(record, 'Session assistant delta', [
     'kind',
     'turnId',
     'runId',
@@ -515,17 +578,34 @@ function decodeAssistantDelta(value: unknown): SessionAssistantDelta {
   if (record.kind !== 'text' && record.kind !== 'thinking') {
     throw invalidProtocolFrame('Invalid Session assistant delta kind');
   }
+  if (record.complete !== undefined && record.complete !== true) {
+    throw invalidProtocolFrame('Invalid Session assistant delta completion');
+  }
+  if (record.reset !== undefined && record.reset !== true) {
+    throw invalidProtocolFrame('Invalid Session assistant delta reset');
+  }
+  const startOffset = requireCount(record.startOffset, 'Session assistant delta start offset');
+  if (record.reset === true && startOffset !== 0) {
+    throw invalidProtocolFrame('Session assistant delta reset must start at offset zero');
+  }
   return {
     kind: record.kind,
     turnId: requireEntityId(record.turnId, 'turnId'),
     runId: requireEntityId(record.runId, 'runId'),
     messageId: requireEntityId(record.messageId, 'messageId'),
-    startOffset: requireCount(record.startOffset, 'Session assistant delta start offset'),
-    text: requireUtf8BoundedString(
-      record.text,
-      'Session assistant delta text',
-      SESSION_LIVE_DELTA_MAX_BYTES,
-    ),
+    startOffset,
+    // A completion may have no unseen suffix. Its empty frame closes the
+    // already accumulated content without resending the full assistant text.
+    text:
+      record.complete === true && record.text === ''
+        ? ''
+        : requireUtf8BoundedString(
+            record.text,
+            'Session assistant delta text',
+            SESSION_LIVE_DELTA_MAX_BYTES,
+          ),
+    ...(record.reset === true ? { reset: true as const } : {}),
+    ...(record.complete === true ? { complete: true as const } : {}),
   };
 }
 

--- a/packages/runtime-host/src/protocol/session-continuity.ts
+++ b/packages/runtime-host/src/protocol/session-continuity.ts
@@ -500,7 +500,7 @@ function decodeActiveAssistantStreams(
   value: unknown,
   snapshot: SessionContinuitySnapshot,
 ): SessionAssistantStreamIdentity[] {
-  if (!Array.isArray(value) || value.length > 2) {
+  if (!Array.isArray(value)) {
     throw invalidProtocolFrame('Invalid active Session assistant streams');
   }
   const root = snapshot.rootTurn;

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -2737,7 +2737,9 @@ function isRuntimeSessionTransientEvent(
 ): event is RuntimeSessionTransientEvent {
   return (
     event.type === 'text_delta' ||
+    event.type === 'text_complete' ||
     event.type === 'thinking_delta' ||
+    event.type === 'thinking_complete' ||
     event.type === 'tool_start' ||
     event.type === 'tool_output_delta' ||
     event.type === 'tool_progress' ||

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -50,7 +50,9 @@ export type RuntimeSessionTransientEvent = Extract<
   {
     type:
       | 'text_delta'
+      | 'text_complete'
       | 'thinking_delta'
+      | 'thinking_complete'
       | 'tool_start'
       | 'tool_output_delta'
       | 'tool_progress'
@@ -72,7 +74,7 @@ interface SessionProjectionState {
   canonical: CanonicalSessionProjection;
   revision: number;
   subscribers: Map<string, Subscriber>;
-  assistantPrefixes: Map<string, ActiveAssistantPrefix>;
+  assistantStreams: Map<string, ActiveAssistantStream>;
   /**
    * Latest live tool_result_preview per toolUseId for the active turn.
    * Replace semantics; cleared on tool_result and terminal publication.
@@ -85,11 +87,12 @@ interface SessionProjectionState {
   terminalPublicationFence?: TerminalPublicationFence;
 }
 
-interface ActiveAssistantPrefix {
+interface ActiveAssistantStream {
   turnId: string;
   messageId: string;
   kind: SessionAssistantDelta['kind'];
   text: string;
+  completedParts?: string[];
 }
 
 interface TerminalPublicationFence {
@@ -497,7 +500,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         state.canonical = canonical;
         state.revision = nextRevision;
         delete state.terminalPublicationFence;
-        state.assistantPrefixes.clear();
+        state.assistantStreams.clear();
         state.toolResultPreviews.clear();
         this.#broadcastProjection(state, snapshot);
         if (state.subscribers.size === 0) this.#sessions.delete(sessionId);
@@ -545,10 +548,10 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       if (event.type === 'text_delta' || event.type === 'thinking_delta') {
         const kind: SessionAssistantDelta['kind'] =
           event.type === 'text_delta' ? 'text' : 'thinking';
-        const prefixKey = assistantPrefixKey(kind, event.messageId);
-        const current = state.assistantPrefixes.get(prefixKey);
+        const prefixKey = assistantStreamKey(kind, event.messageId);
+        const current = state.assistantStreams.get(prefixKey);
         const startOffset = current?.text.length ?? 0;
-        state.assistantPrefixes.set(prefixKey, {
+        state.assistantStreams.set(prefixKey, {
           turnId: event.turnId,
           messageId: event.messageId,
           kind,
@@ -556,6 +559,62 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         });
         for (const subscriber of state.subscribers.values()) {
           this.#enqueueAssistantDelta(subscriber, sessionId, runId, event, kind, startOffset);
+        }
+        return;
+      }
+      if (event.type === 'text_complete' || event.type === 'thinking_complete') {
+        if (event.type === 'thinking_complete') {
+          const prefixKey = assistantStreamKey('thinking', event.messageId);
+          const current = state.assistantStreams.get(prefixKey) ?? {
+            kind: 'thinking' as const,
+            turnId: event.turnId,
+            messageId: event.messageId,
+            text: '',
+          };
+          current.completedParts = [...(current.completedParts ?? []), event.text];
+          state.assistantStreams.set(prefixKey, current);
+          return;
+        }
+
+        const thinkingKey = assistantStreamKey('thinking', event.messageId);
+        const thinking = state.assistantStreams.get(thinkingKey);
+        if (thinking) {
+          const finalThinking = thinking.completedParts?.join('') ?? thinking.text;
+          for (const subscriber of state.subscribers.values()) {
+            this.#enqueueAssistantCompletion(
+              subscriber,
+              sessionId,
+              runId,
+              thinking,
+              'thinking',
+              finalThinking,
+            );
+          }
+          state.assistantStreams.delete(thinkingKey);
+        }
+
+        const textKey = assistantStreamKey('text', event.messageId);
+        const text = state.assistantStreams.get(textKey);
+        if (text || event.text.length > 0) {
+          const current =
+            text ??
+            ({
+              kind: 'text',
+              turnId: event.turnId,
+              messageId: event.messageId,
+              text: '',
+            } satisfies ActiveAssistantStream);
+          for (const subscriber of state.subscribers.values()) {
+            this.#enqueueAssistantCompletion(
+              subscriber,
+              sessionId,
+              runId,
+              current,
+              'text',
+              event.text,
+            );
+          }
+          state.assistantStreams.delete(textKey);
         }
         return;
       }
@@ -702,6 +761,9 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
             subscriptionId,
             nextSequence: firstSequence,
             snapshot: committed.value,
+            activeAssistantStreams: [...committed.state.assistantStreams.values()].map(
+              ({ kind, turnId, messageId }) => ({ kind, turnId, messageId }),
+            ),
           },
         };
       });
@@ -753,7 +815,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
           connectionId,
           subscriptionId: subscriber.subscriptionId,
           sessionId: subscriber.sessionId,
-          messages: mergeActiveAssistantPrefixes(messages, state?.assistantPrefixes.values()),
+          messages: mergeActiveAssistantStreams(messages, state?.assistantStreams.values()),
         });
       } catch {
         return {
@@ -859,6 +921,61 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     kind: SessionAssistantDelta['kind'],
     startOffset: number,
   ): void {
+    this.#enqueueAssistantText(subscriber, sessionId, runId, event, kind, startOffset, event.text);
+  }
+
+  #enqueueAssistantCompletion(
+    subscriber: Subscriber,
+    sessionId: string,
+    runId: string,
+    current: Pick<ActiveAssistantStream, 'turnId' | 'messageId' | 'text'>,
+    kind: SessionAssistantDelta['kind'],
+    finalText: string,
+  ): void {
+    const extendsPrefix = finalText.startsWith(current.text);
+    const suffix = extendsPrefix ? finalText.slice(current.text.length) : finalText;
+    if (suffix) {
+      this.#enqueueAssistantText(
+        subscriber,
+        sessionId,
+        runId,
+        current,
+        kind,
+        extendsPrefix ? current.text.length : 0,
+        suffix,
+        !extendsPrefix,
+      );
+    }
+    if (subscriber.phase !== 'open') return;
+    this.#enqueue(subscriber, {
+      kind: 'subscription.session_delta',
+      hostEpoch: this.#hostEpoch,
+      subscriptionId: subscriber.subscriptionId,
+      sequence: subscriber.nextSequence,
+      sessionId,
+      delta: {
+        kind,
+        turnId: current.turnId,
+        runId,
+        messageId: current.messageId,
+        startOffset: finalText.length,
+        text: '',
+        ...(!extendsPrefix && finalText.length === 0 ? { reset: true as const } : {}),
+        complete: true,
+      },
+    });
+  }
+
+  #enqueueAssistantText(
+    subscriber: Subscriber,
+    sessionId: string,
+    runId: string,
+    event: Pick<ActiveAssistantStream, 'turnId' | 'messageId' | 'text'>,
+    kind: SessionAssistantDelta['kind'],
+    startOffset: number,
+    text: string,
+    reset = false,
+  ): void {
     let chunk = '';
     let rawBytes = 0;
     let wireBytes = 0;
@@ -876,10 +993,11 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         messageId: event.messageId,
         startOffset: startOffset + emittedCharacters,
         text,
+        ...(reset && emittedCharacters === 0 ? { reset: true } : {}),
       },
     });
     let wireLimit = wireTextByteLimit(frame(''));
-    for (const character of event.text) {
+    for (const character of text) {
       const rawCharacterBytes = Buffer.byteLength(character, 'utf8');
       const wireCharacterBytes = jsonStringContentBytes(character);
       if (
@@ -1027,7 +1145,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         canonical,
         revision: 1,
         subscribers: new Map(),
-        assistantPrefixes: new Map(),
+        assistantStreams: new Map(),
         toolResultPreviews: new Map(),
       };
       this.#sessions.set(sessionId, state);
@@ -1035,6 +1153,10 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     }
     const changed = !isDeepStrictEqual(state.canonical, canonical);
     if (changed) {
+      if (state.canonical.rootTurn?.runId !== canonical.rootTurn?.runId) {
+        state.assistantStreams.clear();
+        state.toolResultPreviews.clear();
+      }
       const nextRevision = state.revision + 1;
       const value = createSessionContinuitySnapshot(canonical, nextRevision);
       state.canonical = canonical;
@@ -1081,13 +1203,13 @@ function slowConsumerFrameBytes(subscriber: Subscriber, hostEpoch: string): numb
   }).byteLength;
 }
 
-function assistantPrefixKey(kind: SessionAssistantDelta['kind'], messageId: string): string {
+function assistantStreamKey(kind: SessionAssistantDelta['kind'], messageId: string): string {
   return `${kind}\0${messageId}`;
 }
 
-function mergeActiveAssistantPrefixes(
+function mergeActiveAssistantStreams(
   messages: readonly StoredMessage[],
-  prefixes: Iterable<ActiveAssistantPrefix> | undefined,
+  prefixes: Iterable<ActiveAssistantStream> | undefined,
 ): readonly StoredMessage[] {
   const activePrefixes = prefixes ? [...prefixes] : [];
   if (activePrefixes.length === 0) return messages;
@@ -1189,7 +1311,10 @@ function jsonStringContentBytes(value: string): number {
 }
 
 function projectToolEvent(
-  event: Exclude<RuntimeSessionTransientEvent, { type: 'text_delta' | 'thinking_delta' }>,
+  event: Exclude<
+    RuntimeSessionTransientEvent,
+    { type: 'text_delta' | 'thinking_delta' | 'text_complete' | 'thinking_complete' }
+  >,
 ): SessionToolEvent {
   const identity = {
     id: event.id,

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -1226,14 +1226,14 @@ function mergeActiveAssistantStreams(
     }
     let nextMessage: StoredMessage;
     if (prefix.kind === 'text') {
-      const text = mergeAssistantPrefix(message.text, prefix.text);
+      const text = reconcileAssistantText(message.text, prefix.text);
       if (text === message.text) continue;
       nextMessage = { ...message, text };
     } else {
       if (!message.thinking) {
         throw new Error('Active thinking prefix has no matching transcript content');
       }
-      const text = mergeAssistantPrefix(message.thinking.text, prefix.text);
+      const text = reconcileAssistantText(message.thinking.text, prefix.text);
       if (text === message.thinking.text) continue;
       nextMessage = { ...message, thinking: { ...message.thinking, text } };
     }
@@ -1243,10 +1243,14 @@ function mergeActiveAssistantStreams(
   return merged ?? messages;
 }
 
-function mergeAssistantPrefix(durable: string, active: string): string {
+function reconcileAssistantText(durable: string, active: string): string {
   if (active.startsWith(durable)) return active;
   if (durable.startsWith(active)) return durable;
-  throw new Error('Active assistant prefix conflicts with the durable transcript');
+  // Persistence is authoritative once it contains a final value. The live
+  // stream may still retain an earlier draft until its completion event enters
+  // this lane; a non-prefix durable value therefore replaces that draft during
+  // transcript catch-up instead of making the snapshot unavailable.
+  return durable;
 }
 
 function transcriptSubscriptionNotFound(): OperationOutcome<'session.transcript.query'> {

--- a/packages/runtime/src/fake-backend.ts
+++ b/packages/runtime/src/fake-backend.ts
@@ -22,6 +22,7 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 export const FAKE_ASK_USER_QUESTION_PROMPT = '__e2e_ask_user_question__';
 export const FAKE_ASK_SANDBOX_BOUNDARY_PROMPT = '__e2e_ask_sandbox_boundary__';
 export const FAKE_WAIT_FOR_STEERING_PROMPT = '__e2e_wait_for_steering__';
+export const FAKE_HOLD_OPEN_PROMPT = '__e2e_hold_open__';
 export const FAKE_MERMAID_PROMPT = '__e2e_mermaid__';
 export const FAKE_MERMAID_HOSTILE_PROMPT = '__e2e_mermaid_hostile__';
 export const FAKE_ERROR_PROMPT_PREFIX = '__e2e_error__:';
@@ -169,6 +170,48 @@ export class FakeBackend implements AgentBackend {
     };
 
     try {
+      if (input.text === FAKE_HOLD_OPEN_PROMPT) {
+        let waitingText = 'Fake backend waiting for the test to stop the Turn.';
+        yield {
+          type: 'text_delta',
+          id: randomUUID(),
+          turnId,
+          ts: Date.now(),
+          messageId,
+          text: waitingText,
+        };
+        while (!this.stopped) {
+          const pending = drainSteering();
+          for (const { leaseId, event } of pending) {
+            yield event;
+            settleOutstanding(leaseId);
+          }
+          if (pending.length > 0) {
+            const nextText = `Fake backend waiting for the test to stop the Turn.\n\nAcknowledged steering: ${steered.join(' | ')}`;
+            const delta = nextText.slice(waitingText.length);
+            waitingText = nextText;
+            yield {
+              type: 'text_delta',
+              id: randomUUID(),
+              turnId,
+              ts: Date.now(),
+              messageId,
+              text: delta,
+            };
+          }
+          await sleep(5);
+        }
+        yield { type: 'abort', id: randomUUID(), turnId, ts: Date.now(), reason: 'user_stop' };
+        yield {
+          type: 'complete',
+          id: randomUUID(),
+          turnId,
+          ts: Date.now(),
+          stopReason: 'user_stop',
+        };
+        return;
+      }
+
       if (input.text === FAKE_WAIT_FOR_STEERING_PROMPT) {
         let pending = drainSteering();
         while (pending.length === 0 && !this.stopped) {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Settle assistant thinking and text streams at their actual step boundaries
- Preserve authoritative completion payloads, including non-prefix replacements and multipart reasoning
- Carry active stream identities through Runtime Host subscriptions so Desktop and CLI/TUI reconnect without reactivating settled output

## Why

Runtime Host previously treated completion as an append-only suffix and did not retain settled state. Multiple reasoning parts or a reconnect could therefore leave finished thinking marked active, duplicate terminal events, or reject the stream when the final provider value replaced earlier deltas.

The subscription wire contract changes, so this advances the compatibility epoch to 17.

## Validation

- `npm test -w @maka/runtime-host` (874 tests)
- `npm test -w maka-agent` (349 tests)
- `npm test -w @maka/desktop` (1094 tests)
- `npm run typecheck -w @maka/runtime-host`
- `npm run typecheck -w maka-agent`
- `npm run typecheck -w @maka/desktop`
- Biome checks and `git diff --check`

</details>

<details>
<summary>中文</summary>

## 概要

- 在实际 step 边界正确结算 assistant 的思考与文本流
- 保留权威的完成内容，包括非前缀替换和多段 reasoning
- 通过 Runtime Host 订阅传递活跃 stream 身份，使 Desktop 与 CLI/TUI 重连时不会重新激活已经结束的输出

## 原因

Runtime Host 之前把完成事件视为仅追加的后缀，并且没有保留已结算状态。因此，多段 reasoning 或重连可能导致已经结束的思考仍显示为活跃、重复产生终态事件，或在 provider 的最终值替换先前 delta 时拒绝该 stream。

本次修改改变了订阅 wire contract，因此 compatibility epoch 提升到 17。

## 验证

- `npm test -w @maka/runtime-host`（874 项测试）
- `npm test -w maka-agent`（349 项测试）
- `npm test -w @maka/desktop`（1094 项测试）
- `npm run typecheck -w @maka/runtime-host`
- `npm run typecheck -w maka-agent`
- `npm run typecheck -w @maka/desktop`
- Biome 检查与 `git diff --check`

</details>
