### PR TITLE
fix(scripts): say what drifted when the notices check fails

### DIFF
--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -333,12 +333,66 @@ function validateAssetNotices() {
   }
 }
 
+/**
+ * Say what drifted, not just that something did.
+ *
+ * The comparison is byte-exact over a 15k-line generated file, so "stale" on
+ * its own leaves whoever hit it — often on a CI runner whose OS they are not
+ * holding — with nothing to act on. The two shapes worth separating are a
+ * changed dependency closure, which the suggested command fixes, and identical
+ * packages whose license bytes moved, which usually means something upstream
+ * or environmental rather than a missed regeneration.
+ */
+function describeNoticeDrift(committed, generated) {
+  const packagesIn = (text) =>
+    new Set(
+      text
+        .split('\n')
+        .filter((line) => line.startsWith('Package: '))
+        .map((line) => line.slice('Package: '.length)),
+    );
+  const committedPackages = packagesIn(committed);
+  const generatedPackages = packagesIn(generated);
+  const onlyGenerated = [...generatedPackages].filter((name) => !committedPackages.has(name));
+  const onlyCommitted = [...committedPackages].filter((name) => !generatedPackages.has(name));
+
+  const lines = [];
+  const list = (label, names) => {
+    if (names.length === 0) return;
+    const shown = names.slice(0, 10);
+    lines.push(`  ${label} (${names.length}):`);
+    for (const name of shown) lines.push(`    ${name}`);
+    if (names.length > shown.length) lines.push(`    …and ${names.length - shown.length} more`);
+  };
+  list('present in the closure but missing from the committed file', onlyGenerated);
+  list('committed but no longer in the closure', onlyCommitted);
+
+  if (onlyGenerated.length === 0 && onlyCommitted.length === 0) {
+    const committedLines = committed.split('\n');
+    const generatedLines = generated.split('\n');
+    const limit = Math.max(committedLines.length, generatedLines.length);
+    let index = 0;
+    while (index < limit && committedLines[index] === generatedLines[index]) index += 1;
+    lines.push('  the same packages are listed, so the difference is in the notice text itself');
+    lines.push(`  first difference at line ${index + 1}:`);
+    lines.push(`    committed:  ${JSON.stringify(committedLines[index] ?? '<end of file>')}`);
+    lines.push(`    generated:  ${JSON.stringify(generatedLines[index] ?? '<end of file>')}`);
+  }
+  return lines.join('\n');
+}
+
 validateAssetNotices();
 const generated = renderNotice();
 if (checkOnly) {
-  if (!existsSync(outputPath) || readFileSync(outputPath, 'utf8') !== generated) {
+  if (!existsSync(outputPath)) {
     throw new Error(
-      'Production dependency notices are stale. Run npm run generate:third-party-notices.',
+      `Production dependency notices are missing at ${outputPath}. Run npm run generate:third-party-notices.`,
+    );
+  }
+  const committed = readFileSync(outputPath, 'utf8');
+  if (committed !== generated) {
+    throw new Error(
+      `Production dependency notices are stale. Run npm run generate:third-party-notices.\n${describeNoticeDrift(committed, generated)}`,
     );
   }
   console.log('[third-party-notices] OK — production dependency inventory is current.');

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -344,12 +344,16 @@ function validateAssetNotices() {
  * or environmental rather than a missed regeneration.
  */
 function describeNoticeDrift(committed, generated) {
+  // Split on either ending. A CRLF checkout would otherwise leave `\r` on every
+  // extracted name, reporting the same packages as both added and removed and
+  // hiding the text-drift branch below — the diagnostic would misdescribe
+  // exactly the environment-specific failure it exists to explain.
+  const linesOf = (text) => text.split(/\r?\n/);
   const packagesIn = (text) =>
     new Set(
-      text
-        .split('\n')
+      linesOf(text)
         .filter((line) => line.startsWith('Package: '))
-        .map((line) => line.slice('Package: '.length)),
+        .map((line) => line.slice('Package: '.length).trim()),
     );
   const committedPackages = packagesIn(committed);
   const generatedPackages = packagesIn(generated);
@@ -368,15 +372,26 @@ function describeNoticeDrift(committed, generated) {
   list('committed but no longer in the closure', onlyCommitted);
 
   if (onlyGenerated.length === 0 && onlyCommitted.length === 0) {
-    const committedLines = committed.split('\n');
-    const generatedLines = generated.split('\n');
+    const committedLines = linesOf(committed);
+    const generatedLines = linesOf(generated);
     const limit = Math.max(committedLines.length, generatedLines.length);
     let index = 0;
     while (index < limit && committedLines[index] === generatedLines[index]) index += 1;
     lines.push('  the same packages are listed, so the difference is in the notice text itself');
-    lines.push(`  first difference at line ${index + 1}:`);
-    lines.push(`    committed:  ${JSON.stringify(committedLines[index] ?? '<end of file>')}`);
-    lines.push(`    generated:  ${JSON.stringify(generatedLines[index] ?? '<end of file>')}`);
+    if (index === limit) {
+      // Every line matches once endings are normalized, so the bytes differ only
+      // in how the lines end. Naming that is the whole answer — regenerating
+      // will not help, and the repository already forces LF through
+      // .gitattributes, so a CRLF checkout means that rule did not take effect.
+      lines.push('  every line matches once line endings are normalized:');
+      lines.push(`    committed uses CRLF: ${committed.includes('\r\n')}`);
+      lines.push(`    generated uses CRLF: ${generated.includes('\r\n')}`);
+      lines.push('  check .gitattributes and the checkout, not the dependency closure');
+    } else {
+      lines.push(`  first difference at line ${index + 1}:`);
+      lines.push(`    committed:  ${JSON.stringify(committedLines[index] ?? '<end of file>')}`);
+      lines.push(`    generated:  ${JSON.stringify(generatedLines[index] ?? '<end of file>')}`);
+    }
   }
   return lines.join('\n');
 }


### PR DESCRIPTION
## Problem

`npm run check:third-party-notices` compares a 15k-line generated file byte-for-byte and, on a mismatch, says only:

```
Error: Production dependency notices are stale. Run npm run generate:third-party-notices.
```

Two different causes produce that message, and the suggested command only fixes one of them:

- the dependency closure changed — regenerating is the fix;
- the same packages are listed but their notice text moved — regenerating will *also* silently absorb it, without anyone seeing what changed or why.

Whoever hits this is usually reading a CI log for an OS they are not sitting in front of, so there is nothing to act on but a guess.

## Change

The check now names the drift.

Changed closure — packages on each side, capped at ten with a count:

```
Error: Production dependency notices are stale. Run npm run generate:third-party-notices.
  present in the closure but missing from the committed file (1):
    mermaid@11.16.1
```

Same packages, different text — the first differing line, both versions quoted:

```
Error: Production dependency notices are stale. Run npm run generate:third-party-notices.
  the same packages are listed, so the difference is in the notice text itself
  first difference at line 430:
    committed:  "================================================================================"
    generated:  ""
```

A missing output file also gets its own message instead of sharing the stale one, since "run the generator" is the whole answer there.

No dependencies added; the comparison itself is unchanged.

## How I know it works

Both branches were exercised against the real file: deleting one package's section produced the first output above, and the second is the actual current output on `main`.

That second one is not hypothetical. It localized a real failure in one line — same packages, line 430 — which pointed at `LICENSE` content rather than a dependency change, and from there to #3140 having landed without the notices file being regenerated. The Windows `package` job that runs this check does not list `LICENSE` in its trigger paths, so that PR never ran it. I will send the regeneration separately, since it is a different concern from the diagnostics.

Verified with `npm ci` rather than an incremental install, so the closure matches what CI resolves.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool and scope: Claude Code assisted with the implementation and diagnostics. The human contributor reviewed the work and accepts responsibility for the contribution.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Required CI checks pass

Does this PR entail a change in behavior?

- [x] Yes — check-mode diagnostics only; notice generation and comparison semantics are unchanged
- [ ] No
