### PR TITLE
fix(eval): harden external prompt and admission handling

### DIFF
--- a/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-eight-arm.json
+++ b/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-eight-arm.json
@@ -127,6 +127,7 @@
           "--dangerously-bypass-approvals-and-sandbox",
           "--model",
           "deepseek-v4-flash",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -158,6 +159,7 @@
           "--dangerously-skip-permissions",
           "--model",
           "deepseek-v4-flash",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -183,6 +185,7 @@
           "max",
           "--output-format",
           "stream-json",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -254,8 +257,7 @@
           "{{task.cwd}}",
           "--disallowedTools",
           "WebSearch,WebFetch,FetchURL",
-          "--prompt",
-          "{{task.input}}"
+          "--prompt={{task.input}}"
         ]
       }
     },
@@ -287,7 +289,7 @@
           "deepseek-v4-flash",
           "--thinking",
           "max",
-          "{{task.input}}"
+          "Task instruction:\n{{task.input}}"
         ]
       }
     }

--- a/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-four-arm.json
+++ b/packages/eval/experiments/terminal-bench-2.1-deepseek-v4-flash-four-arm.json
@@ -103,6 +103,7 @@
           "--dangerously-bypass-approvals-and-sandbox",
           "--model",
           "deepseek-v4-flash",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -129,6 +130,7 @@
           "--dangerously-skip-permissions",
           "--model",
           "deepseek-v4-flash",
+          "--",
           "{{task.input}}"
         ]
       }
@@ -153,6 +155,7 @@
           "max",
           "--output-format",
           "stream-json",
+          "--",
           "{{task.input}}"
         ]
       }

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -33,6 +33,9 @@ RESULT_PAYLOAD_LIMIT_BYTES = 2 * 1024
 RESULT_CARRIER_LIMIT_BYTES = 64 * 1024
 SUBJECT_STDOUT_PATH = "/logs/artifacts/maka-subject.stdout.txt"
 SUBJECT_STDERR_PATH = "/logs/artifacts/maka-subject.stderr.txt"
+RECOVERY_PATH_PATTERN = re.compile(
+    r"/logs/agent/[a-z][a-z0-9-]*\.provider-usage\.json"
+)
 
 _host_teardown_requested = False
 
@@ -112,6 +115,7 @@ class RelayAgent(BaseAgent):
                 raise RelayTransportClosed("Maka Eval relay received control before execution")
             result = execution.result()
             await _persist_subject_outputs(environment, result)
+            recovery = await _read_recovery(environment, request)
             stdout, diagnostic = _project_result(result, request)
             if diagnostic["category"] != "execution-scope-unavailable":
                 await _quiesce_scope(environment, cwd, scope_path)
@@ -123,6 +127,7 @@ class RelayAgent(BaseAgent):
                     "termination": "exited",
                     "exitCode": result.return_code,
                     "stdout": stdout,
+                    **({"recovery": recovery} if recovery is not None else {}),
                     "diagnostic": diagnostic,
                 },
             ):
@@ -156,6 +161,7 @@ class RelayAgent(BaseAgent):
                     and not execution_reported
                     and (execution_terminal or not _host_teardown_requested)
                 ):
+                    recovery = await _read_recovery(environment, request)
                     stdout, diagnostic = terminal_projection or _project_result(result, request)
                     with contextlib.suppress(Exception):
                         await _send(
@@ -166,10 +172,16 @@ class RelayAgent(BaseAgent):
                                 "termination": "exited" if execution_terminal else "framework_timeout",
                                 "exitCode": result.return_code if execution_terminal else 124,
                                 "stdout": stdout,
+                                **(
+                                    {"recovery": recovery}
+                                    if recovery is not None
+                                    else {}
+                                ),
                                 "diagnostic": diagnostic,
                             },
                         )
                 elif not execution_reported and not _host_teardown_requested:
