### PR TITLE
test(ui): give the answer-identity guards teeth

### DIFF
--- a/apps/desktop/e2e/quote-selection.spec.ts
+++ b/apps/desktop/e2e/quote-selection.spec.ts
@@ -104,5 +104,19 @@ test.fixme('a drag begun while the answer streams still offers a quote', async (
   await page.mouse.move(bounds.x + bounds.width - 2, y, { steps: 5 });
   await page.mouse.up();
 
-  await expect(page.locator('.maka-quote-actions')).toBeVisible();
+  // Assert the contract that is actually broken, not the quote bar: the bar is
+  // also reachable while the gap is open, because the hook's 350ms read can win
+  // the race against the stream close and leave a bar standing over a Selection
+  // the browser has already erased. Wait for the close, then require the
+  // Selection to still be there — that is the state the quote hook needs and
+  // the one the fragment rebuild destroys.
+  await expect
+    .poll(() => page.evaluate(() => window.getSelection()?.isCollapsed === false))
+    .toBe(true);
+  await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, {
+    timeout: 20_000,
+  });
+  await expect
+    .poll(() => page.evaluate(() => window.getSelection()?.isCollapsed === false))
+    .toBe(true);
 });

--- a/packages/ui/src/__tests__/chat-turn-answer-identity.test.tsx
+++ b/packages/ui/src/__tests__/chat-turn-answer-identity.test.tsx
@@ -93,24 +93,39 @@ const RUNNING_TOOL: TurnTimelineItem = {
  * The transition here is the real one from `timeline-fold.ts`: a run's last
  * tools group is projected away, so the Processing block dissolves and the
  * leading entry stops being a fold.
+ *
+ * Both halves of the fix are pinned: the segment `<article>` (the key), and the
+ * bubble inside it (the single component type). Splitting the bubble back into
+ * a streaming and a historical component leaves the article identical and
+ * remounts only the bubble — which is the node a Selection actually lives in.
  */
 test('keeps the assistant answer element as a turn settles around it', async () => {
   const { container, root } = domRoot();
 
   await renderTurn(root, turnWith([RUNNING_TOOL, ANSWER]));
   const streaming = container.querySelector('.maka-assistant-answer');
+  const streamingBubble = container.querySelector('.maka-chat-message-bubble-assistant');
   assert.ok(streaming, 'the answer renders while the turn runs');
+  assert.ok(streamingBubble, 'the answer bubble renders while the turn runs');
 
   await renderTurn(root, turnWith([{ ...ANSWER, live: false }]));
   const settled = container.querySelector('.maka-assistant-answer');
+  const settledBubble = container.querySelector('.maka-chat-message-bubble-assistant');
   assert.ok(settled, 'the answer still renders once the turn settles');
+  assert.ok(settledBubble, 'the answer bubble still renders once the turn settles');
   assert.equal(settled.isSameNode(streaming), true, 'the answer element survives the turn settling');
+  assert.equal(
+    settledBubble.isSameNode(streamingBubble),
+    true,
+    'the answer bubble survives the turn settling',
+  );
 });
 
 /**
- * Locks the keying scheme rather than the regression above: two answers in one
- * turn must not collide on a shared key. This is what catches an identity that
- * is constant across segments — the sentinel-vs-real-id collision, say.
+ * Extends the regression above to a steered turn: both segments exist side by
+ * side and each keeps its own element across the settle. It does not pin the
+ * keying scheme — React reconciles duplicate-key siblings of one component type
+ * by position, so a key collision would still leave both elements identical.
  */
 test('gives each answer in a steered turn its own stable element', async () => {
   const { container, root } = domRoot();


### PR DESCRIPTION
## Summary

Follow-up to #2946. Three test-layer findings from an adversarial review of that PR; no product code changes.

**The regression tests guarded only half the fix.** Both identity assertions read `container.querySelector('.maka-assistant-answer')` — the segment-level article, which pins the key half of the fix. The merged `AssistantAnswerBubble` renders a descendant carrying `.maka-chat-message-bubble-assistant`, and that is the node a text Selection actually lives in. Splitting the bubble back into separate streaming and historical component types remounts it while the article stays identical, so every test stayed green. The narrowed e2e now deliberately selects from a settled answer, so it does not cover that transition either. Test 1 now retains and asserts the bubble node as well.

**The steered-turn docstring overclaimed.** It said the test catches "an identity that is constant across segments — the sentinel-vs-real-id collision". It cannot: React reconciles duplicate-key siblings of the same component type by position, so `isSameNode` still holds and regressing the key to the collision-prone form leaves all three tests green. Corrected to state what the test really pins — two segments exist and each keeps its element across a settle.

**The `test.fixme` could go green with the bug fully present.** It asserted `.maka-quote-actions` is visible, and that state is reachable from two worlds: the Selection survived, or the quote hook's 350ms read won the race against the stream close and left a stale bar standing over text whose highlight the browser had already erased — verbatim the outcome the comment above the test calls unacceptable. Instrumented runs reproduced the underlying bug 7/7 while the body passed 6/7. It now asserts the contract that is actually broken: wait for the stream to close, then require `window.getSelection()` to still be uncollapsed. With `retries: 0`, un-fixme-ing the old body would have yielded either a false "gap closed" or a ~1-in-6 CI flake.

Refs #2946

## Verification

- `npm --workspace @maka/ui run test` — 136 passing, 0 failing.
- **Teeth check for finding 1 (required, not just asserted):** temporarily split the bubble into a distinct component type at the `TurnTimelineEntry` call site, rebuilt, re-ran — the new bubble assertion fails (`the answer bubble survives the turn settling`) while the pre-existing article assertion still passes, confirming the old test could not see the split. Reverted.
- **Teeth check for finding 3:** temporarily flipped `test.fixme` to `test`, ran `playwright test e2e/quote-selection.spec.ts --repeat-each=3` against a fresh `build:with-deps` — the streaming-drag test failed 3/3, every failure at the post-close poll (not the pre-close one), i.e. the Selection is present right after `mouse.up()` and gone once the stream closes. The pointer-capture test passed 3/3. Restored to `test.fixme`.
- `npm --workspace @maka/ui run typecheck`, `npm run format:check` — clean.
- Not run: repository-wide suites (left to CI). `apps/desktop/e2e/slash-command-menu.spec.ts` is a known pre-existing flake tracked as #2948 and was not exercised here.

## Review focus

Whether the two teeth checks are the right falsification for each guard — a test that stays green under the regression it names is worse than no test.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

---
Generated-by: Claude Code (Opus 5). Authored under human direction; the human contributor reviews the final diff and owns the merge decision.