### PR TITLE
feat: enable DeepSeek V4 Pro Responses tools

### DIFF
--- a/docs/web-search-provider-capability.md
+++ b/docs/web-search-provider-capability.md
@@ -142,7 +142,7 @@ request. The selected connection wire is authoritative:
 - an Anthropic Messages session receives `anthropic.web_search_20250305`.
 
 For a provider that supports both, an explicit connection/model `apiProtocol`
-wins. An ambiguous standard DeepSeek V4 Flash connection defaults to Responses;
+wins. An ambiguous standard DeepSeek V4 connection defaults to Responses;
 using the CC wire requires an explicit Anthropic-compatible connection. Maka
 does not retry a failed native search over the other protocol.
 
@@ -164,7 +164,7 @@ search-heavy workflows that value source visibility over cache economics.
 
 | Provider or access path | Official hosted search surface | Model boundary | Maka state |
 | --- | --- | --- | --- |
-| DeepSeek | Responses `web_search`, server-executed | `deepseek-v4-flash`; DeepSeek documents V4 Pro as not yet supported by Responses | Integrated through `openai-responses` |
+| DeepSeek | Responses `web_search`, server-executed | `deepseek-v4-flash` and `deepseek-v4-pro` | Integrated through `openai-responses` |
 | OpenAI API | Responses `web_search` tool | Maka currently enables the native path for GPT-5 families, whose runtime wire is already Responses | Integrated through `openai-responses` |
 | Custom Responses relay | Responses `web_search` tool when explicitly declared by model metadata | `openai-responses-compatible` connections with `apiProtocol=openai-responses` and `capabilities.webSearch=true` | Integrated through `openai-responses` |
 | xAI API / OAuth | Responses Agent Tools `web_search` | Maka currently enables the verified Grok 4.5 Responses route | Integrated through `openai-responses` |

--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -71,8 +71,9 @@ describe('openAiAdapterApiProtocol', () => {
     assert.equal(openAiAdapterApiProtocol('grok-4.5', 'openai'), 'openai-chat');
   });
 
-  it('routes only DeepSeek V4 Flash through the provider Responses wire', () => {
+  it('routes official DeepSeek V4 models through the provider Responses wire', () => {
     assert.equal(openAiAdapterApiProtocol('deepseek-v4-flash', 'deepseek'), 'openai-responses');
-    assert.equal(openAiAdapterApiProtocol('deepseek-v4-pro', 'deepseek'), 'openai-chat');
+    assert.equal(openAiAdapterApiProtocol('deepseek-v4-pro', 'deepseek'), 'openai-responses');
+    assert.equal(openAiAdapterApiProtocol('deepseek-chat', 'deepseek'), 'openai-chat');
   });
 });

--- a/packages/core/src/__tests__/model-web-search.test.ts
+++ b/packages/core/src/__tests__/model-web-search.test.ts
@@ -1,10 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { lookupModelMetadata } from '../model-metadata.js';
 import { resolveHostedWebSearchCapability } from '../model-web-search.js';
 
 describe('hosted web search capability', () => {
   it('enables the implemented Responses path only for declared model families', () => {
     assert.deepEqual(resolveHostedWebSearchCapability('deepseek', undefined, 'deepseek-v4-flash'), {
+      adapter: 'openai-responses',
+      implemented: true,
+    });
+    assert.deepEqual(resolveHostedWebSearchCapability('deepseek', undefined, 'deepseek-v4-pro'), {
       adapter: 'openai-responses',
       implemented: true,
     });
@@ -127,5 +132,14 @@ describe('hosted web search capability', () => {
       ),
       null,
     );
+  });
+
+  it('publishes native search for both first-party DeepSeek V4 models', () => {
+    assert.equal(
+      lookupModelMetadata('deepseek', 'deepseek-v4-flash').capabilities?.webSearch,
+      true,
+    );
+    assert.equal(lookupModelMetadata('deepseek', 'deepseek-v4-pro').capabilities?.webSearch, true);
+    assert.equal(lookupModelMetadata('deepseek', 'deepseek-v4-pro').lastUpdated, '2026-08-13');
   });
 });

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -102,11 +102,17 @@ export function openAiAdapterApiProtocol(
   providerType?: ProviderType,
 ): 'openai-responses' | 'openai-chat' {
   const id = modelId.trim();
-  return (providerType === 'deepseek' && id === 'deepseek-v4-flash') ||
+  return (providerType === 'deepseek' && deepSeekModelSupportsResponses(id)) ||
     /^gpt-5/i.test(id) ||
     ((providerType === 'xai' || providerType === 'xai-oauth') && id === 'grok-4.5')
     ? 'openai-responses'
     : 'openai-chat';
+}
+
+/** DeepSeek models whose first-party API contract includes the Responses wire. */
+export function deepSeekModelSupportsResponses(modelId: string): boolean {
+  const id = modelId.trim().toLowerCase();
+  return id === 'deepseek-v4-flash' || id === 'deepseek-v4-pro';
 }
 
 /** Vision-capable Claude families, including models newer than the generated snapshot. */
