### PR TITLE
docs(runtime-host): align architecture guide with current boundaries

### DIFF
--- a/docs/architecture/runtime-host-architecture.md
+++ b/docs/architecture/runtime-host-architecture.md
@@ -1,80 +1,128 @@
 ---
 doc_id: architecture.runtime-host
-title: "Runtime Host: One Online Owner for Runtime Execution"
+title: "Runtime Host Architecture"
 language: en
 source_language: zh-CN
 counterpart: ./runtime-host-architecture.zh-CN.md
 implementation_status: current
 document_status: current
 translation_status: synced
-last_verified: 2026-08-10
+last_verified: 2026-08-11
 owners:
   - maka-backend
 ---
 
-# Runtime Host: One Online Owner for Runtime Execution
+# Runtime Host architecture
 
-> Runtime Host is the single online owner of a State Root and its Runtime executions. Clients submit bounded operations; the Host owns durable state, execution admission, recovery, and shutdown. A Client disconnect never transfers that ownership back to the Client.
+> Runtime Host is the long-lived process that owns one State Root and the Runtime work using it. Desktop, TUI, CLI, bots, and evaluation code are Clients. They ask the Host to do work; they do not own a second Runtime.
 
-This chapter is for engineers who maintain Runtime Host or connect a product domain to it. It explains the stable ownership and lifecycle contracts without repeating individual operation schemas or coordinator internals.
+This chapter explains the stable boundaries needed to maintain Runtime Host or connect a product feature to it. It does not repeat individual protocol schemas or coordinator internals.
+
+In this document, an **owner** or **authority** is the only component allowed to make a particular state transition while the Host is online. It is not necessarily the Client or user that initiated the work.
 
 ## Why Runtime Host exists
 
-Runtime execution outlives a request connection. A model call may continue after a Desktop window reloads, an authenticated remote Client may disconnect, and a process may restart while durable work is active.
+Runtime work outlives a request connection. A model call may continue after a Desktop window reloads, an authenticated remote Client may disconnect, and a process may restart while durable work is active. The State Root is the directory containing the durable state that must survive those events.
 
 If each Client owns its own Runtime and recovery path, the system gains multiple writers, conflicting Session state, and connection-dependent execution. Runtime Host removes that ambiguity:
 
 - one process owns writes for one State Root;
-- Local IPC and authenticated WebSocket use the same canonical state;
-- Domain code owns business decisions;
-- one execution authority owns admission, stop, settlement, and recovery.
+- Local IPC and authenticated WebSocket use the same durable state;
+- business code decides what work means;
+- one execution authority admits and stops top-level Session work, tracks its final result, and waits for cleanup.
 
-## The mental model
+## Parts in plain language
+
+| Part | Plain meaning |
+|---|---|
+| Host Kernel | The process gate: owns the State Root's exclusive lease and connections, stops new work, and shuts the process down |
+| Host Composition | The fixed startup recipe: creates Stores, shared authorities, and the Module list |
+| Domain Module | A static record assigning a group of protocol operations and startup/shutdown duties to one owner |
+| Hosted Execution | The traffic controller for top-level Session work: accepts one exact execution, stops or recovers it, and distinguishes its final result from finished cleanup |
+| Run Composer | Records the unchanging prompt and tool basis before a provider call |
+| Session Continuity | Gives Clients a canonical Session snapshot plus size-limited live updates |
+| Client Capability | Lets the Host invoke a capability published by a connected Client without transferring Runtime ownership |
+
+Durable Stores are the recovery source of truth. In the rest of this document, **canonical state** means state rebuilt from those Stores, and a **projection** is a read-oriented view derived from that state.
+
+**Bounded** means that the protocol sets explicit schema, size, count, or time limits instead of accepting arbitrary work or payloads.
+
+The execution names also describe different scopes:
+
+| Name | Scope |
+|---|---|
+| Session | The durable conversation and workspace context |
+| Turn | One top-level unit of work represented in that Session, whether started by a user or by the Host |
+| Run | The durable execution entity that performs model and tool work for a Turn |
+| Root execution | The one top-level execution currently admitted for a Session |
+
+## One Turn through the system
 
 ```mermaid
-flowchart LR
-    Client[Client] --> Kernel[Host Kernel]
-    Kernel --> Composition[Host Composition]
-    Composition --> Domain[Domain Module]
-    Domain --> Execution[Hosted Execution Authority]
-    Execution --> Runtime[Maka Runtime]
-    Domain --> Composer[Run Composer]
-    Composer --> Runtime
-    Composition --> Store[Durable Stores]
+sequenceDiagram
+    participant Client
+    participant Kernel as Host Kernel
+    participant Domain as Domain Module
+    participant Execution as Hosted Execution
+    participant Runtime as Maka Runtime
+    participant Store as Durable Stores
+    participant Continuity as Session Continuity
+    participant Capability as Client Capability
+
+    Client->>Kernel: Submit a message
+    Kernel->>Domain: Route an authenticated operation
+    Domain->>Execution: Reserve and admit the root execution
+    Execution->>Runtime: Start the exact execution
+    loop Model and tool work
+        Runtime->>Store: Append durable facts
+        Runtime-->>Continuity: Publish a size-limited live event
+        Continuity-->>Client: Send the next sequenced update
+        opt A selected tool needs the Client environment
+            Runtime->>Capability: Invoke a frozen capability binding
+            Capability->>Client: Bounded reverse call
+        end
+    end
+    Store-->>Continuity: Rebuild canonical state
+    Continuity-->>Client: Return a fresh snapshot
 ```
 
-| Component | Owns |
-|---|---|
-| Host Kernel | State Root ownership, transport, connection authority, residency, drain, and shutdown |
-| Host Composition | Static composition identity, Store construction, Domain Modules, and shared authorities |
-| Domain Module | One domain's handlers, recovery, drain, close, and connection cleanup |
-| Hosted Execution Authority | Root admission, execution identity, stop, terminal reconciliation, and recovery |
-| Run Composer | The immutable prompt, tool, policy, and source-revision basis for one Run |
+Before requests arrive, the Host Composition has already constructed these parts and assigned each business operation to one Domain Module. Process, diagnostics, upgrade, and access-credential operations remain Kernel-owned. Composition is the startup plan, not an extra service called on every request.
 
-## Four identities that must stay separate
+For a user message, the Kernel authenticates and routes the request but does not interpret it. The owning Domain applies message and Session rules, then uses Hosted Execution when root work can start. Before the first provider request, Run Composer freezes and persists the prompt and tool basis. Runtime writes canonical facts, and Session Continuity projects those facts back to every Client.
 
-| Identity | Meaning | Lifetime |
+A Scheduled Task follows the same execution path but starts inside its Domain rather than from a connected Client. This is why Client disconnects do not control execution lifetime.
+
+## Host identities
+
+These values answer different questions and must not be used as substitutes for one another:
+
+| Identity | Plain meaning | Lifetime |
 |---|---|---|
