### PR TITLE
test: remove pass-through and compatibility checks

### DIFF
--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -1,7 +1,6 @@
 import { describe, test } from 'node:test';
 import { expect } from '../test-helpers.js';
 import {
-  PROVIDER_AUTH_ACTIONS,
   deriveProviderAuthContract,
   deriveProviderAuthContractFromConnection,
 } from '../provider-auth.js';
@@ -271,54 +270,5 @@ describe('ProviderAuth contract', () => {
     expect(contract.providerType).toBe('zai-coding-plan');
     expect(contract.state).toBe('validated');
     expect(contract.validationStatus).toBe('verified');
-  });
-
-});
-describe('ProviderAuth contract unknown-providerType fallback', () => {
-  // A connection persisted on another branch may carry a providerType this
-  // build's PROVIDER_REGISTRY doesn't know. The contract must
-  // surface a non-real, non-actionable state instead of crashing on
-  // `defaults.modelDiscovery` / `defaults.authKind`. Mirrors `isFakeBackend`.
-  test('enabled unknown provider → not_configured, no actions, no secret required', () => {
-    const contract = deriveProviderAuthContract({
-      providerType: 'branch-only-provider' as never,
-      enabled: true,
-      hasSecret: true,
-    });
-
-    expect(contract.providerType).toBe('branch-only-provider');
-    expect(contract.setupMode).toBe('none');
-    expect(contract.state).toBe('not_configured');
-    expect(contract.requiresSecret).toBe(false);
-    expect(contract.sendMayUseWithoutSecret).toBe(false);
-    expect(contract.validationStatus).toBe('not_required');
-    for (const action of PROVIDER_AUTH_ACTIONS) {
-      expect(contract.actionAvailability[action]).toBe('hidden');
-    }
-    expect(contract.copy.label).toContain('branch-only-provider');
-  });
-
-  test('disabled unknown provider → disabled state', () => {
-    const contract = deriveProviderAuthContract({
-      providerType: 'branch-only-provider' as never,
-      enabled: false,
-      hasSecret: false,
-    });
-
-    expect(contract.state).toBe('disabled');
-  });
-
-  test('deriveProviderAuthContractFromConnection tolerates an unknown providerType', () => {
-    const contract = deriveProviderAuthContractFromConnection(
-      {
-        providerType: 'branch-only-provider' as never,
-        enabled: true,
-        lastTestStatus: undefined,
-      } as never,
-      true,
-    );
-
-    expect(contract.state).toBe('not_configured');
-    expect(contract.setupMode).toBe('none');
   });
 });

--- a/packages/core/src/__tests__/provider-catalog-contract.test.ts
+++ b/packages/core/src/__tests__/provider-catalog-contract.test.ts
@@ -25,7 +25,6 @@ import {
 import {
   CATALOG_PROVIDER_TYPES,
   PROVIDER_REGISTRY,
-  isWiredOAuthProvider,
   type ProviderCatalogGroup,
 } from '../provider-registry.js';
 
@@ -53,20 +52,6 @@ describe('provider connection slug derivation contract', () => {
     assert.equal(derived, 'openai-100');
     assert.ok(!existing.includes(derived));
     assert.equal(validateSlug(derived), null);
-  });
-});
-
-describe('provider OAuth wiring contract', () => {
-  it('derives runnable account providers from the registry adapter boundary', () => {
-    for (const type of [
-      'claude-subscription',
-      'openai-codex',
-      'github-copilot',
-      'xai-oauth',
-    ] as const) {
-      assert.equal(isWiredOAuthProvider(type), true, `${type} must be wired`);
-    }
-    assert.equal(isWiredOAuthProvider('gemini-cli'), false);
   });
 });
 

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -15,7 +15,6 @@ import {
   decodePersistedRuntimeEvent,
   decodeRuntimeEvent,
   isTerminalRuntimeEvent,
-  isPartialRuntimeEvent,
   runtimeEventHasModelVisibleContent,
   type RuntimeEvent,
   type RuntimeEventActions,
@@ -667,13 +666,6 @@ describe('isTerminalRuntimeEvent', () => {
       expect(isTerminalRuntimeEvent(event)).toBe(false);
     }
     expect(isTerminalRuntimeEvent(baseEvent({ actions: { endInvocation: true } }))).toBe(true);
-  });
-});
-
-describe('isPartialRuntimeEvent', () => {
-  test('reflects the partial flag exactly', () => {
-    expect(isPartialRuntimeEvent(baseEvent({ partial: true }))).toBe(true);
-    expect(isPartialRuntimeEvent(baseEvent({ partial: false }))).toBe(false);
   });
 });
 

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -19,7 +19,6 @@ import {
   mapSessionEventToRuntimeEvent,
   createSessionEventMapMemory,
 } from '../ai-sdk-flow.js';
