### PR TITLE
fix(runtime): bound text history summarizer inputs

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -1086,6 +1086,8 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     assert.equal(remembered.result.kind, 'committed');
 
     const turnIds: string[] = [];
+    // Cross the history high-water without making the text-only compact input
+    // exceed this fixture's 2,304-token summarizer budget.
     for (let index = 0; index < 5; index += 1) {
       const turnId = randomUUID();
       turnIds.push(turnId);
@@ -1094,10 +1096,10 @@ test('production Host executes a canonical ai-sdk Session against a real provide
         session.id,
         turnId,
         index === 0
-          ? `Reply with the hosted execution result.${' HISTORY_PRESSURE'.repeat(160)}`
+          ? `Reply with the hosted execution result.${' HISTORY_PRESSURE'.repeat(128)}`
           : index === 1
-            ? `/skill:hosted-skill Continue hosted execution turn ${index}.${' HISTORY_PRESSURE'.repeat(160)}`
-            : `Continue hosted execution turn ${index}.${' HISTORY_PRESSURE'.repeat(160)}`,
+            ? `/skill:hosted-skill Continue hosted execution turn ${index}.${' HISTORY_PRESSURE'.repeat(128)}`
+            : `Continue hosted execution turn ${index}.${' HISTORY_PRESSURE'.repeat(128)}`,
         connectionContext,
       );
       const terminal = await waitForTerminal(

--- a/packages/runtime/src/__tests__/history-compact-input-fit.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-input-fit.test.ts
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { stableJsonLength } from '../context-budget-helpers.js';
+import { HistoryCompactSummarizerError } from '../history-compact-error.js';
+import { fitHistoryCompactMessages } from '../history-compact-input-fit.js';
+import type { ModelMessage } from '../model-protocol.js';
+
+describe('history compaction input fitting', () => {
+  test('bounds oversized tool evidence without breaking the call/result pair', () => {
+    const oversizedOutput = 'raw-tool-output-'.repeat(1_024);
+    const messages: ModelMessage[] = [
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-1',
+            toolName: 'shell',
+            input: { command: 'inspect' },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: [
+          {
+            type: 'tool-result',
+            toolCallId: 'call-1',
+            toolName: 'shell',
+            output: { type: 'text', value: oversizedOutput },
+          },
+        ],
+      },
+      { role: 'assistant', content: [{ type: 'text', text: 'The inspection completed.' }] },
+    ];
+
+    const bounded = fitHistoryCompactMessages(messages, {
+      maxInputEstimatedTokens: 600,
+      charsPerToken: 1,
+    });
+
+    assert.ok(stableJsonLength(bounded) <= 600);
+    assert.equal(JSON.stringify(bounded).includes(oversizedOutput), false);
+    assert.deepEqual(
+      bounded.flatMap((message) =>
+        typeof message.content === 'string'
+          ? []
+          : message.content
+              .filter((part) => part.type === 'tool-call' || part.type === 'tool-result')
+              .map((part) => ({ type: part.type, toolCallId: part.toolCallId })),
+      ),
+      [
+        { type: 'tool-call', toolCallId: 'call-1' },
+        { type: 'tool-result', toolCallId: 'call-1' },
+      ],
+    );
+  });
+
+  test('fails before dispatch when non-tool history cannot fit', () => {
+    assert.throws(
+      () =>
+        fitHistoryCompactMessages(
+          [{ role: 'user', content: [{ type: 'text', text: 'x'.repeat(1_000) }] }],
+          { maxInputEstimatedTokens: 10, charsPerToken: 1 },
+        ),
+      (error) =>
+        error instanceof HistoryCompactSummarizerError && error.reason === 'input_too_large',
+    );
+  });
+
+  test('keeps the projection unchanged without a budget or when it already fits', () => {
+    const messages: ModelMessage[] = [
+      { role: 'user', content: [{ type: 'text', text: 'bounded history' }] },
+    ];
+
+    assert.deepEqual(fitHistoryCompactMessages(messages, {}), messages);
+    assert.deepEqual(
+      fitHistoryCompactMessages(messages, {
+        maxInputEstimatedTokens: 1_000,
+        charsPerToken: 1,
+      }),
+      messages,
+    );
+  });
+});

--- a/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
+++ b/packages/runtime/src/__tests__/history-compact-summarizer.test.ts
@@ -15,6 +15,7 @@ import { ProviderRequestTracker } from '../provider-request-telemetry.js';
 import type { HistoryCompactSummaryInput } from '../ai-sdk-compaction-contract.js';
 import {
   buildLlmHistorySummarizer,
+  HistoryCompactSummarizerError,
   type AiSdkGenerateTextLike,
 } from '../history-compact-summarizer.js';
 import { buildHistoryCompactCheckpoint } from '../history-compact-checkpoint.js';
@@ -57,9 +58,10 @@ describe('buildLlmHistorySummarizer', () => {
       },
     });
 
