### PR TITLE
test(desktop): remove checker and formatter cases

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-preview-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-preview-registry.test.ts
@@ -8,7 +8,6 @@ import {
   decideImagePostLoad,
   decideImageReadOutcome,
   exceedsImagePayloadCap,
-  formatPreviewSize,
   normalizeAllowedImageMime,
   resolvePreviewKind,
 } from '@maka/ui/artifact-preview-registry';
@@ -73,19 +72,6 @@ describe('artifact preview registry', () => {
     }
   });
 
-  it('formats representative sizes and invalid metadata', () => {
-    const cases: Array<[number | undefined, string]> = [
-      [0, '0 B'],
-      [1023, '1023 B'],
-      [1024, '1.0 KB'],
-      [IMAGE_PAYLOAD_MAX_BYTES, '2.0 MB'],
-      [undefined, '未知大小'],
-      [-1, '未知大小'],
-      [NaN, '未知大小'],
-      [Infinity, '未知大小'],
-    ];
-    for (const [size, expected] of cases) assert.equal(formatPreviewSize(size), expected);
-  });
 
   it('normalizes only allowlisted image MIME values', () => {
     for (const mimeType of ALLOWED_IMAGE_MIMES) {

--- a/apps/desktop/src/main/__tests__/browser-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-tools.test.ts
@@ -1,5 +1,5 @@
 /**
- * The six browser tools: ref normalization, takeover note, browser_wait
+ * Browser tools: ref normalization, takeover note, browser_wait
  * argument validation, and each tool's output formatting driven end-to-end
  * through a fake view Host + fake CDP page (no Electron, no live browser).
  */
@@ -13,7 +13,6 @@ import {
   buildBrowserExtractTool,
   buildBrowserNavigateTool,
   buildBrowserSnapshotTool,
-  buildBrowserTools,
   buildBrowserTypeTool,
   buildBrowserWaitTool,
   normalizeElementRef,
@@ -118,14 +117,6 @@ describe('browser tool helpers', () => {
     assert.match(takeoverNote({ takeoverReloaded: true }), /reloaded once/);
   });
 
-  it('buildBrowserTools returns the six tools, all in the browser category', () => {
-    const tools = buildBrowserTools();
-    assert.deepEqual(
-      tools.map((t) => t.name),
-      ['browser_navigate', 'browser_snapshot', 'browser_click', 'browser_type', 'browser_wait', 'browser_extract'],
-    );
-    assert.ok(tools.every((t) => t.categoryHint === 'browser'));
-  });
 });
 
 describe('browser tool execution', () => {

--- a/apps/desktop/src/main/__tests__/session-event-health.test.ts
+++ b/apps/desktop/src/main/__tests__/session-event-health.test.ts
@@ -9,14 +9,6 @@ import {
 } from '../../renderer/session-event-health.js';
 
 describe('renderer session event health projection', () => {
-  it('creates a connected subscription snapshot', () => {
-    assert.deepEqual(createSessionEventStreamSubscription({ sessionId: 's1', now: 1_000 }), {
-      sessionId: 's1',
-      status: 'connected',
-      subscribedAt: 1_000,
-      checkedAt: 1_000,
-    });
-  });
 
   it('marks stale running sessions and asks for one throttled refresh', () => {
     const previous = createSessionEventStreamSubscription({ sessionId: 's1', now: 1_000 });


### PR DESCRIPTION
## Summary

- remove a byte-size formatter matrix
- remove a browser tool catalog self-check
- remove a constructor object-literal snapshot
- retain MIME/URL security, browser execution failures, stale detection, refresh throttling, and recovery coverage

## Validation

- semantic inventory: exactly three intended titles removed
- unused test-only imports and stale comment cleaned up
- `npx biome check` on all changed files
- `git diff --check`

Full test suites were intentionally left to CI.