### PR TITLE
fix(eval): fail closed when the egress audit log is incomplete

### DIFF
--- a/packages/eval/harbor/egress-proxy/entrypoint.sh
+++ b/packages/eval/harbor/egress-proxy/entrypoint.sh
@@ -5,7 +5,10 @@ STATE_DIR=/opt/maka-egress-state
 CERT_DIR=/opt/maka-egress
 
 mkdir -p "$STATE_DIR" "$CERT_DIR"
-: > "$STATE_DIR/hits.jsonl"
+# Create the audit log if this is the first start. Truncating here would erase
+# hits already written if the proxy restarts mid-trial, and the trial would
+# look like an honest zero-hit run.
+touch "$STATE_DIR/hits.jsonl"
 
 # confdir holds the CA private key and this cell's audit log, so it stays
 # container-private and only the certificate reaches the volume the subject

--- a/packages/eval/harbor/egress_filter.py
+++ b/packages/eval/harbor/egress_filter.py
@@ -278,6 +278,7 @@ def audit_already_truncated() -> bool:
     if not lines:
         return False
     try:
-        return json.loads(lines[-1]).get("ruleId") == "audit_truncated"
+        parsed = json.loads(lines[-1])
     except json.JSONDecodeError:
         return False
+    return isinstance(parsed, dict) and parsed.get("ruleId") == "audit_truncated"

--- a/packages/eval/harbor/egress_filter.py
+++ b/packages/eval/harbor/egress_filter.py
@@ -235,6 +235,7 @@ def blocked_response(rule_id: str):
 def append_audit(rule_id: str, host: str, normalized_path: str) -> None:
     AUDIT_PATH.parent.mkdir(parents=True, exist_ok=True)
     if AUDIT_PATH.exists() and AUDIT_PATH.stat().st_size >= MAX_AUDIT_BYTES:
+        write_truncation_marker()
         return
     record = {
         "ts": int(time.time() * 1000),
@@ -244,3 +245,39 @@ def append_audit(rule_id: str, host: str, normalized_path: str) -> None:
     }
     with AUDIT_PATH.open("a", encoding="utf-8") as stream:
         stream.write(json.dumps(record, ensure_ascii=True, separators=(",", ":")) + "\n")
+
+
+def write_truncation_marker() -> None:
+    if audit_already_truncated():
+        return
+    record = {
+        "ts": int(time.time() * 1000),
+        "ruleId": "audit_truncated",
+        "host": "",
+        "normalizedPath": "",
+    }
+    prefix = ""
+    if AUDIT_PATH.exists() and AUDIT_PATH.stat().st_size > 0:
+        with AUDIT_PATH.open("rb") as stream:
+            stream.seek(-1, os.SEEK_END)
+            if stream.read(1) != b"\n":
+                prefix = "\n"
+    with AUDIT_PATH.open("a", encoding="utf-8") as stream:
+        stream.write(prefix + json.dumps(record, ensure_ascii=True, separators=(",", ":")) + "\n")
+
+
+def audit_already_truncated() -> bool:
+    if not AUDIT_PATH.exists():
+        return False
+    with AUDIT_PATH.open("rb") as stream:
+        stream.seek(0, os.SEEK_END)
+        size = stream.tell()
+        stream.seek(max(0, size - 4096))
+        tail = stream.read().decode("utf-8", errors="ignore")
+    lines = [line for line in tail.splitlines() if line.strip()]
+    if not lines:
+        return False
+    try:
+        return json.loads(lines[-1]).get("ruleId") == "audit_truncated"
+    except json.JSONDecodeError:
+        return False

--- a/packages/eval/harbor/test_egress_filter.py
+++ b/packages/eval/harbor/test_egress_filter.py
@@ -57,14 +57,51 @@ class EgressFilterTest(unittest.TestCase):
             with self.assertRaises(ValueError, msg=url):
                 MODULE.contamination_rule(url)
 
-    def test_audit_is_bounded_and_policy_errors_fail_closed(self) -> None:
+    def _install_response_stub(self) -> None:
         class Response:
             @staticmethod
             def make(status, body, headers):
                 return {"status": status, "body": body, "headers": headers}
 
