### PR TITLE
feat(runtime): admit cross-epoch graph results

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
@@ -67,6 +67,7 @@ function installGraphRenderer(
   container: Element;
   root: Root;
   setSnapshot(next: AgentGraphClientSnapshot): Promise<void>;
+  evict(graphId: string): void;
   renderSession(sessionId: string): Promise<void>;
 } {
   const { document, window } = parseHTML('<div id="root"></div>');
@@ -99,17 +100,20 @@ function installGraphRenderer(
   const listeners = new Set<GraphListener>();
   (window as unknown as { maka: unknown }).maka = {
     graphs: {
-      listEpochs: async (sessionId: string): Promise<AgentGraphEpochSummary[]> => {
+      listEpochs: async (sessionId: string) => {
         const currentGraphId = currentGraphIds.get(sessionId);
         const entries = [...snapshots.values()]
           .filter((entry) => entry.rootSessionId === sessionId)
           .sort((left, right) => Number(right.graphId === currentGraphId) - Number(left.graphId === currentGraphId));
-        return entries.map((entry, index) => ({
-          epoch: entries.length - index,
-          graphId: entry.graphId,
-          createdAt: index + 1,
-          current: currentGraphIds.get(sessionId) === entry.graphId,
-        }));
+        return {
+          epochs: entries.map((entry, index) => ({
+            epoch: entries.length - index,
+            graphId: entry.graphId,
+            createdAt: index + 1,
+            current: currentGraphIds.get(sessionId) === entry.graphId,
+          })),
+          truncated: false,
+        };
       },
       getSnapshot: async (sessionId: string, options?: { graphId?: string }) => {
         const graphId = options?.graphId ?? currentGraphIds.get(sessionId);
@@ -145,6 +149,9 @@ function installGraphRenderer(
         for (const listener of [...listeners]) listener();
         await Promise.resolve();
       });
+    },
+    evict(graphId) {
+      snapshots.delete(graphId);
     },
     async renderSession(sessionId) {
       await act(async () => {
@@ -216,6 +223,51 @@ describe('AgentGraphPanel dismiss', () => {
     assert.match(harness.container.textContent ?? '', /#1 · History \(read-only\)/);
     assert.doesNotMatch(harness.container.textContent ?? '', /Stop graph/);
     assert.equal(harness.container.querySelector('.maka-agent-graph-dismiss'), null);
+    await act(async () => harness.root.unmount());
+  });
+
+  it('resumes following the current epoch after the selected history expires', async () => {
+    const current = snapshot({ graphId: 'graph-2', status: 'active' });
+    const previous = snapshot({ graphId: 'graph-1', status: 'completed' });
+    const harness = installGraphRenderer(current, [previous]);
+    await act(async () => {
+      harness.root.render(
+        createElement(AgentGraphPanel, {
+          rootSessionId: 'session-1',
+          enabled: true,
+          locale: 'en',
+          onOpenSession: () => undefined,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    const selector = harness.container.querySelector('[role="combobox"]');
+    assert.ok(selector);
+    await act(async () => {
+      (selector as HTMLElement).click();
+      await Promise.resolve();
+    });
+    const historyOption = [...document.querySelectorAll('[role="option"]')].find((option) =>
+      option.textContent?.includes('History'),
+    );
+    assert.ok(historyOption);
+    await act(async () => {
+      (historyOption as HTMLElement).click();
+      await Promise.resolve();
+    });
+    const combobox = () => harness.container.querySelector('[role="combobox"]')?.textContent ?? '';
+    assert.match(combobox(), /#1 · History \(read-only\)/);
+
+    // The selected epoch leaves the bounded directory while the graph rolls over.
+    harness.evict('graph-1');
+    await harness.setSnapshot(snapshot({ graphId: 'graph-3', status: 'active' }));
+    assert.match(combobox(), /#2 · Current/);
+
+    // Follow restored: the next rollover refreshes the panel instead of
+    // staying pinned on the fallback graph.
+    await harness.setSnapshot(snapshot({ graphId: 'graph-4', status: 'waiting' }));
+    assert.match(combobox(), /#3 · Current/);
     await act(async () => harness.root.unmount());
   });
 

--- a/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
@@ -4,6 +4,7 @@ import { parseHTML } from 'linkedom';
 import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { AgentGraphClientSnapshot } from '@maka/runtime/stream-graph-read-model';
+import type { AgentGraphEpochSummary } from '@maka/runtime-host/protocol';
 import { AgentGraphPanel } from '../../renderer/agent-graph-panel.js';
 
 type GraphListener = () => void;
@@ -59,7 +60,10 @@ function snapshot(
   };
 }
 
-function installGraphRenderer(initial: AgentGraphClientSnapshot): {
+function installGraphRenderer(
+  initial: AgentGraphClientSnapshot,
+  historical: readonly AgentGraphClientSnapshot[] = [],
+): {
   container: Element;
   root: Root;
   setSnapshot(next: AgentGraphClientSnapshot): Promise<void>;
@@ -88,15 +92,31 @@ function installGraphRenderer(initial: AgentGraphClientSnapshot): {
     IS_REACT_ACT_ENVIRONMENT: true,
   });
 
-  const snapshots = new Map<string, AgentGraphClientSnapshot>([
-    [initial.rootSessionId, initial],
-  ]);
+  const snapshots = new Map(
+    [initial, ...historical].map((entry) => [entry.graphId, entry] as const),
+  );
+  const currentGraphIds = new Map([[initial.rootSessionId, initial.graphId]]);
   const listeners = new Set<GraphListener>();
   (window as unknown as { maka: unknown }).maka = {
     graphs: {
-      getSnapshot: async (sessionId: string) => {
-        const next = snapshots.get(sessionId);
-        if (!next) throw new Error(`missing graph snapshot for ${sessionId}`);
+      listEpochs: async (sessionId: string): Promise<AgentGraphEpochSummary[]> => {
+        const currentGraphId = currentGraphIds.get(sessionId);
+        const entries = [...snapshots.values()]
+          .filter((entry) => entry.rootSessionId === sessionId)
+          .sort((left, right) => Number(right.graphId === currentGraphId) - Number(left.graphId === currentGraphId));
+        return entries.map((entry, index) => ({
+          epoch: entries.length - index,
+          graphId: entry.graphId,
+          createdAt: index + 1,
+          current: currentGraphIds.get(sessionId) === entry.graphId,
+        }));
+      },
+      getSnapshot: async (sessionId: string, options?: { graphId?: string }) => {
+        const graphId = options?.graphId ?? currentGraphIds.get(sessionId);
+        const next = graphId ? snapshots.get(graphId) : undefined;
+        if (!next || next.rootSessionId !== sessionId) {
+          throw new Error(`missing graph snapshot for ${sessionId}`);
+        }
         return next;
       },
       inspectOperator: async () => {
@@ -119,7 +139,8 @@ function installGraphRenderer(initial: AgentGraphClientSnapshot): {
     container,
     root,
     async setSnapshot(next) {
-      snapshots.set(next.rootSessionId, next);
+      snapshots.set(next.graphId, next);
+      currentGraphIds.set(next.rootSessionId, next.graphId);
       await act(async () => {
         for (const listener of [...listeners]) listener();
         await Promise.resolve();
@@ -160,6 +181,44 @@ async function renderPanel(
 }
 
 describe('AgentGraphPanel dismiss', () => {
+  it('switches to a historical epoch without exposing current-graph controls', async () => {
+    const current = snapshot({ graphId: 'graph-2', status: 'active' });
+    const previous = snapshot({ graphId: 'graph-1', status: 'completed' });
+    const harness = installGraphRenderer(current, [previous]);
+    await act(async () => {
+      harness.root.render(
+        createElement(AgentGraphPanel, {
+          rootSessionId: 'session-1',
+          enabled: true,
+          locale: 'en',
+          onOpenSession: () => undefined,
+        }),
+      );
+      await Promise.resolve();
+    });
+
+    const selector = harness.container.querySelector('[role="combobox"]');
+    assert.ok(selector);
+    assert.match(harness.container.textContent ?? '', /Stop graph/);
+    await act(async () => {
+      (selector as HTMLElement).click();
+      await Promise.resolve();
+    });
+    const historyOption = [...document.querySelectorAll('[role="option"]')].find((option) =>
+      option.textContent?.includes('History'),
+    );
+    assert.ok(historyOption);
+    await act(async () => {
+      (historyOption as HTMLElement).click();
+      await Promise.resolve();
+    });
+
+    assert.match(harness.container.textContent ?? '', /#1 · History \(read-only\)/);
+    assert.doesNotMatch(harness.container.textContent ?? '', /Stop graph/);
+    assert.equal(harness.container.querySelector('.maka-agent-graph-dismiss'), null);
+    await act(async () => harness.root.unmount());
+  });
+
   it('shows dismiss only after the graph has settled', async () => {
     const active = await renderPanel(snapshot({ graphId: 'graph-1', status: 'active' }));
     assert.ok(active.container.querySelector('.maka-agent-graph-panel'));

--- a/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-panel.test.ts
@@ -9,6 +9,28 @@ import { AgentGraphPanel } from '../../renderer/agent-graph-panel.js';
 
 type GraphListener = () => void;
 
+interface DeferredRead {
+  started: Promise<void>;
+  release(): void;
+}
+
+interface DeferredReadGate extends DeferredRead {
+  markStarted(): void;
+  waitForRelease: Promise<void>;
+}
+
+function deferredReadGate(): DeferredReadGate {
+  let markStarted = () => {};
+  let release = () => {};
+  const started = new Promise<void>((resolve) => {
+    markStarted = resolve;
+  });
+  const waitForRelease = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  return { started, markStarted, release, waitForRelease };
+}
+
 const originalGlobals = {
   document: globalThis.document,
   window: globalThis.window,
@@ -69,6 +91,9 @@ function installGraphRenderer(
   setSnapshot(next: AgentGraphClientSnapshot): Promise<void>;
   evict(graphId: string): void;
   renderSession(sessionId: string): Promise<void>;
+  holdNextEpochList(sessionId: string): DeferredRead;
+  holdNextSnapshot(graphId: string): DeferredRead;
+  stopCalls: string[];
 } {
   const { document, window } = parseHTML('<div id="root"></div>');
   const matchMedia = (media: string) => ({
@@ -96,11 +121,25 @@ function installGraphRenderer(
   const snapshots = new Map(
     [initial, ...historical].map((entry) => [entry.graphId, entry] as const),
   );
-  const currentGraphIds = new Map([[initial.rootSessionId, initial.graphId]]);
+  const currentGraphIds = new Map<string, string>();
+  for (const entry of [initial, ...historical]) {
+    if (!currentGraphIds.has(entry.rootSessionId)) {
+      currentGraphIds.set(entry.rootSessionId, entry.graphId);
+    }
+  }
   const listeners = new Set<GraphListener>();
+  const epochListGates = new Map<string, DeferredReadGate>();
+  const snapshotGates = new Map<string, DeferredReadGate>();
+  const stopCalls: string[] = [];
   (window as unknown as { maka: unknown }).maka = {
     graphs: {
       listEpochs: async (sessionId: string) => {
+        const gate = epochListGates.get(sessionId);
+        if (gate) {
+          epochListGates.delete(sessionId);
+          gate.markStarted();
+          await gate.waitForRelease;
+        }
         const currentGraphId = currentGraphIds.get(sessionId);
         const entries = [...snapshots.values()]
           .filter((entry) => entry.rootSessionId === sessionId)
@@ -117,6 +156,12 @@ function installGraphRenderer(
       },
       getSnapshot: async (sessionId: string, options?: { graphId?: string }) => {
         const graphId = options?.graphId ?? currentGraphIds.get(sessionId);
+        const gate = graphId ? snapshotGates.get(graphId) : undefined;
+        if (gate && graphId) {
+          snapshotGates.delete(graphId);
+          gate.markStarted();
+          await gate.waitForRelease;
+        }
         const next = graphId ? snapshots.get(graphId) : undefined;
         if (!next || next.rootSessionId !== sessionId) {
           throw new Error(`missing graph snapshot for ${sessionId}`);
@@ -132,7 +177,9 @@ function installGraphRenderer(
           listeners.delete(listener);
         };
       },
-      stop: async () => undefined,
+      stop: async (sessionId: string) => {
+        stopCalls.push(sessionId);
+      },
     },
   };
 
@@ -166,6 +213,17 @@ function installGraphRenderer(
         await Promise.resolve();
       });
     },
+    holdNextEpochList(sessionId) {
+      const gate = deferredReadGate();
+      epochListGates.set(sessionId, gate);
+      return gate;
+    },
+    holdNextSnapshot(graphId) {
+      const gate = deferredReadGate();
+      snapshotGates.set(graphId, gate);
+      return gate;
+    },
+    stopCalls,
   };
 }
 
@@ -188,6 +246,37 @@ async function renderPanel(
 }
 
 describe('AgentGraphPanel dismiss', () => {
+  it('keeps the new session loading when a disposed read settles later', async () => {
+    const sessionA = snapshot({ graphId: 'graph-a', status: 'active' });
+    const sessionB = snapshot({
+      graphId: 'graph-b',
+      status: 'active',
+      rootSessionId: 'session-2',
+    });
+    const harness = installGraphRenderer(sessionA, [sessionB]);
+    const readA = harness.holdNextEpochList('session-1');
+    await harness.renderSession('session-1');
+    await readA.started;
+
+    const readB = harness.holdNextEpochList('session-2');
+    await harness.renderSession('session-2');
+    await readB.started;
+    assert.match(harness.container.textContent ?? '', /Loading graph state/);
+
+    await act(async () => {
+      readA.release();
+      await Promise.resolve();
+    });
+    assert.match(harness.container.textContent ?? '', /Loading graph state/);
+
+    await act(async () => {
+      readB.release();
+      await Promise.resolve();
+    });
+    assert.match(harness.container.textContent ?? '', /Agent Graph/);
+    await act(async () => harness.root.unmount());
+  });
+
   it('switches to a historical epoch without exposing current-graph controls', async () => {
     const current = snapshot({ graphId: 'graph-2', status: 'active' });
     const previous = snapshot({ graphId: 'graph-1', status: 'completed' });
@@ -215,14 +304,20 @@ describe('AgentGraphPanel dismiss', () => {
       option.textContent?.includes('History'),
     );
     assert.ok(historyOption);
+    const historyRead = harness.holdNextSnapshot('graph-1');
     await act(async () => {
       (historyOption as HTMLElement).click();
-      await Promise.resolve();
+      await historyRead.started;
     });
 
     assert.match(harness.container.textContent ?? '', /#1 · History \(read-only\)/);
     assert.doesNotMatch(harness.container.textContent ?? '', /Stop graph/);
     assert.equal(harness.container.querySelector('.maka-agent-graph-dismiss'), null);
+    assert.deepEqual(harness.stopCalls, []);
+    await act(async () => {
+      historyRead.release();
+      await Promise.resolve();
+    });
     await act(async () => harness.root.unmount());
   });
 

--- a/apps/desktop/src/main/__tests__/agent-graph-refresh.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-graph-refresh.test.ts
@@ -1,0 +1,118 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { createAgentGraphRefreshScheduler } from '../../renderer/agent-graph-refresh.js';
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function tick(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('agent graph refresh scheduler', () => {
+  it('lets an in-flight read commit when a notification arrives mid-flight', async () => {
+    const reads: Promise<void>[] = [];
+    const gates: Array<ReturnType<typeof deferred<void>>> = [];
+    const committed: number[] = [];
+    const scheduler = createAgentGraphRefreshScheduler((fence) => {
+      const gate = deferred<void>();
+      gates.push(gate);
+      const started = fence;
+      const read = gate.promise.then(() => {
+        if (scheduler.isCurrent(started)) committed.push(started);
+      });
+      reads.push(read);
+      return read;
+    });
+
+    scheduler.requestRefresh();
+    assert.equal(gates.length, 1);
+
+    // A graphs:changed notification while the read is in flight queues one
+    // follow-up but must not invalidate the current read (#2991).
+    scheduler.requestRefresh();
+    gates[0]!.resolve();
+    await tick();
+    assert.deepEqual(committed, [0]);
+
+    // The queued follow-up runs and commits too. Soft follow-ups share the
+    // fence: only an explicit invalidation advances it.
+    assert.equal(gates.length, 2);
+    gates[1]!.resolve();
+    await tick();
+    assert.deepEqual(committed, [0, 0]);
+    assert.equal(reads.length, 2);
+    scheduler.dispose();
+  });
+
+  it('coalesces a notification storm into one follow-up read', async () => {
+    const gates: Array<ReturnType<typeof deferred<void>>> = [];
+    const scheduler = createAgentGraphRefreshScheduler(async () => {
+      const gate = deferred<void>();
+      gates.push(gate);
+      await gate.promise;
+    });
+
+    scheduler.requestRefresh();
+    scheduler.requestRefresh();
+    scheduler.requestRefresh();
+    scheduler.requestRefresh();
+    gates[0]!.resolve();
+    await tick();
+    assert.equal(gates.length, 2);
+    gates[1]!.resolve();
+    await tick();
+    assert.equal(gates.length, 2);
+    scheduler.dispose();
+  });
+
+  it('discards an in-flight read only when the selection is invalidated', async () => {
+    const gates: Array<ReturnType<typeof deferred<void>>> = [];
+    const committed: number[] = [];
+    const scheduler = createAgentGraphRefreshScheduler((fence) => {
+      const gate = deferred<void>();
+      gates.push(gate);
+      const started = fence;
+      return gate.promise.then(() => {
+        if (scheduler.isCurrent(started)) committed.push(started);
+      });
+    });
+
+    scheduler.requestRefresh();
+    scheduler.invalidateAndRefresh();
+    gates[0]!.resolve();
+    await tick();
+    assert.deepEqual(committed, []);
+
+    assert.equal(gates.length, 2);
+    gates[1]!.resolve();
+    await tick();
+    assert.deepEqual(committed, [1]);
+    scheduler.dispose();
+  });
+
+  it('stops scheduling after dispose', async () => {
+    const gates: Array<ReturnType<typeof deferred<void>>> = [];
+    const scheduler = createAgentGraphRefreshScheduler(async () => {
+      const gate = deferred<void>();
+      gates.push(gate);
+      await gate.promise;
+    });
+
+    scheduler.requestRefresh();
+    scheduler.requestRefresh();
+    scheduler.dispose();
+    gates[0]!.resolve();
+    await tick();
+    assert.equal(gates.length, 1);
+    scheduler.requestRefresh();
+    scheduler.invalidateAndRefresh();
+    await tick();
+    assert.equal(gates.length, 1);
+  });
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
@@ -88,7 +88,10 @@ test('adapts bounded Agent Graph epoch reads without changing graph identity', a
   const client = domainClient({
     listAgentGraphEpochs: async (rootSessionId) => {
       calls.push(rootSessionId);
-      return [{ epoch: 2, graphId: 'graph-2', createdAt: 2, current: true }];
+      return {
+        epochs: [{ epoch: 2, graphId: 'graph-2', createdAt: 2, current: true }],
+        truncated: false,
+      };
     },
     queryAgentGraph: async (input) => {
       calls.push(input);
@@ -98,9 +101,10 @@ test('adapts bounded Agent Graph epoch reads without changing graph identity', a
   const ipc = ipcHarness();
   registerDomainsIpc({ client, emitModeChanged() {} }, ipc);
 
-  assert.deepEqual(await ipc.invoke('graphs:listEpochs', 'session-1'), [
-    { epoch: 2, graphId: 'graph-2', createdAt: 2, current: true },
-  ]);
+  assert.deepEqual(await ipc.invoke('graphs:listEpochs', 'session-1'), {
+    epochs: [{ epoch: 2, graphId: 'graph-2', createdAt: 2, current: true }],
+    truncated: false,
+  });
   assert.equal(
     (await ipc.invoke('graphs:getSnapshot', 'session-1', { graphId: 'graph-2' }) as {
       graphId: string;

--- a/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
@@ -83,6 +83,36 @@ test('adapts Host Goal, Task, Deep Research, and Resource projections', async ()
   });
 });
 
+test('adapts bounded Agent Graph epoch reads without changing graph identity', async () => {
+  const calls: unknown[] = [];
+  const client = domainClient({
+    listAgentGraphEpochs: async (rootSessionId) => {
+      calls.push(rootSessionId);
+      return [{ epoch: 2, graphId: 'graph-2', createdAt: 2, current: true }];
+    },
+    queryAgentGraph: async (input) => {
+      calls.push(input);
+      return graphSnapshot(input.rootSessionId, input.graphId ?? 'graph-current');
+    },
+  });
+  const ipc = ipcHarness();
+  registerDomainsIpc({ client, emitModeChanged() {} }, ipc);
+
+  assert.deepEqual(await ipc.invoke('graphs:listEpochs', 'session-1'), [
+    { epoch: 2, graphId: 'graph-2', createdAt: 2, current: true },
+  ]);
+  assert.equal(
+    (await ipc.invoke('graphs:getSnapshot', 'session-1', { graphId: 'graph-2' }) as {
+      graphId: string;
+    }).graphId,
+    'graph-2',
+  );
+  assert.deepEqual(calls, [
+    'session-1',
+    { rootSessionId: 'session-1', graphId: 'graph-2' },
+  ]);
+});
+
 test('adapts interactive terminal ownership to one Host controller lease', async () => {
   const calls: Array<{ operation: string; input: unknown }> = [];
   const update = shellRunUpdate({
@@ -680,6 +710,7 @@ function domainClient(overrides: Partial<DomainClient>): DomainClient {
     getRuntimeResource: unavailable,
     getPlanState: unavailable,
     listRuntimeResources: unavailable,
+    listAgentGraphEpochs: unavailable,
     listTasks: unavailable,
     queryAgentGraph: unavailable,
     queryAgentGraphOperator: unavailable,
@@ -710,6 +741,39 @@ function goalProjection() {
     lastReason: null,
     achievedAt: null,
     pausedAt: null,
+  };
+}
+
+function graphSnapshot(rootSessionId: string, graphId: string) {
+  return {
+    schemaVersion: 1 as const,
+    rootSessionId,
+    graphId,
+    orchestrationMode: 'graph' as const,
+    snapshotVersion: `sha256:${'1'.repeat(64)}` as const,
+    status: 'completed' as const,
+    scheduleRevision: 1,
+    topologyFingerprint: `sha256:${'2'.repeat(64)}` as const,
+    closed: true,
+    operators: [],
+    edges: [],
+    work: [],
+    reconciliationFailures: [],
+    stoppedTargets: [],
+    claims: [],
+    recentControlDecisions: [],
+    recentActivity: [],
+    terminalHistory: { records: [] },
+    omitted: {
+      operators: 0,
+      edges: 0,
+      work: 0,
+      reconciliationFailures: 0,
+      stoppedTargets: 0,
+      claims: 0,
+      controlDecisions: 0,
+      recentActivity: 0,
+    },
   };
 }
 

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -28,6 +28,7 @@ import {
   type RuntimeHostSessionSubscription,
   RuntimeHostCatalogReadError,
   RuntimeHostOperationError,
+  readRuntimeHostAgentGraphEpochs,
   readRuntimeHostConnectionCatalog,
   readRuntimeHostInvocableSkills,
   readRuntimeHostResources,
@@ -1265,6 +1266,11 @@ export class DesktopRuntimeHostClient {
     input: OperationInput<"agent.graph.query">,
   ): Promise<OperationOutput<"agent.graph.query">> {
     return this.request("agent.graph.query", input);
+  }
+
+  listAgentGraphEpochs(rootSessionId: string) {
+    this.#assertOpen();
+    return readRuntimeHostAgentGraphEpochs(this.connection, rootSessionId);
   }
 
   queryAgentGraphOperator(

--- a/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
@@ -7,7 +7,11 @@ import type {
 } from '@maka/runtime/stream-graph-read-model';
 import type { GoalState } from '@maka/runtime/goal-state';
 import type { ShellRunPtyDataEvent } from '@maka/runtime/shell-run-contract';
-import type { GoalProjection, SessionDomainChange } from '@maka/runtime-host/protocol';
+import type {
+  AgentGraphEpochSummary,
+  GoalProjection,
+  SessionDomainChange,
+} from '@maka/runtime-host/protocol';
 import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
 import type { RuntimeHostSessionObserver } from './runtime-host-session-observer.js';
 import { projectHostedDeepResearch } from './deep-research-desktop-projection.js';
@@ -28,6 +32,7 @@ type RuntimeHostSessionDomainClient = RuntimeHostShellRunsClient &
   | 'getRuntimeResource'
   | 'getPlanState'
   | 'listRuntimeResources'
+  | 'listAgentGraphEpochs'
   | 'listTasks'
   | 'queryAgentGraph'
   | 'queryAgentGraphOperator'
@@ -188,15 +193,25 @@ export function registerRuntimeHostSessionDomainsIpc(
   );
   handleReconnectableRead(
     ipcMain,
+    'graphs:listEpochs',
+    async (_event, rootSessionId: unknown): Promise<readonly AgentGraphEpochSummary[]> =>
+      deps.client.listAgentGraphEpochs(requiredId(rootSessionId, 'root Session')),
+  );
+  handleReconnectableRead(
+    ipcMain,
     'graphs:inspectOperator',
     async (
       _event,
       rootSessionId: unknown,
       operatorId: unknown,
+      graphId?: unknown,
     ): Promise<AgentGraphOperatorInspection> =>
       mutableGraphInspection(
         await deps.client.queryAgentGraphOperator({
           rootSessionId: requiredId(rootSessionId, 'root Session'),
+          ...(graphId === undefined
+            ? {}
+            : { graphId: requiredId(graphId, 'Agent graph') }),
           operatorId: requiredId(operatorId, 'Agent graph operator'),
         }),
       ),
@@ -287,18 +302,31 @@ function toDesktopGoal(goal: GoalProjection): GoalState {
   };
 }
 
-function snapshotOptions(value: unknown): AgentGraphClientSnapshotOptions {
+function snapshotOptions(
+  value: unknown,
+): AgentGraphClientSnapshotOptions & { readonly graphId?: string } {
   if (value === undefined) return {};
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new TypeError('Invalid agent graph snapshot options');
   }
   const record = value as Record<string, unknown>;
-  if (Object.keys(record).some((key) => key !== 'terminalCursor')) {
+  if (Object.keys(record).some((key) => key !== 'graphId' && key !== 'terminalCursor')) {
     throw new TypeError('Invalid agent graph snapshot options');
   }
-  return record.terminalCursor === undefined
-    ? {}
-    : { terminalCursor: requiredId(record.terminalCursor, 'Agent graph terminal cursor', 2_048) };
+  return {
+    ...(record.graphId === undefined
+      ? {}
+      : { graphId: requiredId(record.graphId, 'Agent graph') }),
+    ...(record.terminalCursor === undefined
+      ? {}
+      : {
+          terminalCursor: requiredId(
+            record.terminalCursor,
+            'Agent graph terminal cursor',
+            2_048,
+          ),
+        }),
+  };
 }
 
 function mutableGraphSnapshot(

--- a/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
@@ -8,10 +8,10 @@ import type {
 import type { GoalState } from '@maka/runtime/goal-state';
 import type { ShellRunPtyDataEvent } from '@maka/runtime/shell-run-contract';
 import type {
-  AgentGraphEpochSummary,
   GoalProjection,
   SessionDomainChange,
 } from '@maka/runtime-host/protocol';
+import type { AgentGraphEpochDirectory } from '@maka/runtime-host/client';
 import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
 import type { RuntimeHostSessionObserver } from './runtime-host-session-observer.js';
 import { projectHostedDeepResearch } from './deep-research-desktop-projection.js';
@@ -194,7 +194,7 @@ export function registerRuntimeHostSessionDomainsIpc(
   handleReconnectableRead(
     ipcMain,
     'graphs:listEpochs',
-    async (_event, rootSessionId: unknown): Promise<readonly AgentGraphEpochSummary[]> =>
+    async (_event, rootSessionId: unknown): Promise<AgentGraphEpochDirectory> =>
       deps.client.listAgentGraphEpochs(requiredId(rootSessionId, 'root Session')),
   );
   handleReconnectableRead(

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -82,6 +82,7 @@ import type {
 } from './transcript-contract.js';
 import type { PetPackManifestV1 } from '@maka/core/pet';
 import type {
+  AgentGraphEpochSummary,
   OperationInput,
   OperationOutput,
 } from '@maka/runtime-host/protocol';
@@ -497,13 +498,15 @@ export interface MakaBridge {
     subscribeChanges(handler: (event: DeepResearchChangedEvent) => void): () => void;
   };
   graphs: {
+    listEpochs(rootSessionId: string): Promise<AgentGraphEpochSummary[]>;
     getSnapshot(
       rootSessionId: string,
-      options?: AgentGraphClientSnapshotOptions,
+      options?: AgentGraphClientSnapshotOptions & { graphId?: string },
     ): Promise<AgentGraphClientSnapshot>;
     inspectOperator(
       rootSessionId: string,
       operatorId: string,
+      graphId?: string,
     ): Promise<AgentGraphOperatorInspection>;
     stop(rootSessionId: string): Promise<void>;
     subscribe(

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -82,10 +82,10 @@ import type {
 } from './transcript-contract.js';
 import type { PetPackManifestV1 } from '@maka/core/pet';
 import type {
-  AgentGraphEpochSummary,
   OperationInput,
   OperationOutput,
 } from '@maka/runtime-host/protocol';
+import type { AgentGraphEpochDirectory } from '@maka/runtime-host/client';
 import type {
   RendererRuntimeHostCommandOperation,
   RendererRuntimeHostQueryOperation,
@@ -498,7 +498,7 @@ export interface MakaBridge {
     subscribeChanges(handler: (event: DeepResearchChangedEvent) => void): () => void;
   };
   graphs: {
-    listEpochs(rootSessionId: string): Promise<AgentGraphEpochSummary[]>;
+    listEpochs(rootSessionId: string): Promise<AgentGraphEpochDirectory>;
     getSnapshot(
       rootSessionId: string,
       options?: AgentGraphClientSnapshotOptions & { graphId?: string },

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -155,10 +155,10 @@ import type { AttachmentRef, InlineReference, QuoteRef } from '@maka/core/events
 import type { OnboardingMilestoneId } from '@maka/core/onboarding';
 import {
   SCHEDULED_TASK_CATALOG_MAX_ITEMS,
-  type AgentGraphEpochSummary,
   type OperationInput,
   type OperationOutput,
 } from '@maka/runtime-host/protocol';
+import type { AgentGraphEpochDirectory } from '@maka/runtime-host/client';
 import {
   desktopSessionKey,
   parseDesktopSessionKey,
@@ -1203,11 +1203,11 @@ const makaBridge = {
     },
   },
   graphs: {
-    async listEpochs(rootSessionId: string): Promise<AgentGraphEpochSummary[]> {
+    async listEpochs(rootSessionId: string): Promise<AgentGraphEpochDirectory> {
       const session = await runtimeHostSessionRef(rootSessionId);
       return ipcRenderer.invoke(
         'graphs:listEpochs', session.scope, session.sessionId,
-      ) as Promise<AgentGraphEpochSummary[]>;
+      ) as Promise<AgentGraphEpochDirectory>;
     },
     async getSnapshot(
       rootSessionId: string,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -155,6 +155,7 @@ import type { AttachmentRef, InlineReference, QuoteRef } from '@maka/core/events
 import type { OnboardingMilestoneId } from '@maka/core/onboarding';
 import {
   SCHEDULED_TASK_CATALOG_MAX_ITEMS,
+  type AgentGraphEpochSummary,
   type OperationInput,
   type OperationOutput,
 } from '@maka/runtime-host/protocol';
@@ -1202,9 +1203,15 @@ const makaBridge = {
     },
   },
   graphs: {
+    async listEpochs(rootSessionId: string): Promise<AgentGraphEpochSummary[]> {
+      const session = await runtimeHostSessionRef(rootSessionId);
+      return ipcRenderer.invoke(
+        'graphs:listEpochs', session.scope, session.sessionId,
+      ) as Promise<AgentGraphEpochSummary[]>;
+    },
     async getSnapshot(
       rootSessionId: string,
-      options?: AgentGraphClientSnapshotOptions,
+      options?: AgentGraphClientSnapshotOptions & { graphId?: string },
     ): Promise<AgentGraphClientSnapshot> {
       const session = await runtimeHostSessionRef(rootSessionId);
       const snapshot = await ipcRenderer.invoke(
@@ -1215,10 +1222,15 @@ const makaBridge = {
     async inspectOperator(
       rootSessionId: string,
       operatorId: string,
+      graphId?: string,
     ): Promise<AgentGraphOperatorInspection> {
       const session = await runtimeHostSessionRef(rootSessionId);
       const inspection = await ipcRenderer.invoke(
-        'graphs:inspectOperator', session.scope, session.sessionId, operatorId,
+        'graphs:inspectOperator',
+        session.scope,
+        session.sessionId,
+        operatorId,
+        graphId,
       ) as AgentGraphOperatorInspection;
       return projectProtocolSessionIds(session.scope.hostId, inspection);
     },

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -36,6 +36,7 @@ type GraphPanelCopy = {
   epoch: string;
   currentEpoch: string;
   historicalEpoch: string;
+  cappedEpochs(count: number): string;
   noOperators: string;
   hiddenOperators(count: number): string;
   progress(settled: number, total: number, hasOmitted: boolean): string;
@@ -63,6 +64,7 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
       epoch: 'Graph 运行轮次',
       currentEpoch: '当前',
       historicalEpoch: '历史记录（只读）',
+      cappedEpochs: (count) => `仅显示最近 ${count} 次运行`,
       noOperators: '等待主 Agent 创建 operator…',
       hiddenOperators: (count) => `另有 ${count} 个 operator`,
       progress: (settled, total, hasOmitted) =>
@@ -109,6 +111,7 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
     epoch: 'Graph run',
     currentEpoch: 'Current',
     historicalEpoch: 'History (read-only)',
+    cappedEpochs: (count) => `Showing the newest ${count} runs`,
     noOperators: 'Waiting for the main agent to create an operator…',
     hiddenOperators: (count) => `${count} more operator${count === 1 ? '' : 's'}`,
     progress: (settled, total, hasOmitted) =>
@@ -147,6 +150,7 @@ export function AgentGraphPanel(props: {
 }): JSX.Element | null {
   const [snapshot, setSnapshot] = useState<AgentGraphClientSnapshot>();
   const [epochs, setEpochs] = useState<readonly AgentGraphEpochSummary[]>([]);
+  const [epochsTruncated, setEpochsTruncated] = useState(false);
   const [loading, setLoading] = useState(props.enabled);
   const [error, setError] = useState(false);
   const [stopPending, setStopPending] = useState(false);
@@ -167,6 +171,7 @@ export function AgentGraphPanel(props: {
 
     setSnapshot(undefined);
     setEpochs([]);
+    setEpochsTruncated(false);
     selectedGraphIdRef.current = undefined;
     followCurrentRef.current = true;
     setError(false);
@@ -185,24 +190,31 @@ export function AgentGraphPanel(props: {
       setLoading(true);
       task = window.maka.graphs
         .listEpochs(props.rootSessionId)
-        .then(async (nextEpochs) => {
+        .then(async (directory) => {
+          const nextEpochs = directory.epochs;
           const current = nextEpochs.find((entry) => entry.current) ?? nextEpochs[0];
           const selected = followCurrentRef.current
             ? current
             : nextEpochs.find((entry) => entry.graphId === selectedGraphIdRef.current);
+          // An evicted selection must not pin the panel on the fallback:
+          // resume following the current epoch so later rollovers refresh.
+          if (!selected && !followCurrentRef.current) {
+            followCurrentRef.current = true;
+          }
           const graphId = (selected ?? current)?.graphId;
           if (!graphId) throw new Error('Agent graph epoch directory is empty');
           selectedGraphIdRef.current = graphId;
           const next = await window.maka.graphs.getSnapshot(props.rootSessionId, { graphId });
-          return { next, nextEpochs };
+          return { next, nextEpochs, truncated: directory.truncated };
         })
-        .then(({ next, nextEpochs }) => {
+        .then(({ next, nextEpochs, truncated }) => {
           if (
             !disposed &&
             generation === refreshGeneration &&
             next.graphId === selectedGraphIdRef.current
           ) {
             setEpochs(nextEpochs);
+            setEpochsTruncated(truncated);
             setSnapshot(next);
             setError(false);
           }
@@ -324,6 +336,9 @@ export function AgentGraphPanel(props: {
                 refreshRef.current();
               }}
             />
+          ) : null}
+          {epochsTruncated ? (
+            <span className="maka-agent-graph-epoch-capped">{copy.cappedEpochs(epochs.length)}</span>
           ) : null}
           {snapshot ? (
             <span className="maka-agent-graph-progress">

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -18,6 +18,17 @@ import {
   shouldShowAgentGraphPanel,
   type AgentGraphPanelDismissals,
 } from './agent-graph-panel-visibility.js';
+import {
+  createAgentGraphRefreshScheduler,
+  type AgentGraphRefreshScheduler,
+} from './agent-graph-refresh.js';
+
+const noopAgentGraphRefreshScheduler: AgentGraphRefreshScheduler = {
+  requestRefresh() {},
+  invalidateAndRefresh() {},
+  isCurrent: () => false,
+  dispose() {},
+};
 
 type GraphPanelCopy = {
   title: string;
@@ -158,17 +169,12 @@ export function AgentGraphPanel(props: {
   const [collapsed, setCollapsed] = useState(false);
   const [dismissedBySession, setDismissedBySession] = useState<AgentGraphPanelDismissals>({});
   const contentId = useId();
-  const refreshRef = useRef<() => void>(() => {});
+  const refreshRef = useRef<AgentGraphRefreshScheduler>(noopAgentGraphRefreshScheduler);
   const selectedGraphIdRef = useRef<string | undefined>(undefined);
   const followCurrentRef = useRef(true);
   const copy = getAgentGraphPanelCopy(props.locale);
 
   useEffect(() => {
-    let disposed = false;
-    let queued = false;
-    let refreshGeneration = 0;
-    let task: Promise<void> | undefined;
-
     setSnapshot(undefined);
     setEpochs([]);
     setEpochsTruncated(false);
@@ -179,66 +185,47 @@ export function AgentGraphPanel(props: {
     setCollapsed(false);
     setLoading(props.enabled);
 
-    const refresh = (): void => {
-      if (disposed) return;
-      refreshGeneration += 1;
-      if (task) {
-        queued = true;
-        return;
-      }
-      const generation = refreshGeneration;
+    const scheduler = createAgentGraphRefreshScheduler(async (fence) => {
       setLoading(true);
-      task = window.maka.graphs
-        .listEpochs(props.rootSessionId)
-        .then(async (directory) => {
-          const nextEpochs = directory.epochs;
-          const current = nextEpochs.find((entry) => entry.current) ?? nextEpochs[0];
-          const selected = followCurrentRef.current
-            ? current
-            : nextEpochs.find((entry) => entry.graphId === selectedGraphIdRef.current);
-          // An evicted selection must not pin the panel on the fallback:
-          // resume following the current epoch so later rollovers refresh.
-          if (!selected && !followCurrentRef.current) {
-            followCurrentRef.current = true;
-          }
-          const graphId = (selected ?? current)?.graphId;
-          if (!graphId) throw new Error('Agent graph epoch directory is empty');
-          selectedGraphIdRef.current = graphId;
-          const next = await window.maka.graphs.getSnapshot(props.rootSessionId, { graphId });
-          return { next, nextEpochs, truncated: directory.truncated };
-        })
-        .then(({ next, nextEpochs, truncated }) => {
-          if (
-            !disposed &&
-            generation === refreshGeneration &&
-            next.graphId === selectedGraphIdRef.current
-          ) {
-            setEpochs(nextEpochs);
-            setEpochsTruncated(truncated);
-            setSnapshot(next);
-            setError(false);
-          }
-        })
-        .catch(() => {
-          if (!disposed && generation === refreshGeneration) setError(true);
-        })
-        .finally(() => {
-          if (disposed) return;
-          setLoading(false);
-          task = undefined;
-          if (queued) {
-            queued = false;
-            refresh();
-          }
-        });
-    };
+      try {
+        const directory = await window.maka.graphs.listEpochs(props.rootSessionId);
+        const nextEpochs = directory.epochs;
+        const current = nextEpochs.find((entry) => entry.current) ?? nextEpochs[0];
+        const selected = followCurrentRef.current
+          ? current
+          : nextEpochs.find((entry) => entry.graphId === selectedGraphIdRef.current);
+        // An evicted selection must not pin the panel on the fallback:
+        // resume following the current epoch so later rollovers refresh.
+        if (!selected && !followCurrentRef.current) {
+          followCurrentRef.current = true;
+        }
+        const graphId = (selected ?? current)?.graphId;
+        if (!graphId) throw new Error('Agent graph epoch directory is empty');
+        selectedGraphIdRef.current = graphId;
+        const next = await window.maka.graphs.getSnapshot(props.rootSessionId, { graphId });
+        if (scheduler.isCurrent(fence) && next.graphId === selectedGraphIdRef.current) {
+          setEpochs(nextEpochs);
+          setEpochsTruncated(directory.truncated);
+          setSnapshot(next);
+          setError(false);
+        }
+      } catch {
+        if (scheduler.isCurrent(fence)) setError(true);
+      } finally {
+        setLoading(false);
+      }
+    });
 
-    refreshRef.current = refresh;
-    const unsubscribe = window.maka.graphs.subscribe(props.rootSessionId, refresh);
-    refresh();
+    refreshRef.current = scheduler;
+    const unsubscribe = window.maka.graphs.subscribe(props.rootSessionId, () =>
+      scheduler.requestRefresh(),
+    );
+    scheduler.requestRefresh();
     return () => {
-      disposed = true;
-      if (refreshRef.current === refresh) refreshRef.current = () => {};
+      scheduler.dispose();
+      if (refreshRef.current === scheduler) {
+        refreshRef.current = noopAgentGraphRefreshScheduler;
+      }
       unsubscribe();
     };
   }, [props.rootSessionId, props.enabled]);
@@ -333,7 +320,7 @@ export function AgentGraphPanel(props: {
                 selectedGraphIdRef.current = graphId;
                 followCurrentRef.current =
                   epochs.find((entry) => entry.graphId === graphId)?.current === true;
-                refreshRef.current();
+                refreshRef.current.invalidateAndRefresh();
               }}
             />
           ) : null}
@@ -408,7 +395,7 @@ export function AgentGraphPanel(props: {
                   variant="secondary"
                   size="sm"
                   label={copy.retry}
-                  onClick={() => refreshRef.current()}
+                  onClick={() => refreshRef.current.requestRefresh()}
                 />
               )}
             />

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -4,7 +4,8 @@ import type {
   AgentGraphClientOperator,
   AgentGraphClientSnapshot,
 } from '@maka/runtime/stream-graph-read-model';
-import { IconButton } from '@maka/ui';
+import type { AgentGraphEpochSummary } from '@maka/runtime-host/protocol';
+import { IconButton, Selector, type SelectorOptionType } from '@maka/ui';
 import { ICON_SIZE, ChevronDown, X } from '@maka/ui/icons';
 import { Banner } from '@astryxdesign/core/Banner';
 import { Button } from '@astryxdesign/core/Button';
@@ -32,6 +33,9 @@ type GraphPanelCopy = {
   openSession: string;
   operators: string;
   selectedResults: string;
+  epoch: string;
+  currentEpoch: string;
+  historicalEpoch: string;
   noOperators: string;
   hiddenOperators(count: number): string;
   progress(settled: number, total: number, hasOmitted: boolean): string;
@@ -56,6 +60,9 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
       openSession: '打开子任务',
       operators: 'Operators',
       selectedResults: '已选择结果',
+      epoch: 'Graph 运行轮次',
+      currentEpoch: '当前',
+      historicalEpoch: '历史记录（只读）',
       noOperators: '等待主 Agent 创建 operator…',
       hiddenOperators: (count) => `另有 ${count} 个 operator`,
       progress: (settled, total, hasOmitted) =>
@@ -99,6 +106,9 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
     openSession: 'Open child task',
     operators: 'Operators',
     selectedResults: 'Selected results',
+    epoch: 'Graph run',
+    currentEpoch: 'Current',
+    historicalEpoch: 'History (read-only)',
     noOperators: 'Waiting for the main agent to create an operator…',
     hiddenOperators: (count) => `${count} more operator${count === 1 ? '' : 's'}`,
     progress: (settled, total, hasOmitted) =>
@@ -136,6 +146,7 @@ export function AgentGraphPanel(props: {
   onOpenSession(sessionId: string): void;
 }): JSX.Element | null {
   const [snapshot, setSnapshot] = useState<AgentGraphClientSnapshot>();
+  const [epochs, setEpochs] = useState<readonly AgentGraphEpochSummary[]>([]);
   const [loading, setLoading] = useState(props.enabled);
   const [error, setError] = useState(false);
   const [stopPending, setStopPending] = useState(false);
@@ -144,14 +155,20 @@ export function AgentGraphPanel(props: {
   const [dismissedBySession, setDismissedBySession] = useState<AgentGraphPanelDismissals>({});
   const contentId = useId();
   const refreshRef = useRef<() => void>(() => {});
+  const selectedGraphIdRef = useRef<string | undefined>(undefined);
+  const followCurrentRef = useRef(true);
   const copy = getAgentGraphPanelCopy(props.locale);
 
   useEffect(() => {
     let disposed = false;
     let queued = false;
+    let refreshGeneration = 0;
     let task: Promise<void> | undefined;
 
     setSnapshot(undefined);
+    setEpochs([]);
+    selectedGraphIdRef.current = undefined;
+    followCurrentRef.current = true;
     setError(false);
     setStopError(false);
     setCollapsed(false);
@@ -159,21 +176,39 @@ export function AgentGraphPanel(props: {
 
     const refresh = (): void => {
       if (disposed) return;
+      refreshGeneration += 1;
       if (task) {
         queued = true;
         return;
       }
+      const generation = refreshGeneration;
       setLoading(true);
       task = window.maka.graphs
-        .getSnapshot(props.rootSessionId)
-        .then((next) => {
-          if (!disposed) {
+        .listEpochs(props.rootSessionId)
+        .then(async (nextEpochs) => {
+          const current = nextEpochs.find((entry) => entry.current) ?? nextEpochs[0];
+          const selected = followCurrentRef.current
+            ? current
+            : nextEpochs.find((entry) => entry.graphId === selectedGraphIdRef.current);
+          const graphId = (selected ?? current)?.graphId;
+          if (!graphId) throw new Error('Agent graph epoch directory is empty');
+          selectedGraphIdRef.current = graphId;
+          const next = await window.maka.graphs.getSnapshot(props.rootSessionId, { graphId });
+          return { next, nextEpochs };
+        })
+        .then(({ next, nextEpochs }) => {
+          if (
+            !disposed &&
+            generation === refreshGeneration &&
+            next.graphId === selectedGraphIdRef.current
+          ) {
+            setEpochs(nextEpochs);
             setSnapshot(next);
             setError(false);
           }
         })
         .catch(() => {
-          if (!disposed) setError(true);
+          if (!disposed && generation === refreshGeneration) setError(true);
         })
         .finally(() => {
           if (disposed) return;
@@ -218,16 +253,18 @@ export function AgentGraphPanel(props: {
     ).length ?? 0;
     return { settled, total: snapshot?.operators.length ?? 0 };
   }, [snapshot]);
+  const selectedEpoch = epochs.find((entry) => entry.graphId === snapshot?.graphId);
 
   const hasGraphActivity =
     snapshot !== undefined &&
     (snapshot.scheduleRevision > 0 ||
       snapshot.operators.length > 0 ||
       snapshot.omitted.operators > 0);
+  const hasGraphHistory = epochs.length > 1;
   if (
     !shouldShowAgentGraphPanel({
       enabled: props.enabled,
-      hasGraphActivity,
+      hasGraphActivity: hasGraphActivity || hasGraphHistory,
       error,
       sessionId: props.rootSessionId,
       graphId: snapshot?.graphId,
@@ -251,9 +288,13 @@ export function AgentGraphPanel(props: {
     }
   };
   const stopAvailable =
-    snapshot !== undefined && ['active', 'waiting', 'closing'].includes(snapshot.status);
+    selectedEpoch?.current === true &&
+    snapshot !== undefined &&
+    ['active', 'waiting', 'closing'].includes(snapshot.status);
   const dismissAvailable =
-    snapshot !== undefined && isAgentGraphPanelDismissible(snapshot.status);
+    selectedEpoch?.current === true &&
+    snapshot !== undefined &&
+    isAgentGraphPanelDismissible(snapshot.status);
 
   return (
     <section
@@ -264,6 +305,26 @@ export function AgentGraphPanel(props: {
       <header className="maka-agent-graph-heading">
         <div className="maka-agent-graph-heading-copy">
           <strong>{copy.title}</strong>
+          {epochs.length > 1 && snapshot ? (
+            <Selector
+              className="maka-agent-graph-epoch-selector"
+              size="sm"
+              label={copy.epoch}
+              isLabelHidden
+              value={snapshot.graphId}
+              options={epochs.map((entry) => ({
+                value: entry.graphId,
+                label: `#${entry.epoch} · ${entry.current ? copy.currentEpoch : copy.historicalEpoch}`,
+              }))}
+              onChange={(graphId: SelectorOptionType) => {
+                if (typeof graphId !== 'string') return;
+                selectedGraphIdRef.current = graphId;
+                followCurrentRef.current =
+                  epochs.find((entry) => entry.graphId === graphId)?.current === true;
+                refreshRef.current();
+              }}
+            />
+          ) : null}
           {snapshot ? (
             <span className="maka-agent-graph-progress">
               {copy.status(snapshot.status)} ·{' '}

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -162,6 +162,7 @@ export function AgentGraphPanel(props: {
   const [snapshot, setSnapshot] = useState<AgentGraphClientSnapshot>();
   const [epochs, setEpochs] = useState<readonly AgentGraphEpochSummary[]>([]);
   const [epochsTruncated, setEpochsTruncated] = useState(false);
+  const [selectedGraphId, setSelectedGraphId] = useState<string>();
   const [loading, setLoading] = useState(props.enabled);
   const [error, setError] = useState(false);
   const [stopPending, setStopPending] = useState(false);
@@ -178,6 +179,7 @@ export function AgentGraphPanel(props: {
     setSnapshot(undefined);
     setEpochs([]);
     setEpochsTruncated(false);
+    setSelectedGraphId(undefined);
     selectedGraphIdRef.current = undefined;
     followCurrentRef.current = true;
     setError(false);
@@ -206,13 +208,14 @@ export function AgentGraphPanel(props: {
         if (scheduler.isCurrent(fence) && next.graphId === selectedGraphIdRef.current) {
           setEpochs(nextEpochs);
           setEpochsTruncated(directory.truncated);
+          setSelectedGraphId(graphId);
           setSnapshot(next);
           setError(false);
         }
       } catch {
         if (scheduler.isCurrent(fence)) setError(true);
       } finally {
-        setLoading(false);
+        if (scheduler.isCurrent(fence)) setLoading(false);
       }
     });
 
@@ -252,7 +255,7 @@ export function AgentGraphPanel(props: {
     ).length ?? 0;
     return { settled, total: snapshot?.operators.length ?? 0 };
   }, [snapshot]);
-  const selectedEpoch = epochs.find((entry) => entry.graphId === snapshot?.graphId);
+  const selectedEpoch = epochs.find((entry) => entry.graphId === selectedGraphId);
 
   const hasGraphActivity =
     snapshot !== undefined &&
@@ -288,11 +291,15 @@ export function AgentGraphPanel(props: {
   };
   const stopAvailable =
     selectedEpoch?.current === true &&
+    !loading &&
     snapshot !== undefined &&
+    snapshot.graphId === selectedGraphId &&
     ['active', 'waiting', 'closing'].includes(snapshot.status);
   const dismissAvailable =
     selectedEpoch?.current === true &&
+    !loading &&
     snapshot !== undefined &&
+    snapshot.graphId === selectedGraphId &&
     isAgentGraphPanelDismissible(snapshot.status);
 
   return (
@@ -310,7 +317,7 @@ export function AgentGraphPanel(props: {
               size="sm"
               label={copy.epoch}
               isLabelHidden
-              value={snapshot.graphId}
+              value={selectedGraphId ?? snapshot.graphId}
               options={epochs.map((entry) => ({
                 value: entry.graphId,
                 label: `#${entry.epoch} · ${entry.current ? copy.currentEpoch : copy.historicalEpoch}`,
@@ -318,6 +325,7 @@ export function AgentGraphPanel(props: {
               onChange={(graphId: SelectorOptionType) => {
                 if (typeof graphId !== 'string') return;
                 selectedGraphIdRef.current = graphId;
+                setSelectedGraphId(graphId);
                 followCurrentRef.current =
                   epochs.find((entry) => entry.graphId === graphId)?.current === true;
                 refreshRef.current.invalidateAndRefresh();

--- a/apps/desktop/src/renderer/agent-graph-refresh.ts
+++ b/apps/desktop/src/renderer/agent-graph-refresh.ts
@@ -1,0 +1,72 @@
+/**
+ * Coalesced refresh scheduling for the Agent Graph panel (#2991).
+ *
+ * A `graphs:changed` notification must NOT invalidate an in-flight read: a
+ * busy graph publishes continuously, and advancing the fence on every
+ * notification discards each valid snapshot until the graph goes quiet,
+ * leaving the panel blank. Notifications therefore only queue one follow-up
+ * read while the in-flight read for the same session and selection commits.
+ *
+ * The fence advances only on an explicit invalidation — the user picking a
+ * different epoch or the effect re-running for another session — so a stale
+ * in-flight read for a superseded selection is still discarded.
+ */
+export interface AgentGraphRefreshScheduler {
+  /** Notification-driven: queue a follow-up read; never invalidates in-flight. */
+  requestRefresh(): void;
+  /** Selection/session change: invalidate any in-flight read and re-read. */
+  invalidateAndRefresh(): void;
+  /** Whether a read started with `fence` may still commit its result. */
+  isCurrent(fence: number): boolean;
+  dispose(): void;
+}
+
+export function createAgentGraphRefreshScheduler(
+  read: (fence: number) => Promise<void>,
+): AgentGraphRefreshScheduler {
+  let disposed = false;
+  let queued = false;
+  let fence = 0;
+  let running = false;
+
+  const start = (): void => {
+    running = true;
+    const current = fence;
+    const settle = (): void => {
+      running = false;
+      if (disposed) return;
+      if (queued) {
+        queued = false;
+        start();
+      }
+    };
+    void read(current).then(settle, settle);
+  };
+
+  return {
+    requestRefresh() {
+      if (disposed) return;
+      if (running) {
+        queued = true;
+        return;
+      }
+      start();
+    },
+    invalidateAndRefresh() {
+      if (disposed) return;
+      fence += 1;
+      if (running) {
+        queued = true;
+        return;
+      }
+      start();
+    },
+    isCurrent(candidate: number): boolean {
+      return !disposed && candidate === fence;
+    },
+    dispose() {
+      disposed = true;
+      queued = false;
+    },
+  };
+}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2251,6 +2251,10 @@ function AppShellContent({
         );
         return true;
       }
+      if (graphCommand.kind === 'history') {
+        toastApi.info(shellCopy.graphHistoryTitle, shellCopy.graphHistoryDescription);
+        return true;
+      }
       if (graphCommand.kind === 'set_mode') {
         const changed = await setGraphMode(graphCommand.mode === 'graph');
         if (changed) {

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -462,6 +462,8 @@ type ShellCopy = {
     graphModeEnabledTitle: string;
     graphModeDisabledTitle: string;
     graphModeStatusDescription: string;
+    graphHistoryTitle: string;
+    graphHistoryDescription: string;
     resizeWorkbar: string;
   };
 };
@@ -1166,6 +1168,8 @@ const SHELL_COPY_BY_LOCALE = {
       graphModeEnabledTitle: 'Graph Mode 已开启',
       graphModeDisabledTitle: 'Graph Mode 未开启',
       graphModeStatusDescription: '使用 /graph on、/graph off，或 /graph <任务> 单次运行。',
+      graphHistoryTitle: 'Graph 历史',
+      graphHistoryDescription: '请在 Agent Graph 面板的运行轮次菜单中查看历史记录。',
       resizeWorkbar: '调整任务工作栏宽度',
     },
   },
@@ -1696,6 +1700,8 @@ const SHELL_COPY_BY_LOCALE = {
       graphModeEnabledTitle: 'Graph Mode is on',
       graphModeDisabledTitle: 'Graph Mode is off',
       graphModeStatusDescription: 'Use /graph on, /graph off, or /graph <task> for one turn.',
+      graphHistoryTitle: 'Graph history',
+      graphHistoryDescription: 'Use the run menu in the Agent Graph panel to inspect history.',
       resizeWorkbar: 'Resize task workbar',
     },
   },

--- a/apps/desktop/src/renderer/styles/agent-graph.css
+++ b/apps/desktop/src/renderer/styles/agent-graph.css
@@ -30,6 +30,12 @@
 
 .maka-agent-graph-heading-copy {
   min-width: 0;
+  flex-wrap: wrap;
+}
+
+.maka-agent-graph-epoch-selector {
+  min-width: 9rem;
+  max-width: 15rem;
 }
 
 .maka-agent-graph-heading-actions {

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -20,6 +20,7 @@ import { type SessionSummary, type StoredMessage } from '@maka/core/session';
 import { type ThinkingLevel } from '@maka/core/model-thinking';
 import { type UserQuestionResponse } from '@maka/core/user-question';
 import type { SkillInvocationResult } from '@maka/core/skill-invocation';
+import type { AgentGraphClientSnapshot } from '@maka/runtime-host/protocol';
 import { SessionActivityRegistry } from '@maka/runtime/goal-turn-lifecycle';
 import { type ContextDiagnostics } from '@maka/runtime/context-diagnostics';
 import type {
@@ -114,6 +115,40 @@ function deferred<T>() {
     resolve = done;
   });
   return { promise, resolve };
+}
+
+function historicalGraphSnapshot(graphId: string): AgentGraphClientSnapshot {
+  return {
+    schemaVersion: 1,
+    rootSessionId: 'session-1',
+    graphId,
+    orchestrationMode: 'graph',
+    snapshotVersion: `sha256:${'1'.repeat(64)}`,
+    status: 'completed',
+    scheduleRevision: 2,
+    topologyFingerprint: `sha256:${'2'.repeat(64)}`,
+    closed: true,
+    operators: [],
+    edges: [],
+    work: [],
+    reconciliationFailures: [],
+    stoppedTargets: [],
+    finish: { resultIds: ['result-1'], reason: 'done', revision: 2, committedAt: 2 },
+    claims: [],
+    recentControlDecisions: [],
+    recentActivity: [],
+    terminalHistory: { records: [] },
+    omitted: {
+      operators: 0,
+      edges: 0,
+      work: 0,
+      reconciliationFailures: 0,
+      stoppedTargets: 0,
+      claims: 0,
+      controlDecisions: 0,
+      recentActivity: 0,
+    },
+  };
 }
 
 /** Catalog API-key providers as wizard entries with no existing connection —
@@ -2463,6 +2498,47 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
     await waitFor(() => terminal.output().includes('Swarm Mode is off'));
 
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('inspects a historical Agent Graph run without starting a turn', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const requestedGraphIds: string[] = [];
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      connectionSlug: 'deepseek',
+      permissionMode: 'ask',
+      terminal,
+      agentGraphHistory: {
+        listEpochs: async () => [
+          { epoch: 2, graphId: 'graph-2', createdAt: 2, current: true },
+          { epoch: 1, graphId: 'graph-1', createdAt: 1, current: false },
+        ],
+        getSnapshot: async (_rootSessionId, graphId) => {
+          requestedGraphIds.push(graphId);
+          return historicalGraphSnapshot(graphId);
+        },
+      },
+    });
+
+    terminal.input('/graph history');
+    terminal.input('\r');
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Agent Graph History'),
+    );
+    terminal.input('\x1b[B');
+    terminal.input('\r');
+    await waitFor(() =>
+      plainTerminalOutput(terminal.output()).includes('Agent Graph run #1 · History (read-only)'),
+    );
+
+    assert.deepEqual(requestedGraphIds, ['graph-1']);
+    assert.deepEqual(driver.prompts, []);
     exitMaka(terminal);
     await run;
   });

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2515,10 +2515,13 @@ describe('Maka Pi TUI runner', () => {
       permissionMode: 'ask',
       terminal,
       agentGraphHistory: {
-        listEpochs: async () => [
-          { epoch: 2, graphId: 'graph-2', createdAt: 2, current: true },
-          { epoch: 1, graphId: 'graph-1', createdAt: 1, current: false },
-        ],
+        listEpochs: async () => ({
+          epochs: [
+            { epoch: 2, graphId: 'graph-2', createdAt: 2, current: true },
+            { epoch: 1, graphId: 'graph-1', createdAt: 1, current: false },
+          ],
+          truncated: false,
+        }),
         getSnapshot: async (_rootSessionId, graphId) => {
           requestedGraphIds.push(graphId);
           return historicalGraphSnapshot(graphId);

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -55,6 +55,7 @@ import type {
 import { AUTO_RECAP_DISPLAY_LIMIT_BYTES, shouldAutoRecap } from './session-recap.js';
 import type { InvocableSkillEntry } from '@maka/runtime/skill-invocation';
 import type { AgentGraphClientSnapshot, AgentGraphEpochSummary } from '@maka/runtime-host/protocol';
+import type { AgentGraphEpochDirectory } from '@maka/runtime-host/client';
 import { MakaSkillHighlightEditor } from './skill-highlight-editor.js';
 import { parseGraphCommand, type ParsedGraphCommand } from '@maka/core/graph-command';
 import { parseSwarmCommand, type ParsedSwarmCommand } from '@maka/core/swarm-command';
@@ -173,7 +174,7 @@ export interface MakaPiTuiInput {
   listSkills?: (cwd: string) => Promise<readonly InvocableSkillEntry[]>;
   /** Read-only Runtime Host projection for inspecting current and historical Graph epochs. */
   agentGraphHistory?: {
-    listEpochs(rootSessionId: string): Promise<readonly AgentGraphEpochSummary[]>;
+    listEpochs(rootSessionId: string): Promise<AgentGraphEpochDirectory>;
     getSnapshot(rootSessionId: string, graphId: string): Promise<AgentGraphClientSnapshot>;
   };
   /** Serializes TUI turn and control activity for the attached Session. */
@@ -2271,7 +2272,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (!rootSessionId || !input.agentGraphHistory) {
       throw new Error('Agent Graph history is unavailable on this session driver.');
     }
-    const epochs = await input.agentGraphHistory.listEpochs(rootSessionId);
+    const directory = await input.agentGraphHistory.listEpochs(rootSessionId);
+    // The TUI may have shut down while the page reads were in flight.
+    if (closed) return;
+    const { epochs, truncated } = directory;
     const items: SelectItem[] = epochs.map((entry) => ({
       value: entry.graphId,
       label: `Run #${entry.epoch}${entry.current ? ' · Current' : ''}`,
@@ -2289,7 +2293,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     const epochsByGraphId = new Map(epochs.map((entry) => [entry.graphId, entry]));
     showSelectPicker(
       'Agent Graph History',
-      `${items.length} run${items.length === 1 ? '' : 's'}`,
+      truncated
+        ? `newest ${items.length} runs (history capped)`
+        : `${items.length} run${items.length === 1 ? '' : 's'}`,
       items,
       (item) => {
         const epoch = epochsByGraphId.get(item.value);

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -54,6 +54,7 @@ import type {
 } from './pi-tui-contracts.js';
 import { AUTO_RECAP_DISPLAY_LIMIT_BYTES, shouldAutoRecap } from './session-recap.js';
 import type { InvocableSkillEntry } from '@maka/runtime/skill-invocation';
+import type { AgentGraphClientSnapshot, AgentGraphEpochSummary } from '@maka/runtime-host/protocol';
 import { MakaSkillHighlightEditor } from './skill-highlight-editor.js';
 import { parseGraphCommand, type ParsedGraphCommand } from '@maka/core/graph-command';
 import { parseSwarmCommand, type ParsedSwarmCommand } from '@maka/core/swarm-command';
@@ -170,6 +171,11 @@ export interface MakaPiTuiInput {
   listShellRunUpdates?: (sessionId: string) => Promise<ShellRunUpdate[]>;
   /** Host-owned invocable Skill catalog used for picker, completion, and token highlighting. */
   listSkills?: (cwd: string) => Promise<readonly InvocableSkillEntry[]>;
+  /** Read-only Runtime Host projection for inspecting current and historical Graph epochs. */
+  agentGraphHistory?: {
+    listEpochs(rootSessionId: string): Promise<readonly AgentGraphEpochSummary[]>;
+    getSnapshot(rootSessionId: string, graphId: string): Promise<AgentGraphClientSnapshot>;
+  };
   /** Serializes TUI turn and control activity for the attached Session. */
   turnActivity: MakaPiTuiTurnActivitySurface;
   /** API-key onboarding surface (#1098). When present, /setup runs the wizard,
@@ -2260,6 +2266,56 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const showGraphHistory = async (): Promise<void> => {
+    const rootSessionId = input.driver.getSessionId();
+    if (!rootSessionId || !input.agentGraphHistory) {
+      throw new Error('Agent Graph history is unavailable on this session driver.');
+    }
+    const epochs = await input.agentGraphHistory.listEpochs(rootSessionId);
+    const items: SelectItem[] = epochs.map((entry) => ({
+      value: entry.graphId,
+      label: `Run #${entry.epoch}${entry.current ? ' · Current' : ''}`,
+      description: entry.current ? 'Current graph' : 'History · read-only',
+    }));
+    if (items.length === 0) {
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: 'This session has no Agent Graph runs.',
+      });
+      requestRender();
+      return;
+    }
+    const epochsByGraphId = new Map(epochs.map((entry) => [entry.graphId, entry]));
+    showSelectPicker(
+      'Agent Graph History',
+      `${items.length} run${items.length === 1 ? '' : 's'}`,
+      items,
+      (item) => {
+        const epoch = epochsByGraphId.get(item.value);
+        if (!epoch) return;
+        void runControl(async () => {
+          const graph = await input.agentGraphHistory!.getSnapshot(rootSessionId, epoch.graphId);
+          state.entries.push({
+            kind: 'notice',
+            level: 'info',
+            text: formatAgentGraphHistory(graph, epoch),
+          });
+          requestRender();
+        });
+      },
+      {
+        minPrimaryColumnWidth: 16,
+        maxPrimaryColumnWidth: 28,
+        selectedIndex: Math.max(
+          0,
+          epochs.findIndex((entry) => entry.current),
+        ),
+        hint: '↑↓ move · Enter inspect · Esc close',
+      },
+    );
+  };
+
   const setGraphMode = async (mode: OrchestrationMode) => {
     if (!input.driver.setOrchestrationMode) {
       throw new Error('Graph Mode is unavailable on this session driver.');
@@ -2277,6 +2333,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const runGraphCommand = (command: ParsedGraphCommand, idleMs: number) => {
     if (command.kind === 'status') {
       showGraphStatus();
+      return;
+    }
+    if (command.kind === 'history') {
+      void runControl(showGraphHistory);
       return;
     }
     if (command.kind === 'set_mode') {
@@ -3019,6 +3079,41 @@ function estimateContextTokens(bytes: number): number {
 
 function formatContextCount(value: number): string {
   return value.toLocaleString('en-US');
+}
+
+function formatAgentGraphHistory(
+  graph: AgentGraphClientSnapshot,
+  epoch: AgentGraphEpochSummary,
+): string {
+  const settled = graph.operators.filter((operator) =>
+    ['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status),
+  ).length;
+  const lines = [
+    `Agent Graph run #${epoch.epoch}${epoch.current ? ' · Current' : ' · History (read-only)'}`,
+    `  ${formatAgentGraphStatus(graph.status)} · ${settled}/${graph.operators.length} operators settled`,
+  ];
+  for (const operator of graph.operators) {
+    lines.push(`  ${operator.agentId}: ${operator.status.replaceAll('_', ' ')}`);
+  }
+  if (graph.finish) {
+    lines.push(`  Selected results: ${graph.finish.resultIds.join(', ') || 'none'}`);
+  }
+  if (graph.omitted.operators > 0) {
+    lines.push(`  ${graph.omitted.operators} more operators omitted`);
+  }
+  return lines.join('\n');
+}
+
+function formatAgentGraphStatus(status: AgentGraphClientSnapshot['status']): string {
+  return {
+    empty: 'Awaiting schedule',
+    active: 'Running',
+    closing: 'Finishing',
+    waiting: 'Waiting',
+    stopped: 'Stopped',
+    failed: 'Failed',
+    completed: 'Completed',
+  }[status];
 }
 
 function flattenLinkedSessionTree(

--- a/packages/cli/src/runtime-host-tui-command.ts
+++ b/packages/cli/src/runtime-host-tui-command.ts
@@ -68,6 +68,7 @@ export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<
       permissionMode: 'ask',
       turnActivity: context.turnActivity,
       listSkills: context.listSkills,
+      agentGraphHistory: context.agentGraphHistory,
       onboarding: context.onboarding,
       recap: context.recap,
       ...(context.profile.kind === 'local'

--- a/packages/cli/src/runtime-host-tui-context.ts
+++ b/packages/cli/src/runtime-host-tui-context.ts
@@ -5,12 +5,17 @@ import type { ConnectionCatalogEntry, ConnectionCatalogSnapshot } from '@maka/co
 import { SessionActivityRegistry } from '@maka/runtime/goal-turn-lifecycle';
 import { type InvocableSkillEntry } from '@maka/runtime/skill-invocation';
 import {
+  readRuntimeHostAgentGraphEpochs,
   readRuntimeHostInvocableSkills,
   readRuntimeHostProjects,
   type RuntimeHostConnection,
   type RuntimeHostProfile,
 } from '@maka/runtime-host/client';
-import type { WorkspaceTarget } from '@maka/runtime-host/protocol';
+import type {
+  AgentGraphClientSnapshot,
+  AgentGraphEpochSummary,
+  WorkspaceTarget,
+} from '@maka/runtime-host/protocol';
 import { connectRuntimeHostCli, resolveRuntimeHostCliTarget } from './runtime-host-cli-context.js';
 import type {
   MakaPiTuiTurnActivitySurface,
@@ -38,6 +43,10 @@ export interface RuntimeHostTuiContext {
   readonly modelChoices: readonly ModelChoice[];
   readonly turnActivity: MakaPiTuiTurnActivitySurface;
   readonly listSkills: (cwd: string) => Promise<readonly InvocableSkillEntry[]>;
+  readonly agentGraphHistory: {
+    listEpochs(rootSessionId: string): Promise<readonly AgentGraphEpochSummary[]>;
+    getSnapshot(rootSessionId: string, graphId: string): Promise<AgentGraphClientSnapshot>;
+  };
   readonly recap: SessionRecapGenerator;
   readonly onboarding: ReturnType<typeof createRuntimeHostOnboardingSurface>;
   readonly profile: RuntimeHostProfile;
@@ -101,6 +110,7 @@ export async function createRuntimeHostTuiContext(
             (connected.profile.kind === 'local' ? { kind: 'host_path', path: cwd } : undefined),
           driver.getPermissionMode?.() ?? 'ask',
         ),
+      agentGraphHistory: createRuntimeHostAgentGraphHistory(connection),
       recap: createRuntimeHostRecapGenerator(connection),
       onboarding: createRuntimeHostOnboardingSurface(connection),
       profile: connected.profile,
@@ -110,6 +120,16 @@ export async function createRuntimeHostTuiContext(
     await connection.close().catch(() => undefined);
     throw error;
   }
+}
+
+function createRuntimeHostAgentGraphHistory(
+  connection: RuntimeHostConnection,
+): RuntimeHostTuiContext['agentGraphHistory'] {
+  return {
+    listEpochs: (rootSessionId) => readRuntimeHostAgentGraphEpochs(connection, rootSessionId),
+    getSnapshot: (rootSessionId, graphId) =>
+      connection.request('agent.graph.query', { rootSessionId, graphId }),
+  };
 }
 
 function createRuntimeHostRecapGenerator(connection: RuntimeHostConnection): SessionRecapGenerator {

--- a/packages/cli/src/runtime-host-tui-context.ts
+++ b/packages/cli/src/runtime-host-tui-context.ts
@@ -8,14 +8,11 @@ import {
   readRuntimeHostAgentGraphEpochs,
   readRuntimeHostInvocableSkills,
   readRuntimeHostProjects,
+  type AgentGraphEpochDirectory,
   type RuntimeHostConnection,
   type RuntimeHostProfile,
 } from '@maka/runtime-host/client';
-import type {
-  AgentGraphClientSnapshot,
-  AgentGraphEpochSummary,
-  WorkspaceTarget,
-} from '@maka/runtime-host/protocol';
+import type { AgentGraphClientSnapshot, WorkspaceTarget } from '@maka/runtime-host/protocol';
 import { connectRuntimeHostCli, resolveRuntimeHostCliTarget } from './runtime-host-cli-context.js';
 import type {
   MakaPiTuiTurnActivitySurface,
@@ -44,7 +41,7 @@ export interface RuntimeHostTuiContext {
   readonly turnActivity: MakaPiTuiTurnActivitySurface;
   readonly listSkills: (cwd: string) => Promise<readonly InvocableSkillEntry[]>;
   readonly agentGraphHistory: {
-    listEpochs(rootSessionId: string): Promise<readonly AgentGraphEpochSummary[]>;
+    listEpochs(rootSessionId: string): Promise<AgentGraphEpochDirectory>;
     getSnapshot(rootSessionId: string, graphId: string): Promise<AgentGraphClientSnapshot>;
   };
   readonly recap: SessionRecapGenerator;

--- a/packages/core/src/__tests__/agent-graph-schedule.test.ts
+++ b/packages/core/src/__tests__/agent-graph-schedule.test.ts
@@ -31,6 +31,21 @@ describe('agent graph schedule contract', () => {
     assert.equal(
       isAgentGraphScheduleUpdateRequest({
         ...scheduleRequest(),
+        addWork: Array.from({ length: 2 }, (_, workIndex) => ({
+          ...scheduleRequest().addWork[0],
+          workId: `graph_work_${String(workIndex + 1).repeat(32)}`,
+          inputIds: [],
+          selectedResultInputs: Array.from({ length: 33 }, (_, resultIndex) => ({
+            sourceGraphId: 'graph-previous',
+            resultId: `selected-${workIndex}-${resultIndex}`,
+          })),
+        })),
+      }),
+      false,
+    );
+    assert.equal(
+      isAgentGraphScheduleUpdateRequest({
+        ...scheduleRequest(),
         addWork: [
           {
             ...scheduleRequest().addWork[0],

--- a/packages/core/src/__tests__/agent-graph-schedule.test.ts
+++ b/packages/core/src/__tests__/agent-graph-schedule.test.ts
@@ -7,6 +7,14 @@ import {
 } from '../agent-graph-schedule.js';
 
 describe('agent graph schedule contract', () => {
+  test('accepts explicit selected results from an earlier graph', () => {
+    const request = scheduleRequest();
+    request.addWork[0]!.selectedResultInputs = [
+      { sourceGraphId: 'graph-previous', resultId: 'selected-result' },
+    ];
+    assert.equal(isAgentGraphScheduleUpdateRequest(request), true);
+  });
+
   test('rejects ambiguous, duplicate, empty, and add-plus-finish updates', () => {
     assert.equal(
       isAgentGraphScheduleUpdateRequest({
@@ -15,6 +23,33 @@ describe('agent graph schedule contract', () => {
           {
             ...scheduleRequest().addWork[0],
             target: { kind: 'agent', agentId: '' },
+          },
+        ],
+      }),
+      false,
+    );
+    assert.equal(
+      isAgentGraphScheduleUpdateRequest({
+        ...scheduleRequest(),
+        addWork: [
+          {
+            ...scheduleRequest().addWork[0],
+            selectedResultInputs: [{ sourceGraphId: 'graph-previous', resultId: 'result-1' }],
+          },
+        ],
+      }),
+      false,
+    );
+    assert.equal(
+      isAgentGraphScheduleUpdateRequest({
+        ...scheduleRequest(),
+        addWork: [
+          {
+            ...scheduleRequest().addWork[0],
+            selectedResultInputs: [
+              { sourceGraphId: 'graph-previous', resultId: 'selected-result' },
+              { sourceGraphId: 'graph-previous', resultId: 'selected-result' },
+            ],
           },
         ],
       }),

--- a/packages/core/src/__tests__/graph-command.test.ts
+++ b/packages/core/src/__tests__/graph-command.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseGraphCommand } from '../graph-command.js';
+
+test('parses Graph lifecycle controls without consuming ordinary one-shot tasks', () => {
+  assert.deepEqual(parseGraphCommand('/graph'), { kind: 'status' });
+  assert.deepEqual(parseGraphCommand('/graph history'), { kind: 'history' });
+  assert.deepEqual(parseGraphCommand('/graph on'), { kind: 'set_mode', mode: 'graph' });
+  assert.deepEqual(parseGraphCommand('/graph investigate history'), {
+    kind: 'run_once',
+    task: 'investigate history',
+  });
+  assert.equal(parseGraphCommand('/graphical history'), null);
+});

--- a/packages/core/src/agent-graph-epoch.ts
+++ b/packages/core/src/agent-graph-epoch.ts
@@ -31,6 +31,13 @@ export interface AgentGraphEpochPageRequest {
 export interface AgentGraphEpochPage {
   readonly epochs: readonly AgentGraphEpochBinding[];
   readonly nextBeforeEpoch: number | null;
+  /**
+   * Current epoch observed by the same read as the page rows, or null when the
+   * store holds no durable rows for the root Session. Keeping this on the page
+   * prevents a rollover between two reads from splitting the current marker
+   * from the directory it annotates.
+   */
+  readonly currentEpoch: number | null;
 }
 
 /**

--- a/packages/core/src/agent-graph-epoch.ts
+++ b/packages/core/src/agent-graph-epoch.ts
@@ -22,6 +22,17 @@ export interface AdvanceAgentGraphEpochRequest {
   readonly nextGraphId: string;
 }
 
+export interface AgentGraphEpochPageRequest {
+  readonly rootSessionId: string;
+  readonly beforeEpoch?: number;
+  readonly limit: number;
+}
+
+export interface AgentGraphEpochPage {
+  readonly epochs: readonly AgentGraphEpochBinding[];
+  readonly nextBeforeEpoch: number | null;
+}
+
 /**
  * Root-to-graph identity authority.
  *
@@ -34,6 +45,8 @@ export interface AgentGraphEpochStore {
     request: ResolveAgentGraphEpochRequest,
   ): Promise<AgentGraphEpochBinding>;
   advanceAgentGraphEpoch(request: AdvanceAgentGraphEpochRequest): Promise<AgentGraphEpochBinding>;
+  readAgentGraphEpochByGraphId(graphId: string): Promise<AgentGraphEpochBinding | undefined>;
+  listAgentGraphEpochPage(request: AgentGraphEpochPageRequest): Promise<AgentGraphEpochPage>;
   listAgentGraphEpochs(rootSessionId: string): Promise<AgentGraphEpochBinding[]>;
 }
 

--- a/packages/core/src/agent-graph-schedule.ts
+++ b/packages/core/src/agent-graph-schedule.ts
@@ -11,6 +11,7 @@ export const AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION = 1 as const;
 export const AGENT_GRAPH_SCHEDULE_MAX_ADD_WORK = 32;
 export const AGENT_GRAPH_SCHEDULE_MAX_STOP = 20;
 export const AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS = 64;
+export const AGENT_GRAPH_SCHEDULE_MAX_SELECTED_RESULT_INPUTS = 64;
 export const AGENT_GRAPH_SCHEDULE_MAX_RESULT_IDS = 64;
 export const AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS = 60_000;
 export const AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS = 4_000;
@@ -187,6 +188,8 @@ export function isAgentGraphScheduleUpdateRequest(
     request.addWork.length <= AGENT_GRAPH_SCHEDULE_MAX_ADD_WORK &&
     request.addWork.every(isScheduledWork) &&
     unique(request.addWork.map((work) => work.workId)) &&
+    request.addWork.reduce((count, work) => count + (work.selectedResultInputs?.length ?? 0), 0) <=
+      AGENT_GRAPH_SCHEDULE_MAX_SELECTED_RESULT_INPUTS &&
     Array.isArray(request.stop) &&
     request.stop.length <= AGENT_GRAPH_SCHEDULE_MAX_STOP &&
     request.stop.every(isStoppedTarget) &&

--- a/packages/core/src/agent-graph-schedule.ts
+++ b/packages/core/src/agent-graph-schedule.ts
@@ -43,7 +43,14 @@ export interface AgentGraphScheduledWork {
   target: AgentGraphWorkTarget;
   instruction: string;
   inputIds: string[];
+  /** Explicit, immutable results selected from completed earlier epochs. */
+  selectedResultInputs?: AgentGraphSelectedResultInput[];
   replaces?: string;
+}
+
+export interface AgentGraphSelectedResultInput {
+  sourceGraphId: string;
+  resultId: string;
 }
 
 export interface AgentGraphStoppedTarget {
@@ -231,6 +238,11 @@ export function decodeAgentGraphScheduleUpdate(value: unknown): AgentGraphSchedu
       target: { ...work.target },
       instruction: work.instruction,
       inputIds: [...work.inputIds],
+      ...(work.selectedResultInputs
+        ? {
+            selectedResultInputs: work.selectedResultInputs.map((input) => ({ ...input })),
+          }
+        : {}),
       ...(work.replaces ? { replaces: work.replaces } : {}),
     })),
     stop: value.stop.map((stopped) => ({ ...stopped })),
@@ -274,21 +286,38 @@ function isScheduledWork(value: unknown): value is AgentGraphScheduledWork {
       'target',
       'instruction',
       'inputIds',
+      ...(hasOwn(value, 'selectedResultInputs') ? ['selectedResultInputs'] : []),
       ...(hasOwn(value, 'replaces') ? ['replaces'] : []),
     ])
   ) {
     return false;
   }
+  const inputIds = Array.isArray(value.inputIds) ? value.inputIds : [];
   return (
     typeof value.workId === 'string' &&
     /^graph_work_[a-f0-9]{32}$/.test(value.workId) &&
     isWorkTarget(value.target) &&
     isBoundedText(value.instruction, AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS) &&
     Array.isArray(value.inputIds) &&
-    value.inputIds.length <= AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS &&
-    value.inputIds.every(isOpaqueIdentity) &&
-    unique(value.inputIds) &&
+    inputIds.length <= AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS &&
+    inputIds.every(isOpaqueIdentity) &&
+    unique(inputIds) &&
+    (value.selectedResultInputs === undefined ||
+      (Array.isArray(value.selectedResultInputs) &&
+        value.selectedResultInputs.length > 0 &&
+        inputIds.length + value.selectedResultInputs.length <= AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS &&
+        value.selectedResultInputs.every(isSelectedResultInput) &&
+        unique(value.selectedResultInputs.map((input) => input.resultId)) &&
+        value.selectedResultInputs.every((input) => !inputIds.includes(input.resultId)))) &&
     (value.replaces === undefined || isOpaqueIdentity(value.replaces))
+  );
+}
+
+function isSelectedResultInput(value: unknown): value is AgentGraphSelectedResultInput {
+  return (
+    isExactRecord(value, ['sourceGraphId', 'resultId']) &&
+    isOpaqueIdentity(value.sourceGraphId) &&
+    isOpaqueIdentity(value.resultId)
   );
 }
 

--- a/packages/core/src/graph-command.ts
+++ b/packages/core/src/graph-command.ts
@@ -2,6 +2,7 @@ import type { OrchestrationMode } from './orchestration.js';
 
 export type ParsedGraphCommand =
   | { kind: 'status' }
+  | { kind: 'history' }
   | { kind: 'set_mode'; mode: OrchestrationMode }
   | { kind: 'run_once'; task: string };
 
@@ -13,6 +14,7 @@ export function parseGraphCommand(input: string): ParsedGraphCommand | null {
 
   const tail = trimmed.slice(commandToken.length).trim();
   if (!tail || tail === 'status') return { kind: 'status' };
+  if (tail === 'history') return { kind: 'history' };
   if (tail === 'on') return { kind: 'set_mode', mode: 'graph' };
   if (tail === 'off') return { kind: 'set_mode', mode: 'default' };
   return { kind: 'run_once', task: tail };

--- a/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
@@ -252,6 +252,13 @@ describe('Host Agent Graph coordinator', () => {
       ],
     );
     assert.equal(second.result.nextBeforeEpoch, null);
+
+    const ahead = await coordinator.handlers['agent.graph.epochs.query'](
+      { rootSessionId: 'root-1', beforeEpoch: 999 },
+      context(),
+    );
+    assert.equal(ahead.ok, false);
+    if (!ahead.ok) assert.equal(ahead.error.code, 'invalid_request');
     coordinator.close();
   });
 

--- a/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
@@ -31,8 +31,23 @@ describe('Host Agent Graph coordinator', () => {
     const invalidations: unknown[] = [];
     const authority = {
       currentGraphId: async () => snapshot.graphId,
+      listGraphEpochPage: async () => ({
+        epochs: [
+          {
+            schemaVersion: 1 as const,
+            rootSessionId: 'root-1',
+            epoch: 1,
+            graphId: snapshot.graphId,
+            createdAt: 0,
+          },
+        ],
+        nextBeforeEpoch: null,
+        currentEpoch: 1,
+      }),
       getSnapshot: async () => snapshot,
+      getGraphSnapshot: async () => snapshot,
       inspectOperator: async () => inspection,
+      inspectGraphOperator: async () => inspection,
       subscribeAll: (candidate: AgentGraphClientChangedListener) => {
         listener = candidate;
         return () => {
@@ -58,6 +73,18 @@ describe('Host Agent Graph coordinator', () => {
     assert.deepEqual(queried.result.work[0]?.target, {
       kind: 'preset',
       presetId: 'deepseek-flash-reader',
+    });
+    const epochs = await coordinator.handlers['agent.graph.epochs.query'](
+      { rootSessionId: 'root-1' },
+      context(),
+    );
+    assert.deepEqual(epochs, {
+      ok: true,
+      result: {
+        rootSessionId: 'root-1',
+        epochs: [{ epoch: 1, graphId: snapshot.graphId, createdAt: 0, current: true }],
+        nextBeforeEpoch: null,
+      },
     });
 
     const inspected = await coordinator.handlers['agent.graph.operator.query'](
@@ -99,6 +126,9 @@ describe('Host Agent Graph coordinator', () => {
   test('returns stable root, archive, operator, and cursor failures', async () => {
     const authority = {
       currentGraphId: async () => agentGraphIdForRootSession('root-1'),
+      listGraphEpochPage: async () => {
+        throw new AgentGraphClientOperationError('not_found', 'Session was not found');
+      },
       getSnapshot: async (_rootSessionId: string, options?: { terminalCursor?: string }) => {
         throw new AgentGraphClientOperationError(
           options?.terminalCursor ? 'invalid_request' : 'operation_conflict',
@@ -107,7 +137,13 @@ describe('Host Agent Graph coordinator', () => {
             : 'Agent graph client operations are available only to root Sessions',
         );
       },
+      getGraphSnapshot: async () => {
+        throw new AgentGraphClientOperationError('not_found', 'Agent graph was not found');
+      },
       inspectOperator: async () => {
+        throw new AgentGraphClientOperationError('not_found', 'Agent graph operator was not found');
+      },
+      inspectGraphOperator: async () => {
         throw new AgentGraphClientOperationError('not_found', 'Agent graph operator was not found');
       },
       subscribeAll: () => () => undefined,
@@ -151,6 +187,72 @@ describe('Host Agent Graph coordinator', () => {
     assert.equal(invalidCursor.ok, false);
     if (!invalidCursor.ok) assert.equal(invalidCursor.error.code, 'invalid_request');
     child.close();
+  });
+
+  test('pages graph epochs newest-first without losing current identity', async () => {
+    const source = graphSnapshot();
+    const epochs = Array.from({ length: 35 }, (_, index) => ({
+      schemaVersion: 1 as const,
+      rootSessionId: 'root-1',
+      epoch: index + 1,
+      graphId: `agent_graph_${index + 1}`,
+      createdAt: index,
+    }));
+    const authority = {
+      currentGraphId: async () => epochs.at(-1)!.graphId,
+      listGraphEpochPage: async (
+        _rootSessionId: string,
+        options: { beforeEpoch?: number; limit: number },
+      ) => {
+        const eligible = epochs.filter(
+          (entry) => entry.epoch < (options.beforeEpoch ?? Number.POSITIVE_INFINITY),
+        );
+        const page = eligible.slice(-options.limit).reverse();
+        return {
+          epochs: page,
+          nextBeforeEpoch: eligible.length > page.length ? page.at(-1)!.epoch : null,
+          currentEpoch: 35,
+        };
+      },
+      getSnapshot: async () => source,
+      getGraphSnapshot: async () => source,
+      inspectOperator: async () => operatorInspection(source),
+      inspectGraphOperator: async () => operatorInspection(source),
+      subscribeAll: () => () => undefined,
+    } satisfies GraphAuthority;
+    const coordinator = new HostAgentGraphCoordinator({
+      authority,
+      continuity: { enqueueAgentGraphChanged: () => undefined },
+      stopExecution: async () => undefined,
+    });
+
+    const first = await coordinator.handlers['agent.graph.epochs.query'](
+      { rootSessionId: 'root-1' },
+      context(),
+    );
+    assert.equal(first.ok, true);
+    if (!first.ok) return;
+    assert.equal(first.result.epochs.length, 32);
+    assert.equal(first.result.epochs[0]?.epoch, 35);
+    assert.equal(first.result.epochs[0]?.current, true);
+    assert.equal(first.result.nextBeforeEpoch, 4);
+
+    const second = await coordinator.handlers['agent.graph.epochs.query'](
+      { rootSessionId: 'root-1', beforeEpoch: first.result.nextBeforeEpoch! },
+      context(),
+    );
+    assert.equal(second.ok, true);
+    if (!second.ok) return;
+    assert.deepEqual(
+      second.result.epochs.map(({ epoch, current }) => ({ epoch, current })),
+      [
+        { epoch: 3, current: false },
+        { epoch: 2, current: false },
+        { epoch: 1, current: false },
+      ],
+    );
+    assert.equal(second.result.nextBeforeEpoch, null);
+    coordinator.close();
   });
 
   test('bounds large snapshots while preserving omission and terminal continuation', () => {
@@ -226,7 +328,13 @@ describe('Host Agent Graph coordinator', () => {
 
 type GraphAuthority = Pick<
   AgentGraphCoordinator,
-  'currentGraphId' | 'getSnapshot' | 'inspectOperator' | 'subscribeAll'
+  | 'currentGraphId'
+  | 'getGraphSnapshot'
+  | 'getSnapshot'
+  | 'inspectGraphOperator'
+  | 'inspectOperator'
+  | 'listGraphEpochPage'
+  | 'subscribeAll'
 >;
 
 function graphSnapshot(): RuntimeAgentGraphClientSnapshot {

--- a/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-coordinator.test.ts
@@ -331,6 +331,58 @@ describe('Host Agent Graph coordinator', () => {
     assert.equal(JSON.stringify(projected).includes('secret'), false);
     assert.doesNotThrow(() => decodeAgentGraphClientSnapshot(projected));
   });
+
+  test('rejects work whose current and selected historical inputs exceed the combined cap', () => {
+    const work = {
+      workId: 'work-1',
+      target: { kind: 'agent', agentId: 'local-read' },
+      inputIds: Array.from({ length: 64 }, (_, index) => `input-${index}`),
+      selectedResultInputs: [{ sourceGraphId: 'graph-prev', resultId: 'result-1' }],
+      status: 'requested',
+      instructionPreview: 'continue',
+      instructionTruncated: false,
+      revision: 1,
+      committedAt: 1,
+    };
+    const frame = {
+      schemaVersion: 1,
+      rootSessionId: 'session-root',
+      graphId: 'graph-1',
+      orchestrationMode: 'graph',
+      snapshotVersion: `sha256:${'a'.repeat(64)}`,
+      status: 'active',
+      scheduleRevision: 1,
+      topologyFingerprint: `sha256:${'b'.repeat(64)}`,
+      closed: false,
+      operators: [],
+      edges: [],
+      work: [work],
+      reconciliationFailures: [],
+      stoppedTargets: [],
+      claims: [],
+      recentControlDecisions: [],
+      recentActivity: [],
+      terminalHistory: { records: [] },
+      omitted: {
+        operators: 0,
+        edges: 0,
+        work: 0,
+        reconciliationFailures: 0,
+        stoppedTargets: 0,
+        claims: 0,
+        controlDecisions: 0,
+        recentActivity: 0,
+      },
+    };
+    // The durable schedule contract caps current + selected historical inputs
+    // combined at 64; 64 + 1 must not decode (#2992 P3 follow-up).
+    assert.throws(() => decodeAgentGraphClientSnapshot(frame), /combined current and historical/);
+    const atCap = {
+      ...frame,
+      work: [{ ...work, inputIds: work.inputIds.slice(0, 63) }],
+    };
+    assert.doesNotThrow(() => decodeAgentGraphClientSnapshot(atCap));
+  });
 });
 
 type GraphAuthority = Pick<

--- a/packages/runtime-host/src/__tests__/agent-graph-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-protocol.test.ts
@@ -6,6 +6,8 @@ import {
   AGENT_GRAPH_OPERATION_SPECS,
   AGENT_GRAPH_RESULT_MAX_BYTES,
   decodeAgentGraphClientSnapshot,
+  decodeAgentGraphEpochListInput,
+  decodeAgentGraphEpochListResult,
   decodeAgentGraphOperatorInspection,
   decodeAgentGraphOperatorQueryInput,
   decodeAgentGraphQueryInput,
@@ -20,16 +22,42 @@ const fingerprint = `sha256:${'a'.repeat(64)}` as const;
 
 describe('Agent Graph Client protocol', () => {
   test('round-trips canonical inputs and bounded projections', () => {
+    assert.deepEqual(decodeAgentGraphEpochListInput({ rootSessionId: 'root-1', beforeEpoch: 2 }), {
+      rootSessionId: 'root-1',
+      beforeEpoch: 2,
+    });
+    assert.deepEqual(
+      decodeAgentGraphEpochListResult({
+        rootSessionId: 'root-1',
+        epochs: [
+          { epoch: 2, graphId: 'agent_graph_2', createdAt: 10, current: true },
+          { epoch: 1, graphId: 'agent_graph_1', createdAt: 0, current: false },
+        ],
+        nextBeforeEpoch: null,
+      }).epochs.map(({ epoch, graphId, current }) => ({ epoch, graphId, current })),
+      [
+        { epoch: 2, graphId: 'agent_graph_2', current: true },
+        { epoch: 1, graphId: 'agent_graph_1', current: false },
+      ],
+    );
     assert.deepEqual(decodeAgentGraphQueryInput({ rootSessionId: 'root-1' }), {
       rootSessionId: 'root-1',
     });
     assert.deepEqual(
-      decodeAgentGraphQueryInput({ rootSessionId: 'root-1', terminalCursor: 'Y3Vyc29y' }),
-      { rootSessionId: 'root-1', terminalCursor: 'Y3Vyc29y' },
+      decodeAgentGraphQueryInput({
+        rootSessionId: 'root-1',
+        graphId: 'agent_graph_1',
+        terminalCursor: 'Y3Vyc29y',
+      }),
+      { rootSessionId: 'root-1', graphId: 'agent_graph_1', terminalCursor: 'Y3Vyc29y' },
     );
     assert.deepEqual(
-      decodeAgentGraphOperatorQueryInput({ rootSessionId: 'root-1', operatorId: 'operator:1' }),
-      { rootSessionId: 'root-1', operatorId: 'operator:1' },
+      decodeAgentGraphOperatorQueryInput({
+        rootSessionId: 'root-1',
+        graphId: 'agent_graph_1',
+        operatorId: 'operator:1',
+      }),
+      { rootSessionId: 'root-1', graphId: 'agent_graph_1', operatorId: 'operator:1' },
     );
     assert.deepEqual(decodeAgentGraphStopInput({ rootSessionId: 'root-1' }), {
       rootSessionId: 'root-1',
@@ -55,6 +83,26 @@ describe('Agent Graph Client protocol', () => {
 
   test('rejects unknown nested fields, invalid correlation, and unbounded pages', () => {
     const snapshot = graphSnapshot();
+    assertInvalid(() =>
+      decodeAgentGraphEpochListResult({
+        rootSessionId: 'root-1',
+        epochs: [{ epoch: 2, graphId: 'agent_graph_2', createdAt: 10, current: true }],
+        nextBeforeEpoch: 1,
+      }),
+    );
+    assertInvalid(() =>
+      decodeAgentGraphEpochListInput({ rootSessionId: 'root-1', beforeEpoch: 0 }),
+    );
+    assertInvalid(() =>
+      AGENT_GRAPH_OPERATION_SPECS['agent.graph.epochs.query'].assertOutputForInput?.(
+        { rootSessionId: 'root-1', beforeEpoch: 2 },
+        {
+          rootSessionId: 'root-1',
+          epochs: [{ epoch: 2, graphId: 'agent_graph_2', createdAt: 10, current: true }],
+          nextBeforeEpoch: null,
+        },
+      ),
+    );
     assertInvalid(() =>
       decodeAgentGraphClientSnapshot({
         ...snapshot,
@@ -87,6 +135,12 @@ describe('Agent Graph Client protocol', () => {
     assertInvalid(() =>
       AGENT_GRAPH_OPERATION_SPECS['agent.graph.query'].assertOutputForInput?.(
         { rootSessionId: 'another-root' },
+        snapshot,
+      ),
+    );
+    assertInvalid(() =>
+      AGENT_GRAPH_OPERATION_SPECS['agent.graph.query'].assertOutputForInput?.(
+        { rootSessionId: 'root-1', graphId: 'another-graph' },
         snapshot,
       ),
     );

--- a/packages/runtime-host/src/__tests__/agent-graph-reader.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-reader.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { readRuntimeHostAgentGraphEpochs } from '../client/agent-graph-reader.js';
+
+test('collects Agent Graph epoch pages newest-first', async () => {
+  const inputs: unknown[] = [];
+  const epochs = await readRuntimeHostAgentGraphEpochs(
+    {
+      request: async (_operation, input) => {
+        inputs.push(input);
+        return (input as { beforeEpoch?: number }).beforeEpoch === undefined
+          ? {
+              rootSessionId: 'session-1',
+              epochs: [{ epoch: 2, graphId: 'graph-2', createdAt: 2, current: true }],
+              nextBeforeEpoch: 2,
+            }
+          : {
+              rootSessionId: 'session-1',
+              epochs: [{ epoch: 1, graphId: 'graph-1', createdAt: 1, current: false }],
+              nextBeforeEpoch: null,
+            };
+      },
+    },
+    'session-1',
+  );
+
+  assert.deepEqual(
+    epochs.map(({ graphId }) => graphId),
+    ['graph-2', 'graph-1'],
+  );
+  assert.deepEqual(inputs, [
+    { rootSessionId: 'session-1' },
+    { rootSessionId: 'session-1', beforeEpoch: 2 },
+  ]);
+});
+
+test('rejects a repeated Agent Graph epoch cursor', async () => {
+  await assert.rejects(
+    readRuntimeHostAgentGraphEpochs(
+      {
+        request: async () => ({
+          rootSessionId: 'session-1',
+          epochs: [],
+          nextBeforeEpoch: 2,
+        }),
+      },
+      'session-1',
+    ),
+    /repeated cursor/,
+  );
+});

--- a/packages/runtime-host/src/__tests__/agent-graph-reader.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-reader.test.ts
@@ -4,7 +4,7 @@ import { readRuntimeHostAgentGraphEpochs } from '../client/agent-graph-reader.js
 
 test('collects Agent Graph epoch pages newest-first', async () => {
   const inputs: unknown[] = [];
-  const epochs = await readRuntimeHostAgentGraphEpochs(
+  const { epochs, truncated } = await readRuntimeHostAgentGraphEpochs(
     {
       request: async (_operation, input) => {
         inputs.push(input);
@@ -24,6 +24,7 @@ test('collects Agent Graph epoch pages newest-first', async () => {
     'session-1',
   );
 
+  assert.equal(truncated, false);
   assert.deepEqual(
     epochs.map(({ graphId }) => graphId),
     ['graph-2', 'graph-1'],
@@ -48,4 +49,34 @@ test('rejects a repeated Agent Graph epoch cursor', async () => {
     ),
     /repeated cursor/,
   );
+});
+
+test('returns a clearly truncated directory at the page bound', async () => {
+  let nextEpoch = 10_000;
+  const { epochs, truncated } = await readRuntimeHostAgentGraphEpochs(
+    {
+      request: async (_operation, input) => {
+        const before = (input as { beforeEpoch?: number }).beforeEpoch ?? nextEpoch + 1;
+        nextEpoch = before - 1;
+        return {
+          rootSessionId: 'session-1',
+          epochs: [
+            {
+              epoch: nextEpoch,
+              graphId: `graph-${nextEpoch}`,
+              createdAt: nextEpoch,
+              current: false,
+            },
+          ],
+          nextBeforeEpoch: nextEpoch,
+        };
+      },
+    },
+    'session-1',
+  );
+
+  // The bound stays, but the result says so instead of throwing away a valid
+  // directory: 64 pages × 1 entry each.
+  assert.equal(truncated, true);
+  assert.equal(epochs.length, 64);
 });

--- a/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-two-client-uds.test.ts
@@ -157,7 +157,13 @@ test('two Clients query and control one Agent graph through Session invalidation
 
 type GraphAuthority = Pick<
   AgentGraphCoordinator,
-  'currentGraphId' | 'getSnapshot' | 'inspectOperator' | 'subscribeAll'
+  | 'currentGraphId'
+  | 'getGraphSnapshot'
+  | 'getSnapshot'
+  | 'inspectGraphOperator'
+  | 'inspectOperator'
+  | 'listGraphEpochPage'
+  | 'subscribeAll'
 >;
 
 class FakeAgentGraphAuthority implements GraphAuthority {
@@ -169,11 +175,35 @@ class FakeAgentGraphAuthority implements GraphAuthority {
     return this.#snapshot.graphId;
   }
 
+  async listGraphEpochPage() {
+    return {
+      epochs: [
+        {
+          schemaVersion: 1 as const,
+          rootSessionId: ROOT_SESSION_ID,
+          epoch: 1,
+          graphId: this.#snapshot.graphId,
+          createdAt: 0,
+        },
+      ],
+      nextBeforeEpoch: null,
+      currentEpoch: 1,
+    };
+  }
+
   async getSnapshot(): Promise<AgentGraphClientSnapshot> {
     return structuredClone(this.#snapshot);
   }
 
+  async getGraphSnapshot(): Promise<AgentGraphClientSnapshot> {
+    return structuredClone(this.#snapshot);
+  }
+
   async inspectOperator(): Promise<AgentGraphOperatorInspection> {
+    return inspection(this.#snapshot);
+  }
+
+  async inspectGraphOperator(): Promise<AgentGraphOperatorInspection> {
     return inspection(this.#snapshot);
   }
 

--- a/packages/runtime-host/src/client/agent-graph-reader.ts
+++ b/packages/runtime-host/src/client/agent-graph-reader.ts
@@ -1,0 +1,37 @@
+import type {
+  AgentGraphEpochListInput,
+  AgentGraphEpochListResult,
+  AgentGraphEpochSummary,
+} from '../protocol/index.js';
+
+const MAX_EPOCH_PAGES = 64;
+export interface AgentGraphReadConnection {
+  request(
+    operation: 'agent.graph.epochs.query',
+    input: AgentGraphEpochListInput,
+  ): Promise<AgentGraphEpochListResult>;
+}
+
+/** Collect one bounded, newest-first directory of Graph epochs from the Host. */
+export async function readRuntimeHostAgentGraphEpochs(
+  connection: AgentGraphReadConnection,
+  rootSessionId: string,
+): Promise<readonly AgentGraphEpochSummary[]> {
+  const epochs: AgentGraphEpochSummary[] = [];
+  const cursors = new Set<number>();
+  let beforeEpoch: number | undefined;
+  for (let pageCount = 0; pageCount < MAX_EPOCH_PAGES; pageCount += 1) {
+    const page = await connection.request('agent.graph.epochs.query', {
+      rootSessionId,
+      ...(beforeEpoch === undefined ? {} : { beforeEpoch }),
+    });
+    epochs.push(...page.epochs);
+    if (page.nextBeforeEpoch === null) return epochs;
+    if (cursors.has(page.nextBeforeEpoch)) {
+      throw new Error('Agent graph epoch query returned a repeated cursor');
+    }
+    cursors.add(page.nextBeforeEpoch);
+    beforeEpoch = page.nextBeforeEpoch;
+  }
+  throw new Error('Agent graph epoch query exceeded the page limit');
+}

--- a/packages/runtime-host/src/client/agent-graph-reader.ts
+++ b/packages/runtime-host/src/client/agent-graph-reader.ts
@@ -5,6 +5,18 @@ import type {
 } from '../protocol/index.js';
 
 const MAX_EPOCH_PAGES = 64;
+
+/** One bounded, newest-first directory of Graph epochs read from the Host. */
+export interface AgentGraphEpochDirectory {
+  readonly epochs: readonly AgentGraphEpochSummary[];
+  /**
+   * True when the read hit its page bound while more valid pages remained.
+   * Consumers must surface this instead of presenting the directory as
+   * complete.
+   */
+  readonly truncated: boolean;
+}
+
 export interface AgentGraphReadConnection {
   request(
     operation: 'agent.graph.epochs.query',
@@ -16,7 +28,7 @@ export interface AgentGraphReadConnection {
 export async function readRuntimeHostAgentGraphEpochs(
   connection: AgentGraphReadConnection,
   rootSessionId: string,
-): Promise<readonly AgentGraphEpochSummary[]> {
+): Promise<AgentGraphEpochDirectory> {
   const epochs: AgentGraphEpochSummary[] = [];
   const cursors = new Set<number>();
   let beforeEpoch: number | undefined;
@@ -26,12 +38,12 @@ export async function readRuntimeHostAgentGraphEpochs(
       ...(beforeEpoch === undefined ? {} : { beforeEpoch }),
     });
     epochs.push(...page.epochs);
-    if (page.nextBeforeEpoch === null) return epochs;
+    if (page.nextBeforeEpoch === null) return { epochs, truncated: false };
     if (cursors.has(page.nextBeforeEpoch)) {
       throw new Error('Agent graph epoch query returned a repeated cursor');
     }
     cursors.add(page.nextBeforeEpoch);
     beforeEpoch = page.nextBeforeEpoch;
   }
-  throw new Error('Agent graph epoch query exceeded the page limit');
+  return { epochs, truncated: true };
 }

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -67,7 +67,11 @@ export {
 } from './connect-or-spawn.js';
 export { runHostedExecution } from './hosted-execution.js';
 export { type ClientCapabilityProvider } from './client-capability.js';
-export { startRuntimeHostCapabilityProviderService } from './capability-provider-service.js';
+export { readRuntimeHostAgentGraphEpochs } from './agent-graph-reader.js';
+export {
+  startRuntimeHostCapabilityProviderService,
+  type RuntimeHostCapabilityProviderService,
+} from './capability-provider-service.js';
 export { loadOrCreateRuntimeHostClientInstanceId } from './client-instance-identity.js';
 export { consumeAccessCredentialDelivery } from '../control/access-credential-delivery.js';
 export {

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -67,7 +67,10 @@ export {
 } from './connect-or-spawn.js';
 export { runHostedExecution } from './hosted-execution.js';
 export { type ClientCapabilityProvider } from './client-capability.js';
-export { readRuntimeHostAgentGraphEpochs } from './agent-graph-reader.js';
+export {
+  readRuntimeHostAgentGraphEpochs,
+  type AgentGraphEpochDirectory,
+} from './agent-graph-reader.js';
 export {
   startRuntimeHostCapabilityProviderService,
   type RuntimeHostCapabilityProviderService,

--- a/packages/runtime-host/src/protocol/agent-graph.ts
+++ b/packages/runtime-host/src/protocol/agent-graph.ts
@@ -32,6 +32,7 @@ export const AGENT_GRAPH_MAX_INSPECTION_WORK = 32;
 export const AGENT_GRAPH_MAX_INSPECTION_CLAIMS = 32;
 export const AGENT_GRAPH_MAX_INSPECTION_ACTIVATIONS = 32;
 export const AGENT_GRAPH_MAX_INSPECTION_RECORDS = 32;
+export const AGENT_GRAPH_EPOCH_PAGE_SIZE = 32;
 
 const AGENT_GRAPH_INSTRUCTION_PREVIEW_MAX_BYTES = 2 * 1024;
 const AGENT_GRAPH_REASON_MAX_BYTES = 12 * 1024;
@@ -300,11 +301,31 @@ export interface AgentGraphOperatorInspection {
 
 export interface AgentGraphQueryInput {
   readonly rootSessionId: string;
+  readonly graphId?: string;
   readonly terminalCursor?: string;
+}
+
+export interface AgentGraphEpochListInput {
+  readonly rootSessionId: string;
+  readonly beforeEpoch?: number;
+}
+
+export interface AgentGraphEpochSummary {
+  readonly epoch: number;
+  readonly graphId: string;
+  readonly createdAt: number;
+  readonly current: boolean;
+}
+
+export interface AgentGraphEpochListResult {
+  readonly rootSessionId: string;
+  readonly epochs: readonly AgentGraphEpochSummary[];
+  readonly nextBeforeEpoch: number | null;
 }
 
 export interface AgentGraphOperatorQueryInput {
   readonly rootSessionId: string;
+  readonly graphId?: string;
   readonly operatorId: string;
 }
 
@@ -318,6 +339,34 @@ export interface AgentGraphStopResult {
 }
 
 export const AGENT_GRAPH_OPERATION_SPECS = {
+  'agent.graph.epochs.query': defineOperation<
+    AgentGraphEpochListInput,
+    AgentGraphEpochListResult,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeAgentGraphEpochListInput,
+    decodeOutput: decodeAgentGraphEpochListResult,
+    assertOutputForInput: (input, output) => {
+      assertRootIdentity(input.rootSessionId, output);
+      if (input.beforeEpoch === undefined) {
+        if (output.epochs.filter((entry) => entry.current).length !== 1) {
+          throw invalidProtocolFrame(
+            'Agent graph first epoch page must identify the current epoch',
+          );
+        }
+      } else {
+        if (output.epochs.some((entry) => entry.current)) {
+          throw invalidProtocolFrame('Agent graph historical epoch pages cannot be current');
+        }
+        if (output.epochs.some((entry) => entry.epoch >= input.beforeEpoch!)) {
+          throw invalidProtocolFrame('Agent graph epoch page did not advance its cursor');
+        }
+      }
+    },
+  }),
   'agent.graph.query': defineOperation<
     AgentGraphQueryInput,
     AgentGraphClientSnapshot,
@@ -328,7 +377,12 @@ export const AGENT_GRAPH_OPERATION_SPECS = {
     errors: QUERY_ERRORS,
     decodeInput: decodeAgentGraphQueryInput,
     decodeOutput: decodeAgentGraphClientSnapshot,
-    assertOutputForInput: (input, output) => assertRootIdentity(input.rootSessionId, output),
+    assertOutputForInput: (input, output) => {
+      assertRootIdentity(input.rootSessionId, output);
+      if (input.graphId !== undefined && input.graphId !== output.graphId) {
+        throw invalidProtocolFrame('Agent graph result changed request graph identity');
+      }
+    },
   }),
   'agent.graph.operator.query': defineOperation<
     AgentGraphOperatorQueryInput,
@@ -342,6 +396,9 @@ export const AGENT_GRAPH_OPERATION_SPECS = {
     decodeOutput: decodeAgentGraphOperatorInspection,
     assertOutputForInput: (input, output) => {
       assertRootIdentity(input.rootSessionId, output);
+      if (input.graphId !== undefined && input.graphId !== output.graphId) {
+        throw invalidProtocolFrame('Agent graph operator result changed request graph identity');
+      }
       if (output.operator.operatorId !== input.operatorId) {
         throw invalidProtocolFrame('Agent graph operator result changed request identity');
       }
@@ -366,10 +423,13 @@ export function decodeAgentGraphQueryInput(value: unknown): AgentGraphQueryInput
     value,
     'agent.graph.query input',
     ['rootSessionId'],
-    ['terminalCursor'],
+    ['graphId', 'terminalCursor'],
   );
   return {
     rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    ...(record.graphId === undefined
+      ? {}
+      : { graphId: requireOpaqueIdentity(record.graphId, 'graphId') }),
     ...(record.terminalCursor === undefined
       ? {}
       : { terminalCursor: requireCursor(record.terminalCursor) }),
@@ -377,14 +437,93 @@ export function decodeAgentGraphQueryInput(value: unknown): AgentGraphQueryInput
 }
 
 export function decodeAgentGraphOperatorQueryInput(value: unknown): AgentGraphOperatorQueryInput {
-  const record = requireExactRecord(value, 'agent.graph.operator.query input', [
-    'rootSessionId',
-    'operatorId',
-  ]);
+  const record = requireShapedRecord(
+    value,
+    'agent.graph.operator.query input',
+    ['rootSessionId', 'operatorId'],
+    ['graphId'],
+  );
   return {
     rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    ...(record.graphId === undefined
+      ? {}
+      : { graphId: requireOpaqueIdentity(record.graphId, 'graphId') }),
     operatorId: requireOpaqueIdentity(record.operatorId, 'operatorId'),
   };
+}
+
+export function decodeAgentGraphEpochListInput(value: unknown): AgentGraphEpochListInput {
+  const record = requireShapedRecord(
+    value,
+    'agent.graph.epochs.query input',
+    ['rootSessionId'],
+    ['beforeEpoch'],
+  );
+  const beforeEpoch =
+    record.beforeEpoch === undefined ? undefined : requireCount(record.beforeEpoch, 'beforeEpoch');
+  if (beforeEpoch === 0) throw invalidProtocolFrame('Invalid beforeEpoch');
+  return {
+    rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    ...(beforeEpoch === undefined ? {} : { beforeEpoch }),
+  };
+}
+
+export function decodeAgentGraphEpochListResult(value: unknown): AgentGraphEpochListResult {
+  requireEncodedByteLimit(value, 'agent.graph.epochs.query result', AGENT_GRAPH_RESULT_MAX_BYTES);
+  const record = requireExactRecord(value, 'agent graph epoch list', [
+    'rootSessionId',
+    'epochs',
+    'nextBeforeEpoch',
+  ]);
+  const result = {
+    rootSessionId: requireEntityId(record.rootSessionId, 'rootSessionId'),
+    epochs: decodeArray(
+      record.epochs,
+      'agent graph epochs',
+      AGENT_GRAPH_EPOCH_PAGE_SIZE,
+      (entry) => {
+        const epoch = requireExactRecord(entry, 'agent graph epoch', [
+          'epoch',
+          'graphId',
+          'createdAt',
+          'current',
+        ]);
+        const epochNumber = requireCount(epoch.epoch, 'epoch');
+        if (epochNumber === 0) throw invalidProtocolFrame('Invalid epoch');
+        return {
+          epoch: epochNumber,
+          graphId: requireOpaqueIdentity(epoch.graphId, 'graphId'),
+          createdAt: requireCount(epoch.createdAt, 'createdAt'),
+          current: requireBoolean(epoch.current, 'current'),
+        };
+      },
+    ),
+    nextBeforeEpoch: decodeOptionalEpochCursor(record.nextBeforeEpoch),
+  };
+  assertUnique(result.epochs, (entry) => String(entry.epoch), 'agent graph epoch');
+  assertUnique(result.epochs, (entry) => entry.graphId, 'agent graph identity');
+  if (result.epochs.filter((entry) => entry.current).length > 1) {
+    throw invalidProtocolFrame('Agent graph epoch list identifies multiple current epochs');
+  }
+  for (let index = 1; index < result.epochs.length; index += 1) {
+    if (result.epochs[index - 1]!.epoch - 1 !== result.epochs[index]!.epoch) {
+      throw invalidProtocolFrame('Agent graph epoch page must be contiguous and newest-first');
+    }
+  }
+  if (result.epochs.some((entry) => entry.current) && !result.epochs[0]?.current) {
+    throw invalidProtocolFrame('Agent graph current epoch must be first');
+  }
+  if (result.nextBeforeEpoch !== null && result.nextBeforeEpoch !== result.epochs.at(-1)?.epoch) {
+    throw invalidProtocolFrame('Agent graph epoch cursor must continue after the oldest result');
+  }
+  return result;
+}
+
+function decodeOptionalEpochCursor(value: unknown): number | null {
+  if (value === null) return null;
+  const cursor = requireCount(value, 'nextBeforeEpoch');
+  if (cursor === 0) throw invalidProtocolFrame('Invalid nextBeforeEpoch');
+  return cursor;
 }
 
 export function decodeAgentGraphStopInput(value: unknown): AgentGraphStopInput {

--- a/packages/runtime-host/src/protocol/agent-graph.ts
+++ b/packages/runtime-host/src/protocol/agent-graph.ts
@@ -908,6 +908,12 @@ function decodeSelectedResultInputs(
   if (!Array.isArray(value) || value.length === 0 || value.length > AGENT_GRAPH_MAX_WORK_INPUTS) {
     throw invalidProtocolFrame('Invalid selected graph result inputs');
   }
+  // The durable schedule contract caps current and selected historical inputs
+  // COMBINED at AGENT_GRAPH_MAX_WORK_INPUTS; the decoder must not admit a
+  // wider frame than the contract it projects.
+  if (currentInputIds.size + value.length > AGENT_GRAPH_MAX_WORK_INPUTS) {
+    throw invalidProtocolFrame('Graph input ids exceed the combined current and historical cap');
+  }
   const selected = value.map((item) => {
     const record = requireExactRecord(item, 'selected graph result input', [
       'sourceGraphId',

--- a/packages/runtime-host/src/protocol/agent-graph.ts
+++ b/packages/runtime-host/src/protocol/agent-graph.ts
@@ -169,6 +169,10 @@ export interface AgentGraphClientScheduledWork {
     | { readonly kind: 'preset'; readonly presetId: string }
     | { readonly kind: 'operator'; readonly operatorId: string };
   readonly inputIds: readonly string[];
+  readonly selectedResultInputs?: readonly {
+    readonly sourceGraphId: string;
+    readonly resultId: string;
+  }[];
   readonly replaces?: string;
   readonly status: 'requested' | 'stopped' | 'superseded';
   readonly instructionPreview: string;
@@ -860,7 +864,7 @@ function decodeWork(value: unknown): AgentGraphClientScheduledWork {
       'revision',
       'committedAt',
     ],
-    ['replaces'],
+    ['replaces', 'selectedResultInputs'],
   );
   if (
     record.status !== 'requested' &&
@@ -869,10 +873,19 @@ function decodeWork(value: unknown): AgentGraphClientScheduledWork {
   ) {
     throw invalidProtocolFrame('Invalid agent graph work status');
   }
+  const inputIds = decodeIdentityArray(record.inputIds, 'inputIds', AGENT_GRAPH_MAX_WORK_INPUTS);
   return {
     workId: requireOpaqueIdentity(record.workId, 'workId'),
     target: decodeWorkTarget(record.target),
-    inputIds: decodeIdentityArray(record.inputIds, 'inputIds', AGENT_GRAPH_MAX_WORK_INPUTS),
+    inputIds,
+    ...(record.selectedResultInputs === undefined
+      ? {}
+      : {
+          selectedResultInputs: decodeSelectedResultInputs(
+            record.selectedResultInputs,
+            new Set(inputIds),
+          ),
+        }),
     ...(record.replaces === undefined
       ? {}
       : { replaces: requireOpaqueIdentity(record.replaces, 'replaces') }),
@@ -886,6 +899,30 @@ function decodeWork(value: unknown): AgentGraphClientScheduledWork {
     revision: requireCount(record.revision, 'revision'),
     committedAt: requireCount(record.committedAt, 'committedAt'),
   };
+}
+
+function decodeSelectedResultInputs(
+  value: unknown,
+  currentInputIds: ReadonlySet<string>,
+): Array<{ sourceGraphId: string; resultId: string }> {
+  if (!Array.isArray(value) || value.length === 0 || value.length > AGENT_GRAPH_MAX_WORK_INPUTS) {
+    throw invalidProtocolFrame('Invalid selected graph result inputs');
+  }
+  const selected = value.map((item) => {
+    const record = requireExactRecord(item, 'selected graph result input', [
+      'sourceGraphId',
+      'resultId',
+    ]);
+    return {
+      sourceGraphId: requireOpaqueIdentity(record.sourceGraphId, 'sourceGraphId'),
+      resultId: requireOpaqueIdentity(record.resultId, 'resultId'),
+    };
+  });
+  assertUnique(selected, (item) => item.resultId, 'selected graph result');
+  if (selected.some((item) => currentInputIds.has(item.resultId))) {
+    throw invalidProtocolFrame('Graph input ids are ambiguous across current and historical data');
+  }
+  return selected;
 }
 
 function decodeReconciliationFailure(value: unknown): AgentGraphClientReconciliationFailure {

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -200,6 +200,7 @@ export type OperationKey = keyof OperationSpecMap;
 // Remote credentials are fail-closed: adding a protocol operation does not
 // grant it to remote owners until this policy is deliberately updated.
 export const REMOTE_OWNER_OPERATION_GRANTS = Object.freeze([
+  'agent.graph.epochs.query',
   'agent.graph.operator.query',
   'agent.graph.query',
   'agent.graph.stop',

--- a/packages/runtime-host/src/server/agent-graph-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-coordinator.ts
@@ -137,6 +137,12 @@ export class HostAgentGraphCoordinator {
         ...(input.beforeEpoch === undefined ? {} : { beforeEpoch: input.beforeEpoch }),
         limit: AGENT_GRAPH_EPOCH_PAGE_SIZE,
       });
+      if (input.beforeEpoch !== undefined && input.beforeEpoch > page.currentEpoch) {
+        throw new AgentGraphClientOperationError(
+          'invalid_request',
+          `Agent graph epoch cursor ${input.beforeEpoch} is ahead of current epoch ${page.currentEpoch}`,
+        );
+      }
       return {
         ok: true,
         result: {

--- a/packages/runtime-host/src/server/agent-graph-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-coordinator.ts
@@ -29,9 +29,11 @@ import {
   AGENT_GRAPH_MAX_STOPPED_TARGETS,
   AGENT_GRAPH_MAX_TERMINAL_ACTIVITY,
   AGENT_GRAPH_MAX_WORK,
+  AGENT_GRAPH_EPOCH_PAGE_SIZE,
   AGENT_GRAPH_RESULT_MAX_BYTES,
   type AgentGraphClientOperator,
   type AgentGraphClientSnapshot,
+  type AgentGraphEpochListInput,
   type AgentGraphOperatorInspection,
   type AgentGraphOperatorQueryInput,
   type AgentGraphQueryInput,
@@ -43,7 +45,13 @@ import type { SessionContinuityCoordinator } from './session-continuity-coordina
 
 type AgentGraphAuthority = Pick<
   AgentGraphCoordinator,
-  'currentGraphId' | 'getSnapshot' | 'inspectOperator' | 'subscribeAll'
+  | 'currentGraphId'
+  | 'getGraphSnapshot'
+  | 'getSnapshot'
+  | 'inspectGraphOperator'
+  | 'inspectOperator'
+  | 'listGraphEpochPage'
+  | 'subscribeAll'
 >;
 
 type GraphContinuity = Pick<SessionContinuityCoordinator, 'enqueueAgentGraphChanged'>;
@@ -65,6 +73,7 @@ type GraphQueryFailureCode =
 /** Client-facing Runtime Host adapter over the durable Agent Graph read model. */
 export class HostAgentGraphCoordinator {
   readonly handlers: AgentGraphOperationHandlerMap = {
+    'agent.graph.epochs.query': (input) => this.#queryEpochs(input),
     'agent.graph.query': (input) => this.#query(input),
     'agent.graph.operator.query': (input) => this.#queryOperator(input),
     'agent.graph.stop': (input) => this.#stop(input),
@@ -93,9 +102,10 @@ export class HostAgentGraphCoordinator {
 
   async #query(input: AgentGraphQueryInput): Promise<OperationOutcome<'agent.graph.query'>> {
     try {
-      const snapshot = await this.#authority.getSnapshot(input.rootSessionId, {
-        ...(input.terminalCursor ? { terminalCursor: input.terminalCursor } : {}),
-      });
+      const options = input.terminalCursor ? { terminalCursor: input.terminalCursor } : {};
+      const snapshot = input.graphId
+        ? await this.#authority.getGraphSnapshot(input.rootSessionId, input.graphId, options)
+        : await this.#authority.getSnapshot(input.rootSessionId, options);
       return { ok: true, result: projectSnapshot(snapshot) };
     } catch (error) {
       return graphQueryFailure(error);
@@ -106,11 +116,40 @@ export class HostAgentGraphCoordinator {
     input: AgentGraphOperatorQueryInput,
   ): Promise<OperationOutcome<'agent.graph.operator.query'>> {
     try {
-      const inspection = await this.#authority.inspectOperator(
-        input.rootSessionId,
-        input.operatorId,
-      );
+      const inspection = input.graphId
+        ? await this.#authority.inspectGraphOperator(
+            input.rootSessionId,
+            input.graphId,
+            input.operatorId,
+          )
+        : await this.#authority.inspectOperator(input.rootSessionId, input.operatorId);
       return { ok: true, result: projectInspection(inspection) };
+    } catch (error) {
+      return graphQueryFailure(error);
+    }
+  }
+
+  async #queryEpochs(
+    input: AgentGraphEpochListInput,
+  ): Promise<OperationOutcome<'agent.graph.epochs.query'>> {
+    try {
+      const page = await this.#authority.listGraphEpochPage(input.rootSessionId, {
+        ...(input.beforeEpoch === undefined ? {} : { beforeEpoch: input.beforeEpoch }),
+        limit: AGENT_GRAPH_EPOCH_PAGE_SIZE,
+      });
+      return {
+        ok: true,
+        result: {
+          rootSessionId: input.rootSessionId,
+          epochs: page.epochs.map((binding) => ({
+            epoch: binding.epoch,
+            graphId: binding.graphId,
+            createdAt: binding.createdAt,
+            current: binding.epoch === page.currentEpoch,
+          })),
+          nextBeforeEpoch: page.nextBeforeEpoch,
+        },
+      };
     } catch (error) {
       return graphQueryFailure(error);
     }

--- a/packages/runtime-host/src/server/agent-graph-coordinator.ts
+++ b/packages/runtime-host/src/server/agent-graph-coordinator.ts
@@ -425,6 +425,9 @@ function projectWork(
           ? { kind: work.target.kind, presetId: work.target.presetId }
           : { kind: work.target.kind, operatorId: work.target.operatorId },
     inputIds: [...work.inputIds],
+    ...(work.selectedResultInputs
+      ? { selectedResultInputs: work.selectedResultInputs.map((input) => ({ ...input })) }
+      : {}),
     ...(work.replaces ? { replaces: work.replaces } : {}),
     status: work.status,
     instructionPreview: work.instructionPreview,

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -160,7 +160,10 @@ describe('host-managed agent graph coordinator', () => {
       const tools = await coordinator.toolsForSession(rootSessionId);
       const view = tools.find((tool) => tool.name === VIEW_AGENT_GRAPH_TOOL_NAME) as MakaTool<
         Record<string, never>,
-        { historicalSelectedResults: Array<{ sourceGraphId: string; resultId: string }> }
+        {
+          historicalSelectedResults: Array<{ sourceGraphId: string; resultId: string }>;
+          nextHistoricalBeforeEpoch: number | null;
+        }
       >;
       const update = tools.find((tool) => tool.name === UPDATE_AGENT_GRAPH_TOOL_NAME) as MakaTool<
         UpdateAgentGraphToolInput,
@@ -168,11 +171,11 @@ describe('host-managed agent graph coordinator', () => {
       >;
       assert.ok(view);
       assert.ok(update);
-      assert.deepEqual(
-        (await view.impl({}, toolContext(rootSessionId, 'root-run-2', 'root-turn-2')))
-          .historicalSelectedResults,
-        [{ sourceGraphId, resultId: selectedRecord.recordId }],
-      );
+      const viewed = await view.impl({}, toolContext(rootSessionId, 'root-run-2', 'root-turn-2'));
+      assert.deepEqual(viewed.historicalSelectedResults, [
+        { sourceGraphId, resultId: selectedRecord.recordId },
+      ]);
+      assert.equal(viewed.nextHistoricalBeforeEpoch, null);
       await update.impl(
         {
           operation: 'add_work',

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -641,6 +641,70 @@ describe('host-managed agent graph coordinator', () => {
     }
   });
 
+  test('lists graph ids for tombstone cleanup without reading the Session header', async () => {
+    const controlStore = createSqliteSessionMetadataStore(':memory:');
+    const epochs = [
+      {
+        schemaVersion: 1 as const,
+        rootSessionId: 'removed-root',
+        epoch: 2,
+        graphId: 'agent_graph_2',
+        createdAt: 2,
+      },
+      {
+        schemaVersion: 1 as const,
+        rootSessionId: 'removed-root',
+        epoch: 1,
+        graphId: 'agent_graph_1',
+        createdAt: 1,
+      },
+    ];
+    const coordinator = new AgentGraphCoordinator({
+      sessionStore: {
+        listForRecovery: async () => [],
+        readHeader: async () => {
+          throw new Error('removed Session header must not be read during cleanup');
+        },
+      },
+      runStore: { listSessionRuns: async () => [] },
+      runtimeEventStore: { readImmutableRuntimeEvents: async () => [] },
+      controlStore,
+      epochStore: {
+        resolveCurrentAgentGraphEpoch: async () => epochs[0]!,
+        advanceAgentGraphEpoch: async () => {
+          throw new Error('unexpected epoch advance');
+        },
+        listAgentGraphEpochs: async () => epochs,
+        readAgentGraphEpochByGraphId: async () => undefined,
+        listAgentGraphEpochPage: async () => ({
+          epochs,
+          nextBeforeEpoch: null,
+          currentEpoch: 2,
+        }),
+      },
+      runtime: {
+        provisionAgentGraphOperator: async () => {
+          throw new Error('unexpected operator provision');
+        },
+        runClaimedAgentGraphIntent: async () => {
+          throw new Error('unexpected operator dispatch');
+        },
+        stopSession: async () => {},
+      },
+      newId: randomUUID,
+      onError: () => {},
+    });
+    try {
+      assert.deepEqual(await coordinator.listGraphIds('removed-root'), [
+        'agent_graph_2',
+        'agent_graph_1',
+      ]);
+    } finally {
+      await coordinator.close();
+      controlStore.close();
+    }
+  });
+
   test('advances only a finished and quiescent graph to a deterministic next epoch', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-graph-epoch-cutover-'));
     const controlStore = createSqliteSessionMetadataStore(

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -19,6 +19,7 @@ import { type RuntimeEvent } from '@maka/core/runtime-event';
 import {
   createSessionStore,
   createSqliteSessionMetadataStore,
+  isSessionNotFoundError,
   OPERATIONAL_STATE_DATABASE_NAME,
 } from '@maka/storage';
 import { createSqliteAgentRunStore, createWorkspaceRuntimeStore } from '@maka/storage';
@@ -328,6 +329,15 @@ describe('host-managed agent graph coordinator', () => {
         coordinator.toolsForSession(childSessions[0]!.id),
         /only to root Sessions/,
       );
+      await assert.rejects(
+        coordinator.listGraphEpochPage(childSessions[0]!.id, { limit: 32 }),
+        (error: unknown) =>
+          error instanceof AgentGraphClientOperationError && error.code === 'operation_conflict',
+      );
+      await assert.rejects(
+        coordinator.listGraphEpochPage(randomUUID(), { limit: 32 }),
+        (error: unknown) => isSessionNotFoundError(error),
+      );
       let childStopEntered = false;
       await assert.rejects(
         coordinator.stopExecution(childSessions[0]!.id, {
@@ -545,11 +555,18 @@ describe('host-managed agent graph coordinator', () => {
   test('reads the epoch page and current marker from one storage observation', async () => {
     const controlStore = createSqliteSessionMetadataStore(':memory:');
     let resolveCalls = 0;
+    let headerReads = 0;
     const coordinator = new AgentGraphCoordinator({
       sessionStore: {
         listForRecovery: async () => [],
-        readHeader: async () => {
-          throw new Error('epoch listing must not read the Session header');
+        readHeader: async (sessionId: string) => {
+          headerReads += 1;
+          return {
+            id: sessionId,
+            status: 'active',
+            isArchived: false,
+            orchestrationMode: 'graph',
+          } as never;
         },
       },
       runStore: { listSessionRuns: async () => [] },
@@ -612,6 +629,12 @@ describe('host-managed agent graph coordinator', () => {
       assert.equal(page.currentEpoch, 3);
       assert.equal(page.epochs[0]?.graphId, 'agent_graph_3');
       assert.equal(resolveCalls, 0);
+      assert.equal(headerReads, 1);
+      await assert.rejects(
+        coordinator.listGraphEpochPage('root-session', { beforeEpoch: 999, limit: 32 }),
+        (error: unknown) =>
+          error instanceof AgentGraphClientOperationError && error.code === 'invalid_request',
+      );
     } finally {
       await coordinator.close();
       controlStore.close();

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -512,7 +512,11 @@ describe('host-managed agent graph coordinator', () => {
         },
         listAgentGraphEpochs: async () => [],
         readAgentGraphEpochByGraphId: async () => undefined,
-        listAgentGraphEpochPage: async () => ({ epochs: [], nextBeforeEpoch: null }),
+        listAgentGraphEpochPage: async () => ({
+          epochs: [],
+          nextBeforeEpoch: null,
+          currentEpoch: null,
+        }),
       },
       runtime: {
         provisionAgentGraphOperator: async () => {
@@ -532,6 +536,82 @@ describe('host-managed agent graph coordinator', () => {
       assert.equal(coordinator.wake('root-session'), undefined);
       await new Promise<void>((resolve) => setImmediate(resolve));
       assert.deepEqual(errors, [failure]);
+    } finally {
+      await coordinator.close();
+      controlStore.close();
+    }
+  });
+
+  test('reads the epoch page and current marker from one storage observation', async () => {
+    const controlStore = createSqliteSessionMetadataStore(':memory:');
+    let resolveCalls = 0;
+    const coordinator = new AgentGraphCoordinator({
+      sessionStore: {
+        listForRecovery: async () => [],
+        readHeader: async () => {
+          throw new Error('epoch listing must not read the Session header');
+        },
+      },
+      runStore: { listSessionRuns: async () => [] },
+      runtimeEventStore: { readImmutableRuntimeEvents: async () => [] },
+      controlStore,
+      epochStore: {
+        resolveCurrentAgentGraphEpoch: async () => {
+          resolveCalls += 1;
+          // A second, separate read could observe a stale epoch after a
+          // rollover; the listing must not consult it when the page is
+          // authoritative.
+          return {
+            schemaVersion: 1 as const,
+            rootSessionId: 'root-session',
+            epoch: 2,
+            graphId: 'agent_graph_2',
+            createdAt: 2,
+          };
+        },
+        advanceAgentGraphEpoch: async () => {
+          throw new Error('unexpected epoch advance');
+        },
+        listAgentGraphEpochs: async () => [],
+        readAgentGraphEpochByGraphId: async () => undefined,
+        listAgentGraphEpochPage: async () => ({
+          epochs: [
+            {
+              schemaVersion: 1 as const,
+              rootSessionId: 'root-session',
+              epoch: 3,
+              graphId: 'agent_graph_3',
+              createdAt: 3,
+            },
+            {
+              schemaVersion: 1 as const,
+              rootSessionId: 'root-session',
+              epoch: 2,
+              graphId: 'agent_graph_2',
+              createdAt: 2,
+            },
+          ],
+          nextBeforeEpoch: null,
+          currentEpoch: 3,
+        }),
+      },
+      runtime: {
+        provisionAgentGraphOperator: async () => {
+          throw new Error('unexpected operator provision');
+        },
+        runClaimedAgentGraphIntent: async () => {
+          throw new Error('unexpected operator dispatch');
+        },
+        stopSession: async () => {},
+      },
+      newId: randomUUID,
+      onError: () => {},
+    });
+    try {
+      const page = await coordinator.listGraphEpochPage('root-session', { limit: 32 });
+      assert.equal(page.currentEpoch, 3);
+      assert.equal(page.epochs[0]?.graphId, 'agent_graph_3');
+      assert.equal(resolveCalls, 0);
     } finally {
       await coordinator.close();
       controlStore.close();
@@ -867,7 +947,11 @@ describe('host-managed agent graph coordinator', () => {
                   createdAt: 2,
                 }
               : undefined,
-        listAgentGraphEpochPage: async () => ({ epochs: [], nextBeforeEpoch: null }),
+        listAgentGraphEpochPage: async () => ({
+          epochs: [],
+          nextBeforeEpoch: null,
+          currentEpoch: null,
+        }),
       },
       controlStore: {
         listAgentGraphOperatorProvisions: async () => [],

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -38,11 +38,204 @@ import {
 import { encodeAgentGraphTerminalCursor } from '../stream-graph-read-model.js';
 import {
   UPDATE_AGENT_GRAPH_TOOL_NAME,
+  VIEW_AGENT_GRAPH_TOOL_NAME,
   YIELD_AGENT_GRAPH_TOOL_NAME,
   compileAgentGraphScheduleUpdate,
+  type UpdateAgentGraphToolInput,
 } from '../stream-graph-supervisor-tools.js';
+import { projectAgentGraphRecords } from '../stream-graph-projection.js';
 
 describe('host-managed agent graph coordinator', () => {
+  test('authorizes only selected committed results from an earlier epoch of the same root', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const rootSessionId = 'root-session';
+    const sourceGraphId = agentGraphIdForRootSession(rootSessionId);
+    const currentGraphId = agentGraphIdForRootSessionEpoch(rootSessionId, 2);
+    const sourceRun: AgentRunHeader = {
+      sessionId: 'source-child',
+      runId: 'source-run',
+      turnId: 'source-turn',
+      invocationId: 'source-invocation',
+      backendKind: 'fake',
+      llmConnectionSlug: 'fake',
+      modelId: 'fake',
+      cwd: '/workspace',
+      permissionMode: 'explore',
+      status: 'completed',
+      createdAt: 1,
+      updatedAt: 2,
+      completedAt: 2,
+    };
+    const sourceEvent: RuntimeEvent = {
+      id: 'source-result-event',
+      invocationId: 'source-invocation',
+      sessionId: sourceRun.sessionId,
+      runId: sourceRun.runId,
+      turnId: sourceRun.turnId,
+      ts: 2,
+      role: 'model',
+      author: 'agent',
+      partial: false,
+      content: { kind: 'text', text: 'Outcome: retain this result.' },
+    };
+    const selectedRecord = projectAgentGraphRecords({
+      graphId: sourceGraphId,
+      streams: [
+        {
+          operator: { operatorId: 'source-operator', sessionId: sourceRun.sessionId },
+          run: sourceRun,
+          events: [sourceEvent],
+        },
+      ],
+    }).records[0]!;
+    const sourceProvision: AgentGraphOperatorProvision = {
+      schemaVersion: AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION,
+      provisionId: `graph_provision_${'1'.repeat(32)}`,
+      provisionFingerprint: `sha256:${'2'.repeat(64)}`,
+      graphId: sourceGraphId,
+      workId: `graph_work_${'3'.repeat(32)}`,
+      agentId: 'source-agent',
+      operatorId: 'source-operator',
+      initialTurnId: sourceRun.turnId,
+      initialRunId: sourceRun.runId,
+      edges: [],
+      targetSessionId: sourceRun.sessionId,
+      provisionedAt: 1,
+    };
+    const controlStore = new Proxy(store, {
+      get(target, property) {
+        if (property === 'listAgentGraphOperatorProvisions') {
+          return async (graphId: string) =>
+            graphId === sourceGraphId ? [structuredClone(sourceProvision)] : [];
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    await store.resolveCurrentAgentGraphEpoch({ rootSessionId, legacyGraphId: sourceGraphId });
+    await store.commitAgentGraphScheduleUpdate(
+      compileAgentGraphScheduleUpdate({
+        graphId: sourceGraphId,
+        input: {
+          operation: 'finish',
+          finish: { result_ids: [selectedRecord.recordId], reason: 'Publish selected output.' },
+        },
+        context: toolContext(rootSessionId, 'root-run-1', 'root-turn-1', 'finish-source'),
+      }),
+    );
+    await store.advanceAgentGraphEpoch({
+      rootSessionId,
+      expectedEpoch: 1,
+      expectedGraphId: sourceGraphId,
+      nextGraphId: currentGraphId,
+    });
+    const coordinator = new AgentGraphCoordinator({
+      sessionStore: {
+        listForRecovery: async () => [],
+        readHeader: async (sessionId: string) =>
+          ({ id: sessionId, status: 'active', isArchived: false }) as never,
+      },
+      runStore: {
+        listSessionRuns: async (sessionId: string) =>
+          sessionId === sourceRun.sessionId ? [sourceRun] : [],
+      },
+      runtimeEventStore: {
+        readImmutableRuntimeEvents: async (sessionId, runId) =>
+          sessionId === sourceRun.sessionId && runId === sourceRun.runId ? [sourceEvent] : [],
+      },
+      controlStore,
+      epochStore: store,
+      runtime: {
+        provisionAgentGraphOperator: async () => {
+          throw new Error('test does not reconcile new work');
+        },
+        runClaimedAgentGraphIntent: async () => {
+          throw new Error('test does not dispatch new work');
+        },
+        stopSession: async () => {},
+      },
+      newId: randomUUID,
+    });
+    try {
+      const tools = await coordinator.toolsForSession(rootSessionId);
+      const view = tools.find((tool) => tool.name === VIEW_AGENT_GRAPH_TOOL_NAME) as MakaTool<
+        Record<string, never>,
+        { historicalSelectedResults: Array<{ sourceGraphId: string; resultId: string }> }
+      >;
+      const update = tools.find((tool) => tool.name === UPDATE_AGENT_GRAPH_TOOL_NAME) as MakaTool<
+        UpdateAgentGraphToolInput,
+        unknown
+      >;
+      assert.ok(view);
+      assert.ok(update);
+      assert.deepEqual(
+        (await view.impl({}, toolContext(rootSessionId, 'root-run-2', 'root-turn-2')))
+          .historicalSelectedResults,
+        [{ sourceGraphId, resultId: selectedRecord.recordId }],
+      );
+      await update.impl(
+        {
+          operation: 'add_work',
+          add_work: [
+            {
+              target_kind: 'new_agent',
+              agent_id: 'reader',
+              instruction: 'Continue from the selected result.',
+              selected_result_inputs: [
+                { source_graph_id: sourceGraphId, result_id: selectedRecord.recordId },
+              ],
+            },
+          ],
+        },
+        toolContext(rootSessionId, 'root-run-2', 'root-turn-2', 'use-selected'),
+      );
+      await assert.rejects(
+        async () =>
+          await update.impl(
+            {
+              operation: 'add_work',
+              add_work: [
+                {
+                  target_kind: 'new_agent',
+                  agent_id: 'reader',
+                  instruction: 'Try an unselected record.',
+                  selected_result_inputs: [
+                    { source_graph_id: sourceGraphId, result_id: 'unselected-record' },
+                  ],
+                },
+              ],
+            },
+            toolContext(rootSessionId, 'root-run-2', 'root-turn-2', 'use-unselected'),
+          ),
+        /did not select result/,
+      );
+      await assert.rejects(
+        async () =>
+          await update.impl(
+            {
+              operation: 'add_work',
+              add_work: [
+                {
+                  target_kind: 'new_agent',
+                  agent_id: 'reader',
+                  instruction: 'Try the current graph.',
+                  selected_result_inputs: [
+                    { source_graph_id: currentGraphId, result_id: selectedRecord.recordId },
+                  ],
+                },
+              ],
+            },
+            toolContext(rootSessionId, 'root-run-2', 'root-turn-2', 'use-current'),
+          ),
+        /not a completed earlier epoch/,
+      );
+      assert.equal((await store.listAgentGraphScheduleUpdates(currentGraphId)).length, 1);
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
   test('boots an empty graph from agent work and recovers it without duplicate topology', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-graph-coordinator-'));
     const sessionStore = createSessionStore(root);

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -511,6 +511,8 @@ describe('host-managed agent graph coordinator', () => {
           throw new Error('unexpected epoch advance');
         },
         listAgentGraphEpochs: async () => [],
+        readAgentGraphEpochByGraphId: async () => undefined,
+        listAgentGraphEpochPage: async () => ({ epochs: [], nextBeforeEpoch: null }),
       },
       runtime: {
         provisionAgentGraphOperator: async () => {
@@ -797,17 +799,20 @@ describe('host-managed agent graph coordinator', () => {
     }
   });
 
-  test('keeps completed graph snapshots readable after the root Session is archived', async () => {
-    let projection:
-      | {
-          schemaVersion: 1;
-          graphId: string;
-          rootSessionId: string;
-          snapshotVersion: string;
-          payload: unknown;
-          materializedAt: number;
-        }
-      | undefined;
+  test('rebuilds an exact historical graph projection without falling through to current', async () => {
+    const historicalGraphId = agentGraphIdForRootSession('root-session');
+    const currentGraphId = agentGraphIdForRootSessionEpoch('root-session', 2);
+    const projections = new Map<
+      string,
+      {
+        schemaVersion: 1;
+        graphId: string;
+        rootSessionId: string;
+        snapshotVersion: string;
+        payload: unknown;
+        materializedAt: number;
+      }
+    >();
     const coordinator = new AgentGraphCoordinator({
       sessionStore: {
         listForRecovery: async () => [],
@@ -820,26 +825,71 @@ describe('host-managed agent graph coordinator', () => {
       },
       runStore: { listSessionRuns: async () => [] },
       runtimeEventStore: { readImmutableRuntimeEvents: async () => [] },
+      epochStore: {
+        resolveCurrentAgentGraphEpoch: async () => ({
+          schemaVersion: 1,
+          rootSessionId: 'root-session',
+          epoch: 2,
+          graphId: currentGraphId,
+          createdAt: 2,
+        }),
+        listAgentGraphEpochs: async () => [
+          {
+            schemaVersion: 1 as const,
+            rootSessionId: 'root-session',
+            epoch: 1,
+            graphId: historicalGraphId,
+            createdAt: 1,
+          },
+          {
+            schemaVersion: 1,
+            rootSessionId: 'root-session',
+            epoch: 2,
+            graphId: currentGraphId,
+            createdAt: 2,
+          },
+        ],
+        readAgentGraphEpochByGraphId: async (graphId: string) =>
+          graphId === historicalGraphId
+            ? {
+                schemaVersion: 1 as const,
+                rootSessionId: 'root-session',
+                epoch: 1,
+                graphId: historicalGraphId,
+                createdAt: 1,
+              }
+            : graphId === currentGraphId
+              ? {
+                  schemaVersion: 1 as const,
+                  rootSessionId: 'root-session',
+                  epoch: 2,
+                  graphId: currentGraphId,
+                  createdAt: 2,
+                }
+              : undefined,
+        listAgentGraphEpochPage: async () => ({ epochs: [], nextBeforeEpoch: null }),
+      },
       controlStore: {
         listAgentGraphOperatorProvisions: async () => [],
         listAgentGraphScheduleUpdates: async () => [],
         listAgentGraphIntentClaims: async () => [],
         listAgentGraphClientClaimAdmissions: async () => [],
-        readAgentGraphClientProjection: async () => projection,
+        readAgentGraphClientProjection: async (graphId: string) => projections.get(graphId),
         commitAgentGraphClientProjection: async (request: {
           graphId: string;
           rootSessionId: string;
           snapshotVersion: string;
           snapshot: unknown;
         }) => {
-          projection = {
-            schemaVersion: 1,
+          const projection = {
+            schemaVersion: 1 as const,
             graphId: request.graphId,
             rootSessionId: request.rootSessionId,
             snapshotVersion: request.snapshotVersion,
             payload: request.snapshot,
             materializedAt: 1,
           };
+          projections.set(request.graphId, projection);
           return projection;
         },
         readAgentGraphClientOperatorProjection: async () => undefined,
@@ -852,8 +902,16 @@ describe('host-managed agent graph coordinator', () => {
       newId: randomUUID,
       rootSessionId: 'root-session',
     } as unknown as AgentGraphCoordinatorInput);
-    const snapshot = await coordinator.getSnapshot('root-session');
-    assert.equal(snapshot.status, 'empty');
+    const historical = await coordinator.getGraphSnapshot('root-session', historicalGraphId);
+    assert.equal(historical.graphId, historicalGraphId);
+    assert.equal(historical.status, 'empty');
+    const current = await coordinator.getSnapshot('root-session');
+    assert.equal(current.graphId, currentGraphId);
+    await assert.rejects(
+      coordinator.getGraphSnapshot('root-session', agentGraphIdForRootSession('another-root')),
+      (error: unknown) =>
+        error instanceof AgentGraphClientOperationError && error.code === 'not_found',
+    );
     await assert.rejects(
       coordinator.toolsForSession('root-session'),
       /Archived Sessions cannot supervise/,

--- a/packages/runtime/src/__tests__/stream-graph-handoff.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-handoff.test.ts
@@ -56,6 +56,7 @@ describe('agent graph operator handoffs', () => {
     assert.equal(reads, 1, 'records from one activation should share one immutable stream read');
     assert.equal(handoffs.length, 2);
     assert.equal(handoffs[0]?.record.recordId, records[0]?.recordId);
+    assert.equal(handoffs[0]?.record.graphId, 'graph-handoff');
     assert.equal(handoffs[0]?.conclusion?.sourceRuntimeEventId, 'result-event');
     assert.equal(handoffs[1]?.record.recordId, records[1]?.recordId);
     assert.equal(
@@ -147,6 +148,7 @@ describe('agent graph operator handoffs', () => {
           schemaVersion: 1,
           record: {
             recordId: 'record-result',
+            graphId: 'graph-handoff',
             operatorId: 'researcher',
             activationId: 'run-child',
             facets: ['message'],

--- a/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
@@ -93,6 +93,203 @@ describe('stream graph schedule reconciliation', () => {
     }
   });
 
+  test('defers work whose historical result source becomes unresolvable', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(90) });
+    const provisions: AgentGraphOperatorProvision[] = [];
+    const controlStore = controlStoreWithProvisions(store, provisions);
+    const observation = new MemoryGraphObservation();
+    const executor = new MemoryScheduleExecutor(controlStore, observation);
+    const historical = historicalRecord();
+    try {
+      await commitSchedule(controlStore, 'tool-unresolvable', {
+        add_work: [
+          {
+            agent_id: 'local-read',
+            instruction: 'Continue from the selected earlier result.',
+            input_ids: [],
+            selected_result_inputs: [
+              { source_graph_id: historical.graphId, result_id: historical.recordId },
+            ],
+          },
+        ],
+      });
+      const result = await reconcileAgentGraphSchedule({
+        topology: topology(),
+        controlStore,
+        executor,
+        stopController: new MemoryStopController(observation),
+        newId: nextId(),
+        maxNewActivations: 1,
+        observeGraph: (currentTopology) => observation.read(currentTopology),
+        resolveSelectedResultInputs: async () => {
+          throw new Error('source epoch runtime events are unreadable');
+        },
+        renderPrompt: ({ work }) => work.instruction,
+      });
+
+      assert.equal(result.status, 'waiting');
+      assert.equal(result.failures.length, 0);
+      assert.equal(result.dispatches.length, 0);
+      assert.deepEqual(
+        result.deferredWork.map((item) => ({
+          reason: item.reason,
+          missingInputIds: item.missingInputIds,
+        })),
+        [{ reason: 'input_not_committed', missingInputIds: [historical.recordId] }],
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test('resolves each historical result source once per reconciliation', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(90) });
+    const provisions: AgentGraphOperatorProvision[] = [];
+    const controlStore = controlStoreWithProvisions(store, provisions);
+    const observation = new MemoryGraphObservation();
+    const executor = new MemoryScheduleExecutor(controlStore, observation);
+    const historical = historicalRecord();
+    try {
+      await commitSchedule(controlStore, 'tool-cached-resolution', {
+        add_work: [
+          {
+            agent_id: 'local-read',
+            instruction: 'Continue from the selected earlier result.',
+            input_ids: [],
+            selected_result_inputs: [
+              { source_graph_id: historical.graphId, result_id: historical.recordId },
+            ],
+          },
+        ],
+      });
+      let resolveCalls = 0;
+      const result = await reconcileAgentGraphSchedule({
+        topology: topology(),
+        controlStore,
+        executor,
+        stopController: new MemoryStopController(observation),
+        newId: nextId(),
+        maxNewActivations: 1,
+        observeGraph: (currentTopology) => observation.read(currentTopology),
+        resolveSelectedResultInputs: async (selected) => {
+          resolveCalls += 1;
+          return selected.map(() => structuredClone(historical));
+        },
+        async provisionOperator(input) {
+          const provision: AgentGraphOperatorProvision = {
+            schemaVersion: 1,
+            provisionId: `graph_provision_${'4'.repeat(32)}`,
+            provisionFingerprint: `sha256:${'5'.repeat(64)}`,
+            graphId: input.graphId,
+            workId: input.workId,
+            agentId: input.agentId!,
+            operatorId: input.operatorId,
+            initialTurnId: 'reserved-turn',
+            initialRunId: 'reserved-run',
+            edges: input.edges,
+            targetSessionId: 'session-historical-reader',
+            provisionedAt: 91,
+          };
+          provisions.push(provision);
+          return {
+            provision,
+            created: true,
+            header: { id: provision.targetSessionId } as SessionHeader,
+          };
+        },
+        renderPrompt: ({ work }) => work.instruction,
+      });
+
+      assert.equal(result.status, 'reconciled');
+      assert.equal(result.dispatches.length, 1);
+      assert.equal(resolveCalls, 1);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('defers only the work items whose historical source failed', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(90) });
+    const provisions: AgentGraphOperatorProvision[] = [];
+    const controlStore = controlStoreWithProvisions(store, provisions);
+    const observation = new MemoryGraphObservation();
+    const executor = new MemoryScheduleExecutor(controlStore, observation);
+    const historical = historicalRecord();
+    try {
+      await commitSchedule(controlStore, 'tool-partial-resolution', {
+        add_work: [
+          {
+            agent_id: 'local-read',
+            instruction: 'Continue from the readable earlier result.',
+            input_ids: [],
+            selected_result_inputs: [
+              { source_graph_id: historical.graphId, result_id: historical.recordId },
+            ],
+          },
+          {
+            agent_id: 'local-read',
+            instruction: 'Continue from the unreadable earlier result.',
+            input_ids: [],
+            selected_result_inputs: [
+              { source_graph_id: 'graph-broken', result_id: 'record-broken' },
+            ],
+          },
+        ],
+      });
+      const result = await reconcileAgentGraphSchedule({
+        topology: topology(),
+        controlStore,
+        executor,
+        stopController: new MemoryStopController(observation),
+        newId: nextId(),
+        maxNewActivations: 2,
+        observeGraph: (currentTopology) => observation.read(currentTopology),
+        resolveSelectedResultInputs: async (selected) => {
+          if (selected.some((item) => item.sourceGraphId === 'graph-broken')) {
+            throw new Error('source epoch runtime events are unreadable');
+          }
+          return selected.map(() => structuredClone(historical));
+        },
+        async provisionOperator(input) {
+          const provision: AgentGraphOperatorProvision = {
+            schemaVersion: 1,
+            provisionId: `graph_provision_${'4'.repeat(32)}`,
+            provisionFingerprint: `sha256:${'5'.repeat(64)}`,
+            graphId: input.graphId,
+            workId: input.workId,
+            agentId: input.agentId!,
+            operatorId: input.operatorId,
+            initialTurnId: 'reserved-turn',
+            initialRunId: 'reserved-run',
+            edges: input.edges,
+            targetSessionId: `session-${input.workId}`,
+            provisionedAt: 91,
+          };
+          provisions.push(provision);
+          return {
+            provision,
+            created: true,
+            header: { id: provision.targetSessionId } as SessionHeader,
+          };
+        },
+        renderPrompt: ({ work }) => work.instruction,
+      });
+
+      assert.equal(result.status, 'waiting');
+      assert.equal(result.failures.length, 0);
+      assert.equal(result.dispatches.length, 1);
+      assert.deepEqual(
+        result.deferredWork.map((item) => ({
+          reason: item.reason,
+          missingInputIds: item.missingInputIds,
+        })),
+        [{ reason: 'input_not_committed', missingInputIds: ['record-broken'] }],
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   test('executes existing operators durably and leaves new agents waiting for topology', async () => {
     const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(100) });
     const observation = new MemoryGraphObservation();

--- a/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
@@ -26,6 +26,73 @@ import {
 import type { AgentGraphTraceTopology } from '../stream-graph-trace.js';
 
 describe('stream graph schedule reconciliation', () => {
+  test('hydrates selected results without creating a cross-graph topology edge', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(90) });
+    const provisions: AgentGraphOperatorProvision[] = [];
+    const controlStore = controlStoreWithProvisions(store, provisions);
+    const observation = new MemoryGraphObservation();
+    const executor = new MemoryScheduleExecutor(controlStore, observation);
+    const historical = historicalRecord();
+    try {
+      await commitSchedule(controlStore, 'tool-historical', {
+        add_work: [
+          {
+            agent_id: 'local-read',
+            instruction: 'Continue from the selected earlier result.',
+            input_ids: [],
+            selected_result_inputs: [
+              { source_graph_id: historical.graphId, result_id: historical.recordId },
+            ],
+          },
+        ],
+      });
+      let renderedRecord: AgentGraphRecord | undefined;
+      const result = await reconcileAgentGraphSchedule({
+        topology: topology(),
+        controlStore,
+        executor,
+        stopController: new MemoryStopController(observation),
+        newId: nextId(),
+        maxNewActivations: 1,
+        observeGraph: (currentTopology) => observation.read(currentTopology),
+        resolveSelectedResultInputs: async () => [historical],
+        async provisionOperator(input) {
+          assert.deepEqual(input.edges, []);
+          const provision: AgentGraphOperatorProvision = {
+            schemaVersion: 1,
+            provisionId: `graph_provision_${'4'.repeat(32)}`,
+            provisionFingerprint: `sha256:${'5'.repeat(64)}`,
+            graphId: input.graphId,
+            workId: input.workId,
+            agentId: input.agentId!,
+            operatorId: input.operatorId,
+            initialTurnId: 'reserved-turn',
+            initialRunId: 'reserved-run',
+            edges: input.edges,
+            targetSessionId: 'session-historical-reader',
+            provisionedAt: 91,
+          };
+          provisions.push(provision);
+          return {
+            provision,
+            created: true,
+            header: { id: provision.targetSessionId } as SessionHeader,
+          };
+        },
+        renderPrompt: ({ inputRecords, work }) => {
+          renderedRecord = inputRecords[0];
+          return work.instruction;
+        },
+      });
+
+      assert.equal(result.status, 'reconciled');
+      assert.equal(renderedRecord?.graphId, historical.graphId);
+      assert.deepEqual(result.dispatches[0]?.intent.triggerRecordIds, [historical.recordId]);
+    } finally {
+      store.close();
+    }
+  });
+
   test('executes existing operators durably and leaves new agents waiting for topology', async () => {
     const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(100) });
     const observation = new MemoryGraphObservation();
@@ -40,6 +107,7 @@ describe('stream graph schedule reconciliation', () => {
         schemaVersion: 1,
         record: {
           recordId: record.recordId,
+          graphId: record.graphId,
           operatorId: record.operatorId,
           activationId: record.activationId,
           facets: record.facets,
@@ -539,6 +607,37 @@ describe('stream graph schedule reconciliation', () => {
 });
 
 const GRAPH_ID = 'graph-schedule';
+
+function historicalRecord(): AgentGraphRecord {
+  return {
+    schemaVersion: 1,
+    recordId: 'record-historical-result',
+    graphId: 'graph-previous',
+    operatorId: 'historical-writer',
+    activationId: 'historical-run',
+    sessionId: 'session-historical-writer',
+    agentRunId: 'historical-run',
+    eventTime: 1,
+    orderKey: {
+      runCreatedAt: 1,
+      operatorId: 'historical-writer',
+      runId: 'historical-run',
+      committedEventOrdinal: 0,
+      runtimeEventId: 'historical-event',
+    },
+    type: 'agent_runtime_event',
+    facets: ['message'],
+    supervisorSignals: [],
+    source: {
+      kind: 'runtime_event',
+      runtimeEventId: 'historical-event',
+      sessionId: 'session-historical-writer',
+      runId: 'historical-run',
+      turnId: 'historical-turn',
+      ts: 1,
+    },
+  };
+}
 
 function topology(): AgentGraphTraceTopology {
   return {

--- a/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
@@ -26,7 +26,7 @@ import {
 import type { AgentGraphTraceTopology } from '../stream-graph-trace.js';
 
 describe('stream graph schedule reconciliation', () => {
-  test('hydrates selected results without creating a cross-graph topology edge', async () => {
+  test('hydrates selected results without leaking them into another work item', async () => {
     const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(90) });
     const provisions: AgentGraphOperatorProvision[] = [];
     const controlStore = controlStoreWithProvisions(store, provisions);
@@ -43,6 +43,11 @@ describe('stream graph schedule reconciliation', () => {
             selected_result_inputs: [
               { source_graph_id: historical.graphId, result_id: historical.recordId },
             ],
+          },
+          {
+            agent_id: 'local-read',
+            instruction: 'This work only requested a current-graph input.',
+            input_ids: [historical.recordId],
           },
         ],
       });
@@ -85,9 +90,23 @@ describe('stream graph schedule reconciliation', () => {
         },
       });
 
-      assert.equal(result.status, 'reconciled');
+      assert.equal(result.status, 'waiting');
       assert.equal(renderedRecord?.graphId, historical.graphId);
       assert.deepEqual(result.dispatches[0]?.intent.triggerRecordIds, [historical.recordId]);
+      assert.deepEqual(
+        result.deferredWork.map((item) => ({
+          instruction: item.work.instruction,
+          reason: item.reason,
+          missingInputIds: item.missingInputIds,
+        })),
+        [
+          {
+            instruction: 'This work only requested a current-graph input.',
+            reason: 'input_not_committed',
+            missingInputIds: [historical.recordId],
+          },
+        ],
+      );
     } finally {
       store.close();
     }

--- a/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
@@ -113,6 +113,7 @@ describe('stream graph schedule reconciliation', () => {
           },
         ],
       });
+      let resolveCalls = 0;
       const result = await reconcileAgentGraphSchedule({
         topology: topology(),
         controlStore,
@@ -122,6 +123,7 @@ describe('stream graph schedule reconciliation', () => {
         maxNewActivations: 1,
         observeGraph: (currentTopology) => observation.read(currentTopology),
         resolveSelectedResultInputs: async () => {
+          resolveCalls += 1;
           throw new Error('source epoch runtime events are unreadable');
         },
         renderPrompt: ({ work }) => work.instruction,
@@ -130,6 +132,7 @@ describe('stream graph schedule reconciliation', () => {
       assert.equal(result.status, 'waiting');
       assert.equal(result.failures.length, 0);
       assert.equal(result.dispatches.length, 0);
+      assert.equal(resolveCalls, 1);
       assert.deepEqual(
         result.deferredWork.map((item) => ({
           reason: item.reason,

--- a/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
@@ -18,9 +18,10 @@ describe('stream graph supervisor tools', () => {
       graphId: 'graph-supervised',
       scheduleStore: store,
       observeGraph: async () => observationWithRecords('graph-supervised', ['verified-result']),
-      listHistoricalSelectedResults: async () => [
-        { sourceGraphId: 'graph-previous', resultId: 'selected-result' },
-      ],
+      listHistoricalSelectedResults: async () => ({
+        results: [{ sourceGraphId: 'graph-previous', resultId: 'selected-result' }],
+        nextBeforeEpoch: null,
+      }),
     });
     try {
       assert.equal(viewTool.name, VIEW_AGENT_GRAPH_TOOL_NAME);
@@ -68,6 +69,7 @@ describe('stream graph supervisor tools', () => {
       assert.deepEqual(first.historicalSelectedResults, [
         { sourceGraphId: 'graph-previous', resultId: 'selected-result' },
       ]);
+      assert.equal(first.nextHistoricalBeforeEpoch, null);
       assert.equal(first.runtime.operators[0]?.status, 'running');
       assert.equal(first.runtime.operators[0]?.childSessionId, 'session-writer');
       assert.equal(first.runtime.operators[0]?.currentRunId, 'run-writer');

--- a/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
@@ -18,6 +18,9 @@ describe('stream graph supervisor tools', () => {
       graphId: 'graph-supervised',
       scheduleStore: store,
       observeGraph: async () => observationWithRecords('graph-supervised', ['verified-result']),
+      listHistoricalSelectedResults: async () => [
+        { sourceGraphId: 'graph-previous', resultId: 'selected-result' },
+      ],
     });
     try {
       assert.equal(viewTool.name, VIEW_AGENT_GRAPH_TOOL_NAME);
@@ -43,6 +46,9 @@ describe('stream graph supervisor tools', () => {
             agent_id: 'fact-checker',
             instruction: 'Verify the conflicting figures.',
             input_ids: ['result-b', 'result-a'],
+            selected_result_inputs: [
+              { source_graph_id: 'graph-previous', result_id: 'selected-result' },
+            ],
           },
           {
             operator_id: 'writer',
@@ -56,6 +62,12 @@ describe('stream graph supervisor tools', () => {
       assert.deepEqual(retry, first);
       assert.equal((await store.listAgentGraphScheduleUpdates('graph-supervised')).length, 1);
       assert.deepEqual(first.schedule.work[0]?.inputIds, ['result-a', 'result-b']);
+      assert.deepEqual(first.schedule.work[0]?.selectedResultInputs, [
+        { sourceGraphId: 'graph-previous', resultId: 'selected-result' },
+      ]);
+      assert.deepEqual(first.historicalSelectedResults, [
+        { sourceGraphId: 'graph-previous', resultId: 'selected-result' },
+      ]);
       assert.equal(first.runtime.operators[0]?.status, 'running');
       assert.equal(first.runtime.operators[0]?.childSessionId, 'session-writer');
       assert.equal(first.runtime.operators[0]?.currentRunId, 'run-writer');

--- a/packages/runtime/src/graph-mode.ts
+++ b/packages/runtime/src/graph-mode.ts
@@ -15,6 +15,7 @@ export function renderGraphModePrompt(): string {
     'Stay available to the user across supervisor turns. Intervene only through the typed graph controls, and explain material supervision decisions.',
     'Before advancing dependencies or finishing, read the committed child result with agent_output like {"locator":"child_session_run","child_session_id":"<childSessionId>","run_id":"<currentRunId>","view":"result","max_bytes":32768}. Use result.resultRecordId when selecting a final committed record. Read runtime_events or view=all only for a narrow diagnostic question. Then select committed result ids with update_agent_graph.finish and synthesize those results for the user.',
     'When scheduling dependent work, pass each upstream result.resultRecordId in input_ids. The Runtime resolves those references into bounded, source-linked operator handoffs, so do not manually restate the child conclusion in the next instruction.',
+    'For a result selected by a finished earlier graph epoch, use selected_result_inputs with the exact source_graph_id and result_id returned by view_agent_graph. Keep input_ids for records in the current graph; historical inputs carry data lineage only and never reuse old operators or control state.',
     'You may continue directly when the request is small or a graph would add ceremony without useful decomposition.',
     '</orchestration_mode>',
   ].join('\n');

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -294,7 +294,7 @@ export class AgentGraphCoordinator {
   }
 
   async listGraphEpochs(rootSessionId: string): Promise<readonly AgentGraphEpochBinding[]> {
-    requireRootSessionId(rootSessionId);
+    await this.#assertRootGraphReader(rootSessionId);
     const current = await this.currentGraphEpoch(rootSessionId);
     if (!this.#input.epochStore) return [current];
     const epochs = await this.#input.epochStore.listAgentGraphEpochs(rootSessionId);
@@ -305,9 +305,10 @@ export class AgentGraphCoordinator {
     rootSessionId: string,
     options: { readonly beforeEpoch?: number; readonly limit: number },
   ): Promise<AgentGraphEpochPage & { readonly currentEpoch: number }> {
-    requireRootSessionId(rootSessionId);
+    await this.#assertRootGraphReader(rootSessionId);
     if (!this.#input.epochStore) {
       const current = await this.currentGraphEpoch(rootSessionId);
+      assertEpochCursorNotAhead(options.beforeEpoch, current.epoch);
       return {
         epochs:
           options.beforeEpoch === undefined || current.epoch < options.beforeEpoch ? [current] : [],
@@ -323,6 +324,7 @@ export class AgentGraphCoordinator {
       ...options,
     });
     if (page.currentEpoch !== null) {
+      assertEpochCursorNotAhead(options.beforeEpoch, page.currentEpoch);
       return {
         epochs: page.epochs,
         nextBeforeEpoch: page.nextBeforeEpoch,
@@ -331,6 +333,7 @@ export class AgentGraphCoordinator {
     }
     // No durable rows yet: synthesize the legacy virtual epoch identity.
     const current = await this.currentGraphEpoch(rootSessionId);
+    assertEpochCursorNotAhead(options.beforeEpoch, current.epoch);
     return {
       epochs: options.beforeEpoch === undefined ? [current] : [],
       nextBeforeEpoch: null,
@@ -1484,6 +1487,15 @@ export class AgentGraphCoordinator {
     );
     failures.push(
       ...stopped.flatMap((result) => (result.status === 'rejected' ? [result.reason] : [])),
+    );
+  }
+}
+
+function assertEpochCursorNotAhead(beforeEpoch: number | undefined, currentEpoch: number): void {
+  if (beforeEpoch !== undefined && beforeEpoch > currentEpoch) {
+    throw new AgentGraphClientOperationError(
+      'invalid_request',
+      `Agent graph epoch cursor ${beforeEpoch} is ahead of current epoch ${currentEpoch}`,
     );
   }
 }

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -1,6 +1,7 @@
 import type { AgentGraphClientProjectionStore } from '@maka/core/agent-graph-client-projection';
 import type { AgentGraphIntentClaim } from '@maka/core/agent-graph-control';
 import type { AgentGraphEpochBinding, AgentGraphEpochStore } from '@maka/core/agent-graph-epoch';
+import type { AgentGraphEpochPage } from '@maka/core/agent-graph-epoch';
 import type {
   AgentGraphScheduleControlStore,
   AgentGraphScheduleUpdate,
@@ -250,67 +251,34 @@ export class AgentGraphCoordinator {
     rootSessionId: string,
     options: AgentGraphClientSnapshotOptions = {},
   ): Promise<AgentGraphClientSnapshot> {
-    await this.#assertRootGraphReader(rootSessionId);
     const graphId = await this.currentGraphId(rootSessionId);
+    return this.getGraphSnapshot(rootSessionId, graphId, options);
+  }
+
+  async getGraphSnapshot(
+    rootSessionId: string,
+    graphId: string,
+    options: AgentGraphClientSnapshotOptions = {},
+  ): Promise<AgentGraphClientSnapshot> {
+    await this.#assertGraphBelongsToRoot(rootSessionId, graphId);
     let before: ReturnType<typeof decodeAgentGraphTerminalCursor> | undefined;
     try {
       before = options.terminalCursor
         ? decodeAgentGraphTerminalCursor(options.terminalCursor)
         : undefined;
-    } catch {
+    } catch (error) {
       throw new AgentGraphClientOperationError(
         'invalid_request',
-        'Agent graph terminal cursor is invalid',
+        error instanceof Error ? error.message : 'Invalid agent graph terminal cursor',
       );
     }
     if (before && before.graphId !== graphId) {
       throw new AgentGraphClientOperationError(
         'invalid_request',
-        'Agent graph terminal cursor belongs to another root Session',
+        'Agent graph terminal cursor belongs to another graph',
       );
     }
-    const record = await this.#readOrRebuildClientProjection(rootSessionId, graphId);
-    const snapshot = decodeMaterializedAgentGraphClientSnapshot(record.payload, {
-      rootSessionId,
-      graphId,
-      snapshotVersion: record.snapshotVersion,
-    });
-    let terminalPage: Awaited<
-      ReturnType<AgentGraphClientProjectionStore['listAgentGraphClientTerminalActivities']>
-    >;
-    try {
-      terminalPage = await this.#input.controlStore.listAgentGraphClientTerminalActivities(
-        graphId,
-        {
-          limit: AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
-          ...(before
-            ? {
-                before: {
-                  eventTime: before.eventTime,
-                  recordId: before.recordId,
-                },
-              }
-            : {}),
-        },
-      );
-    } catch (error) {
-      if (error instanceof AgentGraphClientTerminalCursorError) {
-        throw new AgentGraphClientOperationError('invalid_request', error.message);
-      }
-      throw error;
-    }
-    snapshot.terminalHistory = materializedAgentGraphTerminalHistoryPage(
-      graphId,
-      terminalPage.records.map((activity) =>
-        decodeMaterializedAgentGraphClientActivity(activity.payload, {
-          graphId,
-          recordId: activity.recordId,
-          eventTime: activity.eventTime,
-        }),
-      ),
-      terminalPage.hasMore,
-    );
-    return snapshot;
+    return this.#readSnapshot(rootSessionId, graphId, before);
   }
 
   async readSessionState(rootSessionId: string): Promise<'absent' | 'live' | 'terminal'> {
@@ -321,21 +289,44 @@ export class AgentGraphCoordinator {
     rootSessionId: string,
     graphId: string,
   ): Promise<'absent' | 'live' | 'terminal'> {
-    if (!(await this.listGraphIds(rootSessionId)).includes(graphId)) {
-      throw new AgentGraphClientOperationError(
-        'not_found',
-        `Agent graph ${graphId} does not belong to root Session ${rootSessionId}`,
-      );
-    }
+    await this.#assertGraphBelongsToRoot(rootSessionId, graphId);
     return this.#readSessionStateForGraph(rootSessionId, graphId);
   }
 
-  async listGraphIds(rootSessionId: string): Promise<readonly string[]> {
+  async listGraphEpochs(rootSessionId: string): Promise<readonly AgentGraphEpochBinding[]> {
     requireRootSessionId(rootSessionId);
-    if (!this.#input.epochStore) return [agentGraphIdForRootSession(rootSessionId)];
     const current = await this.currentGraphEpoch(rootSessionId);
+    if (!this.#input.epochStore) return [current];
     const epochs = await this.#input.epochStore.listAgentGraphEpochs(rootSessionId);
-    return epochs.length > 0 ? epochs.map(({ graphId }) => graphId) : [current.graphId];
+    return epochs.length > 0 ? epochs : [current];
+  }
+
+  async listGraphEpochPage(
+    rootSessionId: string,
+    options: { readonly beforeEpoch?: number; readonly limit: number },
+  ): Promise<AgentGraphEpochPage & { readonly currentEpoch: number }> {
+    requireRootSessionId(rootSessionId);
+    const current = await this.currentGraphEpoch(rootSessionId);
+    if (!this.#input.epochStore) {
+      return {
+        epochs:
+          options.beforeEpoch === undefined || current.epoch < options.beforeEpoch ? [current] : [],
+        nextBeforeEpoch: null,
+        currentEpoch: current.epoch,
+      };
+    }
+    const page = await this.#input.epochStore.listAgentGraphEpochPage({
+      rootSessionId,
+      ...options,
+    });
+    if (page.epochs.length > 0 || options.beforeEpoch !== undefined) {
+      return { ...page, currentEpoch: current.epoch };
+    }
+    return { epochs: [current], nextBeforeEpoch: null, currentEpoch: current.epoch };
+  }
+
+  async listGraphIds(rootSessionId: string): Promise<readonly string[]> {
+    return (await this.listGraphEpochs(rootSessionId)).map(({ graphId }) => graphId);
   }
 
   async hasLiveSessionState(rootSessionId: string): Promise<boolean> {
@@ -369,8 +360,16 @@ export class AgentGraphCoordinator {
     rootSessionId: string,
     operatorId: string,
   ): Promise<AgentGraphOperatorInspection> {
-    await this.#assertRootGraphReader(rootSessionId);
     const graphId = await this.currentGraphId(rootSessionId);
+    return this.inspectGraphOperator(rootSessionId, graphId, operatorId);
+  }
+
+  async inspectGraphOperator(
+    rootSessionId: string,
+    graphId: string,
+    operatorId: string,
+  ): Promise<AgentGraphOperatorInspection> {
+    await this.#assertGraphBelongsToRoot(rootSessionId, graphId);
     await this.#readOrRebuildClientProjection(rootSessionId, graphId);
     const materialized = await this.#input.controlStore.readAgentGraphClientProjectionWithOperator(
       graphId,
@@ -825,10 +824,7 @@ export class AgentGraphCoordinator {
       const expectedSnapshotVersion =
         (await this.#input.controlStore.readAgentGraphClientProjection(graphId))?.snapshotVersion ??
         null;
-      const input = await this.#readClientModelInput(rootSessionId);
-      if (input.graphId !== graphId) {
-        throw new Error(`Agent graph rebuild resolved ${input.graphId}, expected ${graphId}`);
-      }
+      const input = await this.#readClientModelInputForGraph(rootSessionId, graphId);
       try {
         return await this.#commitClientProjection(
           input,
@@ -955,7 +951,11 @@ export class AgentGraphCoordinator {
       const existing = await this.#input.controlStore.readAgentGraphClientProjection(
         driver.graphId,
       );
-      const input = await this.#readClientModelInput(driver.rootSessionId, projected);
+      const input = await this.#readClientModelInputForGraph(
+        driver.rootSessionId,
+        driver.graphId,
+        projected,
+      );
       try {
         await this.#commitClientProjection(
           input,
@@ -1253,6 +1253,70 @@ export class AgentGraphCoordinator {
     );
     if (snapshot.scheduleRevision === 0) return 'absent';
     return !snapshot.closed || snapshot.status === 'closing' ? 'live' : 'terminal';
+  }
+
+  async #assertGraphBelongsToRoot(rootSessionId: string, graphId: string): Promise<void> {
+    await this.#assertRootGraphReader(rootSessionId);
+    const current = await this.currentGraphEpoch(rootSessionId);
+    const binding =
+      current.graphId === graphId
+        ? current
+        : await this.#input.epochStore?.readAgentGraphEpochByGraphId(graphId);
+    if (!binding || binding.rootSessionId !== rootSessionId) {
+      throw new AgentGraphClientOperationError(
+        'not_found',
+        `Agent graph ${graphId} does not belong to root Session ${rootSessionId}`,
+      );
+    }
+  }
+
+  async #readSnapshot(
+    rootSessionId: string,
+    graphId: string,
+    before?: ReturnType<typeof decodeAgentGraphTerminalCursor>,
+  ): Promise<AgentGraphClientSnapshot> {
+    const record = await this.#readOrRebuildClientProjection(rootSessionId, graphId);
+    const snapshot = decodeMaterializedAgentGraphClientSnapshot(record.payload, {
+      rootSessionId,
+      graphId,
+      snapshotVersion: record.snapshotVersion,
+    });
+    let terminalPage: Awaited<
+      ReturnType<AgentGraphClientProjectionStore['listAgentGraphClientTerminalActivities']>
+    >;
+    try {
+      terminalPage = await this.#input.controlStore.listAgentGraphClientTerminalActivities(
+        graphId,
+        {
+          limit: AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
+          ...(before
+            ? {
+                before: {
+                  eventTime: before.eventTime,
+                  recordId: before.recordId,
+                },
+              }
+            : {}),
+        },
+      );
+    } catch (error) {
+      if (error instanceof AgentGraphClientTerminalCursorError) {
+        throw new AgentGraphClientOperationError('invalid_request', error.message);
+      }
+      throw error;
+    }
+    snapshot.terminalHistory = materializedAgentGraphTerminalHistoryPage(
+      graphId,
+      terminalPage.records.map((activity) =>
+        decodeMaterializedAgentGraphClientActivity(activity.payload, {
+          graphId,
+          recordId: activity.recordId,
+          eventTime: activity.eventTime,
+        }),
+      ),
+      terminalPage.hasMore,
+    );
+    return snapshot;
   }
 
   async #driver(rootSessionId: string): Promise<GraphDriver> {

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -4,6 +4,7 @@ import type { AgentGraphEpochBinding, AgentGraphEpochStore } from '@maka/core/ag
 import type { AgentGraphEpochPage } from '@maka/core/agent-graph-epoch';
 import type {
   AgentGraphScheduleControlStore,
+  AgentGraphSelectedResultInput,
   AgentGraphScheduleUpdate,
 } from '@maka/core/agent-graph-schedule';
 import type { AgentGraphTimelineMetadataStore } from '@maka/core/agent-graph-timeline';
@@ -19,7 +20,10 @@ import {
 import { decodeAgentGraphIntentClaim } from '@maka/core/agent-graph-control';
 import type { MakaTool } from './tool-runtime.js';
 import type { SessionManager } from './session-manager.js';
-import { readCommittedAgentGraphProjection } from './stream-graph-projection.js';
+import {
+  readCommittedAgentGraphProjection,
+  type AgentGraphRecord,
+} from './stream-graph-projection.js';
 import {
   hydrateAgentGraphInputHandoffs,
   renderAgentGraphScheduledWorkPrompt,
@@ -54,6 +58,7 @@ import {
 } from './stream-graph-read-model.js';
 import {
   buildAgentGraphSupervisorTools,
+  projectAgentGraphSchedule,
   type AgentGraphYieldPermit,
 } from './stream-graph-supervisor-tools.js';
 import type { AgentGraphTraceTopology } from './stream-graph-trace.js';
@@ -222,13 +227,20 @@ export class AgentGraphCoordinator {
         graphId: driver.graphId,
         scheduleStore: this.#input.controlStore,
         observeGraph: () => this.observe(rootSessionId),
+        listHistoricalSelectedResults: () =>
+          this.#listHistoricalSelectedResults(rootSessionId, driver.graphId),
         prepareYieldPermit: () => this.#prepareYieldPermit(driver),
-        authorizeScheduleUpdate: (request): ScheduleWakeFence => {
+        authorizeScheduleUpdate: async (request): Promise<ScheduleWakeFence> => {
           if (request.graphId !== driver.graphId || request.source.sessionId !== rootSessionId) {
             throw new Error(
               `Agent graph schedule update is not authorized for root Session ${rootSessionId}`,
             );
           }
+          await this.#resolveSelectedResultInputs(
+            rootSessionId,
+            driver.graphId,
+            request.addWork.flatMap((work) => work.selectedResultInputs ?? []),
+          );
           return {
             stopGeneration: driver.stopGeneration,
             mayResumePaused: driver.paused && !driver.stopping,
@@ -702,6 +714,8 @@ export class AgentGraphCoordinator {
       newId: this.#input.newId,
       maxNewActivations: this.#input.maxNewActivations!,
       observeGraph: (topology) => this.#observeTopology(topology),
+      resolveSelectedResultInputs: (selected) =>
+        this.#resolveSelectedResultInputs(driver.rootSessionId, driver.graphId, selected),
       hydrateInputHandoffs: (records) =>
         hydrateAgentGraphInputHandoffs({
           records,
@@ -1156,6 +1170,97 @@ export class AgentGraphCoordinator {
       graphId,
       await this.#input.controlStore.listAgentGraphOperatorProvisions(graphId),
     );
+  }
+
+  async #resolveSelectedResultInputs(
+    rootSessionId: string,
+    currentGraphId: string,
+    selectedInputs: readonly AgentGraphSelectedResultInput[],
+  ): Promise<readonly AgentGraphRecord[]> {
+    if (selectedInputs.length === 0) return [];
+    if (!this.#input.epochStore) {
+      throw new Error('Historical graph result inputs require agent graph epoch authority');
+    }
+    const current = await this.#input.epochStore.readAgentGraphEpochByGraphId(currentGraphId);
+    if (!current || current.rootSessionId !== rootSessionId) {
+      throw new Error(`Current agent graph ${currentGraphId} is not owned by ${rootSessionId}`);
+    }
+    const sourceGraphIds = [...new Set(selectedInputs.map((input) => input.sourceGraphId))];
+    const recordsBySource = new Map<string, Map<string, AgentGraphRecord>>();
+    for (const sourceGraphId of sourceGraphIds) {
+      const source = await this.#input.epochStore.readAgentGraphEpochByGraphId(sourceGraphId);
+      if (!source || source.rootSessionId !== rootSessionId || source.epoch >= current.epoch) {
+        throw new Error(
+          `Agent graph ${sourceGraphId} is not a completed earlier epoch of ${currentGraphId}`,
+        );
+      }
+      const updates = await this.#input.controlStore.listAgentGraphScheduleUpdates(sourceGraphId);
+      updates.forEach((update) =>
+        this.#assertScheduleOwnedByRoot(update, rootSessionId, sourceGraphId),
+      );
+      const schedule = projectAgentGraphSchedule(sourceGraphId, updates);
+      if (!schedule.closed || !schedule.finish) {
+        throw new Error(`Agent graph ${sourceGraphId} has not selected final results`);
+      }
+      const requestedIds = selectedInputs
+        .filter((input) => input.sourceGraphId === sourceGraphId)
+        .map((input) => input.resultId);
+      const selectedIds = new Set(schedule.finish.resultIds);
+      const unselected = requestedIds.filter((resultId) => !selectedIds.has(resultId));
+      if (unselected.length > 0) {
+        throw new Error(
+          `Agent graph ${sourceGraphId} did not select result ${unselected.join(', ')}`,
+        );
+      }
+      const topology = await this.#readTopology(sourceGraphId);
+      const projection = await readCommittedAgentGraphProjection({
+        graphId: sourceGraphId,
+        operators: topology.operators,
+        runStore: this.#input.runStore,
+        runtimeEventStore: this.#input.runtimeEventStore,
+      });
+      recordsBySource.set(
+        sourceGraphId,
+        new Map(projection.records.map((record) => [record.recordId, record])),
+      );
+    }
+    return selectedInputs.map((selected) => {
+      const record = recordsBySource.get(selected.sourceGraphId)?.get(selected.resultId);
+      if (!record) {
+        throw new Error(
+          `Selected result ${selected.resultId} is not a committed record of ${selected.sourceGraphId}`,
+        );
+      }
+      return structuredClone(record);
+    });
+  }
+
+  async #listHistoricalSelectedResults(
+    rootSessionId: string,
+    currentGraphId: string,
+  ): Promise<readonly AgentGraphSelectedResultInput[]> {
+    if (!this.#input.epochStore) return [];
+    const current = await this.#input.epochStore.readAgentGraphEpochByGraphId(currentGraphId);
+    if (!current || current.rootSessionId !== rootSessionId || current.epoch <= 1) return [];
+    const page = await this.#input.epochStore.listAgentGraphEpochPage({
+      rootSessionId,
+      beforeEpoch: current.epoch,
+      limit: 16,
+    });
+    const selected: AgentGraphSelectedResultInput[] = [];
+    for (const binding of page.epochs) {
+      const updates = await this.#input.controlStore.listAgentGraphScheduleUpdates(binding.graphId);
+      updates.forEach((update) =>
+        this.#assertScheduleOwnedByRoot(update, rootSessionId, binding.graphId),
+      );
+      const finish = projectAgentGraphSchedule(binding.graphId, updates).finish;
+      if (!finish) continue;
+      for (const resultId of finish.resultIds) {
+        selected.push({ sourceGraphId: binding.graphId, resultId });
+        if (selected.length === 64) return selected;
+      }
+    }
+    return selected;
   }
 
   async #assertRootSupervisor(rootSessionId: string): Promise<SessionHeader> {

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -1250,7 +1250,7 @@ export class AgentGraphCoordinator {
     }
     const page = await this.#input.epochStore.listAgentGraphEpochPage({
       rootSessionId,
-      beforeEpoch: beforeEpoch ?? current.epoch,
+      beforeEpoch: Math.min(beforeEpoch ?? current.epoch, current.epoch),
       limit: 1,
     });
     const selected: AgentGraphSelectedResultInput[] = [];

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -306,8 +306,8 @@ export class AgentGraphCoordinator {
     options: { readonly beforeEpoch?: number; readonly limit: number },
   ): Promise<AgentGraphEpochPage & { readonly currentEpoch: number }> {
     requireRootSessionId(rootSessionId);
-    const current = await this.currentGraphEpoch(rootSessionId);
     if (!this.#input.epochStore) {
+      const current = await this.currentGraphEpoch(rootSessionId);
       return {
         epochs:
           options.beforeEpoch === undefined || current.epoch < options.beforeEpoch ? [current] : [],
@@ -315,14 +315,27 @@ export class AgentGraphCoordinator {
         currentEpoch: current.epoch,
       };
     }
+    // Page rows and the current marker must describe one storage observation:
+    // a rollover between two reads would mark a non-first row current, which
+    // the protocol rejects.
     const page = await this.#input.epochStore.listAgentGraphEpochPage({
       rootSessionId,
       ...options,
     });
-    if (page.epochs.length > 0 || options.beforeEpoch !== undefined) {
-      return { ...page, currentEpoch: current.epoch };
+    if (page.currentEpoch !== null) {
+      return {
+        epochs: page.epochs,
+        nextBeforeEpoch: page.nextBeforeEpoch,
+        currentEpoch: page.currentEpoch,
+      };
     }
-    return { epochs: [current], nextBeforeEpoch: null, currentEpoch: current.epoch };
+    // No durable rows yet: synthesize the legacy virtual epoch identity.
+    const current = await this.currentGraphEpoch(rootSessionId);
+    return {
+      epochs: options.beforeEpoch === undefined ? [current] : [],
+      nextBeforeEpoch: null,
+      currentEpoch: current.epoch,
+    };
   }
 
   async listGraphIds(rootSessionId: string): Promise<readonly string[]> {

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -227,8 +227,8 @@ export class AgentGraphCoordinator {
         graphId: driver.graphId,
         scheduleStore: this.#input.controlStore,
         observeGraph: () => this.observe(rootSessionId),
-        listHistoricalSelectedResults: () =>
-          this.#listHistoricalSelectedResults(rootSessionId, driver.graphId),
+        listHistoricalSelectedResults: (beforeEpoch) =>
+          this.#listHistoricalSelectedResults(rootSessionId, driver.graphId, beforeEpoch),
         prepareYieldPermit: () => this.#prepareYieldPermit(driver),
         authorizeScheduleUpdate: async (request): Promise<ScheduleWakeFence> => {
           if (request.graphId !== driver.graphId || request.source.sessionId !== rootSessionId) {
@@ -1238,14 +1238,20 @@ export class AgentGraphCoordinator {
   async #listHistoricalSelectedResults(
     rootSessionId: string,
     currentGraphId: string,
-  ): Promise<readonly AgentGraphSelectedResultInput[]> {
-    if (!this.#input.epochStore) return [];
+    beforeEpoch?: number,
+  ): Promise<{
+    results: readonly AgentGraphSelectedResultInput[];
+    nextBeforeEpoch: number | null;
+  }> {
+    if (!this.#input.epochStore) return { results: [], nextBeforeEpoch: null };
     const current = await this.#input.epochStore.readAgentGraphEpochByGraphId(currentGraphId);
-    if (!current || current.rootSessionId !== rootSessionId || current.epoch <= 1) return [];
+    if (!current || current.rootSessionId !== rootSessionId || current.epoch <= 1) {
+      return { results: [], nextBeforeEpoch: null };
+    }
     const page = await this.#input.epochStore.listAgentGraphEpochPage({
       rootSessionId,
-      beforeEpoch: current.epoch,
-      limit: 16,
+      beforeEpoch: beforeEpoch ?? current.epoch,
+      limit: 1,
     });
     const selected: AgentGraphSelectedResultInput[] = [];
     for (const binding of page.epochs) {
@@ -1257,10 +1263,9 @@ export class AgentGraphCoordinator {
       if (!finish) continue;
       for (const resultId of finish.resultIds) {
         selected.push({ sourceGraphId: binding.graphId, resultId });
-        if (selected.length === 64) return selected;
       }
     }
-    return selected;
+    return { results: selected, nextBeforeEpoch: page.nextBeforeEpoch };
   }
 
   async #assertRootSupervisor(rootSessionId: string): Promise<SessionHeader> {

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -342,7 +342,15 @@ export class AgentGraphCoordinator {
   }
 
   async listGraphIds(rootSessionId: string): Promise<readonly string[]> {
-    return (await this.listGraphEpochs(rootSessionId)).map(({ graphId }) => graphId);
+    requireRootSessionId(rootSessionId);
+    // Retirement calls this after the Session header has been tombstoned. Keep
+    // that internal cleanup path on the epoch authority while client-facing
+    // epoch queries continue to validate a live root Session above.
+    if (!this.#input.epochStore) return [agentGraphIdForRootSession(rootSessionId)];
+    const epochs = await this.#input.epochStore.listAgentGraphEpochs(rootSessionId);
+    return epochs.length > 0
+      ? epochs.map(({ graphId }) => graphId)
+      : [agentGraphIdForRootSession(rootSessionId)];
   }
 
   async hasLiveSessionState(rootSessionId: string): Promise<boolean> {

--- a/packages/runtime/src/stream-graph-handoff.ts
+++ b/packages/runtime/src/stream-graph-handoff.ts
@@ -8,6 +8,7 @@ export const DEFAULT_AGENT_GRAPH_HANDOFF_MAX_TOTAL_CONCLUSION_BYTES = 48 * 1024;
 
 export interface AgentGraphHandoffRecordReference {
   recordId: string;
+  graphId: string;
   operatorId: string;
   activationId: string;
   facets: AgentGraphRecord['facets'];
@@ -147,6 +148,7 @@ export function renderAgentGraphScheduledWorkPrompt(input: {
 function graphRecordReference(record: AgentGraphRecord): AgentGraphHandoffRecordReference {
   return {
     recordId: record.recordId,
+    graphId: record.graphId,
     operatorId: record.operatorId,
     activationId: record.activationId,
     facets: [...record.facets],

--- a/packages/runtime/src/stream-graph-read-model.ts
+++ b/packages/runtime/src/stream-graph-read-model.ts
@@ -117,6 +117,7 @@ export interface AgentGraphClientScheduledWork {
     | { kind: 'preset'; presetId: string }
     | { kind: 'operator'; operatorId: string };
   inputIds: string[];
+  selectedResultInputs?: Array<{ sourceGraphId: string; resultId: string }>;
   replaces?: string;
   status: AgentGraphScheduleWorkView['status'];
   instructionPreview: string;
@@ -1049,6 +1050,9 @@ function clientWork(work: AgentGraphScheduleWorkView): AgentGraphClientScheduled
     workId: work.workId,
     target: { ...work.target },
     inputIds: [...work.inputIds],
+    ...(work.selectedResultInputs
+      ? { selectedResultInputs: work.selectedResultInputs.map((input) => ({ ...input })) }
+      : {}),
     ...(work.replaces ? { replaces: work.replaces } : {}),
     status: work.status,
     instructionPreview: instructionTruncated

--- a/packages/runtime/src/stream-graph-schedule-reconcile.ts
+++ b/packages/runtime/src/stream-graph-schedule-reconcile.ts
@@ -154,9 +154,13 @@ export async function reconcileAgentGraphSchedule(
   const dispatches: AgentGraphDispatchedActivation[] = [];
   const stops: AgentGraphScheduleStopResult[] = [];
   const failures: AgentGraphScheduleReconciliationFailure[] = [];
+  // Resolved historical results are immutable for the lifetime of one
+  // reconciliation; cache them per source graph so repeated snapshot reads do
+  // not replay the full committed projection of a closed epoch.
+  const selectedResultCache: SelectedResultCache = new Map();
   let newActivationCount = 0;
   let observedExistingActivationCount = 0;
-  let snapshot = await readScheduleSnapshot(input);
+  let snapshot = await readScheduleSnapshot(input, selectedResultCache);
 
   for (let attempt = 0; attempt < MAX_RECONCILIATION_ATTEMPTS; attempt += 1) {
     if (input.abortSignal?.aborted) {
@@ -176,7 +180,7 @@ export async function reconcileAgentGraphSchedule(
     stops.push(...stopWave.stops);
     for (const failure of stopWave.failures) recordReconciliationFailure(input, failures, failure);
     if (failures.length > 0) {
-      snapshot = await readScheduleSnapshot(input);
+      snapshot = await readScheduleSnapshot(input, selectedResultCache);
       return reconciliationResult(
         input.abortSignal?.aborted ? 'cancelled' : 'failed',
         newActivationCount,
@@ -212,7 +216,7 @@ export async function reconcileAgentGraphSchedule(
         deferredWork.push({ work, reason: 'graph_closed' });
         continue;
       }
-      const missingInputIds = work.inputIds.filter((recordId) => !committedRecords.has(recordId));
+      const missingInputIds = missingWorkInputIds(work, committedRecords);
       if (missingInputIds.length > 0) {
         deferredWork.push({ work, reason: 'input_not_committed', missingInputIds });
         continue;
@@ -250,7 +254,7 @@ export async function reconcileAgentGraphSchedule(
       }
     }
     if (topologyChanged || topologyStale) {
-      snapshot = await readScheduleSnapshot(input);
+      snapshot = await readScheduleSnapshot(input, selectedResultCache);
       if (failures.length === 0) continue;
     }
     if (failures.length > 0) {
@@ -292,7 +296,7 @@ export async function reconcileAgentGraphSchedule(
         deferredWork.push({ work, reason: 'graph_closed' });
         continue;
       }
-      const missingInputIds = work.inputIds.filter((recordId) => !committedRecords.has(recordId));
+      const missingInputIds = missingWorkInputIds(work, committedRecords);
       if (missingInputIds.length > 0) {
         deferredWork.push({
           work,
@@ -305,7 +309,7 @@ export async function reconcileAgentGraphSchedule(
     }
 
     if (failures.length > 0) {
-      snapshot = await readScheduleSnapshot(input);
+      snapshot = await readScheduleSnapshot(input, selectedResultCache);
       return reconciliationResult(
         'failed',
         newActivationCount,
@@ -366,7 +370,7 @@ export async function reconcileAgentGraphSchedule(
       }
     });
     if (failures.length > 0) {
-      snapshot = await readScheduleSnapshot(input);
+      snapshot = await readScheduleSnapshot(input, selectedResultCache);
       return reconciliationResult(
         'failed',
         newActivationCount,
@@ -409,7 +413,7 @@ export async function reconcileAgentGraphSchedule(
       }
     }
 
-    const nextSnapshot = await readScheduleSnapshot(input);
+    const nextSnapshot = await readScheduleSnapshot(input, selectedResultCache);
     if (stale || nextSnapshot.schedule.revision !== snapshot.schedule.revision) {
       snapshot = nextSnapshot;
       continue;
@@ -449,7 +453,7 @@ export async function reconcileAgentGraphSchedule(
     );
   }
 
-  snapshot = await readScheduleSnapshot(input);
+  snapshot = await readScheduleSnapshot(input, selectedResultCache);
   return reconciliationResult(
     'stale',
     newActivationCount,
@@ -464,6 +468,7 @@ export async function reconcileAgentGraphSchedule(
 
 async function readScheduleSnapshot(
   input: ReconcileAgentGraphScheduleInput,
+  selectedResultCache: SelectedResultCache,
 ): Promise<ScheduleSnapshot> {
   const [updates, provisions, claims] = await Promise.all([
     input.controlStore.listAgentGraphScheduleUpdates(input.topology.graphId),
@@ -478,7 +483,11 @@ async function readScheduleSnapshot(
   const selectedInputs = schedule.work
     .filter((work) => work.status === 'requested')
     .flatMap((work) => work.selectedResultInputs ?? []);
-  const selectedResultRecords = await resolveSelectedResultRecords(input, selectedInputs);
+  const selectedResultRecords = await resolveSelectedResultRecords(
+    input,
+    selectedInputs,
+    selectedResultCache,
+  );
   return {
     schedule,
     observation,
@@ -490,9 +499,34 @@ async function readScheduleSnapshot(
   };
 }
 
+/** Missing inputs include unresolved selected historical result ids so an
+ * unresolvable source defers its own work item via `input_not_committed`. */
+function missingWorkInputIds(
+  work: AgentGraphScheduleWorkView,
+  committedRecords: ReadonlyMap<string, AgentGraphRecord>,
+): string[] {
+  return [
+    ...work.inputIds.filter((recordId) => !committedRecords.has(recordId)),
+    ...(work.selectedResultInputs ?? [])
+      .map((selected) => selected.resultId)
+      .filter((recordId) => !committedRecords.has(recordId)),
+  ];
+}
+
+/** Resolved historical records keyed by source graph id, then result id. */
+type SelectedResultCache = Map<string, Map<string, AgentGraphRecord>>;
+
+/**
+ * Resolves selected historical result inputs, isolating failures per source
+ * graph: an unresolvable source omits its records so dependent work items
+ * defer with `input_not_committed` instead of wedging the whole graph.
+ * Contract violations that commit-time authorization already rejected
+ * (missing resolver, ambiguous result ids) still throw.
+ */
 async function resolveSelectedResultRecords(
   input: ReconcileAgentGraphScheduleInput,
   selectedInputs: readonly AgentGraphSelectedResultInput[],
+  cache: SelectedResultCache,
 ): Promise<Map<string, AgentGraphRecord>> {
   if (selectedInputs.length === 0) return new Map();
   if (!input.resolveSelectedResultInputs) {
@@ -506,21 +540,49 @@ async function resolveSelectedResultRecords(
       ]),
     ).values(),
   ];
-  const records = await input.resolveSelectedResultInputs(distinct);
-  if (records.length !== distinct.length) {
-    throw new Error('Selected graph result resolver returned an incomplete result set');
+  const bySource = new Map<string, AgentGraphSelectedResultInput[]>();
+  for (const selected of distinct) {
+    const group = bySource.get(selected.sourceGraphId);
+    if (group) {
+      group.push(selected);
+    } else {
+      bySource.set(selected.sourceGraphId, [selected]);
+    }
+  }
+  for (const [sourceGraphId, group] of bySource) {
+    let cached = cache.get(sourceGraphId);
+    if (!cached) {
+      cached = new Map();
+      cache.set(sourceGraphId, cached);
+    }
+    const pending = group.filter((selected) => !cached.has(selected.resultId));
+    if (pending.length === 0) continue;
+    let records: readonly AgentGraphRecord[];
+    try {
+      records = await input.resolveSelectedResultInputs(pending);
+    } catch {
+      continue;
+    }
+    if (
+      records.length !== pending.length ||
+      records.some((record, index) => {
+        const selected = pending[index]!;
+        return record.graphId !== selected.sourceGraphId || record.recordId !== selected.resultId;
+      })
+    ) {
+      continue;
+    }
+    records.forEach((record) => cached.set(record.recordId, record));
   }
   const resolved = new Map<string, AgentGraphRecord>();
-  records.forEach((record, index) => {
-    const selected = distinct[index]!;
-    if (record.graphId !== selected.sourceGraphId || record.recordId !== selected.resultId) {
-      throw new Error('Selected graph result resolver returned a mismatched record');
-    }
+  for (const selected of distinct) {
+    const record = cache.get(selected.sourceGraphId)?.get(selected.resultId);
+    if (!record) continue;
     if (resolved.has(record.recordId)) {
       throw new Error(`Selected graph result id ${record.recordId} is ambiguous`);
     }
     resolved.set(record.recordId, clonePlain(record));
-  });
+  }
   return resolved;
 }
 

--- a/packages/runtime/src/stream-graph-schedule-reconcile.ts
+++ b/packages/runtime/src/stream-graph-schedule-reconcile.ts
@@ -5,6 +5,7 @@ import type {
 import {
   AgentGraphScheduleRevisionConflictError,
   type AgentGraphScheduleControlStore,
+  type AgentGraphSelectedResultInput,
   type AgentGraphScheduleUpdate,
   type AgentGraphScheduleUpdateSource,
 } from '@maka/core/agent-graph-schedule';
@@ -60,6 +61,9 @@ export interface ReconcileAgentGraphScheduleInput {
     input: ProvisionAgentGraphOperatorInput,
   ): Promise<ProvisionAgentGraphOperatorResult>;
   hydrateInputHandoffs?(records: readonly AgentGraphRecord[]): Promise<AgentGraphInputHandoff[]>;
+  resolveSelectedResultInputs?(
+    inputs: readonly AgentGraphSelectedResultInput[],
+  ): Promise<readonly AgentGraphRecord[]>;
   renderPrompt(input: RenderAgentGraphScheduledWorkPromptInput): string | Promise<string>;
   abortSignal?: AbortSignal;
   supervisor?: AgentGraphSupervisorObserver;
@@ -106,6 +110,7 @@ interface ScheduleSnapshot {
   topology: AgentGraphTraceTopology;
   provisions: AgentGraphOperatorProvision[];
   sourceByWorkId: Map<string, AgentGraphScheduleUpdateSource>;
+  selectedResultRecords: Map<string, AgentGraphRecord>;
 }
 
 interface PreparedWork {
@@ -191,6 +196,9 @@ export async function reconcileAgentGraphSchedule(
     const committedRecords = new Map(
       snapshot.observation.projection.records.map((record) => [record.recordId, record]),
     );
+    for (const [recordId, record] of snapshot.selectedResultRecords) {
+      committedRecords.set(recordId, record);
+    }
     const deferredWork: AgentGraphScheduleDeferredWork[] = [];
     let topologyChanged = false;
     let topologyStale = false;
@@ -322,9 +330,10 @@ export async function reconcileAgentGraphSchedule(
 
     const rendered = await Promise.allSettled(
       selected.map(async ({ work, intent }): Promise<PreparedWork> => {
-        const inputRecords = work.inputIds.map((recordId) =>
-          clonePlain(committedRecords.get(recordId)!),
-        );
+        const inputRecords = [
+          ...work.inputIds,
+          ...(work.selectedResultInputs ?? []).map((selected) => selected.resultId),
+        ].map((recordId) => clonePlain(committedRecords.get(recordId)!));
         const inputHandoffs = input.hydrateInputHandoffs
           ? await input.hydrateInputHandoffs(inputRecords)
           : [];
@@ -462,14 +471,54 @@ async function readScheduleSnapshot(
   const observation = await input.observeGraph(topology);
   assertGraphObservation(input.topology.graphId, observation);
   notifySupervisor(input.supervisor?.onObservation, observation);
+  const schedule = projectAgentGraphSchedule(input.topology.graphId, updates);
+  const selectedInputs = schedule.work
+    .filter((work) => work.status === 'requested')
+    .flatMap((work) => work.selectedResultInputs ?? []);
+  const selectedResultRecords = await resolveSelectedResultRecords(input, selectedInputs);
   return {
-    schedule: projectAgentGraphSchedule(input.topology.graphId, updates),
+    schedule,
     observation,
     claims,
     topology,
     provisions,
     sourceByWorkId: scheduleSourceByWorkId(updates),
+    selectedResultRecords,
   };
+}
+
+async function resolveSelectedResultRecords(
+  input: ReconcileAgentGraphScheduleInput,
+  selectedInputs: readonly AgentGraphSelectedResultInput[],
+): Promise<Map<string, AgentGraphRecord>> {
+  if (selectedInputs.length === 0) return new Map();
+  if (!input.resolveSelectedResultInputs) {
+    throw new Error('Selected graph result inputs require a Runtime Host resolver');
+  }
+  const distinct = [
+    ...new Map(
+      selectedInputs.map((selected) => [
+        `${selected.sourceGraphId}\u0000${selected.resultId}`,
+        selected,
+      ]),
+    ).values(),
+  ];
+  const records = await input.resolveSelectedResultInputs(distinct);
+  if (records.length !== distinct.length) {
+    throw new Error('Selected graph result resolver returned an incomplete result set');
+  }
+  const resolved = new Map<string, AgentGraphRecord>();
+  records.forEach((record, index) => {
+    const selected = distinct[index]!;
+    if (record.graphId !== selected.sourceGraphId || record.recordId !== selected.resultId) {
+      throw new Error('Selected graph result resolver returned a mismatched record');
+    }
+    if (resolved.has(record.recordId)) {
+      throw new Error(`Selected graph result id ${record.recordId} is ambiguous`);
+    }
+    resolved.set(record.recordId, clonePlain(record));
+  });
+  return resolved;
 }
 
 async function applyScheduleStops(
@@ -712,6 +761,9 @@ function scheduledWorkIntent(
     workId: work.workId,
     target: work.target,
     inputIds: work.inputIds,
+    ...(work.selectedResultInputs?.length
+      ? { selectedResultInputs: work.selectedResultInputs }
+      : {}),
     ...(work.replaces ? { replaces: work.replaces } : {}),
   });
   const readinessContextFingerprint = stableHash({
@@ -721,6 +773,9 @@ function scheduledWorkIntent(
     operatorId,
     targetSessionId: topologyBinding.sessionId,
     inputIds: work.inputIds,
+    ...(work.selectedResultInputs?.length
+      ? { selectedResultInputs: work.selectedResultInputs }
+      : {}),
   });
   return {
     schemaVersion: 1,
@@ -733,7 +788,10 @@ function scheduledWorkIntent(
     targetSessionId: topologyBinding.sessionId,
     policyKind: 'supervisor',
     triggerRouteIds: [],
-    triggerRecordIds: [...work.inputIds],
+    triggerRecordIds: [
+      ...work.inputIds,
+      ...(work.selectedResultInputs ?? []).map((input) => input.resultId),
+    ],
   };
 }
 

--- a/packages/runtime/src/stream-graph-schedule-reconcile.ts
+++ b/packages/runtime/src/stream-graph-schedule-reconcile.ts
@@ -513,8 +513,8 @@ function missingWorkInputIds(
   ];
 }
 
-/** Resolved historical records keyed by source graph id, then result id. */
-type SelectedResultCache = Map<string, Map<string, AgentGraphRecord>>;
+/** Historical resolution attempts keyed by source graph id, then result id. */
+type SelectedResultCache = Map<string, Map<string, AgentGraphRecord | undefined>>;
 
 /**
  * Resolves selected historical result inputs, isolating failures per source
@@ -557,6 +557,10 @@ async function resolveSelectedResultRecords(
     }
     const pending = group.filter((selected) => !cached.has(selected.resultId));
     if (pending.length === 0) continue;
+    // Cache unsuccessful attempts for this reconciliation too. Repeated
+    // snapshot reads must not replay a resolver that already failed or
+    // returned records that violate its identity contract.
+    pending.forEach((selected) => cached.set(selected.resultId, undefined));
     let records: readonly AgentGraphRecord[];
     try {
       records = await input.resolveSelectedResultInputs(pending);

--- a/packages/runtime/src/stream-graph-schedule-reconcile.ts
+++ b/packages/runtime/src/stream-graph-schedule-reconcile.ts
@@ -200,11 +200,12 @@ export async function reconcileAgentGraphSchedule(
     const committedRecords = new Map(
       snapshot.observation.projection.records.map((record) => [record.recordId, record]),
     );
-    for (const [recordId, record] of snapshot.selectedResultRecords) {
-      if (committedRecords.has(recordId)) {
-        throw new Error(`Selected graph result id ${recordId} collides with the current graph`);
+    for (const record of snapshot.selectedResultRecords.values()) {
+      if (committedRecords.has(record.recordId)) {
+        throw new Error(
+          `Selected graph result id ${record.recordId} collides with the current graph`,
+        );
       }
-      committedRecords.set(recordId, record);
     }
     const deferredWork: AgentGraphScheduleDeferredWork[] = [];
     let topologyChanged = false;
@@ -216,7 +217,11 @@ export async function reconcileAgentGraphSchedule(
         deferredWork.push({ work, reason: 'graph_closed' });
         continue;
       }
-      const missingInputIds = missingWorkInputIds(work, committedRecords);
+      const missingInputIds = missingWorkInputIds(
+        work,
+        committedRecords,
+        snapshot.selectedResultRecords,
+      );
       if (missingInputIds.length > 0) {
         deferredWork.push({ work, reason: 'input_not_committed', missingInputIds });
         continue;
@@ -296,7 +301,11 @@ export async function reconcileAgentGraphSchedule(
         deferredWork.push({ work, reason: 'graph_closed' });
         continue;
       }
-      const missingInputIds = missingWorkInputIds(work, committedRecords);
+      const missingInputIds = missingWorkInputIds(
+        work,
+        committedRecords,
+        snapshot.selectedResultRecords,
+      );
       if (missingInputIds.length > 0) {
         deferredWork.push({
           work,
@@ -338,9 +347,11 @@ export async function reconcileAgentGraphSchedule(
     const rendered = await Promise.allSettled(
       selected.map(async ({ work, intent }): Promise<PreparedWork> => {
         const inputRecords = [
-          ...work.inputIds,
-          ...(work.selectedResultInputs ?? []).map((selected) => selected.resultId),
-        ].map((recordId) => clonePlain(committedRecords.get(recordId)!));
+          ...work.inputIds.map((recordId) => clonePlain(committedRecords.get(recordId)!)),
+          ...(work.selectedResultInputs ?? []).map((selected) =>
+            clonePlain(snapshot.selectedResultRecords.get(selectedResultKey(selected))!),
+          ),
+        ];
         const inputHandoffs = input.hydrateInputHandoffs
           ? await input.hydrateInputHandoffs(inputRecords)
           : [];
@@ -504,12 +515,13 @@ async function readScheduleSnapshot(
 function missingWorkInputIds(
   work: AgentGraphScheduleWorkView,
   committedRecords: ReadonlyMap<string, AgentGraphRecord>,
+  selectedResultRecords: ReadonlyMap<string, AgentGraphRecord>,
 ): string[] {
   return [
     ...work.inputIds.filter((recordId) => !committedRecords.has(recordId)),
     ...(work.selectedResultInputs ?? [])
-      .map((selected) => selected.resultId)
-      .filter((recordId) => !committedRecords.has(recordId)),
+      .filter((selected) => !selectedResultRecords.has(selectedResultKey(selected)))
+      .map((selected) => selected.resultId),
   ];
 }
 
@@ -579,15 +591,22 @@ async function resolveSelectedResultRecords(
     records.forEach((record) => cached.set(record.recordId, record));
   }
   const resolved = new Map<string, AgentGraphRecord>();
+  const sourceByRecordId = new Map<string, string>();
   for (const selected of distinct) {
     const record = cache.get(selected.sourceGraphId)?.get(selected.resultId);
     if (!record) continue;
-    if (resolved.has(record.recordId)) {
+    const previousSource = sourceByRecordId.get(record.recordId);
+    if (previousSource !== undefined && previousSource !== record.graphId) {
       throw new Error(`Selected graph result id ${record.recordId} is ambiguous`);
     }
-    resolved.set(record.recordId, clonePlain(record));
+    sourceByRecordId.set(record.recordId, record.graphId);
+    resolved.set(selectedResultKey(selected), clonePlain(record));
   }
   return resolved;
+}
+
+function selectedResultKey(selected: AgentGraphSelectedResultInput): string {
+  return `${selected.sourceGraphId}\u0000${selected.resultId}`;
 }
 
 async function applyScheduleStops(

--- a/packages/runtime/src/stream-graph-schedule-reconcile.ts
+++ b/packages/runtime/src/stream-graph-schedule-reconcile.ts
@@ -197,6 +197,9 @@ export async function reconcileAgentGraphSchedule(
       snapshot.observation.projection.records.map((record) => [record.recordId, record]),
     );
     for (const [recordId, record] of snapshot.selectedResultRecords) {
+      if (committedRecords.has(recordId)) {
+        throw new Error(`Selected graph result id ${recordId} collides with the current graph`);
+      }
       committedRecords.set(recordId, record);
     }
     const deferredWork: AgentGraphScheduleDeferredWork[] = [];

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -263,6 +263,14 @@ const viewSchema = z.preprocess(
         .describe(
           'Opaque cursor returned by an earlier view_agent_graph call. Ignored when mode=latest.',
         ),
+      historical_before_epoch: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          'Continue historical selected-result discovery before this epoch, using nextHistoricalBeforeEpoch from an earlier view.',
+        ),
     })
     .strip()
     .superRefine((value, ctx) => {
@@ -331,6 +339,7 @@ function cleanViewInput(input: unknown): unknown {
 export interface ViewAgentGraphToolInput {
   mode?: 'latest' | 'page';
   cursor?: string;
+  historical_before_epoch?: number;
 }
 
 export interface UpdateAgentGraphToolInput {
@@ -446,6 +455,7 @@ export type ViewAgentGraphToolResult = {
   schedule: AgentGraphToolScheduleView;
   runtime: AgentGraphToolRuntimeView;
   historicalSelectedResults: AgentGraphSelectedResultInputView[];
+  nextHistoricalBeforeEpoch: number | null;
   nextCursor?: string;
 };
 
@@ -454,6 +464,7 @@ export type UpdateAgentGraphToolResult = {
   schedule: AgentGraphToolScheduleView;
   runtime: AgentGraphToolRuntimeView;
   historicalSelectedResults: AgentGraphSelectedResultInputView[];
+  nextHistoricalBeforeEpoch: number | null;
   nextCursor?: string;
 };
 
@@ -477,7 +488,10 @@ export interface BuildAgentGraphSupervisorToolsInput {
   graphId: string;
   scheduleStore: AgentGraphScheduleStore;
   observeGraph(): Promise<AgentGraphSupervisorObservation>;
-  listHistoricalSelectedResults?(): Promise<readonly AgentGraphSelectedResultInput[]>;
+  listHistoricalSelectedResults?(beforeEpoch?: number): Promise<{
+    readonly results: readonly AgentGraphSelectedResultInput[];
+    readonly nextBeforeEpoch: number | null;
+  }>;
   /** Register before state reads so runtime/reconciliation transitions cannot escape yield admission. */
   prepareYieldPermit?(): AgentGraphYieldPermit;
   /** Host ownership check performed before append-only schedule admission. */
@@ -523,6 +537,7 @@ export function buildAgentGraphSupervisorTools(
         graphId,
         input.observeGraph,
         input.listHistoricalSelectedResults,
+        toolInput.historical_before_epoch,
         resolveViewCursor(toolInput),
       );
       return {
@@ -557,6 +572,7 @@ export function buildAgentGraphSupervisorTools(
         graphId,
         input.observeGraph,
         input.listHistoricalSelectedResults,
+        undefined,
         undefined,
       );
       return {
@@ -854,19 +870,27 @@ async function readToolGraphView(
   graphId: string,
   observeGraph: () => Promise<AgentGraphSupervisorObservation>,
   listHistoricalSelectedResults:
-    | (() => Promise<readonly AgentGraphSelectedResultInput[]>)
+    | ((beforeEpoch?: number) => Promise<{
+        readonly results: readonly AgentGraphSelectedResultInput[];
+        readonly nextBeforeEpoch: number | null;
+      }>)
     | undefined,
+  historicalBeforeEpoch: number | undefined,
   cursor: string | undefined,
 ): Promise<{
   schedule: AgentGraphToolScheduleView;
   runtime: AgentGraphToolRuntimeView;
   historicalSelectedResults: AgentGraphSelectedResultInputView[];
+  nextHistoricalBeforeEpoch: number | null;
   nextCursor?: string;
 }> {
-  const [updates, observation, historicalSelectedResults] = await Promise.all([
+  const [updates, observation, historicalPage] = await Promise.all([
     store.listAgentGraphScheduleUpdates(graphId),
     observeGraph(),
-    listHistoricalSelectedResults?.() ?? [],
+    listHistoricalSelectedResults?.(historicalBeforeEpoch) ?? {
+      results: [],
+      nextBeforeEpoch: null,
+    },
   ]);
   assertGraphObservation(graphId, observation);
   const projection = projectAgentGraphSchedule(graphId, updates);
@@ -874,9 +898,10 @@ async function readToolGraphView(
   return {
     schedule: agentGraphToolScheduleView(projection, livePage),
     runtime: agentGraphToolRuntimeView(observation, livePage),
-    historicalSelectedResults: historicalSelectedResults
+    historicalSelectedResults: historicalPage.results
       .slice(0, TOOL_VIEW_MAX_HISTORICAL_RESULTS)
       .map((selected) => ({ ...selected })),
+    nextHistoricalBeforeEpoch: historicalPage.nextBeforeEpoch,
     ...(livePage.nextCursor ? { nextCursor: livePage.nextCursor } : {}),
   };
 }

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -5,6 +5,7 @@ import {
   AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS,
   AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS,
   AGENT_GRAPH_SCHEDULE_MAX_RESULT_IDS,
+  AGENT_GRAPH_SCHEDULE_MAX_SELECTED_RESULT_INPUTS,
   AGENT_GRAPH_SCHEDULE_MAX_STOP,
   AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
   decodeAgentGraphScheduleUpdate,
@@ -210,6 +211,16 @@ const updateSchema = z.preprocess(
     .superRefine((value, ctx) => {
       const addWork = value.add_work ?? [];
       const stop = value.stop ?? [];
+      if (
+        addWork.reduce((count, work) => count + (work.selected_result_inputs?.length ?? 0), 0) >
+        AGENT_GRAPH_SCHEDULE_MAX_SELECTED_RESULT_INPUTS
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['add_work'],
+          message: `One graph update may select at most ${AGENT_GRAPH_SCHEDULE_MAX_SELECTED_RESULT_INPUTS} historical results`,
+        });
+      }
       if (value.operation) {
         const hasSelectedPayload =
           (value.operation === 'add_work' && addWork.length > 0) ||

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -12,6 +12,7 @@ import {
   type AgentGraphScheduleStore,
   type AgentGraphScheduleUpdate,
   type AgentGraphScheduleUpdateRequest,
+  type AgentGraphSelectedResultInput,
   type AgentGraphScheduledWork,
   type AgentGraphStoppedTarget,
   type AgentGraphWorkTarget,
@@ -41,6 +42,7 @@ const TOOL_VIEW_MAX_INSTRUCTION_CHARS = 2_000;
 const TOOL_VIEW_MAX_ACTIVITY = 64;
 const TOOL_VIEW_MAX_TERMINAL_OPERATORS = 64;
 const TOOL_VIEW_MAX_LIVE_STATE = 64;
+const TOOL_VIEW_MAX_HISTORICAL_RESULTS = 64;
 
 const identitySchema = z
   .string()
@@ -85,6 +87,20 @@ const addWorkSchema = z.preprocess(
         .max(AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS)
         .default([])
         .describe('Durable record or result ids that form this work item input frontier.'),
+      selected_result_inputs: z
+        .array(
+          z
+            .object({
+              source_graph_id: identitySchema.describe('Completed earlier graph epoch id.'),
+              result_id: identitySchema.describe(
+                'Record id selected by the earlier graph finish operation.',
+              ),
+            })
+            .strict(),
+        )
+        .max(AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS)
+        .optional()
+        .describe('Explicit results selected from completed earlier graph epochs.'),
       replaces: identitySchema
         .optional()
         .describe('Existing work or activation superseded by this request.'),
@@ -119,6 +135,31 @@ const addWorkSchema = z.preprocess(
         });
       }
       addDuplicateIssue(ctx, value.input_ids, ['input_ids']);
+      addDuplicateIssue(
+        ctx,
+        (value.selected_result_inputs ?? []).map((input) => input.result_id),
+        ['selected_result_inputs'],
+      );
+      const currentInputIds = new Set(value.input_ids);
+      value.selected_result_inputs?.forEach((selected, index) => {
+        if (currentInputIds.has(selected.result_id)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['selected_result_inputs', index, 'result_id'],
+            message: 'A result id cannot be both a current and historical graph input',
+          });
+        }
+      });
+      if (
+        value.input_ids.length + (value.selected_result_inputs?.length ?? 0) >
+        AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['selected_result_inputs'],
+          message: `Combined graph inputs must contain at most ${AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS} entries`,
+        });
+      }
     }),
 );
 
@@ -301,6 +342,10 @@ export interface UpdateAgentGraphToolInput {
     operator_id?: string;
     instruction: string;
     input_ids?: string[];
+    selected_result_inputs?: Array<{
+      source_graph_id: string;
+      result_id: string;
+    }>;
     replaces?: string;
     replacement_mode?: 'none' | 'replace';
   }>;
@@ -394,10 +439,13 @@ export interface AgentGraphToolRuntimeView {
   omittedActivityCount: number;
 }
 
+export interface AgentGraphSelectedResultInputView extends AgentGraphSelectedResultInput {}
+
 export type ViewAgentGraphToolResult = {
   kind: 'agent_graph_view';
   schedule: AgentGraphToolScheduleView;
   runtime: AgentGraphToolRuntimeView;
+  historicalSelectedResults: AgentGraphSelectedResultInputView[];
   nextCursor?: string;
 };
 
@@ -405,6 +453,7 @@ export type UpdateAgentGraphToolResult = {
   kind: 'agent_graph_updated';
   schedule: AgentGraphToolScheduleView;
   runtime: AgentGraphToolRuntimeView;
+  historicalSelectedResults: AgentGraphSelectedResultInputView[];
   nextCursor?: string;
 };
 
@@ -428,6 +477,7 @@ export interface BuildAgentGraphSupervisorToolsInput {
   graphId: string;
   scheduleStore: AgentGraphScheduleStore;
   observeGraph(): Promise<AgentGraphSupervisorObservation>;
+  listHistoricalSelectedResults?(): Promise<readonly AgentGraphSelectedResultInput[]>;
   /** Register before state reads so runtime/reconciliation transitions cannot escape yield admission. */
   prepareYieldPermit?(): AgentGraphYieldPermit;
   /** Host ownership check performed before append-only schedule admission. */
@@ -472,6 +522,7 @@ export function buildAgentGraphSupervisorTools(
         input.scheduleStore,
         graphId,
         input.observeGraph,
+        input.listHistoricalSelectedResults,
         resolveViewCursor(toolInput),
       );
       return {
@@ -505,6 +556,7 @@ export function buildAgentGraphSupervisorTools(
         input.scheduleStore,
         graphId,
         input.observeGraph,
+        input.listHistoricalSelectedResults,
         undefined,
       );
       return {
@@ -604,6 +656,12 @@ export function compileAgentGraphScheduleUpdate(input: {
   const addWork = addWorkInput.map((work, index): AgentGraphScheduledWork => {
     const target = normalizeWorkTarget(work);
     const inputIds = normalizeUniqueIdentities(work.input_ids, 'input id');
+    const selectedResultInputs: AgentGraphSelectedResultInput[] = (
+      work.selected_result_inputs ?? []
+    ).map((input) => ({
+      sourceGraphId: requireIdentity(input.source_graph_id, 'source graph id'),
+      resultId: requireIdentity(input.result_id, 'selected result id'),
+    }));
     const workHash = stableHash({
       schemaVersion: AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
       updateId,
@@ -618,6 +676,7 @@ export function compileAgentGraphScheduleUpdate(input: {
         'instruction',
       ),
       inputIds,
+      ...(selectedResultInputs.length > 0 ? { selectedResultInputs } : {}),
       ...(work.replaces && work.replacement_mode !== 'none'
         ? { replaces: requireIdentity(work.replaces, 'replacement target id') }
         : {}),
@@ -698,6 +757,9 @@ export function projectAgentGraphSchedule(
         ...item,
         target: { ...item.target },
         inputIds: [...item.inputIds],
+        ...(item.selectedResultInputs
+          ? { selectedResultInputs: item.selectedResultInputs.map((input) => ({ ...input })) }
+          : {}),
         status: 'requested',
         updateId: update.updateId,
         revision: update.revision,
@@ -755,6 +817,9 @@ function agentGraphToolScheduleView(
       ...item,
       target: { ...item.target },
       inputIds: [...item.inputIds],
+      ...(item.selectedResultInputs
+        ? { selectedResultInputs: item.selectedResultInputs.map((input) => ({ ...input })) }
+        : {}),
       instruction: instructionTruncated
         ? `${item.instruction.slice(0, TOOL_VIEW_MAX_INSTRUCTION_CHARS)}…`
         : item.instruction,
@@ -788,15 +853,20 @@ async function readToolGraphView(
   store: AgentGraphScheduleStore,
   graphId: string,
   observeGraph: () => Promise<AgentGraphSupervisorObservation>,
+  listHistoricalSelectedResults:
+    | (() => Promise<readonly AgentGraphSelectedResultInput[]>)
+    | undefined,
   cursor: string | undefined,
 ): Promise<{
   schedule: AgentGraphToolScheduleView;
   runtime: AgentGraphToolRuntimeView;
+  historicalSelectedResults: AgentGraphSelectedResultInputView[];
   nextCursor?: string;
 }> {
-  const [updates, observation] = await Promise.all([
+  const [updates, observation, historicalSelectedResults] = await Promise.all([
     store.listAgentGraphScheduleUpdates(graphId),
     observeGraph(),
+    listHistoricalSelectedResults?.() ?? [],
   ]);
   assertGraphObservation(graphId, observation);
   const projection = projectAgentGraphSchedule(graphId, updates);
@@ -804,6 +874,9 @@ async function readToolGraphView(
   return {
     schedule: agentGraphToolScheduleView(projection, livePage),
     runtime: agentGraphToolRuntimeView(observation, livePage),
+    historicalSelectedResults: historicalSelectedResults
+      .slice(0, TOOL_VIEW_MAX_HISTORICAL_RESULTS)
+      .map((selected) => ({ ...selected })),
     ...(livePage.nextCursor ? { nextCursor: livePage.nextCursor } : {}),
   };
 }

--- a/packages/storage/src/__tests__/agent-graph-epochs.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-epochs.test.ts
@@ -85,6 +85,7 @@ describe('SQLite Agent Graph epochs', () => {
         },
       ],
       nextBeforeEpoch: 2,
+      currentEpoch: 2,
     });
     assert.deepEqual(
       await store.listAgentGraphEpochPage({
@@ -103,8 +104,16 @@ describe('SQLite Agent Graph epochs', () => {
           },
         ],
         nextBeforeEpoch: null,
+        currentEpoch: 2,
       },
     );
+    // A root Session without durable rows reports no current epoch, letting the
+    // caller fall back to the legacy virtual identity.
+    assert.deepEqual(await store.listAgentGraphEpochPage({ rootSessionId: 'root-2', limit: 1 }), {
+      epochs: [],
+      nextBeforeEpoch: null,
+      currentEpoch: null,
+    });
     store.close();
   });
 

--- a/packages/storage/src/__tests__/agent-graph-epochs.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-epochs.test.ts
@@ -73,6 +73,38 @@ describe('SQLite Agent Graph epochs', () => {
         { epoch: 2, graphId: 'agent_graph_2' },
       ],
     );
+    assert.equal((await store.readAgentGraphEpochByGraphId('agent_graph_1'))?.epoch, 1);
+    assert.deepEqual(await store.listAgentGraphEpochPage({ rootSessionId: 'root-1', limit: 1 }), {
+      epochs: [
+        {
+          schemaVersion: 1,
+          rootSessionId: 'root-1',
+          epoch: 2,
+          graphId: 'agent_graph_2',
+          createdAt: 100,
+        },
+      ],
+      nextBeforeEpoch: 2,
+    });
+    assert.deepEqual(
+      await store.listAgentGraphEpochPage({
+        rootSessionId: 'root-1',
+        beforeEpoch: 2,
+        limit: 1,
+      }),
+      {
+        epochs: [
+          {
+            schemaVersion: 1,
+            rootSessionId: 'root-1',
+            epoch: 1,
+            graphId: 'agent_graph_1',
+            createdAt: 0,
+          },
+        ],
+        nextBeforeEpoch: null,
+      },
+    );
     store.close();
   });
 

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -2761,7 +2761,11 @@ export class SqliteSessionMetadataStore {
     rootSessionId: string;
     beforeEpoch?: number;
     limit: number;
-  }): Promise<{ epochs: AgentGraphEpochBinding[]; nextBeforeEpoch: number | null }> {
+  }): Promise<{
+    epochs: AgentGraphEpochBinding[];
+    nextBeforeEpoch: number | null;
+    currentEpoch: number | null;
+  }> {
     this.assertOpen();
     assertSafeSessionId(request.rootSessionId);
     if (
@@ -2773,32 +2777,36 @@ export class SqliteSessionMetadataStore {
     ) {
       throw new Error('Invalid Agent Graph epoch page request');
     }
-    const rows = this.db
-      .prepare(
-        `
-        SELECT
-          schema_version AS schemaVersion,
-          root_session_id AS rootSessionId,
-          epoch,
-          graph_id AS graphId,
-          created_at AS createdAt
-        FROM agent_graph_epochs
-        WHERE root_session_id = ? AND epoch < ?
-        ORDER BY epoch DESC
-        LIMIT ?
-      `,
-      )
-      .all(
-        request.rootSessionId,
-        request.beforeEpoch ?? Number.MAX_SAFE_INTEGER,
-        request.limit + 1,
-      ) as unknown as AgentGraphEpochRow[];
-    const hasMore = rows.length > request.limit;
-    const epochs = rows.slice(0, request.limit).map(decodeAgentGraphEpochBinding);
-    return {
-      epochs,
-      nextBeforeEpoch: hasMore ? (epochs.at(-1)?.epoch ?? null) : null,
-    };
+    return this.readTransaction(() => {
+      const current = this.readCurrentAgentGraphEpochSync(request.rootSessionId);
+      const rows = this.db
+        .prepare(
+          `
+          SELECT
+            schema_version AS schemaVersion,
+            root_session_id AS rootSessionId,
+            epoch,
+            graph_id AS graphId,
+            created_at AS createdAt
+          FROM agent_graph_epochs
+          WHERE root_session_id = ? AND epoch < ?
+          ORDER BY epoch DESC
+          LIMIT ?
+        `,
+        )
+        .all(
+          request.rootSessionId,
+          request.beforeEpoch ?? Number.MAX_SAFE_INTEGER,
+          request.limit + 1,
+        ) as unknown as AgentGraphEpochRow[];
+      const hasMore = rows.length > request.limit;
+      const epochs = rows.slice(0, request.limit).map(decodeAgentGraphEpochBinding);
+      return {
+        epochs,
+        nextBeforeEpoch: hasMore ? (epochs.at(-1)?.epoch ?? null) : null,
+        currentEpoch: current?.epoch ?? null,
+      };
+    });
   }
 
   async purgeAgentGraphEpochs(rootSessionId: string): Promise<number> {

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -2751,6 +2751,56 @@ export class SqliteSessionMetadataStore {
     return rows.map(decodeAgentGraphEpochBinding);
   }
 
+  async readAgentGraphEpochByGraphId(graphId: string): Promise<AgentGraphEpochBinding | undefined> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    return this.readAgentGraphEpochByGraphIdSync(graphId);
+  }
+
+  async listAgentGraphEpochPage(request: {
+    rootSessionId: string;
+    beforeEpoch?: number;
+    limit: number;
+  }): Promise<{ epochs: AgentGraphEpochBinding[]; nextBeforeEpoch: number | null }> {
+    this.assertOpen();
+    assertSafeSessionId(request.rootSessionId);
+    if (
+      !Number.isSafeInteger(request.limit) ||
+      request.limit < 1 ||
+      request.limit > 128 ||
+      (request.beforeEpoch !== undefined &&
+        (!Number.isSafeInteger(request.beforeEpoch) || request.beforeEpoch < 1))
+    ) {
+      throw new Error('Invalid Agent Graph epoch page request');
+    }
+    const rows = this.db
+      .prepare(
+        `
+        SELECT
+          schema_version AS schemaVersion,
+          root_session_id AS rootSessionId,
+          epoch,
+          graph_id AS graphId,
+          created_at AS createdAt
+        FROM agent_graph_epochs
+        WHERE root_session_id = ? AND epoch < ?
+        ORDER BY epoch DESC
+        LIMIT ?
+      `,
+      )
+      .all(
+        request.rootSessionId,
+        request.beforeEpoch ?? Number.MAX_SAFE_INTEGER,
+        request.limit + 1,
+      ) as unknown as AgentGraphEpochRow[];
+    const hasMore = rows.length > request.limit;
+    const epochs = rows.slice(0, request.limit).map(decodeAgentGraphEpochBinding);
+    return {
+      epochs,
+      nextBeforeEpoch: hasMore ? (epochs.at(-1)?.epoch ?? null) : null,
+    };
+  }
+
   async purgeAgentGraphEpochs(rootSessionId: string): Promise<number> {
     this.assertOpen();
     assertSafeSessionId(rootSessionId);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -2212,6 +2212,9 @@ export class SqliteSessionMetadataStore {
           ...work,
           target: { ...work.target },
           inputIds: [...work.inputIds],
+          ...(work.selectedResultInputs
+            ? { selectedResultInputs: work.selectedResultInputs.map((input) => ({ ...input })) }
+            : {}),
         })),
         stop: request.stop.map((stopped) => ({ ...stopped })),
         ...(request.finish


### PR DESCRIPTION
## Summary

- persist typed `selected_result_inputs` with the source graph identity for scheduled work
- admit only committed results selected by a finished earlier epoch of the same root Session
- revalidate historical inputs during recovery and hydrate them with explicit graph provenance
- page historical result discovery without reusing old operators, claims, routes, or control state

Historical results cross the epoch boundary as immutable data only. Runtime Host authorization verifies the root, epoch ordering, finished schedule selection, and exact RuntimeEvent-backed record before the schedule is committed; recovery performs the same resolution again. Input counts and discovery pages are bounded, and ambiguous current/historical record identities fail closed.

This completes the cross-epoch result-input slice of #2588 after the historical-read slice.

Depends on #2991
Refs #2588

This is intentionally opened as a Draft during the pre-Incubator stabilization window. It is not requesting merge until feature work resumes.

## Verification

- `npm run build:test`
- `npm run typecheck`
- Agent Graph authority, reconciliation, handoff, protocol, storage, Desktop, and TUI tests in the stacked latest-main run — 168 passed
- Biome check on all changed files
- `git diff --check`

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — a new Agent Graph epoch can explicitly consume selected results from an earlier finished epoch
- [ ] No

<details>
<summary>中文说明</summary>

## 摘要

- 为 schedule work 持久化带来源 graph 身份的 `selected_result_inputs`
- 只允许引用同一 root Session 下、已结束旧 epoch 在 `finish` 中明确选择的已提交结果
- 恢复时重新执行相同授权，并在传给新 operator 的输入中保留 graph 来源
- 历史结果发现采用有界分页，不复用旧 operator、claim、route 或控制状态

跨 epoch 传递的只有不可变数据，不包含旧图的控制权。Runtime Host 会在 schedule 提交前验证 root、epoch 顺序、旧图的 `finish` 选择以及由 RuntimeEvent 支撑的精确 record；崩溃恢复时再次验证。输入数量与发现页都有上限，当前图和历史图的 record identity 若出现歧义会 fail closed。

这是 #2588 的跨 epoch 结果输入部分，接续前一项历史读取改动。

本 PR 在进入孵化器前的稳定期内以 Draft 打开；在 feature 合并恢复前不请求进入 `main`。

</details>

## AI disclosure / AI 披露

This PR was implemented by Codex under me2seeks’s direction and review. / 本 PR 由 Codex 在 me2seeks 的指导与审核下完成。
