### PR TITLE
fix(eval): make the subject isolation contract hold

### DIFF
--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -58,8 +58,8 @@ redirecting the remainder also closes a connection the subject inherits from an 
 redirect is a NAT rule, and NAT is evaluated only on a connection's first packet. The
 namespace-local exemption keeps the loopback provider proxies reachable and, with them, Docker's
 embedded resolver at `127.0.0.11`, which forwards names it does not own to the host's upstream
-resolvers. That is an unaudited channel out of the cell and back; removing it is tracked separately,
-and until then the audited proxy is the only path for everything except DNS. The policy exempts no
+resolvers. That is an unaudited channel out of the cell and back, tracked in issue #2976; until it is
+closed the audited proxy is the only path for everything except DNS. The policy exempts no
 packet mark: the
 sidecar shares the subject's network namespace, so a mark the sidecar can set is one the subject can
 set too, and gost forwards nothing in this mode anyway. Because that shared namespace also means the
@@ -83,7 +83,7 @@ the overlay and the checked-in policy and asserts that contract in a real cell n
 a Docker daemon and outbound network, and skips otherwise. This URL policy is a blocklist for known
 benchmark and public-solution contamination surfaces, not a complete defense against a deliberately
 invented lookup channel. It classifies what it can read: a `CONNECT` tunnel carrying something other
-than TLS or HTTP reaches no rule and no audit record, which is tracked separately. Collected Maka runtime files
+than TLS or HTTP reaches no rule and no audit record, which is tracked in issue #2977. Collected Maka runtime files
 and egress audit logs are represented in attempt artifacts with byte counts and SHA-256 digests.
 The local image tag remains a machine deployment identity rather than a registry digest; digest
 pinning is tracked in issue #2953.

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -73,8 +73,9 @@ joins the same namespace with the default capability set, so a task that declare
 isolated than a task that does not. The
 same gate refuses when the subject is not in the namespace the policy was applied to: Harbor applies
 the policy inside the sidecar but respects a task's own networking on the subject service, so a task
-that declares it would otherwise leave the subject unpoliced. The evidence is the sidecar proxy's
-listening socket, which is visible only from inside its own network namespace. The gate reads that
+that declares it would otherwise leave the subject unpoliced. The evidence is the namespace identity
+itself: the gate reads `/proc/self/ns/net` in the subject and in the service Harbor installs the
+policy in, and requires the two to name one namespace. The gate reads that
 evidence through the task image's own userland, so it establishes that a task did not lose the
 isolation by accident, not that a task could not lie about it; a task image that lies already
 controls everything else in the cell. What it does hold against is the subject, which starts only

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -59,9 +59,13 @@ sidecar shares the subject's network namespace, so a mark the sidecar can set is
 set too, and gost forwards nothing in this mode anyway. Because that shared namespace also means the
 policy only constrains what the IP output hooks can see, the overlay drops `NET_RAW`, which would
 otherwise grant an `AF_PACKET` socket that writes beneath them; a task's own Compose can add that
-capability back, and a `cap_add` wins over an overlay's `cap_drop`, so the relay reads the subject's
-effective capability set once the policy is live and refuses to start the subject when it holds
-`NET_RAW` or `NET_ADMIN`. Harbor task
+capability back, and a `cap_add` wins over an overlay's `cap_drop`, so once the policy is live the
+relay reads every capability set the subject could raise or reacquire one from, the bounding set
+included, and refuses to start the subject when any of them carries `NET_RAW` or `NET_ADMIN`. The
+same gate refuses when the subject is not in the namespace the policy was applied to: Harbor applies
+the policy inside the sidecar but respects a task's own networking on the subject service, so a task
+that declares it would otherwise leave the subject unpoliced. The evidence is the sidecar proxy's
+listening socket, which is visible only from inside its own network namespace. Harbor task
 download and verifier phases retain their native network policy. Build the pinned
 `maka-eval-egress-proxy:12.2.3` image from `harbor/egress-proxy/Dockerfile` before running the
 cohort. `MAKA_EVAL_EGRESS_NAMESPACE_TEST=1 python3 harbor/test_cell_egress_namespace.py` brings up

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -56,7 +56,12 @@ variables or requests `--noproxy`. The namespace policy accepts TCP to that prox
 namespace-local addresses, which keeps the loopback provider proxies and Docker's embedded DNS
 resolver reachable, and rejects every other protocol, ICMP included. It exempts no packet mark: the
 sidecar shares the subject's network namespace, so a mark the sidecar can set is one the subject can
-set too, and gost forwards nothing in this mode anyway. Harbor task
+set too, and gost forwards nothing in this mode anyway. Because that shared namespace also means the
+policy only constrains what the IP output hooks can see, the overlay drops `NET_RAW`, which would
+otherwise grant an `AF_PACKET` socket that writes beneath them; a task's own Compose can add that
+capability back, and a `cap_add` wins over an overlay's `cap_drop`, so the relay reads the subject's
+effective capability set once the policy is live and refuses to start the subject when it holds
+`NET_RAW` or `NET_ADMIN`. Harbor task
 download and verifier phases retain their native network policy. Build the pinned
 `maka-eval-egress-proxy:12.2.3` image from `harbor/egress-proxy/Dockerfile` before running the
 cohort. `MAKA_EVAL_EGRESS_NAMESPACE_TEST=1 python3 harbor/test_cell_egress_namespace.py` brings up

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -53,8 +53,14 @@ mounts read-only, so the CA private key and the audit log never enter the subjec
 `Agent.run()`, Harbor's Docker egress sidecar applies an nftables allowlist containing only that
 proxy service; direct subject egress is therefore rejected even when a command unsets proxy
 variables or requests `--noproxy`. The namespace policy accepts TCP to that proxy and traffic to
-namespace-local addresses, which keeps the loopback provider proxies and Docker's embedded DNS
-resolver reachable, and rejects every other protocol, ICMP included. It exempts no packet mark: the
+namespace-local addresses, and rejects everything else, ICMP included. Rejecting rather than
+redirecting the remainder also closes a connection the subject inherits from an earlier phase: the
+redirect is a NAT rule, and NAT is evaluated only on a connection's first packet. The
+namespace-local exemption keeps the loopback provider proxies reachable and, with them, Docker's
+embedded resolver at `127.0.0.11`, which forwards names it does not own to the host's upstream
+resolvers. That is an unaudited channel out of the cell and back; removing it is tracked separately,
+and until then the audited proxy is the only path for everything except DNS. The policy exempts no
+packet mark: the
 sidecar shares the subject's network namespace, so a mark the sidecar can set is one the subject can
 set too, and gost forwards nothing in this mode anyway. Because that shared namespace also means the
 policy only constrains what the IP output hooks can see, the overlay drops `NET_RAW`, which would
@@ -65,15 +71,19 @@ included, and refuses to start the subject when any of them carries `NET_RAW` or
 same gate refuses when the subject is not in the namespace the policy was applied to: Harbor applies
 the policy inside the sidecar but respects a task's own networking on the subject service, so a task
 that declares it would otherwise leave the subject unpoliced. The evidence is the sidecar proxy's
-listening socket, which is visible only from inside its own network namespace. Harbor task
+listening socket, which is visible only from inside its own network namespace. The gate reads that
+evidence through the task image's own userland, so it establishes that a task did not lose the
+isolation by accident, not that a task could not lie about it; a task image that lies already
+controls everything else in the cell. What it does hold against is the subject, which starts only
+after the gate has passed. Harbor task
 download and verifier phases retain their native network policy. Build the pinned
 `maka-eval-egress-proxy:12.2.3` image from `harbor/egress-proxy/Dockerfile` before running the
 cohort. `MAKA_EVAL_EGRESS_NAMESPACE_TEST=1 python3 harbor/test_cell_egress_namespace.py` brings up
 the overlay and the checked-in policy and asserts that contract in a real cell namespace; it needs
 a Docker daemon and outbound network, and skips otherwise. This URL policy is a blocklist for known
 benchmark and public-solution contamination surfaces, not a complete defense against a deliberately
