### PR TITLE
fix(runtime): validate history-compact summaries at the write gates (#3029)

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -5302,6 +5302,97 @@ describe('AiSdkBackend model history', () => {
     );
   });
 
+  test('V2 malformed summary fails open without recording a checkpoint and reports malformed_summary', async () => {
+    const model = completionModel();
+    const storedMessages: StoredMessage[] = [];
+    let recordCalls = 0;
+    const events: SessionEvent[] = [];
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => {
+        storedMessages.push(message);
+      },
+      connection: connection(),
+      apiKey: '[redacted]',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      contextBudget: {
+        maxHistoryEstimatedTokens: 1_500,
+        charsPerToken: 1,
+        historyCompact: {
+          enabled: true,
+          mode: 'read_write',
+          highWaterRatio: 0.01,
+          tailEstimatedTokens: 20,
+          maxSummaryEstimatedTokens: 500,
+        },
+      },
+      summarizeHistoryCompact: async () => '确认服务端语义后，决定：结尾：',
+      recordHistoryCompactCheckpoint: () => {
+        recordCalls += 1;
+      },
+    });
+    for await (const event of backend.send({
+      turnId: 'turn-current',
+      text: 'continue',
+      context: [],
+      runtimeContext: [
+        runtimeTextEvent({
+          id: 'malformed-old-1',
+          turnId: 'malformed-turn-1',
+          role: 'user',
+          author: 'user',
+          text: 'malformed old source one '.repeat(30),
+        }),
+        runtimeTextEvent({
+          id: 'malformed-old-2',
+          turnId: 'malformed-turn-2',
+          role: 'model',
+          author: 'agent',
+          text: 'malformed old source two '.repeat(50),
+        }),
+        runtimeTextEvent({
+          id: 'malformed-recent',
+          turnId: 'malformed-recent-turn',
+          role: 'user',
+          author: 'user',
+          text: 'MALFORMED_RETAINED_TAIL',
+        }),
+      ],
+    })) {
+      events.push(event);
+    }
+
+    const prompt = JSON.stringify(compactPrompt(model));
+    assert.equal(prompt.includes('malformed old source one'), false);
+    assert.equal(prompt.includes('malformed old source two'), false);
+    assert.match(prompt, /MALFORMED_RETAINED_TAIL/);
+    assert.equal(recordCalls, 0);
+    assert.equal(
+      storedMessages.filter(
+        (message) =>
+          message.type === 'system_note' && message.kind === 'context_compaction_failed_open',
+      ).length,
+      1,
+    );
+    const usage = events.find(
+      (event): event is Extract<SessionEvent, { type: 'token_usage' }> =>
+        event.type === 'token_usage',
+    );
+    assert.equal(
+      usage?.contextBudget?.historyCompactWriteSkippedReasonCounts?.malformed_summary,
+      1,
+    );
+    assert.equal(
+      usage?.contextBudget?.compactionDecisions?.[0]?.failOpenReason,
+      'malformed_summary',
+    );
+  });
+
   test('keeps RuntimeEvent replay when a tool result is unmatched (orphan dropped, rest replayed)', async () => {
     // `unmatched_tool_result` is a non-blocking diagnostic: the materializer
     // drops the orphan itself (a standalone tool message is an Anthropic 400),

--- a/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
@@ -15,7 +15,6 @@ import { ProviderRequestTracker } from '../provider-request-telemetry.js';
 import type { HistoryCompactSummaryInput } from '../ai-sdk-compaction-contract.js';
 import {
   buildLlmHistorySummarizer,
-  replayPlanItemsToModelMessages,
   type AiSdkGenerateTextLike,
 } from '../history-compact-summarizer.js';
 import { buildHistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
@@ -260,69 +259,5 @@ describe('buildLlmHistorySummarizer', () => {
     expect(serialized).toContain('PRIOR_SUMMARY');
     expect(serialized).toContain('NEWLY_EVICTED_RAW');
     expect(serialized.includes('ALREADY_SUMMARIZED_RAW')).toBe(false);
-  });
-});
-
-describe('replayPlanItemsToModelMessages tool-call grouping', () => {
-  // #3030: strict OpenAI-compatible providers 400 when parallel tool calls of
-  // one step are split across multiple assistant messages. The primary
-  // materializer merges a step's tool calls into one provider message; the
-  // summarizer's projection must honor the same invariant.
-  function callItem(toolCallId: string) {
-    return {
-      kind: 'tool_call' as const,
-      toolCallId,
-      toolName: 'Bash',
-      input: { command: 'true' },
-      eventId: `evt-${toolCallId}`,
-      ts: 1,
-    };
-  }
-  function resultItem(toolCallId: string) {
-    return {
-      kind: 'tool_result' as const,
-      toolCallId,
-      toolName: 'Bash',
-      output: { stdout: '' },
-      isError: false,
-      eventId: `evt-r-${toolCallId}`,
-      ts: 2,
-    };
-  }
-
-  test('merges consecutive tool calls into one assistant message', () => {
-    const messages = replayPlanItemsToModelMessages([
-      callItem('call-1'),
-      callItem('call-2'),
-      resultItem('call-1'),
-      resultItem('call-2'),
-    ]);
-    assert.equal(messages.length, 3);
-    const [assistant, tool1, tool2] = messages;
-    assert.equal(assistant?.role, 'assistant');
-    const parts = Array.isArray(assistant?.content) ? assistant.content : [];
-    assert.deepEqual(
-      parts.map((p) => p.type),
-      ['tool-call', 'tool-call'],
-    );
-    assert.deepEqual(
-      parts.map((p) => (p.type === 'tool-call' ? p.toolCallId : undefined)),
-      ['call-1', 'call-2'],
-    );
-    assert.equal(tool1?.role, 'tool');
-    assert.equal(tool2?.role, 'tool');
-  });
-
-  test('does not merge tool calls separated by other content', () => {
-    const messages = replayPlanItemsToModelMessages([
-      callItem('call-1'),
-      resultItem('call-1'),
-      callItem('call-2'),
-      resultItem('call-2'),
-    ]);
-    assert.deepEqual(
-      messages.map((m) => m.role),
-      ['assistant', 'tool', 'assistant', 'tool'],
-    );
   });
 });

--- a/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
@@ -15,6 +15,7 @@ import { ProviderRequestTracker } from '../provider-request-telemetry.js';
 import type { HistoryCompactSummaryInput } from '../ai-sdk-compaction-contract.js';
 import {
   buildLlmHistorySummarizer,
+  replayPlanItemsToModelMessages,
   type AiSdkGenerateTextLike,
 } from '../history-compact-summarizer.js';
 import { buildHistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
@@ -259,5 +260,69 @@ describe('buildLlmHistorySummarizer', () => {
     expect(serialized).toContain('PRIOR_SUMMARY');
     expect(serialized).toContain('NEWLY_EVICTED_RAW');
     expect(serialized.includes('ALREADY_SUMMARIZED_RAW')).toBe(false);
+  });
+});
+
+describe('replayPlanItemsToModelMessages tool-call grouping', () => {
+  // #3030: strict OpenAI-compatible providers 400 when parallel tool calls of
+  // one step are split across multiple assistant messages. The primary
+  // materializer merges a step's tool calls into one provider message; the
+  // summarizer's projection must honor the same invariant.
+  function callItem(toolCallId: string) {
+    return {
+      kind: 'tool_call' as const,
+      toolCallId,
+      toolName: 'Bash',
+      input: { command: 'true' },
+      eventId: `evt-${toolCallId}`,
+      ts: 1,
+    };
+  }
+  function resultItem(toolCallId: string) {
+    return {
+      kind: 'tool_result' as const,
+      toolCallId,
+      toolName: 'Bash',
+      output: { stdout: '' },
+      isError: false,
+      eventId: `evt-r-${toolCallId}`,
+      ts: 2,
+    };
+  }
+
+  test('merges consecutive tool calls into one assistant message', () => {
+    const messages = replayPlanItemsToModelMessages([
+      callItem('call-1'),
+      callItem('call-2'),
+      resultItem('call-1'),
+      resultItem('call-2'),
+    ]);
+    assert.equal(messages.length, 3);
+    const [assistant, tool1, tool2] = messages;
+    assert.equal(assistant?.role, 'assistant');
+    const parts = Array.isArray(assistant?.content) ? assistant.content : [];
+    assert.deepEqual(
+      parts.map((p) => p.type),
+      ['tool-call', 'tool-call'],
+    );
+    assert.deepEqual(
+      parts.map((p) => (p.type === 'tool-call' ? p.toolCallId : undefined)),
+      ['call-1', 'call-2'],
+    );
+    assert.equal(tool1?.role, 'tool');
+    assert.equal(tool2?.role, 'tool');
+  });
+
+  test('does not merge tool calls separated by other content', () => {
+    const messages = replayPlanItemsToModelMessages([
+      callItem('call-1'),
+      resultItem('call-1'),
+      callItem('call-2'),
+      resultItem('call-2'),
+    ]);
+    assert.deepEqual(
+      messages.map((m) => m.role),
+      ['assistant', 'tool', 'assistant', 'tool'],
+    );
   });
 });

