### PR TITLE
feat(memory): use stable workspace identities

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,7 @@
     "./tool-recovery-bundle": "./dist/tool-recovery-bundle.js",
     "./tool-result-preview": "./dist/tool-result-preview.js",
     "./workspace-version-authority": "./dist/workspace-version-authority.js",
+    "./workspace-identity": "./dist/workspace-identity.js",
     "./runtime-policy": "./dist/runtime-policy.js",
     "./goal": "./dist/goal.js",
     "./execution-log-coverage": "./dist/execution-log-coverage.js",

--- a/packages/core/src/__tests__/workspace-identity.test.ts
+++ b/packages/core/src/__tests__/workspace-identity.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isWorkspaceIdentity, workspaceIdentityFromUuid } from '../workspace-identity.js';
+
+test('Workspace identities use one canonical lowercase representation', () => {
+  const uuid = '123E4567-E89B-42D3-A456-426614174000';
+
+  assert.equal(
+    workspaceIdentityFromUuid(uuid),
+    'workspace:v1:123e4567-e89b-42d3-a456-426614174000',
+  );
+  assert.equal(isWorkspaceIdentity('workspace:v1:123e4567-e89b-42d3-a456-426614174000'), true);
+  assert.equal(isWorkspaceIdentity(`workspace:v1:${uuid}`), false);
+  assert.equal(isWorkspaceIdentity('/workspace/maka'), false);
+});

