### PR TITLE
refactor(eval): make framework selection single-source

### DIFF
--- a/packages/eval/harbor/eval_framework.py
+++ b/packages/eval/harbor/eval_framework.py
@@ -1,0 +1,23 @@
+"""Authoritative Eval harness framework selection.
+
+`run_trial.py` validates the argv framework and installs it here before Harbor,
+Pier, or the shared relay can import. The relay must not read the environment.
+"""
+
+from __future__ import annotations
+
+_FRAMEWORKS = frozenset({"harbor", "pier"})
+_framework: str | None = None
+
+
+def install(framework: str) -> None:
+    if framework not in _FRAMEWORKS:
+        raise RuntimeError("framework must be harbor or pier")
+    global _framework
+    _framework = framework
+
+
+def selected() -> str:
+    if _framework not in _FRAMEWORKS:
+        raise RuntimeError("Eval framework selection is not installed")
+    return _framework

--- a/packages/eval/harbor/relay_agent.py
+++ b/packages/eval/harbor/relay_agent.py
@@ -14,13 +14,13 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-framework = os.environ.get("MAKA_EVAL_FRAMEWORK")
+from eval_framework import selected
+
+framework = selected()
 if framework == "harbor":
     from harbor.agents.base import BaseAgent
-elif framework == "pier":
-    from pier.agents.base import BaseAgent
 else:
-    raise RuntimeError("MAKA_EVAL_FRAMEWORK must be harbor or pier")
+    from pier.agents.base import BaseAgent
 
 
 class RelayTransportClosed(RuntimeError):

--- a/packages/eval/harbor/run_trial.py
+++ b/packages/eval/harbor/run_trial.py
@@ -100,9 +100,10 @@ def publish_ready_task(namespace: Path, target: Path) -> None:
 
 
 async def run_trial(framework: str, expected_version: str, config_file: Path) -> None:
-    distribution = {"harbor": "harbor", "pier": "datacurve-pier"}.get(framework)
-    if distribution is None:
-        raise RuntimeError("framework must be harbor or pier")
+    from eval_framework import install
+
+    install(framework)
+    distribution = {"harbor": "harbor", "pier": "datacurve-pier"}[framework]
     if importlib.metadata.version(distribution) != expected_version:
         raise FrameworkVersionMismatch
     try:
@@ -166,7 +167,10 @@ async def create_harbor_trial(trial_type: type, config: object) -> object:
 
 
 async def main() -> None:
+    from eval_framework import install
+
     framework, expected_version, config_path = sys.argv[1:]
+    install(framework)
     task = asyncio.current_task()
     assert task is not None
     loop = asyncio.get_running_loop()

