### PR TITLE
fix(ui): show only the stop button while streaming

### DIFF
--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -1769,43 +1769,19 @@ export const Composer = forwardRef<
           sendActions={(
             <div className="maka-composer-right-controls" />
           )}
-          sendButton={props.streaming && props.onStreamingSubmit ? (
-            <div className="maka-composer-running-actions">
-              <IconButton
-                variant="ghost"
-                type="button"
-                isDisabled={props.stopPending}
-                label={props.stopPending ? copy.stopping : copy.stopLabel}
-                aria-busy={props.stopPending ? 'true' : undefined}
-                data-pending={props.stopPending ? 'true' : undefined}
-                onClick={() => {
-                  if (props.stopPending) return;
-                  void props.onStop();
-                }}
-                icon={<Square size={ICON_SIZE.control} aria-hidden="true" />}
-              />
-              <IconButton
-                variant="primary"
-                type="submit"
-                isDisabled={sendDisabled}
-                label={copy.steerLabel}
-                aria-busy={sendPending ? 'true' : undefined}
-                data-pending={sendPending ? 'true' : undefined}
-                tooltip={copy.steerLabel}
-                icon={<ArrowUp size={ICON_SIZE.chrome} aria-hidden="true" />}
-              />
-            </div>
-          ) : props.streaming ? (
-            <UiButton
-              variant="primary"
+          sendButton={props.streaming ? (
+            <IconButton
+              variant="ghost"
+              type="button"
               isDisabled={props.stopPending}
+              label={props.stopPending ? copy.stopping : copy.stopLabel}
+              aria-busy={props.stopPending ? 'true' : undefined}
+              data-pending={props.stopPending ? 'true' : undefined}
               onClick={() => {
                 if (props.stopPending) return;
                 void props.onStop();
               }}
-              aria-busy={props.stopPending ? 'true' : undefined}
-              data-pending={props.stopPending ? 'true' : undefined}
-              label={props.stopPending ? copy.stopping : copy.stopLabel}
+              icon={<Square size={ICON_SIZE.control} aria-hidden="true" />}
             />
           ) : (
             <IconButton


### PR DESCRIPTION
## Summary
- While a turn is streaming, the composer now shows a single stop control instead of both a stop button and a steer/send button at once.
- Removes the steer send button from the running-actions row; the stop button keeps its original ghost + square-icon styling.

## Test plan
- [x] Start a turn and confirm the composer shows only the stop (square) button while streaming
- [x] Confirm clicking stop still aborts the turn
- [x] Confirm the send (arrow-up) button returns once streaming ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)