### PR TITLE
fix(ui): keep steering messages in conversation order

### DIFF
--- a/packages/ui/src/__tests__/chat-turn-steering-order.test.ts
+++ b/packages/ui/src/__tests__/chat-turn-steering-order.test.ts
@@ -12,9 +12,6 @@ test('renders steering where it arrived in the assistant timeline', () => {
     status: 'completed',
     partialOutputRetained: false,
     user: { id: 'original', role: 'user', text: 'original request', ts: 1 },
-    userInterjections: [
-      { id: 'steer-1', role: 'user', text: 'inserted instruction', ts: 3 },
-    ],
     tools: [],
     notes: [],
     startedAt: 1,

--- a/packages/ui/src/__tests__/chat-turn-steering-order.test.ts
+++ b/packages/ui/src/__tests__/chat-turn-steering-order.test.ts
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { TurnView } from '../chat-turn.js';
+import { LocaleProvider } from '../locale-context.js';
+import type { TurnViewModel } from '../materialize.js';
+
+test('renders steering where it arrived in the assistant timeline', () => {
+  const turn: TurnViewModel = {
+    turnId: 'turn-1',
+    status: 'completed',
+    partialOutputRetained: false,
+    user: { id: 'original', role: 'user', text: 'original request', ts: 1 },
+    userInterjections: [
+      { id: 'steer-1', role: 'user', text: 'inserted instruction', ts: 3 },
+    ],
+    tools: [],
+    notes: [],
+    startedAt: 1,
+    timeline: [
+      {
+        kind: 'text',
+        text: 'output visible before steering',
+        messageId: 'before-steer',
+        ts: 2,
+      },
+      {
+        kind: 'user',
+        message: { id: 'steer-1', role: 'user', text: 'inserted instruction', ts: 3 },
+        messageId: 'steer-1',
+      },
+      {
+        kind: 'text',
+        text: 'output visible after steering',
+        messageId: 'after-steer',
+        ts: 4,
+      },
+    ],
+  };
+
+  const markup = renderToStaticMarkup(
+    createElement(LocaleProvider, {
+      locale: 'en',
+      children: createElement(TurnView, { turn }),
+    }),
+  );
+  const before = markup.indexOf('output visible before steering');
+  const steering = markup.indexOf('inserted instruction');
+  const after = markup.indexOf('output visible after steering');
+
+  assert.notEqual(before, -1);
+  assert.notEqual(steering, -1);
+  assert.notEqual(after, -1);
+  assert.equal(before < steering && steering < after, true);
+});

--- a/packages/ui/src/__tests__/chat-turn-steering-order.test.ts
+++ b/packages/ui/src/__tests__/chat-turn-steering-order.test.ts
@@ -9,7 +9,7 @@ import type { TurnViewModel } from '../materialize.js';
 test('renders steering where it arrived in the assistant timeline', () => {
   const turn: TurnViewModel = {
     turnId: 'turn-1',
-    status: 'completed',
+    status: 'failed',
     partialOutputRetained: false,
     user: { id: 'original', role: 'user', text: 'original request', ts: 1 },
     tools: [],
@@ -39,7 +39,7 @@ test('renders steering where it arrived in the assistant timeline', () => {
   const markup = renderToStaticMarkup(
     createElement(LocaleProvider, {
       locale: 'en',
-      children: createElement(TurnView, { turn }),
+      children: createElement(TurnView, { turn, failedReasonLabel: 'failure detail' }),
     }),
   );
   const before = markup.indexOf('output visible before steering');
@@ -50,4 +50,12 @@ test('renders steering where it arrived in the assistant timeline', () => {
   assert.notEqual(steering, -1);
   assert.notEqual(after, -1);
   assert.equal(before < steering && steering < after, true);
+  for (const text of [
+    'output visible before steering',
+    'inserted instruction',
+    'output visible after steering',
+    'failure detail',
+  ]) {
+    assert.equal(markup.split(text).length - 1, 1, `${text} should render exactly once`);
+  }
 });

--- a/packages/ui/src/__tests__/chat-turn-steering-order.test.ts
+++ b/packages/ui/src/__tests__/chat-turn-steering-order.test.ts
@@ -16,23 +16,13 @@ test('renders steering where it arrived in the assistant timeline', () => {
     notes: [],
     startedAt: 1,
     timeline: [
-      {
-        kind: 'text',
-        text: 'output visible before steering',
-        messageId: 'before-steer',
-        ts: 2,
-      },
+      { kind: 'text', text: 'output visible before steering', messageId: 'before-steer', ts: 2 },
       {
         kind: 'user',
         message: { id: 'steer-1', role: 'user', text: 'inserted instruction', ts: 3 },
         messageId: 'steer-1',
       },
-      {
-        kind: 'text',
-        text: 'output visible after steering',
-        messageId: 'after-steer',
-        ts: 4,
-      },
+      { kind: 'text', text: 'output visible after steering', messageId: 'after-steer', ts: 4 },
     ],
   };
 
@@ -42,20 +32,14 @@ test('renders steering where it arrived in the assistant timeline', () => {
       children: createElement(TurnView, { turn, failedReasonLabel: 'failure detail' }),
     }),
   );
-  const before = markup.indexOf('output visible before steering');
-  const steering = markup.indexOf('inserted instruction');
-  const after = markup.indexOf('output visible after steering');
-
-  assert.notEqual(before, -1);
-  assert.notEqual(steering, -1);
-  assert.notEqual(after, -1);
-  assert.equal(before < steering && steering < after, true);
-  for (const text of [
+  const texts = [
     'output visible before steering',
     'inserted instruction',
     'output visible after steering',
-    'failure detail',
-  ]) {
+  ];
+  const [before, steering, after] = texts.map((text) => markup.indexOf(text));
+  assert.equal(before < steering && steering < after, true);
+  for (const text of [...texts, 'failure detail']) {
     assert.equal(markup.split(text).length - 1, 1, `${text} should render exactly once`);
   }
 });

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -274,7 +274,15 @@ describe('applyLiveTurnEvent', () => {
 
 
   it('moves an output-first tool into its real step without duplicating or regressing it', () => {
-    const output = applyLiveTurnEvent(undefined, {
+    const steering = applyLiveTurnEvent(undefined, {
+      type: 'steering_message',
+      id: 'steering-event',
+      messageId: 'steer-1',
+      turnId: 'turn-1',
+      ts: 99,
+      content: { text: 'change direction' },
+    });
+    const output = applyLiveTurnEvent(steering, {
       type: 'tool_output_delta',
       id: 'event-1',
       turnId: 'turn-1',
@@ -288,6 +296,17 @@ describe('applyLiveTurnEvent', () => {
       createdAt: 100,
       ts: 100,
     });
+    assert.deepEqual(
+      overlayLiveTurn([], output)[0]?.timeline.map((item) =>
+        item.kind === 'user'
+          ? `user:${item.messageId}`
+          : item.kind === 'tools'
+            ? `tools:${item.items.map((tool) => tool.toolUseId).join(',')}`
+            : item.kind,
+      ),
+      ['user:steer-1', 'tools:tool-1'],
+    );
+
     const projection = applyLiveTurnEvent(output, {
       type: 'tool_start',
       id: 'event-2',
@@ -301,6 +320,16 @@ describe('applyLiveTurnEvent', () => {
 
     assert.equal(projection.steps.length, 1);
     assert.equal(projection.steps[0]?.stepId, 'step-1');
+    assert.deepEqual(
+      overlayLiveTurn([], projection)[0]?.timeline.map((item) =>
+        item.kind === 'user'
+          ? `user:${item.messageId}`
+          : item.kind === 'tools'
+            ? `tools:${item.items.map((tool) => tool.toolUseId).join(',')}`
+            : item.kind,
+      ),
+      ['user:steer-1', 'tools:tool-1'],
+    );
     assert.deepEqual(projection.steps[0]?.tools, [{
       toolUseId: 'tool-1',
       toolName: 'Bash',
@@ -416,6 +445,30 @@ describe('applyLiveTurnEvent', () => {
     assert.equal(aborted?.steps[0]?.text?.complete, true);
     assert.equal(aborted?.steps[0]?.tools[0]?.status, 'interrupted');
   });
+
+  for (const terminalEvent of [
+    { type: 'abort' as const, id: 'terminal', turnId: 'turn-1', ts: 2, reason: 'user_stop' as const },
+    { type: 'error' as const, id: 'terminal', turnId: 'turn-1', ts: 2, recoverable: false, message: 'failed' },
+  ]) {
+    it(`keeps steering-only evidence across ${terminalEvent.type}`, () => {
+      const withSteering = applyLiveTurnEvent(armLiveTurn('turn-1'), {
+        type: 'steering_message',
+        id: 'steering-event',
+        messageId: 'steer-1',
+        turnId: 'turn-1',
+        ts: 1,
+        content: { text: 'change direction' },
+      });
+
+      assert.deepEqual(applyLiveTurnEvent(withSteering, terminalEvent), {
+        turnId: 'turn-1',
+        phase: 'waiting',
+        terminal: true,
+        pendingSteering: [{ id: 'steer-1', content: { text: 'change direction' }, ts: 1 }],
+        steps: [],
+      });
+    });
+  }
 });
 
 describe('settleLiveTurnStep', () => {
@@ -522,24 +575,72 @@ describe('reconcileTerminalLiveTurn', () => {
     assert.equal(reconcileTerminalLiveTurn(toolOnly, []), toolOnly);
   });
 
-  it('drops terminal live steering even while other uncovered evidence remains', () => {
+  it('retains terminal live steering until persisted history reaches the terminal fence', () => {
     const withSteering: LiveTurnProjection = {
       ...toolOnly,
       pendingSteering: [{ id: 'steer-1', content: { text: 'change direction' }, ts: 2 }],
     };
 
-    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, []), toolOnly);
-    assert.equal(reconcileTerminalLiveTurn({ ...withSteering, steps: [] }, []), undefined);
+    const staleTranscript = [{
+      type: 'turn_state' as const,
+      id: 'running-1',
+      turnId: 'turn-1',
+      ts: 1,
+      status: 'running' as const,
+      partialOutputRetained: false,
+    }, {
+      type: 'tool_call' as const,
+      id: 'tool-1',
+      turnId: 'turn-1',
+      stepId: 'step-1',
+      ts: 1,
+      toolName: 'Bash',
+      args: {},
+    }, {
+      type: 'tool_result' as const,
+      id: 'result-1',
+      turnId: 'turn-1',
+      ts: 2,
+      toolUseId: 'tool-1',
+      isError: false,
+      content: { kind: 'text' as const, text: 'ok' },
+    }];
+    const terminalTranscript = [{
+      type: 'turn_state' as const,
+      id: 'terminal-1',
+      turnId: 'turn-1',
+      ts: 3,
+      status: 'completed' as const,
+      partialOutputRetained: false,
+    }];
+
+    assert.equal(reconcileTerminalLiveTurn(withSteering, staleTranscript), withSteering);
+    assert.deepEqual(
+      reconcileTerminalLiveTurn(withSteering, terminalTranscript),
+      toolOnly,
+    );
+    assert.equal(
+      reconcileTerminalLiveTurn({ ...withSteering, steps: [] }, terminalTranscript),
+      undefined,
+    );
   });
 
-  it('drops terminal steering already bound to a provider step', () => {
+  it('hands bound steering off only after the persisted terminal fence', () => {
     const message = { id: 'steer-1', content: { text: 'change direction' }, ts: 2 };
     const withSteering: LiveTurnProjection = {
       ...toolOnly,
       steps: [{ ...toolOnly.steps[0]!, leadingSteering: [message] }],
     };
 
-    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, []), toolOnly);
+    assert.equal(reconcileTerminalLiveTurn(withSteering, []), withSteering);
+    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, [{
+      type: 'turn_state',
+      id: 'terminal-1',
+      turnId: 'turn-1',
+      ts: 3,
+      status: 'completed',
+      partialOutputRetained: false,
+    }]), toolOnly);
   });
 
   it('retains interrupted live output until a persisted result covers it', () => {

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -10,6 +10,16 @@ import {
 } from '../live-turn-projection.js';
 import { overlayLiveTurn, type ToolActivityItem } from '../materialize.js';
 
+function visibleTimeline(projection: LiveTurnProjection): string[] {
+  return overlayLiveTurn([], projection)[0]?.timeline.map((item) =>
+    item.kind === 'user'
+      ? `user:${item.messageId}`
+      : item.kind === 'tools'
+        ? `tools:${item.items.map((tool) => tool.toolUseId).join(',')}`
+        : item.kind,
+  ) ?? [];
+}
+
 // A client that just sent cannot read "has my turn started" off session status:
 // it is the same before the turn starts and after it ends. The arm carries
 // `unconfirmed` until the authority says something about THAT turn, which is
@@ -296,16 +306,7 @@ describe('applyLiveTurnEvent', () => {
       createdAt: 100,
       ts: 100,
     });
-    assert.deepEqual(
-      overlayLiveTurn([], output)[0]?.timeline.map((item) =>
-        item.kind === 'user'
-          ? `user:${item.messageId}`
-          : item.kind === 'tools'
-            ? `tools:${item.items.map((tool) => tool.toolUseId).join(',')}`
-            : item.kind,
-      ),
-      ['user:steer-1', 'tools:tool-1'],
-    );
+    assert.deepEqual(visibleTimeline(output), ['user:steer-1', 'tools:tool-1']);
 
     const projection = applyLiveTurnEvent(output, {
       type: 'tool_start',
@@ -320,16 +321,7 @@ describe('applyLiveTurnEvent', () => {
 
     assert.equal(projection.steps.length, 1);
     assert.equal(projection.steps[0]?.stepId, 'step-1');
-    assert.deepEqual(
-      overlayLiveTurn([], projection)[0]?.timeline.map((item) =>
-        item.kind === 'user'
-          ? `user:${item.messageId}`
-          : item.kind === 'tools'
-            ? `tools:${item.items.map((tool) => tool.toolUseId).join(',')}`
-            : item.kind,
-      ),
-      ['user:steer-1', 'tools:tool-1'],
-    );
+    assert.deepEqual(visibleTimeline(projection), ['user:steer-1', 'tools:tool-1']);
     assert.deepEqual(projection.steps[0]?.tools, [{
       toolUseId: 'tool-1',
       toolName: 'Bash',
@@ -551,6 +543,14 @@ describe('reconcileTerminalLiveTurn', () => {
       tools: [{ toolUseId: 'tool-1', toolName: 'Bash', status: 'completed' as const, args: {} }],
     }],
   };
+  const terminalState = {
+    type: 'turn_state' as const,
+    id: 'terminal-1',
+    turnId: 'turn-1',
+    ts: 3,
+    status: 'completed' as const,
+    partialOutputRetained: false,
+  };
 
   it('settles a tool-only terminal step once persisted history covers it', () => {
     assert.equal(reconcileTerminalLiveTurn(toolOnly, [
@@ -605,14 +605,7 @@ describe('reconcileTerminalLiveTurn', () => {
       isError: false,
       content: { kind: 'text' as const, text: 'ok' },
     }];
-    const terminalTranscript = [{
-      type: 'turn_state' as const,
-      id: 'terminal-1',
-      turnId: 'turn-1',
-      ts: 3,
-      status: 'completed' as const,
-      partialOutputRetained: false,
-    }];
+    const terminalTranscript = [terminalState];
 
     assert.equal(reconcileTerminalLiveTurn(withSteering, staleTranscript), withSteering);
     assert.deepEqual(
@@ -633,14 +626,7 @@ describe('reconcileTerminalLiveTurn', () => {
     };
 
     assert.equal(reconcileTerminalLiveTurn(withSteering, []), withSteering);
-    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, [{
-      type: 'turn_state',
-      id: 'terminal-1',
-      turnId: 'turn-1',
-      ts: 3,
-      status: 'completed',
-      partialOutputRetained: false,
-    }]), toolOnly);
+    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, [terminalState]), toolOnly);
   });
 
   it('retains interrupted live output until a persisted result covers it', () => {

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -10,16 +10,6 @@ import {
 } from '../live-turn-projection.js';
 import { overlayLiveTurn, type ToolActivityItem } from '../materialize.js';
 
-function visibleTimeline(projection: LiveTurnProjection): string[] {
-  return overlayLiveTurn([], projection)[0]?.timeline.map((item) =>
-    item.kind === 'user'
-      ? `user:${item.messageId}`
-      : item.kind === 'tools'
-        ? `tools:${item.items.map((tool) => tool.toolUseId).join(',')}`
-        : item.kind,
-  ) ?? [];
-}
-
 // A client that just sent cannot read "has my turn started" off session status:
 // it is the same before the turn starts and after it ends. The arm carries
 // `unconfirmed` until the authority says something about THAT turn, which is
@@ -284,15 +274,7 @@ describe('applyLiveTurnEvent', () => {
 
 
   it('moves an output-first tool into its real step without duplicating or regressing it', () => {
-    const steering = applyLiveTurnEvent(undefined, {
-      type: 'steering_message',
-      id: 'steering-event',
-      messageId: 'steer-1',
-      turnId: 'turn-1',
-      ts: 99,
-      content: { text: 'change direction' },
-    });
-    const output = applyLiveTurnEvent(steering, {
+    const output = applyLiveTurnEvent(undefined, {
       type: 'tool_output_delta',
       id: 'event-1',
       turnId: 'turn-1',
@@ -306,8 +288,6 @@ describe('applyLiveTurnEvent', () => {
       createdAt: 100,
       ts: 100,
     });
-    assert.deepEqual(visibleTimeline(output), ['user:steer-1', 'tools:tool-1']);
-
     const projection = applyLiveTurnEvent(output, {
       type: 'tool_start',
       id: 'event-2',
@@ -321,7 +301,6 @@ describe('applyLiveTurnEvent', () => {
 
     assert.equal(projection.steps.length, 1);
     assert.equal(projection.steps[0]?.stepId, 'step-1');
-    assert.deepEqual(visibleTimeline(projection), ['user:steer-1', 'tools:tool-1']);
     assert.deepEqual(projection.steps[0]?.tools, [{
       toolUseId: 'tool-1',
       toolName: 'Bash',
@@ -337,6 +316,38 @@ describe('applyLiveTurnEvent', () => {
       }],
       outputTruncated: false,
     }]);
+  });
+
+  it('preserves steering positions when an output-first tool receives its real step', () => {
+    const firstSteer = applyLiveTurnEvent(undefined, {
+      type: 'steering_message', id: 'steer-event-1', messageId: 'steer-1',
+      turnId: 'turn-1', ts: 99, content: { text: 'before tool' },
+    });
+    const output = applyLiveTurnEvent(firstSteer, {
+      type: 'tool_output_delta', id: 'output-1', turnId: 'turn-1',
+      sessionId: 'session-1', toolCallId: 'tool-1', toolUseId: 'tool-1',
+      seq: 0, stream: 'stdout', chunk: 'hello\n', redacted: false,
+      createdAt: 100, ts: 100,
+    });
+    const answer = applyLiveTurnEvent(output, {
+      type: 'text_delta', id: 'text-1', messageId: 'step-1',
+      turnId: 'turn-1', ts: 101, text: 'answer',
+    });
+    const secondSteer = applyLiveTurnEvent(answer, {
+      type: 'steering_message', id: 'steer-event-2', messageId: 'steer-2',
+      turnId: 'turn-1', ts: 102, content: { text: 'after tool' },
+    });
+    const projection = applyLiveTurnEvent(secondSteer, {
+      type: 'tool_start', id: 'start-1', turnId: 'turn-1', stepId: 'step-1',
+      toolUseId: 'tool-1', toolName: 'Bash', args: {}, ts: 103,
+    });
+
+    assert.equal(projection.steps.flatMap((step) => step.tools).length, 1);
+    assert.deepEqual(
+      overlayLiveTurn([], projection)[0]?.timeline.map((item) =>
+        item.kind === 'user' ? `user:${item.message.text}` : item.kind),
+      ['user:before tool', 'text', 'tools', 'user:after tool'],
+    );
   });
 
 
@@ -437,30 +448,6 @@ describe('applyLiveTurnEvent', () => {
     assert.equal(aborted?.steps[0]?.text?.complete, true);
     assert.equal(aborted?.steps[0]?.tools[0]?.status, 'interrupted');
   });
-
-  for (const terminalEvent of [
-    { type: 'abort' as const, id: 'terminal', turnId: 'turn-1', ts: 2, reason: 'user_stop' as const },
-    { type: 'error' as const, id: 'terminal', turnId: 'turn-1', ts: 2, recoverable: false, message: 'failed' },
-  ]) {
-    it(`keeps steering-only evidence across ${terminalEvent.type}`, () => {
-      const withSteering = applyLiveTurnEvent(armLiveTurn('turn-1'), {
-        type: 'steering_message',
-        id: 'steering-event',
-        messageId: 'steer-1',
-        turnId: 'turn-1',
-        ts: 1,
-        content: { text: 'change direction' },
-      });
-
-      assert.deepEqual(applyLiveTurnEvent(withSteering, terminalEvent), {
-        turnId: 'turn-1',
-        phase: 'waiting',
-        terminal: true,
-        pendingSteering: [{ id: 'steer-1', content: { text: 'change direction' }, ts: 1 }],
-        steps: [],
-      });
-    });
-  }
 });
 
 describe('settleLiveTurnStep', () => {
@@ -543,14 +530,6 @@ describe('reconcileTerminalLiveTurn', () => {
       tools: [{ toolUseId: 'tool-1', toolName: 'Bash', status: 'completed' as const, args: {} }],
     }],
   };
-  const terminalState = {
-    type: 'turn_state' as const,
-    id: 'terminal-1',
-    turnId: 'turn-1',
-    ts: 3,
-    status: 'completed' as const,
-    partialOutputRetained: false,
-  };
 
   it('settles a tool-only terminal step once persisted history covers it', () => {
     assert.equal(reconcileTerminalLiveTurn(toolOnly, [
@@ -575,50 +554,7 @@ describe('reconcileTerminalLiveTurn', () => {
     assert.equal(reconcileTerminalLiveTurn(toolOnly, []), toolOnly);
   });
 
-  it('retains terminal live steering until persisted history reaches the terminal fence', () => {
-    const withSteering: LiveTurnProjection = {
-      ...toolOnly,
-      pendingSteering: [{ id: 'steer-1', content: { text: 'change direction' }, ts: 2 }],
-    };
-
-    const staleTranscript = [{
-      type: 'turn_state' as const,
-      id: 'running-1',
-      turnId: 'turn-1',
-      ts: 1,
-      status: 'running' as const,
-      partialOutputRetained: false,
-    }, {
-      type: 'tool_call' as const,
-      id: 'tool-1',
-      turnId: 'turn-1',
-      stepId: 'step-1',
-      ts: 1,
-      toolName: 'Bash',
-      args: {},
-    }, {
-      type: 'tool_result' as const,
-      id: 'result-1',
-      turnId: 'turn-1',
-      ts: 2,
-      toolUseId: 'tool-1',
-      isError: false,
-      content: { kind: 'text' as const, text: 'ok' },
-    }];
-    const terminalTranscript = [terminalState];
-
-    assert.equal(reconcileTerminalLiveTurn(withSteering, staleTranscript), withSteering);
-    assert.deepEqual(
-      reconcileTerminalLiveTurn(withSteering, terminalTranscript),
-      toolOnly,
-    );
-    assert.equal(
-      reconcileTerminalLiveTurn({ ...withSteering, steps: [] }, terminalTranscript),
-      undefined,
-    );
-  });
-
-  it('hands bound steering off only after the persisted terminal fence', () => {
+  it('keeps terminal live steering until the terminal transcript catches up', () => {
     const message = { id: 'steer-1', content: { text: 'change direction' }, ts: 2 };
     const withSteering: LiveTurnProjection = {
       ...toolOnly,
@@ -626,7 +562,26 @@ describe('reconcileTerminalLiveTurn', () => {
     };
 
     assert.equal(reconcileTerminalLiveTurn(withSteering, []), withSteering);
-    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, [terminalState]), toolOnly);
+    const steeringOnly = { ...withSteering, steps: [] };
+    assert.equal(reconcileTerminalLiveTurn(steeringOnly, []), steeringOnly);
+    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, [{
+      type: 'turn_state', id: 'state-1', turnId: 'turn-1', ts: 3,
+      status: 'completed', partialOutputRetained: false,
+    }]), toolOnly);
+  });
+
+  it('keeps steering-only aborts visible for transcript handoff', () => {
+    const message = { id: 'steer-1', content: { text: 'change direction' }, ts: 2 };
+    const withSteering = applyLiveTurnEvent(undefined, {
+      type: 'steering_message', id: 'steer-event', messageId: message.id,
+      turnId: 'turn-1', ts: message.ts, content: message.content,
+    });
+    const aborted = applyLiveTurnEvent(withSteering, {
+      type: 'abort', id: 'abort-1', turnId: 'turn-1', ts: 3, reason: 'user_stop',
+    });
+
+    assert.equal(aborted?.terminal, true);
+    assert.deepEqual(aborted?.pendingSteering, [message]);
   });
 
   it('retains interrupted live output until a persisted result covers it', () => {

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -522,6 +522,16 @@ describe('reconcileTerminalLiveTurn', () => {
     assert.equal(reconcileTerminalLiveTurn(toolOnly, []), toolOnly);
   });
 
+  it('drops terminal live steering even while other uncovered evidence remains', () => {
+    const withSteering: LiveTurnProjection = {
+      ...toolOnly,
+      steering: [{ id: 'steer-1', text: 'change direction', ts: 2 }],
+    };
+
+    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, []), toolOnly);
+    assert.equal(reconcileTerminalLiveTurn({ ...withSteering, steps: [] }, []), undefined);
+  });
+
   it('retains interrupted live output until a persisted result covers it', () => {
     const withOutput: LiveTurnProjection = {
       ...toolOnly,

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -525,11 +525,21 @@ describe('reconcileTerminalLiveTurn', () => {
   it('drops terminal live steering even while other uncovered evidence remains', () => {
     const withSteering: LiveTurnProjection = {
       ...toolOnly,
-      steering: [{ id: 'steer-1', text: 'change direction', ts: 2 }],
+      pendingSteering: [{ id: 'steer-1', content: { text: 'change direction' }, ts: 2 }],
     };
 
     assert.deepEqual(reconcileTerminalLiveTurn(withSteering, []), toolOnly);
     assert.equal(reconcileTerminalLiveTurn({ ...withSteering, steps: [] }, []), undefined);
+  });
+
+  it('drops terminal steering already bound to a provider step', () => {
+    const message = { id: 'steer-1', content: { text: 'change direction' }, ts: 2 };
+    const withSteering: LiveTurnProjection = {
+      ...toolOnly,
+      steps: [{ ...toolOnly.steps[0]!, leadingSteering: [message] }],
+    };
+
+    assert.deepEqual(reconcileTerminalLiveTurn(withSteering, []), toolOnly);
   });
 
   it('retains interrupted live output until a persisted result covers it', () => {

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -11,6 +11,84 @@ import {
 import { applyLiveTurnEvent, armLiveTurn } from "../live-turn-projection.js";
 
 describe("materializeChat attachments", () => {
+  test("keeps a steering message at its conversational position", () => {
+    const [turn] = materializeTurns([
+      { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
+      {
+        type: "assistant",
+        id: "before-steer",
+        turnId: "t1",
+        ts: 2,
+        text: "working on the original request",
+        modelId: "fixture",
+      },
+      { type: "user", id: "steer-1", turnId: "t1", ts: 3, text: "inserted instruction" },
+      {
+        type: "assistant",
+        id: "after-steer",
+        turnId: "t1",
+        ts: 4,
+        text: "following the inserted instruction",
+        modelId: "fixture",
+      },
+    ]);
+
+    assert.deepEqual(
+      turn?.timeline.map((item) =>
+        item.kind === "user" ? `user:${item.message.text}` : `${item.kind}:${"text" in item ? item.text : ""}`,
+      ),
+      [
+        "text:working on the original request",
+        "user:inserted instruction",
+        "text:following the inserted instruction",
+      ],
+    );
+  });
+
+  test("keeps a live steering message between the output visible before and after it", () => {
+    let live = applyLiveTurnEvent(armLiveTurn("t1"), {
+      type: "text_complete",
+      id: "event-before",
+      messageId: "before-steer",
+      turnId: "t1",
+      ts: 2,
+      text: "working on the original request",
+    });
+    live = applyLiveTurnEvent(live, {
+      type: "steering_message",
+      id: "event-steer",
+      messageId: "steer-1",
+      turnId: "t1",
+      ts: 3,
+      content: { text: "inserted instruction" },
+    })!;
+    live = applyLiveTurnEvent(live, {
+      type: "text_complete",
+      id: "event-after",
+      messageId: "after-steer",
+      turnId: "t1",
+      ts: 4,
+      text: "following the inserted instruction",
+    });
+
+    const [turn] = overlayLiveTurn(
+      materializeTurns([
+        { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
+      ]),
+      live,
+    );
+    assert.deepEqual(
+      turn?.timeline.map((item) =>
+        item.kind === "user" ? `user:${item.message.text}` : `${item.kind}:${"text" in item ? item.text : ""}`,
+      ),
+      [
+        "text:working on the original request",
+        "user:inserted instruction",
+        "text:following the inserted instruction",
+      ],
+    );
+  });
+
   test("overlays a steering message immediately and deduplicates its persisted row", () => {
     const settled = materializeTurns([
       { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
@@ -28,6 +106,12 @@ describe("materializeChat attachments", () => {
     assert.deepEqual(overlaid?.userInterjections?.map((message) => message.text), [
       "inserted instruction",
     ]);
+    assert.deepEqual(
+      overlaid?.timeline.flatMap((item) =>
+        item.kind === "user" ? [item.message.text] : [],
+      ),
+      ["inserted instruction"],
+    );
 
     const persisted = materializeTurns([
       { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
@@ -38,6 +122,12 @@ describe("materializeChat attachments", () => {
     assert.deepEqual(deduplicated?.userInterjections?.map((message) => message.text), [
       "inserted instruction",
     ]);
+    assert.deepEqual(
+      deduplicated?.timeline.flatMap((item) =>
+        item.kind === "user" ? [item.message.text] : [],
+      ),
+      ["inserted instruction"],
+    );
   });
 
 

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -14,7 +14,7 @@ import {
   settleLiveTurnStep,
 } from "../live-turn-projection.js";
 
-describe("materializeChat attachments", () => {
+describe("steering timeline", () => {
   test("keeps a steering message at its conversational position", () => {
     const [turn] = materializeTurns([
       { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
@@ -194,8 +194,9 @@ describe("materializeChat attachments", () => {
       ["inserted instruction"],
     );
   });
+});
 
-
+describe("materializeChat message metadata", () => {
   test("preserves an explicit empty reference projection as the new-format marker", () => {
     const messages: StoredMessage[] = [
       {
@@ -210,8 +211,6 @@ describe("materializeChat attachments", () => {
     assert.deepEqual(materializeChat(messages)[0]?.inlineReferences, []);
     assert.deepEqual(materializeTurns(messages)[0]?.user?.inlineReferences, []);
   });
-
-
 
   test("preserves Host provenance on a Goal continuation", () => {
     const messages: StoredMessage[] = [
@@ -234,9 +233,6 @@ describe("materializeChat attachments", () => {
       goalId: "goal-1",
     });
   });
-
-
-
 });
 
 // ── #1307: the timeline model stays flat (fold is a render concern) ──────────

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -11,36 +11,7 @@ import {
 import {
   applyLiveTurnEvent,
   armLiveTurn,
-  settleLiveTurnStep,
-  type LiveTurnProjection,
 } from "../live-turn-projection.js";
-
-function textStep(
-  live: LiveTurnProjection | undefined,
-  messageId: string,
-  text: string,
-  ts: number,
-): LiveTurnProjection {
-  return applyLiveTurnEvent(live, {
-    type: "text_complete",
-    id: `event-${messageId}`,
-    messageId,
-    turnId: "t1",
-    ts,
-    text,
-  });
-}
-
-function steer(live: LiveTurnProjection | undefined): LiveTurnProjection {
-  return applyLiveTurnEvent(live, {
-    type: "steering_message",
-    id: "event-steer",
-    messageId: "steer-1",
-    turnId: "t1",
-    ts: 3,
-    content: { text: "steer" },
-  })!;
-}
 
 const originalUser = {
   type: "user" as const,
@@ -94,81 +65,35 @@ describe("steering timeline", () => {
     ]);
   });
 
-  test("keeps a live steering message between the output visible before and after it", () => {
-    let live = textStep(armLiveTurn("t1"), "before-steer", "before", 2);
-    live = steer(live);
-    live = textStep(live, "after-steer", "after", 4);
-
-    const [turn] = overlayLiveTurn(
-      materializeTurns([originalUser]),
-      live,
-    );
-    assert.deepEqual(timelineText(turn), [
-      "text:before",
-      "user:steer",
-      "text:after",
-    ]);
-  });
-
-  test("keeps a live steering message visible when its preceding step settles first", () => {
-    let live = textStep(armLiveTurn("t1"), "before-steer", "before", 2);
-    live = steer(live);
-    live = settleLiveTurnStep(live, "before-steer")!;
-
-    const [turn] = overlayLiveTurn(
-      materializeTurns([originalUser, beforeAssistant]),
-      live,
-    );
-
-    assert.deepEqual(timelineText(turn), [
-      "text:before",
-      "user:steer",
-    ]);
-  });
-
-  test("overlays a steering message immediately and deduplicates its persisted row", () => {
+  test("renders one live steering message while its persisted row catches up", () => {
     const settled = materializeTurns([originalUser]);
-    const content = {
-      text: "model-facing instruction",
-      displayText: "inserted instruction",
-      attachments: [{
-        kind: "code" as const,
-        name: "example.ts",
-        mimeType: "text/typescript",
-        bytes: 12,
-        ref: { kind: "workspace_file" as const, relativePath: "example.ts" },
-      }],
-      quotes: [{ text: "source excerpt", sourceTurnId: "source-turn" }],
-      inlineReferences: [],
-    };
-    const live = applyLiveTurnEvent(armLiveTurn("t1"), {
+    const before = applyLiveTurnEvent(armLiveTurn("t1"), {
+      type: "text_complete",
+      id: "event-before",
+      messageId: "before-steer",
+      turnId: "t1",
+      ts: 1,
+      text: "before",
+    });
+    const live = applyLiveTurnEvent(before, {
       type: "steering_message",
       id: "event-steer",
       messageId: "steer-1",
       turnId: "t1",
       ts: 2,
-      content,
+      content: { text: "inserted instruction" },
     });
 
     const [overlaid] = overlayLiveTurn(settled, live);
-    const liveUser = overlaid?.timeline.find((item) => item.kind === "user")?.message;
-    assert.equal(liveUser?.text, content.displayText);
-    assert.deepEqual(liveUser?.attachments, content.attachments);
-    assert.deepEqual(liveUser?.quotes, content.quotes);
-    assert.deepEqual(liveUser?.inlineReferences, content.inlineReferences);
+    assert.deepEqual(timelineText(overlaid), ["text:before", "user:inserted instruction"]);
 
     const persisted = materializeTurns([
       originalUser,
+      beforeAssistant,
       { type: "user", id: "steer-1", turnId: "t1", ts: 2, text: "inserted instruction" },
     ]);
     const [deduplicated] = overlayLiveTurn(persisted, live);
-    assert.equal(deduplicated?.user?.text, "request");
-    assert.deepEqual(
-      deduplicated?.timeline.flatMap((item) =>
-        item.kind === "user" ? [item.message.text] : [],
-      ),
-      ["inserted instruction"],
-    );
+    assert.deepEqual(timelineText(deduplicated), ["text:before", "user:inserted instruction"]);
   });
 });
 

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -8,7 +8,11 @@ import {
   overlayLiveTurn,
   type TurnTimelineItem,
 } from "../materialize.js";
-import { applyLiveTurnEvent, armLiveTurn } from "../live-turn-projection.js";
+import {
+  applyLiveTurnEvent,
+  armLiveTurn,
+  settleLiveTurnStep,
+} from "../live-turn-projection.js";
 
 describe("materializeChat attachments", () => {
   test("keeps a steering message at its conversational position", () => {
@@ -89,6 +93,51 @@ describe("materializeChat attachments", () => {
     );
   });
 
+  test("keeps a live steering message visible when its preceding step settles first", () => {
+    let live = applyLiveTurnEvent(armLiveTurn("t1"), {
+      type: "text_complete",
+      id: "event-before",
+      messageId: "before-steer",
+      turnId: "t1",
+      ts: 2,
+      text: "working on the original request",
+    })!;
+    live = applyLiveTurnEvent(live, {
+      type: "steering_message",
+      id: "event-steer",
+      messageId: "steer-1",
+      turnId: "t1",
+      ts: 3,
+      content: { text: "inserted instruction" },
+    })!;
+    live = settleLiveTurnStep(live, "before-steer")!;
+
+    const [turn] = overlayLiveTurn(
+      materializeTurns([
+        { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
+        {
+          type: "assistant",
+          id: "before-steer",
+          turnId: "t1",
+          ts: 2,
+          text: "working on the original request",
+          modelId: "fixture",
+        },
+      ]),
+      live,
+    );
+
+    assert.deepEqual(
+      turn?.timeline.map((item) =>
+        item.kind === "user" ? `user:${item.message.text}` : `${item.kind}:${"text" in item ? item.text : ""}`,
+      ),
+      [
+        "text:working on the original request",
+        "user:inserted instruction",
+      ],
+    );
+  });
+
   test("overlays a steering message immediately and deduplicates its persisted row", () => {
     const settled = materializeTurns([
       { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
@@ -99,19 +148,38 @@ describe("materializeChat attachments", () => {
       messageId: "steer-1",
       turnId: "t1",
       ts: 2,
-      content: { text: "inserted instruction" },
+      content: {
+        text: "model-facing instruction",
+        displayText: "inserted instruction",
+        attachments: [{
+          kind: "code",
+          name: "example.ts",
+          mimeType: "text/typescript",
+          bytes: 12,
+          ref: { kind: "workspace_file", relativePath: "example.ts" },
+        }],
+        quotes: [{ text: "source excerpt", sourceTurnId: "source-turn" }],
+        inlineReferences: [],
+      },
     });
 
     const [overlaid] = overlayLiveTurn(settled, live);
-    assert.deepEqual(overlaid?.userInterjections?.map((message) => message.text), [
-      "inserted instruction",
-    ]);
-    assert.deepEqual(
-      overlaid?.timeline.flatMap((item) =>
-        item.kind === "user" ? [item.message.text] : [],
-      ),
-      ["inserted instruction"],
-    );
+    const liveUser = overlaid?.timeline.find((item) => item.kind === "user")?.message;
+    assert.deepEqual(liveUser, {
+      id: "steer-1",
+      role: "user",
+      text: "inserted instruction",
+      ts: 2,
+      attachments: [{
+        kind: "code",
+        name: "example.ts",
+        mimeType: "text/typescript",
+        bytes: 12,
+        ref: { kind: "workspace_file", relativePath: "example.ts" },
+      }],
+      quotes: [{ text: "source excerpt", sourceTurnId: "source-turn" }],
+      inlineReferences: [],
+    });
 
     const persisted = materializeTurns([
       { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
@@ -119,9 +187,6 @@ describe("materializeChat attachments", () => {
     ]);
     const [deduplicated] = overlayLiveTurn(persisted, live);
     assert.equal(deduplicated?.user?.text, "original request");
-    assert.deepEqual(deduplicated?.userInterjections?.map((message) => message.text), [
-      "inserted instruction",
-    ]);
     assert.deepEqual(
       deduplicated?.timeline.flatMap((item) =>
         item.kind === "user" ? [item.message.text] : [],

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -12,181 +12,157 @@ import {
   applyLiveTurnEvent,
   armLiveTurn,
   settleLiveTurnStep,
+  type LiveTurnProjection,
 } from "../live-turn-projection.js";
+
+function textStep(
+  live: LiveTurnProjection | undefined,
+  messageId: string,
+  text: string,
+  ts: number,
+): LiveTurnProjection {
+  return applyLiveTurnEvent(live, {
+    type: "text_complete",
+    id: `event-${messageId}`,
+    messageId,
+    turnId: "t1",
+    ts,
+    text,
+  });
+}
+
+function steer(live: LiveTurnProjection | undefined): LiveTurnProjection {
+  return applyLiveTurnEvent(live, {
+    type: "steering_message",
+    id: "event-steer",
+    messageId: "steer-1",
+    turnId: "t1",
+    ts: 3,
+    content: { text: "steer" },
+  })!;
+}
+
+const originalUser = {
+  type: "user" as const,
+  id: "original",
+  turnId: "t1",
+  ts: 1,
+  text: "request",
+};
+const beforeAssistant = {
+  type: "assistant" as const,
+  id: "before-steer",
+  turnId: "t1",
+  ts: 2,
+  text: "before",
+  modelId: "fixture",
+};
+const steeringUser = {
+  type: "user" as const,
+  id: "steer-1",
+  turnId: "t1",
+  ts: 3,
+  text: "steer",
+};
+
+function timelineText(turn: ReturnType<typeof materializeTurns>[number] | undefined): string[] {
+  return turn?.timeline.map((item) =>
+    item.kind === "user" ? `user:${item.message.text}` : `${item.kind}:${"text" in item ? item.text : ""}`,
+  ) ?? [];
+}
 
 describe("steering timeline", () => {
   test("keeps a steering message at its conversational position", () => {
     const [turn] = materializeTurns([
-      { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
-      {
-        type: "assistant",
-        id: "before-steer",
-        turnId: "t1",
-        ts: 2,
-        text: "working on the original request",
-        modelId: "fixture",
-      },
-      { type: "user", id: "steer-1", turnId: "t1", ts: 3, text: "inserted instruction" },
+      originalUser,
+      beforeAssistant,
+      steeringUser,
       {
         type: "assistant",
         id: "after-steer",
         turnId: "t1",
         ts: 4,
-        text: "following the inserted instruction",
+        text: "after",
         modelId: "fixture",
       },
     ]);
 
-    assert.deepEqual(
-      turn?.timeline.map((item) =>
-        item.kind === "user" ? `user:${item.message.text}` : `${item.kind}:${"text" in item ? item.text : ""}`,
-      ),
-      [
-        "text:working on the original request",
-        "user:inserted instruction",
-        "text:following the inserted instruction",
-      ],
-    );
+    assert.deepEqual(timelineText(turn), [
+      "text:before",
+      "user:steer",
+      "text:after",
+    ]);
   });
 
   test("keeps a live steering message between the output visible before and after it", () => {
-    let live = applyLiveTurnEvent(armLiveTurn("t1"), {
-      type: "text_complete",
-      id: "event-before",
-      messageId: "before-steer",
-      turnId: "t1",
-      ts: 2,
-      text: "working on the original request",
-    });
-    live = applyLiveTurnEvent(live, {
-      type: "steering_message",
-      id: "event-steer",
-      messageId: "steer-1",
-      turnId: "t1",
-      ts: 3,
-      content: { text: "inserted instruction" },
-    })!;
-    live = applyLiveTurnEvent(live, {
-      type: "text_complete",
-      id: "event-after",
-      messageId: "after-steer",
-      turnId: "t1",
-      ts: 4,
-      text: "following the inserted instruction",
-    });
+    let live = textStep(armLiveTurn("t1"), "before-steer", "before", 2);
+    live = steer(live);
+    live = textStep(live, "after-steer", "after", 4);
 
     const [turn] = overlayLiveTurn(
-      materializeTurns([
-        { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
-      ]),
+      materializeTurns([originalUser]),
       live,
     );
-    assert.deepEqual(
-      turn?.timeline.map((item) =>
-        item.kind === "user" ? `user:${item.message.text}` : `${item.kind}:${"text" in item ? item.text : ""}`,
-      ),
-      [
-        "text:working on the original request",
-        "user:inserted instruction",
-        "text:following the inserted instruction",
-      ],
-    );
+    assert.deepEqual(timelineText(turn), [
+      "text:before",
+      "user:steer",
+      "text:after",
+    ]);
   });
 
   test("keeps a live steering message visible when its preceding step settles first", () => {
-    let live = applyLiveTurnEvent(armLiveTurn("t1"), {
-      type: "text_complete",
-      id: "event-before",
-      messageId: "before-steer",
-      turnId: "t1",
-      ts: 2,
-      text: "working on the original request",
-    })!;
-    live = applyLiveTurnEvent(live, {
-      type: "steering_message",
-      id: "event-steer",
-      messageId: "steer-1",
-      turnId: "t1",
-      ts: 3,
-      content: { text: "inserted instruction" },
-    })!;
+    let live = textStep(armLiveTurn("t1"), "before-steer", "before", 2);
+    live = steer(live);
     live = settleLiveTurnStep(live, "before-steer")!;
 
     const [turn] = overlayLiveTurn(
-      materializeTurns([
-        { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
-        {
-          type: "assistant",
-          id: "before-steer",
-          turnId: "t1",
-          ts: 2,
-          text: "working on the original request",
-          modelId: "fixture",
-        },
-      ]),
+      materializeTurns([originalUser, beforeAssistant]),
       live,
     );
 
-    assert.deepEqual(
-      turn?.timeline.map((item) =>
-        item.kind === "user" ? `user:${item.message.text}` : `${item.kind}:${"text" in item ? item.text : ""}`,
-      ),
-      [
-        "text:working on the original request",
-        "user:inserted instruction",
-      ],
-    );
+    assert.deepEqual(timelineText(turn), [
+      "text:before",
+      "user:steer",
+    ]);
   });
 
   test("overlays a steering message immediately and deduplicates its persisted row", () => {
-    const settled = materializeTurns([
-      { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
-    ]);
+    const settled = materializeTurns([originalUser]);
+    const content = {
+      text: "model-facing instruction",
+      displayText: "inserted instruction",
+      attachments: [{
+        kind: "code" as const,
+        name: "example.ts",
+        mimeType: "text/typescript",
+        bytes: 12,
+        ref: { kind: "workspace_file" as const, relativePath: "example.ts" },
+      }],
+      quotes: [{ text: "source excerpt", sourceTurnId: "source-turn" }],
+      inlineReferences: [],
+    };
     const live = applyLiveTurnEvent(armLiveTurn("t1"), {
       type: "steering_message",
       id: "event-steer",
       messageId: "steer-1",
       turnId: "t1",
       ts: 2,
-      content: {
-        text: "model-facing instruction",
-        displayText: "inserted instruction",
-        attachments: [{
-          kind: "code",
-          name: "example.ts",
-          mimeType: "text/typescript",
-          bytes: 12,
-          ref: { kind: "workspace_file", relativePath: "example.ts" },
-        }],
-        quotes: [{ text: "source excerpt", sourceTurnId: "source-turn" }],
-        inlineReferences: [],
-      },
+      content,
     });
 
     const [overlaid] = overlayLiveTurn(settled, live);
     const liveUser = overlaid?.timeline.find((item) => item.kind === "user")?.message;
-    assert.deepEqual(liveUser, {
-      id: "steer-1",
-      role: "user",
-      text: "inserted instruction",
-      ts: 2,
-      attachments: [{
-        kind: "code",
-        name: "example.ts",
-        mimeType: "text/typescript",
-        bytes: 12,
-        ref: { kind: "workspace_file", relativePath: "example.ts" },
-      }],
-      quotes: [{ text: "source excerpt", sourceTurnId: "source-turn" }],
-      inlineReferences: [],
-    });
+    assert.equal(liveUser?.text, content.displayText);
+    assert.deepEqual(liveUser?.attachments, content.attachments);
+    assert.deepEqual(liveUser?.quotes, content.quotes);
+    assert.deepEqual(liveUser?.inlineReferences, content.inlineReferences);
 
     const persisted = materializeTurns([
-      { type: "user", id: "original", turnId: "t1", ts: 1, text: "original request" },
+      originalUser,
       { type: "user", id: "steer-1", turnId: "t1", ts: 2, text: "inserted instruction" },
     ]);
     const [deduplicated] = overlayLiveTurn(persisted, live);
-    assert.equal(deduplicated?.user?.text, "original request");
+    assert.equal(deduplicated?.user?.text, "request");
     assert.deepEqual(
       deduplicated?.timeline.flatMap((item) =>
         item.kind === "user" ? [item.message.text] : [],

--- a/packages/ui/src/__tests__/materialize.test.ts
+++ b/packages/ui/src/__tests__/materialize.test.ts
@@ -95,6 +95,56 @@ describe("steering timeline", () => {
     const [deduplicated] = overlayLiveTurn(persisted, live);
     assert.deepEqual(timelineText(deduplicated), ["text:before", "user:inserted instruction"]);
   });
+
+  test("keeps a persisted tool before live steering during handoff", () => {
+    const persisted = materializeTurns([
+      originalUser,
+      {
+        type: "tool_call",
+        id: "tool-1",
+        turnId: "t1",
+        stepId: "tool-step",
+        ts: 2,
+        toolName: "Read",
+        args: {},
+      },
+      steeringUser,
+    ]);
+    const tool = applyLiveTurnEvent(armLiveTurn("t1"), {
+      type: "tool_start",
+      id: "tool-event",
+      turnId: "t1",
+      stepId: "tool-step",
+      toolUseId: "tool-1",
+      toolName: "Read",
+      args: {},
+      ts: 2,
+    });
+    const steering = applyLiveTurnEvent(tool, {
+      type: "steering_message",
+      id: "steer-event",
+      messageId: "steer-1",
+      turnId: "t1",
+      ts: 3,
+      content: { text: "steer" },
+    });
+    const live = applyLiveTurnEvent(steering, {
+      type: "text_delta",
+      id: "text-event",
+      messageId: "after-steer",
+      turnId: "t1",
+      ts: 4,
+      text: "after",
+    });
+
+    const [overlaid] = overlayLiveTurn(persisted, live);
+    assert.deepEqual(timelineText(overlaid), ["tools:", "user:steer", "text:after"]);
+    assert.deepEqual(
+      overlaid?.timeline.flatMap((item) =>
+        item.kind === "tools" ? item.items.map((tool) => tool.toolUseId) : []),
+      ["tool-1"],
+    );
+  });
 });
 
 describe("materializeChat message metadata", () => {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -36,7 +36,7 @@ import {
   type TurnTimelineItem,
   type TurnViewModel,
 } from './materialize.js';
-import { foldTimeline, type FoldedTimelineChild } from './timeline-fold.js';
+import { foldTimeline, type FoldedTimelineChild, type FoldedTimelineEntry } from './timeline-fold.js';
 import { AttachmentKindIcon } from './attachment-kinds.js';
 import { QuoteRefChip } from './quote-ref-chip.js';
 import { Marker, markerVariants } from './primitives/chat.js';
@@ -408,6 +408,13 @@ export const TurnView = memo(function TurnView(props: {
   // flat timeline. Settled turn identities are stable (memoized projections),
   // so this only recomputes for the turn whose timeline actually changed.
   const foldedTimeline = useMemo(() => foldTimeline(turn.timeline), [turn.timeline]);
+  const conversationSegments = useMemo(
+    () => splitTimelineAtUserMessages(foldedTimeline, showAssistantMessage),
+    [foldedTimeline, showAssistantMessage],
+  );
+  const lastAssistantSegment = conversationSegments.findLastIndex(
+    (segment) => segment.kind === 'assistant',
+  );
   return (
     <section
       className="maka-turn"
@@ -515,24 +522,6 @@ export const TurnView = memo(function TurnView(props: {
 
         </LocalizedChatMessage>
       )}
-      {turn.userInterjections?.map((message) => (
-        <LocalizedChatMessage
-          key={message.id}
-          accessibleLabel={copy.userAriaLabel}
-          sender="user"
-          className="maka-chat-message maka-user-message maka-steering-message"
-        >
-          <MessageBody
-            role="user"
-            text={message.text}
-            ts={message.ts}
-            attachments={message.attachments}
-            quotes={message.quotes}
-            inlineReferences={message.inlineReferences}
-            onReadAttachmentBytes={props.onReadAttachmentBytes}
-          />
-        </LocalizedChatMessage>
-      ))}
       {turn.notes.map((note) => (
         <ChatSystemMessage
           key={note.id}
@@ -542,21 +531,45 @@ export const TurnView = memo(function TurnView(props: {
           {note.text}
         </ChatSystemMessage>
       ))}
-      {showAssistantMessage && (
-        <LocalizedChatMessage
-          accessibleLabel={copy.assistantAriaLabel}
-          sender="assistant"
-          data-turn-status={turn.status}
-          className="maka-chat-message maka-assistant-answer"
-        >
-          <div className="maka-assistant-answer-content">
-            {turn.status === 'aborted' && (
+      {conversationSegments.map((segment, segmentIndex) => {
+        if (segment.kind === 'user') {
+          const message = segment.item.message;
+          return (
+            <LocalizedChatMessage
+              key={`user-${message.id}`}
+              accessibleLabel={copy.userAriaLabel}
+              sender="user"
+              className="maka-chat-message maka-user-message maka-steering-message"
+            >
+              <MessageBody
+                role="user"
+                text={message.text}
+                ts={message.ts}
+                attachments={message.attachments}
+                quotes={message.quotes}
+                inlineReferences={message.inlineReferences}
+                onReadAttachmentBytes={props.onReadAttachmentBytes}
+              />
+            </LocalizedChatMessage>
+          );
+        }
+        const ownsTurnChrome = segmentIndex === lastAssistantSegment;
+        return (
+          <LocalizedChatMessage
+            key={`assistant-${segment.items[0] ? foldedTimelineEntryKey(segment.items[0], 0) : 'empty'}`}
+            accessibleLabel={copy.assistantAriaLabel}
+            sender="assistant"
+            data-turn-status={turn.status}
+            className="maka-chat-message maka-assistant-answer"
+          >
+            <div className="maka-assistant-answer-content">
+              {ownsTurnChrome && turn.status === 'aborted' && (
               <Marker variant="aborted" role="status">
                 <Ban size={ICON_SIZE.meta} aria-hidden="true" />
                 <em>{turnAbortMarkerLabel(turn.abortSource, locale)}</em>
               </Marker>
-            )}
-            {turn.status === 'failed' && props.failedReasonLabel && (
+              )}
+              {ownsTurnChrome && turn.status === 'failed' && props.failedReasonLabel && (
               <Marker variant="failed-banner" role="alert">
                 <Marker as="span" variant="failed-icon" aria-hidden="true">
                   <AlertOctagon size={ICON_SIZE.control} />
@@ -578,29 +591,29 @@ export const TurnView = memo(function TurnView(props: {
                   />
                 )}
               </Marker>
-            )}
-            {/* The turn timeline is the rendering source of truth
+              )}
+              {/* The turn timeline is the rendering source of truth
                 (materialize.ts): each step's 深度思考 disclosure, answer bubble,
                 and Astryx tool group in the order the model produced them.
                 #1307: runs of reasoning + tools between answer texts render
                 through the derived fold as collapsed Processing blocks. */}
-            {foldedTimeline.map((item, index) =>
-              item.kind === 'processing' ? (
-                <ProcessingBlock
-                  key={`processing-${item.id}`}
-                  entries={item.children}
-                  onOpenLinkedSession={props.onOpenLinkedSession}
-                />
-              ) : (
-                <TurnTimelineEntry
-                  key={timelineEntryKey(item, index)}
-                  item={item}
-                  onStreamingSettled={props.liveStreaming?.onStreamingSettled}
-                  onOpenLinkedSession={props.onOpenLinkedSession}
-                />
-              ),
-            )}
-            {props.liveStreaming && (
+              {segment.items.map((item, index) =>
+                item.kind === 'processing' ? (
+                  <ProcessingBlock
+                    key={`processing-${item.id}`}
+                    entries={item.children}
+                    onOpenLinkedSession={props.onOpenLinkedSession}
+                  />
+                ) : (
+                  <TurnTimelineEntry
+                    key={timelineEntryKey(item, index)}
+                    item={item}
+                    onStreamingSettled={props.liveStreaming?.onStreamingSettled}
+                    onOpenLinkedSession={props.onOpenLinkedSession}
+                  />
+                ),
+              )}
+              {ownsTurnChrome && props.liveStreaming && (
               <>
                 {props.liveStreaming.providerRetry ? (
                   <ModelProviderRetryIndicator retry={props.liveStreaming.providerRetry} />
@@ -608,9 +621,9 @@ export const TurnView = memo(function TurnView(props: {
                   props.liveStreaming.runningStatus && <TurnRunningStatus startedAt={turn.startedAt} />
                 )}
               </>
-            )}
-          </div>
-          {reverseBadges.length > 0 && (
+              )}
+            </div>
+            {ownsTurnChrome && reverseBadges.length > 0 && (
             <Marker variant="lineage-row-reverse" aria-label={copy.derivativesAriaLabel}>
               {reverseBadges.map((badge) => (
                 <UiButton
@@ -626,8 +639,8 @@ export const TurnView = memo(function TurnView(props: {
                 />
               ))}
             </Marker>
-          )}
-          {props.liveStreaming ? (
+            )}
+            {ownsTurnChrome && (props.liveStreaming ? (
             /* #642: reserved-height footer placeholder while streaming — same
                `mt-0.5 h-8` box the real footer occupies, so the live→settled
                swap is height-neutral (the footer slot never grows/shrinks). No
@@ -635,7 +648,7 @@ export const TurnView = memo(function TurnView(props: {
                `completed`, so a real `TurnFooterActions` would render a
                clickable regenerate/branch on a still-streaming answer. */
             (<div aria-hidden="true" className="maka-live-turn-footer-placeholder" />)
-          ) : (
+            ) : (
             props.footerActions && props.footerActions.length > 0 && (
               <TurnFooterActions
                 actions={props.footerActions}
@@ -643,12 +656,49 @@ export const TurnView = memo(function TurnView(props: {
                 assistantText={finalAssistantReplyText(turn)}
               />
             )
-          )}
-        </LocalizedChatMessage>
-      )}
+            ))}
+          </LocalizedChatMessage>
+        );
+      })}
     </section>
   );
 });
+
+type UserTimelineItem = Extract<TurnTimelineItem, { kind: 'user' }>;
+type AssistantFoldedTimelineEntry = Exclude<FoldedTimelineEntry, UserTimelineItem>;
+type ConversationSegment =
+  | { kind: 'user'; item: UserTimelineItem }
+  | { kind: 'assistant'; items: AssistantFoldedTimelineEntry[] };
+
+function splitTimelineAtUserMessages(
+  items: readonly FoldedTimelineEntry[],
+  includeEmptyAssistant: boolean,
+): ConversationSegment[] {
+  const segments: ConversationSegment[] = [];
+  let assistantItems: AssistantFoldedTimelineEntry[] = [];
+  const flushAssistant = (): void => {
+    if (assistantItems.length === 0) return;
+    segments.push({ kind: 'assistant', items: assistantItems });
+    assistantItems = [];
+  };
+  for (const item of items) {
+    if (item.kind === 'user') {
+      flushAssistant();
+      segments.push({ kind: 'user', item });
+    } else {
+      assistantItems.push(item);
+    }
+  }
+  flushAssistant();
+  if (includeEmptyAssistant && segments.at(-1)?.kind !== 'assistant') {
+    segments.push({ kind: 'assistant', items: [] });
+  }
+  return segments;
+}
+
+function foldedTimelineEntryKey(item: FoldedTimelineEntry, index: number): string {
+  return item.kind === 'processing' ? `processing-${item.id}` : timelineEntryKey(item, index);
+}
 
 export interface TurnFooterActionMeta {
   id: 'regenerate' | 'branch' | 'copy' | 'info';
@@ -976,7 +1026,7 @@ function timelineEntryKey(item: TurnTimelineItem, index: number): string {
 
 /** Render one timeline entry: reasoning disclosure / answer bubble / tool group. */
 function TurnTimelineEntry(props: {
-  item: TurnTimelineItem;
+  item: Exclude<TurnTimelineItem, { kind: 'user' }>;
   onStreamingSettled?: (messageId?: string) => void;
   onOpenLinkedSession?(sessionId: string): void;
 }) {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -412,9 +412,6 @@ export const TurnView = memo(function TurnView(props: {
     () => splitTimelineAtUserMessages(foldedTimeline, showAssistantMessage),
     [foldedTimeline, showAssistantMessage],
   );
-  const lastAssistantSegment = conversationSegments.findLastIndex(
-    (segment) => segment.kind === 'assistant',
-  );
   return (
     <section
       className="maka-turn"
@@ -553,7 +550,7 @@ export const TurnView = memo(function TurnView(props: {
             </LocalizedChatMessage>
           );
         }
-        const ownsTurnChrome = segmentIndex === lastAssistantSegment;
+        const ownsTurnChrome = segmentIndex === conversationSegments.length - 1;
         return (
           <LocalizedChatMessage
             key={`assistant-${
@@ -687,21 +684,16 @@ function splitTimelineAtUserMessages(
   includeEmptyAssistant: boolean,
 ): ConversationSegment[] {
   const segments: ConversationSegment[] = [];
-  let assistantItems: AssistantFoldedTimelineEntry[] = [];
-  const flushAssistant = (): void => {
-    if (assistantItems.length === 0) return;
-    segments.push({ kind: 'assistant', items: assistantItems });
-    assistantItems = [];
-  };
   for (const item of items) {
+    const last = segments.at(-1);
     if (item.kind === 'user') {
-      flushAssistant();
       segments.push({ kind: 'user', item });
+    } else if (last?.kind === 'assistant') {
+      last.items.push(item);
     } else {
-      assistantItems.push(item);
+      segments.push({ kind: 'assistant', items: [item] });
     }
   }
-  flushAssistant();
   if (includeEmptyAssistant && segments.at(-1)?.kind !== 'assistant') {
     segments.push({ kind: 'assistant', items: [] });
   }

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -556,7 +556,9 @@ export const TurnView = memo(function TurnView(props: {
         const ownsTurnChrome = segmentIndex === lastAssistantSegment;
         return (
           <LocalizedChatMessage
-            key={`assistant-${segment.items[0] ? foldedTimelineEntryKey(segment.items[0], 0) : 'empty'}`}
+            key={`assistant-${
+              segment.items[0] ? foldedTimelineEntryKey(segment.items[0], 0) : 'empty'
+            }`}
             accessibleLabel={copy.assistantAriaLabel}
             sender="assistant"
             data-turn-status={turn.status}
@@ -564,33 +566,35 @@ export const TurnView = memo(function TurnView(props: {
           >
             <div className="maka-assistant-answer-content">
               {ownsTurnChrome && turn.status === 'aborted' && (
-              <Marker variant="aborted" role="status">
-                <Ban size={ICON_SIZE.meta} aria-hidden="true" />
-                <em>{turnAbortMarkerLabel(turn.abortSource, locale)}</em>
-              </Marker>
+                <Marker variant="aborted" role="status">
+                  <Ban size={ICON_SIZE.meta} aria-hidden="true" />
+                  <em>{turnAbortMarkerLabel(turn.abortSource, locale)}</em>
+                </Marker>
               )}
               {ownsTurnChrome && turn.status === 'failed' && props.failedReasonLabel && (
-              <Marker variant="failed-banner" role="alert">
-                <Marker as="span" variant="failed-icon" aria-hidden="true">
-                  <AlertOctagon size={ICON_SIZE.control} />
-                </Marker>
-                <span>{props.failedReasonLabel}</span>
-                {(props.safeResumeAction?.detail ?? props.failedRecoveryLabel) && (
-                  <Marker as="span" variant="failed-recovery">
-                    {props.safeResumeAction?.detail ?? props.failedRecoveryLabel}
+                <Marker variant="failed-banner" role="alert">
+                  <Marker as="span" variant="failed-icon" aria-hidden="true">
+                    <AlertOctagon size={ICON_SIZE.control} />
                   </Marker>
-                )}
-                {props.safeResumeAction && (
-                  <UiButton
-                    variant="ghost"
-                    size="sm"
-                    className="maka-turn-failed-resume"
-                    isDisabled={props.safeResumeAction.pending}
-                    onClick={props.safeResumeAction.onResume}
-                    label={props.safeResumeAction.pending ? copy.safeResumePending : copy.safeResume}
-                  />
-                )}
-              </Marker>
+                  <span>{props.failedReasonLabel}</span>
+                  {(props.safeResumeAction?.detail ?? props.failedRecoveryLabel) && (
+                    <Marker as="span" variant="failed-recovery">
+                      {props.safeResumeAction?.detail ?? props.failedRecoveryLabel}
+                    </Marker>
+                  )}
+                  {props.safeResumeAction && (
+                    <UiButton
+                      variant="ghost"
+                      size="sm"
+                      className="maka-turn-failed-resume"
+                      isDisabled={props.safeResumeAction.pending}
+                      onClick={props.safeResumeAction.onResume}
+                      label={
+                        props.safeResumeAction.pending ? copy.safeResumePending : copy.safeResume
+                      }
+                    />
+                  )}
+                </Marker>
               )}
               {/* The turn timeline is the rendering source of truth
                 (materialize.ts): each step's 深度思考 disclosure, answer bubble,
@@ -614,49 +618,57 @@ export const TurnView = memo(function TurnView(props: {
                 ),
               )}
               {ownsTurnChrome && props.liveStreaming && (
-              <>
-                {props.liveStreaming.providerRetry ? (
-                  <ModelProviderRetryIndicator retry={props.liveStreaming.providerRetry} />
-                ) : (
-                  props.liveStreaming.runningStatus && <TurnRunningStatus startedAt={turn.startedAt} />
-                )}
-              </>
+                <>
+                  {props.liveStreaming.providerRetry ? (
+                    <ModelProviderRetryIndicator retry={props.liveStreaming.providerRetry} />
+                  ) : (
+                    props.liveStreaming.runningStatus && (
+                      <TurnRunningStatus startedAt={turn.startedAt} />
+                    )
+                  )}
+                </>
               )}
             </div>
             {ownsTurnChrome && reverseBadges.length > 0 && (
-            <Marker variant="lineage-row-reverse" aria-label={copy.derivativesAriaLabel}>
-              {reverseBadges.map((badge) => (
-                <UiButton
-                  key={badge.id}
-                  variant="ghost"
-                  size="sm"
-                  className={markerVariants({ variant: 'lineage-badge' })}
-                  data-direction="reverse"
-                  tooltip={badge.tooltip ?? badge.label}
-                  onClick={() => props.onLineageBadgeClick?.(badge.targetTurnId)}
-                  icon={<GitBranch size={ICON_SIZE.meta} aria-hidden="true" />}
-                  label={badge.label}
-                />
-              ))}
-            </Marker>
+              <Marker variant="lineage-row-reverse" aria-label={copy.derivativesAriaLabel}>
+                {reverseBadges.map((badge) => (
+                  <UiButton
+                    key={badge.id}
+                    variant="ghost"
+                    size="sm"
+                    className={markerVariants({ variant: 'lineage-badge' })}
+                    data-direction="reverse"
+                    tooltip={badge.tooltip ?? badge.label}
+                    onClick={() => props.onLineageBadgeClick?.(badge.targetTurnId)}
+                    icon={<GitBranch size={ICON_SIZE.meta} aria-hidden="true" />}
+                    label={badge.label}
+                  />
+                ))}
+              </Marker>
             )}
-            {ownsTurnChrome && (props.liveStreaming ? (
-            /* #642: reserved-height footer placeholder while streaming — same
-               `mt-0.5 h-8` box the real footer occupies, so the live→settled
-               swap is height-neutral (the footer slot never grows/shrinks). No
-               actionable footer here: the live tail's derived status is
-               `completed`, so a real `TurnFooterActions` would render a
-               clickable regenerate/branch on a still-streaming answer. */
-            (<div aria-hidden="true" className="maka-live-turn-footer-placeholder" />)
-            ) : (
-            props.footerActions && props.footerActions.length > 0 && (
-              <TurnFooterActions
-                actions={props.footerActions}
-                onAction={props.onFooterAction ? (actionId) => props.onFooterAction?.(turn.turnId, actionId) : undefined}
-                assistantText={finalAssistantReplyText(turn)}
-              />
-            )
-            ))}
+            {ownsTurnChrome &&
+              (props.liveStreaming ? (
+                /* #642: reserved-height footer placeholder while streaming — same
+                   `mt-0.5 h-8` box the real footer occupies, so the live→settled
+                   swap is height-neutral (the footer slot never grows/shrinks). No
+                   actionable footer here: the live tail's derived status is
+                   `completed`, so a real `TurnFooterActions` would render a
+                   clickable regenerate/branch on a still-streaming answer. */
+                <div aria-hidden="true" className="maka-live-turn-footer-placeholder" />
+              ) : (
+                props.footerActions &&
+                props.footerActions.length > 0 && (
+                  <TurnFooterActions
+                    actions={props.footerActions}
+                    onAction={
+                      props.onFooterAction
+                        ? (actionId) => props.onFooterAction?.(turn.turnId, actionId)
+                        : undefined
+                    }
+                    assistantText={finalAssistantReplyText(turn)}
+                  />
+                )
+              ))}
           </LocalizedChatMessage>
         );
       })}

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -1,4 +1,4 @@
-import type { ProviderRetryEvent, SessionEvent } from '@maka/core/events';
+import type { MessageContent, ProviderRetryEvent, SessionEvent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { materializeToolResultPreviewForActivity } from '@maka/core/tool-result-preview';
@@ -23,6 +23,8 @@ export interface LiveThinkingProjection {
 export interface LiveTurnStepProjection {
   stepId: string;
   contentOrder?: LiveTurnStepContentKind[];
+  /** Steering drained immediately before this provider step began. */
+  leadingSteering?: LiveSteeringProjection[];
   thinking?: LiveThinkingProjection;
   text?: LiveTextProjection;
   tools: ToolActivityItem[];
@@ -40,17 +42,16 @@ export interface LiveTextProjection {
 
 export interface LiveSteeringProjection {
   id: string;
-  text: string;
+  content: MessageContent;
   ts: number;
-  /** The last provider step visible when Runtime acknowledged this message. */
-  afterStepId?: string;
 }
 
 export interface LiveTurnProjection {
   turnId: string;
   phase: 'waiting' | 'streamed';
   terminal?: true;
-  steering?: LiveSteeringProjection[];
+  /** Steering acknowledged after the current content and awaiting its next provider step. */
+  pendingSteering?: LiveSteeringProjection[];
   /**
    * Set by `armLiveTurn` and cleared by the first word the authority says about
    * this turn (`confirmLiveTurn`, or any event carrying the same turnId).
@@ -154,21 +155,17 @@ export function applyLiveTurnEvent(
     const prior = current?.turnId === event.turnId
       ? current
       : { turnId: event.turnId, phase: 'waiting' as const, steps: [] };
-    const steering = prior.steering ?? [];
-    if (steering.some((message) => message.id === event.messageId)) {
+    if (liveSteeringMessages(prior).some((message) => message.id === event.messageId)) {
       return confirmed(prior);
     }
     return {
       ...confirmed(prior),
-      steering: [
-        ...steering,
+      pendingSteering: [
+        ...(prior.pendingSteering ?? []),
         {
           id: event.messageId,
-          text: event.content.displayText ?? event.content.text,
+          content: structuredClone(event.content),
           ts: event.ts,
-          ...(prior.steps.at(-1)?.stepId
-            ? { afterStepId: prior.steps.at(-1)!.stepId }
-            : {}),
         },
       ],
     };
@@ -188,7 +185,7 @@ export function applyLiveTurnEvent(
   }
   if (event.type === 'complete') {
     if (!current || current.turnId !== event.turnId) return current;
-    if (current.steps.length === 0 && (current.steering?.length ?? 0) === 0) {
+    if (current.steps.length === 0 && liveSteeringMessages(current).length === 0) {
       return undefined;
     }
     const { providerRetry: _providerRetry, ...withoutRetry } = confirmed(current);
@@ -230,7 +227,16 @@ export function applyLiveTurnEvent(
       ? event.stepId ?? existingToolStep?.stepId ?? `tool:${event.toolUseId}`
       : existingToolStep?.stepId ?? `tool:${event.toolUseId}`;
   const stepIndex = prior.steps.findIndex((step) => step.stepId === stepId);
-  const step = stepIndex >= 0 ? prior.steps[stepIndex]! : { stepId, tools: [] };
+  const isNewStep = stepIndex < 0;
+  const step: LiveTurnStepProjection = isNewStep
+    ? {
+        stepId,
+        tools: [],
+        ...((prior.pendingSteering?.length ?? 0) > 0
+          ? { leadingSteering: prior.pendingSteering }
+          : {}),
+      }
+    : prior.steps[stepIndex]!;
   let nextStep: LiveTurnStepProjection;
   if (event.type === 'thinking_delta') {
     const delta = replaySafeDelta(step.thinking?.sourceEndOffset, event);
@@ -416,7 +422,19 @@ export function applyLiveTurnEvent(
       ? prior.steps.map((candidate, index) => index === stepIndex ? nextStep : candidate)
       : [...prior.steps, nextStep];
   }
-  return { ...priorWithoutRetry, phase: 'streamed', steps };
+  const { pendingSteering: _pendingSteering, ...withoutPendingSteering } = priorWithoutRetry;
+  return {
+    ...(isNewStep ? withoutPendingSteering : priorWithoutRetry),
+    phase: 'streamed',
+    steps,
+  };
+}
+
+function liveSteeringMessages(current: LiveTurnProjection): LiveSteeringProjection[] {
+  return [
+    ...(current.pendingSteering ?? []),
+    ...current.steps.flatMap((step) => step.leadingSteering ?? []),
+  ];
 }
 
 function replaySafeDelta(
@@ -516,7 +534,7 @@ export function reconcileTerminalLiveTurn(
   const assistantIds = new Set(turnMessages.flatMap((message) => message.type === 'assistant' ? [message.id] : []));
   const toolCallIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_call' ? [message.id] : []));
   const toolResultIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_result' ? [message.toolUseId] : []));
-  const steps = current.steps.filter((step) => {
+  let steps = current.steps.filter((step) => {
     if (step.text?.text.length) return true;
     if (step.thinking && !assistantIds.has(step.stepId)) return true;
     const toolsCovered = step.tools.every((tool) => {
@@ -535,10 +553,17 @@ export function reconcileTerminalLiveTurn(
   // every accepted steer. Anything still present only in the live projection
   // was either persisted (and now renders from `messages`) or nacked before
   // persistence; retaining it would leave a ghost user instruction on screen.
-  const steeringSettled = current.terminal === true && current.steering !== undefined;
+  const steeringSettled = current.terminal === true && liveSteeringMessages(current).length > 0;
+  if (steeringSettled) {
+    steps = steps.map((step) => {
+      if (!step.leadingSteering) return step;
+      const { leadingSteering: _leadingSteering, ...withoutSteering } = step;
+      return withoutSteering;
+    });
+  }
   if (steps.length === current.steps.length && !steeringSettled) return current;
   if (steps.length === 0 && current.terminal) return undefined;
   if (!steeringSettled) return { ...current, steps };
-  const { steering: _steering, ...withoutSteering } = current;
+  const { pendingSteering: _pendingSteering, ...withoutSteering } = current;
   return { ...withoutSteering, steps };
 }

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -228,7 +228,9 @@ export function applyLiveTurnEvent(
       : existingToolStep?.stepId ?? `tool:${event.toolUseId}`;
   const stepIndex = prior.steps.findIndex((step) => step.stepId === stepId);
   const isNewStep = stepIndex < 0;
-  const claimsPendingSteering = isNewStep && (prior.pendingSteering?.length ?? 0) > 0;
+  const claimsPendingSteering = isNewStep
+    && existingToolStep === undefined
+    && (prior.pendingSteering?.length ?? 0) > 0;
   const step: LiveTurnStepProjection = isNewStep
     ? {
         stepId,
@@ -404,19 +406,10 @@ export function applyLiveTurnEvent(
     if (sourceWithoutTool.tools.length === 0 && sourceWithoutTool.contentOrder) {
       sourceWithoutTool.contentOrder = sourceWithoutTool.contentOrder.filter((kind) => kind !== 'tools');
     }
-    const sourceIsEmpty = !sourceWithoutTool.thinking && !sourceWithoutTool.text && sourceWithoutTool.tools.length === 0;
-    if (sourceIsEmpty && (sourceWithoutTool.leadingSteering?.length ?? 0) > 0) {
-      const migratedIds = new Set(
-        (sourceWithoutTool.leadingSteering ?? []).map((message) => message.id),
-      );
-      nextStep = {
-        ...nextStep,
-        leadingSteering: [
-          ...(sourceWithoutTool.leadingSteering ?? []),
-          ...(nextStep.leadingSteering ?? []).filter((message) => !migratedIds.has(message.id)),
-        ],
-      };
-    }
+    const sourceIsEmpty = !sourceWithoutTool.thinking
+      && !sourceWithoutTool.text
+      && sourceWithoutTool.tools.length === 0
+      && (sourceWithoutTool.leadingSteering?.length ?? 0) === 0;
     steps = [];
     for (let index = 0; index < prior.steps.length; index += 1) {
       const candidate = prior.steps[index]!;
@@ -544,16 +537,17 @@ export function reconcileTerminalLiveTurn(
   messages: readonly StoredMessage[],
 ): LiveTurnProjection | undefined {
   const turnMessages = messages.filter((message) => message.turnId === current.turnId);
-  const assistantIds = new Set(turnMessages.flatMap((message) => message.type === 'assistant' ? [message.id] : []));
-  const toolCallIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_call' ? [message.id] : []));
-  const toolResultIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_result' ? [message.toolUseId] : []));
   const transcriptReachedTerminal = turnMessages.some(
     (message) => message.type === 'turn_state' && message.status !== 'running',
   );
-  const steering = liveSteeringMessages(current);
-  if (current.terminal && steering.length > 0 && !transcriptReachedTerminal) {
-    return current;
-  }
+  if (
+    current.terminal === true
+    && liveSteeringMessages(current).length > 0
+    && !transcriptReachedTerminal
+  ) return current;
+  const assistantIds = new Set(turnMessages.flatMap((message) => message.type === 'assistant' ? [message.id] : []));
+  const toolCallIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_call' ? [message.id] : []));
+  const toolResultIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_result' ? [message.toolUseId] : []));
   let steps = current.steps.filter((step) => {
     if (step.text?.text.length) return true;
     if (step.thinking && !assistantIds.has(step.stepId)) return true;
@@ -569,14 +563,12 @@ export function reconcileTerminalLiveTurn(
     });
     return !toolsCovered;
   });
-  // A live terminal event can render before the asynchronously refreshed
-  // transcript. Only a persisted terminal turn_state proves this snapshot is
-  // new enough to own every accepted steer; before that fence, dropping live
-  // steering would create a visible gap. Past it, an absent user row means the
-  // steer was nacked, so retaining the live copy would create a ghost.
+  // Once persisted turn_state records the terminal handoff, the transcript is
+  // authoritative for accepted steering; retaining the live copy would leave
+  // a duplicate or a nacked ghost instruction on screen.
   const steeringSettled = current.terminal === true
     && transcriptReachedTerminal
-    && steering.length > 0;
+    && liveSteeringMessages(current).length > 0;
   if (steeringSettled) {
     steps = steps.map((step) => {
       if (!step.leadingSteering) return step;

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -531,7 +531,14 @@ export function reconcileTerminalLiveTurn(
     });
     return !toolsCovered;
   });
-  if (steps.length === current.steps.length) return current;
+  // Once the turn is terminal, the refreshed transcript is authoritative for
+  // every accepted steer. Anything still present only in the live projection
+  // was either persisted (and now renders from `messages`) or nacked before
+  // persistence; retaining it would leave a ghost user instruction on screen.
+  const steeringSettled = current.terminal === true && current.steering !== undefined;
+  if (steps.length === current.steps.length && !steeringSettled) return current;
   if (steps.length === 0 && current.terminal) return undefined;
-  return { ...current, steps };
+  if (!steeringSettled) return { ...current, steps };
+  const { steering: _steering, ...withoutSteering } = current;
+  return { ...withoutSteering, steps };
 }

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -179,7 +179,7 @@ export function applyLiveTurnEvent(
   if (event.type === 'error' || event.type === 'abort') {
     if (!current || current.turnId !== event.turnId) return current;
     const steps = terminalizeLiveSteps(current.steps);
-    if (steps.length === 0) return undefined;
+    if (steps.length === 0 && liveSteeringMessages(current).length === 0) return undefined;
     const { providerRetry: _providerRetry, ...withoutRetry } = confirmed(current);
     return { ...withoutRetry, terminal: true, steps };
   }
@@ -228,11 +228,12 @@ export function applyLiveTurnEvent(
       : existingToolStep?.stepId ?? `tool:${event.toolUseId}`;
   const stepIndex = prior.steps.findIndex((step) => step.stepId === stepId);
   const isNewStep = stepIndex < 0;
+  const claimsPendingSteering = isNewStep && (prior.pendingSteering?.length ?? 0) > 0;
   const step: LiveTurnStepProjection = isNewStep
     ? {
         stepId,
         tools: [],
-        ...((prior.pendingSteering?.length ?? 0) > 0
+        ...(claimsPendingSteering
           ? { leadingSteering: prior.pendingSteering }
           : {}),
       }
@@ -404,6 +405,18 @@ export function applyLiveTurnEvent(
       sourceWithoutTool.contentOrder = sourceWithoutTool.contentOrder.filter((kind) => kind !== 'tools');
     }
     const sourceIsEmpty = !sourceWithoutTool.thinking && !sourceWithoutTool.text && sourceWithoutTool.tools.length === 0;
+    if (sourceIsEmpty && (sourceWithoutTool.leadingSteering?.length ?? 0) > 0) {
+      const migratedIds = new Set(
+        (sourceWithoutTool.leadingSteering ?? []).map((message) => message.id),
+      );
+      nextStep = {
+        ...nextStep,
+        leadingSteering: [
+          ...(sourceWithoutTool.leadingSteering ?? []),
+          ...(nextStep.leadingSteering ?? []).filter((message) => !migratedIds.has(message.id)),
+        ],
+      };
+    }
     steps = [];
     for (let index = 0; index < prior.steps.length; index += 1) {
       const candidate = prior.steps[index]!;
@@ -424,7 +437,7 @@ export function applyLiveTurnEvent(
   }
   const { pendingSteering: _pendingSteering, ...withoutPendingSteering } = priorWithoutRetry;
   return {
-    ...(isNewStep ? withoutPendingSteering : priorWithoutRetry),
+    ...(claimsPendingSteering ? withoutPendingSteering : priorWithoutRetry),
     phase: 'streamed',
     steps,
   };
@@ -534,6 +547,13 @@ export function reconcileTerminalLiveTurn(
   const assistantIds = new Set(turnMessages.flatMap((message) => message.type === 'assistant' ? [message.id] : []));
   const toolCallIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_call' ? [message.id] : []));
   const toolResultIds = new Set(turnMessages.flatMap((message) => message.type === 'tool_result' ? [message.toolUseId] : []));
+  const transcriptReachedTerminal = turnMessages.some(
+    (message) => message.type === 'turn_state' && message.status !== 'running',
+  );
+  const steering = liveSteeringMessages(current);
+  if (current.terminal && steering.length > 0 && !transcriptReachedTerminal) {
+    return current;
+  }
   let steps = current.steps.filter((step) => {
     if (step.text?.text.length) return true;
     if (step.thinking && !assistantIds.has(step.stepId)) return true;
@@ -549,11 +569,14 @@ export function reconcileTerminalLiveTurn(
     });
     return !toolsCovered;
   });
-  // Once the turn is terminal, the refreshed transcript is authoritative for
-  // every accepted steer. Anything still present only in the live projection
-  // was either persisted (and now renders from `messages`) or nacked before
-  // persistence; retaining it would leave a ghost user instruction on screen.
-  const steeringSettled = current.terminal === true && liveSteeringMessages(current).length > 0;
+  // A live terminal event can render before the asynchronously refreshed
+  // transcript. Only a persisted terminal turn_state proves this snapshot is
+  // new enough to own every accepted steer; before that fence, dropping live
+  // steering would create a visible gap. Past it, an absent user row means the
+  // steer was nacked, so retaining the live copy would create a ghost.
+  const steeringSettled = current.terminal === true
+    && transcriptReachedTerminal
+    && steering.length > 0;
   if (steeringSettled) {
     steps = steps.map((step) => {
       if (!step.leadingSteering) return step;

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -42,6 +42,8 @@ export interface LiveSteeringProjection {
   id: string;
   text: string;
   ts: number;
+  /** The last provider step visible when Runtime acknowledged this message. */
+  afterStepId?: string;
 }
 
 export interface LiveTurnProjection {
@@ -164,6 +166,9 @@ export function applyLiveTurnEvent(
           id: event.messageId,
           text: event.content.displayText ?? event.content.text,
           ts: event.ts,
+          ...(prior.steps.at(-1)?.stepId
+            ? { afterStepId: prior.steps.at(-1)!.stepId }
+            : {}),
         },
       ],
     };

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -18,7 +18,10 @@ import type {
 import type { ToolActivityStatus } from '@maka/core/tool-result-status';
 import type { ShellRunToolResult } from '@maka/core/shell-run-result';
 import type { StoredMessage, TurnRecord, TurnStatus, UserMessage } from '@maka/core/session';
-import type { LiveTurnProjection } from "./live-turn-projection.js";
+import type {
+  LiveSteeringProjection,
+  LiveTurnProjection,
+} from "./live-turn-projection.js";
 
 export { isCancelledToolResultContent, isInFlightToolStatus, toolResultActivityStatus } from '@maka/core/tool-result-status';
 
@@ -355,8 +358,6 @@ export interface TurnViewModel {
   errorClass?: string;
   partialOutputRetained: boolean;
   user?: ChatItem;
-  /** User instructions inserted while this turn was already running. */
-  userInterjections?: ChatItem[];
   tools: ToolActivityItem[];
   assistant?: ChatItem;
   /**
@@ -403,7 +404,7 @@ export function overlayLiveTurn(
   if (
     targetIndex >= 0
     && liveTurn.steps.length === 0
-    && (liveTurn.steering?.length ?? 0) === 0
+    && (liveTurn.pendingSteering?.length ?? 0) === 0
   ) {
     return turns;
   }
@@ -457,28 +458,34 @@ export function overlayLiveTurn(
   }
   const persistedUserIds = new Set([
     ...(current.user ? [current.user.id] : []),
-    ...(current.userInterjections ?? []).map((message) => message.id),
+    ...current.timeline.flatMap((item) => item.kind === "user" ? [item.messageId] : []),
   ]);
-  const pendingSteering = (liveTurn.steering ?? []).filter(
-    (message) => !persistedUserIds.has(message.id),
-  );
-  const appendSteeringAfter = (stepId: string | undefined): void => {
-    for (const message of pendingSteering) {
-      if (message.afterStepId !== stepId) continue;
+  const appendLiveSteering = (
+    messages: readonly LiveSteeringProjection[],
+  ): void => {
+    for (const message of messages) {
+      if (persistedUserIds.has(message.id)) continue;
       timeline.push({
         kind: "user",
         message: {
           id: message.id,
           role: "user",
-          text: message.text,
+          text: message.content.displayText ?? message.content.text,
           ts: message.ts,
+          ...(message.content.attachments?.length
+            ? { attachments: message.content.attachments }
+            : {}),
+          ...(message.content.quotes?.length ? { quotes: message.content.quotes } : {}),
+          ...(message.content.inlineReferences !== undefined
+            ? { inlineReferences: message.content.inlineReferences }
+            : {}),
         },
         messageId: message.id,
       });
     }
   };
-  appendSteeringAfter(undefined);
   for (const step of liveTurn.steps) {
+    appendLiveSteering(step.leadingSteering ?? []);
     const contentOrder = step.contentOrder ?? [
       ...(step.thinking ? ["thinking" as const] : []),
       ...(step.text ? ["text" as const] : []),
@@ -511,25 +518,11 @@ export function overlayLiveTurn(
           timeline.push({ kind: "tools", items: stepTools });
       }
     }
-    appendSteeringAfter(step.stepId);
   }
+  appendLiveSteering(liveTurn.pendingSteering ?? []);
   const mergedTimeline = mergeAdjacentTimeline(timeline);
-  const userInterjections = [
-    ...(current.userInterjections ?? []),
-    ...(liveTurn.steering ?? []).flatMap((message) =>
-      persistedUserIds.has(message.id)
-        ? []
-        : [{
-            id: message.id,
-            role: "user" as const,
-            text: message.text,
-            ts: message.ts,
-          }],
-    ),
-  ];
   const next = {
     ...current,
-    ...(userInterjections.length > 0 ? { userInterjections } : {}),
     tools: timelineTools(mergedTimeline),
     timeline: mergedTimeline,
   };
@@ -675,8 +668,6 @@ export function materializeTurns(
       const user = chatItemFromUserMessage(message);
       if (!turn.user) {
         turn.user = user;
-      } else {
-        turn.userInterjections = [...(turn.userInterjections ?? []), user];
       }
     } else if (message.type === "assistant") {
       // A turn now holds one AssistantMessage per model step. Concatenate their

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -10,6 +10,7 @@ import { projectToolActivityArgs } from '@maka/core/tool-activity-args';
 import type {
   AttachmentRef,
   InlineReference,
+  MessageContent,
   QuoteRef,
   ShellRunUpdate,
   ToolActivityKind,
@@ -467,19 +468,7 @@ export function overlayLiveTurn(
       if (persistedUserIds.has(message.id)) continue;
       timeline.push({
         kind: "user",
-        message: {
-          id: message.id,
-          role: "user",
-          text: message.content.displayText ?? message.content.text,
-          ts: message.ts,
-          ...(message.content.attachments?.length
-            ? { attachments: message.content.attachments }
-            : {}),
-          ...(message.content.quotes?.length ? { quotes: message.content.quotes } : {}),
-          ...(message.content.inlineReferences !== undefined
-            ? { inlineReferences: message.content.inlineReferences }
-            : {}),
-        },
+        message: chatItemFromContent(message.id, message.ts, message.content),
         messageId: message.id,
       });
     }
@@ -1011,21 +1000,30 @@ function buildTurnTimeline(
 }
 
 function chatItemFromUserMessage(message: UserMessage): ChatItem {
+  return chatItemFromContent(message.id, message.ts, message, message.origin);
+}
+
+function chatItemFromContent(
+  id: string,
+  ts: number,
+  content: MessageContent,
+  hostOrigin?: NonNullable<UserMessage["origin"]>,
+): ChatItem {
   return {
-    id: message.id,
+    id,
     role: "user",
-    text: message.displayText ?? message.text,
-    ts: message.ts,
-    ...(message.attachments && message.attachments.length > 0
-      ? { attachments: message.attachments }
+    text: content.displayText ?? content.text,
+    ts,
+    ...(content.attachments && content.attachments.length > 0
+      ? { attachments: content.attachments }
       : {}),
-    ...(message.quotes && message.quotes.length > 0
-      ? { quotes: message.quotes }
+    ...(content.quotes && content.quotes.length > 0
+      ? { quotes: content.quotes }
       : {}),
-    ...(message.inlineReferences !== undefined
-      ? { inlineReferences: message.inlineReferences }
+    ...(content.inlineReferences !== undefined
+      ? { inlineReferences: content.inlineReferences }
       : {}),
-    ...(message.origin ? { hostOrigin: message.origin } : {}),
+    ...(hostOrigin ? { hostOrigin } : {}),
   };
 }
 

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -430,7 +430,9 @@ export function overlayLiveTurn(
   );
   const liveToolIds = new Set<string>();
   const liveContentKeys = new Set<string>();
+  const liveSteeringIds = new Set<string>();
   for (const step of liveTurn.steps) {
+    for (const message of step.leadingSteering ?? []) liveSteeringIds.add(message.id);
     if (step.thinking) liveContentKeys.add(`thinking\0${step.stepId}`);
     if (step.text) liveContentKeys.add(`text\0${step.stepId}`);
     for (const liveTool of step.tools) {
@@ -444,9 +446,11 @@ export function overlayLiveTurn(
       );
     }
   }
+  for (const message of liveTurn.pendingSteering ?? []) liveSteeringIds.add(message.id);
   const timeline: TurnTimelineItem[] = [];
   for (const item of current.timeline) {
     if (item.kind !== "tools") {
+      if (item.kind === "user" && liveSteeringIds.has(item.messageId)) continue;
       if (liveContentKeys.has(`${item.kind}\0${item.messageId}`)) continue;
       timeline.push(item);
       continue;
@@ -457,15 +461,13 @@ export function overlayLiveTurn(
     if (settledItems.length > 0)
       timeline.push({ kind: "tools", items: settledItems });
   }
-  const persistedUserIds = new Set([
-    ...(current.user ? [current.user.id] : []),
-    ...current.timeline.flatMap((item) => item.kind === "user" ? [item.messageId] : []),
-  ]);
+  const emittedSteeringIds = new Set<string>();
   const appendLiveSteering = (
     messages: readonly LiveSteeringProjection[],
   ): void => {
     for (const message of messages) {
-      if (persistedUserIds.has(message.id)) continue;
+      if (emittedSteeringIds.has(message.id)) continue;
+      emittedSteeringIds.add(message.id);
       timeline.push({
         kind: "user",
         message: chatItemFromContent(message.id, message.ts, message.content),

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -282,8 +282,8 @@ function mergeLiveOverPersisted(
 }
 
 /**
- * One entry on a turn's render timeline — the interleaved thinking / answer /
- * tool sequence in the order the model actually produced it. This is the
+ * One entry on a turn's render timeline — interleaved thinking, answer, tool,
+ * and mid-turn user messages in conversational order. This is the
  * rendering source of truth (see `TurnViewModel.timeline`); the aggregate
  * `assistant` / `assistantThinking` fields are kept only for older consumers
  * (copy, export, prompt rail).
@@ -295,6 +295,8 @@ function mergeLiveOverPersisted(
  * - `tools`: one contiguous group of tool activity. Adjacent groups are
  *   pre-merged; presentation may split ordinary evidence and linked-session
  *   navigation into adjacent native Astryx segments without reordering them.
+ * - `user`: an instruction inserted after the turn began, kept at the ledger
+ *   position where Runtime acknowledged it.
  *
  * The model stays FLAT: the collapsed "Processing" fold (#1307) is a render
  * concern applied by `foldTimeline` (timeline-fold.ts) at the component layer,
@@ -302,6 +304,11 @@ function mergeLiveOverPersisted(
  * folding) never have to maintain a nesting invariant.
  */
 export type TurnTimelineItem =
+  | {
+      kind: "user";
+      message: ChatItem;
+      messageId: string;
+    }
   | {
       kind: "thinking";
       text: string;
@@ -360,7 +367,7 @@ export interface TurnViewModel {
    */
   assistantThinking?: string;
   /**
-   * Interleaved thinking / answer / tool sequence in production order — the
+   * Interleaved thinking / answer / tool / steering sequence in production order — the
    * rendering source of truth for the turn body. Built from the per-step
    * assistant rows and each step's paired tools (see buildTurnTimeline).
    */
@@ -448,6 +455,29 @@ export function overlayLiveTurn(
     if (settledItems.length > 0)
       timeline.push({ kind: "tools", items: settledItems });
   }
+  const persistedUserIds = new Set([
+    ...(current.user ? [current.user.id] : []),
+    ...(current.userInterjections ?? []).map((message) => message.id),
+  ]);
+  const pendingSteering = (liveTurn.steering ?? []).filter(
+    (message) => !persistedUserIds.has(message.id),
+  );
+  const appendSteeringAfter = (stepId: string | undefined): void => {
+    for (const message of pendingSteering) {
+      if (message.afterStepId !== stepId) continue;
+      timeline.push({
+        kind: "user",
+        message: {
+          id: message.id,
+          role: "user",
+          text: message.text,
+          ts: message.ts,
+        },
+        messageId: message.id,
+      });
+    }
+  };
+  appendSteeringAfter(undefined);
   for (const step of liveTurn.steps) {
     const contentOrder = step.contentOrder ?? [
       ...(step.thinking ? ["thinking" as const] : []),
@@ -481,12 +511,9 @@ export function overlayLiveTurn(
           timeline.push({ kind: "tools", items: stepTools });
       }
     }
+    appendSteeringAfter(step.stepId);
   }
   const mergedTimeline = mergeAdjacentTimeline(timeline);
-  const persistedUserIds = new Set([
-    ...(current.user ? [current.user.id] : []),
-    ...(current.userInterjections ?? []).map((message) => message.id),
-  ]);
   const userInterjections = [
     ...(current.userInterjections ?? []),
     ...(liveTurn.steering ?? []).flatMap((message) =>
@@ -645,22 +672,7 @@ export function materializeTurns(
     if (turnMessageList) turnMessageList.push(message);
     else messagesByTurn.set(turnId, [message]);
     if (message.type === "user") {
-      const user: ChatItem = {
-        id: message.id,
-        role: "user",
-        text: message.displayText ?? message.text,
-        ts: message.ts,
-        ...(message.attachments && message.attachments.length > 0
-          ? { attachments: message.attachments }
-          : {}),
-        ...(message.quotes && message.quotes.length > 0
-          ? { quotes: message.quotes }
-          : {}),
-        ...(message.inlineReferences !== undefined
-          ? { inlineReferences: message.inlineReferences }
-          : {}),
-        ...(message.origin ? { hostOrigin: message.origin } : {}),
-      };
+      const user = chatItemFromUserMessage(message);
       if (!turn.user) {
         turn.user = user;
       } else {
@@ -917,11 +929,24 @@ function buildTurnTimeline(
 ): TurnTimelineItem[] {
   const raw: TurnTimelineItem[] = [];
   let pending: ToolActivityItem[] = [];
+  let sawUser = false;
   const flushTools = (items: ToolActivityItem[]): void => {
     if (items.length > 0) raw.push({ kind: "tools", items });
   };
   for (const message of turnMessages) {
-    if (message.type === "tool_call") {
+    if (message.type === "user") {
+      if (!sawUser) {
+        sawUser = true;
+        continue;
+      }
+      flushTools(pending);
+      pending = [];
+      raw.push({
+        kind: "user",
+        message: chatItemFromUserMessage(message),
+        messageId: message.id,
+      });
+    } else if (message.type === "tool_call") {
       const item = toolItemByUseId.get(message.id);
       if (item) pending.push(item);
     } else if (message.type === "assistant") {
@@ -992,6 +1017,25 @@ function buildTurnTimeline(
   }
   flushTools(pending);
   return mergeAdjacentTimeline(raw);
+}
+
+function chatItemFromUserMessage(message: UserMessage): ChatItem {
+  return {
+    id: message.id,
+    role: "user",
+    text: message.displayText ?? message.text,
+    ts: message.ts,
+    ...(message.attachments && message.attachments.length > 0
+      ? { attachments: message.attachments }
+      : {}),
+    ...(message.quotes && message.quotes.length > 0
+      ? { quotes: message.quotes }
+      : {}),
+    ...(message.inlineReferences !== undefined
+      ? { inlineReferences: message.inlineReferences }
+      : {}),
+    ...(message.origin ? { hostOrigin: message.origin } : {}),
+  };
 }
 
 function mergeAdjacentTimeline(

--- a/packages/ui/src/timeline-fold.ts
+++ b/packages/ui/src/timeline-fold.ts
@@ -9,7 +9,7 @@ import type { TurnTimelineItem } from './materialize.js';
  * maintain a nesting invariant. This module derives the folded view right
  * before rendering:
  *
- *  - answer `text` entries stay in place and are the only grouping boundary;
+ *  - answer `text` and inserted `user` entries stay in place and bound groups;
  *  - a maximal thinking+tools run between two texts folds into ONE
  *    `processing` block when it contains at least one tools group, preserving
  *    the run's interleaved order as `children`;

--- a/packages/ui/src/timeline-fold.ts
+++ b/packages/ui/src/timeline-fold.ts
@@ -16,8 +16,8 @@ import type { TurnTimelineItem } from './materialize.js';
  *  - a pure-thinking run stays bare (the 深度思考 disclosure renders it
  *    directly — wrapping a lone reasoning block would just double the fold).
  *
- * Each block carries a stable `id` derived from the PRECEDING answer text's
- * messageId (`'start'` when the block opens the turn). Between two texts there
+ * Each block carries a stable `id` derived from the preceding text or inserted
+ * user entry's messageId (`'start'` when the block opens the turn). Between two boundaries there
  * is at most one block, so the id is unique per turn — and, unlike a key
  * guessed from the first child, it survives the first tool being projected
  * away (shell-run folding) without remounting the disclosure or dropping a
@@ -33,7 +33,7 @@ export type FoldedTimelineChild = Extract<TurnTimelineItem, { kind: 'thinking' |
 
 export interface ProcessingFold {
   kind: 'processing';
-  /** Stable identity: `'start'` or the preceding answer text's messageId. */
+  /** Stable identity: `'start'` or the preceding text/user boundary's messageId. */
   id: string;
   children: FoldedTimelineChild[];
 }


### PR DESCRIPTION
## Summary

Keep mid-turn steering messages at their actual conversational position instead of moving them to the turn header or rendering them twice.

The UI now uses the turn timeline as the sole source of truth for post-head user messages. Live steering remains pending until the next provider step starts, then becomes that step’s leading timeline entry. This removes the parallel `userInterjections` state and the fragile `afterStepId` anchor while preserving attachments, quotes, and inline references. Terminal handoff now waits for the persisted terminal fence, and provisional tool steps preserve steering when their real step identity arrives.

Fixes #2898

## Verification

- `npm --workspace @maka/ui test` — 121 tests passed
- `npm --workspace @maka/desktop run typecheck`
- `npx biome check packages/ui/src/__tests__/chat-turn-steering-order.test.ts packages/ui/src/__tests__/live-turn-projection.test.ts packages/ui/src/__tests__/materialize.test.ts packages/ui/src/chat-turn.tsx packages/ui/src/live-turn-projection.ts packages/ui/src/materialize.ts packages/ui/src/timeline-fold.ts`
- `git diff --check`

Codex assisted with diagnosis and implementation. The final diff still requires human review before merge.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No