### PR TITLE
test(desktop): fence staged steering before side chat

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -117,9 +117,11 @@ test('dispatches a staged slash command instead of steering it into a running tu
   await expect(page.getByRole('button', { name: '停止' })).toBeVisible();
 
   await composer.fill('/compact explain');
-  await expect(page.getByRole('button', { name: '插入消息' })).toBeVisible();
+  const steerSubmit = page.getByRole('button', { name: '插入消息' });
+  await expect(steerSubmit).toBeVisible();
   await composer.press('Enter');
   await expect(page.getByText(/Acknowledged steering: \/compact explain/)).toBeVisible();
+  await expect(steerSubmit).not.toHaveAttribute('aria-busy', 'true');
 
   await composer.fill('/');
   const menu = page.getByRole('listbox', { name: '命令和技能' });

--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -119,6 +119,7 @@ test('dispatches a staged slash command instead of steering it into a running tu
   await composer.fill('/compact explain');
   await expect(page.getByRole('button', { name: '插入消息' })).toBeVisible();
   await composer.press('Enter');
+  await expect(page.getByText(/Acknowledged steering: \/compact explain/)).toBeVisible();
 
   await composer.fill('/');
   const menu = page.getByRole('listbox', { name: '命令和技能' });
@@ -133,6 +134,5 @@ test('dispatches a staged slash command instead of steering it into a running tu
   await composer.press('Enter');
 
   await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(1);
-  await expect(page.getByText(/Acknowledged steering: \/compact explain/)).toBeVisible();
   await page.getByRole('button', { name: '停止' }).click();
 });


### PR DESCRIPTION
## Summary

Move the existing steering acknowledgement assertion before the `/side` flow so it acts as an observable completion fence for `sendCurrent()`. This prevents the test from submitting an overlapping command under CI load without increasing timeouts.

Fixes #2916

## Verification

- `npm --workspace @maka/desktop run e2e -- e2e/slash-command-menu.spec.ts --grep "dispatches a staged slash command" --repeat-each=5` (5 passed)
- `npm run build`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`

OpenAI Codex assisted with implementation and verification; I reviewed the change and am the human contributor of record.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes - described under Summary above
- [x] No
