### PR TITLE
fix(ui): collapse the composer send slot to one control

### DIFF
--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1948,6 +1948,12 @@ function AppShellContent({
       revision && activeIdRef.current === revision.draftSessionId,
     );
     const slashCommand = parseDesktopSlashCommand(text);
+    // The composer has one submit; mid-turn it means steering, and this is
+    // where that reading lives. Slash commands are exempt because they are
+    // control instructions to the shell, not text for the running turn.
+    if (!slashCommand && (turnActive || activeStreamingLive)) {
+      return steerWithText(text);
+    }
     if (
       revisionSend &&
       revision &&
@@ -2139,15 +2145,6 @@ function AppShellContent({
       }
       return false;
     }
-  }
-
-  function submitWhileStreaming(
-    text: string,
-    metadata?: ComposerSendMetadata,
-  ): Promise<boolean | void> {
-    return parseDesktopSlashCommand(text)
-      ? sendWithAttachments(text, metadata)
-      : steerWithText(text);
   }
 
   const stop = createAppShellStopAction({
@@ -2798,7 +2795,6 @@ function AppShellContent({
                   processing={showProcessingIndicator && !activeStreamingLive}
                   continuing={showContinuingIndicator && !activeStreamingLive}
                   onSend={sendWithAttachments}
-                  onStreamingSubmit={submitWhileStreaming}
                   onStop={stop}
                   revisionNotice={
                     revisionDraft && activeId === revisionDraft.draftSessionId

--- a/apps/desktop/src/renderer/quote-companion-panel.tsx
+++ b/apps/desktop/src/renderer/quote-companion-panel.tsx
@@ -205,6 +205,9 @@ export function QuoteCompanionPanel(props: {
             <Composer
               ref={composerRef}
               onSend={async (text) => {
+                // Mid-turn the same submit is steering — the side chat has no
+                // slash commands, so the split is just the turn's state.
+                if (companion.streaming) return companion.steer(text);
                 try {
                   preflightAttachmentItems(pendingAttachments, locale);
                 } catch (error) {
@@ -227,7 +230,6 @@ export function QuoteCompanionPanel(props: {
                 return accepted;
               }}
               onStop={() => void companion.stop()}
-              onStreamingSubmit={(text: string) => companion.steer(text)}
               hidden={Boolean(activeInteraction)}
               streaming={companion.streaming}
               processing={companion.processing}

--- a/packages/ui/src/__tests__/composer-send-toggle.test.tsx
+++ b/packages/ui/src/__tests__/composer-send-toggle.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * The composer's send slot holds ONE control (Astryx's send/stop toggle), and
+ * mid-turn it reads Stop while the draft is empty. This is the shape the slot
+ * drifted out of once already — a Stop button and a Steer button side by side —
+ * so the count is asserted, not just the label.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { Composer } from '../composer.js';
+import { LocaleProvider } from '../locale-context.js';
+
+function renderComposer(streaming: boolean): string {
+  return renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <Composer streaming={streaming} onSend={() => undefined} onStop={() => undefined} />
+    </LocaleProvider>,
+  );
+}
+
+function sendSlotButtons(markup: string): string[] {
+  const slot = markup.split('class="maka-composer-right-controls"').pop() ?? '';
+  return slot.match(/aria-label="[^"]*"/g) ?? [];
+}
+
+test('an idle composer offers Send alone', () => {
+  const buttons = sendSlotButtons(renderComposer(false));
+  assert.deepEqual(buttons, ['aria-label="Send"']);
+});
+
+test('a turn in flight turns the same single control into Stop', () => {
+  const buttons = sendSlotButtons(renderComposer(true));
+  assert.deepEqual(buttons, ['aria-label="Stop"']);
+});

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -194,10 +194,10 @@ export const Composer = forwardRef<
     hidden?: boolean;
     /**
      * When true, a turn is in flight — live output OR the pre-first-token wait.
-     * Send becomes Stop. The ＋ menu and permission control stay reachable
-     * (#1444); the model and thinking menus stay mounted but lock with an
-     * explanatory tooltip, so the footer row never reflows mid-turn; import
-     * stays blocked mid-turn.
+     * Send becomes Stop while the draft is empty. The ＋ menu and permission
+     * control stay reachable (#1444); the model and thinking menus stay
+     * mounted but lock with an explanatory tooltip, so the footer row never
+     * reflows mid-turn; import stays blocked mid-turn.
      */
     streaming?: boolean;
     /**
@@ -216,12 +216,12 @@ export const Composer = forwardRef<
     draftKey?: string;
     /** Optional host persistence for reload-safe draft scopes. */
     draftPersistence?: ComposerDraftPersistence;
+    /**
+     * The composer's one submit. Mid-turn the host decides what handing the
+     * draft over means there — steering, a control command — because that is a
+     * reading of the same action, not a second control on this surface.
+     */
     onSend(
-      text: string,
-      metadata?: ComposerSendMetadata,
-    ): boolean | void | Promise<boolean | void>;
-    /** Submit while a turn is active; the host owns control-command versus steering semantics. */
-    onStreamingSubmit?(
       text: string,
       metadata?: ComposerSendMetadata,
     ): boolean | void | Promise<boolean | void>;
@@ -1041,10 +1041,7 @@ export const Composer = forwardRef<
     setSendPending(true);
     let sent: boolean | void;
     try {
-      const submit = props.streaming && props.onStreamingSubmit
-        ? props.onStreamingSubmit
-        : props.onSend;
-      sent = await submit(
+      sent = await props.onSend(
         text,
         workspaceFileReferences.length > 0 ? { workspaceFileReferences } : undefined,
       );
@@ -1220,6 +1217,12 @@ export const Composer = forwardRef<
   // The disabled Send is explanatory only in the no-model dead-end; other
   // disabled reasons (empty draft, in-flight import) keep the neutral label.
   const sendTitle = noModelConnection && !props.disabled ? copy.noModelSendTitle : copy.sendLabel;
+  // One slot, one button, two states — Astryx's send/stop toggle. Mid-turn an
+  // empty draft has nothing to submit, so the slot is Stop; the moment there is
+  // a draft, handing it over is the only meaningful action there and the button
+  // returns to Send (the host reads that as steering). Stop is not lost in that
+  // window: Esc interrupts from the input, which is where the hands already are.
+  const stopShown = props.streaming === true && !text.trim();
   const modelChipLabel = props.modelLabel?.trim() || copy.selectModel;
   // Mid-turn the model and thinking menus stay mounted but locked, each
   // carrying the reason in its own words (model vs thinking level) — the
@@ -1769,53 +1772,30 @@ export const Composer = forwardRef<
           sendActions={(
             <div className="maka-composer-right-controls" />
           )}
-          sendButton={props.streaming && props.onStreamingSubmit ? (
-            <div className="maka-composer-running-actions">
-              <IconButton
-                variant="ghost"
-                type="button"
-                isDisabled={props.stopPending}
-                label={props.stopPending ? copy.stopping : copy.stopLabel}
-                aria-busy={props.stopPending ? 'true' : undefined}
-                data-pending={props.stopPending ? 'true' : undefined}
-                onClick={() => {
-                  if (props.stopPending) return;
-                  void props.onStop();
-                }}
-                icon={<Square size={ICON_SIZE.control} aria-hidden="true" />}
-              />
-              <IconButton
-                variant="primary"
-                type="submit"
-                isDisabled={sendDisabled}
-                label={copy.steerLabel}
-                aria-busy={sendPending ? 'true' : undefined}
-                data-pending={sendPending ? 'true' : undefined}
-                tooltip={copy.steerLabel}
-                icon={<ArrowUp size={ICON_SIZE.chrome} aria-hidden="true" />}
-              />
-            </div>
-          ) : props.streaming ? (
-            <UiButton
-              variant="primary"
+          sendButton={stopShown ? (
+            <IconButton
+              variant="secondary"
+              type="button"
               isDisabled={props.stopPending}
+              label={props.stopPending ? copy.stopping : copy.stopLabel}
+              aria-busy={props.stopPending ? 'true' : undefined}
+              data-pending={props.stopPending ? 'true' : undefined}
+              tooltip={props.stopPending ? copy.stopping : copy.stopLabel}
               onClick={() => {
                 if (props.stopPending) return;
                 void props.onStop();
               }}
-              aria-busy={props.stopPending ? 'true' : undefined}
-              data-pending={props.stopPending ? 'true' : undefined}
-              label={props.stopPending ? copy.stopping : copy.stopLabel}
+              icon={<Square size={ICON_SIZE.control} aria-hidden="true" />}
             />
           ) : (
             <IconButton
               variant="primary"
               type="submit"
               isDisabled={sendDisabled}
-              label={copy.sendLabel}
+              label={props.streaming ? copy.steerLabel : copy.sendLabel}
               aria-busy={sendPending ? 'true' : undefined}
               data-pending={sendPending ? 'true' : undefined}
-              tooltip={sendTitle}
+              tooltip={props.streaming ? copy.steerLabel : sendTitle}
               icon={<ArrowUp size={ICON_SIZE.chrome} aria-hidden="true" />}
             />
           )}

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -57,7 +57,6 @@
    type lives on `.maka-quote-chip-text`, which is why the derived scan needed
    two arms rather than three to see it at all. */
 .maka-quote-chip-collapsed { height: var(--h-control-sm); max-width: 240px; align-items: center; padding-block: 2px; border-radius: var(--radius-pill); }
-.maka-composer-running-actions { display: inline-flex; align-items: center; gap: var(--space-1); }
 .maka-quote-chip-removable { padding-right: 2px; }
 .maka-quote-chip-readonly { padding-right: 8px; }
 .maka-quote-chip-icon { width: var(--icon-meta); height: var(--icon-meta); flex: 0 0 auto; color: var(--muted-foreground); }


### PR DESCRIPTION
## Summary

Mid-turn the composer's send slot held two buttons: a ghost Stop and a primary Steer arrow. That is a control group standing in the position Astryx defines as one send/stop toggle (`ChatSendButton` — "a circular send/stop toggle button"), and the prop doc right above it still described the older, correct contract ("Send becomes Stop"). The second button was redundant on its own terms too: Enter already steered mid-turn, and Esc already interrupts.

The slot is one button with two states again. While a turn is in flight and the draft is empty there is nothing to submit, so it reads Stop; the moment there is a draft, handing it over is the only meaningful action in that position and the button returns to the arrow (labelled "Steer" mid-turn). Stop is not lost in that window — Esc interrupts from the input, where the hands already are.

With a single submit on the surface, `onStreamingSubmit` had nothing left to mean: what handing the draft over *does* mid-turn is the host's reading of one action, not a second control. Both hosts now fold steering into `onSend` — the shell exempts slash commands, which are control instructions rather than text for the running turn, and the side chat has none to exempt. Dropping the prop takes the composer's knowledge of steering with it.

<img width="2944" height="1298" alt="image" src="https://github.com/user-attachments/assets/b02dfd25-41d2-479c-bfbe-86b1a5fd73bd" />

## Verification

- `packages/ui` + `apps/desktop` typecheck (preload, main, renderer, storybook)
- `npm run format:check`
- New `packages/ui/src/__tests__/composer-send-toggle.test.tsx` — asserts the slot renders exactly one control (Send when idle, Stop mid-turn). It fails against the previous markup, which rendered two.
- Storybook, driven by hand: mid-turn with an empty draft the slot is a 32px circular secondary Stop; typing flips the same slot to the primary arrow with `aria-label="Steer"` and `type="submit"`; idle reads Send. No console errors.
- Not run: the desktop E2E suite (needs a full Electron build; no existing spec selects the stop button by name) — left to CI.

## Review focus

The one deliberate omission is switching to Astryx's `ChatSendButton`. It resolves `isDisabled` as `!isStopShown && isDisabled`, so a stop state can never be disabled, and we would lose `stopPending` ("Stopping…"). `IconButton` is already an Astryx primitive, so the swap would buy a circular xstyle at the cost of product semantics.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
