### PR TITLE
test(runtime): remove legacy cap backend matrix

### DIFF
--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -1096,22 +1096,6 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     assert.equal(fixture.recorded.length, 0);
   });
 
-  test('persists a complete summary above the legacy block cap when the full replay shrinks and fits', async () => {
-    const fixture = buildFixture({
-      priorChars: 10_000,
-      summarize: () => 'S'.repeat(5_000),
-    });
-    await runFixtureTurn(fixture, consumer);
-
-    assert.equal(fixture.recorded.length, 1);
-    assert.equal(fixture.model.doStreamCalls.length, 3);
-    const complete = fixture.events.find((event) => event.type === 'complete');
-    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
-    const thirdPrompt = promptJson(fixture, 2);
-    assert.equal(thirdPrompt.includes('PRIOR_FACT'), false);
-    assert.equal(thirdPrompt.includes('maka_history_compact_checkpoint'), true);
-  });
-
   test('the cold-start estimate covers the FULL provider input including the system prompt (review round-5 finding 2)', async () => {
     // The system prompt travels in the separate `system` field, not in
     // messages. With usage missing, a cold-start estimate over messages+tools


### PR DESCRIPTION
Summary:
- remove an expensive backend integration matrix for the retired compact-block cap
- retain the focused checkpoint policy owner
- retain normal persist-before-continue and long-turn compaction integration coverage

Validation:
- Biome on changed file
- git diff --check
- ownership audit

Test suites intentionally not run; CI owns execution.