-invented lookup channel; the network namespace still forces all subject traffic through the audited
-proxy. Collected Maka runtime files
+invented lookup channel. It classifies what it can read: a `CONNECT` tunnel carrying something other
+than TLS or HTTP reaches no rule and no audit record, which is tracked separately. Collected Maka runtime files
 and egress audit logs are represented in attempt artifacts with byte counts and SHA-256 digests.
 The local image tag remains a machine deployment identity rather than a registry digest; digest
 pinning is tracked in issue #2953.

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -67,7 +67,10 @@ policy only constrains what the IP output hooks can see, the overlay drops `NET_
 otherwise grant an `AF_PACKET` socket that writes beneath them; a task's own Compose can add that
 capability back, and a `cap_add` wins over an overlay's `cap_drop`, so once the policy is live the
 relay reads every capability set the subject could raise or reacquire one from, the bounding set
-included, and refuses to start the subject when any of them carries `NET_RAW` or `NET_ADMIN`. The
+included, and refuses to start the subject when any of them carries `NET_RAW` or `NET_ADMIN`. Both
+the drop and the gate cover the subject alone, not the namespace: a sibling service a task declares
+joins the same namespace with the default capability set, so a task that declares one is less
+isolated than a task that does not. The
 same gate refuses when the subject is not in the namespace the policy was applied to: Harbor applies
 the policy inside the sidecar but respects a task's own networking on the subject service, so a task
 that declares it would otherwise leave the subject unpoliced. The evidence is the sidecar proxy's

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -42,15 +42,29 @@ the Eval metering proxy, which structurally removes named and provider-native we
 requests. Shell networking remains enabled. The configured HTTPS egress proxy blocks only
 benchmark and public-solution contamination URLs, including normalized or recursively wrapped
 `terminal-bench` references, pinned benchmark revisions, task registries, benchmark repositories,
-public trajectories, and known patch mirrors. The checked-in Compose overlay gives every cell its
-own MITM proxy, CA, bounded audit log, and health gate. During `Agent.run()`, Harbor's Docker egress
-sidecar applies an nftables allowlist containing only that proxy service; direct subject egress is
-therefore rejected even when a command unsets proxy variables or requests `--noproxy`. Harbor task
+public trajectories, and known patch mirrors. The general `terminal-bench` match searches the host
+and the path separately, so a contamination surface named only in the hostname is blocked too, and
+no rule can match across the boundary between the two fields. Only Harbor applies
+the namespace policy, so a pier executor spec that declares `egressProxy` is rejected when it is
+decoded rather than running with the proxy set up and enforcement absent. The checked-in Compose
+overlay gives every cell its own MITM proxy, CA, bounded audit log, and health gate. The proxy keeps its confdir and audit log
+private and publishes only `mitmproxy-ca-cert.pem` into the certificate-only volume the subject
+mounts read-only, so the CA private key and the audit log never enter the subject namespace. During
+`Agent.run()`, Harbor's Docker egress sidecar applies an nftables allowlist containing only that
+proxy service; direct subject egress is therefore rejected even when a command unsets proxy
+variables or requests `--noproxy`. The namespace policy accepts TCP to that proxy and traffic to
+namespace-local addresses, which keeps the loopback provider proxies and Docker's embedded DNS
+resolver reachable, and rejects every other protocol, ICMP included. It exempts no packet mark: the
+sidecar shares the subject's network namespace, so a mark the sidecar can set is one the subject can
+set too, and gost forwards nothing in this mode anyway. Harbor task
 download and verifier phases retain their native network policy. Build the pinned
 `maka-eval-egress-proxy:12.2.3` image from `harbor/egress-proxy/Dockerfile` before running the
-cohort. This URL policy is a blocklist for known benchmark and public-solution contamination
-surfaces, not a complete defense against a deliberately invented lookup channel; the network
-namespace still forces all subject traffic through the audited proxy. Collected Maka runtime files
+cohort. `MAKA_EVAL_EGRESS_NAMESPACE_TEST=1 python3 harbor/test_cell_egress_namespace.py` brings up
+the overlay and the checked-in policy and asserts that contract in a real cell namespace; it needs
+a Docker daemon and outbound network, and skips otherwise. This URL policy is a blocklist for known
+benchmark and public-solution contamination surfaces, not a complete defense against a deliberately
+invented lookup channel; the network namespace still forces all subject traffic through the audited
+proxy. Collected Maka runtime files
 and egress audit logs are represented in attempt artifacts with byte counts and SHA-256 digests.
 The local image tag remains a machine deployment identity rather than a registry digest; digest
 pinning is tracked in issue #2953.

--- a/packages/eval/harbor/docker-compose-egress-proxy.yaml
+++ b/packages/eval/harbor/docker-compose-egress-proxy.yaml
@@ -10,6 +10,12 @@ services:
     depends_on:
       maka-eval-mitmproxy:
         condition: service_healthy
+    # An AF_PACKET socket writes below the IP output hooks the policy installs,
+    # so no nftables rule can constrain it. NET_RAW is what gates that socket.
+    # A task's own compose can add the capability back, which this cannot
+    # prevent — the relay refuses to start the subject when that happens.
+    cap_drop:
+      - NET_RAW
     volumes:
       - maka-eval-egress-ca:/opt/maka-egress:ro
 

--- a/packages/eval/harbor/docker-compose-egress-proxy.yaml
+++ b/packages/eval/harbor/docker-compose-egress-proxy.yaml
@@ -11,14 +11,14 @@ services:
       maka-eval-mitmproxy:
         condition: service_healthy
     volumes:
-      - maka-eval-egress-state:/opt/maka-egress:ro
+      - maka-eval-egress-ca:/opt/maka-egress:ro
 
   maka-eval-mitmproxy:
     image: maka-eval-egress-proxy:12.2.3
     networks:
       - default
     volumes:
-      - maka-eval-egress-state:/opt/maka-egress
+      - maka-eval-egress-ca:/opt/maka-egress
     healthcheck:
       test:
         - CMD
@@ -30,4 +30,4 @@ services:
       retries: 30
 
 volumes:
-  maka-eval-egress-state:
+  maka-eval-egress-ca:

--- a/packages/eval/harbor/egress-proxy/entrypoint.sh
+++ b/packages/eval/harbor/egress-proxy/entrypoint.sh
@@ -1,13 +1,29 @@
 #!/bin/sh
 set -eu
 
-mkdir -p /opt/maka-egress
-: > /opt/maka-egress/hits.jsonl
+STATE_DIR=/opt/maka-egress-state
+CERT_DIR=/opt/maka-egress
+
+mkdir -p "$STATE_DIR" "$CERT_DIR"
+: > "$STATE_DIR/hits.jsonl"
+
+# confdir holds the CA private key and this cell's audit log, so it stays
+# container-private and only the certificate reaches the volume the subject
+# mounts. Creating the CA here instead of letting mitmdump create it on startup
+# publishes the certificate before the proxy port opens, so the health gate
+# cannot release `main` against a missing or left-over certificate.
+python -c 'import sys
+from mitmproxy.certs import CertStore
+CertStore.from_store(sys.argv[1], "mitmproxy", 2048)' "$STATE_DIR"
+# Publish by rename so a restart cannot expose a truncated certificate to a
+# subject that is already running against the previous one.
+cp "$STATE_DIR/mitmproxy-ca-cert.pem" "$CERT_DIR/.mitmproxy-ca-cert.pem"
+mv "$CERT_DIR/.mitmproxy-ca-cert.pem" "$CERT_DIR/mitmproxy-ca-cert.pem"
 
 exec mitmdump \
   --quiet \
   --listen-host 0.0.0.0 \
   --listen-port 8080 \
   --set block_global=false \
-  --set confdir=/opt/maka-egress \
+  --set confdir="$STATE_DIR" \
   --scripts /opt/maka-eval/egress_filter.py

--- a/packages/eval/harbor/egress-proxy/network-policy
+++ b/packages/eval/harbor/egress-proxy/network-policy
@@ -2,8 +2,11 @@
 set -eu
 
 ALLOWLIST=/opt/egress-sidecar/allowlist.txt
+# The proxy-only ruleset carries no packet-mark exemption. gost only needs one
+# when it forwards, and this mode empties its allowlist so it forwards nothing;
+# trusting a mark here would let the subject set the same mark on its own socket
+# and leave the namespace unproxied.
 GOST_PORT=12345
-GOST_MARK=114514
 NFTABLES_RULESET_NAME=gost_egress
 PROXY_HOST=maka-eval-mitmproxy
 PROXY_PORT=8080
@@ -32,7 +35,6 @@ table inet $NFTABLES_RULESET_NAME {
   chain output {
     type nat hook output priority dstnat; policy accept;
 
-    meta mark $GOST_MARK return
     fib daddr type local return
     ip daddr $proxy_ip tcp dport $PROXY_PORT return
     meta l4proto tcp redirect to :$GOST_PORT
@@ -41,11 +43,8 @@ table inet $NFTABLES_RULESET_NAME {
   chain egress {
     type filter hook output priority filter; policy accept;
 
-    meta mark $GOST_MARK accept
     fib daddr type local accept
     ip daddr $proxy_ip tcp dport $PROXY_PORT accept
-    ip protocol icmp accept
-    ip6 nexthdr icmpv6 accept
     meta l4proto != tcp reject
   }
 }

--- a/packages/eval/harbor/egress-proxy/network-policy
+++ b/packages/eval/harbor/egress-proxy/network-policy
@@ -1,11 +1,11 @@
 #!/bin/sh
 set -eu
 
-ALLOWLIST=/opt/egress-sidecar/allowlist.txt
-# The proxy-only ruleset carries no packet-mark exemption. gost only needs one
-# when it forwards, and this mode empties its allowlist so it forwards nothing;
-# trusting a mark here would let the subject set the same mark on its own socket
-# and leave the namespace unproxied.
+# gost's allowlist is never written here: the sidecar entrypoint empties it at
+# start and this policy only ever forwards through the audited proxy, so gost
+# forwards nothing on its own. That also removes the packet-mark exemption gost
+# needs when it does forward — the sidecar shares the subject's network
+# namespace, so a mark the sidecar can set is one the subject can set too.
 GOST_PORT=12345
 NFTABLES_RULESET_NAME=gost_egress
 PROXY_HOST=maka-eval-mitmproxy
@@ -25,8 +25,6 @@ setup_proxy_only() {
     echo "could not resolve Eval egress proxy" >&2
     exit 1
   fi
-  : > "$ALLOWLIST"
-  sleep 2
   nft --file - <<EOF
 add table inet $NFTABLES_RULESET_NAME
 flush table inet $NFTABLES_RULESET_NAME
@@ -45,7 +43,11 @@ table inet $NFTABLES_RULESET_NAME {
 
     fib daddr type local accept
     ip daddr $proxy_ip tcp dport $PROXY_PORT accept
-    meta l4proto != tcp reject
+    # Rejecting everything else rather than only non-TCP: the nat chain above
+    # rewrote every TCP destination this policy admits to a local one, so what
+    # reaches here still carrying a public destination is traffic the nat hook
+    # never saw — a connection conntrack established before the policy existed.
+    reject
   }
 }
 EOF
@@ -55,12 +57,9 @@ EOF
 case "${1:-}" in
   allow-all)
     remove_nftables
-    : > "$ALLOWLIST"
     echo "ok: allow all egress"
     ;;
   deny-all)
-    : > "$ALLOWLIST"
-    sleep 2
     setup_proxy_only
     ;;
   allow)

--- a/packages/eval/harbor/egress-proxy/network-policy
+++ b/packages/eval/harbor/egress-proxy/network-policy
@@ -19,12 +19,11 @@ resolve_proxy_ip() {
   getent ahostsv4 "$PROXY_HOST" | awk 'NR == 1 { print $1 }'
 }
 
-setup_proxy_only() {
-  proxy_ip="$(resolve_proxy_ip)"
-  if [ -z "$proxy_ip" ]; then
-    echo "could not resolve Eval egress proxy" >&2
-    exit 1
-  fi
+# The only difference between the two modes this policy installs is whether the
+# audited proxy is exempt, so they are one ruleset with one optional pair of
+# rules rather than two rulesets that have to be kept in step.
+apply_ruleset() {
+  proxy_ip="${1:-}"
   nft --file - <<EOF
 add table inet $NFTABLES_RULESET_NAME
 flush table inet $NFTABLES_RULESET_NAME
@@ -34,7 +33,7 @@ table inet $NFTABLES_RULESET_NAME {
     type nat hook output priority dstnat; policy accept;
 
     fib daddr type local return
-    ip daddr $proxy_ip tcp dport $PROXY_PORT return
+${proxy_ip:+    ip daddr $proxy_ip tcp dport $PROXY_PORT return}
     meta l4proto tcp redirect to :$GOST_PORT
   }
 
@@ -42,7 +41,7 @@ table inet $NFTABLES_RULESET_NAME {
     type filter hook output priority filter; policy accept;
 
     fib daddr type local accept
-    ip daddr $proxy_ip tcp dport $PROXY_PORT accept
+${proxy_ip:+    ip daddr $proxy_ip tcp dport $PROXY_PORT accept}
     # Rejecting everything else rather than only non-TCP: the nat chain above
     # rewrote every TCP destination this policy admits to a local one, so what
     # reaches here still carrying a public destination is traffic the nat hook
@@ -51,6 +50,15 @@ table inet $NFTABLES_RULESET_NAME {
   }
 }
 EOF
+}
+
+setup_proxy_only() {
+  proxy_ip="$(resolve_proxy_ip)"
+  if [ -z "$proxy_ip" ]; then
+    echo "could not resolve Eval egress proxy" >&2
+    exit 1
+  fi
+  apply_ruleset "$proxy_ip"
   echo "ok: Eval proxy-only egress applied ($proxy_ip:$PROXY_PORT)"
 }
 
@@ -60,7 +68,11 @@ case "${1:-}" in
     echo "ok: allow all egress"
     ;;
   deny-all)
-    setup_proxy_only
+    # A phase that asked for no network gets none. Answering it with the
+    # proxy-only ruleset would hand it a route this override invented, which
+    # Harbor's own deny-all does not grant either.
+    apply_ruleset
+    echo "ok: Eval no-network egress applied"
     ;;
   allow)
     shift
@@ -71,11 +83,13 @@ case "${1:-}" in
     setup_proxy_only
     ;;
   show)
-    if nft list table inet "$NFTABLES_RULESET_NAME" >/dev/null 2>&1; then
+    if ! rules="$(nft list table inet "$NFTABLES_RULESET_NAME" 2>/dev/null)"; then
+      echo "mode: allow-all"
+    elif printf '%s' "$rules" | grep -q "dport $PROXY_PORT"; then
       echo "mode: Eval proxy-only"
       echo "proxy: $PROXY_HOST:$PROXY_PORT"
     else
-      echo "mode: allow-all"
+      echo "mode: Eval no-network"
     fi
     ;;
   rules)

--- a/packages/eval/harbor/egress_filter.py
+++ b/packages/eval/harbor/egress_filter.py
@@ -12,7 +12,9 @@ from urllib.parse import unquote, urlsplit
 PINNED_REVISION = "d49e28f1e4ddd13d289e85a5f312a66750951932"
 MAX_DECODE_PASSES = 4
 MAX_AUDIT_BYTES = 1024 * 1024
-AUDIT_PATH = Path(os.environ.get("MAKA_EVAL_EGRESS_AUDIT", "/opt/maka-egress/hits.jsonl"))
+AUDIT_PATH = Path(
+    os.environ.get("MAKA_EVAL_EGRESS_AUDIT", "/opt/maka-egress-state/hits.jsonl")
+)
 PERCENT_ESCAPE = re.compile(r"%(?![0-9a-fA-F]{2})")
 TERMINAL_BENCH = re.compile(r"terminal[-_.%/+\s]*bench", re.IGNORECASE)
 
@@ -33,7 +35,7 @@ def contamination_rule(raw_url: str) -> tuple[str, str, str] | None:
 
     if PINNED_REVISION in lowered:
         return ("pinned_revision", host, path_query)
-    if host == "tbench.ai":
+    if host == "tbench.ai" or host.endswith(".tbench.ai"):
         return ("tbench_domain", host, path_query)
     if host == "hub.harborframework.com" and "/tasks/terminal-bench" in lowered:
         return ("harbor_task_registry", host, path_query)
@@ -43,7 +45,10 @@ def contamination_rule(raw_url: str) -> tuple[str, str, str] | None:
         return ("public_trajectory", host, path_query)
     if "patches-terminalbench-" in lowered:
         return ("known_patch_artifact", host, path_query)
-    if TERMINAL_BENCH.search(lowered):
+    # Search the host and the path separately. A benchmark name in the hostname
+    # is a contamination surface, and searching the two fields joined would let
+    # a rule match across their boundary.
+    if TERMINAL_BENCH.search(host) or TERMINAL_BENCH.search(lowered):
         return ("terminal_bench_url", host, path_query)
     return None
 

--- a/packages/eval/harbor/egress_filter.py
+++ b/packages/eval/harbor/egress_filter.py
@@ -26,6 +26,12 @@ def contamination_rule(raw_url: str) -> tuple[str, str, str] | None:
     path_query = f"{url.path}?{url.query}" if url.query else url.path
     lowered = path_query.lower()
 
+    # Search the host and the path separately. A benchmark name in the hostname
+    # is a contamination surface, and searching the two fields joined would let
+    # a rule match across their boundary.
+    def anywhere(needle: str) -> bool:
+        return needle in host or needle in lowered
+
     if host == "r.jina.ai":
         inner = unquote(url.path.lstrip("/"))
         if inner.startswith(("http://", "https://")):
@@ -33,7 +39,7 @@ def contamination_rule(raw_url: str) -> tuple[str, str, str] | None:
             if nested:
                 return (f"jina_recursive:{nested[0]}", host, path_query)
 
-    if PINNED_REVISION in lowered:
+    if anywhere(PINNED_REVISION):
         return ("pinned_revision", host, path_query)
     if host == "tbench.ai" or host.endswith(".tbench.ai"):
         return ("tbench_domain", host, path_query)
@@ -43,11 +49,8 @@ def contamination_rule(raw_url: str) -> tuple[str, str, str] | None:
         return ("benchmark_repository", host, path_query)
     if public_trajectory_repository(host, lowered):
         return ("public_trajectory", host, path_query)
-    if "patches-terminalbench-" in lowered:
+    if anywhere("patches-terminalbench-"):
         return ("known_patch_artifact", host, path_query)
-    # Search the host and the path separately. A benchmark name in the hostname
-    # is a contamination surface, and searching the two fields joined would let
-    # a rule match across their boundary.
     if TERMINAL_BENCH.search(host) or TERMINAL_BENCH.search(lowered):
         return ("terminal_bench_url", host, path_query)
     return None

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -33,6 +33,13 @@ RESULT_PAYLOAD_LIMIT_BYTES = 2 * 1024
 RESULT_CARRIER_LIMIT_BYTES = 64 * 1024
 SUBJECT_STDOUT_PATH = "/logs/artifacts/maka-subject.stdout.txt"
 SUBJECT_STDERR_PATH = "/logs/artifacts/maka-subject.stderr.txt"
+CAPABILITY_PREFIX = "MAKA-EVAL-CAPABILITIES-V1 "
+# The egress policy only constrains what the IP output hooks can see. NET_RAW
+# grants an AF_PACKET socket that writes beneath them, and NET_ADMIN grants the
+# ability to delete the ruleset outright. The overlay drops NET_RAW, but a
+# task's own compose can add either back, and a `cap_add` wins over an
+# overlay's `cap_drop`.
+BYPASS_CAPABILITIES = {"NET_RAW": 1 << 13, "NET_ADMIN": 1 << 12}
 
 _host_teardown_requested = False
 
@@ -91,6 +98,7 @@ class RelayAgent(BaseAgent):
             cwd = cwd_lines[0] if len(cwd_lines) == 1 else ""
             if working_directory.return_code != 0 or not cwd.startswith("/") or "\x00" in cwd:
                 raise RuntimeError("Maka Eval could not resolve the task working directory")
+            await _require_constrained_subject(environment)
             if not await _send(
                 writer,
                 {
@@ -282,6 +290,39 @@ async def _prepare_command(
         f"exec {subject}{output_redirect}"
     )
     return f"setsid --wait sh -c {shlex.quote(inner)}"
+
+
+async def _require_constrained_subject(environment: Any) -> None:
+    """Refuse to start the subject when it holds a capability the policy cannot see.
+
+    Runs after the egress policy is applied and before the subject exists, so a
+    task that restores one of these capabilities fails the attempt instead of
+    producing a result the isolation contract never actually covered.
+    """
+    if os.environ.get("MAKA_EVAL_EGRESS_REQUIRED") != "1":
+        return
+    probe = await environment.exec(
+        f"printf {shlex.quote(CAPABILITY_PREFIX)}; "
+        "sed -n 's/^CapEff:[[:space:]]*//p' /proc/self/status"
+    )
+    reported = [
+        line[len(CAPABILITY_PREFIX) :]
+        for line in str(probe.stdout or "").splitlines()
+        if line.startswith(CAPABILITY_PREFIX)
+    ]
+    if probe.return_code != 0 or len(reported) != 1:
+        raise RuntimeError("Maka Eval could not read the subject capability set")
+    try:
+        effective = int(reported[0].strip(), 16)
+    except ValueError:
+        raise RuntimeError("Maka Eval could not read the subject capability set") from None
+    held = sorted(name for name, bit in BYPASS_CAPABILITIES.items() if effective & bit)
+    if held:
+        raise RuntimeError(
+            "the subject holds "
+            + ", ".join(held)
+            + ", which bypasses the Eval egress policy; remove it from the task"
+        )
 
 
 async def _persist_subject_outputs(environment: Any, result: Any) -> None:

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -46,10 +46,15 @@ BYPASS_CAPABILITIES = {"NET_RAW": 1 << 13, "NET_ADMIN": 1 << 12}
 # anything the bounding set kept, and the permitted, inheritable and ambient
 # sets each raise into the effective set without an exec at all.
 CAPABILITY_FIELDS = ("CapEff", "CapPrm", "CapBnd")
-# The port the policy redirects to, and therefore the port the sidecar's gost
-# listens on. A listening socket is visible only inside its own network
-# namespace, so seeing it from the subject is what proves the two share one.
-POLICY_PROXY_PORT = 12345
+# Harbor installs the policy by running `network-policy` inside this service, so
+# its network namespace is what "the namespace the policy was applied to" means.
+# Reading the identity from both sides answers that question directly, rather
+# than inferring it from something only the shared namespace would expose.
+POLICY_SERVICE = "harbor-docker-egress-control-sidecar"
+NAMESPACE_PROBE = f"printf %s {shlex.quote(NAMESPACE_PREFIX)}; readlink /proc/self/ns/net"
+# The kernel's own form for a namespace link target. Matching it keeps an
+# unexpected answer from being compared as if it were an identity.
+NAMESPACE_IDENTITY = re.compile(r"^net:\[[0-9]+\]$")
 
 _host_teardown_requested = False
 
@@ -312,23 +317,19 @@ async def _require_constrained_subject(environment: Any) -> None:
     """
     if os.environ.get("MAKA_EVAL_EGRESS_REQUIRED") != "1":
         return
-    listening = (
-        "^[[:space:]]*[0-9]+: [0-9A-F]+:"
-        f"{POLICY_PROXY_PORT:04X}"
-        " [0-9A-F]+:0000 0A"
-    )
     probe = await environment.exec(
         f"printf %s {shlex.quote(CAPABILITY_PREFIX)}; "
         r"sed -n 's/^\(Cap[A-Za-z]*\):[[:space:]]*/\1=/p' /proc/self/status | tr '\n' ' '; "
-        "echo; "
-        f"printf %s {shlex.quote(NAMESPACE_PREFIX)}; "
-        f"if cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -qE {shlex.quote(listening)}; "
-        "then echo shared; else echo separate; fi"
+        "echo; " + NAMESPACE_PROBE
     )
-    if probe.return_code != 0:
+    policy = await environment.service_exec(NAMESPACE_PROBE, service=POLICY_SERVICE)
+    if probe.return_code != 0 or policy.return_code != 0:
         raise RuntimeError("Maka Eval could not read the subject isolation evidence")
     capabilities = _sole_probe_line(probe, CAPABILITY_PREFIX)
     namespace = _sole_probe_line(probe, NAMESPACE_PREFIX)
+    policy_namespace = _sole_probe_line(policy, NAMESPACE_PREFIX)
+    if not all(NAMESPACE_IDENTITY.match(value) for value in (namespace, policy_namespace)):
+        raise RuntimeError("Maka Eval could not read the subject isolation evidence")
     reported: dict[str, int] = {}
     for field in capabilities.split():
         name, _, value = field.partition("=")
@@ -348,7 +349,7 @@ async def _require_constrained_subject(environment: Any) -> None:
             + ", ".join(held)
             + ", which bypasses the Eval egress policy; remove it from the task"
         )
-    if namespace != "shared":
+    if namespace != policy_namespace:
         raise RuntimeError(
             "the subject does not share the network namespace the Eval egress policy "
             "was applied to; remove the task's own networking on the subject service"

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -34,12 +34,22 @@ RESULT_CARRIER_LIMIT_BYTES = 64 * 1024
 SUBJECT_STDOUT_PATH = "/logs/artifacts/maka-subject.stdout.txt"
 SUBJECT_STDERR_PATH = "/logs/artifacts/maka-subject.stderr.txt"
 CAPABILITY_PREFIX = "MAKA-EVAL-CAPABILITIES-V1 "
+NAMESPACE_PREFIX = "MAKA-EVAL-POLICY-NAMESPACE-V1 "
 # The egress policy only constrains what the IP output hooks can see. NET_RAW
 # grants an AF_PACKET socket that writes beneath them, and NET_ADMIN grants the
 # ability to delete the ruleset outright. The overlay drops NET_RAW, but a
 # task's own compose can add either back, and a `cap_add` wins over an
 # overlay's `cap_drop`.
 BYPASS_CAPABILITIES = {"NET_RAW": 1 << 13, "NET_ADMIN": 1 << 12}
+# Every set is read, not just the effective one: a non-root subject reports an
+# empty effective set while a file-capability executable still reacquires
+# anything the bounding set kept, and the permitted, inheritable and ambient
+# sets each raise into the effective set without an exec at all.
+CAPABILITY_FIELDS = ("CapEff", "CapPrm", "CapBnd")
+# The port the policy redirects to, and therefore the port the sidecar's gost
+# listens on. A listening socket is visible only inside its own network
+# namespace, so seeing it from the subject is what proves the two share one.
+POLICY_PROXY_PORT = 12345
 
 _host_teardown_requested = False
 
@@ -293,36 +303,67 @@ async def _prepare_command(
 
 
 async def _require_constrained_subject(environment: Any) -> None:
-    """Refuse to start the subject when it holds a capability the policy cannot see.
+    """Refuse to start the subject unless the egress policy actually governs it.
 
-    Runs after the egress policy is applied and before the subject exists, so a
-    task that restores one of these capabilities fails the attempt instead of
+    Runs after the policy is applied and before the subject exists, so a task
+    that keeps a capability the policy cannot see, or that keeps the subject out
+    of the namespace the policy was applied to, fails the attempt instead of
     producing a result the isolation contract never actually covered.
     """
     if os.environ.get("MAKA_EVAL_EGRESS_REQUIRED") != "1":
         return
-    probe = await environment.exec(
-        f"printf {shlex.quote(CAPABILITY_PREFIX)}; "
-        "sed -n 's/^CapEff:[[:space:]]*//p' /proc/self/status"
+    listening = (
+        "^[[:space:]]*[0-9]+: [0-9A-F]+:"
+        f"{POLICY_PROXY_PORT:04X}"
+        " [0-9A-F]+:0000 0A"
     )
-    reported = [
-        line[len(CAPABILITY_PREFIX) :]
-        for line in str(probe.stdout or "").splitlines()
-        if line.startswith(CAPABILITY_PREFIX)
-    ]
-    if probe.return_code != 0 or len(reported) != 1:
+    probe = await environment.exec(
+        f"printf %s {shlex.quote(CAPABILITY_PREFIX)}; "
+        r"sed -n 's/^\(Cap[A-Za-z]*\):[[:space:]]*/\1=/p' /proc/self/status | tr '\n' ' '; "
+        "echo; "
+        f"printf %s {shlex.quote(NAMESPACE_PREFIX)}; "
+        f"if cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -qE {shlex.quote(listening)}; "
+        "then echo shared; else echo separate; fi"
+    )
+    if probe.return_code != 0:
+        raise RuntimeError("Maka Eval could not read the subject isolation evidence")
+    capabilities = _sole_probe_line(probe, CAPABILITY_PREFIX)
+    namespace = _sole_probe_line(probe, NAMESPACE_PREFIX)
+    reported: dict[str, int] = {}
+    for field in capabilities.split():
+        name, _, value = field.partition("=")
+        try:
+            reported[name] = int(value, 16)
+        except ValueError:
+            raise RuntimeError("Maka Eval could not read the subject capability set") from None
+    if not all(field in reported for field in CAPABILITY_FIELDS):
         raise RuntimeError("Maka Eval could not read the subject capability set")
-    try:
-        effective = int(reported[0].strip(), 16)
-    except ValueError:
-        raise RuntimeError("Maka Eval could not read the subject capability set") from None
-    held = sorted(name for name, bit in BYPASS_CAPABILITIES.items() if effective & bit)
+    granted = 0
+    for value in reported.values():
+        granted |= value
+    held = sorted(name for name, bit in BYPASS_CAPABILITIES.items() if granted & bit)
     if held:
         raise RuntimeError(
             "the subject holds "
             + ", ".join(held)
             + ", which bypasses the Eval egress policy; remove it from the task"
         )
+    if namespace != "shared":
+        raise RuntimeError(
+            "the subject does not share the network namespace the Eval egress policy "
+            "was applied to; remove the task's own networking on the subject service"
+        )
+
+
+def _sole_probe_line(probe: Any, prefix: str) -> str:
+    reported = [
+        line[len(prefix) :]
+        for line in str(probe.stdout or "").splitlines()
+        if line.startswith(prefix)
+    ]
+    if len(reported) != 1:
+        raise RuntimeError("Maka Eval could not read the subject isolation evidence")
+    return reported[0].strip()
 
 
 async def _persist_subject_outputs(environment: Any, result: Any) -> None:

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -360,6 +360,21 @@ class CellEgressNamespaceTest(unittest.TestCase):
     def ping(cls) -> subprocess.CompletedProcess[str]:
         return cls.exec_main(["ping", "-c", "1", "-W", "5", "1.1.1.1"])
 
+    def test_no_network_phase_is_not_answered_with_proxy_access(self) -> None:
+        # Harbor's deny-all denies controlled egress outright, so answering it
+        # with the proxy-only ruleset would grant a phase that asked for no
+        # network a route this override invented.
+        reachable = self.curl([], environment=PROXY_ENVIRONMENT)
+        self.assertEqual(reachable.returncode, 0, reachable.stderr)
+        try:
+            denied = self.exec_service(SIDECAR, ["network-policy", "deny-all"])
+            self.assertEqual(denied.returncode, 0, denied.stderr)
+            blocked = self.curl([], environment=PROXY_ENVIRONMENT)
+            self.assertNotEqual(blocked.returncode, 0)
+        finally:
+            restored = self.exec_service(SIDECAR, ["network-policy", "allow", PROXY_HOST])
+            self.assertEqual(restored.returncode, 0, restored.stderr)
+
     def test_relay_admits_only_a_subject_the_policy_governs(self) -> None:
         # The gate runs against live containers rather than a fixture, so what
         # it parses is a real `/proc` and what it judges is a real namespace.

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -14,12 +14,17 @@ It needs a working Docker daemon and outbound network, so it is opt-in:
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 import subprocess
 import tempfile
+import types
 import unittest
 from pathlib import Path
+from unittest.mock import patch
+
+from test_relay_contract import load_relay
 
 HARBOR_DIR = Path(__file__).parent
 OVERLAY = HARBOR_DIR / "docker-compose-egress-proxy.yaml"
@@ -42,7 +47,11 @@ services:
 
   {SIDECAR}:
     image: {SIDECAR_IMAGE}
-    command: ["sleep", "infinity"]
+    # Harbor's own sidecar runs gost on the port the policy redirects to, so a
+    # redirected connection is accepted and then goes nowhere. Standing in for
+    # it keeps the negative assertions honest: without a listener they would
+    # hold on a refused connection instead of on the policy.
+    command: ["sh", "-c", "nc -l -k 12345 >/dev/null 2>&1 & exec sleep infinity"]
     network_mode: "service:main"
     cap_add:
       - NET_ADMIN
@@ -62,16 +71,23 @@ RUN apt-get update \\
 SIDECAR_DOCKERFILE = """\
 FROM debian:trixie-slim
 RUN apt-get update \\
-  && apt-get install -y --no-install-recommends nftables \\
+  && apt-get install -y --no-install-recommends nftables netcat-openbsd \\
   && rm -rf /var/lib/apt/lists/* \\
   && mkdir -p /opt/egress-sidecar
 """
 
+# The policy redirects TCP to the sidecar's proxy port rather than dropping it,
+# so the connection still completes and only the response tells a direct route
+# from a redirected one. Judging this on `connect` would assert nothing in a
+# cell where that proxy is listening, which is every real one.
 TCP_PROBE = (
     "import socket\n"
+    "request = b'GET / HTTP/1.0\\r\\nHost: one.one.one.one\\r\\n\\r\\n'\n"
     "try:\n"
-    "    socket.create_connection(('1.1.1.1', 443), 5).close()\n"
-    "    print('reachable')\n"
+    "    with socket.create_connection(('1.1.1.1', 80), 5) as sock:\n"
+    "        sock.settimeout(5)\n"
+    "        sock.sendall(request)\n"
+    "        print('reachable' if sock.recv(16).startswith(b'HTTP/') else 'blocked')\n"
     "except OSError:\n"
     "    print('blocked')\n"
 )
@@ -151,24 +167,6 @@ PACKET_PROBE = (
     "            if len(packet) >= 20 and packet[12:16] == socket.inet_aton('8.8.8.8'):\n"
     "                print('reachable')\n"
     "                break\n"
-    "    except OSError:\n"
-    "        print('blocked')\n"
-)
-
-# SO_MARK is 36 on Linux. gost marks its forwarded traffic, so a policy that
-# exempted that mark would let any subject able to set it leave unproxied.
-MARK_PROBE = (
-    "import socket\n"
-    "sock = socket.socket()\n"
-    "try:\n"
-    "    sock.setsockopt(socket.SOL_SOCKET, 36, 114514)\n"
-    "except OSError:\n"
-    "    print('blocked')\n"
-    "else:\n"
-    "    try:\n"
-    "        sock.settimeout(5)\n"
-    "        sock.connect(('1.1.1.1', 443))\n"
-    "        print('reachable')\n"
     "    except OSError:\n"
     "        print('blocked')\n"
 )
@@ -340,6 +338,14 @@ class CellEgressNamespaceTest(unittest.TestCase):
     def ping(cls) -> subprocess.CompletedProcess[str]:
         return cls.exec_main(["ping", "-c", "1", "-W", "5", "1.1.1.1"])
 
+    def test_relay_admits_a_subject_the_policy_governs(self) -> None:
+        # The relay's precondition gate runs against the live cell rather than a
+        # fixture, so the port it looks for and the shape it parses are the ones
+        # a real sidecar and a real `/proc` produce.
+        relay = load_relay()
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            asyncio.run(relay._require_constrained_subject(CellEnvironment()))
+
     def test_subject_sees_only_the_ca_certificate(self) -> None:
         listed = self.exec_main(["ls", "--almost-all", "/opt/maka-egress"])
         self.assertEqual(listed.returncode, 0, listed.stderr)
@@ -371,9 +377,6 @@ class CellEgressNamespaceTest(unittest.TestCase):
         with self.subTest("direct IP TCP"):
             self.assertEqual(self.probe_main(TCP_PROBE), "blocked")
 
-        with self.subTest("forged sidecar packet mark"):
-            self.assertEqual(self.probe_main(MARK_PROBE), "blocked")
-
         # Not preceded by a reachability assertion like the others: this path is
         # closed by the missing capability rather than by the policy, so it is
         # already shut before the policy exists. `denied` rather than `blocked`
@@ -393,6 +396,16 @@ class CellEgressNamespaceTest(unittest.TestCase):
         with self.subTest("Docker DNS"):
             resolved = self.exec_main(["getent", "hosts", PROXY_HOST])
             self.assertEqual(resolved.returncode, 0, resolved.stderr)
+
+class CellEnvironment:
+    """Presents the live cell's `main` service as the relay's environment."""
+
+    async def exec(self, command: str, cwd=None, timeout_sec=None):
+        result = CellEgressNamespaceTest.exec_main(["sh", "-c", command])
+        return types.SimpleNamespace(
+            return_code=result.returncode, stdout=result.stdout, stderr=result.stderr
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -95,6 +95,66 @@ UDP_PROBE = (
     "    print('blocked')\n"
 )
 
+# An AF_PACKET socket writes at the link layer, below the IP output hooks the
+# policy installs, so no nftables rule can see this traffic at all. Only the
+# absence of NET_RAW stops it. The frame is addressed to the default gateway's
+# hardware address, which the pre-policy reachability assertions leave in the
+# neighbour table.
+PACKET_PROBE = (
+    "import socket, struct\n"
+    "query = (\n"
+    "    b'\\xab\\xcd\\x01\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00'\n"
+    "    b'\\x07example\\x03com\\x00\\x00\\x01\\x00\\x01'\n"
+    ")\n"
+    "def route():\n"
+    "    with open('/proc/net/route') as handle:\n"
+    "        for line in handle.readlines()[1:]:\n"
+    "            f = line.split()\n"
+    "            if f[1] == '00000000':\n"
+    "                return f[0], socket.inet_ntoa(struct.pack('<L', int(f[2], 16)))\n"
+    "    return None, None\n"
+    "def neighbour(address):\n"
+    "    with open('/proc/net/arp') as handle:\n"
+    "        for line in handle.readlines()[1:]:\n"
+    "            f = line.split()\n"
+    "            if f[0] == address and f[3] != '00:00:00:00:00:00':\n"
+    "                return bytes.fromhex(f[3].replace(':', ''))\n"
+    "    return None\n"
+    "def checksum(data):\n"
+    "    total = sum(struct.unpack('!%dH' % (len(data) // 2), data))\n"
+    "    while total >> 16:\n"
+    "        total = (total & 0xFFFF) + (total >> 16)\n"
+    "    return ~total & 0xFFFF\n"
+    "interface, gateway = route()\n"
+    "mac = neighbour(gateway) if gateway else None\n"
+    "if not interface or not mac:\n"
+    "    print('unusable')\n"
+    "else:\n"
+    "    try:\n"
+    "        sock = socket.socket(socket.AF_PACKET, socket.SOCK_DGRAM, 0x0800)\n"
+    "    except PermissionError:\n"
+    "        print('denied')\n"
+    "        raise SystemExit\n"
+    "    try:\n"
+    "        source = socket.gethostbyname(socket.gethostname())\n"
+    "        sock.bind((interface, 0x0800))\n"
+    "        sock.settimeout(5)\n"
+    "        udp = struct.pack('!HHHH', 40000, 53, 8 + len(query), 0) + query\n"
+    "        header = struct.pack(\n"
+    "            '!BBHHHBBH4s4s', 0x45, 0, 20 + len(udp), 0x1234, 0, 64, 17, 0,\n"
+    "            socket.inet_aton(source), socket.inet_aton('8.8.8.8'),\n"
+    "        )\n"
+    "        header = header[:10] + struct.pack('!H', checksum(header)) + header[12:]\n"
+    "        sock.sendto(header + udp, (interface, 0x0800, 0, 0, mac))\n"
+    "        while True:\n"
+    "            packet = sock.recv(2048)\n"
+    "            if len(packet) >= 20 and packet[12:16] == socket.inet_aton('8.8.8.8'):\n"
+    "                print('reachable')\n"
+    "                break\n"
+    "    except OSError:\n"
+    "        print('blocked')\n"
+)
+
 # SO_MARK is 36 on Linux. gost marks its forwarded traffic, so a policy that
 # exempted that mark would let any subject able to set it leave unproxied.
 MARK_PROBE = (
@@ -313,6 +373,13 @@ class CellEgressNamespaceTest(unittest.TestCase):
 
         with self.subTest("forged sidecar packet mark"):
             self.assertEqual(self.probe_main(MARK_PROBE), "blocked")
+
+        # Not preceded by a reachability assertion like the others: this path is
+        # closed by the missing capability rather than by the policy, so it is
+        # already shut before the policy exists. `denied` rather than `blocked`
+        # so a probe that breaks for any other reason cannot report success.
+        with self.subTest("link-layer AF_PACKET"):
+            self.assertEqual(self.probe_main(PACKET_PROBE), "denied")
 
         with self.subTest("external UDP"):
             self.assertEqual(self.probe_main(UDP_PROBE), "blocked")

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -1,0 +1,331 @@
+"""Prove the cell namespace forces subject egress through the audited proxy.
+
+The Python policy test only checks that `run_trial.py` hands Harbor the right
+allowlist. This test brings up the checked-in Compose overlay against a minimal
+Harbor-shaped base, applies the checked-in `network-policy` from a sidecar that
+shares the subject namespace, and asserts what the README promises: explicit
+proxy traffic works, everything else does not, and the subject never sees the
+CA private key or the audit log.
+
+It needs a working Docker daemon and outbound network, so it is opt-in:
+
+    MAKA_EVAL_EGRESS_NAMESPACE_TEST=1 python3 harbor/test_cell_egress_namespace.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+HARBOR_DIR = Path(__file__).parent
+OVERLAY = HARBOR_DIR / "docker-compose-egress-proxy.yaml"
+NETWORK_POLICY = HARBOR_DIR / "egress-proxy" / "network-policy"
+PROXY_IMAGE = "maka-eval-egress-proxy:12.2.3"
+MAIN_IMAGE = "maka-eval-egress-namespace-main:test"
+SIDECAR_IMAGE = "maka-eval-egress-namespace-sidecar:test"
+PROJECT = "maka-eval-egress-namespace-test"
+PROXY_HOST = "maka-eval-mitmproxy"
+SIDECAR = "harbor-docker-egress-control-sidecar"
+CA_PATH = "/opt/maka-egress/mitmproxy-ca-cert.pem"
+BUILD_TIMEOUT_S = 900
+COMMAND_TIMEOUT_S = 120
+
+BASE_COMPOSE = f"""\
+services:
+  main:
+    image: {MAIN_IMAGE}
+    command: ["sleep", "infinity"]
+
+  {SIDECAR}:
+    image: {SIDECAR_IMAGE}
+    command: ["sleep", "infinity"]
+    network_mode: "service:main"
+    cap_add:
+      - NET_ADMIN
+    depends_on:
+      - main
+"""
+
+MAIN_DOCKERFILE = """\
+FROM python:3.12-slim
+RUN apt-get update \\
+  && apt-get install -y --no-install-recommends ca-certificates curl iputils-ping \\
+  && rm -rf /var/lib/apt/lists/*
+"""
+
+# Debian bookworm ships nftables 1.0.6, which rejects the `dstnat` priority name
+# on a nat output chain; the policy needs 1.1 or newer, as Harbor's sidecar has.
+SIDECAR_DOCKERFILE = """\
+FROM debian:trixie-slim
+RUN apt-get update \\
+  && apt-get install -y --no-install-recommends nftables \\
+  && rm -rf /var/lib/apt/lists/* \\
+  && mkdir -p /opt/egress-sidecar
+"""
+
+TCP_PROBE = (
+    "import socket\n"
+    "try:\n"
+    "    socket.create_connection(('1.1.1.1', 443), 5).close()\n"
+    "    print('reachable')\n"
+    "except OSError:\n"
+    "    print('blocked')\n"
+)
+
+# A well-formed query for example.com. A malformed datagram is dropped without a
+# reply even by a reachable resolver, which would report the open network as
+# blocked and silently retire this probe's assertion.
+UDP_PROBE = (
+    "import socket\n"
+    "query = (\n"
+    "    b'\\xab\\xcd\\x01\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00'\n"
+    "    b'\\x07example\\x03com\\x00\\x00\\x01\\x00\\x01'\n"
+    ")\n"
+    "sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n"
+    "sock.settimeout(5)\n"
+    "try:\n"
+    "    sock.sendto(query, ('8.8.8.8', 53))\n"
+    "    sock.recvfrom(512)\n"
+    "    print('reachable')\n"
+    "except OSError:\n"
+    "    print('blocked')\n"
+)
+
+# SO_MARK is 36 on Linux. gost marks its forwarded traffic, so a policy that
+# exempted that mark would let any subject able to set it leave unproxied.
+MARK_PROBE = (
+    "import socket\n"
+    "sock = socket.socket()\n"
+    "try:\n"
+    "    sock.setsockopt(socket.SOL_SOCKET, 36, 114514)\n"
+    "except OSError:\n"
+    "    print('blocked')\n"
+    "else:\n"
+    "    try:\n"
+    "        sock.settimeout(5)\n"
+    "        sock.connect(('1.1.1.1', 443))\n"
+    "        print('reachable')\n"
+    "    except OSError:\n"
+    "        print('blocked')\n"
+)
+
+LOOPBACK_PROBE = (
+    "import socket\n"
+    "server = socket.socket()\n"
+    "server.bind(('127.0.0.1', 0))\n"
+    "server.listen(1)\n"
+    "client = socket.create_connection(server.getsockname(), 5)\n"
+    "client.close()\n"
+    "print('reachable')\n"
+)
+
+PROXY_ENVIRONMENT = {
+    "HTTPS_PROXY": f"http://{PROXY_HOST}:8080",
+    "CURL_CA_BUNDLE": CA_PATH,
+}
+
+# The bypass attempt carries no CA override: pinning trust to the cell CA would
+# fail a successful direct connection on certificate verification instead, and
+# the assertion would hold even with the policy removed.
+BYPASS_ENVIRONMENT = {"HTTPS_PROXY": f"http://{PROXY_HOST}:8080"}
+
+
+def docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    probe = subprocess.run(
+        ["docker", "version", "--format", "{{.Server.Version}}"],
+        capture_output=True,
+        timeout=COMMAND_TIMEOUT_S,
+    )
+    return probe.returncode == 0
+
+
+@unittest.skipUnless(
+    os.environ.get("MAKA_EVAL_EGRESS_NAMESPACE_TEST") == "1",
+    "set MAKA_EVAL_EGRESS_NAMESPACE_TEST=1 to run the Docker cell namespace test",
+)
+class CellEgressNamespaceTest(unittest.TestCase):
+    workdir: Path | None = None
+    compose: list[str] = []
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        if not docker_available():
+            raise unittest.SkipTest("Docker daemon is unavailable")
+        cls.workdir = Path(tempfile.mkdtemp(prefix="maka-eval-egress-namespace-"))
+        # Registered before anything can fail: `tearDownClass` does not run when
+        # `setUpClass` raises, which would leak the stack and the named volume.
+        cls.addClassCleanup(shutil.rmtree, cls.workdir, ignore_errors=True)
+        (cls.workdir / "base.yaml").write_text(BASE_COMPOSE)
+        cls.build_image(MAIN_IMAGE, dockerfile=MAIN_DOCKERFILE, name="main")
+        cls.build_image(SIDECAR_IMAGE, dockerfile=SIDECAR_DOCKERFILE, name="sidecar")
+        cls.build_image(
+            PROXY_IMAGE, context=HARBOR_DIR, path=HARBOR_DIR / "egress-proxy" / "Dockerfile"
+        )
+        cls.compose = [
+            "docker",
+            "compose",
+            "--project-name",
+            PROJECT,
+            "--file",
+            str(cls.workdir / "base.yaml"),
+            "--file",
+            str(OVERLAY),
+        ]
+        cls.run_compose(["down", "--volumes", "--remove-orphans"], check=False)
+        cls.addClassCleanup(
+            cls.run_compose, ["down", "--volumes", "--remove-orphans"], check=False
+        )
+        cls.run_compose(["up", "--detach", "--wait"], timeout=BUILD_TIMEOUT_S)
+
+    @classmethod
+    def build_image(
+        cls,
+        tag: str,
+        *,
+        dockerfile: str | None = None,
+        name: str | None = None,
+        context: Path | None = None,
+        path: Path | None = None,
+    ) -> None:
+        if dockerfile is not None:
+            context = cls.workdir / name
+            context.mkdir()
+            (context / "Dockerfile").write_text(dockerfile)
+        subprocess.run(
+            [
+                "docker",
+                "build",
+                "--tag",
+                tag,
+                *(["--file", str(path)] if path else []),
+                str(context),
+            ],
+            check=True,
+            timeout=BUILD_TIMEOUT_S,
+        )
+
+    @classmethod
+    def run_compose(
+        cls,
+        arguments: list[str],
+        *,
+        check: bool = True,
+        timeout: int = COMMAND_TIMEOUT_S,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [*cls.compose, *arguments],
+            env={**os.environ, "MAKA_EVAL_NETWORK_POLICY_PATH": str(NETWORK_POLICY)},
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=timeout,
+        )
+
+    @classmethod
+    def exec_service(
+        cls,
+        service: str,
+        command: list[str],
+        *,
+        environment: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        overrides = [
+            argument
+            for name, value in (environment or {}).items()
+            for argument in ("--env", f"{name}={value}")
+        ]
+        return cls.run_compose(
+            ["exec", "--no-TTY", *overrides, service, *command], check=False
+        )
+
+    @classmethod
+    def exec_main(
+        cls, command: list[str], *, environment: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return cls.exec_service("main", command, environment=environment)
+
+    @classmethod
+    def probe_main(cls, script: str) -> str:
+        result = cls.exec_main(["python3", "-c", script])
+        if result.returncode != 0:
+            raise AssertionError(f"probe failed to run: {result.stderr}")
+        return result.stdout.strip()
+
+    @classmethod
+    def curl(
+        cls, arguments: list[str], *, environment: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        return cls.exec_main(
+            [
+                "curl",
+                "--silent",
+                "--show-error",
+                "--max-time",
+                "20",
+                "--output",
+                "/dev/null",
+                *arguments,
+                "https://example.com",
+            ],
+            environment=environment,
+        )
+
+    @classmethod
+    def ping(cls) -> subprocess.CompletedProcess[str]:
+        return cls.exec_main(["ping", "-c", "1", "-W", "5", "1.1.1.1"])
+
+    def test_subject_sees_only_the_ca_certificate(self) -> None:
+        listed = self.exec_main(["ls", "--almost-all", "/opt/maka-egress"])
+        self.assertEqual(listed.returncode, 0, listed.stderr)
+        self.assertEqual(listed.stdout.split(), ["mitmproxy-ca-cert.pem"])
+
+    def test_cell_namespace_admits_only_the_audited_proxy(self) -> None:
+        # Every negative assertion below is vacuous on a host that cannot reach
+        # the target anyway, so the reachability of each one is asserted before
+        # the policy exists. Failing there is the point: a skip would report a
+        # contract this run never actually exercised.
+        self.assertEqual(self.curl([]).returncode, 0, "no HTTPS before any policy")
+        self.assertEqual(self.probe_main(TCP_PROBE), "reachable")
+        self.assertEqual(self.probe_main(UDP_PROBE), "reachable")
+        self.assertEqual(self.ping().returncode, 0, "no ICMP before any policy")
+
+        applied = self.exec_service(
+            SIDECAR, ["network-policy", "allow", PROXY_HOST]
+        )
+        self.assertEqual(applied.returncode, 0, applied.stderr)
+
+        with self.subTest("explicit proxy HTTPS"):
+            allowed = self.curl([], environment=PROXY_ENVIRONMENT)
+            self.assertEqual(allowed.returncode, 0, allowed.stderr)
+
+        with self.subTest("curl --noproxy"):
+            bypassed = self.curl(["--noproxy", "*"], environment=BYPASS_ENVIRONMENT)
+            self.assertNotEqual(bypassed.returncode, 0)
+
+        with self.subTest("direct IP TCP"):
+            self.assertEqual(self.probe_main(TCP_PROBE), "blocked")
+
+        with self.subTest("forged sidecar packet mark"):
+            self.assertEqual(self.probe_main(MARK_PROBE), "blocked")
+
+        with self.subTest("external UDP"):
+            self.assertEqual(self.probe_main(UDP_PROBE), "blocked")
+
+        with self.subTest("external ICMP"):
+            self.assertNotEqual(self.ping().returncode, 0)
+
+        with self.subTest("loopback provider proxy"):
+            self.assertEqual(self.probe_main(LOOPBACK_PROBE), "reachable")
+
+        with self.subTest("Docker DNS"):
+            resolved = self.exec_main(["getent", "hosts", PROXY_HOST])
+            self.assertEqual(resolved.returncode, 0, resolved.stderr)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -448,7 +448,14 @@ class CellEnvironment:
         self.service = service
 
     async def exec(self, command: str, cwd=None, timeout_sec=None):
-        result = CellEgressNamespaceTest.exec_service(self.service, ["sh", "-c", command])
+        return self._run(self.service, command)
+
+    async def service_exec(self, command: str, *, service: str, **kwargs):
+        return self._run(service, command)
+
+    @staticmethod
+    def _run(service: str, command: str):
+        result = CellEgressNamespaceTest.exec_service(service, ["sh", "-c", command])
         return types.SimpleNamespace(
             return_code=result.returncode, stdout=result.stdout, stderr=result.stderr
         )

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -35,6 +35,8 @@ SIDECAR_IMAGE = "maka-eval-egress-namespace-sidecar:test"
 PROJECT = "maka-eval-egress-namespace-test"
 PROXY_HOST = "maka-eval-mitmproxy"
 SIDECAR = "harbor-docker-egress-control-sidecar"
+OUTSIDER = "maka-eval-outside-the-namespace"
+BOUNDED = "maka-eval-bounded-capability"
 CA_PATH = "/opt/maka-egress/mitmproxy-ca-cert.pem"
 BUILD_TIMEOUT_S = 900
 COMMAND_TIMEOUT_S = 120
@@ -55,6 +57,26 @@ services:
     network_mode: "service:main"
     cap_add:
       - NET_ADMIN
+    depends_on:
+      - main
+
+  # Two services the gate must refuse, so its live coverage is not only the
+  # positive case. This one keeps its own network namespace, the way Harbor
+  # leaves a subject whose task declares its own networking.
+  {OUTSIDER}:
+    image: {MAIN_IMAGE}
+    command: ["sleep", "infinity"]
+    cap_drop:
+      - NET_RAW
+
+  # This one shares the policy's namespace and reports an empty effective set,
+  # while the bounding set still lets a file-capability executable take NET_RAW
+  # back. Reading only the effective set would admit it.
+  {BOUNDED}:
+    image: {MAIN_IMAGE}
+    command: ["sleep", "infinity"]
+    network_mode: "service:main"
+    user: "1000"
     depends_on:
       - main
 """
@@ -338,13 +360,20 @@ class CellEgressNamespaceTest(unittest.TestCase):
     def ping(cls) -> subprocess.CompletedProcess[str]:
         return cls.exec_main(["ping", "-c", "1", "-W", "5", "1.1.1.1"])
 
-    def test_relay_admits_a_subject_the_policy_governs(self) -> None:
-        # The relay's precondition gate runs against the live cell rather than a
-        # fixture, so the port it looks for and the shape it parses are the ones
-        # a real sidecar and a real `/proc` produce.
+    def test_relay_admits_only_a_subject_the_policy_governs(self) -> None:
+        # The gate runs against live containers rather than a fixture, so what
+        # it parses is a real `/proc` and what it judges is a real namespace.
+        # The refusals matter more than the admission: without them nothing
+        # would catch a probe that reports one constant answer.
         relay = load_relay()
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
-            asyncio.run(relay._require_constrained_subject(CellEnvironment()))
+            asyncio.run(relay._require_constrained_subject(CellEnvironment("main")))
+            with self.assertRaises(RuntimeError) as outside:
+                asyncio.run(relay._require_constrained_subject(CellEnvironment(OUTSIDER)))
+            with self.assertRaises(RuntimeError) as bounded:
+                asyncio.run(relay._require_constrained_subject(CellEnvironment(BOUNDED)))
+        self.assertIn("network namespace", str(outside.exception))
+        self.assertIn("NET_RAW", str(bounded.exception))
 
     def test_subject_sees_only_the_ca_certificate(self) -> None:
         listed = self.exec_main(["ls", "--almost-all", "/opt/maka-egress"])
@@ -398,10 +427,13 @@ class CellEgressNamespaceTest(unittest.TestCase):
             self.assertEqual(resolved.returncode, 0, resolved.stderr)
 
 class CellEnvironment:
-    """Presents the live cell's `main` service as the relay's environment."""
+    """Presents one live cell service as the relay's environment."""
+
+    def __init__(self, service: str) -> None:
+        self.service = service
 
     async def exec(self, command: str, cwd=None, timeout_sec=None):
-        result = CellEgressNamespaceTest.exec_main(["sh", "-c", command])
+        result = CellEgressNamespaceTest.exec_service(self.service, ["sh", "-c", command])
         return types.SimpleNamespace(
             return_code=result.returncode, stdout=result.stdout, stderr=result.stderr
         )

--- a/packages/eval/harbor/test_egress_filter.py
+++ b/packages/eval/harbor/test_egress_filter.py
@@ -30,6 +30,8 @@ class EgressFilterTest(unittest.TestCase):
             "https://example.test/search?q=TeRmInAlBeNcH": "terminal_bench_url",
             "https://google.com/search?q=terminal+bench": "terminal_bench_url",
             "https://github.com/harbor-framework/terminal%252Dbench-2-1.git": "benchmark_repository",
+            "https://terminal-bench.io/tasks/answers": "terminal_bench_url",
+            "https://sub.tbench.ai/x": "tbench_domain",
         }
         for url, rule_id in blocked.items():
             matched = MODULE.contamination_rule(url)
@@ -43,6 +45,7 @@ class EgressFilterTest(unittest.TestCase):
             "https://huggingface.co/datasets/mteb/leaderboard",
             "https://pypi.org/simple/requests/",
             "https://deb.debian.org/debian/",
+            "https://my-terminal/bench",
         ]
         for url in allowed:
             self.assertIsNone(MODULE.contamination_rule(url), url)

--- a/packages/eval/harbor/test_egress_filter.py
+++ b/packages/eval/harbor/test_egress_filter.py
@@ -32,6 +32,10 @@ class EgressFilterTest(unittest.TestCase):
             "https://github.com/harbor-framework/terminal%252Dbench-2-1.git": "benchmark_repository",
             "https://terminal-bench.io/tasks/answers": "terminal_bench_url",
             "https://sub.tbench.ai/x": "tbench_domain",
+            # A DNS label is as good a place to name a contamination surface as
+            # a path, so every rule searches both fields.
+            f"https://{MODULE.PINNED_REVISION}.example.test/archive": "pinned_revision",
+            "https://patches-terminalbench-task-1.example.test/x": "known_patch_artifact",
         }
         for url, rule_id in blocked.items():
             matched = MODULE.contamination_rule(url)

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -295,10 +295,14 @@ class RelayContractTest(unittest.TestCase):
 
 # Every default Docker capability except the two that bypass the policy.
 CONSTRAINED_CAPABILITIES = 0xA80425FB & ~(1 << 13) & ~(1 << 12)
+# The kernel's form for a namespace link target. Two distinct ones, because what
+# the check compares is identity: the same string means the same namespace.
+POLICY_NAMESPACE = "net:[4026532001]"
+OWN_NAMESPACE = "net:[4026532099]"
 
 
 class SubjectEnvironment:
-    """Reports the evidence the probe reads: every `Cap` set, and the namespace."""
+    """Reports the evidence the probe reads: every `Cap` set, and both namespaces."""
 
     def __init__(
         self,
@@ -306,7 +310,7 @@ class SubjectEnvironment:
         permitted: int = CONSTRAINED_CAPABILITIES,
         effective: int | None = None,
         bounding: int | None = None,
-        namespace: str = "shared",
+        namespace: str = POLICY_NAMESPACE,
     ) -> None:
         self.sets = {
             "CapInh": 0,
@@ -317,6 +321,7 @@ class SubjectEnvironment:
         }
         self.namespace = namespace
         self.commands: list[str] = []
+        self.services: list[str] = []
 
     async def exec(self, command: str, cwd=None, timeout_sec=None):
         self.commands.append(command)
@@ -329,6 +334,25 @@ class SubjectEnvironment:
             ),
             stderr="",
         )
+
+    async def service_exec(self, command: str, *, service: str, **kwargs):
+        self.services.append(service)
+        return types.SimpleNamespace(
+            return_code=0,
+            stdout=f"MAKA-EVAL-POLICY-NAMESPACE-V1 {POLICY_NAMESPACE}\n",
+            stderr="",
+        )
+
+
+def _echoing_service_exec(answer: str):
+    async def service_exec(command: str, *, service: str, **kwargs):
+        return types.SimpleNamespace(
+            return_code=0,
+            stdout=f"MAKA-EVAL-POLICY-NAMESPACE-V1 {answer}\n",
+            stderr="",
+        )
+
+    return service_exec
 
 
 class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
@@ -366,11 +390,22 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
         # Harbor applies the policy inside the sidecar and respects a task's own
         # networking on `main`, so a task that declares it leaves the subject in
         # a namespace no policy was ever applied to.
-        environment = SubjectEnvironment(namespace="separate")
+        environment = SubjectEnvironment(namespace=OWN_NAMESPACE)
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
             with self.assertRaises(RuntimeError) as raised:
                 await relay._require_constrained_subject(environment)
         self.assertIn("network namespace", str(raised.exception))
+
+    async def test_policy_namespace_is_read_from_the_service_that_applies_the_policy(self):
+        relay = load_relay()
+        # The comparison is only meaningful against the namespace the policy was
+        # installed in, and Harbor installs it by running `network-policy` in the
+        # egress sidecar. Reading the other side from anywhere else would compare
+        # the subject against a namespace nothing was applied to.
+        environment = SubjectEnvironment()
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            await relay._require_constrained_subject(environment)
+        self.assertEqual(environment.services, ["harbor-docker-egress-control-sidecar"])
 
     async def test_constrained_subject_proceeds(self):
         relay = load_relay()
@@ -384,16 +419,32 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
             async def exec(self, command, cwd=None, timeout_sec=None):
                 return types.SimpleNamespace(return_code=0, stdout="", stderr="")
 
+            async def service_exec(self, command, *, service, **kwargs):
+                return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
             with self.assertRaises(RuntimeError):
                 await relay._require_constrained_subject(SilentEnvironment())
 
+    async def test_answer_that_is_not_a_namespace_identity_fails_closed(self):
+        relay = load_relay()
+        # Two sides that both failed to answer must not compare equal. Anything
+        # that is not the kernel's own form is not an identity to compare.
+        for answer in ("", "shared", "net:[]"):
+            with self.subTest(answer):
+                environment = SubjectEnvironment(namespace=answer)
+                environment.service_exec = _echoing_service_exec(answer)
+                with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+                    with self.assertRaises(RuntimeError):
+                        await relay._require_constrained_subject(environment)
+
     async def test_check_is_scoped_to_runs_that_require_the_proxy(self):
         relay = load_relay()
-        environment = SubjectEnvironment(permitted=1 << 13, namespace="separate")
+        environment = SubjectEnvironment(permitted=1 << 13, namespace=OWN_NAMESPACE)
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": ""}):
             await relay._require_constrained_subject(environment)
         self.assertEqual(environment.commands, [])
+        self.assertEqual(environment.services, [])
 
 
 if __name__ == "__main__":

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -293,5 +293,61 @@ class RelayContractTest(unittest.TestCase):
                 target.unlink(missing_ok=True)
 
 
+class CapabilityEnvironment:
+    """Reports one `CapEff` mask, the way `/proc/self/status` does."""
+
+    def __init__(self, effective: int) -> None:
+        self.effective = effective
+        self.commands: list[str] = []
+
+    async def exec(self, command: str, cwd=None, timeout_sec=None):
+        self.commands.append(command)
+        return types.SimpleNamespace(
+            return_code=0,
+            stdout=f"MAKA-EVAL-CAPABILITIES-V1 {self.effective:016x}\n",
+            stderr="",
+        )
+
+
+class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
+    async def test_subject_holding_a_bypass_capability_never_starts(self):
+        relay = load_relay()
+        # Named here rather than read from the module: sourcing the expectation
+        # from the code under test would let deleting a capability delete its
+        # own coverage. NET_RAW grants AF_PACKET, NET_ADMIN grants `nft flush`.
+        for name, bit in (("NET_RAW", 1 << 13), ("NET_ADMIN", 1 << 12)):
+            with self.subTest(name):
+                environment = CapabilityEnvironment(bit | (1 << 21))
+                with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+                    with self.assertRaises(RuntimeError) as raised:
+                        await relay._require_constrained_subject(environment)
+                self.assertIn(name, str(raised.exception))
+
+    async def test_constrained_subject_proceeds(self):
+        relay = load_relay()
+        # Every default Docker capability except the two that bypass the policy.
+        environment = CapabilityEnvironment(0xA80425FB & ~(1 << 13) & ~(1 << 12))
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            await relay._require_constrained_subject(environment)
+
+    async def test_unreadable_capability_set_fails_closed(self):
+        relay = load_relay()
+
+        class SilentEnvironment:
+            async def exec(self, command, cwd=None, timeout_sec=None):
+                return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            with self.assertRaises(RuntimeError):
+                await relay._require_constrained_subject(SilentEnvironment())
+
+    async def test_check_is_scoped_to_runs_that_require_the_proxy(self):
+        relay = load_relay()
+        environment = CapabilityEnvironment(1 << 13)
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": ""}):
+            await relay._require_constrained_subject(environment)
+        self.assertEqual(environment.commands, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -293,18 +293,40 @@ class RelayContractTest(unittest.TestCase):
                 target.unlink(missing_ok=True)
 
 
-class CapabilityEnvironment:
-    """Reports one `CapEff` mask, the way `/proc/self/status` does."""
+# Every default Docker capability except the two that bypass the policy.
+CONSTRAINED_CAPABILITIES = 0xA80425FB & ~(1 << 13) & ~(1 << 12)
 
-    def __init__(self, effective: int) -> None:
-        self.effective = effective
+
+class SubjectEnvironment:
+    """Reports the evidence the probe reads: every `Cap` set, and the namespace."""
+
+    def __init__(
+        self,
+        *,
+        permitted: int = CONSTRAINED_CAPABILITIES,
+        effective: int | None = None,
+        bounding: int | None = None,
+        namespace: str = "shared",
+    ) -> None:
+        self.sets = {
+            "CapInh": 0,
+            "CapPrm": permitted,
+            "CapEff": permitted if effective is None else effective,
+            "CapBnd": permitted if bounding is None else bounding,
+            "CapAmb": 0,
+        }
+        self.namespace = namespace
         self.commands: list[str] = []
 
     async def exec(self, command: str, cwd=None, timeout_sec=None):
         self.commands.append(command)
+        reported = " ".join(f"{name}={value:016x}" for name, value in self.sets.items())
         return types.SimpleNamespace(
             return_code=0,
-            stdout=f"MAKA-EVAL-CAPABILITIES-V1 {self.effective:016x}\n",
+            stdout=(
+                f"MAKA-EVAL-CAPABILITIES-V1 {reported}\n"
+                f"MAKA-EVAL-POLICY-NAMESPACE-V1 {self.namespace}\n"
+            ),
             stderr="",
         )
 
@@ -317,20 +339,45 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
         # own coverage. NET_RAW grants AF_PACKET, NET_ADMIN grants `nft flush`.
         for name, bit in (("NET_RAW", 1 << 13), ("NET_ADMIN", 1 << 12)):
             with self.subTest(name):
-                environment = CapabilityEnvironment(bit | (1 << 21))
+                environment = SubjectEnvironment(permitted=bit | (1 << 21))
                 with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
                     with self.assertRaises(RuntimeError) as raised:
                         await relay._require_constrained_subject(environment)
                 self.assertIn(name, str(raised.exception))
 
+    async def test_capability_reachable_only_through_the_bounding_set_never_starts(self):
+        relay = load_relay()
+        # A non-root subject reports an empty effective set while a
+        # `cap_net_raw+ep` executable still reacquires whatever the bounding set
+        # kept. Verified in a container: with the capability bounded away the
+        # same executable cannot be run at all.
+        environment = SubjectEnvironment(
+            permitted=0,
+            effective=0,
+            bounding=CONSTRAINED_CAPABILITIES | (1 << 13),
+        )
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            with self.assertRaises(RuntimeError) as raised:
+                await relay._require_constrained_subject(environment)
+        self.assertIn("NET_RAW", str(raised.exception))
+
+    async def test_subject_outside_the_policy_namespace_never_starts(self):
+        relay = load_relay()
+        # Harbor applies the policy inside the sidecar and respects a task's own
+        # networking on `main`, so a task that declares it leaves the subject in
+        # a namespace no policy was ever applied to.
+        environment = SubjectEnvironment(namespace="separate")
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            with self.assertRaises(RuntimeError) as raised:
+                await relay._require_constrained_subject(environment)
+        self.assertIn("network namespace", str(raised.exception))
+
     async def test_constrained_subject_proceeds(self):
         relay = load_relay()
-        # Every default Docker capability except the two that bypass the policy.
-        environment = CapabilityEnvironment(0xA80425FB & ~(1 << 13) & ~(1 << 12))
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
-            await relay._require_constrained_subject(environment)
+            await relay._require_constrained_subject(SubjectEnvironment())
 
-    async def test_unreadable_capability_set_fails_closed(self):
+    async def test_unreadable_evidence_fails_closed(self):
         relay = load_relay()
 
         class SilentEnvironment:
@@ -343,7 +390,7 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_check_is_scoped_to_runs_that_require_the_proxy(self):
         relay = load_relay()
-        environment = CapabilityEnvironment(1 << 13)
+        environment = SubjectEnvironment(permitted=1 << 13, namespace="separate")
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": ""}):
             await relay._require_constrained_subject(environment)
         self.assertEqual(environment.commands, [])

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -19,7 +19,7 @@
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test:dist": "node --test \"dist/**/*.test.js\" && python3 harbor/test_relay_contract.py && python3 harbor/test_relay_lifecycle.py && python3 harbor/test_egress_filter.py && python3 harbor/test_run_trial_policy.py && python3 harbor/test_relay_artifacts.py"
+    "test:dist": "node --test \"dist/**/*.test.js\" && python3 harbor/test_relay_contract.py && python3 harbor/test_relay_lifecycle.py && python3 harbor/test_egress_filter.py && python3 harbor/test_run_trial_policy.py && python3 harbor/test_relay_artifacts.py && python3 harbor/test_cell_egress_namespace.py"
   },
   "dependencies": {
     "@maka/core": "0.1.0",

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -821,13 +821,23 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
   assert.match(egressCompose, /networks:\s*\n\s+- default/u);
   assert.match(egressCompose, /target: \/usr\/local\/bin\/network-policy/u);
   // The subject shares the sidecar's network namespace, so any packet mark it
-  // could set is one the subject can set too. The namespace test proves this in
-  // a live cell; this keeps the rule from reappearing where that test is opt-in.
+  // could set is one the subject can set too. No live probe can show this any
+  // more — without NET_RAW the subject cannot set a mark at all — so the rule's
+  // absence is asserted where it is written.
   const networkPolicy = await readFile(
     new URL('../../harbor/egress-proxy/network-policy', import.meta.url),
     'utf8',
   );
   assert.doesNotMatch(networkPolicy, /meta mark \S+ (?:accept|return)/u);
+  // The relay proves the subject shares the policy's namespace by looking for
+  // the proxy's listening socket, so its port has to be the one the policy
+  // redirects to. The two constants live in different languages.
+  const relayAgent = await readFile(
+    new URL('../../harbor/relay_agent.py', import.meta.url),
+    'utf8',
+  );
+  const policyPort = /^GOST_PORT=(\d+)$/mu.exec(networkPolicy)![1];
+  assert.match(relayAgent, new RegExp(`^POLICY_PROXY_PORT = ${policyPort}$`, 'mu'));
   assert.deepEqual(
     spec.executor.config.mounts.map(({ target }) => target),
     [

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -834,15 +834,17 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
     'utf8',
   );
   assert.doesNotMatch(networkPolicy, /meta mark \S+ (?:accept|return)/u);
-  // The relay proves the subject shares the policy's namespace by looking for
-  // the proxy's listening socket, so its port has to be the one the policy
-  // redirects to. The two constants live in different languages.
+  // The relay compares the subject's namespace against the namespace of the
+  // service that installs the policy, so the service it reads has to be the one
+  // the overlay mounts the policy script into. The two names live in different
+  // languages, and a rename on either side leaves the comparison meaningless
+  // rather than failing.
   const relayAgent = await readFile(
     new URL('../../harbor/relay_agent.py', import.meta.url),
     'utf8',
   );
-  const policyPort = /^GOST_PORT=(\d+)$/mu.exec(networkPolicy)![1];
-  assert.match(relayAgent, new RegExp(`^POLICY_PROXY_PORT = ${policyPort}$`, 'mu'));
+  const policyService = /^POLICY_SERVICE = "([^"]+)"$/mu.exec(relayAgent)![1];
+  assert.match(egressCompose, new RegExp(`^ {2}${policyService}:$`, 'mu'));
   assert.deepEqual(
     spec.executor.config.mounts.map(({ target }) => target),
     [

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -817,6 +817,7 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
   assert.doesNotMatch(egressCompose, /^\s*ports:/mu);
   assert.match(egressCompose, /condition: service_healthy/u);
   assert.match(egressCompose, /maka-eval-egress-ca:\/opt\/maka-egress:ro/u);
+  assert.match(egressCompose, /cap_drop:\s*\n\s+- NET_RAW/u);
   assert.match(egressCompose, /networks:\s*\n\s+- default/u);
   assert.match(egressCompose, /target: \/usr\/local\/bin\/network-policy/u);
   // The subject shares the sidecar's network namespace, so any packet mark it

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -816,8 +816,13 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
   );
   assert.doesNotMatch(egressCompose, /^\s*ports:/mu);
   assert.match(egressCompose, /condition: service_healthy/u);
-  assert.match(egressCompose, /maka-eval-egress-ca:\/opt\/maka-egress:ro/u);
-  assert.match(egressCompose, /cap_drop:\s*\n\s+- NET_RAW/u);
+  // Scoped to the subject's own block: a whole-file match would still hold with
+  // the capability drop or the read-only flag moved onto the proxy service.
+  const subjectService = egressCompose
+    .split(/\n(?= {2}\S)/u)
+    .find((block) => block.trimStart().startsWith('main:'))!;
+  assert.match(subjectService, /maka-eval-egress-ca:\/opt\/maka-egress:ro/u);
+  assert.match(subjectService, /cap_drop:\s*\n\s+- NET_RAW/u);
   assert.match(egressCompose, /networks:\s*\n\s+- default/u);
   assert.match(egressCompose, /target: \/usr\/local\/bin\/network-policy/u);
   // The subject shares the sidecar's network namespace, so any packet mark it

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -8,7 +8,7 @@ import { promisify } from 'node:util';
 import { FileAttemptStore } from '../attempt-store.js';
 import type { ExperimentCell, ExperimentSpec, JsonObject } from '../experiment.js';
 import { createExternalSubjectAdapter } from '../external-subject.js';
-import { createHarborExecutor } from '../harness-executor.js';
+import { createHarborExecutor, createPierExecutor } from '../harness-executor.js';
 import { makaEvalRuntimePolicyDocument } from '../maka-runtime-policy.js';
 import { createMakaSubjectAdapter } from '../maka-subject.js';
 import {
@@ -816,9 +816,17 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
   );
   assert.doesNotMatch(egressCompose, /^\s*ports:/mu);
   assert.match(egressCompose, /condition: service_healthy/u);
-  assert.match(egressCompose, /maka-eval-egress-state:\/opt\/maka-egress/u);
+  assert.match(egressCompose, /maka-eval-egress-ca:\/opt\/maka-egress:ro/u);
   assert.match(egressCompose, /networks:\s*\n\s+- default/u);
   assert.match(egressCompose, /target: \/usr\/local\/bin\/network-policy/u);
+  // The subject shares the sidecar's network namespace, so any packet mark it
+  // could set is one the subject can set too. The namespace test proves this in
+  // a live cell; this keeps the rule from reappearing where that test is opt-in.
+  const networkPolicy = await readFile(
+    new URL('../../harbor/egress-proxy/network-policy', import.meta.url),
+    'utf8',
+  );
+  assert.doesNotMatch(networkPolicy, /meta mark \S+ (?:accept|return)/u);
   assert.deepEqual(
     spec.executor.config.mounts.map(({ target }) => target),
     [
@@ -1003,6 +1011,25 @@ function experiment(): ExperimentSpec {
     verifier: { reward: 'reward' },
   };
 }
+
+test('pier cannot declare an egress proxy it never enforces', () => {
+  const egressProxy = {
+    composeSourceEnv: 'MAKA_TEST_BUNDLE',
+    composeRelativePath: 'packages/eval/harbor/docker-compose-egress-proxy.yaml',
+    networkPolicyRelativePath: 'packages/eval/harbor/egress-proxy/network-policy',
+    proxyUrl: 'http://maka-eval-mitmproxy:8080',
+    allowedHost: 'maka-eval-mitmproxy',
+    containerCaPath: '/opt/maka-egress/mitmproxy-ca-cert.pem',
+  };
+  assert.throws(
+    () =>
+      createPierExecutor(
+        { ...executorConfig(), tasksRootEnv: 'MAKA_TEST_TASKS', egressProxy },
+        'experiment.json',
+      ),
+    /egressProxy is Harbor-only/u,
+  );
+});
 
 function executorConfig(): JsonObject {
   return {

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -406,7 +406,7 @@ async function startTrial(
           ? {
               artifacts: [
                 {
-                  source: '/opt/maka-egress/hits.jsonl',
+                  source: '/opt/maka-egress-state/hits.jsonl',
                   destination: 'egress-hits.jsonl',
                   service: 'maka-eval-mitmproxy',
                 },
@@ -788,6 +788,14 @@ function decodeOptions(value: JsonObject, framework: Framework): HarnessOptions 
     'preparationEnvironment',
     'mounts',
   ];
+  // Only the Harbor branch of run_trial.py applies the namespace policy, so a
+  // pier spec declaring egressProxy would set the proxy up and inject its
+  // environment while enforcement silently did not exist.
+  if (framework === 'pier' && Object.hasOwn(value, 'egressProxy')) {
+    throw new Error(
+      'executor.config.egressProxy is Harbor-only: pier does not apply the subject namespace policy',
+    );
+  }
   if (Object.hasOwn(value, 'egressProxy')) fields.push('egressProxy');
   if (framework === 'pier') fields.push('tasksRootEnv');
   const options = exact(value, fields, 'executor.config');


### PR DESCRIPTION
## Summary

`packages/eval/README.md` states that the subject receives only what it needs to trust the per-cell CA, that all its traffic is forced through the audited proxy, and that the proxy blocks benchmark and public-solution contamination URLs. Five places from #2947 let that contract silently not hold.

**The CA private key was readable by the subject.** mitmproxy's `confdir` was the shared state volume, so the volume the subject mounts to trust the CA also carried `mitmproxy-ca.pem` and `hits.jsonl`, which records which of the subject's own requests were blocked. The proxy now creates the CA before it serves, keeps confdir and the audit log container-private, and publishes only `mitmproxy-ca-cert.pem` into a certificate-only volume, by rename so a restart cannot expose a truncated certificate. Publishing before the port opens means the health gate cannot release `main` against a missing or left-over certificate. The subject-visible path and `containerCaPath` are unchanged.

**The namespace policy accepted ICMP unconditionally** while rejecting every other non-TCP protocol. Harbor needs no ICMP here, so both accepts are gone and no narrowed exception replaces them.

**The subject could forge the sidecar's packet mark and bypass the proxy entirely.** The policy returned and accepted on that mark as a trusted identity — but the sidecar shares the subject's network namespace, so a mark the sidecar can set is one the subject can set too. Verified in a real cell before the fix: `setsockopt(SOL_SOCKET, SO_MARK, 114514)` followed by a direct connection to `1.1.1.1:443` succeeded, skipping both the NAT redirect and the filter chain (Docker grants `NET_RAW` by default, and on Linux 5.17+ `NET_RAW` alone suffices for `SO_MARK`).

The exemption also protected nothing: proxy-only mode empties gost's allowlist, so gost forwards no traffic that would need it. Both rules are therefore deleted rather than defended — removing them cannot widen the policy, since traffic gost would have carried is refused in this mode either way.

**The subject could also send below the policy entirely.** The rules hook the IP output path, so a socket that writes beneath it is invisible to them. With Docker's default capabilities the subject can open an `AF_PACKET` socket and address a frame to the gateway's hardware address: reproduced in a cell with the full policy applied, where a DNS query reached `8.8.8.8` and its answer came back while ordinary UDP to the same address was rejected. Reported by @M4n5ter, who found it independently. `NET_ADMIN` is equivalent in effect for a different reason — it can delete the ruleset outright.

The overlay drops `NET_RAW`, which closes the socket. That alone is not enough: this overlay is merged onto the task's own Compose file, and a `cap_add` there wins over a `cap_drop` here, so any task declaring either capability would silently restore the bypass — confirmed with `docker compose config` and `docker run --cap-drop NET_RAW --cap-add NET_ADMIN`. So the relay also reads the subject's effective capability set inside the subject container, after the policy is live and before the subject exists, and fails the attempt when it holds `NET_RAW` or `NET_ADMIN`; an unreadable capability set fails the same way. Both layers are needed: without the drop every task fails, and without the check the drop is advisory.

**Contamination rules never saw the hostname.** The search subject was path and query only, so only the exact `tbench.ai` host matched and `https://terminal-bench.io/tasks/answers` was allowed through. The host is now searched alongside the path, as a separate field so no rule can match across their boundary.

