### PR TITLE
fix(licenses): regenerate the notices after the bundled-font declaration

### DIFF
--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -427,6 +427,112 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+Geist and Geist Mono (bundled webfonts)
+
+Source: https://github.com/vercel/geist-font
+Emitted by: @fontsource-variable/geist 5.3.0, @fontsource-variable/geist-mono 5.3.0
+Copyright 2024 The Geist Project Authors
+License: SIL Open Font License, Version 1.1
+
+Maka's desktop renderer bundle embeds Geist Variable and Geist Mono Variable
+webfont files. The packages that carry them are build-time dependencies, but
+the `.woff2` files themselves are emitted into the renderer bundle and are
+therefore redistributed in binary artifacts. The upstream license text for
+that material follows verbatim:
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.
+
 ================================================================================
 
 Package: @antfu/install-pkg@1.1.0


### PR DESCRIPTION
`npm run check:third-party-notices` currently fails on `main`. This regenerates the file it checks.

## Cause

#3140 added the Geist OFL declaration to `LICENSE`. The notices generator folds `LICENSE` into its output, so `THIRD_PARTY_NOTICES.txt` went stale the moment that merged — my PR, my omission.

## Why CI did not catch it

The Windows `package` job is the only caller of `check:third-party-notices`. It runs on pull requests only, and its trigger paths do not include `LICENSE`:

```
07:30  #3140 merges — touches LICENSE alone, so this job never runs
   ↓
       main is now stale, and nothing on main re-runs the check
   ↓
08:38  #3148 touches electron-builder.config.mjs, which *is* a trigger path
       → the job wakes up and fails on debt from a different PR
```

So the failure surfaced on an unrelated PR, two paths and an hour removed from what caused it. Worth noting for anyone deciding whether that job should also run on `main`, or whether `LICENSE` belongs in its trigger paths — I have not changed either here, since both are policy calls.

## The change

Generator output only. 107 lines added, none removed, all of them the OFL text #3140 introduced.

Verified with `npm ci` rather than an incremental install, so the dependency closure matches what CI resolves; `check:third-party-notices` passes afterward.

Sent separately from #3154, which makes this class of failure self-describing — it is what localized this one, in one line, to LICENSE content rather than a dependency change.

Unblocks #3148.