### PR TITLE
feat(graph): support sequential graph epochs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,6 +58,7 @@
     "./cron-expression": "./dist/cron-expression.js",
     "./scheduled-task": "./dist/scheduled-task.js",
     "./agent-graph-control": "./dist/agent-graph-control.js",
+    "./agent-graph-instance": "./dist/agent-graph-instance.js",
     "./agent-graph-schedule": "./dist/agent-graph-schedule.js",
     "./agent-graph-topology": "./dist/agent-graph-topology.js",
     "./agent-graph-client-projection": "./dist/agent-graph-client-projection.js",

--- a/packages/core/src/__tests__/agent-graph-instance.test.ts
+++ b/packages/core/src/__tests__/agent-graph-instance.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  assertCreateAgentGraphInstanceRequest,
+  decodeAgentGraphInstance,
+  isAgentGraphInstance,
+} from '../agent-graph-instance.js';
+
+describe('Agent Graph instance contract', () => {
+  test('decodes open and finished instances with strict lifecycle invariants', () => {
+    assert.deepEqual(
+      decodeAgentGraphInstance({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'root-1',
+        sequence: 1,
+        status: 'open',
+        createdAt: 10,
+      }),
+      {
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'root-1',
+        sequence: 1,
+        status: 'open',
+        createdAt: 10,
+      },
+    );
+    assert.equal(
+      isAgentGraphInstance({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'root-1',
+        sequence: 1,
+        status: 'finished',
+        createdAt: 10,
+        finishedAt: 11,
+      }),
+      true,
+    );
+    assert.equal(
+      isAgentGraphInstance({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'root-1',
+        sequence: 1,
+        status: 'open',
+        createdAt: 10,
+        finishedAt: 11,
+      }),
+      false,
+    );
+  });
+
+  test('accepts only exact create requests', () => {
+    assert.doesNotThrow(() =>
+      assertCreateAgentGraphInstanceRequest({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'root-1',
+      }),
+    );
+    assert.throws(() =>
+      assertCreateAgentGraphInstanceRequest({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'root-1',
+        extra: true,
+      }),
+    );
+  });
+});

--- a/packages/core/src/agent-graph-instance.ts
+++ b/packages/core/src/agent-graph-instance.ts
@@ -1,0 +1,108 @@
+export const AGENT_GRAPH_INSTANCE_SCHEMA_VERSION = 1 as const;
+
+export type AgentGraphInstanceStatus = 'open' | 'finished';
+
+/**
+ * One independently closable graph owned by a long-lived root Session.
+ *
+ * A root Session may own several sequential instances. `finish` closes one
+ * instance permanently; later work is admitted into a newly created instance.
+ */
+export interface AgentGraphInstance {
+  schemaVersion: typeof AGENT_GRAPH_INSTANCE_SCHEMA_VERSION;
+  graphId: string;
+  rootSessionId: string;
+  sequence: number;
+  status: AgentGraphInstanceStatus;
+  createdAt: number;
+  finishedAt?: number;
+}
+
+export interface CreateAgentGraphInstanceRequest {
+  schemaVersion: typeof AGENT_GRAPH_INSTANCE_SCHEMA_VERSION;
+  graphId: string;
+  rootSessionId: string;
+}
+
+export interface AgentGraphInstanceResult {
+  instance: AgentGraphInstance;
+  created: boolean;
+}
+
+export interface AgentGraphInstanceStore {
+  getOrCreateActiveAgentGraphInstance(
+    request: CreateAgentGraphInstanceRequest,
+  ): Promise<AgentGraphInstanceResult>;
+  readActiveAgentGraphInstance(rootSessionId: string): Promise<AgentGraphInstance | undefined>;
+  readLatestAgentGraphInstance(rootSessionId: string): Promise<AgentGraphInstance | undefined>;
+  listAgentGraphInstances(rootSessionId: string): Promise<AgentGraphInstance[]>;
+}
+
+export function isAgentGraphInstance(value: unknown): value is AgentGraphInstance {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const instance = value as Record<string, unknown>;
+  const expectedKeys = [
+    'schemaVersion',
+    'graphId',
+    'rootSessionId',
+    'sequence',
+    'status',
+    'createdAt',
+    ...(Object.prototype.hasOwnProperty.call(instance, 'finishedAt') ? ['finishedAt'] : []),
+  ].sort();
+  const actualKeys = Object.keys(instance).sort();
+  return (
+    actualKeys.length === expectedKeys.length &&
+    actualKeys.every((key, index) => key === expectedKeys[index]) &&
+    instance.schemaVersion === AGENT_GRAPH_INSTANCE_SCHEMA_VERSION &&
+    isIdentity(instance.graphId) &&
+    isIdentity(instance.rootSessionId) &&
+    isPositiveSafeInteger(instance.sequence) &&
+    (instance.status === 'open' || instance.status === 'finished') &&
+    isNonNegativeSafeInteger(instance.createdAt) &&
+    (instance.finishedAt === undefined || isNonNegativeSafeInteger(instance.finishedAt)) &&
+    (instance.status === 'open'
+      ? instance.finishedAt === undefined
+      : instance.finishedAt !== undefined && instance.finishedAt >= instance.createdAt)
+  );
+}
+
+export function decodeAgentGraphInstance(value: unknown): AgentGraphInstance {
+  if (!isAgentGraphInstance(value)) throw new Error('Invalid agent graph instance');
+  return { ...value };
+}
+
+export function assertCreateAgentGraphInstanceRequest(
+  value: unknown,
+): asserts value is CreateAgentGraphInstanceRequest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid agent graph instance request');
+  }
+  const request = value as Record<string, unknown>;
+  if (
+    Object.keys(request).sort().join(',') !== 'graphId,rootSessionId,schemaVersion' ||
+    request.schemaVersion !== AGENT_GRAPH_INSTANCE_SCHEMA_VERSION ||
+    !isIdentity(request.graphId) ||
+    !isIdentity(request.rootSessionId)
+  ) {
+    throw new Error('Invalid agent graph instance request');
+  }
+}
+
+function isIdentity(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= 256 &&
+    value.trim() === value &&
+    !/[\u0000-\u001f\u007f]/.test(value)
+  );
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}

--- a/packages/runtime-host/src/__tests__/sandbox-boundary-graph-wake.test.ts
+++ b/packages/runtime-host/src/__tests__/sandbox-boundary-graph-wake.test.ts
@@ -6,35 +6,39 @@ import {
   sandboxBoundaryGraphWakeRoot,
 } from '../server/sandbox-boundary-graph-wake.js';
 