**pier could declare an egress proxy it never enforces.** `decodeOptions` accepted `egressProxy` for both frameworks, but only Harbor's branch of `run_trial.py` applies the namespace policy. Decoding a pier spec that declares it now fails with that reason.

Fixes #2958, which covers the first two. The rest come from the approving review on #2947 and from adversarial review of this branch; the remaining follow-ups there are not about isolation and are out of scope.

## Verification

`test_run_trial_policy.py` only asserts that two Python attributes are assigned, which nftables rules failing outright would not disturb — the coverage gap the review named. `harbor/test_cell_egress_namespace.py` brings up the checked-in Compose overlay and `network-policy` against a minimal Harbor-shaped base, with a sidecar sharing the subject namespace, and asserts the contract in a real cell namespace. It is opt-in (`MAKA_EVAL_EGRESS_NAMESPACE_TEST=1`).

Every negative assertion is vacuous on a host that cannot reach the target anyway, so each target's reachability is asserted before the policy exists. Failing there is deliberate: an earlier revision skipped instead, and that skip silently retired one of the assertions for an unrelated reason (see below).

`MAKA_EVAL_EGRESS_NAMESPACE_TEST=1 python3 harbor/test_cell_egress_namespace.py` — passes on Docker 29.7.2, all eight assertions executing. With the policy applied: `ls -A /opt/maka-egress` shows exactly `mitmproxy-ca-cert.pem`; explicit-proxy HTTPS succeeds; `curl --noproxy '*'`, direct-IP TCP, a forged `SO_MARK`, a link-layer `AF_PACKET` frame, external UDP and external ICMP all fail; the loopback provider proxy and Docker DNS still work.

