### PR TITLE
ci: reduce redundant Copilot reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+# Code Review Priorities
+
+When reviewing pull requests:
+
+- Review the change against the problem and root cause it claims to address.
+- Prioritize concrete correctness, security, data-loss, concurrency, compatibility, and behavioral-regression risks.
+- Check whether the change extends the existing source of truth or creates a parallel path.
+- Flag code that can be deleted or simplified when doing so has a concrete correctness or maintenance benefit.
+- Flag tests that duplicate stronger coverage, assert implementation details, or do not protect observable behavior.
+- Avoid style-only comments, speculative refactors, praise, and restating the pull request summary.
+- Lead with actionable findings. If none exist, say so and identify only material residual validation gaps.

--- a/.github/workflows/copilot-auto-review.yml
+++ b/.github/workflows/copilot-auto-review.yml
@@ -1,8 +1,9 @@
 name: Copilot auto review
 
 on:
+  # Review once by default. Add copilot-rereview for an explicit follow-up review.
   pull_request_target:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, reopened, ready_for_review, labeled]
 
 permissions: {}
 
@@ -15,7 +16,8 @@ jobs:
     if: >-
       github.event.pull_request.draft == false &&
       !endsWith(github.event.pull_request.user.login, '[bot]') &&
-      !contains(github.event.pull_request.labels.*.name, 'copilot-skip')
+      !contains(github.event.pull_request.labels.*.name, 'copilot-skip') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'copilot-rereview')
     runs-on: ubuntu-latest
     timeout-minutes: 5
 


### PR DESCRIPTION
## Summary

Reduce redundant GitHub Copilot review consumption while preserving an explicit re-review path.

- Stop requesting a new Copilot review on every pull request push.
- Request the normal automatic review when a pull request is opened, reopened, or marked ready for review.
- Allow an explicit follow-up review by adding the `copilot-rereview` label.
- Add concise repository instructions that prioritize actionable correctness and maintenance findings while suppressing style-only feedback and repeated summaries.

The configured Copilot review effort remains `Lite`; GitHub Copilot Code Review does not support selecting a specific model.

## Rationale

The previous `synchronize` trigger requested another review after every push once the prior review had completed. Recent pull requests accumulated three to four Copilot reviews in a short period. This change makes one review the default and makes subsequent reviews intentional.

## Verification

- Parsed `.github/workflows/copilot-auto-review.yml` with Ruby YAML
- Ran structural assertions for the event set, `copilot-rereview` gate, dedicated PAT, and absence of `synchronize`
- Ran `git diff --check`
- Confirmed the Copilot review effort shown on recent pull requests is `Lite`
- Created the `copilot-rereview` repository label

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex audited the live workflow, review frequency, Copilot effort level, and official configuration limits; it then implemented and verified the scoped workflow and instruction changes.

## Checklist

- [x] Lint, format, and focused configuration checks pass locally

Does this PR entail a change in behavior?

- [x] Yes - routine pushes no longer trigger repeated Copilot reviews; maintainers can add `copilot-rereview` for a follow-up review.
- [ ] No
