### PR TITLE
test(ui): trim facade projection cases

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -321,23 +321,6 @@ test('treats empty configuration patches as read-only lookups', async () => {
   ]);
 });
 
-test('reads the bounded Host execution boundary summary', async () => {
-  const { client, requests } = clientWithResponses([
-    { kind: 'managed', access: 'read_only', revision: 4 },
-  ]);
-
-  assert.deepEqual(await client.readExecutionBoundary('session-1'), {
-    kind: 'managed',
-    access: 'read_only',
-    revision: 4,
-  });
-  assert.deepEqual(requests, [
-    {
-      operation: 'session.execution_boundary.query',
-      input: { sessionId: 'session-1' },
-    },
-  ]);
-});
 
 test('binds message controls to the current Host Epoch', async () => {
   const { client, requests } = clientWithResponses([

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -77,42 +77,6 @@ describe("materializeChat attachments", () => {
     ]);
   });
 
-  test("projects frozen inline references onto chat and turn user messages", () => {
-    const inlineReferences = [
-      {
-        kind: "skill" as const,
-        value: "/skill:writer",
-        label: "Writer",
-        start: 4,
-      },
-      {
-        kind: "workspace_file" as const,
-        value: "@docs/my plan.md",
-        label: "my plan.md",
-        start: 21,
-      },
-    ];
-    const messages: StoredMessage[] = [
-      {
-        type: "user",
-        id: "m1",
-        turnId: "t1",
-        ts: 1,
-        text: "model envelope",
-        displayText: "Use /skill:writer on @docs/my plan.md",
-        inlineReferences,
-      },
-    ];
-
-    assert.deepEqual(
-      materializeChat(messages)[0]?.inlineReferences,
-      inlineReferences,
-    );
-    assert.deepEqual(
-      materializeTurns(messages)[0]?.user?.inlineReferences,
-      inlineReferences,
-    );
-  });
 
   test("preserves an explicit empty reference projection as the new-format marker", () => {
     const messages: StoredMessage[] = [
@@ -129,21 +93,6 @@ describe("materializeChat attachments", () => {
     assert.deepEqual(materializeTurns(messages)[0]?.user?.inlineReferences, []);
   });
 
-  test("projects user message attachments onto the chat item", () => {
-    const messages: StoredMessage[] = [
-      {
-        type: "user",
-        id: "m1",
-        turnId: "t1",
-        ts: 1,
-        text: "see this",
-        attachments: [imageAttachment, codeAttachment],
-      },
-    ];
-    const items = materializeChat(messages);
-    assert.equal(items.length, 1);
-    assert.deepEqual(items[0].attachments, [imageAttachment, codeAttachment]);
-  });
 
 
   test("preserves Host provenance on a Goal continuation", () => {
@@ -168,24 +117,6 @@ describe("materializeChat attachments", () => {
     });
   });
 
-  test("surfaces automatic context compaction system notes inline", () => {
-    const messages: StoredMessage[] = [
-      {
-        type: "system_note",
-        id: "note-1",
-        turnId: "t1",
-        ts: 1,
-        kind: "context_compacted",
-      },
-    ];
-    const items = materializeChat(messages);
-    assert.equal(items.length, 1);
-    assert.equal(items[0].role, "system");
-    assert.equal(
-      items[0].text,
-      "Context compacted to keep this session within the model window.",
-    );
-  });
 
 
 });


### PR DESCRIPTION
## Summary

- remove three UI materialization cases that only mirror field/presentation projection
- remove one Desktop Host client request/response passthrough test
- retain empty-marker, Host provenance, steering dedupe, race, failure, and persistence handoff coverage
- remove 86 lines without modifying retained tests

## Validation

- semantic inventory: exactly four intended titles removed
- strict line-subsequence audit: retained code unchanged
- `npx biome check` on both changed files
- `git diff --check`

Full test suites were intentionally left to CI.