### PR TITLE
refactor(runtime): remove unused AgentRun execute path

### DIFF
--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -1158,43 +1158,6 @@ describe('SessionManager terminal ledger invariants', () => {
     ).toBe(false);
   });
 
-  test('Runtime execution records terminal RuntimeEvents before terminal headers', async () => {
-    const runStore = new TinyAgentRunStore({ requireTerminalFactBeforeHeader: true });
-    const { manager, session } = await makeHarness([{ type: 'complete', stopReason: 'end_turn' }], {
-      runStore,
-    });
-
-    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
-
-    const [header] = await runStore.listSessionRuns(session.id);
-    if (!header) throw new Error('run was not recorded');
-    expect(header.status).toBe('completed');
-    const terminalEvents = (await runStore.readRuntimeEvents(session.id, header.runId)).filter(
-      isTerminalRuntimeEvent,
-    );
-    expect(terminalEvents).toHaveLength(1);
-    expect(terminalEvents[0]?.status).toBe('completed');
-  });
-
-  test('Runtime execution forwards the effective tool mode to the backend', async () => {
-    let observedToolMode: BackendSendInput['toolMode'];
-    const { manager, session } = await makeHarness([{ type: 'complete', stopReason: 'end_turn' }], {
-      onInput: (input) => {
-        observedToolMode = input.toolMode;
-      },
-    });
-
-    await drain(
-      manager.sendMessage(session.id, {
-        turnId: 'turn-code-mode',
-        text: 'hello',
-        toolMode: 'code_mode',
-      }),
-    );
-
-    expect(observedToolMode).toBe('code_mode');
-  });
-
   test('direct AgentRun finalize synthesizes a failed terminal fact when no terminal event was recorded', async () => {
     const store = new TinySessionStore();
     const runStore = new TinyAgentRunStore();
@@ -2165,8 +2128,6 @@ async function makeHarness(
   events: readonly ScriptEvent[],
   options: {
     store?: TinySessionStore;
-    runStore?: TinyAgentRunStore;
-    onInput?: (input: BackendSendInput) => void;
   } = {},
 ): Promise<{
   manager: SessionManager;
@@ -2174,9 +2135,9 @@ async function makeHarness(
   session: SessionSummary;
 }> {
   const store = options.store ?? new TinySessionStore();
-  const runStore = options.runStore ?? new TinyAgentRunStore();
+  const runStore = new TinyAgentRunStore();
   const backends = new BackendRegistry();
-  backends.register('fake', (ctx) => new ScriptBackend(ctx, events, options.onInput));
+  backends.register('fake', (ctx) => new ScriptBackend(ctx, events));
   const manager = new SessionManager({
     store,
     runStore,
@@ -2197,13 +2158,11 @@ class ScriptBackend implements AgentBackend {
   constructor(
     ctx: BackendFactoryContext,
     private readonly events: readonly ScriptEvent[],
-    private readonly onInput?: (input: BackendSendInput) => void,
   ) {
     this.sessionId = ctx.sessionId;
   }
 
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
-    this.onInput?.(input);
     let index = 0;
     for (const event of this.events) {
       index += 1;
@@ -2380,13 +2339,18 @@ class TinySessionStore implements SessionStore {
   }
 
   async appendMessage(sessionId: string, message: StoredMessage): Promise<void> {
-    if (message.type === 'turn_state' && message.status === this.options.failTurnStateStatus) {
-      throw new Error('turn state write failed');
-    }
     await this.appendMessages(sessionId, [message]);
   }
 
   async appendMessages(sessionId: string, messages: StoredMessage[]): Promise<void> {
+    if (
+      messages.some(
+        (message) =>
+          message.type === 'turn_state' && message.status === this.options.failTurnStateStatus,
+      )
+    ) {
+      throw new Error('turn state write failed');
+    }
     this.messages.set(sessionId, [...(this.messages.get(sessionId) ?? []), ...clone(messages)]);
   }
 
@@ -2447,8 +2411,6 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
       corruptLedger?: boolean;
       /** SqliteRuntimeStore is `canonical`; declare it when a test needs that shape. */
       durability?: 'best_effort' | 'canonical';
-      /** Enforce the durable terminal-fact-before-header ordering at the store boundary. */
-      requireTerminalFactBeforeHeader?: boolean;
     } = {},
   ) {}
 
@@ -2466,14 +2428,6 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
     runId: string,
     patch: Partial<AgentRunHeader>,
   ): Promise<AgentRunHeader> {
-    if (
-      this.options.requireTerminalFactBeforeHeader &&
-      patch.status !== undefined &&
-      patch.status !== 'running' &&
-      !(this.runtimeEvents.get(key(sessionId, runId)) ?? []).some(isTerminalRuntimeEvent)
-    ) {
-      throw new Error('terminal run header committed before terminal RuntimeEvent');
-    }
     const current = await this.readRun(sessionId, runId);
     const next = { ...current, ...patch, sessionId, runId };
     this.headers.set(key(sessionId, runId), clone(next));

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -1158,158 +1158,39 @@ describe('SessionManager terminal ledger invariants', () => {
     ).toBe(false);
   });
 
-  test('direct AgentRun execute records terminal RuntimeEvents before terminal headers', async () => {
-    const store = new TinySessionStore();
-    const runStore = new TinyAgentRunStore();
-    const session = await store.create(makeInput());
-    const backend = new ScriptBackend({ sessionId: session.id } as BackendFactoryContext, [
-      { type: 'complete', stopReason: 'end_turn' },
-    ]);
-    const activeRuns = new Map<string, AgentRun>();
-    const turnToRunId = new Map<string, string>();
-    const run = new AgentRun({
-      sessionId: session.id,
-      header: session,
-      userInput: { turnId: 'turn-1', text: 'hello' },
-      store,
+  test('Runtime execution records terminal RuntimeEvents before terminal headers', async () => {
+    const runStore = new TinyAgentRunStore({ requireTerminalFactBeforeHeader: true });
+    const { manager, session } = await makeHarness([{ type: 'complete', stopReason: 'end_turn' }], {
       runStore,
-      runtimeEventStore: runStore,
-      newId: nextId(),
-      now: nextNow(40_000),
-      hooks: {
-        reserveRun: async (_sessionId, _header, activeRun) => {
-          activeRuns.set(activeRun.runId, activeRun);
-          turnToRunId.set(activeRun.turnId, activeRun.runId);
-          return {
-            sessionId: session.id,
-            backend,
-            cachedHeader: session,
-            activeRuns,
-            turnToRunId,
-          };
-        },
-        unregisterRun: (_active, activeRun) => {
-          activeRuns.delete(activeRun.runId);
-          turnToRunId.delete(activeRun.turnId);
-        },
-        updateHeader: (sessionId, patch) => store.updateHeader(sessionId, patch),
-        updateStatus: async () => {},
-        appendTurnState: async () => {},
-      },
     });
 
-    await drain(run.execute());
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
 
-    const header = await runStore.readRun(session.id, run.runId);
+    const [header] = await runStore.listSessionRuns(session.id);
+    if (!header) throw new Error('run was not recorded');
     expect(header.status).toBe('completed');
-    const terminalEvents = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(
+    const terminalEvents = (await runStore.readRuntimeEvents(session.id, header.runId)).filter(
       isTerminalRuntimeEvent,
     );
     expect(terminalEvents).toHaveLength(1);
     expect(terminalEvents[0]?.status).toBe('completed');
   });
 
-  test('direct AgentRun execute ignores backend events after the terminal event', async () => {
-    const store = new TinySessionStore();
-    const runStore = new TinyAgentRunStore();
-    const session = await store.create(makeInput());
-    const backend = new ScriptBackend({ sessionId: session.id } as BackendFactoryContext, [
-      { type: 'complete', stopReason: 'end_turn' },
-      { type: 'text_delta', messageId: 'message-after-terminal', text: 'after-terminal' },
-    ]);
-    const activeRuns = new Map<string, AgentRun>();
-    const turnToRunId = new Map<string, string>();
-    const run = new AgentRun({
-      sessionId: session.id,
-      header: session,
-      userInput: { turnId: 'turn-1', text: 'hello' },
-      store,
-      runStore,
-      runtimeEventStore: runStore,
-      newId: nextId(),
-      now: nextNow(40_500),
-      hooks: {
-        reserveRun: async (_sessionId, _header, activeRun) => {
-          activeRuns.set(activeRun.runId, activeRun);
-          turnToRunId.set(activeRun.turnId, activeRun.runId);
-          return {
-            sessionId: session.id,
-            backend,
-            cachedHeader: session,
-            activeRuns,
-            turnToRunId,
-          };
-        },
-        unregisterRun: (_active, activeRun) => {
-          activeRuns.delete(activeRun.runId);
-          turnToRunId.delete(activeRun.turnId);
-        },
-        updateHeader: (sessionId, patch) => store.updateHeader(sessionId, patch),
-        updateStatus: async () => {},
-        appendTurnState: async () => {},
-      },
-    });
-
-    const yielded: SessionEvent[] = [];
-    for await (const event of run.execute()) {
-      yielded.push(event);
-    }
-
-    expect(yielded.map((event) => event.type)).toEqual(['complete']);
-    const runtimeEvents = await runStore.readRuntimeEvents(session.id, run.runId);
-    expect(
-      runtimeEvents.map((event) =>
-        event.content?.kind === 'text' ? event.content.text : event.status,
-      ),
-    ).toEqual(['hello', 'completed']);
-  });
-
-  test('direct AgentRun execute forwards the effective tool mode to the Flow', async () => {
-    const store = new TinySessionStore();
-    const runStore = new TinyAgentRunStore();
-    const session = await store.create(makeInput());
+  test('Runtime execution forwards the effective tool mode to the backend', async () => {
     let observedToolMode: BackendSendInput['toolMode'];
-    const backend = new ScriptBackend(
-      { sessionId: session.id } as BackendFactoryContext,
-      [{ type: 'complete', stopReason: 'end_turn' }],
-      (input) => {
+    const { manager, session } = await makeHarness([{ type: 'complete', stopReason: 'end_turn' }], {
+      onInput: (input) => {
         observedToolMode = input.toolMode;
       },
-    );
-    const activeRuns = new Map<string, AgentRun>();
-    const turnToRunId = new Map<string, string>();
-    const run = new AgentRun({
-      sessionId: session.id,
-      header: session,
-      userInput: { turnId: 'turn-code-mode', text: 'hello', toolMode: 'code_mode' },
-      store,
-      runStore,
-      runtimeEventStore: runStore,
-      newId: nextId(),
-      now: nextNow(40_750),
-      hooks: {
-        reserveRun: async (_sessionId, _header, activeRun) => {
-          activeRuns.set(activeRun.runId, activeRun);
-          turnToRunId.set(activeRun.turnId, activeRun.runId);
-          return {
-            sessionId: session.id,
-            backend,
-            cachedHeader: session,
-            activeRuns,
-            turnToRunId,
-          };
-        },
-        unregisterRun: (_active, activeRun) => {
-          activeRuns.delete(activeRun.runId);
-          turnToRunId.delete(activeRun.turnId);
-        },
-        updateHeader: (sessionId, patch) => store.updateHeader(sessionId, patch),
-        updateStatus: async () => {},
-        appendTurnState: async () => {},
-      },
     });
 
-    await drain(run.execute());
+    await drain(
+      manager.sendMessage(session.id, {
+        turnId: 'turn-code-mode',
+        text: 'hello',
+        toolMode: 'code_mode',
+      }),
+    );
 
     expect(observedToolMode).toBe('code_mode');
   });
@@ -1780,54 +1661,20 @@ describe('SessionManager terminal ledger invariants', () => {
     expect(cancelled).toHaveLength(1);
   });
 
-  test('direct AgentRun error events still commit failed terminal facts when failed turn projection fails', async () => {
-    const store = new TinySessionStore();
-    const runStore = new TinyAgentRunStore();
-    const session = await store.create(makeInput());
-    const backend = new ScriptBackend({ sessionId: session.id } as BackendFactoryContext, [
-      { type: 'error', recoverable: false, reason: 'tool_failed', message: 'Tool failed' },
-    ]);
-    const activeRuns = new Map<string, AgentRun>();
-    const turnToRunId = new Map<string, string>();
-    const run = new AgentRun({
-      sessionId: session.id,
-      header: session,
-      userInput: { turnId: 'turn-1', text: 'hello' },
-      store,
-      runStore,
-      runtimeEventStore: runStore,
-      newId: nextId(),
-      now: nextNow(41_500),
-      hooks: {
-        reserveRun: async (_sessionId, _header, activeRun) => {
-          activeRuns.set(activeRun.runId, activeRun);
-          turnToRunId.set(activeRun.turnId, activeRun.runId);
-          return {
-            sessionId: session.id,
-            backend,
-            cachedHeader: session,
-            activeRuns,
-            turnToRunId,
-          };
-        },
-        unregisterRun: (_active, activeRun) => {
-          activeRuns.delete(activeRun.runId);
-          turnToRunId.delete(activeRun.turnId);
-        },
-        updateHeader: (sessionId, patch) => store.updateHeader(sessionId, patch),
-        updateStatus: async () => {},
-        appendTurnState: async (_sessionId, _turnId, status) => {
-          if (status === 'failed') throw new Error('turn state write failed');
-        },
-      },
-    });
+  test('Runtime execution still commits failed terminal facts when failed turn projection fails', async () => {
+    const store = new TinySessionStore({ failTurnStateStatus: 'failed' });
+    const { manager, runStore, session } = await makeHarness(
+      [{ type: 'error', recoverable: false, reason: 'tool_failed', message: 'Tool failed' }],
+      { store },
+    );
 
-    await drain(run.execute());
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }));
 
-    const header = await runStore.readRun(session.id, run.runId);
+    const [header] = await runStore.listSessionRuns(session.id);
+    if (!header) throw new Error('run was not recorded');
     expect(header.status).toBe('failed');
     expect(header.failureClass).toBe('tool_failed');
-    const terminalEvents = (await runStore.readRuntimeEvents(session.id, run.runId)).filter(
+    const terminalEvents = (await runStore.readRuntimeEvents(session.id, header.runId)).filter(
       isTerminalRuntimeEvent,
     );
     expect(terminalEvents).toHaveLength(1);
@@ -2314,15 +2161,22 @@ type ScriptEvent =
   | Omit<Extract<SessionEvent, { type: 'abort' }>, 'id' | 'turnId' | 'ts'>
   | Omit<Extract<SessionEvent, { type: 'complete' }>, 'id' | 'turnId' | 'ts'>;
 
-async function makeHarness(events: readonly ScriptEvent[]): Promise<{
+async function makeHarness(
+  events: readonly ScriptEvent[],
+  options: {
+    store?: TinySessionStore;
+    runStore?: TinyAgentRunStore;
+    onInput?: (input: BackendSendInput) => void;
+  } = {},
+): Promise<{
   manager: SessionManager;
   runStore: TinyAgentRunStore;
   session: SessionSummary;
 }> {
-  const store = new TinySessionStore();
-  const runStore = new TinyAgentRunStore();
+  const store = options.store ?? new TinySessionStore();
+  const runStore = options.runStore ?? new TinyAgentRunStore();
   const backends = new BackendRegistry();
-  backends.register('fake', (ctx) => new ScriptBackend(ctx, events));
+  backends.register('fake', (ctx) => new ScriptBackend(ctx, events, options.onInput));
   const manager = new SessionManager({
     store,
     runStore,
@@ -2443,6 +2297,8 @@ class TinySessionStore implements SessionStore {
   private headers = new Map<string, SessionHeader>();
   private messages = new Map<string, StoredMessage[]>();
 
+  constructor(private readonly options: { failTurnStateStatus?: TurnRecord['status'] } = {}) {}
+
   async createSubagent(
     _input: CreateSessionInput,
   ): Promise<{ header: SessionHeader; created: boolean }> {
@@ -2524,6 +2380,9 @@ class TinySessionStore implements SessionStore {
   }
 
   async appendMessage(sessionId: string, message: StoredMessage): Promise<void> {
+    if (message.type === 'turn_state' && message.status === this.options.failTurnStateStatus) {
+      throw new Error('turn state write failed');
+    }
     await this.appendMessages(sessionId, [message]);
   }
 
@@ -2588,6 +2447,8 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
       corruptLedger?: boolean;
       /** SqliteRuntimeStore is `canonical`; declare it when a test needs that shape. */
       durability?: 'best_effort' | 'canonical';
+      /** Enforce the durable terminal-fact-before-header ordering at the store boundary. */
+      requireTerminalFactBeforeHeader?: boolean;
     } = {},
   ) {}
 
@@ -2605,6 +2466,14 @@ class TinyAgentRunStore implements AgentRunStore, RuntimeEventStore {
     runId: string,
     patch: Partial<AgentRunHeader>,
   ): Promise<AgentRunHeader> {
+    if (
+      this.options.requireTerminalFactBeforeHeader &&
+      patch.status !== undefined &&
+      patch.status !== 'running' &&
+      !(this.runtimeEvents.get(key(sessionId, runId)) ?? []).some(isTerminalRuntimeEvent)
+    ) {
+      throw new Error('terminal run header committed before terminal RuntimeEvent');
+    }
     const current = await this.readRun(sessionId, runId);
     const next = { ...current, ...patch, sessionId, runId };
     this.headers.set(key(sessionId, runId), clone(next));

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -5477,7 +5477,11 @@ describe('SessionManager permission mode updates', () => {
     const runtimeEventStore = new MemoryRuntimeEventStore();
     const backends = new BackendRegistry();
     const observed: InvocationResult[] = [];
-    backends.register('fake', (ctx) => new FinalTextTestBackend(ctx));
+    let backend: FinalTextTestBackend | undefined;
+    backends.register('fake', (ctx) => {
+      backend = new FinalTextTestBackend(ctx);
+      return backend;
+    });
     const manager = new SessionManager({
       store,
       runStore,
@@ -5493,11 +5497,16 @@ describe('SessionManager permission mode updates', () => {
     const session = await manager.createSession(makeInput());
 
     const sessionEvents = await collectSessionEvents(
-      manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hello' }),
+      manager.sendMessage(session.id, {
+        turnId: 'turn-1',
+        text: 'hello',
+        toolMode: 'code_mode',
+      }),
     );
 
     expect(sessionEvents.map((event) => event.type)).toEqual(['text_complete', 'complete']);
     expect(sessionEvents.map((event) => event.id)).toEqual(['turn-1-final', 'turn-1-complete']);
+    expect(backend?.sendInputs[0]?.toolMode).toBe('code_mode');
     expect(observed.length).toBe(1);
 
     const [run] = await runStore.listSessionRuns(session.id);

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -61,8 +61,6 @@ import {
   buildSyntheticTerminalRuntimeEvent,
   commitOrCreateTerminalRunFact,
 } from './terminal-run-commit.js';
-import { AiSdkFlow } from './ai-sdk-flow.js';
-import type { InvocationContext } from './invocation-context.js';
 import { buildInitialUserRuntimeEvent } from './runtime-runner.js';
 import type { RuntimeContinuation } from './runtime-resume.js';
 import {
@@ -597,85 +595,6 @@ export class AgentRun {
         },
       });
     });
-  }
-
-  async *execute(): AsyncIterable<SessionEvent> {
-    try {
-      const begin = await this.begin();
-      const invocationId = begin.initialRuntimeEvent.invocationId;
-      const source = 'desktop' as const;
-      const request: InvocationContext['request'] = {
-        sessionId: this.sessionId,
-        invocationId,
-        runId: this.runId,
-        turnId: this.turnId,
-        orchestration: this.effectiveOrchestration,
-        toolMode: this.toolMode,
-        ...(this.input.userInput.maxSteps !== undefined
-          ? { maxSteps: this.input.userInput.maxSteps }
-          : {}),
-        text: this.input.userInput.text,
-        ...(this.input.userInput.attachments
-          ? { attachments: this.input.userInput.attachments }
-          : {}),
-        ...(this.input.userInput.quotes ? { quotes: this.input.userInput.quotes } : {}),
-        ...(this.input.userInput.inlineReferences
-          ? { inlineReferences: this.input.userInput.inlineReferences }
-          : {}),
-        context: begin.backendInput.context,
-        ...(begin.backendInput.runtimeContext
-          ? { runtimeContext: begin.backendInput.runtimeContext }
-          : {}),
-        initialRuntimeEvent: begin.initialRuntimeEvent,
-        source,
-        lineage: this.lineage,
-      };
-      const ctx: InvocationContext = {
-        sessionId: this.sessionId,
-        invocationId,
-        runId: this.runId,
-        turnId: this.turnId,
-        source,
-        startedAt: begin.initialRuntimeEvent.ts,
-        request,
-        newId: this.input.newId,
-        now: this.input.now,
-      };
-      let acceptedSessionEvent: SessionEvent | undefined;
-      const flow = new AiSdkFlow({
-        backend: begin.backend,
-        drainAfterTerminal: true,
-        onSessionEvent: async (sessionEvent, runtimeEvent) => {
-          await this.acceptMappedEvent(sessionEvent, runtimeEvent);
-          acceptedSessionEvent = sessionEvent;
-        },
-      });
-      for await (const _runtimeEvent of flow.run(ctx, {
-        text: begin.backendInput.text,
-        ...(begin.backendInput.toolMode !== undefined
-          ? { toolMode: begin.backendInput.toolMode }
-          : {}),
-        ...(begin.backendInput.maxSteps !== undefined
-          ? { maxSteps: begin.backendInput.maxSteps }
-          : {}),
-        ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
-        ...(begin.backendInput.quotes ? { quotes: begin.backendInput.quotes } : {}),
-        context: begin.backendInput.context,
-        ...(begin.backendInput.runtimeContext
-          ? { runtimeContext: begin.backendInput.runtimeContext }
-          : {}),
-      })) {
-        if (acceptedSessionEvent) {
-          yield acceptedSessionEvent;
-          acceptedSessionEvent = undefined;
-        }
-      }
-    } catch (error) {
-      await this.recordFailure(error);
-      throw error;
-    } finally {
-      await this.finalize();
-    }
   }
 
   async acceptMappedEvent(


### PR DESCRIPTION
## Summary

- Remove `AgentRun.execute()`, an unused test-only path that reconstructed `AiSdkFlow` outside `RuntimeKernel`.
- Keep `RuntimeKernel` as the sole production execution authority.
- Preserve projection-failure and normal tool-mode coverage at their production boundaries while removing duplicate and ineffective test guards.

Fixes #3034

## Verification

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/runtime run build`
- `node --test dist/__tests__/session-manager-terminal-ledger.test.js` — 39 passed
- `node --test dist/__tests__/session-manager.test.js` — 220 passed
- `npm --workspace @maka/runtime run typecheck`
- `npx biome check packages/runtime/src/agent-run.ts packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts packages/runtime/src/__tests__/session-manager.test.ts`

The branch was rebased onto the latest `main` before running these checks. The full repository test suite was not run locally; repository-wide coverage is left to CI.

## Review focus

Confirm that removing the internal parallel execution path leaves `RuntimeKernel` as the single execution authority and that the remaining tests cover production seams without duplicate fixtures. `AgentRun` is not exported by the private `@maka/runtime` package, so this does not change a public contract.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the code and test changes, performed focused verification, and adjudicated review feedback. Claude Opus High and a Codex reviewer agent performed adversarial reviews of the implementation and test coverage. The human contributor of record reviews the final diff and commits and owns the submission, provenance, licensing, and merge decision.

## Checklist

- [ ] Tests cover the change and fail without it — the production change is deletion of an unused path; retained behavior is covered through production execution seams rather than by preserving a test-only caller.
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No