### PR TITLE
test(desktop): make slash caret movement portable

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -101,7 +101,10 @@ test('offers commands only for the first token and keeps explicit Skill queries 
   await expect(inlineMenu.getByRole('option', { name: /\/compact/ })).toHaveCount(0);
 
   await composer.fill('/side');
-  await composer.press('Home');
+  // macOS maps Home to document scrolling rather than line-start movement in
+  // contentEditable. Put the caret at the same semantic position on every OS
+  // before checking that a slash with text after the caret is not a command.
+  await composer.press(process.platform === 'darwin' ? 'Meta+ArrowLeft' : 'Home');
   await composer.press('ArrowRight');
   await expect(inlineMenu.getByRole('group', { name: '命令' })).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

- use the platform-native line-start shortcut in the slash-command menu E2E
- keep `Home` on Windows/Linux and use `Meta+ArrowLeft` on macOS
- make the caret-in-query assertion deterministic instead of depending on menu update timing

## Root cause

The product command filter already rejects a slash when non-whitespace text remains after the caret. The flaky test attempted to place the caret after `/` with `Home` followed by `ArrowRight`. In macOS contentEditable, `Home` scrolls the document rather than moving to line start, so the caret remained at the end of `/side`; the assertion only passed when unrelated menu timing temporarily hid the command group.

## Verification

- baseline focused repetition: 15/20 passed
- fixed focused repetition: 20/20 passed
- complete `slash-command-menu.spec.ts`: 4/4 passed
- Desktop typecheck
- Biome and `git diff --check`

Closes #2948