### PR TITLE
test: remove presentation copy checks

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-onboarding-main.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-onboarding-main.test.ts
@@ -492,21 +492,6 @@ describe('BotOnboardingService', () => {
     assert.equal(result.state, 'error');
   });
 
-  it('categorizes a fatal provider error into specific Chinese copy', async () => {
-    // PR1197 review (P2-11): 鉴权/网络/超时 categories must survive to the user
-    // instead of collapsing to one generic line.
-    const adapter: BotOnboardingProviderAdapter = {
-      async start() { return startResult(); },
-      async poll() { throw new Error('auth failed: invalid client credentials'); },
-    };
-    const test = harness(adapter);
-    const started = await test.service.start({ provider: 'dingtalk' });
-    test.advance(5_000);
-    const result = await test.service.poll(started.sessionId);
-    assert.equal(result.state, 'error');
-    assert.equal(result.error, '鉴权失败');
-  });
-
   it('expires locally without polling after the provider TTL', async () => {
     let polls = 0;
     const adapter: BotOnboardingProviderAdapter = {

--- a/apps/desktop/src/main/__tests__/thread-search.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-search.test.ts
@@ -8,7 +8,6 @@ import {
   collectSearchableText,
   findMatch,
   foldForMatch,
-  formatSearchResultSummary,
   runThreadSearch,
 } from '../search/thread-search.js';
 
@@ -386,11 +385,4 @@ describe('thread search text projection', () => {
     for (const message of excluded) assert.equal(collectSearchableText(message), undefined);
   });
 
-  it('labels searchable message types without leaking raw enum names', () => {
-    assert.equal(formatSearchResultSummary(userMessage('hello')), '用户消息');
-    assert.equal(formatSearchResultSummary(assistantMessage('hello')), '助手回复');
-    assert.equal(formatSearchResultSummary(toolCall('list files')), '工具调用：Shell command');
-    assert.equal(formatSearchResultSummary(toolResult({ ok: true })), '工具结果：成功');
-    assert.equal(formatSearchResultSummary(toolResult({ ok: false }, true)), '工具结果：失败');
-  });
 });

--- a/packages/core/src/__tests__/bot-events.test.ts
+++ b/packages/core/src/__tests__/bot-events.test.ts
@@ -7,12 +7,8 @@ import {
   botDisplayLabel,
   botSourceEventKey,
   formatBotMessageForSession,
-  humanizeBotStatusReason,
   isPlaintextHelpCommand,
   isPlaintextResetCommand,
-  nonTextMessageAck,
-  plaintextHelpReply,
-  type BotAttachmentKind,
   type BotMessageEvent,
 } from '../bot-events.js';
 
@@ -56,66 +52,4 @@ describe('bot event contract', () => {
     }
   });
 
-  test('help copy exposes actionable commands without roadmap language', () => {
-    const reply = plaintextHelpReply();
-    assert.match(reply, /Maka 机器人帮助/);
-    assert.match(reply, /restart/);
-    assert.match(reply, /重置/);
-    assert.equal(/即将|尚未|TODO|coming soon/i.test(reply), false);
-  });
-
-  test('humanizes known runtime reasons and preserves useful diagnostics', () => {
-    const cases: Array<[string, RegExp]> = [
-      ['rate-limited', /节流/],
-      ['polling-timeout', /轮询超时/],
-      ['send-failed', /发送失败/],
-      ['get-me-failed', /凭据探测失败/],
-      ['gateway-bot-401', /Gateway.*401/],
-      ['gateway-closed-4004', /Gateway 连接关闭.*4004.*重连/],
-      ['connections-open-503', /Stream 订阅打开失败.*503/],
-      ['stream-closed-1006', /Stream 连接关闭.*1006.*重连/],
-      ['send-failed-403', /发送失败.*403/],
-      ['getAppAccessToken-401', /access_token.*401/],
-    ];
-    for (const [reason, expected] of cases)
-      assert.match(humanizeBotStatusReason(reason)!, expected);
-    assert.equal(humanizeBotStatusReason('  Unauthorized  '), 'Unauthorized');
-    assert.equal(humanizeBotStatusReason('something-weird-42'), 'something-weird-42');
-    assert.equal(humanizeBotStatusReason('A'.repeat(300)), 'A'.repeat(200));
-  });
-
-  test('does not manufacture errors for empty or non-error status reasons', () => {
-    for (const reason of [
-      undefined,
-      '',
-      '   ',
-      'disabled',
-      'stopped',
-      'no-token',
-      'scaffold-only',
-      'unimplemented',
-      'feishu-domain-required',
-    ]) {
-      assert.equal(humanizeBotStatusReason(reason), undefined);
-    }
-  });
-
-  test('attachment acknowledgements describe current text-only behavior', () => {
-    const expected: Array<[BotAttachmentKind, RegExp]> = [
-      ['photo', /caption/],
-      ['voice', /语音/],
-      ['audio', /语音/],
-      ['sticker', /贴纸/],
-      ['video', /视频/],
-      ['animation', /视频/],
-      ['document', /附件文件/],
-      ['unknown', /文字/],
-    ];
-    for (const [kind, pattern] of expected) {
-      const reply = nonTextMessageAck(kind);
-      assert.match(reply, pattern);
-      assert.match(reply, /Maka/);
-      assert.equal(/即将|尚未|TODO|coming soon|后续版本/i.test(reply), false);
-    }
-  });
 });

