### PR TITLE
refactor: remove stale Codex request normalization

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-readiness.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-readiness.test.ts
@@ -147,25 +147,6 @@ describe('chat readiness guard', () => {
     assert.equal(real.model, 'claude-3-5-sonnet-20241022');
   });
 
-  test('normalizes stale Codex OAuth session model away from unsupported ChatGPT-account model', async () => {
-    const ready = await requireReadyConnection(
-      'openai-codex',
-      deps({
-        connection: connection({
-          slug: 'openai-codex',
-          name: 'Codex Subscription',
-          providerType: 'openai-codex',
-          defaultModel: 'gpt-5.5',
-          models: [{ id: 'gpt-5.5' }, { id: 'gpt-5.4' }],
-        }),
-        apiKey: 'codex-oauth-secret',
-      }),
-      'gpt-5-codex',
-    );
-    assert.equal(ready.connection.slug, 'openai-codex');
-    assert.equal(ready.model, 'gpt-5.5');
-  });
-
   test('send path blocks explicit fake sessions and revalidates old ai sessions', async () => {
     await assertRejectsReadiness(
       'explicit fake session',

--- a/apps/desktop/src/main/chat-readiness.ts
+++ b/apps/desktop/src/main/chat-readiness.ts
@@ -1,7 +1,6 @@
 import {
   isConnectionReady,
   normalizeOpenAiCodexConnection,
-  normalizeRequestedModelForReadiness,
   type ChatConfigurationReason,
 } from '@maka/core/connection-readiness';
 import { NO_REAL_CONNECTION_CODE } from '@maka/core/connection-error-copy';
@@ -85,16 +84,15 @@ export async function requireReadyConnection(
   // copy, (3) the throw-error API the rest of main.ts expects.
   const normalizedConnection = normalizeOpenAiCodexConnection(connection);
   const apiKey = await deps.getApiKey(normalizedConnection.slug);
-  const normalizedRequestedModel = normalizeRequestedModelForReadiness(connection, requestedModel);
   const verdict = isConnectionReady({
     connection: normalizedConnection,
     hasSecret: typeof apiKey === 'string' && apiKey.length > 0,
-    requestedModel: normalizedRequestedModel,
+    requestedModel,
   });
 
   if (verdict.ready === false) {
     throw chatConfigurationError(
-      messageForReason(verdict.reason, normalizedConnection, normalizedRequestedModel),
+      messageForReason(verdict.reason, normalizedConnection, requestedModel),
       verdict.reason,
     );
   }

--- a/packages/core/src/__tests__/session-send-projection.test.ts
+++ b/packages/core/src/__tests__/session-send-projection.test.ts
@@ -249,33 +249,6 @@ describe('projectSessionSendOutcome — silent rebind walk', () => {
 });
 
 describe('projectSessionSendOutcome — codex normalization', () => {
-  // 'gpt-5-codex' is the one entry in CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS.
-  const codex = connection({
-    slug: 'codex-sub',
-    providerType: 'openai-codex',
-    defaultModel: 'gpt-5.6-sol',
-    models: [{ id: 'gpt-5.6-sol' }],
-  });
-
-  it('a requested ChatGPT-unsupported session model falls back to the servable default', () => {
-    // Without normalization the sticky 'gpt-5-codex' is not in the
-    // enabled list → model_not_enabled. The send path drops it and
-    // validates the normalized default instead → ready.
-    const outcome = projectSessionSendOutcome(
-      input({
-        session: {
-          backend: 'ai-sdk',
-          llmConnectionSlug: 'codex-sub',
-          model: 'gpt-5-codex',
-          connectionLocked: true,
-        },
-        connections: [codex],
-        defaultSlug: 'codex-sub',
-      }),
-    );
-    assert.deepEqual(outcome, { kind: 'ready' });
-  });
-
   it('a codex connection with only unsupported models rebinds onto the fallback list', () => {
     const outcome = projectSessionSendOutcome(
       input({

--- a/packages/core/src/connection-readiness.ts
+++ b/packages/core/src/connection-readiness.ts
@@ -176,26 +176,6 @@ export function normalizeOpenAiCodexConnection(connection: LlmConnection): LlmCo
 }
 
 /**
- * The requested model as the readiness gate should see it: a requested
- * ChatGPT-subscription-unsupported model on a Codex connection is
- * dropped so the gate validates the connection's (normalized) default
- * instead of a model the subscription cannot serve.
- */
-export function normalizeRequestedModelForReadiness(
-  connection: LlmConnection,
-  requestedModel: string | undefined,
-): string | undefined {
-  if (
-    connection.providerType === 'openai-codex' &&
-    requestedModel &&
-    CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS.has(requestedModel)
-  ) {
-    return undefined;
-  }
-  return requestedModel;
-}
-
-/**
  * Whether a connection is backed by a real LLM provider (anything
  * whose `backendKind === 'ai-sdk'`), as opposed to the in-process
  * `fake` backend or an unrecognized legacy provider type.

--- a/packages/core/src/session-send-projection.ts
+++ b/packages/core/src/session-send-projection.ts
@@ -12,7 +12,7 @@
  *
  * The logic mirrors the send path exactly:
  *   1. The session's own connection must pass `isConnectionReady` with
- *      the sticky session model (after codex normalization).
+ *      the sticky session model.
  *   2. A locked session (has user messages) can never rebind — any
  *      failure of its own connection blocks the send.
  *   3. An unlocked session may silently rebind only for reasons in
@@ -28,7 +28,6 @@
 import {
   isConnectionReady,
   normalizeOpenAiCodexConnection,
-  normalizeRequestedModelForReadiness,
   type ChatConfigurationReason,
 } from './connection-readiness.js';
 import type { LlmConnection } from './llm-connections.js';
@@ -124,7 +123,7 @@ export function sessionOwnConnectionBlockReason(
   const verdict = isConnectionReady({
     connection: normalized,
     hasSecret: hasSecret(normalized.slug),
-    requestedModel: normalizeRequestedModelForReadiness(ownConnection, session.model),
+    requestedModel: session.model,
   });
   return verdict.ready ? undefined : verdict.reason;
 }

--- a/packages/core/src/task-submission-readiness.ts
+++ b/packages/core/src/task-submission-readiness.ts
@@ -1,7 +1,6 @@
 import {
   isConnectionReady,
   normalizeOpenAiCodexConnection,
-  normalizeRequestedModelForReadiness,
   type ChatConfigurationReason,
 } from './connection-readiness.js';
 import type { LlmConnection } from './llm-connections.js';
@@ -157,7 +156,7 @@ function modelTargetDimension(
   const verdict = isConnectionReady({
     connection: normalizedConnection,
     hasSecret: target.hasSecret === true,
-    requestedModel: normalizeRequestedModelForReadiness(target.connection, target.requestedModel),
+    requestedModel: target.requestedModel,
   });
   if (verdict.ready) {
     return dimension('model_target', 'ready', 'connection_readiness', target.checkedAt);


### PR DESCRIPTION
## Summary
- stop erasing an explicitly requested legacy Codex model before readiness checks
- pass requested models unchanged through desktop send, session projection, and task readiness
- remove compatibility tests and their dedicated fixture
- retain current Codex inventory filtering for provider interoperability

## Validation
- Biome check on changed files
- git diff --check
- removed-symbol and consumer audit
- no test suites run; CI owns execution