### PR TITLE
fix(runtime-host): reconnect after hosted target changes

### DIFF
--- a/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
@@ -91,7 +91,119 @@ test('post-connect cancellation reports the owned Host settlement outcome', asyn
   }
 });
 
+test('explicit target mutation settles the first Host before execution reconnects', async () => {
+  const projection = settled('completed');
+  const events: string[] = [];
+  const first = mutatingFirstHost(events);
+  const second = ownedHost({
+    request: async (operation: string) => {
+      events.push(`second:${operation}`);
+      assert.equal(operation, 'hosted.execution.start');
+      return projection;
+    },
+  });
+  second.connection.close = async () => {
+    events.push('second:close');
+  };
+  second.host.releaseToEnvironment = () => {
+    events.push('second:release');
+  };
+  const hosts = [first, second];
+  let connects = 0;
+
+  const result = await runHostedExecutionWithDependencies(explicitInput(), {
+    connectOwnedRuntimeHost: async () => {
+      connects += 1;
+      events.push(`connect:${connects}`);
+      return hosts.shift() as never;
+    },
+  });
+
+  assert.deepEqual(result, projection);
+  assert.deepEqual(events, [
+    'connect:1',
+    'first:connection.catalog.query',
+    'first:connection.models.fetch',
+    'first:connection.catalog.query',
+    'first:close',
+    'first:settle',
+    'connect:2',
+    'second:hosted.execution.start',
+    'second:close',
+    'second:release',
+  ]);
+});
+
+test('explicit target already admitted executes without reconnecting', async () => {
+  const projection = settled('completed');
+  const events: string[] = [];
+  const host = ownedHost({
+    request: async (operation: string) => {
+      events.push(operation);
+      if (operation === 'connection.catalog.query') return catalogPage(true);
+      if (operation === 'hosted.execution.start') return projection;
+      throw new Error(`Unexpected operation ${operation}`);
+    },
+  });
+  host.host.releaseToEnvironment = () => {
+    events.push('release');
+  };
+  let connects = 0;
+
+  const result = await runHostedExecutionWithDependencies(explicitInput(), {
+    connectOwnedRuntimeHost: async () => {
+      connects += 1;
+      return host as never;
+    },
+  });
+
+  assert.deepEqual(result, projection);
+  assert.equal(connects, 1);
+  assert.deepEqual(events, [
+    'connection.catalog.query',
+    'connection.catalog.query',
+    'hosted.execution.start',
+    'release',
+  ]);
+});
+
+test('explicit target reconnect failure reports the second Host startup cause', async () => {
+  const first = mutatingFirstHost([]);
+  let connects = 0;
+
+  const result = await runHostedExecutionWithDependencies(explicitInput(), {
+    connectOwnedRuntimeHost: async () => {
+      connects += 1;
+      return connects === 1
+        ? (first as never)
+        : { kind: 'failed' as const, reason: 'host_unresponsive' };
+    },
+  });
+
+  assert.equal(result.failureReason, 'Runtime Host did not start: host_unresponsive');
+  assert.equal(connects, 2);
+});
+
+test('explicit target reconnect cancellation preserves the cancelled outcome', async () => {
+  const abort = new AbortController();
+  const first = mutatingFirstHost([]);
+  let connects = 0;
+
+  const result = await runHostedExecutionWithDependencies(explicitInput(abort.signal), {
+    connectOwnedRuntimeHost: async () => {
+      connects += 1;
+      if (connects === 1) return first as never;
+      abort.abort(new Error('cancelled'));
+      return { kind: 'failed' as const, reason: 'host_unresponsive' };
+    },
+  });
+
+  assert.equal(result.failureReason, 'Hosted execution was cancelled');
+  assert.equal(connects, 2);
+});
+
 const ID = '00000000-0000-4000-8000-000000000001';
