### PR TITLE
feat(runtime): add extension lifecycle kernel

### DIFF
--- a/docs/architecture/extension-lifecycle-kernel.md
+++ b/docs/architecture/extension-lifecycle-kernel.md
@@ -1,0 +1,54 @@
+# Extension Lifecycle Kernel (Phase 1)
+
+This module implements the product-independent lifecycle and revision semantics from issue #2973. It deliberately does not register Tools, UI, hooks, or execute dynamic scripts.
+
+## Authority and objects
+
+- An **Extension** is a stable identity.
+- A **Revision** is immutable after `install`. Installing a revision never executes extension code.
+- A **Binding** selects one exact revision for one scope. Only one binding for an extension may exist in a scope.
+- A **Candidate** owns everything allocated by `prepare`, `healthCheck`, and `activate` until it either becomes current or is rolled back.
+- A **Current Activation** owns its exposed dependency value and every registered effect.
+- A **Composition Snapshot** is an immutable, deterministic view of the active revisions and contribution descriptors in a scope.
+
+## Lifecycle
+
+```text
+install revision (no effects)
+  -> enable binding
+  -> wait for same-scope dependencies
+  -> prepare candidate
+  -> health check
+  -> activate
+  -> commit current
+  -> stop / remove binding / uninstall revision
+```
+
+Updates use current/candidate semantics:
+
+```text
+current remains active
+  -> prepare + health-check candidate
+  -> stop active dependents
+  -> activate candidate
+  -> commit candidate as current
+  -> dispose old current
+  -> reactivate dependents against the new dependency value
+```
+
+If preparation, health checking, or activation fails, the candidate is disposed in reverse effect-registration order and current remains committed. If candidate activation had already stopped dependents, they are reconciled back against the old current.
+
+## Invariants
+
+- All mutations are serialized by the kernel.
+- Dependencies resolve only inside the binding's scope.
+- Missing dependencies produce `waiting`; activating the provider reconciles waiting consumers.
+- Stopping a provider stops transitive dependents before the provider.
+- Dependency cycles fail without executing extension code.
+- Effects are disposed in reverse registration order; failed disposers remain inspectable and retryable.
+- A revision cannot be uninstalled while any binding, current activation, or candidate references it.
+- Previously returned composition snapshots never mutate.
+
+## Adapter boundary
+
+Future contribution adapters register their reversible work through `ExtensionActivationContext.ownEffect`. A Tool adapter, for example, will own the Tool registry entry's disposer. The kernel does not bypass Maka's existing Runtime, permission, sandbox, or Run-composition authorities; those integrations belong to later phases.

--- a/docs/architecture/extension-lifecycle-kernel.md
+++ b/docs/architecture/extension-lifecycle-kernel.md
@@ -52,3 +52,17 @@ If preparation, health checking, or activation fails, the candidate is disposed 
 ## Adapter boundary
 
 Future contribution adapters register their reversible work through `ExtensionActivationContext.ownEffect`. A Tool adapter, for example, will own the Tool registry entry's disposer. The kernel does not bypass Maka's existing Runtime, permission, sandbox, or Run-composition authorities; those integrations belong to later phases.
+
+## System verification
+
+`extension-lifecycle-kernel.system.test.ts` treats the exported kernel as the test boundary. It does not replace lifecycle methods or assert mock call counts. The scenarios exercise:
+
+- a real TCP server and persistent client through health check, dependency injection, provider stop, automatic consumer restart, scope disposal, and port release;
+- real `EventEmitter` listeners and timers to detect resource leaks across stop, restart, and binding removal;
+- a diamond dependency graph moving from one provider revision to another, including transitive stop and reactivation order;
+- candidate, dependent, binding-removal, and scope-disposal cleanup failures with retained ownership and retry;
+- invalid definitions, candidates, effect registration, dependency reads, binding conflicts, and missing objects through public error codes;
+- deterministic revision/composition ordering and stable composition digests across generation changes;
+- 2,000 seeded public lifecycle operations across four scopes, three dependent extensions, and two revisions while continuously checking public-state/composition agreement and exact live-resource counts.
+
+The focused fault-matrix tests remain alongside these system scenarios. Coverage is collected from the compiled JavaScript with Node's test runner so the result measures the implementation that actually executes.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -31,6 +31,7 @@
     "./runtime-event-read-model": "./dist/runtime-event-read-model.js",
     "./runtime-resume": "./dist/runtime-resume.js",
     "./runtime-kernel": "./dist/runtime-kernel.js",
+    "./extension-lifecycle-kernel": "./dist/extension-lifecycle-kernel.js",
     "./invocation-context": "./dist/invocation-context.js",
     "./ai-sdk-flow": "./dist/ai-sdk-flow.js",
     "./stream-graph-readiness": "./dist/stream-graph-readiness.js",

