### PR TITLE
refactor: remove unused compatibility shapes

### DIFF
--- a/apps/desktop/src/main/runtime-host-native-capabilities.ts
+++ b/apps/desktop/src/main/runtime-host-native-capabilities.ts
@@ -446,9 +446,6 @@ function projectContentPart(
         );
       }
       return projectBinaryContent(part.data.data, part.mediaType);
-    case "file-data":
-    case "image-data":
-      return projectBinaryContent(part.data, part.mediaType);
     default:
       throw new Error(
         `Desktop native capability cannot return ${part.type} content`,

--- a/docs/archive/runtime-v2-implementation-notes.md
+++ b/docs/archive/runtime-v2-implementation-notes.md
@@ -54,8 +54,8 @@ formal flow seam:
   `AgentFlow.run(ctx, input)` contract.
 
 The runtime barrel re-exports the canonical `InvocationContext` from
-`invocation-context.ts`; the previous duplicate flow-local context has been
-removed so runner and flow code share the same identity/provider spine.
+`invocation-context.ts`; the previous duplicate flow-local context was removed
+so runner and flow code share the same identity/provider spine.
 
 ## What remains (by phase)
 
@@ -84,8 +84,7 @@ removed so runner and flow code share the same identity/provider spine.
 - **Flow runnable surface:** `RuntimeRunner` depends on the centrally owned
   `RunnableAgentFlow` (`Pick<AgentFlow, 'run'>`) so it remains decoupled from
   flow metadata (`kind`, `sessionId`) while sharing the formal `AgentFlow.run`
-  signature. The old `AgentFlowLike` name remains as a deprecated compatibility
-  alias.
+  signature.
 
 ## Verification snapshot
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1570,7 +1570,6 @@ export type {
   ChatDefaultPermissionMode,
   ChatDefaultsSettings,
   NetworkProxySettings,
-  NetworkSettings,
   NotificationSettings,
   PrivacySettings,
   ProxyProtocol,

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -101,9 +101,6 @@ export interface AppNetworkSettings {
   proxy: NetworkProxySettings;
 }
 
-/** @deprecated Use AppNetworkSettings for the persisted application settings shape. */
-export type NetworkSettings = AppNetworkSettings;
-
 export type UsageRange = '24h' | '7d' | '30d' | 'all';
 export type UsageStatus = 'all' | 'success' | 'error';
 export type UsageTab = 'requests' | 'providers' | 'models' | 'tools' | 'pricing';

--- a/packages/core/src/settings/network-settings.ts
+++ b/packages/core/src/settings/network-settings.ts
@@ -34,9 +34,6 @@ export interface RuntimeNetworkSettings {
   preferIpv4: boolean;
 }
 
-/** @deprecated Use RuntimeNetworkSettings for the runtime network contract. */
-export type NetworkSettings = RuntimeNetworkSettings;
-
 export const PROXY_DEFAULTS: ProxySettings = {
   enabled: false,
   type: 'http',

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1277,7 +1277,6 @@ export { RuntimeRunner, runtimeGateFromCallback } from './runtime-runner.js';
 export type {
   RuntimeGate,
   RuntimeGateDecision,
-  AgentFlowLike,
   RuntimeRunnerDeps,
 } from './runtime-runner.js';
 

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -46,7 +46,7 @@ export type ProviderOptions = Record<string, JSONObject>;
  * A mapping of provider names to provider-specific file identifiers. A
  * provider reference identifies a file across providers without re-uploading.
  * The `type?: never` constraint excludes any object that has a `type` property,
- * so a provider reference cannot be confused with a tagged file-data shape
+ * so a provider reference cannot be confused with a tagged `FileData` shape
  * (`{ type: 'data', data }` / `{ type: 'reference', reference }`) when both
  * appear in the same union.
  */
@@ -149,12 +149,7 @@ export type ToolApprovalResponse = {
 // Tool result output contract
 // ---------------------------------------------------------------------------
 
-/**
- * One part of a `content`-shaped tool result output. Includes the legacy
- * `file-data` / `file-url` / `file-id` / `file-reference` / `image-*` arms so
- * any provider-emitted tool result stays structurally compatible with the
- * Maka-owned union.
- */
+/** One part of a `content`-shaped tool result output. */
 export type ToolResultContentPart =
   | { type: 'text'; text: string; providerOptions?: ProviderOptions }
   | {
@@ -162,58 +157,6 @@ export type ToolResultContentPart =
       data: FileData;
       mediaType: string;
       filename?: string;
-      providerOptions?: ProviderOptions;
-    }
-  | {
-      /** @deprecated use `{ type: 'file', data: { type: 'data', data } }` */
-      type: 'file-data';
-      data: string;
-      mediaType: string;
-      filename?: string;
-      providerOptions?: ProviderOptions;
-    }
-  | {
-      /** @deprecated use `{ type: 'file', data: { type: 'url', url } }` */
-      type: 'file-url';
-      url: string;
-      mediaType?: string;
-      providerOptions?: ProviderOptions;
-    }
-  | {
-      /** @deprecated use `{ type: 'file', data: { type: 'reference', reference } }` */
-      type: 'file-id';
-      fileId: string | Record<string, string>;
-      providerOptions?: ProviderOptions;
-    }
-  | {
-      /** @deprecated use `{ type: 'file', data: { type: 'reference', reference } }` */
-      type: 'file-reference';
-      providerReference: ProviderReference;
-      providerOptions?: ProviderOptions;
-    }
-  | {
-      /** @deprecated use `{ type: 'file', mediaType: 'image', data }` */
-      type: 'image-data';
-      data: string;
-      mediaType: string;
-      providerOptions?: ProviderOptions;
-    }
-  | {
-      /** @deprecated use `{ type: 'file', mediaType: 'image', data: { type: 'url', url } }` */
-      type: 'image-url';
-      url: string;
-      providerOptions?: ProviderOptions;
-    }
-  | {
-      /** @deprecated use `{ type: 'file', data: { type: 'reference', reference } }` */
-      type: 'image-file-id';
-      fileId: string | Record<string, string>;
-      providerOptions?: ProviderOptions;
-    }
-  | {
-      /** @deprecated use `{ type: 'file', data: { type: 'reference', reference } }` */
-      type: 'image-file-reference';
-      providerReference: ProviderReference;
       providerOptions?: ProviderOptions;
     }
   | { type: 'custom'; providerOptions?: ProviderOptions };

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -90,15 +90,6 @@ export function runtimeGateFromCallback(
 }
 
 // ============================================================================
-// AgentFlowLike — compatibility alias
-// ============================================================================
-
-/**
- * @deprecated Use `RunnableAgentFlow` from `./agent-flow.js`.
- */
-export type AgentFlowLike = RunnableAgentFlow;
-
-// ============================================================================
 // RuntimeRunnerDeps
 // ============================================================================
 


### PR DESCRIPTION
## Summary
- remove eight deprecated tool-result content variants with no producers
- keep one canonical file content representation
- remove zero-reference runtime and network type aliases

## Rationale
These compatibility shapes represented states the product cannot create. Their presence widened protocol handling and public types without preserving any active behavior or persisted-data recovery path.

## Verification
- repository-wide deprecated-shape reference scan
- Biome on changed source/docs
- git diff --check

Full tests and typecheck intentionally left to CI.