### PR TITLE
test: trim provider readiness positive matrices

### DIFF
--- a/apps/desktop/src/main/__tests__/chat-readiness.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-readiness.test.ts
@@ -128,25 +128,6 @@ describe('chat readiness guard', () => {
     );
   });
 
-  test('allows none-auth local providers and real providers with secrets', async () => {
-    const local = await requireReadyConnection(
-      'ollama',
-      deps({ connection: connection({ slug: 'ollama', providerType: 'ollama', name: 'Ollama', defaultModel: 'llama3.2' }) }),
-    );
-    assert.equal(local.connection.slug, 'ollama');
-    assert.equal(local.apiKey, '');
-    assert.equal(local.model, 'llama3.2');
-
-    const real = await requireReadyConnection(
-      'anthropic',
-      deps({ connection: connection(), apiKey: 'sk-ant-test' }),
-      'claude-3-5-sonnet-20241022',
-    );
-    assert.equal(real.connection.slug, 'anthropic');
-    assert.equal(real.apiKey, 'sk-ant-test');
-    assert.equal(real.model, 'claude-3-5-sonnet-20241022');
-  });
-
   test('send path blocks explicit fake sessions and revalidates old ai sessions', async () => {
     await assertRejectsReadiness(
       'explicit fake session',

--- a/packages/core/src/__tests__/connection-readiness.test.ts
+++ b/packages/core/src/__tests__/connection-readiness.test.ts
@@ -104,7 +104,7 @@ describe('isConnectionReady — model capability gate', () => {
     assert.deepEqual(verdict, { ready: true, model: 'qwen3-8b' });
   });
 
-  it('keeps Vercel Gateway gated on its key while preserving the exact creator/model id', () => {
+  it('keeps Vercel Gateway gated on its key', () => {
     const vercel = connection({
       slug: 'vercel',
       name: 'Vercel AI Gateway',
@@ -117,25 +117,6 @@ describe('isConnectionReady — model capability gate', () => {
       ready: false,
       reason: 'missing_api_key',
     });
-    assert.deepEqual(isConnectionReady({ connection: vercel, hasSecret: true }), {
-      ready: true,
-      model: 'xai/grok-4.3',
-    });
-  });
-
-  it('keeps a runtime-backed xAI OAuth connection send-ready', () => {
-    const verdict = isConnectionReady({
-      connection: connection({
-        slug: 'xai-oauth',
-        name: 'xAI OAuth',
-        providerType: 'xai-oauth',
-        defaultModel: 'grok-4.5',
-        models: [{ id: 'grok-4.5', capabilities: { chat: true, functionCalling: true } }],
-      }),
-      hasSecret: true,
-    });
-
-    assert.deepEqual(verdict, { ready: true, model: 'grok-4.5' });
   });
 
   it('treats an enumerated fallback model list as the local send gate', () => {
@@ -151,17 +132,7 @@ describe('isConnectionReady — model capability gate', () => {
     assert.deepEqual(verdict, { ready: false, reason: 'model_not_enabled' });
   });
 
-  it('returns the normalized model id after validating a whitespace-padded model', () => {
-    assert.deepEqual(
-      isConnectionReady({
-        connection: connection({
-          defaultModel: ' gpt-4.1 ',
-        }),
-        hasSecret: true,
-      }),
-      { ready: true, model: 'gpt-4.1' },
-    );
-
+  it('returns the normalized requested model id', () => {
     assert.deepEqual(
       isConnectionReady({
         connection: connection(),


### PR DESCRIPTION
## Summary
- remove duplicate credential-success cases across Vercel, xAI OAuth, and the desktop wrapper
- keep one owner for required-key and optional-key readiness predicates
- collapse equivalent default/requested model trimming to the explicit requested-model boundary
- retain capability, inventory, telemetry, and failure semantics

## Validation
- Biome check on changed files
- git diff --check
- readiness predicate ownership audit
- no test suites run; CI owns execution