-| State Root | The canonical directory for durable Host state | Survives Host processes |
-| Host Epoch | One process instance that acquired the root owner | Ends with that process |
-| Composition ID | The static Host composition allowed to use the State Root | Persistently bound to the root |
-| Host Generation | The Runtime Host build requested by a local ephemeral Client | Product build, or one development Client process |
+| State Root | The directory containing durable Host state; one process holds its exclusive writer lease | Survives Host processes |
+| Host Epoch | The identity of the process currently holding that lease | Ends with that process |
+| Composition ID | The kind of Host program allowed to interpret the State Root | Persistently bound to the root |
+| Composition Revision | The revision of that Composition expected by a Client | Changes when startup wiring or compatibility changes |
+| Host Generation | The replacement generation requested by a local owner Client | Shared by one product version, or unique to one development Client process |
 
-A restart creates a new Host Epoch. A software update can also change the Host Generation. Neither changes the State Root or its Composition ID.
+A restart changes the Host Epoch. A Composition change may change its Revision. A product-version update or development Client restart may change the Host Generation. None of those changes implicitly moves the State Root or changes its persistently bound Composition ID.
 
-## Ownership boundaries
+For example, a State Root bound to the interactive Composition cannot be opened by a different kind of Composition. The interactive Composition may evolve to a new revision without changing that persistent identity.
+
+## What each part owns
 
 ### Host Kernel owns process lifecycle
 
-The Kernel acquires the State Root writer owner, starts required listeners, authenticates connections, creates immutable connection authority, and drives Composition recovery, drain, and close.
+The Kernel acquires the State Root's exclusive writer lease, starts listeners, and authenticates connections. Authentication produces an immutable set of permissions for that connection. The Kernel also tracks active operations and **residencies**—explicit reasons the process must remain alive—and drives Composition recovery, drain, and close.
 
-The Kernel does not interpret messages, prompts, tools, Goal state, Automation state, or Agent Graph state. New domain behavior enters through a Domain Module rather than another Kernel branch.
+The Kernel does not interpret business state such as messages, tools, Goals, or Scheduled Tasks. New business behavior enters through a Domain Module rather than another Kernel branch.
 
-### Host Composition owns static assembly
+### Host Composition is the fixed startup plan
 
-Composition is fixed before startup. Its descriptor contains only a stable ID and revision. Actual Module IDs come from the created Composition, so diagnostics cannot drift from runtime ownership.
+The Composition ID, revision, and construction function are chosen before listeners start. Modules are created once during startup and remain fixed after the Host becomes Ready. Diagnostics read the actual Module IDs from that created Composition instead of maintaining a second list.
 
-Each protocol operation has exactly one Module owner. Composition combines those owners; it does not keep a parallel implementation of their handlers or lifecycle.
+Each business operation has exactly one Module owner. Composition combines those owners; it does not keep a parallel implementation of their handlers or lifecycle. Kernel operations stay outside Domain Modules.
+
+For example, the interactive Composition constructs Session and Scheduled Task Modules, among others, along with their Stores and shared execution authority. That list is chosen once for the Host process. Composition is not a dynamic plugin registry or per-Session configuration.
 
 Recovery runs through five fixed phases:
 
@@ -84,37 +132,66 @@ Recovery runs through five fixed phases:
 4. `domains`
 5. `schedulers`
 
+This order makes durable state and resources available before executions and business domains recover, and starts schedulers last.
+
 Close runs in reverse Module order. Drain and close attempt every owner and aggregate failures.
 
-### Domain Modules own business lifecycle
+### A Domain Module groups operation and lifecycle ownership
 
-A Domain Module receives narrow constructor ports and owns its handlers and resources. It can use shared Host contracts, but it does not find services through a dynamic registry or create a second Runtime authority.
+A Domain Module is a static record that answers four questions:
+
+- which protocol operations does this group handle;
+- what must it recover in each startup phase;
+- what new work must it reject during drain;
+- which resources and connection-scoped state must it release.
+
+For example, the Scheduled Task Module owns Scheduled Task operations, restores durable scheduling state, starts its scheduler only after recovery, and stops and closes that scheduler during shutdown. When a task fires, the Module still asks the shared Hosted Execution authority to run it; it does not create another Runtime.
+
+A Module does not have to be a separate process, package, or source directory. It may represent one focused feature or a closely related lifecycle group. Construction code passes dependencies directly; Modules do not look them up by name at runtime.
 
 The Domain decides what an execution result means and what should happen next. Hosted Execution only owns the execution lifecycle.
 
-### Hosted Execution owns root execution lifecycle
+### Hosted Execution controls top-level work in a Session
 
-Hosted Execution is the only online authority for root execution. Admission atomically returns the initial snapshot, completion handle, and cleanup settlement handle for the exact execution.
+**Admission** is the atomic decision that reserves a Session for one exact root execution, preventing two top-level Turns from running concurrently.
 
-Consumers use durable terminal projection to decide the business result and the settlement handle to know when execution cleanup has finished. They do not reconstruct these handles later from a Session ID or Turn ID.
+Successful admission returns three related values:
 
-Subscriptions are wake-up hints. Recovery always rereads durable facts.
+- `snapshot`: the state observed when the execution was admitted;
+- `completion`: a terminal snapshot with completed, failed, or cancelled status, or an explicit `authority_error`;
+- `settled`: a signal that execution cleanup has also finished and its temporary resources have been released.
 
-### Run Composer owns the provider-dispatch basis
+A Domain uses `completion` to decide the business result and `settled` to know that cleanup is over. It keeps the handles returned for that exact execution rather than reconstructing them later from a Session ID or Turn ID.
 
-Run Composer freezes the model-visible basis for a Run: base system prompt, tool catalog, tool availability policy, base provider options, and source revisions.
+Hosted Execution subscriptions only tell same-Epoch observers that something may have changed. They are not proof of the new state; recovery always rereads durable facts.
 
-Before the first physical provider dispatch:
+### Session Continuity owns Client observation
+
+Session Continuity is the public read model for a live Session. Opening a subscription returns a canonical snapshot, the next expected sequence number, and the identities of assistant streams that are still active. The potentially larger transcript is read through a separate size-limited snapshot.
+
+Live projection, assistant, and tool updates have explicit size limits and sequence numbers. After a connection loss, Host Epoch change, sequence gap, or expired transcript snapshot, a Client opens a new subscription and rereads canonical state. For example, a Desktop reload during model output restores the current transcript and active stream identities; it does not resend the user message. Stream delivery is never a recovery authority.
+
+### Run Composer freezes what the model sees
+
+Run Composer freezes the model-visible basis for one Run: base system prompt, tool catalog, tool availability policy, base provider options, and the revisions of inputs used to construct them.
+
+Before the first real provider request:
 
 1. build the immutable Run Composition snapshot;
 2. commit it to the AgentRun Store;
-3. dispatch only after the commit succeeds.
+3. call the provider only after the commit succeeds.
 