--- a/packages/runtime/src/__tests__/extension-lifecycle-kernel.system.test.ts
+++ b/packages/runtime/src/__tests__/extension-lifecycle-kernel.system.test.ts
@@ -1,0 +1,735 @@
+import assert from 'node:assert/strict';
+import { EventEmitter, once } from 'node:events';
+import { createConnection, createServer, type Server, type Socket } from 'node:net';
+import { test } from 'node:test';
+
+import {
+  ExtensionLifecycleKernel,
+  ExtensionLifecycleOperationError,
+  type ExtensionActivationContext,
+  type ExtensionLifecycleErrorCode,
+  type ExtensionRevisionDefinition,
+} from '../extension-lifecycle-kernel.js';
+
+test('system: a real TCP provider is health-checked, consumed, restarted, and fully released', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  const providerPorts: number[] = [];
+  const consumerReplies: string[] = [];
+
+  await kernel.install(tcpProviderRevision('tcp-provider', '1', providerPorts, events));
+  await kernel.install({
+    extensionId: 'tcp-consumer',
+    revision: '1',
+    dependencies: [{ extensionId: 'tcp-provider' }],
+    prepare: () => ({
+      activate: async (context) => {
+        const endpoint = context.dependency<TcpEndpoint>('tcp-provider');
+        const socket = createConnection({ host: '127.0.0.1', port: endpoint.port });
+        context.ownEffect('tcp-client', async () => {
+          events.push(`consumer:${endpoint.instance}:close`);
+          await destroySocket(socket);
+        });
+        await once(socket, 'connect');
+        socket.write('keep');
+        consumerReplies.push(await nextData(socket));
+        events.push(`consumer:${endpoint.instance}:active`);
+      },
+    }),
+  });
+
+  const waiting = await kernel.activate(
+    binding('consumer-binding', 'session-system', 'tcp-consumer', '1'),
+  );
+  assert.equal(waiting.status, 'waiting');
+
+  await kernel.activate(binding('provider-binding', 'session-system', 'tcp-provider', '1'));
+  assert.equal(kernel.inspect('consumer-binding').status, 'active');
+  assert.deepEqual(consumerReplies, ['pong:1:1']);
+  const firstPort = providerPorts[0]!;
+  assert.equal(await request(firstPort, 'health'), 'healthy:1:1');
+
+  events.length = 0;
+  await kernel.stop('provider-binding');
+  assert.deepEqual(events, ['consumer:1:close', 'provider:1:close']);
+  await assert.rejects(request(firstPort, 'health'));
+  assert.equal(kernel.inspect('consumer-binding').status, 'waiting');
+
+  await kernel.start('provider-binding');
+  assert.equal(kernel.inspect('provider-binding').status, 'active');
+  assert.equal(kernel.inspect('consumer-binding').status, 'active');
+  assert.deepEqual(consumerReplies, ['pong:1:1', 'pong:1:2']);
+  assert.equal(await request(providerPorts[1]!, 'health'), 'healthy:1:2');
+
+  const secondPort = providerPorts[1]!;
+  await kernel.disposeScope('session-system');
+  await assert.rejects(request(secondPort, 'health'));
+  assert.deepEqual(kernel.inspectScope('session-system'), []);
+  assert.deepEqual(kernel.composition('session-system').entries, []);
+});
+
+test('system: real event listeners and timers do not survive stop or restart', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const bus = new EventEmitter();
+  let messages = 0;
+  let ticks = 0;
+
+  await kernel.install({
+    extensionId: 'event-worker',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        const listener = () => {
+          messages += 1;
+        };
+        bus.on('message', listener);
+        context.ownEffect('event-listener', () => {
+          bus.off('message', listener);
+        });
+        const timer = setInterval(() => {
+          ticks += 1;
+        }, 2);
+        context.ownEffect('timer', () => clearInterval(timer));
+      },
+    }),
+  });
+
+  await kernel.activate(binding('worker-binding', 'session-resources', 'event-worker', '1'));
+  bus.emit('message');
+  await waitFor(() => ticks > 0);
+  assert.equal(messages, 1);
+  assert.equal(bus.listenerCount('message'), 1);
+
+  await kernel.stop('worker-binding');
+  const stoppedTicks = ticks;
+  bus.emit('message');
+  await delay(15);
+  assert.equal(messages, 1);
+  assert.equal(ticks, stoppedTicks);
+  assert.equal(bus.listenerCount('message'), 0);
+
+  await kernel.start('worker-binding');
+  bus.emit('message');
+  await waitFor(() => ticks > stoppedTicks);
+  assert.equal(messages, 2);
+  assert.equal(bus.listenerCount('message'), 1);
+  await kernel.removeBinding('worker-binding');
+  assert.equal(bus.listenerCount('message'), 0);
+});
+
+test('system: a diamond dependency graph moves atomically to the new provider value', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  const workerValues: string[] = [];
+
+  await kernel.install(valueRevision('database', '1', 'db-v1', events));
+  await kernel.install(valueRevision('database', '2', 'db-v2', events));
+  await kernel.install(derivedRevision('api', ['database'], events));
+  await kernel.install(derivedRevision('cache', ['database'], events));
+  await kernel.install({
+    extensionId: 'worker',
+    revision: '1',
+    dependencies: [{ extensionId: 'api' }, { extensionId: 'cache' }],
+    prepare: () => ({
+      activate: (context) => {
+        const value = `${context.dependency<string>('api')}+${context.dependency<string>('cache')}`;
+        workerValues.push(value);
+        events.push(`worker:activate:${value}`);
+        context.ownEffect('worker', () => {
+          events.push('worker:dispose');
+        });
+      },
+    }),
+  });
+
+  await kernel.activate(binding('d-worker', 'session-graph', 'worker', '1'));
+  await kernel.activate(binding('b-api', 'session-graph', 'api', '1'));
+  await kernel.activate(binding('c-cache', 'session-graph', 'cache', '1'));
+  await kernel.activate(binding('a-database', 'session-graph', 'database', '1'));
+  assert.deepEqual(workerValues, ['api(db-v1@1)+cache(db-v1@1)']);
+
+  events.length = 0;
+  const before = kernel.composition('session-graph');
+  await kernel.update('a-database', '2');
+  const after = kernel.composition('session-graph');
+
+  assert.deepEqual(events, [
+    'worker:dispose',
+    'api:dispose',
+    'cache:dispose',
+    'database:2:activate',
+    'database:1:dispose',
+    'api:activate:db-v2@2',
+    'cache:activate:db-v2@2',
+    'worker:activate:api(db-v2@2)+cache(db-v2@2)',
+  ]);
+  assert.deepEqual(workerValues, ['api(db-v1@1)+cache(db-v1@1)', 'api(db-v2@2)+cache(db-v2@2)']);
+  assert.equal(before.entries.find((entry) => entry.extensionId === 'database')?.revision, '1');
+  assert.equal(after.entries.find((entry) => entry.extensionId === 'database')?.revision, '2');
+  assert.notEqual(before.digest, after.digest);
+  assert.ok(kernel.inspectScope('session-graph').every((item) => item.status === 'active'));
+});
+
+test('system: a dependent cleanup failure blocks provider cutover and is recoverable', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  let cleanupAttempts = 0;
+  const values: string[] = [];
+  await kernel.install(valueRevision('provider', '1', 'old', []));
+  await kernel.install(valueRevision('provider', '2', 'new', []));
+  await kernel.install({
+    extensionId: 'consumer',
+    revision: '1',
+    dependencies: [{ extensionId: 'provider' }],
+    prepare: () => ({
+      activate: (context) => {
+        values.push(context.dependency<string>('provider'));
+        context.ownEffect('flaky-consumer', () => {
+          cleanupAttempts += 1;
+          if (cleanupAttempts === 1) throw new Error('busy');
+        });
+      },
+    }),
+  });
+  await kernel.activate(binding('a-provider', 'session-retry', 'provider', '1'));
+  await kernel.activate(binding('b-consumer', 'session-retry', 'consumer', '1'));
+
+  await assertCode(kernel.update('a-provider', '2'), 'cleanup_failed');
+  assert.equal(kernel.inspect('a-provider').current?.revision, '1');
+  assert.equal(kernel.inspect('b-consumer').status, 'failed');
+  assert.equal(kernel.inspect('b-consumer').pendingCleanupEffects, 1);
+
+  await kernel.retry('b-consumer');
+  assert.equal(kernel.inspect('b-consumer').status, 'active');
+  assert.equal(
+    kernel.inspect('a-provider').desiredRevision,
+    '2',
+    'the failed update remains desired and the scope converges after cleanup retry',
+  );
+  assert.equal(kernel.inspect('a-provider').current?.revision, '2');
+  assert.equal(kernel.inspect('b-consumer').status, 'active');
+  assert.deepEqual(values, ['old', 'new']);
+});
+
+test('system: failed candidate cleanup is retained, retried, and leaves no duplicate resource', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  let activationAttempts = 0;
+  let cleanupAttempts = 0;
+  let liveResources = 0;
+  await kernel.install({
+    extensionId: 'candidate-recovery',
+    revision: '1',
+    prepare: (context) => {
+      liveResources += 1;
+      context.ownEffect('candidate-resource', () => {
+        cleanupAttempts += 1;
+        if (cleanupAttempts === 1) throw new Error('temporarily locked');
+        liveResources -= 1;
+      });
+      return {
+        activate: () => {
+          activationAttempts += 1;
+          if (activationAttempts === 1) throw new Error('first activation fails');
+        },
+      };
+    },
+  });
+
+  await assertCode(
+    kernel.activate(binding('recovery-binding', 'session-recovery', 'candidate-recovery', '1')),
+    'cleanup_failed',
+  );
+  assert.equal(liveResources, 1);
+  assert.equal(kernel.inspect('recovery-binding').pendingCleanupEffects, 1);
+
+  await kernel.retry('recovery-binding');
+  assert.equal(liveResources, 1, 'the retired resource is released before the retry allocates one');
+  assert.equal(kernel.inspect('recovery-binding').status, 'active');
+  await kernel.stop('recovery-binding');
+  assert.equal(liveResources, 0);
+});
+
+test('system: disposeScope is retryable after a real cleanup failure', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const bus = new EventEmitter();
+  let attempts = 0;
+  const listener = () => undefined;
+  await kernel.install({
+    extensionId: 'scope-resource',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        bus.on('data', listener);
+        context.ownEffect('listener', () => {
+          attempts += 1;
+          if (attempts === 1) throw new Error('temporary release failure');
+          bus.off('data', listener);
+        });
+      },
+    }),
+  });
+  await kernel.activate(binding('scope-binding', 'session-dispose', 'scope-resource', '1'));
+
+  await assertCode(kernel.disposeScope('session-dispose'), 'cleanup_failed');
+  assert.equal(bus.listenerCount('data'), 1);
+  assert.equal(kernel.inspect('scope-binding').status, 'failed');
+  await kernel.disposeScope('session-dispose');
+  assert.equal(bus.listenerCount('data'), 0);
+  assert.deepEqual(kernel.inspectScope('session-dispose'), []);
+});
+
+test('system: public error paths preserve state and the serialized queue remains usable', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const valid = valueRevision('valid', '1', 'value', []);
+
+  for (const definition of [
+    null,
+    { extensionId: 'Bad', revision: '1', prepare: () => ({ activate: () => undefined }) },
+    { extensionId: 'missing-prepare', revision: '1' },
+    { ...valid, revision: '' },
+    { ...valid, dependencies: [{ extensionId: 'valid' }] },
+    { ...valid, dependencies: [{ extensionId: 'dep' }, { extensionId: 'dep' }] },
+    {
+      ...valid,
+      contributions: [
+        { id: 'same', kind: 'fake' },
+        { id: 'same', kind: 'fake' },
+      ],
+    },
+  ]) {
+    await assertCode(
+      kernel.install(definition as ExtensionRevisionDefinition),
+      'invalid_definition',
+    );
+  }
+
+  await kernel.install(valid);
+  await assertCode(kernel.install(valid), 'revision_already_installed');
+  await assertCode(kernel.uninstall('valid', 'missing'), 'revision_not_installed');
+  await assertCode(
+    kernel.activate(binding('missing-revision', 'session-errors', 'valid', '2')),
+    'revision_not_installed',
+  );
+  await assertCode(kernel.update('missing-binding', '1'), 'binding_not_found');
+  assert.throws(() => kernel.inspect('missing-binding'), hasCode('binding_not_found'));
+
+  await kernel.activate(binding('valid-binding', 'session-errors', 'valid', '1'));
+  await assertCode(
+    kernel.activate(binding('valid-binding', 'other-scope', 'valid', '1')),
+    'binding_conflict',
+  );
+  await assertCode(
+    kernel.activate(binding('other-binding', 'session-errors', 'valid', '1')),
+    'binding_conflict',
+  );
+  assert.equal(kernel.inspect('valid-binding').status, 'active');
+
+  await kernel.stop('valid-binding');
+  await kernel.start('valid-binding');
+  assert.equal(kernel.inspect('valid-binding').status, 'active');
+});
+
+test('system: effect registration is validated and sealed after activation', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  let retainedContext: ExtensionActivationContext | undefined;
+  await kernel.install({
+    extensionId: 'bad-effect',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => context.ownEffect('', () => undefined),
+    }),
+  });
+  await assertCode(
+    kernel.activate(binding('bad-effect-binding', 'session-effects', 'bad-effect', '1')),
+    'invalid_definition',
+  );
+
+  await kernel.install({
+    extensionId: 'sealed-effect',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        retainedContext = context;
+      },
+    }),
+  });
+  await kernel.activate(binding('sealed-binding', 'session-effects', 'sealed-effect', '1'));
+  assert.throws(
+    () => retainedContext!.ownEffect('too-late', () => undefined),
+    hasCode('activation_failed'),
+  );
+});
+
+test('system: invalid prepared candidates and unavailable dependency reads roll back cleanly', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  await kernel.install({
+    extensionId: 'invalid-candidate',
+    revision: '1',
+    prepare: () => null as never,
+  });
+  await assertCode(
+    kernel.activate(binding('invalid-binding', 'session-invalid', 'invalid-candidate', '1')),
+    'invalid_definition',
+  );
+  assert.equal(kernel.composition('session-invalid').entries.length, 0);
+
+  await kernel.install({
+    extensionId: 'missing-value',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        context.dependency('not-active');
+      },
+    }),
+  });
+  await assertCode(
+    kernel.activate(binding('missing-value-binding', 'session-invalid', 'missing-value', '1')),
+    'activation_failed',
+  );
+
+  await kernel.install({
+    extensionId: 'missing-revision-read',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        context.dependencyRevision('not-active');
+      },
+    }),
+  });
+  await assertCode(
+    kernel.activate(
+      binding('missing-revision-binding', 'session-invalid', 'missing-revision-read', '1'),
+    ),
+    'activation_failed',
+  );
+});
+
+test('system: remove and repeated cleanup failures retain ownership until release succeeds', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  let removeAttempts = 0;
+  await kernel.install({
+    extensionId: 'remove-retry',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        context.ownEffect('remove-resource', () => {
+          removeAttempts += 1;
+          if (removeAttempts === 1) throw new Error('first release fails');
+        });
+      },
+    }),
+  });
+  await kernel.activate(binding('remove-binding', 'session-remove', 'remove-retry', '1'));
+  await assertCode(kernel.removeBinding('remove-binding'), 'cleanup_failed');
+  assert.equal(kernel.inspect('remove-binding').pendingCleanupEffects, 1);
+  await kernel.removeBinding('remove-binding');
+  assert.throws(() => kernel.inspect('remove-binding'), hasCode('binding_not_found'));
+
+  let persistentAttempts = 0;
+  await kernel.install({
+    extensionId: 'persistent-cleanup',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        context.ownEffect('persistent-resource', () => {
+          persistentAttempts += 1;
+          if (persistentAttempts < 3) throw new Error('still busy');
+        });
+      },
+    }),
+  });
+  await kernel.activate(binding('persistent-binding', 'session-remove', 'persistent-cleanup', '1'));
+  await assertCode(kernel.stop('persistent-binding'), 'cleanup_failed');
+  await assertCode(kernel.retry('persistent-binding'), 'cleanup_failed');
+  assert.equal(kernel.inspect('persistent-binding').pendingCleanupEffects, 1);
+  await kernel.retry('persistent-binding');
+  assert.equal(kernel.inspect('persistent-binding').status, 'active');
+});
+
+test('system: installed revisions and composition remain deterministically ordered', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  for (const [extensionId, revision] of [
+    ['zeta', '2'],
+    ['alpha', '1'],
+    ['zeta', '1'],
+  ] as const) {
+    await kernel.install(valueRevision(extensionId, revision, revision, []));
+  }
+  assert.deepEqual(kernel.installedRevisions(), [
+    { extensionId: 'alpha', revision: '1' },
+    { extensionId: 'zeta', revision: '1' },
+    { extensionId: 'zeta', revision: '2' },
+  ]);
+  await kernel.activate(binding('zeta-binding', 'session-order', 'zeta', '2'));
+  const before = kernel.composition('session-order');
+  await kernel.stop('zeta-binding');
+  await kernel.start('zeta-binding');
+  const after = kernel.composition('session-order');
+  assert.equal(before.digest, after.digest, 'generation changes do not alter composition identity');
+  assert.notEqual(before.entries[0]?.generation, after.entries[0]?.generation);
+});
+
+test('system: 2,000 deterministic lifecycle operations preserve composition and resource invariants', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const scopes = ['soak-a', 'soak-b', 'soak-c', 'soak-d'];
+  const extensions = ['alpha', 'beta', 'gamma'] as const;
+  const dependencies: Record<(typeof extensions)[number], readonly string[]> = {
+    alpha: [],
+    beta: ['alpha'],
+    gamma: ['beta'],
+  };
+  const liveByBinding = new Map<string, number>();
+
+  for (const extensionId of extensions) {
+    for (const revision of ['1', '2']) {
+      await kernel.install({
+        extensionId,
+        revision,
+        dependencies: dependencies[extensionId].map((dependency) => ({ extensionId: dependency })),
+        contributions: [{ id: `${extensionId}.service`, kind: 'service' }],
+        prepare: () => ({
+          activate: (context) => {
+            const current = liveByBinding.get(context.bindingId) ?? 0;
+            liveByBinding.set(context.bindingId, current + 1);
+            context.ownEffect('resource', async () => {
+              await Promise.resolve();
+              liveByBinding.set(context.bindingId, liveByBinding.get(context.bindingId)! - 1);
+            });
+            return { value: `${context.scopeId}:${extensionId}:${revision}` };
+          },
+        }),
+      });
+    }
+  }
+
+  const random = seededRandom(0x2973);
+  for (let step = 0; step < 2_000; step += 1) {
+    const scope = scopes[Math.floor(random() * scopes.length)]!;
+    const extensionId = extensions[Math.floor(random() * extensions.length)]!;
+    const revision = random() < 0.5 ? '1' : '2';
+    const bindingId = `${scope}-${extensionId}`;
+    const existing = kernel.inspectScope(scope).find((item) => item.bindingId === bindingId);
+    switch (Math.floor(random() * 6)) {
+      case 0:
+        await kernel.activate(binding(bindingId, scope, extensionId, revision));
+        break;
+      case 1:
+        if (existing) await kernel.update(bindingId, revision);
+        break;
+      case 2:
+        if (existing) await kernel.stop(bindingId);
+        break;
+      case 3:
+        if (existing) await kernel.start(bindingId);
+        break;
+      case 4:
+        if (existing) await kernel.removeBinding(bindingId);
+        break;
+      default:
+        await kernel.disposeScope(scope);
+    }
+    if (step % 25 === 0) assertKernelInvariants(kernel, scopes, liveByBinding);
+  }
+
+  assertKernelInvariants(kernel, scopes, liveByBinding);
+  for (const scope of scopes) await kernel.disposeScope(scope);
+  assert.equal(
+    [...liveByBinding.values()].reduce((sum, count) => sum + count, 0),
+    0,
+  );
+});
+
+interface TcpEndpoint {
+  readonly port: number;
+  readonly instance: number;
+}
+
+function tcpProviderRevision(
+  extensionId: string,
+  revision: string,
+  ports: number[],
+  events: string[],
+): ExtensionRevisionDefinition {
+  let instance = 0;
+  return {
+    extensionId,
+    revision,
+    prepare: async (context) => {
+      instance += 1;
+      const currentInstance = instance;
+      const server = createServer((socket) => {
+        socket.once('data', (data) => {
+          const requestBody = data.toString();
+          if (requestBody === 'health') socket.end(`healthy:${revision}:${currentInstance}`);
+          else socket.write(`pong:${revision}:${currentInstance}`);
+        });
+      });
+      await listen(server);
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      ports.push(address.port);
+      context.ownEffect('tcp-server', async () => {
+        await closeServer(server);
+        events.push(`provider:${currentInstance}:close`);
+      });
+      return {
+        healthCheck: async () => {
+          assert.equal(
+            await request(address.port, 'health'),
+            `healthy:${revision}:${currentInstance}`,
+          );
+        },
+        activate: () => ({ value: { port: address.port, instance: currentInstance } }),
+      };
+    },
+  };
+}
+
+function valueRevision(
+  extensionId: string,
+  revision: string,
+  value: string,
+  events: string[],
+): ExtensionRevisionDefinition {
+  return {
+    extensionId,
+    revision,
+    prepare: () => ({
+      activate: (context) => {
+        events.push(`${extensionId}:${revision}:activate`);
+        context.ownEffect(extensionId, () => {
+          events.push(`${extensionId}:${revision}:dispose`);
+        });
+        return { value };
+      },
+    }),
+  };
+}
+
+function derivedRevision(
+  extensionId: string,
+  dependencyIds: string[],
+  events: string[],
+): ExtensionRevisionDefinition {
+  return {
+    extensionId,
+    revision: '1',
+    dependencies: dependencyIds.map((dependency) => ({ extensionId: dependency })),
+    prepare: () => ({
+      activate: (context) => {
+        const derived = dependencyIds
+          .map(
+            (dependency) =>
+              `${context.dependency<string>(dependency)}@${context.dependencyRevision(dependency)}`,
+          )
+          .join('+');
+        events.push(`${extensionId}:activate:${derived}`);
+        context.ownEffect(extensionId, () => {
+          events.push(`${extensionId}:dispose`);
+        });
+        return { value: `${extensionId}(${derived})` };
+      },
+    }),
+  };
+}
+
+function assertKernelInvariants(
+  kernel: ExtensionLifecycleKernel,
+  scopes: string[],
+  liveByBinding: ReadonlyMap<string, number>,
+): void {
+  let composedResources = 0;
+  for (const scope of scopes) {
+    const inspections = kernel.inspectScope(scope);
+    const composition = kernel.composition(scope);
+    assert.ok(Object.isFrozen(inspections));
+    assert.ok(Object.isFrozen(composition));
+    assert.ok(Object.isFrozen(composition.entries));
+    assert.equal(kernel.composition(scope).digest, composition.digest);
+    assert.deepEqual(
+      inspections.map((item) => item.bindingId),
+      [...inspections.map((item) => item.bindingId)].sort(),
+    );
+    assert.equal(new Set(inspections.map((item) => item.extensionId)).size, inspections.length);
+    assert.equal(
+      new Set(composition.entries.map((item) => item.extensionId)).size,
+      composition.entries.length,
+    );
+    for (const entry of composition.entries) {
+      const inspection = inspections.find((item) => item.bindingId === entry.bindingId);
+      assert.equal(inspection?.current?.revision, entry.revision);
+      assert.equal(liveByBinding.get(entry.bindingId), 1);
+      composedResources += 1;
+    }
+    for (const inspection of inspections) {
+      if (!inspection.current) assert.equal(liveByBinding.get(inspection.bindingId) ?? 0, 0);
+      assert.ok(inspection.pendingCleanupEffects >= 0);
+    }
+  }
+  assert.equal(
+    [...liveByBinding.values()].reduce((sum, count) => sum + count, 0),
+    composedResources,
+  );
+}
+
+function binding(bindingId: string, scopeId: string, extensionId: string, revision: string) {
+  return { bindingId, scopeId, extensionId, revision };
+}
+
+async function assertCode(promise: Promise<unknown>, code: ExtensionLifecycleErrorCode) {
+  await assert.rejects(promise, hasCode(code));
+}
+
+function hasCode(code: ExtensionLifecycleErrorCode) {
+  return (error: unknown) =>
+    error instanceof ExtensionLifecycleOperationError && error.code === code;
+}
+
+function seededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+async function listen(server: Server): Promise<void> {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+}
+
+async function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return;
+  server.close();
+  await once(server, 'close');
+}
+
+async function destroySocket(socket: Socket): Promise<void> {
+  if (socket.destroyed) return;
+  socket.destroy();
+  await once(socket, 'close');
+}
+
+async function request(port: number, body: string): Promise<string> {
+  const socket = createConnection({ host: '127.0.0.1', port });
+  socket.setTimeout(1_000, () => socket.destroy(new Error('request timeout')));
+  await once(socket, 'connect');
+  socket.end(body);
+  return nextData(socket);
+}
+
+async function nextData(socket: Socket): Promise<string> {
+  const [data] = (await once(socket, 'data')) as [Buffer];
+  return data.toString();
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 1_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('condition timed out');
+    await delay(2);
+  }
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}

