### PR TITLE
fix(runtime-host): report startup recovery failures

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
@@ -184,7 +184,7 @@ test('restores the previous Runtime Host when a target switch fails', async () =
     },
   );
 
-  await assert.rejects(owner.switchTarget(remoteTarget('offline')), /startup failed/);
+  await assert.rejects(owner.switchTarget(remoteTarget('offline')), /stopped responding/);
   await owner.handleBotIncomingMessage({ text: 'restored' } as BotIncomingMessage);
 
   assert.equal(first.closeCalls, 1);

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-owner.test.ts
@@ -260,7 +260,7 @@ test('reconnects when the same profile id resolves to a different target', async
   await owner.close();
 });
 
-test('keeps reconnecting with bounded backoff until the Desktop adapter is restored', async () => {
+test('keeps reconnecting through transient startup failures until the Desktop adapter is restored', async () => {
   const first = candidateHarness();
   const replacement = candidateHarness();
   let starts = 0;
@@ -273,6 +273,7 @@ test('keeps reconnecting with bounded backoff until the Desktop adapter is resto
     startCandidate: async (): Promise<DesktopRuntimeHostCandidateStartResult> => {
       starts += 1;
       if (starts === 1) return ready(first.candidate);
+      if (starts === 2) return { kind: 'failed', reason: 'internal_startup_failure' };
       if (starts < 4) return { kind: 'failed', reason: 'host_unresponsive' };
       resolveRestored();
       return ready(replacement.candidate);

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -7,7 +7,6 @@ import type { BotRegistry } from '@maka/runtime/bots';
 import {
   connectOrSpawnRuntimeHost,
   connectRemoteRuntimeHostProfile,
-  waitForRuntimeHostReady,
   type ConnectOrSpawnRuntimeHostInput,
   type ConnectOrSpawnRuntimeHostResult,
   type RuntimeHostConnection,
@@ -243,11 +242,6 @@ export async function startDesktopRuntimeHostCandidate(
   const connection = await connectOrSpawnRuntimeHost(connectInput(input));
   if (connection.kind !== "connected") return connection;
   try {
-    await waitForRuntimeHostReady(
-      connection.connection,
-      input.electionDeadlineMs ?? 45_000,
-      input.signal,
-    );
     return {
       kind: "ready",
       candidate: await createDesktopRuntimeHostCandidate(

--- a/apps/desktop/src/main/runtime-host-desktop-owner.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-owner.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import type { BotIncomingMessage } from '@maka/runtime/bots';
 import {
   RuntimeHostPermanentReconnectError,
+  runtimeHostStartupError,
   LOCAL_RUNTIME_HOST_PROFILE,
   startRuntimeHostReconnectLifecycle,
   type ResolvedRuntimeHostProfile,
@@ -400,7 +401,7 @@ class RuntimeHostDesktopOwnerImpl implements RuntimeHostDesktopOwner {
         await this.waitForHostRetirement(result.registration, signal);
         continue;
       }
-      throw new Error(`Runtime Host startup failed: ${result.reason}`);
+      throw runtimeHostStartupError(result.reason);
     }
   }
 

--- a/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
   connectRemoteRuntimeHostProfile,
+  RuntimeHostStartupError,
   type RuntimeHostConnection,
 } from '@maka/runtime-host/client';
 import {
@@ -91,6 +92,26 @@ test('non-interactive CLI reports how to retire an incompatible Runtime Host', a
       assert.ok(error instanceof RuntimeHostCliConflictError);
       assert.equal(error.code, 'RUNTIME_HOST_RESTART_REQUIRED');
       assert.match(error.message, /Stop the previous Maka Desktop or CLI process/);
+      return true;
+    },
+  );
+});
+
+test('CLI reports an actionable stored-data startup failure', async () => {
+  await assert.rejects(
+    connectRuntimeHostCli(
+      { rootPath: '/runtime-host-root', surface: 'run' },
+      {
+        connectOrSpawn: async () => ({
+          kind: 'failed',
+          reason: 'stored_data_incompatible',
+        }),
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeHostStartupError);
+      assert.equal(error.reason, 'stored_data_incompatible');
+      assert.match(error.message, /STORED_DATA_INCOMPATIBLE/);
       return true;
     },
   );

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -11,7 +11,7 @@ import {
   LOCAL_RUNTIME_HOST_PROFILE,
   readRuntimeHostConnectionCatalog,
   RuntimeHostPermanentReconnectError,
-  waitForRuntimeHostReady,
+  runtimeHostStartupError,
   type RuntimeHostConnection,
   type RuntimeHostProfile,
   type ResolvedRuntimeHostProfile,
@@ -114,15 +114,9 @@ export async function connectRuntimeHostCli(
       );
     }
     if (connected.kind === 'failed') {
-      throw new Error(`Runtime Host startup failed: ${connected.reason}`);
+      throw runtimeHostStartupError(connected.reason);
     }
-    try {
-      await waitForRuntimeHostReady(connected.connection, 45_000, signal);
-      return connected.connection;
-    } catch (error) {
-      await connected.connection.close().catch(() => undefined);
-      throw error;
-    }
+    return connected.connection;
   };
   const initialConnection = await connect();
   const connection = await createRuntimeHostReconnectingConnection({

--- a/packages/runtime-host/src/__tests__/candidate-startup-failure.test.ts
+++ b/packages/runtime-host/src/__tests__/candidate-startup-failure.test.ts
@@ -24,6 +24,26 @@ test('preserves the primary startup classification through cleanup aggregation',
   );
 });
 
+test('does not classify cleanup errors as the primary startup failure', () => {
+  const primary = new Error('primary recovery failure');
+  const cleanup = Object.assign(new Error('secondary cleanup failure'), { errcode: 10 });
+  const aggregated = new AggregateError([primary, cleanup], 'startup and cleanup failed', {
+    cause: primary,
+  });
+
+  assert.deepEqual(classifyCandidateStartupFailure(aggregated), {
+    reason: 'internal_startup_failure',
+  });
+});
+
+test('classifies filesystem access and health failures as unavailable storage', () => {
+  for (const code of ['EACCES', 'EIO', 'ENOSPC', 'EPERM', 'EROFS']) {
+    assert.deepEqual(classifyCandidateStartupFailure(Object.assign(new Error(code), { code })), {
+      reason: 'storage_unavailable',
+    });
+  }
+});
+
 test('classifies unknown startup failures without serializing their message', () => {
   const failure = classifyCandidateStartupFailure(new Error('private provider or workspace data'));
   assert.deepEqual(failure, { reason: 'internal_startup_failure' });

--- a/packages/runtime-host/src/__tests__/candidate-startup-failure.test.ts
+++ b/packages/runtime-host/src/__tests__/candidate-startup-failure.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  candidateStartupFailureExitCode,
+  candidateStartupFailureForExitCode,
+  classifyCandidateStartupFailure,
+} from '../candidate-startup-failure.js';
+
+test('preserves the primary startup classification through cleanup aggregation', () => {
+  const primary = Object.assign(new Error('stored row contains private data'), {
+    code: 'stored_session_message_incompatible',
+  });
+  const aggregated = new AggregateError(
+    [primary, new Error('cleanup failed')],
+    'startup and cleanup failed',
+    { cause: primary },
+  );
+
+  const failure = classifyCandidateStartupFailure(aggregated);
+  assert.deepEqual(failure, { reason: 'stored_data_incompatible' });
+  assert.deepEqual(
+    candidateStartupFailureForExitCode(candidateStartupFailureExitCode(failure)),
+    failure,
+  );
+});
+
+test('classifies unknown startup failures without serializing their message', () => {
+  const failure = classifyCandidateStartupFailure(new Error('private provider or workspace data'));
+  assert.deepEqual(failure, { reason: 'internal_startup_failure' });
+  assert.equal(JSON.stringify(failure).includes('private'), false);
+});

--- a/packages/runtime-host/src/__tests__/candidate-startup-failure.test.ts
+++ b/packages/runtime-host/src/__tests__/candidate-startup-failure.test.ts
@@ -36,12 +36,13 @@ test('does not classify cleanup errors as the primary startup failure', () => {
   });
 });
 
-test('classifies filesystem access and health failures as unavailable storage', () => {
-  for (const code of ['EACCES', 'EIO', 'ENOSPC', 'EPERM', 'EROFS']) {
-    assert.deepEqual(classifyCandidateStartupFailure(Object.assign(new Error(code), { code })), {
-      reason: 'storage_unavailable',
-    });
-  }
+test('does not infer workspace ownership from a generic filesystem error', () => {
+  const filesystemError = Object.assign(new Error('resource is unavailable'), { code: 'EACCES' });
+  const resourceError = new Error('Bundled resource is unavailable', { cause: filesystemError });
+
+  assert.deepEqual(classifyCandidateStartupFailure(resourceError), {
+    reason: 'internal_startup_failure',
+  });
 });
 
 test('classifies unknown startup failures without serializing their message', () => {

--- a/packages/runtime-host/src/__tests__/fixtures/kernel-candidate.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/kernel-candidate.ts
@@ -4,15 +4,28 @@ import { defineInteractiveRuntimeHostComposition } from '../../server/host-compo
 import { createUnavailableDomainOperationHandlers } from '../../server/operation-dispatcher.js';
 import { startInteractiveRuntimeHostCandidate } from '../../server/candidate.js';
 import { runRuntimeHostProcessLifecycle } from '../../server/process-lifecycle.js';
+import {
+  candidateStartupFailureExitCode,
+  classifyCandidateStartupFailure,
+} from '../../candidate-startup-failure.js';
 
 const composition = defineInteractiveRuntimeHostComposition(async () => ({
   handlers: createUnavailableDomainOperationHandlers(),
   beginDrain() {},
-  async recover() {},
+  async recover() {
+    const code = process.env.MAKA_TEST_STARTUP_ERROR_CODE;
+    if (!code) return;
+    throw Object.assign(new Error('forced candidate startup failure'), { code });
+  },
   async close() {},
 }));
 const options = parseInteractiveRuntimeHostCandidateArguments(process.argv.slice(2));
-const result = await startInteractiveRuntimeHostCandidate(options, composition);
+let result: Awaited<ReturnType<typeof startInteractiveRuntimeHostCandidate>>;
+try {
+  result = await startInteractiveRuntimeHostCandidate(options, composition);
+} catch (error) {
+  process.exit(candidateStartupFailureExitCode(classifyCandidateStartupFailure(error)));
+}
 if (result.kind === 'loser') process.exit(2);
 
 try {

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -86,7 +86,7 @@ const require = createRequire(import.meta.url);
 const execFileAsync = promisify(execFile);
 
 describe('non-serving Runtime Host kernel', () => {
-  test('reports a recovery failure instead of returning a draining Host', async () => {
+  test('reports a recovery failure when the election produces no ready Host', async () => {
     await withHostPaths(async (paths) => {
       const result = await connectOrSpawnRuntimeHostWithDependencies(
         {
@@ -110,6 +110,38 @@ describe('non-serving Runtime Host kernel', () => {
       );
 
       assert.deepEqual(result, { kind: 'failed', reason: 'stored_data_incompatible' });
+    });
+  });
+
+  test('accepts a ready successor after an earlier Candidate fails', async () => {
+    await withHostPaths(async (paths) => {
+      let launches = 0;
+      const result = await connectOrSpawnRuntimeHostWithDependencies(
+        {
+          rootPath: paths.root,
+          surface: 'desktop',
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          electionDeadlineMs: 5_000,
+        },
+        {
+          random: () => 0.5,
+          launchCandidate: (input) => {
+            launches += 1;
+            return launchTestRuntimeHostCandidate(paths, {
+              ...input,
+              ...(launches === 1
+                ? { env: { MAKA_TEST_STARTUP_ERROR_CODE: 'transient_startup_failure' } }
+                : {}),
+            });
+          },
+        },
+      );
+
+      assert.equal(result.kind, 'connected');
+      assert.ok(launches >= 2);
+      if (result.kind === 'connected') await result.connection.close();
     });
   });
 

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -131,9 +131,7 @@ describe('non-serving Runtime Host kernel', () => {
             launches += 1;
             return launchTestRuntimeHostCandidate(paths, {
               ...input,
-              ...(launches === 1
-                ? { env: { MAKA_TEST_STARTUP_ERROR_CODE: 'transient_startup_failure' } }
-                : {}),
+              ...(launches === 1 ? { env: { MAKA_TEST_STARTUP_ERROR_CODE: 'EACCES' } } : {}),
             });
           },
         },

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -86,6 +86,33 @@ const require = createRequire(import.meta.url);
 const execFileAsync = promisify(execFile);
 
 describe('non-serving Runtime Host kernel', () => {
+  test('reports a recovery failure instead of returning a draining Host', async () => {
+    await withHostPaths(async (paths) => {
+      const result = await connectOrSpawnRuntimeHostWithDependencies(
+        {
+          rootPath: paths.root,
+          surface: 'desktop',
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          electionDeadlineMs: 5_000,
+        },
+        {
+          random: () => 0.5,
+          launchCandidate: (input) =>
+            launchTestRuntimeHostCandidate(paths, {
+              ...input,
+              env: {
+                MAKA_TEST_STARTUP_ERROR_CODE: 'stored_session_message_incompatible',
+              },
+            }),
+        },
+      );
+
+      assert.deepEqual(result, { kind: 'failed', reason: 'stored_data_incompatible' });
+    });
+  });
+
   test('rejects a bound composition mismatch without launching a Candidate', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
@@ -615,7 +642,7 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
-  test('startup failure uses the active shutdown deadline without releasing ownership', async () => {
+  test('startup failure preserves its cause when shutdown reaches the active deadline', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
       const owner = await tryAcquireInteractiveRootOwner(capability);
@@ -661,7 +688,13 @@ describe('non-serving Runtime Host kernel', () => {
           1_000,
           'Runtime Host startup ignored its shutdown deadline',
         );
-        assert.ok(error instanceof RuntimeHostProcessTerminationRequiredError);
+        assert.ok(error instanceof AggregateError);
+        assert.match(String(error.cause), /forced startup recovery failure/);
+        assert.ok(
+          error.errors.some(
+            (candidate: unknown) => candidate instanceof RuntimeHostProcessTerminationRequiredError,
+          ),
+        );
         assert.deepEqual(lifecycle, ['begin-drain', 'recover', 'close']);
         assert.equal(await tryAcquireInteractiveRootOwner(capability), undefined);
       } finally {

--- a/packages/runtime-host/src/__tests__/startup-error.test.ts
+++ b/packages/runtime-host/src/__tests__/startup-error.test.ts
@@ -16,9 +16,7 @@ test('keeps an unresponsive Host retryable', () => {
   assert.match(error.message, /stopped responding/u);
 });
 
-for (const reason of ['internal_startup_failure', 'storage_unavailable'] as const) {
-  test(`keeps ${reason} retryable`, () => {
-    const error = runtimeHostStartupError(reason);
-    assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
-  });
-}
+test('keeps internal startup failures retryable', () => {
+  const error = runtimeHostStartupError('internal_startup_failure');
+  assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
+});

--- a/packages/runtime-host/src/__tests__/startup-error.test.ts
+++ b/packages/runtime-host/src/__tests__/startup-error.test.ts
@@ -15,3 +15,10 @@ test('keeps an unresponsive Host retryable', () => {
   assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
   assert.match(error.message, /stopped responding/u);
 });
+
+for (const reason of ['internal_startup_failure', 'storage_unavailable'] as const) {
+  test(`keeps ${reason} retryable`, () => {
+    const error = runtimeHostStartupError(reason);
+    assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
+  });
+}

--- a/packages/runtime-host/src/__tests__/startup-error.test.ts
+++ b/packages/runtime-host/src/__tests__/startup-error.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RuntimeHostPermanentReconnectError } from '../client/reconnect-lifecycle.js';
+import { runtimeHostStartupError } from '../client/startup-error.js';
+
+test('presents stored-data startup failures as actionable and permanent', () => {
+  const error = runtimeHostStartupError('stored_data_incompatible');
+  assert.ok(error instanceof RuntimeHostPermanentReconnectError);
+  assert.match(error.message, /cannot read part of this workspace/u);
+  assert.match(error.message, /STORED_DATA_INCOMPATIBLE/u);
+});
+
+test('keeps an unresponsive Host retryable', () => {
+  const error = runtimeHostStartupError('host_unresponsive');
+  assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
+  assert.match(error.message, /stopped responding/u);
+});

--- a/packages/runtime-host/src/candidate-startup-failure.ts
+++ b/packages/runtime-host/src/candidate-startup-failure.ts
@@ -1,0 +1,68 @@
+export type CandidateStartupFailureReason =
+  | 'stored_data_incompatible'
+  | 'migration_blocked'
+  | 'storage_unavailable'
+  | 'internal_startup_failure';
+
+export interface CandidateStartupFailure {
+  readonly reason: CandidateStartupFailureReason;
+}
+
+const EXIT_CODE_BY_REASON: Readonly<Record<CandidateStartupFailureReason, number>> = {
+  stored_data_incompatible: 65,
+  internal_startup_failure: 70,
+  storage_unavailable: 74,
+  migration_blocked: 78,
+};
+
+export function classifyCandidateStartupFailure(error: unknown): CandidateStartupFailure {
+  const errors = errorGraph(error);
+  if (errors.some((candidate) => errorCode(candidate) === 'stored_session_message_incompatible')) {
+    return { reason: 'stored_data_incompatible' };
+  }
+  if (errors.some((candidate) => errorCode(candidate) === 'operational_state_migration_blocked')) {
+    return { reason: 'migration_blocked' };
+  }
+  if (errors.some(isSqliteStorageUnavailable)) return { reason: 'storage_unavailable' };
+  return { reason: 'internal_startup_failure' };
+}
+
+export function candidateStartupFailureExitCode(failure: CandidateStartupFailure): number {
+  return EXIT_CODE_BY_REASON[failure.reason];
+}
+
+export function candidateStartupFailureForExitCode(
+  exitCode: number | null,
+): CandidateStartupFailure | undefined {
+  for (const [reason, code] of Object.entries(EXIT_CODE_BY_REASON)) {
+    if (exitCode === code) return { reason: reason as CandidateStartupFailureReason };
+  }
+  return undefined;
+}
+
+function errorGraph(root: unknown): unknown[] {
+  const discovered: unknown[] = [];
+  const pending = [root];
+  const visited = new Set<object>();
+  while (pending.length > 0) {
+    const value = pending.pop();
+    discovered.push(value);
+    if (typeof value !== 'object' || value === null || visited.has(value)) continue;
+    visited.add(value);
+    if ('cause' in value) pending.push((value as { cause?: unknown }).cause);
+    if (value instanceof AggregateError) pending.push(...value.errors);
+  }
+  return discovered;
+}
+
+function errorCode(error: unknown): unknown {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? (error as { code?: unknown }).code
+    : undefined;
+}
+
+function isSqliteStorageUnavailable(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const errcode = (error as { errcode?: unknown }).errcode;
+  return typeof errcode === 'number' && [7, 8, 10, 13, 14].includes(errcode & 0xff);
+}

--- a/packages/runtime-host/src/candidate-startup-failure.ts
+++ b/packages/runtime-host/src/candidate-startup-failure.ts
@@ -1,6 +1,5 @@
 export type CandidateStartupFailureReason =
   | 'stored_data_incompatible'
-  | 'migration_blocked'
   | 'storage_unavailable'
   | 'internal_startup_failure';
 
@@ -12,18 +11,16 @@ const EXIT_CODE_BY_REASON: Readonly<Record<CandidateStartupFailureReason, number
   stored_data_incompatible: 65,
   internal_startup_failure: 70,
   storage_unavailable: 74,
-  migration_blocked: 78,
 };
 
+const STORAGE_UNAVAILABLE_ERROR_CODES = new Set(['EACCES', 'EIO', 'ENOSPC', 'EPERM', 'EROFS']);
+
 export function classifyCandidateStartupFailure(error: unknown): CandidateStartupFailure {
-  const errors = errorGraph(error);
+  const errors = primaryErrorChain(error);
   if (errors.some((candidate) => errorCode(candidate) === 'stored_session_message_incompatible')) {
     return { reason: 'stored_data_incompatible' };
   }
-  if (errors.some((candidate) => errorCode(candidate) === 'operational_state_migration_blocked')) {
-    return { reason: 'migration_blocked' };
-  }
-  if (errors.some(isSqliteStorageUnavailable)) return { reason: 'storage_unavailable' };
+  if (errors.some(isStorageUnavailable)) return { reason: 'storage_unavailable' };
   return { reason: 'internal_startup_failure' };
 }
 
@@ -40,19 +37,26 @@ export function candidateStartupFailureForExitCode(
   return undefined;
 }
 
-function errorGraph(root: unknown): unknown[] {
-  const discovered: unknown[] = [];
-  const pending = [root];
+function primaryErrorChain(root: unknown): unknown[] {
+  const chain: unknown[] = [];
   const visited = new Set<object>();
-  while (pending.length > 0) {
-    const value = pending.pop();
-    discovered.push(value);
-    if (typeof value !== 'object' || value === null || visited.has(value)) continue;
+  let value: unknown = root;
+  while (true) {
+    chain.push(value);
+    if (typeof value !== 'object' || value === null || visited.has(value)) break;
     visited.add(value);
-    if ('cause' in value) pending.push((value as { cause?: unknown }).cause);
-    if (value instanceof AggregateError) pending.push(...value.errors);
+    const cause = 'cause' in value ? (value as { cause?: unknown }).cause : undefined;
+    if (cause !== undefined) {
+      value = cause;
+      continue;
+    }
+    if (value instanceof AggregateError && value.errors.length > 0) {
+      [value] = value.errors;
+      continue;
+    }
+    break;
   }
-  return discovered;
+  return chain;
 }
 
 function errorCode(error: unknown): unknown {
@@ -61,8 +65,12 @@ function errorCode(error: unknown): unknown {
     : undefined;
 }
 
-function isSqliteStorageUnavailable(error: unknown): boolean {
+function isStorageUnavailable(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   const errcode = (error as { errcode?: unknown }).errcode;
-  return typeof errcode === 'number' && [7, 8, 10, 13, 14].includes(errcode & 0xff);
+  const code = errorCode(error);
+  return (
+    (typeof errcode === 'number' && [7, 8, 10, 13, 14].includes(errcode & 0xff)) ||
+    (typeof code === 'string' && STORAGE_UNAVAILABLE_ERROR_CODES.has(code))
+  );
 }

--- a/packages/runtime-host/src/candidate-startup-failure.ts
+++ b/packages/runtime-host/src/candidate-startup-failure.ts
@@ -1,7 +1,4 @@
-export type CandidateStartupFailureReason =
-  | 'stored_data_incompatible'
-  | 'storage_unavailable'
-  | 'internal_startup_failure';
+export type CandidateStartupFailureReason = 'stored_data_incompatible' | 'internal_startup_failure';
 
 export interface CandidateStartupFailure {
   readonly reason: CandidateStartupFailureReason;
@@ -10,17 +7,13 @@ export interface CandidateStartupFailure {
 const EXIT_CODE_BY_REASON: Readonly<Record<CandidateStartupFailureReason, number>> = {
   stored_data_incompatible: 65,
   internal_startup_failure: 70,
-  storage_unavailable: 74,
 };
-
-const STORAGE_UNAVAILABLE_ERROR_CODES = new Set(['EACCES', 'EIO', 'ENOSPC', 'EPERM', 'EROFS']);
 
 export function classifyCandidateStartupFailure(error: unknown): CandidateStartupFailure {
   const errors = primaryErrorChain(error);
   if (errors.some((candidate) => errorCode(candidate) === 'stored_session_message_incompatible')) {
     return { reason: 'stored_data_incompatible' };
   }
-  if (errors.some(isStorageUnavailable)) return { reason: 'storage_unavailable' };
   return { reason: 'internal_startup_failure' };
 }
 
@@ -63,14 +56,4 @@ function errorCode(error: unknown): unknown {
   return typeof error === 'object' && error !== null && 'code' in error
     ? (error as { code?: unknown }).code
     : undefined;
-}
-
-function isStorageUnavailable(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) return false;
-  const errcode = (error as { errcode?: unknown }).errcode;
-  const code = errorCode(error);
-  return (
-    (typeof errcode === 'number' && [7, 8, 10, 13, 14].includes(errcode & 0xff)) ||
-    (typeof code === 'string' && STORAGE_UNAVAILABLE_ERROR_CODES.has(code))
-  );
 }

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -178,13 +178,8 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
   let backoffMs = DEFAULT_BACKOFF_MIN_MS;
   let sawUnresponsiveEndpoint = false;
   let startupFailure: CandidateStartupFailure | undefined;
-  let reportStartupFailure!: (failure: CandidateStartupFailure) => void;
-  const startupFailureReported = new Promise<CandidateStartupFailure>((resolve) => {
-    reportStartupFailure = resolve;
-  });
 
   while (performance.now() < deadline) {
-    if (startupFailure) return { kind: 'failed', reason: startupFailure.reason };
     input.signal?.throwIfAborted();
     const result = await connectResolvedRuntimeHost({
       capability,
@@ -211,22 +206,15 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
         await result.connection.close().catch(() => undefined);
         break;
       }
-      const ready = waitForRuntimeHostReady(
-        result.connection,
-        Math.max(1, Math.ceil(remaining)),
-        input.signal,
-      ).then(
-        () => ({ kind: 'ready' as const }),
-        (error: unknown) => ({ kind: 'not_ready' as const, error }),
-      );
-      const outcome = await Promise.race([
-        ready,
-        startupFailureReported.then((failure) => ({ kind: 'startup_failure' as const, failure })),
-      ]);
-      if (outcome.kind === 'ready') return result;
-      await result.connection.close().catch(() => undefined);
-      if (outcome.kind === 'startup_failure') {
-        return { kind: 'failed', reason: outcome.failure.reason };
+      try {
+        await waitForRuntimeHostReady(
+          result.connection,
+          Math.max(1, Math.ceil(remaining)),
+          input.signal,
+        );
+        return result;
+      } catch {
+        await result.connection.close().catch(() => undefined);
       }
       input.signal?.throwIfAborted();
       sawUnresponsiveEndpoint = true;
@@ -240,7 +228,11 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
     }
 
     const now = performance.now();
-    if (shouldLaunchCandidate(result) && now >= nextCandidateAt) {
+    if (
+      shouldLaunchCandidate(result) &&
+      (!startupFailure || startupFailure.reason === 'internal_startup_failure') &&
+      now >= nextCandidateAt
+    ) {
       try {
         const remaining = deadline - performance.now();
         if (remaining <= 0) break;
@@ -253,9 +245,14 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
         });
         const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);
         void attempt.startupFailure?.then((failure) => {
-          if (!failure || startupFailure) return;
-          startupFailure = failure;
-          reportStartupFailure(failure);
+          if (
+            failure &&
+            (!startupFailure ||
+              startupFailure.reason === 'internal_startup_failure' ||
+              failure.reason === 'stored_data_incompatible')
+          ) {
+            startupFailure = failure;
+          }
         });
       } catch {
         // A failed Candidate attempt is ordinary election evidence; discovery continues.

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -230,7 +230,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
     const now = performance.now();
     if (
       shouldLaunchCandidate(result) &&
-      (!startupFailure || startupFailure.reason === 'internal_startup_failure') &&
+      startupFailure?.reason !== 'stored_data_incompatible' &&
       now >= nextCandidateAt
     ) {
       try {
@@ -245,12 +245,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
         });
         const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);
         void attempt.startupFailure?.then((failure) => {
-          if (
-            failure &&
-            (!startupFailure ||
-              startupFailure.reason === 'internal_startup_failure' ||
-              failure.reason === 'stored_data_incompatible')
-          ) {
+          if (failure && (!startupFailure || failure.reason === 'stored_data_incompatible')) {
             startupFailure = failure;
           }
         });

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -24,6 +24,7 @@ import {
   type CandidateLauncher,
   type OwnedCandidateAttempt,
 } from './launcher.js';
+import type { CandidateStartupFailure } from '../candidate-startup-failure.js';
 import { abortable, waitForRuntimeHostReady } from './wait-for-ready.js';
 
 const DEFAULT_ELECTION_DEADLINE_MS = 45_000;
@@ -69,7 +70,10 @@ export type ConnectOrSpawnRuntimeHostResult =
       reason: 'composition_mismatch';
       requiredCompositionId: string;
     }
-  | { kind: 'failed'; reason: 'startup_timeout' | 'host_unresponsive' };
+  | {
+      kind: 'failed';
+      reason: CandidateStartupFailure['reason'] | 'startup_timeout' | 'host_unresponsive';
+    };
 
 export async function connectOrSpawnRuntimeHost(
   input: ConnectOrSpawnRuntimeHostInput,
@@ -134,7 +138,6 @@ export async function connectOwnedRuntimeHostWithDependencies(
       await host.settle(1_000);
       return { kind: 'failed', reason: 'existing_host' };
     }
-    await waitForRuntimeHostReady(ownedConnection, input.electionDeadlineMs, input.signal);
     return { kind: 'connected', connection: ownedConnection, host };
   } catch {
     await connection?.close().catch(() => undefined);
@@ -174,8 +177,14 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
   let nextCandidateAt = startedAt;
   let backoffMs = DEFAULT_BACKOFF_MIN_MS;
   let sawUnresponsiveEndpoint = false;
+  let startupFailure: CandidateStartupFailure | undefined;
+  let reportStartupFailure!: (failure: CandidateStartupFailure) => void;
+  const startupFailureReported = new Promise<CandidateStartupFailure>((resolve) => {
+    reportStartupFailure = resolve;
+  });
 
   while (performance.now() < deadline) {
+    if (startupFailure) return { kind: 'failed', reason: startupFailure.reason };
     input.signal?.throwIfAborted();
     const result = await connectResolvedRuntimeHost({
       capability,
@@ -196,7 +205,32 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
       if (result.endpointConnected) sawUnresponsiveEndpoint = true;
       break;
     }
-    if (result.kind === 'connected') return result;
+    if (result.kind === 'connected') {
+      const remaining = deadline - performance.now();
+      if (remaining <= 0) {
+        await result.connection.close().catch(() => undefined);
+        break;
+      }
+      const ready = waitForRuntimeHostReady(
+        result.connection,
+        Math.max(1, Math.ceil(remaining)),
+        input.signal,
+      ).then(
+        () => ({ kind: 'ready' as const }),
+        (error: unknown) => ({ kind: 'not_ready' as const, error }),
+      );
+      const outcome = await Promise.race([
+        ready,
+        startupFailureReported.then((failure) => ({ kind: 'startup_failure' as const, failure })),
+      ]);
+      if (outcome.kind === 'ready') return result;
+      await result.connection.close().catch(() => undefined);
+      if (outcome.kind === 'startup_failure') {
+        return { kind: 'failed', reason: outcome.failure.reason };
+      }
+      input.signal?.throwIfAborted();
+      sawUnresponsiveEndpoint = true;
+    }
     if (result.kind === 'upgrade_required') return result;
     if (result.kind === 'unavailable' && result.reason === 'handshake_failed') {
       sawUnresponsiveEndpoint = true;
@@ -217,7 +251,12 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
           initialConnectionTimeoutMs: Math.ceil(remaining),
           ...(input.generation === undefined ? {} : { generation: input.generation }),
         });
-        await settleBeforeDeadline(launch.spawned, deadline, input.signal);
+        const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);
+        void attempt.startupFailure?.then((failure) => {
+          if (!failure || startupFailure) return;
+          startupFailure = failure;
+          reportStartupFailure(failure);
+        });
       } catch {
         // A failed Candidate attempt is ordinary election evidence; discovery continues.
       }
@@ -231,6 +270,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
     await sleep(Math.min(remaining, Math.max(1, Math.round(backoffMs * jitter))), input.signal);
     backoffMs = Math.min(DEFAULT_BACKOFF_MAX_MS, backoffMs * 2);
   }
+  if (startupFailure) return { kind: 'failed', reason: startupFailure.reason };
   return {
     kind: 'failed',
     reason: sawUnresponsiveEndpoint ? 'host_unresponsive' : 'startup_timeout',

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -50,6 +50,11 @@ export {
 } from './session-subscription.js';
 export { waitForRuntimeHostReady } from './wait-for-ready.js';
 export {
+  RuntimeHostStartupError,
+  runtimeHostStartupError,
+  type RuntimeHostStartupFailureReason,
+} from './startup-error.js';
+export {
   RuntimeHostCatalogReadError,
   readRuntimeHostConnectionCatalog,
   readRuntimeHostInvocableSkills,

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -1,6 +1,10 @@
 import { spawn } from 'node:child_process';
 import { dirname, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import {
+  candidateStartupFailureForExitCode,
+  type CandidateStartupFailure,
+} from '../candidate-startup-failure.js';
 
 export interface DetachedCandidateInput {
   rootPath: string;
@@ -16,6 +20,7 @@ export interface DetachedCandidateInput {
 
 export interface DetachedCandidateAttempt {
   pid: number;
+  startupFailure?: Promise<CandidateStartupFailure | undefined>;
 }
 
 export interface OwnedCandidateAttempt extends DetachedCandidateAttempt {
@@ -33,9 +38,10 @@ export function launchDetachedRuntimeHostCandidate(
   input: DetachedCandidateInput,
 ): DetachedCandidateLaunch {
   const child = spawnCandidate(input, true);
+  const startupFailure = readStartupFailure(child);
   const spawned = spawnedPid(child).then(({ pid }) => {
     child.unref();
-    return { pid };
+    return { pid, startupFailure };
   });
   return { spawned };
 }
@@ -44,12 +50,14 @@ export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): 
   readonly spawned: Promise<OwnedCandidateAttempt>;
 } {
   const child = spawnCandidate(input, false);
+  const startupFailure = readStartupFailure(child);
   const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
     child.once('exit', (code, signal) => resolve({ code, signal }));
   });
   return {
     spawned: spawnedPid(child).then(({ pid }) => ({
       pid,
+      startupFailure,
       releaseToEnvironment(): void {
         child.unref();
       },
@@ -93,8 +101,8 @@ function spawnCandidate(input: DetachedCandidateInput, detached: boolean) {
   return child;
 }
 
-function spawnedPid(child: ReturnType<typeof spawn>): Promise<DetachedCandidateAttempt> {
-  return new Promise<DetachedCandidateAttempt>((resolve, reject) => {
+function spawnedPid(child: ReturnType<typeof spawn>): Promise<{ pid: number }> {
+  return new Promise<{ pid: number }>((resolve, reject) => {
     const onSpawn = () => {
       child.off('error', onError);
       const pid = child.pid;
@@ -110,6 +118,15 @@ function spawnedPid(child: ReturnType<typeof spawn>): Promise<DetachedCandidateA
     };
     child.once('spawn', onSpawn);
     child.once('error', onError);
+  });
+}
+
+function readStartupFailure(
+  child: ReturnType<typeof spawn>,
+): Promise<CandidateStartupFailure | undefined> {
+  return new Promise((resolve) => {
+    child.once('exit', (code) => resolve(candidateStartupFailureForExitCode(code)));
+    child.once('error', () => resolve(undefined));
   });
 }
 

--- a/packages/runtime-host/src/client/startup-error.ts
+++ b/packages/runtime-host/src/client/startup-error.ts
@@ -25,10 +25,6 @@ export function runtimeHostStartupError(reason: RuntimeHostStartupFailureReason)
         reason,
         'Maka cannot read part of this workspace’s stored data. The workspace was left in place. Update Maka or report diagnostic code STORED_DATA_INCOMPATIBLE.',
       );
-    case 'storage_unavailable':
-      return new Error(
-        'Maka cannot access this workspace storage. Check disk space, filesystem permissions, and storage health. Diagnostic code: STORAGE_UNAVAILABLE.',
-      );
     case 'internal_startup_failure':
       return new Error(
         'Runtime Host failed while recovering this workspace. Try again; if the problem persists, report diagnostic code INTERNAL_STARTUP_FAILURE.',

--- a/packages/runtime-host/src/client/startup-error.ts
+++ b/packages/runtime-host/src/client/startup-error.ts
@@ -1,0 +1,53 @@
+import type { CandidateStartupFailureReason } from '../candidate-startup-failure.js';
+import { RuntimeHostPermanentReconnectError } from './reconnect-lifecycle.js';
+
+export type RuntimeHostStartupFailureReason =
+  | CandidateStartupFailureReason
+  | 'composition_mismatch'
+  | 'startup_timeout'
+  | 'host_unresponsive';
+
+export class RuntimeHostStartupError extends RuntimeHostPermanentReconnectError {
+  readonly name = 'RuntimeHostStartupError';
+
+  constructor(
+    readonly reason: CandidateStartupFailureReason | 'composition_mismatch',
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function runtimeHostStartupError(reason: RuntimeHostStartupFailureReason): Error {
+  switch (reason) {
+    case 'stored_data_incompatible':
+      return new RuntimeHostStartupError(
+        reason,
+        'Maka cannot read part of this workspace’s stored data. The workspace was left in place. Update Maka or report diagnostic code STORED_DATA_INCOMPATIBLE.',
+      );
+    case 'migration_blocked':
+      return new RuntimeHostStartupError(
+        reason,
+        'Maka cannot migrate this workspace safely. Open it with the Maka version that last used it, then repair or export the workspace. Diagnostic code: MIGRATION_BLOCKED.',
+      );
+    case 'storage_unavailable':
+      return new RuntimeHostStartupError(
+        reason,
+        'Maka cannot access this workspace storage. Check disk space, filesystem permissions, and storage health. Diagnostic code: STORAGE_UNAVAILABLE.',
+      );
+    case 'internal_startup_failure':
+      return new RuntimeHostStartupError(
+        reason,
+        'Runtime Host failed while recovering this workspace. Restarting it automatically is unlikely to help. Report diagnostic code INTERNAL_STARTUP_FAILURE.',
+      );
+    case 'composition_mismatch':
+      return new RuntimeHostStartupError(
+        reason,
+        'This workspace belongs to a different Runtime Host composition. Diagnostic code: COMPOSITION_MISMATCH.',
+      );
+    case 'startup_timeout':
+      return new Error('Runtime Host did not become ready before the startup deadline');
+    case 'host_unresponsive':
+      return new Error('Runtime Host stopped responding during startup');
+  }
+}

--- a/packages/runtime-host/src/client/startup-error.ts
+++ b/packages/runtime-host/src/client/startup-error.ts
@@ -11,7 +11,7 @@ export class RuntimeHostStartupError extends RuntimeHostPermanentReconnectError 
   readonly name = 'RuntimeHostStartupError';
 
   constructor(
-    readonly reason: CandidateStartupFailureReason | 'composition_mismatch',
+    readonly reason: 'stored_data_incompatible' | 'composition_mismatch',
     message: string,
   ) {
     super(message);
@@ -25,20 +25,13 @@ export function runtimeHostStartupError(reason: RuntimeHostStartupFailureReason)
         reason,
         'Maka cannot read part of this workspace’s stored data. The workspace was left in place. Update Maka or report diagnostic code STORED_DATA_INCOMPATIBLE.',
       );
-    case 'migration_blocked':
-      return new RuntimeHostStartupError(
-        reason,
-        'Maka cannot migrate this workspace safely. Open it with the Maka version that last used it, then repair or export the workspace. Diagnostic code: MIGRATION_BLOCKED.',
-      );
     case 'storage_unavailable':
-      return new RuntimeHostStartupError(
-        reason,
+      return new Error(
         'Maka cannot access this workspace storage. Check disk space, filesystem permissions, and storage health. Diagnostic code: STORAGE_UNAVAILABLE.',
       );
     case 'internal_startup_failure':
-      return new RuntimeHostStartupError(
-        reason,
-        'Runtime Host failed while recovering this workspace. Restarting it automatically is unlikely to help. Report diagnostic code INTERNAL_STARTUP_FAILURE.',
+      return new Error(
+        'Runtime Host failed while recovering this workspace. Try again; if the problem persists, report diagnostic code INTERNAL_STARTUP_FAILURE.',
       );
     case 'composition_mismatch':
       return new RuntimeHostStartupError(

--- a/packages/runtime-host/src/execution-candidate-main.ts
+++ b/packages/runtime-host/src/execution-candidate-main.ts
@@ -3,11 +3,21 @@ import { parseInteractiveRuntimeHostCandidateArguments } from './candidate-cli.j
 import { startExecutionRuntimeHostCandidate } from './server/execution-candidate.js';
 import { runRuntimeHostProcessLifecycle } from './server/process-lifecycle.js';
 import { installRuntimeHostLogCapture } from './process-diagnostics.js';
+import {
+  candidateStartupFailureExitCode,
+  classifyCandidateStartupFailure,
+} from './candidate-startup-failure.js';
 
 installRuntimeHostLogCapture();
 
-const options = parseInteractiveRuntimeHostCandidateArguments(process.argv.slice(2));
-const result = await startExecutionRuntimeHostCandidate(options);
+let result: Awaited<ReturnType<typeof startExecutionRuntimeHostCandidate>>;
+try {
+  const options = parseInteractiveRuntimeHostCandidateArguments(process.argv.slice(2));
+  result = await startExecutionRuntimeHostCandidate(options);
+} catch (error) {
+  console.error('[runtime-host] startup failed:', error);
+  process.exit(candidateStartupFailureExitCode(classifyCandidateStartupFailure(error)));
+}
 if (result.kind === 'loser') process.exit(2);
 
 try {

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -228,7 +228,11 @@ export class RuntimeHostKernel {
           try {
             await host.closed;
           } catch (shutdownError) {
-            throw shutdownError;
+            throw new AggregateError(
+              [error, shutdownError],
+              'Runtime Host startup failed and shutdown did not complete cleanly',
+              { cause: error },
+            );
           }
         } else {
           await host.#abortStartup();

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -22,6 +22,7 @@ import {
   SessionMetadataConflictError,
   SessionMetadataVersionConflictError,
   SQLITE_SESSION_METADATA_SCHEMA_VERSION,
+  StoredSessionMessageIncompatibleError,
   type SqliteSessionMetadataStoreFailpoint,
 } from '../sqlite-session-metadata-store.js';
 import {
@@ -31,6 +32,57 @@ import {
 import { SQLITE_AGENT_GRAPH_CONTROL_TABLES } from '../sqlite-session-metadata-schema.js';
 
 describe('SqliteSessionMetadataStore', () => {
+  test('identifies an incompatible persisted message without exposing its content', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-message-incompatible-'));
+    const path = join(root, 'state.sqlite');
+    try {
+      const setup = createSqliteSessionMetadataStore(path);
+      await setup.create(fullHeader());
+      setup.close();
+
+      const database = new DatabaseSync(path);
+      database
+        .prepare(`
+          INSERT INTO session_messages(
+            session_id, sequence, message_id, message_type, message_ts, record_json
+          ) VALUES (?, ?, ?, ?, ?, ?)
+        `)
+        .run(
+          'session-1',
+          104,
+          'message-legacy',
+          'user',
+          5,
+          JSON.stringify({
+            type: 'user',
+            id: 'message-legacy',
+            turnId: 'turn-legacy',
+            ts: 5,
+            text: 'private message text',
+            origin: { kind: 'automation', automationId: 'legacy-automation' },
+          }),
+        );
+      database.close();
+
+      const store = createSqliteSessionMetadataStore(path);
+      try {
+        await assert.rejects(
+          () => store.readMessagesForRecovery('session-1'),
+          (error: unknown) =>
+            error instanceof StoredSessionMessageIncompatibleError &&
+            error.code === 'stored_session_message_incompatible' &&
+            error.sessionId === 'session-1' &&
+            error.sequence === 104 &&
+            !error.message.includes('private message text'),
+        );
+      } finally {
+        store.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('round-trips every SessionHeader field and reopens the same schema', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-metadata-'));
     const path = join(root, 'state.sqlite');

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -250,6 +250,19 @@ export class SessionMetadataConflictError extends Error {
   readonly name: string = 'SessionMetadataConflictError';
 }
 
+export class StoredSessionMessageIncompatibleError extends Error {
+  readonly name = 'StoredSessionMessageIncompatibleError';
+  readonly code = 'stored_session_message_incompatible';
+
+  constructor(
+    readonly sessionId: string,
+    readonly sequence: number,
+    options?: ErrorOptions,
+  ) {
+    super(`Stored Session message ${sequence} for ${sessionId} is incompatible`, options);
+  }
+}
+
 export class SessionMetadataVersionConflictError extends SessionMetadataConflictError {
   readonly name = 'SessionMetadataVersionConflictError';
 
@@ -1395,17 +1408,15 @@ export class SqliteSessionMetadataStore {
     const rows = this.db
       .prepare(
         `
-        SELECT record_json
+        SELECT sequence, record_json
         FROM session_messages
         WHERE session_id = ?
         ORDER BY sequence DESC
         LIMIT ?
       `,
       )
-      .all(sessionId, limit) as Array<{ record_json?: unknown }>;
-    return rows
-      .reverse()
-      .map((row, index) => decodeStoredMessageRow(row.record_json, sessionId, index));
+      .all(sessionId, limit) as Array<{ sequence?: unknown; record_json?: unknown }>;
+    return rows.reverse().map((row) => decodeStoredMessageRow(row, sessionId));
   }
 
   async beginCatalogProjectionWrite(): Promise<void> {
@@ -3253,21 +3264,22 @@ export class SqliteSessionMetadataStore {
     const rows = this.db
       .prepare(
         `
-        SELECT record_json
+        SELECT sequence, record_json
         FROM session_messages
         WHERE session_id = ?
         ORDER BY sequence
       `,
       )
-      .all(sessionId) as Array<{ record_json?: unknown }>;
-    return rows.map((row, index) => {
+      .all(sessionId) as Array<{ sequence?: unknown; record_json?: unknown }>;
+    return rows.map((row) => {
+      const sequence = requireStoredMessageSequence(row.sequence, sessionId);
       if (typeof row.record_json !== 'string') {
-        throw new Error(`Invalid Session message row ${index} for ${sessionId}`);
+        throw new StoredSessionMessageIncompatibleError(sessionId, sequence);
       }
       try {
         return decode(JSON.parse(row.record_json) as unknown);
       } catch (error) {
-        throw new Error(`Invalid Session message row ${index} for ${sessionId}`, { cause: error });
+        throw new StoredSessionMessageIncompatibleError(sessionId, sequence, { cause: error });
       }
     });
   }
@@ -4569,16 +4581,27 @@ function assertGraphIntentId(value: string): void {
   }
 }
 
-function decodeStoredMessageRow(value: unknown, sessionId: string, index: number): StoredMessage {
-  if (typeof value !== 'string') {
-    throw new Error(`Invalid Session message row ${index} for ${sessionId}`);
+function decodeStoredMessageRow(
+  row: { sequence?: unknown; record_json?: unknown },
+  sessionId: string,
+): StoredMessage {
+  const sequence = requireStoredMessageSequence(row.sequence, sessionId);
+  if (typeof row.record_json !== 'string') {
+    throw new StoredSessionMessageIncompatibleError(sessionId, sequence);
   }
   try {
-    const parsed = JSON.parse(value) as unknown;
+    const parsed = JSON.parse(row.record_json) as unknown;
     return decodeStoredMessage(parsed);
   } catch (error) {
-    throw new Error(`Invalid Session message row ${index} for ${sessionId}`, {
+    throw new StoredSessionMessageIncompatibleError(sessionId, sequence, {
       cause: error,
     });
   }
+}
+
+function requireStoredMessageSequence(value: unknown, sessionId: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new StoredSessionMessageIncompatibleError(sessionId, -1);
+  }
+  return value as number;
 }


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Runtime Host recovery failures could be hidden by shutdown errors, while Candidate election exposed the temporary `host_draining` state to Desktop, TUI, and CLI. This made an incompatible stored record look like a generic startup failure.

This change preserves the primary recovery error, carries a bounded non-sensitive failure reason through Candidate exit and election, and presents an actionable shared startup message. It does not migrate or accept incompatible stored records; that remains separate migration work.

## Verification

- Reproduced with a real SQLite workspace containing an incompatible persisted message; election returned `{"kind":"failed","reason":"stored_data_incompatible"}`
- `npm test -w @maka/storage`
- `npm run build -w @maka/runtime-host` and the full Runtime Host test suite
- Typechecks for Storage, Runtime Host, Desktop, and CLI
- Biome check for all changed files and `git diff --check`

## AI disclosure

OpenAI Codex assisted with the implementation and verification. I reviewed the resulting changes and confirm this submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 摘要

Runtime Host 的恢复错误可能被 shutdown 错误掩盖，同时 Candidate election 会把临时的 `host_draining` 状态暴露给 Desktop、TUI 和 CLI，导致不兼容的持久化记录最终只显示为模糊的启动失败。

本次变更保留首要恢复错误，通过 Candidate 退出和 election 传递有界且不包含敏感信息的失败分类，并统一显示可操作的启动提示。它不会迁移或接受不兼容的持久化记录；相关兼容工作仍由独立变更负责。

## 验证

- 使用包含不兼容持久化消息的真实 SQLite 工作区复现；election 返回 `{"kind":"failed","reason":"stored_data_incompatible"}`
- `npm test -w @maka/storage`
- `npm run build -w @maka/runtime-host` 及 Runtime Host 全量测试
- Storage、Runtime Host、Desktop 和 CLI typecheck
- 所有变更文件的 Biome check 与 `git diff --check`

## AI 披露

OpenAI Codex 协助了实现与验证。我已人工审核最终变更，并确认提交此 PR。

## 检查清单

- [x] 测试覆盖该变更，且在修复前会失败
- [x] lint、format、typecheck 和受影响测试均在本地通过

此 PR 是否改变行为？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
