### PR TITLE
test: trim incidental happy and presentation checks

### DIFF
--- a/apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts
@@ -62,10 +62,7 @@ test('formats one redacted Desktop and Runtime Host diagnostic report', () => {
     new Date('2026-08-09T00:00:00Z'),
   );
 
-  assert.match(report, /Recent main-process logs \(1\)\nmain log/);
-  assert.match(report, /Build: dev @ a{12}/);
   assert.match(report, /Runtime Host[\s\S]*Recent Runtime Host logs \(1\)\nhost log/);
-  assert.match(report, /Protocol: v0 · compatibility 16/);
   assert.match(report, /Workspace: ~\/\.local\/share\/maka\/workspaces\/default/);
   assert.doesNotMatch(report, /sk-secretvalue123|\/home\/tester/);
 });
@@ -207,6 +204,4 @@ test('copies bounded evidence for the exact failed Turn', async () => {
   assert.deepEqual(result, { ok: true });
   assert.match(clipboard, /Runtime Host execution[\s\S]*Run: run-1/);
   assert.match(clipboard, /Failure message: No endpoints accepted the request/);
-  assert.match(clipboard, /openrouter\/openrouter\/free · failed · 3501ms/);
-  assert.match(clipboard, /attempt-1 · failed · 3501ms · unknown/);
 });

--- a/packages/runtime/src/__tests__/filesystem-apply-patch.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-apply-patch.test.ts
@@ -42,7 +42,7 @@ test('deletes a self-referential symlink entry without following it', {
   await assert.rejects(readFile(link, 'utf8'), { code: 'ENOENT' });
 });
 
-test('creates nested files exclusively and deletes their entries', async (t) => {
+test('creates nested files exclusively', async (t) => {
   const cwd = await temporaryDirectory(t);
   await writeFile(join(cwd, 'existing.txt'), 'keep\n', 'utf8');
   const filesystem = localFilesystem();
@@ -64,14 +64,6 @@ test('creates nested files exclusively and deletes their entries', async (t) => 
   );
   assert.equal(await readFile(join(cwd, 'existing.txt'), 'utf8'), 'keep\n');
 
-  assert.deepEqual(
-    await filesystem.applyPatch({
-      cwd,
-      operation: { type: 'delete_file', path: 'nested/file.txt' },
-    }),
-    { status: 'completed' },
-  );
-  await assert.rejects(readFile(join(cwd, 'nested/file.txt'), 'utf8'), { code: 'ENOENT' });
 });
 
 test('does not report an invalid backend result as completed', async (t) => {


### PR DESCRIPTION
## Summary
- remove a duplicate ordinary delete subcase already owned by the stronger symlink deletion boundary test
- remove diagnostic report copy-format assertions while retaining redaction, evidence, routing, and failure behavior

## Validation
- `npx biome check packages/runtime/src/__tests__/filesystem-apply-patch.test.ts apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts`
- `git diff --check`
- branch ownership and reference audit only; test suites intentionally left to CI