### PR TITLE
test(desktop): remove shell capture implementation tests

### DIFF
--- a/apps/desktop/src/main/__tests__/shell-env.test.ts
+++ b/apps/desktop/src/main/__tests__/shell-env.test.ts
@@ -292,12 +292,12 @@ describe('selectLoginShell', () => {
 
 describe('buildCaptureCommand', () => {
   describe('POSIX family (bash / zsh / fish / sh)', () => {
-    it('zsh produces the -i -l -c argv and a flush-marker payload', () => {
-      const { command, shellArgs } = buildCaptureCommand('zsh', '/usr/bin/node', MARK);
+    it('escapes the executable and produces a flush-marker payload', () => {
+      const { command, shellArgs } = buildCaptureCommand('bash', "/Users/Bob's/node", MARK);
       assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
       assert.equal(
         command,
-        `'/usr/bin/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
+        `'/Users/Bob'\\''s/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
       );
       // The payload concatenates mark + JSON + mark with no separator, so the
       // emitted bytes are `<mark>{...}<mark>` — markers flush against the
@@ -306,17 +306,6 @@ describe('buildCaptureCommand', () => {
       const match = buildMarkerRegex(MARK).exec(emitted);
       assert.ok(match);
       assert.equal(match[1], JSON.stringify({ PATH: '/usr/bin' }));
-    });
-
-    it('round-trips an apostrophe in execPath via the close-quote / escape / reopen sequence', () => {
-      // POSIX single-quoting cannot contain a literal `'`; the safe escape is
-      // to close the quote, emit a backslash-escaped quote, and reopen.
-      const { command, shellArgs } = buildCaptureCommand('bash', "/Users/Bob's/node", MARK);
-      assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
-      assert.equal(
-        command,
-        `'/Users/Bob'\\''s/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
-      );
     });
   });
 
@@ -350,35 +339,6 @@ describe('buildCaptureCommand', () => {
         `^'/usr/bin/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
       );
     });
-  });
-
-  it('xonsh falls into the POSIX branch (the dedicated branch is gone)', () => {
-    // xonsh is intentionally unsupported. It must NOT get a special argv and
-    // must share the POSIX payload — proving the dead branch was removed.
-    const { command, shellArgs } = buildCaptureCommand('xonsh', '/usr/bin/node', MARK);
-    assert.deepEqual(shellArgs, ['-i', '-l', '-c']);
-    assert.equal(
-      command,
-      `'/usr/bin/node' -p '"${MARK}" + JSON.stringify({ PATH: process.env.PATH }) + "${MARK}"'`,
-    );
-  });
-});
-
-describe('buildMarkerRegex', () => {
-  it('matches <mark>{...}<mark> and captures the JSON body', () => {
-    const regex = buildMarkerRegex(MARK);
-    const match = regex.exec(`${MARK}${JSON.stringify({ k: 'v' })}${MARK}`);
-    assert.ok(match);
-    assert.equal(match[1], JSON.stringify({ k: 'v' }));
-  });
-
-  it('captures the body across newlines (dotall via [\\s\\S])', () => {
-    const body = `{
-  "PATH": "/usr/bin"
-}`;
-    const match = buildMarkerRegex(MARK).exec(`${MARK}${body}${MARK}`);
-    assert.ok(match);
-    assert.equal(match[1], body);
   });
 
 });


### PR DESCRIPTION
## Summary
- remove an unsupported-shell case that only repeated the default POSIX branch
- remove standalone marker-regex tests already owned by the POSIX capture integration
- combine POSIX marker and executable-escaping coverage into one representative test

## Validation
- `npx biome check apps/desktop/src/main/__tests__/shell-env.test.ts`
- `git diff --check`
- branch and producer reachability audit only; test suites intentionally left to CI