-A failed composition or commit fails closed. A Run that never dispatches does not invent a composition snapshot.
+If composition or persistence fails, the provider is not called. A Run that never reaches provider dispatch does not invent a composition snapshot.
+
+### Client Capability keeps Client-local effects bounded
+
+An authenticated Client may publish size-limited, versioned tool or service **offers** describing what it can do. Runtime Host selects an exact provider **binding**, and a Run records selected model tools through its normal Run Composition path. The Host may then make a bounded reverse call for an effect that must execute in the Client environment—for example, an OS-facing capability published by Desktop.
+
+Publishing or invoking a capability does not transfer Session, Run, or execution ownership to the Client. Connection loss makes that provider unavailable; the owning Domain handles capability loss or an explicit result-unknown outcome through its normal durable contract.
 
 ### Runtime Host resolves workspaces
 
-Clients identify a workspace with one closed target:
+Clients identify a workspace with exactly one of two target forms:
 
 ```ts
 type WorkspaceTarget =
@@ -122,68 +199,74 @@ type WorkspaceTarget =
   | { kind: "host_path"; path: string };
 ```
 
-`project` is the portable form. Runtime Host resolves it through its Project Catalog and returns a projection containing the canonical target and `hostCwd`. `host_path` is for a Client that has explicit Host-path authority, such as a local CLI started in a checkout.
+`project` is the portable form. Runtime Host resolves it through its Project Catalog and returns the canonical target plus `hostCwd`, the absolute directory on the Host. `host_path` is for a Client explicitly permitted to name Host paths, such as a local CLI started in a checkout.
 
-The Project Catalog has revision-pinned, paginated summary and location views. The summary is path-free; reading locations requires Host-path authority.
+Project summaries do not expose paths. Only a connection allowed to read Host paths may read or change project locations, reveal a path on the Host, or submit `host_path`.
 
-Clients do not combine a path with a Project ID or resolve a Host path themselves. Desktop keeps its selected Project as a root-scoped Client preference; selecting a Project does not mutate global Host state. A Client without Host-path authority can use a registered Project, but cannot register, relink, request a Host-side reveal, or submit a Host path.
-
-Skill catalog management is a Host-filesystem operation. It requires Host-path authority and returns the workspace resolved by that operation.
+Clients do not combine a path with a Project ID or resolve a Host path themselves. Desktop remembers the selected Project locally for each State Root; selecting it does not mutate global Host state.
 
 ## Lifecycle
 
+Two Host lifetimes use the same Kernel and Composition:
+
+| Host kind | Who manages its lifetime |
+|---|---|
+| Ephemeral Host | A local Client launches it; it may exit when no connection, operation, or residency keeps it alive |
+| Service Host | A deployment owner runs it; Client generations do not replace it and it does not use Client-driven idle exit |
+
 | Stage | Contract |
 |---|---|
-| Startup | Acquire root owner, bind Composition identity, build Composition, recover Modules, start schedulers, then publish Ready |
-| Request | Authenticate, decode bounded input, enforce connection authority, route to the unique Module handler |
-| Execution | Reserve and admit through Hosted Execution, then reconcile terminal state from durable facts |
-| Drain | Reject new admission while already accepted work converges |
-| Close | Close Modules in reverse order, close listeners, then release the State Root owner |
+| Startup | Acquire the State Root lease, bind Composition identity, build Composition, recover Modules, start schedulers, then publish Ready |
+| Request | Authenticate, enforce input limits and connection permissions, then route to the Kernel or the unique Domain Module handler |
+| Execution | Reserve and admit through Hosted Execution, then reread durable facts to confirm the final state |
+| Drain | Stop accepting new work while already accepted work finishes or reaches a recoverable state |
+| Close | Stop listeners from accepting connections, drain operations, close Modules in reverse order, clean up listeners, then release the State Root lease |
 
 A Client disconnect releases only connection-scoped resources. It does not cancel an admitted execution.
 
 ### Local ephemeral upgrade handoff
 
-A Host Generation is separate from protocol compatibility: two builds can speak the same protocol but still require process replacement so the new Runtime code becomes authoritative. A local owner Client may request an exact-Host-Epoch drain. The Kernel then uses the normal drain path, and the successor waits for the existing owner lock to be released.
+A Host Generation is separate from protocol compatibility: two local Client generations can speak the same protocol but still request process replacement so the requested Runtime generation becomes authoritative. A local owner Client names the Host Epoch it observed when asking that process to drain; a stale Client therefore cannot drain a replacement process. The next Host waits for the existing State Root lease to be released.
 
-When startup finds another generation, the Host may return bounded activity counts for connections, operations, and residency categories. These facts explain why the process remains resident; they do not grant termination authority. Only local ephemeral Hosts support takeover. Service Hosts publish their lifecycle explicitly and remain connectable across Client generations; their deployment owner coordinates upgrades.
+When startup finds another generation, the Host may return limited counts of active connections, operations, and residencies. These counts explain why it remains alive but do not permit the Client to kill it. Only local ephemeral Hosts support replacement, and interrupting active work requires an explicit Client decision. Service Host upgrades remain the responsibility of their deployment owner. A waiting Client stops connection attempts until the observed Host exits, so waiting does not keep an otherwise idle Host alive.
 
-Choosing Wait stops connection attempts until the observed Host process exits, so waiting does not keep an otherwise idle Host alive.
-
-For an ephemeral Host, update preparation carries the user's interrupt choice into the Host. The Kernel checks existing work and closes admission in one decision, then enters the normal drain path. For a service Host, Desktop quiesces only its own reconnection; it does not drain the deployment-owned Host. Desktop resumes reconnection if installation is rejected.
-
-## Core invariants
+## Rules that must remain true
 
 1. One State Root has at most one writer owner.
 2. One Session has at most one root Hosted Execution or pending root admission.
-3. Local IPC and WebSocket share one dispatcher, authority model, and canonical state.
-4. Transport owns framing and authentication, not Domain state.
-5. Composition is fixed before startup.
-6. One protocol operation has one Module owner.
-7. Notifications are hints; Stores remain recovery authority.
+3. Local IPC and WebSocket share one routing table, permission model, and canonical state.
+4. Transport frames and authenticates messages; it does not own business state.
+5. Composition identity is fixed before listeners start, and its Module set is fixed before Ready.
+6. One business operation has one Module owner; process and access operations remain Kernel-owned.
+7. Notifications and streams do not replace Stores as the recovery authority.
 8. Provider dispatch waits for a durable Run Composition commit.
 9. Domain lifecycle and execution lifecycle remain separate.
 10. Shutdown continues closing other owners after one owner fails.
 11. Runtime Host is the only resolver from `WorkspaceTarget` to a canonical Host path.
+12. Client-local capability execution does not transfer Runtime ownership out of the Host.
+13. Clients rebuild observation from canonical snapshots after a stream discontinuity.
 
 ## How failures converge
 
 | Failure | Required behavior |
 |---|---|
-| Composition mismatch | Fail before listeners or Domain Store mutation; do not enter a candidate spawn loop |
-| Host crash | A successor rereads Stores and idempotently reconciles execution and Domain state |
+| Composition mismatch | Fail before listeners or Domain Store mutation; report terminal incompatibility instead of repeatedly starting candidates |
+| Host crash | The next Host rereads Stores and safely repeats recovery until execution and Domain state converge |
 | Lost notification | Reread the canonical projection; never infer terminal state from callback delivery |