--- a/packages/runtime/src/__tests__/history-compact-summary-validation.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summary-validation.test.ts
@@ -8,7 +8,6 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   HISTORY_COMPACT_REQUIRED_SECTIONS,
-  HISTORY_COMPACT_SUMMARY_SECTIONS,
   validateHistoryCompactSummary,
 } from '../history-compact-summary-validation.js';
 
@@ -60,10 +59,6 @@ describe('validateHistoryCompactSummary', () => {
     assert.equal(validateHistoryCompactSummary(incident), 'missing_sections');
   });
 
-  test('rejects a single word', () => {
-    assert.equal(validateHistoryCompactSummary('done'), 'missing_sections');
-  });
-
   test('rejects raw tool-call markup instead of a summary', () => {
     // Observed live from a weak summarizer model that continued the
     // conversation instead of summarizing it (DeepSeek DSML output).
@@ -79,24 +74,41 @@ describe('validateHistoryCompactSummary', () => {
     }
   });
 
+  test('requires each section as its own heading line, not a prose mention', () => {
+    const proseMention = [
+      '## Goal',
+      'Fix the gate.',
+      '',
+      '## Progress',
+      'Done.',
+      '',
+      'The required headings are ## Goal, ## Progress, and ## Next Steps.',
+    ].join('\n');
+    assert.equal(validateHistoryCompactSummary(proseMention), 'missing_sections');
+  });
+
+  test('rejects a near-match heading like ## Goals for the ## Goal section', () => {
+    const plural = CONFORMING.replace('## Goal\n', '## Goals\n');
+    assert.equal(validateHistoryCompactSummary(plural), 'missing_sections');
+  });
+
   test('rejects output that stops inside a code fence', () => {
     assert.equal(validateHistoryCompactSummary(CONFORMING + '\n\n```ts\nconst x = 1'), 'truncated');
   });
 
   test('rejects a summary ending on truncation punctuation', () => {
-    for (const tail of [':', '：', ',', '，', '、', ';', '；', '(', '（', '`', '—']) {
+    // Representative sample of the tail class; the full char list lives next to
+    // the regex so it stays co-located with the implementation it describes.
+    for (const tail of [':', '：', '`']) {
       assert.equal(validateHistoryCompactSummary(CONFORMING + ' ' + tail), 'truncated', tail);
     }
+    // Sentence terminals are completion, not truncation, and must be accepted.
+    assert.equal(validateHistoryCompactSummary(CONFORMING + '.'), undefined);
+    assert.equal(validateHistoryCompactSummary(CONFORMING + '。'), undefined);
   });
 
   test('accepts a closed fence and terminal punctuation', () => {
     const withFence = CONFORMING + '\n\n```sh\nnpm test\n```\n\nDone.';
     assert.equal(validateHistoryCompactSummary(withFence), undefined);
-  });
-
-  test('required sections are a subset of the full prompt contract', () => {
-    for (const section of HISTORY_COMPACT_REQUIRED_SECTIONS) {
-      assert.ok((HISTORY_COMPACT_SUMMARY_SECTIONS as readonly string[]).includes(section), section);
-    }
   });
 });

