### PR TITLE
test: remove basic projection cases

### DIFF
--- a/apps/desktop/src/main/__tests__/task-submission-readiness-main.test.ts
+++ b/apps/desktop/src/main/__tests__/task-submission-readiness-main.test.ts
@@ -6,24 +6,6 @@ import {
   resolveStoredModelTarget,
 } from '../task-submission-readiness-main.js';
 
-test('resolves defaults and projects authoritative model and workspace readiness', async () => {
-  const service = createDesktopTaskSubmissionReadinessService({
-    workspaceRoot: '/workspace',
-    runtimeState: () => ({ state: 'ready', checkedAt: 90 }),
-    resolveModelTarget: async () => ({ kind: 'resolved', connection: connection(), hasSecret: true }),
-    inspectWorkspace: async () => 'ready',
-    now: () => 100,
-  });
-
-  const snapshot = await service.getSnapshot(undefined);
-  assert.equal(snapshot.state, 'ready');
-  assert.deepEqual(snapshot.dimensions.map(({ id }) => id), [
-    'runtime',
-    'model_target',
-    'workspace',
-  ]);
-});
-
 test('keeps credential lookup failure unknown instead of inventing a repair failure', async () => {
   const service = createDesktopTaskSubmissionReadinessService({
     workspaceRoot: '/workspace',

--- a/packages/runtime/src/__tests__/computer-use-menu.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-menu.test.ts
@@ -132,16 +132,6 @@ test('a menu cut short by the executor says so, and a menu merely unopened does 
   assert.doesNotMatch(renderObservationForModel(observation()), /truncated=true\(this menu/);
 });
 
-test('an observation with no menu bar renders as it did before menus existed', () => {
-  const base = observation();
-  const text = renderObservationForModel({
-    ...base,
-    elements: base.elements.slice(0, 3),
-  });
-  assert.doesNotMatch(text, /menu_bar=/);
-  assert.match(text, /elements=3$/m);
-});
-
 test('a wrapper around exactly one thing is collapsed, and its child keeps its id', () => {
   // `mergeSingleItemGroups`, which is one of the thirteen transforms Codex's own
   // renderer runs. Measured here: VS Code 172 of 985 elements, Calculator 4 of

--- a/packages/runtime/src/__tests__/computer-use-query.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-query.test.ts
@@ -94,10 +94,3 @@ test('a query matches a role and a value, not only a label', () => {
   assert.match(renderObservationForModel(observation('AXButton')), /9 AXButton "共享"/);
   assert.match(renderObservationForModel(observation('共享')), /9 AXButton "共享"/);
 });
-
-test('no query renders the window as before', () => {
-  const text = renderObservationForModel(observation());
-  assert.doesNotMatch(text, /query=/);
-  assert.match(text, /文稿/);
-  assert.match(text, /共享/);
-});


### PR DESCRIPTION
## Summary
- remove all-ready Desktop readiness shape coverage
- remove no-query and no-menu backward-presentation cases
- retain readiness unknown/unavailable/repair routing and Computer Use filter/menu semantics

## Review note
A pricing normalizer success test was considered, then retained because it is the sole positive owner preventing an always-invalid implementation.

## Validation
- Biome check on all changed files
- `git diff --check`
- manual positive/negative ownership review

Test suites intentionally not run; CI owns execution.