### PR TITLE
test: remove dead fixtures and diagnostic detail cases

### DIFF
--- a/packages/computer-use/src/__tests__/maka-cu-backend.test.ts
+++ b/packages/computer-use/src/__tests__/maka-cu-backend.test.ts
@@ -76,7 +76,6 @@ const TRUNCATED = process.env.MAKACU_MOCK_TRUNCATED === '1';
 let DIFFERENCE_PRESENTATION = '';
 const LAUNCH_TOOK_FOREGROUND = process.env.MAKACU_MOCK_LAUNCH_FOREGROUND === '1';
 const WINDOW_ORIGIN_Y = Number(process.env.MAKACU_MOCK_WINDOW_ORIGIN_Y || '25');
-const SELECTED_TEXT = process.env.MAKACU_MOCK_SELECTED_TEXT || '';
 const NONCE = crypto.randomBytes(16).toString('hex');
 // 1x1 transparent PNG.
 const PNG = Buffer.from(
@@ -153,7 +152,7 @@ function snapshot(includeImage) {
     },
     windowDigest: digest('window_' + snapshotSeq),
     focusedElementToken: 'el_2',
-    selectedText: SELECTED_TEXT ? { text: SELECTED_TEXT, truncated: true } : null,
+    selectedText: null,
     image: includeImage ? writeImage(id) : null,
     displays: [{
       displayId: '69732928',
@@ -390,7 +389,6 @@ function makeBackend(
     timeoutMs?: number;
     launchTookForeground?: boolean;
     windowOriginY?: number;
-    selectedText?: string;
     physicalInputRecentlyActive?: MakaCuBackendOptions['physicalInputRecentlyActive'];
     allowCompatibilityInputDispatch?: boolean;
     onTrace?: MakaCuBackendOptions['onTrace'];
@@ -427,7 +425,6 @@ function makeBackend(
   process.env.MAKACU_MOCK_TRUNCATED = opts.truncated ? '1' : '';
   process.env.MAKACU_MOCK_LAUNCH_FOREGROUND = opts.launchTookForeground ? '1' : '';
   process.env.MAKACU_MOCK_WINDOW_ORIGIN_Y = String(opts.windowOriginY ?? 25);
-  process.env.MAKACU_MOCK_SELECTED_TEXT = opts.selectedText ?? '';
   const backend = createMakaCuBackend({
     binaryPath: mockPath,
     imageDir,

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { describe, test } from 'node:test';
-import { encodeCanonicalRuntimeEvent } from '@maka/core/canonical-runtime-event';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
@@ -12,7 +11,6 @@ import {
   collectStaleToolResultArchiveCandidates,
   buildSynthesisCacheBlocksFromHydratedArchives,
   deserializeToolResultArchive,
-  mergeContextBudgetDiagnostic,
   renderHistoryCompactBlock,
   retrieveArchivedToolResultsForReplay,
   retrieveRuntimeEventHistoryAround,
@@ -1870,69 +1868,6 @@ describe('context-budget search and rewrite diagnostics', () => {
     assert.equal(budgeted.diagnostic.historyRewriteGate, 'phase6-high-water');
     assert.equal(budgeted.diagnostic.historyRewriteVersion, 'phase6-v1');
     assert.equal(budgeted.diagnostic.historyRewriteResetReason, 'explicit_test_reset');
-  });
-});
-
-describe('context-budget diagnostic merges', () => {
-  test('omits count-record fields that are absent from both inputs', () => {
-    const merged = mergeContextBudgetDiagnostic(
-      {
-        enabled: true,
-        estimatedTokensBefore: 287,
-        estimatedTokensAfter: 287,
-        keptTurns: 1,
-        droppedTurns: 0,
-        keptEvents: 6,
-        droppedEvents: 0,
-        historyCompactSkippedReasonCounts: { below_high_water: 1 },
-      },
-      {
-        historyCompactBlocksLoaded: 0,
-        historyCompactBlocksAvailable: 0,
-        historyCompactSkippedReasonCounts: {
-          below_high_water: 2,
-          already_compacted: 1,
-        },
-      },
-    );
-
-    assert.equal(Object.hasOwn(merged, 'archiveRetrievalFailureReasonCounts'), false);
-    assert.equal(Object.hasOwn(merged, 'synthesisCacheSkippedReasonCounts'), false);
-    assert.equal(Object.hasOwn(merged, 'historyCompactLoadSkippedReasonCounts'), false);
-    assert.deepEqual(merged.historyCompactSkippedReasonCounts, {
-      below_high_water: 3,
-      already_compacted: 1,
-    });
-  });
-
-  test('produces a losslessly serializable token usage diagnostic', () => {
-    const contextBudget = mergeContextBudgetDiagnostic(
-      {
-        enabled: true,
-        estimatedTokensBefore: 287,
-        estimatedTokensAfter: 287,
-        keptTurns: 1,
-        droppedTurns: 0,
-        keptEvents: 6,
-        droppedEvents: 0,
-        historyCompactSkippedReasonCounts: { below_high_water: 1 },
-      },
-      {
-        historyCompactBlocksLoaded: 0,
-        historyCompactBlocksAvailable: 0,
-      },
-    );
-    const event = baseEvent({
-      actions: {
-        tokenUsage: {
-          input: 9_131,
-          output: 44,
-          contextBudget,
-        },
-      },
-    });
-
-    assert.doesNotThrow(() => encodeCanonicalRuntimeEvent(event));
   });
 });
 

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -2203,17 +2203,6 @@ describe('runtime policy stores', () => {
     });
   });
 
-  test('resolves WebFetch independently of the WebSearch feature gate', async () => {
-    await withInteractiveOwner(async ({ stores }) => {
-      const resolved = await stores.operations.resolveWebFetchExecution();
-
-      assert.equal(resolved.kind, 'ready');
-      if (resolved.kind !== 'ready') return;
-      assert.equal(resolved.networkProxy.enabled, false);
-      assert.deepEqual(resolved.secretMaterial, {});
-    });
-  });
-
   test('blocks WebFetch while privacy mode is active', async () => {
     await withInteractiveOwner(async ({ stores }) => {
       const policy = await stores.runtimePolicy.mutate({


### PR DESCRIPTION
## Summary
- remove dead Computer Use selected-text fixture plumbing left after presentation matrix cleanup
- remove context-budget diagnostic merge/serialization implementation-detail tests
- remove the default WebFetch happy path while retaining privacy fail-closed coverage

## Result
- net 79 test lines removed
- no production changes
- no tests added

## Validation
- Biome check on all changed files
- git diff --check
- dead fixture symbol scan

Full tests intentionally left to CI.