### PR TITLE
test(core): remove recursive cleanup overlap

### DIFF
--- a/packages/core/src/__tests__/tool-args-identity.test.ts
+++ b/packages/core/src/__tests__/tool-args-identity.test.ts
@@ -88,18 +88,6 @@ describe('stripUndefinedDeep', () => {
     );
   });
 
-  it('reaches an undefined nested inside an array', () => {
-    const value = { calls: [{ id: 'a', toolId: undefined }] };
-
-    assert.deepEqual(stripUndefinedDeep(value), { calls: [{ id: 'a' }] });
-  });
-
-  it('leaves everything else exactly as it was', () => {
-    const value = { a: 0, b: '', c: false, d: null, e: [1, 2], f: { g: 1 } };
-
-    assert.deepEqual(stripUndefinedDeep(value), value);
-  });
-
   it('returns the value itself when nothing needed removing', () => {
     // Rebuilding a value that needed nothing would drop symbol keys and re-run
     // getters for no gain, and by far the common case is that nothing needs


### PR DESCRIPTION
## Summary
- remove the nested-array composition test already owned by the object and array branch tests
- remove the deep-equality no-op test already superseded by the stronger identity-preservation test

## Validation
- `npx biome check packages/core/src/__tests__/tool-args-identity.test.ts`
- `git diff --check`
- ownership and reference audit only; test suites intentionally left to CI