### PR TITLE
test: remove mirror and presentation-only cases

### DIFF
--- a/packages/core/src/__tests__/computer-use.test.ts
+++ b/packages/core/src/__tests__/computer-use.test.ts
@@ -1,49 +1,13 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { expect } from '../test-helpers.js';
-import { ACTION_APPROVAL_STATES } from '../capabilities.js';
 import {
-  COMPUTER_USE_DISPATCH_TIERS,
-  COMPUTER_USE_ERROR_CODES,
   computerUseApprovalScopeKey,
   computerUseApprovalSummary,
   computerUseModelCallArgs,
-  isComputerUseErrorCode,
 } from '../computer-use.js';
 
 describe('Computer Use foundation contract', () => {
-  test('capability vocabulary can describe scoped approval leases', () => {
-    expect(ACTION_APPROVAL_STATES.includes('required_scoped_lease')).toBe(true);
-  });
-
-  test('has no foreground dispatch tier', () => {
-    expect(COMPUTER_USE_DISPATCH_TIERS).toEqual([
-      'ax',
-      'semantic-background',
-      'coordinate-background',
-    ]);
-  });
-
-  test('includes lifecycle and unknown-outcome errors', () => {
-    for (const code of [
-      'reobserve_required',
-      'permission_pending',
-      'policy_denied',
-      'policy_forbidden',
-      'no_active_session',
-      'ambiguous_target',
-      'screen_locked',
-      'blocked_url',
-      'user_stopped',
-      'service_unavailable',
-      'service_mismatch',
-      'outcome_unknown',
-    ]) {
-      expect(isComputerUseErrorCode(code)).toBe(true);
-      expect(COMPUTER_USE_ERROR_CODES.includes(code as never)).toBe(true);
-    }
-  });
-
   test('classifies read, screenshot, pointer, keyboard, and semantic approval', () => {
     expect(computerUseApprovalSummary({ action: 'list_apps' }).approvalClass).toBe('metadata_read');
     expect(

--- a/packages/core/src/__tests__/incognito.test.ts
+++ b/packages/core/src/__tests__/incognito.test.ts
@@ -1,16 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import {
-  defaultWorkspacePrivacyContext,
   isWorkspacePrivacyContext,
   validateWorkspacePrivacyContext,
 } from '../incognito.js';
 
 describe('workspace privacy context', () => {
-  it('defaults explicitly to non-incognito', () => {
-    assert.deepEqual(defaultWorkspacePrivacyContext(), { incognitoActive: false });
-  });
-
   it('accepts booleans and strips renderer-supplied authority fields', () => {
     assert.deepEqual(
       validateWorkspacePrivacyContext({

--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -7,7 +7,7 @@ import {
   resolveModelPdfSupport,
   resolveModelVisionSupport,
 } from '../model-metadata.js';
-import { PROVIDER_DEFAULTS, type ModelInfo, type ProviderType } from '../llm-connections.js';
+import type { ModelInfo, ProviderType } from '../llm-connections.js';
 
 describe('model-metadata vision capability', () => {
   it('treats a Claude newer than the generated snapshot as able to read images', () => {
@@ -85,43 +85,6 @@ describe('model-metadata vision capability', () => {
     );
   });
 
-  it('uses synchronized facts while preserving access-path overrides', () => {
-    const metadata = lookupModelMetadata('anthropic', 'claude-sonnet-4-5');
-    assert.equal(metadata.contextWindow, 200_000);
-    assert.equal(
-      lookupModelMetadata('anthropic', 'claude-sonnet-4-5-20250929').contextWindow,
-      200_000,
-    );
-    assert.deepEqual(metadata.thinkingOptions, {
-      toggle: true,
-      offBehavior: 'anthropic-thinking-disabled',
-    });
-  });
-
-  it('reports vision false for text-only models', () => {
-    assert.equal(lookupModelMetadata('deepseek', 'deepseek-chat').capabilities?.vision, false);
-    assert.equal(lookupModelMetadata('zai-coding-plan', 'glm-5.2').capabilities?.vision, false);
-    assert.equal(lookupModelMetadata('zai-coding-plan', 'glm-4.7').capabilities?.vision, false);
-  });
-
-  it('keeps Tencent Coding Plan text-only even when an upstream model supports vision elsewhere', () => {
-    const capabilities = lookupModelMetadata('tencent-coding-plan', 'kimi-k2.5').capabilities;
-    assert.equal(capabilities?.vision, false);
-    assert.equal(capabilities?.reasoning, true);
-    assert.equal(capabilities?.functionCalling, true);
-    assert.equal(
-      resolveModelVisionSupport('tencent-coding-plan', [{ id: 'kimi-k2.5' }], 'kimi-k2.5'),
-      false,
-    );
-  });
-
-  it('keeps complete metadata for every Codex subscription model alias', () => {
-    for (const modelId of PROVIDER_DEFAULTS['openai-codex'].fallbackModels) {
-      const metadata = lookupModelMetadata('openai-codex', modelId);
-      assert.ok(metadata.displayName);
-      assert.equal(metadata.capabilities?.vision, true);
-    }
-  });
 });
 
 describe('resolveModelVisionSupport', () => {

--- a/packages/runtime/src/__tests__/context-budget-model-facts.test.ts
+++ b/packages/runtime/src/__tests__/context-budget-model-facts.test.ts
@@ -31,29 +31,6 @@ test('invalid zero input limits do not disable the context-window fallback', () 
   assert.equal(resolveSelectedModelContextWindow(connection, undefined), 1_000);
 });
 
-test('access-path context windows remain authoritative for the real Codex models', () => {
-  const limits = [
-    ['gpt-5.5', 272_000],
-    ['gpt-5.6-sol', 372_000],
-  ] as const;
-
-  for (const [modelId, expected] of limits) {
-    assert.equal(
-      resolveSelectedModelContextWindow(
-        {
-          slug: 'openai-codex',
-          providerType: 'openai-codex',
-          defaultModel: modelId,
-          models: [{ id: modelId }],
-        },
-        undefined,
-      ),
-      expected,
-      `${modelId} must use its Codex access-path limit instead of the generated input limit`,
-    );
-  }
-});
-
 test('a relay user declaration remains ahead of runtime and static model facts', () => {
   const connection = {
     slug: 'relay',

--- a/packages/runtime/src/__tests__/task-ledger-tools.test.ts
+++ b/packages/runtime/src/__tests__/task-ledger-tools.test.ts
@@ -167,16 +167,6 @@ function findTool(tools: MakaTool[], name: string): MakaTool {
 }
 
 describe('task ledger tools', () => {
-  test('builds snake_case task tools by default, all local (no permission gate)', () => {
-    const tools = buildTaskLedgerTools({ store: new FakeTaskLedgerStore() });
-    assert.deepEqual(
-      tools.map((t) => t.name),
-      [TASK_CREATE_TOOL_NAME, TASK_UPDATE_TOOL_NAME, TASK_LIST_TOOL_NAME, TASK_GET_TOOL_NAME],
-    );
-    for (const tool of tools) {
-    }
-  });
-
   test('task tool feature flag defaults on and can be disabled explicitly', () => {
     assert.equal(isTaskLedgerToolsEnabled({}), true);
     assert.equal(isTaskLedgerToolsEnabled({ MAKA_TASK_LEDGER_TOOLS: 'false' }), false);

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup as renderReactToStaticMarkup } from 'react-dom/server';
-import { ToolCallDetail, ToolTrow } from '../tool-activity.js';
+import { ToolCallDetail } from '../tool-activity.js';
 import type { ToolActivityItem } from '../materialize.js';
 import { LocaleProvider } from '../locale-context.js';
 
@@ -13,71 +13,7 @@ function renderToStaticMarkup(node: ReactNode): string {
   }));
 }
 
-/** The collapsed row. Astryx owns its expansion, so detail asserts use ToolCallDetail. */
-function renderTool(item: ToolActivityItem): string {
-  return renderToStaticMarkup(createElement(ToolTrow, { items: [item] }));
-}
-
 describe('tool activity presentation', () => {
-  it('presents a command sandbox denial as blocked instead of failed', () => {
-    const item: ToolActivityItem = {
-      toolUseId: 'tool-sandbox-blocked',
-      toolName: 'Bash',
-      activityKind: 'command',
-      intent: '写入工作区外文件',
-      status: 'errored',
-      args: { command: 'printf blocked > ../outside.txt' },
-      result: {
-        kind: 'terminal',
-        cwd: '/tmp/maka',
-        cmd: 'printf blocked > ../outside.txt',
-        status: 'failed',
-        exitCode: 1,
-        output: pipeOutput('', 'Operation not permitted\n'),
-        sandboxDenial: {
-          likely: true,
-          backend: 'macos-seatbelt',
-          recovery: 'require_escalated',
-        },
-      },
-    };
-
-    // The row says "blocked", never "failed"; the raw stderr stays available to
-    // assistive tech via Astryx's errorMessage but is not the visible word.
-    const collapsed = renderTool(item);
-    assert.match(collapsed, /可能被沙箱阻止/);
-    assert.doesNotMatch(collapsed, /失败/);
-
-    const expanded = renderToStaticMarkup(createElement(ToolCallDetail, { item }));
-    assert.match(expanded, /可能被沙箱阻止/);
-    assert.match(expanded, /操作可能被沙箱阻止/);
-    assert.match(expanded, /失败前可能已经产生部分结果/);
-    assert.doesNotMatch(expanded, /因此未执行/);
-    assert.doesNotMatch(expanded, /工具调用失败/);
-  });
-
-  it('keeps an ordinary filesystem permission error as Astryx error detail, not a sandbox block', () => {
-    const markup = renderToStaticMarkup(createElement(ToolCallDetail, {
-      item: {
-        toolUseId: 'tool-filesystem-denied',
-        toolName: 'Read',
-        activityKind: 'read',
-        intent: '读取受限文件',
-        status: 'errored',
-        args: { path: '/workspace/private.txt' },
-        result: {
-          kind: 'text',
-          text: 'Filesystem access was denied.',
-        },
-      } satisfies ToolActivityItem,
-    }));
-
-    // Product: error text surfaces; sandbox copy must not fire for ordinary FS denial.
-    assert.match(markup, /Filesystem access was denied/);
-    assert.doesNotMatch(markup, /工具调用失败/);
-    assert.doesNotMatch(markup, /可能被沙箱阻止/);
-  });
-
   it('contains a malformed persisted terminal result instead of crashing the renderer', () => {
     const malformed = {
       kind: 'terminal',
@@ -125,58 +61,6 @@ describe('tool activity presentation', () => {
       );
       assert.match(markup, /redacted/i);
     }
-  });
-
-  it('renders a failed WriteStdin as operation metadata without its ShellRun panel', () => {
-    const markup = renderToStaticMarkup(createElement(ToolCallDetail, {
-      item: {
-        toolUseId: 'tool-pty-control',
-        toolName: 'WriteStdin',
-        activityKind: 'command',
-        status: 'errored',
-        args: {
-          ref: 'maka://runtime/background-tasks/pty-1',
-          inputPreview: { text: 'echo x\\n', bytes: 7, truncated: false },
-          size: { cols: 100, rows: 30 },
-        },
-        result: {
-          kind: 'shell_run',
-          ref: 'maka://runtime/background-tasks/pty-1',
-          mode: 'pty',
-          status: 'failed',
-          cwd: '/PRIVATE-CWD',
-          cmd: 'PRIVATE-COMMAND',
-          startedAt: 1,
-          updatedAt: 2,
-          completedAt: 2,
-          failureMessage: 'PRIVATE-FAILURE',
-          revision: 2,
-          output: {
-            mode: 'pty',
-            screen: 'PRIVATE-TERMINAL-FRAME',
-            scrollback: '',
-            cols: 100,
-            rows: 30,
-            cursor: { x: 0, y: 0, visible: true },
-            alternateScreen: false,
-            truncated: false,
-            redacted: false,
-          },
-          operation: {
-            kind: 'pty_control',
-            failed: true,
-            input: { bytes: 7, queued: false },
-            resize: { cols: 100, rows: 30, applied: true, changed: true },
-          },
-        },
-      } satisfies ToolActivityItem,
-    }));
-
-    assert.match(markup, /未输入：echo x\\n/);
-    assert.match(markup, /已调整为 100x30/);
-    assert.match(markup, /后台终端交互失败/);
-    assert.doesNotMatch(markup, /PRIVATE-CWD|PRIVATE-COMMAND|PRIVATE-FAILURE|PRIVATE-TERMINAL-FRAME/);
-    assert.equal((markup.match(/data-slot="tool-output"/g) ?? []).length, 0);
   });
 
   it('keeps pre-handoff live output when shell_run lands with empty streams', () => {
@@ -245,14 +129,3 @@ describe('tool activity presentation', () => {
     assert.equal(panels.length, 1);
   });
 });
-
-function pipeOutput(stdout = '', stderr = '') {
-  return {
-    mode: 'pipes' as const,
-    stdout,
-    stderr,
-    stdoutTruncated: false,
-    stderrTruncated: false,
-    redacted: false,
-  };
-}


### PR DESCRIPTION
## Summary

- remove static vocabulary and generated model-fact mirrors
- remove UI copy/presentation-only assertions while retaining redaction, corruption containment, and live-output coverage
- remove a default-value mirror and a task tool inventory test containing an empty loop

## Validation

- `npx biome check` on all changed files
- `git diff --check`
- reviewed removed cases by test ownership and retained security/data-integrity cases
- test suites intentionally deferred to CI