### PR TITLE
feat(runtime): stream Telegram bot replies

### DIFF
--- a/apps/desktop/src/main/__tests__/bot-incoming-typing.test.ts
+++ b/apps/desktop/src/main/__tests__/bot-incoming-typing.test.ts
@@ -93,3 +93,66 @@ test('the bot typing loop owns only its active abort listener', async (t) => {
   assert.equal(typingAttempts, 4, 'abort must not allow a later typing attempt');
   assert.deepEqual(replies, ['Bot reply']);
 });
+
+test('streams reply snapshots and persists the final reply through one channel stream', async () => {
+  const updates: string[] = [];
+  const finals: string[] = [];
+  let fallbackSends = 0;
+  const service = createBotIncomingMainService({
+    botRegistry: {
+      startReplyStream(
+        _platform: string,
+        _chatId: string,
+        options: { isGroup: boolean; streamId: string },
+      ) {
+        assert.equal(options.isGroup, false);
+        assert.match(options.streamId, /^[0-9a-f-]{36}$/);
+        return {
+          update(text: string) {
+            updates.push(text);
+          },
+          async finish(text: string) {
+            finals.push(text);
+            return 'bot-message';
+          },
+          async abort() {},
+        };
+      },
+      async sendMessage() {
+        fallbackSends += 1;
+        return 'fallback-message';
+      },
+      async sendTypingIndicator() {
+        return true;
+      },
+    } as unknown as BotRegistry,
+    sessions: {
+      async createSession() {
+        return 'bot-session';
+      },
+      async prepareSession() {
+        return 'ready';
+      },
+      async runTurn(input) {
+        input.onReplySnapshot?.('Hello');
+        input.onReplySnapshot?.('Hello world');
+        return { kind: 'completed', text: 'Hello world' };
+      },
+    },
+  });
+
+  await service.handleBotIncomingMessage({
+    platform: 'telegram',
+    userId: 'user',
+    userName: 'User',
+    chatId: 'chat',
+    isGroup: false,
+    text: 'hello',
+    sourceMessageId: 'source',
+    receivedAt: Date.now(),
+  } as BotIncomingMessage);
+
+  assert.deepEqual(updates, ['Hello', 'Hello world']);
+  assert.deepEqual(finals, ['Hello world']);
+  assert.equal(fallbackSends, 0);
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
@@ -113,6 +113,7 @@ test('reconciles an uncertain Host Session create with its stable Session identi
 test('subscribes before Turn start and settles a fast Host reply without losing text', async () => {
   const events = new AsyncFrameQueue();
   const changes: unknown[] = [];
+  const replySnapshots: string[] = [];
   let closeCount = 0;
   const handle: DesktopRuntimeHostSession = {
     snapshot: continuitySnapshot(null),
@@ -131,9 +132,10 @@ test('subscribes before Turn start and settles a fast Host reply without losing 
       events.push(projectionFrame(1, runningTurn(input.sessionId, input.turnId)));
       events.push(deltaFrame(2, input.sessionId, input.turnId, 0, 'Hello'));
       events.push(deltaFrame(3, input.sessionId, input.turnId, 3, 'lo world'));
-      events.push(deltaFrame(4, input.sessionId, input.turnId, 0, 'Corrected reply', true));
+      events.push(deltaFrame(4, input.sessionId, input.turnId, 0, 'Hello world'));
+      events.push(deltaFrame(5, input.sessionId, input.turnId, 0, 'Corrected reply', true));
       events.push(
-        projectionFrame(5, {
+        projectionFrame(6, {
           ...runningTurn(input.sessionId, input.turnId),
           status: 'completed',
           terminalEventId: 'terminal-1',
@@ -153,9 +155,11 @@ test('subscribes before Turn start and settles a fast Host reply without losing 
     sessionId: 'bot-session-1',
     turnId: 'turn-1',
     text: 'hello',
+    onReplySnapshot: (text) => replySnapshots.push(text),
   });
 
   assert.deepEqual(result, { kind: 'completed', text: 'Corrected reply' });
+  assert.deepEqual(replySnapshots, ['Hello', 'Hello world', 'Corrected reply']);
   assert.equal(closeCount, 1);
   assert.deepEqual(changes, [
     {
@@ -168,6 +172,7 @@ test('subscribes before Turn start and settles a fast Host reply without losing 
 
 test('accepts an empty reset delta as the authoritative Bot reply', async () => {
   const events = new AsyncFrameQueue();
+  const replySnapshots: string[] = [];
   const adapter = createRuntimeHostBotSessionAdapter({
     client: botClient({
       openSession: async () => ({
@@ -201,8 +206,52 @@ test('accepts an empty reset delta as the authoritative Bot reply', async () => 
       sessionId: 'bot-session-1',
       turnId: 'turn-1',
       text: 'hello',
+      onReplySnapshot: (text) => replySnapshots.push(text),
     }),
     { kind: 'completed', text: '' },
+  );
+  assert.deepEqual(replySnapshots, ['Provisional reply', '']);
+});
+
+test('reply snapshot observers cannot interrupt the authoritative Host Turn', async () => {
+  const events = new AsyncFrameQueue();
+  const adapter = createRuntimeHostBotSessionAdapter({
+    client: botClient({
+      openSession: async () => ({
+        snapshot: continuitySnapshot(null),
+        activeAssistantStreams: [],
+        transcript: Promise.resolve([]),
+        events,
+        async close() {
+          events.end();
+        },
+      }),
+      startTurn: async (input) => {
+        events.push(deltaFrame(1, input.sessionId, input.turnId, 0, 'Reply'));
+        events.push(
+          projectionFrame(2, {
+            ...runningTurn(input.sessionId, input.turnId),
+            status: 'completed',
+            terminalEventId: 'terminal-1',
+          }),
+        );
+        return startedTurn(runningTurn(input.sessionId, input.turnId));
+      },
+    }),
+    resolveCreateTarget: hostPathCreateTarget,
+    emitSessionsChanged() {},
+  });
+
+  assert.deepEqual(
+    await adapter.runTurn({
+      sessionId: 'bot-session-1',
+      turnId: 'turn-1',
+      text: 'hello',
+      onReplySnapshot() {
+        throw new Error('delivery failed');
+      },
+    }),
+    { kind: 'completed', text: 'Reply' },
   );
 });
 

--- a/apps/desktop/src/main/bot-incoming-main.ts
+++ b/apps/desktop/src/main/bot-incoming-main.ts
@@ -10,7 +10,7 @@ import {
   plaintextHelpReply,
 } from '@maka/core/bot-events';
 import { generalizedErrorMessage } from '@maka/core/redaction';
-import type { BotIncomingMessage, BotRegistry } from '@maka/runtime/bots';
+import type { BotIncomingMessage, BotRegistry, BotReplyStream } from '@maka/runtime/bots';
 import type { BotSessionAdapter, BotSessionTurnResult } from './bot-session-adapter.js';
 import { isBotSessionUnavailableError } from './bot-session-adapter.js';
 import { isSessionWorkspaceUnavailableError } from './project-context-root.js';
@@ -204,6 +204,7 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
     text: string,
   ): Promise<void> {
     if (closed) return;
+    let replyStream: BotReplyStream | null = null;
     // PR-BOT-EPHEMERAL-REPLY-0: TTL for system notices (help / reset ack /
     // fallback errors). Five minutes is long enough for the user to read
     // and process the notice on mobile; short enough that bot DMs do not
@@ -284,10 +285,19 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
       }
 
       const turnId = randomUUID();
+      const replyOptions = message.sourceMessageId
+        ? { replyToMessageId: message.sourceMessageId }
+        : undefined;
+      replyStream = deps.botRegistry.startReplyStream?.(
+        message.platform,
+        message.chatId,
+        { ...(replyOptions ?? {}), isGroup: message.isGroup, streamId: turnId },
+      ) ?? null;
       const turn = deps.sessions.runTurn({
         sessionId,
         turnId,
         text: formatBotMessageForSession({ ...message, text }),
+        onReplySnapshot: (snapshot) => replyStream?.update(snapshot),
       });
       // PR-BOT-TYPING-INDICATOR-0 (external bot research): keep "Maka 正在
       // 输入…" visible in the Telegram client while the agent generates
@@ -323,20 +333,27 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
         typingAbort.abort();
         await typingLoop.catch(() => {});
       }
-      if (closed) return;
+      if (closed) {
+        await replyStream?.abort();
+        return;
+      }
       // PR-BOT-REPLY-TO-MESSAGE-0 (external bot research): thread the bot reply
       // under the originating user message. Group chats with concurrent
       // conversations otherwise visually scramble; even in DMs the threading
       // keeps a long reply attached to the question that produced it. Bot
       // bridge layer drops the field for non-Telegram platforms / multi-chunk
       // continuation pieces.
-      const replyOptions = message.sourceMessageId
-        ? { replyToMessageId: message.sourceMessageId }
-        : undefined;
       if (reply.trim()) {
         // Actual agent reply: NO ephemeral TTL. The answer must stay
         // visible — auto-deleting it would defeat the bot's purpose.
-        const sent = await deps.botRegistry.sendMessage(message.platform, message.chatId, reply.trim(), replyOptions);
+        const sent = replyStream
+          ? await replyStream.finish(reply.trim())
+          : await deps.botRegistry.sendMessage(
+              message.platform,
+              message.chatId,
+              reply.trim(),
+              replyOptions,
+            );
         if (!sent) {
           // Fallback transient notice: 5-minute TTL so the chat does
           // not accumulate "delivery failed" markers.
@@ -347,8 +364,11 @@ export function createBotIncomingMainService(deps: BotIncomingMainServiceDeps): 
             { ...(replyOptions ?? {}), ephemeralTtlMs: 5 * 60 * 1_000 },
           ).catch(() => null);
         }
+      } else {
+        await replyStream?.abort();
       }
     } catch (error) {
+      await replyStream?.abort().catch(() => {});
       if (closed) return;
       const detail = isSessionWorkspaceUnavailableError(error)
         ? '工作目录不可用，请在桌面端选择有效目录后重试'

--- a/apps/desktop/src/main/bot-session-adapter.ts
+++ b/apps/desktop/src/main/bot-session-adapter.ts
@@ -17,6 +17,15 @@ export interface BotSessionAdapter {
     readonly sessionId: string;
     readonly turnId: string;
     readonly text: string;
+    /**
+     * Best-effort projection of the latest assistant text for this Turn.
+     *
+     * Snapshots may replace previously observed text, so consumers must not
+     * treat them as append-only deltas. The callback is synchronous by design:
+     * a slow delivery channel must enqueue its own work instead of applying
+     * backpressure to the Runtime Host subscription.
+     */
+    readonly onReplySnapshot?: (text: string) => void;
   }): Promise<BotSessionTurnResult>;
 }
 

--- a/apps/desktop/src/main/runtime-host-bot-session-adapter.ts
+++ b/apps/desktop/src/main/runtime-host-bot-session-adapter.ts
@@ -104,7 +104,7 @@ export function createRuntimeHostBotSessionAdapter(
       return 'ready';
     },
 
-    async runTurn({ sessionId, turnId, text }) {
+    async runTurn({ sessionId, turnId, text, onReplySnapshot }) {
       let session;
       try {
         session = await deps.client.openSession(sessionId);
@@ -113,7 +113,11 @@ export function createRuntimeHostBotSessionAdapter(
         throw error;
       }
 
-      const completion = collectRuntimeHostBotTurn(session.events, turnId);
+      const completion = collectRuntimeHostBotTurn(
+        session.events,
+        turnId,
+        onReplySnapshot,
+      );
       void completion.catch(() => undefined);
       try {
         try {
@@ -152,9 +156,11 @@ export function createRuntimeHostBotSessionAdapter(
 async function collectRuntimeHostBotTurn(
   events: AsyncIterable<SubscriptionFrame>,
   turnId: string,
+  onReplySnapshot?: (text: string) => void,
 ): Promise<BotSessionTurnResult> {
   const assistantText = new Map<string, string>();
   let latestMessageId: string | undefined;
+  let publishedSnapshot: string | undefined;
 
   for await (const frame of events) {
     if (frame.kind === 'subscription.closed') {
@@ -168,6 +174,16 @@ async function collectRuntimeHostBotTurn(
         frame.delta,
       );
       assistantText.set(latestMessageId, folded.text);
+      if (folded.text !== publishedSnapshot) {
+        publishedSnapshot = folded.text;
+        try {
+          onReplySnapshot?.(folded.text);
+        } catch {
+          // Reply streaming is a best-effort projection. A channel-specific
+          // delivery failure must not stop subscription draining or change the
+          // authoritative Runtime Host Turn outcome.
+        }
+      }
       continue;
     }
     if (frame.kind !== 'subscription.session_projection') continue;

--- a/packages/runtime/src/bots/__tests__/telegram-reply-stream.test.ts
+++ b/packages/runtime/src/bots/__tests__/telegram-reply-stream.test.ts
@@ -1,0 +1,259 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { createDefaultBotChannel } from '@maka/core/settings';
+import { __TEST__, SimpleBotBridge } from '../simple-bridge.js';
+
+const { createTelegramReplyStream, normalizeTelegramPrivateChatId, telegramDraftId } = __TEST__;
+
+const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+describe('Telegram reply streaming', () => {
+  test('keeps private-only drafts disabled for Telegram groups', () => {
+    class RunningTelegramBridge extends SimpleBotBridge {
+      markRunning(): void {
+        this.running = true;
+      }
+    }
+    const bridge = new RunningTelegramBridge('telegram', {
+      ...createDefaultBotChannel('telegram'),
+      enabled: true,
+      token: 'token',
+    });
+    bridge.markRunning();
+
+    assert.equal(bridge.startReplyStream('-100123', { isGroup: true, streamId: 'turn-1' }), null);
+    assert.equal(
+      bridge.startReplyStream('not-a-chat', { isGroup: false, streamId: 'turn-1' }),
+      null,
+    );
+  });
+
+  test('coalesces snapshots and always persists the final reply', async () => {
+    let now = 1_000;
+    const timers: Array<{ callback: () => void; delayMs: number }> = [];
+    const drafts: Array<{ draftId: number; text: string }> = [];
+    const finals: string[] = [];
+    const stream = createTelegramReplyStream({
+      chatId: 'chat-1',
+      streamId: 'turn-1',
+      now: () => now,
+      setTimer: (callback, delayMs) => {
+        timers.push({ callback, delayMs });
+        return { unref() {} } as ReturnType<typeof setTimeout>;
+      },
+      clearTimer() {},
+      sendDraft: async (draftId, text) => {
+        drafts.push({ draftId, text });
+        return true;
+      },
+      sendFinal: async (text) => {
+        finals.push(text);
+        return 'message-1';
+      },
+    });
+
+    stream.update('Hel');
+    await settle();
+    stream.update('Hello');
+    stream.update('Hello world');
+    assert.deepEqual(
+      drafts.map(({ text }) => text),
+      ['Hel'],
+    );
+    const updateTimer = timers.find(({ delayMs }) => delayMs === 250);
+    assert.ok(updateTimer);
+
+    now += 250;
+    updateTimer.callback();
+    await settle();
+    assert.deepEqual(
+      drafts.map(({ text }) => text),
+      ['Hel', 'Hello world'],
+    );
+    assert.equal(drafts[0]?.draftId, drafts[1]?.draftId);
+
+    assert.equal(await stream.finish('Hello world!'), 'message-1');
+    assert.deepEqual(finals, ['Hello world!']);
+  });
+
+  test('falls back to the final send after native draft delivery fails', async () => {
+    let draftAttempts = 0;
+    const finals: string[] = [];
+    const stream = createTelegramReplyStream({
+      chatId: 'chat-1',
+      streamId: 'turn-1',
+      sendDraft: async () => {
+        draftAttempts += 1;
+        return false;
+      },
+      sendFinal: async (text) => {
+        finals.push(text);
+        return 'message-1';
+      },
+    });
+
+    stream.update('partial');
+    await settle();
+    stream.update('later');
+    assert.equal(await stream.finish('final'), 'message-1');
+    assert.equal(draftAttempts, 1);
+    assert.deepEqual(finals, ['final']);
+  });
+
+  test('does not resend a bounded draft when only hidden overflow changes', async () => {
+    const drafts: string[] = [];
+    const stream = createTelegramReplyStream({
+      chatId: 'chat-1',
+      streamId: 'turn-1',
+      prepareDraftText: (text) => text.slice(0, 5),
+      sendDraft: async (_draftId, text) => {
+        drafts.push(text);
+        return true;
+      },
+      sendFinal: async () => 'message-1',
+    });
+
+    stream.update('12345');
+    await settle();
+    stream.update('123456789');
+    await settle();
+    await stream.finish('123456789');
+    assert.deepEqual(drafts, ['12345']);
+  });
+
+  test('waits for an in-flight draft before publishing the final message', async () => {
+    let releaseDraft = () => {};
+    const draftReleased = new Promise<void>((resolve) => {
+      releaseDraft = resolve;
+    });
+    const order: string[] = [];
+    const stream = createTelegramReplyStream({
+      chatId: 'chat-1',
+      streamId: 'turn-1',
+      sendDraft: async () => {
+        order.push('draft-start');
+        await draftReleased;
+        order.push('draft-end');
+        return true;
+      },
+      sendFinal: async () => {
+        order.push('final');
+        return 'message-1';
+      },
+    });
+
+    stream.update('partial');
+    await settle();
+    const finished = stream.finish('final');
+    await settle();
+    assert.deepEqual(order, ['draft-start']);
+    releaseDraft();
+    assert.equal(await finished, 'message-1');
+    assert.deepEqual(order, ['draft-start', 'draft-end', 'final']);
+  });
+
+  test('persists the final reply at most once', async () => {
+    let finalSends = 0;
+    const stream = createTelegramReplyStream({
+      chatId: 'chat-1',
+      streamId: 'turn-1',
+      sendDraft: async () => true,
+      sendFinal: async () => {
+        finalSends += 1;
+        return 'message-1';
+      },
+    });
+
+    assert.deepEqual(await Promise.all([stream.finish('final'), stream.finish('final')]), [
+      'message-1',
+      'message-1',
+    ]);
+    assert.equal(finalSends, 1);
+  });
+
+  test('keeps only the latest pending snapshot while a draft request is slow', async () => {
+    let now = 1_000;
+    let releaseFirst = () => {};
+    const firstReleased = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const timers: Array<{ callback: () => void; delayMs: number }> = [];
+    const drafts: string[] = [];
+    const stream = createTelegramReplyStream({
+      chatId: 'chat-1',
+      streamId: 'turn-1',
+      now: () => now,
+      setTimer: (callback, delayMs) => {
+        timers.push({ callback, delayMs });
+        return { unref() {} } as ReturnType<typeof setTimeout>;
+      },
+      clearTimer() {},
+      sendDraft: async (_draftId, text) => {
+        drafts.push(text);
+        if (drafts.length === 1) await firstReleased;
+        return true;
+      },
+      sendFinal: async () => 'message-1',
+    });
+
+    stream.update('first');
+    await settle();
+    stream.update('second');
+    stream.update('latest');
+    assert.deepEqual(drafts, ['first']);
+    assert.equal(timers.filter(({ delayMs }) => delayMs === 250).length, 0);
+
+    releaseFirst();
+    await settle();
+    const updateTimer = timers.find(({ delayMs }) => delayMs === 250);
+    assert.ok(updateTimer);
+    now += 250;
+    updateTimer.callback();
+    await settle();
+    assert.deepEqual(drafts, ['first', 'latest']);
+    await stream.finish('final');
+  });
+
+  test('refreshes an unchanged draft before Telegram expires it', async () => {
+    const timers: Array<{ callback: () => void; delayMs: number }> = [];
+    const drafts: string[] = [];
+    const stream = createTelegramReplyStream({
+      chatId: 'chat-1',
+      streamId: 'turn-1',
+      setTimer: (callback, delayMs) => {
+        timers.push({ callback, delayMs });
+        return { unref() {} } as ReturnType<typeof setTimeout>;
+      },
+      clearTimer() {},
+      sendDraft: async (_draftId, text) => {
+        drafts.push(text);
+        return true;
+      },
+      sendFinal: async () => 'message-1',
+    });
+
+    stream.update('waiting for a tool');
+    await settle();
+    const keepalive = timers.find(({ delayMs }) => delayMs === 20_000);
+    assert.ok(keepalive);
+    keepalive.callback();
+    await settle();
+    assert.deepEqual(drafts, ['waiting for a tool', 'waiting for a tool']);
+    await stream.abort();
+  });
+
+  test('derives a stable non-zero draft identity for one Turn stream', () => {
+    const first = telegramDraftId('chat-1', 'turn-1');
+    assert.equal(first, telegramDraftId('chat-1', 'turn-1'));
+    assert.notEqual(first, telegramDraftId('chat-1', 'turn-2'));
+    assert.notEqual(first, telegramDraftId('chat-2', 'turn-1'));
+    assert.ok(first > 0);
+  });
+
+  test('accepts only safe positive private chat identities', () => {
+    assert.equal(normalizeTelegramPrivateChatId(' 123 '), 123);
+    for (const value of ['-123', 'chat-name', '9007199254740992']) {
+      assert.equal(normalizeTelegramPrivateChatId(value), undefined);
+    }
+  });
+});

--- a/packages/runtime/src/bots/bot-registry.ts
+++ b/packages/runtime/src/bots/bot-registry.ts
@@ -16,6 +16,8 @@ import type {
   BotBridge,
   BotIncomingMessage,
   BotPlatform,
+  BotReplyStream,
+  BotReplyStreamOptions,
   BotSendOptions,
   BotStatus,
   SendCapable,
@@ -69,6 +71,16 @@ export class BotRegistry extends EventEmitter {
     const bridge = this.bridges.get(platform) as (BotBridge & Partial<SendCapable>) | undefined;
     if (!bridge || typeof bridge.sendMessage !== 'function') return null;
     return bridge.sendMessage(chatId, text, options);
+  }
+
+  startReplyStream(
+    platform: BotPlatform,
+    chatId: string,
+    options: BotReplyStreamOptions,
+  ): BotReplyStream | null {
+    const bridge = this.bridges.get(platform) as (BotBridge & Partial<SendCapable>) | undefined;
+    if (!bridge || typeof bridge.startReplyStream !== 'function') return null;
+    return bridge.startReplyStream(chatId, options);
   }
 
   /**

--- a/packages/runtime/src/bots/index.ts
+++ b/packages/runtime/src/bots/index.ts
@@ -23,6 +23,8 @@ export type {
   BotBridge,
   BotIncomingMessage,
   BotPlatform,
+  BotReplyStream,
+  BotReplyStreamOptions,
   BotStatus,
   BotTestResult,
   SendCapable,

--- a/packages/runtime/src/bots/simple-bridge.ts
+++ b/packages/runtime/src/bots/simple-bridge.ts
@@ -2,7 +2,14 @@ import type { BotAttachmentKind } from '@maka/core/bot-events';
 import type { BotChannelSettings } from '@maka/core/bot-chat-settings';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import { BaseBotAdapter, botReadinessFromSettings } from './base-adapter.js';
-import type { BotPlatform, BotSendOptions, BotStatus, SendCapable } from './types.js';
+import type {
+  BotPlatform,
+  BotReplyStream,
+  BotReplyStreamOptions,
+  BotSendOptions,
+  BotStatus,
+  SendCapable,
+} from './types.js';
 import { proxiedFetch } from './proxied-fetch.js';
 
 const TELEGRAM_POLL_TIMEOUT_S = 15;
@@ -21,6 +28,9 @@ const FEISHU_REQUEST_TIMEOUT_MS = 10_000;
  * inside the cap on the producer side without re-measuring.
  */
 const TELEGRAM_MAX_UTF16_PER_MESSAGE = 4000;
+const TELEGRAM_DRAFT_UPDATE_INTERVAL_MS = 250;
+const TELEGRAM_DRAFT_KEEPALIVE_MS = 20_000;
+const TELEGRAM_DRAFT_ID_MAX = 2_147_483_647;
 
 /** Count UTF-16 code units in `s` (surrogate pairs count as 2). */
 function utf16Len(s: string): number {
@@ -106,6 +116,13 @@ function buildTelegramSendBody(
 
 function normalizeTelegramReplyToMessageId(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  if (!/^[1-9]\d*$/.test(trimmed)) return undefined;
+  const numeric = Number(trimmed);
+  return Number.isSafeInteger(numeric) ? numeric : undefined;
+}
+
+function normalizeTelegramPrivateChatId(value: string): number | undefined {
   const trimmed = value.trim();
   if (!/^[1-9]\d*$/.test(trimmed)) return undefined;
   const numeric = Number(trimmed);
@@ -225,8 +242,11 @@ export const __TEST__ = {
   splitForTelegram,
   buildTelegramSendBody,
   normalizeTelegramReplyToMessageId,
+  normalizeTelegramPrivateChatId,
   isAllowedUser,
   classifyTelegramSendResponse,
+  createTelegramReplyStream,
+  telegramDraftId,
 };
 
 export class SimpleBotBridge extends BaseBotAdapter implements SendCapable {
@@ -339,6 +359,27 @@ export class SimpleBotBridge extends BaseBotAdapter implements SendCapable {
       }, ephemeralDelay).unref?.();
     }
     return lastMessageId;
+  }
+
+  startReplyStream(chatId: string, options: BotReplyStreamOptions): BotReplyStream | null {
+    if (this.platform !== 'telegram' || !this.running || options.isGroup) return null;
+    const privateChatId = normalizeTelegramPrivateChatId(chatId);
+    if (privateChatId === undefined) return null;
+    const token = this.settings.token;
+    return createTelegramReplyStream({
+      chatId,
+      streamId: options.streamId,
+      prepareDraftText: (text) => prefixWithinUtf16(text, TELEGRAM_MAX_UTF16_PER_MESSAGE),
+      sendDraft: async (draftId, text) => {
+        const response = await telegramApi(token, 'sendMessageDraft', {
+          chat_id: privateChatId,
+          draft_id: draftId,
+          text,
+        });
+        return response?.ok === true;
+      },
+      sendFinal: (text) => this.sendMessage(chatId, text, options),
+    });
   }
 
   /**
@@ -494,6 +535,144 @@ export class SimpleBotBridge extends BaseBotAdapter implements SendCapable {
     if (this.platform === 'discord' || this.platform === 'feishu') return 'gateway';
     return 'none';
   }
+}
+
+interface TelegramReplyStreamDeps {
+  readonly chatId: string;
+  readonly streamId: string;
+  readonly prepareDraftText?: (text: string) => string;
+  readonly sendDraft: (draftId: number, text: string) => Promise<boolean>;
+  readonly sendFinal: (text: string) => Promise<string | null>;
+  readonly now?: () => number;
+  readonly setTimer?: (callback: () => void, delayMs: number) => NodeJS.Timeout | number;
+  readonly clearTimer?: (timer: NodeJS.Timeout | number) => void;
+}
+
+function createTelegramReplyStream(deps: TelegramReplyStreamDeps): BotReplyStream {
+  const now = deps.now ?? Date.now;
+  const setTimer = deps.setTimer ?? setTimeout;
+  const clearTimer = deps.clearTimer ?? clearTimeout;
+  const prepareDraftText = deps.prepareDraftText ?? ((text: string) => text);
+  const draftId = telegramDraftId(deps.chatId, deps.streamId);
+  let latestText = '';
+  let deliveredText: string | undefined;
+  let lastAttemptAt = Number.NEGATIVE_INFINITY;
+  let updateTimer: NodeJS.Timeout | number | undefined;
+  let keepaliveTimer: NodeJS.Timeout | number | undefined;
+  let closed = false;
+  let nativeDraftAvailable = true;
+  let inFlight: Promise<void> | undefined;
+  let finishTask: Promise<string | null> | undefined;
+
+  const cancelKeepalive = (): void => {
+    if (keepaliveTimer === undefined) return;
+    clearTimer(keepaliveTimer);
+    keepaliveTimer = undefined;
+  };
+
+  const scheduleKeepalive = (): void => {
+    if (
+      closed ||
+      !nativeDraftAvailable ||
+      deliveredText === undefined ||
+      keepaliveTimer !== undefined
+    )
+      return;
+    keepaliveTimer = setTimer(() => {
+      keepaliveTimer = undefined;
+      sendLatestDraft(true);
+    }, TELEGRAM_DRAFT_KEEPALIVE_MS);
+    if (typeof keepaliveTimer !== 'number') keepaliveTimer.unref?.();
+  };
+
+  const sendLatestDraft = (force = false): void => {
+    if (closed || !nativeDraftAvailable || inFlight || (!force && latestText === deliveredText)) {
+      return;
+    }
+    const text = latestText;
+    lastAttemptAt = now();
+    inFlight = (async () => {
+      try {
+        if (!(await deps.sendDraft(draftId, text))) {
+          nativeDraftAvailable = false;
+          return;
+        }
+        deliveredText = text;
+      } catch {
+        nativeDraftAvailable = false;
+      } finally {
+        inFlight = undefined;
+        if (latestText !== deliveredText) scheduleDraft();
+        else scheduleKeepalive();
+      }
+    })();
+  };
+
+  const scheduleDraft = (): void => {
+    if (
+      closed ||
+      !nativeDraftAvailable ||
+      inFlight ||
+      latestText === deliveredText ||
+      updateTimer !== undefined
+    ) {
+      return;
+    }
+    const remaining = Math.max(0, TELEGRAM_DRAFT_UPDATE_INTERVAL_MS - (now() - lastAttemptAt));
+    if (remaining === 0) {
+      sendLatestDraft();
+      return;
+    }
+    updateTimer = setTimer(() => {
+      updateTimer = undefined;
+      sendLatestDraft();
+    }, remaining);
+    if (typeof updateTimer !== 'number') updateTimer.unref?.();
+  };
+
+  return {
+    update(text) {
+      const prepared = prepareDraftText(text);
+      if (closed || prepared === latestText) return;
+      latestText = prepared;
+      cancelKeepalive();
+      scheduleDraft();
+    },
+    async finish(finalText) {
+      if (finishTask) return finishTask;
+      if (!closed) {
+        closed = true;
+        if (updateTimer !== undefined) clearTimer(updateTimer);
+        updateTimer = undefined;
+        cancelKeepalive();
+      }
+      finishTask = (async () => {
+        await inFlight;
+        return deps.sendFinal(finalText);
+      })();
+      return finishTask;
+    },
+    async abort() {
+      if (finishTask) {
+        await finishTask.catch(() => undefined);
+        return;
+      }
+      if (closed) return;
+      closed = true;
+      if (updateTimer !== undefined) clearTimer(updateTimer);
+      updateTimer = undefined;
+      cancelKeepalive();
+      await inFlight;
+    },
+  };
+}
+
+function telegramDraftId(chatId: string, streamId: string): number {
+  let hash = 2_166_136_261;
+  for (const unit of `${chatId}\0${streamId}`) {
+    hash = Math.imul(hash ^ unit.charCodeAt(0), 16_777_619);
+  }
+  return ((hash >>> 0) % TELEGRAM_DRAFT_ID_MAX) + 1;
 }
 
 async function telegramApi(

--- a/packages/runtime/src/bots/types.ts
+++ b/packages/runtime/src/bots/types.ts
@@ -63,8 +63,30 @@ export interface BotSendOptions {
   readonly ephemeralTtlMs?: number;
 }
 
+export interface BotReplyStreamOptions extends BotSendOptions {
+  /** Whether the reply target is a group/channel rather than a direct chat. */
+  readonly isGroup: boolean;
+  /** Stable identity of the Runtime Host Turn being projected. */
+  readonly streamId: string;
+}
+
+/**
+ * Best-effort progressive delivery for one agent reply.
+ *
+ * `update` receives the latest complete text snapshot, not an append-only
+ * chunk. `finish` persists the authoritative final text through the channel's
+ * normal message path. Implementations must serialize their own network work;
+ * callers never await `update` while draining Runtime Host events.
+ */
+export interface BotReplyStream {
+  update(text: string): void;
+  finish(finalText: string): Promise<string | null>;
+  abort(): Promise<void>;
+}
+
 export interface SendCapable {
   sendMessage(chatId: string, text: string, options?: BotSendOptions): Promise<string | null>;
+  startReplyStream?(chatId: string, options: BotReplyStreamOptions): BotReplyStream | null;
   /**
    * PR-BOT-TYPING-INDICATOR-0 (external bot research): post a one-shot
    * presence/typing signal. Telegram auto-clears it after ~5 seconds;


### PR DESCRIPTION
## Summary

- project the latest complete assistant snapshot from the Runtime Host into a best-effort bot reply stream
- stream Telegram private-chat previews through `sendMessageDraft` with one stable draft identity per Turn
- coalesce slow draft updates and keep the existing `sendMessage` path authoritative for final persistence and fallback

The Host projection is replacement-safe rather than append-only because a session delta may reset or correct prior text. Draft delivery never blocks the Host subscription, and a draft failure does not change the Turn outcome. Groups and unsupported channels retain the existing one-shot behavior.

Refs #2504

## Verification

- `npm --workspace @maka/runtime run test:dist` — 2,794 passed, 6 skipped
- `npm --workspace @maka/desktop run build:main`
- focused Desktop and Telegram reply-stream tests — 20 passed
- Biome check on all 10 changed files

Not run: live Telegram Bot API smoke; that requires a bot credential and a test private chat.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

<details>
<summary>中文说明</summary>

## 摘要

- 将 Runtime Host 中最新、完整的 assistant 文本快照投影为尽力而为的 bot 回复流
- Telegram 私聊通过 `sendMessageDraft` 渐进展示，每个 Turn 使用稳定且独立的草稿标识
- 对慢速草稿请求做合并，最终回复与失败回退仍统一走现有 `sendMessage` 持久化路径

这里传递的是可替换的完整快照，而不是只能追加的 chunk，因为 Host delta 可能重置或修正之前的文本。草稿发送不会阻塞 Host 订阅，草稿失败也不会改变 Turn 的权威结果。群聊和暂不支持流式的渠道继续使用原有的一次性发送行为。

</details>
