### PR TITLE
refactor(core): unify persisted message decoding

### DIFF
--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -2,7 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import type { AttachmentRef, ShellRunUpdate } from "@maka/core/events";
 import type { PlanSessionState, PlanUserControlInput } from "@maka/core/plan";
 import {
-  decodeStoredMessageForRead,
+  decodeStoredMessage,
   type StoredMessage,
 } from "@maka/core/session";
 import type { Task } from "@maka/core/task-ledger";
@@ -1395,7 +1395,7 @@ class DesktopSessionHandle implements DesktopRuntimeHostSession {
     this.snapshot = subscription.snapshot;
     this.activeAssistantStreams = subscription.activeAssistantStreams;
     this.events = subscription;
-    this.transcript = subscription.loadTranscript(decodeStoredMessageForRead);
+    this.transcript = subscription.loadTranscript(decodeStoredMessage);
     void this.transcript.catch(() => undefined);
   }
 

--- a/packages/cli/src/runtime-host-session-channel.ts
+++ b/packages/cli/src/runtime-host-session-channel.ts
@@ -1,4 +1,4 @@
-import { decodeStoredMessageForRead, type StoredMessage } from '@maka/core/session';
+import { decodeStoredMessage, type StoredMessage } from '@maka/core/session';
 import { type SessionEvent } from '@maka/core/events';
 import {
   RuntimeHostSessionProjector,
@@ -120,7 +120,7 @@ export class RuntimeHostSessionChannel {
   async #hydrateInitial(subscription: RuntimeHostSessionSubscription): Promise<boolean> {
     let messages: StoredMessage[] | undefined;
     try {
-      messages = await subscription.loadTranscript(decodeStoredMessageForRead);
+      messages = await subscription.loadTranscript(decodeStoredMessage);
     } catch (error) {
       if (!this.#canRecover(error)) throw error;
       this.#failedSubscriptions.add(subscription);
@@ -313,7 +313,7 @@ export class RuntimeHostSessionChannel {
       this.#pendingFrames.length = 0;
       void this.#pump(replacement);
       try {
-        const messages = await replacement.loadTranscript(decodeStoredMessageForRead);
+        const messages = await replacement.loadTranscript(decodeStoredMessage);
         if (this.#failedSubscriptions.has(replacement)) {
           throw new RuntimeHostSubscriptionError(
             'connection_closed',

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { DEFAULT_SESSION_NAME } from '@maka/core/session-name';
 import {
-  decodeStoredMessageForRead,
+  decodeStoredMessage,
   userFacingText,
   type SessionSummary,
   type StoredMessage,
@@ -1016,7 +1016,7 @@ async function loadCurrentMessages(
     }
   })();
   try {
-    return await subscription.loadTranscript(decodeStoredMessageForRead);
+    return await subscription.loadTranscript(decodeStoredMessage);
   } finally {
     await subscription.close().catch(() => undefined);
     await draining.catch(() => undefined);

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -18,7 +18,7 @@ import {
   type RuntimeEvent,
   type RuntimeEventActions,
 } from '../runtime-event.js';
-import { decodeStoredMessageForRecovery } from '../session.js';
+import { decodeStoredMessage } from '../session.js';
 
 /** Minimal valid RuntimeEvent; callers spread overrides on top. */
 function baseEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
@@ -78,7 +78,7 @@ test('Stored assistant reasoning parts survive recovery decoding', () => {
       },
     },
   ];
-  const stored = decodeStoredMessageForRecovery({
+  const stored = decodeStoredMessage({
     type: 'assistant',
     id: 'message-1',
     turnId: 'turn-1',
@@ -386,7 +386,7 @@ describe('RuntimeEvent content variants', () => {
       event.content && 'quotes' in event.content ? event.content.quotes?.[0] : undefined,
       quotes[0],
     );
-    const stored = decodeStoredMessageForRecovery({
+    const stored = decodeStoredMessage({
       type: 'user',
       id: 'message-1',
       turnId: 'turn-1',
@@ -410,7 +410,7 @@ describe('RuntimeEvent content variants', () => {
     assert.notEqual(stored.quotes?.[0], quotes[0]);
     assert.throws(
       () =>
-        decodeStoredMessageForRecovery({
+        decodeStoredMessage({
           type: 'user',
           id: 'message-1',
           turnId: 'turn-1',

--- a/packages/core/src/__tests__/tool-result-record-schema.test.ts
+++ b/packages/core/src/__tests__/tool-result-record-schema.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { StoredMessage } from '../session.js';
-import { decodeStoredMessageForRecovery } from '../session.js';
+import { decodeStoredMessage } from '../session.js';
 import { decodeCanonicalToolResultContent } from '../tool-result-record-schema.js';
 
 describe('sandbox denial tool result metadata', () => {
@@ -17,7 +17,7 @@ describe('sandbox denial tool result metadata', () => {
 
     assert.deepEqual(decodeCanonicalToolResultContent(result), result);
     assert.deepEqual(
-      toolResultContent(decodeStoredMessageForRecovery(storedToolResult(result))),
+      toolResultContent(decodeStoredMessage(storedToolResult(result))),
       result,
     );
   });
@@ -55,7 +55,7 @@ describe('sandbox boundary failure tool result metadata', () => {
 
     assert.deepEqual(decodeCanonicalToolResultContent(result), result);
     assert.deepEqual(
-      toolResultContent(decodeStoredMessageForRecovery(storedToolResult(result))),
+      toolResultContent(decodeStoredMessage(storedToolResult(result))),
       result,
     );
   });
@@ -92,7 +92,7 @@ describe('uncertain tool outcome metadata', () => {
 
     assert.deepEqual(decodeCanonicalToolResultContent(result), result);
     assert.deepEqual(
-      toolResultContent(decodeStoredMessageForRecovery(storedToolResult(result))),
+      toolResultContent(decodeStoredMessage(storedToolResult(result))),
       result,
     );
   });

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,11 +1,3 @@
-/**
- * Session disk format: JSONL with SessionHeader as line 1 + append-only
- * StoredMessage lines.
- * Storage layer enforces append-only for messages and read-rewrite-write
- * (atomic temp + rename) for header. Per-session write queue invariant
- * is enforced by the storage implementation.
- */
-
 import {
   decodeMessageContent,
   TOOL_ACTIVITY_KINDS,
@@ -31,10 +23,7 @@ import {
 } from './record-schema.js';
 import { isPermissionDecisionFields } from './interaction-record-schema.js';
 import { isTokenUsageFields, type TokenUsageFields } from './usage-record-schema.js';
-import {
-  decodePersistedToolResultContentForRecovery,
-  normalizeToolResultContentForRead,
-} from './tool-result-record-schema.js';
+import { decodeCanonicalToolResultContent } from './tool-result-record-schema.js';
 import type { SubagentWorkspaceBinding } from './subagent-workspace.js';
 
 export { DEEP_RESEARCH_SESSION_LABEL, isDeepResearchSession } from './explore-agent.js';
@@ -971,19 +960,8 @@ const SYSTEM_NOTE_KINDS = new Set([
   'abort',
 ]);
 
-export function decodeStoredMessageForRead(value: unknown): StoredMessage {
-  return decodeStoredMessage(value, normalizeToolResultContentForRead);
-}
-
-export function decodeStoredMessageForRecovery(value: unknown): StoredMessage {
-  return decodeStoredMessage(value, decodePersistedToolResultContentForRecovery);
-}
-
-function decodeStoredMessage(
-  value: unknown,
-  decodeToolResultContent: (content: unknown) => ToolResultContent,
-): StoredMessage {
-  const message = decodeStoredMessageContent(value, decodeToolResultContent);
+export function decodeStoredMessage(value: unknown): StoredMessage {
+  const message = decodeStoredMessageContent(value, decodeCanonicalToolResultContent);
   if (!isRecord(message)) throw new Error('Invalid stored message schema');
   switch (message.type) {
     case 'user':

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -189,17 +189,6 @@ const RIVE_ERROR_SHAPE = defineObjectShape<RiveError>()(
   ['code', 'suggestedAction'],
 );
 
-export function normalizeToolResultContentForRead(value: unknown): ToolResultContent {
-  const shell = decodeCanonicalShellToolResultContent(value);
-  if (shell.state === 'invalid') throw new Error('Invalid shell tool result content');
-  const normalized = shell.state === 'valid' ? shell.content : value;
-  return decodeCanonicalToolResultContent(normalizeLegacySubagentToolResultContent(normalized));
-}
-
-export function decodePersistedToolResultContentForRecovery(value: unknown): ToolResultContent {
-  return decodeCanonicalToolResultContent(normalizeLegacySubagentToolResultContent(value));
-}
-
 export function decodeCanonicalToolResultContent(value: unknown): ToolResultContent {
   const shell = decodeCanonicalShellToolResultContent(value);
   if (shell.state === 'invalid') throw new Error('Invalid shell tool result content');
@@ -208,18 +197,6 @@ export function decodeCanonicalToolResultContent(value: unknown): ToolResultCont
     throw new Error('Invalid tool result content');
   }
   return value;
-}
-
-function normalizeLegacySubagentToolResultContent(value: unknown): unknown {
-  if (
-    !isRecord(value) ||
-    value.kind !== 'subagent' ||
-    value.status !== 'waiting_permission' ||
-    !hasValidSubagentResultFields(value)
-  ) {
-    return value;
-  }
-  return { ...value, status: 'waiting_for_user' };
 }
 
 function isNonShellToolResultContent(value: unknown): value is ToolResultContent {

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -21,7 +21,7 @@ import { canonicalToolArgsHash } from '@maka/core/tool-args-identity';
 import type { AgentRunHeader } from '@maka/core/agent-run';
 import type { MessageContent } from '@maka/core/events';
 import type { ConnectionCatalogEntry } from '@maka/core/runtime-policy';
-import { decodeStoredMessageForRead, type StoredMessage } from '@maka/core/session';
+import { decodeStoredMessage, type StoredMessage } from '@maka/core/session';
 import type { Task } from '@maka/core/task-ledger';
 import type { ScheduledTask } from '@maka/core/scheduled-task';
 import { isTerminalRuntimeEvent } from '@maka/core/runtime-event';
@@ -547,7 +547,7 @@ test('two Clients share one execution after the starting Client disconnects', as
     const secondSubscription = await second.openSessionSubscription({
       sessionId: fixture.sessionId,
     });
-    const transcript = await secondSubscription.loadTranscript(decodeStoredMessageForRead);
+    const transcript = await secondSubscription.loadTranscript(decodeStoredMessage);
     assert.ok(
       transcript.some(
         (message) =>

--- a/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
+++ b/packages/runtime-host/src/__tests__/session-subscription-client.test.ts
@@ -9,7 +9,7 @@ import {
   prepareStorageRootControlDirectory,
   resolveStorageRoot,
 } from '@maka/storage/root-authority';
-import { decodeStoredMessageForRead } from '@maka/core/session';
+import { decodeStoredMessage } from '@maka/core/session';
 import {
   connectRuntimeHost,
   RuntimeHostSubscriptionError,
@@ -312,7 +312,7 @@ test('loads a canonical transcript while live frames continue on the same connec
     },
     async (connection) => {
       const subscription = await connection.openSessionSubscription({ sessionId: 'session-1' });
-      assert.deepEqual(await subscription.loadTranscript(decodeStoredMessageForRead), [message]);
+      assert.deepEqual(await subscription.loadTranscript(decodeStoredMessage), [message]);
       assert.deepEqual(await subscription[Symbol.asyncIterator]().next(), {
         done: false,
         value: deltaFrame(connection.hostEpoch, subscription.subscriptionId, 1),
@@ -404,10 +404,10 @@ test('restarts transcript loading after an expired snapshot', async () => {
     async (connection) => {
       const subscription = await connection.openSessionSubscription({ sessionId: 'session-1' });
       await assert.rejects(
-        () => subscription.loadTranscript(decodeStoredMessageForRead),
+        () => subscription.loadTranscript(decodeStoredMessage),
         hasSubscriptionReason('transcript_expired'),
       );
-      assert.deepEqual(await subscription.loadTranscript(decodeStoredMessageForRead), [message]);
+      assert.deepEqual(await subscription.loadTranscript(decodeStoredMessage), [message]);
       await subscription.close();
     },
   );

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-import { decodeStoredMessageForRecovery, type BackendKind } from '@maka/core/session';
+import type { BackendKind } from '@maka/core/session';
 import type { AgentRunHeader } from '@maka/core/agent-run';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type { SessionEvent } from '@maka/core/events';

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -44,7 +44,6 @@ import {
 } from '@maka/core/runtime-event';
 import { formatAttachmentResourceRef } from '@maka/core/attachments';
 import { decodeCanonicalShellToolResultContent } from '@maka/core/shell-run-result';
-import { normalizeToolResultContentForRead } from '@maka/core/tool-result-record-schema';
 import type { AttachmentRef, QuoteRef } from '@maka/core/events';
 import type { ModelMessage, UserContent, UserModelMessage } from './model-protocol.js';
 import { projectBashToolResultForModel } from './bash-model-output.js';
@@ -596,16 +595,8 @@ export function buildRuntimeEventModelReplayPlan(
             : event.content.result;
         if (shellResult.state === 'invalid') {
           invalidResultMessage = 'function_response contains an invalid shell tool result';
-        } else if (
-          shellResult.state === 'valid' ||
-          isLegacySubagentToolResultCandidate(event.content.name, event.content.result)
-        ) {
-          try {
-            normalizedResult = normalizeToolResultContentForRead(event.content.result);
-          } catch {
-            invalidResultMessage =
-              'function_response contains an invalid legacy subagent tool result';
-          }
+        } else if (shellResult.state === 'valid') {
+          normalizedResult = shellResult.content;
         }
         if (!invalidResultMessage && event.content.name === 'Bash') {
           normalizedResult = projectBashToolResultForModel(normalizedResult);
@@ -890,15 +881,6 @@ export function stripSteeringMessages(
     const eventId = steeringEventIdOf(message);
     return eventId === undefined || !ids.has(eventId);
   });
-}
-
-const LEGACY_SUBAGENT_RESULT_TOOL_NAMES = new Set(['Task', 'agent_spawn']);
-
-function isLegacySubagentToolResultCandidate(toolName: string, value: unknown): boolean {
-  if (!LEGACY_SUBAGENT_RESULT_TOOL_NAMES.has(toolName)) return false;
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const candidate = value as Record<string, unknown>;
-  return candidate.kind === 'subagent' && candidate.status === 'waiting_permission';
 }
 
 /**

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -15,7 +15,7 @@ import {
   isTerminalRuntimeEventStatus,
 } from '@maka/core/runtime-event';
 
-import { normalizeToolResultContentForRead } from '@maka/core/tool-result-record-schema';
+import { decodeCanonicalToolResultContent } from '@maka/core/tool-result-record-schema';
 
 /** The statuses a settled boundary decision can carry — every status but `pending`. */
 type SettledSandboxBoundaryStatus = Exclude<
@@ -814,7 +814,7 @@ function projectFunctionResponse(
   let normalizedResult: ToolResultContent | undefined;
   if (!archivedPlaceholder) {
     try {
-      normalizedResult = normalizeToolResultContentForRead(compatibleResult);
+      normalizedResult = decodeCanonicalToolResultContent(compatibleResult);
     } catch (error) {
       diagnostic(
         state,

--- a/packages/storage/src/__tests__/codex-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/codex-session-adapter.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { decodeStoredMessageForRecovery } from '@maka/core/session';
+import { decodeStoredMessage } from '@maka/core/session';
 import { CodexSessionAdapter } from '../codex-session-adapter.js';
 import { createExternalSessionAdapterRegistry } from '../external-session-adapters.js';
 
@@ -109,7 +109,7 @@ describe('CodexSessionAdapter', () => {
       });
       assert.equal(session.messages.length, 9);
       for (const message of session.messages) {
-        assert.deepEqual(decodeStoredMessageForRecovery(message), message);
+        assert.deepEqual(decodeStoredMessage(message), message);
       }
 
       assert.deepEqual(session.messages[0], {

--- a/packages/storage/src/execution-record-codec.ts
+++ b/packages/storage/src/execution-record-codec.ts
@@ -10,9 +10,9 @@ import {
   type RuntimeEvent,
 } from '@maka/core/runtime-event';
 
-import { decodeStoredMessageForRead, decodeStoredMessageForRecovery } from '@maka/core/session';
+import { decodeStoredMessage } from '@maka/core/session';
 
-export { decodeStoredMessageForRead, decodeStoredMessageForRecovery };
+export { decodeStoredMessage };
 
 export function decodeAgentRunHeader(
   value: unknown,

--- a/packages/storage/src/operational-state-backup.ts
+++ b/packages/storage/src/operational-state-backup.ts
@@ -16,7 +16,7 @@ import { dirname, relative, resolve } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { decodeArtifactRecordJsons } from './artifact-metadata-codec.js';
 import { withArtifactWriterLock } from './artifact-writer-lock.js';
-import { decodeStoredMessageForRecovery } from './execution-record-codec.js';
+import { decodeStoredMessage } from './execution-record-codec.js';
 import {
   acquireOperationalStateDatabase,
   OPERATIONAL_STATE_DATABASE_NAME,
@@ -490,7 +490,7 @@ function validateSqlite(path: string, files: readonly OperationalBackupFile[]): 
         ) {
           throw new Error('session message index is invalid');
         }
-        const message = decodeStoredMessageForRecovery(JSON.parse(row.record_json));
+        const message = decodeStoredMessage(JSON.parse(row.record_json));
         if (
           message.id !== row.message_id ||
           message.type !== row.message_type ||

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -18,7 +18,7 @@ import {
 } from './operational-state-store.js';
 import { DEFAULT_SESSION_NAME, normalizeUserSessionName } from '@maka/core/session-name';
 import {
-  decodeStoredMessageForRecovery,
+  decodeStoredMessage,
   deriveTurnRecords,
   isSessionBlockedReason,
   isSessionConversationCopy,
@@ -325,7 +325,7 @@ class SqliteSessionStore implements SessionAuthorityStore {
       throw new Error('Subagent spawn metadata requires createSubagent()');
     }
     const canonicalMessages = messages.map((message) =>
-      decodeStoredMessageForRecovery(JSON.parse(JSON.stringify(message)) as unknown),
+      decodeStoredMessage(JSON.parse(JSON.stringify(message)) as unknown),
     );
     const header: SessionHeader = {
       ...buildSessionHeader(this.workspaceRoot, input),

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -61,8 +61,7 @@ import {
   type SessionHeader,
   type StoredMessage,
   type SubagentSessionParent,
-  decodeStoredMessageForRead,
-  decodeStoredMessageForRecovery,
+  decodeStoredMessage,
 } from '@maka/core/session';
 import {
   type AgentGraphIntentAdmissionSnapshot,
@@ -1277,7 +1276,7 @@ export class SqliteSessionMetadataStore {
     // through JSON so the stored form matches what the recovery path reads.
     const encoded = messages.map((message) => {
       const json = JSON.stringify(message);
-      const canonical = decodeStoredMessageForRecovery(JSON.parse(json) as unknown);
+      const canonical = decodeStoredMessage(JSON.parse(json) as unknown);
       return { message: canonical, json };
     });
     return this.transaction(() => {
@@ -1337,7 +1336,7 @@ export class SqliteSessionMetadataStore {
     if (messages.length === 0) return;
     const encoded = messages.map((message) => {
       const json = JSON.stringify(message);
-      const canonical = decodeStoredMessageForRecovery(JSON.parse(json) as unknown);
+      const canonical = decodeStoredMessage(JSON.parse(json) as unknown);
       return { message: canonical, json };
     });
     this.transaction(() => {
@@ -1379,11 +1378,11 @@ export class SqliteSessionMetadataStore {
   }
 
   async readMessages(sessionId: string): Promise<StoredMessage[]> {
-    return this.readMessagesWith(sessionId, decodeStoredMessageForRead);
+    return this.readMessagesWith(sessionId, decodeStoredMessage);
   }
 
   async readMessagesForRecovery(sessionId: string): Promise<StoredMessage[]> {
-    return this.readMessagesWith(sessionId, decodeStoredMessageForRecovery);
+    return this.readMessagesWith(sessionId, decodeStoredMessage);
   }
 
   async readPreviewMessages(sessionId: string, limit = 10): Promise<StoredMessage[]> {
@@ -1406,7 +1405,7 @@ export class SqliteSessionMetadataStore {
       .all(sessionId, limit) as Array<{ record_json?: unknown }>;
     return rows
       .reverse()
-      .map((row, index) => decodeStoredMessageRow(row.record_json, sessionId, index, false));
+      .map((row, index) => decodeStoredMessageRow(row.record_json, sessionId, index));
   }
 
   async beginCatalogProjectionWrite(): Promise<void> {
@@ -4574,14 +4573,13 @@ function decodeStoredMessageRow(
   value: unknown,
   sessionId: string,
   index: number,
-  recovery: boolean,
 ): StoredMessage {
   if (typeof value !== 'string') {
     throw new Error(`Invalid Session message row ${index} for ${sessionId}`);
   }
   try {
     const parsed = JSON.parse(value) as unknown;
-    return recovery ? decodeStoredMessageForRecovery(parsed) : decodeStoredMessageForRead(parsed);
+    return decodeStoredMessage(parsed);
   } catch (error) {
     throw new Error(`Invalid Session message row ${index} for ${sessionId}`, {
       cause: error,


### PR DESCRIPTION
## Summary
- remove the obsolete subagent waiting_permission compatibility migration
- replace read and recovery decoder variants with one canonical stored-message decoder
- route runtime replay, CLI, desktop, and SQLite consumers through the same schema authority
- remove an obsolete JSONL storage comment

## Validation
- Biome check on all changed source and test files
- git diff --check
- legacy symbol, producer, consumer, and decoder reachability audit

No test suite was run; CI owns suite execution.