### PR TITLE
fix(desktop): use platform-neutral project folder label

### DIFF
--- a/apps/desktop/src/renderer/locales/settings-projects-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-projects-copy.ts
@@ -157,7 +157,7 @@ const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
     rename: '重命名',
     renameLabel: '项目名称',
     renameFailed: '重命名失败',
-    openFolder: '在访达中打开',
+    openFolder: '打开项目文件夹',
     // Says which of the two things went wrong, because the fix differs: a
     // missing folder is the user's to restore, a refusal to open is not.
     openFolderFailed: '打不开这个目录，它可能已被移动或删除',
@@ -243,7 +243,7 @@ const SETTINGS_PROJECTS_COPY_BY_LOCALE = {
     rename: 'Rename',
     renameLabel: 'Project name',
     renameFailed: 'Could not rename the project',
-    openFolder: 'Reveal in Finder',
+    openFolder: 'Open project folder',
     openFolderFailed: 'Could not open this folder — it may have been moved or deleted',
     save: 'Save',
     cancel: 'Cancel',


### PR DESCRIPTION
## Summary

Replace the macOS-specific project menu label with wording that describes the action on every platform:

| Locale | Before | After |
| --- | --- | --- |
| Chinese | `在访达中打开` | `打开项目文件夹` |
| English | `Reveal in Finder` | `Open project folder` |

The underlying folder-opening behavior is unchanged.

## Verification

- `npx biome check apps/desktop/src/renderer/locales/settings-projects-copy.ts`
- `npx tsc -p apps/desktop/tsconfig.renderer.json --noEmit`
- `git diff --check`

## Fast path

This is a low-impact, easily reversible copy correction with no functional behavior change.

## AI disclosure

Codex prepared the change under my direction. I reviewed the result and take responsibility for it.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
