### PR TITLE
fix(eval): redact query strings from egress audit

### DIFF
--- a/packages/eval/harbor/egress_filter.py
+++ b/packages/eval/harbor/egress_filter.py
@@ -102,7 +102,7 @@ def request(flow: object) -> None:
         if not matched:
             return
         rule_id, host, normalized_path = matched
-        append_audit(rule_id, host, normalized_path)
+        append_audit(rule_id, host, normalized_path.partition("?")[0])
         flow.response = blocked_response(rule_id)
     except Exception as error:
         flow.response = http.Response.make(

--- a/packages/eval/harbor/test_egress_filter.py
+++ b/packages/eval/harbor/test_egress_filter.py
@@ -71,6 +71,37 @@ class EgressFilterTest(unittest.TestCase):
             self.assertIn("host", record)
             self.assertIn("normalizedPath", record)
 
+    def test_audit_omits_query_strings_without_changing_matching(self) -> None:
+        class Response:
+            @staticmethod
+            def make(status, body, headers):
+                return {"status": status, "body": body, "headers": headers}
+
+        with tempfile.TemporaryDirectory() as directory:
+            MODULE.http = SimpleNamespace(Response=Response)
+            MODULE.AUDIT_PATH = Path(directory) / "hits.jsonl"
+            flow = type(
+                "Flow",
+                (),
+                {
+                    "request": type(
+                        "Request",
+                        (),
+                        {
+                            "pretty_url": "https://example.test/search?q=terminal+bench&token=fake-secret"
+                        },
+                    )()
+                },
+            )()
+
+            MODULE.request(flow)
+
+            self.assertEqual(flow.response["status"], 451)
+            record = json.loads(MODULE.AUDIT_PATH.read_text().splitlines()[0])
+            self.assertEqual(record["ruleId"], "terminal_bench_url")
+            self.assertEqual(record["normalizedPath"], "/search")
+            self.assertNotIn("fake-secret", json.dumps(record))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #2980.

## Summary

- keep the normalized query string available for egress contamination matching
- remove the query component before writing a blocked request to the audit log
- add a regression proving query-only rules still block while query values and tokens are not persisted

## Root cause

The filter passed the same normalized path to both rule matching and audit persistence. Query parameters are useful matching signals, but persisting that value could record sensitive query data.

## Validation

- `python packages/eval/harbor/test_egress_filter.py` - 4 passed
- full Harbor Python suite under WSL Ubuntu - 29 passed
- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- Knip for `apps/desktop` and `packages/ui`
- `npm run build:test`
- before/after artifact reproduction confirmed the rule still returns 451 and the patched audit record contains `/search` without the test token

Windows-only Eval and CLI test failures were reproduced unchanged on the untouched base; the affected CI jobs run on Ubuntu.

## AI assistance

Implemented with OpenAI Codex assistance. I reviewed the final diff, decided to submit it, and accept responsibility for its accuracy, provenance, and Apache-2.0 licensing. The commit includes the repository-required `Generated-by: Codex` trailer.
