### PR TITLE
fix(desktop): import Plan Mode copy types from core subpaths

### DIFF
--- a/apps/desktop/src/renderer/locales/plan-mode-copy.ts
+++ b/apps/desktop/src/renderer/locales/plan-mode-copy.ts
@@ -1,4 +1,5 @@
-import type { PlanExecutionStep, PlanProposal, UiCatalog, UiLocale } from '@maka/core';
+import type { PlanExecutionStep, PlanProposal } from '@maka/core/plan';
+import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
 
 export interface PlanModeCopy {
   readonly abandonConfirmation: {


### PR DESCRIPTION
## Summary

`main` is currently red after #2688. Plan Mode locale types import the removed `@maka/core` root barrel:

```ts
import type { PlanExecutionStep, PlanProposal, UiCatalog, UiLocale } from '@maka/core';
```

`@maka/core` no longer has a `.` export (see #3094). Desktop main typecheck follows `src/main/__tests__/plan-mode-copy.test.ts` into that renderer file and fails with `TS2307: Cannot find module '@maka/core'`. That cascades to `typecheck`, `test_workspaces`, `test_runtime_host`, `test`, `e2e`, and `windows_recovery` on every PR merged with current `main`.

Other locale catalogs already use the live subpaths. This PR matches them:

```ts
import type { PlanExecutionStep, PlanProposal } from '@maka/core/plan';
import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
```

## Test plan

- [x] `@maka/desktop` typecheck (preload / main / renderer / storybook)
- [x] `plan-mode-copy` official node:test `1/1`

Generated-by: Grok
