### PR TITLE
fix(runtime): fence node-pty writes at PTY exit

### DIFF
--- a/packages/runtime/src/__tests__/node-pty-write-lifecycle.test.ts
+++ b/packages/runtime/src/__tests__/node-pty-write-lifecycle.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { test } from 'node:test';
+
+const CHILD_SOURCE = String.raw`
+  import { spawn as spawnPty } from 'node-pty';
+  import { execFileSync } from 'node:child_process';
+  import {
+    closeSync,
+    constants,
+    fstatSync,
+    mkdtempSync,
+    open,
+    openSync,
+    rmSync,
+    stat,
+  } from 'node:fs';
+  import { tmpdir } from 'node:os';
+  import { join } from 'node:path';
+  import { promisify } from 'node:util';
+
+  const delay = promisify(setTimeout);
+  const root = mkdtempSync(join(tmpdir(), 'maka-node-pty-write-lifecycle-'));
+  const fifo = join(root, 'worker-blocker');
+  const sentinelPath = join(root, 'sentinel');
+  let readerFd;
+  let sentinelFd;
+  let terminal;
+
+  try {
+    execFileSync('mkfifo', [fifo]);
+    terminal = spawnPty(
+      process.execPath,
+      ['-e', 'process.stdin.pause(); setInterval(() => {}, 1000)'],
+      { cols: 80, rows: 24 },
+    );
+    const terminalFd = terminal.fd;
+
+    const reader = new Promise((resolve, reject) => {
+      open(fifo, constants.O_RDONLY, (error, fd) => {
+        if (error) reject(error);
+        else {
+          readerFd = fd;
+          resolve();
+        }
+      });
+    });
+    let probeCompleted = false;
+    const blockedPoolProbe = new Promise((resolve, reject) => {
+      stat(root, (error) => {
+        if (error) reject(error);
+        else {
+          probeCompleted = true;
+          resolve();
+        }
+      });
+    });
+    await delay(50);
+    if (probeCompleted) throw new Error('FIFO did not occupy the libuv worker');
+
+    terminal.write('R'.repeat(4 * 1024 * 1024));
+    setTimeout(() => terminal.kill('SIGKILL'), 5);
+    await new Promise((resolve) => terminal.onExit(resolve));
+
+    sentinelFd = openSync(
+      sentinelPath,
+      constants.O_RDWR | constants.O_CREAT | constants.O_TRUNC,
+      0o600,
+    );
+    if (sentinelFd !== terminalFd) {
+      throw new Error(
+        'Expected retired PTY fd ' + terminalFd + ' to be reused, received ' + sentinelFd,
+      );
+    }
+
+    const writerFd = openSync(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
+    closeSync(writerFd);
+    const writeCompletionBarrier = new Promise((resolve, reject) => {
+      stat(root, (error) => (error ? reject(error) : resolve()));
+    });
+    await Promise.all([reader, blockedPoolProbe, writeCompletionBarrier]);
+    closeSync(readerFd);
+    readerFd = undefined;
+
+    if (fstatSync(sentinelFd).size !== 0) {
+      throw new Error('Queued PTY input reached the reused sentinel fd');
+    }
+    closeSync(sentinelFd);
+    sentinelFd = undefined;
+    console.log('sentinel-ok');
+  } finally {
+    try {
+      terminal?.kill('SIGKILL');
+    } catch {}
+    if (readerFd !== undefined) closeSync(readerFd);
+    if (sentinelFd !== undefined) closeSync(sentinelFd);
+    rmSync(root, { recursive: true, force: true });
+  }
+`;
+
+test('does not carry queued Unix PTY writes past native exit', {
+  skip: process.platform === 'win32' ? 'Unix PTY file-descriptor lifecycle only' : false,
+}, () => {
+  const result = spawnSync(process.execPath, ['--input-type=module', '--eval', CHILD_SOURCE], {
+    cwd: process.cwd(),
+    encoding: 'utf8',
+    env: { ...process.env, UV_THREADPOOL_SIZE: '1' },
+    timeout: 10_000,
+  });
+
+  assert.ifError(result.error);
+  assert.equal(result.signal, null, result.stderr);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), 'sentinel-ok');
+  assert.doesNotMatch(result.stderr, /Unhandled pty write error/);
+});

