### PR TITLE
feat: persist external session origins

### DIFF
--- a/apps/desktop/src/main/__tests__/external-session-catalog-projection.test.ts
+++ b/apps/desktop/src/main/__tests__/external-session-catalog-projection.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { SessionSummary } from '@maka/core/session';
+import {
+  projectDesktopExternalSessionCatalogItem,
+} from '../../preload/external-session-catalog.js';
+import { projectDesktopSessionSummary } from '../../shared/desktop-session-projection.js';
+import { desktopSessionKey } from '../../shared/runtime-host-identity.js';
+
+test('projects imported Session ids into the same Desktop identity space as Session summaries', () => {
+  const host = { hostId: 'host-a' };
+  const catalogItem = projectDesktopExternalSessionCatalogItem(host, {
+    id: 'source-1',
+    name: 'Source',
+    cwd: '/external',
+    importState: {
+      importedCount: 1,
+      importedSessionIds: ['imported-1'],
+      isImporting: false,
+    },
+  });
+  const summary = projectDesktopSessionSummary(
+    {
+      ...host,
+      profileId: 'profile-a',
+      profileName: 'Profile A',
+      profileKind: 'remote',
+    },
+    session('imported-1'),
+  );
+
+  assert.deepEqual(catalogItem.importState.importedSessionIds, [
+    desktopSessionKey({ hostId: host.hostId, sessionId: 'imported-1' }),
+  ]);
+  assert.equal(catalogItem.importState.importedSessionIds[0], summary.id);
+});
+
+function session(id: string): SessionSummary {
+  return {
+    id,
+    name: 'Imported',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'default',
+    connectionLocked: false,
+    model: 'gpt-5',
+    permissionMode: 'ask',
+  };
+}

