### PR TITLE
refactor(runtime): remove legacy archive URI format

### DIFF
--- a/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
+++ b/packages/runtime/src/__tests__/tool-result-archive-resource.test.ts
@@ -19,23 +19,15 @@ describe('tool-result archive resources', () => {
       originalBytes: Buffer.byteLength(body),
     };
     const ref = buildToolResultArchiveResourceRef(identity);
-    const legacyRef = `maka://archive/${identity.artifactId}?sha256=${identity.bodySha256}&bytes=${identity.originalBytes}`;
 
     assert.match(ref, /^maka:\/\/archive\//);
     assert.doesNotMatch(ref, /[?&]/);
     assert.deepEqual(parseToolResultArchiveResourceRef(ref), identity);
-    assert.deepEqual(parseToolResultArchiveResourceRef(legacyRef), identity);
-    assert.equal(
-      parseToolResultArchiveResourceRef(
-        `maka://archive/${identity.artifactId}?sha256=${identity.bodySha256}`,
-      ),
-      null,
-    );
     assert.equal(parseToolResultArchiveResourceRef('tool-result-archive-abc'), null);
     assert.equal(parseToolResultArchiveResourceRef('maka://runtime/background-tasks/1'), null);
-    assert.equal(parseToolResultArchiveResourceRef(`${ref}&unexpected=true`), null);
+    assert.equal(parseToolResultArchiveResourceRef(`${ref}?unexpected=true`), null);
     assert.equal(
-      parseToolResultArchiveResourceRef('maka://archive/%E0%A4%A?sha256=0&bytes=1'),
+      parseToolResultArchiveResourceRef(`maka://archive/%E0%A4%A/${'0'.repeat(64)}/1`),
       null,
     );
   });

--- a/packages/runtime/src/tool-result-archive-resource.ts
+++ b/packages/runtime/src/tool-result-archive-resource.ts
@@ -66,34 +66,15 @@ export function parseToolResultArchiveResourceRef(
     return null;
   }
   const pathParts = url.pathname.split('/').filter(Boolean);
-  if (url.hash) return null;
+  if (url.hash || url.search || pathParts.length !== 3) return null;
   let artifactId: string;
+  let bodySha256: string;
+  let bytesText: string;
   try {
     artifactId = decodeURIComponent(pathParts[0] ?? '');
+    bodySha256 = decodeURIComponent(pathParts[1] ?? '');
+    bytesText = decodeURIComponent(pathParts[2] ?? '');
   } catch {
-    return null;
-  }
-  let bodySha256 = '';
-  let bytesText = '';
-  if (pathParts.length === 3 && url.search === '') {
-    try {
-      bodySha256 = decodeURIComponent(pathParts[1] ?? '');
-      bytesText = decodeURIComponent(pathParts[2] ?? '');
-    } catch {
-      return null;
-    }
-  } else if (pathParts.length === 1) {
-    const queryKeys = [...url.searchParams.keys()];
-    if (
-      queryKeys.length !== 2 ||
-      queryKeys.filter((key) => key === 'sha256').length !== 1 ||
-      queryKeys.filter((key) => key === 'bytes').length !== 1
-    ) {
-      return null;
-    }
-    bodySha256 = url.searchParams.get('sha256') ?? '';
-    bytesText = url.searchParams.get('bytes') ?? '';
-  } else {
     return null;
   }
   if (


### PR DESCRIPTION
## Summary
- remove the legacy query-string ArchiveRead URI parser branch
- keep one canonical path-based URI contract
- remove test assertions that preserved the obsolete format while retaining canonical round-trip and malformed-ref coverage

## Validation
- `npx biome check packages/runtime/src/tool-result-archive-resource.ts packages/runtime/src/__tests__/tool-result-archive-resource.test.ts`
- `git diff --check`
- repository search confirms no legacy archive URI fixtures remain
- no test suite run; CI owns execution