### PR TITLE
refactor: remove connection v1 compatibility

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1415,7 +1415,6 @@ export {
   reconcileConnectionAfterEnabledModelsChange,
   reconcileConnectionAfterModelFetch,
   effectiveBaseUrl,
-  migrateConnectionV1ToV2,
   normalizeConnectionBaseUrl,
   persistedBaseUrl,
   providerSupportsModelDiscovery,

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -607,53 +607,16 @@ export interface UpdateConnectionInput {
 
 export type { RequestHeaderUpdate, SavedRequestHeaders } from './request-customization.js';
 
-export function migrateConnectionV1ToV2(old: unknown): LlmConnection {
-  const value = old as Partial<LlmConnection> & {
-    backend?: string;
-    authType?: string;
-    slug?: string;
-    name?: string;
-    defaultModel?: string;
-    baseUrl?: string;
-    createdAt?: number;
-  };
-  if (value.providerType) {
-    return {
-      ...value,
-      providerType: value.providerType as ProviderType,
-      enabledModelIds: connectionEnabledModelIds(value),
-    } as LlmConnection;
+export function normalizePersistedConnection(input: unknown): LlmConnection {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Invalid connection: expected an object');
   }
-  if (!value.slug) throw new Error('Cannot migrate connection without slug');
-
-  const now = Date.now();
-  if (value.backend === 'claude' && value.authType === 'oauth_token') {
-    return {
-      slug: value.slug,
-      name: value.name ?? value.slug,
-      providerType: 'claude-subscription',
-      ...(value.baseUrl ? { baseUrl: value.baseUrl } : {}),
-      defaultModel: value.defaultModel || 'claude-sonnet-4-5-20250929',
-      enabled: false,
-      enabledModelIds: [value.defaultModel || 'claude-sonnet-4-5-20250929'],
-      createdAt: value.createdAt ?? now,
-      updatedAt: now,
-    };
+  const value = input as Partial<LlmConnection>;
+  if (typeof value.providerType !== 'string' || !value.providerType) {
+    throw new Error('Invalid connection: providerType is required');
   }
-
-  if (value.backend === 'claude' || value.backend === undefined) {
-    return {
-      slug: value.slug,
-      name: value.name ?? value.slug,
-      providerType: 'anthropic',
-      ...(value.baseUrl ? { baseUrl: value.baseUrl } : {}),
-      defaultModel: value.defaultModel || 'claude-sonnet-4-5-20250929',
-      enabled: true,
-      enabledModelIds: [value.defaultModel || 'claude-sonnet-4-5-20250929'],
-      createdAt: value.createdAt ?? now,
-      updatedAt: now,
-    };
-  }
-
-  throw new Error(`Cannot migrate connection ${value.slug} with backend=${value.backend}`);
+  return {
+    ...value,
+    enabledModelIds: connectionEnabledModelIds(value),
+  } as LlmConnection;
 }

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -1158,38 +1158,6 @@ describe('FileConnectionStore', () => {
         assert.equal(await store.getDefaultConnection(), null);
       });
     });
-
-    test('tolerates an unrelated invalid entry instead of failing the read', async () => {
-      await withConnectionStore(async (store, dir) => {
-        // A valid default plus an unrelated stale entry that cannot migrate
-        // (no providerType, no slug, unknown backend). getDefaultConnection must
-        // drop the bad entry and still resolve the valid default.
-        await writeFile(
-          join(dir, 'llm-connections.json'),
-          JSON.stringify({
-            defaultSlug: 'valid-default',
-            connections: [
-              {
-                slug: 'valid-default',
-                name: 'Valid',
-                providerType: 'anthropic',
-                defaultModel: 'claude-sonnet-4-20250514',
-                enabled: true,
-                createdAt: 1,
-                updatedAt: 1,
-              },
-              { backend: 'totally-unknown-legacy-backend' },
-            ],
-          }),
-          'utf8',
-        );
-
-        const conn = await store.getDefaultConnection();
-
-        assert.equal(conn?.slug, 'valid-default');
-        assert.equal(conn?.defaultModel, 'claude-sonnet-4-20250514');
-      });
-    });
   });
 });
 

