### PR TITLE
test(desktop): remove lifecycle happy paths

### DIFF
--- a/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
@@ -3,26 +3,6 @@ import { describe, it } from 'node:test';
 import { createAppQuitCoordinator } from '../app-quit-coordinator.js';
 
 describe('app quit coordinator', () => {
-  it('focuses or creates the main window while the app is running', () => {
-    let focusOrCreateCount = 0;
-    let windowCreationSignal: AbortSignal | undefined;
-    const coordinator = createAppQuitCoordinator({
-      cleanup: async () => {},
-      focusOrCreateWindow: (signal?: AbortSignal) => {
-        focusOrCreateCount += 1;
-        windowCreationSignal = signal;
-      },
-      onCleanupError: () => {},
-      resumeQuit: () => {},
-    });
-
-    coordinator.focusOrCreateWindow();
-
-    assert.equal(focusOrCreateCount, 1);
-    assert.equal(windowCreationSignal?.aborted, false);
-    assert.equal(coordinator.getWindowCreationSignal(), windowCreationSignal);
-  });
-
   it('keeps quit prevented until it resumes in a fresh event-loop turn', async () => {
     let resumeQuitCount = 0;
     let preventedCount = 0;

--- a/apps/desktop/src/main/__tests__/browser-view-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-view-manager.test.ts
@@ -38,15 +38,6 @@ function makeManager() {
 }
 
 describe('BrowserViewManager', () => {
-  it('creates a view once and reuses it', () => {
-    const { manager, created } = makeManager();
-    const a = manager.getOrCreate('s1');
-    const b = manager.getOrCreate('s1');
-    assert.equal(a, b);
-    assert.equal(created.length, 1);
-    assert.equal(manager.liveCount(), 1);
-  });
-
   it('fires onLiveChange on create and dispose, not on reuse', async () => {
     const { manager, liveSets } = makeManager();
     manager.getOrCreate('s1');

--- a/apps/desktop/src/main/__tests__/keep-system-awake.test.ts
+++ b/apps/desktop/src/main/__tests__/keep-system-awake.test.ts
@@ -34,17 +34,6 @@ function createFakeBlocker() {
 }
 
 describe('keep-system-awake controller', () => {
-  it('starts a prevent-app-suspension blocker when enabled', () => {
-    const fake = createFakeBlocker();
-    const controller = createKeepSystemAwakeController(fake.blocker);
-
-    controller.apply(true);
-
-    assert.deepEqual(fake.startCalls, ['prevent-app-suspension']);
-    assert.equal(controller.isActive(), true);
-    assert.equal(fake.started.size, 1);
-  });
-
   it('does NOT force the display on (never uses prevent-display-sleep)', () => {
     const fake = createFakeBlocker();
     const controller = createKeepSystemAwakeController(fake.blocker);
@@ -68,29 +57,6 @@ describe('keep-system-awake controller', () => {
     assert.equal(fake.startCalls.length, 1, 'blocker must start exactly once');
     assert.equal(fake.started.size, 1);
     assert.equal(controller.isActive(), true);
-  });
-
-  it('stops the blocker when disabled', () => {
-    const fake = createFakeBlocker();
-    const controller = createKeepSystemAwakeController(fake.blocker);
-
-    controller.apply(true);
-    controller.apply(false);
-
-    assert.equal(fake.stopCalls.length, 1);
-    assert.equal(fake.started.size, 0);
-    assert.equal(controller.isActive(), false);
-  });
-
-  it('disabling when nothing is held is a no-op', () => {
-    const fake = createFakeBlocker();
-    const controller = createKeepSystemAwakeController(fake.blocker);
-
-    controller.apply(false);
-
-    assert.equal(fake.startCalls.length, 0);
-    assert.equal(fake.stopCalls.length, 0);
-    assert.equal(controller.isActive(), false);
   });
 
   it('re-enabling after a stop starts a fresh blocker', () => {


### PR DESCRIPTION
## Summary
- remove basic keep-awake start/stop/no-op cases
- remove ordinary app focus and BrowserView create/reuse cases
- retain double-start, re-acquire, refcount, cleanup race/failure, live-change, disposal, and leak invariants

## Validation
- Biome check on all changed files
- `git diff --check`
- manual lifecycle ownership review

Test suites intentionally not run; CI owns execution.