### PR TITLE
feat(runtime-host): admit bootstrapped DeepSeek targets

### DIFF
--- a/packages/runtime-host/src/__tests__/bootstrap-runtime-policy.test.ts
+++ b/packages/runtime-host/src/__tests__/bootstrap-runtime-policy.test.ts
@@ -83,6 +83,29 @@ test('bootstrap resumes after interruption and prefers the supported environment
   });
 });
 
+test('bootstrap preserves DeepSeek provider semantics for a DeepSeek environment key', async () => {
+  await withFixture(async ({ root, stores }) => {
+    await ensureBootstrapRuntimePolicy({
+      workspaceRoot: root,
+      stores,
+      environment: {
+        DEEPSEEK_API_KEY: 'deepseek-secret',
+        DEEPSEEK_BASE_URL: 'https://deepseek.example/v1',
+      },
+    });
+
+    const catalog = await stores.connectionCatalog.getSnapshot();
+    const deepseek = catalog.connections.find(({ slug }) => slug === 'env-deepseek');
+    assert.equal(deepseek?.providerType, 'deepseek');
+    assert.equal(deepseek?.baseUrl, 'https://deepseek.example/v1');
+    assert.deepEqual(deepseek?.enabledModelIds, ['deepseek-v4-flash']);
+    assert.deepEqual(catalog.defaultTarget, {
+      connectionId: deepseek?.connectionId,
+      modelId: 'deepseek-v4-flash',
+    });
+  });
+});
+
 test('bootstrap does not alter an existing user catalog', async () => {
   await withFixture(async ({ root, stores }) => {
     const created = await stores.connectionCatalog.create({

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -140,7 +140,7 @@ test('backend creation aborts a stalled pricing snapshot read', async () => {
   });
 });
 
-test('backend creation admits an enabled statically known model before discovery', async () => {
+test('backend creation admits the enabled bootstrap DeepSeek model before discovery', async () => {
   const modelId = 'deepseek-v4-flash';
   const backend = await createHostAiSdkBackend(
     backendCreationFixture({
@@ -162,6 +162,56 @@ test('backend creation admits an enabled statically known model before discovery
   );
 
   await backend.dispose();
+});
+
+test('backend creation does not bypass a non-empty DeepSeek inventory', async () => {
+  const modelId = 'deepseek-v4-flash';
+  await assert.rejects(
+    createHostAiSdkBackend(
+      backendCreationFixture({
+        abortSignal: new AbortController().signal,
+        modelId,
+        resolveExecutionConnection: async () => ({
+          kind: 'ready',
+          connection: {
+            slug: 'backend-creation-connection',
+            providerType: 'deepseek',
+            enabledModelIds: [modelId],
+            models: [{ id: 'deepseek-chat' }],
+          },
+          networkProxy: { enabled: false },
+          secretMaterial: { connection: { secret: API_KEY } },
+        }),
+        readPricing: async () => ({ revision: 0, overrides: [] }),
+      }),
+    ),
+    /Session model is not enabled/,
+  );
+});
+
+test('backend creation does not treat aliased provider metadata as inventory', async () => {
+  const modelId = 'claude-opus-5';
+  await assert.rejects(
+    createHostAiSdkBackend(
+      backendCreationFixture({
+        abortSignal: new AbortController().signal,
+        modelId,
+        resolveExecutionConnection: async () => ({
+          kind: 'ready',
+          connection: {
+            slug: 'backend-creation-connection',
+            providerType: 'opencode-free',
+            enabledModelIds: [modelId],
+            models: [],
+          },
+          networkProxy: { enabled: false },
+          secretMaterial: {},
+        }),
+        readPricing: async () => ({ revision: 0, overrides: [] }),
+      }),
+    ),
+    /Session model is not enabled/,
+  );
 });
 
 test('provider dispatch fails closed when the Run Composition commit fails', async () => {

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -140,6 +140,30 @@ test('backend creation aborts a stalled pricing snapshot read', async () => {
   });
 });
 
+test('backend creation admits an enabled statically known model before discovery', async () => {
+  const modelId = 'deepseek-v4-flash';
+  const backend = await createHostAiSdkBackend(
+    backendCreationFixture({
+      abortSignal: new AbortController().signal,
+      modelId,
+      resolveExecutionConnection: async () => ({
+        kind: 'ready',
+        connection: {
+          slug: 'backend-creation-connection',
+          providerType: 'deepseek',
+          enabledModelIds: [modelId],
+          models: [],
+        },
+        networkProxy: { enabled: false },
+        secretMaterial: { connection: { secret: API_KEY } },
+      }),
+      readPricing: async () => ({ revision: 0, overrides: [] }),
+    }),
+  );
+
+  await backend.dispose();
+});
+
 test('provider dispatch fails closed when the Run Composition commit fails', async () => {
   const provider = await startProvider();
   let commits = 0;

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -283,7 +283,7 @@ test('creation on a relay connection honours declared levels via the catalog pro
   assert.equal(persistedThinkingLevel, 'low');
 });
 
-test('creation admits an enabled statically known model before discovery', async () => {
+test('creation admits the enabled bootstrap DeepSeek model before discovery', async () => {
   const modelId = 'deepseek-v4-flash';
   let createAttempts = 0;
   const fixture = createFixture({
@@ -317,6 +317,39 @@ test('creation admits an enabled statically known model before discovery', async
 
   assert.equal(outcome.ok, true);
   assert.equal(createAttempts, 1);
+});
+
+test('creation does not bypass a non-empty DeepSeek inventory', async () => {
+  const modelId = 'deepseek-v4-flash';
+  let createAttempts = 0;
+  const fixture = createFixture({
+    connection: {
+      providerType: 'deepseek',
+      enabledModelIds: [modelId],
+      models: [{ id: 'deepseek-chat' }],
+    },
+    stores: {
+      createStableSession: async () => {
+        createAttempts += 1;
+        assert.fail('A model missing from a non-empty inventory must not be persisted');
+      },
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.create'](
+    {
+      sessionId: fixture.sessionId,
+      workspace: { kind: 'host_path', path: process.cwd() },
+      modelTarget: { kind: 'explicit', connectionSlug: 'test', model: modelId },
+    },
+    context,
+  );
+
+  assert.deepEqual(outcome, {
+    ok: false,
+    error: { code: 'invalid_request', message: 'Session model is not enabled' },
+  });
+  assert.equal(createAttempts, 0);
 });
 
 test('creation on a relay connection without declarations still fails closed on any thinkingLevel', async () => {

--- a/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-coordinator.test.ts
@@ -283,6 +283,42 @@ test('creation on a relay connection honours declared levels via the catalog pro
   assert.equal(persistedThinkingLevel, 'low');
 });
 
+test('creation admits an enabled statically known model before discovery', async () => {
+  const modelId = 'deepseek-v4-flash';
+  let createAttempts = 0;
+  const fixture = createFixture({
+    connection: {
+      providerType: 'deepseek',
+      enabledModelIds: [modelId],
+      models: [],
+    },
+    stores: {
+      createStableSession: async (args) => {
+        createAttempts += 1;
+        return {
+          kind: 'existing' as const,
+          record: headerSnapshot(
+            { ...sessionHeader(args.sessionId, ['user-label']), model: modelId },
+            1,
+          ),
+        };
+      },
+    },
+  });
+
+  const outcome = await fixture.coordinator.handlers['session.create'](
+    {
+      sessionId: fixture.sessionId,
+      workspace: { kind: 'host_path', path: process.cwd() },
+      modelTarget: { kind: 'explicit', connectionSlug: 'test', model: modelId },
+    },
+    context,
+  );
+
+  assert.equal(outcome.ok, true);
+  assert.equal(createAttempts, 1);
+});
+
 test('creation on a relay connection without declarations still fails closed on any thinkingLevel', async () => {
   // Undeclared relay models resolve no variants — accepting an unverifiable
   // level would be worse than rejecting it, because the wire could never
@@ -827,7 +863,7 @@ function createFixture(
 }
 
 type FixtureConnection = {
-  readonly providerType?: 'openai' | 'openai-compatible';
+  readonly providerType?: 'deepseek' | 'openai' | 'openai-compatible';
   readonly enabledModelIds?: readonly string[];
   readonly models?: readonly { id: string }[];
   readonly relayModelProfiles?: Readonly<Record<string, RelayModelProfile>>;

--- a/packages/runtime-host/src/server/bootstrap-runtime-policy.ts
+++ b/packages/runtime-host/src/server/bootstrap-runtime-policy.ts
@@ -12,6 +12,8 @@ import type { RuntimePolicyStoresWriter } from '@maka/storage/runtime-policy-sto
 const JOURNAL_FILE = '.runtime-host-bootstrap.json';
 interface BootstrapEnvironment {
   readonly ANTHROPIC_API_KEY?: string;
+  readonly DEEPSEEK_API_KEY?: string;
+  readonly DEEPSEEK_BASE_URL?: string;
   readonly OPENAI_API_KEY?: string;
 }
 
@@ -20,6 +22,7 @@ interface BootstrapSeed {
   readonly name: string;
   readonly providerType: ProviderType;
   readonly enabledModelIds: readonly string[];
+  readonly baseUrl?: string;
   readonly secret?: string;
 }
 
@@ -78,9 +81,19 @@ function bootstrapSeeds(environment: BootstrapEnvironment): readonly BootstrapSe
       enabledModelIds: OPENCODE_FREE_DEFAULT_ENABLED_MODELS,
     },
   ];
+  const deepseek = environment.DEEPSEEK_API_KEY?.trim();
   const anthropic = environment.ANTHROPIC_API_KEY?.trim();
   const openai = environment.OPENAI_API_KEY?.trim();
-  if (anthropic) {
+  if (deepseek) {
+    seeds.push({
+      slug: 'env-deepseek',
+      name: 'DeepSeek (env)',
+      providerType: 'deepseek',
+      enabledModelIds: ['deepseek-v4-flash'],
+      baseUrl: environment.DEEPSEEK_BASE_URL?.trim() || 'https://api.deepseek.com',
+      secret: deepseek,
+    });
+  } else if (anthropic) {
     seeds.push({
       slug: 'env-anthropic',
       name: 'Anthropic (env)',
@@ -119,6 +132,7 @@ async function ensureConnection(
         slug: seed.slug,
         name: seed.name,
         providerType: seed.providerType,
+        ...(seed.baseUrl === undefined ? {} : { baseUrl: seed.baseUrl }),
         enabled: true,
         enabledModelIds: seed.enabledModelIds,
       },

--- a/packages/runtime-host/src/server/connection-model-admission.ts
+++ b/packages/runtime-host/src/server/connection-model-admission.ts
@@ -1,0 +1,25 @@
+import type { ModelInfo, ProviderType } from '@maka/core/llm-connections';
+
+interface ConnectionModelAdmissionInput {
+  readonly providerType: ProviderType;
+  readonly enabledModelIds: readonly string[];
+  readonly models: readonly ModelInfo[];
+}
+
+/** Resolves one executable model without treating provider metadata as connection inventory. */
+export function resolveAdmittedConnectionModel(
+  connection: ConnectionModelAdmissionInput,
+  modelId: string,
+): ModelInfo | undefined {
+  if (!connection.enabledModelIds.includes(modelId)) return undefined;
+  const discovered = connection.models.find(({ id }) => id === modelId);
+  if (discovered) return discovered;
+  if (
+    connection.models.length === 0 &&
+    connection.providerType === 'deepseek' &&
+    modelId === 'deepseek-v4-flash'
+  ) {
+    return { id: modelId };
+  }
+  return undefined;
+}

--- a/packages/runtime-host/src/server/execution-model-authority.ts
+++ b/packages/runtime-host/src/server/execution-model-authority.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { PROVIDER_DEFAULTS, type RuntimeExecutionConnection } from '@maka/core/llm-connections';
 import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
-import { modelMetadataIdsForProvider } from '@maka/core/model-metadata';
 import { parseRequestHeaders, type RuntimePolicy } from '@maka/core/runtime-policy';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { SessionHeader } from '@maka/core/session';
@@ -43,6 +42,7 @@ import {
   type HostOAuthExecutionBinding,
 } from './oauth-execution-authority.js';
 import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
+import { resolveAdmittedConnectionModel } from './connection-model-admission.js';
 
 export interface HostGoalEvaluatorInput {
   readonly runtimePolicy: RuntimePolicyStoresWriter;
@@ -776,20 +776,13 @@ export async function resolveExecutionTarget(
     throw new AuxiliaryModelCallConfigurationError('Runtime Host model provider is not executable');
   }
   const model = header.model.trim();
-  const discovered = resolved.connection.models.find((candidate) => candidate.id === model);
-  const staticallyKnown = modelMetadataIdsForProvider(resolved.connection.providerType).includes(
-    model,
-  );
-  if (
-    !model ||
-    !resolved.connection.enabledModelIds.includes(model) ||
-    (!discovered && !staticallyKnown)
-  ) {
+  const discovered = resolved.connection.models.some((candidate) => candidate.id === model);
+  const modelInfo = resolveAdmittedConnectionModel(resolved.connection, model);
+  if (!model || !modelInfo) {
     throw new AuxiliaryModelCallConfigurationError(
       'Runtime Host Session model is not enabled by its canonical connection',
     );
   }
-  const modelInfo = discovered ?? { id: model };
   if (isModelExplicitlyUnsupportedForChat(modelInfo)) {
     throw new AuxiliaryModelCallConfigurationError(
       'Runtime Host Session model is not chat-capable',

--- a/packages/runtime-host/src/server/execution-model-authority.ts
+++ b/packages/runtime-host/src/server/execution-model-authority.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { PROVIDER_DEFAULTS, type RuntimeExecutionConnection } from '@maka/core/llm-connections';
 import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
+import { modelMetadataIdsForProvider } from '@maka/core/model-metadata';
 import { parseRequestHeaders, type RuntimePolicy } from '@maka/core/runtime-policy';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { SessionHeader } from '@maka/core/session';
@@ -775,12 +776,20 @@ export async function resolveExecutionTarget(
     throw new AuxiliaryModelCallConfigurationError('Runtime Host model provider is not executable');
   }
   const model = header.model.trim();
-  const modelInfo = resolved.connection.models.find((candidate) => candidate.id === model);
-  if (!model || !resolved.connection.enabledModelIds.includes(model) || !modelInfo) {
+  const discovered = resolved.connection.models.find((candidate) => candidate.id === model);
+  const staticallyKnown = modelMetadataIdsForProvider(resolved.connection.providerType).includes(
+    model,
+  );
+  if (
+    !model ||
+    !resolved.connection.enabledModelIds.includes(model) ||
+    (!discovered && !staticallyKnown)
+  ) {
     throw new AuxiliaryModelCallConfigurationError(
       'Runtime Host Session model is not enabled by its canonical connection',
     );
   }
+  const modelInfo = discovered ?? { id: model };
   if (isModelExplicitlyUnsupportedForChat(modelInfo)) {
     throw new AuxiliaryModelCallConfigurationError(
       'Runtime Host Session model is not chat-capable',
@@ -794,7 +803,9 @@ export async function resolveExecutionTarget(
     providerType: resolved.connection.providerType,
     ...(resolved.connection.baseUrl ? { baseUrl: resolved.connection.baseUrl } : {}),
     defaultModel: model,
-    models: [...resolved.connection.models],
+    models: discovered
+      ? [...resolved.connection.models]
+      : [...resolved.connection.models, modelInfo],
     ...(resolved.connection.relayModelProfiles === undefined
       ? {}
       : { relayModelProfiles: resolved.connection.relayModelProfiles }),

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto';
 import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
-import { modelMetadataIdsForProvider } from '@maka/core/model-metadata';
 import { thinkingVariantsForConnection } from '@maka/core/model-thinking';
 import {
   executionBoundaryDisplayMode,
@@ -56,6 +55,7 @@ import {
 } from '../protocol/index.js';
 import type { SessionCatalogOperationHandlerMap } from './operation-dispatcher.js';
 import { type SessionAdmissionLease, SessionAdmissionGate } from './session-admission-gate.js';
+import { resolveAdmittedConnectionModel } from './connection-model-admission.js';
 import type { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
 import { type HostWorkspaceResolver, WorkspaceResolutionError } from './workspace-resolver.js';
 
@@ -599,17 +599,10 @@ export class HostSessionCatalogCoordinator {
       );
     }
     const connection = readiness.connection;
-    const discovered = connection.models.find((candidate) => candidate.id === selected.modelId);
-    const staticallyKnown = modelMetadataIdsForProvider(connection.providerType).includes(
-      selected.modelId,
-    );
-    if (
-      !connection.enabledModelIds.includes(selected.modelId) ||
-      (!discovered && !staticallyKnown)
-    ) {
+    const model = resolveAdmittedConnectionModel(connection, selected.modelId);
+    if (!model) {
       throw new SessionOperationFailure('invalid_request', 'Session model is not enabled');
     }
-    const model = discovered ?? { id: selected.modelId };
     if (isModelExplicitlyUnsupportedForChat(model)) {
       throw new SessionOperationFailure('invalid_request', 'Session model is not chat-capable');
     }

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
+import { modelMetadataIdsForProvider } from '@maka/core/model-metadata';
 import { thinkingVariantsForConnection } from '@maka/core/model-thinking';
 import {
   executionBoundaryDisplayMode,
@@ -598,10 +599,17 @@ export class HostSessionCatalogCoordinator {
       );
     }
     const connection = readiness.connection;
-    const model = connection.models.find((candidate) => candidate.id === selected.modelId);
-    if (!connection.enabledModelIds.includes(selected.modelId) || !model) {
+    const discovered = connection.models.find((candidate) => candidate.id === selected.modelId);
+    const staticallyKnown = modelMetadataIdsForProvider(connection.providerType).includes(
+      selected.modelId,
+    );
+    if (
+      !connection.enabledModelIds.includes(selected.modelId) ||
+      (!discovered && !staticallyKnown)
+    ) {
       throw new SessionOperationFailure('invalid_request', 'Session model is not enabled');
     }
+    const model = discovered ?? { id: selected.modelId };
     if (isModelExplicitlyUnsupportedForChat(model)) {
       throw new SessionOperationFailure('invalid_request', 'Session model is not chat-capable');
     }


### PR DESCRIPTION
## Summary

- bootstrap a canonical `env-deepseek` connection from `DEEPSEEK_API_KEY`, preserving the optional `DEEPSEEK_BASE_URL`
- admit only the explicitly enabled `deepseek / deepseek-v4-flash` bootstrap target while its connection inventory is still empty
- share the same narrow admission rule between Session creation and execution; non-empty inventories, unknown models, disabled models, and aliased providers remain fail-closed

This extracts the reusable Runtime prerequisite previously embedded in the comparison work. It contains no Eval cohort or framework-specific execution path.

## Verification

- RED before the initial implementation: bootstrap, Session admission, and execution admission rejected the required DeepSeek bootstrap target
- RED before the review fix: a non-empty DeepSeek inventory and `opencode-free` alias metadata both bypassed connection inventory
- `npm --workspace @maka/runtime-host run build`
- focused bootstrap test (1 passed)
- focused Session/execution admission tests covering the positive bootstrap target and fail-closed inventory/alias boundaries (5 passed)
- `npm --workspace @maka/runtime-host run typecheck`
- focused Biome check on the six affected files
- `git diff --check`

No full evaluation was run.

## Review focus

- the exception requires all four facts: enabled model, empty inventory, native `deepseek` provider, exact `deepseek-v4-flash` model
- once an inventory is non-empty, it remains authoritative even if provider metadata knows the missing model
- provider metadata and aliases are not treated as executable connection inventory
- existing user catalogs remain untouched, and no credential values are logged or committed

## AI assistance and provenance

The original product-code source is recorded in the first commit. Codex authored the scoped review fix and tests under human direction; material commits include `Generated-by: Codex`. The human contributor remains responsible for final review and submission.

## Checklist

- [x] Tests cover the changes and fail without them
- [x] Format, typecheck, build, and focused tests pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
