### PR TITLE
refactor(runtime): remove legacy timestamp session read marker

### DIFF
--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -1894,17 +1894,6 @@ class ReadOnlyStore implements SessionStore {
     return { ...makeHeader(id), ...patch };
   }
 
-  async markSessionReadThrough(id: string, readThroughTs: number): Promise<SessionHeader> {
-    const header = makeHeader(id);
-    if (
-      !Number.isFinite(readThroughTs) ||
-      !header.hasUnread ||
-      (header.lastMessageAt !== undefined && header.lastMessageAt > readThroughTs)
-    )
-      return header;
-    return { ...header, hasUnread: false };
-  }
-
   async archive(_sessionId: string): Promise<void> {}
   async unarchive(_sessionId: string): Promise<void> {}
   async setFlagged(_sessionId: string, _isFlagged: boolean): Promise<void> {}

--- a/packages/runtime/src/__tests__/runtime-kernel-interaction.test.ts
+++ b/packages/runtime/src/__tests__/runtime-kernel-interaction.test.ts
@@ -641,7 +641,6 @@ function memoryStore(): SessionStore {
       header = { ...header, ...patch };
       return header;
     },
-    markSessionReadThrough: async () => header,
     archive: async () => {},
     unarchive: async () => {},
     setFlagged: async () => {},

--- a/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
+++ b/packages/runtime/src/__tests__/session-manager-terminal-ledger.test.ts
@@ -2538,10 +2538,6 @@ class TinySessionStore implements SessionStore {
     return clone(next);
   }
 
-  async markSessionReadThrough(sessionId: string, _readThroughTs: number): Promise<SessionHeader> {
-    return this.readHeader(sessionId);
-  }
-
   async archive(sessionId: string): Promise<void> {
     await this.updateHeader(sessionId, { isArchived: true, status: 'archived' });
   }

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -17060,7 +17060,6 @@ class MemorySessionStore implements SessionStore {
   readonly failNextReadMessagesFor = new Map<string, number>();
   readonly failListTurnsFor = new Set<string>();
   readonly failUpdateHeaderFor = new Set<string>();
-  readonly interleaveBeforeMarkSessionReadWriteFor = new Map<string, () => Promise<void> | void>();
   failNextAppendMessage: ((message: StoredMessage) => boolean) | undefined;
   failAfterNextAppendMessage: ((message: StoredMessage) => boolean) | undefined;
   disposeCount = 0;
@@ -17277,7 +17276,6 @@ class MemorySessionStore implements SessionStore {
       error.code = 'ENOENT';
       throw error;
     }
-    await this.runMarkSessionReadInterleave(sessionId);
     return header;
   }
 
