### PR TITLE
test(core): remove schema happy paths

### DIFF
--- a/apps/desktop/src/main/__tests__/mcp-import.test.ts
+++ b/apps/desktop/src/main/__tests__/mcp-import.test.ts
@@ -2,17 +2,6 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { parseMcpImport } from '../../renderer/mcp-import.js';
 
-test('MCP import accepts a version 1 config or a direct server map', () => {
-  assert.deepEqual(parseMcpImport('{"version":1,"mcpServers":{"local":{"command":"node"}}}'), {
-    version: 1,
-    mcpServers: { local: { command: 'node' } },
-  });
-  assert.deepEqual(parseMcpImport('{"remote":{"url":"https://example.com/mcp"}}'), {
-    version: 1,
-    mcpServers: { remote: { url: 'https://example.com/mcp' } },
-  });
-});
-
 test('MCP import rejects unsupported versions and malformed full configs', () => {
   assert.throws(
     () => parseMcpImport('{"version":2,"mcpServers":{}}'),

--- a/packages/core/src/__tests__/agent-graph-topology.test.ts
+++ b/packages/core/src/__tests__/agent-graph-topology.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
-  decodeAgentGraphOperatorProvision,
   isAgentGraphOperatorProvisionRequest,
   type AgentGraphOperatorProvisionRequest,
 } from '../agent-graph-topology.js';
@@ -9,7 +8,6 @@ import {
 describe('agent graph topology provisions', () => {
   test('strictly validates one monotonic operator addition', () => {
     const request = provisionRequest();
-    assert.equal(isAgentGraphOperatorProvisionRequest(request), true);
     assert.equal(
       isAgentGraphOperatorProvisionRequest({
         ...request,
@@ -24,18 +22,6 @@ describe('agent graph topology provisions', () => {
       }),
       false,
     );
-  });
-
-  test('decodes a persisted provision without sharing edge objects', () => {
-    const request = provisionRequest();
-    const persisted = {
-      ...request,
-      targetSessionId: 'child-session',
-      provisionedAt: 12,
-    };
-    const decoded = decodeAgentGraphOperatorProvision(persisted);
-    assert.deepEqual(decoded, persisted);
-    assert.notEqual(decoded.edges, persisted.edges);
   });
 });
 

--- a/packages/core/src/__tests__/goal-authority.test.ts
+++ b/packages/core/src/__tests__/goal-authority.test.ts
@@ -2,17 +2,6 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { decodeGoalAuthorityRecord, type GoalAuthorityRecord } from '../goal.js';
 
-test('Goal authority decoder freezes one exact, internally consistent record', () => {
-  const record = goalAuthorityRecord();
-  const decoded = decodeGoalAuthorityRecord(record);
-
-  assert.deepEqual(decoded, record);
-  assert.ok(Object.isFrozen(decoded));
-  assert.ok(Object.isFrozen(decoded.goal));
-  assert.ok(Object.isFrozen(decoded.controlLease));
-  assert.ok(Object.isFrozen(decoded.currentExecution));
-});
-
 test('Goal authority decoder rejects cross-authority execution state', () => {
   const valid = goalAuthorityRecord();
   const current = valid.currentExecution;

--- a/packages/core/src/__tests__/subagent-workspace.test.ts
+++ b/packages/core/src/__tests__/subagent-workspace.test.ts
@@ -7,10 +7,6 @@ import {
 } from '../subagent-workspace.js';
 
 describe('subagent workspace binding', () => {
-  test('accepts the strict durable Git worktree shape', () => {
-    assert.equal(isSubagentWorkspaceBinding(binding()), true);
-  });
-
   test('rejects unknown fields, unsafe leases, and malformed commits', () => {
     assert.equal(isSubagentWorkspaceBinding({ ...binding(), extra: true }), false);
     assert.equal(isSubagentWorkspaceBinding({ ...binding(), leaseId: '../shared' }), false);


### PR DESCRIPTION
## Summary
- remove canonical acceptance and clone/freeze assertions from small schema suites
- retain malformed identity, unknown-field, path-safety, and cross-authority rejection coverage
- retain unsupported MCP import version and shape checks

## Validation
- `npx biome check` on changed files
- `git diff --check`
- title inventory: 4 tests removed
- no full test run (CI owns execution)