### PR TITLE
test: remove copy and fetch happy paths

### DIFF
--- a/apps/desktop/src/main/__tests__/external-session-import-lifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/external-session-import-lifecycle.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { ExternalSessionImportLifecycle } from '../../renderer/external-session-import-lifecycle.js';
-import { getExternalSessionImportCopy } from '../../renderer/locales/external-session-import-copy.js';
 
 test('blocks dialog close while an import is active', () => {
   const lifecycle = new ExternalSessionImportLifecycle();
@@ -25,15 +24,4 @@ test('invalidates an old completion before a later dialog lifetime starts', () =
   assert.equal(lifecycle.finish(oldToken), false);
   assert.equal(lifecycle.isCurrent(newToken), true);
   assert.equal(lifecycle.canClose(), false);
-});
-
-test('commit uncertainty copy directs users to inspect sessions before retrying', () => {
-  const zhCopy = getExternalSessionImportCopy('zh');
-  const enCopy = getExternalSessionImportCopy('en');
-
-  assert.match(zhCopy.importOutcomeUnknownDescription, /检查 Maka 会话列表/);
-  assert.match(zhCopy.importOutcomeUnknownDescription, /不要再次导入/);
-  assert.doesNotMatch(zhCopy.importOutcomeUnknownDescription, /请重试/);
-  assert.match(enCopy.importOutcomeUnknownDescription, /check the Maka Session list/i);
-  assert.match(enCopy.importOutcomeUnknownDescription, /do not import it again/i);
 });

--- a/packages/runtime/src/__tests__/local-web-fetch.test.ts
+++ b/packages/runtime/src/__tests__/local-web-fetch.test.ts
@@ -2,19 +2,6 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { createLocalWebFetchExecutor, WEB_FETCH_RESPONSE_MAX_BYTES } from '../local-web-fetch.js';
 
-test('local WebFetch passes plain text through', async () => {
-  const executor = createLocalWebFetchExecutor({
-    fetch: async () =>
-      new Response('plain body', {
-        headers: { 'content-type': 'text/plain; charset=utf-8' },
-      }),
-  });
-
-  const result = await executor.fetch({ url: 'https://example.com/readme', sessionId: 's1' });
-
-  assert.equal(result, 'plain body');
-});
-
 test('local WebFetch decodes the charset declared by the response', async () => {
   const executor = createLocalWebFetchExecutor({
     fetch: async () =>


### PR DESCRIPTION
## Summary
- remove a localization-copy regex snapshot unrelated to import lifecycle behavior
- remove a plain-text WebFetch happy path already owned by the private-network allow-boundary test

## Validation
- `npx biome check apps/desktop/src/main/__tests__/external-session-import-lifecycle.test.ts packages/runtime/src/__tests__/local-web-fetch.test.ts`
- `git diff --check`
- reference and test-ownership audit only; test suites intentionally left to CI