### PR TITLE
fix(desktop): move model switch warning into picker

### DIFF
--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1248,6 +1248,13 @@ function AppShellContent({
     content: <PlanProposalCard proposal={proposal} planMode={planMode} />,
   }));
   const activeMessageLoading = Boolean(activeId && messageLoadPending);
+  // Session switches clear the transcript projection before its async read.
+  // Keep the switch warning anchored to the durable session summary, while
+  // retaining the local projection for an optimistic first message that has
+  // not reached the catalog yet.
+  const modelSwitchHasHistory =
+    activeSessionForView?.lastMessageAt !== undefined ||
+    messages.some((message) => message.type === 'user' || message.type === 'assistant');
   // PR110c: OnboardingState is now the single source of truth for
   // first-run UI. The renderer never re-derives provider readiness;
   // `useOnboardingSnapshot()` pulls the derived state from the main
@@ -2945,14 +2952,11 @@ function AppShellContent({
                   }
                   modelLabel={activeModelLabel ?? newChatModelLabel ?? undefined}
                   activeSession={activeSessionForView}
-                  activeConnectionLabel={activeConnectionLabel}
                   activeModel={activeModel}
                   activeModelLabel={activeModelLabel}
                   activeProviderType={activeConnection?.providerType}
                   modelChoices={chatModelChoices}
-                  modelSwitchHasHistory={messages.some(
-                    (message) => message.type === 'user' || message.type === 'assistant',
-                  )}
+                  modelSwitchHasHistory={modelSwitchHasHistory}
                   renderProviderMark={(type) => <ProviderBrandMark type={type} />}
                   modelChangePending={activeId ? pendingSessionModelBySession[activeId] === true : false}
                   onModelChange={(input) => setSessionModel(input)}

--- a/apps/desktop/src/renderer/styles/model-switcher.css
+++ b/apps/desktop/src/renderer/styles/model-switcher.css
@@ -26,9 +26,25 @@
   white-space: nowrap;
 }
 
