### PR TITLE
test(runtime): dedupe cross-layer policy cases

### DIFF
--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -717,46 +717,7 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     assert.equal(fixture.recorded.length, 1);
   });
 
-  test('fails open under the window when the summarizer fails, with a diagnostic', async () => {
-    const fixture = buildFixture({ summarize: () => undefined });
-    await runFixtureTurn(fixture, consumer);
 
-    // The turn still completes; the third request keeps the raw span.
-    assert.equal(fixture.model.doStreamCalls.length, 3);
-    const complete = fixture.events.find((event) => event.type === 'complete');
-    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
-    assert.equal(fixture.recorded.length, 0);
-    const thirdPrompt = promptJson(fixture, 2);
-    assert.equal(thirdPrompt.includes('RAW_SPAN_ONE_'), true);
-    assert.equal(thirdPrompt.includes('maka_history_compact_checkpoint'), false);
-
-    const failedOpen = compactionDecisions(fixture).find(
-      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
-    );
-    assert.equal(failedOpen?.failOpenReason, 'summarizer_failed');
-    // The recorder was never reached, so the diagnostics claim no write.
-    const usageEvent = fixture.events.find((event) => event.type === 'token_usage') as
-      | { contextBudget?: ContextBudgetDiagnostic }
-      | undefined;
-    assert.equal(usageEvent?.contextBudget?.historyCompactWritesAttempted, undefined);
-    assert.equal(usageEvent?.contextBudget?.historyCompactWriteFailures, undefined);
-  });
-
-  test('preserves the typed summarizer failure in mid-turn diagnostics', async () => {
-    const fixture = buildFixture({
-      summarize: () => {
-        throw new HistoryCompactSummarizerError('provider_error');
-      },
-    });
-    await runFixtureTurn(fixture, consumer);
-
-    assert.equal(fixture.recorded.length, 0);
-    const failedOpen = compactionDecisions(fixture).find(
-      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
-    );
-    assert.equal(failedOpen?.failOpenReason, 'provider_error');
-    assert.equal(failedOpen?.skippedReasonCounts?.provider_error, 1);
-  });
 
   test('fails open with write_failed diagnostics when the checkpoint write fails under the window', async () => {
     const fixture = buildFixture({

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -445,23 +445,6 @@ describe('getAIModel: models.dev registry providers', () => {
     }
   });
 
-  test('routes only xAI Grok 4.5 through Responses', () => {
-    for (const providerType of ['xai', 'xai-oauth'] as const) {
-      const responses = getAIModel({
-        connection: conn(providerType),
-        apiKey: 'xai-test-key',
-        modelId: 'grok-4.5',
-      });
-      const chat = getAIModel({
-        connection: conn(providerType),
-        apiKey: 'xai-test-key',
-        modelId: 'grok-4.3',
-      });
-
-      assert.equal(responses.provider, 'openai.responses');
-      assert.equal(chat.provider, `${providerType}.chat`);
-    }
-  });
 
   test('routes each exact GitHub Copilot model through its account-advertised wire', () => {
     for (const [modelId, apiProtocol, expectedProvider] of [


### PR DESCRIPTION
## Summary

- remove two backend summarizer-failure cases owned by the focused mid-turn compact suite
- remove a runtime xAI routing matrix already owned by the core protocol policy suite
- keep backend continuation/outcome integration and the core routing authority
- remove 56 lines and three duplicate cases

## Validation

- semantic inventory: exactly three intended titles removed
- strict line-subsequence audit: retained code is unchanged
- `npx biome check` on both changed files
- `git diff --check`

Full test suites were intentionally left to CI.