@@ -17321,26 +17319,6 @@ class MemorySessionStore implements SessionStore {
     const next = { ...current, ...patch };
     this.headers.set(sessionId, next);
     return next;
-  }
-
-  async markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader> {
-    await this.runMarkSessionReadInterleave(sessionId);
-    if (this.failUpdateHeaderFor.has(sessionId))
-      throw new Error(`Cannot update header for ${sessionId}`);
-    const current = await this.readHeader(sessionId);
-    if (!current.hasUnread) return current;
-    if (current.lastMessageAt !== undefined && current.lastMessageAt > readThroughTs)
-      return current;
-    const next = { ...current, hasUnread: false };
-    this.headers.set(sessionId, next);
-    return next;
-  }
-
-  private async runMarkSessionReadInterleave(sessionId: string): Promise<void> {
-    const hook = this.interleaveBeforeMarkSessionReadWriteFor.get(sessionId);
-    if (!hook) return;
-    this.interleaveBeforeMarkSessionReadWriteFor.delete(sessionId);
-    await hook();
   }
 
   async archive(sessionId: string): Promise<void> {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -678,7 +678,6 @@ export interface SessionStore {
     sessionId: string,
     input: SessionConfigurationStoreUpdate,
   ): Promise<VersionedSessionHeader>;
-  markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader>;
   archive(sessionId: string): Promise<void>;
   unarchive(sessionId: string): Promise<void>;
   setFlagged(sessionId: string, isFlagged: boolean): Promise<void>;
@@ -1640,12 +1639,6 @@ export class SessionManager {
     await this.deps.store.setFlagged(sessionId, isFlagged);
     const header = await this.deps.store.readHeader(sessionId).catch(() => undefined);
     if (header) this.runtimeKernel.updateCachedHeader(sessionId, header);
-  }
-
-  async markSessionRead(sessionId: string, readThroughTs: number | undefined): Promise<void> {
-    if (readThroughTs === undefined || !Number.isFinite(readThroughTs)) return;
-    const next = await this.deps.store.markSessionReadThrough(sessionId, readThroughTs);
-    this.runtimeKernel.updateCachedHeader(sessionId, next);
   }
 
   async renameSession(sessionId: string, name: string): Promise<void> {

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -395,8 +395,6 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
         run(() => sessionStore.updateSessionConfiguration(sessionId, input)),
       markSessionReadThroughMessage: (sessionId, messageId) =>
         run(() => sessionStore.markSessionReadThroughMessage(sessionId, messageId)),
-      markSessionReadThrough: (sessionId, readThroughTs) =>
-        run(() => sessionStore.markSessionReadThrough(sessionId, readThroughTs)),
       archive: (sessionId) => run(() => sessionStore.archive(sessionId)),
       unarchive: (sessionId) => run(() => sessionStore.unarchive(sessionId)),
       setFlagged: (sessionId, isFlagged) =>

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -260,7 +260,6 @@ export interface SessionStore {
   appendMessage(sessionId: string, message: StoredMessage): Promise<void>;
   appendMessages(sessionId: string, messages: StoredMessage[]): Promise<void>;
   updateHeader(sessionId: string, patch: Partial<SessionHeader>): Promise<SessionHeader>;
-  markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader>;
   archive(sessionId: string): Promise<void>;
   unarchive(sessionId: string): Promise<void>;
   setFlagged(sessionId: string, isFlagged: boolean): Promise<void>;
@@ -868,23 +867,6 @@ class SqliteSessionStore implements SessionAuthorityStore {
   async completeSessionRetirementCleanup(sessionId: string): Promise<void> {
     await this.ensureReady();
     await this.metadata.completeSessionRetirementCleanup(sessionId);
-  }
-
-  async markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader> {
-    const header = await this.readHeaderSnapshot(sessionId);
-    const messages = await this.readMessagesSnapshot(sessionId);
-    const effectiveLastMessageAt = maxTimestamp(
-      header.lastMessageAt,
-      latestVisibleMessageAt(messages),
-    );
-    if (
-      !Number.isFinite(readThroughTs) ||
-      !header.hasUnread ||
-      (effectiveLastMessageAt !== undefined && effectiveLastMessageAt > readThroughTs)
-    ) {
-      return header;
-    }
-    return this.updateHeader(sessionId, { hasUnread: false });
   }
 
   async archive(sessionId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Remove the unused timestamp-based Session read-marker path from Runtime and storage. Runtime Host message identity remains the sole authority for mutating `lastReadMessageId` and `hasUnread`.

Fixes #3072

## Verification

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/storage run typecheck`
- `npm run format:check`
- `node --test dist/__tests__/session-store.test.js` in `packages/storage` (16/16 passed)
- Confirmed tracked source references only retain `markSessionReadThroughMessage()`

Full Runtime and Storage suites were attempted on Windows. They remain blocked by unrelated existing Windows symlink, `fsutil`, PowerShell, PTY, and path-containment failures. Runtime Host build is independently blocked by the existing implicit-`any` error at `src/server/session-transcript-pager.ts:249`.

## Breaking change

Embedded legacy Runtime compositions can no longer mark a Session read using only a timestamp. Callers must use the supported Runtime Host message-ID operation.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex assessed issue #3072, removed the legacy Runtime/storage timestamp path and related test-double code, and assisted with verification and review. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No