+| Lost Session stream | Open a new subscription and reread its snapshot and transcript |
 | Run Composition failure | Do not call the provider |
 | Client disconnect | Keep admitted work under Host ownership |
+| Client Capability loss | Surface bounded capability-loss or outcome-unknown state; do not silently retry an uncertain effect |
 | Partial shutdown failure | Aggregate the error while continuing to release remaining resources |
 
-Runtime Host does not claim exactly-once behavior for arbitrary external side effects. The concrete Tool or resource owner must report an observed outcome, an unknown outcome, or an explicit recovery result.
+Runtime Host does not promise that an arbitrary external side effect happens exactly once. If a connection is lost after dispatch, the Host may know only that the outcome is unknown. The Tool or resource contract must preserve that uncertainty and must not retry automatically unless the operation explicitly permits it.
 
 ## Protocol and security boundary
 
-- Protocol messages use closed schemas, bounded input and output, and typed errors.
+- Protocol messages use closed schemas that reject unknown fields, explicit size and count limits, and stable error codes.
 - Authentication completes before protocol connection admission.
-- Connection authority fixes the principal, operation grants, and path or capability access.
+- Authentication fixes the principal, allowed operations, and path or capability access for the lifetime of a connection.
+- Client Capability offers and reverse calls remain authenticated, size-limited, and tied to that connection.
 - Adding a protocol operation does not expand an existing credential grant.
 - Status and diagnostics expose only bounded, redacted lifecycle and composition facts.
 
@@ -191,25 +274,14 @@ Runtime Host does not claim exactly-once behavior for arbitrary external side ef
 
 - [`host-kernel.ts`](../../packages/runtime-host/src/server/host-kernel.ts): process ownership, listeners, connection lifecycle, drain, and shutdown
 - [`host-composition.ts`](../../packages/runtime-host/src/server/host-composition.ts): composition identity, Module contract, recovery, and close order
+- [`execution-composition.ts`](../../packages/runtime-host/src/server/execution-composition.ts): static coordinator and Module assembly
 - [`hosted-execution-authority.ts`](../../packages/runtime-host/src/server/hosted-execution-authority.ts): root execution contract
+- [`session-continuity-coordinator.ts`](../../packages/runtime-host/src/server/session-continuity-coordinator.ts): canonical Client observation and live stream continuity
+- [`client-capability-coordinator.ts`](../../packages/runtime-host/src/server/client-capability-coordinator.ts): capability publication, binding, and reverse-call lifecycle
 - [`workspace-resolver.ts`](../../packages/runtime-host/src/server/workspace-resolver.ts): Project and Host-path workspace resolution
 - [`run-composition.ts`](../../packages/core/src/run-composition.ts): durable Run Composition schema
 - [`state-root-composition.ts`](../../packages/storage/src/state-root-composition.ts): persistent Composition binding
 
-## Validation contract
-
-Changes to these boundaries should preserve tests for:
-
-- State Root ownership and Composition binding;
-- Local IPC and WebSocket state sharing, authentication, and listener rollback;
-- unique handler ownership, phased recovery, reverse close, and aggregate failure;
-- Hosted Execution admission, stop, settlement, and restart recovery;
-- immutable Run Composition commit and pre-dispatch fail-closed behavior;
-- Client disconnect, drain, and crash recovery end to end.
-- Project-based workspace use without Host-path authority, and rejection of unauthorized Host paths.
-
-Repository-wide format, lint, typecheck, and test gates remain required for changes that cross these boundaries.
-
 ## Summary
 
-Runtime Host keeps one ownership story: the Kernel owns the process, Composition owns assembly, Modules own business lifecycle, Hosted Execution owns execution lifecycle, and Run Composer owns the provider-dispatch basis. Durable Stores connect those lifetimes across process restart.
+Runtime Host keeps one ownership path. The Kernel controls the process. Composition builds a fixed set of Modules. Modules own business behavior, while Hosted Execution controls top-level work. Run Composer records what the model sees, Session Continuity rebuilds what Clients see, and Client Capability allows limited callbacks into a Client. Durable Stores let all of them recover after a process restart without creating a second Runtime owner.

--- a/docs/architecture/runtime-host-architecture.zh-CN.md
+++ b/docs/architecture/runtime-host-architecture.zh-CN.md
@@ -1,80 +1,128 @@
 ---
 doc_id: architecture.runtime-host
-title: "Runtime Host：Runtime 执行的唯一在线宿主"
+title: "Runtime Host 架构"
 language: zh-CN
 source_language: zh-CN
 counterpart: ./runtime-host-architecture.md
 implementation_status: current
 document_status: current
 translation_status: synced
-last_verified: 2026-08-10
+last_verified: 2026-08-11
 owners:
   - maka-backend
 ---
 
-# Runtime Host：Runtime 执行的唯一在线宿主
+# Runtime Host 架构
 
-> Runtime Host 是一个 State Root 及其 Runtime execution 的唯一在线 owner。Client 只提交有界操作；Host 持有 durable state、execution admission、recovery 和 shutdown。Client disconnect 不会把这些所有权转回 Client。
+> Runtime Host 是一个长期运行的进程，负责一个 State Root 以及使用该 State Root 的 Runtime work。Desktop、TUI、CLI、bot 和 Eval 都是 Client；它们请求 Host 执行工作，不拥有第二套 Runtime。
 
-本文面向维护 Runtime Host 或接入产品领域的工程师。它只解释稳定的所有权和 lifecycle contract，不重复每个 operation schema 或 coordinator 的实现细节。
+本文解释维护 Runtime Host 或接入产品功能时需要理解的稳定边界，不重复每个 protocol schema 或 coordinator 的实现细节。
+
+本文所说的 **owner** 或 **authority**，是指 Host 在线时唯一有权改变某类状态的组件，不一定是发起操作的 Client 或用户。
 
 ## 为什么需要 Runtime Host
 
-Runtime execution 的生命周期长于一次连接。模型调用可能在 Desktop window reload 后继续，authenticated remote Client 可能断开，进程也可能在 durable work 尚未结束时重启。
+Runtime work 的生命周期长于一次连接。模型调用可能在 Desktop window reload 后继续，authenticated remote Client 可能断开，进程也可能在 durable work 尚未结束时重启。State Root 是保存这些持久状态的目录。
 
 如果每个 Client 都拥有自己的 Runtime 与恢复路径，系统会出现多个 writer、冲突的 Session state，以及依赖连接存活的 execution。Runtime Host 消除这些歧义：
 
 - 一个进程拥有一个 State Root 的写权限；
-- Local IPC 与 authenticated WebSocket 使用同一份 canonical state；
-- Domain code 拥有业务决策；
-- 一个 execution authority 拥有 admission、stop、settlement 与 recovery。
+- Local IPC 与 authenticated WebSocket 使用同一份持久状态；
+- 业务代码决定一项工作的含义；
+- 一个 execution authority 负责顶层 Session work 的 admission 与 stop，跟踪最终结果，并等待 cleanup 结束。
 