--- a/packages/eval/harbor/test_eval_framework.py
+++ b/packages/eval/harbor/test_eval_framework.py
@@ -1,0 +1,37 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+class EvalFrameworkTest(unittest.TestCase):
+    def test_selected_fails_closed_before_install(self) -> None:
+        module = self._load_fresh()
+        with self.assertRaisesRegex(RuntimeError, "not installed"):
+            module.selected()
+
+    def test_invalid_framework_fails_closed(self) -> None:
+        module = self._load_fresh()
+        with self.assertRaisesRegex(RuntimeError, "harbor or pier"):
+            module.install("other")
+        with self.assertRaisesRegex(RuntimeError, "not installed"):
+            module.selected()
+
+    def test_install_selects_harbor_and_pier(self) -> None:
+        module = self._load_fresh()
+        module.install("harbor")
+        self.assertEqual(module.selected(), "harbor")
+        module.install("pier")
+        self.assertEqual(module.selected(), "pier")
+
+    @staticmethod
+    def _load_fresh():
+        path = Path(__file__).with_name("eval_framework.py")
+        spec = importlib.util.spec_from_file_location("maka_eval_framework_under_test", path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/eval/harbor/test_relay_artifacts.py
+++ b/packages/eval/harbor/test_relay_artifacts.py
@@ -16,7 +16,9 @@ class BaseAgent:
 
 
 def load_relay():
-    os.environ["MAKA_EVAL_FRAMEWORK"] = "harbor"
+    from eval_framework import install
+
+    install("harbor")
     package = types.ModuleType("harbor")
     agents = types.ModuleType("harbor.agents")
     base = types.ModuleType("harbor.agents.base")

--- a/packages/eval/harbor/test_relay_contract.py
+++ b/packages/eval/harbor/test_relay_contract.py
@@ -33,7 +33,9 @@ class Environment:
 
 
 def load_relay(framework="harbor"):
-    os.environ["MAKA_EVAL_FRAMEWORK"] = framework
+    from eval_framework import install
+
+    install(framework)
     package = types.ModuleType(framework)
     agents = types.ModuleType(f"{framework}.agents")
     base = types.ModuleType(f"{framework}.agents.base")
@@ -445,6 +447,19 @@ class SubjectCapabilityTest(unittest.IsolatedAsyncioTestCase):
             await relay._require_constrained_subject(environment)
         self.assertEqual(environment.commands, [])
         self.assertEqual(environment.services, [])
+
+
+class FrameworkSelectionTest(unittest.TestCase):
+    def test_relay_loads_harbor_and_pier_from_the_installed_selection(self):
+        for framework in ("harbor", "pier"):
+            with self.subTest(framework):
+                relay = load_relay(framework)
+                self.assertEqual(relay.framework, framework)
+
+    def test_relay_does_not_select_a_framework_from_the_environment(self):
+        os.environ["MAKA_EVAL_FRAMEWORK"] = "pier"
+        relay = load_relay("harbor")
+        self.assertEqual(relay.framework, "harbor")
 
 
 if __name__ == "__main__":

--- a/packages/eval/harbor/test_relay_lifecycle.py
+++ b/packages/eval/harbor/test_relay_lifecycle.py
@@ -158,7 +158,9 @@ class SettleCompletionEnvironment(SimultaneousEnvironment):
 
 
 def load_relay():
-    os.environ["MAKA_EVAL_FRAMEWORK"] = "harbor"
+    from eval_framework import install
+
+    install("harbor")
     package = types.ModuleType("harbor")
     agents = types.ModuleType("harbor.agents")
     base = types.ModuleType("harbor.agents.base")

--- a/packages/eval/harbor/test_run_trial_policy.py
+++ b/packages/eval/harbor/test_run_trial_policy.py
@@ -1,5 +1,7 @@
+import asyncio
 import importlib.util
 import os
+import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -33,6 +35,27 @@ class RunTrialPolicyTest(unittest.TestCase):
         with patch.dict(os.environ, {"MAKA_EVAL_EGRESS_REQUIRED": "1"}, clear=True):
             with self.assertRaisesRegex(RuntimeError, "proxy host is unavailable"):
                 MODULE.apply_subject_egress_policy(task)
+
+    def test_invalid_framework_fails_before_framework_import(self) -> None:
+        with patch.object(MODULE.importlib, "import_module") as imported:
+            with self.assertRaisesRegex(RuntimeError, "harbor or pier"):
+                asyncio.run(MODULE.run_trial("other", "1.0.0", Path("missing.json")))
+        imported.assert_not_called()
+
+    def test_main_installs_the_argv_framework_before_the_trial(self) -> None:
+        import eval_framework
+
+        installed: list[str] = []
+
+        async def fake_trial(framework: str, expected_version: str, config_file: Path) -> None:
+            installed.append(eval_framework.selected())
+            self.assertEqual(framework, "pier")
+            self.assertEqual(expected_version, "1.2.3")
+
+        with patch.object(sys, "argv", ["run_trial.py", "pier", "1.2.3", "config.json"]):
+            with patch.object(MODULE, "run_trial", fake_trial):
+                asyncio.run(MODULE.main())
+        self.assertEqual(installed, ["pier"])
 
 
 if __name__ == "__main__":

--- a/packages/eval/package.json
+++ b/packages/eval/package.json
@@ -19,7 +19,7 @@
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test:dist": "node --test \"dist/**/*.test.js\" && python3 harbor/test_relay_contract.py && python3 harbor/test_relay_lifecycle.py && python3 harbor/test_egress_filter.py && python3 harbor/test_run_trial_policy.py && python3 harbor/test_relay_artifacts.py && python3 harbor/test_cell_egress_namespace.py"
+    "test:dist": "node --test \"dist/**/*.test.js\" && python3 harbor/test_eval_framework.py && python3 harbor/test_relay_contract.py && python3 harbor/test_relay_lifecycle.py && python3 harbor/test_egress_filter.py && python3 harbor/test_run_trial_policy.py && python3 harbor/test_relay_artifacts.py && python3 harbor/test_cell_egress_namespace.py"
   },
   "dependencies": {
     "@maka/core": "0.1.0",

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -1055,6 +1055,11 @@ test('pier cannot declare an egress proxy it never enforces', () => {
   );
 });
 
