### PR TITLE
fix(ui): separate project row actions from navigation

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -342,6 +342,7 @@ export const test = base.extend<{
   gitReviewWindow: { page: Page; projectRoot: string };
   invocableSkillsWindow: Page;
   linkColorWindow: Page;
+  projectSidebarWindow: Page;
   promptRailWindow: Page;
   promptRailMotionWindow: Page;
 }>({
@@ -379,6 +380,17 @@ export const test = base.extend<{
       seed: false,
       readinessSelector: '.settingsBotConfigDocLink',
       e2eFixtureScenario: 'settings-bots-onboarding',
+    }, use);
+  },
+  // A real project with several sessions. Shown because the contract under
+  // test is native focus order across independently interactive row controls.
+  projectSidebarWindow: async ({}, use) => {
+    await withE2eWindow({
+      seed: false,
+      readinessSelector: '[data-maka-contract="search-modal"]',
+      e2eFixtureScenario: 'sidebar-search-modal-open',
+      locale: 'zh',
+      showWindow: true,
     }, use);
   },
   // A multi-prompt transcript for the prompt anchor rail. Shown, because every

--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -1,0 +1,64 @@
+import {
+  LONG_SIDEBAR_PROJECT_ID,
+  LONG_SIDEBAR_PROJECT_NAME,
+} from '../src/main/e2e-fixture/seed-helpers';
+import { expect, test } from './fixtures';
+
+test('project navigation and actions remain adjacent keyboard controls', async ({
+  projectSidebarWindow: page,
+}) => {
+  await page.keyboard.press('Escape');
+  await expect(page.locator('[data-maka-contract="search-modal"]')).not.toBeVisible();
+
+  const sidebar = page.getByRole('navigation', { name: '对话列表' });
+  await sidebar.getByRole('radio', { name: '按项目', exact: true }).click();
+
+  const projectRow = sidebar.locator(
+    `[data-project-id="project:${LONG_SIDEBAR_PROJECT_ID}"]`,
+  );
+  const action = projectRow.getByRole('button', {
+    name: `${LONG_SIDEBAR_PROJECT_NAME} 项目操作`,
+    exact: true,
+  });
+  const navigation = projectRow.locator(
+    'button[aria-controls]:not([aria-haspopup="menu"])',
+  );
+  const controlledGroupId = await navigation.getAttribute('aria-controls');
+  expect(controlledGroupId).toBeTruthy();
+  const controlledGroup = page.locator(`[id="${controlledGroupId}"]`);
+  const firstSessionControl = controlledGroup.locator('[data-session-id] button').first();
+
+  await expect(projectRow.locator('button button')).toHaveCount(0);
+  await expect(navigation).toHaveAttribute('aria-expanded', 'true');
+
+  await action.focus();
+  await page.keyboard.press('Tab');
+  await expect(navigation).toBeFocused();
+  await page.keyboard.press('Tab');
+  await expect(firstSessionControl).toBeFocused();
+
+  await navigation.focus();
+  await page.keyboard.press('Enter');
+  await expect(navigation).toHaveAttribute('aria-expanded', 'false');
+  await expect(controlledGroup).toHaveAttribute('aria-hidden', 'true');
+  expect(await controlledGroup.getAttribute('inert')).not.toBeNull();
+  await page.keyboard.press('Enter');
+  await expect(navigation).toHaveAttribute('aria-expanded', 'true');
+  await expect(controlledGroup).toHaveAttribute('aria-hidden', 'false');
+  expect(await controlledGroup.getAttribute('inert')).toBeNull();
+
+  await action.focus();
+  await page.keyboard.press('Enter');
+  const newTaskItem = page.getByRole('menuitem', { name: '新建任务', exact: true });
+  await expect(newTaskItem).toBeVisible();
+  await expect(navigation).toHaveAttribute('aria-expanded', 'true');
+  await page.keyboard.press('Escape');
+  await expect(newTaskItem).not.toBeVisible();
+  await expect(action).toBeFocused();
+
+  await page.keyboard.press('Enter');
+  await page.getByRole('menuitem', { name: '重命名', exact: true }).click();
+  await expect(page.getByRole('dialog', { name: '重命名项目' })).toBeVisible();
+  await page.getByRole('button', { name: '关闭', exact: true }).click();
+  await expect(action).toBeFocused();
+});

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -189,7 +189,8 @@
   -webkit-app-region: no-drag;
 }
 
