### PR TITLE
refactor(core): inject the SHA-256 digest in local-memory.ts

### DIFF
--- a/apps/desktop/src/renderer/local-memory-digest.ts
+++ b/apps/desktop/src/renderer/local-memory-digest.ts
@@ -2,8 +2,12 @@ import type { Sha256Digest } from '@maka/core/local-memory';
 
 /** Precompute one SubtleCrypto digest so the sync Sha256Digest seam can run in the renderer. */
 export async function webSha256Digest(input: string): Promise<Sha256Digest> {
+  const subtle = globalThis.crypto?.subtle;
+  if (typeof subtle?.digest !== 'function') {
+    throw new Error('SubtleCrypto SHA-256 is not available');
+  }
   const bytes = new Uint8Array(
-    await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input)),
+    await subtle.digest('SHA-256', new TextEncoder().encode(input)),
   );
   return {
     digest(value: string): Uint8Array {

--- a/apps/desktop/src/renderer/local-memory-digest.ts
+++ b/apps/desktop/src/renderer/local-memory-digest.ts
@@ -1,0 +1,16 @@
+import type { Sha256Digest } from '@maka/core/local-memory';
+
+/** Precompute one SubtleCrypto digest so the sync Sha256Digest seam can run in the renderer. */
+export async function webSha256Digest(input: string): Promise<Sha256Digest> {
+  const bytes = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input)),
+  );
+  return {
+    digest(value: string): Uint8Array {
+      if (value !== input) {
+        throw new Error('webSha256Digest was asked to hash a different string');
+      }
+      return bytes;
+    },
+  };
+}