--- a/packages/runtime/src/__tests__/history-compact-summary-validation.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summary-validation.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for validateHistoryCompactSummary — the structural gate that keeps a
+ * degraded summarizer response from replacing folded history (#3029).
+ *
+ * Run: `npm --workspace @maka/runtime run test`
+ */
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  HISTORY_COMPACT_REQUIRED_SECTIONS,
+  HISTORY_COMPACT_SUMMARY_SECTIONS,
+  validateHistoryCompactSummary,
+} from '../history-compact-summary-validation.js';
+
+const CONFORMING = [
+  '## Goal',
+  'Fix the compaction gate.',
+  '',
+  '## Progress',
+  '### Done',
+  '- Gate added.',
+  '### In Progress',
+  '- Tests.',
+  '',
+  '## Key Decisions',
+  '- **Fail open**: never persist fragments.',
+  '',
+  '## Next Steps',
+  '1. Review.',
+  '',
+  '## Critical Context',
+  '- packages/runtime/src/mid-turn-capacity-compact.ts',
+].join('\n');
+
+describe('validateHistoryCompactSummary', () => {
+  test('accepts a fully conforming summary', () => {
+    assert.equal(validateHistoryCompactSummary(CONFORMING), undefined);
+  });
+
+  test('accepts a summary with only the required sections', () => {
+    const thin = [
+      '## Goal',
+      'g',
+      '',
+      '## Progress',
+      '### Done',
+      '- d',
+      '',
+      '## Next Steps',
+      '1. n',
+    ].join('\n');
+    assert.equal(validateHistoryCompactSummary(thin), undefined);
+  });
+
+  test('rejects the incident fragment verbatim (sections missing, tail truncated)', () => {
+    // The exact summary persisted by checkpoint hcheckpoint-981ceab8…: the
+    // pipeline accepted it and replaced 742 events / ~235k tokens (#3029).
+    const incident =
+      '确认服务端语义后，决定：`/goal pause|resume|clear` 走 `runControl`（写操作互斥），turn 中不可达但提示明确。现在看 desktop 的 retry 循环结尾：';
+    assert.equal(validateHistoryCompactSummary(incident), 'missing_sections');
+  });
+
+  test('rejects a single word', () => {
+    assert.equal(validateHistoryCompactSummary('done'), 'missing_sections');
+  });
+
+  test('rejects raw tool-call markup instead of a summary', () => {
+    // Observed live from a weak summarizer model that continued the
+    // conversation instead of summarizing it (DeepSeek DSML output).
+    const dsml =
+      '<｜｜DSML｜｜tool_calls>\n<｜｜DSML｜｜invoke name="Bash">\n<｜｜DSML｜｜parameter name="command" string="true">ls</｜｜DSML｜｜parameter>\n</｜｜DSML｜｜invoke>\n</｜｜DSML｜｜tool_calls>';
+    assert.equal(validateHistoryCompactSummary(dsml), 'missing_sections');
+  });
+
+  test('rejects when a required section is missing', () => {
+    for (const section of HISTORY_COMPACT_REQUIRED_SECTIONS) {
+      const broken = CONFORMING.replace(section, section.replace('## ', '## Removed '));
+      assert.equal(validateHistoryCompactSummary(broken), 'missing_sections', section);
+    }
+  });
+
+  test('rejects output that stops inside a code fence', () => {
+    assert.equal(validateHistoryCompactSummary(CONFORMING + '\n\n```ts\nconst x = 1'), 'truncated');
+  });
+
+  test('rejects a summary ending on truncation punctuation', () => {
+    for (const tail of [':', '：', ',', '，', '、', ';', '；', '(', '（', '`', '—']) {
+      assert.equal(validateHistoryCompactSummary(CONFORMING + ' ' + tail), 'truncated', tail);
+    }
+  });
+
+  test('accepts a closed fence and terminal punctuation', () => {
+    const withFence = CONFORMING + '\n\n```sh\nnpm test\n```\n\nDone.';
+    assert.equal(validateHistoryCompactSummary(withFence), undefined);
+  });
+
+  test('required sections are a subset of the full prompt contract', () => {
+    for (const section of HISTORY_COMPACT_REQUIRED_SECTIONS) {
+      assert.ok((HISTORY_COMPACT_SUMMARY_SECTIONS as readonly string[]).includes(section), section);
+    }
+  });
+});

