### PR TITLE
feat(runtime): add trusted PreToolUse policy hooks

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,6 +96,7 @@
     "./result": "./dist/result.js",
     "./settings": "./dist/settings.js",
     "./mcp": "./dist/mcp.js",
+    "./hooks": "./dist/hooks.js",
     "./settings/network-settings": "./dist/settings/network-settings.js",
     "./usage-stats/types": "./dist/usage-stats/types.js",
     "./usage-stats/pricing": "./dist/usage-stats/pricing.js",

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -1,0 +1,90 @@
+export const HOOK_CONFIG_VERSION = 1 as const;
+export const HOOK_TRUST_VERSION = 1 as const;
+export const PRE_TOOL_USE_HOOK_EVENT = 'PreToolUse' as const;
+
+export type HookEventName = typeof PRE_TOOL_USE_HOOK_EVENT;
+export type HookSource = 'user' | 'project';
+
+export interface HookCommandConfig {
+  id: string;
+  type: 'command';
+  command: string;
+  args?: string[];
+  timeoutMs?: number;
+  enabled?: boolean;
+}
+
+export interface HookMatcherGroupConfig {
+  matcher?: string;
+  hooks: HookCommandConfig[];
+}
+
+export interface HookConfigFile {
+  version: typeof HOOK_CONFIG_VERSION;
+  hooks: {
+    PreToolUse?: HookMatcherGroupConfig[];
+  };
+}
+
+export interface HookTrustRecord {
+  definitionHash: `sha256:${string}`;
+  source: HookSource;
+  projectIdentity: string;
+  trustedAt: number;
+}
+
+export interface HookTrustFile {
+  version: typeof HOOK_TRUST_VERSION;
+  trustedDefinitions: HookTrustRecord[];
+}
+
+export interface ResolvedHookDefinition {
+  id: string;
+  eventName: HookEventName;
+  matcher: string;
+  command: string;
+  args: string[];
+  timeoutMs: number;
+  source: HookSource;
+  sourceOrder: number;
+  definitionOrder: number;
+  projectIdentity: string;
+  definitionHash: `sha256:${string}`;
+  trusted: boolean;
+}
+
+export interface PreToolUseHookInput {
+  schema_version: 1;
+  hook_event_name: HookEventName;
+  session_id: string;
+  turn_id: string;
+  run_id: string;
+  tool_use_id: string;
+  tool_name: string;
+  tool_input: unknown;
+  cwd: string;
+  permission_mode: string;
+  origin: 'provider' | 'code_mode';
+}
+
+export type HookExecutionStatus = 'allowed' | 'denied' | 'failed' | 'skipped_untrusted';
+
+export interface HookCompletedAudit {
+  eventName: HookEventName;
+  handlerId: string;
+  definitionHash: `sha256:${string}`;
+  source: HookSource;
+  toolUseId: string;
+  toolName: string;
+  status: HookExecutionStatus;
+  durationMs: number;
+  message?: string;
+}
+
+export function createDefaultHookConfig(): HookConfigFile {
+  return { version: HOOK_CONFIG_VERSION, hooks: {} };
+}
+
+export function createDefaultHookTrust(): HookTrustFile {
+  return { version: HOOK_TRUST_VERSION, trustedDefinitions: [] };
+}

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -23,6 +23,7 @@ import {
 import { INTERACTION_ID_MAX_BYTES, INTERACTION_TOOL_NAME_MAX_BYTES } from './interaction.js';
 import type { PermissionRequestPayload, PermissionResponse } from './permission.js';
 import type { TurnOrigin } from './runtime-inputs.js';
+import type { HookExecutionStatus, HookSource } from './hooks.js';
 import type { UserQuestionRequest } from './user-question.js';
 import {
   defineObjectShape,
@@ -241,6 +242,18 @@ export interface RuntimeEventProtocolMarker {
   toolBoundary: ToolBoundaryProtocol;
 }
 
+export interface RuntimeEventHookCompleted {
+  eventName: 'PreToolUse';
+  handlerId: string;
+  definitionHash: `sha256:${string}`;
+  source: HookSource;
+  toolUseId: string;
+  toolName: string;
+  status: HookExecutionStatus;
+  durationMs: number;
+  message?: string;
+}
+
 export interface RuntimeEventContinuationStartV2 {
   protocol: 'continuation_start_v2';
   /** Mirrors store-owned claim state; recovery never trusts this field alone. */
@@ -308,6 +321,8 @@ export interface RuntimeEventActions {
   toolRecovery?: ToolRecoveryFactEnvelope;
   /** Protocols that were actually active from the first event of this run. */
   runtimeProtocol?: RuntimeEventProtocolMarker;
+  /** Bounded, non-model-visible result of one user-configured lifecycle Hook. */
+  hookCompleted?: RuntimeEventHookCompleted;
   /** Durable provider-call T1 for a claimed continuation. */
   continuationStart?: RuntimeEventContinuationStartV2;
   /** Reserved workspace authority fact; only its atomic SQLite writer may persist it. */
@@ -497,6 +512,7 @@ const RUNTIME_ACTIONS_SHAPE = defineObjectShape<RuntimeEventActions>()(
     'toolDispatch',
     'toolRecovery',
     'runtimeProtocol',
+    'hookCompleted',
     'continuationStart',
     'workspaceFact',
   ],
@@ -526,6 +542,19 @@ const RUNTIME_TOOL_DISPATCH_SHAPE = defineObjectShape<RuntimeEventToolDispatch>(
 const RUNTIME_PROTOCOL_MARKER_SHAPE = defineObjectShape<RuntimeEventProtocolMarker>()(
   ['toolBoundary'],
   [],
+);
+const RUNTIME_HOOK_COMPLETED_SHAPE = defineObjectShape<RuntimeEventHookCompleted>()(
+  [
+    'eventName',
+    'handlerId',
+    'definitionHash',
+    'source',
+    'toolUseId',
+    'toolName',
+    'status',
+    'durationMs',
+  ],
+  ['message'],
 );
 const RUNTIME_CONTINUATION_START_SHAPE = defineObjectShape<RuntimeEventContinuationStartV2>()(
   [
@@ -741,9 +770,34 @@ function isRuntimeEventActions(value: unknown): value is RuntimeEventActions {
     (value.toolDispatch === undefined || isRuntimeToolDispatch(value.toolDispatch)) &&
     (value.toolRecovery === undefined || isToolRecoveryFactEnvelope(value.toolRecovery)) &&
     (value.runtimeProtocol === undefined || isRuntimeProtocolMarker(value.runtimeProtocol)) &&
+    (value.hookCompleted === undefined || isRuntimeHookCompleted(value.hookCompleted)) &&
     (value.continuationStart === undefined ||
       isRuntimeContinuationStart(value.continuationStart)) &&
     (value.workspaceFact === undefined || isRuntimeEventWorkspaceFactEnvelope(value.workspaceFact))
+  );
+}
+
+function isRuntimeHookCompleted(value: unknown): value is RuntimeEventHookCompleted {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, RUNTIME_HOOK_COMPLETED_SHAPE) &&
+    value.eventName === 'PreToolUse' &&
+    typeof value.handlerId === 'string' &&
+    value.handlerId.length > 0 &&
+    typeof value.definitionHash === 'string' &&
+    /^sha256:[0-9a-f]{64}$/u.test(value.definitionHash) &&
+    (value.source === 'user' || value.source === 'project') &&
+    typeof value.toolUseId === 'string' &&
+    value.toolUseId.length > 0 &&
+    typeof value.toolName === 'string' &&
+    value.toolName.length > 0 &&
+    (value.status === 'allowed' ||
+      value.status === 'denied' ||
+      value.status === 'failed' ||
+      value.status === 'skipped_untrusted') &&
+    isFiniteNumber(value.durationMs) &&
+    value.durationMs >= 0 &&
+    isOptionalString(value.message)
   );
 }
 

--- a/packages/runtime-host/src/__tests__/host-hook-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/host-hook-composition.test.ts
@@ -1,0 +1,140 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import type { PreToolUseHookInput } from '@maka/core/hooks';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { SessionHeader } from '@maka/core/session';
+import { createHookConfigStore, createHookTrustStore } from '@maka/storage';
+import { createHostHookComposition, hashHookDefinition } from '../server/host-hook-composition.js';
+
+describe('Host Hook composition', () => {
+  it('invalidates exact-definition trust on the next Turn after an execution change', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-host-hooks-'));
+    const events: RuntimeEvent[] = [];
+    try {
+      const config = createHookConfigStore(root);
+      const trust = createHookTrustStore(root);
+      const firstArgs = ['-e', 'process.stderr.write("denied");process.exit(2)'];
+      await config.set({
+        version: 1,
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                {
+                  id: 'policy',
+                  type: 'command',
+                  command: process.execPath,
+                  args: firstArgs,
+                  timeoutMs: 1_000,
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const hash = hashHookDefinition({
+        source: 'user',
+        projectIdentity: 'user',
+        matcher: 'Bash',
+        command: process.execPath,
+        args: firstArgs,
+        timeoutMs: 1_000,
+      });
+      await trust.trust({
+        definitionHash: hash,
+        source: 'user',
+        projectIdentity: 'user',
+        trustedAt: Date.now(),
+      });
+      const composition = createHostHookComposition({
+        stateRoot: root,
+        runtimeEvents: {
+          appendRuntimeEvent: async (_sessionId, _runId, event) => {
+            events.push(event);
+          },
+        },
+      });
+      const dispatcher = composition.dispatcherFor(header(root));
+      const first = await dispatcher.runPreToolUse(
+        hookInput('turn-1', 'run-1', root),
+        new AbortController().signal,
+        { invocationId: 'invocation-1' },
+      );
+      assert.equal(first.denied, true);
+      assert.equal(first.audits[0]?.definitionHash, hash);
+      assert.equal(events[0]?.actions?.hookCompleted?.status, 'denied');
+
+      await config.set({
+        version: 1,
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                {
+                  id: 'policy',
+                  type: 'command',
+                  command: process.execPath,
+                  args: ['-e', 'process.exit(0)'],
+                  timeoutMs: 1_000,
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const second = await dispatcher.runPreToolUse(
+        hookInput('turn-2', 'run-2', root),
+        new AbortController().signal,
+        { invocationId: 'invocation-2' },
+      );
+      assert.equal(second.denied, false);
+      assert.equal(second.audits[0]?.status, 'skipped_untrusted');
+      assert.notEqual(second.audits[0]?.definitionHash, hash);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function hookInput(turnId: string, runId: string, cwd: string): PreToolUseHookInput {
+  return {
+    schema_version: 1,
+    hook_event_name: 'PreToolUse',
+    session_id: 'session-1',
+    turn_id: turnId,
+    run_id: runId,
+    tool_use_id: `tool-${turnId}`,
+    tool_name: 'Bash',
+    tool_input: { command: 'git push' },
+    cwd,
+    permission_mode: 'ask',
+    origin: 'provider',
+  };
+}
+
+function header(root: string): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: root,
+    cwd: root,
+    projectId: null,
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Hook test',
+    titleIsManual: false,
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    connectionId: 'connection-1',
+    modelId: 'model-1',
+    thinkingLevel: 'medium',
+  } as unknown as SessionHeader;
+}

--- a/packages/runtime-host/src/__tests__/host-hook-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/host-hook-composition.test.ts
@@ -3,10 +3,17 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
+import { createExternalExecutionBoundary } from '@maka/core/sandbox-boundary';
 import type { PreToolUseHookInput } from '@maka/core/hooks';
+import type { SessionEvent } from '@maka/core/events';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { SessionHeader } from '@maka/core/session';
-import { createHookConfigStore, createHookTrustStore } from '@maka/storage';
+import {
+  createHookConfigStore,
+  createHookTrustStore,
+  createSqliteRuntimeStore,
+} from '@maka/storage';
+import { ToolRuntime, type MakaTool } from '@maka/runtime/tool-runtime';
 import { createHostHookComposition, hashHookDefinition } from '../server/host-hook-composition.js';
 
 describe('Host Hook composition', () => {
@@ -96,6 +103,119 @@ describe('Host Hook composition', () => {
       assert.equal(second.audits[0]?.status, 'skipped_untrusted');
       assert.notEqual(second.audits[0]?.definitionHash, hash);
     } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('denies a real configured and trusted command before ToolRuntime T1 and side effects', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-host-hook-e2e-'));
+    const runtimeStore = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
+    try {
+      const args = [
+        '-e',
+        `let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{const x=JSON.parse(s);if(x.schema_version===1&&x.tool_name==='Bash'&&x.tool_input.command==='git push'){process.stderr.write('push blocked by fixture');process.exit(2)}process.exit(9)})`,
+      ];
+      const config = createHookConfigStore(root);
+      await config.set({
+        version: 1,
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                {
+                  id: 'push-policy',
+                  type: 'command',
+                  command: process.execPath,
+                  args,
+                  timeoutMs: 1_000,
+                },
+              ],
+            },
+          ],
+        },
+      });
+      const definitionHash = hashHookDefinition({
+        source: 'user',
+        projectIdentity: 'user',
+        matcher: 'Bash',
+        command: process.execPath,
+        args,
+        timeoutMs: 1_000,
+      });
+      await createHookTrustStore(root).trust({
+        definitionHash,
+        source: 'user',
+        projectIdentity: 'user',
+        trustedAt: Date.now(),
+      });
+
+      const sessionHeader = header(root);
+      const dispatcher = createHostHookComposition({
+        stateRoot: root,
+        runtimeEvents: runtimeStore,
+      }).dispatcherFor(sessionHeader);
+      let implementationCalls = 0;
+      let id = 0;
+      let now = 0;
+      const runtime = new ToolRuntime({
+        sessionId: 'session-1',
+        header: sessionHeader,
+        connection: {
+          slug: 'connection-1',
+          providerType: 'openai',
+          defaultModel: 'model-1',
+        },
+        modelId: 'model-1',
+        appendMessage: async () => {},
+        readExecutionBoundary: async () => createExternalExecutionBoundary(),
+        newId: () => `id-${++id}`,
+        now: () => ++now,
+        getPermissionPauseTarget: () => null,
+        turnId: 'turn-1',
+        runId: 'run-1',
+        invocationId: 'invocation-1',
+        runtimeCommitSink: runtimeStore,
+        preToolUseHooks: dispatcher,
+      });
+      const tool: MakaTool<{ command: string }, string> = {
+        name: 'Bash',
+        description: 'fixture',
+        parameters: { type: 'object' },
+        impl: async () => {
+          implementationCalls += 1;
+          return 'should not run';
+        },
+      };
+      const sessionEvents: SessionEvent[] = [];
+      const settlement = await runtime.settleToolCall({
+        tool,
+        turnId: 'turn-1',
+        toolCallId: 'provider-call-1',
+        input: { command: 'git push' },
+        abortSignal: new AbortController().signal,
+        eventSink: {
+          push: (event) => sessionEvents.push(event),
+          pushAndWaitUntilConsumed: async (event) => {
+            sessionEvents.push(event);
+          },
+        },
+      });
+
+      assert.equal(implementationCalls, 0);
+      assert.match(JSON.stringify(settlement.result), /push blocked by fixture/u);
+      const toolStart = sessionEvents.find((event) => event.type === 'tool_start');
+      assert.ok(toolStart && toolStart.type === 'tool_start');
+      assert.equal(toolStart.operationId, undefined);
+      assert.equal(sessionEvents.filter((event) => event.type === 'tool_result').length, 1);
+
+      const runtimeEvents = await runtimeStore.readImmutableRuntimeEvents('session-1', 'run-1');
+      assert.equal(runtimeEvents.length, 1);
+      assert.equal(runtimeEvents[0]?.actions?.hookCompleted?.status, 'denied');
+      assert.equal(runtimeEvents[0]?.actions?.hookCompleted?.definitionHash, definitionHash);
+      assert.equal(runtimeEvents[0]?.content, undefined);
+    } finally {
+      runtimeStore.close();
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -99,6 +99,7 @@ import { HostClientCapabilityCoordinator } from './client-capability-coordinator
 import { HostDeepResearchCoordinator } from './deep-research-coordinator.js';
 import { HostDailyReviewCoordinator } from './daily-review-coordinator.js';
 import { createHostAiSdkBackend } from './execution-model-composition.js';
+import { createHostHookComposition } from './host-hook-composition.js';
 import {
   createInteractiveRunComposer,
   createInteractiveRunComposerFactory,
@@ -277,6 +278,10 @@ export async function createExecutionRuntimeHostComposition(
     });
     await stores.messageReceiptStore.beginHostEpoch(context.hostEpoch);
     const backends = new BackendRegistry();
+    const hooks = createHostHookComposition({
+      stateRoot: context.owner.capability.canonicalPath,
+      runtimeEvents: stores.runtimeEventStore,
+    });
     backends.register('fake', (backendContext) => new FakeBackend(backendContext));
     const runtimePolicyActivation = new RuntimePolicyActivationGate();
     const runtimePolicy = new HostRuntimePolicyCoordinator(
@@ -653,6 +658,7 @@ export async function createExecutionRuntimeHostComposition(
               backendContext.sessionId,
             ),
             runtimeCommitSink: stores.runtimeEventStore,
+            hooks,
             requestDrain: context.requestDrain,
           })),
     );

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -39,6 +39,7 @@ import type { HostMemoryExtractionCoordinator } from './memory-extraction-coordi
 import { readDuringBackendCreation, resolveExecutionTarget } from './execution-model-authority.js';
 import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 import type { HostRunComposer, HostRunComposerFactory } from './host-run-composer.js';
+import type { HostHookComposition } from './host-hook-composition.js';
 
 export interface HostAiSdkBackendInput {
   readonly context: BackendFactoryContext;
@@ -53,6 +54,7 @@ export interface HostAiSdkBackendInput {
   readonly requestDrain: () => void;
   readonly runtimeCommitSink?: RuntimeCommitSink;
   readonly childAgents?: HostChildAgentBackendCapabilities;
+  readonly hooks?: HostHookComposition;
   readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
 }
 
@@ -338,6 +340,9 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
           sessionId: input.context.sessionId,
         }),
         recordToolArtifacts: input.executionArtifacts.recordToolArtifacts,
+        ...(input.hooks
+          ? { preToolUseHooks: input.hooks.dispatcherFor(input.context.header) }
+          : {}),
         toolResultArchive: input.executionArtifacts.toolResultArchive,
         ...(!input.context.tools &&
         !input.context.header.subagentParent &&

--- a/packages/runtime-host/src/server/host-hook-composition.ts
+++ b/packages/runtime-host/src/server/host-hook-composition.ts
@@ -10,7 +10,9 @@ import type {
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { SessionHeader } from '@maka/core/session';
 import {
+  createHookExecutionLimiter,
   createPreToolUseHookDispatcher,
+  type HookExecutionLimiter,
   type PreToolUseHookDispatcher,
 } from '@maka/runtime/hooks/engine';
 import {
@@ -35,12 +37,14 @@ export function createHostHookComposition(input: {
 }): HostHookComposition {
   const userConfig = createHookConfigStore(input.stateRoot);
   const trust = createHookTrustStore(input.stateRoot);
+  const executionLimiter = createHookExecutionLimiter();
   return {
     dispatcherFor(header) {
       return createSessionHookDispatcher({
         header,
         userConfig,
         trust,
+        executionLimiter,
         runtimeEvents: input.runtimeEvents,
       });
     },
@@ -51,10 +55,12 @@ function createSessionHookDispatcher(input: {
   header: SessionHeader;
   userConfig: HookConfigStore;
   trust: HookTrustStore;
+  executionLimiter: HookExecutionLimiter;
   runtimeEvents: HookRuntimeEventWriter;
 }): PreToolUseHookDispatcher {
   return createPreToolUseHookDispatcher({
     loadSnapshot: () => loadSnapshot(input),
+    executionLimiter: input.executionLimiter,
     recordAudit: (hookInput, audit, context) =>
       recordAudit(input.runtimeEvents, hookInput, audit, context.invocationId),
   });

--- a/packages/runtime-host/src/server/host-hook-composition.ts
+++ b/packages/runtime-host/src/server/host-hook-composition.ts
@@ -1,0 +1,191 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import type {
+  HookCompletedAudit,
+  HookConfigFile,
+  HookSource,
+  PreToolUseHookInput,
+  ResolvedHookDefinition,
+} from '@maka/core/hooks';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type { SessionHeader } from '@maka/core/session';
+import {
+  createPreToolUseHookDispatcher,
+  type PreToolUseHookDispatcher,
+} from '@maka/runtime/hooks/engine';
+import {
+  createHookConfigStore,
+  createHookTrustStore,
+  readHookConfigFile,
+  type HookConfigStore,
+  type HookTrustStore,
+} from '@maka/storage';
+
+interface HookRuntimeEventWriter {
+  appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void>;
+}
+
+export interface HostHookComposition {
+  dispatcherFor(header: SessionHeader): PreToolUseHookDispatcher;
+}
+
+export function createHostHookComposition(input: {
+  stateRoot: string;
+  runtimeEvents: HookRuntimeEventWriter;
+}): HostHookComposition {
+  const userConfig = createHookConfigStore(input.stateRoot);
+  const trust = createHookTrustStore(input.stateRoot);
+  return {
+    dispatcherFor(header) {
+      return createSessionHookDispatcher({
+        header,
+        userConfig,
+        trust,
+        runtimeEvents: input.runtimeEvents,
+      });
+    },
+  };
+}
+
+function createSessionHookDispatcher(input: {
+  header: SessionHeader;
+  userConfig: HookConfigStore;
+  trust: HookTrustStore;
+  runtimeEvents: HookRuntimeEventWriter;
+}): PreToolUseHookDispatcher {
+  return createPreToolUseHookDispatcher({
+    loadSnapshot: () => loadSnapshot(input),
+    recordAudit: (hookInput, audit, context) =>
+      recordAudit(input.runtimeEvents, hookInput, audit, context.invocationId),
+  });
+}
+
+async function loadSnapshot(input: {
+  header: SessionHeader;
+  userConfig: HookConfigStore;
+  trust: HookTrustStore;
+}): Promise<ResolvedHookDefinition[]> {
+  const projectIdentity = input.header.projectId
+    ? `project:${input.header.projectId}`
+    : `workspace:${input.header.workspaceRoot}`;
+  const [userConfig, projectConfig, trust] = await Promise.all([
+    input.userConfig.get(),
+    readHookConfigFile(join(input.header.cwd, '.maka', 'hooks.json')),
+    input.trust.get(),
+  ]);
+  const trustedHashes = new Set(trust.trustedDefinitions.map((record) => record.definitionHash));
+  const definitions: ResolvedHookDefinition[] = [];
+  appendDefinitions(definitions, userConfig, {
+    source: 'user',
+    sourceOrder: 0,
+    projectIdentity: 'user',
+    trustedHashes,
+  });
+  appendDefinitions(definitions, projectConfig, {
+    source: 'project',
+    sourceOrder: 1,
+    projectIdentity,
+    trustedHashes,
+  });
+  return definitions;
+}
+
+function appendDefinitions(
+  output: ResolvedHookDefinition[],
+  config: HookConfigFile,
+  input: {
+    source: HookSource;
+    sourceOrder: number;
+    projectIdentity: string;
+    trustedHashes: ReadonlySet<string>;
+  },
+): void {
+  for (const group of config.hooks.PreToolUse ?? []) {
+    for (const handler of group.hooks) {
+      if (handler.enabled === false) continue;
+      const definitionOrder = output.length;
+      const definitionHash = hashDefinition({
+        source: input.source,
+        projectIdentity: input.projectIdentity,
+        matcher: group.matcher ?? '*',
+        command: handler.command,
+        args: handler.args ?? [],
+        timeoutMs: handler.timeoutMs ?? 3_000,
+      });
+      output.push({
+        id: handler.id,
+        eventName: 'PreToolUse',
+        matcher: group.matcher ?? '*',
+        command: handler.command,
+        args: handler.args ?? [],
+        timeoutMs: handler.timeoutMs ?? 3_000,
+        source: input.source,
+        sourceOrder: input.sourceOrder,
+        definitionOrder,
+        projectIdentity: input.projectIdentity,
+        definitionHash,
+        trusted: input.trustedHashes.has(definitionHash),
+      });
+    }
+  }
+}
+
+export function hashHookDefinition(input: {
+  source: HookSource;
+  projectIdentity: string;
+  matcher: string;
+  command: string;
+  args: readonly string[];
+  timeoutMs: number;
+}): `sha256:${string}` {
+  return hashDefinition(input);
+}
+
+function hashDefinition(input: {
+  source: HookSource;
+  projectIdentity: string;
+  matcher: string;
+  command: string;
+  args: readonly string[];
+  timeoutMs: number;
+}): `sha256:${string}` {
+  const digest = createHash('sha256')
+    .update(
+      JSON.stringify([
+        1,
+        input.source,
+        input.projectIdentity,
+        'PreToolUse',
+        input.matcher,
+        'command',
+        input.command,
+        input.args,
+        input.timeoutMs,
+      ]),
+    )
+    .digest('hex');
+  return `sha256:${digest}`;
+}
+
+async function recordAudit(
+  runtimeEvents: HookRuntimeEventWriter,
+  input: PreToolUseHookInput,
+  audit: HookCompletedAudit,
+  invocationId: string,
+): Promise<void> {
+  await runtimeEvents.appendRuntimeEvent(input.session_id, input.run_id, {
+    id: randomUUID(),
+    invocationId,
+    runId: input.run_id,
+    sessionId: input.session_id,
+    turnId: input.turn_id,
+    ts: Date.now(),
+    partial: false,
+    role: 'system',
+    author: 'host',
+    origin: input.origin,
+    modelVisibility: 'hidden',
+    actions: { hookCompleted: audit },
+    refs: { toolCallId: input.tool_use_id },
+  });
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -111,6 +111,7 @@
     "./tool-result-archive-capability": "./dist/tool-result-archive-capability.js",
     "./tool-result-archive-resource": "./dist/tool-result-archive-resource.js",
     "./tool-runtime": "./dist/tool-runtime.js",
+    "./hooks/engine": "./dist/hooks/engine.js",
     "./web-fetch-tool": "./dist/web-fetch-tool.js",
     "./web-search-tool": "./dist/web-search-tool.js",
     "./xai-oauth-enrollment": "./dist/xai-oauth-enrollment.js"

--- a/packages/runtime/src/__tests__/hooks-engine.test.ts
+++ b/packages/runtime/src/__tests__/hooks-engine.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { PreToolUseHookInput, ResolvedHookDefinition } from '@maka/core/hooks';
-import { createHookCommandRunner, type HookCommandRunner } from '../hooks/command-runner.js';
-import { createPreToolUseHookDispatcher } from '../hooks/engine.js';
+import {
+  createHookCommandRunner,
+  HOOK_EXECUTION_MARKER,
+  type HookCommandRunner,
+} from '../hooks/command-runner.js';
+import { createHookExecutionLimiter, createPreToolUseHookDispatcher } from '../hooks/engine.js';
 
 describe('PreToolUse Hook engine', () => {
   it('freezes one snapshot per turn and skips untrusted matching definitions', async () => {
@@ -35,6 +39,37 @@ describe('PreToolUse Hook engine', () => {
     assert.equal(runs, 0);
     assert.equal(first.denied, false);
     assert.equal(first.audits[0]?.status, 'skipped_untrusted');
+  });
+
+  it('retains every active Turn snapshot until that Turn is released', async () => {
+    let revision = 1;
+    let loads = 0;
+    const dispatcher = createPreToolUseHookDispatcher({
+      loadSnapshot: async () => {
+        loads += 1;
+        return [definition({ id: `revision-${revision}`, trusted: false })];
+      },
+    });
+    for (let index = 1; index <= 9; index += 1) dispatcher.prepareTurn(`turn-${index}`);
+    await Promise.resolve();
+    revision = 2;
+
+    const retained = await dispatcher.runPreToolUse(
+      hookInput('turn-1'),
+      new AbortController().signal,
+      { invocationId: 'invocation-1' },
+    );
+    assert.equal(retained.audits[0]?.handlerId, 'revision-1');
+    assert.equal(loads, 9);
+
+    dispatcher.releaseTurn('turn-1');
+    const reloaded = await dispatcher.runPreToolUse(
+      hookInput('turn-1'),
+      new AbortController().signal,
+      { invocationId: 'invocation-1-reloaded' },
+    );
+    assert.equal(reloaded.audits[0]?.handlerId, 'revision-2');
+    assert.equal(loads, 10);
   });
 
   it('runs matching handlers concurrently and reports denials in configuration order', async () => {
@@ -71,6 +106,49 @@ describe('PreToolUse Hook engine', () => {
       output.audits.map((audit) => audit.handlerId),
       ['first', 'second'],
     );
+  });
+
+  it('shares one concurrency ceiling across simultaneous dispatchers and sessions', async () => {
+    let active = 0;
+    let maxActive = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const runner: HookCommandRunner = {
+      run: async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await gate;
+        active -= 1;
+        return result(0);
+      },
+    };
+    const limiter = createHookExecutionLimiter(2);
+    const createDispatcher = () =>
+      createPreToolUseHookDispatcher({
+        loadSnapshot: async () => [
+          definition({ id: 'first', definitionOrder: 0 }),
+          definition({ id: 'second', definitionOrder: 1 }),
+        ],
+        commandRunner: runner,
+        executionLimiter: limiter,
+      });
+    const first = createDispatcher().runPreToolUse(
+      hookInput('turn-1'),
+      new AbortController().signal,
+      { invocationId: 'invocation-1' },
+    );
+    const second = createDispatcher().runPreToolUse(
+      { ...hookInput('turn-2'), session_id: 'session-2' },
+      new AbortController().signal,
+      { invocationId: 'invocation-2' },
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(maxActive, 2);
+    release();
+    await Promise.all([first, second]);
+    assert.equal(maxActive, 2);
   });
 
   it('fails open on handler and audit failures but preserves an explicit denial', async () => {
@@ -131,6 +209,37 @@ describe('PreToolUse Hook engine', () => {
     );
     assert.equal(output.denied, true);
     assert.equal(output.reason, 'structured policy denial');
+  });
+
+  it('marks Hook children and refuses execution in a Host recursively started by a Hook', async () => {
+    const runner = createHookCommandRunner();
+    const markerProbe = await runner.run(
+      definition({
+        command: process.execPath,
+        args: [
+          '-e',
+          `process.exit(process.env[${JSON.stringify(HOOK_EXECUTION_MARKER)}] === '1' ? 0 : 9)`,
+        ],
+      }),
+      hookInput('turn-1'),
+      new AbortController().signal,
+    );
+    assert.equal(markerProbe.exitCode, 0);
+
+    const previous = process.env[HOOK_EXECUTION_MARKER];
+    process.env[HOOK_EXECUTION_MARKER] = '1';
+    try {
+      const recursive = await runner.run(
+        definition({ command: process.execPath, args: ['-e', 'process.exit(99)'] }),
+        hookInput('turn-recursive'),
+        new AbortController().signal,
+      );
+      assert.equal(recursive.exitCode, null);
+      assert.equal(recursive.spawnError, 'Recursive Hook execution is not allowed');
+    } finally {
+      if (previous === undefined) delete process.env[HOOK_EXECUTION_MARKER];
+      else process.env[HOOK_EXECUTION_MARKER] = previous;
+    }
   });
 
   it('terminates timed-out Hook process trees and fails open', async () => {

--- a/packages/runtime/src/__tests__/hooks-engine.test.ts
+++ b/packages/runtime/src/__tests__/hooks-engine.test.ts
@@ -1,0 +1,220 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { PreToolUseHookInput, ResolvedHookDefinition } from '@maka/core/hooks';
+import { createHookCommandRunner, type HookCommandRunner } from '../hooks/command-runner.js';
+import { createPreToolUseHookDispatcher } from '../hooks/engine.js';
+
+describe('PreToolUse Hook engine', () => {
+  it('freezes one snapshot per turn and skips untrusted matching definitions', async () => {
+    let loads = 0;
+    let runs = 0;
+    const dispatcher = createPreToolUseHookDispatcher({
+      loadSnapshot: async () => {
+        loads += 1;
+        return [definition({ trusted: false })];
+      },
+      commandRunner: {
+        run: async () => {
+          runs += 1;
+          return result(0);
+        },
+      },
+    });
+    const first = await dispatcher.runPreToolUse(
+      hookInput('turn-1'),
+      new AbortController().signal,
+      { invocationId: 'invocation-1' },
+    );
+    await dispatcher.runPreToolUse(hookInput('turn-1'), new AbortController().signal, {
+      invocationId: 'invocation-1',
+    });
+    await dispatcher.runPreToolUse(hookInput('turn-2'), new AbortController().signal, {
+      invocationId: 'invocation-2',
+    });
+    assert.equal(loads, 2);
+    assert.equal(runs, 0);
+    assert.equal(first.denied, false);
+    assert.equal(first.audits[0]?.status, 'skipped_untrusted');
+  });
+
+  it('runs matching handlers concurrently and reports denials in configuration order', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const runner: HookCommandRunner = {
+      run: async (definition) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, definition.id === 'first' ? 20 : 1));
+        active -= 1;
+        return {
+          ...result(2),
+          stderr: `${definition.id} denied`,
+        };
+      },
+    };
+    const dispatcher = createPreToolUseHookDispatcher({
+      loadSnapshot: async () => [
+        definition({ id: 'first', definitionOrder: 0 }),
+        definition({ id: 'second', definitionOrder: 1 }),
+      ],
+      commandRunner: runner,
+    });
+    const output = await dispatcher.runPreToolUse(
+      hookInput('turn-1'),
+      new AbortController().signal,
+      { invocationId: 'invocation-1' },
+    );
+    assert.equal(maxActive, 2);
+    assert.equal(output.denied, true);
+    assert.equal(output.reason, 'first denied\nsecond denied');
+    assert.deepEqual(
+      output.audits.map((audit) => audit.handlerId),
+      ['first', 'second'],
+    );
+  });
+
+  it('fails open on handler and audit failures but preserves an explicit denial', async () => {
+    const dispatcher = createPreToolUseHookDispatcher({
+      loadSnapshot: async () => [
+        definition({ id: 'failed', definitionOrder: 0 }),
+        definition({ id: 'denied', definitionOrder: 1 }),
+      ],
+      commandRunner: {
+        run: async (definition) =>
+          definition.id === 'failed'
+            ? { ...result(1), stderr: 'crashed' }
+            : { ...result(2), stderr: 'policy denial' },
+      },
+      recordAudit: async () => {
+        throw new Error('audit unavailable');
+      },
+    });
+    const output = await dispatcher.runPreToolUse(
+      hookInput('turn-1'),
+      new AbortController().signal,
+      { invocationId: 'invocation-1' },
+    );
+    assert.equal(output.denied, true);
+    assert.equal(output.reason, 'policy denial');
+    assert.deepEqual(
+      output.audits.map((audit) => audit.status),
+      ['failed', 'denied'],
+    );
+    assert.equal(output.auditWriteFailures.length, 2);
+  });
+
+  it('passes versioned JSON on stdin and accepts structured deny output', async () => {
+    const runner = createHookCommandRunner();
+    const structured = JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'structured policy denial',
+      },
+    });
+    const dispatcher = createPreToolUseHookDispatcher({
+      loadSnapshot: async () => [
+        definition({
+          command: process.execPath,
+          args: [
+            '-e',
+            `let s='';process.stdin.on('data',c=>s+=c);process.stdin.on('end',()=>{const x=JSON.parse(s);if(x.schema_version!==1||x.tool_name!=='Bash')process.exit(9);process.stdout.write(${JSON.stringify(structured)})})`,
+          ],
+        }),
+      ],
+      commandRunner: runner,
+    });
+    const output = await dispatcher.runPreToolUse(
+      hookInput('turn-1'),
+      new AbortController().signal,
+      { invocationId: 'invocation-1' },
+    );
+    assert.equal(output.denied, true);
+    assert.equal(output.reason, 'structured policy denial');
+  });
+
+  it('terminates timed-out Hook process trees and fails open', async () => {
+    const dispatcher = createPreToolUseHookDispatcher({
+      loadSnapshot: async () => [
+        definition({
+          command: process.execPath,
+          args: ['-e', 'setInterval(()=>{},1000)'],
+          timeoutMs: 100,
+        }),
+      ],
+    });
+    const output = await dispatcher.runPreToolUse(
+      hookInput('turn-1'),
+      new AbortController().signal,
+      { invocationId: 'invocation-1' },
+    );
+    assert.equal(output.denied, false);
+    assert.equal(output.audits[0]?.status, 'failed');
+    assert.equal(output.audits[0]?.message, 'Hook timed out');
+  });
+
+  it('terminates Hook process trees when the Turn is aborted', async () => {
+    const dispatcher = createPreToolUseHookDispatcher({
+      loadSnapshot: async () => [
+        definition({
+          command: process.execPath,
+          args: ['-e', 'setInterval(()=>{},1000)'],
+          timeoutMs: 5_000,
+        }),
+      ],
+    });
+    const controller = new AbortController();
+    const pending = dispatcher.runPreToolUse(hookInput('turn-1'), controller.signal, {
+      invocationId: 'invocation-1',
+    });
+    setTimeout(() => controller.abort(), 50);
+    const output = await pending;
+    assert.equal(output.denied, false);
+    assert.equal(output.audits[0]?.status, 'failed');
+    assert.equal(output.audits[0]?.message, 'Hook aborted with the Turn');
+  });
+});
+
+function definition(input: Partial<ResolvedHookDefinition> = {}): ResolvedHookDefinition {
+  return {
+    id: 'policy',
+    eventName: 'PreToolUse',
+    matcher: 'Bash',
+    command: '/usr/bin/true',
+    args: [],
+    timeoutMs: 1_000,
+    source: 'user',
+    sourceOrder: 0,
+    definitionOrder: 0,
+    projectIdentity: 'user',
+    definitionHash: `sha256:${'a'.repeat(64)}`,
+    trusted: true,
+    ...input,
+  };
+}
+
+function hookInput(turnId: string): PreToolUseHookInput {
+  return {
+    schema_version: 1,
+    hook_event_name: 'PreToolUse',
+    session_id: 'session-1',
+    turn_id: turnId,
+    run_id: `run-${turnId}`,
+    tool_use_id: 'tool-use-1',
+    tool_name: 'Bash',
+    tool_input: { command: 'git push' },
+    cwd: process.cwd(),
+    permission_mode: 'ask',
+    origin: 'provider',
+  };
+}
+
+function result(exitCode: number) {
+  return {
+    exitCode,
+    stdout: '',
+    stderr: '',
+    timedOut: false,
+    aborted: false,
+  };
+}

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -1687,6 +1687,19 @@ const ACTION_COVERAGE_SAMPLES: ActionCoverageSamples = {
     },
   },
   runtimeProtocol: { action: { toolBoundary: 't1_after_preflight_v1' } },
+  hookCompleted: {
+    action: {
+      eventName: 'PreToolUse',
+      handlerId: 'coverage-hook',
+      definitionHash: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      source: 'user',
+      toolUseId: 'coverage-tool',
+      toolName: 'Bash',
+      status: 'allowed',
+      durationMs: 1,
+    },
+    event: { refs: { toolCallId: 'coverage-tool' } },
+  },
 };
 
 describe('RuntimeEventActions projection coverage', () => {

--- a/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
@@ -17,6 +17,69 @@ import type { InvocationContext } from '../invocation-context.js';
 import { MAX_ACTIVE_SUBAGENT_TOOLS_PER_TURN, ToolRuntime, type MakaTool } from '../tool-runtime.js';
 
 describe('ToolRuntime with real SQLite boundary', () => {
+  it('keeps a PreToolUse denial on the generic lane before T1 and never calls the tool', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-tool-sqlite-hook-deny-'));
+    const store = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
+    try {
+      let implementationCalls = 0;
+      const events: SessionEvent[] = [];
+      const runtime = createTestToolRuntime({
+        sessionId: 'session-1',
+        header: header(),
+        connection: connection(),
+        modelId: 'model-1',
+        appendMessage: async () => {},
+        newId: nextId(),
+        now: nextNow(),
+        getPermissionPauseTarget: () => null,
+        runId: 'run-1',
+        invocationId: 'invocation-1',
+        runtimeCommitSink: store,
+        preToolUseHooks: {
+          prepareTurn: () => {},
+          runPreToolUse: async () => ({
+            denied: true,
+            reason: 'Policy denied this command',
+            audits: [],
+            auditWriteFailures: [],
+          }),
+        },
+      });
+      const tool: MakaTool<Record<string, never>, string> = {
+        name: 'Bash',
+        description: 'fixture',
+        parameters: { type: 'object', additionalProperties: false },
+        impl: async () => {
+          implementationCalls += 1;
+          return 'should not run';
+        },
+      };
+      const settlement = await runtime.settleToolCall({
+        tool,
+        turnId: 'turn-1',
+        toolCallId: 'provider-call-1',
+        input: {},
+        abortSignal: new AbortController().signal,
+        eventSink: {
+          push: (event) => events.push(event),
+          pushAndWaitUntilConsumed: async (event) => {
+            events.push(event);
+          },
+        },
+      });
+      assert.equal(implementationCalls, 0);
+      assert.match(JSON.stringify(settlement.result), /Policy denied this command/u);
+      const toolStart = events.find((event) => event.type === 'tool_start');
+      assert.ok(toolStart && toolStart.type === 'tool_start');
+      assert.equal(toolStart.operationId, undefined);
+      assert.equal(events.filter((event) => event.type === 'tool_result').length, 1);
+      assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), []);
+    } finally {
+      store.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('replays raw MCP model arguments without persisting the execution binding', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-tool-sqlite-mcp-args-'));
     const store = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));

--- a/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
@@ -37,6 +37,7 @@ describe('ToolRuntime with real SQLite boundary', () => {
         runtimeCommitSink: store,
         preToolUseHooks: {
           prepareTurn: () => {},
+          releaseTurn: () => {},
           runPreToolUse: async () => ({
             denied: true,
             reason: 'Policy denied this command',

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -744,6 +744,8 @@ export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {
   openAiResponsesTransportState?: OpenAiResponsesTransportState;
   /** Optional fire-and-forget telemetry hook. Tool implementations remain unaware. */
   recordToolInvocation?: ToolTelemetryRecorder;
+  /** User/project PreToolUse policy dispatcher, frozen per turn by its snapshot loader. */
+  preToolUseHooks?: ToolRuntimeInput['preToolUseHooks'];
   /** Optional Phase 2 SQLite T1/T2 boundary for real tool execution. */
   runtimeCommitSink?: RuntimeCommitSink;
   /** Durable session-lifetime cumulative usage checkpoint after each completed provider step. */
@@ -1241,6 +1243,7 @@ export class AiSdkBackend implements AgentBackend {
       readChildAgentOutput: input.readChildAgentOutput,
       getRunTrace: () => identity.scope().runTrace,
       recordToolInvocation: input.recordToolInvocation,
+      preToolUseHooks: input.preToolUseHooks,
       runtimeCommitSink: input.runtimeCommitSink,
       recordToolArtifacts: input.recordToolArtifacts,
     });

--- a/packages/runtime/src/hooks/command-runner.ts
+++ b/packages/runtime/src/hooks/command-runner.ts
@@ -8,6 +8,7 @@ import {
 import { DEFAULT_PROCESS_TERMINATION_GRACE_MS } from '../process-tree-terminator.js';
 
 const HOOK_OUTPUT_LIMIT = 64 * 1024;
+export const HOOK_EXECUTION_MARKER = 'MAKA_HOOK_EXECUTION' as const;
 
 export interface HookCommandResult {
   exitCode: number | null;
@@ -36,6 +37,9 @@ async function runHookCommand(
   abortSignal: AbortSignal,
 ): Promise<HookCommandResult> {
   if (abortSignal.aborted) return emptyResult({ aborted: true });
+  if (process.env[HOOK_EXECUTION_MARKER] !== undefined) {
+    return emptyResult({ spawnError: 'Recursive Hook execution is not allowed' });
+  }
   let child: ReturnType<typeof spawn>;
   try {
     child = spawn(definition.command, definition.args, {
@@ -142,6 +146,7 @@ function minimalHookEnvironment(): NodeJS.ProcessEnv {
   for (const key of keep) {
     if (process.env[key] !== undefined) env[key] = process.env[key];
   }
+  env[HOOK_EXECUTION_MARKER] = '1';
   return env;
 }
 

--- a/packages/runtime/src/hooks/command-runner.ts
+++ b/packages/runtime/src/hooks/command-runner.ts
@@ -1,0 +1,161 @@
+import { spawn } from 'node:child_process';
+import type { PreToolUseHookInput, ResolvedHookDefinition } from '@maka/core/hooks';
+import { BashTailBuffer } from '../bash-tail-buffer.js';
+import {
+  DEFAULT_PROCESS_IO_DRAIN_TIMEOUT_MS,
+  manageChildProcessLifecycle,
+} from '../child-process-lifecycle.js';
+import { DEFAULT_PROCESS_TERMINATION_GRACE_MS } from '../process-tree-terminator.js';
+
+const HOOK_OUTPUT_LIMIT = 64 * 1024;
+
+export interface HookCommandResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  aborted: boolean;
+  spawnError?: string;
+}
+
+export interface HookCommandRunner {
+  run(
+    definition: ResolvedHookDefinition,
+    input: PreToolUseHookInput,
+    abortSignal: AbortSignal,
+  ): Promise<HookCommandResult>;
+}
+
+export function createHookCommandRunner(): HookCommandRunner {
+  return { run: runHookCommand };
+}
+
+async function runHookCommand(
+  definition: ResolvedHookDefinition,
+  input: PreToolUseHookInput,
+  abortSignal: AbortSignal,
+): Promise<HookCommandResult> {
+  if (abortSignal.aborted) return emptyResult({ aborted: true });
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(definition.command, definition.args, {
+      cwd: input.cwd,
+      env: minimalHookEnvironment(),
+      shell: false,
+      detached: process.platform !== 'win32',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    return emptyResult({ spawnError: errorMessage(error) });
+  }
+
+  const stdout = new BashTailBuffer(HOOK_OUTPUT_LIMIT);
+  const stderr = new BashTailBuffer(HOOK_OUTPUT_LIMIT);
+  child.stdout?.setEncoding('utf8');
+  child.stderr?.setEncoding('utf8');
+  child.stdout?.on('data', (chunk: string) => stdout.push(chunk));
+  child.stderr?.on('data', (chunk: string) => stderr.push(chunk));
+
+  const lifecycle = manageChildProcessLifecycle(
+    child,
+    [
+      ...(child.stdout ? [{ key: 'stdout' as const, stream: child.stdout }] : []),
+      ...(child.stderr ? [{ key: 'stderr' as const, stream: child.stderr }] : []),
+    ],
+    {
+      killGraceMs: DEFAULT_PROCESS_TERMINATION_GRACE_MS,
+      ioDrainTimeoutMs: DEFAULT_PROCESS_IO_DRAIN_TIMEOUT_MS,
+    },
+  );
+
+  let timedOut = false;
+  let aborted = false;
+  let inputError: string | undefined;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    lifecycle.terminate();
+  }, definition.timeoutMs);
+  const abort = () => {
+    aborted = true;
+    lifecycle.terminate();
+  };
+  abortSignal.addEventListener('abort', abort, { once: true });
+
+  try {
+    await writeHookInput(child.stdin, input).catch((error) => {
+      inputError = errorMessage(error);
+      lifecycle.terminate();
+    });
+    const result = await lifecycle.completion;
+    return {
+      exitCode: result.exitCode,
+      stdout: stdout.value(),
+      stderr: stderr.value(),
+      timedOut,
+      aborted,
+      ...(inputError ? { spawnError: `Failed to write Hook stdin: ${inputError}` } : {}),
+    };
+  } catch (error) {
+    return {
+      ...emptyResult({ spawnError: errorMessage(error) }),
+      stdout: stdout.value(),
+      stderr: stderr.value(),
+      timedOut,
+      aborted,
+    };
+  } finally {
+    clearTimeout(timer);
+    abortSignal.removeEventListener('abort', abort);
+  }
+}
+
+function writeHookInput(
+  stdin: NodeJS.WritableStream | null,
+  input: PreToolUseHookInput,
+): Promise<void> {
+  if (!stdin) return Promise.reject(new Error('Hook stdin is unavailable'));
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    stdin.once('error', onError);
+    stdin.end(`${JSON.stringify(input)}\n`, () => {
+      stdin.removeListener('error', onError);
+      resolve();
+    });
+  });
+}
+
+function minimalHookEnvironment(): NodeJS.ProcessEnv {
+  const keep = [
+    'PATH',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LC_CTYPE',
+    'TMPDIR',
+    'TMP',
+    'TEMP',
+    'SystemRoot',
+    'ComSpec',
+    'PATHEXT',
+  ];
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of keep) {
+    if (process.env[key] !== undefined) env[key] = process.env[key];
+  }
+  return env;
+}
+
+function emptyResult(input: { aborted?: boolean; spawnError?: string }): HookCommandResult {
+  return {
+    exitCode: null,
+    stdout: '',
+    stderr: '',
+    timedOut: false,
+    aborted: input.aborted ?? false,
+    ...(input.spawnError ? { spawnError: input.spawnError } : {}),
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/runtime/src/hooks/engine.ts
+++ b/packages/runtime/src/hooks/engine.ts
@@ -1,0 +1,259 @@
+import type {
+  HookCompletedAudit,
+  PreToolUseHookInput,
+  ResolvedHookDefinition,
+} from '@maka/core/hooks';
+import {
+  createHookCommandRunner,
+  type HookCommandResult,
+  type HookCommandRunner,
+} from './command-runner.js';
+import { hookMatcherMatches } from './matcher.js';
+
+const DEFAULT_CONCURRENCY = 8;
+const MAX_DENIAL_REASON_CHARS = 4_000;
+const MAX_AUDIT_MESSAGE_CHARS = 4_000;
+
+export interface HookDispatchResult {
+  denied: boolean;
+  reason?: string;
+  audits: HookCompletedAudit[];
+  auditWriteFailures: string[];
+}
+
+export interface PreToolUseHookDispatcher {
+  prepareTurn(turnId: string): void;
+  runPreToolUse(
+    input: PreToolUseHookInput,
+    abortSignal: AbortSignal,
+    context: HookDispatchRuntimeContext,
+  ): Promise<HookDispatchResult>;
+}
+
+export interface HookDispatchRuntimeContext {
+  invocationId: string;
+}
+
+export interface PreToolUseHookDispatcherInput {
+  loadSnapshot(turnId: string): Promise<readonly ResolvedHookDefinition[]>;
+  recordAudit?: (
+    input: PreToolUseHookInput,
+    audit: HookCompletedAudit,
+    context: HookDispatchRuntimeContext,
+  ) => Promise<void>;
+  commandRunner?: HookCommandRunner;
+  now?: () => number;
+  concurrency?: number;
+}
+
+export function createPreToolUseHookDispatcher(
+  input: PreToolUseHookDispatcherInput,
+): PreToolUseHookDispatcher {
+  const commandRunner = input.commandRunner ?? createHookCommandRunner();
+  const now = input.now ?? Date.now;
+  const concurrency = input.concurrency ?? DEFAULT_CONCURRENCY;
+  const snapshots = new Map<string, Promise<readonly ResolvedHookDefinition[]>>();
+
+  const snapshotForTurn = (turnId: string): Promise<readonly ResolvedHookDefinition[]> => {
+    let snapshot = snapshots.get(turnId);
+    if (!snapshot) {
+      snapshot = input.loadSnapshot(turnId);
+      snapshots.set(turnId, snapshot);
+      while (snapshots.size > 8) snapshots.delete(snapshots.keys().next().value!);
+    }
+    return snapshot;
+  };
+
+  return {
+    prepareTurn(turnId) {
+      void snapshotForTurn(turnId).catch(() => {});
+    },
+    async runPreToolUse(hookInput, abortSignal, context) {
+      const definitions = await snapshotForTurn(hookInput.turn_id);
+      const matching = definitions.filter((definition) =>
+        hookMatcherMatches(definition.matcher, hookInput.tool_name),
+      );
+      const audits = await mapConcurrent(matching, concurrency, async (definition) => {
+        if (!definition.trusted) {
+          return auditFor(definition, hookInput, 'skipped_untrusted', 0, 'Review required');
+        }
+        const startedAt = now();
+        const result = await commandRunner.run(definition, hookInput, abortSignal);
+        return auditFromCommandResult(
+          definition,
+          hookInput,
+          result,
+          Math.max(0, now() - startedAt),
+        );
+      });
+      const auditWriteFailures: string[] = [];
+      if (input.recordAudit) {
+        for (const audit of audits) {
+          try {
+            await input.recordAudit(hookInput, audit, context);
+          } catch (error) {
+            auditWriteFailures.push(errorMessage(error));
+          }
+        }
+      }
+      const denials = audits.filter((audit) => audit.status === 'denied');
+      return {
+        denied: denials.length > 0,
+        ...(denials.length > 0
+          ? {
+              reason: boundText(
+                denials
+                  .map((audit) => audit.message || `Hook ${audit.handlerId} denied this tool call.`)
+                  .join('\n'),
+                MAX_DENIAL_REASON_CHARS,
+              ),
+            }
+          : {}),
+        audits,
+        auditWriteFailures,
+      };
+    },
+  };
+}
+
+function auditFromCommandResult(
+  definition: ResolvedHookDefinition,
+  input: PreToolUseHookInput,
+  result: HookCommandResult,
+  durationMs: number,
+): HookCompletedAudit {
+  if (result.aborted) {
+    return auditFor(definition, input, 'failed', durationMs, 'Hook aborted with the Turn');
+  }
+  if (result.timedOut) {
+    return auditFor(definition, input, 'failed', durationMs, 'Hook timed out');
+  }
+  if (result.spawnError) {
+    return auditFor(definition, input, 'failed', durationMs, result.spawnError);
+  }
+  if (result.exitCode === 2) {
+    return auditFor(
+      definition,
+      input,
+      'denied',
+      durationMs,
+      result.stderr.trim() || `Hook ${definition.id} denied this tool call.`,
+    );
+  }
+  if (result.exitCode !== 0) {
+    return auditFor(
+      definition,
+      input,
+      'failed',
+      durationMs,
+      `Hook exited with code ${String(result.exitCode)}`,
+    );
+  }
+  const stdout = result.stdout.trim();
+  if (!stdout) return auditFor(definition, input, 'allowed', durationMs);
+  try {
+    const decision = parseStructuredDecision(stdout);
+    return auditFor(
+      definition,
+      input,
+      decision.decision === 'deny' ? 'denied' : 'allowed',
+      durationMs,
+      decision.reason,
+    );
+  } catch (error) {
+    return auditFor(definition, input, 'failed', durationMs, errorMessage(error));
+  }
+}
+
+function parseStructuredDecision(stdout: string): { decision: 'allow' | 'deny'; reason?: string } {
+  const root = exactRecord(JSON.parse(stdout), ['hookSpecificOutput'], 'Hook output');
+  const output = exactRecord(
+    root.hookSpecificOutput,
+    ['hookEventName', 'permissionDecision', 'permissionDecisionReason'],
+    'hookSpecificOutput',
+  );
+  if (output.hookEventName !== 'PreToolUse') {
+    throw new Error('hookSpecificOutput.hookEventName must be PreToolUse');
+  }
+  if (output.permissionDecision !== 'allow' && output.permissionDecision !== 'deny') {
+    throw new Error('hookSpecificOutput.permissionDecision must be allow or deny');
+  }
+  if (
+    output.permissionDecisionReason !== undefined &&
+    typeof output.permissionDecisionReason !== 'string'
+  ) {
+    throw new Error('hookSpecificOutput.permissionDecisionReason must be a string');
+  }
+  return {
+    decision: output.permissionDecision,
+    ...(output.permissionDecisionReason
+      ? { reason: boundText(output.permissionDecisionReason, MAX_AUDIT_MESSAGE_CHARS) }
+      : {}),
+  };
+}
+
+function auditFor(
+  definition: ResolvedHookDefinition,
+  input: PreToolUseHookInput,
+  status: HookCompletedAudit['status'],
+  durationMs: number,
+  message?: string,
+): HookCompletedAudit {
+  return {
+    eventName: 'PreToolUse',
+    handlerId: definition.id,
+    definitionHash: definition.definitionHash,
+    source: definition.source,
+    toolUseId: input.tool_use_id,
+    toolName: input.tool_name,
+    status,
+    durationMs,
+    ...(message ? { message: boundText(message, MAX_AUDIT_MESSAGE_CHARS) } : {}),
+  };
+}
+
+async function mapConcurrent<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  worker: (value: T) => Promise<R>,
+): Promise<R[]> {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('Hook concurrency must be a positive integer');
+  }
+  const results = new Array<R>(values.length);
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+      while (next < values.length) {
+        const index = next;
+        next += 1;
+        results[index] = await worker(values[index]!);
+      }
+    }),
+  );
+  return results;
+}
+
+function exactRecord(
+  value: unknown,
+  keys: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const record = value as Record<string, unknown>;
+  const allowed = new Set(keys);
+  const unknown = Object.keys(record).find((key) => !allowed.has(key));
+  if (unknown) throw new Error(`${label} contains unknown field: ${unknown}`);
+  return record;
+}
+
+function boundText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, Math.max(0, maxChars - 1))}…`;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/runtime/src/hooks/engine.ts
+++ b/packages/runtime/src/hooks/engine.ts
@@ -23,6 +23,7 @@ export interface HookDispatchResult {
 
 export interface PreToolUseHookDispatcher {
   prepareTurn(turnId: string): void;
+  releaseTurn(turnId: string): void;
   runPreToolUse(
     input: PreToolUseHookInput,
     abortSignal: AbortSignal,
@@ -44,6 +45,41 @@ export interface PreToolUseHookDispatcherInput {
   commandRunner?: HookCommandRunner;
   now?: () => number;
   concurrency?: number;
+  executionLimiter?: HookExecutionLimiter;
+}
+
+export interface HookExecutionLimiter {
+  run<T>(operation: () => Promise<T>): Promise<T>;
+}
+
+export function createHookExecutionLimiter(
+  concurrency = DEFAULT_CONCURRENCY,
+): HookExecutionLimiter {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('Hook concurrency must be a positive integer');
+  }
+  let active = 0;
+  const queued: Array<() => void> = [];
+  const drain = () => {
+    while (active < concurrency && queued.length > 0) queued.shift()?.();
+  };
+  return {
+    run<T>(operation: () => Promise<T>): Promise<T> {
+      return new Promise<T>((resolve, reject) => {
+        queued.push(() => {
+          active += 1;
+          void Promise.resolve()
+            .then(operation)
+            .then(resolve, reject)
+            .finally(() => {
+              active -= 1;
+              drain();
+            });
+        });
+        drain();
+      });
+    },
+  };
 }
 
 export function createPreToolUseHookDispatcher(
@@ -52,6 +88,7 @@ export function createPreToolUseHookDispatcher(
   const commandRunner = input.commandRunner ?? createHookCommandRunner();
   const now = input.now ?? Date.now;
   const concurrency = input.concurrency ?? DEFAULT_CONCURRENCY;
+  const executionLimiter = input.executionLimiter ?? createHookExecutionLimiter(concurrency);
   const snapshots = new Map<string, Promise<readonly ResolvedHookDefinition[]>>();
 
   const snapshotForTurn = (turnId: string): Promise<readonly ResolvedHookDefinition[]> => {
@@ -59,7 +96,6 @@ export function createPreToolUseHookDispatcher(
     if (!snapshot) {
       snapshot = input.loadSnapshot(turnId);
       snapshots.set(turnId, snapshot);
-      while (snapshots.size > 8) snapshots.delete(snapshots.keys().next().value!);
     }
     return snapshot;
   };
@@ -67,6 +103,9 @@ export function createPreToolUseHookDispatcher(
   return {
     prepareTurn(turnId) {
       void snapshotForTurn(turnId).catch(() => {});
+    },
+    releaseTurn(turnId) {
+      snapshots.delete(turnId);
     },
     async runPreToolUse(hookInput, abortSignal, context) {
       const definitions = await snapshotForTurn(hookInput.turn_id);
@@ -78,7 +117,9 @@ export function createPreToolUseHookDispatcher(
           return auditFor(definition, hookInput, 'skipped_untrusted', 0, 'Review required');
         }
         const startedAt = now();
-        const result = await commandRunner.run(definition, hookInput, abortSignal);
+        const result = await executionLimiter.run(() =>
+          commandRunner.run(definition, hookInput, abortSignal),
+        );
         return auditFromCommandResult(
           definition,
           hookInput,

--- a/packages/runtime/src/hooks/matcher.ts
+++ b/packages/runtime/src/hooks/matcher.ts
@@ -1,0 +1,11 @@
+export function hookMatcherMatches(matcher: string, toolName: string): boolean {
+  for (const token of matcher.split('|')) {
+    if (token === '*') return true;
+    if (token.endsWith('*')) {
+      if (toolName.startsWith(token.slice(0, -1))) return true;
+      continue;
+    }
+    if (token === toolName) return true;
+  }
+  return false;
+}

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -321,6 +321,12 @@ export function projectRuntimeEventsToStoredMessages(
       projected = true;
     }
 
+    if (event.actions?.hookCompleted) {
+      // Lifecycle Hook results are bounded policy/audit facts. A denial's
+      // synthetic function response owns the provider-visible row.
+      projected = true;
+    }
+
     if (isContinuationStartRuntimeEvent(event)) {
       // Continuation start is a canonical lineage/recovery fact with no
       // legacy chat row. Its following model events own the visible output.

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -78,6 +78,7 @@ import {
   type RuntimeInteractionClosureReason,
   type RuntimeUserQuestionClosureReason,
 } from './interaction-authority.js';
+import type { PreToolUseHookDispatcher } from './hooks/engine.js';
 
 export interface ResolvedMakaToolCall {
   tool: MakaTool;
@@ -437,6 +438,8 @@ export interface ToolRuntimeInput {
   getRunTrace?: () => RunTraceLike | null;
   recordToolInvocation?: ToolTelemetryRecorder;
   recordToolArtifacts?: ToolArtifactRecorder;
+  /** Immutable-per-turn user/project policy Hook dispatcher. */
+  preToolUseHooks?: PreToolUseHookDispatcher;
   /** Optional Phase 2 T1/T2 commit boundary for hosts that persist RuntimeEvents. */
   runtimeCommitSink?: RuntimeCommitSink;
 }
@@ -525,6 +528,7 @@ export class ToolRuntime {
     this.turnId = input.turnId;
     this.hostedInteraction = hosted;
     this.readExecutionBoundary = input.readExecutionBoundary;
+    input.preToolUseHooks?.prepareTurn(this.turnId);
   }
 
   async endTurn(reason: 'completed' | 'aborted' = 'completed'): Promise<void> {
@@ -1257,6 +1261,78 @@ export class ToolRuntime {
       await refuseBeforeDispatch(SUBAGENT_TOOL_LIMIT_MESSAGE);
       this.recordLoopGateOutcome(callSignature, true);
       return this.errorReturn(SUBAGENT_TOOL_LIMIT_MESSAGE);
+    }
+
+    if (this.input.preToolUseHooks) {
+      let hookResult;
+      try {
+        hookResult = await this.input.preToolUseHooks.runPreToolUse(
+          {
+            schema_version: 1,
+            hook_event_name: 'PreToolUse',
+            session_id: this.input.sessionId,
+            turn_id: turnId,
+            run_id: runId ?? turnId,
+            tool_use_id: toolUseId,
+            tool_name: tool.name,
+            tool_input: structuredClone(executionArgs),
+            cwd: this.input.header.cwd,
+            permission_mode: this.input.header.permissionMode,
+            origin: ctx.origin,
+          },
+          ctx.abortSignal,
+          { invocationId: invocationId ?? runId ?? turnId },
+        );
+      } catch (error) {
+        if (ctx.abortSignal.aborted) {
+          this.releaseSubagentSlot(tool);
+          throw ctx.abortSignal.reason ?? new DOMException('Aborted', 'AbortError');
+        }
+        trace?.emit('tool', 'tool_failed', 'PreToolUse Hook dispatcher failed open', {
+          toolUseId,
+          toolName: tool.name,
+          status: 'warning',
+          errorClass: 'HookDispatcherFailure',
+        });
+      }
+      if (ctx.abortSignal.aborted) {
+        this.releaseSubagentSlot(tool);
+        throw ctx.abortSignal.reason ?? new DOMException('Aborted', 'AbortError');
+      }
+      if (hookResult) {
+        for (const audit of hookResult.audits) {
+          if (audit.status === 'failed' || audit.status === 'skipped_untrusted') {
+            trace?.emit('tool', 'tool_failed', 'PreToolUse Hook did not produce a decision', {
+              toolUseId,
+              toolName: tool.name,
+              hookId: audit.handlerId,
+              hookStatus: audit.status,
+              errorClass: 'HookFailure',
+            });
+          }
+        }
+        if (hookResult.auditWriteFailures.length > 0) {
+          trace?.emit('tool', 'tool_failed', 'PreToolUse Hook audit write failed', {
+            toolUseId,
+            toolName: tool.name,
+            failureCount: hookResult.auditWriteFailures.length,
+            errorClass: 'HookAuditFailure',
+          });
+        }
+        if (hookResult.denied) {
+          this.releaseSubagentSlot(tool);
+          const reason = hookResult.reason ?? 'A PreToolUse Hook denied this tool call.';
+          await refuseBeforeDispatch(reason);
+          trace?.emit('tool', 'tool_failed', 'PreToolUse Hook denied tool execution', {
+            toolUseId,
+            toolName: tool.name,
+            status: 'error',
+            errorClass: 'HookDenied',
+          });
+          this.recordLoopGateOutcome(callSignature, true);
+          return this.errorReturn(reason);
+        }
+      }
     }
 
     let durableAttempt: DurableToolAttempt | undefined;

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -593,6 +593,7 @@ export class ToolRuntime {
     // Bounded, not open-ended: every rejection above has already been
     // dispatched, and running impls observe the turn abort signal.
     await Promise.allSettled([...this.activeToolSettlements]);
+    this.input.preToolUseHooks?.releaseTurn(turnId);
     if (boundarySettlementErrors.length > 0) {
       throw new AggregateError(
         boundarySettlementErrors,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -38,7 +38,9 @@
     "./model-call-ledger": "./dist/model-call-ledger.js",
     "./usage-stores": "./dist/usage-stores.js",
     "./workspace-identity": "./dist/workspace-identity.js",
-    "./write-queue": "./dist/write-queue.js"
+    "./write-queue": "./dist/write-queue.js",
+    "./hook-config-store": "./dist/hook-config-store.js",
+    "./hook-trust-store": "./dist/hook-trust-store.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/storage/src/__tests__/hook-config-store.test.ts
+++ b/packages/storage/src/__tests__/hook-config-store.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { createHookConfigStore, normalizeHookConfig } from '../hook-config-store.js';
+import { createHookTrustStore } from '../hook-trust-store.js';
+
+describe('Hook config store', () => {
+  it('normalizes the bounded command-only v1 contract', () => {
+    const config = normalizeHookConfig({
+      version: 1,
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: 'Bash|mcp__github__*',
+            hooks: [
+              {
+                id: 'policy',
+                type: 'command',
+                command: '/usr/bin/true',
+              },
+            ],
+          },
+        ],
+      },
+    });
+    assert.deepEqual(config.hooks.PreToolUse?.[0]?.hooks[0], {
+      id: 'policy',
+      type: 'command',
+      command: '/usr/bin/true',
+      args: [],
+      timeoutMs: 3_000,
+      enabled: true,
+    });
+  });
+
+  it('rejects unknown fields, shell strings, arbitrary globs, and duplicate ids', () => {
+    assert.throws(
+      () => normalizeHookConfig({ version: 1, hooks: {}, typo: true }),
+      /unknown field/u,
+    );
+    assert.throws(
+      () =>
+        normalizeHookConfig({
+          version: 1,
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: 'B*sh',
+                hooks: [{ id: 'x', type: 'command', command: '/usr/bin/true' }],
+              },
+            ],
+          },
+        }),
+      /matcher is invalid/u,
+    );
+    assert.throws(
+      () =>
+        normalizeHookConfig({
+          version: 1,
+          hooks: {
+            PreToolUse: [
+              {
+                hooks: [
+                  { id: 'same', type: 'command', command: '/usr/bin/true' },
+                  { id: 'same', type: 'command', command: '/usr/bin/false' },
+                ],
+              },
+            ],
+          },
+        }),
+      /Duplicate/u,
+    );
+    assert.throws(
+      () =>
+        normalizeHookConfig({
+          version: 1,
+          hooks: {
+            PreToolUse: [{ hooks: [{ id: 'x', type: 'command', command: 'echo unsafe' }] }],
+          },
+        }),
+      /absolute path/u,
+    );
+  });
+
+  it('persists private config and exact-hash trust records atomically', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-hooks-store-'));
+    try {
+      const configStore = createHookConfigStore(root);
+      await configStore.set({
+        version: 1,
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [{ id: 'policy', type: 'command', command: '/usr/bin/true' }],
+            },
+          ],
+        },
+      });
+      assert.equal((await configStore.get()).hooks.PreToolUse?.[0]?.matcher, 'Bash');
+      assert.match(await readFile(join(root, 'hooks.json'), 'utf8'), /"policy"/u);
+
+      const trustStore = createHookTrustStore(root);
+      const hash = `sha256:${'a'.repeat(64)}` as const;
+      await trustStore.trust({
+        definitionHash: hash,
+        source: 'user',
+        projectIdentity: 'user',
+        trustedAt: 123,
+      });
+      assert.equal((await trustStore.get()).trustedDefinitions[0]?.definitionHash, hash);
+      await trustStore.revoke(hash);
+      assert.deepEqual((await trustStore.get()).trustedDefinitions, []);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/storage/src/hook-config-store.ts
+++ b/packages/storage/src/hook-config-store.ts
@@ -1,0 +1,209 @@
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, isAbsolute, join } from 'node:path';
+import {
+  HOOK_CONFIG_VERSION,
+  createDefaultHookConfig,
+  type HookCommandConfig,
+  type HookConfigFile,
+  type HookMatcherGroupConfig,
+} from '@maka/core/hooks';
+
+const MAX_CONFIG_BYTES = 1_048_576;
+const MAX_HANDLERS = 128;
+const MAX_ID_LENGTH = 128;
+const MAX_STRING_LENGTH = 8_192;
+const DEFAULT_TIMEOUT_MS = 3_000;
+const MIN_TIMEOUT_MS = 100;
+const MAX_TIMEOUT_MS = 30_000;
+
+export interface HookConfigStore {
+  get(): Promise<HookConfigFile>;
+  set(config: HookConfigFile): Promise<HookConfigFile>;
+}
+
+export function createHookConfigStore(stateRoot: string): HookConfigStore {
+  return new FileHookConfigStore(join(stateRoot, 'hooks.json'));
+}
+
+export async function readHookConfigFile(path: string): Promise<HookConfigFile> {
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return createDefaultHookConfig();
+    throw error;
+  }
+  if (Buffer.byteLength(text, 'utf8') > MAX_CONFIG_BYTES) {
+    throw new Error('Hook config exceeds 1 MiB');
+  }
+  return normalizeHookConfig(JSON.parse(text));
+}
+
+export function normalizeHookConfig(value: unknown): HookConfigFile {
+  const root = recordWithKeys(value, ['version', 'hooks'], 'Hook config');
+  if (root.version !== HOOK_CONFIG_VERSION) {
+    throw new Error(`Unsupported Hook config version: ${String(root.version)}`);
+  }
+  const hooks = recordWithKeys(root.hooks, ['PreToolUse'], 'hooks');
+  const rawGroups = hooks.PreToolUse ?? [];
+  if (!Array.isArray(rawGroups)) throw new Error('hooks.PreToolUse must be an array');
+
+  const ids = new Set<string>();
+  let handlerCount = 0;
+  const groups: HookMatcherGroupConfig[] = rawGroups.map((rawGroup, groupIndex) => {
+    const group = recordWithKeys(rawGroup, ['matcher', 'hooks'], `PreToolUse[${groupIndex}]`);
+    const matcher = normalizeMatcher(group.matcher, groupIndex);
+    if (!Array.isArray(group.hooks)) {
+      throw new Error(`PreToolUse[${groupIndex}].hooks must be an array`);
+    }
+    const handlers = group.hooks.map((rawHandler, handlerIndex) => {
+      handlerCount += 1;
+      if (handlerCount > MAX_HANDLERS) {
+        throw new Error(`Hook config exceeds ${MAX_HANDLERS} handlers`);
+      }
+      const handler = normalizeHandler(rawHandler, groupIndex, handlerIndex);
+      if (ids.has(handler.id)) throw new Error(`Duplicate Hook handler id: ${handler.id}`);
+      ids.add(handler.id);
+      return handler;
+    });
+    return { matcher, hooks: handlers };
+  });
+
+  return {
+    version: HOOK_CONFIG_VERSION,
+    hooks: groups.length > 0 ? { PreToolUse: groups } : {},
+  };
+}
+
+class FileHookConfigStore implements HookConfigStore {
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(private readonly path: string) {}
+
+  get(): Promise<HookConfigFile> {
+    return this.serial(() => readHookConfigFile(this.path));
+  }
+
+  async set(config: HookConfigFile): Promise<HookConfigFile> {
+    const normalized = normalizeHookConfig(config);
+    return this.serial(async () => {
+      await writePrivateJson(this.path, normalized, '.hooks-');
+      return normalized;
+    });
+  }
+
+  private async serial<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.queue;
+    let release!: () => void;
+    this.queue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
+function normalizeMatcher(value: unknown, groupIndex: number): string {
+  if (value === undefined) return '*';
+  const matcher = boundedString(value, `PreToolUse[${groupIndex}].matcher`, 1_024);
+  const tokens = matcher.split('|');
+  if (
+    tokens.some(
+      (token) =>
+        !token ||
+        token.trim() !== token ||
+        token.includes('\0') ||
+        (token.includes('*') && !/^[^*]+\*$/u.test(token) && token !== '*'),
+    )
+  ) {
+    throw new Error(`PreToolUse[${groupIndex}].matcher is invalid`);
+  }
+  return matcher;
+}
+
+function normalizeHandler(
+  value: unknown,
+  groupIndex: number,
+  handlerIndex: number,
+): HookCommandConfig {
+  const label = `PreToolUse[${groupIndex}].hooks[${handlerIndex}]`;
+  const handler = recordWithKeys(
+    value,
+    ['id', 'type', 'command', 'args', 'timeoutMs', 'enabled'],
+    label,
+  );
+  const id = boundedString(handler.id, `${label}.id`, MAX_ID_LENGTH);
+  if (handler.type !== 'command') throw new Error(`${label}.type must be command`);
+  const command = boundedString(handler.command, `${label}.command`, MAX_STRING_LENGTH);
+  if (!isAbsolute(command)) throw new Error(`${label}.command must be an absolute path`);
+  const args = handler.args === undefined ? [] : normalizeArgs(handler.args, `${label}.args`);
+  const timeoutMs = handler.timeoutMs === undefined ? DEFAULT_TIMEOUT_MS : handler.timeoutMs;
+  if (
+    !Number.isInteger(timeoutMs) ||
+    (timeoutMs as number) < MIN_TIMEOUT_MS ||
+    (timeoutMs as number) > MAX_TIMEOUT_MS
+  ) {
+    throw new Error(`${label}.timeoutMs must be between ${MIN_TIMEOUT_MS} and ${MAX_TIMEOUT_MS}`);
+  }
+  const enabled = handler.enabled === undefined ? true : handler.enabled;
+  if (typeof enabled !== 'boolean') throw new Error(`${label}.enabled must be boolean`);
+  return { id, type: 'command', command, args, timeoutMs: timeoutMs as number, enabled };
+}
+
+function normalizeArgs(value: unknown, label: string): string[] {
+  if (!Array.isArray(value) || value.length > 1_000) throw new Error(`${label} must be an array`);
+  return value.map((item, index) =>
+    boundedString(item, `${label}[${index}]`, MAX_STRING_LENGTH, true),
+  );
+}
+
+function boundedString(value: unknown, label: string, max: number, allowEmpty = false): string {
+  if (
+    typeof value !== 'string' ||
+    (!allowEmpty && !value.trim()) ||
+    value.length > max ||
+    value.includes('\0')
+  ) {
+    throw new Error(`${label} must be a valid string`);
+  }
+  return value;
+}
+
+function recordWithKeys(
+  value: unknown,
+  keys: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const record = value as Record<string, unknown>;
+  const allowed = new Set(keys);
+  const unknown = Object.keys(record).find((key) => !allowed.has(key));
+  if (unknown) throw new Error(`${label} contains unknown field: ${unknown}`);
+  return record;
+}
+
+async function writePrivateJson(path: string, value: unknown, prefix: string): Promise<void> {
+  const dir = dirname(path);
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  if (process.platform !== 'win32') await chmod(dir, 0o700);
+  const tempPath = join(dir, `${prefix}${randomUUID()}.tmp`);
+  try {
+    await writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600,
+      flag: 'wx',
+    });
+    if (process.platform !== 'win32') await chmod(tempPath, 0o600);
+    await rename(tempPath, path);
+    if (process.platform !== 'win32') await chmod(path, 0o600);
+  } finally {
+    await rm(tempPath, { force: true }).catch(() => {});
+  }
+}

--- a/packages/storage/src/hook-trust-store.ts
+++ b/packages/storage/src/hook-trust-store.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from 'node:crypto';
+import { chmod, mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import {
+  HOOK_TRUST_VERSION,
+  createDefaultHookTrust,
+  type HookSource,
+  type HookTrustFile,
+  type HookTrustRecord,
+} from '@maka/core/hooks';
+
+const MAX_TRUST_BYTES = 1_048_576;
+const MAX_RECORDS = 4_096;
+const HASH_PATTERN = /^sha256:[0-9a-f]{64}$/u;
+
+export interface HookTrustStore {
+  get(): Promise<HookTrustFile>;
+  trust(record: HookTrustRecord): Promise<HookTrustFile>;
+  revoke(definitionHash: string): Promise<HookTrustFile>;
+}
+
+export function createHookTrustStore(stateRoot: string): HookTrustStore {
+  return new FileHookTrustStore(join(stateRoot, 'hook-trust.json'));
+}
+
+export function normalizeHookTrust(value: unknown): HookTrustFile {
+  const root = exactRecord(value, ['version', 'trustedDefinitions'], 'Hook trust');
+  if (root.version !== HOOK_TRUST_VERSION) {
+    throw new Error(`Unsupported Hook trust version: ${String(root.version)}`);
+  }
+  if (!Array.isArray(root.trustedDefinitions) || root.trustedDefinitions.length > MAX_RECORDS) {
+    throw new Error(`trustedDefinitions must contain at most ${MAX_RECORDS} records`);
+  }
+  const seen = new Set<string>();
+  const records = root.trustedDefinitions.map((value, index) => {
+    const label = `trustedDefinitions[${index}]`;
+    const record = exactRecord(
+      value,
+      ['definitionHash', 'source', 'projectIdentity', 'trustedAt'],
+      label,
+    );
+    if (typeof record.definitionHash !== 'string' || !HASH_PATTERN.test(record.definitionHash)) {
+      throw new Error(`${label}.definitionHash is invalid`);
+    }
+    if (seen.has(record.definitionHash)) throw new Error(`Duplicate trusted definition hash`);
+    seen.add(record.definitionHash);
+    if (record.source !== 'user' && record.source !== 'project') {
+      throw new Error(`${label}.source is invalid`);
+    }
+    if (
+      typeof record.projectIdentity !== 'string' ||
+      !record.projectIdentity ||
+      record.projectIdentity.length > 8_192
+    ) {
+      throw new Error(`${label}.projectIdentity is invalid`);
+    }
+    if (!Number.isFinite(record.trustedAt) || (record.trustedAt as number) < 0) {
+      throw new Error(`${label}.trustedAt is invalid`);
+    }
+    return {
+      definitionHash: record.definitionHash as `sha256:${string}`,
+      source: record.source as HookSource,
+      projectIdentity: record.projectIdentity,
+      trustedAt: record.trustedAt as number,
+    };
+  });
+  return { version: HOOK_TRUST_VERSION, trustedDefinitions: records };
+}
+
+class FileHookTrustStore implements HookTrustStore {
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(private readonly path: string) {}
+
+  get(): Promise<HookTrustFile> {
+    return this.serial(() => this.read());
+  }
+
+  trust(record: HookTrustRecord): Promise<HookTrustFile> {
+    const normalizedRecord = normalizeHookTrust({
+      version: HOOK_TRUST_VERSION,
+      trustedDefinitions: [record],
+    }).trustedDefinitions[0]!;
+    return this.serial(async () => {
+      const current = await this.read();
+      const next = normalizeHookTrust({
+        version: HOOK_TRUST_VERSION,
+        trustedDefinitions: [
+          ...current.trustedDefinitions.filter(
+            (candidate) => candidate.definitionHash !== normalizedRecord.definitionHash,
+          ),
+          normalizedRecord,
+        ],
+      });
+      await this.write(next);
+      return next;
+    });
+  }
+
+  revoke(definitionHash: string): Promise<HookTrustFile> {
+    return this.serial(async () => {
+      const current = await this.read();
+      const next: HookTrustFile = {
+        version: HOOK_TRUST_VERSION,
+        trustedDefinitions: current.trustedDefinitions.filter(
+          (record) => record.definitionHash !== definitionHash,
+        ),
+      };
+      await this.write(next);
+      return next;
+    });
+  }
+
+  private async read(): Promise<HookTrustFile> {
+    let text: string;
+    try {
+      text = await readFile(this.path, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return createDefaultHookTrust();
+      throw error;
+    }
+    if (Buffer.byteLength(text, 'utf8') > MAX_TRUST_BYTES) {
+      throw new Error('Hook trust file exceeds 1 MiB');
+    }
+    return normalizeHookTrust(JSON.parse(text));
+  }
+
+  private async write(value: HookTrustFile): Promise<void> {
+    const dir = dirname(this.path);
+    await mkdir(dir, { recursive: true, mode: 0o700 });
+    if (process.platform !== 'win32') await chmod(dir, 0o700);
+    const tempPath = join(dir, `.hook-trust-${randomUUID()}.tmp`);
+    try {
+      await writeFile(tempPath, `${JSON.stringify(value, null, 2)}\n`, {
+        encoding: 'utf8',
+        mode: 0o600,
+        flag: 'wx',
+      });
+      if (process.platform !== 'win32') await chmod(tempPath, 0o600);
+      await rename(tempPath, this.path);
+      if (process.platform !== 'win32') await chmod(this.path, 0o600);
+    } finally {
+      await rm(tempPath, { force: true }).catch(() => {});
+    }
+  }
+
+  private async serial<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.queue;
+    let release!: () => void;
+    this.queue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
+function exactRecord(
+  value: unknown,
+  keys: readonly string[],
+  label: string,
+): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  const record = value as Record<string, unknown>;
+  const allowed = new Set(keys);
+  const unknown = Object.keys(record).find((key) => !allowed.has(key));
+  if (unknown) throw new Error(`${label} contains unknown field: ${unknown}`);
+  return record;
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -123,6 +123,8 @@ export * from './runtime-event-persistence.js';
 export * from './operational-state-store.js';
 export * from './operational-state-backup.js';
 export * from './mcp-config-store.js';
+export * from './hook-config-store.js';
+export * from './hook-trust-store.js';
 export * from './workspace-identity.js';
 export * from './memory-bundle-store.js';
 export * from './long-term-memory-store.js';


### PR DESCRIPTION
## Summary

Introduce the backend foundation for user- and project-configurable `PreToolUse` policy hooks.

This PR implements the first two backend phases of #2908:

- a bounded, command-only Hook configuration and exact-definition trust model;
- Runtime Host composition and immutable per-Turn snapshots;
- a process runner and decision engine with deterministic denial semantics;
- the `ToolRuntime` integration point before durable dispatch (T1) and tool side effects;
- hidden, bounded runtime audit events;
- end-to-end coverage proving that a configured and trusted Hook can block a real tool call.

The goal is to support policies such as blocking `git push`, rejecting dangerous shell commands, or protecting project paths without allowing Hooks to bypass Maka's existing permission, sandbox, and durable-execution boundaries.

Refs #2908

## Configuration and trust contract

Runtime Host loads and merges:

- user Hooks from `<State Root>/hooks.json`;
- project Hooks from `<cwd>/.maka/hooks.json`.

V1 intentionally supports only `PreToolUse` command handlers. Matchers are bounded to `*`, exact-name unions such as `Bash|Write`, and trailing-prefix matches such as `mcp__github__*`. Commands must be absolute executable paths and are spawned with argv directly, never through an implicit shell.

```json
{
  "version": 1,
  "hooks": {
    "PreToolUse": [
      {
        "matcher": "Bash|Write|Edit|apply_patch",
        "hooks": [
          {
            "id": "project-policy",
            "type": "command",
            "command": "/absolute/path/to/check-tool-policy",
            "args": [],
            "timeoutMs": 3000,
            "enabled": true
          }
        ]
      }
    ]
  }
}
```

Each enabled definition is normalized and hashed from its source, project identity, event, matcher, command, arguments, and timeout. Trust records live in `<State Root>/hook-trust.json`; an execution-relevant change produces a new hash and is skipped until that exact definition is trusted again.

The effective Hook set is snapshotted once per Turn, so configuration changes cannot alter policy midway through an active Turn.

## Execution semantics

Each matching trusted handler receives versioned JSON on stdin containing the session, Turn, run, tool call, validated tool input, cwd, permission mode, and origin.

Decision handling is deliberately narrow:

| Hook result | Runtime behavior |
| --- | --- |
| `exit 0` with empty stdout | Allow |
| `exit 0` with valid structured output | Apply the explicit `allow` or `deny` decision |
| `exit 2` | Deny, using bounded stderr as the reason |
| Timeout, spawn failure, ordinary non-zero exit, or invalid output | Audit the failure and fail open |
| Untrusted matching definition | Skip execution and audit `skipped_untrusted` |

Matching handlers execute concurrently under a global limit. Any explicit denial wins, and multiple denial reasons are returned in stable configuration order rather than process-completion order.

The Hook gate runs in `ToolRuntime.executeTool()` after the existing admission/preflight guards and before `prepareDurableToolAttempt()`:

```text
existing tool admission and loop guards
  -> PreToolUse snapshot
       deny  -> paired synthetic error result, no T1, no operation ID, no tool side effect
       fail  -> bounded audit, continue
       allow -> existing durable dispatch, permission, sandbox, and tool implementation path
```

An allow result therefore does not grant permission or weaken any existing execution boundary.

## Security and failure boundaries

- Hook processes run with `shell: false`, the Host-resolved cwd, and a minimal environment allowlist.
- stdout and stderr are bounded to 64 KiB; denial and audit messages are bounded again before entering runtime state.
- timeouts and Turn aborts terminate the complete process tree.
- configuration and trust files use strict schemas, size/count limits, serialized updates, atomic replacement, and private file modes where supported.
- Hook audit facts are written as model-hidden `hookCompleted` RuntimeEvents; raw tool input and complete process output are not copied into the transcript.
- dispatcher failures and audit-write failures do not make tools unavailable; they fail open and emit trace diagnostics.

## Verification

Local verification:

- Runtime: `2755 passed / 9 skipped / 0 failed`
- Runtime Host: `831 passed / 0 failed`

The added tests cover:

- strict configuration normalization, private atomic persistence, trust/revoke, and invalid input rejection;
- per-Turn snapshotting and exact-hash trust invalidation on the next Turn;
- bounded matcher normalization and rejection of malformed wildcard forms;
- concurrent execution with deterministic denial aggregation;
- JSON stdin, `exit 0`, `exit 2`, and structured allow/deny output;
- fail-open behavior for handler, timeout, abort, dispatcher, and audit failures;
- pre-T1 denial with no operation ID and no tool implementation side effect;
- a real end-to-end `git push` policy fixture spanning config, trust, Runtime Host, `ToolRuntime`, SQLite audit persistence, and the synthetic tool result.

CI for `7589253f5` is green:

- CI: changes, typecheck, Runtime Host, workspace tests, desktop e2e, Storybook, and aggregate test gate;
- Dependency audit;
- Windows baseline;
- Windows recovery.

## Follow-up scope

This PR does not add the product-facing Hooks settings page, trust-review dialog, diagnostics UI, fixture-based “Test hook” action, or migration documentation. Those remain the third delivery phase tracked in #2908. Until that surface lands, this PR should be reviewed as the backend contract and runtime enforcement path, not as the complete end-user workflow.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — configured, trusted `PreToolUse` Hooks can deny a tool before durable dispatch
- [ ] No
