### PR TITLE
fix(desktop): point link token at solid accent

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -337,6 +337,7 @@ export const test = base.extend<{
   window: Page;
   gitReviewWindow: { page: Page; projectRoot: string };
   invocableSkillsWindow: Page;
+  linkColorWindow: Page;
 }>({
   // Seeded: a pre-staged connection clears onboarding so the composer is ready.
   window: async ({}, use) => {
@@ -365,6 +366,13 @@ export const test = base.extend<{
       readinessSelector: COMPOSER_INPUT,
       locale: 'zh',
       invocableSkills: true,
+    }, use);
+  },
+  linkColorWindow: async ({}, use) => {
+    await withE2eWindow({
+      seed: false,
+      readinessSelector: '.settingsBotConfigDocLink',
+      e2eFixtureScenario: 'settings-bots-onboarding',
     }, use);
   },
 });

--- a/apps/desktop/e2e/link-color-contract.spec.ts
+++ b/apps/desktop/e2e/link-color-contract.spec.ts
@@ -1,0 +1,52 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+
+async function renderedLinkColors(page: Page, dark: boolean) {
+  return page.evaluate(async (isDark) => {
+    const root = document.documentElement;
+    const renderedLink = document.querySelector<HTMLElement>('.settingsBotConfigDocLink')!;
+    renderedLink.style.setProperty('transition', 'none', 'important');
+    root.setAttribute('data-maka-theme', 'tokyo-night');
+    root.classList.toggle('dark', isDark);
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+
+    const resolve = (value: string) => {
+      const probe = document.createElement('span');
+      probe.style.setProperty('color', value, 'important');
+      document.body.appendChild(probe);
+      const color = getComputedStyle(probe).color;
+      probe.remove();
+      return color;
+    };
+    const canvas = document.createElement('canvas');
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext('2d', { willReadFrequently: true })!;
+    const rgba = (value: string) => {
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = value;
+      context.fillRect(0, 0, 1, 1);
+      return [...context.getImageData(0, 0, 1, 1).data];
+    };
+    const colors = {
+      link: rgba(resolve('var(--link)')),
+      solid: rgba(resolve('var(--accent-solid)')),
+      accent: rgba(resolve('var(--accent)')),
+      rendered: rgba(getComputedStyle(renderedLink).color),
+    };
+    return colors;
+  }, dark);
+}
+
+test('link text follows the solid accent tier in light and dark palettes', async ({
+  linkColorWindow: page,
+}) => {
+  const light = await renderedLinkColors(page, false);
+  const dark = await renderedLinkColors(page, true);
+  for (const colors of [light, dark]) {
+    expect(colors.link).toEqual(colors.solid);
+    expect(colors.link).not.toEqual(colors.accent);
+    expect(colors.rendered).toEqual(colors.link);
+  }
+  expect(dark.link).not.toEqual(light.link);
+});

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -143,8 +143,8 @@
   /* Brand accent = logo blue (oklch L0.70 C0.135 h250), sampled from
      apps/desktop/assets/icon.png (owner decision 2026-07-03). --success stays
      an independent green
-     (connected/ok semantics); running/focus-ring/link/nav-active/selection
-     all follow --accent. */
+     (connected/ok semantics); running/focus-ring/nav-active/selection follow
+     --accent, while link text follows the solid tier below. */
   --accent: oklch(0.70 0.135 250);
   /* Checked controls (--control) use a slightly deeper blue (L0.65, one step
      below the accent) so the near-white glyph clears WCAG 1.4.11 non-text
@@ -168,7 +168,7 @@
      below hands to --color-accent. */
   --accent-solid: oklch(from var(--accent) 0.52 c h);
   --accent-wash: oklch(from var(--accent) 0.96 min(c, 0.035) h);
-  --link: var(--accent);
+  --link: var(--accent-solid);
   --focus-ring: var(--accent);
   --status-running: var(--accent);
   /* Cool info blue (h240, azure-family — see the blue-info alt themes at
@@ -998,7 +998,7 @@
      cannot serve this role. */
   --accent-solid: oklch(from var(--accent) 0.76 c h);
   --accent-wash: oklch(from var(--accent) 0.28 min(c, 0.05) h);
-  --link: var(--accent);
+  --link: var(--accent-solid);
   --focus-ring: var(--accent);
   --status-running: var(--accent);
   /* All four together, same shape as the light block. Warning is the hue that

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -1312,9 +1312,8 @@
  * This styles the `.maka-turn` container (NOT a per-turn marker), so it
  * stays hand-written here alongside the other model-catalog-preview turn
  * chrome. */
