### PR TITLE
refactor(cli): unify MakaRunOutcome classification

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -233,13 +233,20 @@ describe('Runtime Host maka run adapter', () => {
   });
 
   test('returns exit code 1 when the final Graph Turn fails', async () => {
+    const stderr: string[] = [];
     const fixture = runFixture({
       graph: true,
       finalMessages: failedGraphMessages('provider_failure'),
     });
-    const exitCode = await runFixtureCommand(fixture, ['delegate once', '--graph']);
+    const exitCode = await runFixtureCommand(
+      fixture,
+      ['delegate once', '--graph'],
+      undefined,
+      (text) => stderr.push(text),
+    );
 
     assert.equal(exitCode, 1);
+    assert.equal(stderr.join(''), 'maka run: Agent Graph final Turn failed\n');
   });
 
   test('waits for Host-started graph supervisor Turns before returning', async () => {
@@ -898,10 +905,11 @@ function runFixtureCommand(
   fixture: ReturnType<typeof runFixture>,
   argv: readonly string[],
   writeStdout: (text: string) => void = () => {},
+  writeStderr: (text: string) => void = () => {},
 ): Promise<number> {
   return runRuntimeHostTextCli(
     argv,
-    { ...publicCommandEnvironment(), writeStdout },
+    { ...publicCommandEnvironment(), writeStdout, writeStderr },
     {
       connect: async () => ({
         connection: readinessConnection(),

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -218,6 +218,20 @@ describe('Runtime Host maka run adapter', () => {
     assert.equal(stdout.join(''), 'Final graph answer\n');
   });
 
+  test('returns exit code 0 when a root Graph boundary failure recovers', async () => {
+    const stdout: string[] = [];
+    const fixture = runFixture({
+      graph: true,
+      turnEvents: recoveredSandboxEvents('turn-1'),
+    });
+    const exitCode = await runFixtureCommand(fixture, ['recover once', '--graph'], (text) =>
+      stdout.push(text),
+    );
+
+    assert.equal(exitCode, 0);
+    assert.equal(stdout.join(''), 'Final graph answer\n');
+  });
+
   test('returns exit code 1 when the final Graph Turn fails', async () => {
     const fixture = runFixture({
       graph: true,

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -292,12 +292,16 @@ describe('Runtime Host maka run adapter', () => {
       finalMessages: abortedGraphMessages(),
     });
 
+    assert.equal(live.status, 'failed');
     assert.equal(live.failure?.class, 'aborted');
+    assert.equal(durable.status, 'failed');
     assert.equal(durable.failure?.class, 'aborted');
   });
 
-  test('classifies a live step limit like a durable failed Turn', async () => {
-    const live = await observeFixtureOutcome({ turnEvents: stepLimitedEvents('turn-1') });
+  test('classifies live and durable step-cap failures equally', async () => {
+    const live = await observeFixtureOutcome({
+      turnEvents: failedEvents('turn-1', 'tool_step_cap_reached'),
+    });
     const durable = await observeFixtureOutcome({
       graph: true,
       finalMessages: failedGraphMessages('tool_step_cap_reached'),
@@ -309,20 +313,14 @@ describe('Runtime Host maka run adapter', () => {
     assert.equal(durable.failure?.class, 'tool_step_cap_reached');
   });
 
-  test('classifies a user-stop complete event as aborted', async () => {
-    const outcome = await observeFixtureOutcome({ turnEvents: userStoppedEvents('turn-1') });
-
-    assert.equal(outcome.status, 'failed');
-    assert.equal(outcome.failure?.class, 'aborted');
-  });
-
-  test('keeps a live Turn failed when complete follows its error', async () => {
+  test('uses the latest durable terminal state for a Graph Turn', async () => {
     const outcome = await observeFixtureOutcome({
-      turnEvents: failedThenCompleteEvents('turn-1'),
+      graph: true,
+      finalMessages: failedThenCompletedGraphMessages(),
     });
 
-    assert.equal(outcome.status, 'failed');
-    assert.equal(outcome.failure?.class, 'provider_failure');
+    assert.equal(outcome.status, 'completed');
+    assert.equal(outcome.finalOutput, 'Final graph answer');
   });
 
   test('waits for the exact final Graph wake after an earlier wake already settled', async () => {
@@ -908,7 +906,6 @@ function publicCommandEnvironment() {
     processCwd: () => process.cwd(),
     stdinIsTTY: () => true,
     readStdin: async () => '',
-    writeStdout: () => {},
     writeStderr: () => {},
     onSigint: () => () => {},
     newId: () => 'turn-1',
@@ -1161,6 +1158,20 @@ function failedGraphMessages(errorClass: string): StoredMessage[] {
   ];
 }
 
+function failedThenCompletedGraphMessages(): StoredMessage[] {
+  return [
+    ...failedGraphMessages('provider_failure'),
+    {
+      type: 'turn_state',
+      id: 'completed-state-turn-2',
+      turnId: 'turn-2',
+      ts: 6,
+      status: 'completed',
+      partialOutputRetained: true,
+    },
+  ];
+}
+
 function multiWakeGraphMessages(includeFinalTerminal: boolean): StoredMessage[] {
   const messages = [
     ...graphMessages(),
@@ -1227,7 +1238,7 @@ async function* abortedEvents(turnId: string): AsyncIterable<SessionEvent> {
   };
 }
 
-async function* stepLimitedEvents(turnId: string): AsyncIterable<SessionEvent> {
+async function* failedEvents(turnId: string, reason: string): AsyncIterable<SessionEvent> {
   yield {
     type: 'text_complete',
     id: `${turnId}-text`,
@@ -1237,44 +1248,13 @@ async function* stepLimitedEvents(turnId: string): AsyncIterable<SessionEvent> {
     text: 'Partial answer',
   };
   yield {
-    type: 'complete',
-    id: `${turnId}-complete`,
-    turnId,
-    ts: 2,
-    stopReason: 'step_limit',
-  };
-}
-
-async function* userStoppedEvents(turnId: string): AsyncIterable<SessionEvent> {
-  yield {
-    type: 'complete',
-    id: `${turnId}-complete`,
-    turnId,
-    ts: 1,
-    stopReason: 'user_stop',
-  };
-}
-
-async function* failedEvents(turnId: string, reason: string): AsyncIterable<SessionEvent> {
-  yield {
     type: 'error',
     id: `${turnId}-error`,
     turnId,
-    ts: 1,
+    ts: 2,
     recoverable: false,
     reason,
     message: 'Turn failed',
-  };
-}
-
-async function* failedThenCompleteEvents(turnId: string): AsyncIterable<SessionEvent> {
-  yield* failedEvents(turnId, 'provider_failure');
-  yield {
-    type: 'complete',
-    id: `${turnId}-complete`,
-    turnId,
-    ts: 2,
-    stopReason: 'end_turn',
   };
 }
 

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -200,6 +200,34 @@ describe('Runtime Host maka run adapter', () => {
     ]);
   });
 
+  test('returns exit code 1 when an ordinary Host Turn fails', async () => {
+    const fixture = runFixture({ turnEvents: failedEvents('turn-1', 'provider_failure') });
+    const exitCode = await runFixtureCommand(fixture, ['fail once']);
+
+    assert.equal(exitCode, 1);
+  });
+
+  test('returns exit code 0 when the final Graph Turn completes', async () => {
+    const stdout: string[] = [];
+    const fixture = runFixture({ graph: true });
+    const exitCode = await runFixtureCommand(fixture, ['delegate once', '--graph'], (text) =>
+      stdout.push(text),
+    );
+
+    assert.equal(exitCode, 0);
+    assert.equal(stdout.join(''), 'Final graph answer\n');
+  });
+
+  test('returns exit code 1 when the final Graph Turn fails', async () => {
+    const fixture = runFixture({
+      graph: true,
+      finalMessages: failedGraphMessages('provider_failure'),
+    });
+    const exitCode = await runFixtureCommand(fixture, ['delegate once', '--graph']);
+
+    assert.equal(exitCode, 1);
+  });
+
   test('waits for Host-started graph supervisor Turns before returning', async () => {
     const observed: MakaRunOutcome[] = [];
     const fixture = runFixture({ observed, graph: true, graphProjectionRace: true });
@@ -244,6 +272,57 @@ describe('Runtime Host maka run adapter', () => {
 
     assert.equal(observed.at(-1)?.outcomeId, 'turn-2');
     assert.equal(observed.at(-1)?.finalOutput, 'Final graph answer');
+  });
+
+  test('reports a recovered sandbox boundary from live and durable Turns', async () => {
+    const live = await observeFixtureOutcome({ turnEvents: recoveredSandboxEvents('turn-1') });
+    const durable = await observeFixtureOutcome({
+      graph: true,
+      finalMessages: recoveredSandboxMessages(),
+    });
+
+    assert.equal(live.sandboxBoundary, 'recovered');
+    assert.equal(durable.sandboxBoundary, 'recovered');
+  });
+
+  test('classifies live and durable Turn cancellations as aborted', async () => {
+    const live = await observeFixtureOutcome({ turnEvents: abortedEvents('turn-1') });
+    const durable = await observeFixtureOutcome({
+      graph: true,
+      finalMessages: abortedGraphMessages(),
+    });
+
+    assert.equal(live.failure?.class, 'aborted');
+    assert.equal(durable.failure?.class, 'aborted');
+  });
+
+  test('classifies a live step limit like a durable failed Turn', async () => {
+    const live = await observeFixtureOutcome({ turnEvents: stepLimitedEvents('turn-1') });
+    const durable = await observeFixtureOutcome({
+      graph: true,
+      finalMessages: failedGraphMessages('tool_step_cap_reached'),
+    });
+
+    assert.equal(live.status, 'failed');
+    assert.equal(live.failure?.class, 'tool_step_cap_reached');
+    assert.equal(durable.status, 'failed');
+    assert.equal(durable.failure?.class, 'tool_step_cap_reached');
+  });
+
+  test('classifies a user-stop complete event as aborted', async () => {
+    const outcome = await observeFixtureOutcome({ turnEvents: userStoppedEvents('turn-1') });
+
+    assert.equal(outcome.status, 'failed');
+    assert.equal(outcome.failure?.class, 'aborted');
+  });
+
+  test('keeps a live Turn failed when complete follows its error', async () => {
+    const outcome = await observeFixtureOutcome({
+      turnEvents: failedThenCompleteEvents('turn-1'),
+    });
+
+    assert.equal(outcome.status, 'failed');
+    assert.equal(outcome.failure?.class, 'provider_failure');
   });
 
   test('waits for the exact final Graph wake after an earlier wake already settled', async () => {
@@ -736,26 +815,25 @@ function runFixture(input: {
       throw new Error(`Unexpected operation: ${operation}`);
     },
   } as unknown as RuntimeHostConnection;
+  const createContext = (contextInput: MakaRunContextInput) =>
+    createRuntimeHostRunContext(connection, connectionCatalog(), contextInput, {
+      createDriver: () => driver,
+    });
   let create = () =>
-    createRuntimeHostRunContext(
-      connection,
-      connectionCatalog(),
-      {
-        workspaceRoot: '/data',
-        cwd: '/workspace',
-        ...(input.graph ? { enableAgentGraph: true } : {}),
-        ...(input.maxSteps ? { maxSteps: input.maxSteps } : {}),
-        ...(input.sessionCwdOverride ? { sessionCwdOverride: input.sessionCwdOverride } : {}),
-        ...(input.observed
-          ? {
-              runOutcomeObserver: (result: MakaRunOutcome) => {
-                input.observed?.push(result);
-              },
-            }
-          : {}),
-      },
-      { createDriver: () => driver },
-    );
+    createContext({
+      workspaceRoot: '/data',
+      cwd: '/workspace',
+      ...(input.graph ? { enableAgentGraph: true } : {}),
+      ...(input.maxSteps ? { maxSteps: input.maxSteps } : {}),
+      ...(input.sessionCwdOverride ? { sessionCwdOverride: input.sessionCwdOverride } : {}),
+      ...(input.observed
+        ? {
+            runOutcomeObserver: (result: MakaRunOutcome) => {
+              input.observed?.push(result);
+            },
+          }
+        : {}),
+    });
   return {
     get context() {
       const context = create();
@@ -768,12 +846,72 @@ function runFixture(input: {
     exactTurnStops,
     preparedMaxSteps,
     sandboxResponses,
+    createContext,
     publishPendingInteraction(pending: InteractionPendingSnapshot) {
       for (const listener of pendingInteractionListeners) listener(structuredClone(pending));
     },
     get turnStops() {
       return turnStops;
     },
+  };
+}
+
+async function observeFixtureOutcome(
+  input: Parameters<typeof runFixture>[0],
+): Promise<MakaRunOutcome> {
+  const observed: MakaRunOutcome[] = [];
+  const fixture = runFixture({ ...input, observed });
+  const session = await fixture.context.runtime.createSession({
+    cwd: '/workspace',
+    llmConnectionSlug: 'openai-main',
+    model: 'gpt-5',
+    permissionMode: 'ask',
+  });
+  await collect(
+    fixture.context.runtime.sendMessage(session.id, {
+      turnId: 'turn-1',
+      text: 'observe outcome',
+      ...(input.graph
+        ? { turnOrchestration: { mode: 'graph' as const, source: 'host_api' as const } }
+        : {}),
+    }),
+  );
+  if (input.graph) await fixture.context.agentGraph?.waitForCompletion(session.id);
+  const outcome = observed.at(-1);
+  assert.ok(outcome);
+  return outcome;
+}
+
+function runFixtureCommand(
+  fixture: ReturnType<typeof runFixture>,
+  argv: readonly string[],
+  writeStdout: (text: string) => void = () => {},
+): Promise<number> {
+  return runRuntimeHostTextCli(
+    argv,
+    { ...publicCommandEnvironment(), writeStdout },
+    {
+      connect: async () => ({
+        connection: readinessConnection(),
+        catalog: connectionCatalog(),
+        profile: LOCAL_RUNTIME_HOST_PROFILE,
+        close: async () => {},
+      }),
+      createContext: (_connection, _catalog, input) => fixture.createContext(input),
+    },
+  );
+}
+
+function publicCommandEnvironment() {
+  return {
+    workspaceRoot: () => '/runtime-host-data',
+    processCwd: () => process.cwd(),
+    stdinIsTTY: () => true,
+    readStdin: async () => '',
+    writeStdout: () => {},
+    writeStderr: () => {},
+    onSigint: () => () => {},
+    newId: () => 'turn-1',
   };
 }
 
@@ -977,6 +1115,52 @@ function graphMessages(includeTerminal = true): StoredMessage[] {
   return messages;
 }
 
+function recoveredSandboxMessages(): StoredMessage[] {
+  return [
+    ...graphMessages(false),
+    sandboxFailureToolResult('turn-2', 5),
+    successfulToolResult('turn-2', 6),
+    {
+      type: 'turn_state',
+      id: 'state-turn-2',
+      turnId: 'turn-2',
+      ts: 7,
+      status: 'completed',
+      partialOutputRetained: true,
+    },
+  ];
+}
+
+function abortedGraphMessages(): StoredMessage[] {
+  return [
+    ...graphMessages(false),
+    {
+      type: 'turn_state',
+      id: 'state-turn-2',
+      turnId: 'turn-2',
+      ts: 5,
+      status: 'aborted',
+      abortSource: 'user_interrupt',
+      partialOutputRetained: true,
+    },
+  ];
+}
+
+function failedGraphMessages(errorClass: string): StoredMessage[] {
+  return [
+    ...graphMessages(false),
+    {
+      type: 'turn_state',
+      id: 'state-turn-2',
+      turnId: 'turn-2',
+      ts: 5,
+      status: 'failed',
+      errorClass,
+      partialOutputRetained: true,
+    },
+  ];
+}
+
 function multiWakeGraphMessages(includeFinalTerminal: boolean): StoredMessage[] {
   const messages = [
     ...graphMessages(),
@@ -1025,6 +1209,115 @@ async function* eventsFor(turnId: string, text: string): AsyncIterable<SessionEv
     text,
   };
   yield { type: 'complete', id: `${turnId}-complete`, turnId, ts: 2, stopReason: 'end_turn' };
+}
+
+async function* recoveredSandboxEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield sandboxFailureToolResult(turnId, 1);
+  yield successfulToolResult(turnId, 2);
+  yield* eventsFor(turnId, 'Recovered answer');
+}
+
+async function* abortedEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield {
+    type: 'abort',
+    id: `${turnId}-abort`,
+    turnId,
+    ts: 1,
+    reason: 'user_stop',
+  };
+}
+
+async function* stepLimitedEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield {
+    type: 'text_complete',
+    id: `${turnId}-text`,
+    turnId,
+    messageId: `${turnId}-message`,
+    ts: 1,
+    text: 'Partial answer',
+  };
+  yield {
+    type: 'complete',
+    id: `${turnId}-complete`,
+    turnId,
+    ts: 2,
+    stopReason: 'step_limit',
+  };
+}
+
+async function* userStoppedEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield {
+    type: 'complete',
+    id: `${turnId}-complete`,
+    turnId,
+    ts: 1,
+    stopReason: 'user_stop',
+  };
+}
+
+async function* failedEvents(turnId: string, reason: string): AsyncIterable<SessionEvent> {
+  yield {
+    type: 'error',
+    id: `${turnId}-error`,
+    turnId,
+    ts: 1,
+    recoverable: false,
+    reason,
+    message: 'Turn failed',
+  };
+}
+
+async function* failedThenCompleteEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield* failedEvents(turnId, 'provider_failure');
+  yield {
+    type: 'complete',
+    id: `${turnId}-complete`,
+    turnId,
+    ts: 2,
+    stopReason: 'end_turn',
+  };
+}
+
+type SharedToolResult = Extract<SessionEvent, { type: 'tool_result' }> &
+  Extract<StoredMessage, { type: 'tool_result' }>;
+
+function sandboxFailureToolResult(turnId: string, ts: number): SharedToolResult {
+  return {
+    type: 'tool_result',
+    id: `${turnId}-sandbox-failure`,
+    turnId,
+    ts,
+    toolUseId: 'tool-1',
+    isError: true,
+    content: sandboxFailureContent(),
+  };
+}
+
+function successfulToolResult(turnId: string, ts: number): SharedToolResult {
+  return {
+    type: 'tool_result',
+    id: `${turnId}-tool-success`,
+    turnId,
+    ts,
+    toolUseId: 'tool-2',
+    isError: false,
+    content: { kind: 'text', text: 'ok' },
+  };
+}
+
+function sandboxFailureContent() {
+  return {
+    kind: 'text' as const,
+    text: 'Write requires an approved sandbox boundary expansion.',
+    sandboxFailure: {
+      reason: 'sandbox_boundary_required' as const,
+      requiredExpansion: {
+        filesystem: {
+          entries: [{ path: '/outside', access: 'write' as const, scope: 'subtree' as const }],
+        },
+      },
+    },
+  };
 }
 
 async function* eventsAfterPendingNotification(

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -239,6 +239,33 @@ describe('Runtime Host maka run adapter', () => {
     );
   });
 
+  test('returns exit code 1 when a denied boundary request follows a sandbox failure', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
+    const fixture = runFixture({
+      turnEvents: sandboxBoundaryEvents(
+        'turn-1',
+        'step-1',
+        'step-2',
+        'Boundary was not widened',
+        'request_sandbox_boundary',
+      ),
+    });
+    const exitCode = await runFixtureCommand(
+      fixture,
+      ['request inaccessible work'],
+      (text) => stdout.push(text),
+      (text) => stderr.push(text),
+    );
+
+    assert.equal(exitCode, 1);
+    assert.equal(stdout.join(''), '');
+    assert.equal(
+      stderr.join(''),
+      'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
+    );
+  });
+
   test('returns exit code 0 when the final Graph Turn completes', async () => {
     const stdout: string[] = [];
     const fixture = runFixture({ graph: true });
@@ -272,6 +299,22 @@ describe('Runtime Host maka run adapter', () => {
     const exitCode = await runFixtureCommand(fixture, ['run parallel tools', '--graph']);
 
     assert.equal(exitCode, 1);
+  });
+
+  test('returns exit code 1 when a denied Graph boundary request follows a sandbox failure', async () => {
+    const stdout: string[] = [];
+    const fixture = runFixture({
+      graph: true,
+      finalMessages: sandboxBoundaryMessages('step-1', 'step-2', 'request_sandbox_boundary'),
+    });
+    const exitCode = await runFixtureCommand(
+      fixture,
+      ['request inaccessible work', '--graph'],
+      (text) => stdout.push(text),
+    );
+
+    assert.equal(exitCode, 1);
+    assert.equal(stdout.join(''), '');
   });
 
   test('returns exit code 1 when the final Graph Turn fails', async () => {
@@ -1211,16 +1254,17 @@ function graphMessages(includeTerminal = true): StoredMessage[] {
 function sandboxBoundaryMessages(
   failureStepId: string | undefined,
   successStepId: string | undefined,
+  successToolName = 'Read',
 ): StoredMessage[] {
   const sameStep = failureStepId !== undefined && failureStepId === successStepId;
   return [
     ...graphMessages(false),
     ...(failureStepId === undefined ? [] : [storedToolCall('turn-2', 'tool-1', failureStepId, 5)]),
-    ...(sameStep ? [storedToolCall('turn-2', 'tool-2', successStepId, 6)] : []),
+    ...(sameStep ? [storedToolCall('turn-2', 'tool-2', successStepId, 6, successToolName)] : []),
     sandboxFailureToolResult('turn-2', 7),
     ...(successStepId === undefined || sameStep
       ? []
-      : [storedToolCall('turn-2', 'tool-2', successStepId, 8)]),
+      : [storedToolCall('turn-2', 'tool-2', successStepId, 8, successToolName)]),
     successfulToolResult('turn-2', 9),
     {
       type: 'turn_state',
@@ -1332,13 +1376,14 @@ async function* sandboxBoundaryEvents(
   failureStepId: string | undefined,
   successStepId: string | undefined,
   text: string,
+  successToolName = 'Read',
 ): AsyncIterable<SessionEvent> {
   const sameStep = failureStepId !== undefined && failureStepId === successStepId;
   if (failureStepId !== undefined) yield toolStart(turnId, 'tool-1', failureStepId, 1);
-  if (sameStep) yield toolStart(turnId, 'tool-2', successStepId, 2);
+  if (sameStep) yield toolStart(turnId, 'tool-2', successStepId, 2, successToolName);
   yield sandboxFailureToolResult(turnId, 3);
   if (successStepId !== undefined && !sameStep) {
-    yield toolStart(turnId, 'tool-2', successStepId, 4);
+    yield toolStart(turnId, 'tool-2', successStepId, 4, successToolName);
   }
   yield successfulToolResult(turnId, 5);
   yield* eventsFor(turnId, text, 6);
@@ -1477,6 +1522,7 @@ function toolStart(
   toolUseId: string,
   stepId: string,
   ts: number,
+  toolName = 'Read',
 ): Extract<SessionEvent, { type: 'tool_start' }> {
   return {
     type: 'tool_start',
@@ -1484,7 +1530,7 @@ function toolStart(
     turnId,
     ts,
     toolUseId,
-    toolName: 'Read',
+    toolName,
     args: {},
     stepId,
   };
@@ -1495,13 +1541,14 @@ function storedToolCall(
   toolUseId: string,
   stepId: string,
   ts: number,
+  toolName = 'Read',
 ): Extract<StoredMessage, { type: 'tool_call' }> {
   return {
     type: 'tool_call',
     id: toolUseId,
     turnId,
     ts,
-    toolName: 'Read',
+    toolName,
     args: {},
     stepId,
   };

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -207,6 +207,15 @@ describe('Runtime Host maka run adapter', () => {
     assert.equal(exitCode, 1);
   });
 
+  test('returns exit code 1 when a same-step sibling succeeds after a sandbox failure', async () => {
+    const fixture = runFixture({
+      turnEvents: sandboxBoundaryEvents('turn-1', 'step-1', 'step-1', 'Incomplete answer'),
+    });
+    const exitCode = await runFixtureCommand(fixture, ['run parallel tools']);
+
+    assert.equal(exitCode, 1);
+  });
+
   test('returns exit code 0 when the final Graph Turn completes', async () => {
     const stdout: string[] = [];
     const fixture = runFixture({ graph: true });
@@ -222,7 +231,7 @@ describe('Runtime Host maka run adapter', () => {
     const stdout: string[] = [];
     const fixture = runFixture({
       graph: true,
-      turnEvents: recoveredSandboxEvents('turn-1'),
+      turnEvents: sandboxBoundaryEvents('turn-1', 'step-1', 'step-2', 'Recovered answer'),
     });
     const exitCode = await runFixtureCommand(fixture, ['recover once', '--graph'], (text) =>
       stdout.push(text),
@@ -230,6 +239,16 @@ describe('Runtime Host maka run adapter', () => {
 
     assert.equal(exitCode, 0);
     assert.equal(stdout.join(''), 'Final graph answer\n');
+  });
+
+  test('returns exit code 1 when a same-step Graph sibling succeeds after a sandbox failure', async () => {
+    const fixture = runFixture({
+      graph: true,
+      finalMessages: sandboxBoundaryMessages('step-1', 'step-1'),
+    });
+    const exitCode = await runFixtureCommand(fixture, ['run parallel tools', '--graph']);
+
+    assert.equal(exitCode, 1);
   });
 
   test('returns exit code 1 when the final Graph Turn fails', async () => {
@@ -296,14 +315,37 @@ describe('Runtime Host maka run adapter', () => {
   });
 
   test('reports a recovered sandbox boundary from live and durable Turns', async () => {
-    const live = await observeFixtureOutcome({ turnEvents: recoveredSandboxEvents('turn-1') });
+    const live = await observeFixtureOutcome({
+      turnEvents: sandboxBoundaryEvents('turn-1', 'step-1', 'step-2', 'Recovered answer'),
+    });
     const durable = await observeFixtureOutcome({
       graph: true,
-      finalMessages: recoveredSandboxMessages(),
+      finalMessages: sandboxBoundaryMessages('step-1', 'step-2'),
     });
 
     assert.equal(live.sandboxBoundary, 'recovered');
     assert.equal(durable.sandboxBoundary, 'recovered');
+  });
+
+  test('leaves sandbox failures unresolved when their provider steps are unavailable', async () => {
+    const live = await observeFixtureOutcome({
+      turnEvents: sandboxBoundaryEvents('turn-1', undefined, undefined, 'Incomplete answer'),
+    });
+    const durable = await observeFixtureOutcome({
+      graph: true,
+      finalMessages: sandboxBoundaryMessages(undefined, undefined),
+    });
+
+    assert.equal(live.sandboxBoundary, 'unresolved');
+    assert.equal(durable.sandboxBoundary, 'unresolved');
+  });
+
+  test('returns a recovered boundary to unresolved after a later sandbox failure', async () => {
+    const outcome = await observeFixtureOutcome({
+      turnEvents: sandboxFailureAfterRecoveryEvents('turn-1'),
+    });
+
+    assert.equal(outcome.sandboxBoundary, 'unresolved');
   });
 
   test('classifies live and durable Turn cancellations as aborted', async () => {
@@ -1134,16 +1176,25 @@ function graphMessages(includeTerminal = true): StoredMessage[] {
   return messages;
 }
 
-function recoveredSandboxMessages(): StoredMessage[] {
+function sandboxBoundaryMessages(
+  failureStepId: string | undefined,
+  successStepId: string | undefined,
+): StoredMessage[] {
+  const sameStep = failureStepId !== undefined && failureStepId === successStepId;
   return [
     ...graphMessages(false),
-    sandboxFailureToolResult('turn-2', 5),
-    successfulToolResult('turn-2', 6),
+    ...(failureStepId === undefined ? [] : [storedToolCall('turn-2', 'tool-1', failureStepId, 5)]),
+    ...(sameStep ? [storedToolCall('turn-2', 'tool-2', successStepId, 6)] : []),
+    sandboxFailureToolResult('turn-2', 7),
+    ...(successStepId === undefined || sameStep
+      ? []
+      : [storedToolCall('turn-2', 'tool-2', successStepId, 8)]),
+    successfulToolResult('turn-2', 9),
     {
       type: 'turn_state',
       id: 'state-turn-2',
       turnId: 'turn-2',
-      ts: 7,
+      ts: 10,
       status: 'completed',
       partialOutputRetained: true,
     },
@@ -1232,22 +1283,43 @@ function multiWakeGraphMessages(includeFinalTerminal: boolean): StoredMessage[] 
   return messages;
 }
 
-async function* eventsFor(turnId: string, text: string): AsyncIterable<SessionEvent> {
+async function* eventsFor(turnId: string, text: string, ts = 1): AsyncIterable<SessionEvent> {
   yield {
     type: 'text_complete',
     id: `${turnId}-text`,
     turnId,
     messageId: `${turnId}-message`,
-    ts: 1,
+    ts,
     text,
   };
-  yield { type: 'complete', id: `${turnId}-complete`, turnId, ts: 2, stopReason: 'end_turn' };
+  yield { type: 'complete', id: `${turnId}-complete`, turnId, ts: ts + 1, stopReason: 'end_turn' };
 }
 
-async function* recoveredSandboxEvents(turnId: string): AsyncIterable<SessionEvent> {
-  yield sandboxFailureToolResult(turnId, 1);
-  yield successfulToolResult(turnId, 2);
-  yield* eventsFor(turnId, 'Recovered answer');
+async function* sandboxBoundaryEvents(
+  turnId: string,
+  failureStepId: string | undefined,
+  successStepId: string | undefined,
+  text: string,
+): AsyncIterable<SessionEvent> {
+  const sameStep = failureStepId !== undefined && failureStepId === successStepId;
+  if (failureStepId !== undefined) yield toolStart(turnId, 'tool-1', failureStepId, 1);
+  if (sameStep) yield toolStart(turnId, 'tool-2', successStepId, 2);
+  yield sandboxFailureToolResult(turnId, 3);
+  if (successStepId !== undefined && !sameStep) {
+    yield toolStart(turnId, 'tool-2', successStepId, 4);
+  }
+  yield successfulToolResult(turnId, 5);
+  yield* eventsFor(turnId, text, 6);
+}
+
+async function* sandboxFailureAfterRecoveryEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield toolStart(turnId, 'tool-1', 'step-1', 1);
+  yield sandboxFailureToolResult(turnId, 2);
+  yield toolStart(turnId, 'tool-2', 'step-2', 3);
+  yield successfulToolResult(turnId, 4);
+  yield toolStart(turnId, 'tool-3', 'step-3', 5);
+  yield sandboxFailureToolResult(turnId, 6, 'tool-3');
+  yield* eventsFor(turnId, 'Incomplete answer', 7);
 }
 
 async function* abortedEvents(turnId: string): AsyncIterable<SessionEvent> {
@@ -1283,13 +1355,52 @@ async function* failedEvents(turnId: string, reason: string): AsyncIterable<Sess
 type SharedToolResult = Extract<SessionEvent, { type: 'tool_result' }> &
   Extract<StoredMessage, { type: 'tool_result' }>;
 
-function sandboxFailureToolResult(turnId: string, ts: number): SharedToolResult {
+function toolStart(
+  turnId: string,
+  toolUseId: string,
+  stepId: string,
+  ts: number,
+): Extract<SessionEvent, { type: 'tool_start' }> {
   return {
-    type: 'tool_result',
-    id: `${turnId}-sandbox-failure`,
+    type: 'tool_start',
+    id: `${turnId}-${toolUseId}-start`,
     turnId,
     ts,
-    toolUseId: 'tool-1',
+    toolUseId,
+    toolName: 'Read',
+    args: {},
+    stepId,
+  };
+}
+
+function storedToolCall(
+  turnId: string,
+  toolUseId: string,
+  stepId: string,
+  ts: number,
+): Extract<StoredMessage, { type: 'tool_call' }> {
+  return {
+    type: 'tool_call',
+    id: toolUseId,
+    turnId,
+    ts,
+    toolName: 'Read',
+    args: {},
+    stepId,
+  };
+}
+
+function sandboxFailureToolResult(
+  turnId: string,
+  ts: number,
+  toolUseId = 'tool-1',
+): SharedToolResult {
+  return {
+    type: 'tool_result',
+    id: `${turnId}-${toolUseId}-sandbox-failure`,
+    turnId,
+    ts,
+    toolUseId,
     isError: true,
     content: sandboxFailureContent(),
   };

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -18,6 +18,7 @@ import { resolveRuntimeHostCliTarget } from '../runtime-host-cli-context.js';
 import { createRuntimeHostRunContext, runRuntimeHostTextCli } from '../runtime-host-run-command.js';
 import type { RuntimeHostMakaSessionDriver } from '../runtime-host-session-driver.js';
 import type { MakaRunContextInput, MakaRunOutcome } from '../run-command-core.js';
+import type { MakaTranscriptReplacementReason } from '../session-driver.js';
 
 describe('Runtime Host maka run adapter', () => {
   test('stops before context creation when CLI preflight finds a confirmed blocker', async () => {
@@ -266,6 +267,33 @@ describe('Runtime Host maka run adapter', () => {
     );
   });
 
+  test('returns exit code 1 when reconnect restores a missed sandbox failure', async () => {
+    let publishReplacement = () => {};
+    const fixture = runFixture({
+      turnEvents: eventsAfterTranscriptReplacement(() => publishReplacement()),
+    });
+    publishReplacement = () =>
+      fixture.publishTranscriptReplacement(
+        'turn-1',
+        [storedToolCall('turn-1', 'tool-1', 'step-1', 1), sandboxFailureToolResult('turn-1', 2)],
+        'reconnect',
+      );
+
+    const exitCode = await runFixtureCommand(fixture, ['resume protected work']);
+
+    assert.equal(exitCode, 1);
+  });
+
+  test('returns exit code 1 when one retry follows two sandbox failures', async () => {
+    const fixture = runFixture({
+      turnEvents: multipleSandboxFailureEvents('turn-1'),
+    });
+
+    const exitCode = await runFixtureCommand(fixture, ['retry one blocked operation']);
+
+    assert.equal(exitCode, 1);
+  });
+
   test('returns exit code 0 when the final Graph Turn completes', async () => {
     const stdout: string[] = [];
     const fixture = runFixture({ graph: true });
@@ -315,6 +343,17 @@ describe('Runtime Host maka run adapter', () => {
 
     assert.equal(exitCode, 1);
     assert.equal(stdout.join(''), '');
+  });
+
+  test('returns exit code 1 when one Graph retry follows two sandbox failures', async () => {
+    const fixture = runFixture({
+      graph: true,
+      finalMessages: multipleSandboxFailureMessages(),
+    });
+
+    const exitCode = await runFixtureCommand(fixture, ['retry one blocked operation', '--graph']);
+
+    assert.equal(exitCode, 1);
   });
 
   test('returns exit code 1 when the final Graph Turn fails', async () => {
@@ -820,7 +859,12 @@ function runFixture(input: {
   let turnStops = 0;
   const pendingInteractionListeners = new Set<(pending: InteractionPendingSnapshot) => void>();
   const transcriptListeners = new Set<
-    (sessionId: string, turnId: string, messages: StoredMessage[]) => void
+    (
+      sessionId: string,
+      turnId: string,
+      messages: StoredMessage[],
+      reason: MakaTranscriptReplacementReason,
+    ) => void
   >();
   let messageReads = 0;
   const preparedMaxSteps: Array<number | undefined> = [];
@@ -832,7 +876,7 @@ function runFixture(input: {
         if (input.graphMultiWakeRace) {
           queueMicrotask(() => {
             for (const listener of transcriptListeners) {
-              listener('session-created', 'turn-2', structuredClone(graphMessages()));
+              listener('session-created', 'turn-2', structuredClone(graphMessages()), 'terminal');
             }
           });
         }
@@ -842,7 +886,7 @@ function runFixture(input: {
         queueMicrotask(() => {
           const terminal = multiWakeGraphMessages(true);
           for (const listener of transcriptListeners) {
-            listener('session-created', 'turn-3', structuredClone(terminal));
+            listener('session-created', 'turn-3', structuredClone(terminal), 'terminal');
           }
         });
         return multiWakeGraphMessages(false);
@@ -855,7 +899,7 @@ function runFixture(input: {
       if (input.graphProjectionRace) {
         queueMicrotask(() => {
           for (const listener of transcriptListeners) {
-            listener('session-created', 'turn-2', structuredClone(messages));
+            listener('session-created', 'turn-2', structuredClone(messages), 'terminal');
           }
         });
         return graphMessages(false);
@@ -918,7 +962,12 @@ function runFixture(input: {
     },
     subscribeStartedTurns: () => () => {},
     subscribeTranscriptReplacements: (
-      listener: (sessionId: string, turnId: string, messages: StoredMessage[]) => void,
+      listener: (
+        sessionId: string,
+        turnId: string,
+        messages: StoredMessage[],
+        reason: MakaTranscriptReplacementReason,
+      ) => void,
     ) => {
       transcriptListeners.add(listener);
       return () => transcriptListeners.delete(listener);
@@ -985,6 +1034,15 @@ function runFixture(input: {
     createContext,
     publishPendingInteraction(pending: InteractionPendingSnapshot) {
       for (const listener of pendingInteractionListeners) listener(structuredClone(pending));
+    },
+    publishTranscriptReplacement(
+      turnId: string,
+      messages: StoredMessage[],
+      reason: MakaTranscriptReplacementReason,
+    ) {
+      for (const listener of transcriptListeners) {
+        listener('session-created', turnId, structuredClone(messages), reason);
+      }
     },
     get turnStops() {
       return turnStops;
@@ -1277,6 +1335,26 @@ function sandboxBoundaryMessages(
   ];
 }
 
+function multipleSandboxFailureMessages(): StoredMessage[] {
+  return [
+    ...graphMessages(false),
+    storedToolCall('turn-2', 'tool-1', 'step-1', 5),
+    storedToolCall('turn-2', 'tool-2', 'step-1', 6),
+    sandboxFailureToolResult('turn-2', 7, 'tool-1'),
+    sandboxFailureToolResult('turn-2', 8, 'tool-2'),
+    storedToolCall('turn-2', 'tool-3', 'step-2', 9),
+    successfulToolResult('turn-2', 10, 'tool-3'),
+    {
+      type: 'turn_state',
+      id: 'state-turn-2',
+      turnId: 'turn-2',
+      ts: 11,
+      status: 'completed',
+      partialOutputRetained: true,
+    },
+  ];
+}
+
 function abortedGraphMessages(): StoredMessage[] {
   return [
     ...graphMessages(false),
@@ -1371,6 +1449,11 @@ async function* eventsFor(turnId: string, text: string, ts = 1): AsyncIterable<S
   yield { type: 'complete', id: `${turnId}-complete`, turnId, ts: ts + 1, stopReason: 'end_turn' };
 }
 
+async function* eventsAfterTranscriptReplacement(publish: () => void): AsyncIterable<SessionEvent> {
+  publish();
+  yield* eventsFor('turn-1', 'Incomplete answer', 3);
+}
+
 async function* sandboxBoundaryEvents(
   turnId: string,
   failureStepId: string | undefined,
@@ -1417,6 +1500,16 @@ async function* projectedSameStepSandboxFailureEvents(turnId: string): AsyncIter
   } satisfies SubscriptionFrame).events;
   yield successfulToolResult(turnId, 4);
   yield* eventsFor(turnId, 'Incomplete answer', 5);
+}
+
+async function* multipleSandboxFailureEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield toolStart(turnId, 'tool-1', 'step-1', 1);
+  yield toolStart(turnId, 'tool-2', 'step-1', 2);
+  yield sandboxFailureToolResult(turnId, 3, 'tool-1');
+  yield sandboxFailureToolResult(turnId, 4, 'tool-2');
+  yield toolStart(turnId, 'tool-3', 'step-2', 5);
+  yield successfulToolResult(turnId, 6, 'tool-3');
+  yield* eventsFor(turnId, 'Incomplete answer', 7);
 }
 
 function continuitySnapshot(
@@ -1570,13 +1663,13 @@ function sandboxFailureToolResult(
   };
 }
 
-function successfulToolResult(turnId: string, ts: number): SharedToolResult {
+function successfulToolResult(turnId: string, ts: number, toolUseId = 'tool-2'): SharedToolResult {
   return {
     type: 'tool_result',
-    id: `${turnId}-tool-success`,
+    id: `${turnId}-${toolUseId}-success`,
     turnId,
     ts,
-    toolUseId: 'tool-2',
+    toolUseId,
     isError: false,
     content: { kind: 'text', text: 'ok' },
   };

--- a/packages/cli/src/__tests__/runtime-host-run-command.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-run-command.test.ts
@@ -2,10 +2,17 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { SessionEvent } from '@maka/core/events';
 import type { SessionSummary, StoredMessage } from '@maka/core/session';
+import {
+  createRuntimeHostSessionProjectionSeed,
+  RuntimeHostSessionProjector,
+} from '@maka/runtime-host/adapter';
 import { LOCAL_RUNTIME_HOST_PROFILE, type RuntimeHostConnection } from '@maka/runtime-host/client';
-import type {
-  InteractionPendingSnapshot,
-  SessionCatalogProjection,
+import {
+  SESSION_CONTINUITY_SCHEMA_VERSION,
+  type InteractionPendingSnapshot,
+  type SessionCatalogProjection,
+  type SessionContinuitySnapshot,
+  type SubscriptionFrame,
 } from '@maka/runtime-host/protocol';
 import { resolveRuntimeHostCliTarget } from '../runtime-host-cli-context.js';
 import { createRuntimeHostRunContext, runRuntimeHostTextCli } from '../runtime-host-run-command.js';
@@ -201,19 +208,35 @@ describe('Runtime Host maka run adapter', () => {
   });
 
   test('returns exit code 1 when an ordinary Host Turn fails', async () => {
+    const stderr: string[] = [];
     const fixture = runFixture({ turnEvents: failedEvents('turn-1', 'provider_failure') });
-    const exitCode = await runFixtureCommand(fixture, ['fail once']);
+    const exitCode = await runFixtureCommand(fixture, ['fail once'], undefined, (text) =>
+      stderr.push(text),
+    );
 
     assert.equal(exitCode, 1);
+    assert.equal(stderr.join(''), 'maka run: Turn failed\n');
   });
 
   test('returns exit code 1 when a same-step sibling succeeds after a sandbox failure', async () => {
+    const stdout: string[] = [];
+    const stderr: string[] = [];
     const fixture = runFixture({
-      turnEvents: sandboxBoundaryEvents('turn-1', 'step-1', 'step-1', 'Incomplete answer'),
+      turnEvents: projectedSameStepSandboxFailureEvents('turn-1'),
     });
-    const exitCode = await runFixtureCommand(fixture, ['run parallel tools']);
+    const exitCode = await runFixtureCommand(
+      fixture,
+      ['run parallel tools'],
+      (text) => stdout.push(text),
+      (text) => stderr.push(text),
+    );
 
     assert.equal(exitCode, 1);
+    assert.equal(stdout.join(''), '');
+    assert.equal(
+      stderr.join(''),
+      'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
+    );
   });
 
   test('returns exit code 0 when the final Graph Turn completes', async () => {
@@ -363,7 +386,7 @@ describe('Runtime Host maka run adapter', () => {
 
   test('classifies live and durable step-cap failures equally', async () => {
     const live = await observeFixtureOutcome({
-      turnEvents: failedEvents('turn-1', 'tool_step_cap_reached'),
+      turnEvents: completionEvents('turn-1', 'step_limit'),
     });
     const durable = await observeFixtureOutcome({
       graph: true,
@@ -374,6 +397,15 @@ describe('Runtime Host maka run adapter', () => {
     assert.equal(live.failure?.class, 'tool_step_cap_reached');
     assert.equal(durable.status, 'failed');
     assert.equal(durable.failure?.class, 'tool_step_cap_reached');
+  });
+
+  test('classifies a standalone context-budget completion as failed', async () => {
+    const outcome = await observeFixtureOutcome({
+      turnEvents: completionEvents('turn-1', 'context_budget_exhausted'),
+    });
+
+    assert.equal(outcome.status, 'failed');
+    assert.equal(outcome.failure?.class, 'context_budget_exhausted');
   });
 
   test('uses the latest durable terminal state for a Graph Turn', async () => {
@@ -1312,6 +1344,64 @@ async function* sandboxBoundaryEvents(
   yield* eventsFor(turnId, text, 6);
 }
 
+async function* projectedSameStepSandboxFailureEvents(turnId: string): AsyncIterable<SessionEvent> {
+  yield toolStart(turnId, 'tool-1', 'step-1', 1);
+  yield toolStart(turnId, 'tool-2', 'step-1', 2);
+  const initial = continuitySnapshot(turnId);
+  const projector = new RuntimeHostSessionProjector(
+    initial,
+    createRuntimeHostSessionProjectionSeed([], initial),
+    () => 10,
+  );
+  yield* projector.accept({
+    kind: 'subscription.session_event',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence: 1,
+    sessionId: 'session-created',
+    runId: 'run-1',
+    event: {
+      type: 'tool_result',
+      id: 'tool-1-result',
+      turnId,
+      ts: 3,
+      toolUseId: 'tool-1',
+      status: 'errored',
+      sandboxFailureReason: 'sandbox_boundary_required',
+    },
+  } satisfies SubscriptionFrame).events;
+  yield successfulToolResult(turnId, 4);
+  yield* eventsFor(turnId, 'Incomplete answer', 5);
+}
+
+function continuitySnapshot(
+  turnId: string,
+  overrides: Partial<SessionContinuitySnapshot> = {},
+): SessionContinuitySnapshot {
+  return {
+    schemaVersion: SESSION_CONTINUITY_SCHEMA_VERSION,
+    session: {
+      sessionId: 'session-created',
+      metadataRevision: 1,
+      status: 'running',
+      createdAt: 1,
+      lastUsedAt: 1,
+      isArchived: false,
+    },
+    projectionRevision: 1,
+    rootTurn: {
+      sessionId: 'session-created',
+      turnId,
+      runId: 'run-1',
+      status: 'running',
+    },
+    goal: null,
+    queue: { hostEpoch: 'host-1', queueRevision: 0, steering: [], followup: [] },
+    interactions: { pending: [] },
+    ...overrides,
+  };
+}
+
 async function* sandboxFailureAfterRecoveryEvents(turnId: string): AsyncIterable<SessionEvent> {
   yield toolStart(turnId, 'tool-1', 'step-1', 1);
   yield sandboxFailureToolResult(turnId, 2);
@@ -1329,6 +1419,13 @@ async function* abortedEvents(turnId: string): AsyncIterable<SessionEvent> {
     turnId,
     ts: 1,
     reason: 'user_stop',
+  };
+  yield {
+    type: 'complete',
+    id: `${turnId}-complete`,
+    turnId,
+    ts: 2,
+    stopReason: 'user_stop',
   };
 }
 
@@ -1349,6 +1446,26 @@ async function* failedEvents(turnId: string, reason: string): AsyncIterable<Sess
     recoverable: false,
     reason,
     message: 'Turn failed',
+  };
+  yield {
+    type: 'complete',
+    id: `${turnId}-complete`,
+    turnId,
+    ts: 3,
+    stopReason: 'error',
+  };
+}
+
+async function* completionEvents(
+  turnId: string,
+  stopReason: Extract<SessionEvent, { type: 'complete' }>['stopReason'],
+): AsyncIterable<SessionEvent> {
+  yield {
+    type: 'complete',
+    id: `${turnId}-complete`,
+    turnId,
+    ts: 1,
+    stopReason,
   };
 }
 

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -1,7 +1,6 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { formatMakaResumeHint } from './cli-invocation.js';
 import { resolveMakaDataRoots } from './workspace-root.js';
 import { parseRuntimeHostCommand, type RuntimeHostCliCommand } from './runtime-host-cli.js';
 import { resolveCliUiLocale } from './cli-ui-locale.js';
@@ -170,13 +169,6 @@ function helpText(cliCommand: string): string {
     '  --credential-env <name>       Read the access credential from this environment variable',
     '  --client-identity <path>      Persist the provider Client instance identity here',
   ].join('\n');
-}
-
-export function formatResumeHint(
-  sessionId: string | null,
-  cliCommand: string = RELEASE_MAKA_CLI_LAUNCH_OPTIONS.cliCommand,
-): string | null {
-  return formatMakaResumeHint(cliCommand, sessionId);
 }
 
 export async function runMakaCli(

--- a/packages/cli/src/run-command-core.ts
+++ b/packages/cli/src/run-command-core.ts
@@ -260,7 +260,7 @@ export async function runMakaTextCliCore(
   }
 
   let outcome: MakaRunOutcome | undefined;
-  let streamBoundaryFailure = false;
+  let unclassifiedBoundaryFailure = false;
   const boundaryFailureInvocationIds = new Set<string>();
   let context: MakaRunContext;
   try {
@@ -293,8 +293,10 @@ export async function runMakaTextCliCore(
       runOutcomeObserver: (result) => {
         if (result.sandboxBoundary === 'recovered') {
           boundaryFailureInvocationIds.delete(result.outcomeId);
+          unclassifiedBoundaryFailure = false;
         } else if (result.sandboxBoundary === 'unresolved') {
           boundaryFailureInvocationIds.add(result.outcomeId);
+          unclassifiedBoundaryFailure = false;
         }
         outcome = result;
       },
@@ -377,7 +379,7 @@ export async function runMakaTextCliCore(
         : {}),
     })) {
       if (event.type === 'sandbox_boundary_request') {
-        streamBoundaryFailure = true;
+        unclassifiedBoundaryFailure = true;
         deps.writeStderr(
           'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
         );
@@ -388,7 +390,7 @@ export async function runMakaTextCliCore(
       }
       const sandboxFailureReason = sessionEventSandboxBoundaryFailureReason(event);
       if (sandboxFailureReason) {
-        streamBoundaryFailure = true;
+        unclassifiedBoundaryFailure = true;
         deps.writeStderr(
           sandboxFailureReason === 'requires_bypass'
             ? 'maka run: sandbox bypass requires an explicit --yolo\n'
@@ -420,10 +422,7 @@ export async function runMakaTextCliCore(
     return 1;
   }
   if (streamFailed) return 1;
-  if (
-    (streamBoundaryFailure && outcome?.sandboxBoundary !== 'recovered') ||
-    boundaryFailureInvocationIds.size > 0
-  ) {
+  if (unclassifiedBoundaryFailure || boundaryFailureInvocationIds.size > 0) {
     return 1;
   }
   if (!outcome) {

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -1,4 +1,4 @@
-import { failureClassFromCompleteStopReason, type SessionEvent } from '@maka/core/events';
+import { type SessionEvent } from '@maka/core/events';
 import { findProjectByIdentity } from '@maka/core/project';
 import { type StoredMessage } from '@maka/core/session';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
@@ -537,9 +537,7 @@ class TurnOutcomeClassifier {
         this.#finalOutput = observation.text;
         return;
       case 'terminal':
-        if (this.#terminal?.status !== 'failed' || observation.status === 'failed') {
-          this.#terminal = observation;
-        }
+        this.#terminal = observation;
         return;
       case 'sandbox_failure':
         this.#unresolvedBoundary = true;
@@ -598,17 +596,7 @@ function observationFromSessionEvent(event: SessionEvent): TurnOutcomeObservatio
     };
   }
   if (event.type === 'complete') {
-    if (event.stopReason === 'user_stop') {
-      return {
-        kind: 'terminal',
-        status: 'failed',
-        failure: { class: 'aborted', message: 'Turn was cancelled' },
-      };
-    }
-    const failureClass = failureClassFromCompleteStopReason(event.stopReason);
-    return failureClass
-      ? { kind: 'terminal', status: 'failed', failure: { class: failureClass } }
-      : { kind: 'terminal', status: 'completed' };
+    return { kind: 'terminal', status: 'completed' };
   }
   return event.type === 'tool_result' ? observationFromToolResult(event) : undefined;
 }

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -1,4 +1,4 @@
-import { type SessionEvent } from '@maka/core/events';
+import { failureClassFromCompleteStopReason, type SessionEvent } from '@maka/core/events';
 import { findProjectByIdentity } from '@maka/core/project';
 import { type StoredMessage } from '@maka/core/session';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
@@ -408,7 +408,7 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
   }
 
   async *#observeTurn(turn: MakaPreparedSessionTurn): AsyncIterable<SessionEvent> {
-    const accumulator = new TurnOutcomeAccumulator(turn.runId ?? turn.turnId);
+    const classifier = new TurnOutcomeClassifier(turn.runId ?? turn.turnId);
     const events = turn.events[Symbol.asyncIterator]();
     for (;;) {
       const next = await this.#interactions.race(events.next());
@@ -417,11 +417,11 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
       if (event.type === 'user_question_request' || event.type === 'sandbox_boundary_request') {
         continue;
       }
-      accumulator.accept(event);
+      classifier.accept(observationFromSessionEvent(event));
       yield event;
     }
     await this.#interactions.settle();
-    await this.#observer?.(accumulator.finish());
+    await this.#observer?.(classifier.outcome('fail'));
   }
 
   async #stopTurn(turn: { sessionId: string; turnId: string; runId: string }): Promise<void> {
@@ -505,11 +505,23 @@ function runtimeHostSessionSummaries(items: readonly SessionCatalogItem[]): Sess
   return items.flatMap((item) => ('kind' in item ? [] : [runtimeHostSessionSummary(item)]));
 }
 
-class TurnOutcomeAccumulator {
+type TurnOutcomeObservation =
+  | { readonly kind: 'output'; readonly text: string }
+  | { readonly kind: 'terminal'; readonly status: 'completed' }
+  | {
+      readonly kind: 'terminal';
+      readonly status: 'failed';
+      readonly failure: NonNullable<MakaRunOutcome['failure']>;
+    }
+  | { readonly kind: 'sandbox_failure' }
+  | { readonly kind: 'tool_success' };
+
+type TerminalOutcomeObservation = Extract<TurnOutcomeObservation, { kind: 'terminal' }>;
+
+class TurnOutcomeClassifier {
   readonly #outcomeId: string;
   #finalOutput: string | undefined;
-  #failure: { class: string; message: string } | undefined;
-  #completed = false;
+  #terminal: TerminalOutcomeObservation | undefined;
   #unresolvedBoundary = false;
   #recoveredBoundary = false;
 
@@ -517,41 +529,47 @@ class TurnOutcomeAccumulator {
     this.#outcomeId = outcomeId;
   }
 
-  accept(event: SessionEvent): void {
-    if (event.type === 'text_complete' && event.text.trim().length > 0) {
-      this.#finalOutput = event.text;
-    } else if (event.type === 'error') {
-      this.#failure = { class: event.reason ?? 'runtime_error', message: event.message };
-    } else if (event.type === 'abort') {
-      this.#failure = { class: 'aborted', message: 'Turn was cancelled' };
-    } else if (event.type === 'complete') {
-      this.#completed = true;
-    }
-    if (event.type !== 'tool_result') return;
-    if (event.isError && event.content.kind === 'text' && event.content.sandboxFailure) {
-      this.#unresolvedBoundary = true;
-      return;
-    }
-    if (!event.isError && this.#unresolvedBoundary) {
-      this.#unresolvedBoundary = false;
-      this.#recoveredBoundary = true;
+  accept(observation: TurnOutcomeObservation | undefined): void {
+    switch (observation?.kind) {
+      case undefined:
+        return;
+      case 'output':
+        this.#finalOutput = observation.text;
+        return;
+      case 'terminal':
+        if (this.#terminal?.status !== 'failed' || observation.status === 'failed') {
+          this.#terminal = observation;
+        }
+        return;
+      case 'sandbox_failure':
+        this.#unresolvedBoundary = true;
+        return;
+      case 'tool_success':
+        if (this.#unresolvedBoundary) {
+          this.#unresolvedBoundary = false;
+          this.#recoveredBoundary = true;
+        }
     }
   }
 
-  finish(): MakaRunOutcome {
-    const completed = this.#completed && !this.#failure;
+  outcome(incomplete: 'fail'): MakaRunOutcome;
+  outcome(incomplete: 'pending'): MakaRunOutcome | undefined;
+  outcome(incomplete: 'fail' | 'pending'): MakaRunOutcome | undefined {
+    const terminal = this.#terminal;
+    if (!terminal && incomplete === 'pending') return undefined;
+    const completed = terminal?.status === 'completed';
+    const failure =
+      terminal?.status === 'failed'
+        ? terminal.failure
+        : {
+            class: 'missing_terminal_event',
+            message: 'Turn ended unexpectedly',
+          };
     return {
       outcomeId: this.#outcomeId,
       status: completed ? 'completed' : 'failed',
       ...(completed && this.#finalOutput !== undefined ? { finalOutput: this.#finalOutput } : {}),
-      ...(!completed
-        ? {
-            failure: this.#failure ?? {
-              class: 'missing_terminal_event',
-              message: 'Turn ended unexpectedly',
-            },
-          }
-        : {}),
+      ...(!completed ? { failure } : {}),
       sandboxBoundary: this.#unresolvedBoundary
         ? 'unresolved'
         : this.#recoveredBoundary
@@ -559,6 +577,73 @@ class TurnOutcomeAccumulator {
           : 'none',
     };
   }
+}
+
+function observationFromSessionEvent(event: SessionEvent): TurnOutcomeObservation | undefined {
+  if (event.type === 'text_complete' && event.text.trim().length > 0) {
+    return { kind: 'output', text: event.text };
+  }
+  if (event.type === 'error') {
+    return {
+      kind: 'terminal',
+      status: 'failed',
+      failure: { class: event.reason ?? event.code ?? 'runtime_error', message: event.message },
+    };
+  }
+  if (event.type === 'abort') {
+    return {
+      kind: 'terminal',
+      status: 'failed',
+      failure: { class: 'aborted', message: 'Turn was cancelled' },
+    };
+  }
+  if (event.type === 'complete') {
+    if (event.stopReason === 'user_stop') {
+      return {
+        kind: 'terminal',
+        status: 'failed',
+        failure: { class: 'aborted', message: 'Turn was cancelled' },
+      };
+    }
+    const failureClass = failureClassFromCompleteStopReason(event.stopReason);
+    return failureClass
+      ? { kind: 'terminal', status: 'failed', failure: { class: failureClass } }
+      : { kind: 'terminal', status: 'completed' };
+  }
+  return event.type === 'tool_result' ? observationFromToolResult(event) : undefined;
+}
+
+function observationFromStoredMessage(message: StoredMessage): TurnOutcomeObservation | undefined {
+  if (message.type === 'assistant' && message.text.trim().length > 0) {
+    return { kind: 'output', text: message.text };
+  }
+  if (message.type === 'turn_state' && message.status === 'completed') {
+    return { kind: 'terminal', status: 'completed' };
+  }
+  if (message.type === 'turn_state' && message.status === 'aborted') {
+    return {
+      kind: 'terminal',
+      status: 'failed',
+      failure: { class: 'aborted', message: 'Turn was cancelled' },
+    };
+  }
+  if (message.type === 'turn_state' && message.status === 'failed') {
+    return {
+      kind: 'terminal',
+      status: 'failed',
+      failure: { class: message.errorClass ?? 'runtime_error' },
+    };
+  }
+  return message.type === 'tool_result' ? observationFromToolResult(message) : undefined;
+}
+
+function observationFromToolResult(
+  result: Pick<Extract<SessionEvent, { type: 'tool_result' }>, 'content' | 'isError'>,
+): TurnOutcomeObservation | undefined {
+  if (result.isError && result.content.kind === 'text' && result.content.sandboxFailure) {
+    return { kind: 'sandbox_failure' };
+  }
+  return result.isError ? undefined : { kind: 'tool_success' };
 }
 
 function graphSupervisorTurnIds(messages: readonly StoredMessage[]): Set<string> {
@@ -587,36 +672,11 @@ function outcomeFromStoredTurn(
   messages: readonly StoredMessage[],
   turnId: string,
 ): MakaRunOutcome | undefined {
-  const turnMessages = messages.filter((message) => message.turnId === turnId);
-  const finalOutput = [...turnMessages]
-    .reverse()
-    .find(
-      (message): message is Extract<StoredMessage, { type: 'assistant' }> =>
-        message.type === 'assistant' && message.text.trim().length > 0,
-    )?.text;
-  const storedTerminal = [...turnMessages]
-    .reverse()
-    .find(
-      (message): message is Extract<StoredMessage, { type: 'turn_state' }> =>
-        message.type === 'turn_state' && message.status !== 'running',
-    );
-  const status = storedTerminal?.status;
-  if (!status) return undefined;
-  const completed = status === 'completed';
-  return {
-    outcomeId: turnId,
-    status: completed ? 'completed' : 'failed',
-    ...(completed && finalOutput !== undefined ? { finalOutput } : {}),
-    ...(!completed
-      ? {
-          failure: {
-            class: storedTerminal?.errorClass ?? storedTerminal?.abortSource ?? status,
-            message: status === 'aborted' ? 'Turn was cancelled' : 'Agent Graph final Turn failed',
-          },
-        }
-      : {}),
-    sandboxBoundary: storedSandboxBoundaryOutcome(turnMessages),
-  };
+  const classifier = new TurnOutcomeClassifier(turnId);
+  for (const message of messages) {
+    if (message.turnId === turnId) classifier.accept(observationFromStoredMessage(message));
+  }
+  return classifier.outcome('pending');
 }
 
 class NonInteractiveInteractionController {
@@ -690,27 +750,6 @@ class NonInteractiveInteractionController {
     this.#failure = error;
     this.#publishFailure(error);
   }
-}
-
-function storedSandboxBoundaryOutcome(
-  messages: readonly StoredMessage[],
-): MakaRunOutcome['sandboxBoundary'] {
-  let unresolved = false;
-  let recovered = false;
-  for (const message of messages) {
-    if (
-      message.type === 'tool_result' &&
-      message.isError &&
-      message.content.kind === 'text' &&
-      message.content.sandboxFailure
-    ) {
-      unresolved = true;
-    } else if (message.type === 'tool_result' && !message.isError && unresolved) {
-      unresolved = false;
-      recovered = true;
-    }
-  }
-  return unresolved ? 'unresolved' : recovered ? 'recovered' : 'none';
 }
 
 function delay(ms: number): Promise<void> {

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -619,7 +619,10 @@ function observationFromStoredMessage(message: StoredMessage): TurnOutcomeObserv
     return {
       kind: 'terminal',
       status: 'failed',
-      failure: { class: message.errorClass ?? 'runtime_error' },
+      failure: {
+        class: message.errorClass ?? 'runtime_error',
+        message: 'Agent Graph final Turn failed',
+      },
     };
   }
   return message.type === 'tool_result' ? observationFromToolResult(message) : undefined;

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -1,4 +1,4 @@
-import { type SessionEvent } from '@maka/core/events';
+import { failureClassFromCompleteStopReason, type SessionEvent } from '@maka/core/events';
 import { findProjectByIdentity } from '@maka/core/project';
 import { type StoredMessage } from '@maka/core/session';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
@@ -507,9 +507,14 @@ function runtimeHostSessionSummaries(items: readonly SessionCatalogItem[]): Sess
 
 type TurnOutcomeObservation =
   | { readonly kind: 'output'; readonly text: string }
-  | { readonly kind: 'terminal'; readonly status: 'completed' }
   | {
       readonly kind: 'terminal';
+      readonly update: 'replace' | 'if_unset';
+      readonly status: 'completed';
+    }
+  | {
+      readonly kind: 'terminal';
+      readonly update: 'replace' | 'if_unset';
       readonly status: 'failed';
       readonly failure: NonNullable<MakaRunOutcome['failure']>;
     }
@@ -549,7 +554,9 @@ class TurnOutcomeClassifier {
         this.#finalOutput = observation.text;
         return;
       case 'terminal':
-        this.#terminal = observation;
+        if (observation.update === 'replace' || this.#terminal === undefined) {
+          this.#terminal = observation;
+        }
         return;
       case 'tool_call':
         if (observation.stepId !== undefined) {
@@ -606,6 +613,7 @@ function observationFromSessionEvent(event: SessionEvent): TurnOutcomeObservatio
   if (event.type === 'error') {
     return {
       kind: 'terminal',
+      update: 'replace',
       status: 'failed',
       failure: { class: event.reason ?? event.code ?? 'runtime_error', message: event.message },
     };
@@ -613,12 +621,13 @@ function observationFromSessionEvent(event: SessionEvent): TurnOutcomeObservatio
   if (event.type === 'abort') {
     return {
       kind: 'terminal',
+      update: 'replace',
       status: 'failed',
       failure: { class: 'aborted', message: 'Turn was cancelled' },
     };
   }
   if (event.type === 'complete') {
-    return { kind: 'terminal', status: 'completed' };
+    return observationFromCompleteEvent(event);
   }
   if (event.type === 'tool_start') {
     return {
@@ -635,11 +644,12 @@ function observationFromStoredMessage(message: StoredMessage): TurnOutcomeObserv
     return { kind: 'output', text: message.text };
   }
   if (message.type === 'turn_state' && message.status === 'completed') {
-    return { kind: 'terminal', status: 'completed' };
+    return { kind: 'terminal', update: 'replace', status: 'completed' };
   }
   if (message.type === 'turn_state' && message.status === 'aborted') {
     return {
       kind: 'terminal',
+      update: 'replace',
       status: 'failed',
       failure: { class: 'aborted', message: 'Turn was cancelled' },
     };
@@ -647,6 +657,7 @@ function observationFromStoredMessage(message: StoredMessage): TurnOutcomeObserv
   if (message.type === 'turn_state' && message.status === 'failed') {
     return {
       kind: 'terminal',
+      update: 'replace',
       status: 'failed',
       failure: {
         class: message.errorClass ?? 'runtime_error',
@@ -662,6 +673,28 @@ function observationFromStoredMessage(message: StoredMessage): TurnOutcomeObserv
     };
   }
   return message.type === 'tool_result' ? observationFromToolResult(message) : undefined;
+}
+
+function observationFromCompleteEvent(
+  event: Extract<SessionEvent, { type: 'complete' }>,
+): TerminalOutcomeObservation {
+  if (event.stopReason === 'user_stop') {
+    return {
+      kind: 'terminal',
+      update: 'if_unset',
+      status: 'failed',
+      failure: { class: 'aborted', message: 'Turn was cancelled' },
+    };
+  }
+  const failureClass = failureClassFromCompleteStopReason(event.stopReason);
+  return failureClass
+    ? {
+        kind: 'terminal',
+        update: 'if_unset',
+        status: 'failed',
+        failure: { class: failureClass },
+      }
+    : { kind: 'terminal', update: 'if_unset', status: 'completed' };
 }
 
 function observationFromToolResult(

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -217,6 +217,13 @@ async function prepareRuntimeHostRunInput(
   return preparedInput;
 }
 
+type ActiveRuntimeHostTurn = {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly runId: string;
+  outcome: TurnOutcomeClassifier;
+};
+
 class RuntimeHostRunRuntime implements MakaRunRuntime {
   readonly #connection: RuntimeHostConnection;
   readonly #driver: RuntimeHostMakaSessionDriver;
@@ -226,7 +233,7 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
   readonly #maxSteps: number | undefined;
   readonly #unsubscribeTranscriptReplacements: () => void;
   #sessionId: string | undefined;
-  #activeTurn: { sessionId: string; turnId: string; runId: string } | undefined;
+  #activeTurn: ActiveRuntimeHostTurn | undefined;
   #stopRequested = false;
   #closed = false;
   readonly #interactions: NonInteractiveInteractionController;
@@ -259,7 +266,10 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
       this.#stopForInteraction(pending),
     );
     this.#unsubscribeTranscriptReplacements = driver.subscribeTranscriptReplacements(
-      (_sessionId, _turnId, messages) => this.#acceptGraphTranscript(messages),
+      (sessionId, turnId, messages) => {
+        this.#acceptRootTranscript(sessionId, turnId, messages);
+        this.#acceptGraphTranscript(messages);
+      },
     );
   }
 
@@ -287,14 +297,19 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
       ...(maxSteps !== undefined ? { maxSteps } : {}),
     });
     if (!turn.runId) throw new Error('Runtime Host did not return a Run identity');
-    const activeTurn = { sessionId: turn.sessionId, turnId: turn.turnId, runId: turn.runId };
+    const activeTurn = {
+      sessionId: turn.sessionId,
+      turnId: turn.turnId,
+      runId: turn.runId,
+      outcome: new TurnOutcomeClassifier(turn.runId),
+    };
     this.#activeTurn = activeTurn;
     if (this.#stopRequested) {
       await this.#stopTurn(activeTurn);
       if (input.turnOrchestration?.mode === 'graph') await this.#stopGraph(sessionId);
     }
     try {
-      yield* this.#observeTurn(turn);
+      yield* this.#observeTurn(turn, activeTurn);
     } finally {
       if (this.#activeTurn === activeTurn) this.#activeTurn = undefined;
     }
@@ -407,8 +422,10 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
     this.#sessionId = sessionId;
   }
 
-  async *#observeTurn(turn: MakaPreparedSessionTurn): AsyncIterable<SessionEvent> {
-    const classifier = new TurnOutcomeClassifier(turn.runId ?? turn.turnId);
+  async *#observeTurn(
+    turn: MakaPreparedSessionTurn,
+    active: ActiveRuntimeHostTurn,
+  ): AsyncIterable<SessionEvent> {
     const events = turn.events[Symbol.asyncIterator]();
     for (;;) {
       const next = await this.#interactions.race(events.next());
@@ -417,11 +434,11 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
       if (event.type === 'user_question_request' || event.type === 'sandbox_boundary_request') {
         continue;
       }
-      classifier.accept(observationFromSessionEvent(event));
+      active.outcome.accept(observationFromSessionEvent(event));
       yield event;
     }
     await this.#interactions.settle();
-    await this.#observer?.(classifier.outcome('fail'));
+    await this.#observer?.(active.outcome.outcome('fail'));
   }
 
   async #stopTurn(turn: { sessionId: string; turnId: string; runId: string }): Promise<void> {
@@ -447,6 +464,12 @@ class RuntimeHostRunRuntime implements MakaRunRuntime {
         waiter.resolve(replacement);
       }
     }
+  }
+
+  #acceptRootTranscript(sessionId: string, turnId: string, messages: StoredMessage[]): void {
+    const active = this.#activeTurn;
+    if (!active || active.sessionId !== sessionId || active.turnId !== turnId) return;
+    active.outcome = classifierFromStoredTurn(messages, turnId, active.runId);
   }
 
   #waitForGraphTurnTerminal(turnId: string): Promise<StoredMessage[]> {
@@ -531,10 +554,6 @@ type TurnOutcomeObservation =
     };
 
 type TerminalOutcomeObservation = Extract<TurnOutcomeObservation, { kind: 'terminal' }>;
-type SandboxBoundaryState =
-  | { readonly status: 'none' }
-  | { readonly status: 'unresolved'; readonly failedStepId: string | undefined }
-  | { readonly status: 'recovered' };
 
 class TurnOutcomeClassifier {
   readonly #outcomeId: string;
@@ -542,9 +561,13 @@ class TurnOutcomeClassifier {
     string,
     { readonly stepId: string | undefined; readonly toolName: string }
   >();
+  readonly #unresolvedSandboxFailures = new Map<
+    string,
+    { readonly failedStepId: string | undefined }
+  >();
   #finalOutput: string | undefined;
   #terminal: TerminalOutcomeObservation | undefined;
-  #sandboxBoundary: SandboxBoundaryState = { status: 'none' };
+  #sandboxBoundaryRecovered = false;
 
   constructor(outcomeId: string) {
     this.#outcomeId = outcomeId;
@@ -571,18 +594,24 @@ class TurnOutcomeClassifier {
       case 'tool_result': {
         const call = this.#callByToolUseId.get(observation.toolUseId);
         if (observation.outcome === 'sandbox_failure') {
-          this.#sandboxBoundary = { status: 'unresolved', failedStepId: call?.stepId };
+          this.#unresolvedSandboxFailures.set(observation.toolUseId, {
+            failedStepId: call?.stepId,
+          });
           return;
         }
+        const unresolved = [...this.#unresolvedSandboxFailures.values()];
+        // The wire has no retry identity. A later success can only prove recovery
+        // when there is exactly one unresolved candidate.
         if (
           observation.outcome === 'success' &&
           call?.toolName !== 'request_sandbox_boundary' &&
-          this.#sandboxBoundary.status === 'unresolved' &&
+          unresolved.length === 1 &&
           call?.stepId !== undefined &&
-          this.#sandboxBoundary.failedStepId !== undefined &&
-          call.stepId !== this.#sandboxBoundary.failedStepId
+          unresolved[0]?.failedStepId !== undefined &&
+          call.stepId !== unresolved[0].failedStepId
         ) {
-          this.#sandboxBoundary = { status: 'recovered' };
+          this.#unresolvedSandboxFailures.clear();
+          this.#sandboxBoundaryRecovered = true;
         }
         return;
       }
@@ -595,6 +624,12 @@ class TurnOutcomeClassifier {
     const terminal = this.#terminal;
     if (!terminal && incomplete === 'pending') return undefined;
     const completed = terminal?.status === 'completed';
+    const sandboxBoundary =
+      this.#unresolvedSandboxFailures.size > 0
+        ? 'unresolved'
+        : this.#sandboxBoundaryRecovered
+          ? 'recovered'
+          : 'none';
     const failure =
       terminal?.status === 'failed'
         ? terminal.failure
@@ -607,7 +642,7 @@ class TurnOutcomeClassifier {
       status: completed ? 'completed' : 'failed',
       ...(completed && this.#finalOutput !== undefined ? { finalOutput: this.#finalOutput } : {}),
       ...(!completed ? { failure } : {}),
-      sandboxBoundary: this.#sandboxBoundary.status,
+      sandboxBoundary,
     };
   }
 }
@@ -746,11 +781,19 @@ function outcomeFromStoredTurn(
   messages: readonly StoredMessage[],
   turnId: string,
 ): MakaRunOutcome | undefined {
-  const classifier = new TurnOutcomeClassifier(turnId);
+  return classifierFromStoredTurn(messages, turnId, turnId).outcome('pending');
+}
+
+function classifierFromStoredTurn(
+  messages: readonly StoredMessage[],
+  turnId: string,
+  outcomeId: string,
+): TurnOutcomeClassifier {
+  const classifier = new TurnOutcomeClassifier(outcomeId);
   for (const message of messages) {
     if (message.turnId === turnId) classifier.accept(observationFromStoredMessage(message));
   }
-  return classifier.outcome('pending');
+  return classifier;
 }
 
 class NonInteractiveInteractionController {

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -513,17 +513,29 @@ type TurnOutcomeObservation =
       readonly status: 'failed';
       readonly failure: NonNullable<MakaRunOutcome['failure']>;
     }
-  | { readonly kind: 'sandbox_failure' }
-  | { readonly kind: 'tool_success' };
+  | {
+      readonly kind: 'tool_call';
+      readonly toolUseId: string;
+      readonly stepId: string | undefined;
+    }
+  | {
+      readonly kind: 'tool_result';
+      readonly toolUseId: string;
+      readonly outcome: 'sandbox_failure' | 'success';
+    };
 
 type TerminalOutcomeObservation = Extract<TurnOutcomeObservation, { kind: 'terminal' }>;
+type SandboxBoundaryState =
+  | { readonly status: 'none' }
+  | { readonly status: 'unresolved'; readonly failedStepId: string | undefined }
+  | { readonly status: 'recovered' };
 
 class TurnOutcomeClassifier {
   readonly #outcomeId: string;
+  readonly #stepByToolUseId = new Map<string, string>();
   #finalOutput: string | undefined;
   #terminal: TerminalOutcomeObservation | undefined;
-  #unresolvedBoundary = false;
-  #recoveredBoundary = false;
+  #sandboxBoundary: SandboxBoundaryState = { status: 'none' };
 
   constructor(outcomeId: string) {
     this.#outcomeId = outcomeId;
@@ -539,14 +551,28 @@ class TurnOutcomeClassifier {
       case 'terminal':
         this.#terminal = observation;
         return;
-      case 'sandbox_failure':
-        this.#unresolvedBoundary = true;
-        return;
-      case 'tool_success':
-        if (this.#unresolvedBoundary) {
-          this.#unresolvedBoundary = false;
-          this.#recoveredBoundary = true;
+      case 'tool_call':
+        if (observation.stepId !== undefined) {
+          this.#stepByToolUseId.set(observation.toolUseId, observation.stepId);
         }
+        return;
+      case 'tool_result': {
+        const stepId = this.#stepByToolUseId.get(observation.toolUseId);
+        if (observation.outcome === 'sandbox_failure') {
+          this.#sandboxBoundary = { status: 'unresolved', failedStepId: stepId };
+          return;
+        }
+        if (
+          observation.outcome === 'success' &&
+          this.#sandboxBoundary.status === 'unresolved' &&
+          stepId !== undefined &&
+          this.#sandboxBoundary.failedStepId !== undefined &&
+          stepId !== this.#sandboxBoundary.failedStepId
+        ) {
+          this.#sandboxBoundary = { status: 'recovered' };
+        }
+        return;
+      }
     }
   }
 
@@ -568,11 +594,7 @@ class TurnOutcomeClassifier {
       status: completed ? 'completed' : 'failed',
       ...(completed && this.#finalOutput !== undefined ? { finalOutput: this.#finalOutput } : {}),
       ...(!completed ? { failure } : {}),
-      sandboxBoundary: this.#unresolvedBoundary
-        ? 'unresolved'
-        : this.#recoveredBoundary
-          ? 'recovered'
-          : 'none',
+      sandboxBoundary: this.#sandboxBoundary.status,
     };
   }
 }
@@ -597,6 +619,13 @@ function observationFromSessionEvent(event: SessionEvent): TurnOutcomeObservatio
   }
   if (event.type === 'complete') {
     return { kind: 'terminal', status: 'completed' };
+  }
+  if (event.type === 'tool_start') {
+    return {
+      kind: 'tool_call',
+      toolUseId: event.toolUseId,
+      stepId: event.stepId,
+    };
   }
   return event.type === 'tool_result' ? observationFromToolResult(event) : undefined;
 }
@@ -625,16 +654,29 @@ function observationFromStoredMessage(message: StoredMessage): TurnOutcomeObserv
       },
     };
   }
+  if (message.type === 'tool_call') {
+    return {
+      kind: 'tool_call',
+      toolUseId: message.id,
+      stepId: message.stepId,
+    };
+  }
   return message.type === 'tool_result' ? observationFromToolResult(message) : undefined;
 }
 
 function observationFromToolResult(
-  result: Pick<Extract<SessionEvent, { type: 'tool_result' }>, 'content' | 'isError'>,
+  result: Pick<Extract<SessionEvent, { type: 'tool_result' }>, 'content' | 'isError' | 'toolUseId'>,
 ): TurnOutcomeObservation | undefined {
   if (result.isError && result.content.kind === 'text' && result.content.sandboxFailure) {
-    return { kind: 'sandbox_failure' };
+    return {
+      kind: 'tool_result',
+      toolUseId: result.toolUseId,
+      outcome: 'sandbox_failure',
+    };
   }
-  return result.isError ? undefined : { kind: 'tool_success' };
+  return result.isError
+    ? undefined
+    : { kind: 'tool_result', toolUseId: result.toolUseId, outcome: 'success' };
 }
 
 function graphSupervisorTurnIds(messages: readonly StoredMessage[]): Set<string> {

--- a/packages/cli/src/runtime-host-run-command.ts
+++ b/packages/cli/src/runtime-host-run-command.ts
@@ -522,6 +522,7 @@ type TurnOutcomeObservation =
       readonly kind: 'tool_call';
       readonly toolUseId: string;
       readonly stepId: string | undefined;
+      readonly toolName: string;
     }
   | {
       readonly kind: 'tool_result';
@@ -537,7 +538,10 @@ type SandboxBoundaryState =
 
 class TurnOutcomeClassifier {
   readonly #outcomeId: string;
-  readonly #stepByToolUseId = new Map<string, string>();
+  readonly #callByToolUseId = new Map<
+    string,
+    { readonly stepId: string | undefined; readonly toolName: string }
+  >();
   #finalOutput: string | undefined;
   #terminal: TerminalOutcomeObservation | undefined;
   #sandboxBoundary: SandboxBoundaryState = { status: 'none' };
@@ -559,22 +563,24 @@ class TurnOutcomeClassifier {
         }
         return;
       case 'tool_call':
-        if (observation.stepId !== undefined) {
-          this.#stepByToolUseId.set(observation.toolUseId, observation.stepId);
-        }
+        this.#callByToolUseId.set(observation.toolUseId, {
+          stepId: observation.stepId,
+          toolName: observation.toolName,
+        });
         return;
       case 'tool_result': {
-        const stepId = this.#stepByToolUseId.get(observation.toolUseId);
+        const call = this.#callByToolUseId.get(observation.toolUseId);
         if (observation.outcome === 'sandbox_failure') {
-          this.#sandboxBoundary = { status: 'unresolved', failedStepId: stepId };
+          this.#sandboxBoundary = { status: 'unresolved', failedStepId: call?.stepId };
           return;
         }
         if (
           observation.outcome === 'success' &&
+          call?.toolName !== 'request_sandbox_boundary' &&
           this.#sandboxBoundary.status === 'unresolved' &&
-          stepId !== undefined &&
+          call?.stepId !== undefined &&
           this.#sandboxBoundary.failedStepId !== undefined &&
-          stepId !== this.#sandboxBoundary.failedStepId
+          call.stepId !== this.#sandboxBoundary.failedStepId
         ) {
           this.#sandboxBoundary = { status: 'recovered' };
         }
@@ -634,6 +640,7 @@ function observationFromSessionEvent(event: SessionEvent): TurnOutcomeObservatio
       kind: 'tool_call',
       toolUseId: event.toolUseId,
       stepId: event.stepId,
+      toolName: event.toolName,
     };
   }
   return event.type === 'tool_result' ? observationFromToolResult(event) : undefined;
@@ -670,6 +677,7 @@ function observationFromStoredMessage(message: StoredMessage): TurnOutcomeObserv
       kind: 'tool_call',
       toolUseId: message.id,
       stepId: message.stepId,
+      toolName: message.toolName,
     };
   }
   return message.type === 'tool_result' ? observationFromToolResult(message) : undefined;

--- a/packages/cli/src/sandbox-boundary-failure.ts
+++ b/packages/cli/src/sandbox-boundary-failure.ts
@@ -1,6 +1,6 @@
 import type { SessionEvent } from '@maka/core/events';
 
-export type SandboxBoundaryFailureReason = 'sandbox_boundary_required' | 'requires_bypass';
+type SandboxBoundaryFailureReason = 'sandbox_boundary_required' | 'requires_bypass';
 
 export function sessionEventSandboxBoundaryFailureReason(
   event: SessionEvent,

--- a/packages/cli/src/sandbox-boundary-failure.ts
+++ b/packages/cli/src/sandbox-boundary-failure.ts
@@ -1,5 +1,4 @@
 import type { SessionEvent } from '@maka/core/events';
-import type { InvocationResult } from '@maka/runtime/invocation-context';
 
 export type SandboxBoundaryFailureReason = 'sandbox_boundary_required' | 'requires_bypass';
 
@@ -17,56 +16,10 @@ export function sessionEventSandboxBoundaryFailureReason(
   return normalizeSandboxBoundaryFailureReason(event.content.sandboxFailure.reason);
 }
 
-export function invocationHasSandboxBoundaryFailure(result: InvocationResult): boolean {
-  return result.events.some(
-    (event) => runtimeEventSandboxBoundaryFailureReason(event) !== undefined,
-  );
-}
-
-export function invocationRecoveredSandboxBoundaryFailure(
-  result: InvocationResult | undefined,
-): boolean {
-  if (!invocationCompletedWithOutput(result)) return false;
-  let unresolvedBoundaryFailure = false;
-  let recoveredBoundaryFailure = false;
-  for (const event of result.events) {
-    if (event.content?.kind !== 'function_response') continue;
-    if (event.content.isError && runtimeEventSandboxBoundaryFailureReason(event)) {
-      unresolvedBoundaryFailure = true;
-      continue;
-    }
-    if (unresolvedBoundaryFailure && !event.content.isError) {
-      unresolvedBoundaryFailure = false;
-      recoveredBoundaryFailure = true;
-    }
-  }
-  return recoveredBoundaryFailure && !unresolvedBoundaryFailure;
-}
-
-function runtimeEventSandboxBoundaryFailureReason(
-  event: InvocationResult['events'][number],
-): SandboxBoundaryFailureReason | undefined {
-  if (event.content?.kind !== 'function_response' || !isRecord(event.content.result)) {
-    return undefined;
-  }
-  const failure = event.content.result.sandboxFailure;
-  return isRecord(failure) ? normalizeSandboxBoundaryFailureReason(failure.reason) : undefined;
-}
-
 function normalizeSandboxBoundaryFailureReason(
   reason: unknown,
 ): SandboxBoundaryFailureReason | undefined {
   return reason === 'sandbox_boundary_required' || reason === 'requires_bypass'
     ? reason
     : undefined;
-}
-
-function invocationCompletedWithOutput(
-  result: InvocationResult | undefined,
-): result is InvocationResult & { status: 'completed'; finalOutput: string } {
-  return result?.status === 'completed' && typeof result.finalOutput === 'string';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/cli/src/session-recap.ts
+++ b/packages/cli/src/session-recap.ts
@@ -5,11 +5,6 @@ export const AUTO_RECAP_MIN_TURNS = 3;
 /** Raw-output size (bytes) above which an automatic recap is not surfaced in the transcript (still persisted). */
 export const AUTO_RECAP_DISPLAY_LIMIT_BYTES = 500;
 
-/**
- * Cleans a raw model recap response: collapses whitespace, strips a leading
- * `Recap:` / `Summary:` / `回顾：`-style label, strips one layer of wrapping
- * quotes, and truncates to 1200 characters (with an ellipsis) if needed.
- */
 export interface ShouldAutoRecapInput {
   /** Milliseconds since the last recorded user activity. */
   idleMs: number;

--- a/packages/cli/src/session-recap.ts
+++ b/packages/cli/src/session-recap.ts
@@ -1,8 +1,3 @@
-import { cleanSessionRecapText, SESSION_RECAP_INSTRUCTION } from '@maka/runtime/session-recap';
-
-export const RECAP_INSTRUCTION = SESSION_RECAP_INSTRUCTION;
-export const cleanRecapText = cleanSessionRecapText;
-
 /** Idle gap (ms) after which the first normal prompt on return triggers an automatic recap. */
 export const AUTO_RECAP_IDLE_MS = 180_000;
 /** Minimum main-turn count (user-prompted turns) before an automatic recap may fire. */

--- a/packages/cli/src/tui-diff.ts
+++ b/packages/cli/src/tui-diff.ts
@@ -9,7 +9,7 @@ import { ansi } from './tui-ansi.js';
  * the transcript at all. Hunk headers stay: they are the only line-number
  * anchor in the terminal rendering.
  */
-export function colorDiffRow(row: UnifiedDiffRow): string {
+function colorDiffRow(row: UnifiedDiffRow): string {
   switch (row.kind) {
     case 'add':
       return ansi.green(row.text);

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -99,7 +99,7 @@ describe('Runtime Host bootstrap protocol', () => {
   });
 
   test('publishes a new compatibility epoch for sandbox failure results', () => {
-    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 29);
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 33);
   });
 
   test('selects the highest mutually supported protocol and rejects a gap', () => {

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -98,6 +98,10 @@ describe('Runtime Host bootstrap protocol', () => {
     assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 25);
   });
 
+  test('publishes a new compatibility epoch for sandbox failure results', () => {
+    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 29);
+  });
+
   test('selects the highest mutually supported protocol and rejects a gap', () => {
     assert.equal(negotiateProtocol({ min: 0, max: 0 }, { min: 0, max: 0 }), 0);
     assert.equal(negotiateProtocol({ min: 1, max: 3 }, { min: 2, max: 4 }), 3);
@@ -255,6 +259,12 @@ describe('Runtime Host bootstrap protocol', () => {
       { ...identity, type: 'tool_result', status: 'completed', durationMs: 3 },
       {
         ...identity,
+        type: 'tool_result',
+        status: 'errored',
+        sandboxFailureReason: 'sandbox_boundary_required',
+      },
+      {
+        ...identity,
         type: 'tool_result_preview',
         isError: false,
         content: {
@@ -287,6 +297,18 @@ describe('Runtime Host bootstrap protocol', () => {
         type: 'tool_result',
         status: 'errored',
         error: 'raw provider error',
+      },
+      {
+        ...identity,
+        type: 'tool_result',
+        status: 'errored',
+        sandboxFailureReason: 'raw provider error',
+      },
+      {
+        ...identity,
+        type: 'tool_result',
+        status: 'completed',
+        sandboxFailureReason: 'requires_bypass',
       },
       {
         ...identity,

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -1808,6 +1808,49 @@ test('tool_result clears retained tool_result_preview so a later open does not s
   coordinator.close();
 });
 
+test('publishes only the minimal sandbox failure reason from a tool result', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const sink = new RecordingSink();
+  const connection = coordinator.attachConnection('connection-1', sink);
+  const opened = await open(coordinator, 'connection-1');
+  connection.activate(opened.subscriptionId);
+
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', {
+    type: 'tool_result',
+    id: 'result-1',
+    turnId: 'turn-1',
+    ts: 2,
+    toolUseId: 'tool-1',
+    isError: true,
+    content: {
+      kind: 'text',
+      text: 'sensitive tool output',
+      sandboxFailure: { reason: 'sandbox_boundary_required' },
+    },
+  });
+  await waitFor(() => sink.frames.length === 1);
+
+  const [frame] = sink.frames;
+  assert.equal(frame?.kind, 'subscription.session_event');
+  if (frame?.kind !== 'subscription.session_event') return;
+  assert.deepEqual(frame.event, {
+    type: 'tool_result',
+    id: 'result-1',
+    turnId: 'turn-1',
+    ts: 2,
+    toolUseId: 'tool-1',
+    status: 'errored',
+    sandboxFailureReason: 'sandbox_boundary_required',
+  });
+
+  connection.abort(opened.subscriptionId);
+  coordinator.close();
+});
+
 class RecordingSink implements SessionContinuityFrameSink {
   readonly frames: SubscriptionFrame[] = [];
 

--- a/packages/runtime-host/src/adapter/session-projector.ts
+++ b/packages/runtime-host/src/adapter/session-projector.ts
@@ -506,7 +506,13 @@ function projectToolEvent(
     type: 'tool_result',
     ...base,
     isError: event.status === 'errored',
-    content: { kind: 'text', text: '' },
+    content: {
+      kind: 'text',
+      text: '',
+      ...(event.sandboxFailureReason
+        ? { sandboxFailure: { reason: event.sandboxFailureReason } }
+        : {}),
+    },
     ...(event.operationId ? { operationId: event.operationId } : {}),
     ...(event.durationMs === undefined ? {} : { durationMs: event.durationMs }),
   };

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -72,7 +72,9 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 32 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 33 as const;
+// 33: Live tool results may carry the bounded sandbox failure reason. Older
+// Clients reject that closed-frame addition, so mixed peers must not connect.
 // 32: `request_authorization_code` leaves the OAuth presentation wire. An older
 // Client still offers it and an older Host still asks for it, and neither side
 // can carry the authorization code the other expects.

--- a/packages/runtime-host/src/protocol/session-continuity.ts
+++ b/packages/runtime-host/src/protocol/session-continuity.ts
@@ -1,5 +1,5 @@
 import { TOOL_ACTIVITY_KINDS, TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
-import type { ToolResultPreviewContent } from '@maka/core/events';
+import type { SandboxBoundaryFailureSignal, ToolResultPreviewContent } from '@maka/core/events';
 import { decodeToolResultPreviewContent } from '@maka/core/tool-result-preview';
 import type { ToolActivityKind } from '@maka/core/events';
 import type { SessionStatus } from '@maka/core/session';
@@ -162,6 +162,7 @@ export type SessionToolEvent =
       type: 'tool_result';
       operationId?: string;
       status: 'completed' | 'errored';
+      sandboxFailureReason?: SandboxBoundaryFailureSignal['reason'];
       durationMs?: number;
     })
   | (SessionToolEventIdentity & {
@@ -801,6 +802,7 @@ function decodeSessionToolEvent(value: unknown): SessionToolEvent {
       'toolUseId',
       'operationId',
       'status',
+      'sandboxFailureReason',
       'durationMs',
     ];
     assertAllowedKeys(record, 'Session tool result event', allowed);
@@ -815,6 +817,9 @@ function decodeSessionToolEvent(value: unknown): SessionToolEvent {
     if (record.status !== 'completed' && record.status !== 'errored') {
       throw invalidProtocolFrame('Invalid Session tool result status');
     }
+    if (record.status === 'completed' && record.sandboxFailureReason !== undefined) {
+      throw invalidProtocolFrame('Completed Session tool result cannot carry a sandbox failure');
+    }
     return {
       type: record.type,
       ...identity,
@@ -822,6 +827,9 @@ function decodeSessionToolEvent(value: unknown): SessionToolEvent {
         ? {}
         : { operationId: requireEntityId(record.operationId, 'operationId') }),
       status: record.status,
+      ...(record.sandboxFailureReason === undefined
+        ? {}
+        : { sandboxFailureReason: requireSandboxFailureReason(record.sandboxFailureReason) }),
       ...(record.durationMs === undefined
         ? {}
         : {
@@ -856,6 +864,11 @@ function decodeSessionToolEvent(value: unknown): SessionToolEvent {
     };
   }
   throw invalidProtocolFrame('Invalid Session tool event type');
+}
+
+function requireSandboxFailureReason(value: unknown): SandboxBoundaryFailureSignal['reason'] {
+  if (value === 'sandbox_boundary_required' || value === 'requires_bypass') return value;
+  throw invalidProtocolFrame('Invalid Session tool result sandbox failure reason');
 }
 
 function decodeSessionContinuityIdentity(value: unknown): SessionContinuityIdentity {

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -1956,6 +1956,9 @@ function projectToolEvent(
         ...identity,
         ...(event.operationId === undefined ? {} : { operationId: event.operationId }),
         status: event.isError ? 'errored' : 'completed',
+        ...(event.isError && event.content.kind === 'text' && event.content.sandboxFailure
+          ? { sandboxFailureReason: event.content.sandboxFailure.reason }
+          : {}),
         ...(event.durationMs === undefined ? {} : { durationMs: event.durationMs }),
       };
     case 'tool_result_preview':


### PR DESCRIPTION
## Summary

- Normalize live `SessionEvent` and durable `StoredMessage` inputs through one internal outcome reducer while preserving their distinct incomplete-terminal policies.
- Align cancellation, failure, complete-stop, and sandbox recovery semantics across `maka run` and `maka run --graph`.
- Remove InvocationResult-era sandbox helpers and unused CLI wrappers and exports.
- Pin ordinary and Graph success/failure exit codes at the public CLI boundary.

Fixes #3088

## Verification

- `npm --workspace maka-agent run build`
- `node --test packages/cli/dist/__tests__/runtime-host-run-command.test.js` — 25 passed
- `npm --workspace maka-agent run typecheck`
- `npm run format:check`
- `npx biome check` on all changed files
- Full-repository tests were not run; the focused CLI suite covers the changed execution seam.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex analyzed the duplicate outcome paths, implemented the reducer and dead-code cleanup, authored and ran the focused tests, and drafted this PR description. The commits include `Generated-by: Codex` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

