### PR TITLE
test: remove runtime legacy compatibility cases

### DIFF
--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -413,82 +413,6 @@ test('restarts transcript loading after an expired snapshot', async () => {
   );
 });
 
-test('routes a legacy Host through incompatible replacement', async () => {
-  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-legacy-epoch-'));
-  const capability = await resolveStorageRoot({
-    path: join(base, 'root'),
-    kind: 'interactive',
-  });
-  const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
-  const hostEpoch = randomUUID();
-  const endpoint = await prepareRuntimeHostEndpoint({ rootId: capability.rootId, hostEpoch });
-  const serverTask = deferred<void>();
-  const server = createServer((socket) => {
-    void (async () => {
-      const transport = new FramedTransport(socket);
-      const hello = decodeClientFrame(await transport.read(1_000));
-      assert.ok('kind' in hello && hello.kind === 'hello');
-      if (!('kind' in hello) || hello.kind !== 'hello') return;
-      assert.deepEqual(
-        { min: hello.protocolMin, max: hello.protocolMax },
-        { min: RUNTIME_HOST_PROTOCOL_VERSION + 1, max: RUNTIME_HOST_PROTOCOL_VERSION + 1 },
-      );
-      await writeRawLocalIpc(
-        transport,
-        encodeLegacyProtocolFrame({
-          kind: 'incompatible',
-          hostEpoch,
-          protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
-          protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
-          state: 'ready',
-          replacement: 'wait_for_idle_exit',
-        }),
-      );
-      transport.closeAfterFlush();
-      await transport.closed;
-    })().then(serverTask.resolve, serverTask.reject);
-  });
-  try {
-    await listen(server, endpoint.path);
-    await endpoint.prepareAfterListen();
-    await writeHostRegistration(controlDirectory, {
-      kind: 'maka-runtime-host',
-      schemaVersion: RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
-      rootId: capability.rootId,
-      hostEpoch,
-      endpoint: endpoint.path,
-      protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
-      protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
-      compatibilityEpoch: 0,
-      compositionId: 'maka.interactive',
-      compositionRevision: '1',
-      state: 'ready',
-      pid: process.pid,
-      createdAt: new Date().toISOString(),
-    });
-
-    const result = await connectRuntimeHost({
-      rootPath: join(base, 'root'),
-      surface: 'desktop',
-      protocol: PROTOCOL,
-    });
-    assert.equal(result.kind, 'incompatible');
-    if (result.kind === 'incompatible') {
-      assert.equal(result.registration.compatibilityEpoch, 0);
-      assert.equal(result.handshake.compatibilityEpoch, 0);
-      assert.equal(result.handshake.compositionId, 'maka.interactive');
-      assert.equal(result.handshake.compositionRevision, 'legacy');
-      assert.equal(result.handshake.replacement, 'wait_for_idle_exit');
-    }
-    await serverTask.promise;
-  } finally {
-    await closeServer(server);
-    await removeHostRegistration(controlDirectory, hostEpoch).catch(() => undefined);
-    await endpoint.cleanup().catch(() => undefined);
-    await rm(base, { recursive: true, force: true });
-  }
-});
-
 async function withProtocolPeer(
   serve: (transport: FramedTransport, hostEpoch: string, rootId: string) => Promise<void>,
   run: (connection: RuntimeHostConnection) => Promise<void>,
@@ -681,10 +605,6 @@ function writeRawLocalIpc(transport: FramedTransport, frame: Uint8Array): Promis
   return new Promise((resolve, reject) => {
     transport.socket.write(frame, (error) => (error ? reject(error) : resolve()));
   });
-}
-
-function encodeLegacyProtocolFrame(frame: unknown): Buffer {
-  return Buffer.from(`${JSON.stringify(frame)}\n`, 'utf8');
 }
 
 function listen(server: Server, path: string): Promise<void> {

--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { createServer } from 'node:http';
 import net from 'node:net';
-import { afterEach, describe, test } from 'node:test';
+import { describe, test } from 'node:test';
 import { PROXY_DEFAULTS, type ProxySettings } from '@maka/core/settings/network-settings';
 import {
   CONNECTION_EFFECT_ERROR_BODY_MAX_BYTES,
@@ -9,12 +9,9 @@ import {
   ConnectionEffectFetchError,
   fetchForConnectionEffect,
 } from '../../connection-effect-fetch.js';
-import { fetchProviderModels, runConnectionModelDiscoveryEffect } from '../../model-fetcher.js';
+import { runConnectionModelDiscoveryEffect } from '../../model-fetcher.js';
 import { runConnectionTestEffect, testConnection } from '../../test-connection.js';
-import { setActiveProxy } from '../active-proxy-state.js';
 import { createConnectionEffectFetchTransport } from '../scoped-fetch-transport.js';
-
-afterEach(() => setActiveProxy(null));
 
 describe('connection effect network transport', () => {
   test('concurrent discovery uses immutable per-effect proxy snapshots', async () => {
@@ -274,29 +271,6 @@ describe('connection effect network transport', () => {
     } finally {
       await transport.close();
       await closeServer(server);
-    }
-  });
-
-  test('legacy discovery fallback still resolves the Desktop active proxy', async () => {
-    const proxy = await startConnectProxy(() =>
-      jsonResponse(200, modelPayload('desktop-global-model')),
-    );
-    setActiveProxy({
-      ...PROXY_DEFAULTS,
-      enabled: true,
-      host: '127.0.0.1',
-      port: proxy.port,
-      bypassList: [],
-    });
-
-    try {
-      assert.deepEqual(await fetchProviderModels(openAiConnection('desktop'), 'provider-key'), [
-        { id: 'desktop-global-model' },
-      ]);
-      assert.equal(proxy.requestCount, 1);
-    } finally {
-      setActiveProxy(null);
-      await proxy.close();
     }
   });
 

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -221,28 +221,6 @@ describe('SqliteSessionMetadataStore', () => {
     }
   });
 
-  test('creates a deterministic revision-zero execution boundary for every legacy mode', async () => {
-    const store = createSqliteSessionMetadataStore(':memory:');
-    try {
-      for (const mode of ['ask', 'execute', 'explore', 'bypass'] as const) {
-        const header = fullHeader({
-          id: `legacy-${mode}`,
-          permissionMode: mode as SessionHeader['permissionMode'],
-        });
-        await store.create(header);
-
-        const boundary = await store.readExecutionBoundary(header.id);
-        assert.equal(boundary.revision, 0);
-        assert.equal(boundary.kind, mode === 'bypass' ? 'bypass' : 'managed');
-        if (boundary.kind === 'managed') {
-          assert.equal(boundary.profile.name, mode === 'explore' ? 'read-only' : 'workspace-write');
-        }
-      }
-    } finally {
-      store.close();
-    }
-  });
-
   test('persists an explicitly supplied external genesis boundary', async () => {
     const store = createSqliteSessionMetadataStore(':memory:');
     try {
@@ -652,27 +630,6 @@ describe('SqliteSessionMetadataStore', () => {
       if (restored.kind === 'managed') {
         assert.equal(canReadPath(restored.profile, '/outside/kept/file.txt'), true);
       }
-    } finally {
-      store.close();
-    }
-  });
-
-  test('projects an explicit legacy mode in the same managed-boundary transition', async () => {
-    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNow(250) });
-    try {
-      await store.create(fullHeader({ labels: ['deep-research', 'kept'] }));
-
-      const explore = await store.setExecutionBoundaryKind('session-1', 'managed', {
-        permissionMode: 'explore',
-        labels: ['kept'],
-      });
-
-      assert.equal(explore.kind, 'managed');
-      assert.equal(explore.revision, 1);
-      if (explore.kind === 'managed') assert.equal(explore.profile.name, 'read-only');
-      const projected = (await store.read('session-1')).header;
-      assert.equal(projected.permissionMode, 'explore');
-      assert.deepEqual(projected.labels, ['kept']);
     } finally {
       store.close();
     }


### PR DESCRIPTION
## Summary
- remove Desktop global-proxy discovery fallback coverage
- remove legacy Session permission-mode projections from SQLite metadata tests
- remove legacy Runtime Host frame replacement coverage and its private encoder

## Preserved ownership
- immutable per-effect proxy snapshots and current discovery errors
- managed/bypass/Explore authority transitions and transactionality
- current Runtime Host compatibility and replacement behavior

## Validation
- Biome check on all changed files
- `git diff --check`
- manual test-ownership and helper reachability review

Test suites intentionally not run; CI owns execution.