### PR TITLE
test(runtime-host): remove protocol registry self-tests

### DIFF
--- a/packages/runtime-host/src/__tests__/agent-graph-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-protocol.test.ts
@@ -19,18 +19,6 @@ import {
 const fingerprint = `sha256:${'a'.repeat(64)}` as const;
 
 describe('Agent Graph Client protocol', () => {
-  test('declares bounded ready query, inspection, and stop operations', () => {
-    assert.equal(AGENT_GRAPH_OPERATION_SPECS['agent.graph.query'].mode, 'query');
-    assert.equal(AGENT_GRAPH_OPERATION_SPECS['agent.graph.operator.query'].mode, 'query');
-    assert.equal(AGENT_GRAPH_OPERATION_SPECS['agent.graph.stop'].mode, 'control');
-    for (const spec of Object.values(AGENT_GRAPH_OPERATION_SPECS)) {
-      assert.equal(spec.availability, 'ready');
-      assert.ok(spec.errors.includes('not_found'));
-      assert.ok(spec.errors.includes('operation_conflict'));
-      assert.ok(spec.errors.includes('internal_failure'));
-    }
-  });
-
   test('round-trips canonical inputs and bounded projections', () => {
     assert.deepEqual(decodeAgentGraphQueryInput({ rootSessionId: 'root-1' }), {
       rootSessionId: 'root-1',

--- a/packages/runtime-host/src/__tests__/artifact-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/artifact-protocol.test.ts
@@ -14,7 +14,6 @@ import {
   decodeHostFrame,
   encodeArtifactQueryResult,
   encodeProtocolMessage,
-  HOST_OPERATION_SPECS,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
   RuntimeHostProtocolError,
 } from '../protocol/index.js';
@@ -23,20 +22,7 @@ import { encodeArtifactProjection } from '../protocol/artifact.js';
 const revision = `sha256:${'a'.repeat(64)}` as const;
 
 describe('Artifact protocol', () => {
-  test('registers the closed ready ingest, query, and delete operations', () => {
-    assert.deepEqual(metadata('artifact.ingest'), {
-      mode: 'command',
-      availability: 'ready',
-    });
-    assert.deepEqual(metadata('artifact.query'), {
-      mode: 'query',
-      availability: 'ready',
-    });
-    assert.deepEqual(metadata('artifact.delete'), {
-      mode: 'command',
-      availability: 'ready',
-    });
-
+  test('accepts closed Artifact operations and rejects open shapes', () => {
     for (const input of [
       { kind: 'list_start', sessionId: 'session-1' },
       { kind: 'list_continue', sessionId: 'session-1', revision, cursor: '128' },
@@ -412,11 +398,6 @@ function validArtifact() {
     summary: 'bounded',
     status: 'live' as const,
   };
-}
-
-function metadata(key: 'artifact.ingest' | 'artifact.query' | 'artifact.delete') {
-  const { mode, availability } = HOST_OPERATION_SPECS[key];
-  return { mode, availability };
 }
 
 function request(

--- a/packages/runtime-host/src/__tests__/connection-effects-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-effects-protocol.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
-  CONNECTION_EFFECT_OPERATION_SPECS,
   decodeClientFrame,
   decodeHostFrame,
 } from '../protocol/index.js';
@@ -13,39 +12,6 @@ const EXPECTED = {
 };
 
 describe('Runtime Host connection effects protocol', () => {
-  test('declares ready commands with bounded mutation errors', () => {
-    assert.deepEqual(Object.keys(CONNECTION_EFFECT_OPERATION_SPECS).sort(), [
-      'connection.models.fetch',
-      'connection.onboarding.save',
-      'connection.onboarding.verify',
-      'connection.test.run',
-    ]);
-    for (const operation of Object.keys(CONNECTION_EFFECT_OPERATION_SPECS) as Array<
-      keyof typeof CONNECTION_EFFECT_OPERATION_SPECS
-    >) {
-      assert.deepEqual(
-        {
-          mode: CONNECTION_EFFECT_OPERATION_SPECS[operation].mode,
-          availability: CONNECTION_EFFECT_OPERATION_SPECS[operation].availability,
-          errors: CONNECTION_EFFECT_OPERATION_SPECS[operation].errors,
-        },
-        {
-          mode: 'command',
-          availability: 'ready',
-          errors: [
-            'host_not_ready',
-            'host_draining',
-            'operation_unavailable',
-            'invalid_request',
-            'internal_failure',
-            'persistence_failed',
-            'commit_outcome_unknown',
-          ],
-        },
-      );
-    }
-  });
-
   test('bounds transient onboarding secrets, models, and save selections', () => {
     const verify = request('connection.onboarding.verify', {
       providerType: 'openrouter',

--- a/packages/runtime-host/src/__tests__/daily-review-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/daily-review-protocol.test.ts
@@ -6,40 +6,7 @@ import {
   decodeDailyReviewMutateInput,
   decodeDailyReviewQueryResult,
   decodeRequestFrame,
-  decodeResponseFrame,
-  HOST_OPERATION_SPECS,
 } from '../protocol/index.js';
-
-test('Daily Review protocol exposes closed query and command operations', () => {
-  assert.equal(HOST_OPERATION_SPECS['daily-review.query'].mode, 'query');
-  assert.equal(HOST_OPERATION_SPECS['daily-review.mutate'].mode, 'command');
-  assert.deepEqual(
-    decodeRequestFrame({
-      requestId: 'request-1',
-      operation: 'daily-review.query',
-      input: { kind: 'summary', daySpan: 14, offsetDays: -1 },
-    }),
-    {
-      requestId: 'request-1',
-      operation: 'daily-review.query',
-      input: { kind: 'summary', daySpan: 14, offsetDays: -1 },
-    },
-  );
-  assert.deepEqual(
-    decodeResponseFrame({
-      requestId: 'request-2',
-      operation: 'daily-review.mutate',
-      ok: true,
-      result: { kind: 'archive', archive: archive() },
-    }),
-    {
-      requestId: 'request-2',
-      operation: 'daily-review.mutate',
-      ok: true,
-      result: { kind: 'archive', archive: archive() },
-    },
-  );
-});
 
 test('Daily Review protocol rejects open and unbounded inputs', () => {
   assert.throws(() =>

--- a/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
@@ -10,29 +10,7 @@ import {
 } from '../protocol/index.js';
 
 describe('external Session protocol', () => {
-  test('declares three bounded ready-only operations', () => {
-    assert.deepEqual(
-      Object.fromEntries(
-        (
-          [
-            'external-session.source.query',
-            'external-session.catalog.query',
-            'external-session.import',
-          ] as const
-        ).map((operation) => [
-          operation,
-          {
-            mode: HOST_OPERATION_SPECS[operation].mode,
-            availability: HOST_OPERATION_SPECS[operation].availability,
-          },
-        ]),
-      ),
-      {
-        'external-session.source.query': { mode: 'query', availability: 'ready' },
-        'external-session.catalog.query': { mode: 'query', availability: 'ready' },
-        'external-session.import': { mode: 'command', availability: 'ready' },
-      },
-    );
+  test('identifies external Session queries that expose Host paths', () => {
     assert.equal(
       HOST_OPERATION_SPECS['external-session.catalog.query'].usesHostPaths?.({
         adapterId: 'codex',

--- a/packages/runtime-host/src/__tests__/memory-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/memory-protocol.test.ts
@@ -4,7 +4,6 @@ import {
   decodeClientFrame,
   decodeHostFrame,
   encodeProtocolMessage,
-  HOST_OPERATION_SPECS,
   MEMORY_DOCUMENT_CHUNK_MAX_BYTES,
   MEMORY_ENTRY_PAGE_MAX_ITEMS,
   MEMORY_RESULT_MAX_BYTES,
@@ -15,10 +14,7 @@ import {
 const revision = `sha256:${'a'.repeat(64)}` as const;
 
 describe('Memory protocol', () => {
-  test('registers only the closed query and mutation operations', () => {
-    assert.deepEqual(metadata('memory.query'), { mode: 'query', availability: 'ready' });
-    assert.deepEqual(metadata('memory.mutate'), { mode: 'command', availability: 'ready' });
-
+  test('accepts closed Memory operations and rejects open shapes', () => {
     assert.doesNotThrow(() =>
       request('memory.query', {
         kind: 'document_continue',
@@ -171,11 +167,6 @@ describe('Memory protocol', () => {
     assert.throws(() => failure('memory.query', 'commit_outcome_unknown'), isInvalidFrame);
   });
 });
-
-function metadata(operation: 'memory.query' | 'memory.mutate') {
-  const { mode, availability } = HOST_OPERATION_SPECS[operation];
-  return { mode, availability };
-}
 
 function request(operation: 'memory.query' | 'memory.mutate', input: unknown): void {
   decodeClientFrame({ requestId: 'request', operation, input });

--- a/packages/runtime-host/src/__tests__/plan-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/plan-protocol.test.ts
@@ -20,10 +20,7 @@ const proposal = {
   submittedAt: 1,
 };
 
-test('Plan protocol declares bounded snapshot queries and stable controls', () => {
-  assert.equal(HOST_OPERATION_SPECS['plan.query'].mode, 'query');
-  assert.equal(HOST_OPERATION_SPECS['plan.control'].mode, 'control');
-  assert.equal(HOST_OPERATION_SPECS['plan.turn.start'].mode, 'command');
+test('Plan controls preserve request and result correlation', () => {
   assert.deepEqual(
     decodeRequestFrame({
       requestId: 'request-1',

--- a/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
@@ -14,22 +14,7 @@ const foreignHostPath = process.platform === 'win32' ? '/workspace' : 'C:\\works
 const revision = `sha256:${'a'.repeat(64)}` as const;
 
 describe('Project catalog protocol', () => {
-  test('declares bounded ready operations and exact invalidations', () => {
-    assert.deepEqual(
-      Object.fromEntries(
-        (['project.catalog.query', 'project.catalog.mutate'] as const).map((operation) => [
-          operation,
-          {
-            mode: HOST_OPERATION_SPECS[operation].mode,
-            availability: HOST_OPERATION_SPECS[operation].availability,
-          },
-        ]),
-      ),
-      {
-        'project.catalog.query': { mode: 'query', availability: 'ready' },
-        'project.catalog.mutate': { mode: 'command', availability: 'ready' },
-      },
-    );
+  test('decodes exact invalidations', () => {
     const frame = { kind: 'project.catalog.changed' as const, revision: 1 };
     assert.deepEqual(decodeHostFrame(frame), frame);
     assert.throws(() => decodeHostFrame({ ...frame, extra: true }), isProtocolError);

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -46,45 +46,8 @@ describe('Runtime Host bootstrap protocol', () => {
     assert.throws(() => negotiateProtocol({ min: -1, max: 0 }, { min: 0, max: 0 }), isInvalidFrame);
   });
 
-  test('keeps subscription operations closed, ready-only, and queue Epoch correlated', () => {
+  test('keeps the subscription queue Epoch correlated', () => {
     assert.equal(SESSION_CONTINUITY_SCHEMA_VERSION, 3);
-    assert.deepEqual(
-      Object.fromEntries(
-        (['subscription.open', 'subscription.close'] as const).map((operation) => [
-          operation,
-          {
-            mode: HOST_OPERATION_SPECS[operation].mode,
-            availability: HOST_OPERATION_SPECS[operation].availability,
-            errors: HOST_OPERATION_SPECS[operation].errors,
-          },
-        ]),
-      ),
-      {
-        'subscription.open': {
-          mode: 'control',
-          availability: 'ready',
-          errors: [
-            'host_not_ready',
-            'host_draining',
-            'operation_unavailable',
-            'not_found',
-            'operation_conflict',
-            'internal_failure',
-          ],
-        },
-        'subscription.close': {
-          mode: 'control',
-          availability: 'ready',
-          errors: [
-            'host_not_ready',
-            'host_draining',
-            'operation_unavailable',
-            'not_found',
-            'internal_failure',
-          ],
-        },
-      },
-    );
     const opened = {
       requestId: 'open-1',
       operation: 'subscription.open',

--- a/packages/runtime-host/src/__tests__/runtime-resource-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-protocol.test.ts
@@ -23,7 +23,6 @@ import {
   RUNTIME_RESOURCE_CONTROL_INPUT_MAX_BYTES,
   RUNTIME_RESOURCE_MAX_CONTROL_SEQUENCE,
   RUNTIME_RESOURCE_CURSOR_MAX_BYTES,
-  RUNTIME_RESOURCE_OPERATION_SPECS,
   RUNTIME_RESOURCE_PAGE_MAX_ITEMS,
   RUNTIME_RESOURCE_RESULT_MAX_BYTES,
 } from '../protocol/runtime-resource.js';
@@ -34,15 +33,6 @@ const runtimeRef = 'maka://runtime/background-tasks/shell-1';
 type PipeShellSnapshot = Extract<ShellRunSnapshotResult, { mode: 'pipes' }>;
 
 describe('Runtime Resource protocol', () => {
-  test('declares the complete ready operation surface', () => {
-    assert.equal(RUNTIME_RESOURCE_OPERATION_SPECS['runtime.resource.query'].mode, 'query');
-    for (const [key, spec] of Object.entries(RUNTIME_RESOURCE_OPERATION_SPECS)) {
-      assert.equal(spec.availability, 'ready', key);
-      if (key === 'runtime.resource.start') assert.equal(spec.mode, 'command', key);
-      else if (key !== 'runtime.resource.query') assert.equal(spec.mode, 'control', key);
-    }
-  });
-
   test('round-trips every query, controller, and stop branch', () => {
     const update = resourceUpdate();
     const unavailable = resourceUpdate({

--- a/packages/runtime-host/src/__tests__/scheduled-task-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/scheduled-task-protocol.test.ts
@@ -3,30 +3,11 @@ import { describe, test } from 'node:test';
 import type { ScheduledTask } from '@maka/core/scheduled-task';
 import {
   decodeScheduledTaskQueryResult,
-  decodeClientFrame,
   decodeHostFrame,
   SCHEDULED_TASK_PAGE_MAX_ITEMS,
-  SCHEDULED_TASK_OPERATION_SPECS,
 } from '../protocol/index.js';
 
 describe('ScheduledTask protocol', () => {
-  test('declares one bounded query and mutation surface', () => {
-    assert.equal(SCHEDULED_TASK_OPERATION_SPECS['scheduled-task.query'].mode, 'query');
-    assert.equal(SCHEDULED_TASK_OPERATION_SPECS['scheduled-task.mutate'].mode, 'command');
-    assert.deepEqual(
-      decodeClientFrame({
-        requestId: 'list-1',
-        operation: 'scheduled-task.query',
-        input: { kind: 'list', cursor: '2', expectedRevision: 4 },
-      }),
-      {
-        requestId: 'list-1',
-        operation: 'scheduled-task.query',
-        input: { kind: 'list', cursor: '2', expectedRevision: 4 },
-      },
-    );
-  });
-
   test('accepts signal-only catalog changes', () => {
     const frame = {
       kind: 'scheduled-task.changed' as const,

--- a/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
@@ -12,37 +12,7 @@ import {
 } from '../protocol/index.js';
 
 describe('Session catalog protocol', () => {
-  test('declares closed ready-only query and mutation operations', () => {
-    assert.deepEqual(
-      Object.fromEntries(
-        (
-          [
-            'session.catalog.query',
-            'session.create',
-            'session.metadata.update',
-            'session.configuration.update',
-            'session.workspace.relocate',
-            'session.read_marker.set',
-            'session.execution_boundary.query',
-          ] as const
-        ).map((operation) => [
-          operation,
-          {
-            mode: HOST_OPERATION_SPECS[operation].mode,
-            availability: HOST_OPERATION_SPECS[operation].availability,
-          },
-        ]),
-      ),
-      {
-        'session.catalog.query': { mode: 'query', availability: 'ready' },
-        'session.create': { mode: 'command', availability: 'ready' },
-        'session.metadata.update': { mode: 'command', availability: 'ready' },
-        'session.configuration.update': { mode: 'command', availability: 'ready' },
-        'session.workspace.relocate': { mode: 'command', availability: 'ready' },
-        'session.read_marker.set': { mode: 'command', availability: 'ready' },
-        'session.execution_boundary.query': { mode: 'query', availability: 'ready' },
-      },
-    );
+  test('identifies Session creation inputs that expose Host paths', () => {
     assert.equal(
       HOST_OPERATION_SPECS['session.create'].usesHostPaths?.({
         sessionId: 'project-session',

--- a/packages/runtime-host/src/__tests__/session-retirement-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-retirement-protocol.test.ts
@@ -9,38 +9,6 @@ import {
 } from '../protocol/index.js';
 
 describe('Session retirement protocol', () => {
-  test('declares exact ready-only lifecycle and remove commands', () => {
-    assert.equal(HOST_OPERATION_SPECS['session.lifecycle.set'].mode, 'command');
-    assert.equal(HOST_OPERATION_SPECS['session.lifecycle.set'].availability, 'ready');
-    assert.equal(HOST_OPERATION_SPECS['session.remove'].mode, 'command');
-    assert.equal(HOST_OPERATION_SPECS['session.remove'].availability, 'ready');
-
-    assert.deepEqual(
-      decodeClientFrame({
-        requestId: 'request-archive',
-        operation: 'session.lifecycle.set',
-        input: { sessionId: 'session-1', state: 'archived' },
-      }),
-      {
-        requestId: 'request-archive',
-        operation: 'session.lifecycle.set',
-        input: { sessionId: 'session-1', state: 'archived' },
-      },
-    );
-    assert.deepEqual(
-      decodeClientFrame({
-        requestId: 'request-remove',
-        operation: 'session.remove',
-        input: { sessionId: 'session-1', expectedRevision: 3 },
-      }),
-      {
-        requestId: 'request-remove',
-        operation: 'session.remove',
-        input: { sessionId: 'session-1', expectedRevision: 3 },
-      },
-    );
-  });
-
   test('rejects open shapes, invalid states, and mismatched result identities', () => {
     assert.throws(
       () =>

--- a/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
@@ -9,35 +9,6 @@ import {
 } from '../protocol/index.js';
 
 describe('Session revision protocol', () => {
-  test('declares exact ready-only branch and revision commands', () => {
-    for (const operation of ['session.branch.create', 'session.revision.create'] as const) {
-      assert.equal(HOST_OPERATION_SPECS[operation].mode, 'command');
-      assert.equal(HOST_OPERATION_SPECS[operation].availability, 'ready');
-      assert.deepEqual(
-        decodeClientFrame({
-          requestId: 'request-1',
-          operation,
-          input: {
-            sourceSessionId: 'source-session',
-            targetSessionId: 'target-session',
-            sourceTurnId: 'turn-1',
-            expectedSourceRevision: 3,
-          },
-        }),
-        {
-          requestId: 'request-1',
-          operation,
-          input: {
-            sourceSessionId: 'source-session',
-            targetSessionId: 'target-session',
-            sourceTurnId: 'turn-1',
-            expectedSourceRevision: 3,
-          },
-        },
-      );
-    }
-  });
-
   test('rejects aliasing, unknown fields, and mismatched response identities', () => {
     assert.throws(
       () =>

--- a/packages/runtime-host/src/__tests__/skill-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-protocol.test.ts
@@ -64,57 +64,7 @@ export type SkillCatalogManagedUpdateMutationTypeContract = [
 ];
 
 describe('Runtime Host Skill catalog protocol', () => {
-  test('declares the four frozen ready operations and their error sets', () => {
-    assert.deepEqual(Object.keys(SKILL_CATALOG_OPERATION_SPECS).sort(), [
-      'skill.catalog.invocable.query',
-      'skill.catalog.mutate',
-      'skill.catalog.preview-update',
-      'skill.catalog.query',
-    ]);
-    const queryErrors = [
-      'host_not_ready',
-      'host_draining',
-      'operation_unavailable',
-      'invalid_request',
-      'persistence_failed',
-      'internal_failure',
-    ];
-    assert.deepEqual(
-      {
-        mode: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.invocable.query'].mode,
-        availability: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.invocable.query'].availability,
-        errors: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.invocable.query'].errors,
-      },
-      { mode: 'query', availability: 'ready', errors: queryErrors },
-    );
-    assert.deepEqual(
-      {
-        mode: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.query'].mode,
-        availability: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.query'].availability,
-        errors: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.query'].errors,
-      },
-      { mode: 'query', availability: 'ready', errors: queryErrors },
-    );
-    assert.deepEqual(
-      {
-        mode: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.preview-update'].mode,
-        availability: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.preview-update'].availability,
-        errors: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.preview-update'].errors,
-      },
-      { mode: 'query', availability: 'ready', errors: queryErrors },
-    );
-    assert.deepEqual(
-      {
-        mode: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.mutate'].mode,
-        availability: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.mutate'].availability,
-        errors: SKILL_CATALOG_OPERATION_SPECS['skill.catalog.mutate'].errors,
-      },
-      {
-        mode: 'command',
-        availability: 'ready',
-        errors: [...queryErrors, 'commit_outcome_unknown'],
-      },
-    );
+  test('identifies Skill catalog queries that expose Host paths', () => {
     assert.equal(
       SKILL_CATALOG_OPERATION_SPECS['skill.catalog.query'].usesHostPaths?.({
         kind: 'start',

--- a/packages/runtime-host/src/__tests__/task-ledger-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/task-ledger-protocol.test.ts
@@ -8,7 +8,6 @@ import {
   encodeTaskLedgerTask,
   encodeTaskLedgerQueryResult,
   TASK_LEDGER_CURSOR_MAX_BYTES,
-  TASK_LEDGER_OPERATION_SPECS,
   TASK_LEDGER_PAGE_MAX_BYTES,
   TASK_LEDGER_PAGE_MAX_ITEMS,
   type TaskLedgerQueryResult,
@@ -18,19 +17,7 @@ const revision = `sha256:${'a'.repeat(64)}` as const;
 const nextRevision = `sha256:${'b'.repeat(64)}` as const;
 
 describe('Task Ledger protocol', () => {
-  test('declares the closed ready query and decodes all input branches', () => {
-    const spec = TASK_LEDGER_OPERATION_SPECS['task.ledger.query'];
-    assert.equal(spec.mode, 'query');
-    assert.equal(spec.availability, 'ready');
-    assert.deepEqual(spec.errors, [
-      'host_not_ready',
-      'host_draining',
-      'operation_unavailable',
-      'invalid_request',
-      'not_found',
-      'internal_failure',
-    ]);
-
+  test('decodes all closed query input branches', () => {
     for (const input of [
       { kind: 'list_start', sessionId: 'session-1' },
       { kind: 'list_continue', sessionId: 'session-1', revision, cursor: 'opaque:2' },

--- a/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
@@ -20,7 +20,6 @@ import {
   decodeUsageQueryInput,
   encodePricingQueryResult,
   encodeProtocolMessage,
-  HOST_OPERATION_SPECS,
   PRICING_PAGE_MAX_BYTES,
   PRICING_PAGE_MAX_ITEMS,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
@@ -45,23 +44,6 @@ const CONNECTION_CONTEXT: ConnectionContext = {
 };
 
 describe('Usage/Pricing protocol', () => {
-  test('registers only the closed ready operations with current Kernel metadata', () => {
-    assert.deepEqual(operationMetadata('usage.query'), {
-      mode: 'query',
-      availability: 'ready',
-    });
-    assert.deepEqual(operationMetadata('pricing.query'), {
-      mode: 'query',
-      availability: 'ready',
-    });
-    assert.deepEqual(operationMetadata('pricing.mutate'), {
-      mode: 'command',
-      availability: 'ready',
-    });
-    const mutationErrors = HOST_OPERATION_SPECS['pricing.mutate'].errors;
-    assert.equal(new Set(mutationErrors).size, mutationErrors.length);
-  });
-
   test('decodes exact bounded usage queries', () => {
     assert.deepEqual(
       decodeUsageQueryInput({
@@ -597,11 +579,6 @@ describe('Usage/Pricing protocol', () => {
     );
   });
 });
-
-function operationMetadata(key: 'usage.query' | 'pricing.query' | 'pricing.mutate') {
-  const { mode, availability } = HOST_OPERATION_SPECS[key];
-  return { mode, availability };
-}
 
 function validProvenance() {
   return {


### PR DESCRIPTION
## Summary
- remove domain-level tests that mirror operation registry metadata
- retain domain-owned wire, bounds, path-exposure, and identity contracts
- keep the central closed-registry boundary test as the single owner

## Validation
- `npx biome check` on all changed TypeScript files
- `git diff --check`
- test-title inventory: 8 tests removed
- no full test run (CI owns execution)