-## 心智模型
+## 用普通语言理解各组件
+
+| 组件 | 直观含义 |
+|---|---|
+| Host Kernel | 进程入口：拥有 State Root 的排他 lease 与 connections，停止接收新工作，并负责关闭进程 |
+| Host Composition | 固定的启动方案：创建 Stores、共享 authorities 与 Module 列表 |
+| Domain Module | 一条静态记录，把一组 protocol operations 与 startup/shutdown 职责分配给一个 owner |
+| Hosted Execution | Session 顶层工作的调度入口：接收一个确切 execution，负责停止或恢复它，并区分最终结果与 cleanup 完成 |
+| Run Composer | 在 provider call 前记录不会再变化的 prompt 与 tool 基线 |
+| Session Continuity | 向 Client 提供 canonical Session snapshot 与带大小限制的 live updates |
+| Client Capability | 允许 Host 调用已连接 Client 发布的能力，但不转移 Runtime ownership |
+
+Durable Stores 是 recovery 的事实来源。下文所说的 **canonical state**，是指从这些 Stores 重建的状态；**projection** 则是从该状态派生、便于读取的视图。
+
+**Bounded** 表示 protocol 对 schema、大小、数量或时间设有明确限制，而不是接受任意 work 或 payload。
+
+下面几个 execution 名称也表示不同范围：
+
+| 名称 | 范围 |
+|---|---|
+| Session | 持久存在的对话与 workspace context |
+| Turn | Session 中一项被记录的顶层工作，可以由用户或 Host 发起 |
+| Run | 为一次 Turn 执行 model 与 tool work 的持久实体 |
+| Root execution | 一个 Session 当前唯一被 admit 的顶层 execution |
+
+## 一次 Turn 如何穿过系统
 
 ```mermaid
-flowchart LR
-    Client[Client] --> Kernel[Host Kernel]
-    Kernel --> Composition[Host Composition]
-    Composition --> Domain[Domain Module]
-    Domain --> Execution[Hosted Execution Authority]
-    Execution --> Runtime[Maka Runtime]
-    Domain --> Composer[Run Composer]
-    Composer --> Runtime
-    Composition --> Store[Durable Stores]
+sequenceDiagram
+    participant Client
+    participant Kernel as Host Kernel
+    participant Domain as Domain Module
+    participant Execution as Hosted Execution
+    participant Runtime as Maka Runtime
+    participant Store as Durable Stores
+    participant Continuity as Session Continuity
+    participant Capability as Client Capability
+
+    Client->>Kernel: 提交一条消息
+    Kernel->>Domain: 路由已认证的 operation
+    Domain->>Execution: 为 root execution 完成 reservation 与 admission
+    Execution->>Runtime: 启动这一 execution
+    loop Model 与 tool work
+        Runtime->>Store: 写入 durable facts
+        Runtime-->>Continuity: 发布带大小限制的 live event
+        Continuity-->>Client: 发送下一个 sequenced update
+        opt 所选 tool 需要 Client environment
+            Runtime->>Capability: 调用已冻结的 capability binding
+            Capability->>Client: 发起有界 reverse call
+        end
+    end
+    Store-->>Continuity: 重建 canonical state
+    Continuity-->>Client: 返回新的 snapshot
 ```
 
-| 组件 | 拥有的责任 |
-|---|---|
-| Host Kernel | State Root ownership、transport、connection authority、residency、drain 与 shutdown |
-| Host Composition | 静态 composition identity、Store 创建、Domain Modules 与共享 authorities |
-| Domain Module | 一个领域的 handlers、recovery、drain、close 与 connection cleanup |
-| Hosted Execution Authority | Root admission、execution identity、stop、terminal reconciliation 与 recovery |
-| Run Composer | 一次 Run 的 immutable prompt、tool、policy 与 source-revision 基线 |
+请求到来前，Host Composition 已经创建这些组件，并把每个业务操作分配给一个 Domain Module。进程状态、diagnostics、upgrade 与 access credential 操作仍由 Kernel 拥有。Composition 是启动方案，不是每次请求都要调用的一层 service。
 
-## 四种不能混合的 identity
+以用户消息为例：Kernel 负责认证和路由，但不解释消息；拥有该操作的 Domain 应用 message 与 Session 规则，并在 root work 可以开始时使用 Hosted Execution。第一次 provider request 之前，Run Composer 会冻结并持久化 prompt 与 tool 基线。Runtime 写入 canonical facts，Session Continuity 再把这些事实投影给所有 Client。
 
-| Identity | 含义 | 生命周期 |
+Scheduled Task 使用同一条 execution path，只是它从自己的 Domain 内部启动，而不是由已连接的 Client 发起。这也是 Client disconnect 不会决定 execution lifetime 的原因。
+
+## Host 的几种身份
+
+这些值回答不同的问题，不能相互替代：
+
+| Identity | 直观含义 | 生命周期 |
 |---|---|---|
-| State Root | Host durable state 的 canonical 目录 | 跨 Host 进程存在 |
-| Host Epoch | 一次取得 root owner 的进程实例 | 随该进程结束 |
-| Composition ID | 允许使用该 State Root 的静态 Host composition | 持久绑定到 root |
-| Host Generation | 本地 ephemeral Client 请求的 Runtime Host build | Product build，或一个 development Client process |
+| State Root | 保存 Host 持久状态的目录；同一时刻只有一个进程持有其排他写 lease | 跨 Host 进程存在 |
+| Host Epoch | 当前持有该 lease 的进程 identity | 随该进程结束 |
+| Composition ID | 允许解释该 State Root 的 Host program 类型 | 持久绑定到 root |
+| Composition Revision | Client 期望连接的 Composition revision | startup wiring 或 compatibility 改变时更新 |
+| Host Generation | 由本地 owner Client 请求的 replacement generation | 一个 product version 共用，或仅属于一个 development Client process |
 
-重启会创建新的 Host Epoch；软件更新也可能改变 Host Generation。两者都不会改变 State Root 或 Composition ID。
+重启会改变 Host Epoch；Composition 变化可能改变其 Revision；product version 更新或 development Client 重启可能改变 Host Generation。这些变化都不会隐式移动 State Root，也不会改变持久绑定的 Composition ID。
 
-## 所有权边界
+例如，绑定到 interactive Composition 的 State Root 不能被另一种 Composition 打开；interactive Composition 自身可以演进到新 revision，而不改变这项持久 identity。
+
+## 各组件分别负责什么
 
 ### Host Kernel 拥有进程生命周期
 
-Kernel 取得 State Root writer owner，启动 required listeners，认证连接，创建 immutable connection authority，并驱动 Composition recovery、drain 与 close。
+Kernel 取得 State Root 的排他写 lease，启动 listeners，并认证连接。认证会为该 connection 生成一组不可变的 permissions。Kernel 还会跟踪 active operations 与 **residencies**——让进程必须继续存活的明确原因——并驱动 Composition recovery、drain 与 close。
 
