### PR TITLE
test(runtime): remove skill happy paths

### DIFF
--- a/packages/runtime/src/__tests__/skills.test.ts
+++ b/packages/runtime/src/__tests__/skills.test.ts
@@ -1,13 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { createHash } from 'node:crypto';
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import {
-  MAX_SKILLS_PROMPT_TOKENS,
   MAX_SKILLS_PROMPT_CHARS,
-  MIN_SKILLS_PROMPT_TOKENS,
   MAX_SKILL_TOOL_BODY_CHARS,
   buildSkillAgentTool,
   buildSkillAgentToolFromInventory,
@@ -18,7 +15,6 @@ import {
   buildSkillsPromptFragmentWithReport,
   gateSkillsByHostCapabilities,
   loadSkillInstructions,
-  parseSkillFrontMatter,
   readSkillRuntimeState,
   resolveSkillsPromptCharBudget,
   resolveSkillDiscoveryPaths,
@@ -38,38 +34,6 @@ import { resolveSkillInvocations } from '../skill-invocation.js';
 import type { MakaToolContext } from '../tool-runtime.js';
 
 describe('runtime skills', () => {
-  it('validates typed SKILL.md metadata and accepts spec and Maka list forms', () => {
-    const result = validateSkillMetadata(`---
-name: writer
-description: Draft polished prose when the user asks for writing help.
-license: Apache-2.0
-compatibility: Requires a local workspace.
-metadata:
-  author: maka
-allowed-tools: Read Bash(git:*)
-required-tools: [Write]
-required-capabilities:
-  - workspace
----
-# Writer
-Use concise prose.`);
-
-    assert.equal(result.valid, true);
-    assert.deepEqual(result.issues, []);
-    assert.deepEqual(result.manifest, {
-      name: 'writer',
-      description: 'Draft polished prose when the user asks for writing help.',
-      allowedTools: ['Read', 'Bash(git:*)'],
-      requiredTools: ['Write'],
-      requiredCapabilities: ['workspace'],
-      license: 'Apache-2.0',
-      compatibility: 'Requires a local workspace.',
-      metadata: { author: 'maka' },
-      category: undefined,
-    });
-    assert.equal(result.body, '# Writer\nUse concise prose.');
-  });
-
   it('reports malformed and missing required metadata as structured errors', () => {
     const missingFrontmatter = validateSkillMetadata('# No metadata');
     assert.equal(missingFrontmatter.valid, false);
@@ -272,49 +236,6 @@ description: Duplicate display name.
       } finally {
         await rm(projectRoot, { recursive: true, force: true });
       }
-    });
-  });
-
-  it('scales the prompt catalog budget from model context with bounded fallback', () => {
-    assert.equal(resolveSkillsPromptCharBudget(), MAX_SKILLS_PROMPT_CHARS);
-    assert.equal(
-      resolveSkillsPromptCharBudget({ contextWindow: Number.NaN }),
-      MAX_SKILLS_PROMPT_CHARS,
-    );
-    assert.equal(
-      resolveSkillsPromptCharBudget({ contextWindow: 128_000 }),
-      MIN_SKILLS_PROMPT_TOKENS * 4,
-    );
-    assert.equal(resolveSkillsPromptCharBudget({ contextWindow: 300_000 }), 6_000 * 4);
-    assert.equal(
-      resolveSkillsPromptCharBudget({ contextWindow: 1_000_000 }),
-      MAX_SKILLS_PROMPT_TOKENS * 4,
-    );
-  });
-  it('scanWorkspaceSkills lists SKILL.md metadata with declared tools as declaration only', async () => {
-    await withWorkspace(async (workspaceRoot) => {
-      const body = `---
-name: Writer
-description: Draft polished prose.
-allowed-tools: [Read, Write]
----
-# Writer
-Use concise prose.`;
-      await writeSkill(workspaceRoot, 'writer', body);
-
-      const skills = await scanWorkspaceSkills(workspaceRoot);
-      assert.equal(skills.length, 1);
-      assert.equal(skills[0].id, 'writer');
-      assert.equal(skills[0].name, 'Writer');
-      assert.equal(skills[0].description, 'Draft polished prose.');
-      assert.deepEqual(skills[0].declaredTools, ['Read', 'Write']);
-      assert.equal(skills[0].enabled, true);
-      assert.equal(skills[0].runtimeStatus, 'enabled');
-      assert.match(skills[0].content, /Use concise prose\./);
-      assert.equal(
-        skills[0].contentSha256,
-        `sha256:${createHash('sha256').update(Buffer.from(body, 'utf8')).digest('hex')}`,
-      );
     });
   });
 
@@ -956,38 +877,6 @@ Plain work.`,
     assert.equal(withCap[0].hiddenReason, undefined);
   });
 
-  it('scanWorkspaceSkills surfaces required-tools and required-capabilities from front matter', async () => {
-    await withWorkspace(async (workspaceRoot) => {
-      await writeSkill(
-        workspaceRoot,
-        'gated-helper',
-        `---
-name: Gated Helper
-description: Host-specific work.
-allowed-tools: [Read]
-required-tools: [ImaginaryTool, ImaginaryEditTool]
-required-capabilities: [specialized]
----
-# Gated Helper
-Route through host tools.`,
-      );
-
-      const skills = await scanWorkspaceSkills(workspaceRoot);
-      assert.equal(skills.length, 1);
-      assert.equal(skills[0].id, 'gated-helper');
-      assert.deepEqual(skills[0].declaredTools, ['Read']);
-      assert.deepEqual(skills[0].requiredTools, ['ImaginaryTool', 'ImaginaryEditTool']);
-      assert.deepEqual(skills[0].requiredCapabilities, ['specialized']);
-    });
-  });
-
-  it('scanWorkspaceSkills returns empty when no skills directory exists', async () => {
-    await withWorkspace(async (workspaceRoot) => {
-      assert.deepEqual(await scanWorkspaceSkills(workspaceRoot), []);
-      assert.equal(await buildSkillsPromptFragment(workspaceRoot), undefined);
-    });
-  });
-
   it('scanSkills discovers skills from multiple directories and dedupes by id (first-found wins)', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const projectRoot = await mkdtemp(join(tmpdir(), 'maka-runtime-skills-proj-'));
@@ -1085,60 +974,6 @@ Body.`,
       '/home/user/.agents/skills',
     ]);
     assert.equal(stateRoot, '/workspace');
