### PR TITLE
feat(desktop): unify native locale authority

### DIFF
--- a/apps/desktop/src/main/__tests__/client-settings-effects.test.ts
+++ b/apps/desktop/src/main/__tests__/client-settings-effects.test.ts
@@ -16,6 +16,7 @@ test('applies each client settings snapshot once across local writes and file wa
     applyBotSettings: async () => {
       botApplications += 1;
     },
+    observeLocale: () => undefined,
     emitExternalChanged: () => {
       rendererEvents += 1;
     },

--- a/apps/desktop/src/main/__tests__/computer-use-status-item-locale.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-status-item-locale.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createDefaultSettings, mergeSettings } from '@maka/core/settings';
+import { createComputerUseStatusItem } from '../computer-use/status-item.js';
+import { createDesktopLocaleAuthority } from '../desktop-locale-authority.js';
+
+type MenuTemplate = Array<{ label?: string }>;
+
+test('rebuilds an active Computer Use menu when its resolved locale changes', () => {
+  const locale = createDesktopLocaleAuthority({
+    readSettings: async () => createDefaultSettings(),
+    preferredSystemLanguages: () => ['en-US'],
+  });
+  const menus: MenuTemplate[] = [];
+  const item = createComputerUseStatusItem({
+    loadImage: () => ({}) as never,
+    createTray: () => ({
+      setIgnoreDoubleClickEvents: () => undefined,
+      setContextMenu: (menu: unknown) => {
+        menus.push((menu as { template: MenuTemplate }).template);
+      },
+      destroy: () => undefined,
+    }) as never,
+    buildMenu: (template) => ({ template }) as never,
+    resolveLocale: () => locale.current(),
+    subscribeLocaleChanges: (listener) => locale.subscribe(listener),
+  });
+
+  item.noteSessionActive('session-1');
+  item.noteSessionApp('session-1', 'Safari');
+  assert.deepEqual(menus.at(-1)?.map((row) => row.label), ['Stop Using Safari']);
+
+  locale.observe(mergeSettings(createDefaultSettings(), {
+    personalization: { uiLocale: 'zh' },
+  }));
+  assert.deepEqual(menus.at(-1)?.map((row) => row.label), ['停止操作 Safari']);
+
+  item.destroy();
+  locale.observe(mergeSettings(createDefaultSettings(), {
+    personalization: { uiLocale: 'en' },
+  }));
+  assert.deepEqual(menus.at(-1)?.map((row) => row.label), ['停止操作 Safari']);
+});

--- a/apps/desktop/src/main/__tests__/desktop-locale-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-locale-authority.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { createDefaultSettings, mergeSettings } from '@maka/core';
+import { createDefaultSettings, mergeSettings } from '@maka/core/settings';
 import { createDesktopLocaleAuthority } from '../desktop-locale-authority.js';
 
 test('resolves explicit preferences and observes a mid-session settings change', async () => {

--- a/apps/desktop/src/main/__tests__/desktop-locale-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-locale-authority.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createDefaultSettings, mergeSettings } from '@maka/core';
+import { createDesktopLocaleAuthority } from '../desktop-locale-authority.js';
+
+test('resolves explicit preferences and observes a mid-session settings change', async () => {
+  let settings = mergeSettings(createDefaultSettings(), {
+    personalization: { uiLocale: 'zh' },
+  });
+  const authority = createDesktopLocaleAuthority({
+    readSettings: async () => settings,
+    preferredSystemLanguages: () => ['en-US'],
+  });
+
+  assert.equal(await authority.resolve(), 'zh');
+  assert.equal(authority.current(), 'zh');
+  settings = mergeSettings(settings, { personalization: { uiLocale: 'en' } });
+  authority.observe(settings);
+  assert.equal(authority.current(), 'en');
+});
+
+test('keeps automatic preference live against the current system fallback', async () => {
+  let languages: readonly string[] = ['en-US'];
+  const authority = createDesktopLocaleAuthority({
+    readSettings: async () => createDefaultSettings(),
+    preferredSystemLanguages: () => languages,
+  });
+
+  assert.equal(await authority.resolve(), 'en');
+  languages = ['zh-CN'];
+  assert.equal(authority.current(), 'zh');
+});
+
+test('does not let a stale read replace a newer observed preference', async () => {
+  let release!: (settings: ReturnType<typeof createDefaultSettings>) => void;
+  const pending = new Promise<ReturnType<typeof createDefaultSettings>>((resolve) => {
+    release = resolve;
+  });
+  const authority = createDesktopLocaleAuthority({
+    readSettings: () => pending,
+    preferredSystemLanguages: () => ['en-US'],
+  });
+
+  const read = authority.resolve();
+  authority.observe(mergeSettings(createDefaultSettings(), {
+    personalization: { uiLocale: 'zh' },
+  }));
+  release(createDefaultSettings());
+
+  assert.equal(await read, 'zh');
+  assert.equal(authority.current(), 'zh');
+});
+
+test('falls back to its current projection when settings cannot be read', async () => {
+  const authority = createDesktopLocaleAuthority({
+    readSettings: async () => { throw new Error('unreadable'); },
+    preferredSystemLanguages: () => ['zh-CN'],
+  });
+  assert.equal(await authority.resolve(), 'zh');
+});

--- a/apps/desktop/src/main/__tests__/desktop-locale-authority.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-locale-authority.test.ts
@@ -19,6 +19,28 @@ test('resolves explicit preferences and observes a mid-session settings change',
   assert.equal(authority.current(), 'en');
 });
 
