### PR TITLE
test(runtime): remove duplicate projection case

### DIFF
--- a/packages/runtime/src/__tests__/session-projection-helpers.test.ts
+++ b/packages/runtime/src/__tests__/session-projection-helpers.test.ts
@@ -134,15 +134,6 @@ describe('session projection helpers', () => {
     });
   });
 
-  test('only resumes a sandbox boundary projection when authority permits it', () => {
-    const decision = { type: 'sandbox_boundary_decision_ack', ts: 1 } as never;
-
-    expect(statusFromEvent(decision, { allowInteractionResume: true })).toEqual({
-      status: 'running',
-    });
-    expect(statusFromEvent(decision, { allowInteractionResume: false })).toBeUndefined();
-  });
-
   test('projects turn terminal events without changing failure classes', () => {
     expect(turnStatusFromEvent({ type: 'abort', ts: 1 } as never)).toEqual({ status: 'aborted' });
     expect(turnStatusFromEvent({ type: 'error', ts: 1, reason: 'tool_failed' } as never)).toEqual({


### PR DESCRIPTION
## Summary
- remove a sandbox-boundary projection test duplicated by the preceding status matrix
- retain default resume and authority-denied behavior for both interaction types

## Validation
- `npx biome check packages/runtime/src/__tests__/session-projection-helpers.test.ts`
- `git diff --check`
- ownership search confirms both branches remain covered
- no test suite run; CI owns execution