-/* Visual System 2.0 (T3): derived from `--accent`, not `--link`. Zero pixels
- * move — `--link` is defined exactly twice and both are `var(--accent)`, and
- * palettes override --accent alone — but the two names mean different things.
+/* Visual System 2.0 (T3): derived from `--accent`, not `--link`. The two names
+ * mean different things: palettes override --accent alone, while
  * DESIGN.md §3 scopes the link tier to link TEXT (and to `--accent-solid` at
  * that, for contrast); this is a selection wash and an outline, i.e. the
  * interaction accent doing its normal job. Deriving a surface from the link

--- a/apps/desktop/src/renderer/styles/search-modal.css
+++ b/apps/desktop/src/renderer/styles/search-modal.css
@@ -38,6 +38,6 @@
 .maka-search-modal-snippet-hit {
   padding: 0 var(--space-0-5);
   border-radius: var(--radius-control);
-  background: oklch(from var(--link) l c h / 0.14);
+  background: oklch(from var(--accent) l c h / 0.14);
   color: var(--foreground);
 }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -524,7 +524,7 @@
  }
 .maka-sandbox-blocked-copy { align-self: start; }
 .maka-sandbox-blocked-copy[data-pending="true"] { cursor: progress; }
-.maka-sandbox-blocked-copy[data-copy-feedback="copied"] { border-color: oklch(from var(--link) l c h / 0.35); color: var(--link); }
+.maka-sandbox-blocked-copy[data-copy-feedback="copied"] { border-color: oklch(from var(--accent) l c h / 0.35); color: var(--link); }
 .maka-sandbox-blocked-copy[data-copy-feedback="failed"] { border-color: oklch(from var(--destructive) l c h / 0.35); color: var(--destructive); }
 .maka-turn-status-icon { flex: 0 0 auto; }
 
@@ -738,7 +738,7 @@
 .maka-tool-diff-line[data-line="del"] { background: oklch(from var(--destructive) l c h / 0.1); color: var(--destructive); }
 .maka-tool-diff-line[data-line="hunk"] {
   font: var(--maka-text-heading-5);
- background: oklch(from var(--link) l c h / 0.08); color: var(--foreground-secondary); }
+ background: oklch(from var(--accent) l c h / 0.08); color: var(--foreground-secondary); }
 .maka-tool-diff-line[data-line="meta"] { color: var(--muted-foreground); }
 .maka-tool-diff-line[data-line="ctx"] { color: var(--foreground-secondary); }
 .maka-tool-terminal-cwd { color: var(--muted-foreground); background: transparent; }
@@ -816,7 +816,7 @@
 .maka-agent-preview-section span {
   font: var(--maka-text-supporting);
  margin: 0; color: var(--foreground-secondary); white-space: pre-wrap; word-break: break-word; }
-.maka-agent-preview-copy[data-copied="true"] { border-color: oklch(from var(--link) l c h / 0.35); color: var(--link); }
+.maka-agent-preview-copy[data-copied="true"] { border-color: oklch(from var(--accent) l c h / 0.35); color: var(--link); }
 
 .maka-web-search-preview { display: grid; gap: var(--space-2); padding: var(--space-2-5) var(--space-3); border: 1px solid var(--foreground-10); border-radius: var(--radius-surface); background: var(--foreground-3); }
 .maka-web-search-preview > header { display: flex; flex-direction: column; gap: var(--space-0-5); padding-bottom: var(--space-1-5); border-bottom: 1px solid var(--foreground-10); }


### PR DESCRIPTION
## Summary

- Make semantic link text use the solid accent tier in both light and dark themes, fixing the contrast mismatch reported in #2505.
- Keep non-text washes and copied-state borders on the raw interaction accent so the token change does not alter those surfaces.
- Add a focused rendered Electron contract for the real settings documentation link in light and dark Tokyo Night.

Fixes #2505

## Verification

- `npm run lint` and `npm run format:check`
- `npm run astryx:theme -- --check`
- `npx knip --workspace apps/desktop` and `npx knip --workspace packages/ui`
- `npm run build` and `npm run typecheck`
- UI/Desktop workspace tests: 113/113 and 760/760 passed
- Focused Electron regression: 5/5 repeated runs passed; reverting the link alias makes the new assertion fail
- Storybook build and render smoke: 124/124 stories passed
- Fixture alignment audit: all clean
- Fresh hosted CI on final SHA: typecheck, workspace tests, full Electron E2E/alignment, Storybook, and Windows checks all passed
- Full local Electron suite: 12/13 passed; the remaining macOS slash-command caret assertion also fails on a clean current `main` worktree

| Before — raw accent | After — solid accent tier |
| --- | --- |
| ![Tokyo Night light link before](https://raw.githubusercontent.com/MoonOld/maka-agent/fd513a95bdc0e4577da6ab7af48df48d97345f3e/pr-evidence/2701/docs-link-before.jpg) | ![Tokyo Night light link after](https://raw.githubusercontent.com/MoonOld/maka-agent/fd513a95bdc0e4577da6ab7af48df48d97345f3e/pr-evidence/2701/docs-link-after.jpg) |

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

AI-assisted implementation and review are disclosed by the `Generated-by: Codex` commit trailer. Independent human review is requested because this changes user-visible link colors.