+const CONNECTION_ID = '00000000-0000-4000-8000-000000000002';
 
 function input(signal?: AbortSignal) {
   return {
@@ -105,6 +217,97 @@ function input(signal?: AbortSignal) {
       content: { text: 'solve' },
     },
     ...(signal ? { signal } : {}),
+  };
+}
+
+function explicitInput(signal?: AbortSignal) {
+  return {
+    ...input(signal),
+    baseUrl: 'https://api.deepseek.com',
+    execution: {
+      ...input().execution,
+      session: {
+        ...input().execution.session,
+        modelTarget: {
+          kind: 'explicit' as const,
+          connectionSlug: 'env-deepseek',
+          model: 'deepseek-v4-flash',
+        },
+      },
+    },
+  };
+}
+
+function mutatingFirstHost(events: string[]) {
+  let catalogQueries = 0;
+  const first = ownedHost({
+    request: async (operation: string) => {
+      events.push(`first:${operation}`);
+      if (operation === 'connection.catalog.query') {
+        catalogQueries += 1;
+        return catalogPage(catalogQueries > 1);
+      }
+      if (operation === 'connection.models.fetch') {
+        return {
+          kind: 'committed',
+          catalogRevision: 2,
+          connection: { connectionId: CONNECTION_ID, revision: 2 },
+          modelCount: 1,
+          source: 'fetched',
+          fetchedAt: 1,
+        };
+      }
+      throw new Error(`Unexpected first Host operation ${operation}`);
+    },
+  });
+  first.connection.close = async () => {
+    events.push('first:close');
+  };
+  first.host.settle = async () => {
+    events.push('first:settle');
+    return true;
+  };
+  return first;
+}
+
+function catalogPage(admitted: boolean) {
+  return {
+    kind: 'page' as const,
+    revision: admitted ? 2 : 1,
+    defaultTarget: { connectionId: CONNECTION_ID, modelId: 'deepseek-v4-flash' },
+    connectionCount: 1,
+    items: [
+      {
+        kind: 'connection' as const,
+        connectionIndex: 0,
+        connectionId: CONNECTION_ID,
+        revision: admitted ? 2 : 1,
+        slug: 'env-deepseek',
+        name: 'DeepSeek',
+        providerType: 'deepseek' as const,
+        baseUrl: 'https://api.deepseek.com/',
+        enabled: true,
+        enabledModelIdCount: 1,
+        modelCount: admitted ? 1 : 0,
+      },
+      {
+        kind: 'enabled_model_id' as const,
+        connectionIndex: 0,
+        itemIndex: 0,
+        modelId: 'deepseek-v4-flash',
+      },
+      ...(admitted
+        ? [
+            {
+              kind: 'model' as const,
+              connectionIndex: 0,
+              itemIndex: 0,
+              model: { id: 'deepseek-v4-flash' },
+            },
+          ]
+        : []),
+    ],
+    nextCursor: null,
   };
 }
 

--- a/packages/runtime-host/src/__tests__/hosted-execution-target.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-target.test.ts
@@ -40,11 +40,14 @@ test('explicit hosted target preserves the default target and proves the request
     },
   } as unknown as Pick<RuntimeHostConnection, 'request'>;
 
-  await configureHostedExecutionTarget(connection, {
-    connectionSlug: 'env-openai',
-    model: 'deepseek-v4-flash',
-    baseUrl: 'https://api.deepseek.com',
-  });
+  assert.equal(
+    await configureHostedExecutionTarget(connection, {
+      connectionSlug: 'env-openai',
+      model: 'deepseek-v4-flash',
+      baseUrl: 'https://api.deepseek.com',
+    }),
+    true,
+  );
 
   assert.deepEqual(
     requests.map(({ operation }) => operation),
@@ -93,12 +96,85 @@ test('explicit hosted target stops waiting when cancelled', { timeout: 1_000 }, 
   await assert.rejects(configuring, /cancelled/u);
 });
 
