### PR TITLE
fix(desktop): settle catch-up text before remounting a live conversation

### DIFF
--- a/apps/desktop/src/main/__tests__/live-content-seed.test.ts
+++ b/apps/desktop/src/main/__tests__/live-content-seed.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  EMPTY_LIVE_CONTENT_SEED,
+  beginLiveContentSeed,
+  completeLiveContentSeed,
+  liveContentSeedRevision,
+} from '../../renderer/live-content-seed.js';
+
+test('withholds live content until the current observation generation is ready', () => {
+  const first = beginLiveContentSeed(EMPTY_LIVE_CONTENT_SEED, 'session-a');
+  assert.equal(liveContentSeedRevision(first, 'session-a'), 0);
+
+  const ready = completeLiveContentSeed(first, 'session-a', first.generation);
+  assert.equal(liveContentSeedRevision(ready, 'session-a'), first.generation);
+  assert.equal(liveContentSeedRevision(ready, 'session-b'), 0);
+});
+
+test('A → B → A does not reuse the previous ready generation', () => {
+  const firstReady = completeLiveContentSeed(
+    beginLiveContentSeed(EMPTY_LIVE_CONTENT_SEED, 'session-a'),
+    'session-a',
+    1,
+  );
+  assert.equal(liveContentSeedRevision(firstReady, 'session-a'), 1);
+
+  const pendingB = beginLiveContentSeed(firstReady, 'session-b');
+  assert.equal(liveContentSeedRevision(pendingB, 'session-b'), 0);
+  assert.equal(liveContentSeedRevision(pendingB, 'session-a'), 0);
+
+  const pendingA = beginLiveContentSeed(pendingB, 'session-a');
+  assert.equal(pendingA.generation, 3);
+  assert.equal(liveContentSeedRevision(pendingA, 'session-a'), 0);
+
+  const staleFirstSeed = completeLiveContentSeed(pendingA, 'session-a', 1);
+  assert.equal(staleFirstSeed, pendingA);
+  assert.equal(liveContentSeedRevision(staleFirstSeed, 'session-a'), 0);
+
+  const recovered = completeLiveContentSeed(pendingA, 'session-a', pendingA.generation);
+  assert.equal(liveContentSeedRevision(recovered, 'session-a'), 3);
+});
+
+test('a recovery generation only exposes live content after that generation completes', () => {
+  const firstReady = completeLiveContentSeed(
+    beginLiveContentSeed(EMPTY_LIVE_CONTENT_SEED, 'session-a'),
+    'session-a',
+    1,
+  );
+  const recovering = beginLiveContentSeed(firstReady, 'session-a');
+  assert.equal(liveContentSeedRevision(recovering, 'session-a'), 0);
+
+  const stale = completeLiveContentSeed(recovering, 'session-a', firstReady.generation);
+  assert.equal(liveContentSeedRevision(stale, 'session-a'), 0);
+
+  const ready = completeLiveContentSeed(recovering, 'session-a', recovering.generation);
+  assert.equal(liveContentSeedRevision(ready, 'session-a'), 2);
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -514,10 +514,14 @@ test('resyncs Goal, exact interaction, and sidecar state after candidate replace
   );
   assert.ok(seedPendingAt >= 0);
   assert.ok(seedReadyAt > seedPendingAt);
+  const sessionEventIndexes = resyncs.flatMap(({ channel }, index) =>
+    channel === 'sessions:event:session-1' ? [index] : [],
+  );
+  assert.ok(sessionEventIndexes.length > 0);
   assert.ok(
-    resyncs
-      .slice(seedPendingAt + 1, seedReadyAt)
-      .some(({ channel }) => channel === 'sessions:event:session-1'),
+    sessionEventIndexes.every(
+      (index) => index > seedPendingAt && index < seedReadyAt,
+    ),
   );
   assert.ok(
     resyncs.some(
@@ -653,12 +657,16 @@ test('retries candidate startup when a restored observation cannot seed', async 
       && (payload as { phase?: unknown }).phase === 'ready',
   );
   assert.ok(pendingAt >= 0);
-  assert.ok(
-    seedEvents
-      .slice(pendingAt + 1, readyAt)
-      .some(({ channel }) => channel === 'sessions:event:session-1'),
-  );
   assert.ok(readyAt > pendingAt);
+  const catchUpEventIndexes = seedEvents.flatMap(({ channel }, index) =>
+    channel === 'sessions:event:session-1' ? [index] : [],
+  );
+  assert.ok(catchUpEventIndexes.length > 0);
+  assert.ok(
+    catchUpEventIndexes.every(
+      (index) => index > pendingAt && index < readyAt,
+    ),
+  );
   await recoveredCandidate.close();
   await observations.close();
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -10,6 +10,7 @@ import type {
   ClientCapabilityCallFrame,
   OperationInput,
   OperationKey,
+  SessionAssistantStreamIdentity,
   SessionCatalogProjection,
   SessionContinuitySnapshot,
   SubscriptionFrame,
@@ -435,7 +436,10 @@ test('does not release or report a Revision the Host retained during cleanup', a
 test('resyncs Goal, exact interaction, and sidecar state after candidate replacement', async () => {
   const ref = 'maka://runtime/background-tasks/shell-1';
   const observations = new RuntimeHostSessionObservationRegistry();
-  const firstIpc = ipcHarness();
+  const resyncs: Array<{ channel: string; payload: unknown }> = [];
+  const firstIpc = ipcHarness((channel, payload) => {
+    resyncs.push({ channel, payload });
+  });
   const firstHost = connectionHarness('first-observer', {
     subscriptionSnapshot: continuitySnapshot({
       interactions: { pending: [pendingQuestion()] },
@@ -465,13 +469,14 @@ test('resyncs Goal, exact interaction, and sidecar state after candidate replace
     'before replacement',
   );
   await firstCandidate.close();
+  resyncs.length = 0;
 
   const secondIpc = ipcHarness();
-  const resyncs: Array<{ channel: string; payload: unknown }> = [];
   const sessionChanges: Array<{ reason: string; sessionId?: string }> = [];
   let terminalReattach: Promise<unknown> | undefined;
   const secondHost = connectionHarness('second-observer', {
     subscriptionSnapshot: continuitySnapshot({ interactions: { pending: [] } }),
+    activeAssistantStreams: [activeText('message-1')],
     runtimeResourcePty: ptySnapshot(ref, 'after replacement'),
   });
   const secondCandidate = await createDesktopRuntimeHostCandidate(
@@ -509,6 +514,11 @@ test('resyncs Goal, exact interaction, and sidecar state after candidate replace
   );
   assert.ok(seedPendingAt >= 0);
   assert.ok(seedReadyAt > seedPendingAt);
+  assert.ok(
+    resyncs
+      .slice(seedPendingAt + 1, seedReadyAt)
+      .some(({ channel }) => channel === 'sessions:event:session-1'),
+  );
   assert.ok(
     resyncs.some(
       ({ channel, payload }) =>
@@ -568,9 +578,94 @@ test('resyncs Goal, exact interaction, and sidecar state after candidate replace
   await observations.close();
 });
 
+test('retries candidate startup when a restored observation cannot seed', async () => {
+  const observations = new RuntimeHostSessionObservationRegistry();
+  const seedEvents: Array<{ channel: string; payload: unknown }> = [];
+  const firstIpc = ipcHarness((channel, payload) => {
+    seedEvents.push({ channel, payload });
+  });
+  const firstHost = connectionHarness('restore-source', {
+    sessionId: 'session-1',
+    subscriptionSnapshot: continuitySnapshot(),
+  });
+  const firstCandidate = await createDesktopRuntimeHostCandidate(
+    firstHost.connection,
+    deps(firstIpc),
+    observations,
+  );
+  await firstIpc.invoke('sessions:observe', 'session-1', 'observer-1');
+  await firstCandidate.close();
+  seedEvents.length = 0;
+
+  const failingHost = connectionHarness('restore-failure', {
+    sessionId: 'session-1',
+    subscriptionError: new Error('restore failed'),
+  });
+  await assert.rejects(
+    () =>
+      createDesktopRuntimeHostCandidate(
+        failingHost.connection,
+        {
+          ...deps(ipcHarness()),
+          renderer: {
+            send(channel, _host, payload) {
+              seedEvents.push({ channel, payload });
+            },
+          },
+        },
+        observations,
+      ),
+    /Failed to restore Session observations: session-1/,
+  );
+  assert.deepEqual(
+    seedEvents
+      .filter(({ channel }) => channel === 'sessions:observation-seed')
+      .map(({ payload }) => (payload as { phase?: unknown }).phase),
+    ['pending'],
+  );
+  seedEvents.length = 0;
+
+  const recoveredHost = connectionHarness('restore-recovered', {
+    sessionId: 'session-1',
+    subscriptionSnapshot: continuitySnapshot(),
+    activeAssistantStreams: [activeText('message-1')],
+  });
+  const recoveredCandidate = await createDesktopRuntimeHostCandidate(
+    recoveredHost.connection,
+    {
+      ...deps(ipcHarness()),
+      renderer: {
+        send(channel, _host, payload) {
+          seedEvents.push({ channel, payload });
+        },
+      },
+    },
+    observations,
+  );
+  const pendingAt = seedEvents.findIndex(
+    ({ channel, payload }) =>
+      channel === 'sessions:observation-seed'
+      && (payload as { phase?: unknown }).phase === 'pending',
+  );
+  const readyAt = seedEvents.findIndex(
+    ({ channel, payload }) =>
+      channel === 'sessions:observation-seed'
+      && (payload as { phase?: unknown }).phase === 'ready',
+  );
+  assert.ok(pendingAt >= 0);
+  assert.ok(
+    seedEvents
+      .slice(pendingAt + 1, readyAt)
+      .some(({ channel }) => channel === 'sessions:event:session-1'),
+  );
+  assert.ok(readyAt > pendingAt);
+  await recoveredCandidate.close();
+  await observations.close();
+});
+
 type IpcHandler = Parameters<Pick<IpcMain, 'handle'>['handle']>[1];
 
-function ipcHarness() {
+function ipcHarness(onSend?: (channel: string, payload: unknown) => void) {
   const handlers = new Map<string, IpcHandler>();
   let epoch = TEST_TARGET_EPOCH;
   const sender = Object.assign(new EventEmitter(), {
@@ -578,11 +673,13 @@ function ipcHarness() {
     sent: [] as Array<{ channel: string; hostId?: string; payload: unknown }>,
     send(channel: string, ...args: unknown[]): void {
       const hostId = (args[0] as { hostId?: unknown } | undefined)?.hostId;
+      const payload = args.at(-1);
       sender.sent.push({
         channel,
         ...(typeof hostId === 'string' ? { hostId } : {}),
-        payload: args.at(-1),
+        payload,
       });
+      onSend?.(channel, payload);
     },
   });
   return {
@@ -682,6 +779,8 @@ function connectionHarness(
     sessionId?: string;
     revisionAbandon?: 'abandoned' | 'retained';
     subscriptionSnapshot?: SessionContinuitySnapshot;
+    activeAssistantStreams?: readonly SessionAssistantStreamIdentity[];
+    subscriptionError?: Error;
     runtimeResourcePty?: ReturnType<typeof ptySnapshot>;
   } = {},
 ) {
@@ -791,6 +890,7 @@ function connectionHarness(
       throw new Error(`Unexpected operation: ${operation}`);
     },
     openSessionSubscription: async ({ sessionId }: { sessionId: string }) => {
+      if (options.subscriptionError) throw options.subscriptionError;
       const subscriptionFrames = new AsyncFrameQueue();
       activeSubscriptionFrames = subscriptionFrames;
       const closeSubscription = () => subscriptionFrames.end();
@@ -812,7 +912,7 @@ function connectionHarness(
           projectionRevision: 1,
           session: { sessionId },
         },
-        activeAssistantStreams: [],
+        activeAssistantStreams: options.activeAssistantStreams ?? [],
         transcriptBootstrap: {
           throughSequence: null,
           overlayMessageCount: 0,
@@ -906,6 +1006,10 @@ function continuitySnapshot(
     interactions: { pending: [] },
     ...overrides,
   };
+}
+
+function activeText(messageId: string): SessionAssistantStreamIdentity {
+  return { kind: 'text', turnId: 'turn-1', messageId };
 }
 
 function pendingQuestion() {

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -495,6 +495,20 @@ test('resyncs Goal, exact interaction, and sidecar state after candidate replace
     observations,
   );
 
+  const seedPendingAt = resyncs.findIndex(
+    ({ channel, payload }) =>
+      channel === 'sessions:observation-seed'
+      && (payload as { sessionId?: unknown; phase?: unknown }).sessionId === 'session-1'
+      && (payload as { phase?: unknown }).phase === 'pending',
+  );
+  const seedReadyAt = resyncs.findIndex(
+    ({ channel, payload }) =>
+      channel === 'sessions:observation-seed'
+      && (payload as { sessionId?: unknown; phase?: unknown }).sessionId === 'session-1'
+      && (payload as { phase?: unknown }).phase === 'ready',
+  );
+  assert.ok(seedPendingAt >= 0);
+  assert.ok(seedReadyAt > seedPendingAt);
   assert.ok(
     resyncs.some(
       ({ channel, payload }) =>

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -1040,6 +1040,7 @@ test("ignores a stale seed failure after its replacement succeeds", async () => 
   assert.deepEqual(await attaching, ["session-1"]);
   await observing;
   assert.equal(ready, true);
+  assert.deepEqual(observations.observedSessionIds(), ["session-1"]);
   await observations.close();
 });
 
@@ -1779,6 +1780,7 @@ test("reconciles terminal, Goal, interaction, and sidecar state after subscripti
   const finishedTurns: Array<[string, "completed" | "abandoned"]> = [];
   const interactionSnapshots: Array<readonly { requestId: string }[]> = [];
   const recoveredSessions: string[] = [];
+  const seedTimeline: string[] = [];
   const sessionChanges: string[] = [];
   const firstInteraction = pendingQuestion("interaction-1", "turn-1", "run-1");
   const secondInteraction = pendingQuestion("interaction-2", "turn-2", "run-2");
@@ -1848,9 +1850,17 @@ test("reconciles terminal, Goal, interaction, and sidecar state after subscripti
     emitSubscriptionRecovered: (sessionId) => {
       recoveredSessions.push(sessionId);
     },
+    emitObservationSeed: (sessionId, phase) => {
+      seedTimeline.push(`${phase}:${sessionId}`);
+    },
     now: () => 50,
   });
   const target = eventTarget(15);
+  const originalSend = target.send.bind(target);
+  target.send = (channel, event) => {
+    seedTimeline.push(`event:${event.type}`);
+    originalSend(channel, event);
+  };
   await observer.observe("session-1", "observer-1", target);
   await observer.watchTurn("session-1", "turn-1");
 
@@ -1865,6 +1875,13 @@ test("reconciles terminal, Goal, interaction, and sidecar state after subscripti
 
   assert.deepEqual(finishedTurns, [["session-1", "completed"]]);
   assert.deepEqual(recoveredSessions, ["session-1"]);
+  const pendingAt = seedTimeline.indexOf("pending:session-1");
+  const readyAt = seedTimeline.indexOf("ready:session-1");
+  assert.ok(pendingAt >= 0);
+  assert.ok(readyAt > pendingAt);
+  assert.ok(
+    seedTimeline.slice(pendingAt + 1, readyAt).some((entry) => entry.startsWith("event:")),
+  );
   assert.ok(sessionChanges.includes("goal-change"));
   assert.deepEqual(
     interactionSnapshots.at(-1)?.map((interaction) => interaction.requestId),

--- a/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
+++ b/apps/desktop/src/main/__tests__/streaming-handoff.test.ts
@@ -252,6 +252,68 @@ describe('single live-turn handoff', () => {
     assert.equal(publications, 2);
   });
 
+  it('applies catch-up deltas immediately until the returning session is seeded', () => {
+    const liveTurns = createStateSetter<Record<string, LiveTurnProjection>>({
+      'session-1': armLiveTurn('turn-1'),
+    });
+    const liveTurnBySessionRef = { current: liveTurns.get() };
+    const interactions = createStateSetter<InteractionQueues>({});
+    const frames: Array<() => void> = [];
+    let publications = 0;
+    const handlers = createAppShellSessionEventHandlers({
+      uiLocale: 'zh',
+      activeIdRef: { current: 'session-1' },
+      liveTurnBySessionRef,
+      refreshMessages: async () => true,
+      refreshSessions: async () => [],
+      setLiveTurnBySession: (updater) => {
+        publications += 1;
+        liveTurns.set(updater);
+        liveTurnBySessionRef.current = liveTurns.get();
+      },
+      setInteractionBySession: interactions.set,
+      showModelSetupToast: () => {},
+      toastApi: { error: () => {} },
+      scheduleFrame: (callback) => { frames.push(callback); },
+    });
+
+    handlers.markDisplayPending('session-1');
+    handlers.handleEvent('session-1', {
+      type: 'text_delta',
+      id: 'seed',
+      turnId: 'turn-1',
+      messageId: 'assistant-1',
+      ts: 1,
+      startOffset: 0,
+      text: 'prefix accumulated while away',
+    });
+    assert.equal(publications, 1);
+    assert.equal(frames.length, 0);
+    assert.equal(
+      liveTurns.get()['session-1']?.steps[0]?.text?.text,
+      'prefix accumulated while away',
+    );
+
+    handlers.flushDisplayEvents('session-1');
+    handlers.markDisplayReady('session-1');
+    handlers.handleEvent('session-1', {
+      type: 'text_delta',
+      id: 'live',
+      turnId: 'turn-1',
+      messageId: 'assistant-1',
+      ts: 2,
+      text: ' new',
+    });
+    assert.equal(publications, 1);
+    assert.equal(frames.length, 1);
+    frames.shift()?.();
+    assert.equal(publications, 2);
+    assert.equal(
+      liveTurns.get()['session-1']?.steps[0]?.text?.text,
+      'prefix accumulated while away new',
+    );
+  });
+
   it('shares pending display events across handler replacement', () => {
     const liveTurns = createStateSetter<Record<string, LiveTurnProjection>>({
       'session-1': armLiveTurn('turn-1'),

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -440,6 +440,8 @@ export async function createDesktopRuntimeHostCandidate(
       emitActiveInteractionsChanged,
       emitSubscriptionRecovered: (sessionId) =>
         domains?.sessionSubscriptionRecovered(sessionId),
+      emitObservationSeed: (sessionId, phase) =>
+        sendToRenderer?.('sessions:observation-seed', { sessionId, phase }),
       onWatchedTurnFinished: (sessionId, outcome) =>
         outcome === "completed"
           ? deps.completeComputerUseTurn(
@@ -465,6 +467,9 @@ export async function createDesktopRuntimeHostCandidate(
       ipc,
     );
     closeSessionDomains = domains.close;
+    for (const sessionId of sessionObservations.observedSessionIds()) {
+      sendToRenderer('sessions:observation-seed', { sessionId, phase: 'pending' });
+    }
     const restoredSessionIds = await sessionObservations.attach(
       sessionObserver,
       (target) => ({
@@ -481,6 +486,7 @@ export async function createDesktopRuntimeHostCandidate(
     );
     observationsAttached = true;
     for (const sessionId of restoredSessionIds) {
+      sendToRenderer('sessions:observation-seed', { sessionId, phase: 'ready' });
       emitSessionsChanged("message-appended", sessionId);
       emitSessionsChanged("goal-change", sessionId);
       domains.sessionSubscriptionRecovered(sessionId);

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -467,9 +467,11 @@ export async function createDesktopRuntimeHostCandidate(
       ipc,
     );
     closeSessionDomains = domains.close;
-    for (const sessionId of sessionObservations.observedSessionIds()) {
+    const observedSessionIds = sessionObservations.observedSessionIds();
+    for (const sessionId of observedSessionIds) {
       sendToRenderer('sessions:observation-seed', { sessionId, phase: 'pending' });
     }
+    observationsAttached = true;
     const restoredSessionIds = await sessionObservations.attach(
       sessionObserver,
       (target) => ({
@@ -484,7 +486,15 @@ export async function createDesktopRuntimeHostCandidate(
         off: target.off.bind(target),
       }),
     );
-    observationsAttached = true;
+    const restoredSessionIdSet = new Set(restoredSessionIds);
+    const failedSessionIds = observedSessionIds.filter(
+      (sessionId) => !restoredSessionIdSet.has(sessionId),
+    );
+    if (failedSessionIds.length > 0) {
+      throw new Error(
+        `Failed to restore Session observations: ${failedSessionIds.join(', ')}`,
+      );
+    }
     for (const sessionId of restoredSessionIds) {
       sendToRenderer('sessions:observation-seed', { sessionId, phase: 'ready' });
       emitSessionsChanged("message-appended", sessionId);

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -184,6 +184,10 @@ export class RuntimeHostSessionObservationRegistry {
     return [...new Set(restored.filter((sessionId): sessionId is string => !!sessionId))];
   }
 
+  observedSessionIds(): string[] {
+    return [...new Set([...this.#registrations.values()].map((registration) => registration.sessionId))];
+  }
+
   detach(source: SessionObservationSource): void {
     if (this.#source === source) {
       this.#source = undefined;

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -76,6 +76,7 @@ export interface RuntimeHostSessionObserverDeps {
     interactions: readonly ActiveInteractionRequestEvent[],
   ) => void;
   emitSubscriptionRecovered?: (sessionId: string) => void;
+  emitObservationSeed?: (sessionId: string, phase: 'pending' | 'ready') => void;
   recoverConnectionClosed?: boolean;
   now?: () => number;
 }
@@ -180,6 +181,10 @@ export class RuntimeHostSessionObserver {
     interactions: readonly ActiveInteractionRequestEvent[],
   ) => void;
   readonly #emitSubscriptionRecovered: (sessionId: string) => void;
+  readonly #emitObservationSeed: (
+    sessionId: string,
+    phase: 'pending' | 'ready',
+  ) => void;
   readonly #recoverConnectionClosed: boolean;
   readonly #now: () => number;
   #closed = false;
@@ -201,6 +206,7 @@ export class RuntimeHostSessionObserver {
       deps.emitActiveInteractionsChanged ?? (() => undefined);
     this.#emitSubscriptionRecovered =
       deps.emitSubscriptionRecovered ?? (() => undefined);
+    this.#emitObservationSeed = deps.emitObservationSeed ?? (() => undefined);
     this.#recoverConnectionClosed = deps.recoverConnectionClosed ?? false;
     this.#now = deps.now ?? Date.now;
   }
@@ -805,6 +811,7 @@ export class RuntimeHostSessionObserver {
       this.#touchReplica(state);
 
       if (replacement) {
+        this.#emitObservationSeed(state.sessionId, 'pending');
         for (const event of replacement.terminalEvents) {
           this.#broadcast(state.sessionId, event);
         }
@@ -812,6 +819,7 @@ export class RuntimeHostSessionObserver {
           this.#broadcast(state.sessionId, event);
         }
         for (const group of state.targets.values()) group.seeded = true;
+        this.#emitObservationSeed(state.sessionId, 'ready');
         for (const turnId of replacement.terminalTurnIds) {
           this.#finishWatchedTurn(state, turnId, "completed");
           this.#emitSessionsChanged("turn-status-change", state.sessionId, {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -463,6 +463,7 @@ export interface MakaBridge {
       sessionId: string,
       handler: (event: SessionEvent) => void,
       onSeeded?: () => void,
+      onObservationSeed?: (phase: 'pending' | 'ready') => void,
     ): () => void;
     subscribeChanges(handler: (event: SessionChangedEvent) => void): () => void;
     archive(sessionId: string, options?: { revisionFamily?: boolean }): Promise<void>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -743,6 +743,7 @@ const makaBridge = {
       sessionId: string,
       handler: (event: SessionEvent) => void,
       onSeeded?: () => void,
+      onObservationSeed?: (phase: 'pending' | 'ready') => void,
     ): () => void {
       const channel = `sessions:event:${sessionId}`;
       const unsubscribeEvents = subscribeActiveRuntimeHostEvent(channel, handler);
@@ -753,8 +754,18 @@ const makaBridge = {
       }));
       const observing = observeDispatch.then(({ completion }) => completion);
       const disposeSeedNotification = notifyWhenSeeded(observing, onSeeded);
+      const unsubscribeObservationSeed = subscribeActiveRuntimeHostEvent(
+        'sessions:observation-seed',
+        (payload: { sessionId?: string; phase?: string }) => {
+          if (payload.sessionId !== sessionId) return;
+          if (payload.phase === 'pending' || payload.phase === 'ready') {
+            onObservationSeed?.(payload.phase);
+          }
+        },
+      );
       return () => {
         disposeSeedNotification();
+        unsubscribeObservationSeed();
         unsubscribeEvents();
         void releaseSessionObservation(observeDispatch, () =>
           ipcRenderer.invoke('sessions:unobserve', observerId),

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -420,6 +420,7 @@ export function useActiveSessionEvents(options: {
   activeIdRef: RefBox<string | undefined>;
   handleEvent: (sessionId: string, event: SessionEvent) => void;
   markSessionReadLocally: (sessionId: string, readMessages: readonly StoredMessage[]) => void;
+  markDisplayPending?: (sessionId: string) => void;
   onEventSeeded?: (sessionId: string) => void;
   setMessageLoadErrorBySession: (updater: (current: Record<string, string>) => Record<string, string>) => void;
   setMessageLoadPending: (pending: boolean) => void;
@@ -485,6 +486,7 @@ export function useActiveSessionEvents(options: {
 
   useLayoutEffect(() => {
     if (!activeId) return;
+    options.markDisplayPending?.(activeId);
     let disposed = false;
     const transcript = new DesktopTranscriptRangeStore();
     const subscribedAt = Date.now();

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -420,8 +420,8 @@ export function useActiveSessionEvents(options: {
   activeIdRef: RefBox<string | undefined>;
   handleEvent: (sessionId: string, event: SessionEvent) => void;
   markSessionReadLocally: (sessionId: string, readMessages: readonly StoredMessage[]) => void;
-  markDisplayPending?: (sessionId: string) => void;
-  onEventSeeded?: (sessionId: string) => void;
+  beginObservationSeed?: (sessionId: string) => number;
+  completeObservationSeed?: (sessionId: string, generation?: number) => void;
   setMessageLoadErrorBySession: (updater: (current: Record<string, string>) => Record<string, string>) => void;
   setMessageLoadPending: (pending: boolean) => void;
   setMessages: (messages: StoredMessage[]) => void;
@@ -465,8 +465,14 @@ export function useActiveSessionEvents(options: {
     });
     options.handleEvent(sessionId, event);
   });
-  const markEventSeeded = useEffectEvent((sessionId: string) => {
-    options.onEventSeeded?.(sessionId);
+  const beginObservationSeed = useEffectEvent((sessionId: string) => {
+    return options.beginObservationSeed?.(sessionId) ?? 0;
+  });
+  const completeObservationSeed = useEffectEvent((
+    sessionId: string,
+    generation?: number,
+  ) => {
+    options.completeObservationSeed?.(sessionId, generation);
   });
   const markSessionEventStreamClosed = useEffectEvent((sessionId: string) => {
     options.setSessionEventHealthBySession((current) => {
@@ -486,7 +492,7 @@ export function useActiveSessionEvents(options: {
 
   useLayoutEffect(() => {
     if (!activeId) return;
-    options.markDisplayPending?.(activeId);
+    const observationGeneration = beginObservationSeed(activeId);
     let disposed = false;
     const transcript = new DesktopTranscriptRangeStore();
     const subscribedAt = Date.now();
@@ -531,7 +537,11 @@ export function useActiveSessionEvents(options: {
       (event) => {
         handleSessionEvent(activeId, event);
       },
-      () => markEventSeeded(activeId),
+      () => completeObservationSeed(activeId, observationGeneration),
+      (phase) => {
+        if (phase === 'pending') beginObservationSeed(activeId);
+        else completeObservationSeed(activeId);
+      },
     );
     return () => {
       disposed = true;

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -37,15 +37,19 @@ export interface AppShellSessionEventHandlers {
   handleEvent(sessionId: string, event: SessionEvent): void;
   reconcilePersistedMessages(sessionId: string, messages: readonly StoredMessage[]): void;
   settleAssistantStreaming(sessionId: string, messageId?: string): Promise<void>;
+  flushDisplayEvents(sessionId: string): void;
+  markDisplayPending(sessionId: string): void;
+  markDisplayReady(sessionId: string): void;
 }
 
 export interface AppShellSessionDisplayBatch {
   readonly pendingEvents: Map<string, SessionEvent[]>;
+  readonly displayPendingSessions: Set<string>;
   framePending: boolean;
 }
 
 export function createAppShellSessionDisplayBatch(): AppShellSessionDisplayBatch {
-  return { pendingEvents: new Map(), framePending: false };
+  return { pendingEvents: new Map(), displayPendingSessions: new Set(), framePending: false };
 }
 
 export function createAppShellSessionEventHandlers(options: {
@@ -140,6 +144,24 @@ export function createAppShellSessionEventHandlers(options: {
     });
   }
 
+  function flushDisplayEvents(sessionId: string): void {
+    const events = takePendingDisplayEvents(sessionId);
+    if (events.length === 0) return;
+    updateLiveTurn(sessionId, events);
+  }
+
+  function markDisplayPending(sessionId: string): void {
+    displayBatch.displayPendingSessions.add(sessionId);
+  }
+
+  function markDisplayReady(sessionId: string): void {
+    displayBatch.displayPendingSessions.delete(sessionId);
+  }
+
+  function canBatchDisplayEvents(sessionId: string): boolean {
+    return !displayBatch.displayPendingSessions.has(sessionId);
+  }
+
   function updateLiveTurn(sessionId: string, events: readonly SessionEvent[]): void {
     setLiveTurnBySession((current) => replaceLiveTurns(current, new Map([[sessionId, events]])));
   }
@@ -190,6 +212,7 @@ export function createAppShellSessionEventHandlers(options: {
     if (
       scheduleFrame
       && activeIdRef.current === sessionId
+      && canBatchDisplayEvents(sessionId)
       && (event.type === 'text_delta' || event.type === 'thinking_delta')
     ) {
       scheduleDisplayEvent(sessionId, event);
@@ -275,7 +298,14 @@ export function createAppShellSessionEventHandlers(options: {
     }
   }
 
-  return { handleEvent, reconcilePersistedMessages, settleAssistantStreaming };
+  return {
+    handleEvent,
+    reconcilePersistedMessages,
+    settleAssistantStreaming,
+    flushDisplayEvents,
+    markDisplayPending,
+    markDisplayReady,
+  };
 }
 
 function sessionEventDiagnosticDetails(

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2186,7 +2186,14 @@ function AppShellContent({
   });
 
   const [sessionDisplayBatch] = useState(createAppShellSessionDisplayBatch);
-  const { handleEvent, reconcilePersistedMessages, settleAssistantStreaming } = useStableActions(createAppShellSessionEventHandlers, {
+  const {
+    handleEvent,
+    reconcilePersistedMessages,
+    settleAssistantStreaming,
+    flushDisplayEvents,
+    markDisplayPending,
+    markDisplayReady,
+  } = useStableActions(createAppShellSessionEventHandlers, {
     uiLocale,
     activeIdRef,
     liveTurnBySessionRef,
@@ -2337,11 +2344,14 @@ function AppShellContent({
     handleEvent,
     markSessionReadLocally,
     onEventSeeded: (sessionId) => {
+      flushDisplayEvents(sessionId);
+      markDisplayReady(sessionId);
       setActiveEventSeed((current) => ({
         sessionId,
         revision: current.revision + 1,
       }));
     },
+    markDisplayPending,
     setMessageLoadErrorBySession,
     setMessageLoadPending,
     setMessages,

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -173,6 +173,13 @@ import {
   useShellRunUpdates,
   useSettledSessionTransientReconcile,
 } from './app-shell-effects';
+import {
+  EMPTY_LIVE_CONTENT_SEED,
+  beginLiveContentSeed,
+  completeLiveContentSeed,
+  liveContentSeedRevision,
+  type LiveContentSeed,
+} from './live-content-seed';
 import { loadComposerDefaults, saveComposerDefaults } from './composer-defaults';
 import { useKeyedPendingRegistry } from './use-pending-action-registry';
 import { useAppShellComposerAttachments } from './use-app-shell-composer-attachments';
@@ -2333,25 +2340,34 @@ function AppShellContent({
     themePalette,
     themePref,
   });
-  const [activeEventSeed, setActiveEventSeed] = useState({
-    sessionId: undefined as string | undefined,
-    revision: 0,
-  });
+  const [activeEventSeed, setActiveEventSeed] = useState<LiveContentSeed>(EMPTY_LIVE_CONTENT_SEED);
+  const activeEventSeedRef = useRef(activeEventSeed);
+  activeEventSeedRef.current = activeEventSeed;
+  const beginObservationSeed = (sessionId: string): number => {
+    const next = beginLiveContentSeed(activeEventSeedRef.current, sessionId);
+    activeEventSeedRef.current = next;
+    markDisplayPending(sessionId);
+    setActiveEventSeed(next);
+    return next.generation;
+  };
+  const completeObservationSeed = (sessionId: string, generation?: number): void => {
+    const current = activeEventSeedRef.current;
+    const expected = generation ?? current.generation;
+    if (current.sessionId !== sessionId || current.generation !== expected) return;
+    flushDisplayEvents(sessionId);
+    markDisplayReady(sessionId);
+    const next = completeLiveContentSeed(current, sessionId, expected);
+    activeEventSeedRef.current = next;
+    setActiveEventSeed(next);
+  };
   useActiveSessionEvents({
     uiLocale,
     activeId,
     activeIdRef,
     handleEvent,
     markSessionReadLocally,
-    onEventSeeded: (sessionId) => {
-      flushDisplayEvents(sessionId);
-      markDisplayReady(sessionId);
-      setActiveEventSeed((current) => ({
-        sessionId,
-        revision: current.revision + 1,
-      }));
-    },
-    markDisplayPending,
+    beginObservationSeed,
+    completeObservationSeed,
     setMessageLoadErrorBySession,
     setMessageLoadPending,
     setMessages,
@@ -3086,9 +3102,7 @@ function AppShellContent({
                 historyLoadPending={historyLoadPendingSessionId === activeId}
                 onLoadEarlierHistory={() => loadTranscriptHistory('earlier')}
                 onReturnToLatestHistory={() => loadTranscriptHistory('latest')}
-                liveContentSeedRevision={activeEventSeed.sessionId === activeId
-                  ? activeEventSeed.revision
-                  : 0}
+                liveContentSeedRevision={liveContentSeedRevision(activeEventSeed, activeId)}
                 messages={messages}
                 messageLoading={activeMessageLoading}
                 runningStatus={showRunningStatus}

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -141,26 +141,30 @@ export function ChatMessageSurface({
     isDeepResearchSession(activeSession?.labels),
   );
   const liveTurn = useAppShellSessionUiSelector(sessionUiController, selectLiveTurn, activeSessionId);
+  const seededLiveTurn = liveContentSeedRevision > 0 ? liveTurn : undefined;
   const [activation, setActivation] = useState(() => ({
     sessionId: activeSessionId,
     seedRevision: liveContentSeedRevision,
-    initialLiveContent: captureLiveContent(liveTurn),
+    initialLiveContent: liveContentSeedRevision > 0 ? captureLiveContent(liveTurn) : undefined,
   }));
-  if (
-    activation.sessionId !== activeSessionId
-    || activation.seedRevision !== liveContentSeedRevision
-  ) {
+  if (activation.sessionId !== activeSessionId) {
     setActivation({
       sessionId: activeSessionId,
       seedRevision: liveContentSeedRevision,
-      initialLiveContent: captureLiveContent(liveTurn),
+      initialLiveContent: liveContentSeedRevision > 0 ? captureLiveContent(liveTurn) : undefined,
+    });
+  } else if (activation.seedRevision !== liveContentSeedRevision) {
+    setActivation({
+      sessionId: activeSessionId,
+      seedRevision: liveContentSeedRevision,
+      initialLiveContent: liveContentSeedRevision > 0 ? captureLiveContent(liveTurn) : undefined,
     });
   } else if (
     activation.initialLiveContent
     && (
-      !liveTurn
-      || liveTurn.terminal
-      || liveTurn.turnId !== activation.initialLiveContent.turnId
+      !seededLiveTurn
+      || seededLiveTurn.terminal
+      || seededLiveTurn.turnId !== activation.initialLiveContent.turnId
     )
   ) {
     setActivation({
@@ -216,10 +220,10 @@ export function ChatMessageSurface({
     <>
       <ChatView
         {...chatViewRest}
-        liveTurn={liveTurn}
+        liveTurn={seededLiveTurn}
         initialLiveContentSnapshot={activation.sessionId === activeSessionId
           ? activation.initialLiveContent
-          : captureLiveContent(liveTurn)}
+          : liveContentSeedRevision > 0 ? captureLiveContent(liveTurn) : undefined}
         shellRunUpdates={shellRunUpdates}
         deepResearchRun={deepResearchRun}
         emptyOverride={emptyOverride}

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -53,7 +53,7 @@ interface ChatMessageSurfaceProps extends Omit<
   sessionUiController: AppShellSessionUiStateController;
   /** The shell's selected session. Not derived from `activeSession`, which the shell substitutes for an unsaved chat. */
   activeSessionId: string | undefined;
-  /** Advances after Runtime Host has seeded the active session's current live projection. */
+  /** Advances after the active session's current observation generation finishes seeding. */
   liveContentSeedRevision: number;
   sessionHealthNotice?: SessionHealthNoticeView;
   workspaceReadinessRecovery?: WorkspaceReadinessRecovery;

--- a/apps/desktop/src/renderer/live-content-seed.ts
+++ b/apps/desktop/src/renderer/live-content-seed.ts
@@ -1,0 +1,52 @@
+export interface LiveContentSeed {
+  readonly sessionId: string | undefined;
+  readonly generation: number;
+  readonly readyGeneration: number;
+}
+
+export const EMPTY_LIVE_CONTENT_SEED: LiveContentSeed = {
+  sessionId: undefined,
+  generation: 0,
+  readyGeneration: 0,
+};
+
+export function beginLiveContentSeed(
+  current: LiveContentSeed,
+  sessionId: string,
+): LiveContentSeed {
+  return {
+    sessionId,
+    generation: current.generation + 1,
+    readyGeneration: 0,
+  };
+}
+
+export function completeLiveContentSeed(
+  current: LiveContentSeed,
+  sessionId: string,
+  generation: number,
+): LiveContentSeed {
+  if (current.sessionId !== sessionId || current.generation !== generation) {
+    return current;
+  }
+  return {
+    sessionId,
+    generation,
+    readyGeneration: generation,
+  };
+}
+
+export function liveContentSeedRevision(
+  seed: LiveContentSeed,
+  activeSessionId: string | undefined,
+): number {
+  if (
+    !activeSessionId
+    || seed.sessionId !== activeSessionId
+    || seed.generation === 0
+    || seed.readyGeneration !== seed.generation
+  ) {
+    return 0;
+  }
+  return seed.generation;
+}


### PR DESCRIPTION
## Summary

Returning to a live conversation remounted the streaming bubble with the leftover prefix as `settledText`, then painted the Runtime Host seed catch-up through the per-frame display batch. `useStreamingText` treated that catch-up as a new stream, so already-produced text replayed (`…Acknowle` → `…Acknowledged steer` → …).

- While a session is waiting to be seeded, `text_delta` / `thinking_delta` apply immediately instead of waiting for rAF.
- Display readiness is keyed to the current observation generation, including A → B → A and Host recovery/restore, not only `sessionId + revision`.
- `ChatMessageSurface` withholds the live bubble until that generation finishes seeding, and snapshots the full buffer in the same activation.

Fixes #3044

## Verification\n\n- `npm --workspace @maka/desktop run typecheck`\n- Desktop main suite — 845/845 passed\n- Focused candidate and observer suites — 48/48 passed\n- `streaming-remount.spec.ts --repeat-each=10` — 20/20 passed\n- `npm run format:check` and `git diff --check`\n\n## Checklist

- [x] Tests cover the change and fail without it
- [x] Focused lint/typecheck and the affected suites pass locally
- [ ] Full workspace lint/format/typecheck

Does this PR entail a change in behavior?

- [x] Yes — switching back to a live conversation no longer replays already-accumulated assistant text
\n\n## AI use\n\n- [ ] No generative tool made a substantive contribution\n- [x] Generative tooling made a substantive contribution\n\nTool(s) and scope: Grok assisted the original implementation, as disclosed by the original contributor. Codex diagnosed the remaining review findings and implemented and tested the observation-restore failure follow-up under M4n5ter&apos;s direction.\n\n