-.maka-session-row {
+.maka-session-row,
+.maka-project-row {
   position: relative;
   min-width: 0;
   -webkit-app-region: no-drag;
@@ -259,7 +260,8 @@
 
 /* Fixed trailing column so StatusDot ↔ MoreMenu swaps do not reflow the label
  * (hover used to steal ~28px and shove the title left). */
-.maka-session-row-trailing {
+.maka-session-row-trailing,
+.maka-project-row-trailing {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -268,10 +270,11 @@
   min-height: var(--h-control-sm, 24px);
 }
 
-/* SideNavItem owns the row button and only supports non-interactive
- * endContent. The action menu occupies the reserved trailing slot visually,
- * but remains its sibling in the DOM so neither control contains the other. */
-.maka-session-row-action {
+/* SideNavItem owns each row button and only supports non-interactive
+ * endContent. Action menus occupy a reserved trailing slot visually, but stay
+ * siblings in the DOM so neither control contains the other. */
+.maka-session-row-action,
+.maka-project-row-action {
   position: absolute;
   inset-block-start: calc(
     (var(--size-element-md) - var(--size-element-sm)) / 2
@@ -282,6 +285,14 @@
   align-items: center;
   justify-content: center;
   width: var(--h-control-sm, 24px);
+}
+
+/* A collapsible project keeps Astryx's 24px disclosure after endContent. Match
+ * the placeholder's original slot immediately before that disclosure: row
+ * gutter + disclosure + SideNavItem gap. Empty projects have no disclosure and
+ * use the default trailing inset above. */
+.maka-project-row-action[data-position="before-disclosure"] {
+  inset-inline-end: calc(var(--space-2) + var(--space-6) + var(--space-2));
 }
 
 .maka-session-row-trailing-spacer {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -260,8 +260,7 @@
 
 /* Fixed trailing column so StatusDot ↔ MoreMenu swaps do not reflow the label
  * (hover used to steal ~28px and shove the title left). */
-.maka-session-row-trailing,
-.maka-project-row-trailing {
+.maka-session-row-trailing {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -273,8 +272,7 @@
 /* SideNavItem owns each row button and only supports non-interactive
  * endContent. Action menus occupy a reserved trailing slot visually, but stay
  * siblings in the DOM so neither control contains the other. */
-.maka-session-row-action,
-.maka-project-row-action {
+.maka-session-row-action {
   position: absolute;
   inset-block-start: calc(
     (var(--size-element-md) - var(--size-element-sm)) / 2
@@ -291,8 +289,27 @@
  * the placeholder's original slot immediately before that disclosure: row
  * gutter + disclosure + SideNavItem gap. Empty projects have no disclosure and
  * use the default trailing inset above. */
-.maka-project-row-action[data-position="before-disclosure"] {
+.maka-project-row
+  > .maka-session-row-action[data-position="before-disclosure"] {
   inset-inline-end: calc(var(--space-2) + var(--space-6) + var(--space-2));
+}
+
+/* The sibling menu is visually part of the project header, but Astryx's
+ * hover/pressed paint lives on the navigation button itself. Restore that
+ * feedback only while the direct project action is targeted; a plain wrapper
+ * :hover selector would also light the header over nested session rows. */
+@media (hover: hover) {
+  .maka-project-row:has(> .maka-session-row-action:hover)
+    > div
+    > .astryx-side-nav-item {
+    background-color: var(--color-overlay-hover);
+  }
+}
+
+.maka-project-row:has(> .maka-session-row-action button:active)
+  > div
+  > .astryx-side-nav-item {
+  background-color: var(--color-overlay-pressed);
 }
 
 .maka-session-row-trailing-spacer {

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { parseHTML } from 'linkedom';
 import { renderToStaticMarkup } from 'react-dom/server';
+import type { ProjectRecord } from '@maka/core/project';
 import type { SessionSummary } from '@maka/core/session';
 import { LocaleProvider } from '../locale-context.js';
-import { SessionHistoryList, type SessionRowActions } from '../session-history-list.js';
+import {
+  SessionHistoryList,
+  type ProjectRowActions,
+  type SessionRowActions,
+} from '../session-history-list.js';
 
 const session: SessionSummary = {
   id: 'session-1',
@@ -28,6 +34,21 @@ const rowActions: SessionRowActions = {
   onDelete: () => undefined,
 };
 
+const project: ProjectRecord = {
+  id: 'project-1',
+  name: 'Maka',
+  locations: [{ path: '/workspace/maka', isWorktree: false }],
+  available: true,
+  preferredPath: '/workspace/maka',
+};
+
+const projectActions: ProjectRowActions = {
+  onNew: () => undefined,
+  onRename: () => undefined,
+  onArchive: () => undefined,
+  onRestore: () => undefined,
+};
+
 test('renders session navigation and row actions as sibling controls', () => {
   const markup = renderToStaticMarkup(
     <LocaleProvider locale="en">
@@ -41,5 +62,47 @@ test('renders session navigation and row actions as sibling controls', () => {
 
   assert.equal((markup.match(/<button\b/g) ?? []).length, 2);
   assert.match(markup, /class="maka-session-row-action"/);
+  assert.doesNotMatch(markup, /<button\b(?:(?!<\/button>)[\s\S])*<button\b/);
+});
+
+test('renders collapsible project navigation and row actions as sibling controls', () => {
+  const markup = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <SessionHistoryList
+        sessions={[session]}
+        groups={[{ id: project.id, label: project.name, project, sessions: [session] }]}
+        groupVariant="project"
+        projectActions={projectActions}
+        onSelectSession={() => undefined}
+      />
+    </LocaleProvider>,
+  );
+
+  const { document } = parseHTML(markup);
+  const projectRow = document.querySelector('.maka-project-row');
+  const action = document.querySelector<HTMLButtonElement>(
+    'button[aria-label="Maka project actions"]',
+  );
+
+  assert.ok(projectRow);
+  assert.ok(action);
+  const navigation = projectRow.querySelector<HTMLButtonElement>('button[aria-expanded="true"]');
+  const metadata = projectRow.querySelector('.maka-project-item-end');
+  const controlledGroupId = navigation?.getAttribute('aria-controls');
+  const controlledGroup = controlledGroupId
+    ? document.getElementById(controlledGroupId)
+    : null;
+
+  assert.ok(navigation);
+  assert.ok(metadata);
+  assert.ok(controlledGroup);
+  assert.equal(navigation.contains(metadata), true);
+  assert.equal(navigation.contains(action), false);
+  assert.equal(metadata.textContent, '1');
+  assert.equal(controlledGroup.getAttribute('aria-hidden'), 'false');
+  assert.equal(action.parentElement?.className, 'maka-project-row-action');
+  assert.equal(action.parentElement?.getAttribute('data-position'), 'before-disclosure');
+  assert.equal(action.parentElement?.parentElement, projectRow);
+  assert.equal(projectRow.querySelector('button button'), null);
   assert.doesNotMatch(markup, /<button\b(?:(?!<\/button>)[\s\S])*<button\b/);
 });

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -86,7 +86,9 @@ test('renders collapsible project navigation and row actions as sibling controls
 
   assert.ok(projectRow);
   assert.ok(action);
-  const navigation = projectRow.querySelector<HTMLButtonElement>('button[aria-expanded="true"]');
+  const navigation = projectRow.querySelector<HTMLButtonElement>(
+    ':scope > div > button[aria-controls]',
+  );
   const metadata = projectRow.querySelector('.maka-project-item-end');
   const controlledGroupId = navigation?.getAttribute('aria-controls');
   const controlledGroup = controlledGroupId
@@ -100,9 +102,8 @@ test('renders collapsible project navigation and row actions as sibling controls
   assert.equal(navigation.contains(action), false);
   assert.equal(metadata.textContent, '1');
   assert.equal(controlledGroup.getAttribute('aria-hidden'), 'false');
-  assert.equal(action.parentElement?.className, 'maka-project-row-action');
-  assert.equal(action.parentElement?.getAttribute('data-position'), 'before-disclosure');
-  assert.equal(action.parentElement?.parentElement, projectRow);
-  assert.equal(projectRow.querySelector('button button'), null);
+  const projectButtons = [...projectRow.querySelectorAll('button')];
+  assert.equal(projectButtons[0], action);
+  assert.equal(projectButtons[1], navigation);
   assert.doesNotMatch(markup, /<button\b(?:(?!<\/button>)[\s\S])*<button\b/);
 });

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -372,7 +372,17 @@ function ProjectNavRow(props: {
   const hasActions = props.project !== undefined && props.projectActions !== undefined;
   return (
     <div data-project-id={props.groupKey} className="maka-project-row">
+      {props.project && props.projectActions ? (
+        <ProjectItemActions
+          key="actions"
+          project={props.project}
+          actions={props.projectActions}
+          onStartRename={props.onStartRename}
+          position={hasSessions ? 'before-disclosure' : 'trailing'}
+        />
+      ) : null}
       <SideNavItem
+        key="navigation"
         label={props.label}
         icon={FolderOpen}
         collapsible={hasSessions ? { defaultIsCollapsed: false } : undefined}
@@ -389,14 +399,6 @@ function ProjectNavRow(props: {
           <VStack gap={0.5}>{props.sessions.map((session) => props.renderSession(session))}</VStack>
         ) : undefined}
       </SideNavItem>
-      {props.project && props.projectActions ? (
-        <ProjectItemActions
-          project={props.project}
-          actions={props.projectActions}
-          onStartRename={props.onStartRename}
-          position={hasSessions ? 'before-disclosure' : 'trailing'}
-        />
-      ) : null}
     </div>
   );
 }
@@ -477,7 +479,7 @@ function ProjectItemMeta(props: {
       )}
       <Badge variant="neutral" label={props.sessionCount} />
       {props.reserveAction ? (
-        <span className="maka-project-row-trailing" aria-hidden="true" />
+        <span className="maka-session-row-trailing" aria-hidden="true" />
       ) : null}
     </span>
   );
@@ -569,12 +571,7 @@ function ProjectItemActions(props: {
       ];
 
   return (
-    <span
-      className="maka-project-row-action"
-      data-position={props.position}
-      ref={trailingRef}
-      onKeyDown={(event) => event.stopPropagation()}
-    >
+    <span className="maka-session-row-action" data-position={props.position} ref={trailingRef}>
       <MoreMenu
         size="sm"
         label={copy.projectActionsAriaLabel(project.name)}

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -6,7 +6,6 @@ import {
   useState,
   type KeyboardEvent,
   type ReactNode,
-  type Ref,
 } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
 import type { ProjectRecord } from '@maka/core/project';
@@ -45,6 +44,7 @@ import { getConversationCopy } from './conversation-copy.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
+type ProjectRowActionId = 'new' | 'relink' | 'rename' | 'archive' | 'restore';
 type SessionHistoryGroupVariant = 'conversation' | 'project';
 
 export interface SessionRowActions {
@@ -369,6 +369,7 @@ function ProjectNavRow(props: {
   // Collapsible only when there is a real session subtree. An empty VStack is
   // still truthy children for Astryx (!!children) and fabricates a disclosure.
   const hasSessions = props.sessions.length > 0;
+  const hasActions = props.project !== undefined && props.projectActions !== undefined;
   return (
     <div data-project-id={props.groupKey} className="maka-project-row">
       <SideNavItem
@@ -376,11 +377,10 @@ function ProjectNavRow(props: {
         icon={FolderOpen}
         collapsible={hasSessions ? { defaultIsCollapsed: false } : undefined}
         endContent={
-          <ProjectItemEndContent
+          <ProjectItemMeta
             project={props.project}
             sessionCount={props.sessions.length}
-            actions={props.projectActions}
-            onStartRename={props.onStartRename}
+            reserveAction={hasActions}
           />
         }
       >
@@ -389,26 +389,15 @@ function ProjectNavRow(props: {
           <VStack gap={0.5}>{props.sessions.map((session) => props.renderSession(session))}</VStack>
         ) : undefined}
       </SideNavItem>
+      {props.project && props.projectActions ? (
+        <ProjectItemActions
+          project={props.project}
+          actions={props.projectActions}
+          onStartRename={props.onStartRename}
+          position={hasSessions ? 'before-disclosure' : 'trailing'}
+        />
+      ) : null}
     </div>
-  );
-}
-
-/** Keeps trailing controls from activating the parent SideNavItem button. */
-function EndContentHitTarget(props: {
-  children: ReactNode;
-  className?: string;
-  ref?: Ref<HTMLSpanElement>;
-}) {
-  return (
-    <span
-      ref={props.ref}
-      className={props.className}
-      onClick={(event) => event.stopPropagation()}
-      onPointerDown={(event) => event.stopPropagation()}
-      onKeyDown={(event) => event.stopPropagation()}
-    >
-      {props.children}
-    </span>
   );
 }
 
@@ -475,18 +464,37 @@ const SessionNavRow = memo(function SessionNavRow(props: {
   );
 });
 
-function ProjectItemEndContent(props: {
+function ProjectItemMeta(props: {
   project?: ProjectRecord;
   sessionCount: number;
-  actions?: ProjectRowActions;
-  onStartRename(opener: HTMLElement | null): void;
+  reserveAction: boolean;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
-  const endRef = useRef<HTMLSpanElement>(null);
+  return (
+    <span className="maka-session-row-end maka-project-item-end">
+      {props.project && !props.project.available && (
+        <AlertTriangle size={ICON_SIZE.meta} aria-label={copy.projectUnavailable} />
+      )}
+      <Badge variant="neutral" label={props.sessionCount} />
+      {props.reserveAction ? (
+        <span className="maka-project-row-trailing" aria-hidden="true" />
+      ) : null}
+    </span>
+  );
+}
+
+function ProjectItemActions(props: {
+  project: ProjectRecord;
+  actions: ProjectRowActions;
+  onStartRename(opener: HTMLElement | null): void;
+  position: 'before-disclosure' | 'trailing';
+}) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
+  const trailingRef = useRef<HTMLSpanElement>(null);
   const [menuOpen, setMenuOpen] = useState(false);
-  const [pendingAction, setPendingAction] = useState<string | null>(null);
+  const [pendingAction, setPendingAction] = useState<ProjectRowActionId | null>(null);
   const mountedRef = useMountedRef();
-  const pendingActionRef = useRef<string | null>(null);
+  const pendingActionRef = useRef<ProjectRowActionId | null>(null);
   const pendingMenuIntentRef = useRef<(() => void) | null>(null);
   const project = props.project;
   const actions = props.actions;
@@ -498,7 +506,7 @@ function ProjectItemEndContent(props: {
     [],
   );
 
-  function runProjectAction(actionId: string, action: () => void | Promise<void>) {
+  function runProjectAction(actionId: ProjectRowActionId, action: () => void | Promise<void>) {
     if (pendingActionRef.current) return;
     pendingActionRef.current = actionId;
     setPendingAction(actionId);
@@ -514,77 +522,74 @@ function ProjectItemEndContent(props: {
     })();
   }
 
-  // Projects keep a permanent MoreMenu (SideNavEndContent pattern). Hover-only
-  // would fire on nested session rows if wired to the project wrapper.
-  const menuItems = project && actions
-    ? project.archivedAt !== undefined
-      ? [
-          {
-            label: copy.projectRestore,
-            icon: ArchiveRestore,
-            onClick: () => runProjectAction('restore', () => actions.onRestore(project.id)),
-          },
-        ]
-      : [
-          ...(project.available
+  // Projects keep a permanent MoreMenu. It is a sibling of SideNavItem so the
+  // row's collapse button and the menu remain separate interactive controls.
+  const menuItems = project.archivedAt !== undefined
+    ? [
+        {
+          label: copy.projectRestore,
+          icon: ArchiveRestore,
+          onClick: () => runProjectAction('restore', () => actions.onRestore(project.id)),
+        },
+      ]
+    : [
+        ...(project.available
+          ? [
+              {
+                label: copy.projectNewTask,
+                icon: SquarePen,
+                onClick: () => runProjectAction('new', () => actions.onNew(project.id)),
+              },
+            ]
+          : actions.onRelink
             ? [
-                {
-                  label: copy.projectNewTask,
-                  icon: SquarePen,
-                  onClick: () => runProjectAction('new', () => actions.onNew(project.id)),
-                },
-              ]
-            : actions.onRelink
-              ? [
-                {
-                  label: copy.projectRelink,
-                  icon: Plug,
-                  onClick: () => runProjectAction('relink', () => actions.onRelink!(project.id)),
-                },
-              ]
-              : []),
-          {
-            label: copy.projectRename,
-            icon: Pencil,
-            onClick: () => {
-              // Read now, while the trigger is still the thing the user is on:
-              // by the time the intent runs the menu has closed and focus is
-              // mid-handover.
-              const opener = endRef.current?.querySelector<HTMLElement>('button') ?? null;
-              pendingMenuIntentRef.current = () => props.onStartRename(opener);
-            },
+              {
+                label: copy.projectRelink,
+                icon: Plug,
+                onClick: () => runProjectAction('relink', () => actions.onRelink!(project.id)),
+              },
+            ]
+            : []),
+        {
+          label: copy.projectRename,
+          icon: Pencil,
+          onClick: () => {
+            // Read now, while the trigger is still the thing the user is on:
+            // by the time the intent runs the menu has closed and focus is
+            // mid-handover.
+            const opener = trailingRef.current?.querySelector<HTMLElement>('button') ?? null;
+            pendingMenuIntentRef.current = () => props.onStartRename(opener);
           },
-          {
-            label: copy.projectArchive,
-            icon: Archive,
-            onClick: () => runProjectAction('archive', () => actions.onArchive(project.id)),
-          },
-        ]
-    : [];
+        },
+        {
+          label: copy.projectArchive,
+          icon: Archive,
+          onClick: () => runProjectAction('archive', () => actions.onArchive(project.id)),
+        },
+      ];
 
   return (
-    <EndContentHitTarget className="maka-session-row-end maka-project-item-end" ref={endRef}>
-      {project && !project.available && (
-        <AlertTriangle size={ICON_SIZE.meta} aria-label={copy.projectUnavailable} />
-      )}
-      <Badge variant="neutral" label={props.sessionCount} />
-      {menuItems.length > 0 && (
-        <MoreMenu
-          size="sm"
-          label={copy.projectActionsAriaLabel(project?.name ?? '')}
-          isDisabled={pendingAction !== null}
-          isMenuOpen={menuOpen}
-          onOpenChange={(open) => {
-            setMenuOpen(open);
-            if (open) return;
-            const intent = pendingMenuIntentRef.current;
-            pendingMenuIntentRef.current = null;
-            if (intent) window.requestAnimationFrame(intent);
-          }}
-          items={menuItems}
-        />
-      )}
-    </EndContentHitTarget>
+    <span
+      className="maka-project-row-action"
+      data-position={props.position}
+      ref={trailingRef}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      <MoreMenu
+        size="sm"
+        label={copy.projectActionsAriaLabel(project.name)}
+        isDisabled={pendingAction !== null}
+        isMenuOpen={menuOpen}
+        onOpenChange={(open) => {
+          setMenuOpen(open);
+          if (open) return;
+          const intent = pendingMenuIntentRef.current;
+          pendingMenuIntentRef.current = null;
+          if (intent) window.requestAnimationFrame(intent);
+        }}
+        items={menuItems}
+      />
+    </span>
   );
 }
 


### PR DESCRIPTION
## Summary

- move the project `MoreMenu` out of `SideNavItem.endContent`, so project navigation and row actions render as sibling buttons instead of nested interactive controls
- keep unavailable state and session-count metadata inside the navigation button, with a reserved trailing slot that preserves the existing layout for collapsible and empty projects
- add a focused project-row DOM regression test covering sibling controls, collapsible ARIA wiring, and the absence of nested buttons

This completes the remaining project-row half of the issue; the session-row half was fixed in #2566. It intentionally keeps the change local to Maka rather than expanding the Astryx `SideNavItem` API in this PR.

Fixes #2360

## Verification

- `npm --workspace @maka/desktop run build:workspace-deps`
- `npm --workspace @maka/ui run test` — 137 passed
- `npm --workspace @maka/desktop run typecheck`
- `npx biome check packages/ui/src/session-history-list.tsx packages/ui/src/__tests__/session-history-row-actions.test.tsx apps/desktop/src/renderer/styles/sidebar.css`
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook` — 126 stories passed
- Storybook `Native Conversation`, grouped by project: 11 project rows, 0 nested buttons, no console errors; collapse, unavailable/relink, archived/restore, and rename focus-return paths verified

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
