### PR TITLE
feat(cli): add a TUI locale authority

### DIFF
--- a/packages/cli/src/__tests__/cli-ui-locale.test.ts
+++ b/packages/cli/src/__tests__/cli-ui-locale.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { resolveCliUiLocale } from '../cli-ui-locale.js';
+
+describe('CLI TUI locale authority', () => {
+  test('an explicit MAKA_LOCALE wins over the POSIX locale', () => {
+    assert.deepEqual(resolveCliUiLocale({ MAKA_LOCALE: 'zh', LC_ALL: 'en_US.UTF-8' }), {
+      ok: true,
+      locale: 'zh',
+    });
+    assert.deepEqual(resolveCliUiLocale({ MAKA_LOCALE: 'EN', LANG: 'zh_CN.UTF-8' }), {
+      ok: true,
+      locale: 'en',
+    });
+  });
+
+  test('auto honors POSIX locale authority order', () => {
+    assert.deepEqual(
+      resolveCliUiLocale({
+        MAKA_LOCALE: 'auto',
+        LC_ALL: 'C.UTF-8',
+        LC_MESSAGES: 'zh_CN.UTF-8',
+        LANG: 'zh_CN.UTF-8',
+      }),
+      { ok: true, locale: 'en' },
+    );
+    assert.deepEqual(resolveCliUiLocale({ LC_MESSAGES: 'zh_CN.UTF-8', LANG: 'en_US.UTF-8' }), {
+      ok: true,
+      locale: 'zh',
+    });
+    assert.deepEqual(resolveCliUiLocale({ LANG: 'en_US.UTF-8' }), {
+      ok: true,
+      locale: 'en',
+    });
+    assert.deepEqual(resolveCliUiLocale({}), { ok: true, locale: 'en' });
+  });
+
+  test('rejects an unsupported explicit preference with a configuration error', () => {
+    assert.deepEqual(resolveCliUiLocale({ MAKA_LOCALE: 'fr' }), {
+      ok: false,
+      message: 'Invalid MAKA_LOCALE "fr". Expected zh, en, or auto.',
+    });
+  });
+});

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -73,6 +73,14 @@ describe('Maka CLI args', () => {
     );
   });
 
