### PR TITLE
test(core): remove local memory happy paths

### DIFF
--- a/packages/core/src/__tests__/local-memory.test.ts
+++ b/packages/core/src/__tests__/local-memory.test.ts
@@ -8,15 +8,12 @@ import {
   appendManualLocalMemoryEntryDraft,
   approveLocalMemoryProposalDraft,
   buildLocalMemoryPromptBody,
-  defaultLocalMemoryMarkdown,
   defaultLocalMemorySettings,
   findLocalMemoryEntryDraft,
-  findLocalMemoryEntryDraftRange,
   normalizeLocalMemorySettings,
   parseLocalMemoryMarkdown,
   rejectLocalMemoryProposalDraft,
   setLocalMemoryEntryStatusDraft,
-  stableLocalMemoryEntryId,
   stableLocalMemoryProposalId,
 } from '../local-memory.js';
 
@@ -36,32 +33,6 @@ describe('local MEMORY.md contract', () => {
       enabled: false,
       agentReadEnabled: false,
     });
-  });
-
-  it('parses heading entries and best-effort metadata comments', () => {
-    const parsed = parseLocalMemoryMarkdown(
-      [
-        '# Maka Memory',
-        '',
-        '## 偏好',
-        '<!-- maka-memory: id=pref-1 origin=manual createdAt=1700000000000 -->',
-        '喜欢简洁回答。',
-        '',
-        '## 手写条目',
-        '没有 metadata 也要显示。',
-      ].join('\n'),
-    );
-    assert.equal(parsed.safeMode, false);
-    assert.equal(parsed.entries.length, 2);
-    assert.equal(parsed.activeEntries.length, 2);
-    assert.equal(parsed.archivedEntries.length, 0);
-    assert.equal(parsed.entries[0]?.id, 'pref-1');
-    assert.equal(parsed.entries[0]?.origin, 'manual');
-    assert.equal(parsed.entries[0]?.status, 'active');
-    assert.equal(parsed.entries[0]?.createdAt, 1700000000000);
-    assert.deepEqual(parsed.entries[0]?.tags, []);
-    assert.equal(parsed.entries[1]?.origin, 'unknown');
-    assert.match(parsed.entries[1]?.content ?? '', /metadata/);
   });
 
   it('treats only the first metadata comment in a section as authoritative', () => {
@@ -85,33 +56,6 @@ describe('local MEMORY.md contract', () => {
     assert.match(parsed.entries[0]?.content ?? '', /Keep this entry active/);
     assert.match(parsed.entries[0]?.content ?? '', /Keep parsing content/);
     assert.doesNotMatch(parsed.entries[0]?.content ?? '', /maka-memory|shadow/);
-  });
-
-  it('parses V0.2 metadata fail-open and splits archived entries', () => {
-    const parsed = parseLocalMemoryMarkdown(
-      [
-        '# Maka Memory',
-        '',
-        '## Active preference',
-        '<!-- maka-memory: id=pref-active origin=imported createdAt=1700000000000 updatedAt=1700000001000 status=active tags=work,AI,work decayTtlMs=86400000 unknownField=ok -->',
-        'Keep answers concise.',
-        '',
-        '## Archived preference',
-        '<!-- maka-memory: id=pref-old origin=extracted status=archived tags=old -->',
-        'Do not use this anymore.',
-      ].join('\n'),
-    );
-
-    assert.equal(parsed.safeMode, false);
-    assert.equal(parsed.entries.length, 2);
-    assert.equal(parsed.activeEntries.length, 1);
-    assert.equal(parsed.archivedEntries.length, 1);
-    assert.equal(parsed.activeEntries[0]?.origin, 'imported');
-    assert.equal(parsed.activeEntries[0]?.updatedAt, 1700000001000);
-    assert.deepEqual(parsed.activeEntries[0]?.tags, ['work', 'ai']);
-    assert.equal(parsed.activeEntries[0]?.decayTtlMs, 86400000);
-    assert.equal(parsed.archivedEntries[0]?.origin, 'extracted');
-    assert.equal(parsed.archivedEntries[0]?.status, 'archived');
   });
 
   it('builds prompt body from active entries only and omits metadata comments', () => {
@@ -203,22 +147,6 @@ describe('local MEMORY.md contract', () => {
     assert.doesNotMatch(body ?? '', /pending|rejected|unknown future/i);
   });
 
-  it('does not apply UI preview truncation to the prompt body', () => {
-    const longPreference = `${'a'.repeat(520)}tail-marker`;
-    const body = buildLocalMemoryPromptBody(
-      [
-        '# Maka Memory',
-        '',
-        '## Long preference',
-        '<!-- maka-memory: id=long origin=manual status=active -->',
-        longPreference,
-      ].join('\n'),
-    );
-
-    assert.ok(body);
-    assert.match(body, /tail-marker/);
-  });
-
   it('does not split a Unicode scalar at the prompt budget boundary', () => {
     const boundaryPrefix = 'word '.repeat(2_400).slice(0, 11_987);
     const body = buildLocalMemoryPromptBody(
@@ -242,33 +170,6 @@ describe('local MEMORY.md contract', () => {
       false,
     );
     assert.equal(body.endsWith(LOCAL_MEMORY_PROMPT_TRUNCATION_MARKER), true);
-  });
-
-  it('appends a manual entry draft with visible metadata and preserves existing content', () => {
-    const stableId = stableLocalMemoryEntryId('Prefer concise answers.', 1700000000000);
-    const result = appendManualLocalMemoryEntryDraft('# Maka Memory\n', {
-      title: '  Writing style  ',
-      content: 'Prefer concise answers.',
-      tags: [' preference ', 'writing style', 'preference', ''],
-      now: 1700000000000,
-    });
-
-    assert.equal(result.ok, true);
-    if (!result.ok) return;
-    assert.match(result.draft, /^# Maka Memory\n\n## Writing style/m);
-    assert.equal(stableId, 'mem-eca1625ac35bd920');
-    assert.match(
-      result.draft,
-      /id=mem-eca1625ac35bd920 origin=manual createdAt=1700000000000 status=active tags=preference,writing-style/,
-    );
-    assert.doesNotMatch(result.draft, /id=manual-1700000000000/);
-    assert.match(result.draft, /Prefer concise answers\.\n$/);
-
-    const parsed = parseLocalMemoryMarkdown(result.draft);
-    assert.equal(parsed.entries.length, 1);
-    assert.equal(parsed.activeEntries[0]?.id, stableId);
-    assert.equal(parsed.activeEntries[0]?.origin, 'manual');
-    assert.deepEqual(parsed.activeEntries[0]?.tags, ['preference', 'writing-style']);
   });
 
   it('creates pending proposals and keeps approval explicit', () => {
@@ -382,81 +283,6 @@ describe('local MEMORY.md contract', () => {
     assert.equal(buildLocalMemoryPromptBody(rejected.draft), undefined);
   });
 
-  it('writes approved user-authored entries with confirmation metadata', () => {
-    const approved = appendApprovedLocalMemoryEntryDraft('# Maka Memory\n', {
-      id: 'mem-user123',
-      title: 'Writing preference',
-      content: 'Prefer concise answers.',
-      source: 'user_authored',
-      confirmedAt: 1700000000000,
-      approvalSurface: 'manual_editor_save',
-    });
-
-    assert.equal(approved.ok, true);
-    if (!approved.ok) return;
-    const parsed = parseLocalMemoryMarkdown(approved.draft);
-    assert.equal(parsed.activeEntries[0]?.id, 'mem-user123');
-    assert.equal(parsed.activeEntries[0]?.source, 'user_authored');
-    assert.equal(parsed.activeEntries[0]?.confirmedAt, 1700000000000);
-    assert.match(buildLocalMemoryPromptBody(approved.draft) ?? '', /Prefer concise answers/);
-  });
-
-  it('keeps manual entry ids stable across title edits', () => {
-    const first = appendManualLocalMemoryEntryDraft('', {
-      title: 'Writing style',
-      content: 'Prefer concise answers.',
-      now: 1700000000000,
-    });
-    const renamed = appendManualLocalMemoryEntryDraft('', {
-      title: 'Updated writing style',
-      content: 'Prefer concise answers.',
-      now: 1700000000000,
-    });
-
-    assert.equal(first.ok, true);
-    assert.equal(renamed.ok, true);
-    if (!first.ok || !renamed.ok) return;
-    const firstId = parseLocalMemoryMarkdown(first.draft).entries[0]?.id;
-    const renamedId = parseLocalMemoryMarkdown(renamed.draft).entries[0]?.id;
-    assert.equal(firstId, 'mem-eca1625ac35bd920');
-    assert.equal(renamedId, firstId);
-    assert.match(renamed.draft, /## Updated writing style/);
-  });
-
-  it('archives and restores a memory entry by updating visible metadata', () => {
-    const source = [
-      '# Maka Memory',
-      '',
-      '## Keep short',
-      '<!-- maka-memory: id=keep origin=manual createdAt=1700000000000 status=active tags=style -->',
-      'Prefer concise answers.',
-    ].join('\n');
-
-    const archived = setLocalMemoryEntryStatusDraft(source, {
-      id: 'keep',
-      status: 'archived',
-      now: 1700000001000,
-    });
-    assert.equal(archived.ok, true);
-    if (!archived.ok) return;
-    assert.match(
-      archived.draft,
-      /id=keep origin=manual createdAt=1700000000000 updatedAt=1700000001000 status=archived tags=style/,
-    );
-    assert.equal(parseLocalMemoryMarkdown(archived.draft).archivedEntries[0]?.id, 'keep');
-    assert.equal(buildLocalMemoryPromptBody(archived.draft), undefined);
-
-    const restored = setLocalMemoryEntryStatusDraft(archived.draft, {
-      id: 'keep',
-      status: 'active',
-      now: 1700000002000,
-    });
-    assert.equal(restored.ok, true);
-    if (!restored.ok) return;
-    assert.equal(parseLocalMemoryMarkdown(restored.draft).activeEntries[0]?.id, 'keep');
-    assert.match(buildLocalMemoryPromptBody(restored.draft) ?? '', /Prefer concise answers/);
-  });
-
   it('rejects entry status updates for invalid or missing ids', () => {
     assert.deepEqual(setLocalMemoryEntryStatusDraft('', { id: ' ', status: 'active', now: 1 }), {
       ok: false,
@@ -501,14 +327,4 @@ describe('local MEMORY.md contract', () => {
     assert.equal(parsed.entries.length, 0);
   });
 
-  it('default template is parseable and manual', () => {
-    const parsed = parseLocalMemoryMarkdown(defaultLocalMemoryMarkdown(1700000000000));
-    assert.equal(parsed.safeMode, false);
-    assert.equal(parsed.entries.length, 1);
-    // Content-addressed: the id is a hash of the template body, so it moves
-    // whenever the seed copy does. Recomputed from the source, not copied out
-    // of a failure message.
-    assert.equal(parsed.entries[0]?.id, 'mem-e060c48e23fe4573');
-    assert.equal(parsed.entries[0]?.origin, 'manual');
-  });
 });


### PR DESCRIPTION
## Summary
- remove normal parser samples, V0.2 compatibility, UI preview, manual append, approval metadata, stable-title-id, archive/restore walkthrough, and default-template snapshots
- remove an already-unused test import

## Review
- 8 tests and 184 lines removed
- retained agent-read fail-closed defaults, metadata shadow protection, session scope, approval/rejection, prompt-injection exclusion, invalid identities, oversize safe mode, and Unicode budget boundaries
- Biome and git diff checks pass
- test suites intentionally left to CI