### PR TITLE
refactor(runtime): remove the legacy child provider-retry path

### DIFF
--- a/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
+++ b/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
@@ -350,21 +350,20 @@ B3（typed retry/reattach branch）仍然 defer，不进入本 PR。
 - authority-capable `SessionManager + SqliteRuntimeStore` 的协议与 production-shaped 路径已覆盖；
 - runtime-host 的 execution-store facade 当前仍以 file RuntimeEvent store 为主，尚未拥有 B2
   continuation authority；
-- 为保持 main 已有的 hosted child provider RateLimit retry，当前 continuation correctness
-  切片保留一条显式
-  `legacy_provider_retry` 兼容 lane：只有 continuation authority 与 safety inspector
-  **同时缺席**时才会在任何 claim/Run/T1 之前选择；它只读 immutable RuntimeEvent、执行前重验
-  immediate source，且不写 continuation claim/start。若两项 capability 只安装了一项，必须
-  fail closed，禁止静默 fallback；claim-repair abandonment 也绝不进入此 lane；
+- hosted child provider RateLimit retry 只保留 `durable_continuation` 单一准入：continuation
+  authority 与 safety inspector 任一缺席，都会在任何 claim/Run/T1 之前 fail closed，禁止
+  静默 fallback；早期的 `legacy_provider_retry` 兼容 lane 已在 host authority lifecycle
+  integration 完成后移除；
 - PR D 必须在同一 storage-root lease 下接入 SQLite authority，并锁定
   `claim repair → linked-child admission repair → generic ledger repair → planning` 的 owner 顺序；
 - SQLite canonical terminal 可幂等提交；文件型 AgentRun projection 当前是跨存储 saga。确定性
   event id 能让单恢复者重试收敛，但两个进程同时 repair 时还没有 append-if-absent/CAS；
   PR D 的 lease/fencing 或 projection CAS 是宣称跨进程 exactly-once 前的硬前置；
 - 在上述 composition/owner 测试完成前，不能把当前切片描述为 hosted auto-resume 已默认可用。
-  `legacy_provider_retry` 只维持升级前的 provider 429 重试能力，不具有 durable continuation、
-  跨进程 exactly-once 或 crash-resume 承诺；host authority lifecycle integration 完成 typed
-  authority composition 后应删除该兼容 lane。
+  `legacy_provider_retry` 兼容 lane（仅维持升级前的 provider 429 重试能力，不具有 durable
+  continuation、跨进程 exactly-once 或 crash-resume 承诺）已在 host authority lifecycle
+  integration 完成 typed authority composition 后移除；child provider retry 现在只走
+  durable continuation 准入，组合不完整即 fail closed。
 
 ### 8.4 明确不进入 PR B
 

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -367,14 +367,13 @@ linked-child RateLimit retry 与 B2.1 repair retry 是窄协议，不代表 runt
 资格。其他能力必须在各自拥有 durable handle/幂等协议后独立设计，不能复用 B2 的普通
 continuation claim 来暗示副作用可重跑。
 
-兼容约束：runtime-host 在 host authority lifecycle integration 完成前仍使用 file
-RuntimeEvent store，因此已有 provider
-RateLimit retry 走显式 `legacy_provider_retry` lane。该 lane 必须在 claim/Run/T1 之前选定，
-只允许 authority 与 safety inspector 同时缺席的组合；半配置状态 fail closed。它执行前重验
-immutable immediate-source replay，但不产生 claim/start，也不能承接
-`continuation_abandoned_before_provider_dispatch`。这不是 durable resume 的降级模式，只是
-保留 mainline provider retry 的临时兼容边界；host authority lifecycle integration 接入 typed
-SQLite authority owner 后删除。
+兼容约束：早期的 `legacy_provider_retry` lane（只允许 continuation authority 与 safety
+inspector 同时缺席的组合，半配置状态 fail closed；执行前重验 immutable immediate-source
+replay，但不产生 claim/start，也不能承接
+`continuation_abandoned_before_provider_dispatch`）已在 host authority lifecycle
+integration 接入 typed SQLite authority owner 后移除。child provider RateLimit retry 现在
+只走 durable continuation 准入：authority 或 safety inspector 任一缺席时在 claim/Run/T1
+之前 fail closed，没有降级模式。
 
 B3 之前，branch/revision preflight 必须在创建目标 Session 之前拒绝任何 V1/V2
 `continuationSource` 与 continuation-start，稳定返回

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -10102,6 +10102,128 @@ describe('SessionManager permission mode updates', () => {
     ).toEqual([]);
   });
 
