### PR TITLE
fix(desktop): select an account default model when discovery fails

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-account-connection.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-account-connection.test.ts
@@ -1,0 +1,103 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { ConnectionCatalogSnapshot, ConnectionTarget } from '@maka/core/runtime-policy';
+import {
+  synchronizeRuntimeHostAccountConnection,
+  type RuntimeHostAccountConnectionClient,
+} from '../runtime-host-account-connection.js';
+
+type FetchModels = RuntimeHostAccountConnectionClient['fetchConnectionModels'];
+
+const CONNECTION_ID = '00000000-0000-4000-8000-0000000000a1';
+
+function catalogWithoutDefault(): ConnectionCatalogSnapshot {
+  return {
+    revision: 4,
+    defaultTarget: null,
+    connections: [
+      {
+        connectionId: CONNECTION_ID,
+        revision: 2,
+        slug: 'claude-subscription',
+        name: 'Claude OAuth',
+        providerType: 'claude-subscription',
+        enabled: true,
+        enabledModelIds: ['claude-opus-5', 'claude-haiku-4-5'],
+        models: [{ id: 'claude-opus-5' }, { id: 'claude-haiku-4-5' }],
+        modelSource: 'fallback',
+        modelsFetchedAt: 0,
+      },
+    ],
+  };
+}
+
+function accountClient(
+  fetchConnectionModels: FetchModels,
+  initial: ConnectionCatalogSnapshot = catalogWithoutDefault(),
+): {
+  readonly client: RuntimeHostAccountConnectionClient;
+  selected(): ConnectionTarget | null | undefined;
+  selectCalls(): number;
+} {
+  let catalog = initial;
+  let selected: ConnectionTarget | null | undefined;
+  let calls = 0;
+  const client = {
+    loadConnectionCatalog: async (): Promise<ConnectionCatalogSnapshot> => catalog,
+    fetchConnectionModels,
+    setDefaultConnectionTarget: async (
+      expectedCatalogRevision: number,
+      target: ConnectionTarget | null,
+    ) => {
+      calls += 1;
+      assert.equal(expectedCatalogRevision, catalog.revision);
+      selected = target;
+      catalog = { ...catalog, revision: catalog.revision + 1, defaultTarget: target };
+      return { kind: 'committed' as const, catalogRevision: catalog.revision };
+    },
+  } as unknown as RuntimeHostAccountConnectionClient;
+  return { client, selected: () => selected, selectCalls: () => calls };
+}
+
+describe('synchronizeRuntimeHostAccountConnection', () => {
+  it('selects a default model when model discovery is rejected', async () => {
+    // A subscription connection serves the curated fallback inventory because
+    // its provider exposes no usable model endpoint. Discovery never commits,
+    // but the connection still has models, so the account must end up usable.
+    const rejected: FetchModels = async () => ({
+      kind: 'rejected',
+      reason: 'provider_action_unavailable',
+    });
+    const { client, selected } = accountClient(rejected);
+
+    await synchronizeRuntimeHostAccountConnection(client, 'claude-subscription');
+
+    assert.deepEqual(selected(), { connectionId: CONNECTION_ID, modelId: 'claude-opus-5' });
+  });
+
+  it('selects a default model when model discovery throws', async () => {
+    const throwing: FetchModels = async () => {
+      throw new Error('network down');
+    };
+    const { client, selected } = accountClient(throwing);
+
+    await synchronizeRuntimeHostAccountConnection(client, 'claude-subscription');
+
+    assert.deepEqual(selected(), { connectionId: CONNECTION_ID, modelId: 'claude-opus-5' });
+  });
+
+  it('leaves an existing default alone', async () => {
+    const rejected: FetchModels = async () => ({
+      kind: 'rejected',
+      reason: 'provider_action_unavailable',
+    });
+    const { client, selectCalls } = accountClient(rejected, {
+      ...catalogWithoutDefault(),
+      defaultTarget: { connectionId: CONNECTION_ID, modelId: 'claude-haiku-4-5' },
+    });
+
+    await synchronizeRuntimeHostAccountConnection(client, 'claude-subscription');
+
+    assert.equal(selectCalls(), 0);
+  });
+});

--- a/apps/desktop/src/main/runtime-host-account-connection.ts
+++ b/apps/desktop/src/main/runtime-host-account-connection.ts
@@ -90,8 +90,12 @@ export async function synchronizeRuntimeHostAccountConnection(
     providerType,
   );
   if (!connection) throw new Error('Account Connection is missing');
-  const fetched = await client.fetchConnectionModels(connection.connectionId);
-  if (fetched.kind !== 'committed') return;
+  // Discovery is best effort. Selecting a default must not depend on it: a
+  // connection whose inventory came from the curated fallback still has usable
+  // models, and leaving `defaultTarget` empty makes every later operation that
+  // needs a default — new Session, send, external Session import — fail with a
+  // reason the user cannot see from the error it produces.
+  await client.fetchConnectionModels(connection.connectionId).catch(() => undefined);
   const catalog = await client.loadConnectionCatalog();
   if (catalog.defaultTarget !== null) return;
   const updated = findRuntimeHostAccountConnection(catalog, providerType);


### PR DESCRIPTION
## Summary

After an account OAuth login, selecting the default model sat behind a
successful model-catalog fetch:

```ts
const fetched = await client.fetchConnectionModels(connection.connectionId);
if (fetched.kind !== 'committed') return;   // ← gives up on the default too
```

A provider that serves the **curated fallback inventory** never commits a
fetch, so the default was never selected — even though the connection already
had usable models sitting in `enabledModelIds`. The call site swallows
failures on purpose ("a transient discovery failure must not turn a committed
login into a false UI failure"), which is right on its own but means the
early return is silent.

The result is an account that signs in, reports success, shows its models and
looks configured, while `defaultTarget` stays `null`. Everything that later
resolves the default then fails — creating a Session, sending a turn,
importing an external Session — and none of those errors name the missing
default, so the account reads as broken rather than unconfigured.

Discovery is now best effort, and the default is chosen from the models the
connection already has. Whether the inventory was fetched or curated does not
change the fact that an account connection needs a default.

## Verification

Three new tests on `synchronizeRuntimeHostAccountConnection`: a default is
selected when discovery is rejected, and when it throws; an existing default
is left alone. **Reverting the one-line change turns two of them red** — the
rejected and throwing cases both fall into the early return.

Reproduced first on a real workspace: a `claude-subscription` connection with
`modelSource: fallback`, `modelsFetchedAt: 0`, six enabled models, and
`defaultTarget: null` after a successful login. External Session import then
failed with "该会话无法转换或保存" — the message for a rejected request, which
is what `resolveExternalSessionImportTarget` produces when there is no
default. Selecting a model by hand made it work.

`lint`, `format:check`, `build`, `typecheck`, `knip` (desktop + ui) and
`astryx:theme` pass. `@maka/desktop` 790/790.

## Review focus

Whether picking `enabledModelIds[0]` is the right choice when discovery
fails, or whether the fallback inventory should be ordered/filtered first —
this keeps the behavior the code already intended for the committed path, but
it now runs in more cases.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No