### PR TITLE
refactor(desktop): let the import page name the conversation it lost track of

### DIFF
--- a/apps/desktop/src/renderer/locales/external-session-import-copy.ts
+++ b/apps/desktop/src/renderer/locales/external-session-import-copy.ts
@@ -31,7 +31,12 @@ type ExternalSessionImportCopy = {
   importFailedTitle: string;
   importFailedFallback: string;
   importOutcomeUnknownTitle: string;
-  importOutcomeUnknownDescription: string;
+  /**
+   * Takes the conversation names because this is the only place that can say
+   * which ones to go look for — the rows they came from may have been filtered
+   * or paged away by the time it renders.
+   */
+  importOutcomeUnknownDescription: (names: readonly string[]) => string;
 };
 
 const COPY = {
@@ -44,7 +49,12 @@ const COPY = {
     emptyTitle: '没有可导入的对话',
     emptyDescription: '当前来源中没有找到符合条件的根对话。',
     unavailableTitle: '没有检测到支持的 Agent',
-    unavailableDescription: 'Maka 会在本机读取 Codex 的对话目录，不会修改其中的文件。',
+    // The title already says nothing was detected, so this says what to do
+    // about it instead of saying it again. It names Codex because the renderer
+    // only ever learns which sources *were* detected — nothing but a copy
+    // string can tell someone with none what to go install. The second half is
+    // the promise that earns the permission to read another app's files.
+    unavailableDescription: '在本机使用过 Codex 后，它的对话会出现在这里。Maka 只读取这些文件，不会修改。',
     loadFailedTitle: '无法读取外部对话',
     loadFailedFallback: '外部对话目录暂时无法读取，请重试。',
     retry: '重试',
@@ -58,8 +68,8 @@ const COPY = {
     importFailedTitle: '导入失败',
     importFailedFallback: '该对话无法转换或保存。请检查来源后重试。',
     importOutcomeUnknownTitle: '需要确认导入结果',
-    importOutcomeUnknownDescription:
-      '导入结果暂时无法确认。请先在任务列表中查找这个对话；如果它已经出现，请不要再次导入。',
+    importOutcomeUnknownDescription: (names) =>
+      `以下对话的导入结果无法确认：${names.map((name) => `「${name}」`).join('、')}。请先在任务列表中查找，已经出现的不要再次导入。`,
   },
   en: {
     sourceLabel: 'Source',
@@ -70,7 +80,8 @@ const COPY = {
     emptyTitle: 'No conversations to import',
     emptyDescription: 'No matching root conversations were found in this source.',
     unavailableTitle: 'No supported Agent detected',
-    unavailableDescription: "Maka reads Codex's local session directory without modifying its files.",
+    unavailableDescription:
+      'Once Codex has been used on this machine, its conversations appear here. Maka only reads those files and never modifies them.',
     loadFailedTitle: 'Could not read external conversations',
     loadFailedFallback: 'The external session directory is temporarily unavailable. Try again.',
     retry: 'Retry',
@@ -84,8 +95,8 @@ const COPY = {
     importFailedTitle: 'Import failed',
     importFailedFallback: 'This conversation could not be converted or saved. Check the source and try again.',
     importOutcomeUnknownTitle: 'Check the import result',
-    importOutcomeUnknownDescription:
-      'Maka could not confirm whether the import completed. Look for this conversation in the task list first; if it is already there, do not import it again.',
+    importOutcomeUnknownDescription: (names) =>
+      `Maka could not confirm the outcome of these imports: ${names.map((name) => `“${name}”`).join(', ')}. Look in the task list first, and do not import again anything that is already there.`,
   },
 } satisfies UiCatalog<ExternalSessionImportCopy>;
 

--- a/apps/desktop/src/renderer/locales/external-session-import-copy.ts
+++ b/apps/desktop/src/renderer/locales/external-session-import-copy.ts
@@ -28,6 +28,13 @@ type ExternalSessionImportCopy = {
   import: string;
   importTask: (name: string) => string;
   importing: string;
+  importInProgressTitle: string;
+  /**
+   * Named, for the same reason the unconfirmed banner names its conversations:
+   * the catalog is free to change while an import runs, so the row this started
+   * from may already be filtered or paged away.
+   */
+  importInProgressDescription: (name: string) => string;
   importFailedTitle: string;
   importFailedFallback: string;
   importOutcomeUnknownTitle: string;
@@ -65,6 +72,8 @@ const COPY = {
     import: '导入',
     importTask: (name) => `导入「${name}」`,
     importing: '正在导入…',
+    importInProgressTitle: '正在导入',
+    importInProgressDescription: (name) => `正在导入「${name}」，完成后会直接打开这个任务。`,
     importFailedTitle: '导入失败',
     importFailedFallback: '该对话无法转换或保存。请检查来源后重试。',
     importOutcomeUnknownTitle: '需要确认导入结果',
@@ -92,6 +101,9 @@ const COPY = {
     import: 'Import',
     importTask: (name) => `Import ${name}`,
     importing: 'Importing…',
+    importInProgressTitle: 'Import in progress',
+    importInProgressDescription: (name) =>
+      `Importing “${name}”. Maka opens the task as soon as it lands.`,
     importFailedTitle: 'Import failed',
     importFailedFallback: 'This conversation could not be converted or saved. Check the source and try again.',
     importOutcomeUnknownTitle: 'Check the import result',

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -266,6 +266,13 @@ export function ImportTasksSettingsPage(props: {
               layout="fill"
               size="sm"
               onChange={setAdapterId}
+              // Frozen during an import for the same reason the filter below
+              // is: either one replaces the catalog, which would take away the
+              // row the in-flight import belongs to while every other row is
+              // still disabled. `importingId` is a bare source id, and those
+              // are unique only within one source — the second adapter would
+              // otherwise be able to show 正在导入… on an unrelated row.
+              isDisabled={catalogLoading || importingId !== null}
             >
               {adapterIds.map((id) => (
                 <SegmentedControlItem key={id} value={id} label={sourceLabel(id, copy.codex)} />

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -201,6 +201,19 @@ export function ImportTasksSettingsPage(props: {
     [adapterId, copy.importFailedFallback, importingId, locale, mountedRef, props],
   );
 
+  /**
+   * The one thing an in-flight import needs is to stay identifiable until it
+   * settles, and every catalog control can take its row away: a `loadCatalog`
+   * without a cursor resets the catalog to page one, and the source switch,
+   * the archived filter and 重试 all trigger one.
+   *
+   * 加载更多 appends, so it would keep the row. It is frozen anyway: a page
+   * where every control but one holds still has to be read control by control
+   * before it can be trusted, and nothing is lost by waiting out an import that
+   * takes well under a second.
+   */
+  const catalogFrozen = importingId !== null;
+
   const noSource = sourceResolved && !sourceLoading && !sourceError && adapterIds.length === 0;
   const catalogEmpty =
     adapterId !== null && !catalogLoading && !catalogError && catalog.sessions.length === 0;
@@ -266,13 +279,11 @@ export function ImportTasksSettingsPage(props: {
               layout="fill"
               size="sm"
               onChange={setAdapterId}
-              // Frozen during an import for the same reason the filter below
-              // is: either one replaces the catalog, which would take away the
-              // row the in-flight import belongs to while every other row is
-              // still disabled. `importingId` is a bare source id, and those
-              // are unique only within one source — the second adapter would
-              // otherwise be able to show 正在导入… on an unrelated row.
-              isDisabled={catalogLoading || importingId !== null}
+              // Freezing this also closes a collision `importingId` is open to:
+              // it holds a bare source id, and those are unique only within one
+              // source, so a second adapter could otherwise show 正在导入… on an
+              // unrelated row.
+              isDisabled={catalogLoading || catalogFrozen}
             >
               {adapterIds.map((id) => (
                 <SegmentedControlItem key={id} value={id} label={sourceLabel(id, copy.codex)} />
@@ -283,7 +294,7 @@ export function ImportTasksSettingsPage(props: {
             label={copy.includeArchived}
             value={includeArchived}
             onChange={setIncludeArchived}
-            isDisabled={catalogLoading || importingId !== null}
+            isDisabled={catalogLoading || catalogFrozen}
           />
         </VStack>
       </SettingsSection>
@@ -301,6 +312,7 @@ export function ImportTasksSettingsPage(props: {
                     variant="ghost"
                     size="sm"
                     label={copy.retry}
+                    isDisabled={catalogFrozen}
                     onClick={() => void loadCatalog(adapterId)}
                   />
                 )
@@ -401,7 +413,7 @@ export function ImportTasksSettingsPage(props: {
               size="sm"
               width="100%"
               label={loadingMore ? copy.loadingMore : copy.loadMore}
-              isDisabled={loadingMore}
+              isDisabled={loadingMore || catalogFrozen}
               // `onClick` for the same reason as the row buttons: inside
               // `clickAction`'s transition `loadingMore` commits too late to
               // disable anything or to say 正在加载….

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -370,12 +370,17 @@ export function ImportTasksSettingsPage(props: {
                               entry.sourceSessionId === session.id,
                           )
                         }
-                        // Returned, not discarded: Astryx's Button awaits a
-                        // promise-returning `clickAction` and drops repeat
-                        // clicks until it settles. `void`-ing it gave that
-                        // guarantee nothing to await, leaving double-submit to
-                        // the `importingId` state alone -- one render behind.
-                        clickAction={() => importConversation(session)}
+                        // `onClick`, not `clickAction`. Astryx runs
+                        // `clickAction` inside a React 19 async transition,
+                        // and React holds a transition's state updates until
+                        // the action settles, so `setImportingId` landed only
+                        // once the import was already over: every control that
+                        // reads it -- this row's 正在导入…, the other rows, the
+                        // archived filter, the source switch -- stayed live for
+                        // the whole import. `clickAction` buys the clicked
+                        // button its own pending state, and that is all it
+                        // buys; this lock is a page fact, so the page owns it.
+                        onClick={() => void importConversation(session)}
                         label={importingId === session.id ? copy.importing : copy.import}
                         // Every row's button reads 导入; only the accessible
                         // name can say which conversation it imports.
@@ -397,7 +402,10 @@ export function ImportTasksSettingsPage(props: {
               width="100%"
               label={loadingMore ? copy.loadingMore : copy.loadMore}
               isDisabled={loadingMore}
-              clickAction={() => loadCatalog(adapterId, catalog.nextCursor ?? undefined)}
+              // `onClick` for the same reason as the row buttons: inside
+              // `clickAction`'s transition `loadingMore` commits too late to
+              // disable anything or to say 正在加载….
+              onClick={() => void loadCatalog(adapterId, catalog.nextCursor ?? undefined)}
             />
           )}
         </VStack>

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -23,19 +23,28 @@ type CatalogState = {
 const EMPTY_CATALOG: CatalogState = { sessions: [], nextCursor: null };
 
 /**
- * An import Desktop Main could neither confirm nor fail.
+ * One conversation this page has handed to Desktop Main.
  *
- * The name is carried, not just the id, because the only thing that can tell
- * the user which conversation to go look for is this record: by the time the
- * banner renders, the row it came from may have been filtered or paged away.
- * The adapter is carried because a source-native id is unique only within its
- * own source.
+ * The record is carried rather than the row's id alone, because everything the
+ * page has to say about an import — which one is running, which one came back
+ * unconfirmed — has to stay true after the row is gone. The archived filter, a
+ * source switch and a retry each replace the catalog, so a bare id is a pointer
+ * into a list that is allowed to change underneath it. The adapter is part of
+ * the record because a source-native id is unique only within its own source.
  */
-type UncertainImport = {
+type ImportAttempt = {
   adapterId: string;
   sourceSessionId: string;
   name: string;
 };
+
+function isSameAttempt(
+  attempt: ImportAttempt,
+  adapterId: string | null,
+  session: ExternalSessionSummary,
+): boolean {
+  return attempt.adapterId === adapterId && attempt.sourceSessionId === session.id;
+}
 
 /**
  * Settings · 活动 · 导入任务 — bring another local agent's conversations in as
@@ -74,7 +83,13 @@ export function ImportTasksSettingsPage(props: {
   const [sourceResolved, setSourceResolved] = useState(false);
   const [catalogLoading, setCatalogLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [importingId, setImportingId] = useState<string | null>(null);
+  /**
+   * At most one import at a time. Not because two conversions would collide —
+   * Desktop Main can take both — but because the first one to succeed calls
+   * `onImported`, which closes Settings and opens the new task, orphaning any
+   * other import on a page the user can no longer see.
+   */
+  const [activeImport, setActiveImport] = useState<ImportAttempt | null>(null);
   const [sourceError, setSourceError] = useState<string | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
@@ -83,7 +98,7 @@ export function ImportTasksSettingsPage(props: {
    * two copies of it, so its row stays disabled for the rest of this page's
    * lifetime and the banner names it as the one to go look for.
    */
-  const [uncertainImports, setUncertainImports] = useState<readonly UncertainImport[]>([]);
+  const [uncertainImports, setUncertainImports] = useState<readonly ImportAttempt[]>([]);
   // Only the newest list request may write. Switching source or toggling the
   // archived filter while a page is in flight would otherwise land the old
   // source's rows under the new source's label.
@@ -170,13 +185,18 @@ export function ImportTasksSettingsPage(props: {
 
   const importConversation = useCallback(
     async (session: ExternalSessionSummary) => {
-      if (adapterId === null || importingId !== null) return;
-      setImportingId(session.id);
+      if (adapterId === null || activeImport !== null) return;
+      const attempt: ImportAttempt = {
+        adapterId,
+        sourceSessionId: session.id,
+        name: session.name,
+      };
+      setActiveImport(attempt);
       setImportError(null);
       try {
         const outcome = await window.maka.externalSessions.import({
-          adapterId,
-          sourceSessionId: session.id,
+          adapterId: attempt.adapterId,
+          sourceSessionId: attempt.sourceSessionId,
         });
         // Navigating away from Settings unmounts this page while the import is
         // still in Desktop Main's hands. The conversion itself completes and is
@@ -184,10 +204,7 @@ export function ImportTasksSettingsPage(props: {
         // the user has left steering the shell somewhere they did not ask for.
         if (!mountedRef.current) return;
         if (!outcome.ok) {
-          setUncertainImports((current) => [
-            ...current,
-            { adapterId, sourceSessionId: session.id, name: session.name },
-          ]);
+          setUncertainImports((current) => [...current, attempt]);
           return;
         }
         props.onImported(outcome.session);
@@ -195,24 +212,11 @@ export function ImportTasksSettingsPage(props: {
         if (!mountedRef.current) return;
         setImportError(localizedShellErrorMessage(error, copy.importFailedFallback, locale));
       } finally {
-        if (mountedRef.current) setImportingId(null);
+        if (mountedRef.current) setActiveImport(null);
       }
     },
-    [adapterId, copy.importFailedFallback, importingId, locale, mountedRef, props],
+    [activeImport, adapterId, copy.importFailedFallback, locale, mountedRef, props],
   );
-
-  /**
-   * The one thing an in-flight import needs is to stay identifiable until it
-   * settles, and every catalog control can take its row away: a `loadCatalog`
-   * without a cursor resets the catalog to page one, and the source switch,
-   * the archived filter and 重试 all trigger one.
-   *
-   * 加载更多 appends, so it would keep the row. It is frozen anyway: a page
-   * where every control but one holds still has to be read control by control
-   * before it can be trusted, and nothing is lost by waiting out an import that
-   * takes well under a second.
-   */
-  const catalogFrozen = importingId !== null;
 
   const noSource = sourceResolved && !sourceLoading && !sourceError && adapterIds.length === 0;
   const catalogEmpty =
@@ -279,11 +283,7 @@ export function ImportTasksSettingsPage(props: {
               layout="fill"
               size="sm"
               onChange={setAdapterId}
-              // Freezing this also closes a collision `importingId` is open to:
-              // it holds a bare source id, and those are unique only within one
-              // source, so a second adapter could otherwise show 正在导入… on an
-              // unrelated row.
-              isDisabled={catalogLoading || catalogFrozen}
+              isDisabled={catalogLoading}
             >
               {adapterIds.map((id) => (
                 <SegmentedControlItem key={id} value={id} label={sourceLabel(id, copy.codex)} />
@@ -294,7 +294,7 @@ export function ImportTasksSettingsPage(props: {
             label={copy.includeArchived}
             value={includeArchived}
             onChange={setIncludeArchived}
-            isDisabled={catalogLoading || catalogFrozen}
+            isDisabled={catalogLoading}
           />
         </VStack>
       </SettingsSection>
@@ -312,7 +312,6 @@ export function ImportTasksSettingsPage(props: {
                     variant="ghost"
                     size="sm"
                     label={copy.retry}
-                    isDisabled={catalogFrozen}
                     onClick={() => void loadCatalog(adapterId)}
                   />
                 )
@@ -322,6 +321,20 @@ export function ImportTasksSettingsPage(props: {
 
           {importError && (
             <Banner status="error" title={copy.importFailedTitle} description={importError} />
+          )}
+
+          {/* Named here rather than only on its row, because the catalog is
+              free to change while an import runs: filter it out, switch source,
+              retry a failed page, and the row is gone. This is also what tells
+              the user why every remaining 导入 is disabled. */}
+          {activeImport !== null && (
+            <div role="status" aria-live="polite">
+              <Banner
+                status="info"
+                title={copy.importInProgressTitle}
+                description={copy.importInProgressDescription(activeImport.name)}
+              />
+            </div>
           )}
 
           {uncertainImports.length > 0 && (
@@ -363,6 +376,8 @@ export function ImportTasksSettingsPage(props: {
                 ]
                   .filter(Boolean)
                   .join(' · ');
+                const isImporting =
+                  activeImport !== null && isSameAttempt(activeImport, adapterId, session);
                 return (
                   <ListItem
                     key={session.id}
@@ -373,27 +388,23 @@ export function ImportTasksSettingsPage(props: {
                       <Button
                         variant="secondary"
                         size="sm"
-                        isLoading={importingId === session.id}
+                        isLoading={isImporting}
                         isDisabled={
-                          importingId !== null ||
-                          uncertainImports.some(
-                            (entry) =>
-                              entry.adapterId === adapterId &&
-                              entry.sourceSessionId === session.id,
+                          activeImport !== null ||
+                          uncertainImports.some((entry) =>
+                            isSameAttempt(entry, adapterId, session),
                           )
                         }
                         // `onClick`, not `clickAction`. Astryx runs
-                        // `clickAction` inside a React 19 async transition,
-                        // and React holds a transition's state updates until
-                        // the action settles, so `setImportingId` landed only
-                        // once the import was already over: every control that
-                        // reads it -- this row's 正在导入…, the other rows, the
-                        // archived filter, the source switch -- stayed live for
-                        // the whole import. `clickAction` buys the clicked
-                        // button its own pending state, and that is all it
-                        // buys; this lock is a page fact, so the page owns it.
+                        // `clickAction` inside a React 19 async transition, and
+                        // React holds a transition's state updates until the
+                        // action settles, so `setActiveImport` landed only once
+                        // the import was already over and nothing on the page
+                        // could tell that one was running. `clickAction` buys
+                        // the clicked button its own pending state, and that is
+                        // all it buys; this is a page fact, so the page owns it.
                         onClick={() => void importConversation(session)}
-                        label={importingId === session.id ? copy.importing : copy.import}
+                        label={isImporting ? copy.importing : copy.import}
                         // Every row's button reads 导入; only the accessible
                         // name can say which conversation it imports.
                         aria-label={copy.importTask(session.name)}
@@ -413,7 +424,7 @@ export function ImportTasksSettingsPage(props: {
               size="sm"
               width="100%"
               label={loadingMore ? copy.loadingMore : copy.loadMore}
-              isDisabled={loadingMore || catalogFrozen}
+              isDisabled={loadingMore}
               // `onClick` for the same reason as the row buttons: inside
               // `clickAction`'s transition `loadingMore` commits too late to
               // disable anything or to say 正在加载….

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -23,6 +23,21 @@ type CatalogState = {
 const EMPTY_CATALOG: CatalogState = { sessions: [], nextCursor: null };
 
 /**
+ * An import Desktop Main could neither confirm nor fail.
+ *
+ * The name is carried, not just the id, because the only thing that can tell
+ * the user which conversation to go look for is this record: by the time the
+ * banner renders, the row it came from may have been filtered or paged away.
+ * The adapter is carried because a source-native id is unique only within its
+ * own source.
+ */
+type UncertainImport = {
+  adapterId: string;
+  sourceSessionId: string;
+  name: string;
+};
+
+/**
  * Settings · 活动 · 导入任务 — bring another local agent's conversations in as
  * Maka tasks.
  *
@@ -64,12 +79,11 @@ export function ImportTasksSettingsPage(props: {
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
   /**
-   * Conversations whose import neither succeeded nor failed — Desktop Main
-   * could not confirm the outcome. Re-importing one is how you end up with two
-   * copies of the same conversation, so those rows stay disabled for the rest
-   * of this page's lifetime and the banner says where to look instead.
+   * Re-importing a conversation whose outcome is unknown is how you end up with
+   * two copies of it, so its row stays disabled for the rest of this page's
+   * lifetime and the banner names it as the one to go look for.
    */
-  const [uncertainIds, setUncertainIds] = useState<ReadonlySet<string>>(new Set());
+  const [uncertainImports, setUncertainImports] = useState<readonly UncertainImport[]>([]);
   // Only the newest list request may write. Switching source or toggling the
   // archived filter while a page is in flight would otherwise land the old
   // source's rows under the new source's label.
@@ -155,14 +169,14 @@ export function ImportTasksSettingsPage(props: {
   );
 
   const importConversation = useCallback(
-    async (sourceSessionId: string) => {
+    async (session: ExternalSessionSummary) => {
       if (adapterId === null || importingId !== null) return;
-      setImportingId(sourceSessionId);
+      setImportingId(session.id);
       setImportError(null);
       try {
         const outcome = await window.maka.externalSessions.import({
           adapterId,
-          sourceSessionId,
+          sourceSessionId: session.id,
         });
         // Navigating away from Settings unmounts this page while the import is
         // still in Desktop Main's hands. The conversion itself completes and is
@@ -170,7 +184,10 @@ export function ImportTasksSettingsPage(props: {
         // the user has left steering the shell somewhere they did not ask for.
         if (!mountedRef.current) return;
         if (!outcome.ok) {
-          setUncertainIds((current) => new Set(current).add(sourceSessionId));
+          setUncertainImports((current) => [
+            ...current,
+            { adapterId, sourceSessionId: session.id, name: session.name },
+          ]);
           return;
         }
         props.onImported(outcome.session);
@@ -288,11 +305,13 @@ export function ImportTasksSettingsPage(props: {
             <Banner status="error" title={copy.importFailedTitle} description={importError} />
           )}
 
-          {uncertainIds.size > 0 && (
+          {uncertainImports.length > 0 && (
             <Banner
               status="warning"
               title={copy.importOutcomeUnknownTitle}
-              description={copy.importOutcomeUnknownDescription}
+              description={copy.importOutcomeUnknownDescription(
+                uncertainImports.map((entry) => entry.name),
+              )}
             />
           )}
 
@@ -336,13 +355,20 @@ export function ImportTasksSettingsPage(props: {
                         variant="secondary"
                         size="sm"
                         isLoading={importingId === session.id}
-                        isDisabled={importingId !== null || uncertainIds.has(session.id)}
+                        isDisabled={
+                          importingId !== null ||
+                          uncertainImports.some(
+                            (entry) =>
+                              entry.adapterId === adapterId &&
+                              entry.sourceSessionId === session.id,
+                          )
+                        }
                         // Returned, not discarded: Astryx's Button awaits a
                         // promise-returning `clickAction` and drops repeat
                         // clicks until it settles. `void`-ing it gave that
                         // guarantee nothing to await, leaving double-submit to
                         // the `importingId` state alone -- one render behind.
-                        clickAction={() => importConversation(session.id)}
+                        clickAction={() => importConversation(session)}
                         label={importingId === session.id ? copy.importing : copy.import}
                         // Every row's button reads 导入; only the accessible
                         // name can say which conversation it imports.
@@ -356,15 +382,16 @@ export function ImportTasksSettingsPage(props: {
           )}
 
           {catalog.nextCursor !== null && adapterId !== null && (
-            <HStack hAlign="center">
-              <Button
-                variant="ghost"
-                size="sm"
-                label={loadingMore ? copy.loadingMore : copy.loadMore}
-                isDisabled={loadingMore}
-                onClick={() => void loadCatalog(adapterId, catalog.nextCursor ?? undefined)}
-              />
-            </HStack>
+            /* Full width and `secondary`: as a centred ghost label this read as
+               a caption under the list rather than the control that extends it. */
+            <Button
+              variant="secondary"
+              size="sm"
+              width="100%"
+              label={loadingMore ? copy.loadingMore : copy.loadMore}
+              isDisabled={loadingMore}
+              clickAction={() => loadCatalog(adapterId, catalog.nextCursor ?? undefined)}
+            />
           )}
         </VStack>
       </SettingsSection>


### PR DESCRIPTION
## Summary

设置 · 活动 · 导入任务 shipped in #3033 as a relocation, not a design, and never got a pass over how it reads. The import behaviour itself does not change here.

The page has one action, and taking it ends the page: a successful import calls `closeSettings()` + `openSessionInChat()` (`app-shell.tsx:3408`), so the page unmounts. Everything below follows from that.

**One thing runs through most of this: the page kept source ids where it needed records.** A bare id is a pointer into a list the user is free to replace — filter it, switch source, retry a failed page — so everything built on one either went mute or had to be protected by freezing the list. Both places that held ids now hold `ImportAttempt` (`{ adapterId, sourceSessionId, name }`), because "which conversation, in which source" is the same question whether an import is running or came back unconfirmed.

- **The warning banner now names the conversation whose outcome is unknown.** When Desktop Main can neither confirm nor fail an import, that row stays disabled for the rest of the page's life — but the banner could only say 查找这个对话, with no way to say which one. It kept the source id and nothing else, and pointing at the row was not an option: by the time the banner renders, that row may be gone. Carrying the record, it names every unconfirmed import and stays true without the row.
- **The in-flight import is named above the list, and no control is frozen.** `importingId` was the same bare id, and it fed the only thing that said which import was running: the row's own 正在导入…. Keeping that readable meant keeping the row alive, so the archived filter was frozen for it in #3033, the source switch in 552156f1, and 重试 and 加载更多 in 861fdccd — four controls carrying one rule, added a review round at a time. `activeImport` carries the record, so the page says 正在导入「X」 in the banner slot, where no catalog change can take it away, and says why every 导入 is disabled. The catalog is then free to move underneath an import and all four freezes are gone, along with the id collision the source-switch freeze was closing: the row predicate compares adapter and id together. (The freezes were raised by CodeRabbit across two rounds; this deletes them rather than completing the set.)
- **`加载更多` is a full-width `secondary` button**, not a centred ghost label that read as a caption under the list. `width="100%"` is the shape Astryx documents for this (`Button.tsx:332-335`, `:543`). No "N remaining" is offered: the adapter returns a cursor, not a total.
- **The page-level import lock engages at all now.** Astryx runs `clickAction` inside a React 19 async transition, and React holds a transition's state updates until the action settles — so the state committed only after the import was over, and nothing on the page could tell one was running. Plain `onClick` runs outside the transition and commits before the next event can be dispatched. `加载更多` moves back for the same reason: inside the transition `loadingMore` could neither disable it nor say 正在加载…. Reported by @M4n5ter; the defect predates this PR, but every claim this PR makes about in-flight state was inert without it. Single-flight itself stays, for the one reason that survives: a success calls `onImported`, which closes Settings, so a second import would be orphaned on a page the user can no longer see.
- **The no-adapter empty state no longer repeats its own title.** The title already says nothing was detected; the description now says what to do about it, and keeps the read-only promise that earns the permission to look at another app's files. It still names Codex — the renderer only ever learns which sources *were* detected, so nothing but a copy string can tell someone with none what to install.

### Deliberately not fixed

**「再次导入同一个对话会创建一个独立的任务」 stays where it is.** It only matters to someone asking "have I already imported this one", and the page unmounts on success, so it can never know the answer. Until an imported session persists its external origin, that sentence cannot become per-row information — and no other position beats a single visible line above the list. See #3081.

**Concurrent imports are still not offered.** A rework was tried and dropped early. Single-flight is not a limitation of the importer — Desktop Main can take two — it follows from the page ending on the first success, and lifting it would mean deciding what happens to the imports that were still running when Settings closed.

**Appending a page still moves nothing in the list.** Skeleton placeholder rows were tried and reverted: `List` does not forward `aria-busy` (it destructures a closed prop list with no rest spread, `List.tsx:143-165`), so the ARIA half was dead on arrival, and `Skeleton` has a built-in 1000ms animation delay against a local directory that answers in tens of milliseconds.

Refs #2984

## Before / after

![image](https://github.com/user-attachments/assets/d801bf2f-ac79-47e6-8da7-44ab6394e503)

## Verification

- `npm run format:check`, `npm run lint` — pass
- `npm --workspace @maka/desktop run typecheck` — pass
- `npm --workspace @maka/desktop run build-storybook` + `smoke:storybook` — pass, 130 stories
- Manual pass in Storybook over `product-settings-pages--import-tasks`: the unconfirmed banner naming one conversation, then two, then surviving an archived-filter toggle with both names intact and both rows still disabled; and `--import-tasks-no-source` for the rewritten empty state
- Deferred-import pass with `import` stubbed to never settle. With `clickAction`: the source switch, the archived filter and every sibling row stay interactive and the row still reads 导入. With `onClick`: the banner reads 正在导入「Draft the release notes for 0.9.0」, that row spins, every other 导入 is disabled
- Then the case the freezes existed for: with that import still in flight, turning the archived filter off reloads the catalog and takes its row away. The banner still names it and every remaining row is still disabled — screenshot below
- Unconfirmed path unchanged against the fixture's failing `import`: one name in the banner, then two, both rows disabled, and the lock released between the two clicks

Not run: repository-wide tests, e2e.

## Review focus

**No test fails without this change.** Every difference is visual or in what a control says, and the unconfirmed state is only reachable by clicking — `scripts/storybook-visual-smoke.mjs` disables every `play`, so a story for it would be skipped in CI. The existing `ImportTasks` fixture already returns `{ ok: false }`, which puts that state one click away in Storybook; adding a `play` on top of that buys nothing CI can see. The evidence I have is the manual pass above.

This branch was reviewed adversarially by Codex and by independent Claude subagents across two rounds. That review removed a concurrent-import rework, skeleton rows, a per-row `Badge`, a per-row tooltip and the archived-filter unfreeze from earlier versions of this PR, and produced the state collapse this revision is built on. It is AI review and does not count as independent human review.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — wrote the implementation and copy changes and ran the verification above, under direction from the human contributor, who chose each option against rendered Storybook comparisons. Codex and Claude subagents performed the adversarial review described above. The commit carries a `Generated-by` trailer.

## Checklist

- [ ] Tests cover the change and fail without it — see Review focus above
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No




