### PR TITLE
ci: charge Copilot reviews to the review owner

### DIFF
--- a/.github/workflows/copilot-auto-review.yml
+++ b/.github/workflows/copilot-auto-review.yml
@@ -4,9 +4,7 @@ on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
 
-permissions:
-  contents: read
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: copilot-auto-review-${{ github.event.pull_request.number }}
@@ -22,13 +20,25 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      # pull_request_target supplies a writable token for fork PRs. Do not
-      # checkout or execute code from the untrusted pull request in this job.
+      # pull_request_target exposes the repository secret to fork PR events.
+      # Never checkout, execute, or otherwise consume untrusted PR code here.
       - name: Request GitHub Copilot review
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.COPILOT_REVIEW_TOKEN }}
+          EXPECTED_REVIEW_REQUESTER: hqhq1025
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "::error::COPILOT_REVIEW_TOKEN is not configured"
+            exit 1
+          fi
+
+          review_requester="$(gh api user --jq '.login')"
+          if [[ "${review_requester}" != "${EXPECTED_REVIEW_REQUESTER}" ]]; then
+            echo "::error::COPILOT_REVIEW_TOKEN belongs to ${review_requester}, expected ${EXPECTED_REVIEW_REQUESTER}"
+            exit 1
+          fi
+
           if gh api \
             "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
             --jq '.users[].login' | \


### PR DESCRIPTION
## Summary

Pin automatic GitHub Copilot review requests to the repository secret
`COPILOT_REVIEW_TOKEN`, which belongs to `hqhq1025`, instead of using the
event-triggering `${{ github.token }}` identity.

The workflow now fails closed when the secret is missing or belongs to another
account. It also removes all permissions from the generated `GITHUB_TOKEN`.

## Security

The workflow still uses `pull_request_target` so it can request reviews for
fork pull requests, but it never checks out, executes, or otherwise consumes
untrusted pull request code. The dedicated token is used only for GitHub API
identity checks and reviewer requests.

## Verification

- Parsed `.github/workflows/copilot-auto-review.yml` with Ruby YAML
- Checked the embedded shell with `bash -n`
- Ran structural assertions for the dedicated secret, expected owner, absent
  `${{ github.token }}` fallback, and absent checkout/head-ref consumption
- Ran `git diff --check`
- Confirmed `COPILOT_REVIEW_TOKEN` is configured in repository Actions secrets
- Previously smoke-tested the same `hqhq1025` user-token identity by requesting
  and completing Copilot review on PR #2941

The final automatic attribution path can be observed after merge on the next
non-draft, non-bot pull request event.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex audited the attribution path, implemented the
least-privileged identity binding, and ran the verification commands.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes - automatic Copilot review usage is attributed to `hqhq1025`.
- [ ] No
