### PR TITLE
chore(eval): raise eight-arm concurrency to 16

### DIFF
--- a/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-eight-arm.json
+++ b/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-eight-arm.json
@@ -79,7 +79,7 @@
       ]
     }
   },
-  "execution": { "maxConcurrentTaskGroups": 14 },
+  "execution": { "maxConcurrentTaskGroups": 16 },
   "subjects": [
     {
       "id": "maka",

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -263,7 +263,7 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
     execution: { maxConcurrentTaskGroups: number };
     executor: { config: { mounts: Array<{ target: string }> } };
   };
-  assert.equal(spec.execution.maxConcurrentTaskGroups, 14);
+  assert.equal(spec.execution.maxConcurrentTaskGroups, 16);
   assert.deepEqual(
     spec.subjects.map(({ id }) => id),
     ['maka', 'codex', 'claude-code', 'reasonix', 'opencode', 'kimi-code', 'zcode', 'pi'],


### PR DESCRIPTION
## Summary

- raise `maxConcurrentTaskGroups` from 14 to 16
- increase peak admission from 112 to 128 cells across eight harnesses
- keep the cohort, task revision, model settings, verifier, credentials, and toolchains unchanged

## Estimate

Historical load simulation projects approximately 2.25–3.25 hours for the full 89-task run. The run will be monitored live by harness for completion, score, tokens, cache rate, cost, machine load, and ETA.

## Verification

- Eval TypeScript: 16/16
- relay contract/lifecycle: 3/3 + 2/2
- `git diff --check`

The full benchmark is not started by this PR.

Generated with Codex assistance.
