### PR TITLE
docs(windows): document preview installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ The signed and notarized Desktop app is available from [GitHub Releases](https:/
 
 Computer Use is not included in this first public build. Intel Macs, Windows, and Linux packages are not supported yet.
 
+### Windows x64 preview
+
+Windows is still an unsigned preview, not a supported release tier. When a release includes Windows
+assets, follow the [Windows preview installation and verification guide](docs/windows-support.md#install-the-windows-x64-preview)
+before running `Maka-<version>-win-x64.exe`. SmartScreen will identify the installer as coming from
+an unknown publisher; do not bypass that warning unless the downloaded SHA-256 matches the checksum
+published with the same release.
+
 ### Requirements
 
 - Node.js 22.19 or newer (CI uses Node.js 24);

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,6 +66,13 @@ Maka 不只回答问题。它可以在受控权限下阅读项目、执行工具
 
 首个公开版本不包含 Computer Use，暂不支持 Intel Mac、Windows 和 Linux 安装包。
 
+### Windows x64 预览版
+
+Windows 目前仍是未签名预览版，不属于正式支持的平台。当某个 release 包含 Windows 资产时，
+请先阅读 [Windows 预览版安装与校验指南](docs/windows-support.md#安装-windows-x64-预览版)，再运行
+`Maka-<version>-win-x64.exe`。SmartScreen 会将安装包显示为未知发布者；只有从同一 release 下载
+并确认 SHA-256 与发布的校验文件一致后，才应选择绕过该提示。
+
 ### 环境要求
 
 - Node.js 22（当前 CI 基线）；

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -1,6 +1,61 @@
 # Windows support baseline
 
-Windows is an active enablement target, not a released or fully supported Maka platform yet. The CLI and Electron desktop application can run from source, but release, recovery, sandbox, and computer-use guarantees are incomplete. Progress is tracked in [GitHub issue #2142](https://github.com/maka-agent/maka-agent/issues/2142).
+Windows is an active enablement target, not a fully supported Maka platform yet. The CLI and Electron desktop application can run from source, and release workflows produce a verified unsigned Windows x64 preview. Signing, automatic updates, sandbox enforcement, and computer-use guarantees remain incomplete. Progress is tracked in [GitHub issue #2142](https://github.com/maka-agent/maka-agent/issues/2142).
+
+## Install the Windows x64 preview
+
+Only use Windows assets attached to a Maka GitHub Release. The NSIS installer is named
+`Maka-<version>-win-x64.exe`; the ZIP is a portable artifact for inspection and troubleshooting.
+
+1. Download the `.exe` and its matching `.sha256` file from the same release.
+2. In PowerShell, compute the installer digest:
+
+   ```powershell
+   Get-FileHash .\Maka-<version>-win-x64.exe -Algorithm SHA256
+   Get-Content .\Maka-<version>-win-x64.exe.sha256
+   ```
+
+3. Require the two SHA-256 values to match exactly. A checksum only establishes the bytes published
+   with that release; it is not a substitute for publisher authentication.
+4. Run the installer. Because the preview has no Authenticode signature, SmartScreen reports an
+   unknown publisher. Continue through **More info → Run anyway** only after completing step 3.
+5. Launch Maka, configure a model under **Settings → Models**, and install `ripgrep` with
+   `winget install BurntSushi.ripgrep.MSVC` if Runtime's `Grep` tool is needed. Restart Maka after
+   changing `PATH`.
+
+The release gate installs a pinned v0.1.9 build, fully smokes it, upgrades the same installation to
+the candidate, fully smokes the candidate, waits for installed processes to exit, and runs the real
+uninstaller. This proves a closed-app upgrade and uninstall path. It does not prove automatic update,
+running-app upgrade, persisted business-data migration, or rollback after a mid-install failure.
+
+To uninstall, use **Settings → Apps → Installed apps → Maka → Uninstall**. Back up any important
+workspace data first; the preview does not yet claim installer rollback or migration guarantees.
+
+## 安装 Windows x64 预览版
+
+只使用 Maka GitHub Release 附带的 Windows 资产。NSIS 安装包名为
+`Maka-<version>-win-x64.exe`；ZIP 主要用于便携检查和问题排查。
+
+1. 从同一个 release 下载 `.exe` 和对应的 `.sha256` 文件。
+2. 在 PowerShell 中分别查看实际摘要和发布的摘要：
+
+   ```powershell
+   Get-FileHash .\Maka-<version>-win-x64.exe -Algorithm SHA256
+   Get-Content .\Maka-<version>-win-x64.exe.sha256
+   ```
+
+3. 两个 SHA-256 必须完全一致。校验和只能确认文件与该 release 发布的字节一致，不能替代发布者身份认证。
+4. 运行安装包。预览版尚无 Authenticode 签名，SmartScreen 会提示未知发布者；只有完成第 3 步后，
+   才应选择 **更多信息 → 仍要运行**。
+5. 启动 Maka，在 **设置 → 模型**中配置模型。需要 Runtime `Grep` 工具时，执行
+   `winget install BurntSushi.ripgrep.MSVC`，并在 `PATH` 更新后重启 Maka。
+
+发布门禁会安装固定的 v0.1.9、执行完整 smoke、在同一目录升级候选版本、再次完整 smoke、等待安装目录内
+进程退出，并运行真实卸载器。这证明关闭应用后的升级与卸载路径，不证明自动更新、运行中升级、业务数据迁移，
+也不证明安装中途失败后的 rollback。
+
+卸载入口为 **设置 → 应用 → 已安装的应用 → Maka → 卸载**。预览版尚未承诺安装器 rollback 或数据迁移，
+请先备份重要 workspace 数据。
 
 ## Phase 0 development target
 
@@ -14,7 +69,7 @@ The initial target is a native Windows 11 x64 development environment with:
 - WebView/runtime components installed by a current Windows 11 installation;
 - Windows Developer Mode or elevation only for tests that create file symlinks. Normal CLI and desktop startup must not require either.
 
-Windows 10, Windows on Arm, packaged installation, automatic updates, sandbox enforcement, and computer-use are not covered by the Phase 0 baseline.
+Windows 10, Windows on Arm, automatic updates, sandbox enforcement, and computer-use are not covered by the current support target. Packaged installation is available only as the unsigned Windows 11 x64 preview described above.
 
 ## Reproducible checks
 
@@ -92,6 +147,6 @@ The root test timeout is tracked separately from individual test failures. Phase
 - PTY execution uses ConPTY through `node-pty`; process-tree termination uses `taskkill /T` where required.
 - Restricted sandbox profiles fail closed because there is no Windows sandbox backend.
 - Computer-use has no Windows backend.
-- There is no signed Windows installer or supported update channel.
+- The Windows x64 NSIS installer is unsigned and there is no supported automatic-update channel.
 
 Do not describe Windows as released or fully supported until the support criteria in issue #2142 are complete for the claimed support tier.


### PR DESCRIPTION
## English

Document the unsigned Windows x64 preview without advertising Windows as a supported release tier.

- add SHA-256 verification and SmartScreen guidance;
- document model/ripgrep setup and uninstall entry point;
- state the evidence already provided by the pinned v0.1.9 -> candidate release gate;
- explicitly exclude automatic updates, running-app upgrades, persisted business-data migration, mid-install rollback, signing, sandboxing, and Computer Use.

Validation: `npm run format:check`, `git diff --check`.

Tracks the Phase 3 publication/documentation item in #2142.

## 中文

补充未签名 Windows x64 预览版文档，同时不把 Windows 提前宣传为正式支持的平台。

- 增加 SHA-256 校验和 SmartScreen 操作说明；
- 说明模型、ripgrep 配置和卸载入口；
- 写明固定 v0.1.9 -> 候选版本发布门禁已经提供的证据；
- 明确排除自动更新、运行中升级、业务数据迁移、安装中途 rollback、签名、沙箱和 Computer Use。

验证：`npm run format:check`、`git diff --check`。

关联 #2142 Phase 3 发布/安装文档任务。