### PR TITLE
fix(desktop): dismiss a completed Agent Graph panel

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -76,6 +76,7 @@
     "electron": "43.2.0",
     "electron-builder": "26.15.3",
     "esbuild": "^0.27.7",
+    "linkedom": "^0.18.13",
     "simple-icons": "16.28.0",
     "storybook": "^10.4.6",
     "vite": "^8.1.5"

--- a/apps/desktop/src/main/__tests__/agent-graph-panel-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel-visibility.test.ts
@@ -122,7 +122,7 @@ describe('dismiss and reconcile', () => {
       reconcileAgentGraphPanelDismissals(
         { 'session-1': 'graph-1' },
         'session-1',
-        { graphId: 'graph-2', status: 'active' },
+        { rootSessionId: 'session-1', graphId: 'graph-2', status: 'active' },
       ),
       {},
     );
@@ -133,7 +133,7 @@ describe('dismiss and reconcile', () => {
       reconcileAgentGraphPanelDismissals(
         { 'session-1': 'graph-1' },
         'session-1',
-        { graphId: 'graph-1', status: 'active' },
+        { rootSessionId: 'session-1', graphId: 'graph-1', status: 'active' },
       ),
       {},
     );
@@ -144,9 +144,20 @@ describe('dismiss and reconcile', () => {
       reconcileAgentGraphPanelDismissals(
         { 'session-1': 'graph-1' },
         'session-1',
-        { graphId: 'graph-1', status: 'completed' },
+        { rootSessionId: 'session-1', graphId: 'graph-1', status: 'completed' },
       ),
       { 'session-1': 'graph-1' },
+    );
+  });
+
+  it('does not clear a dismissal against a snapshot still owned by the previous session', () => {
+    assert.deepEqual(
+      reconcileAgentGraphPanelDismissals(
+        { 'session-a': 'graph-a' },
+        'session-a',
+        { rootSessionId: 'session-b', graphId: 'graph-b', status: 'completed' },
+      ),
+      { 'session-a': 'graph-a' },
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/agent-graph-panel-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel-visibility.test.ts
@@ -1,0 +1,152 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  dismissAgentGraphPanel,
+  isAgentGraphPanelDismissible,
+  reconcileAgentGraphPanelDismissals,
+  shouldShowAgentGraphPanel,
+} from '../../renderer/agent-graph-panel-visibility.js';
+
+describe('isAgentGraphPanelDismissible', () => {
+  it('allows hiding a graph that no longer has active work', () => {
+    assert.equal(isAgentGraphPanelDismissible('completed'), true);
+    assert.equal(isAgentGraphPanelDismissible('stopped'), true);
+    assert.equal(isAgentGraphPanelDismissible('failed'), true);
+  });
+
+  it('keeps the panel while the graph is still in flight', () => {
+    for (const status of ['empty', 'active', 'closing', 'waiting'] as const) {
+      assert.equal(isAgentGraphPanelDismissible(status), false, status);
+    }
+    assert.equal(isAgentGraphPanelDismissible(undefined), false);
+  });
+});
+
+describe('shouldShowAgentGraphPanel', () => {
+  it('hides a dismissed completed graph for that session', () => {
+    assert.equal(
+      shouldShowAgentGraphPanel({
+        enabled: true,
+        hasGraphActivity: true,
+        error: false,
+        sessionId: 'session-1',
+        graphId: 'graph-1',
+        status: 'completed',
+        dismissedBySession: { 'session-1': 'graph-1' },
+      }),
+      false,
+    );
+  });
+
+  it('shows a new graph after the previous one was dismissed', () => {
+    assert.equal(
+      shouldShowAgentGraphPanel({
+        enabled: true,
+        hasGraphActivity: true,
+        error: false,
+        sessionId: 'session-1',
+        graphId: 'graph-2',
+        status: 'active',
+        dismissedBySession: { 'session-1': 'graph-1' },
+      }),
+      true,
+    );
+  });
+
+  it('shows the same graph again if it leaves a terminal state', () => {
+    assert.equal(
+      shouldShowAgentGraphPanel({
+        enabled: true,
+        hasGraphActivity: true,
+        error: false,
+        sessionId: 'session-1',
+        graphId: 'graph-1',
+        status: 'active',
+        dismissedBySession: { 'session-1': 'graph-1' },
+      }),
+      true,
+    );
+  });
+
+  it('does not apply another session\'s dismissal', () => {
+    assert.equal(
+      shouldShowAgentGraphPanel({
+        enabled: true,
+        hasGraphActivity: true,
+        error: false,
+        sessionId: 'session-2',
+        graphId: 'graph-1',
+        status: 'completed',
+        dismissedBySession: { 'session-1': 'graph-1' },
+      }),
+      true,
+    );
+  });
+
+  it('keeps the existing empty-state hide when graph mode is off', () => {
+    assert.equal(
+      shouldShowAgentGraphPanel({
+        enabled: false,
+        hasGraphActivity: false,
+        error: false,
+        sessionId: 'session-1',
+        dismissedBySession: {},
+      }),
+      false,
+    );
+  });
+
+  it('still shows an enabled graph that has not produced activity yet', () => {
+    assert.equal(
+      shouldShowAgentGraphPanel({
+        enabled: true,
+        hasGraphActivity: false,
+        error: false,
+        sessionId: 'session-1',
+        dismissedBySession: {},
+      }),
+      true,
+    );
+  });
+});
+
+describe('dismiss and reconcile', () => {
+  it('records the dismissed graph for the session', () => {
+    assert.deepEqual(dismissAgentGraphPanel({}, 'session-1', 'graph-1'), {
+      'session-1': 'graph-1',
+    });
+  });
+
+  it('drops a stale dismissal when a later snapshot is a different graph', () => {
+    assert.deepEqual(
+      reconcileAgentGraphPanelDismissals(
+        { 'session-1': 'graph-1' },
+        'session-1',
+        { graphId: 'graph-2', status: 'active' },
+      ),
+      {},
+    );
+  });
+
+  it('drops a stale dismissal when the same graph becomes active again', () => {
+    assert.deepEqual(
+      reconcileAgentGraphPanelDismissals(
+        { 'session-1': 'graph-1' },
+        'session-1',
+        { graphId: 'graph-1', status: 'active' },
+      ),
+      {},
+    );
+  });
+
+  it('keeps a matching terminal dismissal', () => {
+    assert.deepEqual(
+      reconcileAgentGraphPanelDismissals(
+        { 'session-1': 'graph-1' },
+        'session-1',
+        { graphId: 'graph-1', status: 'completed' },
+      ),
+      { 'session-1': 'graph-1' },
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
@@ -1,0 +1,181 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { AgentGraphClientSnapshot } from '@maka/runtime/stream-graph-read-model';
+import { AgentGraphPanel } from '../../renderer/agent-graph-panel.js';
+
+type GraphListener = () => void;
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  matchMedia: globalThis.matchMedia,
+  HTMLElement: globalThis.HTMLElement,
+  HTMLIFrameElement: globalThis.HTMLIFrameElement,
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+  cancelAnimationFrame: globalThis.cancelAnimationFrame,
+  IS_REACT_ACT_ENVIRONMENT: (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT,
+};
+
+afterEach(() => {
+  Object.assign(globalThis, originalGlobals);
+});
+
+function snapshot(
+  overrides: Pick<AgentGraphClientSnapshot, 'graphId' | 'status'> &
+    Partial<AgentGraphClientSnapshot>,
+): AgentGraphClientSnapshot {
+  return {
+    schemaVersion: 1,
+    rootSessionId: 'session-1',
+    orchestrationMode: 'graph',
+    snapshotVersion: '1',
+    scheduleRevision: 1,
+    topologyFingerprint: 'fp',
+    closed: overrides.status === 'completed',
+    operators: [],
+    edges: [],
+    work: [],
+    reconciliationFailures: [],
+    stoppedTargets: [],
+    claims: [],
+    recentControlDecisions: [],
+    recentActivity: [],
+    terminalHistory: { records: [] },
+    omitted: {
+      operators: 0,
+      edges: 0,
+      work: 0,
+      reconciliationFailures: 0,
+      stoppedTargets: 0,
+      claims: 0,
+      controlDecisions: 0,
+      recentActivity: 0,
+    },
+    ...overrides,
+  };
+}
+
+function installGraphRenderer(initial: AgentGraphClientSnapshot): {
+  container: Element;
+  root: Root;
+  setSnapshot(next: AgentGraphClientSnapshot): Promise<void>;
+} {
+  const { document, window } = parseHTML('<div id="root"></div>');
+  const matchMedia = (media: string) => ({
+    matches: false,
+    media,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent: () => false,
+  });
+  Object.assign(window, { matchMedia });
+  Object.assign(globalThis, {
+    document,
+    window,
+    matchMedia,
+    HTMLElement: window.HTMLElement,
+    HTMLIFrameElement: window.HTMLIFrameElement ?? class HTMLIFrameElement {},
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(callback, 0),
+    cancelAnimationFrame: (handle: number) => clearTimeout(handle),
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+
+  let current = initial;
+  const listeners = new Set<GraphListener>();
+  (window as unknown as { maka: unknown }).maka = {
+    graphs: {
+      getSnapshot: async () => current,
+      inspectOperator: async () => {
+        throw new Error('inspectOperator is unused by AgentGraphPanel');
+      },
+      subscribe: (_sessionId: string, listener: GraphListener) => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+      stop: async () => undefined,
+    },
+  };
+
+  const container = document.querySelector('#root');
+  assert.ok(container);
+  const root = createRoot(container);
+  return {
+    container,
+    root,
+    async setSnapshot(next) {
+      current = next;
+      await act(async () => {
+        for (const listener of [...listeners]) listener();
+        await Promise.resolve();
+      });
+    },
+  };
+}
+
+async function renderPanel(
+  initial: AgentGraphClientSnapshot,
+): Promise<ReturnType<typeof installGraphRenderer>> {
+  const harness = installGraphRenderer(initial);
+  await act(async () => {
+    harness.root.render(
+      createElement(AgentGraphPanel, {
+        rootSessionId: 'session-1',
+        enabled: true,
+        locale: 'en',
+        onOpenSession: () => undefined,
+      }),
+    );
+    await Promise.resolve();
+  });
+  return harness;
+}
+
+describe('AgentGraphPanel dismiss', () => {
+  it('shows dismiss only after the graph has settled', async () => {
+    const active = await renderPanel(snapshot({ graphId: 'graph-1', status: 'active' }));
+    assert.ok(active.container.querySelector('.maka-agent-graph-panel'));
+    assert.equal(active.container.querySelector('.maka-agent-graph-dismiss'), null);
+    await act(async () => active.root.unmount());
+
+    const completed = await renderPanel(snapshot({ graphId: 'graph-1', status: 'completed' }));
+    assert.ok(completed.container.querySelector('.maka-agent-graph-dismiss'));
+    await act(async () => completed.root.unmount());
+  });
+
+  it('hides the panel after dismiss and brings it back for a new graph', async () => {
+    const harness = await renderPanel(snapshot({ graphId: 'graph-1', status: 'completed' }));
+    const dismiss = harness.container.querySelector('.maka-agent-graph-dismiss');
+    assert.ok(dismiss);
+    await act(async () => {
+      (dismiss as HTMLElement).click();
+    });
+    assert.equal(harness.container.querySelector('.maka-agent-graph-panel'), null);
+
+    await harness.setSnapshot(snapshot({ graphId: 'graph-2', status: 'active' }));
+    assert.ok(harness.container.querySelector('.maka-agent-graph-panel'));
+    assert.equal(harness.container.querySelector('.maka-agent-graph-dismiss'), null);
+    await act(async () => harness.root.unmount());
+  });
+
+  it('lets the user dismiss a stopped or failed graph', async () => {
+    for (const status of ['stopped', 'failed'] as const) {
+      const harness = await renderPanel(snapshot({ graphId: `graph-${status}`, status }));
+      const dismiss = harness.container.querySelector('.maka-agent-graph-dismiss');
+      assert.ok(dismiss, status);
+      await act(async () => {
+        (dismiss as HTMLElement).click();
+      });
+      assert.equal(harness.container.querySelector('.maka-agent-graph-panel'), null, status);
+      await act(async () => harness.root.unmount());
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
@@ -63,6 +63,7 @@ function installGraphRenderer(initial: AgentGraphClientSnapshot): {
   container: Element;
   root: Root;
   setSnapshot(next: AgentGraphClientSnapshot): Promise<void>;
+  renderSession(sessionId: string): Promise<void>;
 } {
   const { document, window } = parseHTML('<div id="root"></div>');
   const matchMedia = (media: string) => ({
@@ -87,11 +88,17 @@ function installGraphRenderer(initial: AgentGraphClientSnapshot): {
     IS_REACT_ACT_ENVIRONMENT: true,
   });
 
-  let current = initial;
+  const snapshots = new Map<string, AgentGraphClientSnapshot>([
+    [initial.rootSessionId, initial],
+  ]);
   const listeners = new Set<GraphListener>();
   (window as unknown as { maka: unknown }).maka = {
     graphs: {
-      getSnapshot: async () => current,
+      getSnapshot: async (sessionId: string) => {
+        const next = snapshots.get(sessionId);
+        if (!next) throw new Error(`missing graph snapshot for ${sessionId}`);
+        return next;
+      },
       inspectOperator: async () => {
         throw new Error('inspectOperator is unused by AgentGraphPanel');
       },
@@ -112,9 +119,22 @@ function installGraphRenderer(initial: AgentGraphClientSnapshot): {
     container,
     root,
     async setSnapshot(next) {
-      current = next;
+      snapshots.set(next.rootSessionId, next);
       await act(async () => {
         for (const listener of [...listeners]) listener();
+        await Promise.resolve();
+      });
+    },
+    async renderSession(sessionId) {
+      await act(async () => {
+        root.render(
+          createElement(AgentGraphPanel, {
+            rootSessionId: sessionId,
+            enabled: true,
+            locale: 'en',
+            onOpenSession: () => undefined,
+          }),
+        );
         await Promise.resolve();
       });
     },
@@ -177,5 +197,34 @@ describe('AgentGraphPanel dismiss', () => {
       assert.equal(harness.container.querySelector('.maka-agent-graph-panel'), null, status);
       await act(async () => harness.root.unmount());
     }
+  });
+
+  it('keeps session A dismissed after switching A → B → A', async () => {
+    const sessionA = snapshot({
+      rootSessionId: 'session-a',
+      graphId: 'graph-a',
+      status: 'completed',
+    });
+    const sessionB = snapshot({
+      rootSessionId: 'session-b',
+      graphId: 'graph-b',
+      status: 'completed',
+    });
+    const harness = installGraphRenderer(sessionA);
+    await harness.setSnapshot(sessionB);
+    await harness.renderSession('session-a');
+    const dismiss = harness.container.querySelector('.maka-agent-graph-dismiss');
+    assert.ok(dismiss);
+    await act(async () => {
+      (dismiss as HTMLElement).click();
+    });
+    assert.equal(harness.container.querySelector('.maka-agent-graph-panel'), null);
+
+    await harness.renderSession('session-b');
+    assert.ok(harness.container.querySelector('.maka-agent-graph-panel'));
+
+    await harness.renderSession('session-a');
+    assert.equal(harness.container.querySelector('.maka-agent-graph-panel'), null);
+    await act(async () => harness.root.unmount());
   });
 });

--- a/apps/desktop/src/renderer/agent-graph-panel-visibility.ts
+++ b/apps/desktop/src/renderer/agent-graph-panel-visibility.ts
@@ -1,0 +1,65 @@
+export type AgentGraphPanelStatus =
+  | 'empty'
+  | 'active'
+  | 'closing'
+  | 'waiting'
+  | 'stopped'
+  | 'failed'
+  | 'completed';
+
+export type AgentGraphPanelDismissals = Readonly<Record<string, string>>;
+
+const DISMISSIBLE_STATUSES = new Set<AgentGraphPanelStatus>([
+  'completed',
+  'stopped',
+  'failed',
+]);
+
+export function isAgentGraphPanelDismissible(
+  status: AgentGraphPanelStatus | undefined,
+): boolean {
+  return status !== undefined && DISMISSIBLE_STATUSES.has(status);
+}
+
+export function dismissAgentGraphPanel(
+  dismissedBySession: AgentGraphPanelDismissals,
+  sessionId: string,
+  graphId: string,
+): AgentGraphPanelDismissals {
+  if (dismissedBySession[sessionId] === graphId) return dismissedBySession;
+  return { ...dismissedBySession, [sessionId]: graphId };
+}
+
+export function reconcileAgentGraphPanelDismissals(
+  dismissedBySession: AgentGraphPanelDismissals,
+  sessionId: string,
+  snapshot: { graphId: string; status: AgentGraphPanelStatus } | undefined,
+): AgentGraphPanelDismissals {
+  const dismissed = dismissedBySession[sessionId];
+  if (!dismissed || !snapshot) return dismissedBySession;
+  if (snapshot.graphId === dismissed && isAgentGraphPanelDismissible(snapshot.status)) {
+    return dismissedBySession;
+  }
+  const next = { ...dismissedBySession };
+  delete next[sessionId];
+  return next;
+}
+
+export function shouldShowAgentGraphPanel(input: {
+  enabled: boolean;
+  hasGraphActivity: boolean;
+  error: boolean;
+  sessionId: string;
+  graphId?: string;
+  status?: AgentGraphPanelStatus;
+  dismissedBySession: AgentGraphPanelDismissals;
+}): boolean {
+  if (
+    input.graphId !== undefined &&
+    input.dismissedBySession[input.sessionId] === input.graphId &&
+    isAgentGraphPanelDismissible(input.status)
+  ) {
+    return false;
+  }
+  return input.enabled || input.hasGraphActivity || input.error;
+}

--- a/apps/desktop/src/renderer/agent-graph-panel-visibility.ts
+++ b/apps/desktop/src/renderer/agent-graph-panel-visibility.ts
@@ -33,10 +33,14 @@ export function dismissAgentGraphPanel(
 export function reconcileAgentGraphPanelDismissals(
   dismissedBySession: AgentGraphPanelDismissals,
   sessionId: string,
-  snapshot: { graphId: string; status: AgentGraphPanelStatus } | undefined,
+  snapshot:
+    | { rootSessionId: string; graphId: string; status: AgentGraphPanelStatus }
+    | undefined,
 ): AgentGraphPanelDismissals {
   const dismissed = dismissedBySession[sessionId];
-  if (!dismissed || !snapshot) return dismissedBySession;
+  if (!dismissed || !snapshot || snapshot.rootSessionId !== sessionId) {
+    return dismissedBySession;
+  }
   if (snapshot.graphId === dismissed && isAgentGraphPanelDismissible(snapshot.status)) {
     return dismissedBySession;
   }

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -202,7 +202,11 @@ export function AgentGraphPanel(props: {
         current,
         props.rootSessionId,
         snapshot
-          ? { graphId: snapshot.graphId, status: snapshot.status }
+          ? {
+              rootSessionId: snapshot.rootSessionId,
+              graphId: snapshot.graphId,
+              status: snapshot.status,
+            }
           : undefined,
       ),
     );

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -5,11 +5,18 @@ import type {
   AgentGraphClientSnapshot,
 } from '@maka/runtime/stream-graph-read-model';
 import { IconButton } from '@maka/ui';
-import { ICON_SIZE, ChevronDown } from '@maka/ui/icons';
+import { ICON_SIZE, ChevronDown, X } from '@maka/ui/icons';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { Spinner } from '@astryxdesign/core/Spinner';
+import {
+  dismissAgentGraphPanel,
+  isAgentGraphPanelDismissible,
+  reconcileAgentGraphPanelDismissals,
+  shouldShowAgentGraphPanel,
+  type AgentGraphPanelDismissals,
+} from './agent-graph-panel-visibility.js';
 
 type GraphPanelCopy = {
   title: string;
@@ -17,6 +24,7 @@ type GraphPanelCopy = {
   retry: string;
   collapse: string;
   expand: string;
+  dismiss: string;
   stop: string;
   stopping: string;
   stopFailed: string;
@@ -40,6 +48,7 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
       retry: '重试',
       collapse: '收起 Agent Graph',
       expand: '展开 Agent Graph',
+      dismiss: '关闭 Agent Graph',
       stop: '停止 Graph',
       stopping: '停止中…',
       stopFailed: '停止 Graph 失败，请重试。',
@@ -82,6 +91,7 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
     retry: 'Retry',
     collapse: 'Collapse Agent Graph',
     expand: 'Expand Agent Graph',
+    dismiss: 'Dismiss Agent Graph',
     stop: 'Stop graph',
     stopping: 'Stopping…',
     stopFailed: 'Could not stop the graph. Try again.',
@@ -131,6 +141,7 @@ export function AgentGraphPanel(props: {
   const [stopPending, setStopPending] = useState(false);
   const [stopError, setStopError] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
+  const [dismissedBySession, setDismissedBySession] = useState<AgentGraphPanelDismissals>({});
   const contentId = useId();
   const refreshRef = useRef<() => void>(() => {});
   const copy = getAgentGraphPanelCopy(props.locale);
@@ -185,6 +196,18 @@ export function AgentGraphPanel(props: {
     };
   }, [props.rootSessionId, props.enabled]);
 
+  useEffect(() => {
+    setDismissedBySession((current) =>
+      reconcileAgentGraphPanelDismissals(
+        current,
+        props.rootSessionId,
+        snapshot
+          ? { graphId: snapshot.graphId, status: snapshot.status }
+          : undefined,
+      ),
+    );
+  }, [props.rootSessionId, snapshot]);
+
   const progress = useMemo(() => {
     const settled = snapshot?.operators.filter((operator) =>
       ['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status),
@@ -197,7 +220,19 @@ export function AgentGraphPanel(props: {
     (snapshot.scheduleRevision > 0 ||
       snapshot.operators.length > 0 ||
       snapshot.omitted.operators > 0);
-  if (!props.enabled && !hasGraphActivity && !error) return null;
+  if (
+    !shouldShowAgentGraphPanel({
+      enabled: props.enabled,
+      hasGraphActivity,
+      error,
+      sessionId: props.rootSessionId,
+      graphId: snapshot?.graphId,
+      status: snapshot?.status,
+      dismissedBySession,
+    })
+  ) {
+    return null;
+  }
 
   const stopGraph = async (): Promise<void> => {
     if (stopPending) return;
@@ -213,6 +248,8 @@ export function AgentGraphPanel(props: {
   };
   const stopAvailable =
     snapshot !== undefined && ['active', 'waiting', 'closing'].includes(snapshot.status);
+  const dismissAvailable =
+    snapshot !== undefined && isAgentGraphPanelDismissible(snapshot.status);
 
   return (
     <section
@@ -242,6 +279,21 @@ export function AgentGraphPanel(props: {
               label={stopPending ? copy.stopping : copy.stop}
               isDisabled={stopPending}
               onClick={() => void stopGraph()}
+            />
+          ) : null}
+          {dismissAvailable && snapshot ? (
+            <IconButton
+              variant="ghost"
+              size="sm"
+              className="maka-agent-graph-dismiss"
+              label={copy.dismiss}
+              tooltip={copy.dismiss}
+              icon={<X size={ICON_SIZE.chrome} aria-hidden="true" />}
+              onClick={() => {
+                setDismissedBySession((current) =>
+                  dismissAgentGraphPanel(current, props.rootSessionId, snapshot.graphId),
+                );
+              }}
             />
           ) : null}
           <IconButton

--- a/apps/desktop/tsconfig.main.json
+++ b/apps/desktop/tsconfig.main.json
@@ -6,6 +6,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "types": ["node", "electron"],
+    "jsx": "react-jsx",
     "incremental": true
   },
   "include": ["src/main", "src/global.d.ts"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "electron": "43.2.0",
         "electron-builder": "26.15.3",
         "esbuild": "^0.27.7",
+        "linkedom": "^0.18.13",
         "simple-icons": "16.28.0",
         "storybook": "^10.4.6",
         "vite": "^8.1.5"


### PR DESCRIPTION
## Summary

Completed Agent Graph panels could only collapse, so they stayed pinned above the composer after the work was done.

This adds a dismiss control for settled graphs (`completed`, `stopped`, `failed`). Dismissal is session-local UI state: the panel comes back if that session starts a new graph, and it does not change Runtime Host, persistence, or the workbar move in #1457.

Fixes #2661

## Verification

Ran locally:

- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/agent-graph-panel.test.js apps/desktop/dist/main/__tests__/agent-graph-panel-visibility.test.js`
  - 15 pass / 0 fail, including a real `AgentGraphPanel` click path
- `tsc -p apps/desktop/tsconfig.renderer.json --noEmit`
- Electron window: injected a completed snapshot, remounted the session, clicked dismiss; `.maka-agent-graph-panel` count went to 0

Not run: full `npm test`, desktop e2e suite, `npm run typecheck` for the whole repo.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Focused lint/typecheck and the affected suites pass locally
- [ ] Full workspace lint/format/typecheck

Does this PR entail a change in behavior?

- [x] Yes — a settled Agent Graph panel can now be dismissed from the composer