### PR TITLE
fix(eval): preserve canonical results and native verifier timeouts

### DIFF
--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -83,3 +83,50 @@ test('provider failures remain infrastructure failures until inference admission
     }
   }
 });
+
+test('canonical Pi settlement remains completed when the CLI exits nonzero', async () => {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.end(
+      'data: {"type":"response.completed","response":{"usage":{"input_tokens":10,"output_tokens":2}}}\n\ndata: [DONE]\n\n',
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const root = await mkdtemp(join(tmpdir(), 'maka-pi-terminal-'));
+  const child = join(root, 'child.mjs');
+  await writeFile(
+    child,
+    [
+      "import {readFile} from 'node:fs/promises';",
+      "const config=JSON.parse(await readFile(`${process.env.PI_CODING_AGENT_DIR}/models.json`,'utf8'));",
+      "if(process.env.OPENAI_API_KEY!=='maka-eval-local'||process.env.ANTHROPIC_API_KEY||process.env.DEEPSEEK_API_KEY)process.exit(9);",
+      "await fetch(`${config.providers['maka-proxy'].baseUrl}/responses`,{method:'POST',body:'{}'});",
+      "console.log(JSON.stringify({type:'agent_end',messages:[]}));",
+      "console.log(JSON.stringify({type:'agent_settled'}));",
+      'process.exit(1);',
+      '',
+    ].join('\n'),
+  );
+  try {
+    const wrapper = new URL('../harbor-external-subject.js', import.meta.url);
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [wrapper.pathname, 'pi', `http://127.0.0.1:${address.port}`, root, process.execPath, child],
+      { env: { ...process.env, OPENAI_API_KEY: 'upstream-test-key' } },
+    );
+    const result = JSON.parse(stdout) as {
+      status: string;
+      artifacts: Array<{ kind: string; exitCode?: number }>;
+    };
+    assert.equal(result.status, 'completed');
+    assert.equal(result.artifacts.find(({ kind }) => kind === 'external-process')?.exitCode, 1);
+  } finally {
+    server.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -103,6 +103,7 @@ try {
       usageRequests: proxy.usageRequestCount(),
     });
     artifacts.push(
+      { kind: 'external-process', profile, exitCode: result.exitCode },
       fileArtifact('trajectory', trajectoryPath, profile, result.trajectory),
       fileArtifact('stderr', stderrPath, profile, result.stderr),
       {
@@ -487,7 +488,7 @@ function classifyExecution(
   if (admittedRequests === 0) {
     return { status: 'infra_failed', failureReason: `${selected} failed before model admission` };
   }
-  if (exitCode === 0 && completed && !reportedError) {
+  if (completed && !reportedError) {
     return { status: 'completed', failureReason: null };
   }
   return { status: 'failed', failureReason: `${selected} execution failed` };


### PR DESCRIPTION
## Summary

- treat a canonical tool-specific completion event as authoritative over a later nonzero CLI exit
- retain the child exit code as an `external-process` artifact
- prevent successful Pi executions with verifier score 1 from being mislabeled `subject_failed`

## Evidence

The fresh eight-arm Canary completed all 8 cells. Pi emitted `agent_end` and `agent_settled`, wrote the correct answer, had empty stderr, 24/24 admitted usage records, and verifier score 1, but its CLI exited nonzero and the wrapper marked it failed.

## Verification

- Eval TypeScript: 20/20
- relay contract/lifecycle: 3/3 + 2/2
- focused Pi integration covers canonical settlement + exit code 1
- lint, format, and `git diff --check`

The full-run Canary also exposed a fixed 20-second Eval wait that cancelled valid long-running verifiers. Normal verification now defers to each task native timeout; only abort and cleanup remain bounded. After this update, the failed verifier cells will be rerun before resuming the 16-group full benchmark.

Generated with Codex assistance.