--- a/packages/runtime/src/__tests__/extension-lifecycle-kernel.test.ts
+++ b/packages/runtime/src/__tests__/extension-lifecycle-kernel.test.ts
@@ -1,0 +1,596 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  ExtensionLifecycleKernel,
+  ExtensionLifecycleOperationError,
+  type ExtensionRevisionDefinition,
+} from '../extension-lifecycle-kernel.js';
+
+test('install is effect-free and snapshots immutable revision metadata', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const contributions = [{ id: 'alpha.fake', kind: 'fake' }];
+  let prepares = 0;
+
+  await kernel.install({
+    extensionId: 'alpha',
+    revision: '1',
+    contributions,
+    prepare: () => {
+      prepares += 1;
+      return { activate: () => undefined };
+    },
+  });
+  contributions.push({ id: 'mutated.after.install', kind: 'fake' });
+
+  assert.equal(prepares, 0, 'install must not execute extension code');
+  assert.deepEqual(kernel.installedRevisions(), [{ extensionId: 'alpha', revision: '1' }]);
+  await assertCode(
+    kernel.install({
+      extensionId: 'alpha',
+      revision: '1',
+      prepare: () => ({ activate: () => undefined }),
+    }),
+    'revision_already_installed',
+  );
+
+  await kernel.activate(binding('alpha-binding', 'session-a', 'alpha', '1'));
+  assert.equal(prepares, 1);
+  const snapshot = kernel.composition('session-a');
+  assert.equal(snapshot.entries.length, 1);
+  assert.deepEqual(snapshot.entries[0]!.contributions, [{ id: 'alpha.fake', kind: 'fake' }]);
+  assert.ok(Object.isFrozen(snapshot));
+  assert.ok(Object.isFrozen(snapshot.entries));
+  assert.ok(Object.isFrozen(snapshot.entries[0]!.contributions));
+});
+
+test('stop disposes activation and preparation effects in reverse ownership order', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  await kernel.install({
+    extensionId: 'ordered',
+    revision: '1',
+    prepare: (context) => {
+      context.ownEffect('prepare-effect', () => {
+        events.push('prepare-effect');
+      });
+      return {
+        dispose: () => {
+          events.push('prepared-dispose');
+        },
+        activate: (activation) => {
+          activation.ownEffect('first', () => {
+            events.push('first');
+          });
+          activation.ownEffect('second', async () => {
+            await Promise.resolve();
+            events.push('second');
+          });
+        },
+      };
+    },
+  });
+
+  await kernel.activate(binding('ordered-binding', 'session-a', 'ordered', '1'));
+  await kernel.stop('ordered-binding');
+
+  assert.deepEqual(events, ['second', 'first', 'prepared-dispose', 'prepare-effect']);
+  assert.equal(kernel.inspect('ordered-binding').status, 'stopped');
+});
+
+test('failed activation rolls back every candidate-owned effect', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  await kernel.install({
+    extensionId: 'broken',
+    revision: '1',
+    prepare: (context) => {
+      context.ownEffect('prepare-effect', () => {
+        events.push('prepare-effect');
+      });
+      return {
+        dispose: () => {
+          events.push('prepared-dispose');
+        },
+        activate: (activation) => {
+          activation.ownEffect('published-effect', () => {
+            events.push('published-effect');
+          });
+          throw new Error('boom');
+        },
+      };
+    },
+  });
+
+  await assertCode(
+    kernel.activate(binding('broken-binding', 'session-a', 'broken', '1')),
+    'activation_failed',
+  );
+  assert.deepEqual(events, ['published-effect', 'prepared-dispose', 'prepare-effect']);
+  assert.deepEqual(kernel.inspect('broken-binding'), {
+    bindingId: 'broken-binding',
+    scopeId: 'session-a',
+    extensionId: 'broken',
+    desiredRevision: '1',
+    enabled: true,
+    status: 'failed',
+    waitingFor: [],
+    pendingCleanupEffects: 0,
+    diagnostic: {
+      code: 'activation_failed',
+      message: 'Extension candidate broken@1 activation failed',
+      revision: '1',
+      at: kernel.inspect('broken-binding').diagnostic!.at,
+    },
+  });
+});
+
+test('health-check failure never publishes the candidate', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  await kernel.install({
+    extensionId: 'unhealthy',
+    revision: '1',
+    prepare: () => ({
+      healthCheck: () => {
+        events.push('health');
+        throw new Error('not ready');
+      },
+      activate: () => {
+        events.push('activate');
+      },
+      dispose: () => {
+        events.push('dispose');
+      },
+    }),
+  });
+
+  await assertCode(
+    kernel.activate(binding('unhealthy-binding', 'session-a', 'unhealthy', '1')),
+    'health_check_failed',
+  );
+  assert.deepEqual(events, ['health', 'dispose']);
+  assert.equal(kernel.composition('session-a').entries.length, 0);
+});
+
+test('dependencies wait, inject the active value, stop dependents first, and recover', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  const seen: string[] = [];
+  await kernel.install(
+    lifecycleRevision('provider', '1', events, {
+      value: 'provider-value',
+    }),
+  );
+  await kernel.install({
+    extensionId: 'consumer',
+    revision: '1',
+    dependencies: [{ extensionId: 'provider' }],
+    prepare: () => ({
+      activate: (context) => {
+        seen.push(
+          `${context.dependency<string>('provider')}@${context.dependencyRevision('provider')}`,
+        );
+        context.ownEffect('consumer', () => {
+          events.push('consumer:dispose');
+        });
+      },
+    }),
+  });
+
+  const waiting = await kernel.activate(binding('b-consumer', 'session-a', 'consumer', '1'));
+  assert.equal(waiting.status, 'waiting');
+  assert.deepEqual(waiting.waitingFor, ['provider']);
+
+  await kernel.activate(binding('a-provider', 'session-a', 'provider', '1'));
+  assert.equal(kernel.inspect('b-consumer').status, 'active');
+  assert.deepEqual(seen, ['provider-value@1']);
+
+  events.length = 0;
+  await kernel.stop('a-provider');
+  assert.deepEqual(events, ['consumer:dispose', 'provider:1:dispose']);
+  assert.equal(kernel.inspect('b-consumer').status, 'waiting');
+  assert.deepEqual(kernel.inspect('b-consumer').waitingFor, ['provider']);
+
+  await kernel.start('a-provider');
+  assert.equal(kernel.inspect('b-consumer').status, 'active');
+  assert.deepEqual(seen, ['provider-value@1', 'provider-value@1']);
+});
+
+test('successful update keeps current during prepare and commits a new immutable composition', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  const gate = deferred<void>();
+  const prepareStarted = deferred<void>();
+  await kernel.install(lifecycleRevision('updatable', '1', events));
+  await kernel.install({
+    extensionId: 'updatable',
+    revision: '2',
+    contributions: [{ id: 'new.fake', kind: 'fake' }],
+    prepare: async () => {
+      prepareStarted.resolve();
+      await gate.promise;
+      return {
+        activate: (context) => {
+          events.push('updatable:2:activate');
+          context.ownEffect('v2', () => {
+            events.push('updatable:2:dispose');
+          });
+        },
+      };
+    },
+  });
+  await kernel.activate(binding('updatable-binding', 'session-a', 'updatable', '1'));
+  const before = kernel.composition('session-a');
+
+  const update = kernel.update('updatable-binding', '2');
+  await prepareStarted.promise;
+  const during = kernel.inspect('updatable-binding');
+  assert.equal(during.current?.revision, '1');
+  assert.deepEqual(during.candidate, { revision: '2', phase: 'preparing' });
+  assert.equal(before.entries[0]!.revision, '1');
+
+  gate.resolve();
+  const updated = await update;
+  assert.equal(updated.current?.revision, '2');
+  assert.equal(updated.status, 'active');
+  assert.deepEqual(events.slice(-2), ['updatable:2:activate', 'updatable:1:dispose']);
+  const after = kernel.composition('session-a');
+  assert.equal(before.entries[0]!.revision, '1', 'old snapshot remains immutable');
+  assert.equal(after.entries[0]!.revision, '2');
+  assert.notEqual(before.digest, after.digest);
+});
+
+test('failed candidate health check preserves the committed activation', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  await kernel.install(lifecycleRevision('safe-update', '1', events));
+  await kernel.install({
+    extensionId: 'safe-update',
+    revision: '2',
+    prepare: (context) => {
+      context.ownEffect('candidate-prepare', () => {
+        events.push('candidate-prepare:dispose');
+      });
+      return {
+        healthCheck: () => {
+          throw new Error('candidate unhealthy');
+        },
+        activate: () => {
+          events.push('candidate:activate');
+        },
+      };
+    },
+  });
+  await kernel.activate(binding('safe-binding', 'session-a', 'safe-update', '1'));
+
+  await assertCode(kernel.update('safe-binding', '2'), 'health_check_failed');
+  const inspection = kernel.inspect('safe-binding');
+  assert.equal(inspection.current?.revision, '1');
+  assert.equal(inspection.status, 'active');
+  assert.equal(inspection.diagnostic?.code, 'health_check_failed');
+  assert.deepEqual(events, ['safe-update:1:activate', 'candidate-prepare:dispose']);
+});
+
+test('failed provider activation restores dependents against the old current', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  const seen: string[] = [];
+  await kernel.install(lifecycleRevision('provider', '1', events, { value: 'old' }));
+  await kernel.install({
+    extensionId: 'provider',
+    revision: '2',
+    prepare: () => ({
+      activate: (context) => {
+        events.push('provider:2:activate');
+        context.ownEffect('provider-v2', () => {
+          events.push('provider:2:dispose');
+        });
+        throw new Error('candidate failed');
+      },
+    }),
+  });
+  await kernel.install({
+    extensionId: 'consumer',
+    revision: '1',
+    dependencies: [{ extensionId: 'provider' }],
+    prepare: () => ({
+      activate: (context) => {
+        seen.push(context.dependency<string>('provider'));
+        context.ownEffect('consumer', () => {
+          events.push('consumer:dispose');
+        });
+      },
+    }),
+  });
+  await kernel.activate(binding('a-provider', 'session-a', 'provider', '1'));
+  await kernel.activate(binding('b-consumer', 'session-a', 'consumer', '1'));
+
+  await assertCode(kernel.update('a-provider', '2'), 'activation_failed');
+  assert.equal(kernel.inspect('a-provider').current?.revision, '1');
+  assert.equal(kernel.inspect('b-consumer').status, 'active');
+  assert.deepEqual(seen, ['old', 'old']);
+  assert.deepEqual(events.slice(-3), [
+    'consumer:dispose',
+    'provider:2:activate',
+    'provider:2:dispose',
+  ]);
+});
+
+test('dependency cycles are diagnosed without executing extension code', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  let activations = 0;
+  await kernel.install({
+    extensionId: 'cycle-a',
+    revision: '1',
+    dependencies: [{ extensionId: 'cycle-b' }],
+    prepare: () => ({ activate: () => void (activations += 1) }),
+  });
+  await kernel.install({
+    extensionId: 'cycle-b',
+    revision: '1',
+    dependencies: [{ extensionId: 'cycle-a' }],
+    prepare: () => ({ activate: () => void (activations += 1) }),
+  });
+
+  const first = await kernel.activate(binding('cycle-a-binding', 'session-a', 'cycle-a', '1'));
+  assert.equal(first.status, 'waiting');
+  await assertCode(
+    kernel.activate(binding('cycle-b-binding', 'session-a', 'cycle-b', '1')),
+    'dependency_cycle',
+  );
+  assert.equal(kernel.inspect('cycle-a-binding').diagnostic?.code, 'dependency_cycle');
+  assert.equal(kernel.inspect('cycle-b-binding').diagnostic?.code, 'dependency_cycle');
+  assert.equal(activations, 0);
+});
+
+test('dependency resolution and stop are isolated by scope', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  const seen: string[] = [];
+  await kernel.install(lifecycleRevision('provider', '1', events, { value: 'scoped' }));
+  await kernel.install({
+    extensionId: 'consumer',
+    revision: '1',
+    dependencies: [{ extensionId: 'provider' }],
+    prepare: () => ({
+      activate: (context) => {
+        seen.push(`${context.scopeId}:${context.dependency<string>('provider')}`);
+        context.ownEffect('consumer', () => undefined);
+      },
+    }),
+  });
+  for (const scope of ['session-a', 'session-b']) {
+    await kernel.activate(binding(`${scope}-provider`, scope, 'provider', '1'));
+    await kernel.activate(binding(`${scope}-consumer`, scope, 'consumer', '1'));
+  }
+
+  await kernel.stop('session-a-provider');
+  assert.equal(kernel.inspect('session-a-consumer').status, 'waiting');
+  assert.equal(kernel.inspect('session-b-consumer').status, 'active');
+  assert.equal(kernel.composition('session-a').entries.length, 0);
+  assert.equal(kernel.composition('session-b').entries.length, 2);
+  assert.deepEqual(seen, ['session-a:scoped', 'session-b:scoped']);
+});
+
+test('uninstall requires all bindings to release the immutable revision', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  await kernel.install({
+    extensionId: 'removable',
+    revision: '1',
+    prepare: () => ({ activate: () => undefined }),
+  });
+  await kernel.activate(binding('removable-binding', 'session-a', 'removable', '1'));
+  await assertCode(kernel.uninstall('removable', '1'), 'revision_in_use');
+  await kernel.stop('removable-binding');
+  await assertCode(kernel.uninstall('removable', '1'), 'revision_in_use');
+  await kernel.removeBinding('removable-binding');
+  await kernel.uninstall('removable', '1');
+  assert.deepEqual(kernel.installedRevisions(), []);
+});
+
+test('concurrent mutations serialize update before a later stop', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  const gate = deferred<void>();
+  const started = deferred<void>();
+  await kernel.install(lifecycleRevision('serialized', '1', events));
+  await kernel.install({
+    extensionId: 'serialized',
+    revision: '2',
+    prepare: async () => {
+      started.resolve();
+      await gate.promise;
+      return {
+        activate: (context) => {
+          events.push('serialized:2:activate');
+          context.ownEffect('v2', () => {
+            events.push('serialized:2:dispose');
+          });
+        },
+      };
+    },
+  });
+  await kernel.activate(binding('serialized-binding', 'session-a', 'serialized', '1'));
+
+  const update = kernel.update('serialized-binding', '2');
+  await started.promise;
+  const stop = kernel.stop('serialized-binding');
+  assert.equal(kernel.inspect('serialized-binding').candidate?.revision, '2');
+  gate.resolve();
+  await update;
+  await stop;
+
+  assert.equal(kernel.inspect('serialized-binding').status, 'stopped');
+  assert.deepEqual(events.slice(-3), [
+    'serialized:2:activate',
+    'serialized:1:dispose',
+    'serialized:2:dispose',
+  ]);
+});
+
+test('failed cleanup remains diagnosable and can be retried', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  let attempts = 0;
+  await kernel.install({
+    extensionId: 'cleanup-retry',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        context.ownEffect('flaky', () => {
+          attempts += 1;
+          if (attempts === 1) throw new Error('temporary cleanup failure');
+        });
+      },
+    }),
+  });
+  await kernel.activate(binding('cleanup-binding', 'session-a', 'cleanup-retry', '1'));
+
+  await assertCode(kernel.stop('cleanup-binding'), 'cleanup_failed');
+  const failed = kernel.inspect('cleanup-binding');
+  assert.equal(failed.status, 'failed');
+  assert.equal(failed.pendingCleanupEffects, 1);
+  assert.equal(failed.diagnostic?.code, 'cleanup_failed');
+
+  const stopped = await kernel.stop('cleanup-binding');
+  assert.equal(stopped.status, 'stopped');
+  assert.equal(stopped.pendingCleanupEffects, 0);
+  assert.equal(attempts, 2);
+});
+
+test('an update waits for new dependencies without disturbing current', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  await kernel.install(lifecycleRevision('switchable', '1', events));
+  await kernel.install({
+    extensionId: 'switchable',
+    revision: '2',
+    dependencies: [{ extensionId: 'provider' }],
+    prepare: () => ({
+      activate: (context) => {
+        events.push(`switchable:2:${context.dependency<string>('provider')}`);
+        context.ownEffect('switchable-v2', () => undefined);
+      },
+    }),
+  });
+  await kernel.install(lifecycleRevision('provider', '1', events, { value: 'ready' }));
+  await kernel.activate(binding('switchable-binding', 'session-a', 'switchable', '1'));
+
+  const waiting = await kernel.update('switchable-binding', '2');
+  assert.equal(waiting.status, 'waiting');
+  assert.equal(waiting.current?.revision, '1');
+  assert.equal(waiting.desiredRevision, '2');
+  assert.deepEqual(waiting.waitingFor, ['provider']);
+
+  await kernel.activate(binding('provider-binding', 'session-a', 'provider', '1'));
+  assert.equal(kernel.inspect('switchable-binding').current?.revision, '2');
+  assert.ok(events.includes('switchable:2:ready'));
+});
+
+test('candidate commit remains authoritative when retired-current cleanup needs retry', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  let oldCleanupAttempts = 0;
+  await kernel.install({
+    extensionId: 'retired-cleanup',
+    revision: '1',
+    prepare: () => ({
+      activate: (context) => {
+        context.ownEffect('old', () => {
+          oldCleanupAttempts += 1;
+          if (oldCleanupAttempts === 1) throw new Error('old cleanup failed');
+        });
+      },
+    }),
+  });
+  await kernel.install({
+    extensionId: 'retired-cleanup',
+    revision: '2',
+    prepare: () => ({
+      activate: (context) => context.ownEffect('new', () => undefined),
+    }),
+  });
+  await kernel.activate(binding('retired-binding', 'session-a', 'retired-cleanup', '1'));
+
+  await assertCode(kernel.update('retired-binding', '2'), 'cleanup_failed');
+  const committed = kernel.inspect('retired-binding');
+  assert.equal(committed.current?.revision, '2');
+  assert.equal(committed.pendingCleanupEffects, 1);
+  assert.equal(committed.diagnostic?.code, 'cleanup_failed');
+
+  const recovered = await kernel.start('retired-binding');
+  assert.equal(recovered.current?.revision, '2');
+  assert.equal(recovered.pendingCleanupEffects, 0);
+  assert.equal(oldCleanupAttempts, 2);
+});
+
+test('disposing a scope retracts dependents before providers and removes every binding', async () => {
+  const kernel = new ExtensionLifecycleKernel();
+  const events: string[] = [];
+  await kernel.install(lifecycleRevision('provider', '1', events));
+  await kernel.install({
+    extensionId: 'consumer',
+    revision: '1',
+    dependencies: [{ extensionId: 'provider' }],
+    prepare: () => ({
+      activate: (context) => {
+        events.push('consumer:activate');
+        context.ownEffect('consumer', () => {
+          events.push('consumer:dispose');
+        });
+      },
+    }),
+  });
+  await kernel.activate(binding('provider-binding', 'session-a', 'provider', '1'));
+  await kernel.activate(binding('consumer-binding', 'session-a', 'consumer', '1'));
+  events.length = 0;
+
+  await kernel.disposeScope('session-a');
+  assert.deepEqual(events, ['consumer:dispose', 'provider:1:dispose']);
+  assert.deepEqual(kernel.inspectScope('session-a'), []);
+  assert.deepEqual(kernel.composition('session-a').entries, []);
+});
+
+function binding(bindingId: string, scopeId: string, extensionId: string, revision: string) {
+  return { bindingId, scopeId, extensionId, revision };
+}
+
+function lifecycleRevision(
+  extensionId: string,
+  revision: string,
+  events: string[],
+  options: { value?: unknown } = {},
+): ExtensionRevisionDefinition {
+  return {
+    extensionId,
+    revision,
+    prepare: () => ({
+      activate: (context) => {
+        events.push(`${extensionId}:${revision}:activate`);
+        context.ownEffect(`${extensionId}:${revision}`, () => {
+          events.push(`${extensionId}:${revision}:dispose`);
+        });
+        return { value: options.value };
+      },
+    }),
+  };
+}
+
+async function assertCode(
+  promise: Promise<unknown>,
+  code: ExtensionLifecycleOperationError['code'],
+): Promise<void> {
+  await assert.rejects(
+    promise,
+    (error) => error instanceof ExtensionLifecycleOperationError && error.code === code,
+  );
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}

