### PR TITLE
fix(desktop): let overflowing task dialogs scroll and dim the titlebar under modals

### DIFF
--- a/apps/desktop/src/main/__tests__/titlebar-modal-dim.test.ts
+++ b/apps/desktop/src/main/__tests__/titlebar-modal-dim.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { compositeScrimOverBackground, parseCssRgbColor } from '../../renderer/titlebar-dim-color.js';
+
+// The two scrim values the app theme pins (astryx-theme/maka.css:
+// light-dark(#00000080, #000000CC)).
+const LIGHT_SCRIM = { r: 0, g: 0, b: 0, a: 0.5 };
+const DARK_SCRIM = { r: 0, g: 0, b: 0, a: 0.8 };
+
+test('light-theme dim: black@50% scrim over a white titlebar', () => {
+  assert.equal(compositeScrimOverBackground(LIGHT_SCRIM, '#ffffff'), '#808080');
+});
+
+test('dark-theme dim: black@80% scrim over the dark titlebar', () => {
+  assert.equal(compositeScrimOverBackground(DARK_SCRIM, '#171719'), '#050505');
+});
+
+test('an opaque scrim wins outright', () => {
+  assert.equal(
+    compositeScrimOverBackground({ r: 16, g: 32, b: 48, a: 1 }, '#ffffff'),
+    '#102030',
+  );
+});
+
+test('an unparseable background comes back unchanged so the caller degrades', () => {
+  assert.equal(compositeScrimOverBackground(LIGHT_SCRIM, 'not-a-color'), 'not-a-color');
+});
+
+test('parseCssRgbColor reads every rgb()/rgba() separator style', () => {
+  assert.deepEqual(parseCssRgbColor('rgba(0, 0, 0, 0.5)'), { r: 0, g: 0, b: 0, a: 0.5 });
+  assert.deepEqual(parseCssRgbColor('rgba(0,0,0,0.8)'), { r: 0, g: 0, b: 0, a: 0.8 });
+  assert.deepEqual(parseCssRgbColor('rgb(255, 255, 255)'), { r: 255, g: 255, b: 255, a: 1 });
+  assert.deepEqual(parseCssRgbColor('rgb(23 23 25 / 80%)'), { r: 23, g: 23, b: 25, a: 0.8 });
+});
+
+test('parseCssRgbColor refuses serializations it cannot trust', () => {
+  assert.equal(parseCssRgbColor('oklch(0.2 0.01 250)'), null);
+  assert.equal(parseCssRgbColor('color(srgb 0 0 0 / 0.5)'), null);
+  assert.equal(parseCssRgbColor(''), null);
+});

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -14,6 +14,7 @@ import { messageReadErrorMessage } from './app-shell-copy';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import { getShellRemainingCopy } from './locales/shell-remaining-copy.js';
 import { applyTheme, applyThemePalette } from './theme';
