### PR TITLE
fix(eval): refuse Docker DNS after pinning the egress proxy host

### DIFF
--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -57,8 +57,10 @@ namespace-local addresses, and rejects everything else, ICMP included. Rejecting
 redirecting the remainder also closes a connection the subject inherits from an earlier phase: the
 redirect is a NAT rule, and NAT is evaluated only on a connection's first packet. The
 namespace-local exemption keeps the loopback provider proxies reachable. Docker's
-embedded resolver at `127.0.0.11:53` is refused, because it forwards names it does
-not own to the host's upstream resolvers. The proxy publishes its IPv4 into the
+embedded resolver at `127.0.0.11` is refused, because it forwards names it does
+not own to the host's upstream resolvers. The engine DNATs `:53` onto another
+local port before the filter hook, so the rule matches the address rather than
+only that port. The proxy publishes its IPv4 into the
 certificate volume; the relay pins `maka-eval-mitmproxy` in `/etc/hosts` before the
 subject starts, so `HTTPS_PROXY` still resolves after DNS is closed. The policy exempts no
 packet mark: the

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -48,7 +48,7 @@ no rule can match across the boundary between the two fields. Only Harbor applie
 the namespace policy, so a pier executor spec that declares `egressProxy` is rejected when it is
 decoded rather than running with the proxy set up and enforcement absent. The checked-in Compose
 overlay gives every cell its own MITM proxy, CA, bounded audit log, and health gate. The proxy keeps its confdir and audit log
-private and publishes only `mitmproxy-ca-cert.pem` into the certificate-only volume the subject
+private and publishes only `mitmproxy-ca-cert.pem` and `proxy-ipv4` into the certificate-only volume the subject
 mounts read-only, so the CA private key and the audit log never enter the subject namespace. During
 `Agent.run()`, Harbor's Docker egress sidecar applies an nftables allowlist containing only that
 proxy service; direct subject egress is therefore rejected even when a command unsets proxy
@@ -56,10 +56,11 @@ variables or requests `--noproxy`. The namespace policy accepts TCP to that prox
 namespace-local addresses, and rejects everything else, ICMP included. Rejecting rather than
 redirecting the remainder also closes a connection the subject inherits from an earlier phase: the
 redirect is a NAT rule, and NAT is evaluated only on a connection's first packet. The
-namespace-local exemption keeps the loopback provider proxies reachable and, with them, Docker's
-embedded resolver at `127.0.0.11`, which forwards names it does not own to the host's upstream
-resolvers. That is an unaudited channel out of the cell and back, tracked in issue #2976; until it is
-closed the audited proxy is the only path for everything except DNS. The policy exempts no
+namespace-local exemption keeps the loopback provider proxies reachable. Docker's
+embedded resolver at `127.0.0.11:53` is refused, because it forwards names it does
+not own to the host's upstream resolvers. The proxy publishes its IPv4 into the
+certificate volume; the relay pins `maka-eval-mitmproxy` in `/etc/hosts` before the
+subject starts, so `HTTPS_PROXY` still resolves after DNS is closed. The policy exempts no
 packet mark: the
 sidecar shares the subject's network namespace, so a mark the sidecar can set is one the subject can
 set too, and gost forwards nothing in this mode anyway. Because that shared namespace also means the

--- a/packages/eval/README.md
+++ b/packages/eval/README.md
@@ -87,7 +87,11 @@ download and verifier phases retain their native network policy. Build the pinne
 `maka-eval-egress-proxy:12.2.3` image from `harbor/egress-proxy/Dockerfile` before running the
 cohort. `MAKA_EVAL_EGRESS_NAMESPACE_TEST=1 python3 harbor/test_cell_egress_namespace.py` brings up
 the overlay and the checked-in policy and asserts that contract in a real cell namespace; it needs
-a Docker daemon and outbound network, and skips otherwise. This URL policy is a blocklist for known
+a Docker daemon and outbound network, and skips otherwise. Official CI does not set that
+variable: the live cell needs a kernel that can load the checked-in `table inet` ruleset
+(`NFT_FIB_INET`), which Docker Desktop and the default runners do not provide. The rule
+text — including that `127.0.0.11` is rejected before `fib daddr type local accept` — is
+locked by `lifecycle-boundaries.test.ts` and the Harbor contract tests. This URL policy is a blocklist for known
 benchmark and public-solution contamination surfaces, not a complete defense against a deliberately
 invented lookup channel. It classifies HTTP(S) requests and `CONNECT` hosts against the blocklist, and
 kills tunnels that fall back to raw TCP. Collected Maka runtime files

--- a/packages/eval/harbor/docker-compose-egress-proxy.yaml
+++ b/packages/eval/harbor/docker-compose-egress-proxy.yaml
@@ -5,6 +5,7 @@ services:
         source: ${MAKA_EVAL_NETWORK_POLICY_PATH}
         target: /usr/local/bin/network-policy
         read_only: true
+      - maka-eval-egress-ca:/opt/maka-egress:ro
 
   main:
     depends_on:

--- a/packages/eval/harbor/docker-compose-egress-proxy.yaml
+++ b/packages/eval/harbor/docker-compose-egress-proxy.yaml
@@ -30,7 +30,7 @@ services:
         - CMD
         - python
         - -c
-        - "import pathlib,socket; assert pathlib.Path('/opt/maka-egress/mitmproxy-ca-cert.pem').is_file(); socket.create_connection(('127.0.0.1',8080),2).close()"
+        - "import pathlib,socket; assert pathlib.Path('/opt/maka-egress/mitmproxy-ca-cert.pem').is_file(); assert pathlib.Path('/opt/maka-egress/proxy-ipv4').is_file(); socket.create_connection(('127.0.0.1',8080),2).close()"
       interval: 1s
       timeout: 3s
       retries: 30

