### PR TITLE
refactor(storage): remove project JSON migrations

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -5,7 +5,13 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
-import { createConnectionStore, createFileCredentialStore, createSettingsStore } from '@maka/storage';
+import {
+  createConnectionStore,
+  createFileCredentialStore,
+  createProjectCatalog,
+  createSettingsStore,
+} from '@maka/storage';
+import { resolveStorageRoot } from '@maka/storage/root-authority';
 import { buildFixtureEnv, isCiLinuxDisplay } from '../../../scripts/fixture-env.mjs';
 import { closeElectronApplication } from '../../../scripts/electron-lifecycle.mjs';
 
@@ -131,12 +137,8 @@ async function seedE2eInvocableSkills(userDataDir: string): Promise<void> {
       `---\nname: Workspace Only\ndescription: Maka workspace suggestion.\n---\n# Workspace Only`,
       'utf8',
     ),
-    writeFile(
-      path.join(workspaceRoot, 'last-project-path.json'),
-      JSON.stringify({ projectPath: projectRoot }),
-      'utf8',
-    ),
   ]);
+  await seedCurrentProject(workspaceRoot, projectRoot);
 }
 
 async function seedE2eGitReviewProject(
@@ -174,11 +176,22 @@ async function seedE2eGitReviewProject(
       ),
     ),
   );