--- a/apps/desktop/src/main/__tests__/import-tasks-settings-page.test.ts
+++ b/apps/desktop/src/main/__tests__/import-tasks-settings-page.test.ts
@@ -1,0 +1,599 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, describe, it } from 'node:test';
+import { parseHTML } from 'linkedom';
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { AstryxLocaleProvider, LocaleProvider } from '@maka/ui';
+import type { DesktopExternalSessionCatalogItem } from '../../preload/external-session-catalog.js';
+import { ImportTasksSettingsPage } from '../../renderer/settings/import-tasks-settings-page.js';
+
+type CatalogResult = {
+  sessions: DesktopExternalSessionCatalogItem[];
+  nextCursor: string | null;
+};
+
+const originalGlobals = {
+  document: globalThis.document,
+  window: globalThis.window,
+  matchMedia: globalThis.matchMedia,
+  HTMLElement: globalThis.HTMLElement,
+  HTMLIFrameElement: globalThis.HTMLIFrameElement,
+  requestAnimationFrame: globalThis.requestAnimationFrame,
+  cancelAnimationFrame: globalThis.cancelAnimationFrame,
+  IS_REACT_ACT_ENVIRONMENT: (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
+    .IS_REACT_ACT_ENVIRONMENT,
+};
+
+afterEach(() => {
+  Object.assign(globalThis, originalGlobals);
+});
+
+describe('ImportTasksSettingsPage durable import state', () => {
+  it('renders imported history and an entry to the newest imported task after remount', async () => {
+    const opened: string[] = [];
+    const harness = await renderPage({
+      catalog: {
+        sessions: [
+          externalSession({
+            importState: {
+              importedCount: 2,
+              importedSessionIds: ['session-newest', 'session-older'],
+              isImporting: false,
+            },
+          }),
+        ],
+        nextCursor: null,
+      },
+      onOpenImported: (sessionId) => opened.push(sessionId),
+    });
+
+    assert.match(harness.container.textContent, /Imported 2 times/);
+    const openButton = buttonWithText(harness.container, 'Open latest imported task');
+    assert.ok(openButton);
+    await act(async () => openButton.click());
+    assert.deepEqual(opened, ['session-newest']);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('uses catalog in-flight state after remount to disable the source row', async () => {
+    const harness = await renderPage({
+      catalog: {
+        sessions: [
+          externalSession({
+            importState: {
+              importedCount: 1,
+              importedSessionIds: ['session-existing'],
+              isImporting: true,
+            },
+          }),
+        ],
+        nextCursor: null,
+      },
+    });
+
+    const importing = harness.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Importing Investigate a flaky test"]',
+    );
+    assert.ok(importing);
+    assert.equal(importing.hasAttribute('disabled'), true);
+    assert.equal(importing.getAttribute('aria-busy'), 'true');
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('renders durable repeat-import state in Chinese', async () => {
+    const harness = await renderPage({
+      locale: 'zh',
+      catalog: catalog(
+        externalSession({
+          importState: {
+            importedCount: 3,
+            importedSessionIds: ['session-zh'],
+            isImporting: false,
+          },
+        }),
+      ),
+    });
+
+    assert.match(harness.container.textContent, /已导入 3 次/);
+    assert.ok(buttonWithText(harness.container, '打开最近导入的任务'));
+    assert.ok(buttonWithText(harness.container, '再次导入'));
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('polls catalog-owned in-flight state until the imported task becomes durable', async () => {
+    const importing = externalSession({
+      importState: { importedCount: 0, importedSessionIds: [], isImporting: true },
+    });
+    const imported = externalSession({
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['session-landed'],
+        isImporting: false,
+      },
+    });
+    const harness = await renderPage({ catalogs: [catalog(importing), catalog(imported)] });
+
+    assert.equal(harness.listCalls(), 1);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_025));
+    });
+
+    assert.equal(harness.listCalls(), 2);
+    assert.match(harness.container.textContent, /Imported once/);
+    assert.equal(harness.container.querySelector('button[aria-busy="true"]'), null);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('polls the whole loaded page window without dropping a later-page import', async () => {
+    const firstPage = externalSession({ id: 'source-first', name: 'First page source' });
+    const secondPageImporting = externalSession({
+      id: 'source-second',
+      name: 'Second page source',
+      importState: { importedCount: 0, importedSessionIds: [], isImporting: true },
+    });
+    const secondPageImported = externalSession({
+      id: 'source-second',
+      name: 'Second page source',
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['second-page-task'],
+        isImporting: false,
+      },
+    });
+    const harness = await renderPage({
+      catalogs: [
+        { sessions: [firstPage], nextCursor: '1' },
+        { sessions: [secondPageImporting], nextCursor: null },
+        { sessions: [firstPage], nextCursor: '1' },
+        { sessions: [secondPageImported], nextCursor: null },
+      ],
+    });
+
+    const loadMore = buttonWithText(harness.container, 'Load more');
+    assert.ok(loadMore);
+    await act(async () => {
+      loadMore.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.match(harness.container.textContent, /Second page source/);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_025));
+    });
+
+    assert.equal(harness.listCalls(), 4);
+    assert.match(harness.container.textContent, /First page source/);
+    assert.match(harness.container.textContent, /Second page source/);
+    assert.match(harness.container.textContent, /Imported once/);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('re-reads the catalog after an unknown outcome and exposes the task that landed', async () => {
+    const initial = externalSession();
+    const recovered = externalSession({
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['session-recovered'],
+        isImporting: false,
+      },
+    });
+    const opened: string[] = [];
+    const harness = await renderPage({
+      catalogs: [catalog(initial), catalog(recovered)],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+      onOpenImported: (sessionId) => opened.push(sessionId),
+    });
+
+    const importButton = buttonWithText(harness.container, 'Import');
+    assert.ok(importButton);
+    await act(async () => {
+      importButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.equal(harness.listCalls(), 2);
+    assert.match(harness.container.textContent, /The imported task is available now/);
+    const openButton = buttonWithText(harness.container, 'Open latest imported task');
+    assert.ok(openButton);
+    await act(async () => openButton.click());
+    assert.deepEqual(opened, ['session-recovered']);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('preserves the loaded page window when unknown-outcome recovery finds its source early', async () => {
+    const firstPage = externalSession({ id: 'source-first', name: 'First page source' });
+    const secondPage = externalSession({ id: 'source-second', name: 'Second page source' });
+    const recoveredFirstPage = externalSession({
+      id: 'source-first',
+      name: 'First page source',
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['first-page-task'],
+        isImporting: false,
+      },
+    });
+    const harness = await renderPage({
+      catalogs: [
+        { sessions: [firstPage], nextCursor: '1' },
+        { sessions: [secondPage], nextCursor: null },
+        { sessions: [recoveredFirstPage], nextCursor: '1' },
+        { sessions: [secondPage], nextCursor: null },
+      ],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+    });
+
+    const loadMore = buttonWithText(harness.container, 'Load more');
+    assert.ok(loadMore);
+    await act(async () => {
+      loadMore.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.match(harness.container.textContent, /Second page source/);
+
+    const importButton = Array.from(harness.container.querySelectorAll<HTMLButtonElement>('button')).find(
+      (button) => button.getAttribute('aria-label') === 'Import First page source',
+    );
+    assert.ok(importButton);
+    await act(async () => {
+      importButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.equal(harness.listCalls(), 4);
+    assert.match(harness.container.textContent, /First page source/);
+    assert.match(harness.container.textContent, /Second page source/);
+    assert.match(harness.container.textContent, /The imported task is available now/);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('allows a safe retry when recovery finds no new imported task', async () => {
+    const source = externalSession({
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['session-existing'],
+        isImporting: false,
+      },
+    });
+    const harness = await renderPage({
+      catalogs: [catalog(source), catalog(source)],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+    });
+
+    const firstImport = buttonWithText(harness.container, 'Import again');
+    assert.ok(firstImport);
+    await act(async () => {
+      firstImport.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.equal(harness.listCalls(), 2);
+    assert.match(harness.container.textContent, /No new task was recorded, so it is safe to retry/);
+    const retry = buttonWithText(harness.container, 'Import again');
+    assert.ok(retry);
+    assert.equal(retry.hasAttribute('disabled'), false);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('keeps the import uncertain when recovery can no longer find the source row', async () => {
+    const harness = await renderPage({
+      catalogs: [catalog(externalSession()), { sessions: [], nextCursor: null }],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+    });
+
+    const importButton = buttonWithText(harness.container, 'Import');
+    assert.ok(importButton);
+    await act(async () => {
+      importButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.match(harness.container.textContent, /Check the import result/);
+    assert.doesNotMatch(harness.container.textContent, /safe to retry/);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('does not let an older catalog poll overwrite unknown-outcome recovery', async () => {
+    let settlePoll: ((result: CatalogResult) => void) | undefined;
+    const pendingPoll = new Promise<CatalogResult>((resolve) => {
+      settlePoll = resolve;
+    });
+    const target = externalSession({ id: 'target-source', name: 'Target source' });
+    const otherImporting = externalSession({
+      id: 'other-source',
+      name: 'Other source',
+      importState: { importedCount: 0, importedSessionIds: [], isImporting: true },
+    });
+    const recoveredTarget = externalSession({
+      id: 'target-source',
+      name: 'Target source',
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['target-task'],
+        isImporting: false,
+      },
+    });
+    const harness = await renderPage({
+      catalogs: [
+        { sessions: [target, otherImporting], nextCursor: null },
+        pendingPoll,
+        { sessions: [recoveredTarget, otherImporting], nextCursor: null },
+      ],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1_025));
+    });
+    assert.equal(harness.listCalls(), 2);
+
+    const importButton = harness.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Import Target source"]',
+    );
+    assert.ok(importButton);
+    await act(async () => {
+      importButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.match(harness.container.textContent, /The imported task is available now/);
+
+    await act(async () => {
+      settlePoll?.({ sessions: [target, otherImporting], nextCursor: null });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.match(harness.container.textContent, /Imported once/);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('clears loading-more state when recovery retires the pending page request', async () => {
+    let settleLoadMore: ((result: CatalogResult) => void) | undefined;
+    const pendingLoadMore = new Promise<CatalogResult>((resolve) => {
+      settleLoadMore = resolve;
+    });
+    const source = externalSession({ name: 'Visible source' });
+    const recovered = externalSession({
+      name: 'Visible source',
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['visible-task'],
+        isImporting: false,
+      },
+    });
+    const harness = await renderPage({
+      catalogs: [
+        { sessions: [source], nextCursor: '1' },
+        pendingLoadMore,
+        { sessions: [recovered], nextCursor: '1' },
+      ],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+    });
+
+    const loadMore = buttonWithText(harness.container, 'Load more');
+    assert.ok(loadMore);
+    await act(async () => loadMore.click());
+
+    const importButton = harness.container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Import Visible source"]',
+    );
+    assert.ok(importButton);
+    await act(async () => {
+      importButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.match(harness.container.textContent, /The imported task is available now/);
+
+    await act(async () => {
+      settleLoadMore?.({ sessions: [], nextCursor: null });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const recoveredLoadMore = Array.from(
+      harness.container.querySelectorAll<HTMLButtonElement>('button'),
+    ).find((button) => button.textContent?.includes('Load more'));
+    assert.ok(recoveredLoadMore);
+    assert.equal(recoveredLoadMore.getAttribute('aria-busy'), null);
+    assert.equal(recoveredLoadMore.hasAttribute('disabled'), false);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('retries a failed unknown-outcome catalog recovery instead of leaving a local lock', async () => {
+    const initial = externalSession();
+    const recovered = externalSession({
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['session-after-read-retry'],
+        isImporting: false,
+      },
+    });
+    const harness = await renderPage({
+      catalogs: [catalog(initial), new Error('catalog temporarily unavailable'), catalog(recovered)],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+    });
+
+    const importButton = buttonWithText(harness.container, 'Import');
+    assert.ok(importButton);
+    await act(async () => {
+      importButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.equal(harness.listCalls(), 2);
+    assert.match(harness.container.textContent, /Check the import result/);
+
+    const retryRead = buttonWithText(harness.container, 'Retry');
+    assert.ok(retryRead);
+    await act(async () => {
+      retryRead.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.equal(harness.listCalls(), 3);
+    assert.doesNotMatch(harness.container.textContent, /Check the import result/);
+    assert.match(harness.container.textContent, /The imported task is available now/);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('does not replace a newer filter catalog while recovering an older import attempt', async () => {
+    let settleImport: ((result: { ok: false; reason: 'commit_outcome_unknown' }) => void) | undefined;
+    const importResult = new Promise<{ ok: false; reason: 'commit_outcome_unknown' }>((resolve) => {
+      settleImport = resolve;
+    });
+    const initial = externalSession({ name: 'Original source conversation' });
+    const filtered = externalSession({ id: 'archived-source', name: 'Current filtered catalog' });
+    const recovered = externalSession({
+      name: 'Original source conversation',
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['session-from-original-filter'],
+        isImporting: false,
+      },
+    });
+    const harness = await renderPage({
+      catalogs: [catalog(initial), catalog(filtered), catalog(recovered)],
+      importResult,
+    });
+
+    const importButton = buttonWithText(harness.container, 'Import');
+    assert.ok(importButton);
+    await act(async () => importButton.click());
+
+    const archivedFilter = harness.container.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    assert.ok(archivedFilter);
+    await act(async () => {
+      archivedFilter.checked = true;
+      archivedFilter.dispatchEvent(new window.Event('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.equal(harness.listCalls(), 2);
+    assert.match(harness.container.textContent, /Current filtered catalog/);
+
+    await act(async () => {
+      settleImport?.({ ok: false, reason: 'commit_outcome_unknown' });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(harness.listInputs().map((input) => input.includeArchived), [false, true, false]);
+    assert.match(harness.container.textContent, /Current filtered catalog/);
+    assert.match(harness.container.textContent, /The imported task is available now/);
+
+    await act(async () => harness.root.unmount());
+  });
+});
+
+function externalSession(
+  overrides: Partial<DesktopExternalSessionCatalogItem> = {},
+): DesktopExternalSessionCatalogItem {
+  return {
+    id: 'codex-source-1',
+    name: 'Investigate a flaky test',
+    cwd: '/workspace/maka-agent',
+    updatedAt: Date.now(),
+    importState: { importedCount: 0, importedSessionIds: [], isImporting: false },
+    ...overrides,
+  };
+}
+
+async function renderPage(options: {
+  catalog?: CatalogResult;
+  catalogs?: Array<CatalogResult | Error | Promise<CatalogResult>>;
+  importResult?:
+    | { ok: false; reason: 'commit_outcome_unknown' }
+    | Promise<{ ok: false; reason: 'commit_outcome_unknown' }>;
+  onOpenImported?: (sessionId: string) => void;
+  locale?: 'en' | 'zh';
+}): Promise<{
+  container: HTMLElement;
+  root: Root;
+  listCalls(): number;
+  listInputs(): Array<{ includeArchived: boolean }>;
+}> {
+  const { document, window } = parseHTML('<div id="root"></div>');
+  const matchMedia = (media: string) => ({
+    matches: false,
+    media,
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent: () => false,
+  });
+  Object.assign(window, { matchMedia });
+  Object.assign(globalThis, {
+    document,
+    window,
+    matchMedia,
+    HTMLElement: window.HTMLElement,
+    HTMLIFrameElement: window.HTMLIFrameElement ?? class HTMLIFrameElement {},
+    requestAnimationFrame: (callback: FrameRequestCallback) => setTimeout(callback, 0),
+    cancelAnimationFrame: (handle: number) => clearTimeout(handle),
+    IS_REACT_ACT_ENVIRONMENT: true,
+  });
+  let listCalls = 0;
+  const listInputs: Array<{ includeArchived: boolean }> = [];
+  const catalogs = options.catalogs ?? [options.catalog ?? { sessions: [], nextCursor: null }];
+  (window as unknown as { maka: unknown }).maka = {
+    externalSessions: {
+      listSources: async () => ({ adapterIds: ['codex'] }),
+      list: async (input: { includeArchived?: boolean }) => {
+        listInputs.push({ includeArchived: input.includeArchived === true });
+        const result = catalogs[Math.min(listCalls++, catalogs.length - 1)];
+        if (result instanceof Error) throw result;
+        return result;
+      },
+      import: async () =>
+        options.importResult ?? Promise.reject(new Error('import is not used by this test')),
+    },
+  };
+
+  const container = document.querySelector<HTMLElement>('#root');
+  assert.ok(container);
+  const root = createRoot(container);
+  await act(async () => {
+    const pageProps = {
+      onImported: () => undefined,
+      onOpenImported: options.onOpenImported ?? (() => undefined),
+    };
+    const page = createElement(ImportTasksSettingsPage, pageProps);
+    const localized = createElement(AstryxLocaleProvider, { children: page });
+    root.render(
+      createElement(LocaleProvider, { locale: options.locale ?? 'en', children: localized }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { container, root, listCalls: () => listCalls, listInputs: () => listInputs };
+}
+
+function catalog(session: DesktopExternalSessionCatalogItem): CatalogResult {
+  return { sessions: [session], nextCursor: null };
+}
+
+function buttonWithText(container: HTMLElement, text: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+    (button) => button.textContent === text,
+  );
+}

--- a/apps/desktop/src/main/__tests__/import-tasks-settings-page.test.ts
+++ b/apps/desktop/src/main/__tests__/import-tasks-settings-page.test.ts
@@ -4,8 +4,10 @@ import { parseHTML } from 'linkedom';
 import { act, createElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { AstryxLocaleProvider, LocaleProvider } from '@maka/ui';
+import type { DesktopRuntimeHostRef } from '../../preload/bridge-contract.js';
 import type { DesktopExternalSessionCatalogItem } from '../../preload/external-session-catalog.js';
 import { ImportTasksSettingsPage } from '../../renderer/settings/import-tasks-settings-page.js';
+import { RuntimeHostSettingsTarget } from '../../renderer/settings/runtime-host-settings-target.js';
 
 type CatalogResult = {
   sessions: DesktopExternalSessionCatalogItem[];
@@ -23,6 +25,11 @@ const originalGlobals = {
   IS_REACT_ACT_ENVIRONMENT: (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean })
     .IS_REACT_ACT_ENVIRONMENT,
 };
+
+const TEST_RUNTIME_HOST = {
+  profileId: 'test-profile',
+  hostId: 'test-host',
+} satisfies DesktopRuntimeHostRef;
 
 afterEach(() => {
   Object.assign(globalThis, originalGlobals);
@@ -52,6 +59,31 @@ describe('ImportTasksSettingsPage durable import state', () => {
     assert.ok(openButton);
     await act(async () => openButton.click());
     assert.deepEqual(opened, ['session-newest']);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('scopes catalog reads, recovery, and import to the selected Runtime Host', async () => {
+    const source = externalSession();
+    const harness = await renderPage({
+      catalogs: [catalog(source), catalog(source)],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+    });
+
+    const importButton = buttonWithText(harness.container, 'Import');
+    assert.ok(importButton);
+    await act(async () => {
+      importButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.deepEqual(harness.hostCalls(), [
+      { operation: 'listSources', host: TEST_RUNTIME_HOST },
+      { operation: 'list', host: TEST_RUNTIME_HOST },
+      { operation: 'import', host: TEST_RUNTIME_HOST },
+      { operation: 'list', host: TEST_RUNTIME_HOST },
+    ]);
 
     await act(async () => harness.root.unmount());
   });
@@ -584,6 +616,7 @@ async function renderPage(options: {
   root: Root;
   listCalls(): number;
   listInputs(): Array<{ includeArchived: boolean }>;
+  hostCalls(): Array<{ operation: 'listSources' | 'list' | 'import'; host?: DesktopRuntimeHostRef }>;
 }> {
   const { document, window } = parseHTML('<div id="root"></div>');
   const matchMedia = (media: string) => ({
@@ -609,18 +642,28 @@ async function renderPage(options: {
   });
   let listCalls = 0;
   const listInputs: Array<{ includeArchived: boolean }> = [];
+  const hostCalls: Array<{
+    operation: 'listSources' | 'list' | 'import';
+    host?: DesktopRuntimeHostRef;
+  }> = [];
   const catalogs = options.catalogs ?? [options.catalog ?? { sessions: [], nextCursor: null }];
   (window as unknown as { maka: unknown }).maka = {
     externalSessions: {
-      listSources: async () => ({ adapterIds: ['codex'] }),
-      list: async (input: { includeArchived?: boolean }) => {
+      listSources: async (host?: DesktopRuntimeHostRef) => {
+        hostCalls.push({ operation: 'listSources', host });
+        return { adapterIds: ['codex'] };
+      },
+      list: async (input: { includeArchived?: boolean }, host?: DesktopRuntimeHostRef) => {
+        hostCalls.push({ operation: 'list', host });
         listInputs.push({ includeArchived: input.includeArchived === true });
         const result = catalogs[Math.min(listCalls++, catalogs.length - 1)];
         if (result instanceof Error) throw result;
         return result;
       },
-      import: async () =>
-        options.importResult ?? Promise.reject(new Error('import is not used by this test')),
+      import: async (_input: unknown, host?: DesktopRuntimeHostRef) => {
+        hostCalls.push({ operation: 'import', host });
+        return options.importResult ?? Promise.reject(new Error('import is not used by this test'));
+      },
     },
   };
 
@@ -633,14 +676,24 @@ async function renderPage(options: {
       onOpenImported: options.onOpenImported ?? (() => undefined),
     };
     const page = createElement(ImportTasksSettingsPage, pageProps);
-    const localized = createElement(AstryxLocaleProvider, { children: page });
+    const targeted = createElement(RuntimeHostSettingsTarget, {
+      host: TEST_RUNTIME_HOST,
+      children: page,
+    });
+    const localized = createElement(AstryxLocaleProvider, { children: targeted });
     root.render(
       createElement(LocaleProvider, { locale: options.locale ?? 'en', children: localized }),
     );
     await Promise.resolve();
     await Promise.resolve();
   });
-  return { container, root, listCalls: () => listCalls, listInputs: () => listInputs };
+  return {
+    container,
+    root,
+    listCalls: () => listCalls,
+    listInputs: () => listInputs,
+    hostCalls: () => hostCalls,
+  };
 }
 
 function catalog(session: DesktopExternalSessionCatalogItem): CatalogResult {

--- a/apps/desktop/src/main/__tests__/import-tasks-settings-page.test.ts
+++ b/apps/desktop/src/main/__tests__/import-tasks-settings-page.test.ts
@@ -103,7 +103,8 @@ describe('ImportTasksSettingsPage durable import state', () => {
     await act(async () => harness.root.unmount());
   });
 
-  it('polls catalog-owned in-flight state until the imported task becomes durable', async () => {
+  it('polls catalog-owned in-flight state until the imported task becomes durable', async (context) => {
+    context.mock.timers.enable({ apis: ['setTimeout'] });
     const importing = externalSession({
       importState: { importedCount: 0, importedSessionIds: [], isImporting: true },
     });
@@ -118,7 +119,9 @@ describe('ImportTasksSettingsPage durable import state', () => {
 
     assert.equal(harness.listCalls(), 1);
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1_025));
+      context.mock.timers.runAll();
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     assert.equal(harness.listCalls(), 2);
@@ -128,7 +131,8 @@ describe('ImportTasksSettingsPage durable import state', () => {
     await act(async () => harness.root.unmount());
   });
 
-  it('polls the whole loaded page window without dropping a later-page import', async () => {
+  it('polls the whole loaded page window without dropping a later-page import', async (context) => {
+    context.mock.timers.enable({ apis: ['setTimeout'] });
     const firstPage = externalSession({ id: 'source-first', name: 'First page source' });
     const secondPageImporting = externalSession({
       id: 'source-second',
@@ -163,7 +167,9 @@ describe('ImportTasksSettingsPage durable import state', () => {
     assert.match(harness.container.textContent, /Second page source/);
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1_025));
+      context.mock.timers.runAll();
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
     assert.equal(harness.listCalls(), 4);
@@ -204,6 +210,52 @@ describe('ImportTasksSettingsPage durable import state', () => {
     assert.ok(openButton);
     await act(async () => openButton.click());
     assert.deepEqual(opened, ['session-recovered']);
+
+    await act(async () => harness.root.unmount());
+  });
+
+  it('clears a recovered import banner when the catalog selection changes', async () => {
+    const initial = externalSession({ name: 'Current source conversation' });
+    const recovered = externalSession({
+      name: 'Current source conversation',
+      importState: {
+        importedCount: 1,
+        importedSessionIds: ['session-recovered-before-filter'],
+        isImporting: false,
+      },
+    });
+    const filtered = externalSession({
+      id: 'archived-source',
+      name: 'Archived catalog conversation',
+      archived: true,
+    });
+    const harness = await renderPage({
+      catalogs: [catalog(initial), catalog(recovered), catalog(filtered)],
+      importResult: { ok: false, reason: 'commit_outcome_unknown' },
+    });
+
+    const importButton = buttonWithText(harness.container, 'Import');
+    assert.ok(importButton);
+    await act(async () => {
+      importButton.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    assert.match(harness.container.textContent, /The imported task is available now/);
+
+    const archivedFilter = harness.container.querySelector<HTMLInputElement>(
+      'input[type="checkbox"]',
+    );
+    assert.ok(archivedFilter);
+    await act(async () => {
+      archivedFilter.checked = true;
+      archivedFilter.dispatchEvent(new window.Event('click', { bubbles: true }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    assert.match(harness.container.textContent, /Archived catalog conversation/);
+    assert.doesNotMatch(harness.container.textContent, /The imported task is available now/);
 
     await act(async () => harness.root.unmount());
   });
@@ -307,7 +359,8 @@ describe('ImportTasksSettingsPage durable import state', () => {
     await act(async () => harness.root.unmount());
   });
 
-  it('does not let an older catalog poll overwrite unknown-outcome recovery', async () => {
+  it('does not let an older catalog poll overwrite unknown-outcome recovery', async (context) => {
+    context.mock.timers.enable({ apis: ['setTimeout'] });
     let settlePoll: ((result: CatalogResult) => void) | undefined;
     const pendingPoll = new Promise<CatalogResult>((resolve) => {
       settlePoll = resolve;
@@ -337,7 +390,9 @@ describe('ImportTasksSettingsPage durable import state', () => {
     });
 
     await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1_025));
+      context.mock.timers.runAll();
+      await Promise.resolve();
+      await Promise.resolve();
     });
     assert.equal(harness.listCalls(), 2);
 

--- a/apps/desktop/src/main/__tests__/runtime-host-external-sessions-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-external-sessions-ipc-main.test.ts
@@ -19,7 +19,18 @@ test('forwards bounded external Session requests and publishes imported Sessions
         listExternalSessions: async (input) => {
           requests.push(input);
           return {
-            sessions: [{ id: 'source-1', name: 'Source', hostCwd: '/external' }],
+            sessions: [
+              {
+                id: 'source-1',
+                name: 'Source',
+                hostCwd: '/external',
+                importState: {
+                  importedCount: 0,
+                  importedSessionIds: [],
+                  isImporting: false,
+                },
+              },
+            ],
             nextCursor: '16',
           };
         },
@@ -41,7 +52,18 @@ test('forwards bounded external Session requests and publishes imported Sessions
       cursor: '16',
     }),
     {
-      sessions: [{ id: 'source-1', name: 'Source', cwd: '/external' }],
+      sessions: [
+        {
+          id: 'source-1',
+          name: 'Source',
+          cwd: '/external',
+          importState: {
+            importedCount: 0,
+            importedSessionIds: [],
+            isImporting: false,
+          },
+        },
+      ],
       nextCursor: '16',
     },
   );

--- a/apps/desktop/src/main/runtime-host-external-sessions-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-external-sessions-ipc-main.ts
@@ -11,7 +11,7 @@ import {
   decodeExternalSessionImportInput,
 } from '@maka/runtime-host/protocol';
 import type { ExternalSessionImportIpcResult } from '../preload/external-session-import-result.js';
-import type { DesktopExternalSessionCatalogItem } from '../preload/external-session-catalog.js';
+import type { DesktopHostExternalSessionCatalogItem } from '../preload/external-session-catalog.js';
 import {
   handleReconnectableRead,
   type ReconnectableReadIpcMain,
@@ -50,7 +50,7 @@ export function registerRuntimeHostExternalSessionsIpc(
       sessions: result.sessions.map(({ hostCwd, ...session }) => ({
         ...session,
         cwd: hostCwd,
-      }) satisfies DesktopExternalSessionCatalogItem),
+      }) satisfies DesktopHostExternalSessionCatalogItem),
     };
   });
   ipcMain.handle('external-sessions:import', async (_event, input: unknown) => {

--- a/apps/desktop/src/main/runtime-host-external-sessions-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-external-sessions-ipc-main.ts
@@ -11,6 +11,7 @@ import {
   decodeExternalSessionImportInput,
 } from '@maka/runtime-host/protocol';
 import type { ExternalSessionImportIpcResult } from '../preload/external-session-import-result.js';
+import type { DesktopExternalSessionCatalogItem } from '../preload/external-session-catalog.js';
 import {
   handleReconnectableRead,
   type ReconnectableReadIpcMain,
@@ -49,7 +50,7 @@ export function registerRuntimeHostExternalSessionsIpc(
       sessions: result.sessions.map(({ hostCwd, ...session }) => ({
         ...session,
         cwd: hostCwd,
-      })),
+      }) satisfies DesktopExternalSessionCatalogItem),
     };
   });
   ipcMain.handle('external-sessions:import', async (_event, input: unknown) => {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -44,7 +44,6 @@ import type { SearchErrorReason, SearchRequest, SearchResult } from '@maka/core/
 import type { SessionChangedEvent, SessionSummary, TurnRecord } from '@maka/core/session';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { E2eFixtureState } from '@maka/core/e2e-fixture';
-import type { ExternalSessionSummary } from '@maka/core/external-session';
 import type {
   GitReviewReadResult,
   GitReviewSource,
@@ -96,6 +95,7 @@ import type { ExternalSessionImportIpcResult } from './external-session-import-r
 import type { DesktopSessionSummary } from '../shared/desktop-session-projection.js';
 export type { DesktopSessionSummary } from '../shared/desktop-session-projection.js';
 import type { DesktopConnectionSnapshot } from '../shared/desktop-connection-snapshot.js';
+import type { DesktopExternalSessionCatalogItem } from './external-session-catalog.js';
 import type {
   DesktopDiagnosticCopyResult,
   DesktopErrorDiagnosticInput,
@@ -632,8 +632,11 @@ export interface MakaBridge {
   };
   externalSessions: {
     listSources(host?: DesktopRuntimeHostRef): Promise<{ adapterIds: string[] }>;
-    list(input: { adapterId: string; includeArchived?: boolean; cursor?: string }, host?: DesktopRuntimeHostRef): Promise<{
-      sessions: ExternalSessionSummary[];
+    list(
+      input: { adapterId: string; includeArchived?: boolean; cursor?: string },
+      host?: DesktopRuntimeHostRef,
+    ): Promise<{
+      sessions: DesktopExternalSessionCatalogItem[];
       nextCursor: string | null;
     }>;
     import(input: {

--- a/apps/desktop/src/preload/external-session-catalog.ts
+++ b/apps/desktop/src/preload/external-session-catalog.ts
@@ -1,0 +1,7 @@
+import type { ExternalSessionCatalogItem } from '@maka/runtime-host/protocol';
+
+/** Renderer projection of a Host external Session catalog item. */
+export type DesktopExternalSessionCatalogItem = Omit<ExternalSessionCatalogItem, 'hostCwd'> & {
+  /** Main maps the Host-only path name onto Desktop's existing cwd vocabulary. */
+  readonly cwd: string;
+};

--- a/apps/desktop/src/preload/external-session-catalog.ts
+++ b/apps/desktop/src/preload/external-session-catalog.ts
@@ -1,7 +1,46 @@
 import type { ExternalSessionCatalogItem } from '@maka/runtime-host/protocol';
+import {
+  desktopSessionKey,
+  type DesktopHostRef,
+} from '../shared/runtime-host-identity.js';
 
-/** Renderer projection of a Host external Session catalog item. */
-export type DesktopExternalSessionCatalogItem = Omit<ExternalSessionCatalogItem, 'hostCwd'> & {
+/** Main-process projection before Host-local Session ids enter the preload boundary. */
+export type DesktopHostExternalSessionCatalogItem = Omit<
+  ExternalSessionCatalogItem,
+  'hostCwd'
+> & {
   /** Main maps the Host-only path name onto Desktop's existing cwd vocabulary. */
   readonly cwd: string;
 };
+
+/** Renderer import state whose Session ids are scoped Desktop Session keys. */
+export type DesktopExternalSessionImportState = Omit<
+  ExternalSessionCatalogItem['importState'],
+  'importedSessionIds'
+> & {
+  /** Values produced by desktopSessionKey for the selected Runtime Host. */
+  readonly importedSessionIds: readonly string[];
+};
+
+/** Renderer projection of a Host external Session catalog item. */
+export type DesktopExternalSessionCatalogItem = Omit<
+  DesktopHostExternalSessionCatalogItem,
+  'importState'
+> & {
+  readonly importState: DesktopExternalSessionImportState;
+};
+
+export function projectDesktopExternalSessionCatalogItem(
+  host: DesktopHostRef,
+  item: DesktopHostExternalSessionCatalogItem,
+): DesktopExternalSessionCatalogItem {
+  return {
+    ...item,
+    importState: {
+      ...item.importState,
+      importedSessionIds: item.importState.importedSessionIds.map((sessionId) =>
+        desktopSessionKey({ hostId: host.hostId, sessionId }),
+      ),
+    },
+  };
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -31,7 +31,11 @@ import type {
   DesktopAppInfo,
 } from './bridge-contract.js';
 import type { ExternalSessionImportIpcResult } from './external-session-import-result.js';
-import type { DesktopExternalSessionCatalogItem } from './external-session-catalog.js';
+import {
+  projectDesktopExternalSessionCatalogItem,
+  type DesktopExternalSessionCatalogItem,
+  type DesktopHostExternalSessionCatalogItem,
+} from './external-session-catalog.js';
 import {
   DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
   assertDesktopTranscriptBatch,
@@ -1666,7 +1670,7 @@ const makaBridge = {
     listSources(host?: DesktopRuntimeHostRef): Promise<{ adapterIds: string[] }> {
       return invokeSelectedRuntimeHost(host, 'external-sessions:listSources');
     },
-    list(input: {
+    async list(input: {
       adapterId: string;
       includeArchived?: boolean;
       cursor?: string;
@@ -1674,7 +1678,19 @@ const makaBridge = {
       sessions: DesktopExternalSessionCatalogItem[];
       nextCursor: string | null;
     }> {
-      return invokeSelectedRuntimeHost(host, 'external-sessions:list', input);
+      const scope = await selectedRuntimeHostScope(host);
+      const result = await ipcRenderer.invoke(
+        'external-sessions:list', scope, input,
+      ) as {
+        sessions: DesktopHostExternalSessionCatalogItem[];
+        nextCursor: string | null;
+      };
+      return {
+        ...result,
+        sessions: result.sessions.map((session) =>
+          projectDesktopExternalSessionCatalogItem(scope, session),
+        ),
+      };
     },
     async import(input: {
       adapterId: string;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -31,6 +31,7 @@ import type {
   DesktopAppInfo,
 } from './bridge-contract.js';
 import type { ExternalSessionImportIpcResult } from './external-session-import-result.js';
+import type { DesktopExternalSessionCatalogItem } from './external-session-catalog.js';
 import {
   DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
   assertDesktopTranscriptBatch,
@@ -81,7 +82,6 @@ import type { SearchErrorReason, SearchRequest, SearchResult } from '@maka/core/
 import type { SessionChangedEvent, SessionSummary, TurnRecord } from '@maka/core/session';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import type { E2eFixtureState } from '@maka/core/e2e-fixture';
-import type { ExternalSessionSummary } from '@maka/core/external-session';
 import type {
   GitReviewReadResult,
   GitReviewSource,
@@ -1671,7 +1671,7 @@ const makaBridge = {
       includeArchived?: boolean;
       cursor?: string;
     }, host?: DesktopRuntimeHostRef): Promise<{
-      sessions: ExternalSessionSummary[];
+      sessions: DesktopExternalSessionCatalogItem[];
       nextCursor: string | null;
     }> {
       return invokeSelectedRuntimeHost(host, 'external-sessions:list', input);

--- a/apps/desktop/src/renderer/locales/external-session-import-copy.ts
+++ b/apps/desktop/src/renderer/locales/external-session-import-copy.ts
@@ -25,9 +25,15 @@ type ExternalSessionImportCopy = {
   loadMore: string;
   loadingMore: string;
   duplicateNote: string;
+  importedCount: (count: number) => string;
+  openLatestImportedTask: string;
+  openLatestImportedTaskFor: (name: string) => string;
   import: string;
+  importAgain: string;
   importTask: (name: string) => string;
+  importTaskAgain: (name: string) => string;
   importing: string;
+  importingTask: (name: string) => string;
   importInProgressTitle: string;
   /**
    * Named, for the same reason the unconfirmed banner names its conversations:
@@ -37,6 +43,10 @@ type ExternalSessionImportCopy = {
   importInProgressDescription: (name: string) => string;
   importFailedTitle: string;
   importFailedFallback: string;
+  importRecoveredTitle: string;
+  importRecoveredDescription: (name: string) => string;
+  importNotRecordedTitle: string;
+  importNotRecordedDescription: string;
   importOutcomeUnknownTitle: string;
   /**
    * Takes the conversation names because this is the only place that can say
@@ -69,13 +79,23 @@ const COPY = {
     loadMore: '加载更多',
     loadingMore: '正在加载…',
     duplicateNote: '再次导入同一个对话会创建一个独立的任务。',
+    importedCount: (count) => `已导入 ${count} 次`,
+    openLatestImportedTask: '打开最近导入的任务',
+    openLatestImportedTaskFor: (name) => `打开「${name}」最近导入的任务`,
     import: '导入',
+    importAgain: '再次导入',
     importTask: (name) => `导入「${name}」`,
+    importTaskAgain: (name) => `再次导入「${name}」`,
     importing: '正在导入…',
+    importingTask: (name) => `正在导入「${name}」`,
     importInProgressTitle: '正在导入',
     importInProgressDescription: (name) => `正在导入「${name}」，完成后会直接打开这个任务。`,
     importFailedTitle: '导入失败',
     importFailedFallback: '该对话无法转换或保存。请检查来源后重试。',
+    importRecoveredTitle: '已确认导入',
+    importRecoveredDescription: (name) => `「${name}」导入的任务现已可用。`,
+    importNotRecordedTitle: '没有发现新任务',
+    importNotRecordedDescription: '没有记录到新的任务，可以安全重试。',
     importOutcomeUnknownTitle: '需要确认导入结果',
     importOutcomeUnknownDescription: (names) =>
       `以下对话的导入结果无法确认：${names.map((name) => `「${name}」`).join('、')}。请先在任务列表中查找，已经出现的不要再次导入。`,
@@ -98,14 +118,25 @@ const COPY = {
     loadMore: 'Load more',
     loadingMore: 'Loading…',
     duplicateNote: 'Importing the same conversation again creates an independent task.',
+    importedCount: (count) => (count === 1 ? 'Imported once' : `Imported ${count} times`),
+    openLatestImportedTask: 'Open latest imported task',
+    openLatestImportedTaskFor: (name) => `Open the latest task imported from ${name}`,
     import: 'Import',
+    importAgain: 'Import again',
     importTask: (name) => `Import ${name}`,
+    importTaskAgain: (name) => `Import ${name} again`,
     importing: 'Importing…',
+    importingTask: (name) => `Importing ${name}`,
     importInProgressTitle: 'Import in progress',
     importInProgressDescription: (name) =>
       `Importing “${name}”. Maka opens the task as soon as it lands.`,
     importFailedTitle: 'Import failed',
     importFailedFallback: 'This conversation could not be converted or saved. Check the source and try again.',
+    importRecoveredTitle: 'Import confirmed',
+    importRecoveredDescription: (name) =>
+      `The imported task is available now for “${name}”.`,
+    importNotRecordedTitle: 'No new task found',
+    importNotRecordedDescription: 'No new task was recorded, so it is safe to retry.',
     importOutcomeUnknownTitle: 'Check the import result',
     importOutcomeUnknownDescription: (names) =>
       `Maka could not confirm the outcome of these imports: ${names.map((name) => `“${name}”`).join(', ')}. Look in the task list first, and do not import again anything that is already there.`,

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -216,6 +216,7 @@ export function ImportTasksSettingsPage(props: {
       else {
         setCatalogLoading(true);
         setCatalog(EMPTY_CATALOG);
+        setImportRecovery(null);
       }
       setCatalogError(null);
       setImportError(null);
@@ -352,9 +353,8 @@ export function ImportTasksSettingsPage(props: {
               entry.sourceSessionId !== attempt.sourceSessionId,
           ),
         );
-        const recoveredSessionId = recoveredSource?.importState.importedSessionIds[0];
+        const recoveredSessionId = recoveredSource.importState.importedSessionIds[0];
         const landed =
-          recoveredSource !== undefined &&
           recoveredSessionId !== undefined &&
           (recoveredSource.importState.importedCount > attempt.importedCountBefore ||
             recoveredSessionId !== attempt.latestImportedSessionIdBefore);

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -7,21 +7,70 @@ import { List, ListItem } from '@astryxdesign/core/List';
 import { SegmentedControl, SegmentedControlItem } from '@astryxdesign/core/SegmentedControl';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { uiLocaleToIntlLocale } from '@maka/core/ui-locale';
-import type { ExternalSessionSummary } from '@maka/core/external-session';
-import type { DesktopSessionSummary } from '../../preload/bridge-contract.js';
+import type {
+  DesktopRuntimeHostRef,
+  DesktopSessionSummary,
+} from '../../preload/bridge-contract.js';
 import { Spinner, useMountedRef, useUiLocale } from '@maka/ui';
 import { ICON_SIZE, MessageSquare } from '@maka/ui/icons';
 import { getExternalSessionImportCopy } from '../locales/external-session-import-copy.js';
 import { localizedShellErrorMessage } from '../locales/shell-copy.js';
-import { SettingsPage, SettingsSection } from './settings-section';
+import type { DesktopExternalSessionCatalogItem } from '../../preload/external-session-catalog.js';
+import { SettingsPage, SettingsSection } from './settings-section.js';
 import { useRuntimeHostSettingsTarget } from './runtime-host-settings-target.js';
 
 type CatalogState = {
-  sessions: ExternalSessionSummary[];
+  sessions: DesktopExternalSessionCatalogItem[];
   nextCursor: string | null;
 };
 
 const EMPTY_CATALOG: CatalogState = { sessions: [], nextCursor: null };
+const EXTERNAL_SESSION_IMPORT_POLL_MS = 1_000;
+
+type CatalogWindow = CatalogState & {
+  targetSource: DesktopExternalSessionCatalogItem | undefined;
+};
+
+async function readCatalogWindow(input: {
+  adapterId: string;
+  includeArchived: boolean;
+  minimumItemCount: number;
+  targetSourceSessionId?: string;
+  host?: DesktopRuntimeHostRef;
+  isCurrent(): boolean;
+}): Promise<CatalogWindow | undefined> {
+  const sessions: DesktopExternalSessionCatalogItem[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  let targetSource: DesktopExternalSessionCatalogItem | undefined;
+
+  do {
+    const result = await window.maka.externalSessions.list(
+      {
+        adapterId: input.adapterId,
+        includeArchived: input.includeArchived,
+        ...(cursor === undefined ? {} : { cursor }),
+      },
+      input.host,
+    );
+    if (!input.isCurrent()) return undefined;
+    sessions.push(...result.sessions);
+    targetSource ??= result.sessions.find(
+      (session) => session.id === input.targetSourceSessionId,
+    );
+    const loadedWindowComplete = sessions.length >= input.minimumItemCount;
+    const targetSearchComplete =
+      input.targetSourceSessionId === undefined || targetSource !== undefined;
+    if (result.nextCursor === null || (loadedWindowComplete && targetSearchComplete)) {
+      return { sessions, nextCursor: result.nextCursor, targetSource };
+    }
+    if (seenCursors.has(result.nextCursor)) {
+      throw new Error('External Session catalog repeated a cursor');
+    }
+    seenCursors.add(result.nextCursor);
+    cursor = result.nextCursor;
+  } while (true);
+}
 
 /**
  * One conversation this page has handed to Desktop Main.
@@ -37,12 +86,21 @@ type ImportAttempt = {
   adapterId: string;
   sourceSessionId: string;
   name: string;
+  includeArchived: boolean;
+  importedCountBefore: number;
+  latestImportedSessionIdBefore: string | undefined;
+  loadedCatalogItemCountBefore: number;
+  catalogSelectionGeneration: number;
 };
+
+type ImportRecovery =
+  | { kind: 'landed'; attempt: ImportAttempt; importedSessionId: string }
+  | { kind: 'not_recorded'; attempt: ImportAttempt };
 
 function isSameAttempt(
   attempt: ImportAttempt,
   adapterId: string | null,
-  session: ExternalSessionSummary,
+  session: DesktopExternalSessionCatalogItem,
 ): boolean {
   return attempt.adapterId === adapterId && attempt.sourceSessionId === session.id;
 }
@@ -61,7 +119,7 @@ function isSameAttempt(
  *
  * Reading the source directory is Desktop Main's job, so this page holds no
  * session state of its own: it lists through `window.maka.externalSessions` and
- * hands the imported `SessionSummary` back to the shell, which is what owns
+ * hands the imported `DesktopSessionSummary` back to the shell, which is what owns
  * navigating to it.
  *
  * Deliberately NOT here: keeping an imported task in sync with its source.
@@ -72,6 +130,8 @@ function isSameAttempt(
 export function ImportTasksSettingsPage(props: {
   /** Hands the freshly imported task to the shell, which opens it. */
   onImported(session: DesktopSessionSummary): void;
+  /** Opens the newest still-existing task previously imported from a row. */
+  onOpenImported?(sessionId: string): void;
 }) {
   const host = useRuntimeHostSettingsTarget();
   const locale = useUiLocale();
@@ -95,16 +155,32 @@ export function ImportTasksSettingsPage(props: {
   const [sourceError, setSourceError] = useState<string | null>(null);
   const [catalogError, setCatalogError] = useState<string | null>(null);
   const [importError, setImportError] = useState<string | null>(null);
+  const [importRecovery, setImportRecovery] = useState<ImportRecovery | null>(null);
+  const [recoveryLoading, setRecoveryLoading] = useState(false);
+  const [catalogPollTick, setCatalogPollTick] = useState(0);
   /**
    * Re-importing a conversation whose outcome is unknown is how you end up with
-   * two copies of it, so its row stays disabled for the rest of this page's
-   * lifetime and the banner names it as the one to go look for.
+   * two copies of it, so its row stays disabled only while the authoritative
+   * catalog recovery itself is unavailable. A successful recovery removes the
+   * local lock and either exposes the landed task or allows a safe retry.
    */
   const [uncertainImports, setUncertainImports] = useState<readonly ImportAttempt[]>([]);
   // Only the newest list request may write. Switching source or toggling the
   // archived filter while a page is in flight would otherwise land the old
   // source's rows under the new source's label.
   const requestGeneration = useRef(0);
+  const recoveryGeneration = useRef(0);
+  const catalogSelectionRef = useRef({ adapterId, includeArchived, generation: 0 });
+  if (
+    catalogSelectionRef.current.adapterId !== adapterId ||
+    catalogSelectionRef.current.includeArchived !== includeArchived
+  ) {
+    catalogSelectionRef.current = {
+      adapterId,
+      includeArchived,
+      generation: catalogSelectionRef.current.generation + 1,
+    };
+  }
 
   const loadSources = useCallback(async () => {
     const generation = ++requestGeneration.current;
@@ -167,6 +243,26 @@ export function ImportTasksSettingsPage(props: {
     [copy.loadFailedFallback, host, includeArchived, locale],
   );
 
+  const refreshLoadedCatalog = useCallback(
+    async (sourceId: string, loadedItemCount: number) => {
+      const generation = ++requestGeneration.current;
+      try {
+        const result = await readCatalogWindow({
+          adapterId: sourceId,
+          includeArchived,
+          minimumItemCount: loadedItemCount,
+          host,
+          isCurrent: () => mountedRef.current && generation === requestGeneration.current,
+        });
+        if (result !== undefined) setCatalog(result);
+      } catch {
+        // Catalog polling is best-effort. Keep the last authoritative page
+        // visible and retry rather than replacing it with a transient error.
+      }
+    },
+    [host, includeArchived, mountedRef],
+  );
+
   useEffect(() => {
     void loadSources();
   }, [loadSources]);
@@ -175,6 +271,37 @@ export function ImportTasksSettingsPage(props: {
     if (adapterId === null) return;
     void loadCatalog(adapterId);
   }, [adapterId, includeArchived, loadCatalog]);
+
+  const hasCatalogImportInFlight = catalog.sessions.some(
+    (session) => session.importState.isImporting,
+  );
+  useEffect(() => {
+    if (
+      adapterId === null ||
+      activeImport !== null ||
+      catalogLoading ||
+      loadingMore ||
+      !hasCatalogImportInFlight
+    ) {
+      return;
+    }
+    const timeout = setTimeout(() => {
+      void refreshLoadedCatalog(adapterId, catalog.sessions.length).finally(() => {
+        if (mountedRef.current) setCatalogPollTick((tick) => tick + 1);
+      });
+    }, EXTERNAL_SESSION_IMPORT_POLL_MS);
+    return () => clearTimeout(timeout);
+  }, [
+    activeImport,
+    adapterId,
+    catalog.sessions.length,
+    catalogPollTick,
+    catalogLoading,
+    hasCatalogImportInFlight,
+    loadingMore,
+    mountedRef,
+    refreshLoadedCatalog,
+  ]);
 
   const dateFormatter = useMemo(
     () =>
@@ -185,16 +312,93 @@ export function ImportTasksSettingsPage(props: {
     [locale],
   );
 
+  const recoverUnknownImport = useCallback(
+    async (attempt: ImportAttempt) => {
+      const generation = ++recoveryGeneration.current;
+      setRecoveryLoading(true);
+      try {
+        const result = await readCatalogWindow({
+          adapterId: attempt.adapterId,
+          includeArchived: attempt.includeArchived,
+          minimumItemCount: attempt.loadedCatalogItemCountBefore,
+          targetSourceSessionId: attempt.sourceSessionId,
+          host,
+          isCurrent: () => mountedRef.current && generation === recoveryGeneration.current,
+        });
+        if (result === undefined) return;
+        const recoveredSource = result.targetSource;
+        if (recoveredSource === undefined) {
+          throw new Error('External Session source disappeared during import recovery');
+        }
+
+        const currentSelection = catalogSelectionRef.current;
+        if (
+          currentSelection.adapterId === attempt.adapterId &&
+          currentSelection.includeArchived === attempt.includeArchived &&
+          currentSelection.generation === attempt.catalogSelectionGeneration
+        ) {
+          // Recovery is the newest authoritative read for this exact catalog
+          // selection. Retire an older poll/load-more response before publishing
+          // it so that response cannot put pre-import state back on screen.
+          requestGeneration.current += 1;
+          setCatalogLoading(false);
+          setLoadingMore(false);
+          setCatalog(result);
+        }
+        setUncertainImports((current) =>
+          current.filter(
+            (entry) =>
+              entry.adapterId !== attempt.adapterId ||
+              entry.sourceSessionId !== attempt.sourceSessionId,
+          ),
+        );
+        const recoveredSessionId = recoveredSource?.importState.importedSessionIds[0];
+        const landed =
+          recoveredSource !== undefined &&
+          recoveredSessionId !== undefined &&
+          (recoveredSource.importState.importedCount > attempt.importedCountBefore ||
+            recoveredSessionId !== attempt.latestImportedSessionIdBefore);
+        setImportRecovery(
+          landed
+            ? { kind: 'landed', attempt, importedSessionId: recoveredSessionId }
+            : { kind: 'not_recorded', attempt },
+        );
+      } catch (error) {
+        if (!mountedRef.current || generation !== recoveryGeneration.current) return;
+        setUncertainImports((current) =>
+          current.some(
+            (entry) =>
+              entry.adapterId === attempt.adapterId &&
+              entry.sourceSessionId === attempt.sourceSessionId,
+          )
+            ? current
+            : [...current, attempt],
+        );
+      } finally {
+        if (mountedRef.current && generation === recoveryGeneration.current) {
+          setRecoveryLoading(false);
+        }
+      }
+    },
+    [host, mountedRef],
+  );
+
   const importConversation = useCallback(
-    async (session: ExternalSessionSummary) => {
+    async (session: DesktopExternalSessionCatalogItem) => {
       if (adapterId === null || activeImport !== null) return;
       const attempt: ImportAttempt = {
         adapterId,
         sourceSessionId: session.id,
         name: session.name,
+        includeArchived,
+        importedCountBefore: session.importState.importedCount,
+        latestImportedSessionIdBefore: session.importState.importedSessionIds[0],
+        loadedCatalogItemCountBefore: catalog.sessions.length,
+        catalogSelectionGeneration: catalogSelectionRef.current.generation,
       };
       setActiveImport(attempt);
       setImportError(null);
+      setImportRecovery(null);
       try {
         const outcome = await window.maka.externalSessions.import({
           adapterId: attempt.adapterId,
@@ -206,7 +410,7 @@ export function ImportTasksSettingsPage(props: {
         // the user has left steering the shell somewhere they did not ask for.
         if (!mountedRef.current) return;
         if (!outcome.ok) {
-          setUncertainImports((current) => [...current, attempt]);
+          await recoverUnknownImport(attempt);
           return;
         }
         props.onImported(outcome.session);
@@ -217,7 +421,18 @@ export function ImportTasksSettingsPage(props: {
         if (mountedRef.current) setActiveImport(null);
       }
     },
-    [activeImport, adapterId, copy.importFailedFallback, host, locale, mountedRef, props],
+    [
+      activeImport,
+      adapterId,
+      catalog.sessions.length,
+      copy.importFailedFallback,
+      host,
+      locale,
+      mountedRef,
+      props,
+      recoverUnknownImport,
+      includeArchived,
+    ],
   );
 
   const noSource = sourceResolved && !sourceLoading && !sourceError && adapterIds.length === 0;
@@ -346,6 +561,42 @@ export function ImportTasksSettingsPage(props: {
               description={copy.importOutcomeUnknownDescription(
                 uncertainImports.map((entry) => entry.name),
               )}
+              endContent={
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  label={copy.retry}
+                  isLoading={recoveryLoading}
+                  isDisabled={recoveryLoading}
+                  onClick={() => void recoverUnknownImport(uncertainImports[0]!)}
+                />
+              }
+            />
+          )}
+
+          {importRecovery?.kind === 'landed' && (
+            <Banner
+              status="success"
+              title={copy.importRecoveredTitle}
+              description={copy.importRecoveredDescription(importRecovery.attempt.name)}
+              endContent={
+                props.onOpenImported ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    label={copy.openLatestImportedTask}
+                    onClick={() => props.onOpenImported?.(importRecovery.importedSessionId)}
+                  />
+                ) : undefined
+              }
+            />
+          )}
+
+          {importRecovery?.kind === 'not_recorded' && (
+            <Banner
+              status="info"
+              title={copy.importNotRecordedTitle}
+              description={copy.importNotRecordedDescription}
             />
           )}
 
@@ -375,11 +626,17 @@ export function ImportTasksSettingsPage(props: {
                   session.cwd,
                   timestamp !== undefined ? dateFormatter.format(timestamp) : null,
                   session.archived ? copy.archived : null,
+                  session.importState.importedCount > 0
+                    ? copy.importedCount(session.importState.importedCount)
+                    : null,
                 ]
                   .filter(Boolean)
                   .join(' · ');
                 const isImporting =
-                  activeImport !== null && isSameAttempt(activeImport, adapterId, session);
+                  session.importState.isImporting ||
+                  (activeImport !== null && isSameAttempt(activeImport, adapterId, session));
+                const latestImportedSessionId = session.importState.importedSessionIds[0];
+                const hasImported = session.importState.importedCount > 0;
                 return (
                   <ListItem
                     key={session.id}
@@ -387,30 +644,48 @@ export function ImportTasksSettingsPage(props: {
                     description={description.length > 0 ? description : undefined}
                     startContent={<MessageSquare size={ICON_SIZE.control} aria-hidden="true" />}
                     endContent={
-                      <Button
-                        variant="secondary"
-                        size="sm"
-                        isLoading={isImporting}
-                        isDisabled={
-                          activeImport !== null ||
-                          uncertainImports.some((entry) =>
-                            isSameAttempt(entry, adapterId, session),
-                          )
-                        }
-                        // `onClick`, not `clickAction`. Astryx runs
-                        // `clickAction` inside a React 19 async transition, and
-                        // React holds a transition's state updates until the
-                        // action settles, so `setActiveImport` landed only once
-                        // the import was already over and nothing on the page
-                        // could tell that one was running. `clickAction` buys
-                        // the clicked button its own pending state, and that is
-                        // all it buys; this is a page fact, so the page owns it.
-                        onClick={() => void importConversation(session)}
-                        label={isImporting ? copy.importing : copy.import}
-                        // Every row's button reads 导入; only the accessible
-                        // name can say which conversation it imports.
-                        aria-label={copy.importTask(session.name)}
-                      />
+                      <HStack gap={2} vAlign="center">
+                        {latestImportedSessionId !== undefined && props.onOpenImported && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            label={copy.openLatestImportedTask}
+                            aria-label={copy.openLatestImportedTaskFor(session.name)}
+                            onClick={() => props.onOpenImported?.(latestImportedSessionId)}
+                          />
+                        )}
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          isLoading={isImporting}
+                          isDisabled={
+                            isImporting ||
+                            activeImport !== null ||
+                            uncertainImports.length > 0
+                          }
+                          // `onClick`, not `clickAction`. Astryx runs
+                          // `clickAction` inside a React 19 async transition, and
+                          // React holds a transition's state updates until the
+                          // action settles, so `setActiveImport` landed only once
+                          // the import was already over and nothing on the page
+                          // could tell that one was running. `clickAction` buys
+                          // the clicked button its own pending state, and that is
+                          // all it buys; this is a page fact, so the page owns it.
+                          onClick={() => void importConversation(session)}
+                          // Every row's button reads 导入; its purpose-specific
+                          // label supplies the accessible name while `children`
+                          // keeps the compact visible copy.
+                          label={
+                            isImporting
+                              ? copy.importingTask(session.name)
+                              : hasImported
+                              ? copy.importTaskAgain(session.name)
+                              : copy.importTask(session.name)
+                          }
+                        >
+                          {isImporting ? copy.importing : hasImported ? copy.importAgain : copy.import}
+                        </Button>
+                      </HStack>
                     }
                   />
                 );

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -900,7 +900,12 @@ function SettingsPageBody(props: {
     case 'archived-tasks':
       return <TasksSettingsPage {...props.archivedTasks} />;
     case 'import-tasks':
-      return <ImportTasksSettingsPage onImported={props.onTaskImported} />;
+      return (
+        <ImportTasksSettingsPage
+          onImported={props.onTaskImported}
+          onOpenImported={props.onOpenSession}
+        />
+      );
     case 'data':
       return (
         <DataSettingsPage

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -18,7 +18,7 @@ import type {
   PermissionSnapshot,
 } from '@maka/core/capabilities';
 import type { HealthSignal, HealthSnapshot } from '@maka/core/health';
-import type { ExternalSessionSummary } from '@maka/core/external-session';
+import type { DesktopExternalSessionCatalogItem } from '../../src/preload/external-session-catalog';
 import type { SessionSummary } from '@maka/core/session';
 import { revisionFamilySessionIds } from '@maka/core/session-revisions';
 import type { LlmConnection, ProviderType } from '@maka/core/llm-connections';
@@ -721,7 +721,7 @@ const makaBridge = {
         nextCursor: end < visible.length ? EXTERNAL_SECOND_PAGE : null,
       };
     },
-    import: async () => ({ ok: false as const }),
+    import: async () => ({ ok: false as const, reason: 'commit_outcome_unknown' as const }),
   },
   // Appearance mounts CustomPetSettingsSection, which reads and subscribes on
   // window.maka.pets. Without this fixture the catalog story throws on mount
@@ -814,24 +814,31 @@ const archivedTaskSessions: SessionSummary[] = [
 const EXTERNAL_PAGE_SIZE = 2;
 const EXTERNAL_SECOND_PAGE = 'page-2';
 
-const externalConversations: ExternalSessionSummary[] = [
+const externalConversations: DesktopExternalSessionCatalogItem[] = [
   {
     id: 'codex-01930f',
     name: 'Trace the flaky worktree teardown in CI',
     cwd: '/Users/storybook-fixture-user/workspace/maka-agent',
     updatedAt: Date.now() - 42 * 60 * 1000,
+    importState: {
+      importedCount: 2,
+      importedSessionIds: ['imported-task-newest', 'imported-task-older'],
+      isImporting: false,
+    },
   },
   {
     id: 'codex-01930e',
     name: '把 provider catalog 的分页改成游标',
     cwd: '/Users/storybook-fixture-user/workspace/maka-agent',
     updatedAt: Date.now() - 3 * 60 * 60 * 1000,
+    importState: { importedCount: 1, importedSessionIds: ['imported-task-1'], isImporting: true },
   },
   {
     id: 'codex-01930a',
     name: 'Reproduce the SQLite lock contention under parallel evals',
     cwd: '/Users/storybook-fixture-user/workspace/maka-agent',
     updatedAt: Date.now() - 2 * 24 * 60 * 60 * 1000,
+    importState: { importedCount: 0, importedSessionIds: [], isImporting: false },
   },
   {
     id: 'codex-01929c',
@@ -839,6 +846,7 @@ const externalConversations: ExternalSessionSummary[] = [
     cwd: '/Users/storybook-fixture-user/workspace/docs',
     updatedAt: Date.now() - 6 * 24 * 60 * 60 * 1000,
     archived: true,
+    importState: { importedCount: 1, importedSessionIds: ['imported-archived'], isImporting: false },
   },
 ];
 
@@ -1369,6 +1377,56 @@ export const ArchivedTasks: Story = {
 export const ImportTasks: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="import-tasks" />,
+};
+
+function importOutcomeRecoveryBridge(): Record<string, unknown> {
+  let importAttempted = false;
+  const source = externalConversations[2];
+  return {
+    ...makaBridge,
+    externalSessions: {
+      ...makaBridge.externalSessions,
+      list: async () => ({
+        sessions: [
+          importAttempted
+            ? {
+                ...source,
+                importState: {
+                  importedCount: 1,
+                  importedSessionIds: ['outcome-recovered-task'],
+                  isImporting: false,
+                },
+              }
+            : source,
+        ],
+        nextCursor: null,
+      }),
+      import: async () => {
+        importAttempted = true;
+        return { ok: false as const, reason: 'commit_outcome_unknown' as const };
+      },
+    },
+  };
+}
+
+// The import response is deliberately unknown; the next authoritative catalog
+// read proves that the task landed and turns the banner into a usable entry.
+// Real path: 设置 → 导入任务 → 导入, when Main reports an unknown commit outcome that catalog recovery confirms.
+export const ImportTasksOutcomeUnknownRecovered: Story = {
+  decorators: [withScopedMakaBridge(importOutcomeRecoveryBridge())],
+  render: () => <SettingsStory section="import-tasks" />,
+  play: async ({ canvasElement }) => {
+    const importButton = await waitForStoryButton(canvasElement, (candidate) =>
+      ['导入', 'Import'].includes(candidate.textContent?.trim() ?? ''),
+    );
+    await userEvent.click(importButton);
+    await waitForStoryCondition(
+      () =>
+        canvasElement.textContent?.includes('已确认导入') === true ||
+        canvasElement.textContent?.includes('Import confirmed') === true,
+      'Unknown-outcome recovery did not expose the imported task',
+    );
+  },
 };
 
 // Real path: the same page on a machine with no supported agent — the common

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -180,6 +180,11 @@ export function isSessionToolProfile(value: unknown): value is SessionToolProfil
   return typeof value === 'string' && (SESSION_TOOL_PROFILES as readonly string[]).includes(value);
 }
 
+export interface SessionExternalOrigin {
+  readonly adapterId: string;
+  readonly sourceSessionId: string;
+}
+
 export interface SessionHeader {
   // Identity
   id: string;
@@ -216,6 +221,8 @@ export interface SessionHeader {
   subagentWorkspace?: SubagentWorkspaceBinding;
   /** Immutable Host publication identity for a cross-Session conversation copy. */
   conversationCopy?: SessionConversationCopy;
+  /** Immutable identity of the external Session imported into this Session. */
+  readonly externalOrigin?: SessionExternalOrigin;
   /** Stable root id for an edit-and-resend version family. */
   revisionRootSessionId?: string;
   /** Immediate previous version in the same conversation slot. */

--- a/packages/runtime-host/src/__tests__/external-session-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-coordinator.test.ts
@@ -4,10 +4,13 @@ import {
   ExternalSessionAdapterRegistry,
   type ExternalSessionAdapter,
 } from '@maka/core/external-session';
-import { type SessionHeader, type StoredMessage } from '@maka/core/session';
+import { type SessionHeader } from '@maka/core/session';
 import { headerToSummary } from '@maka/runtime/session-manager';
 import type { SessionCatalogRecord } from '@maka/storage/execution-stores';
-import { EXTERNAL_SESSION_RESULT_MAX_BYTES } from '../protocol/index.js';
+import {
+  EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS,
+  EXTERNAL_SESSION_RESULT_MAX_BYTES,
+} from '../protocol/index.js';
 import type { ConnectionContext } from '../server/operation-dispatcher.js';
 import { HostExternalSessionCoordinator } from '../server/external-session-coordinator.js';
 import { SessionAdmissionGate } from '../server/session-admission-gate.js';
@@ -72,6 +75,114 @@ test('resolves a Project filter before calling the Host adapter', async () => {
   assert.deepEqual(filters, [{ cwd: '/resolved-project', includeArchived: true }]);
 });
 
+test('projects zero import state for never-imported source Sessions with one batch lookup', async () => {
+  const fixture = coordinatorFixture([adapterFixture({ count: 2 })]);
+
+  const outcome = await fixture.coordinator.handlers['external-session.catalog.query'](
+    { adapterId: 'codex' },
+    context,
+  );
+
+  assert.equal(outcome.ok, true);
+  if (!outcome.ok) assert.fail('Expected the external Session catalog');
+  assert.deepEqual(
+    outcome.result.sessions.map(({ importState }) => importState),
+    [
+      { importedCount: 0, importedSessionIds: [], isImporting: false },
+      { importedCount: 0, importedSessionIds: [], isImporting: false },
+    ],
+  );
+  assert.deepEqual(fixture.lookupCalls, [
+    {
+      adapterId: 'codex',
+      sourceSessionIds: ['source-0', 'source-1'],
+      recentSessionIdLimit: EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS,
+    },
+  ]);
+});
+
+test('projects the complete durable import count and newest eight imported Session ids', async () => {
+  const importedSessionIds = Array.from({ length: 8 }, (_, index) => `imported-${12 - index}`);
+  const fixture = coordinatorFixture([adapterFixture()], {
+    lookupExternalSessionImports: async () => [
+      {
+        sourceSessionId: 'source-0',
+        livePublishedImportCount: 12,
+        recentSessionIds: importedSessionIds,
+      },
+    ],
+  });
+
+  const outcome = await fixture.coordinator.handlers['external-session.catalog.query'](
+    { adapterId: 'codex' },
+    context,
+  );
+
+  assert.equal(outcome.ok, true);
+  if (!outcome.ok) assert.fail('Expected the external Session catalog');
+  assert.deepEqual(outcome.result.sessions[0]?.importState, {
+    importedCount: 12,
+    importedSessionIds,
+    isImporting: false,
+  });
+});
+
+test('reports an unresolved import independently from durable import history', async () => {
+  let markReadStarted!: () => void;
+  const readStarted = new Promise<void>((resolve) => {
+    markReadStarted = resolve;
+  });
+  let releaseRead!: () => void;
+  const readRelease = new Promise<void>((resolve) => {
+    releaseRead = resolve;
+  });
+  const fixture = coordinatorFixture(
+    [
+      adapterFixture({
+        readSession: async (sourceSessionId) => {
+          markReadStarted();
+          await readRelease;
+          return {
+            sourceSessionId,
+            metadata: { name: 'Source 0', cwd: '/external' },
+            messages: [],
+          };
+        },
+      }),
+    ],
+    {
+      lookupExternalSessionImports: async () => [
+        {
+          sourceSessionId: 'source-0',
+          livePublishedImportCount: 2,
+          recentSessionIds: ['imported-2', 'imported-1'],
+        },
+      ],
+    },
+  );
+
+  const importing = fixture.coordinator.handlers['external-session.import'](
+    { adapterId: 'codex', sourceSessionId: 'source-0' },
+    context,
+  );
+  await readStarted;
+  const catalog = await fixture.coordinator.handlers['external-session.catalog.query'](
+    { adapterId: 'codex' },
+    context,
+  );
+
+  assert.equal(catalog.ok, true);
+  if (!catalog.ok) assert.fail('Expected the external Session catalog');
+  assert.deepEqual(catalog.result.sessions[0]?.importState, {
+    importedCount: 2,
+    importedSessionIds: ['imported-2', 'imported-1'],
+    isImporting: true,
+  });
+
+  releaseRead();
+  assert.equal((await importing).ok, true);
+});
+
 test('stops catalog pages before the encoded result limit', async () => {
   const adapter = adapterFixture({ count: 20 });
   adapter.listSessions = async () =>
@@ -80,7 +191,17 @@ test('stops catalog pages before the encoded result limit', async () => {
       name: `Source ${index}`,
       cwd: `/${'\u0000'.repeat(4_000)}`,
     }));
-  const fixture = coordinatorFixture([adapter]);
+  const fixture = coordinatorFixture([adapter], {
+    lookupExternalSessionImports: async (_adapterId, sourceSessionIds) =>
+      sourceSessionIds.map((sourceSessionId) => ({
+        sourceSessionId,
+        livePublishedImportCount: 8,
+        recentSessionIds: Array.from(
+          { length: 8 },
+          (_, index) => `${sourceSessionId}-${index}-${'x'.repeat(100)}`,
+        ),
+      })),
+  });
 
   const outcome = await fixture.coordinator.handlers['external-session.catalog.query'](
     { adapterId: 'codex' },
@@ -91,10 +212,12 @@ test('stops catalog pages before the encoded result limit', async () => {
   if (!outcome.ok) assert.fail('Expected a bounded catalog page');
   assert.ok(outcome.result.sessions.length > 0);
   assert.ok(outcome.result.sessions.length < 16);
-  assert.ok(outcome.result.nextCursor);
+  assert.equal(outcome.result.nextCursor, String(outcome.result.sessions.length));
   assert.ok(
     Buffer.byteLength(JSON.stringify(outcome.result), 'utf8') <= EXTERNAL_SESSION_RESULT_MAX_BYTES,
   );
+  assert.equal(fixture.lookupCalls.length, 1);
+  assert.equal(fixture.lookupCalls[0]?.sourceSessionIds.length, 16);
 });
 
 test('imports through the generic importer and treats repeats as independent copies', async () => {
@@ -114,15 +237,28 @@ test('imports through the generic importer and treats repeats as independent cop
   if (!first.ok || !second.ok) assert.fail('Expected both imports to commit');
   assert.notEqual(first.result.session.id, second.result.session.id);
   assert.deepEqual(
-    fixture.creates.map(({ input, messages }) => ({
+    fixture.creates.map(({ input, messages, externalOrigin }) => ({
       cwd: input.cwd,
       name: input.name,
       backend: input.backend,
       messageTypes: messages.map(({ type }) => type),
+      externalOrigin,
     })),
     [
-      { cwd: '/external', name: 'Source 0', backend: 'ai-sdk', messageTypes: ['user'] },
-      { cwd: '/external', name: 'Source 0', backend: 'ai-sdk', messageTypes: ['user'] },
+      {
+        cwd: '/external',
+        name: 'Source 0',
+        backend: 'ai-sdk',
+        messageTypes: ['user'],
+        externalOrigin: { adapterId: 'codex', sourceSessionId: 'source-0' },
+      },
+      {
+        cwd: '/external',
+        name: 'Source 0',
+        backend: 'ai-sdk',
+        messageTypes: ['user'],
+        externalOrigin: { adapterId: 'codex', sourceSessionId: 'source-0' },
+      },
     ],
   );
   assert.equal(fixture.drainRequests(), 0);
@@ -313,14 +449,12 @@ test('recovers or discards staged imported Sessions after restart', async () => 
 
 function coordinatorFixture(
   adapters: readonly ExternalSessionAdapter[],
-  storeOverrides: Partial<{
-    createImportedSession(
-      input: Parameters<HostStore['createImportedSession']>[0],
-      messages: readonly StoredMessage[],
-    ): Promise<SessionHeader>;
-    prepareImportedSessionHistory(sessionId: string): Promise<void>;
-    discardImportedSession(sessionId: string): Promise<void>;
-  }> = {},
+  storeOverrides: Partial<
+    Pick<HostStore, 'createImportedSession' | 'lookupExternalSessionImports'> & {
+      prepareImportedSessionHistory(sessionId: string): Promise<void>;
+      discardImportedSession(sessionId: string): Promise<void>;
+    }
+  > = {},
 ) {
   let sequence = 0;
   let drains = 0;
@@ -328,15 +462,25 @@ function coordinatorFixture(
   const records = new Map<string, SessionCatalogRecord>();
   const creates: Array<{
     input: Parameters<HostStore['createImportedSession']>[0];
-    messages: readonly StoredMessage[];
+    messages: Parameters<HostStore['createImportedSession']>[1];
+    externalOrigin: Parameters<HostStore['createImportedSession']>[2];
   }> = [];
-  const defaultCreate: HostStore['createImportedSession'] = async (input, messages) => {
+  const lookupCalls: Array<{
+    adapterId: string;
+    sourceSessionIds: readonly string[];
+    recentSessionIdLimit: number;
+  }> = [];
+  const defaultCreate: HostStore['createImportedSession'] = async (
+    input,
+    messages,
+    externalOrigin,
+  ) => {
     sequence += 1;
     const header = {
       ...sessionHeader(`imported-${sequence}`, input.cwd, input.name ?? 'Imported'),
       transcriptLedgerVersion: 0 as const,
     };
-    creates.push({ input, messages });
+    creates.push({ input, messages, externalOrigin });
     records.set(header.id, {
       header,
       revision: 1,
@@ -347,6 +491,16 @@ function coordinatorFixture(
   };
   const store: HostStore = {
     createImportedSession: storeOverrides.createImportedSession ?? defaultCreate,
+    lookupExternalSessionImports: async (adapterId, sourceSessionIds, recentSessionIdLimit) => {
+      lookupCalls.push({ adapterId, sourceSessionIds, recentSessionIdLimit });
+      return (
+        storeOverrides.lookupExternalSessionImports?.(
+          adapterId,
+          sourceSessionIds,
+          recentSessionIdLimit,
+        ) ?? []
+      );
+    },
     listHeaders: async () => [...records.values()].map((record) => record.header),
     readCatalogRecord: async (sessionId) => {
       const record = records.get(sessionId);
@@ -407,6 +561,7 @@ function coordinatorFixture(
       },
     }),
     creates,
+    lookupCalls,
     admission,
     seedStagingSession: () =>
       defaultCreate(
@@ -418,6 +573,7 @@ function coordinatorFixture(
           permissionMode: 'ask',
         },
         [],
+        { adapterId: 'codex', sourceSessionId: 'source-0' },
       ),
     readHeader: (sessionId: string) => records.get(sessionId)?.header,
     hasRecord: (sessionId: string) => records.has(sessionId),

--- a/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
@@ -173,6 +173,30 @@ describe('external Session protocol', () => {
     );
   });
 
+  test('rejects sparse imported Session id arrays', () => {
+    const importedSessionIds = Array<string>(1);
+
+    assert.throws(
+      () =>
+        decodeExternalSessionCatalogQueryResult({
+          sessions: [
+            {
+              id: 'source-1',
+              name: 'Imported source',
+              hostCwd: '/workspace',
+              importState: {
+                importedCount: 1,
+                importedSessionIds,
+                isImporting: false,
+              },
+            },
+          ],
+          nextCursor: null,
+        }),
+      isProtocolError,
+    );
+  });
+
   test('rejects open-ended, malformed, and oversized frames', () => {
     assert.throws(
       () =>

--- a/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
@@ -5,6 +5,7 @@ import {
   decodeClientFrame,
   decodeExternalSessionCatalogQueryResult,
   decodeExternalSessionSourceQueryResult,
+  EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS,
   EXTERNAL_SESSION_PAGE_MAX_ITEMS,
   HOST_OPERATION_SPECS,
 } from '../protocol/index.js';
@@ -76,6 +77,102 @@ describe('external Session protocol', () => {
     );
   });
 
+  test('round-trips required external Session import state', () => {
+    const result = {
+      sessions: [
+        {
+          id: 'source-1',
+          name: 'Imported source',
+          hostCwd: '/workspace',
+          importState: {
+            importedCount: 10,
+            importedSessionIds: Array.from(
+              { length: EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS },
+              (_, index) => `imported-${EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS - index}`,
+            ),
+            isImporting: true,
+          },
+        },
+      ],
+      nextCursor: null,
+    };
+
+    assert.deepEqual(decodeExternalSessionCatalogQueryResult(result), result);
+  });
+
+  test('rejects missing, open, malformed, and inconsistent external Session import state', () => {
+    const summary = {
+      id: 'source-1',
+      name: 'Imported source',
+      hostCwd: '/workspace',
+    };
+    const decodeState = (importState?: unknown) =>
+      decodeExternalSessionCatalogQueryResult({
+        sessions: [{ ...summary, ...(importState === undefined ? {} : { importState }) }],
+        nextCursor: null,
+      });
+
+    assert.throws(() => decodeState(), isProtocolError);
+    assert.throws(
+      () =>
+        decodeState({
+          importedCount: 1,
+          importedSessionIds: ['imported-1'],
+          isImporting: false,
+          extra: true,
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeState({
+          importedCount: -1,
+          importedSessionIds: [],
+          isImporting: false,
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeState({
+          importedCount: EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS + 1,
+          importedSessionIds: Array.from(
+            { length: EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS + 1 },
+            (_, index) => `imported-${index}`,
+          ),
+          isImporting: false,
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeState({
+          importedCount: 1,
+          importedSessionIds: ['invalid id'],
+          isImporting: false,
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeState({
+          importedCount: 0,
+          importedSessionIds: [],
+          isImporting: 'yes',
+        }),
+      isProtocolError,
+    );
+    assert.throws(
+      () =>
+        decodeState({
+          importedCount: 1,
+          importedSessionIds: ['imported-2', 'imported-1'],
+          isImporting: false,
+        }),
+      isProtocolError,
+    );
+  });
+
   test('rejects open-ended, malformed, and oversized frames', () => {
     assert.throws(
       () =>
@@ -111,6 +208,11 @@ describe('external Session protocol', () => {
             id: `source-${index}`,
             name: `Session ${index}`,
             hostCwd: '/workspace',
+            importState: {
+              importedCount: 0,
+              importedSessionIds: [],
+              isImporting: false,
+            },
           })),
           nextCursor: null,
         }),

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -63,11 +63,11 @@ describe('Runtime Host bootstrap protocol', () => {
   });
 
   test('publishes a new compatibility epoch for external Session import state', () => {
-    // Epoch 23 added remote Project registration. Requiring importState on
+    // Epoch 24 removed Session catalog filters. Requiring importState on
     // external catalog items is another closed wire-schema change, so Clients
-    // and Hosts from epoch 23 must fail the handshake instead of decoding each
+    // and Hosts from epoch 24 must fail the handshake instead of decoding each
     // other's catalog responses asymmetrically.
-    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 23);
+    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 24);
   });
 
   test('selects the highest mutually supported protocol and rejects a gap', () => {

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -63,11 +63,11 @@ describe('Runtime Host bootstrap protocol', () => {
   });
 
   test('publishes a new compatibility epoch for external Session import state', () => {
-    // Epoch 24 removed Session catalog filters. Requiring importState on
+    // Epoch 25 added authoritative live run state. Requiring importState on
     // external catalog items is another closed wire-schema change, so Clients
-    // and Hosts from epoch 24 must fail the handshake instead of decoding each
+    // and Hosts from epoch 25 must fail the handshake instead of decoding each
     // other's catalog responses asymmetrically.
-    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 24);
+    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 25);
   });
 
   test('selects the highest mutually supported protocol and rejects a gap', () => {

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -62,6 +62,14 @@ describe('Runtime Host bootstrap protocol', () => {
     );
   });
 
+  test('publishes a new compatibility epoch for external Session import state', () => {
+    // Epoch 23 added remote Project registration. Requiring importState on
+    // external catalog items is another closed wire-schema change, so Clients
+    // and Hosts from epoch 23 must fail the handshake instead of decoding each
+    // other's catalog responses asymmetrically.
+    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 23);
+  });
+
   test('selects the highest mutually supported protocol and rejects a gap', () => {
     assert.equal(negotiateProtocol({ min: 0, max: 0 }, { min: 0, max: 0 }), 0);
     assert.equal(negotiateProtocol({ min: 1, max: 3 }, { min: 2, max: 4 }), 3);

--- a/packages/runtime-host/src/protocol/external-session.ts
+++ b/packages/runtime-host/src/protocol/external-session.ts
@@ -260,7 +260,7 @@ function decodeExternalSessionImportState(
   ) {
     throw invalidProtocolFrame('Invalid external Session imported Session ids');
   }
-  const importedSessionIds = state.importedSessionIds.map((id) =>
+  const importedSessionIds = Array.from(state.importedSessionIds, (id) =>
     requireEntityId(id, 'imported Session id'),
   );
   const importedCount = requireCount(state.importedCount, 'external Session imported count');

--- a/packages/runtime-host/src/protocol/external-session.ts
+++ b/packages/runtime-host/src/protocol/external-session.ts
@@ -17,6 +17,7 @@ export const EXTERNAL_SESSION_CWD_MAX_BYTES = 4 * 1024;
 export const EXTERNAL_SESSION_NAME_MAX_BYTES = 320;
 export const EXTERNAL_SESSION_SOURCE_SESSION_ID_MAX_BYTES = 512;
 export const EXTERNAL_SESSION_SOURCE_MAX_ITEMS = 16;
+export const EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS = 8;
 const EXTERNAL_SESSION_CURSOR_MAX_BYTES = 32;
 
 const QUERY_ERRORS = [
@@ -56,6 +57,11 @@ export interface ExternalSessionCatalogItem {
   readonly id: string;
   readonly name: string;
   readonly hostCwd: string;
+  readonly importState: {
+    readonly importedCount: number;
+    readonly importedSessionIds: readonly string[];
+    readonly isImporting: boolean;
+  };
   readonly createdAt?: number;
   readonly updatedAt?: number;
   readonly archived?: boolean;
@@ -209,7 +215,7 @@ function decodeExternalSessionSummary(value: unknown): ExternalSessionCatalogIte
   const summary = requireShapedRecord(
     value,
     'external Session summary',
-    ['id', 'name', 'hostCwd'],
+    ['id', 'name', 'hostCwd', 'importState'],
     ['createdAt', 'updatedAt', 'archived'],
   );
   const id = requireUtf8String(
@@ -227,6 +233,7 @@ function decodeExternalSessionSummary(value: unknown): ExternalSessionCatalogIte
       'external Session Host cwd',
       EXTERNAL_SESSION_CWD_MAX_BYTES,
     ),
+    importState: decodeExternalSessionImportState(summary.importState),
     ...(Object.hasOwn(summary, 'createdAt')
       ? { createdAt: requireCount(summary.createdAt, 'external Session createdAt') }
       : {}),
@@ -236,6 +243,34 @@ function decodeExternalSessionSummary(value: unknown): ExternalSessionCatalogIte
     ...(Object.hasOwn(summary, 'archived')
       ? { archived: boolean(summary.archived, 'archived') }
       : {}),
+  };
+}
+
+function decodeExternalSessionImportState(
+  value: unknown,
+): ExternalSessionCatalogItem['importState'] {
+  const state = requireExactRecord(value, 'external Session import state', [
+    'importedCount',
+    'importedSessionIds',
+    'isImporting',
+  ]);
+  if (
+    !Array.isArray(state.importedSessionIds) ||
+    state.importedSessionIds.length > EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS
+  ) {
+    throw invalidProtocolFrame('Invalid external Session imported Session ids');
+  }
+  const importedSessionIds = state.importedSessionIds.map((id) =>
+    requireEntityId(id, 'imported Session id'),
+  );
+  const importedCount = requireCount(state.importedCount, 'external Session imported count');
+  if (importedCount < importedSessionIds.length) {
+    throw invalidProtocolFrame('Invalid external Session imported count');
+  }
+  return {
+    importedCount,
+    importedSessionIds,
+    isImporting: boolean(state.isImporting, 'external Session import state'),
   };
 }
 

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -71,7 +71,7 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 25 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 26 as const;
 // Transcript pages amortize storage and network round trips with a 512 KiB raw
 // payload. Base64 expansion plus the bounded fragment envelope must still fit in
 // one transport message; narrower domains retain their own encoded limits.

--- a/packages/runtime-host/src/server/external-session-coordinator.ts
+++ b/packages/runtime-host/src/server/external-session-coordinator.ts
@@ -4,11 +4,13 @@ import type {
   ExternalSessionSummary,
 } from '@maka/core/external-session';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
-import type { SessionHeader, StoredMessage } from '@maka/core/session';
+import type { SessionExternalOrigin, SessionHeader, StoredMessage } from '@maka/core/session';
+import type { ExternalSessionImportLookupResult } from '@maka/storage';
 import type { SessionCatalogRecord } from '@maka/storage/execution-stores';
 import { ExternalSessionImporter } from '@maka/storage/external-sessions';
 import {
   EXTERNAL_SESSION_CWD_MAX_BYTES,
+  EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS,
   EXTERNAL_SESSION_NAME_MAX_BYTES,
   EXTERNAL_SESSION_PAGE_MAX_ITEMS,
   EXTERNAL_SESSION_RESULT_MAX_BYTES,
@@ -32,7 +34,13 @@ type ExternalSessionStore = {
   createImportedSession(
     input: CreateSessionInput,
     messages: readonly StoredMessage[],
+    externalOrigin: SessionExternalOrigin,
   ): Promise<SessionHeader>;
+  lookupExternalSessionImports(
+    adapterId: string,
+    sourceSessionIds: readonly string[],
+    recentSessionIdLimit: number,
+  ): Promise<readonly ExternalSessionImportLookupResult[]>;
   listHeaders(): Promise<SessionHeader[]>;
   readCatalogRecord(sessionId: string): Promise<SessionCatalogRecord>;
 };
@@ -151,7 +159,25 @@ export class HostExternalSessionCoordinator {
       )
         .map(toWireSummary)
         .filter((summary): summary is ExternalSessionCatalogItem => summary !== undefined);
-      const page = boundedCatalogPage(sessions, offset);
+      const candidates = sessions.slice(offset, offset + EXTERNAL_SESSION_PAGE_MAX_ITEMS);
+      const imports = await this.#sessions.lookupExternalSessionImports(
+        input.adapterId,
+        candidates.map(({ id }) => id),
+        EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS,
+      );
+      const importsBySource = new Map(imports.map((state) => [state.sourceSessionId, state]));
+      const enrichedCandidates = candidates.map((session) => {
+        const state = importsBySource.get(session.id);
+        return {
+          ...session,
+          importState: {
+            importedCount: state?.livePublishedImportCount ?? 0,
+            importedSessionIds: state?.recentSessionIds ?? [],
+            isImporting: this.#importsInFlight.has(importKey(input.adapterId, session.id)),
+          },
+        };
+      });
+      const page = boundedCatalogPage(enrichedCandidates, offset, sessions.length);
       const nextOffset = offset + page.length;
       return {
         ok: true,
@@ -171,7 +197,7 @@ export class HostExternalSessionCoordinator {
   async importSession(
     input: ExternalSessionImportInput,
   ): Promise<OperationOutcome<'external-session.import'>> {
-    const key = JSON.stringify([input.adapterId, input.sourceSessionId]);
+    const key = importKey(input.adapterId, input.sourceSessionId);
     const running = this.#importsInFlight.get(key);
     if (running) return running;
     const attempt = this.#importSession(input);
@@ -204,9 +230,9 @@ export class HostExternalSessionCoordinator {
 
     let commitAttempted = false;
     const importer = new ExternalSessionImporter(this.#adapters, {
-      createImportedSession: async (sessionInput, messages) => {
+      createImportedSession: async (sessionInput, messages, externalOrigin) => {
         commitAttempted = true;
-        return this.#sessions.createImportedSession(sessionInput, messages);
+        return this.#sessions.createImportedSession(sessionInput, messages, externalOrigin);
       },
     });
     let header: SessionHeader;
@@ -295,6 +321,7 @@ function toWireSummary(summary: ExternalSessionSummary): ExternalSessionCatalogI
     id: summary.id,
     name,
     hostCwd: truncateUtf8(summary.cwd, EXTERNAL_SESSION_CWD_MAX_BYTES),
+    importState: { importedCount: 0, importedSessionIds: [], isImporting: false },
     ...(createdAt === undefined ? {} : { createdAt }),
     ...(updatedAt === undefined ? {} : { updatedAt }),
     ...(typeof summary.archived === 'boolean' ? { archived: summary.archived } : {}),
@@ -302,19 +329,17 @@ function toWireSummary(summary: ExternalSessionSummary): ExternalSessionCatalogI
 }
 
 function boundedCatalogPage(
-  sessions: readonly ExternalSessionCatalogItem[],
+  candidates: readonly ExternalSessionCatalogItem[],
   offset: number,
+  totalCount: number,
 ): ExternalSessionCatalogItem[] {
   const page: ExternalSessionCatalogItem[] = [];
-  const end = Math.min(sessions.length, offset + EXTERNAL_SESSION_PAGE_MAX_ITEMS);
-  for (let index = offset; index < end; index += 1) {
-    const candidate = sessions[index];
-    if (!candidate) break;
+  for (const candidate of candidates) {
     const nextPage = [...page, candidate];
     const nextOffset = offset + nextPage.length;
     const result = {
       sessions: nextPage,
-      nextCursor: nextOffset < sessions.length ? String(nextOffset) : null,
+      nextCursor: nextOffset < totalCount ? String(nextOffset) : null,
     };
     if (Buffer.byteLength(JSON.stringify(result), 'utf8') > EXTERNAL_SESSION_RESULT_MAX_BYTES) {
       break;
@@ -361,6 +386,10 @@ function safeTimestamp(value: number | undefined): number | undefined {
 
 function isSourceSessionNotFound(error: unknown): boolean {
   return error instanceof Error && /Session not found|Session does not exist/i.test(error.message);
+}
+
+function importKey(adapterId: string, sourceSessionId: string): string {
+  return JSON.stringify([adapterId, sourceSessionId]);
 }
 
 function queryFailure(

--- a/packages/runtime/src/__tests__/runtime-ledger-repair.test.ts
+++ b/packages/runtime/src/__tests__/runtime-ledger-repair.test.ts
@@ -76,6 +76,7 @@ test('repairs imported transcript turns into provider-neutral canonical history'
         permissionMode: 'ask',
       },
       messages,
+      { adapterId: 'test', sourceSessionId: 'source-session-1' },
     );
     assert.equal(session.transcriptLedgerVersion, 0);
     const repair = new RuntimeLedgerRepair({

--- a/packages/storage/src/__tests__/external-session-importer.test.ts
+++ b/packages/storage/src/__tests__/external-session-importer.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import type { StoredMessage } from '@maka/core/session';
+import type { SessionExternalOrigin, SessionHeader, StoredMessage } from '@maka/core/session';
 import {
   ExternalSessionAdapterRegistry,
   type ExternalSessionAdapter,
@@ -15,6 +15,28 @@ import {
 import { createSessionStore } from '../session-store.js';
 
 describe('ExternalSessionImporter', () => {
+  test('forwards the exact external Session origin to imported persistence', async () => {
+    const calls: SessionExternalOrigin[] = [];
+    const adapter = fakeAdapter({
+      metadata: { name: 'Imported parser work', cwd: '/external/repo' },
+      messages: [],
+    });
+    const importer = new ExternalSessionImporter(new ExternalSessionAdapterRegistry([adapter]), {
+      createImportedSession: async (_input, _messages, externalOrigin) => {
+        calls.push(externalOrigin);
+        return {} as SessionHeader;
+      },
+    });
+
+    await importer.import({
+      adapterId: 'fake',
+      sourceSessionId: 'source-1',
+      target: target(),
+    });
+
+    assert.deepEqual(calls, [{ adapterId: 'fake', sourceSessionId: 'source-1' }]);
+  });
+
   test('persists adapter output as native Maka StoredMessages', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-external-session-import-'));
     const sessions = createSessionStore(root);
@@ -49,7 +71,23 @@ describe('ExternalSessionImporter', () => {
       assert.equal(header.cwd, '/external/repo');
       assert.equal(header.model, 'maka-model');
       assert.equal(header.connectionLocked, true);
+      assert.deepEqual(header.externalOrigin, {
+        adapterId: 'fake',
+        sourceSessionId: 'source-1',
+      });
       assert.deepEqual(await sessions.readMessages(header.id), messages);
+
+      await sessions.close?.();
+      const reopened = createSessionStore(root);
+      try {
+        assert.deepEqual((await reopened.readHeaderSnapshot(header.id)).externalOrigin, {
+          adapterId: 'fake',
+          sourceSessionId: 'source-1',
+        });
+        assert.deepEqual(await reopened.readMessages(header.id), messages);
+      } finally {
+        await reopened.close?.();
+      }
     } finally {
       await sessions.close?.();
       await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -6,11 +6,158 @@ import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
 import type { CreateSessionInput } from '@maka/core/runtime-inputs';
-import { createSessionStore, isSessionNotFoundError } from '../session-store.js';
+import {
+  EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_RECENT_SESSION_IDS,
+  EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_SOURCE_IDS,
+  createSessionStore,
+  isSessionNotFoundError,
+} from '../session-store.js';
 import { OPERATIONAL_STATE_DATABASE_NAME } from '../operational-state-store.js';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
 
 describe('SQLite SessionStore', () => {
+  test('ordinary Sessions have no external origin and provenance metadata is immutable', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-external-origin-'));
+    const store = createSessionStore(root);
+    try {
+      const ordinary = await store.create(makeInput());
+
+      assert.equal(ordinary.externalOrigin, undefined);
+      await assert.rejects(
+        store.updateHeader(ordinary.id, { externalOrigin: undefined }),
+        /external.*origin.*immutable/i,
+      );
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('looks up complete published import counts with bounded newest Session ids', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-external-origin-lookup-'));
+    const store = createSessionStore(root);
+    const importSession = async (sourceSessionId: string) =>
+      store.createImportedSession(makeInput(), [], {
+        adapterId: 'fake',
+        sourceSessionId,
+      });
+    try {
+      const duplicates = await Promise.all([
+        importSession('duplicate'),
+        importSession('duplicate'),
+        importSession('duplicate'),
+      ]);
+      await Promise.all(
+        duplicates.map((session, index) =>
+          store.updateHeader(session.id, {
+            createdAt: index === 0 ? 100 : 200,
+            transcriptLedgerVersion: 1,
+          }),
+        ),
+      );
+      const archived = await importSession('archived');
+      await store.updateHeader(archived.id, { transcriptLedgerVersion: 1 });
+      const archivedSnapshot = await store.readHeaderRecordSnapshot(archived.id);
+      await store.setSessionsArchivedVersioned(
+        [{ sessionId: archived.id, expectedVersion: archivedSnapshot.revision }],
+        true,
+      );
+      await importSession('staging');
+      const deleted = await importSession('deleted');
+      await store.updateHeader(deleted.id, { transcriptLedgerVersion: 1 });
+      await store.remove(deleted.id);
+      await store.create(makeInput({ parentSessionId: duplicates[0]!.id }));
+
+      const result = await store.lookupExternalSessionImports(
+        'fake',
+        ['duplicate', 'archived', 'staging', 'deleted', 'ordinary', 'missing'],
+        2,
+      );
+      const newestDuplicateIds = duplicates
+        .slice(1)
+        .map(({ id }) => id)
+        .sort((left, right) => left.localeCompare(right));
+
+      assert.deepEqual(result, [
+        {
+          sourceSessionId: 'duplicate',
+          livePublishedImportCount: 3,
+          recentSessionIds: newestDuplicateIds,
+        },
+        {
+          sourceSessionId: 'archived',
+          livePublishedImportCount: 1,
+          recentSessionIds: [archived.id],
+        },
+      ]);
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('bounds external import lookup source and recent-id requests', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-external-origin-bounds-'));
+    const store = createSessionStore(root);
+    try {
+      await assert.rejects(
+        store.lookupExternalSessionImports(
+          'fake',
+          Array.from(
+            { length: EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_SOURCE_IDS + 1 },
+            (_, index) => `source-${index}`,
+          ),
+          1,
+        ),
+        /at most .* source ids/,
+      );
+      await assert.rejects(
+        store.lookupExternalSessionImports(
+          'fake',
+          ['source-1'],
+          EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_RECENT_SESSION_IDS + 1,
+        ),
+        /recent id limit must be between/,
+      );
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('fails closed when persisted external origin metadata is malformed', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-external-origin-invalid-'));
+    const store = createSessionStore(root);
+    let sessionId = '';
+    try {
+      const session = await store.create(makeInput());
+      sessionId = session.id;
+    } finally {
+      await store.close?.();
+    }
+
+    const database = new DatabaseSync(join(root, OPERATIONAL_STATE_DATABASE_NAME));
+    try {
+      database
+        .prepare(
+          `UPDATE session_metadata
+           SET payload_json = json_set(payload_json, '$.externalOrigin', json(?))
+           WHERE session_id = ?`,
+        )
+        .run(JSON.stringify({ adapterId: '', sourceSessionId: 42 }), sessionId);
+    } finally {
+      database.close();
+    }
+
+    const reopened = createSessionStore(root);
+    try {
+      await assert.rejects(reopened.readHeaderSnapshot(sessionId), /malformed fields/);
+    } finally {
+      await reopened.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('persists session metadata and messages in one SQLite authority', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-sqlite-'));
     const store = createSessionStore(root);
@@ -51,7 +198,10 @@ describe('SQLite SessionStore', () => {
       const visible = await store.create(makeInput({ name: 'Visible Session' }));
       const staging = await Promise.all(
         Array.from({ length: 32 }, (_, index) =>
-          store.createImportedSession(makeInput({ name: `Staging Session ${index}` }), []),
+          store.createImportedSession(makeInput({ name: `Staging Session ${index}` }), [], {
+            adapterId: 'fake',
+            sourceSessionId: `source-${index}`,
+          }),
         ),
       );
 
@@ -340,6 +490,9 @@ describe('SQLite SessionStore', () => {
       ALTER TABLE session_metadata ADD COLUMN status_updated_at INTEGER;
       CREATE INDEX session_metadata_by_status
         ON session_metadata(status, status_updated_at DESC, session_id);
+      DROP INDEX session_metadata_by_external_origin;
+      ALTER TABLE session_metadata DROP COLUMN external_adapter_id;
+      ALTER TABLE session_metadata DROP COLUMN external_source_session_id;
       UPDATE session_metadata_schema SET version = 22 WHERE scope = 'session_metadata';
     `);
     legacy.close();

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -516,6 +516,9 @@ describe('SqliteSessionMetadataStore', () => {
             status_updated_at = json_extract(payload_json, '$.statusUpdatedAt');
           CREATE INDEX session_metadata_by_status
             ON session_metadata(status, status_updated_at DESC, session_id);
+          DROP INDEX session_metadata_by_external_origin;
+          ALTER TABLE session_metadata DROP COLUMN external_adapter_id;
+          ALTER TABLE session_metadata DROP COLUMN external_source_session_id;
           UPDATE session_metadata_schema SET version = 26 WHERE scope = 'session_metadata';
         `);
         legacy

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -85,6 +85,16 @@ describe('SqliteSessionMetadataStore', () => {
         columns.some(({ name }) => name === 'external_source_session_id'),
         true,
       );
+      const externalOriginIndex = schema
+        .prepare(
+          `SELECT sql FROM sqlite_master
+           WHERE type = 'index' AND name = 'session_metadata_by_external_origin'`,
+        )
+        .get() as { readonly sql: string } | undefined;
+      assert.match(
+        externalOriginIndex?.sql ?? '',
+        /WHERE\s+external_adapter_id IS NOT NULL\s+AND external_source_session_id IS NOT NULL/i,
+      );
     } finally {
       schema.close();
       await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -33,6 +33,64 @@ import {
 import { SQLITE_AGENT_GRAPH_CONTROL_TABLES } from '../sqlite-session-metadata-schema.js';
 
 describe('SqliteSessionMetadataStore', () => {
+  test('migrates v27 metadata to v28 without backfilling external origin', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-metadata-v27-'));
+    const path = join(root, 'state.sqlite');
+    const legacyHeader = fullHeader({
+      parentSessionId: undefined,
+      branchOfTurnId: undefined,
+      revisionRootSessionId: undefined,
+      revisionParentSessionId: undefined,
+      revisionOfTurnId: undefined,
+      revisionIndex: undefined,
+      revisionState: undefined,
+    });
+    const setup = createSqliteSessionMetadataStore(path);
+    try {
+      await setup.create(legacyHeader);
+    } finally {
+      setup.close();
+    }
+    const legacy = new DatabaseSync(path);
+    try {
+      legacy.exec(`
+        DROP INDEX session_metadata_by_external_origin;
+        ALTER TABLE session_metadata DROP COLUMN external_adapter_id;
+        ALTER TABLE session_metadata DROP COLUMN external_source_session_id;
+        UPDATE session_metadata_schema SET version = 27 WHERE scope = 'session_metadata';
+      `);
+    } finally {
+      legacy.close();
+    }
+
+    const migrated = createSqliteSessionMetadataStore(path);
+    try {
+      assert.equal(migrated.schemaVersion(), 28);
+      assert.equal((await migrated.read(legacyHeader.id)).header.externalOrigin, undefined);
+    } finally {
+      migrated.close();
+    }
+    const schema = new DatabaseSync(path);
+    try {
+      const columns = schema
+        .prepare('PRAGMA table_info(session_metadata)')
+        .all() as unknown as Array<{
+        readonly name: string;
+      }>;
+      assert.equal(
+        columns.some(({ name }) => name === 'external_adapter_id'),
+        true,
+      );
+      assert.equal(
+        columns.some(({ name }) => name === 'external_source_session_id'),
+        true,
+      );
+    } finally {
+      schema.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('identifies an incompatible persisted message without exposing its content', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-message-incompatible-'));
     const path = join(root, 'state.sqlite');
@@ -188,6 +246,9 @@ describe('SqliteSessionMetadataStore', () => {
             status_updated_at = json_extract(payload_json, '$.statusUpdatedAt');
           CREATE INDEX session_metadata_by_status
             ON session_metadata(status, status_updated_at DESC, session_id);
+          DROP INDEX session_metadata_by_external_origin;
+          ALTER TABLE session_metadata DROP COLUMN external_adapter_id;
+          ALTER TABLE session_metadata DROP COLUMN external_source_session_id;
         `);
         legacy
           .prepare(

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -98,6 +98,7 @@ export type {
 } from './message-receipt-store.js';
 export type {
   ProbeSessionRemovalResult,
+  ExternalSessionImportLookupResult,
   SessionCatalogPageCursor,
   SessionCatalogPageResult,
   SessionCatalogRecord,
@@ -321,8 +322,16 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
     sessionStore: {
       ready: () => run(() => sessionStore.ready()),
       create: (input, initialBoundary) => run(() => sessionStore.create(input, initialBoundary)),
-      createImportedSession: (input, messages) =>
-        run(() => sessionStore.createImportedSession(input, messages)),
+      createImportedSession: (input, messages, externalOrigin) =>
+        run(() => sessionStore.createImportedSession(input, messages, externalOrigin)),
+      lookupExternalSessionImports: (adapterId, sourceSessionIds, recentSessionIdLimit) =>
+        run(() =>
+          sessionStore.lookupExternalSessionImports(
+            adapterId,
+            sourceSessionIds,
+            recentSessionIdLimit,
+          ),
+        ),
       probeStableSessionCreate: (sessionId, requestFingerprint) =>
         run(() => sessionStore.probeStableSessionCreate(sessionId, requestFingerprint)),
       createStableSession: (request, initialBoundary) =>

--- a/packages/storage/src/external-session-importer.ts
+++ b/packages/storage/src/external-session-importer.ts
@@ -35,6 +35,10 @@ export class ExternalSessionImporter {
         name: request.target.name ?? external.metadata.name,
       },
       external.messages,
+      {
+        adapterId: request.adapterId,
+        sourceSessionId: request.sourceSessionId,
+      },
     );
   }
 }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,6 +1,8 @@
 export {
   SessionNotFoundError,
   SessionReadMarkerMessageNotFoundError,
+  EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_RECENT_SESSION_IDS,
+  EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_SOURCE_IDS,
   assertSafeSessionId,
   createSessionStore,
   createUserMessage,
@@ -12,6 +14,7 @@ export {
 export type {
   CreateStableSessionRequest,
   CreateStableSessionResult,
+  ExternalSessionImportLookupResult,
   ProbeStableSessionCreateResult,
   SessionAuthorityStore,
   SessionCatalogPageCursor,

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -53,6 +53,7 @@ import {
   type SessionHeader,
   type SessionHeaderPatch,
   type SessionConversationCopy,
+  type SessionExternalOrigin,
   type SessionSummary,
   type StoredMessage,
   type TurnRecord,
@@ -112,6 +113,15 @@ export interface SessionCatalogRecord extends SessionHeaderSnapshot {
 export interface SessionCatalogPageCursor {
   readonly activityAt: number;
   readonly sessionId: string;
+}
+
+export const EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_SOURCE_IDS = 256;
+export const EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_RECENT_SESSION_IDS = 16;
+
+export interface ExternalSessionImportLookupResult {
+  readonly sourceSessionId: string;
+  readonly livePublishedImportCount: number;
+  readonly recentSessionIds: readonly string[];
 }
 
 export type SessionCatalogPageResult =
@@ -282,7 +292,14 @@ export interface SessionAuthorityStore extends SessionStore {
   createImportedSession(
     input: CreateSessionInput,
     messages: readonly StoredMessage[],
+    externalOrigin: SessionExternalOrigin,
   ): Promise<SessionHeader>;
+  /** Look up live published imports for a bounded page of source Sessions. */
+  lookupExternalSessionImports(
+    adapterId: string,
+    sourceSessionIds: readonly string[],
+    recentSessionIdLimit: number,
+  ): Promise<readonly ExternalSessionImportLookupResult[]>;
   createSubagent(
     input: CreateSessionInput,
     initialBoundary?: ExecutionBoundary,
@@ -403,6 +420,7 @@ class SqliteSessionStore implements SessionAuthorityStore {
   async createImportedSession(
     input: CreateSessionInput,
     messages: readonly StoredMessage[],
+    externalOrigin: SessionExternalOrigin,
   ): Promise<SessionHeader> {
     await this.ensureReady();
     assertNoConversationCopyMetadata(input);
@@ -414,6 +432,7 @@ class SqliteSessionStore implements SessionAuthorityStore {
     );
     const header: SessionHeader = {
       ...buildSessionHeader(this.workspaceRoot, input),
+      externalOrigin,
       transcriptLedgerVersion: 0,
     };
     const outcome = await this.metadata.importSession(
@@ -425,6 +444,51 @@ class SqliteSessionStore implements SessionAuthorityStore {
       throw new Error(`Generated Session id already exists: ${header.id}`);
     }
     return (await this.metadata.read(header.id)).header;
+  }
+
+  async lookupExternalSessionImports(
+    adapterId: string,
+    sourceSessionIds: readonly string[],
+    recentSessionIdLimit: number,
+  ): Promise<readonly ExternalSessionImportLookupResult[]> {
+    await this.ensureReady();
+    if (typeof adapterId !== 'string' || adapterId.trim().length === 0) {
+      throw new Error('External Session import lookup adapter id must not be empty');
+    }
+    if (
+      !Array.isArray(sourceSessionIds) ||
+      sourceSessionIds.length > EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_SOURCE_IDS
+    ) {
+      throw new Error(
+        `External Session import lookup accepts at most ${EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_SOURCE_IDS} source ids`,
+      );
+    }
+    const uniqueSourceSessionIds: string[] = [];
+    const seen = new Set<string>();
+    for (const sourceSessionId of sourceSessionIds) {
+      if (typeof sourceSessionId !== 'string' || sourceSessionId.length === 0) {
+        throw new Error('External Session import lookup source id must not be empty');
+      }
+      if (!seen.has(sourceSessionId)) {
+        seen.add(sourceSessionId);
+        uniqueSourceSessionIds.push(sourceSessionId);
+      }
+    }
+    if (
+      !Number.isSafeInteger(recentSessionIdLimit) ||
+      recentSessionIdLimit < 1 ||
+      recentSessionIdLimit > EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_RECENT_SESSION_IDS
+    ) {
+      throw new Error(
+        `External Session import lookup recent id limit must be between 1 and ${EXTERNAL_SESSION_IMPORT_LOOKUP_MAX_RECENT_SESSION_IDS}`,
+      );
+    }
+    if (uniqueSourceSessionIds.length === 0) return [];
+    return this.metadata.lookupExternalSessionImports(
+      adapterId,
+      uniqueSourceSessionIds,
+      recentSessionIdLimit,
+    );
   }
 
   async probeStableSessionCreate(
@@ -1023,6 +1087,7 @@ export function normalizeSessionHeader(
     isValidConversationCopyLineage(header) &&
     isValidRevisionLineage(header) &&
     isValidSubagentSessionLineage(header) &&
+    isValidSessionExternalOrigin(header.externalOrigin) &&
     (header.lastReadMessageId === undefined || typeof header.lastReadMessageId === 'string') &&
     typeof header.hasUnread === 'boolean' &&
     isBackendKind(header.backend) &&
@@ -1046,6 +1111,18 @@ export function normalizeSessionHeader(
     return { ...withoutBlockedReason, name: normalizedName };
   }
   return { ...header, name: normalizedName };
+}
+
+function isValidSessionExternalOrigin(origin: SessionHeader['externalOrigin']): boolean {
+  if (origin === undefined) return true;
+  return (
+    typeof origin === 'object' &&
+    origin !== null &&
+    typeof origin.adapterId === 'string' &&
+    origin.adapterId.length > 0 &&
+    typeof origin.sourceSessionId === 'string' &&
+    origin.sourceSessionId.length > 0
+  );
 }
 
 function isValidRevisionLineage(header: SessionHeader): boolean {

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1031,7 +1031,9 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
         external_source_session_id,
         created_at DESC,
         session_id
-      );
+      )
+      WHERE external_adapter_id IS NOT NULL
+        AND external_source_session_id IS NOT NULL;
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 27;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 28;
 export const SQLITE_SESSION_MESSAGE_CHUNK_BYTES = 64 * 1024;
 export const SQLITE_SESSION_MESSAGE_CHUNK_MARKER = '{"$maka":"session-message-chunks-v1"}';
 
@@ -1017,6 +1017,21 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
     DROP INDEX session_metadata_by_status;
     ALTER TABLE session_metadata DROP COLUMN status;
     ALTER TABLE session_metadata DROP COLUMN status_updated_at;
+  `,
+  ],
+  [
+    28,
+    `
+    ALTER TABLE session_metadata ADD COLUMN external_adapter_id TEXT;
+    ALTER TABLE session_metadata ADD COLUMN external_source_session_id TEXT;
+
+    CREATE INDEX session_metadata_by_external_origin
+      ON session_metadata(
+        external_adapter_id,
+        external_source_session_id,
+        created_at DESC,
+        session_id
+      );
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -93,6 +93,7 @@ import {
   assertSafeSessionId,
   normalizeSessionHeader,
   SessionNotFoundError,
+  type ExternalSessionImportLookupResult,
   type SessionTranscriptMessageLookupRequest,
   type SessionTranscriptPageRequest,
   type SessionTranscriptStoragePage,
@@ -1332,6 +1333,67 @@ export class SqliteSessionMetadataStore {
         this.updateCatalogProjectionSync(normalized.id, projection, false, lockConnection);
       }
       return 'imported';
+    });
+  }
+
+  async lookupExternalSessionImports(
+    adapterId: string,
+    sourceSessionIds: readonly string[],
+    recentSessionIdLimit: number,
+  ): Promise<readonly ExternalSessionImportLookupResult[]> {
+    this.assertOpen();
+    if (sourceSessionIds.length === 0) return [];
+    const placeholders = sourceSessionIds.map(() => '?').join(', ');
+    const rows = this.db
+      .prepare(
+        `
+        SELECT external_source_session_id, session_id, import_count
+        FROM (
+          SELECT
+            external_source_session_id,
+            session_id,
+            COUNT(*) OVER (
+              PARTITION BY external_source_session_id
+            ) AS import_count,
+            ROW_NUMBER() OVER (
+              PARTITION BY external_source_session_id
+              ORDER BY created_at DESC, session_id
+            ) AS recent_rank
+          FROM session_metadata
+          WHERE external_adapter_id = ?
+            AND external_source_session_id IN (${placeholders})
+            AND COALESCE(
+              json_extract(payload_json, '$.transcriptLedgerVersion'),
+              1
+            ) <> 0
+        )
+        WHERE recent_rank <= ?
+        ORDER BY external_source_session_id, recent_rank
+      `,
+      )
+      .all(adapterId, ...sourceSessionIds, recentSessionIdLimit) as unknown as Array<{
+      readonly external_source_session_id: string;
+      readonly session_id: string;
+      readonly import_count: number;
+    }>;
+    const bySource = new Map<
+      string,
+      { readonly livePublishedImportCount: number; readonly recentSessionIds: string[] }
+    >();
+    for (const row of rows) {
+      const existing = bySource.get(row.external_source_session_id);
+      if (existing) {
+        existing.recentSessionIds.push(row.session_id);
+      } else {
+        bySource.set(row.external_source_session_id, {
+          livePublishedImportCount: row.import_count,
+          recentSessionIds: [row.session_id],
+        });
+      }
+    }
+    return sourceSessionIds.flatMap((sourceSessionId) => {
+      const result = bySource.get(sourceSessionId);
+      return result ? [{ sourceSessionId, ...result }] : [];
     });
   }
 
@@ -3328,6 +3390,9 @@ export class SqliteSessionMetadataStore {
     if (Object.prototype.hasOwnProperty.call(patch, 'subagentWorkspace')) {
       throw new Error('Subagent session workspace binding is immutable');
     }
+    if (Object.prototype.hasOwnProperty.call(patch, 'externalOrigin')) {
+      throw new Error('External Session origin is immutable');
+    }
     return this.transaction(() =>
       this.updateHeaderSync(sessionId, patch, {
         ...(options.expectedVersion === undefined
@@ -3513,6 +3578,8 @@ export class SqliteSessionMetadataStore {
           subagent_request_fingerprint,
           subagent_initial_turn_id,
           subagent_initial_run_id,
+          external_adapter_id,
+          external_source_session_id,
           revision_root_session_id,
           revision_index,
           has_unread,
@@ -3521,7 +3588,7 @@ export class SqliteSessionMetadataStore {
           model,
           metadata_version,
           committed_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `,
       )
       .run(
@@ -3542,6 +3609,8 @@ export class SqliteSessionMetadataStore {
         header.subagentSpawn?.requestFingerprint ?? null,
         header.subagentSpawn?.initialTurnId ?? null,
         header.subagentSpawn?.initialRunId ?? null,
+        header.externalOrigin?.adapterId ?? null,
+        header.externalOrigin?.sourceSessionId ?? null,
         header.revisionRootSessionId ?? null,
         header.revisionIndex ?? null,
         booleanInteger(header.hasUnread),


### PR DESCRIPTION
## Summary

- Persist immutable external adapter/session provenance for imported Sessions in SQLite schema v25.
- Add a batched lookup that returns the complete durable import count and newest eight surviving published Session IDs.
- Enrich external Session catalog items with durable history and orthogonal in-flight state while preserving the 72 KiB response bound.
- Bump the closed Runtime Host compatibility epoch for the wire-contract change.
- Make the Desktop catalog authoritative across remounts, repeat imports, in-flight polling, and `commit_outcome_unknown` recovery, with localized UI and a newest-task entry.

Fixes #3081

## Verification

- `npm --workspace @maka/storage test` (821 passed, 14 existing skips)
- `npm --workspace @maka/runtime-host test` (944 passed)
- `npm --workspace @maka/desktop test` (876 passed)
- `npm --workspace @maka/storage run typecheck`
- `npm --workspace @maka/runtime-host run typecheck`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook` (131 stories)
- `npm run format:check`
- `npm run lint`
- `git diff --check`

## Review focus

This changes a public closed protocol contract and migrates Session metadata to schema v25. It requires independent human review and is not eligible for the self-merge fast path. Please pay particular attention to the migration transaction, batched provenance lookup filters/order, 72 KiB catalog pagination, and Desktop unknown-outcome recovery races.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented and tested the Core, Storage, protocol, Runtime Host, and Desktop changes under human direction. Each materially authored commit includes a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
