### PR TITLE
test(runtime-host): remove exhaustive protocol happy matrices

### DIFF
--- a/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
@@ -20,38 +20,7 @@ describe('Project catalog protocol', () => {
     assert.throws(() => decodeHostFrame({ ...frame, extra: true }), isProtocolError);
   });
 
-  test('round-trips every closed mutation shape and correlates its result', () => {
-    for (const input of [
-      { kind: 'register', path: projectPath },
-      { kind: 'relink', projectId: 'project-1', path: projectPath },
-      { kind: 'rename', projectId: 'project-1', name: 'Project' },
-      { kind: 'archive', projectId: 'project-1' },
-      { kind: 'restore', projectId: 'project-1' },
-    ] as const) {
-      const request = {
-        requestId: `request-${input.kind}`,
-        operation: 'project.catalog.mutate' as const,
-        input,
-      };
-      assert.deepEqual(decodeClientFrame(request), request);
-    }
-    const mutation = {
-      requestId: 'request-register',
-      operation: 'project.catalog.mutate' as const,
-      ok: true as const,
-      result: {
-        kind: 'project' as const,
-        project: {
-          id: 'project-1',
-          aliases: [],
-          name: 'Project',
-          locationCount: 1,
-          archivedAt: null,
-          available: true,
-        },
-      },
-    };
-    assert.deepEqual(decodeHostFrame(mutation), mutation);
+  test('identifies Project catalog operations that expose Host paths', () => {
     const location = {
       requestId: 'request-location',
       operation: 'project.catalog.query' as const,
@@ -73,7 +42,6 @@ describe('Project catalog protocol', () => {
         nextCursor: null,
       },
     };
-    assert.deepEqual(decodeHostFrame(location), location);
     const foreignLocation = {
       ...location,
       result: {

--- a/packages/runtime-host/src/__tests__/runtime-resource-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-resource-protocol.test.ts
@@ -8,17 +8,9 @@ import {
   SESSION_RUNTIME_RESOURCE_CHANGES_MAX,
 } from '../protocol/session-continuity.js';
 import {
-  decodeRuntimeResourceControllerAcquireInput,
-  decodeRuntimeResourceControllerAcquireResult,
   decodeRuntimeResourceControllerControlInput,
-  decodeRuntimeResourceControllerControlResult,
-  decodeRuntimeResourceControllerReleaseInput,
-  decodeRuntimeResourceControllerReleaseResult,
   decodeRuntimeResourceQueryInput,
   decodeRuntimeResourceQueryResult,
-  decodeRuntimeResourceStartInput,
-  decodeRuntimeResourceStartResult,
-  decodeRuntimeResourceStopInput,
   decodeRuntimeResourceStopResult,
   RUNTIME_RESOURCE_CONTROL_INPUT_MAX_BYTES,
   RUNTIME_RESOURCE_MAX_CONTROL_SEQUENCE,
@@ -28,81 +20,10 @@ import {
 } from '../protocol/runtime-resource.js';
 
 const revision = `sha256:${'a'.repeat(64)}` as const;
-const nextRevision = `sha256:${'b'.repeat(64)}` as const;
 const runtimeRef = 'maka://runtime/background-tasks/shell-1';
 type PipeShellSnapshot = Extract<ShellRunSnapshotResult, { mode: 'pipes' }>;
 
 describe('Runtime Resource protocol', () => {
-  test('round-trips every query, controller, and stop branch', () => {
-    const update = resourceUpdate();
-    const unavailable = resourceUpdate({
-      ownership: { kind: 'source_unavailable', sourceSessionId: 'source-session' },
-      result: compactState(),
-    });
-    for (const input of [
-      { kind: 'list_start', sessionId: 'session-1' },
-      { kind: 'list_continue', sessionId: 'session-1', revision, cursor: '2' },
-      { kind: 'get', sessionId: 'session-1', ref: runtimeRef },
-    ] as const) {
-      assert.deepEqual(decodeRuntimeResourceQueryInput(input), input);
-    }
-    for (const result of [
-      {
-        kind: 'page',
-        sessionId: 'session-1',
-        revision,
-        resources: [update, unavailable],
-        nextCursor: '1',
-      },
-      { kind: 'revision_changed', expected: revision, actual: nextRevision },
-      { kind: 'resource', sessionId: 'session-1', revision, resource: update },
-      { kind: 'resource', sessionId: 'session-1', revision, resource: null },
-    ] as const) {
-      assert.deepEqual(decodeRuntimeResourceQueryResult(result), result);
-    }
-
-    const identity = { sessionId: 'session-1', ref: runtimeRef, controllerId: 'client-1' };
-    assert.deepEqual(decodeRuntimeResourceControllerAcquireInput(identity), identity);
-    assert.deepEqual(decodeRuntimeResourceControllerReleaseInput(identity), identity);
-    assert.deepEqual(
-      decodeRuntimeResourceControllerAcquireResult({
-        controllerId: 'client-1',
-        nextSequence: 1,
-        pty: ptySnapshot(),
-      }),
-      { controllerId: 'client-1', nextSequence: 1, pty: ptySnapshot() },
-    );
-    assert.deepEqual(
-      decodeRuntimeResourceStartInput({ sessionId: 'session-1', launchId: 'launch-1' }),
-      { sessionId: 'session-1', launchId: 'launch-1' },
-    );
-    assert.deepEqual(decodeRuntimeResourceStartResult({ resource: snapshot() }), {
-      resource: snapshot(),
-    });
-
-    for (const control of [
-      { kind: 'input', input: 'hello' },
-      { kind: 'resize', cols: 80, rows: 24 },
-      { kind: 'input_and_resize', input: 'hello', cols: 80, rows: 24 },
-    ] as const) {
-      const input = { ...identity, sequence: 1, control };
-      assert.deepEqual(decodeRuntimeResourceControllerControlInput(input), input);
-    }
-    const controlled = { controllerId: 'client-1', sequence: 1, resource: snapshot() };
-    assert.deepEqual(decodeRuntimeResourceControllerControlResult(controlled), controlled);
-    assert.deepEqual(
-      decodeRuntimeResourceControllerReleaseResult({ controllerId: 'client-1', released: true }),
-      { controllerId: 'client-1', released: true },
-    );
-    assert.deepEqual(decodeRuntimeResourceStopInput({ sessionId: 'session-1', ref: runtimeRef }), {
-      sessionId: 'session-1',
-      ref: runtimeRef,
-    });
-    assert.deepEqual(decodeRuntimeResourceStopResult({ resource: snapshot() }), {
-      resource: snapshot(),
-    });
-  });
-
   test('rejects unknown fields and non-canonical snapshots', () => {
     assertInvalid(() =>
       decodeRuntimeResourceQueryInput({

--- a/packages/runtime-host/src/__tests__/task-ledger-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/task-ledger-protocol.test.ts
@@ -17,46 +17,6 @@ const revision = `sha256:${'a'.repeat(64)}` as const;
 const nextRevision = `sha256:${'b'.repeat(64)}` as const;
 
 describe('Task Ledger protocol', () => {
-  test('decodes all closed query input branches', () => {
-    for (const input of [
-      { kind: 'list_start', sessionId: 'session-1' },
-      { kind: 'list_continue', sessionId: 'session-1', revision, cursor: 'opaque:2' },
-      { kind: 'get', sessionId: 'session-1', taskRef: 'T1.2' },
-    ] as const) {
-      assert.deepEqual(decodeTaskLedgerQueryInput(input), input);
-    }
-  });
-
-  test('round-trips every result branch and the current child-session owner', () => {
-    const task = validTask(0, {
-      owner: {
-        actor: 'child_agent',
-        sessionId: 'child-session-1',
-        agentId: 'child-1',
-        runId: 'run-1',
-        turnId: 'turn-1',
-      },
-      resumeTrust: 'needs_revalidation',
-    });
-    const results: TaskLedgerQueryResult[] = [
-      {
-        kind: 'page',
-        sessionId: 'session-1',
-        revision,
-        tasks: [task],
-        nextCursor: 'opaque:2',
-      },
-      { kind: 'revision_changed', expected: revision, actual: nextRevision },
-      { kind: 'task', sessionId: 'session-1', revision, task },
-      { kind: 'task', sessionId: 'session-1', revision, task: null },
-    ];
-
-    for (const result of results) {
-      const encoded = encodeTaskLedgerQueryResult(result);
-      assert.deepEqual(decodeTaskLedgerQueryResult(encoded), encoded);
-    }
-  });
-
   test('rejects unknown fields and invalid current Task DTO values', () => {
     const task = validTask();
     for (const invalid of [


### PR DESCRIPTION
## Summary
- remove exhaustive positive branch matrices from Runtime Resource and Task Ledger codecs
- trim Project catalog mutation round-trips while retaining Host-path exposure behavior
- preserve negative shape, bounds, identity, revision, and transport-budget coverage

## Validation
- `npx biome check` on all changed files
- `git diff --check`
- test-title inventory: 3 tests removed
- no full test run (CI owns execution)