### PR TITLE
fix(desktop): import plan-mode copy types from core subpaths

### DIFF
--- a/apps/desktop/src/renderer/locales/plan-mode-copy.ts
+++ b/apps/desktop/src/renderer/locales/plan-mode-copy.ts
@@ -1,4 +1,5 @@
-import type { PlanExecutionStep, PlanProposal, UiCatalog, UiLocale } from '@maka/core';
+import type { PlanExecutionStep, PlanProposal } from '@maka/core/plan';
+import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
 
 export interface PlanModeCopy {
   readonly abandonConfirmation: {


### PR DESCRIPTION
## Summary

`apps/desktop/src/renderer/locales/plan-mode-copy.ts` imported `PlanExecutionStep`, `PlanProposal`, `UiCatalog` and `UiLocale` from the `@maka/core` root. The package only exposes subpath exports (no `"."` entry), so the import failed to resolve and TypeScript fell back to implicit `any`. That broke the desktop build and took down every CI lane on `main` and every branch based on it since `feat(desktop): localize Plan Mode (#2688)` merged.

Switch to the `@maka/core/plan` and `@maka/core/ui-locale` subpaths, matching how every other renderer file imports from core.

## Verification

- `npm run format:check` — passes
- `npm run typecheck` — passes (incl. desktop main/preload/renderer/storybook tsconfigs)
- `npm run build:main` in `apps/desktop` — passes (the exact step that failed in CI)

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (coding agent) diagnosed the failing import and authored the one-line import fix; commit carries `Generated-by: pi`.