--- a/packages/core/src/workspace-identity.ts
+++ b/packages/core/src/workspace-identity.ts
@@ -1,0 +1,20 @@
+export const WORKSPACE_IDENTITY_PREFIX = 'workspace:v1:' as const;
+
+export type WorkspaceIdentity = `${typeof WORKSPACE_IDENTITY_PREFIX}${string}`;
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+export function isWorkspaceIdentityUuid(value: unknown): value is string {
+  return typeof value === 'string' && UUID_PATTERN.test(value);
+}
+
+export function workspaceIdentityFromUuid(value: string): WorkspaceIdentity {
+  if (!isWorkspaceIdentityUuid(value)) throw new Error('Invalid Workspace identity UUID');
+  return `${WORKSPACE_IDENTITY_PREFIX}${value.toLowerCase()}`;
+}
+
+export function isWorkspaceIdentity(value: unknown): value is WorkspaceIdentity {
+  if (typeof value !== 'string' || !value.startsWith(WORKSPACE_IDENTITY_PREFIX)) return false;
+  const uuid = value.slice(WORKSPACE_IDENTITY_PREFIX.length);
+  return isWorkspaceIdentityUuid(uuid) && uuid === uuid.toLowerCase();
+}

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -2507,7 +2507,7 @@ test('Host auxiliary models meter provider usage and abort physical requests', {
       sessionId: session.id,
       runId: 'memory-source-run',
       turnId: 'memory-source-turn',
-      workspaceKey: capability.canonicalPath,
+      workspaceIdentity: 'workspace:v1:123e4567-e89b-42d3-a456-426614174000' as const,
       toolCallId: 'memory-source-call',
     };
     const memoryRequestsBefore = provider.requests.length;

--- a/packages/runtime-host/src/__tests__/memory-extraction-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/memory-extraction-coordinator.test.ts
@@ -45,6 +45,8 @@ import { type MemoryExtractionSourceSnapshot } from '@maka/runtime/memory-extrac
 import { HostMemoryExtractionCoordinator } from '../server/memory-extraction-coordinator.js';
 import { MemoryExtractionSessionLane } from '../server/memory-extraction-session-lane.js';
 
+const WORKSPACE_IDENTITY = 'workspace:v1:123e4567-e89b-42d3-a456-426614174000' as const;
+
 describe('HostMemoryExtractionCoordinator', () => {
   test('extracts incidental memory through the post-terminal memory_extract path', async () => {
     await withMemoryWriter(async (writer) => {
@@ -85,7 +87,7 @@ describe('HostMemoryExtractionCoordinator', () => {
       const stored = await writer.searchByKeys({
         terms: ['response preference'],
         match: 'exact',
-        workspaceKey: '/workspace/maka',
+        workspaceKey: WORKSPACE_IDENTITY,
       });
       assert.deepEqual(
         stored.map(({ item: storedItem }) => storedItem.content),
@@ -156,7 +158,7 @@ describe('HostMemoryExtractionCoordinator', () => {
         await writer.searchByKeys({
           terms: ['response preference'],
           match: 'exact',
-          workspaceKey: '/workspace/maka',
+          workspaceKey: WORKSPACE_IDENTITY,
         }),
         [],
       );
@@ -215,13 +217,13 @@ describe('HostMemoryExtractionCoordinator', () => {
       const stored = await writer.searchByKeys({
         terms: ['response preference'],
         match: 'exact',
-        workspaceKey: '/workspace/maka',
+        workspaceKey: WORKSPACE_IDENTITY,
       });
       assert.equal(stored.length, 2);
       assert.deepEqual(
         stored.map(({ item }) => [item.content, item.scopeType, item.scopeKey]),
         [
-          ['The user prefers detailed English.', 'workspace', '/workspace/maka'],
+          ['The user prefers detailed English.', 'workspace', WORKSPACE_IDENTITY],
           ['The user prefers concise Chinese.', 'global', null],
         ],
       );
@@ -1109,7 +1111,7 @@ describe('HostMemoryExtractionCoordinator', () => {
           await writer.searchByKeys({
             terms: ['response preference'],
             match: 'exact',
-            workspaceKey: '/workspace/maka',
+            workspaceKey: WORKSPACE_IDENTITY,
           })
         ).map(({ item }) => item.content),
         ['The user approved SQLite for the project database.'],
@@ -2365,7 +2367,7 @@ function snapshot(
     sessionId: 'session-1',
     runId,
     turnId,
-    workspaceKey: '/workspace/maka',
+    workspaceIdentity: WORKSPACE_IDENTITY,
     toolCallId,
   };
 }
@@ -2394,7 +2396,7 @@ function extractSnapshot(
     sessionId: 'session-1',
     runId,
     turnId,
-    workspaceKey: '/workspace/maka',
+    workspaceIdentity: WORKSPACE_IDENTITY,
     terminalEventId,
   };
 }
@@ -2422,7 +2424,7 @@ function compactionSnapshot(
     sessionId: 'session-1',
     runId: 'run-current-trigger',
     turnId: 'turn-current-trigger',
-    workspaceKey: '/workspace/maka',
+    workspaceIdentity: WORKSPACE_IDENTITY,
     compactionCheckpointId: checkpoint.checkpointId,
     compactionBoundaryEventId: boundary.runtimeEventId,
   };

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -628,9 +628,27 @@ export async function createExecutionRuntimeHostComposition(
     backends.register(
       'ai-sdk',
       dependencies.primaryBackendFactory ??
-        ((backendContext) =>
-          createHostAiSdkBackend({
+        (async (backendContext) => {
+          const memoryExtractionEnabled =
+            !backendContext.tools &&
+            !backendContext.header.subagentParent &&
+            backendContext.header.collaborationMode !== 'plan' &&
+            hostedExecutionRunProfile(backendContext.header.toolProfile)?.memoryExtraction !==
+              false &&
+            memoryExtraction !== undefined;
+          let workspaceIdentity;
+          if (memoryExtractionEnabled) {
+            try {
+              workspaceIdentity = (
+                await resolveWorkspaceIdentity({ path: backendContext.workspaceRoot })
+              ).workspaceIdentity;
+            } catch {
+              // Long-term memory is optional and fail-open. Never fall back to a path Scope.
+            }
+          }
+          return createHostAiSdkBackend({
             context: backendContext,
+            ...(workspaceIdentity ? { workspaceIdentity } : {}),
             runtimePolicy: runtimePolicyStores,
             oauthCredentials,
             sandboxDiagnostics,
@@ -655,10 +673,7 @@ export async function createExecutionRuntimeHostComposition(
               childTools: childAgentTools.childTools,
               worktreePatchWriteBackAvailable: true,
             }),
-            ...(hostedExecutionRunProfile(backendContext.header.toolProfile)?.memoryExtraction ===
-            false
-              ? {}
-              : { memoryExtraction }),
+            ...(memoryExtractionEnabled && workspaceIdentity ? { memoryExtraction } : {}),
             artifacts: openedArtifactStore,
             executionArtifacts,
             usage: openedUsageStores,
@@ -668,7 +683,8 @@ export async function createExecutionRuntimeHostComposition(
             ),
             runtimeCommitSink: stores.runtimeEventStore,
             requestDrain: context.requestDrain,
-          })),
+          });
+        }),
     );
     const runtimeAuthority: RuntimeHostedRootAuthority = {
       bindRun: (identity) => messages.bindRun(identity),

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -23,6 +23,7 @@ import { resolveModelVisionSupport } from '@maka/core/model-metadata';
 import { relayModelProfile } from '@maka/core/model-thinking';
 import type { ModelCallAttempt } from '@maka/core/model-call-attempt';
 import type { ModelCallCommit } from '@maka/core/agent-run';
+import { isWorkspaceIdentity, type WorkspaceIdentity } from '@maka/core/workspace-identity';
 import type { PermissionMode } from '@maka/core/permission';
 import { AiSdkBackend } from '@maka/runtime/ai-sdk-backend';
 import {
@@ -64,6 +65,7 @@ import type { HostRunComposer, HostRunComposerFactory } from './host-run-compose
 
 export interface HostAiSdkBackendInput {
   readonly context: BackendFactoryContext;
+  readonly workspaceIdentity?: WorkspaceIdentity;
   readonly runtimePolicy: HostExecutionRuntimePolicyAuthority;
   readonly oauthCredentials: HostOAuthExecutionAuthority;
   readonly createRunComposer: HostRunComposerFactory;
@@ -99,6 +101,14 @@ type HostExecutionUsageAuthority = {
 
 /** Builds one real provider backend from canonical Host state. */
 export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Promise<AiSdkBackend> {
+  const memoryExtractionEligible =
+    !input.context.tools &&
+    !input.context.header.subagentParent &&
+    input.context.header.collaborationMode !== 'plan' &&
+    input.memoryExtraction !== undefined;
+  if (memoryExtractionEligible && !isWorkspaceIdentity(input.workspaceIdentity)) {
+    throw new Error('Host memory extraction requires a stable Workspace identity');
+  }
   const createFetchTransport = input.createFetchTransport ?? createProxiedFetchTransport;
   const target = await readDuringBackendCreation(
     () =>
@@ -326,11 +336,21 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
         );
       }
     : undefined;
-
+  const memoryExtractionCapabilities =
+    memoryExtractionEligible && input.memoryExtraction
+      ? input.memoryExtraction.sourceCapabilities(
+          runtimePolicySnapshot.policy.privacy.incognitoActive
+            ? { allowed: false, reason: 'incognito' }
+            : runtimePolicySnapshot.policy.memory.enabled
+              ? { allowed: true }
+              : { allowed: false, reason: 'disabled' },
+        )
+      : undefined;
   try {
     return new HostAiSdkBackend(
       {
         sessionId: input.context.sessionId,
+        ...(input.workspaceIdentity ? { workspaceIdentity: input.workspaceIdentity } : {}),
         header: {
           ...input.context.header,
           model: target.model,
@@ -384,20 +404,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
         }),
         recordToolArtifacts: input.executionArtifacts.recordToolArtifacts,
         toolResultArchive: input.executionArtifacts.toolResultArchive,
-        ...(!input.context.tools &&
-        !input.context.header.subagentParent &&
-        input.context.header.collaborationMode !== 'plan' &&
-        input.memoryExtraction
-          ? {
-              memoryExtraction: input.memoryExtraction.sourceCapabilities(
-                runtimePolicySnapshot.policy.privacy.incognitoActive
-                  ? { allowed: false, reason: 'incognito' }
-                  : runtimePolicySnapshot.policy.memory.enabled
-                    ? { allowed: true }
-                    : { allowed: false, reason: 'disabled' },
-              ),
-            }
-          : {}),
+        ...(memoryExtractionCapabilities ? { memoryExtraction: memoryExtractionCapabilities } : {}),
         loadHistoryCompactCheckpoint: input.context.loadHistoryCompactCheckpoint,
         summarizeHistoryCompact,
         historyCompactRoute,

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -530,6 +530,29 @@ describe('AiSdkBackend ApplyPatch routing', () => {
 });
 
 describe('AiSdkBackend Memory Extraction triggers', () => {
+  test('rejects path-based Workspace identity before exposing Memory extraction', () => {
+    assert.throws(
+      () =>
+        createTestAiSdkBackend({
+          sessionId: 'session-1',
+          header: header(),
+          workspaceIdentity: '/workspace/maka' as unknown as `workspace:v1:${string}`,
+          appendMessage: async () => {},
+          connection: connection(),
+          apiKey: 'sk-test',
+          modelId: 'mock-model-id',
+          modelFactory: () => completionModel(),
+          tools: [],
+          memoryExtraction: {
+            gate: async () => ({ allowed: true }),
+            remember: async () => ({ status: 'unavailable', requestedItems: [] }),
+            extract: () => {},
+          },
+        }),
+      /stable Workspace identity/,
+    );
+  });
+
   test('dispatches a pre-turn Compaction recipe without projecting history or awaiting it', async () => {
     const model = completionModel();
     const recorded: HistoryCompactCheckpoint[] = [];
@@ -608,6 +631,7 @@ describe('AiSdkBackend Memory Extraction triggers', () => {
     assert.equal(recorded.length, 1);
     assert.equal(recorded[0]?.memoryExtractionBoundary?.runtimeEventId, 'memory-compact-boundary');
     assert.equal(snapshot?.trigger, 'compaction');
+    assert.equal(snapshot?.workspaceIdentity, 'workspace:v1:123e4567-e89b-42d3-a456-426614174000');
     assert.equal(snapshot?.compactionCheckpointId, recorded[0]?.checkpointId);
     assert.equal(snapshot?.compactionBoundaryEventId, 'memory-compact-boundary');
     assert.equal(snapshot?.sourceSystemPrompt, undefined);

--- a/packages/runtime/src/__tests__/execution-boundary-test-helpers.ts
+++ b/packages/runtime/src/__tests__/execution-boundary-test-helpers.ts
@@ -30,12 +30,16 @@ import { ToolRuntime, type ToolRuntimeInput } from '../tool-runtime.js';
 export const readExternalExecutionBoundary: AiSdkBackendInput['readExecutionBoundary'] = async () =>
   createExternalExecutionBoundary();
 
-type TestAiSdkBackendInput = Omit<AiSdkBackendInput, 'readExecutionBoundary'> &
-  Partial<Pick<AiSdkBackendInput, 'readExecutionBoundary'>>;
+type TestAiSdkBackendInput = Omit<
+  AiSdkBackendInput,
+  'readExecutionBoundary' | 'workspaceIdentity'
+> &
+  Partial<Pick<AiSdkBackendInput, 'readExecutionBoundary' | 'workspaceIdentity'>>;
 
 export function createTestAiSdkBackend(input: TestAiSdkBackendInput): AiSdkBackend {
   return new AiSdkBackend({
     readExecutionBoundary: readExternalExecutionBoundary,
+    workspaceIdentity: 'workspace:v1:123e4567-e89b-42d3-a456-426614174000',
     ...input,
   });
 }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -79,6 +79,7 @@ import type {
 } from '@maka/core/backend-types';
 import type { AgentSpec } from '@maka/core/runtime-inputs';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { isWorkspaceIdentity, type WorkspaceIdentity } from '@maka/core/workspace-identity';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type { UserQuestionResponse } from '@maka/core/user-question';
 import { DEFAULT_TOOL_MODE, isToolMode, type ToolMode } from '@maka/core/tool-mode';
@@ -700,6 +701,8 @@ export interface AiSdkBackendInput extends AiSdkCompactionCapabilities {
   // ── Session context ────────────────────────────────────────────────────
   sessionId: string;
   header: SessionHeader;
+  /** Stable workspace identity used as the long-term-memory Scope key. */
+  workspaceIdentity?: WorkspaceIdentity;
   /** Append-message function bound to this session (e.g. SessionStore wrapper). */
   appendMessage: AppendMessageFn;
   /** Reads the authoritative session boundary immediately before every local tool invocation. */
@@ -1109,6 +1112,9 @@ export class AiSdkBackend implements AgentBackend {
   private cumulativeUsageCheckpoint: NormalizedAiSdkUsage | undefined;
   private readonly memoryReplayMessageEvents = new WeakMap<ModelMessage, readonly string[]>();
   constructor(input: AiSdkBackendInput) {
+    if (input.memoryExtraction && !isWorkspaceIdentity(input.workspaceIdentity)) {
+      throw new Error('Long-term-memory extraction requires a stable Workspace identity');
+    }
     this.input = input;
     this.sessionId = input.sessionId;
     this.newId = input.newId ?? (() => crypto.randomUUID());
@@ -1259,7 +1265,7 @@ export class AiSdkBackend implements AgentBackend {
       sessionId: this.sessionId,
       runId: scope.runId,
       turnId: scope.turnId,
-      workspaceKey: this.input.header.workspaceRoot,
+      workspaceIdentity: this.input.workspaceIdentity!,
     };
   }
 
@@ -1302,7 +1308,7 @@ export class AiSdkBackend implements AgentBackend {
         sessionId: this.sessionId,
         runId: scope.runId,
         turnId: scope.turnId,
-        workspaceKey: this.input.header.workspaceRoot,
+        workspaceIdentity: this.input.workspaceIdentity!,
         compactionCheckpointId: dispatch.checkpoint.checkpointId,
         compactionBoundaryEventId: boundary.runtimeEventId,
       });

--- a/packages/runtime/src/memory-extraction.ts
+++ b/packages/runtime/src/memory-extraction.ts
@@ -30,6 +30,7 @@ import type {
 } from '@maka/core/long-term-memory';
 import { redactSecrets } from '@maka/core/redaction';
 import type { SessionHeader } from '@maka/core/session';
+import type { WorkspaceIdentity } from '@maka/core/workspace-identity';
 import { z } from 'zod';
 import {
   fitMemoryExtractionEvidence,
@@ -94,7 +95,7 @@ export interface MemoryExtractionSourceSnapshot {
   readonly sessionId: string;
   readonly runId: string;
   readonly turnId: string;
-  readonly workspaceKey: string;
+  readonly workspaceIdentity: WorkspaceIdentity;
   /** Present only for memory_remember; identifies the call excluded from evidence. */
   readonly toolCallId?: string;
   /** Present only for post-terminal memory_extract. */
@@ -1602,7 +1603,7 @@ function rebuildCompactionSnapshot(
     sessionId: current.sessionId,
     runId: current.runId,
     turnId: current.turnId,
-    workspaceKey: current.workspaceKey,
+    workspaceIdentity: current.workspaceIdentity,
     compactionCheckpointId: checkpoint.checkpointId,
     compactionBoundaryEventId: boundary.runtimeEventId,
   };
@@ -1638,7 +1639,7 @@ function rebuildExplicitPendingSnapshot(
     sessionId: current.sessionId,
     runId: boundary.event.runId,
     turnId: boundary.event.turnId,
-    workspaceKey: current.workspaceKey,
+    workspaceIdentity: current.workspaceIdentity,
   };
   if (pending.firstTrigger === 'remember') {
     const call = entries.find(
@@ -1875,7 +1876,7 @@ function memoryItemWrite(
     statementType: fields.statementType,
     temporalType: fields.temporalType,
     scopeType: fields.scopeType,
-    scopeKey: fields.scopeType === 'workspace' ? snapshot.workspaceKey : null,
+    scopeKey: fields.scopeType === 'workspace' ? snapshot.workspaceIdentity : null,
     eventStartedAt: fields.eventStartedAt,
     eventEndedAt: fields.eventEndedAt,
     observedAt: minuteTimestamp(Math.max(...fields.citedEvents.map((event) => event.ts))),

--- a/packages/storage/src/__tests__/sqlite-long-term-memory-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-long-term-memory-store.test.ts
@@ -54,6 +54,7 @@ import {
 after(removeTrackedControlDirectories);
 
 const require = createRequire(import.meta.url);
+const WORKSPACE_IDENTITY = 'workspace:v1:123e4567-e89b-42d3-a456-426614174000';
 
 describe('SqliteMemoryItemStore', () => {
   test('creates a private, versioned WAL database and reopens it idempotently', async () => {
@@ -319,7 +320,7 @@ describe('SqliteMemoryItemStore', () => {
           content: 'Maka uses RuntimeEvent as evidence.',
           kind: 'knowledge',
           scopeType: 'workspace',
-          scopeKey: 'workspace-maka',
+          scopeKey: WORKSPACE_IDENTITY,
           keys: [
             { key: 'RuntimeEvent', keyType: 'code', keyOrigin: 'deterministic' },
             { key: 'memory_item', keyType: 'code', keyOrigin: 'deterministic' },
@@ -336,8 +337,12 @@ describe('SqliteMemoryItemStore', () => {
       assert.equal((await store.readItem(global))?.keys[1]?.keyOrigin, 'user');
       assert.deepEqual(await itemIds(store, ['偏好']), [global]);
       assert.deepEqual(await itemIds(store, ['runtime'], 'prefix'), []);
-      assert.deepEqual(await itemIds(store, ['runtime'], 'prefix', 'workspace-maka'), [workspace]);
-      assert.deepEqual(await itemIds(store, ['memory_'], 'prefix', 'workspace-maka'), [workspace]);
+      assert.deepEqual(await itemIds(store, ['runtime'], 'prefix', WORKSPACE_IDENTITY), [
+        workspace,
+      ]);
+      assert.deepEqual(await itemIds(store, ['memory_'], 'prefix', WORKSPACE_IDENTITY), [
+        workspace,
+      ]);
       assert.deepEqual(await itemIds(store, ['偏'], 'prefix'), [global]);
       await assert.rejects(
         store.searchByKeys({
@@ -346,6 +351,30 @@ describe('SqliteMemoryItemStore', () => {
           includeArchived: 'false' as unknown as boolean,
         }),
         /includeArchived/,
+      );
+      await assert.rejects(
+        store.searchByKeys({
+          terms: ['runtime'],
+          match: 'prefix',
+          workspaceKey: '/workspace/maka',
+        }),
+        /stable Workspace identity/,
+      );
+    });
+  });
+
+  test('rejects path-based Workspace scope keys for new Memory Items', async () => {
+    await withStore(async ({ store }) => {
+      await assert.rejects(
+        createItem(
+          store,
+          'create-path-scoped-workspace',
+          write({
+            scopeType: 'workspace',
+            scopeKey: '/workspace/maka',
+          }),
+        ),
+        /stable Workspace identity/,
       );
     });
   });

--- a/packages/storage/src/sqlite-long-term-memory-store.ts
+++ b/packages/storage/src/sqlite-long-term-memory-store.ts
@@ -62,6 +62,7 @@ import {
   type SettleMemoryExtractionFailureRequest,
   type SettleMemoryExtractionFailureResult,
 } from '@maka/core/long-term-memory';
+import { isWorkspaceIdentity } from '@maka/core/workspace-identity';
 import {
   assertSupportedSqliteLongTermMemorySchemaVersion,
   configureSqliteLongTermMemoryDatabase,
@@ -863,6 +864,9 @@ export class SqliteMemoryItemStore implements MemoryItemStore {
       request.workspaceKey === undefined
         ? undefined
         : normalizeIdentifier(request.workspaceKey, 'workspaceKey');
+    if (workspaceKey !== undefined && !isWorkspaceIdentity(workspaceKey)) {
+      throw new Error('Memory search workspaceKey must be a stable Workspace identity');
+    }
     const limit = request.limit ?? 20;
     if (!Number.isSafeInteger(limit) || limit < 1 || limit > MAX_SEARCH_RESULTS) {
       throw new Error(`Memory key search limit must be between 1 and ${MAX_SEARCH_RESULTS}`);
@@ -1355,7 +1359,11 @@ function normalizeScopeKey(
     }
     return null;
   }
-  return normalizeIdentifier(input, 'workspace scopeKey');
+  const scopeKey = normalizeIdentifier(input, 'workspace scopeKey');
+  if (!isWorkspaceIdentity(scopeKey)) {
+    throw new Error('Workspace Memory scopeKey must be a stable Workspace identity');
+  }
+  return scopeKey;
 }
 
 function normalizeKeys(input: readonly MemoryItemKeyInput[]): readonly MemoryItemKey[] {

--- a/packages/storage/src/workspace-identity.ts
+++ b/packages/storage/src/workspace-identity.ts
@@ -24,12 +24,19 @@ import { lstat, open, realpath, stat } from 'node:fs/promises';
 import { isAbsolute, join, normalize, parse, resolve } from 'node:path';
 import { promisify } from 'node:util';
 
+import {
+  isWorkspaceIdentityUuid,
+  workspaceIdentityFromUuid,
+  WORKSPACE_IDENTITY_PREFIX,
+  type WorkspaceIdentity,
+} from '@maka/core/workspace-identity';
+
 import { hasEnclosingGitEntry } from './git-entry.js';
 import { publishMarkerFile, readBoundedMarkerFile } from './marker-file.js';
 
 export const WORKSPACE_MARKER_FILE = '.maka-workspace.json';
 export const WORKSPACE_MARKER_SCHEMA_VERSION = 1 as const;
-export const WORKSPACE_IDENTITY_PREFIX = 'workspace:v1:' as const;
+export { WORKSPACE_IDENTITY_PREFIX };
 const MAX_WORKSPACE_MARKER_BYTES = 4_096;
 const MAX_GIT_EXCLUDE_BYTES = 1024 * 1024;
 const execFileAsync = promisify(execFile);
@@ -40,7 +47,7 @@ interface WorkspaceMarker {
 }
 
 export interface WorkspaceIdentityResolution {
-  workspaceIdentity: string;
+  workspaceIdentity: WorkspaceIdentity;
   canonicalPath: string;
 }
 
@@ -267,17 +274,13 @@ function isWorkspaceMarker(value: unknown): value is WorkspaceMarker {
     keys[1] === 'workspaceId' &&
     marker.schemaVersion === WORKSPACE_MARKER_SCHEMA_VERSION &&
     typeof marker.workspaceId === 'string' &&
-    isUuid(marker.workspaceId)
+    isWorkspaceIdentityUuid(marker.workspaceId)
   );
-}
-
-function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }
 
 function toResolution(canonicalPath: string, marker: WorkspaceMarker): WorkspaceIdentityResolution {
   return {
-    workspaceIdentity: `${WORKSPACE_IDENTITY_PREFIX}${marker.workspaceId}`,
+    workspaceIdentity: workspaceIdentityFromUuid(marker.workspaceId),
     canonicalPath,
   };
 }


### PR DESCRIPTION
## Summary

This is PR ③-A of the long-term-memory work tracked by #1615.

### Background

PR ① introduced the SQLite-backed atomic `memory_item` store, and PR ②-A / PR ②-B added explicit and Compaction-triggered extraction. Workspace-scoped Items already use `scopeType = workspace`, but the extraction path previously filled `scopeKey` from `SessionHeader.workspaceRoot`, which is a filesystem path.

A path describes where a Workspace is currently mounted; it is not the Workspace's durable identity. Renaming or relocating a Workspace can split one project's memories across different Scope keys, while reusing an old path can associate that string with a different Workspace. This becomes a correctness and isolation problem before PR ③ adds Group and Summary projections: Group membership, Summary visibility, projection cursors, and later recall all need one stable Scope key.

Maka already has an intrinsic Workspace marker containing a UUID and exposes it as `workspace:v1:<uuid>`. PR ③-A makes that existing identity the only valid Workspace Scope for long-term memory.

### What this PR does

- adds a shared Core Workspace identity contract and runtime validation for the canonical lowercase form `workspace:v1:<uuid>`
- reuses the existing Workspace marker resolver instead of creating a second memory-specific identity system
- resolves the identity in Runtime Host only for eligible root-session memory extraction, then passes it explicitly through `AiSdkBackend` and every extraction snapshot
- writes explicit `memory_remember`, explicit `memory_extract`, and automatic Compaction extraction results with the stable Workspace identity as `scopeKey`
- rejects filesystem paths and other non-canonical values for new Workspace-scoped Item writes and scoped key searches
- leaves `global` Items and global search behavior unchanged
- treats long-term memory as optional when identity resolution fails: extraction is disabled for that backend, and the Runtime never falls back to a path
- keeps existing path-scoped rows isolated instead of guessing an unsafe path-to-UUID migration; they are not returned by normal canonical Workspace searches

### Scope

This intentionally does not add Group, Summary, recall, or new SQLite tables. Those remain separate PR ③ slices.

Refs #1615

## Verification

- `npx biome check` on all 14 changed files
- Core, Storage, Runtime, and Runtime Host builds
- Core, Storage, Runtime, and Runtime Host typechecks
- Core Workspace identity test: 1 passed
- Storage Workspace identity and long-term-memory suites: 58 passed
- Runtime `ai-sdk-backend` suite: 195 passed
- Runtime Host memory coordinator and execution composition suites: 53 passed
- `git diff --check`

## Review focus

- Workspace scope is now canonical and lowercase.
- Runtime Host resolves the identity only for eligible root-session memory extraction.
- Legacy path-scoped data is not automatically rebound to a UUID.

<details>
<summary>点击展开中文</summary>

## 概述

这是 Issue #1615 长期记忆功能的 PR ③-A。

### 背景

PR ①实现了基于 SQLite 的原子 `memory_item` 存储，PR ②-A 和 PR ②-B 分别加入了显式提取与 Compaction 自动提取。Workspace Item 已经使用 `scopeType = workspace`，但此前提取流程会直接把 `SessionHeader.workspaceRoot`，也就是文件系统路径，写入 `scopeKey`。

路径只能表示 Workspace 当前位于哪里，不能作为 Workspace 的长期身份。Workspace 被重命名或移动后，同一个项目的记忆可能被拆到不同 Scope；旧路径被另一个 Workspace 复用时，同一个路径字符串也可能指向不同项目。PR ③后续的 Group、Summary、投影 Cursor 和召回都依赖准确的 Scope 隔离，因此必须先解决这个基础问题。

Maka 已经通过 Workspace Marker 保存 UUID，并使用 `workspace:v1:<uuid>` 表示稳定 Workspace Identity。PR ③-A 复用这套已有能力，将其收紧为长期记忆中唯一合法的 Workspace Scope。

### 本 PR 做了什么

- 在 Core 中增加共享 Workspace Identity 契约，并校验唯一的小写规范格式 `workspace:v1:<uuid>`
- 直接复用现有 Workspace Marker Resolver，不再为长期记忆创建第二套身份系统
- Runtime Host 只为符合条件的 root Session 长期记忆提取解析 Identity，并显式传递到 `AiSdkBackend` 和每个 Extraction Snapshot
- `memory_remember`、显式 `memory_extract` 和 Compaction 自动提取统一使用稳定 Workspace Identity 写入 `scopeKey`
- 新增 Workspace Item 和按 Workspace 执行 Key Search 时，拒绝路径及其他非规范 Scope 值
- Global Item 和 Global Search 的既有行为保持不变
- 无法解析稳定 Identity 时，将长期记忆提取作为可选能力安全关闭；Runtime 绝不回退到路径
- 历史 path-scoped 数据继续隔离，不猜测路径与 UUID 的对应关系，也不进入正常的规范 Workspace Search

### 范围

本 PR 不增加 Group、Summary、召回或新的 SQLite 表，这些内容由后续 PR ③切片完成。

## 验证

- 对全部 14 个变更文件执行 `npx biome check`
- Core、Storage、Runtime、Runtime Host 构建通过
- Core、Storage、Runtime、Runtime Host 类型检查通过
- Core Workspace Identity 测试：1 项通过
- Storage Workspace Identity 与长期记忆测试：58 项通过
- Runtime `ai-sdk-backend` 测试：195 项通过
- Runtime Host Memory Coordinator 与 Execution Composition 测试：53 项通过
- `git diff --check` 通过

## Review 重点

- Workspace Scope 现在只有一种小写规范表示。
- Runtime Host 只为符合条件的 root Session 长期记忆提取解析 Workspace Identity。
- 历史 path-scoped 数据不会被自动绑定到某个 UUID。

</details>