--- a/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-backend.test.ts
@@ -298,7 +298,12 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
   const commits: ModelCallCommit<ModelCallAttempt>[] = [];
   const summarizerModel = new MockLanguageModelV4({
     doGenerate: {
-      content: [{ type: 'text', text: 'MID_TURN_SUMMARY_SENTINEL' }],
+      content: [
+        {
+          type: 'text',
+          text: '## Goal\nMID_TURN_SUMMARY_SENTINEL\n\n## Progress\n### Done\n- folded span summarized\n\n### In Progress\n- none\n\n## Next Steps\n1. continue the turn\n\n## Critical Context\n- (none)',
+        },
+      ],
       finishReason: { unified: 'stop', raw: 'stop' },
       usage: {
         inputTokens: { total: 31, noCache: 31, cacheRead: 0, cacheWrite: 0 },
@@ -422,7 +427,9 @@ function buildFixture(options: MidTurnFixtureOptions = {}): MidTurnFixture {
       // The real summarizer is what carries the accounting the backend hands
       // it, so the metered case must go through it rather than a stub.
       if (options.meteredSummarizer) return await meteredSummarize(input);
-      const summary = options.summarize ? await options.summarize() : 'MID_TURN_SUMMARY_SENTINEL';
+      const summary = options.summarize
+        ? await options.summarize()
+        : '## Goal\nMID_TURN_SUMMARY_SENTINEL\n\n## Progress\n### Done\n- folded span summarized\n\n### In Progress\n- none\n\n## Next Steps\n1. continue the turn\n\n## Critical Context\n- (none)';
       return summary;
     },
     ...(options.meteredSummarizer
@@ -797,6 +804,27 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     assert.equal(usageEvent?.contextBudget?.historyCompactWriteFailures, 1);
   });
 
+  test('fails open with malformed_summary diagnostics when the summarizer returns a fragment (#3029)', async () => {
+    // Regression for the incident: a degraded provider returned a section-less
+    // fragment ending mid-sentence, and the pipeline persisted it as the
+    // checkpoint, replacing the folded span. The gate must refuse it.
+    const fixture = buildFixture({
+      summarize: () => '确认服务端语义后，决定走 runControl。现在看 desktop 的 retry 循环结尾：',
+    });
+    await runFixtureTurn(fixture, consumer);
+
+    // No checkpoint is recorded; the turn continues on the raw projection.
+    assert.equal(fixture.recorded.length, 0);
+    assert.equal(fixture.model.doStreamCalls.length, 3);
+    const complete = fixture.events.find((event) => event.type === 'complete');
+    assert.equal(complete?.type === 'complete' ? complete.stopReason : undefined, 'end_turn');
+
+    const failedOpen = compactionDecisions(fixture).find(
+      (decision) => decision.phase === 'mid_turn' && decision.decision === 'failedOpen',
+    );
+    assert.equal(failedOpen?.failOpenReason, 'malformed_summary');
+  });
+
   test('exhausts with write_failed in the durable diagnostics when the write fails over the window', async () => {
     // Big priors make folding rescue the over-window estimate, so the plan
     // compacts and the failure happens AT the recorder — over the window that
@@ -1029,7 +1057,12 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     // projection; the hook measures the materialized payload and keeps the raw
     // messages instead. Validation runs before the recorder, so the rejected
     // checkpoint is never persisted (asserted below).
-    const fixture = buildFixture({ summarize: () => 'GIANT_SUMMARY_'.repeat(600) });
+    const fixture = buildFixture({
+      summarize: () =>
+        '## Goal\n' +
+        'GIANT_SUMMARY_'.repeat(600) +
+        '\n\n## Progress\n### Done\n- padded\n\n## Next Steps\n1. continue',
+    });
     await runFixtureTurn(fixture, consumer);
 
     assert.equal(fixture.model.doStreamCalls.length, 3);
@@ -1127,7 +1160,10 @@ function defineMidTurnSuite(consumer: ConsumerMode): void {
     const fixture = buildFixture({
       contextWindow: 150,
       reserveTokens: 100,
-      summarize: () => 'GIANT_SUMMARY_'.repeat(600),
+      summarize: () =>
+        '## Goal\n' +
+        'GIANT_SUMMARY_'.repeat(600) +
+        '\n\n## Progress\n### Done\n- padded\n\n## Next Steps\n1. continue',
     });
     await runFixtureTurn(fixture, consumer);
 

--- a/packages/runtime/src/__tests__/mid-turn-capacity-compact.test.ts
+++ b/packages/runtime/src/__tests__/mid-turn-capacity-compact.test.ts
@@ -151,7 +151,8 @@ describe('plan mid-turn capacity compaction', () => {
       reserveTailEvents: 1,
       charsPerToken: 4,
       now: 1_800_000_010_000,
-      summarize: () => 'A faithful mid-turn summary.',
+      summarize: () =>
+        '## Goal\nFold prior work.\n\n## Progress\n### Done\n- Prior turns summarized.\n\n## Next Steps\n1. Continue the turn.',
       ...over,
     };
   }
@@ -242,6 +243,23 @@ describe('plan mid-turn capacity compaction', () => {
     assert.deepEqual(result, { decision: 'fail_open', reason: 'summarizer_failed' });
   });
 
+  test('fails open when the summarizer returns a malformed fragment (#3029)', async () => {
+    // Regression: the incident's actual summary — a section-less fragment
+    // ending mid-sentence — was persisted as the checkpoint, replacing the
+    // folded events. The write gate must reject it instead.
+    const result = await planMidTurnCapacityCompaction(
+      planInput({
+        estimatedNextRequestTokens: 120_000, // over high-water, under window
+        summarize: () => '确认服务端语义后，决定走 runControl。现在看 desktop 的 retry 循环结尾：',
+      }),
+    );
+    assert.deepEqual(result, {
+      decision: 'fail_open',
+      reason: 'summarizer_failed',
+      diagnosticReason: 'malformed_summary',
+    });
+  });
+
   test('preserves a typed summarizer failure as the mid-turn diagnostic reason', async () => {
     const result = await planMidTurnCapacityCompaction(
       planInput({
@@ -328,7 +346,7 @@ describe('plan mid-turn capacity compaction', () => {
         summarize: ({ newlyFoldedRuntimeEvents, previousCheckpoint }) => {
           seenNewlyFolded = newlyFoldedRuntimeEvents.map((event) => event.id);
           assert.equal(previousCheckpoint?.checkpointId, first.checkpoint.checkpointId);
-          return 'rolled-forward summary';
+          return '## Goal\nFold prior work.\n\n## Progress\n### Done\n- Prior turns summarized.\n\n## Next Steps\n1. Continue the turn.';
         },
       }),
     );

--- a/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
+++ b/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
@@ -410,7 +410,9 @@ function buildReactiveFixture(options: ReactiveFixtureOptions): ReactiveFixture 
         }) => {
           counters.summarizerCalls += 1;
           summarizedSources.push(JSON.stringify(input.source.foldedRuntimeEvents));
-          return options.summarize ? await options.summarize() : 'REACTIVE_SUMMARY_SENTINEL';
+          return options.summarize
+            ? await options.summarize()
+            : '## Goal\nREACTIVE_SUMMARY_SENTINEL\n\n## Progress\n### Done\n- folded span summarized\n\n### In Progress\n- none\n\n## Next Steps\n1. continue the turn\n\n## Critical Context\n- (none)';
         },
         recordHistoryCompactCheckpoint: (checkpoint: HistoryCompactCheckpoint) => {
           recorded.push(checkpoint);

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3891,7 +3891,12 @@ describe('SessionManager manual compaction and quiescent session changes', () =>
     const modelCalls: ModelCallAttempt[] = [];
     const summarizerModel = new MockLanguageModelV4({
       doGenerate: {
-        content: [{ type: 'text', text: 'MANUAL_COMPACT_SUMMARY' }],
+        content: [
+          {
+            type: 'text',
+            text: '## Goal\nMANUAL_COMPACT_SUMMARY\n\n## Progress\n### Done\n- folded span summarized\n\n### In Progress\n- none\n\n## Next Steps\n1. continue the turn\n\n## Critical Context\n- (none)',
+          },
+        ],
         finishReason: { unified: 'stop', raw: 'stop' },
         usage: {
           inputTokens: { total: 41, noCache: 41, cacheRead: 0, cacheWrite: 0 },

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -41,6 +41,7 @@ import {
   isHistoryCompactContentEvent,
 } from './history-compact.js';
 import { HistoryCompactSummarizerError } from './history-compact-error.js';
+import { validateHistoryCompactSummary } from './history-compact-summary-validation.js';
 import {
   buildHistoryCompactCheckpoint,
   matchHistoryCompactCheckpointPrefix,
@@ -546,6 +547,12 @@ export class AiSdkCompaction {
             }),
           },
         };
+      }
+      // A degraded provider response (section-less fragment, truncated
+      // mid-sentence, raw tool markup) must never replace the folded events;
+      // throw so the enclosing catch fails open with `malformed_summary` (#3029).
+      if (validateHistoryCompactSummary(summary) !== undefined) {
+        throw new HistoryCompactSummarizerError('malformed_summary');
       }
       const checkpoint = buildHistoryCompactCheckpoint({
         sessionId: this.sessionId,

--- a/packages/runtime/src/history-compact-error.ts
+++ b/packages/runtime/src/history-compact-error.ts
@@ -1,4 +1,7 @@
-export type HistoryCompactSummarizerFailureReason = 'output_length' | 'provider_error';
+export type HistoryCompactSummarizerFailureReason =
+  | 'output_length'
+  | 'provider_error'
+  | 'malformed_summary';
 
 export class HistoryCompactSummarizerError extends Error {
   constructor(

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -149,27 +149,17 @@ export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMes
         out.push({ role: 'assistant', content: [textPart] });
       }
     } else if (item.kind === 'tool_call') {
-      // Merge consecutive tool calls into ONE assistant message, mirroring the
-      // primary materializer's step merge (model-history.ts): strict
-      // OpenAI-compatible providers 400 when an assistant message's tool_calls
-      // are interrupted by another assistant message before their tool
-      // results arrive (#3030).
-      const toolCallPart = {
-        type: 'tool-call' as const,
-        toolCallId: item.toolCallId,
-        toolName: item.toolName,
-        input: item.input,
-      };
-      const previous = out[out.length - 1];
-      if (
-        previous?.role === 'assistant' &&
-        Array.isArray(previous.content) &&
-        previous.content.every((part) => part.type === 'tool-call')
-      ) {
-        previous.content.push(toolCallPart);
-      } else {
-        out.push({ role: 'assistant', content: [toolCallPart] });
-      }
+      out.push({
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: item.toolCallId,
+            toolName: item.toolName,
+            input: item.input,
+          },
+        ],
+      });
     } else if (item.kind === 'tool_result') {
       out.push({
         role: 'tool',

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -143,17 +143,27 @@ export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMes
         out.push({ role: 'assistant', content: [textPart] });
       }
     } else if (item.kind === 'tool_call') {
-      out.push({
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool-call',
-            toolCallId: item.toolCallId,
-            toolName: item.toolName,
-            input: item.input,
-          },
-        ],
-      });
+      // Merge consecutive tool calls into ONE assistant message, mirroring the
+      // primary materializer's step merge (model-history.ts): strict
+      // OpenAI-compatible providers 400 when an assistant message's tool_calls
+      // are interrupted by another assistant message before their tool
+      // results arrive (#3030).
+      const toolCallPart = {
+        type: 'tool-call' as const,
+        toolCallId: item.toolCallId,
+        toolName: item.toolName,
+        input: item.input,
+      };
+      const previous = out[out.length - 1];
+      if (
+        previous?.role === 'assistant' &&
+        Array.isArray(previous.content) &&
+        previous.content.every((part) => part.type === 'tool-call')
+      ) {
+        previous.content.push(toolCallPart);
+      } else {
+        out.push({ role: 'assistant', content: [toolCallPart] });
+      }
     } else if (item.kind === 'tool_result') {
       out.push({
         role: 'tool',

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -1,6 +1,7 @@
 import { rawFinishReasonString, type ModelMessage } from './model-protocol.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { toolResultOutput } from './tool-result-output.js';
+import { HISTORY_COMPACT_SUMMARY_SECTIONS } from './history-compact-summary-validation.js';
 import type { HistoryCompactSummaryInput } from './ai-sdk-compaction-contract.js';
 import { HistoryCompactSummarizerError } from './history-compact-error.js';
 import type { AiSdkUsageLike } from './model-adapter.js';
@@ -34,30 +35,35 @@ export interface BuildLlmHistorySummarizerOptions {
 // asks for a checkpoint another LLM can continue from. Tool calls and their
 // results are part of the conversation sent to the summarizer, because the
 // folded events are projected with the same policy the model would see them.
+//
+// Section names come from history-compact-summary-validation.ts — the same
+// constant the checkpoint write gates validate against, so the requested
+// contract and the enforced contract cannot drift apart.
+const SECTION_PLACEHOLDERS: Record<(typeof HISTORY_COMPACT_SUMMARY_SECTIONS)[number], string[]> = {
+  '## Goal': ['[What the user is trying to accomplish]'],
+  '## Progress': [
+    '### Done',
+    '- [Completed work and changes]',
+    '### In Progress',
+    '- [Current work]',
+  ],
+  '## Key Decisions': ['- **[Decision]**: [Brief rationale]'],
+  '## Next Steps': ['1. [Ordered list of what should happen next]'],
+  '## Critical Context': [
+    '- [Files, commands/results, errors, anything needed to continue; or "(none)"]',
+  ],
+};
 const SUMMARIZATION_SYSTEM_PROMPT = [
   'You are a context summarization assistant.',
   'Read the conversation between a user and an AI assistant, then produce a structured summary another LLM will use to continue the same task.',
   'Do NOT continue the conversation. Do NOT answer questions in it. ONLY output the structured summary.',
   '',
   'Use this exact format:',
-  '',
-  '## Goal',
-  '[What the user is trying to accomplish]',
-  '',
-  '## Progress',
-  '### Done',
-  '- [Completed work and changes]',
-  '### In Progress',
-  '- [Current work]',
-  '',
-  '## Key Decisions',
-  '- **[Decision]**: [Brief rationale]',
-  '',
-  '## Next Steps',
-  '1. [Ordered list of what should happen next]',
-  '',
-  '## Critical Context',
-  '- [Files, commands/results, errors, anything needed to continue; or "(none)"]',
+  ...HISTORY_COMPACT_SUMMARY_SECTIONS.flatMap((section) => [
+    '',
+    section,
+    ...SECTION_PLACEHOLDERS[section],
+  ]),
   '',
   'Keep each section concise. Preserve exact file paths, function names, commands, and error messages.',
 ].join('\n');

--- a/packages/runtime/src/history-compact-summary-validation.ts
+++ b/packages/runtime/src/history-compact-summary-validation.ts
@@ -1,0 +1,58 @@
+/**
+ * Structural contract for history-compact checkpoint summaries.
+ *
+ * A checkpoint summary is the only survivor of a history fold: once written,
+ * the covered RuntimeEvents are replaced by this text alone. The summarizer
+ * prompt (history-compact-summarizer.ts) declares a sectioned contract, but a
+ * degraded provider can return anything non-empty — a single word, raw tool
+ * markup, or a fragment ending mid-sentence — and before this gate existed the
+ * pipeline persisted all of it (see #3029). Both checkpoint write paths call
+ * `validateHistoryCompactSummary` and fail open on a rejection, so a bad
+ * summary never replaces folded history.
+ *
+ * The section names are the single source of truth: the summarizer prompt is
+ * built from them, and validation reuses the same constants.
+ */
+
+/** Every section the summarization prompt asks for, in order. */
+export const HISTORY_COMPACT_SUMMARY_SECTIONS = [
+  '## Goal',
+  '## Progress',
+  '## Key Decisions',
+  '## Next Steps',
+  '## Critical Context',
+] as const;
+
+/**
+ * Sections without which a continuation cannot recover the task: what is being
+ * done, how far it got, and what happens next. `## Key Decisions` and
+ * `## Critical Context` are valuable but not load-bearing, so a summary that
+ * omits them is thin rather than malformed.
+ */
+export const HISTORY_COMPACT_REQUIRED_SECTIONS = [
+  '## Goal',
+  '## Progress',
+  '## Next Steps',
+] as const;
+
+/** Terminal punctuation that indicates the output was cut off mid-thought. */
+const TRUNCATED_TAIL_PATTERN = /[:：,，、;；(（`—]\s*$/u;
+
+/** Why a summary failed validation, for diagnostics and tests. */
+export type HistoryCompactSummaryRejection = 'missing_sections' | 'truncated';
+
+/**
+ * Returns why the summary is malformed, or undefined when it satisfies the
+ * contract. Callers map any rejection to `malformed_summary` and fail open.
+ */
+export function validateHistoryCompactSummary(
+  summary: string,
+): HistoryCompactSummaryRejection | undefined {
+  const missing = HISTORY_COMPACT_REQUIRED_SECTIONS.filter((section) => !summary.includes(section));
+  if (missing.length > 0) return 'missing_sections';
+  // An odd number of fences means the output stops inside a code block.
+  const fenceCount = (summary.match(/^```/gm) ?? []).length;
+  if (fenceCount % 2 === 1) return 'truncated';
+  if (TRUNCATED_TAIL_PATTERN.test(summary)) return 'truncated';
+  return undefined;
+}

--- a/packages/runtime/src/history-compact-summary-validation.ts
+++ b/packages/runtime/src/history-compact-summary-validation.ts
@@ -33,7 +33,20 @@ export const HISTORY_COMPACT_REQUIRED_SECTIONS = [
   '## Goal',
   '## Progress',
   '## Next Steps',
-] as const;
+] as const satisfies readonly (typeof HISTORY_COMPACT_SUMMARY_SECTIONS)[number][];
+
+/**
+ * Line-anchored heading matchers: a required section must appear as its own
+ * heading line. A substring match would also accept `## Goals` or a prose
+ * mention of `## Goal`, neither of which follows the summarizer contract.
+ */
+const REQUIRED_SECTION_HEADING_PATTERNS = HISTORY_COMPACT_REQUIRED_SECTIONS.map(
+  (section) => new RegExp(`^${escapeRegExp(section)}\\b`, 'm'),
+);
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 /** Terminal punctuation that indicates the output was cut off mid-thought. */
 const TRUNCATED_TAIL_PATTERN = /[:：,，、;；(（`—]\s*$/u;
@@ -48,8 +61,9 @@ export type HistoryCompactSummaryRejection = 'missing_sections' | 'truncated';
 export function validateHistoryCompactSummary(
   summary: string,
 ): HistoryCompactSummaryRejection | undefined {
-  const missing = HISTORY_COMPACT_REQUIRED_SECTIONS.filter((section) => !summary.includes(section));
-  if (missing.length > 0) return 'missing_sections';
+  if (REQUIRED_SECTION_HEADING_PATTERNS.some((pattern) => !pattern.test(summary))) {
+    return 'missing_sections';
+  }
   // An odd number of fences means the output stops inside a code block.
   const fenceCount = (summary.match(/^```/gm) ?? []).length;
   if (fenceCount % 2 === 1) return 'truncated';

--- a/packages/runtime/src/mid-turn-capacity-compact.ts
+++ b/packages/runtime/src/mid-turn-capacity-compact.ts
@@ -4,6 +4,7 @@ import {
   HistoryCompactSummarizerError,
   type HistoryCompactSummarizerFailureReason,
 } from './history-compact-error.js';
+import { validateHistoryCompactSummary } from './history-compact-summary-validation.js';
 import {
   buildHistoryCompactCheckpoint,
   historyCompactCheckpointToRuntimeEvent,
@@ -332,6 +333,16 @@ export async function planMidTurnCapacityCompaction(
   }
   if (!summary) {
     return { decision: 'fail_open', reason: 'summarizer_failed' };
+  }
+  // The summary replaces the folded events outright, so a degraded provider
+  // response (section-less fragment, truncated mid-sentence, raw tool markup)
+  // must fail open rather than be persisted as the checkpoint (#3029).
+  if (validateHistoryCompactSummary(summary) !== undefined) {
+    return {
+      decision: 'fail_open',
+      reason: 'summarizer_failed',
+      diagnosticReason: 'malformed_summary',
+    };
   }
 
   const checkpoint = buildHistoryCompactCheckpoint({


### PR DESCRIPTION
## Summary

History compaction folds hundreds of RuntimeEvents into one checkpoint summary. Before this change the **only** gate on that summary was `empty_summary`, so a degraded provider response — a section-less fragment ending mid-sentence, a single word, or raw tool-call markup — replaced the folded history and made the continuation model hallucinate implementation details (see [#3029](https://github.com/maka-agent/maka-agent/issues/3029)).

## Root cause (reproduced)

Incident session `fbdb3fd3`: compaction folded **742 events / ~235,503 tokens into a 138-token section-less fragment**, persisted because every non-empty string passed the gate. Three `provider_error` fail-opens preceded the degraded write.

The model returned ~160 tokens of raw tool-call markup (no summary sections). The old gate **accepted** it. (The other failure layer — the summarizer emitting parallel tool calls as separate assistant messages, triggering the `provider_error` retries — is tracked as [#3030](https://github.com/maka-agent/maka-agent/issues/3030) and fixed independently by [#3038](https://github.com/maka-agent/maka-agent/pull/3038).)

## Changes

- **`history-compact-summary-validation.ts`** (new): `validateHistoryCompactSummary()` enforces the summarizer's own structural contract — the required section headings (`## Goal` / `## Progress` / `## Next Steps`) matched **line-anchored**, plus truncation signals (unclosed code fence, trailing continuation punctuation). Section names are the single source of truth for both the prompt and the validator.
- **Both checkpoint write gates enforce it** and fail open:
  - `writeHistoryCompactCheckpoint` → throws `HistoryCompactSummarizerError('malformed_summary')`, mapped to `failOpenReason: 'malformed_summary'`.
  - `planMidTurnCapacityCompaction` → returns `fail_open` with `diagnosticReason: 'malformed_summary'`.
- `'malformed_summary'` added to the failure-reason union.
- Tests: validation unit tests (incident fragment verbatim, raw DeepSeek DSML output, per-section missing, truncation, heading-vs-prose, near-match `## Goals`), a direct `writeHistoryCompactCheckpoint` gate test, and a backend-level fail-open regression test. Fixtures updated to the conforming shape.

## Verification

- `npm --workspace @maka/runtime run test` → **2805 pass / 0 fail**
- `npm run typecheck` → clean (all packages)
- `npx biome check` → clean (2298 files)
- Post-fix empirical checks: the incident fragment now fails open with `malformed_summary`; the non-compliant output is rejected with `missing_sections`.

## Review notes

- **First-principles + Occam's-razor dual review** was run on the first two commits; findings applied in the third commit (line-anchored headings instead of substring match, compile-time pinning of the required-section list, direct coverage of the checkpoint write gate, removal of tautological/redundant tests).
- **Deliberately deferred** (not in scope of #3029): validating summaries at **load** time. The loader sees a heterogeneous history (checkpoints written by older binaries), so the same validator would reject legacy valid-but-sectionless summaries; that needs a version-aware or migration approach and will be filed separately.

## Related

- Closes #3029
