### PR TITLE
fix(ui): stop remounting a turn's answer as it settles

### DIFF
--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -10,10 +10,9 @@ test('a transcript drag releases outside the window through its owning Turn', as
 
   const reply = page.getByText(/Fake backend received: pointer capture source/);
   await expect(reply).toBeVisible();
-  // Select from a settled answer, not a streaming one. The markdown renderer
-  // rebuilds a paragraph's inline fragments when the stream closes, and the
-  // browser drops any Selection inside the removed nodes — a race that has
-  // nothing to do with the pointer-capture contract under test here.
+  // Select from a settled answer. Selecting from a streaming one is broken for
+  // an unrelated reason — see the fixme below — and this test exists to pin the
+  // pointer-capture contract, not Selection survival across a stream close.
   await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
     timeout: 20_000,
   });
@@ -70,4 +69,40 @@ test('a transcript drag releases outside the window through its owning Turn', as
 
   await expect(turn).toHaveAttribute('data-e2e-captured-pointer-up', 'true');
   await expect(quoteLayer).toBeVisible();
+});
+
+// Known broken, kept visible rather than described in a PR nobody re-reads.
+// Selecting inside a still-streaming answer loses the Selection when the
+// stream closes: the markdown renderer rebuilds the paragraph's inline
+// fragments, the browser discards the Selection those nodes held, and it does
+// so without a `selectionchange` — so the quote hook, which re-reads the
+// Selection 350ms after pointer release, finds nothing to offer.
+//
+// Not fixable from this repo as it stands: the rebuild is inside
+// @astryxdesign/core, and pinning the `isStreaming` / `settledText` props that
+// drive it still reproduces. Closing this needs an upstream fix, or a decision
+// to snapshot the quote at pointerup — which would show a quote bar over text
+// whose highlight the browser has already erased.
+test.fixme('a drag begun while the answer streams still offers a quote', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('pointer capture source');
+  await composer.press('Enter');
+
+  const reply = page.getByText(/Fake backend received: pointer capture source/);
+  await expect(reply).toBeVisible();
+  const bounds = await reply.evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const rect = range.getBoundingClientRect();
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  });
+  const y = bounds.y + bounds.height / 2;
+  await page.mouse.move(bounds.x + 2, y);
+  await page.mouse.down();
+  await page.mouse.move(bounds.x + bounds.width - 2, y, { steps: 5 });
+  await page.mouse.up();
+
+  await expect(page.locator('.maka-quote-actions')).toBeVisible();
 });