--- a/packages/eval/harbor/egress-proxy/entrypoint.sh
+++ b/packages/eval/harbor/egress-proxy/entrypoint.sh
@@ -23,6 +23,18 @@ CertStore.from_store(sys.argv[1], "mitmproxy", 2048)' "$STATE_DIR"
 cp "$STATE_DIR/mitmproxy-ca-cert.pem" "$CERT_DIR/.mitmproxy-ca-cert.pem"
 mv "$CERT_DIR/.mitmproxy-ca-cert.pem" "$CERT_DIR/mitmproxy-ca-cert.pem"
 
+# The subject only needs this address so HTTPS_PROXY can keep using the
+# service hostname after the namespace policy refuses Docker DNS.
+ip="$(getent ahostsv4 "$(hostname)" | awk 'NR == 1 { print $1 }')"
+case "$ip" in
+  "" | 127.*)
+    echo "could not publish Eval egress proxy IPv4" >&2
+    exit 1
+    ;;
+esac
+printf '%s\n' "$ip" > "$CERT_DIR/.proxy-ipv4"
+mv "$CERT_DIR/.proxy-ipv4" "$CERT_DIR/proxy-ipv4"
+
 exec mitmdump \
   --quiet \
   --listen-host 0.0.0.0 \

--- a/packages/eval/harbor/egress-proxy/network-policy
+++ b/packages/eval/harbor/egress-proxy/network-policy
@@ -29,6 +29,18 @@ resolve_proxy_ip() {
       return
       ;;
   esac
+  # Same four-octet program as relay_agent.IPV4_OCTET_AWK.
+  if ! printf '%s\n' "$ip" | awk '
+BEGIN { FS = "." }
+NF != 4 { exit 1 }
+{
+  for (i = 1; i <= 4; i++) {
+    if ($i !~ /^(0|[1-9][0-9]*)$/ || $i + 0 > 255) exit 1
+  }
+}
+'; then
+    return
+  fi
   printf '%s\n' "$ip"
 }
 

--- a/packages/eval/harbor/egress-proxy/network-policy
+++ b/packages/eval/harbor/egress-proxy/network-policy
@@ -15,7 +15,13 @@ remove_nftables() {
   nft delete table inet "$NFTABLES_RULESET_NAME" 2>/dev/null || true
 }
 
+PROXY_IP_CACHE=/tmp/maka-eval-proxy.ipv4
+
 resolve_proxy_ip() {
+  if [ -s "$PROXY_IP_CACHE" ]; then
+    cat "$PROXY_IP_CACHE"
+    return
+  fi
   getent ahostsv4 "$PROXY_HOST" | awk 'NR == 1 { print $1 }'
 }
 
@@ -40,6 +46,8 @@ ${proxy_ip:+    ip daddr $proxy_ip tcp dport $PROXY_PORT return}
   chain egress {
     type filter hook output priority filter; policy accept;
 
+    ip daddr 127.0.0.11 udp dport 53 reject
+    ip daddr 127.0.0.11 tcp dport 53 reject
     fib daddr type local accept
 ${proxy_ip:+    ip daddr $proxy_ip tcp dport $PROXY_PORT accept}
     # Rejecting everything else rather than only non-TCP: the nat chain above
@@ -58,6 +66,7 @@ setup_proxy_only() {
     echo "could not resolve Eval egress proxy" >&2
     exit 1
   fi
+  printf '%s\n' "$proxy_ip" > "$PROXY_IP_CACHE"
   apply_ruleset "$proxy_ip"
   echo "ok: Eval proxy-only egress applied ($proxy_ip:$PROXY_PORT)"
 }

--- a/packages/eval/harbor/egress-proxy/network-policy
+++ b/packages/eval/harbor/egress-proxy/network-policy
@@ -15,14 +15,21 @@ remove_nftables() {
   nft delete table inet "$NFTABLES_RULESET_NAME" 2>/dev/null || true
 }
 
-PROXY_IP_CACHE=/tmp/maka-eval-proxy.ipv4
+PROXY_IPV4_PATH=/opt/maka-egress/proxy-ipv4
 
 resolve_proxy_ip() {
-  if [ -s "$PROXY_IP_CACHE" ]; then
-    cat "$PROXY_IP_CACHE"
+  # The proxy publishes this file before it is healthy. Reading it does not
+  # depend on Docker DNS, so deny-all then allow still has an address.
+  if [ ! -s "$PROXY_IPV4_PATH" ]; then
     return
   fi
-  getent ahostsv4 "$PROXY_HOST" | awk 'NR == 1 { print $1 }'
+  ip=$(tr -d ' \t\r\n' < "$PROXY_IPV4_PATH")
+  case "$ip" in
+    "" | *.*.*.*.* | *[!0-9.]*)
+      return
+      ;;
+  esac
+  printf '%s\n' "$ip"
 }
 
 # The only difference between the two modes this policy installs is whether the
@@ -68,7 +75,6 @@ setup_proxy_only() {
     echo "could not resolve Eval egress proxy" >&2
     exit 1
   fi
-  printf '%s\n' "$proxy_ip" > "$PROXY_IP_CACHE"
   apply_ruleset "$proxy_ip"
   echo "ok: Eval proxy-only egress applied ($proxy_ip:$PROXY_PORT)"
 }