-Kernel 不解释 message、prompt、tool、Goal state、Automation state 或 Agent Graph state。新增领域行为通过 Domain Module 接入，而不是给 Kernel 状态机增加分支。
+Kernel 不解释 message、tool、Goal 或 Scheduled Task 等业务状态。新增业务行为通过 Domain Module 接入，而不是给 Kernel 状态机增加分支。
 
-### Host Composition 拥有静态装配
+### Host Composition 是固定的启动方案
 
-Composition 在启动前固定。Descriptor 只包含稳定 ID 与 revision；实际 Module IDs 来自已创建的 Composition，因此 diagnostics 不会与真实 ownership 漂移。
+Composition ID、revision 与 construction function 在 listener 启动前选定。Modules 在启动期间只创建一次，并在 Host Ready 后保持不变。Diagnostics 直接读取已创建 Composition 的实际 Module IDs，不维护第二份列表。
 
-每个 protocol operation 只有一个 Module owner。Composition 组合这些 owner，不保留平行的 handler 或 lifecycle 实现。
+每个业务操作只有一个 Module owner。Composition 组合这些 owner，不保留平行的 handler 或 lifecycle 实现。Kernel operations 不属于 Domain Module。
+
+例如，interactive Composition 会创建 Session、Scheduled Task 等 Modules，以及它们使用的 Stores 与共享 execution authority。这个列表在 Host process 内只选择一次。Composition 不是 dynamic plugin registry，也不是每个 Session 各自拥有的配置。
 
 Recovery 使用五个固定 phase：
 
@@ -84,37 +132,66 @@ Recovery 使用五个固定 phase：
 4. `domains`
 5. `schedulers`
 
+这个顺序保证 durable state 与 resources 先就绪，随后恢复 executions 与 business domains，最后才启动 schedulers。
+
 Close 按 Module 反序执行。Drain 与 close 会尝试每个 owner，并聚合失败。
 
-### Domain Module 拥有业务生命周期
+### Domain Module 负责一组操作及其生命周期
 
-Domain Module 通过明确的 constructor ports 获取依赖，并拥有自己的 handlers 与 resources。它可以使用共享 Host contract，但不会通过动态 registry 查找 service，也不会创建第二个 Runtime authority。
+Domain Module 是一条静态记录，用于回答四个问题：
+
+- 这一组职责处理哪些 protocol operations；
+- 每个 startup phase 需要恢复什么；
+- drain 时必须拒绝哪些新工作；
+- close 时需要释放哪些 resources 与 connection-scoped state。
+
+例如，Scheduled Task Module 拥有 Scheduled Task operations，恢复 durable scheduling state，只在 recovery 完成后启动 scheduler，并在 shutdown 时停止和关闭 scheduler。Task 触发后，Module 仍然请求共享的 Hosted Execution authority 执行它，不会创建另一套 Runtime。
+
+Module 不一定对应独立 process、package 或源码目录。它可以表示一个聚焦功能，也可以表示生命周期紧密相关的一组职责。Construction code 直接传入依赖；Module 不会在 runtime 按名称查找依赖。
 
 Domain 决定 execution result 的业务含义和下一步动作。Hosted Execution 只拥有 execution lifecycle。
 
-### Hosted Execution 拥有 root execution 生命周期
+### Hosted Execution 控制 Session 的顶层工作
 
-Hosted Execution 是 root execution 的唯一在线 authority。Admission 原子返回该 execution 的初始 snapshot、completion handle 与 cleanup settlement handle。
+**Admission** 是为一个确切 root execution 原子保留 Session 的决策，用来防止两个顶层 Turn 并发运行。
 
-Consumer 使用 durable terminal projection 判断业务结果，使用 settlement handle 判断 execution cleanup 是否完成。它们不能在 admission 后再用 Session ID 或 Turn ID 重新拼装这些引用。
+Admission 成功后返回三个相关值：
 
-Subscription 只是唤醒提示。Recovery 始终重新读取 durable facts。
+- `snapshot`：execution 被 admit 时观察到的状态；
+- `completion`：状态为 completed、failed 或 cancelled 的 terminal snapshot，或者明确的 `authority_error`；
+- `settled`：execution cleanup 已结束、临时 resources 已释放的信号。
 
-### Run Composer 拥有 provider dispatch 基线
+Domain 使用 `completion` 判断业务结果，使用 `settled` 判断 cleanup 是否结束。它保留这次确切 execution 返回的 handles，而不是事后通过 Session ID 或 Turn ID 重新拼装。
 
-Run Composer 冻结一次 Run 的 model-visible 基线：base system prompt、tool catalog、tool availability policy、base provider options 与 source revisions。
+Hosted Execution subscription 只告诉同一 Host Epoch 内的 observer“可能发生了变化”，不能证明新状态是什么。Recovery 始终重新读取 durable facts。
 
-首次 physical provider dispatch 前必须：
+### Session Continuity 负责 Client 如何观察 Session
+
+Session Continuity 是 live Session 面向 Client 的公开 read model。打开 subscription 会返回 canonical snapshot、下一个预期 sequence number，以及仍处于 active 状态的 assistant stream identities。可能更大的 transcript 通过单独、带大小限制的 snapshot 读取。
+
+Live projection、assistant 与 tool updates 都有明确的大小限制和 sequence number。发生 connection loss、Host Epoch 变化、sequence gap 或 transcript snapshot 过期后，Client 应重新打开 subscription，并重读 canonical state。例如，Desktop 在模型输出期间 reload 时，会恢复当前 transcript 与 active stream identities，而不是重新发送用户消息。Stream delivery 永远不是 recovery authority。
+
+### Run Composer 冻结模型实际看到的内容
+
+Run Composer 冻结一次 Run 的 model-visible 基线：base system prompt、tool catalog、tool availability policy、base provider options，以及构建这些内容时使用的 input revisions。
+
+第一次真实 provider request 前必须：
 
 1. 创建 immutable Run Composition snapshot；
 2. 将其提交到 AgentRun Store；
-3. durable commit 成功后才能 dispatch。
+3. durable commit 成功后才能调用 provider。
 
-Composition 或 commit 失败时必须 fail closed。没有发生 dispatch 的 Run 不伪造 composition snapshot。
+Composition 或 persistence 失败时不调用 provider。没有到达 provider dispatch 的 Run 不伪造 composition snapshot。
+
+### Client Capability 让 Host 安全调用 Client 能力
+
+Authenticated Client 可以发布带大小限制、带版本的 tool 或 service **offers**，描述自己能够做什么。Runtime Host 选择确切的 provider **binding**；Run 仍通过正常的 Run Composition 路径记录所选 model tools。对于必须在 Client 环境执行的 effect，Host 可以发起有界 reverse call，例如调用 Desktop 发布的 OS-facing capability。
+
+发布或调用 capability 不会把 Session、Run 或 execution ownership 转移给 Client。Connection loss 会使对应 provider unavailable；拥有该操作的 Domain 仍通过自己的 durable contract 处理 capability loss 或明确的 result-unknown outcome。
 
 ### Runtime Host 解析 workspace
 
