### PR TITLE
test(core): remove duplicate policy coverage

### DIFF
--- a/packages/core/src/__tests__/capabilities.test.ts
+++ b/packages/core/src/__tests__/capabilities.test.ts
@@ -24,28 +24,6 @@ describe('permission and capability snapshot contracts', () => {
     ).toBe('paused');
   });
 
-  test('unavailable feature is not_configured even when OS permission is granted', () => {
-    expect(
-      deriveCapabilityReadiness({
-        feature: { state: 'not_available', source: 'scaffold' },
-        configuration: presentConfig,
-        osPermissions: [requiredPermission('accessibility', 'granted')],
-        runtimeProbe: { state: 'healthy', source: 'runtime_probe' },
-      }),
-    ).toBe('not_configured');
-  });
-
-  test('partial feature stays not_configured until runtime probe reports degradation', () => {
-    expect(
-      deriveCapabilityReadiness({
-        feature: { state: 'partial', source: 'runtime', reason: 'local smoke only' },
-        configuration: presentConfig,
-        osPermissions: [requiredPermission('accessibility', 'granted')],
-        runtimeProbe: { state: 'not_run', source: 'runtime_probe' },
-      }),
-    ).toBe('not_configured');
-  });
-
   test('missing configuration is not_configured before runtime health', () => {
     expect(
       deriveCapabilityReadiness({
@@ -112,32 +90,6 @@ describe('permission and capability snapshot contracts', () => {
     expect(
       deriveCapabilityReadiness({
         feature: enabledFeature,
-        configuration: presentConfig,
-        osPermissions: [requiredPermission('accessibility', 'granted')],
-        runtimeProbe: { state: 'degraded', source: 'runtime_probe', reason: 'probe failed' },
-      }),
-    ).toBe('degraded');
-  });
-
-  test('unavailable runtime probe degrades an otherwise enabled capability', () => {
-    expect(
-      deriveCapabilityReadiness({
-        feature: enabledFeature,
-        configuration: presentConfig,
-        osPermissions: [requiredPermission('accessibility', 'granted')],
-        runtimeProbe: {
-          state: 'not_available',
-          source: 'runtime_probe',
-          reason: 'service exited',
-        },
-      }),
-    ).toBe('degraded');
-  });
-
-  test('degraded runtime probe still wins over partial feature copy', () => {
-    expect(
-      deriveCapabilityReadiness({
-        feature: { state: 'partial', source: 'runtime', reason: 'local smoke only' },
         configuration: presentConfig,
         osPermissions: [requiredPermission('accessibility', 'granted')],
         runtimeProbe: { state: 'degraded', source: 'runtime_probe', reason: 'probe failed' },

--- a/packages/core/src/__tests__/long-term-memory.test.ts
+++ b/packages/core/src/__tests__/long-term-memory.test.ts
@@ -1,44 +1,8 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import {
-  isMemoryItemKind,
-  isMemoryKeyType,
-  normalizeLongTermMemoryContent,
-  validateMemoryTemporalBounds,
-} from '../long-term-memory.js';
+import { validateMemoryTemporalBounds } from '../long-term-memory.js';
 
 describe('long-term memory contract', () => {
-  test('validates temporal bounds without deriving a relative status', () => {
-    assert.doesNotThrow(() =>
-      validateMemoryTemporalBounds({
-        temporalType: 'undated',
-        eventStartedAt: null,
-        eventEndedAt: null,
-      }),
-    );
-    assert.doesNotThrow(() =>
-      validateMemoryTemporalBounds({
-        temporalType: 'point',
-        eventStartedAt: 100,
-        eventEndedAt: null,
-      }),
-    );
-    assert.doesNotThrow(() =>
-      validateMemoryTemporalBounds({
-        temporalType: 'interval',
-        eventStartedAt: 100,
-        eventEndedAt: 200,
-      }),
-    );
-    assert.doesNotThrow(() =>
-      validateMemoryTemporalBounds({
-        temporalType: 'open_ended',
-        eventStartedAt: 100,
-        eventEndedAt: null,
-      }),
-    );
-  });
-
   test('fails closed over invalid temporal combinations', () => {
     assert.throws(
       () =>
@@ -67,12 +31,5 @@ describe('long-term memory contract', () => {
         }),
       /later than its start/,
     );
-  });
-
-  test('keeps provisional categories and key types closed', () => {
-    assert.equal(isMemoryItemKind('preference'), true);
-    assert.equal(isMemoryItemKind('misc'), false);
-    assert.equal(isMemoryKeyType('code'), true);
-    assert.equal(isMemoryKeyType('keyword'), false);
   });
 });

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -1,12 +1,6 @@
 import { describe, test } from 'node:test';
 import { expect } from '../test-helpers.js';
-import {
-  THEME_PALETTES,
-  createDefaultSettings,
-  isThemePalette,
-  mergeSettings,
-  normalizeSettings,
-} from '../settings.js';
+import { mergeSettings, normalizeSettings } from '../settings.js';
 
 test('normalizes user-approved subagent presets without widening the catalog', () => {
   const normalized = normalizeSettings({
@@ -57,50 +51,6 @@ test('normalizes user-approved subagent presets without widening the catalog', (
   ]);
 });
 
-test('delegates bot patches and persisted normalization to the bot settings owner', () => {
-  const current = createDefaultSettings();
-  Object.assign(current.botChat.channels.telegram, {
-    enabled: true,
-    token: 'live-token',
-    readiness: 'operational',
-  });
-
-  const normalized = normalizeSettings(
-    mergeSettings(current, {
-      botChat: {
-        channels: {
-          telegram: { token: '', allowedUserIds: [' 123 ', '456', '123', ''] },
-        },
-      },
-    }),
-  );
-  expect(normalized.botChat.channels.telegram.token).toBe('');
-  expect(normalized.botChat.channels.telegram.readiness).toBe('scaffolded');
-  expect(normalized.botChat.channels.telegram.allowedUserIds).toEqual(['123', '456']);
-});
-
-describe('appearance settings boundaries', () => {
-  test('validates, normalizes, and merges the palette as one closed vocabulary', () => {
-    for (const palette of THEME_PALETTES) {
-      expect(isThemePalette(palette)).toBe(true);
-      expect(normalizeSettings({ appearance: { theme: 'auto', palette } }).appearance.palette).toBe(
-        palette,
-      );
-    }
-    for (const invalid of ['evil-unknown', '', 'Default', undefined, null, 42, {}, []]) {
-      expect(isThemePalette(invalid)).toBe(false);
-    }
-
-    expect(normalizeSettings({}).appearance.palette).toBe('default');
-    expect(
-      normalizeSettings({ appearance: { theme: 'dark', palette: 'evil-unknown' } }).appearance,
-    ).toMatchObject({ theme: 'dark', palette: 'default' });
-    expect(
-      mergeSettings(createDefaultSettings(), { appearance: { palette: 'onedark' } }).appearance,
-    ).toMatchObject({ theme: 'auto', palette: 'onedark' });
-  });
-});
-
 describe('custom pet selection settings', () => {
   test('fails closed for missing, unsafe, or malformed persisted selections', () => {
     for (const selectedPetId of [undefined, '../maodie', 'MAODIE', '', 42, {}]) {
@@ -114,24 +64,6 @@ describe('custom pet selection settings', () => {
       });
       expect(normalized.personalization.selectedPetId).toBe(null);
     }
-  });
-});
-
-test('web-search settings stay owned by their normalization boundary', () => {
-  const normalized = normalizeSettings(
-    mergeSettings(createDefaultSettings(), {
-      webSearch: {
-        enabled: true,
-        providers: { tavily: { apiKey: 'stored-key' } },
-      },
-    }),
-  );
-
-  expect(normalized.webSearch.enabled).toBe(true);
-  expect(normalized.webSearch.providers.tavily).toMatchObject({
-    apiKey: 'stored-key',
-    credentialSource: 'saved',
-    credentialVersion: 1,
   });
 });
 


### PR DESCRIPTION
## Summary
- remove cross-layer bot and web-search settings happy paths already owned by dedicated normalization tests
- remove theme palette and long-term-memory vocabulary mirrors
- reduce capability readiness matrices to representative permission, configuration, and runtime precedence boundaries

## Review
- 9 tests removed, 161 net lines removed
- retained fail-closed temporal validation, permission boundaries, secret handling, and user-input normalization
- Biome and git diff checks pass
- test suites intentionally left to CI