### PR TITLE
fix(runtime-host): bound a never-connected ephemeral candidate's lifetime

### DIFF
--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -752,6 +752,40 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
+  test('a silent handshake defers the never-connected drain instead of being drained under it', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      const host = await RuntimeHostKernel.start({
+        owner,
+        initialConnectionTimeoutMs: 500,
+        idleGraceMs: 10_000,
+        handshakeTimeoutMs: 2_000,
+        composition: defineInteractiveRuntimeHostComposition(async () => testComposition()),
+      });
+
+      const silent = await openSocket(host.endpoint);
+      try {
+        // Past the initial connection timeout but inside the handshake
+        // deferral window: the pending handshake must keep the Host alive.
+        await new Promise((resolve) => setTimeout(resolve, 1_000));
+        assert.equal(host.state, 'ready');
+      } finally {
+        silent.destroy();
+      }
+      // With the handshake gone, the deferred deadline drains the Host.
+      await withTimeout(
+        host.closed,
+        5_000,
+        'silently-handshaked ephemeral candidate never drained after the deferral',
+      );
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successor);
+      await successor.close();
+    });
+  });
+
   test('drain requested before factory completion begins drain before recovery exactly once', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -688,6 +688,70 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
+  test('never-connected ephemeral candidate drains after the initial connection timeout despite a boot residency', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      let releaseBootWork: (() => void) | undefined;
+      const host = await RuntimeHostKernel.start({
+        owner,
+        initialConnectionTimeoutMs: 100,
+        idleGraceMs: 10_000,
+        composition: defineInteractiveRuntimeHostComposition(async (context) => {
+          const residency = context.acquireResidency('boot-work');
+          releaseBootWork = () => residency.release();
+          return testComposition({
+            beginDrain: () => releaseBootWork?.(),
+          });
+        }),
+      });
+
+      await withTimeout(
+        host.closed,
+        2_000,
+        'ephemeral candidate outlived its initial connection timeout',
+      );
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successor);
+      await successor.close();
+    });
+  });
+
+  test('never-connected ephemeral candidate with a hung composition startup fails stop at the deadlines', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      const hostTask = RuntimeHostKernel.start({
+        owner,
+        initialConnectionTimeoutMs: 100,
+        idleGraceMs: 10_000,
+        shutdownGraceMs: 100,
+        composition: defineInteractiveRuntimeHostComposition(() => new Promise(() => {})),
+      });
+
+      try {
+        const error = await withTimeout(
+          hostTask.then(
+            () => assert.fail('Runtime Host startup unexpectedly succeeded'),
+            (startupError: unknown) => startupError,
+          ),
+          2_000,
+          'hung composition startup was not bounded by the initial connection deadline',
+        );
+        assert.ok(error instanceof AggregateError);
+        assert.ok(
+          error.errors.some(
+            (candidate: unknown) => candidate instanceof RuntimeHostProcessTerminationRequiredError,
+          ),
+        );
+      } finally {
+        await owner.close();
+      }
+    });
+  });
+
   test('drain requested before factory completion begins drain before recovery exactly once', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -68,6 +68,7 @@ const DEFAULT_HANDSHAKE_TIMEOUT_MS = 5_000;
 const DEFAULT_SHUTDOWN_GRACE_MS = 10_000;
 const SHUTDOWN_HANDSHAKE_GRACE_MS = 1_000;
 const SHUTDOWN_OPERATION_GRACE_MS = 1_000;
+const INITIAL_CONNECTION_DEADLINE_DEFERRAL_LIMIT = 3;
 const HOST_PROTOCOL = {
   min: RUNTIME_HOST_PROTOCOL_VERSION,
   max: RUNTIME_HOST_PROTOCOL_VERSION,
@@ -180,6 +181,8 @@ export class RuntimeHostKernel {
   #compositionStartup: Promise<void> | undefined;
   #operationHandlers: OperationHandlerMap;
   #idleTimer: NodeJS.Timeout | undefined;
+  #initialConnectionDeadline: NodeJS.Timeout | undefined;
+  #initialConnectionDeadlineDeferrals = 0;
   #shutdownRequested = false;
   #shutdownTask: Promise<void> | undefined;
   #shutdownDeadlineTimer: NodeJS.Timeout | undefined;
@@ -278,6 +281,7 @@ export class RuntimeHostKernel {
     if (!this.#shutdownRequested) {
       this.#shutdownRequested = true;
       this.#cancelIdle();
+      this.#cancelInitialConnectionDeadline();
       this.#armShutdownDeadline();
       this.#beginCompositionDrain();
     }
@@ -300,6 +304,10 @@ export class RuntimeHostKernel {
     this.#compositionStartup = new Promise((resolve) => {
       settleCompositionStartup = resolve;
     });
+    // Armed only once #compositionStartup is assigned: a deadline that fired
+    // earlier would drive #closeResources past an undefined startup await and
+    // let shutdown complete without closing the composition created below.
+    this.#armInitialConnectionDeadline();
     const compositionStartup = (async () => {
       try {
         this.#composition = await this.#options.composition.create({
@@ -456,6 +464,7 @@ export class RuntimeHostKernel {
       };
     }
     this.#hasAcceptedConnection = true;
+    this.#cancelInitialConnectionDeadline();
     this.#acceptedTransports.add(transport);
     this.#handshakingTransports.delete(transport);
     this.#cancelIdle();
@@ -703,6 +712,39 @@ export class RuntimeHostKernel {
     );
   }
 
+  // The idle timer only arms once the kernel reaches true idle, so a
+  // composition startup that never settles or a residency held from boot
+  // would keep an ephemeral candidate that no Client ever reached alive
+  // forever. This deadline bounds the wait for the first accepted connection
+  // independently of composition progress. A handshake in flight defers it by
+  // the handshake budget instead of draining under a connecting Client, but
+  // only a bounded number of times: connections enter the handshaking set
+  // before their first hello byte, so a reconnect loop that never completes a
+  // handshake must not push the deadline out indefinitely.
+  #armInitialConnectionDeadline(delayMs?: number): void {
+    if (this.#lifecycle.kind !== 'ephemeral') return;
+    if (this.#hasAcceptedConnection || this.#shutdownRequested) return;
+    this.#initialConnectionDeadline = setTimeout(() => {
+      this.#initialConnectionDeadline = undefined;
+      if (this.#hasAcceptedConnection || this.#shutdownRequested) return;
+      if (
+        this.#handshakingTransports.size > 0 &&
+        this.#initialConnectionDeadlineDeferrals < INITIAL_CONNECTION_DEADLINE_DEFERRAL_LIMIT
+      ) {
+        this.#initialConnectionDeadlineDeferrals += 1;
+        this.#armInitialConnectionDeadline(this.#handshakeTimeoutMs);
+        return;
+      }
+      this.#requestDrain();
+    }, delayMs ?? this.#lifecycle.initialConnectionTimeoutMs);
+  }
+
+  #cancelInitialConnectionDeadline(): void {
+    if (!this.#initialConnectionDeadline) return;
+    clearTimeout(this.#initialConnectionDeadline);
+    this.#initialConnectionDeadline = undefined;
+  }
+
   #cancelIdle(): void {
     if (!this.#idleTimer) return;
     clearTimeout(this.#idleTimer);
@@ -732,6 +774,7 @@ export class RuntimeHostKernel {
       }
       this.#state = 'draining';
       this.#cancelIdle();
+      this.#cancelInitialConnectionDeadline();
       this.#shutdownTask = this.#closeResources();
       void this.#shutdownTask.then(
         () => {

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -692,15 +692,17 @@ export class RuntimeHostKernel {
   #scheduleIdleIfNeeded(): void {
     if (this.#lifecycle.kind === 'service') return;
     if (this.#shutdownRequested) return;
+    // One timer authority per lifecycle phase: until the first connection is
+    // accepted, only #initialConnectionDeadline governs (it defers under an
+    // in-flight handshake, which #isTrueIdle() cannot see); afterwards the
+    // idle timer owns the idleGraceMs exit.
+    if (!this.#hasAcceptedConnection) return;
     if (!this.#isTrueIdle() || this.#idleTimer) return;
-    const timeoutMs = this.#hasAcceptedConnection
-      ? this.#lifecycle.idleGraceMs
-      : this.#lifecycle.initialConnectionTimeoutMs;
     this.#idleTimer = setTimeout(() => {
       this.#idleTimer = undefined;
       if (!this.#isTrueIdle()) return;
       void this.#commitShutdown().catch(() => undefined);
-    }, timeoutMs);
+    }, this.#lifecycle.idleGraceMs);
   }
 
   #isTrueIdle(): boolean {


### PR DESCRIPTION
## Summary

Fixes #2943.

An ephemeral candidate's initial-connection timeout was implemented only as the true-idle timer (`#scheduleIdleIfNeeded`), which never arms while composition startup is still pending or any residency is held. A candidate whose composition startup hung or that held boot-time residencies before any Client ever connected therefore outlived `--initial-connection-timeout-ms` indefinitely — the orphaned `execution-candidate-main.js` processes in #2943 survived 26+ hours.

## What changed

- `RuntimeHostKernel` now arms a dedicated first-connection deadline for ephemeral lifecycles. If no handshake has been accepted when it fires, the kernel requests a drain, which already carries the bounded fail-stop shutdown deadline (`shutdownGraceMs` → `RuntimeHostProcessTerminationRequiredError` → `process.exit(1)`), so the candidate's lifetime is bounded regardless of what the composition is doing.
- The deadline is cancelled by the first accepted connection, so a Client waiting through a slow recovery is unaffected (Clients handshake before polling `waitForRuntimeHostReady`).
- A handshake in flight defers the deadline by the handshake budget instead of draining under a connecting Client — bounded to 3 deferrals, so a reconnect loop that never completes a handshake cannot push the deadline out indefinitely.
- The deadline is armed only after `#compositionStartup` is assigned: an earlier fire would drive `#closeResources` past an undefined startup await and let shutdown complete without closing the composition created afterwards.

## Notes on the issue's analysis

- `#armShutdownDeadline()` is already called from `#requestDrain()` (since #1355), so the poison path (`retainUntilProcessExit` + `requestDrain`) was already bounded; suggested direction 2 was in place.
- `process-retention` deliberately blocks the clean-close path so a poisoned host fail-stops instead of pretending a clean shutdown; excluding it from `#isTrueIdle()` (direction 1) is unnecessary once the pre-connection lifetime is bounded, and would change post-connection semantics.
- The sustained 70–82% CPU is consistent with a hung/spinning composition startup (state never leaves `recovering`, so neither the idle timer nor any drain existed to stop it). This change does not diagnose the spin, but it bounds it: the process now fail-stops after `initialConnectionTimeoutMs + shutdownGraceMs`.

## Tests

- New: `never-connected ephemeral candidate drains after the initial connection timeout despite a boot residency`
- New: `never-connected ephemeral candidate with a hung composition startup fails stop at the deadlines`
- Full `@maka/runtime-host` suite: 935 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)