### PR TITLE
fix(runtime): request inference scope for Claude subscription OAuth

### DIFF
--- a/packages/runtime/src/oauth-provider-contracts.ts
+++ b/packages/runtime/src/oauth-provider-contracts.ts
@@ -45,7 +45,12 @@ export const OAUTH_PROVIDER_CONTRACTS = {
     authorizationEndpoint: 'https://claude.com/cai/oauth/authorize',
     tokenEndpoint: 'https://platform.claude.com/v1/oauth/token',
     redirectUri: 'https://platform.claude.com/oauth/code/callback',
-    scope: 'user:sessions:claude_code user:mcp_servers user:file_upload',
+    // `user:inference` is what authorizes Messages API calls; without it the
+    // granted token is session-scoped only and every inference request fails
+    // with `permission_error: OAuth token does not meet scope requirement
+    // any_of(..., user:inference, ...)`. The consent screen renders it as
+    // "Contribute to your Claude subscription usage".
+    scope: 'user:inference user:sessions:claude_code user:mcp_servers user:file_upload',
     tokenUserAgent: 'claude-cli/2.1.153 (external, cli)',
     presentation: 'paste-code',
     experimentalEnvironmentVariable: 'MAKA_CLAUDE_SUBSCRIPTION_EXPERIMENTAL',


### PR DESCRIPTION
## Summary

Claude subscription OAuth could sign in but never send a turn. The authorize
request asked only for `user:sessions:claude_code user:mcp_servers user:file_upload`,
so the granted token had no inference permission and the Messages API rejected
every request:

```
403 permission_error: OAuth token does not meet scope requirement
any_of(org:service_key_inference, user:ccr_inference, user:developer,
       user:inference, user:voice, workspace:developer, workspace:inference)
```

The failure is invisible until you send a message: the connection signs in,
its test reports "Claude OAuth 已登录", and it can be picked as the default
model. It is also why `GET /v1/models` returns 401 and the catalog stays on
the curated fallback list.

Adding `user:inference` to the requested scope is the whole fix. The consent
screen renders it as "Contribute to your Claude subscription usage".

**Existing tokens keep the scope they were granted with, so users have to
re-authenticate once.**

## Verification

Probed `POST /v1/messages` with a real subscription token, replicating the
exact request Maka sends (Bearer auth, `oauth-2025-04-20` +
`claude-code-20250219` betas, `claude-cli` UA, Claude Code system prefix):

| token | opus-5 | haiku-4-5 |
|---|---|---|
| before (no `user:inference`) | 403 `permission_error` | 403 `permission_error` |
| after re-auth (with `user:inference`) | **200** | **200** |

The granted scope after re-authenticating:
`user:file_upload user:inference user:mcp_servers user:sessions:claude_code`

Also confirmed end to end in a local packaged build: sign in, send a turn.

`lint`, `format:check`, `build`, `typecheck` pass. `@maka/core` 539/539 and
the OAuth login suite 13/13 pass. `@maka/runtime` has 5 failures on this
machine (file-tool path containment and Grep sandbox tests) that reproduce
unchanged on `main` with this commit reverted.

## Review focus

Whether `user:inference` is the scope this client should request, or whether
the subscription flow is meant to stay session-scoped and route inference
some other way. The rest of the request shape already matches Claude Code's.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

The scope string is a provider contract constant verified against the live
authorization server; I did not add a unit test that would only assert the
constant equals itself. Happy to add one if you want it pinned.

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No