### PR TITLE
fix(cli): isolate source development profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,8 @@ Architecture is documented in [ARCHITECTURE.md](./ARCHITECTURE.md).
 npm run dev          # desktop app with HMR
 npm run dev:full     # full build, then launch the desktop app
 
-npm --workspace maka-agent exec -- maka          # TUI
-npm --workspace maka-agent exec -- maka run "…"  # one non-interactive turn
+npm run cli:dev                                  # TUI with the Maka Dev profile
+npm run cli:dev -- run "…"                       # one non-interactive turn
 ```
 
 Evaluation commands and contracts live in [`packages/eval`](./packages/eval).

--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ npm run build
 Then start the TUI or run one Turn:
 
 ```sh
-npm --workspace maka-agent exec -- maka
-npm --workspace maka-agent exec -- maka run "Summarize this repository and identify its most important risk"
-npm --workspace maka-agent exec -- maka run --graph "Implement two independent slices, integrate them, then review the result"
-npm --workspace maka-agent exec -- maka --help
+npm run cli:dev
+npm run cli:dev -- run "Summarize this repository and identify its most important risk"
+npm run cli:dev -- run --graph "Implement two independent slices, integrate them, then review the result"
+npm run cli:dev -- --help
 ```
 
 The TUI also accepts `/graph on`, `/graph off`, and `/graph <task>`. Non-interactive
@@ -135,7 +135,9 @@ The TUI also accepts `/graph on`, `/graph off`, and `/graph <task>`. Non-interac
 supervisor output. Graph implementation operators use isolated Git worktrees, so
 the source project must be a clean Git worktree.
 
-The CLI reads the same model connections and workspace configuration written by Desktop. Evaluation specs and adapters live in [`packages/eval`](./packages/eval).
+The repository CLI uses the same `Maka Dev` profile as a development Desktop build. The
+released `maka` binary continues to use the `Maka` profile; the two profiles are not copied or
+synchronized automatically. Evaluation specs and adapters live in [`packages/eval`](./packages/eval).
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:dist:serial": "node scripts/run-workspace-tests-parallel.mjs --serial",
     "dev": "npm --workspace @maka/desktop run dev:hmr --",
     "dev:full": "npm run build && npm --workspace @maka/desktop run start",
+    "cli:dev": "node packages/cli/dist/dev-cli.js",
     "build": "npm --workspace @maka/code-mode run build && npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/mcp run build && npm --workspace @maka/runtime run build && npm --workspace @maka/runtime-host run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/eval run build && npm --workspace maka-agent run build && npm --workspace @maka/ui run build && npm --workspace @maka/desktop run build",
     "build:test": "npm run clean && npm --workspace @maka/code-mode run build && npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/mcp run build && npm --workspace @maka/runtime run build && npm --workspace @maka/runtime-host run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/eval run build && npm --workspace maka-agent run build && npm --workspace @maka/ui run build && npm --workspace @maka/desktop run build:test",
     "clean": "node scripts/clean-build.mjs",

--- a/packages/cli/src/__tests__/cli-invocation.test.ts
+++ b/packages/cli/src/__tests__/cli-invocation.test.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { formatMakaResumeCommand, formatMakaResumeHint } from '../cli-invocation.js';
+
+describe('Maka CLI invocation copy', () => {
+  test('keeps release resume instructions on the release launcher', () => {
+    assert.equal(
+      formatMakaResumeHint('maka', 'session-1'),
+      'Resume this session with:\n  maka --resume session-1',
+    );
+  });
+
+  test('keeps development remote and cwd retries on the development launcher', () => {
+    assert.equal(
+      formatMakaResumeHint('npm run cli:dev --', 'session-2', { hostProfileId: 'office' }),
+      'Resume this session with:\n  npm run cli:dev -- --resume session-2 --host office',
+    );
+    assert.equal(
+      formatMakaResumeCommand('npm run cli:dev --', 'session-2', { cwd: '<new-path>' }),
+      'npm run cli:dev -- --resume session-2 --cwd <new-path>',
+    );
+  });
+});

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,8 +1,13 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { once } from 'node:events';
+import { access, mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { parseMakaCliArgs } from '../cli.js';
+import { fileURLToPath } from 'node:url';
+import { parseMakaCliArgs, runMakaCli } from '../cli.js';
 
 describe('Maka CLI args', () => {
   test('selects a Runtime Host and Project for TUI startup', () => {
@@ -11,6 +16,34 @@ describe('Maka CLI args', () => {
       hostProfileId: 'office',
       projectId: 'project-1',
     });
+  });
+
+  test('uses the active launcher in development help and rejects an empty profile name', async () => {
+    const help = parseMakaCliArgs(['--help'], '0.1.0', 'npm run cli:dev --');
+    assert.equal(help.kind, 'help');
+    if (help.kind === 'help') {
+      assert.match(help.text, /^Usage: npm run cli:dev --$/m);
+      assert.match(
+        help.text,
+        /^  npm run cli:dev -- runtime-host access issue --principal <id> --preset /m,
+      );
+      assert.match(help.text, /^  npm run cli:dev -- runtime-host project list /m);
+      assert.match(
+        help.text,
+        /^  npm run cli:dev -- runtime-host profile set .*--ssh-destination /m,
+      );
+      assert.match(help.text, /^  npm run cli:dev -- runtime-host profile set .*--plaintext-url /m);
+      assert.doesNotMatch(help.text, /^  maka runtime-host /m);
+      assert.doesNotMatch(help.text, /maka-agent/);
+    }
+    await assert.rejects(
+      runMakaCli(['--version'], {
+        dataProfileName: '',
+        cliCommand: 'invalid',
+        capabilityProviderIdentityScope: 'client-data-root',
+      }),
+      /profile name must be a non-empty path segment/,
+    );
   });
 
   test('establishes the fatal exit before reporting can throw', async () => {
@@ -29,4 +62,199 @@ describe('Maka CLI args', () => {
     assert.equal(signal, null);
     assert.equal(code, 1);
   });
+
+  test('compiled release and repository entries isolate profile writes', async (t) => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-cli-launch-profile-'));
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const home = join(root, 'home');
+    const applicationData = join(root, 'application-data');
+    const releaseRoot = platformProfileRoot(home, applicationData, 'Maka');
+    const developmentRoot = platformProfileRoot(home, applicationData, 'Maka Dev');
+    const env = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      APPDATA: applicationData,
+      XDG_CONFIG_HOME: applicationData,
+      MAKA_TEST_RUNTIME_HOST_CREDENTIAL: 'opaque-token',
+    };
+    const profileArgs = [
+      'runtime-host',
+      'profile',
+      'set',
+      '--id',
+      'office',
+      '--name',
+      'Office',
+      '--tls-url',
+      'wss://runtime.example.com/runtime-host',
+      '--expected-root',
+      'a'.repeat(64),
+      '--credential-env',
+      'MAKA_TEST_RUNTIME_HOST_CREDENTIAL',
+    ];
+
+    await mkdir(releaseRoot, { recursive: true });
+    await writeFile(join(releaseRoot, 'sentinel.txt'), 'release-data\n', 'utf8');
+    const development = await runCompiledCli('dev-cli.js', profileArgs, env);
+    assert.equal(development.signal, null);
+    assert.equal(development.code, 0, development.stderr);
+    await assertProfileFiles(developmentRoot);
+    assert.deepEqual(await readdir(releaseRoot), ['sentinel.txt']);
+    assert.equal(await readFile(join(releaseRoot, 'sentinel.txt'), 'utf8'), 'release-data\n');
+    await assert.rejects(access(join(developmentRoot, 'sentinel.txt')), { code: 'ENOENT' });
+
+    const developmentProfile = await readFile(
+      join(developmentRoot, 'runtime-host-profiles.json'),
+      'utf8',
+    );
+    const release = await runCompiledCli('cli.js', profileArgs, env);
+    assert.equal(release.signal, null);
+    assert.equal(release.code, 0, release.stderr);
+    await assertProfileFiles(releaseRoot);
+    assert.equal(
+      await readFile(join(developmentRoot, 'runtime-host-profiles.json'), 'utf8'),
+      developmentProfile,
+    );
+    assert.equal(await readFile(join(releaseRoot, 'sentinel.txt'), 'utf8'), 'release-data\n');
+  });
+
+  test('compiled launchers isolate capability-provider identities', async (t) => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-cli-provider-identity-'));
+    t.after(() => rm(root, { recursive: true, force: true }));
+    const home = join(root, 'home');
+    const applicationData = join(root, 'application-data');
+    const releaseRoot = platformProfileRoot(home, applicationData, 'Maka');
+    const developmentRoot = platformProfileRoot(home, applicationData, 'Maka Dev');
+    const configPath = join(root, 'mcp.json');
+    const url = 'https://invalid.example/runtime-host';
+    const identityFile = providerIdentityFileName(url, configPath);
+    const developmentIdentityPath = join(
+      developmentRoot,
+      'runtime-host-capability-providers',
+      identityFile,
+    );
+    const releaseIdentityPath = join(
+      home,
+      '.maka',
+      'runtime-host-capability-providers',
+      identityFile,
+    );
+    const releaseProfileIdentityPath = join(
+      releaseRoot,
+      'runtime-host-capability-providers',
+      identityFile,
+    );
+    const explicitUrl = 'https://explicit.invalid/runtime-host';
+    const explicitDefaultIdentityPath = join(
+      developmentRoot,
+      'runtime-host-capability-providers',
+      providerIdentityFileName(explicitUrl, configPath),
+    );
+    const explicitIdentityPath = join(root, 'explicit-provider-identity.json');
+    const env = {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      APPDATA: applicationData,
+      XDG_CONFIG_HOME: applicationData,
+      MAKA_TEST_RUNTIME_HOST_CREDENTIAL: 'opaque-token',
+    };
+    await writeFile(configPath, '{"mcpServers": {}}\n', 'utf8');
+    const providerArgs = [
+      'runtime-host',
+      'capability-provider',
+      'serve',
+      '--url',
+      url,
+      '--mcp-config',
+      configPath,
+      '--expected-root',
+      'b'.repeat(64),
+      '--credential-env',
+      'MAKA_TEST_RUNTIME_HOST_CREDENTIAL',
+    ];
+
+    const development = await runCompiledCli('dev-cli.js', providerArgs, env);
+    assert.equal(development.signal, null);
+    assert.equal(development.code, 1);
+    const developmentIdentity = await readClientInstanceId(developmentIdentityPath);
+    await assert.rejects(access(releaseIdentityPath), { code: 'ENOENT' });
+
+    const release = await runCompiledCli('cli.js', providerArgs, env);
+    assert.equal(release.signal, null);
+    assert.equal(release.code, 1);
+    const releaseIdentity = await readClientInstanceId(releaseIdentityPath);
+    assert.notEqual(releaseIdentity, developmentIdentity);
+    await assert.rejects(access(releaseProfileIdentityPath), { code: 'ENOENT' });
+
+    const developmentIdentityBeforeOverride = await readFile(developmentIdentityPath, 'utf8');
+    const explicitProviderArgs = providerArgs.map((arg) => (arg === url ? explicitUrl : arg));
+    const explicit = await runCompiledCli(
+      'dev-cli.js',
+      [...explicitProviderArgs, '--client-identity', explicitIdentityPath],
+      env,
+    );
+    assert.equal(explicit.signal, null);
+    assert.equal(explicit.code, 1);
+    const explicitIdentity = await readClientInstanceId(explicitIdentityPath);
+    assert.notEqual(explicitIdentity, developmentIdentity);
+    assert.notEqual(explicitIdentity, releaseIdentity);
+    await assert.rejects(access(explicitDefaultIdentityPath), { code: 'ENOENT' });
+    assert.equal(
+      await readFile(developmentIdentityPath, 'utf8'),
+      developmentIdentityBeforeOverride,
+    );
+  });
 });
+
+async function runCompiledCli(
+  entrypoint: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stderr: string }> {
+  const child = spawn(
+    process.execPath,
+    [fileURLToPath(new URL(`../${entrypoint}`, import.meta.url)), ...args],
+    { env, stdio: ['ignore', 'ignore', 'pipe'], timeout: 15_000, killSignal: 'SIGKILL' },
+  );
+  let stderr = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => {
+    stderr += chunk;
+  });
+  const [code, signal] = (await once(child, 'close')) as [number | null, NodeJS.Signals | null];
+  return { code, signal, stderr };
+}
+
+function platformProfileRoot(home: string, applicationData: string, profileName: string): string {
+  if (process.platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', profileName);
+  }
+  return join(applicationData, profileName);
+}
+
+async function assertProfileFiles(root: string): Promise<void> {
+  await access(join(root, 'runtime-host-profiles.json'));
+  await access(join(root, 'runtime-host-client', 'credentials.json'));
+}
+
+function providerIdentityFileName(url: string, configPath: string): string {
+  const identity = createHash('sha256')
+    .update(`runtime-host-capability-provider\0${url}\0${configPath}`)
+    .digest('hex')
+    .slice(0, 24);
+  return `${identity}.json`;
+}
+
+async function readClientInstanceId(path: string): Promise<string> {
+  const document = JSON.parse(await readFile(path, 'utf8')) as {
+    schemaVersion?: unknown;
+    clientInstanceId?: unknown;
+  };
+  assert.equal(document.schemaVersion, 1);
+  if (typeof document.clientInstanceId !== 'string') {
+    assert.fail('Expected a persisted Client instance id');
+  }
+  return document.clientInstanceId;
+}

--- a/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
@@ -1,9 +1,12 @@
 import assert from 'node:assert/strict';
-import { basename } from 'node:path';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import {
   connectRemoteRuntimeHostProfile,
+  createClientRuntimeHostProfileCatalog,
   RuntimeHostStartupError,
   type RuntimeHostConnection,
 } from '@maka/runtime-host/client';
@@ -189,6 +192,64 @@ test('remote CLI profiles pin root identity and resolve credential outside the p
   assert.equal(remoteInput?.credential, 'opaque-token');
   assert.equal(remoteInput?.clientInstanceId, '11111111-1111-4111-8111-111111111111');
   assert.equal(Object.hasOwn(context.profile, 'credential'), false);
+  await context.close();
+});
+
+test('remote CLI profile state and Client identity use the explicit Client Data Root', async (t) => {
+  const clientDataRoot = await mkdtemp(join(tmpdir(), 'maka-cli-client-root-'));
+  t.after(() => rm(clientDataRoot, { recursive: true, force: true }));
+  const rootId = 'b'.repeat(64);
+  await createClientRuntimeHostProfileCatalog(clientDataRoot).save(
+    {
+      id: 'office',
+      name: 'Office',
+      kind: 'remote',
+      transport: { kind: 'tls', url: 'wss://runtime.example.com/runtime-host' },
+      rootId,
+    },
+    'opaque-token',
+  );
+  let identityPath: string | undefined;
+  let credential: string | undefined;
+  const connection = {
+    rootId,
+    hostEpoch: 'host-remote',
+    connectionId: 'connection-remote',
+    selectedProtocol: 0,
+    closed: new Promise<void>(() => {}),
+    status: async () => ({ state: 'ready' }),
+    subscribeConfigurationChanges: () => () => {},
+    subscribeProjectCatalogChanges: () => () => {},
+    subscribeSessionCatalogChanges: () => () => {},
+    subscribeScheduledTaskChanges: () => () => {},
+    close: async () => {},
+  } as unknown as RuntimeHostConnection;
+
+  const context = await connectRuntimeHostCli(
+    {
+      rootPath: '/unused-local-root',
+      clientDataRoot,
+      surface: 'run',
+      profileId: 'office',
+    },
+    {
+      connectOrSpawn: async () => {
+        throw new Error('remote profile must not use local discovery');
+      },
+      connectRemoteProfile: async (input) => {
+        credential = input.credential;
+        return connection;
+      },
+      loadClientInstanceId: async (path) => {
+        identityPath = path;
+        return '22222222-2222-4222-8222-222222222222';
+      },
+      readConnectionCatalog: async () => ({ revision: 1, defaultTarget: null, connections: [] }),
+    },
+  );
+
+  assert.equal(credential, 'opaque-token');
+  assert.equal(identityPath, join(clientDataRoot, 'runtime-host-client.json'));
   await context.close();
 });
 

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -43,15 +43,18 @@ describe('Runtime Host maka run adapter', () => {
           return publicCommandContext(input);
         },
       },
+      { clientDataRoot: '/client-data', cliCommand: 'npm run cli:dev --' },
     );
 
     assert.equal(exitCode, 2);
     assert.equal(contextCreations, 0);
     assert.match(stderr.join(''), /model_connection_disabled/);
-    assert.match(stderr.join(''), /repair connection "openai-main" in `maka`/);
+    assert.match(stderr.join(''), /repair connection "openai-main" in `npm run cli:dev --`/);
   });
 
-  test('routes a remote run through the selected Host profile and canonical Project', async () => {
+  test('routes both launch roots through the selected Host profile and canonical Project', async () => {
+    let selectedWorkspaceRoot: string | undefined;
+    let selectedClientDataRoot: string | undefined;
     let selectedProfile: string | undefined;
     let contextInput: MakaRunContextInput | undefined;
     const connection = remoteReadinessConnection();
@@ -68,7 +71,9 @@ describe('Runtime Host maka run adapter', () => {
         newId: () => 'turn-remote',
       },
       {
-        connect: async (_rootPath, profileId) => {
+        connect: async (rootPath, profileId, clientDataRoot) => {
+          selectedWorkspaceRoot = rootPath;
+          selectedClientDataRoot = clientDataRoot;
           selectedProfile = profileId;
           return {
             connection,
@@ -88,9 +93,12 @@ describe('Runtime Host maka run adapter', () => {
           return publicCommandContext(input);
         },
       },
+      { clientDataRoot: '/client-data', cliCommand: 'npm run cli:dev --' },
     );
 
     assert.equal(exitCode, 0);
+    assert.equal(selectedWorkspaceRoot, '/runtime-host-data');
+    assert.equal(selectedClientDataRoot, '/client-data');
     assert.equal(selectedProfile, 'office');
     assert.equal(contextInput?.projectId, 'project-1');
   });

--- a/packages/cli/src/cli-invocation.ts
+++ b/packages/cli/src/cli-invocation.ts
@@ -1,0 +1,25 @@
+export interface MakaResumeCommandOptions {
+  readonly cwd?: string;
+  readonly hostProfileId?: string;
+}
+
+export function formatMakaResumeCommand(
+  cliCommand: string,
+  sessionId: string,
+  options: MakaResumeCommandOptions = {},
+): string {
+  return [
+    `${cliCommand} --resume ${sessionId}`,
+    ...(options.cwd ? ['--cwd', options.cwd] : []),
+    ...(options.hostProfileId ? ['--host', options.hostProfileId] : []),
+  ].join(' ');
+}
+
+export function formatMakaResumeHint(
+  cliCommand: string,
+  sessionId: string | null,
+  options: MakaResumeCommandOptions = {},
+): string | null {
+  if (!sessionId) return null;
+  return `Resume this session with:\n  ${formatMakaResumeCommand(cliCommand, sessionId, options)}`;
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,8 +2,10 @@
 
 import { readFile } from 'node:fs/promises';
 import { realpathSync } from 'node:fs';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { resolveMakaWorkspaceRoot } from './workspace-root.js';
+import { formatMakaResumeHint } from './cli-invocation.js';
+import { resolveMakaDataRoots } from './workspace-root.js';
 import { parseRuntimeHostCommand, type RuntimeHostCliCommand } from './runtime-host-cli.js';
 
 export type MakaCliCommand =
@@ -22,10 +24,26 @@ export type MakaCliCommand =
   | { kind: 'version'; text: string }
   | { kind: 'error'; message: string; exitCode: number };
 
-export function parseMakaCliArgs(argv: string[], version: string): MakaCliCommand {
+export interface MakaCliLaunchOptions {
+  readonly dataProfileName: string;
+  readonly cliCommand: string;
+  readonly capabilityProviderIdentityScope: 'legacy-home' | 'client-data-root';
+}
+
+const RELEASE_MAKA_CLI_LAUNCH_OPTIONS = {
+  dataProfileName: 'Maka',
+  cliCommand: 'maka',
+  capabilityProviderIdentityScope: 'legacy-home',
+} satisfies MakaCliLaunchOptions;
+
+export function parseMakaCliArgs(
+  argv: string[],
+  version: string,
+  cliCommand = RELEASE_MAKA_CLI_LAUNCH_OPTIONS.cliCommand,
+): MakaCliCommand {
   if (argv.length === 0) return { kind: 'tui' };
   const [first] = argv;
-  if (first === '--help' || first === '-h') return { kind: 'help', text: helpText() };
+  if (first === '--help' || first === '-h') return { kind: 'help', text: helpText(cliCommand) };
   if (first === '--version' || first === '-v') return { kind: 'version', text: version };
   if (first?.startsWith('--')) return parseTuiArgs(argv);
   if (first === 'run' || first === '-p') return { kind: 'run', args: argv.slice(1) };
@@ -71,32 +89,32 @@ export function handleMakaCliProcessExit(
   if (error) writeFatal(`${formatMakaCliFatalError(error)}\n`);
 }
 
-function helpText(): string {
+function helpText(cliCommand: string): string {
   return [
-    'Usage: maka',
+    `Usage: ${cliCommand}`,
     '',
     'Launches the Maka terminal UI in the current working directory.',
     '',
     'Commands:',
-    '  maka              Start the TUI',
-    '  maka-agent        Start the TUI',
-    '  maka run ...      Run one non-interactive model turn',
-    '  maka activate ... Run one Cloud Session activation and emit JSONL',
-    '  maka -p ...       Alias for maka run',
-    '  maka eval ...     Run one declarative multi-arm experiment',
-    '  maka runtime-host serve [options]  Run a Runtime Host service',
-    '  maka runtime-host access issue --principal <id> --grant <operation>',
-    '  maka runtime-host access issue --principal <id> --preset <desktop-client|terminal-client>',
-    '  maka runtime-host access issue --kind capability-provider --principal <id>',
-    '  maka runtime-host access revoke --credential <id>',
-    '  maka runtime-host project list [--root <path>]',
-    '  maka runtime-host project add <path> [--root <path>]',
-    '  maka runtime-host profile list',
-    '  maka runtime-host profile set --id <id> --name <name> --tls-url <wss-url> --expected-root <root-id> [--credential-env <name>]',
-    '  maka runtime-host profile set --id <id> --name <name> --ssh-destination <user@host> --ssh-remote-port <port> --expected-root <root-id> [--ssh-port <port>] [--credential-env <name>]',
-    '  maka runtime-host profile set --id <id> --name <name> --plaintext-url <ws-url> --acknowledge-plaintext --expected-root <root-id> [--credential-env <name>]',
-    '  maka runtime-host profile remove --id <id>',
-    '  maka runtime-host capability-provider serve --url <ws-url> --mcp-config <path> --expected-root <root-id>',
+    `  ${cliCommand}              Start the TUI`,
+    ...(cliCommand === 'maka' ? ['  maka-agent        Start the TUI'] : []),
+    `  ${cliCommand} run ...      Run one non-interactive model turn`,
+    `  ${cliCommand} activate ... Run one Cloud Session activation and emit JSONL`,
+    `  ${cliCommand} -p ...       Alias for ${cliCommand} run`,
+    `  ${cliCommand} eval ...     Run one declarative multi-arm experiment`,
+    `  ${cliCommand} runtime-host serve [options]  Run a Runtime Host service`,
+    `  ${cliCommand} runtime-host access issue --principal <id> --grant <operation>`,
+    `  ${cliCommand} runtime-host access issue --principal <id> --preset <desktop-client|terminal-client>`,
+    `  ${cliCommand} runtime-host access issue --kind capability-provider --principal <id>`,
+    `  ${cliCommand} runtime-host access revoke --credential <id>`,
+    `  ${cliCommand} runtime-host project list [--root <path>]`,
+    `  ${cliCommand} runtime-host project add <path> [--root <path>]`,
+    `  ${cliCommand} runtime-host profile list`,
+    `  ${cliCommand} runtime-host profile set --id <id> --name <name> --tls-url <wss-url> --expected-root <root-id> [--credential-env <name>]`,
+    `  ${cliCommand} runtime-host profile set --id <id> --name <name> --ssh-destination <user@host> --ssh-remote-port <port> --expected-root <root-id> [--ssh-port <port>] [--credential-env <name>]`,
+    `  ${cliCommand} runtime-host profile set --id <id> --name <name> --plaintext-url <ws-url> --acknowledge-plaintext --expected-root <root-id> [--credential-env <name>]`,
+    `  ${cliCommand} runtime-host profile remove --id <id>`,
+    `  ${cliCommand} runtime-host capability-provider serve --url <ws-url> --mcp-config <path> --expected-root <root-id>`,
     '',
     'Options:',
     '  -h, --help        Show help',
@@ -136,18 +154,29 @@ function helpText(): string {
   ].join('\n');
 }
 
-export function formatResumeHint(sessionId: string | null): string | null {
-  if (!sessionId) return null;
-  return `Resume this session with:\n  maka --resume ${sessionId}`;
+export function formatResumeHint(
+  sessionId: string | null,
+  cliCommand: string = RELEASE_MAKA_CLI_LAUNCH_OPTIONS.cliCommand,
+): string | null {
+  return formatMakaResumeHint(cliCommand, sessionId);
 }
 
-export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promise<number> {
+export async function runMakaCli(
+  argv: string[] = process.argv.slice(2),
+  options: MakaCliLaunchOptions = RELEASE_MAKA_CLI_LAUNCH_OPTIONS,
+): Promise<number> {
   const version = await readPackageVersion();
-  const command = parseMakaCliArgs(argv, version);
+  const command = parseMakaCliArgs(argv, version, options.cliCommand);
+  const dataRoots = resolveMakaDataRoots({ profileName: options.dataProfileName });
   switch (command.kind) {
     case 'run': {
       const { runRuntimeHostTextCli } = await import('./runtime-host-run-command.js');
-      return runRuntimeHostTextCli(command.args);
+      return runRuntimeHostTextCli(
+        command.args,
+        { workspaceRoot: () => dataRoots.workspaceRoot },
+        {},
+        { clientDataRoot: dataRoots.clientDataRoot, cliCommand: options.cliCommand },
+      );
     }
     case 'activate': {
       const { runMakaActivationCli } = await import('./activation-command.js');
@@ -160,7 +189,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
     case 'runtime-host-serve': {
       const { runRuntimeHostServiceCli } = await import('./runtime-host-service-command.js');
       return runRuntimeHostServiceCli({
-        rootPath: command.rootPath ?? resolveMakaWorkspaceRoot(),
+        rootPath: command.rootPath ?? dataRoots.workspaceRoot,
         json: command.json,
         ...(command.websocket ? { websocket: command.websocket } : {}),
       });
@@ -168,7 +197,7 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
     case 'runtime-host-access-issue': {
       const { runRuntimeHostAccessIssueCli } = await import('./runtime-host-access-command.js');
       return runRuntimeHostAccessIssueCli({
-        rootPath: command.rootPath ?? resolveMakaWorkspaceRoot(),
+        rootPath: command.rootPath ?? dataRoots.workspaceRoot,
         principalKind: command.principalKind,
         principalId: command.principalId,
         operationGrants: command.operationGrants,
@@ -180,14 +209,14 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
     case 'runtime-host-access-revoke': {
       const { runRuntimeHostAccessRevokeCli } = await import('./runtime-host-access-command.js');
       return runRuntimeHostAccessRevokeCli({
-        rootPath: command.rootPath ?? resolveMakaWorkspaceRoot(),
+        rootPath: command.rootPath ?? dataRoots.workspaceRoot,
         credentialId: command.credentialId,
       });
     }
     case 'runtime-host-project-list':
     case 'runtime-host-project-add': {
       const { runRuntimeHostProjectCli } = await import('./runtime-host-project-command.js');
-      const rootPath = command.rootPath ?? resolveMakaWorkspaceRoot();
+      const rootPath = command.rootPath ?? dataRoots.workspaceRoot;
       return command.kind === 'runtime-host-project-list'
         ? runRuntimeHostProjectCli({ kind: 'list', rootPath })
         : runRuntimeHostProjectCli({ kind: 'add', rootPath, path: command.path });
@@ -200,6 +229,14 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
         url: command.url,
         mcpConfigPath: command.mcpConfigPath,
         expectedRootId: command.expectedRootId,
+        ...(options.capabilityProviderIdentityScope === 'client-data-root'
+          ? {
+              defaultClientIdentityRoot: join(
+                dataRoots.clientDataRoot,
+                'runtime-host-capability-providers',
+              ),
+            }
+          : {}),
         ...(command.credentialEnv ? { credentialEnv: command.credentialEnv } : {}),
         ...(command.clientIdentityPath ? { clientIdentityPath: command.clientIdentityPath } : {}),
       });
@@ -208,20 +245,25 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
     case 'runtime-host-profile-set':
     case 'runtime-host-profile-remove': {
       const { runRuntimeHostProfileCommand } = await import('./runtime-host-profile-command.js');
+      const profileOptions = { clientDataRoot: dataRoots.clientDataRoot };
       if (command.kind === 'runtime-host-profile-list') {
-        return runRuntimeHostProfileCommand({ kind: 'list' });
+        return runRuntimeHostProfileCommand({ kind: 'list' }, {}, profileOptions);
       }
       if (command.kind === 'runtime-host-profile-remove') {
-        return runRuntimeHostProfileCommand({ kind: 'remove', id: command.id });
+        return runRuntimeHostProfileCommand({ kind: 'remove', id: command.id }, {}, profileOptions);
       }
-      return runRuntimeHostProfileCommand({
-        kind: 'set',
-        id: command.id,
-        name: command.name,
-        transport: command.transport,
-        expectedRootId: command.expectedRootId,
-        ...(command.credentialEnv ? { credentialEnv: command.credentialEnv } : {}),
-      });
+      return runRuntimeHostProfileCommand(
+        {
+          kind: 'set',
+          id: command.id,
+          name: command.name,
+          transport: command.transport,
+          expectedRootId: command.expectedRootId,
+          ...(command.credentialEnv ? { credentialEnv: command.credentialEnv } : {}),
+        },
+        {},
+        profileOptions,
+      );
     }
     case 'help':
       process.stdout.write(`${command.text}\n`);
@@ -230,13 +272,14 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
       process.stdout.write(`${command.text}\n`);
       return 0;
     case 'error':
-      process.stderr.write(`${command.message}\n\n${helpText()}\n`);
+      process.stderr.write(`${command.message}\n\n${helpText(options.cliCommand)}\n`);
       return command.exitCode;
     case 'tui': {
-      const workspaceRoot = resolveMakaWorkspaceRoot();
       const { runRuntimeHostTui } = await import('./runtime-host-tui-command.js');
       return runRuntimeHostTui({
-        workspaceRoot,
+        cliCommand: options.cliCommand,
+        clientDataRoot: dataRoots.clientDataRoot,
+        workspaceRoot: dataRoots.workspaceRoot,
         cwd: process.cwd(),
         onProcessExit: handleMakaCliProcessExit,
         ...(command.resumeSessionId ? { resumeSessionId: command.resumeSessionId } : {}),
@@ -296,8 +339,8 @@ async function readPackageVersion(): Promise<string> {
   return typeof parsed.version === 'string' ? parsed.version : '0.0.0';
 }
 
-if (isMainModule()) {
-  runMakaCli().then(
+export function launchMakaCli(options: MakaCliLaunchOptions): void {
+  runMakaCli(process.argv.slice(2), options).then(
     (code) => {
       beginMakaCliExit(code);
     },
@@ -306,6 +349,8 @@ if (isMainModule()) {
     },
   );
 }
+
+if (isMainModule()) launchMakaCli(RELEASE_MAKA_CLI_LAUNCH_OPTIONS);
 
 // ShellRun escalates SIGTERM to SIGKILL after two seconds. Keep the CLI alive
 // long enough for that cleanup to finish before the final process fallback.

--- a/packages/cli/src/dev-cli.ts
+++ b/packages/cli/src/dev-cli.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+import { launchMakaCli } from './cli.js';
+
+launchMakaCli({
+  dataProfileName: 'Maka Dev',
+  cliCommand: 'npm run cli:dev --',
+  capabilityProviderIdentityScope: 'client-data-root',
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,7 +37,13 @@ export {
   type MakaRunSessionSelectionInput,
 } from './run-session-selection.js';
 export {
+  deriveMakaDataRoots,
+  resolveMakaClientDataRoot,
+  resolveMakaDataRoots,
   resolveMakaWorkspaceRoot,
+  type DeriveMakaDataRootsInput,
+  type MakaDataRoots,
+  type ResolveMakaClientDataRootInput,
   type ResolveMakaWorkspaceRootInput,
 } from './workspace-root.js';
 export {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -108,8 +108,11 @@ import {
   thinkingLevelPickerItems,
   type MakaSlashCommand,
 } from './pi-tui-pickers.js';
+import { formatMakaResumeCommand } from './cli-invocation.js';
 
 export interface MakaPiTuiInput {
+  /** Launcher command used in resume and recovery instructions. */
+  cliCommand?: string;
   title: string;
   driver: MakaSessionDriver;
   cwd: string;
@@ -2846,7 +2849,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         }
         const recoveryHint =
           input.resumeCwd === undefined && message.startsWith('Session cwd no longer exists:')
-            ? ` Retry with: maka --resume ${input.resumeSessionId} --cwd <new-path>.`
+            ? ` Retry with: ${formatMakaResumeCommand(
+                input.cliCommand ?? 'maka',
+                input.resumeSessionId!,
+                { cwd: '<new-path>' },
+              )}.`
             : '';
         state.entries.push({
           kind: 'notice',

--- a/packages/cli/src/run-command-core.ts
+++ b/packages/cli/src/run-command-core.ts
@@ -84,6 +84,7 @@ export interface MakaRunDeps {
   createContext(input: MakaRunContextInput): Promise<MakaRunContext>;
   listSessions(workspaceRoot: string, hostProfileId?: string): Promise<SessionSummary[]>;
   workspaceRoot(): string;
+  cliCommand(): string;
   processCwd(): string;
   stdinIsTTY(): boolean;
   readStdin(): Promise<string>;
@@ -213,11 +214,11 @@ export async function runMakaTextCliCore(
   const deps: MakaRunDeps = { ...defaultMakaRunEnvironmentDeps(), ...adapter, ...overrides };
   const parsed = parseMakaRunArgs(argv);
   if (parsed.kind === 'help') {
-    deps.writeStdout(`${makaRunHelpText()}\n`);
+    deps.writeStdout(`${makaRunHelpText(deps.cliCommand())}\n`);
     return 0;
   }
   if (parsed.kind === 'error') {
-    deps.writeStderr(`maka run: ${parsed.message}\n\n${makaRunHelpText()}\n`);
+    deps.writeStderr(`maka run: ${parsed.message}\n\n${makaRunHelpText(deps.cliCommand())}\n`);
     return 2;
   }
 
@@ -458,10 +459,10 @@ async function canonicalDirectory(input: string): Promise<string> {
   return canonical;
 }
 
-function makaRunHelpText(): string {
+function makaRunHelpText(cliCommand: string): string {
   return [
-    'Usage: maka run [PROMPT] [options]',
-    '       maka -p [PROMPT] [options]',
+    `Usage: ${cliCommand} run [PROMPT] [options]`,
+    `       ${cliCommand} -p [PROMPT] [options]`,
     '',
     'Input:',
     '  -                         Read the complete prompt from stdin',
@@ -487,6 +488,7 @@ function makaRunHelpText(): string {
 function defaultMakaRunEnvironmentDeps(): MakaRunEnvironmentDeps {
   return {
     workspaceRoot: () => resolveMakaWorkspaceRoot(),
+    cliCommand: () => 'maka',
     processCwd: () => process.cwd(),
     stdinIsTTY: () => process.stdin.isTTY === true,
     readStdin: readProcessStdin,

--- a/packages/cli/src/runtime-host-capability-provider-command.ts
+++ b/packages/cli/src/runtime-host-capability-provider-command.ts
@@ -42,6 +42,7 @@ export interface RuntimeHostCapabilityProviderCliOptions {
   readonly expectedRootId: string;
   readonly credentialEnv?: string;
   readonly clientIdentityPath?: string;
+  readonly defaultClientIdentityRoot?: string;
 }
 
 export async function runRuntimeHostCapabilityProviderCli(
@@ -49,7 +50,8 @@ export async function runRuntimeHostCapabilityProviderCli(
 ): Promise<number> {
   const configPath = resolve(options.mcpConfigPath);
   const identityPath = resolve(
-    options.clientIdentityPath ?? defaultProviderClientIdentityPath(options.url, configPath),
+    options.clientIdentityPath ??
+      defaultProviderClientIdentityPath(options.url, configPath, options.defaultClientIdentityRoot),
   );
   const credentialEnv = options.credentialEnv ?? DEFAULT_CREDENTIAL_ENV;
   const credential = process.env[credentialEnv];
@@ -121,12 +123,18 @@ export async function runRuntimeHostCapabilityProviderCli(
   }
 }
 
-function defaultProviderClientIdentityPath(url: string, configPath: string): string {
+function defaultProviderClientIdentityPath(
+  url: string,
+  configPath: string,
+  defaultClientIdentityRoot?: string,
+): string {
   const identity = createHash('sha256')
     .update(`runtime-host-capability-provider\0${url}\0${configPath}`)
     .digest('hex')
     .slice(0, 24);
-  return join(homedir(), '.maka', 'runtime-host-capability-providers', `${identity}.json`);
+  const identityRoot =
+    defaultClientIdentityRoot ?? join(homedir(), '.maka', 'runtime-host-capability-providers');
+  return join(identityRoot, `${identity}.json`);
 }
 
 async function connectRemoteCapabilityProvider(input: {

--- a/packages/cli/src/runtime-host-profile-command.ts
+++ b/packages/cli/src/runtime-host-profile-command.ts
@@ -26,11 +26,16 @@ export interface RuntimeHostProfileCommandDeps {
   readonly write: (value: string) => void;
 }
 
+export interface RuntimeHostProfileCommandOptions {
+  readonly clientDataRoot: string;
+}
+
 export async function runRuntimeHostProfileCommand(
   command: RuntimeHostProfileCommand,
   overrides: Partial<RuntimeHostProfileCommandDeps> = {},
+  options: RuntimeHostProfileCommandOptions = { clientDataRoot: resolveMakaClientDataRoot() },
 ): Promise<number> {
-  const deps = { ...defaultDeps(), ...overrides };
+  const deps = { ...defaultDeps(options.clientDataRoot), ...overrides };
   if (command.kind === 'list') {
     const document = await deps.catalog.read();
     deps.write(`${JSON.stringify([LOCAL_RUNTIME_HOST_PROFILE, ...document.profiles], null, 2)}\n`);
@@ -59,10 +64,9 @@ export async function runRuntimeHostProfileCommand(
   return 0;
 }
 
-function defaultDeps(): RuntimeHostProfileCommandDeps {
-  const root = resolveMakaClientDataRoot();
+function defaultDeps(clientDataRoot: string): RuntimeHostProfileCommandDeps {
   return {
-    catalog: createClientRuntimeHostProfileCatalog(root),
+    catalog: createClientRuntimeHostProfileCatalog(clientDataRoot),
     env: process.env,
     write: (value) => process.stdout.write(value),
   };

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -37,11 +37,16 @@ import {
   isRuntimeHostCliTaskBlocked,
   readRuntimeHostCliTaskReadiness,
 } from './runtime-host-task-readiness.js';
+import { resolveMakaClientDataRoot } from './workspace-root.js';
 
 const GRAPH_POLL_INTERVAL_MS = 25;
 
 export interface RuntimeHostRunCommandDeps {
-  connect(rootPath: string, hostProfileId?: string): Promise<RuntimeHostCliConnectionContext>;
+  connect(
+    rootPath: string,
+    hostProfileId: string | undefined,
+    clientDataRoot: string,
+  ): Promise<RuntimeHostCliConnectionContext>;
   createContext(
     connection: RuntimeHostConnection,
     catalog: RuntimeHostCliConnectionContext['catalog'],
@@ -49,6 +54,11 @@ export interface RuntimeHostRunCommandDeps {
     profile: RuntimeHostProfile,
   ): MakaRunContext | Promise<MakaRunContext>;
   run: typeof runMakaTextCliCore;
+}
+
+export interface RuntimeHostTextCliOptions {
+  readonly cliCommand: string;
+  readonly clientDataRoot: string;
 }
 
 export interface RuntimeHostRunContextDeps {
@@ -61,6 +71,10 @@ export async function runRuntimeHostTextCli(
   argv: readonly string[],
   overrides: Partial<MakaRunEnvironmentDeps> = {},
   commandOverrides: Partial<RuntimeHostRunCommandDeps> = {},
+  options: RuntimeHostTextCliOptions = {
+    cliCommand: 'maka',
+    clientDataRoot: resolveMakaClientDataRoot(),
+  },
 ): Promise<number> {
   const commandDeps = { ...defaultRuntimeHostRunCommandDeps(), ...commandOverrides };
   let connected: RuntimeHostCliConnectionContext | undefined;
@@ -68,7 +82,7 @@ export async function runRuntimeHostTextCli(
     rootPath: string,
     hostProfileId?: string,
   ): Promise<RuntimeHostCliConnectionContext> => {
-    connected ??= await commandDeps.connect(rootPath, hostProfileId);
+    connected ??= await commandDeps.connect(rootPath, hostProfileId, options.clientDataRoot);
     return connected;
   };
   try {
@@ -86,6 +100,7 @@ export async function runRuntimeHostTextCli(
             context.catalog,
             context.profile,
             input,
+            options.cliCommand,
           );
           return commandDeps.createContext(
             context.connection,
@@ -95,7 +110,7 @@ export async function runRuntimeHostTextCli(
           );
         },
       },
-      overrides,
+      { ...overrides, cliCommand: () => options.cliCommand },
     );
   } finally {
     await connected?.close().catch(() => undefined);
@@ -104,11 +119,12 @@ export async function runRuntimeHostTextCli(
 
 function defaultRuntimeHostRunCommandDeps(): RuntimeHostRunCommandDeps {
   return {
-    connect: (rootPath, hostProfileId) =>
+    connect: (rootPath, hostProfileId, clientDataRoot) =>
       connectRuntimeHostCli({
         rootPath,
         surface: 'run',
         ...(hostProfileId ? { profileId: hostProfileId } : {}),
+        clientDataRoot,
       }),
     createContext: (connection, catalog, input) =>
       createRuntimeHostRunContext(connection, catalog, input),
@@ -170,6 +186,7 @@ async function prepareRuntimeHostRunInput(
   catalog: RuntimeHostCliConnectionContext['catalog'],
   profile: RuntimeHostProfile,
   input: Parameters<MakaRunDeps['createContext']>[0],
+  cliCommand: string,
 ): Promise<Parameters<MakaRunDeps['createContext']>[0]> {
   let projectId = input.projectId;
   if (profile.kind === 'remote' && !input.resumeSessionId) {
@@ -194,7 +211,9 @@ async function prepareRuntimeHostRunInput(
     ...(preparedInput.requestedModel ? { model: preparedInput.requestedModel } : {}),
   });
   if (isRuntimeHostCliTaskBlocked(snapshot)) {
-    throw new Error(`Task is not ready:\n${formatRuntimeHostCliTaskBlockers(snapshot)}`);
+    throw new Error(
+      `Task is not ready:\n${formatRuntimeHostCliTaskBlockers(snapshot, cliCommand)}`,
+    );
   }
   return preparedInput;
 }

--- a/packages/cli/src/runtime-host-task-readiness.ts
+++ b/packages/cli/src/runtime-host-task-readiness.ts
@@ -50,10 +50,11 @@ export function isRuntimeHostCliTaskBlocked(snapshot: TaskSubmissionReadinessSna
 
 export function formatRuntimeHostCliTaskBlockers(
   snapshot: TaskSubmissionReadinessSnapshot,
+  cliCommand = 'maka',
 ): string {
   return snapshot.blockers
     .filter((blocker) => blocker.state !== 'unknown')
-    .map((blocker) => `${blocker.blockerCode ?? blocker.id}: ${repairHint(blocker)}`)
+    .map((blocker) => `${blocker.blockerCode ?? blocker.id}: ${repairHint(blocker, cliCommand)}`)
     .join('\n');
 }
 
@@ -126,14 +127,14 @@ async function inspectWorkspace(
   }
 }
 
-function repairHint(blocker: TaskSubmissionReadinessDimension): string {
+function repairHint(blocker: TaskSubmissionReadinessDimension, cliCommand: string): string {
   const target = blocker.repairTarget;
   if (!target) return 'retry the command';
   switch (target.kind) {
     case 'provider_catalog':
-      return 'run `maka` to configure a model provider';
+      return `run \`${cliCommand}\` to configure a model provider`;
     case 'connection':
