### PR TITLE
test(e2e): seed Runtime Host policy authority

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -5,7 +5,9 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { createConnectionStore, createFileCredentialStore, createSettingsStore } from '@maka/storage';
+import { createSettingsStore } from '@maka/storage';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import { buildFixtureEnv, isCiLinuxDisplay } from '../../../scripts/fixture-env.mjs';
 import { closeElectronApplication } from '../../../scripts/electron-lifecycle.mjs';
 
@@ -46,34 +48,101 @@ export async function waitForInvocableSkills(
 /**
  * Pre-seed a real-looking connection into the throwaway workspace so onboarding
  * clears and the composer is enabled. Actual sessions still run on the fake
- * backend (BackendRegistry override in main); this only satisfies the UI
- * readiness gates. Kept in the fixture so test data stays out of production main.
+ * backend in the Desktop E2E Runtime Host candidate; this only satisfies the
+ * UI readiness gates. Kept in the fixture so test data stays out of production main.
  */
 async function seedE2eConnection(
   userDataDir: string,
   extraConnectionCount = 0,
 ): Promise<void> {
   const workspaceRoot = path.join(userDataDir, 'workspaces', 'default');
-  const connections = createConnectionStore(workspaceRoot);
-  const credentials = createFileCredentialStore(workspaceRoot);
-  await connections.create({
-    slug: 'e2e',
-    name: 'E2E',
-    providerType: 'anthropic',
-    defaultModel: 'claude-sonnet-4-5-20250929',
-  });
-  await credentials.setSecret('e2e', 'api_key', 'e2e-placeholder');
-  for (let index = 0; index < extraConnectionCount; index += 1) {
-    const slug = `e2e-extra-${index + 1}`;
-    await connections.create({
-      slug,
-      name: `E2E Extra ${index + 1}`,
-      providerType: 'anthropic',
-      defaultModel: `claude-e2e-${index + 1}`,
+  const capability = await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  if (!owner) throw new Error('Unable to acquire the E2E workspace for connection setup');
+
+  try {
+    const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const connections = [
+      {
+        slug: 'e2e',
+        name: 'E2E',
+        modelId: 'claude-sonnet-4-5-20250929',
+      },
+      ...Array.from({ length: extraConnectionCount }, (_, index) => ({
+        slug: `e2e-extra-${index + 1}`,
+        name: `E2E Extra ${index + 1}`,
+        modelId: `claude-e2e-${index + 1}`,
+      })),
+    ];
+    let defaultConnectionId: string | undefined;
+
+    for (const connection of connections) {
+      const catalog = await stores.connectionCatalog.getSnapshot();
+      const created = await stores.connectionCatalog.create({
+        expectedCatalogRevision: catalog.revision,
+        connection: {
+          slug: connection.slug,
+          name: connection.name,
+          providerType: 'anthropic',
+          enabled: true,
+          enabledModelIds: [connection.modelId],
+        },
+      });
+      if (created.kind !== 'committed') {
+        throw new Error(`Unable to create the ${connection.slug} E2E connection: ${created.kind}`);
+      }
+      const entry = created.snapshot.connections.find(({ slug }) => slug === connection.slug);
+      if (!entry) throw new Error(`The ${connection.slug} E2E connection was not persisted`);
+
+      const credential = await stores.credentialVault.set({
+        locator: {
+          scope: 'connection',
+          connectionId: entry.connectionId,
+          kind: 'api_key',
+        },
+        expected: null,
+        secret: 'e2e-placeholder',
+      });
+      if (credential.kind !== 'committed') {
+        throw new Error(
+          `Unable to store the ${connection.slug} E2E credential: ${credential.kind}`,
+        );
+      }
+
+      const modelFetch = await stores.operations.beginModelFetch(entry.connectionId);
+      if (modelFetch.kind !== 'ready') {
+        throw new Error(
+          `Unable to prepare the ${connection.slug} E2E model inventory: ${modelFetch.kind}`,
+        );
+      }
+      const modelInventory = await stores.operations.completeModelFetch(modelFetch.ticket, {
+        models: [{ id: connection.modelId }],
+        source: 'fallback',
+        fetchedAt: 0,
+      });
+      if (modelInventory.kind !== 'committed') {
+        throw new Error(
+          `Unable to store the ${connection.slug} E2E model inventory: ${modelInventory.kind}`,
+        );
+      }
+      if (connection.slug === 'e2e') defaultConnectionId = entry.connectionId;
+    }
+
+    if (!defaultConnectionId) throw new Error('The default E2E connection was not created');
+    const catalog = await stores.connectionCatalog.getSnapshot();
+    const selected = await stores.connectionCatalog.setDefaultTarget({
+      expectedCatalogRevision: catalog.revision,
+      target: {
+        connectionId: defaultConnectionId,
+        modelId: 'claude-sonnet-4-5-20250929',
+      },
     });
-    await credentials.setSecret(slug, 'api_key', 'e2e-placeholder');
+    if (selected.kind !== 'committed') {
+      throw new Error(`Unable to select the default E2E connection: ${selected.kind}`);
+    }
+  } finally {
+    await owner.close();
   }
-  await connections.setDefault('e2e');
 }
 
 async function seedE2eLocale(userDataDir: string, locale: 'zh' | 'en'): Promise<void> {

--- a/apps/desktop/e2e/send-message.spec.ts
+++ b/apps/desktop/e2e/send-message.spec.ts
@@ -16,6 +16,38 @@ import { test, expect, COMPOSER_INPUT } from './fixtures';
 test('Enter mid-IME commits the candidate, then an ordinary send streams a reply', async ({
   window: page,
 }) => {
+  const authority = await page.evaluate(async () => {
+    const snapshot = await window.maka.onboarding.getSnapshot();
+    return {
+      state: snapshot.state,
+      defaultSlug: snapshot.defaultSlug,
+      connections: snapshot.connections.map((connection) => ({
+        slug: connection.slug,
+        defaultModel: connection.defaultModel,
+        enabledModelIds: connection.enabledModelIds,
+        modelIds: connection.models?.map(({ id }) => id),
+      })),
+      hasSecret: await window.maka.connections.hasSecret('e2e'),
+    };
+  });
+  expect(authority).toEqual({
+    state: {
+      kind: 'ready_empty',
+      connectionSlug: 'e2e',
+      model: 'claude-sonnet-4-5-20250929',
+    },
+    defaultSlug: 'e2e',
+    connections: [
+      {
+        slug: 'e2e',
+        defaultModel: 'claude-sonnet-4-5-20250929',
+        enabledModelIds: ['claude-sonnet-4-5-20250929'],
+        modelIds: ['claude-sonnet-4-5-20250929'],
+      },
+    ],
+    hasSecret: true,
+  });
+
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill('中文草稿');
   await composer.evaluate((element) => {


### PR DESCRIPTION
## Summary

- Seed Desktop Playwright connections through the current Runtime Host policy authority after #2700 removed the legacy migration.
- Persist credentials, model inventories, and the default target, then release the root owner before Electron starts.
- Assert the public Host-backed onboarding projection before exercising the real session send path.

Fixes #2705

## Verification

- `npm --workspace @maka/desktop run build:with-deps`
- `npm run lint`
- `npm run typecheck`
- `settings.spec.ts`: 3 passed
- `send-message.spec.ts`: 1 passed
- `send-message.spec.ts` + `settings.spec.ts`, `--repeat-each=3`: 12 passed
- Hosted Linux CI: 17/17 Desktop E2E passed and the alignment audit was clean ([run](https://github.com/maka-agent/maka-agent/actions/runs/31500009066/job/93807308116)).
- Full Desktop E2E locally: 16 passed; the existing macOS `Home` caret assertion in `slash-command-menu.spec.ts` failed identically on the pre-#2700 baseline.
- `npm run format:check`: blocked by 62 existing files outside this diff; #2702 fixes that baseline.
- `npx knip --workspace apps/desktop`: blocked by the existing unused `session-list-render-helpers.ts`; #2702 removes it.

## Root cause

The shared fixture still wrote legacy connection and credential files. With migration removed and automatic bootstrap disabled for the Desktop E2E candidate, Runtime Host saw an empty catalog and 16 tests stopped at onboarding before their assertions.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No