+test('framework selection is not a reserved preparation environment value', async () => {
+  const harness = await readFile(new URL('../../src/harness-executor.ts', import.meta.url), 'utf8');
+  assert.doesNotMatch(harness, /MAKA_EVAL_FRAMEWORK/u);
+});
+
 function executorConfig(): JsonObject {
   return {
     frameworkVersion: '0.20.0',

--- a/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
+++ b/packages/eval/src/__tests__/lifecycle-boundaries.test.ts
@@ -1055,9 +1055,88 @@ test('pier cannot declare an egress proxy it never enforces', () => {
   );
 });
 
-test('framework selection is not a reserved preparation environment value', async () => {
-  const harness = await readFile(new URL('../../src/harness-executor.ts', import.meta.url), 'utf8');
-  assert.doesNotMatch(harness, /MAKA_EVAL_FRAMEWORK/u);
+test('launched trial environment does not inherit MAKA_EVAL_FRAMEWORK', {
+  timeout: 10_000,
+}, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-eval-framework-env-'));
+  const executable = join(root, 'fake-python.mjs');
+  const envDump = join(root, 'env.json');
+  await writeFile(
+    executable,
+    `#!/usr/bin/env node
+import { connect } from 'node:net';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+const config = JSON.parse(await readFile(process.argv.at(-1), 'utf8'));
+await writeFile(process.env.MAKA_TEST_ENV, JSON.stringify({
+  framework: process.env.MAKA_EVAL_FRAMEWORK ?? null,
+}));
+const socket = connect(config.agent.kwargs.relay_port, config.agent.kwargs.relay_host);
+socket.setEncoding('utf8');
+let buffered = '';
+const message = () => new Promise((resolve) => {
+  const read = (chunk) => {
+    buffered += chunk;
+    const boundary = buffered.indexOf('\\n');
+    if (boundary < 0) return;
+    socket.off('data', read);
+    const line = buffered.slice(0, boundary);
+    buffered = buffered.slice(boundary + 1);
+    resolve(JSON.parse(line));
+  };
+  socket.on('data', read);
+});
+await new Promise((resolve, reject) => {
+  socket.once('connect', resolve);
+  socket.once('error', reject);
+});
+socket.write(JSON.stringify({ token: config.agent.kwargs.relay_token, kind: 'ready', instruction: 'solve', cwd: '/workspace' }) + '\\n');
+await message();
+socket.write(JSON.stringify({ token: config.agent.kwargs.relay_token, kind: 'executed', termination: 'exited', exitCode: 0, stdout: '', diagnostic: { category: 'none' } }) + '\\n');
+await message();
+const trialPath = new URL('./' + config.trial_name + '/', new URL('file://' + config.trials_dir + '/'));
+await mkdir(trialPath, { recursive: true });
+await writeFile(new URL('result.json', trialPath), JSON.stringify({ verifier_result: { rewards: { reward: 1 } } }));
+socket.end();
+`,
+  );
+  await chmod(executable, 0o755);
+  const restoreEnvironment = setEnvironment({
+    MAKA_TEST_PYTHON: executable,
+    MAKA_TEST_TRIALS: root,
+    MAKA_TEST_ENV: envDump,
+    MAKA_EVAL_FRAMEWORK: 'pier',
+  });
+  try {
+    const results = await runExperiment({
+      spec: experiment(),
+      store: new FileAttemptStore(join(root, 'attempts')),
+      executor: createHarborExecutor(
+        { ...executorConfig(), preparationEnvironment: ['MAKA_TEST_ENV'] },
+        join(root, 'experiment.json'),
+      ),
+      subjects: [
+        {
+          kind: 'external',
+          execute: async ({ context }) => {
+            await context.execute({ command: '/bin/true', args: [], credentialEnvironment: {} });
+            return {
+              usage: null,
+              costUsd: null,
+              durationMs: 1,
+              status: 'completed',
+              failureReason: null,
+              artifacts: [],
+            };
+          },
+        },
+      ],
+    });
+    assert.equal(results.get('task::1::external')?.result.status, 'completed');
+    assert.deepEqual(JSON.parse(await readFile(envDump, 'utf8')), { framework: null });
+  } finally {
+    restoreEnvironment();
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 function executorConfig(): JsonObject {

--- a/packages/eval/src/harness-executor.ts
+++ b/packages/eval/src/harness-executor.ts
@@ -356,7 +356,6 @@ async function startTrial(
   const relayPath = resolve(dirname(fileURLToPath(import.meta.url)), '../harbor');
   const executionEnvironment = egressExecutionEnvironment(options.egressProxy);
   const environment = preparationEnvironment(
-    framework,
     relayPath,
     [...subjectCredentialNames, ...cell.subject.credentials],
     options.preparationEnvironment,
@@ -588,7 +587,6 @@ function preparationCode(
 }
 
 function preparationEnvironment(
-  framework: Framework,
   relayPath: string,
   subjectCredentialNames: readonly string[],
   declared: readonly string[],
@@ -619,7 +617,6 @@ function preparationEnvironment(
   );
   return {
     ...inherited,
-    MAKA_EVAL_FRAMEWORK: framework,
     PYTHONPATH: [relayPath, inherited.PYTHONPATH].filter(Boolean).join(delimiter),
     ...(egressAllowedHost
       ? {
@@ -887,9 +884,6 @@ function decodeOptions(value: JsonObject, framework: Framework): HarnessOptions 
   ).map((name, index) => machinePathEnv(name, `preparationEnvironment[${index}]`));
   if (new Set(preparationEnvironment).size !== preparationEnvironment.length) {
     throw new Error('preparationEnvironment must contain unique names');
-  }
-  if (preparationEnvironment.includes('MAKA_EVAL_FRAMEWORK')) {
-    throw new Error('preparationEnvironment contains a reserved name');
   }
   const decoded: HarnessOptions = {
     frameworkVersion: text(options.frameworkVersion, 'frameworkVersion'),


### PR DESCRIPTION
## Summary

Harbor or Pier was selected twice: once as the validated `run_trial.py` argv, and again via `MAKA_EVAL_FRAMEWORK` for `relay_agent.py`. Those contracts could disagree.

`run_trial.py` now validates argv and installs the selection before any framework or relay import. The relay reads that installed value. TypeScript no longer injects or reserves `MAKA_EVAL_FRAMEWORK`.

Fixes #3036

## Verification

- `python3.13` `test_eval_framework.py` 3/3, `test_run_trial_policy.py` 4/4, `test_relay_contract.py` 20/20 (harbor and pier load; env is ignored), `test_relay_artifacts.py` 1/1, `test_relay_lifecycle.py` 12 (2 skip GNU `setsid`)
- `npm --workspace @maka/eval run typecheck` — pass
- `lifecycle-boundaries` including the new no-`MAKA_EVAL_FRAMEWORK` lock — pass
- `biome check` on the touched TypeScript — clean

## Checklist

- [x] Tests cover the change and fail without it
- [x] Focused lint/typecheck and the affected suites pass locally
- [ ] Full workspace lint/format/typecheck

Does this PR entail a change in behavior?

- [x] Yes — framework selection is only the validated `run_trial.py` argument
