### PR TITLE
fix(desktop): keep task menu interactive while open

### DIFF
--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -1,6 +1,7 @@
 import {
   LONG_SIDEBAR_PROJECT_ID,
   LONG_SIDEBAR_PROJECT_NAME,
+  LONG_SIDEBAR_SESSION_PREFIX,
 } from '../src/main/e2e-fixture/seed-helpers';
 import { expect, test } from './fixtures';
 
@@ -61,6 +62,26 @@ test('project navigation and actions remain adjacent keyboard controls', async (
   await expect(page.getByRole('dialog', { name: '重命名项目' })).toBeVisible();
   await page.getByRole('button', { name: '关闭', exact: true }).click();
   await expect(action).toBeFocused();
+});
+
+test('task row action menu accepts pointer selection', async ({
+  projectSidebarWindow: page,
+}) => {
+  await page.keyboard.press('Escape');
+  await expect(page.locator('[data-maka-contract="search-modal"]')).not.toBeVisible();
+
+  const sidebar = page.getByRole('navigation', { name: '任务列表' });
+  const taskRow = sidebar.locator(
+    `[data-session-id="${LONG_SIDEBAR_SESSION_PREFIX}00"]`,
+  );
+  await taskRow.hover();
+  await taskRow.getByRole('button', { name: '任务操作', exact: true }).click();
+
+  const rename = page.getByRole('menuitem', { name: '重命名', exact: true });
+  await expect(rename).toBeVisible();
+  await rename.click();
+
+  await expect(page.getByRole('dialog', { name: '重命名任务' })).toBeVisible();
 });
 
 test('rail grouping survives a renderer reload', async ({ projectSidebarWindow: page }) => {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -284,7 +284,10 @@
  * five things wide.
  *
  * :focus-within covers the keyboard: focus on the row's own button reveals the
- * menu, and focus moving into the menu keeps it revealed.
+ * menu. The native popover's own open state covers the pointer handoff into the
+ * top layer: once the pointer leaves the row, :hover drops before the item can
+ * receive its click, and pointer-events: none on this ancestor otherwise makes
+ * the page underneath the visible popover win hit testing.
  */
 .maka-session-row-time {
   display: inline-flex;
@@ -312,7 +315,8 @@
 }
 
 .maka-session-row:hover > .maka-session-row-action,
-.maka-session-row:focus-within > .maka-session-row-action {
+.maka-session-row:focus-within > .maka-session-row-action,
+.maka-session-row > .maka-session-row-action:has([popover]:popover-open) {
   opacity: 1;
   pointer-events: auto;
 }


### PR DESCRIPTION
## Summary

Fix task row action menus whose visible native popover stopped accepting pointer clicks after the cursor left the row. Keep the action host pointer-interactive for the full popover-open lifetime so the underlying chat surface cannot intercept menu item clicks.

## Verification

- Focused Electron pointer regression failed on main because the chat message list intercepted the menu-item click, then passed after the fix.
- npm --workspace @maka/desktop run e2e -- sidebar-project-row.spec.ts --grep "task row action menu accepts pointer selection"
- npx playwright test --config e2e/playwright.config.ts sidebar-project-row.spec.ts — 3 passed
- npm run format:check — 1463 files checked, no fixes needed
- Manual real-window coordinate check: opening the task menu and clicking 重命名 opens the rename dialog.

## Root cause

The hover-only task action host returned to pointer-events: none while its native popover remained visibly open in the top layer. That value made hit testing fall through the menu to the chat surface underneath. The open popover is now an additional authority for keeping the host interactive.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the pointer hit-testing regression, authored the CSS fix and Electron regression test, and ran the reported verification.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No