### PR TITLE
test: remove contract checker self-tests

### DIFF
--- a/packages/core/src/__tests__/model-thinking.test.ts
+++ b/packages/core/src/__tests__/model-thinking.test.ts
@@ -6,20 +6,11 @@ import {
   normalizeRelayModelProfiles,
   relayModelProfile,
   resolveThinkingLevel,
-  THINKING_LEVELS,
   deriveThinkingChoices,
-  isThinkingLevel,
   thinkingOptionsForModel,
   thinkingVariantsForConnection,
   thinkingVariantsForModel,
 } from '../model-thinking.js';
-
-test('thinking-level guard accepts only the closed display vocabulary', () => {
-  for (const level of THINKING_LEVELS) assert.equal(isThinkingLevel(level), true);
-  for (const value of ['default', 'turbo', undefined, 123]) {
-    assert.equal(isThinkingLevel(value), false);
-  }
-});
 
 test('declarable relay levels are every intensity tier but off', () => {
   // `off` is a disable-wire encoding (reasoning_effort 'none'), not an

--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -4,7 +4,6 @@ import {
   PROVIDER_AUTH_ACTIONS,
   deriveProviderAuthContract,
   deriveProviderAuthContractFromConnection,
-  isProviderAuthState,
 } from '../provider-auth.js';
 import type { LlmConnection } from '../llm-connections.js';
 
@@ -274,21 +273,6 @@ describe('ProviderAuth contract', () => {
     expect(contract.validationStatus).toBe('verified');
   });
 
-  test('locks provider auth state guard', () => {
-    expect(isProviderAuthState('validated')).toBe(true);
-    expect(isProviderAuthState('operational')).toBe(false);
-  });
-
-  test('action availability map covers every closed action key', () => {
-    const contract = deriveProviderAuthContract({
-      providerType: 'openai',
-      hasSecret: true,
-    });
-
-    expect(Object.keys(contract.actionAvailability).sort()).toEqual(
-      [...PROVIDER_AUTH_ACTIONS].sort(),
-    );
-  });
 });
 describe('ProviderAuth contract unknown-providerType fallback', () => {
   // A connection persisted on another branch may carry a providerType this

--- a/packages/core/src/__tests__/tool-result-record-schema.test.ts
+++ b/packages/core/src/__tests__/tool-result-record-schema.test.ts
@@ -4,15 +4,6 @@ import type { StoredMessage } from '../session.js';
 import { decodeStoredMessageForRead, decodeStoredMessageForRecovery } from '../session.js';
 import { decodeCanonicalToolResultContent } from '../tool-result-record-schema.js';
 
-describe('legacy subagent tool result compatibility', () => {
-  test('keeps the public canonical decoder strict', () => {
-    assert.throws(
-      () => decodeCanonicalToolResultContent(legacySubagentResult()),
-      /Invalid tool result content/,
-    );
-  });
-});
-
 describe('sandbox denial tool result metadata', () => {
   test('accepts a canonical text result carrying a sandbox denial signal', () => {
     const result = {
@@ -124,23 +115,6 @@ describe('uncertain tool outcome metadata', () => {
     }
   });
 });
-
-function legacySubagentResult(): Record<string, unknown> {
-  return {
-    kind: 'subagent',
-    childSessionId: 'child-session-1',
-    agentId: 'local-read',
-    agentName: 'Local Read',
-    turnId: 'child-turn-1',
-    runId: 'child-run-1',
-    status: 'waiting_permission',
-    permissionMode: 'ask',
-    summary: 'Waiting for permission.',
-    artifactIds: [],
-    startedAt: 10,
-    eventCount: 3,
-  };
-}
 
 function storedToolResult(content: unknown) {
   return {

--- a/packages/core/src/__tests__/web-search.test.ts
+++ b/packages/core/src/__tests__/web-search.test.ts
@@ -1,13 +1,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
-  WEB_SEARCH_CREDENTIAL_SOURCES,
-  WEB_SEARCH_CREDENTIAL_PROVIDERS,
-  WEB_SEARCH_PROVIDERS,
   defaultWebSearchSettings,
-  isWebSearchCredentialSource,
-  isWebSearchCredentialStatus,
-  isWebSearchProvider,
   maskedTokenForDisplay,
   mergeWebSearchSettings,
   normalizeWebSearchLimit,
@@ -36,24 +30,6 @@ describe('web search settings', () => {
       [11, 10],
     ];
     for (const [value, expected] of limits) assert.equal(normalizeWebSearchLimit(value), expected);
-  });
-
-  it('accepts only closed provider and credential enums', () => {
-    for (const provider of WEB_SEARCH_PROVIDERS) assert.equal(isWebSearchProvider(provider), true);
-    for (const value of ['google', '', undefined]) assert.equal(isWebSearchProvider(value), false);
-    assert.deepEqual(WEB_SEARCH_CREDENTIAL_PROVIDERS, ['tavily']);
-
-    for (const source of WEB_SEARCH_CREDENTIAL_SOURCES) {
-      assert.equal(isWebSearchCredentialSource(source), true);
-    }
-    for (const value of ['anonymous', '']) assert.equal(isWebSearchCredentialSource(value), false);
-
-    for (const value of ['valid', 'invalid_credentials']) {
-      assert.equal(isWebSearchCredentialStatus(value), true);
-    }
-    for (const value of ['unsupported_provider', '']) {
-      assert.equal(isWebSearchCredentialStatus(value), false);
-    }
   });
 
   it('masks persisted tokens while preserving explicit replace and clear operations', () => {

--- a/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/runtime/src/__tests__/provider-contract-matrix.test.ts
@@ -1,36 +1,9 @@
-/**
- * Registry-driven provider conformance matrix — generative execution.
- *
- * This suite interprets {@link PROVIDER_CONTRACT_MATRIX_PLAN}: it does not carry
- * a hard-coded provider list. For every (provider, dimension) cell the plan
- * derives from the registry, one of three things happens here:
- *
- *   - `generated`      a parametric wire test is executed against a scripted
- *                      local HTTP server (discovery, exact-model-id, tool-loop,
- *                      reasoning-replay), driven entirely by the derived cell.
- *   - `override`       the cell binds to an executable entry in
- *                      {@link PROVIDER_CONTRACT_OVERRIDE_BINDINGS}
- *                      (`provider-contract-overrides.ts`), and this suite runs
- *                      the bound provider-specific contract directly — deleting
- *                      or breaking an override fails here, with no reliance on
- *                      test titles in another source file.
- *   - `not-applicable` the machine-readable reason is asserted, and any reverse
- *                      assertion (e.g. fallback discovery must not call /models)
- *                      is executed.
- *
- * The gap report (`test('no contract gaps ...')`) fails loudly, listing
- * provider + dimension + what is missing, whenever a ready provider's dimension
- * satisfies none of the three states — this is Phase 7's gap reporting.
- */
-
 import assert from 'node:assert/strict';
 import type { IncomingMessage } from 'node:http';
 import { after, describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import {
-  PROVIDER_CONTRACT_DIMENSIONS,
   PROVIDER_CONTRACT_MATRIX_PLAN,
-  listProviderContractCells,
   type ProviderContractDiscoveryPlan,
   type ProviderContractRow,
   type ProviderContractGeneratedCell,
@@ -47,10 +20,7 @@ import {
   respondJson,
   startJsonServer,
 } from './conformance-harness.js';
-import {
-  PROVIDER_CONTRACT_OVERRIDE_BINDINGS,
-  type ProviderContractOverrideBinding,
-} from './provider-contract-overrides.js';
+import { PROVIDER_CONTRACT_OVERRIDE_BINDINGS } from './provider-contract-overrides.js';
 
 const REASONING_TEXT = 'I should call echo with the requested text.';
 const FINAL_TEXT = 'Echoed hello.';
@@ -59,95 +29,6 @@ const API_KEY = 'contract-matrix-test-key';
 const plan = PROVIDER_CONTRACT_MATRIX_PLAN;
 
 after(closeAllJsonServers);
-
-/** Executable override lookup: plan `overrideKey` → its runnable binding. */
-const OVERRIDE_BINDING_BY_KEY: ReadonlyMap<string, ProviderContractOverrideBinding> = new Map(
-  PROVIDER_CONTRACT_OVERRIDE_BINDINGS.flatMap((binding) =>
-    binding.keys.map((key) => [key, binding]),
-  ),
-);
-
-const KNOWN_WIRES: ReadonlySet<ProviderContractWire> = new Set([
-  'openai-chat',
-  'anthropic-messages',
-  'google-generate',
-  'cohere-v2',
-]);
-
-describe('provider conformance matrix — gap report', () => {
-  test('no contract gaps: every ready provider dimension is generated, overridden, or justified N/A', () => {
-    const expectedRows = Object.entries(PROVIDER_DEFAULTS)
-      .filter(
-        ([, definition]) =>
-          definition.status === 'ready' && definition.runtimeAdapter.kind !== 'unavailable',
-      )
-      .map(([providerType]) => providerType)
-      .sort();
-    assert.deepEqual(
-      plan.rows.map((row) => row.providerType).sort(),
-      expectedRows,
-      'every ready provider with a runtime adapter must have a conformance row',
-    );
-    assert.deepEqual(plan.dimensions, PROVIDER_CONTRACT_DIMENSIONS);
-
-    const gaps: string[] = [];
-    for (const { providerType, dimension, cell } of listProviderContractCells(plan)) {
-      const where = `${providerType} · ${dimension}`;
-      switch (cell.state) {
-        case 'generated':
-          if (dimension === 'discovery') {
-            if (!cell.discovery)
-              gaps.push(`${where}: generated discovery cell is missing its derived plan`);
-          } else if (!cell.wire || !KNOWN_WIRES.has(cell.wire)) {
-            gaps.push(
-              `${where}: generated wire cell has no executable wire (${String(cell.wire)})`,
-            );
-          }
-          break;
-        case 'override':
-          if (!OVERRIDE_BINDING_BY_KEY.has(cell.overrideKey)) {
-            gaps.push(
-              `${where}: no executable override binding registered for key "${cell.overrideKey}"`,
-            );
-          }
-          break;
-        case 'not-applicable':
-          if (!cell.reason)
-            gaps.push(`${where}: not-applicable cell is missing a machine-readable reason`);
-          break;
-        default:
-          gaps.push(`${where}: unknown cell state`);
-      }
-    }
-    assert.deepEqual(gaps, [], `provider contract gaps found:\n  ${gaps.join('\n  ')}`);
-  });
-
-  test('every registered override binding maps to a real override cell in the plan', () => {
-    const overrideKeys = new Set(
-      listProviderContractCells(plan)
-        .filter((entry) => entry.cell.state === 'override')
-        .map((entry) => (entry.cell.state === 'override' ? entry.cell.overrideKey : '')),
-    );
-    const seen = new Set<string>();
-    for (const binding of PROVIDER_CONTRACT_OVERRIDE_BINDINGS) {
-      assert.ok(
-        binding.keys.length > 0,
-        `override binding "${binding.title}" must own at least one key`,
-      );
-      for (const key of binding.keys) {
-        assert.ok(
-          !seen.has(key),
-          `override key "${key}" is bound by more than one executable binding`,
-        );
-        seen.add(key);
-        assert.ok(
-          overrideKeys.has(key),
-          `override binding key "${key}" has no matching override cell`,
-        );
-      }
-    }
-  });
-});
 
 describe('provider conformance matrix — override cells execute their bound contract', () => {
   for (const binding of PROVIDER_CONTRACT_OVERRIDE_BINDINGS) {

--- a/packages/runtime/src/__tests__/tool-availability.test.ts
+++ b/packages/runtime/src/__tests__/tool-availability.test.ts
@@ -169,12 +169,6 @@ describe('ToolAvailabilityRuntime — durable ledger seed', () => {
     assert.ok(plan.activeTools.includes('rive_run'), 'seeded group active from turn start');
     assert.ok(!plan.activeTools.includes('docs_edit'), 'unseeded group still hidden');
   });
-
-  test('an unknown seeded group id is ignored (forward compatible)', () => {
-    const plan = runtime(true).prepare([event(LOAD_TOOLS_NAME, { group: 'ghost' })]);
-    assert.ok(!plan.activeTools.includes('rive_run'));
-    assert.ok(!plan.activeTools.includes('docs_edit'));
-  });
 });
 
 describe('ToolAvailabilityRuntime — diagnostics', () => {


### PR DESCRIPTION
## Summary
- remove provider matrix gap checks that validate the test plan rather than provider wire behavior
- remove enum/guard mirrors for thinking, auth, and web-search contracts
- remove internal legacy/forward-compat negative cases while retaining current behavior boundaries

## Validation
- `npx biome check` on all changed files
- `git diff --check`
- manual title inventory: 8 tests removed
- no full test run (CI owns execution)