### PR TITLE
refactor(runtime-host): specialize composition to interactive roots

### DIFF
--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -54,6 +54,9 @@ import {
   type InteractiveRuntimeHostCandidateResult,
   type RuntimeHostComposition,
   type RuntimeHostCompositionContext,
+  type RuntimeHostCompositionFactory,
+  type RuntimeHostCompositionSource,
+  type RuntimeHostKernelOptions,
 } from '../server/index.js';
 import { createUnavailableDomainOperationHandlers } from '../server/operation-dispatcher.js';
 import { HostConfigurationChangeService } from '../server/configuration-change-service.js';
@@ -66,6 +69,7 @@ import {
   STORAGE_ROOT_MARKER_FILE,
   StorageRootAuthorityError,
   tryAcquireInteractiveRootOwner,
+  type InteractiveRootOwner,
   type StorageRootCapability,
 } from '@maka/storage/root-authority';
 import { bindStateRootComposition } from '@maka/storage/state-root-composition';
@@ -84,6 +88,28 @@ const KERNEL_COMPOSITION = defineInteractiveRuntimeHostComposition(async () => (
 }));
 const require = createRequire(import.meta.url);
 const execFileAsync = promisify(execFile);
+
+type IsExact<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <Value>() => Value extends Right ? 1 : 2
+    ? (<Value>() => Value extends Right ? 1 : 2) extends <Value>() => Value extends Left ? 1 : 2
+      ? true
+      : false
+    : false;
+type AssertTrue<Value extends true> = Value;
+
+export type RuntimeHostInteractiveRootTypeContract = [
+  AssertTrue<IsExact<RuntimeHostCompositionContext['owner'], InteractiveRootOwner>>,
+  AssertTrue<IsExact<RuntimeHostKernelOptions['owner'], InteractiveRootOwner>>,
+];
+
+// @ts-expect-error Runtime Host composition contexts are concretely interactive.
+export type GenericRuntimeHostCompositionContext = RuntimeHostCompositionContext<'interactive'>;
+// @ts-expect-error Runtime Host composition factories are concretely interactive.
+export type GenericRuntimeHostCompositionFactory = RuntimeHostCompositionFactory<'interactive'>;
+// @ts-expect-error Runtime Host composition sources are concretely interactive.
+export type GenericRuntimeHostCompositionSource = RuntimeHostCompositionSource<'interactive'>;
+// @ts-expect-error Runtime Host kernel options are concretely interactive.
+export type GenericRuntimeHostKernelOptions = RuntimeHostKernelOptions<'interactive'>;
 
 describe('non-serving Runtime Host kernel', () => {
   test('reports a recovery failure when the election produces no ready Host', async () => {

--- a/packages/runtime-host/src/server/candidate.ts
+++ b/packages/runtime-host/src/server/candidate.ts
@@ -17,7 +17,7 @@ export type InteractiveRuntimeHostCandidateResult =
 
 export async function startInteractiveRuntimeHostCandidate(
   options: InteractiveRuntimeHostCandidateOptions,
-  composition: RuntimeHostCompositionSource<'interactive'>,
+  composition: RuntimeHostCompositionSource,
 ): Promise<InteractiveRuntimeHostCandidateResult> {
   const capability = await resolveExistingStorageRoot({
     path: options.rootPath,

--- a/packages/runtime-host/src/server/execution-composition-factory.ts
+++ b/packages/runtime-host/src/server/execution-composition-factory.ts
@@ -17,7 +17,7 @@ export interface ExecutionRuntimeHostCompositionSourceOptions {
 
 export interface ExecutionRuntimeHostCompositionDependencies {
   readonly createComposition?: (
-    context: RuntimeHostCompositionContext<'interactive'>,
+    context: RuntimeHostCompositionContext,
     options: Parameters<typeof createExecutionRuntimeHostComposition>[1],
   ) => Promise<ExecutionRuntimeHostComposition>;
 }
@@ -25,7 +25,7 @@ export interface ExecutionRuntimeHostCompositionDependencies {
 export async function createExecutionRuntimeHostCompositionSource(
   options: ExecutionRuntimeHostCompositionSourceOptions,
   dependencies: ExecutionRuntimeHostCompositionDependencies = {},
-): Promise<RuntimeHostCompositionSource<'interactive'>> {
+): Promise<RuntimeHostCompositionSource> {
   if (options.managedWorkspaceGitRuntime && options.bundledGitResourcesRoot) {
     throw new Error('Managed workspace Git runtime must have exactly one authority');
   }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -197,7 +197,7 @@ export function runtimeHostFilesystemWorkerRuntime(versions: {
 }
 
 export async function createExecutionRuntimeHostComposition(
-  context: RuntimeHostCompositionContext<'interactive'>,
+  context: RuntimeHostCompositionContext,
   options: CreateExecutionRuntimeHostCompositionOptions = {},
   dependencies: ExecutionRuntimeHostCompositionDependencies = {},
 ): Promise<ExecutionRuntimeHostComposition> {

--- a/packages/runtime-host/src/server/host-composition.ts
+++ b/packages/runtime-host/src/server/host-composition.ts
@@ -1,4 +1,3 @@
-import type { StorageRootKind } from '@maka/storage/root-authority';
 import type { RuntimeHostCompositionFactory } from './host-kernel.js';
 import { INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID } from '../protocol/index.js';
 import {
@@ -199,15 +198,15 @@ async function closeModuleResources(
   }
 }
 
-export interface RuntimeHostCompositionSource<K extends StorageRootKind = 'interactive'> {
+export interface RuntimeHostCompositionSource {
   readonly descriptor: HostCompositionDescriptor;
-  readonly create: RuntimeHostCompositionFactory<K>;
+  readonly create: RuntimeHostCompositionFactory;
 }
 
-export function defineRuntimeHostComposition<K extends StorageRootKind>(
+export function defineRuntimeHostComposition(
   descriptor: HostCompositionDescriptor,
-  create: RuntimeHostCompositionFactory<K>,
-): RuntimeHostCompositionSource<K> {
+  create: RuntimeHostCompositionFactory,
+): RuntimeHostCompositionSource {
   return Object.freeze({
     descriptor: normalizeHostCompositionDescriptor(descriptor),
     create,
@@ -215,8 +214,8 @@ export function defineRuntimeHostComposition<K extends StorageRootKind>(
 }
 
 export function defineInteractiveRuntimeHostComposition(
-  create: RuntimeHostCompositionFactory<'interactive'>,
-): RuntimeHostCompositionSource<'interactive'> {
+  create: RuntimeHostCompositionFactory,
+): RuntimeHostCompositionSource {
   return defineRuntimeHostComposition(INTERACTIVE_HOST_COMPOSITION_DESCRIPTOR, create);
 }
 

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -1,10 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { arch as osArch, release as osRelease } from 'node:os';
 import {
-  assertStateRootOwner,
-  authenticateStateRootOwner,
-  type StateRootOwner,
-  type StorageRootKind,
+  assertInteractiveRootOwner,
+  authenticateInteractiveRootOwner,
+  type InteractiveRootOwner,
 } from '@maka/storage/root-authority';
 import { bindStateRootComposition } from '@maka/storage/state-root-composition';
 import { removeHostRegistration, writeHostRegistration } from '../control/registration.js';
@@ -84,8 +83,8 @@ export class RuntimeHostProcessTerminationRequiredError extends Error {
   }
 }
 
-export interface RuntimeHostCompositionContext<K extends StorageRootKind = 'interactive'> {
-  owner: StateRootOwner<K>;
+export interface RuntimeHostCompositionContext {
+  owner: InteractiveRootOwner;
   hostEpoch: string;
   acquireResidency(label: string): RuntimeHostResidency;
   /** Irreversible fail-stop latch; normal residency still uses acquireResidency(). */
@@ -110,39 +109,36 @@ export interface RuntimeHostComposition {
   close(): Promise<void>;
 }
 
-export type RuntimeHostCompositionFactory<K extends StorageRootKind = 'interactive'> = (
-  context: RuntimeHostCompositionContext<K>,
+export type RuntimeHostCompositionFactory = (
+  context: RuntimeHostCompositionContext,
 ) => Promise<RuntimeHostComposition>;
 
-interface RuntimeHostKernelCommonOptions<K extends StorageRootKind> {
-  owner: StateRootOwner<K>;
+interface RuntimeHostKernelCommonOptions {
+  owner: InteractiveRootOwner;
   handshakeTimeoutMs?: number;
   shutdownGraceMs?: number;
-  composition: RuntimeHostCompositionSource<K>;
+  composition: RuntimeHostCompositionSource;
   listenerSetFactory?: RuntimeHostListenerSetFactory;
   accessAuthority?: RuntimeHostAccessAuthority;
 }
 
 export type RuntimeHostLifecycleMode = 'ephemeral' | 'service';
 
-export type RuntimeHostKernelOptions<K extends StorageRootKind = 'interactive'> =
-  RuntimeHostKernelCommonOptions<K> &
-    (
-      | {
-          lifecycleMode?: 'ephemeral';
-          initialConnectionTimeoutMs?: number;
-          idleGraceMs?: number;
-          generation?: string;
-        }
-      | {
-          lifecycleMode: 'service';
-          initialConnectionTimeoutMs?: never;
-          idleGraceMs?: never;
-          generation?: never;
-        }
-    );
-
-type RuntimeHostKernelInternalOptions = RuntimeHostKernelOptions<StorageRootKind>;
+export type RuntimeHostKernelOptions = RuntimeHostKernelCommonOptions &
+  (
+    | {
+        lifecycleMode?: 'ephemeral';
+        initialConnectionTimeoutMs?: number;
+        idleGraceMs?: number;
+        generation?: string;
+      }
+    | {
+        lifecycleMode: 'service';
+        initialConnectionTimeoutMs?: never;
+        idleGraceMs?: never;
+        generation?: never;
+      }
+  );
 
 type RuntimeHostLifecycle =
   | {
@@ -155,7 +151,7 @@ type RuntimeHostLifecycle =
 export class RuntimeHostKernel {
   readonly hostEpoch = randomUUID();
   readonly closed: Promise<void>;
-  readonly #options: RuntimeHostKernelInternalOptions;
+  readonly #options: RuntimeHostKernelOptions;
   readonly #createdAt = new Date().toISOString();
   readonly #handshakingTransports = new Set<RuntimeHostMessageTransport>();
   readonly #acceptedTransports = new Set<RuntimeHostMessageTransport>();
@@ -188,7 +184,7 @@ export class RuntimeHostKernel {
   #rejectClosed!: (error: unknown) => void;
   readonly #unsubscribeAccessRevocations: (() => void) | undefined;
 
-  private constructor(options: RuntimeHostKernelInternalOptions) {
+  private constructor(options: RuntimeHostKernelOptions) {
     this.#lifecycle = normalizeLifecycle(options);
     if (options.generation !== undefined) requireHostGeneration(options.generation);
     assertDuration(
@@ -212,13 +208,11 @@ export class RuntimeHostKernel {
     });
   }
 
-  static async start<K extends StorageRootKind>(
-    options: RuntimeHostKernelOptions<K>,
-  ): Promise<RuntimeHostKernel> {
-    const owner = authenticateStateRootOwner(options.owner, options.owner.capability.kind);
+  static async start(options: RuntimeHostKernelOptions): Promise<RuntimeHostKernel> {
+    const owner = authenticateInteractiveRootOwner(options.owner);
     let host: RuntimeHostKernel | undefined;
     try {
-      host = new RuntimeHostKernel(eraseRootKind(options, owner));
+      host = new RuntimeHostKernel(options);
       await host.#start();
       return host;
     } catch (error) {
@@ -285,7 +279,7 @@ export class RuntimeHostKernel {
   }
 
   async #start(): Promise<void> {
-    await assertStateRootOwner(this.#options.owner, this.#options.owner.capability.kind);
+    await assertInteractiveRootOwner(this.#options.owner);
     await bindStateRootComposition(this.#options.owner.lease, this.compositionDescriptor.id);
     this.#listeners = await (this.#options.listenerSetFactory ?? startLocalRuntimeHostListenerSet)({
       rootId: this.#options.owner.capability.rootId,
@@ -530,7 +524,7 @@ export class RuntimeHostKernel {
   async #hasLiveOwnerOrDrain(): Promise<boolean> {
     if (this.#isDraining()) return false;
     try {
-      await assertStateRootOwner(this.#options.owner, this.#options.owner.capability.kind);
+      await assertInteractiveRootOwner(this.#options.owner);
     } catch {
       void this.#commitShutdown().catch(() => undefined);
       return false;
@@ -888,9 +882,7 @@ function assertDuration(value: number, label: string, minimum: 0 | 1): void {
   }
 }
 
-function normalizeLifecycle<K extends StorageRootKind>(
-  options: RuntimeHostKernelOptions<K>,
-): RuntimeHostLifecycle {
+function normalizeLifecycle(options: RuntimeHostKernelOptions): RuntimeHostLifecycle {
   const lifecycleMode: unknown = options.lifecycleMode;
   if (lifecycleMode === 'service') {
     if (
@@ -909,19 +901,4 @@ function normalizeLifecycle<K extends StorageRootKind>(
   assertDuration(initialConnectionTimeoutMs, 'initialConnectionTimeoutMs', 0);
   assertDuration(idleGraceMs, 'idleGraceMs', 0);
   return { kind: 'ephemeral', initialConnectionTimeoutMs, idleGraceMs };
-}
-
-function eraseRootKind<K extends StorageRootKind>(
-  options: RuntimeHostKernelOptions<K>,
-  owner: StateRootOwner<K>,
-): RuntimeHostKernelInternalOptions {
-  return {
-    ...options,
-    owner,
-    composition: {
-      descriptor: options.composition.descriptor,
-      create: (context: RuntimeHostCompositionContext<StorageRootKind>) =>
-        options.composition.create({ ...context, owner }),
-    },
-  };
 }


### PR DESCRIPTION
## Summary

Specialize Runtime Host composition and kernel APIs to interactive storage roots.

This removes the unused `StorageRootKind` generic parameters and the `eraseRootKind()` adapter while preserving existing storage-root authentication, ownership, locking, lease, and lifecycle behavior.

Closes #3037

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `node --test packages/runtime-host/dist/__tests__/host-kernel.test.js` — 42 passed
- `npm --workspace @maka/runtime-host run test:dist` — 933 passed

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No