### PR TITLE
ci: automatically request Copilot reviews

### DIFF
--- a/.github/workflows/copilot-auto-review.yml
+++ b/.github/workflows/copilot-auto-review.yml
@@ -29,6 +29,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          if gh api \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
+            --jq '.users[].login' | \
+            grep -Fxq 'copilot-pull-request-reviewer[bot]'; then
+            exit 0
+          fi
+
           gh api \
             --method POST \
             "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \

--- a/.github/workflows/copilot-auto-review.yml
+++ b/.github/workflows/copilot-auto-review.yml
@@ -1,0 +1,35 @@
+name: Copilot auto review
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: copilot-auto-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  request-review:
+    if: >-
+      github.event.pull_request.draft == false &&
+      !endsWith(github.event.pull_request.user.login, '[bot]') &&
+      !contains(github.event.pull_request.labels.*.name, 'copilot-skip')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # pull_request_target supplies a writable token for fork PRs. Do not
+      # checkout or execute code from the untrusted pull request in this job.
+      - name: Request GitHub Copilot review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -f 'reviewers[]=copilot-pull-request-reviewer[bot]'


### PR DESCRIPTION
## Summary

- automatically request native GitHub Copilot code review when a non-draft human PR is opened, reopened, marked ready, or updated
- re-request review on every new push
- allow maintainers to opt out with the `copilot-skip` label

## Security

The workflow uses `pull_request_target` only to obtain the write permission needed to request a reviewer for fork PRs. It never checks out or executes pull-request code and uses no repository secrets.

## Why

Maka currently has no automatic AI review. This uses the repository author's native Copilot entitlement and AI credits rather than introducing a separate model API key or custom review bot.

## Validation

- YAML parsed successfully with Ruby Psych
- workflow structure and permissions checked locally
- `git diff --check`
- live GitHub API smoke: `copilot-pull-request-reviewer[bot]` was successfully requested on #2634 and appears as `Copilot` in the PR timeline / GraphQL review requests