### PR TITLE
test(desktop): hold the prompt-rail eviction jump at the top

### DIFF
--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -74,6 +74,27 @@ async function scrollTranscriptTo(page: Page, position: 'top' | 'bottom'): Promi
   }, position);
 }
 
+async function waitForPaintedFrames(page: Page, count = 2): Promise<void> {
+  await page.evaluate((frames) => new Promise<void>((resolve) => {
+    const tick = (left: number) => {
+      if (left <= 0) {
+        resolve();
+        return;
+      }
+      requestAnimationFrame(() => tick(left - 1));
+    };
+    tick(frames);
+  }), count);
+}
+
+function notifyTranscriptScrolled(page: Page): Promise<void> {
+  return page.evaluate(() => {
+    const root = document.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');
+    if (!root) throw new Error('the chat scroll container is missing');
+    root.dispatchEvent(new Event('scroll'));
+  });
+}
+
 async function loadPromptRailBeyondVirtualWindow(page: Page): Promise<void> {
   const transcript = page.locator('.maka-chat-message-list');
   await scrollTranscriptTo(page, 'top');
@@ -267,13 +288,31 @@ test('evicting a turn-owned sibling interaction hands focus back to the transcri
     return turn.dataset.virtualTurnId;
   });
 
-  await page.evaluate(() => {
+  // The injected control resizes the tail Turn. That can queue a scroll-anchor
+  // restore captured at the bottom. Let that setup-only restore finish before
+  // the one-shot jump so the assertion still catches any later restore that
+  // would pin the viewport back on the retained Turn (#3121).
+  await waitForPaintedFrames(page);
+  await scrollTranscriptTo(page, 'top');
+  await notifyTranscriptScrolled(page);
+  await expect.poll(async () => page.evaluate((turnId) => {
     const root = document.querySelector<HTMLElement>('[data-chat-scroll-container="true"]');
     if (!root) throw new Error('the chat scroll container is missing');
-    root.scrollTop = 0;
-    root.dispatchEvent(new Event('scroll'));
-  });
-  await expect(page.locator(`[data-virtual-turn-id="${retainedTurnId}"]`)).toHaveCount(0);
+    const mounted = [...document.querySelectorAll<HTMLElement>('[data-virtual-turn-id]')]
+      .map((turn) => turn.dataset.virtualTurnId ?? '');
+    return {
+      retained: mounted.includes(turnId),
+      scrollTop: Math.round(root.scrollTop),
+      firstMounted: mounted[0] ?? null,
+      lastMounted: mounted.at(-1) ?? null,
+      active: document.activeElement instanceof HTMLElement
+        ? (document.activeElement.className || document.activeElement.tagName)
+        : null,
+      selectionCollapsed: document.getSelection()?.isCollapsed ?? true,
+    };
+  }, retainedTurnId), {
+    message: 'the retained tail turn leaves after one jump to the top',
+  }).toMatchObject({ retained: false, scrollTop: 0 });
   await expect.poll(() => page.evaluate(() => ({
     focus: document.activeElement?.classList.contains('maka-chat-message-list') ?? false,
     selection: document.getSelection()?.isCollapsed ?? true,

--- a/apps/desktop/e2e/prompt-rail.spec.ts
+++ b/apps/desktop/e2e/prompt-rail.spec.ts
@@ -300,23 +300,24 @@ test('evicting a turn-owned sibling interaction hands focus back to the transcri
     if (!root) throw new Error('the chat scroll container is missing');
     const mounted = [...document.querySelectorAll<HTMLElement>('[data-virtual-turn-id]')]
       .map((turn) => turn.dataset.virtualTurnId ?? '');
+    const active = document.activeElement;
     return {
       retained: mounted.includes(turnId),
       scrollTop: Math.round(root.scrollTop),
       firstMounted: mounted[0] ?? null,
       lastMounted: mounted.at(-1) ?? null,
-      active: document.activeElement instanceof HTMLElement
-        ? (document.activeElement.className || document.activeElement.tagName)
-        : null,
+      focusOnTranscript: active instanceof HTMLElement
+        && active.classList.contains('maka-chat-message-list'),
       selectionCollapsed: document.getSelection()?.isCollapsed ?? true,
     };
   }, retainedTurnId), {
     message: 'the retained tail turn leaves after one jump to the top',
-  }).toMatchObject({ retained: false, scrollTop: 0 });
-  await expect.poll(() => page.evaluate(() => ({
-    focus: document.activeElement?.classList.contains('maka-chat-message-list') ?? false,
-    selection: document.getSelection()?.isCollapsed ?? true,
-  }))).toEqual({ focus: true, selection: true });
+  }).toMatchObject({
+    retained: false,
+    scrollTop: 0,
+    focusOnTranscript: true,
+    selectionCollapsed: true,
+  });
 });
 
 test('a tick is what the pointer lands on, not the scrollbar', async ({

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -164,7 +164,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `packages/ui/src/chat-empty-hero.tsx` | shell-chrome-or-panel | Item | aligned — uses Astryx (Item) | aligned |
 | `packages/ui/src/chat-model-switcher.tsx` | shell-chrome-or-panel | Button | aligned — uses Astryx (Button) | aligned |
 | `packages/ui/src/chat-surface-layout.tsx` | shell-chrome-or-panel | ChatLayout | aligned — uses Astryx (ChatLayout) | aligned |
-| `packages/ui/src/chat-turn.tsx` | shell-chrome-or-panel | Badge, Button, HStack, IconButton, Token, Tooltip | aligned — uses Astryx (Badge, Button, HStack, IconButton, Token, Tooltip) | aligned |
+| `packages/ui/src/chat-turn.tsx` | shell-chrome-or-panel | Badge, Banner, Button, HStack, IconButton, Token, Tooltip | aligned — uses Astryx (Badge, Banner, Button, HStack, IconButton, Token, Tooltip) | aligned |
 | `packages/ui/src/chat-view.tsx` | shell-chrome-or-panel | Button, EmptyState, Spinner | aligned — uses Astryx (Button, EmptyState, Spinner) | aligned |
 | `packages/ui/src/components.tsx` | ui-composition | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `packages/ui/src/composer.tsx` | shell-chrome-or-panel | Button, ChatComposer, IconButton, Lightbox, Token, Tooltip | aligned — uses Astryx (Button, ChatComposer, IconButton, Lightbox, Token, Tooltip) | aligned |


### PR DESCRIPTION
## Summary

The Desktop E2E `evicting a turn-owned sibling interaction hands focus back to the transcript` can leave `turn-prompt-rail-120` mounted for the full 10s timeout after a one-shot `scrollTop = 0`.

Injecting the turn-owned control resizes the tail Turn and can queue a scroll-anchor restore captured at the bottom. If that restore lands after the jump, the viewport is pinned back on the retained Turn and the virtualizer never excludes it.

This test now:

- waits for painted frames so the setup-only restore can finish
- jumps to the top once and notifies the scroller
- polls eviction together with `scrollTop`, the mounted window, focus, and selection so a later restore still fails the assertion

No product change.

Fixes #3121

## Test plan

- [x] `apps/desktop/e2e/prompt-rail.spec.ts` focused eviction case
- [x] full `prompt-rail.spec.ts` file
