### PR TITLE
test(cli): remove basic presentation paths

### DIFF
--- a/packages/cli/src/__tests__/activation-command.test.ts
+++ b/packages/cli/src/__tests__/activation-command.test.ts
@@ -13,7 +13,6 @@ import {
   type MakaActivationDeps,
   type MakaActivationRuntime,
 } from '../activation-command.js';
-import { parseMakaCliArgs } from '../cli.js';
 import type { MakaRunOutcome } from '../run-command-core.js';
 
 const ROOTS = {
@@ -169,13 +168,6 @@ function fakeDeps(
 }
 
 describe('maka activate argument and request contracts', () => {
-  test('routes activate through the CLI parser', () => {
-    assert.deepEqual(parseMakaCliArgs(['activate'], '0.1.0'), {
-      kind: 'activate',
-      args: [],
-    });
-  });
-
   test('requires explicit non-overlapping roots and accepts JSON input options', () => {
     assert.deepEqual(
       parseMakaActivateArgs([

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -359,68 +359,6 @@ describe('Maka Pi TUI transcript', () => {
     );
   });
 
-  test('rebuilds transcript from stored session messages', () => {
-    const state = createMakaPiTranscriptState();
-
-    replaceTranscriptWithStoredMessages(state, [
-      {
-        type: 'user',
-        id: 'user-1',
-        turnId: 'turn-1',
-        ts: 1,
-        text: 'What did we decide?',
-      },
-      {
-        type: 'assistant',
-        id: 'assistant-1',
-        turnId: 'turn-1',
-        ts: 2,
-        text: 'We decided to keep the TUI small.',
-        thinking: { text: 'recall the decision' },
-        modelId: 'deepseek-v4-flash',
-      },
-      {
-        type: 'tool_call',
-        id: 'tool-1',
-        turnId: 'turn-1',
-        ts: 3,
-        toolName: 'Read',
-        args: { path: 'README.md' },
-      },
-      {
-        type: 'tool_result',
-        id: 'tool-result-1',
-        turnId: 'turn-1',
-        ts: 4,
-        toolUseId: 'tool-1',
-        isError: false,
-        content: { kind: 'text', text: 'README contents' },
-      },
-    ] satisfies StoredMessage[]);
-
-    // Stored thinking happened before the reply text, so it resumes above it.
-    assert.deepEqual(
-      state.entries.map((entry) => entry.kind),
-      ['user', 'thinking', 'assistant', 'tool'],
-    );
-    assert.equal(
-      state.entries[0]?.kind === 'user' ? state.entries[0].text : '',
-      'What did we decide?',
-    );
-    assert.equal(
-      state.entries[1]?.kind === 'thinking' ? state.entries[1].text : '',
-      'recall the decision',
-    );
-    assert.equal(
-      state.entries[2]?.kind === 'assistant' ? state.entries[2].text : '',
-      'We decided to keep the TUI small.',
-    );
-    assert.equal(
-      state.entries[3]?.kind === 'tool' ? state.entries[3].output : '',
-      'README contents',
-    );
-  });
-
   test('folds stored background-task polling into its parent Bash card on resume', () => {
     const state = createMakaPiTranscriptState();
     const ref = 'maka://runtime/background-tasks/bg-1';
@@ -933,55 +871,6 @@ describe('Maka Pi TUI transcript', () => {
     assert.match(rendered, /Entered: echo hello\\r/);
     assert.match(rendered, /Resized to 100x30/);
     assert.equal(rendered.split('UNIQUE-PTY-FRAME').length - 1, 1);
-  });
-
-  test('projects raw live WriteStdin args at the TUI transcript boundary', () => {
-    const state = createMakaPiTranscriptState();
-    const ref = 'maka://runtime/background-tasks/pty-live';
-
-    applyMakaSessionEventToTranscript(
-      state,
-      event({
-        type: 'tool_start',
-        toolUseId: 'write-live',
-        toolName: 'WriteStdin',
-        args: { ref, input: 'echo live\r' },
-      }),
-    );
-
-    const entry = state.entries.find(
-      (candidate): candidate is Extract<typeof candidate, { kind: 'tool' }> =>
-        candidate.kind === 'tool',
-    );
-    assert.deepEqual(entry?.input, {
-      ref,
-      inputPreview: { text: 'echo live\\r', bytes: 10, truncated: false },
-    });
-  });
-
-  test('rebuilds fail-open notes without claiming history was trimmed', () => {
-    const state = createMakaPiTranscriptState();
-
-    replaceTranscriptWithStoredMessages(state, [
-      {
-        type: 'system_note',
-        id: 'note-failed-open',
-        turnId: 'turn-1',
-        ts: 1,
-        kind: 'context_compaction_failed_open',
-      },
-    ] satisfies StoredMessage[]);
-
-    assert.deepEqual(
-      state.entries.filter((entry) => entry.kind === 'notice'),
-      [
-        {
-          kind: 'notice',
-          level: 'info',
-          text: 'Context summary failed; the session continued without a new summary.',
-        },
-      ],
-    );
   });
 
   test('renders an unboxed session sandbox boundary request with exact scopes', () => {

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -13,40 +13,6 @@ import type { RuntimeHostMakaSessionDriver } from '../runtime-host-session-drive
 import type { MakaRunContextInput, MakaRunOutcome } from '../run-command-core.js';
 
 describe('Runtime Host maka run adapter', () => {
-  test('runs the public command through one Host connection and preserves stdout semantics', async () => {
-    const stdout: string[] = [];
-    const stderr: string[] = [];
-    let closes = 0;
-    const exitCode = await runRuntimeHostTextCli(
-      ['answer once'],
-      {
-        workspaceRoot: () => '/runtime-host-data',
-        processCwd: () => process.cwd(),
-        stdinIsTTY: () => true,
-        readStdin: async () => '',
-        writeStdout: (text) => stdout.push(text),
-        writeStderr: (text) => stderr.push(text),
-        onSigint: () => () => {},
-        newId: () => 'turn-1',
-      },
-      {
-        connect: async () => ({
-          connection: readinessConnection(),
-          catalog: connectionCatalog(),
-          close: async () => {
-            closes += 1;
-          },
-        }),
-        createContext: (_connection, _catalog, input) => publicCommandContext(input),
-      },
-    );
-
-    assert.equal(exitCode, 0);
-    assert.deepEqual(stdout, ['Host answer\n']);
-    assert.deepEqual(stderr, []);
-    assert.equal(closes, 1);
-  });
-
   test('stops before context creation when CLI preflight finds a confirmed blocker', async () => {
     const stderr: string[] = [];
     let contextCreations = 0;
@@ -177,36 +143,6 @@ describe('Runtime Host maka run adapter', () => {
     assert.deepEqual(fixture.exactTurnStops, [
       { sessionId: 'session-created', turnId: 'turn-1', runId: 'run-1' },
     ]);
-  });
-
-  test('folds one Host Turn into the shared one-shot invocation contract', async () => {
-    const observed: MakaRunOutcome[] = [];
-    const fixture = runFixture({ observed });
-    const context = fixture.context;
-    const session = await context.runtime.createSession({
-      cwd: '/workspace',
-      name: 'Run once',
-      backend: 'ai-sdk',
-      llmConnectionSlug: 'openai-main',
-      model: 'gpt-5',
-      permissionMode: 'ask',
-    });
-    const events = await collect(
-      context.runtime.sendMessage(session.id, { turnId: 'turn-1', text: 'answer once' }),
-    );
-
-    assert.deepEqual(
-      events.map((event) => event.type),
-      ['text_complete', 'complete'],
-    );
-    assert.equal(observed.length, 1);
-    assert.equal(observed[0]?.outcomeId, 'run-1');
-    assert.equal(observed[0]?.status, 'completed');
-    assert.equal(observed[0]?.finalOutput, 'Host answer');
-    assert.deepEqual(context.target, {
-      connection: { slug: 'openai-main' },
-      model: 'gpt-5',
-    });
   });
 
   test('waits for Host-started graph supervisor Turns before returning', async () => {


### PR DESCRIPTION
## Summary
- remove trivial activate parser routing coverage
- remove basic Runtime Host command success and one-shot projection paths
- remove stored transcript happy path, duplicate WriteStdin projection, and fail-open copy snapshot

## Review
- 6 tests removed, 183 lines removed
- retained JSONL protocol validation, redaction, permission boundaries, Graph/Swarm behavior, transcript ordering, background settlement, and terminal recovery
- lower owners still cover WriteStdin projection and compaction failure persistence
- Biome and git diff checks pass
- test suites intentionally left to CI