-  });
-
-  it('parseSkillFrontMatter parses inline and list-style allowed-tools', () => {
-    assert.deepEqual(
-      parseSkillFrontMatter(
-        '---\nname: A\ndescription: Desc one.\nallowed-tools: [Read, Write]\n---\nbody',
-      ),
-      {
-        name: 'A',
-        description: 'Desc one.',
-        allowedTools: ['Read', 'Write'],
-        requiredTools: [],
-        requiredCapabilities: [],
-      },
-    );
-    assert.deepEqual(
-      parseSkillFrontMatter(
-        '---\nname: B\ndescription: Desc two.\nallowed-tools:\n  - Read\n  - Bash\n---\nbody',
-      ),
-      {
-        name: 'B',
-        description: 'Desc two.',
-        allowedTools: ['Read', 'Bash'],
-        requiredTools: [],
-        requiredCapabilities: [],
-      },
-    );
-  });
-
-  it('parseSkillFrontMatter parses required-tools and required-capabilities alongside allowed-tools', () => {
-    assert.deepEqual(
-      parseSkillFrontMatter(
-        '---\nname: A\ndescription: Desc one.\nallowed-tools: [Read]\nrequired-tools: [ImaginaryTool, ImaginaryEditTool]\nrequired-capabilities: [specialized]\n---\nbody',
-      ),
-      {
-        name: 'A',
-        description: 'Desc one.',
-        allowedTools: ['Read'],
-        requiredTools: ['ImaginaryTool', 'ImaginaryEditTool'],
-        requiredCapabilities: ['specialized'],
-      },
-    );
-    assert.deepEqual(
-      parseSkillFrontMatter(
-        '---\nname: B\ndescription: Desc two.\nallowed-tools:\n  - Read\nrequired-tools:\n  - ImaginaryTool\n---\nbody',
-      ),
-      {
-        name: 'B',
-        description: 'Desc two.',
-        allowedTools: ['Read'],
-        requiredTools: ['ImaginaryTool'],
-        requiredCapabilities: [],
-      },
-    );
   });
 
   it('buildSkillsPromptFragment does not impose an arbitrary count limit', async () => {


### PR DESCRIPTION
## Summary
- remove standalone positive SKILL.md parser and metadata shape tests
- remove prompt budget formula and empty-directory mirrors
- remove redundant scanned field projection checks
- retain malformed/fail-closed, symlink containment, host gating, prompt budget enforcement, duplicate ownership, and no-arbitrary-count coverage

## Validation
- `npx biome check packages/runtime/src/__tests__/skills.test.ts`
- `git diff --check`
- manual test-ownership review

Test suites intentionally not run; CI owns execution.