### PR TITLE
refactor(core): remove legacy shell result decoders

### DIFF
--- a/packages/core/src/__tests__/shell-run-result.test.ts
+++ b/packages/core/src/__tests__/shell-run-result.test.ts
@@ -3,10 +3,10 @@ import { describe, it } from 'node:test';
 
 import {
   ShellRunUpdateBuffer,
+  decodeCanonicalShellToolResultContent,
   mergeShellRunState,
   mergeShellRunStateWithDiagnostics,
   mergeShellRunUpdate,
-  normalizeShellToolResultContent,
   projectShellRunUpdateForSession,
   type ShellRunMergeDiagnostic,
   type ShellRunToolResult,
@@ -170,56 +170,7 @@ describe('ShellRun view updates', () => {
   });
 });
 
-describe('normalizeShellToolResultContent', () => {
-  it('normalizes the exact pre-status terminal result and preserves its truncation marker', () => {
-    assert.deepEqual(
-      normalizeShellToolResultContent({
-        kind: 'terminal',
-        cwd: '/repo',
-        cmd: 'printf ok',
-        exitCode: 0,
-        stdout: '...12 bytes truncated. historical recovery guidance\n\nok',
-        stderr: '',
-      }),
-      {
-        state: 'valid',
-        content: {
-          kind: 'terminal',
-          cwd: '/repo',
-          cmd: 'printf ok',
-          status: 'completed',
-          exitCode: 0,
-          output: {
-            mode: 'pipes',
-            stdout: '...12 bytes truncated. historical recovery guidance\n\nok',
-            stderr: '',
-            stdoutTruncated: true,
-            stderrTruncated: false,
-            redacted: false,
-          },
-        },
-      },
-    );
-  });
-
-  it('rejects incomplete or contradictory pre-status terminal results', () => {
-    const historical = {
-      kind: 'terminal',
-      cwd: '/repo',
-      cmd: 'printf ok',
-      exitCode: 0,
-      stdout: 'ok',
-      stderr: '',
-    };
-    for (const value of [
-      { ...historical, exitCode: 1 },
-      { ...historical, status: 'completed' },
-      { kind: 'terminal', cwd: '/repo', cmd: 'printf ok', exitCode: 0, stdout: 'ok' },
-    ]) {
-      assert.equal(normalizeShellToolResultContent(value).state, 'invalid');
-    }
-  });
-
+describe('decodeCanonicalShellToolResultContent', () => {
   it('accepts canonical current terminal state and rejects contradictory exit status', () => {
     const current = {
       kind: 'terminal',
@@ -229,10 +180,10 @@ describe('normalizeShellToolResultContent', () => {
       exitCode: 0,
       output: pipeOutput('ok'),
     };
-    assert.equal(normalizeShellToolResultContent(current).state, 'valid');
-    assert.equal(normalizeShellToolResultContent({ ...current, exitCode: 1 }).state, 'invalid');
+    assert.equal(decodeCanonicalShellToolResultContent(current).state, 'valid');
+    assert.equal(decodeCanonicalShellToolResultContent({ ...current, exitCode: 1 }).state, 'invalid');
     assert.equal(
-      normalizeShellToolResultContent({
+      decodeCanonicalShellToolResultContent({
         kind: 'terminal',
         cwd: '/repo',
         cmd: 'printf bad',
@@ -249,8 +200,8 @@ describe('normalizeShellToolResultContent', () => {
 
   it('rejects non-canonical nested output and contradictory current state', () => {
     const valid = shellRun();
-    assert.equal(normalizeShellToolResultContent(valid).state, 'valid');
-    assert.equal(normalizeShellToolResultContent({ ...valid, status: 'starting' }).state, 'valid');
+    assert.equal(decodeCanonicalShellToolResultContent(valid).state, 'valid');
+    assert.equal(decodeCanonicalShellToolResultContent({ ...valid, status: 'starting' }).state, 'valid');
 
     const invalid = [
       {
@@ -269,7 +220,7 @@ describe('normalizeShellToolResultContent', () => {
       },
     ];
     for (const value of invalid) {
-      assert.equal(normalizeShellToolResultContent(value).state, 'invalid');
+      assert.equal(decodeCanonicalShellToolResultContent(value).state, 'invalid');
     }
   });
 
@@ -290,7 +241,7 @@ describe('normalizeShellToolResultContent', () => {
       },
     } as const;
     assert.equal(
-      normalizeShellToolResultContent({
+      decodeCanonicalShellToolResultContent({
         ...base,
         operation: {
           kind: 'pty_control',
@@ -301,7 +252,7 @@ describe('normalizeShellToolResultContent', () => {
       'valid',
     );
     assert.equal(
-      normalizeShellToolResultContent({
+      decodeCanonicalShellToolResultContent({
         ...base,
         operation: {
           kind: 'pty_control',

--- a/packages/core/src/__tests__/tool-result-record-schema.test.ts
+++ b/packages/core/src/__tests__/tool-result-record-schema.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { StoredMessage } from '../session.js';
-import { decodeStoredMessageForRead, decodeStoredMessageForRecovery } from '../session.js';
+import { decodeStoredMessageForRecovery } from '../session.js';
 import { decodeCanonicalToolResultContent } from '../tool-result-record-schema.js';
 
 describe('sandbox denial tool result metadata', () => {

--- a/packages/core/src/shell-run-result.ts
+++ b/packages/core/src/shell-run-result.ts
@@ -117,61 +117,6 @@ const PTY_CONTROL_OPERATION_KEYS = new Set(['kind', 'failed', 'input', 'resize']
 const PTY_CONTROL_INPUT_KEYS = new Set(['bytes', 'queued']);
 const PTY_CONTROL_RESIZE_KEYS = new Set(['cols', 'rows', 'applied', 'changed']);
 
-const LEGACY_TERMINAL_RESULT_KEYS = new Set([
-  'kind',
-  'cwd',
-  'cmd',
-  'status',
-  'exitCode',
-  'stdout',
-  'stderr',
-  'stdoutTruncated',
-  'stderrTruncated',
-]);
-
-const PRE_STATUS_TERMINAL_RESULT_KEYS = new Set([
-  'kind',
-  'cwd',
-  'cmd',
-  'exitCode',
-  'stdout',
-  'stderr',
-]);
-
-const LEGACY_SHELL_RUN_RESULT_KEYS = new Set([
-  'kind',
-  'ref',
-  'status',
-  'cwd',
-  'cmd',
-  'startedAt',
-  'updatedAt',
-  'completedAt',
-  'exitCode',
-  'failureMessage',
-  'stdout',
-  'stderr',
-  'latestOutputStream',
-  'stdoutTruncated',
-  'stderrTruncated',
-  'timeoutMs',
-  'observedAt',
-  'orphanedReason',
-  'cancelled',
-]);
-
-/** Validate current shell results and normalize only the exact preceding shape. */
-export function normalizeShellToolResultContent(value: unknown): ShellToolResultNormalization {
-  const canonical = decodeCanonicalShellToolResultContent(value);
-  if (canonical.state !== 'invalid') return canonical;
-  if (!isRecord(value)) return canonical;
-  const legacy =
-    value.kind === 'terminal'
-      ? (normalizeLegacyTerminalResult(value) ?? normalizePreStatusTerminalResult(value))
-      : normalizeLegacyShellRunResult(value);
-  return legacy ? { state: 'valid', content: legacy } : { state: 'invalid' };
-}
-
 export function decodeCanonicalShellToolResultContent(
   value: unknown,
 ): ShellToolResultNormalization {
@@ -183,46 +128,12 @@ export function decodeCanonicalShellToolResultContent(
   return current ? { state: 'valid', content: current } : { state: 'invalid' };
 }
 
-function normalizePreStatusTerminalResult(
-  value: Record<string, unknown>,
-): Extract<ToolResultContent, { kind: 'terminal' }> | undefined {
-  if (
-    !hasOnlyKeys(value, PRE_STATUS_TERMINAL_RESULT_KEYS) ||
-    typeof value.cwd !== 'string' ||
-    typeof value.cmd !== 'string' ||
-    value.exitCode !== 0 ||
-    typeof value.stdout !== 'string' ||
-    typeof value.stderr !== 'string'
-  )
-    return undefined;
-
-  return {
-    kind: 'terminal',
-    cwd: value.cwd,
-    cmd: value.cmd,
-    status: 'completed',
-    exitCode: 0,
-    output: {
-      mode: 'pipes',
-      stdout: value.stdout,
-      stderr: value.stderr,
-      stdoutTruncated: hasLegacyTruncationMarker(value.stdout),
-      stderrTruncated: hasLegacyTruncationMarker(value.stderr),
-      redacted: false,
-    },
-  };
-}
-
-function hasLegacyTruncationMarker(value: string): boolean {
-  return /^\.\.\.\d+ (?:bytes|lines) truncated\./.test(value);
-}
-
 function currentTerminalResult(value: Record<string, unknown>): TerminalToolResult | undefined {
   if (
     !hasExactShape(value, CURRENT_TERMINAL_RESULT_SHAPE) ||
     typeof value.cwd !== 'string' ||
     typeof value.cmd !== 'string' ||
-    !isLegacyTerminalStatus(value.status) ||
+    !isTerminalStatus(value.status) ||
     !isOptionalFiniteNumber(value.exitCode) ||
     !isOptionalString(value.failureMessage) ||
     !isOptionalSandboxDenial(value.sandboxDenial) ||
@@ -278,100 +189,7 @@ function currentShellRunResult(value: Record<string, unknown>): ShellRunToolResu
   return value as ShellRunToolResult;
 }
 
-function normalizeLegacyTerminalResult(
-  value: Record<string, unknown>,
-): Extract<ToolResultContent, { kind: 'terminal' }> | undefined {
-  if (
-    !hasOnlyKeys(value, LEGACY_TERMINAL_RESULT_KEYS) ||
-    typeof value.cwd !== 'string' ||
-    typeof value.cmd !== 'string' ||
-    !isLegacyTerminalStatus(value.status) ||
-    !isFiniteNumber(value.exitCode) ||
-    typeof value.stdout !== 'string' ||
-    typeof value.stderr !== 'string' ||
-    typeof value.stdoutTruncated !== 'boolean' ||
-    typeof value.stderrTruncated !== 'boolean' ||
-    !isValidTerminalState(value)
-  )
-    return undefined;
-
-  return {
-    kind: 'terminal',
-    cwd: value.cwd,
-    cmd: value.cmd,
-    status: value.status,
-    exitCode: value.exitCode,
-    output: legacyPipeOutput(value),
-  };
-}
-
-function normalizeLegacyShellRunResult(
-  value: Record<string, unknown>,
-): ShellRunToolResult | undefined {
-  if (
-    !hasOnlyKeys(value, LEGACY_SHELL_RUN_RESULT_KEYS) ||
-    typeof value.ref !== 'string' ||
-    !isShellRunStatus(value.status) ||
-    typeof value.cwd !== 'string' ||
-    typeof value.cmd !== 'string' ||
-    !isFiniteNumber(value.startedAt) ||
-    !isFiniteNumber(value.updatedAt) ||
-    typeof value.stdout !== 'string' ||
-    typeof value.stderr !== 'string' ||
-    typeof value.stdoutTruncated !== 'boolean' ||
-    typeof value.stderrTruncated !== 'boolean' ||
-    !isOptionalFiniteNumber(value.completedAt) ||
-    !isOptionalFiniteNumber(value.exitCode) ||
-    !isOptionalFiniteNumber(value.timeoutMs) ||
-    !isOptionalFiniteNumber(value.observedAt) ||
-    !isOptionalString(value.failureMessage) ||
-    !isOptionalString(value.orphanedReason) ||
-    !isOptionalBoolean(value.cancelled) ||
-    !isOptionalOutputStream(value.latestOutputStream) ||
-    !isValidLegacyShellRunState(value)
-  )
-    return undefined;
-
-  const failureMessage =
-    typeof value.failureMessage === 'string'
-      ? value.failureMessage
-      : value.status === 'orphaned'
-        ? (value.orphanedReason as string)
-        : undefined;
-  return {
-    kind: 'shell_run',
-    ref: value.ref,
-    mode: 'pipes',
-    status: value.status,
-    cwd: value.cwd,
-    cmd: value.cmd,
-    startedAt: value.startedAt,
-    updatedAt: value.updatedAt,
-    ...(isFiniteNumber(value.completedAt) ? { completedAt: value.completedAt } : {}),
-    ...(isFiniteNumber(value.timeoutMs) ? { timeoutMs: value.timeoutMs } : {}),
-    ...(isFiniteNumber(value.exitCode) ? { exitCode: value.exitCode } : {}),
-    ...(failureMessage !== undefined ? { failureMessage } : {}),
-    revision: 1,
-    output: legacyPipeOutput(value),
-    ...(typeof value.cancelled === 'boolean'
-      ? { operation: { kind: 'stop', applied: value.cancelled } as const }
-      : {}),
-  };
-}
-
-function legacyPipeOutput(value: Record<string, unknown>): Extract<ShellOutput, { mode: 'pipes' }> {
-  return {
-    mode: 'pipes',
-    stdout: value.stdout as string,
-    stderr: value.stderr as string,
-    ...(isOutputStream(value.latestOutputStream) ? { latestStream: value.latestOutputStream } : {}),
-    stdoutTruncated: value.stdoutTruncated as boolean,
-    stderrTruncated: value.stderrTruncated as boolean,
-    redacted: false,
-  };
-}
-
-function isLegacyTerminalStatus(
+function isTerminalStatus(
   value: unknown,
 ): value is Exclude<ShellRunStatus, 'starting' | 'running' | 'orphaned'> {
   return (
@@ -410,55 +228,6 @@ function isCurrentShellRunOperation(value: unknown, mode: unknown, hasOutput: bo
       typeof value.resize.applied === 'boolean' &&
       typeof value.resize.changed === 'boolean')
   );
-}
-
-export function isValidLegacyShellRunState(value: Record<string, unknown>): boolean {
-  switch (value.status) {
-    case 'running':
-      return (
-        value.completedAt === undefined &&
-        value.exitCode === undefined &&
-        value.failureMessage === undefined &&
-        value.observedAt === undefined &&
-        value.orphanedReason === undefined
-      );
-    case 'completed':
-      return (
-        isFiniteNumber(value.completedAt) &&
-        value.exitCode === 0 &&
-        value.failureMessage === undefined &&
-        value.orphanedReason === undefined
-      );
-    case 'failed':
-      return (
-        isFiniteNumber(value.completedAt) &&
-        isFiniteNumber(value.exitCode) &&
-        value.exitCode !== 0 &&
-        value.orphanedReason === undefined
-      );
-    case 'timed_out':
-      return (
-        isFiniteNumber(value.completedAt) &&
-        value.exitCode === 124 &&
-        value.orphanedReason === undefined
-      );
-    case 'cancelled':
-      return (
-        isFiniteNumber(value.completedAt) &&
-        value.exitCode === 130 &&
-        value.orphanedReason === undefined
-      );
-    case 'orphaned':
-      return (
-        isFiniteNumber(value.completedAt) &&
-        value.exitCode === undefined &&
-        value.failureMessage === undefined &&
-        typeof value.orphanedReason === 'string' &&
-        value.orphanedReason.length > 0
-      );
-    default:
-      return false;
-  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -510,18 +279,6 @@ function isOptionalSandboxDenial(value: unknown): boolean {
         value.backend === 'linux') &&
       value.recovery === 'require_escalated')
   );
-}
-
-function isOptionalBoolean(value: unknown): boolean {
-  return value === undefined || typeof value === 'boolean';
-}
-
-function isOutputStream(value: unknown): value is 'stdout' | 'stderr' {
-  return value === 'stdout' || value === 'stderr';
-}
-
-function isOptionalOutputStream(value: unknown): boolean {
-  return value === undefined || isOutputStream(value);
 }
 
 export interface ShellRunStateMerge<Result extends ShellRunStateResult = ShellRunStateResult> {

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -1,7 +1,6 @@
 import {
   decodeCanonicalShellToolResultContent,
   isSandboxDenialSignal,
-  normalizeShellToolResultContent,
 } from './shell-run-result.js';
 import { isPermissionMode } from './permission.js';
 import { isStorageRef, type ToolResultContent } from './events.js';
@@ -191,7 +190,7 @@ const RIVE_ERROR_SHAPE = defineObjectShape<RiveError>()(
 );
 
 export function normalizeToolResultContentForRead(value: unknown): ToolResultContent {
-  const shell = normalizeShellToolResultContent(value);
+  const shell = decodeCanonicalShellToolResultContent(value);
   if (shell.state === 'invalid') throw new Error('Invalid shell tool result content');
   const normalized = shell.state === 'valid' ? shell.content : value;
   return decodeCanonicalToolResultContent(normalizeLegacySubagentToolResultContent(normalized));

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -43,7 +43,7 @@ import {
   type RuntimeEventRole,
 } from '@maka/core/runtime-event';
 import { formatAttachmentResourceRef } from '@maka/core/attachments';
-import { normalizeShellToolResultContent } from '@maka/core/shell-run-result';
+import { decodeCanonicalShellToolResultContent } from '@maka/core/shell-run-result';
 import { normalizeToolResultContentForRead } from '@maka/core/tool-result-record-schema';
 import type { AttachmentRef, QuoteRef } from '@maka/core/events';
 import type { ModelMessage, UserContent, UserModelMessage } from './model-protocol.js';
@@ -588,7 +588,7 @@ export function buildRuntimeEventModelReplayPlan(
           );
           continue;
         }
-        const shellResult = normalizeShellToolResultContent(event.content.result);
+        const shellResult = decodeCanonicalShellToolResultContent(event.content.result);
         let invalidResultMessage: string | undefined;
         let normalizedResult: unknown =
           event.content.providerExecuted && event.content.providerOutput !== undefined


### PR DESCRIPTION
## Summary
- remove pre-status terminal and legacy shell result compatibility decoders
- route history, persisted reads, recovery, and protocol validation through the canonical shell decoder
- delete legacy state validation helpers and their compatibility tests

## Validation
- Biome check on all changed source and test files
- git diff --check
- producer, consumer, symbol reachability, and canonical predicate ownership audit

No test suite was run; CI owns suite execution.