### PR TITLE
test(runtime-host): stop the parked busy turn before Host shutdown

### DIFF
--- a/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
@@ -1,4 +1,5 @@
 import { join } from 'node:path';
+import { inspect } from 'node:util';
 import { createSqliteRuntimeStore } from '@maka/storage';
 import { startExecutionRuntimeHostCandidate } from '../../server/execution-candidate.js';
 import { runRuntimeHostProcessLifecycle } from '../../server/process-lifecycle.js';
@@ -59,7 +60,7 @@ try {
       }),
   });
 } catch (error) {
-  console.error(error);
+  console.error(inspect(error, { depth: null }));
   process.exitCode = 1;
 } finally {
   if (process.connected) process.disconnect?.();

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -22,6 +22,7 @@ import {
 } from '@maka/storage/root-authority';
 import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
 import { removePosixEndpointDirectories } from './fixtures/endpoint-hygiene.js';
+import { requireStartedTurn } from './fixtures/execution-host-suite.js';
 import {
   connectRuntimeHost,
   RuntimeHostOperationError,
@@ -320,13 +321,13 @@ async function verifyConcurrentRevisionAuthority(
       operationError('operation_conflict'),
     );
 
-    const busyTurn = await desktop.startTurn({
-      sessionId: busySessionId,
-      turnId: 'busy-turn',
-      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
-    });
-    assert.equal(busyTurn.kind, 'started');
-    if (busyTurn.kind !== 'started') return;
+    const busyTurn = requireStartedTurn(
+      await desktop.startTurn({
+        sessionId: busySessionId,
+        turnId: 'busy-turn',
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+      }),
+    );
     try {
       const busy = await querySession(desktop, busySessionId);
       await assert.rejects(
@@ -340,13 +341,16 @@ async function verifyConcurrentRevisionAuthority(
       );
     } finally {
       // This case only needs a live Turn to prove `session_busy`. Leaving the
-      // parked ask-question continuation for Host SIGTERM is what made
-      // composition close miss its 1s drain under CI load (#2295).
-      const stopped = await desktop.stopTurn({
-        sessionId: busySessionId,
-        turnId: 'busy-turn',
-        runId: busyTurn.turn.runId,
-      });
+      // parked ask-question continuation for Host SIGTERM leaves live
+      // interactions at close, which poisons composition shutdown (#2295).
+      const stopped = await desktop.stopTurn(
+        {
+          sessionId: busySessionId,
+          turnId: 'busy-turn',
+          runId: busyTurn.runId,
+        },
+        PROCESS_TIMEOUT_MS,
+      );
       assert.equal(stopped.status, 'cancelled');
     }
   } finally {

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -328,6 +328,12 @@ async function verifyConcurrentRevisionAuthority(
         content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
       }),
     );
+    // This case only needs a live Turn to prove `session_busy`. Leaving the
+    // parked ask-question continuation for Host SIGTERM leaves live
+    // interactions at close, which poisons composition shutdown (#2295).
+    // Cleanup must still run if the assertion fails, but it must not replace
+    // that failure with a stopTurn error.
+    let assertionError: unknown;
     try {
       const busy = await querySession(desktop, busySessionId);
       await assert.rejects(
@@ -339,10 +345,10 @@ async function verifyConcurrentRevisionAuthority(
         }),
         operationError('session_busy'),
       );
-    } finally {
-      // This case only needs a live Turn to prove `session_busy`. Leaving the
-      // parked ask-question continuation for Host SIGTERM leaves live
-      // interactions at close, which poisons composition shutdown (#2295).
+    } catch (error) {
+      assertionError = error;
+    }
+    try {
       const stopped = await desktop.stopTurn(
         {
           sessionId: busySessionId,
@@ -352,7 +358,16 @@ async function verifyConcurrentRevisionAuthority(
         PROCESS_TIMEOUT_MS,
       );
       assert.equal(stopped.status, 'cancelled');
+    } catch (cleanupError) {
+      if (assertionError !== undefined) {
+        throw new AggregateError(
+          [assertionError, cleanupError],
+          'session_busy check failed and parked-turn cleanup failed',
+        );
+      }
+      throw cleanupError;
     }
+    if (assertionError !== undefined) throw assertionError;
   } finally {
     await Promise.allSettled([desktop.close(), tui.close()]);
   }

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -327,25 +327,28 @@ async function verifyConcurrentRevisionAuthority(
     });
     assert.equal(busyTurn.kind, 'started');
     if (busyTurn.kind !== 'started') return;
