### PR TITLE
feat(runtime): support explicit Git Bash selection on Windows

### DIFF
--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -158,12 +158,12 @@ jobs:
         timeout-minutes: 5
         shell: pwsh
         run: |
-          node.exe --test --test-force-exit --test-timeout=15000 --test-reporter=tap --test-concurrency=1 --test-name-pattern="semantic text and Enter actions|terminal mode parsed before the control cut" packages/runtime/dist/__tests__/shell-run-manager.test.js 2>&1 |
+          node.exe --test --test-force-exit --test-timeout=15000 --test-reporter=tap --test-concurrency=1 --test-name-pattern="semantic text and Enter actions|terminal mode parsed before the control cut|preserves the requested cwd through a real Git Bash login PTY" packages/runtime/dist/__tests__/shell-run-manager.test.js 2>&1 |
             Tee-Object -FilePath "$env:WINDOWS_BASELINE_LOG_DIR/runtime-pty-input.log"
           $exitCode = $LASTEXITCODE
           $output = Get-Content "$env:WINDOWS_BASELINE_LOG_DIR/runtime-pty-input.log"
-          if ($exitCode -eq 0 -and ($output -notcontains '# tests 2' -or $output -notcontains '# pass 2')) {
-            Write-Error 'Runtime PTY input gate did not run exactly two passing tests'
+          if ($exitCode -eq 0 -and ($output -notcontains '# tests 3' -or $output -notcontains '# pass 3')) {
+            Write-Error 'Runtime PTY input gate did not run exactly three passing tests'
             exit 1
           }
           exit $exitCode

--- a/apps/desktop/src/main/runtime-host-settings-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-settings-ipc-main.ts
@@ -180,6 +180,7 @@ export async function loadRuntimeHostSettings(
     workspaceInstructions: policy.workspaceInstructions,
     privacy: policy.privacy,
     chatDefaults: policy.chatDefaults,
+    shell: policy.shell,
     webSearch: {
       ...local.webSearch,
       ...policy.webSearch,
@@ -273,6 +274,9 @@ async function applyHostPatch(
       "set_chat_defaults",
     );
   }
+  if (patch.shell) {
+    await mergePolicy(client, "shell", patch.shell, "set_shell");
+  }
   if (patch.webSearch) {
     const webSearch = patch.webSearch;
     await client.updateRuntimePolicy((policy) => ({
@@ -303,7 +307,7 @@ async function applyHostPatch(
 }
 
 async function mergePolicy<
-  K extends "memory" | "workspaceInstructions" | "privacy" | "chatDefaults",
+  K extends "memory" | "workspaceInstructions" | "privacy" | "chatDefaults" | "shell",
 >(
   client: RuntimeHostSettingsClient,
   key: K,
@@ -312,7 +316,8 @@ async function mergePolicy<
     | "set_memory"
     | "set_workspace_instructions"
     | "set_privacy"
-    | "set_chat_defaults",
+    | "set_chat_defaults"
+    | "set_shell",
 ): Promise<void> {
   await client.updateRuntimePolicy(
     ((policy) => ({

--- a/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
@@ -33,6 +33,8 @@ export type SettingsPreferencesCopy = {
     privacyHelp: string;
     chatDefaults: string;
     chatDefaultsHelp: string;
+    shell: string;
+    shellHelp: string;
     network: string;
     networkHelp: string;
     theme: string;
@@ -116,6 +118,17 @@ export type SettingsPreferencesCopy = {
     followModelDefault: string;
     saveDefaultThinkingFailed: string;
     saveDefaultPermissionFailed: string;
+    shellPreference: string;
+    shellPreferenceHelp: string;
+    shellAuto: string;
+    shellGitBash: string;
+    shellExecutable: string;
+    shellExecutableHelp: string;
+    saveShell: string;
+    savingShell: string;
+    shellSaved: string;
+    saveShellFailed: string;
+    shellExecutableRejected: string;
     proxy: string;
     proxyHelp: string;
     enableProxy: string;
@@ -195,6 +208,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       identity: '身份', identityHelp: 'Maka 如何称呼你，以及界面语言和回答语气。',
       privacy: '隐私与通知', privacyHelp: '本地数据的读写范围，以及桌面通知时机。',
       chatDefaults: '任务默认', chatDefaultsHelp: '新任务的起始模型、权限模式与思考级别。',
+      shell: '命令行环境', shellHelp: '选择 Runtime Host 执行 Bash 工具和终端命令时使用的 shell。',
       network: '网络', networkHelp: 'AI 模型请求走的网络通道。',
       theme: '主题', themeHelp: '界面跟随系统，还是固定浅色或深色。',
       palette: '调色板', paletteHelp: '强调色与画布色调；切换会立即生效并保存在本地。',
@@ -221,6 +235,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
     general: {
       incognito: '隐身模式', incognitoHelp: '开启后暂停本地记忆读写、联网搜索和定时任务触发。', enableIncognito: '启用隐身模式', incognitoFailed: '隐身模式切换失败', notifications: '完成时发送系统通知', notificationsHelp: '窗口不在前台时，在回答完成或出错后发送桌面通知。', notificationsFailed: '通知设置切换失败', workspaceInstructions: '遵循项目指令', workspaceInstructionsHelp: '自动读取每个项目中已有的 AGENTS.md、CLAUDE.md 或 GEMINI.md；文件仍由各自项目管理。', workspaceInstructionsFailed: '项目指令设置切换失败', updateFailed: '设置未生效，请稍后重试。',
       defaultModel: '默认模型', defaultModelHelp: '新任务默认使用的模型。', notSet: '未设置', saveDefaultModelFailed: '保存默认模型失败', defaultPermission: '默认权限模式', defaultPermissionHelp: '新任务默认使用的权限模式；可在任务内随时切换。', saveDefaultPermissionFailed: '保存默认权限模式失败', defaultThinking: '默认思考级别', defaultThinkingHelp: '新任务的思考级别；当前模型不支持所选级别时用模型默认。', followModelDefault: '跟随模型默认', saveDefaultThinkingFailed: '保存默认思考级别失败',
+      shellPreference: 'Bash 工具 shell', shellPreferenceHelp: '自动模式保持 Windows 的 PowerShell 优先规则；Git Bash 是仅对当前 Runtime Host 生效的显式覆盖。', shellAuto: '自动（推荐）', shellGitBash: 'Git Bash', shellExecutable: 'Git Bash 可执行文件', shellExecutableHelp: '填写 Runtime Host 所在 Windows 机器上 bash.exe 的绝对路径。也支持该机器上的旧版 System32 WSL Bash；保存时会验证 GNU Bash。', saveShell: '保存 shell 设置', savingShell: '正在保存…', shellSaved: '已保存', saveShellFailed: '保存 shell 设置失败', shellExecutableRejected: '当前 Runtime Host 无法把该路径作为 GNU Bash 运行。请检查 Host 是否为 Windows、路径是否存在，并确认文件名为 bash.exe。',
       proxy: '代理服务器', proxyHelp: '为 AI 模型请求配置网络代理', enableProxy: '启用代理服务器', saveNetworkFailed: '保存网络设置失败', proxyProtocol: '代理协议', serverAddress: '服务器地址', port: '端口', proxyAuth: '代理认证', proxyAuthHelp: '需要用户名和密码时开启。', enableProxyAuth: '启用代理认证', username: '用户名', password: '密码', bypassList: '代理白名单', bypassHelp: '这些域名将绕过代理直连，多个用逗号分隔。', autoBypass: (count) => `已自动添加 ${count} 个域名。代理仅作用于 AI 模型请求。`, testing: '测试中…', testCurrent: '测试当前配置', proxyReachable: '代理可达', proxyTestFailed: '代理测试失败', proxyTestError: '代理测试出错',
     },
     about: {
@@ -249,6 +264,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       identity: 'Identity', identityHelp: 'How Maka addresses you, plus interface language and response tone.',
       privacy: 'Privacy and notifications', privacyHelp: 'What Maka may read and write locally, and when it notifies you.',
       chatDefaults: 'Task defaults', chatDefaultsHelp: 'The model, permission mode, and thinking level a new task starts on.',
+      shell: 'Command environment', shellHelp: 'Choose the shell the Runtime Host uses for Bash tools and terminal commands.',
       network: 'Network', networkHelp: 'The network path AI model requests take.',
       theme: 'Theme', themeHelp: 'Follow the system appearance, or stay on light or dark.',
       palette: 'Color palette', paletteHelp: 'Accent and canvas colors. Changes apply immediately and are saved locally.',
@@ -270,6 +286,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
     },
     general: {
       incognito: 'Incognito mode', incognitoHelp: 'Pause local memory, web search, and scheduled task triggers.', enableIncognito: 'Enable incognito mode', incognitoFailed: 'Could not change incognito mode', notifications: 'Send a system notification when finished', notificationsHelp: 'Notify when a response finishes or fails while the window is in the background.', notificationsFailed: 'Could not change notification settings', workspaceInstructions: 'Follow project instructions', workspaceInstructionsHelp: 'Automatically read existing AGENTS.md, CLAUDE.md, or GEMINI.md files in each project. Manage the files in their respective projects.', workspaceInstructionsFailed: 'Could not change project instruction settings', updateFailed: 'The setting was not applied. Try again later.', defaultModel: 'Default model', defaultModelHelp: 'Model used by new tasks.', notSet: 'Not set', saveDefaultModelFailed: 'Could not save the default model', defaultPermission: 'Default permission mode', defaultPermissionHelp: 'Initial permission mode for new tasks; it can be changed at any time.', saveDefaultPermissionFailed: 'Could not save the default permission mode', defaultThinking: 'Default thinking level', defaultThinkingHelp: 'Thinking level for new tasks; models that do not offer the chosen level use their own default.', followModelDefault: 'Follow model default', saveDefaultThinkingFailed: 'Could not save the default thinking level', proxy: 'Proxy server', proxyHelp: 'Configure a network proxy for AI model requests', enableProxy: 'Enable proxy server', saveNetworkFailed: 'Could not save network settings', proxyProtocol: 'Proxy protocol', serverAddress: 'Server address', port: 'Port', proxyAuth: 'Proxy authentication', proxyAuthHelp: 'Enable this when a username and password are required.', enableProxyAuth: 'Enable proxy authentication', username: 'Username', password: 'Password', bypassList: 'Proxy bypass list', bypassHelp: 'These domains connect directly. Separate multiple domains with commas.', autoBypass: (count) => `${count} ${count === 1 ? 'domain was' : 'domains were'} added automatically. The proxy applies to AI model requests only.`, testing: 'Testing…', testCurrent: 'Test current configuration', proxyReachable: 'Proxy is reachable', proxyTestFailed: 'Proxy test failed', proxyTestError: 'Could not test proxy',
+      shellPreference: 'Bash tool shell', shellPreferenceHelp: 'Automatic keeps the PowerShell-first Windows default. Git Bash is an explicit override for the current Runtime Host.', shellAuto: 'Automatic (recommended)', shellGitBash: 'Git Bash', shellExecutable: 'Git Bash executable', shellExecutableHelp: 'Enter the absolute path to bash.exe on the Windows machine running the Runtime Host. The legacy System32 WSL Bash shim is also recognized; Maka verifies GNU Bash before saving.', saveShell: 'Save shell setting', savingShell: 'Saving…', shellSaved: 'Saved', saveShellFailed: 'Could not save shell setting', shellExecutableRejected: 'The current Runtime Host could not run that path as GNU Bash. Check that the Host runs Windows, the path exists, and the file is named bash.exe.',
     },
     about: {
       loadFailed: 'Could not load About information', loading: 'Loading About', unavailable: 'About information is unavailable', copied: 'Environment info copied', pasteHint: 'Paste it directly into an issue report', copyFailed: 'Copy failed', clipboardUnavailable: 'The clipboard is unavailable or access was denied.', devBuild: 'Local development build', packagedBuild: 'Release build', subtitle: 'A local-first AI assistant · Desktop runtime', privacyLabel: 'Privacy and security', privacyTitle: 'Local first · Private by default', privacyPoints: ['Tasks, settings, credentials, and Skill instructions stay in the local workspace.', 'Model keys stay in a local credential file; subscription tokens use secure system storage.', 'Maka sends no usage telemetry and contacts a model provider only when you enable it.', 'High-risk tool operations require explicit permission in the task.', 'Messages, tool calls, permission decisions, and mode changes are retained locally for each task.'], copying: 'Copying…', copyEnvironment: 'Copy environment info', copyHelp: 'Copy version and platform details to help diagnose an issue. The workspace path is excluded.', keyboardShortcuts: 'Keyboard shortcuts', keyboardShortcutsHelp: 'Every shortcut Maka responds to.', keyboardShortcutsOpen: 'View', reportIssueLabel: 'Report an issue',

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { PersonalizationSettingsSection } from "./personalization-settings-section";
 import {
   SettingsActions,
@@ -10,6 +10,7 @@ import {
 import type {
   AppSettings,
   ChatDefaultPermissionMode,
+  ShellPreference,
   NetworkProxySettings,
   UpdateAppSettingsResult,
 } from '@maka/core/settings';
@@ -173,6 +174,7 @@ export function GeneralSettingsPage(props: {
             thinkingLevel={props.settings.chatDefaults.thinkingLevel}
             onUpdate={props.onUpdate}
           />
+          <ShellSettingsSection settings={props.settings} onUpdate={props.onUpdate} />
           <SettingsSection
             title={sections.network}
             description={sections.networkHelp}
@@ -186,6 +188,118 @@ export function GeneralSettingsPage(props: {
         </>
       ) : null}
     </SettingsPage>
+  );
+}
+
+const DEFAULT_GIT_BASH_EXECUTABLE = "C:\\Program Files\\Git\\bin\\bash.exe";
+
+function ShellSettingsSection(props: {
+  settings: AppSettings;
+  onUpdate(
+    patch: Parameters<typeof window.maka.settings.update>[0],
+  ): Promise<UpdateAppSettingsResult>;
+}) {
+  const locale = useUiLocale();
+  const copy = getSettingsPreferencesCopy(locale).general;
+  const sections = getSettingsPreferencesCopy(locale).sections;
+  const toast = useToast();
+  const mountedRef = useMountedRef();
+  const saveGuard = useActionGuard<"save-shell">();
+  const [preference, setPreference] = useState<ShellPreference>(
+    props.settings.shell.preference,
+  );
+  const [executable, setExecutable] = useState(props.settings.shell.executable);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setPreference(props.settings.shell.preference);
+    setExecutable(props.settings.shell.executable);
+  }, [props.settings.shell.executable, props.settings.shell.preference]);
+
+  const normalizedExecutable = executable.trim();
+  const dirty =
+    preference !== props.settings.shell.preference ||
+    normalizedExecutable !== props.settings.shell.executable;
+  const canSave =
+    dirty && !saving && (preference === "auto" || normalizedExecutable.length > 0);
+
+  async function save(): Promise<void> {
+    if (!saveGuard.begin("save-shell")) return;
+    setSaving(true);
+    try {
+      await props.onUpdate({
+        shell: { preference, executable: normalizedExecutable },
+      });
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(
+          copy.saveShellFailed,
+          isRejectedShellPreference(error)
+            ? copy.shellExecutableRejected
+            : settingsActionErrorMessage(error, locale),
+        );
+      }
+    } finally {
+      saveGuard.finish();
+      if (mountedRef.current) setSaving(false);
+    }
+  }
+
+  return (
+    <SettingsSection title={sections.shell} description={sections.shellHelp}>
+      <SettingsRow
+        label={copy.shellPreference}
+        description={copy.shellPreferenceHelp}
+        end={
+          <Selector
+            label={copy.shellPreference}
+            isLabelHidden
+            value={preference}
+            options={[
+              { value: "auto", label: copy.shellAuto },
+              { value: "git_bash", label: copy.shellGitBash },
+            ]}
+            isDisabled={saving}
+            onChange={(value) => {
+              const next = value as ShellPreference;
+              setPreference(next);
+              if (next === "git_bash" && executable.trim().length === 0) {
+                setExecutable(DEFAULT_GIT_BASH_EXECUTABLE);
+              }
+            }}
+          />
+        }
+      />
+      {preference === "git_bash" ? (
+        <SettingsField>
+          <TextInput
+            value={executable}
+            onChange={setExecutable}
+            label={copy.shellExecutable}
+            description={copy.shellExecutableHelp}
+            placeholder={DEFAULT_GIT_BASH_EXECUTABLE}
+            width="100%"
+            isDisabled={saving}
+          />
+        </SettingsField>
+      ) : null}
+      <SettingsActions>
+        <Button
+          variant="primary"
+          isDisabled={!canSave}
+          isLoading={saving}
+          onClick={() => void save()}
+          label={saving ? copy.savingShell : dirty ? copy.saveShell : copy.shellSaved}
+        />
+      </SettingsActions>
+    </SettingsSection>
+  );
+}
+
+function isRejectedShellPreference(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes("Runtime policy mutation is invalid for the current state")
   );
 }
 

--- a/apps/desktop/src/shared/settings-ownership.ts
+++ b/apps/desktop/src/shared/settings-ownership.ts
@@ -34,7 +34,8 @@ export function hasRuntimeHostSettingsPatch(
   patch: UpdateAppSettingsInput,
 ): boolean {
   return Boolean(
-    patch.network ||
+    patch.shell ||
+      patch.network ||
       patch.localMemory ||
       patch.workspaceInstructions ||
       patch.privacy ||

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -918,6 +918,24 @@ function useArchivedTasksStoryBridge(seed: readonly SessionSummary[]): ArchivedT
     },
   };
 }
+const gitBashSettings = mergeSettings(createDefaultSettings(), {
+  shell: {
+    preference: 'git_bash',
+    executable: 'C:\\Program Files\\Git\\bin\\bash.exe',
+  },
+});
+const withGitBashSettingsBridge = withScopedMakaBridge({
+  ...makaBridge,
+  settings: {
+    ...makaBridge.settings,
+    get: async () => gitBashSettings,
+    update: async (
+      patch: Parameters<typeof window.maka.settings.update>[0],
+    ): Promise<UpdateAppSettingsResult> => ({
+      settings: mergeSettings(gitBashSettings, patch),
+    }),
+  },
+} satisfies Record<string, unknown>);
 
 // #1364: list-page variants — empty vs populated vs long-content, per the
 // tracking issue's expected deliverables.
@@ -1241,6 +1259,11 @@ export const SubagentEditor: Story = {
 // Real path: 设置 → 通用.
 export const General: Story = {
   decorators: [withSettingsBridge],
+  render: () => <SettingsStory section="general" />,
+};
+// Real path: 设置 → 通用, after selecting Git Bash for the current Runtime Host.
+export const GeneralGitBash: Story = {
+  decorators: [withGitBashSettingsBridge],
   render: () => <SettingsStory section="general" />,
 };
 // Real path: 设置 → 外观.

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -154,7 +154,8 @@ The root test timeout is tracked separately from individual test failures. Phase
 - CLI `--help`, `--version`, TUI startup, and non-interactive commands are native Node.js paths.
 - Desktop development startup uses the Windows Electron binary.
 - Runtime Host endpoints use Windows named pipes rather than Unix domain sockets.
-- Shell selection prefers PowerShell 7, then Windows PowerShell, then `cmd.exe`.
+- Automatic shell selection prefers PowerShell 7, then Windows PowerShell, then `cmd.exe`.
+- Desktop can explicitly select a GNU Bash `bash.exe` on the Runtime Host machine (Git Bash or the legacy `System32\bash.exe` WSL shim). The Host validates the executable before persisting it and fails closed if the configured path later disappears; remote Desktop clients do not resolve the path on their own machine.
 - PTY execution uses ConPTY through `node-pty`; process-tree termination uses `taskkill /T` where required.
 - Restricted managed profiles use the packaged AppContainer broker when available and fail closed
   when the native capability or requested policy is unavailable.

--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -16,10 +16,10 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 | Classification | Count |
 |---|---:|
 | windows-backend-gap | 20 |
-| portable-candidate | 3 |
+| portable-candidate | 9 |
 | platform-contract | 35 |
 
-Total Windows-excluded declarations: **58**
+Total Windows-excluded declarations: **64**
 
 ## Inventory
 
@@ -54,12 +54,18 @@ Total Windows-excluded declarations: **58**
 | portable-candidate | `packages/runtime/src/__tests__/filesystem-apply-patch.test.ts` deletes a self-referential symlink entry without following it | `process.platform === 'win32'` |
 | platform-contract | `packages/runtime/src/__tests__/filesystem-worker-process-runner.test.ts` filesystem worker rejects boundedly when a detached descendant retains stdout | `process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false` |
 | platform-contract | `packages/runtime/src/__tests__/filesystem-worker-smoke.test.ts` macOS filesystem worker smoke | `process.platform !== 'darwin'` |
+| portable-candidate | `packages/runtime/src/__tests__/node-pty-write-lifecycle.test.ts` does not carry queued Unix PTY writes past native exit | `process.platform === 'win32' ? 'Unix PTY file-descriptor lifecycle only' : false` |
+| portable-candidate | `packages/runtime/src/__tests__/shell-exec.test.ts` writes a legacy WSL Bash command through stdin | `process.platform === 'win32' ? 'uses /bin/sh as a portable stdin probe' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-exec.test.ts` bounds output drain after the root exits while a detached descendant retains stdout | `process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false` |
+| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves CJK PowerShell output through pipes | `process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression'` |
+| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves the requested cwd through a real Git Bash login PTY | `process.platform === 'win32' ? false : 'Git Bash PTY regression'` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` latches timeout when the root exits during POSIX process discovery | `process.platform === 'win32' ? 'POSIX process discovery only' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves cancellation when timeout fires during POSIX process discovery | `process.platform === 'win32' ? 'POSIX process discovery only' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` ignores a Stop abort that occurs after another admitted Stop commits termination | `process.platform === 'win32' ? 'Windows termination has no asynchronous POSIX snapshot window' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps a pipe task alive when Stop aborts during process-tree preparation | `process.platform === 'win32' ? 'Windows termination does not take a POSIX process snapshot' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps a PTY task controllable when Stop aborts during process-tree preparation | `process.platform === 'win32' ? 'Windows termination does not take a POSIX process snapshot' : false` |
+| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves CJK PowerShell output through a real PTY | `process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression'` |
+| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves the caller environment through a PowerShell PTY | `process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression'` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` settles after root exit when a detached descendant retains inherited stdout | `process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps the first committed lifecycle cause across Stop and timeout races | `process.platform === 'win32' ? 'Windows tree termination has no graceful SIGTERM phase' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps SIGTERM final output and escalates an ignored SIGTERM without leaking slots | `process.platform === 'win32' ? 'Windows tree termination has no graceful SIGTERM phase' : false` |

--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -16,10 +16,10 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 | Classification | Count |
 |---|---:|
 | windows-backend-gap | 20 |
-| portable-candidate | 9 |
+| portable-candidate | 7 |
 | platform-contract | 35 |
 
-Total Windows-excluded declarations: **64**
+Total Windows-excluded declarations: **62**
 
 ## Inventory
 
@@ -30,6 +30,7 @@ Total Windows-excluded declarations: **64**
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` keeps the inherited PATH and does not log shell stderr when capture fails | `process.platform === 'win32'` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` kills login-shell descendants when capture times out | `process.platform === 'win32'` |
 | platform-contract | `apps/desktop/src/main/__tests__/shell-env.test.ts` bounds shell output instead of buffering until the global timeout | `process.platform === 'win32'` |
+| portable-candidate | `packages/eval/src/__tests__/install-preflight.test.ts` rejects an unusable trials root before invoking external prerequisites | `process.platform === 'win32' \|\| process.geteuid?.() === 0` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts` leaves canonical onboarding state unchanged when the durable intent cannot be published | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts` recovers a durable onboarding intent instead of rolling back a partial publication | `process.platform === 'win32'` |
 | windows-backend-gap | `packages/runtime-host/src/__tests__/control-endpoint.test.ts` runtime host control endpoint | `process.platform === 'win32'` |
@@ -57,15 +58,11 @@ Total Windows-excluded declarations: **64**
 | portable-candidate | `packages/runtime/src/__tests__/node-pty-write-lifecycle.test.ts` does not carry queued Unix PTY writes past native exit | `process.platform === 'win32' ? 'Unix PTY file-descriptor lifecycle only' : false` |
 | portable-candidate | `packages/runtime/src/__tests__/shell-exec.test.ts` writes a legacy WSL Bash command through stdin | `process.platform === 'win32' ? 'uses /bin/sh as a portable stdin probe' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-exec.test.ts` bounds output drain after the root exits while a detached descendant retains stdout | `process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves CJK PowerShell output through pipes | `process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression'` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves the requested cwd through a real Git Bash login PTY | `process.platform === 'win32' ? false : 'Git Bash PTY regression'` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` latches timeout when the root exits during POSIX process discovery | `process.platform === 'win32' ? 'POSIX process discovery only' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves cancellation when timeout fires during POSIX process discovery | `process.platform === 'win32' ? 'POSIX process discovery only' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` ignores a Stop abort that occurs after another admitted Stop commits termination | `process.platform === 'win32' ? 'Windows termination has no asynchronous POSIX snapshot window' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps a pipe task alive when Stop aborts during process-tree preparation | `process.platform === 'win32' ? 'Windows termination does not take a POSIX process snapshot' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps a PTY task controllable when Stop aborts during process-tree preparation | `process.platform === 'win32' ? 'Windows termination does not take a POSIX process snapshot' : false` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves CJK PowerShell output through a real PTY | `process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression'` |
-| portable-candidate | `packages/runtime/src/__tests__/shell-run-manager.test.ts` preserves the caller environment through a PowerShell PTY | `process.platform === 'win32' ? false : 'Windows PowerShell 5.1 regression'` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` settles after root exit when a detached descendant retains inherited stdout | `process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps the first committed lifecycle cause across Stop and timeout races | `process.platform === 'win32' ? 'Windows tree termination has no graceful SIGTERM phase' : false` |
 | platform-contract | `packages/runtime/src/__tests__/shell-run-manager.test.ts` keeps SIGTERM final output and escalates an ignored SIGTERM without leaking slots | `process.platform === 'win32' ? 'Windows tree termination has no graceful SIGTERM phase' : false` |
@@ -89,3 +86,4 @@ Total Windows-excluded declarations: **64**
 | platform-contract | `packages/storage/src/__tests__/runtime-policy-stores.test.ts` fails closed on final symlinks, FIFOs, and oversized documents without changing bytes | `process.platform === 'win32'` |
 | platform-contract | `packages/storage/src/__tests__/usage-stores.test.ts` classifies a renamed or replaced live root as a draining persistence failure | `process.platform === 'win32' ? 'Windows does not permit renaming a directory with an open SQLite database' : false` |
 | platform-contract | `packages/storage/src/__tests__/workspace-identity.test.ts` an unmarked read-only workspace fails without leaving marker state | `process.platform === 'win32' ? 'POSIX permissions are required to create a read-only workspace fixture' : false` |
+| portable-candidate | `scripts/release-cli-eval-support.test.mjs` preserves the primary process failure when diagnostics cannot be read | `process.platform === 'win32'` |

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "generate:bundled-skills": "node scripts/gen-bundled-skill-catalog.mjs",
     "cost:deepseek-baseline": "node scripts/deepseek-live-cost-baseline.mjs",
     "computer-use": "node scripts/computer-use.mjs",
-    "windows:inventory": "node scripts/windows-test-inventory.mjs --check",
+    "windows:inventory": "node --test scripts/windows-test-inventory.test.mjs && node scripts/windows-test-inventory.mjs --check",
     "windows:inventory:write": "node scripts/windows-test-inventory.mjs --write",
     "smoke:windows": "npm run build && npm run smoke:windows:dist",
     "smoke:windows:dist": "node scripts/windows-smoke.mjs",

--- a/packages/core/src/__tests__/runtime-policy-codec.test.ts
+++ b/packages/core/src/__tests__/runtime-policy-codec.test.ts
@@ -82,6 +82,42 @@ test('keeps user-approved subagent presets canonical in Runtime Policy', () => {
   );
 });
 
+test('normalizes the explicit Git Bash preference and rejects arbitrary shell kinds', () => {
+  assert.deepEqual(
+    normalizeRuntimePolicyMutation({
+      expectedRevision: 3,
+      operation: {
+        kind: 'set_shell',
+        value: {
+          preference: 'git_bash',
+          executable: ' C:\\Program Files\\Git\\bin\\bash.exe ',
+        },
+      },
+    }),
+    {
+      expectedRevision: 3,
+      operation: {
+        kind: 'set_shell',
+        value: {
+          preference: 'git_bash',
+          executable: 'C:\\Program Files\\Git\\bin\\bash.exe',
+        },
+      },
+    },
+  );
+  assert.throws(
+    () =>
+      normalizeRuntimePolicyMutation({
+        expectedRevision: 3,
+        operation: {
+          kind: 'set_shell',
+          value: { preference: 'custom', executable: 'C:\\tools\\fish.exe' },
+        },
+      }),
+    RuntimePolicyDomainDecodeError,
+  );
+});
+
 test('normalizes only the bounded agent settings patch surface', () => {
   assert.deepEqual(
     normalizeRuntimePolicyMutation({

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, test } from 'node:test';
 import { expect } from './test-helpers.js';
-import { normalizeSettings } from '../settings.js';
+import { createDefaultSettings, mergeSettings, normalizeSettings } from '../settings.js';
 
 test('normalizes user-approved subagent presets without widening the catalog', () => {
   const normalized = normalizeSettings({
@@ -65,6 +65,29 @@ describe('custom pet selection settings', () => {
       expect(normalized.personalization.selectedPetId).toBe(null);
     }
   });
+});
+
+test('shell settings default, normalize, and merge through their shared boundary', () => {
+  const defaults = createDefaultSettings();
+  expect(defaults.shell).toEqual({ preference: 'auto', executable: '' });
+
+  expect(
+    normalizeSettings({
+      shell: { preference: 'git_bash', executable: ' C:\\Program Files\\Git\\bin\\bash.exe ' },
+    }).shell,
+  ).toEqual({
+    preference: 'git_bash',
+    executable: 'C:\\Program Files\\Git\\bin\\bash.exe',
+  });
+  expect(normalizeSettings({ shell: { preference: 'fish', executable: 42 } }).shell).toEqual({
+    preference: 'auto',
+    executable: '',
+  });
+  expect(
+    mergeSettings(defaults, {
+      shell: { preference: 'git_bash', executable: 'C:\\Git\\bin\\bash.exe' },
+    }).shell,
+  ).toEqual({ preference: 'git_bash', executable: 'C:\\Git\\bin\\bash.exe' });
 });
 
 test('a chat-default thinking level the app does not recognize drops to no preference', () => {

--- a/packages/core/src/runtime-policy.ts
+++ b/packages/core/src/runtime-policy.ts
@@ -7,7 +7,7 @@ import type {
 import type { ThinkingLevel } from './model-thinking.js';
 import type { ProviderType } from './provider-registry.js';
 import type { RelayModelProfile } from './model-thinking.js';
-import type { ChatDefaultPermissionMode, ProxyProtocol } from './settings.js';
+import type { ChatDefaultPermissionMode, ProxyProtocol, ShellSettings } from './settings.js';
 import type { SubagentSettings } from './subagent-settings.js';
 import type { JsonObject } from './request-customization.js';
 import {
@@ -24,6 +24,7 @@ export {
 } from './runtime-policy/domain-codec.js';
 export {
   decodeCanonicalRuntimePolicy,
+  decodeRuntimePolicyV2,
   normalizeRuntimePolicyMutation,
 } from './runtime-policy/policy-codec.js';
 export {
@@ -124,6 +125,7 @@ export interface RuntimePolicy {
     readonly defaultProvider: WebSearchProvider;
   };
   readonly subagents: SubagentSettings;
+  readonly shell: ShellSettings;
 }
 
 export interface RuntimePolicySnapshot {
@@ -151,6 +153,7 @@ export type RuntimePolicyMutation =
   | { readonly kind: 'set_chat_defaults'; readonly value: RuntimePolicy['chatDefaults'] }
   | { readonly kind: 'set_web_search'; readonly value: RuntimePolicy['webSearch'] }
   | { readonly kind: 'set_subagents'; readonly value: RuntimePolicy['subagents'] }
+  | { readonly kind: 'set_shell'; readonly value: RuntimePolicy['shell'] }
   | { readonly kind: 'patch_agent_settings'; readonly value: AgentRuntimeSettingsPatch };
 
 export interface MutateRuntimePolicyInput {
@@ -181,6 +184,7 @@ export function createDefaultRuntimePolicy(): RuntimePolicy {
     chatDefaults: { permissionMode: 'ask' },
     webSearch: { enabled: false, defaultProvider: 'model' },
     subagents: { presets: [] },
+    shell: { preference: 'auto', executable: '' },
   };
 }
 

--- a/packages/core/src/runtime-policy/policy-codec.ts
+++ b/packages/core/src/runtime-policy/policy-codec.ts
@@ -25,6 +25,27 @@ export function decodeCanonicalRuntimePolicy(value: unknown): RuntimePolicy {
   return decoded;
 }
 
+/** Upgrade the immediately previous canonical document with the new shell default. */
+export function decodeRuntimePolicyV2(value: unknown): RuntimePolicy {
+  const policy = exactRecord(value, 'runtime policy v2', [
+    'networkProxy',
+    'personalization',
+    'memory',
+    'workspaceInstructions',
+    'privacy',
+    'chatDefaults',
+    'webSearch',
+    'subagents',
+  ]);
+  const decoded = normalizeRuntimePolicyFields(
+    policy,
+    normalizeSubagentSettings(policy.subagents),
+    { preference: 'auto', executable: '' },
+  );
+  assertCanonicalValue(value, withoutShell(decoded), 'runtime policy v2');
+  return decoded;
+}
+
 export function normalizeRuntimePolicyMutation(value: unknown): MutateRuntimePolicyInput {
   const input = exactRecord(value, 'runtime policy mutation', ['expectedRevision', 'operation']);
   const operation = exactRecord(input.operation, 'runtime policy operation', ['kind', 'value']);
@@ -44,13 +65,19 @@ function normalizeRuntimePolicy(value: unknown): RuntimePolicy {
     'chatDefaults',
     'webSearch',
     'subagents',
+    'shell',
   ]);
-  return normalizeRuntimePolicyFields(policy, normalizeSubagentSettings(policy.subagents));
+  return normalizeRuntimePolicyFields(
+    policy,
+    normalizeSubagentSettings(policy.subagents),
+    normalizeShell(policy.shell),
+  );
 }
 
 function normalizeRuntimePolicyFields(
   policy: Record<string, unknown>,
   subagents: RuntimePolicy['subagents'],
+  shell: RuntimePolicy['shell'],
 ): RuntimePolicy {
   return {
     networkProxy: normalizeNetworkProxy(policy.networkProxy),
@@ -61,7 +88,13 @@ function normalizeRuntimePolicyFields(
     chatDefaults: normalizeChatDefaults(policy.chatDefaults),
     webSearch: normalizeWebSearch(policy.webSearch),
     subagents,
+    shell,
   };
+}
+
+function withoutShell(policy: RuntimePolicy): Omit<RuntimePolicy, 'shell'> {
+  const { shell: _shell, ...legacy } = policy;
+  return legacy;
 }
 
 function normalizeMutationOperation(operation: Record<string, unknown>): RuntimePolicyMutation {
@@ -82,11 +115,28 @@ function normalizeMutationOperation(operation: Record<string, unknown>): Runtime
       return { kind: operation.kind, value: normalizeWebSearch(operation.value) };
     case 'set_subagents':
       return { kind: operation.kind, value: normalizeSubagentSettings(operation.value) };
+    case 'set_shell':
+      return { kind: operation.kind, value: normalizeShell(operation.value) };
     case 'patch_agent_settings':
       return { kind: operation.kind, value: normalizeAgentRuntimeSettingsPatch(operation.value) };
     default:
       throw domainError(`runtime policy operation '${String(operation.kind)}' is unknown`);
   }
+}
+
+function normalizeShell(value: unknown): RuntimePolicy['shell'] {
+  const item = exactRecord(value, 'shell policy', ['preference', 'executable']);
+  if (item.preference !== 'auto' && item.preference !== 'git_bash') {
+    throw domainError('shell preference is invalid');
+  }
+  const executable = stringValue(item.executable, 'shell executable', 4_096).trim();
+  if (/[\u0000-\u001f\u007f-\u009f]/.test(executable)) {
+    throw domainError('shell executable must not contain control characters');
+  }
+  if (item.preference === 'git_bash' && executable.length === 0) {
+    throw domainError('Git Bash executable must not be empty');
+  }
+  return { preference: item.preference, executable };
 }
 
 function normalizeAgentRuntimeSettingsPatch(value: unknown): AgentRuntimeSettingsPatch {

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -232,6 +232,16 @@ export interface SystemSettings {
   keepSystemAwake: boolean;
 }
 
+/** Host-machine shell preference used by Bash tools and interactive PTYs. */
+export type ShellPreference = 'auto' | 'git_bash';
+
+export interface ShellSettings {
+  /** `auto` preserves the platform default; `git_bash` is an explicit Windows override. */
+  preference: ShellPreference;
+  /** Absolute executable selected by the user. Retained while `auto` is active for easy reuse. */
+  executable: string;
+}
+
 export interface AppSettings {
   schemaVersion: 1;
   network: AppNetworkSettings;
@@ -248,6 +258,7 @@ export interface AppSettings {
   projects: ProjectPreferencesSettings;
   notifications: NotificationSettings;
   system: SystemSettings;
+  shell: ShellSettings;
   subagents: SubagentSettings;
 }
 
@@ -350,6 +361,7 @@ export type UpdateAppSettingsInput = Partial<{
   projects: Partial<ProjectPreferencesSettings>;
   notifications: Partial<NotificationSettings>;
   system: Partial<SystemSettings>;
+  shell: Partial<ShellSettings>;
   webSearch: WebSearchSettingsPatch;
   subagents: SubagentSettings;
 }>;
@@ -430,6 +442,10 @@ export function createDefaultSettings(): AppSettings {
       // battery-affecting opt-in, not a silent default.
       keepSystemAwake: false,
     },
+    shell: {
+      preference: 'auto',
+      executable: '',
+    },
     subagents: { presets: [] },
   };
 }
@@ -501,6 +517,10 @@ export function mergeSettings(current: AppSettings, patch: UpdateAppSettingsInpu
       ...current.system,
       ...(patch.system ?? {}),
     },
+    shell: {
+      ...current.shell,
+      ...(patch.shell ?? {}),
+    },
     webSearch: mergeWebSearchSettings(current.webSearch, patch.webSearch),
     subagents:
       patch.subagents === undefined
@@ -527,6 +547,7 @@ export function normalizeSettings(input: unknown): AppSettings {
     projects: value.projects,
     notifications: value.notifications,
     system: value.system,
+    shell: value.shell,
     subagents: value.subagents,
   });
   // PR110b: milestones bypass the generic patch surface so we can
@@ -605,12 +626,23 @@ export function normalizeSettings(input: unknown): AppSettings {
       keepSystemAwake:
         typeof base.system.keepSystemAwake === 'boolean' ? base.system.keepSystemAwake : false,
     },
+    shell: normalizeShellSettings(base.shell),
     subagents: normalizeSubagentSettings(base.subagents),
   };
 }
 
 function normalizeSelectedPetId(value: unknown): string | null {
   return isPetPackId(value) ? value : null;
+}
+
+function normalizeShellSettings(settings: ShellSettings): ShellSettings {
+  return {
+    preference: settings.preference === 'git_bash' ? 'git_bash' : 'auto',
+    executable:
+      typeof settings.executable === 'string'
+        ? settings.executable.replace(/[\u0000-\u001f\u007f-\u009f]/g, '').trim()
+        : '',
+  };
 }
 
 function normalizeWorkspaceInstructionsSettings(

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -35,7 +35,7 @@ import {
 } from '@maka/runtime/network/scoped-fetch-transport';
 import { type ScannedSkill } from '@maka/runtime/skills';
 import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinator';
-import { ShellPreferenceError } from '@maka/runtime/shell-detect';
+import { resolveTurnShellPlan, ShellPreferenceError } from '@maka/runtime/shell-detect';
 import { buildParentAgentTools } from '@maka/runtime/subagent-tools';
 import { SESSION_RECAP_INSTRUCTION } from '@maka/runtime/session-recap';
 import { hostedExecutionToolNames } from '../server/hosted-execution-tool-profile.js';
@@ -2726,6 +2726,11 @@ test('backend composition survives a moved saved Git Bash executable while Bash 
     } as unknown as HostClientCapabilityCoordinator,
     resolveTavilyWebSearchReadiness: async () => false,
     builtinTools: {},
+    resolveTurnShellPlan: (settings) =>
+      resolveTurnShellPlan(settings, {
+        platform: 'win32',
+        fileExists: () => false,
+      }),
   });
   const connection = readyExecutionConnection()
     .connection as unknown as import('@maka/core/llm-connections').RuntimeExecutionConnection;
@@ -2742,6 +2747,11 @@ test('backend composition survives a moved saved Git Bash executable while Bash 
     | MakaTool<{ command: string }, unknown>
     | undefined;
   assert.ok(bash, 'expected the default tool surface to include Bash');
+  const unavailableShell = resolveTurnShellPlan(policy.shell, {
+    platform: 'win32',
+    fileExists: () => false,
+  });
+  assert.equal(unavailableShell.setupError?.code, 'executable_missing');
   assert.match(bash.description, /unavailable this turn/);
   assert.doesNotMatch(bash.description, /write PowerShell syntax/);
   await assert.rejects(
@@ -2755,7 +2765,8 @@ test('backend composition survives a moved saved Git Bash executable while Bash 
         emitOutput: () => {},
       } satisfies MakaToolContext);
     },
-    (error: unknown) => error instanceof ShellPreferenceError,
+    (error: unknown) =>
+      error instanceof ShellPreferenceError && error.code === 'executable_missing',
   );
 
   // Text-only composition — prompts and the rest of the tool surface — is unaffected.

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -2703,6 +2703,7 @@ test('backend composition survives a moved saved Git Bash executable while Bash 
     resolveExecutionConnection: async () => readyExecutionConnection(),
     readPricing: async () => ({ revision: 0, overrides: [] }),
   });
+  let shellPolicyResolutions = 0;
   const factory = createInteractiveRunComposerFactory({
     skills: {
       readCanonicalModelInventory: async () => ({
@@ -2727,11 +2728,13 @@ test('backend composition survives a moved saved Git Bash executable while Bash 
     } as unknown as HostClientCapabilityCoordinator,
     resolveTavilyWebSearchReadiness: async () => false,
     builtinTools: {},
-    resolveTurnShellPlan: (settings) =>
-      resolveTurnShellPlan(settings, {
+    resolveTurnShellPlan: (settings) => {
+      shellPolicyResolutions += 1;
+      return resolveTurnShellPlan(settings, {
         platform: 'win32',
         fileExists: () => false,
-      }),
+      });
+    },
   });
   const connection = readyExecutionConnection()
     .connection as unknown as import('@maka/core/llm-connections').RuntimeExecutionConnection;
@@ -2778,6 +2781,48 @@ test('backend composition survives a moved saved Git Bash executable while Bash 
     workspaceRoot: '/workspace',
   });
   assert.ok(prompt.sourceRevisions.length > 0);
+
+  const capturedChildShell = {
+    plan: {
+      kind: 'git-bash' as const,
+      displayName: 'captured child shell',
+      exe: 'C:\\captured\\bash.exe',
+    },
+  };
+  const capturedChildTools = createHostChildAgentToolComposition({
+    taskLedger: {} as TaskLedgerStore,
+    builtinTools: { shell: capturedChildShell },
+    hostTools: [],
+    worktreePatchWriteBackAvailable: true,
+  }).childTools;
+  const childComposer = await factory({
+    backendContext: {
+      ...fixture.context,
+      tools: capturedChildTools,
+      turnShellPlan: capturedChildShell,
+    },
+    connection,
+    modelId: MODEL_ID,
+    runtimePolicy: { revision: 1, policy },
+    contextWindow: null,
+  });
+  assert.equal(
+    shellPolicyResolutions,
+    1,
+    'a child activation must not re-read shell policy after Runtime captured its plan',
+  );
+  const capturedBash = childComposer.tools.find((tool) => tool.name === 'Bash');
+  assert.match(capturedBash?.description ?? '', /captured child shell/);
+  assert.doesNotMatch(capturedBash?.description ?? '', /unavailable this turn/);
+  assert.match(
+    await childComposer.turnTailPrompt({
+      sessionId: 'session',
+      turnId: 'turn-child',
+      cwd: '/workspace',
+      workspaceRoot: '/workspace',
+    }),
+    /captured child shell/,
+  );
 });
 
 test('child execution Bash carries the configured shell guidance and spawn plan', async () => {

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -60,6 +60,7 @@ import {
 import type { TurnSnapshot, UsageQueryResult } from '../protocol/index.js';
 import type { ClientCapabilityHostFrame } from '../protocol/index.js';
 import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
+import { createHostChildAgentToolComposition } from '../server/child-agent-composition.js';
 import {
   createHostDailyReviewModel,
   createHostGoalEvaluator,
@@ -2777,6 +2778,66 @@ test('backend composition survives a moved saved Git Bash executable while Bash 
     workspaceRoot: '/workspace',
   });
   assert.ok(prompt.sourceRevisions.length > 0);
+});
+
+test('child execution Bash carries the configured shell guidance and spawn plan', async () => {
+  const calls: unknown[] = [];
+  const shell = {
+    plan: {
+      kind: 'git-bash' as const,
+      displayName: 'Git Bash',
+      exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+    },
+  };
+  const composition = createHostChildAgentToolComposition({
+    taskLedger: {} as TaskLedgerStore,
+    builtinTools: {
+      shell,
+      shellRuns: {
+        async runForegroundBash(input) {
+          calls.push(input);
+          return {
+            kind: 'terminal' as const,
+            cwd: input.cwd,
+            cmd: input.command,
+            status: 'completed' as const,
+            exitCode: 0,
+            output: {
+              mode: 'pipes' as const,
+              stdout: '',
+              stderr: '',
+              stdoutTruncated: false,
+              stderrTruncated: false,
+              redacted: false,
+            },
+          };
+        },
+        async runBackgroundBash() {
+          throw new Error('background execution was not requested');
+        },
+      },
+    },
+    worktreePatchWriteBackAvailable: true,
+  });
+  const bash = composition.childTools.find((tool) => tool.name === 'Bash') as
+    | MakaTool<{ command: string }, unknown>
+    | undefined;
+  assert.ok(bash);
+  assert.match(bash.description, /Git Bash/);
+  assert.match(bash.description, /POSIX shell syntax/);
+
+  await bash.impl(
+    { command: 'printf child-shell' },
+    {
+      sessionId: 'child-session',
+      turnId: 'child-turn',
+      cwd: '/workspace',
+      toolCallId: 'child-bash',
+      abortSignal: new AbortController().signal,
+      emitOutput: () => {},
+    },
+  );
+  assert.deepEqual((calls[0] as { shell?: unknown }).shell, shell.plan);
 });
 
 test('a bound tool ceiling excludes dynamic Client Capability tools', () => {

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -35,6 +35,7 @@ import {
 } from '@maka/runtime/network/scoped-fetch-transport';
 import { type ScannedSkill } from '@maka/runtime/skills';
 import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinator';
+import { ShellPreferenceError } from '@maka/runtime/shell-detect';
 import { buildParentAgentTools } from '@maka/runtime/subagent-tools';
 import { SESSION_RECAP_INSTRUCTION } from '@maka/runtime/session-recap';
 import { hostedExecutionToolNames } from '../server/hosted-execution-tool-profile.js';
@@ -2681,6 +2682,90 @@ test('one composer freezes Runtime Policy while each Run freezes its remaining p
       { id: 'skill-catalog', revision: 'skills-4' },
     ],
   );
+});
+
+test('backend composition survives a moved saved Git Bash executable while Bash fails closed', async () => {
+  // A previously valid Git Bash path that was moved or uninstalled is a
+  // repairable optional-tool configuration error: it must not fail text-only
+  // backend composition. The turn plan carries the setup error, the tool
+  // description declares the outage, and the Bash boundary rethrows it
+  // instead of silently falling back to another shell.
+  const policy = {
+    ...createDefaultRuntimePolicy(),
+    shell: {
+      preference: 'git_bash' as const,
+      executable: 'C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe',
+    },
+  };
+  const fixture = backendCreationFixture({
+    abortSignal: new AbortController().signal,
+    resolveExecutionConnection: async () => readyExecutionConnection(),
+    readPricing: async () => ({ revision: 0, overrides: [] }),
+  });
+  const factory = createInteractiveRunComposerFactory({
+    skills: {
+      readCanonicalModelInventory: async () => ({
+        revision: 'skills-fixture',
+        projectRoot: '/workspace',
+        inventory: [],
+        diagnostics: [],
+        discoveryDiagnostics: [],
+      }),
+    } as unknown as HostSkillCatalogCoordinator,
+    memory: {
+      readPromptProjection: async () => ({
+        policy: { revision: 0, policy: createDefaultRuntimePolicy() },
+        bundleRevision: null,
+        memoryRevision: null,
+        body: '',
+      }),
+    } as unknown as HostMemoryCoordinator,
+    taskLedger: { list: async () => [] } as unknown as TaskLedgerStore,
+    clientCapabilities: {
+      snapshotForSession: () => undefined,
+    } as unknown as HostClientCapabilityCoordinator,
+    resolveTavilyWebSearchReadiness: async () => false,
+    builtinTools: {},
+  });
+  const connection = readyExecutionConnection()
+    .connection as unknown as import('@maka/core/llm-connections').RuntimeExecutionConnection;
+
+  const composer = await factory({
+    backendContext: fixture.context,
+    connection,
+    modelId: MODEL_ID,
+    runtimePolicy: { revision: 0, policy },
+    contextWindow: null,
+  });
+
+  const bash = composer.tools.find((tool) => tool.name === 'Bash') as
+    | MakaTool<{ command: string }, unknown>
+    | undefined;
+  assert.ok(bash, 'expected the default tool surface to include Bash');
+  assert.match(bash.description, /unavailable this turn/);
+  assert.doesNotMatch(bash.description, /write PowerShell syntax/);
+  await assert.rejects(
+    async () => {
+      await bash.impl({ command: 'echo never-runs' }, {
+        sessionId: 'session',
+        turnId: 'turn-1',
+        cwd: '/workspace',
+        toolCallId: 'tool-call',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+      } satisfies MakaToolContext);
+    },
+    (error: unknown) => error instanceof ShellPreferenceError,
+  );
+
+  // Text-only composition — prompts and the rest of the tool surface — is unaffected.
+  const prompt = await composer.resolveSystemPrompt({
+    sessionId: 'session',
+    turnId: 'turn-1',
+    cwd: '/workspace',
+    workspaceRoot: '/workspace',
+  });
+  assert.ok(prompt.sourceRevisions.length > 0);
 });
 
 test('a bound tool ceiling excludes dynamic Client Capability tools', () => {

--- a/packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts
@@ -446,6 +446,43 @@ test('projects runtime policy CAS results without returning the committed snapsh
   });
 });
 
+test('rejects a Host-invalid shell preference before it reaches durable policy', async () => {
+  await withCoordinator(async ({ stores }) => {
+    const coordinator = new HostRuntimePolicyCoordinator(
+      stores,
+      new RuntimePolicyActivationGate(),
+      async () => {},
+      async (input) => {
+        if (input.operation.kind === 'set_shell') throw new Error('not GNU Bash');
+      },
+    );
+    const result = await coordinator.handlers['runtime.policy.mutate'](
+      {
+        expectedRevision: 0,
+        operation: {
+          kind: 'set_shell',
+          value: {
+            preference: 'git_bash',
+            executable: 'C:\\tools\\bash.exe',
+          },
+        },
+      },
+      context,
+    );
+    assert.deepEqual(result, {
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'Runtime policy mutation is invalid for the current state',
+      },
+    });
+    assert.deepEqual((await stores.runtimePolicy.getSnapshot()).policy.shell, {
+      preference: 'auto',
+      executable: '',
+    });
+  });
+});
+
 test('awaits committed mutation invalidation before returning the outcome', async () => {
   await withCoordinator(async ({ stores }) => {
     let releaseInvalidation!: () => void;

--- a/packages/runtime-host/src/__tests__/runtime-resource-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-coordinator.test.ts
@@ -275,6 +275,66 @@ describe('Host Runtime Resource coordinator', () => {
     assert.equal(harness.activeResidencies, 0);
   });
 
+  test('starts the interactive terminal with the Host-resolved Git Bash plan', async () => {
+    const shell = {
+      kind: 'git-bash' as const,
+      displayName: 'Git Bash',
+      exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+    };
+    const harness = createHarness({ resolveShell: async () => shell });
+    const started = await harness.coordinator.handlers['runtime.resource.start'](
+      { sessionId: SESSION_ID, launchId: 'desktop-launch-git-bash' },
+      connection('connection-1'),
+    );
+
+    assert.equal(started.ok, true);
+    assert.deepEqual(harness.lastBackgroundInput?.shell, shell);
+    assert.equal(harness.lastBackgroundInput?.command, 'exec "$SHELL" -l');
+    assert.equal(harness.lastBackgroundInput?.env?.SHELL, shell.exe);
+    harness.finishBackground({ successful: true });
+  });
+
+  test('makes the Host-resolved shell authoritative over a caller plan', async () => {
+    const shell = {
+      kind: 'git-bash' as const,
+      displayName: 'Git Bash',
+      exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+    };
+    const harness = createHarness({ resolveShell: async () => shell });
+    await harness.coordinator.runForegroundBash({
+      ...backgroundInput(),
+      shell: { kind: 'cmd', displayName: 'cmd.exe' },
+    });
+
+    assert.deepEqual(harness.lastForegroundInput?.shell, shell);
+  });
+
+  test('does not start a process when draining begins during shell resolution', async () => {
+    let announceResolution!: () => void;
+    const resolving = new Promise<void>((resolve) => {
+      announceResolution = resolve;
+    });
+    let releaseResolution!: () => void;
+    const resolved = new Promise<void>((resolve) => {
+      releaseResolution = resolve;
+    });
+    const harness = createHarness({
+      resolveShell: async () => {
+        announceResolution();
+        await resolved;
+        return { kind: 'posix', displayName: '/bin/sh' };
+      },
+    });
+
+    const foreground = harness.coordinator.runForegroundBash(backgroundInput());
+    await resolving;
+    harness.coordinator.beginDrain();
+    releaseResolution();
+
+    await assert.rejects(foreground, /Runtime resources are draining/);
+    assert.equal(harness.lastForegroundInput, undefined);
+  });
+
   test('lets stop bypass the controller, releases terminal ownership, and keeps control replay safe', async () => {
     const harness = createHarness();
     const firstConnection = connection('connection-1');
@@ -413,7 +473,7 @@ describe('Host Runtime Resource coordinator', () => {
   });
 });
 
-function createHarness() {
+function createHarness(options: Pick<HostRuntimeResourceCoordinatorInput, 'resolveShell'> = {}) {
   let backgroundCompletion: ShellRunBashInput['onCompletion'];
   let currentSnapshot = ptySnapshot();
   const state = {
@@ -428,13 +488,16 @@ function createHarness() {
     stateReadFailure: undefined as Error | undefined,
     activeResidencies: 0,
     lastBackgroundInput: undefined as ShellRunBashInput | undefined,
+    lastForegroundInput: undefined as ShellRunBashInput | undefined,
     foregroundRun: undefined as
       | HostRuntimeResourceCoordinatorInput['manager']['runForegroundBash']
       | undefined,
   };
   const manager: HostRuntimeResourceCoordinatorInput['manager'] = {
-    runForegroundBash: (input) =>
-      state.foregroundRun?.(input) ?? Promise.resolve(foregroundResult()),
+    runForegroundBash: (input) => {
+      state.lastForegroundInput = input;
+      return state.foregroundRun?.(input) ?? Promise.resolve(foregroundResult());
+    },
     runBackgroundBash: async (input) => {
       state.lastBackgroundInput = input;
       backgroundCompletion = input.onCompletion;
@@ -541,6 +604,7 @@ function createHarness() {
     requestDrain: () => {
       state.drainCount += 1;
     },
+    ...options,
   });
   return Object.assign(state, {
     coordinator,

--- a/packages/runtime-host/src/__tests__/runtime-resource-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-coordinator.test.ts
@@ -335,17 +335,42 @@ describe('Host Runtime Resource coordinator', () => {
     assert.equal(harness.drainCount, 0);
   });
 
-  test('makes the Host-resolved shell authoritative over a caller plan', async () => {
+  test('keeps the caller-supplied turn plan authoritative over the settings snapshot', async () => {
+    // The turn's Bash tool carries the plan resolved at turn admission. A
+    // mid-turn settings change must not split model guidance from execution,
+    // so the coordinator never overwrites a supplied plan — it does not even
+    // consult the settings snapshot when one is present.
+    const callerPlan = { kind: 'cmd' as const, displayName: 'cmd.exe' };
+    let resolveCalls = 0;
+    const harness = createHarness({
+      resolveShell: async () => {
+        resolveCalls += 1;
+        return {
+          kind: 'git-bash' as const,
+          displayName: 'Git Bash',
+          exe: 'C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe',
+        };
+      },
+    });
+
+    await harness.coordinator.runForegroundBash({ ...backgroundInput(), shell: callerPlan });
+    assert.deepEqual(harness.lastForegroundInput?.shell, callerPlan);
+    assert.equal(resolveCalls, 0);
+
+    await harness.coordinator.runBackgroundBash({ ...backgroundInput(), shell: callerPlan });
+    assert.deepEqual(harness.lastBackgroundInput?.shell, callerPlan);
+    assert.equal(resolveCalls, 0);
+    harness.finishBackground({ successful: true });
+  });
+
+  test('falls back to the Host-resolved plan only when the caller carries none', async () => {
     const shell = {
       kind: 'git-bash' as const,
       displayName: 'Git Bash',
-      exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+      exe: 'C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe',
     };
     const harness = createHarness({ resolveShell: async () => shell });
-    await harness.coordinator.runForegroundBash({
-      ...backgroundInput(),
-      shell: { kind: 'cmd', displayName: 'cmd.exe' },
-    });
+    await harness.coordinator.runForegroundBash(backgroundInput());
 
     assert.deepEqual(harness.lastForegroundInput?.shell, shell);
   });

--- a/packages/runtime-host/src/__tests__/runtime-resource-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-coordinator.test.ts
@@ -7,6 +7,7 @@ import {
   type ShellRunUpdate,
 } from '@maka/core/events';
 import type { ShellRunBashInput, ShellRunWriteInput } from '@maka/runtime/shell-run-contract';
+import { ShellPreferenceError } from '@maka/runtime/shell-detect';
 import { SessionNotFoundError } from '@maka/storage';
 import { RUNTIME_RESOURCE_RESULT_MAX_BYTES } from '../protocol/runtime-resource.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
@@ -291,7 +292,47 @@ describe('Host Runtime Resource coordinator', () => {
     assert.deepEqual(harness.lastBackgroundInput?.shell, shell);
     assert.equal(harness.lastBackgroundInput?.command, 'exec "$SHELL" -l');
     assert.equal(harness.lastBackgroundInput?.env?.SHELL, shell.exe);
+    assert.equal(harness.lastBackgroundInput?.env?.CHERE_INVOKING, '1');
     harness.finishBackground({ successful: true });
+  });
+
+  test('starts the legacy WSL shim with a Linux-visible login shell', async () => {
+    const shell = {
+      kind: 'legacy-wsl-bash' as const,
+      displayName: 'Legacy WSL Bash',
+      exe: 'C:\\Windows\\System32\\bash.exe',
+    };
+    const harness = createHarness({ resolveShell: async () => shell });
+    const started = await harness.coordinator.handlers['runtime.resource.start'](
+      { sessionId: SESSION_ID, launchId: 'desktop-launch-wsl' },
+      connection('connection-1'),
+    );
+
+    assert.equal(started.ok, true);
+    assert.deepEqual(harness.lastBackgroundInput?.shell, shell);
+    assert.equal(harness.lastBackgroundInput?.command, 'exec bash -l');
+    assert.notEqual(harness.lastBackgroundInput?.env?.SHELL, shell.exe);
+    harness.finishBackground({ successful: true });
+  });
+
+  test('rejects an unavailable saved shell without draining Runtime Host', async () => {
+    const harness = createHarness({
+      resolveShell: async () => {
+        throw new ShellPreferenceError(
+          'executable_missing',
+          'The configured Git Bash was not found',
+        );
+      },
+    });
+    const started = await harness.coordinator.handlers['runtime.resource.start'](
+      { sessionId: SESSION_ID, launchId: 'desktop-launch-missing-shell' },
+      connection('connection-1'),
+    );
+
+    assert.equal(started.ok, false);
+    assert.equal(!started.ok && started.error.code, 'invalid_request');
+    assert.equal(harness.lastBackgroundInput, undefined);
+    assert.equal(harness.drainCount, 0);
   });
 
   test('makes the Host-resolved shell authoritative over a caller plan', async () => {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -72,7 +72,9 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 26 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 27 as const;
+// 27: Runtime Policy carries the Host-owned shell preference used by tool,
+// PTY, and prompt composition. Older peers cannot safely preserve that field.
 // Transcript pages amortize storage and network round trips with a 512 KiB raw
 // payload. Base64 expansion plus the bounded fragment envelope must still fit in
 // one transport message; narrower domains retain their own encoded limits.

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -984,7 +984,6 @@ export async function createExecutionRuntimeHostComposition(
       canonicalPermissionOutcomes,
       shellRuns,
       planStore: openedPlanStore,
-      childTools: childAgentTools.childTools,
       resolveChildTools,
       worktreeChildExecutor,
       listArtifactsForTurn: (sessionId, turnId) =>

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -41,6 +41,7 @@ import {
 } from '@maka/runtime/agent-swarm-status-tool';
 import { SessionActivityRegistry } from '@maka/runtime/goal-turn-lifecycle';
 import { ShellRunProcessManager } from '@maka/runtime/shell-run-manager';
+import { resolveShellPlan, validateShellPreference } from '@maka/runtime/shell-detect';
 import { type MakaTool } from '@maka/runtime/tool-runtime';
 import { type RuntimeHostedRootAuthority } from '@maka/runtime/message-authority';
 import {
@@ -303,6 +304,11 @@ export async function createExecutionRuntimeHostComposition(
       runtimePolicyStores,
       runtimePolicyActivation,
       applyRuntimePolicyMutationEffects,
+      async (input) => {
+        if (input.operation.kind === 'set_shell') {
+          await validateShellPreference(input.operation.value);
+        }
+      },
     );
     const sessionAdmission = new SessionAdmissionGate();
     const memoryExtractionLane = new MemoryExtractionSessionLane();
@@ -376,6 +382,8 @@ export async function createExecutionRuntimeHostComposition(
       sessionAdmission,
       acquireResidency: () => context.acquireResidency('runtime-resource'),
       requestDrain: context.requestDrain,
+      resolveShell: async () =>
+        resolveShellPlan((await runtimePolicyStores.runtimePolicy.getSnapshot()).policy.shell),
       onProjectionChanged: (update) =>
         requireContinuity(continuity).enqueueRuntimeResourceChanged(update),
     });
@@ -782,6 +790,7 @@ export async function createExecutionRuntimeHostComposition(
         const runProfile = hostedExecutionRunProfile(header.toolProfile);
         return createInteractiveRunComposer({
           runtimePolicy,
+          shell: resolveShellPlan(runtimePolicy.policy.shell),
           skills,
           memory: requireMemory(memory),
           taskLedger,
@@ -843,6 +852,7 @@ export async function createExecutionRuntimeHostComposition(
           });
           return createInteractiveRunComposer({
             runtimePolicy,
+            shell: resolveShellPlan(runtimePolicy.policy.shell),
             skills,
             memory: requireMemory(memory),
             taskLedger,
@@ -890,11 +900,20 @@ export async function createExecutionRuntimeHostComposition(
     sessionEffects = sessionEffectCoordinator;
     const resolveChildTools = async (sessionId: string): Promise<readonly MakaTool[]> => {
       const header = await stores.sessionStore.readHeader(sessionId);
+      const shell = resolveShellPlan(
+        (await runtimePolicyStores.runtimePolicy.getSnapshot()).policy.shell,
+      );
+      const childTools = createHostChildAgentToolComposition({
+        taskLedger,
+        builtinTools: { ...builtinTools, shell },
+        hostTools,
+        worktreePatchWriteBackAvailable: true,
+      }).childTools;
       const { surface } = await resolveInteractiveToolSurface({
         connectionSlug: header.llmConnectionSlug,
         modelId: header.model,
         hostTools: [],
-        childTools: childAgentTools.childTools,
+        childTools,
       });
       return surface.childTools ?? [];
     };

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -41,7 +41,11 @@ import {
 } from '@maka/runtime/agent-swarm-status-tool';
 import { SessionActivityRegistry } from '@maka/runtime/goal-turn-lifecycle';
 import { ShellRunProcessManager } from '@maka/runtime/shell-run-manager';
-import { resolveShellPlan, validateShellPreference } from '@maka/runtime/shell-detect';
+import {
+  resolveShellPlan,
+  resolveTurnShellPlan,
+  validateShellPreference,
+} from '@maka/runtime/shell-detect';
 import { type MakaTool } from '@maka/runtime/tool-runtime';
 import { type RuntimeHostedRootAuthority } from '@maka/runtime/message-authority';
 import {
@@ -790,7 +794,7 @@ export async function createExecutionRuntimeHostComposition(
         const runProfile = hostedExecutionRunProfile(header.toolProfile);
         return createInteractiveRunComposer({
           runtimePolicy,
-          shell: resolveShellPlan(runtimePolicy.policy.shell),
+          shell: resolveTurnShellPlan(runtimePolicy.policy.shell),
           skills,
           memory: requireMemory(memory),
           taskLedger,
@@ -852,7 +856,7 @@ export async function createExecutionRuntimeHostComposition(
           });
           return createInteractiveRunComposer({
             runtimePolicy,
-            shell: resolveShellPlan(runtimePolicy.policy.shell),
+            shell: resolveTurnShellPlan(runtimePolicy.policy.shell),
             skills,
             memory: requireMemory(memory),
             taskLedger,
@@ -900,7 +904,7 @@ export async function createExecutionRuntimeHostComposition(
     sessionEffects = sessionEffectCoordinator;
     const resolveChildTools = async (sessionId: string): Promise<readonly MakaTool[]> => {
       const header = await stores.sessionStore.readHeader(sessionId);
-      const shell = resolveShellPlan(
+      const shell = resolveTurnShellPlan(
         (await runtimePolicyStores.runtimePolicy.getSnapshot()).policy.shell,
       );
       const childTools = createHostChildAgentToolComposition({

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -902,7 +902,7 @@ export async function createExecutionRuntimeHostComposition(
       requestDrain: context.requestDrain,
     });
     sessionEffects = sessionEffectCoordinator;
-    const resolveChildTools = async (sessionId: string): Promise<readonly MakaTool[]> => {
+    const resolveChildTools = async (sessionId: string) => {
       const header = await stores.sessionStore.readHeader(sessionId);
       const shell = resolveTurnShellPlan(
         (await runtimePolicyStores.runtimePolicy.getSnapshot()).policy.shell,
@@ -919,7 +919,7 @@ export async function createExecutionRuntimeHostComposition(
         hostTools: [],
         childTools,
       });
-      return surface.childTools ?? [];
+      return { tools: surface.childTools ?? [], shell };
     };
     const subagentCatalog = createConfiguredSubagentCatalog({
       getPresets: async () =>

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -57,7 +57,11 @@ import { routeWebFetchTools } from '@maka/runtime/web-fetch-tool';
 import { routeWebSearchTools } from '@maka/runtime/native-web-search-tool';
 import { type MakaTool } from '@maka/runtime/tool-runtime';
 import { type ToolAvailabilityConfig, type ToolGroup } from '@maka/runtime/tool-availability';
-import { resolveShellPlan, type ShellPlan } from '@maka/runtime/shell-detect';
+import {
+  resolveTurnShellPlan,
+  type TurnShellPlan,
+  turnShellDisplayName,
+} from '@maka/runtime/shell-detect';
 import type {
   ClientCapabilitySnapshot,
   HostClientCapabilityCoordinator,
@@ -98,7 +102,13 @@ export interface InteractiveRunComposerInput {
   readonly toolProfile?: SessionToolProfile;
   readonly skillBudget?: SkillCatalogBudgetOptions;
   readonly platform?: NodeJS.Platform;
-  readonly shell?: ShellPlan;
+  /**
+   * Turn-scoped shell resolution captured at backend admission. One plan
+   * drives guidance and every Bash execution for the turn; a broken saved
+   * preference rides along as `setupError` so text-only turns still compose
+   * while the Bash/PTY boundary fails closed.
+   */
+  readonly shell?: TurnShellPlan;
   readonly now?: () => Date;
   readonly clientCapabilities?: Pick<ClientCapabilitySnapshot, 'tools' | 'groups'>;
   readonly builtinTools?: BuildBuiltinToolsOptions;
@@ -274,7 +284,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
         cwd: context.cwd,
         projectGit: await resolveProjectGitInfo(context.cwd),
         ...(input.platform ? { platform: input.platform } : {}),
-        ...(input.shell ? { shell: input.shell.displayName } : {}),
+        ...(input.shell ? { shell: turnShellDisplayName(input.shell) } : {}),
         ...(input.now ? { now: input.now() } : {}),
       });
       const tasks = filterModelVisibleTaskLedgerTasks(
@@ -389,7 +399,10 @@ export function createInteractiveRunComposerFactory(
   input: InteractiveRunComposerFactoryInput,
 ): HostRunComposerFactory {
   return async ({ backendContext, connection, modelId, runtimePolicy, contextWindow }) => {
-    const shell = resolveShellPlan(runtimePolicy.policy.shell);
+    // Turn admission: resolve the Host-owned plan once per backend. The
+    // captured setupError keeps a moved/uninstalled Git Bash scoped to the
+    // Bash/PTY boundary instead of failing text-only turns here.
+    const shell = resolveTurnShellPlan(runtimePolicy.policy.shell);
     const clientCapabilities = backendContext.tools
       ? undefined
       : input.clientCapabilities.snapshotForSession(backendContext.sessionId);

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -404,7 +404,9 @@ export function createInteractiveRunComposerFactory(
     // Turn admission: resolve the Host-owned plan once per backend. The
     // captured setupError keeps a moved/uninstalled Git Bash scoped to the
     // Bash/PTY boundary instead of failing text-only turns here.
-    const shell = (input.resolveTurnShellPlan ?? resolveTurnShellPlan)(runtimePolicy.policy.shell);
+    const shell =
+      (backendContext.tools ? backendContext.turnShellPlan : undefined) ??
+      (input.resolveTurnShellPlan ?? resolveTurnShellPlan)(runtimePolicy.policy.shell);
     const clientCapabilities = backendContext.tools
       ? undefined
       : input.clientCapabilities.snapshotForSession(backendContext.sessionId);

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -57,6 +57,7 @@ import { routeWebFetchTools } from '@maka/runtime/web-fetch-tool';
 import { routeWebSearchTools } from '@maka/runtime/native-web-search-tool';
 import { type MakaTool } from '@maka/runtime/tool-runtime';
 import { type ToolAvailabilityConfig, type ToolGroup } from '@maka/runtime/tool-availability';
+import { resolveShellPlan, type ShellPlan } from '@maka/runtime/shell-detect';
 import type {
   ClientCapabilitySnapshot,
   HostClientCapabilityCoordinator,
@@ -97,7 +98,7 @@ export interface InteractiveRunComposerInput {
   readonly toolProfile?: SessionToolProfile;
   readonly skillBudget?: SkillCatalogBudgetOptions;
   readonly platform?: NodeJS.Platform;
-  readonly shell?: string;
+  readonly shell?: ShellPlan;
   readonly now?: () => Date;
   readonly clientCapabilities?: Pick<ClientCapabilitySnapshot, 'tools' | 'groups'>;
   readonly builtinTools?: BuildBuiltinToolsOptions;
@@ -118,6 +119,10 @@ export interface InteractiveRunComposerInput {
 
 /** Composes one Interactive prompt and tool surface from canonical Host authorities. */
 export function createInteractiveRunComposer(input: InteractiveRunComposerInput): HostRunComposer {
+  const builtinTools =
+    input.builtinTools && input.shell
+      ? { ...input.builtinTools, shell: input.shell }
+      : input.builtinTools;
   const inventorySnapshotFor = createTurnSkillInventorySnapshotResolver(input.skills);
   const inventoryFor: SkillInventoryResolver = async (context) =>
     (await inventorySnapshotFor(context)).inventory;
@@ -129,7 +134,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
     : buildDefaultHostTools(
         input.taskLedger,
         inventoryFor,
-        input.builtinTools,
+        builtinTools,
         input.hostTools,
         input.scheduledTaskTool,
         input.goalTools,
@@ -269,7 +274,7 @@ export function createInteractiveRunComposer(input: InteractiveRunComposerInput)
         cwd: context.cwd,
         projectGit: await resolveProjectGitInfo(context.cwd),
         ...(input.platform ? { platform: input.platform } : {}),
-        ...(input.shell ? { shell: input.shell } : {}),
+        ...(input.shell ? { shell: input.shell.displayName } : {}),
         ...(input.now ? { now: input.now() } : {}),
       });
       const tasks = filterModelVisibleTaskLedgerTasks(
@@ -384,6 +389,7 @@ export function createInteractiveRunComposerFactory(
   input: InteractiveRunComposerFactoryInput,
 ): HostRunComposerFactory {
   return async ({ backendContext, connection, modelId, runtimePolicy, contextWindow }) => {
+    const shell = resolveShellPlan(runtimePolicy.policy.shell);
     const clientCapabilities = backendContext.tools
       ? undefined
       : input.clientCapabilities.snapshotForSession(backendContext.sessionId);
@@ -459,6 +465,7 @@ export function createInteractiveRunComposerFactory(
           ? { deepResearch: { tools: requireDeepResearchTools(input.deepResearchTools) } }
           : {}),
         skillBudget: contextWindow === null ? {} : { contextWindow },
+        shell,
       });
       return Object.freeze({
         ...composer,

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -338,6 +338,8 @@ export interface InteractiveRunComposerFactoryInput
   readonly worktreePatchWriteBackAvailable?: boolean;
   readonly planStore?: PlanStore;
   readonly deepResearchTools?: readonly MakaTool[];
+  /** Internal dependency seam for deterministic Host shell-resolution tests. */
+  readonly resolveTurnShellPlan?: typeof resolveTurnShellPlan;
 }
 
 export interface InteractiveRunToolSurfaceInput {
@@ -402,7 +404,7 @@ export function createInteractiveRunComposerFactory(
     // Turn admission: resolve the Host-owned plan once per backend. The
     // captured setupError keeps a moved/uninstalled Git Bash scoped to the
     // Bash/PTY boundary instead of failing text-only turns here.
-    const shell = resolveTurnShellPlan(runtimePolicy.policy.shell);
+    const shell = (input.resolveTurnShellPlan ?? resolveTurnShellPlan)(runtimePolicy.policy.shell);
     const clientCapabilities = backendContext.tools
       ? undefined
       : input.clientCapabilities.snapshotForSession(backendContext.sessionId);

--- a/packages/runtime-host/src/server/runtime-policy-coordinator.ts
+++ b/packages/runtime-host/src/server/runtime-policy-coordinator.ts
@@ -5,6 +5,7 @@ import type {
   CredentialLocator,
   CredentialStatus,
   MutateRuntimePolicyResult,
+  MutateRuntimePolicyInput,
   RuntimePolicySnapshot,
 } from '@maka/core/runtime-policy';
 import type { MakaTool } from '@maka/runtime/tool-runtime';
@@ -66,6 +67,10 @@ type StoreMutationOutcome<T> =
       };
     };
 
+export type RuntimePolicyMutationValidator = (
+  input: MutateRuntimePolicyInput,
+) => Promise<void> | void;
+
 /** Runtime Host control-plane projection over the authentic interactive policy stores. */
 export class HostRuntimePolicyCoordinator {
   readonly modelTools: readonly MakaTool[];
@@ -90,6 +95,7 @@ export class HostRuntimePolicyCoordinator {
     stores: RuntimePolicyStoresWriter,
     private readonly activation: RuntimePolicyActivationGate,
     private readonly onCommittedMutation: () => Promise<void> = async () => {},
+    private readonly validateMutation: RuntimePolicyMutationValidator = async () => {},
   ) {
     this.#stores = authenticateRuntimePolicyStoresWriter(stores);
     this.modelTools = buildHostAgentSettingsTools({
@@ -105,9 +111,18 @@ export class HostRuntimePolicyCoordinator {
   async #mutatePolicy(
     input: RuntimePolicyMutateInput,
   ): Promise<OperationOutcome<'runtime.policy.mutate'>> {
-    return this.#storeMutation(async () =>
-      projectPolicyMutation(await this.#stores.runtimePolicy.mutate(input)),
-    );
+    return this.#storeMutation(async () => {
+      try {
+        await this.validateMutation(input);
+      } catch (error) {
+        throw new RuntimePolicyStoreError(
+          'invalid_policy_input',
+          'Runtime policy mutation failed Host validation',
+          { cause: error },
+        );
+      }
+      return projectPolicyMutation(await this.#stores.runtimePolicy.mutate(input));
+    });
   }
 
   async #queryCatalog(

--- a/packages/runtime-host/src/server/runtime-resource-coordinator.ts
+++ b/packages/runtime-host/src/server/runtime-resource-coordinator.ts
@@ -13,7 +13,7 @@ import {
   isShellRunResourceRef,
 } from '@maka/runtime/shell-run-contract';
 import { type ShellRunLauncher } from '@maka/runtime/shell-tools';
-import { defaultShellPlan, type ShellPlan } from '@maka/runtime/shell-detect';
+import { defaultShellPlan, ShellPreferenceError, type ShellPlan } from '@maka/runtime/shell-detect';
 import { isSessionNotFoundError } from '@maka/storage/execution-stores';
 import {
   decodeRuntimeResourceControllerAcquireResult,
@@ -339,13 +339,18 @@ export class HostRuntimeResourceCoordinator
       const shell = await this.#resolveShell();
       const env = { ...process.env };
       let command: string;
-      if (shell.kind === 'posix' || shell.kind === 'git-bash' || shell.kind === 'legacy-wsl-bash') {
-        if (shell.kind === 'git-bash' || shell.kind === 'legacy-wsl-bash') {
-          env.SHELL = shell.exe;
-        } else {
-          env.SHELL ||=
-            userInfo().shell || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh');
-        }
+      if (shell.kind === 'git-bash') {
+        env.SHELL = shell.exe;
+        env.CHERE_INVOKING = '1';
+        env.DISABLE_AUTO_UPDATE = 'true';
+        env.DISABLE_UPDATE_PROMPT = 'true';
+        command = 'exec "$SHELL" -l';
+      } else if (shell.kind === 'legacy-wsl-bash') {
+        env.DISABLE_AUTO_UPDATE = 'true';
+        env.DISABLE_UPDATE_PROMPT = 'true';
+        command = 'exec bash -l';
+      } else if (shell.kind === 'posix') {
+        env.SHELL ||= userInfo().shell || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh');
         env.DISABLE_AUTO_UPDATE = 'true';
         env.DISABLE_UPDATE_PROMPT = 'true';
         command = 'exec "$SHELL" -l';
@@ -375,6 +380,12 @@ export class HostRuntimeResourceCoordinator
         }),
       };
     } catch (error) {
+      if (error instanceof ShellPreferenceError) {
+        return mutationFailure('runtime.resource.start', {
+          code: 'invalid_request',
+          message: error.message,
+        });
+      }
       return this.#resourceFailure('runtime.resource.start', error);
     }
   }

--- a/packages/runtime-host/src/server/runtime-resource-coordinator.ts
+++ b/packages/runtime-host/src/server/runtime-resource-coordinator.ts
@@ -81,6 +81,12 @@ export interface HostRuntimeResourceCoordinatorInput {
   readonly acquireResidency: () => RuntimeHostResidency;
   readonly requestDrain: () => void;
   readonly onProjectionChanged?: (update: ShellRunUpdate) => void;
+  /**
+   * Fallback shell resolution for callers that do not carry a plan (e.g.
+   * integrated terminal launches, which capture their plan at launch). A
+   * caller-supplied plan — the turn's admission-time resolution — always
+   * wins, so a mid-turn settings change cannot split guidance from execution.
+   */
   readonly resolveShell?: () => Promise<ShellPlan> | ShellPlan;
 }
 
@@ -148,7 +154,7 @@ export class HostRuntimeResourceCoordinator
         if (this.#draining) throw new Error('Runtime resources are draining');
         await this.#assertActiveSession(input.sessionId);
         if (this.#draining) throw new Error('Runtime resources are draining');
-        const shell = await this.#resolveShell();
+        const shell = input.shell ?? (await this.#resolveShell());
         if (this.#draining) throw new Error('Runtime resources are draining');
         return { execution: this.#manager.runForegroundBash({ ...input, shell }) };
       });
@@ -178,7 +184,7 @@ export class HostRuntimeResourceCoordinator
         if (this.#draining) throw new Error('Runtime resources are draining');
         await this.#assertActiveSession(input.sessionId);
         if (this.#draining) throw new Error('Runtime resources are draining');
-        const shell = await this.#resolveShell();
+        const shell = input.shell ?? (await this.#resolveShell());
         if (this.#draining) throw new Error('Runtime resources are draining');
         return this.#manager.runBackgroundBash({ ...input, shell, onCompletion: complete });
       });

--- a/packages/runtime-host/src/server/runtime-resource-coordinator.ts
+++ b/packages/runtime-host/src/server/runtime-resource-coordinator.ts
@@ -13,7 +13,7 @@ import {
   isShellRunResourceRef,
 } from '@maka/runtime/shell-run-contract';
 import { type ShellRunLauncher } from '@maka/runtime/shell-tools';
-import { defaultShellPlan } from '@maka/runtime/shell-detect';
+import { defaultShellPlan, type ShellPlan } from '@maka/runtime/shell-detect';
 import { isSessionNotFoundError } from '@maka/storage/execution-stores';
 import {
   decodeRuntimeResourceControllerAcquireResult,
@@ -81,6 +81,7 @@ export interface HostRuntimeResourceCoordinatorInput {
   readonly acquireResidency: () => RuntimeHostResidency;
   readonly requestDrain: () => void;
   readonly onProjectionChanged?: (update: ShellRunUpdate) => void;
+  readonly resolveShell?: () => Promise<ShellPlan> | ShellPlan;
 }
 
 interface ControllerState {
@@ -118,6 +119,7 @@ export class HostRuntimeResourceCoordinator
   readonly #acquireResidency: () => RuntimeHostResidency;
   readonly #requestDrain: () => void;
   readonly #onProjectionChanged: (update: ShellRunUpdate) => void;
+  readonly #resolveShell: () => Promise<ShellPlan> | ShellPlan;
   readonly #resourceQueue = new ResourceSerialQueue();
   readonly #controllers = new Map<string, ControllerState>();
   readonly #controllerResources = new Map<string, string>();
@@ -133,6 +135,7 @@ export class HostRuntimeResourceCoordinator
     this.#acquireResidency = input.acquireResidency;
     this.#requestDrain = input.requestDrain;
     this.#onProjectionChanged = input.onProjectionChanged ?? (() => undefined);
+    this.#resolveShell = input.resolveShell ?? defaultShellPlan;
   }
 
   async runForegroundBash(
@@ -145,7 +148,9 @@ export class HostRuntimeResourceCoordinator
         if (this.#draining) throw new Error('Runtime resources are draining');
         await this.#assertActiveSession(input.sessionId);
         if (this.#draining) throw new Error('Runtime resources are draining');
-        return { execution: this.#manager.runForegroundBash(input) };
+        const shell = await this.#resolveShell();
+        if (this.#draining) throw new Error('Runtime resources are draining');
+        return { execution: this.#manager.runForegroundBash({ ...input, shell }) };
       });
       return await execution;
     } finally {
@@ -170,8 +175,12 @@ export class HostRuntimeResourceCoordinator
     };
     try {
       return await this.#sessionAdmission.run(input.sessionId, async () => {
+        if (this.#draining) throw new Error('Runtime resources are draining');
         await this.#assertActiveSession(input.sessionId);
-        return this.#manager.runBackgroundBash({ ...input, onCompletion: complete });
+        if (this.#draining) throw new Error('Runtime resources are draining');
+        const shell = await this.#resolveShell();
+        if (this.#draining) throw new Error('Runtime resources are draining');
+        return this.#manager.runBackgroundBash({ ...input, shell, onCompletion: complete });
       });
     } catch (error) {
       complete({ successful: false });
@@ -327,11 +336,16 @@ export class HostRuntimeResourceCoordinator
     if (unavailable) return mutationFailure('runtime.resource.start', unavailable);
     try {
       const header = await this.#sessionHeaders.readHeader(input.sessionId);
-      const shell = defaultShellPlan();
+      const shell = await this.#resolveShell();
       const env = { ...process.env };
       let command: string;
-      if (shell.kind === 'posix') {
-        env.SHELL ||= userInfo().shell || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh');
+      if (shell.kind === 'posix' || shell.kind === 'git-bash' || shell.kind === 'legacy-wsl-bash') {
+        if (shell.kind === 'git-bash' || shell.kind === 'legacy-wsl-bash') {
+          env.SHELL = shell.exe;
+        } else {
+          env.SHELL ||=
+            userInfo().shell || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/sh');
+        }
         env.DISABLE_AUTO_UPDATE = 'true';
         env.DISABLE_UPDATE_PROMPT = 'true';
         command = 'exec "$SHELL" -l';

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -255,7 +255,7 @@ describe('builtin Bash projection and shell execution', () => {
     // executor's spawn, stdout echoes the PowerShell flags and wrapper instead
     // of a bare 'wired-marker' from the default POSIX shell.
     const tools = buildBuiltinTools({
-      shell: { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: '/bin/echo' },
+      shell: { plan: { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: '/bin/echo' } },
     });
     const bash = tools.find((tool) => tool.name === 'Bash')!;
     const result = (await bash.impl(

--- a/packages/runtime/src/__tests__/pipe-process-driver.test.ts
+++ b/packages/runtime/src/__tests__/pipe-process-driver.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { PipeProcessDriver, type PipeProcessExit } from '../pipe-process-driver.js';
+
+test('reports a partial stdin delivery failure before the child exit', async () => {
+  const failures: Error[] = [];
+  const events: string[] = [];
+  let resolveExit!: (exit: PipeProcessExit) => void;
+  const exited = new Promise<PipeProcessExit>((resolve) => {
+    resolveExit = resolve;
+  });
+  const driver = new PipeProcessDriver({
+    plan: {
+      file: process.execPath,
+      args: [
+        '-e',
+        [
+          "const fs = require('node:fs');",
+          'fs.closeSync(0);',
+          'setTimeout(() => process.exit(0), 50);',
+        ].join(' '),
+      ],
+      useShellOption: false,
+      stdin: 'x'.repeat(8 * 1024 * 1024),
+    },
+    cwd: process.cwd(),
+    outputDrainMs: 1_000,
+    onData() {},
+    onRootExit() {},
+    onFailure(error) {
+      events.push('failure');
+      failures.push(error);
+    },
+    onExit(exit) {
+      events.push('exit');
+      resolveExit(exit);
+    },
+  });
+
+  try {
+    driver.writeInputs();
+    await driver.ready;
+    const exit = await exited;
+    assert.equal(exit.exitCode, 0);
+    assert.equal(failures.length, 1);
+    assert.match(String((failures[0] as NodeJS.ErrnoException).code), /EPIPE|ERR_STREAM_DESTROYED/);
+    assert.deepEqual(events, ['failure', 'exit']);
+  } finally {
+    driver.dispose();
+  }
+});

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -9959,8 +9959,9 @@ describe('SessionManager permission mode updates', () => {
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
     const sendInputs: BackendSendInput[] = [];
+    const contexts: BackendFactoryContext[] = [];
     let childAttempt = 0;
-    backends.register('fake', (ctx) => ({
+    const createBackend = (ctx: BackendFactoryContext) => ({
       kind: 'fake' as const,
       sessionId: ctx.sessionId,
       async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
@@ -10004,13 +10005,47 @@ describe('SessionManager permission mode updates', () => {
       async stop(): Promise<void> {},
       async respondToSandboxBoundary(): Promise<void> {},
       async dispose(): Promise<void> {},
-    }));
+    });
+    backends.register('fake', (ctx) => {
+      contexts.push(ctx);
+      return createBackend(ctx);
+    });
+    const retryResolutionStarted = makeGate();
+    const releaseRetryResolution = makeGate();
+    const policyGate = makeTestRuntimePolicyGate();
+    let activationDepth = 0;
+    let holdRetryActivation = false;
+    let shellRevision = 'A';
     const manager = new SessionManager({
       store,
       runStore,
       runtimeEventStore: runStore,
       backends,
-      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      resolveChildTools: async () => {
+        const capturedRevision = shellRevision;
+        if (holdRetryActivation && activationDepth > 0) {
+          retryResolutionStarted.release();
+          await releaseRetryResolution.promise;
+        }
+        return {
+          tools: ['Read', 'Glob', 'Grep'].map((name) => ({
+            ...testTool(name),
+            description: `${name} retry shell ${capturedRevision}`,
+          })),
+          shell: {
+            plan: { kind: 'posix', displayName: `retry shell ${capturedRevision}` },
+          },
+        };
+      },
+      runBackendActivation: (operation) =>
+        policyGate.runBackendActivation(async () => {
+          activationDepth += 1;
+          try {
+            return await operation();
+          } finally {
+            activationDepth -= 1;
+          }
+        }),
       inspectContinuationSafety: async () => ({
         workspaceIdentity: '/tmp/cwd',
         backgroundOperationsSettled: true,
@@ -10087,13 +10122,27 @@ describe('SessionManager permission mode updates', () => {
     expect(sendInputs).toHaveLength(2);
     expect(abortedRetryReady).toBe(0);
 
-    const retried = await manager.retryChildAgent(session.id, {
+    holdRetryActivation = true;
+    const retriedPromise = manager.retryChildAgent(session.id, {
       parentRunId: parentRun.runId,
       sourceRunId: second.runId,
     });
+    await retryResolutionStarted.promise;
+    let mutationApplied = false;
+    const mutation = policyGate.runMutation(async () => {
+      shellRevision = 'B';
+      mutationApplied = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(mutationApplied).toBe(false);
+    releaseRetryResolution.release();
+    const retried = await retriedPromise;
+    await mutation;
 
     expect(retried.status).toBe('completed');
     expect(retried.retriedFromRunId).toBe(second.runId);
+    expect(contexts.at(-1)?.turnShellPlan?.plan.displayName).toBe('retry shell A');
+    expect(contexts.at(-1)?.tools?.[0]?.description).toMatch(/retry shell A/);
     expect(sendInputs.map((input) => input.text)).toEqual([
       'inspect auth',
       'retry with additional guidance',
@@ -10334,10 +10383,12 @@ describe('SessionManager permission mode updates', () => {
       backends,
       resolveChildTools: async () => {
         resolutions += 1;
-        return ['Read', 'Glob', 'Grep'].map((name) => ({
-          ...testTool(name),
-          description: `${name} turn-scoped toolset ${resolutions}`,
-        }));
+        return {
+          tools: ['Read', 'Glob', 'Grep'].map((name) => ({
+            ...testTool(name),
+            description: `${name} turn-scoped toolset ${resolutions}`,
+          })),
+        };
       },
       newId: nextId(),
       now: nextNow(6_851),
@@ -10356,6 +10407,71 @@ describe('SessionManager permission mode updates', () => {
 
     assert.equal(resolutions, 1);
     assert.match(contexts[1]?.tools?.[0]?.description ?? '', /turn-scoped toolset/);
+  });
+
+  test('captures child tools and shell plan inside one backend activation snapshot', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const contexts: BackendFactoryContext[] = [];
+    backends.register('fake', (ctx) => {
+      contexts.push(ctx);
+      return new TestBackend(ctx);
+    });
+    const resolutionStarted = makeGate();
+    const releaseResolution = makeGate();
+    const { runBackendActivation, runMutation } = makeTestRuntimePolicyGate();
+    let shellRevision = 'A';
+    let mutationApplied = false;
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      resolveChildTools: async () => {
+        const capturedRevision = shellRevision;
+        resolutionStarted.release();
+        await releaseResolution.promise;
+        return {
+          tools: ['Read', 'Glob', 'Grep'].map((name) => ({
+            ...testTool(name),
+            description: `${name} shell snapshot ${capturedRevision}`,
+          })),
+          shell: {
+            plan: { kind: 'posix', displayName: `shell ${capturedRevision}` },
+          },
+        };
+      },
+      runBackendActivation,
+      newId: nextId(),
+      now: nextNow(6_852),
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    await drain(manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'parent context' }));
+    const [parentRun] = await runStore.listSessionRuns(session.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    const childTurn = manager.spawnChildAgent(session.id, {
+      turnId: 'child-turn',
+      parentRunId: parentRun.runId,
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Reader', systemPrompt: 'read only' },
+      prompt: 'inspect',
+    });
+    await resolutionStarted.promise;
+    const mutation = runMutation(async () => {
+      shellRevision = 'B';
+      mutationApplied = true;
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(mutationApplied).toBe(false);
+
+    releaseResolution.release();
+    await childTurn;
+    await mutation;
+
+    expect(contexts[1]?.turnShellPlan?.plan.displayName).toBe('shell A');
+    expect(contexts[1]?.tools?.[0]?.description).toMatch(/shell snapshot A/);
+    expect(shellRevision).toBe('B');
   });
 
   test('spawnChildAgent returns the terminal RuntimeEvent status when the child header commit fails', async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -10317,6 +10317,47 @@ describe('SessionManager permission mode updates', () => {
     expect(capabilities[1]?.allowMidTurnHistoryCompaction).toBe(false);
   });
 
+  test('resolves the child execution toolset at activation time', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const contexts: BackendFactoryContext[] = [];
+    backends.register('fake', (ctx) => {
+      contexts.push(ctx);
+      return new TestBackend(ctx);
+    });
+    let resolutions = 0;
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      resolveChildTools: async () => {
+        resolutions += 1;
+        return ['Read', 'Glob', 'Grep'].map((name) => ({
+          ...testTool(name),
+          description: `${name} turn-scoped toolset ${resolutions}`,
+        }));
+      },
+      newId: nextId(),
+      now: nextNow(6_851),
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    await drain(manager.sendMessage(session.id, { turnId: 'parent-turn', text: 'parent context' }));
+    const [parentRun] = await runStore.listSessionRuns(session.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    await manager.spawnChildAgent(session.id, {
+      turnId: 'child-turn',
+      parentRunId: parentRun.runId,
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Reader', systemPrompt: 'read only' },
+      prompt: 'inspect',
+    });
+
+    assert.equal(resolutions, 1);
+    assert.match(contexts[1]?.tools?.[0]?.description ?? '', /turn-scoped toolset/);
+  });
+
   test('spawnChildAgent returns the terminal RuntimeEvent status when the child header commit fails', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore({ failUpdateRunStatusOnce: 'completed' });

--- a/packages/runtime/src/__tests__/shell-detect.test.ts
+++ b/packages/runtime/src/__tests__/shell-detect.test.ts
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { buildPtyShellSpawnPlan, buildShellSpawnPlan, detectShell } from '../shell-detect.js';
+import {
+  buildPtyShellSpawnPlan,
+  buildShellSpawnPlan,
+  detectShell,
+  resolveShellPlan,
+  ShellPreferenceError,
+  validateShellPreference,
+} from '../shell-detect.js';
 
 const winEnv = (over: Record<string, string> = {}) => ({
   Path: 'C:\\Windows\\System32;C:\\Users\\u\\bin',
@@ -59,7 +66,136 @@ describe('detectShell', () => {
   });
 });
 
+describe('resolveShellPlan', () => {
+  const executable = 'C:\\Program Files\\Git\\bin\\bash.exe';
+
+  test('keeps automatic detection unchanged when no override is selected', () => {
+    const plan = resolveShellPlan(
+      { preference: 'auto', executable },
+      {
+        platform: 'win32',
+        env: winEnv(),
+        fileExists: existsIn('C:\\Program Files\\PowerShell\\7\\pwsh.exe'),
+      },
+    );
+    assert.equal(plan.kind, 'pwsh');
+  });
+
+  test('resolves an existing absolute bash.exe on the Windows Host', () => {
+    assert.deepEqual(
+      resolveShellPlan(
+        { preference: 'git_bash', executable },
+        { platform: 'win32', fileExists: existsIn(executable) },
+      ),
+      { kind: 'git-bash', displayName: 'Git Bash', exe: executable },
+    );
+  });
+
+  test('recognizes the legacy System32 WSL shim as a distinct Bash plan', () => {
+    const executable = 'C:\\Windows\\System32\\bash.exe';
+    assert.deepEqual(
+      resolveShellPlan(
+        { preference: 'git_bash', executable },
+        { platform: 'win32', env: winEnv(), fileExists: existsIn(executable) },
+      ),
+      { kind: 'legacy-wsl-bash', displayName: 'Legacy WSL Bash', exe: executable },
+    );
+  });
+
+  test('fails closed for another platform, a relative path, or a missing executable', () => {
+    for (const run of [
+      () =>
+        resolveShellPlan(
+          { preference: 'git_bash', executable },
+          { platform: 'linux', fileExists: existsIn(executable) },
+        ),
+      () =>
+        resolveShellPlan(
+          { preference: 'git_bash', executable: '.\\bash.exe' },
+          { platform: 'win32', fileExists: () => true },
+        ),
+      () =>
+        resolveShellPlan(
+          { preference: 'git_bash', executable },
+          { platform: 'win32', fileExists: () => false },
+        ),
+    ]) {
+      assert.throws(run, ShellPreferenceError);
+    }
+  });
+
+  test('probes GNU Bash identity before accepting the preference', async () => {
+    const settings = { preference: 'git_bash' as const, executable };
+    const plan = await validateShellPreference(settings, {
+      platform: 'win32',
+      fileExists: existsIn(executable),
+      probeVersion: async () => 'GNU bash, version 5.2.37(1)-release',
+    });
+    assert.equal(plan.kind, 'git-bash');
+    await assert.rejects(
+      validateShellPreference(settings, {
+        platform: 'win32',
+        fileExists: existsIn(executable),
+        probeVersion: async () => 'not a shell',
+      }),
+      (error: unknown) => error instanceof ShellPreferenceError && error.code === 'not_bash',
+    );
+  });
+});
+
 describe('buildShellSpawnPlan', () => {
+  test('spawns an explicit Git Bash executable with POSIX command syntax', () => {
+    assert.deepEqual(
+      buildShellSpawnPlan(
+        {
+          kind: 'git-bash',
+          displayName: 'Git Bash',
+          exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+        },
+        'printf "%s\\n" ready',
+      ),
+      {
+        file: 'C:\\Program Files\\Git\\bin\\bash.exe',
+        args: ['-c', 'printf "%s\\n" ready'],
+        useShellOption: false,
+      },
+    );
+  });
+
+  test('feeds the legacy WSL shim through stdin instead of quoting a command argument', () => {
+    assert.deepEqual(
+      buildShellSpawnPlan(
+        {
+          kind: 'legacy-wsl-bash',
+          displayName: 'Legacy WSL Bash',
+          exe: 'C:\\Windows\\System32\\bash.exe',
+        },
+        'printf "%s\\n" ready',
+      ),
+      {
+        file: 'C:\\Windows\\System32\\bash.exe',
+        args: ['-s'],
+        useShellOption: false,
+        stdin: 'printf "%s\\n" ready\n',
+      },
+    );
+  });
+
+  test('never falls back to the platform shell for a malformed explicit Bash plan', () => {
+    assert.throws(
+      () => buildShellSpawnPlan({ kind: 'git-bash', displayName: 'Git Bash' }, 'echo unsafe'),
+      /missing its executable/,
+    );
+    assert.throws(
+      () =>
+        buildPtyShellSpawnPlan(
+          { kind: 'legacy-wsl-bash', displayName: 'Legacy WSL Bash' },
+          'echo unsafe',
+        ),
+      /missing its executable/,
+    );
+  });
+
   test('spawns PowerShell explicitly and preserves the command in an isolated script block', () => {
     const command = "using namespace System.Text\nWrite-Output '$HOME'";
     const spawnPlan = buildShellSpawnPlan(
@@ -160,6 +296,35 @@ describe('buildPtyShellSpawnPlan', () => {
     assert.equal(powershell.env?.INHERITED, 'kept');
     assert.ok(
       powershell.env?.__MAKA_RUNTIME_POWERSHELL_COMMAND?.startsWith('Write-Output ready\n'),
+    );
+
+    assert.deepEqual(
+      buildPtyShellSpawnPlan(
+        {
+          kind: 'git-bash',
+          displayName: 'Git Bash',
+          exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+        },
+        'exec bash -l',
+      ),
+      {
+        file: 'C:\\Program Files\\Git\\bin\\bash.exe',
+        args: ['-c', 'exec bash -l'],
+      },
+    );
+    assert.deepEqual(
+      buildPtyShellSpawnPlan(
+        {
+          kind: 'legacy-wsl-bash',
+          displayName: 'Legacy WSL Bash',
+          exe: 'C:\\Windows\\System32\\bash.exe',
+        },
+        'exec bash -l',
+      ),
+      {
+        file: 'C:\\Windows\\System32\\bash.exe',
+        args: ['-c', 'exec bash -l'],
+      },
     );
   });
 });

--- a/packages/runtime/src/__tests__/shell-detect.test.ts
+++ b/packages/runtime/src/__tests__/shell-detect.test.ts
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
+  bashToolTurnShellGuidance,
   buildPtyShellSpawnPlan,
   buildShellSpawnPlan,
   detectShell,
   resolveShellPlan,
+  resolveTurnShellPlan,
   ShellPreferenceError,
+  throwIfShellSetupFailed,
+  turnShellDisplayName,
   validateShellPreference,
 } from '../shell-detect.js';
 
@@ -140,6 +144,74 @@ describe('resolveShellPlan', () => {
       }),
       (error: unknown) => error instanceof ShellPreferenceError && error.code === 'not_bash',
     );
+  });
+});
+
+describe('resolveTurnShellPlan', () => {
+  const executable = 'C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe';
+
+  test('resolves a healthy explicit preference into a ready plan', () => {
+    const shell = resolveTurnShellPlan(
+      { preference: 'git_bash', executable },
+      { platform: 'win32', fileExists: existsIn(executable) },
+    );
+    assert.deepEqual(shell, {
+      plan: { kind: 'git-bash', displayName: 'Git Bash', exe: executable },
+    });
+    assert.equal(shell.setupError, undefined);
+  });
+
+  test('captures a moved or uninstalled executable instead of throwing at turn admission', () => {
+    const shell = resolveTurnShellPlan(
+      { preference: 'git_bash', executable },
+      { platform: 'win32', fileExists: () => false },
+    );
+    assert.ok(shell.setupError instanceof ShellPreferenceError);
+    assert.equal(shell.setupError.code, 'executable_missing');
+    // The fallback plan exists only so guidance surfaces still have a shape;
+    // execution never reaches it (throwIfShellSetupFailed gates the boundary).
+    assert.equal(shell.plan, resolveTurnShellPlan({ preference: 'auto', executable }).plan);
+  });
+
+  test('keeps automatic detection error-free', () => {
+    const shell = resolveTurnShellPlan(
+      { preference: 'auto', executable: '' },
+      { platform: 'darwin', env: {}, fileExists: () => false },
+    );
+    assert.equal(shell.plan.kind, 'posix');
+    assert.equal(shell.setupError, undefined);
+  });
+
+  test('fails closed at the Bash boundary without falling back to another shell', () => {
+    const broken = resolveTurnShellPlan(
+      { preference: 'git_bash', executable },
+      { platform: 'win32', fileExists: () => false },
+    );
+    assert.throws(() => throwIfShellSetupFailed(broken), ShellPreferenceError);
+    const healthy = resolveTurnShellPlan(
+      { preference: 'git_bash', executable },
+      { platform: 'win32', fileExists: existsIn(executable) },
+    );
+    throwIfShellSetupFailed(healthy);
+  });
+
+  test('declares the outage to the model instead of naming a shell that cannot run', () => {
+    const broken = resolveTurnShellPlan(
+      { preference: 'git_bash', executable },
+      { platform: 'win32', fileExists: () => false },
+    );
+    const guidance = bashToolTurnShellGuidance(broken);
+    assert.match(guidance, /unavailable this turn/);
+    assert.match(guidance, /not found/i);
+    assert.doesNotMatch(guidance, /write POSIX shell syntax/);
+    assert.match(turnShellDisplayName(broken), /Unavailable/);
+
+    const healthy = resolveTurnShellPlan(
+      { preference: 'git_bash', executable },
+      { platform: 'win32', fileExists: existsIn(executable) },
+    );
+    assert.match(bashToolTurnShellGuidance(healthy), /write POSIX shell syntax/);
+    assert.equal(turnShellDisplayName(healthy), 'Git Bash');
   });
 });
 

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -52,6 +52,17 @@ function findPwsh(): string | undefined {
 }
 
 describe('runShellWithBoundedTail', () => {
+  test('writes a legacy WSL Bash command through stdin', {
+    skip: process.platform === 'win32' ? 'uses /bin/sh as a portable stdin probe' : false,
+  }, async () => {
+    const result = await runShellWithBoundedTail(
+      "printf 'legacy-stdin-ready\\n'",
+      base({ shell: { kind: 'legacy-wsl-bash', displayName: 'Legacy WSL Bash', exe: '/bin/sh' } }),
+    );
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, 'legacy-stdin-ready\n');
+  });
+
   test('keeps only the bounded, line-aligned TAIL of large output (never killed by size)', async () => {
     const r = await runShellWithBoundedTail(
       "printf 'HEADMARK\\n'; seq 1 50; printf 'TAILMARK\\n'",

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -29,6 +29,7 @@ import { PTY_PROTOCOL_REPLY_MAX_BYTES } from '../pty-screen-collector.js';
 
 const NO_ABORT = new AbortController().signal;
 const TEMPORARY_WORKSPACES = new Set<string>();
+const REAL_WINDOWS_GIT_BASH = windowsGitBashPlan();
 
 after(async () => {
   await Promise.all(
@@ -118,10 +119,15 @@ describe('ShellRunProcessManager', () => {
   });
 
   test('preserves the requested cwd through a real Git Bash login PTY', {
-    skip: process.platform === 'win32' ? false : 'Git Bash PTY regression',
+    skip:
+      process.platform !== 'win32'
+        ? 'Git Bash PTY regression'
+        : REAL_WINDOWS_GIT_BASH
+          ? false
+          : 'Git Bash is not installed on this Windows runner',
   }, async () => {
-    const shell = windowsGitBashPlan();
-    assert.ok(shell, 'Git Bash must exist on the Windows baseline runner');
+    const shell = REAL_WINDOWS_GIT_BASH;
+    assert.ok(shell, 'the test skip requires a discovered Git Bash plan');
     const cwd = await workspace();
     await writeFile(join(cwd, 'maka-cwd-marker'), 'expected workspace', 'utf8');
     const manager = await createTestManager();

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -117,6 +117,53 @@ describe('ShellRunProcessManager', () => {
     assert.doesNotMatch(result.output.stdout, /\uFFFD/u);
   });
 
+  test('preserves the requested cwd through a real Git Bash login PTY', {
+    skip: process.platform === 'win32' ? false : 'Git Bash PTY regression',
+  }, async () => {
+    const shell = windowsGitBashPlan();
+    assert.ok(shell, 'Git Bash must exist on the Windows baseline runner');
+    const cwd = await workspace();
+    await writeFile(join(cwd, 'maka-cwd-marker'), 'expected workspace', 'utf8');
+    const manager = await createTestManager();
+    const initial = await manager.runBackgroundBash(
+      shellInput({
+        cwd,
+        command: 'exec "$SHELL" -l',
+        env: {
+          ...process.env,
+          SHELL: shell.exe,
+          CHERE_INVOKING: '1',
+          DISABLE_AUTO_UPDATE: 'true',
+          DISABLE_UPDATE_PROMPT: 'true',
+        },
+        shell,
+        pty: true,
+        timeoutMs: 10_000,
+      }),
+    );
+    assert.equal(initial.kind, 'shell_run');
+
+    await manager.writeStdin({
+      sessionId: 'session-1',
+      ref: initial.ref,
+      input: "test -f maka-cwd-marker && printf 'MAKA_CWD_OK\\n'\r",
+      abortSignal: NO_ABORT,
+    });
+    const observed = await waitForPtyText(manager, initial.ref, /MAKA_CWD_OK/u, 10_000);
+    assert.equal(observed.output?.mode, 'pty');
+    if (observed.output?.mode !== 'pty') throw new Error('expected pty output');
+    assert.match(terminalText(observed.output), /MAKA_CWD_OK/u);
+
+    await manager.writeStdin({
+      sessionId: 'session-1',
+      ref: initial.ref,
+      input: 'exit\r',
+      abortSignal: NO_ABORT,
+    });
+    const completed = await waitForTerminalShellRun(manager, initial.ref, 10_000);
+    assert.equal(completed.status, 'completed');
+  });
+
   test('uses the shared explicit PowerShell pipe plan', async () => {
     const manager = await createTestManager();
     const result = await manager.runForegroundBash(
@@ -2768,6 +2815,18 @@ function windowsPowerShellPlan(): ShellPlan | undefined {
   );
   if (!existsSync(executable)) return undefined;
   return { kind: 'powershell', displayName: 'Windows PowerShell 5.1', exe: executable };
+}
+
+function windowsGitBashPlan(): ShellPlan | undefined {
+  if (process.platform !== 'win32') return undefined;
+  const executable = join(
+    process.env.ProgramFiles ?? 'C:\\Program Files',
+    'Git',
+    'bin',
+    'bash.exe',
+  );
+  if (!existsSync(executable)) return undefined;
+  return { kind: 'git-bash', displayName: 'Git Bash', exe: executable };
 }
 
 function record(input: { shellRunId: string; status: ShellRunRecord['status'] }): ShellRunRecord {

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -7,6 +7,7 @@ import {
   type ShellRunLauncher,
 } from '../shell-tools.js';
 import type { ShellPlan } from '../shell-detect.js';
+import { ShellPreferenceError } from '../shell-detect.js';
 
 const pwshPlan: ShellPlan = {
   kind: 'pwsh',
@@ -17,14 +18,60 @@ const pwshPlan: ShellPlan = {
 test('an explicit Git Bash tool declares POSIX syntax', () => {
   const tool = buildLocalForegroundBashTool({
     shell: {
-      kind: 'git-bash',
-      displayName: 'Git Bash',
-      exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+      plan: {
+        kind: 'git-bash',
+        displayName: 'Git Bash',
+        exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+      },
     },
   });
   assert.match(tool.description, /Git Bash/);
   assert.match(tool.description, /POSIX shell syntax/);
   assert.doesNotMatch(tool.description, /write PowerShell syntax/);
+});
+
+describe('Bash tool fails closed when the turn shell plan carries a setup error', () => {
+  const brokenShell = {
+    plan: { kind: 'cmd', displayName: 'cmd.exe' } as ShellPlan,
+    setupError: new ShellPreferenceError(
+      'executable_missing',
+      'The configured Git Bash was not found',
+    ),
+  };
+
+  test('description declares the outage instead of dialect guidance', () => {
+    const tool = buildLocalForegroundBashTool({ shell: brokenShell });
+    assert.match(tool.description, /unavailable this turn/);
+    assert.doesNotMatch(tool.description, /write cmd syntax/);
+  });
+
+  test('local foreground execution throws the setup error before spawning', async () => {
+    const tool = buildLocalForegroundBashTool({ shell: brokenShell });
+    await assert.rejects(
+      async () => {
+        await tool.impl({ command: 'echo never-runs' }, fakeToolContext());
+      },
+      (error: unknown) => {
+        assert.ok(error instanceof ShellPreferenceError);
+        assert.equal(error.code, 'executable_missing');
+        return true;
+      },
+    );
+  });
+
+  test('managed execution throws before any shell-run reaches the host', async () => {
+    const controller: ShellRunLauncher = {
+      runForegroundBash: () => Promise.reject(new Error('must not be called')),
+      runBackgroundBash: () => Promise.reject(new Error('must not be called')),
+    };
+    const tool = buildManagedBashTool(controller, { shell: brokenShell });
+    await assert.rejects(async () => {
+      await tool.impl({ command: 'echo never-runs' }, fakeToolContext());
+    }, ShellPreferenceError);
+    await assert.rejects(async () => {
+      await tool.impl({ command: 'echo never-runs', run_in_background: true }, fakeToolContext());
+    }, ShellPreferenceError);
+  });
 });
 
 describe('Bash tool shell is threaded through to execution, not just the description', () => {
@@ -34,7 +81,7 @@ describe('Bash tool shell is threaded through to execution, not just the descrip
     // reached the description would run via the default POSIX shell and
     // print a bare 'wired-marker'.
     const tool = buildLocalForegroundBashTool({
-      shell: { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: '/bin/echo' },
+      shell: { plan: { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: '/bin/echo' } },
     });
     const result = (await tool.impl({ command: 'echo wired-marker' }, fakeToolContext())) as {
       output: { stdout: string };
@@ -66,7 +113,7 @@ describe('Bash tool shell is threaded through to execution, not just the descrip
         });
       },
     };
-    const tool = buildManagedBashTool(controller, { shell: pwshPlan });
+    const tool = buildManagedBashTool(controller, { shell: { plan: pwshPlan } });
     await tool.impl({ command: 'echo hi', run_in_background: true }, fakeToolContext());
     assert.deepEqual((captured[0] as { shell?: unknown }).shell, pwshPlan);
   });

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -14,6 +14,19 @@ const pwshPlan: ShellPlan = {
   exe: 'C:\\pf\\pwsh.exe',
 };
 
+test('an explicit Git Bash tool declares POSIX syntax', () => {
+  const tool = buildLocalForegroundBashTool({
+    shell: {
+      kind: 'git-bash',
+      displayName: 'Git Bash',
+      exe: 'C:\\Program Files\\Git\\bin\\bash.exe',
+    },
+  });
+  assert.match(tool.description, /Git Bash/);
+  assert.match(tool.description, /POSIX shell syntax/);
+  assert.doesNotMatch(tool.description, /write PowerShell syntax/);
+});
+
 describe('Bash tool shell is threaded through to execution, not just the description', () => {
   test('foreground tool executes with the same shell it declares', async () => {
     // /bin/echo stands in for pwsh.exe: if the tool's shell reaches the

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -32,10 +32,10 @@ import {
   buildStopBackgroundTaskTool,
   buildWriteStdinTool,
   shapeTerminalResult,
-  withShellGuidance,
+  withTurnShellGuidance,
 } from './shell-tools.js';
 import type { ShellRunLauncher } from './shell-tools.js';
-import { defaultShellPlan, type ShellPlan } from './shell-detect.js';
+import { defaultShellPlan, throwIfShellSetupFailed, type TurnShellPlan } from './shell-detect.js';
 import type {
   BackgroundTaskStopper,
   PtyControlWriter,
@@ -146,8 +146,12 @@ export interface BuildBuiltinToolsOptions {
   backgroundTasks?: BackgroundTaskStopper;
   ptyControls?: PtyControlWriter;
   executor?: WorkspaceExecutor;
-  /** Shell that runs Bash commands. Defaults to the process-wide detected shell. */
-  shell?: ShellPlan;
+  /**
+   * Turn-scoped shell resolution that runs Bash commands. Defaults to the
+   * process-wide detected shell. A broken saved preference rides along as
+   * `setupError` and fails closed at the Bash boundary.
+   */
+  shell?: TurnShellPlan;
   permissionProfile?: PermissionProfile;
   sandboxManager?: SandboxManager;
   /** Sandboxed worker used for all local filesystem tools. */
@@ -264,7 +268,7 @@ export function buildBuiltinTools(options: BuildBuiltinToolsOptions = {}): MakaT
         },
       })
     : fileReadParameters;
-  const shell = options.shell ?? defaultShellPlan();
+  const shell = options.shell ?? { plan: defaultShellPlan() };
   const sandboxPlatform = options.sandboxPlatform ?? process.platform;
   const bashTools = options.shellRuns
     ? [
@@ -595,14 +599,14 @@ interface ExecutorBashSandboxOptions {
 
 function buildExecutorBashTool(
   executor: WorkspaceExecutor,
-  shell: ShellPlan,
+  shell: TurnShellPlan,
   sandboxOptions: ExecutorBashSandboxOptions,
 ): MakaTool {
   return {
     name: 'Bash',
     activityKind: 'command',
     description:
-      withShellGuidance('Run a shell command in the session cwd.', shell) +
+      withTurnShellGuidance('Run a shell command in the session cwd.', shell) +
       ' Enforced by the current session sandbox boundary.',
     parameters: z
       .object({
@@ -618,6 +622,7 @@ function buildExecutorBashTool(
     toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     executionFacts: executor.facts,
     impl: async ({ command, timeout_ms, required_boundary }, ctx) => {
+      throwIfShellSetupFailed(shell);
       const normalizedRequiredBoundary = await preflightDeclaredSandboxBoundary(
         required_boundary,
         ctx,
@@ -661,7 +666,7 @@ function buildExecutorBashTool(
           timeoutMs: timeout,
           ...(abortSignal ? { abortSignal } : {}),
           emitOutput,
-          shell,
+          shell: shell.plan,
         });
         const executionResult = {
           ...result,

--- a/packages/runtime/src/pipe-process-driver.ts
+++ b/packages/runtime/src/pipe-process-driver.ts
@@ -54,7 +54,10 @@ export class PipeProcessDriver {
         cwd: options.cwd,
         env: options.env,
         shell: options.plan.useShellOption,
-        stdio: buildSpawnStdio(options.fdInputs),
+        stdio: buildSpawnStdio(
+          options.fdInputs,
+          options.plan.stdin === undefined ? 'ignore' : 'pipe',
+        ),
         detached: process.platform !== 'win32',
       });
     } finally {
@@ -91,6 +94,11 @@ export class PipeProcessDriver {
 
   writeInputs(): void {
     writeChildFdInputs(this.child, this.options.fdInputs);
+    if (this.options.plan.stdin !== undefined) {
+      if (!this.child.stdin) throw new Error('Pipe process did not expose stdin');
+      this.child.stdin.on('error', () => {});
+      this.child.stdin.end(this.options.plan.stdin);
+    }
   }
 
   kill(signal: 'SIGTERM' | 'SIGKILL'): boolean {

--- a/packages/runtime/src/pipe-process-driver.ts
+++ b/packages/runtime/src/pipe-process-driver.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
-import type { Readable } from 'node:stream';
+import type { Readable, Writable } from 'node:stream';
 
 import type { ShellSpawnPlan } from './shell-detect.js';
 import {
@@ -42,11 +42,14 @@ export class PipeProcessDriver {
   private readonly child: ChildProcess;
   private readonly stdout: Readable;
   private readonly stderr: Readable;
+  private readonly stdin: Writable | undefined;
   private readonly outputDrain: CapturedOutputDrain<PipeOutputStream>;
   private disposed = false;
   private settled = false;
   private outputDrainResult: CapturedOutputDrainResult<PipeOutputStream> | undefined;
   private rootExit: Omit<PipeProcessExit, 'stdoutTruncated' | 'stderrTruncated'> | undefined;
+  private stdinSettled: boolean;
+  private stdinError: Error | undefined;
 
   constructor(private readonly options: PipeProcessDriverOptions) {
     try {
@@ -69,6 +72,12 @@ export class PipeProcessDriver {
     }
     this.stdout = this.child.stdout;
     this.stderr = this.child.stderr;
+    this.stdin = options.plan.stdin === undefined ? undefined : (this.child.stdin ?? undefined);
+    if (options.plan.stdin !== undefined && !this.stdin) {
+      this.child.kill('SIGKILL');
+      throw new Error('Pipe process did not expose stdin');
+    }
+    this.stdinSettled = this.stdin === undefined;
     this.pid = this.child.pid;
     this.stdout.setEncoding('utf8');
     this.stderr.setEncoding('utf8');
@@ -94,11 +103,9 @@ export class PipeProcessDriver {
 
   writeInputs(): void {
     writeChildFdInputs(this.child, this.options.fdInputs);
-    if (this.options.plan.stdin !== undefined) {
-      if (!this.child.stdin) throw new Error('Pipe process did not expose stdin');
-      this.child.stdin.on('error', () => {});
-      this.child.stdin.end(this.options.plan.stdin);
-    }
+    if (!this.stdin || this.options.plan.stdin === undefined) return;
+    this.stdin.once('error', this.onStdinError);
+    this.stdin.end(this.options.plan.stdin, this.onStdinEnd);
   }
 
   kill(signal: 'SIGTERM' | 'SIGKILL'): boolean {
@@ -114,6 +121,7 @@ export class PipeProcessDriver {
     this.child.off('exit', this.onRootExit);
     this.child.off('close', this.onCloseFallback);
     this.child.off('error', this.onError);
+    this.stdin?.off('error', this.onStdinError);
     this.stdout.destroy();
     this.stderr.destroy();
   }
@@ -142,13 +150,14 @@ export class PipeProcessDriver {
   };
 
   private settleAfterDrain(): void {
-    if (!this.rootExit || !this.outputDrainResult) return;
+    if (!this.rootExit || !this.outputDrainResult || !this.stdinSettled) return;
     this.settle();
   }
 
   private settle(): void {
     if (this.disposed || this.settled || !this.rootExit || !this.outputDrainResult) return;
     this.settled = true;
+    if (this.stdinError) this.options.onFailure(this.stdinError);
     this.options.onExit({
       ...this.rootExit,
       stdoutTruncated: this.outputDrainResult.incomplete.has('stdout'),
@@ -158,6 +167,18 @@ export class PipeProcessDriver {
 
   private readonly onError = (error: Error): void => {
     if (!this.disposed && !this.settled) this.options.onFailure(error);
+  };
+
+  private readonly onStdinError = (error: Error): void => {
+    this.stdinError ??= error;
+    this.stdinSettled = true;
+    this.settleAfterDrain();
+  };
+
+  private readonly onStdinEnd = (error?: Error | null): void => {
+    if (error) this.stdinError ??= error;
+    this.stdinSettled = true;
+    this.settleAfterDrain();
   };
 }
 

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -59,9 +59,11 @@ import type {
   BackendFactoryContext,
   BackendRegistry,
   CompactSessionInput,
+  ResolvedChildToolActivation,
   SessionStore,
   StopSessionInput,
 } from './session-manager.js';
+import type { TurnShellPlan } from './shell-detect.js';
 import type { ShellRunProcessManager } from './shell-run-manager.js';
 import {
   buildStatusPatch,
@@ -273,6 +275,18 @@ interface SessionSteeringState {
 
 export type BackendActivationBoundary = <T>(operation: () => Promise<T> | T) => Promise<T>;
 
+interface ChildToolActivation {
+  readonly tools: readonly MakaTool[];
+  readonly shell?: TurnShellPlan;
+}
+
+function requireChildToolActivation(
+  activation: ChildToolActivation | undefined,
+): ChildToolActivation {
+  if (!activation) throw new Error('Child tool activation was not prepared');
+  return activation;
+}
+
 export interface RuntimeKernelDeps {
   store: SessionStore;
   runStore?: AgentRunStore;
@@ -283,7 +297,7 @@ export interface RuntimeKernelDeps {
   newId: () => string;
   now: () => number;
   childTools?: readonly MakaTool[];
-  resolveChildTools?: (sessionId: string) => Promise<readonly MakaTool[]>;
+  resolveChildTools?: (sessionId: string) => Promise<ResolvedChildToolActivation>;
   runtimeSource?: InvocationSource;
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
   repairRunRuntimeLedger?: (sessionId: string, runId: string) => Promise<boolean>;
@@ -708,15 +722,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
         throw new Error('Turn start was cancelled before runtime admission');
       }
       this.attachExecutionClaim(execution, run);
-      yield* this.runAgentTurn(
-        sessionId,
-        input,
-        run,
-        execution,
-        true,
-        options.onRunStarted,
-        header,
-      );
+      yield* this.runAgentTurn(sessionId, input, run, execution, {
+        steering: true,
+        onRunStarted: options.onRunStarted,
+        initialHeader: header,
+      });
     } finally {
       this.releaseExecutionClaim(execution);
     }
@@ -1150,12 +1160,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     await this.enterExecutionClaim(execution);
     const parentHeader = await this.deps.store.readHeader(sessionId);
     const definition = requireBuiltinAgentDefinition(input.spec.id);
-    const availableChildTools = await this.childToolsForSession(sessionId);
-    assertAgentDefinitionRunnable({
-      definition,
-      tools: availableChildTools,
-    });
-    const childTools = buildToolsForAgentDefinition(availableChildTools, definition);
+    let childActivation: ChildToolActivation | undefined;
     const childHeader: SessionHeader = {
       ...parentHeader,
       permissionMode: definition.permissionMode,
@@ -1187,12 +1192,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
       recordSessionMessages: false,
       hooks: {
         reserveRun: async (targetSessionId, nextHeader, activeRun) => {
+          const activation = requireChildToolActivation(childActivation);
           const active = await this.reserveChildRun(
             activeKey,
             targetSessionId,
             nextHeader,
             definition.systemPrompt,
-            childTools,
+            activation.tools,
+            activation.shell,
             activeRun,
             execution,
           );
@@ -1207,7 +1214,16 @@ export class RuntimeKernel implements RuntimeKernelLike {
     });
 
     this.attachExecutionClaim(execution, run);
-    yield* this.runAgentTurn(sessionId, userInput, run, execution);
+    yield* this.runAgentTurn(sessionId, userInput, run, execution, {
+      prepareBackendActivation: async () => {
+        const available = await this.childToolActivationForSession(sessionId);
+        assertAgentDefinitionRunnable({ definition, tools: available.tools });
+        childActivation = {
+          tools: buildToolsForAgentDefinition(available.tools, definition),
+          ...(available.shell ? { shell: available.shell } : {}),
+        };
+      },
+    });
   }
 
   async *startChildRetry(
@@ -1252,15 +1268,15 @@ export class RuntimeKernel implements RuntimeKernelLike {
           tools: linkedSnapshot.toolNames,
         }
       : requireBuiltinAgentDefinition(input.spec.id);
-    const availableChildTools = await this.childToolsForSession(sessionId);
+    const preflightActivation = await this.childToolActivationForSession(sessionId);
     if (!linkedSnapshot) {
       assertAgentDefinitionRunnable({
         definition: requireBuiltinAgentDefinition(input.spec.id),
-        tools: availableChildTools,
+        tools: preflightActivation.tools,
       });
     }
-    const childTools = buildToolsForAgentDefinition(availableChildTools, definition);
-    if (linkedSnapshot && childTools.length !== linkedSnapshot.toolNames.length) {
+    const preflightChildTools = buildToolsForAgentDefinition(preflightActivation.tools, definition);
+    if (linkedSnapshot && preflightChildTools.length !== linkedSnapshot.toolNames.length) {
       throw new Error('Linked child retry durable runtime tool snapshot is unavailable');
     }
     const childHeader: SessionHeader = linkedSnapshot
@@ -1289,7 +1305,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     assertContinuationSourceUnchanged(continuation, sourceRun, sourceEvents);
     await this.revalidateContinuationSafety(
       continuation,
-      childTools.map((tool) => tool.name),
+      preflightChildTools.map((tool) => tool.name),
     );
 
     const claimedAt = this.deps.now();
@@ -1370,6 +1386,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       },
     };
     const activeKey = childActiveKey(sessionId, continuation.turnId);
+    let childActivation: ChildToolActivation | undefined;
     const run = new AgentRun({
       sessionId,
       header: childHeader,
@@ -1392,17 +1409,22 @@ export class RuntimeKernel implements RuntimeKernelLike {
       recordSessionMessages: false,
       hooks: {
         reserveRun: async (targetSessionId, nextHeader, activeRun) => {
-          const active = linkedSnapshot
-            ? await this.reserveParentRun(targetSessionId, nextHeader, activeRun, execution)
-            : await this.reserveChildRun(
-                activeKey,
-                targetSessionId,
-                nextHeader,
-                definition.systemPrompt,
-                childTools,
-                activeRun,
-                execution,
-              );
+          let active: BackendGeneration;
+          if (linkedSnapshot) {
+            active = await this.reserveParentRun(targetSessionId, nextHeader, activeRun, execution);
+          } else {
+            const activation = requireChildToolActivation(childActivation);
+            active = await this.reserveChildRun(
+              activeKey,
+              targetSessionId,
+              nextHeader,
+              definition.systemPrompt,
+              activation.tools,
+              activation.shell,
+              activeRun,
+              execution,
+            );
+          }
           this.reserveExecutionClaim(execution, active, activeRun);
           return active;
         },
@@ -1440,11 +1462,27 @@ export class RuntimeKernel implements RuntimeKernelLike {
           }
         : undefined,
       input.onRunStarted,
-      () =>
-        this.revalidateContinuationSafety(
+      async () => {
+        const available = await this.childToolActivationForSession(sessionId);
+        if (!linkedSnapshot) {
+          assertAgentDefinitionRunnable({
+            definition: requireBuiltinAgentDefinition(input.spec.id),
+            tools: available.tools,
+          });
+        }
+        const tools = buildToolsForAgentDefinition(available.tools, definition);
+        if (linkedSnapshot && tools.length !== linkedSnapshot.toolNames.length) {
+          throw new Error('Linked child retry durable runtime tool snapshot is unavailable');
+        }
+        childActivation = {
+          tools,
+          ...(available.shell ? { shell: available.shell } : {}),
+        };
+        await this.revalidateContinuationSafety(
           continuation,
-          childTools.map((tool) => tool.name),
-        ),
+          tools.map((tool) => tool.name),
+        );
+      },
     );
   }
 
@@ -1453,10 +1491,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
     input: UserMessageInput,
     run: AgentRun,
     execution: PendingExecutionClaim,
-    steering = false,
-    onRunStarted?: (runId: string, initialHeader: SessionHeader) => void | Promise<void>,
-    initialHeader?: SessionHeader,
+    options: {
+      steering?: boolean;
+      onRunStarted?: (runId: string, initialHeader: SessionHeader) => void | Promise<void>;
+      initialHeader?: SessionHeader;
+      prepareBackendActivation?: () => Promise<void>;
+    } = {},
   ): AsyncIterable<SessionEvent> {
+    const { steering = false, onRunStarted, initialHeader, prepareBackendActivation } = options;
     const sessionEvents = new DeliveryAckQueue<SessionEvent>();
     const { abortController, release: releaseExecutionAbort } =
       this.inheritExecutionAbort(execution);
@@ -1472,6 +1514,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         });
       }
       begin = await this.runBackendActivation(async () => {
+        await prepareBackendActivation?.();
         const started = await run.begin();
         await owners.bindInteraction(this.deps.interactionAuthority, {
           sessionId,
@@ -2831,6 +2874,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           ? {
               systemPrompt: subagent.systemPrompt,
               tools: subagent.tools,
+              ...(subagent.shell ? { turnShellPlan: subagent.shell } : {}),
             }
           : {}),
         ...this.buildBackendRecorderHooks({
@@ -2872,7 +2916,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
 
   private async resolveSubagentActivation(
     header: SessionHeader,
-  ): Promise<{ systemPrompt: string; tools: MakaTool[] } | undefined> {
+  ): Promise<{ systemPrompt: string; tools: MakaTool[]; shell?: TurnShellPlan } | undefined> {
     const snapshot = header.subagentRuntime;
     if (!snapshot) {
       if (header.subagentParent) {
@@ -2888,18 +2932,21 @@ export class RuntimeKernel implements RuntimeKernelLike {
       permissionMode: header.permissionMode,
       tools: snapshot.toolNames,
     };
-    const availableTools = await this.childToolsForSession(header.id);
-    const tools = buildToolsForAgentDefinition(availableTools, snapshotDefinition);
+    const available = await this.childToolActivationForSession(header.id);
+    const tools = buildToolsForAgentDefinition(available.tools, snapshotDefinition);
     if (tools.length !== snapshot.toolNames.length) {
       throw new Error('Subagent runtime tool snapshot is unavailable');
     }
-    return { systemPrompt: snapshot.systemPrompt, tools };
+    return {
+      systemPrompt: snapshot.systemPrompt,
+      tools,
+      ...(available.shell ? { shell: available.shell } : {}),
+    };
   }
 
-  private async childToolsForSession(sessionId: string): Promise<readonly MakaTool[]> {
-    return this.deps.resolveChildTools
-      ? await this.deps.resolveChildTools(sessionId)
-      : (this.deps.childTools ?? []);
+  private async childToolActivationForSession(sessionId: string): Promise<ChildToolActivation> {
+    if (!this.deps.resolveChildTools) return { tools: this.deps.childTools ?? [] };
+    return await this.deps.resolveChildTools(sessionId);
   }
 
   private async ensureChildActive(
@@ -2908,6 +2955,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     header: SessionHeader,
     systemPrompt: string,
     tools: readonly MakaTool[],
+    turnShellPlan: TurnShellPlan | undefined,
     execution: PendingExecutionClaim,
   ): Promise<BackendGeneration> {
     await this.clearBackendQuarantineForActivation(sessionId, execution);
@@ -2934,6 +2982,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         appendMessage: async () => {},
         systemPrompt,
         tools,
+        ...(turnShellPlan ? { turnShellPlan } : {}),
         ...this.buildBackendRecorderHooks({
           resolveActive: () => this.childActive.get(activeKey),
           sessionId,
@@ -2975,6 +3024,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     header: SessionHeader,
     systemPrompt: string,
     tools: readonly MakaTool[],
+    turnShellPlan: TurnShellPlan | undefined,
     run: AgentRun,
     execution: PendingExecutionClaim,
   ): Promise<BackendGeneration> {
@@ -2984,6 +3034,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       header,
       systemPrompt,
       tools,
+      turnShellPlan,
       execution,
     );
     this.reserveGenerationRun(active, run);

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -283,6 +283,7 @@ export interface RuntimeKernelDeps {
   newId: () => string;
   now: () => number;
   childTools?: readonly MakaTool[];
+  resolveChildTools?: (sessionId: string) => Promise<readonly MakaTool[]>;
   runtimeSource?: InvocationSource;
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
   repairRunRuntimeLedger?: (sessionId: string, runId: string) => Promise<boolean>;
@@ -1149,7 +1150,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     await this.enterExecutionClaim(execution);
     const parentHeader = await this.deps.store.readHeader(sessionId);
     const definition = requireBuiltinAgentDefinition(input.spec.id);
-    const availableChildTools = this.deps.childTools ?? [];
+    const availableChildTools = await this.childToolsForSession(sessionId);
     assertAgentDefinitionRunnable({
       definition,
       tools: availableChildTools,
@@ -1251,7 +1252,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           tools: linkedSnapshot.toolNames,
         }
       : requireBuiltinAgentDefinition(input.spec.id);
-    const availableChildTools = this.deps.childTools ?? [];
+    const availableChildTools = await this.childToolsForSession(sessionId);
     if (!linkedSnapshot) {
       assertAgentDefinitionRunnable({
         definition: requireBuiltinAgentDefinition(input.spec.id),
@@ -2819,7 +2820,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const entry = await this.shareBackendActivation(`parent:${sessionId}`, async () => {
       const current = this.active.get(sessionId);
       if (current) return current;
-      const subagent = this.resolveSubagentActivation(header);
+      const subagent = await this.resolveSubagentActivation(header);
       const backend = await this.deps.backends.build(header.backend, {
         sessionId,
         workspaceRoot: header.workspaceRoot,
@@ -2869,9 +2870,9 @@ export class RuntimeKernel implements RuntimeKernelLike {
     }
   }
 
-  private resolveSubagentActivation(
+  private async resolveSubagentActivation(
     header: SessionHeader,
-  ): { systemPrompt: string; tools: MakaTool[] } | undefined {
+  ): Promise<{ systemPrompt: string; tools: MakaTool[] } | undefined> {
     const snapshot = header.subagentRuntime;
     if (!snapshot) {
       if (header.subagentParent) {
@@ -2887,12 +2888,18 @@ export class RuntimeKernel implements RuntimeKernelLike {
       permissionMode: header.permissionMode,
       tools: snapshot.toolNames,
     };
-    const availableTools = this.deps.childTools ?? [];
+    const availableTools = await this.childToolsForSession(header.id);
     const tools = buildToolsForAgentDefinition(availableTools, snapshotDefinition);
     if (tools.length !== snapshot.toolNames.length) {
       throw new Error('Subagent runtime tool snapshot is unavailable');
     }
     return { systemPrompt: snapshot.systemPrompt, tools };
+  }
+
+  private async childToolsForSession(sessionId: string): Promise<readonly MakaTool[]> {
+    return this.deps.resolveChildTools
+      ? await this.deps.resolveChildTools(sessionId)
+      : (this.deps.childTools ?? []);
   }
 
   private async ensureChildActive(

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -149,6 +149,7 @@ import {
 
 import type { AgentBackend, BackendStopMode } from '@maka/core/backend-types';
 import type { MakaTool } from './tool-runtime.js';
+import type { TurnShellPlan } from './shell-detect.js';
 import type { RunTraceRecorder } from './run-trace.js';
 import type { ModelCallAttempt } from '@maka/core/model-call-attempt';
 import type {
@@ -735,6 +736,8 @@ export interface BackendFactoryContext {
    * silently strip the decoder for placeholders that child will still receive.
    */
   tools?: readonly MakaTool[];
+  /** Turn-scoped shell plan captured with a bound child tool ceiling. */
+  turnShellPlan?: TurnShellPlan;
   recordRunTrace?: RunTraceRecorder;
   /** Durable AgentRun metadata row written after the private capture artifact. */
   recordProviderRequestCapture?: (capture: ProviderRequestCaptureLedgerRecord) => Promise<void>;
@@ -813,7 +816,7 @@ interface SessionManagerBaseDeps {
   newId: () => string;
   now: () => number;
   childTools?: readonly MakaTool[];
-  resolveChildTools?: (sessionId: string) => Promise<readonly MakaTool[]>;
+  resolveChildTools?: (sessionId: string) => Promise<ResolvedChildToolActivation>;
   /** Host-owned user catalog. Runtime receives ids from models, never raw model targets. */
   subagentCatalog?: {
     list(): Promise<SubagentPresetListItem[]>;
@@ -853,6 +856,11 @@ interface SessionManagerBaseDeps {
     sourceText: string;
   }) => Promise<string | undefined>;
   onSessionTitleChanged?: (sessionId: string) => void;
+}
+
+export interface ResolvedChildToolActivation {
+  readonly tools: readonly MakaTool[];
+  readonly shell?: TurnShellPlan;
 }
 
 type SessionManagerInteractionDeps =
@@ -4401,9 +4409,8 @@ export class SessionManager {
   }
 
   private async childToolsForSession(sessionId: string): Promise<readonly MakaTool[]> {
-    return this.deps.resolveChildTools
-      ? await this.deps.resolveChildTools(sessionId)
-      : (this.deps.childTools ?? []);
+    if (!this.deps.resolveChildTools) return this.deps.childTools ?? [];
+    return (await this.deps.resolveChildTools(sessionId)).tools;
   }
 
   async readChildAgentOutput(

--- a/packages/runtime/src/shell-detect.ts
+++ b/packages/runtime/src/shell-detect.ts
@@ -51,6 +51,19 @@ export class ShellPreferenceError extends Error {
 
 export interface ResolveShellPlanInput extends DetectShellInput {}
 
+/**
+ * The one Host-owned shell resolution captured at turn admission. `plan`
+ * drives model guidance and Bash execution for the whole turn so a mid-turn
+ * settings change cannot split guidance from execution; a broken saved
+ * preference rides along as `setupError` instead of throwing at composition
+ * time, so text-only turns keep working while the Bash/PTY boundary stays
+ * fail-closed (and never falls back to another shell).
+ */
+export interface TurnShellPlan {
+  readonly plan: ShellPlan;
+  readonly setupError?: ShellPreferenceError;
+}
+
 /** Resolves the Host-owned user preference into the one plan every shell surface consumes. */
 export function resolveShellPlan(
   settings: ShellSettings,
@@ -83,6 +96,37 @@ export function resolveShellPlan(
     return { kind: 'legacy-wsl-bash', displayName: 'Legacy WSL Bash', exe: executable };
   }
   return { kind: 'git-bash', displayName: 'Git Bash', exe: executable };
+}
+
+/**
+ * Resolves the turn-scoped shell plan without throwing. A saved preference
+ * whose executable moved or was uninstalled is a repairable optional-tool
+ * configuration error: composition must not widen it into whole-turn
+ * unavailability, so the failure is captured in `setupError` and the Bash/PTY
+ * boundary re-throws it when a command actually runs.
+ */
+export function resolveTurnShellPlan(
+  settings: ShellSettings,
+  input: ResolveShellPlanInput = {},
+): TurnShellPlan {
+  try {
+    return { plan: resolveShellPlan(settings, input) };
+  } catch (error) {
+    if (error instanceof ShellPreferenceError) {
+      return { plan: defaultShellPlan(), setupError: error };
+    }
+    throw error;
+  }
+}
+
+/** Fail-closed gate for the Bash/PTY boundary: never execute through a broken preference. */
+export function throwIfShellSetupFailed(shell: TurnShellPlan): void {
+  if (shell.setupError) throw shell.setupError;
+}
+
+/** Model-facing shell name; a broken preference is declared, not silently hidden. */
+export function turnShellDisplayName(shell: TurnShellPlan): string {
+  return shell.setupError ? `Unavailable (${shell.setupError.message})` : shell.plan.displayName;
 }
 
 export interface ValidateShellPreferenceInput extends ResolveShellPlanInput {
@@ -294,6 +338,17 @@ export function bashToolShellGuidance(shell: ShellPlan): string {
           ? 'Commands are executed by Windows PowerShell 5.1; write PowerShell 5.1-compatible syntax, not cmd or bash syntax.'
           : 'Commands are executed by cmd.exe; write cmd syntax, not bash syntax.';
   return `${dialect} Prefer \`git ls-files\` or the Grep/Glob tools over recursive directory listings, and always exclude node_modules and build output when enumerating files.`;
+}
+
+/**
+ * Turn-scoped variant of {@link bashToolShellGuidance}. When the saved
+ * preference is broken, dialect guidance would be a lie — every command fails
+ * at the boundary — so the description declares the outage and the repair
+ * instead of naming a shell that cannot run.
+ */
+export function bashToolTurnShellGuidance(shell: TurnShellPlan): string {
+  if (!shell.setupError) return bashToolShellGuidance(shell.plan);
+  return `Bash is unavailable this turn: ${shell.setupError.message} Repair the shell setting to re-enable it; commands keep failing closed rather than falling back to another shell.`;
 }
 
 function findAt(

--- a/packages/runtime/src/shell-detect.ts
+++ b/packages/runtime/src/shell-detect.ts
@@ -12,15 +12,18 @@
 // session environment fragment). Selection without declaration — or the other
 // way round — makes the model guess the dialect, which is the original bug.
 
+import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { win32 } from 'node:path';
+import type { ShellSettings } from '@maka/core/settings';
 
-export type ShellKind = 'posix' | 'pwsh' | 'powershell' | 'cmd';
+export type ShellKind = 'posix' | 'git-bash' | 'legacy-wsl-bash' | 'pwsh' | 'powershell' | 'cmd';
 
 export interface ShellPlan {
   kind: ShellKind;
   /** Human-readable name for prompt surfaces, e.g. "PowerShell 7 (pwsh)". */
   displayName: string;
-  /** Executable to spawn explicitly (pwsh/powershell only). */
+  /** Executable to spawn explicitly for non-default shell plans. */
   exe?: string;
 }
 
@@ -28,6 +31,81 @@ export interface DetectShellInput {
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
   fileExists?: (path: string) => boolean;
+}
+
+export type ShellPreferenceErrorCode =
+  | 'unsupported_platform'
+  | 'invalid_executable'
+  | 'executable_missing'
+  | 'not_bash';
+
+export class ShellPreferenceError extends Error {
+  constructor(
+    readonly code: ShellPreferenceErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ShellPreferenceError';
+  }
+}
+
+export interface ResolveShellPlanInput extends DetectShellInput {}
+
+/** Resolves the Host-owned user preference into the one plan every shell surface consumes. */
+export function resolveShellPlan(
+  settings: ShellSettings,
+  input: ResolveShellPlanInput = {},
+): ShellPlan {
+  if (settings.preference === 'auto') {
+    return input.platform !== undefined || input.env !== undefined || input.fileExists !== undefined
+      ? detectShell(input)
+      : defaultShellPlan();
+  }
+  const platform = input.platform ?? process.platform;
+  if (platform !== 'win32') {
+    throw new ShellPreferenceError(
+      'unsupported_platform',
+      'Git Bash can only be selected on a Windows Runtime Host',
+    );
+  }
+  const executable = settings.executable.trim();
+  if (!win32.isAbsolute(executable) || win32.basename(executable).toLowerCase() !== 'bash.exe') {
+    throw new ShellPreferenceError(
+      'invalid_executable',
+      'Git Bash must use an absolute path to bash.exe',
+    );
+  }
+  const fileExists = input.fileExists ?? defaultFileExists;
+  if (!fileExists(executable)) {
+    throw new ShellPreferenceError('executable_missing', 'The configured Git Bash was not found');
+  }
+  if (isLegacyWslShim(executable, input.env ?? process.env)) {
+    return { kind: 'legacy-wsl-bash', displayName: 'Legacy WSL Bash', exe: executable };
+  }
+  return { kind: 'git-bash', displayName: 'Git Bash', exe: executable };
+}
+
+export interface ValidateShellPreferenceInput extends ResolveShellPlanInput {
+  probeVersion?: (executable: string) => Promise<string>;
+}
+
+/** Rejects a persisted override unless the Host can execute it as GNU Bash. */
+export async function validateShellPreference(
+  settings: ShellSettings,
+  input: ValidateShellPreferenceInput = {},
+): Promise<ShellPlan> {
+  const plan = resolveShellPlan(settings, input);
+  if ((plan.kind !== 'git-bash' && plan.kind !== 'legacy-wsl-bash') || !plan.exe) return plan;
+  let version: string;
+  try {
+    version = await (input.probeVersion ?? probeBashVersion)(plan.exe);
+  } catch {
+    throw new ShellPreferenceError('not_bash', 'The configured executable could not run Bash');
+  }
+  if (!/\bGNU bash, version\b/i.test(version)) {
+    throw new ShellPreferenceError('not_bash', 'The configured executable is not GNU Bash');
+  }
+  return plan;
 }
 
 export function detectShell(input: DetectShellInput = {}): ShellPlan {
@@ -70,6 +148,8 @@ export interface ShellSpawnPlan {
   useShellOption: boolean;
   /** Required environment snapshot; callers must pass it to spawn when present. */
   env?: NodeJS.ProcessEnv;
+  /** Script body for shells whose executable consumes commands from stdin. */
+  stdin?: string;
 }
 
 export interface PtyShellSpawnPlan {
@@ -142,6 +222,21 @@ export function buildShellSpawnPlan(
   command: string,
   env: NodeJS.ProcessEnv = process.env,
 ): ShellSpawnPlan {
+  if (shell.kind === 'legacy-wsl-bash') {
+    return {
+      file: requireExplicitShellExecutable(shell),
+      args: ['-s'],
+      useShellOption: false,
+      stdin: `${command}\n`,
+    };
+  }
+  if (shell.kind === 'git-bash') {
+    return {
+      file: requireExplicitShellExecutable(shell),
+      args: ['-c', command],
+      useShellOption: false,
+    };
+  }
   if ((shell.kind === 'pwsh' || shell.kind === 'powershell') && shell.exe) {
     const wrapped = buildPowerShellCommand(command, env);
     return {
@@ -159,6 +254,12 @@ export function buildPtyShellSpawnPlan(
   command: string,
   env: NodeJS.ProcessEnv = process.env,
 ): PtyShellSpawnPlan {
+  if (shell.kind === 'legacy-wsl-bash') {
+    return { file: requireExplicitShellExecutable(shell), args: ['-c', command] };
+  }
+  if (shell.kind === 'git-bash') {
+    return { file: requireExplicitShellExecutable(shell), args: ['-c', command] };
+  }
   if ((shell.kind === 'pwsh' || shell.kind === 'powershell') && shell.exe) {
     const wrapped = buildPowerShellCommand(command, env);
     return {
@@ -185,11 +286,13 @@ export function buildPtyShellSpawnPlan(
 export function bashToolShellGuidance(shell: ShellPlan): string {
   if (shell.kind === 'posix') return '';
   const dialect =
-    shell.kind === 'pwsh'
-      ? 'Commands are executed by PowerShell 7 (pwsh); write PowerShell syntax, not cmd or bash syntax.'
-      : shell.kind === 'powershell'
-        ? 'Commands are executed by Windows PowerShell 5.1; write PowerShell 5.1-compatible syntax, not cmd or bash syntax.'
-        : 'Commands are executed by cmd.exe; write cmd syntax, not bash syntax.';
+    shell.kind === 'git-bash' || shell.kind === 'legacy-wsl-bash'
+      ? `Commands are executed by ${shell.displayName}; write POSIX shell syntax, not PowerShell or cmd syntax.`
+      : shell.kind === 'pwsh'
+        ? 'Commands are executed by PowerShell 7 (pwsh); write PowerShell syntax, not cmd or bash syntax.'
+        : shell.kind === 'powershell'
+          ? 'Commands are executed by Windows PowerShell 5.1; write PowerShell 5.1-compatible syntax, not cmd or bash syntax.'
+          : 'Commands are executed by cmd.exe; write cmd syntax, not bash syntax.';
   return `${dialect} Prefer \`git ls-files\` or the Grep/Glob tools over recursive directory listings, and always exclude node_modules and build output when enumerating files.`;
 }
 
@@ -223,4 +326,32 @@ function defaultFileExists(path: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isLegacyWslShim(executable: string, env: NodeJS.ProcessEnv): boolean {
+  const systemRoot = env.SystemRoot ?? env.SYSTEMROOT;
+  if (!systemRoot) return false;
+  return (
+    win32.normalize(executable).toLowerCase() ===
+    win32.normalize(win32.join(systemRoot, 'System32', 'bash.exe')).toLowerCase()
+  );
+}
+
+function requireExplicitShellExecutable(shell: ShellPlan): string {
+  if (shell.exe) return shell.exe;
+  throw new Error(`${shell.displayName} shell plan is missing its executable`);
+}
+
+function probeBashVersion(executable: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      executable,
+      ['--version'],
+      { timeout: 3_000, windowsHide: true, maxBuffer: 64 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) reject(error);
+        else resolve(`${stdout}\n${stderr}`);
+      },
+    );
+  });
 }

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -117,10 +117,16 @@ export function runShellWithBoundedTail(
     command,
     options.env ?? process.env,
   );
-  return runSpawnedProcessWithBoundedTail(plan.file, plan.args, plan.useShellOption, {
-    ...options,
-    ...(plan.env ? { env: plan.env } : {}),
-  });
+  return runSpawnedProcessWithBoundedTail(
+    plan.file,
+    plan.args,
+    plan.useShellOption,
+    {
+      ...options,
+      ...(plan.env ? { env: plan.env } : {}),
+    },
+    plan.stdin,
+  );
 }
 
 /** Run an argv command directly, without a second shell parsing pass. */
@@ -137,6 +143,7 @@ function runSpawnedProcessWithBoundedTail(
   args: readonly string[],
   useShellOption: boolean,
   options: BoundedShellOptions,
+  stdin?: string,
 ): Promise<BoundedShellResult> {
   const cap = options.maxRetainedChars ?? BASH_MAX_RETAINED_CHARS;
   const liveCap = options.maxLiveEmitChars ?? BASH_MAX_LIVE_EMIT_CHARS;
@@ -161,7 +168,7 @@ function runSpawnedProcessWithBoundedTail(
         cwd: options.cwd,
         env: options.env,
         shell: useShellOption,
-        stdio: buildSpawnStdio(options.fdInputs),
+        stdio: buildSpawnStdio(options.fdInputs, stdin === undefined ? 'ignore' : 'pipe'),
         // POSIX: make the shell its own process-group leader (setsid). Termination
         // signals the group and removes descendants visible outside it at each
         // process-table snapshot.
@@ -208,6 +215,11 @@ function runSpawnedProcessWithBoundedTail(
     }
     try {
       writeChildFdInputs(child, options.fdInputs);
+      if (stdin !== undefined) {
+        if (!child.stdin) throw new Error('Shell process did not expose stdin');
+        child.stdin.on('error', () => {});
+        child.stdin.end(stdin);
+      }
     } catch (error) {
       settled = true;
       cleanup();

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -20,7 +20,14 @@ import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 import type { SandboxType } from './sandbox/types.js';
 import { isLikelySandboxDenial } from './sandbox/detect.js';
 import { runShellWithBoundedTail, type BoundedShellResult } from './shell-exec.js';
-import { bashToolShellGuidance, defaultShellPlan, type ShellPlan } from './shell-detect.js';
+import {
+  bashToolShellGuidance,
+  bashToolTurnShellGuidance,
+  defaultShellPlan,
+  type ShellPlan,
+  throwIfShellSetupFailed,
+  type TurnShellPlan,
+} from './shell-detect.js';
 import { truncateToolOutput } from './tool-output.js';
 import {
   DEFAULT_BASH_TIMEOUT_MS,
@@ -121,23 +128,25 @@ export function buildForegroundBashTool(options: BuildForegroundBashToolOptions)
 }
 
 export function buildLocalForegroundBashTool(
-  options: { executionFacts?: ToolExecutionFacts; shell?: ShellPlan } = {},
+  options: { executionFacts?: ToolExecutionFacts; shell?: TurnShellPlan } = {},
 ): MakaTool {
-  const shell = options.shell ?? defaultShellPlan();
+  const shell = options.shell ?? { plan: defaultShellPlan() };
   return buildForegroundBashTool({
     description:
-      withShellGuidance('Run a shell command in the session cwd.', shell) +
+      withTurnShellGuidance('Run a shell command in the session cwd.', shell) +
       ' Subject to permission policy.',
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
     defaultTimeoutMs: () => 120_000,
-    execute: async ({ command, cwd, timeoutMs, ctx }) =>
-      runShellWithBoundedTail(command, {
+    execute: async ({ command, cwd, timeoutMs, ctx }) => {
+      throwIfShellSetupFailed(shell);
+      return runShellWithBoundedTail(command, {
         cwd,
         timeoutMs: timeoutMs ?? 120_000,
         abortSignal: ctx.abortSignal,
         emitOutput: ctx.emitOutput,
-        shell,
-      }),
+        shell: shell.plan,
+      });
+    },
   });
 }
 
@@ -145,7 +154,7 @@ export function buildManagedBashTool(
   shellRuns: ShellRunLauncher,
   options: {
     executionFacts?: ToolExecutionFacts;
-    shell?: ShellPlan;
+    shell?: TurnShellPlan;
     /** Opening sentence of the description, before the shared foreground/background/PTY contract. */
     lead?: string;
     /**
@@ -192,7 +201,7 @@ export function buildManagedBashTool(
       | undefined;
   } = {},
 ): MakaTool {
-  const shell = options.shell ?? defaultShellPlan();
+  const shell = options.shell ?? { plan: defaultShellPlan() };
   const declareSandboxBoundary = options.declareSandboxBoundary !== false;
   const managedBashFields = {
     command: z.string().describe('The shell command to execute'),
@@ -230,7 +239,7 @@ export function buildManagedBashTool(
     name: 'Bash',
     activityKind: 'command',
     description:
-      withShellGuidance(options.lead ?? 'Run a shell command in the session cwd.', shell) +
+      withTurnShellGuidance(options.lead ?? 'Run a shell command in the session cwd.', shell) +
       ` Foreground is the default (timeout ${DEFAULT_BASH_TIMEOUT_MS}ms, maximum ${MAX_FOREGROUND_BASH_TIMEOUT_MS}ms).` +
       ` Set run_in_background=true only when the command should continue as a tracked runtime background task; background commands have no default timeout (maximum explicit timeout ${MAX_SHELL_RUN_TIMEOUT_MS}ms).` +
       ' Set pty=true together with run_in_background=true only for terminal semantics or later input; use the returned ref with Read or WriteStdin.' +
@@ -251,6 +260,7 @@ export function buildManagedBashTool(
     toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
     impl: async (input, ctx) => {
+      throwIfShellSetupFailed(shell);
       const { command, timeout_ms, run_in_background, pty } = input;
       const normalizedRequiredBoundary = await preflightDeclaredSandboxBoundary(
         'required_boundary' in input ? input.required_boundary : undefined,
@@ -279,7 +289,7 @@ export function buildManagedBashTool(
           cwd: transformed?.cwd ?? ctx.cwd,
           command,
           ...(pty !== undefined ? { pty } : {}),
-          ...(transformed?.argv ? { argv: transformed.argv } : { shell }),
+          ...(transformed?.argv ? { argv: transformed.argv } : { shell: shell.plan }),
           ...(transformed?.env ? { env: transformed.env } : {}),
           ...(transformed?.fdInputs ? { fdInputs: transformed.fdInputs } : {}),
           ...(timeoutMs !== undefined ? { timeoutMs } : {}),
@@ -330,6 +340,12 @@ function onceCompletion(
 
 export function withShellGuidance(lead: string, shell: ShellPlan): string {
   const guidance = bashToolShellGuidance(shell);
+  return guidance ? `${lead} ${guidance}` : lead;
+}
+
+/** {@link withShellGuidance} for a turn-scoped plan, including the broken-preference outage notice. */
+export function withTurnShellGuidance(lead: string, shell: TurnShellPlan): string {
+  const guidance = bashToolTurnShellGuidance(shell);
   return guidance ? `${lead} ${guidance}` : lead;
 }
 

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -35,6 +35,29 @@ import {
 const execFileAsync = promisify(execFile);
 
 describe('runtime policy stores', () => {
+  test('upgrades schema v2 with the automatic Host shell default', async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const { shell: _shell, ...policyV2 } = createDefaultRuntimePolicy();
+      await writeFile(
+        join(root, 'runtime-policy.json'),
+        `${JSON.stringify({ schemaVersion: 2, revision: 4, policy: policyV2 })}\n`,
+      );
+
+      const snapshot = await stores.runtimePolicy.getSnapshot();
+      assert.equal(snapshot.revision, 4);
+      assert.deepEqual(snapshot.policy.shell, { preference: 'auto', executable: '' });
+      const committed = await stores.runtimePolicy.mutate({
+        expectedRevision: 4,
+        operation: { kind: 'set_shell', value: snapshot.policy.shell },
+      });
+      assert.equal(committed.kind, 'committed');
+      const persisted = JSON.parse(await readFile(join(root, 'runtime-policy.json'), 'utf8')) as {
+        schemaVersion: number;
+      };
+      assert.equal(persisted.schemaVersion, 3);
+    });
+  });
+
   test('persists extra request bodies and resolves custom headers as secret execution material', async () => {
     await withInteractiveOwner(async ({ stores }) => {
       const connection = await createConnection(stores, 0, {

--- a/packages/storage/src/runtime-policy/policy-document.ts
+++ b/packages/storage/src/runtime-policy/policy-document.ts
@@ -1,6 +1,7 @@
 import {
   createDefaultRuntimePolicy,
   decodeCanonicalRuntimePolicy,
+  decodeRuntimePolicyV2,
   normalizeRuntimePolicyMutation,
   type MutateRuntimePolicyInput,
   type MutateRuntimePolicyResult,
@@ -23,7 +24,7 @@ import {
 } from './document-io.js';
 
 const FILE = 'runtime-policy.json';
-const SCHEMA_VERSION = 2 as const;
+const SCHEMA_VERSION = 3 as const;
 
 export interface RuntimePolicyDocument {
   readonly schemaVersion: typeof SCHEMA_VERSION;
@@ -48,13 +49,17 @@ export class RuntimePolicyDocumentOwner {
       'revision',
       'policy',
     ]);
-    if (document.schemaVersion !== SCHEMA_VERSION) {
+    if (document.schemaVersion !== 2 && document.schemaVersion !== SCHEMA_VERSION) {
       throw codecError('invalid_document', `${FILE} has an unsupported schema version`);
     }
     return {
       schemaVersion: SCHEMA_VERSION,
       revision: revision(document.revision, `${FILE}.revision`, 'invalid_document'),
-      policy: decodePersistedDomain(() => decodeCanonicalRuntimePolicy(document.policy)),
+      policy: decodePersistedDomain(() =>
+        document.schemaVersion === 2
+          ? decodeRuntimePolicyV2(document.policy)
+          : decodeCanonicalRuntimePolicy(document.policy),
+      ),
     };
   }
 
@@ -127,6 +132,8 @@ function applyMutation(policy: RuntimePolicy, operation: RuntimePolicyMutation):
       return { ...policy, webSearch: operation.value };
     case 'set_subagents':
       return { ...policy, subagents: operation.value };
+    case 'set_shell':
+      return { ...policy, shell: operation.value };
     case 'patch_agent_settings':
       return {
         ...policy,

--- a/scripts/windows-test-inventory.mjs
+++ b/scripts/windows-test-inventory.mjs
@@ -222,12 +222,16 @@ function classifySkip(path, title, expression) {
   return 'portable-candidate';
 }
 
-function excludesWindows(expression) {
+export function excludesWindows(expression) {
   const compact = expression.replaceAll(/\s+/gu, ' ');
   // A Windows-only regression commonly uses `false` on Windows and a skip
-  // reason elsewhere. Mentioning win32 in that ternary means the opposite of
-  // excluding Windows, so do not count it in the Windows skip inventory.
-  if (/process\.platform\s*===\s*['"]win32['"]\s*\?\s*false\s*:/u.test(compact)) {
+  // reason elsewhere. Exempt only when that ternary is the complete skip
+  // expression: a surrounding boolean expression may still skip on Windows.
+  if (
+    /^process\.platform\s*===\s*(['"])win32\1\s*\?\s*false\s*:\s*(?:'(?:\\.|[^'\\])*'|"(?:\\.|[^"\\])*")$/u.test(
+      compact,
+    )
+  ) {
     return false;
   }
   return (

--- a/scripts/windows-test-inventory.mjs
+++ b/scripts/windows-test-inventory.mjs
@@ -223,7 +223,7 @@ function classifySkip(path, title, expression) {
 }
 
 export function excludesWindows(expression) {
-  const compact = expression.replaceAll(/\s+/gu, ' ');
+  const compact = stripBalancedOuterParentheses(expression.replaceAll(/\s+/gu, ' ').trim());
   // A Windows-only regression commonly uses `false` on Windows and a skip
   // reason elsewhere. Exempt only when that ternary is the complete skip
   // expression: a surrounding boolean expression may still skip on Windows.
@@ -238,6 +238,39 @@ export function excludesWindows(expression) {
     /process\.platform\s*===\s*['"]win32['"]/u.test(compact) ||
     /process\.platform\s*!==\s*['"]darwin['"]/u.test(compact)
   );
+}
+
+function stripBalancedOuterParentheses(expression) {
+  let compact = expression;
+  while (hasCompleteOuterParentheses(compact)) compact = compact.slice(1, -1).trim();
+  return compact;
+}
+
+function hasCompleteOuterParentheses(expression) {
+  if (!expression.startsWith('(') || !expression.endsWith(')')) return false;
+  let depth = 0;
+  let quote;
+  let escaped = false;
+  for (let index = 0; index < expression.length; index += 1) {
+    const char = expression[index];
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = undefined;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '(') depth += 1;
+    else if (char === ')') {
+      depth -= 1;
+      if (depth === 0) return index === expression.length - 1;
+      if (depth < 0) return false;
+    }
+  }
+  return false;
 }
 
 function nearbyTestTitle(lines, skipIndex) {

--- a/scripts/windows-test-inventory.mjs
+++ b/scripts/windows-test-inventory.mjs
@@ -224,6 +224,12 @@ function classifySkip(path, title, expression) {
 
 function excludesWindows(expression) {
   const compact = expression.replaceAll(/\s+/gu, ' ');
+  // A Windows-only regression commonly uses `false` on Windows and a skip
+  // reason elsewhere. Mentioning win32 in that ternary means the opposite of
+  // excluding Windows, so do not count it in the Windows skip inventory.
+  if (/process\.platform\s*===\s*['"]win32['"]\s*\?\s*false\s*:/u.test(compact)) {
+    return false;
+  }
   return (
     /process\.platform\s*===\s*['"]win32['"]/u.test(compact) ||
     /process\.platform\s*!==\s*['"]darwin['"]/u.test(compact)

--- a/scripts/windows-test-inventory.test.mjs
+++ b/scripts/windows-test-inventory.test.mjs
@@ -7,12 +7,22 @@ test('exempts a complete Windows-false ternary from the skip inventory', () => {
     excludesWindows("process.platform === 'win32' ? false : 'Windows-only regression'"),
     false,
   );
+  assert.equal(
+    excludesWindows("((process.platform === 'win32' ? false : 'Windows-only regression'))"),
+    false,
+  );
 });
 
 test('keeps a composite expression that can still skip on Windows', () => {
   assert.equal(
     excludesWindows(
       "(process.platform === 'win32' ? false : 'Unix-only') || process.env.CI === '1'",
+    ),
+    true,
+  );
+  assert.equal(
+    excludesWindows(
+      "(process.platform === 'win32' ? false : 'Unix-only') || (process.env.CI === '1')",
     ),
     true,
   );

--- a/scripts/windows-test-inventory.test.mjs
+++ b/scripts/windows-test-inventory.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { excludesWindows } from './windows-test-inventory.mjs';
+
+test('exempts a complete Windows-false ternary from the skip inventory', () => {
+  assert.equal(
+    excludesWindows("process.platform === 'win32' ? false : 'Windows-only regression'"),
+    false,
+  );
+});
+
+test('keeps a composite expression that can still skip on Windows', () => {
+  assert.equal(
+    excludesWindows(
+      "(process.platform === 'win32' ? false : 'Unix-only') || process.env.CI === '1'",
+    ),
+    true,
+  );
+});
+
+test('keeps a direct Windows exclusion in the skip inventory', () => {
+  assert.equal(excludesWindows("process.platform === 'win32' ? 'POSIX-only' : false"), true);
+});


### PR DESCRIPTION
## Summary

- add a Host-owned `auto` / `git_bash` shell preference while keeping the existing PowerShell-first Windows detection unchanged by default
- validate an explicit `bash.exe` on the Runtime Host before persisting it, then use the resolved `ShellPlan` for Bash tools, child agents, background and PTY execution, the integrated terminal, and model-facing shell guidance
- add the Desktop setting and preserve older Runtime Policy documents through the schema migration; the legacy `System32\bash.exe` WSL shim uses stdin for non-PTY commands

The executable path is intentionally resolved on the Runtime Host, not the Desktop Client. This keeps remote Desktop connections honest and makes an invalid or later-missing explicit path fail closed instead of silently returning to PowerShell.

Fixes #2195

### Desktop

![Git Bash setting in Desktop](https://raw.githubusercontent.com/me2seeks/maka-agent/16712606719decf799038c5ed7d2d1c8736d9e31/git-bash-settings.png)

## Verification

- `npm run build:test`
- `npm run test:dist:serial` — all workspace tests passed
- `npm run typecheck`
- `npx biome check .`
- `git diff --check`
- rendered and inspected `Product/Settings/Pages/General Git Bash` in Storybook at 1440×1000

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

<details>
<summary>中文对照</summary>

## 概要

- 增加由 Runtime Host 持有的 `auto` / `git_bash` shell 偏好；默认仍保持现有的 Windows PowerShell 优先检测
- 显式选择时，由 Runtime Host 在持久化前验证 `bash.exe`，并将解析出的同一个 `ShellPlan` 用于 Bash 工具、子 Agent、后台与 PTY 执行、集成终端以及面向模型的 shell 方言说明
- 增加 Desktop 设置，并通过 schema 迁移兼容旧 Runtime Policy 文档；旧版 `System32\bash.exe` WSL shim 的非 PTY 命令通过 stdin 输入

可执行文件路径刻意在 Runtime Host 而不是 Desktop Client 上解析。这样远程 Desktop 连接不会误用客户端机器的路径；显式路径无效或之后消失时也会失败关闭，而不会静默回退到 PowerShell。

</details>

## AI use

- [ ] No generative tool was used for implementation.
- [x] Generative tooling was used and the result was reviewed and verified by the author.

Tool(s) and scope: OpenAI Codex (Maka) assisted with the original implementation, tests, and review remediation. OpenAI Codex handled the current-main rebase, compatibility-epoch conflict resolution, and final local verification.

Final squash trailers:

```
Generated-by: Maka
Generated-by: Codex
```
