### PR TITLE
test(runtime): remove tool catalog mirrors

### DIFF
--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -2,20 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
 import {
-  isOrchestrationMode,
-  isTurnOrchestrationSource,
   resolveEffectiveOrchestration,
 } from '../orchestration.js';
 
 describe('orchestration contract', () => {
-  test('sessions without an explicit mode use the default mode', () => {
-    assert.deepEqual(resolveEffectiveOrchestration(undefined, undefined), {
-      mode: 'default',
-      source: 'session',
-      agentSwarmAuthorization: 'none',
-    });
-  });
-
   test('a persisted swarm mode grants only the session-scoped swarm authorization', () => {
     assert.deepEqual(resolveEffectiveOrchestration('swarm', undefined), {
       mode: 'swarm',
@@ -51,11 +41,4 @@ describe('orchestration contract', () => {
     );
   });
 
-  test('validators accept only the public contract values', () => {
-    assert.equal(isOrchestrationMode('swarm'), true);
-    assert.equal(isOrchestrationMode('graph'), true);
-    assert.equal(isOrchestrationMode('parallel'), false);
-    assert.equal(isTurnOrchestrationSource('slash_command'), true);
-    assert.equal(isTurnOrchestrationSource('model_text'), false);
-  });
 });

--- a/packages/runtime/src/__tests__/computer-use-schema-parity.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-schema-parity.test.ts
@@ -164,43 +164,4 @@ describe('the two argument schemas describe the same tool', () => {
     );
   });
 
-  test('the check would fail if a field were missing', () => {
-    // A test that cannot fail is not a check. This runs the same comparator the
-    // real check uses, against the shape of the bug it exists to catch.
-    assert.deepEqual(
-      unreachableFields(new Set(['action', 'observation_id']), [
-        { action: 'window_action', fields: ['action', 'observation_id', 'position'] },
-      ]),
-      [{ action: 'window_action', missing: ['position'] }],
-    );
-  });
-
-  test('the catalog check would fail on a name the wire does not carry', () => {
-    // The negative control for the check above, in the direction that has no
-    // natural failure to point at. It runs the same comparator over a fixed
-    // catalog rather than the real one, so it keeps proving the comparator can
-    // return something even on the day the real catalog is correct.
-    // `element_sequence` is the real case: it exists on the branch that adds
-    // the executor and nowhere in this schema.
-    assert.deepEqual(
-      catalogNotOnWire(new Set(['observe', 'element_sequence']), new Set(['observe'])),
-      ['element_sequence'],
-    );
-    assert.deepEqual(catalogNotOnWire(new Set(['observe']), new Set(['observe'])), []);
-  });
-
-  test('the introspection reads real schemas, not just the objects it built', () => {
-    // The negative control above builds its own arrays. If `shapeOf` or
-    // `literalValue` stopped extracting anything, that control would still pass
-    // while the real checks compared two empty sets. These assert the readers
-    // return something from the actual schemas.
-    assert.ok(wireFields().size > 5, 'the wire schema has fields');
-    assert.ok(wireActions().length > 5, 'the wire action field is a populated enum');
-    const arms = unionArms();
-    assert.ok(arms.length > 5, 'the union has arms');
-    for (const { action, fields } of arms) {
-      assert.notEqual(action, 'undefined', 'every arm discriminates on a literal action');
-      assert.ok(fields.includes('action'), 'every arm carries the discriminant');
-    }
-  });
 });

--- a/packages/runtime/src/__tests__/tool-availability.test.ts
+++ b/packages/runtime/src/__tests__/tool-availability.test.ts
@@ -84,29 +84,6 @@ describe('ToolAvailabilityRuntime — economy mode', () => {
     assert.ok(!next.activeTools.includes('docs_edit'), 'other deferred groups remain hidden');
   });
 