Every assertion was checked against the mutation it exists to catch, and fails on it:

- restore the `accept` lines in `network-policy` → `[external ICMP] AssertionError: 0 == 0`
- restore the `meta mark` rules → `[forged sidecar packet mark] AssertionError: 'reachable' != 'blocked'`
- remove `cap_drop: [NET_RAW]` → `[link-layer AF_PACKET] AssertionError: 'reachable' != 'denied'`
- drop `NET_ADMIN` from the relay's bypass set → the capability contract test fails
- remove the TCP redirect rule → `[curl --noproxy] AssertionError: 0 == 0` and `[direct IP TCP] AssertionError: 'reachable' != 'blocked'`
- point `confdir` back at the shared volume → the listing becomes `['hits.jsonl', 'mitmproxy-ca-cert.cer', 'mitmproxy-ca-cert.p12', 'mitmproxy-ca-cert.pem', 'mitmproxy-ca.p12', 'mitmproxy-ca.pem', 'mitmproxy-dhparam.pem']`
- search the path alone → the new host-only URLs return `None` instead of a rule
- accept `egressProxy` for any framework → `✖ pier cannot declare an egress proxy it never enforces`
- report only `CapEff` from the probe → the bounded-capability service is admitted, live and in the contract test
- make the namespace evidence a constant → the out-of-namespace service is admitted, live
- move `cap_drop` or the read-only flag onto the proxy service → the compose assertions fail
- answer `deny-all` with the proxy-only ruleset → `[no-network] AssertionError: 0 == 0`
- keep `meta l4proto != tcp reject` → a connection opened before the policy keeps serving requests after it

