### PR TITLE
refactor: remove unowned legacy normalizers

### DIFF
--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -11,7 +11,6 @@ import {
 import { INTERACTION_ID_MAX_BYTES, INTERACTION_TOOL_NAME_MAX_BYTES } from '../interaction.js';
 import {
   TERMINAL_RUNTIME_EVENT_STATUSES,
-  decodePersistedRuntimeEvent,
   decodeRuntimeEvent,
   isTerminalRuntimeEvent,
   runtimeEventHasModelVisibleContent,

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -633,35 +633,6 @@ export function decodeRuntimeEvent(value: unknown): RuntimeEvent {
   return value as unknown as RuntimeEvent;
 }
 
-export function decodePersistedRuntimeEvent(value: unknown): RuntimeEvent {
-  return decodeRuntimeEvent(normalizeLegacyPermissionRequest(value));
-}
-
-function normalizeLegacyPermissionRequest(value: unknown): unknown {
-  if (!isRecord(value) || !isRecord(value.actions)) return value;
-  const request = value.actions.permissionRequest;
-  if (
-    !isRecord(request) ||
-    Object.hasOwn(request, 'kind') ||
-    Object.hasOwn(request, 'rememberForTurnAllowed')
-  ) {
-    return value;
-  }
-  const normalized = {
-    ...request,
-    kind: 'tool_permission',
-    rememberForTurnAllowed: false,
-  };
-  if (!isPermissionRequestPayload(normalized)) return value;
-  return {
-    ...value,
-    actions: {
-      ...value.actions,
-      permissionRequest: normalized,
-    },
-  };
-}
-
 function isRuntimeEventContent(value: unknown): value is RuntimeEventContent {
   if (!isRecord(value)) return false;
   switch (value.kind) {

--- a/packages/runtime/src/skills-metadata.ts
+++ b/packages/runtime/src/skills-metadata.ts
@@ -127,30 +127,13 @@ export function validateSkillMetadata(text: string): SkillMetadataValidationResu
   try {
     rawManifest = parseStrictSkillManifest(extracted.frontmatter);
   } catch {
-    const repaired = repairLegacySkillFrontmatter(extracted.frontmatter);
-    if (repaired) {
-      try {
-        rawManifest = parseStrictSkillManifest(repaired);
-        issues.push({
-          code: 'malformed_frontmatter',
-          severity: 'warning',
-          field: 'frontmatter',
-          message:
-            'SKILL.md frontmatter used legacy syntax and was loaded after a compatibility repair.',
-        });
-      } catch {
-        // The constrained compatibility repair was insufficient; fail closed.
-      }
-    }
-    if (rawManifest === undefined) {
-      issues.push({
-        code: 'malformed_frontmatter',
-        severity: 'error',
-        field: 'frontmatter',
-        message: 'SKILL.md frontmatter is not valid YAML.',
-      });
-      return { manifest, body: extracted.body, issues, valid: false };
-    }
+    issues.push({
+      code: 'malformed_frontmatter',
+      severity: 'error',
+      field: 'frontmatter',
+      message: 'SKILL.md frontmatter is not valid YAML.',
+    });
+    return { manifest, body: extracted.body, issues, valid: false };
   }
 
   if (!isRecord(rawManifest)) {
@@ -336,35 +319,6 @@ function parseStrictSkillManifest(frontmatter: string): unknown {
   });
   if (document.errors.length > 0 || document.warnings.length > 0) throw new Error('invalid yaml');
   return document.toJS({ maxAliasCount: 0 });
-}
-
-/**
- * Repair only the two legacy forms accepted by Maka's former line parser:
- * unquoted colons in required scalar fields and tab-indented list items.
- * The repaired document must still pass the strict YAML parser and the full
- * typed validator, so this cannot bypass required-tools/capability checks.
- */
-function repairLegacySkillFrontmatter(frontmatter: string): string | undefined {
-  let changed = false;
-  const repaired = frontmatter.split(/\r?\n/).map((line) => {
-    let next = line;
-    const leading = next.match(/^[ \t]+/)?.[0];
-    if (leading?.includes('\t')) {
-      next = leading.replace(/\t/g, '  ') + next.slice(leading.length);
-    }
-
-    const scalar = next.match(/^(name|description):[ \t]*(.*)$/);
-    if (scalar) {
-      const value = scalar[2].trim();
-      if (value.includes(': ') && !value.startsWith('"') && !value.startsWith("'")) {
-        next = `${scalar[1]}: ${JSON.stringify(value)}`;
-      }
-    }
-
-    if (next !== line) changed = true;
-    return next;
-  });
-  return changed ? repaired.join('\n') : undefined;
 }
 
 function readRequiredSkillString(


### PR DESCRIPTION
## Summary
- remove the unused persisted RuntimeEvent compatibility decoder and legacy permission-request repair
- remove legacy Skill frontmatter rewriting and fail closed through the strict YAML parser
- delete the stale test-only import left by the unused decoder

## Validation
- Biome check on all changed files
- git diff --check
- producer, consumer, symbol, and canonical failure-ownership audit

No test suite was run; CI owns suite execution.