--- a/packages/eval/harbor/egress-proxy/network-policy
+++ b/packages/eval/harbor/egress-proxy/network-policy
@@ -46,8 +46,10 @@ ${proxy_ip:+    ip daddr $proxy_ip tcp dport $PROXY_PORT return}
   chain egress {
     type filter hook output priority filter; policy accept;
 
-    ip daddr 127.0.0.11 udp dport 53 reject
-    ip daddr 127.0.0.11 tcp dport 53 reject
+    # Docker DNATs 127.0.0.11:53 onto another local port before this hook.
+    # Matching only dport 53 here misses, and the local exemption below
+    # would then accept the rewritten packet.
+    ip daddr 127.0.0.11 reject
     fib daddr type local accept
 ${proxy_ip:+    ip daddr $proxy_ip tcp dport $PROXY_PORT accept}
     # Rejecting everything else rather than only non-TCP: the nat chain above

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -388,7 +388,7 @@ cat "$tmp" > /etc/hosts
 printf %s {shlex.quote(PROXY_HOSTS_PREFIX)}
 printf '%s %s\\n' "$ip" "$host"
 """
-    probe = await environment.exec(script)
+    probe = await environment.exec(script, user="root")
     if probe.return_code != 0:
         raise RuntimeError("Maka Eval could not pin the Eval egress proxy hostname")
     reported = _sole_probe_line(probe, PROXY_HOSTS_PREFIX)

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -52,6 +52,8 @@ CAPABILITY_FIELDS = ("CapEff", "CapPrm", "CapBnd")
 # than inferring it from something only the shared namespace would expose.
 POLICY_SERVICE = "harbor-docker-egress-control-sidecar"
 NAMESPACE_PROBE = f"printf %s {shlex.quote(NAMESPACE_PREFIX)}; readlink /proc/self/ns/net"
+PROXY_IPV4_PATH = "/opt/maka-egress/proxy-ipv4"
+PROXY_HOSTS_PREFIX = "MAKA-EVAL-PROXY-HOST-V1 "
 # The kernel's own form for a namespace link target. Matching it keeps an
 # unexpected answer from being compared as if it were an identity.
 NAMESPACE_IDENTITY = re.compile(r"^net:\[[0-9]+\]$")
@@ -354,6 +356,45 @@ async def _require_constrained_subject(environment: Any) -> None:
             "the subject does not share the network namespace the Eval egress policy "
             "was applied to; remove the task's own networking on the subject service"
         )
+    await _pin_proxy_hostname(environment)
+
+
+async def _pin_proxy_hostname(environment: Any) -> None:
+    """Point the proxy hostname at the published IPv4 so Docker DNS can be refused.
+
+    The subject only needs that one name, because the HTTP proxy does remote
+    resolution itself. Pinning it in /etc/hosts lets the namespace policy reject
+    127.0.0.11:53 without breaking HTTPS_PROXY.
+    """
+    host = os.environ.get("MAKA_EVAL_EGRESS_ALLOWED_HOST") or "maka-eval-mitmproxy"
+    if "/" in host or "\x00" in host or host in {".", ".."}:
+        raise RuntimeError("Eval egress proxy host is invalid")
+    script = f"""
+set -eu
+path={shlex.quote(PROXY_IPV4_PATH)}
+host={shlex.quote(host)}
+test -f "$path"
+ip=$(tr -d ' \\t\\r\\n' < "$path")
+case "$ip" in
+  ""|*.*.*.*.*|*[!0-9.]*) exit 1 ;;
+esac
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+if [ -f /etc/hosts ]; then
+  grep -v "[[:space:]]$host$" /etc/hosts > "$tmp" || true
+fi
+printf '%s %s\\n' "$ip" "$host" >> "$tmp"
+cat "$tmp" > /etc/hosts
+printf %s {shlex.quote(PROXY_HOSTS_PREFIX)}
+printf '%s %s\\n' "$ip" "$host"
+"""
+    probe = await environment.exec(script)
+    if probe.return_code != 0:
+        raise RuntimeError("Maka Eval could not pin the Eval egress proxy hostname")
+    reported = _sole_probe_line(probe, PROXY_HOSTS_PREFIX)
+    ip, _, pinned = reported.partition(" ")
+    if pinned != host or not ip or ip.count(".") != 3:
+        raise RuntimeError("Maka Eval could not pin the Eval egress proxy hostname")
 
 
 def _sole_probe_line(probe: Any, prefix: str) -> str:

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -369,11 +369,33 @@ HOSTS_ALIAS_AWK = r"""
 }
 """
 
+# Four decimal octets 0-255, no empty fields and no leading zeros. The same
+# program is embedded in egress-proxy/network-policy; the contract test
+# requires the two copies to stay identical.
+IPV4_OCTET_AWK = r"""
+BEGIN { FS = "." }
+NF != 4 { exit 1 }
+{
+  for (i = 1; i <= 4; i++) {
+    if ($i !~ /^(0|[1-9][0-9]*)$/ || $i + 0 > 255) exit 1
+  }
+}
+"""
+
+_PUBLISHED_IPV4 = re.compile(
+    r"^(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}"
+    r"(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)$"
+)
+
 
 def _valid_egress_proxy_host(host: str) -> bool:
     if not host or host.startswith(".") or host.endswith(".") or ".." in host:
         return False
     return all(character.isalnum() or character in ".-" for character in host)
+
+
+def _valid_published_ipv4(ip: str) -> bool:
+    return bool(_PUBLISHED_IPV4.fullmatch(ip))
 
 
 async def _pin_proxy_hostname(environment: Any) -> None:
@@ -399,6 +421,9 @@ ip=$(tr -d ' \\t\\r\\n' < "$path")
 case "$ip" in
   ""|*.*.*.*.*|*[!0-9.]*) exit 1 ;;
 esac
+if ! printf '%s\\n' "$ip" | awk {shlex.quote(IPV4_OCTET_AWK)}; then
+  exit 1
+fi
 tmp=$(mktemp)
 trap 'rm -f "$tmp"' EXIT
 if [ -f /etc/hosts ]; then
@@ -409,12 +434,14 @@ cat "$tmp" > /etc/hosts
 printf %s {shlex.quote(PROXY_HOSTS_PREFIX)}
 printf '%s %s\\n' "$ip" "$host"
 """
+    # Harbor 0.20.0 BaseEnvironment.exec and DockerEnvironment.exec take user=;
+    # DockerEnvironment._compose_exec forwards it as `docker compose exec -u`.
     probe = await environment.exec(script, user="root")
     if probe.return_code != 0:
         raise RuntimeError("Maka Eval could not pin the Eval egress proxy hostname")
     reported = _sole_probe_line(probe, PROXY_HOSTS_PREFIX)
     ip, _, pinned = reported.partition(" ")
