### PR TITLE
test(core): trim model metadata history and matrices

### DIFF
--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -9,38 +9,21 @@ import type { ModelInfo, ProviderType } from '../llm-connections.js';
 
 describe('model-metadata vision capability', () => {
   it('treats a Claude newer than the generated snapshot as able to read images', () => {
-    // The generated table is a snapshot of models.dev, so a Claude released
-    // after it is absent from the table rather than listed as text-only.
-    // Resolving absent to "no vision" silently drops the user's attachment and
-    // turns an image tool result into a sentence about the model.
     assert.deepEqual(lookupModelMetadata('anthropic', 'claude-opus-6'), {});
     assert.equal(resolveModelVisionSupport('anthropic', undefined, 'claude-opus-6'), true);
-    assert.equal(resolveModelVisionSupport('anthropic', undefined, 'claude-fable-1'), true);
+    assert.equal(
+      resolveModelVisionSupport('anthropic', undefined, 'claude-3-9-sonnet-20990101'),
+      true,
+    );
   });
 
   it('still fails closed for the Claude generation that cannot read images', () => {
-    // claude-2.x and claude-instant carry no family segment, so widening the
-    // default to the pre-4 id shape must not reach them.
-    for (const id of ['claude-2.1', 'claude-2.0', 'claude-instant-1.2']) {
-      assert.equal(resolveModelVisionSupport('anthropic', undefined, id), false, id);
-    }
+    assert.equal(resolveModelVisionSupport('anthropic', undefined, 'claude-2.1'), false);
   });
 
   it('confines the default to the providers that serve Anthropic their own models', () => {
-    // A claude-prefixed id on somebody else's provider says nothing about what
-    // is actually behind it, so the default must not travel with the id.
-    for (const providerType of [
-      'openrouter',
-      'anthropic-compatible',
-      'kimi-coding-plan',
-    ] satisfies ProviderType[]) {
-      assert.equal(
-        resolveModelVisionSupport(providerType, undefined, 'claude-opus-6'),
-        false,
-        providerType,
-      );
-    }
-    assert.equal(resolveModelVisionSupport('openai', undefined, 'some-unlisted-model'), false);
+    const providerType = 'anthropic-compatible' satisfies ProviderType;
+    assert.equal(resolveModelVisionSupport(providerType, undefined, 'claude-opus-6'), false);
   });
 
   it('yields to what a connection reports, in both directions', () => {
@@ -51,28 +34,18 @@ describe('model-metadata vision capability', () => {
   });
 
   it('lets a user declaration outrank every other signal, in both directions', () => {
-    // Declared vision wins over stored capabilities, generated metadata, and
-    // the provider default — the relay user knows what the backing model is,
-    // none of the inferred sources can.
     const stored: ModelInfo[] = [
       { id: 'my-reasoner', capabilities: { vision: true } },
-      { id: 'claude-opus-6', capabilities: { vision: true } },
     ];
     assert.equal(
       resolveModelVisionSupport('openai-compatible', stored, 'my-reasoner', false),
       false,
     );
     assert.equal(
-      resolveModelVisionSupport('openai-compatible', stored, 'claude-opus-6', false),
-      false,
-    );
-    assert.equal(
       resolveModelVisionSupport('openai-compatible', undefined, 'some-unlisted-model', true),
       true,
     );
-    // anthropic defaults claude-* to vision; an explicit declaration still wins.
     assert.equal(resolveModelVisionSupport('anthropic', undefined, 'claude-opus-6', false), false);
-    // undefined declaration means "no opinion": the old chain decides.
     assert.equal(
       resolveModelVisionSupport('openai-compatible', stored, 'my-reasoner', undefined),
       true,
@@ -82,7 +55,6 @@ describe('model-metadata vision capability', () => {
       false,
     );
   });
-
 });
 
 describe('openAiAdapterApiProtocol', () => {

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -109,77 +109,16 @@ export function openAiAdapterApiProtocol(
     : 'openai-chat';
 }
 
-/**
- * Anthropic model families whose every member reads images.
- *
- * The generated table is a snapshot of models.dev, so a Claude released after
- * that snapshot is simply absent from it — `lookupModelMetadata('anthropic',
- * 'claude-opus-5')` returns `{}` today. Absent used to resolve to "no vision",
- * which is the wrong default for this provider: every Claude in these families
- * accepts image input, and the fail-closed rule was written for text-only
- * models, not for models nobody has listed yet.
- *
- * The two mistakes are not symmetrical. Sending an image to a Claude that
- * turned out not to read it costs one turn and produces a message. Withholding
- * it silently drops the user's attachment and downgrades an image tool result
- * to a sentence, with nothing on screen to explain why, until someone
- * regenerates the table.
- *
- * Anthropic has used two id shapes, and both have to match. From Claude 4 on
- * the family comes first (`claude-opus-5`); before that the version came first
- * and the family sat behind it (`claude-3-5-sonnet-20241022`,
- * `claude-3-opus-20240229`). The pre-4 ids are the ones most likely to be
- * pinned by hand, none of them is in the generated table, and all of them read
- * images — so `(?:[\d.]+-)*` skips any leading version segments before the
- * family name.
- *
- * What must keep missing is the generation that genuinely cannot read images:
- * `claude-2.1`, `claude-2.0` and `claude-instant-*` have no family segment at
- * all, so they never reach the alternation.
- *
- * A connection that reports `vision` still wins over this, in both directions.
- */
+/** Vision-capable Claude families, including models newer than the generated snapshot. */
 const VISION_BY_DEFAULT = /^claude-(?:[\d.]+-)*(?:opus|sonnet|haiku|fable)\b/;
 
-/**
- * The providers whose bare `claude-*` ids are Anthropic's own models.
- *
- * Both fetch over the Anthropic protocol and both store the bare `{ id }`
- * entries that leave `vision` unknown, and `claude-subscription` is usually
- * where a new Claude becomes usable first — it is the same table of models
- * reached through a subscription instead of an API key.
- *
- * Deliberately narrower than "speaks the Anthropic protocol". `anthropic`
- * and `claude-subscription` are the only two whose base URL is Anthropic's own;
- * `anthropic-compatible`, `kimi-coding-plan` and `minimax-coding-plan` share
- * the wire format while serving somebody else's models, and a `claude-`
- * prefixed id there says nothing about what is behind it. The same goes for
- * aggregators like OpenRouter, which do serve Claude but under ids the
- * generated table already carries.
- */
+/** First-party paths where a bare `claude-*` id identifies an Anthropic model. */
 const VISION_BY_DEFAULT_PROVIDERS: ReadonlySet<ProviderType> = new Set<ProviderType>([
   'anthropic',
   'claude-subscription',
 ]);
 
-/**
- * Resolve whether a model accepts image input for the send path.
- *
- * A user declaration (`declaredVision`, from the relay connection's
- * `relayModelProfiles[modelId].vision`) wins over everything below:
- * for custom relays the user is the only one who actually knows the backing
- * model. Absent a declaration, stored `connection.models` win when they
- * declare `vision` explicitly (provider-fetched facts). But `model-fetcher`
- * stores bare `{ id }` entries for many providers, and older connections
- * predate any enrichment — so when `vision` is unknown we fall back to the
- * generated models.dev snapshot and access-path-specific in-repo overrides.
- *
- * Unknown then resolves to false — the send path stays fail-closed for
- * text-only models — with one exception: an unlisted Claude on one of
- * Anthropic's own providers resolves to true, because there absent means
- * "newer than the snapshot" rather than "text-only". See
- * {@link VISION_BY_DEFAULT}.
- */
+/** Resolve vision support by user declaration, inventory, metadata, then first-party Claude fallback. */
 export function resolveModelVisionSupport(
   providerType: ProviderType,
   models: readonly ModelInfo[] | undefined,


### PR DESCRIPTION
## Summary

- collapse equivalent Claude family and non-first-party provider samples
- retain modern and legacy Claude id shapes, precedence, and fail-closed behavior
- preserve every OpenAI/xAI/DeepSeek protocol split
- replace long historical model-vision comments with the current invariants

## Validation

- `npx biome check` on source and test
- `git diff --check`
- vision-precedence, provider-boundary, and wire-protocol ownership audit
- test suites intentionally not run; CI owns execution