### PR TITLE
test: reduce provider and plumbing matrices

### DIFF
--- a/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
@@ -270,32 +270,6 @@ describe('performCompanionTurn', () => {
     );
   });
 
-  it('happy path: forks at the completed turn, preserves permission, sends, then commits + consumes', async () => {
-    const { api, calls } = makeApi({
-      turns: [turn('t-old', 'completed'), turn('t-settled', 'completed'), turn('t-running', 'running')],
-    });
-    const rec = recorder();
-    const result = await performCompanionTurn({ api, isDisposed: () => false, ...base, ...rec });
-    assert.equal(result.status, 'sent');
-    assert.deepEqual(
-      calls.branchedFrom.map(({ sourceTurnId, name, sideConversation }) => ({
-        sourceTurnId,
-        name,
-        sideConversation,
-      })),
-      [{ sourceTurnId: 't-settled', name: base.name, sideConversation: true }],
-    );
-    assert.equal(calls.sent.length, 1);
-    assert.deepEqual(calls.sent[0].cmd.quotes, [{ text: 'excerpt' }]);
-    assert.deepEqual(calls.removed, []);
-    // Quotes are consumed only AFTER the send is accepted.
-    assert.deepEqual(rec.events, [
-      `created:${calls.branchedFrom[0]!.copyId}`,
-      `committed:${calls.branchedFrom[0]!.copyId}`,
-      `beforeSend:${calls.branchedFrom[0]!.copyId}`,
-      'consumed',
-    ]);
-  });
 
   it('reports and commits the created id before sending', async () => {
     const events: string[] = [];
@@ -317,22 +291,6 @@ describe('performCompanionTurn', () => {
     ]);
   });
 
