### PR TITLE
fix(eval): stabilize native timeouts, usage, and artifacts

### DIFF
--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -65,8 +65,9 @@ External CLI specs terminate option parsing or bind the prompt inside one option
 that begins with `-` cannot become a CLI flag. Relay results contain only bounded metering counts;
 the complete observed model and tool-name lists remain in the hashed metering artifact. The
 provider proxy also writes a bounded credential-free request/response JSONL trace, so a timed-out
-CLI that never flushes stdout still leaves model I/O tied to its usage; downstream disconnects
-cancel the corresponding upstream request instead of holding finalization open.
+CLI that never flushes stdout still leaves model I/O tied to its usage. In-flight provider requests
+remain eligible to settle inside the benchmark-native task window after the CLI disconnects, so
+late usage is not discarded.
 The local image tag remains a machine deployment identity rather than a registry digest; digest
 pinning is tracked in issue #2953.
 

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -38,8 +38,9 @@ developer prompt and complete tool schema. The profile disables Runtime's produc
 watchdog and Undici's provider headers/body inactivity timers after provider activity;
 benchmark-native subject timeouts remain the execution deadline, while the model stream connect
 timeout still rejects requests that never establish a response. Hosted Eval clients also use a
-10-second liveness cadence with a 30-second response budget so a CPU-bound one-core task cannot
-starve the Runtime Host briefly enough to be mistaken for a dead connection.
+disabled active liveness probe for their owned Runtime Host process so a CPU-bound one-core task
+cannot starve the Host briefly enough to be mistaken for a dead connection. Child-process exit,
+transport closure, and the benchmark-native subject timeout remain authoritative.
 
 Every benchmark subject removes `WebSearch`, `WebFetch`, and `FetchURL` from the provider-visible
 tool list. Maka enforces that through its Hosted Execution profile; external harnesses pass through

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -61,6 +61,9 @@ and egress audit logs are represented in attempt artifacts with byte counts and 
 The external wrapper persists up to 64 MiB of each subject's stdout and stderr under `/logs/agent`;
 after Harbor finalization, Eval inventories the complete trial `agent/` directory into the attempt
 so trajectory, metering, wrapper-state, and runtime-event files remain tied to the scored result.
+External CLI specs terminate option parsing or bind the prompt inside one option value so task text
+that begins with `-` cannot become a CLI flag. Relay results contain only bounded metering counts;
+the complete observed model and tool-name lists remain in the hashed metering artifact.
 The local image tag remains a machine deployment identity rather than a registry digest; digest
 pinning is tracked in issue #2953.
 

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -58,6 +58,9 @@ cohort. This URL policy is a blocklist for known benchmark and public-solution c
 surfaces, not a complete defense against a deliberately invented lookup channel; the network
 namespace still forces all subject traffic through the audited proxy. Collected Maka runtime files
 and egress audit logs are represented in attempt artifacts with byte counts and SHA-256 digests.
+The external wrapper persists up to 64 MiB of each subject's stdout and stderr under `/logs/agent`;
+after Harbor finalization, Eval inventories the complete trial `agent/` directory into the attempt
+so trajectory, metering, wrapper-state, and runtime-event files remain tied to the scored result.
 The local image tag remains a machine deployment identity rather than a registry digest; digest
 pinning is tracked in issue #2953.
 

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -63,7 +63,10 @@ after Harbor finalization, Eval inventories the complete trial `agent/` director
 so trajectory, metering, wrapper-state, and runtime-event files remain tied to the scored result.
 External CLI specs terminate option parsing or bind the prompt inside one option value so task text
 that begins with `-` cannot become a CLI flag. Relay results contain only bounded metering counts;
-the complete observed model and tool-name lists remain in the hashed metering artifact.
+the complete observed model and tool-name lists remain in the hashed metering artifact. The
+provider proxy also writes a bounded credential-free request/response JSONL trace, so a timed-out
+CLI that never flushes stdout still leaves model I/O tied to its usage; downstream disconnects
+cancel the corresponding upstream request instead of holding finalization open.
 The local image tag remains a machine deployment identity rather than a registry digest; digest
 pinning is tracked in issue #2953.
 

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -34,7 +34,9 @@ and exposes a foreground-only Bash schema without `run_in_background` or `pty`. 
 routing remains authoritative: DeepSeek Responses exposes `apply_patch` instead of `Write` and
 `Edit`, and Runtime-owned `ArchiveRead` remains available for archived tool results. A real
 `hosted.execution.start` regression test pins SHA-256 hashes for the first main provider request's
-developer prompt and complete tool schema.
+developer prompt and complete tool schema. The profile disables Runtime's product stream-idle
+watchdog after provider activity; benchmark-native subject timeouts remain the execution deadline,
+while the model stream connect timeout still rejects requests that never establish a response.
 
 Every benchmark subject removes `WebSearch`, `WebFetch`, and `FetchURL` from the provider-visible
 tool list. Maka enforces that through its Hosted Execution profile; external harnesses pass through

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -35,8 +35,11 @@ routing remains authoritative: DeepSeek Responses exposes `apply_patch` instead 
 `Edit`, and Runtime-owned `ArchiveRead` remains available for archived tool results. A real
 `hosted.execution.start` regression test pins SHA-256 hashes for the first main provider request's
 developer prompt and complete tool schema. The profile disables Runtime's product stream-idle
-watchdog after provider activity; benchmark-native subject timeouts remain the execution deadline,
-while the model stream connect timeout still rejects requests that never establish a response.
+watchdog and Undici's provider headers/body inactivity timers after provider activity;
+benchmark-native subject timeouts remain the execution deadline, while the model stream connect
+timeout still rejects requests that never establish a response. Hosted Eval clients also use a
+10-second liveness cadence with a 30-second response budget so a CPU-bound one-core task cannot
+starve the Runtime Host briefly enough to be mistaken for a dead connection.
 
 Every benchmark subject removes `WebSearch`, `WebFetch`, and `FetchURL` from the provider-visible
 tool list. Maka enforces that through its Hosted Execution profile; external harnesses pass through

--- a/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-eight-arm.json
+++ b/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-eight-arm.json
@@ -127,6 +127,7 @@
           "--dangerously-bypass-approvals-and-sandbox",
           "--model",
           "deepseek-v4-flash",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -158,6 +159,7 @@
           "--dangerously-skip-permissions",
           "--model",
           "deepseek-v4-flash",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -183,6 +185,7 @@
           "max",
           "--output-format",
           "stream-json",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -254,8 +257,7 @@
           "{{task.cwd}}",
           "--disallowedTools",
           "WebSearch,WebFetch,FetchURL",
-          "--prompt",
-          "{{task.input}}"
+          "--prompt={{task.input}}"
         ]
       }
     },
@@ -287,7 +289,7 @@
           "deepseek-v4-flash",
           "--thinking",
           "max",
-          "{{task.input}}"
+          "Task instruction:\n{{task.input}}"
         ]
       }
     }

--- a/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-four-arm.json
+++ b/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-four-arm.json
@@ -103,6 +103,7 @@
           "--dangerously-bypass-approvals-and-sandbox",
           "--model",
           "deepseek-v4-flash",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -129,6 +130,7 @@
           "--dangerously-skip-permissions",
           "--model",
           "deepseek-v4-flash",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -153,6 +155,7 @@
           "max",
           "--output-format",
           "stream-json",
+          "--",
           "{{task.input}}"
         ]
       }

