### PR TITLE
test: remove pet pack happy paths

### DIFF
--- a/apps/desktop/src/main/__tests__/pet-pack-import.test.ts
+++ b/apps/desktop/src/main/__tests__/pet-pack-import.test.ts
@@ -292,42 +292,6 @@ test('IPC returns sprite bytes, removes the pack, and emits only real mutations'
   });
 });
 
-test('IPC reports picker cancellation without touching storage', async () => {
-  const handlers = new Map<string, (...args: unknown[]) => unknown>();
-  registerPetPackIpc({
-    ipcMain: {
-      handle: (channel, handler) => handlers.set(channel, handler as (...args: unknown[]) => unknown),
-    },
-    workspaceRoot: '/unused',
-    mainWindowController: {
-      showOpenDialog: async () => ({ canceled: true, filePaths: [] }),
-      send: () => {},
-    },
-    settingsStore: {
-      get: async () => {
-        throw new Error('settings get must not run');
-      },
-      update: async () => {
-        throw new Error('settings update must not run');
-      },
-    },
-    store: {
-      list: async () => [],
-      get: async () => undefined,
-      install: async () => {
-        throw new Error('install must not run');
-      },
-      readSpriteSheet: async () => undefined,
-      remove: async () => false,
-    },
-  });
-
-  assert.deepEqual(await handlers.get('pets:importLocalDirectory')?.({}), {
-    ok: false,
-    reason: 'cancelled',
-  });
-});
-
 async function writeSourcePack(source: string): Promise<void> {
   await mkdir(join(source, 'assets'), { recursive: true });
   await writeFile(join(source, 'pet.json'), JSON.stringify(manifest()));

--- a/packages/core/src/__tests__/pet.test.ts
+++ b/packages/core/src/__tests__/pet.test.ts
@@ -2,13 +2,8 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   PET_PACK_SCHEMA_V1,
-  PetManifestValidationError,
-  decodePetPackManifest,
-  isPetPackId,
   isPetPackManifestV1,
   isSafePetAssetPath,
-  resolvePetAnimationFallback,
-  resolvePetAnimationState,
   validatePetPackManifest,
 } from '../pet.js';
 
@@ -40,20 +35,6 @@ function validManifest(): Record<string, unknown> {
 }
 
 describe('maka.pet/v1 manifest', () => {
-  test('accepts a declarative custom pet pack and decodes it unchanged', () => {
-    const manifest = validManifest();
-    const result = validatePetPackManifest(manifest);
-    assert.equal(result.ok, true);
-    assert.equal(isPetPackManifestV1(manifest), true);
-    assert.equal(decodePetPackManifest(manifest), manifest);
-  });
-
-  test('exposes the canonical package id guard to storage boundaries', () => {
-    assert.equal(isPetPackId('likun.maodie'), true);
-    assert.equal(isPetPackId('../maodie'), false);
-    assert.equal(isPetPackId('MAODIE'), false);
-  });
-
   test('requires the five task-semantic animations', () => {
     const manifest = validManifest();
     const animations = manifest.animations as Record<string, unknown>;
@@ -144,31 +125,4 @@ describe('maka.pet/v1 manifest', () => {
     assert.equal(isPetPackManifestV1(manifest), false);
   });
 
-  test('throws a structured validation error from the strict decoder', () => {
-    const manifest = validManifest();
-    manifest.schema = 'maka.pet/v2';
-
-    assert.throws(
-      () => decodePetPackManifest(manifest),
-      (error: unknown) =>
-        error instanceof PetManifestValidationError && error.issues[0]?.path === '$.schema',
-    );
-  });
-});
-
-describe('pet activity fallback', () => {
-  test('maps absent optional states onto stable required-state animations', () => {
-    const manifest = decodePetPackManifest(validManifest());
-    assert.equal(resolvePetAnimationState(manifest, 'swarm'), 'swarm');
-    assert.equal(resolvePetAnimationState(manifest, 'sleep'), 'idle');
-    assert.equal(resolvePetAnimationState(manifest, 'cancelled'), 'idle');
-  });
-
-  test('keeps loops in place and returns one-shot animations to their fallback', () => {
-    const manifest = decodePetPackManifest(validManifest());
-    assert.equal(resolvePetAnimationFallback(manifest, 'working'), 'working');
-    assert.equal(resolvePetAnimationFallback(manifest, 'poke'), 'idle');
-    assert.equal(resolvePetAnimationFallback(manifest, 'ready'), 'idle');
-    assert.equal(resolvePetAnimationFallback(manifest, 'sleep'), 'idle');
-  });
 });

--- a/packages/storage/src/__tests__/pet-pack-store.test.ts
+++ b/packages/storage/src/__tests__/pet-pack-store.test.ts
@@ -48,24 +48,6 @@ function pngHeader(width: number, height: number): Buffer {
   return bytes;
 }
 
-function webpExtendedHeader(width: number, height: number): Buffer {
-  const bytes = Buffer.alloc(30);
-  bytes.write('RIFF', 0, 'ascii');
-  bytes.writeUInt32LE(bytes.length - 8, 4);
-  bytes.write('WEBP', 8, 'ascii');
-  bytes.write('VP8X', 12, 'ascii');
-  bytes.writeUInt32LE(10, 16);
-  writeUInt24LE(bytes, 24, width - 1);
-  writeUInt24LE(bytes, 27, height - 1);
-  return bytes;
-}
-
-function writeUInt24LE(bytes: Buffer, offset: number, value: number): void {
-  bytes[offset] = value & 0xff;
-  bytes[offset + 1] = (value >>> 8) & 0xff;
-  bytes[offset + 2] = (value >>> 16) & 0xff;
-}
-
 describe('PetPackStore', () => {
   test('atomically installs, lists, reads, and removes a custom pet', async () => {
     await withStore(async ({ root, store }) => {
@@ -99,28 +81,6 @@ describe('PetPackStore', () => {
       assert.equal(await store.remove('likun.maodie'), true);
       assert.equal(await store.remove('likun.maodie'), false);
       assert.deepEqual(await store.list(), []);
-    });
-  });
-
-  test('accepts a WebP sprite sheet whose header matches the manifest grid', async () => {
-    await withStore(async ({ store }) => {
-      const webpManifest = manifest({
-        id: 'likun.maodie-webp',
-        spriteSheet: {
-          path: 'maodie.webp',
-          format: 'webp',
-          frameWidth: 32,
-          frameHeight: 32,
-          columns: 2,
-          rows: 2,
-          frameCount: 4,
-        },
-      });
-      await store.install({
-        manifest: webpManifest,
-        spriteSheet: webpExtendedHeader(64, 64),
-      });
-      assert.equal((await store.readSpriteSheet('likun.maodie-webp'))?.format, 'webp');
     });
   });
 


### PR DESCRIPTION
## Summary
- remove manifest success/decoder/fallback presentation tests
- remove duplicate canonical-id guard coverage already owned by storage boundaries
- remove WebP success-only store case and picker-cancellation no-op case with their dedicated helpers

## Review
- 7 tests and 122 lines removed
- retained executable-field rejection, path traversal/symlink containment, geometry and asset bounds, invalid references, atomic publication, duplicate protection, caller snapshotting, and corruption handling
- Biome and git diff checks pass
- test suites intentionally left to CI