### PR TITLE
fix(desktop): preserve state across Runtime Host reconnects

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -88,6 +88,27 @@ test("does not return a late read from a replaced Runtime Host candidate", async
   router.close();
 });
 
+test("does not return a late failure from a replaced Runtime Host candidate", async () => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc);
+  const firstTarget = router.createTarget("target-a");
+  const oldRead = deferred<string>();
+  firstTarget.handleReconnectableRead?.("sessions:list", () => oldRead.promise);
+  router.activate("target-a");
+
+  const reading = ipc.invoke("sessions:list");
+  firstTarget.removeHandler("sessions:list");
+  const replacementTarget = router.createTarget("target-a");
+  replacementTarget.handleReconnectableRead?.(
+    "sessions:list",
+    async () => "replacement",
+  );
+  oldRead.reject(new Error("stale ordinary failure"));
+
+  assert.equal(await reading, "replacement");
+  router.close();
+});
+
 test("does not replay a command IPC handler after a draining rejection", async () => {
   const ipc = ipcHarness();
   const router = new RuntimeHostReconnectingIpcMain(ipc);
@@ -225,8 +246,10 @@ function ipcHarness() {
 
 function deferred<T = void>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((settle) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((settle, fail) => {
     resolve = settle;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }

--- a/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-reconnecting-ipc-main.test.ts
@@ -66,6 +66,28 @@ test("holds an invocation across a Runtime Host candidate replacement", async ()
   assert.equal(ipc.size, 0);
 });
 
+test("does not return a late read from a replaced Runtime Host candidate", async () => {
+  const ipc = ipcHarness();
+  const router = new RuntimeHostReconnectingIpcMain(ipc);
+  const firstTarget = router.createTarget("target-a");
+  const oldRead = deferred<string>();
+  firstTarget.handleReconnectableRead?.("sessions:list", () => oldRead.promise);
+  router.activate("target-a");
+
+  const reading = ipc.invoke("sessions:list");
+  firstTarget.removeHandler("sessions:list");
+  const replacementTarget = router.createTarget("target-a");
+  replacementTarget.handleReconnectableRead?.(
+    "sessions:list",
+    async () => "replacement",
+  );
+  assert.equal(await ipc.invoke("sessions:list"), "replacement");
+  oldRead.resolve("stale");
+
+  assert.equal(await reading, "replacement");
+  router.close();
+});
+
 test("does not replay a command IPC handler after a draining rejection", async () => {
   const ipc = ipcHarness();
   const router = new RuntimeHostReconnectingIpcMain(ipc);

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -186,6 +186,7 @@ if (runtimeHostStartupSelection.kind === "unavailable") {
 const startupRuntimeHostProfileId = runtimeHostStartupSelection.selectedProfileId;
 let startupRuntimeHost = runtimeHostStartupSelection.target;
 let lastRuntimeHostTarget = startupRuntimeHost;
+let lastPublishedRuntimeHostTargetEpoch: string | undefined;
 let owner: RuntimeHostDesktopOwner | undefined;
 const currentRuntimeHost = (): ResolvedRuntimeHostProfile | undefined =>
   owner ? owner.current()?.target : startupRuntimeHost;
@@ -566,10 +567,13 @@ owner = await startRuntimeHostDesktopOwner(
   {
     upgradePrompts: runtimeHostUpgradePrompts,
     onTargetStateChanged: ({ epoch, target, readiness }) => {
+      const targetChanged = lastPublishedRuntimeHostTargetEpoch !== epoch;
+      lastPublishedRuntimeHostTargetEpoch = epoch;
       lastRuntimeHostTarget = target;
       mainWindowController.send("runtime-host-profiles:changed", {
         epoch,
         profileId: target.profile.id,
+        targetChanged,
         readiness,
       });
       if (readiness === "ready") {

--- a/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
@@ -155,6 +155,10 @@ export class RuntimeHostReconnectingIpcMain {
         return result;
       } catch (error) {
         this.#assertActive(epoch);
+        if (slot.reconnectableRead && slot.handler !== handler) {
+          handler = await this.#waitForHandler(slot, epoch, handler);
+          continue;
+        }
         if (!slot.reconnectableRead || !isReconnectableReadFailure(error)) {
           throw error;
         }

--- a/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-reconnecting-ipc-main.ts
@@ -39,8 +39,8 @@ export class RuntimeHostTargetChangedError extends Error {
 
 /**
  * Keeps Electron IPC registration stable across reconnects while fencing each
- * cross-Host target generation. A candidate may be replaced within one epoch;
- * an invocation may never cross into another epoch.
+ * target generation. Reconnectable reads may move to a replacement candidate,
+ * but a late result from the replaced candidate is never returned.
  */
 export class RuntimeHostReconnectingIpcMain {
   readonly #ipcMain: Pick<IpcMain, "handle" | "removeHandler">;
@@ -148,6 +148,10 @@ export class RuntimeHostReconnectingIpcMain {
       try {
         const result = await handler.listener(event, ...args);
         this.#assertActive(epoch);
+        if (slot.reconnectableRead && slot.handler !== handler) {
+          handler = await this.#waitForHandler(slot, epoch, handler);
+          continue;
+        }
         return result;
       } catch (error) {
         this.#assertActive(epoch);

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -235,6 +235,7 @@ export interface DesktopRuntimeHostProfileSaveInput {
 export interface DesktopRuntimeHostProfileChangedEvent {
   readonly epoch: string;
   readonly profileId: string;
+  readonly targetChanged: boolean;
   readonly readiness: 'connecting' | 'ready' | 'reconnecting' | 'unavailable';
 }
 

--- a/apps/desktop/src/renderer/app-shell-command-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-command-actions.ts
@@ -48,6 +48,7 @@ export interface AppShellCommandListOptions {
   activeId: string | undefined;
   activePermissionMode: PermissionMode | undefined;
   canSetPermissionMode: boolean;
+  clientPathsAccessible: boolean;
   connections: LlmConnection[];
   defaultConnection: string | null;
   dailyReviewBridge: DailyReviewBridge;
@@ -167,8 +168,12 @@ export function buildAppShellCommandList(
     onOpenWorkspace: async () => {
       await optionsRef.current.openWorkspaceFolder();
     },
-    onOpenProjectFolder: () => optionsRef.current.openProjectFolder(),
-    onOpenSkillsFolder: () => optionsRef.current.openSkillsFolder(),
+    ...(options.clientPathsAccessible
+      ? {
+          onOpenProjectFolder: () => optionsRef.current.openProjectFolder(),
+          onOpenSkillsFolder: () => optionsRef.current.openSkillsFolder(),
+        }
+      : {}),
     onSelectModule: (selection) => {
       optionsRef.current.setNavSelection(selection);
     },

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -250,7 +250,7 @@ export function useAppShellBootstrapSubscriptions(options: {
     options.handleConnectionEvent(event);
   });
   const handleRuntimeHostChange = useEffectEvent((event: DesktopRuntimeHostProfileChangedEvent) => {
-    options.clearRuntimeHostRendererState();
+    if (event.targetChanged) options.clearRuntimeHostRendererState();
     if (event.readiness !== 'ready') return;
     void options.refreshProjects();
     void options.refreshSessions();

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2469,6 +2469,7 @@ function AppShellContent({
     activeId,
     activePermissionMode,
     canSetPermissionMode: activeBoundarySurface.localInteractionAvailable,
+    clientPathsAccessible: projectCapabilities.viewClientPath,
     connections,
     defaultConnection,
     dailyReviewBridge,
@@ -2584,7 +2585,12 @@ function AppShellContent({
                 }}
                 project={
                   titlebarProjectName
-                    ? { name: titlebarProjectName, onOpenFolder: () => void openProjectFolder() }
+                    ? {
+                        name: titlebarProjectName,
+                        ...(projectCapabilities.viewClientPath
+                          ? { onOpenFolder: () => void openProjectFolder() }
+                          : {}),
+                      }
                     : undefined
                 }
                 parentSession={titlebarParentSession}
@@ -2665,11 +2671,17 @@ function AppShellContent({
                   scheduledTasks={scheduledTasks}
                   onRefreshSkills={() => refreshSkills()}
                   onRefreshManagedSkillSources={() => refreshManagedSkillSources()}
-                  onOpenSkill={(skillId) => openSkill(skillId)}
+                  onOpenSkill={projectCapabilities.viewClientPath
+                    ? (skillId) => openSkill(skillId)
+                    : undefined}
                   onUseSkill={useSkillInChat}
-                  onOpenSkillsFolder={() => openSkillsFolder()}
+                  onOpenSkillsFolder={projectCapabilities.viewClientPath
+                    ? () => openSkillsFolder()
+                    : undefined}
                   managedSkillSources={managedSkillSources}
-                  onImportManagedSkillSource={() => importManagedSkillSource()}
+                  onImportManagedSkillSource={projectCapabilities.viewClientPath
+                    ? () => importManagedSkillSource()
+                    : undefined}
                   onInstallManagedSkill={(sourceId) => installManagedSkill(sourceId)}
                   bundledSkillCatalog={bundledSkillCatalog}
                   onRefreshBundledSkillCatalog={() => refreshBundledSkillCatalog()}

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -74,7 +74,7 @@ export function ProjectsSettingsPage(props: {
     void reload();
     const unsubscribe = window.maka.projects.subscribeChanges(() => void reload());
     const unsubscribeRuntimeHost = window.maka.runtimeHostProfiles.subscribeChanges((event) => {
-      if (event.readiness === 'ready') return;
+      if (!event.targetChanged) return;
       reloadGeneration.current += 1;
       setProjects([]);
       setCapabilities(NO_PROJECT_CAPABILITIES);

--- a/packages/ui/src/titlebar-session-identity.tsx
+++ b/packages/ui/src/titlebar-session-identity.tsx
@@ -15,7 +15,7 @@ import { useUiLocale } from './locale-context.js';
  */
 export interface TitlebarProject {
   name: string;
-  onOpenFolder(): void;
+  onOpenFolder?(): void;
 }
 
 /**
@@ -131,13 +131,17 @@ export function TitlebarSessionIdentity(props: {
           <BreadcrumbItem onClick={props.project.onOpenFolder}>
             <span
               className="maka-titlebar-identity__segment"
-              title={copy.chat.openProjectFolder(props.project.name)}
+              title={props.project.onOpenFolder
+                ? copy.chat.openProjectFolder(props.project.name)
+                : props.project.name}
             >
               {props.project.name}
             </span>
-            <span className="maka-visually-hidden">
-              {copy.chat.openProjectFolderAction}
-            </span>
+            {props.project.onOpenFolder ? (
+              <span className="maka-visually-hidden">
+                {copy.chat.openProjectFolderAction}
+              </span>
+            ) : null}
           </BreadcrumbItem>
         ) : null}
         {props.parentSession ? (


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Prevent a replaced Runtime Host candidate from returning a late reconnectable-read result. The IPC router reuses its existing per-candidate handler identity as the connection fence and retries the read through the current candidate.

Desktop now distinguishes a real target change from a reconnect to the same target. Same-target reconnects retain Client-owned Session selection, composer drafts, attachments, and quotes while refreshing Host projections. Local-path actions in the titlebar, command palette, and Skills surface are hidden when the active target cannot expose Client paths; project identity remains visible.

Follow-up to #2834.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npm test -w @maka/desktop` — 761 passed
- `npm test -w @maka/ui` — 113 passed
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- Electron smoke through `agent-browser`: the local project breadcrumb remained visible and actionable after making the action optional

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 摘要

阻止已被替换的 Runtime Host candidate 返回延迟完成的可重连读取结果。IPC router 直接复用现有的 candidate handler 身份作为连接 fence，并通过当前 candidate 重新执行读取。

Desktop 现在会区分真正的目标切换和同一目标的重连。同目标重连会保留 Client 侧的 Session 选择、输入草稿、附件和引用，同时刷新 Host 投影。当当前目标无法暴露 Client 路径时，标题栏、命令面板和 Skills 页面会隐藏本地路径操作，但仍保留项目身份展示。

这是 #2834 的跟进修复。

## 验证

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npm test -w @maka/desktop` — 761 项通过
- `npm test -w @maka/ui` — 113 项通过
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- 使用 `agent-browser` 完成 Electron smoke：将打开动作改为可选后，本地项目 breadcrumb 仍正常显示且可操作

## 检查清单

- [x] 测试覆盖该变更，并会在缺少修复时失败
- [x] lint、format、typecheck 与受影响测试套件均在本地通过

这个 PR 是否改变行为？

- [x] 是 — 已在上方摘要说明
- [ ] 否

</details>

AI disclosure: Codex materially assisted with the implementation, validation, and this draft description; M4n5ter remains the contributor of record.
