### PR TITLE
fix(mcp): bound repeated tool rediscovery

### DIFF
--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -267,11 +267,10 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       assert.notEqual(bindingFor(manager, 'first', 'echo'), bindingFor(manager, 'second', 'echo'));
     });
 
-    test('coalesces a refresh signal and publishes only the final attempt', async () => {
+    test('coalesces a refresh signal and keeps the latest valid snapshot', async () => {
       const fixture = await createRemoteFixture('streamable-http');
       const manager = createManager();
       await manager.sync(remoteConfig(fixture.url));
-      const before = manager.status('remote')?.tools;
       const listsBefore = countProtocolMethod(fixture, 'tools/list');
 
       fixture.setToolListMode('replacement');
@@ -290,7 +289,10 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       for (const result of settled) {
         if (result.status === 'rejected') assert.match(String(result.reason), /duplicate tool/u);
       }
-      assert.deepEqual(manager.status('remote')?.tools, before);
+      assert.deepEqual(
+        manager.status('remote')?.tools.map((tool) => tool.name),
+        ['replacement'],
+      );
       assert.equal(countProtocolMethod(fixture, 'tools/list') - listsBefore, 2);
     });
 
@@ -322,7 +324,7 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       let now = 0;
       const manager = createManager({ now: () => now });
       await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
-      fixture.setToolListClockAdvance(() => {
+      fixture.setToolListResponseClockAdvance(() => {
         now += 1_100;
       });
       fixture.setNotifyOnEveryToolList(true);
@@ -335,6 +337,23 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
 
       assert.equal(countProtocolMethod(fixture, 'tools/list') <= 4, true);
       assert.match(manager.status('remote')?.error ?? '', /changed too frequently/u);
+    });
+
+    test('publishes the latest valid snapshot before suppressing rediscovery', async () => {
+      const fixture = await createRemoteFixture('sse');
+      const manager = createManager();
+      await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+      fixture.setToolListMode('replacement');
+      fixture.setNotifyOnEveryToolList(true);
+
+      await fixture.notifyToolListChanged();
+      await waitFor(() => /changed too frequently/u.test(manager.status('remote')?.error ?? ''));
+
+      assert.equal(countProtocolMethod(fixture, 'tools/list'), 4);
+      assert.deepEqual(
+        manager.status('remote')?.tools.map((tool) => tool.name),
+        ['replacement'],
+      );
     });
 
     test('coalesces a burst of legitimate list-changed notifications', async () => {
@@ -851,6 +870,7 @@ interface RemoteFixture {
   holdNextToolList(): { started: Promise<void>; release(): void };
   setNotifyOnEveryToolList(enabled: boolean): void;
   setToolListClockAdvance(advance: () => void): void;
+  setToolListResponseClockAdvance(advance: () => void): void;
   notifyToolListChanged(): Promise<void>;
   close(): Promise<void>;
 }
@@ -874,7 +894,16 @@ async function createRemoteFixture(
   let nextToolListGate: InternalToolListGate | undefined;
   let notifyOnEveryToolList = false;
   let toolListClockAdvance = () => {};
+  let toolListResponseClockAdvance = () => {};
   const sseTransports = new Map<string, { transport: SSEServerTransport; server: McpServer }>();
+  const beforeToolList = async () => {
+    toolListClockAdvance();
+    const gate = nextToolListGate;
+    if (!gate) return;
+    nextToolListGate = undefined;
+    gate.markStarted();
+    await gate.waitForRelease;
+  };
   const httpServer = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
     const request: RemoteRequest = {
@@ -914,14 +943,8 @@ async function createRemoteFixture(
         const server = createProtocolServer({
           advertiseTools: true,
           toolListMode: () => toolListMode,
-          beforeToolList: async () => {
-            toolListClockAdvance();
-            const gate = nextToolListGate;
-            if (!gate) return;
-            nextToolListGate = undefined;
-            gate.markStarted();
-            await gate.waitForRelease;
-          },
+          beforeToolList,
+          afterToolList: () => toolListResponseClockAdvance(),
           notifyOnEveryToolList: () => notifyOnEveryToolList,
         });
         await server.connect(transport);
@@ -937,14 +960,8 @@ async function createRemoteFixture(
         const server = createProtocolServer({
           advertiseTools: options.advertiseTools !== false,
           toolListMode: () => toolListMode,
-          beforeToolList: async () => {
-            toolListClockAdvance();
-            const gate = nextToolListGate;
-            if (!gate) return;
-            nextToolListGate = undefined;
-            gate.markStarted();
-            await gate.waitForRelease;
-          },
+          beforeToolList,
+          afterToolList: () => toolListResponseClockAdvance(),
           notifyOnEveryToolList: () => notifyOnEveryToolList,
         });
         sseTransports.set(transport.sessionId, { transport, server });
@@ -1005,6 +1022,9 @@ async function createRemoteFixture(
     setToolListClockAdvance: (advance) => {
       toolListClockAdvance = advance;
     },
+    setToolListResponseClockAdvance: (advance) => {
+      toolListResponseClockAdvance = advance;
+    },
     notifyToolListChanged: async () => {
       const servers = [...sseTransports.values()].map(({ server }) => server);
       if (servers.length === 0) throw new Error('no persistent MCP server is connected');
@@ -1030,6 +1050,7 @@ function createProtocolServer(options: {
   advertiseTools: boolean;
   toolListMode: () => ToolListMode;
   beforeToolList: () => Promise<void>;
+  afterToolList: () => void;
   notifyOnEveryToolList: () => boolean;
 }): McpServer {
   const server = new McpServer(
@@ -1073,6 +1094,7 @@ function createProtocolServer(options: {
                       ]
                     : [remoteToolDefinition('echo'), remoteToolDefinition('invalid-output')],
     };
+    options.afterToolList();
     if (options.notifyOnEveryToolList()) {
       setTimeout(() => {
         void server.sendToolListChanged().catch(() => {});

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -290,26 +290,48 @@ describe('McpClientManager remote transport E2E', () => {
     assert.equal(countProtocolMethod(fixture, 'tools/list') - listsBefore, 2);
   });
 
-  test('bounds rediscovery when every tools list triggers a list-changed notification', async () => {
+  test('bounds response-followed-by-notification rediscovery during initial sync', async () => {
     const fixture = await createRemoteFixture('sse');
     const manager = createManager();
-    await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
-    const binding = bindingFor(manager, 'remote', 'echo');
-    const listsBefore = countProtocolMethod(fixture, 'tools/list');
-
     fixture.setNotifyOnEveryToolList(true);
-    await fixture.notifyToolListChanged();
+
+    const sync = manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+    assert.equal(await settlesWithin(sync, 1_000), true);
+    await sync;
     await waitFor(() => /changed too frequently/u.test(manager.status('remote')?.error ?? ''));
 
-    assert.equal(countProtocolMethod(fixture, 'tools/list') - listsBefore, 3);
+    const binding = bindingFor(manager, 'remote', 'echo');
+    assert.equal(countProtocolMethod(fixture, 'tools/list'), 3);
     assert.match(manager.status('remote')?.error ?? '', /changed too frequently/u);
     assert.deepEqual(await manager.callTool(binding, { value: 'still-callable' }), {
       content: [{ type: 'text', text: 'still-callable' }],
       structuredContent: undefined,
     });
 
+    fixture.setNotifyOnEveryToolList(false);
+    await manager.refreshTools('remote');
+    assert.equal(manager.status('remote')?.error, undefined);
+  });
+
+  test('lets configuration removal preempt active notification rediscovery', async () => {
+    const fixture = await createRemoteFixture('sse');
+    const manager = createManager();
+    await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+    const gate = fixture.holdNextToolList();
+    fixture.setNotifyOnEveryToolList(true);
+    await fixture.notifyToolListChanged();
+    await gate.started;
+
     const removal = manager.sync({ version: 1, mcpServers: {} });
-    assert.equal(await settlesWithin(removal, 1_000), true);
+    let removedBeforeRelease: boolean;
+    try {
+      removedBeforeRelease = await settlesWithin(removal, 1_000);
+    } finally {
+      gate.release();
+    }
+    await removal;
+
+    assert.equal(removedBeforeRelease, true);
     assert.equal(manager.status('remote'), undefined);
   });
 
@@ -855,7 +877,13 @@ async function createRemoteFixture(
         const server = createProtocolServer({
           advertiseTools: options.advertiseTools !== false,
           toolListMode: () => toolListMode,
-          beforeToolList: async () => {},
+          beforeToolList: async () => {
+            const gate = nextToolListGate;
+            if (!gate) return;
+            nextToolListGate = undefined;
+            gate.markStarted();
+            await gate.waitForRelease;
+          },
           notifyOnEveryToolList: () => notifyOnEveryToolList,
         });
         sseTransports.set(transport.sessionId, { transport, server });
@@ -947,8 +975,7 @@ function createProtocolServer(options: {
   server.setRequestHandler('tools/list', async () => {
     const mode = options.toolListMode();
     await options.beforeToolList();
-    if (options.notifyOnEveryToolList()) await server.sendToolListChanged();
-    return {
+    const result = {
       tools:
         mode === 'duplicate'
           ? [remoteToolDefinition('echo'), remoteToolDefinition('echo')]
@@ -982,6 +1009,12 @@ function createProtocolServer(options: {
                       ]
                     : [remoteToolDefinition('echo'), remoteToolDefinition('invalid-output')],
     };
+    if (options.notifyOnEveryToolList()) {
+      setTimeout(() => {
+        void server.sendToolListChanged().catch(() => {});
+      }, 5);
+    }
+    return result;
   });
   server.setRequestHandler('tools/call', async ({ params }) => {
     const args = params.arguments ?? {};

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -17,674 +17,728 @@ afterEach(async () => {
   await Promise.all(remoteFixtures.splice(0).map((fixture) => fixture.close()));
 });
 
-describe('McpClientManager remote transport E2E', () => {
-  test('connects with Streamable HTTP and forwards configured headers', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
+describe('McpClientManager E2E', { concurrency: false }, () => {
+  describe('McpClientManager remote transport E2E', () => {
+    test('connects with Streamable HTTP and forwards configured headers', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
 
-    assert.equal(manager.status('remote')?.transport, 'streamable-http');
-    assert.doesNotMatch(JSON.stringify(manager.status('remote')), /mcpb1\./u);
-    assert.deepEqual(
-      await manager.callTool(bindingFor(manager, 'remote', 'echo'), {
-        value: 'http',
-      }),
-      {
-        content: [{ type: 'text', text: 'http' }],
-        structuredContent: undefined,
-      },
-    );
-    assert.ok(
-      fixture.requests.some(
-        (request) => request.path === '/mcp' && request.authorization === 'Bearer remote-test',
-      ),
-    );
-    assertLegacyHandshake(fixture);
-  });
-
-  test('bounds and sanitizes connection errors before publishing status', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    fixture.setToolListMode('duplicate');
-    const serverId = `remote\r\n\u206a token=sk-live-secret-token-value ${'x'.repeat(10_000)}`;
-    const manager = createManager();
-
-    await manager.sync({
-      version: 1,
-      mcpServers: {
-        [serverId]: { url: fixture.url, transport: 'streamable-http' },
-      },
-    });
-
-    const error = manager.status(serverId)?.error ?? '';
-    assert.match(error, /connection failed/u);
-    assert.match(error, /diagnostic omitted/u);
-    assert.doesNotMatch(error, /sk-live|secret-token/u);
-    assert.doesNotMatch(error, /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
-  });
-
-  test('does not expose hostile HTTP bodies through refresh or reconnect errors', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const hostile = `remote\r\nforged\u2028token=sk-live-secret-token-value ${'x'.repeat(9_000)}`;
-
-    fixture.setHttpFailure('tools/list', hostile);
-    await assert.rejects(manager.refreshTools('remote'), isSafeMcpOperationError);
-    assert.doesNotMatch(JSON.stringify(manager.status('remote')), /sk-live|forged/u);
-
-    fixture.setHttpFailure('initialize', hostile);
-    await assert.rejects(manager.reconnect('remote'), isSafeMcpOperationError);
-    const statusError = manager.status('remote')?.error ?? '';
-    assert.match(statusError, /connection failed/u);
-    assert.doesNotMatch(statusError, /sk-live|forged/u);
-    assert.doesNotMatch(statusError, /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
-  });
-
-  test('keeps the previous callable snapshot after an invalid refresh', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const before = manager.status('remote')?.tools;
-    const binding = bindingFor(manager, 'remote', 'echo');
-
-    fixture.setToolListMode('duplicate');
-    await assert.rejects(manager.refreshTools('remote'), /duplicate tool "echo"/u);
-
-    assert.deepEqual(manager.status('remote')?.tools, before);
-    assert.equal(bindingFor(manager, 'remote', 'echo'), binding);
-    assert.deepEqual(await manager.callTool(binding, { value: 'still-valid' }), {
-      content: [{ type: 'text', text: 'still-valid' }],
-      structuredContent: undefined,
-    });
-  });
-
-  test('publishes one immutable callable snapshot after a real list-changed notification', async () => {
-    const fixture = await createRemoteFixture('sse');
-    const manager = createManager();
-    await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
-    const initial = manager.toolSnapshot();
-
-    assert.equal(Object.isFrozen(initial), true);
-    assert.equal(Object.isFrozen(initial.tools), true);
-    assert.equal(Object.isFrozen(initial.tools[0]), true);
-    assert.equal(Object.isFrozen(initial.tools[0]?.descriptor.inputSchema), true);
-
-    fixture.setToolListMode('replacement');
-    await fixture.notifyToolListChanged();
-    await waitFor(() => manager.toolSnapshot().tools[0]?.descriptor.name === 'replacement');
-    const replacement = manager.toolSnapshot();
-    assert.equal(replacement.revision, initial.revision + 1);
-    assert.deepEqual(
-      replacement.tools.map(({ descriptor }) => descriptor.name),
-      ['replacement'],
-    );
-
-    fixture.setToolListMode('duplicate');
-    await fixture.notifyToolListChanged();
-    await waitFor(() => manager.status('remote')?.error?.includes('duplicate tool') === true);
-    assert.equal(manager.toolSnapshot(), replacement);
-    assert.deepEqual(await manager.callTool(replacement.tools[0]!.binding, { value: 'retained' }), {
-      content: [{ type: 'text', text: 'retained' }],
-      structuredContent: undefined,
-    });
-  });
-
-  test('bounds raw Tool definitions without replacing the callable snapshot', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const binding = bindingFor(manager, 'remote', 'echo');
-
-    fixture.setToolListMode('oversized');
-    await assert.rejects(manager.refreshTools('remote'), /tool definition exceeds/u);
-
-    assert.equal(bindingFor(manager, 'remote', 'echo'), binding);
-    await manager.callTool(binding, { value: 'retained' });
-  });
-
-  test('retains a binding for the same canonical definition on one connection', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const before = bindingFor(manager, 'remote', 'echo');
-    const beforeSnapshot = manager.toolSnapshot();
-
-    fixture.setToolListMode('reordered');
-    await manager.refreshTools('remote');
-
-    assert.equal(bindingFor(manager, 'remote', 'echo'), before);
-    assert.equal(manager.toolSnapshot(), beforeSnapshot);
-  });
-
-  test('rotates a binding for a raw-only definition change and stale-fails before the wire', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const stale = bindingFor(manager, 'remote', 'echo');
-    const publicDescriptor = manager.status('remote')?.tools.find((tool) => tool.name === 'echo');
-
-    fixture.setToolListMode('output-schema-change');
-    await manager.refreshTools('remote');
-    const current = bindingFor(manager, 'remote', 'echo');
-    assert.notEqual(current, stale);
-    assert.deepEqual(
-      manager.status('remote')?.tools.find((tool) => tool.name === 'echo'),
-      publicDescriptor,
-    );
-
-    const callsBefore = countProtocolMethod(fixture, 'tools/call');
-    await assert.rejects(
-      manager.callTool(stale, { value: 'stale' }),
-      (error: unknown) =>
-        error instanceof McpToolCallError &&
-        error.serverId === 'unknown' &&
-        error.toolName === 'unknown' &&
-        /tool binding is stale/u.test(error.message),
-    );
-    assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
-
-    assert.deepEqual(await manager.callTool(current, { value: 'current' }), {
-      content: [{ type: 'text', text: 'current' }],
-      structuredContent: { version: 2 },
-    });
-  });
-
-  test('revokes a removed tool binding before the wire', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const removed = bindingFor(manager, 'remote', 'echo');
-
-    fixture.setToolListMode('replacement');
-    await manager.refreshTools('remote');
-
-    const callsBefore = countProtocolMethod(fixture, 'tools/call');
-    await assert.rejects(manager.callTool(removed, {}), /tool binding is stale/u);
-    assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
-  });
-
-  test('rotates bindings across a replacement connection', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const stale = bindingFor(manager, 'remote', 'echo');
-
-    await manager.reconnect('remote');
-    const current = bindingFor(manager, 'remote', 'echo');
-    assert.notEqual(current, stale);
-
-    const callsBefore = countProtocolMethod(fixture, 'tools/call');
-    await assert.rejects(manager.callTool(stale, {}), /tool binding is stale/u);
-    assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
-    await manager.callTool(current, { value: 'reconnected' });
-  });
-
-  test('revokes bindings synchronously when disconnect begins', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const stale = bindingFor(manager, 'remote', 'echo');
-    const callsBefore = countProtocolMethod(fixture, 'tools/call');
-
-    const disconnecting = manager.disconnect('remote');
-    await assert.rejects(manager.callTool(stale, {}), /tool binding is stale/u);
-    await assert.rejects(manager.connect('remote'), /server "remote" is closing/u);
-    assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
-    await disconnecting;
-    assert.equal(manager.status('remote')?.state, 'disconnected');
-  });
-
-  test('revokes bindings and refresh authority as soon as close begins', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const stale = bindingFor(manager, 'remote', 'echo');
-    const callsBefore = countProtocolMethod(fixture, 'tools/call');
-
-    const closing = manager.close();
-    assert.deepEqual(manager.toolSnapshot().tools, []);
-    await assert.rejects(manager.callTool(stale, {}), /client manager is closed/u);
-    await assert.rejects(manager.refreshTools('remote'), /client manager is closed/u);
-    assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
-    await closing;
-  });
-
-  test('binds the same tool name independently for each server', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync({
-      version: 1,
-      mcpServers: {
-        first: { url: fixture.url, transport: 'streamable-http' },
-        second: { url: fixture.url, transport: 'streamable-http' },
-      },
-    });
-
-    assert.notEqual(bindingFor(manager, 'first', 'echo'), bindingFor(manager, 'second', 'echo'));
-  });
-
-  test('coalesces a refresh signal and publishes only the final attempt', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const before = manager.status('remote')?.tools;
-    const listsBefore = countProtocolMethod(fixture, 'tools/list');
-
-    fixture.setToolListMode('replacement');
-    const gate = fixture.holdNextToolList();
-    const first = manager.refreshTools('remote');
-    await gate.started;
-    fixture.setToolListMode('duplicate');
-    const second = manager.refreshTools('remote');
-    gate.release();
-
-    const settled = await Promise.allSettled([first, second]);
-    assert.equal(
-      settled.every((result) => result.status === 'rejected'),
-      true,
-    );
-    for (const result of settled) {
-      if (result.status === 'rejected') assert.match(String(result.reason), /duplicate tool/u);
-    }
-    assert.deepEqual(manager.status('remote')?.tools, before);
-    assert.equal(countProtocolMethod(fixture, 'tools/list') - listsBefore, 2);
-  });
-
-  test('bounds response-followed-by-notification rediscovery during initial sync', async () => {
-    const fixture = await createRemoteFixture('sse');
-    const manager = createManager();
-    fixture.setNotifyOnEveryToolList(true);
-
-    const sync = manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
-    assert.equal(await settlesWithin(sync, 1_000), true);
-    await sync;
-    await waitFor(() => /changed too frequently/u.test(manager.status('remote')?.error ?? ''));
-
-    const binding = bindingFor(manager, 'remote', 'echo');
-    assert.equal(countProtocolMethod(fixture, 'tools/list'), 3);
-    assert.match(manager.status('remote')?.error ?? '', /changed too frequently/u);
-    assert.deepEqual(await manager.callTool(binding, { value: 'still-callable' }), {
-      content: [{ type: 'text', text: 'still-callable' }],
-      structuredContent: undefined,
-    });
-
-    fixture.setNotifyOnEveryToolList(false);
-    await manager.refreshTools('remote');
-    assert.equal(manager.status('remote')?.error, undefined);
-  });
-
-  test('lets configuration removal preempt active notification rediscovery', async () => {
-    const fixture = await createRemoteFixture('sse');
-    const manager = createManager();
-    await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
-    const gate = fixture.holdNextToolList();
-    fixture.setNotifyOnEveryToolList(true);
-    await fixture.notifyToolListChanged();
-    await gate.started;
-
-    const removal = manager.sync({ version: 1, mcpServers: {} });
-    let removedBeforeRelease: boolean;
-    try {
-      removedBeforeRelease = await settlesWithin(removal, 1_000);
-    } finally {
-      gate.release();
-    }
-    await removal;
-
-    assert.equal(removedBeforeRelease, true);
-    assert.equal(manager.status('remote'), undefined);
-  });
-
-  test('does not let an old client refresh overwrite a replacement connection', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const stale = bindingFor(manager, 'remote', 'echo');
-    const gate = fixture.holdNextToolList();
-    fixture.setToolListMode('replacement');
-    const refresh = manager.refreshTools('remote');
-    void refresh.catch(() => {});
-    await gate.started;
-
-    fixture.setToolListMode('valid');
-    const reconnect = manager.reconnect('remote');
-    let reconnectedBeforeRelease: boolean;
-    try {
-      reconnectedBeforeRelease = await settlesWithin(reconnect, 1_000);
-    } finally {
-      gate.release();
-    }
-    await reconnect;
-
-    assert.equal(reconnectedBeforeRelease, true);
-    await assert.rejects(refresh, (error: unknown) => {
-      assert.match(String(error), /connection changed during tool refresh/u);
-      assert.doesNotMatch(String(error), /undefined/u);
-      return true;
-    });
-    assert.deepEqual(
-      manager.status('remote')?.tools.map((tool) => tool.name),
-      ['echo', 'invalid-output'],
-    );
-    assert.notEqual(bindingFor(manager, 'remote', 'echo'), stale);
-  });
-
-  test('uses the validated Tool definition for output checks', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const callsBefore = countProtocolMethod(fixture, 'tools/call');
-
-    await assert.rejects(
-      manager.callTool(bindingFor(manager, 'remote', 'invalid-output'), {}),
-      (error: unknown) =>
-        error instanceof McpToolCallError && /invalid tool result/u.test(error.message),
-    );
-    assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore + 1);
-  });
-
-  test('classifies decoded deferred markers before output-schema validation', async () => {
-    const unsupportedResults = [
-      { content: [], toolResult: { legacy: true } },
-      {
-        content: [],
-        task: {
-          taskId: 'legacy-task-with-output',
-          status: 'working',
-          ttl: null,
-          createdAt: '2026-07-30T00:00:00Z',
-          lastUpdatedAt: '2026-07-30T00:00:00Z',
+      assert.equal(manager.status('remote')?.transport, 'streamable-http');
+      assert.doesNotMatch(JSON.stringify(manager.status('remote')), /mcpb1\./u);
+      assert.deepEqual(
+        await manager.callTool(bindingFor(manager, 'remote', 'echo'), {
+          value: 'http',
+        }),
+        {
+          content: [{ type: 'text', text: 'http' }],
+          structuredContent: undefined,
         },
-      },
-      { content: [], inputRequests: {} },
-      { content: [], requestState: 'input-required' },
-    ];
+      );
+      assert.ok(
+        fixture.requests.some(
+          (request) => request.path === '/mcp' && request.authorization === 'Bearer remote-test',
+        ),
+      );
+      assertLegacyHandshake(fixture);
+    });
 
-    for (const legacyToolCallResult of unsupportedResults) {
-      const fixture = await createRemoteFixture('streamable-http', {
-        advertiseTools: false,
-        legacyToolCallResult,
+    test('bounds and sanitizes connection errors before publishing status', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      fixture.setToolListMode('duplicate');
+      const serverId = `remote\r\n\u206a token=sk-live-secret-token-value ${'x'.repeat(10_000)}`;
+      const manager = createManager();
+
+      await manager.sync({
+        version: 1,
+        mcpServers: {
+          [serverId]: { url: fixture.url, transport: 'streamable-http' },
+        },
       });
+
+      const error = manager.status(serverId)?.error ?? '';
+      assert.match(error, /connection failed/u);
+      assert.match(error, /diagnostic omitted/u);
+      assert.doesNotMatch(error, /sk-live|secret-token/u);
+      assert.doesNotMatch(error, /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
+    });
+
+    test('does not expose hostile HTTP bodies through refresh or reconnect errors', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const hostile = `remote\r\nforged\u2028token=sk-live-secret-token-value ${'x'.repeat(9_000)}`;
+
+      fixture.setHttpFailure('tools/list', hostile);
+      await assert.rejects(manager.refreshTools('remote'), isSafeMcpOperationError);
+      assert.doesNotMatch(JSON.stringify(manager.status('remote')), /sk-live|forged/u);
+
+      fixture.setHttpFailure('initialize', hostile);
+      await assert.rejects(manager.reconnect('remote'), isSafeMcpOperationError);
+      const statusError = manager.status('remote')?.error ?? '';
+      assert.match(statusError, /connection failed/u);
+      assert.doesNotMatch(statusError, /sk-live|forged/u);
+      assert.doesNotMatch(statusError, /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
+    });
+
+    test('keeps the previous callable snapshot after an invalid refresh', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const before = manager.status('remote')?.tools;
+      const binding = bindingFor(manager, 'remote', 'echo');
+
+      fixture.setToolListMode('duplicate');
+      await assert.rejects(manager.refreshTools('remote'), /duplicate tool "echo"/u);
+
+      assert.deepEqual(manager.status('remote')?.tools, before);
+      assert.equal(bindingFor(manager, 'remote', 'echo'), binding);
+      assert.deepEqual(await manager.callTool(binding, { value: 'still-valid' }), {
+        content: [{ type: 'text', text: 'still-valid' }],
+        structuredContent: undefined,
+      });
+    });
+
+    test('publishes one immutable callable snapshot after a real list-changed notification', async () => {
+      const fixture = await createRemoteFixture('sse');
+      const manager = createManager();
+      await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+      const initial = manager.toolSnapshot();
+
+      assert.equal(Object.isFrozen(initial), true);
+      assert.equal(Object.isFrozen(initial.tools), true);
+      assert.equal(Object.isFrozen(initial.tools[0]), true);
+      assert.equal(Object.isFrozen(initial.tools[0]?.descriptor.inputSchema), true);
+
+      fixture.setToolListMode('replacement');
+      await fixture.notifyToolListChanged();
+      await waitFor(() => manager.toolSnapshot().tools[0]?.descriptor.name === 'replacement');
+      const replacement = manager.toolSnapshot();
+      assert.equal(replacement.revision, initial.revision + 1);
+      assert.deepEqual(
+        replacement.tools.map(({ descriptor }) => descriptor.name),
+        ['replacement'],
+      );
+
+      fixture.setToolListMode('duplicate');
+      await fixture.notifyToolListChanged();
+      await waitFor(() => manager.status('remote')?.error?.includes('duplicate tool') === true);
+      assert.equal(manager.toolSnapshot(), replacement);
+      assert.deepEqual(
+        await manager.callTool(replacement.tools[0]!.binding, { value: 'retained' }),
+        {
+          content: [{ type: 'text', text: 'retained' }],
+          structuredContent: undefined,
+        },
+      );
+    });
+
+    test('bounds raw Tool definitions without replacing the callable snapshot', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const binding = bindingFor(manager, 'remote', 'echo');
+
+      fixture.setToolListMode('oversized');
+      await assert.rejects(manager.refreshTools('remote'), /tool definition exceeds/u);
+
+      assert.equal(bindingFor(manager, 'remote', 'echo'), binding);
+      await manager.callTool(binding, { value: 'retained' });
+    });
+
+    test('retains a binding for the same canonical definition on one connection', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const before = bindingFor(manager, 'remote', 'echo');
+      const beforeSnapshot = manager.toolSnapshot();
+
+      fixture.setToolListMode('reordered');
+      await manager.refreshTools('remote');
+
+      assert.equal(bindingFor(manager, 'remote', 'echo'), before);
+      assert.equal(manager.toolSnapshot(), beforeSnapshot);
+    });
+
+    test('rotates a binding for a raw-only definition change and stale-fails before the wire', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const stale = bindingFor(manager, 'remote', 'echo');
+      const publicDescriptor = manager.status('remote')?.tools.find((tool) => tool.name === 'echo');
+
+      fixture.setToolListMode('output-schema-change');
+      await manager.refreshTools('remote');
+      const current = bindingFor(manager, 'remote', 'echo');
+      assert.notEqual(current, stale);
+      assert.deepEqual(
+        manager.status('remote')?.tools.find((tool) => tool.name === 'echo'),
+        publicDescriptor,
+      );
+
+      const callsBefore = countProtocolMethod(fixture, 'tools/call');
+      await assert.rejects(
+        manager.callTool(stale, { value: 'stale' }),
+        (error: unknown) =>
+          error instanceof McpToolCallError &&
+          error.serverId === 'unknown' &&
+          error.toolName === 'unknown' &&
+          /tool binding is stale/u.test(error.message),
+      );
+      assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
+
+      assert.deepEqual(await manager.callTool(current, { value: 'current' }), {
+        content: [{ type: 'text', text: 'current' }],
+        structuredContent: { version: 2 },
+      });
+    });
+
+    test('revokes a removed tool binding before the wire', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const removed = bindingFor(manager, 'remote', 'echo');
+
+      fixture.setToolListMode('replacement');
+      await manager.refreshTools('remote');
+
+      const callsBefore = countProtocolMethod(fixture, 'tools/call');
+      await assert.rejects(manager.callTool(removed, {}), /tool binding is stale/u);
+      assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
+    });
+
+    test('rotates bindings across a replacement connection', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const stale = bindingFor(manager, 'remote', 'echo');
+
+      await manager.reconnect('remote');
+      const current = bindingFor(manager, 'remote', 'echo');
+      assert.notEqual(current, stale);
+
+      const callsBefore = countProtocolMethod(fixture, 'tools/call');
+      await assert.rejects(manager.callTool(stale, {}), /tool binding is stale/u);
+      assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
+      await manager.callTool(current, { value: 'reconnected' });
+    });
+
+    test('revokes bindings synchronously when disconnect begins', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const stale = bindingFor(manager, 'remote', 'echo');
+      const callsBefore = countProtocolMethod(fixture, 'tools/call');
+
+      const disconnecting = manager.disconnect('remote');
+      await assert.rejects(manager.callTool(stale, {}), /tool binding is stale/u);
+      await assert.rejects(manager.connect('remote'), /server "remote" is closing/u);
+      assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
+      await disconnecting;
+      assert.equal(manager.status('remote')?.state, 'disconnected');
+    });
+
+    test('revokes bindings and refresh authority as soon as close begins', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const stale = bindingFor(manager, 'remote', 'echo');
+      const callsBefore = countProtocolMethod(fixture, 'tools/call');
+
+      const closing = manager.close();
+      assert.deepEqual(manager.toolSnapshot().tools, []);
+      await assert.rejects(manager.callTool(stale, {}), /client manager is closed/u);
+      await assert.rejects(manager.refreshTools('remote'), /client manager is closed/u);
+      assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
+      await closing;
+    });
+
+    test('binds the same tool name independently for each server', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync({
+        version: 1,
+        mcpServers: {
+          first: { url: fixture.url, transport: 'streamable-http' },
+          second: { url: fixture.url, transport: 'streamable-http' },
+        },
+      });
+
+      assert.notEqual(bindingFor(manager, 'first', 'echo'), bindingFor(manager, 'second', 'echo'));
+    });
+
+    test('coalesces a refresh signal and publishes only the final attempt', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const before = manager.status('remote')?.tools;
+      const listsBefore = countProtocolMethod(fixture, 'tools/list');
+
+      fixture.setToolListMode('replacement');
+      const gate = fixture.holdNextToolList();
+      const first = manager.refreshTools('remote');
+      await gate.started;
+      fixture.setToolListMode('duplicate');
+      const second = manager.refreshTools('remote');
+      gate.release();
+
+      const settled = await Promise.allSettled([first, second]);
+      assert.equal(
+        settled.every((result) => result.status === 'rejected'),
+        true,
+      );
+      for (const result of settled) {
+        if (result.status === 'rejected') assert.match(String(result.reason), /duplicate tool/u);
+      }
+      assert.deepEqual(manager.status('remote')?.tools, before);
+      assert.equal(countProtocolMethod(fixture, 'tools/list') - listsBefore, 2);
+    });
+
+    test('bounds response-followed-by-notification rediscovery during initial sync', async () => {
+      const fixture = await createRemoteFixture('sse');
+      const manager = createManager();
+      fixture.setNotifyOnEveryToolList(true);
+
+      const sync = manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+      assert.equal(await settlesWithin(sync, 1_000), true);
+      await sync;
+      await waitFor(() => /changed too frequently/u.test(manager.status('remote')?.error ?? ''));
+
+      const binding = bindingFor(manager, 'remote', 'echo');
+      assert.equal(countProtocolMethod(fixture, 'tools/list'), 4);
+      assert.match(manager.status('remote')?.error ?? '', /changed too frequently/u);
+      assert.deepEqual(await manager.callTool(binding, { value: 'still-callable' }), {
+        content: [{ type: 'text', text: 'still-callable' }],
+        structuredContent: undefined,
+      });
+
+      fixture.setNotifyOnEveryToolList(false);
+      await manager.refreshTools('remote');
+      assert.equal(manager.status('remote')?.error, undefined);
+    });
+
+    test('bounds slow response-followed-by-notification rediscovery', async () => {
+      const fixture = await createRemoteFixture('sse');
+      let now = 0;
+      const manager = createManager({ now: () => now });
+      await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+      fixture.setToolListClockAdvance(() => {
+        now += 1_100;
+      });
+      fixture.setNotifyOnEveryToolList(true);
+
+      await fixture.notifyToolListChanged();
+      await waitFor(
+        () => /changed too frequently/u.test(manager.status('remote')?.error ?? ''),
+        10_000,
+      );
+
+      assert.equal(countProtocolMethod(fixture, 'tools/list') <= 4, true);
+      assert.match(manager.status('remote')?.error ?? '', /changed too frequently/u);
+    });
+
+    test('coalesces a burst of legitimate list-changed notifications', async () => {
+      const fixture = await createRemoteFixture('sse');
+      const manager = createManager();
+      await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+      const gate = fixture.holdNextToolList();
+      fixture.setToolListMode('replacement');
+      const refresh = manager.refreshTools('remote');
+      await gate.started;
+
+      const notifications = [
+        fixture.notifyToolListChanged(),
+        fixture.notifyToolListChanged(),
+        fixture.notifyToolListChanged(),
+      ];
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      gate.release();
+      await refresh;
+      await Promise.all(notifications);
+
+      assert.equal(countProtocolMethod(fixture, 'tools/list'), 3);
+      assert.equal(manager.status('remote')?.error, undefined);
+      assert.deepEqual(
+        manager.status('remote')?.tools.map((tool) => tool.name),
+        ['replacement'],
+      );
+    });
+
+    test('lets configuration removal preempt active notification rediscovery', async () => {
+      const fixture = await createRemoteFixture('sse');
+      const manager = createManager();
+      await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+      const gate = fixture.holdNextToolList();
+      fixture.setNotifyOnEveryToolList(true);
+      await fixture.notifyToolListChanged();
+      await gate.started;
+
+      const removal = manager.sync({ version: 1, mcpServers: {} });
+      let removedBeforeRelease: boolean;
+      try {
+        removedBeforeRelease = await settlesWithin(removal, 1_000);
+      } finally {
+        gate.release();
+      }
+      await removal;
+
+      assert.equal(removedBeforeRelease, true);
+      assert.equal(manager.status('remote'), undefined);
+    });
+
+    test('does not let an old client refresh overwrite a replacement connection', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const stale = bindingFor(manager, 'remote', 'echo');
+      const gate = fixture.holdNextToolList();
+      fixture.setToolListMode('replacement');
+      const refresh = manager.refreshTools('remote');
+      void refresh.catch(() => {});
+      await gate.started;
+
+      fixture.setToolListMode('valid');
+      const reconnect = manager.reconnect('remote');
+      let reconnectedBeforeRelease: boolean;
+      try {
+        reconnectedBeforeRelease = await settlesWithin(reconnect, 1_000);
+      } finally {
+        gate.release();
+      }
+      await reconnect;
+
+      assert.equal(reconnectedBeforeRelease, true);
+      await assert.rejects(refresh, (error: unknown) => {
+        assert.match(String(error), /connection changed during tool refresh/u);
+        assert.doesNotMatch(String(error), /undefined/u);
+        return true;
+      });
+      assert.deepEqual(
+        manager.status('remote')?.tools.map((tool) => tool.name),
+        ['echo', 'invalid-output'],
+      );
+      assert.notEqual(bindingFor(manager, 'remote', 'echo'), stale);
+    });
+
+    test('uses the validated Tool definition for output checks', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
       const manager = createManager();
       await manager.sync(remoteConfig(fixture.url));
       const callsBefore = countProtocolMethod(fixture, 'tools/call');
 
       await assert.rejects(
         manager.callTool(bindingFor(manager, 'remote', 'invalid-output'), {}),
-        /unsupported deferred tool result/u,
+        (error: unknown) =>
+          error instanceof McpToolCallError && /invalid tool result/u.test(error.message),
       );
       assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore + 1);
-    }
-  });
-
-  test('rejects a malformed output schema before invoking the Tool', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    fixture.setToolListMode('invalid-output-schema');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const callsBefore = countProtocolMethod(fixture, 'tools/call');
-
-    await assert.rejects(
-      manager.callTool(bindingFor(manager, 'remote', 'invalid-schema'), {}),
-      /invalid output schema/u,
-    );
-    assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
-  });
-
-  test('requires structured output only for successful output-schema calls', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const binding = bindingFor(manager, 'remote', 'invalid-output');
-
-    await assert.rejects(manager.callTool(binding, { mode: 'missing' }), /invalid tool result/u);
-    await assert.rejects(
-      manager.callTool(binding, { mode: 'is-error' }),
-      /deliberate output failure/u,
-    );
-    await assert.rejects(
-      manager.callTool(binding, { mode: 'oversized-error' }),
-      /oversized error content/u,
-    );
-    await assert.rejects(
-      manager.callTool(binding, { mode: 'too-many-error-blocks' }),
-      /oversized error content/u,
-    );
-  });
-
-  test('rejects an invalid binding before the wire', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    await manager.sync(remoteConfig(fixture.url));
-    const callsBefore = countProtocolMethod(fixture, 'tools/call');
-
-    await assert.rejects(
-      manager.callTool('not-a-binding' as McpToolBinding, {}),
-      (error: unknown) =>
-        error instanceof McpToolCallError && /tool binding is invalid/u.test(error.message),
-    );
-
-    assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
-  });
-});
-
-describe('McpClientManager stdio E2E', () => {
-  test('discovers paginated tools and calls structured content', async () => {
-    const manager = createManager();
-    await manager.sync(fixtureConfig());
-
-    const status = manager.status('fixture');
-    assert.equal(status?.state, 'connected');
-    assert.equal(status?.transport, 'stdio');
-    assert.deepEqual(
-      status?.tools.map((tool) => tool.name),
-      ['echo', 'rich', 'fail', 'slow'],
-    );
-    assert.equal(status?.tools[0]?.annotations?.readOnlyHint, true);
-
-    const echo = await manager.callTool(bindingFor(manager, 'fixture', 'echo'), { value: 'Maka' });
-    assert.deepEqual(echo.content, [{ type: 'text', text: 'Maka' }]);
-    assert.deepEqual(echo.structuredContent, { echoed: 'Maka' });
-
-    const rich = await manager.callTool(bindingFor(manager, 'fixture', 'rich'), {});
-    assert.deepEqual(
-      rich.content.map((block) => block.type),
-      ['text', 'image', 'audio', 'resource', 'resource_link'],
-    );
-  });
-
-  test('maps protocol isError to the Maka error path', async () => {
-    const manager = createManager();
-    await manager.sync(fixtureConfig());
-    await assert.rejects(
-      manager.callTool(bindingFor(manager, 'fixture', 'fail'), {}),
-      (error: unknown) =>
-        error instanceof McpToolCallError && /deliberate failure/u.test(error.message),
-    );
-  });
-
-  test('propagates caller abort to an in-flight tool call', async () => {
-    const manager = createManager();
-    await manager.sync(fixtureConfig());
-    const controller = new AbortController();
-    const call = manager.callTool(
-      bindingFor(manager, 'fixture', 'slow'),
-      {},
-      {
-        signal: controller.signal,
-      },
-    );
-    controller.abort();
-    await assert.rejects(call, /abort|cancel/iu);
-  });
-
-  test('enforces the configured tool call timeout', async () => {
-    const manager = new McpClientManager({
-      timeouts: { stdioConnectMs: 5_000, listToolsMs: 5_000, callToolMs: 25 },
     });
-    managers.push(manager);
-    await manager.sync(fixtureConfig());
-    await assert.rejects(
-      manager.callTool(bindingFor(manager, 'fixture', 'slow'), {}),
-      /timed out|timeout/iu,
-    );
-  });
 
-  test('captures bounded stderr diagnostics when stdio startup fails', async () => {
-    const manager = createManager();
-    const config = fixtureConfig(['--crash']);
-    await manager.sync(config);
-    const status = manager.status('fixture');
-    assert.equal(status?.state, 'error');
-    assert.match(status?.error ?? '', /fixture startup failed/u);
-    assert.deepEqual(status?.stderrTail, ['fixture startup failed: deliberate diagnostic']);
-  });
+    test('classifies decoded deferred markers before output-schema validation', async () => {
+      const unsupportedResults = [
+        { content: [], toolResult: { legacy: true } },
+        {
+          content: [],
+          task: {
+            taskId: 'legacy-task-with-output',
+            status: 'working',
+            ttl: null,
+            createdAt: '2026-07-30T00:00:00Z',
+            lastUpdatedAt: '2026-07-30T00:00:00Z',
+          },
+        },
+        { content: [], inputRequests: {} },
+        { content: [], requestState: 'input-required' },
+      ];
 
-  test('excludes credential keys case-insensitively from a real stdio child', async () => {
-    const key = 'XDG_MAKA_PROVIDER_CREDENTIAL';
-    const previous = process.env[key];
-    process.env[key] = 'provider-secret';
-    const manager = new McpClientManager({
-      excludedStdioEnvironmentKeys: ['xdg_maka_provider_credential'],
-    });
-    managers.push(manager);
-    try {
-      await manager.sync(fixtureConfig(['--environment']));
-      const result = await manager.callTool(bindingFor(manager, 'fixture', 'environment'), {
-        names: [key],
-      });
-      assert.deepEqual(
-        JSON.parse(result.content[0]?.type === 'text' ? result.content[0].text : ''),
-        { [key]: null },
-      );
-    } finally {
-      if (previous === undefined) delete process.env[key];
-      else process.env[key] = previous;
-    }
-  });
+      for (const legacyToolCallResult of unsupportedResults) {
+        const fixture = await createRemoteFixture('streamable-http', {
+          advertiseTools: false,
+          legacyToolCallResult,
+        });
+        const manager = createManager();
+        await manager.sync(remoteConfig(fixture.url));
+        const callsBefore = countProtocolMethod(fixture, 'tools/call');
 
-  test('cancels an in-flight installation connect without leaving tools visible', async () => {
-    const manager = createManager();
-    const sync = manager.sync(fixtureConfig(['--slow-start']));
-    await waitFor(() => manager.status('fixture')?.state === 'connecting');
-    assert.equal(manager.cancelConnect('fixture'), true);
-    await sync;
-    await manager.sync({ version: 1, mcpServers: {} });
-    assert.equal(manager.status('fixture'), undefined);
-    assert.deepEqual(manager.toolSnapshot().tools, []);
-  });
-
-  test('cancels installation after remote tool discovery starts', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    const gate = fixture.holdNextToolList();
-    const sync = manager.sync(remoteConfig(fixture.url));
-    await gate.started;
-
-    assert.equal(manager.status('remote')?.state, 'connecting');
-    assert.equal(manager.cancelConnect('remote'), true);
-    let settledBeforeRelease: boolean;
-    try {
-      settledBeforeRelease = await settlesWithin(sync, 500);
-    } finally {
-      gate.release();
-    }
-    await sync;
-
-    assert.equal(settledBeforeRelease, true);
-    assert.equal(manager.status('remote')?.state, 'disconnected');
-    assert.deepEqual(manager.toolSnapshot().tools, []);
-  });
-
-  test('does not report a cancellable connect after connected status is published', async () => {
-    const fixture = await createRemoteFixture('streamable-http');
-    const manager = createManager();
-    let cancelResult: boolean | undefined;
-    manager.onChange((status) => {
-      if (status.serverId === 'remote' && status.state === 'connected') {
-        cancelResult = manager.cancelConnect('remote');
+        await assert.rejects(
+          manager.callTool(bindingFor(manager, 'remote', 'invalid-output'), {}),
+          /unsupported deferred tool result/u,
+        );
+        assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore + 1);
       }
     });
 
-    await manager.sync(remoteConfig(fixture.url));
+    test('rejects a malformed output schema before invoking the Tool', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      fixture.setToolListMode('invalid-output-schema');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const callsBefore = countProtocolMethod(fixture, 'tools/call');
 
-    assert.equal(cancelResult, false);
-    assert.equal(manager.status('remote')?.state, 'connected');
-    assert.equal(manager.toolSnapshot().tools.length > 0, true);
-  });
-
-  test('close aborts an in-flight connection before it can publish tools', async () => {
-    const manager = createManager();
-    const sync = manager.sync(fixtureConfig(['--slow-start']));
-    await waitFor(() => manager.status('fixture')?.state === 'connecting');
-
-    const closing = manager.close();
-    assert.deepEqual(manager.toolSnapshot().tools, []);
-    await Promise.all([sync, closing]);
-
-    assert.equal(manager.status('fixture'), undefined);
-    assert.deepEqual(manager.toolSnapshot().tools, []);
-  });
-
-  test('captures and redacts a final stderr fragment without a newline', async () => {
-    const manager = createManager();
-    await manager.sync(fixtureConfig(['--crash-secret-tail']));
-    const status = manager.status('fixture');
-    assert.equal(status?.state, 'error');
-    assert.deepEqual(status?.stderrTail, ['token=[redacted]']);
-    assert.doesNotMatch(status?.error ?? '', /sk-live/u);
-  });
-
-  test('redacts across stream chunks and discards oversized physical stderr lines', async () => {
-    const manager = createManager();
-    await manager.sync(fixtureConfig(['--crash-hostile-stderr']));
-    const status = manager.status('fixture');
-    const tail = status?.stderrTail ?? [];
-
-    assert.equal(status?.state, 'error');
-    assert.equal(tail.length, 6);
-    assert.equal(tail[1], '[stderr line omitted: exceeds diagnostic limit]');
-    assert.equal(tail[2], 'after\uFFFDline');
-    assert.equal(tail[3], 'sk-live-\uFFFD12345678');
-    assert.deepEqual(tail.slice(4), [
-      '[stderr continuation omitted]',
-      '[stderr continuation omitted]',
-    ]);
-    assert.ok([...tail[0]].length <= 2_000);
-    assert.doesNotMatch(
-      tail.join(''),
-      /sk-live-secret-token-value|sk-live-12345678|environment-secret|continued-secret/u,
-    );
-    assert.doesNotMatch(tail.join(''), /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
-  });
-
-  test('publishes a stderr chunk once instead of once per physical line', async () => {
-    const manager = createManager();
-    let updatesWithStderr = 0;
-    manager.onChange((status) => {
-      if (status.stderrTail?.length) updatesWithStderr += 1;
+      await assert.rejects(
+        manager.callTool(bindingFor(manager, 'remote', 'invalid-schema'), {}),
+        /invalid output schema/u,
+      );
+      assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
     });
 
-    await manager.sync(fixtureConfig(['--crash-many-stderr-lines']));
+    test('requires structured output only for successful output-schema calls', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const binding = bindingFor(manager, 'remote', 'invalid-output');
 
-    assert.deepEqual(manager.status('fixture')?.stderrTail, Array<string>(10).fill('x'));
-    assert.ok(updatesWithStderr <= 5, `received ${updatesWithStderr} stderr-bearing updates`);
+      await assert.rejects(manager.callTool(binding, { mode: 'missing' }), /invalid tool result/u);
+      await assert.rejects(
+        manager.callTool(binding, { mode: 'is-error' }),
+        /deliberate output failure/u,
+      );
+      await assert.rejects(
+        manager.callTool(binding, { mode: 'oversized-error' }),
+        /oversized error content/u,
+      );
+      await assert.rejects(
+        manager.callTool(binding, { mode: 'too-many-error-blocks' }),
+        /oversized error content/u,
+      );
+    });
+
+    test('rejects an invalid binding before the wire', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      await manager.sync(remoteConfig(fixture.url));
+      const callsBefore = countProtocolMethod(fixture, 'tools/call');
+
+      await assert.rejects(
+        manager.callTool('not-a-binding' as McpToolBinding, {}),
+        (error: unknown) =>
+          error instanceof McpToolCallError && /tool binding is invalid/u.test(error.message),
+      );
+
+      assert.equal(countProtocolMethod(fixture, 'tools/call'), callsBefore);
+    });
   });
 
-  test('reconciles disable and removal without leaving tools visible', async () => {
-    const manager = createManager();
-    await manager.sync(fixtureConfig());
-    await manager.sync({
-      version: 1,
-      mcpServers: {
-        fixture: { ...fixtureConfig().mcpServers.fixture, enabled: false },
-      },
+  describe('McpClientManager stdio E2E', () => {
+    test('discovers paginated tools and calls structured content', async () => {
+      const manager = createManager();
+      await manager.sync(fixtureConfig());
+
+      const status = manager.status('fixture');
+      assert.equal(status?.state, 'connected');
+      assert.equal(status?.transport, 'stdio');
+      assert.deepEqual(
+        status?.tools.map((tool) => tool.name),
+        ['echo', 'rich', 'fail', 'slow'],
+      );
+      assert.equal(status?.tools[0]?.annotations?.readOnlyHint, true);
+
+      const echo = await manager.callTool(bindingFor(manager, 'fixture', 'echo'), {
+        value: 'Maka',
+      });
+      assert.deepEqual(echo.content, [{ type: 'text', text: 'Maka' }]);
+      assert.deepEqual(echo.structuredContent, { echoed: 'Maka' });
+
+      const rich = await manager.callTool(bindingFor(manager, 'fixture', 'rich'), {});
+      assert.deepEqual(
+        rich.content.map((block) => block.type),
+        ['text', 'image', 'audio', 'resource', 'resource_link'],
+      );
     });
-    assert.equal(manager.status('fixture')?.state, 'disabled');
-    assert.deepEqual(manager.toolSnapshot().tools, []);
-    assert.equal((await manager.test('fixture')).ok, false);
-    await manager.sync({ version: 1, mcpServers: {} });
-    assert.equal(manager.status('fixture'), undefined);
+
+    test('maps protocol isError to the Maka error path', async () => {
+      const manager = createManager();
+      await manager.sync(fixtureConfig());
+      await assert.rejects(
+        manager.callTool(bindingFor(manager, 'fixture', 'fail'), {}),
+        (error: unknown) =>
+          error instanceof McpToolCallError && /deliberate failure/u.test(error.message),
+      );
+    });
+
+    test('propagates caller abort to an in-flight tool call', async () => {
+      const manager = createManager();
+      await manager.sync(fixtureConfig());
+      const controller = new AbortController();
+      const call = manager.callTool(
+        bindingFor(manager, 'fixture', 'slow'),
+        {},
+        {
+          signal: controller.signal,
+        },
+      );
+      controller.abort();
+      await assert.rejects(call, /abort|cancel/iu);
+    });
+
+    test('enforces the configured tool call timeout', async () => {
+      const manager = new McpClientManager({
+        timeouts: { stdioConnectMs: 5_000, listToolsMs: 5_000, callToolMs: 25 },
+      });
+      managers.push(manager);
+      await manager.sync(fixtureConfig());
+      await assert.rejects(
+        manager.callTool(bindingFor(manager, 'fixture', 'slow'), {}),
+        /timed out|timeout/iu,
+      );
+    });
+
+    test('captures bounded stderr diagnostics when stdio startup fails', async () => {
+      const manager = createManager();
+      const config = fixtureConfig(['--crash']);
+      await manager.sync(config);
+      const status = manager.status('fixture');
+      assert.equal(status?.state, 'error');
+      assert.match(status?.error ?? '', /fixture startup failed/u);
+      assert.deepEqual(status?.stderrTail, ['fixture startup failed: deliberate diagnostic']);
+    });
+
+    test('excludes credential keys case-insensitively from a real stdio child', async () => {
+      const key = 'XDG_MAKA_PROVIDER_CREDENTIAL';
+      const previous = process.env[key];
+      process.env[key] = 'provider-secret';
+      const manager = new McpClientManager({
+        excludedStdioEnvironmentKeys: ['xdg_maka_provider_credential'],
+      });
+      managers.push(manager);
+      try {
+        await manager.sync(fixtureConfig(['--environment']));
+        const result = await manager.callTool(bindingFor(manager, 'fixture', 'environment'), {
+          names: [key],
+        });
+        assert.deepEqual(
+          JSON.parse(result.content[0]?.type === 'text' ? result.content[0].text : ''),
+          { [key]: null },
+        );
+      } finally {
+        if (previous === undefined) delete process.env[key];
+        else process.env[key] = previous;
+      }
+    });
+
+    test('cancels an in-flight installation connect without leaving tools visible', async () => {
+      const manager = createManager();
+      const sync = manager.sync(fixtureConfig(['--slow-start']));
+      await waitFor(() => manager.status('fixture')?.state === 'connecting');
+      assert.equal(manager.cancelConnect('fixture'), true);
+      await sync;
+      await manager.sync({ version: 1, mcpServers: {} });
+      assert.equal(manager.status('fixture'), undefined);
+      assert.deepEqual(manager.toolSnapshot().tools, []);
+    });
+
+    test('cancels installation after remote tool discovery starts', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      const gate = fixture.holdNextToolList();
+      const sync = manager.sync(remoteConfig(fixture.url));
+      await gate.started;
+
+      assert.equal(manager.status('remote')?.state, 'connecting');
+      assert.equal(manager.cancelConnect('remote'), true);
+      let settledBeforeRelease: boolean;
+      try {
+        settledBeforeRelease = await settlesWithin(sync, 500);
+      } finally {
+        gate.release();
+      }
+      await sync;
+
+      assert.equal(settledBeforeRelease, true);
+      assert.equal(manager.status('remote')?.state, 'disconnected');
+      assert.deepEqual(manager.toolSnapshot().tools, []);
+    });
+
+    test('does not report a cancellable connect after connected status is published', async () => {
+      const fixture = await createRemoteFixture('streamable-http');
+      const manager = createManager();
+      let cancelResult: boolean | undefined;
+      manager.onChange((status) => {
+        if (status.serverId === 'remote' && status.state === 'connected') {
+          cancelResult = manager.cancelConnect('remote');
+        }
+      });
+
+      await manager.sync(remoteConfig(fixture.url));
+
+      assert.equal(cancelResult, false);
+      assert.equal(manager.status('remote')?.state, 'connected');
+      assert.equal(manager.toolSnapshot().tools.length > 0, true);
+    });
+
+    test('close aborts an in-flight connection before it can publish tools', async () => {
+      const manager = createManager();
+      const sync = manager.sync(fixtureConfig(['--slow-start']));
+      await waitFor(() => manager.status('fixture')?.state === 'connecting');
+
+      const closing = manager.close();
+      assert.deepEqual(manager.toolSnapshot().tools, []);
+      await Promise.all([sync, closing]);
+
+      assert.equal(manager.status('fixture'), undefined);
+      assert.deepEqual(manager.toolSnapshot().tools, []);
+    });
+
+    test('captures and redacts a final stderr fragment without a newline', async () => {
+      const manager = createManager();
+      await manager.sync(fixtureConfig(['--crash-secret-tail']));
+      const status = manager.status('fixture');
+      assert.equal(status?.state, 'error');
+      assert.deepEqual(status?.stderrTail, ['token=[redacted]']);
+      assert.doesNotMatch(status?.error ?? '', /sk-live/u);
+    });
+
+    test('redacts across stream chunks and discards oversized physical stderr lines', async () => {
+      const manager = createManager();
+      await manager.sync(fixtureConfig(['--crash-hostile-stderr']));
+      const status = manager.status('fixture');
+      const tail = status?.stderrTail ?? [];
+
+      assert.equal(status?.state, 'error');
+      assert.equal(tail.length, 6);
+      assert.equal(tail[1], '[stderr line omitted: exceeds diagnostic limit]');
+      assert.equal(tail[2], 'after\uFFFDline');
+      assert.equal(tail[3], 'sk-live-\uFFFD12345678');
+      assert.deepEqual(tail.slice(4), [
+        '[stderr continuation omitted]',
+        '[stderr continuation omitted]',
+      ]);
+      assert.ok([...tail[0]].length <= 2_000);
+      assert.doesNotMatch(
+        tail.join(''),
+        /sk-live-secret-token-value|sk-live-12345678|environment-secret|continued-secret/u,
+      );
+      assert.doesNotMatch(tail.join(''), /[\p{Cc}\p{Cf}\p{Zl}\p{Zp}]/u);
+    });
+
+    test('publishes a stderr chunk once instead of once per physical line', async () => {
+      const manager = createManager();
+      let updatesWithStderr = 0;
+      manager.onChange((status) => {
+        if (status.stderrTail?.length) updatesWithStderr += 1;
+      });
+
+      await manager.sync(fixtureConfig(['--crash-many-stderr-lines']));
+
+      assert.deepEqual(manager.status('fixture')?.stderrTail, Array<string>(10).fill('x'));
+      assert.ok(updatesWithStderr <= 5, `received ${updatesWithStderr} stderr-bearing updates`);
+    });
+
+    test('reconciles disable and removal without leaving tools visible', async () => {
+      const manager = createManager();
+      await manager.sync(fixtureConfig());
+      await manager.sync({
+        version: 1,
+        mcpServers: {
+          fixture: { ...fixtureConfig().mcpServers.fixture, enabled: false },
+        },
+      });
+      assert.equal(manager.status('fixture')?.state, 'disabled');
+      assert.deepEqual(manager.toolSnapshot().tools, []);
+      assert.equal((await manager.test('fixture')).ok, false);
+      await manager.sync({ version: 1, mcpServers: {} });
+      assert.equal(manager.status('fixture'), undefined);
+    });
   });
 });
 
@@ -710,9 +764,12 @@ test('buildStdioEnvironment uses an allowlist and explicit values override it', 
   );
 });
 
-function createManager(): McpClientManager {
+function createManager(
+  options: ConstructorParameters<typeof McpClientManager>[0] = {},
+): McpClientManager {
   const manager = new McpClientManager({
     timeouts: { stdioConnectMs: 5_000, listToolsMs: 5_000, callToolMs: 5_000 },
+    ...options,
   });
   managers.push(manager);
   return manager;
@@ -793,6 +850,7 @@ interface RemoteFixture {
   setHttpFailure(method: string, body: string): void;
   holdNextToolList(): { started: Promise<void>; release(): void };
   setNotifyOnEveryToolList(enabled: boolean): void;
+  setToolListClockAdvance(advance: () => void): void;
   notifyToolListChanged(): Promise<void>;
   close(): Promise<void>;
 }
@@ -815,6 +873,7 @@ async function createRemoteFixture(
   let httpFailure: { method: string; body: string } | undefined;
   let nextToolListGate: InternalToolListGate | undefined;
   let notifyOnEveryToolList = false;
+  let toolListClockAdvance = () => {};
   const sseTransports = new Map<string, { transport: SSEServerTransport; server: McpServer }>();
   const httpServer = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
@@ -856,6 +915,7 @@ async function createRemoteFixture(
           advertiseTools: true,
           toolListMode: () => toolListMode,
           beforeToolList: async () => {
+            toolListClockAdvance();
             const gate = nextToolListGate;
             if (!gate) return;
             nextToolListGate = undefined;
@@ -878,6 +938,7 @@ async function createRemoteFixture(
           advertiseTools: options.advertiseTools !== false,
           toolListMode: () => toolListMode,
           beforeToolList: async () => {
+            toolListClockAdvance();
             const gate = nextToolListGate;
             if (!gate) return;
             nextToolListGate = undefined;
@@ -940,6 +1001,9 @@ async function createRemoteFixture(
     },
     setNotifyOnEveryToolList: (enabled) => {
       notifyOnEveryToolList = enabled;
+    },
+    setToolListClockAdvance: (advance) => {
+      toolListClockAdvance = advance;
     },
     notifyToolListChanged: async () => {
       const servers = [...sseTransports.values()].map(({ server }) => server);

--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -290,6 +290,29 @@ describe('McpClientManager remote transport E2E', () => {
     assert.equal(countProtocolMethod(fixture, 'tools/list') - listsBefore, 2);
   });
 
+  test('bounds rediscovery when every tools list triggers a list-changed notification', async () => {
+    const fixture = await createRemoteFixture('sse');
+    const manager = createManager();
+    await manager.sync(remoteConfig(`${fixture.url}/sse`, 'auto'));
+    const binding = bindingFor(manager, 'remote', 'echo');
+    const listsBefore = countProtocolMethod(fixture, 'tools/list');
+
+    fixture.setNotifyOnEveryToolList(true);
+    await fixture.notifyToolListChanged();
+    await waitFor(() => /changed too frequently/u.test(manager.status('remote')?.error ?? ''));
+
+    assert.equal(countProtocolMethod(fixture, 'tools/list') - listsBefore, 3);
+    assert.match(manager.status('remote')?.error ?? '', /changed too frequently/u);
+    assert.deepEqual(await manager.callTool(binding, { value: 'still-callable' }), {
+      content: [{ type: 'text', text: 'still-callable' }],
+      structuredContent: undefined,
+    });
+
+    const removal = manager.sync({ version: 1, mcpServers: {} });
+    assert.equal(await settlesWithin(removal, 1_000), true);
+    assert.equal(manager.status('remote'), undefined);
+  });
+
   test('does not let an old client refresh overwrite a replacement connection', async () => {
     const fixture = await createRemoteFixture('streamable-http');
     const manager = createManager();
@@ -747,6 +770,7 @@ interface RemoteFixture {
   setToolListMode(mode: ToolListMode): void;
   setHttpFailure(method: string, body: string): void;
   holdNextToolList(): { started: Promise<void>; release(): void };
+  setNotifyOnEveryToolList(enabled: boolean): void;
   notifyToolListChanged(): Promise<void>;
   close(): Promise<void>;
 }
@@ -768,6 +792,7 @@ async function createRemoteFixture(
   let toolListMode: ToolListMode = 'valid';
   let httpFailure: { method: string; body: string } | undefined;
   let nextToolListGate: InternalToolListGate | undefined;
+  let notifyOnEveryToolList = false;
   const sseTransports = new Map<string, { transport: SSEServerTransport; server: McpServer }>();
   const httpServer = createServer(async (req, res) => {
     const url = new URL(req.url ?? '/', 'http://127.0.0.1');
@@ -815,6 +840,7 @@ async function createRemoteFixture(
             gate.markStarted();
             await gate.waitForRelease;
           },
+          notifyOnEveryToolList: () => notifyOnEveryToolList,
         });
         await server.connect(transport);
         res.once('close', () => {
@@ -830,6 +856,7 @@ async function createRemoteFixture(
           advertiseTools: options.advertiseTools !== false,
           toolListMode: () => toolListMode,
           beforeToolList: async () => {},
+          notifyOnEveryToolList: () => notifyOnEveryToolList,
         });
         sseTransports.set(transport.sessionId, { transport, server });
         res.once('close', () => sseTransports.delete(transport.sessionId));
@@ -883,6 +910,9 @@ async function createRemoteFixture(
       nextToolListGate = { markStarted, waitForRelease };
       return { started, release };
     },
+    setNotifyOnEveryToolList: (enabled) => {
+      notifyOnEveryToolList = enabled;
+    },
     notifyToolListChanged: async () => {
       const servers = [...sseTransports.values()].map(({ server }) => server);
       if (servers.length === 0) throw new Error('no persistent MCP server is connected');
@@ -908,6 +938,7 @@ function createProtocolServer(options: {
   advertiseTools: boolean;
   toolListMode: () => ToolListMode;
   beforeToolList: () => Promise<void>;
+  notifyOnEveryToolList: () => boolean;
 }): McpServer {
   const server = new McpServer(
     { name: 'maka-remote-fixture', version: '1.0.0' },
@@ -916,6 +947,7 @@ function createProtocolServer(options: {
   server.setRequestHandler('tools/list', async () => {
     const mode = options.toolListMode();
     await options.beforeToolList();
+    if (options.notifyOnEveryToolList()) await server.sendToolListChanged();
     return {
       tools:
         mode === 'duplicate'

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -45,6 +45,7 @@ const STDERR_CONTINUATION = '[stderr continuation omitted]';
 const MAX_SUMMARIZED_ERROR_BLOCKS = 100;
 const OVERSIZED_TOOL_ERROR_CONTENT = 'server returned oversized error content';
 const MAX_CONSECUTIVE_TOOL_REFRESH_ATTEMPTS = 3;
+const TOOL_REFRESH_QUIET_PERIOD_MS = 1_000;
 
 export interface McpClientManagerOptions {
   clientName?: string;
@@ -74,6 +75,16 @@ interface ToolRefreshState {
   promise: Promise<McpToolDescriptor[]>;
 }
 
+interface ToolRefreshNotificationState {
+  // This state intentionally outlives one refresh promise so a notification
+  // sent just after every response cannot reset the consecutive-signal bound.
+  readonly client: Client;
+  readonly connectionGeneration: number;
+  consecutiveSignals: number;
+  lastSignalAt: number;
+  suppressed: boolean;
+}
+
 interface Connection {
   config: McpServerConfig;
   fingerprint: string;
@@ -86,6 +97,7 @@ interface Connection {
   toolSnapshot: Map<string, ToolSnapshotEntry>;
   connectionGeneration?: number;
   refreshState?: ToolRefreshState;
+  refreshNotificationState?: ToolRefreshNotificationState;
   closing: boolean;
 }
 
@@ -230,6 +242,7 @@ export class McpClientManager {
     this.replaceToolSnapshot(entry, new Map());
     entry.connectionGeneration = undefined;
     entry.refreshState = undefined;
+    entry.refreshNotificationState = undefined;
     await safeClose(client, transport);
     await connectPromise?.catch(() => {});
     if (remove) {
@@ -253,6 +266,7 @@ export class McpClientManager {
       this.replaceToolSnapshot(entry, new Map());
       entry.connectionGeneration = undefined;
       entry.refreshState = undefined;
+      entry.refreshNotificationState = undefined;
       return safeClose(entry.client, entry.transport);
     });
     await Promise.all(closing);
@@ -269,6 +283,22 @@ export class McpClientManager {
     const client = entry.client;
     if (!client) throw new Error(`MCP server "${serverId}" is not connected`);
     const connectionGeneration = this.requireConnectionGeneration(serverId, entry);
+    entry.refreshNotificationState = {
+      client,
+      connectionGeneration,
+      consecutiveSignals: 0,
+      lastSignalAt: this.now(),
+      suppressed: false,
+    };
+    return this.startToolRefresh(serverId, entry, client, connectionGeneration);
+  }
+
+  private startToolRefresh(
+    serverId: string,
+    entry: Connection,
+    client: Client,
+    connectionGeneration: number,
+  ): Promise<McpToolDescriptor[]> {
     if (
       entry.refreshState?.client === client &&
       entry.refreshState.connectionGeneration === connectionGeneration
@@ -288,6 +318,42 @@ export class McpClientManager {
     });
     entry.refreshState = state;
     return state.promise;
+  }
+
+  private refreshToolsAfterNotification(
+    serverId: string,
+    entry: Connection,
+    client: Client,
+    connectionGeneration: number,
+  ): Promise<McpToolDescriptor[]> {
+    const now = this.now();
+    let notificationState = entry.refreshNotificationState;
+    if (
+      notificationState?.client !== client ||
+      notificationState.connectionGeneration !== connectionGeneration
+    ) {
+      notificationState = {
+        client,
+        connectionGeneration,
+        consecutiveSignals: 0,
+        lastSignalAt: now,
+        suppressed: false,
+      };
+      entry.refreshNotificationState = notificationState;
+    } else if (now - notificationState.lastSignalAt > TOOL_REFRESH_QUIET_PERIOD_MS) {
+      notificationState.consecutiveSignals = 0;
+      notificationState.suppressed = false;
+    }
+    notificationState.lastSignalAt = now;
+    if (notificationState.suppressed) {
+      return Promise.reject(this.toolRefreshFrequencyError(serverId));
+    }
+    notificationState.consecutiveSignals += 1;
+    if (notificationState.consecutiveSignals >= MAX_CONSECUTIVE_TOOL_REFRESH_ATTEMPTS) {
+      notificationState.suppressed = true;
+      return Promise.reject(this.toolRefreshFrequencyError(serverId));
+    }
+    return this.startToolRefresh(serverId, entry, client, connectionGeneration);
   }
 
   async callTool(
@@ -466,7 +532,12 @@ export class McpClientManager {
         ) {
           return;
         }
-        await this.refreshTools(serverId).catch((error) => {
+        await this.refreshToolsAfterNotification(
+          serverId,
+          entry,
+          connectedClient,
+          connectionGeneration,
+        ).catch((error) => {
           if (
             this.connections.get(serverId) !== entry ||
             entry.client !== connectedClient ||
@@ -510,6 +581,7 @@ export class McpClientManager {
         this.replaceToolSnapshot(entry, new Map());
         entry.connectionGeneration = undefined;
         entry.refreshState = undefined;
+        entry.refreshNotificationState = undefined;
       }
       if (signal.aborted) {
         if (!entry.closing && this.connections.get(serverId) === entry) {
@@ -601,7 +673,6 @@ export class McpClientManager {
     entry: Connection,
     state: ToolRefreshState,
   ): Promise<McpToolDescriptor[]> {
-    let supersededAttempts = 0;
     while (true) {
       state.pending = false;
       let definitions: McpDiscoveredTool[] | undefined;
@@ -619,15 +690,14 @@ export class McpClientManager {
       ) {
         throw safeMcpOperationError(serverId, 'connection changed during tool refresh', failure);
       }
+      if (
+        entry.refreshNotificationState?.client === state.client &&
+        entry.refreshNotificationState.connectionGeneration === state.connectionGeneration &&
+        entry.refreshNotificationState.suppressed
+      ) {
+        throw this.toolRefreshFrequencyError(serverId);
+      }
       if (state.pending) {
-        supersededAttempts += 1;
-        if (supersededAttempts >= MAX_CONSECUTIVE_TOOL_REFRESH_ATTEMPTS) {
-          throw safeMcpOperationError(
-            serverId,
-            'tool refresh failed',
-            new Error('tool list changed too frequently during discovery'),
-          );
-        }
         continue;
       }
       if (failure !== undefined) {
@@ -654,6 +724,14 @@ export class McpClientManager {
     }
   }
 
+  private toolRefreshFrequencyError(serverId: string): Error {
+    return safeMcpOperationError(
+      serverId,
+      'tool refresh failed',
+      new Error('tool list changed too frequently during discovery'),
+    );
+  }
+
   private watchClientClose(serverId: string, entry: Connection, client: Client): () => boolean {
     let closed = false;
     client.onclose = () => {
@@ -673,6 +751,7 @@ export class McpClientManager {
     this.replaceToolSnapshot(entry, new Map());
     entry.connectionGeneration = undefined;
     entry.refreshState = undefined;
+    entry.refreshNotificationState = undefined;
     this.update(entry, {
       ...entry.status,
       state: 'disconnected',

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -45,7 +45,6 @@ const STDERR_CONTINUATION = '[stderr continuation omitted]';
 const MAX_SUMMARIZED_ERROR_BLOCKS = 100;
 const OVERSIZED_TOOL_ERROR_CONTENT = 'server returned oversized error content';
 const MAX_TOOL_REFRESH_PASSES = 3;
-const TOOL_REFRESH_QUIET_PERIOD_MS = 1_000;
 
 export interface McpClientManagerOptions {
   clientName?: string;
@@ -82,7 +81,6 @@ interface ToolRefreshNotificationState {
   // This state intentionally outlives one refresh promise. A notification
   // sent just after every response must consume the same bounded pass budget.
   refreshPasses: number;
-  lastRefreshCompletedAt?: number;
   suppressed: boolean;
 }
 
@@ -284,12 +282,18 @@ export class McpClientManager {
     const client = entry.client;
     if (!client) throw new Error(`MCP server "${serverId}" is not connected`);
     const connectionGeneration = this.requireConnectionGeneration(serverId, entry);
-    entry.refreshNotificationState = {
-      client,
-      connectionGeneration,
-      refreshPasses: 0,
-      suppressed: false,
-    };
+    const activeRefresh = entry.refreshState;
+    const refreshIsActive =
+      activeRefresh?.client === client &&
+      activeRefresh.connectionGeneration === connectionGeneration;
+    if (!refreshIsActive) {
+      entry.refreshNotificationState = {
+        client,
+        connectionGeneration,
+        refreshPasses: 0,
+        suppressed: false,
+      };
+    }
     return this.startToolRefresh(serverId, entry, client, connectionGeneration);
   }
 
@@ -329,7 +333,6 @@ export class McpClientManager {
     client: Client,
     connectionGeneration: number,
   ): Promise<McpToolDescriptor[]> {
-    const now = this.now();
     let notificationState = entry.refreshNotificationState;
     if (
       notificationState?.client !== client ||
@@ -351,13 +354,6 @@ export class McpClientManager {
       activeRefresh.pending = true;
       activeRefresh.pendingNotification = true;
       return activeRefresh.promise;
-    }
-    if (
-      notificationState.lastRefreshCompletedAt !== undefined &&
-      now - notificationState.lastRefreshCompletedAt > TOOL_REFRESH_QUIET_PERIOD_MS
-    ) {
-      notificationState.refreshPasses = 0;
-      notificationState.suppressed = false;
     }
     if (notificationState.suppressed) {
       return Promise.reject(this.toolRefreshFrequencyError(serverId));
@@ -727,27 +723,20 @@ export class McpClientManager {
         throw safeMcpOperationError(serverId, 'connection changed during tool refresh', failure);
       }
       const notificationState = entry.refreshNotificationState;
-      if (
-        notificationPass &&
+      const notificationStateMatches =
         notificationState?.client === state.client &&
-        notificationState.connectionGeneration === state.connectionGeneration
-      ) {
-        notificationState.lastRefreshCompletedAt = this.now();
-      }
-      if (
-        notificationState?.client === state.client &&
-        notificationState.connectionGeneration === state.connectionGeneration &&
-        notificationState.suppressed
-      ) {
-        throw this.toolRefreshFrequencyError(serverId);
-      }
-      if (state.pending) {
-        continue;
-      }
+        notificationState.connectionGeneration === state.connectionGeneration;
+      const refreshSuppressed = notificationStateMatches && notificationState.suppressed;
       if (failure !== undefined) {
+        if (refreshSuppressed) throw this.toolRefreshFrequencyError(serverId);
+        if (state.pending) continue;
         throw safeMcpOperationError(serverId, 'tool refresh failed', failure);
       }
-      if (!definitions) throw new Error(`MCP server "${serverId}" returned no tool definitions`);
+      if (!definitions) {
+        if (refreshSuppressed) throw this.toolRefreshFrequencyError(serverId);
+        if (state.pending) continue;
+        throw new Error(`MCP server "${serverId}" returned no tool definitions`);
+      }
 
       const snapshot = createToolSnapshot(
         serverId,
@@ -764,6 +753,8 @@ export class McpClientManager {
         error: undefined,
         updatedAt: this.now(),
       });
+      if (refreshSuppressed) throw this.toolRefreshFrequencyError(serverId);
+      if (state.pending) continue;
       return snapshot.descriptors.map(cloneTool);
     }
   }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -44,6 +44,7 @@ const STDERR_OVERSIZED_LINE = '[stderr line omitted: exceeds diagnostic limit]';
 const STDERR_CONTINUATION = '[stderr continuation omitted]';
 const MAX_SUMMARIZED_ERROR_BLOCKS = 100;
 const OVERSIZED_TOOL_ERROR_CONTENT = 'server returned oversized error content';
+const MAX_CONSECUTIVE_TOOL_REFRESH_ATTEMPTS = 3;
 
 export interface McpClientManagerOptions {
   clientName?: string;
@@ -600,6 +601,7 @@ export class McpClientManager {
     entry: Connection,
     state: ToolRefreshState,
   ): Promise<McpToolDescriptor[]> {
+    let supersededAttempts = 0;
     while (true) {
       state.pending = false;
       let definitions: McpDiscoveredTool[] | undefined;
@@ -617,7 +619,17 @@ export class McpClientManager {
       ) {
         throw safeMcpOperationError(serverId, 'connection changed during tool refresh', failure);
       }
-      if (state.pending) continue;
+      if (state.pending) {
+        supersededAttempts += 1;
+        if (supersededAttempts >= MAX_CONSECUTIVE_TOOL_REFRESH_ATTEMPTS) {
+          throw safeMcpOperationError(
+            serverId,
+            'tool refresh failed',
+            new Error('tool list changed too frequently during discovery'),
+          );
+        }
+        continue;
+      }
       if (failure !== undefined) {
         throw safeMcpOperationError(serverId, 'tool refresh failed', failure);
       }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -44,7 +44,7 @@ const STDERR_OVERSIZED_LINE = '[stderr line omitted: exceeds diagnostic limit]';
 const STDERR_CONTINUATION = '[stderr continuation omitted]';
 const MAX_SUMMARIZED_ERROR_BLOCKS = 100;
 const OVERSIZED_TOOL_ERROR_CONTENT = 'server returned oversized error content';
-const MAX_CONSECUTIVE_TOOL_REFRESH_ATTEMPTS = 3;
+const MAX_TOOL_REFRESH_PASSES = 3;
 const TOOL_REFRESH_QUIET_PERIOD_MS = 1_000;
 
 export interface McpClientManagerOptions {
@@ -72,16 +72,17 @@ interface ToolRefreshState {
   readonly client: Client;
   readonly connectionGeneration: number;
   pending: boolean;
+  pendingNotification: boolean;
   promise: Promise<McpToolDescriptor[]>;
 }
 
 interface ToolRefreshNotificationState {
-  // This state intentionally outlives one refresh promise so a notification
-  // sent just after every response cannot reset the consecutive-signal bound.
   readonly client: Client;
   readonly connectionGeneration: number;
-  consecutiveSignals: number;
-  lastSignalAt: number;
+  // This state intentionally outlives one refresh promise. A notification
+  // sent just after every response must consume the same bounded pass budget.
+  refreshPasses: number;
+  lastRefreshCompletedAt?: number;
   suppressed: boolean;
 }
 
@@ -286,8 +287,7 @@ export class McpClientManager {
     entry.refreshNotificationState = {
       client,
       connectionGeneration,
-      consecutiveSignals: 0,
-      lastSignalAt: this.now(),
+      refreshPasses: 0,
       suppressed: false,
     };
     return this.startToolRefresh(serverId, entry, client, connectionGeneration);
@@ -298,12 +298,14 @@ export class McpClientManager {
     entry: Connection,
     client: Client,
     connectionGeneration: number,
+    notification = false,
   ): Promise<McpToolDescriptor[]> {
     if (
       entry.refreshState?.client === client &&
       entry.refreshState.connectionGeneration === connectionGeneration
     ) {
       entry.refreshState.pending = true;
+      entry.refreshState.pendingNotification ||= notification;
       return entry.refreshState.promise;
     }
 
@@ -311,6 +313,7 @@ export class McpClientManager {
       client,
       connectionGeneration,
       pending: false,
+      pendingNotification: notification,
       promise: Promise.resolve([]),
     };
     state.promise = this.refreshToolLoop(serverId, entry, state).finally(() => {
@@ -335,25 +338,35 @@ export class McpClientManager {
       notificationState = {
         client,
         connectionGeneration,
-        consecutiveSignals: 0,
-        lastSignalAt: now,
+        refreshPasses: 0,
         suppressed: false,
       };
       entry.refreshNotificationState = notificationState;
-    } else if (now - notificationState.lastSignalAt > TOOL_REFRESH_QUIET_PERIOD_MS) {
-      notificationState.consecutiveSignals = 0;
+    }
+    const activeRefresh = entry.refreshState;
+    if (
+      activeRefresh?.client === client &&
+      activeRefresh.connectionGeneration === connectionGeneration
+    ) {
+      activeRefresh.pending = true;
+      activeRefresh.pendingNotification = true;
+      return activeRefresh.promise;
+    }
+    if (
+      notificationState.lastRefreshCompletedAt !== undefined &&
+      now - notificationState.lastRefreshCompletedAt > TOOL_REFRESH_QUIET_PERIOD_MS
+    ) {
+      notificationState.refreshPasses = 0;
       notificationState.suppressed = false;
     }
-    notificationState.lastSignalAt = now;
     if (notificationState.suppressed) {
       return Promise.reject(this.toolRefreshFrequencyError(serverId));
     }
-    notificationState.consecutiveSignals += 1;
-    if (notificationState.consecutiveSignals >= MAX_CONSECUTIVE_TOOL_REFRESH_ATTEMPTS) {
+    if (notificationState.refreshPasses >= MAX_TOOL_REFRESH_PASSES) {
       notificationState.suppressed = true;
       return Promise.reject(this.toolRefreshFrequencyError(serverId));
     }
-    return this.startToolRefresh(serverId, entry, client, connectionGeneration);
+    return this.startToolRefresh(serverId, entry, client, connectionGeneration, true);
   }
 
   async callTool(
@@ -674,7 +687,30 @@ export class McpClientManager {
     state: ToolRefreshState,
   ): Promise<McpToolDescriptor[]> {
     while (true) {
+      const notificationPass = state.pendingNotification;
       state.pending = false;
+      state.pendingNotification = false;
+      if (notificationPass) {
+        const notificationState = entry.refreshNotificationState;
+        if (
+          notificationState?.client !== state.client ||
+          notificationState.connectionGeneration !== state.connectionGeneration
+        ) {
+          throw safeMcpOperationError(
+            serverId,
+            'connection changed during tool refresh',
+            undefined,
+          );
+        }
+        if (notificationState.suppressed) {
+          throw this.toolRefreshFrequencyError(serverId);
+        }
+        if (notificationState.refreshPasses >= MAX_TOOL_REFRESH_PASSES) {
+          notificationState.suppressed = true;
+          throw this.toolRefreshFrequencyError(serverId);
+        }
+        notificationState.refreshPasses += 1;
+      }
       let definitions: McpDiscoveredTool[] | undefined;
       let failure: unknown;
       try {
@@ -690,10 +726,18 @@ export class McpClientManager {
       ) {
         throw safeMcpOperationError(serverId, 'connection changed during tool refresh', failure);
       }
+      const notificationState = entry.refreshNotificationState;
       if (
-        entry.refreshNotificationState?.client === state.client &&
-        entry.refreshNotificationState.connectionGeneration === state.connectionGeneration &&
-        entry.refreshNotificationState.suppressed
+        notificationPass &&
+        notificationState?.client === state.client &&
+        notificationState.connectionGeneration === state.connectionGeneration
+      ) {
+        notificationState.lastRefreshCompletedAt = this.now();
+      }
+      if (
+        notificationState?.client === state.client &&
+        notificationState.connectionGeneration === state.connectionGeneration &&
+        notificationState.suppressed
       ) {
         throw this.toolRefreshFrequencyError(serverId);
       }


### PR DESCRIPTION
## Summary

Bound consecutive MCP Tool rediscovery attempts when a server emits `tools/list_changed` for every `tools/list`. The manager now stops after three superseded attempts, keeps the previous callable snapshot, reports the hostile notification pattern, and remains removable through config sync.

Fixes #2981

## Verification

- `npm --workspace @maka/mcp test` — 58 passed
- `npm run lint`
- `npm run format:check`
- `npm run check:third-party-notices`
- `npx biome check packages/mcp/src/index.ts packages/mcp/src/__tests__/manager.test.ts`
- Root `npm run build` reaches an unrelated existing `packages/runtime-host/src/server/session-transcript-pager.ts:249` TS7006 error on `main`; the affected MCP workspace builds and typechecks in its test command.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — repeated hostile discovery notifications now produce a bounded refresh error instead of an infinite loop
- [ ] No

Generated with Codex; reviewed and submitted by the human contributor of record.