### PR TITLE
refactor(storage): remove runtime policy v1 reader

### DIFF
--- a/packages/core/src/runtime-policy.ts
+++ b/packages/core/src/runtime-policy.ts
@@ -24,7 +24,6 @@ export {
 } from './runtime-policy/domain-codec.js';
 export {
   decodeCanonicalRuntimePolicy,
-  decodeLegacyRuntimePolicyV1,
   normalizeRuntimePolicyMutation,
 } from './runtime-policy/policy-codec.js';
 export {

--- a/packages/core/src/runtime-policy/policy-codec.ts
+++ b/packages/core/src/runtime-policy/policy-codec.ts
@@ -25,21 +25,6 @@ export function decodeCanonicalRuntimePolicy(value: unknown): RuntimePolicy {
   return decoded;
 }
 
-export function decodeLegacyRuntimePolicyV1(value: unknown): RuntimePolicy {
-  const policy = exactRecord(value, 'legacy runtime policy', [
-    'networkProxy',
-    'personalization',
-    'memory',
-    'workspaceInstructions',
-    'privacy',
-    'chatDefaults',
-    'webSearch',
-  ]);
-  const decoded = normalizeRuntimePolicyFields(policy, { presets: [] });
-  assertCanonicalValue(value, withoutSubagents(decoded), 'legacy runtime policy');
-  return decoded;
-}
-
 export function normalizeRuntimePolicyMutation(value: unknown): MutateRuntimePolicyInput {
   const input = exactRecord(value, 'runtime policy mutation', ['expectedRevision', 'operation']);
   const operation = exactRecord(input.operation, 'runtime policy operation', ['kind', 'value']);
@@ -77,11 +62,6 @@ function normalizeRuntimePolicyFields(
     webSearch: normalizeWebSearch(policy.webSearch),
     subagents,
   };
-}
-
-function withoutSubagents(policy: RuntimePolicy): Omit<RuntimePolicy, 'subagents'> {
-  const { subagents: _subagents, ...legacy } = policy;
-  return legacy;
 }
 
 function normalizeMutationOperation(operation: Record<string, unknown>): RuntimePolicyMutation {

--- a/packages/storage/src/runtime-policy/policy-document.ts
+++ b/packages/storage/src/runtime-policy/policy-document.ts
@@ -1,7 +1,6 @@
 import {
   createDefaultRuntimePolicy,
   decodeCanonicalRuntimePolicy,
-  decodeLegacyRuntimePolicyV1,
   normalizeRuntimePolicyMutation,
   type MutateRuntimePolicyInput,
   type MutateRuntimePolicyResult,
@@ -49,17 +48,13 @@ export class RuntimePolicyDocumentOwner {
       'revision',
       'policy',
     ]);
-    if (document.schemaVersion !== 1 && document.schemaVersion !== SCHEMA_VERSION) {
+    if (document.schemaVersion !== SCHEMA_VERSION) {
       throw codecError('invalid_document', `${FILE} has an unsupported schema version`);
     }
     return {
       schemaVersion: SCHEMA_VERSION,
       revision: revision(document.revision, `${FILE}.revision`, 'invalid_document'),
-      policy: decodePersistedDomain(() =>
-        document.schemaVersion === 1
-          ? decodeLegacyRuntimePolicyV1(document.policy)
-          : decodeCanonicalRuntimePolicy(document.policy),
-      ),
+      policy: decodePersistedDomain(() => decodeCanonicalRuntimePolicy(document.policy)),
     };
   }
 


### PR DESCRIPTION
## Summary
- remove the unreferenced Runtime Policy v1 decoder
- accept only the schema v2 document emitted by the current writer
- remove the compatibility export and branch

## Rationale
No fixture, producer, or active caller depends on schema v1. Keeping an untested compatibility decoder widens persisted-state acceptance without protecting current data.

## Verification
- repository-wide legacy decoder reference scan
- Biome on changed source
- git diff --check

Full tests intentionally left to CI.