### PR TITLE
test(desktop): cover conversation pin lifecycle

### DIFF
--- a/apps/desktop/e2e/conversation-pin.spec.ts
+++ b/apps/desktop/e2e/conversation-pin.spec.ts
@@ -1,0 +1,39 @@
+import { COMPOSER_INPUT, expect, test } from './fixtures';
+
+test('a conversation can be pinned, survives reload, and can be unpinned by keyboard', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('conversation pin persistence');
+  await composer.press('Enter');
+  await expect(page.getByText(/Fake backend received: conversation pin persistence/)).toBeVisible();
+
+  await page.getByRole('button', { name: '展开侧边栏', exact: true }).click();
+  const sidebar = page.getByRole('navigation', { name: '对话列表' });
+  const row = sidebar.locator('[data-maka-contract="session-row"]').first();
+  const actions = row.getByRole('button', { name: '对话操作', exact: true });
+
+  await actions.focus();
+  await page.keyboard.press('Enter');
+  await page.getByRole('menuitem', { name: '置顶', exact: true }).click();
+
+  await expect(sidebar.getByText('置顶', { exact: true })).toBeVisible();
+  await expect(row.getByRole('button', { name: '对话操作', exact: true })).toBeVisible();
+
+  await page.reload();
+  await expect(page.locator(COMPOSER_INPUT)).toBeVisible();
+
+  const reloadedSidebar = page.getByRole('navigation', { name: '对话列表' });
+  const reloadedRow = reloadedSidebar.locator('[data-maka-contract="session-row"]').first();
+  const reloadedActions = reloadedRow.getByRole('button', { name: '对话操作', exact: true });
+  await expect(reloadedSidebar.getByText('置顶', { exact: true })).toBeVisible();
+
+  await reloadedActions.focus();
+  await page.keyboard.press('Enter');
+  await page.getByRole('menuitem', { name: '取消置顶', exact: true }).click();
+
+  // The closed MoreMenu keeps its next "置顶" item mounted but hidden; the
+  // section heading itself must disappear from the visible rail.
+  await expect(reloadedSidebar.getByText('置顶', { exact: true })).not.toBeVisible();
+  await expect(reloadedSidebar.getByText('最近', { exact: true })).toBeVisible();
+});

--- a/packages/ui/src/__tests__/session-history-row-actions.test.tsx
+++ b/packages/ui/src/__tests__/session-history-row-actions.test.tsx
@@ -107,3 +107,30 @@ test('renders collapsible project navigation and row actions as sibling controls
   assert.equal(projectButtons[1], navigation);
   assert.doesNotMatch(markup, /<button\b(?:(?!<\/button>)[\s\S])*<button\b/);
 });
+
+test('groups multiple pinned sessions first and sorts each section by recent activity', () => {
+  const sessions: SessionSummary[] = [
+    { ...session, id: 'recent', name: 'Recent', lastMessageAt: 30, isFlagged: false },
+    { ...session, id: 'pinned-old', name: 'Pinned old', lastMessageAt: 10, isFlagged: true },
+    { ...session, id: 'pinned-new', name: 'Pinned new', lastMessageAt: 20, isFlagged: true },
+  ];
+  const markup = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <SessionHistoryList
+        sessions={sessions}
+        onSelectSession={() => undefined}
+        rowActions={rowActions}
+      />
+    </LocaleProvider>,
+  );
+
+  const { document } = parseHTML(markup);
+  const rows = [...document.querySelectorAll<HTMLElement>('[data-maka-contract="session-row"]')];
+  assert.deepEqual(rows.map((row) => row.dataset.sessionId), [
+    'pinned-new',
+    'pinned-old',
+    'recent',
+  ]);
+  assert.match(markup, /Pinned/);
+  assert.match(markup, /Recent/);
+});


### PR DESCRIPTION
## Summary

- add a Desktop E2E journey for pin, renderer reload persistence, and keyboard unpin
- cover multiple pinned conversations and deterministic recent-activity ordering
- reuse the existing durable isFlagged authority instead of introducing a second pin state

## Verification

- npm --workspace @maka/ui run build
- node --test packages/ui/dist/__tests__/session-history-row-actions.test.js
- npx playwright test --config e2e/playwright.config.ts e2e/conversation-pin.spec.ts
- npm --workspace @maka/desktop run typecheck
- npx biome check packages/ui/src/__tests__/session-history-row-actions.test.tsx apps/desktop/e2e/conversation-pin.spec.ts

Fixes #3015