--- a/packages/eval/src/__tests__/external-provider-dispatcher.test.ts
+++ b/packages/eval/src/__tests__/external-provider-dispatcher.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+import { fetch as undiciFetch } from 'undici';
+import { createExternalProviderDispatcher } from '../external-provider-dispatcher.js';
+
+test('external provider dispatcher defers inactivity deadlines to the benchmark', async () => {
+  const server = createServer((_request, response) => {
+    setTimeout(() => {
+      response.writeHead(200, { 'content-type': 'text/plain' });
+      response.end('ok');
+    }, 1_500);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  const bounded = createExternalProviderDispatcher(undefined, {
+    headersTimeoutMs: 100,
+    bodyTimeoutMs: 100,
+  });
+  const evalTransport = createExternalProviderDispatcher(undefined);
+  const url = `http://127.0.0.1:${address.port}/slow`;
+
+  try {
+    await assert.rejects(() => undiciFetch(url, { dispatcher: bounded.dispatcher }));
+    const response = await undiciFetch(url, { dispatcher: evalTransport.dispatcher });
+    assert.equal(await response.text(), 'ok');
+  } finally {
+    await Promise.all([bounded.close(), evalTransport.close()]);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});

--- a/packages/eval/src/__tests__/external-subject.test.ts
+++ b/packages/eval/src/__tests__/external-subject.test.ts
@@ -4,10 +4,51 @@ import { mkdir, mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { createExternalSubjectAdapter } from '../external-subject.js';
+import { createExternalSubjectAdapter, recoverExternalMetering } from '../external-subject.js';
 import type { ExperimentCell, ExperimentSpec } from '../experiment.js';
 import type { CellAttempt } from '../result.js';
 import { TOOLCHAIN_IDENTITIES, TOOLCHAIN_IDENTITY_ENV } from '../toolchain-verification.js';
+
+test('recovers complete external metering from a timed-out trial', async () => {
+  const trialPath = await mkdtemp(join(tmpdir(), 'maka-eval-metering-'));
+  try {
+    await mkdir(join(trialPath, 'agent'), { recursive: true });
+    await writeFile(
+      join(trialPath, 'agent/reasonix.metering.json'),
+      `${JSON.stringify({
+        schemaVersion: 1,
+        profile: 'reasonix',
+        usage: {
+          inputTokens: 100,
+          outputTokens: 20,
+          cacheReadTokens: 80,
+          cacheWriteTokens: 0,
+          reasoningTokens: 10,
+          totalTokens: 120,
+        },
+        costUsd: 0.001,
+        requests: 2,
+        admittedRequests: 2,
+        usageRequests: 2,
+        usageComplete: true,
+      })}\n`,
+    );
+
+    const recovered = await recoverExternalMetering({ trialPath }, 'reasonix');
+    assert.deepEqual(recovered?.usage, {
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 80,
+      cacheWriteTokens: 0,
+      reasoningTokens: 10,
+      totalTokens: 120,
+    });
+    assert.equal(recovered?.costUsd, 0.001);
+    assert.equal(recovered?.artifact.kind, 'provider-metering-snapshot');
+  } finally {
+    await rm(trialPath, { recursive: true, force: true });
+  }
+});
 
 test('passes declared environment and credential bindings to one external command', async () => {
   const cell = externalCell({

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -79,6 +79,9 @@ while (true) {
 }
 const trialPath = new URL('./' + config.trial_name + '/', new URL('file://' + config.trials_dir + '/'));
 await mkdir(trialPath, { recursive: true });
+const agentArtifacts = new URL('agent/', trialPath);
+await mkdir(agentArtifacts, { recursive: true });
+await writeFile(new URL('opencode.metering.json', agentArtifacts), '{"usageRequests":1}\\n');
 await writeFile(new URL('result.json', trialPath), JSON.stringify({ verifier_result: { rewards: { reward: 1 } } }));
 socket.end();
 `,
@@ -130,7 +133,20 @@ socket.end();
     assert.doesNotThrow(() => process.kill(pid, 0));
     await writeFile(release, '');
     const results = await running;
-    assert.equal(results.get('task::1::external')?.result.status, 'completed');
+    const result = results.get('task::1::external')?.result;
+    assert.equal(result?.status, 'completed');
+    assert.deepEqual(
+      result?.artifacts.find(
+        ({ kind, path }) =>
+          kind === 'collected-artifact' && path === 'agent/opencode.metering.json',
+      ),
+      {
+        kind: 'collected-artifact',
+        path: 'agent/opencode.metering.json',
+        bytes: 20,
+        sha256: 'sha256:8f625fe55aa6336fccf93df0b9431dfac84d7d6fe772a745b56c9a284364310a',
+      },
+    );
   } finally {
     await writeFile(release, '').catch(() => undefined);
     globalThis.setTimeout = nativeSetTimeout;

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -665,6 +665,9 @@ test('eight-arm spec and wrappers freeze the working provider contracts', async 
   const maka = spec.subjects.find(({ id }) => id === 'maka')!;
   const codex = spec.subjects.find(({ id }) => id === 'codex')!;
   const claude = spec.subjects.find(({ id }) => id === 'claude-code')!;
+  const reasonix = spec.subjects.find(({ id }) => id === 'reasonix')!;
+  const zcode = spec.subjects.find(({ id }) => id === 'zcode')!;
+  const pi = spec.subjects.find(({ id }) => id === 'pi')!;
   assert.deepEqual(maka.credentials, ['DEEPSEEK_API_KEY']);
   assert.equal(maka.config.connectionSlug, 'env-deepseek');
   assert.equal(maka.config.baseUrl, 'https://api.deepseek.com');
@@ -673,6 +676,12 @@ test('eight-arm spec and wrappers freeze the working provider contracts', async 
   assert.equal(codex.config.args?.includes('--skip-git-repo-check'), true);
   assert.equal(claude.config.args?.includes('--bare'), true);
   assert.equal(claude.config.args?.includes('--effort'), true);
+  for (const subject of [codex, claude, reasonix]) {
+    assert.deepEqual(subject.config.args?.slice(-2), ['--', '{{task.input}}']);
+  }
+  assert.equal(zcode.config.args?.includes('{{task.cwd}}'), true);
+  assert.equal(zcode.config.args?.at(-1), '--prompt={{task.input}}');
+  assert.equal(pi.config.args?.at(-1), 'Task instruction:\n{{task.input}}');
   for (const subject of spec.subjects) {
     assert.deepEqual(subject.credentials, ['DEEPSEEK_API_KEY']);
     if (subject.id === 'maka') continue;

--- a/packages/eval/src/__tests__/maka-artifacts.test.ts
+++ b/packages/eval/src/__tests__/maka-artifacts.test.ts
@@ -10,6 +10,7 @@ import {
   MAKA_RUNTIME_ARTIFACT_PATH,
   MAKA_SUBJECT_STDERR_PATH,
   MAKA_SUBJECT_STDOUT_PATH,
+  recoverMakaRuntimeUsage,
 } from '../maka-artifacts.js';
 import { createMakaSubjectAdapter } from '../maka-subject.js';
 import type { ExperimentCell } from '../experiment.js';
@@ -63,6 +64,78 @@ test('runtime artifact capture includes committed WAL rows in a standalone datab
   } finally {
     database.close();
     await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('Maka timeout usage recovery returns committed usage with explicit lower-bound provenance', async () => {
+  const trialPath = await mkdtemp(join(tmpdir(), 'maka-eval-usage-recovery-'));
+  const artifactRoot = join(trialPath, 'artifacts', 'logs', 'artifacts', 'maka-runtime-host');
+  await mkdir(artifactRoot, { recursive: true });
+  const database = new DatabaseSync(join(artifactRoot, 'runtime.sqlite'));
+  try {
+    database.exec(
+      'CREATE TABLE usage_model_call_attempts (record_json TEXT NOT NULL);' +
+        'CREATE TABLE usage_llm_calls (record_json TEXT NOT NULL);',
+    );
+    const insertAttempt = database.prepare(
+      'INSERT INTO usage_model_call_attempts (record_json) VALUES (?)',
+    );
+    insertAttempt.run(
+      JSON.stringify({
+        status: 'completed',
+        usageBasis: 'reported',
+        inputTokens: 100,
+        outputTokens: 20,
+        cacheReadInputTokens: 80,
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 10,
+        costUsd: 0.01,
+      }),
+    );
+    insertAttempt.run(
+      JSON.stringify({
+        status: 'aborted',
+        usageBasis: 'missing',
+        costBasis: 'unpriced',
+      }),
+    );
+    database.prepare('INSERT INTO usage_llm_calls (record_json) VALUES (?)').run(
+      JSON.stringify({
+        status: 'success',
+        inputTokens: 5,
+        outputTokens: 2,
+        cacheHitInputTokens: 4,
+        reasoningTokens: 1,
+        costUsd: 0.001,
+      }),
+    );
+  } finally {
+    database.close();
+  }
+
+  try {
+    const recovered = await recoverMakaRuntimeUsage({ trialPath });
+    assert.ok(recovered);
+    assert.deepEqual(recovered.usage, {
+      inputTokens: 105,
+      outputTokens: 22,
+      cacheReadTokens: 84,
+      cacheWriteTokens: 0,
+      reasoningTokens: 11,
+      totalTokens: 127,
+    });
+    assert.equal(recovered.costUsd, 0.011);
+    assert.deepEqual(recovered.artifact, {
+      kind: 'maka-runtime-usage-recovery',
+      path: 'artifacts/logs/artifacts/maka-runtime-host/runtime.sqlite',
+      usageComplete: false,
+      confirmedAttempts: 2,
+      missingAttempts: 1,
+      tokenBasis: 'lower-bound',
+      costBasis: 'lower-bound',
+    });
+  } finally {
+    await rm(trialPath, { recursive: true, force: true });
   }
 });
 

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -219,8 +219,9 @@ test('unbounded tool diagnostics stay in the metering snapshot, not the relay fr
 
 test('late provider usage survives a downstream CLI disconnect', async () => {
   const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.flushHeaders();
     setTimeout(() => {
-      response.writeHead(200, { 'content-type': 'text/event-stream' });
       response.end(
         'data: {"type":"response.completed","response":{"usage":{"input_tokens":10,"output_tokens":2}}}\n\ndata: [DONE]\n\n',
       );
@@ -237,9 +238,7 @@ test('late provider usage survives a downstream CLI disconnect', async () => {
   await writeFile(
     child,
     [
-      'const controller=new AbortController();',
-      'setTimeout(()=>controller.abort(),20);',
-      "await fetch(`${process.env.DEEPSEEK_BASE_URL}/responses`,{method:'POST',body:'{}',signal:controller.signal}).catch(()=>{});",
+      "await fetch(`${process.env.DEEPSEEK_BASE_URL}/responses`,{method:'POST',body:'{}'});",
       "console.log(JSON.stringify({type:'error'}));",
       '',
     ].join('\n'),

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -195,7 +195,77 @@ test('unbounded tool diagnostics stay in the metering snapshot, not the relay fr
       await readFile(join(root, 'logs/agent/opencode.metering.json'), 'utf8'),
     ) as { toolNames: string[] };
     assert.deepEqual(snapshot.toolNames, [...toolNames].sort());
+    const providerEvents = (
+      await readFile(join(root, 'logs/agent/opencode.provider-events.jsonl'), 'utf8')
+    )
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as { type: string; bodyBase64?: string });
+    assert.equal(providerEvents[0]?.type, 'provider_request');
+    assert.match(
+      Buffer.from(providerEvents[0]?.bodyBase64 ?? '', 'base64').toString('utf8'),
+      /tool_199/u,
+    );
+    assert.equal(
+      providerEvents.some(({ type }) => type === 'provider_response_chunk'),
+      true,
+    );
+    assert.equal(providerEvents.at(-1)?.type, 'provider_response_end');
   } finally {
+    server.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('downstream cancellation aborts an in-flight upstream provider request', async () => {
+  const server = createServer(() => undefined);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const root = await mkdtemp(join(tmpdir(), 'maka-provider-abort-'));
+  const child = join(root, 'child.mjs');
+  await writeFile(
+    child,
+    [
+      'const controller=new AbortController();',
+      'setTimeout(()=>controller.abort(),50);',
+      "await fetch(`${process.env.DEEPSEEK_BASE_URL}/responses`,{method:'POST',body:'{}',signal:controller.signal}).catch(()=>{});",
+      "console.log(JSON.stringify({type:'error'}));",
+      '',
+    ].join('\n'),
+  );
+  try {
+    const wrapper = new URL('../harbor-external-subject.js', import.meta.url);
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        wrapper.pathname,
+        'opencode',
+        `http://127.0.0.1:${address.port}`,
+        root,
+        process.execPath,
+        child,
+      ],
+      {
+        env: {
+          ...process.env,
+          OPENAI_API_KEY: 'upstream-test-key',
+          MAKA_EVAL_RESULT_TOKEN: RESULT_TOKEN,
+        },
+        timeout: 2_000,
+      },
+    );
+    const result = decodeResultFrame(stdout) as { status: string };
+    assert.equal(result.status, 'infra_failed');
+    assert.match(
+      await readFile(join(root, 'logs/agent/opencode.provider-events.jsonl'), 'utf8'),
+      /provider_error/u,
+    );
+  } finally {
+    server.closeAllConnections();
     server.close();
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -217,21 +217,28 @@ test('unbounded tool diagnostics stay in the metering snapshot, not the relay fr
   }
 });
 
-test('downstream cancellation aborts an in-flight upstream provider request', async () => {
-  const server = createServer(() => undefined);
+test('late provider usage survives a downstream CLI disconnect', async () => {
+  const server = createServer((_request, response) => {
+    setTimeout(() => {
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.end(
+        'data: {"type":"response.completed","response":{"usage":{"input_tokens":10,"output_tokens":2}}}\n\ndata: [DONE]\n\n',
+      );
+    }, 100);
+  });
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
     server.listen(0, '127.0.0.1', resolve);
   });
   const address = server.address();
   assert.ok(address && typeof address !== 'string');
-  const root = await mkdtemp(join(tmpdir(), 'maka-provider-abort-'));
+  const root = await mkdtemp(join(tmpdir(), 'maka-provider-late-usage-'));
   const child = join(root, 'child.mjs');
   await writeFile(
     child,
     [
       'const controller=new AbortController();',
-      'setTimeout(()=>controller.abort(),50);',
+      'setTimeout(()=>controller.abort(),20);',
       "await fetch(`${process.env.DEEPSEEK_BASE_URL}/responses`,{method:'POST',body:'{}',signal:controller.signal}).catch(()=>{});",
       "console.log(JSON.stringify({type:'error'}));",
       '',
@@ -258,14 +265,15 @@ test('downstream cancellation aborts an in-flight upstream provider request', as
         timeout: 2_000,
       },
     );
-    const result = decodeResultFrame(stdout) as { status: string };
-    assert.equal(result.status, 'infra_failed');
+    const result = decodeResultFrame(stdout) as {
+      usage: { totalTokens: number } | null;
+    };
+    assert.equal(result.usage?.totalTokens, 12);
     assert.match(
       await readFile(join(root, 'logs/agent/opencode.provider-events.jsonl'), 'utf8'),
-      /provider_error/u,
+      /provider_response_end/u,
     );
   } finally {
-    server.closeAllConnections();
     server.close();
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -133,9 +133,9 @@ test('oversized external records are attributed to bounded classification', asyn
 });
 
 test('external trajectories are truncated at the persisted byte limit', async () => {
-  const result = await executePiWithTerminalRecord(65 * 1024 * 1024);
+  const result = await executePiWithTerminalRecord(65 * 1024, 64 * 1024);
   const stdout = result.artifacts.find(({ kind }) => kind === 'stdout');
-  assert.equal(stdout?.persistedBytes, 64 * 1024 * 1024);
+  assert.equal(stdout?.persistedBytes, 64 * 1024);
   assert.ok((stdout?.bytes ?? 0) > (stdout?.persistedBytes ?? 0));
   assert.equal(stdout?.truncatedBytes, (stdout?.bytes ?? 0) - (stdout?.persistedBytes ?? 0));
 });
@@ -278,7 +278,10 @@ test('late provider usage survives a downstream CLI disconnect', async () => {
   }
 });
 
-async function executePiWithTerminalRecord(contentBytes: number): Promise<{
+async function executePiWithTerminalRecord(
+  contentBytes: number,
+  persistedStreamLimitBytes?: number,
+): Promise<{
   status: string;
   failureReason: string | null;
   artifacts: Array<{
@@ -330,6 +333,11 @@ async function executePiWithTerminalRecord(contentBytes: number): Promise<{
           ...process.env,
           OPENAI_API_KEY: 'upstream-test-key',
           MAKA_EVAL_RESULT_TOKEN: RESULT_TOKEN,
+          ...(persistedStreamLimitBytes === undefined
+            ? {}
+            : {
+                MAKA_EVAL_TEST_PERSISTED_STREAM_LIMIT_BYTES: String(persistedStreamLimitBytes),
+              }),
         },
       },
     );

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -136,11 +136,69 @@ test('external trajectories are truncated at the persisted byte limit', async ()
   const result = await executePiWithTerminalRecord(65 * 1024 * 1024);
   const stdout = result.artifacts.find(({ kind }) => kind === 'stdout');
   assert.equal(stdout?.persistedBytes, 64 * 1024 * 1024);
-  assert.ok((stdout?.observedBytes ?? 0) > (stdout?.persistedBytes ?? 0));
-  assert.equal(
-    stdout?.truncatedBytes,
-    (stdout?.observedBytes ?? 0) - (stdout?.persistedBytes ?? 0),
+  assert.ok((stdout?.bytes ?? 0) > (stdout?.persistedBytes ?? 0));
+  assert.equal(stdout?.truncatedBytes, (stdout?.bytes ?? 0) - (stdout?.persistedBytes ?? 0));
+});
+
+test('unbounded tool diagnostics stay in the metering snapshot, not the relay frame', async () => {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'text/event-stream' });
+    response.end(
+      'data: {"type":"response.completed","response":{"usage":{"input_tokens":10,"output_tokens":2}}}\n\ndata: [DONE]\n\n',
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const root = await mkdtemp(join(tmpdir(), 'maka-bounded-relay-result-'));
+  const child = join(root, 'child.mjs');
+  const toolNames = Array.from({ length: 200 }, (_, index) => `tool_${index}`);
+  await writeFile(
+    child,
+    [
+      `const tools=${JSON.stringify(toolNames)}.map(name=>({type:'function',function:{name}}));`,
+      "await fetch(`${process.env.DEEPSEEK_BASE_URL}/responses`,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({model:'deepseek-v4-flash',tools})});",
+      "console.log(JSON.stringify({type:'step_finish'}));",
+      '',
+    ].join('\n'),
   );
+  try {
+    const wrapper = new URL('../harbor-external-subject.js', import.meta.url);
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [
+        wrapper.pathname,
+        'opencode',
+        `http://127.0.0.1:${address.port}`,
+        root,
+        process.execPath,
+        child,
+      ],
+      {
+        env: {
+          ...process.env,
+          OPENAI_API_KEY: 'upstream-test-key',
+          MAKA_EVAL_RESULT_TOKEN: RESULT_TOKEN,
+        },
+      },
+    );
+    const result = decodeResultFrame(stdout) as {
+      artifacts: Array<Record<string, unknown>>;
+    };
+    const metering = result.artifacts.find(({ kind }) => kind === 'provider-metering');
+    assert.equal(metering?.toolNameCount, toolNames.length);
+    assert.equal('toolNames' in (metering ?? {}), false);
+    const snapshot = JSON.parse(
+      await readFile(join(root, 'logs/agent/opencode.metering.json'), 'utf8'),
+    ) as { toolNames: string[] };
+    assert.deepEqual(snapshot.toolNames, [...toolNames].sort());
+  } finally {
+    server.close();
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 async function executePiWithTerminalRecord(contentBytes: number): Promise<{
@@ -151,7 +209,6 @@ async function executePiWithTerminalRecord(contentBytes: number): Promise<{
     profile?: string;
     exitCode?: number;
     bytes?: number;
-    observedBytes?: number;
     persistedBytes?: number;
     truncatedBytes?: number;
     sha256?: string;

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -74,6 +74,7 @@ test('provider failures remain infrastructure failures until inference admission
         usage: { cacheWriteTokens: number } | null;
         artifacts: Array<{
           kind: string;
+          path?: string;
           admittedRequests?: number;
           usageComplete?: boolean;
         }>;
@@ -88,16 +89,22 @@ test('provider failures remain infrastructure failures until inference admission
         JSON.stringify(result),
         /(?:credential|stdout|stderr)-sentinel-must-not-persist/u,
       );
+      assert.match(
+        await readFile(join(root, 'logs/agent/opencode.jsonl'), 'utf8'),
+        /stdout-sentinel-must-not-persist/u,
+      );
+      assert.match(
+        await readFile(join(root, 'logs/agent/opencode.stderr.txt'), 'utf8'),
+        /stderr-sentinel-must-not-persist/u,
+      );
       assert.equal(
-        (await readdir(join(root, 'logs/agent')).catch(() => [])).some((name) =>
-          name.endsWith('.stderr.txt'),
-        ),
-        false,
+        result.artifacts.find(({ kind }) => kind === 'stdout')?.path,
+        '/logs/agent/opencode.jsonl',
       );
       for (const name of await readdir(join(root, 'logs/agent'))) {
         assert.doesNotMatch(
           await readFile(join(root, 'logs/agent', name), 'utf8'),
-          /(?:credential|stdout|stderr)-sentinel-must-not-persist|0123456789abcdef0123456789abcdef/u,
+          /credential-sentinel-must-not-persist|0123456789abcdef0123456789abcdef/u,
         );
       }
     } finally {
@@ -125,6 +132,17 @@ test('oversized external records are attributed to bounded classification', asyn
   assert.match(stdout?.sha256 ?? '', /^[0-9a-f]{64}$/u);
 });
 
+test('external trajectories are truncated at the persisted byte limit', async () => {
+  const result = await executePiWithTerminalRecord(65 * 1024 * 1024);
+  const stdout = result.artifacts.find(({ kind }) => kind === 'stdout');
+  assert.equal(stdout?.persistedBytes, 64 * 1024 * 1024);
+  assert.ok((stdout?.observedBytes ?? 0) > (stdout?.persistedBytes ?? 0));
+  assert.equal(
+    stdout?.truncatedBytes,
+    (stdout?.observedBytes ?? 0) - (stdout?.persistedBytes ?? 0),
+  );
+});
+
 async function executePiWithTerminalRecord(contentBytes: number): Promise<{
   status: string;
   failureReason: string | null;
@@ -133,6 +151,9 @@ async function executePiWithTerminalRecord(contentBytes: number): Promise<{
     profile?: string;
     exitCode?: number;
     bytes?: number;
+    observedBytes?: number;
+    persistedBytes?: number;
+    truncatedBytes?: number;
     sha256?: string;
     classification?: string;
     limitBytes?: number;

--- a/packages/eval/src/external-provider-dispatcher.ts
+++ b/packages/eval/src/external-provider-dispatcher.ts
@@ -1,0 +1,33 @@
+import { Agent, ProxyAgent, type Dispatcher } from 'undici';
+
+export interface ExternalProviderDispatcher {
+  readonly dispatcher: Dispatcher;
+  close(): Promise<void>;
+}
+
+export function createExternalProviderDispatcher(
+  proxyUrl: string | undefined,
+  options: {
+    readonly headersTimeoutMs?: number;
+    readonly bodyTimeoutMs?: number;
+  } = {},
+): ExternalProviderDispatcher {
+  const base = proxyUrl ? new ProxyAgent(proxyUrl) : new Agent();
+  const headersTimeout = timeout(options.headersTimeoutMs ?? 0, 'headersTimeoutMs');
+  const bodyTimeout = timeout(options.bodyTimeoutMs ?? 0, 'bodyTimeoutMs');
+  const dispatcher = base.compose(
+    (dispatch) => (request, handler) =>
+      dispatch({ ...request, headersTimeout, bodyTimeout }, handler),
+  );
+  return {
+    dispatcher,
+    close: () => base.close(),
+  };
+}
+
+function timeout(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${label} must be a non-negative integer`);
+  }
+  return value;
+}

--- a/packages/eval/src/external-subject.ts
+++ b/packages/eval/src/external-subject.ts
@@ -1,3 +1,6 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import type { JsonObject } from './experiment.js';
 import type { NormalizedUsage } from './result.js';
 import type { SubjectAdapter } from './runner.js';
@@ -57,6 +60,7 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
     async execute({ cell, context }) {
       const config = decodeConfig(cell.subject.config, cell.subject.credentials);
       const toolchain = wrapperToolchain(config, cell.executor.config);
+      const profile = bundledProfile(config.args);
       const identity = toolchain ? verifiedToolchains.get(cell.subject.id) : undefined;
       if (toolchain && !identity) {
         throw new Error(`${cell.subject.id} toolchain was not verified before execution`);
@@ -84,14 +88,16 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
         });
         const decoded = execution.stdout.length === 0 ? undefined : decodeResult(execution.stdout);
         if (execution.termination === 'framework_timeout') {
+          const recovered = await recoverExternalMetering(context.metadata, profile);
           return {
-            usage: decoded?.usage ?? null,
-            costUsd: decoded?.costUsd ?? null,
+            usage: decoded?.usage ?? recovered?.usage ?? null,
+            costUsd: decoded?.costUsd ?? recovered?.costUsd ?? null,
             durationMs: Date.now() - startedAt,
             status: 'failed' as const,
             failureReason: 'external subject exceeded the framework timeout',
             artifacts: [
               ...(decoded?.artifacts ?? []),
+              ...(recovered ? [recovered.artifact] : []),
               { kind: 'external_process', exitCode: execution.exitCode },
             ],
           };
@@ -185,6 +191,55 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
       }
     },
   };
+}
+
+export async function recoverExternalMetering(
+  metadata: JsonObject,
+  profile: ExternalProfile | undefined,
+): Promise<
+  | {
+      readonly usage: NormalizedUsage;
+      readonly costUsd: number;
+      readonly artifact: JsonObject;
+    }
+  | undefined
+> {
+  if (!profile || typeof metadata.trialPath !== 'string') return undefined;
+  const path = join(metadata.trialPath, 'agent', `${profile}.metering.json`);
+  const bytes = await readFile(path).catch(() => undefined);
+  if (!bytes) return undefined;
+  let value: unknown;
+  try {
+    value = JSON.parse(bytes.toString('utf8'));
+  } catch {
+    return undefined;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const record = value as Record<string, unknown>;
+  if (
+    record.schemaVersion !== 1 ||
+    record.profile !== profile ||
+    record.usageComplete !== true ||
+    record.usage === null ||
+    record.costUsd === null
+  ) {
+    return undefined;
+  }
+  try {
+    return {
+      usage: decodeUsage(record.usage),
+      costUsd: nonnegative(record.costUsd, 'external metering cost'),
+      artifact: {
+        kind: 'provider-metering-snapshot',
+        profile,
+        path: `agent/${profile}.metering.json`,
+        bytes: bytes.byteLength,
+        sha256: createHash('sha256').update(bytes).digest('hex'),
+      },
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 interface ExternalSubjectConfig {

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -19,7 +19,7 @@ const resultToken = takeRelayResultToken();
 
 type SubjectStatus = 'completed' | 'failed' | 'infra_failed' | 'indeterminate';
 const CLASSIFIABLE_RECORD_LIMIT_BYTES = 16 * 1024 * 1024;
-const PERSISTED_STREAM_LIMIT_BYTES = 64 * 1024 * 1024;
+const PERSISTED_STREAM_LIMIT_BYTES = takePersistedStreamLimit();
 
 interface Usage {
   inputTokens: number;
@@ -28,6 +28,17 @@ interface Usage {
   cacheWriteTokens: number;
   reasoningTokens: number;
   totalTokens: number;
+}
+
+function takePersistedStreamLimit(): number {
+  const override = process.env.MAKA_EVAL_TEST_PERSISTED_STREAM_LIMIT_BYTES;
+  delete process.env.MAKA_EVAL_TEST_PERSISTED_STREAM_LIMIT_BYTES;
+  if (override === undefined) return 64 * 1024 * 1024;
+  const parsed = Number(override);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > 64 * 1024 * 1024) {
+    throw new Error('invalid external trajectory persistence limit');
+  }
+  return parsed;
 }
 
 const [rawProfile, baseUrl, systemRoot, command, ...args] = process.argv.slice(2);

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -51,6 +51,7 @@ process.once('SIGINT', interrupt);
 
 const logsRoot = rooted(systemRoot, '/logs/agent');
 const statePath = join(logsRoot, `${profile}.wrapper-state.json`);
+const meteringPath = join(logsRoot, `${profile}.metering.json`);
 const artifacts: Record<string, unknown>[] = [];
 let usage: Usage | null = null;
 let costUsd: number | null = null;
@@ -70,7 +71,7 @@ try {
   delete process.env.ANTHROPIC_API_KEY;
   delete process.env.DEEPSEEK_API_KEY;
   if (!key) throw new Error('external subject credential is missing');
-  const proxy = await startMeteringProxy(baseUrl, key, profile === 'claude-code');
+  const proxy = await startMeteringProxy(baseUrl, key, profile === 'claude-code', meteringPath);
   try {
     await writeState('proxy_started');
     const prepared = await prepareProfile(profile, proxy.baseUrl, systemRoot, command, args);
@@ -112,6 +113,7 @@ try {
         toolNames: proxy.observedToolNames(),
       },
       fileArtifact('wrapper-state', statePath, profile),
+      fileArtifact('provider-metering-snapshot', meteringPath, profile),
     );
   } finally {
     await proxy.close();
@@ -588,6 +590,7 @@ async function startMeteringProxy(
   upstreamBaseUrl: string,
   upstreamKey: string,
   anthropic: boolean,
+  meteringPath: string,
 ): Promise<{
   baseUrl: string;
   usage(): Usage | null;
@@ -608,6 +611,22 @@ async function startMeteringProxy(
   let removedWebTools = 0;
   const requestModels = new Set<string>();
   const observedToolNames = new Set<string>();
+  let snapshotWrite = Promise.resolve();
+  const persistSnapshot = () => {
+    const snapshot = `${JSON.stringify({
+      schemaVersion: 1,
+      profile,
+      usage: measured ? { ...total, totalTokens: total.inputTokens + total.outputTokens } : null,
+      costUsd: measured ? estimateCost(total) : null,
+      requests,
+      admittedRequests,
+      usageRequests,
+      usageComplete: admittedRequests > 0 && usageRequests === admittedRequests,
+    })}\n`;
+    snapshotWrite = snapshotWrite.then(() => writeFile(meteringPath, snapshot, { mode: 0o600 }));
+    return snapshotWrite;
+  };
+  await persistSnapshot();
   const providerTransport = createExternalProviderDispatcher(process.env.HTTPS_PROXY);
   const active = new Set<Promise<void>>();
   const server = createServer((request, response) => {
@@ -666,6 +685,7 @@ async function startMeteringProxy(
             addUsage(total, parsed.usage);
           }
         }
+        await persistSnapshot();
       }
     })().catch((error: unknown) => {
       response.statusCode = 502;
@@ -690,6 +710,7 @@ async function startMeteringProxy(
     observedToolNames: () => [...observedToolNames].sort(),
     close: async () => {
       await Promise.allSettled([...active]);
+      await snapshotWrite;
       await closeServer(server);
       await providerTransport.close();
     },

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -53,6 +53,7 @@ process.once('SIGINT', interrupt);
 const logsRoot = rooted(systemRoot, '/logs/agent');
 const statePath = join(logsRoot, `${profile}.wrapper-state.json`);
 const meteringPath = join(logsRoot, `${profile}.metering.json`);
+const providerEventsPath = join(logsRoot, `${profile}.provider-events.jsonl`);
 const stdoutPath = join(logsRoot, `${profile}.jsonl`);
 const stderrPath = join(logsRoot, `${profile}.stderr.txt`);
 const artifacts: Record<string, unknown>[] = [];
@@ -74,7 +75,13 @@ try {
   delete process.env.ANTHROPIC_API_KEY;
   delete process.env.DEEPSEEK_API_KEY;
   if (!key) throw new Error('external subject credential is missing');
-  const proxy = await startMeteringProxy(baseUrl, key, profile === 'claude-code', meteringPath);
+  const proxy = await startMeteringProxy(
+    baseUrl,
+    key,
+    profile === 'claude-code',
+    meteringPath,
+    providerEventsPath,
+  );
   try {
     await writeState('proxy_started');
     const prepared = await prepareProfile(profile, proxy.baseUrl, systemRoot, command, args);
@@ -669,6 +676,7 @@ async function startMeteringProxy(
   upstreamKey: string,
   anthropic: boolean,
   meteringPath: string,
+  eventsPath: string,
 ): Promise<{
   baseUrl: string;
   usage(): Usage | null;
@@ -690,6 +698,7 @@ async function startMeteringProxy(
   let removedWebTools = 0;
   const requestModels = new Set<string>();
   const observedToolNames = new Set<string>();
+  const events = await createBoundedJsonlWriter(eventsPath, PERSISTED_STREAM_LIMIT_BYTES);
   let snapshotWrite = Promise.resolve();
   const persistSnapshot = () => {
     const snapshot = `${JSON.stringify({
@@ -712,12 +721,20 @@ async function startMeteringProxy(
   const providerTransport = createExternalProviderDispatcher(process.env.HTTPS_PROXY);
   const active = new Set<Promise<void>>();
   const server = createServer((request, response) => {
+    const requestId = requests + 1;
     const operation = (async () => {
       requests += 1;
       const projected = removeEvalWebTools(await readRequest(request));
       removedWebTools += projected.removed;
       if (projected.model) requestModels.add(projected.model);
       for (const name of projected.toolNames) observedToolNames.add(name);
+      await events.write({
+        type: 'provider_request',
+        requestId,
+        method: request.method ?? 'GET',
+        path: request.url ?? '/',
+        bodyBase64: projected.body.toString('base64'),
+      });
       const target = joinUpstream(upstreamBaseUrl, request.url ?? '/');
       const headers: Record<string, string> = {};
       for (const [name, value] of Object.entries(request.headers)) {
@@ -732,11 +749,29 @@ async function startMeteringProxy(
       }
       if (anthropic) headers['x-api-key'] = upstreamKey;
       else headers.authorization = `Bearer ${upstreamKey}`;
+      const upstreamAbort = new AbortController();
+      const abortUpstream = () => {
+        if (!upstreamAbort.signal.aborted) {
+          upstreamAbort.abort(new Error('provider proxy downstream disconnected'));
+        }
+      };
+      const closeUpstream = () => {
+        if (!response.writableEnded) abortUpstream();
+      };
+      request.once('aborted', abortUpstream);
+      response.once('close', closeUpstream);
       const upstream = await undiciFetch(target, {
         method: request.method,
         headers,
         body: projected.body.length === 0 ? undefined : new Uint8Array(projected.body),
         dispatcher: providerTransport.dispatcher,
+        signal: upstreamAbort.signal,
+      });
+      await events.write({
+        type: 'provider_response_start',
+        requestId,
+        status: upstream.status,
+        contentType: upstream.headers.get('content-type'),
       });
       response.statusCode = upstream.status;
       upstream.headers.forEach((value, name) => {
@@ -752,12 +787,20 @@ async function startMeteringProxy(
           for (;;) {
             const next = await reader.read();
             if (next.done) break;
-            response.write(Buffer.from(next.value));
-            parser.push(Buffer.from(next.value).toString('utf8'));
+            const bytes = Buffer.from(next.value);
+            await events.write({
+              type: 'provider_response_chunk',
+              requestId,
+              bodyBase64: bytes.toString('base64'),
+            });
+            response.write(bytes);
+            parser.push(bytes.toString('utf8'));
           }
         }
         response.end();
       } finally {
+        request.removeListener('aborted', abortUpstream);
+        response.removeListener('close', closeUpstream);
         const parsed = parser.finish();
         if (upstream.ok && parsed.admitted) {
           admittedRequests += 1;
@@ -767,11 +810,24 @@ async function startMeteringProxy(
             addUsage(total, parsed.usage);
           }
         }
+        await events.write({
+          type: 'provider_response_end',
+          requestId,
+          admitted: parsed.admitted,
+          usage: parsed.usage,
+        });
         await persistSnapshot();
       }
     })().catch((error: unknown) => {
-      response.statusCode = 502;
-      response.end(JSON.stringify({ error: safeFailure(error, 'provider proxy failed') }));
+      void events.write({
+        type: 'provider_error',
+        requestId,
+        error: safeFailure(error, 'provider proxy failed'),
+      });
+      if (!response.destroyed) {
+        response.statusCode = 502;
+        response.end(JSON.stringify({ error: safeFailure(error, 'provider proxy failed') }));
+      }
     });
     active.add(operation);
     void operation.finally(() => active.delete(operation));
@@ -799,6 +855,37 @@ async function startMeteringProxy(
       await snapshotWrite;
       await closeServer(server);
       await providerTransport.close();
+      await events.close();
+    },
+  };
+}
+
+async function createBoundedJsonlWriter(
+  path: string,
+  limitBytes: number,
+): Promise<{
+  write(value: unknown): Promise<void>;
+  close(): Promise<void>;
+}> {
+  const output = await open(path, 'w', 0o600);
+  let queue = Promise.resolve();
+  let persistedBytes = 0;
+  let closed = false;
+  return {
+    write(value: unknown): Promise<void> {
+      const line = Buffer.from(`${JSON.stringify(value)}\n`);
+      queue = queue.then(async () => {
+        if (closed || persistedBytes + line.byteLength > limitBytes) return;
+        await writeAll(output, line);
+        persistedBytes += line.byteLength;
+      });
+      return queue;
+    },
+    async close(): Promise<void> {
+      await queue;
+      if (closed) return;
+      closed = true;
+      await output.close();
     },
   };
 }

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -749,23 +749,11 @@ async function startMeteringProxy(
       }
       if (anthropic) headers['x-api-key'] = upstreamKey;
       else headers.authorization = `Bearer ${upstreamKey}`;
-      const upstreamAbort = new AbortController();
-      const abortUpstream = () => {
-        if (!upstreamAbort.signal.aborted) {
-          upstreamAbort.abort(new Error('provider proxy downstream disconnected'));
-        }
-      };
-      const closeUpstream = () => {
-        if (!response.writableEnded) abortUpstream();
-      };
-      request.once('aborted', abortUpstream);
-      response.once('close', closeUpstream);
       const upstream = await undiciFetch(target, {
         method: request.method,
         headers,
         body: projected.body.length === 0 ? undefined : new Uint8Array(projected.body),
         dispatcher: providerTransport.dispatcher,
-        signal: upstreamAbort.signal,
       });
       await events.write({
         type: 'provider_response_start',
@@ -799,8 +787,6 @@ async function startMeteringProxy(
         }
         response.end();
       } finally {
-        request.removeListener('aborted', abortUpstream);
-        response.removeListener('close', closeUpstream);
         const parsed = parser.finish();
         if (upstream.ok && parsed.admitted) {
           admittedRequests += 1;

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -79,6 +79,7 @@ try {
     if (profile === 'claude-code') prepareClaudeWorkspace(systemRoot, prepared.home);
     const result = await runChild(prepared.command, prepared.args, prepared.env, profile);
     child = undefined;
+    await proxy.settle();
     await writeState('child_exited', { exitCode: result.exitCode });
     usage = proxy.usage();
     costUsd = usage && proxy.usageComplete() ? estimateCost(usage) : null;
@@ -601,6 +602,7 @@ async function startMeteringProxy(
   removedWebToolCount(): number;
   requestModels(): readonly string[];
   observedToolNames(): readonly string[];
+  settle(): Promise<void>;
   close(): Promise<void>;
 }> {
   const total = zeroUsage();
@@ -708,6 +710,10 @@ async function startMeteringProxy(
     removedWebToolCount: () => removedWebTools,
     requestModels: () => [...requestModels].sort(),
     observedToolNames: () => [...observedToolNames].sort(),
+    settle: async () => {
+      await Promise.allSettled([...active]);
+      await snapshotWrite;
+    },
     close: async () => {
       await Promise.allSettled([...active]);
       await snapshotWrite;

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -120,8 +120,8 @@ try {
         usageRequests: proxy.usageRequestCount(),
         usageComplete: proxy.usageComplete(),
         removedWebTools: proxy.removedWebToolCount(),
-        models: proxy.requestModels(),
-        toolNames: proxy.observedToolNames(),
+        modelCount: proxy.requestModels().length,
+        toolNameCount: proxy.observedToolNames().length,
       },
       fileArtifact('wrapper-state', statePath, profile),
       fileArtifact('provider-metering-snapshot', meteringPath, profile),
@@ -571,11 +571,9 @@ function streamArtifact(kind: string, profile: Profile, capture: StreamDiagnosti
     profile,
     path: capture.path,
     bytes: capture.observedBytes,
-    observedBytes: capture.observedBytes,
     persistedBytes: capture.persistedBytes,
     truncatedBytes: capture.truncatedBytes,
     sha256: capture.sha256,
-    observedSha256: capture.observedSha256,
     ...('classification' in capture &&
     capture.classification === 'record-too-large' &&
     'limitBytes' in capture
@@ -703,6 +701,9 @@ async function startMeteringProxy(
       admittedRequests,
       usageRequests,
       usageComplete: admittedRequests > 0 && usageRequests === admittedRequests,
+      removedWebTools,
+      models: [...requestModels].sort(),
+      toolNames: [...observedToolNames].sort(),
     })}\n`;
     snapshotWrite = snapshotWrite.then(() => writeFile(meteringPath, snapshot, { mode: 0o600 }));
     return snapshotWrite;

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { readFileSync, rmSync, statSync } from 'node:fs';
-import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, open, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type Server } from 'node:http';
 import { basename, dirname, join } from 'node:path';
 import type { Readable } from 'node:stream';
@@ -19,6 +19,7 @@ const resultToken = takeRelayResultToken();
 
 type SubjectStatus = 'completed' | 'failed' | 'infra_failed' | 'indeterminate';
 const CLASSIFIABLE_RECORD_LIMIT_BYTES = 16 * 1024 * 1024;
+const PERSISTED_STREAM_LIMIT_BYTES = 64 * 1024 * 1024;
 
 interface Usage {
   inputTokens: number;
@@ -52,6 +53,8 @@ process.once('SIGINT', interrupt);
 const logsRoot = rooted(systemRoot, '/logs/agent');
 const statePath = join(logsRoot, `${profile}.wrapper-state.json`);
 const meteringPath = join(logsRoot, `${profile}.metering.json`);
+const stdoutPath = join(logsRoot, `${profile}.jsonl`);
+const stderrPath = join(logsRoot, `${profile}.stderr.txt`);
 const artifacts: Record<string, unknown>[] = [];
 let usage: Usage | null = null;
 let costUsd: number | null = null;
@@ -77,7 +80,14 @@ try {
     const prepared = await prepareProfile(profile, proxy.baseUrl, systemRoot, command, args);
     credentialPath = prepared.credentialPath;
     if (profile === 'claude-code') prepareClaudeWorkspace(systemRoot, prepared.home);
-    const result = await runChild(prepared.command, prepared.args, prepared.env, profile);
+    const result = await runChild(
+      prepared.command,
+      prepared.args,
+      prepared.env,
+      profile,
+      stdoutPath,
+      stderrPath,
+    );
     child = undefined;
     await proxy.settle();
     await writeState('child_exited', { exitCode: result.exitCode });
@@ -404,14 +414,16 @@ async function runChild(
   executableArgs: string[],
   env: NodeJS.ProcessEnv,
   selected: Profile,
+  stdoutDestination: string,
+  stderrDestination: string,
 ): Promise<{ exitCode: number; stdout: ClassifiedStream; stderr: StreamDiagnostic }> {
   const running = spawn(executable, executableArgs, {
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   child = running;
-  const stdout = classifyStream(running.stdout, selected);
-  const stderr = captureStreamDiagnostic(running.stderr);
+  const stdout = classifyStream(running.stdout, selected, stdoutDestination);
+  const stderr = captureStreamDiagnostic(running.stderr, stderrDestination);
   const exitCode = await new Promise<number>((resolveExit, reject) => {
     running.once('error', reject);
     running.once('exit', (code) => resolveExit(code ?? 1));
@@ -422,7 +434,11 @@ async function runChild(
 
 interface StreamDiagnostic {
   readonly observedBytes: number;
+  readonly persistedBytes: number;
+  readonly truncatedBytes: number;
   readonly sha256: string;
+  readonly observedSha256: string;
+  readonly path: string;
 }
 
 type ClassifiedStream = StreamDiagnostic &
@@ -439,10 +455,17 @@ type ClassifiedStream = StreamDiagnostic &
       }
   );
 
-async function classifyStream(input: Readable, selected: Profile): Promise<ClassifiedStream> {
-  const digest = createHash('sha256');
+async function classifyStream(
+  input: Readable,
+  selected: Profile,
+  destination: string,
+): Promise<ClassifiedStream> {
+  const persistedDigest = createHash('sha256');
+  const observedDigest = createHash('sha256');
+  const output = await open(destination, 'w', 0o600);
   const decoder = new TextDecoder();
   let observedBytes = 0;
+  let persistedBytes = 0;
   let buffered = '';
   let completed = false;
   let reportedError = false;
@@ -454,25 +477,43 @@ async function classifyStream(input: Readable, selected: Profile): Promise<Class
     completed ||= signal.completed;
     reportedError ||= signal.reportedError;
   };
-  for await (const chunk of input) {
-    const bytes = Buffer.from(chunk);
-    observedBytes += bytes.byteLength;
-    digest.update(bytes);
-    buffered += decoder.decode(bytes, { stream: true });
-    let newline = buffered.indexOf('\n');
-    while (newline >= 0) {
-      consume(buffered.slice(0, newline));
-      buffered = buffered.slice(newline + 1);
-      newline = buffered.indexOf('\n');
+  try {
+    for await (const chunk of input) {
+      const bytes = Buffer.from(chunk);
+      observedBytes += bytes.byteLength;
+      observedDigest.update(bytes);
+      const remaining = PERSISTED_STREAM_LIMIT_BYTES - persistedBytes;
+      if (remaining > 0) {
+        const persisted = bytes.subarray(0, remaining);
+        await writeAll(output, persisted);
+        persistedBytes += persisted.byteLength;
+        persistedDigest.update(persisted);
+      }
+      buffered += decoder.decode(bytes, { stream: true });
+      let newline = buffered.indexOf('\n');
+      while (newline >= 0) {
+        consume(buffered.slice(0, newline));
+        buffered = buffered.slice(newline + 1);
+        newline = buffered.indexOf('\n');
+      }
+      if (Buffer.byteLength(buffered) > CLASSIFIABLE_RECORD_LIMIT_BYTES) {
+        recordTooLarge = true;
+        buffered = '';
+      }
     }
-    if (Buffer.byteLength(buffered) > CLASSIFIABLE_RECORD_LIMIT_BYTES) {
-      recordTooLarge = true;
-      buffered = '';
-    }
+  } finally {
+    await output.close();
   }
   buffered += decoder.decode();
   if (buffered) consume(buffered);
-  const streamDiagnostic = { observedBytes, sha256: digest.digest('hex') };
+  const streamDiagnostic = {
+    observedBytes,
+    persistedBytes,
+    truncatedBytes: observedBytes - persistedBytes,
+    sha256: persistedDigest.digest('hex'),
+    observedSha256: observedDigest.digest('hex'),
+    path: `/logs/agent/${basename(destination)}`,
+  };
   if (recordTooLarge) {
     return {
       ...streamDiagnostic,
@@ -489,29 +530,67 @@ async function classifyStream(input: Readable, selected: Profile): Promise<Class
   };
 }
 
-async function captureStreamDiagnostic(input: Readable): Promise<StreamDiagnostic> {
-  const digest = createHash('sha256');
+async function captureStreamDiagnostic(
+  input: Readable,
+  destination: string,
+): Promise<StreamDiagnostic> {
+  const persistedDigest = createHash('sha256');
+  const observedDigest = createHash('sha256');
+  const output = await open(destination, 'w', 0o600);
   let observedBytes = 0;
-  for await (const chunk of input) {
-    const bytes = Buffer.from(chunk);
-    observedBytes += bytes.byteLength;
-    digest.update(bytes);
+  let persistedBytes = 0;
+  try {
+    for await (const chunk of input) {
+      const bytes = Buffer.from(chunk);
+      observedBytes += bytes.byteLength;
+      observedDigest.update(bytes);
+      const remaining = PERSISTED_STREAM_LIMIT_BYTES - persistedBytes;
+      if (remaining > 0) {
+        const persisted = bytes.subarray(0, remaining);
+        await writeAll(output, persisted);
+        persistedBytes += persisted.byteLength;
+        persistedDigest.update(persisted);
+      }
+    }
+  } finally {
+    await output.close();
   }
-  return { observedBytes, sha256: digest.digest('hex') };
+  return {
+    observedBytes,
+    persistedBytes,
+    truncatedBytes: observedBytes - persistedBytes,
+    sha256: persistedDigest.digest('hex'),
+    observedSha256: observedDigest.digest('hex'),
+    path: `/logs/agent/${basename(destination)}`,
+  };
 }
 
 function streamArtifact(kind: string, profile: Profile, capture: StreamDiagnostic) {
   return {
     kind,
     profile,
+    path: capture.path,
     bytes: capture.observedBytes,
+    observedBytes: capture.observedBytes,
+    persistedBytes: capture.persistedBytes,
+    truncatedBytes: capture.truncatedBytes,
     sha256: capture.sha256,
+    observedSha256: capture.observedSha256,
     ...('classification' in capture &&
     capture.classification === 'record-too-large' &&
     'limitBytes' in capture
       ? { classification: capture.classification, limitBytes: capture.limitBytes }
       : {}),
   };
+}
+
+async function writeAll(output: Awaited<ReturnType<typeof open>>, value: Buffer): Promise<void> {
+  let offset = 0;
+  while (offset < value.byteLength) {
+    const { bytesWritten } = await output.write(value.subarray(offset));
+    if (bytesWritten <= 0) throw new Error('external trajectory write did not advance');
+    offset += bytesWritten;
+  }
 }
 
 function prepareClaudeWorkspace(root: string, home: string): void {

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -5,11 +5,12 @@ import { chmod, mkdir, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type Server } from 'node:http';
 import { basename, dirname, join } from 'node:path';
 import type { Readable } from 'node:stream';
-import { fetch as undiciFetch, ProxyAgent } from 'undici';
+import { fetch as undiciFetch } from 'undici';
 import {
   decodePreverifiedToolchain,
   type ExternalProfile as Profile,
 } from './toolchain-verification.js';
+import { createExternalProviderDispatcher } from './external-provider-dispatcher.js';
 import { isInferenceAdmissionEvent } from './provider-admission.js';
 import { removeEvalWebTools } from './provider-web-tool-surface.js';
 import { takeRelayResultToken, writeRelayResult } from './relay-result-frame.js';
@@ -607,7 +608,7 @@ async function startMeteringProxy(
   let removedWebTools = 0;
   const requestModels = new Set<string>();
   const observedToolNames = new Set<string>();
-  const dispatcher = process.env.HTTPS_PROXY ? new ProxyAgent(process.env.HTTPS_PROXY) : undefined;
+  const providerTransport = createExternalProviderDispatcher(process.env.HTTPS_PROXY);
   const active = new Set<Promise<void>>();
   const server = createServer((request, response) => {
     const operation = (async () => {
@@ -634,7 +635,7 @@ async function startMeteringProxy(
         method: request.method,
         headers,
         body: projected.body.length === 0 ? undefined : new Uint8Array(projected.body),
-        ...(dispatcher ? { dispatcher } : {}),
+        dispatcher: providerTransport.dispatcher,
       });
       response.statusCode = upstream.status;
       upstream.headers.forEach((value, name) => {
@@ -690,7 +691,7 @@ async function startMeteringProxy(
     close: async () => {
       await Promise.allSettled([...active]);
       await closeServer(server);
-      await dispatcher?.close();
+      await providerTransport.close();
     },
   };
 }

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -227,7 +227,7 @@ function relayContext(state: RelayState, signal?: AbortSignal): SubjectExecution
   return {
     cwd: state.cwd,
     taskInput: state.taskInput,
-    metadata: { trialName: state.trialName },
+    metadata: { trialName: state.trialName, trialPath: state.trialPath },
     ...(signal ? { signal } : {}),
     execute: async (input) => {
       signal?.throwIfAborted();

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -13,6 +13,7 @@ import {
   MAKA_RUNTIME_ARTIFACT_PATH,
   MAKA_SUBJECT_STDERR_PATH,
   MAKA_SUBJECT_STDOUT_PATH,
+  recoverMakaRuntimeUsage,
 } from './maka-artifacts.js';
 import {
   type ExecutorAttemptOutcome,
@@ -222,8 +223,13 @@ async function runHarnessAttempt(
   }
   if (!hasValue) throw new Error('executor operation did not settle');
   if (value!.usage === null) {
-    const profile = externalProfile(cell.subject.id);
-    const recovered = await recoverExternalMetering({ trialPath: state.trialPath }, profile);
+    const recovered =
+      cell.subject.kind === 'maka'
+        ? await recoverMakaRuntimeUsage({ trialPath: state.trialPath })
+        : await recoverExternalMetering(
+            { trialPath: state.trialPath },
+            externalProfile(cell.subject.id),
+          );
     if (recovered) {
       value = {
         ...value!,

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -182,6 +182,12 @@ async function runHarnessAttempt(
     }
     await state.closeRelay();
   }
+  if (hasValue && finalizationEvidence && finalizationConfirmed(finalizationEvidence)) {
+    value = {
+      ...value!,
+      artifacts: [...value!.artifacts, ...(await collectedArtifactInventory(state.trialPath))],
+    };
+  }
   if (
     hasValue &&
     (state.transport.failure || cleanupAction || state.diagnostic?.category !== 'none')
@@ -731,7 +737,6 @@ async function readVerification(
     failureReason: score === null ? 'verifier produced no reward' : null,
     artifacts: [
       { kind: 'trial', framework: cell.executor.kind, trialName: state.trialName },
-      ...(await collectedArtifactInventory(state.trialPath)),
       ...(egressAudit
         ? [
             {
@@ -753,6 +758,7 @@ async function collectedArtifactInventory(trialPath: string): Promise<JsonObject
     join(root, basename(MAKA_RUNTIME_ARTIFACT_PATH)),
     join(root, basename(MAKA_SUBJECT_STDOUT_PATH)),
     join(root, basename(MAKA_SUBJECT_STDERR_PATH)),
+    join(trialPath, 'agent'),
   ];
   for (const target of targets) {
     await walkCollectedArtifacts(trialPath, target, files).catch((error: NodeJS.ErrnoException) => {

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -8,6 +8,7 @@ import { basename, delimiter, dirname, join, relative, resolve, sep } from 'node
 import { createInterface } from 'node:readline';
 import { fileURLToPath } from 'node:url';
 import { decodeJsonObject, type ExperimentCell, type JsonObject } from './experiment.js';
+import { recoverExternalMetering } from './external-subject.js';
 import {
   MAKA_RUNTIME_ARTIFACT_PATH,
   MAKA_SUBJECT_STDERR_PATH,
@@ -220,7 +221,34 @@ async function runHarnessAttempt(
       : { kind: 'indeterminate', cause: 'cleanup-unconfirmed' };
   }
   if (!hasValue) throw new Error('executor operation did not settle');
+  if (value!.usage === null) {
+    const profile = externalProfile(cell.subject.id);
+    const recovered = await recoverExternalMetering({ trialPath: state.trialPath }, profile);
+    if (recovered) {
+      value = {
+        ...value!,
+        usage: recovered.usage,
+        costUsd: recovered.costUsd,
+        artifacts: [...value!.artifacts, recovered.artifact],
+      };
+    }
+  }
   return { kind: 'settled', value };
+}
+
+function externalProfile(value: string) {
+  if (
+    value === 'codex' ||
+    value === 'claude-code' ||
+    value === 'reasonix' ||
+    value === 'opencode' ||
+    value === 'kimi-code' ||
+    value === 'zcode' ||
+    value === 'pi'
+  ) {
+    return value;
+  }
+  return undefined;
 }
 
 function relayContext(state: RelayState, signal?: AbortSignal): SubjectExecutionContext {

--- a/packages/eval/src/maka-artifacts.ts
+++ b/packages/eval/src/maka-artifacts.ts
@@ -3,6 +3,8 @@ import { createReadStream } from 'node:fs';
 import { chmod, copyFile, mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, dirname, join, resolve } from 'node:path';
 import { backup, DatabaseSync } from 'node:sqlite';
+import type { JsonObject } from './experiment.js';
+import type { NormalizedUsage } from './result.js';
 
 export const MAKA_RUNTIME_ARTIFACT_PATH = '/logs/artifacts/maka-runtime-host';
 export const MAKA_SUBJECT_STDOUT_PATH = '/logs/artifacts/maka-subject.stdout.txt';
@@ -19,6 +21,79 @@ export interface MakaRuntimeArtifactManifest {
   readonly reason: 'settled' | 'signal';
   readonly capturedAt: number;
   readonly files: readonly CapturedFile[];
+}
+
+export async function recoverMakaRuntimeUsage(input: { readonly trialPath: string }): Promise<
+  | {
+      readonly usage: NormalizedUsage;
+      readonly costUsd: number;
+      readonly artifact: JsonObject;
+    }
+  | undefined
+> {
+  const path = join(
+    resolve(input.trialPath),
+    'artifacts',
+    'logs',
+    'artifacts',
+    'maka-runtime-host',
+    'runtime.sqlite',
+  );
+  let database: DatabaseSync;
+  try {
+    database = new DatabaseSync(path, { readOnly: true });
+  } catch {
+    return undefined;
+  }
+  try {
+    const attempts = readUsageRecords(database, 'usage_model_call_attempts');
+    const legacy = readUsageRecords(database, 'usage_llm_calls');
+    const missingAttempts = attempts.filter((record) => record.usageBasis === 'missing').length;
+    const inputTokens = sumRecords(attempts, 'inputTokens') + sumRecords(legacy, 'inputTokens');
+    const outputTokens = sumRecords(attempts, 'outputTokens') + sumRecords(legacy, 'outputTokens');
+    const cacheReadTokens =
+      sumRecords(attempts, 'cacheReadInputTokens') +
+      legacy.reduce(
+        (total, record) =>
+          total + count(record.cacheHitInputTokens ?? record.cachedInputTokens ?? 0),
+        0,
+      );
+    const cacheWriteTokens =
+      sumRecords(attempts, 'cacheWriteInputTokens') + sumRecords(legacy, 'cacheWriteInputTokens');
+    const reasoningTokens =
+      sumRecords(attempts, 'reasoningTokens') + sumRecords(legacy, 'reasoningTokens');
+    if (inputTokens + outputTokens === 0) return undefined;
+    const confirmedAttempts =
+      attempts.filter((record) => record.usageBasis !== 'missing').length + legacy.length;
+    const usageComplete = missingAttempts === 0;
+    return {
+      usage: {
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        cacheWriteTokens,
+        reasoningTokens,
+        totalTokens: inputTokens + outputTokens,
+      },
+      costUsd: [...attempts, ...legacy].reduce(
+        (total, record) => total + nonnegative(record.costUsd ?? 0),
+        0,
+      ),
+      artifact: {
+        kind: 'maka-runtime-usage-recovery',
+        path: 'artifacts/logs/artifacts/maka-runtime-host/runtime.sqlite',
+        usageComplete,
+        confirmedAttempts,
+        missingAttempts,
+        tokenBasis: usageComplete ? 'complete' : 'lower-bound',
+        costBasis: usageComplete ? 'complete' : 'lower-bound',
+      },
+    };
+  } catch {
+    return undefined;
+  } finally {
+    database.close();
+  }
 }
 
 export async function captureMakaRuntimeArtifacts(input: {
@@ -132,4 +207,39 @@ function safeErrorCode(error: unknown): string | null {
 function safeErrorMessage(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return Buffer.from(message).subarray(0, 1024).toString();
+}
+
+function readUsageRecords(
+  database: DatabaseSync,
+  table: 'usage_model_call_attempts' | 'usage_llm_calls',
+): ReadonlyArray<Record<string, unknown>> {
+  return (
+    database.prepare(`SELECT record_json FROM ${table}`).all() as Array<{
+      record_json: string;
+    }>
+  ).map(({ record_json }) => {
+    const value = JSON.parse(record_json) as unknown;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new Error('Runtime usage record is invalid');
+    }
+    return value as Record<string, unknown>;
+  });
+}
+
+function sumRecords(records: ReadonlyArray<Record<string, unknown>>, field: string): number {
+  return records.reduce((total, record) => total + count(record[field] ?? 0), 0);
+}
+
+function count(value: unknown): number {
+  if (!Number.isSafeInteger(value) || Number(value) < 0) {
+    throw new Error('Runtime usage token count is invalid');
+  }
+  return Number(value);
+}
+
+function nonnegative(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error('Runtime usage cost is invalid');
+  }
+  return value;
 }

--- a/packages/runtime-host/src/__tests__/fixtures/owned-candidate-exit.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/owned-candidate-exit.ts
@@ -1,1 +1,2 @@
+console.error('owned candidate stderr sentinel');
 process.exitCode = Number(process.env.MAKA_TEST_EXIT_CODE ?? 0);

--- a/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
@@ -52,7 +52,7 @@ test('startup failure preserves its fixed safe cause', async () => {
   assert.equal(result.failureReason, 'Runtime Host did not start: existing_host');
 });
 
-test('headless hosted execution widens liveness for CPU-bound task containers', async () => {
+test('headless hosted execution disables liveness probes for CPU-bound task containers', async () => {
   let observed: unknown;
   const result = await runHostedExecutionWithDependencies(headlessInput(), {
     connectOwnedRuntimeHost: async (input) => {
@@ -62,7 +62,7 @@ test('headless hosted execution widens liveness for CPU-bound task containers', 
   });
 
   assert.equal(result.failureReason, 'Runtime Host did not start: existing_host');
-  assert.equal((observed as { livenessIntervalMs?: number }).livenessIntervalMs, 10_000);
+  assert.equal((observed as { livenessIntervalMs?: number }).livenessIntervalMs, 0);
   assert.equal((observed as { livenessTimeoutMs?: number }).livenessTimeoutMs, 30_000);
 });
 

--- a/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
@@ -52,6 +52,20 @@ test('startup failure preserves its fixed safe cause', async () => {
   assert.equal(result.failureReason, 'Runtime Host did not start: existing_host');
 });
 
+test('headless hosted execution widens liveness for CPU-bound task containers', async () => {
+  let observed: unknown;
+  const result = await runHostedExecutionWithDependencies(headlessInput(), {
+    connectOwnedRuntimeHost: async (input) => {
+      observed = input;
+      return { kind: 'failed', reason: 'existing_host' };
+    },
+  });
+
+  assert.equal(result.failureReason, 'Runtime Host did not start: existing_host');
+  assert.equal((observed as { livenessIntervalMs?: number }).livenessIntervalMs, 10_000);
+  assert.equal((observed as { livenessTimeoutMs?: number }).livenessTimeoutMs, 30_000);
+});
+
 test('startup cancellation closes admission with the cancelled result', async () => {
   const abort = new AbortController();
   const result = await runHostedExecutionWithDependencies(input(abort.signal), {
@@ -65,11 +79,8 @@ test('startup cancellation closes admission with the cancelled result', async ()
   assert.equal(result.failureReason, 'Hosted execution was cancelled');
 });
 
-test('post-connect cancellation reports the owned Host settlement outcome', async () => {
-  for (const [clean, failureReason] of [
-    [true, 'Hosted execution was cancelled'],
-    [false, 'Runtime Host did not exit cleanly'],
-  ] as const) {
+test('post-connect cancellation preserves its primary cause across Host cleanup', async () => {
+  for (const clean of [true, false]) {
     const abort = new AbortController();
     const connected = ownedHost(
       {
@@ -87,7 +98,7 @@ test('post-connect cancellation reports the owned Host settlement outcome', asyn
       },
     });
 
-    assert.equal(result.failureReason, failureReason);
+    assert.equal(result.failureReason, 'Hosted execution was cancelled');
   }
 });
 
@@ -217,6 +228,20 @@ function input(signal?: AbortSignal) {
       content: { text: 'solve' },
     },
     ...(signal ? { signal } : {}),
+  };
+}
+
+function headlessInput() {
+  const base = input();
+  return {
+    ...base,
+    execution: {
+      ...base.execution,
+      session: {
+        ...base.execution.session,
+        toolProfile: 'headless-coding-v1' as const,
+      },
+    },
   };
 }
 

--- a/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-client.test.ts
@@ -64,6 +64,10 @@ test('headless hosted execution disables liveness probes for CPU-bound task cont
   assert.equal(result.failureReason, 'Runtime Host did not start: existing_host');
   assert.equal((observed as { livenessIntervalMs?: number }).livenessIntervalMs, 0);
   assert.equal((observed as { livenessTimeoutMs?: number }).livenessTimeoutMs, 30_000);
+  assert.equal(
+    (observed as { candidateStderrPath?: string }).candidateStderrPath,
+    '/runtime-host/runtime-host-candidate.log',
+  );
 });
 
 test('startup cancellation closes admission with the cancelled result', async () => {

--- a/packages/runtime-host/src/__tests__/hosted-execution-tool-profile.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-tool-profile.test.ts
@@ -42,6 +42,7 @@ test('the headless coding profile freezes prompt, tools, memory, and foreground 
     'apply_patch',
   ]);
   assert.equal(profile.memoryExtraction, false);
+  assert.equal(profile.streamIdleTimeoutMs, 0);
   assert.equal(
     profile.systemPrompt,
     [

--- a/packages/runtime-host/src/__tests__/hosted-execution-tool-profile.test.ts
+++ b/packages/runtime-host/src/__tests__/hosted-execution-tool-profile.test.ts
@@ -43,6 +43,8 @@ test('the headless coding profile freezes prompt, tools, memory, and foreground 
   ]);
   assert.equal(profile.memoryExtraction, false);
   assert.equal(profile.streamIdleTimeoutMs, 0);
+  assert.equal(profile.providerHeadersTimeoutMs, 0);
+  assert.equal(profile.providerBodyTimeoutMs, 0);
   assert.equal(
     profile.systemPrompt,
     [

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -58,7 +58,10 @@ test('owned Host exits promptly after its first connection closes', async () => 
         max: RUNTIME_HOST_PROTOCOL_VERSION,
       },
       compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
-      electionDeadlineMs: 2_000,
+      // This test owns the post-connect exit deadline below. Give a cold CI
+      // process the same election window as the preceding startup test so
+      // scheduler load cannot fail it before the connection under test exists.
+      electionDeadlineMs: 6_000,
     },
     { launchCandidate: launchOwnedRuntimeHostCandidate },
   );

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readdir } from 'node:fs/promises';
+import { mkdtemp, readFile, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -71,15 +71,19 @@ test('owned Host exits promptly after its first connection closes', async () => 
 
 test('owned candidate settlement requires a clean process exit', async () => {
   const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-candidate-'));
+  const stderrPath = join(rootPath, 'runtime-host-candidate.log');
   const launch = launchOwnedRuntimeHostCandidate({
     rootPath,
     expectedRootId: '00000000-0000-4000-8000-000000000001',
     entrypoint: new URL('./fixtures/owned-candidate-exit.js', import.meta.url),
     env: { MAKA_TEST_EXIT_CODE: '1' },
+    stderrPath,
   });
 
   const candidate = await launch.spawned;
   assert.equal(await candidate.settle(2_000), false);
+  assert.match(await readFile(stderrPath, 'utf8'), /owned candidate stderr sentinel/u);
+  assert.match(await readFile(stderrPath, 'utf8'), /MAKA_RUNTIME_HOST_EXIT_V1 code=1 signal=none/u);
 });
 
 test('owned candidate can be released to the enclosing environment without termination', async () => {

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -81,9 +81,16 @@ test('owned candidate settlement requires a clean process exit', async () => {
   });
 
   const candidate = await launch.spawned;
+  assert.ok(candidate.recordDiagnostic);
+  candidate.recordDiagnostic('MAKA_RUNTIME_HOST_CLIENT_ERROR_V1 {"name":"Sentinel"}');
   assert.equal(await candidate.settle(2_000), false);
   assert.match(await readFile(stderrPath, 'utf8'), /owned candidate stderr sentinel/u);
   assert.match(await readFile(stderrPath, 'utf8'), /MAKA_RUNTIME_HOST_EXIT_V1 code=1 signal=none/u);
+  assert.ok(
+    (await readFile(stderrPath, 'utf8')).includes(
+      'MAKA_RUNTIME_HOST_CLIENT_ERROR_V1 {"name":"Sentinel"}',
+    ),
+  );
 });
 
 test('owned candidate can be released to the enclosing environment without termination', async () => {

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -45,6 +45,7 @@ export interface ConnectOrSpawnRuntimeHostInput {
   handshakeTimeoutMs?: number;
   livenessIntervalMs?: number;
   livenessTimeoutMs?: number;
+  candidateStderrPath?: string;
   candidateEntrypoint: string | URL;
   signal?: AbortSignal;
 }
@@ -243,6 +244,9 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
           expectedRootId: capability.rootId,
           entrypoint: input.candidateEntrypoint,
           initialConnectionTimeoutMs: Math.ceil(remaining),
+          ...(input.candidateStderrPath === undefined
+            ? {}
+            : { stderrPath: input.candidateStderrPath }),
           ...(input.generation === undefined ? {} : { generation: input.generation }),
         });
         const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -197,6 +197,8 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
       clientInstanceId,
       connectTimeoutMs: input.connectTimeoutMs,
       handshakeTimeoutMs: input.handshakeTimeoutMs,
+      livenessIntervalMs: input.livenessIntervalMs,
+      livenessTimeoutMs: input.livenessTimeoutMs,
       electionDeadline: deadline,
     });
     if (result.kind === 'election_deadline_elapsed') {

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -43,6 +43,8 @@ export interface ConnectOrSpawnRuntimeHostInput {
   electionDeadlineMs?: number;
   connectTimeoutMs?: number;
   handshakeTimeoutMs?: number;
+  livenessIntervalMs?: number;
+  livenessTimeoutMs?: number;
   candidateEntrypoint: string | URL;
   signal?: AbortSignal;
 }

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -912,6 +912,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #scheduleLivenessCheck(): void {
     if (
       this.#terminalError ||
+      this.#livenessIntervalMs === 0 ||
       this.#livenessTimer ||
       this.#livenessProbePending ||
       !this.#hasOutstandingDomainRequest()
@@ -1192,7 +1193,7 @@ function normalizeConnectRuntimeHostInput(
       input.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS,
       'handshakeTimeoutMs',
     ),
-    livenessIntervalMs: requireTimeout(
+    livenessIntervalMs: requireLivenessInterval(
       input.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS,
       'livenessIntervalMs',
     ),
@@ -1236,7 +1237,7 @@ export async function connectResolvedRuntimeHost(
     input.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS,
     'handshakeTimeoutMs',
   );
-  const livenessIntervalMs = requireTimeout(
+  const livenessIntervalMs = requireLivenessInterval(
     input.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS,
     'livenessIntervalMs',
   );
@@ -1646,6 +1647,13 @@ function openTransport(
 function requireTimeout(value: number, label: string): number {
   if (!Number.isSafeInteger(value) || value < 1 || value > 120_000) {
     throw new RangeError(`${label} must be an integer between 1 and 120000`);
+  }
+  return value;
+}
+
+function requireLivenessInterval(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 120_000) {
+    throw new RangeError(`${label} must be an integer between 0 and 120000`);
   }
   return value;
 }

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -113,6 +113,8 @@ export interface ConnectRuntimeHostInput {
    * waiting the real cadence; defaults to DEFAULT_LIVENESS_INTERVAL_MS (2s).
    */
   livenessIntervalMs?: number;
+  /** Timeout for each liveness probe response. Defaults to 2s. */
+  livenessTimeoutMs?: number;
   /**
    * Invoked after each liveness probe round-trips and validates its Host
    * Epoch. Test observability: lets a probe-crossing test prove probes
@@ -174,6 +176,7 @@ export interface ConnectRemoteRuntimeHostInput {
   readonly connectTimeoutMs?: number;
   readonly handshakeTimeoutMs?: number;
   readonly livenessIntervalMs?: number;
+  readonly livenessTimeoutMs?: number;
   readonly onLivenessProbe?: () => void;
   readonly connectionResource?: RuntimeHostConnectionResource;
 }
@@ -377,6 +380,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   #inFlightDomainRequests = 0;
   #terminalError: Error | undefined;
   readonly #livenessIntervalMs: number;
+  readonly #livenessTimeoutMs: number;
   readonly #onLivenessProbe: (() => void) | undefined;
 
   constructor(
@@ -393,11 +397,13 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     // the other connect timeouts, before any transport work happens.
     options?: {
       livenessIntervalMs?: number;
+      livenessTimeoutMs?: number;
       onLivenessProbe?: () => void;
       connectionResource?: RuntimeHostConnectionResource;
     },
   ) {
     this.#livenessIntervalMs = options?.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS;
+    this.#livenessTimeoutMs = options?.livenessTimeoutMs ?? DEFAULT_LIVENESS_TIMEOUT_MS;
     this.#onLivenessProbe = options?.onLivenessProbe;
     this.#transport = transport;
     this.rootId = accepted.rootId;
@@ -458,7 +464,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     return this.#requestOperation(
       operation,
       input,
-      timeoutMs ?? (operation === 'host.status' ? DEFAULT_LIVENESS_TIMEOUT_MS : undefined),
+      timeoutMs ?? (operation === 'host.status' ? this.#livenessTimeoutMs : undefined),
       (result) => result,
       operation === 'host.status' ? 'connection' : 'request',
     );
@@ -938,7 +944,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     void this.#requestOperation(
       'host.status',
       {},
-      DEFAULT_LIVENESS_TIMEOUT_MS,
+      this.#livenessTimeoutMs,
       (status) => {
         if (status.hostEpoch !== this.hostEpoch) {
           throw new Error('Runtime Host returned status for a different Host Epoch');
@@ -1131,6 +1137,7 @@ export async function connectRemoteRuntimeHost(
         compositionId,
         expectedRootId,
         livenessIntervalMs: normalized.livenessIntervalMs,
+        livenessTimeoutMs: normalized.livenessTimeoutMs,
         onLivenessProbe: input.onLivenessProbe,
         connectionResource,
       });
@@ -1165,12 +1172,14 @@ function normalizeConnectRuntimeHostInput(
     | 'connectTimeoutMs'
     | 'handshakeTimeoutMs'
     | 'livenessIntervalMs'
+    | 'livenessTimeoutMs'
   >,
 ): {
   clientInstanceId: string;
   connectTimeoutMs: number;
   handshakeTimeoutMs: number;
   livenessIntervalMs: number;
+  livenessTimeoutMs: number;
 } {
   validateProtocolRange(input.protocol);
   return {
@@ -1186,6 +1195,10 @@ function normalizeConnectRuntimeHostInput(
     livenessIntervalMs: requireTimeout(
       input.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS,
       'livenessIntervalMs',
+    ),
+    livenessTimeoutMs: requireTimeout(
+      input.livenessTimeoutMs ?? DEFAULT_LIVENESS_TIMEOUT_MS,
+      'livenessTimeoutMs',
     ),
   };
 }
@@ -1226,6 +1239,10 @@ export async function connectResolvedRuntimeHost(
   const livenessIntervalMs = requireTimeout(
     input.livenessIntervalMs ?? DEFAULT_LIVENESS_INTERVAL_MS,
     'livenessIntervalMs',
+  );
+  const livenessTimeoutMs = requireTimeout(
+    input.livenessTimeoutMs ?? DEFAULT_LIVENESS_TIMEOUT_MS,
+    'livenessTimeoutMs',
   );
   const compositionId = requireHostCompositionId(
     input.compositionId ?? INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
@@ -1312,6 +1329,7 @@ export async function connectResolvedRuntimeHost(
         : registration.compositionRevision,
       hostProtocol: { min: registration.protocolMin, max: registration.protocolMax },
       livenessIntervalMs,
+      livenessTimeoutMs,
       onLivenessProbe: input.onLivenessProbe,
     });
     if (result.kind === 'connected') {
@@ -1387,6 +1405,7 @@ interface ExchangeRuntimeHostHandshakeInput {
   readonly expectedRootId?: string;
   readonly expectedCompositionRevision?: string;
   readonly livenessIntervalMs?: number;
+  readonly livenessTimeoutMs?: number;
   readonly onLivenessProbe?: () => void;
   readonly connectionResource?: RuntimeHostConnectionResource;
 }
@@ -1454,6 +1473,7 @@ async function exchangeRuntimeHostHandshake(
     kind: 'connected',
     connection: new RuntimeHostConnectionImpl(input.transport, handshake, {
       livenessIntervalMs: input.livenessIntervalMs,
+      livenessTimeoutMs: input.livenessTimeoutMs,
       onLivenessProbe: input.onLivenessProbe,
       connectionResource: input.connectionResource,
     }),

--- a/packages/runtime-host/src/client/hosted-execution.ts
+++ b/packages/runtime-host/src/client/hosted-execution.ts
@@ -22,6 +22,10 @@ interface RunHostedExecutionDependencies {
 }
 
 const defaultDependencies: RunHostedExecutionDependencies = { connectOwnedRuntimeHost };
+const HEADLESS_LIVENESS = {
+  livenessIntervalMs: 10_000,
+  livenessTimeoutMs: 30_000,
+} as const;
 
 export async function runHostedExecution(
   input: RunHostedExecutionInput,
@@ -36,6 +40,8 @@ export async function runHostedExecutionWithDependencies(
   if (input.signal?.aborted) {
     return indeterminate(input.execution.executionId, 'Hosted execution was cancelled');
   }
+  const liveness =
+    input.execution.session.toolProfile === 'headless-coding-v1' ? HEADLESS_LIVENESS : {};
   const initial = await dependencies.connectOwnedRuntimeHost({
     rootPath: input.rootPath,
     surface: 'run',
@@ -44,6 +50,7 @@ export async function runHostedExecutionWithDependencies(
       max: RUNTIME_HOST_PROTOCOL_VERSION,
     },
     compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+    ...liveness,
     ...(input.signal ? { signal: input.signal } : {}),
   });
   if (initial.kind !== 'connected') {
@@ -85,6 +92,7 @@ export async function runHostedExecutionWithDependencies(
             max: RUNTIME_HOST_PROTOCOL_VERSION,
           },
           compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+          ...liveness,
           ...(input.signal ? { signal: input.signal } : {}),
         });
         if (reconnected.kind !== 'connected') {
@@ -114,9 +122,8 @@ export async function runHostedExecutionWithDependencies(
     return projection;
   }
   const clean = await connected.host.settle(input.hostSettlementTimeoutMs ?? 15_000);
-  return clean
-    ? projection
-    : indeterminate(input.execution.executionId, 'Runtime Host did not exit cleanly');
+  if (clean || projection.kind === 'indeterminate') return projection;
+  return indeterminate(input.execution.executionId, 'Runtime Host did not exit cleanly');
 }
 
 async function executeHostedExecution(

--- a/packages/runtime-host/src/client/hosted-execution.ts
+++ b/packages/runtime-host/src/client/hosted-execution.ts
@@ -135,6 +135,14 @@ export async function runHostedExecutionWithDependencies(
 
 function runtimeHostClientErrorMarker(error: unknown): string {
   const failure = error instanceof Error ? error : new Error(String(error));
+  const details = failure as Error & {
+    readonly operation?: unknown;
+    readonly mode?: unknown;
+    readonly dispatch?: unknown;
+    readonly reason?: unknown;
+    readonly retryable?: unknown;
+  };
+  const cause = failure.cause instanceof Error ? failure.cause : undefined;
   const code =
     typeof (failure as NodeJS.ErrnoException).code === 'string'
       ? (failure as NodeJS.ErrnoException).code
@@ -143,7 +151,26 @@ function runtimeHostClientErrorMarker(error: unknown): string {
     name: failure.name,
     code,
     message: failure.message,
+    operation: stringField(details.operation),
+    mode: stringField(details.mode),
+    dispatch: stringField(details.dispatch),
+    reason: stringField(details.reason),
+    retryable: typeof details.retryable === 'boolean' ? details.retryable : null,
+    cause: cause
+      ? {
+          name: cause.name,
+          code:
+            typeof (cause as NodeJS.ErrnoException).code === 'string'
+              ? (cause as NodeJS.ErrnoException).code
+              : null,
+          message: cause.message,
+        }
+      : null,
   })}`;
+}
+
+function stringField(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
 }
 
 async function executeHostedExecution(

--- a/packages/runtime-host/src/client/hosted-execution.ts
+++ b/packages/runtime-host/src/client/hosted-execution.ts
@@ -5,6 +5,7 @@ import {
   type HostedExecutionProjection,
   type HostedExecutionStartInput,
 } from '../protocol/index.js';
+import { join } from 'node:path';
 import { connectOwnedRuntimeHost } from './connect-or-spawn.js';
 import type { RuntimeHostConnection } from './connection.js';
 import { configureHostedExecutionTarget } from './hosted-execution-target.js';
@@ -41,7 +42,12 @@ export async function runHostedExecutionWithDependencies(
     return indeterminate(input.execution.executionId, 'Hosted execution was cancelled');
   }
   const liveness =
-    input.execution.session.toolProfile === 'headless-coding-v1' ? HEADLESS_LIVENESS : {};
+    input.execution.session.toolProfile === 'headless-coding-v1'
+      ? {
+          ...HEADLESS_LIVENESS,
+          candidateStderrPath: join(input.rootPath, 'runtime-host-candidate.log'),
+        }
+      : {};
   const initial = await dependencies.connectOwnedRuntimeHost({
     rootPath: input.rootPath,
     surface: 'run',

--- a/packages/runtime-host/src/client/hosted-execution.ts
+++ b/packages/runtime-host/src/client/hosted-execution.ts
@@ -112,7 +112,8 @@ export async function runHostedExecutionWithDependencies(
       }
     }
     projection = await executeHostedExecution(connected.connection, input.execution, input.signal);
-  } catch {
+  } catch (error) {
+    connected.host.recordDiagnostic?.(runtimeHostClientErrorMarker(error));
     projection = input.signal?.aborted
       ? indeterminate(input.execution.executionId, 'Hosted execution was cancelled')
       : indeterminate(
@@ -130,6 +131,19 @@ export async function runHostedExecutionWithDependencies(
   const clean = await connected.host.settle(input.hostSettlementTimeoutMs ?? 15_000);
   if (clean || projection.kind === 'indeterminate') return projection;
   return indeterminate(input.execution.executionId, 'Runtime Host did not exit cleanly');
+}
+
+function runtimeHostClientErrorMarker(error: unknown): string {
+  const failure = error instanceof Error ? error : new Error(String(error));
+  const code =
+    typeof (failure as NodeJS.ErrnoException).code === 'string'
+      ? (failure as NodeJS.ErrnoException).code
+      : null;
+  return `MAKA_RUNTIME_HOST_CLIENT_ERROR_V1 ${JSON.stringify({
+    name: failure.name,
+    code,
+    message: failure.message,
+  })}`;
 }
 
 async function executeHostedExecution(

--- a/packages/runtime-host/src/client/hosted-execution.ts
+++ b/packages/runtime-host/src/client/hosted-execution.ts
@@ -23,7 +23,7 @@ interface RunHostedExecutionDependencies {
 
 const defaultDependencies: RunHostedExecutionDependencies = { connectOwnedRuntimeHost };
 const HEADLESS_LIVENESS = {
-  livenessIntervalMs: 10_000,
+  livenessIntervalMs: 0,
   livenessTimeoutMs: 30_000,
 } as const;
 

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { closeSync, constants, fstatSync, openSync, writeSync } from 'node:fs';
 import { dirname, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -16,6 +17,7 @@ export interface DetachedCandidateInput {
   executable?: string;
   entrypoint: string | URL;
   env?: NodeJS.ProcessEnv;
+  stderrPath?: string;
 }
 
 export interface DetachedCandidateAttempt {
@@ -37,7 +39,7 @@ export type CandidateLauncher = (input: DetachedCandidateInput) => DetachedCandi
 export function launchDetachedRuntimeHostCandidate(
   input: DetachedCandidateInput,
 ): DetachedCandidateLaunch {
-  const child = spawnCandidate(input, true);
+  const { child } = spawnCandidate(input, true);
   const startupFailure = readStartupFailure(child);
   const spawned = spawnedPid(child).then(({ pid }) => {
     child.unref();
@@ -49,11 +51,8 @@ export function launchDetachedRuntimeHostCandidate(
 export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): {
   readonly spawned: Promise<OwnedCandidateAttempt>;
 } {
-  const child = spawnCandidate(input, false);
+  const { child, closed } = spawnCandidate(input, false);
   const startupFailure = readStartupFailure(child);
-  const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-    child.once('exit', (code, signal) => resolve({ code, signal }));
-  });
   return {
     spawned: spawnedPid(child).then(({ pid }) => ({
       pid,
@@ -62,10 +61,10 @@ export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): 
         child.unref();
       },
       async settle(timeoutMs: number): Promise<boolean> {
-        const result = await within(exited, timeoutMs);
+        const result = await within(closed, timeoutMs);
         if (result) return result.code === 0 && result.signal === null;
         child.kill('SIGKILL');
-        await exited;
+        await closed;
         return false;
       },
     })),
@@ -86,19 +85,85 @@ function spawnCandidate(input: DetachedCandidateInput, detached: boolean) {
   appendArgument(args, '--handshake-timeout-ms', input.handshakeTimeoutMs);
   appendArgument(args, '--generation', input.generation);
 
-  // spawn() commits the side effect synchronously; spawned only reports that commit's outcome.
-  const child = spawn(executable, args, {
-    cwd: dirname(isAbsolute(executable) ? executable : process.execPath),
-    detached,
-    stdio: 'ignore',
-    windowsHide: true,
-    env: {
-      ...process.env,
-      ...(process.versions.electron ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
-      ...input.env,
-    },
+  const stderr = openCandidateStderr(input.stderrPath);
+  let child: ReturnType<typeof spawn>;
+  try {
+    // spawn() commits the side effect synchronously; spawned only reports that commit's outcome.
+    child = spawn(executable, args, {
+      cwd: dirname(isAbsolute(executable) ? executable : process.execPath),
+      detached,
+      stdio: ['ignore', 'ignore', stderr?.descriptor ?? 'ignore'],
+      windowsHide: true,
+      env: {
+        ...process.env,
+        ...(process.versions.electron ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
+        ...input.env,
+      },
+    });
+  } catch (error) {
+    stderr?.close();
+    throw error;
+  }
+  const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+    let settled = false;
+    const finish = (code: number | null, signal: NodeJS.Signals | null, errorCode?: string) => {
+      if (settled) return;
+      settled = true;
+      stderr?.finish(code, signal, errorCode);
+      resolve({ code, signal });
+    };
+    child.once('close', (code, signal) => finish(code, signal));
+    child.once('error', (error) =>
+      finish(
+        null,
+        null,
+        typeof (error as NodeJS.ErrnoException).code === 'string'
+          ? (error as NodeJS.ErrnoException).code
+          : 'UNKNOWN',
+      ),
+    );
   });
-  return child;
+  return { child, closed };
+}
+
+function openCandidateStderr(path: string | undefined):
+  | {
+      descriptor: number;
+      finish(code: number | null, signal: NodeJS.Signals | null, errorCode?: string): void;
+      close(): void;
+    }
+  | undefined {
+  if (!path) return undefined;
+  const descriptor = openSync(
+    path,
+    constants.O_WRONLY |
+      constants.O_CREAT |
+      constants.O_APPEND |
+      (process.platform === 'win32' ? 0 : constants.O_NOFOLLOW),
+    0o600,
+  );
+  if (!fstatSync(descriptor).isFile()) {
+    closeSync(descriptor);
+    throw new Error('Runtime Host candidate stderr target is not a file');
+  }
+  let closed = false;
+  const close = () => {
+    if (closed) return;
+    closed = true;
+    closeSync(descriptor);
+  };
+  return {
+    descriptor,
+    finish: (code, signal, errorCode) => {
+      if (closed) return;
+      const marker = errorCode
+        ? `MAKA_RUNTIME_HOST_EXIT_V1 code=none signal=none error=${errorCode}\n`
+        : `MAKA_RUNTIME_HOST_EXIT_V1 code=${code ?? 'none'} signal=${signal ?? 'none'}\n`;
+      writeSync(descriptor, marker);
+      close();
+    },
+    close,
+  };
 }
 
 function spawnedPid(child: ReturnType<typeof spawn>): Promise<{ pid: number }> {

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -27,6 +27,7 @@ export interface DetachedCandidateAttempt {
 
 export interface OwnedCandidateAttempt extends DetachedCandidateAttempt {
   releaseToEnvironment(): void;
+  recordDiagnostic?(value: string): void;
   settle(timeoutMs: number): Promise<boolean>;
 }
 
@@ -51,7 +52,7 @@ export function launchDetachedRuntimeHostCandidate(
 export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): {
   readonly spawned: Promise<OwnedCandidateAttempt>;
 } {
-  const { child, closed } = spawnCandidate(input, false);
+  const { child, closed, recordDiagnostic } = spawnCandidate(input, false);
   const startupFailure = readStartupFailure(child);
   return {
     spawned: spawnedPid(child).then(({ pid }) => ({
@@ -59,6 +60,9 @@ export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): 
       startupFailure,
       releaseToEnvironment(): void {
         child.unref();
+      },
+      recordDiagnostic(value: string): void {
+        recordDiagnostic(value);
       },
       async settle(timeoutMs: number): Promise<boolean> {
         const result = await within(closed, timeoutMs);
@@ -123,13 +127,18 @@ function spawnCandidate(input: DetachedCandidateInput, detached: boolean) {
       ),
     );
   });
-  return { child, closed };
+  return {
+    child,
+    closed,
+    recordDiagnostic: (value: string) => stderr?.writeDiagnostic(value),
+  };
 }
 
 function openCandidateStderr(path: string | undefined):
   | {
       descriptor: number;
       finish(code: number | null, signal: NodeJS.Signals | null, errorCode?: string): void;
+      writeDiagnostic(value: string): void;
       close(): void;
     }
   | undefined {
@@ -161,6 +170,13 @@ function openCandidateStderr(path: string | undefined):
         : `MAKA_RUNTIME_HOST_EXIT_V1 code=${code ?? 'none'} signal=${signal ?? 'none'}\n`;
       writeSync(descriptor, marker);
       close();
+    },
+    writeDiagnostic: (value) => {
+      if (closed) return;
+      const line = Buffer.from(value.replace(/[\r\n]+/gu, ' '))
+        .subarray(0, 1024)
+        .toString();
+      writeSync(descriptor, `${line}\n`);
     },
     close,
   };

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -18,6 +18,7 @@ import {
   createProxiedFetchTransport,
   type ProxiedFetchProxy,
   type ProxiedFetchTransport,
+  type ProxiedFetchTransportOptions,
 } from '@maka/runtime/network/scoped-fetch-transport';
 import { stableHash, toolCatalogHash } from '@maka/runtime/request-shape';
 import { toolAvailabilityHash } from '@maka/runtime/tool-availability';
@@ -55,7 +56,10 @@ export interface HostAiSdkBackendInput {
   readonly requestDrain: () => void;
   readonly runtimeCommitSink?: RuntimeCommitSink;
   readonly childAgents?: HostChildAgentBackendCapabilities;
-  readonly createFetchTransport?: (proxy: ProxiedFetchProxy | null) => ProxiedFetchTransport;
+  readonly createFetchTransport?: (
+    proxy: ProxiedFetchProxy | null,
+    options?: ProxiedFetchTransportOptions,
+  ) => ProxiedFetchTransport;
 }
 
 type HostExecutionRuntimePolicyAuthority = {
@@ -80,6 +84,7 @@ type HostExecutionUsageAuthority = {
 /** Builds one real provider backend from canonical Host state. */
 export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Promise<AiSdkBackend> {
   const createFetchTransport = input.createFetchTransport ?? createProxiedFetchTransport;
+  const runProfile = hostedExecutionRunProfile(input.context.header.toolProfile);
   const target = await readDuringBackendCreation(
     () =>
       resolveExecutionTarget(
@@ -101,6 +106,12 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
   );
   const transport = createFetchTransport(
     toRuntimePolicyProxy(target.networkProxy, target.proxySecret),
+    runProfile
+      ? {
+          headersTimeoutMs: runProfile.providerHeadersTimeoutMs,
+          bodyTimeoutMs: runProfile.providerBodyTimeoutMs,
+        }
+      : undefined,
   );
   let apiKey = target.apiKey;
   let modelFetch: typeof fetch = transport.fetch;
@@ -253,7 +264,6 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       })
     : undefined;
   const recordProviderRequestAttempt = input.context.recordProviderRequestAttempt ?? (() => {});
-  const runProfile = hostedExecutionRunProfile(input.context.header.toolProfile);
   const resolveRunPrompt = async (context: {
     readonly turnId: string;
     readonly runId?: string;

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -40,6 +40,7 @@ import type { HostMemoryExtractionCoordinator } from './memory-extraction-coordi
 import { readDuringBackendCreation, resolveExecutionTarget } from './execution-model-authority.js';
 import { toRuntimePolicyProxy } from './runtime-policy-proxy.js';
 import type { HostRunComposer, HostRunComposerFactory } from './host-run-composer.js';
+import { hostedExecutionRunProfile } from './hosted-execution-tool-profile.js';
 
 export interface HostAiSdkBackendInput {
   readonly context: BackendFactoryContext;
@@ -252,6 +253,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
       })
     : undefined;
   const recordProviderRequestAttempt = input.context.recordProviderRequestAttempt ?? (() => {});
+  const runProfile = hostedExecutionRunProfile(input.context.header.toolProfile);
   const resolveRunPrompt = async (context: {
     readonly turnId: string;
     readonly runId?: string;
@@ -329,6 +331,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
           : {}),
         ...(!input.context.tools && input.childAgents ? input.childAgents : {}),
         providerOptions,
+        ...(runProfile ? { streamIdleTimeoutMs: runProfile.streamIdleTimeoutMs } : {}),
         contextBudget: buildDefaultContextBudgetPolicy(target.connection, {
           name: 'runtime-host-default-history-budget',
           modelId: target.model,

--- a/packages/runtime-host/src/server/hosted-execution-tool-profile.ts
+++ b/packages/runtime-host/src/server/hosted-execution-tool-profile.ts
@@ -34,6 +34,8 @@ export interface HostedExecutionRunProfile {
   readonly systemPrompt: string;
   readonly memoryExtraction: boolean;
   readonly streamIdleTimeoutMs: number;
+  readonly providerHeadersTimeoutMs: number;
+  readonly providerBodyTimeoutMs: number;
 }
 
 export function hostedExecutionRunProfile(
@@ -46,6 +48,8 @@ export function hostedExecutionRunProfile(
       systemPrompt: HEADLESS_CODING_V1_SYSTEM_PROMPT,
       memoryExtraction: false,
       streamIdleTimeoutMs: 0,
+      providerHeadersTimeoutMs: 0,
+      providerBodyTimeoutMs: 0,
     };
   }
   profile satisfies never;

--- a/packages/runtime-host/src/server/hosted-execution-tool-profile.ts
+++ b/packages/runtime-host/src/server/hosted-execution-tool-profile.ts
@@ -33,6 +33,7 @@ export interface HostedExecutionRunProfile {
   readonly toolNames: readonly string[];
   readonly systemPrompt: string;
   readonly memoryExtraction: boolean;
+  readonly streamIdleTimeoutMs: number;
 }
 
 export function hostedExecutionRunProfile(
@@ -44,6 +45,7 @@ export function hostedExecutionRunProfile(
       toolNames: HEADLESS_CODING_V1_TOOL_NAMES,
       systemPrompt: HEADLESS_CODING_V1_SYSTEM_PROMPT,
       memoryExtraction: false,
+      streamIdleTimeoutMs: 0,
     };
   }
   profile satisfies never;

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -11,6 +11,7 @@ import { join } from 'node:path';
 import { after, describe, test, type TestContext } from 'node:test';
 import {
   SHELL_RUN_SOURCE_TOOL_CALL_ID_MAX_BYTES,
+  nextShellRunRecord,
   type ShellRunRecord,
   type ShellRunStore,
 } from '@maka/core/shell-run';
@@ -2198,7 +2199,7 @@ describe('ShellRunProcessManager', () => {
 
   test('redacts a secret across a soft wrap and the scrollback/screen boundary', async () => {
     const secret = 'ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    const manager = await createTestManager();
+    const manager = createManager(createMemoryShellRunStore());
     const initial = await manager.runBackgroundBash(
       shellInput({
         cwd: await workspace(),
@@ -2620,6 +2621,38 @@ async function createTestManager(
   },
 ): Promise<ShellRunProcessManager> {
   return createManager(createSqliteShellRunStore(await workspace()), onShellRunUpdate, options);
+}
+
+function createMemoryShellRunStore(): ShellRunStore {
+  const records = new Map<string, ShellRunRecord>();
+  const key = (sessionId: string, shellRunId: string) => `${sessionId}\0${shellRunId}`;
+  const copy = (record: ShellRunRecord) => structuredClone(record);
+  const missing = (sessionId: string, shellRunId: string) =>
+    Object.assign(new Error(`ShellRun not found: ${sessionId}/${shellRunId}`), { code: 'ENOENT' });
+  return {
+    async createShellRun(record) {
+      const recordKey = key(record.sessionId, record.shellRunId);
+      if (records.has(recordKey)) throw new Error(`ShellRun already exists: ${record.shellRunId}`);
+      records.set(recordKey, copy(record));
+      return copy(record);
+    },
+    async updateShellRun(sessionId, shellRunId, patch) {
+      const recordKey = key(sessionId, shellRunId);
+      const current = records.get(recordKey);
+      if (!current) throw missing(sessionId, shellRunId);
+      const next = nextShellRunRecord(current, patch);
+      records.set(recordKey, copy(next));
+      return copy(next);
+    },
+    async readShellRun(sessionId, shellRunId) {
+      const current = records.get(key(sessionId, shellRunId));
+      if (!current) throw missing(sessionId, shellRunId);
+      return copy(current);
+    },
+    async listSessionShellRuns(sessionId) {
+      return [...records.values()].filter((record) => record.sessionId === sessionId).map(copy);
+    },
+  };
 }
 
 function shellInput(input: {

--- a/packages/runtime/src/__tests__/stream-watchdog.test.ts
+++ b/packages/runtime/src/__tests__/stream-watchdog.test.ts
@@ -45,6 +45,26 @@ describe('StreamWatchdog', () => {
     expect(fired).toEqual([{ phase: 'idle', elapsedMs: 10_000 }]);
   });
 
+  test('zero idle timeout disables the idle phase after provider activity', () => {
+    const timers = fakeTimers(2_500);
+    const fired: StreamWatchdogTimeout[] = [];
+    const watchdog = new StreamWatchdog({
+      now: timers.now,
+      setTimer: timers.setTimer,
+      clearTimer: timers.clearTimer,
+      connectTimeoutMs: 30_000,
+      idleTimeoutMs: 0,
+      onTimeout: (timeout) => fired.push(timeout),
+    });
+
+    watchdog.start();
+    timers.advance(5_000);
+    watchdog.markActivity();
+    timers.advance(600_000);
+
+    expect(fired).toEqual([]);
+  });
+
   test('pause suppresses timeout while waiting for user permission', () => {
     const timers = fakeTimers(3_000);
     const fired: StreamWatchdogTimeout[] = [];

--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -11,9 +11,39 @@ import {
 } from '../../connection-effect-fetch.js';
 import { runConnectionModelDiscoveryEffect } from '../../model-fetcher.js';
 import { runConnectionTestEffect, testConnection } from '../../test-connection.js';
-import { createConnectionEffectFetchTransport } from '../scoped-fetch-transport.js';
+import {
+  createConnectionEffectFetchTransport,
+  createProxiedFetchTransport,
+} from '../scoped-fetch-transport.js';
 
 describe('connection effect network transport', () => {
+  test('provider transport can disable Undici header and body inactivity timeouts', async () => {
+    const server = createServer((_request, response) => {
+      setTimeout(() => {
+        response.writeHead(200, { 'content-type': 'text/plain' });
+        response.end('ok');
+      }, 1_500);
+    });
+    const port = await listen(server);
+    const bounded = createProxiedFetchTransport(null, {
+      headersTimeoutMs: 100,
+      bodyTimeoutMs: 100,
+    });
+    const unbounded = createProxiedFetchTransport(null, {
+      headersTimeoutMs: 0,
+      bodyTimeoutMs: 0,
+    });
+
+    try {
+      await assert.rejects(() => bounded.fetch(`http://127.0.0.1:${port}/slow`));
+      const response = await unbounded.fetch(`http://127.0.0.1:${port}/slow`);
+      assert.equal(await response.text(), 'ok');
+    } finally {
+      await Promise.all([bounded.close(), unbounded.close()]);
+      await closeServer(server);
+    }
+  });
+
   test('concurrent discovery uses immutable per-effect proxy snapshots', async () => {
     const firstProxy = await startConnectProxy(() =>
       jsonResponse(200, modelPayload('first-model')),

--- a/packages/runtime/src/network/scoped-fetch-transport.ts
+++ b/packages/runtime/src/network/scoped-fetch-transport.ts
@@ -28,6 +28,11 @@ export interface ProxiedFetchTransport {
   close(): Promise<void>;
 }
 
+export interface ProxiedFetchTransportOptions {
+  readonly headersTimeoutMs?: number;
+  readonly bodyTimeoutMs?: number;
+}
+
 export function inheritFetchProxySnapshot(
   fetch: typeof globalThis.fetch,
   source: typeof globalThis.fetch,
@@ -46,12 +51,23 @@ export function createConnectionEffectFetchTransport(
 /** Owns one immutable direct/proxy dispatcher snapshot for a provider client. */
 export function createProxiedFetchTransport(
   proxy: ProxiedFetchProxy | null,
+  options: ProxiedFetchTransportOptions = {},
 ): ProxiedFetchTransport {
   const proxySnapshot: ProxySettings | null = proxy?.enabled
     ? { ...proxy, bypassList: [...proxy.bypassList] }
     : null;
+  const requestTimeouts = {
+    ...(options.headersTimeoutMs === undefined
+      ? {}
+      : { headersTimeout: requireTimeout(options.headersTimeoutMs, 'headersTimeoutMs') }),
+    ...(options.bodyTimeoutMs === undefined
+      ? {}
+      : { bodyTimeout: requireTimeout(options.bodyTimeoutMs, 'bodyTimeoutMs') }),
+  };
   const directDispatcher = new Agent();
+  const directRequestDispatcher = withRequestTimeouts(directDispatcher, requestTimeouts);
   let proxyDispatcher: Dispatcher | undefined;
+  let proxyRequestDispatcher: Dispatcher | undefined;
   let closePromise: Promise<void> | undefined;
   let closed = false;
 
@@ -62,13 +78,16 @@ export function createProxiedFetchTransport(
       typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
     const useProxy =
       proxySnapshot !== null && !matchesBypassList(new URL(url).hostname, proxySnapshot.bypassList);
-    if (useProxy) proxyDispatcher ??= buildProxyDispatcher(proxySnapshot) as Dispatcher;
+    if (useProxy) {
+      proxyDispatcher ??= buildProxyDispatcher(proxySnapshot) as Dispatcher;
+      proxyRequestDispatcher ??= withRequestTimeouts(proxyDispatcher, requestTimeouts);
+    }
 
     return (await undiciFetch(
       input as Parameters<typeof undiciFetch>[0],
       {
         ...init,
-        dispatcher: useProxy ? proxyDispatcher : directDispatcher,
+        dispatcher: useProxy ? proxyRequestDispatcher : directRequestDispatcher,
       } as Parameters<typeof undiciFetch>[1],
     )) as unknown as Response;
   };
@@ -92,4 +111,21 @@ export function createProxiedFetchTransport(
   };
 
   return { fetch, close };
+}
+
+function requireTimeout(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new TypeError(`${label} must be a non-negative integer`);
+  }
+  return value;
+}
+
+function withRequestTimeouts(
+  dispatcher: Dispatcher,
+  timeouts: Readonly<Pick<Dispatcher.DispatchOptions, 'headersTimeout' | 'bodyTimeout'>>,
+): Dispatcher {
+  if (Object.keys(timeouts).length === 0) return dispatcher;
+  return dispatcher.compose(
+    (dispatch) => (options, handler) => dispatch({ ...options, ...timeouts }, handler),
+  );
 }


### PR DESCRIPTION
## Root causes

This PR now carries the complete real-machine Eval reliability line.

1. Maka hosted eval sessions inherited the product 120-second model stream idle watchdog, aborting admitted DeepSeek V4 Flash calls before the Terminal-Bench native deadline.
2. External stdout/stderr were hashed in memory but not persisted, and `trial/agent` was omitted from post-finalization artifact inventory.
3. Task instructions beginning with `-` were parsed as CLI flags by several harnesses.
4. Reasonix's large tool list could exceed the 2 KiB atomic relay frame.
5. Timeout paths could lose external or Maka usage already committed to metering snapshots or `runtime.sqlite`.
6. Kimi/ZCode may not flush stdout before timeout, requiring an independent provider request/response trace. Late provider responses must remain eligible to settle inside the task-native window so usage is not discarded.

## Fixes

- Defer only Eval model stream idleness to the benchmark-native timeout while retaining connect deadlines.
- Preserve Runtime Host exit/client diagnostics and owned-host liveness policy.
- Persist bounded external stdout/stderr and credential-free provider request/response JSONL under `/logs/agent`.
- Inventory the complete `trial/agent` directory after confirmed Harbor finalization, with bytes and SHA-256.
- Keep unbounded model/tool details in the hashed metering artifact and bounded counts in the relay frame.
- Recover finalized external usage and partial Maka usage with explicit completeness/lower-bound provenance.
- Prevent dash-leading task text from entering CLI option parsing.
- Preserve late provider usage after the downstream CLI stops reading, within the native task window.

## Regression verification

All new guards were run red-green against the prior implementation: trajectory persistence, `agent/` inventory, 64 MiB bounds, dash-leading prompts, relay payload bounds, provider-events, and late usage recovery.

Current PR head:

- Eval typecheck: PASS
- Eval Node suite: 36/36 PASS
- Python relay contract: 10/10 PASS
- Python relay lifecycle: 12/12 PASS
- Python egress/policy/artifact suites: 6/6 PASS

## Real-machine validation

Terminal-Bench 2.1 revision `d49e28f1e4ddd13d289e85a5f312a66750951932`, DeepSeek V4 Flash, thinking=max, native task timeouts:

- seven-arm canary: 7/7 with score, usage, physical trajectory, and attempt bytes/SHA;
- repaired trajectory cells: 23/23 valid replacements;
- final selected coverage: 712/712 cells have usage and a physically readable trajectory tied to the scored attempt;
- manifest: `/mnt/deepswe/eval-runs/deepseek-v4-flash-final-trajectory-overlay-8a1ab4635.json`;
- missing cells: 0;
- artifact failures: 0;
- active recovery runners: 0.

The real-machine artifacts are authoritative for this timing- and finalization-sensitive path.