### PR TITLE
refactor(runtime): remove task tool compatibility seams

### DIFF
--- a/packages/core/src/task-ledger.ts
+++ b/packages/core/src/task-ledger.ts
@@ -1,5 +1,5 @@
 // Session-scoped task ledger primitive for the main agent. The model manages a
-// flat task list via TaskCreate/TaskUpdate; each turn tail re-injects the
+// flat task list via task_create/task_update; each turn tail re-injects the
 // current list. The durable contract is intentionally narrow: task status,
 // compact evidence/reason fields, append-only task events, and conservative
 // resume trust diagnostics. Priority, dependencies, and assignee fields remain
@@ -209,7 +209,7 @@ export function isResumeTrust(value: unknown): value is ResumeTrust {
  * emits the id bare), no whitespace (would break the list-line structure), no
  * huge length (would bloat every turn tail), and redaction-stable (a renderer
  * that runs redactSecrets must not turn the id into [redacted] while the store
- * keeps the real id -- a later TaskUpdate would miss). The whitelist
+ * keeps the real id -- a later task_update would miss). The whitelist
  * (alphanumeric plus . _ : -, 1-64 chars) plus redactSecrets(id) === id enforces
  * these constraints without coupling to the UUID format.
  */
@@ -218,7 +218,7 @@ export function isSafeTaskId(value: unknown): value is string {
   // the id is rendered verbatim, so a secret-shaped id (ghp_..., sk-..., a
   // 40-char hex, AIza...) must be rejected -- otherwise a renderer that does
   // run redactSecrets would turn it into [redacted] while the store keeps the
-  // real id, and a later TaskUpdate would miss.
+  // real id, and a later task_update would miss.
   return (
     typeof value === 'string' &&
     /^[A-Za-z0-9][A-Za-z0-9._:-]{0,63}$/.test(value) &&
@@ -652,7 +652,7 @@ function validateTaskLedgerEventType(
  *   - the canonical id is rendered verbatim, and the subject is a safe
  *     (redacted, tag-stripped) rendered payload of what the store holds; and
  *   - the model can unambiguously recover each task's id from what it sees, so
- *     a later TaskUpdate hits the right task.
+ *     a later task_update hits the right task.
  *
  * Rendering is per-task and fielded, not a free-text bullet: each line is
  * `id=<id> status=<status> subject=<JSON-stringified safe subject>`. The
@@ -660,7 +660,7 @@ function validateTaskLedgerEventType(
  * `id=` field or any other id-like span past it -- any id-like text in the subject stays
  * inside the quoted JSON payload. The id is emitted verbatim: it is a
  * redaction-stable stable token validated on write and read, so scrubbing it
- * could only deform it (and break TaskUpdate); it must not be redacted or
+ * could only deform it (and break task_update); it must not be redacted or
  * tag-stripped. Each subject is redacted (secrets) and tag-stripped (complete
  * `<task-ledger ...>` / `</task-ledger ...>` tags on a single line, so a
  * model-authored subject cannot open or close the <task-ledger> data envelope)

--- a/packages/core/src/tool-catalog.ts
+++ b/packages/core/src/tool-catalog.ts
@@ -112,9 +112,6 @@ export const MAKA_CATALOG_TOOLS: readonly CatalogToolDef[] = Object.freeze(
     { name: 'task_get' },
     { name: 'memory_remember' },
     { name: 'memory_extract' },
-    // Legacy task-ledger aliases still registered on some hosts
-    { name: 'TaskCreate' },
-    { name: 'TaskUpdate' },
     // browser surface
     { name: 'browser_navigate' },
     { name: 'browser_snapshot' },

--- a/packages/runtime/src/__tests__/task-ledger-tools.test.ts
+++ b/packages/runtime/src/__tests__/task-ledger-tools.test.ts
@@ -13,14 +13,11 @@ import {
   type TaskOwner,
 } from '@maka/core/task-ledger';
 import {
-  LEGACY_TASK_CREATE_TOOL_NAME,
-  LEGACY_TASK_UPDATE_TOOL_NAME,
   TASK_CREATE_TOOL_NAME,
   TASK_GET_TOOL_NAME,
   TASK_LIST_TOOL_NAME,
   TASK_UPDATE_TOOL_NAME,
   buildTaskLedgerTools,
-  isTaskLedgerToolsEnabled,
 } from '../task-ledger-tools.js';
 import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
 
@@ -167,14 +164,6 @@ function findTool(tools: MakaTool[], name: string): MakaTool {
 }
 
 describe('task ledger tools', () => {
-  test('task tool feature flag defaults on and can be disabled explicitly', () => {
-    assert.equal(isTaskLedgerToolsEnabled({}), true);
-    assert.equal(isTaskLedgerToolsEnabled({ MAKA_TASK_LEDGER_TOOLS: 'false' }), false);
-    assert.equal(isTaskLedgerToolsEnabled({ MAKA_TASK_LEDGER_TOOLS: '0' }), false);
-    assert.equal(isTaskLedgerToolsEnabled({ MAKA_TASK_LEDGER_TOOLS: 'off' }), false);
-    assert.equal(isTaskLedgerToolsEnabled({ MAKA_TASK_LEDGER_TOOLS: 'true' }), true);
-  });
-
   test('task_create schema rejects a batch larger than the ledger cap and accepts the cap boundary', () => {
     const create = findTool(
       buildTaskLedgerTools({ store: new FakeTaskLedgerStore() }),

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -2,8 +2,8 @@
  * Goal tools — GoalSet / GoalClear / GoalStatus / GoalPause / GoalResume.
  *
  * Model-facing autonomous-execution controls. The agent can arm its own stop
- * condition (GoalSet), and pause/resume/clear the loop. PascalCase names match
- * the builtin tool family (Bash/Read/TaskCreate/ScheduledTask).
+ * condition (GoalSet), and pause/resume/clear the loop. Names follow their
+ * canonical registered tool identities.
  */
 
 import { z } from 'zod';

--- a/packages/runtime/src/task-ledger-tools.ts
+++ b/packages/runtime/src/task-ledger-tools.ts
@@ -18,35 +18,13 @@ export const TASK_UPDATE_TOOL_NAME = 'task_update';
 export const TASK_LIST_TOOL_NAME = 'task_list';
 export const TASK_GET_TOOL_NAME = 'task_get';
 
-export const LEGACY_TASK_CREATE_TOOL_NAME = 'TaskCreate';
-export const LEGACY_TASK_UPDATE_TOOL_NAME = 'TaskUpdate';
-
-export interface BuildTaskLedgerToolsOptions {
-  includeLegacyAliases?: boolean;
-}
-
-export function isTaskLedgerToolsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
-  const value = env.MAKA_TASK_LEDGER_TOOLS;
-  return value === undefined || !/^(0|false|off)$/i.test(value.trim());
-}
-
-export function buildTaskLedgerTools(
-  deps: { store: TaskLedgerStore },
-  options: BuildTaskLedgerToolsOptions = {},
-): MakaTool[] {
-  const tools = [
+export function buildTaskLedgerTools(deps: { store: TaskLedgerStore }): MakaTool[] {
+  return [
     buildTaskCreateTool(deps.store, TASK_CREATE_TOOL_NAME, 'task_update'),
     buildTaskUpdateTool(deps.store, TASK_UPDATE_TOOL_NAME),
     buildTaskListTool(deps.store),
     buildTaskGetTool(deps.store),
   ];
-  if (options.includeLegacyAliases === true) {
-    tools.push(
-      buildTaskCreateTool(deps.store, LEGACY_TASK_CREATE_TOOL_NAME, 'TaskUpdate'),
-      buildTaskUpdateTool(deps.store, LEGACY_TASK_UPDATE_TOOL_NAME),
-    );
-  }
-  return tools;
 }
 
 function buildTaskCreateTool(

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -192,7 +192,7 @@ class SqliteTaskLedgerStoreImpl implements SqliteTaskLedgerStore {
   ): Promise<{ created: Task[]; total: number }> {
     assertSafeSessionId(sessionId);
     if (!Array.isArray(drafts) || drafts.length === 0) {
-      throw new Error('TaskCreate requires at least one task draft');
+      throw new Error('Task creation requires at least one task draft');
     }
     // Front-door the per-batch cap before generating ids or normalizing drafts:
     // a single call can never add more than the absolute ledger cap, and rejecting
@@ -201,7 +201,7 @@ class SqliteTaskLedgerStoreImpl implements SqliteTaskLedgerStore {
     // inside the serialized mutate callback below.
     if (drafts.length > TASK_LEDGER_MAX_TASKS) {
       throw new Error(
-        `TaskCreate batch of ${drafts.length} tasks exceeds the ${TASK_LEDGER_MAX_TASKS}-task per-batch cap; split the work into smaller calls.`,
+        `Task creation batch of ${drafts.length} tasks exceeds the ${TASK_LEDGER_MAX_TASKS}-task per-batch cap; split the work into smaller calls.`,
       );
     }
     const normalizedDrafts = drafts.map((draft) => {


### PR DESCRIPTION
Summary:
- remove unreachable TaskCreate/TaskUpdate alias registration and catalog entries
- remove the unused task-tool environment flag and builder option
- keep one canonical task_create/task_update API surface and clean stale terminology

Validation:
- Biome on all changed files
- git diff --check
- full-repository reachability audit for aliases, option, and env flag

Test suites intentionally not run; CI owns execution.