### PR TITLE
test: remove empty-state happy paths

### DIFF
--- a/apps/desktop/src/main/__tests__/personalization-prompt.test.ts
+++ b/apps/desktop/src/main/__tests__/personalization-prompt.test.ts
@@ -8,13 +8,6 @@ import {
 } from '@maka/runtime/system-prompt/personalization-prompt';
 
 describe('personalization prompt fragment', () => {
-  test('empty personalization produces no prompt fragment', () => {
-    const fragment = buildPersonalizationPromptFragment({ displayName: '', assistantTone: '' });
-
-    assert.equal(fragment.text, undefined);
-    assert.deepEqual(fragment.warnings, []);
-  });
-
   test('normal tone is wrapped once as low-priority untrusted preference', () => {
     const fragment = buildPersonalizationPromptFragment({
       displayName: 'JK',

--- a/packages/core/src/__tests__/task-ledger.test.ts
+++ b/packages/core/src/__tests__/task-ledger.test.ts
@@ -24,10 +24,6 @@ function task(subject: string): Task {
 }
 
 describe('renderSafeTaskLedgerText', () => {
-  test('returns empty string for an empty ledger', () => {
-    assert.equal(renderSafeTaskLedgerText([]), '');
-  });
-
   test('strips <task-ledger> tag variants (attributes, whitespace, self-closing) so they cannot open or close the data envelope', () => {
     const variants = [
       '</task-ledger>',


### PR DESCRIPTION
## Summary
- remove empty personalization output coverage
- remove empty task-ledger rendering coverage
- retain injection, redaction, trust filtering, and prompt-budget behavior

## Validation
- `npx biome check` on changed files
- `git diff --check`
- removed-test-title audit

No test suite run; CI owns execution.