### PR TITLE
test: trim boundary normalization matrices

### DIFF
--- a/apps/desktop/src/main/__tests__/artifact-preview-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/artifact-preview-registry.test.ts
@@ -12,12 +12,10 @@ import {
 
 describe('artifact preview registry', () => {
   it('treats present MIME metadata as authoritative and rejects unsafe formats', () => {
-    for (const mimeType of ['image/svg+xml', 'image/heic', 'image/bmp']) {
-      assert.deepEqual(
-        resolvePreviewKind({ name: 'tricky.png', kind: 'image', mimeType }),
-        { kind: 'unsupported', reason: 'mime_disallowed' },
-      );
-    }
+    assert.deepEqual(
+      resolvePreviewKind({ name: 'tricky.png', kind: 'image', mimeType: 'image/svg+xml' }),
+      { kind: 'unsupported', reason: 'mime_disallowed' },
+    );
   });
 
   it('enforces the inclusive metadata size boundary before loading', () => {
@@ -35,9 +33,7 @@ describe('artifact preview registry', () => {
   it('fails closed at the post-load payload cap', () => {
     assert.equal(exceedsImagePayloadCap('A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH)), false);
     assert.equal(exceedsImagePayloadCap('A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH + 1)), true);
-    for (const value of [null, undefined, 42]) {
-      assert.equal(exceedsImagePayloadCap(value as never), true);
-    }
+    assert.equal(exceedsImagePayloadCap(null as never), true);
   });
   it('uses sniffed MIME and checks size before MIME after loading', () => {
     const base64 = 'AAAA';
@@ -46,12 +42,10 @@ describe('artifact preview registry', () => {
       safeMime: 'image/png',
       base64,
     });
-    for (const mimeType of ['image/svg+xml', 'application/octet-stream']) {
-      assert.deepEqual(decideImagePostLoad({ base64, mimeType }), {
-        kind: 'unsupported',
-        reason: 'mime_disallowed',
-      });
-    }
+    assert.deepEqual(decideImagePostLoad({ base64, mimeType: 'image/svg+xml' }), {
+      kind: 'unsupported',
+      reason: 'mime_disallowed',
+    });
     assert.deepEqual(
       decideImagePostLoad({
         base64: 'A'.repeat(IMAGE_PAYLOAD_MAX_BASE64_LENGTH + 1),
@@ -62,12 +56,10 @@ describe('artifact preview registry', () => {
   });
 
   it('routes IPC failures and malformed successful payloads without retaining base64', () => {
-    for (const reason of ['not_found', 'too_large', 'read_failed', 'not_allowed', 'deleted', 'unsupported_mime'] as const) {
-      assert.deepEqual(decideImageReadOutcome({ ok: false, reason }), {
-        kind: 'unsupported',
-        reason: 'read_failed',
-      });
-    }
+    assert.deepEqual(decideImageReadOutcome({ ok: false, reason: 'not_found' }), {
+      kind: 'unsupported',
+      reason: 'read_failed',
+    });
 
     const valid: ArtifactBinaryReadResult = { ok: true, base64: 'AAAA', mimeType: 'image/png' };
     assert.deepEqual(decideImageReadOutcome(valid), {

--- a/apps/desktop/src/main/__tests__/notifications-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/notifications-policy.test.ts
@@ -31,7 +31,7 @@ it('sanitizes renderer content, caps it, and falls back per field', () => {
   assert.deepEqual(clean, { title: '会话 A', body: 'line one line two indented' });
 
   const completedFallback = runNotificationCopy('completed');
-  for (const value of ['', '   ', undefined, null, 42, {}]) {
+  for (const value of ['   ', undefined]) {
     assert.deepEqual(
       resolveNotificationContent({ kind: 'completed', title: value, body: value }),
       completedFallback,

--- a/packages/core/src/__tests__/incognito.test.ts
+++ b/packages/core/src/__tests__/incognito.test.ts
@@ -17,10 +17,10 @@ describe('workspace privacy context', () => {
   });
 
   it('fails closed for non-objects and missing or non-boolean state', () => {
-    for (const input of [null, undefined, 'incognito', 42, true, []]) {
+    for (const input of [null, 'incognito', []]) {
       assert.equal(validateWorkspacePrivacyContext(input).ok, false);
     }
-    for (const input of [{}, { incognitoActive: 'true' }, { incognitoActive: 1 }]) {
+    for (const input of [{}, { incognitoActive: 'true' }]) {
       assert.deepEqual(validateWorkspacePrivacyContext(input), {
         ok: false,
         reason: 'incognito_active_invalid',
@@ -32,7 +32,7 @@ describe('workspace privacy context', () => {
   it('guards the documented field without requiring an exact object shape', () => {
     assert.equal(isWorkspacePrivacyContext({ incognitoActive: false }), true);
     assert.equal(isWorkspacePrivacyContext({ incognitoActive: true, extra: 'ignored' }), true);
-    for (const input of [null, undefined, [], {}, { incognitoActive: 'true' }]) {
+    for (const input of [null, [], {}, { incognitoActive: 'true' }]) {
       assert.equal(isWorkspacePrivacyContext(input), false);
     }
   });

--- a/packages/core/src/incognito.ts
+++ b/packages/core/src/incognito.ts
@@ -1,52 +1,13 @@
-/**
- * Shared workspace privacy contract.
- *
- * The main process owns the effective state. Renderers may request or
- * display it, but consumers must receive a main-resolved context rather
- * than trust renderer input. Invalid boundary data fails closed.
- *
- * @see docs/workspace-privacy-context.md
- */
+/** Main-owned workspace privacy state. Invalid boundary data fails closed. */
 
-// ---------------------------------------------------------------------------
-// Shape
-// ---------------------------------------------------------------------------
-
-/**
- * Workspace-wide privacy context.
- *
- * The contract has exactly one field. Adding fields requires updating
- * this interface, the main-process authority path, and every consumer.
- */
 export interface WorkspacePrivacyContext {
-  /**
-   * True when the workspace is in incognito mode. Source-of-truth is
-   * the main process; renderers may read but cannot durably claim
-   * incognito on their own. Defaults to `false` on a fresh workspace.
-   *
-   * Each consumer defines its own fail-closed result at the main-process
-   * boundary. Main composition and focused consumer tests own the inventory.
-   */
+  /** Renderers may read this value but cannot claim write authority. */
   incognitoActive: boolean;
 }
 
-// ---------------------------------------------------------------------------
-// Default / factory
-// ---------------------------------------------------------------------------
-
-/**
- * Canonical default. A fresh workspace, or any path that has not yet
- * resolved an authoritative privacy snapshot, MUST use this — never
- * leave `incognitoActive` undefined and never assume true unless main
- * has confirmed.
- */
 export function defaultWorkspacePrivacyContext(): WorkspacePrivacyContext {
   return { incognitoActive: false };
 }
-
-// ---------------------------------------------------------------------------
-// Result envelope (mirrors PR-MEMORY-1 / PR-SEARCH-0 normalizer pattern)
-// ---------------------------------------------------------------------------
 
 export type WorkspacePrivacyContextResult =
   | { ok: true; value: WorkspacePrivacyContext }
@@ -54,44 +15,13 @@ export type WorkspacePrivacyContextResult =
 
 export type WorkspacePrivacyContextInvalidReason = 'not_object' | 'incognito_active_invalid';
 
-// ---------------------------------------------------------------------------
-// Type guard + validator
-// ---------------------------------------------------------------------------
-
-/**
- * Type guard. Use when the caller has already accepted that a non-
- * matching value should fall back to a default — for cases where the
- * caller wants a typed reason on failure, use
- * `validateWorkspacePrivacyContext`.
- */
 export function isWorkspacePrivacyContext(value: unknown): value is WorkspacePrivacyContext {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
   const record = value as Record<string, unknown>;
   return typeof record.incognitoActive === 'boolean';
 }
 
-/**
- * Validate + canonicalize a `WorkspacePrivacyContext` payload.
- *
- * Pipeline:
- *   1. typeof object guard (rejects null / array / primitive / function).
- *   2. `incognitoActive` typeof boolean guard.
- *
- * Returns the canonical record (only `incognitoActive`; extra fields
- * stripped) on success, or a typed rejection. Missing or non-boolean
- * `incognitoActive` is REJECTED — the validator never invents a
- * default. The only path to a default is the explicit
- * `defaultWorkspacePrivacyContext()` factory.
- *
- * Authority gate (per xuan `ece30c92`): renderer payloads passing
- * through this validator are still subject to the rule that the
- * renderer is NOT the write source. An IPC handler accepting an
- * incognito snapshot from renderer MUST treat the renderer's value
- * as untrusted; main / session / workspace owner is the only valid
- * write authority for the actual workspace state.
- *
- * @see docs/workspace-privacy-context.md "Consumer rule"
- */
+/** Validate and strip a privacy payload without inventing a default. */
 export function validateWorkspacePrivacyContext(input: unknown): WorkspacePrivacyContextResult {
   if (typeof input !== 'object' || input === null || Array.isArray(input)) {
     return {
@@ -108,8 +38,5 @@ export function validateWorkspacePrivacyContext(input: unknown): WorkspacePrivac
       message: 'WorkspacePrivacyContext.incognitoActive must be a boolean',
     };
   }
-  // Extra fields stripped — canonical return contains ONLY documented
-  // fields. Matches the IPC-1 / IPC-2 / IPC-3 normalize-and-strip
-  // pattern.
   return { ok: true, value: { incognitoActive: record.incognitoActive } };
 }

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -350,7 +350,6 @@ describe('fetchProviderModels', () => {
     for (const body of [
       null,
       { data: { id: 'not-an-array', secret } },
-      { data: [null, { id: secret }] },
       { data: [42, { id: secret }] },
     ]) {
       const server = await startJsonServer((_request, response) => {

--- a/packages/ui/src/artifact-preview-registry.ts
+++ b/packages/ui/src/artifact-preview-registry.ts
@@ -1,139 +1,37 @@
-/**
- * PR-UI-RENDER-3a — Artifact preview registry (image-only first pass).
- *
- * Establishes the SHAPE that future PR-RENDER-3b/c/d/e expansions
- * will follow. Each future PR adds one more `PreviewResolution.kind`
- * variant and one more component implementation in the renderer. The
- * resolver is intentionally narrow today: it accepts only `image`,
- * and only the five universally-rendered raster MIMEs. SVG is
- * deferred to PR-RENDER-3b (sanitizer / script / foreignObject /
- * external href / SMIL animation / `<use href="javascript:...">`
- * surface area is non-trivial). HTML, Mermaid, PDF, Docx, Excel,
- * PPTX, Zip each get their own gated PR.
- *
- * Locked scope (PR-RENDER-3a review gate, @kenji msg 2aa3cfc3):
- *
- *   - Pure mapping. TextInput is a narrow `ArtifactPreviewInput`, never
- *     the full `ArtifactRecord` (so the registry can't see
- *     `relativePath` or anything path-like — registry decisions
- *     can't accidentally leak filesystem state).
- *   - Allowlist by MIME first, ext fallback second, both
- *     case-insensitive. Otherwise → unsupported with a reason that
- *     tells the renderer which Unsupported sub-copy to show and
- *     lets tests lock the path.
- *   - Size cap is part of resolution. `sizeBytes > IMAGE_PAYLOAD_
- *     MAX_BYTES` → `unsupported('oversize')` BEFORE the renderer
- *     attempts `readBinary`. The renderer also re-checks after
- *     load (cap can be hit even if `sizeBytes` was unknown).
- *   - No new internal protocol. The renderer keeps using the desktop preload's
- *     artifact reader → `data:<mime>;base64,...`,
- *     where main does path safety + MIME sniffing. We are NOT
- *     inventing `app-file://` / `maka-asset://` here; that's a
- *     trust-boundary PR, not a registry-shape PR.
- *
- * Adding a new preview kind in a future PR is a single edit here:
- *   1. Extend `PreviewResolution.kind` with the new variant
- *      (e.g. `'svg'`).
- *   2. Add MIME / ext allowlist entries.
- *   3. Add the renderer component + IPC plumbing.
- *   4. Add reason enum variants if new failure modes appear.
- *   5. Add deterministic fixture and journey coverage.
- */
+/** Safe raster-image preview classification for renderer data URLs. */
 
 import type { ArtifactBinaryReadResult, ArtifactKind } from '@maka/core/artifacts';
 
 import type { UiLocale } from '@maka/core/ui-locale';
 import { getSharedUiCopy } from './shared-ui-copy.js';
 
-/**
- * Narrow input to the resolver. Deliberately excludes
- * `relativePath`, `id`, `sessionId`, `turnId` — none of those drive
- * preview classification, and the registry has no business seeing
- * them.
- */
+/** Path and ownership fields are intentionally outside this boundary. */
 export interface ArtifactPreviewInput {
-  /** Display name (also the source for ext fallback). */
   name: string;
-  /** Backend-classified kind. */
   kind: ArtifactKind;
-  /** MIME if main process sniffed one. */
   mimeType?: string;
-  /** Byte count if known. */
   sizeBytes?: number;
 }
 
-/**
- * Discriminated union telling the renderer which component to
- * mount AND why the classifier picked that outcome. Tests assert
- * on `reason`; Unsupported card sub-copy reads `reason` to pick a
- * specific localized message ("格式不受支持" vs "文件过大" vs
- * "无法识别类型" — all distinct user-facing failures).
- */
 export type PreviewResolution =
   | {
       kind: 'image';
-      /**
-       * - `mime_match`: `input.mimeType` was in the allowlist.
-       * - `ext_fallback`: no MIME (or MIME didn't match); filename
-       *   extension was in the allowlist.
-       */
       reason: 'mime_match' | 'ext_fallback';
     }
   | {
       kind: 'unsupported';
-      /**
-       * - `kind_disallowed`: `input.kind` is not one this registry
-       *   version handles (currently only `'image'`).
-       * - `mime_disallowed`: kind is `image` but MIME is outside the
-       *   allowlist (e.g. `image/svg+xml`, `image/heic`).
-       * - `no_mime_no_ext`: kind is `image` but neither MIME nor
-       *   ext could classify it.
-       * - `oversize`: `input.sizeBytes` exceeds `IMAGE_PAYLOAD_MAX_BYTES`.
-       * - `read_failed`: the post-load IPC (`readBinary`) returned an
-       *   error (`not_found` / `read_failed` / `not_allowed` /
-       *   `deleted` / `unsupported_mime` / `too_large`). The L1
-       *   resolver (`resolvePreviewKind`) NEVER returns this — it is
-       *   emitted by the L2 layer (`decideImageReadOutcome`) and
-       *   surfaced via the same `<UnsupportedArtifactPreview>` so the
-       *   user sees a distinct "load failed" copy instead of
-       *   misleading "格式不支持". @kenji review @msg 5fa6f6a5.
-       */
       reason: 'kind_disallowed' | 'mime_disallowed' | 'no_mime_no_ext' | 'oversize' | 'read_failed';
     };
 
-/**
- * Max decoded image payload allowed into React state. 2MB is well
- * past every e2e-fixture fixture and most user screenshots; a
- * real 10MB PNG should display via Finder open / future blob-URL
- * protocol rather than as a `data:` URL inside `setState`.
- *
- * @kenji review @msg 2aa3cfc3 — large payloads must NOT live as
- * base64 strings in React state.
- */
+/** Maximum decoded image payload allowed into renderer state. */
 export const IMAGE_PAYLOAD_MAX_BYTES = 2 * 1024 * 1024;
 
-/**
- * Max base64 string length corresponding to `IMAGE_PAYLOAD_MAX_BYTES`.
- * `Math.ceil(bytes * 4 / 3)` — base64 expands 4:3 plus up to 2 chars
- * of padding. The renderer's post-load cap check is just
- * `base64.length > IMAGE_PAYLOAD_MAX_BASE64_LENGTH` (O(1) string
- * length comparison; NO `atob` / NO decode). This is the load-bearing
- * defense — @kenji review @msg adc10d66 explicitly: do not decode a
- * super-large payload just to check whether it should be rejected.
- *
- * Cap is a policy boundary, not exact byte accounting; the small
- * over-approximation from padding doesn't matter.
- */
+/** Encoded-length cap, including base64 padding. */
 export const IMAGE_PAYLOAD_MAX_BASE64_LENGTH = Math.ceil((IMAGE_PAYLOAD_MAX_BYTES * 4) / 3) + 2;
 
 /**
- * MIME allowlist. Lower-cased exact match. SVG is intentionally
- * absent — it's deferred to PR-RENDER-3b.
- *
- * Exported so the renderer shell can use the SAME set for the
- * post-load L2 MIME re-validation (@kenji review @msg c9eb3b6f
- * point #2 / #3). Single source of truth; no parallel string
- * table on the renderer side.
+ * MIME allowlist shared by metadata and post-load validation. SVG is
+ * intentionally absent.
  */
 export const ALLOWED_IMAGE_MIMES: ReadonlySet<string> = new Set([
   'image/png',
@@ -143,15 +41,7 @@ export const ALLOWED_IMAGE_MIMES: ReadonlySet<string> = new Set([
   'image/avif',
 ]);
 
-/**
- * Pure: returns the lower-cased MIME if it's in the allowlist;
- * `null` otherwise. Renderer uses this AFTER `readBinary` to
- * re-validate the MIME main sniffed, since the metadata MIME the
- * resolver consulted is user-controlled (could be `image/png`
- * metadata claim over actual SVG payload). The `<img src="data:
- * <mime>;base64,...">` attribute MUST be built from the result
- * of this function, never from the raw `mimeType` field.
- */
+/** Return a normalized allowlisted MIME for constructing an image data URL. */
 export function normalizeAllowedImageMime(mimeType: string | undefined): string | null {
   if (typeof mimeType !== 'string') return null;
   const mime = mimeType.trim().toLowerCase();
@@ -159,22 +49,7 @@ export function normalizeAllowedImageMime(mimeType: string | undefined): string 
   return ALLOWED_IMAGE_MIMES.has(mime) ? mime : null;
 }
 
-/**
- * L2 outcome (post-`readBinary`). Pure decision that combines the
- * base64 cap check with the MIME re-validation, returning either
- * a `<img>`-renderable payload OR a typed Unsupported reason.
- *
- * Why this is its own function and not inlined in the component:
- * the cross-layer scenarios @kenji asked for in @msg f1ef0cc5 —
- *   - metadata `image/png` + sniffed `image/svg+xml` → Unsupported
- *   - metadata none + ext `.png` + sniffed `image/png` → image
- *   - metadata none + ext `.png` + sniffed `application/octet
- *     -stream` → Unsupported
- * are renderer-decision tests that don't need a DOM. The
- * component is then a thin shell over this function, exactly the
- * same shape as the L1 `resolvePreviewKind` / `<RegistryArtifact
- * Preview>` relationship.
- */
+/** Post-load decision after payload size and sniffed MIME validation. */
 export type ImagePostLoadOutcome =
   | { kind: 'image'; safeMime: string; base64: string }
   | { kind: 'unsupported'; reason: 'oversize' | 'mime_disallowed' | 'read_failed' };
@@ -193,53 +68,18 @@ export function decideImagePostLoad(input: {
   return { kind: 'image', safeMime, base64: input.base64 };
 }
 
-/**
- * PR-UI-RENDER-3a fixup (@kenji review @msg 5fa6f6a5) — single
- * chokepoint for the post-`readBinary` decision.
- *
- * The bug v1 had: `useBinaryRead` stored the raw
- * `ArtifactBinaryReadResult` (which carries the full base64 string)
- * in React state, and `decideImagePostLoad` only ran at render time.
- * That meant a 10MB base64 payload entered React state / DevTools
- * snapshot BEFORE the cap check ran. The cap blocked `<img src=...>`
- * rendering, but the load-bearing invariant ("large payloads must
- * NOT live as base64 strings in React state") was already violated.
- *
- * This helper is the new boundary. The renderer hook calls
- * `decideImageReadOutcome(rawReadResult)` INSIDE the async, BEFORE
- * `setState`. The hook state then only holds the post-decision
- * outcome, which is either an image branch (carrying the verified
- * base64) or an unsupported branch (NO base64 in state).
- *
- * Three failure paths feed `read_failed`:
- *   - `readResult.ok === false` (any IPC failure reason)
- *   - `readResult` missing required fields (defensive; would be a
- *     contract break by main, but we'd rather show a typed failure
- *     than crash)
- *
- * Image success calls into `decideImagePostLoad`, which is still
- * responsible for the L2 cap + MIME re-validation.
- */
+/** Reject raw IPC payloads before base64 can enter renderer state. */
 export function decideImageReadOutcome(readResult: ArtifactBinaryReadResult): ImagePostLoadOutcome {
   if (!readResult.ok) {
     return { kind: 'unsupported', reason: 'read_failed' };
   }
-  // Defensive shape check. `ArtifactBinaryReadResult`'s `ok: true`
-  // branch is typed to carry `base64` and `mimeType`, but a future
-  // main-process change that ever weakens that contract should
-  // route to `read_failed` rather than crashing or — worse —
-  // shoving an undefined into a `<img src="data:undefined;...">`.
   if (typeof readResult.base64 !== 'string' || typeof readResult.mimeType !== 'string') {
     return { kind: 'unsupported', reason: 'read_failed' };
   }
   return decideImagePostLoad({ base64: readResult.base64, mimeType: readResult.mimeType });
 }
 
-/**
- * Extension fallback. Lower-cased exact match including the dot.
- * Note `.jpg` and `.jpeg` both included; `.heic` / `.heif` / `.svg`
- * intentionally absent.
- */
+/** Safe extension fallback when MIME metadata is absent. */
 const ALLOWED_IMAGE_EXTS: ReadonlySet<string> = new Set([
   '.png',
   '.jpg',
@@ -249,40 +89,22 @@ const ALLOWED_IMAGE_EXTS: ReadonlySet<string> = new Set([
   '.avif',
 ]);
 
-/**
- * Pure classifier. Maps `ArtifactPreviewInput` to a
- * `PreviewResolution`. Never throws, never reads `window`, never
- * touches `relativePath`. Future PRs extend the union but must
- * never broaden the input shape.
- */
 export function resolvePreviewKind(input: ArtifactPreviewInput): PreviewResolution {
-  // Kind gate first — keeps the rest of the function focused on
-  // image classification only.
   if (input.kind !== 'image') {
     return { kind: 'unsupported', reason: 'kind_disallowed' };
   }
-  // Size cap is a cheap reject before the renderer attempts
-  // `readBinary` (which could materialize 50MB of base64 into
-  // memory).
+  // Reject by metadata before materializing base64.
   if (input.sizeBytes !== undefined && input.sizeBytes > IMAGE_PAYLOAD_MAX_BYTES) {
     return { kind: 'unsupported', reason: 'oversize' };
   }
-  // MIME is authoritative when present. If main sniffed
-  // `image/svg+xml` on a file whose name happens to be `tricky.png`,
-  // we trust the sniff and reject SVG (PR-RENDER-3b boundary) —
-  // we do NOT then look at the extension and accept it as PNG.
-  // The ext fallback only applies when MIME is missing entirely.
+  // A present MIME is authoritative; extension fallback cannot override it.
   if (input.mimeType) {
     const mime = input.mimeType.trim().toLowerCase();
     if (ALLOWED_IMAGE_MIMES.has(mime)) {
       return { kind: 'image', reason: 'mime_match' };
     }
-    // MIME present and not allowed — surface as a distinct failure
-    // so Unsupported can show "format unsupported" instead of "no
-    // info".
     return { kind: 'unsupported', reason: 'mime_disallowed' };
   }
-  // No MIME — ext fallback is the only hope for classification.
   const ext = lowercaseExt(input.name);
   if (ext && ALLOWED_IMAGE_EXTS.has(ext)) {
     return { kind: 'image', reason: 'ext_fallback' };
@@ -290,31 +112,12 @@ export function resolvePreviewKind(input: ArtifactPreviewInput): PreviewResoluti
   return { kind: 'unsupported', reason: 'no_mime_no_ext' };
 }
 
-/**
- * Pure: returns true iff `base64` is longer than the policy cap,
- * implying its decoded payload would exceed `IMAGE_PAYLOAD_MAX_BYTES`.
- *
- * Implementation is `base64.length > IMAGE_PAYLOAD_MAX_BASE64_LENGTH`
- * — a single O(1) string-length compare. The function does NOT call
- * `atob` and does NOT decode. The renderer component calls this
- * AFTER `readBinary` returns to enforce the cap even when the main
- * process didn't provide `sizeBytes` (resolver's L1 gate is best
- * effort; this is the L2 final defense).
- *
- * @kenji review @msg adc10d66 — never decode an oversize payload
- * just to check the cap. The L1 metadata gate in `resolvePreviewKind`
- * already covers the common case; this is the slim fallback.
- */
+/** Enforce the post-load cap using encoded length without decoding. */
 export function exceedsImagePayloadCap(base64: string): boolean {
   if (typeof base64 !== 'string') return true;
   return base64.length > IMAGE_PAYLOAD_MAX_BASE64_LENGTH;
 }
 
-/**
- * Pure: format a byte count as a short human-readable string for
- * Unsupported metadata display. KB / MB; no fractional precision
- * past 1 decimal. Returns `'未知大小'` for `undefined`.
- */
 export function formatPreviewSize(sizeBytes: number | undefined, locale: UiLocale = 'zh'): string {
   if (sizeBytes === undefined || sizeBytes < 0 || !Number.isFinite(sizeBytes)) return getSharedUiCopy(locale).artifact.unknownSize;
   if (sizeBytes < 1024) return `${sizeBytes} B`;


### PR DESCRIPTION
## Summary
- collapse equivalent privacy, notification, artifact, and provider-response invalid-input matrices
- retain active-content, payload-cap, MIME authority, fail-closed, and redaction boundaries
- remove obsolete review-history commentary while keeping current security invariants explicit

## Validation
- targeted Biome check for all six changed files
- `git diff --check`
- predicate and security-boundary ownership audit

Test suites intentionally not run; CI owns execution.