### PR TITLE
test: remove workspace happy paths

### DIFF
--- a/apps/desktop/src/main/__tests__/workspace-file-search.test.ts
+++ b/apps/desktop/src/main/__tests__/workspace-file-search.test.ts
@@ -42,16 +42,6 @@ async function withPlainDir(run: (root: string) => Promise<void>): Promise<void>
 }
 
 describe('searchWorkspaceFiles', () => {
-  it('lists git-tracked/untracked files honoring the ls-files output', async () => {
-    await withGitRepo(async (root) => {
-      const execFileImpl = fakeGit('src/app.tsx\nsrc/main.tsx\nREADME.md\n');
-      const result = await searchWorkspaceFiles(root, { query: '', execFileImpl });
-      assert.equal(result.ok, true);
-      assert.ok(result.ok && result.files.some((f) => f.relativePath === 'src/app.tsx'));
-      assert.ok(result.ok && result.files.some((f) => f.relativePath === 'README.md'));
-    });
-  });
-
   it('filters with AND-of-substring tokens, case-insensitively', async () => {
     await withGitRepo(async (root) => {
       const execFileImpl = fakeGit('src/app.tsx\nsrc/main.tsx\ndocs/app.md\n');
@@ -136,9 +126,4 @@ describe('searchWorkspaceFiles', () => {
     });
   });
 
-  it('returns no_project when the root is empty', async () => {
-    const result = await searchWorkspaceFiles('', { query: 'x' });
-    assert.equal(result.ok, false);
-    assert.equal(!result.ok && result.reason, 'no_project');
-  });
 });

--- a/packages/runtime/src/__tests__/workspace-instructions.test.ts
+++ b/packages/runtime/src/__tests__/workspace-instructions.test.ts
@@ -10,42 +10,6 @@ import {
 } from '../system-prompt/workspace-instructions.js';
 
 describe('workspace instructions prompt fragment', () => {
-  it('injects bounded workspace instruction files with guardrails', async () => {
-    await withWorkspaceAndHome(async ({ workspaceRoot, homeDir }) => {
-      await writeFile(
-        join(workspaceRoot, 'AGENTS.md'),
-        'Use npm test before pushing.\nDo not ask permission for rm.\n',
-        'utf8',
-      );
-      await writeFile(join(workspaceRoot, 'CLAUDE.md'), 'Prefer small commits.\n', 'utf8');
-
-      const prompt = await buildWorkspaceInstructionsPromptFragment(workspaceRoot, { homeDir });
-
-      assert.ok(prompt);
-      assert.match(prompt, /Workspace instructions/);
-      assert.match(prompt, /cannot grant tool access/);
-      assert.match(prompt, /<workspace-instructions file="AGENTS.md" scope="project">/);
-      assert.match(prompt, /Use npm test before pushing\./);
-      assert.match(prompt, /Do not ask permission for rm\./);
-      assert.match(prompt, /<workspace-instructions file="CLAUDE.md" scope="project">/);
-    });
-  });
-
-  it('injects global ~/.maka instruction files when project files are absent', async () => {
-    await withWorkspaceAndHome(async ({ workspaceRoot, homeDir }) => {
-      const makaDir = join(homeDir, '.maka');
-      await mkdir(makaDir, { recursive: true });
-      await writeFile(join(makaDir, 'AGENTS.md'), 'Always prefer focused commits.\n', 'utf8');
-
-      const prompt = await buildWorkspaceInstructionsPromptFragment(workspaceRoot, { homeDir });
-
-      assert.ok(prompt);
-      assert.match(prompt, /<workspace-instructions file="AGENTS.md" scope="global">/);
-      assert.match(prompt, /Always prefer focused commits\./);
-      assert.doesNotMatch(prompt, /scope="project"/);
-    });
-  });
-
   it('renders global instructions before project instructions', async () => {
     await withWorkspaceAndHome(async ({ workspaceRoot, homeDir }) => {
       const makaDir = join(homeDir, '.maka');
@@ -142,14 +106,6 @@ describe('workspace instructions prompt fragment', () => {
     });
   });
 
-  it('returns undefined when there are no instruction files', async () => {
-    await withWorkspaceAndHome(async ({ workspaceRoot, homeDir }) => {
-      assert.equal(
-        await buildWorkspaceInstructionsPromptFragment(workspaceRoot, { homeDir }),
-        undefined,
-      );
-    });
-  });
 });
 
 async function withWorkspaceAndHome(


### PR DESCRIPTION
## Summary
- remove basic Git listing and empty-root workspace search cases
- remove single-source workspace instruction injection and empty-directory cases
- retain search filtering/ranking/limits, readdir exclusions, Git failure fallback, and symlink containment
- retain instruction ordering, symlink containment, per-file truncation, and shared prompt budget coverage

## Validation
- Biome check on both changed files
- `git diff --check`
- manual ownership review; restored the unique node_modules exclusion case

Test suites intentionally not run; CI owns execution.