### PR TITLE
test(storage): remove credential store scaffolding

### DIFF
--- a/packages/storage/src/__tests__/credential-store.test.ts
+++ b/packages/storage/src/__tests__/credential-store.test.ts
@@ -37,16 +37,6 @@ describe('FileCredentialStore', () => {
     });
   });
 
-  test('keeps Ollama Cloud credentials separate from local Ollama state', async () => {
-    await withTempDir(async (dir) => {
-      const store = createFileCredentialStore(dir);
-      await store.setSecret('ollama-cloud', 'api_key', 'ollama-cloud-test-key');
-
-      assert.equal(await store.getSecret('ollama-cloud', 'api_key'), 'ollama-cloud-test-key');
-      assert.equal(await store.getSecret('ollama-local', 'api_key'), null);
-    });
-  });
-
   test('deleteSecret(slug) with no kind clears every kind for that slug only', async () => {
     await withTempDir(async (dir) => {
       const store = createFileCredentialStore(dir);
@@ -233,13 +223,6 @@ describe('FileCredentialStore compareAndSetSecret', () => {
     return store.compareAndSetSecret(slug, kind, expected, value);
   }
 
-  test('the file store advertises the optional CAS capability', async () => {
-    await withTempDir(async (dir) => {
-      const store = createFileCredentialStore(dir);
-      assert.equal(typeof store.compareAndSetSecret, 'function');
-    });
-  });
-
   test('commits when the basis still matches, and the write persists', async () => {
     await withTempDir(async (dir) => {
       const store = createFileCredentialStore(dir);
@@ -253,9 +236,8 @@ describe('FileCredentialStore compareAndSetSecret', () => {
 
   test('commits a write-if-absent (expected null) only while the entry is absent', async () => {
     await withTempDir(async (dir) => {
-      // The one-shot legacy import: decide "store has no token" and write in one
-      // serialized step. A value written between the check and the write must
-      // make the import lose, not clobber.
+      // Decide "store has no token" and write in one serialized step. A value
+      // written between the check and the write must make this writer lose.
       const importer = createFileCredentialStore(dir);
       const other = createFileCredentialStore(dir);
 
@@ -332,18 +314,4 @@ describe('FileCredentialStore compareAndSetSecret', () => {
       assert.equal(await reader.getSecret('acct', 'oauth_token'), winnerValue);
     });
   });
-});
-
-describe('FileCredentialStore secret-kind + slug contract', () => {
-  // The on-disk stored-kind suffixes are a backward-compat contract: a
-  // migrated legacy file keeps the same `slug:kind` keys, so the suffix
-  // names must not drift.
-  const kindToStoredSuffix: Array<[CredentialKind, string]> = [
-    ['api_key', 'apiKey'],
-    ['oauth_token', 'oauthToken'],
-    ['bot_token', 'botToken'],
-    ['app_secret', 'botAppSecret'],
-    ['proxy_password', 'proxyPassword'],
-    ['tavily_api_key', 'tavilyApiKey'],
-  ];
 });


### PR DESCRIPTION
## Summary
- remove a provider-named key-isolation happy path already owned by generic slug tests
- remove a standalone CAS-presence assertion repeated by every CAS behavior test
- delete an empty legacy suffix describe block and stale import wording

## Validation
- `npx biome check packages/storage/src/__tests__/credential-store.test.ts`
- `git diff --check`
- ownership audit retains CRUD, filesystem permissions, atomic writes, locks, and CAS races
- no test suite run; CI owns execution