### PR TITLE
fix(desktop): queue a busy-raced send as steering instead of dropping it

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-busy-race-settlement.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-busy-race-settlement.test.ts
@@ -1,0 +1,284 @@
+/**
+ * #1954 busy-race settlement: a sessions:send that raced a root turn another
+ * client opened can come back `steered` (the send owns no turn) or under a
+ * Host-chosen turnId. Both results must be interpreted identically by the
+ * new-chat and existing-session branches, and a rebind must never overwrite
+ * an authoritative live projection that beat the IPC response.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import type { StoredMessage } from '@maka/core/session';
+import type { LiveTurnProjection } from '@maka/ui';
+import { createAppShellChatActions } from '../../renderer/app-shell-chat-actions.js';
+
+function installWindow(maka: unknown): () => void {
+  const target = globalThis as unknown as { window?: unknown };
+  const hadWindow = Object.prototype.hasOwnProperty.call(target, 'window');
+  const previousWindow = target.window;
+  Object.defineProperty(target, 'window', {
+    configurable: true,
+    value: { maka },
+    writable: true,
+  });
+  return () => {
+    if (hadWindow) {
+      Object.defineProperty(target, 'window', {
+        configurable: true,
+        value: previousWindow,
+        writable: true,
+      });
+    } else {
+      delete target.window;
+    }
+  };
+}
+
+function createTurnState() {
+  const liveTurnBySession: Record<string, LiveTurnProjection> = {};
+  return {
+    liveTurnBySession,
+    setLiveTurnBySession(
+      updater: (c: Record<string, LiveTurnProjection>) => Record<string, LiveTurnProjection>,
+    ) {
+      const next = updater({ ...liveTurnBySession });
+      for (const key of Object.keys(liveTurnBySession)) delete liveTurnBySession[key];
+      Object.assign(liveTurnBySession, next);
+    },
+  };
+}
+
+function createMessageState() {
+  const messages: StoredMessage[] = [];
+  return {
+    messages,
+    setMessages(updater: StoredMessage[] | ((current: StoredMessage[]) => StoredMessage[])) {
+      const next = typeof updater === 'function' ? updater([...messages]) : updater;
+      messages.length = 0;
+      messages.push(...next);
+    },
+  };
+}
+
+function createActionsDeps() {
+  return {
+    uiLocale: 'en' as const,
+    activeIdRef: { current: undefined as string | undefined },
+    addPendingSessionAction: () => true,
+    captureComposerImportOwner: () => ({
+      sessionId: undefined,
+      navSection: 'sessions' as const,
+    }),
+    checkTaskSubmissionReadiness: async () => true,
+    clearPendingSessionAction: () => undefined,
+    isNewChatSendSurfaceActive: () => true,
+    isShellSurfaceOwnerActive: () => true,
+    markSessionReadLocally: () => undefined,
+    messageRetryPendingRef: { current: new Set<string>() },
+    refreshSessions: async () => [],
+    setActiveId: () => undefined,
+    setMessageLoadErrorBySession: () => undefined,
+    setMessageRetryPendingBySession: () => undefined,
+    setMessages: () => undefined,
+    transcriptRangeRef: { current: undefined },
+    setNavSelection: () => undefined,
+    setLiveTurnBySession: () => undefined,
+    setInteractionBySession: () => undefined,
+    showModelSetupToast: () => undefined,
+    toastApi: { error: () => undefined, info: () => undefined },
+    upsertSessionSummary: () => undefined,
+    newChatModel: null,
+    pendingNewChatThinkingLevel: null,
+    newChatCollaborationMode: 'agent' as const,
+    newChatOrchestrationMode: 'default' as const,
+    newChatProjectId: undefined,
+  };
+}
+
+const EMPTY_SKILL_INVOCATION = { loaded: [], failed: [], receipts: [] };
+
+describe('busy-raced send settlement', () => {
+  it('a steered send on an existing session disarms its turn and shows no optimistic message', async () => {
+    const activeIdRef = { current: 'session-a' as string | undefined };
+    const turnState = createTurnState();
+    const messageState = createMessageState();
+    const restoreWindow = installWindow({
+      sessions: {
+        send: async (_sessionId: string, command: { turnId: string }) => ({
+          ok: true,
+          steered: true,
+          turnId: command.turnId,
+          attachments: [],
+          inlineReferences: [],
+          skillInvocation: EMPTY_SKILL_INVOCATION,
+        }),
+      },
+    });
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef,
+        setLiveTurnBySession: turnState.setLiveTurnBySession,
+        setMessages: messageState.setMessages,
+      });
+      assert.equal(await actions.send('also check the tests'), true);
+      assert.equal(turnState.liveTurnBySession['session-a'], undefined);
+      assert.deepEqual(messageState.messages, []);
+    } finally {
+      restoreWindow();
+    }
+  });
+
+  it('rebinds the unconfirmed arm onto a Host-chosen turn id', async () => {
+    const activeIdRef = { current: 'session-a' as string | undefined };
+    const turnState = createTurnState();
+    const messageState = createMessageState();
+    const restoreWindow = installWindow({
+      sessions: {
+        send: async () => ({
+          ok: true,
+          turnId: 'host-turn',
+          attachments: [],
+          inlineReferences: [],
+          skillInvocation: EMPTY_SKILL_INVOCATION,
+        }),
+      },
+    });
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef,
+        setLiveTurnBySession: turnState.setLiveTurnBySession,
+        setMessages: messageState.setMessages,
+      });
+      assert.equal(await actions.send('also check the tests'), true);
+      const live = turnState.liveTurnBySession['session-a'];
+      assert.equal(live?.turnId, 'host-turn');
+      assert.equal(live?.unconfirmed, true);
+      const optimistic = messageState.messages.filter((message) => message.type === 'user');
+      assert.equal(optimistic.length, 1);
+      assert.equal(optimistic[0]?.turnId, 'host-turn');
+    } finally {
+      restoreWindow();
+    }
+  });
+
+  it('keeps an authoritative projection that arrived before the send response', async () => {
+    const activeIdRef = { current: 'session-a' as string | undefined };
+    const turnState = createTurnState();
+    const messageState = createMessageState();
+    const restoreWindow = installWindow({
+      sessions: {
+        send: async () => {
+          // The Host streamed under its own turn id before the IPC response.
+          turnState.setLiveTurnBySession((current) => ({
+            ...current,
+            'session-a': { turnId: 'host-turn', phase: 'streamed', steps: [] } as LiveTurnProjection,
+          }));
+          return {
+            ok: true,
+            turnId: 'host-turn',
+            attachments: [],
+            inlineReferences: [],
+            skillInvocation: EMPTY_SKILL_INVOCATION,
+          };
+        },
+      },
+    });
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef,
+        setLiveTurnBySession: turnState.setLiveTurnBySession,
+        setMessages: messageState.setMessages,
+      });
+      assert.equal(await actions.send('also check the tests'), true);
+      const live = turnState.liveTurnBySession['session-a'];
+      assert.equal(live?.turnId, 'host-turn');
+      assert.equal(live?.phase, 'streamed');
+      assert.equal(live?.unconfirmed, undefined);
+    } finally {
+      restoreWindow();
+    }
+  });
+
+  it('a steered send on the new-chat path navigates without a ghost optimistic turn', async () => {
+    const activeIdRef = { current: undefined as string | undefined };
+    const turnState = createTurnState();
+    const messageState = createMessageState();
+    const activated: string[] = [];
+    const removed: string[] = [];
+    const restoreWindow = installWindow({
+      sessions: {
+        create: async () => ({ id: 'session-new' }),
+        remove: async (sessionId: string) => {
+          removed.push(sessionId);
+        },
+        send: async (_sessionId: string, command: { turnId: string }) => ({
+          ok: true,
+          steered: true,
+          turnId: command.turnId,
+          attachments: [],
+          inlineReferences: [],
+          skillInvocation: EMPTY_SKILL_INVOCATION,
+        }),
+      },
+    });
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef,
+        setActiveId: (sessionId: string | undefined) => {
+          if (sessionId !== undefined) activated.push(sessionId);
+          activeIdRef.current = sessionId;
+        },
+        setLiveTurnBySession: turnState.setLiveTurnBySession,
+        setMessages: messageState.setMessages,
+      });
+      assert.equal(await actions.send('also check the tests'), true);
+      assert.deepEqual(activated, ['session-new']);
+      assert.equal(turnState.liveTurnBySession['session-new'], undefined);
+      assert.deepEqual(messageState.messages, []);
+      assert.deepEqual(removed, []);
+    } finally {
+      restoreWindow();
+    }
+  });
+
+  it('a Host-chosen turn id on the new-chat path keys the optimistic state to it', async () => {
+    const activeIdRef = { current: undefined as string | undefined };
+    const turnState = createTurnState();
+    const messageState = createMessageState();
+    const restoreWindow = installWindow({
+      sessions: {
+        create: async () => ({ id: 'session-new' }),
+        send: async () => ({
+          ok: true,
+          turnId: 'host-turn',
+          attachments: [],
+          inlineReferences: [],
+          skillInvocation: EMPTY_SKILL_INVOCATION,
+        }),
+      },
+    });
+    try {
+      const actions = createAppShellChatActions({
+        ...createActionsDeps(),
+        activeIdRef,
+        setActiveId: (sessionId: string | undefined) => {
+          activeIdRef.current = sessionId;
+        },
+        setLiveTurnBySession: turnState.setLiveTurnBySession,
+        setMessages: messageState.setMessages,
+      });
+      assert.equal(await actions.send('also check the tests'), true);
+      assert.equal(turnState.liveTurnBySession['session-new']?.turnId, 'host-turn');
+      const optimistic = messageState.messages.filter((message) => message.type === 'user');
+      assert.equal(optimistic.length, 1);
+      assert.equal(optimistic[0]?.turnId, 'host-turn');
+    } finally {
+      restoreWindow();
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -7,6 +7,7 @@ import test from "node:test";
 import type { IpcMain } from "electron";
 import { SIDE_CONVERSATION_SESSION_LABEL } from '@maka/core/side-conversation';
 import { type AttachmentRef } from '@maka/core/events';
+import { RuntimeHostOperationError } from '@maka/runtime-host/client';
 import type { SessionCatalogProjection } from "@maka/runtime-host/protocol";
 import { createAttachmentApprovalRegistry } from "../attachment-approval.js";
 import type { DesktopRuntimeHostSession } from "../runtime-host-client.js";
@@ -491,6 +492,158 @@ test("forwards explicit Skill invocation to the Host-owned Turn admission", asyn
       receipts: [],
     },
   });
+});
+
+test("queues a mid-turn send as steering when the Host reports the session busy", async () => {
+  const submits: unknown[] = [];
+  const changes: unknown[] = [];
+  const ipc = ipcHarness();
+  registerExecutionIpc(
+    {
+      client: executionClient({
+        getSession: async () => session(),
+        startTurn: async () => {
+          throw new RuntimeHostOperationError(
+            "turn.start",
+            "session_busy",
+            "Session already has an active root Turn",
+          );
+        },
+        submitMessage: async (input) => {
+          submits.push(input);
+          return { disposition: "steering", queueRevision: 1 };
+        },
+      }),
+      observer: unusedObserver(),
+      attachmentApprovals: createAttachmentApprovalRegistry(),
+      emitSessionsChanged: (reason, sessionId, extra) =>
+        changes.push({ reason, sessionId, ...extra }),
+      stat: async () => ({ size: 0 }),
+      resizeImage: async (bytes) => bytes,
+      beforeStop() {},
+      newId: () => "id-1",
+    },
+    ipc,
+  );
+
+  const result = await ipc.invoke("sessions:send", "session-1", {
+    type: "send",
+    turnId: "turn-1",
+    text: "also check the tests",
+  });
+
+  assert.deepEqual(submits, [
+    {
+      sessionId: "session-1",
+      messageId: "id-1",
+      content: { text: "also check the tests", inlineReferences: [] },
+      placement: "current_turn",
+    },
+  ]);
+  assert.deepEqual(result, {
+    ok: true,
+    steered: true,
+    turnId: "turn-1",
+    attachments: [],
+    inlineReferences: [],
+    skillInvocation: { loaded: [], failed: [], receipts: [] },
+  });
+  assert.deepEqual(changes, [
+    { reason: "status-change", sessionId: "session-1" },
+  ]);
+});
+
+test("starts the turn from the queued message when the busy race resolves idle", async () => {
+  const changes: unknown[] = [];
+  const ipc = ipcHarness();
+  registerExecutionIpc(
+    {
+      client: executionClient({
+        getSession: async () => session(),
+        startTurn: async () => {
+          throw new RuntimeHostOperationError(
+            "turn.start",
+            "session_busy",
+            "Session already has an active root Turn",
+          );
+        },
+        submitMessage: async () => ({
+          disposition: "turn_started",
+          turnId: "turn-9",
+        }),
+      }),
+      observer: unusedObserver(),
+      attachmentApprovals: createAttachmentApprovalRegistry(),
+      emitSessionsChanged: (reason, sessionId, extra) =>
+        changes.push({ reason, sessionId, ...extra }),
+      stat: async () => ({ size: 0 }),
+      resizeImage: async (bytes) => bytes,
+      beforeStop() {},
+      newId: () => "id-1",
+    },
+    ipc,
+  );
+
+  const result = await ipc.invoke("sessions:send", "session-1", {
+    type: "send",
+    turnId: "turn-1",
+    text: "also check the tests",
+  });
+
+  assert.deepEqual(result, {
+    ok: true,
+    turnId: "turn-9",
+    attachments: [],
+    inlineReferences: [],
+    skillInvocation: { loaded: [], failed: [], receipts: [] },
+  });
+  assert.deepEqual(changes, [
+    { reason: "status-change", sessionId: "session-1", turnId: "turn-9" },
+  ]);
+});
+
+test("keeps the busy failure for a Skill send instead of degrading it to steering", async () => {
+  const submits: unknown[] = [];
+  const ipc = ipcHarness();
+  registerExecutionIpc(
+    {
+      client: executionClient({
+        getSession: async () => session(),
+        startTurn: async () => {
+          throw new RuntimeHostOperationError(
+            "turn.start",
+            "session_busy",
+            "Session already has an active root Turn",
+          );
+        },
+        submitMessage: async (input) => {
+          submits.push(input);
+          return { disposition: "steering", queueRevision: 1 };
+        },
+      }),
+      observer: unusedObserver(),
+      attachmentApprovals: createAttachmentApprovalRegistry(),
+      emitSessionsChanged() {},
+      stat: async () => ({ size: 0 }),
+      resizeImage: async (bytes) => bytes,
+      beforeStop() {},
+      newId: () => "id-1",
+    },
+    ipc,
+  );
+
+  await assert.rejects(
+    ipc.invoke("sessions:send", "session-1", {
+      type: "send",
+      turnId: "turn-1",
+      text: "",
+      displayText: "/skill:review",
+      skillIds: ["review"],
+    }),
+    (error: unknown) =>
+      error instanceof RuntimeHostOperationError && error.code === "session_busy",
+  );
+  assert.deepEqual(submits, []);
 });
 
 test("binds steer and stop to Host-owned queue and active Turn identities", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-execution-ipc-main.test.ts
@@ -632,6 +632,17 @@ test("keeps the busy failure for a Skill send instead of degrading it to steerin
     ipc,
   );
 
+  // The Desktop composer carries Skills as canonical /skill: tokens in the
+  // text; explicit skillIds is the protocol-level variant.
+  await assert.rejects(
+    ipc.invoke("sessions:send", "session-1", {
+      type: "send",
+      turnId: "turn-1",
+      text: "/skill:review explain the tests",
+    }),
+    (error: unknown) =>
+      error instanceof RuntimeHostOperationError && error.code === "session_busy",
+  );
   await assert.rejects(
     ipc.invoke("sessions:send", "session-1", {
       type: "send",

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import type { IpcMainInvokeEvent } from "electron";
 import { RuntimeHostOperationError } from '@maka/runtime-host/client';
+import { SKILL_INVOCATION_TOKEN_SOURCE } from '@maka/core/skill-invocation-token';
 import {
   type SessionChangedEvent,
   type SessionChangedReason,
@@ -250,12 +251,15 @@ export function registerRuntimeHostSessionExecutionIpc(
         // the user's message (#1954). `turn.message.submit` resolves the race
         // on the Host: an active session queues the text as steering, an idle
         // one starts the Turn. Skill and orchestration sends keep the error —
-        // their turn semantics cannot be expressed as a queued message.
+        // their turn semantics cannot be expressed as a queued message — and
+        // the Desktop composer carries Skills as canonical /skill: tokens in
+        // the text, not as skillIds.
         if (
           !(error instanceof RuntimeHostOperationError) ||
           error.code !== "session_busy" ||
           (command.skillIds?.length ?? 0) > 0 ||
-          command.turnOrchestration
+          command.turnOrchestration ||
+          new RegExp(SKILL_INVOCATION_TOKEN_SOURCE).test(command.text)
         ) {
           throw error;
         }

--- a/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-execution-ipc-main.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { IpcMainInvokeEvent } from "electron";
+import { RuntimeHostOperationError } from '@maka/runtime-host/client';
 import {
   type SessionChangedEvent,
   type SessionChangedReason,
@@ -238,7 +239,57 @@ export function registerRuntimeHostSessionExecutionIpc(
           ? { turnOrchestration: command.turnOrchestration }
           : {}),
       };
-      const startResult = await deps.client.startTurn(startInput);
+      let startResult;
+      try {
+        startResult = await deps.client.startTurn(startInput);
+      } catch (error) {
+        // The renderer routes text at a session it sees as running to
+        // `sessions:steer`, but its view can lag the Host: another window, a
+        // Bot, or a Goal continuation may have opened the root Turn first, and
+        // that race surfaced here as a session_busy send failure that dropped
+        // the user's message (#1954). `turn.message.submit` resolves the race
+        // on the Host: an active session queues the text as steering, an idle
+        // one starts the Turn. Skill and orchestration sends keep the error —
+        // their turn semantics cannot be expressed as a queued message.
+        if (
+          !(error instanceof RuntimeHostOperationError) ||
+          error.code !== "session_busy" ||
+          (command.skillIds?.length ?? 0) > 0 ||
+          command.turnOrchestration
+        ) {
+          throw error;
+        }
+        const submitted = await deps.client.submitMessage({
+          sessionId,
+          messageId: newId(),
+          content: startInput.content,
+          placement: "current_turn",
+        });
+        const emptySkillInvocation = { loaded: [], failed: [], receipts: [] };
+        if (submitted.disposition === "turn_started") {
+          deps.emitSessionsChanged("status-change", sessionId, {
+            turnId: submitted.turnId,
+          });
+          return {
+            ok: true as const,
+            turnId: submitted.turnId,
+            attachments,
+            inlineReferences,
+            skillInvocation: emptySkillInvocation,
+          };
+        }
+        // The steering renderer believed this session idle; nudge it to
+        // refresh so its composer converges on the running turn.
+        deps.emitSessionsChanged("status-change", sessionId);
+        return {
+          ok: true as const,
+          steered: true as const,
+          turnId,
+          attachments,
+          inlineReferences,
+          skillInvocation: emptySkillInvocation,
+        };
+      }
       if (startResult.kind === "blocked") {
         return {
           ok: false as const,

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -421,6 +421,11 @@ export interface MakaBridge {
       | {
           ok: true;
           turnId: string;
+          /**
+           * The send raced a root Turn another client opened first and was
+           * queued into it as steering instead of starting `turnId`.
+           */
+          steered?: true;
           attachments: import('@maka/core/events').AttachmentRef[];
           inlineReferences: import('@maka/core/events').InlineReference[];
           skillInvocation: import('@maka/runtime/skill-invocation').SkillInvocationResult;

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -448,13 +448,29 @@ export function createAppShellChatActions(deps: {
         disarmTurnActive(sessionId, turnId);
         return false;
       }
+      if (sendResult.steered) {
+        // The send raced a root turn another client opened first; the text was
+        // queued into that turn as steering, so this send owns no turn. The
+        // steering_message event renders it in the transcript.
+        disarmTurnActive(sessionId, turnId);
+        options.onSessionResolved?.(sessionId);
+        return true;
+      }
+      // A busy-race fallback may have started the turn under an id the main
+      // process chose; move the arm and the optimistic message onto it.
+      const startedTurnId = sendResult.turnId ?? turnId;
+      if (startedTurnId !== turnId) {
+        disarmTurnActive(sessionId, turnId);
+        armTurnActive(sessionId, startedTurnId);
+        optimisticTurnId = startedTurnId;
+      }
       options.onSessionResolved?.(sessionId);
       if (activeIdRef.current === sessionId) {
         showSkillInvocationFeedback(uiLocale, toastApi, sendResult.skillInvocation);
       }
       showOptimisticUserMessage(
         sessionId,
-        turnId,
+        startedTurnId,
         options.displayText ??
           skillInvocationDisplayText(text, sendResult.skillInvocation),
         sendResult.attachments,

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -288,6 +288,40 @@ export function createAppShellChatActions(deps: {
     });
   }
 
+  // Rename only the exact unconfirmed arm this send created. Host events can
+  // beat the IPC response (main emits the sessions-changed nudge before it
+  // returns), and an authoritative projection that already arrived for the
+  // Host-chosen turn must not be replaced with a fresh waiting arm.
+  function rebindTurnActive(sessionId: string, fromTurnId: string, toTurnId: string): void {
+    setLiveTurnBySession((current) => {
+      const active = current[sessionId];
+      if (!active || active.turnId !== fromTurnId || !active.unconfirmed || active.phase !== 'waiting') {
+        return current;
+      }
+      return { ...current, [sessionId]: armLiveTurn(toTurnId) };
+    });
+  }
+
+  // One interpretation of a successful sessions:send for both the new-chat and
+  // existing-session branches: a busy-raced send can come back `steered` (this
+  // send owns no turn — the steering_message event renders the text) or under
+  // a Host-chosen turnId. Returns the turn the send owns, if any.
+  function settleSendBookkeeping(
+    sessionId: string,
+    requestedTurnId: string,
+    sendResult: { steered?: true; turnId?: string },
+  ): string | undefined {
+    if (sendResult.steered) {
+      disarmTurnActive(sessionId, requestedTurnId);
+      return undefined;
+    }
+    const startedTurnId = sendResult.turnId ?? requestedTurnId;
+    if (startedTurnId !== requestedTurnId) {
+      rebindTurnActive(sessionId, requestedTurnId, startedTurnId);
+    }
+    return startedTurnId;
+  }
+
   async function send(
     text: string,
     pending?: readonly PendingAttachment[],
@@ -381,6 +415,8 @@ export function createAppShellChatActions(deps: {
           return false;
         }
         unsentSessionId = undefined;
+        const settledTurnId = settleSendBookkeeping(session.id, turnId, sendResult);
+        if (settledTurnId !== undefined) optimisticTurnId = settledTurnId;
         options.onSessionResolved?.(session.id);
         if (newChatOwner && isNewChatSendSurfaceActive(newChatOwner)) {
           showSkillInvocationFeedback(uiLocale, toastApi, sendResult.skillInvocation);
@@ -388,18 +424,20 @@ export function createAppShellChatActions(deps: {
         if (newChatOwner && isNewChatSendSurfaceActive(newChatOwner)) {
           setNavSelection({ section: 'sessions' });
           setActiveId(session.id);
-          showOptimisticUserMessage(
-            session.id,
-            turnId,
-            options.displayText ??
-              skillInvocationDisplayText(text, sendResult.skillInvocation),
-            sendResult.attachments,
-            {
-              replaceCurrentMessages: true,
-              ...(quotes && quotes.length > 0 ? { quotes } : {}),
-              inlineReferences: sendResult.inlineReferences ?? [],
-            },
-          );
+          if (settledTurnId !== undefined) {
+            showOptimisticUserMessage(
+              session.id,
+              settledTurnId,
+              options.displayText ??
+                skillInvocationDisplayText(text, sendResult.skillInvocation),
+              sendResult.attachments,
+              {
+                replaceCurrentMessages: true,
+                ...(quotes && quotes.length > 0 ? { quotes } : {}),
+                inlineReferences: sendResult.inlineReferences ?? [],
+              },
+            );
+          }
         }
         await refreshSessions();
         return true;
@@ -448,23 +486,10 @@ export function createAppShellChatActions(deps: {
         disarmTurnActive(sessionId, turnId);
         return false;
       }
-      if (sendResult.steered) {
-        // The send raced a root turn another client opened first; the text was
-        // queued into that turn as steering, so this send owns no turn. The
-        // steering_message event renders it in the transcript.
-        disarmTurnActive(sessionId, turnId);
-        options.onSessionResolved?.(sessionId);
-        return true;
-      }
-      // A busy-race fallback may have started the turn under an id the main
-      // process chose; move the arm and the optimistic message onto it.
-      const startedTurnId = sendResult.turnId ?? turnId;
-      if (startedTurnId !== turnId) {
-        disarmTurnActive(sessionId, turnId);
-        armTurnActive(sessionId, startedTurnId);
-        optimisticTurnId = startedTurnId;
-      }
+      const startedTurnId = settleSendBookkeeping(sessionId, turnId, sendResult);
       options.onSessionResolved?.(sessionId);
+      if (startedTurnId === undefined) return true;
+      optimisticTurnId = startedTurnId;
       if (activeIdRef.current === sessionId) {
         showSkillInvocationFeedback(uiLocale, toastApi, sendResult.skillInvocation);
       }


### PR DESCRIPTION
## Summary

Fixes #1954 (the slice that survived the M5 cutover).

Since the production cutover, `turn.start` carries an active-root guard, so the parallel-turn/interleaving symptoms in #1954 no longer occur, and the composer already routes text at a session it sees as running to `sessions:steer` (the button flips to 插入消息). What remained: that reading is renderer-local state. Another window, a Bot, or a Goal continuation can open the root Turn first, and the raced `sessions:send` then failed with `session_busy` — surfaced as a generic send-failure toast with the user's message dropped.

What changed:

- Desktop main's `sessions:send` falls back to `turn.message.submit` (placement `current_turn`) when `turn.start` reports `session_busy`. The Host resolves the race atomically per #1357's submit semantics: an active session queues the text as steering into the running turn; a session that went idle in between starts the turn (`turn_started`).
- Skill (`skillIds`), `turnOrchestration`, and canonical `/skill:` token sends rethrow the busy error instead — their turn semantics cannot be expressed as a queued message.
- The renderer settles both send branches through one `settleSendBookkeeping` helper: it skips new-turn bookkeeping for a `steered` result (the steering_message event renders the text in the transcript, same as the composer steer path) and re-keys only the exact optimistic state this send created when the fallback started the turn under a Host-chosen id, preserving an authoritative projection that arrived first.
- A steered send also emits a sessions-changed nudge so the stale renderer converges on the running turn.

Attachments survive the fallback: the steering injection path (`drainSteeringInto` → `appendImageParts`) carries `MessageContent.attachments`.

## Verification

- New handler tests: steering fallback, `turn_started` fallback, and busy preserved for Skill sends (both the `skillIds` and `/skill:` text forms).
- New renderer settlement tests (`app-shell-busy-race-settlement.test.ts`): steering into an active turn, Host-id rebind, authoritative-projection-first preserved, and both new-chat outcomes without ghost optimistic turns.
- Full `@maka/desktop` main suite: 848 pass; desktop typecheck (preload/main/renderer/storybook) clean.
- The earlier `streaming-remount.spec.ts` e2e failure was bisected to a pre-existing virtualization regression, filed as #3044, fixed by #3048; this branch is rebased past that fix.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code authored the fix, the tests, and this description under human direction and review; commits carry `Generated-by: Claude Code` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
