### PR TITLE
test(runtime-host): reject a handshake with a mismatched compatibility epoch

### DIFF
--- a/packages/runtime-host/src/__tests__/handshake-compatibility.test.ts
+++ b/packages/runtime-host/src/__tests__/handshake-compatibility.test.ts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  prepareStorageRootControlDirectory,
+  resolveStorageRoot,
+} from '@maka/storage/root-authority';
+import { connectRuntimeHost } from '../client/index.js';
+import { prepareRuntimeHostEndpoint } from '../control/endpoint.js';
+import { removeHostRegistration, writeHostRegistration } from '../control/registration.js';
+import {
+  decodeClientFrame,
+  encodeProtocolMessage,
+  RUNTIME_HOST_COMPATIBILITY_EPOCH,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
+  type HostFrame,
+  type RequestFrame,
+} from '../protocol/index.js';
+import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+test('rejects a Host that accepts with a different compatibility epoch before any domain command', async () => {
+  let admittedRequest: RequestFrame | undefined;
+  await withForgedHandshakePeer(
+    async (transport, hostEpoch, rootId) => {
+      const hello = decodeClientFrame(await transport.read(2_000));
+      assert.ok('kind' in hello && hello.kind === 'hello');
+      await writeProtocolFrame(transport, {
+        kind: 'accepted',
+        rootId,
+        hostEpoch,
+        connectionId: 'forged-epoch-connection',
+        selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+        compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH + 1,
+        compositionId: 'maka.interactive',
+        compositionRevision: '1',
+        state: 'ready',
+      });
+      try {
+        const next = decodeClientFrame(await transport.read(1_000));
+        if (!('kind' in next)) admittedRequest = next;
+      } catch (error) {
+        assert.ok(
+          error instanceof RuntimeHostTransportError &&
+            (error.code === 'closed' || error.code === 'read_eof'),
+        );
+      }
+    },
+    async (result) => {
+      assert.equal(result.kind, 'unavailable');
+      if (result.kind === 'unavailable') {
+        assert.equal(result.reason, 'handshake_failed');
+      }
+    },
+  );
+  assert.equal(admittedRequest, undefined);
+});
+
+async function withForgedHandshakePeer(
+  serve: (transport: FramedTransport, hostEpoch: string, rootId: string) => Promise<void>,
+  run: (result: Awaited<ReturnType<typeof connectRuntimeHost>>) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-handshake-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
+  const hostEpoch = randomUUID();
+  const endpoint = await prepareRuntimeHostEndpoint({
+    rootId: capability.rootId,
+    hostEpoch,
+  });
+  const serverTask = deferred<void>();
+  const server = createServer((socket) => {
+    void serve(new FramedTransport(socket), hostEpoch, capability.rootId).then(
+      serverTask.resolve,
+      serverTask.reject,
+    );
+  });
+  try {
+    await listen(server, endpoint.path);
+    await endpoint.prepareAfterListen();
+    await writeHostRegistration(controlDirectory, {
+      kind: 'maka-runtime-host',
+      schemaVersion: RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
+      rootId: capability.rootId,
+      hostEpoch,
+      endpoint: endpoint.path,
+      protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
+      protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+      compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+      compositionId: 'maka.interactive',
+      compositionRevision: '1',
+      state: 'ready',
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+    });
+    const result = await connectRuntimeHost({
+      rootPath: join(base, 'root'),
+      surface: 'tui',
+      protocol: PROTOCOL,
+    });
+    try {
+      await run(result);
+    } finally {
+      if (result.kind === 'connected') await result.connection.close();
+    }
+    await serverTask.promise;
+  } finally {
+    await closeServer(server);
+    await removeHostRegistration(controlDirectory, hostEpoch).catch(() => undefined);
+    await endpoint.cleanup().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+function writeProtocolFrame(transport: FramedTransport, frame: HostFrame): Promise<void> {
+  return transport.write(encodeProtocolMessage(frame));
+}
+
+function listen(server: Server, path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(path, resolve);
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: unknown): void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  return {
+    promise: new Promise<T>((nextResolve, nextReject) => {
+      resolve = nextResolve;
+      reject = nextReject;
+    }),
+    resolve,
+    reject,
+  };
+}

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1681,6 +1681,47 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
+  test('rejects a handshake whose compatibility epoch does not match', async () => {
+    await withHostPaths(async (paths) => {
+      const candidate = await startTestRuntimeHostCandidate(paths, {
+        rootPath: paths.root,
+        idleGraceMs: 10_000,
+      });
+      assert.equal(candidate.kind, 'winner');
+      if (candidate.kind !== 'winner') return;
+
+      const transport = new FramedTransport(await openSocket(candidate.host.endpoint));
+      try {
+        await writeClientFrame(transport, {
+          kind: 'hello',
+          clientInstanceId: 'epoch-mismatch-client',
+          surface: 'tui',
+          protocolMin: CURRENT_PROTOCOL.min,
+          protocolMax: CURRENT_PROTOCOL.max,
+          compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH + 1,
+          compositionId: 'maka.interactive',
+        });
+        const response = decodeHostFrame(await transport.read(2_000));
+        assert.ok('kind' in response && response.kind === 'incompatible');
+        if (!('kind' in response) || response.kind !== 'incompatible') return;
+        assert.equal(response.compatibilityEpoch, RUNTIME_HOST_COMPATIBILITY_EPOCH);
+        assert.equal(response.hostEpoch, candidate.host.hostEpoch);
+        await transport.closed;
+        await assert.rejects(
+          () =>
+            writeClientFrame(transport, {
+              requestId: 'post-epoch-mismatch-status',
+              operation: 'host.status',
+              input: {},
+            }),
+          (error: unknown) => error instanceof RuntimeHostTransportError && error.code === 'closed',
+        );
+      } finally {
+        transport.abort();
+      }
+    });
+  });
+
   test('releases composition connection resources after admitted requests settle', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });


### PR DESCRIPTION
## Summary

`exchangeRuntimeHostHandshake` already rejects a peer whose `compatibilityEpoch` differs, and later work depends on that rejection keeping a mismatched Host away from domain commands. That path had no handshake-level test: `host-kernel` only covered an incompatible protocol range, and both ends share the compile-time epoch constant.

This adds two seams:

- A live Host hello with `compatibilityEpoch + 1` is answered `incompatible`, then the connection is closed so a follow-up `host.status` cannot be admitted.
- A transport peer answers `accepted` with a different epoch while the registration file stays current. `connectRuntimeHost` returns `unavailable` / `handshake_failed`, and the peer never receives a domain request.

Fixes #3130

## Test plan

- [x] `@maka/runtime-host` typecheck
- [x] `handshake-compatibility` (1/1)
- [x] `host-kernel` (46/46), including the new epoch-mismatch case