### PR TITLE
chore(deps): group official Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,7 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      official-actions:
+        patterns:
+          - 'actions/*'


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Group official GitHub Actions matching `actions/*` into one Dependabot pull request.
- Keep third-party Actions separate for independent review.
- Reduce recurring dependency pull request noise without changing the update schedule or pull request limit.

## Verification

- `.github/dependabot.yml` parsed successfully.
- `git diff --check` passed.
- Application tests were not run because this change only updates Dependabot configuration.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

- 将匹配 `actions/*` 的 GitHub 官方 Actions 更新合并到一个 Dependabot 拉取请求中。
- 第三方 Actions 继续使用独立拉取请求，以便单独审查。
- 减少重复的依赖更新拉取请求，不改变更新周期或拉取请求数量上限。

## 验证

- `.github/dependabot.yml` 解析成功。
- `git diff --check` 通过。
- 此变更仅修改 Dependabot 配置，因此未运行应用测试。

</details>
