### PR TITLE
docs: add DISCLAIMER-WIP for podling releases

### DIFF
--- a/DISCLAIMER-WIP
+++ b/DISCLAIMER-WIP
@@ -1,15 +1,15 @@
-Apache Maka (incubating) is an effort undergoing incubation at the Apache
-Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is
-required of all newly accepted projects until a further review indicates that
-the infrastructure, communications, and decision making process have stabilized
-in a manner consistent with other successful ASF projects. While incubation
-status is not necessarily a reflection of the completeness or stability of the
-code, it does indicate that the project has yet to be fully endorsed by the ASF.
+Apache Maka is an effort undergoing incubation at The Apache Software
+Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of
+all newly accepted projects until a further review indicates that the
+infrastructure, communications, and decision-making process have stabilized in
+a manner consistent with other successful ASF projects. While incubation status
+is not necessarily a reflection of the completeness or stability of the code,
+it does indicate that the project has yet to be fully endorsed by the ASF.
 
 Some of the incubating project's releases may not be fully compliant with ASF
 policy. For example, releases may have incomplete or un-reviewed licensing
-conditions. What follows is a list of known issues the project is currently
-aware of (note that this list, by definition, is likely to be incomplete):
+conditions. What follows is a list of issues the project is currently aware of
+(this list is likely to be incomplete):
 
  * Source files do not yet carry Apache license headers.
  * NOTICE has not yet been reworked into ASF form.
@@ -18,5 +18,5 @@ aware of (note that this list, by definition, is likely to be incomplete):
 If you are planning to incorporate this work into your product/project, please
 be aware that you will need to conduct a thorough licensing review to determine
 the overall implications of including this work. For the current status of this
-project through the Apache Incubator visit:
+project through the Apache Incubator, visit:
 https://incubator.apache.org/projects/maka.html

--- a/DISCLAIMER-WIP
+++ b/DISCLAIMER-WIP
@@ -1,0 +1,22 @@
+Apache Maka (incubating) is an effort undergoing incubation at the Apache
+Software Foundation (ASF), sponsored by the Apache Incubator. Incubation is
+required of all newly accepted projects until a further review indicates that
+the infrastructure, communications, and decision making process have stabilized
+in a manner consistent with other successful ASF projects. While incubation
+status is not necessarily a reflection of the completeness or stability of the
+code, it does indicate that the project has yet to be fully endorsed by the ASF.
+
+Some of the incubating project's releases may not be fully compliant with ASF
+policy. For example, releases may have incomplete or un-reviewed licensing
+conditions. What follows is a list of known issues the project is currently
+aware of (note that this list, by definition, is likely to be incomplete):
+
+ * Source files do not yet carry Apache license headers.
+ * NOTICE has not yet been reworked into ASF form.
+ * The software grant and committer ICLAs are not yet complete.
+
+If you are planning to incorporate this work into your product/project, please
+be aware that you will need to conduct a thorough licensing review to determine
+the overall implications of including this work. For the current status of this
+project through the Apache Incubator visit:
+https://incubator.apache.org/projects/maka.html

--- a/DISCLAIMER-WIP
+++ b/DISCLAIMER-WIP
@@ -1,10 +1,10 @@
-Apache Maka is an effort undergoing incubation at The Apache Software
-Foundation (ASF), sponsored by the Apache Incubator. Incubation is required of
-all newly accepted projects until a further review indicates that the
-infrastructure, communications, and decision-making process have stabilized in
-a manner consistent with other successful ASF projects. While incubation status
-is not necessarily a reflection of the completeness or stability of the code,
-it does indicate that the project has yet to be fully endorsed by the ASF.
+Apache Maka is an effort undergoing incubation at The Apache Software Foundation
+(ASF), sponsored by the Apache Incubator PMC. Incubation is required of all
+newly accepted projects until a further review indicates that the
+infrastructure, communications, and decision-making process have stabilized in a
+manner consistent with other successful ASF projects. While incubation status is
+not necessarily a reflection of the completeness or stability of the code, it
+does indicate that the project has yet to be fully endorsed by the ASF.
 
 Some of the incubating project's releases may not be fully compliant with ASF
 policy. For example, releases may have incomplete or un-reviewed licensing

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -67,6 +67,14 @@ export default {
       to: 'licenses/maka/NOTICE',
     },
     {
+      // Incubator policy requires every release archive to carry a DISCLAIMER
+      // or DISCLAIMER-WIP. Shipping it beside LICENSE and NOTICE is what makes
+      // the repository-root file reach the DMG, the ZIP and the Windows
+      // installer; `assertPackagedResources` then requires it on both paths.
+      from: '../../DISCLAIMER-WIP',
+      to: 'licenses/maka/DISCLAIMER-WIP',
+    },
+    {
       from: '../../node_modules/electron/dist/LICENSE',
       to: 'licenses/electron/LICENSE',
     },