Also run: root `npm run build`, `npm run test:dist` in `packages/eval` (31 node tests, all Python suites), `npm run format:check` at the root. No full-repository test run.

Two things worth confirming outside this change. The policy's `priority dstnat` on a nat output chain needs nftables 1.1 or newer; Debian bookworm's 1.0.6 rejects it outright, which is why the test sidecar is built on trixie — Harbor's own sidecar image is outside this PR, but on 1.0.x the policy would never apply at all. And `test:dist` runs in CI without `MAKA_EVAL_EGRESS_NAMESPACE_TEST=1`, so this test currently skips there; wiring a Docker-capable job for it is a separate infrastructure decision.

## Review record

Reviewed adversarially in two rounds by Codex, kimi-k3-256k, and a Claude subagent, run independently against this branch; the second round was given no knowledge of the first. Their findings were verified against source and by running the cell before being accepted; severities here are mine, not theirs.

Round one accepted: the forged-mark bypass (Codex only, reproduced in a live cell), the cross-field false positive introduced by the host-matching commit, the all-or-nothing skip in the test baseline, a vacuous compose assertion, the undiagnosable pier error, and several deletions.

Round two accepted, each reproduced first: the `cap_drop` layer being overridable by the task's own compose (two reviewers), which replaced that fix with deleting the mark exemption; a UDP probe sending a malformed one-byte datagram, whose reply never comes, so that assertion had never once executed; a `--noproxy` assertion neutered by its own `CURL_CA_BUNDLE`; the per-capability skip machinery itself, whose failure mode is reporting `OK (skipped)` for a contract the run never exercised; a README over-claim about which rules match the host; a missing `mkdir -p`; and a class-cleanup leak.