+import { startTitlebarModalSync } from './titlebar-modal-sync';
 import { safeLocalStorageSet } from './browser-storage';
 import type { NavigationState } from './nav-selection.js';
 import {
@@ -70,7 +71,6 @@ export function useAppShellNavRefSync(options: { navSelection: NavSelection; nav
 
 export function useAppShellHostEffects(options: {
   activeId: string | undefined;
-  hasModalOpen: boolean;
   setLiveBrowserSessionIds: (sessionIds: string[]) => void;
 }) {
   // Tag the document with the host OS so glass-material CSS rules
@@ -106,12 +106,11 @@ export function useAppShellHostEffects(options: {
     window.maka.browser.setActiveSession(options.activeId ?? null);
   }, [options.activeId]);
 
-  useEffect(() => {
-    void window.maka.appWindow.setTitlebarControlsVisible(!options.hasModalOpen).catch(() => {});
-    return () => {
-      void window.maka.appWindow.setTitlebarControlsVisible(true).catch(() => {});
-    };
-  }, [options.hasModalOpen]);
+  // Modal-open titlebar dimming/hiding is driven by observing the top layer
+  // (`dialog:modal`) rather than the shell's own modal state, so dialogs
+  // mounted deep in module pages — the scheduled-task form above all — are
+  // covered too. See titlebar-modal-sync.ts.
+  useEffect(() => startTitlebarModalSync(), []);
 }
 
 export function useAppShellPersistenceEffects(options: {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2259,7 +2259,6 @@ function AppShellContent({
   });
   useAppShellHostEffects({
     activeId,
-    hasModalOpen,
     setLiveBrowserSessionIds,
   });
   useAppShellBootstrapSubscriptions({

--- a/apps/desktop/src/renderer/side-chat-close-confirmation.tsx
+++ b/apps/desktop/src/renderer/side-chat-close-confirmation.tsx
@@ -30,7 +30,6 @@ export function SideChatCloseConfirmation(props: {
       width={420}
     >
       <Layout
-        height="auto"
         header={<DialogHeader title={copy.title(props.sideChatCount)} />}
         content={
           <LayoutContent>

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -7,6 +7,7 @@
 //
 import type { ThemePalette, ThemePreference } from '@maka/core/settings';
 import { safeLocalStorageSet } from './browser-storage';
+import { compositeScrimOverBackground, parseCssRgbColor } from './titlebar-dim-color.js';
 
 const DARK_CLASS = 'dark';
 
@@ -60,6 +61,26 @@ function setDarkClass(isDark: boolean): void {
 }
 
 /**
+ * A modal dialog's ::backdrop dims every pixel of the page — except the
+ * OS-drawn window-controls strip (the Windows titleBarOverlay box, the macOS
+ * traffic lights), which is composited above web content and stays bright.
+ * While any native `<dialog>` is modal-open, `titlebar-modal-sync.ts` sets
+ * this flag so the overlay color below folds the backdrop scrim in and the
+ * strip reads as part of the dimmed window; macOS additionally hides its
+ * traffic lights outright via the same signal.
+ */
+let titlebarModalDimmed = false;
+
+export function setTitlebarModalDimmed(dimmed: boolean): void {
+  if (titlebarModalDimmed === dimmed) return;
+  titlebarModalDimmed = dimmed;
+  // No-ops outside darwin (main-process gate); Windows has no hide API, so
+  // the dimmed overlay color below is the whole fix there.
+  void window.maka?.appWindow?.setTitlebarControlsVisible?.(!dimmed).catch(() => {});
+  syncTitleBarOverlay(document.documentElement);
+}
+
+/**
  * PR-UI-2 (@yuejing 2026-05-22): apply a base46 palette by writing
  * `data-maka-theme="<palette>"` on `<html>`. CSS variable overrides
  * live in `maka-tokens.css`. `default` removes the attribute so the
@@ -86,16 +107,45 @@ function syncTitleBarOverlay(root: HTMLElement): void {
   // The native Windows overlay sits on top of the renderer's content surface.
   // Sample the actual resolved --background color instead of approximating it
   // with one hard-coded light and dark pair; this also follows every palette.
+  const isDark = root.classList.contains(DARK_CLASS);
   const backgroundColor = cssColorToHex(
     getComputedStyle(root).getPropertyValue('--background'),
-    root.classList.contains(DARK_CLASS) ? '#1c1d21' : '#ffffff',
+    isDark ? '#1c1d21' : '#ffffff',
   );
   void window.maka?.appWindow
     ?.setTitleBarOverlayTheme?.({
-      isDark: root.classList.contains(DARK_CLASS),
-      backgroundColor,
+      isDark,
+      backgroundColor: titlebarModalDimmed
+        ? dimmedTitlebarColor(backgroundColor, isDark)
+        : backgroundColor,
     })
     .catch(() => {});
+}
+
+/**
+ * The color the titlebar strip appears under an open modal: the dialog
+ * backdrop scrim composited over `--background`. The scrim is sampled from
+ * the open modal's own ::backdrop — the engine has already resolved its
+ * `var()` indirection and `light-dark()` branch, which neither a token read
+ * nor a canvas fillStyle can do — so the dim tracks theme and palette
+ * automatically.
+ */
+function dimmedTitlebarColor(backgroundHex: string, isDark: boolean): string {
+  // The app's theme pins the scrim to black@50%/80% (astryx-theme/maka.css);
+  // mirror that as the fallback if no modal backdrop can be sampled.
+  const scrim = readModalBackdropColor() ?? { r: 0, g: 0, b: 0, a: isDark ? 0.8 : 0.5 };
+  return compositeScrimOverBackground(scrim, backgroundHex);
+}
+
+/**
+ * The computed color of the open modal's ::backdrop. Callers only dim while a
+ * `dialog:modal` exists, so a null here means something unusual happened —
+ * fall back rather than dimming wrong.
+ */
+function readModalBackdropColor(): { r: number; g: number; b: number; a: number } | null {
+  const dialog = document.querySelector('dialog:modal');
+  if (!dialog) return null;
+  return parseCssRgbColor(getComputedStyle(dialog, '::backdrop').backgroundColor);
 }
 
 function cssColorToHex(value: string, fallback: string): string {

--- a/apps/desktop/src/renderer/titlebar-dim-color.ts
+++ b/apps/desktop/src/renderer/titlebar-dim-color.ts
@@ -1,0 +1,63 @@
+// apps/desktop/src/renderer/titlebar-dim-color.ts
+//
+// Pure color math for the modal-open titlebar dim (theme.ts drives it; the
+// main-process tests pin it). No DOM access and no imports, so the module
+// compiles standalone into `dist/renderer/` for `node --test`.
+
+/**
+ * scrim composited over an opaque hex background, channel-wise. An
+ * unparseable background comes back unchanged so the caller degrades to the
+ * undimmed color rather than dimming wrong.
+ */
+export function compositeScrimOverBackground(
+  scrim: { r: number; g: number; b: number; a: number },
+  backgroundHex: string,
+): string {
+  const base = hexToRgb(backgroundHex);
+  if (!base) return backgroundHex;
+  const channel = (top: number, bottom: number): number =>
+    Math.round(scrim.a * top + (1 - scrim.a) * bottom);
+  return rgbToHex(channel(scrim.r, base.r), channel(scrim.g, base.g), channel(scrim.b, base.b));
+}
+
+/**
+ * Parse a computed `rgb()`/`rgba()` serialization (any separator style —
+ * commas, spaces, slash alpha, percent alpha). Returns null for anything
+ * else (e.g. `oklch()`/`color(...)` serializations), letting callers fall
+ * back instead of guessing.
+ */
+export function parseCssRgbColor(
+  used: string,
+): { r: number; g: number; b: number; a: number } | null {
+  const match = /^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)(?:\s*[,/]\s*([\d.]+%?))?\s*\)$/.exec(used);
+  if (!match) return null;
+  const alphaRaw = match[4];
+  const alpha = alphaRaw === undefined
+    ? 1
+    : alphaRaw.endsWith('%')
+      ? Number.parseFloat(alphaRaw) / 100
+      : Number.parseFloat(alphaRaw);
+  if ([match[1], match[2], match[3]].some((c) => Number.isNaN(Number.parseFloat(c))) || Number.isNaN(alpha)) {
+    return null;
+  }
+  return {
+    r: Number.parseFloat(match[1]),
+    g: Number.parseFloat(match[2]),
+    b: Number.parseFloat(match[3]),
+    a: alpha,
+  };
+}
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const match = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i.exec(hex);
+  if (!match) return null;
+  return {
+    r: Number.parseInt(match[1], 16),
+    g: Number.parseInt(match[2], 16),
+    b: Number.parseInt(match[3], 16),
+  };
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${[r, g, b].map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
+}

--- a/apps/desktop/src/renderer/titlebar-modal-sync.ts
+++ b/apps/desktop/src/renderer/titlebar-modal-sync.ts
@@ -1,0 +1,70 @@
+// apps/desktop/src/renderer/titlebar-modal-sync.ts
+//
+// Keeps the OS-drawn window controls in visual sync with modal dialogs.
+//
+// A modal `<dialog>`'s ::backdrop dims the whole page, but the native window
+// controls — the Windows titleBarOverlay box in the top-right corner, the
+// macOS traffic lights — are composited above web content and stay bright,
+// reading as an undimmed white patch floating over the scrim. React state
+// used to track the four shell-owned modals by name (help, palette, search,
+// external import), so every dialog mounted deeper in the tree — the
+// scheduled-task form, session rename, bot onboarding, the narrow inspector
+// sheet — dimmed the page but never the strip.
+//
+// This observer replaces that hand-maintained list with the platform truth:
+// `dialog:modal` matches exactly the elements that paint a ::backdrop,
+// whoever rendered them. While at least one exists, theme.ts folds the scrim
+// color into the Windows overlay color and macOS hides its traffic lights;
+// when the last one closes, the strip restores.
+
+import { setTitlebarModalDimmed } from './theme';
+
+function subtreeTouchesDialog(nodes: NodeList): boolean {
+  for (const node of nodes) {
+    if (
+      node instanceof HTMLElement &&
+      (node.tagName === 'DIALOG' || node.querySelector('dialog') !== null)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Starts watching for top-layer modals. Returns a disposer that disconnects
+ * and restores the undimmed strip — the cleanup path the old effect took on
+ * unmount.
+ */
+export function startTitlebarModalSync(): () => void {
+  const sync = (): void => {
+    setTitlebarModalDimmed(document.querySelector('dialog:modal') !== null);
+  };
+  // Attribute mutations fire for <details open> too; only <dialog> can enter
+  // the modal state, so filter before touching the DOM further.
+  const observer = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (mutation.type === 'attributes') {
+        if ((mutation.target as HTMLElement).tagName === 'DIALOG') sync();
+        continue;
+      }
+      if (
+        subtreeTouchesDialog(mutation.addedNodes) ||
+        subtreeTouchesDialog(mutation.removedNodes)
+      ) {
+        sync();
+      }
+    }
+  });
+  observer.observe(document.documentElement, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['open'],
+  });
+  sync();
+  return () => {
+    observer.disconnect();
+    setTitlebarModalDimmed(false);
+  };
+}

--- a/packages/ui/src/primitives/module-page.tsx
+++ b/packages/ui/src/primitives/module-page.tsx
@@ -187,7 +187,6 @@ export function ModulePage({
               width={420}
             >
               <Layout
-                height="auto"
                 header={<DialogHeader title={inspectorLabel ?? title} onOpenChange={(open) => {
                   if (!open) onInspectorDismiss?.();
                 }} />}

--- a/packages/ui/src/scheduled-task-form-dialog.tsx
+++ b/packages/ui/src/scheduled-task-form-dialog.tsx
@@ -215,7 +215,6 @@ export function ScheduledTaskFormDialog(props: {
       width={480}
     >
       <Layout
-        height="auto"
         header={(
           <DialogHeader
             title={isEditing ? copy.editTitle : copy.createTitle}

--- a/packages/ui/src/session-rename-dialog.tsx
+++ b/packages/ui/src/session-rename-dialog.tsx
@@ -62,7 +62,6 @@ export function SessionRenameDialog(props: {
   return (
     <Dialog isOpen onOpenChange={props.onOpenChange} purpose="form" width={440}>
       <Layout
-        height="auto"
         header={
           <DialogHeader
             title={title}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

The scheduled-task edit dialog rendered wrong in two ways (#3010 carries the reporter's screenshot):

1. **A form taller than the dialog's 75vh max-height was clipped, not scrolled** — the 保存 footer was unreachable and the last field (方式) sat flush against the bottom edge. The form's `Layout height="auto"` grows with content and ignores the `--container-max-height` the Dialog publishes, so `LayoutContent` never scrolls. Fixed by dropping `height="auto"` (the vendor's default `fill` honors the constraint) in `ScheduledTaskFormDialog`, and in `ModulePage`'s narrow inspector sheet which clipped long run histories the same way.

2. **On Windows, the OS-drawn titlebar controls box stayed bright white over the dimmed window.** Modal-open tracking was a hand-maintained list of four shell modals, and `setTitlebarControlsVisible` no-ops off macOS. Replaced by a `dialog:modal` top-layer observer (`titlebar-modal-sync.ts`): while any modal exists, the backdrop scrim (`--color-overlay`) is folded into the `titleBarOverlay` color on Windows and the traffic lights are hidden on macOS; the strip restores when the last dialog closes.

Fixes #3010
Fixes #3011

## Verification

- #3010 reproduced and fixed in Storybook (1240×820, light): before — dialog 615px vs content 690px, inner `overflow: hidden` cuts the footer; after — content scrolls, footer visible (submit rect 670–702 within the dialog's 718px bottom edge, 16px below it), the create dialog still hugs short content, and the narrow inspector (700×500) scrolls instead of clipping.

| Before — footer clipped, no padding below 方式 | After — footer pinned, content scrolls |
| --- | --- |
| <img alt="before: edit dialog clipped" src="https://github.com/user-attachments/assets/e4ca0d96-0f39-43fb-957f-0c2e46df7dcc" /> | <img alt="after: edit dialog with visible footer" src="https://github.com/user-attachments/assets/2deb69b7-cbdc-4af5-a9bd-a4217433e2da" /> |

After — create dialog hugs its content: <img alt="after: create dialog" src="https://github.com/user-attachments/assets/0dc5b996-3bb1-4bdc-b7cf-729226e6abf9" />
After — narrow inspector scrolls: <img alt="after: narrow inspector scrolls" src="https://github.com/user-attachments/assets/68d70f59-19af-47ed-ba2a-aafa56d177ca" />
- #3011 verified through a bridge spy: dialog open → `setTitlebarControlsVisible(false)` + `setTitleBarOverlayTheme(#808080)` light / `#050505` dark; close → restored to `#ffffff`. The Windows visual itself could not be exercised on this Linux dev machine (no overlay there) — worth one confirming look on Windows.
- `node --test dist/main/__tests__/titlebar-modal-dim.test.js` — 6 tests pin the scrim composite (`#808080` light / `#050505` dark) and the `rgb()`/`rgba()` parser's separator styles and refusal paths.
- `npm --workspace @maka/desktop run typecheck` (all four configs) and `tsc -p tsconfig.json --noEmit` in `packages/ui` pass; `biome check` clean on the changed files (the UI surface is formatter-excluded by design, see biome.jsonc); knip reports nothing for the changed files.
- Review pass 2 (independent blind review) found no blockers; its follow-ups landed here: the remaining two `height="auto"` dialogs (session rename, side-chat confirmation) are unified to the default `fill`, and the scrim is now sampled from the open modal's own `::backdrop` computed color instead of a probe element — fewer moving parts, exact by construction.

## Checklist

- [x] Tests cover the change and fail without it — `titlebar-modal-dim.test.ts` pins the color math; the dialog-scroll behavior is pinned with the Storybook measurements above (no DOM harness exists for it)
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above

## AI disclosure

Prepared by Maka under me2seeks's direction and review; the commit carries the `Generated-by: Maka` trailer. me2seeks takes responsibility for the final changes and their outcomes.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

定时任务编辑弹窗有两个渲染缺陷（#3010 附报告截图）：

1. **表单高于弹窗 75vh 上限时被裁切而非滚动**——保存 footer 完全不可达，最后一个字段（方式）紧贴底边无留白。根因是 `Layout height="auto"` 随内容增长、不读 Dialog 发布的 `--container-max-height`，`LayoutContent` 无法滚动。修复：移除 `ScheduledTaskFormDialog` 和 `ModulePage` 窄屏检查器中的 `height="auto"`（vendor 默认的 `fill` 会遵守该约束）。

2. **Windows 下原生标题栏控制块在遮罩上保持亮白。** 原有 modal 追踪是手工维护的四个 shell 弹窗名单，且 `setTitlebarControlsVisible` 仅在 macOS 生效。改为用 `dialog:modal` 顶层观察器（`titlebar-modal-sync.ts`）：任何 modal 打开时把遮罩色（`--color-overlay`）合成进 Windows 的 `titleBarOverlay` 颜色、macOS 隐藏 traffic lights，最后一个弹窗关闭后恢复。

修复 #3010、#3011。

## 验证

- #3010 在 Storybook（1240×820 亮色）复现并验证修复：修复前弹窗 615px vs 内容 690px、footer 被裁；修复后内容滚动、footer 可见（提交按钮位于弹窗内、下方 16px），新建弹窗仍贴合短内容，窄屏检查器（700×500）滚动而非裁切。前后对比截图见上方英文区。
- #3011 通过 bridge 探针验证：弹窗打开 → `setTitlebarControlsVisible(false)` + `setTitleBarOverlayTheme(#808080)`（亮色）/ `#050505`（暗色）；关闭 → 恢复 `#ffffff`。本机是 Linux 无法呈现 Windows overlay 视觉效果，建议在 Windows 上确认一眼。
- 新增 `titlebar-modal-dim.test.ts` 6 个用例：钉住 scrim 合成（亮色 `#808080` / 暗色 `#050505`）与 `rgb()`/`rgba()` 解析器的各分隔符形式及拒绝路径。
- `@maka/desktop` 四套 tsconfig typecheck 与 `packages/ui` typecheck 通过；`biome check` 通过（UI surface 按设计不参与 formatter，见 biome.jsonc）；knip 对改动文件无告警。
- 第二遍独立盲审无阻塞项，其跟进项已落地：剩余两处 `height="auto"` 弹窗（会话重命名、侧聊关闭确认）统一为默认 `fill`；scrim 改为直接采样打开弹窗的 `::backdrop` 计算颜色（取代探针元素），部件更少、构造上即精确。

## AI 披露

本 PR 由 Maka 在 me2seeks 的指导和审查下完成；提交带有 `Generated-by: Maka` trailer。me2seeks 对最终改动及其结果负责。

</details>

