### PR TITLE
fix(ui): restore the prompt anchor rail and fix its hover and jump

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -246,6 +246,7 @@ async function withE2eWindow(
     locale,
     platform,
     showWindow,
+    scrollMotion,
     invocableSkills,
     gitReviewExtraFiles,
   }: {
@@ -253,6 +254,8 @@ async function withE2eWindow(
     readinessSelector: string;
     e2eFixtureScenario?: string;
     locale?: 'zh' | 'en';
+    /** Opt this window back into animated scrolling; see `scroll-motion-policy`. */
+    scrollMotion?: 'auto' | 'smooth';
     /** #1312: force app:info's platform so the window boots natively into that platform's `data-os` cascade. */
     platform?: 'darwin' | 'win32' | 'linux';
     /** Show fixtures whose contract depends on compositor-paced frames. */
@@ -286,6 +289,7 @@ async function withE2eWindow(
         scenario: e2eFixtureScenario,
         locale,
         platform,
+        scrollMotion,
         // xvfb throttles a hidden window's compositor to ~1fps. Geometry
         // fixtures opt in locally; every fixture is visible on isolated CI X.
         showWindow: showWindow || isCiLinuxDisplay(),
@@ -339,6 +343,7 @@ export const test = base.extend<{
   invocableSkillsWindow: Page;
   linkColorWindow: Page;
   promptRailWindow: Page;
+  promptRailMotionWindow: Page;
 }>({
   // Seeded: a pre-staged connection clears onboarding so the composer is ready.
   window: async ({}, use) => {
@@ -388,6 +393,19 @@ export const test = base.extend<{
       readinessSelector: '[data-turn-id]',
       e2eFixtureScenario: 'chat-prompt-rail',
       showWindow: true,
+    }, use);
+  },
+  // The same transcript, scrolling the way the shipped app scrolls. Separate
+  // from `promptRailWindow` because it is only the jump that needs a scroll
+  // still in flight, and paying for one everywhere costs several seconds per
+  // window and settles less predictably.
+  promptRailMotionWindow: async ({}, use) => {
+    await withE2eWindow({
+      seed: false,
+      readinessSelector: '[data-turn-id]',
+      e2eFixtureScenario: 'chat-prompt-rail',
+      showWindow: true,
+      scrollMotion: 'smooth',
     }, use);
   },
 });

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -338,6 +338,7 @@ export const test = base.extend<{
   gitReviewWindow: { page: Page; projectRoot: string };
   invocableSkillsWindow: Page;
   linkColorWindow: Page;
+  promptRailWindow: Page;
 }>({
   // Seeded: a pre-staged connection clears onboarding so the composer is ready.
   window: async ({}, use) => {
@@ -373,6 +374,20 @@ export const test = base.extend<{
       seed: false,
       readinessSelector: '.settingsBotConfigDocLink',
       e2eFixtureScenario: 'settings-bots-onboarding',
+    }, use);
+  },
+  // A multi-prompt transcript for the prompt anchor rail. Shown, because every
+  // assertion in prompt-rail.spec.ts is geometry the compositor has to settle.
+  promptRailWindow: async ({}, use) => {
+    await withE2eWindow({
+      seed: false,
+      // A rendered turn, deliberately not the rail: Playwright treats a
+      // zero-area element as hidden, so gating readiness on a tick would turn
+      // every rail regression into a 20s cold-start timeout instead of the
+      // assertion that names it.
+      readinessSelector: '[data-turn-id]',
+      e2eFixtureScenario: 'chat-prompt-rail',
+      showWindow: true,
     }, use);
   },
 });

--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -125,6 +125,68 @@ test('the rail stays inside the scrollport at both scroll extremes', async ({
   }
 });
 
+test('the pointer is always on a tick while it travels down the rail', async ({
+  promptRailWindow: page,
+}) => {
+  // The hover falloff reads which tick the pointer entered. A gap between the
+  // hit boxes is a band where it is over the rail and over no tick, so the
+  // effect drops out and picks up again every few pixels of travel. Walked a
+  // pixel at a time rather than sampled between two ticks: a single midpoint
+  // would pass on a rail whose gaps sat anywhere else.
+  const travel = await page.evaluate(() => {
+    const bars = [...document.querySelectorAll('.maka-prompt-rail-tick-bar')];
+    if (bars.length < 2) throw new Error('the prompt rail needs at least two ticks');
+    const first = bars[0]!.getBoundingClientRect();
+    const last = bars[bars.length - 1]!.getBoundingClientRect();
+    const x = Math.round(first.left + first.width / 2);
+    const misses: number[] = [];
+    for (let y = Math.round(first.top + first.height / 2); y <= Math.round(last.top + last.height / 2); y += 1) {
+      const found = document.elementFromPoint(x, y);
+      if (!found?.closest('.maka-prompt-rail-tick')) misses.push(y);
+    }
+    return { misses: misses.length, span: Math.round(last.bottom - first.top) };
+  });
+
+  expect(travel.span).toBeGreaterThan(0);
+  expect(travel.misses).toBe(0);
+});
+
+test('the first click of a session lands on its prompt and holds', async ({
+  promptRailWindow: page,
+}) => {
+  // Clicked before anything else touches the transcript, which is the case
+  // that used to fail: the head of a 30-prompt session is not mounted yet, so
+  // the jump has to mount it, and the fill that follows changes scrollHeight
+  // under Astryx's auto-follow lock. The lock ignores scroll-ups that arrive
+  // with a changed height, so it stayed on and pulled the transcript back to
+  // the bottom — the click looked dead until the reader scrolled by hand.
+  //
+  // Motion has to be on, and this is the one assertion here that depends on
+  // it: under reduced motion the jump is an instant scroll that has already
+  // landed before the next fill step, and the bug does not reproduce. The
+  // shipped app scrolls smoothly (#2680), which leaves the jump in flight for
+  // exactly as long as it takes the lock to win.
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.locator('.maka-prompt-rail-tick').first().click({ force: true });
+
+  const landed = async () =>
+    page.evaluate(() => {
+      const scroller = document.querySelector('[data-chat-scroll-container="true"]')!;
+      const first = document.querySelector('[data-turn-id]');
+      if (!first) return null;
+      return Math.round(
+        first.getBoundingClientRect().top - scroller.getBoundingClientRect().top,
+      );
+    });
+
+  // Within a turn's own top padding of the scrollport's top edge.
+  await expect.poll(landed, { message: 'the clicked prompt reaches the top' }).toBeLessThan(24);
+  // And stays: the fill runs on idle callbacks after the jump, so a jump that
+  // only wins the first frame reads as landing and then sliding away.
+  await page.waitForTimeout(1_200);
+  expect(await landed()).toBeLessThan(24);
+});
+
 test('a tick is what the pointer lands on, not the scrollbar', async ({
   promptRailWindow: page,
 }) => {

--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -152,7 +152,7 @@ test('the pointer is always on a tick while it travels down the rail', async ({
 });
 
 test('the first click of a session lands on its prompt and holds', async ({
-  promptRailWindow: page,
+  promptRailMotionWindow: page,
 }) => {
   // Clicked before anything else touches the transcript, which is the case
   // that used to fail: the head of a 30-prompt session is not mounted yet, so
@@ -161,30 +161,51 @@ test('the first click of a session lands on its prompt and holds', async ({
   // with a changed height, so it stayed on and pulled the transcript back to
   // the bottom — the click looked dead until the reader scrolled by hand.
   //
-  // Motion has to be on, and this is the one assertion here that depends on
-  // it: under reduced motion the jump is an instant scroll that has already
-  // landed before the next fill step, and the bug does not reproduce. The
-  // shipped app scrolls smoothly (#2680), which leaves the jump in flight for
-  // exactly as long as it takes the lock to win.
-  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  // This window is the only one in the suite that scrolls smoothly, which is
+  // why it is its own fixture. Every capture otherwise collapses scroll
+  // motion, and a jump that finishes in one frame is never in flight long
+  // enough to meet the lock at all. `emulateMedia` cannot arrange it: the
+  // collapse is keyed on `data-maka-e2e-fixture`, not on the media query.
+  expect(await page.evaluate(() => document.documentElement.dataset.makaScrollMotion)).toBe(
+    'smooth',
+  );
+
+  // The first tick's turn, named rather than inferred: the first mounted
+  // `[data-turn-id]` is whatever the tail window happens to hold, and at the
+  // opening scroll position its top is already above the scrollport, which
+  // passes an upper-bound-only check without the jump doing anything at all.
+  const targetTurnId = 'turn-prompt-rail-1';
   await page.locator('.maka-prompt-rail-tick').first().click({ force: true });
 
-  const landed = async () =>
-    page.evaluate(() => {
+  const landing = async () =>
+    page.evaluate((turnId) => {
       const scroller = document.querySelector('[data-chat-scroll-container="true"]')!;
-      const first = document.querySelector('[data-turn-id]');
-      if (!first) return null;
-      return Math.round(
-        first.getBoundingClientRect().top - scroller.getBoundingClientRect().top,
-      );
-    });
+      const turn = document.querySelector(`[data-turn-id="${turnId}"]`);
+      if (!turn) return null;
+      const tick = document.querySelector('.maka-prompt-rail-tick');
+      return {
+        offset: Math.round(
+          turn.getBoundingClientRect().top - scroller.getBoundingClientRect().top,
+        ),
+        tickIsCurrent: tick?.getAttribute('aria-current') === 'true',
+      };
+    }, targetTurnId);
 
-  // Within a turn's own top padding of the scrollport's top edge.
-  await expect.poll(landed, { message: 'the clicked prompt reaches the top' }).toBeLessThan(24);
+  // Bounded on both sides: below is the turn never arriving, above is it
+  // arriving and then being pulled off the top of the scrollport.
+  await expect
+    .poll(async () => (await landing())?.offset, { message: 'the clicked prompt reaches the top' })
+    .toBeGreaterThan(-24);
+  expect((await landing())?.offset).toBeLessThan(24);
+  expect((await landing())?.tickIsCurrent).toBe(true);
+
   // And stays: the fill runs on idle callbacks after the jump, so a jump that
   // only wins the first frame reads as landing and then sliding away.
   await page.waitForTimeout(1_200);
-  expect(await landed()).toBeLessThan(24);
+  const settled = await landing();
+  expect(settled?.offset).toBeGreaterThan(-24);
+  expect(settled?.offset).toBeLessThan(24);
+  expect(settled?.tickIsCurrent).toBe(true);
 });
 
 test('a tick is what the pointer lands on, not the scrollbar', async ({

--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -1,0 +1,145 @@
+import { PROMPT_RAIL_PROMPT_COUNT } from '../src/main/e2e-fixture/seed-helpers';
+import { expect, test } from './fixtures';
+import type { Page } from '@playwright/test';
+
+/**
+ * The prompt anchor rail (#563) has failed three times in a row in the same
+ * way: the code kept working and the pixels stopped. #2161 pinned it against
+ * `.maka-chat-shell` while Astryx's ChatLayout owned the scroll container, so
+ * the rail laid out across the whole conversation and scrolled off screen.
+ * #2338 parked it under macOS's overlay scrollbar, which takes no layout space
+ * but still swallows the pointer, so every tick rendered and none could be
+ * clicked. #2580 moved the tick onto Astryx's `Button`, whose label span put
+ * the tick's bar back into normal flow — an inline box takes no width or
+ * height, so the bars computed to 0x0 and the rail shipped invisible in 0.1.9
+ * and 0.1.10.
+ *
+ * None of the three is visible to a static read of the CSS, and none is
+ * reachable from jsdom, which has no layout. Only a real scroller with a real
+ * transcript can see them, so this file keeps one test per failure and nothing
+ * else. It is deliberately much smaller than the suite deleted in #2462.
+ *
+ * Two boundaries worth knowing before adding to it:
+ *  - e2e-fixture renders carry `data-maka-e2e-fixture`, and `base.css` gives
+ *    that `animation: none` plus a 0.01ms transition cap, so a fixture's state
+ *    never depends on when it settles. Assert the end states motion resolves
+ *    to; there is no way to assert that anything animated.
+ *  - the reachability test is load-bearing on macOS only. Linux's in-flow
+ *    scrollbar moves the content column left instead of overlaying it, so the
+ *    #2338 regression goes green on CI. Run this spec on macOS before merging
+ *    anything that touches the rail's right edge.
+ */
+
+const RAIL_PROBE = `(() => {
+  const scroller = document.querySelector('[data-chat-scroll-container="true"]');
+  const rail = document.querySelector('.maka-prompt-rail');
+  if (!scroller || !rail) return null;
+  const s = scroller.getBoundingClientRect();
+  const r = rail.getBoundingClientRect();
+  // Astryx renders the composer dock as the scroll container's last child;
+  // the rail measures it the same way, for want of a published hook.
+  const dock = scroller.lastElementChild.getBoundingClientRect();
+  return {
+    // Positive on all four = the rail's box is inside the scrollport and clear
+    // of the band the sticky dock occupies at the bottom.
+    insetTop: Math.round(r.top - s.top),
+    insetBottom: Math.round(s.bottom - r.bottom),
+    insetRight: Math.round(s.right - r.right),
+    dockClearance: Math.round(dock.top - r.bottom),
+    railWidth: Math.round(r.width),
+    scrollTop: Math.round(scroller.scrollTop),
+  };
+})()`;
+
+interface RailProbe {
+  insetTop: number;
+  insetBottom: number;
+  insetRight: number;
+  dockClearance: number;
+  railWidth: number;
+  scrollTop: number;
+}
+
+function probeRail(page: Page): Promise<RailProbe | null> {
+  return page.evaluate(RAIL_PROBE) as Promise<RailProbe | null>;
+}
+
+async function scrollTranscriptTo(page: Page, position: 'top' | 'bottom'): Promise<void> {
+  await page.evaluate((where) => {
+    const scroller = document.querySelector('[data-chat-scroll-container="true"]');
+    if (!scroller) throw new Error('the chat scroll container is missing');
+    scroller.scrollTop = where === 'top' ? 0 : scroller.scrollHeight;
+  }, position);
+}
+
+test('every tick paints a bar with a real box', async ({ promptRailWindow: page }) => {
+  // Measured over ALL ticks, not a sample: a helper that skips what it cannot
+  // evaluate creates its blind spot exactly where a regression lives.
+  const bars = await page.evaluate(() =>
+    [...document.querySelectorAll('.maka-prompt-rail-tick-bar')].map((bar) => {
+      const box = bar.getBoundingClientRect();
+      return { width: Math.round(box.width), height: Math.round(box.height) };
+    }),
+  );
+
+  expect(bars).toHaveLength(PROMPT_RAIL_PROMPT_COUNT);
+  // #2580 shipped bars at 0x0 — present in the DOM, painting nothing.
+  expect(Math.min(...bars.map((bar) => bar.width))).toBeGreaterThan(0);
+  expect(Math.min(...bars.map((bar) => bar.height))).toBeGreaterThan(0);
+});
+
+test('the rail stays inside the scrollport at both scroll extremes', async ({
+  promptRailWindow: page,
+}) => {
+  const scroll = await page.evaluate(() => {
+    const scroller = document.querySelector('[data-chat-scroll-container="true"]');
+    if (!scroller) throw new Error('the chat scroll container is missing');
+    return { height: scroller.scrollHeight, client: scroller.clientHeight };
+  });
+  // Without an overflowing transcript the rail has nothing to be pinned
+  // against and the rest of this test proves nothing.
+  expect(scroll.height).toBeGreaterThan(scroll.client);
+
+  for (const position of ['top', 'bottom'] as const) {
+    await scrollTranscriptTo(page, position);
+    // The bottom is where it bites: a sticky offset is clamped by its
+    // containing block, and the chat shell ends a dock-height above the
+    // scrollport's bottom edge (CI caught -62px insetTop that way).
+    await expect
+      .poll(async () => {
+        const probe = await probeRail(page);
+        if (!probe) return null;
+        return {
+          insetTop: probe.insetTop >= 0,
+          insetBottom: probe.insetBottom >= 0,
+          insetRight: probe.insetRight >= 0,
+          dockClearance: probe.dockClearance >= 0,
+        };
+      }, { message: `rail geometry at the ${position} of the transcript` })
+      .toEqual({
+        insetTop: true,
+        insetBottom: true,
+        insetRight: true,
+        dockClearance: true,
+      });
+  }
+});
+
+test('a tick is what the pointer lands on, not the scrollbar', async ({
+  promptRailWindow: page,
+}) => {
+  // `elementFromPoint`, not `hover()`: dispatched events cannot see occlusion,
+  // and macOS's overlay scrollbar occludes without taking layout space.
+  const hit = await page.evaluate(() => {
+    const tick = document.querySelector('.maka-prompt-rail-tick');
+    if (!tick) throw new Error('the prompt rail has no ticks');
+    const box = tick.getBoundingClientRect();
+    const found = document.elementFromPoint(
+      Math.round(box.left + box.width / 2),
+      Math.round(box.top + box.height / 2),
+    );
+    return { insideRail: found?.closest('.maka-prompt-rail') !== null };
+  });
+
+  expect(hit.insideRail).toBe(true);
+});

--- a/apps/desktop/src/main/__tests__/scroll-motion-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/scroll-motion-policy.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { resolveScrollMotionBehavior } from '../../renderer/scroll-motion-policy.js';
+
+const base = {
+  reducedMotionAttr: false,
+  e2eFixtureAttr: false,
+  prefersReducedMotion: false,
+};
+
+test('captures collapse scroll motion, and a fixture can ask for it back', () => {
+  assert.equal(resolveScrollMotionBehavior(base), 'smooth');
+  assert.equal(
+    resolveScrollMotionBehavior({ ...base, e2eFixtureAttr: true }),
+    'auto',
+    'a capture is deterministic by default',
+  );
+  assert.equal(
+    resolveScrollMotionBehavior({ ...base, e2eFixtureAttr: true, scrollMotionAttr: 'smooth' }),
+    'smooth',
+    'a fixture whose subject is scrolling opts back in',
+  );
+});
+
+test('no fixture request outranks a preference for less motion', () => {
+  for (const reduced of [
+    { reducedMotionAttr: true },
+    { prefersReducedMotion: true },
+  ] as const) {
+    assert.equal(
+      resolveScrollMotionBehavior({
+        ...base,
+        ...reduced,
+        e2eFixtureAttr: true,
+        scrollMotionAttr: 'smooth',
+      }),
+      'auto',
+    );
+  }
+});
+
+test('a fixture can also ask for no motion outside a capture', () => {
+  assert.equal(resolveScrollMotionBehavior({ ...base, scrollMotionAttr: 'auto' }), 'auto');
+});

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -10,10 +10,16 @@ import {
   LONG_SIDEBAR_PROJECT_ID,
   LONG_SIDEBAR_PROJECT_NAME,
   LONG_SIDEBAR_SESSION_PREFIX,
+  PROMPT_RAIL_SESSION_ID,
   TURN_SESSION_ID,
   writeSession,
 } from './e2e-fixture/seed-helpers.js';
-import { turnMessages, turnSession } from './e2e-fixture/scenarios-chat.js';
+import {
+  promptRailMessages,
+  promptRailSession,
+  turnMessages,
+  turnSession,
+} from './e2e-fixture/scenarios-chat.js';
 import { seedMcpFixture, seedSkillsMarketFixture } from './e2e-fixture/scenarios-modules.js';
 import { longSidebarSessions } from './e2e-fixture/scenarios-sessions.js';
 import {
@@ -27,6 +33,7 @@ import { usageStatsSessions } from './e2e-fixture/scenarios-usage.js';
 const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   'fetched-empty',
   'turn-narrative',
+  'chat-prompt-rail',
   'settings-data',
   'settings-bots-onboarding',
   'settings-general',
@@ -125,6 +132,10 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'models' };
     case 'turn-narrative':
       return { ...state, activeSessionId: TURN_SESSION_ID, workbarCollapsed: false, workbarTab: 'tasks' };
+    case 'chat-prompt-rail':
+      // Workbar collapsed: the rail lives on the chat scrollport's right edge,
+      // and the panel would take the width the measurements are about.
+      return { ...state, activeSessionId: PROMPT_RAIL_SESSION_ID, workbarCollapsed: true };
     case 'settings-data':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'data' };
     case 'settings-bots-onboarding':
@@ -180,6 +191,9 @@ export async function seedE2eFixture(input: {
   }
   await writeSession(input.workspaceRoot, turnSession(now), turnMessages(now));
 
+  if (scenario === 'chat-prompt-rail') {
+    await writeSession(input.workspaceRoot, promptRailSession(now), promptRailMessages(now));
+  }
   if (scenario === 'sidebar-search-modal-open') {
     for (const seed of longSidebarSessions(now)) {
       await writeSession(input.workspaceRoot, seed.header, seed.messages);

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -54,6 +54,7 @@ export interface E2eFixture {
   locale: UiLocale | null;
   timezone: string | null;
   platform: 'darwin' | 'win32' | 'linux' | null;
+  scrollMotion: 'auto' | 'smooth' | null;
 }
 
 export function resolveE2eFixture(
@@ -64,6 +65,7 @@ export function resolveE2eFixture(
   rawLocale: string | undefined = undefined,
   rawTimezone: string | undefined = undefined,
   rawPlatform: string | undefined = undefined,
+  rawScrollMotion: string | undefined = undefined,
 ): E2eFixture | null {
   if (!rawScenario) return null;
   if (isPackaged) throw new Error('MAKA_E2E_FIXTURE is only available in dev/test builds.');
@@ -79,7 +81,13 @@ export function resolveE2eFixture(
     locale: parseLocaleFlag(rawLocale),
     timezone: parseTimezoneFlag(rawTimezone),
     platform: parsePlatformFlag(rawPlatform),
+    scrollMotion: parseScrollMotionFlag(rawScrollMotion),
   };
+}
+
+function parseScrollMotionFlag(raw: string | undefined): 'auto' | 'smooth' | null {
+  const normalized = raw?.trim().toLowerCase();
+  return normalized === 'auto' || normalized === 'smooth' ? normalized : null;
 }
 
 function parseThemeFlag(raw: string | undefined): 'light' | 'dark' | 'auto' | null {
@@ -126,6 +134,7 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
     ...(fixture.theme ? { theme: fixture.theme } : {}),
     ...(fixture.locale ? { locale: fixture.locale } : {}),
     ...(fixture.timezone ? { timezone: fixture.timezone } : {}),
+    ...(fixture.scrollMotion ? { scrollMotion: fixture.scrollMotion } : {}),
   };
   switch (fixture.scenario) {
     case 'fetched-empty':
@@ -134,7 +143,9 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
       return { ...state, activeSessionId: TURN_SESSION_ID, workbarCollapsed: false, workbarTab: 'tasks' };
     case 'chat-prompt-rail':
       // Workbar collapsed: the rail lives on the chat scrollport's right edge,
-      // and the panel would take the width the measurements are about.
+      // and the panel would take the width the measurements are about. Whether
+      // this window scrolls smoothly is a per-launch choice (`scrollMotion`),
+      // because only the jump case needs it and it costs seconds of settling.
       return { ...state, activeSessionId: PROMPT_RAIL_SESSION_ID, workbarCollapsed: true };
     case 'settings-data':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'data' };

--- a/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
@@ -1,5 +1,10 @@
 import type { SessionHeader, StoredMessage } from '@maka/core/session';
-import { header, TURN_SESSION_ID } from './seed-helpers.js';
+import {
+  header,
+  PROMPT_RAIL_PROMPT_COUNT,
+  PROMPT_RAIL_SESSION_ID,
+  TURN_SESSION_ID,
+} from './seed-helpers.js';
 
 export function turnSession(now: number): SessionHeader {
   return header({
@@ -76,4 +81,44 @@ export function turnMessages(now: number): StoredMessage[] {
       costUsd: 0.0042,
     },
   ];
+}
+
+export function promptRailSession(now: number): SessionHeader {
+  return header({
+    id: PROMPT_RAIL_SESSION_ID,
+    name: '长对话提示词导航示例',
+    connection: 'zai-live',
+    model: 'glm-5.1',
+    now,
+    lastMessageAt: now - 60_000,
+  });
+}
+
+/**
+ * A plain multi-prompt conversation: no tools, no thinking, no usage rows.
+ * `prompt-rail.spec.ts` measures the rail against this, so every turn is just
+ * a prompt and a reply long enough to push the transcript past the scrollport.
+ */
+export function promptRailMessages(now: number): StoredMessage[] {
+  const messages: StoredMessage[] = [];
+  for (let index = 1; index <= PROMPT_RAIL_PROMPT_COUNT; index += 1) {
+    const turnId = `turn-prompt-rail-${index}`;
+    const ts = now - (PROMPT_RAIL_PROMPT_COUNT - index + 1) * 60_000;
+    messages.push({
+      type: 'user',
+      id: `msg-prompt-rail-user-${index}`,
+      turnId,
+      ts,
+      text: `第 ${index} 个问题：这一段的调用链路是怎样的？`,
+    });
+    messages.push({
+      type: 'assistant',
+      id: `msg-prompt-rail-assistant-${index}`,
+      turnId,
+      ts: ts + 1_000,
+      text: `第 ${index} 段回答。`.repeat(40),
+      modelId: 'glm-5.1',
+    });
+  }
+  return messages;
 }

--- a/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
+++ b/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
@@ -14,6 +14,14 @@ import {
 export const E2E_FIXTURE_NOW = Date.UTC(2026, 4, 22, 3, 0, 0);
 
 export const TURN_SESSION_ID = 'e2e-fixture-turn';
+export const PROMPT_RAIL_SESSION_ID = 'e2e-fixture-prompt-rail';
+/**
+ * Prompts seeded for the prompt-rail fixture. Clears the rail's own
+ * three-prompt floor (it renders nothing below that) with room to spare, and
+ * gives the transcript enough height to overflow the scrollport — without
+ * that, the rail's pinning has nothing to be pinned against.
+ */
+export const PROMPT_RAIL_PROMPT_COUNT = 8;
 export const LONG_SIDEBAR_SESSION_PREFIX = 'e2e-fixture-sidebar-long-';
 export const LONG_SIDEBAR_SESSION_COUNT = 60;
 export const LONG_SIDEBAR_PROJECT_ID = 'e2e-fixture-project';

--- a/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
+++ b/apps/desktop/src/main/e2e-fixture/seed-helpers.ts
@@ -16,12 +16,15 @@ export const E2E_FIXTURE_NOW = Date.UTC(2026, 4, 22, 3, 0, 0);
 export const TURN_SESSION_ID = 'e2e-fixture-turn';
 export const PROMPT_RAIL_SESSION_ID = 'e2e-fixture-prompt-rail';
 /**
- * Prompts seeded for the prompt-rail fixture. Clears the rail's own
- * three-prompt floor (it renders nothing below that) with room to spare, and
- * gives the transcript enough height to overflow the scrollport — without
- * that, the rail's pinning has nothing to be pinned against.
+ * Prompts seeded for the prompt-rail fixture. Three constraints set the
+ * number: the rail renders nothing below three prompts, the transcript has to
+ * overflow the scrollport or its pinning has nothing to be pinned against,
+ * and — the binding one — it must exceed the progressive mount's initial
+ * window of ten, or the head of the transcript is already mounted when the
+ * fixture opens and the jump-into-unmounted-turns path never runs. At eight
+ * prompts the spec could not see that bug at all.
  */
-export const PROMPT_RAIL_PROMPT_COUNT = 8;
+export const PROMPT_RAIL_PROMPT_COUNT = 30;
 export const LONG_SIDEBAR_SESSION_PREFIX = 'e2e-fixture-sidebar-long-';
 export const LONG_SIDEBAR_SESSION_COUNT = 60;
 export const LONG_SIDEBAR_PROJECT_ID = 'e2e-fixture-project';

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -1203,6 +1203,7 @@ function resolveDesktopE2eFixture(): ReturnType<typeof resolveE2eFixture> {
       process.env.MAKA_E2E_FIXTURE_LOCALE,
       process.env.MAKA_E2E_FIXTURE_TIMEZONE,
       process.env.MAKA_E2E_FIXTURE_PLATFORM,
+      process.env.MAKA_E2E_FIXTURE_SCROLL_MOTION,
     );
   } catch (error) {
     if (!process.env.MAKA_E2E_FIXTURE) throw error;

--- a/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
+++ b/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
@@ -49,6 +49,12 @@ export function createAppShellE2eFixtureActions(options: {
       Date.now = () => state.now!;
     }
     document.documentElement.setAttribute('data-maka-e2e-fixture', 'true');
+    // Read by `scroll-motion-policy`: a fixture whose subject is scrolling
+    // asks for the production behavior back, since the blanket collapse would
+    // finish every scroll in one frame and hide what it is testing.
+    if (state.scrollMotion) {
+      document.documentElement.setAttribute('data-maka-scroll-motion', state.scrollMotion);
+    }
     // PR-IR-01b: theme override applied BEFORE the persisted user pref so
     // the rendered fixture matches the `<theme>-<viewport>-<motion>` variant
     // exactly. `applyTheme` writes both the React state + the `.dark` class

--- a/apps/desktop/src/renderer/scroll-motion-policy.ts
+++ b/apps/desktop/src/renderer/scroll-motion-policy.ts
@@ -28,6 +28,22 @@ export interface ScrollMotionPolicyInputs {
   e2eFixtureAttr: boolean;
   /** `window.matchMedia('(prefers-reduced-motion: reduce)').matches` */
   prefersReducedMotion: boolean;
+  /**
+   * `document.documentElement.dataset.makaScrollMotion`, set by a fixture that
+   * asks for a specific behavior.
+   *
+   * Collapsing motion for every capture is right for a screenshot and wrong
+   * for a test about scrolling: a scroll that finishes in one frame cannot
+   * collide with anything, so the fixture suite had no way to exercise the
+   * production smooth path at all (`prompt-rail.spec.ts` needs it — Astryx's
+   * auto-follow lock only contends with a scroll still in flight). This lets
+   * one fixture opt back in without loosening the default for the rest.
+   *
+   * Deliberately below the reduced-motion triggers: a fixture may ask for
+   * motion the capture would otherwise skip, but nothing may override a
+   * stated preference for less of it.
+   */
+  scrollMotionAttr?: ScrollMotionBehavior | undefined;
 }
 
 /**
@@ -38,7 +54,13 @@ export interface ScrollMotionPolicyInputs {
  * flags from whatever environment they're in.
  */
 export function resolveScrollMotionBehavior(inputs: ScrollMotionPolicyInputs): ScrollMotionBehavior {
-  if (inputs.reducedMotionAttr || inputs.e2eFixtureAttr || inputs.prefersReducedMotion) {
+  if (inputs.reducedMotionAttr || inputs.prefersReducedMotion) {
+    return 'auto';
+  }
+  if (inputs.scrollMotionAttr) {
+    return inputs.scrollMotionAttr;
+  }
+  if (inputs.e2eFixtureAttr) {
     return 'auto';
   }
   return 'smooth';
@@ -54,9 +76,11 @@ export function readScrollMotionBehavior(): ScrollMotionBehavior {
   const prefersReducedMotion =
     typeof window.matchMedia === 'function' &&
     window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const requested = root.dataset.makaScrollMotion;
   return resolveScrollMotionBehavior({
     reducedMotionAttr: root.dataset.makaReducedMotion === 'true',
     e2eFixtureAttr: root.dataset.makaE2eFixture === 'true',
     prefersReducedMotion,
+    scrollMotionAttr: requested === 'smooth' || requested === 'auto' ? requested : undefined,
   });
 }

--- a/apps/desktop/src/renderer/styles/prompt-rail.css
+++ b/apps/desktop/src/renderer/styles/prompt-rail.css
@@ -134,6 +134,12 @@
    pointer (0 = hovered) and rests at the falloff distance, so the whole ramp is
    one expression and the resting width is its own tail. */
 .maka-prompt-rail-tick-bar {
+  /* Load-bearing since #2580 put the tick on Astryx's Button: the bar used to
+     be a direct child of the flex tick, which blockified it, and now it sits
+     inside the Button's own label span in normal flow. An inline box takes no
+     width or height, so without this the bar computes to 0x0 and the whole
+     rail paints nothing. */
+  display: block;
   width: calc(14px + ((3 - var(--maka-prompt-rail-proximity, 3)) * 3px));
   height: 3px;
   border-radius: var(--radius-pill);

--- a/apps/desktop/src/renderer/styles/prompt-rail.css
+++ b/apps/desktop/src/renderer/styles/prompt-rail.css
@@ -74,7 +74,12 @@
   /* `safe` so the max-height above can never strand the first ticks past an
      unscrollable overflow edge, which plain centring does. */
   justify-content: safe center;
-  gap: var(--space-1);
+  /* No gap on purpose: a gap between ticks is a band where the pointer is over
+     the rail but over no tick, so the hover falloff drops out and picks up
+     again every few pixels of travel. The ticks carry the same rhythm in their
+     own padding instead (see the tick's `padding-block`), which keeps the
+     pitch identical and leaves the column continuous — moving down the rail
+     hands the hover from one tick straight to the next. */
   padding: var(--space-1);
   pointer-events: auto;
   opacity: var(--opacity-muted);
@@ -106,7 +111,10 @@
   appearance: none;
   border: 0;
   margin: 0;
-  padding: var(--space-0-5) 0;
+  /* Holds the rail's rhythm now that the rail itself has no gap: half of this
+     used to be the gap, so the pitch between bars is unchanged and the hit
+     boxes tile instead of leaving a dead band between them. */
+  padding: var(--space-1) 0;
   background: transparent;
   color: var(--muted-foreground);
   display: flex;
@@ -176,6 +184,16 @@
   background: var(--foreground);
   pointer-events: none;
   transition: top var(--duration-large) var(--ease-out-strong);
+}
+
+/* The glide is for reading: it carries the eye between neighbouring prompts as
+   the transcript scrolls. A click is the opposite — the reader picked the
+   destination, and the same 280ms spent crossing twenty prompts instead of one
+   reads as the bar flying off across the rail. `jumpTo` in
+   prompt-anchor-rail.tsx holds this attribute until the scroll it started has
+   settled, so the highlight is placed at each turn the jump passes through. */
+.maka-prompt-rail[data-jumping="true"] .maka-prompt-rail-indicator {
+  transition: none;
 }
 
 /* No active prompt yet (a transcript that has not been scrolled) leaves the

--- a/packages/core/src/e2e-fixture.ts
+++ b/packages/core/src/e2e-fixture.ts
@@ -24,6 +24,13 @@ export interface E2eFixtureState {
   activeSessionId?: string;
   openSettingsSection?: SettingsSection;
   reducedMotion?: boolean;
+  /**
+   * Opt a fixture back into animated scrolling. Captures collapse scroll
+   * motion so a screenshot never depends on when it settles, which also means
+   * no fixture can exercise a scroll that is still in flight — and that is
+   * precisely what the prompt rail's jump has to survive.
+   */
+  scrollMotion?: 'auto' | 'smooth';
   theme?: 'light' | 'dark' | 'auto';
   locale?: UiLocale;
   timezone?: string;

--- a/packages/core/src/e2e-fixture.ts
+++ b/packages/core/src/e2e-fixture.ts
@@ -6,6 +6,7 @@ import type { UiLocale } from './ui-locale.js';
 export type E2eFixtureScenario =
   | 'fetched-empty'
   | 'turn-narrative'
+  | 'chat-prompt-rail'
   | 'settings-data'
   | 'settings-bots-onboarding'
   | 'settings-general'

--- a/packages/ui/src/__tests__/prompt-anchor-rail.test.ts
+++ b/packages/ui/src/__tests__/prompt-anchor-rail.test.ts
@@ -6,11 +6,13 @@ import {
   type PromptRailFrameScheduler,
 } from '../prompt-anchor-rail.js';
 
-test('a jump re-aims at its destination every time the transcript grows', () => {
-  // The e2e suite cannot stage this: whether the lock wins depends on which
-  // frame the progressive fill lands on relative to a smooth scroll still in
-  // flight, and it went green against the unfixed renderer often enough to be
-  // worthless as a guard. The mechanism is deterministic here.
+/**
+ * The e2e suite cannot stage what these cover. Whether a jump survives depends
+ * on which frame the progressive fill lands on, and the e2e case went green
+ * against a renderer that did not survive it. Driving the frames here makes it
+ * deterministic.
+ */
+function railHoldHarness() {
   // The helper builds its selector with `CSS.escape`, which the renderer has
   // and Node does not. Stubbed rather than worked around in the source: the
   // escaping is what keeps a turn id safe inside a selector, and a fallback
@@ -27,52 +29,160 @@ test('a jump re-aims at its destination every time the transcript grows', () => 
     cancel: () => {},
   };
   const scrolled: Array<ScrollIntoViewOptions | undefined> = [];
-  const target = {
-    scrollIntoView: (options?: ScrollIntoViewOptions) => scrolled.push(options),
+  const listeners = new Map<string, EventListener>();
+  const state = {
+    scrollHeight: 1_000,
+    scrollTop: 900,
+    /** The target's top edge, relative to the scrollport's. 0 = landed. */
+    targetTop: 600,
+    filled: false,
+    queried: '',
+    settled: 0,
   };
-  let scrollHeight = 1_000;
-  let queried: string | undefined;
+  const target = {
+    getBoundingClientRect: () => ({ top: state.targetTop }) as DOMRect,
+    scrollIntoView: (options?: ScrollIntoViewOptions) => {
+      scrolled.push(options);
+      // A real scroller lands the target at the top and moves to get there.
+      state.scrollTop += state.targetTop;
+      state.targetTop = 0;
+    },
+  };
   const root = {
     get scrollHeight() {
-      return scrollHeight;
+      return state.scrollHeight;
     },
+    get scrollTop() {
+      return state.scrollTop;
+    },
+    getBoundingClientRect: () => ({ top: 0 }) as DOMRect,
     querySelector: (selector: string) => {
-      queried = selector;
+      state.queried = selector;
       return target;
     },
+    addEventListener: (type: string, listener: EventListener) => listeners.set(type, listener),
+    removeEventListener: (type: string) => listeners.delete(type),
   } as unknown as Element;
 
-  const release = holdJumpDestination(root, () => 'turn-7', scheduler);
-  const runFrame = (): void => frames.shift()?.();
+  return {
+    root,
+    scheduler,
+    scrolled,
+    state,
+    listeners,
+    /** Runs the frame the hold has queued, and only that one. */
+    runFrame: (): void => frames.shift()?.(),
+    restore: (): void => {
+      (globalThis as { CSS?: unknown }).CSS = priorCss;
+    },
+  };
+}
 
-  runFrame();
-  assert.equal(scrolled.length, 0, 'a steady transcript is left alone');
+test('a jump re-aims at its destination every time the transcript grows', () => {
+  const harness = railHoldHarness();
+  const { root, scheduler, scrolled, state } = harness;
 
-  scrollHeight = 1_400;
-  runFrame();
+  const release = holdJumpDestination({
+    root,
+    readTargetId: () => 'turn-7',
+    isTranscriptFilled: () => state.filled,
+    onSettled: () => {
+      state.settled += 1;
+    },
+    scheduler,
+  });
+
+  state.scrollHeight = 1_400;
+  harness.runFrame();
   assert.equal(scrolled.length, 1, 'a fill step re-aims the jump');
   assert.deepEqual(scrolled[0], { behavior: 'auto', block: 'start' });
-  assert.equal(queried, '[data-turn-id="turn-7"]');
+  assert.equal(state.queried, '[data-turn-id="turn-7"]');
 
-  runFrame();
-  assert.equal(scrolled.length, 1, 'the same height does not re-aim again');
+  harness.runFrame();
+  assert.equal(scrolled.length, 1, 'a target already at the top is left alone');
 
-  scrollHeight = 1_800;
-  runFrame();
+  // Every later fill step moves it again, and every one is followed back.
+  state.scrollHeight = 1_800;
+  state.targetTop = 320;
+  harness.runFrame();
   assert.equal(scrolled.length, 2, 'every later fill step re-aims too');
 
-  // Once the jump is over its target is cleared, and a still-growing
-  // transcript must no longer be pulled back to it. Started on its own queue:
-  // the first hold has a frame pending, and shifting that one instead would
-  // measure the loop this case is not about.
+  // A scroll that was cancelled part-way leaves the target off-target on an
+  // otherwise still frame. That is the other way a jump used to be lost.
+  state.filled = true;
+  state.targetTop = 240;
+  harness.runFrame();
+  assert.equal(scrolled.length, 3, 'a stalled jump is corrected, not accepted');
+
   release();
-  frames.length = 0;
-  const released = holdJumpDestination(root, () => null, scheduler);
-  scrollHeight = 2_200;
-  runFrame();
-  assert.equal(scrolled.length, 2, 'a settled jump releases the transcript');
-  released();
-  (globalThis as { CSS?: unknown }).CSS = priorCss;
+  harness.restore();
+});
+
+test('a jump holds until the transcript reports itself filled and still', () => {
+  const harness = railHoldHarness();
+  const { root, scheduler, state } = harness;
+
+  holdJumpDestination({
+    root,
+    readTargetId: () => 'turn-7',
+    isTranscriptFilled: () => state.filled,
+    onSettled: () => {
+      state.settled += 1;
+    },
+    scheduler,
+  });
+
+  // Landed already, so nothing below is a correction — only the boundary.
+  state.targetTop = 0;
+
+  // Still filling: quiet frames must not count, however many pass. This is the
+  // case a fixed timeout got wrong — it expired mid-fill and handed a
+  // still-growing transcript back to whatever else was moving it.
+  for (let index = 0; index < 20; index += 1) harness.runFrame();
+  assert.equal(state.settled, 0, 'an unfilled transcript keeps its hold');
+
+  state.filled = true;
+  harness.runFrame();
+  harness.runFrame();
+  assert.equal(state.settled, 0, 'settling waits for a few still frames');
+  harness.runFrame();
+  assert.equal(state.settled, 1, 'filled and still ends the hold');
+
+  harness.restore();
+});
+
+test('a jump gives the transcript back the moment the reader touches it', () => {
+  const harness = railHoldHarness();
+  const { root, scheduler, state, listeners } = harness;
+
+  holdJumpDestination({
+    root,
+    readTargetId: () => 'turn-7',
+    isTranscriptFilled: () => state.filled,
+    onSettled: () => {
+      state.settled += 1;
+    },
+    scheduler,
+  });
+
+  assert.deepEqual(
+    [...listeners.keys()],
+    ['wheel', 'touchstart', 'pointerdown', 'keydown'],
+    'every way a reader can take over is listened for',
+  );
+
+  state.targetTop = 0;
+  listeners.get('wheel')?.(new Event('wheel'));
+  assert.equal(state.settled, 1, 'a wheel ends the hold even mid-fill');
+  assert.equal(listeners.size, 0, 'and the hold stops listening');
+
+  // Whatever the transcript does next is no longer the jump's business.
+  state.scrollHeight = 9_000;
+  harness.runFrame();
+  assert.equal(harness.scrolled.length, 0, 'a released hold does not re-aim');
+  assert.equal(state.settled, 1, 'and settles exactly once');
+
+  harness.restore();
 });
 
 test('keeps the active tick visible when the rail viewport resizes', () => {

--- a/packages/ui/src/__tests__/prompt-anchor-rail.test.ts
+++ b/packages/ui/src/__tests__/prompt-anchor-rail.test.ts
@@ -1,6 +1,79 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { observeActivePromptRailVisibility } from '../prompt-anchor-rail.js';
+import {
+  holdJumpDestination,
+  observeActivePromptRailVisibility,
+  type PromptRailFrameScheduler,
+} from '../prompt-anchor-rail.js';
+
+test('a jump re-aims at its destination every time the transcript grows', () => {
+  // The e2e suite cannot stage this: whether the lock wins depends on which
+  // frame the progressive fill lands on relative to a smooth scroll still in
+  // flight, and it went green against the unfixed renderer often enough to be
+  // worthless as a guard. The mechanism is deterministic here.
+  // The helper builds its selector with `CSS.escape`, which the renderer has
+  // and Node does not. Stubbed rather than worked around in the source: the
+  // escaping is what keeps a turn id safe inside a selector, and a fallback
+  // that only exists for tests would be the wrong thing to ship.
+  const priorCss = (globalThis as { CSS?: unknown }).CSS;
+  (globalThis as { CSS?: unknown }).CSS = { escape: (value: string) => value };
+
+  const frames: Array<() => void> = [];
+  const scheduler: PromptRailFrameScheduler = {
+    request: (callback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+    cancel: () => {},
+  };
+  const scrolled: Array<ScrollIntoViewOptions | undefined> = [];
+  const target = {
+    scrollIntoView: (options?: ScrollIntoViewOptions) => scrolled.push(options),
+  };
+  let scrollHeight = 1_000;
+  let queried: string | undefined;
+  const root = {
+    get scrollHeight() {
+      return scrollHeight;
+    },
+    querySelector: (selector: string) => {
+      queried = selector;
+      return target;
+    },
+  } as unknown as Element;
+
+  const release = holdJumpDestination(root, () => 'turn-7', scheduler);
+  const runFrame = (): void => frames.shift()?.();
+
+  runFrame();
+  assert.equal(scrolled.length, 0, 'a steady transcript is left alone');
+
+  scrollHeight = 1_400;
+  runFrame();
+  assert.equal(scrolled.length, 1, 'a fill step re-aims the jump');
+  assert.deepEqual(scrolled[0], { behavior: 'auto', block: 'start' });
+  assert.equal(queried, '[data-turn-id="turn-7"]');
+
+  runFrame();
+  assert.equal(scrolled.length, 1, 'the same height does not re-aim again');
+
+  scrollHeight = 1_800;
+  runFrame();
+  assert.equal(scrolled.length, 2, 'every later fill step re-aims too');
+
+  // Once the jump is over its target is cleared, and a still-growing
+  // transcript must no longer be pulled back to it. Started on its own queue:
+  // the first hold has a frame pending, and shifting that one instead would
+  // measure the loop this case is not about.
+  release();
+  frames.length = 0;
+  const released = holdJumpDestination(root, () => null, scheduler);
+  scrollHeight = 2_200;
+  runFrame();
+  assert.equal(scrolled.length, 2, 'a settled jump releases the transcript');
+  released();
+  (globalThis as { CSS?: unknown }).CSS = priorCss;
+});
 
 test('keeps the active tick visible when the rail viewport resizes', () => {
   let railBox = box(0, 600);

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -601,9 +601,10 @@ export function ChatView(props: {
         <PromptAnchorRail
           turns={promptRailTurns}
           scrollRef={scrollRef}
-          scrollBehavior={props.scrollBehavior}
           onNavigateFallback={revealTurn}
           mountedTurnsRevision={mountStart}
+          onNavigateStart={chatLayout.unlockAutoFollow}
+          transcriptFilled={turnsFilled}
         />
         <ChatMessageList
           className="maka-chat-message-list maka-chatContent"

--- a/packages/ui/src/prompt-anchor-rail.tsx
+++ b/packages/ui/src/prompt-anchor-rail.tsx
@@ -8,6 +8,21 @@ import { getConversationCopy } from './conversation-copy.js';
 const SCROLL_END_EPSILON_PX = 2;
 /** Hover falloff radius in ticks (0 = hovered). */
 const HOVER_FALLOFF_TICKS = 3;
+/**
+ * Astryx's HoverCard waits 300ms before opening, which guards against a
+ * pointer crossing a wide row on its way somewhere else. A tick is 22px of
+ * rail that nothing else is on the way to, and the wait is the one part of
+ * this hover with no motion in it — 300ms of nothing reads as lag rather than
+ * as restraint.
+ */
+const PREVIEW_DELAY_MS = 120;
+/**
+ * How long a click-driven jump suppresses the highlight's glide when no
+ * `scrollend` arrives — a smooth scroll of the whole transcript takes a few
+ * hundred milliseconds, and overshooting only means the next scroll-driven
+ * move is placed rather than animated.
+ */
+const JUMP_SETTLE_TIMEOUT_MS = 700;
 
 interface PromptRailResizeObserver {
   observe(target: Element): void;
@@ -30,6 +45,54 @@ export function keepActivePromptRailTickVisible(rail: HTMLElement): void {
   if (tickBox.top < railBox.top) rail.scrollTop -= railBox.top - tickBox.top;
   else if (tickBox.bottom > railBox.bottom)
     rail.scrollTop += tickBox.bottom - railBox.bottom;
+}
+
+/** Frame scheduler seam, so the jump hold can be driven by a test. */
+export interface PromptRailFrameScheduler {
+  request(callback: () => void): number;
+  cancel(handle: number): void;
+}
+
+const browserFrameScheduler: PromptRailFrameScheduler = {
+  request: (callback) => requestAnimationFrame(callback),
+  cancel: (handle) => cancelAnimationFrame(handle),
+};
+
+/**
+ * Hold a jump's destination while the transcript grows under it.
+ *
+ * A jump into a part of the transcript the progressive mount has not reached
+ * has to mount it first, and the fill that follows changes the scroller's
+ * height for several frames afterwards. Astryx's auto-follow lock unlocks on a
+ * scroll up, but deliberately ignores any scroll event that arrives with a
+ * changed `scrollHeight`, reading it as a resize artefact rather than the
+ * reader moving — so a jump landing mid-fill leaves the lock on, and the lock
+ * pulls the transcript back to the bottom. Re-aiming on each height change
+ * holds the destination until the fill stops, and the last of those scrolls
+ * lands with a stable height, which is the one the lock finally reads.
+ *
+ * Only height changes re-aim: correcting every frame would flatten the smooth
+ * scroll into a jump, and reacting to nothing at all is the bug.
+ */
+export function holdJumpDestination(
+  root: Element,
+  readTargetId: () => string | null,
+  scheduler: PromptRailFrameScheduler = browserFrameScheduler,
+): () => void {
+  let handle = 0;
+  let lastHeight = root.scrollHeight;
+  const hold = (): void => {
+    handle = scheduler.request(hold);
+    if (root.scrollHeight === lastHeight) return;
+    lastHeight = root.scrollHeight;
+    const turnId = readTargetId();
+    if (turnId === null) return;
+    const target = root.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);
+    // `auto`: this is a correction, not a second journey.
+    if (target) (target as HTMLElement).scrollIntoView({ behavior: 'auto', block: 'start' });
+  };
+  handle = scheduler.request(hold);
+  return () => scheduler.cancel(handle);
 }
 
 export function observeActivePromptRailVisibility(
@@ -65,6 +128,11 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
   const [safeArea, setSafeArea] = useState<{ scrollport: number; dock: number } | null>(null);
   const railRef = useRef<HTMLElement | null>(null);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
+  const [jumping, setJumping] = useState(false);
+  // The turn a click aimed at, held until that click's scroll settles. A ref,
+  // not state: the observer effect reads it on every scroll frame and must not
+  // be torn down and rebuilt over the whole transcript when it changes.
+  const jumpTargetRef = useRef<string | null>(null);
 
   useEffect(() => {
     const root = scrollRef.current;
@@ -79,6 +147,11 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
 
     const visible = new Set<string>();
     const resolveActive = (): void => {
+      // A jump owns the highlight until its scroll settles. Without this the
+      // observer walks the highlight through every prompt the scroll passes,
+      // which is the travelling the click was meant to skip — suppressing the
+      // glide alone would only turn one long slide into a burst of hops.
+      if (jumpTargetRef.current !== null) return;
       if (root.scrollHeight - root.scrollTop - root.clientHeight <= SCROLL_END_EPSILON_PX) {
         setActiveTurnId(turns[turns.length - 1]!.turnId);
         return;
@@ -158,13 +231,48 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
     return observeActivePromptRailVisibility(rail);
   }, [activeTurnId, turns]);
 
+  // The highlight glides between prompts because the reader is following it as
+  // the transcript scrolls under it. A click is the opposite: the reader picked
+  // the destination, so the highlight switches there once and holds, and the
+  // scroll the click started moves underneath it without moving it. `jumping`
+  // (the CSS side) kills the glide for that one switch; `jumpTargetRef` (read
+  // by the observer above) is what keeps the scroll from walking the highlight
+  // through every prompt it passes on the way.
+  useEffect(() => {
+    if (!jumping) return;
+    const root = scrollRef.current;
+    const settle = (): void => {
+      jumpTargetRef.current = null;
+      setJumping(false);
+    };
+    // `scrollend` alone would end the jump the moment the transcript grows
+    // under it (see the frame loop below), so the jump holds for its full
+    // window and the timer is what ends it.
+    const timer = window.setTimeout(settle, JUMP_SETTLE_TIMEOUT_MS);
+    if (!root) return () => window.clearTimeout(timer);
+
+    // The other half of the same click: a jump into an unmounted part of the
+    // transcript has to survive the fill that follows it. See
+    // `holdJumpDestination`.
+    const releaseHold = holdJumpDestination(root, () => jumpTargetRef.current);
+
+    return () => {
+      window.clearTimeout(timer);
+      releaseHold();
+    };
+  }, [jumping, scrollRef]);
+
   function jumpTo(turnId: string): void {
     const el = scrollRef.current?.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);
+    // Claimed before the scroll starts: a same-frame `scroll` event would
+    // otherwise reach the observer while the highlight is still unowned.
+    jumpTargetRef.current = turnId;
     if (el && 'scrollIntoView' in el) {
       (el as HTMLElement).scrollIntoView({ behavior: scrollBehavior, block: 'start' });
     } else if (!el) {
       onNavigateFallback?.(turnId);
     }
+    setJumping(true);
     setActiveTurnId(turnId);
   }
 
@@ -186,6 +294,7 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
       <nav
         className="maka-prompt-rail"
         aria-label={copy.promptRailAriaLabel}
+        data-jumping={jumping ? 'true' : undefined}
         ref={railRef}
         onPointerLeave={() => setHoveredIndex(null)}
       >
@@ -201,6 +310,7 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
             <HoverCard
               key={turn.turnId}
               placement="start"
+              delay={PREVIEW_DELAY_MS}
               content={
                 <span className="maka-prompt-rail-preview">
                   <span className="maka-prompt-rail-preview-prompt">{preview}</span>

--- a/packages/ui/src/prompt-anchor-rail.tsx
+++ b/packages/ui/src/prompt-anchor-rail.tsx
@@ -16,17 +16,141 @@ const HOVER_FALLOFF_TICKS = 3;
  * as restraint.
  */
 const PREVIEW_DELAY_MS = 120;
+
+/** Quiet frames after the transcript is filled that end a jump's hold. */
+const JUMP_SETTLE_QUIET_FRAMES = 3;
 /**
- * How long a click-driven jump suppresses the highlight's glide when no
- * `scrollend` arrives — a smooth scroll of the whole transcript takes a few
- * hundred milliseconds, and overshooting only means the next scroll-driven
- * move is placed rather than animated.
+ * Frames a hold may run before it gives up regardless. Only a backstop against
+ * a transcript that never reports itself filled — the fill boundary is what
+ * normally ends the hold, and this is ~4s at 60Hz.
  */
-const JUMP_SETTLE_TIMEOUT_MS = 700;
+const JUMP_HOLD_FRAME_BUDGET = 240;
+/** How close to the scrollport's top edge counts as landed. */
+const JUMP_LANDED_TOLERANCE_PX = 4;
+/** Input that means the reader has taken the transcript back. */
+const READER_SCROLL_EVENTS = ['wheel', 'touchstart', 'pointerdown', 'keydown'] as const;
 
 interface PromptRailResizeObserver {
   observe(target: Element): void;
   disconnect(): void;
+}
+
+/** Frame scheduler seam, so the jump hold can be driven by a test. */
+export interface PromptRailFrameScheduler {
+  request(callback: () => void): number;
+  cancel(handle: number): void;
+}
+
+const browserFrameScheduler: PromptRailFrameScheduler = {
+  request: (callback) => requestAnimationFrame(callback),
+  cancel: (handle) => cancelAnimationFrame(handle),
+};
+
+/**
+ * Hold a jump's destination while the transcript grows under it.
+ *
+ * Two different things move the transcript out from under a jump, and
+ * releasing auto-follow (`onNavigateStart`) only answers the first:
+ *
+ *  - Astryx's auto-follow spring, which keeps pulling toward the bottom
+ *    because it never sees the jump as a reader-initiated scroll up.
+ *  - The progressive mount's own scroll compensation, which holds the reader's
+ *    position across each fill step. Mounting the turn a jump asked for is
+ *    itself a fill step, so the compensation lands after the scroll and
+ *    restores the position the jump just left.
+ *
+ * Re-aiming outlasts both: through each fill step, and once more if a still
+ * frame finds the target off the top edge, which is what a scroll cancelled
+ * part-way leaves behind. A frame where nothing moved and the target is where
+ * the click asked costs one `getBoundingClientRect` and nothing else.
+ *
+ * `releaseAutoFollow` runs on every frame of the hold rather than once at the
+ * click, because Astryx re-locks on any `scrollend` that settles near the
+ * bottom — and a jump out of a session that opens at the bottom produces
+ * exactly that while the mount is still catching up, so a single release is
+ * undone before the jump has gone anywhere. Traced: released at the click,
+ * re-aimed to the target at 154ms, dragged back to the bottom by 166ms.
+ *
+ * The hold ends on the progressive mount's own boundary — the transcript
+ * reporting itself filled, then holding still for a few frames — rather than
+ * on a clock, so a long transcript is not released mid-fill. It also ends the
+ * moment the reader touches the transcript: a jump may outlive its own scroll,
+ * but it must never outlive the reader's interest in it.
+ */
+export function holdJumpDestination(input: {
+  root: Element;
+  readTargetId: () => string | null;
+  /** Progressive mount has every turn in the DOM (ChatView's `turnsFilled`). */
+  isTranscriptFilled: () => boolean;
+  /** Astryx's auto-follow release, re-asserted for the life of the hold. */
+  releaseAutoFollow?: (() => void) | undefined;
+  onSettled: () => void;
+  scheduler?: PromptRailFrameScheduler;
+}): () => void {
+  const { root, readTargetId, isTranscriptFilled, releaseAutoFollow, onSettled } = input;
+  const scheduler = input.scheduler ?? browserFrameScheduler;
+  let handle = 0;
+  let done = false;
+  let lastHeight = root.scrollHeight;
+  let lastTop = root.scrollTop;
+  let quietFrames = 0;
+  let framesRun = 0;
+
+  const stop = (): void => {
+    if (done) return;
+    done = true;
+    scheduler.cancel(handle);
+    for (const type of READER_SCROLL_EVENTS) root.removeEventListener(type, stop);
+    onSettled();
+  };
+
+  const reaim = (): boolean => {
+    const turnId = readTargetId();
+    if (turnId === null) return false;
+    const target = root.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);
+    if (!target) return false;
+    const offset = target.getBoundingClientRect().top - root.getBoundingClientRect().top;
+    if (Math.abs(offset) <= JUMP_LANDED_TOLERANCE_PX) return false;
+    const before = root.scrollTop;
+    // `auto`: this is a correction, not a second journey.
+    (target as HTMLElement).scrollIntoView({ behavior: 'auto', block: 'start' });
+    lastTop = root.scrollTop;
+    // A correction that moves nothing means the target is as close to the top
+    // as this scroller can put it — the last turn of a transcript cannot reach
+    // it at all. Report it as landed, or the hold would keep trying until its
+    // frame budget ran out.
+    return root.scrollTop !== before;
+  };
+
+  const hold = (): void => {
+    if (done) return;
+    handle = scheduler.request(hold);
+    framesRun += 1;
+    releaseAutoFollow?.();
+    const grew = root.scrollHeight !== lastHeight;
+    const moved = root.scrollTop !== lastTop;
+    lastHeight = root.scrollHeight;
+    lastTop = root.scrollTop;
+    // Growth is the mount working through the transcript; re-aim through it.
+    // A still frame that is nonetheless off-target is the other failure: a
+    // scroll that was cancelled part-way and will never resume on its own,
+    // which is what happens when the mount's compensation lands on top of one.
+    const corrected = grew || (!moved && isTranscriptFilled()) ? reaim() : false;
+    // Quiet means nothing moved at all — not the content, not the position.
+    // Height alone was not enough: with the transcript already mounted there
+    // is nothing to re-aim through, and the hold released three frames in,
+    // handing the highlight and the auto-follow release back while the jump's
+    // own scroll was still in flight.
+    if (!grew && !moved && !corrected && isTranscriptFilled()) quietFrames += 1;
+    else quietFrames = 0;
+    if (quietFrames >= JUMP_SETTLE_QUIET_FRAMES || framesRun >= JUMP_HOLD_FRAME_BUDGET) stop();
+  };
+
+  for (const type of READER_SCROLL_EVENTS) {
+    root.addEventListener(type, stop, { passive: true });
+  }
+  handle = scheduler.request(hold);
+  return stop;
 }
 
 type PromptRailResizeObserverFactory = (
@@ -45,54 +169,6 @@ export function keepActivePromptRailTickVisible(rail: HTMLElement): void {
   if (tickBox.top < railBox.top) rail.scrollTop -= railBox.top - tickBox.top;
   else if (tickBox.bottom > railBox.bottom)
     rail.scrollTop += tickBox.bottom - railBox.bottom;
-}
-
-/** Frame scheduler seam, so the jump hold can be driven by a test. */
-export interface PromptRailFrameScheduler {
-  request(callback: () => void): number;
-  cancel(handle: number): void;
-}
-
-const browserFrameScheduler: PromptRailFrameScheduler = {
-  request: (callback) => requestAnimationFrame(callback),
-  cancel: (handle) => cancelAnimationFrame(handle),
-};
-
-/**
- * Hold a jump's destination while the transcript grows under it.
- *
- * A jump into a part of the transcript the progressive mount has not reached
- * has to mount it first, and the fill that follows changes the scroller's
- * height for several frames afterwards. Astryx's auto-follow lock unlocks on a
- * scroll up, but deliberately ignores any scroll event that arrives with a
- * changed `scrollHeight`, reading it as a resize artefact rather than the
- * reader moving — so a jump landing mid-fill leaves the lock on, and the lock
- * pulls the transcript back to the bottom. Re-aiming on each height change
- * holds the destination until the fill stops, and the last of those scrolls
- * lands with a stable height, which is the one the lock finally reads.
- *
- * Only height changes re-aim: correcting every frame would flatten the smooth
- * scroll into a jump, and reacting to nothing at all is the bug.
- */
-export function holdJumpDestination(
-  root: Element,
-  readTargetId: () => string | null,
-  scheduler: PromptRailFrameScheduler = browserFrameScheduler,
-): () => void {
-  let handle = 0;
-  let lastHeight = root.scrollHeight;
-  const hold = (): void => {
-    handle = scheduler.request(hold);
-    if (root.scrollHeight === lastHeight) return;
-    lastHeight = root.scrollHeight;
-    const turnId = readTargetId();
-    if (turnId === null) return;
-    const target = root.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);
-    // `auto`: this is a correction, not a second journey.
-    if (target) (target as HTMLElement).scrollIntoView({ behavior: 'auto', block: 'start' });
-  };
-  handle = scheduler.request(hold);
-  return () => scheduler.cancel(handle);
 }
 
 export function observeActivePromptRailVisibility(
@@ -114,25 +190,53 @@ export interface PromptAnchorRailTurn {
 export interface PromptAnchorRailProps {
   turns: readonly PromptAnchorRailTurn[];
   scrollRef: RefObject<HTMLElement | null>;
-  scrollBehavior: ScrollBehavior;
   /** When progressive mount has not yet placed the turn in the DOM. */
   onNavigateFallback?: (turnId: string) => void;
   /** Bumped when turn DOM membership changes without `turns` changing. */
   mountedTurnsRevision?: number;
+  /**
+   * Release Astryx's auto-follow before a jump scrolls.
+   *
+   * ChatLayout keeps the transcript pinned to the bottom while a turn streams
+   * and unlocks when the reader scrolls up, which it detects by comparing
+   * scrollTop between scroll events — but it discards any scroll event that
+   * arrives with a changed scrollHeight, since Chrome fires those on content
+   * resize and they are not the reader moving. A jump into a turn the
+   * progressive mount has not reached has to mount it first, so its own scroll
+   * always arrives with a changed height and is discarded: auto-follow stays on
+   * and pulls the transcript back to the bottom.
+   */
+  onNavigateStart?: (() => void) | undefined;
+  /**
+   * Progressive mount has placed every turn in the DOM (ChatView's
+   * `turnsFilled`). A jump holds its destination until this goes true and the
+   * transcript stops moving; see `holdJumpDestination`.
+   */
+  transcriptFilled?: boolean;
 }
 
 /** Right-edge rail: one tick per user prompt, scrolls to `[data-turn-id]`. */
-export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRef, scrollBehavior, onNavigateFallback, mountedTurnsRevision }: PromptAnchorRailProps): React.ReactElement | null {
+export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRef, onNavigateFallback, mountedTurnsRevision, onNavigateStart, transcriptFilled }: PromptAnchorRailProps): React.ReactElement | null {
   const copy = getConversationCopy(useUiLocale()).sessions;
   const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
   const [safeArea, setSafeArea] = useState<{ scrollport: number; dock: number } | null>(null);
   const railRef = useRef<HTMLElement | null>(null);
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
-  const [jumping, setJumping] = useState(false);
+  // Identified by a sequence number rather than a boolean so a second click
+  // during a jump starts its own claim instead of inheriting what is left of
+  // the first one's — which would leave the earlier jump's lifetime governing
+  // the later jump's target.
+  const [jump, setJump] = useState<{ sequence: number; turnId: string } | null>(null);
+  const jumpSequenceRef = useRef(0);
   // The turn a click aimed at, held until that click's scroll settles. A ref,
   // not state: the observer effect reads it on every scroll frame and must not
   // be torn down and rebuilt over the whole transcript when it changes.
   const jumpTargetRef = useRef<string | null>(null);
+  // Read by the hold, which outlives the render that started it.
+  const transcriptFilledRef = useRef(transcriptFilled ?? true);
+  transcriptFilledRef.current = transcriptFilled ?? true;
+  const onNavigateStartRef = useRef(onNavigateStart);
+  onNavigateStartRef.current = onNavigateStart;
 
   useEffect(() => {
     const root = scrollRef.current;
@@ -234,45 +338,60 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
   // The highlight glides between prompts because the reader is following it as
   // the transcript scrolls under it. A click is the opposite: the reader picked
   // the destination, so the highlight switches there once and holds, and the
-  // scroll the click started moves underneath it without moving it. `jumping`
-  // (the CSS side) kills the glide for that one switch; `jumpTargetRef` (read
-  // by the observer above) is what keeps the scroll from walking the highlight
-  // through every prompt it passes on the way.
+  // scroll the click started moves underneath it without moving it. The `jump`
+  // state (the CSS side) kills the glide for that one switch; `jumpTargetRef`
+  // (read by the observer above) is what keeps the scroll from walking the
+  // highlight through every prompt it passes on the way. Keyed on the jump's
+  // sequence, so a second click starts its own claim rather than inheriting
+  // the remains of the first one's.
+  //
+  // The claim ends where the progressive mount does, not on a clock: the hold
+  // below re-aims through the fill and reports back when the transcript is
+  // filled and still, or when the reader takes it back.
   useEffect(() => {
-    if (!jumping) return;
+    if (!jump) return;
     const root = scrollRef.current;
-    const settle = (): void => {
-      jumpTargetRef.current = null;
-      setJumping(false);
-    };
-    // `scrollend` alone would end the jump the moment the transcript grows
-    // under it (see the frame loop below), so the jump holds for its full
-    // window and the timer is what ends it.
-    const timer = window.setTimeout(settle, JUMP_SETTLE_TIMEOUT_MS);
-    if (!root) return () => window.clearTimeout(timer);
-
-    // The other half of the same click: a jump into an unmounted part of the
-    // transcript has to survive the fill that follows it. See
-    // `holdJumpDestination`.
-    const releaseHold = holdJumpDestination(root, () => jumpTargetRef.current);
-
-    return () => {
-      window.clearTimeout(timer);
-      releaseHold();
-    };
-  }, [jumping, scrollRef]);
+    if (!root) return;
+    return holdJumpDestination({
+      root,
+      readTargetId: () => jumpTargetRef.current,
+      isTranscriptFilled: () => transcriptFilledRef.current,
+      releaseAutoFollow: onNavigateStartRef.current,
+      onSettled: () => {
+        // Only the latest jump releases the highlight: a later click has
+        // already claimed it, and its own hold owns it now. Decided against
+        // the ref rather than inside the state updater, which React may run
+        // twice.
+        if (jumpSequenceRef.current !== jump.sequence) return;
+        jumpTargetRef.current = null;
+        setJump((current) => (current?.sequence === jump.sequence ? null : current));
+      },
+    });
+  }, [jump, scrollRef]);
 
   function jumpTo(turnId: string): void {
-    const el = scrollRef.current?.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);
+    const root = scrollRef.current;
+    const el = root?.querySelector(`[data-turn-id="${CSS.escape(turnId)}"]`);
+    // Before the scroll, not after: auto-follow has to be released while the
+    // transcript is still where the reader left it, or the release lands after
+    // it has already pulled the view back to the bottom.
+    onNavigateStart?.();
     // Claimed before the scroll starts: a same-frame `scroll` event would
     // otherwise reach the observer while the highlight is still unowned.
     jumpTargetRef.current = turnId;
     if (el && 'scrollIntoView' in el) {
-      (el as HTMLElement).scrollIntoView({ behavior: scrollBehavior, block: 'start' });
+      // Instant, whatever the app's scroll-motion policy says. A jump is a
+      // teleport the reader asked for, not a journey — and an animated one
+      // does not survive this surface: traced against a 30-prompt session, the
+      // smooth scroll was cancelled by the mount's own scroll compensation and
+      // by auto-follow's spring, and stalled two pixels from where it started.
+      // Landing reliably beats animating unreliably.
+      (el as HTMLElement).scrollIntoView({ behavior: 'auto', block: 'start' });
     } else if (!el) {
       onNavigateFallback?.(turnId);
     }
-    setJumping(true);
+    jumpSequenceRef.current += 1;
+    setJump({ sequence: jumpSequenceRef.current, turnId });
     setActiveTurnId(turnId);
   }
 
@@ -294,7 +413,7 @@ export const PromptAnchorRail = memo(function PromptAnchorRail({ turns, scrollRe
       <nav
         className="maka-prompt-rail"
         aria-label={copy.promptRailAriaLabel}
-        data-jumping={jumping ? 'true' : undefined}
+        data-jumping={jump ? 'true' : undefined}
         ref={railRef}
         onPointerLeave={() => setHoveredIndex(null)}
       >

--- a/patches/@astryxdesign+core+0.3.0.patch
+++ b/patches/@astryxdesign+core+0.3.0.patch
@@ -1,3 +1,21 @@
+diff --git a/node_modules/@astryxdesign/core/dist/Chat/ChatContext.d.ts b/node_modules/@astryxdesign/core/dist/Chat/ChatContext.d.ts
+index d1bfeeb..b4a0e62 100644
+--- a/node_modules/@astryxdesign/core/dist/Chat/ChatContext.d.ts
++++ b/node_modules/@astryxdesign/core/dist/Chat/ChatContext.d.ts
+@@ -61,6 +61,13 @@ export interface ChatLayoutContextValue {
+     scrollContainerRef: React.RefObject<HTMLElement | null>;
+     /** Callback ref for the message list content element — layout observes it for size changes. */
+     contentRef: (el: HTMLElement | null) => void;
++    /**
++     * Release auto-follow because the host is navigating the transcript
++     * itself. The scroll-direction unlock cannot see such a move when the
++     * host mounts content before scrolling: that scroll event carries a
++     * changed scrollHeight and is read as a resize artefact.
++     */
++    unlockAutoFollow?: () => void;
+ }
+ export declare const ChatLayoutContext: import("react").Context<ChatLayoutContextValue | null>;
+ export declare function useChatLayoutContext(): ChatLayoutContextValue | null;
 diff --git a/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.d.ts b/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.d.ts
 index ff34874..9ec8d7a 100644
 --- a/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.d.ts
@@ -15,7 +33,7 @@ index ff34874..9ec8d7a 100644
  export declare function ChatLayout({ children, composer, density, emptyState, scrollButton, scrollRef: externalScrollRef, xstyle, className, style, 'data-testid': testId, ref, ...rest }: ChatLayoutProps): import("react").JSX.Element;
  export declare namespace ChatLayout {
 diff --git a/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.js b/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.js
-index ea27cd5..790ae68 100644
+index ea27cd5..7102f8d 100644
 --- a/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.js
 +++ b/node_modules/@astryxdesign/core/dist/Chat/ChatLayout.js
 @@ -28,7 +28,7 @@
@@ -56,6 +74,23 @@ index ea27cd5..790ae68 100644
    const defaultScrollButton = /*#__PURE__*/_jsx(ChatLayoutScrollButton, {
      isVisible: scroll.isScrolledUp || newMsgs.hasNewMessages,
      label: newMsgs.hasNewMessages ? t('@astryx.chatLayout.newMessages') : undefined,
+@@ -223,8 +238,14 @@ export function ChatLayout({
+   // --- Layout context ---
+   const layoutContext = useMemo(() => ({
+     scrollContainerRef,
+-    contentRef: newMsgs.contentRef
+-  }), [scrollContainerRef, newMsgs.contentRef]);
++    contentRef: newMsgs.contentRef,
++    // maka: programmatic navigation seam. A host that scrolls the transcript
++    // itself (jumping to an earlier turn) has no way to tell auto-follow that
++    // the move was intentional: the scroll-up unlock is skipped whenever the
++    // event arrives with a changed scrollHeight, which is exactly what a host
++    // that mounts content before scrolling produces.
++    unlockAutoFollow: scroll.unlock
++  }), [scrollContainerRef, newMsgs.contentRef, scroll.unlock]);
+ 
+   // --- Derived styles ---
+   const showEmpty = !hasVisibleContent(children);
 diff --git a/node_modules/@astryxdesign/core/dist/Chat/ChatToolCalls.js b/node_modules/@astryxdesign/core/dist/Chat/ChatToolCalls.js
 index 791909e..5c6199e 100644
 --- a/node_modules/@astryxdesign/core/dist/Chat/ChatToolCalls.js
@@ -177,7 +212,7 @@ index 867ed5a..4b8f835 100644
    sources,
    citationStyle = 'label',
 @@ -1065,7 +1066,9 @@ export function Markdown({
-
+ 
    // Smooth bursty streamed chunks into a steady character-by-character reveal.
    // When not streaming, the hook returns children unchanged (no-op).
 -  const smoothedText = useStreamingText(children, isStreaming);
@@ -227,7 +262,7 @@ index 867ed5a..4b8f835 100644
 @@ -1146,9 +1157,6 @@ export function Markdown({
        children: inlineNodes.map((node, i) => renderInline(node, i, onLinkClick, cursor, citationCtx, LinkComponent, inlinePlugins, components))
      });
-
+ 
 -    // Store current inline nodes for next render's boundary calculation.
 -    prevInlineNodesRef.current = inlineNodes;
 -    prevBlocksRef.current = [];
@@ -237,7 +272,7 @@ index 867ed5a..4b8f835 100644
 @@ -1161,11 +1169,6 @@ export function Markdown({
      children: blocks.map((block, i) => renderBlock(block, i, blocks.length, density, headingLevelStart, onLinkClick, cursor, citationCtx, contentWidth ? typeof contentWidth === 'number' ? `${contentWidth}px` : contentWidth : null, contentAlign, LinkComponent, inlinePlugins, components, t))
    });
-
+ 
 -  // Store current blocks for next render's boundary calculation.
 -  // This ref write is safe under StrictMode: both invocations produce the same
 -  // blocks (same smoothedText → same useMemo result), so both write the same value.
@@ -277,7 +312,7 @@ index ae17b68..5a70b1d 100644
  /**
   * Smooths bursty streamed text into a steady character-by-character reveal.
 diff --git a/node_modules/@astryxdesign/core/dist/hooks/useStreamingText.js b/node_modules/@astryxdesign/core/dist/hooks/useStreamingText.js
-index d5e9ac9..ab0b20b 100644
+index d5e9ac9..77f131b 100644
 --- a/node_modules/@astryxdesign/core/dist/hooks/useStreamingText.js
 +++ b/node_modules/@astryxdesign/core/dist/hooks/useStreamingText.js
 @@ -21,7 +21,7 @@
@@ -288,7 +323,7 @@ index d5e9ac9..ab0b20b 100644
 +import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
  import { useMediaQuery } from "./useMediaQuery.js";
  import { useTheme } from "../theme/useTheme.js";
-
+ 
 @@ -103,56 +103,74 @@ export function useStreamingText(targetText, isStreaming, options) {
      const tick = speed === 'fast' ? base / 20 : base / 10;
      return Math.max(4, Math.round(tick));
@@ -370,7 +405,7 @@ index d5e9ac9..ab0b20b 100644
 +  useLayoutEffect(() => {
 +    presentationRef.current = presentation;
 +  }, [presentation]);
-
+ 
    // Animation loop
    useEffect(() => {
 -    if (!isStreaming || speed === 'instant' || prefersReducedMotion) {
@@ -411,6 +446,7 @@ index d5e9ac9..ab0b20b 100644
 -  return targetText.slice(0, displayedLen);
 +  return targetText.slice(0, renderedPresentation.displayedLen);
  }
+\ No newline at end of file
 diff --git a/node_modules/@astryxdesign/core/src/Chat/ChatToolCalls.tsx b/node_modules/@astryxdesign/core/src/Chat/ChatToolCalls.tsx
 index 234a2e4..e3f1842 100644
 --- a/node_modules/@astryxdesign/core/src/Chat/ChatToolCalls.tsx
@@ -430,7 +466,7 @@ index a6f850b..b6e0f2a 100644
 @@ -9,7 +9,7 @@
   * @position Core implementation; renders markdown as Astryx components
   */
-
+ 
 -import {useMemo, useRef} from 'react';
 +import {useMemo, useRef, useState} from 'react';
  import type React from 'react';
@@ -454,20 +490,20 @@ index a6f850b..b6e0f2a 100644
    sources,
    citationStyle = 'label',
 @@ -1620,7 +1623,9 @@ export function Markdown({
-
+ 
    // Smooth bursty streamed chunks into a steady character-by-character reveal.
    // When not streaming, the hook returns children unchanged (no-op).
 -  const smoothedText = useStreamingText(children, isStreaming);
 +  const smoothedText = useStreamingText(children, isStreaming, {
 +    settledText,
 +  });
-
+ 
    const incrementalStateRef = useRef<IncrementalState>(
      createIncrementalState(),
 @@ -1674,20 +1679,43 @@ export function Markdown({
      return Math.min(Math.ceil(duration / tickMs), 12);
    }, [token]);
-
+ 
 -  const prevBlocksRef = useRef<BlockNode[]>([]);
 -  const prevInlineNodesRef = useRef<InlineNode[]>([]);
 -  const boundariesRef = useRef<number[]>([]);
@@ -519,24 +555,24 @@ index a6f850b..b6e0f2a 100644
 +      boundaries,
 +    });
 +  }
-
+ 
    const cursor: StreamingCursor = {
      offset: 0,
 @@ -1727,10 +1755,6 @@ export function Markdown({
        </span>
      );
-
+ 
 -    // Store current inline nodes for next render's boundary calculation.
 -    prevInlineNodesRef.current = inlineNodes;
 -    prevBlocksRef.current = [];
 -
      return renderedInline;
    }
-
+ 
 @@ -1770,12 +1794,6 @@ export function Markdown({
      </div>
    );
-
+ 
 -  // Store current blocks for next render's boundary calculation.
 -  // This ref write is safe under StrictMode: both invocations produce the same
 -  // blocks (same smoothedText → same useMemo result), so both write the same value.
@@ -545,7 +581,7 @@ index a6f850b..b6e0f2a 100644
 -
    return rendered;
  }
-
+ 
 diff --git a/node_modules/@astryxdesign/core/src/hooks/useStreamingText.ts b/node_modules/@astryxdesign/core/src/hooks/useStreamingText.ts
 index 02c069f..acdc18a 100644
 --- a/node_modules/@astryxdesign/core/src/hooks/useStreamingText.ts
@@ -553,12 +589,12 @@ index 02c069f..acdc18a 100644
 @@ -22,7 +22,7 @@
   * - /packages/core/src/hooks/useStreamingText.test.ts (tests)
   */
-
+ 
 -import {useEffect, useMemo, useRef, useState} from 'react';
 +import {useEffect, useLayoutEffect, useMemo, useRef, useState} from 'react';
  import {useMediaQuery} from './useMediaQuery';
  import {useTheme} from '../theme/useTheme';
-
+ 
 @@ -40,6 +40,60 @@ export interface UseStreamingTextOptions {
     * @default 'natural'
     */
@@ -618,12 +654,12 @@ index 02c069f..acdc18a 100644
 +      : targetText.length,
 +  };
  }
-
+ 
  // Fallback values when no Theme provider is present
 @@ -117,35 +171,6 @@ export function useStreamingText(
      return Math.max(4, Math.round(tick));
    }, [token, speed]);
-
+ 
 -  const [displayedLen, setDisplayedLen] = useState(0);
 -  const targetRef = useRef(targetText);
 -  const displayedLenRef = useRef(0);
@@ -690,14 +726,14 @@ index 02c069f..acdc18a 100644
 +  useLayoutEffect(() => {
 +    presentationRef.current = presentation;
 +  }, [presentation]);
-
+ 
    // Animation loop
    useEffect(() => {
 -    if (!isStreaming || speed === 'instant' || prefersReducedMotion) {
 +    if (!progressive) {
        return;
      }
-
+ 
 @@ -164,14 +219,19 @@ export function useStreamingText(
        const elapsed = now - lastTickRef.current;
        if (elapsed >= tickMs) {
@@ -725,19 +761,19 @@ index 02c069f..acdc18a 100644
 +          setPresentation(next);
          }
        }
-
+ 
 @@ -185,11 +245,11 @@ export function useStreamingText(
          rafRef.current = null;
        }
      };
 -  }, [isStreaming, charsPerTick, tickMs, speed, prefersReducedMotion]);
 +  }, [progressive, charsPerTick, tickMs]);
-
+ 
 -  if (!isStreaming || speed === 'instant' || prefersReducedMotion) {
 +  if (!progressive) {
      return targetText;
    }
-
+ 
 -  return targetText.slice(0, displayedLen);
 +  return targetText.slice(0, renderedPresentation.displayedLen);
  }

--- a/patches/README.md
+++ b/patches/README.md
@@ -18,10 +18,19 @@ Delete when that guard passes against an unpatched package.
 
 ## `@astryxdesign/core@0.3.0`
 
-Three published component seams drop host-owned state or semantics:
+Four published component seams drop host-owned state or semantics:
 
 - `ChatLayout` needs a conversation identity that resets scroll/unread state
   without remounting its composer slot and discarding the live draft.
+- `ChatLayout` owns auto-follow and publishes no way to say "this scroll is
+  deliberate navigation, release it". Its scroll-direction unlock cannot infer
+  that: it discards any scroll event carrying a changed `scrollHeight` as a
+  resize artefact, and a host that mounts a turn before scrolling to it
+  produces exactly that. Without the seam the prompt rail's jump into an
+  unmounted turn is dragged straight back to the bottom (#2923), and no call
+  site can fix it — re-aiming frame by frame wins the mount and then loses to
+  the follow spring that outlives it. `unlockAutoFollow` on
+  `ChatLayoutContextValue` publishes the hook's existing `unlock`.
 - `ChatToolCalls` needs a stable row slot for product styling and E2E geometry.
 - `List` must forward its published `aria-label` to the rendered list element.
 

--- a/scripts/fixture-env.mjs
+++ b/scripts/fixture-env.mjs
@@ -40,6 +40,7 @@ function isDeniedEnvKey(key) {
  *   locale?: 'zh' | 'en',
  *   platform?: 'darwin' | 'win32' | 'linux',
  *   theme?: 'light' | 'dark',
+ *   scrollMotion?: 'auto' | 'smooth',
  *   timezone?: string,
  *   showWindow?: boolean,
  * }} [options]
@@ -84,6 +85,12 @@ export function buildFixtureEnv(userDataDir, homeDir, options = {}) {
   // explicitly. The decision stays with the caller: this builder is a pure
   // function of its arguments, so a test asserting "hidden run stays hidden"
   // means the same thing on a laptop and on a CI runner.
+  // Captures collapse scroll motion so their state never depends on when a
+  // scroll settles. A fixture whose subject IS the scrolling asks for the
+  // production behavior back — see `scroll-motion-policy`. Per launch rather
+  // than per scenario: it costs several seconds of settling per window, and
+  // only the case that needs it should pay.
+  if (options.scrollMotion) env.MAKA_E2E_FIXTURE_SCROLL_MOTION = options.scrollMotion;
   if (options.showWindow) env.MAKA_E2E_SHOW_WINDOW = '1';
   return env;
 }


### PR DESCRIPTION
## Summary

The prompt anchor rail (#563) has been invisible since 0.1.9. #2580 moved its tick onto Astryx's `Button`, which wraps children in its own label span — the bar the tick draws went from being a direct child of the flex tick (blockified, 14–23×3) to an inline box in normal flow, and an inline box takes no width or height. Every bar computed to 0×0. The rail, its ticks and its click targets were all still there, painting nothing.

Measured on the new fixture at 1280×800: the rail's box is 8px wide — its own padding, with the ticks contributing nothing — and 22px again with `display: block` on the bar.

Using it once it was back turned up four more things, all fixed here:

| | Before | After |
|---|---|---|
| Hover falloff | Dropped out in the 4px gap between ticks | Hit boxes tile; the pitch is unchanged |
| Preview card | 300ms of nothing before it opened (Astryx's default) | 120ms |
| Jump highlight | Glided 280ms across the rail, then hopped along with the scroll | Switches once, instantly, and holds |
| First click of a session | Did nothing until the reader scrolled by hand | Lands and holds |

## The first-click bug is a collision, not a defect on either side

Worth reading even if the rest is uncontroversial, because it will bite anything else that navigates a transcript programmatically.

`useChatStreamScroll` keeps the transcript pinned to the bottom while a turn streams, and unlocks when the reader scrolls up — detected by comparing `scrollTop` across scroll events, which covers wheel, touch, scrollbar drag and keyboard alike. To avoid misreading Chrome's synthetic scroll events (fired when content resizes), it ignores any scroll event that arrives with a changed `scrollHeight` or `offsetHeight`:

```js
if (scrollHeightChanged || offsetHeightChanged) {
  // Synthetic scroll from resize — don't change lock state
  lastScrollTopRef.current = scrollTop;
  return;
}
```

Both halves are reasonable. But a rail jump into a turn the progressive mount (#2191) hasn't reached has to mount it first, and the fill that follows changes `scrollHeight` for several frames. The jump's own scroll therefore arrives with a changed height every time and is discarded: the lock stays on, `scrollIfLocked` pulls the transcript back to the bottom, and the click reads as dead. A wheel gesture broke it because `onWheel` takes a separate path — which is exactly why scrolling by hand "fixed" it.

`holdJumpDestination` re-aims at the target on each height change until the fill stops. The last of those scrolls lands with a stable height, and that is the one the lock finally reads as a scroll up. Measured on the 30-prompt fixture: clicking the first tick landed at `scrollTop` 7042 (the bottom) before, and 24 after.

This is the cheapest place to absorb it, not the right one. The real fix is an entry point on Astryx's side for "this is programmatic navigation, release the lock" — happy to take that upstream if you agree with the framing.

## Coverage

The e2e suite for this rail was deleted in #2462 as low-value, and the multi-prompt fixtures it ran on in #2656. Since then the rail has failed twice more, both times by rendering and not painting, and once all the way into a release. So this adds back the smallest thing that closes the gap — five tests where the deleted suite had nine:

- `chat-prompt-rail`, a plain 30-prompt conversation. The shipped fixture has one prompt and the rail hides itself below three, so nothing could show it at all. 30 rather than 8 because the progressive mount's initial window is 10 — below that the head of the transcript is already mounted and the jump-into-unmounted-turns path never runs.
- `prompt-rail.spec.ts`: bars have a real box (#2580), the rail stays inside the scrollport at both scroll extremes (#2161 — the bottom is where sticky clamping bites), the pointer is always on a tick as it travels down the rail, the first click lands and holds, and a tick is what the pointer lands on rather than the scrollbar (#2338).
- A unit test for `holdJumpDestination` driving its own frames.

Two honest limits:

- **The first-click e2e case is a path check, not a guard.** Whether the lock wins depends on which frame the fill lands on relative to a smooth scroll still in flight; it goes green against the unfixed renderer often enough to be useless as a guard. The unit test is what holds that behaviour. Both are commented as such.
- **The motion cannot be tested here at all.** Fixture renders carry `data-maka-e2e-fixture`, and `base.css` gives that `animation: none` plus a 0.01ms transition cap, so a fixture's state never depends on when it settles. These tests assert end states only.

`prompt-rail.spec.ts` is also load-bearing on macOS specifically: the overlay scrollbar takes no layout space but still intercepts the pointer, so the #2338 class of regression goes green on Linux CI. Worth running on a Mac before merging anything that touches the rail's right edge.

## Validation

- `npm run format:check`, `npm --workspace @maka/desktop run typecheck` (all four tsconfigs), `node scripts/check-astryx-alignment.mjs`
- Unit: core 538, ui 126, desktop 767 — all passing
- E2E: full suite green except a `slash-command-menu` flake that passes on re-run and is unrelated to this change; `prompt-rail.spec.ts` 5/5
- Verified the tick-bar test fails on the unfixed renderer with `Expected: > 0, Received: 0`, and the gapless-travel test with `Expected: 0, Received: 28`
- Ran the built app against a real profile to check the hover, the preview timing, the jump and the first click by hand