--- a/packages/storage/src/connection-store.ts
+++ b/packages/storage/src/connection-store.ts
@@ -4,7 +4,7 @@ import { defaultEnabledModelIdsWhenOmitted } from '@maka/core';
 import {
   PROVIDER_DEFAULTS,
   connectionEnabledModelIds,
-  migrateConnectionV1ToV2,
+  normalizePersistedConnection,
   reconcileConnectionAfterEnabledModelsChange,
   persistedBaseUrl,
   reconcileConnectionAfterModelFetch,
@@ -33,13 +33,7 @@ export interface ConnectionStore {
   remove(slug: string): Promise<void>;
   getDefault(): Promise<string | null>;
   setDefault(slug: string | null): Promise<void>;
-  /**
-   * Resolve the default connection in a SINGLE read snapshot (slug + connection
-   * come from the same file read, so a concurrent write cannot tear them apart)
-   * and tolerate an unrelated invalid entry (a stale record that fails
-   * migration is skipped, not allowed to strand a valid default). Returns null
-   * when there is no default, or when the default entry itself is unusable.
-   */
+  /** Resolve the default connection from one fail-closed file snapshot. */
   getDefaultConnection(): Promise<LlmConnection | null>;
 }
 
@@ -415,7 +409,7 @@ class FileConnectionStore implements ConnectionStore {
   }
 
   async getDefaultConnection(): Promise<LlmConnection | null> {
-    const snapshot = await this.readDefaultSnapshot();
+    const snapshot = await this.read();
     if (!snapshot.defaultSlug) return null;
     return snapshot.connections.find((c) => c.slug === snapshot.defaultSlug) ?? null;
   }
@@ -428,43 +422,7 @@ class FileConnectionStore implements ConnectionStore {
     try {
       const raw = JSON.parse(await readFile(this.path, 'utf8')) as unknown;
       const parsed = normalizeConnectionsFile(raw);
-      const connections = parsed.connections.map((connection) =>
-        migrateConnectionV1ToV2(connection),
-      );
-      return {
-        defaultSlug: normalizeDefaultSlug(parsed.defaultSlug, connections),
-        connections,
-      };
-    } catch (error) {
-      if ((error as { code?: string }).code === 'ENOENT') return emptyConnectionsFile();
-      throw error;
-    }
-  }
-
-  /**
-   * Read-only snapshot for default resolution. Mirrors {@link readUnlocked}
-   * but with a deliberately different fault contract: an entry that fails
-   * {@link migrateConnectionV1ToV2} is DROPPED, not thrown. {@link readUnlocked}
-   * (used by every write path) stays fail-closed so a corrupt file never
-   * silently feeds a write; this path only answers "is there a usable
-   * default?", where an unrelated stale entry must not strand a valid default
-   * and silently switch the consumer to hardcoded fallback.
-   *
-   * The default entry itself still has to migrate cleanly: if the configured
-   * default is the broken one, there genuinely is no usable default.
-   */
-  private async readDefaultSnapshot(): Promise<ConnectionsFile> {
-    try {
-      const raw = JSON.parse(await readFile(this.path, 'utf8')) as unknown;
-      const parsed = normalizeConnectionsFile(raw);
-      const connections: LlmConnection[] = [];
-      for (const entry of parsed.connections) {
-        try {
-          connections.push(migrateConnectionV1ToV2(entry));
-        } catch {
-          // Skip an un-migratable entry rather than failing the whole read.
-        }
-      }
+      const connections = parsed.connections.map(normalizePersistedConnection);
       return {
         defaultSlug: normalizeDefaultSlug(parsed.defaultSlug, connections),
         connections,


### PR DESCRIPTION
## Summary
- replace the V1 `backend/authType` migrator with one current-format connection normalizer
- remove the second default-connection reader that silently skipped invalid legacy entries
- make every connection-file read share the same fail-closed semantics
- remove the compatibility-only test and obsolete root export

## Validation
- Biome on changed Core and Storage files
- Core TypeScript compile with the existing workspace compiler
- stale-reference search
- git diff --check
- no test suite run, per cleanup policy