-test('routes sandbox boundary graph wakes to the durable root Session', () => {
-  assert.equal(sandboxBoundaryGraphWakeRoot({ id: 'root-session' }), 'root-session');
+test('routes sandbox boundary graph wakes to the durable root Session', async () => {
+  const graphInstances = instanceStore('root-session');
+  assert.equal(await sandboxBoundaryGraphWakeRoot({ id: 'root-session' }), 'root-session');
   assert.equal(
-    sandboxBoundaryGraphWakeRoot({
+    await sandboxBoundaryGraphWakeRoot({
       id: 'ordinary-child',
       subagentParent: subagentParent('root-session'),
     }),
     undefined,
   );
   assert.equal(
-    sandboxBoundaryGraphWakeRoot({
-      id: 'graph-operator',
-      subagentParent: {
-        ...subagentParent('root-session'),
-        graph: {
-          graphId: agentGraphIdForRootSession('root-session'),
-          workId: 'work-1',
-          operatorId: 'operator-1',
+    await sandboxBoundaryGraphWakeRoot(
+      {
+        id: 'graph-operator',
+        subagentParent: {
+          ...subagentParent('root-session'),
+          graph: {
+            graphId: agentGraphIdForRootSession('root-session'),
+            workId: 'work-1',
+            operatorId: 'operator-1',
+          },
         },
       },
-    }),
+      graphInstances,
+    ),
     'root-session',
   );
 });
 
-test('rejects graph operator lineage that is not owned by its parent Session', () => {
-  assert.throws(
-    () =>
-      sandboxBoundaryGraphWakeRoot({
+test('rejects graph operator lineage that is not owned by its parent Session', async () => {
+  await assert.rejects(
+    sandboxBoundaryGraphWakeRoot(
+      {
         id: 'graph-operator',
         subagentParent: {
           ...subagentParent('root-session'),
@@ -44,7 +48,9 @@ test('rejects graph operator lineage that is not owned by its parent Session', (
             operatorId: 'operator-1',
           },
         },
-      }),
+      },
+      instanceStore('root-session'),
+    ),
     /does not match root Session/,
   );
 });
@@ -81,8 +87,9 @@ test('reads durable operator lineage before notifying only its root graph', asyn
     wakes.push(sessionId);
   };
 
-  await notifySandboxBoundaryGraphWake('graph-operator', reader, notify);
-  await notifySandboxBoundaryGraphWake('ordinary-child', reader, notify);
+  const graphInstances = instanceStore('root-session');
+  await notifySandboxBoundaryGraphWake('graph-operator', reader, graphInstances, notify);
+  await notifySandboxBoundaryGraphWake('ordinary-child', reader, graphInstances, notify);
 
   assert.deepEqual(reads, ['graph-operator', 'ordinary-child']);
   assert.deepEqual(wakes, ['root-session']);
@@ -98,5 +105,23 @@ function subagentParent(parentSessionId: string) {
       toolCallId: 'tool-call',
     },
     lifecycle: 'foreground' as const,
+  };
+}
+
+function instanceStore(rootSessionId: string) {
+  return {
+    listAgentGraphInstances: async (requestedRootSessionId: string) =>
+      requestedRootSessionId === rootSessionId
+        ? [
+            {
+              schemaVersion: 1 as const,
+              graphId: agentGraphIdForRootSession(rootSessionId),
+              rootSessionId,
+              sequence: 1,
+              status: 'open' as const,
+              createdAt: 1,
+            },
+          ]
+        : [],
   };
 }

--- a/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-retirement-coordinator.test.ts
@@ -888,6 +888,7 @@ async function withHarness(
       },
       graph: {
         hasLiveSessionState: async (sessionId) => blockers.graph.has(sessionId),
+        listGraphInstances: (sessionId) => graphStore.listAgentGraphInstances(sessionId),
       },
       graphWake: {
         hasLiveSessionState: (sessionId) => blockers.graphWake.has(sessionId),

--- a/packages/runtime-host/src/server/agent-graph-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-coordinator.ts
@@ -1,6 +1,5 @@
 import {
   AgentGraphClientOperationError,
-  agentGraphIdForRootSession,
   type AgentGraphClientChangedEvent,
   type AgentGraphCoordinator,
 } from '@maka/runtime/stream-graph-coordinator';
@@ -120,11 +119,12 @@ export class HostAgentGraphCoordinator {
   async #stop(input: AgentGraphStopInput): Promise<OperationOutcome<'agent.graph.stop'>> {
     try {
       await this.#stopExecution(input.rootSessionId);
+      const snapshot = await this.#authority.getSnapshot(input.rootSessionId);
       return {
         ok: true,
         result: {
           rootSessionId: input.rootSessionId,
-          graphId: agentGraphIdForRootSession(input.rootSessionId),
+          graphId: snapshot.graphId,
         },
       };
     } catch (error) {

--- a/packages/runtime-host/src/server/agent-graph-execution-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-execution-coordinator.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import type { AgentGraphInstanceStore } from '@maka/core/agent-graph-instance';
 import { normalizeMessageContent } from '@maka/core/events';
 import { type UserMessageInput } from '@maka/core/runtime-inputs';
 import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinator';
@@ -32,6 +33,7 @@ type AgentGraphRuntime = Pick<SessionManager, 'compactSession' | 'sendMessage'>;
 export interface HostAgentGraphExecutionCoordinatorOptions {
   readonly executions: AgentGraphExecutionAuthority;
   readonly runtime: AgentGraphRuntime;
+  readonly graphInstances?: Pick<AgentGraphInstanceStore, 'listAgentGraphInstances'>;
   readonly newId?: () => string;
 }
 
@@ -39,11 +41,13 @@ export interface HostAgentGraphExecutionCoordinatorOptions {
 export class HostAgentGraphExecutionCoordinator {
   readonly #executions: AgentGraphExecutionAuthority;
   readonly #runtime: AgentGraphRuntime;
+  readonly #graphInstances: Pick<AgentGraphInstanceStore, 'listAgentGraphInstances'> | undefined;
   readonly #newId: () => string;
 
   constructor(options: HostAgentGraphExecutionCoordinatorOptions) {
     this.#executions = options.executions;
     this.#runtime = options.runtime;
+    this.#graphInstances = options.graphInstances;
     this.#newId = options.newId ?? randomUUID;
   }
 
@@ -53,7 +57,7 @@ export class HostAgentGraphExecutionCoordinator {
     abortSignal: AbortSignal,
     isCurrent: () => Promise<boolean>,
   ): Promise<AgentGraphSupervisorTurnOutcome> {
-    assertAgentGraphInput(sessionId, input);
+    await assertAgentGraphInput(sessionId, input, this.#graphInstances);
     const origin = input.origin;
     if (origin?.kind !== 'agent_graph') {
       throw new RuntimeMessageAuthorityInvariantError('Agent Graph execution lost its origin');
@@ -172,10 +176,21 @@ export class HostAgentGraphExecutionCoordinator {
   }
 }
 
-function assertAgentGraphInput(sessionId: string, input: UserMessageInput): void {
+async function assertAgentGraphInput(
+  sessionId: string,
+  input: UserMessageInput,
+  graphInstances?: Pick<AgentGraphInstanceStore, 'listAgentGraphInstances'>,
+): Promise<void> {
+  const ownedGraphIds = new Set(
+    graphInstances
+      ? (await graphInstances.listAgentGraphInstances(sessionId)).map(
+          (instance) => instance.graphId,
+        )
+      : [agentGraphIdForRootSession(sessionId)],
+  );
   if (
     input.origin?.kind !== 'agent_graph' ||
-    input.origin.graphId !== agentGraphIdForRootSession(sessionId) ||
+    !ownedGraphIds.has(input.origin.graphId) ||
     input.turnOrchestration?.mode !== 'graph' ||
     input.turnOrchestration.source !== 'host_api'
   ) {

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -4,10 +4,7 @@ import { emptyPlanSessionState } from '@maka/core/plan';
 import type { PermissionMode } from '@maka/core/permission';
 import { isDeepResearchSession } from '@maka/core/session';
 import { filterModelVisibleTaskLedgerTasks } from '@maka/core/task-ledger';
-import {
-  AgentGraphCoordinator,
-  agentGraphIdForRootSession,
-} from '@maka/runtime/stream-graph-coordinator';
+import { AgentGraphCoordinator } from '@maka/runtime/stream-graph-coordinator';
 import { AgentGraphSupervisorWakeCoordinator } from '@maka/runtime/agent-graph-supervisor-wake';
 import {
   BackendRegistry,
@@ -583,8 +580,12 @@ export async function createExecutionRuntimeHostComposition(
         context.requestDrain();
       },
       onSandboxBoundarySettled: (sessionId) =>
-        notifySandboxBoundaryGraphWake(sessionId, stores.sessionStore, (rootSessionId) =>
-          requireGraphSupervisorWake(graphSupervisorWake).notifyPermissionResponse(rootSessionId),
+        notifySandboxBoundaryGraphWake(
+          sessionId,
+          stores.sessionStore,
+          openedGraphControlStore,
+          (rootSessionId) =>
+            requireGraphSupervisorWake(graphSupervisorWake).notifyPermissionResponse(rootSessionId),
         ),
     });
     memory = new HostMemoryCoordinator({
@@ -910,11 +911,15 @@ export async function createExecutionRuntimeHostComposition(
       runtime: manager,
       newId: randomUUID,
       acquireResidency: () => context.acquireResidency('agent-graph'),
-      onReconciliation: (rootSessionId, result) => {
-        void requireGraphSupervisorWake(graphSupervisorWake).notify(rootSessionId, result);
+      onReconciliation: (rootSessionId, result, graphId) => {
+        void requireGraphSupervisorWake(graphSupervisorWake).notify(rootSessionId, result, graphId);
       },
-      onCheckpoint: (rootSessionId) => {
-        void requireGraphSupervisorWake(graphSupervisorWake).notify(rootSessionId);
+      onCheckpoint: (rootSessionId, graphId) => {
+        void requireGraphSupervisorWake(graphSupervisorWake).notify(
+          rootSessionId,
+          undefined,
+          graphId,
+        );
       },
     });
     graphClient = new HostAgentGraphCoordinator({
@@ -1016,6 +1021,7 @@ export async function createExecutionRuntimeHostComposition(
           host: buildHostCapabilitiesFromBinding(toolNames),
         });
       },
+      openedGraphControlStore,
     );
     const coordinator = rootCoordinator;
     const contextOperations = new HostContextCoordinator({
@@ -1036,12 +1042,13 @@ export async function createExecutionRuntimeHostComposition(
     const graphExecutions = new HostAgentGraphExecutionCoordinator({
       executions: coordinator,
       runtime: manager,
+      graphInstances: openedGraphControlStore,
     });
     graphSupervisorWake = new AgentGraphSupervisorWakeCoordinator({
       activityRegistry: graphWakeActivities,
       wakeStore: openedGraphControlStore,
-      readSnapshot: (rootSessionId) =>
-        requireGraphCoordinator(graphCoordinator).getSnapshot(rootSessionId),
+      readSnapshot: (rootSessionId, graphId) =>
+        requireGraphCoordinator(graphCoordinator).getSnapshot(rootSessionId, {}, graphId),
       startTurn: (sessionId, input, _activity, abortSignal, isCurrent) =>
         graphExecutions.run(sessionId, input, abortSignal, isCurrent),
       inspectAttempt: async (rootSessionId, attemptId, turnId) => {
@@ -1212,9 +1219,7 @@ export async function createExecutionRuntimeHostComposition(
         await openedDeepResearchStore.purgeSessionState(sessionId);
       },
       purgeAgentGraphState: async (sessionId) => {
-        await openedGraphControlStore.purgeAgentGraphControlState(
-          agentGraphIdForRootSession(sessionId),
-        );
+        await openedGraphControlStore.purgeAgentGraphControlStateForRootSession(sessionId);
       },
       worktrees: worktreeChildExecutor,
       requestDrain: context.requestDrain,

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto';
 import { isDeepStrictEqual } from 'node:util';
 import type { BackendStopMode } from '@maka/core/backend-types';
+import type { AgentGraphInstanceStore } from '@maka/core/agent-graph-instance';
 import type { AgentRunHeader, RootExecutionDescriptor } from '@maka/core/agent-run';
 import {
   INLINE_REFERENCE_MAX_COUNT,
@@ -16,7 +17,10 @@ import {
   decodeSkillInvocationResult,
   type SkillInvocationResult,
 } from '@maka/core/skill-invocation';
-import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinator';
+import {
+  agentGraphIdForRootSession,
+  agentGraphIdForRootSessionEpoch,
+} from '@maka/runtime/stream-graph-coordinator';
 import {
   RuntimeHostedRootConflictError,
   RuntimeHostedRootUnavailableError,
@@ -298,6 +302,12 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
     ) => Promise<void>,
     attachmentValidator?: HostTurnAttachmentValidator,
     prepareSkillInvocation?: HostSkillInvocationPreparer,
+    private readonly graphInstances?: Pick<
+      AgentGraphInstanceStore,
+      | 'getOrCreateActiveAgentGraphInstance'
+      | 'readActiveAgentGraphInstance'
+      | 'readLatestAgentGraphInstance'
+    >,
   ) {
     this.stores = authenticateExecutionStoresWriter(stores, 'interactive');
     this.executionProjection = new HostedExecutionProjectionReader(this.stores);
@@ -928,11 +938,10 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
       mode?: BackendStopMode;
     } = {},
   ): Promise<void> {
-    const graphId = agentGraphIdForRootSession(sessionId);
     const identity = await this.runCommand(() =>
       this.sessionAdmission.run(sessionId, () => {
         const active = this.#executions.get(sessionId);
-        if (!active || !activeRootOwnsAgentGraph(active, graphId)) return undefined;
+        if (!active?.graphOwnerId) return undefined;
         return {
           sessionId,
           turnId: active.turnId,
@@ -2346,9 +2355,22 @@ export class RootTurnCoordinator implements HostedExecutionAuthority {
           resolveEffectiveOrchestration(session.orchestrationMode, undefined).mode)
         : resolveEffectiveOrchestration(session.orchestrationMode, admission.turnOrchestration)
             .mode;
-    return mode === 'graph' || mode === 'swarm'
-      ? agentGraphIdForRootSession(admission.sessionId)
-      : undefined;
+    if (mode !== 'graph' && mode !== 'swarm') return undefined;
+    if (admission.execution.kind === 'agent_graph_supervisor_wake') {
+      return admission.execution.graphId;
+    }
+    if (!this.graphInstances) return agentGraphIdForRootSession(admission.sessionId);
+    const active = await this.graphInstances.readActiveAgentGraphInstance(admission.sessionId);
+    if (active) return active.graphId;
+    const latest = await this.graphInstances.readLatestAgentGraphInstance(admission.sessionId);
+    const sequence = (latest?.sequence ?? 0) + 1;
+    return (
+      await this.graphInstances.getOrCreateActiveAgentGraphInstance({
+        schemaVersion: 1,
+        graphId: agentGraphIdForRootSessionEpoch(admission.sessionId, sequence),
+        rootSessionId: admission.sessionId,
+      })
+    ).instance.graphId;
   }
 
   private async assertRunMatchesDurableExecution(
@@ -2699,10 +2721,6 @@ function isTerminalSnapshot(snapshot: TurnSnapshot): boolean {
     snapshot.status === 'failed' ||
     snapshot.status === 'cancelled'
   );
-}
-
-function activeRootOwnsAgentGraph(active: ActiveRootTurn, graphId: string): boolean {
-  return active.graphOwnerId === graphId;
 }
 
 function isShutdownCancelledBackendStart(error: unknown): boolean {

--- a/packages/runtime-host/src/server/sandbox-boundary-graph-wake.ts
+++ b/packages/runtime-host/src/server/sandbox-boundary-graph-wake.ts
@@ -1,18 +1,23 @@
 import type { SessionHeader } from '@maka/core/session';
-import { agentGraphIdForRootSession } from '@maka/runtime/stream-graph-coordinator';
+import type { AgentGraphInstanceStore } from '@maka/core/agent-graph-instance';
 
 export interface SandboxBoundaryGraphWakeHeaderReader {
   readHeaderSnapshot(sessionId: string): Promise<Pick<SessionHeader, 'id' | 'subagentParent'>>;
 }
 
 /** Resolve the root Session whose parked graph wake a boundary answer can release. */
-export function sandboxBoundaryGraphWakeRoot(
+export async function sandboxBoundaryGraphWakeRoot(
   header: Pick<SessionHeader, 'id' | 'subagentParent'>,
-): string | undefined {
+  graphInstances?: Pick<AgentGraphInstanceStore, 'listAgentGraphInstances'>,
+): Promise<string | undefined> {
   const parent = header.subagentParent;
   if (!parent) return header.id;
   if (!parent.graph) return undefined;
-  if (parent.graph.graphId !== agentGraphIdForRootSession(parent.parentSessionId)) {
+  if (!graphInstances) {
+    throw new Error('Graph operator lineage requires the graph instance authority');
+  }
+  const owned = await graphInstances.listAgentGraphInstances(parent.parentSessionId);
+  if (!owned.some((instance) => instance.graphId === parent.graph?.graphId)) {
     throw new Error(
       `Graph operator Session ${header.id} does not match root Session ${parent.parentSessionId}`,
     );
@@ -24,9 +29,10 @@ export function sandboxBoundaryGraphWakeRoot(
 export async function notifySandboxBoundaryGraphWake(
   sessionId: string,
   sessions: SandboxBoundaryGraphWakeHeaderReader,
+  graphInstances: Pick<AgentGraphInstanceStore, 'listAgentGraphInstances'>,
   notifyPermissionResponse: (rootSessionId: string) => Promise<void> | void,
 ): Promise<void> {
   const header = await sessions.readHeaderSnapshot(sessionId);
-  const rootSessionId = sandboxBoundaryGraphWakeRoot(header);
+  const rootSessionId = await sandboxBoundaryGraphWakeRoot(header, graphInstances);
   if (rootSessionId) await notifyPermissionResponse(rootSessionId);
 }

--- a/packages/runtime-host/src/server/session-retirement-coordinator.ts
+++ b/packages/runtime-host/src/server/session-retirement-coordinator.ts
@@ -66,6 +66,7 @@ type RetirementSessionEffects = {
 };
 type RetirementGraph = {
   hasLiveSessionState(sessionId: string): Promise<boolean>;
+  listGraphInstances?(sessionId: string): Promise<readonly { readonly graphId: string }[]>;
 };
 type RetirementGraphWake = {
   hasLiveSessionState(sessionId: string): boolean;
@@ -378,7 +379,21 @@ export class HostSessionRetirementCoordinator {
         sessionRevisionFamilyId(header) === familyId,
     );
     const graphRoots = new Map(
-      roots.map((header) => [header.id, agentGraphIdForRootSession(header.id)]),
+      await Promise.all(
+        roots.map(
+          async (header) =>
+            [
+              header.id,
+              new Set(
+                this.#graph.listGraphInstances
+                  ? (await this.#graph.listGraphInstances(header.id)).map(
+                      (instance) => instance.graphId,
+                    )
+                  : [agentGraphIdForRootSession(header.id)],
+              ),
+            ] as const,
+        ),
+      ),
     );
     const members = headers
       .filter((header) => {
@@ -387,7 +402,7 @@ export class HostSessionRetirementCoordinator {
         const parent = header.subagentParent;
         return (
           parent?.graph !== undefined &&
-          parent.graph.graphId === graphRoots.get(parent.parentSessionId)
+          graphRoots.get(parent.parentSessionId)?.has(parent.graph.graphId) === true
         );
       })
       .map((header) => header.id);

--- a/packages/runtime-host/src/server/session-revision-coordinator.ts
+++ b/packages/runtime-host/src/server/session-revision-coordinator.ts
@@ -76,7 +76,7 @@ export interface HostSessionRevisionCoordinatorOptions {
   readonly continuity: SessionContinuityCoordinator;
   readonly graph: Pick<
     import('@maka/runtime/stream-graph-coordinator').AgentGraphCoordinator,
-    'readSessionState'
+    'readSessionState' | 'listGraphInstances'
   >;
   readonly isSessionActive: (sessionId: string) => boolean;
   readonly requestDrain: () => void;

--- a/packages/runtime-host/src/server/session-revision-graph-references.ts
+++ b/packages/runtime-host/src/server/session-revision-graph-references.ts
@@ -23,7 +23,8 @@ export type AgentGraphRevisionReferencePreparation =
       readonly message: string;
     };
 
-type GraphReader = Pick<AgentGraphCoordinator, 'readSessionState'>;
+type GraphReader = Pick<AgentGraphCoordinator, 'readSessionState'> &
+  Partial<Pick<AgentGraphCoordinator, 'listGraphInstances'>>;
 
 interface GraphRevisionDependencies {
   readonly agentRunStore: {
@@ -119,15 +120,31 @@ export async function prepareAgentGraphRevisionReferences(
 
   const references = new Map<string, MutableExternalChildReferences>();
   const runsByChildSession = new Map<string, ReadonlyMap<string, AgentRunHeader>>();
+  const graphIdsByRoot = new Map<string, ReadonlySet<string>>();
   for (const request of requests) {
     const childSessionId = request.childSessionId;
     const child = headersById.get(childSessionId);
     const parent = child?.subagentParent;
+    let ownedGraphIds = graphIdsByRoot.get(parent?.parentSessionId ?? '');
+    if (parent?.graph && !ownedGraphIds) {
+      try {
+        ownedGraphIds = new Set(
+          dependencies.graph.listGraphInstances
+            ? (await dependencies.graph.listGraphInstances(parent.parentSessionId)).map(
+                (instance) => instance.graphId,
+              )
+            : [agentGraphIdForRootSession(parent.parentSessionId)],
+        );
+      } catch {
+        return failure('operation_unavailable', 'Retained Agent Graph lineage is unavailable');
+      }
+      graphIdsByRoot.set(parent.parentSessionId, ownedGraphIds);
+    }
     if (
       !child ||
       !parent?.graph ||
       !familySessionIds.has(parent.parentSessionId) ||
-      parent.graph.graphId !== agentGraphIdForRootSession(parent.parentSessionId) ||
+      !ownedGraphIds?.has(parent.graph.graphId) ||
       !retainedTurnIds.has(parent.spawnedBy.parentTurnId)
     ) {
       return failure(

--- a/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
@@ -491,6 +491,32 @@ describe('Agent Graph supervisor wake delivery', () => {
     }
   });
 
+  test('recovers a historical wake from its exact graph instance snapshot', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const requestedGraphIds: Array<string | undefined> = [];
+    await createRunningAttempt(store);
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async (_rootSessionId, graphId) => {
+        requestedGraphIds.push(graphId);
+        return snapshot({ graphId: graphId ?? 'graph-current' });
+      },
+      startTurn: async (_sessionId, input) => ({ kind: 'completed', turnId: input.turnId }),
+      inspectAttempt: async () => 'failed',
+      newId: sequentialIds(),
+    });
+    try {
+      await coordinator.recover();
+      await coordinator.waitForIdle();
+      assert.ok(requestedGraphIds.length > 0);
+      assert.ok(requestedGraphIds.every((graphId) => graphId === 'graph-1'));
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
   test('converges a completed crash-window AgentRun without duplicate delivery', async () => {
     const store = createSqliteSessionMetadataStore(':memory:');
     await createRunningAttempt(store);

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -31,6 +31,7 @@ import {
   AgentGraphClientOperationError,
   AgentGraphCoordinator,
   agentGraphIdForRootSession,
+  agentGraphIdForRootSessionEpoch,
   type AgentGraphCoordinatorInput,
 } from '../stream-graph-coordinator.js';
 import { encodeAgentGraphTerminalCursor } from '../stream-graph-read-model.js';
@@ -485,6 +486,9 @@ describe('host-managed agent graph coordinator', () => {
     const graphId = agentGraphIdForRootSession('root-session');
     assert.match(graphId, /^agent_graph_[a-f0-9]{32}$/);
     assert.equal(graphId, agentGraphIdForRootSession('root-session'));
+    assert.equal(graphId, agentGraphIdForRootSessionEpoch('root-session', 1));
+    assert.notEqual(graphId, agentGraphIdForRootSessionEpoch('root-session', 2));
+    assert.deepEqual(['root-session'].map(agentGraphIdForRootSession), [graphId]);
     assert.notEqual(graphId, agentGraphIdForRootSession('other-root'));
   });
 
@@ -968,6 +972,88 @@ describe('host-managed agent graph coordinator', () => {
             (failure) => failure instanceof AggregateError && failure.errors.length === 2,
           )),
     );
+  });
+
+  test('binds later supervisor turns to a new graph instance after finish', async () => {
+    const rootSessionId = 'root-session';
+    const controlStore = createSqliteSessionMetadataStore(':memory:');
+    const coordinator = new AgentGraphCoordinator({
+      sessionStore: {
+        listForRecovery: async () => [],
+        readHeader: async (sessionId: string) =>
+          ({ id: sessionId, status: 'active', isArchived: false }) as never,
+      },
+      runStore: { listSessionRuns: async () => [] },
+      runtimeEventStore: { readImmutableRuntimeEvents: async () => [] },
+      controlStore,
+      runtime: {
+        provisionAgentGraphOperator: async () => {
+          throw new Error('no work should be provisioned');
+        },
+        runClaimedAgentGraphIntent: async () => {
+          throw new Error('no work should be dispatched');
+        },
+        stopSession: async () => {},
+      },
+      newId: randomUUID,
+      rootSessionId,
+    } as unknown as AgentGraphCoordinatorInput);
+    try {
+      const firstTools = await coordinator.toolsForSession(rootSessionId);
+      const first = await controlStore.readActiveAgentGraphInstance(rootSessionId);
+      assert.ok(first);
+      assert.equal(first.sequence, 1);
+
+      await controlStore.commitAgentGraphScheduleUpdate(
+        compileAgentGraphScheduleUpdate({
+          graphId: first.graphId,
+          input: {
+            operation: 'finish',
+            finish: { result_ids: ['published-result'], reason: 'first graph complete' },
+          },
+          context: toolContext(rootSessionId, 'run-first', 'turn-first', 'tool-finish'),
+        }),
+      );
+
+      const secondTools = await coordinator.toolsForSession(rootSessionId);
+      const second = await controlStore.readActiveAgentGraphInstance(rootSessionId);
+      assert.ok(second);
+      assert.equal(second.sequence, 2);
+      assert.notEqual(second.graphId, first.graphId);
+      assert.equal(firstTools.length, secondTools.length);
+      assert.deepEqual(
+        (await controlStore.listAgentGraphInstances(rootSessionId)).map(
+          (instance) => instance.status,
+        ),
+        ['finished', 'open'],
+      );
+
+      const staleUpdate = firstTools.find((tool) => tool.name === UPDATE_AGENT_GRAPH_TOOL_NAME);
+      assert.ok(staleUpdate);
+      await assert.rejects(
+        async () =>
+          await staleUpdate.impl(
+            {
+              operation: 'add_work',
+              add_work: [
+                {
+                  target_kind: 'new_agent',
+                  agent_id: 'implementation',
+                  instruction: 'This must not drift into the next graph.',
+                  input_ids: [],
+                  replacement_mode: 'none',
+                },
+              ],
+            },
+            toolContext(rootSessionId, 'run-stale', 'turn-stale', 'tool-stale'),
+          ),
+        /already finished/,
+      );
+      assert.deepEqual(await controlStore.listAgentGraphScheduleUpdates(second.graphId), []);
+    } finally {
+      await coordinator.close();
+      controlStore.close();
+    }
   });
 
   test('rejects concurrent yield when reconciliation only waits for uncommitted input', async () => {

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -158,7 +158,7 @@ export type AgentGraphSupervisorWakeDiagnostic =
 export interface AgentGraphSupervisorWakeInput {
   activityRegistry: SessionActivityRegistry;
   wakeStore: AgentGraphSupervisorWakeStore;
-  readSnapshot(rootSessionId: string): Promise<AgentGraphClientSnapshot>;
+  readSnapshot(rootSessionId: string, graphId?: string): Promise<AgentGraphClientSnapshot>;
   startTurn(
     sessionId: string,
     input: UserMessageInput,
@@ -246,6 +246,7 @@ export class AgentGraphSupervisorWakeCoordinator {
   notify(
     rootSessionId: string,
     result?: AgentGraphScheduleReconciliationResult,
+    graphId?: string,
   ): Promise<void> | undefined {
     if (
       this.#closed ||
@@ -256,7 +257,7 @@ export class AgentGraphSupervisorWakeCoordinator {
     }
     return this.#runTracked(rootSessionId, async (abortSignal) => {
       try {
-        await this.#wake(rootSessionId, abortSignal, result);
+        await this.#wake(rootSessionId, abortSignal, result, graphId);
       } catch (error) {
         if (!this.#closed && !isAbortError(error)) {
           await notifyError(this.#input.onError, rootSessionId, error);
@@ -350,10 +351,11 @@ export class AgentGraphSupervisorWakeCoordinator {
     rootSessionId: string,
     abortSignal: AbortSignal,
     result?: AgentGraphScheduleReconciliationResult,
+    graphId?: string,
   ): Promise<void> {
     abortSignal.throwIfAborted();
     if (!(await this.#isSessionDeliverable(rootSessionId))) return;
-    const snapshot = await this.#input.readSnapshot(rootSessionId);
+    const snapshot = await this.#input.readSnapshot(rootSessionId, graphId);
     abortSignal.throwIfAborted();
     const wakeDecision = await this.#input.shouldWake?.(rootSessionId, result, snapshot);
     abortSignal.throwIfAborted();
@@ -425,7 +427,7 @@ export class AgentGraphSupervisorWakeCoordinator {
       await this.#supersedeSession(wake.rootSessionId, 'session_unavailable');
       return;
     }
-    const snapshot = await this.#input.readSnapshot(wake.rootSessionId);
+    const snapshot = await this.#input.readSnapshot(wake.rootSessionId, wake.graphId);
     if (
       this.#closed ||
       snapshot.closed ||
@@ -618,7 +620,7 @@ export class AgentGraphSupervisorWakeCoordinator {
   ): Promise<AgentGraphSupervisorContextOverflowError> {
     let currentSnapshot = fallbackSnapshot;
     try {
-      currentSnapshot = await this.#input.readSnapshot(rootSessionId);
+      currentSnapshot = await this.#input.readSnapshot(rootSessionId, fallbackSnapshot.graphId);
     } catch {
       // The checkpoint snapshot is already durable and sufficient for a bounded fallback.
     }
@@ -650,7 +652,7 @@ export class AgentGraphSupervisorWakeCoordinator {
   async #isWakeCurrent(wake: AgentGraphSupervisorWakeRecord): Promise<boolean> {
     if (this.#sessionWakesSuppressed(wake.rootSessionId)) return false;
     if (!(await this.#isSessionDeliverable(wake.rootSessionId))) return false;
-    const snapshot = await this.#input.readSnapshot(wake.rootSessionId);
+    const snapshot = await this.#input.readSnapshot(wake.rootSessionId, wake.graphId);
     return (
       !snapshot.closed &&
       snapshot.graphId === wake.graphId &&

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -1,5 +1,6 @@
 import type { AgentGraphClientProjectionStore } from '@maka/core/agent-graph-client-projection';
 import type { AgentGraphIntentClaim } from '@maka/core/agent-graph-control';
+import type { AgentGraphInstance, AgentGraphInstanceStore } from '@maka/core/agent-graph-instance';
 import type {
   AgentGraphScheduleControlStore,
   AgentGraphScheduleUpdate,
@@ -86,6 +87,7 @@ export interface AgentGraphCoordinatorInput {
   runStore: Pick<AgentRunStore, 'listSessionRuns'>;
   runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'>;
   controlStore: AgentGraphScheduleControlStore &
+    AgentGraphInstanceStore &
     AgentGraphClientProjectionStore &
     AgentGraphTimelineMetadataStore;
   runtime: AgentGraphCoordinatorRuntime;
@@ -104,9 +106,10 @@ export interface AgentGraphCoordinatorInput {
   onReconciliation?(
     rootSessionId: string,
     result: AgentGraphScheduleReconciliationResult,
+    graphId: string,
   ): void | Promise<void>;
   /** Durable client projection reached a checkpoint before the whole dispatch wave settled. */
-  onCheckpoint?(rootSessionId: string): void | Promise<void>;
+  onCheckpoint?(rootSessionId: string, graphId: string): void | Promise<void>;
   onError?(rootSessionId: string, error: unknown): void | Promise<void>;
 }
 
@@ -194,6 +197,7 @@ interface AgentGraphClientSubscription {
 export class AgentGraphCoordinator {
   readonly #input: AgentGraphCoordinatorInput;
   readonly #drivers = new Map<string, GraphDriver>();
+  readonly #currentGraphIds = new Map<string, string>();
   readonly #clientSubscriptions = new Set<AgentGraphClientSubscription>();
   #drainTask: Promise<unknown[]> | undefined;
   #closed = false;
@@ -219,12 +223,13 @@ export class AgentGraphCoordinator {
    */
   async toolsForSession(rootSessionId: string): Promise<MakaTool[]> {
     await this.#assertRootSupervisor(rootSessionId);
-    const driver = this.#driver(rootSessionId);
+    const instance = await this.#resolveGraphInstance(rootSessionId, true);
+    const driver = this.#driver(rootSessionId, instance.graphId);
     return [
       ...buildAgentGraphSupervisorTools({
         graphId: driver.graphId,
         scheduleStore: this.#input.controlStore,
-        observeGraph: () => this.observe(rootSessionId),
+        observeGraph: () => this.#observeGraph(rootSessionId, driver.graphId),
         prepareYieldPermit: () => this.#prepareYieldPermit(driver),
         authorizeScheduleUpdate: (request): ScheduleWakeFence => {
           if (request.graphId !== driver.graphId || request.source.sessionId !== rootSessionId) {
@@ -242,7 +247,9 @@ export class AgentGraphCoordinator {
           this.#wakeFromSchedule(driver, decodeScheduleWakeFence(authorization));
         },
       }),
-      buildAgentSwarmStatusTool({ readSnapshot: () => this.getSnapshot(rootSessionId) }),
+      buildAgentSwarmStatusTool({
+        readSnapshot: () => this.getSnapshot(rootSessionId, {}, driver.graphId),
+      }),
     ];
   }
 
@@ -253,9 +260,21 @@ export class AgentGraphCoordinator {
   async getSnapshot(
     rootSessionId: string,
     options: AgentGraphClientSnapshotOptions = {},
+    graphIdOverride?: string,
   ): Promise<AgentGraphClientSnapshot> {
     await this.#assertRootGraphReader(rootSessionId);
-    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const instance = graphIdOverride
+      ? (await this.#input.controlStore.listAgentGraphInstances(rootSessionId)).find(
+          (candidate) => candidate.graphId === graphIdOverride,
+        )
+      : await this.#resolveGraphInstance(rootSessionId, false);
+    if (graphIdOverride && !instance) {
+      throw new AgentGraphClientOperationError(
+        'not_found',
+        `Agent graph ${graphIdOverride} does not belong to root Session ${rootSessionId}`,
+      );
+    }
+    const graphId = instance?.graphId ?? agentGraphIdForRootSession(rootSessionId);
     let before: ReturnType<typeof decodeAgentGraphTerminalCursor> | undefined;
     try {
       before = options.terminalCursor
@@ -318,13 +337,22 @@ export class AgentGraphCoordinator {
   }
 
   async readSessionState(rootSessionId: string): Promise<'absent' | 'live' | 'terminal'> {
-    const snapshot = buildAgentGraphClientSnapshot(await this.#readClientModelInput(rootSessionId));
+    const instance = await this.#resolveGraphInstance(rootSessionId, false);
+    if (!instance) return 'absent';
+    const snapshot = buildAgentGraphClientSnapshot(
+      await this.#readClientModelInput(rootSessionId, undefined, instance.graphId),
+    );
     if (snapshot.scheduleRevision === 0) return 'absent';
     return !snapshot.closed || snapshot.status === 'closing' ? 'live' : 'terminal';
   }
 
   async hasLiveSessionState(rootSessionId: string): Promise<boolean> {
     return (await this.readSessionState(rootSessionId)) === 'live';
+  }
+
+  async listGraphInstances(rootSessionId: string): Promise<AgentGraphInstance[]> {
+    await this.#assertRootGraphReader(rootSessionId);
+    return this.#input.controlStore.listAgentGraphInstances(rootSessionId);
   }
 
   /**
@@ -338,7 +366,8 @@ export class AgentGraphCoordinator {
     options: AgentGraphTimelinePageOptions = {},
   ): Promise<AgentGraphTimelinePage> {
     await this.#assertRootGraphReader(rootSessionId);
-    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const instance = await this.#resolveGraphInstance(rootSessionId, false);
+    const graphId = instance?.graphId ?? agentGraphIdForRootSession(rootSessionId);
     return readAgentGraphTimelinePage({
       rootSessionId,
       graphId,
@@ -355,7 +384,8 @@ export class AgentGraphCoordinator {
     operatorId: string,
   ): Promise<AgentGraphOperatorInspection> {
     await this.#assertRootGraphReader(rootSessionId);
-    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const instance = await this.#resolveGraphInstance(rootSessionId, false);
+    const graphId = instance?.graphId ?? agentGraphIdForRootSession(rootSessionId);
     await this.#readOrRebuildClientProjection(rootSessionId, graphId);
     const materialized = await this.#input.controlStore.readAgentGraphClientProjectionWithOperator(
       graphId,
@@ -418,19 +448,43 @@ export class AgentGraphCoordinator {
   /** Wake reconciliation without making the caller part of the data path. */
   wake(rootSessionId: string): void {
     if (this.#closed) return;
-    const driver = this.#driver(rootSessionId);
+    const graphId = this.#currentGraphIds.get(rootSessionId);
+    if (!graphId) {
+      void this.#wakeActiveGraph(rootSessionId);
+      return;
+    }
+    const driver = this.#driver(rootSessionId, graphId);
+    this.#wakeDriver(driver);
+  }
+
+  #wakeDriver(driver: GraphDriver): void {
     if (driver.stopping) return;
     driver.paused = false;
     this.#requestDrive(driver);
   }
 
+  async #wakeActiveGraph(rootSessionId: string): Promise<void> {
+    try {
+      const active = await this.#input.controlStore.readActiveAgentGraphInstance(rootSessionId);
+      if (!active || this.#closed) return;
+      this.#wakeDriver(this.#driver(rootSessionId, active.graphId));
+    } catch (error) {
+      void notify(this.#input.onError, rootSessionId, error);
+    }
+  }
+
   /** Reconcile now and surface any host-level failure to explicit callers. */
   async reconcile(rootSessionId: string): Promise<AgentGraphScheduleReconciliationResult> {
     await this.#assertRootSupervisor(rootSessionId);
-    const driver = this.#driver(rootSessionId);
+    const instance = await this.#resolveGraphInstance(rootSessionId, true);
+    const driver = this.#driver(rootSessionId, instance.graphId);
+    return this.#reconcileDriver(driver);
+  }
+
+  async #reconcileDriver(driver: GraphDriver): Promise<AgentGraphScheduleReconciliationResult> {
     driver.lastError = undefined;
-    this.wake(rootSessionId);
-    await this.waitForIdle(rootSessionId);
+    this.#wakeDriver(driver);
+    while (driver.task) await driver.task;
     if (driver.lastError !== undefined) throw driver.lastError;
     if (!driver.lastResult) {
       throw new Error(`Agent graph ${driver.graphId} produced no reconciliation result`);
@@ -439,7 +493,9 @@ export class AgentGraphCoordinator {
   }
 
   async waitForIdle(rootSessionId: string): Promise<void> {
-    const driver = this.#driver(rootSessionId);
+    const graphId = this.#currentGraphIds.get(rootSessionId);
+    if (!graphId) return;
+    const driver = this.#driver(rootSessionId, graphId);
     while (driver.task) await driver.task;
   }
 
@@ -454,19 +510,38 @@ export class AgentGraphCoordinator {
     for (const header of await this.#input.sessionStore.listForRecovery()) {
       if (this.#input.rootSessionId && header.id !== this.#input.rootSessionId) continue;
       if (header.subagentParent || header.isArchived || header.status === 'archived') continue;
-      const graphId = agentGraphIdForRootSession(header.id);
-      const updates = await this.#input.controlStore.listAgentGraphScheduleUpdates(graphId);
-      if (updates.length === 0) continue;
-      updates.forEach((update) => this.#assertScheduleOwnedByRoot(update, header.id, graphId));
-      await this.reconcile(header.id);
-      recovered.push(header.id);
+      const instances = await this.#input.controlStore.listAgentGraphInstances(header.id);
+      let recoveredRoot = false;
+      for (const instance of instances) {
+        const updates = await this.#input.controlStore.listAgentGraphScheduleUpdates(
+          instance.graphId,
+        );
+        if (updates.length === 0) continue;
+        updates.forEach((update) =>
+          this.#assertScheduleOwnedByRoot(update, header.id, instance.graphId),
+        );
+        await this.#reconcileDriver(
+          this.#driver(header.id, instance.graphId, instance.status === 'open'),
+        );
+        recoveredRoot = true;
+      }
+      if (recoveredRoot) recovered.push(header.id);
     }
     return recovered;
   }
 
   async observe(rootSessionId: string): Promise<AgentGraphSupervisorObservation> {
     await this.#assertRootSupervisor(rootSessionId);
-    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const instance = await this.#resolveGraphInstance(rootSessionId, false);
+    const graphId = instance?.graphId ?? agentGraphIdForRootSession(rootSessionId);
+    return this.#observeGraph(rootSessionId, graphId);
+  }
+
+  async #observeGraph(
+    rootSessionId: string,
+    graphId: string,
+  ): Promise<AgentGraphSupervisorObservation> {
+    await this.#assertRootSupervisor(rootSessionId);
     const topology = await this.#readTopology(graphId);
     return this.#observeTopology(topology);
   }
@@ -506,14 +581,18 @@ export class AgentGraphCoordinator {
    */
   async stop(rootSessionId: string): Promise<void> {
     await this.#assertRootSupervisor(rootSessionId);
-    const driver = this.#driver(rootSessionId);
+    const instance = await this.#resolveGraphInstance(rootSessionId, false);
+    if (!instance) return;
+    const driver = this.#driver(rootSessionId, instance.graphId);
     return this.#stopGraph(driver);
   }
 
   /** Stop the validated root supervisor and its graph under one wake fence. */
   async stopExecution(rootSessionId: string, input: AgentGraphExecutionStopInput): Promise<void> {
     await this.#assertRootSupervisor(rootSessionId);
-    const driver = this.#driver(rootSessionId);
+    const instance = await this.#resolveGraphInstance(rootSessionId, false);
+    if (!instance) return;
+    const driver = this.#driver(rootSessionId, instance.graphId);
     await input.withSupervisorWakesSuppressed(async () => {
       const failures: unknown[] = [];
       try {
@@ -625,7 +704,7 @@ export class AgentGraphCoordinator {
         if (driver.clientProjectionDirty) {
           await this.#repairClientProjectionBestEffort(driver);
         }
-        await notify(this.#input.onReconciliation, driver.rootSessionId, result);
+        await notify(this.#input.onReconciliation, driver.rootSessionId, result, driver.graphId);
         if (isAgentGraphSupervisorMilestone(result)) {
           for (const waiter of driver.yieldWaiters) {
             if (!waiter.cancelled && generation >= waiter.minimumGeneration) {
@@ -730,7 +809,7 @@ export class AgentGraphCoordinator {
                 advancement &&
                 isSwarmCheckpointTransition(advancement.before, advancement.after)
               ) {
-                await notify(this.#input.onCheckpoint, driver.rootSessionId);
+                await notify(this.#input.onCheckpoint, driver.rootSessionId, driver.graphId);
               }
             });
           }
@@ -739,7 +818,7 @@ export class AgentGraphCoordinator {
         onReconciliationFailure: (failure) => {
           this.#queueClientProjectionUpdate(driver, async () => {
             await this.#mergeReconciliationFailure(driver, failure);
-            await notify(this.#input.onCheckpoint, driver.rootSessionId);
+            await notify(this.#input.onCheckpoint, driver.rootSessionId, driver.graphId);
           });
           void notify(this.#input.supervisor?.onReconciliationFailure, failure);
         },
@@ -750,9 +829,13 @@ export class AgentGraphCoordinator {
   async #readClientModelInput(
     rootSessionId: string,
     reconciliationFailures?: readonly AgentGraphClientReconciliationFailure[],
+    resolvedGraphId?: string,
   ): Promise<BuildAgentGraphClientReadModelInput> {
     await this.#assertRootGraphReader(rootSessionId);
-    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const graphId =
+      resolvedGraphId ??
+      (await this.#resolveGraphInstance(rootSessionId, false))?.graphId ??
+      agentGraphIdForRootSession(rootSessionId);
     const [provisions, scheduleUpdates, claimAdmissions, header, existing] = await Promise.all([
       this.#input.controlStore.listAgentGraphOperatorProvisions(graphId),
       this.#input.controlStore.listAgentGraphScheduleUpdates(graphId),
@@ -805,7 +888,7 @@ export class AgentGraphCoordinator {
       const expectedSnapshotVersion =
         (await this.#input.controlStore.readAgentGraphClientProjection(graphId))?.snapshotVersion ??
         null;
-      const input = await this.#readClientModelInput(rootSessionId);
+      const input = await this.#readClientModelInput(rootSessionId, undefined, graphId);
       if (input.graphId !== graphId) {
         throw new Error(`Agent graph rebuild resolved ${input.graphId}, expected ${graphId}`);
       }
@@ -935,7 +1018,11 @@ export class AgentGraphCoordinator {
       const existing = await this.#input.controlStore.readAgentGraphClientProjection(
         driver.graphId,
       );
-      const input = await this.#readClientModelInput(driver.rootSessionId, projected);
+      const input = await this.#readClientModelInput(
+        driver.rootSessionId,
+        projected,
+        driver.graphId,
+      );
       try {
         await this.#commitClientProjection(
           input,
@@ -1158,18 +1245,64 @@ export class AgentGraphCoordinator {
     }
   }
 
-  #driver(rootSessionId: string): GraphDriver {
+  async #resolveGraphInstance(rootSessionId: string, create: true): Promise<AgentGraphInstance>;
+  async #resolveGraphInstance(
+    rootSessionId: string,
+    create: false,
+  ): Promise<AgentGraphInstance | undefined>;
+  async #resolveGraphInstance(
+    rootSessionId: string,
+    create: boolean,
+  ): Promise<AgentGraphInstance | undefined> {
+    requireRootSessionId(rootSessionId);
+    const store = this.#input.controlStore as Partial<AgentGraphInstanceStore>;
+    if (
+      typeof store.readActiveAgentGraphInstance !== 'function' ||
+      typeof store.readLatestAgentGraphInstance !== 'function' ||
+      typeof store.getOrCreateActiveAgentGraphInstance !== 'function'
+    ) {
+      const graphId = agentGraphIdForRootSession(rootSessionId);
+      const listUpdates = (this.#input.controlStore as Partial<AgentGraphScheduleControlStore>)
+        .listAgentGraphScheduleUpdates;
+      const updates = listUpdates ? await listUpdates.call(this.#input.controlStore, graphId) : [];
+      if (!create && updates.length === 0) return undefined;
+      const finish = [...updates].reverse().find((update) => update.finish)?.committedAt;
+      return {
+        schemaVersion: 1,
+        graphId,
+        rootSessionId,
+        sequence: 1,
+        status: finish === undefined ? 'open' : 'finished',
+        createdAt: updates[0]?.committedAt ?? 0,
+        ...(finish === undefined ? {} : { finishedAt: finish }),
+      };
+    }
+    const active = await store.readActiveAgentGraphInstance(rootSessionId);
+    if (active) return active;
+    const latest = await store.readLatestAgentGraphInstance(rootSessionId);
+    if (!create) return latest;
+    const sequence = (latest?.sequence ?? 0) + 1;
+    return (
+      await store.getOrCreateActiveAgentGraphInstance({
+        schemaVersion: 1,
+        graphId: agentGraphIdForRootSessionEpoch(rootSessionId, sequence),
+        rootSessionId,
+      })
+    ).instance;
+  }
+
+  #driver(rootSessionId: string, graphId: string, bindCurrent = true): GraphDriver {
     if (this.#input.rootSessionId && rootSessionId !== this.#input.rootSessionId) {
       throw new Error(
         `Agent graph coordinator is scoped to root Session ${this.#input.rootSessionId}`,
       );
     }
-    const graphId = agentGraphIdForRootSession(rootSessionId);
     const existing = this.#drivers.get(graphId);
     if (existing) {
       if (existing.rootSessionId !== rootSessionId) {
         throw new Error(`Agent graph ${graphId} is already bound to another root Session`);
       }
+      if (bindCurrent) this.#currentGraphIds.set(rootSessionId, graphId);
       return existing;
     }
     const created: GraphDriver = {
@@ -1186,6 +1319,7 @@ export class AgentGraphCoordinator {
       yieldWaiters: new Set(),
     };
     this.#drivers.set(graphId, created);
+    if (bindCurrent) this.#currentGraphIds.set(rootSessionId, graphId);
     return created;
   }
 
@@ -1254,7 +1388,7 @@ export class AgentGraphCoordinator {
             }
             if (proved) await task;
           }
-          const current = await this.observe(driver.rootSessionId);
+          const current = await this.#observeGraph(driver.rootSessionId, driver.graphId);
           return (
             hasLiveGraphOperator(current) ||
             waiter.activationReady ||
@@ -1327,10 +1461,18 @@ function throwCollectedFailures(message: string, failures: readonly unknown[]): 
 }
 
 export function agentGraphIdForRootSession(rootSessionId: string): string {
+  return agentGraphIdForRootSessionEpoch(rootSessionId, 1);
+}
+
+export function agentGraphIdForRootSessionEpoch(rootSessionId: string, sequence: number): string {
   requireRootSessionId(rootSessionId);
+  if (!Number.isSafeInteger(sequence) || sequence < 1) {
+    throw new Error('Agent graph instance sequence must be a positive safe integer');
+  }
   const suffix = stableHash({
     schemaVersion: 1,
     rootSessionId,
+    ...(sequence === 1 ? {} : { sequence }),
   }).slice('sha256:'.length, 'sha256:'.length + 32);
   return `agent_graph_${suffix}`;
 }

--- a/packages/storage/src/__tests__/agent-graph-schedule-updates.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-schedule-updates.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
+import { DatabaseSync } from 'node:sqlite';
 import {
   AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
   AgentGraphScheduleClosedError,
@@ -137,6 +138,58 @@ describe('SQLite agent graph schedule updates', () => {
     }
   });
 
+  test('backfills legacy schedule ownership as the first graph instance', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-agent-graph-instance-migration-'));
+    const path = join(root, 'state.sqlite');
+    try {
+      const store = createSqliteSessionMetadataStore(path, { now: () => 77 });
+      await store.commitAgentGraphScheduleUpdate(request());
+      await store.commitAgentGraphScheduleUpdate(
+        request({
+          updateId: `graph_update_${'d'.repeat(32)}`,
+          updateFingerprint: `sha256:${'e'.repeat(64)}`,
+          source: {
+            sessionId: 'session-main',
+            runId: 'run-main',
+            turnId: 'turn-finish',
+            toolCallId: 'tool-finish',
+          },
+          addWork: [],
+          finish: { resultIds: ['result-1'], reason: 'legacy graph complete' },
+        }),
+      );
+      store.close();
+
+      const legacy = new DatabaseSync(path);
+      legacy.exec(`
+        DROP TABLE agent_graph_instances;
+        UPDATE session_metadata_schema
+        SET version = 23
+        WHERE scope = 'session_metadata';
+      `);
+      legacy.close();
+
+      const migrated = createSqliteSessionMetadataStore(path);
+      try {
+        assert.deepEqual(await migrated.listAgentGraphInstances('session-main'), [
+          {
+            schemaVersion: 1,
+            graphId: 'graph-1',
+            rootSessionId: 'session-main',
+            sequence: 1,
+            status: 'finished',
+            createdAt: 77,
+            finishedAt: 77,
+          },
+        ]);
+      } finally {
+        migrated.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('linearizes scheduled admission against revision changes and closure', async () => {
     const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(90) });
     try {
@@ -197,6 +250,103 @@ describe('SQLite agent graph schedule updates', () => {
         AgentGraphScheduleClosedError,
       );
       assert.equal((await store.listAgentGraphIntentClaims('graph-1')).length, 1);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('creates sequential graph instances after finish without reopening history', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(200) });
+    try {
+      const first = await store.getOrCreateActiveAgentGraphInstance({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'session-main',
+      });
+      assert.equal(first.created, true);
+      assert.equal(first.instance.sequence, 1);
+
+      await store.commitAgentGraphScheduleUpdate(request());
+      await store.commitAgentGraphScheduleUpdate(
+        request({
+          updateId: `graph_update_${'d'.repeat(32)}`,
+          updateFingerprint: `sha256:${'e'.repeat(64)}`,
+          source: {
+            sessionId: 'session-main',
+            runId: 'run-main',
+            turnId: 'turn-finish',
+            toolCallId: 'tool-finish',
+          },
+          addWork: [],
+          finish: { resultIds: ['result-1'], reason: 'first graph complete' },
+        }),
+      );
+
+      assert.equal(await store.readActiveAgentGraphInstance('session-main'), undefined);
+      assert.equal((await store.readLatestAgentGraphInstance('session-main'))?.status, 'finished');
+
+      const second = await store.getOrCreateActiveAgentGraphInstance({
+        schemaVersion: 1,
+        graphId: 'graph-2',
+        rootSessionId: 'session-main',
+      });
+      assert.equal(second.created, true);
+      assert.equal(second.instance.sequence, 2);
+      assert.notEqual(second.instance.graphId, first.instance.graphId);
+
+      const concurrentRetry = await store.getOrCreateActiveAgentGraphInstance({
+        schemaVersion: 1,
+        graphId: 'graph-3',
+        rootSessionId: 'session-main',
+      });
+      assert.equal(concurrentRetry.created, false);
+      assert.equal(concurrentRetry.instance.graphId, 'graph-2');
+
+      const secondUpdate = await store.commitAgentGraphScheduleUpdate(
+        request({
+          graphId: 'graph-2',
+          updateId: `graph_update_${'f'.repeat(32)}`,
+          updateFingerprint: `sha256:${'1'.repeat(64)}`,
+          source: {
+            sessionId: 'session-main',
+            runId: 'run-second',
+            turnId: 'turn-second',
+            toolCallId: 'tool-second',
+          },
+        }),
+      );
+      assert.equal(secondUpdate.update.revision, 1);
+      assert.deepEqual(
+        (await store.listAgentGraphInstances('session-main')).map((instance) => ({
+          graphId: instance.graphId,
+          sequence: instance.sequence,
+          status: instance.status,
+        })),
+        [
+          { graphId: 'graph-1', sequence: 1, status: 'finished' },
+          { graphId: 'graph-2', sequence: 2, status: 'open' },
+        ],
+      );
+
+      await assert.rejects(
+        store.commitAgentGraphScheduleUpdate(
+          request({
+            updateId: `graph_update_${'2'.repeat(32)}`,
+            updateFingerprint: `sha256:${'3'.repeat(64)}`,
+            source: {
+              sessionId: 'session-main',
+              runId: 'run-old',
+              turnId: 'turn-old',
+              toolCallId: 'tool-old',
+            },
+          }),
+        ),
+        /already finished/,
+      );
+      assert.equal(await store.purgeAgentGraphControlStateForRootSession('session-main'), 5);
+      assert.deepEqual(await store.listAgentGraphInstances('session-main'), []);
+      assert.deepEqual(await store.listAgentGraphScheduleUpdates('graph-1'), []);
+      assert.deepEqual(await store.listAgentGraphScheduleUpdates('graph-2'), []);
     } finally {
       store.close();
     }

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -1802,7 +1802,7 @@ describe('SQLite agent graph operator provisions', () => {
       assert.equal(await store.has(child.record.header.id), false);
       assert.equal((await store.listAgentGraphOperatorProvisions('graph-1')).length, 1);
 
-      assert.equal(await store.purgeAgentGraphControlState('graph-1'), 9);
+      assert.equal(await store.purgeAgentGraphControlState('graph-1'), 10);
       assert.deepEqual(await store.listAgentGraphOperatorProvisions('graph-1'), []);
       assert.deepEqual(await store.listAgentGraphScheduleUpdates('graph-1'), []);
       assert.deepEqual(await store.listAgentGraphIntentClaims('graph-1'), []);

--- a/packages/storage/src/operational-state-backup.ts
+++ b/packages/storage/src/operational-state-backup.ts
@@ -381,6 +381,7 @@ function validateSqlite(path: string, files: readonly OperationalBackupFile[]): 
         'session_metadata_labels',
         'session_metadata_tombstones',
         'subagent_spawns',
+        'agent_graph_instances',
         'agent_graph_intent_claims',
         'agent_graph_schedule_updates',
         'agent_graph_operator_provisions',

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1,10 +1,11 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 23;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 24;
 export const SQLITE_SESSION_MESSAGE_CHUNK_BYTES = 64 * 1024;
 export const SQLITE_SESSION_MESSAGE_CHUNK_MARKER = '{"$maka":"session-message-chunks-v1"}';
 
 export const SQLITE_AGENT_GRAPH_CONTROL_TABLES = [
+  'agent_graph_instances',
   'agent_graph_intent_claims',
   'agent_graph_schedule_updates',
   'agent_graph_operator_provisions',
@@ -877,7 +878,56 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
         REFERENCES session_message_payloads(session_id, sequence)
         ON DELETE CASCADE
     ) WITHOUT ROWID;
+  `,
+  ],
+  [
+    24,
+    `
+    CREATE TABLE IF NOT EXISTS agent_graph_instances (
+      graph_id TEXT PRIMARY KEY,
+      root_session_id TEXT NOT NULL,
+      sequence INTEGER NOT NULL CHECK (sequence > 0),
+      status TEXT NOT NULL CHECK (status IN ('open', 'finished')),
+      created_at INTEGER NOT NULL CHECK (created_at >= 0),
+      finished_at INTEGER,
+      CHECK (
+        (status = 'open' AND finished_at IS NULL)
+        OR (status = 'finished' AND finished_at IS NOT NULL AND finished_at >= created_at)
+      ),
+      UNIQUE(root_session_id, sequence)
+    );
 
+    CREATE UNIQUE INDEX IF NOT EXISTS agent_graph_instances_one_open_per_root
+      ON agent_graph_instances(root_session_id)
+      WHERE status = 'open';
+
+    INSERT OR IGNORE INTO agent_graph_instances(
+      graph_id,
+      root_session_id,
+      sequence,
+      status,
+      created_at,
+      finished_at
+    )
+    SELECT
+      updates.graph_id,
+      (
+        SELECT first_update.source_session_id
+        FROM agent_graph_schedule_updates first_update
+        WHERE first_update.graph_id = updates.graph_id
+        ORDER BY first_update.revision ASC
+        LIMIT 1
+      ),
+      1,
+      CASE WHEN MAX(updates.closes_graph) = 1 THEN 'finished' ELSE 'open' END,
+      MIN(updates.committed_at),
+      CASE
+        WHEN MAX(updates.closes_graph) = 1
+        THEN MAX(CASE WHEN updates.closes_graph = 1 THEN updates.committed_at END)
+        ELSE NULL
+      END
+    FROM agent_graph_schedule_updates updates
+    GROUP BY updates.graph_id;
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -17,6 +17,13 @@ import {
   type CommitAgentGraphClientProjectionRequest,
 } from '@maka/core/agent-graph-client-projection';
 import {
+  assertCreateAgentGraphInstanceRequest,
+  decodeAgentGraphInstance,
+  type AgentGraphInstance,
+  type AgentGraphInstanceResult,
+  type CreateAgentGraphInstanceRequest,
+} from '@maka/core/agent-graph-instance';
+import {
   assessSandboxBoundaryExpansion,
   assertExecutionBoundaryCapacity,
   decodeExecutionBoundary,
@@ -2179,6 +2186,51 @@ export class SqliteSessionMetadataStore {
     return rows.map(decodeAgentGraphIntentClaim);
   }
 
+  async getOrCreateActiveAgentGraphInstance(
+    request: CreateAgentGraphInstanceRequest,
+  ): Promise<AgentGraphInstanceResult> {
+    this.assertOpen();
+    assertCreateAgentGraphInstanceRequest(request);
+    return this.transaction(() => this.getOrCreateActiveAgentGraphInstanceSync(request));
+  }
+
+  async readActiveAgentGraphInstance(
+    rootSessionId: string,
+  ): Promise<AgentGraphInstance | undefined> {
+    this.assertOpen();
+    assertGraphLookupIdentity(rootSessionId, 'root Session id');
+    return this.readActiveAgentGraphInstanceSync(rootSessionId);
+  }
+
+  async readLatestAgentGraphInstance(
+    rootSessionId: string,
+  ): Promise<AgentGraphInstance | undefined> {
+    this.assertOpen();
+    assertGraphLookupIdentity(rootSessionId, 'root Session id');
+    return this.readLatestAgentGraphInstanceSync(rootSessionId);
+  }
+
+  async listAgentGraphInstances(rootSessionId: string): Promise<AgentGraphInstance[]> {
+    this.assertOpen();
+    assertGraphLookupIdentity(rootSessionId, 'root Session id');
+    const rows = this.db
+      .prepare(`
+        SELECT
+          1 AS schemaVersion,
+          graph_id AS graphId,
+          root_session_id AS rootSessionId,
+          sequence,
+          status,
+          created_at AS createdAt,
+          finished_at AS finishedAt
+        FROM agent_graph_instances
+        WHERE root_session_id = ?
+        ORDER BY sequence ASC
+      `)
+      .all(rootSessionId) as unknown as AgentGraphInstanceRow[];
+    return rows.map(decodeAgentGraphInstanceRow);
+  }
+
   async commitAgentGraphScheduleUpdate(
     request: AgentGraphScheduleUpdateRequest,
   ): Promise<AgentGraphScheduleUpdateResult> {
@@ -2189,6 +2241,30 @@ export class SqliteSessionMetadataStore {
       if (existingById) return this.matchAgentGraphScheduleUpdate(existingById, request);
       const existingBySource = this.readAgentGraphScheduleUpdateBySourceSync(request.source);
       if (existingBySource) return this.matchAgentGraphScheduleUpdate(existingBySource, request);
+      let committedAt: number | undefined;
+      const instance = this.readAgentGraphInstanceByIdSync(request.graphId);
+      if (!instance) {
+        committedAt = this.now();
+        const created = this.getOrCreateActiveAgentGraphInstanceSync(
+          {
+            schemaVersion: 1,
+            graphId: request.graphId,
+            rootSessionId: request.source.sessionId,
+          },
+          committedAt,
+        ).instance;
+        if (created.graphId !== request.graphId) {
+          throw new AgentGraphScheduleUpdateConflictError(
+            `Root Session ${request.source.sessionId} already has active graph ${created.graphId}`,
+          );
+        }
+      } else if (instance.rootSessionId !== request.source.sessionId) {
+        throw new AgentGraphScheduleUpdateConflictError(
+          `Agent graph ${request.graphId} belongs to another root Session`,
+        );
+      } else if (instance.status === 'finished') {
+        throw new AgentGraphScheduleUpdateConflictError('Agent graph schedule is already finished');
+      }
       if (this.hasClosedAgentGraphSchedule(request.graphId)) {
         throw new AgentGraphScheduleUpdateConflictError('Agent graph schedule is already finished');
       }
@@ -2211,7 +2287,7 @@ export class SqliteSessionMetadataStore {
             }
           : {}),
         revision,
-        committedAt: this.now(),
+        committedAt: committedAt ?? this.now(),
       };
       this.db
         .prepare(
@@ -2247,6 +2323,20 @@ export class SqliteSessionMetadataStore {
           update.committedAt,
         );
       this.options.failpoint?.('after_agent_graph_schedule_update_write');
+      if (update.finish) {
+        const closed = this.db
+          .prepare(`
+            UPDATE agent_graph_instances
+            SET status = 'finished', finished_at = ?
+            WHERE graph_id = ? AND status = 'open'
+          `)
+          .run(update.committedAt, update.graphId);
+        if (closed.changes !== 1) {
+          throw new AgentGraphScheduleUpdateConflictError(
+            `Agent graph instance ${update.graphId} could not be finished`,
+          );
+        }
+      }
       return { update: decodeAgentGraphScheduleUpdate(update), created: true };
     });
   }
@@ -2641,6 +2731,36 @@ export class SqliteSessionMetadataStore {
         0,
       ),
     );
+  }
+
+  async purgeAgentGraphControlStateForRootSession(rootSessionId: string): Promise<number> {
+    this.assertOpen();
+    assertGraphLookupIdentity(rootSessionId, 'root Session id');
+    return this.transaction(() => {
+      const graphIds = (
+        this.db
+          .prepare(`
+            SELECT graph_id AS graphId
+            FROM agent_graph_instances
+            WHERE root_session_id = ?
+            ORDER BY sequence ASC
+          `)
+          .all(rootSessionId) as Array<{ graphId: string }>
+      ).map((row) => row.graphId);
+      return graphIds.reduce(
+        (total, graphId) =>
+          total +
+          AGENT_GRAPH_CONTROL_DELETE_TABLES.reduce(
+            (removed, table) =>
+              removed +
+              Number(
+                this.db.prepare(`DELETE FROM ${table} WHERE graph_id = ?`).run(graphId).changes,
+              ),
+            0,
+          ),
+        0,
+      );
+    });
   }
 
   async readAgentGraphTimelineMetadata(
@@ -4493,6 +4613,112 @@ export class SqliteSessionMetadataStore {
     }
   }
 
+  private getOrCreateActiveAgentGraphInstanceSync(
+    request: CreateAgentGraphInstanceRequest,
+    createdAtOverride?: number,
+  ): AgentGraphInstanceResult {
+    const active = this.readActiveAgentGraphInstanceSync(request.rootSessionId);
+    if (active) return { instance: active, created: false };
+
+    const reused = this.readAgentGraphInstanceByIdSync(request.graphId);
+    if (reused) {
+      if (reused.rootSessionId !== request.rootSessionId) {
+        throw new SessionMetadataConflictError(
+          `Agent graph ${request.graphId} belongs to another root Session`,
+        );
+      }
+      if (reused.status !== 'open') {
+        throw new SessionMetadataConflictError(
+          `Finished agent graph ${request.graphId} cannot be reused`,
+        );
+      }
+      return { instance: reused, created: false };
+    }
+
+    const latest = this.readLatestAgentGraphInstanceSync(request.rootSessionId);
+    const sequence = (latest?.sequence ?? 0) + 1;
+    const createdAt = createdAtOverride ?? this.now();
+    this.db
+      .prepare(`
+        INSERT INTO agent_graph_instances(
+          graph_id,
+          root_session_id,
+          sequence,
+          status,
+          created_at,
+          finished_at
+        ) VALUES (?, ?, ?, 'open', ?, NULL)
+      `)
+      .run(request.graphId, request.rootSessionId, sequence, createdAt);
+    return {
+      instance: {
+        schemaVersion: 1,
+        graphId: request.graphId,
+        rootSessionId: request.rootSessionId,
+        sequence,
+        status: 'open',
+        createdAt,
+      },
+      created: true,
+    };
+  }
+
+  private readAgentGraphInstanceByIdSync(graphId: string): AgentGraphInstance | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT
+          1 AS schemaVersion,
+          graph_id AS graphId,
+          root_session_id AS rootSessionId,
+          sequence,
+          status,
+          created_at AS createdAt,
+          finished_at AS finishedAt
+        FROM agent_graph_instances
+        WHERE graph_id = ?
+      `)
+      .get(graphId) as unknown as AgentGraphInstanceRow | undefined;
+    return row ? decodeAgentGraphInstanceRow(row) : undefined;
+  }
+
+  private readActiveAgentGraphInstanceSync(rootSessionId: string): AgentGraphInstance | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT
+          1 AS schemaVersion,
+          graph_id AS graphId,
+          root_session_id AS rootSessionId,
+          sequence,
+          status,
+          created_at AS createdAt,
+          finished_at AS finishedAt
+        FROM agent_graph_instances
+        WHERE root_session_id = ? AND status = 'open'
+      `)
+      .get(rootSessionId) as unknown as AgentGraphInstanceRow | undefined;
+    return row ? decodeAgentGraphInstanceRow(row) : undefined;
+  }
+
+  private readLatestAgentGraphInstanceSync(rootSessionId: string): AgentGraphInstance | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT
+          1 AS schemaVersion,
+          graph_id AS graphId,
+          root_session_id AS rootSessionId,
+          sequence,
+          status,
+          created_at AS createdAt,
+          finished_at AS finishedAt
+        FROM agent_graph_instances
+        WHERE root_session_id = ?
+        ORDER BY sequence DESC
+        LIMIT 1
+      `)
+      .get(rootSessionId) as unknown as AgentGraphInstanceRow | undefined;
+    return row ? decodeAgentGraphInstanceRow(row) : undefined;
+  }
+
   private transaction<T>(operation: () => T): T {
     if (this.databaseLease) return this.databaseLease.transaction('write', operation);
     this.db.exec('BEGIN IMMEDIATE');
@@ -4659,6 +4885,16 @@ interface SubagentSpawnClaim {
 
 interface AgentGraphScheduleUpdateRow {
   payloadJson: string;
+}
+
+interface AgentGraphInstanceRow {
+  schemaVersion: number;
+  graphId: string;
+  rootSessionId: string;
+  sequence: number;
+  status: string;
+  createdAt: number;
+  finishedAt: number | null;
 }
 
 interface AgentGraphOperatorProvisionRow {
@@ -5132,6 +5368,18 @@ function encodeProjectionPayload(payload: unknown, name: string): string {
     throw new Error(`Invalid agent graph ${name} payload`);
   }
   return encoded;
+}
+
+function decodeAgentGraphInstanceRow(row: AgentGraphInstanceRow): AgentGraphInstance {
+  return decodeAgentGraphInstance({
+    schemaVersion: row.schemaVersion,
+    graphId: row.graphId,
+    rootSessionId: row.rootSessionId,
+    sequence: row.sequence,
+    status: row.status,
+    createdAt: row.createdAt,
+    ...(row.finishedAt === null ? {} : { finishedAt: row.finishedAt }),
+  });
 }
 
 function decodeAgentGraphClientProjectionRow(


### PR DESCRIPTION
## Summary

- persist sequential Agent Graph instances for each root Session
- preserve finished graph epochs as immutable history while routing new work to a new epoch
- carry exact graph identity through wake recovery, host execution, revision checks, and retirement cleanup

This implements the graph lifecycle and recovery portion of #2588. Cross-graph published-result inputs remain a follow-up and this PR does not close the issue.

## Breaking Changes

None.

## DB Migrations

- bumps the Session metadata schema to v24
- adds `agent_graph_instances`, backfills legacy graph schedules as epoch 1, and enforces one open graph per root plus unique root/sequence identities

## Merge Order

Standalone; no dependency ordering required.

## Related PRs

- Related to #2588

## Test Plan

- `npm run build`
- `npm run format:check`
- `npm run lint`
- `git diff --check`
- 156 focused tests across core, storage, runtime, and runtime-host
