### PR TITLE
fix(search): hide unready Tavily WebSearch

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-composition.test.ts
@@ -529,6 +529,127 @@ test('new Full Access Plan Skill previews use the mutating tool surface', async 
   });
 });
 
+test('Skill capability previews omit unavailable Tavily search surfaces', async () => {
+  await withCompositionRoot(async ({ root, owner }) => {
+    for (const [id, requiredTool] of [
+      ['web-search-preview', 'WebSearch'],
+      ['web-research-preview', 'web_research'],
+    ] as const) {
+      const skillDirectory = join(root, '.agents', 'skills', id);
+      await mkdir(skillDirectory, { recursive: true });
+      await writeFile(
+        join(skillDirectory, 'SKILL.md'),
+        [
+          '---',
+          `name: ${id}`,
+          `description: Requires ${requiredTool}.`,
+          `required-tools: [${requiredTool}]`,
+          '---',
+          `# ${id}`,
+          '',
+        ].join('\n'),
+      );
+    }
+
+    const policy = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const created = await policy.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: 'skill-preview-model',
+        name: 'Skill preview model',
+        providerType: 'ollama',
+        enabled: true,
+        enabledModelIds: ['fake-model'],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+    const fetch = await policy.operations.beginModelFetch(connection.connectionId);
+    assert.equal(fetch.kind, 'ready');
+    if (fetch.kind !== 'ready') return;
+    const fetched = await policy.operations.completeModelFetch(fetch.ticket, {
+      models: [{ id: 'fake-model' }],
+      source: 'fetched',
+      fetchedAt: Date.now(),
+    });
+    assert.equal(fetched.kind, 'committed');
+    if (fetched.kind !== 'committed') return;
+    const defaultTarget = await policy.connectionCatalog.setDefaultTarget({
+      expectedCatalogRevision: fetched.snapshot.revision,
+      target: { connectionId: connection.connectionId, modelId: 'fake-model' },
+    });
+    assert.equal(defaultTarget.kind, 'committed');
+    const policySnapshot = await policy.runtimePolicy.getSnapshot();
+    const webSearchEnabled = await policy.runtimePolicy.mutate({
+      expectedRevision: policySnapshot.revision,
+      operation: {
+        kind: 'set_web_search',
+        value: { enabled: true, defaultProvider: 'tavily' },
+      },
+    });
+    assert.equal(webSearchEnabled.kind, 'committed');
+    assert.equal(
+      (await policy.operations.resolveExecutionConnection(connection.slug)).kind,
+      'ready',
+    );
+
+    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await stores.sessionStore.create({
+      cwd: root,
+      backend: 'fake',
+      llmConnectionSlug: connection.slug,
+      model: 'fake-model',
+      permissionMode: 'bypass',
+    });
+    const composition = await createExecutionRuntimeHostComposition(compositionContext(owner), {
+      bootstrapRuntimePolicy: false,
+    });
+    try {
+      await composition.recover();
+      const connectionContext = {
+        hostEpoch: 'execution-composition-test',
+        connectionId: 'web-search-skill-preview-client',
+        surface: 'desktop' as const,
+        principal: 'local_os_user' as const,
+        acquireResidency: () => ({ release() {} }),
+      };
+      const query = (target: 'session' | 'new_session') =>
+        composition.handlers['skill.catalog.invocable.query'](
+          {
+            kind: 'start',
+            target:
+              target === 'session'
+                ? { kind: 'session', sessionId: session.id }
+                : {
+                    kind: 'new_session',
+                    context: { workspace: { kind: 'host_path', path: root } },
+                    collaborationMode: 'agent',
+                    permissionMode: 'bypass',
+                  },
+          },
+          connectionContext,
+        );
+
+      for (const target of ['session', 'new_session'] as const) {
+        const outcome = await query(target);
+        assert.equal(outcome.ok, true);
+        if (!outcome.ok || outcome.result.kind !== 'page') continue;
+        assert.equal(
+          outcome.result.items.some(
+            (item) => item.id === 'web-search-preview' || item.id === 'web-research-preview',
+          ),
+          false,
+        );
+      }
+    } finally {
+      await composition.close();
+    }
+  });
+});
+
 test('production composition validates graph stop before aborting a claimed child', async () => {
   await withCompositionRoot(async ({ root, owner }) => {
     const stores = await openInteractiveExecutionStoresForWrite(owner.lease);

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -92,7 +92,6 @@ const RESPONSE_TEXT = 'Hosted real-model execution completed.';
 const SUMMARY_TEXT = '## Goal\nContinue hosted real-model execution.';
 const CLIENT_CAPABILITY_RESULT_TEXT = 'HOSTED_CLIENT_CAPABILITY_RESULT_SENTINEL';
 const CHILD_AGENT_RESULT_TEXT = 'HOSTED_CHILD_AGENT_RESULT_SENTINEL';
-const WEB_RESEARCH_CHILD_RESULT_TEXT = 'HOSTED_WEB_RESEARCH_RESULT_SENTINEL';
 const MAX_IMPLEMENTATION_CHILD_PTY_READS = 5;
 const MIN_IMPLEMENTATION_CHILD_REQUESTS = 6;
 const MAX_IMPLEMENTATION_CHILD_REQUESTS =
@@ -1152,6 +1151,8 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     assert.match(requestText, /HOSTED_PERSONALIZATION_SENTINEL/);
     assert.match(requestText, /HOSTED_MEMORY_SENTINEL/);
     assert.match(JSON.stringify(mainRequests[1]?.body), /HOSTED_SKILL_BODY_MUST_STAY_LAZY/);
+    // Tavily is selected but no web-search credential exists, so the provider
+    // must never see WebSearch in the effective root tool surface.
     assert.deepEqual(toolNames(request?.body), [
       'ArchiveRead',
       'AskUserQuestion',
@@ -1174,7 +1175,6 @@ test('production Host executes a canonical ai-sdk Session against a real provide
       'SkillSearch',
       'StopBackgroundTask',
       'WebFetch',
-      'WebSearch',
       'Write',
       'WriteStdin',
       'load_tools',
@@ -1603,13 +1603,13 @@ test('production Host executes a durable runnable child with an exact tool ceili
     );
 
     const requests = provider.requests.filter((request) => request.body.stream === true);
-    assert.equal(requests.length, 7);
+    assert.equal(requests.length, 4);
     assert.ok(toolNames(requests[0]?.body).includes('load_tools'));
     assert.equal(toolNames(requests[0]?.body).includes('agent_spawn'), false);
     assert.ok(toolNames(requests[1]?.body).includes('agent_spawn'));
+    // The same routed child surface removes web_research when Tavily cannot run.
     assert.deepEqual(toolParameterEnum(requests[1]?.body, 'agent_spawn', 'profile'), [
       'local_read',
-      'web_research',
       'implementation',
     ]);
     // A child now carries the archive decoder alongside its allowlist (#2026).
@@ -1618,9 +1618,6 @@ test('production Host executes a durable runnable child with an exact tool ceili
     // can read back a result the runtime itself pruned.
     assert.deepEqual(toolNames(requests[2]?.body), ['ArchiveRead', 'Glob', 'Grep', 'Read']);
     assert.ok(toolNames(requests[3]?.body).includes('agent_spawn'));
-    assert.deepEqual(toolNames(requests[4]?.body), ['ArchiveRead', 'WebSearch']);
-    assert.deepEqual(toolNames(requests[5]?.body), ['ArchiveRead', 'WebSearch']);
-    assert.ok(toolNames(requests[6]?.body).includes('agent_spawn'));
 
     const sessions = await execution.sessionStore.listForRecovery();
     const child = sessions.find((session) => session.subagentRuntime?.profile === 'local_read');
@@ -1628,7 +1625,7 @@ test('production Host executes a durable runnable child with an exact tool ceili
       (session) => session.subagentRuntime?.profile === 'web_research',
     );
     assert.ok(child);
-    assert.ok(webChild);
+    assert.equal(webChild, undefined);
     assert.equal(child?.subagentRuntime?.profile, 'local_read');
     assert.equal(child?.subagentParent?.parentSessionId, parent.id);
     if (!child) return;
@@ -1643,31 +1640,6 @@ test('production Host executes a durable runnable child with an exact tool ceili
       childMessages.find((message) => message.type === 'assistant')?.text,
       CHILD_AGENT_RESULT_TEXT,
     );
-    if (!webChild) return;
-    const webChildRuns = await execution.agentRunStore.listSessionRuns(webChild.id);
-    assert.equal(webChildRuns.length, 1);
-    assert.equal(webChildRuns[0]?.status, 'completed');
-    const webChildMessages = await execution.sessionStore.readMessagesSnapshot(webChild.id);
-    assert.equal(
-      webChildMessages.find((message) => message.type === 'assistant')?.text,
-      WEB_RESEARCH_CHILD_RESULT_TEXT,
-    );
-    const webChildEvents = await execution.runtimeEventStore.readRuntimeEvents(
-      webChild.id,
-      webChildRuns[0]!.runId,
-    );
-    const searchResult = webChildEvents.find(
-      (event) => event.content?.kind === 'function_response' && event.content.name === 'WebSearch',
-    );
-    assert.ok(searchResult?.content?.kind === 'function_response');
-    assert.deepEqual(decodeCanonicalToolResultContent(searchResult.content.result), {
-      kind: 'web_search_error',
-      ok: false,
-      provider: 'tavily',
-      query: 'latest hosted web result',
-      reason: 'not_configured',
-      message: 'Configure a Tavily API key before using web search.',
-    });
     const artifacts = await openInteractiveArtifactStoreForWrite(owner.lease);
     const childArtifacts = await artifacts.listTurnArtifacts(child.id, childRuns[0]!.turnId);
     assert.equal(childArtifacts.length, 1);
@@ -2951,6 +2923,7 @@ function backendCreationFixture(input: {
       clientCapabilities: {
         snapshotForSession: input.snapshotClientCapabilities ?? (() => undefined),
       } as unknown as HostClientCapabilityCoordinator,
+      resolveTavilyWebSearchReadiness: async () => false,
     });
   return {
     context: {
@@ -3444,25 +3417,7 @@ async function handleProviderRequest(
   }
   if (flow.kind === 'child_agent' && streamRequestIndex === 4) {
     assert.ok(toolNames(body).includes('agent_spawn'));
-    respondProviderToolCall(response, streamRequestIndex, 'agent_spawn', {
-      profile: 'web_research',
-      task: 'Find one current hosted web result.',
-      isolation: 'same_workspace',
-      write_back: 'summary',
-    });
-    return;
-  }
-  if (flow.kind === 'child_agent' && streamRequestIndex === 5) {
-    assert.deepEqual(toolNames(body), ['ArchiveRead', 'WebSearch']);
-    respondProviderToolCall(response, streamRequestIndex, 'WebSearch', {
-      query: 'latest hosted web result',
-      limit: 1,
-    });
-    return;
-  }
-  if (flow.kind === 'child_agent' && streamRequestIndex === 6) {
-    assert.deepEqual(toolNames(body), ['ArchiveRead', 'WebSearch']);
-    respondProviderText(response, WEB_RESEARCH_CHILD_RESULT_TEXT);
+    respondProviderText(response, RESPONSE_TEXT);
     return;
   }
   if (flow.kind === 'implementation_child_agent' && streamRequestIndex === 3) {

--- a/packages/runtime-host/src/__tests__/web-search-tool.test.ts
+++ b/packages/runtime-host/src/__tests__/web-search-tool.test.ts
@@ -7,7 +7,29 @@ import type {
   ResolveWebSearchExecutionResult,
   RuntimePolicyOperationCoordinator,
 } from '@maka/storage/runtime-policy-stores';
-import { createHostWebSearchTool } from '../server/web-search-tool.js';
+import {
+  createHostWebSearchTool,
+  resolveHostTavilyWebSearchReadiness,
+} from '../server/web-search-tool.js';
+
+test('Host Tavily readiness follows the canonical execution resolver', async () => {
+  assert.equal(
+    await resolveHostTavilyWebSearchReadiness(
+      resolver({
+        kind: 'credential_not_configured',
+        status: {
+          locator: { scope: 'web_search', provider: 'tavily', kind: 'api_key' },
+          configured: false,
+          credentialId: null,
+          revision: null,
+          updatedAt: null,
+        },
+      }),
+    ),
+    false,
+  );
+  assert.equal(await resolveHostTavilyWebSearchReadiness(resolver(readyDirectExecution())), true);
+});
 
 test('Host WebSearch fails closed before transport creation for unavailable policy states', async () => {
   const states: readonly ResolveWebSearchExecutionResult[] = [

--- a/packages/runtime-host/src/__tests__/web-search-tool.test.ts
+++ b/packages/runtime-host/src/__tests__/web-search-tool.test.ts
@@ -10,7 +10,28 @@ import type {
 import {
   createHostWebSearchTool,
   resolveHostTavilyWebSearchReadiness,
+  shouldResolveHostTavilyWebSearchReadiness,
 } from '../server/web-search-tool.js';
+
+test('Host only resolves Tavily readiness when that execution path can be exposed', () => {
+  const policy = createDefaultRuntimePolicy();
+  assert.equal(shouldResolveHostTavilyWebSearchReadiness(policy), false);
+  assert.equal(
+    shouldResolveHostTavilyWebSearchReadiness({
+      ...policy,
+      webSearch: { enabled: true, defaultProvider: 'tavily' },
+    }),
+    true,
+  );
+  assert.equal(
+    shouldResolveHostTavilyWebSearchReadiness({
+      ...policy,
+      privacy: { incognitoActive: true },
+      webSearch: { enabled: true, defaultProvider: 'tavily' },
+    }),
+    false,
+  );
+});
 
 test('Host Tavily readiness follows the canonical execution resolver', async () => {
   assert.equal(

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
+import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import { emptyPlanSessionState } from '@maka/core/plan';
 import type { PermissionMode } from '@maka/core/permission';
@@ -31,7 +32,6 @@ import {
 } from '@maka/runtime/history-compact-ledger';
 import { prepareSkillInvocationMessageFromInventory } from '@maka/runtime/skill-invocation';
 import { RuntimeReadModel } from '@maka/runtime/runtime-read-model';
-import { routeWebSearchTools } from '@maka/runtime/native-web-search-tool';
 import {
   renderAgentSwarmSupervisorWake,
   shouldWakeAgentSwarmSupervisor,
@@ -102,6 +102,7 @@ import { createHostAiSdkBackend } from './execution-model-composition.js';
 import {
   createInteractiveRunComposer,
   createInteractiveRunComposerFactory,
+  routeInteractiveRunToolSurface,
 } from './interactive-run-composer.js';
 import {
   createHostGoalEvaluator,
@@ -164,6 +165,7 @@ import {
   createHostWebSearchService,
   createHostWebSearchToolFromService,
   resolveHostTavilyWebSearchReadiness,
+  shouldResolveHostTavilyWebSearchReadiness,
 } from './web-search-tool.js';
 import { createHostWebFetchService, createHostWebFetchToolFromService } from './web-fetch-tool.js';
 import { createHostExecutionArtifactServices } from './execution-artifacts.js';
@@ -681,6 +683,49 @@ export async function createExecutionRuntimeHostComposition(
       stopSession: (sessionId, input) =>
         requireRootCoordinator(rootCoordinator).stopSession(sessionId, input),
     };
+    const resolveInteractiveToolSurface = async (input: {
+      readonly connectionSlug?: string;
+      readonly modelId: string;
+      readonly hostTools: readonly MakaTool[];
+      readonly boundTools?: readonly MakaTool[];
+      readonly childTools?: readonly MakaTool[];
+      readonly parentAgentTools?: readonly MakaTool[];
+    }) => {
+      const [runtimePolicy, resolved] = await Promise.all([
+        runtimePolicyStores.runtimePolicy.getSnapshot(),
+        input.connectionSlug
+          ? runtimePolicyStores.operations.resolveExecutionConnection(input.connectionSlug)
+          : Promise.resolve(undefined),
+      ]);
+      let connection: RuntimeExecutionConnection | undefined;
+      if (resolved?.kind === 'ready') {
+        const { models, ...configuration } = resolved.connection;
+        connection = {
+          ...configuration,
+          defaultModel: input.modelId,
+          ...(models ? { models: [...models] } : {}),
+        };
+      }
+      const tavilyReady =
+        connection && shouldResolveHostTavilyWebSearchReadiness(runtimePolicy.policy)
+          ? await resolveHostTavilyWebSearchReadiness(runtimePolicyStores.operations)
+          : false;
+      return {
+        runtimePolicy,
+        surface: routeInteractiveRunToolSurface({
+          runtimePolicy,
+          ...(connection ? { connection } : {}),
+          modelId: input.modelId,
+          hostTools: input.hostTools,
+          ...(input.boundTools ? { boundTools: input.boundTools } : {}),
+          ...(input.childTools ? { childTools: input.childTools } : {}),
+          ...(input.parentAgentTools ? { parentAgentTools: input.parentAgentTools } : {}),
+          taskLedger,
+          worktreePatchWriteBackAvailable: true,
+          tavilyReady,
+        }),
+      };
+    };
     resolveAvailableToolNames = async (sessionId: string): Promise<string[]> => {
       const header = await stores.sessionStore.readHeaderSnapshot(sessionId);
       if (header.subagentRuntime) {
@@ -695,7 +740,13 @@ export async function createExecutionRuntimeHostComposition(
         if (tools.length !== header.subagentRuntime.toolNames.length) {
           throw new Error('Subagent runtime tool snapshot is unavailable');
         }
-        return tools.map((tool) => tool.name);
+        const { surface } = await resolveInteractiveToolSurface({
+          connectionSlug: header.llmConnectionSlug,
+          modelId: header.model,
+          hostTools: [],
+          boundTools: tools,
+        });
+        return (surface.boundTools ?? []).map((tool) => tool.name);
       }
       if (header.subagentParent) {
         throw new Error('Linked child session is missing its durable runtime snapshot');
@@ -703,14 +754,20 @@ export async function createExecutionRuntimeHostComposition(
       const capabilitySnapshot =
         requireClientCapabilities(clientCapabilities).snapshotForSession(sessionId);
       try {
-        const [graphTools, planState, runtimePolicySnapshot] = await Promise.all([
+        const [graphTools, planState] = await Promise.all([
           requireGraphCoordinator(graphCoordinator).toolsForSession(sessionId),
           openedPlanStore.readState(sessionId),
-          runtimePolicyStores.runtimePolicy.getSnapshot(),
         ]);
+        const { runtimePolicy, surface } = await resolveInteractiveToolSurface({
+          connectionSlug: header.llmConnectionSlug,
+          modelId: header.model,
+          hostTools: [...hostTools, ...graphTools],
+          childTools: childAgentTools.childTools,
+          parentAgentTools: childAgentTools.parentTools,
+        });
         const runProfile = hostedExecutionRunProfile(header.toolProfile);
         return createInteractiveRunComposer({
-          runtimePolicy: runtimePolicySnapshot,
+          runtimePolicy,
           skills,
           memory: requireMemory(memory),
           taskLedger,
@@ -722,10 +779,10 @@ export async function createExecutionRuntimeHostComposition(
             : {}),
           ...(capabilitySnapshot ? { clientCapabilities: capabilitySnapshot } : {}),
           builtinTools,
-          hostTools: [...hostTools, ...graphTools],
+          hostTools: surface.hostTools,
           ...(scheduledTaskTool ? { scheduledTaskTool } : {}),
           goalTools: requireGoal(goal).tools,
-          parentAgentTools: childAgentTools.parentTools,
+          ...(surface.parentAgentTools ? { parentAgentTools: surface.parentAgentTools } : {}),
           plan: {
             store: openedPlanStore,
             state: planState,
@@ -756,18 +813,31 @@ export async function createExecutionRuntimeHostComposition(
         const capabilitySnapshot =
           requireClientCapabilities(clientCapabilities).snapshotForSession(previewSessionId);
         try {
-          const runtimePolicySnapshot = await runtimePolicyStores.runtimePolicy.getSnapshot();
+          const catalog = await runtimePolicyStores.connectionCatalog.getSnapshot();
+          const target = catalog.defaultTarget;
+          const connection = target
+            ? catalog.connections.find(
+                (candidate) => candidate.connectionId === target.connectionId,
+              )
+            : undefined;
+          const { runtimePolicy, surface } = await resolveInteractiveToolSurface({
+            ...(connection ? { connectionSlug: connection.slug } : {}),
+            modelId: target?.modelId ?? '',
+            hostTools,
+            childTools: childAgentTools.childTools,
+            parentAgentTools: childAgentTools.parentTools,
+          });
           return createInteractiveRunComposer({
-            runtimePolicy: runtimePolicySnapshot,
+            runtimePolicy,
             skills,
             memory: requireMemory(memory),
             taskLedger,
             ...(capabilitySnapshot ? { clientCapabilities: capabilitySnapshot } : {}),
             builtinTools,
-            hostTools,
+            hostTools: surface.hostTools,
             ...(scheduledTaskTool ? { scheduledTaskTool } : {}),
             goalTools: requireGoal(goal).tools,
-            parentAgentTools: childAgentTools.parentTools,
+            ...(surface.parentAgentTools ? { parentAgentTools: surface.parentAgentTools } : {}),
             plan: {
               store: openedPlanStore,
               state: emptyPlanSessionState(previewSessionId),
@@ -806,30 +876,13 @@ export async function createExecutionRuntimeHostComposition(
     sessionEffects = sessionEffectCoordinator;
     const resolveChildTools = async (sessionId: string): Promise<readonly MakaTool[]> => {
       const header = await stores.sessionStore.readHeader(sessionId);
-      const [resolved, snapshot] = await Promise.all([
-        runtimePolicyStores.operations.resolveExecutionConnection(header.llmConnectionSlug),
-        runtimePolicyStores.runtimePolicy.getSnapshot(),
-      ]);
-      if (resolved.kind !== 'ready') {
-        return childAgentTools.childTools.filter((tool) => tool.name !== 'WebSearch');
-      }
-      const { models, ...connection } = resolved.connection;
-      const tavilyReady =
-        snapshot.policy.webSearch.defaultProvider === 'tavily'
-          ? await resolveHostTavilyWebSearchReadiness(runtimePolicyStores.operations)
-          : false;
-      return routeWebSearchTools({
-        tools: childAgentTools.childTools,
-        settings: snapshot.policy.webSearch,
-        connection: {
-          ...connection,
-          defaultModel: header.model,
-          ...(models ? { models: [...models] } : {}),
-        },
-        model: header.model,
-        tavilyReady,
-        privacy: snapshot.policy.privacy,
+      const { surface } = await resolveInteractiveToolSurface({
+        connectionSlug: header.llmConnectionSlug,
+        modelId: header.model,
+        hostTools: [],
+        childTools: childAgentTools.childTools,
       });
+      return surface.childTools ?? [];
     };
     const subagentCatalog = createConfiguredSubagentCatalog({
       getPresets: async () =>

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -163,6 +163,7 @@ import { HostWebSearchCoordinator } from './web-search-coordinator.js';
 import {
   createHostWebSearchService,
   createHostWebSearchToolFromService,
+  resolveHostTavilyWebSearchReadiness,
 } from './web-search-tool.js';
 import { createHostWebFetchService, createHostWebFetchToolFromService } from './web-fetch-tool.js';
 import { createHostExecutionArtifactServices } from './execution-artifacts.js';
@@ -640,6 +641,8 @@ export async function createExecutionRuntimeHostComposition(
               memory: requireMemory(memory),
               taskLedger,
               clientCapabilities: requireClientCapabilities(clientCapabilities),
+              resolveTavilyWebSearchReadiness: () =>
+                resolveHostTavilyWebSearchReadiness(runtimePolicyStores.operations),
               ...(scheduledTaskTool ? { scheduledTaskTool } : {}),
               planStore: openedPlanStore,
               deepResearchTools: requireDeepResearch(deepResearch).toolsForSession(
@@ -811,6 +814,10 @@ export async function createExecutionRuntimeHostComposition(
         return childAgentTools.childTools.filter((tool) => tool.name !== 'WebSearch');
       }
       const { models, ...connection } = resolved.connection;
+      const tavilyReady =
+        snapshot.policy.webSearch.defaultProvider === 'tavily'
+          ? await resolveHostTavilyWebSearchReadiness(runtimePolicyStores.operations)
+          : false;
       return routeWebSearchTools({
         tools: childAgentTools.childTools,
         settings: snapshot.policy.webSearch,
@@ -820,6 +827,7 @@ export async function createExecutionRuntimeHostComposition(
           ...(models ? { models: [...models] } : {}),
         },
         model: header.model,
+        tavilyReady,
         privacy: snapshot.policy.privacy,
       });
     };

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -315,6 +315,7 @@ export interface InteractiveRunComposerFactoryInput
     'runtimePolicy' | 'boundTools' | 'boundToolNames' | 'clientCapabilities' | 'plan'
   > {
   readonly clientCapabilities: HostClientCapabilityCoordinator;
+  readonly resolveTavilyWebSearchReadiness: () => Promise<boolean>;
   readonly resolveRootTools?: (sessionId: string) => Promise<readonly MakaTool[]>;
   readonly childTools?: readonly MakaTool[];
   readonly worktreePatchWriteBackAvailable?: boolean;
@@ -344,12 +345,20 @@ export function createInteractiveRunComposerFactory(
               backendContext.abortSignal,
             )
           : [];
+      const tavilyReady =
+        runtimePolicy.policy.webSearch.defaultProvider === 'tavily'
+          ? await readDuringBackendCreation(
+              input.resolveTavilyWebSearchReadiness,
+              backendContext.abortSignal,
+            )
+          : false;
       const candidateHostTools = [...(input.hostTools ?? []), ...rootTools];
       const webSearchRouting = {
         tools: routeWebFetchTools(candidateHostTools, runtimePolicy.policy.privacy),
         settings: runtimePolicy.policy.webSearch,
         connection,
         model: modelId,
+        tavilyReady,
         privacy: runtimePolicy.policy.privacy,
       } as const;
       const hostTools = routeWebSearchTools(webSearchRouting);

--- a/packages/runtime-host/src/server/interactive-run-composer.ts
+++ b/packages/runtime-host/src/server/interactive-run-composer.ts
@@ -9,6 +9,7 @@ import {
 } from '@maka/core/explore-agent';
 import { activePlanExecution, type PlanSessionState, type PlanStore } from '@maka/core/plan';
 import type { PermissionMode } from '@maka/core/permission';
+import type { RuntimeExecutionConnection } from '@maka/core/llm-connections';
 import type { RuntimePolicySnapshot } from '@maka/core/runtime-policy';
 import type { SessionToolProfile } from '@maka/core/session';
 import {
@@ -74,6 +75,7 @@ import {
   hostedExecutionRunProfile,
   projectHostedExecutionTools,
 } from './hosted-execution-tool-profile.js';
+import { shouldResolveHostTavilyWebSearchReadiness } from './web-search-tool.js';
 
 const INTERACTIVE_RUN_COMPOSER_ID = 'maka.interactive';
 const INTERACTIVE_RUN_COMPOSER_REVISION = '1';
@@ -323,6 +325,61 @@ export interface InteractiveRunComposerFactoryInput
   readonly deepResearchTools?: readonly MakaTool[];
 }
 
+export interface InteractiveRunToolSurfaceInput {
+  readonly runtimePolicy: RuntimePolicySnapshot;
+  readonly connection?: RuntimeExecutionConnection;
+  readonly modelId: string;
+  readonly hostTools: readonly MakaTool[];
+  readonly boundTools?: readonly MakaTool[];
+  readonly childTools?: readonly MakaTool[];
+  readonly parentAgentTools?: readonly MakaTool[];
+  readonly taskLedger: TaskLedgerStore;
+  readonly worktreePatchWriteBackAvailable?: boolean;
+  readonly tavilyReady: boolean;
+}
+
+/** Routes every model-visible tool surface through the same policy and readiness snapshot. */
+export function routeInteractiveRunToolSurface(input: InteractiveRunToolSurfaceInput): {
+  readonly hostTools: readonly MakaTool[];
+  readonly boundTools?: readonly MakaTool[];
+  readonly childTools?: readonly MakaTool[];
+  readonly parentAgentTools?: readonly MakaTool[];
+} {
+  const route = (tools: readonly MakaTool[]): MakaTool[] => {
+    const webFetchTools = routeWebFetchTools(tools, input.runtimePolicy.policy.privacy);
+    if (!input.connection) {
+      return webFetchTools.filter((tool) => tool.name !== 'WebSearch');
+    }
+    return routeWebSearchTools({
+      tools: webFetchTools,
+      settings: input.runtimePolicy.policy.webSearch,
+      connection: input.connection,
+      model: input.modelId,
+      tavilyReady: input.tavilyReady,
+      privacy: input.runtimePolicy.policy.privacy,
+    });
+  };
+  const childTools = input.childTools ? route(input.childTools) : undefined;
+  return {
+    hostTools: route(input.hostTools),
+    ...(input.boundTools ? { boundTools: route(input.boundTools) } : {}),
+    ...(childTools ? { childTools } : {}),
+    ...(childTools
+      ? {
+          parentAgentTools: buildParentAgentTools({
+            taskLedger: input.taskLedger,
+            definitions: listRunnableBuiltinAgentDefinitions({
+              tools: childTools,
+              worktreeChildExecutorAvailable: input.worktreePatchWriteBackAvailable,
+            }),
+          }),
+        }
+      : input.parentAgentTools
+        ? { parentAgentTools: input.parentAgentTools }
+        : {}),
+  };
+}
+
 export function createInteractiveRunComposerFactory(
   input: InteractiveRunComposerFactoryInput,
 ): HostRunComposerFactory {
@@ -345,44 +402,26 @@ export function createInteractiveRunComposerFactory(
               backendContext.abortSignal,
             )
           : [];
-      const tavilyReady =
-        runtimePolicy.policy.webSearch.defaultProvider === 'tavily'
-          ? await readDuringBackendCreation(
-              input.resolveTavilyWebSearchReadiness,
-              backendContext.abortSignal,
-            )
-          : false;
+      const tavilyReady = shouldResolveHostTavilyWebSearchReadiness(runtimePolicy.policy)
+        ? await readDuringBackendCreation(
+            input.resolveTavilyWebSearchReadiness,
+            backendContext.abortSignal,
+          )
+        : false;
       const candidateHostTools = [...(input.hostTools ?? []), ...rootTools];
-      const webSearchRouting = {
-        tools: routeWebFetchTools(candidateHostTools, runtimePolicy.policy.privacy),
-        settings: runtimePolicy.policy.webSearch,
+      const toolSurface = routeInteractiveRunToolSurface({
+        runtimePolicy,
         connection,
-        model: modelId,
+        modelId,
+        hostTools: candidateHostTools,
+        ...(backendContext.tools ? { boundTools: backendContext.tools } : {}),
+        ...(input.childTools ? { childTools: input.childTools } : {}),
+        ...(input.parentAgentTools ? { parentAgentTools: input.parentAgentTools } : {}),
+        taskLedger: input.taskLedger,
+        worktreePatchWriteBackAvailable: input.worktreePatchWriteBackAvailable,
         tavilyReady,
-        privacy: runtimePolicy.policy.privacy,
-      } as const;
-      const hostTools = routeWebSearchTools(webSearchRouting);
-      const boundTools = backendContext.tools
-        ? routeWebSearchTools({
-            ...webSearchRouting,
-            tools: routeWebFetchTools(backendContext.tools, runtimePolicy.policy.privacy),
-          })
-        : undefined;
-      const routedChildTools = input.childTools
-        ? routeWebSearchTools({
-            ...webSearchRouting,
-            tools: routeWebFetchTools(input.childTools, runtimePolicy.policy.privacy),
-          })
-        : undefined;
-      const parentAgentTools = routedChildTools
-        ? buildParentAgentTools({
-            taskLedger: input.taskLedger,
-            definitions: listRunnableBuiltinAgentDefinitions({
-              tools: routedChildTools,
-              worktreeChildExecutorAvailable: input.worktreePatchWriteBackAvailable,
-            }),
-          })
-        : input.parentAgentTools;
+      });
+      const { hostTools, boundTools, parentAgentTools } = toolSurface;
       const composer = createInteractiveRunComposer({
         runtimePolicy,
         skills: input.skills,

--- a/packages/runtime-host/src/server/web-search-tool.ts
+++ b/packages/runtime-host/src/server/web-search-tool.ts
@@ -7,6 +7,7 @@ import {
 import { queryTavily } from '@maka/runtime/tavily-search';
 import { type MakaTool } from '@maka/runtime/tool-runtime';
 import type { WebSearchResponse } from '@maka/core/web-search';
+import type { RuntimePolicy } from '@maka/core/runtime-policy';
 import type {
   ResolveWebSearchExecutionInput,
   RuntimePolicyOperationCoordinator,
@@ -25,6 +26,16 @@ export interface HostWebSearchService {
     readonly abortSignal?: AbortSignal;
     readonly policy?: ResolveWebSearchExecutionInput;
   }): Promise<WebSearchResponse>;
+}
+
+export function shouldResolveHostTavilyWebSearchReadiness(
+  policy: Pick<RuntimePolicy, 'privacy' | 'webSearch'>,
+): boolean {
+  return (
+    policy.webSearch.enabled &&
+    policy.webSearch.defaultProvider === 'tavily' &&
+    policy.privacy.incognitoActive !== true
+  );
 }
 
 export async function resolveHostTavilyWebSearchReadiness(

--- a/packages/runtime-host/src/server/web-search-tool.ts
+++ b/packages/runtime-host/src/server/web-search-tool.ts
@@ -27,6 +27,12 @@ export interface HostWebSearchService {
   }): Promise<WebSearchResponse>;
 }
 
+export async function resolveHostTavilyWebSearchReadiness(
+  policy: Pick<RuntimePolicyOperationCoordinator, 'resolveWebSearchExecution'>,
+): Promise<boolean> {
+  return (await policy.resolveWebSearchExecution({ provider: 'tavily' })).kind === 'ready';
+}
+
 export function createHostWebSearchService(input: HostWebSearchServiceInput): HostWebSearchService {
   const createFetchTransport = input.createFetchTransport ?? createProxiedFetchTransport;
   return {

--- a/packages/runtime/src/__tests__/native-web-search-tool.test.ts
+++ b/packages/runtime/src/__tests__/native-web-search-tool.test.ts
@@ -44,6 +44,7 @@ test('turn-start routing keeps native and client-executed search mutually exclus
     settings: { enabled: true, defaultProvider: 'model' },
     connection,
     model: 'deepseek-v4-flash',
+    tavilyReady: false,
   });
   assert.equal(native.filter((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME).length, 1);
   assert.equal(
@@ -56,10 +57,23 @@ test('turn-start routing keeps native and client-executed search mutually exclus
     settings: { enabled: true, defaultProvider: 'tavily' },
     connection,
     model: 'deepseek-v4-flash',
+    tavilyReady: true,
   });
   assert.equal(
     external.find((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME),
     clientSearch,
+  );
+
+  const unavailableExternal = routeWebSearchTools({
+    tools: [read, clientSearch],
+    settings: { enabled: true, defaultProvider: 'tavily' },
+    connection,
+    model: 'deepseek-v4-flash',
+    tavilyReady: false,
+  });
+  assert.deepEqual(
+    unavailableExternal.map((tool) => tool.name),
+    ['Read'],
   );
 
   const disabled = routeWebSearchTools({
@@ -67,6 +81,7 @@ test('turn-start routing keeps native and client-executed search mutually exclus
     settings: { enabled: false, defaultProvider: 'model' },
     connection,
     model: 'deepseek-v4-flash',
+    tavilyReady: false,
   });
   assert.deepEqual(
     disabled.map((tool) => tool.name),
@@ -79,6 +94,7 @@ test('turn-start routing keeps native and client-executed search mutually exclus
     privacy: { incognitoActive: true },
     connection,
     model: 'deepseek-v4-flash',
+    tavilyReady: false,
   });
   assert.deepEqual(
     incognito.map((tool) => tool.name),
@@ -102,6 +118,7 @@ test('turn-start routing compiles Claude models to the CC-compatible Anthropic t
       defaultModel: 'claude-sonnet-4-6',
     },
     model: 'claude-sonnet-4-6',
+    tavilyReady: false,
   });
 
   assert.deepEqual(routed[0]?.providerTool, {
@@ -121,6 +138,7 @@ test('root surfaces may add native search without widening scoped child tools', 
     settings: { enabled: true, defaultProvider: 'model' },
     connection,
     model: 'deepseek-v4-flash',
+    tavilyReady: false,
     allowAddNative: true,
   });
   assert.equal(root[0]?.providerTool?.kind, 'openai-web-search');
@@ -130,6 +148,7 @@ test('root surfaces may add native search without widening scoped child tools', 
     settings: { enabled: true, defaultProvider: 'model' },
     connection,
     model: 'deepseek-v4-flash',
+    tavilyReady: false,
   });
   assert.deepEqual(child, []);
 });
@@ -151,6 +170,7 @@ test('the WebSearch feature gate leaves WebFetch available', () => {
       defaultModel: 'deepseek-v4-flash',
     },
     model: 'deepseek-v4-flash',
+    tavilyReady: false,
   });
 
   assert.deepEqual(

--- a/packages/runtime/src/native-web-search-tool.ts
+++ b/packages/runtime/src/native-web-search-tool.ts
@@ -48,6 +48,8 @@ export function routeWebSearchTools(input: {
   readonly settings: Pick<WebSearchSettings, 'enabled' | 'defaultProvider'>;
   readonly connection: RuntimeExecutionConnection;
   readonly model: string;
+  /** Canonical call-time readiness for the client-executed Tavily path. */
+  readonly tavilyReady: boolean;
   readonly privacy?: { readonly incognitoActive: boolean };
   /** Root surfaces may add native search even when no client WebSearch exists. */
   readonly allowAddNative?: boolean;
@@ -59,7 +61,9 @@ export function routeWebSearchTools(input: {
   if (!input.settings.enabled || input.privacy?.incognitoActive === true) return withoutWebSearch;
   let selected: MakaTool | undefined;
   if (input.settings.defaultProvider === 'tavily') {
-    selected = input.tools.find((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME);
+    selected = input.tavilyReady
+      ? input.tools.find((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME)
+      : undefined;
   } else {
     const capability = resolveHostedWebSearchCapability(
       input.connection.providerType,


### PR DESCRIPTION
## Problem

When Web Search selected Tavily, the effective model tool surface kept advertising `WebSearch` even when the canonical runtime-policy resolver reported that the Tavily or required proxy credential was unavailable. The model could therefore spend a turn calling a tool that was guaranteed to fail, and child-agent composition could advertise the `web_research` profile without a runnable search tool.

The existing call-time fail-closed check remains necessary, but it happens after the model has already chosen the tool.

## Solution

- Derive Tavily readiness from the existing canonical `resolveWebSearchExecution({ provider: 'tavily' })` authority.
- Pass that readiness into the unified `routeWebSearchTools()` seam and retain the client-executed `WebSearch` only when the result is `ready`.
- Apply the same routed surface to root, bound, and child tools, so `web_research` is omitted when Tavily cannot run.
- Preserve provider-native search behavior: selecting `model` still depends only on the selected model's hosted-search capability and never requires a Tavily credential.
- Keep the call-time fail-closed guard as defense in depth.

Closes #2085.

## Verification

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime-host run typecheck`
- Biome check for all 7 touched files
- Focused Runtime and Runtime Host WebSearch tests: 10/10 passed
- Relevant Runtime Host production lifecycle tests: 2/2 passed
  - canonical AI SDK session omits unready Tavily `WebSearch`
  - child-agent surface omits `web_research` when Tavily is unavailable

Broader checks attempted:

- `npm run build:test` compiled Code Mode, Core, Storage, MCP, Runtime, Runtime Host, Computer Use, Eval, and the CLI, then stopped in untouched UI files on existing interface mismatches involving `settledText`, `conversationKey`, and `unlockAutoFollow`.
- The full Runtime test file was not claimed green: unrelated macOS sandbox/process smoke tests cannot run in the managed sandbox, and unrelated model-factory streaming assertions also failed. The focused WebSearch suite is green.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with repository analysis, implementation, regression tests, and review revisions. The human contributor reviewed, tested, and accepted the final change.

<details>
<summary>点击展开中文</summary>

## 问题

当联网搜索选择 Tavily 时，即使 Runtime Policy 的权威解析器已经确认 Tavily 凭证或必需的代理凭证不可用，`WebSearch` 仍然会出现在模型可见的工具列表中。模型可能因此浪费一轮调用一个必然失败的工具，子代理表面也可能错误地提供无法真正执行搜索的 `web_research`。

现有的调用阶段 fail-closed 检查仍然有必要，但它发生在模型选择工具之后，无法避免这次无效调用。

## 解决方案

- 复用现有的权威检查 `resolveWebSearchExecution({ provider: 'tavily' })` 获取 Tavily 就绪状态。
- 将就绪状态传入统一的 `routeWebSearchTools()`；只有结果为 `ready` 时，才保留由 Runtime 执行的 `WebSearch`。
- 根任务、受限工具表面和子代理工具表面全部使用相同的路由结果；Tavily 不可用时同时移除 `web_research`。
- 保持模型原生搜索逻辑不变：选择 `model` 时只检查当前模型是否支持原生联网搜索，不要求 Tavily 凭证。
- 保留调用阶段的 fail-closed 检查，作为第二层保护。

## 验证

- Runtime 与 Runtime Host 类型检查通过。
- 7 个修改文件的 Biome 检查通过。
- WebSearch 聚焦测试 10/10 通过。
- 相关 Runtime Host 生产生命周期测试 2/2 通过：根任务不再暴露不可用的 Tavily `WebSearch`，子代理也不再暴露不可用的 `web_research`。

更大范围检查中，`npm run build:test` 在完成 Code Mode、Core、Storage、MCP、Runtime、Runtime Host、Computer Use、Eval 和 CLI 编译后，停在未修改的 UI 文件接口不一致；完整 Runtime 测试还受到受管沙箱中的 macOS sandbox/process smoke test 和无关 model-factory streaming 断言影响，因此没有声明全量测试通过。

</details>