+test('publishes only resolved-locale changes and allows listeners to detach', () => {
+  const authority = createDesktopLocaleAuthority({
+    readSettings: async () => createDefaultSettings(),
+    preferredSystemLanguages: () => ['en-US'],
+  });
+  const observed: string[] = [];
+  const unsubscribe = authority.subscribe((locale) => observed.push(locale));
+
+  authority.observe(mergeSettings(createDefaultSettings(), {
+    personalization: { uiLocale: 'en' },
+  }));
+  authority.observe(mergeSettings(createDefaultSettings(), {
+    personalization: { uiLocale: 'zh' },
+  }));
+  unsubscribe();
+  authority.observe(mergeSettings(createDefaultSettings(), {
+    personalization: { uiLocale: 'en' },
+  }));
+
+  assert.deepEqual(observed, ['zh']);
+});
+
 test('keeps automatic preference live against the current system fallback', async () => {
   let languages: readonly string[] = ['en-US'];
   const authority = createDesktopLocaleAuthority({
@@ -40,6 +62,8 @@ test('does not let a stale read replace a newer observed preference', async () =
     readSettings: () => pending,
     preferredSystemLanguages: () => ['en-US'],
   });
+  const observed: string[] = [];
+  authority.subscribe((locale) => observed.push(locale));
 
   const read = authority.resolve();
   authority.observe(mergeSettings(createDefaultSettings(), {
@@ -49,6 +73,7 @@ test('does not let a stale read replace a newer observed preference', async () =
 
   assert.equal(await read, 'zh');
   assert.equal(authority.current(), 'zh');
+  assert.deepEqual(observed, ['zh']);
 });
 
 test('falls back to its current projection when settings cannot be read', async () => {

--- a/apps/desktop/src/main/__tests__/desktop-native-copy.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-native-copy.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  clientSettingsConfirmation,
+} from '../client-settings-confirmation-copy.js';
+import { projectPickerTitle } from '../project-picker-copy.js';
+
+test('localizes native picker and client settings confirmation copy', () => {
+  assert.equal(projectPickerTitle('zh'), '添加项目');
+  assert.deepEqual(
+    clientSettingsConfirmation(
+      [{ key: 'keepSystemAwake', current: false, next: true }],
+      'zh',
+    ),
+    {
+      message: '允许 Maka 更新此客户端的设置吗？',
+      detail: '保持系统唤醒: 关闭 → 开启',
+      buttons: ['应用更改', '取消'],
+    },
+  );
+});

--- a/apps/desktop/src/main/__tests__/notifications-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/notifications-policy.test.ts
@@ -1,7 +1,9 @@
 import { it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  isRunNotificationKind,
   resolveNotificationContent,
+  runNotificationCopy,
   shouldRaiseRunNotification,
 } from '../notifications-policy.js';
 
@@ -21,29 +23,44 @@ it('gates native notifications through every required condition', () => {
   }
 });
 
+it('recognizes terminal kinds and keeps distinct localized fallback copy', () => {
+  for (const value of ['completed', 'errored']) assert.equal(isRunNotificationKind(value), true);
+  for (const value of ['complete', 'error', 'aborted', '', undefined, null, 1, {}]) {
+    assert.equal(isRunNotificationKind(value), false);
+  }
+
+  const completed = runNotificationCopy('completed', 'zh');
+  const errored = runNotificationCopy('errored', 'zh');
+  assert.ok(completed.title && completed.body);
+  assert.ok(errored.title && errored.body);
+  assert.notEqual(completed.title, errored.title);
+});
+
 it('sanitizes renderer content, caps it, and falls back per field', () => {
-  const clean = resolveNotificationContent({
-    kind: 'completed',
-    title: '  会话  A  ',
-    body: 'line one\n\nline two\tindented',
-  });
+  const clean = resolveNotificationContent(
+    { kind: 'completed', title: '  会话  A  ', body: 'line one\n\nline two\tindented' },
+    'zh',
+  );
   assert.deepEqual(clean, { title: '会话 A', body: 'line one line two indented' });
 
-  const completedFallback = resolveNotificationContent({ kind: 'completed' });
-  for (const value of ['   ', undefined]) {
+  const completedFallback = runNotificationCopy('completed', 'zh');
+  for (const value of ['', '   ', undefined, null, 42, {}]) {
     assert.deepEqual(
-      resolveNotificationContent({ kind: 'completed', title: value, body: value }),
+      resolveNotificationContent({ kind: 'completed', title: value, body: value }, 'zh'),
       completedFallback,
     );
   }
 
-  const capped = resolveNotificationContent({ kind: 'completed', title: 'S', body: 'x'.repeat(500) });
+  const capped = resolveNotificationContent(
+    { kind: 'completed', title: 'S', body: 'x'.repeat(500) },
+    'zh',
+  );
   assert.equal(capped.body.length, 160);
   assert.ok(capped.body.endsWith('…'));
 
-  const erroredFallback = resolveNotificationContent({ kind: 'errored' });
-  assert.deepEqual(resolveNotificationContent({ kind: 'errored', title: '出错的会话', body: '' }), {
-    title: '出错的会话',
-    body: erroredFallback.body,
-  });
+  const erroredFallback = runNotificationCopy('errored', 'zh');
+  assert.deepEqual(
+    resolveNotificationContent({ kind: 'errored', title: '出错的会话', body: '' }, 'zh'),
+    { title: '出错的会话', body: erroredFallback.body },
+  );
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-upgrade-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-upgrade-dialog.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { buildRuntimeHostUpgradeDialogOptions } from '../runtime-host-upgrade-copy.js';
+
+const conflict = {
+  kind: 'upgrade_required',
+  restartable: true,
+  registration: {},
+  handshake: {
+    activity: {
+      connections: 2,
+      activeOperations: 1,
+      processUptimeSeconds: 120,
+      residencies: [
+        { label: 'scheduled-task', count: 2 },
+        { label: 'daily-review', count: 1 },
+      ],
+    },
+  },
+} as never;
+
+test('localizes upgrade activity without changing decision indexes', () => {
+  const en = buildRuntimeHostUpgradeDialogOptions(conflict, true, 'en');
+  const zh = buildRuntimeHostUpgradeDialogOptions(conflict, true, 'zh');
+  assert.deepEqual(en.buttons, ['Restart Runtime Host', 'Wait', 'Cancel Startup']);
+  assert.deepEqual(zh.buttons, ['重启 Runtime Host', '等待', '取消启动']);
+  assert.equal(en.defaultId, 1);
+  assert.equal(zh.defaultId, 1);
+  assert.match(zh.detail ?? '', /仍有 2 个其他客户端连接/);
+  assert.match(zh.detail ?? '', /每日回顾: 1/);
+  assert.match(en.detail ?? '', /Scheduled Task: 2/);
+  assert.match(zh.detail ?? '', /计划任务: 2/);
+});

--- a/apps/desktop/src/main/client-settings-confirmation-copy.ts
+++ b/apps/desktop/src/main/client-settings-confirmation-copy.ts
@@ -1,0 +1,34 @@
+import type { UiLocale } from '@maka/core';
+import type { ClientSettingsChange } from './client-settings-tools.js';
+
+export function clientSettingsConfirmation(
+  changes: readonly ClientSettingsChange[],
+  locale: UiLocale,
+): { message: string; detail: string; buttons: [string, string] } {
+  const zh = locale === 'zh';
+  const labels: Record<ClientSettingsChange['key'], readonly [string, string]> = {
+    theme: ['Theme', '主题'],
+    palette: ['Palette', '配色'],
+    uiLocale: ['UI language', '界面语言'],
+    runComplete: ['Run-complete notifications', '回答完成通知'],
+    keepSystemAwake: ['Keep system awake', '保持系统唤醒'],
+  };
+  const value = (input: string | boolean | undefined): string => {
+    if (!zh) return String(input);
+    if (input === true) return '开启';
+    if (input === false) return '关闭';
+    return String(input);
+  };
+  return {
+    message: zh
+      ? '允许 Maka 更新此客户端的设置吗？'
+      : "Allow Maka to update this client's settings?",
+    detail: changes
+      .map(
+        (change) =>
+          `${labels[change.key][zh ? 1 : 0]}: ${value(change.current)} → ${value(change.next)}`,
+      )
+      .join('\n'),
+    buttons: zh ? ['应用更改', '取消'] : ['Apply changes', 'Cancel'],
+  };
+}

--- a/apps/desktop/src/main/client-settings-confirmation-copy.ts
+++ b/apps/desktop/src/main/client-settings-confirmation-copy.ts
@@ -1,4 +1,4 @@
-import type { UiLocale } from '@maka/core';
+import type { UiLocale } from '@maka/core/ui-locale';
 import type { ClientSettingsChange } from './client-settings-tools.js';
 
 export function clientSettingsConfirmation(

--- a/apps/desktop/src/main/client-settings-effects.ts
+++ b/apps/desktop/src/main/client-settings-effects.ts
@@ -10,6 +10,7 @@ interface ClientSettingsEffectDependencies {
   readonly settingsStore: Pick<SettingsStore, 'get'>;
   readonly applyKeepSystemAwake: (enabled: boolean) => Promise<void>;
   readonly applyBotSettings: (settings: AppSettings['botChat']) => Promise<void>;
+  readonly observeLocale: (settings: AppSettings) => void;
   readonly emitExternalChanged: () => void;
 }
 
@@ -32,6 +33,7 @@ export function createClientSettingsEffects(
       const rendererChanged = nextRendererFingerprint !== rendererFingerprint;
       const keepAwakeChanged = settings.system.keepSystemAwake !== keepSystemAwake;
       const botChanged = nextBotFingerprint !== botFingerprint;
+      dependencies.observeLocale(settings);
       if (keepAwakeChanged) {
         await dependencies.applyKeepSystemAwake(settings.system.keepSystemAwake);
         keepSystemAwake = settings.system.keepSystemAwake;

--- a/apps/desktop/src/main/client-settings-tools.ts
+++ b/apps/desktop/src/main/client-settings-tools.ts
@@ -23,7 +23,13 @@ type ClientSettingsPatch = z.infer<typeof patchSchema>;
 export interface ClientSettingsToolAuthority {
   read(): Promise<AppSettings>;
   update(patch: UpdateAppSettingsInput): Promise<AppSettings>;
-  confirm(changes: readonly string[]): Promise<boolean>;
+  confirm(changes: readonly ClientSettingsChange[]): Promise<boolean>;
+}
+
+export interface ClientSettingsChange {
+  readonly key: 'theme' | 'palette' | 'uiLocale' | 'runComplete' | 'keepSystemAwake';
+  readonly current: string | boolean | undefined;
+  readonly next: string | boolean;
 }
 
 interface ClientSettingsSnapshot {
@@ -60,9 +66,10 @@ export function buildClientSettingsTools(
     executionSemantics: 'exclusive_step',
     impl: async (input) => {
       const current = await authority.read();
-      const changes = describeChanges(current, input);
+      const proposedChanges = describeChanges(current, input);
+      const changes = proposedChanges.map(describeChange);
       if (changes.length === 0) return unchanged(current);
-      if (!(await authority.confirm(changes))) {
+      if (!(await authority.confirm(proposedChanges))) {
         return {
           kind: 'maka_client_settings_update',
           applied: false,
@@ -123,20 +130,20 @@ function toSettingsPatch(input: ClientSettingsPatch): UpdateAppSettingsInput {
   };
 }
 
-function describeChanges(current: AppSettings, patch: ClientSettingsPatch): string[] {
-  const changes: string[] = [];
-  compare(changes, 'Theme', current.appearance.theme, patch.appearance?.theme);
-  compare(changes, 'Palette', current.appearance.palette, patch.appearance?.palette);
-  compare(changes, 'UI language', current.personalization.uiLocale, patch.uiLocale);
+function describeChanges(current: AppSettings, patch: ClientSettingsPatch): ClientSettingsChange[] {
+  const changes: ClientSettingsChange[] = [];
+  compare(changes, 'theme', current.appearance.theme, patch.appearance?.theme);
+  compare(changes, 'palette', current.appearance.palette, patch.appearance?.palette);
+  compare(changes, 'uiLocale', current.personalization.uiLocale, patch.uiLocale);
   compare(
     changes,
-    'Run-complete notifications',
+    'runComplete',
     current.notifications.runComplete,
     patch.notifications?.runComplete,
   );
   compare(
     changes,
-    'Keep system awake',
+    'keepSystemAwake',
     current.system.keepSystemAwake,
     patch.system?.keepSystemAwake,
   );
@@ -144,12 +151,23 @@ function describeChanges(current: AppSettings, patch: ClientSettingsPatch): stri
 }
 
 function compare(
-  changes: string[],
-  label: string,
+  changes: ClientSettingsChange[],
+  key: ClientSettingsChange['key'],
   current: string | boolean | undefined,
   next: string | boolean | undefined,
 ): void {
   if (next !== undefined && next !== current) {
-    changes.push(`${label}: ${String(current)} → ${String(next)}`);
+    changes.push({ key, current, next });
   }
+}
+
+function describeChange(change: ClientSettingsChange): string {
+  const labels: Record<ClientSettingsChange['key'], string> = {
+    theme: 'Theme',
+    palette: 'Palette',
+    uiLocale: 'UI language',
+    runComplete: 'Run-complete notifications',
+    keepSystemAwake: 'Keep system awake',
+  };
+  return `${labels[change.key]}: ${String(change.current)} → ${String(change.next)}`;
 }

--- a/apps/desktop/src/main/computer-use/status-item.ts
+++ b/apps/desktop/src/main/computer-use/status-item.ts
@@ -89,6 +89,8 @@ export interface ComputerUseStatusItemDeps {
    * main-process strings.
    */
   resolveLocale?: () => UiLocale;
+  /** Registers a listener for resolved-locale changes. */
+  subscribeLocaleChanges?: (listener: () => void) => () => void;
   /** Test seams: the contract is drivable without an Electron main process. */
   loadImage?: () => Electron.NativeImage;
   buildMenu?: (template: Electron.MenuItemConstructorOptions[]) => MenuType;
@@ -227,6 +229,8 @@ export function createComputerUseStatusItem(
     tray = null;
   }
 
+  const unsubscribeLocale = deps.subscribeLocaleChanges?.(rebuildMenu) ?? (() => undefined);
+
   return {
     noteSessionActive(sessionId: string): void {
       if (typeof sessionId !== 'string' || sessionId.length === 0) return;
@@ -266,6 +270,7 @@ export function createComputerUseStatusItem(
     },
 
     destroy(): void {
+      unsubscribeLocale();
       const wasLive = sessions.size > 0;
       sessions.clear();
       hide();

--- a/apps/desktop/src/main/desktop-locale-authority.ts
+++ b/apps/desktop/src/main/desktop-locale-authority.ts
@@ -15,6 +15,8 @@ export interface DesktopLocaleAuthority {
   resolve(): Promise<UiLocale>;
   /** Advances the synchronous projection from an already-read settings snapshot. */
   observe(settings: LocaleSettings): UiLocale;
+  /** Observes resolved-locale changes for already-materialized native presentation. */
+  subscribe(listener: (locale: UiLocale) => void): () => void;
 }
 
 /** One locale owner for post-settings Desktop main-process presentation. */
@@ -24,17 +26,36 @@ export function createDesktopLocaleAuthority(input: {
 }): DesktopLocaleAuthority {
   let preference: UiLocalePreference = 'auto';
   let observation = 0;
+  const listeners = new Set<(locale: UiLocale) => void>();
   const systemLocale = (): UiLocale =>
     resolveSystemUiLocale([...input.preferredSystemLanguages()]);
   const current = (): UiLocale => resolveUiLocale(preference, systemLocale());
+  let published = current();
+  const publish = (): UiLocale => {
+    const next = current();
+    if (next === published) return next;
+    published = next;
+    for (const listener of [...listeners]) {
+      try {
+        listener(next);
+      } catch {
+        // A native projection must not make a persisted settings update fail.
+      }
+    }
+    return next;
+  };
   const observe = (settings: LocaleSettings): UiLocale => {
     observation += 1;
     preference = settings.personalization.uiLocale;
-    return current();
+    return publish();
   };
   return Object.freeze({
     current,
     observe,
+    subscribe: (listener: (locale: UiLocale) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
     resolve: async () => {
       const request = ++observation;
       try {
@@ -43,7 +64,7 @@ export function createDesktopLocaleAuthority(input: {
       } catch {
         // Locale presentation must not block startup or an unrelated native action.
       }
-      return current();
+      return publish();
     },
   });
 }

--- a/apps/desktop/src/main/desktop-locale-authority.ts
+++ b/apps/desktop/src/main/desktop-locale-authority.ts
@@ -1,10 +1,10 @@
 import {
   resolveSystemUiLocale,
   resolveUiLocale,
-  type AppSettings,
   type UiLocale,
   type UiLocalePreference,
-} from '@maka/core';
+} from '@maka/core/ui-locale';
+import type { AppSettings } from '@maka/core/settings';
 
 type LocaleSettings = Pick<AppSettings, 'personalization'>;
 

--- a/apps/desktop/src/main/desktop-locale-authority.ts
+++ b/apps/desktop/src/main/desktop-locale-authority.ts
@@ -1,0 +1,49 @@
+import {
+  resolveSystemUiLocale,
+  resolveUiLocale,
+  type AppSettings,
+  type UiLocale,
+  type UiLocalePreference,
+} from '@maka/core';
+
+type LocaleSettings = Pick<AppSettings, 'personalization'>;
+
+export interface DesktopLocaleAuthority {
+  /** Latest observed preference, resolved against the current system languages. */
+  current(): UiLocale;
+  /** Reads the persisted Client preference before an asynchronous native interaction. */
+  resolve(): Promise<UiLocale>;
+  /** Advances the synchronous projection from an already-read settings snapshot. */
+  observe(settings: LocaleSettings): UiLocale;
+}
+
+/** One locale owner for post-settings Desktop main-process presentation. */
+export function createDesktopLocaleAuthority(input: {
+  readonly readSettings: () => Promise<LocaleSettings>;
+  readonly preferredSystemLanguages: () => readonly string[];
+}): DesktopLocaleAuthority {
+  let preference: UiLocalePreference = 'auto';
+  let observation = 0;
+  const systemLocale = (): UiLocale =>
+    resolveSystemUiLocale([...input.preferredSystemLanguages()]);
+  const current = (): UiLocale => resolveUiLocale(preference, systemLocale());
+  const observe = (settings: LocaleSettings): UiLocale => {
+    observation += 1;
+    preference = settings.personalization.uiLocale;
+    return current();
+  };
+  return Object.freeze({
+    current,
+    observe,
+    resolve: async () => {
+      const request = ++observation;
+      try {
+        const settings = await input.readSettings();
+        if (request === observation) preference = settings.personalization.uiLocale;
+      } catch {
+        // Locale presentation must not block startup or an unrelated native action.
+      }
+      return current();
+    },
+  });
+}

--- a/apps/desktop/src/main/desktop-native-capability-assembly.ts
+++ b/apps/desktop/src/main/desktop-native-capability-assembly.ts
@@ -28,7 +28,7 @@ const COMPUTER_USE_WAKE_HOLD = 'computer-use';
 
 export interface DesktopNativeCapabilityAssemblyDeps {
   readonly isComputerUseRealModelE2e: boolean;
-  readonly locale: Pick<DesktopLocaleAuthority, 'current'>;
+  readonly locale: Pick<DesktopLocaleAuthority, 'current' | 'subscribe'>;
   readonly keepSystemAwake?: { hold(reason: string): void; release(reason: string): void };
   readonly mainWindow?: {
     windowBounds(): { x: number; y: number; width: number; height: number } | undefined;
@@ -57,6 +57,7 @@ export function assembleDesktopNativeCapabilities(
 
   const computerUseStatusItem = createComputerUseStatusItem({
     resolveLocale: () => deps.locale.current(),
+    subscribeLocaleChanges: (listener) => deps.locale.subscribe(listener),
     onLiveChanged: (live) => {
       if (live) deps.keepSystemAwake?.hold(COMPUTER_USE_WAKE_HOLD);
       else deps.keepSystemAwake?.release(COMPUTER_USE_WAKE_HOLD);

--- a/apps/desktop/src/main/desktop-native-capability-assembly.ts
+++ b/apps/desktop/src/main/desktop-native-capability-assembly.ts
@@ -1,7 +1,4 @@
 import { app, nativeImage, powerMonitor, screen } from 'electron';
-import { resolveSystemUiLocale, resolveUiLocale } from '@maka/core/ui-locale';
-import type { AppSettings } from '@maka/core/settings';
-import type { UiLocale } from '@maka/core/ui-locale';
 import { createComputerUseOverlayHook } from '@maka/computer-use';
 import { buildBrowserTools } from './browser/browser-tools.js';
 import {
@@ -25,12 +22,13 @@ import {
   applyComputerUseRealModelPolicy,
   parseComputerUseRealModelPolicy,
 } from './computer-use-real-model-policy.js';
+import type { DesktopLocaleAuthority } from './desktop-locale-authority.js';
 
 const COMPUTER_USE_WAKE_HOLD = 'computer-use';
 
 export interface DesktopNativeCapabilityAssemblyDeps {
   readonly isComputerUseRealModelE2e: boolean;
-  readonly settings: { get(): Promise<AppSettings> };
+  readonly locale: Pick<DesktopLocaleAuthority, 'current'>;
   readonly keepSystemAwake?: { hold(reason: string): void; release(reason: string): void };
   readonly mainWindow?: {
     windowBounds(): { x: number; y: number; width: number; height: number } | undefined;
@@ -57,19 +55,8 @@ export function assembleDesktopNativeCapabilities(
       : {},
   );
 
-  let uiLocale: UiLocale | undefined;
-  const resolveComputerUseLocale = (): UiLocale => {
-    const system = resolveSystemUiLocale(app.getPreferredSystemLanguages());
-    void deps.settings
-      .get()
-      .then((settings) => {
-        uiLocale = resolveUiLocale(settings.personalization.uiLocale, system);
-      })
-      .catch(() => undefined);
-    return uiLocale ?? system;
-  };
   const computerUseStatusItem = createComputerUseStatusItem({
-    resolveLocale: resolveComputerUseLocale,
+    resolveLocale: () => deps.locale.current(),
     onLiveChanged: (live) => {
       if (live) deps.keepSystemAwake?.hold(COMPUTER_USE_WAKE_HOLD);
       else deps.keepSystemAwake?.release(COMPUTER_USE_WAKE_HOLD);

--- a/apps/desktop/src/main/notifications-ipc-main.ts
+++ b/apps/desktop/src/main/notifications-ipc-main.ts
@@ -1,6 +1,7 @@
 import { ipcMain, Notification } from 'electron';
 import type { AppSettings } from '@maka/core/settings';
 import type { createMainWindowController } from './main-window.js';
+import type { DesktopLocaleAuthority } from './desktop-locale-authority.js';
 import {
   isRunNotificationKind,
   resolveNotificationContent,
@@ -12,6 +13,7 @@ type MainWindowController = ReturnType<typeof createMainWindowController>;
 interface NotificationsIpcDeps {
   ipcMain?: Pick<typeof ipcMain, 'handle'>;
   settingsStore: { get(): Promise<AppSettings> };
+  locale: Pick<DesktopLocaleAuthority, 'observe'>;
   mainWindowController: MainWindowController;
   e2e: boolean;
 }
@@ -48,7 +50,10 @@ export function registerNotificationsIpc(deps: NotificationsIpcDeps): void {
 
     // Prefer the renderer's session name + reply preview; policy applies
     // per-field fallbacks + sanitization for blank/oversize/non-strings.
-    const copy = resolveNotificationContent({ kind: raw.kind, title: raw.title, body: raw.body });
+    const copy = resolveNotificationContent(
+      { kind: raw.kind, title: raw.title, body: raw.body },
+      deps.locale.observe(settings),
+    );
     const notification = new Notification({ title: copy.title, body: copy.body });
     // Clicking the banner should pull the (unfocused/minimized) window
     // back to the foreground — `focus()` already restores + shows.

--- a/apps/desktop/src/main/notifications-policy.ts
+++ b/apps/desktop/src/main/notifications-policy.ts
@@ -1,3 +1,5 @@
+import type { UiLocale } from '@maka/core/ui-locale';
+
 /**
  * Pure decision + copy helpers for desktop run-completion notifications.
  *

--- a/apps/desktop/src/main/notifications-policy.ts
+++ b/apps/desktop/src/main/notifications-policy.ts
@@ -56,7 +56,15 @@ export interface RunNotificationCopy {
  * could not supply a session name / reply preview (e.g. an untitled
  * session or a tool-only turn with no assistant text).
  */
-function runNotificationCopy(kind: RunNotificationKind): RunNotificationCopy {
+export function runNotificationCopy(
+  kind: RunNotificationKind,
+  locale: UiLocale,
+): RunNotificationCopy {
+  if (locale === 'en') {
+    return kind === 'errored'
+      ? { title: 'Conversation error', body: 'This response did not finish. Click to view details.' }
+      : { title: 'Response ready', body: 'Maka finished this response. Click to view it.' };
+  }
   if (kind === 'errored') {
     return { title: '任务出错', body: '本轮回答未能完成，点击查看详情。' };
   }
@@ -96,8 +104,11 @@ function sanitizeLine(value: unknown, max: number): string {
  * missing or blank. Sanitization + capping live here so the IPC handler
  * stays a thin shell and the logic is unit-testable without Electron.
  */
-export function resolveNotificationContent(input: RunNotificationInput): RunNotificationCopy {
-  const fallback = runNotificationCopy(input.kind);
+export function resolveNotificationContent(
+  input: RunNotificationInput,
+  locale: UiLocale,
+): RunNotificationCopy {
+  const fallback = runNotificationCopy(input.kind, locale);
   return {
     title: sanitizeLine(input.title, MAX_TITLE_CHARS) || fallback.title,
     body: sanitizeLine(input.body, MAX_BODY_CHARS) || fallback.body,

--- a/apps/desktop/src/main/project-picker-copy.ts
+++ b/apps/desktop/src/main/project-picker-copy.ts
@@ -1,4 +1,4 @@
-import type { UiLocale } from '@maka/core';
+import type { UiLocale } from '@maka/core/ui-locale';
 
 export function projectPickerTitle(locale: UiLocale): string {
   return locale === 'zh' ? '添加项目' : 'Add project';

--- a/apps/desktop/src/main/project-picker-copy.ts
+++ b/apps/desktop/src/main/project-picker-copy.ts
@@ -1,0 +1,5 @@
+import type { UiLocale } from '@maka/core';
+
+export function projectPickerTitle(locale: UiLocale): string {
+  return locale === 'zh' ? '添加项目' : 'Add project';
+}

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -6,7 +6,6 @@ import { type ConnectionEvent } from '@maka/core/connections';
 import type { UsageRange } from '@maka/core/settings';
 import { type SessionChangedEvent, type SessionChangedReason } from '@maka/core/session';
 import { isBotDeliveryProvider } from '@maka/core/bot-chat-settings';
-import { resolveSystemUiLocale, resolveUiLocale } from '@maka/core/ui-locale';
 import {
   PROVIDER_DEFAULTS,
   providerAuthRequiresSecret,
@@ -104,7 +103,7 @@ import {
   startRuntimeHostDesktopManager,
   type RuntimeHostDesktopManager,
 } from "./runtime-host-desktop-manager.js";
-import { runtimeHostUpgradePrompts } from "./runtime-host-upgrade-dialog.js";
+import { createRuntimeHostUpgradePrompts } from "./runtime-host-upgrade-dialog.js";
 import { registerRuntimeHostMemoryIpc } from "./runtime-host-memory-ipc-main.js";
 import {
   createDesktopRuntimeHostProfileService,
@@ -233,7 +232,7 @@ const runtimeHostSshTerminal = createDesktopRuntimeHostSshTerminal({
 });
 const native = assembleDesktopNativeCapabilities({
   isComputerUseRealModelE2e,
-  settings: settingsStore,
+  locale: desktopLocale,
   keepSystemAwake,
   mainWindow: mainWindowController,
 });
@@ -253,13 +252,7 @@ const releaseComputerUseSession = (sessionId: string): void => {
   native.computerUseTools.clearSession(sessionId);
 };
 const permissionOverlay = createPermissionOverlayMain({
-  resolveLocale: async () => {
-    const settings = await settingsStore.get();
-    return resolveUiLocale(
-      settings.personalization.uiLocale,
-      resolveSystemUiLocale(app.getPreferredSystemLanguages()),
-    );
-  },
+  resolveLocale: () => desktopLocale.resolve(),
 });
 onMainWindowClose = () => {
   native.computerUseOverlay.destroyAll();
@@ -371,6 +364,7 @@ const clientSettingsEffects = createClientSettingsEffects({
   applyBotSettings: useBotOnboardingFixture
     ? async () => undefined
     : (settings) => botRegistry.applySettings(settings),
+  observeLocale: (settings) => desktopLocale.observe(settings),
   emitExternalChanged: () => {
     mainWindowController.send("settings:clientChanged");
     sendActiveRuntimeHostEvent("settings:externalChanged", { ts: Date.now() });
@@ -384,11 +378,12 @@ const clientSettingsTools = buildClientSettingsTools({
     return settings;
   },
   confirm: async (changes) => {
+    const copy = clientSettingsConfirmation(changes, await desktopLocale.resolve());
     const result = await dialog.showMessageBox({
       type: "question",
-      message: "Allow Maka to update this client's settings?",
-      detail: changes.join("\n"),
-      buttons: ["Apply changes", "Cancel"],
+      message: copy.message,
+      detail: copy.detail,
+      buttons: copy.buttons,
       defaultId: 0,
       cancelId: 1,
       noLink: true,
@@ -442,6 +437,7 @@ const browserIpc = registerBrowserIpc({
 registerNotificationsIpc({
   ipcMain,
   settingsStore,
+  locale: desktopLocale,
   mainWindowController,
   e2e: isE2e,
 });
@@ -566,7 +562,7 @@ runtimeHostManager = await startRuntimeHostDesktopManager(
     openSshTunnel: runtimeHostSshTerminal.openSshTunnel,
   },
   {
-    upgradePrompts: runtimeHostUpgradePrompts,
+    upgradePrompts: createRuntimeHostUpgradePrompts(() => desktopLocale.resolve()),
     onTargetStateChanged: (state) => {
       const hostId = state.readiness === "ready"
         ? state.candidate.client.hostId

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -6,6 +6,7 @@ import { type ConnectionEvent } from '@maka/core/connections';
 import type { UsageRange } from '@maka/core/settings';
 import { type SessionChangedEvent, type SessionChangedReason } from '@maka/core/session';
 import { isBotDeliveryProvider } from '@maka/core/bot-chat-settings';
+import { resolveSystemUiLocale } from '@maka/core/ui-locale';
 import {
   PROVIDER_DEFAULTS,
   providerAuthRequiresSecret,
@@ -41,6 +42,8 @@ import { resolveBuildInfo } from "./build-info.js";
 import { computerUseServiceHealth } from "./computer-use-host.js";
 import { registerDesktopDiagnosticsIpc } from "./desktop-diagnostics-ipc-main.js";
 import { assembleDesktopNativeCapabilities } from "./desktop-native-capability-assembly.js";
+import { clientSettingsConfirmation } from "./client-settings-confirmation-copy.js";
+import { createDesktopLocaleAuthority } from "./desktop-locale-authority.js";
 import { buildRiveWorkflowTool } from "./rive-workflow-tool.js";
 import { installDesktopShellPresentation } from "./desktop-shell-presentation.js";
 import {
@@ -75,6 +78,7 @@ import {
 import { resolveProjectContextRoot } from "./project-context-root.js";
 import { resolveDefaultPermissionMode } from "./permission-mode-default.js";
 import { createProjectManagementService } from "./project-management-service.js";
+import { projectPickerTitle } from "./project-picker-copy.js";
 import type { ProjectManagementService } from "./project-management-service.js";
 import {
   createProjectRootController,
@@ -196,6 +200,10 @@ if (!startupLocalStorageRoot) {
 }
 const localRuntimeHostId = startupLocalStorageRoot.rootId;
 const settingsStore = createSettingsStore(workspaceRoot);
+const desktopLocale = createDesktopLocaleAuthority({
+  readSettings: () => settingsStore.get(),
+  preferredSystemLanguages: () => app.getPreferredSystemLanguages(),
+});
 const mcpConfigStore = createMcpConfigStore(workspaceRoot);
 const mcpManager = new McpClientManager({
   clientName: "maka-desktop",
@@ -749,7 +757,7 @@ function registerHostClientIpc(
     catalog: targetProjectCatalog,
     chooseDirectory: async () => {
       const result = await mainWindowController.showOpenDialog({
-        title: "Add project",
+        title: projectPickerTitle(await desktopLocale.resolve()),
         properties: ["openDirectory"],
       });
       return result.canceled ? undefined : result.filePaths[0];

--- a/apps/desktop/src/main/runtime-host-upgrade-copy.ts
+++ b/apps/desktop/src/main/runtime-host-upgrade-copy.ts
@@ -1,4 +1,4 @@
-import type { UiLocale } from '@maka/core';
+import type { UiLocale } from '@maka/core/ui-locale';
 import type { MessageBoxOptions } from 'electron';
 import type {
   RuntimeHostRestartableConflict,

--- a/apps/desktop/src/main/runtime-host-upgrade-copy.ts
+++ b/apps/desktop/src/main/runtime-host-upgrade-copy.ts
@@ -1,0 +1,111 @@
+import type { UiLocale } from '@maka/core';
+import type { MessageBoxOptions } from 'electron';
+import type {
+  RuntimeHostRestartableConflict,
+  RuntimeHostWaitConflict,
+} from './runtime-host-desktop-manager.js';
+
+type Conflict = RuntimeHostRestartableConflict | RuntimeHostWaitConflict;
+type ActivityKey =
+  | 'goal'
+  | 'scheduledTask'
+  | 'dailyReview'
+  | 'execution'
+  | 'resource'
+  | 'graph'
+  | 'other';
+
+export function buildRuntimeHostUpgradeDialogOptions(
+  conflict: Conflict,
+  canRestart: boolean,
+  locale: UiLocale,
+): MessageBoxOptions {
+  const activity = conflict.handshake?.activity;
+  const hasWork =
+    (activity?.activeOperations ?? 0) > 0 || (activity?.residencies.length ?? 0) > 0;
+  const copy = UPGRADE_COPY[locale];
+  const buttons = canRestart ? [copy.restart, copy.wait, copy.cancel] : [copy.wait, copy.cancel];
+  return {
+    type: 'warning',
+    title: copy.title,
+    message: copy.message,
+    detail: formatActivity(conflict, locale),
+    buttons,
+    defaultId: hasWork || !canRestart ? (canRestart ? 1 : 0) : 0,
+    cancelId: canRestart ? 2 : 1,
+    noLink: true,
+  };
+}
+
+function formatActivity(conflict: Conflict, locale: UiLocale): string {
+  const activity = conflict.handshake?.activity;
+  const copy = UPGRADE_COPY[locale];
+  const lines: string[] = [];
+  if (activity) {
+    const minutes = Math.max(1, Math.round(activity.processUptimeSeconds / 60));
+    lines.push(copy.uptime(minutes));
+    if (activity.connections > 0) lines.push(copy.connections(activity.connections));
+    if (activity.activeOperations > 0) lines.push(copy.operations(activity.activeOperations));
+    for (const residency of activity.residencies) {
+      lines.push(`${copy.activity[activityKey(residency.label)]}: ${residency.count}`);
+    }
+  } else lines.push(copy.unknownActivity);
+  lines.push('', copy.restartWarning);
+  if (conflict.kind !== 'upgrade_required' || !conflict.restartable) lines.push(copy.exitOwner);
+  lines.push(copy.waitExplanation);
+  return lines.join('\n');
+}
+
+function activityKey(label: string): ActivityKey {
+  const keys: Record<string, ActivityKey> = {
+    goal: 'goal',
+    'scheduled-task': 'scheduledTask',
+    'daily-review': 'dailyReview',
+    'hosted-execution': 'execution',
+    'runtime-resource': 'resource',
+    'agent-graph': 'graph',
+    'agent-graph-supervisor': 'graph',
+  };
+  return keys[label] ?? 'other';
+}
+
+const UPGRADE_COPY = {
+  en: {
+    title: 'Older Runtime Host is running',
+    message: 'Another Runtime Host process still owns this workspace.',
+    restart: 'Restart Runtime Host',
+    wait: 'Wait',
+    cancel: 'Cancel Startup',
+    uptime: (n: number) => `Running for about ${n} ${n === 1 ? 'minute' : 'minutes'}`,
+    connections: (n: number) => `${n} other client(s) are still connected`,
+    operations: (n: number) => `${n} operation(s) are running`,
+    unknownActivity: 'This Host version cannot report its background activity.',
+    restartWarning:
+      'Restarting preserves durable state, but it can interrupt in-flight external work.',
+    exitOwner: 'Exit the process that owns this Host to replace it safely.',
+    waitExplanation: 'If you wait, Maka will continue automatically when this Host exits.',
+    activity: {
+      goal: 'Goal', scheduledTask: 'Scheduled Task', dailyReview: 'Daily Review',
+      execution: 'Active execution', resource: 'Runtime resource', graph: 'Agent Graph',
+      other: 'Other background activity',
+    },
+  },
+  zh: {
+    title: '旧版 Runtime Host 正在运行',
+    message: '另一个 Runtime Host 进程仍占用此工作区。',
+    restart: '重启 Runtime Host',
+    wait: '等待',
+    cancel: '取消启动',
+    uptime: (n: number) => `已运行约 ${n} 分钟`,
+    connections: (n: number) => `仍有 ${n} 个其他客户端连接`,
+    operations: (n: number) => `有 ${n} 个操作正在运行`,
+    unknownActivity: '此 Host 版本无法报告后台活动。',
+    restartWarning: '重启会保留持久化状态，但可能中断正在进行的外部工作。',
+    exitOwner: '请退出当前占用此 Host 的进程，以便安全替换。',
+    waitExplanation: '若选择等待，当前 Host 退出后 Maka 将自动继续。',
+    activity: {
+      goal: '目标', scheduledTask: '计划任务', dailyReview: '每日回顾', execution: '活动执行',
+      resource: 'Runtime 资源', graph: 'Agent Graph', other: '其他后台活动',
+    },
+  },
+} as const;

--- a/apps/desktop/src/main/runtime-host-upgrade-dialog.ts
+++ b/apps/desktop/src/main/runtime-host-upgrade-dialog.ts
@@ -1,102 +1,34 @@
+import type { UiLocale } from '@maka/core';
 import { dialog } from 'electron';
 import type {
-  RuntimeHostRestartableConflict,
   RuntimeHostRestartDecision,
   RuntimeHostUpgradePrompts,
-  RuntimeHostWaitConflict,
   RuntimeHostWaitDecision,
 } from './runtime-host-desktop-manager.js';
 import { whileAwaitingPerson } from './startup-step.js';
+import { buildRuntimeHostUpgradeDialogOptions } from './runtime-host-upgrade-copy.js';
 
-export const runtimeHostUpgradePrompts: RuntimeHostUpgradePrompts = {
-  restartable: confirmRestartableRuntimeHost,
-  waitOnly: confirmWaitOnlyRuntimeHost,
-};
-
-async function confirmRestartableRuntimeHost(
-  conflict: RuntimeHostRestartableConflict,
-): Promise<RuntimeHostRestartDecision> {
-  const response = await showRuntimeHostUpgradeDialog(conflict, true);
-  if (response === 0) return 'restart';
-  if (response === 1) return 'wait';
-  return 'cancel';
-}
-
-async function confirmWaitOnlyRuntimeHost(
-  conflict: RuntimeHostWaitConflict,
-): Promise<RuntimeHostWaitDecision> {
-  const response = await showRuntimeHostUpgradeDialog(conflict, false);
-  return response === 0 ? 'wait' : 'cancel';
-}
-
-type RuntimeHostUpgradeConflict = RuntimeHostRestartableConflict | RuntimeHostWaitConflict;
-
-async function showRuntimeHostUpgradeDialog(
-  conflict: RuntimeHostUpgradeConflict,
-  canRestart: boolean,
-): Promise<number> {
-  const activity = conflict.handshake?.activity;
-  const hasWork =
-    (activity?.activeOperations ?? 0) > 0 || (activity?.residencies.length ?? 0) > 0;
-  const buttons = canRestart
-    ? ['Restart Runtime Host', 'Wait', 'Cancel Startup']
-    : ['Wait', 'Cancel Startup'];
-  const restartId = canRestart ? 0 : -1;
-  const waitId = canRestart ? 1 : 0;
-  const cancelId = canRestart ? 2 : 1;
-  const { response } = await whileAwaitingPerson(
-    dialog.showMessageBox({
-      type: 'warning',
-      title: 'Older Runtime Host is running',
-      message: 'Another Runtime Host process still owns this workspace.',
-      detail: formatRuntimeHostUpgradeActivity(conflict),
-      buttons,
-      defaultId: hasWork || !canRestart ? waitId : restartId,
-      cancelId,
-      noLink: true,
-    }),
-  );
-  return response;
-}
-
-function formatRuntimeHostUpgradeActivity(conflict: RuntimeHostUpgradeConflict): string {
-  const activity = conflict.handshake?.activity;
-  const lines: string[] = [];
-  if (activity) {
-    const ageMinutes = Math.max(1, Math.round(activity.processUptimeSeconds / 60));
-    lines.push(`Running for about ${ageMinutes} ${ageMinutes === 1 ? 'minute' : 'minutes'}`);
-    if (activity.connections > 0) {
-      lines.push(`${activity.connections} other client(s) are still connected`);
-    }
-    if (activity.activeOperations > 0) {
-      lines.push(`${activity.activeOperations} operation(s) are running`);
-    }
-    for (const residency of activity.residencies) {
-      lines.push(`${runtimeHostActivityLabel(residency.label)}: ${residency.count}`);
-    }
-  } else {
-    lines.push('This Host version cannot report its background activity.');
-  }
-  lines.push(
-    '',
-    'Restarting preserves durable state, but it can interrupt in-flight external work.',
-  );
-  if (conflict.kind !== 'upgrade_required' || !conflict.restartable) {
-    lines.push('Exit the process that owns this Host to replace it safely.');
-  }
-  lines.push('If you wait, Maka will continue automatically when this Host exits.');
-  return lines.join('\n');
-}
-
-function runtimeHostActivityLabel(label: string): string {
-  const names: Record<string, string> = {
-    goal: 'Goal',
-    'scheduled-task': 'Scheduled Task',
-    'daily-review': 'Daily Review',
-    'hosted-execution': 'Active execution',
-    'runtime-resource': 'Runtime resource',
-    'agent-graph': 'Agent Graph',
-    'agent-graph-supervisor': 'Agent Graph',
+export function createRuntimeHostUpgradePrompts(
+  resolveLocale: () => Promise<UiLocale>,
+): RuntimeHostUpgradePrompts {
+  return {
+    restartable: async (conflict): Promise<RuntimeHostRestartDecision> => {
+      const { response } = await whileAwaitingPerson(
+        dialog.showMessageBox(
+          buildRuntimeHostUpgradeDialogOptions(conflict, true, await resolveLocale()),
+        ),
+      );
+      if (response === 0) return 'restart';
+      if (response === 1) return 'wait';
+      return 'cancel';
+    },
+    waitOnly: async (conflict): Promise<RuntimeHostWaitDecision> => {
+      const { response } = await whileAwaitingPerson(
+        dialog.showMessageBox(
+          buildRuntimeHostUpgradeDialogOptions(conflict, false, await resolveLocale()),
+        ),
+      );
+      return response === 0 ? 'wait' : 'cancel';
+    },
   };
-  return names[label] ?? 'Other background activity';
 }

--- a/apps/desktop/src/main/runtime-host-upgrade-dialog.ts
+++ b/apps/desktop/src/main/runtime-host-upgrade-dialog.ts
@@ -1,4 +1,4 @@
-import type { UiLocale } from '@maka/core';
+import type { UiLocale } from '@maka/core/ui-locale';
 import { dialog } from 'electron';
 import type {
   RuntimeHostRestartDecision,


### PR DESCRIPTION
## Summary

- add one Desktop main-process locale authority backed by Client settings and Electron system languages
- route Runtime Host upgrade prompts, notification fallbacks, Client settings confirmation, permission UI, Computer Use status, and the project picker through it
- keep each domain's copy local while preserving model-visible Client settings results
- prevent stale reads from rolling back a newer locale and fall back safely when locale settings cannot be read

Fixes #2685
Part of #2672

## Tests

- npm --workspace @maka/desktop test
- npm --workspace @maka/desktop run typecheck
- npm run lint
- npm run format:check

<details>
<summary>中文对照</summary>

## 摘要

- 新增由客户端设置和 Electron 系统语言驱动的 Desktop 主进程语言 authority
- 让 Runtime Host 升级提示、通知兜底文案、客户端设置确认、权限界面、Computer Use 状态和项目选择器共用该 authority
- 文案仍由各自领域维护，并保持模型可见的客户端设置结果不变
- 防止过期读取回滚新的语言设置；语言设置读取失败时安全回退，不阻断原生操作

## 测试

- npm --workspace @maka/desktop test
- npm --workspace @maka/desktop run typecheck
- npm run lint
- npm run format:check

</details>