### PR TITLE
test: remove prompt and wrapper snapshots

### DIFF
--- a/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
+++ b/apps/desktop/src/main/__tests__/rive-workflow-tool.test.ts
@@ -10,20 +10,10 @@ import {
 } from '../rive-cli.js';
 import {
   buildRiveWorkflowTool,
-  RIVE_WORKFLOW_TOOL_NAME,
   type RiveWorkflowToolResult,
 } from '../rive-workflow-tool.js';
 
 describe('RiveWorkflow tool and CLI bridge', { concurrency: false }, () => {
-  it('registers as a categorized custom MakaTool', () => {
-    const tool = buildRiveWorkflowTool();
-    assert.equal(tool.name, RIVE_WORKFLOW_TOOL_NAME);
-    assert.equal(tool.displayName, 'Rive 工作流');
-    assert.equal(tool.categoryHint, 'custom_tool');
-    assert.match(tool.description, /Rive remains the source of truth/);
-    assert.ok('action' in ((tool.parameters as { shape: Record<string, unknown> }).shape));
-  });
-
   it('builds shell-free argv for high-level workflow commands', () => {
     assert.deepEqual(buildRiveCommand({
       action: 'workflow_run',

--- a/packages/core/src/__tests__/explore-agent.test.ts
+++ b/packages/core/src/__tests__/explore-agent.test.ts
@@ -4,7 +4,6 @@ import {
   DEEP_RESEARCH_IMPLEMENTATION_PROMPT_MAX_CHARS,
   DEEP_RESEARCH_SESSION_LABEL,
   buildDeepResearchImplementationPrompt,
-  buildDeepResearchSystemPromptFragment,
   isDeepResearchSession,
 } from '../explore-agent.js';
 import type { DeepResearchRun } from '../deep-research-run.js';
@@ -72,25 +71,5 @@ describe('deep research session profile', () => {
       entries: [{ kind: 'special', access: 'read', special: ':workspace_roots' }],
     });
     assert.equal(boundary.profile.network.kind, 'restricted');
-  });
-
-  it('keeps the system prompt source-grounded, read-only, and explicit about its write exception', () => {
-    const prompt = buildDeepResearchSystemPromptFragment();
-    for (const contract of [
-      /Read, Glob, Grep/,
-      /Do not write/,
-      /deep_research_\* tools are the one write exception/,
-      /archive each important raw source first/,
-      /all five report sections are completed/,
-      /role=handoff artifact/,
-      /borrow \/ diverge \/ risk \/ gate/,
-    ]) {
-      assert.match(prompt, contract);
-    }
-    assert.match(prompt, /ExploreAgent/);
-    assert.doesNotMatch(
-      buildDeepResearchSystemPromptFragment({ exploreAgentAvailable: false }),
-      /ExploreAgent/,
-    );
   });
 });

--- a/packages/runtime/src/__tests__/builtin-tools-file-worker.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools-file-worker.test.ts
@@ -31,14 +31,6 @@ describe('builtin file tools use the sandboxed worker', () => {
     );
   });
 
-  test('uses a sandboxed worker without one-call permission metadata', () => {
-    const linuxTools = buildBuiltinTools({
-      filesystemWorker: { execute: async () => ({ kind: 'read', content: '' }) },
-      sandboxPlatform: 'linux',
-    });
-    assert.ok(linuxTools.find((tool) => tool.name === 'Write'));
-  });
-
   for (const kind of ['bypass', 'external'] as const) {
     test(`uses the host filesystem path for an authoritative ${kind} boundary`, async () => {
       const cwd = await temporaryDirectory(`maka-file-${kind}-`);

--- a/packages/runtime/src/__tests__/tool-availability.test.ts
+++ b/packages/runtime/src/__tests__/tool-availability.test.ts
@@ -125,14 +125,11 @@ describe('ToolAvailabilityRuntime — economy mode', () => {
     assert.ok(plan.gating!.activeNames().has('rive_run'), 'snapshot updated after rive load');
   });
 
-  test('connector impl returns the group tool names; unknown group throws', async () => {
+  test('connector rejects an unknown group', async () => {
     const connector = runtime(true)
       .prepare([])
       .providerTools.find((t) => t.name === LOAD_TOOLS_NAME);
     assert.ok(connector);
-    assert.deepEqual(await connector!.impl({ group: 'docs' }, ctx), {
-      loaded: ['docs_edit', 'docs_read'],
-    });
     await assert.rejects(async () => connector!.impl({ group: 'nope' }, ctx), /Unknown tool group/);
   });
 });
@@ -179,25 +176,6 @@ describe('ToolAvailabilityRuntime — diagnostics', () => {
     const d = plan.diagnostics(active, 100);
     assert.deepEqual(d!.enabledSourceIds, ['rive']);
     assert.deepEqual(d!.availableSourceIds, ['docs']);
-  });
-});
-
-describe('ToolAvailabilityRuntime — connector shape', () => {
-  function connector() {
-    const found = runtime(true)
-      .prepare([])
-      .providerTools.find((t) => t.name === LOAD_TOOLS_NAME);
-    assert.ok(found);
-    return found!;
-  }
-
-  test('loading a group returns exactly its tool names — a thin result, no schema', async () => {
-    const result = await connector().impl({ group: 'docs' }, ctx);
-    assert.deepEqual(result, { loaded: ['docs_edit', 'docs_read'] });
-    const keys = Object.keys(result as object);
-    assert.ok(
-      !keys.includes('schema') && !keys.includes('parameters') && !keys.includes('inputSchema'),
-    );
   });
 });
 


### PR DESCRIPTION
## Summary
- remove Deep Research system-prompt wording assertions while retaining enforced sandbox and completed-run boundaries
- remove Rive and builtin-tool registration metadata mirrors while retaining execution/error/security coverage
- collapse duplicate `load_tools` success-shape tests into the single invalid-group behavior check

## Validation
- `npx biome check` on changed files
- `git diff --check`
- stale-reference and removed-test-title audit

No test suite run; CI owns execution.