### PR TITLE
fix(desktop): wrap bot session adapter test Host Session literal in the shared fixture

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts
@@ -217,7 +217,7 @@ test('reply snapshot observers cannot interrupt the authoritative Host Turn', as
   const events = new AsyncFrameQueue();
   const adapter = createRuntimeHostBotSessionAdapter({
     client: botClient({
-      openSession: async () => ({
+      openSession: async () => runtimeHostSessionFixture({
         snapshot: continuitySnapshot(null),
         activeAssistantStreams: [],
         transcript: Promise.resolve([]),


### PR DESCRIPTION
## Summary

`main` is red: `apps/desktop` `build:main` (`tsc -p tsconfig.main.json`) fails, which cascades into the `typecheck`, `e2e`, `test_workspaces` and `test` jobs on every open PR. This unblocks CI repo-wide.

In `apps/desktop/src/main/__tests__/runtime-host-bot-session-adapter.test.ts`, the test `reply snapshot observers cannot interrupt the authoritative Host Turn` passes a bare object literal as the `openSession` return value, so it is missing `hostEpoch`, `subscriptionId`, `transcriptBootstrap`, `loadTranscript` and the remaining `DesktopRuntimeHostSession` fields:

```
src/main/__tests__/runtime-host-bot-session-adapter.test.ts(220,7): error TS2322:
Type '() => Promise<{ snapshot: SessionContinuitySnapshot; ... }>' is not assignable to
type '(sessionId: string) => Promise<DesktopRuntimeHostSession>'.
```

Every other `openSession` in the same file wraps its literal in the `runtimeHostSessionFixture(...)` helper that supplies those fields. This one call site was left unwrapped by #2966; the fix wraps it to match its siblings. No test restructuring, one line changed. I checked the rest of the file — this was the only unwrapped `openSession` literal #2966 introduced.

Refs #2966

## Verification

- `npx tsc -p tsconfig.main.json --noEmit` in `apps/desktop` — passes (fails on the parent commit with TS2322)
- `node --test dist/main/__tests__/runtime-host-bot-session-adapter.test.js` — 8/8 pass
- `npm run format` (Biome) — no fixes applied

Per AGENTS.md I ran only the affected test file, not the repository-wide suite; full coverage is left to CI.

## Fast path

This change qualifies for the self-merge fast path: test-only and mechanical (one call wrapped in an existing helper), trivially reversible, no protected area touched (no Runtime Host authority, `@maka/eval` semantics, Harbor/Pier executor, or Eval CLI), and the required checks pass. It also restores CI for all open PRs, so leaving it queued behind a full review keeps the whole queue blocked.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

---

Generated-by: Claude Code (Opus 5) — authored the diff, commit message and this PR body; typecheck, the affected test file and Biome format were run and their results are reported above. Awaiting human review of record.