-  it('forwards staged attachments through the same session send command', async () => {
-    const { api, calls } = makeApi();
-    const rec = recorder();
-    const attachmentItems = [
-      { approvalId: 'attachment-1', name: 'notes.txt', mimeType: 'text/plain' },
-    ];
-    const result = await performCompanionTurn({
-      api,
-      isDisposed: () => false,
-      ...base,
-      ...rec,
-      attachmentItems,
-    });
-    assert.equal(result.status, 'sent');
-    assert.deepEqual(calls.sent[0].cmd.attachmentItems, attachmentItems);
-  });
 
   it('structures listTurns rejection and never creates or sends', async () => {
     const { api, calls } = makeApi({ listTurnsThrows: true });
@@ -525,20 +483,6 @@ describe('performCompanionTurn', () => {
     assert.equal(rec.events.includes('consumed'), false);
   });
 
-  it('existing fork: skips creation and sends directly', async () => {
-    const { api, calls } = makeApi();
-    const rec = recorder();
-    const result = await performCompanionTurn({
-      api,
-      isDisposed: () => false,
-      ...base,
-      existingForkId: 'fork-existing',
-      ...rec,
-    });
-    assert.deepEqual(result, { status: 'sent', forkId: 'fork-existing' });
-    assert.equal(calls.created, 0);
-    assert.deepEqual(rec.events, ['beforeSend:fork-existing', 'consumed']);
-  });
 });
 
 describe('isCompanionTurnTerminal', () => {
@@ -655,12 +599,6 @@ describe('applyCompanionInteractionEvent', () => {
     toolUseId: 'tu1',
   } as unknown as SessionEvent;
 
-  it('enqueues a request and ignores a duplicate requestId', () => {
-    let queues = applyCompanionInteractionEvent({}, 'S', req);
-    assert.equal(queues.S.length, 1);
-    queues = applyCompanionInteractionEvent(queues, 'S', req);
-    assert.equal(queues.S.length, 1);
-  });
 
 
   it('a terminal complete clears the queue', () => {

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -23,38 +23,6 @@ function processContractStderr(stderr: string): string {
 }
 
 describe('maka run argument parsing', () => {
-  test('parses prompt, target, thinking, timeout, and max steps', () => {
-    assert.deepEqual(
-      parseMakaRunArgs([
-        'explain this',
-        '--cwd',
-        '/repo',
-        '--connection',
-        'local',
-        '--model',
-        'model-1',
-        '--thinking',
-        'high',
-        '--timeout',
-        '1.5',
-        '--max-steps',
-        '7',
-      ]),
-      {
-        kind: 'run',
-        options: {
-          prompt: 'explain this',
-          stdinPrompt: false,
-          cwd: '/repo',
-          connection: 'local',
-          model: 'model-1',
-          thinking: 'high',
-          timeoutMs: 1500,
-          maxSteps: 7,
-        },
-      },
-    );
-  });
 
   test('recognizes stdin prompt mode and rejects malformed limits', () => {
     assert.deepEqual(parseMakaRunArgs(['-']), {
@@ -65,17 +33,6 @@ describe('maka run argument parsing', () => {
     assert.equal(parseMakaRunArgs(['x', '--max-steps', '1.5']).kind, 'error');
   });
 
-  test('parses Graph Mode as an explicit non-interactive turn', () => {
-    assert.deepEqual(parseMakaRunArgs(['implement the graph', '--graph']), {
-      kind: 'run',
-      options: {
-        prompt: 'implement the graph',
-        stdinPrompt: false,
-        graph: true,
-      },
-    });
-    assert.equal(parseMakaRunArgs(['x', '--graph', '--graph']).kind, 'error');
-  });
 
   test('accepts only the explicit non-interactive sandbox bypass flag', () => {
     assert.deepEqual(parseMakaRunArgs(['run tools', '--yolo']), {
@@ -106,39 +63,10 @@ describe('maka run argument parsing', () => {
     assert.equal(parseMakaRunArgs(['next', '--resume', 'session-1', '--continue']).kind, 'error');
   });
 
-  test('preserves an explicit default thinking constraint for resumed sessions', () => {
-    assert.deepEqual(parseMakaRunArgs(['next', '--resume', 'session-1', '--thinking', 'default']), {
-      kind: 'run',
-      options: {
-        prompt: 'next',
-        stdinPrompt: false,
-        resumeId: 'session-1',
-        thinkingDefaultExplicit: true,
-      },
-    });
-  });
 });
 
 describe('maka run process contract', () => {
-  test('writes only the final answer to stdout', async () => {
-    const result = await runFixture(['hello'], { input: '' });
-    assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stdout, 'prompt=hello\n');
-    assert.equal(processContractStderr(result.stderr), '');
-  });
 
-  test('normalizes a generated Session name after truncating the prompt', async () => {
-    const prompt = 'Use Bash exactly once to run pwd and node -p';
-    assert.equal(prompt.slice(0, 42).endsWith(' '), true);
-
-    const result = await runFixture([prompt], {
-      input: '',
-      env: { MAKA_RUN_EXPECT_SESSION_NAME: 'Use Bash exactly once to run pwd and node' },
-    });
-
-    assert.equal(result.code, 0, result.stderr);
-    assert.equal(processContractStderr(result.stderr), '');
-  });
 
   test('waits for the complete Graph before printing the final supervisor output', async () => {
     const result = await runFixture(['implement it', '--graph'], {
@@ -162,17 +90,7 @@ describe('maka run process contract', () => {
     assert.doesNotMatch(result.stderr, /graph-wait-called/);
   });
 
-  test('uses stdin as the complete prompt for run -', async () => {
-    const result = await runFixture(['-'], { input: 'from stdin\nsecond line' });
-    assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stdout, 'prompt=from stdin\nsecond line\n');
-  });
 
-  test('uses non-TTY stdin as the prompt when no positional prompt is provided', async () => {
-    const result = await runFixture([], { input: 'implicit stdin prompt' });
-    assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stdout, 'prompt=implicit stdin prompt\n');
-  });
 
   test('combines a positional instruction with piped stdin context', async () => {
     const result = await runFixture(['summarize'], { input: 'document body' });
@@ -225,33 +143,8 @@ describe('maka run process contract', () => {
     assert.equal(result.stdout, '');
   });
 
-  test('accepts a completed boundary-safe alternative', async () => {
-    const result = await runFixture(['hello'], {
-      scenario: 'sandbox-boundary-recovered',
-      input: '',
-    });
-    assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stdout, 'recovered safely\n');
-  });
 
-  test('creates an Auto boundary by default', async () => {
-    const result = await runFixture(['hello'], {
-      input: '',
-      env: { MAKA_RUN_EXPECT_PERMISSION_MODE: 'ask' },
-    });
 
-    assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stdout, 'prompt=hello\n');
-  });
-
-  test('passes max steps as an invocation-local context limit', async () => {
-    const result = await runFixture(['hello', '--max-steps', '3'], {
-      input: '',
-      env: { MAKA_RUN_EXPECT_MAX_STEPS: '3' },
-    });
-    assert.equal(result.code, 0, result.stderr);
-    assert.match(result.stdout, /^maxSteps=3;/);
-  });
 
   test('creates a bypass boundary only when --yolo is explicit', async () => {
     const result = await runFixture(['hello', '--yolo'], {
@@ -270,42 +163,6 @@ describe('maka run process contract', () => {
     assert.equal(result.stdout, '');
   });
 
-  test('resumes an explicit session without creating a new identity', async () => {
-    const cwd = await realpath(process.cwd());
-    const resumed = fixtureSession({
-      id: 'resume-me',
-      cwd,
-      llmConnectionSlug: 'fixture',
-      model: 'fixture-model',
-      permissionMode: 'execute',
-    });
-    const result = await runFixture(
-      [
-        'continue this',
-        '--resume',
-        resumed.id,
-        '--connection',
-        resumed.llmConnectionSlug,
-        '--model',
-        resumed.model,
-      ],
-      {
-        input: '',
-        env: {
-          MAKA_RUN_FIXTURE_SESSIONS: JSON.stringify([resumed]),
-          MAKA_RUN_EXPECT_NO_CREATE: '1',
-          MAKA_RUN_EXPECT_SESSION_ID: resumed.id,
-          MAKA_RUN_EXPECT_CONTEXT_CWD: cwd,
-          MAKA_RUN_EXPECT_CONTEXT_CONNECTION: resumed.llmConnectionSlug,
-          MAKA_RUN_EXPECT_CONTEXT_MODEL: resumed.model,
-          MAKA_RUN_EXPECT_CWD_OVERRIDE: JSON.stringify({ sessionId: resumed.id, cwd }),
-        },
-      },
-    );
-
-    assert.equal(result.code, 0, result.stderr);
-    assert.equal(result.stdout, 'prompt=continue this\n');
-  });
 
   test('fails closed when resuming a bypass session without --yolo', async () => {
     const cwd = await realpath(process.cwd());

--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -14,74 +14,10 @@ import {
   thinkingVariantsForModel,
 } from '../model-thinking.js';
 
-test('thinking choices are filtered, ordered, and expose off only with a real wire', () => {
-  assert.deepEqual(
-    [...deriveThinkingChoices({ efforts: ['max', 'turbo', 'none', 'low', 'high'] })],
-    ['off', 'low', 'high', 'max'],
-  );
-  assert.deepEqual([...deriveThinkingChoices({ toggle: true })], []);
-  assert.deepEqual(
-    [...deriveThinkingChoices({ toggle: true, offBehavior: 'anthropic-thinking-disabled' })],
-    ['off'],
-  );
-  assert.deepEqual([...deriveThinkingChoices(undefined)], []);
-});
 
-test('model options preserve declared effort and off-wire facts', () => {
-  assert.deepEqual(thinkingOptionsForModel('openai', 'gpt-5.5'), {
-    efforts: ['none', 'low', 'medium', 'high', 'xhigh'],
-  });
-  assert.deepEqual(thinkingOptionsForModel('anthropic', 'claude-haiku-4-5'), {
-    toggle: true,
-    offBehavior: 'anthropic-thinking-disabled',
-  });
-  assert.deepEqual(thinkingOptionsForModel('deepseek', 'deepseek-v4-flash'), {
-    efforts: ['high', 'max'],
-    toggle: true,
-  });
-  assert.equal(thinkingOptionsForModel('openai', 'unknown-model'), undefined);
-});
 
-test("model variants expose each provider model's declared choices", () => {
-  for (const [provider, model, expected] of [
-    ['openai', 'gpt-5.5', ['off', 'low', 'medium', 'high', 'xhigh']],
-    ['anthropic', 'claude-opus-4-8', ['low', 'medium', 'high', 'xhigh', 'max']],
-    ['google', 'gemini-2.5-flash', ['off']],
-    ['deepseek', 'deepseek-v4-flash', ['high', 'max']],
-    ['cohere', 'command-a-plus-05-2026', ['off']],
-    ['ollama', 'llama3', []],
-  ] as const) {
-    assert.deepEqual(
-      [...thinkingVariantsForModel(provider, model)],
-      expected,
-      `${provider}:${model}`,
-    );
-  }
-});
 
-test('account access paths inherit thinking metadata from their provider', () => {
-  assert.deepEqual(
-    thinkingOptionsForModel('openai-codex', 'gpt-5.5'),
-    thinkingOptionsForModel('openai', 'gpt-5.5'),
-  );
-  assert.deepEqual(
-    thinkingOptionsForModel('claude-subscription', 'claude-opus-4-8'),
-    thinkingOptionsForModel('anthropic', 'claude-opus-4-8'),
-  );
-  assert.deepEqual(
-    thinkingOptionsForModel('openai-codex', 'gpt-5.6-luna'),
-    thinkingOptionsForModel('openai', 'gpt-5.6-luna'),
-  );
-});
 
-test('provider-scoped model ids do not leak metadata to ambiguous ids', () => {
-  assert.deepEqual(
-    [...thinkingVariantsForModel('vercel', 'xai/grok-4.3')],
-    ['off', 'low', 'medium', 'high'],
-  );
-  assert.deepEqual([...thinkingVariantsForModel('vercel', 'grok-4.3')], []);
-  assert.deepEqual([...thinkingVariantsForModel('openai-compatible', 'gpt-5.5')], []);
-});
 
 test('thinking-level guard accepts only the closed display vocabulary', () => {
   for (const level of THINKING_LEVELS) assert.equal(isThinkingLevel(level), true);
@@ -224,55 +160,7 @@ test('resolveThinkingLevel discards levels the model does not offer', () => {
   assert.equal(resolveThinkingLevel({ providerType: 'openai' }, 'gpt-5.5', 'xhigh'), 'xhigh');
 });
 
-test('openai-compatible thinking variants are declared per model', () => {
-  const connection = {
-    providerType: 'openai-compatible',
-    relayModelProfiles: { reasoner: { thinkingLevels: ['high', 'low', 'turbo'] } },
-  } as unknown as ConnectionThinkingContext;
-  assert.deepEqual([...thinkingVariantsForConnection(connection, 'reasoner')], ['low', 'high']);
-  // A sibling model on the same relay without a declaration sees no menu —
-  // the granularity is the model, not the connection.
-  assert.deepEqual([...thinkingVariantsForConnection(connection, 'plain-instruct')], []);
-});
 
-test('openai-compatible connections without a declaration fall back to metadata variants', () => {
-  for (const relayModelProfiles of [
-    undefined,
-    {},
-    { 'deepseek-v4-flash': {} },
-    { 'deepseek-v4-flash': { thinkingLevels: [] } },
-    { 'deepseek-v4-flash': { thinkingLevels: 'low' } },
-    { 'deepseek-v4-flash': { thinkingLevels: ['turbo'] } },
-  ]) {
-    assert.deepEqual(
-      [
-        ...thinkingVariantsForConnection(
-          {
-            providerType: 'openai-compatible',
-            relayModelProfiles,
-          } as unknown as ConnectionThinkingContext,
-          'deepseek-v4-flash',
-        ),
-      ],
-      [],
-      JSON.stringify(relayModelProfiles),
-    );
-  }
-  // Non-custom providers keep metadata-derived variants: a profiles table
-  // riding along on their connection is inert.
-  assert.deepEqual(
-    [
-      ...thinkingVariantsForConnection(
-        {
-          providerType: 'openai',
-          relayModelProfiles: { 'gpt-5.5': { thinkingLevels: ['off'] } },
-        },
-        'gpt-5.5',
-      ),
-    ],
-    ['off', 'low', 'medium', 'high', 'xhigh'],
-  );
-});
 
 // Reasoning replay has no toggle: DeepSeek-like relays require
 // reasoning_content in tool-call history (400 otherwise), and other relays

--- a/packages/runtime/src/__tests__/automation.test.ts
+++ b/packages/runtime/src/__tests__/automation.test.ts
@@ -70,23 +70,6 @@ describe('AutomationManager', () => {
   });
 
   describe('markFired', () => {
-    test('one-shot completes after a successful fire', () => {
-      const mgr = createManager();
-      const auto = mgr.create({
-        name: 'once',
-        prompt: 'p',
-        sessionId: 'sess-1',
-        schedule: { type: 'once', delaySeconds: 30 },
-      });
-      assert.ok(!('error' in auto));
-      // Started nulls nextFireAt but stays active until the outcome is known.
-      const started = mgr.attemptStarted(auto.id);
-      assert.equal(started?.status, 'active');
-      assert.equal(started?.nextFireAt, null);
-      mgr.attemptSucceeded(auto.id, 'run-1');
-      assert.equal(mgr.get(auto.id)?.status, 'completed');
-      assert.equal(mgr.get(auto.id)?.lastRunId, 'run-1');
-    });
 
     test('maxFires completes on the successful fire that reaches the cap', () => {
       const mgr = createManager();
@@ -195,36 +178,9 @@ describe('AutomationManager', () => {
       assert.equal(mgr.get(auto.id)?.lastError, 'Automation run failed');
     });
 
-    test('attemptSucceeded resets failure count', () => {
-      const mgr = createManager();
-      const auto = mgr.create({
-        name: 'test',
-        prompt: 'p',
-        sessionId: 'sess-1',
-        schedule: { type: 'interval', seconds: 60 },
-      });
-      assert.ok(!('error' in auto));
-      mgr.attemptFailed(auto.id, 'fail');
-      mgr.attemptFailed(auto.id, 'fail');
-      mgr.attemptSucceeded(auto.id);
-      assert.equal(mgr.get(auto.id)?.consecutiveFailures, 0);
-      assert.equal(mgr.get(auto.id)?.lastError, null);
-    });
   });
 
   describe('removeAllForSession', () => {
-    test('removes every automation owned by the session', () => {
-      const mgr = createManager();
-      mgr.create({
-        name: 'h1',
-        prompt: 'p',
-        sessionId: 's1',
-        schedule: { type: 'interval', seconds: 60 },
-      });
-      const removed = mgr.removeAllForSession('s1');
-      assert.equal(removed, 1);
-      assert.equal(mgr.listForSession('s1').length, 0);
-    });
   });
 
   describe('registerAll — restart recovery', () => {
@@ -435,17 +391,6 @@ describe('computeJitter', () => {
     }
   });
 
-  test('one-shot jitter is zero off round marks and negative within bounds on them', () => {
-    const firesAt = new Date(2026, 0, 1, 10, 37, 0, 0).getTime();
-    assert.equal(computeJitter(30 * 60 * 1000, false, Math.random, firesAt), 0);
-    assert.equal(computeJitter(60_000, false), 0);
-    for (let i = 0; i < 50; i++) {
-      const roundMark = new Date(2026, 0, 1, 11, i % 2 === 0 ? 0 : 30, 0, 0).getTime();
-      const jitter = computeJitter(17 * 60 * 1000, false, Math.random, roundMark);
-      assert.ok(jitter <= 0, `one-shot jitter should be <= 0, got ${jitter}`);
-      assert.ok(jitter >= -90_000, `one-shot jitter should be >= -90000, got ${jitter}`);
-    }
-  });
 });
 
 describe('schedule jitter wiring (AutomationManager.computeNextFire)', () => {
@@ -456,18 +401,6 @@ describe('schedule jitter wiring (AutomationManager.computeNextFire)', () => {
     return new AutomationManager({ generateId: () => `j-${++idc}`, now: () => NOW, random });
   }
 
-  test('interval schedules get positive recurring jitter', () => {
-    const mgr = managerWithRandom(() => 0.5);
-    const auto = mgr.create({
-      name: 'poll',
-      prompt: 'p',
-      sessionId: 's1',
-      schedule: { type: 'interval', seconds: 600 },
-    });
-    assert.ok(!('error' in auto));
-    // 600s interval → 10% max = 60s; random 0.5 → +30s jitter.
-    assert.equal(auto.nextFireAt, NOW + 600_000 + 30_000);
-  });
 
   test('cron schedules get positive recurring jitter (never fire before the mark)', () => {
     const zero = managerWithRandom(() => 0);

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -132,11 +132,6 @@ describe('buildProviderOptions: thinking level', () => {
     });
   });
 
-  test('openai-codex gpt-5.6-sol sends xhigh reasoning effort', () => {
-    assert.deepEqual(buildProviderOptions(conn('openai-codex'), 'gpt-5.6-sol', 'xhigh'), {
-      openai: { store: false, textVerbosity: 'medium', reasoningEffort: 'xhigh' },
-    });
-  });
 
   test('google effort model (gemini-3) sends thinkingLevel; Gemini 2.5 Flash off sends thinkingBudget 0; safetySettings always present', () => {
     const g3 = buildProviderOptions(conn('google'), 'gemini-3-pro-preview', 'high');
@@ -306,20 +301,6 @@ describe('buildProviderOptions: thinking level', () => {
     assert.deepEqual([...thinkingVariantsForModel('stepfun-step-plan', 'step-router-v1')], []);
   });
 
-  test('StepFun Step Plan Global sends only officially supported reasoning effort levels', () => {
-    assert.deepEqual(
-      buildProviderOptions(conn('stepfun-ai-step-plan'), 'step-3.7-flash', 'medium'),
-      { 'stepfun-ai-step-plan': { reasoningEffort: 'medium' } },
-    );
-    assert.deepEqual(
-      buildProviderOptions(conn('stepfun-ai-step-plan'), 'step-3.5-flash-2603', 'low'),
-      { 'stepfun-ai-step-plan': { reasoningEffort: 'low' } },
-    );
-    assert.deepEqual(
-      buildProviderOptions(conn('stepfun-ai-step-plan'), 'step-3.5-flash', 'medium'),
-      {},
-    );
-  });
 
   test('Volcengine Ark sends its official thinking object and optional reasoning effort', () => {
     const modelId = 'doubao-seed-2-0-pro-260215';
@@ -613,11 +594,6 @@ describe('buildProviderOptions: openai-compatible namespace', () => {
   });
 });
 
-test('models without a real off wire do not expose off', () => {
-  assert.equal(thinkingVariantsForModel('deepseek', 'deepseek-v4-flash').includes('off'), false);
-  assert.equal(thinkingVariantsForModel('zai-coding-plan', 'glm-5.1').includes('off'), false);
-  assert.equal(thinkingVariantsForModel('zai-coding-plan', 'glm-4.5-air').includes('off'), false);
-});
 
 describe('changesBackendConfig', () => {
   test('thinkingLevel change triggers backend reconfiguration', () => {
@@ -625,16 +601,7 @@ describe('changesBackendConfig', () => {
     assert.equal(changesBackendConfig({ thinkingLevel: undefined }), true);
   });
 
-  test('unrelated patches do not', () => {
-    assert.equal(changesBackendConfig({ name: 'x' }), false);
-    assert.equal(changesBackendConfig({}), false);
-  });
 
-  test('backend / llmConnectionSlug / model still trigger', () => {
-    assert.equal(changesBackendConfig({ backend: 'ai-sdk' }), true);
-    assert.equal(changesBackendConfig({ llmConnectionSlug: 'a' }), true);
-    assert.equal(changesBackendConfig({ model: 'm' }), true);
-  });
 
   test('permissionMode triggers, so a mode change is enforced and not merely stored', () => {
     // The backend snapshots the header at construction and decides every

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -239,60 +239,7 @@ describe('fetchProviderModels', () => {
     );
   });
 
-  test('Z.ai baseUrl trailing slash is trimmed before appending /models', async () => {
-    let observedPath = '';
-    const server = await startJsonServer((request, response) => {
-      observedPath = request.url ?? '';
-      respondJson(response, 200, { data: [{ id: 'glm-live' }] });
-    });
 
-    const models = await fetchProviderModels(
-      { ...zaiConnection(), baseUrl: `${server.url}/` },
-      'zai-live-secret',
-    );
-
-    assert.equal(observedPath, '/models');
-    assert.deepEqual(models, [{ id: 'glm-live' }]);
-  });
-
-  test('provider model capability fields are preserved when present', async () => {
-    const server = await startJsonServer((_request, response) => {
-      respondJson(response, 200, {
-        data: [
-          {
-            id: 'kimi-k2.7',
-            supports_image_in: true,
-            supports_reasoning: true,
-            context_length: 262_144,
-          },
-          { id: 'moonshot-v1-8k', supports_image_in: false },
-        ],
-      });
-    });
-
-    const models = await fetchProviderModels(
-      {
-        slug: 'moonshot',
-        name: 'Moonshot',
-        providerType: 'moonshot',
-        baseUrl: server.url,
-        defaultModel: 'kimi-k2.7',
-        enabled: true,
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      'moonshot-secret',
-    );
-
-    assert.deepEqual(models, [
-      {
-        id: 'kimi-k2.7',
-        contextWindow: 262_144,
-        capabilities: { vision: true, reasoning: true },
-      },
-      { id: 'moonshot-v1-8k', capabilities: { vision: false } },
-    ]);
-  });
 
   test('provider fetch failures throw generalized errors instead of returning fallback models', async () => {
     const server = await startJsonServer((_request, response) => {
@@ -313,63 +260,7 @@ describe('fetchProviderModels', () => {
     );
   });
 
-  test('Claude subscription model fetch serves the curated list without calling /v1/models', async () => {
-    // The subscription OAuth token is session-scoped (no user:inference), so
-    // GET /v1/models would 401. Discovery must stay off the network entirely.
-    let requests = 0;
-    const server = await startJsonServer((_request, response) => {
-      requests += 1;
-      respondJson(response, 401, { error: 'insufficient scope' });
-    });
 
-    const models = await fetchProviderModels(
-      {
-        slug: 'claude-subscription',
-        name: 'Claude OAuth',
-        providerType: 'claude-subscription',
-        baseUrl: server.url,
-        defaultModel: 'claude-sonnet-4-5-20250929',
-        enabled: true,
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      'oauth-access-token',
-    );
-
-    assert.equal(requests, 0);
-    assert.deepEqual(
-      models,
-      PROVIDER_DEFAULTS['claude-subscription'].fallbackModels.map((id) => ({ id })),
-    );
-  });
-
-  test('Anthropic model fetch accepts a stored /v1 base URL without doubling it', async () => {
-    let observedPath = '';
-    let observedApiKey = '';
-    const server = await startJsonServer((request, response) => {
-      observedPath = request.url ?? '';
-      observedApiKey = (request.headers['x-api-key'] as string | undefined) ?? '';
-      respondJson(response, 200, { data: [{ id: 'claude-sonnet-4-5-20250929' }] });
-    });
-
-    const models = await fetchProviderModels(
-      {
-        slug: 'anthropic-main',
-        name: 'Anthropic',
-        providerType: 'anthropic',
-        baseUrl: `${server.url}/v1`,
-        defaultModel: 'claude-sonnet-4-5-20250929',
-        enabled: true,
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      'anthropic-api-key',
-    );
-
-    assert.equal(observedPath, '/v1/models');
-    assert.equal(observedApiKey, 'anthropic-api-key');
-    assert.deepEqual(models, [{ id: 'claude-sonnet-4-5-20250929' }]);
-  });
 
   test('Codex OAuth discovers models from the chatgpt.com/backend-api/codex/models endpoint', async () => {
     const requests: Array<{ url: string; authorization: string | undefined }> = [];
@@ -458,39 +349,7 @@ describe('fetchProviderModels', () => {
     );
   });
 
-  test('normalization leaves empty-catalog policy to the caller that owns persistence', async () => {
-    const server = await startJsonServer((_request, response) => {
-      respondJson(response, 200, { data: [] });
-    });
 
-    assert.deepEqual(
-      await fetchProviderModels({ ...zaiConnection(), baseUrl: server.url }, 'zai-live-secret'),
-      [],
-    );
-  });
-
-  test('discovery trims model IDs, drops malformed entries, and deduplicates before persistence', async () => {
-    const server = await startJsonServer((_request, response) => {
-      respondJson(response, 200, {
-        data: [
-          { id: ' model-a ' },
-          { id: 'model-a' },
-          { id: '' },
-          { id: 42 },
-          { id: 'bad\nmodel' },
-          { id: 'x'.repeat(513) },
-          { id: 'model-b', name: 'Model B' },
-        ],
-      });
-    });
-
-    const models = await fetchProviderModels(
-      { ...zaiConnection(), baseUrl: server.url },
-      'zai-live-secret',
-    );
-
-    assert.deepEqual(models, [{ id: 'model-a' }, { id: 'model-b', displayName: 'Model B' }]);
-  });
 
   test('connection discovery classifies structurally invalid JSON from a real HTTP response', async () => {
     const secret = 'raw-provider-secret';

--- a/packages/runtime/src/__tests__/request-shape.test.ts
+++ b/packages/runtime/src/__tests__/request-shape.test.ts
@@ -240,91 +240,9 @@ describe('prepared provider request capture', () => {
     assert.notEqual(anthropicMax, hash({ kimiCodingPlan: { reasoningEffort: 'none' } }, 32_768));
   });
 
-  test('normalizes disabled Anthropic reasoning to OpenAI none', () => {
-    const hash = (providerOptions: Record<string, unknown>) =>
-      requestShape.capturePreparedProviderRequest({
-        providerId: 'provider',
-        modelId: 'model',
-        messages: [{ role: 'user', content: 'hello' }],
-        tools: [],
-        providerOptions,
-        requestPayload: {
-          prompt: [{ role: 'user', content: 'hello' }],
-          maxOutputTokens: 32_768,
-          providerOptions,
-        },
-      }).requestPayloadWithoutProviderOptionsHash;
 
-    assert.equal(
-      hash({ anthropic: { thinking: { type: 'disabled' } } }),
-      hash({ openai: { reasoningEffort: 'none' } }),
-    );
-  });
 
-  test('normalizes Google thinking level to OpenAI reasoning effort', () => {
-    const hash = (providerOptions: Record<string, unknown>) =>
-      requestShape.capturePreparedProviderRequest({
-        providerId: 'provider',
-        modelId: 'model',
-        messages: [{ role: 'user', content: 'hello' }],
-        tools: [],
-        providerOptions,
-        requestPayload: {
-          prompt: [{ role: 'user', content: 'hello' }],
-          maxOutputTokens: 32_768,
-          providerOptions,
-        },
-      }).requestPayloadWithoutProviderOptionsHash;
 
-    assert.equal(
-      hash({ google: { thinkingConfig: { includeThoughts: true, thinkingLevel: 'high' } } }),
-      hash({ openai: { reasoningEffort: 'high' } }),
-    );
-  });
-
-  test('normalizes zero Google thinking budget to OpenAI none', () => {
-    const hash = (providerOptions: Record<string, unknown>) =>
-      requestShape.capturePreparedProviderRequest({
-        providerId: 'provider',
-        modelId: 'model',
-        messages: [{ role: 'user', content: 'hello' }],
-        tools: [],
-        providerOptions,
-        requestPayload: {
-          prompt: [{ role: 'user', content: 'hello' }],
-          maxOutputTokens: 32_768,
-          providerOptions,
-        },
-      }).requestPayloadWithoutProviderOptionsHash;
-
-    assert.equal(
-      hash({ google: { thinkingConfig: { thinkingBudget: 0 } } }),
-      hash({ openai: { reasoningEffort: 'none' } }),
-    );
-  });
-
-  test('normalizes disabled Cloudflare thinking to OpenAI none', () => {
-    const hash = (providerOptions: Record<string, unknown>) =>
-      requestShape.capturePreparedProviderRequest({
-        providerId: 'provider',
-        modelId: 'model',
-        messages: [{ role: 'user', content: 'hello' }],
-        tools: [],
-        providerOptions,
-        requestPayload: {
-          prompt: [{ role: 'user', content: 'hello' }],
-          maxOutputTokens: 32_768,
-          providerOptions,
-        },
-      }).requestPayloadWithoutProviderOptionsHash;
-
-    assert.equal(
-      hash({
-        'cloudflare-workers-ai': { chat_template_kwargs: { thinking: false } },
-      }),
-      hash({ openai: { reasoningEffort: 'none' } }),
-    );
-  });
 
   test('normalizes Anthropic thinking budget into the protocol-independent output limit', () => {
     const capture = (providerOptions: Record<string, unknown>, maxOutputTokens: number) =>

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -171,62 +171,7 @@ describe('RuntimeRunner', () => {
     expect(result.startedAt <= result.finishedAt).toBe(true);
   });
 
-  test('initial user RuntimeEvent is emitted before any flow event', async () => {
-    const providers = makeProviders();
-    const flow = new ScriptFlow((ctx) => [
-      flowTextEvent(ctx, 'hello'),
-      flowTerminalEvent(ctx, 'completed'),
-    ]);
-    const runner = new RuntimeRunner({ flow, providers });
 
-    const result = await runner.run(makeRequest({ text: 'ping' }));
-
-    expect(result.status).toBe('completed');
-    expect(result.finalOutput).toBe('hello');
-    expect(result.events).toHaveLength(3);
-
-    const userEvent = result.events[0]!;
-    expect(userEvent.role).toBe('user');
-    expect(userEvent.author).toBe('user');
-    expect(userEvent.partial).toBe(false);
-    expect(userEvent.content).toEqual({ kind: 'text', text: 'ping' });
-    expect(userEvent.sessionId).toBe('sess-1');
-    expect(userEvent.turnId).toBe('turn-1');
-
-    // The flow event follows the user event and is on a different lane.
-    expect(result.events[1]!.role).toBe('model');
-    expect(result.events[1]!.author).toBe('agent');
-  });
-
-  test('preserves a host-authored initial user-role RuntimeEvent', async () => {
-    const providers = makeProviders();
-    const flow = new ScriptFlow((ctx) => [flowTerminalEvent(ctx, 'completed')]);
-    const runner = new RuntimeRunner({ flow, providers });
-    const request = makeRequest({
-      text: 'graph checkpoint',
-      initialRuntimeEvent: buildInitialUserRuntimeEvent({
-        id: 'evt-host',
-        invocationId: 'inv-host',
-        runId: 'run-host',
-        sessionId: 'sess-1',
-        turnId: 'turn-1',
-        ts: 1,
-        text: 'graph checkpoint',
-        origin: {
-          kind: 'agent_graph',
-          graphId: 'graph-1',
-          wakeId: 'wake-1',
-          attemptId: 'attempt-1',
-        },
-      }),
-    });
-
-    const result = await runner.run(request);
-
-    expect(result.events[0]?.role).toBe('user');
-    expect(result.events[0]?.author).toBe('host');
-    expect(result.events[0]?.content?.kind).toBe('text');
-  });
 
   test('initial event declares the tool boundary protocol only when the durable boundary is active', async () => {
     const providers = makeProviders();
@@ -291,63 +236,7 @@ describe('RuntimeRunner', () => {
     expect(result.failure?.class).toBe('missing_final_output');
   });
 
-  test('caller-provided invocationId and runId are used across result, user event, and flow', async () => {
-    const providers = makeProviders();
-    const flow = new ScriptFlow((ctx) => [
-      flowTextEvent(ctx, 'flow-uses-caller-ids'),
-      flowTerminalEvent(ctx, 'completed'),
-    ]);
-    const runner = new RuntimeRunner({ flow, providers });
 
-    const result = await runner.run(
-      makeRequest({
-        invocationId: 'inv-production-1',
-        runId: 'run-production-1',
-      }),
-    );
-
-    expect(result.invocationId).toBe('inv-production-1');
-    expect(result.runId).toBe('run-production-1');
-    expect(flow.seen).toHaveLength(1);
-    expect(flow.seen[0]!.invocationId).toBe('inv-production-1');
-    expect(flow.seen[0]!.runId).toBe('run-production-1');
-
-    const userEvent = result.events[0]!;
-    expect(userEvent.author).toBe('user');
-    expect(userEvent.invocationId).toBe('inv-production-1');
-    expect(userEvent.runId).toBe('run-production-1');
-
-    for (const ev of result.events) {
-      expect(ev.invocationId).toBe('inv-production-1');
-      expect(ev.runId).toBe('run-production-1');
-    }
-  });
-
-  test('default behavior stops collecting at the first terminal flow event', async () => {
-    const providers = makeProviders();
-    const flow = new ScriptFlow((ctx) => [
-      flowTextEvent(ctx, 'partial'),
-      flowTerminalEvent(ctx, 'completed'),
-      // These should never be collected once the terminal event is seen.
-      flowTextEvent(ctx, 'after-terminal-1'),
-      flowTerminalEvent(ctx, 'failed'),
-    ]);
-    const runner = new RuntimeRunner({ flow, providers });
-
-    const result = await runner.run(makeRequest());
-
-    expect(result.status).toBe('completed');
-    // user + partial text + terminal = 3; nothing after the terminal event.
-    expect(result.events).toHaveLength(3);
-    const terminal = result.events.at(-1)!;
-    expect(terminal.status).toBe('completed');
-    expect(terminal.actions?.endInvocation).toBe(true);
-    expect(
-      result.events.some(
-        (ev) => ev.content?.kind === 'text' && ev.content.text === 'after-terminal-1',
-      ),
-    ).toBe(false);
-  });
 
   test('stopOnTerminal false keeps draining and fails on any non-completed terminal event', async () => {
     const providers = makeProviders();
@@ -553,37 +442,7 @@ describe('RuntimeRunner', () => {
     expect(result.failure?.terminalStatus).toBe('failed');
   });
 
-  test('omitting the gate means preflight always passes', async () => {
-    const providers = makeProviders();
-    const flow = new ScriptFlow((ctx) => [
-      flowTextEvent(ctx, 'ok'),
-      flowTerminalEvent(ctx, 'completed'),
-    ]);
-    const runner = new RuntimeRunner({ flow, providers });
 
-    const result = await runner.run(makeRequest());
-
-    expect(result.status).toBe('completed');
-    expect(result.events).toHaveLength(3);
-  });
-
-  test('runtimeGateFromCallback adapts a sync callback', async () => {
-    const providers = makeProviders();
-    let flowCalled = false;
-    const flow: RunnableAgentFlow = {
-      async *run(): AsyncIterable<RuntimeEvent> {
-        flowCalled = true;
-      },
-    };
-    const gate = runtimeGateFromCallback(() => ({ ok: false, reason: 'nope' }));
-    const runner = new RuntimeRunner({ flow, gate, providers });
-
-    const result = await runner.run(makeRequest());
-
-    expect(result.status).toBe('failed');
-    expect(result.failure?.class).toBe('preflight');
-    expect(flowCalled).toBe(false);
-  });
 
   test('already-aborted signal before dispatch yields a failed result without flow dispatch', async () => {
     const providers = makeProviders();
@@ -600,129 +459,8 @@ describe('RuntimeRunner', () => {
     expect(flow.seen).toEqual([]);
   });
 
-  test('emitted events carry the invocation identity hierarchy', async () => {
-    const providers = makeProviders();
-    const flow = new ScriptFlow((ctx) => [
-      flowTextEvent(ctx, 'a'),
-      flowTerminalEvent(ctx, 'completed'),
-    ]);
-    const runner = new RuntimeRunner({ flow, providers });
 
-    const result = await runner.run(
-      makeRequest({ sessionId: 'sess-7', turnId: 'turn-7', branch: 'b1' }),
-    );
 
-    expect(result.invocationId).toBeDefined();
-    expect(result.runId).toBeDefined();
-    expect(result.invocationId !== result.runId).toBe(true);
-    for (const ev of result.events) {
-      expect(ev.invocationId).toBe(result.invocationId);
-      expect(ev.runId).toBe(result.runId);
-      expect(ev.sessionId).toBe('sess-7');
-      expect(ev.turnId).toBe('turn-7');
-      expect(ev.branch).toBe('b1');
-    }
-  });
 
-  test('flow receives a context wired to the injected providers and request', async () => {
-    const providers = makeProviders();
-    const flow = new ScriptFlow((ctx) => [flowTextEvent(ctx, 'x')]);
-    const runner = new RuntimeRunner({ flow, providers });
 
-    await runner.run(makeRequest({ source: 'bot', text: 'hello' }));
-
-    expect(flow.seen).toHaveLength(1);
-    const ctx = flow.seen[0]!;
-    expect(ctx.source).toBe('bot');
-    expect(ctx.request.text).toBe('hello');
-    expect(ctx.sessionId).toBe('sess-1');
-    expect(ctx.turnId).toBe('turn-1');
-    expect(typeof ctx.newId()).toBe('string');
-    expect(typeof ctx.now()).toBe('number');
-    // Providers are shared, so a fresh id from ctx is unique against runId.
-    expect(ctx.newId() !== ctx.runId).toBe(true);
-  });
-
-  test('flow receives normalized FlowInput with context default and attachments preserved', async () => {
-    const providers = makeProviders();
-    const context = [
-      {
-        type: 'user' as const,
-        id: 'u-prev',
-        turnId: 'prev-turn',
-        ts: 1,
-        text: 'previous',
-      },
-    ];
-    const runtimeContext: RuntimeEvent[] = [
-      {
-        id: 'rt-prev',
-        invocationId: 'inv-prev',
-        runId: 'run-prev',
-        sessionId: 'sess-1',
-        turnId: 'prev-turn',
-        ts: 1,
-        partial: false,
-        role: 'user',
-        author: 'user',
-        content: { kind: 'text', text: 'previous' },
-      },
-    ];
-    let seenInput: Parameters<RunnableAgentFlow['run']>[1] | undefined;
-    const flow: RunnableAgentFlow = {
-      async *run(ctx, input) {
-        seenInput = input;
-        yield flowTextEvent(ctx, 'done');
-        yield flowTerminalEvent(ctx, 'completed');
-      },
-    };
-    const runner = new RuntimeRunner({ flow, providers });
-
-    const result = await runner.run(
-      makeRequest({ text: 'with file', context, runtimeContext, attachments: [attachment] }),
-    );
-
-    expect(result.status).toBe('completed');
-    expect(seenInput).toEqual({
-      text: 'with file',
-      context,
-      runtimeContext,
-      attachments: [attachment],
-    });
-    expect(result.events[0]!.content).toEqual({
-      kind: 'text',
-      text: 'with file',
-      attachments: [attachment],
-    });
-  });
-
-  test('flow input context defaults to an empty array', async () => {
-    const providers = makeProviders();
-    let seenInput: Parameters<RunnableAgentFlow['run']>[1] | undefined;
-    const flow: RunnableAgentFlow = {
-      async *run(ctx, input) {
-        seenInput = input;
-        yield flowTerminalEvent(ctx, 'completed');
-      },
-    };
-    const runner = new RuntimeRunner({ flow, providers });
-
-    await runner.run(makeRequest());
-
-    expect(seenInput?.context).toEqual([]);
-  });
-
-  test('flow input carries parentRunId from invocation lineage', async () => {
-    const providers = makeProviders();
-    const flow = new ScriptFlow((ctx) => [flowTerminalEvent(ctx, 'completed')]);
-    const runner = new RuntimeRunner({ flow, providers });
-
-    await runner.run(
-      makeRequest({
-        lineage: { parentRunId: 'parent-run-1' },
-      }),
-    );
-
-    expect(flow.seenInputs[0]?.parentRunId).toBe('parent-run-1');
-  });
 });

--- a/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
+++ b/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
@@ -52,20 +52,6 @@ describe('subscription model fetch', () => {
     assert.equal(body.cache_control, undefined);
   });
 
-  test('leaves Claude subscription requests untouched when the cloak opt-out is disabled', async () => {
-    const modelFetch = buildSubscriptionModelFetch({
-      connection: claudeSubscriptionConnection(),
-      sessionId: 'session-123',
-      modelId: 'claude-sonnet-4-5',
-      claude: {
-        cloakEnabled: false,
-        deviceId: 'device-123',
-        accountUuid: 'account-123',
-      },
-    });
-
-    assert.equal(modelFetch, undefined);
-  });
 
   test('rejects Claude subscription cloaking without complete metadata', () => {
     assert.throws(
@@ -246,85 +232,8 @@ describe('subscription model fetch', () => {
     assert.equal(attempts, 1);
   });
 
-  test('does not retry an HTML 403 when the body belongs to a Request object', async () => {
-    let attempts = 0;
-    const modelFetch = buildSubscriptionModelFetch({
-      connection: openAiCodexConnection(),
-      sessionId: 'session-123',
-      modelId: 'gpt-5.6-sol',
-      fetchFn: async (request) => {
-        attempts += 1;
-        if (request instanceof Request) await request.text();
-        return new Response('<html><title>Request rejected</title>', {
-          status: 403,
-          headers: { 'content-type': 'text/html', 'retry-after': '0' },
-        });
-      },
-    });
 
-    assert.ok(modelFetch);
-    const request = new Request('https://chatgpt.com/backend-api/codex/responses', {
-      method: 'POST',
-      body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
-    });
-    await assert.rejects(modelFetch(request), /Codex OAuth request failed: HTTP 403/);
-    assert.equal(request.bodyUsed, true);
-    assert.equal(attempts, 1);
-  });
 
-  test('does not treat a null body override as clearing a Request body', async () => {
-    let attempts = 0;
-    const modelFetch = buildSubscriptionModelFetch({
-      connection: openAiCodexConnection(),
-      sessionId: 'session-123',
-      modelId: 'gpt-5.6-sol',
-      fetchFn: async (request) => {
-        attempts += 1;
-        if (request instanceof Request) await request.text();
-        return new Response('<html><title>Request rejected</title>', {
-          status: 403,
-          headers: { 'content-type': 'text/html', 'retry-after': '0' },
-        });
-      },
-    });
-
-    assert.ok(modelFetch);
-    const request = new Request('https://chatgpt.com/backend-api/codex/responses', {
-      method: 'POST',
-      body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
-    });
-    await assert.rejects(
-      modelFetch(request, { body: null }),
-      /Codex OAuth request failed: HTTP 403/,
-    );
-    assert.equal(attempts, 1);
-  });
-
-  test('does not retry an HTML 403 with a non-string request body', async () => {
-    let attempts = 0;
-    const modelFetch = buildSubscriptionModelFetch({
-      connection: openAiCodexConnection(),
-      sessionId: 'session-123',
-      modelId: 'gpt-5.6-sol',
-      fetchFn: async () => {
-        attempts += 1;
-        return new Response('<html><title>Request rejected</title>', {
-          status: 403,
-          headers: { 'content-type': 'text/html', 'retry-after': '0' },
-        });
-      },
-    });
-
-    assert.ok(modelFetch);
-    await assert.rejects(
-      modelFetch('https://chatgpt.com/backend-api/codex/responses', {
-        method: 'POST',
-        body: new Uint8Array([123, 125]),
-      }),
-      /Codex OAuth request failed: HTTP 403/,
-    );
-    assert.equal(attempts, 1);
-  });
 
   test('aborts while waiting to retry an HTML 403', async () => {
     let attempts = 0;


### PR DESCRIPTION
## Summary

- remove ordinary CLI/Runtime plumbing success cases while retaining failure and boundary behavior
- remove duplicate Quote Companion and Automation happy transitions
- reduce overlapping provider metadata, thinking, fetch, and request-shape matrices
- preserve real provider wire, authentication retry, size bounds, invalid input, and unsupported-level coverage

## Impact

- 57 redundant tests removed from 9 suites
- test LOC: 315,309 -> 314,316 (-993)

## Validation

- `git diff --check`
- Biome on all changed files
- full test suite intentionally left to CI