+  test('retryChildAgent fails closed without a complete continuation composition', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    let providerDispatches = 0;
+    backends.register('fake', (ctx) => ({
+      kind: 'fake' as const,
+      sessionId: ctx.sessionId,
+      async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+        providerDispatches += 1;
+        yield {
+          type: 'error',
+          id: `${input.turnId}-error`,
+          turnId: input.turnId,
+          ts: 1,
+          recoverable: true,
+          reason: 'RateLimit',
+          message: 'provider 429',
+        };
+        yield {
+          type: 'complete',
+          id: `${input.turnId}-complete`,
+          turnId: input.turnId,
+          ts: 2,
+          stopReason: 'error',
+        };
+      },
+      async stop(): Promise<void> {},
+      async respondToSandboxBoundary(): Promise<void> {},
+      async dispose(): Promise<void> {},
+    }));
+    const inspectContinuationSafety = async () => ({
+      workspaceIdentity: '/tmp/cwd',
+      backgroundOperationsSettled: true,
+      availableToolNames: [] as string[],
+    });
+    const composeManager = (options: {
+      runtimeEventStore?: RuntimeEventStore;
+      withSafetyInspector?: boolean;
+    }) =>
+      new SessionManager({
+        store,
+        runStore,
+        runtimeEventStore: options.runtimeEventStore ?? runStore,
+        backends,
+        childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+        ...(options.withSafetyInspector ? { inspectContinuationSafety } : {}),
+        newId: nextId(),
+        now: nextNow(6_845),
+        runtimeSource: 'test',
+      });
+    const eventStoreWithoutAuthority = new Proxy(runStore, {
+      get(target, property, receiver) {
+        if (property === 'continuationAuthorityCapability') return undefined;
+        return Reflect.get(target, property, receiver);
+      },
+    });
+
+    const seeder = composeManager({});
+    const session = await seeder.createSession(makeInput({ permissionMode: 'ask' }));
+    const parentRun = makeRunHeader({
+      sessionId: session.id,
+      runId: 'parent-run',
+      turnId: 'parent-turn',
+      status: 'completed',
+      createdAt: 100,
+      updatedAt: 110,
+      completedAt: 110,
+    });
+    await seedRuntimeRun(runStore, parentRun, [
+      runtimeEvent({
+        id: 'parent-complete',
+        sessionId: session.id,
+        runId: parentRun.runId,
+        turnId: parentRun.turnId,
+        ts: 110,
+        status: 'completed',
+        actions: { endInvocation: true },
+      }),
+    ]);
+    const first = await seeder.spawnChildAgent(session.id, {
+      turnId: 'child-rate-limited',
+      parentRunId: parentRun.runId,
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Reader', systemPrompt: 'read only' },
+      prompt: 'inspect auth',
+    });
+    expect(first.status).toBe('failed');
+    expect(first.failureClass).toBe('RateLimit');
+    if (!first.runId) throw new Error('rate-limited child run id was not recorded');
+    const runsBeforeRetries = await runStore.listSessionRuns(session.id);
+
+    const incompleteCompositions = [
+      {
+        label: 'continuation authority and safety inspector are both missing',
+        runtimeEventStore: eventStoreWithoutAuthority,
+        withSafetyInspector: false,
+      },
+      {
+        label: 'continuation authority is missing its safety inspector',
+        runtimeEventStore: runStore,
+        withSafetyInspector: false,
+      },
+      {
+        label: 'safety inspector is missing its continuation authority',
+        runtimeEventStore: eventStoreWithoutAuthority,
+        withSafetyInspector: true,
+      },
+    ];
+    for (const composition of incompleteCompositions) {
+      const manager = composeManager(composition);
+      await expectRejects(
+        manager.retryChildAgent(session.id, {
+          parentRunId: parentRun.runId,
+          sourceRunId: first.runId,
+        }),
+        /composition is incomplete/,
+      );
+    }
+    expect(providerDispatches).toBe(1);
+    expect(await runStore.listSessionRuns(session.id)).toHaveLength(runsBeforeRetries.length);
+  });
+
   test('parent and child runs can read their ledger while only parents may compact session history', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -53,7 +53,6 @@ import {
   issueRuntimeContinuationAdmissionReceipt,
   RuntimeRunner,
   runAdmittedRuntimeContinuation,
-  runLegacyProviderRetry,
 } from './runtime-runner.js';
 import type {
   BackendFactoryContext,
@@ -228,11 +227,6 @@ export interface ChildAgentRetryInput {
   parentRunId: string;
   spec: ChildAgentTurnInput['spec'];
   continuation: RuntimeContinuation;
-  /**
-   * Chosen by SessionManager before any claim, Run creation, or provider T1.
-   * There is no fallback between these modes after execution begins.
-   */
-  admissionMode: 'durable_continuation' | 'legacy_provider_retry';
   /** Retry an ordinary session-inline AgentRun inside a linked child Session. */
   linkedSession?: boolean;
   onRunStarted?: () => void | Promise<void>;
@@ -922,7 +916,6 @@ export class RuntimeKernel implements RuntimeKernelLike {
       continuation,
       run,
       execution,
-      'durable_continuation',
       {
         sessionId: continuation.sessionId,
         turnId: continuation.turnId,
@@ -1289,117 +1282,92 @@ export class RuntimeKernel implements RuntimeKernelLike {
     }
     const sourceRun = await this.deps.runStore.readRun(sessionId, continuation.sourceRunId);
     const effectiveToolMode = effectiveToolModeForRun(sourceRun);
-    let durableAdmission:
-      | {
-          claimedRunHeader: AgentRunHeader;
-          commitContinuationStart: (
-            startedAt: number,
-          ) => Promise<{ startEventId: string; created: true }>;
-        }
-      | undefined;
-    if (input.admissionMode === 'durable_continuation') {
-      const continuationAuthority = requireRuntimeContinuationAuthority(
-        this.deps.runtimeEventStore,
-      );
-      const sourceEvents = await revalidateContinuationBoundary(
-        continuationAuthority,
-        continuation,
-      );
-      assertContinuationSourceUnchanged(continuation, sourceRun, sourceEvents);
-      await this.revalidateContinuationSafety(
-        continuation,
-        childTools.map((tool) => tool.name),
-      );
+    const continuationAuthority = requireRuntimeContinuationAuthority(this.deps.runtimeEventStore);
+    const sourceEvents = await revalidateContinuationBoundary(continuationAuthority, continuation);
+    assertContinuationSourceUnchanged(continuation, sourceRun, sourceEvents);
+    await this.revalidateContinuationSafety(
+      continuation,
+      childTools.map((tool) => tool.name),
+    );
 
-      const claimedAt = this.deps.now();
-      const targetRunHeader = continuationTargetRunHeaderForExecution({
-        continuation,
-        sessionHeader: childHeader,
-        userInput,
-        workspaceIdentity: continuation.safetySnapshot.workspaceIdentity,
-        effectiveOrchestration,
-        effectiveToolMode,
-        claimedAt,
-      });
-      const claim = continuationClaimForExecution(continuation, claimedAt, targetRunHeader);
-      const claimResult = await continuationAuthority.claimContinuation({
-        claim,
-      });
-      if (claimResult.kind !== 'acquired') {
-        throw new RuntimeContinuationRevalidationError(
-          'continuation_claim_conflict',
-          `Child retry continuation boundary is already claimed by ${claimResult.claim.claimId}`,
-        );
-      }
-      await this.deps.continuationFailpoint?.('after_continuation_claim_committed');
-      const continuationToolBoundaryProtocol = runtimeToolBoundaryProtocol(this.deps, childHeader);
-      durableAdmission = {
-        claimedRunHeader: claim.targetRunHeader,
-        commitContinuationStart: async (startedAt) => {
-          const source = claim.boundary.segments.at(-1)!;
-          const eventId = this.deps.newId();
-          const result = await continuationAuthority.commitContinuationStart({
-            claim,
-            event: {
-              id: eventId,
-              ...claim.target,
-              ts: startedAt,
-              partial: false,
-              role: 'system',
-              author: 'system',
-              actions: {
-                ...(continuationToolBoundaryProtocol
-                  ? {
-                      runtimeProtocol: {
-                        toolBoundary: continuationToolBoundaryProtocol,
-                      },
-                    }
-                  : {}),
-                continuationStart: {
-                  protocol: 'continuation_start_v2',
-                  provenance: 'runtime_admission',
-                  claimId: claim.claimId,
-                  boundaryDigest: claim.boundaryDigest,
-                  immediateSource: {
-                    sessionId: source.identity.sessionId,
-                    invocationId: source.identity.invocationId,
-                    runId: source.identity.runId,
-                    turnId: source.identity.turnId,
-                    highWater: source.position.lastEventSeq,
-                    prefixDigest: source.prefixDigest,
-                  },
-                  replayManifestDigest: claim.boundary.manifestDigest,
-                  providerProjectionVersion: claim.providerProjectionVersion,
-                  providerReplayDigest: claim.providerReplayDigest,
+    const claimedAt = this.deps.now();
+    const targetRunHeader = continuationTargetRunHeaderForExecution({
+      continuation,
+      sessionHeader: childHeader,
+      userInput,
+      workspaceIdentity: continuation.safetySnapshot.workspaceIdentity,
+      effectiveOrchestration,
+      effectiveToolMode,
+      claimedAt,
+    });
+    const claim = continuationClaimForExecution(continuation, claimedAt, targetRunHeader);
+    const claimResult = await continuationAuthority.claimContinuation({
+      claim,
+    });
+    if (claimResult.kind !== 'acquired') {
+      throw new RuntimeContinuationRevalidationError(
+        'continuation_claim_conflict',
+        `Child retry continuation boundary is already claimed by ${claimResult.claim.claimId}`,
+      );
+    }
+    await this.deps.continuationFailpoint?.('after_continuation_claim_committed');
+    const continuationToolBoundaryProtocol = runtimeToolBoundaryProtocol(this.deps, childHeader);
+    const durableAdmission: {
+      claimedRunHeader: AgentRunHeader;
+      commitContinuationStart: (
+        startedAt: number,
+      ) => Promise<{ startEventId: string; created: true }>;
+    } = {
+      claimedRunHeader: claim.targetRunHeader,
+      commitContinuationStart: async (startedAt) => {
+        const source = claim.boundary.segments.at(-1)!;
+        const eventId = this.deps.newId();
+        const result = await continuationAuthority.commitContinuationStart({
+          claim,
+          event: {
+            id: eventId,
+            ...claim.target,
+            ts: startedAt,
+            partial: false,
+            role: 'system',
+            author: 'system',
+            actions: {
+              ...(continuationToolBoundaryProtocol
+                ? {
+                    runtimeProtocol: {
+                      toolBoundary: continuationToolBoundaryProtocol,
+                    },
+                  }
+                : {}),
+              continuationStart: {
+                protocol: 'continuation_start_v2',
+                provenance: 'runtime_admission',
+                claimId: claim.claimId,
+                boundaryDigest: claim.boundaryDigest,
+                immediateSource: {
+                  sessionId: source.identity.sessionId,
+                  invocationId: source.identity.invocationId,
+                  runId: source.identity.runId,
+                  turnId: source.identity.turnId,
+                  highWater: source.position.lastEventSeq,
+                  prefixDigest: source.prefixDigest,
                 },
+                replayManifestDigest: claim.boundary.manifestDigest,
+                providerProjectionVersion: claim.providerProjectionVersion,
+                providerReplayDigest: claim.providerReplayDigest,
               },
             },
-          });
-          if (!result.created) {
-            throw new Error(
-              'Continuation-start already existed; refusing to reissue provider admission',
-            );
-          }
-          return { startEventId: eventId, created: true };
-        },
-      };
-    } else {
-      const readImmutable = this.deps.runtimeEventStore.readImmutableRuntimeEvents;
-      if (!readImmutable) {
-        throw new Error('Legacy child provider retry requires immutable RuntimeEvent reads');
-      }
-      if (sourceRun.status !== 'failed' || sourceRun.failureClass !== 'RateLimit') {
-        throw new Error('Legacy child provider retry requires a provider rate-limit failure');
-      }
-      const sourceEvents = await readImmutable.call(
-        this.deps.runtimeEventStore,
-        sessionId,
-        continuation.sourceRunId,
-      );
-      assertContinuationSourceUnchanged(continuation, sourceRun, sourceEvents);
-    }
+          },
+        });
+        if (!result.created) {
+          throw new Error(
+            'Continuation-start already existed; refusing to reissue provider admission',
+          );
+        }
+        return { startEventId: eventId, created: true };
+      },
+    };
     const activeKey = childActiveKey(sessionId, continuation.turnId);
-    const continuationToolBoundaryProtocol = runtimeToolBoundaryProtocol(this.deps, childHeader);
     const run = new AgentRun({
       sessionId,
       header: childHeader,
@@ -1418,7 +1386,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       workspaceIdentity: continuation.safetySnapshot.workspaceIdentity,
       effectiveOrchestration,
       effectiveToolMode,
-      ...(durableAdmission ?? {}),
+      ...durableAdmission,
       recordSessionMessages: false,
       hooks: {
         reserveRun: async (targetSessionId, nextHeader, activeRun) => {
@@ -1456,13 +1424,12 @@ export class RuntimeKernel implements RuntimeKernelLike {
     });
 
     this.attachExecutionClaim(execution, run);
-    // Both paths replay without a second user prompt. Only the durable mode
-    // consumes the source boundary through claim + continuation-start T1.
+    // The retry replays without a second user prompt; the source boundary is
+    // consumed through claim + continuation-start T1.
     yield* this.runAgentContinuation(
       continuation,
       run,
       execution,
-      input.admissionMode,
       input.linkedSession === true
         ? {
             sessionId,
@@ -1471,13 +1438,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
           }
         : undefined,
       input.onRunStarted,
-      input.admissionMode === 'durable_continuation'
-        ? () =>
-            this.revalidateContinuationSafety(
-              continuation,
-              childTools.map((tool) => tool.name),
-            )
-        : undefined,
+      () =>
+        this.revalidateContinuationSafety(
+          continuation,
+          childTools.map((tool) => tool.name),
+        ),
     );
   }
 
@@ -1727,7 +1692,6 @@ export class RuntimeKernel implements RuntimeKernelLike {
     continuation: RuntimeContinuation,
     run: AgentRun,
     execution: PendingExecutionClaim,
-    admissionMode: ChildAgentRetryInput['admissionMode'],
     messageOwner?: RuntimeMessageRunIdentity,
     onRunStarted?: () => void | Promise<void>,
     revalidateSafety?: () => Promise<void>,
@@ -1737,22 +1701,15 @@ export class RuntimeKernel implements RuntimeKernelLike {
       this.inheritExecutionAbort(execution);
     let flowDone = false;
     const owners = this.createRunOwnerScope(run, execution);
-    let begin:
-      | Awaited<ReturnType<AgentRun['beginContinuation']>>
-      | Awaited<ReturnType<AgentRun['beginOperation']>>;
+    let begin: Awaited<ReturnType<AgentRun['beginContinuation']>>;
     try {
       if (messageOwner) owners.bindMessage(this.deps.messageAuthority, messageOwner);
       begin = await this.runBackendActivation(async () => {
-        if (admissionMode === 'durable_continuation') {
-          if (!revalidateSafety) {
-            throw new Error('Durable continuation omitted final safety revalidation');
-          }
-          await revalidateSafety();
+        if (!revalidateSafety) {
+          throw new Error('Durable continuation omitted final safety revalidation');
         }
-        const started =
-          admissionMode === 'durable_continuation'
-            ? await run.beginContinuation(continuation)
-            : await run.beginOperation();
+        await revalidateSafety();
+        const started = await run.beginContinuation(continuation);
         await owners.bindInteraction(this.deps.interactionAuthority, {
           sessionId: continuation.sessionId,
           turnId: run.turnId,
@@ -1763,10 +1720,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       await onRunStarted?.();
     } catch (error) {
       releaseExecutionAbort();
-      if (
-        admissionMode === 'durable_continuation' &&
-        error instanceof ContinuationStartCommitError
-      ) {
+      if (error instanceof ContinuationStartCommitError) {
         await owners.abandonUnstartedContinuation(error);
         return;
       }
@@ -1817,31 +1771,22 @@ export class RuntimeKernel implements RuntimeKernelLike {
     });
     if (run.isStopped()) abortController.abort();
     let runnerFailure: unknown;
-    const runnerResult = (
-      admissionMode === 'durable_continuation'
-        ? runAdmittedRuntimeContinuation(
-            runner,
-            issueRuntimeContinuationAdmissionReceipt(
-              runner,
-              continuation,
-              'continuationStartAdmission' in begin
-                ? begin.continuationStartAdmission
-                : (() => {
-                    throw new Error('Durable continuation is missing its start admission');
-                  })(),
-              { orchestration: run.effectiveOrchestration, toolMode: run.toolMode },
-            ),
-            {
-              source: this.deps.runtimeSource ?? 'desktop',
-              abortSignal: abortController.signal,
-            },
-          )
-        : runLegacyProviderRetry(runner, continuation, {
-            source: this.deps.runtimeSource ?? 'desktop',
-            orchestration: run.effectiveOrchestration,
-            toolMode: run.toolMode,
-            abortSignal: abortController.signal,
-          })
+    const runnerResult = runAdmittedRuntimeContinuation(
+      runner,
+      issueRuntimeContinuationAdmissionReceipt(
+        runner,
+        continuation,
+        'continuationStartAdmission' in begin
+          ? begin.continuationStartAdmission
+          : (() => {
+              throw new Error('Durable continuation is missing its start admission');
+            })(),
+        { orchestration: run.effectiveOrchestration, toolMode: run.toolMode },
+      ),
+      {
+        source: this.deps.runtimeSource ?? 'desktop',
+        abortSignal: abortController.signal,
+      },
     ).then(
       async (result) => {
         if (!flowDone) {

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -138,11 +138,6 @@ export interface RuntimeContinuationAdmissionOptions {
   toolMode?: InvocationRequest['toolMode'];
 }
 
-interface LegacyProviderRetryRunOptions extends RuntimeContinuationRunOptions {
-  orchestration?: InvocationRequest['orchestration'];
-  toolMode?: InvocationRequest['toolMode'];
-}
-
 type AdmittedContinuationDispatcher = (request: InvocationRequest) => Promise<InvocationResult>;
 
 const admittedContinuationDispatchers = new WeakMap<
@@ -447,45 +442,6 @@ export function runAdmittedRuntimeContinuation(
     ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
   });
   return dispatch(request);
-}
-
-/**
- * @internal Transitional provider-rate-limit retry path for compositions that
- * have not yet installed durable continuation authority. This is deliberately
- * not a continuation admission fallback: SessionManager must select this mode
- * before planning/T1, and RuntimeKernel calls it only from the explicitly
- * tagged legacy provider-retry branch.
- *
- * The function remains package-private (absent from the barrel/exports map).
- * It preserves the pre-authority provider replay behavior until hosted
- * execution owns a typed SQLite authority and lifecycle.
- */
-export function runLegacyProviderRetry(
-  runner: RuntimeRunner,
-  continuation: RuntimeContinuation,
-  options: LegacyProviderRetryRunOptions,
-): Promise<InvocationResult> {
-  assertRuntimeContinuationEnvelope(continuation);
-  const dispatch = admittedContinuationDispatchers.get(runner);
-  if (!dispatch) {
-    throw new Error('RuntimeRunner instance is not registered for provider retry');
-  }
-  return dispatch(
-    snapshotInvocationRequest({
-      sessionId: continuation.sessionId,
-      invocationId: continuation.invocationId,
-      runId: continuation.runId,
-      turnId: continuation.turnId,
-      text: '',
-      context: [],
-      runtimeContext: continuation.runtimeContext,
-      continuation: invocationContinuationMetadata(continuation),
-      source: options.source,
-      ...(options.orchestration ? { orchestration: options.orchestration } : {}),
-      ...(options.toolMode ? { toolMode: options.toolMode } : {}),
-      ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
-    }),
-  );
 }
 
 /**

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -217,7 +217,6 @@ import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { stableHash } from './request-shape.js';
 import type { SubagentExecutionRef } from './subagent-execution.js';
 import {
-  buildResumePlanFromRuntimeEvents,
   RuntimeContinuationPlanner,
   type RuntimeContinuation,
   type RuntimeContinuationPlannerInput,
@@ -4106,33 +4105,19 @@ export class SessionManager {
     }
     this.assertChildRunHasNoSuccessor(runs, sourceRun.runId);
 
-    const hasAuthority = authority !== undefined;
-    const hasSafetyInspector = this.deps.inspectContinuationSafety !== undefined;
-    if (hasAuthority !== hasSafetyInspector) {
+    if (!authority || !this.deps.inspectContinuationSafety) {
       throw new Error(
         'Child agent retry continuation authority composition is incomplete; refusing legacy fallback',
       );
     }
-    const admissionMode = hasAuthority
-      ? ('durable_continuation' as const)
-      : ('legacy_provider_retry' as const);
-    const continuation =
-      admissionMode === 'durable_continuation'
-        ? await this.planDurableChildProviderRetry({
-            targetSessionId,
-            sourceRun,
-            runs,
-            authority: authority!,
-            inspectSafety: this.deps.inspectContinuationSafety!,
-            availableToolNames: definition.toolNames,
-          })
-        : await this.planLegacyChildProviderRetry({
-            targetSessionId,
-            rawSourceRun,
-            sourceRun,
-            runs,
-            availableToolNames: definition.toolNames,
-          });
+    const continuation = await this.planDurableChildProviderRetry({
+      targetSessionId,
+      sourceRun,
+      runs,
+      authority,
+      inspectSafety: this.deps.inspectContinuationSafety,
+      availableToolNames: definition.toolNames,
+    });
     const retryReplay = buildRuntimeEventModelReplayPlan(continuation.runtimeContext);
     const retryAnchor = retryReplay.items[0];
     if (!retryAnchor || retryAnchor.kind !== 'text' || retryAnchor.role !== 'user') {
@@ -4192,7 +4177,6 @@ export class SessionManager {
                       systemPrompt: definition.systemPrompt,
                     },
                     continuation,
-                    admissionMode,
                     linkedSession: true,
                     onRunStarted,
                   },
@@ -4215,7 +4199,6 @@ export class SessionManager {
                   systemPrompt: definition.systemPrompt,
                 },
                 continuation,
-                admissionMode,
               },
               runtimeExecution,
             ),
@@ -4339,81 +4322,6 @@ export class SessionManager {
       );
     }
     return retryPlan.continuation;
-  }
-
-  /**
-   * Preserves the pre-PR-B provider RateLimit retry for compositions that have
-   * neither continuation authority nor a safety inspector. It is intentionally
-   * not a durable continuation: no claim or continuation-start is written, and
-   * it cannot recover a claim-repair abandonment. The host authority lifecycle
-   * integration replaces this path with a typed SQLite composition.
-   */
-  private async planLegacyChildProviderRetry(input: {
-    targetSessionId: string;
-    rawSourceRun: AgentRunHeader;
-    sourceRun: AgentRunHeader;
-    runs: readonly AgentRunHeader[];
-    availableToolNames: readonly string[];
-  }): Promise<RuntimeContinuation> {
-    if (!this.deps.runtimeEventStore?.readImmutableRuntimeEvents) {
-      throw new Error('Legacy child provider retry requires immutable RuntimeEvent reads');
-    }
-    if (input.sourceRun.failureClass !== 'RateLimit') {
-      throw new Error('Legacy child provider retry only supports provider rate-limit failures');
-    }
-
-    const replaySegments: RuntimeEvent[][] = [];
-    let sourceEvents: RuntimeEvent[] | undefined;
-    let sourceReplay: RuntimeEvent[] | undefined;
-    let chainRun: AgentRunHeader | undefined = input.rawSourceRun;
-    const visited = new Set<string>();
-    while (chainRun) {
-      if (visited.has(chainRun.runId)) {
-        throw new Error('Child agent retry lineage contains a cycle');
-      }
-      visited.add(chainRun.runId);
-      const events = await this.deps.runtimeEventStore.readImmutableRuntimeEvents(
-        input.targetSessionId,
-        chainRun.runId,
-      );
-      const plan = buildResumePlanFromRuntimeEvents(events);
-      if (plan.disposition !== 'safe_replay') {
-        throw new Error(`Child agent retry source is not safely replayable: ${chainRun.runId}`);
-      }
-      replaySegments.unshift(plan.replayRuntimeEvents);
-      if (chainRun.runId === input.sourceRun.runId) {
-        sourceEvents = events;
-        sourceReplay = plan.replayRuntimeEvents;
-      }
-      const previousRunId: string | undefined =
-        chainRun.retriedFromRunId ?? chainRun.resumedFromRunId;
-      if (!previousRunId) break;
-      chainRun = input.runs.find((run) => run.runId === previousRunId);
-      if (!chainRun) throw new Error('Child agent retry lineage source is missing');
-    }
-    if (!sourceEvents || !sourceReplay) {
-      throw new Error('Child agent retry source ledger is missing');
-    }
-    const sourceInvocationId = input.sourceRun.invocationId ?? sourceEvents[0]?.invocationId;
-    if (!sourceInvocationId) throw new Error('Child agent retry source has no invocation id');
-
-    return {
-      sessionId: input.targetSessionId,
-      invocationId: this.deps.newId(),
-      runId: this.deps.newId(),
-      turnId: this.deps.newId(),
-      sourceInvocationId,
-      sourceRunId: input.sourceRun.runId,
-      sourceTurnId: input.sourceRun.turnId,
-      sourceRuntimeEventHighWater: sourceEvents.length,
-      sourceRuntimeContext: sourceReplay,
-      runtimeContext: replaySegments.flat(),
-      safetySnapshot: {
-        workspaceIdentity: input.sourceRun.workspaceIdentity ?? input.sourceRun.cwd,
-        backgroundOperationsSettled: true,
-        availableToolNames: [...input.availableToolNames],
-      },
-    };
   }
 
   private assertChildRunHasNoSuccessor(runs: readonly AgentRunHeader[], sourceRunId: string): void {


### PR DESCRIPTION
## Summary

Removes the legacy `legacy_provider_retry` admission lane for child provider retries so durable continuation is the only path, per #3035. Production Runtime Hosts always provide both the SQLite continuation authority and the safety inspector, so host behavior is unchanged.

- `ChildAgentRetryInput` no longer carries an `admissionMode`; `retryChildAgentWithExecution` replaces the mismatch/fallback selection with a single fail-closed guard that rejects an incomplete continuation composition (authority or safety inspector missing) before any claim, Run creation, or provider dispatch.
- Deleted `planLegacyChildProviderRetry()` (session-manager) and `runLegacyProviderRetry()` + `LegacyProviderRetryRunOptions` (runtime-runner); the durable claim + continuation-start block in `startChildRetryClaimed` and `runAgentContinuation` is now unconditional.
- Provider rate-limit retry, continuation recovery, and linked-child behavior remain covered by the existing durable-path tests, unchanged.
- Updated the two zh-CN architecture docs that documented the legacy lane.

Behavior change: a directly constructed `SessionManager` without a complete continuation composition no longer retries child provider failures — it fails closed. This is not a supported product surface (per #3035).

Fixes #3035

## Verification

- `npm run format:check` — clean (8 formatting nits auto-fixed and folded in)
- `npm run lint` — 2304 files, no issues
- `npm run typecheck` 
- `npm --workspace @maka/runtime run build` — clean
- `npm --workspace @maka/runtime run test:dist` — 2983 tests, 2971 pass, 12 skip


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: ZCode (GLM) — analyzed the retry admission paths and issue #3035, implemented the removal across runtime/runtime-runner/session-manager and the regression test, ran the verification suites. Human contributor of record reviewed the change and is responsible for the submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No