### PR TITLE
test(runtime): trim materializer status matrix

### DIFF
--- a/packages/runtime/src/__tests__/materializer.test.ts
+++ b/packages/runtime/src/__tests__/materializer.test.ts
@@ -199,8 +199,6 @@ describe('materializeSession', () => {
   // while the turn runs, so does the call.
   for (const [turnStatus, expected] of [
     ['running', 'running'],
-    ['aborted', 'interrupted'],
-    ['failed', 'interrupted'],
     ['completed', 'interrupted'],
   ] as const) {
     test(`resultless tool_call in a ${turnStatus} turn → ${expected}`, () => {


### PR DESCRIPTION
## Summary
- reduce equivalent aborted/failed/completed matrix rows to one terminal representative
- retain running, terminal, and missing-turn branches
- remove two dynamically generated tests

## Validation
- `npx biome check packages/runtime/src/__tests__/materializer.test.ts`
- `git diff --check`
- branch ownership audit against `unfinishedToolActivityStatus`
- no test suite run; CI owns execution