### PR TITLE
docs: connect project metadata to public website

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![docs](https://img.shields.io/badge/docs-%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-blue?logo=googletranslate&logoColor=white)](./README.zh-CN.md)
 
+[Website](https://maka-agent.com/) · [Download](https://maka-agent.com/download/) · [Documentation](https://maka-agent.com/docs/) · [Architecture](https://maka-agent.com/architecture/) · [Latest release](https://github.com/maka-agent/maka-agent/releases/latest)
+
 ![Maka — Your work. Your agent.](./.github/assets/maka-hero.en.png)
 
 **A local-first Agent workspace built for real work.**
@@ -55,16 +57,18 @@ Read [Maka Backend Architecture](./ARCHITECTURE.md) for the complete design.
 
 ## Quick start
 
-### Download Desktop for macOS
+### Download Desktop
 
-The signed and notarized Desktop app is available from [GitHub Releases](https://github.com/Maka-Agent/maka-agent/releases/latest) for Apple Silicon Macs only (`arm64`).
+The signed and notarized Apple Silicon macOS build and an unsigned Windows x64 preview are available from the [Maka download page](https://maka-agent.com/download/) and [GitHub Releases](https://github.com/Maka-Agent/maka-agent/releases/latest).
+
+On macOS:
 
 1. Download `Maka-<version>-mac-arm64.dmg`;
 2. Open the DMG and drag Maka to Applications;
 3. Install `ripgrep` with `brew install ripgrep` to enable Runtime's `Grep` tool;
 4. Launch Maka and configure your own model connection under `Settings → Models`.
 
-Computer Use is not included in this first public build. Intel Macs, Windows, and Linux packages are not supported yet.
+The Windows x64 installer is currently unsigned and may trigger SmartScreen. Verify it against the attached `.sha256` file before opening it. Intel Macs and Linux do not have published installers. Computer Use is not included in the current release.
 
 ### Requirements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,6 +4,8 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![docs](https://img.shields.io/badge/docs-English-blue?logo=googletranslate&logoColor=white)](./README.md)
 
+[官网](https://maka-agent.com/zh/) · [下载](https://maka-agent.com/download/) · [文档](https://maka-agent.com/docs/) · [架构](https://maka-agent.com/architecture/) · [最新版本](https://github.com/maka-agent/maka-agent/releases/latest)
+
 ![Maka——你的工作，你的 Agent。](./.github/assets/maka-hero.zh-CN.png)
 
 **一个为真实工作而生的本地优先 Agent 工作台。**
@@ -55,16 +57,18 @@ Maka 不只回答问题。它可以在受控权限下阅读项目、执行工具
 
 ## 快速开始
 
-### 下载 macOS 桌面版
+### 下载桌面版
 
-已签名并完成 Apple 公证的桌面应用可从 [GitHub Releases](https://github.com/Maka-Agent/maka-agent/releases/latest) 下载，目前仅支持 Apple Silicon Mac（`arm64`）。
+已签名并完成 Apple 公证的 Apple Silicon macOS 版本，以及未签名的 Windows x64 预览版，可以从 [Maka 下载页](https://maka-agent.com/download/) 或 [GitHub Releases](https://github.com/Maka-Agent/maka-agent/releases/latest) 获取。
+
+在 macOS 上：
 
 1. 下载 `Maka-<version>-mac-arm64.dmg`；
 2. 打开 DMG，将 Maka 拖入“应用程序”；
 3. 执行 `brew install ripgrep`，启用 Runtime 的 `Grep` 工具；
 4. 启动 Maka，在`设置 → 模型`中配置自己的模型连接。
 
-首个公开版本不包含 Computer Use，暂不支持 Intel Mac、Windows 和 Linux 安装包。
+Windows x64 安装包目前未签名，首次启动可能触发 SmartScreen。打开前请使用 Release 中附带的 `.sha256` 文件校验。Intel Mac 和 Linux 暂无发布安装包。当前版本不包含 Computer Use。
 
 ### 环境要求
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,8 @@
 
 This page is the authority map for Maka documentation. Code and contract tests remain the final authority when documentation disagrees with the implementation.
 
+Public entry points: [website](https://maka-agent.com/) · [download](https://maka-agent.com/download/) · [documentation index](https://maka-agent.com/docs/) · [architecture overview](https://maka-agent.com/architecture/) · [security overview](https://maka-agent.com/security/)
+
 ## Where information belongs
 
 - Root and package READMEs describe stable product entry points, public seams, and local ownership.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,24 @@
 {
   "name": "maka",
   "version": "0.1.10",
+  "description": "Maka — local-first AI desktop assistant",
+  "homepage": "https://maka-agent.com/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/maka-agent/maka-agent.git"
+  },
+  "bugs": {
+    "url": "https://github.com/maka-agent/maka-agent/issues"
+  },
+  "keywords": [
+    "ai-agent",
+    "desktop-app",
+    "local-first",
+    "agent-runtime",
+    "electron",
+    "cli",
+    "tui"
+  ],
   "license": "Apache-2.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Status

Draft. This PR depends on the unfinished website page work in https://github.com/maka-agent/maka-agent.github.io/pull/1. The website PR now includes the complete page inventory, planned public URLs, desktop/mobile screenshots, and an explicit design/content revision checklist.

Do not merge this PR before the website pages are redesigned, reviewed, merged, and deployed; otherwise the new README links will point to 404 routes.

## Summary

- add first-screen links to the official website, download, documentation, architecture, and latest release
- update English and Chinese download guidance to reflect the current signed Apple Silicon macOS build and unsigned Windows x64 preview
- add repository-facing package metadata: description, homepage, repository, issue tracker, and discovery keywords
- link the documentation authority map to the public project pages

## Verification

- `git diff --check`
- parsed `package.json` and `package-lock.json` successfully
- all 12 GitHub checks passed

## Maintainer follow-up

The current account can push code but cannot update repository settings. After the website and this PR are ready, please set:

- GitHub Homepage: `https://maka-agent.com/`
- Topics: `ai-agent`, `desktop-app`, `local-first`, `agent-runtime`, `electron`, `typescript`, `cli`, `tui`, `open-source`

GitHub returned a permission-masked 404 when those settings were attempted through the API; they were not changed.