-import { flowSupportsControl } from '../agent-flow.js';
 import type { AgentBackend } from '@maka/core/backend-types';
 import { RuntimeRunner } from '../runtime-runner.js';
 import type { InvocationContext } from '../invocation-context.js';
@@ -149,20 +148,6 @@ describe('AiSdkFlow seam', () => {
     );
 
     assert.equal(runtimeEvent.refs?.sourceMessageDigest, digest);
-  });
-
-  test('implements AgentFlow + AgentFlowControl and reflects the wrapped backend', () => {
-    const backend = new ScriptedBackend({ events: [] });
-    const flow = new AiSdkFlow({ backend });
-
-    assert.equal(flow.kind, 'ai-sdk');
-    assert.equal(flow.sessionId, 'session-1');
-    assert.equal(typeof flow.run, 'function');
-    assert.equal(flowSupportsControl(flow), true);
-    assert.equal(flow.backendRef, backend);
-    // Structural: an AiSdkFlow is assignable to the AgentFlow contract.
-    const _asFlow: import('../agent-flow.js').AgentFlow = flow;
-    void _asFlow;
   });
 
   test('single-flights a pending backend stop and retries after it settles', async () => {

--- a/packages/runtime/src/__tests__/computer-use-codec-summary.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-codec-summary.test.ts
@@ -45,15 +45,6 @@ test('a refusal that does not declare itself stays a bare code', () => {
   assert.doesNotMatch(text, /salary/);
 });
 
-test('a successful call is unchanged', () => {
-  const text = summarize(
-    { type: 'click_element' },
-    { outcome: { ok: true, tier: 'ax', verified: true } },
-  );
-  assert.match(text, /computer\.click_element/);
-  assert.doesNotMatch(text, /failed/);
-});
-
 test('a dispatch that changed nothing does not start with the word ok', () => {
   // Measured on a real run: `cmd+p` came back `ok ... suspected_noop` seven
   // times and the model sent it seven times, then switched to `key` and sent it

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -29,14 +29,6 @@ describe('Bash tool description declares the executing shell', () => {
     assert.match(tool.description, /Subject to permission policy\.$/);
   });
 
-  test('foreground tool description is unchanged on POSIX', () => {
-    const tool = buildLocalForegroundBashTool({ shell: { kind: 'posix', displayName: '/bin/sh' } });
-    assert.equal(
-      tool.description,
-      'Run a shell command in the session cwd. Subject to permission policy.',
-    );
-  });
-
   test('background tool tells the model commands run under PowerShell 7', () => {
     const tool = buildManagedBashTool(fakeShellRuns(), { shell: pwshPlan });
     assert.match(tool.description, /PowerShell 7 \(pwsh\)/);


### PR DESCRIPTION
## Summary
- remove pure pass-through, identity, and structural wrapper tests
- remove persisted unknown-provider fallback compatibility tests
- retain provider behavior, Computer Use safety copy, shell execution, and RuntimeEvent terminal semantics

## Validation
- `npx biome check` on all changed files
- `git diff --check`
- manual title inventory: 8 tests removed
- no full test run (CI owns execution)