-  await writeFile(
-    path.join(workspaceRoot, 'last-project-path.json'),
-    JSON.stringify({ projectPath: projectRoot }),
-    'utf8',
-  );
+  await seedCurrentProject(workspaceRoot, projectRoot);
+}
+
+async function seedCurrentProject(workspaceRoot: string, projectRoot: string): Promise<void> {
+  const storageRoot = await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
+  const catalog = createProjectCatalog(workspaceRoot);
+  try {
+    const project = await catalog.register(projectRoot);
+    await writeFile(
+      path.join(workspaceRoot, 'project-preferences.json'),
+      JSON.stringify({ version: 1, selections: { [storageRoot.rootId]: project.id } }),
+      'utf8',
+    );
+  } finally {
+    catalog.close();
+  }
 }
 
 /**

--- a/apps/desktop/src/main/__tests__/project-root-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/project-root-controller.test.ts
@@ -68,7 +68,6 @@ function controller(base: string, fallback: string, rootId: string) {
   return createProjectRootController({
     rootId,
     preferenceFile: join(base, 'project-preferences.json'),
-    legacySelectionFile: join(base, 'last-project-path.json'),
     fallbackRoots: () => [fallback],
   });
 }

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -1,7 +1,7 @@
 import { mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { E2eFixtureScenario, E2eFixtureState, UiLocale } from '@maka/core';
-import { createFileCredentialStore } from '@maka/storage';
+import { createFileCredentialStore, createProjectCatalog } from '@maka/storage';
 import type { CredentialStore } from '@maka/storage';
 import { resolveStorageRoot } from '@maka/storage/root-authority';
 import {
@@ -11,7 +11,6 @@ import {
   LONG_SIDEBAR_PROJECT_NAME,
   LONG_SIDEBAR_SESSION_PREFIX,
   TURN_SESSION_ID,
-  writeJson,
   writeSession,
 } from './e2e-fixture/seed-helpers.js';
 import {
@@ -203,16 +202,16 @@ export async function seedE2eFixture(input: {
     for (const seed of longSidebarSessions(now)) {
       await writeSession(input.workspaceRoot, seed.header, seed.messages);
     }
-    await writeJson(join(input.workspaceRoot, 'projects.json'), {
-      schemaVersion: 1,
-      projects: [{
-        id: LONG_SIDEBAR_PROJECT_ID,
-        name: LONG_SIDEBAR_PROJECT_NAME,
-        identity: `folder:${input.workspaceRoot}`,
-        locations: [{ path: input.workspaceRoot, isWorktree: false, lastUsedAt: now }],
-        lastUsedAt: now,
-      }],
+    const catalog = createProjectCatalog(input.workspaceRoot, {
+      now: () => now,
+      createId: () => LONG_SIDEBAR_PROJECT_ID,
     });
+    try {
+      const project = await catalog.register(input.workspaceRoot);
+      await catalog.rename(project.id, LONG_SIDEBAR_PROJECT_NAME);
+    } finally {
+      catalog.close();
+    }
   }
   if (scenario === 'scheduled-tasks') await writeScheduledTasks(input.workspaceRoot, now);
   if (scenario === 'module-daily-review') await writeDailyReviewArchives(input.workspaceRoot, now);

--- a/apps/desktop/src/main/project-root-controller.ts
+++ b/apps/desktop/src/main/project-root-controller.ts
@@ -22,7 +22,6 @@ export interface ProjectRootController {
 export interface ProjectRootControllerDeps {
   readonly rootId: string;
   readonly preferenceFile: string;
-  readonly legacySelectionFile: string;
   readonly fallbackRoots: () => string[];
 }
 
@@ -76,24 +75,14 @@ async function loadInitialSelection(
 ): Promise<CurrentProjectSelection> {
   const fallbackPath = await resolveProjectRoot(deps.fallbackRoots());
   const preference = await readPreference(deps.preferenceFile, deps.rootId);
-  if (preference !== undefined) return { projectId: preference, path: fallbackPath };
-
-  const legacy = await readLegacySelection(deps.legacySelectionFile);
-  if (!legacy) return { projectId: undefined, path: fallbackPath };
-  if (typeof legacy.projectId !== 'string') return legacy;
-  if (!(await savePreference(deps, legacy.projectId))) {
-    return legacy;
-  }
-  await rm(deps.legacySelectionFile, { force: true }).catch(() => undefined);
-  return legacy;
+  return { projectId: preference, path: fallbackPath };
 }
 
 async function persistSelection(
   deps: ProjectRootControllerDeps,
   projectId: string | null,
 ): Promise<void> {
-  if (!(await savePreference(deps, projectId))) return;
-  await rm(deps.legacySelectionFile, { force: true }).catch(() => undefined);
+  await savePreference(deps, projectId);
 }
 
 async function readPreference(file: string, rootId: string): Promise<string | null | undefined> {
@@ -106,23 +95,6 @@ async function readPreference(file: string, rootId: string): Promise<string | nu
     return typeof value === 'string' || value === null ? value : undefined;
   } catch {
     return undefined;
-  }
-}
-
-async function readLegacySelection(file: string): Promise<CurrentProjectSelection | null> {
-  try {
-    const parsed = JSON.parse(await readFile(file, 'utf8')) as Record<string, unknown>;
-    if (typeof parsed.projectPath !== 'string' || !parsed.projectPath) return null;
-    await stat(parsed.projectPath);
-    return {
-      projectId:
-        typeof parsed.projectId === 'string' || parsed.projectId === null
-          ? parsed.projectId
-          : undefined,
-      path: await resolveProjectRoot([parsed.projectPath]),
-    };
-  } catch {
-    return null;
   }
 }
 

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -233,7 +233,6 @@ onMainWindowClose = () => {
 const projectRoot = createProjectRootController({
   rootId: storageRoot.rootId,
   preferenceFile: join(workspaceRoot, "project-preferences.json"),
-  legacySelectionFile: join(workspaceRoot, "last-project-path.json"),
   fallbackRoots: () => [process.cwd(), app.getAppPath()],
 });
 const attachmentApprovals = createAttachmentApprovalRegistry();

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -227,10 +227,7 @@ export async function createExecutionRuntimeHostComposition(
   let projectCatalog: InteractiveProjectCatalogWriter | undefined;
   let goalExecutions: HostGoalExecutionCoordinator | undefined;
   try {
-    const openedProjectCatalog = await openInteractiveProjectCatalogForWrite(context.owner.lease, {
-      onLegacyImportFailure: (error) =>
-        console.error('[runtime-host] projects.json could not be imported:', error),
-    });
+    const openedProjectCatalog = await openInteractiveProjectCatalogForWrite(context.owner.lease);
     projectCatalog = openedProjectCatalog;
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -285,10 +285,6 @@ test('two catalogs changing one project at the same time keep both changes', asy
     const first = createProjectCatalog(storage, { now: () => 1_000 });
     const second = createProjectCatalog(storage, { now: () => 2_000 });
     const project = await first.register(workspace);
-    // Both catalogs settle their one-time legacy-import probe first, so the two
-    // mutations below really do overlap instead of queueing behind that I/O.
-    await Promise.all([first.list(), second.list()]);
-
     // Each catalog rewrites the whole table; without holding the write lock
     // across its own read, the later writer replays a stale copy and the other
     // window's edit disappears with no error anywhere.

--- a/packages/storage/src/project-catalog-authority.ts
+++ b/packages/storage/src/project-catalog-authority.ts
@@ -31,7 +31,6 @@ export function authenticateInteractiveProjectCatalogWriter(
 
 export async function openInteractiveProjectCatalogForWrite(
   lease: StorageRootLease<'interactive', 'write'>,
-  options: { readonly onLegacyImportFailure?: (error: unknown) => void } = {},
 ): Promise<InteractiveProjectCatalogWriter> {
   await assertStorageRootLease(lease, 'interactive', 'write');
   const existing = writerByLease.get(lease);
@@ -43,7 +42,7 @@ export async function openInteractiveProjectCatalogForWrite(
     let catalog: ProjectCatalog | undefined;
     try {
       catalog = await runWithStorageRootLease(lease, 'interactive', 'write', async (root) =>
-        createProjectCatalog(root, options),
+        createProjectCatalog(root),
       );
       await assertStorageRootLease(lease, 'interactive', 'write');
       const recoveredExisting = writerByLease.get(lease);

--- a/packages/storage/src/project-catalog.ts
+++ b/packages/storage/src/project-catalog.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { readFile, realpath, rename, stat } from 'node:fs/promises';
+import { realpath, stat } from 'node:fs/promises';
 import { basename, dirname, join, normalize, resolve } from 'node:path';
 import { promisify } from 'node:util';
 import type { ProjectLocation, ProjectRecord, SessionHeader } from '@maka/core';
@@ -115,17 +115,13 @@ export function createProjectCatalog(
   deps: {
     now?: () => number;
     createId?: () => string;
-    /** Report a `projects.json` that could not be imported; the catalog still opens. */
-    onLegacyImportFailure?: (error: unknown) => void;
     relinkFailpoint?: (stage: 'after_session_updates') => void;
   } = {},
 ): ProjectCatalog {
   return new SqliteProjectCatalog(
     acquireOperationalStateDatabase(storageRoot),
-    join(storageRoot, 'projects.json'),
     deps.now ?? Date.now,
     deps.createId ?? randomUUID,
-    deps.onLegacyImportFailure ?? (() => {}),
     deps.relinkFailpoint,
   );
 }