--- a/packages/runtime/src/extension-lifecycle-kernel.ts
+++ b/packages/runtime/src/extension-lifecycle-kernel.ts
@@ -1,0 +1,1065 @@
+import { createHash } from 'node:crypto';
+
+const ID_PATTERN = /^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$/;
+const MAX_ID_LENGTH = 128;
+
+export type ExtensionEffectDisposer = () => void | Promise<void>;
+
+export interface ExtensionDependencyDefinition {
+  readonly extensionId: string;
+}
+
+export interface ExtensionContributionDefinition {
+  readonly id: string;
+  readonly kind: string;
+}
+
+export interface ExtensionPreparationContext {
+  readonly bindingId: string;
+  readonly scopeId: string;
+  readonly extensionId: string;
+  readonly revision: string;
+  readonly signal: AbortSignal;
+  ownEffect(label: string, dispose: ExtensionEffectDisposer): void;
+}
+
+export interface ExtensionActivationContext extends ExtensionPreparationContext {
+  dependency<T = unknown>(extensionId: string): T;
+  dependencyRevision(extensionId: string): string;
+}
+
+export interface ExtensionActivationResult {
+  readonly value?: unknown;
+}
+
+export interface PreparedExtension {
+  /** Validate candidate-local resources without publishing contributions. */
+  healthCheck?(): void | Promise<void>;
+  /** Publish activation-owned effects through `context.ownEffect`. */
+  activate(
+    context: ExtensionActivationContext,
+  ): void | ExtensionActivationResult | Promise<void | ExtensionActivationResult>;
+  /** Release candidate-local resources allocated by `prepare`. */
+  dispose?(): void | Promise<void>;
+}
+
+export interface ExtensionRevisionDefinition {
+  readonly extensionId: string;
+  readonly revision: string;
+  readonly dependencies?: readonly ExtensionDependencyDefinition[];
+  readonly contributions?: readonly ExtensionContributionDefinition[];
+  /**
+   * Definition/install is data-only. The kernel calls `prepare` only when a
+   * binding is enabled and all required dependencies are active.
+   */
+  prepare(context: ExtensionPreparationContext): PreparedExtension | Promise<PreparedExtension>;
+}
+
+export interface ExtensionBindingInput {
+  readonly bindingId: string;
+  readonly scopeId: string;
+  readonly extensionId: string;
+  readonly revision: string;
+}
+
+export type ExtensionBindingStatus =
+  | 'stopped'
+  | 'waiting'
+  | 'preparing'
+  | 'health_check'
+  | 'activating'
+  | 'active'
+  | 'failed';
+
+export type ExtensionLifecycleErrorCode =
+  | 'invalid_definition'
+  | 'revision_already_installed'
+  | 'revision_not_installed'
+  | 'revision_in_use'
+  | 'binding_conflict'
+  | 'binding_not_found'
+  | 'dependency_cycle'
+  | 'prepare_failed'
+  | 'health_check_failed'
+  | 'activation_failed'
+  | 'cleanup_failed';
+
+export interface ExtensionLifecycleDiagnostic {
+  readonly code: ExtensionLifecycleErrorCode;
+  readonly message: string;
+  readonly revision?: string;
+  readonly at: number;
+}
+
+export interface ExtensionBindingInspection {
+  readonly bindingId: string;
+  readonly scopeId: string;
+  readonly extensionId: string;
+  readonly desiredRevision: string;
+  readonly enabled: boolean;
+  readonly status: ExtensionBindingStatus;
+  readonly current?: {
+    readonly revision: string;
+    readonly generation: number;
+  };
+  readonly candidate?: {
+    readonly revision: string;
+    readonly phase: 'preparing' | 'health_check' | 'activating';
+  };
+  readonly waitingFor: readonly string[];
+  readonly pendingCleanupEffects: number;
+  readonly diagnostic?: ExtensionLifecycleDiagnostic;
+}
+
+export interface ExtensionCompositionEntry {
+  readonly bindingId: string;
+  readonly extensionId: string;
+  readonly revision: string;
+  readonly generation: number;
+  readonly contributions: readonly ExtensionContributionDefinition[];
+}
+
+export interface ExtensionCompositionSnapshot {
+  readonly schemaVersion: 1;
+  readonly scopeId: string;
+  readonly digest: `sha256:${string}`;
+  readonly entries: readonly ExtensionCompositionEntry[];
+}
+
+export class ExtensionLifecycleOperationError extends Error {
+  readonly name = 'ExtensionLifecycleOperationError';
+
+  constructor(
+    readonly code: ExtensionLifecycleErrorCode,
+    message: string,
+    options?: { cause?: unknown },
+  ) {
+    super(message, options);
+  }
+}
+
+interface InstalledRevision {
+  readonly extensionId: string;
+  readonly revision: string;
+  readonly dependencies: readonly ExtensionDependencyDefinition[];
+  readonly contributions: readonly ExtensionContributionDefinition[];
+  readonly prepare: ExtensionRevisionDefinition['prepare'];
+}
+
+interface OwnedEffect {
+  readonly label: string;
+  readonly dispose: ExtensionEffectDisposer;
+}
+
+interface EffectCleanupFailure {
+  readonly label: string;
+  readonly cause: unknown;
+}
+
+class EffectCleanupError extends Error {
+  readonly name = 'EffectCleanupError';
+
+  constructor(readonly failures: readonly EffectCleanupFailure[]) {
+    super(
+      `Failed to clean up ${failures.length} extension effect${failures.length === 1 ? '' : 's'}`,
+      { cause: failures[0]?.cause },
+    );
+  }
+}
+
+class EffectOwner {
+  readonly #effects: OwnedEffect[] = [];
+  #accepting = true;
+
+  get size(): number {
+    return this.#effects.length;
+  }
+
+  own(label: string, dispose: ExtensionEffectDisposer): void {
+    if (!this.#accepting) {
+      throw new ExtensionLifecycleOperationError(
+        'activation_failed',
+        `Cannot register effect "${label}" after activation setup completed`,
+      );
+    }
+    if (!label || label.length > 256 || typeof dispose !== 'function') {
+      throw new ExtensionLifecycleOperationError(
+        'invalid_definition',
+        'Extension effects require a non-empty label and disposer',
+      );
+    }
+    this.#effects.push({ label, dispose });
+  }
+
+  seal(): void {
+    this.#accepting = false;
+  }
+
+  async dispose(): Promise<void> {
+    this.#accepting = false;
+    const failures: EffectCleanupFailure[] = [];
+    for (let index = this.#effects.length - 1; index >= 0; index -= 1) {
+      const effect = this.#effects[index]!;
+      try {
+        await effect.dispose();
+        this.#effects.splice(index, 1);
+      } catch (cause) {
+        failures.push({ label: effect.label, cause });
+      }
+    }
+    if (failures.length > 0) throw new EffectCleanupError(Object.freeze(failures));
+  }
+}
+
+interface CandidateActivation {
+  readonly definition: InstalledRevision;
+  readonly owner: EffectOwner;
+  readonly controller: AbortController;
+  prepared?: PreparedExtension;
+  phase: 'preparing' | 'health_check' | 'activating';
+}
+
+interface CurrentActivation {
+  readonly definition: InstalledRevision;
+  readonly owner: EffectOwner;
+  readonly generation: number;
+  readonly value: unknown;
+}
+
+interface BindingRecord {
+  readonly bindingId: string;
+  readonly scopeId: string;
+  readonly extensionId: string;
+  desiredRevision: string;
+  enabled: boolean;
+  status: ExtensionBindingStatus;
+  waitingFor: readonly string[];
+  current?: CurrentActivation;
+  candidate?: CandidateActivation;
+  readonly retiredOwners: EffectOwner[];
+  diagnostic?: ExtensionLifecycleDiagnostic;
+}
+
+interface ReconcileResult {
+  readonly errors: Map<string, ExtensionLifecycleOperationError>;
+}
+
+/**
+ * Product-independent Phase 1 lifecycle authority.
+ *
+ * Mutations are serialized. Installed revisions are immutable, definition is
+ * effect-free, dependencies resolve only inside the same scope, candidates do
+ * not replace current until preparation/health/activation succeeds, and every
+ * owned effect is disposed in reverse registration order.
+ */
+export class ExtensionLifecycleKernel {
+  readonly #revisions = new Map<string, InstalledRevision>();
+  readonly #bindings = new Map<string, BindingRecord>();
+  readonly #scopeExtensionBindings = new Map<string, string>();
+  #mutationTail: Promise<void> = Promise.resolve();
+  #generation = 0;
+
+  install(definition: ExtensionRevisionDefinition): Promise<void> {
+    return this.#mutate(async () => {
+      const installed = normalizeDefinition(definition);
+      const key = revisionKey(installed.extensionId, installed.revision);
+      if (this.#revisions.has(key)) {
+        throw new ExtensionLifecycleOperationError(
+          'revision_already_installed',
+          `Extension revision already installed: ${key}`,
+        );
+      }
+      this.#revisions.set(key, installed);
+      await this.#reconcileAllScopes();
+    });
+  }
+
+  uninstall(extensionId: string, revision: string): Promise<void> {
+    return this.#mutate(async () => {
+      validateId('extensionId', extensionId);
+      validateRevision(revision);
+      const key = revisionKey(extensionId, revision);
+      if (!this.#revisions.has(key)) {
+        throw new ExtensionLifecycleOperationError(
+          'revision_not_installed',
+          `Extension revision is not installed: ${key}`,
+        );
+      }
+      const user = [...this.#bindings.values()].find(
+        (binding) =>
+          binding.extensionId === extensionId &&
+          (binding.desiredRevision === revision ||
+            binding.current?.definition.revision === revision ||
+            binding.candidate?.definition.revision === revision),
+      );
+      if (user) {
+        throw new ExtensionLifecycleOperationError(
+          'revision_in_use',
+          `Extension revision ${key} is still referenced by binding ${user.bindingId}`,
+        );
+      }
+      this.#revisions.delete(key);
+    });
+  }
+
+  activate(input: ExtensionBindingInput): Promise<ExtensionBindingInspection> {
+    return this.#mutate(async () => {
+      validateBindingInput(input);
+      this.#requireRevision(input.extensionId, input.revision);
+      const existing = this.#bindings.get(input.bindingId);
+      let record: BindingRecord;
+      if (existing) {
+        if (existing.scopeId !== input.scopeId || existing.extensionId !== input.extensionId) {
+          throw new ExtensionLifecycleOperationError(
+            'binding_conflict',
+            `Binding ${input.bindingId} cannot change scope or extension identity`,
+          );
+        }
+        record = existing;
+        const cleanupFailures = await this.#retryRetiredOwners(record);
+        if (cleanupFailures.length > 0) throw cleanupOperationError(cleanupFailures);
+        record.desiredRevision = input.revision;
+        record.enabled = true;
+      } else {
+        const scopeKey = scopeExtensionKey(input.scopeId, input.extensionId);
+        const owner = this.#scopeExtensionBindings.get(scopeKey);
+        if (owner) {
+          throw new ExtensionLifecycleOperationError(
+            'binding_conflict',
+            `Scope ${input.scopeId} already binds extension ${input.extensionId} as ${owner}`,
+          );
+        }
+        record = {
+          bindingId: input.bindingId,
+          scopeId: input.scopeId,
+          extensionId: input.extensionId,
+          desiredRevision: input.revision,
+          enabled: true,
+          status: 'waiting',
+          waitingFor: Object.freeze([]),
+          retiredOwners: [],
+        };
+        this.#bindings.set(input.bindingId, record);
+        this.#scopeExtensionBindings.set(scopeKey, input.bindingId);
+      }
+      const result = await this.#reconcileScope(record.scopeId);
+      const error = result.errors.get(record.bindingId);
+      if (error) throw error;
+      return this.#inspectRecord(record);
+    });
+  }
+
+  update(bindingId: string, revision: string): Promise<ExtensionBindingInspection> {
+    return this.#mutate(async () => {
+      const record = this.#requireBinding(bindingId);
+      const cleanupFailures = await this.#retryRetiredOwners(record);
+      if (cleanupFailures.length > 0) throw cleanupOperationError(cleanupFailures);
+      validateRevision(revision);
+      this.#requireRevision(record.extensionId, revision);
+      record.desiredRevision = revision;
+      record.enabled = true;
+      record.diagnostic = undefined;
+      const result = await this.#reconcileScope(record.scopeId);
+      const error = result.errors.get(record.bindingId);
+      if (error) throw error;
+      return this.#inspectRecord(record);
+    });
+  }
+
+  start(bindingId: string): Promise<ExtensionBindingInspection> {
+    return this.#mutate(async () => {
+      const record = this.#requireBinding(bindingId);
+      const cleanupFailures = await this.#retryRetiredOwners(record);
+      if (cleanupFailures.length > 0) throw cleanupOperationError(cleanupFailures);
+      record.enabled = true;
+      record.diagnostic = undefined;
+      const result = await this.#reconcileScope(record.scopeId);
+      const error = result.errors.get(record.bindingId);
+      if (error) throw error;
+      return this.#inspectRecord(record);
+    });
+  }
+
+  retry(bindingId: string): Promise<ExtensionBindingInspection> {
+    return this.start(bindingId);
+  }
+
+  stop(bindingId: string): Promise<ExtensionBindingInspection> {
+    return this.#mutate(async () => {
+      const record = this.#requireBinding(bindingId);
+      record.enabled = false;
+      record.candidate?.controller.abort();
+      const failures = await this.#retryRetiredOwners(record);
+      failures.push(...(await this.#deactivateCascade(record, new Set())));
+      await this.#reconcileScope(record.scopeId);
+      record.waitingFor = Object.freeze([]);
+      if (record.retiredOwners.length === 0) {
+        record.status = 'stopped';
+        record.diagnostic = undefined;
+      } else {
+        record.status = 'failed';
+        record.diagnostic = cleanupDiagnostic(record.desiredRevision, failures);
+      }
+      if (failures.length > 0) throw cleanupOperationError(failures);
+      return this.#inspectRecord(record);
+    });
+  }
+
+  removeBinding(bindingId: string): Promise<void> {
+    return this.#mutate(async () => {
+      const record = this.#requireBinding(bindingId);
+      record.enabled = false;
+      record.candidate?.controller.abort();
+      const failures = await this.#retryRetiredOwners(record);
+      failures.push(...(await this.#deactivateCascade(record, new Set())));
+      if (record.retiredOwners.length > 0 || failures.length > 0) {
+        record.status = 'failed';
+        record.diagnostic = cleanupDiagnostic(record.desiredRevision, failures);
+        throw cleanupOperationError(failures);
+      }
+      this.#bindings.delete(bindingId);
+      this.#scopeExtensionBindings.delete(scopeExtensionKey(record.scopeId, record.extensionId));
+      await this.#reconcileScope(record.scopeId);
+    });
+  }
+
+  disposeScope(scopeId: string): Promise<void> {
+    return this.#mutate(async () => {
+      validateId('scopeId', scopeId);
+      const records = this.#scopeBindings(scopeId);
+      for (const record of records) record.enabled = false;
+      const failures: EffectCleanupFailure[] = [];
+      for (const record of records) {
+        failures.push(...(await this.#retryRetiredOwners(record)));
+      }
+      const visited = new Set<string>();
+      for (const record of records) {
+        failures.push(...(await this.#deactivateCascade(record, visited)));
+      }
+      if (records.some((record) => record.retiredOwners.length > 0)) {
+        for (const record of records) {
+          if (record.retiredOwners.length === 0) continue;
+          record.status = 'failed';
+          record.diagnostic = cleanupDiagnostic(record.desiredRevision, failures);
+        }
+        throw cleanupOperationError(failures);
+      }
+      for (const record of records) {
+        this.#bindings.delete(record.bindingId);
+        this.#scopeExtensionBindings.delete(scopeExtensionKey(scopeId, record.extensionId));
+      }
+    });
+  }
+
+  inspect(bindingId: string): ExtensionBindingInspection {
+    return this.#inspectRecord(this.#requireBinding(bindingId));
+  }
+
+  inspectScope(scopeId: string): readonly ExtensionBindingInspection[] {
+    validateId('scopeId', scopeId);
+    return Object.freeze(this.#scopeBindings(scopeId).map((record) => this.#inspectRecord(record)));
+  }
+
+  installedRevisions(): readonly {
+    readonly extensionId: string;
+    readonly revision: string;
+  }[] {
+    return Object.freeze(
+      [...this.#revisions.values()]
+        .map(({ extensionId, revision }) => Object.freeze({ extensionId, revision }))
+        .sort(compareExtensionRevision),
+    );
+  }
+
+  composition(scopeId: string): ExtensionCompositionSnapshot {
+    validateId('scopeId', scopeId);
+    const entries = this.#scopeBindings(scopeId)
+      .flatMap((binding): ExtensionCompositionEntry[] => {
+        const current = binding.current;
+        if (!current) return [];
+        return [
+          Object.freeze({
+            bindingId: binding.bindingId,
+            extensionId: binding.extensionId,
+            revision: current.definition.revision,
+            generation: current.generation,
+            contributions: current.definition.contributions,
+          }),
+        ];
+      })
+      .sort((left, right) => compareString(left.extensionId, right.extensionId));
+    const digestInput = entries.map((entry) => ({
+      bindingId: entry.bindingId,
+      extensionId: entry.extensionId,
+      revision: entry.revision,
+      contributions: entry.contributions,
+    }));
+    const digest = createHash('sha256').update(JSON.stringify(digestInput)).digest('hex');
+    return Object.freeze({
+      schemaVersion: 1,
+      scopeId,
+      digest: `sha256:${digest}`,
+      entries: Object.freeze(entries),
+    });
+  }
+
+  #mutate<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#mutationTail.then(operation, operation);
+    this.#mutationTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  async #reconcileAllScopes(): Promise<void> {
+    const scopes = [...new Set([...this.#bindings.values()].map((binding) => binding.scopeId))];
+    for (const scope of scopes.sort(compareString)) await this.#reconcileScope(scope);
+  }
+
+  async #reconcileScope(scopeId: string): Promise<ReconcileResult> {
+    const errors = new Map<string, ExtensionLifecycleOperationError>();
+    const attempted = new Set<string>();
+    const cycles = this.#dependencyCycles(scopeId);
+    for (const bindingId of cycles) {
+      const record = this.#bindings.get(bindingId)!;
+      const error = new ExtensionLifecycleOperationError(
+        'dependency_cycle',
+        `Extension dependency cycle includes binding ${bindingId}`,
+      );
+      record.status = 'failed';
+      record.waitingFor = Object.freeze([]);
+      record.diagnostic = diagnostic(error, record.desiredRevision);
+      errors.set(bindingId, error);
+      attempted.add(bindingId);
+    }
+
+    let progress = true;
+    while (progress) {
+      progress = false;
+      for (const record of this.#scopeBindings(scopeId)) {
+        if (!record.enabled || attempted.has(record.bindingId)) continue;
+        if (record.retiredOwners.length > 0) {
+          record.status = 'failed';
+          continue;
+        }
+        const definition = this.#requireRevision(record.extensionId, record.desiredRevision);
+        const waitingFor = this.#missingDependencies(record, definition);
+        if (waitingFor.length > 0) {
+          record.status = 'waiting';
+          record.waitingFor = Object.freeze(waitingFor);
+          continue;
+        }
+        record.waitingFor = Object.freeze([]);
+        if (record.current?.definition.revision === record.desiredRevision) {
+          record.status = 'active';
+          continue;
+        }
+        attempted.add(record.bindingId);
+        try {
+          if (record.current) await this.#updateCurrent(record, definition);
+          else await this.#activateInitial(record, definition);
+          record.status = 'active';
+          record.diagnostic = undefined;
+          progress = true;
+        } catch (cause) {
+          const error = asLifecycleError(cause);
+          record.status = record.current ? 'active' : 'failed';
+          record.diagnostic = diagnostic(error, definition.revision);
+          errors.set(record.bindingId, error);
+          // Candidate activation can temporarily stop dependents; one more pass
+          // restores them against the still-current revision.
+          if (record.current) progress = true;
+        }
+      }
+    }
+    return { errors };
+  }
+
+  async #activateInitial(record: BindingRecord, definition: InstalledRevision): Promise<void> {
+    const candidate = await this.#prepareCandidate(record, definition);
+    try {
+      const activation = await this.#activateCandidate(record, candidate);
+      record.current = activation;
+      record.candidate = undefined;
+    } catch (cause) {
+      await this.#discardCandidate(record, candidate, cause);
+    }
+  }
+
+  async #updateCurrent(record: BindingRecord, definition: InstalledRevision): Promise<void> {
+    const current = record.current!;
+    const candidate = await this.#prepareCandidate(record, definition);
+    const dependentCleanupFailures = await this.#deactivateDependents(record, new Set());
+    if (dependentCleanupFailures.length > 0) {
+      return this.#discardCandidate(
+        record,
+        candidate,
+        new ExtensionLifecycleOperationError(
+          'cleanup_failed',
+          'Cannot activate candidate because a dependent did not stop cleanly',
+          { cause: dependentCleanupFailures[0]?.cause },
+        ),
+      );
+    }
+    let activation: CurrentActivation;
+    try {
+      activation = await this.#activateCandidate(record, candidate);
+    } catch (cause) {
+      return this.#discardCandidate(record, candidate, cause);
+    }
+    record.current = activation;
+    record.candidate = undefined;
+    const cleanupFailures = await this.#disposeOwner(record, current.owner);
+    if (cleanupFailures.length > 0) {
+      throw cleanupOperationError(
+        cleanupFailures,
+        'Candidate committed, but old activation cleanup failed',
+      );
+    }
+  }
+
+  async #prepareCandidate(
+    record: BindingRecord,
+    definition: InstalledRevision,
+  ): Promise<CandidateActivation> {
+    const owner = new EffectOwner();
+    const candidate: CandidateActivation = {
+      definition,
+      owner,
+      controller: new AbortController(),
+      phase: 'preparing',
+    };
+    record.candidate = candidate;
+    record.status = 'preparing';
+    try {
+      const prepared = await definition.prepare(
+        this.#preparationContext(record, definition, candidate),
+      );
+      if (!prepared || typeof prepared !== 'object' || typeof prepared.activate !== 'function') {
+        throw new ExtensionLifecycleOperationError(
+          'invalid_definition',
+          `Extension ${definition.extensionId}@${definition.revision} returned an invalid candidate`,
+        );
+      }
+      candidate.prepared = prepared;
+      if (prepared.dispose) owner.own('prepared.dispose', () => prepared.dispose!());
+      candidate.phase = 'health_check';
+      record.status = 'health_check';
+      await prepared.healthCheck?.();
+      return candidate;
+    } catch (cause) {
+      const phaseCode =
+        candidate.phase === 'health_check' ? 'health_check_failed' : 'prepare_failed';
+      const error =
+        cause instanceof ExtensionLifecycleOperationError
+          ? cause
+          : new ExtensionLifecycleOperationError(
+              phaseCode,
+              `Extension candidate ${definition.extensionId}@${definition.revision} ${candidate.phase} failed`,
+              { cause },
+            );
+      return this.#discardCandidate(record, candidate, error);
+    }
+  }
+
+  async #activateCandidate(
+    record: BindingRecord,
+    candidate: CandidateActivation,
+  ): Promise<CurrentActivation> {
+    const prepared = candidate.prepared!;
+    candidate.phase = 'activating';
+    record.status = 'activating';
+    try {
+      const result = await prepared.activate(this.#activationContext(record, candidate));
+      candidate.owner.seal();
+      return {
+        definition: candidate.definition,
+        owner: candidate.owner,
+        generation: ++this.#generation,
+        value: result?.value,
+      };
+    } catch (cause) {
+      throw cause instanceof ExtensionLifecycleOperationError
+        ? cause
+        : new ExtensionLifecycleOperationError(
+            'activation_failed',
+            `Extension candidate ${candidate.definition.extensionId}@${candidate.definition.revision} activation failed`,
+            { cause },
+          );
+    }
+  }
+
+  async #discardCandidate(
+    record: BindingRecord,
+    candidate: CandidateActivation,
+    cause: unknown,
+  ): Promise<never> {
+    candidate.controller.abort();
+    candidate.owner.seal();
+    record.candidate = undefined;
+    const cleanupFailures = await this.#disposeOwner(record, candidate.owner);
+    if (cleanupFailures.length > 0) {
+      throw cleanupOperationError(
+        cleanupFailures,
+        'Candidate failed and cleanup was incomplete',
+        cause,
+      );
+    }
+    throw cause;
+  }
+
+  #preparationContext(
+    record: BindingRecord,
+    definition: InstalledRevision,
+    candidate: CandidateActivation,
+  ): ExtensionPreparationContext {
+    return Object.freeze({
+      bindingId: record.bindingId,
+      scopeId: record.scopeId,
+      extensionId: record.extensionId,
+      revision: definition.revision,
+      signal: candidate.controller.signal,
+      ownEffect: (label: string, dispose: ExtensionEffectDisposer) =>
+        candidate.owner.own(label, dispose),
+    });
+  }
+
+  #activationContext(
+    record: BindingRecord,
+    candidate: CandidateActivation,
+  ): ExtensionActivationContext {
+    const base = this.#preparationContext(record, candidate.definition, candidate);
+    const dependency = <T = unknown>(extensionId: string): T => {
+      const activation = this.#dependencyActivation(record.scopeId, extensionId);
+      if (!activation) {
+        throw new ExtensionLifecycleOperationError(
+          'activation_failed',
+          `Required dependency ${extensionId} is no longer active`,
+        );
+      }
+      return activation.value as T;
+    };
+    return Object.freeze({
+      ...base,
+      dependency,
+      dependencyRevision: (extensionId: string) => {
+        const activation = this.#dependencyActivation(record.scopeId, extensionId);
+        if (!activation) {
+          throw new ExtensionLifecycleOperationError(
+            'activation_failed',
+            `Required dependency ${extensionId} is no longer active`,
+          );
+        }
+        return activation.definition.revision;
+      },
+    });
+  }
+
+  #missingDependencies(record: BindingRecord, definition: InstalledRevision): string[] {
+    return definition.dependencies
+      .filter((dependency) => !this.#dependencyActivation(record.scopeId, dependency.extensionId))
+      .map((dependency) => dependency.extensionId)
+      .sort(compareString);
+  }
+
+  #dependencyActivation(scopeId: string, extensionId: string): CurrentActivation | undefined {
+    const bindingId = this.#scopeExtensionBindings.get(scopeExtensionKey(scopeId, extensionId));
+    return bindingId ? this.#bindings.get(bindingId)?.current : undefined;
+  }
+
+  #dependencyCycles(scopeId: string): Set<string> {
+    const records = this.#scopeBindings(scopeId).filter((record) => record.enabled);
+    const byExtension = new Map(records.map((record) => [record.extensionId, record]));
+    const visiting = new Set<string>();
+    const visited = new Set<string>();
+    const stack: string[] = [];
+    const cycles = new Set<string>();
+    const visit = (record: BindingRecord): void => {
+      if (visited.has(record.bindingId)) return;
+      if (visiting.has(record.bindingId)) {
+        const start = stack.indexOf(record.bindingId);
+        for (const bindingId of stack.slice(start)) cycles.add(bindingId);
+        return;
+      }
+      visiting.add(record.bindingId);
+      stack.push(record.bindingId);
+      const definition = this.#revisions.get(
+        revisionKey(record.extensionId, record.desiredRevision),
+      );
+      for (const dependency of definition?.dependencies ?? []) {
+        const target = byExtension.get(dependency.extensionId);
+        if (target) visit(target);
+      }
+      stack.pop();
+      visiting.delete(record.bindingId);
+      visited.add(record.bindingId);
+    };
+    for (const record of records) visit(record);
+    return cycles;
+  }
+
+  async #deactivateDependents(
+    record: BindingRecord,
+    visited: Set<string>,
+  ): Promise<EffectCleanupFailure[]> {
+    const failures: EffectCleanupFailure[] = [];
+    for (const dependent of this.#activeDependents(record)) {
+      failures.push(...(await this.#deactivateCascade(dependent, visited)));
+    }
+    return failures;
+  }
+
+  async #deactivateCascade(
+    record: BindingRecord,
+    visited: Set<string>,
+  ): Promise<EffectCleanupFailure[]> {
+    if (visited.has(record.bindingId)) return [];
+    visited.add(record.bindingId);
+    const failures = await this.#deactivateDependents(record, visited);
+    if (record.current) failures.push(...(await this.#stopCurrent(record)));
+    record.waitingFor = record.enabled
+      ? Object.freeze(this.#missingDependencies(record, this.#desiredDefinition(record)))
+      : Object.freeze([]);
+    if (record.retiredOwners.length > 0) {
+      record.status = 'failed';
+      record.diagnostic = cleanupDiagnostic(record.desiredRevision, failures);
+    } else {
+      record.status = record.enabled ? 'waiting' : 'stopped';
+    }
+    return failures;
+  }
+
+  #activeDependents(record: BindingRecord): BindingRecord[] {
+    return this.#scopeBindings(record.scopeId).filter((candidate) => {
+      const definition = candidate.current?.definition;
+      return definition?.dependencies.some(
+        (dependency) => dependency.extensionId === record.extensionId,
+      );
+    });
+  }
+
+  async #stopCurrent(record: BindingRecord): Promise<EffectCleanupFailure[]> {
+    const current = record.current;
+    if (!current) return [];
+    record.current = undefined;
+    return this.#disposeOwner(record, current.owner);
+  }
+
+  async #disposeOwner(record: BindingRecord, owner: EffectOwner): Promise<EffectCleanupFailure[]> {
+    try {
+      await owner.dispose();
+      return [];
+    } catch (cause) {
+      if (owner.size > 0 && !record.retiredOwners.includes(owner)) record.retiredOwners.push(owner);
+      return cleanupFailures(cause);
+    }
+  }
+
+  async #retryRetiredOwners(record: BindingRecord): Promise<EffectCleanupFailure[]> {
+    const failures: EffectCleanupFailure[] = [];
+    for (let index = record.retiredOwners.length - 1; index >= 0; index -= 1) {
+      const owner = record.retiredOwners[index]!;
+      try {
+        await owner.dispose();
+        record.retiredOwners.splice(index, 1);
+      } catch (cause) {
+        failures.push(...cleanupFailures(cause));
+      }
+    }
+    return failures;
+  }
+
+  #desiredDefinition(record: BindingRecord): InstalledRevision {
+    return this.#requireRevision(record.extensionId, record.desiredRevision);
+  }
+
+  #requireRevision(extensionId: string, revision: string): InstalledRevision {
+    const key = revisionKey(extensionId, revision);
+    const definition = this.#revisions.get(key);
+    if (!definition) {
+      throw new ExtensionLifecycleOperationError(
+        'revision_not_installed',
+        `Extension revision is not installed: ${key}`,
+      );
+    }
+    return definition;
+  }
+
+  #requireBinding(bindingId: string): BindingRecord {
+    validateId('bindingId', bindingId);
+    const record = this.#bindings.get(bindingId);
+    if (!record) {
+      throw new ExtensionLifecycleOperationError(
+        'binding_not_found',
+        `Extension binding not found: ${bindingId}`,
+      );
+    }
+    return record;
+  }
+
+  #scopeBindings(scopeId: string): BindingRecord[] {
+    return [...this.#bindings.values()]
+      .filter((binding) => binding.scopeId === scopeId)
+      .sort((left, right) => compareString(left.bindingId, right.bindingId));
+  }
+
+  #inspectRecord(record: BindingRecord): ExtensionBindingInspection {
+    const pendingCleanupEffects = record.retiredOwners.reduce((sum, owner) => sum + owner.size, 0);
+    return Object.freeze({
+      bindingId: record.bindingId,
+      scopeId: record.scopeId,
+      extensionId: record.extensionId,
+      desiredRevision: record.desiredRevision,
+      enabled: record.enabled,
+      status: record.status,
+      ...(record.current
+        ? {
+            current: Object.freeze({
+              revision: record.current.definition.revision,
+              generation: record.current.generation,
+            }),
+          }
+        : {}),
+      ...(record.candidate
+        ? {
+            candidate: Object.freeze({
+              revision: record.candidate.definition.revision,
+              phase: record.candidate.phase,
+            }),
+          }
+        : {}),
+      waitingFor: Object.freeze([...record.waitingFor]),
+      pendingCleanupEffects,
+      ...(record.diagnostic ? { diagnostic: Object.freeze({ ...record.diagnostic }) } : {}),
+    });
+  }
+}
+
+function normalizeDefinition(definition: ExtensionRevisionDefinition): InstalledRevision {
+  if (!definition || typeof definition !== 'object') invalidDefinition('Definition is required');
+  validateId('extensionId', definition.extensionId);
+  validateRevision(definition.revision);
+  if (typeof definition.prepare !== 'function') invalidDefinition('Definition requires prepare');
+  const dependencies = [...(definition.dependencies ?? [])].map((dependency) => {
+    validateId('dependency.extensionId', dependency.extensionId);
+    if (dependency.extensionId === definition.extensionId) {
+      invalidDefinition('An extension cannot depend on itself');
+    }
+    return Object.freeze({ extensionId: dependency.extensionId });
+  });
+  dependencies.sort((left, right) => compareString(left.extensionId, right.extensionId));
+  if (
+    new Set(dependencies.map((dependency) => dependency.extensionId)).size !== dependencies.length
+  ) {
+    invalidDefinition('Extension dependencies must be unique');
+  }
+  const contributions = [...(definition.contributions ?? [])].map((contribution) => {
+    validateId('contribution.id', contribution.id);
+    validateId('contribution.kind', contribution.kind);
+    return Object.freeze({ id: contribution.id, kind: contribution.kind });
+  });
+  contributions.sort((left, right) => compareString(left.id, right.id));
+  if (new Set(contributions.map((contribution) => contribution.id)).size !== contributions.length) {
+    invalidDefinition('Extension contribution IDs must be unique');
+  }
+  return Object.freeze({
+    extensionId: definition.extensionId,
+    revision: definition.revision,
+    dependencies: Object.freeze(dependencies),
+    contributions: Object.freeze(contributions),
+    prepare: definition.prepare,
+  });
+}
+
+function validateBindingInput(input: ExtensionBindingInput): void {
+  if (!input || typeof input !== 'object') invalidDefinition('Binding input is required');
+  validateId('bindingId', input.bindingId);
+  validateId('scopeId', input.scopeId);
+  validateId('extensionId', input.extensionId);
+  validateRevision(input.revision);
+}
+
+function validateId(label: string, value: string): void {
+  if (typeof value !== 'string' || value.length > MAX_ID_LENGTH || !ID_PATTERN.test(value)) {
+    invalidDefinition(`Invalid ${label}: ${String(value)}`);
+  }
+}
+
+function validateRevision(revision: string): void {
+  if (
+    typeof revision !== 'string' ||
+    revision.length === 0 ||
+    revision.length > MAX_ID_LENGTH ||
+    /[\r\n]/.test(revision)
+  ) {
+    invalidDefinition(`Invalid revision: ${String(revision)}`);
+  }
+}
+
+function invalidDefinition(message: string): never {
+  throw new ExtensionLifecycleOperationError('invalid_definition', message);
+}
+
+function revisionKey(extensionId: string, revision: string): string {
+  return `${extensionId}@${revision}`;
+}
+
+function scopeExtensionKey(scopeId: string, extensionId: string): string {
+  return `${scopeId}\u0000${extensionId}`;
+}
+
+function compareString(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareExtensionRevision(
+  left: { extensionId: string; revision: string },
+  right: { extensionId: string; revision: string },
+): number {
+  return (
+    compareString(left.extensionId, right.extensionId) ||
+    compareString(left.revision, right.revision)
+  );
+}
+
+function asLifecycleError(cause: unknown): ExtensionLifecycleOperationError {
+  return cause instanceof ExtensionLifecycleOperationError
+    ? cause
+    : new ExtensionLifecycleOperationError('activation_failed', 'Extension activation failed', {
+        cause,
+      });
+}
+
+function diagnostic(
+  error: ExtensionLifecycleOperationError,
+  revision?: string,
+): ExtensionLifecycleDiagnostic {
+  return Object.freeze({
+    code: error.code,
+    message: error.message,
+    ...(revision ? { revision } : {}),
+    at: Date.now(),
+  });
+}
+
+function cleanupDiagnostic(
+  revision: string,
+  failures: readonly EffectCleanupFailure[],
+): ExtensionLifecycleDiagnostic {
+  return diagnostic(cleanupOperationError(failures), revision);
+}
+
+function cleanupFailures(cause: unknown): EffectCleanupFailure[] {
+  return cause instanceof EffectCleanupError ? [...cause.failures] : [{ label: 'unknown', cause }];
+}
+
+function cleanupOperationError(
+  failures: readonly EffectCleanupFailure[],
+  message = 'Extension effect cleanup failed',
+  cause?: unknown,
+): ExtensionLifecycleOperationError {
+  return new ExtensionLifecycleOperationError('cleanup_failed', message, {
+    cause: cause ?? failures[0]?.cause,
+  });
+}


### PR DESCRIPTION
## Summary

Add the product-independent Phase 1 lifecycle kernel from #2973, without wiring Tool, UI, or dynamic-script contribution adapters yet.

- install immutable extension revisions without executing extension code
- bind exact revisions to scopes and support start, stop, update, removal, and scope disposal
- own preparation and activation effects with reverse-order cleanup and retryable cleanup diagnostics
- wait for same-scope dependencies, detect cycles, stop dependents before providers, and reactivate them after recovery or update
- update through current/candidate prepare, health-check, activation, commit, and rollback semantics
- expose immutable, deterministic composition snapshots plus live binding diagnostics
- serialize lifecycle mutations so committed state and cleanup ownership remain consistent

The implementation is intentionally isolated from Maka's existing Tool, permission, sandbox, and Run authorities. Those integrations remain follow-up phases in the issue roadmap.

Refs #2973

## Verification

- `npm --workspace @maka/runtime run test:dist`: **2819 pass / 0 fail / 12 skip**
- lifecycle-focused suite: **28 pass / 0 fail**
- compiled implementation coverage: **99.73% lines / 94.96% branches / 100% functions**
- system suite repeated 20 times without intermittent failures
- `npm run typecheck`: passed for all workspaces
- `npx biome check packages/runtime/src/__tests__/extension-lifecycle-kernel.system.test.ts docs/architecture/extension-lifecycle-kernel.md`: passed
- `git diff --check`: passed

The system suite drives the exported kernel rather than mocking lifecycle behavior. It uses a real TCP server/client, actual port release, EventEmitter listeners, timers, a transitive dependency graph, cleanup-failure recovery, and a 2,000-operation seeded lifecycle soak across multiple scopes and revisions.

## Review focus

- current/candidate commit and rollback boundaries
- dependency teardown and reactivation order
- effect ownership when cleanup partially fails
- distinction between deterministic composition identity and activation generation
- Phase 1 boundary: this PR does not yet admit contributions into active Agent Runs

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
