### PR TITLE
test(core): remove constant and baseline checks

### DIFF
--- a/packages/core/src/__tests__/daily-review.test.ts
+++ b/packages/core/src/__tests__/daily-review.test.ts
@@ -2,10 +2,8 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import {
-  DAILY_REVIEW_LIST_LIMIT,
   buildDailyReviewSummary,
   dailyReviewArchiveId,
-  dailyUsageQuery,
   normalizeDailyReviewArchive,
   normalizeDailyReviewConfig,
   parseDailyReviewArchiveId,
@@ -176,21 +174,6 @@ describe('buildDailyReviewSummary', () => {
     assert.equal(out.totals.totalTokens, 300);
     assert.equal(out.totals.costUsd, 1.23);
     assert.equal(out.totals.errorCount, 2);
-  });
-});
-
-describe('dailyUsageQuery', () => {
-  it('produces a UsageQuery with the day range and no filters', () => {
-    const q = dailyUsageQuery({ fromMs: 100, toMs: 200 });
-    assert.deepEqual(q, { range: { from: 100, to: 200 } });
-  });
-});
-
-describe('DAILY_REVIEW_LIST_LIMIT', () => {
-  it('is a small positive integer', () => {
-    assert.ok(Number.isInteger(DAILY_REVIEW_LIST_LIMIT));
-    assert.ok(DAILY_REVIEW_LIST_LIMIT > 0);
-    assert.ok(DAILY_REVIEW_LIST_LIMIT <= 32);
   });
 });
 

--- a/packages/core/src/__tests__/events.test.ts
+++ b/packages/core/src/__tests__/events.test.ts
@@ -3,8 +3,6 @@ import { expect } from '../test-helpers.js';
 import {
   aggregateMessageContents,
   failureClassFromCompleteStopReason,
-  TOOL_OUTPUT_DELTA_MAX_CHARS,
-  TOOL_OUTPUT_STREAMS,
 } from '../events.js';
 
 test('aggregates inline references against the combined display text', () => {
@@ -35,13 +33,6 @@ test('preserves an explicit empty inline-reference marker while aggregating', ()
   expect(aggregateMessageContents([{ text: 'plain', inlineReferences: [] }])).toEqual({
     text: 'plain',
     inlineReferences: [],
-  });
-});
-
-describe('ToolOutputDelta event contract', () => {
-  test('locks finite stream union and chunk bound constant', () => {
-    expect(TOOL_OUTPUT_STREAMS).toEqual(['stdout', 'stderr']);
-    expect(TOOL_OUTPUT_DELTA_MAX_CHARS).toBe(8192);
   });
 });
 

--- a/packages/core/src/__tests__/provider-catalog-contract.test.ts
+++ b/packages/core/src/__tests__/provider-catalog-contract.test.ts
@@ -1,20 +1,3 @@
-/**
- * Provider catalog contract — structural invariants over the registry.
- *
- * These invariants replace the per-provider add-flow E2E clones that used to
- * live in apps/desktop/e2e/providers.spec.ts. They are data-driven over
- * CATALOG_PROVIDER_TYPES, so adding a provider is covered automatically with
- * zero manual test updates. They assert *shape*, never snapshot values (no
- * "provider X's model is exactly Y"), so a legitimate model/endpoint refresh
- * does not churn this file.
- *
- * Brand-mark completeness (every catalog provider resolves to a real mark, not
- * the generic fallback) is asserted on the desktop side — core cannot import a
- * renderer module — in
- * apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
- * ("renders a registered brand mark for every catalog provider").
- */
-
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {

--- a/packages/core/src/__tests__/task-submission-readiness.test.ts
+++ b/packages/core/src/__tests__/task-submission-readiness.test.ts
@@ -7,18 +7,6 @@ import {
 import { expect } from '../test-helpers.js';
 
 describe('task submission readiness', () => {
-  test('projects a ready baseline from current authorities', () => {
-    const snapshot = deriveTaskSubmissionReadiness(readyInput());
-
-    expect(snapshot.state).toBe('ready');
-    expect(snapshot.blockers).toEqual([]);
-    expect(snapshot.dimensions.map((dimension) => dimension.id)).toEqual([
-      'runtime',
-      'model_target',
-      'workspace',
-    ]);
-  });
-
   test('reuses connection readiness and routes an invalid model to its connection', () => {
     const input = readyInput();
     if (input.modelTarget.kind !== 'resolved') throw new Error('expected resolved model target');


### PR DESCRIPTION
## Summary
- remove direct constant and trivial mapper assertions
- remove a ready-state baseline duplicated by requested-capability behavior coverage
- remove stale test commentary referencing a deleted Desktop suite

## Validation
- `npx biome check` on all changed files
- `git diff --check`
- manual title inventory: 4 tests removed
- no full test run (CI owns execution)