### PR TITLE
fix(runtime): group parallel tool calls in history summarizer replay

### DIFF
--- a/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
@@ -13,10 +13,13 @@ import type { RuntimeEvent, RuntimeEventContent } from '@maka/core/runtime-event
 import { decodeModelCallAttempt, type ModelCallAttempt } from '@maka/core/model-call-attempt';
 import { ProviderRequestTracker } from '../provider-request-telemetry.js';
 import type { HistoryCompactSummaryInput } from '../ai-sdk-compaction-contract.js';
+import type { ModelMessage } from '../model-protocol.js';
 import {
   buildLlmHistorySummarizer,
+  replayPlanItemsToModelMessages,
   type AiSdkGenerateTextLike,
 } from '../history-compact-summarizer.js';
+import { buildRuntimeEventModelReplayPlan } from '../model-history.js';
 import { buildHistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
 
 const ts = 1_700_000_000_000;
@@ -33,6 +36,24 @@ function ev(overrides: Partial<RuntimeEvent> & { content?: RuntimeEventContent }
     partial: false,
     ...overrides,
   } as RuntimeEvent;
+}
+
+function assertStrictOpenAiToolCallFollowed(messages: ModelMessage[]): void {
+  for (const [index, message] of messages.entries()) {
+    if (message.role !== 'assistant' || typeof message.content === 'string') continue;
+    const callIds = message.content
+      .filter((part) => part.type === 'tool-call')
+      .map((part) => part.toolCallId);
+    if (callIds.length === 0) continue;
+    const answered: string[] = [];
+    for (const following of messages.slice(index + 1)) {
+      if (following.role !== 'tool') break;
+      for (const part of following.content) {
+        if (part.type === 'tool-result') answered.push(part.toolCallId);
+      }
+    }
+    assert.deepEqual(answered, callIds);
+  }
 }
 
 function inputWith(events: RuntimeEvent[], abortSignal?: AbortSignal): HistoryCompactSummaryInput {
@@ -164,6 +185,95 @@ describe('buildLlmHistorySummarizer', () => {
     expect(toolPart.toolName).toBe('read');
     // output must be the {type, value} wrapper, not the raw result object
     expect(toolPart.output).toEqual({ type: 'json', value: { name: 'maka' } });
+  });
+
+  test('groups consecutive parallel tool calls into one assistant message', async () => {
+    const seen: ModelMessage[][] = [];
+    const summarize = buildLlmHistorySummarizer({
+      resolveModel: () => 'fake-model',
+      generateText: async (options) => {
+        seen.push(options.messages);
+        return { text: '## Goal\nX' };
+      },
+    });
+
+    const events: RuntimeEvent[] = [
+      ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'read both files' } }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc-a', name: 'read', args: { path: 'a.ts' } },
+        refs: { stepId: 'step-1' },
+      }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'fc-b', name: 'read', args: { path: 'b.ts' } },
+        refs: { stepId: 'step-1' },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc-a', name: 'read', result: { ok: 'a' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: { kind: 'function_response', id: 'fc-b', name: 'read', result: { ok: 'b' } },
+      }),
+    ];
+
+    expect(await summarize(inputWith(events))).toBe('## Goal\nX');
+    const messages = seen[0]!;
+    const assistantCalls = messages.filter(
+      (message) =>
+        message.role === 'assistant' && message.content.some((part) => part.type === 'tool-call'),
+    );
+    expect(assistantCalls).toHaveLength(1);
+    expect(assistantCalls[0]?.content).toEqual([
+      { type: 'tool-call', toolCallId: 'fc-a', toolName: 'read', input: { path: 'a.ts' } },
+      { type: 'tool-call', toolCallId: 'fc-b', toolName: 'read', input: { path: 'b.ts' } },
+    ]);
+    expect(
+      messages
+        .filter((message) => message.role === 'tool')
+        .flatMap((message) => message.content.map((part) => part.toolCallId)),
+    ).toEqual(['fc-a', 'fc-b']);
+    assertStrictOpenAiToolCallFollowed(messages);
+
+    const plan = buildRuntimeEventModelReplayPlan(events);
+    expect(
+      replayPlanItemsToModelMessages(plan.items).filter((message) => message.role === 'assistant'),
+    ).toHaveLength(1);
+  });
+
+  test('does not merge sequential tool-call rounds that already have answers between them', () => {
+    const messages = replayPlanItemsToModelMessages(
+      buildRuntimeEventModelReplayPlan([
+        ev({
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'fc-a', name: 'read', args: { path: 'a.ts' } },
+        }),
+        ev({
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'fc-a', name: 'read', result: { ok: 'a' } },
+        }),
+        ev({
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'function_call', id: 'fc-b', name: 'read', args: { path: 'b.ts' } },
+        }),
+        ev({
+          role: 'tool',
+          author: 'tool',
+          content: { kind: 'function_response', id: 'fc-b', name: 'read', result: { ok: 'b' } },
+        }),
+      ]).items,
+    );
+    expect(messages.filter((message) => message.role === 'assistant')).toHaveLength(2);
+    assertStrictOpenAiToolCallFollowed(messages);
   });
 
   test('surfaces provider failures so the runtime can report the real compact reason', async () => {

--- a/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
@@ -227,7 +227,9 @@ describe('buildLlmHistorySummarizer', () => {
     const messages = seen[0]!;
     const assistantCalls = messages.filter(
       (message) =>
-        message.role === 'assistant' && message.content.some((part) => part.type === 'tool-call'),
+        message.role === 'assistant' &&
+        typeof message.content !== 'string' &&
+        message.content.some((part) => part.type === 'tool-call'),
     );
     expect(assistantCalls).toHaveLength(1);
     expect(assistantCalls[0]?.content).toEqual([
@@ -237,7 +239,9 @@ describe('buildLlmHistorySummarizer', () => {
     expect(
       messages
         .filter((message) => message.role === 'tool')
-        .flatMap((message) => message.content.map((part) => part.toolCallId)),
+        .flatMap((message) =>
+          message.content.flatMap((part) => (part.type === 'tool-result' ? [part.toolCallId] : [])),
+        ),
     ).toEqual(['fc-a', 'fc-b']);
     assertStrictOpenAiToolCallFollowed(messages);
 

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -130,10 +130,13 @@ async function loadAiSdkTextModule(): Promise<AiSdkTextModule> {
 }
 
 type ReplayPlanItems = ReturnType<typeof buildRuntimeEventModelReplayPlan>['items'];
+type ReplayToolCallItem = Extract<ReplayPlanItems[number], { kind: 'tool_call' }>;
 
 export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMessage[] {
   const out: ModelMessage[] = [];
-  for (const item of items) {
+  let index = 0;
+  while (index < items.length) {
+    const item = items[index]!;
     if (item.kind === 'text') {
       // Split on role so each push matches exactly one ModelMessage arm — no cast.
       const textPart = { type: 'text' as const, text: item.content };
@@ -142,17 +145,27 @@ export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMes
       } else {
         out.push({ role: 'assistant', content: [textPart] });
       }
+      index += 1;
     } else if (item.kind === 'tool_call') {
+      // Consecutive tool_call items are one assistant step. Emitting each as
+      // its own assistant message leaves the previous tool_calls unanswered
+      // and is rejected by strict OpenAI-compatible providers.
+      const calls: ReplayToolCallItem[] = [item];
+      index += 1;
+      while (index < items.length) {
+        const next = items[index];
+        if (next?.kind !== 'tool_call') break;
+        calls.push(next);
+        index += 1;
+      }
       out.push({
         role: 'assistant',
-        content: [
-          {
-            type: 'tool-call',
-            toolCallId: item.toolCallId,
-            toolName: item.toolName,
-            input: item.input,
-          },
-        ],
+        content: calls.map((call) => ({
+          type: 'tool-call' as const,
+          toolCallId: call.toolCallId,
+          toolName: call.toolName,
+          input: call.input,
+        })),
       });
     } else if (item.kind === 'tool_result') {
       out.push({
@@ -166,8 +179,11 @@ export function replayPlanItemsToModelMessages(items: ReplayPlanItems): ModelMes
           },
         ],
       });
+      index += 1;
+    } else {
+      // thinking entries are intentionally skipped for summarization
+      index += 1;
     }
-    // thinking entries are intentionally skipped for summarization
   }
   return out;
 }


### PR DESCRIPTION
## Summary

`replayPlanItemsToModelMessages` emitted every `tool_call` replay item as its own assistant message. Parallel calls therefore looked like:

```
assistant [call A]
assistant [call B]
tool [result A]
tool [result B]
```

Strict OpenAI-compatible providers reject that (DeepSeek 400: previous `tool_calls` not yet answered). Compaction then fail-opens as `provider_error`.

Consecutive `tool_call` items are now one assistant message with N tool-call parts, followed by N tool messages. Sequential rounds that already have answers between them stay separate. The primary replay materializer is unchanged.

Fixes #3030

## Verification

- `npx tsx --test packages/runtime/src/__tests__/history-compact-summarizer.test.ts` — 10/10
- New cases: two parallel reads → one assistant + two tool messages; sequential rounds stay two assistants
- Both cases assert every assistant `tool-call` id is answered by the immediately following tool messages

Not run: live DeepSeek generateText. The unit test locks the rejected message shape.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Focused lint/typecheck and the affected suites pass locally
- [ ] Full workspace lint/format/typecheck

Does this PR entail a change in behavior?

- [x] Yes — history summarizer requests over parallel tool calls now use one assistant message