@@ -380,6 +386,11 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
     'deepseek-v4-flash': {
       capabilities: { ...REASONING_FUNCTION_CALLING, webSearch: true },
       thinkingOptions: { efforts: ['high', 'max'], toggle: true },
+    },
+    'deepseek-v4-pro': {
+      capabilities: { ...REASONING_FUNCTION_CALLING, webSearch: true },
+      lastUpdated: '2026-08-13',
+      thinkingOptions: { efforts: ['low', 'high', 'max'], toggle: true },
     },
   },
   'zai-coding-plan': {

--- a/packages/core/src/model-web-search.ts
+++ b/packages/core/src/model-web-search.ts
@@ -1,4 +1,5 @@
 import type { ModelInfo, ProviderType } from './llm-connections.js';
+import { deepSeekModelSupportsResponses } from './model-metadata.js';
 
 export type HostedWebSearchAdapter =
   | 'openai-responses'
@@ -95,7 +96,7 @@ function providerDefaultHostedWebSearchCapability(
 ): HostedWebSearchCapability | null {
   switch (providerType) {
     case 'deepseek':
-      return modelId === 'deepseek-v4-flash' ? capability : null;
+      return deepSeekModelSupportsResponses(modelId) ? capability : null;
     case 'openai':
       return /^gpt-5(?:[.-]|$)/i.test(modelId) ? capability : null;
     case 'xai':

--- a/packages/runtime/src/__tests__/apply-patch-profile.test.ts
+++ b/packages/runtime/src/__tests__/apply-patch-profile.test.ts
@@ -18,13 +18,17 @@ describe('ApplyPatch profile routing', () => {
       ).applyPatchProfile,
       { kind: 'codex-v4a-freeform' },
     );
+    assert.deepEqual(
+      resolveModelRuntime({ providerType: 'deepseek' }, 'deepseek-v4-pro').applyPatchProfile,
+      { kind: 'codex-v4a-freeform' },
+    );
     assert.equal(
       resolveModelRuntime({ providerType: 'xai' }, 'deepseek-v4-flash').applyPatchProfile,
       null,
     );
   });
 
-  test('selects Codex V4A freeform only for declared V4 Flash Responses', () => {
+  test('selects Codex V4A freeform for declared DeepSeek V4 Responses models', () => {
     assert.deepEqual(
       resolveApplyPatchProfile(
         { wire: 'openai-responses', applyPatchProtocol: 'codex-v4a-freeform' },
@@ -39,12 +43,12 @@ describe('ApplyPatch profile routing', () => {
       ),
       null,
     );
-    assert.equal(
+    assert.deepEqual(
       resolveApplyPatchProfile(
         { wire: 'openai-responses', applyPatchProtocol: 'codex-v4a-freeform' },
         'deepseek-v4-pro',
       ),
-      null,
+      { kind: 'codex-v4a-freeform' },
     );
     assert.equal(resolveApplyPatchProfile({ wire: 'openai-responses' }, 'deepseek-v4-flash'), null);
   });

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -481,12 +481,13 @@ describe('buildProviderOptions: openai-compatible namespace', () => {
     );
   });
   test('deepseek uses its own raw namespace on the chat wire, the OpenAI one on Responses', () => {
-    assert.deepEqual(
-      buildProviderOptions(conn('deepseek', 'deepseek'), 'deepseek-v4-pro', 'high'),
-      {
-        deepseek: { reasoningEffort: 'high' },
-      },
-    );
+    const chatConnection: LlmConnection = {
+      ...conn('deepseek', 'deepseek'),
+      models: [{ id: 'deepseek-v4-pro', apiProtocol: 'openai-chat' }],
+    };
+    assert.deepEqual(buildProviderOptions(chatConnection, 'deepseek-v4-pro', 'high'), {
+      deepseek: { reasoningEffort: 'high' },
+    });
     assert.deepEqual(
       buildProviderOptions(conn('deepseek', 'deepseek'), 'deepseek-v4-flash', 'high'),
       { openai: { store: false, forceReasoning: true, reasoningEffort: 'high' } },

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -930,7 +930,7 @@ describe('models.dev provider conformance', () => {
     assert.equal(body?.store, false);
   });
 
-  test('DeepSeek connection probes use the same account-declared Responses wire as execution', async () => {
+  test('DeepSeek V4 Pro connection probes use its default Responses wire', async () => {
     let body: Record<string, unknown> | undefined;
     const server = await startJsonServer(async (request, response) => {
       assert.equal(request.method, 'POST');
@@ -944,7 +944,6 @@ describe('models.dev provider conformance', () => {
       providerType: 'deepseek',
       baseUrl: `${server.url}/v1`,
       defaultModel: 'deepseek-v4-pro',
-      models: [{ id: 'deepseek-v4-pro', apiProtocol: 'openai-responses' }],
       enabled: true,
       createdAt: 1,
       updatedAt: 1,

--- a/packages/runtime/src/apply-patch-profile.ts
+++ b/packages/runtime/src/apply-patch-profile.ts
@@ -1,4 +1,5 @@
 import type { ApplyPatchProtocol } from '@maka/core/llm-connections';
+import { deepSeekModelSupportsResponses } from '@maka/core/model-metadata';
 import { z } from 'zod';
 import { parseCodexV4aPatch, serializeCodexV4aOperation } from './codex-v4a-patch.js';
 import type { ApplyPatchOperation } from './filesystem-executor.js';
@@ -25,7 +26,7 @@ export function resolveApplyPatchProfile(
   if (runtime.applyPatchProtocol === 'openai-structured' && openAiModelSupportsApplyPatch(id)) {
     return { kind: 'openai-structured' };
   }
-  if (runtime.applyPatchProtocol === 'codex-v4a-freeform' && id === 'deepseek-v4-flash') {
+  if (runtime.applyPatchProtocol === 'codex-v4a-freeform' && deepSeekModelSupportsResponses(id)) {
     return { kind: 'codex-v4a-freeform' };
   }
   return null;


### PR DESCRIPTION
## Summary

DeepSeek now documents `deepseek-v4-pro` as supporting its Responses API, hosted web search, and the Codex-compatible `apply_patch` custom tool. Maka still defaulted that model to Chat Completions and kept those tools restricted to V4 Flash.

This change makes the first-party V4 Responses model boundary explicit and reuses it for protocol selection, hosted search, and ApplyPatch routing. It enables V4 Pro without adding a second transport or model-specific tool implementation, while legacy DeepSeek model IDs and explicit per-connection protocol overrides retain their existing behavior.

The static metadata overlay records the official 2026-08-13 update and V4 Pro's current reasoning effort/search capabilities. Generated models.dev files remain untouched because its snapshot still reports the older 2026-04-24 date; the existing generated pricing already matches DeepSeek's current published prices.

Official contract references:

- https://api-docs.deepseek.com/quick_start/pricing/
- https://api-docs.deepseek.com/guides/responses_api/

## Verification

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/runtime run build`
- `node --test packages/core/dist/__tests__/model-metadata.test.js packages/core/dist/__tests__/model-web-search.test.js packages/core/dist/__tests__/provider-contract-matrix.test.js`
- `node --test packages/runtime/dist/__tests__/model-factory-thinking.test.js packages/runtime/dist/__tests__/apply-patch-profile.test.js packages/runtime/dist/__tests__/provider-conformance.test.js`
- `npm run format:check`
- `git diff --check`

Live provider smoke on 2026-08-13 used the repository's local DeepSeek credential through Maka's current `getAIModel` and runtime routing. `deepseek-v4-pro` selected `openai-responses`; streamed reasoning was observed; a function-tool round trip returned `5`; provider-native web search returned `Maka-Agent/maka-agent`; and the model emitted a valid Codex V4A freeform `apply_patch` call for an add-file request. The credential was read directly from the ignored local secret file and was not written to command arguments or logs.

## AI assistance

Codex identified the existing provider capability seams, implemented the change with test-first iterations, and ran the checks listed above. The contributor of record must independently review the final diff, confirm the cited DeepSeek contract, run or verify the live provider smoke, and own the merge decision.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No