### PR TITLE
test(runtime): remove bot backoff test seams

### DIFF
--- a/packages/runtime/src/bots/__tests__/dingtalk-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/dingtalk-bridge.test.ts
@@ -5,7 +5,6 @@ import { __TEST__ } from '../dingtalk-bridge.js';
 
 const {
   decideDingTalkClose,
-  dingTalkReconnectBackoffMs,
   pickDingTalkSendRoute,
   classifyDingTalkSendResponse,
   dingTalkPayloadToEvent,
@@ -16,15 +15,6 @@ describe('decideDingTalkClose (PR-BOT-DINGTALK-OPERATIONAL-0)', () => {
   it('only treats explicit stops as terminal', () => {
     assert.deepEqual(decideDingTalkClose(1000, true), { kind: 'stopped' });
     assert.deepEqual(decideDingTalkClose(1000, false), { kind: 'reconnect' });
-  });
-});
-
-describe('dingTalkReconnectBackoffMs', () => {
-  it('doubles from 1s and caps at 30s', () => {
-    assert.equal(dingTalkReconnectBackoffMs(0), 1_000);
-    assert.equal(dingTalkReconnectBackoffMs(1), 2_000);
-    assert.equal(dingTalkReconnectBackoffMs(2), 4_000);
-    assert.equal(dingTalkReconnectBackoffMs(5), 30_000);
   });
 });
 

--- a/packages/runtime/src/bots/__tests__/discord-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/discord-bridge.test.ts
@@ -5,7 +5,6 @@ import { __TEST__ } from '../discord-bridge.js';
 
 const {
   decideDiscordClose,
-  reconnectBackoffMs,
   buildDiscordSendBody,
   normalizeDiscordReplyToMessageId,
   normalizeDiscordChannelId,
@@ -24,16 +23,6 @@ describe('Discord gateway helpers', () => {
       assert.deepEqual(decideDiscordClose(code, false), { kind: 'reconnect', resumable: false });
     }
     assert.deepEqual(decideDiscordClose(4000, false), { kind: 'reconnect', resumable: true });
-  });
-
-  it('exponentially backs off reconnects with a 30-second cap', () => {
-    for (const [attempt, expected] of [
-      [0, 1_000],
-      [3, 8_000],
-      [5, 30_000],
-    ]) {
-      assert.equal(reconnectBackoffMs(attempt), expected, String(attempt));
-    }
   });
 });
 

--- a/packages/runtime/src/bots/__tests__/qq-bridge.test.ts
+++ b/packages/runtime/src/bots/__tests__/qq-bridge.test.ts
@@ -5,7 +5,6 @@ import { __TEST__ } from '../qq-bridge.js';
 
 const {
   decideQQClose,
-  qqReconnectBackoffMs,
   classifyQQSendResponse,
   qqChannelMessageToEvent,
   qqGroupMessageToEvent,
@@ -24,16 +23,6 @@ describe('QQ gateway helpers', () => {
       assert.deepEqual(decideQQClose(code, false), { kind: 'reconnect', resumable: false });
     }
     assert.deepEqual(decideQQClose(4000, false), { kind: 'reconnect', resumable: true });
-  });
-
-  it('exponentially backs off reconnects with a 30-second cap', () => {
-    for (const [attempt, expected] of [
-      [0, 1_000],
-      [1, 2_000],
-      [5, 30_000],
-    ]) {
-      assert.equal(qqReconnectBackoffMs(attempt), expected, String(attempt));
-    }
   });
 });
 

--- a/packages/runtime/src/bots/dingtalk-bridge.ts
+++ b/packages/runtime/src/bots/dingtalk-bridge.ts
@@ -74,7 +74,7 @@ export function decideDingTalkClose(
 /**
  * Pure helper: exponential backoff for stream reconnect.
  */
-export function dingTalkReconnectBackoffMs(attempts: number): number {
+function dingTalkReconnectBackoffMs(attempts: number): number {
   const exp = Math.min(2 ** attempts, RECONNECT_DELAY_MAX_MS / RECONNECT_DELAY_MIN_MS);
   return Math.min(RECONNECT_DELAY_MIN_MS * exp, RECONNECT_DELAY_MAX_MS);
 }
@@ -551,7 +551,6 @@ export class DingTalkBotBridge extends BaseBotAdapter implements SendCapable {
 
 export const __TEST__ = {
   decideDingTalkClose,
-  dingTalkReconnectBackoffMs,
   buildDingTalkGroupSendBody,
   buildDingTalkSingleSendBody,
   pickDingTalkSendRoute,

--- a/packages/runtime/src/bots/discord-bridge.ts
+++ b/packages/runtime/src/bots/discord-bridge.ts
@@ -93,7 +93,7 @@ export function decideDiscordClose(code: number, explicitlyStopped: boolean): Di
  * Pure helper: compute the next backoff delay given the attempt count.
  * Exponential up to RECONNECT_DELAY_MAX_MS.
  */
-export function reconnectBackoffMs(attempts: number): number {
+function reconnectBackoffMs(attempts: number): number {
   const exp = Math.min(2 ** attempts, RECONNECT_DELAY_MAX_MS / RECONNECT_DELAY_MIN_MS);
   return Math.min(RECONNECT_DELAY_MIN_MS * exp, RECONNECT_DELAY_MAX_MS);
 }
@@ -618,7 +618,6 @@ export function splitDiscordContent(text: string): string[] {
 
 export const __TEST__ = {
   decideDiscordClose,
-  reconnectBackoffMs,
   buildDiscordSendBody,
   normalizeDiscordReplyToMessageId,
   normalizeDiscordChannelId,

--- a/packages/runtime/src/bots/qq-bridge.ts
+++ b/packages/runtime/src/bots/qq-bridge.ts
@@ -101,7 +101,7 @@ export function decideQQClose(code: number, explicitlyStopped: boolean): QQClose
   return { kind: 'reconnect', resumable };
 }
 
-export function qqReconnectBackoffMs(attempts: number): number {
+function qqReconnectBackoffMs(attempts: number): number {
   const exp = Math.min(2 ** attempts, RECONNECT_DELAY_MAX_MS / RECONNECT_DELAY_MIN_MS);
   return Math.min(RECONNECT_DELAY_MIN_MS * exp, RECONNECT_DELAY_MAX_MS);
 }
@@ -730,7 +730,6 @@ export class QQBotBridge extends BaseBotAdapter implements SendCapable {
 
 export const __TEST__ = {
   decideQQClose,
-  qqReconnectBackoffMs,
   classifyQQSendResponse,
   qqChannelMessageToEvent,
   qqGroupMessageToEvent,


### PR DESCRIPTION
## Summary
- remove three equivalent arithmetic backoff matrices across QQ, DingTalk, and Discord
- remove the helpers from each bridge `__TEST__` surface and make them module-private
- retain reconnect close classification and all provider wire/message tests

## Validation
- `npx biome check` on the six changed bridge and test files
- `git diff --check`
- static export/reference audit

Test suites intentionally not run; CI owns execution.