@@ -143,14 +139,11 @@ export function createProjectCatalog(
  */
 class SqliteProjectCatalog implements ProjectCatalog {
   private queue: Promise<void> = Promise.resolve();
-  private legacyImport: Promise<void> | undefined;
 
   constructor(
     private readonly lease: OperationalStateDatabaseLease,
-    private readonly legacyPath: string,
     private readonly now: () => number,
     private readonly createId: () => string,
-    private readonly onLegacyImportFailure: (error: unknown) => void,
     private readonly relinkFailpoint?: (stage: 'after_session_updates') => void,
   ) {}
 
@@ -336,7 +329,6 @@ class SqliteProjectCatalog implements ProjectCatalog {
       | { readonly project: PersistedProject; readonly updatedSessionIds: readonly string[] }
       | undefined;
     await this.withQueue(async () => {
-      await this.importLegacyCatalogOnce();
       committed = this.lease.transaction('write', () => {
         const file = this.selectCatalog();
         const project = findProjectById(file.projects, projectId);
@@ -427,7 +419,6 @@ class SqliteProjectCatalog implements ProjectCatalog {
   }
 
   private async read(): Promise<ProjectCatalogFile> {
-    await this.importLegacyCatalogOnce();
     return this.selectCatalog();
   }
 
@@ -444,7 +435,6 @@ class SqliteProjectCatalog implements ProjectCatalog {
    * `relink` await the filesystem mid-change and keep the two-phase form.
    */
   private async mutate<T>(change: (file: ProjectCatalogFile) => T): Promise<T> {
-    await this.importLegacyCatalogOnce();
     return this.lease.transaction('write', () => {
       const file = this.selectCatalog();
       const result = change(file);
@@ -544,47 +534,6 @@ class SqliteProjectCatalog implements ProjectCatalog {
         for (const alias of project.aliases ?? []) insertAlias.run(alias, project.id);
       }
     });
-  }
-
-  /**
-   * `projects.json` predates the operational database and was left behind when
-   * the rest of the File stores were retired, so it still holds the only copy
-   * of every project name, relink alias and archive state. Importing it once is
-   * not legacy-format support: it recovers state this refactor would otherwise
-   * strand. The file is renamed rather than deleted so a failed upgrade stays
-   * inspectable, and a malformed file leaves SQLite untouched.
-   *
-   * An import that cannot complete — unreadable file, malformed contents, a
-   * read-only disk — is reported and then dropped rather than rethrown. SQLite
-   * is the authority now, so failing the import must not take the read path
-   * down with it; `projects.json` is still on disk to recover from by hand.
-   */
-  private importLegacyCatalogOnce(): Promise<void> {
-    this.legacyImport ??= (async () => {
-      try {
-        let raw: string;
-        try {
-          raw = await readFile(this.legacyPath, 'utf8');
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return;
-          throw error;
-        }
-        const imported = normalizeProjectCatalogFile(JSON.parse(raw));
-        const occupied = this.lease.transaction(
-          'read',
-          () =>
-            this.lease.database.prepare('SELECT 1 AS found FROM projects LIMIT 1').get() !==
-            undefined,
-        );
-        if (!occupied) this.replaceCatalog(imported);
-        // Timestamped so a second upgrade attempt cannot overwrite the only
-        // remaining copy of a catalog that failed to import the first time.
-        await rename(this.legacyPath, `${this.legacyPath}.imported-${this.now()}`);
-      } catch (error) {
-        this.onLegacyImportFailure(error);
-      }
-    })();
-    return this.legacyImport;
   }
 
   private withQueue(operation: () => Promise<void>): Promise<void> {


### PR DESCRIPTION
## Summary
- remove projects.json import from the SQLite ProjectCatalog hot path
- remove last-project-path.json migration from Desktop project selection
- seed E2E state through the current SQLite catalog and root-scoped preference authority
- remove migration callbacks and obsolete test setup

## Rationale
SQLite and root-scoped preferences are the only current authorities. The old JSON readers remained alive primarily because test fixtures still wrote the retired formats. Updating those fixtures removes the real dependency instead of hiding migration work from CI.

## Verification
- repository-wide retired filename and migration-hook scan
- Biome on changed source, fixtures, and tests
- git diff --check

Full tests and typecheck intentionally left to CI.