### PR TITLE
chore: configure CodeRabbit reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,7 +11,7 @@ reviews:
   request_changes_workflow: false
 
   path_instructions:
-    - path: "**/*"
+    - path: "{**/*,**/.*,**/.*/**}"
       instructions: |
         Review the diff adversarially against the problem it claims to solve.
         Determine whether it is the smallest coherent solution at the existing source of truth.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "en-US"
+tone_instructions: >-
+  Be concise, direct, and evidence-based. Report only concrete, reproducible
+  issues caused by the diff. Explain the impact and cite the relevant code.
+
+reviews:
+  profile: "chill"
+  poem: false
+  enable_prompt_for_ai_agents: false
+  request_changes_workflow: false
+
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  high_level_summary_instructions: |
+    Explain:
+    1. What problem the PR solves.
+    2. Whether it extends the existing source of truth or creates a parallel path.
+    3. Whether any added complexity is necessary.
+    4. The concrete risks and validation performed.
+
+  auto_review:
+    enabled: true
+    drafts: false
+
+knowledge_base:
+  code_guidelines:
+    enabled: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -8,6 +8,7 @@ tone_instructions: >-
 reviews:
   profile: "chill"
   poem: false
+  in_progress_fortune: false
   enable_prompt_for_ai_agents: false
   request_changes_workflow: false
 

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,7 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 language: "en-US"
-tone_instructions: >-
-  Be concise, direct, and evidence-based. Report only concrete, reproducible
-  issues caused by the diff. Explain the impact and cite the relevant code.
+tone_instructions: "Be concise, direct, and evidence-based."
 
 reviews:
   profile: "chill"
@@ -12,19 +10,25 @@ reviews:
   enable_prompt_for_ai_agents: false
   request_changes_workflow: false
 
+  path_instructions:
+    - path: "**/*"
+      instructions: |
+        Review the diff adversarially against the problem it claims to solve.
+        Determine whether it is the smallest coherent solution at the existing source of truth.
+        Flag concrete cases where code can be deleted or simplified.
+        Flag tests that duplicate existing coverage, assert implementation details, or do not protect observable behavior.
+        Do not suggest speculative refactors or alternatives without a concrete correctness or maintenance benefit.
+
   high_level_summary: true
   high_level_summary_in_walkthrough: true
   high_level_summary_instructions: |
     Explain:
     1. What problem the PR solves.
     2. Whether it extends the existing source of truth or creates a parallel path.
-    3. Whether any added complexity is necessary.
-    4. The concrete risks and validation performed.
+    3. Whether it is the smallest coherent solution and any added complexity is necessary.
+    4. What code or tests, if any, can be deleted or simplified without weakening behavior or regression coverage.
+    5. The concrete risks and validation performed.
 
   auto_review:
     enabled: true
     drafts: false
-
-knowledge_base:
-  code_guidelines:
-    enabled: true


### PR DESCRIPTION
## Summary

- Add a version-controlled CodeRabbit configuration.
- Keep automatic reviews concise, evidence-based, advisory, and limited to non-draft PRs.
- Review each changed path adversarially for problem fit, source-of-truth ownership, necessary complexity, and removable code or tests.
- Structure walkthrough summaries around the problem, the existing source of truth, necessary complexity, deletion opportunities, concrete risks, and validation.

Refs #2903

## Verification

- `uvx check-jsonschema --schemafile /tmp/maka-coderabbit-schema.json .coderabbit.yaml`
- YAML parsed successfully with Ruby Psych.
- `git diff --check`
- The automatic CodeRabbit review on this PR is the live integration check.

Not run: product tests, lint, or typecheck; this change only adds CodeRabbit configuration, and Biome ignores YAML files.

## Provenance

The configuration and PR text were drafted with Codex. The human contributor remains responsible for reviewing the final policy and merge decision.

## Checklist

- [ ] Tests cover the change and fail without it — not applicable to repository-only review configuration
- [ ] Lint, format, typecheck and the affected suites pass locally — not applicable; schema validation passed

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No