-    if pinned != host or not ip or ip.count(".") != 3:
+    if pinned != host or not _valid_published_ipv4(ip):
         raise RuntimeError("Maka Eval could not pin the Eval egress proxy hostname")
 
 

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -391,7 +391,13 @@ _PUBLISHED_IPV4 = re.compile(
 def _valid_egress_proxy_host(host: str) -> bool:
     if not host or host.startswith(".") or host.endswith(".") or ".." in host:
         return False
-    return all(character.isalnum() or character in ".-" for character in host)
+    # Match the pin script's `*[!A-Za-z0-9.-]*` class. str.isalnum() also
+    # accepts Unicode letters, which the shell would later reject as a pin
+    # failure instead of an invalid host.
+    return all(
+        (character.isalnum() and character.isascii()) or character in ".-"
+        for character in host
+    )
 
 
 def _valid_published_ipv4(ip: str) -> bool:

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -359,6 +359,23 @@ async def _require_constrained_subject(environment: Any) -> None:
     await _pin_proxy_hostname(environment)
 
 
+HOSTS_ALIAS_AWK = r"""
+/^[[:space:]]*#/ { print; next }
+{
+  for (i = 2; i <= NF; i++) {
+    if ($i == host) next
+  }
+  print
+}
+"""
+
+
+def _valid_egress_proxy_host(host: str) -> bool:
+    if not host or host.startswith(".") or host.endswith(".") or ".." in host:
+        return False
+    return all(character.isalnum() or character in ".-" for character in host)
+
+
 async def _pin_proxy_hostname(environment: Any) -> None:
     """Point the proxy hostname at the published IPv4 so Docker DNS can be refused.
 
@@ -367,12 +384,16 @@ async def _pin_proxy_hostname(environment: Any) -> None:
     127.0.0.11:53 without breaking HTTPS_PROXY.
     """
     host = os.environ.get("MAKA_EVAL_EGRESS_ALLOWED_HOST") or "maka-eval-mitmproxy"
-    if "/" in host or "\x00" in host or host in {".", ".."}:
+    if not _valid_egress_proxy_host(host):
         raise RuntimeError("Eval egress proxy host is invalid")
     script = f"""
 set -eu
 path={shlex.quote(PROXY_IPV4_PATH)}
 host={shlex.quote(host)}
+case "$host" in
+  ""|.*|*..*|*.) exit 1 ;;
+  *[!A-Za-z0-9.-]*) exit 1 ;;
+esac
 test -f "$path"
 ip=$(tr -d ' \\t\\r\\n' < "$path")
 case "$ip" in
@@ -381,7 +402,7 @@ esac
 tmp=$(mktemp)
 trap 'rm -f "$tmp"' EXIT
 if [ -f /etc/hosts ]; then
-  grep -v "[[:space:]]$host$" /etc/hosts > "$tmp" || true
+  awk -v host="$host" {shlex.quote(HOSTS_ALIAS_AWK)} /etc/hosts > "$tmp"
 fi
 printf '%s %s\\n' "$ip" "$host" >> "$tmp"
 cat "$tmp" > /etc/hosts

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -472,10 +472,9 @@ class CellEnvironment:
     def __init__(self, service: str) -> None:
         self.service = service
 
-    async def exec(self, command: str, cwd=None, timeout_sec=None, **kwargs):
-        user = kwargs.get("user")
+    async def exec(self, command: str, cwd=None, env=None, timeout_sec=None, user=None):
         return self._run(
-            self.service, command, user=user if isinstance(user, str) else None
+            self.service, command, user=str(user) if user is not None else None
         )
 
     async def service_exec(self, command: str, *, service: str, **kwargs):

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -133,6 +133,22 @@ UDP_PROBE = (
     "    print('blocked')\n"
 )
 
+DOCKER_DNS_PROBE = (
+    "import socket\n"
+    "query = (\n"
+    "    b'\\xab\\xcd\\x01\\x00\\x00\\x01\\x00\\x00\\x00\\x00\\x00\\x00'\n"
+    "    b'\\x07example\\x03com\\x00\\x00\\x01\\x00\\x01'\n"
+    ")\n"
+    "sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)\n"
+    "sock.settimeout(5)\n"
+    "try:\n"
+    "    sock.sendto(query, ('127.0.0.11', 53))\n"
+    "    sock.recvfrom(512)\n"
+    "    print('reachable')\n"
+    "except OSError:\n"
+    "    print('blocked')\n"
+)
+
 # An AF_PACKET socket writes at the link layer, below the IP output hooks the
 # policy installs, so no nftables rule can see this traffic at all. Only the
 # absence of NET_RAW stops it. The frame is addressed to the default gateway's
@@ -262,6 +278,9 @@ class CellEgressNamespaceTest(unittest.TestCase):
             cls.run_compose, ["down", "--volumes", "--remove-orphans"], check=False
         )
         cls.run_compose(["up", "--detach", "--wait"], timeout=BUILD_TIMEOUT_S)
+        # Pin the proxy hostname before any test applies the policy, so
+        # HTTPS_PROXY still resolves after Docker DNS is refused.
+        asyncio.run(load_relay()._pin_proxy_hostname(CellEnvironment("main")))
 
     @classmethod
     def build_image(
@@ -393,7 +412,7 @@ class CellEgressNamespaceTest(unittest.TestCase):
     def test_subject_sees_only_the_ca_certificate(self) -> None:
         listed = self.exec_main(["ls", "--almost-all", "/opt/maka-egress"])
         self.assertEqual(listed.returncode, 0, listed.stderr)
-        self.assertEqual(listed.stdout.split(), ["mitmproxy-ca-cert.pem"])
+        self.assertEqual(sorted(listed.stdout.split()), ["mitmproxy-ca-cert.pem", "proxy-ipv4"])
 
     def test_cell_namespace_admits_only_the_audited_proxy(self) -> None:
         # Every negative assertion below is vacuous on a host that cannot reach
@@ -437,9 +456,12 @@ class CellEgressNamespaceTest(unittest.TestCase):
         with self.subTest("loopback provider proxy"):
             self.assertEqual(self.probe_main(LOOPBACK_PROBE), "reachable")
 
-        with self.subTest("Docker DNS"):
+        with self.subTest("pinned proxy hostname"):
             resolved = self.exec_main(["getent", "hosts", PROXY_HOST])
             self.assertEqual(resolved.returncode, 0, resolved.stderr)
+
+        with self.subTest("Docker DNS"):
+            self.assertEqual(self.probe_main(DOCKER_DNS_PROBE), "blocked")
 
 class CellEnvironment:
     """Presents one live cell service as the relay's environment."""

--- a/packages/eval/harbor/test_cell_egress_namespace.py
+++ b/packages/eval/harbor/test_cell_egress_namespace.py
@@ -333,14 +333,16 @@ class CellEgressNamespaceTest(unittest.TestCase):
         command: list[str],
         *,
         environment: dict[str, str] | None = None,
+        user: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         overrides = [
             argument
             for name, value in (environment or {}).items()
             for argument in ("--env", f"{name}={value}")
         ]
+        user_args = ["--user", user] if user else []
         return cls.run_compose(
-            ["exec", "--no-TTY", *overrides, service, *command], check=False
+            ["exec", "--no-TTY", *user_args, *overrides, service, *command], check=False
         )
 
     @classmethod
@@ -422,6 +424,7 @@ class CellEgressNamespaceTest(unittest.TestCase):
         self.assertEqual(self.curl([]).returncode, 0, "no HTTPS before any policy")
         self.assertEqual(self.probe_main(TCP_PROBE), "reachable")
         self.assertEqual(self.probe_main(UDP_PROBE), "reachable")
+        self.assertEqual(self.probe_main(DOCKER_DNS_PROBE), "reachable")
         self.assertEqual(self.ping().returncode, 0, "no ICMP before any policy")
 
         applied = self.exec_service(
@@ -469,15 +472,20 @@ class CellEnvironment:
     def __init__(self, service: str) -> None:
         self.service = service
 
-    async def exec(self, command: str, cwd=None, timeout_sec=None):
-        return self._run(self.service, command)
+    async def exec(self, command: str, cwd=None, timeout_sec=None, **kwargs):
+        user = kwargs.get("user")
+        return self._run(
+            self.service, command, user=user if isinstance(user, str) else None
+        )
 
     async def service_exec(self, command: str, *, service: str, **kwargs):
         return self._run(service, command)
 
     @staticmethod
-    def _run(service: str, command: str):
-        result = CellEgressNamespaceTest.exec_service(service, ["sh", "-c", command])
+    def _run(service: str, command: str, user: str | None = None):
+        result = CellEgressNamespaceTest.exec_service(
+            service, ["sh", "-c", command], user=user
+        )
         return types.SimpleNamespace(
             return_code=result.returncode, stdout=result.stdout, stderr=result.stderr
         )

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -505,6 +505,44 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(probe_users, ["1000"])
         self.assertEqual(pin_users, ["root"])
 
+    async def test_invalid_proxy_hostname_is_rejected_before_hosts_rewrite(self):
+        relay = load_relay()
+        for host in (".*", "evil.com\n127.0.0.1 pwned", "foo bar", "foo..bar", ".hidden"):
+            with self.subTest(host=host):
+                environment = SubjectEnvironment()
+                with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_ALLOWED_HOST": host}):
+                    with self.assertRaisesRegex(RuntimeError, "proxy host is invalid"):
+                        await relay._pin_proxy_hostname(environment)
+                self.assertEqual(environment.commands, [])
+
+    async def test_proxy_hostname_pin_matches_hosts_aliases_exactly(self):
+        relay = load_relay()
+        environment = SubjectEnvironment()
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            await relay._require_constrained_subject(environment)
+        pin = next(command for command in environment.commands if "proxy-ipv4" in command)
+        self.assertIn("awk -v host=", pin)
+        self.assertNotIn("grep -v", pin)
+
+        completed = subprocess.run(
+            ["awk", "-v", "host=maka-eval-mitmproxy", relay.HOSTS_ALIAS_AWK],
+            input=(
+                "127.0.0.1 localhost\n"
+                "10.0.0.1 maka-eval-mitmproxy extra\n"
+                "10.0.0.2 prefix-maka-eval-mitmproxy\n"
+                "10.0.0.3 other.example\n"
+            ),
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            completed.stdout,
+            "127.0.0.1 localhost\n"
+            "10.0.0.2 prefix-maka-eval-mitmproxy\n"
+            "10.0.0.3 other.example\n",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -531,6 +531,7 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
             "foo bar",
             "foo..bar",
             ".hidden",
+            "maka-évál",
         ):
             with self.subTest(host=host):
                 environment = SubjectEnvironment()
@@ -580,7 +581,7 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
 
     def test_published_ipv4_requires_four_0_255_octets(self):
         relay = load_relay()
-        accepted = ("172.18.0.2", "0.0.0.0", "255.255.255.255", "10.0.0.1")
+        accepted = ("172.18.0.2", "0.1.2.3", "255.255.255.255", "10.0.0.1")
         rejected = (
             "999.1.1.1",
             "1.2.3",

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -321,10 +321,12 @@ class SubjectEnvironment:
         }
         self.namespace = namespace
         self.commands: list[str] = []
+        self.users: list[str | None] = []
         self.services: list[str] = []
 
-    async def exec(self, command: str, cwd=None, timeout_sec=None):
+    async def exec(self, command: str, cwd=None, timeout_sec=None, **kwargs):
         self.commands.append(command)
+        self.users.append(kwargs.get("user") if isinstance(kwargs.get("user"), str) else None)
         if "proxy-ipv4" in command:
             return types.SimpleNamespace(
                 return_code=0,
@@ -456,16 +458,28 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
         relay = load_relay()
 
         class MissingAddressEnvironment(SubjectEnvironment):
-            async def exec(self, command, cwd=None, timeout_sec=None):
+            async def exec(self, command, cwd=None, timeout_sec=None, **kwargs):
                 self.commands.append(command)
                 if "proxy-ipv4" in command:
                     return types.SimpleNamespace(return_code=1, stdout="", stderr="")
-                return await super().exec(command, cwd=cwd, timeout_sec=timeout_sec)
+                return await super().exec(command, cwd=cwd, timeout_sec=timeout_sec, **kwargs)
 
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
             with self.assertRaises(RuntimeError) as raised:
                 await relay._require_constrained_subject(MissingAddressEnvironment())
         self.assertIn("pin the Eval egress proxy hostname", str(raised.exception))
+
+    async def test_proxy_hostname_pin_runs_as_root(self):
+        relay = load_relay()
+        environment = SubjectEnvironment()
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            await relay._require_constrained_subject(environment)
+        pin_users = [
+            user
+            for command, user in zip(environment.commands, environment.users, strict=True)
+            if "proxy-ipv4" in command
+        ]
+        self.assertEqual(pin_users, ["root"])
 
 
 if __name__ == "__main__":

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -325,6 +325,12 @@ class SubjectEnvironment:
 
     async def exec(self, command: str, cwd=None, timeout_sec=None):
         self.commands.append(command)
+        if "proxy-ipv4" in command:
+            return types.SimpleNamespace(
+                return_code=0,
+                stdout="MAKA-EVAL-PROXY-HOST-V1 172.18.0.2 maka-eval-mitmproxy\n",
+                stderr="",
+            )
         reported = " ".join(f"{name}={value:016x}" for name, value in self.sets.items())
         return types.SimpleNamespace(
             return_code=0,
@@ -445,6 +451,21 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
             await relay._require_constrained_subject(environment)
         self.assertEqual(environment.commands, [])
         self.assertEqual(environment.services, [])
+
+    async def test_missing_published_proxy_address_fails_closed(self):
+        relay = load_relay()
+
+        class MissingAddressEnvironment(SubjectEnvironment):
+            async def exec(self, command, cwd=None, timeout_sec=None):
+                self.commands.append(command)
+                if "proxy-ipv4" in command:
+                    return types.SimpleNamespace(return_code=1, stdout="", stderr="")
+                return await super().exec(command, cwd=cwd, timeout_sec=timeout_sec)
+
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            with self.assertRaises(RuntimeError) as raised:
+                await relay._require_constrained_subject(MissingAddressEnvironment())
+        self.assertIn("pin the Eval egress proxy hostname", str(raised.exception))
 
 
 if __name__ == "__main__":

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import hashlib
 import importlib
+import inspect
 import os
 import shlex
 import subprocess
@@ -326,9 +327,12 @@ class SubjectEnvironment:
         self.users: list[str | None] = []
         self.services: list[str] = []
 
-    async def exec(self, command: str, cwd=None, timeout_sec=None, **kwargs):
+    async def exec(self, command: str, cwd=None, env=None, timeout_sec=None, user=None):
+        # Harbor 0.20.0 BaseEnvironment.exec takes user= as a named argument,
+        # not **kwargs. Absorbing unknown keywords here would hide a TypeError
+        # against the real Docker environment.
         self.commands.append(command)
-        explicit = kwargs.get("user") if isinstance(kwargs.get("user"), str) else None
+        explicit = str(user) if user is not None else None
         self.users.append(explicit if explicit is not None else self.default_user)
         if "proxy-ipv4" in command:
             return types.SimpleNamespace(
@@ -461,16 +465,29 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
         relay = load_relay()
 
         class MissingAddressEnvironment(SubjectEnvironment):
-            async def exec(self, command, cwd=None, timeout_sec=None, **kwargs):
-                self.commands.append(command)
+            async def exec(self, command, cwd=None, env=None, timeout_sec=None, user=None):
                 if "proxy-ipv4" in command:
+                    self.commands.append(command)
+                    explicit = str(user) if user is not None else None
+                    self.users.append(
+                        explicit if explicit is not None else self.default_user
+                    )
                     return types.SimpleNamespace(return_code=1, stdout="", stderr="")
-                return await super().exec(command, cwd=cwd, timeout_sec=timeout_sec, **kwargs)
+                return await super().exec(
+                    command, cwd=cwd, env=env, timeout_sec=timeout_sec, user=user
+                )
 
+        environment = MissingAddressEnvironment()
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
             with self.assertRaises(RuntimeError) as raised:
-                await relay._require_constrained_subject(MissingAddressEnvironment())
+                await relay._require_constrained_subject(environment)
         self.assertIn("pin the Eval egress proxy hostname", str(raised.exception))
+        pin_users = [
+            user
+            for command, user in zip(environment.commands, environment.users, strict=True)
+            if "proxy-ipv4" in command
+        ]
+        self.assertEqual(pin_users, ["root"])
 
     async def test_proxy_hostname_pin_runs_as_root(self):
         relay = load_relay()
@@ -507,7 +524,14 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_invalid_proxy_hostname_is_rejected_before_hosts_rewrite(self):
         relay = load_relay()
-        for host in (".*", "evil.com\n127.0.0.1 pwned", "foo bar", "foo..bar", ".hidden"):
+        for host in (
+            ".*",
+            "proxy*",
+            "evil.com\n127.0.0.1 pwned",
+            "foo bar",
+            "foo..bar",
+            ".hidden",
+        ):
             with self.subTest(host=host):
                 environment = SubjectEnvironment()
                 with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_ALLOWED_HOST": host}):
@@ -521,8 +545,7 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
             await relay._require_constrained_subject(environment)
         pin = next(command for command in environment.commands if "proxy-ipv4" in command)
-        self.assertIn("awk -v host=", pin)
-        self.assertNotIn("grep -v", pin)
+        self.assertIn(relay.HOSTS_ALIAS_AWK, pin)
 
         completed = subprocess.run(
             ["awk", "-v", "host=maka-eval-mitmproxy", relay.HOSTS_ALIAS_AWK],
@@ -531,6 +554,7 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
                 "10.0.0.1 maka-eval-mitmproxy extra\n"
                 "10.0.0.2 prefix-maka-eval-mitmproxy\n"
                 "10.0.0.3 other.example\n"
+                "10.0.0.4 other.example maka-eval-mitmproxy\n"
             ),
             check=True,
             capture_output=True,
@@ -542,6 +566,89 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
             "10.0.0.2 prefix-maka-eval-mitmproxy\n"
             "10.0.0.3 other.example\n",
         )
+
+    def test_harbor_0_20_0_exec_declares_user_as_a_named_parameter(self):
+        # Harbor 0.20.0 BaseEnvironment.exec / DockerEnvironment.exec:
+        #   (command, cwd=None, env=None, timeout_sec=None, user=None)
+        # A **kwargs-only double would absorb user= and hide a TypeError
+        # against that signature.
+        parameter = inspect.signature(SubjectEnvironment.exec).parameters["user"]
+        self.assertNotEqual(parameter.kind, inspect.Parameter.VAR_KEYWORD)
+        inspect.signature(SubjectEnvironment.exec).bind(
+            None, "true", user="root"
+        )
+
+    def test_published_ipv4_requires_four_0_255_octets(self):
+        relay = load_relay()
+        accepted = ("172.18.0.2", "0.0.0.0", "255.255.255.255", "10.0.0.1")
+        rejected = (
+            "999.1.1.1",
+            "1.2.3",
+            "1..2.3",
+            "1.2.3.4.5",
+            "01.2.3.4",
+            "1.2.3.08",
+            "...",
+            "",
+            "172.18.0.2/32",
+            "localhost",
+        )
+        for ip in accepted:
+            with self.subTest(ip=ip):
+                self.assertTrue(relay._valid_published_ipv4(ip))
+        for ip in rejected:
+            with self.subTest(ip=ip):
+                self.assertFalse(relay._valid_published_ipv4(ip))
+
+        for ip in (*accepted, *rejected):
+            with self.subTest(awk=ip):
+                completed = subprocess.run(
+                    ["awk", relay.IPV4_OCTET_AWK],
+                    input=f"{ip}\n",
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(
+                    completed.returncode == 0,
+                    relay._valid_published_ipv4(ip),
+                    ip,
+                )
+
+    def test_network_policy_uses_the_same_ipv4_octet_check(self):
+        relay = load_relay()
+        policy = Path(__file__).with_name("egress-proxy").joinpath("network-policy")
+        self.assertIn(relay.IPV4_OCTET_AWK.strip(), policy.read_text())
+
+    def test_network_policy_rejects_docker_dns_before_local_accept(self):
+        policy = Path(__file__).with_name("egress-proxy").joinpath("network-policy").read_text()
+        reject = policy.index("ip daddr 127.0.0.11 reject")
+        local = policy.index("fib daddr type local accept")
+        self.assertLess(reject, local)
+
+    async def test_malformed_published_proxy_address_fails_closed(self):
+        relay = load_relay()
+
+        class BadAddressEnvironment(SubjectEnvironment):
+            async def exec(self, command, cwd=None, env=None, timeout_sec=None, user=None):
+                if "proxy-ipv4" in command:
+                    self.commands.append(command)
+                    explicit = str(user) if user is not None else None
+                    self.users.append(
+                        explicit if explicit is not None else self.default_user
+                    )
+                    return types.SimpleNamespace(
+                        return_code=0,
+                        stdout="MAKA-EVAL-PROXY-HOST-V1 999.1.1.1 maka-eval-mitmproxy\n",
+                        stderr="",
+                    )
+                return await super().exec(
+                    command, cwd=cwd, env=env, timeout_sec=timeout_sec, user=user
+                )
+
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            with self.assertRaises(RuntimeError) as raised:
+                await relay._require_constrained_subject(BadAddressEnvironment())
+        self.assertIn("pin the Eval egress proxy hostname", str(raised.exception))
 
 
 if __name__ == "__main__":

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -311,6 +311,7 @@ class SubjectEnvironment:
         effective: int | None = None,
         bounding: int | None = None,
         namespace: str = POLICY_NAMESPACE,
+        default_user: str | None = None,
     ) -> None:
         self.sets = {
             "CapInh": 0,
@@ -320,13 +321,15 @@ class SubjectEnvironment:
             "CapAmb": 0,
         }
         self.namespace = namespace
+        self.default_user = default_user
         self.commands: list[str] = []
         self.users: list[str | None] = []
         self.services: list[str] = []
 
     async def exec(self, command: str, cwd=None, timeout_sec=None, **kwargs):
         self.commands.append(command)
-        self.users.append(kwargs.get("user") if isinstance(kwargs.get("user"), str) else None)
+        explicit = kwargs.get("user") if isinstance(kwargs.get("user"), str) else None
+        self.users.append(explicit if explicit is not None else self.default_user)
         if "proxy-ipv4" in command:
             return types.SimpleNamespace(
                 return_code=0,
@@ -479,6 +482,27 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
             for command, user in zip(environment.commands, environment.users, strict=True)
             if "proxy-ipv4" in command
         ]
+        self.assertEqual(pin_users, ["root"])
+
+    async def test_proxy_hostname_pin_does_not_inherit_a_non_root_default_user(self):
+        # Harbor scopes every exec to the task's agent.user unless the call
+        # names another identity. Pinning /etc/hosts is infrastructure, so it
+        # must still be root when that default is a supported non-root user.
+        relay = load_relay()
+        environment = SubjectEnvironment(default_user="1000")
+        with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}):
+            await relay._require_constrained_subject(environment)
+        probe_users = [
+            user
+            for command, user in zip(environment.commands, environment.users, strict=True)
+            if "proxy-ipv4" not in command
+        ]
+        pin_users = [
+            user
+            for command, user in zip(environment.commands, environment.users, strict=True)
+            if "proxy-ipv4" in command
+        ]
+        self.assertEqual(probe_users, ["1000"])
         self.assertEqual(pin_users, ["root"])
 
 

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -825,6 +825,10 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
   assert.match(subjectService, /cap_drop:\s*\n\s+- NET_RAW/u);
   assert.match(egressCompose, /networks:\s*\n\s+- default/u);
   assert.match(egressCompose, /target: \/usr\/local\/bin\/network-policy/u);
+  const sidecarService = egressCompose
+    .split(/\n(?= {2}\S)/u)
+    .find((block) => block.trimStart().startsWith('harbor-docker-egress-control-sidecar:'))!;
+  assert.match(sidecarService, /maka-eval-egress-ca:\/opt\/maka-egress:ro/u);
   // The subject shares the sidecar's network namespace, so any packet mark it
   // could set is one the subject can set too. No live probe can show this any
   // more — without NET_RAW the subject cannot set a mark at all — so the rule's
@@ -836,6 +840,8 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
   assert.doesNotMatch(networkPolicy, /meta mark \S+ (?:accept|return)/u);
   assert.match(networkPolicy, /ip daddr 127\.0\.0\.11 reject/u);
   assert.doesNotMatch(networkPolicy, /127\.0\.0\.11 (?:udp|tcp) dport 53 reject/u);
+  assert.match(networkPolicy, /\/opt\/maka-egress\/proxy-ipv4/u);
+  assert.doesNotMatch(networkPolicy, /\bgetent\b/u);
   assert.match(egressCompose, /proxy-ipv4/u);
   const entrypoint = await readFile(
     new URL('../../harbor/egress-proxy/entrypoint.sh', import.meta.url),

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -840,6 +840,9 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
   assert.doesNotMatch(networkPolicy, /meta mark \S+ (?:accept|return)/u);
   assert.match(networkPolicy, /ip daddr 127\.0\.0\.11 reject/u);
   assert.doesNotMatch(networkPolicy, /127\.0\.0\.11 (?:udp|tcp) dport 53 reject/u);
+  const dockerDnsReject = networkPolicy.indexOf('ip daddr 127.0.0.11 reject');
+  const localAccept = networkPolicy.indexOf('fib daddr type local accept');
+  assert.ok(dockerDnsReject >= 0 && localAccept > dockerDnsReject);
   assert.match(networkPolicy, /\/opt\/maka-egress\/proxy-ipv4/u);
   assert.doesNotMatch(networkPolicy, /\bgetent\b/u);
   assert.match(egressCompose, /proxy-ipv4/u);

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -834,7 +834,8 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
     'utf8',
   );
   assert.doesNotMatch(networkPolicy, /meta mark \S+ (?:accept|return)/u);
-  assert.match(networkPolicy, /ip daddr 127\.0\.0\.11 udp dport 53 reject/u);
+  assert.match(networkPolicy, /ip daddr 127\.0\.0\.11 reject/u);
+  assert.doesNotMatch(networkPolicy, /127\.0\.0\.11 (?:udp|tcp) dport 53 reject/u);
   assert.match(egressCompose, /proxy-ipv4/u);
   const entrypoint = await readFile(
     new URL('../../harbor/egress-proxy/entrypoint.sh', import.meta.url),

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -834,6 +834,8 @@ test('eight-arm spec adds Pi with the same pinned DeepSeek execution contract', 
     'utf8',
   );
   assert.doesNotMatch(networkPolicy, /meta mark \S+ (?:accept|return)/u);
+  assert.match(networkPolicy, /ip daddr 127\.0\.0\.11 udp dport 53 reject/u);
+  assert.match(egressCompose, /proxy-ipv4/u);
   const entrypoint = await readFile(
     new URL('../../harbor/egress-proxy/entrypoint.sh', import.meta.url),
     'utf8',


### PR DESCRIPTION
## Summary

The namespace-local exemption keeps loopback provider proxies reachable, and with them Docker's resolver at `127.0.0.11`. That resolver forwards unknown names to the host, so a TXT query can leave the cell and come back without touching mitmproxy.

- The proxy publishes its IPv4 as `/opt/maka-egress/proxy-ipv4` on the certificate volume.
- The sidecar reads that file. There is no `/tmp` cache and no `getent`, so `deny-all` then the first `allow` still has an address after Docker DNS is refused.
- The relay pins `maka-eval-mitmproxy` in `/etc/hosts` as root after the isolation gate, so `HTTPS_PROXY` still resolves for a supported non-root `agent.user`.
- The nftables policy rejects all traffic to `127.0.0.11` before the generic local accept. Docker DNATs `:53` onto another local port before the filter hook; matching only `dport 53` missed, and `fib daddr type local` then accepted the rewritten packet.

Fixes #2976

## Verification

- `python3.13` Harbor units — 47 pass (lifecycle 2 skipped, no GNU `setsid` on macOS). Includes missing `proxy-ipv4` fail-closed and pin-as-root.
- `node --test packages/eval/dist/**/*.test.js` — 52/52, including lifecycle-boundaries locks for `127.0.0.11` reject, `proxy-ipv4`, no `getent`, sidecar CA mount, and `touch` of the audit log.
- Official `MAKA_EVAL_EGRESS_NAMESPACE_TEST=1` — 2/4. Cert volume (`mitmproxy-ca-cert.pem` + `proxy-ipv4`) and the isolation gate pass. Applying the checked-in `table inet` ruleset fails on this Docker Desktop VM at the pre-existing `fib daddr type local` rule (`NFT_FIB_INET` is unset). Linux CI is the environment that can apply that family.
- Live Harbor-shaped cell (`maka-eval-egress-proxy:12.2.3` + subject + sidecar sharing the netns), closest `table ip` equivalent (this kernel can load `ip` fib): 23/23.
  - Published address `172.20.0.2`; sidecar reads the same file without `getent`.
  - Non-root cannot write `/etc/hosts`; root pin succeeds; `getent hosts maka-eval-mitmproxy` returns the published IPv4.
  - Before policy: proxy HTTPS 200, direct TCP/UDP, Docker DNS, and ICMP all reachable.
  - `deny-all` then first `allow` from the published file: proxy HTTPS 200; `--noproxy`, direct TCP, external UDP, Docker DNS, and ICMP blocked; loopback still reachable.

Not run: full `maka eval run` cohort (no Harbor / provider env on this host). Full workspace `npm test` blocked by an unrelated `unlockAutoFollow` type error on current `main`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Focused lint/typecheck and the affected suites pass locally
- [ ] Full workspace lint/format/typecheck

Does this PR entail a change in behavior?

- [x] Yes — Docker DNS is no longer an unaudited path out of a proxy-only cell