### PR TITLE
fix(desktop): contain narrow workbar content

### DIFF
--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -16,13 +16,16 @@ async function openGitChanges(page: Page) {
 
 async function setRightWorkbarWidth(page: Page, width: number) {
   const workbar = page.locator('.maka-session-workbar[data-placement="right"]');
+  await expect(workbar).toBeVisible();
   await workbar.evaluate((element, nextWidth) => {
     (element as HTMLElement).style.setProperty(
       '--maka-session-workbar-width',
       `${nextWidth}px`,
     );
   }, width);
-  await expect.poll(async () => (await workbar.boundingBox())?.width).toBe(width);
+  await expect
+    .poll(async () => (await workbar.boundingBox())?.width)
+    .toBeCloseTo(width, 0);
   return workbar;
 }
 
@@ -41,7 +44,7 @@ test('narrow right workbar keeps launcher shortcuts and side-chat send button in
 
   const workbarBox = await workbar.boundingBox();
   const shortcutBoxes = await launcher
-    .getByRole('img')
+    .locator('kbd')
     .evaluateAll((elements) =>
       elements.map((element) => {
         const box = element.getBoundingClientRect();

--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -14,6 +14,76 @@ async function openGitChanges(page: Page) {
   return page.getByRole('region', { name: 'Git 变更' });
 }
 
+async function setRightWorkbarWidth(page: Page, width: number) {
+  const workbar = page.locator('.maka-session-workbar[data-placement="right"]');
+  await workbar.evaluate((element, nextWidth) => {
+    (element as HTMLElement).style.setProperty(
+      '--maka-session-workbar-width',
+      `${nextWidth}px`,
+    );
+  }, width);
+  await expect.poll(async () => (await workbar.boundingBox())?.width).toBe(width);
+  return workbar;
+}
+
+test('narrow right workbar keeps launcher shortcuts and side-chat send button inside', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('create narrow workbar session');
+  await composer.press('Enter');
+  await expect(page.getByText(/Fake backend received: create narrow workbar session/)).toBeVisible();
+
+  await page.getByRole('button', { name: '展开任务工作栏' }).click();
+  const launcher = page.getByRole('list', { name: '打开工具' });
+  await expect(launcher).toBeVisible();
+  const workbar = await setRightWorkbarWidth(page, 320);
+
+  const workbarBox = await workbar.boundingBox();
+  const shortcutBoxes = await launcher
+    .getByRole('img')
+    .evaluateAll((elements) =>
+      elements.map((element) => {
+        const box = element.getBoundingClientRect();
+        return { left: box.left, right: box.right };
+      }),
+    );
+  expect(workbarBox).not.toBeNull();
+  expect(shortcutBoxes.length).toBeGreaterThan(0);
+  for (const shortcutBox of shortcutBoxes) {
+    expect.soft(shortcutBox.left).toBeGreaterThanOrEqual(workbarBox!.x);
+    expect.soft(shortcutBox.right).toBeLessThanOrEqual(workbarBox!.x + workbarBox!.width);
+  }
+
+  await page
+    .getByRole('button', {
+      name: /侧边对话.*在不打断主任务的情况下追问和只读探索/,
+    })
+    .click();
+  const companion = page.locator('.maka-quote-companion');
+  await expect(companion).toBeVisible();
+  await setRightWorkbarWidth(page, 320);
+
+  const composerCard = companion.locator('.maka-composer-astryx');
+  // Match the long model-label pressure from the reported side-chat screenshot
+  // without coupling the fixture's globally useful default model to this test.
+  await companion.locator('.maka-composer-model-chip-text').evaluate((element) => {
+    element.textContent = 'Nemotron 3 Ultra Long Context Model';
+  });
+  const sendButton = companion.getByRole('button', { name: '发送' });
+  await expect(sendButton).toBeVisible();
+  const [composerBox, sendBox] = await Promise.all([
+    composerCard.boundingBox(),
+    sendButton.boundingBox(),
+  ]);
+  expect(composerBox).not.toBeNull();
+  expect(sendBox).not.toBeNull();
+  expect(sendBox!.x).toBeGreaterThanOrEqual(composerBox!.x);
+  expect(sendBox!.x + sendBox!.width).toBeLessThanOrEqual(
+    composerBox!.x + composerBox!.width,
+  );
+});
+
 test('titlebar workbar action restores an existing tool instead of the picker', async ({
   gitReviewWindow,
 }) => {

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -614,27 +614,29 @@ function WorkbarLauncher(props: {
   ];
   return (
     <div className="maka-workbar-launcher">
-      <List
-        className="maka-workbar-launcher-list"
-        density="compact"
-        header={<Heading level={4}>{copy.openTools}</Heading>}
-      >
-        {actions.map((action) => (
-          <ListItem
-            key={action.kind}
-            startContent={<Icon icon={action.icon} size="sm" color="secondary" />}
-            label={action.label}
-            description={action.description}
-            endContent={
-              action.shortcut ? (
-                <Kbd keys={action.shortcut} />
-              ) : undefined
-            }
-            isDisabled={action.disabled}
-            onClick={() => props.onOpen(action.kind)}
-          />
-        ))}
-      </List>
+      <div className="maka-workbar-launcher-frame">
+        <List
+          className="maka-workbar-launcher-list"
+          density="compact"
+          header={<Heading level={4}>{copy.openTools}</Heading>}
+        >
+          {actions.map((action) => (
+            <ListItem
+              key={action.kind}
+              startContent={<Icon icon={action.icon} size="sm" color="secondary" />}
+              label={action.label}
+              description={action.description}
+              endContent={
+                action.shortcut ? (
+                  <Kbd keys={action.shortcut} />
+                ) : undefined
+              }
+              isDisabled={action.disabled}
+              onClick={() => props.onOpen(action.kind)}
+            />
+          ))}
+        </List>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -298,8 +298,16 @@
   padding: var(--space-5);
 }
 
+.maka-workbar-launcher-frame {
+  width: 100%;
+  max-width: 360px;
+  min-width: 0;
+}
+
 .maka-workbar-launcher-list {
-  width: min(100%, 360px);
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 /* Session trace (#1625): a read-only causal timeline in the workbar.


### PR DESCRIPTION
## Summary

Keep the launcher and side-chat composer inside the 320px minimum right workbar. An explicit shrinkable launcher frame owns the width constraint instead of relying on the headed Astryx `List` wrapper, which otherwise resolves to its 360px max-content width and clips shortcut hints.

Electron coverage directly measures the shortcut hint containers and composer send button at the narrow boundary.

## Verification

- `npx biome check apps/desktop/src/renderer/session-workbar.tsx apps/desktop/src/renderer/styles/chat-detail.css apps/desktop/e2e/session-workbar.spec.ts` — passed
- `npx playwright test --config e2e/playwright.config.ts e2e/session-workbar.spec.ts` — 3 passed
- `npm --workspace @maka/desktop run typecheck` — passed before review
- `npm --workspace @maka/desktop run build:renderer` — passed before review

## Review focus

The wrapper avoids coupling product CSS to Astryx's internal headed-list DOM. The regression test targets actual `kbd` hint containers and uses tolerant geometry polling, incorporating both resolved review findings.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the workbar layout, implemented and tested the containment fix, incorporated review feedback, and drafted this description. The human contributor reviewed the work, chose to submit it, and remains responsible for its accuracy, provenance, and licensing.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
