### PR TITLE
fix(runtime): persist provider failure diagnostics

### DIFF
--- a/apps/desktop/src/main/__tests__/session-inspector-panel-model.test.ts
+++ b/apps/desktop/src/main/__tests__/session-inspector-panel-model.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  SESSION_TRACE_SCHEMA_VERSION,
+  emptyTraceTotals,
+  type SessionTrace,
+} from '@maka/core/session-trace';
+import { deriveInspectorPanelModel } from '../../renderer/session-inspector-panel-model.js';
+
+test('shows one compact diagnostic line for a failed history-compaction call', () => {
+  const trace: SessionTrace = {
+    schemaVersion: SESSION_TRACE_SCHEMA_VERSION,
+    sessionId: 'session-1',
+    turns: [
+      {
+        turnId: 'turn-1',
+        runId: 'run-1',
+        startedAt: 1,
+        endedAt: 10,
+        durationMs: 9,
+        steps: [
+          {
+            kind: 'model_call',
+            id: 'call-compact-1',
+            turnId: 'turn-1',
+            runId: 'run-1',
+            startedAt: 1,
+            endedAt: 10,
+            durationMs: 9,
+            callKind: 'history_compact',
+            historyCompactRoute: 'provider_native',
+            providerId: 'openai-codex',
+            modelId: 'gpt-5.6-luna',
+            step: 0,
+            status: 'failed',
+            attempts: [
+              {
+                attemptId: 'attempt-compact-1',
+                attempt: 0,
+                status: 'failed',
+                startedAt: 1,
+                completedAt: 10,
+                latencyMs: 9,
+                errorClass: 'RequestRejected',
+                httpStatus: 400,
+                providerCode: 'invalid_request_error',
+                providerRequestId: 'req-compact-1',
+                retryable: false,
+                costBasis: 'unpriced',
+                usageBasis: 'missing',
+              },
+            ],
+          },
+        ],
+        totals: {
+          ...emptyTraceTotals(),
+          durationMs: 9,
+          modelAttempts: 1,
+          unpricedAttempts: 1,
+        },
+      },
+    ],
+    totals: {
+      ...emptyTraceTotals(),
+      durationMs: 9,
+      modelAttempts: 1,
+      unpricedAttempts: 1,
+    },
+    coverage: {
+      modelCalls: 'no_known_gap',
+      turnsMissingModelCalls: [],
+      turnsWithFewerModelCallsThanSteps: [],
+      unreadableRecords: 0,
+    },
+  };
+
+  const row = deriveInspectorPanelModel(trace).turns[0]?.steps[0];
+  assert.equal(row?.callKind, 'history_compact');
+  assert.equal(
+    row?.detail,
+    'route=provider_native · error=RequestRejected · HTTP 400 · code=invalid_request_error · request=req-compact-1 · retryable=false',
+  );
+});

--- a/apps/desktop/src/renderer/session-inspector-panel-model.ts
+++ b/apps/desktop/src/renderer/session-inspector-panel-model.ts
@@ -1,4 +1,10 @@
-import { emptyTraceTotals, type SessionTrace, type TraceStep, type TraceTotals } from '@maka/core/session-trace';
+import {
+  emptyTraceTotals,
+  type SessionTrace,
+  type TraceModelCallStep,
+  type TraceStep,
+  type TraceTotals,
+} from '@maka/core/session-trace';
 
 /**
  * View model for the Inspector panel (#1625).
@@ -16,7 +22,7 @@ export interface InspectorStepRow {
    * is the panel's job, in the reader's language, not this file's in English.
    */
   label?: string;
-  /** Free text the trace already carries in words — an error message. */
+  /** Concise supporting detail — a trace error message or bounded provider facts. */
   detail?: string;
   /** Why this call was made, when it was not the turn's own request. */
   callKind?: string;
