### PR TITLE
refactor(runtime-host): trim dead export surface from barrels

### DIFF
--- a/packages/runtime-host/src/__tests__/agent-graph-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/agent-graph-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
@@ -13,7 +14,6 @@ import {
   decodeHostFrame,
   type AgentGraphClientSnapshot,
   type AgentGraphOperatorInspection,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 
 const fingerprint = `sha256:${'a'.repeat(64)}` as const;

--- a/packages/runtime-host/src/__tests__/artifact-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/artifact-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { ArtifactRecord } from '@maka/core/artifacts';
@@ -15,7 +16,6 @@ import {
   encodeArtifactQueryResult,
   encodeProtocolMessage,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 import { encodeArtifactProjection } from '../protocol/artifact.js';
 

--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -18,10 +18,8 @@ import {
   RUNTIME_HOST_PROTOCOL_VERSION,
   type RequestFrame,
 } from '../protocol/index.js';
-import {
-  openRuntimeHostAccessAuthority,
-  startExecutionRuntimeHostService,
-} from '../server/index.js';
+import { openRuntimeHostAccessAuthority } from '../server/access-authority.js';
+import { startExecutionRuntimeHostService } from '../server/execution-service.js';
 import { authorizeRuntimeHostOperation } from '../server/connection-authority.js';
 
 const PROTOCOL = {

--- a/packages/runtime-host/src/__tests__/client-capability-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { SCHEDULED_TASK_NATIVE_EFFECT_SERVICE_ID } from '@maka/runtime/scheduled-task-tools';
@@ -8,7 +9,6 @@ import {
   decodeClientCapabilityResult,
   decodeClientFrame,
   decodeHostFrame,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 
 describe('Client Capability protocol', () => {

--- a/packages/runtime-host/src/__tests__/connection-effects-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-effects-protocol.test.ts
@@ -1,7 +1,7 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { decodeClientFrame, decodeHostFrame } from '../protocol/index.js';
-import { RuntimeHostProtocolError } from '../protocol/errors.js';
 
 const EXPECTED = {
   connectionId: '00000000-0000-4000-8000-000000000001',

--- a/packages/runtime-host/src/__tests__/context-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/context-protocol.test.ts
@@ -1,6 +1,7 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { decodeClientFrame, decodeHostFrame, RuntimeHostProtocolError } from '../protocol/index.js';
+import { decodeClientFrame, decodeHostFrame } from '../protocol/index.js';
 
 test('context operations preserve bounded exact wire values', () => {
   assert.deepEqual(

--- a/packages/runtime-host/src/__tests__/execution-inspect-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-inspect-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { AgentRunInspectDocument, SessionInspectDocument } from '@maka/core/execution-inspect';
@@ -7,7 +8,6 @@ import {
   EXECUTION_INSPECT_CANDIDATE_MAX_ITEMS,
   EXECUTION_INSPECT_RESULT_MAX_BYTES,
   HOST_OPERATION_SPECS,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 
 describe('execution inspect protocol', () => {

--- a/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
@@ -6,7 +7,6 @@ import {
   decodeExternalSessionSourceQueryResult,
   EXTERNAL_SESSION_PAGE_MAX_ITEMS,
   HOST_OPERATION_SPECS,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 
 describe('external Session protocol', () => {

--- a/packages/runtime-host/src/__tests__/framed-transport.test.ts
+++ b/packages/runtime-host/src/__tests__/framed-transport.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { createServer, Socket, type Server } from 'node:net';
 import { test } from 'node:test';
@@ -6,7 +7,6 @@ import {
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
   RUNTIME_HOST_PROTOCOL_VERSION,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
 import { frameLocalIpcProtocolMessage } from '../transport/local-ipc-framing.js';

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -2061,23 +2061,25 @@ describe('non-serving Runtime Host kernel', () => {
           }),
         RangeError,
       );
-      await assert.rejects(() =>
-        connectRuntimeHost({
-          rootPath: paths.root,
-          surface: 'tui',
-          protocol: CURRENT_PROTOCOL,
-          clientInstanceId: '',
-        }),
+      await assert.rejects(
+        () =>
+          connectRuntimeHost({
+            rootPath: paths.root,
+            surface: 'tui',
+            protocol: CURRENT_PROTOCOL,
+            clientInstanceId: '',
+          }),
         RuntimeHostProtocolError,
       );
-      await assert.rejects(() =>
-        connectOrSpawnRuntimeHost({
-          rootPath: paths.root,
-          surface: 'tui',
-          protocol: CURRENT_PROTOCOL,
-          compositionId: 'Invalid Composition',
-          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
-        }),
+      await assert.rejects(
+        () =>
+          connectOrSpawnRuntimeHost({
+            rootPath: paths.root,
+            surface: 'tui',
+            protocol: CURRENT_PROTOCOL,
+            compositionId: 'Invalid Composition',
+            candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          }),
         RuntimeHostProtocolError,
       );
       await assertPathMissing(paths.root);
@@ -2088,16 +2090,17 @@ describe('non-serving Runtime Host kernel', () => {
       });
       assert.equal(candidate.kind, 'winner');
       if (candidate.kind !== 'winner') return;
-      await assert.rejects(() =>
-        connectOrSpawnRuntimeHost({
-          rootPath: paths.root,
-          surface: 'tui',
-          protocol: CURRENT_PROTOCOL,
-          compositionId: KERNEL_COMPOSITION.descriptor.id,
-          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
-          clientInstanceId: 'x'.repeat(129),
-          electionDeadlineMs: 100,
-        }),
+      await assert.rejects(
+        () =>
+          connectOrSpawnRuntimeHost({
+            rootPath: paths.root,
+            surface: 'tui',
+            protocol: CURRENT_PROTOCOL,
+            compositionId: KERNEL_COMPOSITION.descriptor.id,
+            candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+            clientInstanceId: 'x'.repeat(129),
+            electionDeadlineMs: 100,
+          }),
         RuntimeHostProtocolError,
       );
       assert.equal(candidate.host.state, 'ready');

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import { defineInteractiveRuntimeHostComposition } from '../server/host-composition.js';
 import assert from 'node:assert/strict';
 import { execFile, fork, type ChildProcess } from 'node:child_process';
@@ -42,22 +43,23 @@ import {
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
   RUNTIME_HOST_PROTOCOL_VERSION,
-  RuntimeHostProtocolError,
   type ClientFrame,
   type ClientSurface,
 } from '../protocol/index.js';
 import {
   RuntimeHostKernel,
   RuntimeHostProcessTerminationRequiredError,
-  startInteractiveRuntimeHostCandidate,
-  type InteractiveRuntimeHostCandidateOptions,
-  type InteractiveRuntimeHostCandidateResult,
   type RuntimeHostComposition,
   type RuntimeHostCompositionContext,
   type RuntimeHostCompositionFactory,
-  type RuntimeHostCompositionSource,
   type RuntimeHostKernelOptions,
-} from '../server/index.js';
+} from '../server/host-kernel.js';
+import {
+  startInteractiveRuntimeHostCandidate,
+  type InteractiveRuntimeHostCandidateOptions,
+  type InteractiveRuntimeHostCandidateResult,
+} from '../server/candidate.js';
+import type { RuntimeHostCompositionSource } from '../server/host-composition.js';
 import { createUnavailableDomainOperationHandlers } from '../server/operation-dispatcher.js';
 import { HostConfigurationChangeService } from '../server/configuration-change-service.js';
 import { HostSessionCatalogChangeService } from '../server/session-catalog-change-service.js';
@@ -2059,25 +2061,23 @@ describe('non-serving Runtime Host kernel', () => {
           }),
         RangeError,
       );
-      await assert.rejects(
-        () =>
-          connectRuntimeHost({
-            rootPath: paths.root,
-            surface: 'tui',
-            protocol: CURRENT_PROTOCOL,
-            clientInstanceId: '',
-          }),
+      await assert.rejects(() =>
+        connectRuntimeHost({
+          rootPath: paths.root,
+          surface: 'tui',
+          protocol: CURRENT_PROTOCOL,
+          clientInstanceId: '',
+        }),
         RuntimeHostProtocolError,
       );
-      await assert.rejects(
-        () =>
-          connectOrSpawnRuntimeHost({
-            rootPath: paths.root,
-            surface: 'tui',
-            protocol: CURRENT_PROTOCOL,
-            compositionId: 'Invalid Composition',
-            candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
-          }),
+      await assert.rejects(() =>
+        connectOrSpawnRuntimeHost({
+          rootPath: paths.root,
+          surface: 'tui',
+          protocol: CURRENT_PROTOCOL,
+          compositionId: 'Invalid Composition',
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+        }),
         RuntimeHostProtocolError,
       );
       await assertPathMissing(paths.root);
@@ -2088,17 +2088,16 @@ describe('non-serving Runtime Host kernel', () => {
       });
       assert.equal(candidate.kind, 'winner');
       if (candidate.kind !== 'winner') return;
-      await assert.rejects(
-        () =>
-          connectOrSpawnRuntimeHost({
-            rootPath: paths.root,
-            surface: 'tui',
-            protocol: CURRENT_PROTOCOL,
-            compositionId: KERNEL_COMPOSITION.descriptor.id,
-            candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
-            clientInstanceId: 'x'.repeat(129),
-            electionDeadlineMs: 100,
-          }),
+      await assert.rejects(() =>
+        connectOrSpawnRuntimeHost({
+          rootPath: paths.root,
+          surface: 'tui',
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          clientInstanceId: 'x'.repeat(129),
+          electionDeadlineMs: 100,
+        }),
         RuntimeHostProtocolError,
       );
       assert.equal(candidate.host.state, 'ready');

--- a/packages/runtime-host/src/__tests__/interaction-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/interaction-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { InteractionRecord, StoredInteractionRequest } from '@maka/storage/interaction-store';
@@ -8,7 +9,6 @@ import {
   decodeSessionInteractionProjection,
   HOST_OPERATION_SPECS,
   INTERACTION_MAX_PENDING_PER_SESSION,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 import {
   answerOutcome,

--- a/packages/runtime-host/src/__tests__/memory-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/memory-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
@@ -8,7 +9,6 @@ import {
   MEMORY_ENTRY_PAGE_MAX_ITEMS,
   MEMORY_RESULT_MAX_BYTES,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 
 const revision = `sha256:${'a'.repeat(64)}` as const;

--- a/packages/runtime-host/src/__tests__/oauth-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/oauth-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
@@ -6,7 +7,6 @@ import {
   decodeOAuthPresentationRequest,
   decodeOAuthPresentationResult,
   OAUTH_PRESENTATION_AUTHORIZATION_CODE_MAX_LENGTH,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 
 test('OAuth login protocol binds attempt identity and closes terminal projections', () => {

--- a/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/project-catalog-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
@@ -6,7 +7,6 @@ import {
   decodeProjectCatalogQueryResult,
   HOST_OPERATION_SPECS,
   PROJECT_CATALOG_PAGE_MAX_ITEMS,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 
 const projectPath = process.platform === 'win32' ? 'C:\\workspace' : '/workspace';

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_COUNT } from '@maka/core/attachments';
@@ -25,7 +26,6 @@ import {
   TURN_MESSAGE_CONTENT_MAX_BYTES,
   TURN_MESSAGE_TEXT_MAX_BYTES,
   RUNTIME_POLICY_OPERATION_SPECS,
-  RuntimeHostProtocolError,
 } from '../protocol/index.js';
 import { HOST_BOOTSTRAP_OPERATION_SPECS } from '../protocol/host-status.js';
 import { composeOperationSpecMaps } from '../protocol/operation-spec.js';

--- a/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
@@ -6,7 +7,6 @@ import {
   decodeSessionCatalogItem,
   decodeSessionCatalogQueryResult,
   HOST_OPERATION_SPECS,
-  RuntimeHostProtocolError,
   SESSION_CATALOG_PAGE_MAX_ITEMS,
   type SessionCatalogProjection,
 } from '../protocol/index.js';

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { fork, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
@@ -27,7 +28,6 @@ import {
   encodeProtocolMessage,
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
-  RuntimeHostProtocolError,
   type ClientFrame,
   type SessionCatalogItem,
   type SessionCatalogProjection,

--- a/packages/runtime-host/src/__tests__/session-effects-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-effects-protocol.test.ts
@@ -1,9 +1,9 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
   decodeClientFrame,
   decodeHostFrame,
-  RuntimeHostProtocolError,
   SESSION_EFFECT_OPERATION_SPECS,
   SESSION_RECAP_RAW_MAX_BYTES,
 } from '../protocol/index.js';

--- a/packages/runtime-host/src/__tests__/session-retirement-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-retirement-protocol.test.ts
@@ -1,10 +1,10 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   decodeClientFrame,
   decodeHostFrame,
   HOST_OPERATION_SPECS,
-  RuntimeHostProtocolError,
   type SessionCatalogProjection,
 } from '../protocol/index.js';
 

--- a/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-protocol.test.ts
@@ -1,10 +1,10 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   decodeClientFrame,
   decodeHostFrame,
   HOST_OPERATION_SPECS,
-  RuntimeHostProtocolError,
   type SessionCatalogProjection,
 } from '../protocol/index.js';
 

--- a/packages/runtime-host/src/__tests__/session-transcript-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
@@ -7,7 +8,6 @@ import {
   encodeProtocolMessage,
   HOST_OPERATION_SPECS,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
-  RuntimeHostProtocolError,
   SESSION_TRANSCRIPT_PAGE_MAX_BYTES,
 } from '../protocol/index.js';
 

--- a/packages/runtime-host/src/__tests__/skill-catalog-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -17,7 +18,6 @@ import {
   type SkillCatalogPreviewUpdateResult,
   type SkillCatalogRevision,
 } from '../protocol/index.js';
-import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import { SkillCatalogRepository } from '../server/skill-catalog-repository.js';
 
 const REVISION = `sha256:${'a'.repeat(64)}` as SkillCatalogRevision;

--- a/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
+++ b/packages/runtime-host/src/__tests__/skill-catalog-repository.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
@@ -9,11 +10,7 @@ import {
   buildStarterSkillTemplate,
   createManagedSkillLock,
 } from '@maka/runtime/skills';
-import {
-  decodeHostFrame,
-  isSkillCatalogProjectRootLexicallyAbsolute,
-  RuntimeHostProtocolError,
-} from '../protocol/index.js';
+import { decodeHostFrame, isSkillCatalogProjectRootLexicallyAbsolute } from '../protocol/index.js';
 import type {
   SkillCatalogGovernanceItem,
   SkillCatalogQueryResult,

--- a/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
@@ -18,7 +19,6 @@ import {
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
   RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
-  RuntimeHostProtocolError,
   type HostFrame,
   type OperationInput,
   type OperationOutput,

--- a/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -23,7 +24,6 @@ import {
   PRICING_PAGE_MAX_BYTES,
   PRICING_PAGE_MAX_ITEMS,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
-  RuntimeHostProtocolError,
   USAGE_PAGE_MAX_BYTES,
   USAGE_PAGE_MAX_ITEMS,
   USAGE_PROJECTION_TEXT_MAX_BYTES,

--- a/packages/runtime-host/src/__tests__/wait-for-ready.test.ts
+++ b/packages/runtime-host/src/__tests__/wait-for-ready.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { waitForRuntimeHostReady } from '../client/index.js';
+import { waitForRuntimeHostReady } from '../client/wait-for-ready.js';
 
 test('stops a pending ready probe when its reconnect attempt is cancelled', async () => {
   const started = deferred();

--- a/packages/runtime-host/src/__tests__/websocket-listener.test.ts
+++ b/packages/runtime-host/src/__tests__/websocket-listener.test.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import assert from 'node:assert/strict';
 import { once } from 'node:events';
 import { mkdtemp, rm } from 'node:fs/promises';
@@ -7,11 +8,7 @@ import { join } from 'node:path';
 import { test } from 'node:test';
 import WebSocket from 'ws';
 import { consumeAccessCredentialDeliveryFromControlDirectory } from '../control/access-credential-delivery.js';
-import {
-  encodeProtocolMessage,
-  RUNTIME_HOST_MAX_MESSAGE_BYTES,
-  RuntimeHostProtocolError,
-} from '../protocol/index.js';
+import { encodeProtocolMessage, RUNTIME_HOST_MAX_MESSAGE_BYTES } from '../protocol/index.js';
 import {
   openRuntimeHostAccessAuthority,
   type RuntimeHostAccessAuthority,

--- a/packages/runtime-host/src/adapter/index.ts
+++ b/packages/runtime-host/src/adapter/index.ts
@@ -4,7 +4,6 @@ export {
   isRuntimeHostTerminalTurn,
   foldRuntimeHostAssistantDelta,
   projectRuntimeHostInteractionRequest,
-  type RuntimeHostProjectionUpdate,
   type RuntimeHostSessionProjectionSeed,
   type RuntimeHostTerminalTurn,
 } from './session-projector.js';

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -2,17 +2,9 @@ export {
   connectRuntimeHost,
   connectExistingRuntimeHost,
   connectRemoteRuntimeHost,
-  normalizeRemoteRuntimeHostUrl,
   RuntimeHostOperationError,
   RuntimeHostRequestInterruptedError,
-  type ConnectRuntimeHostInput,
-  type ConnectRuntimeHostResult,
-  type ConnectRemoteRuntimeHostInput,
-  type ConnectRemoteRuntimeHostResult,
   type RuntimeHostConnection,
-  type RuntimeHostRequestDispatch,
-  type RuntimeHostRequestInterruptionReason,
-  type RuntimeHostUnavailableReason,
   type DirectRequestOperationKey,
 } from './connection.js';
 export {
@@ -22,7 +14,6 @@ export {
   createFileRuntimeHostProfileCatalog,
   createRuntimeHostProfileCredentialStore,
   connectRemoteRuntimeHostProfile,
-  decodeRuntimeHostProfileDocument,
   remoteRuntimeHostUnavailableError,
   sameResolvedRuntimeHostProfileTarget,
   type RemoteRuntimeHostProfile,
@@ -30,13 +21,11 @@ export {
   type ResolvedRuntimeHostProfile,
   type RuntimeHostProfile,
   type RuntimeHostProfileCatalog,
-  type RuntimeHostProfileCredentialStore,
   type RuntimeHostProfileDocument,
 } from './host-profile.js';
 export {
   createRuntimeHostReconnectingConnection,
   isRuntimeHostReconnectingConnection,
-  type RuntimeHostReconnectingConnection,
 } from './reconnecting-connection.js';
 export {
   openRuntimeHostSshTunnel,
@@ -51,19 +40,15 @@ export {
   startRuntimeHostReconnectLifecycle,
   type RuntimeHostReconnectBackoff,
   type RuntimeHostReconnectLifecycle,
-  type RuntimeHostReconnectResource,
 } from './reconnect-lifecycle.js';
 export {
   RuntimeHostSubscriptionError,
   type DecodedSessionTranscriptPage,
   type RuntimeHostSessionSubscription,
-  type RuntimeHostSubscriptionFailureReason,
 } from './session-subscription.js';
-export { waitForRuntimeHostReady } from './wait-for-ready.js';
 export {
   RuntimeHostStartupError,
   runtimeHostStartupError,
-  type RuntimeHostStartupFailureReason,
 } from './startup-error.js';
 export {
   RuntimeHostCatalogReadError,
@@ -74,32 +59,18 @@ export {
   readRuntimeHostProjects,
   readRuntimeHostSessions,
   readRuntimeHostSkillCatalog,
-  type RuntimeHostConnectionCatalogEntry,
-  type RuntimeHostConnectionCatalogSnapshot,
-  type RuntimeHostSkillCatalogSnapshot,
 } from './catalog-reader.js';
 export {
   connectOrSpawnRuntimeHost,
-  connectOwnedRuntimeHost,
   type ConnectOrSpawnRuntimeHostInput,
   type ConnectOrSpawnRuntimeHostResult,
-  type ConnectOwnedRuntimeHostResult,
 } from './connect-or-spawn.js';
-export { runHostedExecution, type RunHostedExecutionInput } from './hosted-execution.js';
-export {
-  configureHostedExecutionTarget,
-  type HostedExecutionTargetInput,
-} from './hosted-execution-target.js';
+export { runHostedExecution } from './hosted-execution.js';
 export { type ClientCapabilityProvider } from './client-capability.js';
-export {
-  startRuntimeHostCapabilityProviderService,
-  type RuntimeHostCapabilityProviderService,
-} from './capability-provider-service.js';
+export { startRuntimeHostCapabilityProviderService } from './capability-provider-service.js';
 export { loadOrCreateRuntimeHostClientInstanceId } from './client-instance-identity.js';
 export { consumeAccessCredentialDelivery } from '../control/access-credential-delivery.js';
 export {
   createOAuthPresentationClientProvider,
-  OAUTH_PRESENTATION_SERVICE_ID,
-  OAUTH_PRESENTATION_SERVICE_VERSION,
   type OAuthPresentationBackend,
 } from './oauth-presentation.js';

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -42,7 +42,6 @@ import {
   type ResponseFrame,
 } from './operations.js';
 
-export { RuntimeHostProtocolError } from './errors.js';
 export * from './access-authority.js';
 export * from './agent-graph.js';
 export * from './interaction.js';

--- a/packages/runtime-host/src/server/index.ts
+++ b/packages/runtime-host/src/server/index.ts
@@ -1,68 +1,9 @@
 export {
   RuntimeHostKernel,
-  RuntimeHostProcessTerminationRequiredError,
   type RuntimeHostComposition,
-  type RuntimeHostCompositionContext,
-  type RuntimeHostCompositionFactory,
-  type RuntimeHostKernelOptions,
-  type RuntimeHostLifecycleMode,
-  type RuntimeHostResidency,
 } from './host-kernel.js';
-export {
-  beginRuntimeHostDomainModuleDrain,
-  closeRuntimeHostDomainModules,
-  composeRuntimeHostDomainHandlers,
-  defineInteractiveRuntimeHostComposition,
-  defineRuntimeHostComposition,
-  HOST_RECOVERY_PHASES,
-  INTERACTIVE_HOST_COMPOSITION_DESCRIPTOR,
-  normalizeHostCompositionDescriptor,
-  recoverRuntimeHostDomainModules,
-  type HostCompositionDescriptor,
-  type HostRecoveryPhase,
-  type RuntimeHostDomainModule,
-  type RuntimeHostCompositionSource,
-} from './host-composition.js';
-export {
-  startInteractiveRuntimeHostCandidate,
-  type InteractiveRuntimeHostCandidateOptions,
-  type InteractiveRuntimeHostCandidateResult,
-} from './candidate.js';
+export { defineInteractiveRuntimeHostComposition } from './host-composition.js';
 export { createUnavailableDomainOperationHandlers } from './operation-dispatcher.js';
-export {
-  RuntimeHostRootAlreadyOwnedError,
-  startExecutionRuntimeHostService,
-  type ExecutionRuntimeHostServiceDependencies,
-  type ExecutionRuntimeHostServiceOptions,
-} from './execution-service.js';
-export {
-  runRuntimeHostProcessLifecycle,
-  type RuntimeHostProcessLifecycleOptions,
-} from './process-lifecycle.js';
+export { startExecutionRuntimeHostService } from './execution-service.js';
+export { runRuntimeHostProcessLifecycle } from './process-lifecycle.js';
 export { installRuntimeHostLogCapture } from '../process-diagnostics.js';
-export {
-  createRuntimeHostListenerSet,
-  startRuntimeHostServiceListenerSet,
-  startLocalRuntimeHostListenerSet,
-  type RuntimeHostListenerSet,
-  type RuntimeHostListener,
-  type RuntimeHostListenerConnection,
-  type RuntimeHostListenerKind,
-  type RuntimeHostListenerSetFactory,
-  type RuntimeHostListenerSetFactoryInput,
-} from './listener-set.js';
-export {
-  startRuntimeHostWebSocketListener,
-  type RuntimeHostWebSocketTls,
-  type StartRuntimeHostWebSocketListenerOptions,
-} from './websocket-listener.js';
-export {
-  openRuntimeHostAccessAuthority,
-  type RuntimeHostAccessAuthority,
-} from './access-authority.js';
-export {
-  createRuntimeHostConnectionAuthority,
-  LOCAL_OWNER_CONNECTION_AUTHORITY,
-  type RuntimeHostConnectionAuthority,
-} from './connection-authority.js';
-export type { RuntimeHostMessageTransport } from '../transport/message-transport.js';

--- a/packages/runtime-host/src/server/session-catalog-coordinator.ts
+++ b/packages/runtime-host/src/server/session-catalog-coordinator.ts
@@ -1,3 +1,4 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import { createHash } from 'node:crypto';
 import { isModelExplicitlyUnsupportedForChat } from '@maka/core/model-catalog';
 import { thinkingVariantsForConnection } from '@maka/core/model-thinking';
@@ -37,7 +38,6 @@ import {
   SESSION_CATALOG_RESULT_MAX_BYTES,
   type OperationError,
   type OperationOutcome,
-  RuntimeHostProtocolError,
   type SessionCatalogFilter,
   type SessionCatalogItem,
   type SessionCatalogProjection,

--- a/packages/runtime-host/src/transport/framed-transport.ts
+++ b/packages/runtime-host/src/transport/framed-transport.ts
@@ -1,9 +1,6 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import type { Socket } from 'node:net';
-import {
-  RUNTIME_HOST_MAX_MESSAGE_BYTES,
-  RuntimeHostProtocolError,
-  type EncodedProtocolMessage,
-} from '../protocol/index.js';
+import { RUNTIME_HOST_MAX_MESSAGE_BYTES, type EncodedProtocolMessage } from '../protocol/index.js';
 import { frameLocalIpcProtocolMessage, LocalIpcProtocolFrameDecoder } from './local-ipc-framing.js';
 import type { RuntimeHostMessageTransport } from './message-transport.js';
 

--- a/packages/runtime-host/src/transport/local-ipc-framing.ts
+++ b/packages/runtime-host/src/transport/local-ipc-framing.ts
@@ -1,9 +1,6 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import { TextDecoder } from 'node:util';
-import {
-  RUNTIME_HOST_MAX_MESSAGE_BYTES,
-  RuntimeHostProtocolError,
-  type EncodedProtocolMessage,
-} from '../protocol/index.js';
+import { RUNTIME_HOST_MAX_MESSAGE_BYTES, type EncodedProtocolMessage } from '../protocol/index.js';
 
 export function frameLocalIpcProtocolMessage(message: EncodedProtocolMessage): Buffer {
   return Buffer.concat([message, Buffer.from('\n')]);

--- a/packages/runtime-host/src/transport/websocket-transport.ts
+++ b/packages/runtime-host/src/transport/websocket-transport.ts
@@ -1,10 +1,7 @@
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
 import { TextDecoder } from 'node:util';
 import WebSocket, { type RawData } from 'ws';
-import {
-  RUNTIME_HOST_MAX_MESSAGE_BYTES,
-  RuntimeHostProtocolError,
-  type EncodedProtocolMessage,
-} from '../protocol/index.js';
+import { RUNTIME_HOST_MAX_MESSAGE_BYTES, type EncodedProtocolMessage } from '../protocol/index.js';
 import { RuntimeHostTransportError } from './framed-transport.js';
 import type { RuntimeHostMessageTransport } from './message-transport.js';
 


### PR DESCRIPTION
## Summary

Trim the consumed API surface of the `@maka/runtime-host` server, client, protocol, and adapter barrels. Package-internal consumers of removed exports now import directly from their leaf modules, so runtime behavior is unchanged.

Fixes #3087

## Verification

- `npm --workspace @maka/runtime-host run build` passed.
- `npm --workspace @maka/runtime-host run typecheck` passed.
- Focused runtime-host protocol tests passed: 127/127.
- `npm run build` passed.
- `npm run typecheck` passed.
- `npm run lint` passed.
- `npm run format:check` passed.
- `npx knip --workspace apps/desktop --workspace packages/ui` passed.
- The full runtime-host test command was started and passed its initial suites, then stopped after Windows shell/PTY cases produced known environment-level failures and a prolonged no-output hang. No UI changes are included.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex performed the implementation, test updates for leaf imports, verification, and code review. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No