-Client 只使用一种 closed target 表达 workspace：
+Client 必须使用下面两种 target form 中的一个来表达 workspace：
 
 ```ts
 type WorkspaceTarget =
@@ -122,68 +199,74 @@ type WorkspaceTarget =
   | { kind: "host_path"; path: string };
 ```
 
-`project` 是可跨机器传递的形式。Runtime Host 通过自己的 Project Catalog 解析它，并返回包含 canonical target 与 `hostCwd` 的 projection。`host_path` 只供拥有明确 Host-path authority 的 Client 使用，例如从本地 checkout 启动的 CLI。
+`project` 是可跨机器传递的形式。Runtime Host 通过自己的 Project Catalog 解析它，并返回 canonical target 与 `hostCwd`；`hostCwd` 是 Host 上的绝对目录。`host_path` 只供被明确允许指定 Host path 的 Client 使用，例如从本地 checkout 启动的 CLI。
 
-Project Catalog 提供 revision-pinned、paginated 的 summary 与 location view。Summary 不包含 path；读取 location 必须拥有 Host-path authority。
+Project summary 不暴露 path。只有被允许读取 Host path 的 connection 才能读取或修改 project location、在 Host 上 reveal path，或提交 `host_path`。
 
-Client 不把 path 与 Project ID 拼在一起，也不自行解析 Host path。Desktop 将所选 Project 保存为按 root 隔离的 Client preference；选择 Project 不修改 Host 全局状态。没有 Host-path authority 的 Client 可以使用已注册 Project，但不能注册、relink、请求 Host 侧 reveal 或提交 Host path。
-
-Skill Catalog 管理属于 Host 文件系统操作。它要求 Host-path authority，并返回该操作实际解析出的 workspace。
+Client 不把 path 与 Project ID 拼在一起，也不自行解析 Host path。Desktop 会按 State Root 在本地记住所选 Project；选择它不会修改 Host 全局状态。
 
 ## 生命周期
 
+两种 Host lifetime 使用同一个 Kernel 与 Composition：
+
+| Host 类型 | 由谁管理生命周期 |
+|---|---|
+| Ephemeral Host | 由本地 Client 启动；没有 connection、operation 或 residency 要求其继续存活时可以退出 |
+| Service Host | 由 deployment owner 运行；Client generation 不能替换它，也不使用 Client 驱动的 idle exit |
+
 | 阶段 | Contract |
 |---|---|
-| Startup | 取得 root owner，绑定 Composition identity，创建 Composition，恢复 Modules，启动 schedulers，最后发布 Ready |
-| Request | Authentication、bounded decode、connection authority 检查，再路由到唯一 Module handler |
-| Execution | 通过 Hosted Execution reservation 与 admission，从 durable facts reconcile terminal state |
-| Drain | 拒绝新 admission，同时让已接收工作收敛 |
-| Close | 反序关闭 Modules，关闭 listeners，最后释放 State Root owner |
+| Startup | 取得 State Root lease，绑定 Composition identity，创建 Composition，恢复 Modules，启动 schedulers，最后发布 Ready |
+| Request | Authentication、input limits 与 connection permissions 检查，再路由到 Kernel 或唯一的 Domain Module handler |
+| Execution | 通过 Hosted Execution reservation 与 admission，再重读 durable facts 确认最终状态 |
+| Drain | 停止接收新工作，同时让已接收工作结束或到达可恢复状态 |
+| Close | 停止 listeners 接收连接，drain operations，反序关闭 Modules，清理 listeners，最后释放 State Root lease |
 
 Client disconnect 只释放 connection-scoped resources，不取消已经 admission 的 execution。
 
-### 本地 ephemeral upgrade handoff
+### 本地 Ephemeral Host 的升级交接
 
-Host Generation 与 protocol compatibility 是两个事实：两个 build 即使使用相同 protocol，也可能必须替换进程，才能让新版 Runtime code 成为 authority。本地 owner Client 可以针对精确 Host Epoch 请求 drain。Kernel 继续使用正常 drain 路径，successor 则等待现有 owner lock 释放。
+Host Generation 与 protocol compatibility 是两个事实：两个本地 Client generation 即使使用相同 protocol，也可能请求替换进程，让所请求的 Runtime generation 成为 authority。本地 owner Client 请求 drain 时必须带上自己观察到的 Host Epoch，因此过期 Client 无法 drain 后来启动的替代进程。下一个 Host 会等待现有 State Root lease 释放。
 
-Startup 发现另一个 generation 时，Host 可以返回 connection、operation 与 residency category 的 bounded activity count。这些事实用于解释进程为什么仍在驻留，并不授予 termination authority。只有本地 ephemeral Host 支持 takeover。Service Host 会明确发布自己的 lifecycle，并可被不同 Client generation 连接；升级由 deployment owner 协调。
+Startup 发现另一个 generation 时，Host 可以返回数量受限的 active connections、operations 与 residencies。这些数量用于解释进程为什么仍然存活，不允许 Client 直接杀死它。只有本地 ephemeral Host 支持 replacement，中断 active work 必须经过 Client 的明确选择；Service Host 的升级仍由 deployment owner 负责。等待中的 Client 会停止连接尝试，直到所观察的 Host 退出，因此等待本身不会让原本应 idle exit 的 Host 继续驻留。
 
-选择等待后，Client 会停止连接尝试，直到所观察的 Host 进程退出。因此，等待本身不会让本应进入 idle exit 的 Host 继续驻留。
-
-对于 ephemeral Host，更新准备会把用户是否允许中断的选择传给 Host。Kernel 在同一个决策点检查现有工作并关闭 admission，然后进入正常 drain。对于 service Host，Desktop 只暂停自己的 reconnect，不会 drain 由部署系统拥有的 Host。安装被拒绝时，Desktop 恢复 reconnect。
-
-## 核心不变量
+## 必须始终成立的规则
 
 1. 一个 State Root 最多有一个 writer owner。
 2. 一个 Session 最多有一个 root Hosted Execution 或 pending root admission。
-3. Local IPC 与 WebSocket 共享一个 dispatcher、authority model 与 canonical state。
-4. Transport 拥有 framing 与 authentication，不拥有 Domain state。
-5. Composition 在启动前固定。
-6. 一个 protocol operation 只有一个 Module owner。
-7. Notification 只是提示；Store 才是 recovery authority。
+3. Local IPC 与 WebSocket 共享一个 routing table、permission model 与 canonical state。
+4. Transport 只负责 message framing 与 authentication，不拥有业务状态。
+5. Composition identity 在 listener 启动前固定，Module set 在 Ready 前固定。
+6. 一个业务操作只有一个 Module owner；进程与 access operations 仍由 Kernel 拥有。
+7. Notification 与 stream 不能替代 Store 成为 recovery authority。
 8. Provider dispatch 等待 Run Composition durable commit。
 9. Domain lifecycle 与 execution lifecycle 保持分离。
 10. 一个 owner 关闭失败时，shutdown 仍继续关闭其余 owner。
 11. 只有 Runtime Host 能把 `WorkspaceTarget` 解析为 canonical Host path。
