### PR TITLE
fix(eval): harden eight-arm result reliability

### DIFF
--- a/packages/eval/src/__tests__/bounded-log.test.ts
+++ b/packages/eval/src/__tests__/bounded-log.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Readable } from 'node:stream';
+import test from 'node:test';
+import { captureBoundedStream } from '../bounded-log.js';
+
+test('bounded capture preserves small output exactly', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-bounded-log-'));
+  const path = join(root, 'small.log');
+  try {
+    const result = await captureBoundedStream(Readable.from(['alpha', 'beta']), path, 256, 32);
+    assert.deepEqual(result, { observedBytes: 9, truncatedBytes: 0 });
+    assert.equal(await readFile(path, 'utf8'), 'alphabeta');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('bounded capture retains prefix and tail with truncation evidence', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-bounded-log-'));
+  const path = join(root, 'large.log');
+  const contents = `${'a'.repeat(300)}${'z'.repeat(64)}`;
+  try {
+    const result = await captureBoundedStream(Readable.from([contents]), path, 256, 64);
+    const retained = await readFile(path, 'utf8');
+    assert.equal(result.observedBytes, Buffer.byteLength(contents));
+    assert.ok(result.truncatedBytes > 0);
+    assert.ok(Buffer.byteLength(retained) <= 256);
+    assert.ok(retained.startsWith('a'));
+    assert.ok(retained.includes('makaEvalTruncatedBytes'));
+    assert.ok(retained.endsWith('z'.repeat(64)));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/eval/src/__tests__/external-subject.test.ts
+++ b/packages/eval/src/__tests__/external-subject.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { test } from 'node:test';
 import { createExternalSubjectAdapter } from '../external-subject.js';
 import type { ExperimentCell, ExperimentSpec } from '../experiment.js';
+import type { CellAttempt } from '../result.js';
 import { TOOLCHAIN_IDENTITIES, TOOLCHAIN_IDENTITY_ENV } from '../toolchain-verification.js';
 
 test('passes declared environment and credential bindings to one external command', async () => {
@@ -161,6 +162,12 @@ test('verifies a mounted toolchain once before cell execution', async () => {
     } satisfies ExperimentCell;
     const adapter = createExternalSubjectAdapter();
     await adapter.prepare?.({ spec: {} as ExperimentSpec, cells: [cell] });
+    const attempt = toolchainAttempt(cell.id, TOOLCHAIN_IDENTITIES.codex.fingerprint);
+    assert.equal(adapter.canReuse?.({ cell, attempt }), true);
+    assert.equal(
+      adapter.canReuse?.({ cell, attempt: toolchainAttempt(cell.id, 'sha256:stale') }),
+      false,
+    );
     await unlink(join(root, 'checksums.sha256'));
     let environment: Readonly<Record<string, string>> | undefined;
 
@@ -195,6 +202,31 @@ test('verifies a mounted toolchain once before cell execution', async () => {
     await rm(root, { recursive: true, force: true });
   }
 });
+
+function toolchainAttempt(cellId: string, fingerprint: string): CellAttempt {
+  return {
+    cellId,
+    sequence: 1,
+    startedAt: 1,
+    completedAt: 2,
+    result: {
+      score: 1,
+      usage: null,
+      costUsd: null,
+      durationMs: 1,
+      status: 'completed',
+      failureReason: null,
+      artifacts: [
+        {
+          kind: 'toolchain',
+          profile: 'codex',
+          version: TOOLCHAIN_IDENTITIES.codex.version,
+          fingerprint,
+        },
+      ],
+    },
+  };
+}
 
 function externalCell(config: ExperimentCell['subject']['config']): ExperimentCell {
   return {

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -130,6 +130,75 @@ test('subject preflight settles before the attempt timer starts', async () => {
   }
 });
 
+test('resume replaces a terminal attempt whose subject identity is stale', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-eval-resume-identity-'));
+  const store = new FileAttemptStore(join(root, 'attempts'));
+  await store.append({
+    cellId: 'task::1::external',
+    sequence: 1,
+    startedAt: 1,
+    completedAt: 2,
+    result: {
+      score: 1,
+      usage: null,
+      costUsd: null,
+      durationMs: 1,
+      status: 'completed',
+      failureReason: null,
+      artifacts: [{ kind: 'identity', value: 'stale' }],
+    },
+  });
+  const executor: ExperimentExecutor = {
+    kind: 'harbor',
+    runAttempt: async (_input, operation) => ({
+      kind: 'settled',
+      value: await operation({
+        context: {
+          cwd: '/app',
+          taskInput: 'solve',
+          metadata: {},
+          execute: async () => assert.fail('resume identity test does not execute a process'),
+        },
+        verify: async () => ({
+          status: 'completed',
+          score: 1,
+          failureReason: null,
+          artifacts: [],
+        }),
+      }),
+    }),
+  };
+  const subject: SubjectAdapter = {
+    kind: 'external',
+    canReuse: ({ attempt }) =>
+      attempt.result.artifacts.some(
+        (artifact) => artifact.kind === 'identity' && artifact.value === 'current',
+      ),
+    execute: async () => ({
+      usage: null,
+      costUsd: null,
+      durationMs: 1,
+      status: 'completed',
+      failureReason: null,
+      artifacts: [{ kind: 'identity', value: 'current' }],
+    }),
+  };
+  try {
+    const results = await runExperiment({
+      spec: experiment(),
+      store,
+      executor,
+      subjects: [subject],
+    });
+    assert.equal(results.get('task::1::external')?.sequence, 2);
+    assert.deepEqual(results.get('task::1::external')?.result.artifacts, [
+      { kind: 'identity', value: 'current' },
+    ]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('eight-arm spec and wrappers freeze the working provider contracts', async () => {
   const specPath = new URL(
     '../../experiments/terminal-bench-2.1-deepseek-v4-flash-eight-arm.json',

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -10,9 +10,24 @@ import { promisify } from 'node:util';
 const execFileAsync = promisify(execFile);
 
 test('provider failures remain infrastructure failures until inference admission', async () => {
-  for (const [statusCode, body, expectedStatus, admittedRequests] of [
-    [429, '{"error":{"type":"rate_limit"}}', 'infra_failed', 0],
-    [200, 'data: {"type":"response.created"}\n\ndata: [DONE]\n\n', 'failed', 1],
+  for (const [
+    statusCode,
+    body,
+    expectedStatus,
+    admittedRequests,
+    usageComplete,
+    expectedCacheWrite,
+  ] of [
+    [429, '{"error":{"type":"rate_limit"}}', 'infra_failed', 0, false, null],
+    [200, 'data: {"type":"response.created"}\n\ndata: [DONE]\n\n', 'failed', 1, false, null],
+    [
+      200,
+      'data: {"type":"response.completed","response":{"usage":{"input_tokens":10,"output_tokens":2,"input_tokens_details":{"cached_tokens":3,"cache_write_tokens":4},"output_tokens_details":{"reasoning_tokens":1}}}}\n\ndata: [DONE]\n\n',
+      'failed',
+      1,
+      true,
+      4,
+    ],
   ] as const) {
     const server = createServer((_request, response) => {
       response.writeHead(statusCode, {
@@ -30,7 +45,7 @@ test('provider failures remain infrastructure failures until inference admission
     const child = join(root, 'child.mjs');
     await writeFile(
       child,
-      "await fetch(`${process.env.DEEPSEEK_BASE_URL}/responses`, {method:'POST',body:'{}'}); console.log(JSON.stringify({type:'error'})); process.exit(1);\n",
+      "if(process.env.OPENAI_API_KEY||process.env.ANTHROPIC_API_KEY||process.env.DEEPSEEK_API_KEY!=='maka-eval-local')process.exit(9);await fetch(`${process.env.DEEPSEEK_BASE_URL}/responses`,{method:'POST',body:'{}'});console.log(JSON.stringify({type:'error'}));process.exit(1);\n",
     );
     try {
       const wrapper = new URL('../harbor-external-subject.js', import.meta.url);
@@ -48,13 +63,20 @@ test('provider failures remain infrastructure failures until inference admission
       );
       const result = JSON.parse(stdout) as {
         status: string;
-        artifacts: Array<{ kind: string; admittedRequests?: number }>;
+        costUsd: number | null;
+        usage: { cacheWriteTokens: number } | null;
+        artifacts: Array<{
+          kind: string;
+          admittedRequests?: number;
+          usageComplete?: boolean;
+        }>;
       };
       assert.equal(result.status, expectedStatus);
-      assert.equal(
-        result.artifacts.find(({ kind }) => kind === 'provider-metering')?.admittedRequests,
-        admittedRequests,
-      );
+      const metering = result.artifacts.find(({ kind }) => kind === 'provider-metering');
+      assert.equal(metering?.admittedRequests, admittedRequests);
+      assert.equal(metering?.usageComplete, usageComplete);
+      assert.equal(result.usage?.cacheWriteTokens ?? null, expectedCacheWrite);
+      assert.equal(result.costUsd === null, !usageComplete);
     } finally {
       server.close();
       await rm(root, { recursive: true, force: true });

--- a/packages/eval/src/bounded-log.ts
+++ b/packages/eval/src/bounded-log.ts
@@ -1,0 +1,59 @@
+import type { Readable } from 'node:stream';
+import { open } from 'node:fs/promises';
+
+export interface BoundedCapture {
+  readonly observedBytes: number;
+  readonly truncatedBytes: number;
+}
+
+const MARKER_RESERVE_BYTES = 128;
+
+export async function captureBoundedStream(
+  input: Readable,
+  path: string,
+  limitBytes: number,
+  tailBytes: number,
+): Promise<BoundedCapture> {
+  if (limitBytes <= MARKER_RESERVE_BYTES || tailBytes < 1 || tailBytes >= limitBytes) {
+    throw new Error('bounded log limits are invalid');
+  }
+  const prefixLimit = limitBytes - tailBytes - MARKER_RESERVE_BYTES;
+  const output = await open(path, 'w', 0o600);
+  let observedBytes = 0;
+  let prefixBytes = 0;
+  let tail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  try {
+    for await (const chunk of input) {
+      let remaining = Buffer.from(chunk);
+      observedBytes += remaining.length;
+      if (prefixBytes < prefixLimit) {
+        const length = Math.min(prefixLimit - prefixBytes, remaining.length);
+        await output.write(remaining.subarray(0, length));
+        prefixBytes += length;
+        remaining = remaining.subarray(length);
+      }
+      if (remaining.length > 0) tail = appendTail(tail, remaining, tailBytes);
+    }
+    if (observedBytes <= limitBytes) {
+      if (tail.length > 0) await output.write(tail);
+      return { observedBytes, truncatedBytes: 0 };
+    }
+    const truncatedBytes = Math.max(0, observedBytes - prefixBytes - tail.length);
+    const marker = Buffer.from(`\n{"makaEvalTruncatedBytes":${truncatedBytes}}\n`);
+    await output.write(marker.subarray(0, MARKER_RESERVE_BYTES));
+    await output.write(tail);
+    return { observedBytes, truncatedBytes };
+  } finally {
+    await output.close();
+  }
+}
+
+function appendTail(
+  current: Buffer<ArrayBufferLike>,
+  chunk: Buffer<ArrayBufferLike>,
+  limit: number,
+): Buffer<ArrayBufferLike> {
+  if (chunk.length >= limit) return chunk.subarray(chunk.length - limit);
+  const combined = Buffer.concat([current, chunk]);
+  return combined.length <= limit ? combined : combined.subarray(combined.length - limit);
+}

--- a/packages/eval/src/external-subject.ts
+++ b/packages/eval/src/external-subject.ts
@@ -37,6 +37,21 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
         );
       }
     },
+    canReuse: ({ cell, attempt }) => {
+      const config = decodeConfig(cell.subject.config, cell.subject.credentials);
+      const toolchain = wrapperToolchain(config, cell.executor.config);
+      if (!toolchain) return true;
+      const identity = verifiedToolchains.get(cell.subject.id);
+      if (!identity) return false;
+      const artifact = attempt.result.artifacts.find(
+        (candidate) =>
+          candidate.kind === 'toolchain' &&
+          candidate.profile === toolchain.profile &&
+          candidate.version === identity.version &&
+          candidate.fingerprint === identity.fingerprint,
+      );
+      return artifact !== undefined;
+    },
     async execute({ cell, context }) {
       const config = decodeConfig(cell.subject.config, cell.subject.credentials);
       const toolchain = wrapperToolchain(config, cell.executor.config);

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -1,6 +1,5 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
-import { createWriteStream } from 'node:fs';
 import { readFileSync, rmSync, statSync } from 'node:fs';
 import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type Server } from 'node:http';
@@ -10,8 +9,12 @@ import {
   type ExternalProfile as Profile,
 } from './toolchain-verification.js';
 import { isInferenceAdmissionEvent } from './provider-admission.js';
+import { captureBoundedStream, type BoundedCapture } from './bounded-log.js';
 
 type SubjectStatus = 'completed' | 'failed' | 'infra_failed' | 'indeterminate';
+const TRAJECTORY_LIMIT_BYTES = 16 * 1024 * 1024;
+const STDERR_LIMIT_BYTES = 4 * 1024 * 1024;
+const LOG_TAIL_BYTES = 1024 * 1024;
 
 interface Usage {
   inputTokens: number;
@@ -59,7 +62,11 @@ try {
   artifacts.push({ kind: 'toolchain', profile, ...identity });
   await writeState('toolchain_verified');
 
-  const key = process.env.OPENAI_API_KEY ?? process.env.ANTHROPIC_API_KEY;
+  const key =
+    process.env.OPENAI_API_KEY ?? process.env.ANTHROPIC_API_KEY ?? process.env.DEEPSEEK_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.ANTHROPIC_API_KEY;
+  delete process.env.DEEPSEEK_API_KEY;
   if (!key) throw new Error('external subject credential is missing');
   const proxy = await startMeteringProxy(baseUrl, key, profile === 'claude-code');
   try {
@@ -77,7 +84,7 @@ try {
     child = undefined;
     await writeState('child_exited', { exitCode: result.exitCode });
     usage = proxy.usage();
-    costUsd = usage ? estimateCost(usage) : null;
+    costUsd = usage && proxy.usageComplete() ? estimateCost(usage) : null;
     const output = await readFile(trajectoryPath, 'utf8').catch(() => '');
     const classified = classifyExecution(
       profile,
@@ -93,16 +100,18 @@ try {
       status,
       requests: proxy.requestCount(),
       admittedRequests: proxy.admittedRequestCount(),
+      usageRequests: proxy.usageRequestCount(),
     });
     artifacts.push(
-      fileArtifact('trajectory', trajectoryPath, profile),
-      fileArtifact('stderr', stderrPath, profile),
+      fileArtifact('trajectory', trajectoryPath, profile, result.trajectory),
+      fileArtifact('stderr', stderrPath, profile, result.stderr),
       {
         kind: 'provider-metering',
         profile,
         requests: proxy.requestCount(),
         admittedRequests: proxy.admittedRequestCount(),
-        usageComplete: usage !== null,
+        usageRequests: proxy.usageRequestCount(),
+        usageComplete: proxy.usageComplete(),
       },
       fileArtifact('wrapper-state', statePath, profile),
       ...profileArtifacts,
@@ -201,6 +210,7 @@ async function prepareProfile(
     );
     const path = join(home, '.env');
     await writeFile(path, 'OPENAI_API_KEY=maka-eval-local\n', { mode: 0o600 });
+    env.OPENAI_API_KEY = 'maka-eval-local';
     env.REASONIX_HOME = home;
     credentialPath = path;
   } else if (selected === 'opencode') {
@@ -397,30 +407,30 @@ async function runChild(
   env: NodeJS.ProcessEnv,
   stdoutPath: string,
   childStderrPath: string,
-): Promise<{ exitCode: number }> {
-  const stdout = createWriteStream(stdoutPath, { flags: 'w', mode: 0o600 });
-  const stderr = createWriteStream(childStderrPath, { flags: 'w', mode: 0o600 });
+): Promise<{ exitCode: number; trajectory: BoundedCapture; stderr: BoundedCapture }> {
   const running = spawn(executable, executableArgs, {
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   child = running;
-  running.stdout.pipe(stdout);
-  running.stderr.pipe(stderr);
+  const trajectory = captureBoundedStream(
+    running.stdout,
+    stdoutPath,
+    TRAJECTORY_LIMIT_BYTES,
+    LOG_TAIL_BYTES,
+  );
+  const stderr = captureBoundedStream(
+    running.stderr,
+    childStderrPath,
+    STDERR_LIMIT_BYTES,
+    LOG_TAIL_BYTES,
+  );
   const exitCode = await new Promise<number>((resolveExit, reject) => {
     running.once('error', reject);
     running.once('exit', (code) => resolveExit(code ?? 1));
   });
-  await Promise.all([finished(stdout), finished(stderr)]);
-  return { exitCode };
-}
-
-function finished(stream: ReturnType<typeof createWriteStream>): Promise<void> {
-  if (stream.closed) return Promise.resolve();
-  return new Promise((resolveFinished, reject) => {
-    stream.once('close', resolveFinished);
-    stream.once('error', reject);
-  });
+  const [trajectoryResult, stderrResult] = await Promise.all([trajectory, stderr]);
+  return { exitCode, trajectory: trajectoryResult, stderr: stderrResult };
 }
 
 function prepareClaudeWorkspace(root: string, home: string): void {
@@ -492,12 +502,15 @@ async function startMeteringProxy(
   usage(): Usage | null;
   requestCount(): number;
   admittedRequestCount(): number;
+  usageRequestCount(): number;
+  usageComplete(): boolean;
   close(): Promise<void>;
 }> {
   const total = zeroUsage();
   let measured = false;
   let requests = 0;
   let admittedRequests = 0;
+  let usageRequests = 0;
   const active = new Set<Promise<void>>();
   const server = createServer((request, response) => {
     const operation = (async () => {
@@ -543,10 +556,13 @@ async function startMeteringProxy(
         response.end();
       } finally {
         const parsed = parser.finish();
-        if (upstream.ok && parsed.admitted) admittedRequests += 1;
-        if (parsed.usage) {
-          measured = true;
-          addUsage(total, parsed.usage);
+        if (upstream.ok && parsed.admitted) {
+          admittedRequests += 1;
+          if (parsed.usage) {
+            usageRequests += 1;
+            measured = true;
+            addUsage(total, parsed.usage);
+          }
         }
       }
     })().catch((error: unknown) => {
@@ -565,6 +581,8 @@ async function startMeteringProxy(
       measured ? { ...total, totalTokens: total.inputTokens + total.outputTokens } : null,
     requestCount: () => requests,
     admittedRequestCount: () => admittedRequests,
+    usageRequestCount: () => usageRequests,
+    usageComplete: () => admittedRequests > 0 && usageRequests === admittedRequests,
     close: async () => {
       await Promise.allSettled([...active]);
       await closeServer(server);
@@ -627,7 +645,12 @@ function usageFromEvent(event: Record<string, unknown>, anthropic: boolean): Usa
       ? raw.completion_tokens_details
       : {};
   const cacheRead = number(raw.cache_read_input_tokens ?? inputDetails.cached_tokens);
-  const cacheWrite = number(raw.cache_creation_input_tokens);
+  const cacheWrite = number(
+    raw.cache_creation_input_tokens ??
+      raw.cache_write_input_tokens ??
+      inputDetails.cache_write_tokens ??
+      inputDetails.cache_creation_tokens,
+  );
   const reasoning = number(outputDetails.reasoning_tokens);
   const totalInput = anthropic ? input + cacheRead + cacheWrite : input;
   return {
@@ -708,7 +731,12 @@ function joinUpstream(baseUrl: string, requestUrl: string): string {
   return base.toString();
 }
 
-function fileArtifact(kind: string, path: string, selected: Profile): Record<string, unknown> {
+function fileArtifact(
+  kind: string,
+  path: string,
+  selected: Profile,
+  capture?: BoundedCapture,
+): Record<string, unknown> {
   const bytes = statSync(path).size;
   return {
     kind,
@@ -716,6 +744,12 @@ function fileArtifact(kind: string, path: string, selected: Profile): Record<str
     path: `/logs/agent/${basename(path)}`,
     bytes,
     sha256: createHash('sha256').update(readFileSync(path)).digest('hex'),
+    ...(capture
+      ? {
+          observedBytes: capture.observedBytes,
+          truncatedBytes: capture.truncatedBytes,
+        }
+      : {}),
   };
 }
 

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -6,9 +6,9 @@ import {
 } from './experiment.js';
 import {
   decodeEvalResult,
-  selectCellResult,
   type CellAttempt,
   type EvalResult,
+  isReplaceableAttempt,
   type NormalizedUsage,
 } from './result.js';
 
@@ -48,6 +48,7 @@ export interface SubjectAdapter {
     readonly spec: ExperimentSpec;
     readonly cells: readonly ExperimentCell[];
   }): Promise<void>;
+  canReuse?(input: { readonly cell: ExperimentCell; readonly attempt: CellAttempt }): boolean;
   execute(input: {
     readonly cell: ExperimentCell;
     readonly context: SubjectExecutionContext;
@@ -140,11 +141,12 @@ export async function runExperiment(input: {
           if (input.signal?.aborted) return;
           const attempts = await input.store.list(cell.id);
           if (input.signal?.aborted) return;
-          if (selectCellResult(attempts)) return;
+          const subject = subjects.get(cell.subject.kind)!;
+          if (selectSubjectResult(attempts, subject, cell)) return;
           const startedAt = (input.now ?? Date.now)();
           const result = await executeCell(
             input.executor,
-            subjects.get(cell.subject.kind)!,
+            subject,
             cell,
             subjectCredentialNames,
             input.signal,
@@ -172,12 +174,33 @@ export async function runExperiment(input: {
       (
         await Promise.all(
           cells.map(
-            async (cell) => [cell.id, selectCellResult(await input.store.list(cell.id))] as const,
+            async (cell) =>
+              [
+                cell.id,
+                selectSubjectResult(
+                  await input.store.list(cell.id),
+                  subjects.get(cell.subject.kind)!,
+                  cell,
+                ),
+              ] as const,
           ),
         )
       ).flatMap(([cellId, result]) => (result ? [[cellId, result] as const] : [])),
     );
   });
+}
+
+function selectSubjectResult(
+  attempts: readonly CellAttempt[],
+  subject: SubjectAdapter,
+  cell: ExperimentCell,
+): CellAttempt | undefined {
+  return [...attempts]
+    .sort((left, right) => left.sequence - right.sequence)
+    .find(
+      (attempt) =>
+        !isReplaceableAttempt(attempt) && (subject.canReuse?.({ cell, attempt }) ?? true),
+    );
 }
 
 function groupTaskCells(cells: readonly ExperimentCell[]): ExperimentCell[][] {


### PR DESCRIPTION
## Summary

- remove upstream provider credentials before launching subject processes; inject only local proxy credentials
- publish cost only when every confirmed model admission has a usage record, including cache-write token parsing
- reject resumable terminal attempts whose recorded toolchain identity does not match the current verified mount
- cap trajectory at 16 MiB and stderr at 4 MiB, preserving a prefix, final 1 MiB, and truncation metadata

## Verification

- full workspace build: passed
- Eval TypeScript: 19/19
- relay contract/lifecycle: 3/3 + 2/2
- release notices, lint, format, and `git diff --check`: passed
- real ZCode smoke: score 1, 12/12 admitted requests with usage, complete cost, bounded log metadata, zero stderr

This PR is stacked on #2914. The full benchmark remains stopped until both follow-ups merge.

Generated with Codex assistance.