--- a/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
+++ b/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
@@ -432,30 +432,46 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
   }
 
   async function addManualMemoryEntry() {
-    const { timestamp, material } = stableLocalMemoryIdMaterial(newMemoryContent, Date.now());
-    const result = appendManualLocalMemoryEntryDraft(draft, {
-      title: newMemoryTitle,
-      content: newMemoryContent,
-      tags: newMemoryTags.split(','),
-      now: timestamp,
-      sha256: await webSha256Digest(material),
-    });
-    if (!result.ok) {
-      switch (result.reason) {
-        case 'empty_title':
-          toast.error(copy.text.emptyTitle, copy.text.emptyTitleDetail);
-          return;
-        case 'empty_content':
-          toast.error(copy.text.emptyContent, copy.text.emptyContentDetail);
-          return;
-        case 'oversize':
-          toast.error(copy.text.draftOversize, copy.text.oversizeDetail);
-          return;
-      }
+    const title = newMemoryTitle;
+    const content = newMemoryContent;
+    const tags = newMemoryTags.split(',');
+    const currentDraft = draft;
+    const currentHost = host;
+    if (!title.trim()) {
+      toast.error(copy.text.emptyTitle, copy.text.emptyTitleDetail);
+      return;
     }
+    if (!content.trim()) {
+      toast.error(copy.text.emptyContent, copy.text.emptyContentDetail);
+      return;
+    }
+
     try {
       await runMemoryWriteAction('save', async (isCurrent) => {
-        const next = await window.maka.memory.save(result.draft, host);
+        const { timestamp, material } = stableLocalMemoryIdMaterial(content, Date.now());
+        const sha256 = await webSha256Digest(material);
+        if (!isCurrent()) return;
+        const result = appendManualLocalMemoryEntryDraft(currentDraft, {
+          title,
+          content,
+          tags,
+          now: timestamp,
+          sha256,
+        });
+        if (!result.ok) {
+          switch (result.reason) {
+            case 'empty_title':
+              toast.error(copy.text.emptyTitle, copy.text.emptyTitleDetail);
+              return;
+            case 'empty_content':
+              toast.error(copy.text.emptyContent, copy.text.emptyContentDetail);
+              return;
+            case 'oversize':
+              toast.error(copy.text.draftOversize, copy.text.oversizeDetail);
+              return;
+          }
+        }
+        const next = await window.maka.memory.save(result.draft, currentHost);
         if (!isCurrent()) return;
         setState(next);
         setDraft(next.content);
@@ -466,7 +482,7 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
         setNewMemoryTitle('');
         setNewMemoryTags('');
         setNewMemoryContent('');
-        toast.success(copy.text.addedDraft, newMemoryTitle.trim());
+        toast.success(copy.text.addedDraft, title.trim());
       });
     } catch (error) {
       toast.error(copy.text.saveFailed, settingsActionErrorMessage(error, locale));

--- a/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
+++ b/apps/desktop/src/renderer/settings/use-memory-settings-controller.ts
@@ -6,7 +6,9 @@ import {
   appendManualLocalMemoryEntryDraft,
   findLocalMemoryEntryDraftRange,
   setLocalMemoryEntryStatusDraft,
+  stableLocalMemoryIdMaterial,
 } from '@maka/core/local-memory';
+import { webSha256Digest } from '../local-memory-digest';
 import { useToast, useUiLocale } from '@maka/ui';
 import { openPathFailureCopy, openPathActionLabel } from '../open-path';
 import { settingsActionErrorMessage } from './settings-error-copy';
@@ -430,10 +432,13 @@ export function useMemoryDocumentController(props: MemoryDocumentControllerProps
   }
 
   async function addManualMemoryEntry() {
+    const { timestamp, material } = stableLocalMemoryIdMaterial(newMemoryContent, Date.now());
     const result = appendManualLocalMemoryEntryDraft(draft, {
       title: newMemoryTitle,
       content: newMemoryContent,
       tags: newMemoryTags.split(','),
+      now: timestamp,
+      sha256: await webSha256Digest(material),
     });
     if (!result.ok) {
       switch (result.reason) {

--- a/packages/core/src/__tests__/local-memory.test.ts
+++ b/packages/core/src/__tests__/local-memory.test.ts
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { createHash } from 'node:crypto';
 import { describe, it } from 'node:test';
 import {
   LOCAL_MEMORY_MAX_BYTES,
@@ -8,14 +9,24 @@ import {
   appendManualLocalMemoryEntryDraft,
   approveLocalMemoryProposalDraft,
   buildLocalMemoryPromptBody,
+  defaultLocalMemoryMarkdown,
   defaultLocalMemorySettings,
   findLocalMemoryEntryDraft,
   normalizeLocalMemorySettings,
   parseLocalMemoryMarkdown,
   rejectLocalMemoryProposalDraft,
   setLocalMemoryEntryStatusDraft,
+  stableLocalMemoryEntryId,
+  stableLocalMemoryIdMaterial,
   stableLocalMemoryProposalId,
+  type Sha256Digest,
 } from '../local-memory.js';
+
+const nodeSha256: Sha256Digest = {
+  digest(input: string): Uint8Array {
+    return new Uint8Array(createHash('sha256').update(input, 'utf8').digest());
+  },
+};
 
 describe('local MEMORY.md contract', () => {
   it('defaults file enabled but agent read disabled', () => {
@@ -173,7 +184,11 @@ describe('local MEMORY.md contract', () => {
   });
 
   it('creates pending proposals and keeps approval explicit', () => {
-    const proposalId = stableLocalMemoryProposalId('Remember dark mode preference.', 1700000000000);
+    const proposalId = stableLocalMemoryProposalId(
+      'Remember dark mode preference.',
+      1700000000000,
+      nodeSha256,
+    );
     const pending = appendLocalMemoryProposalDraft('# Maka Pending Memory\n', {
       proposalId,
       title: 'Theme preference',
@@ -299,14 +314,24 @@ describe('local MEMORY.md contract', () => {
 
   it('rejects blank manual draft entries and oversized resulting drafts', () => {
     assert.deepEqual(
-      appendManualLocalMemoryEntryDraft('', { title: ' ', content: 'body', now: 1 }),
+      appendManualLocalMemoryEntryDraft('', {
+        title: ' ',
+        content: 'body',
+        now: 1,
+        sha256: nodeSha256,
+      }),
       {
         ok: false,
         reason: 'empty_title',
       },
     );
     assert.deepEqual(
-      appendManualLocalMemoryEntryDraft('', { title: 'title', content: ' ', now: 1 }),
+      appendManualLocalMemoryEntryDraft('', {
+        title: 'title',
+        content: ' ',
+        now: 1,
+        sha256: nodeSha256,
+      }),
       {
         ok: false,
         reason: 'empty_content',
@@ -316,8 +341,37 @@ describe('local MEMORY.md contract', () => {
       title: 'title',
       content: 'body',
       now: 1,
+      sha256: nodeSha256,
     });
     assert.deepEqual(oversized, { ok: false, reason: 'oversize' });
+  });
+
+  it('pins persisted memory ids to the injected Node digest', () => {
+    const content = 'Remember dark mode preference.';
+    const createdAt = 1_700_000_000_000;
+    const { material } = stableLocalMemoryIdMaterial(content, createdAt);
+    assert.equal(material, `${content}\n${createdAt}`);
+    assert.equal(stableLocalMemoryEntryId(content, createdAt, nodeSha256), 'mem-e6ab8f36e9096a9f');
+    assert.equal(
+      stableLocalMemoryProposalId(content, createdAt, nodeSha256),
+      'proposal-e6ab8f36e9096a9f',
+    );
+    assert.equal(
+      stableLocalMemoryEntryId(content, createdAt, nodeSha256),
+      stableLocalMemoryEntryId(content, createdAt, nodeSha256),
+    );
+
+    const markdown = defaultLocalMemoryMarkdown(nodeSha256, createdAt);
+    assert.match(markdown, /id=mem-e060c48e23fe4573/);
+    const added = appendManualLocalMemoryEntryDraft('# Maka Memory\n', {
+      title: 'Theme',
+      content,
+      now: createdAt,
+      sha256: nodeSha256,
+    });
+    assert.equal(added.ok, true);
+    if (!added.ok) return;
+    assert.match(added.draft, /id=mem-e6ab8f36e9096a9f/);
   });
 
   it('returns safe mode instead of parsing oversized content', () => {

--- a/packages/core/src/__tests__/local-memory.test.ts
+++ b/packages/core/src/__tests__/local-memory.test.ts
@@ -363,6 +363,18 @@ describe('local MEMORY.md contract', () => {
 
     const markdown = defaultLocalMemoryMarkdown(nodeSha256, createdAt);
     assert.match(markdown, /id=mem-e060c48e23fe4573/);
+    assert.match(markdown, /createdAt=1700000000000/);
+
+    const exampleContent =
+      '这里写你希望 Maka 记住的长期偏好。默认不会提供给模型；需要在设置里单独开启“模型上下文可读取”。';
+    const fractional = defaultLocalMemoryMarkdown(nodeSha256, -1.7);
+    const { timestamp } = stableLocalMemoryIdMaterial(exampleContent, -1.7);
+    assert.equal(timestamp, 0);
+    assert.match(
+      fractional,
+      new RegExp(`id=${stableLocalMemoryEntryId(exampleContent, timestamp, nodeSha256)}`),
+    );
+    assert.match(fractional, /createdAt=0/);
     const added = appendManualLocalMemoryEntryDraft('# Maka Memory\n', {
       title: 'Theme',
       content,

--- a/packages/core/src/local-memory.ts
+++ b/packages/core/src/local-memory.ts
@@ -5,7 +5,10 @@
  * hidden durable memory, extraction, embeddings, recall, or agent tools.
  */
 
+import type { Sha256Digest } from './oauth-subscription.js';
 import { redactSecrets } from './redaction.js';
+
+export type { Sha256Digest };
 
 export interface LocalMemorySettings {
   readonly enabled: boolean;
@@ -102,6 +105,7 @@ export interface AppendManualLocalMemoryEntryInput {
   readonly content: string;
   readonly tags?: readonly string[];
   readonly now?: number;
+  readonly sha256: Sha256Digest;
 }
 
 export type AppendManualLocalMemoryEntryResult =
@@ -230,17 +234,6 @@ export interface LocalMemoryPromptContext {
   readonly sessionId?: string;
 }
 
-const SHA256_K = [
-  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
-  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
-  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
-  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
-  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
-  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
-  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
-  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
-] as const;
-
 export function defaultLocalMemorySettings(): LocalMemorySettings {
   return { enabled: true, agentReadEnabled: false };
 }
@@ -254,10 +247,10 @@ export function normalizeLocalMemorySettings(input: unknown): LocalMemorySetting
   };
 }
 
-export function defaultLocalMemoryMarkdown(now = Date.now()): string {
+export function defaultLocalMemoryMarkdown(sha256: Sha256Digest, now = Date.now()): string {
   const exampleContent =
     '这里写你希望 Maka 记住的长期偏好。默认不会提供给模型；需要在设置里单独开启“模型上下文可读取”。';
-  const exampleId = stableLocalMemoryEntryId(exampleContent, now);
+  const exampleId = stableLocalMemoryEntryId(exampleContent, now, sha256);
   return [
     '# Maka Memory',
     '',
@@ -314,7 +307,7 @@ export function appendManualLocalMemoryEntryDraft(
       ? Math.max(0, Math.floor(input.now))
       : Date.now();
   const tags = normalizeManualEntryTags(input.tags ?? []);
-  const id = stableLocalMemoryEntryId(content, now);
+  const id = stableLocalMemoryEntryId(content, now, input.sha256);
   const meta = [
     `id=${id}`,
     'origin=manual',
@@ -403,16 +396,30 @@ export function appendLocalMemoryProposalDraft(
   return appendEntrySection(currentDraft, title, meta, content);
 }
 
-export function stableLocalMemoryEntryId(content: string, createdAt: number): string {
-  const normalizedCreatedAt = Number.isFinite(createdAt) ? Math.max(0, Math.floor(createdAt)) : 0;
-  return `mem-${sha256Hex(`${content.trim()}\n${normalizedCreatedAt}`).slice(0, 16)}`;
+export function stableLocalMemoryIdMaterial(
+  content: string,
+  timestamp: number,
+): { readonly timestamp: number; readonly material: string } {
+  const normalized = Number.isFinite(timestamp) ? Math.max(0, Math.floor(timestamp)) : 0;
+  return { timestamp: normalized, material: `${content.trim()}\n${normalized}` };
 }
 
-export function stableLocalMemoryProposalId(content: string, proposedAt: number): string {
-  const normalizedProposedAt = Number.isFinite(proposedAt)
-    ? Math.max(0, Math.floor(proposedAt))
-    : 0;
-  return `proposal-${sha256Hex(`${content.trim()}\n${normalizedProposedAt}`).slice(0, 16)}`;
+export function stableLocalMemoryEntryId(
+  content: string,
+  createdAt: number,
+  sha256: Sha256Digest,
+): string {
+  const { material } = stableLocalMemoryIdMaterial(content, createdAt);
+  return `mem-${hexSha256(sha256, material).slice(0, 16)}`;
+}
+
+export function stableLocalMemoryProposalId(
+  content: string,
+  proposedAt: number,
+  sha256: Sha256Digest,
+): string {
+  const { material } = stableLocalMemoryIdMaterial(content, proposedAt);
+  return `proposal-${hexSha256(sha256, material).slice(0, 16)}`;
 }
 
 export function setLocalMemoryEntryStatusDraft(
@@ -877,10 +884,7 @@ function serializeMetaComment(meta: Record<string, string>): string {
     if (seen.has(key)) return;
     const value = meta[key];
     if (value === undefined) return;
-    const safeValue = value
-      .replace(/[\s<>]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 128);
+    const safeValue = normalizeMetaValue(value);
     if (!safeValue) return;
     seen.add(key);
     parts.push(`${key}=${safeValue}`);
@@ -1055,84 +1059,6 @@ function slugId(title: string): string {
   return slug.length > 0 ? slug : 'memory-entry';
 }
 
-function sha256Hex(input: string): string {
-  const bytes = new TextEncoder().encode(input);
-  const bitLength = bytes.length * 8;
-  const paddedLength = Math.ceil((bytes.length + 9) / 64) * 64;
-  const padded = new Uint8Array(paddedLength);
-  padded.set(bytes);
-  padded[bytes.length] = 0x80;
-  const view = new DataView(padded.buffer);
-  view.setUint32(paddedLength - 8, Math.floor(bitLength / 0x100000000), false);
-  view.setUint32(paddedLength - 4, bitLength >>> 0, false);
-
-  let h0 = 0x6a09e667;
-  let h1 = 0xbb67ae85;
-  let h2 = 0x3c6ef372;
-  let h3 = 0xa54ff53a;
-  let h4 = 0x510e527f;
-  let h5 = 0x9b05688c;
-  let h6 = 0x1f83d9ab;
-  let h7 = 0x5be0cd19;
-  const w = new Uint32Array(64);
-
-  for (let offset = 0; offset < paddedLength; offset += 64) {
-    for (let i = 0; i < 16; i += 1) {
-      w[i] = view.getUint32(offset + i * 4, false);
-    }
-    for (let i = 16; i < 64; i += 1) {
-      const s0 = rotateRight(w[i - 15]!, 7) ^ rotateRight(w[i - 15]!, 18) ^ (w[i - 15]! >>> 3);
-      const s1 = rotateRight(w[i - 2]!, 17) ^ rotateRight(w[i - 2]!, 19) ^ (w[i - 2]! >>> 10);
-      w[i] = add32(w[i - 16]!, s0, w[i - 7]!, s1);
-    }
-
-    let a = h0;
-    let b = h1;
-    let c = h2;
-    let d = h3;
-    let e = h4;
-    let f = h5;
-    let g = h6;
-    let h = h7;
-
-    for (let i = 0; i < 64; i += 1) {
-      const s1 = rotateRight(e, 6) ^ rotateRight(e, 11) ^ rotateRight(e, 25);
-      const ch = (e & f) ^ (~e & g);
-      const temp1 = add32(h, s1, ch, SHA256_K[i]!, w[i]!);
-      const s0 = rotateRight(a, 2) ^ rotateRight(a, 13) ^ rotateRight(a, 22);
-      const maj = (a & b) ^ (a & c) ^ (b & c);
-      const temp2 = add32(s0, maj);
-      h = g;
-      g = f;
-      f = e;
-      e = add32(d, temp1);
-      d = c;
-      c = b;
-      b = a;
-      a = add32(temp1, temp2);
-    }
-
-    h0 = add32(h0, a);
-    h1 = add32(h1, b);
-    h2 = add32(h2, c);
-    h3 = add32(h3, d);
-    h4 = add32(h4, e);
-    h5 = add32(h5, f);
-    h6 = add32(h6, g);
-    h7 = add32(h7, h);
-  }
-
-  return [h0, h1, h2, h3, h4, h5, h6, h7]
-    .map((word) => word.toString(16).padStart(8, '0'))
-    .join('');
-}
-
-function rotateRight(value: number, bits: number): number {
-  return (value >>> bits) | (value << (32 - bits));
-}
-
-function add32(...values: readonly number[]): number {
-  let result = 0;
-  for (const value of values) result = (result + value) >>> 0;
-  return result;
+function hexSha256(sha256: Sha256Digest, input: string): string {
+  return Array.from(sha256.digest(input), (byte) => byte.toString(16).padStart(2, '0')).join('');
 }

--- a/packages/core/src/local-memory.ts
+++ b/packages/core/src/local-memory.ts
@@ -250,12 +250,13 @@ export function normalizeLocalMemorySettings(input: unknown): LocalMemorySetting
 export function defaultLocalMemoryMarkdown(sha256: Sha256Digest, now = Date.now()): string {
   const exampleContent =
     '这里写你希望 Maka 记住的长期偏好。默认不会提供给模型；需要在设置里单独开启“模型上下文可读取”。';
-  const exampleId = stableLocalMemoryEntryId(exampleContent, now, sha256);
+  const { timestamp } = stableLocalMemoryIdMaterial(exampleContent, now);
+  const exampleId = stableLocalMemoryEntryId(exampleContent, timestamp, sha256);
   return [
     '# Maka Memory',
     '',
     '## 示例：我的偏好',
-    `<!-- maka-memory: id=${exampleId} origin=manual createdAt=${now} -->`,
+    `<!-- maka-memory: id=${exampleId} origin=manual createdAt=${timestamp} -->`,
     exampleContent,
     '',
   ].join('\n');

--- a/packages/runtime-host/src/server/memory-coordinator.ts
+++ b/packages/runtime-host/src/server/memory-coordinator.ts
@@ -11,6 +11,7 @@ import {
   setLocalMemoryEntryStatusDraft,
   stableLocalMemoryEntryId,
   stableLocalMemoryProposalId,
+  type Sha256Digest,
 } from '@maka/core/local-memory';
 import { redactSecrets } from '@maka/core/redaction';
 import type { RuntimePolicySnapshot } from '@maka/core/runtime-policy';
@@ -45,6 +46,11 @@ import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js
 import { ConnectionBoundChunkUploads } from './connection-bound-chunk-uploads.js';
 
 const PENDING_DOCUMENT_DEFAULT = '# Maka Pending Memory\n';
+const nodeSha256: Sha256Digest = {
+  digest(input: string): Uint8Array {
+    return new Uint8Array(createHash('sha256').update(input, 'utf8').digest());
+  },
+};
 const MAX_ACTIVE_UPLOADS = 8;
 const MAX_STAGED_UPLOAD_BYTES = 1024 * 1024;
 const UPLOAD_TTL_MS = 5 * 60 * 1000;
@@ -345,13 +351,15 @@ export class HostMemoryCoordinator {
 
     const now = this.#now();
     const memory =
-      snapshot.memory.kind === 'missing' ? defaultLocalMemoryMarkdown(now) : memoryText(snapshot);
+      snapshot.memory.kind === 'missing'
+        ? defaultLocalMemoryMarkdown(nodeSha256, now)
+        : memoryText(snapshot);
     const pending = pendingText(snapshot);
     switch (input.kind) {
       case 'propose': {
         const content = redactSecrets(input.content);
         const result = appendLocalMemoryProposalDraft(pending, {
-          proposalId: stableLocalMemoryProposalId(content, now),
+          proposalId: stableLocalMemoryProposalId(content, now, nodeSha256),
           title: input.title,
           content,
           ...projectScope(input.scope),
@@ -368,7 +376,7 @@ export class HostMemoryCoordinator {
       case 'remember': {
         const content = redactSecrets(input.content);
         const result = appendApprovedLocalMemoryEntryDraft(memory, {
-          id: stableLocalMemoryEntryId(content, now),
+          id: stableLocalMemoryEntryId(content, now, nodeSha256),
           title: input.title,
           content,
           source: 'user_authored',
@@ -390,7 +398,7 @@ export class HostMemoryCoordinator {
         const content = redactSecrets(proposal.content);
         const result = approveLocalMemoryProposalDraft(memory, pending, {
           proposalId: input.proposalId,
-          entryId: stableLocalMemoryEntryId(content, now),
+          entryId: stableLocalMemoryEntryId(content, now, nodeSha256),
           confirmedAt: now,
           approvalSurface: 'settings_review_queue',
         });
@@ -433,7 +441,7 @@ export class HostMemoryCoordinator {
       case 'reset':
         return this.#commitBundle({
           expectedRevision: input.expectedRevision,
-          memory: encodeText(defaultLocalMemoryMarkdown(now)),
+          memory: encodeText(defaultLocalMemoryMarkdown(nodeSha256, now)),
           pending: documentBytesOrNull(snapshot.pending),
           backup: 'reset',
         });
@@ -514,7 +522,7 @@ export class HostMemoryCoordinator {
       if (snapshot.memory.kind === 'missing' && snapshot.pending.kind !== 'safe_mode') {
         await this.#store.commit({
           expectedRevision: snapshot.revision,
-          memory: encodeText(defaultLocalMemoryMarkdown(this.#now())),
+          memory: encodeText(defaultLocalMemoryMarkdown(nodeSha256, this.#now())),
           pending: documentBytesOrNull(snapshot.pending),
         });
       }


### PR DESCRIPTION
## Summary

`local-memory.ts` hashed `mem-` / `proposal-` ids with an embedded SHA-256. That is the same job `Sha256Digest` already does for OAuth PKCE.

This change:

- injects `Sha256Digest` into `stableLocalMemoryEntryId` and `stableLocalMemoryProposalId`
- routes Host through Node `createHash`, and the settings editor through SubtleCrypto
- collapses `serializeMetaComment` onto `normalizeMetaValue`
- pins persisted ids so Node crypto produces the same hex as before

#820 has landed, so the earlier coordination block is gone.

Fixes #1414

## Test plan

- [x] `packages/core` `local-memory` tests, including the pinned Node digest ids