+12. Client-local capability execution 不会把 Runtime ownership 转移出 Host。
+13. Stream 中断后，Client 从 canonical snapshot 重建 observation。
 
 ## 失败如何收敛
 
 | 失败 | 必须遵守的行为 |
 |---|---|
-| Composition mismatch | 在 listener 或 Domain Store mutation 前失败，不能进入 Candidate spawn loop |
-| Host crash | Successor 重新读取 Store，幂等 reconcile execution 与 Domain state |
+| Composition mismatch | 在 listener 或 Domain Store mutation 前失败；报告终态 incompatibility，不重复启动 Candidate |
+| Host crash | 下一个 Host 重读 Stores，并安全地重复 recovery，直到 execution 与 Domain state 收敛 |
 | Notification 丢失 | 重读 canonical projection，不能从 callback delivery 推断 terminal state |
+| Session stream 丢失 | 重新打开 subscription，并重读 snapshot 与 transcript |
 | Run Composition 失败 | 不调用 provider |
 | Client disconnect | 已 admission 的工作继续由 Host 持有 |
+| Client Capability 丢失 | 暴露有界的 capability-loss 或 outcome-unknown state，不静默重试结果不确定的 effect |
 | Partial shutdown failure | 聚合错误，同时继续释放其余 resources |
 
-Runtime Host 不承诺任意 external side effect 的 exactly-once。具体 Tool 或 resource owner 必须报告 observed outcome、unknown outcome 或明确的 recovery result。
+Runtime Host 不保证任意 external side effect 恰好发生一次。如果 connection 在 dispatch 后丢失，Host 可能只能确认 outcome unknown。Tool 或 resource contract 必须保留这种不确定性；除非 operation 明确允许，否则不能自动重试。
 
 ## 协议与安全边界
 
-- Protocol message 使用 closed schema、bounded input/output 与 typed errors。
+- Protocol message 使用拒绝未知字段的 closed schema、明确的大小与数量限制，以及稳定的 error code。
 - Authentication 在 protocol connection admission 前完成。
-- Connection authority 固定 principal、operation grants 与 path/capability access。
+- Authentication 会在 connection 的整个生命周期内固定 principal、允许的 operations，以及 path 或 capability access。
+- Client Capability offers 与 reverse calls 必须经过认证、带大小限制，并绑定到该 connection。
 - 新增 protocol operation 不会扩张既有 credential grant。
 - Status 与 diagnostics 只公开 bounded、redacted 的 lifecycle 与 composition facts。
 
@@ -191,25 +274,14 @@ Runtime Host 不承诺任意 external side effect 的 exactly-once。具体 Tool
 
 - [`host-kernel.ts`](../../packages/runtime-host/src/server/host-kernel.ts)：process ownership、listeners、connection lifecycle、drain 与 shutdown
 - [`host-composition.ts`](../../packages/runtime-host/src/server/host-composition.ts)：composition identity、Module contract、recovery 与 close order
+- [`execution-composition.ts`](../../packages/runtime-host/src/server/execution-composition.ts)：静态 coordinator 与 Module assembly
 - [`hosted-execution-authority.ts`](../../packages/runtime-host/src/server/hosted-execution-authority.ts)：root execution contract
+- [`session-continuity-coordinator.ts`](../../packages/runtime-host/src/server/session-continuity-coordinator.ts)：canonical Client observation 与 live stream continuity
+- [`client-capability-coordinator.ts`](../../packages/runtime-host/src/server/client-capability-coordinator.ts)：capability publication、binding 与 reverse-call lifecycle
 - [`workspace-resolver.ts`](../../packages/runtime-host/src/server/workspace-resolver.ts)：Project 与 Host-path workspace resolution
 - [`run-composition.ts`](../../packages/core/src/run-composition.ts)：durable Run Composition schema
 - [`state-root-composition.ts`](../../packages/storage/src/state-root-composition.ts)：persistent Composition binding
 
-## 验证契约
-
-修改这些边界时，应保留以下测试：
-
-- State Root ownership 与 Composition binding；
-- Local IPC/WebSocket state sharing、authentication 与 listener rollback；
-- unique handler ownership、phased recovery、reverse close 与 aggregate failure；
-- Hosted Execution admission、stop、settlement 与 restart recovery；
-- immutable Run Composition commit 与 pre-dispatch fail-closed；
-- Client disconnect、drain 与 crash recovery 的端到端行为。
-- 无 Host-path authority 时使用 Project workspace，并拒绝未授权 Host path。
-
-跨越这些边界的改动仍须通过全仓 format、lint、typecheck 与 tests。
-
 ## 小结
 
-Runtime Host 只保留一套 ownership：Kernel 拥有 process，Composition 拥有 assembly，Modules 拥有 business lifecycle，Hosted Execution 拥有 execution lifecycle，Run Composer 拥有 provider-dispatch basis。Durable Stores 让这些生命周期在进程重启后继续收敛。
+Runtime Host 只保留一条 ownership path：Kernel 控制 process；Composition 创建一组固定 Modules；Modules 拥有业务行为，Hosted Execution 控制顶层工作；Run Composer 记录模型看到的内容，Session Continuity 重建 Client 看到的内容，Client Capability 则允许 Host 对 Client 发起受限回调。Durable Stores 让这些组件在进程重启后恢复，而不产生第二个 Runtime owner。


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- restructure the Runtime Host guide around plain-language component definitions and one end-to-end Turn
- explain Host Composition and Domain Module with concrete responsibilities, examples, and non-examples
- document Client Capability and Session Continuity as stable Host boundaries
- clarify Host identities, process lifetimes, upgrade handoff, and failure behavior
- keep the English and Chinese guides aligned while removing lower-value implementation detail

## Why

The previous guide described the core contracts but assumed too much implementation context. Important terms appeared before readers could connect them to a real request, and the Domain Module description overstated the isolation present in the current composition. This revision makes the ownership model concrete without turning the architecture guide into an implementation manual.

## Impact

Documentation only. No runtime or protocol behavior changes.

## Validation

- parsed both Mermaid diagrams with the repository's Mermaid version
- verified all local documentation links
- verified matching English and Chinese section structure
- `git diff --check`

</details>

<details>
<summary>中文</summary>

## 摘要

- 以普通语言的组件定义和一条端到端 Turn 为主线重组 Runtime Host 文档
- 通过具体职责、例子和反例解释 Host Composition 与 Domain Module
- 将 Client Capability 与 Session Continuity 补充为稳定的 Host 边界
- 讲清 Host identities、进程生命周期、升级交接与 failure behavior
- 同步维护中英文版本，并删除价值较低的实现细节

## 原因

原文对核心 contract 的描述基本正确，但假设读者已经了解太多实现背景。重要术语在读者能够把它们对应到真实请求之前就出现了，Domain Module 的描述也高估了当前 composition 的隔离程度。本次修订让 ownership model 更具体，同时避免把架构文档写成实现手册。

## 影响

仅修改文档，不改变 Runtime 或协议行为。

## 验证

- 使用仓库当前 Mermaid 版本解析中英文流程图
- 验证所有本地文档链接
- 验证中英文文档章节结构一致
- `git diff --check`

</details>
