### PR TITLE
test(runtime): remove backend error wrapper coverage

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -5972,30 +5972,6 @@ describe('AiSdkBackend error surfaces', () => {
       },
     });
   });
-
-  test('model stream timeout errors carry a stable reason for turn-history UI', () => {
-    const backend = createTestAiSdkBackend({
-      sessionId: 'session-1',
-      header: header(),
-      appendMessage: async () => {},
-      connection: connection(),
-      apiKey: 'sk-test',
-      modelId: 'claude-sonnet-4-5-20250929',
-      modelFactory: () => ({}),
-      tools: [],
-      newId: idGenerator(),
-      now: () => 1,
-    });
-
-    const event = (
-      backend as unknown as {
-        makeErrorEvent(turnId: string, err: unknown): Extract<SessionEvent, { type: 'error' }>;
-      }
-    ).makeErrorEvent('turn-1', new Error('Model stream idle timeout after 120000ms'));
-
-    assert.equal(event.message, 'Request timed out');
-    assert.equal(event.reason, 'timeout');
-  });
 });
 
 describe('AiSdkBackend usage telemetry', () => {


### PR DESCRIPTION
## Summary
- remove a private AiSdkBackend wrapper test that duplicates ModelAdapter timeout classification
- retain the direct adapter owner and watchdog formatter coverage

## Validation
- `npx biome check packages/runtime/src/__tests__/ai-sdk-backend.test.ts`
- `git diff --check`
- ownership search confirms the delegate and direct test remain
- no test suite run; CI owns execution