### PR TITLE
test(ui): remove duplicate terminal claim case

### DIFF
--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -44,28 +44,6 @@ describe('the unconfirmed claim an arm carries', () => {
 
     assert.equal(streamed.unconfirmed, undefined);
   });
-
-  it('is dropped when the turn terminates', () => {
-    const streamed = applyLiveTurnEvent(armLiveTurn('turn-1'), {
-      type: 'text_delta',
-      id: 'event-1',
-      turnId: 'turn-1',
-      messageId: 'step-1',
-      ts: 100,
-      text: '你',
-    });
-    const rearmed = { ...streamed, unconfirmed: true as const };
-    const done = applyLiveTurnEvent(rearmed, {
-      type: 'complete',
-      id: 'event-2',
-      turnId: 'turn-1',
-      ts: 200,
-      stopReason: 'end_turn',
-    });
-
-    assert.equal(done?.terminal, true);
-    assert.equal(done?.unconfirmed, undefined);
-  });
 });
 
 describe('applyLiveTurnEvent', () => {


### PR DESCRIPTION
## Summary
- remove an equivalent event-type matrix for clearing a live-turn unconfirmed claim
- drop a manually reintroduced claim state that production does not create
- retain same-turn, other-turn, content-event, terminalization, and abort ownership

## Validation
- `npx biome check packages/ui/src/__tests__/live-turn-projection.test.ts`
- `git diff --check`
- live-turn state ownership audit

Test suites intentionally not run; CI owns execution.