### PR TITLE
feat(storage): define quiescent session snapshot boundary

### DIFF
--- a/docs/windows-test-inventory.md
+++ b/docs/windows-test-inventory.md
@@ -16,10 +16,10 @@ Locations intentionally omit line numbers so unrelated edits do not invalidate t
 | Classification | Count |
 |---|---:|
 | windows-backend-gap | 27 |
-| portable-candidate | 10 |
+| portable-candidate | 11 |
 | platform-contract | 31 |
 
-Total Windows-excluded declarations: **68**
+Total Windows-excluded declarations: **69**
 
 ## Inventory
 
@@ -78,6 +78,7 @@ Total Windows-excluded declarations: **68**
 | portable-candidate | `packages/storage/src/__tests__/managed-dependency-environment.test.ts` isolates published POSIX content from a producer-retained writable handle | `process.platform === 'win32'` |
 | platform-contract | `packages/storage/src/__tests__/operational-state-store.test.ts` does not classify a SQLite write failure as a migration blocker | `process.platform === 'win32' ? 'POSIX permissions are required to make the SQLite database read-only' : false` |
 | platform-contract | `packages/storage/src/__tests__/pet-pack-store.test.ts` detects sprite sheets redirected outside the installed pack | `process.platform === 'win32' ? 'Windows file-symlink permissions are not guaranteed in CI' : false` |
+| portable-candidate | `packages/storage/src/__tests__/quiescent-session-snapshot.test.ts` requires a private staging parent on POSIX | `process.platform === 'win32'` |
 | platform-contract | `packages/storage/src/__tests__/root-authority.test.ts` preserves unexpected marker I/O failures at the public authority boundary | `process.platform === 'win32' ? 'POSIX permissions are required to make the marker unreadable' : typeof process.getuid === 'function' && process.getuid() === 0` |
 | platform-contract | `packages/storage/src/__tests__/root-authority.test.ts` rejects FIFO marker paths without blocking root resolution | `process.platform === 'win32'` |
 | platform-contract | `packages/storage/src/__tests__/root-authority.test.ts` rejects a lock path that aliases another filesystem object | `process.platform === 'win32' ? 'Windows file-symlink permissions are not guaranteed in CI' : false` |