--- a/patches/README.md
+++ b/patches/README.md
@@ -8,6 +8,16 @@ Keep this directory small. Prefer product code that uses the dependency's
 published API; only patch for bugs that block shipping and cannot be worked
 around at the call site.
 
+## `node-pty@1.2.0-beta.14`
+
+On Unix, `CustomWriteStream` submits raw file-descriptor writes through libuv.
+Those writes can survive PTY exit and target an unrelated file after descriptor
+reuse. The patch keeps writes synchronous on node-pty's non-blocking PTY master,
+checks an `fstat` fingerprint before retries, yields between attempts, and cancels
+the queue at the native exit fence. See #2978.
+
+Delete when node-pty ships an equivalent Unix write-lifecycle fix.
+
 ## `@ai-sdk/provider-utils@5.0.27`
 
 Streaming tool-call association for gateways that reuse or omit `index` / `id`

--- a/patches/node-pty+1.2.0-beta.14.patch
+++ b/patches/node-pty+1.2.0-beta.14.patch
@@ -1,0 +1,132 @@
+diff --git a/node_modules/node-pty/lib/unixTerminal.js b/node_modules/node-pty/lib/unixTerminal.js
+index af2d24c..a16ab59 100644
+--- a/node_modules/node-pty/lib/unixTerminal.js
++++ b/node_modules/node-pty/lib/unixTerminal.js
+@@ -65,6 +65,10 @@ var UnixTerminal = /** @class */ (function (_super) {
+         var parsedEnv = _this._parseEnv(env);
+         var encoding = (opt.encoding === undefined ? 'utf8' : opt.encoding);
+         var onexit = function (code, signal) {
++            // Stop queued writes while the PTY fd is still owned by this terminal.
++            // An async write that outlives the fd can target an unrelated file if
++            // the operating system reuses the descriptor before libuv runs it.
++            _this._writeStream.dispose();
+             // XXX Sometimes a data event is emitted after exit. Wait til socket is
+             // destroyed.
+             if (!_this._emittedClose) {
+@@ -105,6 +109,7 @@ var UnixTerminal = /** @class */ (function (_super) {
+                     return;
+                 }
+             }
++            _this._writeStream.dispose();
+             // close
+             _this._close();
+             // EIO on exit from fs.ReadStream:
+@@ -134,6 +139,7 @@ var UnixTerminal = /** @class */ (function (_super) {
+         _this._readable = true;
+         _this._writable = true;
+         _this._socket.on('close', function () {
++            _this._writeStream.dispose();
+             if (_this._emittedClose) {
+                 return;
+             }
+@@ -288,12 +294,19 @@ var CustomWriteStream = /** @class */ (function () {
+         this._fd = _fd;
+         this._encoding = _encoding;
+         this._writeQueue = [];
++        this._disposed = false;
++        this._fdIdentity = fs.fstatSync(_fd);
+     }
+     CustomWriteStream.prototype.dispose = function () {
++        this._disposed = true;
+         clearImmediate(this._writeImmediate);
+         this._writeImmediate = undefined;
++        this._writeQueue.length = 0;
+     };
+     CustomWriteStream.prototype.write = function (data) {
++        if (this._disposed) {
++            return;
++        }
+         // Writes are put in a queue and processed asynchronously in order to handle
+         // backpressure from the kernel buffer.
+         var buffer = typeof data === 'string'
+@@ -309,42 +322,53 @@ var CustomWriteStream = /** @class */ (function () {
+     CustomWriteStream.prototype._processWriteQueue = function () {
+         var _this = this;
+         this._writeImmediate = undefined;
+-        if (this._writeQueue.length === 0) {
++        if (this._disposed || this._writeQueue.length === 0) {
+             return;
+         }
+         var task = this._writeQueue[0];
++        if (!this._ownsFileDescriptor()) {
++            this.dispose();
++            return;
++        }
+         // Write to the underlying file descriptor and handle it directly, rather
+         // than using the `net.Socket`/`tty.WriteStream` wrappers which swallow and
+         // mask errors like EAGAIN and can cause the thread to block indefinitely.
+-        fs.write(this._fd, task.buffer, task.offset, function (err, written) {
+-            if (err) {
+-                if ('code' in err && err.code === 'EAGAIN') {
+-                    // `setImmediate` is used to yield to the event loop and re-attempt
+-                    // the write later.
+-                    _this._writeImmediate = setImmediate(function () { return _this._processWriteQueue(); });
+-                }
+-                else {
+-                    // Stop processing immediately on unexpected error and log
+-                    _this._writeQueue.length = 0;
+-                    console.error('Unhandled pty write error', err);
+-                }
+-                return;
+-            }
++        // The native layer marks the PTY master fd as non-blocking. Keep each raw-fd
++        // write synchronous so no libuv request can outlive the descriptor, then
++        // yield between writes to retain asynchronous queue and backpressure behavior.
++        try {
++            var written = fs.writeSync(this._fd, task.buffer, task.offset);
+             task.offset += written;
+             if (task.offset >= task.buffer.byteLength) {
+-                _this._writeQueue.shift();
++                this._writeQueue.shift();
+             }
+-            // Since there is more room in the kernel buffer, we can continue to write
+-            // until we hit EAGAIN or exhaust the queue.
+-            //
+-            // Note that old versions of bash, like v3.2 which ships in macOS, appears
+-            // to have a bug in its readline implementation that causes data
+-            // corruption when writes to the pty happens too quickly. Instead of
+-            // trying to workaround that we just accept it so that large pastes are as
+-            // fast as possible.
+-            // Context: https://github.com/microsoft/node-pty/issues/833
+-            _this._processWriteQueue();
+-        });
++        }
++        catch (err) {
++            if (typeof err !== 'object' || err === null || !('code' in err) || err.code !== 'EAGAIN') {
++                // Stop processing immediately on unexpected error and log
++                this._writeQueue.length = 0;
++                console.error('Unhandled pty write error', err);
++                return;
++            }
++        }
++        if (!this._disposed && this._writeQueue.length > 0) {
++            this._writeImmediate = setImmediate(function () { return _this._processWriteQueue(); });
++        }
++    };
++    CustomWriteStream.prototype._ownsFileDescriptor = function () {
++        try {
++            var current = fs.fstatSync(this._fd);
++            return current.dev === this._fdIdentity.dev
++                && current.ino === this._fdIdentity.ino
++                && current.mode === this._fdIdentity.mode
++                && current.rdev === this._fdIdentity.rdev;
++        }
++        catch (err) {
++            if (typeof err === 'object' && err !== null && 'code' in err && err.code === 'EBADF') {
++                return false;
++            }
++            throw err;
++        }
+     };
+     return CustomWriteStream;
+ }());


### PR DESCRIPTION
## Summary

Patch the node-pty Unix writer so queued PTY input cannot outlive its raw file descriptor and corrupt a subsequently opened file after fd reuse. Writes now use the already nonblocking descriptor synchronously, verify descriptor identity before retries, and stop at every exit or close fence.

Add an isolated deterministic regression that blocks the sole libuv worker, reopens a sentinel at the exact retired PTY fd, and proves that the unpatched queued write reaches that sentinel.

Fixes #2978

## Verification

- `npm ci` — patch-package reapplies `node-pty@1.2.0-beta.14`
- `npm run build:test`
- `npm run typecheck`
- `npm --workspace @maka/runtime test` — 2,836 tests, 0 failures
- Targeted regression on Node 22.19, Node 24.5, and Node 26.3
- `npm run lint`
- `npm run format:check`
- Regression confirmed to fail with the patch reversed and pass after restoration

## Review focus

This is a temporary dependency patch for an upstream Unix lifecycle defect. Remove it when node-pty publishes an equivalent fix. This PR intentionally does not upgrade to beta.15 because that release does not modify the Unix write path.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck, and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — queued Unix PTY writes stop at descriptor retirement instead of reaching a reused file
- [ ] No

AI disclosure: Codex prepared this draft with direction from M4n5ter; M4n5ter is the contributor of record and will review the result.

