### PR TITLE
fix(ui): separate sidebar row actions from navigation buttons

### DIFF
--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -189,7 +189,8 @@
   -webkit-app-region: no-drag;
 }
 
-.maka-session-row {
+.maka-session-row,
+.maka-project-row {
   position: relative;
   min-width: 0;
   -webkit-app-region: no-drag;
@@ -259,7 +260,8 @@
 
 /* Fixed trailing column so StatusDot ↔ MoreMenu swaps do not reflow the label
  * (hover used to steal ~28px and shove the title left). */
-.maka-session-row-trailing {
+.maka-session-row-trailing,
+.maka-project-row-trailing {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -268,10 +270,11 @@
   min-height: var(--h-control-sm, 24px);
 }
 
-/* SideNavItem owns the row button and only supports non-interactive
- * endContent. The action menu occupies the reserved trailing slot visually,
- * but remains its sibling in the DOM so neither control contains the other. */
-.maka-session-row-action {
+/* SideNavItem owns each row button and only supports non-interactive
+ * endContent. Action menus occupy reserved trailing slots visually, but stay
+ * sibling controls in the DOM so neither button contains another button. */
+.maka-session-row-action,
+.maka-project-row-action {
   position: absolute;
   inset-block-start: calc(
     (var(--size-element-md) - var(--size-element-sm)) / 2
@@ -282,6 +285,18 @@
   align-items: center;
   justify-content: center;
   width: var(--h-control-sm, 24px);
+}
+
+/* A project disclosure chevron follows endContent inside SideNavItem. Keep the
+ * overlaid menu in its reserved slot immediately before that chevron. */
+.maka-project-row[data-has-sessions="true"] > div > .maka-project-row-action {
+  inset-inline-end: calc(var(--space-2) + var(--space-6) + var(--space-2));
+}
+
+/* Collapsed SideNavItem intentionally omits endContent. Preserve that contract
+ * for the sibling action while the project row becomes an icon-only trigger. */
+.appFrame[data-sidebar-state="collapsed"] .maka-project-row-action {
+  display: none;
 }
 
 .maka-session-row-trailing-spacer {

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
+import type { ProjectRecord } from '@maka/core/project';
 import type { SessionSummary } from '@maka/core/session';
 import { LocaleProvider } from '../locale-context.js';
-import { SessionHistoryList, type SessionRowActions } from '../session-history-list.js';
+import {
+  SessionHistoryList,
+  type ProjectRowActions,
+  type SessionRowActions,
+} from '../session-history-list.js';
 
 const session: SessionSummary = {
   id: 'session-1',
@@ -28,6 +33,20 @@ const rowActions: SessionRowActions = {
   onDelete: () => undefined,
 };
 
+const project: ProjectRecord = {
+  id: 'project-1',
+  name: 'Maka',
+  locations: [],
+  available: true,
+};
+
+const projectActions: ProjectRowActions = {
+  onNew: () => undefined,
+  onRename: () => undefined,
+  onArchive: () => undefined,
+  onRestore: () => undefined,
+};
+
 test('renders session navigation and row actions as sibling controls', () => {
   const markup = renderToStaticMarkup(
     <LocaleProvider locale="en">
@@ -42,4 +61,30 @@ test('renders session navigation and row actions as sibling controls', () => {
   assert.equal((markup.match(/<button\b/g) ?? []).length, 2);
   assert.match(markup, /class="maka-session-row-action"/);
   assert.doesNotMatch(markup, /<button\b(?:(?!<\/button>)[\s\S])*<button\b/);
+});
+
+test('renders project navigation and row actions as sibling controls', () => {
+  const markup = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <SessionHistoryList
+        sessions={[session]}
+        groups={[{ id: project.id, label: project.name, sessions: [session], project }]}
+        groupVariant="project"
+        onSelectSession={() => undefined}
+        projectActions={projectActions}
+      />
+    </LocaleProvider>,
+  );
+
+  assert.equal((markup.match(/<button\b/g) ?? []).length, 3);
+  assert.match(markup, /data-has-sessions="true"/);
+  assert.match(markup, /class="maka-project-row-action"/);
+  assert.doesNotMatch(markup, /<button\b(?:(?!<\/button>)[\s\S])*<button\b/);
+  const projectRowStart = markup.indexOf('data-project-id="project-1"');
+  const projectAction = markup.indexOf('class="maka-project-row-action"', projectRowStart);
+  const projectSessions = markup.indexOf('role="group"', projectRowStart);
+  assert.ok(
+    projectRowStart >= 0 && projectAction > projectRowStart && projectAction < projectSessions,
+    'project actions should precede nested sessions in the DOM and keyboard order',
+  );
 });

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -6,7 +6,6 @@ import {
   useState,
   type KeyboardEvent,
   type ReactNode,
-  type Ref,
 } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
 import type { ProjectRecord } from '@maka/core/project';
@@ -370,18 +369,30 @@ function ProjectNavRow(props: {
   // still truthy children for Astryx (!!children) and fabricates a disclosure.
   const hasSessions = props.sessions.length > 0;
   return (
-    <div data-project-id={props.groupKey} className="maka-project-row">
+    <div
+      data-project-id={props.groupKey}
+      data-has-sessions={hasSessions ? 'true' : undefined}
+      className="maka-project-row"
+    >
       <SideNavItem
         label={props.label}
         icon={FolderOpen}
         collapsible={hasSessions ? { defaultIsCollapsed: false } : undefined}
         endContent={
-          <ProjectItemEndContent
+          <ProjectItemMeta
             project={props.project}
             sessionCount={props.sessions.length}
-            actions={props.projectActions}
-            onStartRename={props.onStartRename}
+            reserveAction={props.project !== undefined && props.projectActions !== undefined}
           />
+        }
+        siblingAction={
+          props.project && props.projectActions ? (
+            <ProjectItemActions
+              project={props.project}
+              actions={props.projectActions}
+              onStartRename={props.onStartRename}
+            />
+          ) : undefined
         }
       >
         {/* Nest indent zeroed one level in sidebar.css (time-sort left edge). */}
@@ -390,25 +401,6 @@ function ProjectNavRow(props: {
         ) : undefined}
       </SideNavItem>
     </div>
-  );
-}
-
-/** Keeps trailing controls from activating the parent SideNavItem button. */
-function EndContentHitTarget(props: {
-  children: ReactNode;
-  className?: string;
-  ref?: Ref<HTMLSpanElement>;
-}) {
-  return (
-    <span
-      ref={props.ref}
-      className={props.className}
-      onClick={(event) => event.stopPropagation()}
-      onPointerDown={(event) => event.stopPropagation()}
-      onKeyDown={(event) => event.stopPropagation()}
-    >
-      {props.children}
-    </span>
   );
 }
 
@@ -475,14 +467,30 @@ const SessionNavRow = memo(function SessionNavRow(props: {
   );
 });
 
-function ProjectItemEndContent(props: {
+function ProjectItemMeta(props: {
   project?: ProjectRecord;
   sessionCount: number;
-  actions?: ProjectRowActions;
+  reserveAction: boolean;
+}) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
+  return (
+    <span className="maka-session-row-end maka-project-item-end">
+      {props.project && !props.project.available && (
+        <AlertTriangle size={ICON_SIZE.meta} aria-label={copy.projectUnavailable} />
+      )}
+      <Badge variant="neutral" label={props.sessionCount} />
+      {props.reserveAction && <span className="maka-project-row-trailing" aria-hidden="true" />}
+    </span>
+  );
+}
+
+function ProjectItemActions(props: {
+  project: ProjectRecord;
+  actions: ProjectRowActions;
   onStartRename(opener: HTMLElement | null): void;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
-  const endRef = useRef<HTMLSpanElement>(null);
+  const trailingRef = useRef<HTMLSpanElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const mountedRef = useMountedRef();
@@ -514,77 +522,73 @@ function ProjectItemEndContent(props: {
     })();
   }
 
-  // Projects keep a permanent MoreMenu (SideNavEndContent pattern). Hover-only
-  // would fire on nested session rows if wired to the project wrapper.
-  const menuItems = project && actions
-    ? project.archivedAt !== undefined
-      ? [
-          {
-            label: copy.projectRestore,
-            icon: ArchiveRestore,
-            onClick: () => runProjectAction('restore', () => actions.onRestore(project.id)),
-          },
-        ]
-      : [
-          ...(project.available
+  // Projects keep a permanent MoreMenu. Hover-only would fire on nested
+  // session rows if wired to the project wrapper.
+  const menuItems = project.archivedAt !== undefined
+    ? [
+        {
+          label: copy.projectRestore,
+          icon: ArchiveRestore,
+          onClick: () => runProjectAction('restore', () => actions.onRestore(project.id)),
+        },
+      ]
+    : [
+        ...(project.available
+          ? [
+              {
+                label: copy.projectNewTask,
+                icon: SquarePen,
+                onClick: () => runProjectAction('new', () => actions.onNew(project.id)),
+              },
+            ]
+          : actions.onRelink
             ? [
-                {
-                  label: copy.projectNewTask,
-                  icon: SquarePen,
-                  onClick: () => runProjectAction('new', () => actions.onNew(project.id)),
-                },
-              ]
-            : actions.onRelink
-              ? [
-                {
-                  label: copy.projectRelink,
-                  icon: Plug,
-                  onClick: () => runProjectAction('relink', () => actions.onRelink!(project.id)),
-                },
-              ]
-              : []),
-          {
-            label: copy.projectRename,
-            icon: Pencil,
-            onClick: () => {
-              // Read now, while the trigger is still the thing the user is on:
-              // by the time the intent runs the menu has closed and focus is
-              // mid-handover.
-              const opener = endRef.current?.querySelector<HTMLElement>('button') ?? null;
-              pendingMenuIntentRef.current = () => props.onStartRename(opener);
-            },
+              {
+                label: copy.projectRelink,
+                icon: Plug,
+                onClick: () => runProjectAction('relink', () => actions.onRelink!(project.id)),
+              },
+            ]
+            : []),
+        {
+          label: copy.projectRename,
+          icon: Pencil,
+          onClick: () => {
+            // Read now, while the trigger is still the thing the user is on:
+            // by the time the intent runs the menu has closed and focus is
+            // mid-handover.
+            const opener = trailingRef.current?.querySelector<HTMLElement>('button') ?? null;
+            pendingMenuIntentRef.current = () => props.onStartRename(opener);
           },
-          {
-            label: copy.projectArchive,
-            icon: Archive,
-            onClick: () => runProjectAction('archive', () => actions.onArchive(project.id)),
-          },
-        ]
-    : [];
+        },
+        {
+          label: copy.projectArchive,
+          icon: Archive,
+          onClick: () => runProjectAction('archive', () => actions.onArchive(project.id)),
+        },
+      ];
 
   return (
-    <EndContentHitTarget className="maka-session-row-end maka-project-item-end" ref={endRef}>
-      {project && !project.available && (
-        <AlertTriangle size={ICON_SIZE.meta} aria-label={copy.projectUnavailable} />
-      )}
-      <Badge variant="neutral" label={props.sessionCount} />
-      {menuItems.length > 0 && (
-        <MoreMenu
-          size="sm"
-          label={copy.projectActionsAriaLabel(project?.name ?? '')}
-          isDisabled={pendingAction !== null}
-          isMenuOpen={menuOpen}
-          onOpenChange={(open) => {
-            setMenuOpen(open);
-            if (open) return;
-            const intent = pendingMenuIntentRef.current;
-            pendingMenuIntentRef.current = null;
-            if (intent) window.requestAnimationFrame(intent);
-          }}
-          items={menuItems}
-        />
-      )}
-    </EndContentHitTarget>
+    <span
+      className="maka-project-row-action"
+      ref={trailingRef}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      <MoreMenu
+        size="sm"
+        label={copy.projectActionsAriaLabel(project.name)}
+        isDisabled={pendingAction !== null}
+        isMenuOpen={menuOpen}
+        onOpenChange={(open) => {
+          setMenuOpen(open);
+          if (open) return;
+          const intent = pendingMenuIntentRef.current;
+          pendingMenuIntentRef.current = null;
+          if (intent) window.requestAnimationFrame(intent);
+        }}
+        items={menuItems}
+      />
+    </span>
   );
 }
 

--- a/patches/@astryxdesign+core+0.3.0.patch
+++ b/patches/@astryxdesign+core+0.3.0.patch
@@ -247,6 +247,52 @@ index 867ed5a..4b8f835 100644
  }
  Markdown.displayName = 'Markdown';
 \ No newline at end of file
+diff --git a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts
+index 16107cf..ce1f7a1 100644
+--- a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts
++++ b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.d.ts
+@@ -61,6 +61,11 @@ export interface SideNavItemProps extends BaseProps<HTMLElement> {
+      * Right-side content (badges, counts).
+      */
+     endContent?: ReactNode;
++    /**
++     * Interactive control rendered as a sibling of the item button and before
++     * any nested children. Use this instead of placing a button in endContent.
++     */
++    siblingAction?: ReactNode;
+     /**
+      * Sub-items for nesting.
+      */
+@@ -107,7 +112,7 @@ export interface SideNavItemProps extends BaseProps<HTMLElement> {
+  * </SideNavItem>
+  * ```
+  */
+-export declare function SideNavItem({ as, label, icon, selectedIcon, isSelected, isDisabled, href, onClick, endContent, children, collapsible: itemCollapsible, size, 'data-testid': testId, ref, xstyle, }: SideNavItemProps): import("react").JSX.Element | null;
++export declare function SideNavItem({ as, label, icon, selectedIcon, isSelected, isDisabled, href, onClick, endContent, siblingAction, children, collapsible: itemCollapsible, size, 'data-testid': testId, ref, xstyle, }: SideNavItemProps): import("react").JSX.Element | null;
+ export declare namespace SideNavItem {
+     var displayName: string;
+ }
+diff --git a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.js b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.js
+index cf5010f..195e082 100644
+--- a/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.js
++++ b/node_modules/@astryxdesign/core/dist/SideNav/SideNavItem.js
+@@ -142,6 +142,7 @@ export function SideNavItem({
+   href,
+   onClick,
+   endContent,
++  siblingAction,
+   children,
+   collapsible: itemCollapsible,
+   size = 'md',
+@@ -441,7 +442,7 @@ export function SideNavItem({
+   const item = /*#__PURE__*/_jsxs("div", {
+     ref: itemRef,
+     ...stylex.props(styles.root, xstyle),
+-    children: [itemElement, hasChildren && !isCollapsed && /*#__PURE__*/_jsx("div", {
++    children: [itemElement, !isCollapsed && siblingAction, hasChildren && !isCollapsed && /*#__PURE__*/_jsx("div", {
+       id: `${id}-children`,
+       role: "group",
+       "aria-labelledby": `${id}-label`,
 diff --git a/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js b/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js
 index 65f9278..f7515e2 100644
 --- a/node_modules/@astryxdesign/core/dist/hooks/useHotkeys.js
@@ -546,6 +592,38 @@ index a6f850b..b6e0f2a 100644
    return rendered;
  }
 
+diff --git a/node_modules/@astryxdesign/core/src/SideNav/SideNavItem.tsx b/node_modules/@astryxdesign/core/src/SideNav/SideNavItem.tsx
+index fcd0442..0409284 100644
+--- a/node_modules/@astryxdesign/core/src/SideNav/SideNavItem.tsx
++++ b/node_modules/@astryxdesign/core/src/SideNav/SideNavItem.tsx
+@@ -287,6 +287,11 @@ export interface SideNavItemProps extends BaseProps<HTMLElement> {
+    * Right-side content (badges, counts).
+    */
+   endContent?: ReactNode;
++  /**
++   * Interactive control rendered as a sibling of the item button and before
++   * any nested children. Use this instead of placing a button in endContent.
++   */
++  siblingAction?: ReactNode;
+   /**
+    * Sub-items for nesting.
+    */
+@@ -350,6 +355,7 @@ export function SideNavItem({
+   href,
+   onClick,
+   endContent,
++  siblingAction,
+   children,
+   collapsible: itemCollapsible,
+   size = 'md',
+@@ -673,6 +679,7 @@ export function SideNavItem({
+   const item = (
+     <div ref={itemRef} {...stylex.props(styles.root, xstyle)}>
+       {itemElement}
++      {!isCollapsed && siblingAction}
+       {hasChildren && !isCollapsed && (
+         <div
+           id={`${id}-children`}
 diff --git a/node_modules/@astryxdesign/core/src/hooks/useStreamingText.ts b/node_modules/@astryxdesign/core/src/hooks/useStreamingText.ts
 index 02c069f..acdc18a 100644
 --- a/node_modules/@astryxdesign/core/src/hooks/useStreamingText.ts

--- a/patches/README.md
+++ b/patches/README.md
@@ -24,6 +24,8 @@ Three published component seams drop host-owned state or semantics:
   without remounting its composer slot and discarding the live draft.
 - `ChatToolCalls` needs a stable row slot for product styling and E2E geometry.
 - `List` must forward its published `aria-label` to the rendered list element.
+- `SideNavItem` needs an interactive sibling-action seam before nested children
+  so a row menu can follow its header in DOM/focus order without nesting buttons.
 
 Blank UA-CH `navigator.userAgentData.platform` must also not mean "not Apple".
 Electron builds with a rewritten identity ship `platform: ''`, which made every


### PR DESCRIPTION
## Summary

- Render session and project overflow menus as sibling controls instead of nesting buttons inside `SideNavItem`.
- Add an Astryx `siblingAction` slot for project rows so keyboard order stays project, project actions, then nested sessions without moving the control visually.
- Cover both row types and project focus order with server-rendered regression tests.

## Verification

- `npm --workspace @maka/ui test` — 131 tests passed
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- Storybook `product-sidebar-session-list--project-groups`: confirmed zero nested buttons, project → project actions → session focus order, and unchanged action placement

## Before review

- [x] Human contributor reviews the diff and confirms ownership of the submission

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

Generated-by: Codex