-    await summarize(
-      inputWith([ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'hi' } })]),
-    );
+    await summarize({
+      ...inputWith([ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'hi' } })]),
+      inputBudget: { maxEstimatedTokens: 10_000, charsPerToken: 1 },
+    });
 
     expect(seen?.providerOptions).toBe(providerOptions);
     expect(seen?.maxOutputTokens).toBe(undefined);
@@ -342,6 +344,142 @@ describe('buildLlmHistorySummarizer', () => {
     ]);
   });
 
+  test('bounds the oldest oversized tool result before dispatch while preserving newer context', async () => {
+    let seen: Parameters<AiSdkGenerateTextLike>[0] | undefined;
+    const generateText: AiSdkGenerateTextLike = async (options) => {
+      seen = options;
+      return { text: '## Goal\nX' };
+    };
+    const summarize = buildLlmHistorySummarizer({ resolveModel: () => 'fake-model', generateText });
+    const oldToolOutput = 'OLD_OVERSIZED_TOOL_OUTPUT_'.repeat(1_024);
+    const events: RuntimeEvent[] = [
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'function_call', id: 'old-call', name: 'read', args: { path: 'old.log' } },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'old-call',
+          name: 'read',
+          result: oldToolOutput,
+        },
+      }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'function_call',
+          id: 'recent-call',
+          name: 'read',
+          args: { path: 'recent.log' },
+        },
+      }),
+      ev({
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'recent-call',
+          name: 'read',
+          result: 'RECENT_TOOL_RESULT',
+        },
+      }),
+      ev({
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'LATEST_GROUNDED_CONTEXT' },
+      }),
+    ];
+
+    await summarize({
+      ...inputWith(events),
+      inputBudget: { maxEstimatedTokens: 4_000, charsPerToken: 1 },
+    });
+
+    const messages = seen!.messages;
+    const serialized = JSON.stringify(messages);
+    assert.ok(serialized.length <= 4_000);
+    assert.equal(serialized.includes(oldToolOutput), false);
+    assert.match(serialized, /Tool output omitted/);
+    assert.match(serialized, /RECENT_TOOL_RESULT/);
+    assert.match(serialized, /LATEST_GROUNDED_CONTEXT/);
+    assert.match(JSON.stringify(events), /OLD_OVERSIZED_TOOL_OUTPUT/);
+    assert.deepEqual(
+      messages.flatMap((message) =>
+        typeof message.content === 'string'
+          ? []
+          : message.content
+              .filter((part) => part.type === 'tool-call' || part.type === 'tool-result')
+              .map((part) => ({ type: part.type, toolCallId: part.toolCallId })),
+      ),
+      [
+        { type: 'tool-call', toolCallId: 'old-call' },
+        { type: 'tool-result', toolCallId: 'old-call' },
+        { type: 'tool-call', toolCallId: 'recent-call' },
+        { type: 'tool-result', toolCallId: 'recent-call' },
+      ],
+    );
+  });
+
+  test('fails with input_too_large before dispatch when non-tool history cannot fit', async () => {
+    let calls = 0;
+    let modelResolutions = 0;
+    const summarize = buildLlmHistorySummarizer({
+      resolveModel: () => {
+        modelResolutions += 1;
+        return 'fake-model';
+      },
+      generateText: async () => {
+        calls += 1;
+        return { text: 'should not dispatch' };
+      },
+    });
+
+    await assert.rejects(
+      summarize({
+        ...inputWith([
+          ev({
+            role: 'user',
+            author: 'user',
+            content: { kind: 'text', text: 'x'.repeat(1_000) },
+          }),
+        ]),
+        inputBudget: { maxEstimatedTokens: 10, charsPerToken: 1 },
+      }),
+      (error) =>
+        error instanceof HistoryCompactSummarizerError && error.reason === 'input_too_large',
+    );
+    assert.equal(calls, 0);
+    assert.equal(modelResolutions, 0);
+  });
+
+  test('charges the summarization instructions against the input budget before dispatch', async () => {
+    let calls = 0;
+    const summarize = buildLlmHistorySummarizer({
+      resolveModel: () => 'fake-model',
+      generateText: async () => {
+        calls += 1;
+        return { text: 'should not dispatch' };
+      },
+    });
+
+    await assert.rejects(
+      summarize({
+        ...inputWith([
+          ev({ role: 'user', author: 'user', content: { kind: 'text', text: 'small history' } }),
+        ]),
+        inputBudget: { maxEstimatedTokens: 500, charsPerToken: 1 },
+      }),
+      (error) =>
+        error instanceof HistoryCompactSummarizerError && error.reason === 'input_too_large',
+    );
+    assert.equal(calls, 0);
+  });
+
   test('stamped step ids decide membership over settledness', async () => {
     const seen: Array<{ messages: unknown[] }> = [];
     const generateText: AiSdkGenerateTextLike = async (opts) => {
@@ -494,6 +632,7 @@ describe('buildLlmHistorySummarizer', () => {
       ...input,
       previousCheckpoint,
       newlyFoldedRuntimeEvents: [newer],
+      inputBudget: { maxEstimatedTokens: 10_000, charsPerToken: 1 },
     });
 
     expect(result).toBe('rolled');

--- a/packages/runtime/src/__tests__/openai-codex-history-compactor.test.ts
+++ b/packages/runtime/src/__tests__/openai-codex-history-compactor.test.ts
@@ -1,75 +1,18 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { stableJsonLength } from '../context-budget-helpers.js';
-import { HistoryCompactSummarizerError } from '../history-compact-error.js';
-import type { ModelMessage } from '../model-protocol.js';
 import {
   extractOpenAiCodexCompactionState,
   fitOpenAiCodexCompactionMessages,
 } from '../openai-codex-history-compactor.js';
 
-describe('OpenAI Codex history compaction input', () => {
-  test('bounds oversized tool evidence without breaking the call/result pair', () => {
-    const oversizedOutput = 'raw-tool-output-'.repeat(1_024);
-    const messages: ModelMessage[] = [
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool-call',
-            toolCallId: 'call-1',
-            toolName: 'shell',
-            input: { command: 'inspect' },
-          },
-        ],
-      },
-      {
-        role: 'tool',
-        content: [
-          {
-            type: 'tool-result',
-            toolCallId: 'call-1',
-            toolName: 'shell',
-            output: { type: 'text', value: oversizedOutput },
-          },
-        ],
-      },
-      { role: 'assistant', content: [{ type: 'text', text: 'The inspection completed.' }] },
-    ];
-
-    const bounded = fitOpenAiCodexCompactionMessages(messages, {
-      maxInputEstimatedTokens: 600,
-      charsPerToken: 1,
-    });
-
-    assert.ok(stableJsonLength(bounded) <= 600);
-    assert.equal(JSON.stringify(bounded).includes(oversizedOutput), false);
-    assert.deepEqual(
-      bounded.flatMap((message) =>
-        typeof message.content === 'string'
-          ? []
-          : message.content
-              .filter((part) => part.type === 'tool-call' || part.type === 'tool-result')
-              .map((part) => ({ type: part.type, toolCallId: part.toolCallId })),
-      ),
-      [
-        { type: 'tool-call', toolCallId: 'call-1' },
-        { type: 'tool-result', toolCallId: 'call-1' },
-      ],
-    );
-  });
-
-  test('fails before dispatch when non-tool history cannot fit', () => {
-    assert.throws(
-      () =>
-        fitOpenAiCodexCompactionMessages(
-          [{ role: 'user', content: [{ type: 'text', text: 'x'.repeat(1_000) }] }],
-          { maxInputEstimatedTokens: 10, charsPerToken: 1 },
-        ),
-      (error) =>
-        error instanceof HistoryCompactSummarizerError && error.reason === 'input_too_large',
-    );
-  });
+test('preserves the provider-specific input-fitting export', () => {
+  assert.deepEqual(
+    fitOpenAiCodexCompactionMessages(
+      [{ role: 'user', content: [{ type: 'text', text: 'bounded history' }] }],
+      { maxInputEstimatedTokens: 1_000, charsPerToken: 1 },
+    ),
+    [{ role: 'user', content: [{ type: 'text', text: 'bounded history' }] }],
+  );
 });
 
 describe('OpenAI Codex compaction output', () => {

--- a/packages/runtime/src/history-compact-input-fit.ts
+++ b/packages/runtime/src/history-compact-input-fit.ts
@@ -1,0 +1,56 @@
+import { finitePositive, stableJsonLength } from './context-budget-helpers.js';
+import { HistoryCompactSummarizerError } from './history-compact-error.js';
+import type { ModelMessage } from './model-protocol.js';
+
+const COMPACTION_TOOL_OUTPUT_PLACEHOLDER =
+  '[Tool output omitted because it exceeded the compaction input budget.]';
+
+/**
+ * Bound a compaction request without breaking tool-call chronology. Old tool
+ * outputs are the only lossy candidates: replacing their payload keeps every
+ * call/result pair valid and preserves more recent evidence.
+ */
+export function fitHistoryCompactMessages(
+  messages: readonly ModelMessage[],
+  options: {
+    maxInputEstimatedTokens?: number;
+    charsPerToken?: number;
+    fixedInputChars?: number;
+  },
+): ModelMessage[] {
+  const maxEstimatedTokens = finitePositive(options.maxInputEstimatedTokens);
+  if (maxEstimatedTokens === undefined) return [...messages];
+  const charsPerToken = finitePositive(options.charsPerToken) ?? 4;
+  const maxEstimatedChars = maxEstimatedTokens * charsPerToken;
+  let estimatedChars = (finitePositive(options.fixedInputChars) ?? 0) + stableJsonLength(messages);
+  if (estimatedChars <= maxEstimatedChars) return [...messages];
+
+  let bounded = [...messages];
+  for (let messageIndex = 0; messageIndex < bounded.length; messageIndex += 1) {
+    const message = bounded[messageIndex]!;
+    if (message.role !== 'tool') continue;
+    for (let partIndex = 0; partIndex < message.content.length; partIndex += 1) {
+      const part = message.content[partIndex]!;
+      if (part.type !== 'tool-result') continue;
+      const output =
+        part.output.type === 'error-text' || part.output.type === 'error-json'
+          ? { type: 'error-text' as const, value: COMPACTION_TOOL_OUTPUT_PLACEHOLDER }
+          : { type: 'text' as const, value: COMPACTION_TOOL_OUTPUT_PLACEHOLDER };
+      const replacement = {
+        ...part,
+        output,
+      };
+      const originalChars = stableJsonLength(part);
+      const replacementChars = stableJsonLength(replacement);
+      if (replacementChars >= originalChars) continue;
+      const content = [...message.content];
+      content[partIndex] = replacement;
+      bounded = [...bounded];
+      bounded[messageIndex] = { ...message, content };
+      estimatedChars -= originalChars - replacementChars;
+      if (estimatedChars <= maxEstimatedChars) return bounded;
+    }
+  }
+
+  throw new HistoryCompactSummarizerError('input_too_large');
+}

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -4,6 +4,7 @@ import { toolResultOutput } from './tool-result-output.js';
 import type { HistoryCompactSummaryInput } from './ai-sdk-compaction-contract.js';
 import { HistoryCompactSummarizerError } from './history-compact-error.js';
 import { isTextHistoryCompactCheckpoint } from './history-compact-checkpoint.js';
+import { fitHistoryCompactMessages } from './history-compact-input-fit.js';
 import type { AiSdkUsageLike } from './model-adapter.js';
 import { withProviderGenerateTracking } from './provider-request-telemetry.js';
 
@@ -78,9 +79,9 @@ export function buildLlmHistorySummarizer(options: BuildLlmHistorySummarizerOpti
     if (newlyFoldedRuntimeEvents.length === 0) return previousCheckpoint?.summary;
     try {
       const plan = buildRuntimeEventModelReplayPlan(newlyFoldedRuntimeEvents);
-      const messages = replayPlanItemsToModelMessages(plan.items);
+      const projectedMessages = replayPlanItemsToModelMessages(plan.items);
       if (previousCheckpoint) {
-        messages.unshift({
+        projectedMessages.unshift({
           role: 'user',
           content: [
             {
@@ -90,6 +91,11 @@ export function buildLlmHistorySummarizer(options: BuildLlmHistorySummarizerOpti
           ],
         });
       }
+      const messages = fitHistoryCompactMessages(projectedMessages, {
+        maxInputEstimatedTokens: input.inputBudget?.maxEstimatedTokens,
+        charsPerToken: input.inputBudget?.charsPerToken,
+        fixedInputChars: SUMMARIZATION_SYSTEM_PROMPT.length,
+      });
       // Handed over whole by the backend, which owns every input a tracker
       // needs — including the run, which no summarizer wiring can know (#1679).
       const providerRequestTracker = input.providerRequestTracker;

--- a/packages/runtime/src/openai-codex-history-compactor.ts
+++ b/packages/runtime/src/openai-codex-history-compactor.ts
@@ -7,13 +7,15 @@ import {
 } from './history-compact-checkpoint.js';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { ModelMessage } from './model-protocol.js';
-import { finitePositive, stableJsonLength } from './context-budget-helpers.js';
+import { fitHistoryCompactMessages } from './history-compact-input-fit.js';
 import {
   buildRuntimeEventModelReplayPlan,
   type RuntimeEventModelReplayItem,
 } from './model-history.js';
 import { withProviderStreamTracking } from './provider-request-telemetry.js';
 import { toolResultOutput } from './tool-result-output.js';
+
+export { fitHistoryCompactMessages as fitOpenAiCodexCompactionMessages } from './history-compact-input-fit.js';
 
 export interface BuildOpenAiCodexHistoryCompactorOptions {
   resolveModel: () => unknown;
@@ -51,7 +53,7 @@ export function buildOpenAiCodexHistoryCompactor(options: BuildOpenAiCodexHistor
       if (canContinuePrevious) {
         projectedMessages.unshift(historyCompactCheckpointToModelMessage(previous));
       }
-      const messages = fitOpenAiCodexCompactionMessages(projectedMessages, {
+      const messages = fitHistoryCompactMessages(projectedMessages, {
         maxInputEstimatedTokens: input.inputBudget?.maxEstimatedTokens,
         charsPerToken: input.inputBudget?.charsPerToken,
       });
@@ -252,55 +254,6 @@ export function openAiCodexCompactionMessages(events: readonly RuntimeEvent[]): 
     }
   }
   return messages;
-}
-
-const COMPACTION_TOOL_OUTPUT_PLACEHOLDER =
-  '[Tool output omitted because it exceeded the compaction input budget.]';
-
-/**
- * Bound the provider-native compaction request without breaking tool-call
- * chronology. Old tool outputs are the only lossy candidates: replacing their
- * payload keeps every call/result pair valid and preserves more recent evidence.
- */
-export function fitOpenAiCodexCompactionMessages(
-  messages: readonly ModelMessage[],
-  options: { maxInputEstimatedTokens?: number; charsPerToken?: number },
-): ModelMessage[] {
-  const maxEstimatedTokens = finitePositive(options.maxInputEstimatedTokens);
-  if (maxEstimatedTokens === undefined) return [...messages];
-  const charsPerToken = finitePositive(options.charsPerToken) ?? 4;
-  const maxEstimatedChars = maxEstimatedTokens * charsPerToken;
-  let estimatedChars = stableJsonLength(messages);
-  if (estimatedChars <= maxEstimatedChars) return [...messages];
-
-  let bounded = [...messages];
-  for (let messageIndex = 0; messageIndex < bounded.length; messageIndex += 1) {
-    const message = bounded[messageIndex]!;
-    if (message.role !== 'tool') continue;
-    for (let partIndex = 0; partIndex < message.content.length; partIndex += 1) {
-      const part = message.content[partIndex]!;
-      if (part.type !== 'tool-result') continue;
-      const output =
-        part.output.type === 'error-text' || part.output.type === 'error-json'
-          ? { type: 'error-text' as const, value: COMPACTION_TOOL_OUTPUT_PLACEHOLDER }
-          : { type: 'text' as const, value: COMPACTION_TOOL_OUTPUT_PLACEHOLDER };
-      const replacement = {
-        ...part,
-        output,
-      };
-      const originalChars = stableJsonLength(part);
-      const replacementChars = stableJsonLength(replacement);
-      if (replacementChars >= originalChars) continue;
-      const content = [...message.content];
-      content[partIndex] = replacement;
-      bounded = [...bounded];
-      bounded[messageIndex] = { ...message, content };
-      estimatedChars -= originalChars - replacementChars;
-      if (estimatedChars <= maxEstimatedChars) return bounded;
-    }
-  }
-
-  throw new HistoryCompactSummarizerError('input_too_large');
 }
 
 export function extractOpenAiCodexCompactionState(


### PR DESCRIPTION
## Summary

- Honor the history compaction input budget in the text LLM summarizer before provider dispatch.
- Share deterministic request fitting with provider-native compaction, omitting older Tool Result payloads while preserving call/result pairs and newer grounded context.
- Charge fixed summarization instructions against the budget, fail locally with typed input_too_large when the request still cannot fit, and preserve the existing provider-specific helper export.

Fixes #3013

## Verification

- `node --test packages/runtime/dist/__tests__/history-compact-input-fit.test.js packages/runtime/dist/__tests__/history-compact-summarizer.test.js packages/runtime/dist/__tests__/openai-codex-history-compactor.test.js` — 22 passed, 0 failed.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm --workspace @maka/runtime run typecheck` — passed.
- `npm --workspace @maka/runtime run test` — affected tests pass; the latest full run had 2,861 passed, 1 failed, and 12 skipped because the pre-existing Unix PTY lifecycle test timed out after 10 seconds. The same test failed on the clean baseline and also passed on intervening full runs.
- `npm run typecheck` — blocked by the existing desktop test fixture at `apps/desktop/src/main/__tests__/runtime-host-external-sessions-ipc-main.test.ts:19`, which is missing the required `importState` field.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the runtime fitting helper, integrations, tests, review fixes, and verification.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No