Rejected with reasons: replacing the capability check with an nftables cgroup match (unnecessary once nothing trusts the mark, and unreliable across cgroup namespaces); an execution-side pier guard for a state the decoder makes unreachable; deleting audit rules that are subsumed for the block decision but distinct in the audit label; and pinning the throwaway test images.

Round five closes the one case @M4n5ter left open when approving: the namespace check read the sidecar proxy's listening socket, which is visible only inside its own namespace but is still a proxy for the claim — a task that declares its own networking and happens to listen on the same port in it satisfied the evidence without sharing the namespace. The claim refers to the namespace Harbor installs the policy in, and the environment interface the relay already holds reaches that service, so the gate now reads `/proc/self/ns/net` on both sides and requires one identity. An inode has no collision space, so the case is removed rather than made unlikely. Net deletion: the port constant and the cross-language pin that kept it in step with the policy script are gone, and the pin now covers the sidecar service name, which is the coupling that remains. New mutations, each verified to fail: dropping the comparison; reading the policy side from the subject instead of the sidecar; removing the check that an answer is the kernel's own link form, without which two sides that both failed to answer compare equal; and renaming the service on either side of the pin.

Round four came from @M4n5ter's second review plus three fresh adversarial model reviews run against the branch. Accepted, each reproduced first: capability sets other than the effective one, where a non-root subject reports nothing while a `cap_net_raw+ep` executable takes `NET_RAW` back from the bounding set; a subject left outside the namespace the policy was applied to, because Harbor respects a task's own networking on the subject service and applies the policy in the sidecar regardless; a connection opened in an earlier phase surviving the policy switch in full, since the redirect is a NAT rule and NAT sees only a connection's first packet; `deny-all` being answered with proxy access; compose assertions that matched anywhere in the file; and an isolation gate whose refusals had no live coverage at all, because the contract test's environment fabricates the probe output rather than running it.

