### PR TITLE
test: remove legacy input cases

### DIFF
--- a/apps/desktop/src/main/__tests__/shell-env.test.ts
+++ b/apps/desktop/src/main/__tests__/shell-env.test.ts
@@ -308,18 +308,6 @@ describe('buildCaptureCommand', () => {
       assert.equal(match[1], JSON.stringify({ PATH: '/usr/bin' }));
     });
 
-    it('tcsh / csh collapse to the legacy single -ic argv', () => {
-      const tcsh = buildCaptureCommand('tcsh', '/usr/bin/node', MARK);
-      assert.deepEqual(tcsh.shellArgs, ['-ic']);
-      const csh = buildCaptureCommand('csh', '/usr/bin/node', MARK);
-      assert.deepEqual(csh.shellArgs, ['-ic']);
-      // Same flush-marker payload as the rest of the POSIX family.
-      assert.equal(
-        tcsh.command,
-        `'/usr/bin/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
-      );
-    });
-
     it('round-trips an apostrophe in execPath via the close-quote / escape / reopen sequence', () => {
       // POSIX single-quoting cannot contain a literal `'`; the safe escape is
       // to close the quote, emit a backslash-escaped quote, and reopen.

--- a/packages/core/src/__tests__/interaction.test.ts
+++ b/packages/core/src/__tests__/interaction.test.ts
@@ -940,7 +940,7 @@ describe('Interaction decoding and validity', () => {
     }
   });
 
-  test('decodes only bounded auto-review rationale while preserving legacy outcomes', () => {
+  test('decodes only bounded auto-review rationale', () => {
     const rationale = 'r'.repeat(INTERACTION_AUTO_REVIEW_RATIONALE_MAX_CHARS);
     const reviewed = decodeInteractionCanonicalOutcome({
       kind: 'permission_answer',
@@ -966,17 +966,6 @@ describe('Interaction decoding and validity', () => {
       retry.kind === 'permission_answer' ? retry.rationale : undefined,
       'A retry may explain the same user-answer semantics differently.',
     );
-
-    const legacy = decodeInteractionCanonicalOutcome({
-      kind: 'permission_answer',
-      decision: 'deny',
-      rememberForTurn: false,
-      reviewer: 'auto_review',
-      committedAt: 3,
-    });
-    assert.equal(legacy.kind, 'permission_answer');
-    if (legacy.kind !== 'permission_answer') return;
-    assert.equal(legacy.rationale, undefined);
 
     assert.throws(() =>
       decodeInteractionCanonicalOutcome({

--- a/packages/runtime/src/__tests__/skills.test.ts
+++ b/packages/runtime/src/__tests__/skills.test.ts
@@ -108,29 +108,6 @@ body`);
     );
   });
 
-  it('recovers legacy scalar colons and tab-indented lists with an explicit warning', () => {
-    const result = validateSkillMetadata(`---
-name: Legacy Writer
-description: Use when: the user asks for writing help.
-allowed-tools: Read, Write
-required-tools:
-\t- Bash
----
-# Legacy Writer`);
-
-    assert.equal(result.valid, true);
-    assert.equal(result.manifest.description, 'Use when: the user asks for writing help.');
-    assert.deepEqual(result.manifest.allowedTools, ['Read', 'Write']);
-    assert.deepEqual(result.manifest.requiredTools, ['Bash']);
-    assert.deepEqual(
-      result.issues.map((issue) => ({
-        code: issue.code,
-        severity: issue.severity,
-      })),
-      [{ code: 'malformed_frontmatter', severity: 'warning' }],
-    );
-  });
-
   it('keeps compatible skills loadable while reporting non-blocking metadata warnings', () => {
     const result = validateSkillMetadata(`---
 name: ${'N'.repeat(65)}
@@ -777,13 +754,6 @@ Use host tools.`,
       if (result.ok) return;
       assert.equal(result.reason, 'host_incompatible');
 
-      // without host: legacy behavior, loads ok.
-      const legacyTool = buildSkillAgentTool(workspaceRoot);
-      const legacy = await legacyTool.impl(
-        { name: 'gated-helper' },
-        {} as unknown as MakaToolContext,
-      );
-      assert.equal(legacy.ok, true);
     });
   });
 
@@ -817,9 +787,6 @@ Use host tools.`,
       });
       assert.equal(ok.ok, true);
 
-      // no host: legacy behavior, load ok.
-      const legacy = await loadSkillInstructions(workspaceRoot, 'gated-helper');
-      assert.equal(legacy.ok, true);
     });
   });
 
@@ -900,11 +867,6 @@ Plain work.`,
       assert.match(full, /<available-skill id="plain-helper"/);
       assert.match(full, /<available-skill id="gated-helper"/);
 
-      // no host (undefined): legacy behavior, both shown (no gating).
-      const legacy = await buildSkillsPromptFragment(workspaceRoot);
-      assert.ok(legacy);
-      assert.match(legacy, /<available-skill id="plain-helper"/);
-      assert.match(legacy, /<available-skill id="gated-helper"/);
     });
   });
 


### PR DESCRIPTION
## Summary

- remove malformed legacy Skill frontmatter recovery coverage
- stop testing no-Host capability-gate bypasses
- remove tcsh/csh legacy capture argv coverage
- remove the rationale-less legacy permission outcome case

Strict Skill validation, Host capability gating, supported shell escaping, and bounded permission rationale coverage remain.

Net result: 62 fewer test lines.

## Verification

- `git diff --check`
- Biome check on all modified test files
- legacy-case reference scan

Full tests intentionally not run; CI owns affected product suites.