### PR TITLE
test(runtime): remove diagnostics snapshots

### DIFF
--- a/packages/runtime/src/__tests__/context-diagnostics.test.ts
+++ b/packages/runtime/src/__tests__/context-diagnostics.test.ts
@@ -72,39 +72,6 @@ test('ignores non-inline child runs when reading session context', async () => {
   });
 });
 
-test('groups the completed request segments into explicit local estimates', async () => {
-  const store = runStore([
-    {
-      header: runHeader('run-1', 1),
-      events: [
-        attemptEvent('run-1', 'attempt-1', 10, 'completed', 'model', 610, 1_000, [
-          { kind: 'system_prompt', index: 0, cacheable: true, hash: 'system', bytes: 400 },
-          { kind: 'tool_schema', index: 0, cacheable: true, hash: 'tool', bytes: 800 },
-          { kind: 'message', index: 0, cacheable: true, hash: 'message', bytes: 1_200 },
-          {
-            kind: 'provider_options',
-            index: 0,
-            cacheable: false,
-            hash: 'options',
-            bytes: 40,
-          },
-        ]),
-      ],
-    },
-  ]);
-
-  const diagnostics = await readLatestContextDiagnostics(store, 'session-1');
-
-  assert.equal(diagnostics.status, 'available');
-  if (diagnostics.status !== 'available') return;
-  assert.deepEqual(diagnostics.segments, [
-    { kind: 'system_instructions', bytes: 400, estimatedTokens: 100 },
-    { kind: 'tool_definitions', bytes: 800, estimatedTokens: 200 },
-    { kind: 'messages', bytes: 1_200, estimatedTokens: 300 },
-    { kind: 'other', bytes: 40, estimatedTokens: 10 },
-  ]);
-});
-
 test('reports that no completed request exists instead of inferring session values', async () => {
   const diagnostics = await readLatestContextDiagnostics(
     runStore([{ header: runHeader('run-1', 1), events: [] }]),

--- a/packages/runtime/src/__tests__/execution-inspect.test.ts
+++ b/packages/runtime/src/__tests__/execution-inspect.test.ts
@@ -14,9 +14,7 @@ import { createSessionStore } from '@maka/storage';
 import { createSqliteAgentRunStore, createWorkspaceRuntimeStore } from '@maka/storage';
 import {
   inspectAgentRunDocument,
-  inspectSessionDocument,
   renderAgentRunInspectTree,
-  renderSessionInspectTree,
 } from '../execution-inspect.js';
 
 describe('versioned execution inspect documents', () => {
@@ -88,56 +86,6 @@ describe('versioned execution inspect documents', () => {
     });
   });
 
-  test('projects a Session as bounded AgentRun documents without reading messages', async () => {
-    await withWorkspace(async (root) => {
-      const sessionStore = createSessionStore(root);
-      const runStore = createSqliteAgentRunStore(root);
-      const runtimeStore = createWorkspaceRuntimeStore(root);
-      const session = await sessionStore.create({
-        cwd: '/tmp/workspace',
-        name: 'Inspectable session',
-        backend: 'fake',
-        llmConnectionSlug: 'fake',
-        model: 'fake-model',
-        permissionMode: 'ask',
-        revisionRootSessionId: 'root-session',
-        revisionParentSessionId: 'previous-version',
-        revisionOfTurnId: 'turn-edited',
-        revisionIndex: 2,
-        revisionState: 'committed',
-      });
-      const header = runHeader(session.id);
-      await runStore.createRun(header);
-      await runStore.appendEvent(session.id, RUN_ID, runEvent(session.id, 'run_completed'));
-      await runtimeStore.appendRuntimeEvent(
-        session.id,
-        RUN_ID,
-        runtimeEvent(session.id, 'terminal', {
-          role: 'system',
-          author: 'system',
-          status: 'completed',
-          actions: { endInvocation: true },
-        }),
-      );
-
-      const document = await inspectSessionDocument(
-        { readHeader: (id) => sessionStore.readHeaderSnapshot(id) },
-        runStore,
-        runtimeStore,
-        session.id,
-      );
-
-      assert.equal(document.schemaVersion, 'maka.session_inspect.v1');
-      assert.equal(document.session.name, 'Inspectable session');
-      assert.equal(document.session.revisionRootSessionId, 'root-session');
-      assert.equal(document.session.revisionParentSessionId, 'previous-version');
-      assert.equal(document.session.revisionOfTurnId, 'turn-edited');
-      assert.equal(document.session.revisionIndex, 2);
-      assert.equal(document.session.revisionState, 'committed');
-      assert.equal(document.agentRuns[0]?.agentRun.agentRunId, RUN_ID);
-      assert.match(renderSessionInspectTree(document), /Runtime Events runtime_event:run-1 0–0/);
-    });
-  });
 });
 
 const RUN_ID = 'run-1';

--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -6,7 +6,6 @@ import { z } from 'zod/v4';
 
 import {
   classifyError,
-  errorPresentationFromClass,
   providerFailureSummary,
   providerRetryMetadata,
 } from '../provider-error-classification.js';
@@ -542,37 +541,6 @@ describe('Provider error classification', () => {
     assert.equal(classifyError(spoofed), 'AI_RetryError');
   });
 
-  test('maps provider classes to stable user-safe presentations', () => {
-    assert.deepEqual(errorPresentationFromClass('ContextLength'), {
-      reason: 'context_overflow',
-      message: 'Context window exceeded',
-    });
-    assert.deepEqual(errorPresentationFromClass('Timeout'), {
-      reason: 'timeout',
-      message: 'Request timed out',
-    });
-    assert.deepEqual(errorPresentationFromClass('Auth'), {
-      reason: 'auth',
-      message: 'Authentication failed',
-    });
-    assert.deepEqual(errorPresentationFromClass('ProviderBilling'), {
-      reason: 'provider_billing',
-      message: 'Provider billing required',
-    });
-    assert.deepEqual(errorPresentationFromClass('ProviderUnavailable'), {
-      reason: 'provider_unavailable',
-      message: 'Provider returned an error',
-    });
-    assert.deepEqual(errorPresentationFromClass('RateLimit'), {
-      reason: 'rate_limit',
-      message: 'Rate limit exceeded',
-    });
-    assert.deepEqual(errorPresentationFromClass('Network'), {
-      reason: 'network',
-      message: 'Network error',
-    });
-    assert.deepEqual(errorPresentationFromClass('Other'), {});
-  });
 });
 test('auth classification preserves broad provider spellings without matching authority', () => {
   for (const message of [

--- a/packages/runtime/src/__tests__/sandbox-diagnostics.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-diagnostics.test.ts
@@ -1,8 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-import { createDangerFullAccessPermissionProfile } from '@maka/core/permission-profile';
-
 import { MacosSeatbeltBackend } from '../sandbox/macos-seatbelt.js';
 import { SandboxManager } from '../sandbox/sandbox-manager.js';
 import {
@@ -14,47 +12,6 @@ import { renderSandboxTurnTailPrompt } from '../system-prompt/sandbox-context-pr
 import { FilesystemWorkerClientError } from '../filesystem-worker/client.js';
 
 describe('sandbox diagnostics', () => {
-  test('reports the effective profile and both active macOS enforcement capabilities', async () => {
-    const provider = createSandboxDiagnosticsProvider({
-      platform: 'darwin',
-      sandboxManager: new SandboxManager([new MacosSeatbeltBackend()]),
-      getFilesystemWorkerLaunchSpec: async () => ({
-        ok: true,
-        spec: {
-          program: '/runtime/node',
-          args: ['/runtime/worker.js'],
-          env: {},
-          runtimeReadableRoots: ['/runtime/worker.js'],
-          executableRoots: ['/runtime'],
-        },
-      }),
-      isExecutable: async () => true,
-      canonicalizePath: async (path) => path,
-    });
-
-    const snapshot = await provider.resolve({ mode: 'ask', cwd: '/workspace' });
-
-    assert.deepEqual(snapshot.profile, {
-      name: 'workspace-write',
-      type: 'managed',
-      fileSystem: 'workspace-write',
-      network: 'restricted',
-      cwd: '/workspace',
-      workspaceRoots: ['/workspace'],
-      protectedMetadata: [],
-    });
-    assert.deepEqual(snapshot.capabilities.command, {
-      status: 'available',
-      backend: 'macos-seatbelt',
-      selectionReason: 'platform_sandbox_selected',
-    });
-    assert.deepEqual(snapshot.capabilities.filesystem, {
-      status: 'available',
-      backend: 'macos-seatbelt',
-      selectionReason: 'platform_sandbox_selected',
-    });
-  });
-
   test('keeps typed selection and filesystem-worker failure reasons', async () => {
     const unsupported = createSandboxDiagnosticsProvider({
       platform: 'win32',
@@ -82,27 +39,6 @@ describe('sandbox diagnostics', () => {
       selectionReason: 'platform_sandbox_selected',
       failure: { stage: 'launch', reason: 'filesystem_worker_unavailable' },
     });
-  });
-
-  test('reports unrestricted profiles as not requiring a Maka sandbox', async () => {
-    const provider = createSandboxDiagnosticsProvider({
-      platform: 'darwin',
-      canonicalizePath: async (path) => path,
-    });
-    const snapshot = await provider.resolve({
-      mode: 'bypass',
-      cwd: '/workspace',
-      permissionProfile: createDangerFullAccessPermissionProfile(),
-    });
-
-    assert.equal(snapshot.profile.name, 'danger-full-access');
-    assert.equal(snapshot.profile.network, 'enabled');
-    assert.deepEqual(snapshot.capabilities.command, {
-      status: 'not_required',
-      backend: 'none',
-      selectionReason: 'sandbox_not_required',
-    });
-    assert.deepEqual(snapshot.capabilities.filesystem, snapshot.capabilities.command);
   });
 
   test('removes paths from durable trace projection but renders them in the turn tail', async () => {


### PR DESCRIPTION
## Summary
- remove exact provider error copy mapping and context-segment presentation snapshots
- remove duplicate successful Session inspect projection
- remove successful sandbox diagnostics shape snapshots already owned by sandbox selection tests

## Review
- 5 tests removed, 181 lines removed
- retained provider classification, redaction, bounded diagnostics, path privacy, sandbox failure reasons, malformed expansion handling, and durable ledger checks
- Biome and git diff checks pass
- test suites intentionally left to CI