### PR TITLE
test: remove shape and metadata mirrors

### DIFF
--- a/apps/desktop/src/main/__tests__/browser-view-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-view-manager.test.ts
@@ -56,14 +56,6 @@ describe('BrowserViewManager', () => {
     assert.deepEqual(liveSets, [['s1'], ['s1', 's2'], ['s2']]);
   });
 
-  it('setViewport forwards to the view and no-ops when absent', () => {
-    const { manager } = makeManager();
-    manager.setViewport('missing', { x: 0, y: 0, width: 1, height: 1 }); // no throw
-    const v = manager.getOrCreate('s1');
-    manager.setViewport('s1', { x: 1, y: 2, width: 3, height: 4 });
-    assert.deepEqual(v.rect, { x: 1, y: 2, width: 3, height: 4 });
-  });
-
   it('hideAllExcept hides every other view and leaves the kept one untouched', () => {
     const { manager } = makeManager();
     const a = manager.getOrCreate('s1');

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -11,7 +11,6 @@ import {
 import { INTERACTION_ID_MAX_BYTES, INTERACTION_TOOL_NAME_MAX_BYTES } from '../interaction.js';
 import {
   TERMINAL_RUNTIME_EVENT_STATUSES,
-  createRuntimeEventId,
   decodePersistedRuntimeEvent,
   decodeRuntimeEvent,
   isTerminalRuntimeEvent,
@@ -716,24 +715,6 @@ describe('runtimeEventHasModelVisibleContent', () => {
       baseEvent({ refs: { toolCallId: 'tc-1' } }),
     ];
     for (const event of hidden) expect(runtimeEventHasModelVisibleContent(event)).toBe(false);
-  });
-});
-
-describe('createRuntimeEventId', () => {
-  test('honors the prefix and returns a string', () => {
-    const id = createRuntimeEventId('turn');
-    expect(typeof id).toBe('string');
-    expect(id.startsWith('turn_')).toBe(true);
-  });
-
-  test('uses the default prefix when none is given', () => {
-    expect(createRuntimeEventId().startsWith('rt-event_')).toBe(true);
-  });
-
-  test('never collides within a process', () => {
-    const ids = new Set<string>();
-    for (let i = 0; i < 500; i += 1) ids.add(createRuntimeEventId());
-    expect(ids.size).toBe(500);
   });
 });
 

--- a/packages/runtime/src/__tests__/deep-research-tools.test.ts
+++ b/packages/runtime/src/__tests__/deep-research-tools.test.ts
@@ -108,26 +108,6 @@ async function withTempRoot(fn: (root: string) => Promise<void>): Promise<void> 
 }
 
 describe('Deep Research runtime tools', () => {
-  it('exposes eight Maka-owned local workspace tools', () => {
-    const tools = buildDeepResearchTools({
-      store: createSqliteDeepResearchStore('/tmp/maka-unused-deep-research'),
-      artifactStore: new FakeArtifactStore(),
-    });
-    assert.deepEqual(
-      tools.map((tool) => tool.name),
-      [
-        DEEP_RESEARCH_START_TOOL_NAME,
-        DEEP_RESEARCH_SAVE_ARTIFACT_TOOL_NAME,
-        DEEP_RESEARCH_READ_ARTIFACT_TOOL_NAME,
-        DEEP_RESEARCH_UPDATE_CHECKLIST_TOOL_NAME,
-        DEEP_RESEARCH_RECORD_STEP_TOOL_NAME,
-        DEEP_RESEARCH_CHECKPOINT_TOOL_NAME,
-        DEEP_RESEARCH_STATUS_TOOL_NAME,
-        DEEP_RESEARCH_COMPLETE_TOOL_NAME,
-      ],
-    );
-  });
-
   it('admits only the explicit Deep Research tool surface', () => {
     const canonicalNames = [
       DEEP_RESEARCH_START_TOOL_NAME,

--- a/packages/runtime/src/__tests__/explore-agent-tool.test.ts
+++ b/packages/runtime/src/__tests__/explore-agent-tool.test.ts
@@ -6,18 +6,6 @@ import { tmpdir } from 'node:os';
 import { buildExploreAgentTool, runReadOnlyExplore } from '../explore-agent-tool.js';
 
 describe('ExploreAgent read-only worker', () => {
-  it('exposes a categorized read-only subagent tool', () => {
-    const tool = buildExploreAgentTool();
-    assert.equal(tool.name, 'ExploreAgent');
-    assert.equal(tool.categoryHint, 'subagent');
-    assert.match(tool.description, /read-only/);
-    assert.match(tool.description, /never writes/);
-    assert.match(tool.description, /Do not use it for one known file/);
-    assert.match(tool.description, /1-3 obvious files/);
-    assert.ok('ignorePaths' in (tool.parameters as { shape: Record<string, unknown> }).shape);
-    assert.ok('stoppingCondition' in (tool.parameters as { shape: Record<string, unknown> }).shape);
-  });
-
   it('returns source-grounded matches without absolute paths', async () => {
     await withWorkspace(async (workspaceRoot) => {
       await mkdir(join(workspaceRoot, 'src'), { recursive: true });

--- a/packages/runtime/src/__tests__/goal-tools.test.ts
+++ b/packages/runtime/src/__tests__/goal-tools.test.ts
@@ -51,21 +51,6 @@ function makeTools(getTokenCount?: (s: string) => number) {
 }
 
 describe('goal tools', () => {
-  test('exposes 5 tools', () => {
-    const { tools } = makeTools();
-    const names = tools.map((t) => t.name).sort();
-    assert.deepEqual(
-      names,
-      [
-        GOAL_CLEAR_TOOL_NAME,
-        GOAL_PAUSE_TOOL_NAME,
-        GOAL_RESUME_TOOL_NAME,
-        GOAL_SET_TOOL_NAME,
-        GOAL_STATUS_TOOL_NAME,
-      ].sort(),
-    );
-  });
-
   test('GoalSet creates a goal with custom limits', async () => {
     const { mgr, tools } = makeTools();
     const set = findTool(tools, GOAL_SET_TOOL_NAME);


### PR DESCRIPTION
## Summary
- remove tool-count and tool-name snapshots already exercised by behavior and capability-boundary tests
- remove ExploreAgent description/metadata copy assertions while retaining filesystem and read-only behavior coverage
- remove trivial RuntimeEvent id implementation mirrors and BrowserView forwarding coverage

## Validation
- `npx biome check` on changed files
- `git diff --check`
- removed-test-title and stale-reference audit

No test suite run; CI owns execution.