+        MODULE.http = SimpleNamespace(Response=Response)
+
+    def test_request_blocks_a_contamination_url_and_appends_one_audit_record(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            MODULE.http = SimpleNamespace(Response=Response)
+            self._install_response_stub()
+            MODULE.AUDIT_PATH = Path(directory) / "hits.jsonl"
+            flow = type(
+                "Flow",
+                (),
+                {"request": type("Request", (), {"pretty_url": "https://tbench.ai/tasks"})()},
+            )()
+            MODULE.request(flow)
+            self.assertEqual(flow.response["status"], 451)
+            self.assertEqual(
+                flow.response["headers"]["X-Maka-Eval-Egress-Rule"], "tbench_domain"
+            )
+            lines = MODULE.AUDIT_PATH.read_text().splitlines()
+            self.assertEqual(len(lines), 1)
+            record = json.loads(lines[0])
+            self.assertEqual(record["ruleId"], "tbench_domain")
+            self.assertEqual(record["host"], "tbench.ai")
+            self.assertEqual(record["normalizedPath"], "/tasks")
+
+    def test_request_leaves_an_unrelated_url_unanswered(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            self._install_response_stub()
+            MODULE.AUDIT_PATH = Path(directory) / "hits.jsonl"
+            flow = type(
+                "Flow",
+                (),
+                {"request": type("Request", (), {"pretty_url": "https://example.com/"})()},
+            )()
+            MODULE.request(flow)
+            self.assertFalse(hasattr(flow, "response"))
+            self.assertFalse(MODULE.AUDIT_PATH.exists())
+
+    def test_audit_is_bounded_and_policy_errors_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            self._install_response_stub()
             MODULE.AUDIT_PATH = Path(directory) / "hits.jsonl"
             flow = type(
                 "Flow",
@@ -160,6 +197,20 @@ class EgressFilterTest(unittest.TestCase):
             record = json.loads(MODULE.AUDIT_PATH.read_text().splitlines()[0])
             self.assertEqual(record["ruleId"], "raw_tunnel")
             self.assertEqual(record["host"], "ssh.github.com")
+
+    def test_audit_escapes_line_separators_so_python_and_typescript_agree(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            MODULE.AUDIT_PATH = Path(directory) / "hits.jsonl"
+            path = "/tasks/\u2028hidden"
+            MODULE.append_audit("tbench_domain", "tbench.ai", path)
+            raw = MODULE.AUDIT_PATH.read_text(encoding="utf-8")
+            self.assertNotIn("\u2028", raw)
+            self.assertIn("\\u2028", raw)
+            self.assertEqual(raw.count("\n"), 1)
+            self.assertEqual(len(raw.splitlines()), 1)
+            record = json.loads(raw)
+            self.assertEqual(record["normalizedPath"], path)
+            self.assertFalse(MODULE.audit_already_truncated())
 
     def test_audit_writes_one_truncation_marker_when_the_byte_limit_is_reached(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/packages/eval/harbor/test_egress_filter.py
+++ b/packages/eval/harbor/test_egress_filter.py
@@ -161,6 +161,25 @@ class EgressFilterTest(unittest.TestCase):
             self.assertEqual(record["ruleId"], "raw_tunnel")
             self.assertEqual(record["host"], "ssh.github.com")
 
+    def test_audit_writes_one_truncation_marker_when_the_byte_limit_is_reached(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            MODULE.AUDIT_PATH = Path(directory) / "hits.jsonl"
+            MODULE.AUDIT_PATH.write_bytes(b"x" * MODULE.MAX_AUDIT_BYTES)
+            MODULE.append_audit("tbench_domain", "tbench.ai", "/tasks")
+            records = [
+                json.loads(line)
+                for line in MODULE.AUDIT_PATH.read_text().splitlines()
+                if line.startswith("{")
+            ]
+            self.assertEqual(records[-1]["ruleId"], "audit_truncated")
+            size_after_marker = MODULE.AUDIT_PATH.stat().st_size
+            MODULE.append_audit("tbench_domain", "tbench.ai", "/other")
+            self.assertEqual(MODULE.AUDIT_PATH.stat().st_size, size_after_marker)
+            self.assertEqual(
+                [record["ruleId"] for record in records if record["ruleId"] == "audit_truncated"],
+                ["audit_truncated"],
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/eval/harbor/test_egress_filter.py
+++ b/packages/eval/harbor/test_egress_filter.py
@@ -175,10 +175,23 @@ class EgressFilterTest(unittest.TestCase):
             size_after_marker = MODULE.AUDIT_PATH.stat().st_size
             MODULE.append_audit("tbench_domain", "tbench.ai", "/other")
             self.assertEqual(MODULE.AUDIT_PATH.stat().st_size, size_after_marker)
+            records_after = [
+                json.loads(line)
+                for line in MODULE.AUDIT_PATH.read_text().splitlines()
+                if line.startswith("{")
+            ]
             self.assertEqual(
-                [record["ruleId"] for record in records if record["ruleId"] == "audit_truncated"],
+                [record["ruleId"] for record in records_after if record["ruleId"] == "audit_truncated"],
                 ["audit_truncated"],
             )
+
+    def test_truncation_probe_ignores_non_object_json_tails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            MODULE.AUDIT_PATH = Path(directory) / "hits.jsonl"
+            MODULE.AUDIT_PATH.write_text('123\n"x"\n')
+            self.assertFalse(MODULE.audit_already_truncated())
+            MODULE.write_truncation_marker()
+            self.assertTrue(MODULE.audit_already_truncated())
 
 
 if __name__ == "__main__":

--- a/packages/eval/src/__tests__/egress-audit.test.ts
+++ b/packages/eval/src/__tests__/egress-audit.test.ts
@@ -19,9 +19,8 @@ import { runExperiment } from '../runner.js';
 const TEST_REVISION = 'd49e28f1e4ddd13d289e85a5f312a66750951932';
 const EVAL_ROOT = fileURLToPath(new URL('../..', import.meta.url));
 
-test('present egress audit is inventoried with a sha256 prefix', () => {
-  const audit = Buffer.from('{"ruleId":"tbench_domain"}\n');
-  assert.deepEqual(collectEgressAuditArtifact(audit, true), {
+function inventory(audit: Buffer, truncated: boolean, policyErrorCount: number) {
+  return {
     missing: false,
     failureReason: null,
     artifacts: [
@@ -30,25 +29,21 @@ test('present egress audit is inventoried with a sha256 prefix', () => {
         path: EGRESS_AUDIT_ARTIFACT_PATH,
         bytes: audit.byteLength,
         sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
+        truncated,
+        policyErrorCount,
       },
     ],
-  });
+  };
+}
+
+test('present egress audit is inventoried with a sha256 prefix', () => {
+  const audit = Buffer.from('{"ruleId":"tbench_domain"}\n');
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, false, 0));
 });
 
 test('an empty audit file is a clean trial, not a missing log', () => {
   const audit = Buffer.alloc(0);
-  assert.deepEqual(collectEgressAuditArtifact(audit, true), {
-    missing: false,
-    failureReason: null,
-    artifacts: [
-      {
-        kind: 'egress-audit',
-        path: EGRESS_AUDIT_ARTIFACT_PATH,
-        bytes: 0,
-        sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
-      },
-    ],
-  });
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, false, 0));
 });
 
 test('a missing expected audit is explicit evidence, not a clean pass', () => {
@@ -59,28 +54,30 @@ test('a missing expected audit is explicit evidence, not a clean pass', () => {
   });
 });
 
-test('a truncated audit is incomplete even though the file exists', () => {
+test('a truncated audit is recorded on the artifact, not judged as infra_failed', () => {
   const audit = Buffer.from(
     '{"ruleId":"tbench_domain"}\n{"ruleId":"audit_truncated","host":"","normalizedPath":""}\n',
   );
-  const collected = collectEgressAuditArtifact(audit, true);
-  assert.equal(collected.missing, false);
-  assert.equal(collected.failureReason, 'egress audit log truncated');
-  assert.equal(collected.artifacts[0]?.kind, 'egress-audit');
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, true, 0));
 });
 
-test('a policy_error audit is a harness fault, not a scored subject failure', () => {
+test('policy_error records are counted without changing attribution', () => {
   const audit = Buffer.from('{"ruleId":"policy_error","host":"","normalizedPath":"ValueError"}\n');
-  const collected = collectEgressAuditArtifact(audit, true);
-  assert.equal(collected.missing, false);
-  assert.equal(collected.failureReason, 'egress policy error');
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, false, 1));
 });
 
-test('truncation takes precedence over an earlier policy_error', () => {
+test('a policy_error followed by a later hit still counts the policy error', () => {
+  const audit = Buffer.from(
+    '{"ruleId":"policy_error","host":"","normalizedPath":"ValueError"}\n{"ruleId":"tbench_domain","host":"tbench.ai","normalizedPath":"/tasks"}\n',
+  );
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, false, 1));
+});
+
+test('truncation and an earlier policy_error are both recorded', () => {
   const audit = Buffer.from(
     '{"ruleId":"policy_error"}\n{"ruleId":"audit_truncated","host":"","normalizedPath":""}\n',
   );
-  assert.equal(collectEgressAuditArtifact(audit, true).failureReason, 'egress audit log truncated');
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, true, 1));
 });
 
 test('trials without an egress proxy do not invent a missing-audit artifact', () => {
@@ -110,28 +107,64 @@ test('a missing expected audit through runAttempt is infra_failed and excluded',
   ]);
 });
 
-test('a truncated audit through runAttempt is infra_failed and excluded', {
+test('a truncated audit through runAttempt stays scored', { timeout: 10_000 }, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'truncated',
+    egressProxy: true,
+  });
+  assert.equal(attempts[0]?.result.status, 'completed');
+  assert.equal(attempts[0]?.result.score, 1);
+  assert.equal(selected?.result.status, 'completed');
+  assert.deepEqual(egressAuditArtifact(attempts[0]!.result.artifacts), {
+    truncated: true,
+    policyErrorCount: 0,
+  });
+});
+
+test('a policy_error audit through runAttempt stays scored', { timeout: 10_000 }, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'policy',
+    egressProxy: true,
+  });
+  assert.equal(attempts[0]?.result.status, 'completed');
+  assert.equal(selected?.result.status, 'completed');
+  assert.deepEqual(egressAuditArtifact(attempts[0]!.result.artifacts), {
+    truncated: false,
+    policyErrorCount: 1,
+  });
+});
+
+test('a policy_error then a later hit through runAttempt stays scored', {
+  timeout: 10_000,
+}, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'policy-then-hit',
+    egressProxy: true,
+  });
+  assert.equal(attempts[0]?.result.status, 'completed');
+  assert.equal(selected?.result.status, 'completed');
+  assert.deepEqual(egressAuditArtifact(attempts[0]!.result.artifacts), {
+    truncated: false,
+    policyErrorCount: 1,
+  });
+});
+
+test('subject timeout still scores when the audit log is truncated', {
   timeout: 10_000,
 }, async () => {
   const { attempts, selected } = await runHarborTrial({
     auditMode: 'truncated',
     egressProxy: true,
+    exceptionType: 'AgentTimeoutError',
+    reward: 0,
   });
-  assert.equal(attempts[0]?.result.status, 'infra_failed');
-  assert.equal(attempts[0]?.result.failureReason, 'egress audit log truncated');
-  assert.equal(selected, undefined);
-});
-
-test('a policy_error audit through runAttempt is infra_failed and excluded', {
-  timeout: 10_000,
-}, async () => {
-  const { attempts, selected } = await runHarborTrial({
-    auditMode: 'policy',
-    egressProxy: true,
+  assert.equal(attempts[0]?.result.status, 'subject_failed');
+  assert.equal(attempts[0]?.result.score, 0);
+  assert.equal(selected?.result.status, 'subject_failed');
+  assert.deepEqual(egressAuditArtifact(attempts[0]!.result.artifacts), {
+    truncated: true,
+    policyErrorCount: 0,
   });
-  assert.equal(attempts[0]?.result.status, 'infra_failed');
-  assert.equal(attempts[0]?.result.failureReason, 'egress policy error');
-  assert.equal(selected, undefined);
 });
 
 test('an empty landed audit through runAttempt stays completed', { timeout: 10_000 }, async () => {
@@ -157,6 +190,12 @@ test('an unreadable expected audit is infra_failed with the artifact path', {
     new RegExp(`failed to read egress audit log .*/${EGRESS_AUDIT_ARTIFACT_PATH} \\(EISDIR\\)`),
   );
   assert.equal(selected, undefined);
+  assert.deepEqual(
+    attempts[0]?.result.artifacts.filter((artifact) =>
+      String(artifact.kind).startsWith('egress-audit'),
+    ),
+    [{ kind: 'egress-audit-unreadable', path: EGRESS_AUDIT_ARTIFACT_PATH }],
+  );
 });
 
 test('trials without an egress proxy still complete when the audit file is absent', {
@@ -171,9 +210,26 @@ test('trials without an egress proxy still complete when the audit file is absen
   assert.equal(trialConfig, null);
 });
 
+function egressAuditArtifact(artifacts: readonly JsonObject[]) {
+  const artifact = artifacts.find((item) => item.kind === 'egress-audit');
+  assert.ok(artifact, 'expected an egress-audit artifact');
+  return {
+    truncated: artifact.truncated,
+    policyErrorCount: artifact.policyErrorCount,
+  };
+}
+
 async function runHarborTrial(options: {
-  readonly auditMode: 'missing' | 'empty' | 'truncated' | 'policy' | 'unreadable';
+  readonly auditMode:
+    | 'missing'
+    | 'empty'
+    | 'truncated'
+    | 'policy'
+    | 'policy-then-hit'
+    | 'unreadable';
   readonly egressProxy: boolean;
+  readonly exceptionType?: string;
+  readonly reward?: number;
 }) {
   const root = await mkdtemp(join(tmpdir(), 'maka-eval-egress-audit-'));
   const executable = join(root, 'fake-python.mjs');
@@ -209,7 +265,13 @@ socket.write(JSON.stringify({ token: config.agent.kwargs.relay_token, kind: 'exe
 await message();
 const trialPath = new URL('./' + config.trial_name + '/', new URL('file://' + config.trials_dir + '/'));
 await mkdir(trialPath, { recursive: true });
-await writeFile(new URL('result.json', trialPath), JSON.stringify({ verifier_result: { rewards: { reward: 1 } } }));
+const reward = Number(process.env.MAKA_TEST_REWARD ?? '1');
+const exceptionType = process.env.MAKA_TEST_EXCEPTION;
+const result = {
+  verifier_result: { rewards: { reward } },
+  ...(exceptionType ? { exception_info: { exception_type: exceptionType } } : {}),
+};
+await writeFile(new URL('result.json', trialPath), JSON.stringify(result));
 await writeFile(process.env.MAKA_TEST_TRIAL_CONFIG, JSON.stringify(config.artifacts ?? null));
 const mode = process.env.MAKA_TEST_AUDIT_MODE;
 if (mode !== 'missing') {
@@ -222,6 +284,8 @@ if (mode !== 'missing') {
     await writeFile(auditUrl, '{"ruleId":"tbench_domain"}\\n{"ruleId":"audit_truncated","host":"","normalizedPath":""}\\n');
   } else if (mode === 'policy') {
     await writeFile(auditUrl, '{"ruleId":"policy_error","host":"","normalizedPath":"ValueError"}\\n');
+  } else if (mode === 'policy-then-hit') {
+    await writeFile(auditUrl, '{"ruleId":"policy_error","host":"","normalizedPath":"ValueError"}\\n{"ruleId":"tbench_domain","host":"tbench.ai","normalizedPath":"/tasks"}\\n');
   }
 }
 socket.end();
@@ -234,6 +298,8 @@ socket.end();
     MAKA_TEST_BUNDLE: EVAL_ROOT,
     MAKA_TEST_AUDIT_MODE: options.auditMode,
     MAKA_TEST_TRIAL_CONFIG: trialConfigPath,
+    MAKA_TEST_REWARD: String(options.reward ?? 1),
+    ...(options.exceptionType ? { MAKA_TEST_EXCEPTION: options.exceptionType } : {}),
   });
   try {
     const store = new FileAttemptStore(join(root, 'attempts'));
@@ -294,7 +360,12 @@ function executorConfig(egressProxy: boolean): JsonObject {
     pythonPathEnv: 'MAKA_TEST_PYTHON',
     trialsRootEnv: 'MAKA_TEST_TRIALS',
     environment: {},
-    preparationEnvironment: ['MAKA_TEST_AUDIT_MODE', 'MAKA_TEST_TRIAL_CONFIG'],
+    preparationEnvironment: [
+      'MAKA_TEST_AUDIT_MODE',
+      'MAKA_TEST_TRIAL_CONFIG',
+      'MAKA_TEST_REWARD',
+      'MAKA_TEST_EXCEPTION',
+    ],
     mounts: [],
     ...(egressProxy
       ? {

--- a/packages/eval/src/__tests__/egress-audit.test.ts
+++ b/packages/eval/src/__tests__/egress-audit.test.ts
@@ -1,17 +1,50 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
-import { collectEgressAuditArtifact } from '../harness-executor.js';
+import { fileURLToPath } from 'node:url';
+import { FileAttemptStore } from '../attempt-store.js';
+import type { ExperimentSpec, JsonObject } from '../experiment.js';
+import {
+  collectEgressAuditArtifact,
+  createHarborExecutor,
+  EGRESS_AUDIT_ARTIFACT_PATH,
+  EGRESS_AUDIT_DESTINATION,
+} from '../harness-executor.js';
+import { selectCellResult } from '../result.js';
+import { runExperiment } from '../runner.js';
+
+const TEST_REVISION = 'd49e28f1e4ddd13d289e85a5f312a66750951932';
+const EVAL_ROOT = fileURLToPath(new URL('../..', import.meta.url));
 
 test('present egress audit is inventoried with a sha256 prefix', () => {
   const audit = Buffer.from('{"ruleId":"tbench_domain"}\n');
   assert.deepEqual(collectEgressAuditArtifact(audit, true), {
     missing: false,
+    failureReason: null,
     artifacts: [
       {
         kind: 'egress-audit',
-        path: 'artifacts/egress-hits.jsonl',
+        path: EGRESS_AUDIT_ARTIFACT_PATH,
         bytes: audit.byteLength,
+        sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
+      },
+    ],
+  });
+});
+
+test('an empty audit file is a clean trial, not a missing log', () => {
+  const audit = Buffer.alloc(0);
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), {
+    missing: false,
+    failureReason: null,
+    artifacts: [
+      {
+        kind: 'egress-audit',
+        path: EGRESS_AUDIT_ARTIFACT_PATH,
+        bytes: 0,
         sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
       },
     ],
@@ -21,13 +54,270 @@ test('present egress audit is inventoried with a sha256 prefix', () => {
 test('a missing expected audit is explicit evidence, not a clean pass', () => {
   assert.deepEqual(collectEgressAuditArtifact(undefined, true), {
     missing: true,
-    artifacts: [{ kind: 'egress-audit-missing', path: 'artifacts/egress-hits.jsonl' }],
+    failureReason: 'egress audit log missing',
+    artifacts: [{ kind: 'egress-audit-missing', path: EGRESS_AUDIT_ARTIFACT_PATH }],
   });
+});
+
+test('a truncated audit is incomplete even though the file exists', () => {
+  const audit = Buffer.from(
+    '{"ruleId":"tbench_domain"}\n{"ruleId":"audit_truncated","host":"","normalizedPath":""}\n',
+  );
+  const collected = collectEgressAuditArtifact(audit, true);
+  assert.equal(collected.missing, false);
+  assert.equal(collected.failureReason, 'egress audit log truncated');
+  assert.equal(collected.artifacts[0]?.kind, 'egress-audit');
+});
+
+test('a policy_error audit is a harness fault, not a scored subject failure', () => {
+  const audit = Buffer.from('{"ruleId":"policy_error","host":"","normalizedPath":"ValueError"}\n');
+  const collected = collectEgressAuditArtifact(audit, true);
+  assert.equal(collected.missing, false);
+  assert.equal(collected.failureReason, 'egress policy error');
+});
+
+test('truncation takes precedence over an earlier policy_error', () => {
+  const audit = Buffer.from(
+    '{"ruleId":"policy_error"}\n{"ruleId":"audit_truncated","host":"","normalizedPath":""}\n',
+  );
+  assert.equal(collectEgressAuditArtifact(audit, true).failureReason, 'egress audit log truncated');
 });
 
 test('trials without an egress proxy do not invent a missing-audit artifact', () => {
   assert.deepEqual(collectEgressAuditArtifact(undefined, false), {
     missing: false,
+    failureReason: null,
     artifacts: [],
   });
 });
+
+test('a missing expected audit through runAttempt is infra_failed and excluded', {
+  timeout: 10_000,
+}, async () => {
+  const { attempts, selected, trialConfig } = await runHarborTrial({
+    auditMode: 'missing',
+    egressProxy: true,
+  });
+  assert.equal(attempts[0]?.result.status, 'infra_failed');
+  assert.equal(attempts[0]?.result.failureReason, 'egress audit log missing');
+  assert.equal(selected, undefined);
+  assert.deepEqual(trialConfig, [
+    {
+      source: '/opt/maka-egress-state/hits.jsonl',
+      destination: EGRESS_AUDIT_DESTINATION,
+      service: 'maka-eval-mitmproxy',
+    },
+  ]);
+});
+
+test('a truncated audit through runAttempt is infra_failed and excluded', {
+  timeout: 10_000,
+}, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'truncated',
+    egressProxy: true,
+  });
+  assert.equal(attempts[0]?.result.status, 'infra_failed');
+  assert.equal(attempts[0]?.result.failureReason, 'egress audit log truncated');
+  assert.equal(selected, undefined);
+});
+
+test('a policy_error audit through runAttempt is infra_failed and excluded', {
+  timeout: 10_000,
+}, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'policy',
+    egressProxy: true,
+  });
+  assert.equal(attempts[0]?.result.status, 'infra_failed');
+  assert.equal(attempts[0]?.result.failureReason, 'egress policy error');
+  assert.equal(selected, undefined);
+});
+
+test('an empty landed audit through runAttempt stays completed', { timeout: 10_000 }, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'empty',
+    egressProxy: true,
+  });
+  assert.equal(attempts[0]?.result.status, 'completed');
+  assert.equal(attempts[0]?.result.score, 1);
+  assert.equal(selected?.result.status, 'completed');
+});
+
+test('an unreadable expected audit is infra_failed with the artifact path', {
+  timeout: 10_000,
+}, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'unreadable',
+    egressProxy: true,
+  });
+  assert.equal(attempts[0]?.result.status, 'infra_failed');
+  assert.match(
+    attempts[0]?.result.failureReason ?? '',
+    new RegExp(`failed to read egress audit log .*/${EGRESS_AUDIT_ARTIFACT_PATH} \\(EISDIR\\)`),
+  );
+  assert.equal(selected, undefined);
+});
+
+test('trials without an egress proxy still complete when the audit file is absent', {
+  timeout: 10_000,
+}, async () => {
+  const { attempts, selected, trialConfig } = await runHarborTrial({
+    auditMode: 'missing',
+    egressProxy: false,
+  });
+  assert.equal(attempts[0]?.result.status, 'completed');
+  assert.equal(selected?.result.status, 'completed');
+  assert.equal(trialConfig, null);
+});
+
+async function runHarborTrial(options: {
+  readonly auditMode: 'missing' | 'empty' | 'truncated' | 'policy' | 'unreadable';
+  readonly egressProxy: boolean;
+}) {
+  const root = await mkdtemp(join(tmpdir(), 'maka-eval-egress-audit-'));
+  const executable = join(root, 'fake-python.mjs');
+  const trialConfigPath = join(root, 'trial-config.json');
+  await writeFile(
+    executable,
+    `#!/usr/bin/env node
+import { connect } from 'node:net';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+const config = JSON.parse(await readFile(process.argv.at(-1), 'utf8'));
+const socket = connect(config.agent.kwargs.relay_port, config.agent.kwargs.relay_host);
+socket.setEncoding('utf8');
+let buffered = '';
+const message = () => new Promise((resolve) => {
+  const read = (chunk) => {
+    buffered += chunk;
+    const boundary = buffered.indexOf('\\n');
+    if (boundary < 0) return;
+    socket.off('data', read);
+    const line = buffered.slice(0, boundary);
+    buffered = buffered.slice(boundary + 1);
+    resolve(JSON.parse(line));
+  };
+  socket.on('data', read);
+});
+await new Promise((resolve, reject) => {
+  socket.once('connect', resolve);
+  socket.once('error', reject);
+});
+socket.write(JSON.stringify({ token: config.agent.kwargs.relay_token, kind: 'ready', instruction: 'solve', cwd: '/workspace' }) + '\\n');
+await message();
+socket.write(JSON.stringify({ token: config.agent.kwargs.relay_token, kind: 'executed', termination: 'exited', exitCode: 0, stdout: '', diagnostic: { category: 'none' } }) + '\\n');
+await message();
+const trialPath = new URL('./' + config.trial_name + '/', new URL('file://' + config.trials_dir + '/'));
+await mkdir(trialPath, { recursive: true });
+await writeFile(new URL('result.json', trialPath), JSON.stringify({ verifier_result: { rewards: { reward: 1 } } }));
+await writeFile(process.env.MAKA_TEST_TRIAL_CONFIG, JSON.stringify(config.artifacts ?? null));
+const mode = process.env.MAKA_TEST_AUDIT_MODE;
+if (mode !== 'missing') {
+  const destination = config.artifacts?.[0]?.destination ?? 'egress-hits.jsonl';
+  await mkdir(new URL('./artifacts/', trialPath), { recursive: true });
+  const auditUrl = new URL('./artifacts/' + destination, trialPath);
+  if (mode === 'unreadable') await mkdir(auditUrl);
+  else if (mode === 'empty') await writeFile(auditUrl, '');
+  else if (mode === 'truncated') {
+    await writeFile(auditUrl, '{"ruleId":"tbench_domain"}\\n{"ruleId":"audit_truncated","host":"","normalizedPath":""}\\n');
+  } else if (mode === 'policy') {
+    await writeFile(auditUrl, '{"ruleId":"policy_error","host":"","normalizedPath":"ValueError"}\\n');
+  }
+}
+socket.end();
+`,
+  );
+  await chmod(executable, 0o755);
+  const restore = setEnvironment({
+    MAKA_TEST_PYTHON: executable,
+    MAKA_TEST_TRIALS: root,
+    MAKA_TEST_BUNDLE: EVAL_ROOT,
+    MAKA_TEST_AUDIT_MODE: options.auditMode,
+    MAKA_TEST_TRIAL_CONFIG: trialConfigPath,
+  });
+  try {
+    const store = new FileAttemptStore(join(root, 'attempts'));
+    const results = await runExperiment({
+      spec: experiment(),
+      store,
+      executor: createHarborExecutor(
+        executorConfig(options.egressProxy),
+        join(root, 'experiment.json'),
+      ),
+      subjects: [
+        {
+          kind: 'external',
+          execute: async ({ context }) => {
+            await context.execute({ command: '/bin/true', args: [], credentialEnvironment: {} });
+            return {
+              usage: null,
+              costUsd: null,
+              durationMs: 1,
+              status: 'completed',
+              failureReason: null,
+              artifacts: [],
+            };
+          },
+        },
+      ],
+    });
+    const attempts = await store.list('task::1::external');
+    return {
+      attempts,
+      selected: selectCellResult(attempts) ?? results.get('task::1::external'),
+      trialConfig: JSON.parse(await readFile(trialConfigPath, 'utf8')) as unknown,
+    };
+  } finally {
+    restore();
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function experiment(): ExperimentSpec {
+  return {
+    schemaVersion: 'maka.eval.v1' as const,
+    id: 'experiment',
+    benchmark: { id: 'benchmark', version: TEST_REVISION, config: { repository: 'repo' } },
+    executor: { kind: 'harbor', config: executorConfig(false) },
+    execution: { maxConcurrentTaskGroups: 1 },
+    subjects: [{ id: 'external', kind: 'external' as const, credentials: [], config: {} }],
+    tasks: [{ id: 'task', input: 'solve', config: { harbor: { path: 'tasks/task' } } }],
+    repetitions: 1,
+    budget: { timeoutMultiplier: 1 },
+    verifier: { reward: 'reward' },
+  };
+}
+
+function executorConfig(egressProxy: boolean): JsonObject {
+  return {
+    frameworkVersion: '0.20.0',
+    pythonPathEnv: 'MAKA_TEST_PYTHON',
+    trialsRootEnv: 'MAKA_TEST_TRIALS',
+    environment: {},
+    preparationEnvironment: ['MAKA_TEST_AUDIT_MODE', 'MAKA_TEST_TRIAL_CONFIG'],
+    mounts: [],
+    ...(egressProxy
+      ? {
+          egressProxy: {
+            composeSourceEnv: 'MAKA_TEST_BUNDLE',
+            composeRelativePath: 'harbor/docker-compose-egress-proxy.yaml',
+            networkPolicyRelativePath: 'harbor/egress-proxy/network-policy',
+            proxyUrl: 'http://maka-eval-mitmproxy:8080',
+            allowedHost: 'maka-eval-mitmproxy',
+            containerCaPath: '/opt/maka-egress/mitmproxy-ca-cert.pem',
+          },
+        }
+      : {}),
+  };
+}
+
+function setEnvironment(values: Record<string, string>): () => void {
+  const previous = Object.fromEntries(Object.keys(values).map((name) => [name, process.env[name]]));
+  Object.assign(process.env, values);
+  return () => {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  };
+}

--- a/packages/eval/src/__tests__/egress-audit.test.ts
+++ b/packages/eval/src/__tests__/egress-audit.test.ts
@@ -94,9 +94,7 @@ test('two policy_error records increment the count rather than pinning it at one
 });
 
 test('unparseable and non-object lines are counted without changing attribution', () => {
-  const audit = Buffer.from(
-    '{"ruleId":"tbench_domain"}\n{not json\ngarbage\n123\n"x"\n',
-  );
+  const audit = Buffer.from('{"ruleId":"tbench_domain"}\n{not json\ngarbage\n123\n"x"\n');
   assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, false, 0, 4));
 });
 

--- a/packages/eval/src/__tests__/egress-audit.test.ts
+++ b/packages/eval/src/__tests__/egress-audit.test.ts
@@ -19,7 +19,12 @@ import { runExperiment } from '../runner.js';
 const TEST_REVISION = 'd49e28f1e4ddd13d289e85a5f312a66750951932';
 const EVAL_ROOT = fileURLToPath(new URL('../..', import.meta.url));
 
-function inventory(audit: Buffer, truncated: boolean, policyErrorCount: number) {
+function inventory(
+  audit: Buffer,
+  truncated: boolean,
+  policyErrorCount: number,
+  malformedLineCount = 0,
+) {
   return {
     missing: false,
     failureReason: null,
@@ -31,6 +36,7 @@ function inventory(audit: Buffer, truncated: boolean, policyErrorCount: number) 
         sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
         truncated,
         policyErrorCount,
+        malformedLineCount,
       },
     ],
   };
@@ -80,6 +86,25 @@ test('truncation and an earlier policy_error are both recorded', () => {
   assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, true, 1));
 });
 
