### PR TITLE
fix(eval): update DeepSeek V4 Flash pricing to current published rates

### DIFF
--- a/packages/eval/src/provider-metering.ts
+++ b/packages/eval/src/provider-metering.ts
@@ -66,6 +66,10 @@ export function deriveMetering(counts: ProviderMeteringCounts): DerivedMetering 
 // other frameworks are given no cost block at all, which is why their figures
 // are not consulted here.
 //
+// Rates as published 2026-08-17, normalized at the off-peak band: DeepSeek
+// bills peak hours (01:00–04:00 and 06:00–10:00 UTC) at exactly double these,
+// and the checkpoint records no request timestamps to split by.
+//
 // DeepSeek bills input in exactly two kinds, cache hit and cache miss, and
 // charges nothing for writing the cache — a written token is a miss token. So
 // `cacheWrite` is the miss rate rather than a rate of its own: it exists to
@@ -73,10 +77,10 @@ export function deriveMetering(counts: ProviderMeteringCounts): DerivedMetering 
 // zero, and for DeepSeek itself it never applies, because the API reports only
 // `prompt_cache_hit_tokens` and `prompt_cache_miss_tokens`.
 export const DEEPSEEK_V4_FLASH_COST = {
-  input: 0.14,
-  output: 0.28,
-  cacheRead: 0.0028,
-  cacheWrite: 0.14,
+  input: 0.22,
+  output: 0.66,
+  cacheRead: 0.007,
+  cacheWrite: 0.22,
 } as const;
 
 // `inputTokens` is normalized to include both cached kinds, so each kind is


### PR DESCRIPTION
## Summary

Follow-up from the #2971 review (@M4n5ter's first non-blocking item): the static DeepSeek pricing was stale.

DeepSeek's published V4 Flash pricing is now time-of-day dependent — peak hours (01:00–04:00 and 06:00–10:00 UTC) bill $0.44/M cache-miss input, $0.014/M cache-hit input and $1.32/M output; all other hours bill half. The old flat table ($0.14 / $0.0028 / $0.28) matches neither band and understated real spend by roughly 2.4× on a mostly off-peak run.

The metering checkpoint records aggregate usage without request timestamps, so a flat table remains the only representable shape. This updates the table to the off-peak band and documents the normalization: reported cost is a normalized API-equivalent, not an invoice, and a run straddling peak hours bills up to 2×. Rates fetched 2026-08-17 from https://api-docs.deepseek.com/quick_start/pricing.

## Verification

- `node --test dist/__tests__/external-subject.test.js` — 13/13 pass, including the billing-identity test that reads the table symbolically.
- `npm run format:check` — clean.
- The 2.4× understatement was reproduced against the three-arm edit-contract run's metered usage, apportioned peak/off-peak by attempt wall-clock windows.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code authored the change and this PR body; a human contributor reviews the final diff and owns the merge decision. The commit carries a Generated-by trailer.

## Checklist

- [ ] Tests cover the change and fail without it — the billing-identity test reads the table symbolically; the rate values are data with no failing test
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