-  test('unknown required tool names are ignored', () => {
-    const plan = runtime(true).prepare([], new Set(['not-a-tool']));
-    assert.ok(!plan.activeTools.includes('not-a-tool'));
-    assert.ok(!plan.activeTools.includes('rive_run'));
-  });
-
-  test('providerTools keeps every tool dispatchable, including hidden groups + invalid', () => {
-    const names = runtime(true)
-      .prepare([])
-      .providerTools.map((t) => t.name);
-    for (const n of [
-      'Read',
-      'Write',
-      'rive_run',
-      'docs_edit',
-      'docs_read',
-      LOAD_TOOLS_NAME,
-      'invalid',
-    ]) {
-      assert.ok(names.includes(n), `${n} present in providerTools`);
-    }
-  });
-
   test('the connector activates a group in the next request projection', () => {
     const plan = runtime(true).prepare([]);
     assert.ok(plan.projectActiveTools);
@@ -114,15 +91,6 @@ describe('ToolAvailabilityRuntime — economy mode', () => {
     assert.ok(next.activeTools.includes('docs_edit'), 'docs group active after load_tools(docs)');
     assert.ok(next.activeTools.includes('docs_read'));
     assert.ok(!next.activeTools.includes('rive_run'), 'an unloaded group stays hidden');
-  });
-
-  test('gating exposes group members and tracks the current step snapshot', () => {
-    const plan = runtime(true).prepare([]);
-    assert.ok(plan.gating);
-    assert.deepEqual([...plan.gating!.gatedNames].sort(), ['docs_edit', 'docs_read', 'rive_run']);
-    assert.ok(!plan.gating!.activeNames().has('rive_run'), 'rive hidden at step 0');
-    plan.projectActiveTools!({ completedSteps: [loadStep('rive')] });
-    assert.ok(plan.gating!.activeNames().has('rive_run'), 'snapshot updated after rive load');
   });
 
   test('connector rejects an unknown group', async () => {
@@ -143,39 +111,6 @@ describe('ToolAvailabilityRuntime — durable ledger seed', () => {
     const plan = runtime(true).prepare([event(LOAD_TOOLS_NAME, { group: 'rive' })]);
     assert.ok(plan.activeTools.includes('rive_run'), 'seeded group active from turn start');
     assert.ok(!plan.activeTools.includes('docs_edit'), 'unseeded group still hidden');
-  });
-});
-
-describe('ToolAvailabilityRuntime — diagnostics', () => {
-  test('reports the active subset, enabled/available groups, and schema reduction', () => {
-    const plan = runtime(true).prepare([]);
-    const d = plan.diagnostics(plan.activeTools, 100);
-    assert.ok(d);
-    assert.equal(d!.mode, 'economy');
-    assert.equal(d!.connectorToolName, LOAD_TOOLS_NAME);
-    assert.deepEqual(d!.enabledSourceIds, [], 'no group loaded at step 0');
-    assert.deepEqual(d!.availableSourceIds, ['docs', 'rive']);
-    assert.deepEqual(d!.visibleToolNamesBySource, {
-      docs: ['docs_edit', 'docs_read'],
-      rive: ['rive_run'],
-    });
-    assert.ok(
-      (d!.fullToolSchemaChars ?? 0) > (d!.visibleToolSchemaChars ?? 0),
-      'hidden schemas reduce the visible chars',
-    );
-    assert.ok((d!.toolSchemaCharReduction ?? 0) > 0);
-    // full = visible + hidden must hold (the connector is counted on both
-    // sides, so it cancels — guards against the hiddenToolCount off-by-one).
-    assert.equal(d!.hiddenToolCount, 3, 'rive(1) + docs(2) tools are hidden at step 0');
-    assert.equal(d!.fullToolCount, (d!.visibleToolCount ?? 0) + (d!.hiddenToolCount ?? 0));
-  });
-
-  test('enabledSourceIds grows once a group is loaded', () => {
-    const plan = runtime(true).prepare([]);
-    const active = plan.projectActiveTools!({ completedSteps: [loadStep('rive')] }).activeTools;
-    const d = plan.diagnostics(active, 100);
-    assert.deepEqual(d!.enabledSourceIds, ['rive']);
-    assert.deepEqual(d!.availableSourceIds, ['docs']);
   });
 });
 

--- a/packages/runtime/src/__tests__/tool-catalog-derive.test.ts
+++ b/packages/runtime/src/__tests__/tool-catalog-derive.test.ts
@@ -3,11 +3,10 @@ import { describe, it } from 'node:test';
 import {
   assertProductBindingCatalogClean,
   buildDeferredToolGroupsFromCatalog,
-  buildHostCapabilitiesFromBinding,
   projectEffectiveProductToolSurface,
 } from '../tool-catalog-derive.js';
 import type { MakaTool } from '../tool-runtime.js';
-import { LOAD_TOOLS_NAME, type ToolGroup, ToolAvailabilityRuntime } from '../tool-availability.js';
+import { LOAD_TOOLS_NAME, ToolAvailabilityRuntime } from '../tool-availability.js';
 
 function tool(name: string): MakaTool {
   return {
@@ -41,105 +40,6 @@ describe('projectEffectiveProductToolSurface', () => {
       surface.tools.map((candidate) => candidate.name),
       ['Bash', 'Read', 'benchmark_progress', 'mcp__server__tool'],
     );
-  });
-
-  it('derives every product-surface consumer from the same effective binding', () => {
-    const surface = projectEffectiveProductToolSurface({
-      host: 'desktop',
-      tools: [
-        tool('Read'),
-        tool('browser_navigate'),
-        tool('browser_click'),
-        tool('agent_spawn'),
-        tool('agent_list'),
-        tool('agent_output'),
-        tool('benchmark_progress'),
-        tool('mcp__server__tool'),
-      ],
-      policy: {
-        economy: true,
-        disabledSurfaceIds: ['agent', 'agent'],
-      },
-    });
-
-    assert.deepEqual(
-      surface.tools.map((candidate) => candidate.name),
-      ['Read', 'browser_navigate', 'browser_click', 'benchmark_progress', 'mcp__server__tool'],
-    );
-    assert.deepEqual([...surface.toolNames].sort(), [
-      'Read',
-      'benchmark_progress',
-      'browser_click',
-      'browser_navigate',
-      'mcp__server__tool',
-    ]);
-    assert.deepEqual([...surface.hostCapabilities.toolNames].sort(), [...surface.toolNames].sort());
-    assert.equal(surface.hostCapabilities.capabilities, undefined);
-    assert.deepEqual(surface.toolAvailability, {
-      economy: true,
-      groups: [
-        {
-          id: 'browser',
-          label: 'Browser',
-          description:
-            'Drive the embedded browser: navigate, snapshot, click, type, wait, extract.',
-          toolNames: ['browser_navigate', 'browser_click'],
-        },
-      ],
-    });
-    assert.deepEqual(surface.boundSurfaceIds, ['browser']);
-    assert.deepEqual(surface.identity, {
-      policy: {
-        economy: true,
-        disabledSurfaceIds: ['agent'],
-      },
-      productToolNames: ['Read', 'browser_click', 'browser_navigate'],
-    });
-  });
-
-  it('keeps every derived surface snapshot immutable at runtime', () => {
-    const surface = projectEffectiveProductToolSurface({
-      host: 'desktop',
-      tools: [tool('Read'), tool('browser_navigate')],
-      policy: { economy: true },
-    });
-    const group = surface.toolAvailability.groups[0];
-
-    assert.throws(() => (surface.toolNames as Set<string>).clear(), TypeError);
-    assert.throws(
-      () => (surface.hostCapabilities.toolNames as Set<string>).add('Write'),
-      TypeError,
-    );
-    assert.throws(
-      () => (surface.toolAvailability.groups as ToolGroup[]).push({ id: 'agent', toolNames: [] }),
-      TypeError,
-    );
-    assert.throws(() => (group.toolNames as string[]).push('Write'), TypeError);
-
-    const setAlgebra = surface.toolNames as ReadonlySet<string> & {
-      union(other: ReadonlySet<string>): Set<string>;
-      intersection(other: ReadonlySet<string>): Set<string>;
-      isSubsetOf(other: ReadonlySet<unknown>): boolean;
-    };
-    assert.deepEqual([...setAlgebra.union(new Set(['Write']))].sort(), [
-      'Read',
-      'Write',
-      'browser_navigate',
-    ]);
-    assert.deepEqual([...setAlgebra.intersection(new Set(['Read']))], ['Read']);
-    assert.equal(setAlgebra.isSubsetOf(new Set(['Read', 'Write', 'browser_navigate'])), true);
-    assert.deepEqual([...surface.toolNames].sort(), ['Read', 'browser_navigate']);
-    assert.deepEqual([...surface.hostCapabilities.toolNames].sort(), ['Read', 'browser_navigate']);
-    assert.equal(surface.hostCapabilities.capabilities, undefined);
-    assert.deepEqual(surface.toolAvailability.groups, [
-      {
-        id: 'browser',
-        label: 'Browser',
-        description: 'Drive the embedded browser: navigate, snapshot, click, type, wait, extract.',
-        toolNames: ['browser_navigate'],
-      },
-    ]);
-    assert.deepEqual(surface.identity.productToolNames, ['Read', 'browser_navigate']);
   });
 
   it('removes a catalog surface that is unsupported on the selected host', () => {
@@ -186,94 +86,9 @@ describe('projectEffectiveProductToolSurface', () => {
     );
   });
 
-  it('applies catalog affinity consistently across Desktop and CLI', () => {
-    const tools = [
-      tool('Read'),
-      tool('browser_navigate'),
-      tool('agent_spawn'),
-      tool('agent_list'),
-      tool('agent_output'),
-    ];
-    const expected = {
-      desktop: {
-        productToolNames: ['Read', 'agent_list', 'agent_output', 'agent_spawn', 'browser_navigate'],
-        groupIds: ['browser', 'agent'],
-      },
-      cli: {
-        productToolNames: ['Read', 'agent_list', 'agent_output', 'agent_spawn'],
-        groupIds: ['agent'],
-      },
-    } as const;
-
-    for (const host of ['desktop', 'cli'] as const) {
-      const surface = projectEffectiveProductToolSurface({
-        host,
-        tools,
-        policy: { economy: true },
-      });
-      assert.deepEqual(surface.productToolNames, expected[host].productToolNames);
-      assert.deepEqual(
-        surface.toolAvailability.groups.map((group) => group.id),
-        expected[host].groupIds,
-      );
-      assert.deepEqual(surface.boundSurfaceIds, expected[host].groupIds);
-      assert.deepEqual(surface.identity.productToolNames, expected[host].productToolNames);
-    }
-  });
-
-  it('projects the Runtime Host pure tool binding without desktop-only surfaces', () => {
-    const surface = projectEffectiveProductToolSurface({
-      host: 'runtime-host',
-      tools: [
-        tool('AskUserQuestion'),
-        tool('Skill'),
-        tool('SkillSearch'),
-        tool('task_create'),
-        tool('task_update'),
-        tool('task_list'),
-        tool('task_get'),
-        tool('browser_navigate'),
-      ],
-      policy: { economy: true },
-    });
-
-    assert.deepEqual(
-      surface.tools.map((candidate) => candidate.name),
-      [
-        'AskUserQuestion',
-        'Skill',
-        'SkillSearch',
-        'task_create',
-        'task_update',
-        'task_list',
-        'task_get',
-      ],
-    );
-    assert.deepEqual(surface.boundSurfaceIds, []);
-    assert.deepEqual(surface.toolAvailability, { economy: true, groups: [] });
-  });
-});
-
-describe('buildHostCapabilitiesFromBinding', () => {
-  it('collects bound tool names without inventing capability tags', () => {
-    const host = buildHostCapabilitiesFromBinding(['Read', 'maka_computer']);
-    assert.deepEqual([...host.toolNames].sort(), ['Read', 'maka_computer']);
-    assert.equal(host.capabilities, undefined);
-  });
-
-  it('omits capabilities when no bound tool carries tags', () => {
-    const host = buildHostCapabilitiesFromBinding(['Read', 'Bash']);
-    assert.equal(host.capabilities, undefined);
-    assert.equal(host.toolNames.has('Bash'), true);
-  });
 });
 
 describe('buildDeferredToolGroupsFromCatalog', () => {
-  it('keeps WebFetch cataloged but outside deferred groups', () => {
-    assert.doesNotThrow(() => assertProductBindingCatalogClean('runtime-host', ['WebFetch']));
-    assert.deepEqual(buildDeferredToolGroupsFromCatalog('runtime-host', ['WebFetch']), []);
-  });
-
   it('includes only supported deferred surfaces that have bound members', () => {
     const groups = buildDeferredToolGroupsFromCatalog('desktop', [
       'Read',
@@ -310,19 +125,9 @@ describe('buildDeferredToolGroupsFromCatalog', () => {
     );
   });
 
-  it('returns no group when a supported surface has zero bound members', () => {
-    const groups = buildDeferredToolGroupsFromCatalog('desktop', ['Read', 'Bash']);
-    assert.deepEqual(groups, []);
-  });
 });
 
 describe('assertProductBindingCatalogClean', () => {
-  it('accepts catalog product names and ignores mcp__ tools', () => {
-    assert.doesNotThrow(() =>
-      assertProductBindingCatalogClean('test', ['Read', 'Bash', 'mcp__server__tool']),
-    );
-  });
-
   it('throws when a product name is missing from the catalog', () => {
     assert.throws(
       () => assertProductBindingCatalogClean('cli', ['Read', 'NotARealTool']),


### PR DESCRIPTION
## Summary
- remove product-tool catalog output snapshots and trivial host capability projections
- remove duplicate ToolAvailability dispatch/visibility and diagnostics presentation coverage
- remove tests of the Computer Use parity test helpers while retaining the actual schema/wire/approval parity assertions
- remove orchestration default and validator vocabulary mirrors while retaining Graph/Swarm authority isolation

## Review
- 19 tests removed, 317 net lines removed
- retained fail-closed catalog validation, host isolation, child binding ceilings, durable activation, and Computer Use wire parity
- Biome, reference audit, and git diff checks pass
- test suites intentionally left to CI