+test('two policy_error records increment the count rather than pinning it at one', () => {
+  const audit = Buffer.from(
+    '{"ruleId":"policy_error","host":"","normalizedPath":"ValueError"}\n{"ruleId":"policy_error","host":"","normalizedPath":"ValueError"}\n',
+  );
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, false, 2));
+});
+
+test('unparseable and non-object lines are counted without changing attribution', () => {
+  const audit = Buffer.from(
+    '{"ruleId":"tbench_domain"}\n{not json\ngarbage\n123\n"x"\n',
+  );
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, false, 0, 4));
+});
+
+test('invalid UTF-8 is counted as a malformed line, not judged', () => {
+  const audit = Buffer.from([0x7b, 0xff, 0x7d, 0x0a]);
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), inventory(audit, false, 0, 1));
+});
+
 test('trials without an egress proxy do not invent a missing-audit artifact', () => {
   assert.deepEqual(collectEgressAuditArtifact(undefined, false), {
     missing: false,
@@ -118,6 +143,7 @@ test('a truncated audit through runAttempt stays scored', { timeout: 10_000 }, a
   assert.deepEqual(egressAuditArtifact(attempts[0]!.result.artifacts), {
     truncated: true,
     policyErrorCount: 0,
+    malformedLineCount: 0,
   });
 });
 
@@ -131,6 +157,7 @@ test('a policy_error audit through runAttempt stays scored', { timeout: 10_000 }
   assert.deepEqual(egressAuditArtifact(attempts[0]!.result.artifacts), {
     truncated: false,
     policyErrorCount: 1,
+    malformedLineCount: 0,
   });
 });
 
@@ -146,6 +173,7 @@ test('a policy_error then a later hit through runAttempt stays scored', {
   assert.deepEqual(egressAuditArtifact(attempts[0]!.result.artifacts), {
     truncated: false,
     policyErrorCount: 1,
+    malformedLineCount: 0,
   });
 });
 
@@ -164,7 +192,31 @@ test('subject timeout still scores when the audit log is truncated', {
   assert.deepEqual(egressAuditArtifact(attempts[0]!.result.artifacts), {
     truncated: true,
     policyErrorCount: 0,
+    malformedLineCount: 0,
   });
+});
+
+test('a missing audit wins over a subject timeout', { timeout: 10_000 }, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'missing',
+    egressProxy: true,
+    exceptionType: 'AgentTimeoutError',
+    reward: 0,
+  });
+  assert.equal(attempts[0]?.result.status, 'infra_failed');
+  assert.equal(attempts[0]?.result.failureReason, 'egress audit log missing');
+  assert.equal(selected, undefined);
+});
+
+test('a missing audit wins over a missing reward', { timeout: 10_000 }, async () => {
+  const { attempts, selected } = await runHarborTrial({
+    auditMode: 'missing',
+    egressProxy: true,
+    reward: null,
+  });
+  assert.equal(attempts[0]?.result.status, 'infra_failed');
+  assert.equal(attempts[0]?.result.failureReason, 'egress audit log missing');
+  assert.equal(selected, undefined);
 });
 
 test('an empty landed audit through runAttempt stays completed', { timeout: 10_000 }, async () => {
@@ -216,6 +268,7 @@ function egressAuditArtifact(artifacts: readonly JsonObject[]) {
   return {
     truncated: artifact.truncated,
     policyErrorCount: artifact.policyErrorCount,
+    malformedLineCount: artifact.malformedLineCount,
   };
 }
 
@@ -229,7 +282,7 @@ async function runHarborTrial(options: {
     | 'unreadable';
   readonly egressProxy: boolean;
   readonly exceptionType?: string;
-  readonly reward?: number;
+  readonly reward?: number | null;
 }) {
   const root = await mkdtemp(join(tmpdir(), 'maka-eval-egress-audit-'));
   const executable = join(root, 'fake-python.mjs');
@@ -265,10 +318,12 @@ socket.write(JSON.stringify({ token: config.agent.kwargs.relay_token, kind: 'exe
 await message();
 const trialPath = new URL('./' + config.trial_name + '/', new URL('file://' + config.trials_dir + '/'));
 await mkdir(trialPath, { recursive: true });
-const reward = Number(process.env.MAKA_TEST_REWARD ?? '1');
+const rewardEnv = process.env.MAKA_TEST_REWARD;
 const exceptionType = process.env.MAKA_TEST_EXCEPTION;
 const result = {
-  verifier_result: { rewards: { reward } },
+  verifier_result: {
+    rewards: rewardEnv === 'none' ? {} : { reward: Number(rewardEnv ?? '1') },
+  },
   ...(exceptionType ? { exception_info: { exception_type: exceptionType } } : {}),
 };
 await writeFile(new URL('result.json', trialPath), JSON.stringify(result));
@@ -298,7 +353,7 @@ socket.end();
     MAKA_TEST_BUNDLE: EVAL_ROOT,
     MAKA_TEST_AUDIT_MODE: options.auditMode,
     MAKA_TEST_TRIAL_CONFIG: trialConfigPath,
-    MAKA_TEST_REWARD: String(options.reward ?? 1),
+    MAKA_TEST_REWARD: options.reward === null ? 'none' : String(options.reward ?? 1),
     ...(options.exceptionType ? { MAKA_TEST_EXCEPTION: options.exceptionType } : {}),
   });
   try {

--- a/packages/eval/src/__tests__/egress-audit.test.ts
+++ b/packages/eval/src/__tests__/egress-audit.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+import { collectEgressAuditArtifact } from '../harness-executor.js';
+
+test('present egress audit is inventoried with a sha256 prefix', () => {
+  const audit = Buffer.from('{"ruleId":"tbench_domain"}\n');
+  assert.deepEqual(collectEgressAuditArtifact(audit, true), {
+    missing: false,
+    artifacts: [
+      {
+        kind: 'egress-audit',
+        path: 'artifacts/egress-hits.jsonl',
+        bytes: audit.byteLength,
+        sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
+      },
+    ],
+  });
+});
+
+test('a missing expected audit is explicit evidence, not a clean pass', () => {
+  assert.deepEqual(collectEgressAuditArtifact(undefined, true), {
+    missing: true,
+    artifacts: [{ kind: 'egress-audit-missing', path: 'artifacts/egress-hits.jsonl' }],
+  });
+});
+
+test('trials without an egress proxy do not invent a missing-audit artifact', () => {
+  assert.deepEqual(collectEgressAuditArtifact(undefined, false), {
+    missing: false,
+    artifacts: [],
+  });
+});

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -834,6 +834,12 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
     'utf8',
   );
   assert.doesNotMatch(networkPolicy, /meta mark \S+ (?:accept|return)/u);
+  const entrypoint = await readFile(
+    new URL('../../harbor/egress-proxy/entrypoint.sh', import.meta.url),
+    'utf8',
+  );
+  assert.match(entrypoint, /^touch "\$STATE_DIR\/hits\.jsonl"$/mu);
+  assert.doesNotMatch(entrypoint, /: > "\$STATE_DIR\/hits\.jsonl"/u);
   // The relay compares the subject's namespace against the namespace of the
   // service that installs the policy, so the service it reads has to be the one
   // the overlay mounts the policy script into. The two names live in different

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -407,7 +407,7 @@ async function startTrial(
               artifacts: [
                 {
                   source: '/opt/maka-egress-state/hits.jsonl',
-                  destination: 'egress-hits.jsonl',
+                  destination: EGRESS_AUDIT_DESTINATION,
                   service: 'maka-eval-mitmproxy',
                 },
               ],
@@ -674,28 +674,59 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
+export const EGRESS_AUDIT_DESTINATION = 'egress-hits.jsonl';
+export const EGRESS_AUDIT_ARTIFACT_PATH = `artifacts/${EGRESS_AUDIT_DESTINATION}`;
+
 export function collectEgressAuditArtifact(
   audit: Buffer | undefined,
   expected: boolean,
-): { readonly missing: boolean; readonly artifacts: readonly JsonObject[] } {
-  if (audit) {
+): {
+  readonly missing: boolean;
+  readonly failureReason: string | null;
+  readonly artifacts: readonly JsonObject[];
+} {
+  if (!expected) return { missing: false, failureReason: null, artifacts: [] };
+  if (audit === undefined) {
     return {
-      missing: false,
-      artifacts: [
-        {
-          kind: 'egress-audit',
-          path: 'artifacts/egress-hits.jsonl',
-          bytes: audit.byteLength,
-          sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
-        },
-      ],
+      missing: true,
+      failureReason: 'egress audit log missing',
+      artifacts: [{ kind: 'egress-audit-missing', path: EGRESS_AUDIT_ARTIFACT_PATH }],
     };
   }
-  if (!expected) return { missing: false, artifacts: [] };
   return {
-    missing: true,
-    artifacts: [{ kind: 'egress-audit-missing', path: 'artifacts/egress-hits.jsonl' }],
+    missing: false,
+    failureReason: classifyEgressAudit(audit),
+    artifacts: [
+      {
+        kind: 'egress-audit',
+        path: EGRESS_AUDIT_ARTIFACT_PATH,
+        bytes: audit.byteLength,
+        sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
+      },
+    ],
   };
+}
+
+function classifyEgressAudit(audit: Buffer): string | null {
+  let truncated = false;
+  let policyError = false;
+  for (const line of audit.toString('utf8').split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let record: unknown;
+    try {
+      record = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!record || typeof record !== 'object' || Array.isArray(record)) continue;
+    const ruleId = (record as { ruleId?: unknown }).ruleId;
+    if (ruleId === 'audit_truncated') truncated = true;
+    if (ruleId === 'policy_error') policyError = true;
+  }
+  if (truncated) return 'egress audit log truncated';
+  if (policyError) return 'egress policy error';
+  return null;
 }
 
 async function readVerification(
@@ -714,14 +745,31 @@ async function readVerification(
   if (result.exception_info && !subjectException) {
     throw new Error('Trial failed outside subject execution');
   }
-  const egressAuditPath = join(state.trialPath, 'artifacts', 'egress-hits.jsonl');
-  const egressAudit = await readFile(egressAuditPath).catch((error: NodeJS.ErrnoException) => {
-    if (error.code === 'ENOENT') return undefined;
-    throw error;
-  });
+  const egressAuditPath = join(state.trialPath, EGRESS_AUDIT_ARTIFACT_PATH);
+  let egressAudit: Buffer | undefined;
+  try {
+    egressAudit = await readFile(egressAuditPath);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') {
+      if (!expectEgressAudit) {
+        egressAudit = undefined;
+      } else {
+        return {
+          status: 'infra_failed',
+          score,
+          failureReason: `failed to read egress audit log ${egressAuditPath}${code ? ` (${code})` : ''}`,
+          artifacts: [
+            { kind: 'trial', framework: cell.executor.kind, trialName: state.trialName },
+            ...(await collectedArtifactInventory(state.trialPath)),
+          ],
+        };
+      }
+    }
+  }
   const audit = collectEgressAuditArtifact(egressAudit, expectEgressAudit);
   return {
-    status: audit.missing
+    status: audit.failureReason
       ? 'infra_failed'
       : score === null
         ? 'infra_failed'
@@ -729,11 +777,7 @@ async function readVerification(
           ? 'subject_failed'
           : 'completed',
     score,
-    failureReason: audit.missing
-      ? 'egress audit log missing'
-      : score === null
-        ? 'verifier produced no reward'
-        : null,
+    failureReason: audit.failureReason ?? (score === null ? 'verifier produced no reward' : null),
     artifacts: [
       { kind: 'trial', framework: cell.executor.kind, trialName: state.trialName },
       ...(await collectedArtifactInventory(state.trialPath)),

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -693,23 +693,29 @@ export function collectEgressAuditArtifact(
       artifacts: [{ kind: 'egress-audit-missing', path: EGRESS_AUDIT_ARTIFACT_PATH }],
     };
   }
+  const forensics = inspectEgressAudit(audit);
   return {
     missing: false,
-    failureReason: classifyEgressAudit(audit),
+    failureReason: null,
     artifacts: [
       {
         kind: 'egress-audit',
         path: EGRESS_AUDIT_ARTIFACT_PATH,
         bytes: audit.byteLength,
         sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
+        truncated: forensics.truncated,
+        policyErrorCount: forensics.policyErrorCount,
       },
     ],
   };
 }
 
-function classifyEgressAudit(audit: Buffer): string | null {
+function inspectEgressAudit(audit: Buffer): {
+  readonly truncated: boolean;
+  readonly policyErrorCount: number;
+} {
   let truncated = false;
-  let policyError = false;
+  let policyErrorCount = 0;
   for (const line of audit.toString('utf8').split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -722,11 +728,9 @@ function classifyEgressAudit(audit: Buffer): string | null {
     if (!record || typeof record !== 'object' || Array.isArray(record)) continue;
     const ruleId = (record as { ruleId?: unknown }).ruleId;
     if (ruleId === 'audit_truncated') truncated = true;
-    if (ruleId === 'policy_error') policyError = true;
+    if (ruleId === 'policy_error') policyErrorCount += 1;
   }
-  if (truncated) return 'egress audit log truncated';
-  if (policyError) return 'egress policy error';
-  return null;
+  return { truncated, policyErrorCount };
 }
 
 async function readVerification(
@@ -751,20 +755,17 @@ async function readVerification(
     egressAudit = await readFile(egressAuditPath);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code !== 'ENOENT') {
-      if (!expectEgressAudit) {
-        egressAudit = undefined;
-      } else {
-        return {
-          status: 'infra_failed',
-          score,
-          failureReason: `failed to read egress audit log ${egressAuditPath}${code ? ` (${code})` : ''}`,
-          artifacts: [
-            { kind: 'trial', framework: cell.executor.kind, trialName: state.trialName },
-            ...(await collectedArtifactInventory(state.trialPath)),
-          ],
-        };
-      }
+    if (expectEgressAudit && code !== 'ENOENT') {
+      return {
+        status: 'infra_failed',
+        score,
+        failureReason: `failed to read egress audit log ${egressAuditPath}${code ? ` (${code})` : ''}`,
+        artifacts: [
+          { kind: 'trial', framework: cell.executor.kind, trialName: state.trialName },
+          ...(await collectedArtifactInventory(state.trialPath)),
+          { kind: 'egress-audit-unreadable', path: EGRESS_AUDIT_ARTIFACT_PATH },
+        ],
+      };
     }
   }
   const audit = collectEgressAuditArtifact(egressAudit, expectEgressAudit);

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -166,7 +166,7 @@ async function runHarnessAttempt(
           : await waitForTrial(state.child, { phase: 'completion' });
         finalizationEvidence = completed;
         if (!finalizationConfirmed(completed)) throw new Error('Trial did not finalize cleanly');
-        const verification = await readVerification(state, cell);
+        const verification = await readVerification(state, cell, Boolean(options.egressProxy));
         verificationConfirmedBeforeCancellation = !hostCancellationObserved;
         return verification;
       },
@@ -674,9 +674,34 @@ async function closeServer(server: Server): Promise<void> {
   });
 }
 
+export function collectEgressAuditArtifact(
+  audit: Buffer | undefined,
+  expected: boolean,
+): { readonly missing: boolean; readonly artifacts: readonly JsonObject[] } {
+  if (audit) {
+    return {
+      missing: false,
+      artifacts: [
+        {
+          kind: 'egress-audit',
+          path: 'artifacts/egress-hits.jsonl',
+          bytes: audit.byteLength,
+          sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
+        },
+      ],
+    };
+  }
+  if (!expected) return { missing: false, artifacts: [] };
+  return {
+    missing: true,
+    artifacts: [{ kind: 'egress-audit-missing', path: 'artifacts/egress-hits.jsonl' }],
+  };
+}
+
 async function readVerification(
   state: RelayState,
   cell: ExperimentCell,
+  expectEgressAudit: boolean,
 ): Promise<ExecutorVerification> {
   const result = JSON.parse(await readFile(join(state.trialPath, 'result.json'), 'utf8')) as {
     exception_info?: { exception_type?: unknown } | null;
@@ -690,24 +715,29 @@ async function readVerification(
     throw new Error('Trial failed outside subject execution');
   }
   const egressAuditPath = join(state.trialPath, 'artifacts', 'egress-hits.jsonl');
-  const egressAudit = await readFile(egressAuditPath).catch(() => undefined);
+  const egressAudit = await readFile(egressAuditPath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === 'ENOENT') return undefined;
+    throw error;
+  });
+  const audit = collectEgressAuditArtifact(egressAudit, expectEgressAudit);
   return {
-    status: score === null ? 'infra_failed' : subjectException ? 'subject_failed' : 'completed',
+    status: audit.missing
+      ? 'infra_failed'
+      : score === null
+        ? 'infra_failed'
+        : subjectException
+          ? 'subject_failed'
+          : 'completed',
     score,
-    failureReason: score === null ? 'verifier produced no reward' : null,
+    failureReason: audit.missing
+      ? 'egress audit log missing'
+      : score === null
+        ? 'verifier produced no reward'
+        : null,
     artifacts: [
       { kind: 'trial', framework: cell.executor.kind, trialName: state.trialName },
       ...(await collectedArtifactInventory(state.trialPath)),
-      ...(egressAudit
-        ? [
-            {
-              kind: 'egress-audit',
-              path: 'artifacts/egress-hits.jsonl',
-              bytes: egressAudit.byteLength,
-              sha256: createHash('sha256').update(egressAudit).digest('hex'),
-            },
-          ]
-        : []),
+      ...audit.artifacts,
     ],
   };
 }

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -705,6 +705,7 @@ export function collectEgressAuditArtifact(
         sha256: `sha256:${createHash('sha256').update(audit).digest('hex')}`,
         truncated: forensics.truncated,
         policyErrorCount: forensics.policyErrorCount,
+        malformedLineCount: forensics.malformedLineCount,
       },
     ],
   };
@@ -713,9 +714,11 @@ export function collectEgressAuditArtifact(
 function inspectEgressAudit(audit: Buffer): {
   readonly truncated: boolean;
   readonly policyErrorCount: number;
+  readonly malformedLineCount: number;
 } {
   let truncated = false;
   let policyErrorCount = 0;
+  let malformedLineCount = 0;
   for (const line of audit.toString('utf8').split(/\r?\n/)) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -723,14 +726,18 @@ function inspectEgressAudit(audit: Buffer): {
     try {
       record = JSON.parse(trimmed);
     } catch {
+      malformedLineCount += 1;
       continue;
     }
-    if (!record || typeof record !== 'object' || Array.isArray(record)) continue;
+    if (!record || typeof record !== 'object' || Array.isArray(record)) {
+      malformedLineCount += 1;
+      continue;
+    }
     const ruleId = (record as { ruleId?: unknown }).ruleId;
     if (ruleId === 'audit_truncated') truncated = true;
     if (ruleId === 'policy_error') policyErrorCount += 1;
   }
-  return { truncated, policyErrorCount };
+  return { truncated, policyErrorCount, malformedLineCount };
 }
 
 async function readVerification(


### PR DESCRIPTION
## Summary

The egress audit log could look clean while the expected file was missing. A consumer could not tell a clean trial from a failed artifact copy.

- When the 1 MiB audit cap is hit, write one terminal `audit_truncated` record and do not append further hits.
- `collectEgressAuditArtifact` inventories a present log with `truncated` and `policyErrorCount`. Those fields are forensic; they do not change attempt attribution.
- If an egress proxy was configured and `egress-hits.jsonl` is absent or unreadable, the cell is `infra_failed` with an explicit reason.
- Present audits use the same `sha256:` prefix as `collectedArtifactInventory`.
- Fail-closed is opt-in: a spec without `egressProxy` still gets neither an audit nor a missing-audit signal.

Fixes #2959

## Verification

- `python3.13 packages/eval/harbor/test_egress_filter.py` — 5 pass
- `node --test packages/eval/dist/**/*.test.js` — 47 pass, including `runAttempt` cases for missing / truncated / `policy_error` / policy-then-hit / empty / unreadable, plus `AgentTimeoutError` with a truncated log remaining `subject_failed`

Not run: full `maka eval run` Terminal-Bench cohort. Harbor `artifacts/manifest.json` is not consumed. Filter liveness (`filter_ready`) is not in this PR.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Focused lint/typecheck and the affected suites pass locally
- [ ] Full workspace lint/format/typecheck

Does this PR entail a change in behavior?

- [x] Yes — a missing or unreadable expected egress audit is `infra_failed`. Truncation and `policy_error` stay on the artifact and do not drop a scored attempt.