--- a/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
+++ b/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
@@ -1,0 +1,744 @@
+import assert from 'node:assert/strict';
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { afterEach, test } from 'node:test';
+import {
+  createFileQuiescentSessionSnapshotCoordinator,
+  type SessionSnapshotCancellation,
+  SessionSnapshotError,
+  type SessionSnapshotQuiescenceAuthority,
+  type SessionSnapshotStatePreparer,
+  type SessionSnapshotWorkspacePreparation,
+  type SessionSnapshotWorkspacePreparer,
+  SESSION_SNAPSHOT_WORKSPACE_POLICY_V1,
+} from '../quiescent-session-snapshot.js';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+test('prepares state and workspace under one quiescence boundary, then releases live writers', async () => {
+  const fixture = await createFixture();
+  let liveState = 'state-at-boundary';
+  let liveWorkspace = 'workspace-at-boundary';
+  const events: string[] = [];
+  let quiescent = false;
+
+  const handle = await createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: {
+      async runQuiescent(_input, operation) {
+        assert.equal(quiescent, false);
+        quiescent = true;
+        events.push('enter');
+        try {
+          return await operation();
+        } finally {
+          quiescent = false;
+          events.push('exit');
+        }
+      },
+    },
+    state: {
+      async prepareState(input) {
+        assert.equal(quiescent, true);
+        events.push('state');
+        await mkdir(input.destinationRoot);
+        await writeFile(join(input.destinationRoot, 'runtime.sqlite'), liveState, 'utf8');
+        return {
+          mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
+          bytes: Buffer.from('{"makaSessionId":"session-1"}', 'utf8'),
+        };
+      },
+    },
+    workspace: {
+      async prepareWorkspace(input) {
+        assert.equal(quiescent, true);
+        assert.equal(input.policy.version, 1);
+        events.push('workspace');
+        await mkdir(input.destinationRoot);
+        await writeFile(join(input.destinationRoot, 'main.ts'), liveWorkspace, 'utf8');
+        return workspaceResult({ includedEntries: 1 });
+      },
+    },
+  }).prepare({ makaSessionId: 'session-1' });
+
+  assert.deepEqual(events, ['enter', 'state', 'workspace', 'exit']);
+  assert.equal(quiescent, false);
+  assert.notEqual(handle.snapshot.stateRoot, fixture.liveStateRoot);
+  assert.notEqual(handle.snapshot.workspaceRoot, fixture.liveWorkspaceRoot);
+  assert.equal(
+    await readFile(join(handle.snapshot.stateRoot, 'runtime.sqlite'), 'utf8'),
+    liveState,
+  );
+  assert.equal(
+    await readFile(join(handle.snapshot.workspaceRoot, 'main.ts'), 'utf8'),
+    liveWorkspace,
+  );
+
+  liveState = 'later-state';
+  liveWorkspace = 'later-workspace';
+  assert.equal(
+    await readFile(join(handle.snapshot.stateRoot, 'runtime.sqlite'), 'utf8'),
+    'state-at-boundary',
+  );
+  assert.equal(
+    await readFile(join(handle.snapshot.workspaceRoot, 'main.ts'), 'utf8'),
+    'workspace-at-boundary',
+  );
+  assert.deepEqual(handle.workspace, workspaceResult({ includedEntries: 1 }));
+
+  const publishedRoot = dirname(handle.snapshot.stateRoot);
+  const cleanupRename = interceptSnapshotCleanupRename(publishedRoot, async () => {
+    await mkdir(publishedRoot, { mode: 0o700 });
+    await writeFile(join(publishedRoot, 'replacement.txt'), 'keep', 'utf8');
+  });
+  await Promise.all([handle.release(), handle.release()]);
+  await cleanupRename.completed;
+  assert.equal(await readFile(join(publishedRoot, 'replacement.txt'), 'utf8'), 'keep');
+  await rm(publishedRoot, { recursive: true });
+  await handle.release();
+});
+
+test('serializes concurrent preparations for the same Session through the authority contract', async () => {
+  const fixture = await createFixture();
+  const authority = new SerialQuiescenceAuthority();
+  const firstWorkspaceEntered = deferred<void>();
+  const allowFirstWorkspace = deferred<void>();
+  let statePreparations = 0;
+
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: authority,
+    state: {
+      async prepareState(input) {
+        statePreparations += 1;
+        await mkdir(input.destinationRoot);
+        return stateIdentity(input.makaSessionId);
+      },
+    },
+    workspace: {
+      async prepareWorkspace(input) {
+        await mkdir(input.destinationRoot);
+        if (statePreparations === 1) {
+          firstWorkspaceEntered.resolve();
+          await allowFirstWorkspace.promise;
+        }
+        return workspaceResult();
+      },
+    },
+  });
+
+  const first = coordinator.prepare({ makaSessionId: 'same-session' });
+  await firstWorkspaceEntered.promise;
+  const second = coordinator.prepare({ makaSessionId: 'same-session' });
+  await Promise.resolve();
+  assert.equal(statePreparations, 1);
+  assert.deepEqual(authority.activeSessions, ['same-session']);
+
+  allowFirstWorkspace.resolve();
+  const firstHandle = await first;
+  const secondHandle = await second;
+  assert.equal(statePreparations, 2);
+  assert.equal(authority.maximumConcurrentBySession.get('same-session'), 1);
+  await Promise.all([firstHandle.release(), secondHandle.release()]);
+});
+
+test('does not globally serialize preparations for different Sessions', async () => {
+  const fixture = await createFixture();
+  const authority = new SerialQuiescenceAuthority();
+  const firstWorkspaceEntered = deferred<void>();
+  const allowFirstWorkspace = deferred<void>();
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: authority,
+    state: directoryStatePreparer,
+    workspace: {
+      async prepareWorkspace(input) {
+        await mkdir(input.destinationRoot);
+        if (input.makaSessionId === 'session-a') {
+          firstWorkspaceEntered.resolve();
+          await allowFirstWorkspace.promise;
+        }
+        return workspaceResult();
+      },
+    },
+  });
+
+  const first = coordinator.prepare({ makaSessionId: 'session-a' });
+  await firstWorkspaceEntered.promise;
+  const secondHandle = await coordinator.prepare({ makaSessionId: 'session-b' });
+  assert.deepEqual(authority.activeSessions, ['session-a']);
+  assert.equal(authority.maximumConcurrentBySession.get('session-a'), 1);
+  assert.equal(authority.maximumConcurrentBySession.get('session-b'), 1);
+
+  allowFirstWorkspace.resolve();
+  const firstHandle = await first;
+  await Promise.all([firstHandle.release(), secondHandle.release()]);
+});
+
+test('removes partial staging and preserves a stable policy rejection', async () => {
+  const fixture = await createFixture();
+  const rejection = new SessionSnapshotError(
+    'policy_rejected',
+    'Workspace snapshot policy rejected an entry',
+    { details: { phase: 'workspace', policyCategory: 'known_secret_file' } },
+  );
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: {
+      async prepareState(input) {
+        await mkdir(input.destinationRoot);
+        await writeFile(join(input.destinationRoot, 'runtime.sqlite'), 'partial', 'utf8');
+        return stateIdentity(input.makaSessionId);
+      },
+    },
+    workspace: {
+      async prepareWorkspace() {
+        throw rejection;
+      },
+    },
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'session-secret' }),
+    (error: unknown) => error === rejection,
+  );
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+  assert.equal(rejection.message.includes('.env'), false);
+});
+
+test('failure cleanup refuses a staging root replaced by an unrelated directory', async () => {
+  const fixture = await createFixture();
+  let unrelatedFile = '';
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: {
+      async prepareWorkspace(input) {
+        const preparingRoot = dirname(input.destinationRoot);
+        await rename(preparingRoot, `${preparingRoot}.displaced`);
+        await mkdir(preparingRoot, { mode: 0o700 });
+        unrelatedFile = join(preparingRoot, 'unrelated.txt');
+        await writeFile(unrelatedFile, 'keep', 'utf8');
+        throw new Error('workspace preparation failed');
+      },
+    },
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'failure-cleanup-owner' }),
+    isSnapshotError('cleanup_failed'),
+  );
+  assert.equal(await readFile(unrelatedFile, 'utf8'), 'keep');
+});
+
+test('cleans a published snapshot when the authority fails while releasing quiescence', async () => {
+  const fixture = await createFixture();
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: {
+      async runQuiescent(_input, operation) {
+        await operation();
+        throw new Error('authority release failed');
+      },
+    },
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'session-release-failure' }),
+    (error: unknown) =>
+      error instanceof SessionSnapshotError &&
+      error.code === 'io_failure' &&
+      error.message === 'Session snapshot preparation failed',
+  );
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('cancellation and an expired deadline stop before staging begins', async () => {
+  const fixture = await createFixture();
+  let authorityCalls = 0;
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    now: () => 10_000,
+    quiescence: {
+      async runQuiescent(_input, operation) {
+        authorityCalls += 1;
+        return operation();
+      },
+    },
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+  const controller = new AbortController();
+  controller.abort();
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'cancelled', signal: controller.signal }),
+    isSnapshotError('snapshot_cancelled'),
+  );
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'expired', deadlineAt: 10_000 }),
+    isSnapshotError('snapshot_cancelled'),
+  );
+  assert.equal(authorityCalls, 0);
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('cancellation while waiting for quiescence is propagated as snapshot_cancelled', async () => {
+  const fixture = await createFixture();
+  const authorityEntered = deferred<void>();
+  const controller = new AbortController();
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: {
+      async runQuiescent(input) {
+        authorityEntered.resolve();
+        await waitForAbort(input.cancellation);
+        throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+      },
+    },
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  const preparation = coordinator.prepare({ makaSessionId: 'waiting', signal: controller.signal });
+  await authorityEntered.promise;
+  controller.abort();
+  await assert.rejects(preparation, isSnapshotError('snapshot_cancelled'));
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('cancellation while leaving quiescence cleans the published snapshot', async () => {
+  const fixture = await createFixture();
+  const controller = new AbortController();
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: {
+      async runQuiescent(_input, operation) {
+        const result = await operation();
+        controller.abort();
+        return result;
+      },
+    },
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'cancel-after-publish', signal: controller.signal }),
+    isSnapshotError('snapshot_cancelled'),
+  );
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('release refuses a replacement directory and remains retryable for its owned root', async () => {
+  const fixture = await createFixture();
+  const handle = await createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  }).prepare({ makaSessionId: 'release-owner' });
+  const publishedRoot = dirname(handle.snapshot.stateRoot);
+  const displacedRoot = `${publishedRoot}.displaced`;
+  await rename(publishedRoot, displacedRoot);
+  await mkdir(publishedRoot, { mode: 0o700 });
+  const unrelated = join(publishedRoot, 'unrelated.txt');
+  await writeFile(unrelated, 'keep', 'utf8');
+
+  await assert.rejects(handle.release(), isSnapshotError('cleanup_failed'));
+  assert.equal(await readFile(unrelated, 'utf8'), 'keep');
+
+  await rm(publishedRoot, { recursive: true });
+  await rename(displacedRoot, publishedRoot);
+  await handle.release();
+  await assert.rejects(readdir(publishedRoot), isCode('ENOENT'));
+});
+
+test('release resumes an interrupted partial cleanup using the external ownership record', async () => {
+  const fixture = await createFixture();
+  const handle = await createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  }).prepare({ makaSessionId: 'partial-release-retry' });
+  const publishedRoot = dirname(handle.snapshot.stateRoot);
+  const snapshotId = basename(publishedRoot).slice('snapshot-'.length);
+  const ownerFile = join(fixture.stagingParent, `.snapshot-${snapshotId}.owner.json`);
+  const owner = JSON.parse(await readFile(ownerFile, 'utf8')) as { ownerToken: string };
+  const cleanupRoot = join(
+    fixture.stagingParent,
+    `.snapshot-${snapshotId}.${owner.ownerToken}.cleanup`,
+  );
+
+  await rename(publishedRoot, cleanupRoot);
+  await rm(join(cleanupRoot, 'state'), { recursive: true });
+  await handle.release();
+
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('creation failure cleans only the inode it created and preserves a colliding owner file', async () => {
+  const fixture = await createFixture();
+  const snapshotId = '00000000-0000-4000-8000-000000000001';
+  const ownerFile = join(fixture.stagingParent, `.snapshot-${snapshotId}.owner.json`);
+  await writeFile(ownerFile, 'unrelated', 'utf8');
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    newSnapshotId: () => snapshotId,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'create-failure-cleanup' }),
+    isSnapshotError('io_failure'),
+  );
+  assert.equal(await readFile(ownerFile, 'utf8'), 'unrelated');
+  assert.deepEqual(await readdir(fixture.stagingParent), [basename(ownerFile)]);
+});
+
+test('rejects a caller-supplied workspace policy override instead of downgrading V1 safety', async () => {
+  const fixture = await createFixture();
+  assert.throws(
+    () =>
+      createFileQuiescentSessionSnapshotCoordinator({
+        stagingParent: fixture.stagingParent,
+        privateStagingRootAuthority,
+        quiescence: immediateAuthority,
+        state: directoryStatePreparer,
+        workspace: directoryWorkspacePreparer,
+        policy: {
+          version: 1,
+          classify: () => ({ kind: 'include' }),
+        },
+      } as Parameters<typeof createFileQuiescentSessionSnapshotCoordinator>[0]),
+    /cannot be overridden/u,
+  );
+});
+
+test('binds private-root verification to the exact canonical staging path', async () => {
+  const fixture = await createFixture();
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority: {
+      async verifyPrivateStagingRoot() {
+        return { canonicalPath: fixture.root };
+      },
+    },
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'wrong-private-root-attestation' }),
+    isSnapshotError('unsafe_source'),
+  );
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('verifies and cleans each newly created snapshot directory when platform privacy fails', async () => {
+  const fixture = await createFixture();
+  let verificationCalls = 0;
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority: {
+      async verifyPrivateStagingRoot(input) {
+        verificationCalls += 1;
+        return {
+          canonicalPath: verificationCalls === 1 ? input.canonicalPath : fixture.stagingParent,
+        };
+      },
+    },
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'unsafe-created-staging-root' }),
+    isSnapshotError('unsafe_source'),
+  );
+  assert.equal(verificationCalls, 2);
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('requires a caller-provided Windows ACL verifier', {
+  skip: process.platform !== 'win32',
+}, async () => {
+  const fixture = await createFixture();
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'missing-windows-acl-verifier' }),
+    isSnapshotError('unsafe_source'),
+  );
+});
+
+test('requires a private staging parent on POSIX', {
+  skip: process.platform === 'win32',
+}, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-session-snapshot-public-'));
+  roots.push(root);
+  const stagingParent = join(root, 'staging');
+  await mkdir(stagingParent, { mode: 0o755 });
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'unsafe-parent' }),
+    isSnapshotError('unsafe_source'),
+  );
+  assert.deepEqual(await readdir(stagingParent), []);
+});
+
+test('V1 workspace policy includes portable inputs, excludes rebuildable data, and rejects secrets', () => {
+  const cases = [
+    ['package.json', 'file', { kind: 'include' }],
+    ['pnpm-lock.yaml', 'file', { kind: 'include' }],
+    ['.maka-workspace.json', 'file', { kind: 'include' }],
+    ['.git/config', 'file', { kind: 'exclude', category: 'source_control' }],
+    [
+      'packages/app/node_modules/pkg/index.js',
+      'file',
+      { kind: 'exclude', category: 'dependency_tree' },
+    ],
+    ['.turbo/cache.bin', 'file', { kind: 'exclude', category: 'cache' }],
+    ['logs/agent.txt', 'file', { kind: 'exclude', category: 'log' }],
+    ['debug.log', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.maka-runtime/input.json', 'file', { kind: 'exclude', category: 'runtime_scratch' }],
+    ['.env.local', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['keys/id_ed25519', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['credentials.yaml', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['secrets.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.terraformrc', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.git-credentials.lock', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['keys/client-private-key.pem', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['certs/client.p12', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['certs/client.crt', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['keys/service-account.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.ssh/config', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.aws/credentials', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.cargo/credentials', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.docker/config.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.kube/config', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    [
+      '.config/gcloud/application_default_credentials.json',
+      'file',
+      { kind: 'reject', category: 'known_secret_file' },
+    ],
+    ['../escape', 'file', { kind: 'reject', category: 'unsafe_path' }],
+    ['a\\b', 'file', { kind: 'reject', category: 'unsafe_path' }],
+  ] as const;
+
+  for (const [relativePath, kind, expected] of cases) {
+    assert.deepEqual(
+      SESSION_SNAPSHOT_WORKSPACE_POLICY_V1.classify({ relativePath, kind }),
+      expected,
+    );
+  }
+});
+
+const immediateAuthority: SessionSnapshotQuiescenceAuthority = {
+  async runQuiescent(_input, operation) {
+    return operation();
+  },
+};
+
+const privateStagingRootAuthority = {
+  async verifyPrivateStagingRoot(input: { canonicalPath: string }) {
+    return { canonicalPath: await realpath(input.canonicalPath) };
+  },
+};
+
+const directoryStatePreparer: SessionSnapshotStatePreparer = {
+  async prepareState(input) {
+    await mkdir(input.destinationRoot);
+    return stateIdentity(input.makaSessionId);
+  },
+};
+
+const directoryWorkspacePreparer: SessionSnapshotWorkspacePreparer = {
+  async prepareWorkspace(input) {
+    await mkdir(input.destinationRoot);
+    return workspaceResult();
+  },
+};
+
+function stateIdentity(makaSessionId: string) {
+  return {
+    mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
+    bytes: Buffer.from(JSON.stringify({ makaSessionId }), 'utf8'),
+  };
+}
+
+function workspaceResult(
+  overrides: Partial<SessionSnapshotWorkspacePreparation> = {},
+): SessionSnapshotWorkspacePreparation {
+  return {
+    includedEntries: 0,
+    excludedEntries: 0,
+    excludedEntriesByCategory: {
+      dependency_tree: 0,
+      source_control: 0,
+      cache: 0,
+      log: 0,
+      runtime_scratch: 0,
+    },
+    payloadBytes: 0,
+    ...overrides,
+  };
+}
+
+async function createFixture(): Promise<{
+  root: string;
+  stagingParent: string;
+  liveStateRoot: string;
+  liveWorkspaceRoot: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-session-snapshot-'));
+  roots.push(root);
+  const stagingParent = join(root, 'staging');
+  const liveStateRoot = join(root, 'live-state');
+  const liveWorkspaceRoot = join(root, 'live-workspace');
+  await Promise.all([
+    mkdir(stagingParent, { mode: 0o700 }),
+    mkdir(liveStateRoot),
+    mkdir(liveWorkspaceRoot),
+  ]);
+  return { root, stagingParent, liveStateRoot, liveWorkspaceRoot };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+class SerialQuiescenceAuthority implements SessionSnapshotQuiescenceAuthority {
+  readonly activeSessions: string[] = [];
+  readonly maximumConcurrentBySession = new Map<string, number>();
+  readonly #tails = new Map<string, Promise<void>>();
+  readonly #activeBySession = new Map<string, number>();
+
+  async runQuiescent<T>(
+    input: { makaSessionId: string; cancellation: SessionSnapshotCancellation },
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const predecessor = this.#tails.get(input.makaSessionId) ?? Promise.resolve();
+    const release = deferred<void>();
+    const tail = predecessor.catch(() => {}).then(() => release.promise);
+    this.#tails.set(input.makaSessionId, tail);
+    await predecessor;
+    if (input.cancellation.signal.aborted) throw Object.assign(new Error(), { name: 'AbortError' });
+
+    const active = (this.#activeBySession.get(input.makaSessionId) ?? 0) + 1;
+    this.#activeBySession.set(input.makaSessionId, active);
+    this.maximumConcurrentBySession.set(
+      input.makaSessionId,
+      Math.max(this.maximumConcurrentBySession.get(input.makaSessionId) ?? 0, active),
+    );
+    this.activeSessions.push(input.makaSessionId);
+    try {
+      return await operation();
+    } finally {
+      this.activeSessions.splice(this.activeSessions.indexOf(input.makaSessionId), 1);
+      this.#activeBySession.set(input.makaSessionId, active - 1);
+      release.resolve();
+      if (this.#tails.get(input.makaSessionId) === tail) this.#tails.delete(input.makaSessionId);
+    }
+  }
+}
+
+async function waitForAbort(cancellation: SessionSnapshotCancellation): Promise<void> {
+  if (cancellation.signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    cancellation.signal.addEventListener('abort', () => resolve(), { once: true });
+  });
+}
+
+function isSnapshotError(code: SessionSnapshotError['code']): (error: unknown) => boolean {
+  return (error) => error instanceof SessionSnapshotError && error.code === code;
+}
+
+function isCode(code: string): (error: unknown) => boolean {
+  return (error) =>
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code;
+}
+
+function interceptSnapshotCleanupRename(
+  publishedRoot: string,
+  afterRename: () => Promise<void>,
+): { completed: Promise<void> } {
+  const stagingParent = dirname(publishedRoot);
+  const expectedName = basename(publishedRoot);
+  let resolveCompleted!: () => void;
+  let rejectCompleted!: (error: unknown) => void;
+  const completed = new Promise<void>((resolve, reject) => {
+    resolveCompleted = resolve;
+    rejectCompleted = reject;
+  });
+  const observer = async () => {
+    try {
+      while (true) {
+        const names = await readdir(stagingParent);
+        if (!names.includes(expectedName)) {
+          await afterRename();
+          resolveCompleted();
+          return;
+        }
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+    } catch (error) {
+      rejectCompleted(error);
+    }
+  };
+  void observer();
+  return { completed };
+}

--- a/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
+++ b/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
@@ -67,7 +67,7 @@ test('prepares state and workspace under one quiescence boundary, then releases 
     workspace: {
       async prepareWorkspace(input) {
         assert.equal(quiescent, true);
-        assert.equal(input.policy.version, 1);
+        assert.equal(input.policy, SESSION_SNAPSHOT_WORKSPACE_POLICY_V1);
         events.push('workspace');
         await mkdir(input.destinationRoot);
         await writeFile(join(input.destinationRoot, 'main.ts'), liveWorkspace, 'utf8');
@@ -546,7 +546,8 @@ test('V1 workspace policy includes portable inputs, excludes rebuildable data, a
     ],
     ['.turbo/cache.bin', 'file', { kind: 'exclude', category: 'cache' }],
     ['logs/agent.txt', 'file', { kind: 'exclude', category: 'log' }],
-    ['debug.log', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['debug.log', 'file', { kind: 'exclude', category: 'log' }],
+    ['secrets.log', 'file', { kind: 'exclude', category: 'log' }],
     ['.maka-runtime/input.json', 'file', { kind: 'exclude', category: 'runtime_scratch' }],
     ['.env.local', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['keys/id_ed25519', 'file', { kind: 'reject', category: 'known_secret_file' }],
@@ -556,7 +557,11 @@ test('V1 workspace policy includes portable inputs, excludes rebuildable data, a
     ['.git-credentials.lock', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['keys/client-private-key.pem', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['certs/client.p12', 'file', { kind: 'reject', category: 'known_secret_file' }],
-    ['certs/client.crt', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['certs/client.crt', 'file', { kind: 'include' }],
+    ['certs/client.cer', 'file', { kind: 'include' }],
+    ['certs/client.csr', 'file', { kind: 'include' }],
+    ['certs/client.pem', 'file', { kind: 'include' }],
+    ['certs/client.der', 'file', { kind: 'include' }],
     ['keys/service-account.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.ssh/config', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.aws/credentials', 'file', { kind: 'reject', category: 'known_secret_file' }],

--- a/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
+++ b/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
@@ -33,19 +33,27 @@ import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { afterEach, test } from 'node:test';
 import {
+  createFileSessionSnapshotStagingCleanupAuthority,
   createFileQuiescentSessionSnapshotCoordinator,
   type SessionSnapshotCancellation,
   SessionSnapshotError,
   type SessionSnapshotQuiescenceAuthority,
   type SessionSnapshotStatePreparer,
+  type SessionSnapshotStagingCleanupAuthority,
   type SessionSnapshotWorkspacePreparation,
   type SessionSnapshotWorkspacePreparer,
   SESSION_SNAPSHOT_WORKSPACE_POLICY_V1,
 } from '../quiescent-session-snapshot.js';
+import {
+  acquireProcessLifetimeOwner,
+  type ProcessLifetimeOwner,
+} from '../process-lifetime-owner.js';
 
 const roots: string[] = [];
+const processLifetimeOwners: ProcessLifetimeOwner[] = [];
 
 afterEach(async () => {
+  await Promise.all(processLifetimeOwners.splice(0).map((owner) => owner.close()));
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
 
@@ -58,6 +66,7 @@ test('prepares state and workspace under one quiescence boundary, then releases 
 
   const handle = await createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: {
       async runQuiescent(_input, operation) {
@@ -148,6 +157,7 @@ test('serializes concurrent preparations for the same Session through the author
 
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: authority,
     state: {
@@ -191,6 +201,7 @@ test('does not globally serialize preparations for different Sessions', async ()
   const allowFirstWorkspace = deferred<void>();
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: authority,
     state: directoryStatePreparer,
@@ -227,6 +238,7 @@ test('removes partial staging and preserves a stable policy rejection', async ()
   );
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: immediateAuthority,
     state: {
@@ -256,6 +268,7 @@ test('failure cleanup refuses a staging root replaced by an unrelated directory'
   let unrelatedFile = '';
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: immediateAuthority,
     state: directoryStatePreparer,
@@ -273,7 +286,13 @@ test('failure cleanup refuses a staging root replaced by an unrelated directory'
 
   await assert.rejects(
     coordinator.prepare({ makaSessionId: 'failure-cleanup-owner' }),
-    isSnapshotError('cleanup_failed'),
+    (error: unknown) => {
+      assert.equal(error instanceof SessionSnapshotError && error.code, 'io_failure');
+      assert.deepEqual(error instanceof SessionSnapshotError && error.details, {
+        cleanupFailed: true,
+      });
+      return true;
+    },
   );
   assert.equal(await readFile(unrelatedFile, 'utf8'), 'keep');
 });
@@ -282,6 +301,7 @@ test('cleans a published snapshot when the authority fails while releasing quies
   const fixture = await createFixture();
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: {
       async runQuiescent(_input, operation) {
@@ -308,6 +328,7 @@ test('cancellation and an expired deadline stop before staging begins', async ()
   let authorityCalls = 0;
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     now: () => 10_000,
     quiescence: {
@@ -341,6 +362,7 @@ test('a deadline beyond the Node timer limit is rescheduled until the absolute t
   let cancellationSignal: AbortSignal | undefined;
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     now: Date.now,
     quiescence: {
@@ -375,6 +397,7 @@ test('cancellation while waiting for quiescence is propagated as snapshot_cancel
   const controller = new AbortController();
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: {
       async runQuiescent(input) {
@@ -399,6 +422,7 @@ test('cancellation while leaving quiescence cleans the published snapshot', asyn
   const controller = new AbortController();
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: {
       async runQuiescent(_input, operation) {
@@ -418,10 +442,40 @@ test('cancellation while leaving quiescence cleans the published snapshot', asyn
   assert.deepEqual(await readdir(fixture.stagingParent), []);
 });
 
+test('an I/O failure racing cancellation remains an I/O failure', async () => {
+  const fixture = await createFixture();
+  const controller = new AbortController();
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: {
+      async prepareWorkspace(input) {
+        await mkdir(input.destinationRoot);
+        controller.abort();
+        throw Object.assign(new Error('workspace disk failed'), { code: 'EIO' });
+      },
+    },
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'io-racing-cancel', signal: controller.signal }),
+    (error: unknown) =>
+      error instanceof SessionSnapshotError &&
+      error.code === 'io_failure' &&
+      error.cause instanceof Error &&
+      error.cause.message === 'workspace disk failed',
+  );
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
 test('release refuses a replacement directory and remains retryable for its owned root', async () => {
   const fixture = await createFixture();
   const handle = await createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: immediateAuthority,
     state: directoryStatePreparer,
@@ -447,6 +501,7 @@ test('release resumes an interrupted partial cleanup using the external ownershi
   const fixture = await createFixture();
   const handle = await createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: immediateAuthority,
     state: directoryStatePreparer,
@@ -468,6 +523,66 @@ test('release resumes an interrupted partial cleanup using the external ownershi
   assert.deepEqual(await readdir(fixture.stagingParent), []);
 });
 
+test('a successor process recovers staging owned by a released process lifetime', async () => {
+  const fixture = await createFixture();
+  const handle = await createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  }).prepare({ makaSessionId: 'orphan-recovery' });
+  const publishedRoot = dirname(handle.snapshot.stateRoot);
+  const snapshotId = basename(publishedRoot).slice('snapshot-'.length);
+
+  await fixture.processLifetimeOwner.close();
+  const successorOwner = await acquireProcessLifetimeOwner(join(fixture.root, 'cleanup-owners'));
+  processLifetimeOwners.push(successorOwner);
+  const successor = createFileSessionSnapshotStagingCleanupAuthority({
+    cleanupStateRoot: join(fixture.root, 'snapshot-cleanup-state'),
+    stagingParent: fixture.stagingParent,
+    processLifetimeOwner: successorOwner,
+    privateStagingRootAuthority,
+  });
+
+  assert.deepEqual(await successor.recover(), { removed: [snapshotId], failed: [] });
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('recovery removes an exact preparing root left before its owner record was written', async () => {
+  const fixture = await createFixture();
+  const lease = {
+    snapshotId: '00000000-0000-4000-8000-000000000002',
+    ownerToken: '00000000-0000-4000-8000-000000000003',
+    makaSessionId: 'orphaned-preparing-root',
+  };
+  const preparingRoot = join(fixture.stagingParent, `.snapshot-${lease.snapshotId}.preparing`);
+  await assert.rejects(
+    fixture.stagingCleanup.ownCreation(lease, async () => {
+      await mkdir(preparingRoot, { mode: 0o700 });
+      throw new Error('simulated process exit before owner record');
+    }),
+    /simulated process exit/u,
+  );
+
+  await fixture.processLifetimeOwner.close();
+  const successorOwner = await acquireProcessLifetimeOwner(join(fixture.root, 'cleanup-owners'));
+  processLifetimeOwners.push(successorOwner);
+  const successor = createFileSessionSnapshotStagingCleanupAuthority({
+    cleanupStateRoot: join(fixture.root, 'snapshot-cleanup-state'),
+    stagingParent: fixture.stagingParent,
+    processLifetimeOwner: successorOwner,
+    privateStagingRootAuthority,
+  });
+
+  assert.deepEqual(await successor.recover(), {
+    removed: [lease.snapshotId],
+    failed: [],
+  });
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
 test('creation failure cleans only the inode it created and preserves a colliding owner file', async () => {
   const fixture = await createFixture();
   const snapshotId = '00000000-0000-4000-8000-000000000001';
@@ -475,6 +590,7 @@ test('creation failure cleans only the inode it created and preserves a collidin
   await writeFile(ownerFile, 'unrelated', 'utf8');
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     newSnapshotId: () => snapshotId,
     quiescence: immediateAuthority,
@@ -496,6 +612,7 @@ test('rejects a caller-supplied workspace policy override instead of downgrading
     () =>
       createFileQuiescentSessionSnapshotCoordinator({
         stagingParent: fixture.stagingParent,
+        stagingCleanup: fixture.stagingCleanup,
         privateStagingRootAuthority,
         quiescence: immediateAuthority,
         state: directoryStatePreparer,
@@ -513,6 +630,7 @@ test('binds private-root verification to the exact canonical staging path', asyn
   const fixture = await createFixture();
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority: {
       async verifyPrivateStagingRoot() {
         return { canonicalPath: fixture.root };
@@ -535,6 +653,7 @@ test('verifies and cleans each newly created snapshot directory when platform pr
   let verificationCalls = 0;
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority: {
       async verifyPrivateStagingRoot(input) {
         verificationCalls += 1;
@@ -562,6 +681,7 @@ test('requires a caller-provided Windows ACL verifier', {
   const fixture = await createFixture();
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     quiescence: immediateAuthority,
     state: directoryStatePreparer,
     workspace: directoryWorkspacePreparer,
@@ -580,8 +700,16 @@ test('requires a private staging parent on POSIX', {
   roots.push(root);
   const stagingParent = join(root, 'staging');
   await mkdir(stagingParent, { mode: 0o755 });
+  const processLifetimeOwner = await acquireProcessLifetimeOwner(join(root, 'cleanup-owners'));
+  processLifetimeOwners.push(processLifetimeOwner);
+  const stagingCleanup = createFileSessionSnapshotStagingCleanupAuthority({
+    cleanupStateRoot: join(root, 'snapshot-cleanup-state'),
+    stagingParent,
+    processLifetimeOwner,
+  });
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent,
+    stagingCleanup,
     quiescence: immediateAuthority,
     state: directoryStatePreparer,
     workspace: directoryWorkspacePreparer,
@@ -713,6 +841,7 @@ test('binds explicit control-plane confirmation to the Session, policy and subtr
   }> = [];
   const handle = await createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: immediateAuthority,
     state: directoryStatePreparer,
@@ -767,6 +896,7 @@ test('rejects a malformed control-plane confirmation grant before quiescence', a
   let enteredQuiescence = false;
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: {
       async runQuiescent(_input, operation) {
@@ -791,6 +921,7 @@ test('fails closed and cleans staging when a suspected path has no explicit conf
   let authorityCalls = 0;
   const coordinator = createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: immediateAuthority,
     state: directoryStatePreparer,
@@ -824,6 +955,7 @@ test('applies an explicit control-plane exclusion with bounded diagnostics', asy
   const fixture = await createFixture();
   const handle = await createFileQuiescentSessionSnapshotCoordinator({
     stagingParent: fixture.stagingParent,
+    stagingCleanup: fixture.stagingCleanup,
     privateStagingRootAuthority,
     quiescence: immediateAuthority,
     state: directoryStatePreparer,
@@ -918,6 +1050,8 @@ function workspaceResult(
 async function createFixture(): Promise<{
   root: string;
   stagingParent: string;
+  stagingCleanup: SessionSnapshotStagingCleanupAuthority;
+  processLifetimeOwner: ProcessLifetimeOwner;
   liveStateRoot: string;
   liveWorkspaceRoot: string;
 }> {
@@ -931,7 +1065,22 @@ async function createFixture(): Promise<{
     mkdir(liveStateRoot),
     mkdir(liveWorkspaceRoot),
   ]);
-  return { root, stagingParent, liveStateRoot, liveWorkspaceRoot };
+  const processLifetimeOwner = await acquireProcessLifetimeOwner(join(root, 'cleanup-owners'));
+  processLifetimeOwners.push(processLifetimeOwner);
+  const stagingCleanup = createFileSessionSnapshotStagingCleanupAuthority({
+    cleanupStateRoot: join(root, 'snapshot-cleanup-state'),
+    stagingParent,
+    processLifetimeOwner,
+    privateStagingRootAuthority,
+  });
+  return {
+    root,
+    stagingParent,
+    stagingCleanup,
+    processLifetimeOwner,
+    liveStateRoot,
+    liveWorkspaceRoot,
+  };
 }
 
 function deferred<T>(): {

--- a/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
+++ b/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
@@ -1,5 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import assert from 'node:assert/strict';
 import {
+  copyFile,
   mkdir,
   mkdtemp,
   readFile,
@@ -31,8 +51,8 @@ afterEach(async () => {
 
 test('prepares state and workspace under one quiescence boundary, then releases live writers', async () => {
   const fixture = await createFixture();
-  let liveState = 'state-at-boundary';
-  let liveWorkspace = 'workspace-at-boundary';
+  await writeFile(join(fixture.liveStateRoot, 'runtime.sqlite'), 'state-at-boundary', 'utf8');
+  await writeFile(join(fixture.liveWorkspaceRoot, 'main.ts'), 'workspace-at-boundary', 'utf8');
   const events: string[] = [];
   let quiescent = false;
 
@@ -57,7 +77,10 @@ test('prepares state and workspace under one quiescence boundary, then releases 
         assert.equal(quiescent, true);
         events.push('state');
         await mkdir(input.destinationRoot);
-        await writeFile(join(input.destinationRoot, 'runtime.sqlite'), liveState, 'utf8');
+        await copyFile(
+          join(fixture.liveStateRoot, 'runtime.sqlite'),
+          join(input.destinationRoot, 'runtime.sqlite'),
+        );
         return {
           mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
           bytes: Buffer.from('{"makaSessionId":"session-1"}', 'utf8'),
@@ -70,7 +93,10 @@ test('prepares state and workspace under one quiescence boundary, then releases 
         assert.equal(input.policy, SESSION_SNAPSHOT_WORKSPACE_POLICY_V1);
         events.push('workspace');
         await mkdir(input.destinationRoot);
-        await writeFile(join(input.destinationRoot, 'main.ts'), liveWorkspace, 'utf8');
+        await copyFile(
+          join(fixture.liveWorkspaceRoot, 'main.ts'),
+          join(input.destinationRoot, 'main.ts'),
+        );
         return workspaceResult({ includedEntries: 1 });
       },
     },
@@ -82,15 +108,15 @@ test('prepares state and workspace under one quiescence boundary, then releases 
   assert.notEqual(handle.snapshot.workspaceRoot, fixture.liveWorkspaceRoot);
   assert.equal(
     await readFile(join(handle.snapshot.stateRoot, 'runtime.sqlite'), 'utf8'),
-    liveState,
+    'state-at-boundary',
   );
   assert.equal(
     await readFile(join(handle.snapshot.workspaceRoot, 'main.ts'), 'utf8'),
-    liveWorkspace,
+    'workspace-at-boundary',
   );
 
-  liveState = 'later-state';
-  liveWorkspace = 'later-workspace';
+  await writeFile(join(fixture.liveStateRoot, 'runtime.sqlite'), 'later-state', 'utf8');
+  await writeFile(join(fixture.liveWorkspaceRoot, 'main.ts'), 'later-workspace', 'utf8');
   assert.equal(
     await readFile(join(handle.snapshot.stateRoot, 'runtime.sqlite'), 'utf8'),
     'state-at-boundary',
@@ -306,6 +332,41 @@ test('cancellation and an expired deadline stop before staging begins', async ()
   );
   assert.equal(authorityCalls, 0);
   assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('a deadline beyond the Node timer limit is rescheduled until the absolute time', async (t) => {
+  t.mock.timers.enable({ apis: ['Date', 'setTimeout'], now: 0 });
+  const fixture = await createFixture();
+  const authorityEntered = deferred<void>();
+  let cancellationSignal: AbortSignal | undefined;
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    now: Date.now,
+    quiescence: {
+      async runQuiescent(input) {
+        cancellationSignal = input.cancellation.signal;
+        authorityEntered.resolve();
+        await waitForAbort(input.cancellation);
+        throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+      },
+    },
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+  const timerLimit = 2_147_483_647;
+  const preparation = coordinator.prepare({
+    makaSessionId: 'long-deadline',
+    deadlineAt: timerLimit + 1_000,
+  });
+  await authorityEntered.promise;
+
+  t.mock.timers.tick(timerLimit);
+  assert.equal(cancellationSignal?.aborted, false);
+  t.mock.timers.tick(999);
+  assert.equal(cancellationSignal?.aborted, false);
+  t.mock.timers.tick(1);
+  await assert.rejects(preparation, isSnapshotError('snapshot_cancelled'));
 });
 
 test('cancellation while waiting for quiescence is propagated as snapshot_cancelled', async () => {
@@ -547,12 +608,21 @@ test('V1 workspace policy includes portable inputs, excludes rebuildable data, a
     ['.turbo/cache.bin', 'file', { kind: 'exclude', category: 'cache' }],
     ['logs/agent.txt', 'file', { kind: 'exclude', category: 'log' }],
     ['debug.log', 'file', { kind: 'exclude', category: 'log' }],
-    ['secrets.log', 'file', { kind: 'exclude', category: 'log' }],
+    ['secrets.log', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.env.log', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['keys/private-key.log', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.maka-runtime/input.json', 'file', { kind: 'exclude', category: 'runtime_scratch' }],
     ['.env.local', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['.env.example', 'file', { kind: 'include' }],
+    ['.env.template', 'file', { kind: 'include' }],
+    ['.env.example.local', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['keys/id_ed25519', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['keys/id_ed25519.pub', 'file', { kind: 'include' }],
+    ['keys/id_rsa.pub', 'file', { kind: 'include' }],
     ['credentials.yaml', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['secrets.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['src/secrets.ts', 'file', { kind: 'include' }],
+    ['docs/secrets.md', 'file', { kind: 'include' }],
     ['.terraformrc', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.git-credentials.lock', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['keys/client-private-key.pem', 'file', { kind: 'reject', category: 'known_secret_file' }],
@@ -562,7 +632,13 @@ test('V1 workspace policy includes portable inputs, excludes rebuildable data, a
     ['certs/client.csr', 'file', { kind: 'include' }],
     ['certs/client.pem', 'file', { kind: 'include' }],
     ['certs/client.der', 'file', { kind: 'include' }],
+    ['privkey.pem', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['private.pem', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['keys/service-account.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['secrets', 'directory', { kind: 'reject', category: 'known_secret_file' }],
+    ['secrets/token', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['credentials/oauth.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    ['private/token', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.ssh/config', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.aws/credentials', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.cargo/credentials', 'file', { kind: 'reject', category: 'known_secret_file' }],
@@ -575,6 +651,11 @@ test('V1 workspace policy includes portable inputs, excludes rebuildable data, a
     ],
     ['../escape', 'file', { kind: 'reject', category: 'unsafe_path' }],
     ['a\\b', 'file', { kind: 'reject', category: 'unsafe_path' }],
+    ['CON', 'file', { kind: 'reject', category: 'unsafe_path' }],
+    ['nested/LPT1.txt', 'file', { kind: 'reject', category: 'unsafe_path' }],
+    ['foo:bar', 'file', { kind: 'reject', category: 'unsafe_path' }],
+    ['name.', 'file', { kind: 'reject', category: 'unsafe_path' }],
+    ['name ', 'directory', { kind: 'reject', category: 'unsafe_path' }],
   ] as const;
 
   for (const [relativePath, kind, expected] of cases) {

--- a/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
+++ b/packages/storage/src/__tests__/quiescent-session-snapshot.test.ts
@@ -623,6 +623,7 @@ test('V1 workspace policy includes portable inputs, excludes rebuildable data, a
     ['secrets.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['src/secrets.ts', 'file', { kind: 'include' }],
     ['docs/secrets.md', 'file', { kind: 'include' }],
+    ['private', 'file', { kind: 'include' }],
     ['.terraformrc', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.git-credentials.lock', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['keys/client-private-key.pem', 'file', { kind: 'reject', category: 'known_secret_file' }],
@@ -635,10 +636,45 @@ test('V1 workspace policy includes portable inputs, excludes rebuildable data, a
     ['privkey.pem', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['private.pem', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['keys/service-account.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
-    ['secrets', 'directory', { kind: 'reject', category: 'known_secret_file' }],
-    ['secrets/token', 'file', { kind: 'reject', category: 'known_secret_file' }],
-    ['credentials/oauth.json', 'file', { kind: 'reject', category: 'known_secret_file' }],
-    ['private/token', 'file', { kind: 'reject', category: 'known_secret_file' }],
+    [
+      'secrets',
+      'directory',
+      { kind: 'confirm', category: 'suspected_secret_path', confirmationPath: 'secrets' },
+    ],
+    [
+      'secrets/token',
+      'file',
+      { kind: 'confirm', category: 'suspected_secret_path', confirmationPath: 'secrets' },
+    ],
+    [
+      'credentials/oauth.json',
+      'file',
+      { kind: 'confirm', category: 'suspected_secret_path', confirmationPath: 'credentials' },
+    ],
+    [
+      'private/token',
+      'file',
+      { kind: 'confirm', category: 'suspected_secret_path', confirmationPath: 'private' },
+    ],
+    [
+      'config/credentials/production.yml.enc',
+      'file',
+      {
+        kind: 'confirm',
+        category: 'suspected_secret_path',
+        confirmationPath: 'config/credentials',
+      },
+    ],
+    [
+      'include/private/header.h',
+      'file',
+      {
+        kind: 'confirm',
+        category: 'suspected_secret_path',
+        confirmationPath: 'include/private',
+      },
+    ],
+    ['include/private/id_ed25519', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.ssh/config', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.aws/credentials', 'file', { kind: 'reject', category: 'known_secret_file' }],
     ['.cargo/credentials', 'file', { kind: 'reject', category: 'known_secret_file' }],
@@ -664,6 +700,167 @@ test('V1 workspace policy includes portable inputs, excludes rebuildable data, a
       expected,
     );
   }
+});
+
+test('binds explicit control-plane confirmation to the Session, policy and subtree', async () => {
+  const fixture = await createFixture();
+  const requests: Array<{
+    makaSessionId: string;
+    confirmationGrantId: string;
+    policyVersion: number;
+    category: string;
+    confirmationPath: string;
+  }> = [];
+  const handle = await createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    confirmationAuthority: {
+      async resolveConfirmation(input) {
+        requests.push({
+          makaSessionId: input.makaSessionId,
+          confirmationGrantId: input.confirmationGrantId,
+          policyVersion: input.policyVersion,
+          category: input.category,
+          confirmationPath: input.confirmationPath,
+        });
+        return { action: 'include' };
+      },
+    },
+    workspace: {
+      async prepareWorkspace(input) {
+        assert.deepEqual(
+          await input.confirmation.resolve({
+            relativePath: 'config/credentials',
+            kind: 'directory',
+          }),
+          { kind: 'include' },
+        );
+        assert.deepEqual(
+          await input.confirmation.resolve({
+            relativePath: 'config/credentials/production.yml.enc',
+            kind: 'file',
+          }),
+          { kind: 'include' },
+        );
+        await mkdir(input.destinationRoot);
+        return workspaceResult({ includedEntries: 2 });
+      },
+    },
+  }).prepare({ makaSessionId: 'confirmed-session', confirmationGrantId: 'grant-1' });
+
+  assert.deepEqual(requests, [
+    {
+      makaSessionId: 'confirmed-session',
+      confirmationGrantId: 'grant-1',
+      policyVersion: 1,
+      category: 'suspected_secret_path',
+      confirmationPath: 'config/credentials',
+    },
+  ]);
+  await handle.release();
+});
+
+test('rejects a malformed control-plane confirmation grant before quiescence', async () => {
+  const fixture = await createFixture();
+  let enteredQuiescence = false;
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: {
+      async runQuiescent(_input, operation) {
+        enteredQuiescence = true;
+        return operation();
+      },
+    },
+    state: directoryStatePreparer,
+    workspace: directoryWorkspacePreparer,
+  });
+
+  await assert.rejects(
+    coordinator.prepare({ makaSessionId: 'confirmed-session', confirmationGrantId: '../grant' }),
+    isSnapshotError('invalid_input'),
+  );
+  assert.equal(enteredQuiescence, false);
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('fails closed and cleans staging when a suspected path has no explicit confirmation', async () => {
+  const fixture = await createFixture();
+  let authorityCalls = 0;
+  const coordinator = createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    confirmationAuthority: {
+      async resolveConfirmation() {
+        authorityCalls += 1;
+        return { action: 'include' };
+      },
+    },
+    workspace: {
+      async prepareWorkspace(input) {
+        await input.confirmation.resolve({ relativePath: 'include/private', kind: 'directory' });
+        throw new Error('unreachable');
+      },
+    },
+  });
+
+  await assert.rejects(coordinator.prepare({ makaSessionId: 'unconfirmed-session' }), (error) => {
+    assert.equal(error instanceof SessionSnapshotError && error.code, 'policy_rejected');
+    assert.deepEqual(error instanceof SessionSnapshotError && error.details, {
+      phase: 'workspace',
+      policyCategory: 'suspected_secret_path',
+    });
+    return true;
+  });
+  assert.equal(authorityCalls, 0);
+  assert.deepEqual(await readdir(fixture.stagingParent), []);
+});
+
+test('applies an explicit control-plane exclusion with bounded diagnostics', async () => {
+  const fixture = await createFixture();
+  const handle = await createFileQuiescentSessionSnapshotCoordinator({
+    stagingParent: fixture.stagingParent,
+    privateStagingRootAuthority,
+    quiescence: immediateAuthority,
+    state: directoryStatePreparer,
+    confirmationAuthority: {
+      async resolveConfirmation() {
+        return { action: 'exclude' };
+      },
+    },
+    workspace: {
+      async prepareWorkspace(input) {
+        assert.deepEqual(
+          await input.confirmation.resolve({ relativePath: 'secrets', kind: 'directory' }),
+          { kind: 'exclude', category: 'confirmed_secret_path' },
+        );
+        await mkdir(input.destinationRoot);
+        return workspaceResult({
+          excludedEntries: 1,
+          excludedEntriesByCategory: {
+            ...workspaceResult().excludedEntriesByCategory,
+            confirmed_secret_path: 1,
+          },
+        });
+      },
+    },
+  }).prepare({ makaSessionId: 'excluded-session', confirmationGrantId: 'grant-2' });
+
+  assert.deepEqual(
+    handle.workspace.excludedEntriesByCategory,
+    workspaceResult({
+      excludedEntries: 1,
+      excludedEntriesByCategory: {
+        ...workspaceResult().excludedEntriesByCategory,
+        confirmed_secret_path: 1,
+      },
+    }).excludedEntriesByCategory,
+  );
+  await handle.release();
 });
 
 const immediateAuthority: SessionSnapshotQuiescenceAuthority = {
@@ -711,6 +908,7 @@ function workspaceResult(
       cache: 0,
       log: 0,
       runtime_scratch: 0,
+      confirmed_secret_path: 0,
     },
     payloadBytes: 0,
     ...overrides,

--- a/packages/storage/src/quiescent-session-snapshot.ts
+++ b/packages/storage/src/quiescent-session-snapshot.ts
@@ -1,0 +1,1209 @@
+import { randomUUID } from 'node:crypto';
+import { constants as fsConstants } from 'node:fs';
+import { lstat, mkdir, open, realpath, rename, rm } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { copyOpaqueStateIdentityDescriptor } from './session-bundle-contract.js';
+import type {
+  OpaqueStateIdentityDescriptor,
+  PreparedSessionBundleSnapshot,
+} from './session-bundle-contract.js';
+import { isSafeSessionId } from './session-store.js';
+
+export const SESSION_SNAPSHOT_POLICY_VERSION = 1 as const;
+export const SESSION_SNAPSHOT_STAGING_SCHEMA_VERSION = 1 as const;
+
+const SNAPSHOT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const MAX_OWNER_RECORD_BYTES = 1_024;
+const NO_FOLLOW_OPEN_FLAG = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
+
+export type SessionSnapshotWorkspaceEntryKind = 'file' | 'directory';
+
+export type SessionSnapshotWorkspaceExclusionCategory =
+  | 'dependency_tree'
+  | 'source_control'
+  | 'cache'
+  | 'log'
+  | 'runtime_scratch';
+
+export type SessionSnapshotWorkspaceRejectionCategory =
+  | 'known_secret_file'
+  | 'unsafe_path'
+  | 'unsupported_entry';
+
+export type SessionSnapshotWorkspacePolicyDecision =
+  | { readonly kind: 'include' }
+  | {
+      readonly kind: 'exclude';
+      readonly category: SessionSnapshotWorkspaceExclusionCategory;
+    }
+  | {
+      readonly kind: 'reject';
+      readonly category: SessionSnapshotWorkspaceRejectionCategory;
+    };
+
+export interface SessionSnapshotWorkspaceEntry {
+  /** Slash-separated relative path supplied without normalization aliases. */
+  readonly relativePath: string;
+  readonly kind: SessionSnapshotWorkspaceEntryKind;
+}
+
+export interface SessionSnapshotWorkspacePolicy {
+  readonly version: typeof SESSION_SNAPSHOT_POLICY_VERSION;
+  /**
+   * Receives normalized relative paths. A preparer must stop descending as
+   * soon as a directory is excluded; descendant entries are not counted.
+   */
+  classify(entry: SessionSnapshotWorkspaceEntry): SessionSnapshotWorkspacePolicyDecision;
+}
+
+const INCLUDE = Object.freeze({ kind: 'include' } as const);
+
+// Keep this list aligned with the workspace measurement/exclusion rules introduced by #1353.
+const SENSITIVE_WORKSPACE_FILE_PATTERNS = [
+  /^\.env(?:\..*)?$/i,
+  /^\.(?:npmrc|netrc|pypirc|terraformrc)$/i,
+  /^\.git-credentials(?:\.lock)?$/i,
+  /^(?:credentials?|secrets?)(?:\..*)?$/i,
+  /(?:^|[-_.])(?:id_(?:rsa|dsa|ecdsa|ed25519)|private[-_.]?key)(?:$|[-_.])/i,
+  /\.(?:key|pem|p12|pfx|der|crt|cer|csr|log)$/i,
+] as const;
+
+/**
+ * V1 portable-workspace policy. It intentionally classifies names only; the
+ * filesystem preparer remains responsible for rejecting symlinks, hard links,
+ * special files, path races, case conflicts, and quota violations.
+ */
+export const SESSION_SNAPSHOT_WORKSPACE_POLICY_V1: SessionSnapshotWorkspacePolicy = Object.freeze({
+  version: SESSION_SNAPSHOT_POLICY_VERSION,
+  classify(entry: SessionSnapshotWorkspaceEntry): SessionSnapshotWorkspacePolicyDecision {
+    const decoded = decodeWorkspaceEntry(entry);
+    if (decoded.kind === 'reject') return decoded;
+    const { segments, basename: name } = decoded;
+    const lowerSegments = segments.map((segment) => segment.toLowerCase());
+    const lowerName = name.toLowerCase();
+
+    if (lowerSegments.includes('.git')) {
+      return { kind: 'exclude', category: 'source_control' };
+    }
+    if (lowerSegments.includes('node_modules')) {
+      return { kind: 'exclude', category: 'dependency_tree' };
+    }
+    if (
+      lowerSegments.includes('.cache') ||
+      lowerSegments.includes('.maka-cache') ||
+      lowerSegments.includes('.turbo')
+    ) {
+      return { kind: 'exclude', category: 'cache' };
+    }
+    if (entry.kind === 'file' && isKnownSecretPath(lowerSegments, lowerName)) {
+      return { kind: 'reject', category: 'known_secret_file' };
+    }
+    if (
+      lowerSegments.includes('logs') ||
+      lowerSegments.includes('.logs') ||
+      (entry.kind === 'file' && lowerName.endsWith('.log'))
+    ) {
+      return { kind: 'exclude', category: 'log' };
+    }
+    if (lowerSegments.includes('.maka-runtime') || lowerSegments.includes('.maka-activation')) {
+      return { kind: 'exclude', category: 'runtime_scratch' };
+    }
+    return INCLUDE;
+  },
+});
+
+export interface SessionSnapshotCancellation {
+  readonly signal: AbortSignal;
+  /** Absolute Unix time in milliseconds. */
+  readonly deadlineAt?: number;
+}
+
+/**
+ * Trusted host/owner authority for one complete Session mutation boundary.
+ *
+ * Before invoking `operation`, an implementation must stop admitting new
+ * mutations for this Maka Session, drain already-admitted state, Artifact and
+ * workspace mutations, and reject non-terminal Activations, background
+ * processes, pending approvals, and externally resumable actions. It must keep
+ * that boundary until `operation` settles, serialize preparations for the same
+ * Session, and honor cancellation/deadline while waiting. This interface does
+ * not make a process-local mutex authoritative by itself: every real writer
+ * must already be governed by the supplied Host/Owner implementation.
+ */
+export interface SessionSnapshotQuiescenceAuthority {
+  runQuiescent<T>(
+    input: {
+      readonly makaSessionId: string;
+      readonly cancellation: SessionSnapshotCancellation;
+    },
+    operation: () => Promise<T>,
+  ): Promise<T>;
+}
+
+export interface SessionSnapshotStatePreparer {
+  /** Creates the exact, previously absent root and closes every source/destination handle. */
+  prepareState(input: {
+    readonly makaSessionId: string;
+    readonly destinationRoot: string;
+    readonly cancellation: SessionSnapshotCancellation;
+  }): Promise<OpaqueStateIdentityDescriptor>;
+}
+
+export interface SessionSnapshotWorkspacePreparation {
+  /** Number of included files and directories, including empty directories. */
+  readonly includedEntries: number;
+  /** Number of topmost excluded entries; descendants of an excluded directory are not counted. */
+  readonly excludedEntries: number;
+  /** Bounded audit diagnostics; paths and file contents are deliberately absent. */
+  readonly excludedEntriesByCategory: Readonly<
+    Record<SessionSnapshotWorkspaceExclusionCategory, number>
+  >;
+  readonly payloadBytes: number;
+}
+
+export interface SessionSnapshotWorkspacePreparer {
+  /**
+   * Creates the exact, previously absent root, applies every supplied policy
+   * decision without downgrading it, and closes every source/destination handle.
+   */
+  prepareWorkspace(input: {
+    readonly makaSessionId: string;
+    readonly destinationRoot: string;
+    readonly policy: SessionSnapshotWorkspacePolicy;
+    readonly cancellation: SessionSnapshotCancellation;
+  }): Promise<SessionSnapshotWorkspacePreparation>;
+}
+
+/**
+ * Trusted platform adapter that verifies a staging root is private to the
+ * current principal. On Windows this must inspect the effective ACL of both
+ * the parent and each newly created snapshot directory; POSIX mode bits are
+ * neither available nor an adequate substitute there.
+ */
+export interface SessionSnapshotPrivateStagingRootAuthority {
+  verifyPrivateStagingRoot(input: {
+    readonly canonicalPath: string;
+  }): Promise<{ readonly canonicalPath: string }>;
+}
+
+export interface PrepareQuiescentSessionSnapshotInput {
+  readonly makaSessionId: string;
+  readonly signal?: AbortSignal;
+  /** Absolute Unix time in milliseconds. */
+  readonly deadlineAt?: number;
+}
+
+export interface PreparedSessionBundleHandle {
+  readonly snapshot: PreparedSessionBundleSnapshot;
+  readonly policyVersion: typeof SESSION_SNAPSHOT_POLICY_VERSION;
+  readonly workspace: SessionSnapshotWorkspacePreparation;
+  /** Idempotent after successful cleanup; failures remain retryable. */
+  release(): Promise<void>;
+}
+
+export interface QuiescentSessionSnapshotCoordinator {
+  prepare(input: PrepareQuiescentSessionSnapshotInput): Promise<PreparedSessionBundleHandle>;
+}
+
+export type SessionSnapshotErrorCode =
+  | 'invalid_input'
+  | 'snapshot_busy'
+  | 'snapshot_cancelled'
+  | 'session_not_quiescent'
+  | 'source_changed'
+  | 'unsafe_source'
+  | 'policy_rejected'
+  | 'quota_exceeded'
+  | 'cleanup_failed'
+  | 'io_failure';
+
+export type SessionSnapshotPhase =
+  | 'admission'
+  | 'staging'
+  | 'state'
+  | 'workspace'
+  | 'publication'
+  | 'cleanup';
+
+export interface SessionSnapshotErrorDetails {
+  readonly phase?: SessionSnapshotPhase;
+  readonly policyCategory?: SessionSnapshotWorkspaceRejectionCategory;
+  readonly limit?: number;
+  readonly observed?: number;
+}
+
+export interface SessionSnapshotErrorOptions extends ErrorOptions {
+  readonly details?: SessionSnapshotErrorDetails;
+}
+
+export class SessionSnapshotError extends Error {
+  readonly details?: Readonly<SessionSnapshotErrorDetails>;
+
+  constructor(
+    readonly code: SessionSnapshotErrorCode,
+    message: string,
+    options: SessionSnapshotErrorOptions = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'SessionSnapshotError';
+    if (options.details !== undefined) this.details = Object.freeze({ ...options.details });
+  }
+}
+
+export interface FileQuiescentSessionSnapshotCoordinatorOptions {
+  /** Private control-plane directory outside live state and workspace roots. */
+  readonly stagingParent: string;
+  readonly quiescence: SessionSnapshotQuiescenceAuthority;
+  readonly state: SessionSnapshotStatePreparer;
+  readonly workspace: SessionSnapshotWorkspacePreparer;
+  /** Required on Windows; optional additional verification on POSIX platforms. */
+  readonly privateStagingRootAuthority?: SessionSnapshotPrivateStagingRootAuthority;
+  readonly now?: () => number;
+  readonly newSnapshotId?: () => string;
+}
+
+export function createFileQuiescentSessionSnapshotCoordinator(
+  options: FileQuiescentSessionSnapshotCoordinatorOptions,
+): QuiescentSessionSnapshotCoordinator {
+  return new FileQuiescentSessionSnapshotCoordinator(options);
+}
+
+class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapshotCoordinator {
+  readonly #stagingParent: string;
+  readonly #quiescence: SessionSnapshotQuiescenceAuthority;
+  readonly #state: SessionSnapshotStatePreparer;
+  readonly #workspace: SessionSnapshotWorkspacePreparer;
+  readonly #privateStagingRootAuthority: SessionSnapshotPrivateStagingRootAuthority | undefined;
+  readonly #now: () => number;
+  readonly #newSnapshotId: () => string;
+
+  constructor(options: FileQuiescentSessionSnapshotCoordinatorOptions) {
+    if (!isAbsolute(options.stagingParent)) {
+      throw new TypeError('Session snapshot stagingParent must be absolute');
+    }
+    if ('policy' in options) {
+      throw new TypeError('Session snapshot V1 safety policy cannot be overridden');
+    }
+    this.#stagingParent = resolve(options.stagingParent);
+    this.#quiescence = options.quiescence;
+    this.#state = options.state;
+    this.#workspace = options.workspace;
+    this.#privateStagingRootAuthority = options.privateStagingRootAuthority;
+    this.#now = options.now ?? Date.now;
+    this.#newSnapshotId = options.newSnapshotId ?? randomUUID;
+  }
+
+  async prepare(input: PrepareQuiescentSessionSnapshotInput): Promise<PreparedSessionBundleHandle> {
+    const makaSessionId = requireMakaSessionId(input.makaSessionId);
+    const cancellation = createCancellation(input, this.#now);
+    let prepared: OwnedPreparedSessionBundleHandle | undefined;
+    let operationStarted = false;
+    try {
+      cancellation.assertActive();
+      const result = await this.#quiescence.runQuiescent(
+        { makaSessionId, cancellation: cancellation.value },
+        async () => {
+          if (operationStarted) {
+            throw new SessionSnapshotError(
+              'io_failure',
+              'Session snapshot quiescence operation was invoked more than once',
+              { details: { phase: 'admission' } },
+            );
+          }
+          operationStarted = true;
+          cancellation.assertActive();
+          const staging = await OwnedSnapshotStaging.create(
+            this.#stagingParent,
+            requireSnapshotId(this.#newSnapshotId()),
+            this.#privateStagingRootAuthority,
+          );
+          try {
+            cancellation.assertActive();
+            const stateIdentity = copyOpaqueStateIdentityDescriptor(
+              await this.#state.prepareState({
+                makaSessionId,
+                destinationRoot: staging.stateRoot,
+                cancellation: cancellation.value,
+              }),
+            );
+            cancellation.assertActive();
+            await assertPreparedRoot(staging.stateRoot, 'state');
+
+            const workspace = normalizeWorkspacePreparation(
+              await this.#workspace.prepareWorkspace({
+                makaSessionId,
+                destinationRoot: staging.workspaceRoot,
+                policy: SESSION_SNAPSHOT_WORKSPACE_POLICY_V1,
+                cancellation: cancellation.value,
+              }),
+            );
+            cancellation.assertActive();
+            await assertPreparedRoot(staging.workspaceRoot, 'workspace');
+            cancellation.assertActive();
+
+            const published = await staging.publish();
+            cancellation.assertActive();
+            const handle = new OwnedPreparedSessionBundleHandle(
+              published,
+              stateIdentity,
+              workspace,
+              SESSION_SNAPSHOT_POLICY_VERSION,
+            );
+            prepared = handle;
+            return handle;
+          } catch (error) {
+            await cleanupAfterPreparationFailure(staging, error);
+          }
+        },
+      );
+      cancellation.assertActive();
+      if (!prepared || result !== prepared) {
+        throw new SessionSnapshotError(
+          'io_failure',
+          'Session snapshot quiescence operation did not return its prepared handle',
+          { details: { phase: 'admission' } },
+        );
+      }
+      return result;
+    } catch (error) {
+      if (prepared) {
+        try {
+          await prepared.release();
+        } catch (cleanupError) {
+          throw cleanupFailure(new AggregateError([error, cleanupError]));
+        }
+      }
+      throw normalizePreparationError(error, cancellation.value.signal);
+    } finally {
+      cancellation.close();
+    }
+  }
+}
+
+interface SnapshotOwnerRecord {
+  readonly schemaVersion: typeof SESSION_SNAPSHOT_STAGING_SCHEMA_VERSION;
+  readonly snapshotId: string;
+  readonly ownerToken: string;
+  readonly rootDev: string;
+  readonly rootIno: string;
+}
+
+interface FilesystemIdentity {
+  readonly dev: bigint;
+  readonly ino: bigint;
+}
+
+interface SnapshotOwnerBinding {
+  readonly path: string;
+  readonly cleanupPath: string;
+  readonly record: SnapshotOwnerRecord;
+  readonly identity: FilesystemIdentity;
+}
+
+interface PublishedSnapshotStaging {
+  readonly parent: string;
+  readonly root: string;
+  readonly cleanupRoot: string;
+  readonly stateRoot: string;
+  readonly workspaceRoot: string;
+  readonly owner: SnapshotOwnerBinding;
+  readonly identity: FilesystemIdentity;
+}
+
+class OwnedSnapshotStaging {
+  readonly stateRoot: string;
+  readonly workspaceRoot: string;
+  readonly #preparingRoot: string;
+  readonly #publishedRoot: string;
+  readonly #cleanupRoot: string;
+  readonly #ownerFile: string;
+  readonly #ownerCleanupFile: string;
+  readonly #snapshotId: string;
+  readonly #ownerToken: string;
+  #owner: SnapshotOwnerBinding | undefined;
+  #identity: FilesystemIdentity | undefined;
+  #published = false;
+
+  private constructor(parent: string, snapshotId: string, ownerToken: string) {
+    this.#preparingRoot = join(parent, `.snapshot-${snapshotId}.preparing`);
+    this.#publishedRoot = join(parent, `snapshot-${snapshotId}`);
+    this.#cleanupRoot = join(parent, `.snapshot-${snapshotId}.${ownerToken}.cleanup`);
+    this.#ownerFile = join(parent, `.snapshot-${snapshotId}.owner.json`);
+    this.#ownerCleanupFile = join(parent, `.snapshot-${snapshotId}.${ownerToken}.owner-cleanup`);
+    this.#snapshotId = snapshotId;
+    this.#ownerToken = ownerToken;
+    this.stateRoot = join(this.#preparingRoot, 'state');
+    this.workspaceRoot = join(this.#preparingRoot, 'workspace');
+  }
+
+  static async create(
+    parent: string,
+    snapshotId: string,
+    privateRootAuthority: SessionSnapshotPrivateStagingRootAuthority | undefined,
+  ): Promise<OwnedSnapshotStaging> {
+    const canonicalParent = await preparePrivateStagingParent(parent, privateRootAuthority);
+    const staging = new OwnedSnapshotStaging(canonicalParent, snapshotId, randomUUID());
+    let rootCreated = false;
+    try {
+      await assertMissing(staging.#preparingRoot);
+      await assertMissing(staging.#publishedRoot);
+      await assertMissing(staging.#cleanupRoot);
+      await assertMissing(staging.#ownerCleanupFile);
+      await mkdir(staging.#preparingRoot, { mode: 0o700 });
+      rootCreated = true;
+      staging.#identity = await readDirectoryIdentity(staging.#preparingRoot);
+      try {
+        await verifyPrivateStagingDirectory(staging.#preparingRoot, privateRootAuthority);
+      } catch (verificationError) {
+        throw new SessionSnapshotError('unsafe_source', 'Session snapshot staging root is unsafe', {
+          cause: verificationError,
+          details: { phase: 'staging' },
+        });
+      }
+      const record: SnapshotOwnerRecord = {
+        schemaVersion: SESSION_SNAPSHOT_STAGING_SCHEMA_VERSION,
+        snapshotId: staging.#snapshotId,
+        ownerToken: staging.#ownerToken,
+        rootDev: staging.#identity.dev.toString(),
+        rootIno: staging.#identity.ino.toString(),
+      };
+      staging.#owner = await writeOwnerRecord(
+        staging.#ownerFile,
+        staging.#ownerCleanupFile,
+        record,
+      );
+      return staging;
+    } catch (error) {
+      if (rootCreated && staging.#identity) {
+        try {
+          await removeDirectoryBoundToIdentity({
+            parent: canonicalParent,
+            root: staging.#preparingRoot,
+            cleanupRoot: staging.#cleanupRoot,
+            identity: staging.#identity,
+          });
+        } catch (cleanupError) {
+          throw cleanupFailure(new AggregateError([error, cleanupError]));
+        }
+      } else if (rootCreated) {
+        throw cleanupFailure(
+          new AggregateError([error, new Error('Snapshot root identity is unavailable')]),
+        );
+      }
+      if (error instanceof SessionSnapshotError) throw error;
+      throw new SessionSnapshotError('io_failure', 'Unable to create Session snapshot staging', {
+        cause: error,
+        details: { phase: 'staging' },
+      });
+    }
+  }
+
+  async publish(): Promise<PublishedSnapshotStaging> {
+    if (this.#published) {
+      throw new SessionSnapshotError(
+        'io_failure',
+        'Session snapshot staging is already published',
+        {
+          details: { phase: 'publication' },
+        },
+      );
+    }
+    try {
+      if (!this.#identity || !this.#owner) {
+        throw new Error('Snapshot ownership is unavailable');
+      }
+      await assertOwnedRoot(this.#preparingRoot, this.#owner, this.#identity);
+      await rename(this.#preparingRoot, this.#publishedRoot);
+      this.#published = true;
+      const identity = await readDirectoryIdentity(this.#publishedRoot);
+      if (!sameFilesystemIdentity(identity, this.#identity)) {
+        throw new Error('Published root identity changed');
+      }
+      await assertOwnerRecord(this.#owner);
+      return {
+        parent: dirname(this.#publishedRoot),
+        root: this.#publishedRoot,
+        cleanupRoot: this.#cleanupRoot,
+        stateRoot: join(this.#publishedRoot, 'state'),
+        workspaceRoot: join(this.#publishedRoot, 'workspace'),
+        owner: this.#owner,
+        identity,
+      };
+    } catch (error) {
+      throw new SessionSnapshotError('io_failure', 'Unable to publish Session snapshot staging', {
+        cause: error,
+        details: { phase: 'publication' },
+      });
+    }
+  }
+
+  async discard(): Promise<void> {
+    const root = this.#published ? this.#publishedRoot : this.#preparingRoot;
+    try {
+      if (!this.#identity || !this.#owner) {
+        throw new Error('Snapshot ownership is unavailable');
+      }
+      await removeOwnedSnapshotDirectory({
+        parent: dirname(root),
+        root,
+        cleanupRoot: this.#cleanupRoot,
+        owner: this.#owner,
+        identity: this.#identity,
+      });
+    } catch (error) {
+      throw cleanupFailure(error);
+    }
+  }
+}
+
+class OwnedPreparedSessionBundleHandle implements PreparedSessionBundleHandle {
+  readonly snapshot: PreparedSessionBundleSnapshot;
+  readonly workspace: SessionSnapshotWorkspacePreparation;
+  readonly policyVersion: typeof SESSION_SNAPSHOT_POLICY_VERSION;
+  readonly #staging: PublishedSnapshotStaging;
+  #releaseTask: Promise<void> | undefined;
+  #released = false;
+
+  constructor(
+    staging: PublishedSnapshotStaging,
+    stateIdentity: OpaqueStateIdentityDescriptor,
+    workspace: SessionSnapshotWorkspacePreparation,
+    policyVersion: typeof SESSION_SNAPSHOT_POLICY_VERSION,
+  ) {
+    this.#staging = staging;
+    this.snapshot = Object.freeze({
+      stateRoot: staging.stateRoot,
+      workspaceRoot: staging.workspaceRoot,
+      stateIdentity: Object.freeze(copyOpaqueStateIdentityDescriptor(stateIdentity)),
+    });
+    this.workspace = Object.freeze({ ...workspace });
+    this.policyVersion = policyVersion;
+  }
+
+  async release(): Promise<void> {
+    if (this.#released) return;
+    if (this.#releaseTask) return this.#releaseTask;
+    const task = this.#releaseOnce();
+    this.#releaseTask = task;
+    try {
+      await task;
+      this.#released = true;
+    } finally {
+      if (!this.#released) this.#releaseTask = undefined;
+    }
+  }
+
+  async #releaseOnce(): Promise<void> {
+    try {
+      await removeOwnedSnapshotDirectory({
+        parent: this.#staging.parent,
+        root: this.#staging.root,
+        cleanupRoot: this.#staging.cleanupRoot,
+        owner: this.#staging.owner,
+        identity: this.#staging.identity,
+      });
+    } catch (error) {
+      throw cleanupFailure(error);
+    }
+  }
+}
+
+function decodeWorkspaceEntry(
+  entry: SessionSnapshotWorkspaceEntry,
+):
+  | { readonly kind: 'valid'; readonly segments: readonly string[]; readonly basename: string }
+  | { readonly kind: 'reject'; readonly category: 'unsafe_path' | 'unsupported_entry' } {
+  if (entry.kind !== 'file' && entry.kind !== 'directory') {
+    return { kind: 'reject', category: 'unsupported_entry' };
+  }
+  if (
+    typeof entry.relativePath !== 'string' ||
+    entry.relativePath.length === 0 ||
+    entry.relativePath.includes('\\') ||
+    entry.relativePath.includes('\0') ||
+    entry.relativePath.startsWith('/') ||
+    entry.relativePath.endsWith('/')
+  ) {
+    return { kind: 'reject', category: 'unsafe_path' };
+  }
+  const segments = entry.relativePath.split('/');
+  if (segments.some((segment) => segment.length === 0 || segment === '.' || segment === '..')) {
+    return { kind: 'reject', category: 'unsafe_path' };
+  }
+  return { kind: 'valid', segments, basename: segments.at(-1)! };
+}
+
+function isKnownSecretPath(lowerSegments: readonly string[], lowerName: string): boolean {
+  if (SENSITIVE_WORKSPACE_FILE_PATTERNS.some((pattern) => pattern.test(lowerName))) return true;
+  if (
+    lowerSegments.includes('.ssh') ||
+    lowerName === 'service-account.json' ||
+    lowerName === 'service-account-key.json'
+  ) {
+    return true;
+  }
+  return (
+    (lowerSegments.at(-2) === '.docker' && lowerName === 'config.json') ||
+    (lowerSegments.at(-2) === '.aws' && lowerName === 'credentials') ||
+    (lowerSegments.at(-2) === '.cargo' && lowerName === 'credentials') ||
+    (lowerSegments.at(-2) === '.kube' && lowerName === 'config') ||
+    (lowerSegments.at(-2) === 'gcloud' &&
+      lowerSegments.at(-3) === '.config' &&
+      lowerName === 'application_default_credentials.json')
+  );
+}
+
+function requireMakaSessionId(value: unknown): string {
+  if (typeof value !== 'string' || !isSafeSessionId(value)) {
+    throw new SessionSnapshotError('invalid_input', 'Maka Session identity is invalid', {
+      details: { phase: 'admission' },
+    });
+  }
+  return value;
+}
+
+function requireSnapshotId(value: unknown): string {
+  if (typeof value !== 'string' || !SNAPSHOT_ID_PATTERN.test(value)) {
+    throw new SessionSnapshotError('io_failure', 'Session snapshot identity allocation failed', {
+      details: { phase: 'staging' },
+    });
+  }
+  return value;
+}
+
+function normalizeWorkspacePreparation(
+  value: SessionSnapshotWorkspacePreparation,
+): SessionSnapshotWorkspacePreparation {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new SessionSnapshotError('io_failure', 'Workspace snapshot result is invalid', {
+      details: { phase: 'workspace' },
+    });
+  }
+  for (const count of [value.includedEntries, value.excludedEntries, value.payloadBytes]) {
+    if (!Number.isSafeInteger(count) || count < 0) {
+      throw new SessionSnapshotError('io_failure', 'Workspace snapshot result is invalid', {
+        details: { phase: 'workspace' },
+      });
+    }
+  }
+  const excludedEntriesByCategory = normalizeExclusionCounts(value.excludedEntriesByCategory);
+  const categorizedExclusions = Object.values(excludedEntriesByCategory).reduce(
+    (total, count) => total + count,
+    0,
+  );
+  if (categorizedExclusions !== value.excludedEntries) {
+    throw new SessionSnapshotError('io_failure', 'Workspace snapshot result is invalid', {
+      details: { phase: 'workspace' },
+    });
+  }
+  return {
+    includedEntries: value.includedEntries,
+    excludedEntries: value.excludedEntries,
+    excludedEntriesByCategory,
+    payloadBytes: value.payloadBytes,
+  };
+}
+
+const WORKSPACE_EXCLUSION_CATEGORIES = [
+  'dependency_tree',
+  'source_control',
+  'cache',
+  'log',
+  'runtime_scratch',
+] as const satisfies readonly SessionSnapshotWorkspaceExclusionCategory[];
+
+function normalizeExclusionCounts(
+  value: Readonly<Record<SessionSnapshotWorkspaceExclusionCategory, number>>,
+): Readonly<Record<SessionSnapshotWorkspaceExclusionCategory, number>> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new SessionSnapshotError('io_failure', 'Workspace snapshot result is invalid', {
+      details: { phase: 'workspace' },
+    });
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (
+    keys.length !== WORKSPACE_EXCLUSION_CATEGORIES.length ||
+    keys.some(
+      (key) =>
+        !WORKSPACE_EXCLUSION_CATEGORIES.includes(key as SessionSnapshotWorkspaceExclusionCategory),
+    )
+  ) {
+    throw new SessionSnapshotError('io_failure', 'Workspace snapshot result is invalid', {
+      details: { phase: 'workspace' },
+    });
+  }
+  const normalized = Object.fromEntries(
+    WORKSPACE_EXCLUSION_CATEGORIES.map((category) => {
+      const count = record[category];
+      if (!Number.isSafeInteger(count) || (count as number) < 0) {
+        throw new SessionSnapshotError('io_failure', 'Workspace snapshot result is invalid', {
+          details: { phase: 'workspace' },
+        });
+      }
+      return [category, count];
+    }),
+  ) as Record<SessionSnapshotWorkspaceExclusionCategory, number>;
+  return Object.freeze(normalized);
+}
+
+function createCancellation(
+  input: PrepareQuiescentSessionSnapshotInput,
+  now: () => number,
+): {
+  readonly value: SessionSnapshotCancellation;
+  assertActive(): void;
+  close(): void;
+} {
+  if (
+    input.deadlineAt !== undefined &&
+    (!Number.isSafeInteger(input.deadlineAt) || input.deadlineAt < 0)
+  ) {
+    throw new SessionSnapshotError('invalid_input', 'Session snapshot deadline is invalid', {
+      details: { phase: 'admission' },
+    });
+  }
+  const controller = new AbortController();
+  const abort = () => controller.abort();
+  input.signal?.addEventListener('abort', abort, { once: true });
+  const remaining = input.deadlineAt === undefined ? undefined : input.deadlineAt - now();
+  const timeout =
+    remaining === undefined || remaining <= 0
+      ? undefined
+      : setTimeout(abort, Math.min(remaining, 2_147_483_647));
+  timeout?.unref();
+  if (input.signal?.aborted || (remaining !== undefined && remaining <= 0)) abort();
+  const value = Object.freeze({
+    signal: controller.signal,
+    ...(input.deadlineAt === undefined ? {} : { deadlineAt: input.deadlineAt }),
+  });
+  return {
+    value,
+    assertActive: () => {
+      if (controller.signal.aborted) {
+        throw new SessionSnapshotError(
+          'snapshot_cancelled',
+          'Session snapshot preparation was cancelled',
+          { details: { phase: 'admission' } },
+        );
+      }
+    },
+    close: () => {
+      if (timeout) clearTimeout(timeout);
+      input.signal?.removeEventListener('abort', abort);
+    },
+  };
+}
+
+async function preparePrivateStagingParent(
+  path: string,
+  authority: SessionSnapshotPrivateStagingRootAuthority | undefined,
+): Promise<string> {
+  try {
+    await mkdir(path, { recursive: true, mode: 0o700 });
+    const canonical = await realpath(path);
+    await verifyPrivateStagingDirectory(canonical, authority);
+    return canonical;
+  } catch (error) {
+    throw new SessionSnapshotError('unsafe_source', 'Session snapshot staging root is unsafe', {
+      cause: error,
+      details: { phase: 'staging' },
+    });
+  }
+}
+
+async function verifyPrivateStagingDirectory(
+  path: string,
+  authority: SessionSnapshotPrivateStagingRootAuthority | undefined,
+): Promise<void> {
+  const canonical = await realpath(path);
+  if (canonical !== path) throw new Error('Staging directory is not canonical');
+  const info = await lstat(canonical, { bigint: true });
+  if (!info.isDirectory() || info.isSymbolicLink()) throw new Error('Staging parent is invalid');
+  if (process.platform === 'win32' && !authority) {
+    throw new Error('A Windows ACL verifier is required for the staging parent');
+  }
+  if (process.platform !== 'win32') {
+    const permissions = Number(info.mode & 0o777n);
+    if ((permissions & 0o077) !== 0) {
+      throw new Error('Staging parent is accessible outside its owner');
+    }
+    const currentUserId = process.getuid?.();
+    if (currentUserId !== undefined && info.uid !== BigInt(currentUserId)) {
+      throw new Error('Staging parent has a different filesystem owner');
+    }
+  }
+  if (authority) {
+    const verification = await authority.verifyPrivateStagingRoot({ canonicalPath: canonical });
+    if (
+      !verification ||
+      typeof verification.canonicalPath !== 'string' ||
+      verification.canonicalPath !== canonical
+    ) {
+      throw new Error('Staging parent privacy verification was bound to a different path');
+    }
+  }
+}
+
+async function assertMissing(path: string): Promise<void> {
+  try {
+    await lstat(path);
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) return;
+    throw error;
+  }
+  throw new Error('Snapshot staging identity already exists');
+}
+
+async function writeOwnerRecord(
+  path: string,
+  cleanupPath: string,
+  record: SnapshotOwnerRecord,
+): Promise<SnapshotOwnerBinding> {
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let identity: FilesystemIdentity | undefined;
+  let failure: unknown;
+  try {
+    handle = await open(
+      path,
+      fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | NO_FOLLOW_OPEN_FLAG,
+      0o600,
+    );
+    const info = await handle.stat({ bigint: true });
+    if (!info.isFile() || info.isSymbolicLink() || info.nlink !== 1n) {
+      throw new Error('Snapshot ownership record is not a private file');
+    }
+    identity = { dev: info.dev, ino: info.ino };
+    await handle.writeFile(`${JSON.stringify(record)}\n`, 'utf8');
+    if (process.platform !== 'win32') await handle.chmod(0o600);
+    await handle.sync();
+  } catch (error) {
+    failure = error;
+  }
+  if (handle) {
+    try {
+      await handle.close();
+    } catch (error) {
+      failure = failure === undefined ? error : new AggregateError([failure, error]);
+    }
+  }
+  if (!identity) {
+    if (failure !== undefined) throw failure;
+    throw new Error('Snapshot ownership record identity is unavailable');
+  }
+  const binding = { path, cleanupPath, record, identity };
+  if (failure === undefined) {
+    try {
+      await assertOwnerRecord(binding);
+      return binding;
+    } catch (error) {
+      failure = error;
+    }
+  }
+  try {
+    await removeFileBoundToIdentity({
+      parent: dirname(path),
+      root: path,
+      cleanupRoot: cleanupPath,
+      identity,
+    });
+  } catch (cleanupError) {
+    throw cleanupFailure(new AggregateError([failure, cleanupError]));
+  }
+  throw failure;
+}
+
+async function assertPreparedRoot(path: string, label: 'state' | 'workspace'): Promise<void> {
+  let info;
+  try {
+    info = await lstat(path, { bigint: true });
+  } catch (error) {
+    throw new SessionSnapshotError('io_failure', `Prepared ${label} snapshot is unavailable`, {
+      cause: error,
+      details: { phase: label },
+    });
+  }
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new SessionSnapshotError('unsafe_source', `Prepared ${label} snapshot is unsafe`, {
+      details: { phase: label },
+    });
+  }
+}
+
+async function assertOwnerRecord(
+  binding: SnapshotOwnerBinding,
+  path = binding.path,
+): Promise<void> {
+  const handle = await open(path, fsConstants.O_RDONLY | NO_FOLLOW_OPEN_FLAG);
+  try {
+    const info = await handle.stat({ bigint: true });
+    if (
+      !info.isFile() ||
+      info.isSymbolicLink() ||
+      info.nlink !== 1n ||
+      info.size > BigInt(MAX_OWNER_RECORD_BYTES) ||
+      !sameFilesystemIdentity({ dev: info.dev, ino: info.ino }, binding.identity)
+    ) {
+      throw new Error('Snapshot ownership record is invalid');
+    }
+    const value = JSON.parse(await handle.readFile('utf8')) as unknown;
+    if (!sameOwnerRecord(value, binding.record)) {
+      throw new Error('Snapshot ownership record changed');
+    }
+  } finally {
+    await handle.close();
+  }
+  const pathIdentity = await readFileIdentity(path);
+  if (!sameFilesystemIdentity(pathIdentity, binding.identity)) {
+    throw new Error('Snapshot ownership record path changed');
+  }
+}
+
+async function assertOwnedRoot(
+  root: string,
+  owner: SnapshotOwnerBinding,
+  identity: FilesystemIdentity,
+): Promise<void> {
+  const actual = await readDirectoryIdentity(root);
+  if (!sameFilesystemIdentity(actual, identity)) {
+    throw new Error('Published Session snapshot root identity changed');
+  }
+  if (
+    owner.record.rootDev !== identity.dev.toString() ||
+    owner.record.rootIno !== identity.ino.toString()
+  ) {
+    throw new Error('Snapshot ownership record is bound to another root');
+  }
+  await assertOwnerRecord(owner);
+}
+
+async function removeOwnedSnapshotDirectory(input: {
+  parent: string;
+  root: string;
+  cleanupRoot: string;
+  owner: SnapshotOwnerBinding;
+  identity: FilesystemIdentity;
+}): Promise<void> {
+  if (
+    dirname(input.root) !== input.parent ||
+    dirname(input.cleanupRoot) !== input.parent ||
+    dirname(input.owner.path) !== input.parent ||
+    dirname(input.owner.cleanupPath) !== input.parent ||
+    input.root === input.cleanupRoot
+  ) {
+    throw new Error('Session snapshot cleanup path escaped its owner');
+  }
+  const cleanupIdentity = await readOptionalDirectoryIdentity(input.cleanupRoot);
+  const rootIdentity = await readOptionalDirectoryIdentity(input.root);
+  if (!cleanupIdentity && !rootIdentity) {
+    await removeOwnerRecord(input.owner);
+    return;
+  }
+  await assertOwnerRecord(input.owner);
+  if (cleanupIdentity) {
+    if (rootIdentity) {
+      throw new Error('Session snapshot cleanup paths conflict');
+    }
+    if (!sameFilesystemIdentity(cleanupIdentity, input.identity)) {
+      throw new Error('Session snapshot cleanup root identity changed');
+    }
+    await assertOwnedRoot(input.cleanupRoot, input.owner, input.identity);
+    await rm(input.cleanupRoot, { recursive: true, force: false });
+    await removeOwnerRecord(input.owner);
+    return;
+  }
+  await assertOwnedRoot(input.root, input.owner, input.identity);
+  await rename(input.root, input.cleanupRoot);
+  await assertOwnedRoot(input.cleanupRoot, input.owner, input.identity);
+  await rm(input.cleanupRoot, { recursive: true, force: false });
+  await removeOwnerRecord(input.owner);
+}
+
+async function removeOwnerRecord(owner: SnapshotOwnerBinding): Promise<void> {
+  const cleanupIdentity = await readOptionalFileIdentity(owner.cleanupPath);
+  const ownerIdentity = await readOptionalFileIdentity(owner.path);
+  if (cleanupIdentity) {
+    if (ownerIdentity) throw new Error('Snapshot ownership cleanup paths conflict');
+    if (!sameFilesystemIdentity(cleanupIdentity, owner.identity)) {
+      throw new Error('Snapshot ownership cleanup file changed');
+    }
+    await assertOwnerRecord(owner, owner.cleanupPath);
+    await rm(owner.cleanupPath, { force: false });
+    return;
+  }
+  if (!ownerIdentity) return;
+  if (!sameFilesystemIdentity(ownerIdentity, owner.identity)) {
+    throw new Error('Snapshot ownership record path changed');
+  }
+  await assertOwnerRecord(owner);
+  await rename(owner.path, owner.cleanupPath);
+  await assertOwnerRecord(owner, owner.cleanupPath);
+  await rm(owner.cleanupPath, { force: false });
+}
+
+async function removeDirectoryBoundToIdentity(input: {
+  parent: string;
+  root: string;
+  cleanupRoot: string;
+  identity: FilesystemIdentity;
+}): Promise<void> {
+  if (
+    dirname(input.root) !== input.parent ||
+    dirname(input.cleanupRoot) !== input.parent ||
+    input.root === input.cleanupRoot
+  ) {
+    throw new Error('Session snapshot cleanup path escaped its owner');
+  }
+  const cleanupIdentity = await readOptionalDirectoryIdentity(input.cleanupRoot);
+  const rootIdentity = await readOptionalDirectoryIdentity(input.root);
+  if (cleanupIdentity) {
+    if (rootIdentity) throw new Error('Session snapshot cleanup paths conflict');
+    if (!sameFilesystemIdentity(cleanupIdentity, input.identity)) {
+      throw new Error('Session snapshot cleanup root identity changed');
+    }
+    await rm(input.cleanupRoot, { recursive: true, force: false });
+    return;
+  }
+  if (!rootIdentity) return;
+  if (!sameFilesystemIdentity(rootIdentity, input.identity)) {
+    throw new Error('Session snapshot root identity changed');
+  }
+  await rename(input.root, input.cleanupRoot);
+  const renamedIdentity = await readDirectoryIdentity(input.cleanupRoot);
+  if (!sameFilesystemIdentity(renamedIdentity, input.identity)) {
+    throw new Error('Session snapshot cleanup root identity changed');
+  }
+  await rm(input.cleanupRoot, { recursive: true, force: false });
+}
+
+async function removeFileBoundToIdentity(input: {
+  parent: string;
+  root: string;
+  cleanupRoot: string;
+  identity: FilesystemIdentity;
+}): Promise<void> {
+  if (
+    dirname(input.root) !== input.parent ||
+    dirname(input.cleanupRoot) !== input.parent ||
+    input.root === input.cleanupRoot
+  ) {
+    throw new Error('Session snapshot file cleanup path escaped its owner');
+  }
+  const cleanupIdentity = await readOptionalFileIdentity(input.cleanupRoot);
+  const rootIdentity = await readOptionalFileIdentity(input.root);
+  if (cleanupIdentity) {
+    if (rootIdentity) throw new Error('Session snapshot file cleanup paths conflict');
+    if (!sameFilesystemIdentity(cleanupIdentity, input.identity)) {
+      throw new Error('Session snapshot file cleanup identity changed');
+    }
+    await rm(input.cleanupRoot, { force: false });
+    return;
+  }
+  if (!rootIdentity) return;
+  if (!sameFilesystemIdentity(rootIdentity, input.identity)) {
+    throw new Error('Session snapshot file identity changed');
+  }
+  await rename(input.root, input.cleanupRoot);
+  const renamedIdentity = await readFileIdentity(input.cleanupRoot);
+  if (!sameFilesystemIdentity(renamedIdentity, input.identity)) {
+    throw new Error('Session snapshot file cleanup identity changed');
+  }
+  await rm(input.cleanupRoot, { force: false });
+}
+
+async function readOptionalDirectoryIdentity(
+  path: string,
+): Promise<FilesystemIdentity | undefined> {
+  try {
+    return await readDirectoryIdentity(path);
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) return undefined;
+    throw error;
+  }
+}
+
+async function readOptionalFileIdentity(path: string): Promise<FilesystemIdentity | undefined> {
+  try {
+    return await readFileIdentity(path);
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) return undefined;
+    throw error;
+  }
+}
+
+async function readDirectoryIdentity(path: string): Promise<FilesystemIdentity> {
+  const info = await lstat(path, { bigint: true });
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error('Session snapshot root is not a directory');
+  }
+  return { dev: info.dev, ino: info.ino };
+}
+
+async function readFileIdentity(path: string): Promise<FilesystemIdentity> {
+  const info = await lstat(path, { bigint: true });
+  if (!info.isFile() || info.isSymbolicLink() || info.nlink !== 1n) {
+    throw new Error('Session snapshot ownership record is not a private file');
+  }
+  return { dev: info.dev, ino: info.ino };
+}
+
+function sameFilesystemIdentity(left: FilesystemIdentity, right: FilesystemIdentity): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function sameOwnerRecord(value: unknown, expected: SnapshotOwnerRecord): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    Object.keys(record).length === 5 &&
+    record.schemaVersion === expected.schemaVersion &&
+    record.snapshotId === expected.snapshotId &&
+    record.ownerToken === expected.ownerToken &&
+    record.rootDev === expected.rootDev &&
+    record.rootIno === expected.rootIno
+  );
+}
+
+async function cleanupAfterPreparationFailure(
+  staging: OwnedSnapshotStaging,
+  primaryError: unknown,
+): Promise<never> {
+  try {
+    await staging.discard();
+  } catch (cleanupError) {
+    throw cleanupFailure(new AggregateError([primaryError, cleanupError]));
+  }
+  throw primaryError;
+}
+
+function normalizePreparationError(error: unknown, signal: AbortSignal): SessionSnapshotError {
+  if (error instanceof SessionSnapshotError) return error;
+  if (signal.aborted || isAbortError(error)) {
+    return new SessionSnapshotError(
+      'snapshot_cancelled',
+      'Session snapshot preparation was cancelled',
+      { details: { phase: 'admission' } },
+    );
+  }
+  return new SessionSnapshotError('io_failure', 'Session snapshot preparation failed', {
+    cause: error,
+  });
+}
+
+function cleanupFailure(cause: unknown): SessionSnapshotError {
+  return new SessionSnapshotError('cleanup_failed', 'Session snapshot cleanup failed', {
+    cause,
+    details: { phase: 'cleanup' },
+  });
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code
+  );
+}

--- a/packages/storage/src/quiescent-session-snapshot.ts
+++ b/packages/storage/src/quiescent-session-snapshot.ts
@@ -59,19 +59,24 @@ export interface SessionSnapshotWorkspacePolicy {
 
 const INCLUDE = Object.freeze({ kind: 'include' } as const);
 
-// Keep this list aligned with the workspace measurement/exclusion rules introduced by #1353.
-const SENSITIVE_WORKSPACE_FILE_PATTERNS = [
+// This fail-closed rejection set is deliberately narrower than the workspace
+// measurement rules introduced by #1353. Snapshot rejection is reserved for
+// names that identify known secret material; public certificate encodings and
+// other ambiguous formats are not rejected by extension alone.
+const KNOWN_SECRET_WORKSPACE_FILE_PATTERNS = [
   /^\.env(?:\..*)?$/i,
   /^\.(?:npmrc|netrc|pypirc|terraformrc)$/i,
   /^\.git-credentials(?:\.lock)?$/i,
   /^(?:credentials?|secrets?)(?:\..*)?$/i,
   /(?:^|[-_.])(?:id_(?:rsa|dsa|ecdsa|ed25519)|private[-_.]?key)(?:$|[-_.])/i,
-  /\.(?:key|pem|p12|pfx|der|crt|cer|csr|log)$/i,
+  /\.(?:key|p12|pfx)$/i,
 ] as const;
 
 /**
- * V1 portable-workspace policy. It intentionally classifies names only; the
- * filesystem preparer remains responsible for rejecting symlinks, hard links,
+ * V1 portable-workspace policy. The coordinator pins this exact policy, while
+ * the trusted filesystem preparer is its enforcement point: the coordinator
+ * does not re-traverse or attest the prepared destination. The preparer remains
+ * responsible for applying every decision and rejecting symlinks, hard links,
  * special files, path races, case conflicts, and quota violations.
  */
 export const SESSION_SNAPSHOT_WORKSPACE_POLICY_V1: SessionSnapshotWorkspacePolicy = Object.freeze({
@@ -96,9 +101,6 @@ export const SESSION_SNAPSHOT_WORKSPACE_POLICY_V1: SessionSnapshotWorkspacePolic
     ) {
       return { kind: 'exclude', category: 'cache' };
     }
-    if (entry.kind === 'file' && isKnownSecretPath(lowerSegments, lowerName)) {
-      return { kind: 'reject', category: 'known_secret_file' };
-    }
     if (
       lowerSegments.includes('logs') ||
       lowerSegments.includes('.logs') ||
@@ -108,6 +110,9 @@ export const SESSION_SNAPSHOT_WORKSPACE_POLICY_V1: SessionSnapshotWorkspacePolic
     }
     if (lowerSegments.includes('.maka-runtime') || lowerSegments.includes('.maka-activation')) {
       return { kind: 'exclude', category: 'runtime_scratch' };
+    }
+    if (entry.kind === 'file' && isKnownSecretPath(lowerSegments, lowerName)) {
+      return { kind: 'reject', category: 'known_secret_file' };
     }
     return INCLUDE;
   },
@@ -164,8 +169,11 @@ export interface SessionSnapshotWorkspacePreparation {
 
 export interface SessionSnapshotWorkspacePreparer {
   /**
-   * Creates the exact, previously absent root, applies every supplied policy
-   * decision without downgrading it, and closes every source/destination handle.
+   * Trusted enforcement point for the supplied workspace policy. Creates the
+   * exact, previously absent root, applies every policy decision without
+   * downgrading it, and closes every source/destination handle. The coordinator
+   * validates the returned root and bounded counters, but does not independently
+   * traverse the result to prove that the policy was applied.
    */
   prepareWorkspace(input: {
     readonly makaSessionId: string;
@@ -198,7 +206,12 @@ export interface PreparedSessionBundleHandle {
   readonly snapshot: PreparedSessionBundleSnapshot;
   readonly policyVersion: typeof SESSION_SNAPSHOT_POLICY_VERSION;
   readonly workspace: SessionSnapshotWorkspacePreparation;
-  /** Idempotent after successful cleanup; failures remain retryable. */
+  /**
+   * Idempotent after successful cleanup; failures remain retryable. Path and
+   * identity checks fail closed on replacements observable before deletion, but
+   * do not defend against an adversarial same-principal replacement in the final
+   * path-based filesystem-operation window.
+   */
   release(): Promise<void>;
 }
 
@@ -252,7 +265,12 @@ export class SessionSnapshotError extends Error {
 }
 
 export interface FileQuiescentSessionSnapshotCoordinatorOptions {
-  /** Private control-plane directory outside live state and workspace roots. */
+  /**
+   * Private control-plane directory outside live state and workspace roots.
+   * Code running as the same OS principal and able to mutate this parent is in
+   * the trusted computing boundary; Node's path-based recursive removal cannot
+   * make an adversarial final-check-to-delete race impossible.
+   */
   readonly stagingParent: string;
   readonly quiescence: SessionSnapshotQuiescenceAuthority;
   readonly state: SessionSnapshotStatePreparer;
@@ -635,7 +653,7 @@ function decodeWorkspaceEntry(
 }
 
 function isKnownSecretPath(lowerSegments: readonly string[], lowerName: string): boolean {
-  if (SENSITIVE_WORKSPACE_FILE_PATTERNS.some((pattern) => pattern.test(lowerName))) return true;
+  if (KNOWN_SECRET_WORKSPACE_FILE_PATTERNS.some((pattern) => pattern.test(lowerName))) return true;
   if (
     lowerSegments.includes('.ssh') ||
     lowerName === 'service-account.json' ||

--- a/packages/storage/src/quiescent-session-snapshot.ts
+++ b/packages/storage/src/quiescent-session-snapshot.ts
@@ -34,6 +34,7 @@ export const SESSION_SNAPSHOT_STAGING_SCHEMA_VERSION = 1 as const;
 
 const SNAPSHOT_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const CONFIRMATION_GRANT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/u;
 const MAX_OWNER_RECORD_BYTES = 1_024;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const NO_FOLLOW_OPEN_FLAG = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
@@ -45,7 +46,10 @@ export type SessionSnapshotWorkspaceExclusionCategory =
   | 'source_control'
   | 'cache'
   | 'log'
-  | 'runtime_scratch';
+  | 'runtime_scratch'
+  | 'confirmed_secret_path';
+
+export type SessionSnapshotWorkspaceConfirmationCategory = 'suspected_secret_path';
 
 export type SessionSnapshotWorkspaceRejectionCategory =
   | 'known_secret_file'
@@ -57,6 +61,12 @@ export type SessionSnapshotWorkspacePolicyDecision =
   | {
       readonly kind: 'exclude';
       readonly category: SessionSnapshotWorkspaceExclusionCategory;
+    }
+  | {
+      readonly kind: 'confirm';
+      readonly category: SessionSnapshotWorkspaceConfirmationCategory;
+      /** Normalized topmost directory whose complete subtree the decision covers. */
+      readonly confirmationPath: string;
     }
   | {
       readonly kind: 'reject';
@@ -73,7 +83,9 @@ export interface SessionSnapshotWorkspacePolicy {
   readonly version: typeof SESSION_SNAPSHOT_POLICY_VERSION;
   /**
    * Receives normalized relative paths. A preparer must stop descending as
-   * soon as a directory is excluded; descendant entries are not counted.
+   * soon as a directory is excluded, including by a confirmed exclusion;
+   * descendant entries are not counted. A confirmed include permits descent
+   * but does not override later high-confidence secret rejections.
    */
   classify(entry: SessionSnapshotWorkspaceEntry): SessionSnapshotWorkspacePolicyDecision;
 }
@@ -85,12 +97,8 @@ const INCLUDE = Object.freeze({ kind: 'include' } as const);
 // names that identify known secret material; public certificate encodings and
 // other ambiguous formats are not rejected by extension alone.
 const PUBLIC_ENV_TEMPLATE_PATTERN = /^\.env\.(?:example|sample|template)$/i;
-const KNOWN_SECRET_WORKSPACE_DIRECTORY_NAMES = new Set([
-  '.ssh',
-  'credentials',
-  'private',
-  'secrets',
-]);
+const KNOWN_SECRET_WORKSPACE_DIRECTORY_NAMES = new Set(['.ssh']);
+const SUSPECTED_SECRET_WORKSPACE_DIRECTORY_NAMES = new Set(['credentials', 'private', 'secrets']);
 const KNOWN_SECRET_WORKSPACE_FILE_PATTERNS = [
   /^\.env(?:\..*)?$/i,
   /^\.(?:npmrc|netrc|pypirc|terraformrc)$/i,
@@ -135,6 +143,10 @@ export const SESSION_SNAPSHOT_WORKSPACE_POLICY_V1: SessionSnapshotWorkspacePolic
     }
     if (isKnownSecretEntry(entry.kind, lowerSegments, lowerName)) {
       return { kind: 'reject', category: 'known_secret_file' };
+    }
+    const confirmationPath = findSuspectedSecretDirectoryPath(entry.kind, segments, lowerSegments);
+    if (confirmationPath !== undefined) {
+      return { kind: 'confirm', category: 'suspected_secret_path', confirmationPath };
     }
     if (
       lowerSegments.includes('logs') ||
@@ -196,11 +208,50 @@ export interface SessionSnapshotWorkspacePreparation {
   readonly payloadBytes: number;
 }
 
+export type SessionSnapshotWorkspaceConfirmationAction = 'include' | 'exclude';
+
+/**
+ * Trusted control-plane lookup for a previously recorded explicit user choice.
+ *
+ * Implementations must authenticate the principal, verify ownership of the
+ * Maka Session, and bind the grant to the exact policy version, normalized
+ * confirmation path and current Workspace source revision/digest. Decisions
+ * live outside Session state, workspaces, staging roots and Session Bundles.
+ * This lookup must not wait for interactive user input while the Session is
+ * quiescent; an absent or stale decision returns `undefined` and fails snapshot
+ * preparation closed.
+ */
+export interface SessionSnapshotWorkspaceConfirmationAuthority {
+  resolveConfirmation(input: {
+    readonly makaSessionId: string;
+    readonly confirmationGrantId: string;
+    readonly policyVersion: typeof SESSION_SNAPSHOT_POLICY_VERSION;
+    readonly category: SessionSnapshotWorkspaceConfirmationCategory;
+    readonly confirmationPath: string;
+    readonly cancellation: SessionSnapshotCancellation;
+  }): Promise<{ readonly action: SessionSnapshotWorkspaceConfirmationAction } | undefined>;
+}
+
+export interface SessionSnapshotWorkspaceConfirmationResolver {
+  /**
+   * Resolves the policy's confirmation decision into a final include/exclude
+   * decision. Repeated descendants of one confirmed directory reuse the same
+   * control-plane lookup for this preparation.
+   */
+  resolve(
+    entry: SessionSnapshotWorkspaceEntry,
+  ): Promise<
+    | { readonly kind: 'include' }
+    | { readonly kind: 'exclude'; readonly category: 'confirmed_secret_path' }
+  >;
+}
+
 export interface SessionSnapshotWorkspacePreparer {
   /**
    * Trusted enforcement point for the supplied workspace policy. Creates the
    * exact, previously absent root, applies every policy decision without
-   * downgrading it, and closes every source/destination handle. The coordinator
+   * downgrading it, resolves every `confirm` decision before copying or
+   * descending, and closes every source/destination handle. The coordinator
    * validates the returned root and bounded counters, but does not independently
    * traverse the result to prove that the policy was applied.
    */
@@ -208,6 +259,7 @@ export interface SessionSnapshotWorkspacePreparer {
     readonly makaSessionId: string;
     readonly destinationRoot: string;
     readonly policy: SessionSnapshotWorkspacePolicy;
+    readonly confirmation: SessionSnapshotWorkspaceConfirmationResolver;
     readonly cancellation: SessionSnapshotCancellation;
   }): Promise<SessionSnapshotWorkspacePreparation>;
 }
@@ -226,6 +278,8 @@ export interface SessionSnapshotPrivateStagingRootAuthority {
 
 export interface PrepareQuiescentSessionSnapshotInput {
   readonly makaSessionId: string;
+  /** Opaque, control-plane-issued grant; never persisted in the Session Bundle. */
+  readonly confirmationGrantId?: string;
   readonly signal?: AbortSignal;
   /** Absolute Unix time in milliseconds. */
   readonly deadlineAt?: number;
@@ -270,7 +324,9 @@ export type SessionSnapshotPhase =
 
 export interface SessionSnapshotErrorDetails {
   readonly phase?: SessionSnapshotPhase;
-  readonly policyCategory?: SessionSnapshotWorkspaceRejectionCategory;
+  readonly policyCategory?:
+    | SessionSnapshotWorkspaceRejectionCategory
+    | SessionSnapshotWorkspaceConfirmationCategory;
   readonly limit?: number;
   readonly observed?: number;
 }
@@ -304,6 +360,8 @@ export interface FileQuiescentSessionSnapshotCoordinatorOptions {
   readonly quiescence: SessionSnapshotQuiescenceAuthority;
   readonly state: SessionSnapshotStatePreparer;
   readonly workspace: SessionSnapshotWorkspacePreparer;
+  /** Optional control-plane lookup; suspected paths fail closed when absent. */
+  readonly confirmationAuthority?: SessionSnapshotWorkspaceConfirmationAuthority;
   /** Required on Windows; optional additional verification on POSIX platforms. */
   readonly privateStagingRootAuthority?: SessionSnapshotPrivateStagingRootAuthority;
   readonly now?: () => number;
@@ -321,6 +379,7 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
   readonly #quiescence: SessionSnapshotQuiescenceAuthority;
   readonly #state: SessionSnapshotStatePreparer;
   readonly #workspace: SessionSnapshotWorkspacePreparer;
+  readonly #confirmationAuthority: SessionSnapshotWorkspaceConfirmationAuthority | undefined;
   readonly #privateStagingRootAuthority: SessionSnapshotPrivateStagingRootAuthority | undefined;
   readonly #now: () => number;
   readonly #newSnapshotId: () => string;
@@ -336,6 +395,7 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
     this.#quiescence = options.quiescence;
     this.#state = options.state;
     this.#workspace = options.workspace;
+    this.#confirmationAuthority = options.confirmationAuthority;
     this.#privateStagingRootAuthority = options.privateStagingRootAuthority;
     this.#now = options.now ?? Date.now;
     this.#newSnapshotId = options.newSnapshotId ?? randomUUID;
@@ -343,6 +403,7 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
 
   async prepare(input: PrepareQuiescentSessionSnapshotInput): Promise<PreparedSessionBundleHandle> {
     const makaSessionId = requireMakaSessionId(input.makaSessionId);
+    const confirmationGrantId = requireOptionalConfirmationGrantId(input.confirmationGrantId);
     const cancellation = createCancellation(input, this.#now);
     let prepared: OwnedPreparedSessionBundleHandle | undefined;
     let operationStarted = false;
@@ -382,6 +443,12 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
                 makaSessionId,
                 destinationRoot: staging.workspaceRoot,
                 policy: SESSION_SNAPSHOT_WORKSPACE_POLICY_V1,
+                confirmation: createWorkspaceConfirmationResolver({
+                  makaSessionId,
+                  confirmationGrantId,
+                  authority: this.#confirmationAuthority,
+                  cancellation: cancellation.value,
+                }),
                 cancellation: cancellation.value,
               }),
             );
@@ -708,11 +775,115 @@ function isKnownSecretEntry(
   );
 }
 
+function findSuspectedSecretDirectoryPath(
+  kind: SessionSnapshotWorkspaceEntryKind,
+  segments: readonly string[],
+  lowerSegments: readonly string[],
+): string | undefined {
+  const directorySegmentCount =
+    kind === 'directory' ? lowerSegments.length : lowerSegments.length - 1;
+  const index = lowerSegments
+    .slice(0, directorySegmentCount)
+    .findIndex((segment) => SUSPECTED_SECRET_WORKSPACE_DIRECTORY_NAMES.has(segment));
+  return index < 0 ? undefined : segments.slice(0, index + 1).join('/');
+}
+
+function createWorkspaceConfirmationResolver(input: {
+  readonly makaSessionId: string;
+  readonly confirmationGrantId: string | undefined;
+  readonly authority: SessionSnapshotWorkspaceConfirmationAuthority | undefined;
+  readonly cancellation: SessionSnapshotCancellation;
+}): SessionSnapshotWorkspaceConfirmationResolver {
+  const resolutions = new Map<
+    string,
+    Promise<
+      | { readonly kind: 'include' }
+      | { readonly kind: 'exclude'; readonly category: 'confirmed_secret_path' }
+    >
+  >();
+
+  return Object.freeze({
+    resolve(entry: SessionSnapshotWorkspaceEntry) {
+      const decision = SESSION_SNAPSHOT_WORKSPACE_POLICY_V1.classify(entry);
+      if (decision.kind !== 'confirm') {
+        throw new TypeError('Workspace entry does not require control-plane confirmation');
+      }
+      const key = `${decision.category}\0${decision.confirmationPath}`;
+      const existing = resolutions.get(key);
+      if (existing !== undefined) return existing;
+      const resolution = resolveWorkspaceConfirmation({
+        ...input,
+        category: decision.category,
+        confirmationPath: decision.confirmationPath,
+      });
+      resolutions.set(key, resolution);
+      return resolution;
+    },
+  });
+}
+
+async function resolveWorkspaceConfirmation(input: {
+  readonly makaSessionId: string;
+  readonly confirmationGrantId: string | undefined;
+  readonly authority: SessionSnapshotWorkspaceConfirmationAuthority | undefined;
+  readonly category: SessionSnapshotWorkspaceConfirmationCategory;
+  readonly confirmationPath: string;
+  readonly cancellation: SessionSnapshotCancellation;
+}): Promise<
+  | { readonly kind: 'include' }
+  | { readonly kind: 'exclude'; readonly category: 'confirmed_secret_path' }
+> {
+  input.cancellation.signal.throwIfAborted();
+  if (input.confirmationGrantId === undefined) throw confirmationRequired(input.category);
+  if (input.authority === undefined) throw confirmationRequired(input.category);
+  const resolution = await input.authority.resolveConfirmation({
+    makaSessionId: input.makaSessionId,
+    confirmationGrantId: input.confirmationGrantId,
+    policyVersion: SESSION_SNAPSHOT_POLICY_VERSION,
+    category: input.category,
+    confirmationPath: input.confirmationPath,
+    cancellation: input.cancellation,
+  });
+  input.cancellation.signal.throwIfAborted();
+  if (resolution === undefined) throw confirmationRequired(input.category);
+  if (resolution.action === 'include') return INCLUDE;
+  if (resolution.action === 'exclude') {
+    return { kind: 'exclude', category: 'confirmed_secret_path' };
+  }
+  throw new SessionSnapshotError(
+    'io_failure',
+    'Session snapshot control-plane confirmation is invalid',
+    { details: { phase: 'workspace' } },
+  );
+}
+
+function confirmationRequired(
+  category: SessionSnapshotWorkspaceConfirmationCategory,
+): SessionSnapshotError {
+  return new SessionSnapshotError(
+    'policy_rejected',
+    'Session snapshot requires an explicit control-plane confirmation',
+    { details: { phase: 'workspace', policyCategory: category } },
+  );
+}
+
 function requireMakaSessionId(value: unknown): string {
   if (typeof value !== 'string' || !isSafeSessionId(value)) {
     throw new SessionSnapshotError('invalid_input', 'Maka Session identity is invalid', {
       details: { phase: 'admission' },
     });
+  }
+  return value;
+}
+
+function requireOptionalConfirmationGrantId(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || !CONFIRMATION_GRANT_ID_PATTERN.test(value)) {
+    throw new SessionSnapshotError(
+      'invalid_input',
+      'Session snapshot confirmation grant identity is invalid',
+      { details: { phase: 'admission' } },
+    );
   }
   return value;
 }
@@ -765,6 +936,7 @@ const WORKSPACE_EXCLUSION_CATEGORIES = [
   'cache',
   'log',
   'runtime_scratch',
+  'confirmed_secret_path',
 ] as const satisfies readonly SessionSnapshotWorkspaceExclusionCategory[];
 
 function normalizeExclusionCounts(

--- a/packages/storage/src/quiescent-session-snapshot.ts
+++ b/packages/storage/src/quiescent-session-snapshot.ts
@@ -27,13 +27,17 @@ import type {
   PreparedSessionBundleSnapshot,
 } from './session-bundle-contract.js';
 import { isSessionBundleUstarPathV1 } from './session-bundle-ustar.js';
+import { createSessionCopyCleanupAuthority } from './session-copy-cleanup.js';
 import { isSafeSessionId } from './session-store.js';
+import type { ProcessLifetimeOwner } from './process-lifetime-owner.js';
 
 export const SESSION_SNAPSHOT_POLICY_VERSION = 1 as const;
 export const SESSION_SNAPSHOT_STAGING_SCHEMA_VERSION = 1 as const;
 
 const SNAPSHOT_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const SNAPSHOT_CLEANUP_ID_PATTERN =
+  /^snapshot-([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})-([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/u;
 const CONFIRMATION_GRANT_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/u;
 const MAX_OWNER_RECORD_BYTES = 1_024;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
@@ -324,6 +328,8 @@ export type SessionSnapshotPhase =
 
 export interface SessionSnapshotErrorDetails {
   readonly phase?: SessionSnapshotPhase;
+  /** Cleanup also failed; the top-level code still classifies the primary failure. */
+  readonly cleanupFailed?: true;
   readonly policyCategory?:
     | SessionSnapshotWorkspaceRejectionCategory
     | SessionSnapshotWorkspaceConfirmationCategory;
@@ -360,12 +366,122 @@ export interface FileQuiescentSessionSnapshotCoordinatorOptions {
   readonly quiescence: SessionSnapshotQuiescenceAuthority;
   readonly state: SessionSnapshotStatePreparer;
   readonly workspace: SessionSnapshotWorkspacePreparer;
+  /** Persistent owner/recovery authority for every private staging root. */
+  readonly stagingCleanup: SessionSnapshotStagingCleanupAuthority;
   /** Optional control-plane lookup; suspected paths fail closed when absent. */
   readonly confirmationAuthority?: SessionSnapshotWorkspaceConfirmationAuthority;
   /** Required on Windows; optional additional verification on POSIX platforms. */
   readonly privateStagingRootAuthority?: SessionSnapshotPrivateStagingRootAuthority;
   readonly now?: () => number;
   readonly newSnapshotId?: () => string;
+}
+
+export interface SessionSnapshotStagingLease {
+  readonly snapshotId: string;
+  readonly ownerToken: string;
+  readonly makaSessionId: string;
+}
+
+export interface SessionSnapshotStagingCleanupRecovery {
+  readonly removed: string[];
+  readonly failed: Array<{ readonly snapshotId: string; readonly error: unknown }>;
+}
+
+/**
+ * Persistent lifetime authority for snapshot staging. Production startup must
+ * call `recover()` after acquiring its ProcessLifetimeOwner and before serving
+ * snapshot requests.
+ */
+export interface SessionSnapshotStagingCleanupAuthority {
+  /** Absolute staging parent this authority's persisted leases are bound to. */
+  readonly stagingParent: string;
+  ownCreation<T>(lease: SessionSnapshotStagingLease, operation: () => Promise<T>): Promise<T>;
+  cleanup(lease: SessionSnapshotStagingLease): Promise<void>;
+  recover(): Promise<SessionSnapshotStagingCleanupRecovery>;
+}
+
+/**
+ * Reuses the Session-copy persisted cleanup lease engine in a separate
+ * operational-state root. The separate root prevents either recovery domain
+ * from interpreting and deleting the other domain's resources.
+ */
+export function createFileSessionSnapshotStagingCleanupAuthority(input: {
+  readonly cleanupStateRoot: string;
+  readonly stagingParent: string;
+  readonly processLifetimeOwner: ProcessLifetimeOwner;
+  readonly privateStagingRootAuthority?: SessionSnapshotPrivateStagingRootAuthority;
+}): SessionSnapshotStagingCleanupAuthority {
+  if (!isAbsolute(input.cleanupStateRoot)) {
+    throw new TypeError('Session snapshot cleanupStateRoot must be absolute');
+  }
+  if (!isAbsolute(input.stagingParent)) {
+    throw new TypeError('Session snapshot stagingParent must be absolute');
+  }
+  return new FileSessionSnapshotStagingCleanupAuthority({
+    cleanupStateRoot: resolve(input.cleanupStateRoot),
+    stagingParent: resolve(input.stagingParent),
+    processLifetimeOwner: input.processLifetimeOwner,
+    privateStagingRootAuthority: input.privateStagingRootAuthority,
+  });
+}
+
+class FileSessionSnapshotStagingCleanupAuthority implements SessionSnapshotStagingCleanupAuthority {
+  readonly stagingParent: string;
+  readonly #cleanup: ReturnType<typeof createSessionCopyCleanupAuthority>;
+
+  constructor(input: {
+    cleanupStateRoot: string;
+    stagingParent: string;
+    processLifetimeOwner: ProcessLifetimeOwner;
+    privateStagingRootAuthority: SessionSnapshotPrivateStagingRootAuthority | undefined;
+  }) {
+    this.stagingParent = input.stagingParent;
+    this.#cleanup = createSessionCopyCleanupAuthority({
+      workspaceRoot: input.cleanupStateRoot,
+      processLifetimeOwner: input.processLifetimeOwner,
+      // A creating snapshot already has enough durable identity to be removed;
+      // unlike a Session copy, it has no remote creation protocol to resume.
+      resumeSessionCopy: async () => {},
+      removeSession: async (cleanupId) => {
+        const lease = decodeSnapshotCleanupId(cleanupId);
+        await removePersistedSnapshotStaging({
+          parent: input.stagingParent,
+          snapshotId: lease.snapshotId,
+          ownerToken: lease.ownerToken,
+          privateRootAuthority: input.privateStagingRootAuthority,
+        });
+      },
+    });
+  }
+
+  ownCreation<T>(lease: SessionSnapshotStagingLease, operation: () => Promise<T>): Promise<T> {
+    const normalized = normalizeSnapshotStagingLease(lease);
+    return this.#cleanup.ownCreation(
+      {
+        sessionId: encodeSnapshotCleanupId(normalized),
+        kind: 'revision',
+        sourceSessionId: normalized.makaSessionId,
+        sourceTurnId: normalized.snapshotId,
+        ownerId: `snapshot:${normalized.ownerToken}`,
+      },
+      operation,
+    );
+  }
+
+  cleanup(lease: SessionSnapshotStagingLease): Promise<void> {
+    return this.#cleanup.cleanup(encodeSnapshotCleanupId(normalizeSnapshotStagingLease(lease)));
+  }
+
+  async recover(): Promise<SessionSnapshotStagingCleanupRecovery> {
+    const recovery = await this.#cleanup.recover();
+    return {
+      removed: recovery.removed.map((cleanupId) => decodeSnapshotCleanupId(cleanupId).snapshotId),
+      failed: recovery.failed.map(({ sessionId, error }) => ({
+        snapshotId: decodeSnapshotCleanupId(sessionId).snapshotId,
+        error,
+      })),
+    };
+  }
 }
 
 export function createFileQuiescentSessionSnapshotCoordinator(
@@ -376,6 +492,7 @@ export function createFileQuiescentSessionSnapshotCoordinator(
 
 class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapshotCoordinator {
   readonly #stagingParent: string;
+  readonly #stagingCleanup: SessionSnapshotStagingCleanupAuthority;
   readonly #quiescence: SessionSnapshotQuiescenceAuthority;
   readonly #state: SessionSnapshotStatePreparer;
   readonly #workspace: SessionSnapshotWorkspacePreparer;
@@ -392,6 +509,10 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
       throw new TypeError('Session snapshot V1 safety policy cannot be overridden');
     }
     this.#stagingParent = resolve(options.stagingParent);
+    if (resolve(options.stagingCleanup.stagingParent) !== this.#stagingParent) {
+      throw new TypeError('Session snapshot staging cleanup authority is bound to another parent');
+    }
+    this.#stagingCleanup = options.stagingCleanup;
     this.#quiescence = options.quiescence;
     this.#state = options.state;
     this.#workspace = options.workspace;
@@ -406,6 +527,8 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
     const confirmationGrantId = requireOptionalConfirmationGrantId(input.confirmationGrantId);
     const cancellation = createCancellation(input, this.#now);
     let prepared: OwnedPreparedSessionBundleHandle | undefined;
+    let stagingLease: SessionSnapshotStagingLease | undefined;
+    let stagingLeaseOwned = false;
     let operationStarted = false;
     try {
       cancellation.assertActive();
@@ -421,13 +544,20 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
           }
           operationStarted = true;
           cancellation.assertActive();
-          const staging = await OwnedSnapshotStaging.create(
-            this.#stagingParent,
-            requireSnapshotId(this.#newSnapshotId()),
-            this.#privateStagingRootAuthority,
-          );
-          try {
+          stagingLease = {
+            snapshotId: requireSnapshotId(this.#newSnapshotId()),
+            ownerToken: randomUUID(),
+            makaSessionId,
+          };
+          return this.#stagingCleanup.ownCreation(stagingLease, async () => {
+            stagingLeaseOwned = true;
             cancellation.assertActive();
+            const staging = await OwnedSnapshotStaging.create(
+              this.#stagingParent,
+              stagingLease!.snapshotId,
+              stagingLease!.ownerToken,
+              this.#privateStagingRootAuthority,
+            );
             const stateIdentity = copyOpaqueStateIdentityDescriptor(
               await this.#state.prepareState({
                 makaSessionId,
@@ -463,12 +593,12 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
               stateIdentity,
               workspace,
               SESSION_SNAPSHOT_POLICY_VERSION,
+              this.#stagingCleanup,
+              stagingLease!,
             );
             prepared = handle;
             return handle;
-          } catch (error) {
-            return cleanupAfterPreparationFailure(staging, error);
-          }
+          });
         },
       );
       cancellation.assertActive();
@@ -481,14 +611,16 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
       }
       return result;
     } catch (error) {
-      if (prepared) {
+      const primaryError = normalizePreparationError(error);
+      if (prepared || (stagingLease && stagingLeaseOwned)) {
         try {
-          await prepared.release();
+          if (prepared) await prepared.release();
+          else await this.#stagingCleanup.cleanup(stagingLease!);
         } catch (cleanupError) {
-          throw cleanupFailure(new AggregateError([error, cleanupError]));
+          throw primaryErrorWithCleanupFailure(primaryError, cleanupError);
         }
       }
-      throw normalizePreparationError(error, cancellation.value.signal);
+      throw primaryError;
     } finally {
       cancellation.close();
     }
@@ -554,10 +686,11 @@ class OwnedSnapshotStaging {
   static async create(
     parent: string,
     snapshotId: string,
+    ownerToken: string,
     privateRootAuthority: SessionSnapshotPrivateStagingRootAuthority | undefined,
   ): Promise<OwnedSnapshotStaging> {
     const canonicalParent = await preparePrivateStagingParent(parent, privateRootAuthority);
-    const staging = new OwnedSnapshotStaging(canonicalParent, snapshotId, randomUUID());
+    const staging = new OwnedSnapshotStaging(canonicalParent, snapshotId, ownerToken);
     let rootCreated = false;
     try {
       await assertMissing(staging.#preparingRoot);
@@ -589,6 +722,7 @@ class OwnedSnapshotStaging {
       );
       return staging;
     } catch (error) {
+      const primaryError = normalizeStagingCreationError(error);
       if (rootCreated && staging.#identity) {
         try {
           await removeDirectoryBoundToIdentity({
@@ -598,18 +732,15 @@ class OwnedSnapshotStaging {
             identity: staging.#identity,
           });
         } catch (cleanupError) {
-          throw cleanupFailure(new AggregateError([error, cleanupError]));
+          throw primaryErrorWithCleanupFailure(primaryError, cleanupError);
         }
       } else if (rootCreated) {
-        throw cleanupFailure(
-          new AggregateError([error, new Error('Snapshot root identity is unavailable')]),
+        throw primaryErrorWithCleanupFailure(
+          primaryError,
+          new Error('Snapshot root identity is unavailable'),
         );
       }
-      if (error instanceof SessionSnapshotError) throw error;
-      throw new SessionSnapshotError('io_failure', 'Unable to create Session snapshot staging', {
-        cause: error,
-        details: { phase: 'staging' },
-      });
+      throw primaryError;
     }
   }
 
@@ -651,31 +782,14 @@ class OwnedSnapshotStaging {
       });
     }
   }
-
-  async discard(): Promise<void> {
-    const root = this.#published ? this.#publishedRoot : this.#preparingRoot;
-    try {
-      if (!this.#identity || !this.#owner) {
-        throw new Error('Snapshot ownership is unavailable');
-      }
-      await removeOwnedSnapshotDirectory({
-        parent: dirname(root),
-        root,
-        cleanupRoot: this.#cleanupRoot,
-        owner: this.#owner,
-        identity: this.#identity,
-      });
-    } catch (error) {
-      throw cleanupFailure(error);
-    }
-  }
 }
 
 class OwnedPreparedSessionBundleHandle implements PreparedSessionBundleHandle {
   readonly snapshot: PreparedSessionBundleSnapshot;
   readonly workspace: SessionSnapshotWorkspacePreparation;
   readonly policyVersion: typeof SESSION_SNAPSHOT_POLICY_VERSION;
-  readonly #staging: PublishedSnapshotStaging;
+  readonly #stagingCleanup: SessionSnapshotStagingCleanupAuthority;
+  readonly #stagingLease: SessionSnapshotStagingLease;
   #releaseTask: Promise<void> | undefined;
   #released = false;
 
@@ -684,8 +798,11 @@ class OwnedPreparedSessionBundleHandle implements PreparedSessionBundleHandle {
     stateIdentity: OpaqueStateIdentityDescriptor,
     workspace: SessionSnapshotWorkspacePreparation,
     policyVersion: typeof SESSION_SNAPSHOT_POLICY_VERSION,
+    stagingCleanup: SessionSnapshotStagingCleanupAuthority,
+    stagingLease: SessionSnapshotStagingLease,
   ) {
-    this.#staging = staging;
+    this.#stagingCleanup = stagingCleanup;
+    this.#stagingLease = stagingLease;
     this.snapshot = Object.freeze({
       stateRoot: staging.stateRoot,
       workspaceRoot: staging.workspaceRoot,
@@ -710,13 +827,7 @@ class OwnedPreparedSessionBundleHandle implements PreparedSessionBundleHandle {
 
   async #releaseOnce(): Promise<void> {
     try {
-      await removeOwnedSnapshotDirectory({
-        parent: this.#staging.parent,
-        root: this.#staging.root,
-        cleanupRoot: this.#staging.cleanupRoot,
-        owner: this.#staging.owner,
-        identity: this.#staging.identity,
-      });
+      await this.#stagingCleanup.cleanup(this.#stagingLease);
     } catch (error) {
       throw cleanupFailure(error);
     }
@@ -895,6 +1006,38 @@ function requireSnapshotId(value: unknown): string {
     });
   }
   return value;
+}
+
+function normalizeSnapshotStagingLease(
+  value: SessionSnapshotStagingLease,
+): SessionSnapshotStagingLease {
+  return Object.freeze({
+    snapshotId: requireSnapshotId(value.snapshotId),
+    ownerToken: requireSnapshotOwnerToken(value.ownerToken),
+    makaSessionId: requireMakaSessionId(value.makaSessionId),
+  });
+}
+
+function requireSnapshotOwnerToken(value: unknown): string {
+  if (typeof value !== 'string' || !SNAPSHOT_ID_PATTERN.test(value)) {
+    throw new SessionSnapshotError('io_failure', 'Session snapshot owner identity is invalid', {
+      details: { phase: 'staging' },
+    });
+  }
+  return value;
+}
+
+function encodeSnapshotCleanupId(lease: SessionSnapshotStagingLease): string {
+  return `snapshot-${lease.snapshotId}-${lease.ownerToken}`;
+}
+
+function decodeSnapshotCleanupId(cleanupId: string): {
+  readonly snapshotId: string;
+  readonly ownerToken: string;
+} {
+  const match = SNAPSHOT_CLEANUP_ID_PATTERN.exec(cleanupId);
+  if (!match) throw new Error('Invalid Session snapshot cleanup identity');
+  return { snapshotId: match[1]!, ownerToken: match[2]! };
 }
 
 function normalizeWorkspacePreparation(
@@ -1142,7 +1285,12 @@ async function writeOwnerRecord(
       identity,
     });
   } catch (cleanupError) {
-    throw cleanupFailure(new AggregateError([failure, cleanupError]));
+    const primaryError = new SessionSnapshotError(
+      'io_failure',
+      'Unable to write Session snapshot ownership record',
+      { cause: failure, details: { phase: 'staging' } },
+    );
+    throw primaryErrorWithCleanupFailure(primaryError, cleanupError);
   }
   throw failure;
 }
@@ -1251,6 +1399,131 @@ async function removeOwnedSnapshotDirectory(input: {
   await assertOwnedRoot(input.cleanupRoot, input.owner, input.identity);
   await rm(input.cleanupRoot, { recursive: true, force: false });
   await removeOwnerRecord(input.owner);
+}
+
+async function removePersistedSnapshotStaging(input: {
+  parent: string;
+  snapshotId: string;
+  ownerToken: string;
+  privateRootAuthority: SessionSnapshotPrivateStagingRootAuthority | undefined;
+}): Promise<void> {
+  const parent = await preparePrivateStagingParent(input.parent, input.privateRootAuthority);
+  const preparingRoot = join(parent, `.snapshot-${input.snapshotId}.preparing`);
+  const publishedRoot = join(parent, `snapshot-${input.snapshotId}`);
+  const cleanupRoot = join(parent, `.snapshot-${input.snapshotId}.${input.ownerToken}.cleanup`);
+  const owner = await readPersistedSnapshotOwnerBinding({
+    parent,
+    snapshotId: input.snapshotId,
+    ownerToken: input.ownerToken,
+  });
+  const [preparingIdentity, publishedIdentity, cleanupIdentity] = await Promise.all([
+    readOptionalDirectoryIdentity(preparingRoot),
+    readOptionalDirectoryIdentity(publishedRoot),
+    readOptionalDirectoryIdentity(cleanupRoot),
+  ]);
+
+  if (preparingIdentity && publishedIdentity) {
+    throw new Error('Session snapshot staging has conflicting preparation and publication roots');
+  }
+  if (!owner) {
+    if (publishedIdentity) {
+      throw new Error('Published Session snapshot has no ownership record');
+    }
+    if (preparingIdentity && cleanupIdentity) {
+      throw new Error('Unbound Session snapshot cleanup paths conflict');
+    }
+    const identity = preparingIdentity ?? cleanupIdentity;
+    if (!identity) return;
+    // The persisted ProcessLifetimeOwner lease authenticates this exact UUID
+    // during the small create-to-owner-record crash window.
+    await removeDirectoryBoundToIdentity({
+      parent,
+      root: preparingRoot,
+      cleanupRoot,
+      identity,
+    });
+    return;
+  }
+
+  const identity = snapshotRootIdentity(owner.record);
+  await removeOwnedSnapshotDirectory({
+    parent,
+    root: preparingIdentity ? preparingRoot : publishedIdentity ? publishedRoot : preparingRoot,
+    cleanupRoot,
+    owner,
+    identity,
+  });
+}
+
+async function readPersistedSnapshotOwnerBinding(input: {
+  parent: string;
+  snapshotId: string;
+  ownerToken: string;
+}): Promise<SnapshotOwnerBinding | undefined> {
+  const path = join(input.parent, `.snapshot-${input.snapshotId}.owner.json`);
+  const cleanupPath = join(
+    input.parent,
+    `.snapshot-${input.snapshotId}.${input.ownerToken}.owner-cleanup`,
+  );
+  const [pathIdentity, cleanupIdentity] = await Promise.all([
+    readOptionalFileIdentity(path),
+    readOptionalFileIdentity(cleanupPath),
+  ]);
+  if (pathIdentity && cleanupIdentity) {
+    throw new Error('Snapshot ownership cleanup paths conflict');
+  }
+  const identity = pathIdentity ?? cleanupIdentity;
+  if (!identity) return undefined;
+  const actualPath = pathIdentity ? path : cleanupPath;
+  const handle = await open(actualPath, fsConstants.O_RDONLY | NO_FOLLOW_OPEN_FLAG);
+  let record: SnapshotOwnerRecord;
+  try {
+    const info = await handle.stat({ bigint: true });
+    if (
+      !info.isFile() ||
+      info.isSymbolicLink() ||
+      info.nlink !== 1n ||
+      info.size > BigInt(MAX_OWNER_RECORD_BYTES) ||
+      !sameFilesystemIdentity({ dev: info.dev, ino: info.ino }, identity)
+    ) {
+      throw new Error('Snapshot ownership record is invalid');
+    }
+    const value = JSON.parse(await handle.readFile('utf8')) as unknown;
+    if (!isSnapshotOwnerRecord(value, input.snapshotId, input.ownerToken)) {
+      throw new Error('Snapshot ownership record changed');
+    }
+    record = value;
+  } finally {
+    await handle.close();
+  }
+  const currentIdentity = await readFileIdentity(actualPath);
+  if (!sameFilesystemIdentity(currentIdentity, identity)) {
+    throw new Error('Snapshot ownership record path changed');
+  }
+  return { path, cleanupPath, record, identity };
+}
+
+function isSnapshotOwnerRecord(
+  value: unknown,
+  snapshotId: string,
+  ownerToken: string,
+): value is SnapshotOwnerRecord {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    Object.keys(record).length === 5 &&
+    record.schemaVersion === SESSION_SNAPSHOT_STAGING_SCHEMA_VERSION &&
+    record.snapshotId === snapshotId &&
+    record.ownerToken === ownerToken &&
+    typeof record.rootDev === 'string' &&
+    /^(?:0|[1-9][0-9]*)$/u.test(record.rootDev) &&
+    typeof record.rootIno === 'string' &&
+    /^(?:0|[1-9][0-9]*)$/u.test(record.rootIno)
+  );
+}
+
+function snapshotRootIdentity(record: SnapshotOwnerRecord): FilesystemIdentity {
+  return { dev: BigInt(record.rootDev), ino: BigInt(record.rootIno) };
 }
 
 async function removeOwnerRecord(owner: SnapshotOwnerBinding): Promise<void> {
@@ -1398,21 +1671,9 @@ function sameOwnerRecord(value: unknown, expected: SnapshotOwnerRecord): boolean
   );
 }
 
-async function cleanupAfterPreparationFailure(
-  staging: OwnedSnapshotStaging,
-  primaryError: unknown,
-): Promise<never> {
-  try {
-    await staging.discard();
-  } catch (cleanupError) {
-    throw cleanupFailure(new AggregateError([primaryError, cleanupError]));
-  }
-  throw primaryError;
-}
-
-function normalizePreparationError(error: unknown, signal: AbortSignal): SessionSnapshotError {
+function normalizePreparationError(error: unknown): SessionSnapshotError {
   if (error instanceof SessionSnapshotError) return error;
-  if (signal.aborted || isAbortError(error)) {
+  if (isAbortError(error)) {
     return new SessionSnapshotError(
       'snapshot_cancelled',
       'Session snapshot preparation was cancelled',
@@ -1421,6 +1682,24 @@ function normalizePreparationError(error: unknown, signal: AbortSignal): Session
   }
   return new SessionSnapshotError('io_failure', 'Session snapshot preparation failed', {
     cause: error,
+  });
+}
+
+function normalizeStagingCreationError(error: unknown): SessionSnapshotError {
+  if (error instanceof SessionSnapshotError) return error;
+  return new SessionSnapshotError('io_failure', 'Unable to create Session snapshot staging', {
+    cause: error,
+    details: { phase: 'staging' },
+  });
+}
+
+function primaryErrorWithCleanupFailure(
+  primaryError: SessionSnapshotError,
+  cleanupError: unknown,
+): SessionSnapshotError {
+  return new SessionSnapshotError(primaryError.code, primaryError.message, {
+    cause: new AggregateError([primaryError, cleanupError]),
+    details: { ...primaryError.details, cleanupFailed: true },
   });
 }
 

--- a/packages/storage/src/quiescent-session-snapshot.ts
+++ b/packages/storage/src/quiescent-session-snapshot.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { randomUUID } from 'node:crypto';
 import { constants as fsConstants } from 'node:fs';
 import { lstat, mkdir, open, realpath, rename, rm } from 'node:fs/promises';
@@ -7,6 +26,7 @@ import type {
   OpaqueStateIdentityDescriptor,
   PreparedSessionBundleSnapshot,
 } from './session-bundle-contract.js';
+import { isSessionBundleUstarPathV1 } from './session-bundle-ustar.js';
 import { isSafeSessionId } from './session-store.js';
 
 export const SESSION_SNAPSHOT_POLICY_VERSION = 1 as const;
@@ -15,6 +35,7 @@ export const SESSION_SNAPSHOT_STAGING_SCHEMA_VERSION = 1 as const;
 const SNAPSHOT_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const MAX_OWNER_RECORD_BYTES = 1_024;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
 const NO_FOLLOW_OPEN_FLAG = process.platform === 'win32' ? 0 : fsConstants.O_NOFOLLOW;
 
 export type SessionSnapshotWorkspaceEntryKind = 'file' | 'directory';
@@ -63,12 +84,20 @@ const INCLUDE = Object.freeze({ kind: 'include' } as const);
 // measurement rules introduced by #1353. Snapshot rejection is reserved for
 // names that identify known secret material; public certificate encodings and
 // other ambiguous formats are not rejected by extension alone.
+const PUBLIC_ENV_TEMPLATE_PATTERN = /^\.env\.(?:example|sample|template)$/i;
+const KNOWN_SECRET_WORKSPACE_DIRECTORY_NAMES = new Set([
+  '.ssh',
+  'credentials',
+  'private',
+  'secrets',
+]);
 const KNOWN_SECRET_WORKSPACE_FILE_PATTERNS = [
   /^\.env(?:\..*)?$/i,
   /^\.(?:npmrc|netrc|pypirc|terraformrc)$/i,
   /^\.git-credentials(?:\.lock)?$/i,
-  /^(?:credentials?|secrets?)(?:\..*)?$/i,
+  /^(?:credentials?|secrets?)(?:\.(?:cfg|conf|ini|json|log|properties|toml|ya?ml))?$/i,
   /(?:^|[-_.])(?:id_(?:rsa|dsa|ecdsa|ed25519)|private[-_.]?key)(?:$|[-_.])/i,
+  /^(?:private|privkey)\.pem$/i,
   /\.(?:key|p12|pfx)$/i,
 ] as const;
 
@@ -101,18 +130,18 @@ export const SESSION_SNAPSHOT_WORKSPACE_POLICY_V1: SessionSnapshotWorkspacePolic
     ) {
       return { kind: 'exclude', category: 'cache' };
     }
+    if (lowerSegments.includes('.maka-runtime') || lowerSegments.includes('.maka-activation')) {
+      return { kind: 'exclude', category: 'runtime_scratch' };
+    }
+    if (isKnownSecretEntry(entry.kind, lowerSegments, lowerName)) {
+      return { kind: 'reject', category: 'known_secret_file' };
+    }
     if (
       lowerSegments.includes('logs') ||
       lowerSegments.includes('.logs') ||
       (entry.kind === 'file' && lowerName.endsWith('.log'))
     ) {
       return { kind: 'exclude', category: 'log' };
-    }
-    if (lowerSegments.includes('.maka-runtime') || lowerSegments.includes('.maka-activation')) {
-      return { kind: 'exclude', category: 'runtime_scratch' };
-    }
-    if (entry.kind === 'file' && isKnownSecretPath(lowerSegments, lowerName)) {
-      return { kind: 'reject', category: 'known_secret_file' };
     }
     return INCLUDE;
   },
@@ -371,7 +400,7 @@ class FileQuiescentSessionSnapshotCoordinator implements QuiescentSessionSnapsho
             prepared = handle;
             return handle;
           } catch (error) {
-            await cleanupAfterPreparationFailure(staging, error);
+            return cleanupAfterPreparationFailure(staging, error);
           }
         },
       );
@@ -649,22 +678,29 @@ function decodeWorkspaceEntry(
   if (segments.some((segment) => segment.length === 0 || segment === '.' || segment === '..')) {
     return { kind: 'reject', category: 'unsafe_path' };
   }
+  const bundlePath = `workspace/${entry.relativePath}${entry.kind === 'directory' ? '/' : ''}`;
+  if (!isSessionBundleUstarPathV1(bundlePath)) {
+    return { kind: 'reject', category: 'unsafe_path' };
+  }
   return { kind: 'valid', segments, basename: segments.at(-1)! };
 }
 
-function isKnownSecretPath(lowerSegments: readonly string[], lowerName: string): boolean {
+function isKnownSecretEntry(
+  kind: SessionSnapshotWorkspaceEntryKind,
+  lowerSegments: readonly string[],
+  lowerName: string,
+): boolean {
+  if (lowerSegments.some((segment) => KNOWN_SECRET_WORKSPACE_DIRECTORY_NAMES.has(segment))) {
+    return true;
+  }
+  if (kind === 'directory') return false;
+  if (PUBLIC_ENV_TEMPLATE_PATTERN.test(lowerName) || lowerName.endsWith('.pub')) return false;
   if (KNOWN_SECRET_WORKSPACE_FILE_PATTERNS.some((pattern) => pattern.test(lowerName))) return true;
-  if (
-    lowerSegments.includes('.ssh') ||
-    lowerName === 'service-account.json' ||
-    lowerName === 'service-account-key.json'
-  ) {
+  if (lowerName === 'service-account.json' || lowerName === 'service-account-key.json') {
     return true;
   }
   return (
     (lowerSegments.at(-2) === '.docker' && lowerName === 'config.json') ||
-    (lowerSegments.at(-2) === '.aws' && lowerName === 'credentials') ||
-    (lowerSegments.at(-2) === '.cargo' && lowerName === 'credentials') ||
     (lowerSegments.at(-2) === '.kube' && lowerName === 'config') ||
     (lowerSegments.at(-2) === 'gcloud' &&
       lowerSegments.at(-3) === '.config' &&
@@ -785,12 +821,19 @@ function createCancellation(
   const controller = new AbortController();
   const abort = () => controller.abort();
   input.signal?.addEventListener('abort', abort, { once: true });
+  let timeout: NodeJS.Timeout | undefined;
+  const scheduleDeadline = () => {
+    if (input.deadlineAt === undefined) return;
+    const remaining = input.deadlineAt - now();
+    if (remaining <= 0) {
+      abort();
+      return;
+    }
+    timeout = setTimeout(scheduleDeadline, Math.min(remaining, MAX_TIMER_DELAY_MS));
+    timeout.unref();
+  };
   const remaining = input.deadlineAt === undefined ? undefined : input.deadlineAt - now();
-  const timeout =
-    remaining === undefined || remaining <= 0
-      ? undefined
-      : setTimeout(abort, Math.min(remaining, 2_147_483_647));
-  timeout?.unref();
+  if (remaining !== undefined && remaining > 0) scheduleDeadline();
   if (input.signal?.aborted || (remaining !== undefined && remaining <= 0)) abort();
   const value = Object.freeze({
     signal: controller.signal,

--- a/packages/storage/src/session-bundle-ustar.ts
+++ b/packages/storage/src/session-bundle-ustar.ts
@@ -38,6 +38,17 @@ export interface SessionBundleUstarHeader {
   size: number;
 }
 
+/** Return whether a path belongs to the exact portable path language used by Bundle V1. */
+export function isSessionBundleUstarPathV1(path: string): boolean {
+  try {
+    splitUstarPath(path);
+    return true;
+  } catch (error) {
+    if (error instanceof SessionBundleFileError && error.code === 'unsafe_path') return false;
+    throw error;
+  }
+}
+
 /**
  * Encode the exact POSIX USTAR header admitted by Session Bundle codec V1.
  * Paths use a portable subset on every host: Windows device names, forbidden


### PR DESCRIPTION
## Summary

Define the contract/foundation slice of the quiescent Session Bundle snapshot coordinator from #2369.

- add a trusted per-Session quiescence boundary that prepares state and workspace at one logical point in time, then returns private staging roots compatible with `PreparedSessionBundleSnapshot`
- pin the exact V1 workspace policy so callers cannot replace or weaken it; the trusted workspace preparer is the enforcement point and production traversal/copy enforcement remains for PR 2
- deterministically exclude rebuildable/runtime content and logs, while rejecting only names that identify known user-authored secret material; public certificate encodings are not rejected by extension alone
- add cancellation/deadline handling, bounded stable errors, normalized exclusion diagnostics, and same-Session serialization requirements
- retain inode-bound cleanup ownership outside the recursively deleted snapshot directory so partial cleanup remains retryable and replacements observable before deletion fail closed
- require a caller-provided ACL verification authority on Windows and bind its result to the exact canonical parent and newly created staging directory

This is PR 1 of the implementation split described in #2369. It establishes contracts and deterministic fakes, but has no production call site and does not solve #2369 end to end. Production quiescence/state/workspace adapters, codec round-trip integration, and mutation-race E2E coverage remain for PR 2.

Refs #2369

## Trust and security boundaries

- `SessionSnapshotQuiescenceAuthority` is a trusted Host/Owner boundary; this PR intentionally does not present a process-local mutex as authoritative.
- The coordinator always supplies `SESSION_SNAPSHOT_WORKSPACE_POLICY_V1`. `SessionSnapshotWorkspacePreparer` is the trusted enforcement point: it must apply every decision without downgrading it. The coordinator validates the returned root and bounded counters, but does not re-traverse the result to attest policy compliance. PR 2 must provide and test the production preparer before that guarantee is claimed end to end.
- Ownership records bind the snapshot directory and record file to their filesystem identities. The current checks detect replacements observable before cleanup and support retry after partial deletion.
- The private staging parent and code running as the same OS principal with access to it are inside the trusted computing boundary. Node's path-based recursive removal does not defend against an adversarial same-principal replacement between the final identity check and deletion. Adversarial same-principal deletion and orphan lifecycle management require a separately specified platform mechanism.
- This PR does not expose prefix-based orphan cleanup; any future orphan API must authenticate an exact snapshot/owner record.

## Remaining PR 2 integration

- production quiescence authority covering every Session writer
- single-Session state exporter
- policy-enforcing workspace traversal and copier
- production call site
- `prepare -> pack -> inspect -> hydrate` round-trip coverage
- real state/workspace mutation-race coverage

## Verification

- `npm run build -w /core`
- `npm test -w /storage` — 1007 tests, 990 passed, 17 skipped, 0 failed
- `node --test packages/storage/dist/__tests__/quiescent-session-snapshot.test.js` — 19 tests, 18 passed, 1 Windows-only skip, 0 failed
- `npx biome check packages/storage/src/quiescent-session-snapshot.ts packages/storage/src/__tests__/quiescent-session-snapshot.test.ts packages/storage/src/session-bundle-ustar.ts`
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with contract design, implementation, regression tests, review remediation, and local verification. The contributor reviewed the resulting changes and remains responsible for their accuracy, provenance, and licensing.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes
- [x] No — this PR defines a foundation contract and has no production call site