+                    recovery = await _read_recovery(environment, request)
                     with contextlib.suppress(Exception):
                         await _send(
                             writer,
@@ -179,6 +191,11 @@ class RelayAgent(BaseAgent):
                                 "termination": "framework_timeout",
                                 "exitCode": 124,
                                 "stdout": "",
+                                **(
+                                    {"recovery": recovery}
+                                    if recovery is not None
+                                    else {}
+                                ),
                                 "diagnostic": (
                                     _carrier_diagnostic("result-frame-missing", b"")
                                     if request.get("captureStdout", True)
@@ -246,6 +263,12 @@ async def _prepare_command(
     capture_stdout = request.get("captureStdout", True)
     if not isinstance(capture_stdout, bool):
         raise RuntimeError("invalid Maka Eval stdout policy")
+    recovery_path = request.get("recoveryPath")
+    if recovery_path is not None and (
+        not isinstance(recovery_path, str)
+        or RECOVERY_PATH_PATTERN.fullmatch(recovery_path) is None
+    ):
+        raise RuntimeError("invalid Maka Eval recovery path")
     result_token = request.get("resultToken")
     if not isinstance(result_token, str) or re.fullmatch(r"[0-9a-f]{32}", result_token) is None:
         raise RuntimeError("invalid Maka Eval result token")
@@ -296,6 +319,24 @@ async def _persist_subject_outputs(environment: Any, result: Any) -> None:
             raise RuntimeError("Maka Eval could not prepare subject artifact output")
         await environment.upload_file(stdout, SUBJECT_STDOUT_PATH)
         await environment.upload_file(stderr, SUBJECT_STDERR_PATH)
+
+
+async def _read_recovery(
+    environment: Any, request: dict[str, Any]
+) -> dict[str, Any] | None:
+    source = request.get("recoveryPath")
+    if source is None:
+        return None
+    if not isinstance(source, str) or RECOVERY_PATH_PATTERN.fullmatch(source) is None:
+        raise RuntimeError("invalid Maka Eval recovery path")
+    with tempfile.TemporaryDirectory() as directory:
+        destination = Path(directory) / "recovery.json"
+        try:
+            await environment.download_file(source, destination)
+            value = json.loads(destination.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, TypeError, ValueError):
+            return None
+    return value if isinstance(value, dict) else None
 
 
 def _decode_result_carrier(carrier: str, token: str) -> tuple[str, dict[str, Any]]:

--- a/packages/eval/harbor/test_relay_artifacts.py
+++ b/packages/eval/harbor/test_relay_artifacts.py
@@ -40,6 +40,9 @@ class ArtifactEnvironment:
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copyfile(source, destination)
 
+    async def download_file(self, source, target):
+        shutil.copyfile(self.root / source.lstrip("/"), target)
+
 
 class RelayArtifactTest(unittest.IsolatedAsyncioTestCase):
     async def test_framed_transport_outputs_are_persisted_without_changing_the_carrier(self):
@@ -60,6 +63,24 @@ class RelayArtifactTest(unittest.IsolatedAsyncioTestCase):
                 "diagnostic\n",
             )
             self.assertEqual(result.stdout, "framed-result\n")
+
+    async def test_provider_usage_checkpoint_is_read_before_container_teardown(self):
+        relay = load_relay()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            environment = ArtifactEnvironment(root)
+            source = root / "logs/agent/opencode.provider-usage.json"
+            source.parent.mkdir(parents=True)
+            source.write_text(
+                '{"schemaVersion":"maka.external_provider_usage.v1","usageRequests":2}\n'
+            )
+
+            recovered = await relay._read_recovery(
+                environment,
+                {"recoveryPath": "/logs/agent/opencode.provider-usage.json"},
+            )
+
+            self.assertEqual(recovered["usageRequests"], 2)
 
 
 if __name__ == "__main__":

--- a/packages/eval/src/__tests__/external-subject.test.ts
+++ b/packages/eval/src/__tests__/external-subject.test.ts
@@ -75,6 +75,116 @@ test('classifies missing executor process scope as infrastructure failure', asyn
   assert.equal(result.failureReason, 'external subject execution scope was unavailable');
 });
 
+test('recovers settled provider usage when the external result frame is unavailable', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-eval-opencode-recovery-'));
+  const sourceEnv = 'MAKA_TEST_OPENCODE_RECOVERY_TOOLCHAIN';
+  const previous = process.env[sourceEnv];
+  const usage = {
+    inputTokens: 100,
+    outputTokens: 20,
+    cacheReadTokens: 80,
+    cacheWriteTokens: 0,
+    reasoningTokens: 10,
+    totalTokens: 120,
+  };
+  try {
+    const executable = join(root, 'bin/opencode');
+    await mkdir(join(root, 'bin'), { recursive: true });
+    await writeFile(executable, 'opencode');
+    const digest = createHash('sha256').update('opencode').digest('hex');
+    await writeFile(join(root, 'checksums.sha256'), `${digest}  bin/opencode\n`);
+    await writeFile(
+      join(root, 'manifest.json'),
+      `${JSON.stringify({ fingerprint: TOOLCHAIN_IDENTITIES.opencode.fingerprint })}\n`,
+    );
+    process.env[sourceEnv] = root;
+    const cell = {
+      ...externalCell({
+        command: '/opt/maka-node-toolchain/bin/node',
+        args: [
+          '/opt/maka-agent/packages/eval/dist/harbor-external-subject.js',
+          'opencode',
+          'https://api.deepseek.com',
+          '/',
+          '/opt/maka-opencode-toolchain/bin/opencode',
+        ],
+        credentialEnvironment: { DEEPSEEK_API_KEY: 'PROVIDER_KEY' },
+      }),
+      executor: {
+        kind: 'harbor',
+        config: {
+          mounts: [
+            {
+              sourceEnv,
+              target: TOOLCHAIN_IDENTITIES.opencode.root,
+              readOnly: true,
+            },
+          ],
+        },
+      },
+    } satisfies ExperimentCell;
+    const adapter = createExternalSubjectAdapter();
+    await adapter.prepare?.({ spec: {} as ExperimentSpec, cells: [cell] });
+    for (const execution of [
+      {
+        termination: 'framework_timeout' as const,
+        exitCode: 124,
+        stdout: '',
+        diagnostic: {
+          category: 'result-frame-missing' as const,
+          bytes: 0,
+          sha256: '0'.repeat(64),
+        },
+      },
+      {
+        termination: 'exited' as const,
+        exitCode: 1,
+        stdout: '',
+        diagnostic: {
+          category: 'result-frame-missing' as const,
+          bytes: 0,
+          sha256: '0'.repeat(64),
+        },
+      },
+    ]) {
+      const result = await adapter.execute({
+        cell,
+        context: {
+          cwd: '/workspace',
+          taskInput: 'solve',
+          metadata: {},
+          execute: async (input) => {
+            assert.equal(input.recoveryPath, '/logs/agent/opencode.provider-usage.json');
+            return {
+              ...execution,
+              recovery: {
+                schemaVersion: 'maka.external_provider_usage.v1',
+                profile: 'opencode',
+                usage,
+                costUsd: 0.01,
+                requests: 2,
+                admittedRequests: 2,
+                usageRequests: 2,
+                usageComplete: true,
+                removedWebTools: 0,
+                models: ['deepseek-v4-flash'],
+                toolNames: ['bash'],
+              },
+            };
+          },
+        },
+      });
+      assert.deepEqual(result.usage, usage);
+      assert.equal(result.costUsd, 0.01);
+      assert.equal(result.status, 'failed');
+    }
+  } finally {
+    if (previous === undefined) delete process.env[sourceEnv];
+    else process.env[sourceEnv] = previous;
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('requires the bundled wrapper for the structured result contract', () => {
   for (const args of [[], ['/tmp/harbor-external-subject.js', 'codex']]) {
     const cell = externalCell({ command: '/opt/tool', args });

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -79,7 +79,7 @@ while (true) {
 }
 const trialPath = new URL('./' + config.trial_name + '/', new URL('file://' + config.trials_dir + '/'));
 await mkdir(trialPath, { recursive: true });
-const agentArtifacts = new URL('artifacts/logs/agent/', trialPath);
+const agentArtifacts = new URL('agent/', trialPath);
 await mkdir(agentArtifacts, { recursive: true });
 await writeFile(new URL('opencode.provider-usage.json', agentArtifacts), '{"usageRequests":1}\\n');
 await writeFile(new URL('result.json', trialPath), JSON.stringify({ verifier_result: { rewards: { reward: 1 } } }));
@@ -138,12 +138,11 @@ socket.end();
     assert.deepEqual(
       result?.artifacts.find(
         ({ kind, path }) =>
-          kind === 'collected-artifact' &&
-          path === 'artifacts/logs/agent/opencode.provider-usage.json',
+          kind === 'collected-artifact' && path === 'agent/opencode.provider-usage.json',
       ),
       {
         kind: 'collected-artifact',
-        path: 'artifacts/logs/agent/opencode.provider-usage.json',
+        path: 'agent/opencode.provider-usage.json',
         bytes: 20,
         sha256: 'sha256:8f625fe55aa6336fccf93df0b9431dfac84d7d6fe772a745b56c9a284364310a',
       },

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -79,6 +79,9 @@ while (true) {
 }
 const trialPath = new URL('./' + config.trial_name + '/', new URL('file://' + config.trials_dir + '/'));
 await mkdir(trialPath, { recursive: true });
+const agentArtifacts = new URL('artifacts/logs/agent/', trialPath);
+await mkdir(agentArtifacts, { recursive: true });
+await writeFile(new URL('opencode.provider-usage.json', agentArtifacts), '{"usageRequests":1}\\n');
 await writeFile(new URL('result.json', trialPath), JSON.stringify({ verifier_result: { rewards: { reward: 1 } } }));
 socket.end();
 `,
@@ -130,7 +133,21 @@ socket.end();
     assert.doesNotThrow(() => process.kill(pid, 0));
     await writeFile(release, '');
     const results = await running;
-    assert.equal(results.get('task::1::external')?.result.status, 'completed');
+    const result = results.get('task::1::external')?.result;
+    assert.equal(result?.status, 'completed');
+    assert.deepEqual(
+      result?.artifacts.find(
+        ({ kind, path }) =>
+          kind === 'collected-artifact' &&
+          path === 'artifacts/logs/agent/opencode.provider-usage.json',
+      ),
+      {
+        kind: 'collected-artifact',
+        path: 'artifacts/logs/agent/opencode.provider-usage.json',
+        bytes: 20,
+        sha256: 'sha256:8f625fe55aa6336fccf93df0b9431dfac84d7d6fe772a745b56c9a284364310a',
+      },
+    );
   } finally {
     await writeFile(release, '').catch(() => undefined);
     globalThis.setTimeout = nativeSetTimeout;

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -649,6 +649,9 @@ test('eight-arm spec and wrappers freeze the working provider contracts', async 
   const maka = spec.subjects.find(({ id }) => id === 'maka')!;
   const codex = spec.subjects.find(({ id }) => id === 'codex')!;
   const claude = spec.subjects.find(({ id }) => id === 'claude-code')!;
+  const reasonix = spec.subjects.find(({ id }) => id === 'reasonix')!;
+  const zcode = spec.subjects.find(({ id }) => id === 'zcode')!;
+  const pi = spec.subjects.find(({ id }) => id === 'pi')!;
   assert.deepEqual(maka.credentials, ['DEEPSEEK_API_KEY']);
   assert.equal(maka.config.connectionSlug, 'env-deepseek');
   assert.equal(maka.config.baseUrl, 'https://api.deepseek.com');
@@ -657,6 +660,12 @@ test('eight-arm spec and wrappers freeze the working provider contracts', async 
   assert.equal(codex.config.args?.includes('--skip-git-repo-check'), true);
   assert.equal(claude.config.args?.includes('--bare'), true);
   assert.equal(claude.config.args?.includes('--effort'), true);
+  for (const subject of [codex, claude, reasonix]) {
+    assert.deepEqual(subject.config.args?.slice(-2), ['--', '{{task.input}}']);
+  }
+  assert.equal(zcode.config.args?.includes('{{task.cwd}}'), true);
+  assert.equal(zcode.config.args?.at(-1), '--prompt={{task.input}}');
+  assert.equal(pi.config.args?.at(-1), 'Task instruction:\n{{task.input}}');
   for (const subject of spec.subjects) {
     assert.deepEqual(subject.credentials, ['DEEPSEEK_API_KEY']);
     if (subject.id === 'maka') continue;

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -74,6 +74,7 @@ test('provider failures remain infrastructure failures until inference admission
         usage: { cacheWriteTokens: number } | null;
         artifacts: Array<{
           kind: string;
+          path?: string;
           admittedRequests?: number;
           usageComplete?: boolean;
         }>;
@@ -88,16 +89,37 @@ test('provider failures remain infrastructure failures until inference admission
         JSON.stringify(result),
         /(?:credential|stdout|stderr)-sentinel-must-not-persist/u,
       );
+      assert.match(
+        await readFile(join(root, 'logs/agent/opencode.jsonl'), 'utf8'),
+        /stdout-sentinel-must-not-persist/u,
+      );
+      assert.match(
+        await readFile(join(root, 'logs/agent/opencode.stderr.txt'), 'utf8'),
+        /stderr-sentinel-must-not-persist/u,
+      );
+      const checkpoint = JSON.parse(
+        await readFile(join(root, 'logs/agent/opencode.provider-usage.json'), 'utf8'),
+      ) as {
+        schemaVersion: string;
+        profile: string;
+        admittedRequests: number;
+        usageRequests: number;
+      };
+      assert.deepEqual(checkpoint, {
+        ...checkpoint,
+        schemaVersion: 'maka.external_provider_usage.v1',
+        profile: 'opencode',
+        admittedRequests,
+        usageRequests: expectedCacheWrite === null ? 0 : 1,
+      });
       assert.equal(
-        (await readdir(join(root, 'logs/agent')).catch(() => [])).some((name) =>
-          name.endsWith('.stderr.txt'),
-        ),
-        false,
+        result.artifacts.find(({ kind }) => kind === 'stdout')?.path,
+        '/logs/agent/opencode.jsonl',
       );
       for (const name of await readdir(join(root, 'logs/agent'))) {
         assert.doesNotMatch(
           await readFile(join(root, 'logs/agent', name), 'utf8'),
-          /(?:credential|stdout|stderr)-sentinel-must-not-persist|0123456789abcdef0123456789abcdef/u,
+          /credential-sentinel-must-not-persist|0123456789abcdef0123456789abcdef/u,
         );
       }
     } finally {
@@ -125,6 +147,17 @@ test('oversized external records are attributed to bounded classification', asyn
   assert.match(stdout?.sha256 ?? '', /^[0-9a-f]{64}$/u);
 });
 
+test('external trajectories are truncated at the persisted byte limit', async () => {
+  const result = await executePiWithTerminalRecord(65 * 1024 * 1024);
+  const stdout = result.artifacts.find(({ kind }) => kind === 'stdout');
+  assert.equal(stdout?.persistedBytes, 64 * 1024 * 1024);
+  assert.ok((stdout?.observedBytes ?? 0) > (stdout?.persistedBytes ?? 0));
+  assert.equal(
+    stdout?.truncatedBytes,
+    (stdout?.observedBytes ?? 0) - (stdout?.persistedBytes ?? 0),
+  );
+});
+
 async function executePiWithTerminalRecord(contentBytes: number): Promise<{
   status: string;
   failureReason: string | null;
@@ -133,6 +166,9 @@ async function executePiWithTerminalRecord(contentBytes: number): Promise<{
     profile?: string;
     exitCode?: number;
     bytes?: number;
+    observedBytes?: number;
+    persistedBytes?: number;
+    truncatedBytes?: number;
     sha256?: string;
     classification?: string;
     limitBytes?: number;

--- a/packages/eval/src/__tests__/provider-admission.test.ts
+++ b/packages/eval/src/__tests__/provider-admission.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { isInferenceAdmissionEvent } from '../provider-admission.js';
+import { isInferenceAdmissionEvent, isSuccessfulInferenceResponse } from '../provider-admission.js';
 
 test('recognizes confirmed provider inference events', () => {
   assert.equal(isInferenceAdmissionEvent({ type: 'response.created' }, false), true);
@@ -16,4 +16,12 @@ test('does not treat provider and transport errors as model admission', () => {
   assert.equal(isInferenceAdmissionEvent({ error: { type: 'rate_limit' } }, false), false);
   assert.equal(isInferenceAdmissionEvent({ type: 'response.failed' }, false), false);
   assert.equal(isInferenceAdmissionEvent({ type: 'ping' }, true), false);
+});
+
+test('treats a successful model response as inference admission without guessing from errors', () => {
+  assert.equal(isSuccessfulInferenceResponse(200, 'deepseek-v4-flash'), true);
+  assert.equal(isSuccessfulInferenceResponse(204, 'deepseek-v4-flash'), true);
+  assert.equal(isSuccessfulInferenceResponse(200, undefined), false);
+  assert.equal(isSuccessfulInferenceResponse(429, 'deepseek-v4-flash'), false);
+  assert.equal(isSuccessfulInferenceResponse(500, 'deepseek-v4-flash'), false);
 });

--- a/packages/eval/src/external-subject.ts
+++ b/packages/eval/src/external-subject.ts
@@ -62,6 +62,7 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
         throw new Error(`${cell.subject.id} toolchain was not verified before execution`);
       }
       const startedAt = Date.now();
+      const profile = bundledProfile(config.args);
       try {
         const execution = await context.execute({
           command: config.command,
@@ -81,12 +82,14 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
                 },
               }),
           ...(config.result === 'exit-code' ? { captureStdout: false } : {}),
+          ...(profile ? { recoveryPath: `/logs/agent/${profile}.provider-usage.json` } : {}),
         });
         const decoded = execution.stdout.length === 0 ? undefined : decodeResult(execution.stdout);
+        const recovered = decodeUsageCheckpoint(execution.recovery, profile);
         if (execution.termination === 'framework_timeout') {
           return {
-            usage: decoded?.usage ?? null,
-            costUsd: decoded?.costUsd ?? null,
+            usage: decoded?.usage ?? recovered?.usage ?? null,
+            costUsd: decoded?.costUsd ?? recovered?.costUsd ?? null,
             durationMs: Date.now() - startedAt,
             status: 'failed' as const,
             failureReason: 'external subject exceeded the framework timeout',
@@ -126,12 +129,14 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
         }
         if (execution.diagnostic?.category.startsWith('result-frame-')) {
           return {
-            usage: null,
-            costUsd: null,
+            usage: recovered?.usage ?? null,
+            costUsd: recovered?.costUsd ?? null,
             durationMs: Date.now() - startedAt,
             status: context.signal?.aborted
               ? ('indeterminate' as const)
-              : ('infra_failed' as const),
+              : recovered && recovered.admittedRequests > 0
+                ? ('failed' as const)
+                : ('infra_failed' as const),
             failureReason: 'external subject result transport failed',
             artifacts: [{ kind: 'external_process', exitCode: execution.exitCode }],
           };
@@ -185,6 +190,52 @@ export function createExternalSubjectAdapter(): SubjectAdapter {
       }
     },
   };
+}
+
+function decodeUsageCheckpoint(
+  value: JsonObject | undefined,
+  profile: ExternalProfile | undefined,
+): { usage: NormalizedUsage | null; costUsd: number | null; admittedRequests: number } | undefined {
+  if (!value || !profile) return undefined;
+  try {
+    const checkpoint = exact(
+      value,
+      [
+        'schemaVersion',
+        'profile',
+        'usage',
+        'costUsd',
+        'requests',
+        'admittedRequests',
+        'usageRequests',
+        'usageComplete',
+        'removedWebTools',
+        'models',
+        'toolNames',
+      ],
+      'external usage checkpoint',
+    );
+    if (
+      checkpoint.schemaVersion !== 'maka.external_provider_usage.v1' ||
+      checkpoint.profile !== profile ||
+      typeof checkpoint.usageComplete !== 'boolean'
+    ) {
+      return undefined;
+    }
+    return {
+      usage: checkpoint.usage === null ? null : decodeUsage(checkpoint.usage),
+      costUsd:
+        checkpoint.costUsd === null
+          ? null
+          : nonnegative(checkpoint.costUsd, 'external checkpoint cost'),
+      admittedRequests: nonnegative(
+        checkpoint.admittedRequests,
+        'external checkpoint admitted requests',
+      ),
+    };
+  } catch {
+    return undefined;
+  }
 }
 
 interface ExternalSubjectConfig {

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -10,7 +10,7 @@ import {
   decodePreverifiedToolchain,
   type ExternalProfile as Profile,
 } from './toolchain-verification.js';
-import { isInferenceAdmissionEvent } from './provider-admission.js';
+import { isInferenceAdmissionEvent, isSuccessfulInferenceResponse } from './provider-admission.js';
 import { removeEvalWebTools } from './provider-web-tool-surface.js';
 import { takeRelayResultToken, writeRelayResult } from './relay-result-frame.js';
 
@@ -657,7 +657,9 @@ async function startMeteringProxy(
         response.end();
       } finally {
         const parsed = parser.finish();
-        if (upstream.ok && parsed.admitted) {
+        const admitted =
+          parsed.admitted || isSuccessfulInferenceResponse(upstream.status, projected.model);
+        if (admitted) {
           admittedRequests += 1;
           if (parsed.usage) {
             usageRequests += 1;

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -1,7 +1,7 @@
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { readFileSync, rmSync, statSync } from 'node:fs';
-import { chmod, mkdir, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, open, rename, writeFile } from 'node:fs/promises';
 import { createServer, type IncomingMessage, type Server } from 'node:http';
 import { basename, dirname, join } from 'node:path';
 import type { Readable } from 'node:stream';
@@ -18,6 +18,8 @@ const resultToken = takeRelayResultToken();
 
 type SubjectStatus = 'completed' | 'failed' | 'infra_failed' | 'indeterminate';
 const CLASSIFIABLE_RECORD_LIMIT_BYTES = 16 * 1024 * 1024;
+const PERSISTED_STREAM_LIMIT_BYTES = 64 * 1024 * 1024;
+let atomicWriteSequence = 0;
 
 interface Usage {
   inputTokens: number;
@@ -50,6 +52,9 @@ process.once('SIGINT', interrupt);
 
 const logsRoot = rooted(systemRoot, '/logs/agent');
 const statePath = join(logsRoot, `${profile}.wrapper-state.json`);
+const stdoutPath = join(logsRoot, `${profile}.jsonl`);
+const stderrPath = join(logsRoot, `${profile}.stderr.txt`);
+const usagePath = join(logsRoot, `${profile}.provider-usage.json`);
 const artifacts: Record<string, unknown>[] = [];
 let usage: Usage | null = null;
 let costUsd: number | null = null;
@@ -69,15 +74,29 @@ try {
   delete process.env.ANTHROPIC_API_KEY;
   delete process.env.DEEPSEEK_API_KEY;
   if (!key) throw new Error('external subject credential is missing');
-  const proxy = await startMeteringProxy(baseUrl, key, profile === 'claude-code');
+  const proxy = await startMeteringProxy(
+    baseUrl,
+    key,
+    profile === 'claude-code',
+    profile,
+    usagePath,
+  );
   try {
     await writeState('proxy_started');
     const prepared = await prepareProfile(profile, proxy.baseUrl, systemRoot, command, args);
     credentialPath = prepared.credentialPath;
     if (profile === 'claude-code') prepareClaudeWorkspace(systemRoot, prepared.home);
-    const result = await runChild(prepared.command, prepared.args, prepared.env, profile);
+    const result = await runChild(
+      prepared.command,
+      prepared.args,
+      prepared.env,
+      profile,
+      stdoutPath,
+      stderrPath,
+    );
     child = undefined;
     await writeState('child_exited', { exitCode: result.exitCode });
+    await proxy.settle();
     usage = proxy.usage();
     costUsd = usage && proxy.usageComplete() ? estimateCost(usage) : null;
     const classified = classifyExecution(
@@ -111,6 +130,7 @@ try {
         toolNames: proxy.observedToolNames(),
       },
       fileArtifact('wrapper-state', statePath, profile),
+      fileArtifact('provider-usage', usagePath, profile),
     );
   } finally {
     await proxy.close();
@@ -400,14 +420,16 @@ async function runChild(
   executableArgs: string[],
   env: NodeJS.ProcessEnv,
   selected: Profile,
+  stdoutDestination: string,
+  stderrDestination: string,
 ): Promise<{ exitCode: number; stdout: ClassifiedStream; stderr: StreamDiagnostic }> {
   const running = spawn(executable, executableArgs, {
     env,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   child = running;
-  const stdout = classifyStream(running.stdout, selected);
-  const stderr = captureStreamDiagnostic(running.stderr);
+  const stdout = classifyStream(running.stdout, selected, stdoutDestination);
+  const stderr = captureStreamDiagnostic(running.stderr, stderrDestination);
   const exitCode = await new Promise<number>((resolveExit, reject) => {
     running.once('error', reject);
     running.once('exit', (code) => resolveExit(code ?? 1));
@@ -418,7 +440,11 @@ async function runChild(
 
 interface StreamDiagnostic {
   readonly observedBytes: number;
+  readonly persistedBytes: number;
+  readonly truncatedBytes: number;
   readonly sha256: string;
+  readonly observedSha256: string;
+  readonly path: string;
 }
 
 type ClassifiedStream = StreamDiagnostic &
@@ -435,10 +461,17 @@ type ClassifiedStream = StreamDiagnostic &
       }
   );
 
-async function classifyStream(input: Readable, selected: Profile): Promise<ClassifiedStream> {
-  const digest = createHash('sha256');
+async function classifyStream(
+  input: Readable,
+  selected: Profile,
+  destination: string,
+): Promise<ClassifiedStream> {
+  const persistedDigest = createHash('sha256');
+  const observedDigest = createHash('sha256');
+  const output = await open(destination, 'w', 0o600);
   const decoder = new TextDecoder();
   let observedBytes = 0;
+  let persistedBytes = 0;
   let buffered = '';
   let completed = false;
   let reportedError = false;
@@ -450,25 +483,43 @@ async function classifyStream(input: Readable, selected: Profile): Promise<Class
     completed ||= signal.completed;
     reportedError ||= signal.reportedError;
   };
-  for await (const chunk of input) {
-    const bytes = Buffer.from(chunk);
-    observedBytes += bytes.byteLength;
-    digest.update(bytes);
-    buffered += decoder.decode(bytes, { stream: true });
-    let newline = buffered.indexOf('\n');
-    while (newline >= 0) {
-      consume(buffered.slice(0, newline));
-      buffered = buffered.slice(newline + 1);
-      newline = buffered.indexOf('\n');
+  try {
+    for await (const chunk of input) {
+      const bytes = Buffer.from(chunk);
+      observedBytes += bytes.byteLength;
+      observedDigest.update(bytes);
+      const remaining = PERSISTED_STREAM_LIMIT_BYTES - persistedBytes;
+      if (remaining > 0) {
+        const persisted = bytes.subarray(0, remaining);
+        await writeAll(output, persisted);
+        persistedBytes += persisted.byteLength;
+        persistedDigest.update(persisted);
+      }
+      buffered += decoder.decode(bytes, { stream: true });
+      let newline = buffered.indexOf('\n');
+      while (newline >= 0) {
+        consume(buffered.slice(0, newline));
+        buffered = buffered.slice(newline + 1);
+        newline = buffered.indexOf('\n');
+      }
+      if (Buffer.byteLength(buffered) > CLASSIFIABLE_RECORD_LIMIT_BYTES) {
+        recordTooLarge = true;
+        buffered = '';
+      }
     }
-    if (Buffer.byteLength(buffered) > CLASSIFIABLE_RECORD_LIMIT_BYTES) {
-      recordTooLarge = true;
-      buffered = '';
-    }
+  } finally {
+    await output.close();
   }
   buffered += decoder.decode();
   if (buffered) consume(buffered);
-  const streamDiagnostic = { observedBytes, sha256: digest.digest('hex') };
+  const streamDiagnostic = {
+    observedBytes,
+    persistedBytes,
+    truncatedBytes: observedBytes - persistedBytes,
+    sha256: persistedDigest.digest('hex'),
+    observedSha256: observedDigest.digest('hex'),
+    path: `/logs/agent/${basename(destination)}`,
+  };
   if (recordTooLarge) {
     return {
       ...streamDiagnostic,
@@ -485,23 +536,52 @@ async function classifyStream(input: Readable, selected: Profile): Promise<Class
   };
 }
 
-async function captureStreamDiagnostic(input: Readable): Promise<StreamDiagnostic> {
-  const digest = createHash('sha256');
+async function captureStreamDiagnostic(
+  input: Readable,
+  destination: string,
+): Promise<StreamDiagnostic> {
+  const persistedDigest = createHash('sha256');
+  const observedDigest = createHash('sha256');
+  const output = await open(destination, 'w', 0o600);
   let observedBytes = 0;
-  for await (const chunk of input) {
-    const bytes = Buffer.from(chunk);
-    observedBytes += bytes.byteLength;
-    digest.update(bytes);
+  let persistedBytes = 0;
+  try {
+    for await (const chunk of input) {
+      const bytes = Buffer.from(chunk);
+      observedBytes += bytes.byteLength;
+      observedDigest.update(bytes);
+      const remaining = PERSISTED_STREAM_LIMIT_BYTES - persistedBytes;
+      if (remaining > 0) {
+        const persisted = bytes.subarray(0, remaining);
+        await writeAll(output, persisted);
+        persistedBytes += persisted.byteLength;
+        persistedDigest.update(persisted);
+      }
+    }
+  } finally {
+    await output.close();
   }
-  return { observedBytes, sha256: digest.digest('hex') };
+  return {
+    observedBytes,
+    persistedBytes,
+    truncatedBytes: observedBytes - persistedBytes,
+    sha256: persistedDigest.digest('hex'),
+    observedSha256: observedDigest.digest('hex'),
+    path: `/logs/agent/${basename(destination)}`,
+  };
 }
 
 function streamArtifact(kind: string, profile: Profile, capture: StreamDiagnostic) {
   return {
     kind,
     profile,
+    path: capture.path,
     bytes: capture.observedBytes,
+    observedBytes: capture.observedBytes,
+    persistedBytes: capture.persistedBytes,
+    truncatedBytes: capture.truncatedBytes,
     sha256: capture.sha256,
+    observedSha256: capture.observedSha256,
     ...('classification' in capture &&
     capture.classification === 'record-too-large' &&
     'limitBytes' in capture
@@ -587,6 +667,8 @@ async function startMeteringProxy(
   upstreamBaseUrl: string,
   upstreamKey: string,
   anthropic: boolean,
+  selected: Profile,
+  checkpointPath: string,
 ): Promise<{
   baseUrl: string;
   usage(): Usage | null;
@@ -597,6 +679,7 @@ async function startMeteringProxy(
   removedWebToolCount(): number;
   requestModels(): readonly string[];
   observedToolNames(): readonly string[];
+  settle(): Promise<void>;
   close(): Promise<void>;
 }> {
   const total = zeroUsage();
@@ -609,6 +692,25 @@ async function startMeteringProxy(
   const observedToolNames = new Set<string>();
   const dispatcher = process.env.HTTPS_PROXY ? new ProxyAgent(process.env.HTTPS_PROXY) : undefined;
   const active = new Set<Promise<void>>();
+  let checkpointWrites = Promise.resolve();
+  const persistCheckpoint = () => {
+    const value = {
+      schemaVersion: 'maka.external_provider_usage.v1',
+      profile: selected,
+      usage: measured ? { ...total, totalTokens: total.inputTokens + total.outputTokens } : null,
+      costUsd: measured ? estimateCost(total) : null,
+      requests,
+      admittedRequests,
+      usageRequests,
+      usageComplete: admittedRequests > 0 && usageRequests === admittedRequests,
+      removedWebTools,
+      models: [...requestModels].sort(),
+      toolNames: [...observedToolNames].sort(),
+    };
+    checkpointWrites = checkpointWrites.then(() => writeJsonAtomic(checkpointPath, value));
+    return checkpointWrites;
+  };
+  await persistCheckpoint();
   const server = createServer((request, response) => {
     const operation = (async () => {
       requests += 1;
@@ -667,10 +769,12 @@ async function startMeteringProxy(
             addUsage(total, parsed.usage);
           }
         }
+        await persistCheckpoint();
       }
-    })().catch((error: unknown) => {
+    })().catch(async (error: unknown) => {
       response.statusCode = 502;
       response.end(JSON.stringify({ error: safeFailure(error, 'provider proxy failed') }));
+      await persistCheckpoint();
     });
     active.add(operation);
     void operation.finally(() => active.delete(operation));
@@ -689,12 +793,32 @@ async function startMeteringProxy(
     removedWebToolCount: () => removedWebTools,
     requestModels: () => [...requestModels].sort(),
     observedToolNames: () => [...observedToolNames].sort(),
+    settle: async () => {
+      await Promise.allSettled([...active]);
+      await checkpointWrites;
+    },
     close: async () => {
       await Promise.allSettled([...active]);
+      await checkpointWrites;
       await closeServer(server);
       await dispatcher?.close();
     },
   };
+}
+
+async function writeJsonAtomic(path: string, value: unknown): Promise<void> {
+  const temporary = `${path}.tmp-${process.pid}-${atomicWriteSequence++}`;
+  await writeFile(temporary, `${JSON.stringify(value)}\n`, { mode: 0o600 });
+  await rename(temporary, path);
+}
+
+async function writeAll(output: Awaited<ReturnType<typeof open>>, value: Buffer): Promise<void> {
+  let offset = 0;
+  while (offset < value.byteLength) {
+    const { bytesWritten } = await output.write(value.subarray(offset));
+    if (bytesWritten <= 0) throw new Error('external trajectory write did not advance');
+    offset += bytesWritten;
+  }
 }
 
 function usageParser(anthropic: boolean): {

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -180,6 +180,12 @@ async function runHarnessAttempt(
     }
     await state.closeRelay();
   }
+  if (hasValue && finalizationEvidence && finalizationConfirmed(finalizationEvidence)) {
+    value = {
+      ...value!,
+      artifacts: [...value!.artifacts, ...(await collectedArtifactInventory(state.trialPath))],
+    };
+  }
   if (
     hasValue &&
     (state.transport.failure || cleanupAction || state.diagnostic?.category !== 'none')
@@ -703,7 +709,6 @@ async function readVerification(
     failureReason: score === null ? 'verifier produced no reward' : null,
     artifacts: [
       { kind: 'trial', framework: cell.executor.kind, trialName: state.trialName },
-      ...(await collectedArtifactInventory(state.trialPath)),
       ...(egressAudit
         ? [
             {

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -254,6 +254,7 @@ function relayContext(state: RelayState, signal?: AbortSignal): SubjectExecution
           credentials,
           resultToken,
           captureStdout: input.captureStdout ?? true,
+          ...(input.recoveryPath ? { recoveryPath: input.recoveryPath } : {}),
         })
       ) {
         throw new Error('relay transport is unavailable');
@@ -276,6 +277,10 @@ function relayContext(state: RelayState, signal?: AbortSignal): SubjectExecution
         (executed.termination !== 'exited' && executed.termination !== 'framework_timeout') ||
         typeof executed.exitCode !== 'number' ||
         typeof executed.stdout !== 'string' ||
+        (executed.recovery !== undefined &&
+          (!executed.recovery ||
+            typeof executed.recovery !== 'object' ||
+            Array.isArray(executed.recovery))) ||
         !validProcessDiagnostic(executed.diagnostic)
       ) {
         state.transport.failure ??= {
@@ -290,6 +295,7 @@ function relayContext(state: RelayState, signal?: AbortSignal): SubjectExecution
         termination: executed.termination,
         exitCode: executed.exitCode,
         stdout: executed.stdout,
+        ...(executed.recovery === undefined ? {} : { recovery: executed.recovery as JsonObject }),
         diagnostic: executed.diagnostic,
       };
     },
@@ -713,12 +719,12 @@ async function readVerification(
 }
 
 async function collectedArtifactInventory(trialPath: string): Promise<JsonObject[]> {
-  const root = join(trialPath, 'artifacts', 'logs', 'artifacts');
   const files: JsonObject[] = [];
   const targets = [
-    join(root, basename(MAKA_RUNTIME_ARTIFACT_PATH)),
-    join(root, basename(MAKA_SUBJECT_STDOUT_PATH)),
-    join(root, basename(MAKA_SUBJECT_STDERR_PATH)),
+    join(trialPath, 'artifacts', 'logs', 'artifacts', basename(MAKA_RUNTIME_ARTIFACT_PATH)),
+    join(trialPath, 'artifacts', 'logs', 'artifacts', basename(MAKA_SUBJECT_STDOUT_PATH)),
+    join(trialPath, 'artifacts', 'logs', 'artifacts', basename(MAKA_SUBJECT_STDERR_PATH)),
+    join(trialPath, 'artifacts', 'logs', 'agent'),
   ];
   for (const target of targets) {
     await walkCollectedArtifacts(trialPath, target, files).catch((error: NodeJS.ErrnoException) => {

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -724,7 +724,7 @@ async function collectedArtifactInventory(trialPath: string): Promise<JsonObject
     join(trialPath, 'artifacts', 'logs', 'artifacts', basename(MAKA_RUNTIME_ARTIFACT_PATH)),
     join(trialPath, 'artifacts', 'logs', 'artifacts', basename(MAKA_SUBJECT_STDOUT_PATH)),
     join(trialPath, 'artifacts', 'logs', 'artifacts', basename(MAKA_SUBJECT_STDERR_PATH)),
-    join(trialPath, 'artifacts', 'logs', 'agent'),
+    join(trialPath, 'agent'),
   ];
   for (const target of targets) {
     await walkCollectedArtifacts(trialPath, target, files).catch((error: NodeJS.ErrnoException) => {

--- a/packages/eval/src/provider-admission.ts
+++ b/packages/eval/src/provider-admission.ts
@@ -19,6 +19,10 @@ export function isInferenceAdmissionEvent(
   return false;
 }
 
+export function isSuccessfulInferenceResponse(status: number, model: string | undefined): boolean {
+  return status >= 200 && status < 300 && typeof model === 'string' && model.length > 0;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/packages/eval/src/runner.ts
+++ b/packages/eval/src/runner.ts
@@ -33,10 +33,12 @@ export interface SubjectExecutionContext {
     readonly environment?: Readonly<Record<string, string>>;
     readonly credentialEnvironment: Readonly<Record<string, string>>;
     readonly captureStdout?: boolean;
+    readonly recoveryPath?: string;
   }) => Promise<{
     readonly termination: 'exited' | 'framework_timeout';
     readonly exitCode: number;
     readonly stdout: string;
+    readonly recovery?: JsonObject;
     readonly diagnostic?: {
       readonly category:
         | 'none'


### PR DESCRIPTION
Fixes two Eval-side attribution failures found while completing the seven-arm Terminal-Bench matrix.

- escapes dash-leading task instructions for positional external CLIs
- passes ZCode prompts as one `--prompt=` argument and keeps its cwd task-derived
- prefixes Pi input because Pi 0.84.1 treats dash-leading positional messages as options even after `--`
- treats a successful 2xx response carrying a model request as inference admission when an external CLI uses an unrecognized provider event envelope
- keeps non-2xx provider and transport failures classified as infrastructure failures

Real-host evidence:
- `pytorch-model-recovery` previously failed before model admission across Codex, Claude Code, Reasonix, ZCode, and Pi because its instruction begins with `- `
- corrected sparse reruns entered model execution and completed on Codex, Claude Code, Reasonix, and ZCode
- Reasonix `adaptive-rejection-sampler` and `gpt2-codegolf` actually consumed model output but were misreported as pre-admission because the response envelope was not recognized
- Reasonix client reasoning limits and task-native timeout failures remain third-party agent outcomes; this PR does not change their limits, prompts, effort, or timeouts

Validation:
- Eval Node 31/31
- relay contract 10/10
- relay lifecycle 12/12
- egress filter 3/3
- run-trial policy 2/2
- relay artifact 1/1
- `git diff --check`