@@ -96,6 +102,7 @@ function toStepRow(step: TraceStep, attributedToStepId: string | undefined): Ins
     step.kind === 'error';
 
   if (step.kind === 'model_call') {
+    const detail = historyCompactDiagnosticDetail(step);
     return {
       id: step.id,
       kind: step.kind,
@@ -104,6 +111,7 @@ function toStepRow(step: TraceStep, attributedToStepId: string | undefined): Ins
       // nothing; a compaction or a title call beside it is the fact worth a
       // second column.
       ...(step.callKind !== 'main' ? { callKind: step.callKind } : {}),
+      ...(detail !== undefined ? { detail } : {}),
       durationMs: step.durationMs,
       ...(step.attempts.length > 1 ? { retries: step.attempts.length - 1 } : {}),
       failed,
@@ -138,6 +146,21 @@ function toStepRow(step: TraceStep, attributedToStepId: string | undefined): Ins
   return { id: step.id, kind: step.kind, detail: step.message, failed: true };
 }
 
+/** Compact, body-free provider facts for the one auxiliary call that needs diagnosis. */
+function historyCompactDiagnosticDetail(step: TraceModelCallStep): string | undefined {
+  if (step.callKind !== 'history_compact') return undefined;
+  const settled = step.attempts.at(-1);
+  const parts = [
+    step.historyCompactRoute !== undefined ? `route=${step.historyCompactRoute}` : undefined,
+    settled?.errorClass !== undefined ? `error=${settled.errorClass}` : undefined,
+    settled?.httpStatus !== undefined ? `HTTP ${settled.httpStatus}` : undefined,
+    settled?.providerCode !== undefined ? `code=${settled.providerCode}` : undefined,
+    settled?.providerRequestId !== undefined ? `request=${settled.providerRequestId}` : undefined,
+    settled?.retryable !== undefined ? `retryable=${settled.retryable}` : undefined,
+  ].filter((part): part is string => part !== undefined);
+  return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
 function coverageNotice(trace: SessionTrace): InspectorCoverageNotice | undefined {
   const { coverage } = trace;
   if (coverage.modelCalls === 'none' || coverage.modelCalls === 'no_known_gap') return undefined;
@@ -148,4 +171,3 @@ function coverageNotice(trace: SessionTrace): InspectorCoverageNotice | undefine
     unreadableRecords: coverage.unreadableRecords,
   };
 }
-

--- a/apps/desktop/src/renderer/session-inspector-panel.tsx
+++ b/apps/desktop/src/renderer/session-inspector-panel.tsx
@@ -654,12 +654,13 @@ function StepRow(props: { step: InspectorStepRow; copy: InspectorCopy }) {
   // A row names itself with whatever identity it has: a model, a tool, or —
   // for a compaction, an error, a permission prompt with no tool — its kind.
   const label = step.label ?? inspectorStepKindLabel(copy, step.kind);
-  const qualifier =
-    step.callKind !== undefined
-      ? copy.callKind(step.callKind)
-      : step.decision !== undefined
-        ? copy.permissionDecision(step.decision)
-        : step.detail;
+  const qualifier = [
+    step.callKind !== undefined ? copy.callKind(step.callKind) : undefined,
+    step.decision !== undefined ? copy.permissionDecision(step.decision) : undefined,
+    step.detail,
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join(' · ');
   const meta = [
     step.retries !== undefined ? copy.retries(step.retries) : undefined,
     step.durationMs !== undefined ? formatDuration(step.durationMs) : undefined,

--- a/packages/core/src/__tests__/model-call-attempt.test.ts
+++ b/packages/core/src/__tests__/model-call-attempt.test.ts
@@ -2,6 +2,7 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  MODEL_CALL_DIAGNOSTIC_FIELD_MAX_LENGTH,
   MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
   decodeModelCallAttempt,
   groupModelCallAttempts,
@@ -39,6 +40,41 @@ function attempt(overrides: Partial<ModelCallAttempt> = {}): ModelCallAttempt {
 }
 
 describe('ModelCallAttempt codec', () => {
+  test('accepts bounded provider failure diagnostics on history compaction calls', () => {
+    const decoded = decodeModelCallAttempt(
+      attempt({
+        callKind: 'history_compact',
+        historyCompactRoute: 'provider_native',
+        status: 'failed',
+        errorClass: 'RateLimit',
+        httpStatus: 429,
+        providerCode: 'rate_limit_exceeded',
+        providerRequestId: 'req-123',
+        retryable: true,
+      }),
+    );
+
+    assert.equal(decoded.historyCompactRoute, 'provider_native');
+    assert.equal(decoded.httpStatus, 429);
+    assert.equal(decoded.providerRequestId, 'req-123');
+  });
+
+  test('rejects invalid or unbounded provider failure diagnostics', () => {
+    assert.throws(() => decodeModelCallAttempt(attempt({ httpStatus: 99, status: 'failed' })));
+    assert.throws(() =>
+      decodeModelCallAttempt(
+        attempt({
+          status: 'failed',
+          providerCode: 'x'.repeat(MODEL_CALL_DIAGNOSTIC_FIELD_MAX_LENGTH + 1),
+        }),
+      ),
+    );
+    assert.throws(
+      () => decodeModelCallAttempt(attempt({ historyCompactRoute: 'text_summary' })),
+      /non-compaction call carries historyCompactRoute/,
+    );
+  });
+
   test('rejects an unpriced attempt that carries a cost', () => {
     assert.throws(
       () => decodeModelCallAttempt(attempt({ costBasis: 'unpriced', costUsd: 0 })),

--- a/packages/core/src/model-call-attempt.ts
+++ b/packages/core/src/model-call-attempt.ts
@@ -53,6 +53,13 @@ export type ModelCallUsageBasis = (typeof MODEL_CALL_USAGE_BASES)[number];
 export const MODEL_CALL_COST_BASES = ['priced', 'unpriced'] as const;
 export type ModelCallCostBasis = (typeof MODEL_CALL_COST_BASES)[number];
 
+/** How a history-compaction call reduced the covered conversation. */
+export const HISTORY_COMPACT_ROUTES = ['text_summary', 'provider_native'] as const;
+export type HistoryCompactRoute = (typeof HISTORY_COMPACT_ROUTES)[number];
+
+/** Hard bound for provider-supplied diagnostic identifiers stored on an attempt. */
+export const MODEL_CALL_DIAGNOSTIC_FIELD_MAX_LENGTH = 256;
+
 export interface ModelCallAttempt {
   schemaVersion: typeof MODEL_CALL_ATTEMPT_SCHEMA_VERSION;
 
@@ -84,6 +91,8 @@ export interface ModelCallAttempt {
   attempt: number;
 
   callKind: ModelCallKind;
+  /** Present on history-compaction calls when the selected route is known. */
+  historyCompactRoute?: HistoryCompactRoute;
   connectionSlug?: string;
   providerId: string;
   modelId: string;
@@ -99,6 +108,10 @@ export interface ModelCallAttempt {
   status: ModelCallAttemptStatus;
   finishReason?: string;
   errorClass?: string;
+  httpStatus?: number;
+  providerCode?: string;
+  providerRequestId?: string;
+  retryable?: boolean;
 
   usageBasis: ModelCallUsageBasis;
   inputTokens?: number;
@@ -140,11 +153,16 @@ const MODEL_CALL_ATTEMPT_SHAPE = defineObjectShape<ModelCallAttempt>()(
   ],
   [
     'connectionSlug',
+    'historyCompactRoute',
     'contextWindow',
     'captureArtifactId',
     'timeToFirstTokenMs',
     'finishReason',
     'errorClass',
+    'httpStatus',
+    'providerCode',
+    'providerRequestId',
+    'retryable',
     'inputTokens',
     'outputTokens',
     'cacheReadInputTokens',
@@ -180,6 +198,22 @@ function isNonNegativeNumber(value: unknown): value is number {
 
 function isOptionalNonNegativeNumber(value: unknown): boolean {
   return value === undefined || isNonNegativeNumber(value);
+}
+
+function isOptionalDiagnosticString(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (typeof value === 'string' &&
+      value.length > 0 &&
+      value.length <= MODEL_CALL_DIAGNOSTIC_FIELD_MAX_LENGTH)
+  );
+}
+
+function isOptionalHttpStatus(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (isFiniteNumber(value) && Number.isInteger(value) && value >= 100 && value <= 599)
+  );
 }
 
 const PRICING_RATES_SHAPE = defineObjectShape<PricingConfig>()(
@@ -226,6 +260,8 @@ export function decodeModelCallAttempt(value: unknown): ModelCallAttempt {
     isNonNegativeInteger(value.step) &&
     isNonNegativeInteger(value.attempt) &&
     (MODEL_CALL_KINDS as readonly unknown[]).includes(value.callKind) &&
+    (value.historyCompactRoute === undefined ||
+      (HISTORY_COMPACT_ROUTES as readonly unknown[]).includes(value.historyCompactRoute)) &&
     isOptionalString(value.connectionSlug) &&
     isNonEmptyString(value.providerId) &&
     isNonEmptyString(value.modelId) &&
@@ -237,7 +273,11 @@ export function decodeModelCallAttempt(value: unknown): ModelCallAttempt {
     isOptionalNonNegativeNumber(value.timeToFirstTokenMs) &&
     (MODEL_CALL_ATTEMPT_STATUSES as readonly unknown[]).includes(value.status) &&
     isOptionalString(value.finishReason) &&
-    isOptionalString(value.errorClass) &&
+    isOptionalDiagnosticString(value.errorClass) &&
+    isOptionalHttpStatus(value.httpStatus) &&
+    isOptionalDiagnosticString(value.providerCode) &&
+    isOptionalDiagnosticString(value.providerRequestId) &&
+    (value.retryable === undefined || typeof value.retryable === 'boolean') &&
     (MODEL_CALL_USAGE_BASES as readonly unknown[]).includes(value.usageBasis) &&
     TOKEN_FIELDS.every((field) => isOptionalNonNegativeNumber(value[field])) &&
     (MODEL_CALL_COST_BASES as readonly unknown[]).includes(value.costBasis) &&
@@ -250,6 +290,9 @@ export function decodeModelCallAttempt(value: unknown): ModelCallAttempt {
   const completedAt = value.completedAt as number;
   if (completedAt < startedAt) {
     throw new Error('ModelCallAttempt completedAt precedes startedAt');
+  }
+  if (value.historyCompactRoute !== undefined && value.callKind !== 'history_compact') {
+    throw new Error('ModelCallAttempt non-compaction call carries historyCompactRoute');
   }
   // `costBasis` and `costUsd` travel together in both directions. A price we
   // could not resolve must never be published as an amount, and a priced record

--- a/packages/core/src/session-trace.ts
+++ b/packages/core/src/session-trace.ts
@@ -1,8 +1,11 @@
 import {
+  HISTORY_COMPACT_ROUTES,
+  MODEL_CALL_DIAGNOSTIC_FIELD_MAX_LENGTH,
   MODEL_CALL_ATTEMPT_STATUSES,
   MODEL_CALL_COST_BASES,
   MODEL_CALL_KINDS,
   MODEL_CALL_USAGE_BASES,
+  type HistoryCompactRoute,
   type ModelCallAttemptStatus,
   type ModelCallKind,
 } from './model-call-attempt.js';
@@ -54,6 +57,10 @@ export interface TraceModelAttempt {
   timeToFirstTokenMs?: number;
   finishReason?: string;
   errorClass?: string;
+  httpStatus?: number;
+  providerCode?: string;
+  providerRequestId?: string;
+  retryable?: boolean;
   inputTokens?: number;
   outputTokens?: number;
   cacheReadInputTokens?: number;
@@ -92,6 +99,8 @@ export interface TraceModelCallStep {
   endedAt: number;
   durationMs: number;
   callKind: ModelCallKind;
+  /** How a history-compaction call reduced the covered conversation. */
+  historyCompactRoute?: HistoryCompactRoute;
   providerId: string;
   modelId: string;
   connectionSlug?: string;
@@ -322,7 +331,7 @@ const MODEL_CALL_STEP_SHAPE = defineObjectShape<TraceModelCallStep>()(
     'attempts',
     'status',
   ],
-  ['connectionSlug', 'costUsd'],
+  ['connectionSlug', 'historyCompactRoute', 'costUsd'],
 );
 const MODEL_ATTEMPT_SHAPE = defineObjectShape<TraceModelAttempt>()(
   [
@@ -339,6 +348,10 @@ const MODEL_ATTEMPT_SHAPE = defineObjectShape<TraceModelAttempt>()(
     'timeToFirstTokenMs',
     'finishReason',
     'errorClass',
+    'httpStatus',
+    'providerCode',
+    'providerRequestId',
+    'retryable',
     'inputTokens',
     'outputTokens',
     'cacheReadInputTokens',
@@ -476,6 +489,9 @@ function isModelCallStep(value: Record<string, unknown>): boolean {
     ) &&
     [value.startedAt, value.endedAt, value.durationMs].every(isNonnegativeNumber) &&
     MODEL_CALL_KINDS.includes(value.callKind as ModelCallKind) &&
+    (value.historyCompactRoute === undefined ||
+      (value.callKind === 'history_compact' &&
+        HISTORY_COMPACT_ROUTES.includes(value.historyCompactRoute as HistoryCompactRoute))) &&
     isOptionalString(value.connectionSlug) &&
     isNonnegativeInteger(value.step) &&
     Array.isArray(value.attempts) &&
@@ -504,8 +520,28 @@ function isModelAttempt(value: unknown): value is TraceModelAttempt {
     ].every(isOptionalNonnegativeNumber) &&
     isOptionalString(value.finishReason) &&
     isOptionalString(value.errorClass) &&
+    isOptionalHttpStatus(value.httpStatus) &&
+    isOptionalDiagnosticString(value.providerCode) &&
+    isOptionalDiagnosticString(value.providerRequestId) &&
+    (value.retryable === undefined || typeof value.retryable === 'boolean') &&
     MODEL_CALL_COST_BASES.includes(value.costBasis as TraceModelAttempt['costBasis']) &&
     MODEL_CALL_USAGE_BASES.includes(value.usageBasis as TraceModelAttempt['usageBasis'])
+  );
+}
+
+function isOptionalHttpStatus(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (Number.isInteger(value) && (value as number) >= 100 && (value as number) <= 599)
+  );
+}
+
+function isOptionalDiagnosticString(value: unknown): boolean {
+  return (
+    value === undefined ||
+    (typeof value === 'string' &&
+      value.length > 0 &&
+      value.length <= MODEL_CALL_DIAGNOSTIC_FIELD_MAX_LENGTH)
   );
 }
 

--- a/packages/runtime-host/src/__tests__/execution-inspect-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-inspect-coordinator.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { AgentRunHeader, EmittedAgentRunEvent } from '@maka/core/agent-run';
+import { MODEL_CALL_ATTEMPT_SCHEMA_VERSION } from '@maka/core/model-call-attempt';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
@@ -14,6 +15,77 @@ import {
 import { HostExecutionInspectCoordinator } from '../server/execution-inspect-coordinator.js';
 
 describe('HostExecutionInspectCoordinator', () => {
+  test('projects persisted history-compaction failure facts into the Session trace', async () => {
+    await withCoordinator(async ({ stores, coordinator }) => {
+      const session = await stores.sessionStore.create(sessionInput('Compaction diagnostics'));
+      const runId = 'compact-run';
+      const turnId = `turn-${runId}`;
+      await stores.agentRunStore.createRun(runHeader(session.id, runId, 1));
+      await stores.agentRunStore.appendEvent(session.id, runId, {
+        type: 'model_call_attempt_recorded',
+        id: 'attempt-compact-1',
+        sessionId: session.id,
+        runId,
+        turnId,
+        ts: 10,
+        data: {
+          schemaVersion: MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
+          logicalCallId: 'call-compact-1',
+          attemptId: 'attempt-compact-1',
+          traceId: 'trace-compact-1',
+          sessionId: session.id,
+          runId,
+          turnId,
+          step: 0,
+          attempt: 0,
+          callKind: 'history_compact',
+          historyCompactRoute: 'provider_native',
+          connectionSlug: 'codex-subscription',
+          providerId: 'openai-codex',
+          modelId: 'gpt-5.6-luna',
+          startedAt: 1,
+          completedAt: 10,
+          latencyMs: 9,
+          status: 'failed',
+          errorClass: 'RequestRejected',
+          httpStatus: 400,
+          providerCode: 'invalid_request_error',
+          providerRequestId: 'req-compact-1',
+          retryable: false,
+          usageBasis: 'missing',
+          costBasis: 'unpriced',
+        },
+      });
+
+      const result = await coordinator.handlers['execution.inspect.query'](
+        { kind: 'session_trace_start', sessionId: session.id },
+        connectionContext(),
+      );
+
+      assert.equal(result.ok, true);
+      if (!result.ok || result.result.kind !== 'session_trace_page') return;
+      const step = result.result.turns[0]?.steps[0];
+      assert.equal(step?.kind, 'model_call');
+      if (step?.kind !== 'model_call') return;
+      assert.equal(step.historyCompactRoute, 'provider_native');
+      assert.deepEqual(step.attempts[0], {
+        attemptId: 'attempt-compact-1',
+        attempt: 0,
+        status: 'failed',
+        startedAt: 1,
+        completedAt: 10,
+        latencyMs: 9,
+        errorClass: 'RequestRejected',
+        httpStatus: 400,
+        providerCode: 'invalid_request_error',
+        providerRequestId: 'req-compact-1',
+        retryable: false,
+        costBasis: 'unpriced',
+        usageBasis: 'missing',
+      });
+    });
+  });
+
   test('resolves duplicate AgentRun identities and returns canonical evidence documents', async () => {
     await withCoordinator(async ({ stores, coordinator }) => {
       const first = await stores.sessionStore.create(sessionInput('First'));

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -16,7 +16,7 @@ import {
 import { createWorkspaceWritePermissionProfile } from '@maka/core/permission-profile';
 import { decodeRunCompositionSnapshot } from '@maka/core/run-composition';
 import { decodeCanonicalToolResultContent } from '@maka/core/tool-result-record-schema';
-import { type ModelCallKind } from '@maka/core/model-call-attempt';
+import { type ModelCallAttempt, type ModelCallKind } from '@maka/core/model-call-attempt';
 import { type RuntimeEvent } from '@maka/core/runtime-event';
 import { createDefaultRuntimePolicy } from '@maka/core/runtime-policy';
 import type { PlanSessionState, PlanStore } from '@maka/core/plan';
@@ -256,6 +256,127 @@ test('provider dispatch fails closed when the Run Composition commit fails', asy
   } finally {
     await backend?.dispose();
     await provider.close();
+  }
+});
+
+test('Codex OAuth history compaction uses the provider-native route and preserves failure facts', async () => {
+  const modelId = 'gpt-5.6-sol';
+  const requests: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const attempts: ModelCallAttempt[] = [];
+  const oauthTokens: OAuthSubscriptionTokens = {
+    access_token: codexAccessToken('compact-account'),
+    refresh_token: 'compact-refresh-token',
+    expires_at: Date.now() + 60_000,
+  };
+  const oauthCredentials = {
+    bind: () => ({
+      providerType: 'openai-codex' as const,
+      connectionSlug: 'backend-creation-connection',
+      resolve: async () => oauthTokens,
+    }),
+  } as unknown as HostOAuthExecutionAuthority;
+  const backend = await createHostAiSdkBackend(
+    backendCreationFixture({
+      abortSignal: new AbortController().signal,
+      modelId,
+      oauthCredentials,
+      resolveExecutionConnection: async () => ({
+        kind: 'ready',
+        connection: {
+          slug: 'backend-creation-connection',
+          providerType: 'openai-codex',
+          enabledModelIds: [modelId],
+          models: [
+            {
+              id: modelId,
+              capabilities: { chat: true, functionCalling: true },
+              contextWindow: 32_768,
+              maxOutputTokens: 1_024,
+            },
+          ],
+        },
+        networkProxy: { enabled: false },
+        secretMaterial: { connection: { secret: 'oauth-material' } },
+      }),
+      readPricing: async () => ({ revision: 0, overrides: [] }),
+      recordHistoryCompactCheckpoint: async () => undefined,
+      recordModelCallAttempt: async ({ attempt }) => {
+        attempts.push(attempt);
+      },
+      createFetchTransport: () => ({
+        fetch: async (url, init) => {
+          requests.push({
+            url: String(url),
+            body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+          });
+          return Response.json(
+            {
+              error: {
+                message: 'request rejected without echoing this body',
+                code: 'invalid_request_error',
+              },
+            },
+            {
+              status: 400,
+              headers: { 'x-request-id': 'req-codex-compact' },
+            },
+          );
+        },
+        close: async () => undefined,
+      }),
+    }),
+  );
+
+  try {
+    const runtimeContext: RuntimeEvent[] = [
+      compactRuntimeTextEvent(
+        'compact-old-user',
+        'turn-old-user',
+        'user',
+        'user',
+        'a'.repeat(8_000),
+      ),
+      compactRuntimeTextEvent(
+        'compact-old-model',
+        'turn-old-model',
+        'model',
+        'agent',
+        'b'.repeat(8_000),
+      ),
+      compactRuntimeTextEvent(
+        'compact-recent-user',
+        'turn-recent-user',
+        'user',
+        'user',
+        'recent context',
+      ),
+    ];
+    const result = await backend.compactHistory({
+      turnId: 'turn-compact',
+      runId: 'run-compact',
+      runtimeContext,
+      minRecentTurns: 1,
+    });
+
+    assert.equal(requests.length, 1, JSON.stringify(result));
+    assert.match(requests[0]!.url, /\/codex\/responses$/);
+    const requestText = JSON.stringify(requests[0]!.body);
+    assert.match(requestText, /"type":"compaction_trigger"/);
+    assert.doesNotMatch(requestText, /context summarization assistant/i);
+    assert.equal(result.contextBudget?.historyCompactWriteFailures, 1);
+    assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'failedOpen');
+    assert.equal(attempts.length, 1);
+    assert.equal(attempts[0]?.callKind, 'history_compact');
+    assert.equal(attempts[0]?.providerId, 'openai-codex');
+    assert.equal(attempts[0]?.historyCompactRoute, 'provider_native');
+    assert.equal(attempts[0]?.status, 'failed');
+    assert.equal(attempts[0]?.errorClass, 'RequestRejected');
+    assert.equal(attempts[0]?.httpStatus, 400);
+    assert.equal(attempts[0]?.providerCode, 'invalid_request_error');
+    assert.equal(attempts[0]?.providerRequestId, 'req-codex-compact');
+    assert.equal(attempts[0]?.retryable, false);
+  } finally {
+    await backend.dispose();
   }
 });
 
@@ -2786,6 +2907,8 @@ function backendCreationFixture(input: {
   recordRunTrace?: (event: RunTraceEvent) => unknown;
   runtimeCommitSink?: HostAiSdkBackendInput['runtimeCommitSink'];
   recordRunComposition?: BackendFactoryContext['recordRunComposition'];
+  recordHistoryCompactCheckpoint?: BackendFactoryContext['recordHistoryCompactCheckpoint'];
+  recordModelCallAttempt?: BackendFactoryContext['recordModelCallAttempt'];
   createFetchTransport?: HostAiSdkBackendInput['createFetchTransport'];
   createRunComposer?: HostAiSdkBackendInput['createRunComposer'];
 }): HostAiSdkBackendInput {
@@ -2844,6 +2967,12 @@ function backendCreationFixture(input: {
         : {}),
       ...(input.recordRunTrace ? { recordRunTrace: input.recordRunTrace } : {}),
       ...(input.recordRunComposition ? { recordRunComposition: input.recordRunComposition } : {}),
+      ...(input.recordHistoryCompactCheckpoint
+        ? { recordHistoryCompactCheckpoint: input.recordHistoryCompactCheckpoint }
+        : {}),
+      ...(input.recordModelCallAttempt
+        ? { recordModelCallAttempt: input.recordModelCallAttempt }
+        : {}),
       store: {
         appendMessage: async () => undefined,
         readExecutionBoundary: async () => input.executionBoundary,
@@ -2869,6 +2998,11 @@ function backendCreationFixture(input: {
       telemetry: {
         recordLlmCall: async () => undefined,
         recordToolInvocation: async () => undefined,
+      },
+      modelCalls: {
+        markRunPendingReprojection: async () => undefined,
+        recordModelCallAttempt: async () => undefined,
+        clearPendingReprojection: async () => undefined,
       },
     },
     requestDrain: () => undefined,
@@ -2910,6 +3044,27 @@ function readyExecutionConnection(
         ? { requestHeaders: { secret: JSON.stringify(customization.requestHeaders) } }
         : {}),
     },
+  };
+}
+
+function compactRuntimeTextEvent(
+  id: string,
+  turnId: string,
+  role: 'user' | 'model',
+  author: 'user' | 'agent',
+  text: string,
+): RuntimeEvent {
+  return {
+    id,
+    invocationId: 'compact-invocation',
+    runId: 'compact-source-run',
+    sessionId: 'backend-creation-session',
+    turnId,
+    ts: 1,
+    partial: false,
+    role,
+    author,
+    content: { kind: 'text', text },
   };
 }
 

--- a/packages/runtime-host/src/server/execution-model-composition.ts
+++ b/packages/runtime-host/src/server/execution-model-composition.ts
@@ -177,6 +177,8 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
           resolveModel: resolveHistoryCompactModel,
           providerOptions,
         });
+  const historyCompactRoute =
+    target.connection.providerType === 'openai-codex' ? 'provider_native' : 'text_summary';
   let telemetryDrainRequested = false;
   const persistTelemetry = async (operation: () => Promise<void>): Promise<void> => {
     try {
@@ -382,6 +384,7 @@ export async function createHostAiSdkBackend(input: HostAiSdkBackendInput): Prom
           : {}),
         loadHistoryCompactCheckpoint: input.context.loadHistoryCompactCheckpoint,
         summarizeHistoryCompact,
+        historyCompactRoute,
         recordHistoryCompactCheckpoint: input.context.recordHistoryCompactCheckpoint,
         loadTurnRuntimeEvents: input.context.loadTurnRuntimeEvents,
         allowMidTurnHistoryCompaction: input.context.allowMidTurnHistoryCompaction,

--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -6,11 +6,86 @@ import { z } from 'zod/v4';
 
 import {
   classifyError,
+  providerFailureDiagnostic,
   providerFailureSummary,
   providerRetryMetadata,
 } from '../provider-error-classification.js';
 
 describe('Provider error classification', () => {
+  test('projects only bounded allowlisted facts into durable diagnostics', () => {
+    const diagnostic = providerFailureDiagnostic(
+      Object.assign(new Error('must not persist sk-secret-or-prompt'), {
+        name: 'AI_APICallError',
+        statusCode: 429,
+        responseHeaders: {
+          'x-request-id': 'req-123',
+          authorization: 'Bearer secret',
+        },
+        data: {
+          error: {
+            code: 'rate_limit_exceeded',
+            message: 'private provider payload',
+          },
+          prompt: 'private customer text',
+        },
+        requestBodyValues: { input: 'private request body' },
+      }),
+    );
+
+    assert.deepEqual(diagnostic, {
+      errorClass: 'RateLimit',
+      httpStatus: 429,
+      providerCode: 'rate_limit_exceeded',
+      providerRequestId: 'req-123',
+      retryable: true,
+    });
+    const serialized = JSON.stringify(diagnostic);
+    assert.doesNotMatch(serialized, /secret|private|authorization|request body/i);
+  });
+
+  test('recovers structured Codex HTTP facts through an SDK wrapper and truncates identifiers', () => {
+    const cause = Object.assign(new Error('Codex OAuth request failed'), {
+      name: 'OpenAiCodexHttpError',
+      statusCode: 400,
+      data: { error: { code: 'x'.repeat(1_024) } },
+      responseHeaders: { 'x-request-id': 'r'.repeat(1_024) },
+    });
+    const diagnostic = providerFailureDiagnostic(
+      Object.assign(new Error('Cannot connect to API'), {
+        name: 'AI_APICallError',
+        code: 'FETCH_FAILED',
+        cause,
+      }),
+    );
+
+    assert.equal(diagnostic.errorClass, 'RequestRejected');
+    assert.equal(diagnostic.httpStatus, 400);
+    assert.ok((diagnostic.providerCode?.length ?? 0) <= 256);
+    assert.ok((diagnostic.providerRequestId?.length ?? 0) <= 256);
+    assert.equal(diagnostic.retryable, false);
+  });
+
+  test('durable diagnostics distinguish the provider failure classes used by fail-open handling', () => {
+    const cases: Array<[unknown, string]> = [
+      [Object.assign(new Error('bad request'), { statusCode: 400 }), 'RequestRejected'],
+      [Object.assign(new Error('slow down'), { statusCode: 429 }), 'RateLimit'],
+      [Object.assign(new Error('upstream failed'), { statusCode: 503 }), 'ProviderUnavailable'],
+      [new DOMException('request timed out', 'TimeoutError'), 'Timeout'],
+      [new TypeError('fetch failed'), 'Network'],
+      [
+        Object.assign(new Error('input rejected'), {
+          statusCode: 400,
+          data: { error: { code: 'context_length_exceeded' } },
+        }),
+        'ContextLength',
+      ],
+    ];
+
+    for (const [error, expected] of cases) {
+      assert.equal(providerFailureDiagnostic(error).errorClass, expected);
+    }
+  });
+
   test('extracts allowlisted fields from JSON string failures without copying the payload', () => {
     const summary = providerFailureSummary(
       JSON.stringify({

--- a/packages/runtime/src/__tests__/provider-request-telemetry.test.ts
+++ b/packages/runtime/src/__tests__/provider-request-telemetry.test.ts
@@ -916,6 +916,8 @@ describe('canonical model-call accounting', () => {
     /** Models a deployment with request capture switched off. */
     withoutCapture?: boolean;
     recordAttempt?: (attempt: telemetry.ProviderRequestAttemptRecord) => void;
+    callKind?: ModelCallAttempt['callKind'];
+    historyCompactRoute?: ModelCallAttempt['historyCompactRoute'];
   }): telemetry.ProviderRequestTracker {
     let n = 0;
     return new telemetry.ProviderRequestTracker({
@@ -930,7 +932,10 @@ describe('canonical model-call accounting', () => {
       accounting: {
         sessionId: 'session-1',
         resolveRunId: overrides.resolveRunId ?? (() => 'run-1'),
-        callKind: 'main',
+        callKind: overrides.callKind ?? 'main',
+        ...(overrides.historyCompactRoute
+          ? { historyCompactRoute: overrides.historyCompactRoute }
+          : {}),
         record: overrides.record,
         ...(overrides.resolveCost ? { resolveCost: overrides.resolveCost } : {}),
         ...(overrides.assertReady ? { assertReady: overrides.assertReady } : {}),
@@ -967,6 +972,58 @@ describe('canonical model-call accounting', () => {
     assert.equal(attempt.pricingRevision, 4);
     // Retries count from zero on the canonical record.
     assert.equal(attempt.attempt, 0);
+  });
+
+  test('persists a structured failure fingerprint and the selected compaction route', async () => {
+    const recorded: ModelCallAttempt[] = [];
+    const diagnosticAttempts: telemetry.ProviderRequestAttemptRecord[] = [];
+    const tracker = accountingTracker({
+      callKind: 'history_compact',
+      historyCompactRoute: 'provider_native',
+      record: ({ attempt }) => {
+        recorded.push(attempt);
+      },
+      recordAttempt: (attempt) => {
+        diagnosticAttempts.push(attempt);
+      },
+    });
+    const providerError = Object.assign(new Error('provider payload must not persist'), {
+      name: 'AI_APICallError',
+      statusCode: 429,
+      data: {
+        error: { code: 'rate_limit_exceeded', message: 'private response body' },
+      },
+      responseHeaders: { 'x-request-id': 'req-compact-1' },
+      requestBodyValues: { input: 'private request body' },
+    });
+
+    await assert.rejects(
+      tracker.trackGenerate({
+        providerId: 'openai.responses',
+        modelId: 'gpt-codex-test',
+        params: preparedParams('private prompt'),
+        doGenerate: async () => {
+          throw providerError;
+        },
+      }),
+      (error) => error === providerError,
+    );
+
+    const attempt = decodeModelCallAttempt(recorded[0]);
+    assert.equal(attempt.historyCompactRoute, 'provider_native');
+    assert.equal(attempt.errorClass, 'RateLimit');
+    assert.equal(attempt.httpStatus, 429);
+    assert.equal(attempt.providerCode, 'rate_limit_exceeded');
+    assert.equal(attempt.providerRequestId, 'req-compact-1');
+    assert.equal(attempt.retryable, true);
+    assert.deepEqual(diagnosticAttempts[0]?.failure, {
+      errorClass: 'RateLimit',
+      httpStatus: 429,
+      providerCode: 'rate_limit_exceeded',
+      providerRequestId: 'req-compact-1',
+      retryable: true,
+    });
+    assert.doesNotMatch(JSON.stringify(attempt), /private|prompt|response body/i);
   });
 
   test('a call the provider reported no usage for records usageBasis missing', async () => {

--- a/packages/runtime/src/__tests__/session-trace-projection.test.ts
+++ b/packages/runtime/src/__tests__/session-trace-projection.test.ts
@@ -10,6 +10,7 @@ import {
   type ModelCallAttempt,
 } from '@maka/core/model-call-attempt';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { isSessionTrace } from '@maka/core/session-trace';
 import { projectSessionTrace } from '../session-trace-projection.js';
 
 function attempt(overrides: Partial<ModelCallAttempt> = {}): ModelCallAttempt {
@@ -55,6 +56,51 @@ function event(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
 }
 
 describe('session trace projection', () => {
+  test('preserves durable history-compaction route and provider failure facts', () => {
+    const trace = projectSessionTrace({
+      sessionId: 'session-1',
+      runtimeEvents: [],
+      modelCallAttempts: [
+        attempt({
+          callKind: 'history_compact',
+          historyCompactRoute: 'provider_native',
+          status: 'failed',
+          usageBasis: 'missing',
+          inputTokens: undefined,
+          outputTokens: undefined,
+          costBasis: 'unpriced',
+          costUsd: undefined,
+          errorClass: 'RequestRejected',
+          httpStatus: 400,
+          providerCode: 'invalid_request_error',
+          providerRequestId: 'req-compact-1',
+          retryable: false,
+        }),
+      ],
+    });
+
+    const step = trace.turns[0]?.steps[0];
+    assert.equal(step?.kind, 'model_call');
+    if (step?.kind !== 'model_call') return;
+    assert.equal(step.historyCompactRoute, 'provider_native');
+    assert.deepEqual(step.attempts[0], {
+      attemptId: 'attempt-1',
+      attempt: 0,
+      status: 'failed',
+      startedAt: 1_000,
+      completedAt: 1_500,
+      latencyMs: 500,
+      errorClass: 'RequestRejected',
+      httpStatus: 400,
+      providerCode: 'invalid_request_error',
+      providerRequestId: 'req-compact-1',
+      retryable: false,
+      costBasis: 'unpriced',
+      usageBasis: 'missing',
+    });
+    assert.equal(isSessionTrace(trace), true, 'the Host protocol accepts the projected trace');
+  });
+
   test('a session of entirely unpriced calls totals to no price, not to zero', () => {
     const trace = projectSessionTrace({
       sessionId: 'session-1',

--- a/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
+++ b/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
@@ -216,7 +216,10 @@ describe('subscription model fetch', () => {
       modelId: 'gpt-5.6-sol',
       fetchFn: async () => {
         attempts += 1;
-        return Response.json({ error: { message: 'account is not authorized' } }, { status: 403 });
+        return Response.json(
+          { error: { message: 'account is not authorized', code: 'account_not_authorized' } },
+          { status: 403, headers: { 'x-request-id': 'req-codex-403' } },
+        );
       },
     });
 
@@ -226,7 +229,18 @@ describe('subscription model fetch', () => {
         method: 'POST',
         body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
       }),
-      /Codex OAuth request failed: HTTP 403/,
+      (error) => {
+        assert.ok(error instanceof Error);
+        assert.match(error.message, /Codex OAuth request failed: HTTP 403/);
+        assert.equal((error as { statusCode?: unknown }).statusCode, 403);
+        assert.deepEqual((error as { data?: unknown }).data, {
+          error: { code: 'account_not_authorized' },
+        });
+        assert.deepEqual((error as { responseHeaders?: unknown }).responseHeaders, {
+          'x-request-id': 'req-codex-403',
+        });
+        return true;
+      },
     );
     assert.equal(attempts, 1);
   });

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -3315,6 +3315,7 @@ export class AiSdkBackend implements AgentBackend {
     turnId: string;
     callKind: ModelCallKind;
     modelId: string;
+    historyCompactRoute?: ModelCallAttempt['historyCompactRoute'];
     /**
      * Stated by every caller, never defaulted: an unattributed provider request
      * is silently dropped by usage accounting, so the compiler has to be the
@@ -3326,6 +3327,7 @@ export class AiSdkBackend implements AgentBackend {
     const accounting = this.modelCallAccounting(input.callKind, {
       modelId: input.modelId,
       ...(input.runId ? { runId: input.runId } : {}),
+      ...(input.historyCompactRoute ? { historyCompactRoute: input.historyCompactRoute } : {}),
     });
     const runId = input.runId;
     const beforeRunProviderDispatch = this.input.beforeRunProviderDispatch;
@@ -3369,6 +3371,7 @@ export class AiSdkBackend implements AgentBackend {
       runId?: string;
       /** The model this call actually runs against; priced as that model. */
       modelId?: string;
+      historyCompactRoute?: ModelCallAttempt['historyCompactRoute'];
     },
   ): ModelCallAccountingInput | undefined {
     const record = this.input.recordModelCallAttempt;
@@ -3380,6 +3383,9 @@ export class AiSdkBackend implements AgentBackend {
       connectionSlug: this.input.connection.slug,
       providerId: this.input.connection.providerType,
       callKind,
+      ...(identity?.historyCompactRoute
+        ? { historyCompactRoute: identity.historyCompactRoute }
+        : {}),
       record,
       resolveCost: (usage: ProviderRequestUsage) => this.resolveModelCallCost(usage, modelId),
       ...(this.input.assertModelCallAccountingReady

--- a/packages/runtime/src/ai-sdk-compaction-contract.ts
+++ b/packages/runtime/src/ai-sdk-compaction-contract.ts
@@ -1,4 +1,5 @@
 import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
+import type { HistoryCompactRoute } from '@maka/core/model-call-attempt';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 
 import type { ProviderRequestTracker } from './provider-request-telemetry.js';
@@ -177,6 +178,8 @@ export interface AiSdkCompactionCapabilities {
   loadHistoryCompactCheckpoint?: HistoryCompactCheckpointLoader;
   /** Produces a checkpoint value from prior state plus newly evicted RuntimeEvents. */
   summarizeHistoryCompact?: HistoryCompactSummarizer;
+  /** Actual route used by the configured history compactor, for durable diagnostics. */
+  historyCompactRoute?: HistoryCompactRoute;
   /** Best-effort durable recorder for accepted checkpoints. */
   recordHistoryCompactCheckpoint?: HistoryCompactCheckpointRecorder;
   /**

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -85,7 +85,7 @@ import {
   type RuntimeEventModelReplayPlan,
 } from './model-history.js';
 import { toolSchemaCharsForDiagnostics } from './request-shape.js';
-import type { ModelCallKind } from '@maka/core/model-call-attempt';
+import type { ModelCallAttempt, ModelCallKind } from '@maka/core/model-call-attempt';
 import type { ProviderRequestTracker } from './provider-request-telemetry.js';
 import {
   estimateNextRequestTokens,
@@ -151,6 +151,7 @@ export interface AiSdkCompactionDeps {
     callKind: ModelCallKind;
     modelId: string;
     runId: string | undefined;
+    historyCompactRoute?: ModelCallAttempt['historyCompactRoute'];
   }) => ProviderRequestTracker | undefined;
   /**
    * Materialize a replay plan. The image budget belongs to the turn whose
@@ -179,6 +180,7 @@ export class AiSdkCompaction {
     callKind: ModelCallKind;
     modelId: string;
     runId: string | undefined;
+    historyCompactRoute?: ModelCallAttempt['historyCompactRoute'];
   }) => ProviderRequestTracker | undefined;
   private readonly materializeRuntimeReplayPlan: (
     plan: RuntimeEventModelReplayPlan,
@@ -467,6 +469,9 @@ export class AiSdkCompaction {
       callKind: 'history_compact',
       modelId: this.input.modelId,
       runId: input.runId,
+      ...(this.input.historyCompactRoute
+        ? { historyCompactRoute: this.input.historyCompactRoute }
+        : {}),
     });
     const foldedIds = new Set(input.draftBlock.coverage.runtimeEventIds);
     const foldedRuntimeEvents = input.priorRuntimeContext.filter((event) =>
@@ -1579,6 +1584,9 @@ export class AiSdkCompaction {
       callKind: 'history_compact',
       modelId: this.input.modelId,
       runId: input.origin.runId,
+      ...(this.input.historyCompactRoute
+        ? { historyCompactRoute: this.input.historyCompactRoute }
+        : {}),
     });
     const recorder = this.input.recordHistoryCompactCheckpoint!;
     const loadTurnRuntimeEvents = this.input.loadTurnRuntimeEvents!;

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -48,6 +48,15 @@ export interface ProviderRetryMetadata {
   retryAfterMs?: number;
 }
 
+/** Bounded, allowlisted provider failure facts safe for durable telemetry. */
+export interface ProviderFailureDiagnostic {
+  errorClass: string;
+  httpStatus?: number;
+  providerCode?: string;
+  providerRequestId?: string;
+  retryable: boolean;
+}
+
 interface ProviderFailureSummary {
   message: string;
   code?: string;
@@ -262,6 +271,88 @@ export function providerFailureSummary(error: unknown): ProviderFailureSummary |
     message: truncateUtf8(summary, PROVIDER_FAILURE_SUMMARY_MAX_BYTES, '…'),
     ...(code || statusCode ? { code: code ?? statusCode } : {}),
   };
+}
+
+const DURABLE_PROVIDER_ERROR_CLASSES: ReadonlySet<string> = new Set([
+  'Abort',
+  'Auth',
+  'ContextLength',
+  'Network',
+  'ProviderBilling',
+  'ProviderUnavailable',
+  'RateLimit',
+  'Timeout',
+]);
+
+/**
+ * Projects provider errors into a small durable fingerprint. Unlike the
+ * presentation summary, this intentionally excludes provider messages and
+ * response bodies: even redacted free text can echo prompts or credentials.
+ */
+export function providerFailureDiagnostic(error: unknown): ProviderFailureDiagnostic {
+  const facts = providerFailureDiagnosticFacts(error);
+  if (!facts) return { errorClass: 'Other', retryable: false };
+  const sources = facts.summarySources;
+  const rawStatus =
+    facts.evidence.statusCode || firstProviderField(sources, ['statusCode', 'status']);
+  const numericStatus = Number(rawStatus);
+  const httpStatus =
+    Number.isInteger(numericStatus) && numericStatus >= 100 && numericStatus <= 599
+      ? numericStatus
+      : undefined;
+  const classified = classifyProviderFacts(facts);
+  const errorClass = durableProviderErrorClass(classified, httpStatus);
+  const providerCode =
+    firstProviderField(sources, ['code']) ?? firstProviderField(sources, ['type']);
+  const providerRequestId =
+    firstProviderField(sources, ['requestId', 'request_id']) ??
+    boundedProviderField(facts.responseHeaders?.['x-request-id']);
+  return {
+    errorClass,
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+    ...(providerCode !== undefined ? { providerCode } : {}),
+    ...(providerRequestId !== undefined ? { providerRequestId } : {}),
+    retryable: providerRetryMetadata(facts.target).retryable,
+  };
+}
+
+function durableProviderErrorClass(classified: string, httpStatus: number | undefined): string {
+  // Structured context-overflow evidence can legitimately arrive behind a
+  // generic 4xx/5xx proxy response and remains stronger than the wrapper code.
+  if (classified === 'ContextLength') return classified;
+  if (httpStatus === 401 || httpStatus === 403) return 'Auth';
+  if (httpStatus === 402) return 'ProviderBilling';
+  if (httpStatus === 408) return 'Timeout';
+  if (httpStatus === 413) return 'ContextLength';
+  if (httpStatus === 429) return 'RateLimit';
+  if (httpStatus !== undefined && httpStatus >= 400 && httpStatus <= 499) {
+    return 'RequestRejected';
+  }
+  if (httpStatus !== undefined && httpStatus >= 500 && httpStatus <= 599) {
+    return 'ProviderUnavailable';
+  }
+  return DURABLE_PROVIDER_ERROR_CLASSES.has(classified) ? classified : 'Other';
+}
+
+function providerFailureDiagnosticFacts(error: unknown): ProviderErrorFacts | undefined {
+  let current = providerErrorTarget(error);
+  let fallback: ProviderErrorFacts | undefined;
+  let codedFallback: ProviderErrorFacts | undefined;
+  const seen = new Set<unknown>();
+  for (let depth = 0; depth < 4 && current !== undefined && !seen.has(current); depth += 1) {
+    seen.add(current);
+    const facts = normalizeProviderError(current);
+    fallback ??= facts;
+    if (facts && (facts.evidence.statusCode || facts.evidence.structuredCodes.length > 0)) {
+      return facts;
+    }
+    if (facts?.evidence.code) codedFallback ??= facts;
+    current =
+      current && typeof current === 'object'
+        ? safeField(current as Record<string, unknown>, 'cause')
+        : undefined;
+  }
+  return codedFallback ?? fallback;
 }
 
 interface ProviderFailureSources {

--- a/packages/runtime/src/provider-request-telemetry.ts
+++ b/packages/runtime/src/provider-request-telemetry.ts
@@ -11,6 +11,10 @@ import {
   type PreparedRequestSegment,
 } from './request-shape.js';
 import { rawFinishReasonString } from './model-protocol.js';
+import {
+  providerFailureDiagnostic,
+  type ProviderFailureDiagnostic,
+} from './provider-error-classification.js';
 import { latestContextProjectionInput } from './latest-context-snapshot.js';
 import type { ContextDiagnosticsCompaction } from './context-diagnostics.js';
 import type { ModelCallCommit } from '@maka/core/agent-run';
@@ -88,6 +92,7 @@ export interface ProviderRequestAttemptRecord extends ProviderRequestUsage {
   completedAt: number;
   status: ProviderRequestAttemptStatus;
   finishReason?: string;
+  failure?: ProviderFailureDiagnostic;
   latencyMs: number;
   timeToFirstTokenMs?: number;
 }
@@ -152,6 +157,7 @@ export interface ModelCallAccountingInput {
    */
   providerId?: string;
   callKind: ModelCallKind;
+  historyCompactRoute?: ModelCallAttempt['historyCompactRoute'];
   /**
    * Commits the attempt, and with it the derived latest-context row when this
    * request is one that answers "what is the context made of" (#2323). One
@@ -370,7 +376,7 @@ export class ProviderRequestTracker {
     try {
       result = await input.doStream();
     } catch (error) {
-      await attempt.finalize(abortStatus(input.abortSignal, error));
+      await attempt.finalize(abortStatus(input.abortSignal, error), { error });
       throw error;
     }
 
@@ -397,6 +403,7 @@ export class ProviderRequestTracker {
           } else if (part?.type === 'error') {
             await attempt.finalize(
               input.abortSignal?.aborted ? 'aborted' : sawOutput ? 'interrupted' : 'failed',
+              { error: part.error },
             );
           }
           controller.enqueue(next.value);
@@ -407,6 +414,7 @@ export class ProviderRequestTracker {
               : sawOutput
                 ? 'interrupted'
                 : abortStatus(input.abortSignal, error),
+            { error },
           );
           controller.error(error);
         }
@@ -439,7 +447,7 @@ export class ProviderRequestTracker {
       });
       return result;
     } catch (error) {
-      await attempt.finalize(abortStatus(input.abortSignal, error));
+      await attempt.finalize(abortStatus(input.abortSignal, error), { error });
       throw error;
     }
   }
@@ -455,7 +463,7 @@ export class ProviderRequestTracker {
     observeOutput(): void;
     finalize(
       status: ProviderRequestAttemptStatus,
-      finish?: { reason?: string; usage?: ProviderRequestUsageLike },
+      finish?: { reason?: string; usage?: ProviderRequestUsageLike; error?: unknown },
     ): Promise<void>;
   } {
     const attempt = (this.attemptsByStep.get(step) ?? 0) + 1;
@@ -480,7 +488,7 @@ export class ProviderRequestTracker {
     let abortListener: (() => void) | undefined;
     const finalize = async (
       status: ProviderRequestAttemptStatus,
-      finish?: { reason?: string; usage?: ProviderRequestUsageLike },
+      finish?: { reason?: string; usage?: ProviderRequestUsageLike; error?: unknown },
     ): Promise<void> => {
       if (settled) return;
       const provisional = status === 'aborted' && finish?.usage === undefined;
@@ -493,6 +501,8 @@ export class ProviderRequestTracker {
       const completedAt = this.input.now();
       const usage = strictProviderRequestUsage(finish?.usage);
       const contextWindow = positiveInteger(this.input.contextWindow);
+      const failure =
+        finish?.error !== undefined ? providerFailureDiagnostic(finish.error) : undefined;
       const record: ProviderRequestAttemptRecord = {
         traceId: this.input.traceId,
         attemptId,
@@ -515,6 +525,7 @@ export class ProviderRequestTracker {
         completedAt,
         status,
         ...(finish?.reason !== undefined ? { finishReason: finish.reason } : {}),
+        ...(failure !== undefined ? { failure } : {}),
         latencyMs: Math.max(0, completedAt - startedAt),
         ...(timeToFirstTokenMs !== undefined ? { timeToFirstTokenMs } : {}),
         ...(usage ?? {}),
@@ -599,6 +610,9 @@ export class ProviderRequestTracker {
       step: Math.max(0, record.step),
       attempt: Math.max(0, record.attempt - 1),
       callKind: accounting.callKind,
+      ...(accounting.historyCompactRoute !== undefined
+        ? { historyCompactRoute: accounting.historyCompactRoute }
+        : {}),
       providerId: accounting.providerId ?? record.providerId,
       modelId: record.modelId,
       ...(context.contextWindow !== undefined ? { contextWindow: context.contextWindow } : {}),
@@ -613,6 +627,7 @@ export class ProviderRequestTracker {
         : {}),
       status: record.status,
       ...(record.finishReason !== undefined ? { finishReason: record.finishReason } : {}),
+      ...(record.failure ?? {}),
       usageBasis,
       ...(usageBasis === 'missing' ? {} : modelCallUsageFields(usage)),
       costBasis: priced ? 'priced' : 'unpriced',

--- a/packages/runtime/src/session-trace-projection.ts
+++ b/packages/runtime/src/session-trace-projection.ts
@@ -225,6 +225,9 @@ function projectModelCallSteps(attempts: readonly ModelCallAttempt[]): TraceMode
       endedAt,
       durationMs: Math.max(0, endedAt - startedAt),
       callKind: first.callKind,
+      ...(first.historyCompactRoute !== undefined
+        ? { historyCompactRoute: first.historyCompactRoute }
+        : {}),
       providerId: first.providerId,
       modelId: first.modelId,
       ...(first.connectionSlug !== undefined ? { connectionSlug: first.connectionSlug } : {}),
@@ -255,6 +258,12 @@ function toTraceAttempt(attempt: ModelCallAttempt): TraceModelAttempt {
       : {}),
     ...(attempt.finishReason !== undefined ? { finishReason: attempt.finishReason } : {}),
     ...(attempt.errorClass !== undefined ? { errorClass: attempt.errorClass } : {}),
+    ...(attempt.httpStatus !== undefined ? { httpStatus: attempt.httpStatus } : {}),
+    ...(attempt.providerCode !== undefined ? { providerCode: attempt.providerCode } : {}),
+    ...(attempt.providerRequestId !== undefined
+      ? { providerRequestId: attempt.providerRequestId }
+      : {}),
+    ...(attempt.retryable !== undefined ? { retryable: attempt.retryable } : {}),
     ...(attempt.inputTokens !== undefined ? { inputTokens: attempt.inputTokens } : {}),
     ...(attempt.outputTokens !== undefined ? { outputTokens: attempt.outputTokens } : {}),
     ...(attempt.cacheReadInputTokens !== undefined

--- a/packages/runtime/src/subscription-model-fetch.ts
+++ b/packages/runtime/src/subscription-model-fetch.ts
@@ -218,7 +218,7 @@ async function checkedOpenAiCodexFetch(
       edgeRetry += 1;
       continue;
     }
-    throw new Error(formatOpenAiCodexHttpError(response.status, detail));
+    throw openAiCodexHttpError(response, detail);
   }
 }
 
@@ -334,6 +334,36 @@ function formatOpenAiCodexHttpError(statusCode: number, detail: string): string 
   return compact
     ? `Codex OAuth request failed: HTTP ${statusCode} ${compact}`
     : `Codex OAuth request failed: HTTP ${statusCode}`;
+}
+
+function openAiCodexHttpError(response: Response, detail: string): Error {
+  const providerCode = openAiCodexProviderCode(detail);
+  const rawRequestId = response.headers.get('x-request-id')?.trim();
+  const requestId = rawRequestId ? redactSecrets(rawRequestId).slice(0, 256) : undefined;
+  return Object.assign(new Error(formatOpenAiCodexHttpError(response.status, detail)), {
+    name: 'OpenAiCodexHttpError',
+    statusCode: response.status,
+    ...(providerCode ? { data: { error: { code: providerCode } } } : {}),
+    ...(requestId ? { responseHeaders: { 'x-request-id': requestId.slice(0, 256) } } : {}),
+  });
+}
+
+function openAiCodexProviderCode(detail: string): string | undefined {
+  try {
+    const payload = JSON.parse(detail) as unknown;
+    if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return undefined;
+    const root = payload as Record<string, unknown>;
+    const error =
+      root.error && typeof root.error === 'object' && !Array.isArray(root.error)
+        ? (root.error as Record<string, unknown>)
+        : root;
+    const value = error.code ?? error.type;
+    if (typeof value !== 'string' && typeof value !== 'number') return undefined;
+    const normalized = redactSecrets(String(value).trim()).slice(0, 256);
+    return normalized || undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function buildClaudeSubscriptionCloakedFetch(

--- a/packages/storage/src/__tests__/model-call-ledger.test.ts
+++ b/packages/storage/src/__tests__/model-call-ledger.test.ts
@@ -72,6 +72,48 @@ describe('canonical model call ledger', () => {
     });
   });
 
+  test('provider failure diagnostics survive closing and reopening the ledger', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-model-call-ledger-reopen-'));
+    const first = createSqliteModelCallLedger(root);
+    try {
+      await first.record(
+        attempt({
+          callKind: 'history_compact',
+          historyCompactRoute: 'provider_native',
+          providerId: 'openai-codex',
+          status: 'failed',
+          usageBasis: 'missing',
+          inputTokens: undefined,
+          outputTokens: undefined,
+          costBasis: 'unpriced',
+          costUsd: undefined,
+          errorClass: 'RequestRejected',
+          httpStatus: 400,
+          providerCode: 'invalid_request_error',
+          providerRequestId: 'req-reopen-1',
+          retryable: false,
+        }),
+      );
+      await first.close();
+
+      const reopened = createSqliteModelCallLedger(root);
+      try {
+        const restored = reopened.read({ from: 0, to: NOW }).attempts[0];
+        assert.equal(restored?.historyCompactRoute, 'provider_native');
+        assert.equal(restored?.errorClass, 'RequestRejected');
+        assert.equal(restored?.httpStatus, 400);
+        assert.equal(restored?.providerCode, 'invalid_request_error');
+        assert.equal(restored?.providerRequestId, 'req-reopen-1');
+        assert.equal(restored?.retryable, false);
+      } finally {
+        await reopened.close();
+      }
+    } finally {
+      await first.close().catch(() => undefined);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('a late settlement replaces the provisional record under the same attempt id', async () => {
     // The abort path records provisionally without usage; a `finish` arriving
     // afterwards settles the same attempt. Two rows would double-count it.

--- a/packages/storage/src/__tests__/sqlite-core-execution-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-core-execution-store.test.ts
@@ -5,6 +5,10 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { DatabaseSync } from 'node:sqlite';
 import type { AgentRunHeader, EmittedAgentRunEvent } from '@maka/core/agent-run';
+import {
+  MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
+  decodeModelCallAttempt,
+} from '@maka/core/model-call-attempt';
 import type { InteractionCanonicalOutcome, InteractionRequest } from '@maka/core/interaction';
 import type { ShellRunRecord } from '@maka/core/shell-run';
 import { createSqliteAgentRunStore } from '../agent-run-store.js';
@@ -29,6 +33,60 @@ describe('SQLite core execution stores', () => {
       try {
         assert.equal((await reopened.readRun('session-1', 'run-1')).runId, 'run-1');
         assert.equal((await reopened.readEvents('session-1', 'run-1'))[0]?.id, 'event-1');
+      } finally {
+        reopened.close?.();
+      }
+    });
+  });
+
+  test('preserves provider failure diagnostics in the AgentRun authority after reopen', async () => {
+    await withRoot(async (root) => {
+      const store = createSqliteAgentRunStore(root);
+      await store.createRun(runHeader());
+      await store.appendEvent('session-1', 'run-1', {
+        type: 'model_call_attempt_recorded',
+        id: 'attempt-1',
+        runId: 'run-1',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        ts: 10,
+        data: {
+          schemaVersion: MODEL_CALL_ATTEMPT_SCHEMA_VERSION,
+          logicalCallId: 'call-1',
+          attemptId: 'attempt-1',
+          traceId: 'trace-1',
+          sessionId: 'session-1',
+          runId: 'run-1',
+          turnId: 'turn-1',
+          step: 0,
+          attempt: 0,
+          callKind: 'history_compact',
+          historyCompactRoute: 'provider_native',
+          connectionSlug: 'codex-subscription',
+          providerId: 'openai-codex',
+          modelId: 'gpt-5.6-sol',
+          startedAt: 1,
+          completedAt: 10,
+          latencyMs: 9,
+          status: 'failed',
+          errorClass: 'RequestRejected',
+          httpStatus: 400,
+          providerCode: 'invalid_request_error',
+          providerRequestId: 'req-authority-1',
+          retryable: false,
+          usageBasis: 'missing',
+          costBasis: 'unpriced',
+        },
+      });
+      store.close?.();
+
+      const reopened = createSqliteAgentRunStore(root);
+      try {
+        const event = (await reopened.readEvents('session-1', 'run-1'))[0];
+        const attempt = decodeModelCallAttempt(event?.data);
+        assert.equal(attempt.historyCompactRoute, 'provider_native');
+        assert.equal(attempt.httpStatus, 400);
+        assert.equal(attempt.providerRequestId, 'req-authority-1');
       } finally {
         reopened.close?.();
       }


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Provider failures during history compaction were previously reduced to a generic status before the durable model-call record was written, leaving operators unable to diagnose the failure after restart.

This change persists a bounded failure fingerprint on canonical model-call attempts, including the selected compaction route, error class, HTTP status, provider code, request ID, and retryability. Codex OAuth HTTP facts survive the fetch and AI SDK wrapper layers without persisting provider messages, request or response bodies, or arbitrary headers. Existing fail-open behavior is unchanged.

Fixes #3098

## Verification

- Relevant `@maka/core`, `@maka/storage`, `@maka/runtime`, and `@maka/runtime-host` builds and type checks passed.
- Biome formatting and lint passed for all changed files.
- 114 relevant tests passed across Core, Storage, Runtime, and Runtime Host.
- The full Runtime Host execution-model composition suite passed, including the Codex OAuth provider-native compaction path with a terminal `compaction_trigger` and no generic summarizer prompt.
- The full repository-wide test suite was not run.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex assisted with investigation, implementation, tests, verification, and PR preparation.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

AI disclosure: This change was completed with assistance from Codex and reviewed by M4n5ter. M4n5ter accepts responsibility for the result.

</details>

<details>
<summary>中文</summary>

## 摘要

历史压缩期间的 Provider 失败此前会在写入持久化 model-call 记录前被归并为通用状态，导致服务重启后无法继续诊断失败原因。

本变更在权威 model-call attempt 中持久化有界的失败指纹，包括实际压缩路由、错误分类、HTTP 状态、Provider code、request ID 与是否可重试。Codex OAuth 的 HTTP 事实可以穿过 fetch 与 AI SDK 包装层，同时不会持久化 Provider 消息、请求或响应正文以及任意响应头。现有 fail-open 行为保持不变。

Fixes #3098

## 验证

- 相关 `@maka/core`、`@maka/storage`、`@maka/runtime` 与 `@maka/runtime-host` workspace 的构建和类型检查通过。
- 所有变更文件均通过 Biome 格式与 lint 检查。
- Core、Storage、Runtime 与 Runtime Host 共 114 项相关测试通过。
- 完整 Runtime Host execution-model composition 测试通过，其中覆盖 Codex OAuth Provider 原生压缩路径：请求末尾包含 `compaction_trigger`，且不包含通用 summarizer prompt。
- 未运行全仓库测试套件。

## AI 使用

请且仅选择一项：

- [ ] 生成式工具未作出实质性贡献
- [x] 生成式工具作出了实质性贡献

工具及范围：Codex 协助完成了调查、实现、测试、验证与 PR 准备。

## 检查清单

- [x] 测试覆盖本次变更，且缺少该变更时会失败
- [x] lint、format、typecheck 与受影响测试套件均在本地通过

此 PR 是否包含行为变化？

- [x] 是 — 已在上方“摘要”中说明
- [ ] 否

AI 披露：本变更由 Codex 辅助完成，并经 M4n5ter 审核。M4n5ter 对结果负责。

</details>