-      return `repair connection "${target.connectionSlug}" in \`maka\``;
+      return `repair connection "${target.connectionSlug}" in \`${cliCommand}\``;
     case 'models':
       return 'choose an available connection with `--connection`';
     case 'runtime_restart':

--- a/packages/cli/src/runtime-host-tui-command.ts
+++ b/packages/cli/src/runtime-host-tui-command.ts
@@ -3,6 +3,7 @@ import { createInterface } from 'node:readline/promises';
 import { SessionActivityRegistry } from '@maka/runtime/goal-turn-lifecycle';
 import { readRuntimeHostConnectionCatalog } from '@maka/runtime-host/client';
 import { createForeignSessionStore } from '@maka/storage';
+import { formatMakaResumeHint } from './cli-invocation.js';
 import { connectRuntimeHostCli, RuntimeHostCliConflictError } from './runtime-host-cli-context.js';
 import { createRuntimeHostOnboardingSurface } from './runtime-host-onboarding.js';
 import type { MakaPiTuiTurnActivitySurface } from './pi-tui-contracts.js';
@@ -11,6 +12,8 @@ import { createRuntimeHostTuiContext } from './runtime-host-tui-context.js';
 import type { MakaSessionDriver } from './session-driver.js';
 
 export interface RunRuntimeHostTuiInput {
+  readonly cliCommand: string;
+  readonly clientDataRoot: string;
   readonly workspaceRoot: string;
   readonly cwd: string;
   readonly resumeSessionId?: string;
@@ -23,6 +26,7 @@ export interface RunRuntimeHostTuiInput {
 export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<number> {
   const foreignSessions = createForeignSessionStore();
   const contextInput = {
+    clientDataRoot: input.clientDataRoot,
     rootPath: input.workspaceRoot,
     cwd: input.cwd,
     ...(input.resumeSessionId ? { resumeSessionId: input.resumeSessionId } : {}),
@@ -36,6 +40,7 @@ export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<
   } catch (error) {
     if (!isMissingDefaultConnection(error) || input.resumeSessionId) throw error;
     const configured = await runFirstRunOnboarding(
+      input.clientDataRoot,
       input.workspaceRoot,
       input.cwd,
       input.hostProfileId,
@@ -70,6 +75,7 @@ export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<
       subscribeShellRunUpdates: (listener) => context.driver.subscribeShellRunUpdates(listener),
       listShellRunUpdates: (sessionId) => context.driver.listShellRunUpdates(sessionId),
       onProcessExit: input.onProcessExit,
+      cliCommand: input.cliCommand,
       resumeSessionId: input.resumeSessionId,
       resumeCwd: input.resumeCwd,
       ...(context.profile.kind === 'remote' && input.resumeSessionId
@@ -77,12 +83,10 @@ export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<
         : {}),
     });
     const sessionId = context.driver.getSessionId();
-    if (sessionId)
-      process.stdout.write(
-        `Resume this session with:\n  maka --resume ${sessionId}${
-          context.profile.kind === 'remote' ? ` --host ${context.profile.id}` : ''
-        }\n`,
-      );
+    const hint = formatMakaResumeHint(input.cliCommand, sessionId, {
+      ...(context.profile.kind === 'remote' ? { hostProfileId: context.profile.id } : {}),
+    });
+    if (hint) process.stdout.write(`${hint}\n`);
     return 0;
   } finally {
     await context.close();
@@ -123,11 +127,13 @@ function waitForHostRetry(): Promise<void> {
 }
 
 async function runFirstRunOnboarding(
+  clientDataRoot: string,
   rootPath: string,
   cwd: string,
   hostProfileId?: string,
 ): Promise<boolean> {
   const connected = await connectRuntimeHostCli({
+    clientDataRoot,
     rootPath,
     surface: 'tui',
     ...(hostProfileId ? { profileId: hostProfileId } : {}),

--- a/packages/cli/src/runtime-host-tui-context.ts
+++ b/packages/cli/src/runtime-host-tui-context.ts
@@ -45,6 +45,7 @@ export interface RuntimeHostTuiContext {
 }
 
 export interface CreateRuntimeHostTuiContextInput {
+  readonly clientDataRoot: string;
   readonly rootPath: string;
   readonly cwd: string;
   readonly resumeSessionId?: string;
@@ -56,6 +57,7 @@ export async function createRuntimeHostTuiContext(
   input: CreateRuntimeHostTuiContextInput,
 ): Promise<RuntimeHostTuiContext> {
   const connected = await connectRuntimeHostCli({
+    clientDataRoot: input.clientDataRoot,
     rootPath: input.rootPath,
     surface: 'tui',
     ...(input.hostProfileId ? { profileId: input.hostProfileId } : {}),

--- a/packages/cli/src/workspace-root.ts
+++ b/packages/cli/src/workspace-root.ts
@@ -1,4 +1,13 @@
 // Workspace-root resolution now lives in @maka/storage, next to
 // createConnectionStore — the two share one path authority. This file
 // remains as a re-export so existing relative CLI importers keep working.
-export { resolveMakaWorkspaceRoot, type ResolveMakaWorkspaceRootInput } from '@maka/storage';
+export {
+  deriveMakaDataRoots,
+  resolveMakaClientDataRoot,
+  resolveMakaDataRoots,
+  resolveMakaWorkspaceRoot,
+  type DeriveMakaDataRootsInput,
+  type MakaDataRoots,
+  type ResolveMakaClientDataRootInput,
+  type ResolveMakaWorkspaceRootInput,
+} from '@maka/storage';

--- a/packages/storage/src/__tests__/workspace-root.test.ts
+++ b/packages/storage/src/__tests__/workspace-root.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { resolveMakaClientDataRoot, resolveMakaWorkspaceRoot } from '../workspace-root.js';
+import {
+  deriveMakaDataRoots,
+  resolveMakaClientDataRoot,
+  resolveMakaWorkspaceRoot,
+} from '../workspace-root.js';
 
 describe('Maka workspace root resolver', () => {
   test('resolves Client-owned data outside every Host State Root', () => {
@@ -10,28 +14,82 @@ describe('Maka workspace root resolver', () => {
     );
   });
 
-  test('resolves each platform under its canonical application-data root', () => {
+  test('resolves release and development profiles under each platform application-data root', () => {
     const cases = [
       [
         { platform: 'darwin', homeDir: '/Users/ada', env: {} },
-        '/Users/ada/Library/Application Support/Maka/workspaces/default',
+        '/Users/ada/Library/Application Support',
       ],
-      [
-        { platform: 'linux', homeDir: '/home/ada', env: {} },
-        '/home/ada/.config/Maka/workspaces/default',
-      ],
+      [{ platform: 'linux', homeDir: '/home/ada', env: {} }, '/home/ada/.config'],
       [
         {
           platform: 'win32',
           homeDir: 'C:\\Users\\Ada',
           env: { APPDATA: 'C:\\Users\\Ada\\AppData\\Roaming' },
         },
-        'C:\\Users\\Ada\\AppData\\Roaming\\Maka\\workspaces\\default',
+        'C:\\Users\\Ada\\AppData\\Roaming',
       ],
     ] as const;
 
-    for (const [options, expected] of cases) {
-      assert.equal(resolveMakaWorkspaceRoot(options), expected, options.platform);
+    for (const [options, base] of cases) {
+      const separator = options.platform === 'win32' ? '\\' : '/';
+      for (const profileName of ['Maka', 'Maka Dev']) {
+        const clientDataRoot = `${base}${separator}${profileName}`;
+        assert.equal(
+          resolveMakaClientDataRoot({ ...options, profileName }),
+          clientDataRoot,
+          `${options.platform} ${profileName} Client Data Root`,
+        );
+        assert.equal(
+          resolveMakaWorkspaceRoot({ ...options, profileName }),
+          `${clientDataRoot}${separator}workspaces${separator}default`,
+          `${options.platform} ${profileName} Workspace Root`,
+        );
+      }
+    }
+  });
+
+  test('derives all subordinate roots from an exact Client Data Root', () => {
+    assert.deepEqual(deriveMakaDataRoots('/custom/maka-profile', { platform: 'linux' }), {
+      clientDataRoot: '/custom/maka-profile',
+      workspaceRoot: '/custom/maka-profile/workspaces/default',
+    });
+  });
+
+  test('honors Linux XDG_CONFIG_HOME and falls back from Windows APPDATA', () => {
+    assert.equal(
+      resolveMakaClientDataRoot({
+        platform: 'linux',
+        homeDir: '/home/ada',
+        env: { XDG_CONFIG_HOME: '/var/config/ada' },
+        profileName: 'Maka Dev',
+      }),
+      '/var/config/ada/Maka Dev',
+    );
+    assert.equal(
+      resolveMakaClientDataRoot({
+        platform: 'win32',
+        homeDir: 'C:\\Users\\Ada',
+        env: {},
+        profileName: 'Maka Dev',
+      }),
+      'C:\\Users\\Ada\\AppData\\Roaming\\Maka Dev',
+    );
+  });
+
+  test('rejects a profile name that can escape its application-data root', () => {
+    for (const profileName of ['', '.', '..', 'Maka/Dev', 'Maka\\Dev', 'Maka\0Dev']) {
+      assert.throws(
+        () =>
+          resolveMakaClientDataRoot({
+            platform: 'linux',
+            homeDir: '/home/ada',
+            env: {},
+            profileName,
+          }),
+        /non-empty path segment/,
+        JSON.stringify(profileName),
+      );
     }
   });
 });

--- a/packages/storage/src/workspace-root.ts
+++ b/packages/storage/src/workspace-root.ts
@@ -1,40 +1,81 @@
 import { homedir } from 'node:os';
 import { posix, win32 } from 'node:path';
 
-export interface ResolveMakaWorkspaceRootInput {
+const DEFAULT_MAKA_PROFILE_NAME = 'Maka';
+
+export interface ResolveMakaClientDataRootInput {
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
   homeDir?: string;
+  profileName?: string;
+}
+
+export interface ResolveMakaWorkspaceRootInput extends ResolveMakaClientDataRootInput {
   workspaceName?: string;
 }
 
-export type ResolveMakaClientDataRootInput = Omit<ResolveMakaWorkspaceRootInput, 'workspaceName'>;
+export interface DeriveMakaDataRootsInput {
+  platform?: NodeJS.Platform;
+  workspaceName?: string;
+}
+
+export interface MakaDataRoots {
+  readonly clientDataRoot: string;
+  readonly workspaceRoot: string;
+}
 
 export function resolveMakaClientDataRoot(input: ResolveMakaClientDataRootInput = {}): string {
   const platform = input.platform ?? process.platform;
   const env = input.env ?? process.env;
   const home = input.homeDir ?? homedir();
-  return resolveElectronUserDataRoot(platform, env, home);
+  const profileName = input.profileName ?? DEFAULT_MAKA_PROFILE_NAME;
+  assertMakaProfileName(profileName);
+  return resolveElectronUserDataRoot(platform, env, home, profileName);
+}
+
+export function deriveMakaDataRoots(
+  clientDataRoot: string,
+  input: DeriveMakaDataRootsInput = {},
+): MakaDataRoots {
+  const platform = input.platform ?? process.platform;
+  const workspaceName = input.workspaceName ?? 'default';
+  const pathApi = platform === 'win32' ? win32 : posix;
+  return {
+    clientDataRoot,
+    workspaceRoot: pathApi.join(clientDataRoot, 'workspaces', workspaceName),
+  };
 }
 
 export function resolveMakaWorkspaceRoot(input: ResolveMakaWorkspaceRootInput = {}): string {
-  const platform = input.platform ?? process.platform;
-  const workspaceName = input.workspaceName ?? 'default';
-  const userDataRoot = resolveMakaClientDataRoot(input);
-  const pathApi = platform === 'win32' ? win32 : posix;
-  return pathApi.join(userDataRoot, 'workspaces', workspaceName);
+  return resolveMakaDataRoots(input).workspaceRoot;
+}
+
+export function resolveMakaDataRoots(input: ResolveMakaWorkspaceRootInput = {}): MakaDataRoots {
+  return deriveMakaDataRoots(resolveMakaClientDataRoot(input), input);
 }
 
 function resolveElectronUserDataRoot(
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
   home: string,
+  profileName: string,
 ): string {
   if (platform === 'darwin') {
-    return posix.join(home, 'Library', 'Application Support', 'Maka');
+    return posix.join(home, 'Library', 'Application Support', profileName);
   }
   if (platform === 'win32') {
-    return win32.join(env.APPDATA || win32.join(home, 'AppData', 'Roaming'), 'Maka');
+    return win32.join(env.APPDATA || win32.join(home, 'AppData', 'Roaming'), profileName);
   }
-  return posix.join(env.XDG_CONFIG_HOME || posix.join(home, '.config'), 'Maka');
+  return posix.join(env.XDG_CONFIG_HOME || posix.join(home, '.config'), profileName);
+}
+
+function assertMakaProfileName(profileName: string): void {
+  if (
+    profileName.length === 0 ||
+    profileName === '.' ||
+    profileName === '..' ||
+    /[\\/\0]/u.test(profileName)
+  ) {
+    throw new Error('Maka profile name must be a non-empty path segment');
+  }
 }


### PR DESCRIPTION
## Summary

- add a repository-only `npm run cli:dev --` launcher that selects the generic `Maka Dev` data profile while the published CLI explicitly remains on `Maka`
- resolve the selected client/workspace roots once and propagate them through TUI, non-interactive run, Runtime Host service/access/profile flows, credentials, and client identity
- isolate the development capability-provider identity under the selected Client Data Root while preserving the released CLI legacy identity path and explicit `--client-identity` overrides
- keep top-level/run help plus TUI resume, recovery, and readiness copy launcher-aware, and expose an exact-client-root derivation seam for a future custom data-directory option
- do not copy, synchronize, or migrate data between profiles

Fixes #2412

## Verification

- compiled release/development entry smoke across isolated macOS, Linux, and Windows-style home/app-data layouts; release data is seeded first and is neither copied nor modified by the development entry
- compiled capability-provider smoke verifies separate release/development Client identities and explicit identity-path precedence
- complete CLI suite: 243 passed
- fresh-install complete repository suite: all workspace tests passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:third-party-notices`
- `git diff --check origin/main...HEAD`

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — repository CLI development now uses the isolated `Maka Dev` profile; released CLI behavior is unchanged
- [ ] No
