### PR TITLE
chore: disable CodeRabbit docstring coverage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -38,6 +38,8 @@ reviews:
     - Do not classify the PR as a fast-path candidate or present the assessment as authorization. State that the person performing the merge reviews the final diff and a maintainer makes the final determination.
 
   pre_merge_checks:
+    docstrings:
+      mode: "off"
     description:
       mode: "warning"
     custom_checks:


### PR DESCRIPTION
## Summary

Disable CodeRabbit's built-in docstring coverage pre-merge check.

The check applies a generic 80% documentation threshold to changed code elements. That threshold does not match this TypeScript and mixed-language repository's documentation conventions and has produced low-signal warnings, including 0% coverage on otherwise normal changes. Disabling it removes that noise without changing the title, description, issue-assessment, or custom AI-use checks.

## Verification

- Parsed `.coderabbit.yaml` successfully with Ruby/Psych.
- `git diff --check` passes.
- No application tests were run because this change only affects CodeRabbit configuration.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex investigated the built-in pre-merge checks, edited the CodeRabbit configuration, validated the YAML, and prepared this PR.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
