### PR TITLE
test: remove duplicate ownership checks

### DIFF
--- a/apps/desktop/src/main/__tests__/permission-mode-default.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-mode-default.test.ts
@@ -5,12 +5,9 @@
  * so main.ts resolves the configured `chatDefaults.permissionMode` here at
  * create time.
  *
- * The two guarantees pinned here (and previously only asserted as a source-grep
- * contract on main.ts):
- *   1. The configured default is returned verbatim (Auto / Bypass).
- *   2. Session creation never fails because settings.json is unreadable — the
- *      store's get() rethrows anything but ENOENT, so a corrupted file must
- *      fall back to the safest mode, not reject the create path.
+ * The guarantees pinned here are the non-default configured mode and failure
+ * behavior. Session creation never fails because settings.json is unreadable:
+ * a corrupted file falls back to the safest mode instead of rejecting create.
  */
 
 import { strict as assert } from 'node:assert';
@@ -20,13 +17,6 @@ import { createDefaultSettings } from '@maka/core/settings';
 import { resolveDefaultPermissionMode } from '../permission-mode-default.js';
 
 describe('resolveDefaultPermissionMode', () => {
-  it('returns the configured chatDefaults.permissionMode', async () => {
-    const settings = createDefaultSettings();
-    settings.chatDefaults.permissionMode = 'ask';
-    const mode = await resolveDefaultPermissionMode(async () => settings);
-    assert.equal(mode, 'ask');
-  });
-
   it('returns bypass when that is the configured default (no special-casing)', async () => {
     const settings = createDefaultSettings();
     settings.chatDefaults.permissionMode = 'bypass';
@@ -39,11 +29,6 @@ describe('resolveDefaultPermissionMode', () => {
       throw new Error("simulated settingsStore.get() rethrow (non-ENOENT)");
     };
     const mode = await resolveDefaultPermissionMode(readFailingSettings);
-    assert.equal(mode, 'ask');
-  });
-
-  it('defaults to ask via createDefaultSettings when no value is configured', async () => {
-    const mode = await resolveDefaultPermissionMode(async () => createDefaultSettings());
     assert.equal(mode, 'ask');
   });
 });

--- a/apps/desktop/src/main/__tests__/quote-companion-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-cleanup.test.ts
@@ -165,37 +165,6 @@ describe('quote companion cleanup authority', () => {
     assert.deepEqual(await readPendingIds(workspaceRoot), []);
   });
 
-  it('upgrades pending cleanup rows written by the previous schema', async () => {
-    const workspaceRoot = await createWorkspace();
-    const database = new DatabaseSync(join(workspaceRoot, 'runtime.sqlite'));
-    try {
-      database.exec(`
-        CREATE TABLE workflow_quote_companion_cleanup (
-          session_id TEXT PRIMARY KEY,
-          tracked_at INTEGER NOT NULL
-        );
-        INSERT INTO workflow_quote_companion_cleanup(session_id, tracked_at)
-        VALUES ('fork-before-lease-schema', 1);
-      `);
-    } finally {
-      database.close();
-    }
-    const removed: string[] = [];
-    const authority = createSessionCopyCleanupAuthority({
-      workspaceRoot,
-      processId: 'process-current',
-      removeSession: async (sessionId) => {
-        removed.push(sessionId);
-      },
-    });
-
-    assert.deepEqual(await authority.recover(), {
-      removed: ['fork-before-lease-schema'],
-      failed: [],
-    });
-    assert.deepEqual(removed, ['fork-before-lease-schema']);
-  });
-
   it('acknowledges abandon after the intent is durable without waiting for removal', async () => {
     const workspaceRoot = await createWorkspace();
     let releaseRemoval: (() => void) | undefined;

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -2,26 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { RetryError } from 'ai';
 
-import { lowerModelTools, ModelAdapter, normalizeAiSdkUsage } from '../model-adapter.js';
+import { ModelAdapter, normalizeAiSdkUsage } from '../model-adapter.js';
 import type { ModelStreamEvent } from '../model-protocol.js';
 
 describe('ModelAdapter stream and error normalization', () => {
-  test('lowers apply_patch to the client-executed OpenAI provider tool', () => {
-    const tools = lowerModelTools({
-      apply_patch: { kind: 'provider', providerTool: { kind: 'openai-apply-patch' } },
-    });
-
-    assert.deepEqual(
-      {
-        type: (tools.apply_patch as { type?: unknown }).type,
-        id: (tools.apply_patch as { id?: unknown }).id,
-        isProviderExecuted: (tools.apply_patch as { isProviderExecuted?: unknown })
-          .isProviderExecuted,
-      },
-      { type: 'provider', id: 'openai.apply_patch', isProviderExecuted: false },
-    );
-  });
-
   test('resolves optional-key LocalAI without fabricating a credential', () => {
     const model = {};
     let observedApiKey: string | undefined;

--- a/packages/runtime/src/__tests__/tool-runtime-settlement.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-settlement.test.ts
@@ -11,29 +11,6 @@ import { buildForegroundBashTool, buildManagedBashTool } from '../shell-tools.js
 import { ToolRuntime, type MakaTool, type ToolRuntimeInput } from '../tool-runtime.js';
 
 describe('ToolRuntime settlement', () => {
-  it('returns the raw result and provider-facing model output', async () => {
-    const runtime = makeRuntime();
-    const result = { ok: true, value: 42 };
-
-    const settlement = await runtime.settleToolCall({
-      tool: tool(() => result),
-      turnId: 'turn-1',
-      stepId: 'step-1',
-      toolCallId: 'call-1',
-      input: {},
-      abortSignal: new AbortController().signal,
-      eventSink: {
-        push: () => {},
-        pushAndWaitUntilConsumed: async () => {},
-      },
-    });
-
-    assert.deepEqual(settlement, {
-      result,
-      modelOutput: { type: 'json', value: result },
-    });
-  });
-
   it('requires the bypass boundary before dispatching Client Capability tools', async () => {
     let calls = 0;
     const clientTool: MakaTool = {

--- a/packages/ui/src/__tests__/turn-size-index.test.ts
+++ b/packages/ui/src/__tests__/turn-size-index.test.ts
@@ -2,7 +2,6 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
   createTurnSizeIndex,
-  layoutKeyFor,
   layoutKeyOf,
   measureSettledGeometry,
   measureTurnGeometry,
@@ -34,7 +33,6 @@ function fakeRoot(options: {
 }
 
 describe('createTurnSizeIndex', () => {
-
   it('drops the oldest session past capacity', () => {
     const index = createTurnSizeIndex(2);
     index.record('s1', 'k', geometry({ a: 1 }));
@@ -44,14 +42,10 @@ describe('createTurnSizeIndex', () => {
     assert.ok(index.lookup('s2', 'k'));
     assert.ok(index.lookup('s3', 'k'));
   });
-
-
 });
 
 describe('prefixHeightFor', () => {
   const ids = ['a', 'b', 'c', 'd'];
-
-
 
   it('is undefined when any prefix turn lacks a height', () => {
     assert.equal(prefixHeightFor(ids, 2, geometry({ a: 100 })), undefined);
@@ -64,16 +58,11 @@ describe('prefixHeightFor', () => {
   });
 });
 
-describe('layoutKeyOf', () => {
-
-});
-
 describe('measureSettledGeometry', () => {
   const turns = [
     { id: 'a', top: 0, height: 100 },
     { id: 'b', top: 104, height: 200 },
   ];
-
 
   it('aborts when the layout moved since the key was captured', () => {
     const before = layoutKeyOf(fakeRoot({ width: 900 }));
@@ -94,11 +83,9 @@ describe('measureSettledGeometry', () => {
       assert.equal(attempt.geometry.gap, 4);
     }
   });
-
 });
 
 describe('measureTurnGeometry', () => {
-
   it('records heights and the median between-turn gap', () => {
     const record = measureTurnGeometry([
       { turnId: 'a', top: 0, height: 100 },


### PR DESCRIPTION
## Summary
- remove previous-schema cleanup coverage that no longer represents a supported contract
- remove duplicate apply_patch lowering and default settlement happy paths already owned by wire/materialization tests
- retain the permission-mode regression while dropping default-value mirrors
- clean orphaned test scaffolding in turn-size-index

## Validation
- `npx biome check` on changed files
- `git diff --check`
- reference and removed-test-title audit

No test suite run; CI owns execution.