### PR TITLE
test(ui): trim URI safety matrices

### DIFF
--- a/apps/desktop/src/main/__tests__/maka-uri.test.ts
+++ b/apps/desktop/src/main/__tests__/maka-uri.test.ts
@@ -1,8 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { SETTINGS_SECTIONS } from '@maka/core/settings';
 import {
-  isMakaUri,
   isMakaUriCandidate,
   isSafeExternalScheme,
   parseMakaUri,
@@ -10,35 +8,26 @@ import {
 
 describe('Maka URI safety boundary', () => {
   it('parses only supported settings and compose destinations', () => {
-    for (const section of SETTINGS_SECTIONS) {
-      assert.deepEqual(parseMakaUri(`maka://settings/${section}`), {
-        kind: 'settings',
-        section,
-      });
-    }
-
-    const composeCases = [
-      ['maka://compose?text=hello', 'hello'],
-      ['maka://compose?text=%E4%BD%A0%E5%A5%BD', '你好'],
-      ['maka://compose/?text=Hello%20world%21', 'Hello world!'],
-    ] as const;
-    for (const [href, text] of composeCases) {
-      assert.deepEqual(parseMakaUri(href), { kind: 'compose', text });
-    }
+    assert.deepEqual(parseMakaUri('maka://settings/account'), {
+      kind: 'settings',
+      section: 'account',
+    });
+    assert.deepEqual(parseMakaUri('maka://compose?text=hello'), {
+      kind: 'compose',
+      text: 'hello',
+    });
+    assert.deepEqual(parseMakaUri('maka://compose/?text=%E4%BD%A0%E5%A5%BD'), {
+      kind: 'compose',
+      text: '你好',
+    });
   });
 
   it('rejects malformed, case-variant, and oversized internal URIs', () => {
     const invalidInputs: unknown[] = [
       '',
       null,
-      undefined,
-      42,
       'https://example.com/',
-      'file:///etc/passwd',
-      'javascript:alert(1)',
-      'data:text/html,<script>',
       'Maka://settings/account',
-      'MAKA://settings/account',
       'maka://',
       'maka:settings/account',
       `maka://compose?text=${'x'.repeat(8192)}`,
@@ -52,22 +41,14 @@ describe('Maka URI safety boundary', () => {
     const invalidHrefs = [
       'maka://settings/zzz',
       'maka://settings/',
-      'maka://settings',
       'maka://settings/account/edit',
       'maka://settings/account?force=1',
       'maka://settings/account#section',
       'maka://SETTINGS/account',
       'maka://compose?text=',
       'maka://compose?other=value',
-      `maka://compose?text=${'a'.repeat(5000)}`,
       'maka://compose/run?text=hi',
       'maka://tool/Bash?cmd=ls',
-      'maka://auth/oauth?provider=claude',
-      'maka://exec/shell',
-      'maka://run/skill',
-      'maka://mcp/connect',
-      'maka://session/abc-123',
-      'maka://runtime/background-tasks/shell-run-1',
       'maka:///account',
       'maka://user@settings/account',
       'maka://settings:9999/account',
@@ -75,38 +56,18 @@ describe('Maka URI safety boundary', () => {
     for (const href of invalidHrefs) assert.equal(parseMakaUri(href), null, href);
   });
 
-  it('recognizes only the exact internal scheme', () => {
-    for (const href of ['maka://settings/account', 'maka://tool/run', 'maka:']) {
-      assert.equal(isMakaUri(href), true, href);
-    }
-    for (const input of [
-      'https://example.com/',
-      'Maka://settings/account',
-      '   maka://settings/account',
-      null,
-      undefined,
-    ]) {
-      assert.equal(isMakaUri(input as string), false, String(input));
-    }
-  });
-
   it('flags case-variant internal candidates without allowing navigation', () => {
     for (const href of [
       'maka://settings/account',
       'Maka://settings/account',
-      'MAKA://compose?text=hi',
-      'MaKa://settings/health',
     ]) {
       assert.equal(isMakaUriCandidate(href), true, href);
       if (!href.startsWith('maka:')) assert.equal(parseMakaUri(href), null, href);
     }
     for (const input of [
       'https://example.com/',
-      'javascript:alert(1)',
       'makafake://oops',
       null,
-      undefined,
-      42,
     ]) {
       assert.equal(isMakaUriCandidate(input as string), false, String(input));
     }
@@ -124,20 +85,11 @@ describe('Maka URI safety boundary', () => {
     const rejected: unknown[] = [
       '',
       null,
-      undefined,
-      42,
       'not a url',
-      '://no-scheme',
-      'user@example.com',
-      'mailto-info:contact',
       'javascript:alert(1)',
       'data:text/html,<script>alert(1)</script>',
       'file:///etc/passwd',
-      'vbscript:msgbox("x")',
       'maka://settings/account',
-      'Maka://settings/account',
-      'ms-excel://something',
-      'telnet://host',
       'ftp://host',
     ];
     for (const href of rejected) {

--- a/packages/ui/src/maka-uri.ts
+++ b/packages/ui/src/maka-uri.ts
@@ -1,106 +1,21 @@
-/**
- * PR-UI-RENDER-2 — Internal `maka://` markdown link router.
- *
- * External reference designs expose a small allowlist of internal
- * markdown links so the assistant can drop "open Settings · 账号"
- * style affordances directly inside its prose. Maka mirrors that,
- * but **strictly**: the parser
- * is a closed-world allowlist that only accepts the two destinations
- * we are willing to wire today.
- *
- * Locked scope (PR-RENDER-2 review gate, @kenji msg 1e9a9d96):
- *
- *   - `maka://settings/<section>` — navigate to a Settings section.
- *     `<section>` must be a member of the existing `SettingsSection`
- *     union from `@maka/core/settings.ts`. No parallel string table.
- *     Adding a section happens only in core; this allowlist follows.
- *   - `maka://compose?text=...` — prefill the composer. Empty text
- *     is rejected (return null). Raw URL is length-capped before
- *     parsing AND decoded text is length-capped after, so a
- *     `%xx`-encoded bomb can't expand past the budget.
- *
- * Explicitly NOT supported (and never will be at this layer — it's
- * a navigation affordance, not an action runner):
- *
- *   - `maka://session/<id>` — defer until a real session navigation
- *     API exists; URI router must not invent navigation contracts.
- *   - `maka://runtime/*` — runtime resource refs for tools such as
- *     Read / StopBackgroundTask. They are not UI navigation links.
- *   - `maka://tool/*`, `maka://auth/*`, `maka://exec/*` — these are
- *     actions, not navigation. Routing markdown into them would let
- *     a prompt-injected assistant turn run tools / log in / execute
- *     commands behind the user's back. Hard `null`.
- *   - External schemes (`http:`, `https:`, `file:`, `javascript:`,
- *     `data:`) — those are not this parser's job. Caller treats
- *     `parseMakaUri(...) === null` as "not an internal link"; the
- *     renderer's normal `<a>` path or the broken-link fallback
- *     handles the rest.
- *
- * `null` covers four kinds of failure indistinguishably (malformed,
- * wrong scheme, unsupported namespace, invalid section). The
- * renderer's job is to render unsupported `maka://` as inline error
- * text — NEVER fall back to `openExternal`. That mapping happens in
- * `components.tsx`; this module is pure.
- */
-
 import { SETTINGS_SECTIONS, type SettingsSection } from '@maka/core/settings';
 
-/**
- * Runtime allowlist derived from Core's canonical section tuple. Adding or
- * removing a section updates both the type and parser from the same value.
- */
 const ALLOWED_SETTINGS_SECTIONS = new Set<SettingsSection>(SETTINGS_SECTIONS);
-
-/**
- * Hard caps applied to incoming hrefs. The renderer never invokes
- * the parser on assistant-controlled strings longer than this; if
- * something is past these limits, treat it as unsupported.
- *
- *   - `RAW_HREF_MAX_LENGTH`: applied to the raw `href` BEFORE the
- *     URL constructor. Bounds CPU of `new URL()` on adversarial
- *     inputs.
- *   - `COMPOSE_TEXT_MAX_LENGTH`: applied to the DECODED compose
- *     text AFTER `searchParams.get`. A 4KB `%xx`-encoded blob
- *     could decode to ~1.3KB of text, but a 4KB `%E4%B8%80`-only
- *     blob decodes to ~1KB of CJK — both well under the cap. The
- *     cap is here for principle, not for the encoding-bomb case
- *     (URL already caps to ~2KB on most browsers).
- */
 const RAW_HREF_MAX_LENGTH = 4096;
 const COMPOSE_TEXT_MAX_LENGTH = 4096;
 
-/**
- * Discriminated destination union. The renderer maps each variant to
- * an app-side callback; the parser itself never invokes anything.
- */
+/** Closed internal navigation surface; it never executes actions. */
 export type MakaUriDest =
   | { kind: 'settings'; section: SettingsSection }
   | { kind: 'compose'; text: string };
 
 /**
- * Parse a candidate internal URI. Returns the typed destination on
- * success; `null` on ANY failure (wrong scheme, malformed, unknown
- * namespace, unknown section, oversized, empty compose text, etc.).
- *
- * Strict invariants:
- *   - `url.protocol === 'maka:'` (lowercase, exact). No
- *     case-insensitive scheme match; users typing `Maka://` get
- *     `null`.
- *   - `url.hostname` must be `settings` or `compose` exactly. Any
- *     other host (including empty) returns `null`.
- *   - `settings` requires a single path segment matching a known
- *     `SettingsSection`. No sub-paths, no query, no fragment.
- *   - `compose` requires a non-empty `text` query param within
- *     `COMPOSE_TEXT_MAX_LENGTH` decoded characters.
- *
- * The parser is intentionally narrow. Adding a destination is a code
- * change here, in the renderer dispatcher, and in the test fixtures.
+ * Parse an exact lowercase internal URI. Unsupported namespaces and malformed
+ * inputs return null; callers must never pass them to external navigation.
  */
 export function parseMakaUri(href: string): MakaUriDest | null {
   if (typeof href !== 'string') return null;
   if (href.length === 0 || href.length > RAW_HREF_MAX_LENGTH) return null;
-  // Cheap scheme prefilter so we don't hand non-maka strings to
-  // `new URL()`. Case-sensitive on purpose (@kenji review gate #2).
   if (!href.startsWith('maka:')) return null;
 
   let url: URL;
@@ -109,35 +24,24 @@ export function parseMakaUri(href: string): MakaUriDest | null {
   } catch {
     return null;
   }
-  // `URL` lowercases the scheme during parsing, so this is a no-op
-  // sanity check — but documenting the invariant in code keeps the
-  // gate visible to future readers.
   if (url.protocol !== 'maka:') return null;
   if (url.username !== '' || url.password !== '') return null;
   if (url.port !== '') return null;
   if (url.hash !== '') return null;
 
-  const host = url.hostname;
-  switch (host) {
+  switch (url.hostname) {
     case 'settings': {
-      // Disallow query and search params on settings — there's no
-      // legitimate use today and any tolerance here invites future
-      // injection ("?section=&debug=…").
       if (url.search !== '') return null;
-      const segments = url.pathname.split('/').filter((seg) => seg.length > 0);
+      const segments = url.pathname.split('/').filter((segment) => segment.length > 0);
       if (segments.length !== 1) return null;
-      const candidate = segments[0]!;
-      if (!isSettingsSection(candidate)) return null;
-      return { kind: 'settings', section: candidate };
+      const section = segments[0]!;
+      if (!isSettingsSection(section)) return null;
+      return { kind: 'settings', section };
     }
     case 'compose': {
-      // `compose` MUST be path-less. Any pathname other than empty or
-      // "/" rejects so `maka://compose/run?text=…` can't sneak in.
       if (url.pathname !== '' && url.pathname !== '/') return null;
       const text = url.searchParams.get('text');
-      if (text === null) return null;
-      if (text.length === 0) return null;
-      if (text.length > COMPOSE_TEXT_MAX_LENGTH) return null;
+      if (text === null || text.length === 0 || text.length > COMPOSE_TEXT_MAX_LENGTH) return null;
       return { kind: 'compose', text };
     }
     default:
@@ -146,69 +50,14 @@ export function parseMakaUri(href: string): MakaUriDest | null {
 }
 
 /**
- * Cheap probe: is `href` syntactically an internal `maka:` URI?
- * Used by the renderer to decide whether to call `parseMakaUri` and
- * branch into the internal-link path vs. the external-link path.
- *
- * Returns `true` even for invalid `maka:` URIs (unknown namespace,
- * malformed section); the caller distinguishes via `parseMakaUri`
- * and renders the broken-link inline error treatment.
- *
- * Strict (case-sensitive) `maka:` only. For the renderer's
- * "candidate" probe — which needs to catch `Maka:` / `MAKA:` and
- * route them to the broken-link inline error rather than letting
- * them fall through to external `<a target=_blank>` — use
- * `isMakaUriCandidate` instead.
- */
-export function isMakaUri(href: string): boolean {
-  if (typeof href !== 'string') return false;
-  return href.startsWith('maka:');
-}
-
-/**
- * PR-UI-C2 review fixup (@kenji msg 7fb8d15c) — case-insensitive
- * "looks like a maka: URI" probe.
- *
- * The strict `parseMakaUri` only accepts lowercase `maka:` (a
- * security-relevant invariant: prompt-injected `Maka://settings/...`
- * must NOT navigate). But the renderer needs a SEPARATE check to
- * decide "is this trying to be an internal URI?" so case-variants
- * route to the broken-link inline error, not to external
- * `<a target=_blank>` (which would let the OS browser handle it).
- *
- * This helper recognizes `maka:` / `Maka:` / `MAKA:` / etc. as
- * candidates. `parseMakaUri()` still rejects them — but the
- * renderer sees `isMakaUriCandidate && parseMakaUri === null` and
- * renders the broken-link `<span>`.
+ * Case-insensitive probe used to keep internal-looking links out of the
+ * external navigation path. Parsing remains lowercase-only.
  */
 export function isMakaUriCandidate(href: string): boolean {
-  if (typeof href !== 'string') return false;
-  return /^maka:/i.test(href);
+  return typeof href === 'string' && /^maka:/i.test(href);
 }
 
-/**
- * PR-UI-C2 review fixup (@kenji msg 7fb8d15c + 73e92ef0) —
- * explicit safe-scheme allowlist for the EXTERNAL link path.
- *
- * Without this gate, `MarkdownLink` would render any non-`maka:`
- * href as `<a href=... target=_blank>` — including `javascript:`,
- * `data:`, `file:`. Even though the Markdown pipeline may sanitize
- * some of these, the link chokepoint should not depend
- * on that. Explicit allowlist here makes the boundary visible
- * and inspectable in e2e-fixture baselines.
- *
- * Allowed: `http:` (HTTP via OS browser), `https:` (HTTPS via OS
- * browser), `mailto:` (default mail client). Everything else
- * (incl. `javascript:`, `data:`, `file:`, `vbscript:`, custom
- * schemes) returns `false` and the renderer falls back to the
- * "unsafe link" broken-link inline error.
- *
- * Uses `new URL(href).protocol` for the check (not a naive
- * prefix-match) — @kenji msg 73e92ef0: `mailto:` must be parsed
- * as a real URL, not matched against a string prefix. A bare
- * email or text like `mailto-info:contact` would otherwise slip
- * past a prefix-only check.
- */
+/** External links are restricted to browser and mail destinations. */
 export function isSafeExternalScheme(href: string): boolean {
   if (typeof href !== 'string') return false;
   let parsed: URL;
@@ -217,13 +66,9 @@ export function isSafeExternalScheme(href: string): boolean {
   } catch {
     return false;
   }
-  // `URL.protocol` includes the trailing colon and is lowercased
-  // by the WHATWG URL spec for special schemes.
   return parsed.protocol === 'http:' || parsed.protocol === 'https:' || parsed.protocol === 'mailto:';
 }
 
 function isSettingsSection(value: string): value is SettingsSection {
-  // ReadonlySet#has accepts any string; the type predicate narrows
-  // the result for the caller.
   return ALLOWED_SETTINGS_SECTIONS.has(value as SettingsSection);
 }


### PR DESCRIPTION
## Summary
- reduce internal and external URI matrices to one owner per parser gate and security class
- retain active-content, local-file, internal-scheme, credential, port, fragment, path, query, and size boundaries
- remove the production `isMakaUri` helper because its only consumer was its own test
- replace PR-history documentation with current closed-world invariants

## Validation
- `npx biome check apps/desktop/src/main/__tests__/maka-uri.test.ts packages/ui/src/maka-uri.ts`
- `git diff --check`
- production reachability and parser-gate ownership audit

Test suites intentionally not run; CI owns execution.