-/* A quiet, always-discoverable warning on the EXISTING-conversation picker.
-   The whole trigger owns the tooltip, so the icon adds no second focus target. */
-.maka-model-switch-warning-icon {
+/* Switching can abandon a provider prompt cache, but that is a property of
+   the pending action, not the current model. Keep the notice inside the open
+   picker so a healthy resting control never looks unhealthy. */
+.maka-model-switch-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-1-5);
+  margin: var(--space-1);
+  padding: var(--space-1-5) var(--space-2);
+  border: var(--border-width-hairline) solid var(--warning-wash-border);
+  border-radius: var(--radius-control);
+  background: var(--warning-wash);
+  color: var(--foreground-secondary);
+  font: var(--maka-text-supporting);
+  white-space: normal;
+}
+
+.maka-model-switch-notice > svg {
+  margin-top: 1px;
   color: var(--warning-text);
   flex: 0 0 auto;
 }

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -195,7 +195,6 @@ const baseComposerProps: ComposerProps = {
   onStop: noop,
   modelLabel: 'Claude Sonnet 4.5',
   activeSession,
-  activeConnectionLabel: 'Anthropic',
   activeModel: 'claude-sonnet-4-5',
   activeModelLabel: 'Claude Sonnet 4.5',
   modelChoices,

--- a/packages/ui/src/chat-model-switcher.tsx
+++ b/packages/ui/src/chat-model-switcher.tsx
@@ -17,7 +17,7 @@
  * Composer places it immediately after the model control in the left footer.
  */
 
-import { type ReactNode, useMemo } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 import { Button as UiButton } from '@astryxdesign/core';
 import { DropdownMenu, DropdownMenuItem } from '@astryxdesign/core/DropdownMenu';
 import { ICON_SIZE, AlertTriangle, Check, Settings } from './icons.js';
@@ -173,7 +173,6 @@ export function ThinkingLevelSelector(props: {
 export function ChatModelSwitcher(props: {
   activeSession: SessionSummary;
   activeModel?: string;
-  activeConnectionLabel?: string;
   activeModelLabel?: string;
   currentProviderType?: ProviderType;
   choices: ChatModelChoice[];
@@ -188,63 +187,69 @@ export function ChatModelSwitcher(props: {
   const currentModel = props.activeModel ?? props.activeSession.model;
   const currentValue = modelChoiceValue(props.activeSession.llmConnectionSlug, currentModel);
   const pending = Boolean(props.pending);
-  const showWarning = props.hasConversationHistory === true;
+  const [menuOpen, setMenuOpen] = useState(false);
   const disabled = pending || Boolean(props.disabledReason) || !props.onChange || props.choices.length === 0;
   const grouped = modelMenuGroups(props.choices, locale);
   const currentKnownChoice = props.choices.some((choice) => modelChoiceValue(choice.connectionSlug, choice.model) === currentValue);
   const displayLabel = props.activeModelLabel ?? currentModel;
-  const currentSessionModelTitle = props.activeConnectionLabel && props.activeModelLabel
-    ? copy.pinnedSession(props.activeConnectionLabel, props.activeModelLabel)
-    : copy.switchSession;
   const title = pending
     ? `${copy.switching}…`
-    : props.disabledReason ??
-      `${copy.switchTitle(currentSessionModelTitle)}${showWarning ? ` ${copy.switchWarning}` : ''}`;
+    : props.disabledReason ?? copy.switchAriaLabel;
+  const announceWarning = menuOpen && props.hasConversationHistory === true;
 
   return (
-    <DropdownMenu
-      placement="above"
-      hasChevron={false}
-      className="maka-composer-quiet-menu"
-      button={{
-        label: displayLabel,
-        icon: providerMarkIcon(props.currentProviderType, props.renderProviderMark),
-        endContent: pending || !showWarning ? undefined : (
-          <AlertTriangle
-            className="maka-model-switch-warning-icon"
-            size={ICON_SIZE.meta}
-            aria-hidden="true"
-          />
-        ),
-        variant: 'ghost',
-        size: 'sm',
-        isDisabled: disabled,
-        isLoading: pending,
-        tooltip: title,
-        className: 'maka-model-switcher-trigger',
-        'aria-label': copy.switchAriaLabel,
-        'aria-description': showWarning ? copy.switchWarning : undefined,
-      }}
-    >
-      <ModelMenuItems
-        groups={grouped}
-        currentValue={currentValue}
-        leadingOption={!currentKnownChoice ? { label: displayLabel, providerType: props.currentProviderType } : undefined}
-        renderProviderMark={props.renderProviderMark}
-        disabled={disabled}
-        onPick={async (next) => {
-          if (
-            next.llmConnectionSlug === props.activeSession.llmConnectionSlug &&
-            next.model === currentModel
-          ) return;
-          try {
-            await props.onChange?.(next);
-          } catch {
-            // The AppShell action owner reports the visible model-switch failure.
-          }
+    <>
+      <DropdownMenu
+        placement="above"
+        hasChevron={false}
+        className="maka-composer-quiet-menu"
+        onOpenChange={setMenuOpen}
+        button={{
+          label: displayLabel,
+          icon: providerMarkIcon(props.currentProviderType, props.renderProviderMark),
+          variant: 'ghost',
+          size: 'sm',
+          isDisabled: disabled,
+          isLoading: pending,
+          tooltip: title,
+          className: 'maka-model-switcher-trigger',
+          'aria-label': copy.switchAriaLabel,
         }}
-      />
-    </DropdownMenu>
+      >
+        {announceWarning ? (
+          <div className="maka-model-switch-notice" aria-hidden="true">
+            <AlertTriangle size={ICON_SIZE.meta} />
+            <span>{copy.switchWarning}</span>
+          </div>
+        ) : null}
+        <ModelMenuItems
+          groups={grouped}
+          currentValue={currentValue}
+          leadingOption={!currentKnownChoice ? { label: displayLabel, providerType: props.currentProviderType } : undefined}
+          renderProviderMark={props.renderProviderMark}
+          disabled={disabled}
+          onPick={async (next) => {
+            if (
+              next.llmConnectionSlug === props.activeSession.llmConnectionSlug &&
+              next.model === currentModel
+            ) return;
+            try {
+              await props.onChange?.(next);
+            } catch {
+              // The AppShell action owner reports the visible model-switch failure.
+            }
+          }}
+        />
+      </DropdownMenu>
+      <span
+        className="maka-visually-hidden maka-model-switch-announcement"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {announceWarning ? copy.switchWarning : ''}
+      </span>
+    </>
   );
 }
 

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -255,7 +255,6 @@ export const Composer = forwardRef<
     onPasteAsQuote?(input: { text: string; label?: string }): void;
     modelLabel?: string;
     activeSession?: SessionSummary;
-    activeConnectionLabel?: string;
     activeModel?: string;
     activeModelLabel?: string;
     activeProviderType?: ProviderType;
@@ -1679,7 +1678,6 @@ export const Composer = forwardRef<
                   <ChatModelSwitcher
                     activeSession={props.activeSession}
                     activeModel={props.activeModel}
-                    activeConnectionLabel={props.activeConnectionLabel}
                     activeModelLabel={props.activeModelLabel}
                     currentProviderType={props.activeProviderType}
                     choices={props.modelChoices ?? []}

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -114,9 +114,6 @@ export interface ConversationCopy {
     switching: string;
     model: string;
     switchAriaLabel: string;
-    switchSession: string;
-    pinnedSession: (connection: string, model: string) => string;
-    switchTitle: (sessionTitle: string) => string;
     switchWarning: string;
     newChatAriaLabel: (label: string) => string;
     newChatTitle: (label: string) => string;
@@ -364,10 +361,8 @@ const CONVERSATION_COPY = {
       // Short single-token labels — trigger + popout size to content.
       // Canonical ladder: 默认 / 关 / 低 / 中 / 高 / 超高 (minimal/max when offered).
       level: { off: '关', minimal: '最少', low: '低', medium: '中', high: '高', xhigh: '超高', max: '最高' },
-      switching: '切换中', model: '模型', switchAriaLabel: '切换当前会话模型', switchSession: '切换当前会话使用的模型',
-      pinnedSession: (connection, model) => `本会话固定模型：${connection} · ${model}`,
-      switchTitle: (title) => `${title}。设置里的默认模型只影响新建会话；这里会更新当前会话。`,
-      switchWarning: '在已有对话中切换模型可能需要重新建立服务商提示缓存，下一次请求可能更慢或更贵。',
+      switching: '切换中', model: '模型', switchAriaLabel: '切换当前会话模型',
+      switchWarning: '切换模型可能需要重建服务商提示缓存，使下一次请求更慢或成本更高。',
       newChatAriaLabel: (label) => `选择新对话模型，当前 ${label}`, newChatTitle: (label) => `新对话使用的模型：${label}`,
       configureAriaLabel: (label) => `配置模型连接，当前 ${label}`, configureTitle: '配置模型连接',
     },
@@ -504,10 +499,8 @@ const CONVERSATION_COPY = {
     model: {
       thinkingLevel: 'Thinking level', thinkingUnsupported: 'This model does not support thinking-level changes', changeThinkingLevel: 'Change the current model thinking level', defaultLevel: 'Model default',
       level: { off: 'Off', minimal: 'Minimal', low: 'Low', medium: 'Medium', high: 'High', xhigh: 'Extra high', max: 'Maximum' },
-      switching: 'Switching', model: 'Model', switchAriaLabel: 'Switch model for this conversation', switchSession: 'Switch the model used by this conversation',
-      pinnedSession: (connection, model) => `Model fixed for this conversation: ${connection} · ${model}`,
-      switchTitle: (title) => `${title}. The default model in Settings affects only new conversations; this updates the current conversation.`,
-      switchWarning: 'Changing the model in an existing conversation may rebuild the provider prompt cache, so the next request can be slower or cost more.',
+      switching: 'Switching', model: 'Model', switchAriaLabel: 'Switch model for this conversation',
+      switchWarning: 'Switching may rebuild the provider prompt cache, making the next request slower or more expensive.',
       newChatAriaLabel: (label) => `Choose a model for the new conversation, currently ${label}`, newChatTitle: (label) => `Model for the new conversation: ${label}`,
       configureAriaLabel: (label) => `Configure model connections, currently ${label}`, configureTitle: 'Configure model connections',
     },

--- a/packages/ui/stories/attachment.stories.tsx
+++ b/packages/ui/stories/attachment.stories.tsx
@@ -82,7 +82,6 @@ const baseComposer: ComposerProps = {
   onStop: noop,
   modelLabel: 'Claude Sonnet 4.5',
   activeSession: session(),
-  activeConnectionLabel: 'Anthropic',
   activeModel: 'claude-sonnet-4-5',
   activeModelLabel: 'Claude Sonnet 4.5',
   modelChoices,

--- a/packages/ui/stories/model-picker.stories.tsx
+++ b/packages/ui/stories/model-picker.stories.tsx
@@ -82,7 +82,8 @@ export const Default: Story = {
 };
 
 // Real path: an existing conversation -> composer footer model control. The
-// warning belongs only to this picker; the new-chat picker below stays quiet.
+// cache notice belongs inside this picker's open decision surface; the resting
+// trigger and the new-chat picker below stay quiet.
 export const ExistingConversation: Story = {
   render: function ExistingConversationRender() {
     const [value, setValue] = useState('anthropic-team:claude-sonnet-4');
@@ -102,11 +103,10 @@ export const ExistingConversation: Story = {
       permissionMode: 'ask',
     } satisfies SessionSummary;
     return (
-      <div style={{ width: 460 }}>
+      <div style={{ width: 460, maxWidth: '100%' }}>
         <ChatModelSwitcher
           activeSession={activeSession}
           activeModelLabel={selectedLabel(value)}
-          activeConnectionLabel="Anthropic"
           currentProviderType="anthropic"
           choices={CHOICES}
           hasConversationHistory
@@ -117,16 +117,44 @@ export const ExistingConversation: Story = {
       </div>
     );
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ canvasElement, globals }) => {
+    const english = globals.locale === 'en';
+    const warning = english
+      ? 'Switching may rebuild the provider prompt cache, making the next request slower or more expensive.'
+      : '切换模型可能需要重建服务商提示缓存，使下一次请求更慢或成本更高。';
     const trigger = within(canvasElement).getByRole('button', {
-      name: '切换当前会话模型',
+      name: /切换当前会话模型|Switch model for this conversation/,
     });
-    await expect(trigger).toHaveAttribute(
-      'aria-description',
-      '在已有对话中切换模型可能需要重新建立服务商提示缓存，下一次请求可能更慢或更贵。',
-    );
+    const announcement = canvasElement.querySelector<HTMLElement>('.maka-model-switch-announcement');
+    await expect(announcement).toHaveAttribute('role', 'status');
+    await expect(trigger).not.toHaveAttribute('aria-description');
+    await expect(announcement).toBeEmptyDOMElement();
+    await expect(document.body.querySelector('.maka-model-switch-notice')).not.toBeInTheDocument();
+
     await userEvent.hover(trigger);
-    await within(document.body).findByText(/下一次请求可能更慢或更贵/);
+    await within(document.body).findByText(
+      english ? 'Switch model for this conversation' : '切换当前会话模型',
+    );
+    await userEvent.unhover(trigger);
+
+    await userEvent.click(trigger);
+    const notice = document.body.querySelector('.maka-model-switch-notice');
+    await expect(notice).toBeInTheDocument();
+    await expect(notice).toHaveAttribute('aria-hidden', 'true');
+    await expect(notice).toHaveTextContent(warning);
+    await expect(announcement).toHaveTextContent(warning);
+    await expect(announcement).toHaveAttribute('aria-live', 'polite');
+    await expect(announcement).toHaveAttribute('aria-atomic', 'true');
+    const menu = within(document.body).getByRole('menu');
+    await expect(menu).not.toContainElement(announcement);
+
+    await userEvent.keyboard('{Escape}');
+    await expect(announcement).toBeEmptyDOMElement();
+    await expect(document.body.querySelector('.maka-model-switch-notice')).not.toBeInTheDocument();
+
+    await userEvent.keyboard('{ArrowDown}');
+    await expect(announcement).toHaveTextContent(warning);
+    await expect(document.body.querySelector('.maka-model-switch-notice')).toBeInTheDocument();
   },
 };
 
@@ -134,7 +162,7 @@ export const ExistingConversation: Story = {
 // prefix to abandon yet, so this stays as quiet as the new-chat picker.
 export const EmptyConversation: Story = {
   render: () => (
-    <div style={{ width: 460 }}>
+    <div style={{ width: 460, maxWidth: '100%' }}>
       <ChatModelSwitcher
         activeSession={{
           id: 'storybook-empty-model-switch',
@@ -146,12 +174,11 @@ export const EmptyConversation: Story = {
           status: 'active',
           backend: 'ai-sdk',
           llmConnectionSlug: 'anthropic-team',
-          connectionLocked: true,
+          connectionLocked: false,
           model: 'claude-sonnet-4',
           permissionMode: 'ask',
         }}
         activeModelLabel="Claude Sonnet 4"
-        activeConnectionLabel="Anthropic"
         currentProviderType="anthropic"
         choices={CHOICES}
         renderProviderMark={providerMark}
@@ -161,12 +188,17 @@ export const EmptyConversation: Story = {
   ),
   play: async ({ canvasElement }) => {
     const trigger = within(canvasElement).getByRole('button', {
-      name: '切换当前会话模型',
+      name: /切换当前会话模型|Switch model for this conversation/,
     });
+    const announcement = canvasElement.querySelector<HTMLElement>('.maka-model-switch-announcement');
+    await expect(announcement).toHaveAttribute('role', 'status');
     await expect(trigger).not.toHaveAttribute('aria-description');
-    await expect(
-      trigger.querySelector('.maka-model-switch-warning-icon'),
-    ).not.toBeInTheDocument();
+    await expect(announcement).toBeEmptyDOMElement();
+    await expect(document.body.querySelector('.maka-model-switch-notice')).not.toBeInTheDocument();
+
+    await userEvent.click(trigger);
+    await expect(announcement).toBeEmptyDOMElement();
+    await expect(document.body.querySelector('.maka-model-switch-notice')).not.toBeInTheDocument();
   },
 };
 


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

PR #2945 added a persistent warning triangle and a long warning tooltip to every established Desktop conversation. Although intended to explain the possible prompt-cache cost of switching models, the closed control made healthy conversations look as if their current model or connection had a problem.

This PR keeps the healthy closed control quiet and moves the existing cache notice into the open model picker, where it is relevant to the switching decision. Empty conversations remain quiet. The model-selection flow, provider requests, session persistence, and post-switch confirmation are unchanged.

The history gate now uses the durable session summary with an optimistic message fallback, and the visible notice is separated from its screen-reader announcement so the menu retains a valid accessibility structure.

## Fast path rationale

This is a low-impact, easily reversible presentation-layer bug fix. It changes only where existing explanatory copy is shown and does not change model resolution, switch execution, provider or runtime behavior, persisted state, public contracts, permissions, security, licensing, releases, or governance.

The affected tests, type checks, renderer build, formatting, lint, and Storybook interaction and accessibility checks pass. On that basis, the contributor records this change as eligible for the Fast Path.

## Verification

- `npm --workspace @maka/ui test` — 143 tests passed
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run typecheck:stories`
- `npm --workspace @maka/desktop run build:renderer`
- `npm run format:check`
- `npm run lint` — 2299 files checked
- `git diff --check`
- Storybook QA covered Chinese and English, light and dark themes, narrow and full AppShell viewports, pointer and keyboard flows, existing and empty conversations, and Chromium accessibility snapshots.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck, build, and affected suites pass locally
- [x] This PR changes only the presentation behavior described above

## AI disclosure

This PR was completed by OpenAI Codex under M4n5ter’s direction and review. M4n5ter takes responsibility for the final changes and their outcomes.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

PR #2945 为 Desktop 中每个已有对话的会话增加了常驻警告三角和冗长的警告 tooltip。它原本用于说明切换模型可能带来的提示缓存成本，但关闭状态下的控件会让健康会话看起来像是当前模型或连接发生了异常。

本 PR 让健康的关闭状态保持安静，并把既有的缓存提示移入打开后的模型选择器，使其只在用户作出切换决策时出现。空会话继续保持安静。模型选择流程、服务商请求、会话持久化和切换成功确认均未改变。

历史判断改为使用稳定的会话摘要，并以 optimistic message 作为兜底；视觉提示与屏幕阅读器播报相互分离，使菜单保持有效的无障碍结构。

## Fast Path 理由

这是一个影响较小、易于回滚的展示层缺陷修复。它只改变既有说明文案的展示位置，不改变模型解析、切换执行、服务商或 Runtime 行为、持久化状态、公共契约、权限、安全、许可证、发布或治理。

相关测试、类型检查、Renderer 构建、格式检查、Lint，以及 Storybook 交互和无障碍验证均已通过。基于以上理由，贡献者将本次变更记录为符合 Fast Path。

## 验证

- `npm --workspace @maka/ui test` — 143 项测试通过
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run typecheck:stories`
- `npm --workspace @maka/desktop run build:renderer`
- `npm run format:check`
- `npm run lint` — 检查 2299 个文件
- `git diff --check`
- Storybook 验收覆盖中英文、深浅色主题、窄视口和完整 AppShell、鼠标与键盘流程、已有对话与空会话，以及 Chromium 无障碍快照。

## 检查清单

- [x] 测试覆盖本次变更，并会在旧实现上失败
- [x] Lint、格式检查、类型检查、构建和相关测试均在本地通过
- [x] 本 PR 仅改变上文所述的展示行为

## AI 使用披露

本 PR 由 OpenAI Codex 在 M4n5ter 的指导和审核下完成。M4n5ter 对最终变更及其结果负责。

</details>

Refs #2945
Fixes #2995