### PR TITLE
fix(desktop): keep a nested folder as its own project

### DIFF
--- a/apps/desktop/src/main/__tests__/project-management-service.test.ts
+++ b/apps/desktop/src/main/__tests__/project-management-service.test.ts
@@ -90,10 +90,7 @@ test('adding a nested folder selects that folder instead of the parent project',
     catalog: managementCatalog(catalog),
     chooseDirectory: async () => nextDirectory,
     selection: {
-      currentSelection: async () => ({
-        projectId: selected.length === 0 ? undefined : `project-${selected.length}`,
-        path: selected.at(-1) ?? (await realpath(parentPath)),
-      }),
+      currentSelection: async () => ({ projectId: undefined, path: parentPath }),
       setSelection: (_projectId, path) => selected.push(path),
     },
   });
@@ -167,9 +164,7 @@ test('does not silently replace a stale Project preference with another Project'
   const service = createProjectManagementService({
     capabilities: LOCAL_CAPABILITIES,
     catalog: {
-      list: async () => [
-        { id: 'other', name: 'Other', locations: [], available: true },
-      ],
+      list: async () => [{ id: 'other', name: 'Other', locations: [], available: true }],
       register: unexpected,
       relink: unexpected,
       rename: unexpected,

--- a/apps/desktop/src/main/__tests__/project-management-service.test.ts
+++ b/apps/desktop/src/main/__tests__/project-management-service.test.ts
@@ -1,8 +1,12 @@
 import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
 import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
 import { createProjectCatalog, type ProjectCatalog } from '@maka/storage';
 import {
   createProjectManagementService,
@@ -63,6 +67,52 @@ test('owns Project selection and reversible lifecycle actions in Desktop', async
     assert.equal(relinked.ok, true);
     assert.equal(selectedPaths.at(-1), await realpath(relocatedPath));
   } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('adding a nested folder selects that folder instead of the parent project', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-nested-add-'));
+  const parentPath = join(base, 'parent-project');
+  const childPath = join(parentPath, 'child-project');
+  await mkdir(childPath, { recursive: true });
+  await execFileAsync('git', ['init', '--quiet'], { cwd: parentPath });
+
+  const selected: string[] = [];
+  let nextDirectory = parentPath;
+  let nextId = 0;
+  const catalog = createProjectCatalog(join(base, 'storage'), {
+    now: () => 1_000,
+    createId: () => `project-${++nextId}`,
+  });
+  const service = createProjectManagementService({
+    capabilities: LOCAL_CAPABILITIES,
+    catalog: managementCatalog(catalog),
+    chooseDirectory: async () => nextDirectory,
+    selection: {
+      currentSelection: async () => ({
+        projectId: selected.length === 0 ? undefined : `project-${selected.length}`,
+        path: selected.at(-1) ?? (await realpath(parentPath)),
+      }),
+      setSelection: (_projectId, path) => selected.push(path),
+    },
+  });
+
+  try {
+    const parent = await service.add();
+    assert.equal(parent.ok, true);
+    if (!parent.ok) return;
+    assert.equal(parent.path, await realpath(parentPath));
+
+    nextDirectory = childPath;
+    const child = await service.add();
+    assert.equal(child.ok, true);
+    if (!child.ok) return;
+    assert.notEqual(child.project.id, parent.project.id);
+    assert.equal(child.path, await realpath(childPath));
+    assert.equal(selected.at(-1), await realpath(childPath));
+  } finally {
+    catalog.close();
     await rm(base, { recursive: true, force: true });
   }
 });

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -157,6 +157,8 @@ test('registering a nested folder keeps that folder instead of the enclosing rep
 
 test('relink and relinkWithSessions keep a nested repository directory', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-project-nested-relink-'));
+  const storage = join(base, 'storage');
+  const sessions = createSessionStore(storage);
   try {
     const parent = join(base, 'parent-project');
     const child = join(parent, 'child-project');
@@ -168,7 +170,7 @@ test('relink and relinkWithSessions keep a nested repository directory', async (
     await mkdir(elsewhere, { recursive: true });
     await mkdir(elsewhereTwo, { recursive: true });
     await execFileAsync('git', ['init', '--quiet'], { cwd: parent });
-    const catalog = createProjectCatalog(join(base, 'storage'), {
+    const catalog = createProjectCatalog(storage, {
       now: () => 1_000,
       createId: (() => {
         let id = 0;
@@ -181,20 +183,26 @@ test('relink and relinkWithSessions keep a nested repository directory', async (
     const originalSessions = await catalog.register(elsewhereTwo);
     const childPath = await realpath(child);
     const childTwoPath = await realpath(childTwo);
+    const assigned = await sessions.create(sessionInput(elsewhereTwo, originalSessions.id));
 
     const relinked = await catalog.relink(original.id, child);
     assert.equal(relinked.id, original.id);
     assert.notEqual(relinked.id, parentProject.id);
     assert.equal(relinked.preferredPath, childPath);
 
-    const { project: relinkedSessions } = await catalog.relinkWithSessions(
+    const { project: relinkedSessions, updatedSessionIds } = await catalog.relinkWithSessions(
       originalSessions.id,
       childTwo,
     );
     assert.equal(relinkedSessions.id, originalSessions.id);
     assert.notEqual(relinkedSessions.id, parentProject.id);
     assert.equal(relinkedSessions.preferredPath, childTwoPath);
+    assert.deepEqual(updatedSessionIds, [assigned.id]);
+    const header = await sessions.readHeaderSnapshot(assigned.id);
+    assert.equal(header.projectId, relinkedSessions.id);
+    assert.equal(header.cwd, childTwoPath);
   } finally {
+    await sessions.close?.();
     await rm(base, { recursive: true, force: true });
   }
 });

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -155,6 +155,50 @@ test('registering a nested folder keeps that folder instead of the enclosing rep
   }
 });
 
+test('relink and relinkWithSessions keep a nested repository directory', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-nested-relink-'));
+  try {
+    const parent = join(base, 'parent-project');
+    const child = join(parent, 'child-project');
+    const childTwo = join(parent, 'child-two');
+    const elsewhere = join(base, 'elsewhere');
+    const elsewhereTwo = join(base, 'elsewhere-two');
+    await mkdir(child, { recursive: true });
+    await mkdir(childTwo, { recursive: true });
+    await mkdir(elsewhere, { recursive: true });
+    await mkdir(elsewhereTwo, { recursive: true });
+    await execFileAsync('git', ['init', '--quiet'], { cwd: parent });
+    const catalog = createProjectCatalog(join(base, 'storage'), {
+      now: () => 1_000,
+      createId: (() => {
+        let id = 0;
+        return () => `project-${++id}`;
+      })(),
+    });
+
+    const parentProject = await catalog.register(parent);
+    const original = await catalog.register(elsewhere);
+    const originalSessions = await catalog.register(elsewhereTwo);
+    const childPath = await realpath(child);
+    const childTwoPath = await realpath(childTwo);
+
+    const relinked = await catalog.relink(original.id, child);
+    assert.equal(relinked.id, original.id);
+    assert.notEqual(relinked.id, parentProject.id);
+    assert.equal(relinked.preferredPath, childPath);
+
+    const { project: relinkedSessions } = await catalog.relinkWithSessions(
+      originalSessions.id,
+      childTwo,
+    );
+    assert.equal(relinkedSessions.id, originalSessions.id);
+    assert.notEqual(relinkedSessions.id, parentProject.id);
+    assert.equal(relinkedSessions.preferredPath, childTwoPath);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 async function resolveProjectLocationWithoutGit(path: string): Promise<ResolvedProjectLocation> {
   const stdout = await runProjectCatalogWithoutGit(
     'const [moduleUrl, path] = process.argv.slice(1); const { resolveProjectLocation } = await import(moduleUrl); console.log(JSON.stringify(await resolveProjectLocation({ path })));',

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -10,9 +10,9 @@ import {
   createProjectCatalog as createProjectCatalogBase,
   type ProjectCatalog,
   ProjectUnavailableError,
+  ProjectPathMismatchError,
   type ResolvedProjectLocation,
   resolveProjectLocation,
-  resolveUserSelectedProjectLocation,
 } from '../project-catalog.js';
 import { createSessionStore } from '../session-store.js';
 import { createGitRepositoryWithWorktree } from './fixtures/git-repository.js';
@@ -136,20 +136,20 @@ test('registering a nested folder keeps that folder instead of the enclosing rep
     const childProject = await catalog.register(child);
     const parentPath = await realpath(parent);
     const childPath = await realpath(child);
-    const parentLocation = await resolveProjectLocation({ path: parent });
 
     assert.notEqual(childProject.id, parentProject.id);
     assert.equal(parentProject.preferredPath, parentPath);
     assert.equal(childProject.preferredPath, childPath);
     assert.equal(childProject.name, 'child-project');
-    assert.equal(parentLocation.kind, 'git');
-    assert.equal((await resolveProjectLocation({ path: child })).identity, parentLocation.identity);
-    assert.deepEqual(await resolveUserSelectedProjectLocation(child), {
-      canonicalPath: childPath,
-      identity: `folder:${childPath}`,
-      kind: 'folder',
-    });
-    assert.equal((await catalog.resolveHistoricalPath(child)).id, parentProject.id);
+
+    // session.create → HostWorkspaceResolver.touch(projectId, preferredPath)
+    const touched = await catalog.touch(childProject.id, childProject.preferredPath);
+    assert.equal(touched.id, childProject.id);
+    assert.equal(touched.preferredPath, childPath);
+    await assert.rejects(
+      () => catalog.touch(childProject.id, parentPath),
+      (error) => error instanceof ProjectPathMismatchError && error.projectId === childProject.id,
+    );
   } finally {
     await rm(base, { recursive: true, force: true });
   }

--- a/packages/storage/src/__tests__/project-catalog.test.ts
+++ b/packages/storage/src/__tests__/project-catalog.test.ts
@@ -12,6 +12,7 @@ import {
   ProjectUnavailableError,
   type ResolvedProjectLocation,
   resolveProjectLocation,
+  resolveUserSelectedProjectLocation,
 } from '../project-catalog.js';
 import { createSessionStore } from '../session-store.js';
 import { createGitRepositoryWithWorktree } from './fixtures/git-repository.js';
@@ -111,6 +112,44 @@ test('a repository and its linked worktree resolve to one project identity', asy
     assert.notEqual(main.canonicalPath, linked.canonicalPath);
     assert.equal(main.git?.isWorktree, false);
     assert.equal(linked.git?.isWorktree, true);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('registering a nested folder keeps that folder instead of the enclosing repository', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-project-nested-folder-'));
+  try {
+    const parent = join(base, 'parent-project');
+    const child = join(parent, 'child-project');
+    await mkdir(child, { recursive: true });
+    await execFileAsync('git', ['init', '--quiet'], { cwd: parent });
+    const catalog = createProjectCatalog(join(base, 'storage'), {
+      now: () => 1_000,
+      createId: (() => {
+        let id = 0;
+        return () => `project-${++id}`;
+      })(),
+    });
+
+    const parentProject = await catalog.register(parent);
+    const childProject = await catalog.register(child);
+    const parentPath = await realpath(parent);
+    const childPath = await realpath(child);
+    const parentLocation = await resolveProjectLocation({ path: parent });
+
+    assert.notEqual(childProject.id, parentProject.id);
+    assert.equal(parentProject.preferredPath, parentPath);
+    assert.equal(childProject.preferredPath, childPath);
+    assert.equal(childProject.name, 'child-project');
+    assert.equal(parentLocation.kind, 'git');
+    assert.equal((await resolveProjectLocation({ path: child })).identity, parentLocation.identity);
+    assert.deepEqual(await resolveUserSelectedProjectLocation(child), {
+      canonicalPath: childPath,
+      identity: `folder:${childPath}`,
+      kind: 'folder',
+    });
+    assert.equal((await catalog.resolveHistoricalPath(child)).id, parentProject.id);
   } finally {
     await rm(base, { recursive: true, force: true });
   }

--- a/packages/storage/src/project-catalog.ts
+++ b/packages/storage/src/project-catalog.ts
@@ -845,7 +845,7 @@ async function resolveUserSelectedProjectLocation(path: string): Promise<Resolve
   if (
     resolved.kind !== 'git' ||
     !resolved.git ||
-    normalize(resolved.canonicalPath) === normalize(resolved.git.worktreeRoot)
+    resolved.canonicalPath === resolved.git.worktreeRoot
   ) {
     return resolved;
   }

--- a/packages/storage/src/project-catalog.ts
+++ b/packages/storage/src/project-catalog.ts
@@ -271,27 +271,24 @@ class SqliteProjectCatalog implements ProjectCatalog {
   }
 
   async touch(projectId: string, path?: string): Promise<ProjectRecord> {
-    let resolved: Awaited<ReturnType<typeof resolveProjectLocation>> | undefined;
-    try {
-      resolved = path ? await resolveProjectLocation({ path }) : undefined;
-    } catch {
-      throw new ProjectUnavailableError(projectId);
+    let canonicalPath: string | undefined;
+    if (path) {
+      try {
+        canonicalPath = normalize(await realpath(resolve(path)));
+      } catch {
+        throw new ProjectUnavailableError(projectId);
+      }
     }
-    const resolvedPath = resolved
-      ? resolved.kind === 'git'
-        ? resolved.git!.worktreeRoot
-        : resolved.canonicalPath
-      : undefined;
     const touched = await this.mutate((file) => {
       const project = findProjectById(file.projects, projectId);
       if (!project) throw new ProjectNotFoundError(projectId);
-      const location = resolvedPath
-        ? project.locations.find((item) => item.path === resolvedPath)
+      const location = canonicalPath
+        ? project.locations.find((item) => item.path === canonicalPath)
         : [...project.locations].sort(
             (a, b) => b.lastUsedAt - a.lastUsedAt || a.path.localeCompare(b.path),
           )[0];
-      if (resolvedPath && !location) {
-        throw new ProjectPathMismatchError(projectId, resolvedPath);
+      if (canonicalPath && !location) {
+        throw new ProjectPathMismatchError(projectId, canonicalPath);
       }
       const timestamp = this.now();
       if (location) location.lastUsedAt = timestamp;
@@ -843,9 +840,7 @@ export async function resolveProjectLocation(input: {
  * The chooser must not do that: selecting `repo/child` would otherwise
  * silently become `repo` and reopen the parent project.
  */
-export async function resolveUserSelectedProjectLocation(
-  path: string,
-): Promise<ResolvedProjectLocation> {
+async function resolveUserSelectedProjectLocation(path: string): Promise<ResolvedProjectLocation> {
   const resolved = await resolveProjectLocation({ path });
   if (
     resolved.kind !== 'git' ||

--- a/packages/storage/src/project-catalog.ts
+++ b/packages/storage/src/project-catalog.ts
@@ -164,7 +164,7 @@ class SqliteProjectCatalog implements ProjectCatalog {
   }
 
   async register(path: string): Promise<ProjectRecord> {
-    const resolved = await resolveProjectLocation({ path });
+    const resolved = await resolveUserSelectedProjectLocation(path);
     return this.upsertResolvedProject(resolved, this.now());
   }
 
@@ -302,7 +302,7 @@ class SqliteProjectCatalog implements ProjectCatalog {
   }
 
   async relink(projectId: string, path: string): Promise<ProjectRecord> {
-    const resolved = await resolveProjectLocation({ path });
+    const resolved = await resolveUserSelectedProjectLocation(path);
     const timestamp = this.now();
     const locationPath =
       resolved.kind === 'git' ? resolved.git!.worktreeRoot : resolved.canonicalPath;
@@ -322,7 +322,7 @@ class SqliteProjectCatalog implements ProjectCatalog {
     projectId: string,
     path: string,
   ): Promise<{ project: ProjectRecord; updatedSessionIds: readonly string[] }> {
-    const resolved = await resolveProjectLocation({ path });
+    const resolved = await resolveUserSelectedProjectLocation(path);
     const timestamp = this.now();
     const locationPath =
       resolved.kind === 'git' ? resolved.git!.worktreeRoot : resolved.canonicalPath;
@@ -832,6 +832,32 @@ export async function resolveProjectLocation(input: {
     identity: `git:${git.commonDir}`,
     kind: 'git',
     git,
+  };
+}
+
+/**
+ * A directory the user picked in the add/relink chooser.
+ *
+ * `resolveProjectLocation` still walks to the enclosing Git worktree so a
+ * historical session cwd inside a repository stays on that repository.
+ * The chooser must not do that: selecting `repo/child` would otherwise
+ * silently become `repo` and reopen the parent project.
+ */
+export async function resolveUserSelectedProjectLocation(
+  path: string,
+): Promise<ResolvedProjectLocation> {
+  const resolved = await resolveProjectLocation({ path });
+  if (
+    resolved.kind !== 'git' ||
+    !resolved.git ||
+    normalize(resolved.canonicalPath) === normalize(resolved.git.worktreeRoot)
+  ) {
+    return resolved;
+  }
+  return {
+    canonicalPath: resolved.canonicalPath,
+    identity: `folder:${resolved.canonicalPath}`,
+    kind: 'folder',
   };
 }
 


### PR DESCRIPTION
## Summary

Adding a project from a folder that lives inside an existing Git project remapped the selection to the repository root. `register` used `resolveProjectLocation`, which walks to the enclosing worktree, so `parent/child` became `parent` and the already-registered parent project was reopened.

User-chosen add/relink paths now keep the exact selected folder when it is not the worktree root. A repository root and a linked worktree still share one Git identity. Historical session cwds still resolve to the enclosing repository, so a session that ran in `repo/src` does not become a new project.

Fixes #2660

## Verification

- `npm --workspace @maka/storage run build`
- `npm --workspace @maka/storage run typecheck`
- `node --test packages/storage/dist/__tests__/project-catalog.test.js` — **19/19** (includes the new parent/child case)
- `npx tsx --test apps/desktop/src/main/__tests__/project-management-service.test.ts` — **6/6**
- `npx tsx --test apps/desktop/src/main/__tests__/new-session-project.test.ts` — **7/7**
- Not run: `@maka/desktop` `build:main` — current `main` fails typecheck on unrelated files (`assistant-stream.test.ts`, `chat-readiness.ts`, `conversation-copy.ts` missing `oauth_subscription_not_wired`)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Grok authored the implementation, tests, and this PR description.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No