### PR TITLE
fix(desktop): keep the slash picker stable across same-content skill refreshes

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -162,3 +162,78 @@ test('dispatches /side instead of steering it into a running turn', async ({
   await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(1);
   await page.getByRole('button', { name: '停止' }).click();
 });
+
+test('an open menu keeps its container and skills group across projection refreshes', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('seed session');
+  await composer.press('Enter');
+  await expect(page.getByText('Fake backend received: seed session')).toBeVisible();
+
+  await composer.click();
+  await composer.pressSequentially('/');
+  const menu = page.getByRole('listbox', { name: '命令和技能' });
+  await expect(menu.getByRole('group', { name: 'Skills' })).toBeVisible();
+
+  // Armed before the refresh: the flicker was the skills group (and with it
+  // the listbox geometry) being torn down and re-created when the projection
+  // cleared and repopulated, so any removal during the refresh is the
+  // regression (#2667).
+  await page.evaluate(() => {
+    const state = { removals: 0 };
+    (globalThis as unknown as { __slashMenuWatch?: unknown }).__slashMenuWatch = state;
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.removedNodes) {
+          if (!(node instanceof HTMLElement)) continue;
+          if (
+            node.matches('[role="listbox"], [role="group"]') ||
+            node.querySelector('[role="listbox"], [role="group"]') !== null
+          ) {
+            state.removals += 1;
+          }
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+
+  // A thinking-level change publishes the session's 'updated' event and
+  // reloads the Skill projection without changing what the menu shows: the
+  // exact same-content refresh that used to alternate the popup (#2667).
+  const sessionId = await page.evaluate(async () => {
+    const sessions = await (
+      window as unknown as {
+        maka: { sessions: { list(): Promise<Array<{ id: string }>> } };
+      }
+    ).maka.sessions.list();
+    return sessions[0]?.id;
+  });
+  for (let round = 0; round < 3; round += 1) {
+    await page.evaluate(
+      (id) =>
+        (
+          window as unknown as {
+            maka: { sessions: { setThinkingLevel(id: string, level?: null): Promise<unknown> } };
+          }
+        ).maka.sessions.setThinkingLevel(id!, null),
+      sessionId,
+    );
+  }
+  // The refresh round trip is IPC-fast; the poll below gives it room while
+  // asserting the menu never lost its skills group.
+  await expect(menu.getByRole('group', { name: 'Skills' })).toBeVisible();
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            (globalThis as unknown as { __slashMenuWatch: { removals: number } }).__slashMenuWatch
+              .removals,
+        ),
+      { timeout: 3_000 },
+    )
+    .toBe(0);
+  await expect(menu.getByRole('group', { name: 'Skills' })).toBeVisible();
+});

--- a/apps/desktop/src/renderer/use-composer-mentions.ts
+++ b/apps/desktop/src/renderer/use-composer-mentions.ts
@@ -27,6 +27,27 @@ import type { DesktopNewTaskTarget } from '../preload/bridge-contract.js';
 const EMPTY_SKILLS: InvocableSkillEntry[] = [];
 
 /**
+ * Whether a reloaded projection describes the same Skills as the one on
+ * screen, so an unchanged refresh can keep the array it already published.
+ */
+function invocableSkillListsEqual(
+  current: readonly InvocableSkillEntry[],
+  next: readonly InvocableSkillEntry[],
+): boolean {
+  if (current.length !== next.length) return false;
+  return current.every((skill, index) => {
+    const other = next[index];
+    return (
+      other !== undefined &&
+      skill.ref === other.ref &&
+      skill.id === other.id &&
+      skill.name === other.name &&
+      skill.description === other.description
+    );
+  });
+}
+
+/**
  * Owns the composer mention popup wiring so app-shell.tsx keeps no inline
  * `window.maka` state (app-shell-composer-attachment-owner-contract). Derives
  * the `/` popup's skill list from Runtime's authoritative invocable projection, and
@@ -105,14 +126,21 @@ export function useComposerMentions(options: {
     let requestVersion = 0;
     const refresh = () => {
       const version = ++requestVersion;
-      setCatalog((previous) => ({
-        contextKey,
-        loading: true,
-        // A same-context refresh keeps its settled verdict; a context switch
-        // has nothing settled to hold.
-        settled: previous.contextKey === contextKey ? previous.settled : undefined,
-        skills: [],
-      }));
+      setCatalog((previous) =>
+        previous.contextKey === contextKey
+          ? // A same-context refresh keeps both its settled verdict and the
+            // Skills already on screen. Clearing here is what made an open `/`
+            // menu alternate between its commands-only and commands-plus-skills
+            // geometries on every session or MCP event (#2667). The backend
+            // surface has not changed, so there is nothing to fail closed
+            // against; and a Skill withdrawn inside the one-IPC-round-trip
+            // stale window still fails safely, because selection resolves
+            // through the Runtime resolver that no longer knows it.
+            { ...previous, loading: true }
+          : // A context switch has nothing settled to hold, and its Skills
+            // belong to the surface being left behind.
+            { contextKey, loading: true, settled: undefined, skills: [] },
+      );
       const context = {
         ...(newSessionModel ?? {}),
         collaborationMode: newSessionCollaborationMode ?? 'agent',
@@ -128,12 +156,19 @@ export function useComposerMentions(options: {
       void request.then(
         (next) => {
           if (cancelled || version !== requestVersion) return;
-          setCatalog({
+          setCatalog((previous) => ({
             contextKey,
             loading: false,
             settled: next.length === 0 ? 'empty' : 'populated',
-            skills: next,
-          });
+            // A refresh that changed nothing keeps the previous array
+            // identity, so the composer's trigger memo and the menu-replay
+            // effect stay quiet instead of remounting the popup.
+            skills:
+              previous.contextKey === contextKey &&
+              invocableSkillListsEqual(previous.skills, next)
+                ? previous.skills
+                : [...next],
+          }));
         },
         () => {
           // Fail soft: an unavailable projection leaves `/` with no suggestions.


### PR DESCRIPTION
## Summary

Typing `/r` and waiting made the slash picker alternate between two popup geometries with a replayed open transition. Every session `updated`/`turn-status-change`/`rebound` event and every MCP change reloads the invocable Skill projection, and the reload cleared the list before repopulating it: the open menu collapsed to its commands-only shape, then sprang back one IPC round trip later, each time replaying the trigger-menu transition because the projection's identity had changed twice.

Two changes in `useComposerMentions`:

- The fail-closed clear now applies only to a key change (session, project, model, or mode switch), where showing the previous surface's Skills would be wrong. A same-key refresh keeps the current list on screen until the fresh one arrives. A Skill withdrawn inside that window still fails safely, because selection resolves through the Runtime resolver that no longer knows it.
- A refresh that changed nothing keeps the previous array identity, so the composer's trigger memo and its menu-replay effect stay quiet and the menu is not re-searched at all.

Fixes #2667

## Verification

- New e2e drives the reported shape with a pre-armed MutationObserver: with the menu open on `/`, three same-content projection refreshes (thinking-level updates publishing the session's `updated` event) must remove neither the listbox nor its groups. Without the fix the watch counts 15 removals; with it, zero, and the Skills group stays visible throughout.
- The full slash-command-menu e2e suite passes three consecutive runs.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
