### PR TITLE
fix(cli): start fresh TUI Sessions at the default permission mode

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -121,6 +121,72 @@ describe('Runtime Host Maka Session driver', () => {
     }
   });
 
+  test('drops a per-session Full access elevation when a fresh Session starts (#3020)', async () => {
+    // The TUI flow behind /new: session A is elevated to bypass, then the
+    // driver is asked to start over. The next prompt lazily creates session B
+    // through preparePrompt. Session B must be created with the
+    // construction-time default — Full access is an explicit per-session
+    // opt-in, never inherited.
+    const connection = new FakeConnection([
+      new FakeSubscription(continuitySnapshot(), Promise.resolve([])),
+      new FakeSubscription(
+        continuitySnapshot({
+          session: {
+            sessionId: 'session-2',
+            metadataRevision: 1,
+            status: 'running',
+            createdAt: 1,
+            lastUsedAt: 1,
+            isArchived: false,
+          },
+          rootTurn: null,
+        }),
+        Promise.resolve([]),
+      ),
+    ]);
+    let nextId = 0;
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/repo',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+      newId: () => `session-${++nextId}`,
+    });
+
+    await driver.createSession({
+      cwd: '/repo',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+      backend: 'ai-sdk',
+      permissionMode: 'ask',
+    });
+    connection.executionBoundary = { kind: 'bypass', revision: 2 };
+    await driver.setPermissionMode('bypass');
+    assert.equal(driver.getPermissionMode?.(), 'bypass');
+
+    driver.startNewSession();
+    assert.equal(driver.getPermissionMode?.(), 'ask');
+
+    // The fresh Session's boundary is managed again once it exists.
+    connection.executionBoundary = { kind: 'managed', access: 'writable', revision: 3 };
+    await driver.preparePrompt('hello');
+
+    const creates = connection.requests.filter(({ operation }) => operation === 'session.create');
+    assert.equal(creates.length, 2);
+    assert.deepEqual(creates[1]!.input, {
+      sessionId: 'session-2',
+      workspace: { kind: 'host_path', path: '/repo' },
+      name: 'New Chat',
+      modelTarget: {
+        kind: 'explicit',
+        connectionSlug: 'openai-main',
+        model: 'gpt-5',
+      },
+      permissionMode: 'ask',
+    });
+  });
+
   test('relocates a moved Session through Host authority before attaching', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-tui-resume-moved-cwd-'));
     const target = join(root, 'new-worktree');
@@ -1205,6 +1271,16 @@ class FakeConnection {
           hostCwd: create.workspace.kind === 'host_path' ? create.workspace.path : '/project',
         },
       }) as OperationOutput<K>;
+    }
+    if (operation === 'session.configuration.update') {
+      const update = input as OperationInput<'session.configuration.update'>;
+      return {
+        kind: 'committed',
+        session: sessionProjection({
+          revision: update.expectedRevision + 1,
+          permissionMode: update.configuration.permissionMode,
+        }),
+      } as OperationOutput<K>;
     }
     const turnInput = input as {
       sessionId?: string;

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -122,6 +122,11 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   #model: string;
   #llmConnectionSlug: string;
   #thinkingLevel: ThinkingLevel | undefined;
+  // Construction-time default a fresh Session is created with. Per-session
+  // elevations (the picker, a resumed Session's boundary) update
+  // `#permissionMode` only; `startNewSession` falls back to this so Full
+  // access never leaks into a fresh Session (#3020).
+  readonly #defaultPermissionMode: PermissionMode;
   #permissionMode: PermissionMode;
   #activeBoundaryDisplayMode: PermissionMode | undefined;
   #orchestrationMode: OrchestrationMode;
@@ -164,7 +169,8 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     };
     this.#model = input.model;
     this.#llmConnectionSlug = input.llmConnectionSlug;
-    this.#permissionMode = input.permissionMode ?? 'ask';
+    this.#defaultPermissionMode = input.permissionMode ?? 'ask';
+    this.#permissionMode = this.#defaultPermissionMode;
     this.#orchestrationMode = input.orchestrationMode ?? 'default';
   }
 
@@ -550,6 +556,12 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
     this.#sessionGeneration += 1;
     this.#channelGeneration += 1;
     this.#sessionId = null;
+    // A fresh Session starts at the construction-time default. Leaving a
+    // previous Session's elevation in `#permissionMode` would both misreport
+    // the mode and create the next Session with it (#3020). Full access stays
+    // an explicit per-session opt-in; `setPermissionMode` can still raise the
+    // mode before the first prompt creates the Session.
+    this.#permissionMode = this.#defaultPermissionMode;
     this.#activeBoundaryDisplayMode = undefined;
     void this.#replaceChannel(undefined);
   }


### PR DESCRIPTION
## Summary

In the TUI, elevating a session to **Full access** (`bypass`) and then running `/new` silently carried the elevation into the fresh session: the status line kept showing Full access, and the next prompt created the new session with `permissionMode: 'bypass'` — tools ran with direct file/network access in a session the user never elevated.

`startNewSession()` cleared the session binding and the boundary *display* mode, but not the base `#permissionMode` that `session.create` uses. The fix captures the construction-time default (`#defaultPermissionMode`, what the TUI passes at cold start — `ask`) and resets to it in `startNewSession()`. This matches the desktop model, where a new chat uses the settings-backed default rather than the previously viewed session's mode, and keeps Full access an explicit per-session opt-in: `setPermissionMode` before the first prompt still raises the fresh session.

Fixes #3020

## Verification

- `packages/cli` suite: **260/260 pass** (includes the new regression test).
- Mutation check: with the reset line removed, the new test fails with `'bypass' !== 'ask'`; restored, it passes.
- End-to-end driver script (reproduces the exact TUI path: `setPermissionMode('bypass')` → `startNewSession()` → `preparePrompt()`): before — `getPermissionMode()` after `/new` returned `bypass` and the new `session.create` carried `bypass`; after — both are `ask`.
- `biome check` clean on both touched files.
- Not run: full monorepo suite and desktop/e2e suites (change is confined to `packages/cli`; left to CI).

## Security

This changes security-relevant behavior (permission/boundary mode of newly created sessions). Per the review policy and the contributor's request, the fast path does **not** apply: **this PR requires independent review by another human before merge** (AI review does not count), in addition to the human contributor of record.

Prepared with AI assistance (Maka agent); the investigation, reproduction, and fix were reviewed by the human contributor. The final commit carries `Generated-by: Maka` — please keep the trailer when squash-merging.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
