### PR TITLE
feat(eval): generalize external subject execution

### DIFF
--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -20,7 +20,7 @@ Use `--cell <cell-id>` to replace one failed or indeterminate cell. The attempt 
 
 The built-in Harbor and Pier executors use one relay Agent. The framework prepares the task environment, the relay invokes exactly one Eval subject from `Agent.run()`, and the framework runs its native verifier and finalizer. Harbor and Pier use separate, explicitly versioned Python environments because their Agent and task contracts differ.
 
-Maka subjects ask the Runtime Host client to run one owned execution in a dedicated Host root. Session, Turn, Goal and continuation semantics remain inside Runtime Host. External subjects declare only a command and arguments; cohort-specific wrappers may configure the external product, but do not gain Runtime authority.
+Maka subjects ask the Runtime Host client to run one owned execution in a dedicated Host root. Session, Turn, Goal and continuation semantics remain inside Runtime Host. External subjects declare a command and arguments, and may add non-secret environment values, target-to-source bindings for declared credentials, and an explicit result contract. Omitted credential bindings use declared names unchanged. The `exit-code` result contract discards unstructured stdout and records null usage and cost; cohort-specific wrappers remain responsible only for configuration that cannot be expressed through this generic seam and do not gain Runtime authority.
 
 The result kernel contains only score, normalized usage, attributable cost, duration, status, and artifacts. Specs carry every semantic setting; environment variables are reserved for credentials and machine-local paths.
 

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -135,7 +135,7 @@ async def _prepare_command(
     subject = shlex.join([request["command"], *request["args"]])
     if not capture_stdout:
         subject = f"{subject} >/dev/null"
-    inner = f"echo $$ > {shlex.quote(scope_path)}; . {shlex.quote(container_path)}; rm -f {shlex.quote(container_path)}; exec {subject}"
+    inner = f"echo $$ > {shlex.quote(scope_path)}; . {shlex.quote(container_path)}; command -p rm -f {shlex.quote(container_path)}; exec {subject}"
     return f"setsid sh -c {shlex.quote(inner)}"
 
 

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -100,15 +100,26 @@ async def _prepare_command(
     environment: Any, request: dict[str, Any], token: str, scope_path: str
 ) -> str:
     credentials = request.get("credentials")
+    public_environment = request.get("environment")
     if not isinstance(credentials, dict) or not all(
         isinstance(key, str) and isinstance(value, str) for key, value in credentials.items()
     ):
         raise RuntimeError("invalid Maka Eval credentials")
+    if not isinstance(public_environment, dict) or not all(
+        isinstance(key, str) and isinstance(value, str)
+        for key, value in public_environment.items()
+    ):
+        raise RuntimeError("invalid Maka Eval environment")
+    if set(credentials) & set(public_environment):
+        raise RuntimeError("Maka Eval environment overlaps credentials")
+    capture_stdout = request.get("captureStdout")
+    if not isinstance(capture_stdout, bool):
+        raise RuntimeError("invalid Maka Eval stdout policy")
     container_path = f"/tmp/maka-eval-{token}.env"
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as secret:
         secret_path = Path(secret.name)
         os.chmod(secret_path, 0o600)
-        for key, value in credentials.items():
+        for key, value in {**public_environment, **credentials}.items():
             if not key or not key.replace("_", "a").isalnum() or key[0].isdigit():
                 raise RuntimeError("invalid Maka Eval credential name")
             secret.write(f"export {key}={shlex.quote(value)}\n")
@@ -117,6 +128,8 @@ async def _prepare_command(
     finally:
         secret_path.unlink(missing_ok=True)
     subject = shlex.join([request["command"], *request["args"]])
+    if not capture_stdout:
+        subject = f"{subject} >/dev/null"
     inner = f"echo $$ > {shlex.quote(scope_path)}; . {shlex.quote(container_path)}; rm -f {shlex.quote(container_path)}; exec {subject}"
     return f"setsid sh -c {shlex.quote(inner)}"
 

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import json
 import os
+import re
 import shlex
 import tempfile
 from pathlib import Path
@@ -115,18 +116,22 @@ async def _prepare_command(
     capture_stdout = request.get("captureStdout")
     if not isinstance(capture_stdout, bool):
         raise RuntimeError("invalid Maka Eval stdout policy")
+    for label, values in (("environment", public_environment), ("credential", credentials)):
+        if any(re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key) is None for key in values):
+            raise RuntimeError(f"invalid Maka Eval {label} name")
+
     container_path = f"/tmp/maka-eval-{token}.env"
-    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as secret:
-        secret_path = Path(secret.name)
-        os.chmod(secret_path, 0o600)
-        for key, value in {**public_environment, **credentials}.items():
-            if not key or not key.replace("_", "a").isalnum() or key[0].isdigit():
-                raise RuntimeError("invalid Maka Eval credential name")
-            secret.write(f"export {key}={shlex.quote(value)}\n")
+    secret_path = None
     try:
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as secret:
+            secret_path = Path(secret.name)
+            os.chmod(secret_path, 0o600)
+            for key, value in {**public_environment, **credentials}.items():
+                secret.write(f"export {key}={shlex.quote(value)}\n")
         await environment.upload_file(secret_path, container_path)
     finally:
-        secret_path.unlink(missing_ok=True)
+        if secret_path is not None:
+            secret_path.unlink(missing_ok=True)
     subject = shlex.join([request["command"], *request["args"]])
     if not capture_stdout:
         subject = f"{subject} >/dev/null"

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -1,10 +1,13 @@
 import asyncio
 import importlib
 import os
+import shlex
+import subprocess
 import sys
 import tempfile
 import types
 import unittest
+import uuid
 from pathlib import Path
 from unittest.mock import patch
 
@@ -15,11 +18,16 @@ class BaseAgent:
 
 
 class Environment:
-    def __init__(self):
+    def __init__(self, stage_upload: bool = False):
         self.uploaded = b""
+        self.uploaded_target = None
+        self.stage_upload = stage_upload
 
-    async def upload_file(self, source: Path, _target: str) -> None:
+    async def upload_file(self, source: Path, target: str) -> None:
         self.uploaded = source.read_bytes()
+        if self.stage_upload:
+            self.uploaded_target = Path(target)
+            self.uploaded_target.write_bytes(self.uploaded)
 
 
 def load_relay():
@@ -90,6 +98,39 @@ class RelayContractTest(unittest.TestCase):
                         )
                     )
             self.assertEqual(list(Path(directory).iterdir()), [])
