### PR TITLE
test(runtime): remove tool metadata checks

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -768,22 +768,6 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
     assert.equal(b.role, 'tool');
   });
 
-  test('tool_start maps its semantic activity kind into runtime state', () => {
-    const event = mapSessionEventToRuntimeEvent(
-      ev({
-        type: 'tool_start',
-        toolUseId: 'tu-kind',
-        toolName: 'CustomCommand',
-        activityKind: 'command',
-        args: {},
-      }),
-      ctx,
-      createSessionEventMapMemory(),
-    );
-
-    assert.equal(event.actions?.stateDelta?.activityKind, 'command');
-  });
-
   test('tool activity mapping retains nested CodeMode replay and parent identity', () => {
     const memory = createSessionEventMapMemory();
     const start = mapSessionEventToRuntimeEvent(

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -48,73 +48,7 @@ const ONE_PIXEL_PNG = Buffer.from(
   'base64',
 );
 
-describe('builtin tool activity kinds', () => {
-  test('declares stable semantic categories independently of tool names', () => {
-    const kinds = Object.fromEntries(
-      buildBuiltinTools().map((tool) => [tool.name, tool.activityKind]),
-    );
-
-    expect(kinds).toEqual({
-      Bash: 'command',
-      Read: 'read',
-      apply_patch: 'edit',
-      Write: 'edit',
-      Edit: 'edit',
-      FormatJson: 'edit',
-      Glob: 'search',
-      Grep: 'search',
-    });
-  });
-
-  test('categorizes background task controls as command activity', () => {
-    const shellRuns = {
-      runForegroundBash: () => Promise.reject(new Error('not used')),
-      runBackgroundBash: () => Promise.reject(new Error('not used')),
-    } satisfies ShellRunLauncher;
-    const backgroundTasks = {
-      stopBackgroundTask: () => Promise.reject(new Error('not used')),
-    } satisfies BackgroundTaskStopper;
-    const ptyControls = {
-      writeStdin: () => Promise.reject(new Error('not used')),
-    } satisfies PtyControlWriter;
-    const kinds = Object.fromEntries(
-      buildBuiltinTools({
-        shellRuns,
-        backgroundTasks,
-        ptyControls,
-      }).map((tool) => [tool.name, tool.activityKind]),
-    );
-
-    expect(kinds.Bash).toBe('command');
-    expect(kinds.StopBackgroundTask).toBe('command');
-    expect(kinds.WriteStdin).toBe('command');
-  });
-
-  test('can omit Edit from a host surface that has no filesystem worker', () => {
-    const tools = buildBuiltinTools({ includeEdit: false } as Parameters<
-      typeof buildBuiltinTools
-    >[0]);
-
-    assert.equal(
-      tools.some((tool) => tool.name === 'Edit'),
-      false,
-    );
-    assert.ok(tools.some((tool) => tool.name === 'Write'));
-  });
-
-  test('includes apply_patch when a custom workspace exposes the capability', () => {
-    const tools = buildBuiltinTools({
-      executor: fakeExecutor({
-        applyPatch: async ({ path }) => ({ ok: true, path }),
-      }),
-    });
-
-    assert.equal(
-      tools.some((tool) => tool.name === 'apply_patch'),
-      true,
-    );
-  });
-
+describe('builtin apply_patch', () => {
   test('applies a freeform V4A patch through the existing filesystem authority', async () => {
     const calls: Array<{
       action: string;
@@ -325,22 +259,6 @@ describe('builtin tool activity kinds', () => {
   });
 });
 
-describe('builtin Read capabilities', () => {
-  test('advertises image support only when image snapshots are available', () => {
-    const textOnly = buildBuiltinTools().find((tool) => tool.name === 'Read')!;
-    const withImages = buildBuiltinTools({
-      snapshotImage: async (input) => ({
-        kind: 'session_file',
-        sessionId: input.sessionId,
-        relativePath: 'image-1',
-      }),
-    }).find((tool) => tool.name === 'Read')!;
-
-    assert.doesNotMatch(textOnly.description, /image/);
-    assert.match(withImages.description, /image/);
-  });
-});
-
 describe('builtin ArchiveRead capabilities', () => {
   test('is not a built-in tool', () => {
     // The archive decoder travels with the archive capability and is bound by
@@ -370,7 +288,7 @@ describe('builtin tool executor facts', () => {
   });
 });
 
-describe('builtin Bash description declares the executing shell', () => {
+describe('builtin Bash projection and shell execution', () => {
   test('executor Bash keeps its durable command out of provider-facing results', async () => {
     const bash = buildBuiltinTools({
       executor: fakeExecutor({
@@ -426,17 +344,6 @@ describe('builtin Bash description declares the executing shell', () => {
         '-NoLogo -NoProfile -NonInteractive -Command echo wired-marker\n',
       ),
     ).toBe(true);
-  });
-
-  test('executor Bash tells the model commands run under PowerShell 7', () => {
-    const tools = buildBuiltinTools({
-      executor: fakeExecutor({ facts: LOCAL_WORKSPACE_EXECUTOR_FACTS }),
-      shell: { kind: 'pwsh', displayName: 'PowerShell 7 (pwsh)', exe: 'C:\\pf\\pwsh.exe' },
-    });
-    const bash = tools.find((tool) => tool.name === 'Bash');
-    expect(bash !== undefined).toBe(true);
-    expect(/PowerShell 7 \(pwsh\)/.test(bash!.description)).toBe(true);
-    expect(/git ls-files/.test(bash!.description)).toBe(true);
   });
 });
 

--- a/packages/runtime/src/__tests__/request-shape.test.ts
+++ b/packages/runtime/src/__tests__/request-shape.test.ts
@@ -53,11 +53,6 @@ describe('canonicalizeToolSet active allow-list', () => {
     assert.ok(names.includes('invalid'), 'repair target present in providerTools');
     assert.ok(!activeTools.includes('invalid'), 'invalid is never advertised to the model');
   });
-
-  test('omitting the active set advertises every visible tool (full surface), names sorted', () => {
-    const { activeTools } = canonicalizeToolSet([tool('Write'), tool('Read')], invalid);
-    assert.deepEqual(activeTools, ['Read', 'Write']);
-  });
 });
 
 describe('diagnostics measure the provider-visible (active) tool subset', () => {

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -14,29 +14,6 @@ const pwshPlan: ShellPlan = {
   exe: 'C:\\pf\\pwsh.exe',
 };
 
-describe('Bash tool description declares the executing shell', () => {
-  test('foreground and background variants declare command activity', () => {
-    assert.equal(buildLocalForegroundBashTool().activityKind, 'command');
-    assert.equal(buildManagedBashTool(fakeShellRuns()).activityKind, 'command');
-  });
-
-  test('foreground tool tells the model commands run under PowerShell 7', () => {
-    const tool = buildLocalForegroundBashTool({ shell: pwshPlan });
-    assert.match(tool.description, /PowerShell 7 \(pwsh\)/);
-    assert.match(tool.description, /PowerShell syntax/);
-    assert.match(tool.description, /git ls-files/);
-    assert.match(tool.description, /node_modules/);
-    assert.match(tool.description, /Subject to permission policy\.$/);
-  });
-
-  test('background tool tells the model commands run under PowerShell 7', () => {
-    const tool = buildManagedBashTool(fakeShellRuns(), { shell: pwshPlan });
-    assert.match(tool.description, /PowerShell 7 \(pwsh\)/);
-    assert.match(tool.description, /git ls-files/);
-    assert.match(tool.description, /run_in_background=true/);
-  });
-});
-
 describe('Bash tool shell is threaded through to execution, not just the description', () => {
   test('foreground tool executes with the same shell it declares', async () => {
     // /bin/echo stands in for pwsh.exe: if the tool's shell reaches the

--- a/packages/runtime/src/__tests__/tool-availability.test.ts
+++ b/packages/runtime/src/__tests__/tool-availability.test.ts
@@ -65,28 +65,6 @@ function loadStep(group: string): StepLike {
   return { toolCalls: [{ toolName: LOAD_TOOLS_NAME, input: { group } }] };
 }
 
-describe('ToolAvailabilityRuntime — full mode', () => {
-  test('economy off advertises every tool, no connector / gating / diagnostics', () => {
-    const plan = runtime(false).prepare([]);
-    assert.ok(
-      plan.activeTools.includes('rive_run'),
-      'grouped tools are active when economy is off',
-    );
-    assert.ok(plan.activeTools.includes('docs_edit'));
-    assert.ok(!plan.activeTools.includes(LOAD_TOOLS_NAME), 'no connector in full mode');
-    assert.equal(plan.projectActiveTools, undefined);
-    assert.equal(plan.gating, undefined);
-    assert.equal(plan.diagnostics([], 0), undefined);
-  });
-
-  test('economy on but no hideable groups falls back to full mode', () => {
-    const r = new ToolAvailabilityRuntime([tool('Read')], { economy: true }, invalid);
-    const plan = r.prepare([]);
-    assert.equal(plan.gating, undefined, 'nothing to hide → no gating');
-    assert.ok(plan.activeTools.includes('Read'));
-  });
-});
-
 describe('ToolAvailabilityRuntime — economy mode', () => {
   test('only ungrouped tools + connector are active at step 0; group tools hidden', () => {
     const plan = runtime(true).prepare([]);


### PR DESCRIPTION
## Summary
- remove tests that mirror built-in tool activity categories and descriptions
- remove default/full-mode happy paths already implied by risk-owning economy and execution coverage
- remove a redundant one-field event projection check
- retain executor isolation facts, sandbox schemas, path containment, shell execution, and provider-facing redaction contracts

## Validation
- `npx biome check` on all changed test files
- `git diff --check`
- removed-import/reference audit

No test suite was run; CI owns broad execution.