+  test('does not add a discoverable global locale flag', () => {
+    assert.deepEqual(parseMakaCliArgs(['--locale', 'zh'], '0.1.0'), {
+      kind: 'error',
+      message: 'Unexpected argument: --locale',
+      exitCode: 2,
+    });
+  });
+
   test('establishes the fatal exit before reporting can throw', async () => {
     const cliUrl = new URL('../cli-core.js', import.meta.url).href;
     const childSource = `

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -40,6 +40,24 @@ describe('Maka Pi TUI transcript', () => {
     );
   });
 
+  test('renders fresh-session guidance in the resolved locale', () => {
+    const state = createMakaPiTranscriptState();
+
+    const english = renderMakaPiTranscript(state, { ...meta(), uiLocale: 'en' }, 100)
+      .map(stripAnsi)
+      .join('\n');
+    assert.match(english, /Get things done together/);
+    assert.match(english, /Type a message to start/);
+    assert.match(english, /\/session\s+Switch or resume a session/);
+
+    const chinese = renderMakaPiTranscript(state, { ...meta(), uiLocale: 'zh' }, 100)
+      .map(stripAnsi)
+      .join('\n');
+    assert.match(chinese, /陪你把事做完/);
+    assert.match(chinese, /输入消息开始对话/);
+    assert.match(chinese, /\/session\s+切换或恢复会话/);
+  });
+
   test('keeps assistant text after a tool call visible after the tool block', () => {
     const state = createMakaPiTranscriptState();
     appendUserPrompt(state, 'inspect the package');

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -155,6 +155,37 @@ function fakeOnboardingSurface(opts: FakeOnboardingOpts = {}): MakaOnboardingSur
 }
 
 describe('Maka Pi TUI runner', () => {
+  test('/help uses the resolved locale for headings and command descriptions', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      locale: 'zh',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitForTuiPaint(terminal);
+    terminal.input('/help');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('快捷键'));
+    const output = plainTerminalOutput(terminal.output());
+    assert.match(output, /\/compact\s+— 压缩会话上下文/);
+    assert.match(output, /Ctrl\+D — 输入为空时退出/);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('disables taskbar progress on Windows and Windows Terminal by default', () => {
     assert.equal(resolveTaskbarProgress(undefined, { platform: 'win32' }), false);
     assert.equal(

--- a/packages/cli/src/__tests__/tui-primary-guidance.test.ts
+++ b/packages/cli/src/__tests__/tui-primary-guidance.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { slashCommandsForSurface } from '@maka/core/slash-command-catalog';
+import { getTuiPrimaryGuidance } from '../tui-primary-guidance.js';
+
+describe('TUI primary guidance catalog', () => {
+  test('both locales describe every TUI slash command', () => {
+    const expected = slashCommandsForSurface('tui')
+      .map((command) => command.id)
+      .sort();
+
+    for (const locale of ['zh', 'en'] as const) {
+      assert.deepEqual(Object.keys(getTuiPrimaryGuidance(locale).commands).sort(), expected);
+    }
+  });
+
+  test('keeps keybinding tokens identical across locales', () => {
+    const tokens = (locale: 'zh' | 'en') =>
+      getTuiPrimaryGuidance(locale).help.keybindings.flatMap((line) => {
+        const match = /^\s*(.*?)\s*—/u.exec(line);
+        return match ? [match[1]!.replace(/\s*[（(].*$/u, '')] : [];
+      });
+
+    assert.deepEqual(tokens('zh'), tokens('en'));
+  });
+});

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { formatMakaResumeHint } from './cli-invocation.js';
 import { resolveMakaDataRoots } from './workspace-root.js';
 import { parseRuntimeHostCommand, type RuntimeHostCliCommand } from './runtime-host-cli.js';
+import { resolveCliUiLocale } from './cli-ui-locale.js';
 
 export type MakaCliCommand =
   | {
@@ -271,11 +272,17 @@ export async function runMakaCli(
       process.stderr.write(`${command.message}\n\n${helpText(options.cliCommand)}\n`);
       return command.exitCode;
     case 'tui': {
+      const locale = resolveCliUiLocale(process.env);
+      if (!locale.ok) {
+        process.stderr.write(`${locale.message}\n`);
+        return 2;
+      }
       const { runRuntimeHostTui } = await import('./runtime-host-tui-command.js');
       return runRuntimeHostTui({
         cliCommand: options.cliCommand,
         clientDataRoot: dataRoots.clientDataRoot,
         workspaceRoot: dataRoots.workspaceRoot,
+        locale: locale.locale,
         cwd: process.cwd(),
         onProcessExit: handleMakaCliProcessExit,
         ...(command.resumeSessionId ? { resumeSessionId: command.resumeSessionId } : {}),

--- a/packages/cli/src/cli-ui-locale.ts
+++ b/packages/cli/src/cli-ui-locale.ts
@@ -1,0 +1,32 @@
+import {
+  isUiLocalePreference,
+  resolveSystemUiLocale,
+  resolveUiLocale,
+  type UiLocale,
+} from '@maka/core/ui-locale';
+
+type CliEnvironment = Readonly<Record<string, string | undefined>>;
+
+export type CliUiLocaleResolution =
+  | { readonly ok: true; readonly locale: UiLocale }
+  | { readonly ok: false; readonly message: string };
+
+/** Resolve the interactive TUI locale without changing the top-level CLI grammar. */
+export function resolveCliUiLocale(environment: CliEnvironment): CliUiLocaleResolution {
+  const rawPreference = environment.MAKA_LOCALE?.trim();
+  const preference = rawPreference ? rawPreference.toLowerCase() : 'auto';
+  if (!isUiLocalePreference(preference)) {
+    return {
+      ok: false,
+      message: `Invalid MAKA_LOCALE ${JSON.stringify(rawPreference)}. Expected zh, en, or auto.`,
+    };
+  }
+
+  // POSIX locale variables are authorities, not a preference list. Once a
+  // higher-priority variable is set, a lower-priority one must not override it.
+  const systemLanguage = [environment.LC_ALL, environment.LC_MESSAGES, environment.LANG]
+    .map((value) => value?.trim())
+    .find((value): value is string => Boolean(value));
+  const systemLocale = resolveSystemUiLocale(systemLanguage ? [systemLanguage] : []);
+  return { ok: true, locale: resolveUiLocale(preference, systemLocale) };
+}

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -14,6 +14,7 @@ import {
 } from '@maka/core/session';
 import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
+import type { UiLocale } from '@maka/core/ui-locale';
 import { isActiveShellRunStatus } from '@maka/core/shell-run';
 import { mergeShellRunStateWithDiagnostics } from '@maka/core/shell-run-result';
 import { projectToolActivityArgs } from '@maka/core/tool-activity-args';
@@ -36,6 +37,7 @@ import {
   renderIndented,
 } from './pi-transcript-format.js';
 import { renderToolBlock } from './pi-transcript-tools.js';
+import { getTuiPrimaryGuidance } from './tui-primary-guidance.js';
 
 export interface MakaPiUsageSummary {
   /** Cumulative cost in USD across the session. */
@@ -190,6 +192,8 @@ export interface MakaPiTranscriptMetadata {
   /** Elapsed milliseconds of the running agent turn, for the activity strip. */
   turnElapsedMs?: number;
   providerRetry?: ProviderRetryEvent;
+  /** Resolved locale for primary TUI guidance. Defaults to English for direct embeddings. */
+  uiLocale?: UiLocale;
 }
 
 export function createMakaPiTranscriptState(): MakaPiTranscriptState {
@@ -1091,7 +1095,7 @@ export function renderMakaPiTranscript(
   // first screen greets and orients instead of showing an empty pane. Once the
   // first prompt lands, entries take over and it never renders again.
   if (state.entries.length === 0 && !state.pendingInteraction) {
-    return renderWelcomeBlock(safeWidth);
+    return renderWelcomeBlock(safeWidth, metadata.uiLocale ?? 'en');
   }
 
   const entryFirstLine = new Map<MakaPiTranscriptEntry, number>();
@@ -1695,16 +1699,17 @@ const MAKA_WORDMARK_LINES = [
 ];
 const MAKA_WORDMARK_WIDTH = Math.max(...MAKA_WORDMARK_LINES.map((line) => line.length));
 
-function renderWelcomeBlock(width: number): string[] {
-  // The branded home greets with the maka wordmark, a short Chinese-first
-  // tagline, and the command-center entry points (direct input, /session,
+function renderWelcomeBlock(width: number, locale: UiLocale): string[] {
+  // The branded home greets with the maka wordmark, a short localized tagline,
+  // and the command-center entry points (direct input, /session,
   // /model, /setup) so a fresh session shows the main actions without typing
   // `/`. The active model and connection live in the statusline, so the
   // welcome does not repeat them.
+  const copy = getTuiPrimaryGuidance(locale).welcome;
   const hints: [string, string][] = [
-    ['/session', '切换或恢复任务'],
-    ['/model', '切换模型'],
-    ['/setup', '配置模型提供商'],
+    ['/session', copy.session],
+    ['/model', copy.model],
+    ['/setup', copy.setup],
   ];
   const keyWidth = Math.max(...hints.map(([key]) => key.length));
   const lines: string[] = [];
@@ -1716,9 +1721,9 @@ function renderWelcomeBlock(width: number): string[] {
     }
   }
   lines.push('');
-  lines.push(fitLine(ansi.dim('陪你把事做完'), width));
+  lines.push(fitLine(ansi.dim(copy.tagline), width));
   lines.push('');
-  lines.push(fitLine('  输入消息开始对话', width));
+  lines.push(fitLine(`  ${copy.start}`, width));
   for (const [key, description] of hints) {
     lines.push(fitLine(ansi.dim(`  ${key.padEnd(keyWidth)}  ${description}`), width));
   }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -33,6 +33,7 @@ import {
   type SessionSummary,
   type StoredMessage,
 } from '@maka/core/session';
+import type { UiLocale } from '@maka/core/ui-locale';
 import {
   buildForeignSessionHandoffMessage,
   foreignSessionHandoffDisplayText,
@@ -114,11 +115,14 @@ import {
   type MakaSlashCommand,
 } from './pi-tui-pickers.js';
 import { formatMakaResumeCommand } from './cli-invocation.js';
+import { getTuiPrimaryGuidance } from './tui-primary-guidance.js';
 
 export interface MakaPiTuiInput {
   /** Launcher command used in resume and recovery instructions. */
   cliCommand?: string;
   title: string;
+  /** Resolved locale for human-facing TUI guidance. Direct embeddings default to English. */
+  locale?: UiLocale;
   driver: MakaSessionDriver;
   cwd: string;
   model: string;
@@ -231,6 +235,8 @@ export function resolveTaskbarProgress(
 }
 
 export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
+  const locale = input.locale ?? 'en';
+  const primaryGuidance = getTuiPrimaryGuidance(locale);
   const terminal = input.terminal ?? new ProcessTerminal();
   const taskbarProgress = resolveTaskbarProgress(input.taskbarProgress);
   const setTaskbarProgress = (active: boolean): void => {
@@ -344,6 +350,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     modelContextWindow,
     turnElapsedMs: turnStartedAt !== undefined ? Date.now() - turnStartedAt : undefined,
     providerRetry: state.providerRetry,
+    uiLocale: locale,
   });
 
   const transcript = new MakaTranscriptComponent(state, metadata);
@@ -2049,22 +2056,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         return `  /${command.name}${aliasSuffix} — ${command.description}`;
       })
       .join('\n');
-    const keybindings = [
-      '  Ctrl+O — expand or collapse all tool output',
-      '  Ctrl+T — expand or collapse the latest thinking block',
-      '  Scroll the transcript with your terminal or trackpad',
-      '  Enter (during a turn) — steer: inject a message into the running turn',
-      '  Alt+Enter (during a turn) — queue a message for the next turn',
-      '  Alt+↑ — take queued messages back into the editor to re-edit',
-      '  Esc Esc (during a turn) — interrupt the turn',
-      '  Esc Esc (when idle) — rewind to an earlier turn',
-      '  Ctrl+C — stop the turn, clear input, or press twice to exit',
-      '  Ctrl+D — exit when input is empty',
-    ].join('\n');
+    const keybindings = primaryGuidance.help.keybindings.join('\n');
     state.entries.push({
       kind: 'notice',
       level: 'info',
-      text: `Commands\n${commands}\n\nKeybindings\n${keybindings}`,
+      text: `${primaryGuidance.help.commandsHeading}\n${commands}\n\n${primaryGuidance.help.keybindingsHeading}\n${keybindings}`,
     });
     requestRender();
   };
@@ -2393,7 +2389,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const slashCommandHandlers = {
     context: {
-      description: 'Show latest request context usage',
+      description: primaryGuidance.commands.context,
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2418,7 +2414,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     compact: {
-      description: 'Compact session context',
+      description: primaryGuidance.commands.compact,
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2433,25 +2429,25 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     exit: {
-      description: 'Exit Maka',
+      description: primaryGuidance.commands.exit,
       run: () => {
         beginGracefulClose();
       },
     },
     help: {
-      description: 'Show commands and keybindings',
+      description: primaryGuidance.commands.help,
       run: () => {
         void runControl(async () => showHelp());
       },
     },
     new: {
-      description: 'Start a new session',
+      description: primaryGuidance.commands.new,
       run: () => {
         void runControl(async () => newSession());
       },
     },
     skill: {
-      description: 'Invoke a skill (or type /skill:<name> inline)',
+      description: primaryGuidance.commands.skill,
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2466,7 +2462,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     setup: {
-      description: 'Set up a model provider (API key)',
+      description: primaryGuidance.commands.setup,
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2481,7 +2477,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     model: {
-      description: 'Select model',
+      description: primaryGuidance.commands.model,
       run: (parts: string[]) => {
         if (parts.length === 1) {
           showModelList();
@@ -2501,7 +2497,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     move: {
-      description: 'Move current session to another directory',
+      description: primaryGuidance.commands.move,
       run: (parts: string[], rawTail?: string) => {
         const targetCwd = (rawTail ?? parts.slice(1).join(' ')).trim();
         if (targetCwd) {
@@ -2512,7 +2508,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     thinking: {
-      description: 'Set thinking level',
+      description: primaryGuidance.commands.thinking,
       run: (parts: string[]) => {
         if (parts.length === 1) {
           if (thinkingLevels.length === 0) {
@@ -2550,7 +2546,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     permissions: {
-      description: 'Set session permissions',
+      description: primaryGuidance.commands.permissions,
       run: (parts: string[]) => {
         if (parts.length === 1) {
           showPermissionModeList();
@@ -2570,13 +2566,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     recap: {
-      description: 'One-sentence recap of the session so far',
+      description: primaryGuidance.commands.recap,
       run: () => {
         void runRecap('manual');
       },
     },
     rename: {
-      description: 'Rename current session',
+      description: primaryGuidance.commands.rename,
       run: (parts: string[]) => {
         const name = parts.slice(1).join(' ').trim();
         if (!name) {
@@ -2601,7 +2597,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     resume: {
-      description: 'Resume latest interrupted run at a safe boundary',
+      description: primaryGuidance.commands.resume,
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2616,13 +2612,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     rewind: {
-      description: 'Rewind to an earlier turn',
+      description: primaryGuidance.commands.rewind,
       run: () => {
         void runControl(showRewindPicker);
       },
     },
     session: {
-      description: 'Resume session',
+      description: primaryGuidance.commands.session,
       run: (parts: string[]) => {
         if (parts.length === 1) {
           void runControl(showSessionList);
@@ -2642,14 +2638,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     },
     graph: {
-      description: 'Show, enable, disable, or run one Graph turn',
+      description: primaryGuidance.commands.graph,
       run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
         const parsed = parseGraphCommand(`/graph${rawTail ? ` ${rawTail}` : ''}`);
         if (parsed) runGraphCommand(parsed, context.idleMs);
       },
     },
     swarm: {
-      description: 'Show, enable, disable, or run one Swarm turn',
+      description: primaryGuidance.commands.swarm,
       run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
         const parsed = parseSwarmCommand(`/swarm${rawTail ? ` ${rawTail}` : ''}`);
         if (parsed) runSwarmCommand(parsed, context.idleMs);

--- a/packages/cli/src/runtime-host-tui-command.ts
+++ b/packages/cli/src/runtime-host-tui-command.ts
@@ -1,4 +1,5 @@
 import { parseNoRealConnectionError } from '@maka/core/connection-error-copy';
+import type { UiLocale } from '@maka/core/ui-locale';
 import { createInterface } from 'node:readline/promises';
 import { SessionActivityRegistry } from '@maka/runtime/goal-turn-lifecycle';
 import { readRuntimeHostConnectionCatalog } from '@maka/runtime-host/client';
@@ -16,6 +17,7 @@ export interface RunRuntimeHostTuiInput {
   readonly clientDataRoot: string;
   readonly workspaceRoot: string;
   readonly cwd: string;
+  readonly locale: UiLocale;
   readonly resumeSessionId?: string;
   readonly resumeCwd?: string;
   readonly hostProfileId?: string;
@@ -43,6 +45,7 @@ export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<
       input.clientDataRoot,
       input.workspaceRoot,
       input.cwd,
+      input.locale,
       input.hostProfileId,
     );
     if (!configured) throw error;
@@ -53,6 +56,7 @@ export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<
       driver: context.driver,
       title: context.profile.kind === 'local' ? 'Maka' : `Maka — ${context.profile.name}`,
       cwd: context.cwd,
+      locale: input.locale,
       model: context.model,
       models: context.modelChoices
         .filter((choice) => choice.connectionSlug === context.connectionSlug)
@@ -130,6 +134,7 @@ async function runFirstRunOnboarding(
   clientDataRoot: string,
   rootPath: string,
   cwd: string,
+  locale: UiLocale,
   hostProfileId?: string,
 ): Promise<boolean> {
   const connected = await connectRuntimeHostCli({
@@ -143,6 +148,7 @@ async function runFirstRunOnboarding(
       driver: createFirstRunSessionDriver(),
       title: 'Maka',
       cwd,
+      locale,
       model: '',
       connectionSlug: '',
       permissionMode: 'ask',

--- a/packages/cli/src/tui-primary-guidance.ts
+++ b/packages/cli/src/tui-primary-guidance.ts
@@ -1,0 +1,117 @@
+import type { SlashCommandIdForSurface } from '@maka/core/slash-command-catalog';
+import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
+
+type TuiCommandId = SlashCommandIdForSurface<'tui'>;
+
+export interface TuiPrimaryGuidanceCopy {
+  readonly welcome: {
+    readonly tagline: string;
+    readonly start: string;
+    readonly session: string;
+    readonly model: string;
+    readonly setup: string;
+  };
+  readonly commands: Readonly<Record<TuiCommandId, string>>;
+  readonly help: {
+    readonly commandsHeading: string;
+    readonly keybindingsHeading: string;
+    readonly keybindings: readonly string[];
+  };
+}
+
+const TUI_PRIMARY_GUIDANCE = {
+  zh: {
+    welcome: {
+      tagline: '陪你把事做完',
+      start: '输入消息开始对话',
+      session: '切换或恢复会话',
+      model: '切换模型',
+      setup: '配置模型提供商',
+    },
+    commands: {
+      compact: '压缩会话上下文',
+      context: '查看最近一次请求的上下文用量',
+      exit: '退出 Maka',
+      graph: '查看、启用、停用 Graph 模式，或执行一次 Graph 任务',
+      help: '查看命令和快捷键',
+      model: '选择模型',
+      move: '将当前会话移到其他目录',
+      new: '新建会话',
+      permissions: '设置会话权限',
+      recap: '用一句话总结当前会话',
+      rename: '重命名当前会话',
+      resume: '从安全边界恢复最近一次中断的执行',
+      rewind: '回退到较早的对话轮次',
+      session: '切换或恢复会话',
+      setup: '配置模型提供商（API Key）',
+      skill: '调用 Skill（也可直接输入 /skill:<name>）',
+      swarm: '查看、启用、停用 Swarm 模式，或执行一次 Swarm 任务',
+      thinking: '设置思考级别',
+    },
+    help: {
+      commandsHeading: '命令',
+      keybindingsHeading: '快捷键',
+      keybindings: [
+        '  Ctrl+O — 展开或折叠所有工具输出',
+        '  Ctrl+T — 展开或折叠最近的思考块',
+        '  使用终端或触控板滚动对话记录',
+        '  Enter（任务运行中）— 将消息注入当前任务',
+        '  Alt+Enter（任务运行中）— 将消息排入下一轮',
+        '  Alt+↑ — 将已排队消息取回编辑器重新编辑',
+        '  Esc Esc（任务运行中）— 中断当前任务',
+        '  Esc Esc（空闲时）— 回退到较早的轮次',
+        '  Ctrl+C — 停止任务、清空输入，或连续按两次退出',
+        '  Ctrl+D — 输入为空时退出',
+      ],
+    },
+  },
+  en: {
+    welcome: {
+      tagline: 'Get things done together',
+      start: 'Type a message to start',
+      session: 'Switch or resume a session',
+      model: 'Switch models',
+      setup: 'Set up a model provider',
+    },
+    commands: {
+      compact: 'Compact session context',
+      context: 'Show latest request context usage',
+      exit: 'Exit Maka',
+      graph: 'Show, enable, disable, or run one Graph turn',
+      help: 'Show commands and keybindings',
+      model: 'Select model',
+      move: 'Move current session to another directory',
+      new: 'Start a new session',
+      permissions: 'Set session permissions',
+      recap: 'One-sentence recap of the session so far',
+      rename: 'Rename current session',
+      resume: 'Resume latest interrupted run at a safe boundary',
+      rewind: 'Rewind to an earlier turn',
+      session: 'Resume session',
+      setup: 'Set up a model provider (API key)',
+      skill: 'Invoke a skill (or type /skill:<name> inline)',
+      swarm: 'Show, enable, disable, or run one Swarm turn',
+      thinking: 'Set thinking level',
+    },
+    help: {
+      commandsHeading: 'Commands',
+      keybindingsHeading: 'Keybindings',
+      keybindings: [
+        '  Ctrl+O — expand or collapse all tool output',
+        '  Ctrl+T — expand or collapse the latest thinking block',
+        '  Scroll the transcript with your terminal or trackpad',
+        '  Enter (during a turn) — steer: inject a message into the running turn',
+        '  Alt+Enter (during a turn) — queue a message for the next turn',
+        '  Alt+↑ — take queued messages back into the editor to re-edit',
+        '  Esc Esc (during a turn) — interrupt the turn',
+        '  Esc Esc (when idle) — rewind to an earlier turn',
+        '  Ctrl+C — stop the turn, clear input, or press twice to exit',
+        '  Ctrl+D — exit when input is empty',
+      ],
+    },
+  },
+} satisfies UiCatalog<TuiPrimaryGuidanceCopy>;
+
+export function getTuiPrimaryGuidance(locale: UiLocale): TuiPrimaryGuidanceCopy {
+  return TUI_PRIMARY_GUIDANCE[locale];
+}

--- a/packages/core/src/ui-locale.ts
+++ b/packages/core/src/ui-locale.ts
@@ -1,9 +1,9 @@
-/** Resolved locales supported by the desktop renderer. */
+/** Resolved locales supported by human-facing Maka clients. */
 export const UI_LOCALES = ['zh', 'en'] as const;
 
 export type UiLocale = (typeof UI_LOCALES)[number];
 
-/** The only persisted locale preference. The resolved locale is never stored. */
+/** Shared UI preference vocabulary. A resolved locale is never persisted. */
 export type UiLocalePreference = 'auto' | UiLocale;
 
 export const UI_LOCALE_PREFERENCES = ['auto', ...UI_LOCALES] as const;
@@ -30,11 +30,11 @@ export function resolveSystemUiLocale(languages: readonly string[] | null | unde
 }
 
 /**
- * Derive the single renderer locale.
+ * Derive one resolved UI locale.
  *
- * Visual/test overrides are deliberately highest priority. Explicit persisted
- * preferences beat the system locale; `auto` follows the supported system
- * locale without persisting the derived value.
+ * Call-site overrides are deliberately highest priority. Explicit preferences
+ * beat the system locale; `auto` follows the supported system locale without
+ * persisting the derived value.
  */
 export function resolveUiLocale(
   preference: UiLocalePreference,


### PR DESCRIPTION
## Summary

- resolve the interactive TUI locale from `MAKA_LOCALE=zh|en|auto`, with `auto` following `LC_ALL`, `LC_MESSAGES`, then `LANG`
- pass one resolved locale through first-run and normal TUI startup, so the welcome surface, slash autocomplete, and `/help` share the same CLI-owned catalog
- keep the top-level CLI grammar and non-interactive output unchanged; unsupported explicit values fail before TUI startup

No global `--locale` option is added.

## Testing

- `npm --workspace maka-agent run typecheck`
- `npm --workspace maka-agent test` (358 tests)
- scoped Biome format and lint checks
- process smoke checks for invalid `MAKA_LOCALE` and locale-independent `--help`

Fixes #2554
Part of #2672

<details>
<summary>中文对照</summary>

## 摘要

- 交互式 TUI 从 `MAKA_LOCALE=zh|en|auto` 解析语言；`auto` 依次遵循 `LC_ALL`、`LC_MESSAGES`、`LANG`
- 在首次配置和正常启动路径中传递同一个已解析 locale，使欢迎页、斜杠补全与 `/help` 共用 CLI 自己维护的 catalog
- 顶层 CLI 语法和非交互输出保持不变；不支持的显式值会在 TUI 启动前给出配置错误

本 PR 不新增全局 `--locale` 参数。

## 验证

- `npm --workspace maka-agent run typecheck`
- `npm --workspace maka-agent test`（358 项测试）
- 对改动文件执行 Biome format 与 lint
- 进程级验证非法 `MAKA_LOCALE` 以及不受 locale 影响的 `--help`

</details>