+
+    def test_removes_credential_file_when_subject_overrides_path(self):
+        relay = load_relay()
+        environment = Environment(stage_upload=True)
+        token = f"contract-{uuid.uuid4().hex}"
+        with tempfile.TemporaryDirectory() as directory:
+            command = asyncio.run(
+                relay._prepare_command(
+                    environment,
+                    {
+                        "command": "/bin/sh",
+                        "args": ["-c", "exit 0"],
+                        "environment": {"PATH": "/definitely-missing"},
+                        "credentials": {"API_KEY": "canary-secret"},
+                        "captureStdout": True,
+                    },
+                    token,
+                    str(Path(directory) / "scope.pid"),
+                )
+            )
+            target = environment.uploaded_target
+            self.assertIsNotNone(target)
+            try:
+                completed = subprocess.run(
+                    ["/bin/sh", "-c", shlex.split(command)[-1]],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(completed.returncode, 0, completed.stderr)
+                self.assertFalse(target.exists())
+            finally:
+                target.unlink(missing_ok=True)
 
 
 if __name__ == "__main__":

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -1,0 +1,62 @@
+import asyncio
+import importlib
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+class BaseAgent:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+class Environment:
+    def __init__(self):
+        self.uploaded = b""
+
+    async def upload_file(self, source: Path, _target: str) -> None:
+        self.uploaded = source.read_bytes()
+
+
+def load_relay():
+    os.environ["MAKA_EVAL_FRAMEWORK"] = "harbor"
+    package = types.ModuleType("harbor")
+    agents = types.ModuleType("harbor.agents")
+    base = types.ModuleType("harbor.agents.base")
+    base.BaseAgent = BaseAgent
+    sys.modules["harbor"] = package
+    sys.modules["harbor.agents"] = agents
+    sys.modules["harbor.agents.base"] = base
+    sys.modules.pop("relay_agent", None)
+    return importlib.import_module("relay_agent")
+
+
+class RelayContractTest(unittest.TestCase):
+    def test_stages_environment_and_discards_unstructured_stdout(self):
+        relay = load_relay()
+        environment = Environment()
+        command = asyncio.run(
+            relay._prepare_command(
+                environment,
+                {
+                    "command": "/opt/agent",
+                    "args": ["run"],
+                    "environment": {"MODE": "offline"},
+                    "credentials": {"API_KEY": "canary-secret"},
+                    "captureStdout": False,
+                },
+                "token",
+                "/tmp/scope.pid",
+            )
+        )
+
+        self.assertIn(b"export MODE=offline", environment.uploaded)
+        self.assertIn(b"export API_KEY=canary-secret", environment.uploaded)
+        self.assertNotIn("canary-secret", command)
+        self.assertIn(">/dev/null", command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -2,9 +2,11 @@ import asyncio
 import importlib
 import os
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 class BaseAgent:
@@ -56,6 +58,38 @@ class RelayContractTest(unittest.TestCase):
         self.assertIn(b"export API_KEY=canary-secret", environment.uploaded)
         self.assertNotIn("canary-secret", command)
         self.assertIn(">/dev/null", command)
+
+    def test_leaves_no_credential_file_when_command_preparation_fails(self):
+        relay = load_relay()
+        environment = Environment()
+        named_temporary_file = tempfile.NamedTemporaryFile
+        with tempfile.TemporaryDirectory() as directory:
+            with patch.object(
+                relay.tempfile,
+                "NamedTemporaryFile",
+                side_effect=lambda *args, **kwargs: named_temporary_file(
+                    *args, dir=directory, **kwargs
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "invalid Maka Eval credential name"):
+                    asyncio.run(
+                        relay._prepare_command(
+                            environment,
+                            {
+                                "command": "/opt/agent",
+                                "args": ["run"],
+                                "environment": {"MODE": "offline"},
+                                "credentials": {
+                                    "API_KEY": "canary-secret",
+                                    "BAD-NAME": "ignored",
+                                },
+                                "captureStdout": False,
+                            },
+                            "token",
+                            "/tmp/scope.pid",
+                        )
+                    )
+            self.assertEqual(list(Path(directory).iterdir()), [])
 
 
 if __name__ == "__main__":

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -19,7 +19,7 @@
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test:dist": "node --test dist/external-subject.test.js && python3 harbor/test_relay_contract.py"
+    "test:dist": "node --test \"dist/**/*.test.js\" && python3 harbor/test_relay_contract.py"
   },
   "dependencies": {
     "@maka/runtime-host": "0.1.0"

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",
     "build": "tsc -p tsconfig.json",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test:dist": "node --test dist/external-subject.test.js && python3 harbor/test_relay_contract.py"
   },
   "dependencies": {
     "@maka/runtime-host": "0.1.0"

--- a/packages/eval/src/__tests__/external-subject.test.ts
+++ b/packages/eval/src/__tests__/external-subject.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { createExternalSubjectAdapter } from './external-subject.js';
-import type { ExperimentCell } from './experiment.js';
+import { createExternalSubjectAdapter } from '../external-subject.js';
+import type { ExperimentCell } from '../experiment.js';
 
 test('passes declared environment and credential bindings to one external command', async () => {
   const cell = externalCell({
@@ -29,7 +29,6 @@ test('passes declared environment and credential bindings to one external comman
   assert.deepEqual(request, {
     command: '/opt/pi/bin/pi',
     args: ['--print', 'solve the task'],
-    credentialNames: ['PROVIDER_KEY'],
     environment: { PI_OFFLINE: '1' },
     credentialEnvironment: { DEEPSEEK_API_KEY: 'PROVIDER_KEY' },
     captureStdout: false,
@@ -68,7 +67,7 @@ test('keeps protocol-v1 as the default result contract', async () => {
   assert.deepEqual(request, {
     command: '/opt/tool',
     args: [],
-    credentialNames: ['PROVIDER_KEY'],
+    credentialEnvironment: { PROVIDER_KEY: 'PROVIDER_KEY' },
   });
   assert.equal(result.status, 'completed');
 });
@@ -99,6 +98,20 @@ test('rejects overlap between public environment and credential targets', () => 
   assert.throws(
     () => createExternalSubjectAdapter().validate?.(cell),
     /environment and credentialEnvironment overlap at API_KEY/u,
+  );
+});
+
+test('rejects overlap with identity credential targets', () => {
+  const cell = externalCell({
+    command: '/opt/tool',
+    args: [],
+    environment: { PROVIDER_KEY: 'not-a-secret' },
+    result: 'exit-code',
+  });
+
+  assert.throws(
+    () => createExternalSubjectAdapter().validate?.(cell),
+    /environment and credentialEnvironment overlap at PROVIDER_KEY/u,
   );
 });
 

--- a/packages/eval/src/external-subject.test.ts
+++ b/packages/eval/src/external-subject.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createExternalSubjectAdapter } from './external-subject.js';
+import type { ExperimentCell } from './experiment.js';
+
+test('passes declared environment and credential bindings to one external command', async () => {
+  const cell = externalCell({
+    command: '/opt/pi/bin/pi',
+    args: ['--print', '{{task.input}}'],
+    environment: { PI_OFFLINE: '1' },
+    credentialEnvironment: { DEEPSEEK_API_KEY: 'PROVIDER_KEY' },
+    result: 'exit-code',
+  });
+  let request: unknown;
+
+  const result = await createExternalSubjectAdapter().execute({
+    cell,
+    context: {
+      cwd: '/app',
+      taskInput: 'solve the task',
+      metadata: {},
+      execute: async (input) => {
+        request = input;
+        return { termination: 'exited', exitCode: 0, stdout: '' };
+      },
+    },
+  });
+
+  assert.deepEqual(request, {
+    command: '/opt/pi/bin/pi',
+    args: ['--print', 'solve the task'],
+    credentialNames: ['PROVIDER_KEY'],
+    environment: { PI_OFFLINE: '1' },
+    credentialEnvironment: { DEEPSEEK_API_KEY: 'PROVIDER_KEY' },
+    captureStdout: false,
+  });
+  assert.equal(result.status, 'completed');
+  assert.equal(result.usage, null);
+  assert.equal(result.costUsd, null);
+});
+
+test('keeps protocol-v1 as the default result contract', async () => {
+  const cell = externalCell({ command: '/opt/tool', args: [] });
+  let request: unknown;
+
+  const result = await createExternalSubjectAdapter().execute({
+    cell,
+    context: {
+      cwd: '/app',
+      taskInput: 'solve the task',
+      metadata: {},
+      execute: async (input) => {
+        request = input;
+        return {
+          termination: 'exited',
+          exitCode: 0,
+          stdout: JSON.stringify({
+            schemaVersion: 'maka.external_subject_result.v1',
+            usage: null,
+            costUsd: null,
+            artifacts: [],
+          }),
+        };
+      },
+    },
+  });
+
+  assert.deepEqual(request, {
+    command: '/opt/tool',
+    args: [],
+    credentialNames: ['PROVIDER_KEY'],
+  });
+  assert.equal(result.status, 'completed');
+});
+
+test('rejects credential bindings that the subject did not declare', () => {
+  const cell = externalCell({
+    command: '/opt/tool',
+    args: [],
+    credentialEnvironment: { DEEPSEEK_API_KEY: 'UNDECLARED_KEY' },
+    result: 'exit-code',
+  });
+
+  assert.throws(
+    () => createExternalSubjectAdapter().validate?.(cell),
+    /credentialEnvironment\.DEEPSEEK_API_KEY must reference a declared credential/u,
+  );
+});
+
+test('rejects overlap between public environment and credential targets', () => {
+  const cell = externalCell({
+    command: '/opt/tool',
+    args: [],
+    environment: { API_KEY: 'not-a-secret' },
+    credentialEnvironment: { API_KEY: 'PROVIDER_KEY' },
+    result: 'exit-code',
+  });
+
+  assert.throws(
+    () => createExternalSubjectAdapter().validate?.(cell),
+    /environment and credentialEnvironment overlap at API_KEY/u,
+  );
+});
+
+function externalCell(config: ExperimentCell['subject']['config']): ExperimentCell {
+  return {
+    id: 'task::1::external',
+    experimentId: 'experiment',
+    benchmark: { id: 'benchmark', version: '1', config: {} },
+    executor: { kind: 'harbor', config: {} },
+    subject: {
+      id: 'external',
+      kind: 'external',
+      credentials: ['PROVIDER_KEY'],
+      config,
+    },
+    task: { id: 'task', input: 'instruction', config: {} },
+    repetition: 1,
+    budget: { maxSteps: 100 },
+    verifier: {},
+  };
+}

--- a/packages/eval/src/external-subject.ts
+++ b/packages/eval/src/external-subject.ts
@@ -17,13 +17,10 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
               .replaceAll('{{task.input}}', context.taskInput)
               .replaceAll('{{task.id}}', cell.task.id),
           ),
-          credentialNames: cell.subject.credentials,
+          credentialEnvironment: config.credentialEnvironment,
           ...(Object.keys(config.environment).length === 0
             ? {}
             : { environment: config.environment }),
-          ...(Object.keys(config.credentialEnvironment).length === 0
-            ? {}
-            : { credentialEnvironment: config.credentialEnvironment }),
           ...(config.result === 'exit-code' ? { captureStdout: false } : {}),
         });
         if (execution.termination === 'cancelled') {
@@ -116,7 +113,9 @@ function decodeConfig(
     throw new Error('external subject args are invalid');
   }
   const environment = stringMap(config.environment, 'environment');
-  const credentialEnvironment = stringMap(config.credentialEnvironment, 'credentialEnvironment');
+  const credentialEnvironment = Object.hasOwn(config, 'credentialEnvironment')
+    ? stringMap(config.credentialEnvironment, 'credentialEnvironment')
+    : Object.freeze(Object.fromEntries(declaredCredentials.map((name) => [name, name])));
   for (const [target, source] of Object.entries(credentialEnvironment)) {
     if (!declaredCredentials.includes(source)) {
       throw new Error(`credentialEnvironment.${target} must reference a declared credential`);

--- a/packages/eval/src/external-subject.ts
+++ b/packages/eval/src/external-subject.ts
@@ -5,9 +5,9 @@ import type { SubjectAdapter } from './runner.js';
 export function createExternalSubjectAdapter(): SubjectAdapter {
   return {
     kind: 'external',
-    validate: (cell) => decodeConfig(cell.subject.config),
+    validate: (cell) => decodeConfig(cell.subject.config, cell.subject.credentials),
     async execute({ cell, context }) {
-      const config = decodeConfig(cell.subject.config);
+      const config = decodeConfig(cell.subject.config, cell.subject.credentials);
       const startedAt = Date.now();
       try {
         const execution = await context.execute({
@@ -18,6 +18,13 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
               .replaceAll('{{task.id}}', cell.task.id),
           ),
           credentialNames: cell.subject.credentials,
+          ...(Object.keys(config.environment).length === 0
+            ? {}
+            : { environment: config.environment }),
+          ...(Object.keys(config.credentialEnvironment).length === 0
+            ? {}
+            : { credentialEnvironment: config.credentialEnvironment }),
+          ...(config.result === 'exit-code' ? { captureStdout: false } : {}),
         });
         if (execution.termination === 'cancelled') {
           return {
@@ -49,6 +56,16 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
             artifacts: [{ kind: 'external_process', exitCode: execution.exitCode }],
           };
         }
+        if (config.result === 'exit-code') {
+          return {
+            usage: null,
+            costUsd: null,
+            durationMs: Date.now() - startedAt,
+            status: 'completed' as const,
+            failureReason: null,
+            artifacts: [{ kind: 'external_process', exitCode: execution.exitCode }],
+          };
+        }
         const result = decodeResult(execution.stdout);
         return {
           ...(result.output === undefined ? {} : { output: result.output }),
@@ -75,15 +92,64 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
   };
 }
 
-function decodeConfig(value: JsonObject): { command: string; args: readonly string[] } {
-  const config = exact(value, ['command', 'args'], 'external subject config');
+interface ExternalSubjectConfig {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly environment: Readonly<Record<string, string>>;
+  readonly credentialEnvironment: Readonly<Record<string, string>>;
+  readonly result: 'protocol-v1' | 'exit-code';
+}
+
+function decodeConfig(
+  value: JsonObject,
+  declaredCredentials: readonly string[],
+): ExternalSubjectConfig {
+  const fields = ['command', 'args'];
+  for (const optional of ['environment', 'credentialEnvironment', 'result']) {
+    if (Object.hasOwn(value, optional)) fields.push(optional);
+  }
+  const config = exact(value, fields, 'external subject config');
   if (
     !Array.isArray(config.args) ||
     !config.args.every((argument) => typeof argument === 'string')
   ) {
     throw new Error('external subject args are invalid');
   }
-  return { command: text(config.command, 'external subject command'), args: config.args };
+  const environment = stringMap(config.environment, 'environment');
+  const credentialEnvironment = stringMap(config.credentialEnvironment, 'credentialEnvironment');
+  for (const [target, source] of Object.entries(credentialEnvironment)) {
+    if (!declaredCredentials.includes(source)) {
+      throw new Error(`credentialEnvironment.${target} must reference a declared credential`);
+    }
+    if (Object.hasOwn(environment, target)) {
+      throw new Error(`environment and credentialEnvironment overlap at ${target}`);
+    }
+  }
+  const result = config.result ?? 'protocol-v1';
+  if (result !== 'protocol-v1' && result !== 'exit-code') {
+    throw new Error('external subject result is invalid');
+  }
+  return {
+    command: text(config.command, 'external subject command'),
+    args: config.args,
+    environment,
+    credentialEnvironment,
+    result,
+  };
+}
+
+function stringMap(value: unknown, where: string): Readonly<Record<string, string>> {
+  if (value === undefined) return Object.freeze({});
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${where} must be an object`);
+  }
+  const entries = Object.entries(value);
+  for (const [name, item] of entries) {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/u.test(name) || typeof item !== 'string') {
+      throw new Error(`${where}.${name} is invalid`);
+    }
+  }
+  return Object.freeze(Object.fromEntries(entries));
 }
 
 function decodeResult(stdout: string): {

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -152,11 +152,8 @@ function relayContext(
     execute: async (input) => {
       if (state.used) throw new Error('Trial already executed its subject');
       state.used = true;
-      const credentialEnvironment =
-        input.credentialEnvironment ??
-        Object.fromEntries(input.credentialNames.map((name) => [name, name]));
       const credentials = Object.fromEntries(
-        Object.entries(credentialEnvironment).map(([target, source]) => {
+        Object.entries(input.credentialEnvironment).map(([target, source]) => {
           const value = state.credentials[source];
           if (value === undefined) throw new Error(`credential ${source} was not admitted`);
           return [target, value];

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -152,11 +152,14 @@ function relayContext(
     execute: async (input) => {
       if (state.used) throw new Error('Trial already executed its subject');
       state.used = true;
+      const credentialEnvironment =
+        input.credentialEnvironment ??
+        Object.fromEntries(input.credentialNames.map((name) => [name, name]));
       const credentials = Object.fromEntries(
-        input.credentialNames.map((name) => {
-          const value = state.credentials[name];
-          if (value === undefined) throw new Error(`credential ${name} was not admitted`);
-          return [name, value];
+        Object.entries(credentialEnvironment).map(([target, source]) => {
+          const value = state.credentials[source];
+          if (value === undefined) throw new Error(`credential ${source} was not admitted`);
+          return [target, value];
         }),
       );
       state.socket.write(
@@ -166,7 +169,9 @@ function relayContext(
           command: input.command,
           args: input.args,
           cwd: state.containerCwd,
+          environment: input.environment ?? {},
           credentials,
+          captureStdout: input.captureStdout ?? true,
           ...(input.cancel ? { cancel: input.cancel } : {}),
         })}\n`,
       );

--- a/packages/eval/src/maka-subject.ts
+++ b/packages/eval/src/maka-subject.ts
@@ -41,7 +41,9 @@ export function createMakaSubjectAdapter(): SubjectAdapter {
         process = await context.execute({
           command: config.nodePath,
           args: [config.shimPath, payload],
-          credentialNames: cell.subject.credentials,
+          credentialEnvironment: Object.fromEntries(
+            cell.subject.credentials.map((name) => [name, name]),
+          ),
         });
       } catch {
         return subjectFailure('relay-execute', startedAt, context.signal);

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -31,6 +31,9 @@ export interface SubjectExecutionContext {
     readonly command: string;
     readonly args: readonly string[];
     readonly credentialNames: readonly string[];
+    readonly environment?: Readonly<Record<string, string>>;
+    readonly credentialEnvironment?: Readonly<Record<string, string>>;
+    readonly captureStdout?: boolean;
     readonly cancel?: { readonly command: string; readonly args: readonly string[] };
   }) => Promise<{
     readonly termination: 'exited' | 'framework_timeout' | 'cancelled';

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -30,9 +30,8 @@ export interface SubjectExecutionContext {
   readonly execute: (input: {
     readonly command: string;
     readonly args: readonly string[];
-    readonly credentialNames: readonly string[];
     readonly environment?: Readonly<Record<string, string>>;
-    readonly credentialEnvironment?: Readonly<Record<string, string>>;
+    readonly credentialEnvironment: Readonly<Record<string, string>>;
     readonly captureStdout?: boolean;
     readonly cancel?: { readonly command: string; readonly args: readonly string[] };
   }) => Promise<{


### PR DESCRIPTION
## Summary

Extend the existing external SubjectAdapter and shared Harbor/Pier relay with three provider-independent capabilities: declared public environment values, credential-name bindings, and an exit-code result mode that discards unstructured stdout.

This keeps provider configuration in frozen experiment data and invokes each CLI directly. Eval contains no Codex, Claude Code, Pi, Reasonix, OpenCode, Kimi, or ZCode branches; no metering proxy, provider pricing, trajectory collection, wrapper state, or second result protocol is introduced. The existing `maka.external_subject_result.v1` path remains the default for compatibility.

The eight-arm experiment remains in #2893.

## Verification

- `npm --workspace @maka/eval run build`
- `npm --workspace @maka/eval run test:dist`
- `npm --workspace @maka/eval run typecheck`
- Focused Biome check for the affected TypeScript and package files
- Python bytecode compilation for the relay and its focused contract test
- `git diff --check`

The TypeScript contract tests cover config parsing, credential admission, environment collision rejection, the exit-code result path, and v1 compatibility. The Python contract test proves that public environment and admitted credentials are staged without putting credential values on the command line, and that exit-code subjects do not relay unstructured stdout. These are the minimum new boundary tests; the private Eval harness suites removed by #2728 are not restored.

Full repository tests and full evaluation were not run.

## Security and review focus

- Experiment data may contain public environment values only; credential values remain outside the spec and are selected by declared credential names.
- Credential bindings must reference credentials declared by the subject and cannot overlap public environment targets.
- Exit-code subjects discard stdout inside the task environment instead of relaying or persisting complete CLI output.
- The production diff contains no provider-specific implementation.

## AI assistance and provenance

Codex designed and implemented the generic seam, tests, scoped validation, and PR rewrite. The implementation commit records `Generated-by: Codex`; the human contributor remains responsible for final review and submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