--- a/packages/core/src/__tests__/health.test.ts
+++ b/packages/core/src/__tests__/health.test.ts
@@ -104,14 +104,6 @@ describe('HealthSignal contract', () => {
     );
   });
 
-  test('unconfigured connection health copy is an actionable waiting state', () => {
-    const result = healthSignalFromConnection(connection({ defaultModel: '' }), 20);
-
-    expect(result.message).toBe('等待选择默认模型。');
-    expect(/缺少默认模型/.test(result.message)).toBe(false);
-    expect(result.blocksSend).toBe(true);
-  });
-
   /*
    * PR-HEALTH-1 — E1 lock (three-layer separation):
    * Connection auth state and bot capability readiness must derive

--- a/packages/runtime/src/__tests__/explore-agent-tool.test.ts
+++ b/packages/runtime/src/__tests__/explore-agent-tool.test.ts
@@ -534,45 +534,6 @@ describe('ExploreAgent read-only worker', () => {
     });
   });
 
-  it('keeps user-visible result notes localized', async () => {
-    await withWorkspace(async (workspaceRoot) => {
-      await writeFile(join(workspaceRoot, 'notes.md'), 'alpha');
-
-      const result = await runReadOnlyExplore({
-        cwd: workspaceRoot,
-        objective: 'find beta references',
-        roots: ['.'],
-        queries: ['beta'],
-        maxFiles: 5,
-        maxMatches: 5,
-      });
-
-      assert.equal(result.ok, true);
-      assert.equal(result.terminalStatus, 'completed_empty');
-      assert.ok(result.notes.some((note) => /没有找到内容命中/.test(note)));
-      assert.match(result.report, /状态：完成，但没有找到可交接证据。/);
-      assert.equal(
-        result.notes.some((note) =>
-          /Read-only worker|Search budget|No content matches|Candidate discovery|Project landmark|Total byte budget|Scope /.test(
-            note,
-          ),
-        ),
-        false,
-      );
-
-      const failed = await runReadOnlyExplore({
-        cwd: workspaceRoot,
-        objective: 'x',
-      });
-      assert.equal(failed.ok, false);
-      assert.ok(failed.notes.some((note) => /不写文件、不联网、不启动进程/.test(note)));
-      assert.equal(
-        failed.notes.some((note) => /Read-only worker/.test(note)),
-        false,
-      );
-    });
-  });
-
   it('keeps the generated research report bounded and source-grounded', async () => {
     await withWorkspace(async (workspaceRoot) => {
       for (let index = 0; index < 20; index++) {

--- a/packages/runtime/src/__tests__/goal-evaluator.test.ts
+++ b/packages/runtime/src/__tests__/goal-evaluator.test.ts
@@ -1,19 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildGoalEvaluationPrompt, parseGoalEvaluation, evaluateGoal } from '../goal-evaluator.js';
-
-describe('buildGoalEvaluationPrompt', () => {
-  test('includes condition, context, and field spec', () => {
-    const p = buildGoalEvaluationPrompt('all tests pass', 'ran tests, 2 failed');
-    assert.ok(p.includes('all tests pass'));
-    assert.ok(p.includes('ran tests, 2 failed'));
-    assert.ok(p.includes('GOAL CONDITION'));
-    assert.ok(p.includes('CONVERSATION CONTEXT'));
-    assert.ok(p.includes('"met"'));
-    assert.ok(p.includes('"progress"'));
-    assert.ok(p.includes('"waiting"'));
-  });
-});
+import { parseGoalEvaluation, evaluateGoal } from '../goal-evaluator.js';
 
 describe('parseGoalEvaluation', () => {
   test('parses a full verdict', () => {

--- a/packages/runtime/src/__tests__/tool-availability.test.ts
+++ b/packages/runtime/src/__tests__/tool-availability.test.ts
@@ -213,14 +213,6 @@ describe('ToolAvailabilityRuntime — connector shape', () => {
     return found!;
   }
 
-  test('lists every group in its description and never requires permission', () => {
-    const c = connector();
-    assert.match(c.description, /rive/);
-    assert.match(c.description, /docs/);
-    assert.match(c.description, /Rive/); // rive group's label
-    assert.match(c.description, /Document tools/); // docs group's description
-  });
-
   test('loading a group returns exactly its tool names — a thin result, no schema', async () => {
     const result = await connector().impl({ group: 'docs' }, ctx);
     assert.deepEqual(result, { loaded: ['docs_edit', 'docs_read'] });


### PR DESCRIPTION
## Summary
- remove tests that only pin localized copy, labels, tool descriptions, and prompt wording
- remove one expensive ExploreAgent localization-only scenario
- retain command boundaries, state-machine behavior, security checks, and interaction contracts

## Validation
- `npx biome check` on all changed files
- `git diff --check`
- removed-import/reference audit

No full test suite was run; CI owns broad coverage.