+test('explicit hosted target reports an already admitted target as unchanged', async () => {
+  const connection = {
+    request: async (operation: string) => {
+      assert.equal(operation, 'connection.catalog.query');
+      return catalogPage(['deepseek-v4-flash'], ['deepseek-v4-flash'], null, 'deepseek');
+    },
+  } as unknown as Pick<RuntimeHostConnection, 'request'>;
+
+  assert.equal(
+    await configureHostedExecutionTarget(connection, {
+      connectionSlug: 'env-openai',
+      model: 'deepseek-v4-flash',
+      baseUrl: 'https://api.deepseek.com',
+    }),
+    false,
+  );
+});
+
+test('explicit hosted target replaces a missing effective endpoint', async () => {
+  const operations: string[] = [];
+  let queryCount = 0;
+  const connection = {
+    request: async (operation: string) => {
+      operations.push(operation);
+      if (operation === 'connection.catalog.query') {
+        queryCount += 1;
+        return queryCount === 1
+          ? catalogPage(['deepseek-v4-flash'], [], null, 'openai-compatible')
+          : catalogPage(
+              ['deepseek-v4-flash'],
+              ['deepseek-v4-flash'],
+              'https://api.deepseek.com/',
+              'openai-compatible',
+            );
+      }
+      if (operation === 'connection.catalog.update') {
+        return {
+          kind: 'committed',
+          catalogRevision: 2,
+          connection: { connectionId: CONNECTION_ID, revision: 2 },
+        };
+      }
+      if (operation === 'connection.models.fetch') {
+        return {
+          kind: 'committed',
+          catalogRevision: 3,
+          connection: { connectionId: CONNECTION_ID, revision: 3 },
+          modelCount: 1,
+          source: 'fetched',
+          fetchedAt: 1,
+        };
+      }
+      throw new Error(`Unexpected operation ${operation}`);
+    },
+  } as unknown as Pick<RuntimeHostConnection, 'request'>;
+
+  assert.equal(
+    await configureHostedExecutionTarget(connection, {
+      connectionSlug: 'env-openai',
+      model: 'deepseek-v4-flash',
+      baseUrl: 'https://api.deepseek.com',
+    }),
+    true,
+  );
+  assert.deepEqual(operations, [
+    'connection.catalog.query',
+    'connection.catalog.update',
+    'connection.models.fetch',
+    'connection.catalog.query',
+  ]);
+});
+
 const CONNECTION_ID = '00000000-0000-4000-8000-000000000001';
 
 function catalogPage(
   enabledModelIds: string[],
   models: string[],
-  baseUrl = 'https://api.openai.com/v1/',
+  baseUrl: string | null = 'https://api.openai.com/v1/',
+  providerType: 'openai' | 'deepseek' | 'openai-compatible' = 'openai',
 ) {
   return {
     kind: 'page' as const,
@@ -113,8 +189,8 @@ function catalogPage(
         revision: 1,
         slug: 'env-openai',
         name: 'OpenAI',
-        providerType: 'openai' as const,
-        baseUrl,
+        providerType,
+        ...(baseUrl === null ? {} : { baseUrl }),
         enabled: true,
         enabledModelIdCount: enabledModelIds.length,
         modelCount: models.length,

--- a/packages/runtime-host/src/client/hosted-execution-target.ts
+++ b/packages/runtime-host/src/client/hosted-execution-target.ts
@@ -1,3 +1,4 @@
+import { effectiveBaseUrl } from '@maka/core/llm-connections';
 import { readRuntimeHostConnectionCatalog } from './catalog-reader.js';
 import type { RuntimeHostConnection } from './connection.js';
 import { abortable } from './wait-for-ready.js';
@@ -14,14 +15,15 @@ export async function configureHostedExecutionTarget(
   connection: TargetConnection,
   input: HostedExecutionTargetInput,
   signal?: AbortSignal,
-): Promise<void> {
+): Promise<boolean> {
   const before = await abortable(() => readRuntimeHostConnectionCatalog(connection), signal);
   const target = before.connections.find((candidate) => candidate.slug === input.connectionSlug);
   if (!target) throw new Error('Runtime Host connection is unavailable');
 
   const baseUrl = new URL(input.baseUrl).toString();
   const enabledModelIds = [...new Set([...target.enabledModelIds, input.model])];
-  const endpointChanged = target.baseUrl !== baseUrl;
+  const endpointChanged = canonicalBaseUrl(effectiveBaseUrl(target)) !== baseUrl;
+  let changed = false;
   if (endpointChanged || !target.enabled || !target.enabledModelIds.includes(input.model)) {
     const updated = await abortable(
       () =>
@@ -39,6 +41,7 @@ export async function configureHostedExecutionTarget(
     if (updated.kind !== 'committed') {
       throw new Error(`Runtime Host connection update was not committed: ${updated.kind}`);
     }
+    changed = true;
   }
 
   if (endpointChanged || !target.models.some((model) => model.id === input.model)) {
@@ -52,6 +55,7 @@ export async function configureHostedExecutionTarget(
     if (fetched.kind !== 'committed') {
       throw new Error(`Runtime Host model discovery did not commit: ${fetched.kind}`);
     }
+    changed = true;
   }
 
   const after = await abortable(() => readRuntimeHostConnectionCatalog(connection), signal);
@@ -60,10 +64,19 @@ export async function configureHostedExecutionTarget(
   );
   if (
     !configured?.enabled ||
-    configured.baseUrl !== baseUrl ||
+    canonicalBaseUrl(effectiveBaseUrl(configured)) !== baseUrl ||
     !configured.enabledModelIds.includes(input.model) ||
     !configured.models.some((model) => model.id === input.model)
   ) {
     throw new Error('Runtime Host did not admit the requested model target');
+  }
+  return changed;
+}
+
+function canonicalBaseUrl(value: string): string | undefined {
+  try {
+    return new URL(value).toString();
+  } catch {
+    return undefined;
   }
 }

--- a/packages/runtime-host/src/client/hosted-execution.ts
+++ b/packages/runtime-host/src/client/hosted-execution.ts
@@ -36,7 +36,7 @@ export async function runHostedExecutionWithDependencies(
   if (input.signal?.aborted) {
     return indeterminate(input.execution.executionId, 'Hosted execution was cancelled');
   }
-  const connected = await dependencies.connectOwnedRuntimeHost({
+  const initial = await dependencies.connectOwnedRuntimeHost({
     rootPath: input.rootPath,
     surface: 'run',
     protocol: {
@@ -46,20 +46,24 @@ export async function runHostedExecutionWithDependencies(
     compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
     ...(input.signal ? { signal: input.signal } : {}),
   });
-  if (connected.kind !== 'connected') {
+  if (initial.kind !== 'connected') {
     if (input.signal?.aborted) {
       return indeterminate(input.execution.executionId, 'Hosted execution was cancelled');
     }
-    const cause = connected.kind === 'failed' ? connected.reason : connected.kind;
+    const cause = initial.kind === 'failed' ? initial.reason : initial.kind;
     return indeterminate(input.execution.executionId, `Runtime Host did not start: ${cause}`);
   }
+  let connected: Extract<
+    Awaited<ReturnType<typeof connectOwnedRuntimeHost>>,
+    { kind: 'connected' }
+  > = initial;
   let projection: HostedExecutionProjection;
   try {
     input.signal?.throwIfAborted();
     const target = input.execution.session.modelTarget;
     if (target.kind === 'explicit') {
       if (!input.baseUrl) throw new Error('Explicit model target requires baseUrl');
-      await configureHostedExecutionTarget(
+      const changed = await configureHostedExecutionTarget(
         connected.connection,
         {
           connectionSlug: target.connectionSlug,
@@ -68,6 +72,30 @@ export async function runHostedExecutionWithDependencies(
         },
         input.signal,
       );
+      if (changed) {
+        await connected.connection.close().catch(() => undefined);
+        if (!(await connected.host.settle(input.hostSettlementTimeoutMs ?? 15_000))) {
+          return indeterminate(input.execution.executionId, 'Runtime Host did not exit cleanly');
+        }
+        const reconnected = await dependencies.connectOwnedRuntimeHost({
+          rootPath: input.rootPath,
+          surface: 'run',
+          protocol: {
+            min: RUNTIME_HOST_PROTOCOL_VERSION,
+            max: RUNTIME_HOST_PROTOCOL_VERSION,
+          },
+          compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+          ...(input.signal ? { signal: input.signal } : {}),
+        });
+        if (reconnected.kind !== 'connected') {
+          if (input.signal?.aborted) {
+            return indeterminate(input.execution.executionId, 'Hosted execution was cancelled');
+          }
+          const cause = reconnected.kind === 'failed' ? reconnected.reason : reconnected.kind;
+          return indeterminate(input.execution.executionId, `Runtime Host did not start: ${cause}`);
+        }
+        connected = reconnected;
+      }
     }
     projection = await executeHostedExecution(connected.connection, input.execution, input.signal);
   } catch {


### PR DESCRIPTION
## Summary

- detect when explicit hosted-target admission mutates the connection catalog or model inventory
- settle the invalidated owned Runtime Host and reconnect before `hosted.execution.start`
- compare provider default URLs canonically so unchanged targets do not restart

## Root cause

The first explicit DeepSeek target admission can commit model discovery. That invalidates the active backend and drains the owned Host. `runHostedExecution` then reused the now-closing connection for `hosted.execution.start`, producing `Runtime Host connection failed before execution settlement` before any model request.

## Verification

- `npm --workspace @maka/runtime-host test`: 841 passed, 0 failed
- focused hosted execution/target tests: 10 passed, 0 failed
- real-machine DeepSeek V4 Flash canary on `dhb`: settled `completed`, 24,708 tokens
- canary recorded `apply_patch` and `Read` as `outcome_committed`; proof file content matched exactly

The real-machine result uses the Terminal-Bench container and the same Maka eval shim as #2905. This PR contains no eval spec or machine-local configuration changes.

Generated with Codex assistance.