--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -10,6 +10,13 @@ test('a transcript drag releases outside the window through its owning Turn', as
 
   const reply = page.getByText(/Fake backend received: pointer capture source/);
   await expect(reply).toBeVisible();
+  // Select from a settled answer, not a streaming one. The markdown renderer
+  // rebuilds a paragraph's inline fragments when the stream closes, and the
+  // browser drops any Selection inside the removed nodes — a race that has
+  // nothing to do with the pointer-capture contract under test here.
+  await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
+    timeout: 20_000,
+  });
   const turn = reply.locator('xpath=ancestor::*[@data-turn-id][1]');
   const quoteLayer = page.locator('.maka-quote-actions');
   await turn.evaluate((element) => {

--- a/packages/ui/src/__tests__/chat-turn-answer-identity.test.tsx
+++ b/packages/ui/src/__tests__/chat-turn-answer-identity.test.tsx
@@ -18,7 +18,11 @@ const originalActEnvironment = (globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 }).IS_REACT_ACT_ENVIRONMENT;
 
-afterEach(() => {
+const mountedRoots: ReturnType<typeof createRoot>[] = [];
+
+afterEach(async () => {
+  // Unmount before restoring globals: React's cleanup reads `document`.
+  for (const root of mountedRoots.splice(0)) await act(() => root.unmount());
   Object.assign(globalThis, {
     ...originalGlobals,
     IS_REACT_ACT_ENVIRONMENT: originalActEnvironment,
@@ -37,7 +41,9 @@ function domRoot() {
   });
   const container = document.querySelector('#root');
   assert.ok(container);
-  return { container, root: createRoot(container) };
+  const root = createRoot(container);
+  mountedRoots.push(root);
+  return { container, root };
 }
 
 function turnWith(timeline: TurnTimelineItem[]): TurnViewModel {
@@ -56,11 +62,12 @@ function turnWith(timeline: TurnTimelineItem[]): TurnViewModel {
 function renderTurn(
   root: ReturnType<typeof createRoot>,
   turn: TurnViewModel,
+  liveStreaming?: { onStreamingSettled?: (messageId?: string) => void },
 ): Promise<void> {
   return act(() => {
     root.render(
       <LocaleProvider locale="en">
-        <TurnView turn={turn} />
+        <TurnView turn={turn} liveStreaming={liveStreaming} />
       </LocaleProvider>,
     );
   }) as unknown as Promise<void>;
@@ -73,37 +80,38 @@ const ANSWER: TurnTimelineItem = {
   live: true,
 };
 
+const RUNNING_TOOL: TurnTimelineItem = {
+  kind: 'tools',
+  items: [{ toolUseId: 'tool-1', toolName: 'read', status: 'running', args: {} }],
+};
+
 /**
- * The bug this pins: keying the answer by its first timeline entry made the
- * key change whenever that entry did, so React unmounted the answer and
- * mounted a copy. The browser drops any Selection inside a removed subtree, so
- * text selected while the answer streamed lost its highlight — and the quote
- * affordance that reads from the Selection never appeared.
+ * Keying the answer by its first timeline entry made the key change whenever
+ * that entry did, so React unmounted the answer and mounted a copy — taking
+ * the scroll position, any open disclosure, and any text Selection inside it.
+ *
+ * The transition here is the real one from `timeline-fold.ts`: a run's last
+ * tools group is projected away, so the Processing block dissolves and the
+ * leading entry stops being a fold.
  */
 test('keeps the assistant answer element as a turn settles around it', async () => {
   const { container, root } = domRoot();
 
-  // While the turn runs, a tools group folds the leading entries into a
-  // Processing block. The answer is the second entry.
-  await renderTurn(root, turnWith([
-    { kind: 'tools', items: [] },
-    ANSWER,
-  ]));
+  await renderTurn(root, turnWith([RUNNING_TOOL, ANSWER]));
   const streaming = container.querySelector('.maka-assistant-answer');
   assert.ok(streaming, 'the answer renders while the turn runs');
 
-  // The last tools group is projected away, the Processing block dissolves,
-  // and the leading entry becomes something else entirely.
-  await renderTurn(root, turnWith([
-    { kind: 'thinking', text: 'reasoning', messageId: 'think-1' },
-    { ...ANSWER, live: false },
-  ]));
+  await renderTurn(root, turnWith([{ ...ANSWER, live: false }]));
   const settled = container.querySelector('.maka-assistant-answer');
   assert.ok(settled, 'the answer still renders once the turn settles');
   assert.equal(settled.isSameNode(streaming), true, 'the answer element survives the turn settling');
 });
 
-/** Each answer in a turn is identified by the steering message that opened it. */
+/**
+ * Locks the keying scheme rather than the regression above: two answers in one
+ * turn must not collide on a shared key. This is what catches an identity that
+ * is constant across segments — the sentinel-vs-real-id collision, say.
+ */
 test('gives each answer in a steered turn its own stable element', async () => {
   const { container, root } = domRoot();
 
@@ -127,4 +135,38 @@ test('gives each answer in a steered turn its own stable element', async () => {
   assert.equal(settledAnswers.length, 2);
   assert.equal(settledAnswers[0]?.isSameNode(answers[0]), true, 'the first answer keeps its element');
   assert.equal(settledAnswers[1]?.isSameNode(answers[1]), true, 'the second answer keeps its element');
+});
+
+/**
+ * The live handoff announces itself exactly once, when the answer enters its
+ * settled phase. A bubble replayed from history mounts already past the
+ * stream; letting it consume that announcement left the real handoff silent
+ * and the answer stuck wearing the live marker until a timeout cleaned up.
+ */
+test('announces settlement when a persisted answer is promoted to a completed live one', async () => {
+  const { container, root } = domRoot();
+  const settled: string[] = [];
+  const onStreamingSettled = (messageId?: string) => { settled.push(messageId ?? '?'); };
+
+  await renderTurn(root, turnWith([{ ...ANSWER, live: false }]));
+  assert.deepEqual(settled, [], 'history alone announces nothing');
+
+  await renderTurn(
+    root,
+    turnWith([{ ...ANSWER, live: true, complete: true }]),
+    { onStreamingSettled },
+  );
+  assert.deepEqual(settled, ['answer-1'], 'the handoff is announced once');
+  assert.equal(
+    container.querySelector('.maka-bubble-streaming') === null,
+    false,
+    'the live marker is still present while the turn is being followed',
+  );
+
+  await renderTurn(
+    root,
+    turnWith([{ ...ANSWER, live: true, complete: true }]),
+    { onStreamingSettled },
+  );
+  assert.deepEqual(settled, ['answer-1'], 'staying settled does not re-announce');
 });

--- a/packages/ui/src/__tests__/chat-turn-answer-identity.test.tsx
+++ b/packages/ui/src/__tests__/chat-turn-answer-identity.test.tsx
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { parseHTML } from 'linkedom';
+import { TurnView } from '../chat-turn.js';
+import { LocaleProvider } from '../locale-context.js';
+import type { TurnTimelineItem, TurnViewModel } from '../materialize.js';
+
+const originalGlobals = {
+  document: globalThis.document,
+  matchMedia: globalThis.matchMedia,
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+  cancelAnimationFrame: globalThis.cancelAnimationFrame,
+  window: globalThis.window,
+};
+const originalActEnvironment = (globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+}).IS_REACT_ACT_ENVIRONMENT;
+
+afterEach(() => {
+  Object.assign(globalThis, {
+    ...originalGlobals,
+    IS_REACT_ACT_ENVIRONMENT: originalActEnvironment,
+  });
+});
+
+function domRoot() {
+  const { document, window } = parseHTML('<div id="root"></div>');
+  Object.assign(globalThis, {
+    document,
+    window,
+    matchMedia: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame() {},
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  const container = document.querySelector('#root');
+  assert.ok(container);
+  return { container, root: createRoot(container) };
+}
+
+function turnWith(timeline: TurnTimelineItem[]): TurnViewModel {
+  return {
+    turnId: 'turn-1',
+    status: 'running',
+    partialOutputRetained: false,
+    user: { id: 'ask', role: 'user', text: 'ask', ts: 1 },
+    tools: [],
+    notes: [],
+    startedAt: 1,
+    timeline,
+  };
+}
+
+function renderTurn(
+  root: ReturnType<typeof createRoot>,
+  turn: TurnViewModel,
+): Promise<void> {
+  return act(() => {
+    root.render(
+      <LocaleProvider locale="en">
+        <TurnView turn={turn} />
+      </LocaleProvider>,
+    );
+  }) as unknown as Promise<void>;
+}
+
+const ANSWER: TurnTimelineItem = {
+  kind: 'text',
+  text: 'the answer',
+  messageId: 'answer-1',
+  live: true,
+};
+
+/**
+ * The bug this pins: keying the answer by its first timeline entry made the
+ * key change whenever that entry did, so React unmounted the answer and
+ * mounted a copy. The browser drops any Selection inside a removed subtree, so
+ * text selected while the answer streamed lost its highlight — and the quote
+ * affordance that reads from the Selection never appeared.
+ */
+test('keeps the assistant answer element as a turn settles around it', async () => {
+  const { container, root } = domRoot();
+
+  // While the turn runs, a tools group folds the leading entries into a
+  // Processing block. The answer is the second entry.
+  await renderTurn(root, turnWith([
+    { kind: 'tools', items: [] },
+    ANSWER,
+  ]));
+  const streaming = container.querySelector('.maka-assistant-answer');
+  assert.ok(streaming, 'the answer renders while the turn runs');
+
+  // The last tools group is projected away, the Processing block dissolves,
+  // and the leading entry becomes something else entirely.
+  await renderTurn(root, turnWith([
+    { kind: 'thinking', text: 'reasoning', messageId: 'think-1' },
+    { ...ANSWER, live: false },
+  ]));
+  const settled = container.querySelector('.maka-assistant-answer');
+  assert.ok(settled, 'the answer still renders once the turn settles');
+  assert.equal(settled.isSameNode(streaming), true, 'the answer element survives the turn settling');
+});
+
+/** Each answer in a turn is identified by the steering message that opened it. */
+test('gives each answer in a steered turn its own stable element', async () => {
+  const { container, root } = domRoot();
+
+  const steered: TurnTimelineItem[] = [
+    { kind: 'text', text: 'first answer', messageId: 'answer-1', live: true },
+    {
+      kind: 'user',
+      message: { id: 'steer-1', role: 'user', text: 'actually...', ts: 2 },
+      messageId: 'steer-1',
+    },
+    { kind: 'text', text: 'second answer', messageId: 'answer-2', live: true },
+  ];
+  await renderTurn(root, turnWith(steered));
+  const answers = [...container.querySelectorAll('.maka-assistant-answer')];
+  assert.equal(answers.length, 2, 'steering splits the turn into two answers');
+
+  await renderTurn(root, turnWith(steered.map((item) =>
+    item.kind === 'text' ? { ...item, live: false } : item,
+  )));
+  const settledAnswers = [...container.querySelectorAll('.maka-assistant-answer')];
+  assert.equal(settledAnswers.length, 2);
+  assert.equal(settledAnswers[0]?.isSameNode(answers[0]), true, 'the first answer keeps its element');
+  assert.equal(settledAnswers[1]?.isSameNode(answers[1]), true, 'the second answer keeps its element');
+});

--- a/packages/ui/src/chat-display-helpers.ts
+++ b/packages/ui/src/chat-display-helpers.ts
@@ -1,6 +1,6 @@
 /**
  * Small pure helpers backing the chat surface (TurnView,
- * RelativeTime, StreamingAssistantBubble, etc.) —
+ * RelativeTime, AssistantAnswerBubble, etc.) —
  * time formatters, turn duration + abort marker copy.
  *
  * PR-UI-LIB-EXTRACT-4 (round 5/10) introduced this module with a
@@ -12,7 +12,7 @@
  * Why this seam: duration formatting has ms→s→m bucket rules, and
  * the abort-marker label is i18n-able copy. Each rule was
  * previously buried between TurnView's 200-line JSX block and
- * StreamingAssistantBubble's rendering lifecycle; the bundle now
+ * the answer bubble's rendering lifecycle; the bundle now
  * sits as short pure functions easy to unit-test in isolation.
  *
  * PR-CHAT-CHROME-FOLLOWUP-0: `messageRoleLabel` / `avatarInitial`

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -554,9 +554,13 @@ export const TurnView = memo(function TurnView(props: {
         const ownsTurnChrome = segmentIndex === conversationSegments.length - 1;
         return (
           <LocalizedChatMessage
-            key={`assistant-${
-              segment.items[0] ? foldedTimelineEntryKey(segment.items[0], 0) : 'empty'
-            }`}
+            // Disjoint namespaces: a steering id is any string, so a bare
+            // sentinel could collide with a real one.
+            key={
+              segment.repliesTo === undefined
+                ? 'assistant-opening'
+                : `assistant-after-${segment.repliesTo}`
+            }
             accessibleLabel={copy.assistantAriaLabel}
             sender="assistant"
             data-turn-status={turn.status}
@@ -680,31 +684,41 @@ type UserTimelineItem = Extract<TurnTimelineItem, { kind: 'user' }>;
 type AssistantFoldedTimelineEntry = Exclude<FoldedTimelineEntry, UserTimelineItem>;
 type ConversationSegment =
   | { kind: 'user'; item: UserTimelineItem }
-  | { kind: 'assistant'; items: AssistantFoldedTimelineEntry[] };
+  | {
+      kind: 'assistant';
+      items: AssistantFoldedTimelineEntry[];
+      /**
+       * What this answer replies to: the steering message that opened it, or
+       * the turn itself for the first answer. This is the segment's identity —
+       * its React key must not be derived from its contents, because those
+       * change as the turn runs (a Processing fold appears, then the answer
+       * lands) and a changing key remounts the whole answer, which drops any
+       * text Selection the user was holding inside it.
+       */
+      repliesTo?: string;
+    };
 
 function splitTimelineAtUserMessages(
   items: readonly FoldedTimelineEntry[],
   includeEmptyAssistant: boolean,
 ): ConversationSegment[] {
   const segments: ConversationSegment[] = [];
+  let repliesTo: string | undefined;
   for (const item of items) {
     const last = segments.at(-1);
     if (item.kind === 'user') {
       segments.push({ kind: 'user', item });
+      repliesTo = item.message.id;
     } else if (last?.kind === 'assistant') {
       last.items.push(item);
     } else {
-      segments.push({ kind: 'assistant', items: [item] });
+      segments.push({ kind: 'assistant', items: [item], repliesTo });
     }
   }
   if (includeEmptyAssistant && segments.at(-1)?.kind !== 'assistant') {
-    segments.push({ kind: 'assistant', items: [] });
+    segments.push({ kind: 'assistant', items: [], repliesTo });
   }
   return segments;
-}
-
-function foldedTimelineEntryKey(item: FoldedTimelineEntry, index: number): string {
-  return item.kind === 'processing' ? `processing-${item.id}` : timelineEntryKey(item, index);
 }
 
 export interface TurnFooterActionMeta {
@@ -984,25 +998,51 @@ export function ModelProviderRetryIndicator(props: { retry: ProviderRetryEvent }
   );
 }
 
-function StreamingAssistantBubble(props: { text: string; live: boolean; settledText?: string; truncated?: boolean; onSettled?: () => void }) {
+/**
+ * The assistant's answer, in every state it can be in: still streaming,
+ * streamed and settled, and replayed from history.
+ *
+ * One component on purpose. Swapping components as a turn ends would unmount
+ * the answer's DOM and remount an identical-looking copy, and the browser
+ * drops any text Selection that lived in the removed subtree — so a user who
+ * selected part of an answer while it was still arriving lost the selection
+ * (and the quote affordance it feeds) the instant the turn finished.
+ */
+const AssistantAnswerBubble = memo(function AssistantAnswerBubble(props: {
+  text: string;
+  /** Belongs to a turn the UI is still following; carries the live-bubble marker. */
+  live: boolean;
+  /** Text is still growing, so the markdown renderer stays behind its cursor. */
+  streaming: boolean;
+  settledText?: string;
+  truncated?: boolean;
+  onSettled?: () => void;
+}) {
   const copy = getConversationCopy(useUiLocale()).messages;
   const settledRef = useRef(false);
 
   useEffect(() => {
     settledRef.current = false;
-  }, [props.text, props.live]);
+  }, [props.text, props.streaming]);
 
   useEffect(() => {
-    if (props.live || settledRef.current) return;
+    if (props.streaming || settledRef.current) return;
     settledRef.current = true;
     props.onSettled?.();
-  }, [props.live, props.onSettled]);
+  }, [props.streaming, props.onSettled]);
 
   return (
-    <ChatMessageBubble variant="ghost" className="maka-chat-message-bubble maka-chat-message-bubble-assistant maka-bubble-streaming">
+    <ChatMessageBubble
+      variant="ghost"
+      className={
+        props.live
+          ? 'maka-chat-message-bubble maka-chat-message-bubble-assistant maka-bubble-streaming'
+          : 'maka-chat-message-bubble maka-chat-message-bubble-assistant'
+      }
+    >
       <Markdown
         text={props.text}
-        streaming={props.live}
+        streaming={props.streaming}
         settledText={props.settledText}
         density="compact"
       />
@@ -1028,7 +1068,7 @@ function StreamingAssistantBubble(props: { text: string; live: boolean; settledT
       )}
     </ChatMessageBubble>
   );
-}
+});
 
 // Semantic keys (no index) so mid-timeline inserts do not remount/collapse disclosures.
 function timelineEntryKey(item: TurnTimelineItem, index: number): string {
@@ -1057,18 +1097,17 @@ function TurnTimelineEntry(props: {
   if (item.kind === 'tools') {
     return <ToolTrow items={item.items} onOpenLinkedSession={props.onOpenLinkedSession} />;
   }
-  if (item.kind === 'text' && item.live) {
-    return (
-      <StreamingAssistantBubble
-        text={item.text}
-        live={item.complete !== true}
-        settledText={props.initialLiveContent?.get(`text:${item.messageId}`)}
-        truncated={item.truncated === true}
-        onSettled={() => props.onStreamingSettled?.(item.messageId)}
-      />
-    );
-  }
-  return <MessageBody role="assistant" text={item.text} ts={item.ts} />;
+  const live = item.live === true;
+  return (
+    <AssistantAnswerBubble
+      text={item.text}
+      live={live}
+      streaming={live && item.complete !== true}
+      settledText={props.initialLiveContent?.get(`text:${item.messageId}`)}
+      truncated={live && item.truncated === true}
+      onSettled={live ? () => props.onStreamingSettled?.(item.messageId) : undefined}
+    />
+  );
 }
 
 function ProcessingBlock(props: {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -681,9 +681,13 @@ type ConversationSegment =
        * What this answer replies to: the steering message that opened it, or
        * the turn itself for the first answer. This is the segment's identity —
        * its React key must not be derived from its contents, because those
-       * change as the turn runs (a Processing fold appears, then the answer
-       * lands) and a changing key remounts the whole answer, which drops any
-       * text Selection the user was holding inside it.
+       * change as the turn runs (a Processing fold dissolves once its last
+       * tools group is projected away) and a changing key remounts the whole
+       * answer, costing the user their scroll position, any disclosure they
+       * had open, and any text Selection held inside it.
+       *
+       * Same rule, same reason as `ProcessingFold.id` in `timeline-fold.ts`:
+       * identity comes from the preceding boundary, never from the first child.
        */
       repliesTo?: string;
     };
@@ -989,54 +993,70 @@ export function ModelProviderRetryIndicator(props: { retry: ProviderRetryEvent }
 }
 
 /**
- * The assistant's answer, in every state it can be in: still streaming,
- * streamed and settled, and replayed from history.
+ * Which of an answer's three lives this bubble is rendering.
  *
- * One component on purpose. Swapping components as a turn ends would unmount
- * the answer's DOM and remount an identical-looking copy, and the browser
- * drops any text Selection that lived in the removed subtree — so a user who
- * selected part of an answer while it was still arriving lost the selection
- * (and the quote affordance it feeds) the instant the turn finished.
+ * One field, not a pair of booleans: a bubble replayed from history has no
+ * stream to be behind, no settlement to announce, and no live-stream seed, so
+ * `historical` must not be able to carry those at all. Spelling it as
+ * `(live, streaming)` made `live: false, streaming: true` representable and
+ * pushed the gating out to every call site, where forgetting one is silent.
  */
-const AssistantAnswerBubble = memo(function AssistantAnswerBubble(props: {
-  text: string;
-  /** Belongs to a turn the UI is still following; carries the live-bubble marker. */
-  live: boolean;
-  /** Text is still growing, so the markdown renderer stays behind its cursor. */
-  streaming: boolean;
-  settledText?: string;
-  truncated?: boolean;
-  onSettled?: () => void;
-}) {
+type AssistantAnswerPhase = 'historical' | 'streaming' | 'settled';
+
+type AssistantAnswerBubbleProps =
+  | { text: string; phase: 'historical' }
+  | {
+      text: string;
+      phase: 'streaming' | 'settled';
+      /** Text already streamed before this mount, so a remount does not replay it. */
+      settledText?: string;
+      truncated?: boolean;
+      /** Called once when this answer's stream closes. */
+      onSettled?: () => void;
+    };
+
+/**
+ * The assistant's answer, in every state it can be in.
+ *
+ * One component on purpose. Swapping component types as a turn ends would
+ * unmount the answer's DOM and mount an identical-looking copy, taking with it
+ * the user's scroll position, any open disclosure inside, and any text
+ * Selection held in the removed subtree.
+ */
+const AssistantAnswerBubble = memo(function AssistantAnswerBubble(props: AssistantAnswerBubbleProps) {
   const copy = getConversationCopy(useUiLocale()).messages;
-  const settledRef = useRef(false);
+  const settledText = props.phase === 'historical' ? undefined : props.settledText;
+  const truncated = props.phase === 'historical' ? false : props.truncated === true;
+  const onSettled = props.phase === 'historical' ? undefined : props.onSettled;
+  // Settlement is an edge, not a value: it happens when this answer *enters*
+  // `settled`, including straight into it on mount. Reading the phase alone
+  // would let a historical bubble — which mounts already past the stream —
+  // consume the announcement that belongs to the live handoff.
+  const announcedFrom = useRef<AssistantAnswerPhase | null>(null);
 
   useEffect(() => {
-    settledRef.current = false;
-  }, [props.text, props.streaming]);
-
-  useEffect(() => {
-    if (props.streaming || settledRef.current) return;
-    settledRef.current = true;
-    props.onSettled?.();
-  }, [props.streaming, props.onSettled]);
+    const previous = announcedFrom.current;
+    announcedFrom.current = props.phase;
+    if (props.phase !== 'settled' || previous === 'settled') return;
+    onSettled?.();
+  }, [props.phase, onSettled]);
 
   return (
     <ChatMessageBubble
       variant="ghost"
       className={
-        props.live
-          ? 'maka-chat-message-bubble maka-chat-message-bubble-assistant maka-bubble-streaming'
-          : 'maka-chat-message-bubble maka-chat-message-bubble-assistant'
+        props.phase === 'historical'
+          ? 'maka-chat-message-bubble maka-chat-message-bubble-assistant'
+          : 'maka-chat-message-bubble maka-chat-message-bubble-assistant maka-bubble-streaming'
       }
     >
       <Markdown
         text={props.text}
-        streaming={props.streaming}
-        settledText={props.settledText}
+        streaming={props.phase === 'streaming'}
+        settledText={settledText}
         density="compact"
       />
-      {props.truncated && (
+      {truncated && (
         <Tooltip content={copy.outputTruncatedTitle}>
           {/* Colour-name archive, not the semantic one: Astryx paints
               `warning` as a solid dark-mode-invariant fill and `yellow` as a
@@ -1087,15 +1107,15 @@ function TurnTimelineEntry(props: {
   if (item.kind === 'tools') {
     return <ToolTrow items={item.items} onOpenLinkedSession={props.onOpenLinkedSession} />;
   }
-  const live = item.live === true;
+  // Same component either way — a type swap here would remount the answer.
+  if (item.live !== true) return <AssistantAnswerBubble text={item.text} phase="historical" />;
   return (
     <AssistantAnswerBubble
       text={item.text}
-      live={live}
-      streaming={live && item.complete !== true}
+      phase={item.complete === true ? 'settled' : 'streaming'}
       settledText={props.initialLiveContent?.get(`text:${item.messageId}`)}
-      truncated={live && item.truncated === true}
-      onSettled={live ? () => props.onStreamingSettled?.(item.messageId) : undefined}
+      truncated={item.truncated === true}
+      onSettled={() => props.onStreamingSettled?.(item.messageId)}
     />
   );
 }

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -84,10 +84,6 @@ function legacySentSkillTokens(text: string) {
   return [...values].map((value) => ({ value, label: value, variant: 'neutral' as const }));
 }
 
-/**
- * One chat message body: user verbatim; assistant/system via Markdown.
- * Memoized so streaming list re-renders do not re-parse settled bubbles.
- */
 function AttachmentImage(props: { attachment: AttachmentRef; onReadAttachmentBytes?: ReadAttachmentBytes }) {
   const [src, setSrc] = useState<string | undefined>(undefined);
   const { onReadAttachmentBytes } = props;
@@ -139,8 +135,11 @@ function LoadedAttachmentImage(props: { src: string; name: string }) {
   );
 }
 
-const MessageBody = memo(function MessageBody(props: {
-  role: string;
+/**
+ * A user message: their text verbatim, with attachments, quotes and the edit
+ * affordance. Memoized so streaming re-renders do not rebuild settled asks.
+ */
+const UserMessageBody = memo(function UserMessageBody(props: {
   text: string;
   ts?: number;
   attachments?: readonly AttachmentRef[];
@@ -154,98 +153,91 @@ const MessageBody = memo(function MessageBody(props: {
 }) {
   const locale = useUiLocale();
   const copyText = getConversationCopy(locale).messages;
-  if (props.role === 'user') {
-    const nonImageAttachments = props.attachments?.filter((attachment) => attachment.kind !== 'image') ?? [];
-    const imageAttachments = props.attachments?.filter((attachment) => attachment.kind === 'image') ?? [];
-    const editActionLabel = props.editDisabled
-      ? (props.editDisabledReason ?? copyText.editMessageDisabledRunning)
-      : copyText.editMessage;
-    const userMetadata = (
-      <ChatMessageMetadata
-        className="maka-message-meta"
-        timestamp={
-          props.ts !== undefined ? (
-            /* `value` takes ms directly: Timestamp's own parseValue reads
-               anything past 1e12 as milliseconds (2001-09-09 onward), and a
-               chat message never predates that. */
-            (<Timestamp className="maka-message-time-inline" value={props.ts} format="time" />)
-          ) : undefined
-        }
-        footer={
-          <>
-            <MessageCopyButton text={props.text} />
-            {props.onEditUserMessage ? (
-              <UiIconButton
-                label={editActionLabel}
-                tooltip={editActionLabel}
-                icon={<Pencil size={ICON_SIZE.control} aria-hidden="true" />}
-                variant="ghost"
-                size="sm"
-                className={markerVariants({ variant: 'footer-action' })}
-                aria-disabled={props.editDisabled === true ? 'true' : undefined}
-                data-action="edit"
-                onClick={() => {
-                  if (props.editDisabled) return;
-                  props.onEditUserMessage?.();
-                }}
-              />
-            ) : null}
-          </>
-        }
-      />
-    );
-    return (
-      <>
-        {nonImageAttachments.length > 0 ? (
-          <HStack gap={1} wrap="wrap" maxWidth="100%" className="maka-user-attachment-tokens">
-            {nonImageAttachments.map((attachment, index) => (
-              <Token
-                key={`${attachment.name}-${index}`}
-                size="sm"
-                label={attachment.name}
-                icon={<AttachmentKindIcon kind={attachment.kind} />}
-                description={attachment.bytes !== undefined ? formatBytes(attachment.bytes) : undefined}
-              />
-            ))}
-          </HStack>
-        ) : null}
-        {props.quotes && props.quotes.length > 0 ? (
-          <div className="maka-user-quotes">
-            {props.quotes.map((quote, index) => (
-              <QuoteRefChip key={`${quote.sourceTurnId ?? 'quote'}-${index}`} quote={quote} />
-            ))}
-          </div>
-        ) : null}
-        {imageAttachments.length > 0 ? (
-          <HStack gap={1} wrap="wrap" maxWidth="100%" className="maka-user-attachments">
-            {imageAttachments.map((attachment, index) => (
-              <AttachmentImage
-                key={`${attachment.name}-${index}`}
-                attachment={attachment}
-                onReadAttachmentBytes={props.onReadAttachmentBytes}
-              />
-            ))}
-          </HStack>
-        ) : null}
-        <ChatMessageBubble
-          className="maka-chat-message-bubble maka-chat-message-bubble-user"
-          metadata={userMetadata}
-        >
-          {props.inlineReferences ? (
-            <InlineReferenceText text={props.text} references={props.inlineReferences} />
-          ) : (
-            <ChatTokenizedText tokens={legacySentSkillTokens(props.text)}>
-              {props.text}
-            </ChatTokenizedText>
-          )}
-        </ChatMessageBubble>
-      </>
-    );
-  }
+  const nonImageAttachments = props.attachments?.filter((attachment) => attachment.kind !== 'image') ?? [];
+  const imageAttachments = props.attachments?.filter((attachment) => attachment.kind === 'image') ?? [];
+  const editActionLabel = props.editDisabled
+    ? (props.editDisabledReason ?? copyText.editMessageDisabledRunning)
+    : copyText.editMessage;
+  const userMetadata = (
+    <ChatMessageMetadata
+      className="maka-message-meta"
+      timestamp={
+        props.ts !== undefined ? (
+          /* `value` takes ms directly: Timestamp's own parseValue reads
+             anything past 1e12 as milliseconds (2001-09-09 onward), and a
+             chat message never predates that. */
+          (<Timestamp className="maka-message-time-inline" value={props.ts} format="time" />)
+        ) : undefined
+      }
+      footer={
+        <>
+          <MessageCopyButton text={props.text} />
+          {props.onEditUserMessage ? (
+            <UiIconButton
+              label={editActionLabel}
+              tooltip={editActionLabel}
+              icon={<Pencil size={ICON_SIZE.control} aria-hidden="true" />}
+              variant="ghost"
+              size="sm"
+              className={markerVariants({ variant: 'footer-action' })}
+              aria-disabled={props.editDisabled === true ? 'true' : undefined}
+              data-action="edit"
+              onClick={() => {
+                if (props.editDisabled) return;
+                props.onEditUserMessage?.();
+              }}
+            />
+          ) : null}
+        </>
+      }
+    />
+  );
   return (
-    <ChatMessageBubble variant="ghost" className="maka-chat-message-bubble maka-chat-message-bubble-assistant">
-      <Markdown text={props.text} density="compact" />
-    </ChatMessageBubble>
+    <>
+      {nonImageAttachments.length > 0 ? (
+        <HStack gap={1} wrap="wrap" maxWidth="100%" className="maka-user-attachment-tokens">
+          {nonImageAttachments.map((attachment, index) => (
+            <Token
+              key={`${attachment.name}-${index}`}
+              size="sm"
+              label={attachment.name}
+              icon={<AttachmentKindIcon kind={attachment.kind} />}
+              description={attachment.bytes !== undefined ? formatBytes(attachment.bytes) : undefined}
+            />
+          ))}
+        </HStack>
+      ) : null}
+      {props.quotes && props.quotes.length > 0 ? (
+        <div className="maka-user-quotes">
+          {props.quotes.map((quote, index) => (
+            <QuoteRefChip key={`${quote.sourceTurnId ?? 'quote'}-${index}`} quote={quote} />
+          ))}
+        </div>
+      ) : null}
+      {imageAttachments.length > 0 ? (
+        <HStack gap={1} wrap="wrap" maxWidth="100%" className="maka-user-attachments">
+          {imageAttachments.map((attachment, index) => (
+            <AttachmentImage
+              key={`${attachment.name}-${index}`}
+              attachment={attachment}
+              onReadAttachmentBytes={props.onReadAttachmentBytes}
+            />
+          ))}
+        </HStack>
+      ) : null}
+      <ChatMessageBubble
+        className="maka-chat-message-bubble maka-chat-message-bubble-user"
+        metadata={userMetadata}
+      >
+        {props.inlineReferences ? (
+          <InlineReferenceText text={props.text} references={props.inlineReferences} />
+        ) : (
+          <ChatTokenizedText tokens={legacySentSkillTokens(props.text)}>
+            {props.text}
+          </ChatTokenizedText>
+        )}
+      </ChatMessageBubble>
+    </>
   );
 });
 
@@ -483,8 +475,7 @@ export const TurnView = memo(function TurnView(props: {
           sender="user"
           className="maka-chat-message maka-user-message"
         >
-          <MessageBody
-            role="user"
+          <UserMessageBody
             text={turn.user.text}
             ts={turn.user.ts}
             attachments={turn.user.attachments}
@@ -539,8 +530,7 @@ export const TurnView = memo(function TurnView(props: {
               sender="user"
               className="maka-chat-message maka-user-message maka-steering-message"
             >
-              <MessageBody
-                role="user"
+              <UserMessageBody
                 text={message.text}
                 ts={message.ts}
                 attachments={message.attachments}


### PR DESCRIPTION
Fixes the only red e2e on `main`: `quote-selection.spec.ts` never sees `.maka-quote-actions`.

## The problem

The assistant answer's React key was derived from its **first timeline entry**. While a turn runs that entry is the Processing fold; when the last tools group is projected away the fold dissolves, the first entry changes, and so does the key — React unmounts the whole answer and mounts an identical-looking copy, taking with it the scroll position, any open disclosure, and any text Selection held inside.

`timeline-fold.ts` already made this argument for the Processing block itself — its id comes from the preceding boundary precisely so it "survives the first tool being projected away without remounting". The answer element was still keyed by a guess at its first child.

## Changes

**1. `fix(ui): stop remounting a turn's answer as it settles`**
Key the assistant message by what it replies to — the steering message that opened it, or a disjoint `assistant-opening` for the turn's first answer (a steering id is any string, so a bare sentinel could collide with a real one). Fold the streaming and settled bubbles into one component so settling changes attributes rather than swapping component types, which is itself an unmount. Adds `chat-turn-answer-identity.test.tsx`, which renders `TurnView` into a real DOM and asserts the answer element `isSameNode` across the transition.

**2. `refactor(ui): narrow MessageBody to the user message it now renders`**
After the merge every caller passed `role="user"`, so the generic prop and the assistant branch were unreachable. Most of that diff is de-indentation.

**3. `fix(ui): announce settlement from the answer's phase`**
The merged component spelled the answer's three lives — historical, streaming, settled — as two independent booleans, which made `live: false, streaming: true` representable and pushed gating of every live-only prop out to the call site. One was already forgotten (`settledText` reached historical bubbles). The same shape produced a real defect: settlement was inferred from a `settledRef` reset by `[text, streaming]`, so a bubble mounted from history — already `streaming: false` — consumed the one-shot ref; when that same message id was promoted to a completed live projection neither dependency had changed, the announcement never fired, and the answer wore the live marker until the shell's 1000ms fallback. Collapsed to one `phase` field: historical bubbles cannot carry live-only props at all, and settlement is the edge into `settled`.

**4. `docs(ui): say what the remount fix fixes, and record what it does not`**
The comments claimed a user-visible outcome the code does not produce. See below.

## The gap this does not close

A Selection taken inside a **still-streaming** answer dies anyway: the markdown renderer rebuilds the paragraph's inline fragments when the stream closes, and the browser discards the Selection those nodes held — without a `selectionchange`, so the quote hook's read 350ms after pointer release finds nothing. Pinning the `isStreaming` and `settledText` props that drive the rebuild still reproduces it; it happens inside `@astryxdesign/core`.

The e2e therefore selects from a settled answer — it exists to pin the pointer-capture contract, not Selection survival across a stream close, and no capture/release assertion was dropped. The lost precondition is recorded as a `test.fixme` beside it rather than only in this description. Closing it needs an upstream fix, or a decision to snapshot the quote at pointerup — which would show a quote bar over text whose highlight the browser has already erased. That is a product call.

## Verification

- `quote-selection` passes 5/5 consecutive runs (5/5 failures before this change, same invocation)
- Desktop e2e: 16 passed, 1 skipped (the fixme above)
- `@maka/ui` 133/133, typecheck and `format:check` clean
- Each new test was checked for teeth by reverting the behaviour it pins and confirming it goes red
- Unrelated: `slash-command-menu.spec.ts:87` is flaky on `origin/main` too — 6 failures in 20 runs there, on an untouched code path

Generated-by: Claude Code