### PR TITLE
fix(runtime): group parallel tool calls into one summarizer assistant message

### DIFF
--- a/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
@@ -225,6 +225,189 @@ describe('buildLlmHistorySummarizer', () => {
     ]);
   });
 
+  test('keeps a step open across interleaved results until every call is settled', async () => {
+    // The production-legal ordering from the primary replay materializer's
+    // fixture: call A, call B, result A, call C, result B, result C. All
+    // three calls must share one assistant message with the results after it.
+    const seen: Array<{ messages: unknown[] }> = [];
+    const generateText: AiSdkGenerateTextLike = async (opts) => {
+      seen.push(opts);
+      return { text: '## Goal\nX' };
+    };
+    const summarize = buildLlmHistorySummarizer({ resolveModel: () => 'fake-model', generateText });
+
+    const events: RuntimeEvent[] = [
+      ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'inspect files' } }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc1', name: 'read', args: { path: 'a.ts' } },
+      }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc2', name: 'read', args: { path: 'b.ts' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc1', name: 'read', result: 'A' },
+      }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc3', name: 'glob', args: { pattern: '*' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc2', name: 'read', result: 'B' },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc3', name: 'glob', result: ['a.ts'] },
+      }),
+    ];
+
+    await summarize(inputWith(events));
+
+    const messages = seen[0]!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; toolCallId?: string }>;
+    }>;
+    const shape = messages.map((m) => `${m.role}:${m.content.map((part) => part.type).join('+')}`);
+    assert.deepEqual(shape, [
+      'user:text',
+      'assistant:tool-call+tool-call+tool-call',
+      'tool:tool-result',
+      'tool:tool-result',
+      'tool:tool-result',
+    ]);
+    assert.deepEqual(
+      messages[1]!.content.map((part) => part.toolCallId),
+      ['fc1', 'fc2', 'fc3'],
+    );
+    assert.deepEqual(
+      messages.slice(2).map((m) => m.content[0]!.toolCallId),
+      ['fc1', 'fc2', 'fc3'],
+    );
+  });
+
+  test('does not merge distinct settled steps into one assistant message', async () => {
+    const seen: Array<{ messages: unknown[] }> = [];
+    const generateText: AiSdkGenerateTextLike = async (opts) => {
+      seen.push(opts);
+      return { text: '## Goal\nX' };
+    };
+    const summarize = buildLlmHistorySummarizer({ resolveModel: () => 'fake-model', generateText });
+
+    const events: RuntimeEvent[] = [
+      // Two sequential legacy steps (no stepId): the second call arrives only
+      // after the first is fully settled, so it opens its own message.
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc1', name: 'read', args: { path: 'a.ts' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc1', name: 'read', result: 'A' },
+      }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc2', name: 'read', args: { path: 'b.ts' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc2', name: 'read', result: 'B' },
+      }),
+    ];
+
+    await summarize(inputWith(events));
+
+    const messages = seen[0]!.messages as Array<{
+      role: string;
+      content: Array<{ type: string }>;
+    }>;
+    const shape = messages.map((m) => `${m.role}:${m.content.map((part) => part.type).join('+')}`);
+    assert.deepEqual(shape, [
+      'assistant:tool-call',
+      'tool:tool-result',
+      'assistant:tool-call',
+      'tool:tool-result',
+    ]);
+  });
+
+  test('stamped step ids decide membership over settledness', async () => {
+    const seen: Array<{ messages: unknown[] }> = [];
+    const generateText: AiSdkGenerateTextLike = async (opts) => {
+      seen.push(opts);
+      return { text: '## Goal\nX' };
+    };
+    const summarize = buildLlmHistorySummarizer({ resolveModel: () => 'fake-model', generateText });
+
+    const events: RuntimeEvent[] = [
+      // Same stamped step: joins even though fc1 settled before fc2 arrived.
+      ev({
+        role: 'model',
+        author: 'agent',
+        refs: { stepId: 'step-1' },
+        content: { kind: 'function_call', id: 'fc1', name: 'read', args: { path: 'a.ts' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc1', name: 'read', result: 'A' },
+      }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        refs: { stepId: 'step-1' },
+        content: { kind: 'function_call', id: 'fc2', name: 'read', args: { path: 'b.ts' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc2', name: 'read', result: 'B' },
+      }),
+      // Different stamped step: never merged into the block above.
+      ev({
+        role: 'model',
+        author: 'agent',
+        refs: { stepId: 'step-2' },
+        content: { kind: 'function_call', id: 'fc3', name: 'glob', args: { pattern: '*' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc3', name: 'glob', result: [] },
+      }),
+    ];
+
+    await summarize(inputWith(events));
+
+    const messages = seen[0]!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; toolCallId?: string }>;
+    }>;
+    const shape = messages.map((m) => `${m.role}:${m.content.map((part) => part.type).join('+')}`);
+    assert.deepEqual(shape, [
+      'assistant:tool-call+tool-call',
+      'tool:tool-result',
+      'tool:tool-result',
+      'assistant:tool-call',
+      'tool:tool-result',
+    ]);
+    assert.deepEqual(
+      messages[0]!.content.map((part) => part.toolCallId),
+      ['fc1', 'fc2'],
+    );
+  });
+
   test('surfaces provider failures so the runtime can report the real compact reason', async () => {
     const generateText: AiSdkGenerateTextLike = async () => {
       throw new Error('model down');

--- a/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
@@ -166,6 +166,65 @@ describe('buildLlmHistorySummarizer', () => {
     expect(toolPart.output).toEqual({ type: 'json', value: { name: 'maka' } });
   });
 
+  test('groups parallel tool calls into one assistant message for strict providers', async () => {
+    const seen: Array<{ messages: unknown[] }> = [];
+    const generateText: AiSdkGenerateTextLike = async (opts) => {
+      seen.push(opts);
+      return { text: '## Goal\nX' };
+    };
+    const summarize = buildLlmHistorySummarizer({ resolveModel: () => 'fake-model', generateText });
+
+    const events: RuntimeEvent[] = [
+      ev({ role: 'user', author: 'user', content: { kind: 'text', text: '并行读两个文件' } }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc1', name: 'read', args: { path: 'a.ts' } },
+      }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc2', name: 'read', args: { path: 'b.ts' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc1', name: 'read', result: 'A' },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc2', name: 'read', result: 'B' },
+      }),
+      ev({ role: 'model', author: 'agent', content: { kind: 'text', text: 'ok' } }),
+    ];
+
+    await summarize(inputWith(events));
+
+    const messages = seen[0]!.messages as Array<{
+      role: string;
+      content: Array<{ type: string; toolCallId?: string }>;
+    }>;
+    // Both calls of the parallel step share one assistant message; a second
+    // assistant message before the first's results is the strict-provider 400
+    // in #3030.
+    const assistantToolCallMessages = messages.filter(
+      (m) => m.role === 'assistant' && m.content.some((part) => part.type === 'tool-call'),
+    );
+    assert.equal(assistantToolCallMessages.length, 1);
+    assert.deepEqual(
+      assistantToolCallMessages[0]!.content.map((part) => part.toolCallId),
+      ['fc1', 'fc2'],
+    );
+    const shape = messages.map((m) => `${m.role}:${m.content.map((part) => part.type).join('+')}`);
+    assert.deepEqual(shape.slice(-4), [
+      'assistant:tool-call+tool-call',
+      'tool:tool-result',
+      'tool:tool-result',
+      'assistant:text',
+    ]);
+  });
+
   test('surfaces provider failures so the runtime can report the real compact reason', async () => {
     const generateText: AiSdkGenerateTextLike = async () => {
       throw new Error('model down');

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -1,4 +1,4 @@
-import { rawFinishReasonString, type ModelMessage } from './model-protocol.js';
+import { rawFinishReasonString, type ModelMessage, type ToolCallPart } from './model-protocol.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { toolResultOutput } from './tool-result-output.js';
 import type { HistoryCompactSummaryInput } from './ai-sdk-compaction-contract.js';
@@ -142,8 +142,15 @@ type ReplayPlanItems = ReturnType<typeof buildRuntimeEventModelReplayPlan>['item
 
 export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMessage[] {
   const out: ModelMessage[] = [];
+  // Parallel tool calls of one step must share one assistant message: strict
+  // OpenAI-compatible providers reject a second assistant message while the
+  // first's tool calls are still unanswered. The primary replay path gets this
+  // from the materializer's step merge; mirror it here by collecting a run of
+  // tool calls (uninterrupted by text or results) into one content array.
+  let openToolCalls: ToolCallPart[] | undefined;
   for (const item of items) {
     if (item.kind === 'text') {
+      openToolCalls = undefined;
       // Split on role so each push matches exactly one ModelMessage arm — no cast.
       const textPart = { type: 'text' as const, text: item.content };
       if (item.role === 'user') {
@@ -152,18 +159,20 @@ export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMes
         out.push({ role: 'assistant', content: [textPart] });
       }
     } else if (item.kind === 'tool_call') {
-      out.push({
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool-call',
-            toolCallId: item.toolCallId,
-            toolName: item.toolName,
-            input: item.input,
-          },
-        ],
-      });
+      const part: ToolCallPart = {
+        type: 'tool-call',
+        toolCallId: item.toolCallId,
+        toolName: item.toolName,
+        input: item.input,
+      };
+      if (openToolCalls) {
+        openToolCalls.push(part);
+      } else {
+        openToolCalls = [part];
+        out.push({ role: 'assistant', content: openToolCalls });
+      }
     } else if (item.kind === 'tool_result') {
+      openToolCalls = undefined;
       out.push({
         role: 'tool',
         content: [
@@ -176,7 +185,8 @@ export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMes
         ],
       });
     }
-    // thinking entries are intentionally skipped for summarization
+    // thinking entries are intentionally skipped for summarization; they do
+    // not interrupt a run of parallel tool calls.
   }
   return out;
 }

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -140,17 +140,35 @@ async function loadAiSdkTextModule(): Promise<AiSdkTextModule> {
 
 type ReplayPlanItems = ReturnType<typeof buildRuntimeEventModelReplayPlan>['items'];
 
+interface OpenToolStep {
+  stepId: string | undefined;
+  calls: ToolCallPart[];
+  callIds: Set<string>;
+  settledCallIds: Set<string>;
+  bufferedResults: ModelMessage[];
+}
+
 export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMessage[] {
   const out: ModelMessage[] = [];
-  // Parallel tool calls of one step must share one assistant message: strict
-  // OpenAI-compatible providers reject a second assistant message while the
-  // first's tool calls are still unanswered. The primary replay path gets this
-  // from the materializer's step merge; mirror it here by collecting a run of
-  // tool calls (uninterrupted by text or results) into one content array.
-  let openToolCalls: ToolCallPart[] | undefined;
+  // One assistant step's tool calls share one assistant message and every
+  // result is deferred to the step boundary: strict OpenAI-compatible
+  // providers reject an assistant message that arrives while a previous
+  // assistant message's tool calls are still unanswered, and Runtime history
+  // can legitimately interleave a step's calls and results
+  // (call A, call B, result A, call C, result B, result C). Step membership
+  // follows the stamped stepId when both sides carry one; legacy items
+  // without a stepId join while the open step still has unsettled calls,
+  // which is exactly the interleaving case. This mirrors the primary replay
+  // materializer's step merge; the primary path is untouched.
+  let openStep: OpenToolStep | undefined;
+  const flushOpenStep = () => {
+    if (!openStep) return;
+    out.push(...openStep.bufferedResults);
+    openStep = undefined;
+  };
   for (const item of items) {
     if (item.kind === 'text') {
-      openToolCalls = undefined;
+      flushOpenStep();
       // Split on role so each push matches exactly one ModelMessage arm — no cast.
       const textPart = { type: 'text' as const, text: item.content };
       if (item.role === 'user') {
@@ -165,15 +183,28 @@ export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMes
         toolName: item.toolName,
         input: item.input,
       };
-      if (openToolCalls) {
-        openToolCalls.push(part);
+      const joinsOpenStep =
+        openStep !== undefined &&
+        (openStep.stepId !== undefined && item.stepId !== undefined
+          ? openStep.stepId === item.stepId
+          : openStep.settledCallIds.size < openStep.callIds.size);
+      if (openStep && joinsOpenStep) {
+        openStep.calls.push(part);
+        openStep.callIds.add(item.toolCallId);
       } else {
-        openToolCalls = [part];
-        out.push({ role: 'assistant', content: openToolCalls });
+        flushOpenStep();
+        const calls = [part];
+        openStep = {
+          stepId: item.stepId,
+          calls,
+          callIds: new Set([item.toolCallId]),
+          settledCallIds: new Set(),
+          bufferedResults: [],
+        };
+        out.push({ role: 'assistant', content: calls });
       }
     } else if (item.kind === 'tool_result') {
-      openToolCalls = undefined;
-      out.push({
+      const message: ModelMessage = {
         role: 'tool',
         content: [
           {
@@ -183,10 +214,20 @@ export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMes
             output: toolResultOutput(item.output, item.isError),
           },
         ],
-      });
+      };
+      if (openStep?.callIds.has(item.toolCallId)) {
+        openStep.settledCallIds.add(item.toolCallId);
+        openStep.bufferedResults.push(message);
+      } else {
+        // A result for a call outside the open step means that step's block
+        // is complete; settle it before emitting the foreign result.
+        flushOpenStep();
+        out.push(message);
+      }
     }
     // thinking entries are intentionally skipped for summarization; they do
-    // not interrupt a run of parallel tool calls.
+    // not interrupt an open tool step.
   }
+  flushOpenStep();
   return out;
 }


### PR DESCRIPTION
## Summary

Fixes #3030.

`replayPlanItemsToModelMessages` mapped every `tool_call` replay item to its own assistant message, so a step with parallel tool calls produced

```
assistant [tool-call A]
assistant [tool-call B]   ← rejected: A's tool_calls not yet answered
tool      [tool-result A]
tool      [tool-result B]
```

Strict OpenAI-compatible providers 400 on that shape, so mid-turn history compaction could never succeed on such providers — the `provider_error` fail-open loop that preceded the #3029 incident.

What changed: grouping is step-based with results buffered to the step boundary, mirroring the step-merge invariant the primary replay path gets from the materializer (`model-history.ts`). Membership follows the stamped `stepId` when both sides carry one; legacy items without a `stepId` join while the open step still has unsettled calls, and a call arriving after the open step fully settled opens its own message. Results for calls in the open step are deferred and emitted in arrival order at the step boundary, so interleaved orderings like `call A, call B, result A, call C, result B, result C` materialize as `assistant [A, B, C] → tool A → tool B → tool C`. Skipped `thinking` items do not break a step. The primary replay path is untouched.

## Verification

- Regression tests: parallel calls produce exactly one assistant message with the tool-call parts followed by the tool messages; the interleaved ordering from the primary materializer's fixture; distinct settled steps never merged; stamped step ids deciding membership over settledness.
- Full `@maka/runtime` suite passes locally (re-verified after rebasing onto `main` past #2993).
- Cross-checked against the #3029 incident repro by @me2seeks (review on this PR); the parallel draft in #3040 was withdrawn in favor of this fix.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code authored the fix, the tests, and this description under human direction and review; commits carry `Generated-by: Claude Code` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