--- a/scripts/verify-packaged-app.mjs
+++ b/scripts/verify-packaged-app.mjs
@@ -299,6 +299,10 @@ export async function assertPackagedResources(
     requirePath,
     forbidPath = assertMissing,
     requireWindowsSandbox = process.platform === 'win32',
+    // The upgrade-lifecycle check runs this against a previously released
+    // build, which predates the disclaimer being packaged. Requiring it there
+    // would fail a release that was correct when it shipped.
+    requireDisclaimer = true,
   } = {},
 ) {
   const required = [
@@ -310,6 +314,7 @@ export async function assertPackagedResources(
     join('workers', 'filesystem-worker.js'),
     join('licenses', 'maka', 'LICENSE'),
     join('licenses', 'maka', 'NOTICE'),
+    ...(requireDisclaimer ? [join('licenses', 'maka', 'DISCLAIMER-WIP')] : []),
     join('licenses', 'dugite', 'LICENSE'),
     join('licenses', 'git', 'NOTICE.txt'),
     join('licenses', 'electron', 'LICENSE'),

--- a/scripts/verify-windows-x64.mjs
+++ b/scripts/verify-windows-x64.mjs
@@ -97,10 +97,18 @@ export async function verifyPackagedWindowsApp(
   const appAsar = join(resources, 'app.asar');
   const sandboxExecutable = join(resources, 'windows-sandbox', 'maka-windows-sandbox.exe');
   const requireWindowsSandbox = expectedVersion === undefined;
+  // Same reason as the sandbox above: a packaged resource added after the
+  // baseline release cannot be required of that baseline.
+  const requireDisclaimer = expectedVersion === undefined;
 
   step('checking packaged resources');
   await requirePath(executable);
-  await assertPackagedResources(resources, { requirePath, forbidPath, requireWindowsSandbox });
+  await assertPackagedResources(resources, {
+    requirePath,
+    forbidPath,
+    requireWindowsSandbox,
+    requireDisclaimer,
+  });
   await requirePath(join(resources, 'git', 'cmd', 'git.exe'));
 
   step('reading the executable architecture');


### PR DESCRIPTION
Part of #2974 (Phase 3, *Add a `DISCLAIMER` file*).

Every podling release artifact has to carry a DISCLAIMER. The `-WIP` variant is the one the Incubator expects while compliance items are still open: it enumerates what is not yet satisfied rather than asserting a compliance the project does not have yet.

The three known-issue bullets are exactly the remaining blocking entries on the checklist — license headers, NOTICE rework, grant/ICLAs — so this file and the issue stay in step. The intent is that each is struck from here as it lands, and the file is renamed to `DISCLAIMER` once the list is empty.

**One thing to confirm:** the Incubator status URL assumes the podling name `maka`. If PODLINGNAMESEARCH lands somewhere else, this line needs to follow. I left it pointing at the expected path rather than omitting it, since a missing status link is itself a review comment during the release vote — but say the word and I will drop it until the name clears.

Text follows the Incubator's standard DISCLAIMER-WIP wording. No code paths touched; lint and format pass.