Deleted rather than fixed: the packet-mark probe. With `NET_RAW` dropped the subject cannot set a mark, so it had stopped measuring the rule it named and only restated that the capability was gone.

Rejected with reasons: rejecting a task's own networking in the decoder rather than observing the outcome, which would reimplement Harbor's service-selection rule here and let the two drift; replacing the probe with behavioural socket tests, which no task image is guaranteed to be able to run — the gate has `sh`, `sed` and `grep` and nothing more; and calling the gate forgeable, which it is, by a task image that already controls everything else in the cell. What the gate holds against is the subject, which starts only after it has passed, and a task that loses the isolation by accident. The README says so now.

Not fixed here and reported separately: Docker's embedded resolver at `127.0.0.11` forwards names it does not own to the host's upstream resolvers, and the namespace-local exemption that keeps the loopback provider proxies reachable keeps that reachable too. Reproduced by three reviewers and again here — a TXT query for an external zone returned real records while every other path was blocked. Closing it means letting the subject reach the proxy without resolving its name, which changes how the cell is addressed rather than what this ruleset says. A `CONNECT` tunnel carrying neither TLS nor HTTP likewise reaches no contamination rule and no audit record. Both are stated in the README instead of being left implied.

Round three came from @M4n5ter's review on this PR: the `AF_PACKET` link-layer bypass, which none of the three model reviewers found and which my own removal of `cap_drop` had left open — I had weighed that capability only against `SO_MARK`. Reproduced before fixing, and both the capability drop and the relay's fail-closed check are covered by mutation-verified tests.

A more fundamental fix exists and is deliberately not in this PR: give the subject its own network namespace whose only route out is the proxy, so isolation comes from topology rather than from packet filtering, and no capability can reach past it. That conflicts with Harbor's phase model, which switches network capability between task download, `Agent.run()`, and verification — topology is a container-lifetime property. It belongs in a separate architecture decision.

This is an AI-assisted review; it does not substitute for independent human review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

Generated-by: Claude Code