-    const busy = await querySession(desktop, busySessionId);
-    await assert.rejects(
-      tui.request('session.branch.create', {
-        sourceSessionId: busySessionId,
-        targetSessionId: 'busy-source-copy',
-        sourceTurnId: 'busy-turn',
-        expectedSourceRevision: busy.revision,
-      }),
-      operationError('session_busy'),
-    );
-    // This case only needs a live Turn to prove `session_busy`. Leaving the
-    // parked ask-question continuation for Host SIGTERM is what made
-    // composition close miss its 1s drain under CI load (#2295).
-    const stopped = await desktop.stopTurn({
-      sessionId: busySessionId,
-      turnId: 'busy-turn',
-      runId: busyTurn.turn.runId,
-    });
-    assert.equal(stopped.status, 'cancelled');
+    try {
+      const busy = await querySession(desktop, busySessionId);
+      await assert.rejects(
+        tui.request('session.branch.create', {
+          sourceSessionId: busySessionId,
+          targetSessionId: 'busy-source-copy',
+          sourceTurnId: 'busy-turn',
+          expectedSourceRevision: busy.revision,
+        }),
+        operationError('session_busy'),
+      );
+    } finally {
+      // This case only needs a live Turn to prove `session_busy`. Leaving the
+      // parked ask-question continuation for Host SIGTERM is what made
+      // composition close miss its 1s drain under CI load (#2295).
+      const stopped = await desktop.stopTurn({
+        sessionId: busySessionId,
+        turnId: 'busy-turn',
+        runId: busyTurn.turn.runId,
+      });
+      assert.equal(stopped.status, 'cancelled');
+    }
   } finally {
     await Promise.allSettled([desktop.close(), tui.close()]);
   }

--- a/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-revision-two-client-uds.test.ts
@@ -320,11 +320,13 @@ async function verifyConcurrentRevisionAuthority(
       operationError('operation_conflict'),
     );
 
-    await desktop.startTurn({
+    const busyTurn = await desktop.startTurn({
       sessionId: busySessionId,
       turnId: 'busy-turn',
       content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
     });
+    assert.equal(busyTurn.kind, 'started');
+    if (busyTurn.kind !== 'started') return;
     const busy = await querySession(desktop, busySessionId);
     await assert.rejects(
       tui.request('session.branch.create', {
@@ -335,6 +337,15 @@ async function verifyConcurrentRevisionAuthority(
       }),
       operationError('session_busy'),
     );
+    // This case only needs a live Turn to prove `session_busy`. Leaving the
+    // parked ask-question continuation for Host SIGTERM is what made
+    // composition close miss its 1s drain under CI load (#2295).
+    const stopped = await desktop.stopTurn({
+      sessionId: busySessionId,
+      turnId: 'busy-turn',
+      runId: busyTurn.turn.runId,
+    });
+    assert.equal(stopped.status, 'cancelled');
   } finally {
     await Promise.allSettled([desktop.close(), tui.close()]);
   }


### PR DESCRIPTION
## Summary

The two-client revision test starts a FakeBackend ask-question turn only to prove `session_busy`, then SIGTERMs the Host. A live parked continuation leaves interactions open at close, so composition shutdown poisons and `stopHost` sees exit code 1.

This test now cancels the busy turn after the `session_busy` assertion, including when that assertion fails. The Host fixture also prints nested close errors at full inspect depth so a later shutdown failure names the resource.

This does not change Host shutdown with a still-parked turn, and it does not touch `session-catalog-two-client-uds`. That catalog case uses a ScheduledTask as the `session_busy` blocker, not a parked ask-question continuation.

Related to #2295

## Test plan

- [x] `@maka/runtime-host` typecheck
- [x] `session-revision-two-client-uds` cancels the parked turn in `finally` and bounds `stopTurn`
