### PR TITLE
refactor(desktop): remove legacy Codex model fallback

### DIFF
--- a/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
+++ b/apps/desktop/src/main/__tests__/model-catalog-choices.test.ts
@@ -1,13 +1,8 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import type { ChatModelChoice } from '@maka/core/chat-model-choice';
 import type { LlmConnection } from '@maka/core/llm-connections';
-import type { SessionSummary } from '@maka/core/session';
 import { buildChatModelChoices } from '@maka/core/chat-model-choice';
-import {
-  normalizeActiveChatModel,
-  pickNewChatModel,
-} from '../../renderer/shell-chat-model-selection.js';
+import { pickNewChatModel } from '../../renderer/shell-chat-model-selection.js';
 
 function connection(
   overrides: Partial<LlmConnection> & Pick<LlmConnection, 'slug' | 'providerType'>,
@@ -24,77 +19,6 @@ function connection(
 }
 
 describe('model catalog picker helpers', () => {
-  it('keeps the first offered Codex model when replacing an unsupported stored model', () => {
-    const choices: ChatModelChoice[] = [
-      {
-        connectionSlug: 'codex-account',
-        providerType: 'openai-codex',
-        providerLabel: 'OpenAI OAuth',
-        model: 'first-offered',
-        label: 'First offered',
-        isDefault: false,
-        thinkingLevels: [],
-      },
-      {
-        connectionSlug: 'codex-account',
-        providerType: 'openai-codex',
-        providerLabel: 'OpenAI OAuth',
-        model: 'later-default',
-        label: 'Later default',
-        isDefault: true,
-        thinkingLevels: [],
-      },
-    ];
-    const session: SessionSummary = {
-      id: 'session-1',
-      name: 'Legacy Codex session',
-      isFlagged: false,
-      isArchived: false,
-      labels: [],
-      hasUnread: false,
-      status: 'active',
-      backend: 'ai-sdk',
-      llmConnectionSlug: 'codex-account',
-      connectionLocked: true,
-      model: 'gpt-5-codex',
-      permissionMode: 'ask',
-    };
-
-    assert.equal(
-      normalizeActiveChatModel(
-        session,
-        connection({
-          slug: 'codex-account',
-          providerType: 'openai-codex',
-          defaultModel: 'gpt-5-codex',
-        }),
-        choices,
-      ),
-      'first-offered',
-    );
-  });
-
-  it('uses the first offered model when no user or workspace preference exists', () => {
-    assert.deepEqual(
-      pickNewChatModel({
-        pending: null,
-        catalogDefault: undefined,
-        choices: [
-          {
-            connectionSlug: 'opencode-free',
-            providerType: 'opencode-free',
-            providerLabel: 'OpenCode Zen',
-            model: 'mimo-v2.5-free',
-            label: 'MiMo V2.5 Free',
-            isDefault: true,
-            thinkingLevels: [],
-          },
-        ],
-      }),
-      { llmConnectionSlug: 'opencode-free', model: 'mimo-v2.5-free' },
-    );
-  });
-
   it('uses the readiness-checked activation candidate before an unverified first choice', () => {
     assert.deepEqual(
       pickNewChatModel({

--- a/apps/desktop/src/renderer/shell-chat-model-selection.ts
+++ b/apps/desktop/src/renderer/shell-chat-model-selection.ts
@@ -1,7 +1,4 @@
 import type { ChatModelChoice } from '@maka/core/chat-model-choice';
-import type { LlmConnection } from '@maka/core/llm-connections';
-import type { SessionSummary } from '@maka/core/session';
-import { CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS } from '@maka/core/codex-model-compatibility';
 
 export type NewChatModel = { llmConnectionSlug: string; model: string };
 
@@ -18,24 +15,6 @@ export function pickNewChatModel(input: {
   }
   const first = input.choices[0];
   return first ? { llmConnectionSlug: first.connectionSlug, model: first.model } : undefined;
-}
-
-export function normalizeActiveChatModel(
-  session: SessionSummary | undefined,
-  connection: LlmConnection | undefined,
-  choices: readonly ChatModelChoice[],
-): string | undefined {
-  if (!session || session.backend === 'fake') return undefined;
-  const requested = session.model || connection?.defaultModel;
-  if (choices.some(
-    (choice) => choice.connectionSlug === session.llmConnectionSlug && choice.model === requested,
-  )) return requested;
-  if (
-    connection?.providerType !== 'openai-codex' ||
-    !requested ||
-    !CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS.has(requested)
-  ) return requested;
-  return choices.find((choice) => choice.connectionSlug === session.llmConnectionSlug)?.model;
 }
 
 export function chatModelChoiceLabel(

--- a/apps/desktop/src/renderer/use-shell-chat-model.ts
+++ b/apps/desktop/src/renderer/use-shell-chat-model.ts
@@ -8,7 +8,6 @@ import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { UiLocale } from '@maka/core/ui-locale';
 import {
   chatModelChoiceLabel,
-  normalizeActiveChatModel,
   pickNewChatModel,
   type NewChatModel,
 } from './shell-chat-model-selection';
@@ -123,7 +122,7 @@ export function useShellChatModel(options: {
     : activeConnection?.name ?? activeSession?.llmConnectionSlug;
   const activeModel = activeSession?.backend === 'fake'
     ? undefined
-    : normalizeActiveChatModel(activeSession, activeConnection, chatModelChoices);
+    : activeSession?.model || activeConnection?.defaultModel;
   const activeModelLabel = activeSession?.backend === 'fake'
     ? undefined
     : chatModelChoiceLabel(chatModelChoices, activeSession?.llmConnectionSlug, activeModel);


### PR DESCRIPTION
## Summary
- remove the renderer-only fallback that silently rewrote a legacy Codex session model to the first catalog choice
- derive the active model directly from session state or the connection default
- remove the legacy compatibility test and trivial first-choice happy path
- retain readiness candidate selection and OAuth identity redaction coverage

## Validation
- Biome check on changed files
- git diff --check
- removed-symbol reachability audit
- no test suites run; CI owns execution