### PR TITLE
chore: make automated reviews complexity-aware

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,15 @@ reviews:
       instructions: |
         Review the diff adversarially against the problem it claims to solve.
         Determine whether it is the smallest coherent solution at the existing source of truth.
+        Treat the reported problem and the proposed remedy as separate decisions.
+        Report only concrete, reproducible correctness or maintenance risks, and give each finding one disposition:
+        - fix-now: the current PR violates its stated behavior or an existing invariant;
+        - follow-up: the risk is real but pre-existing or outside the PR's goal;
+        - optional: the change would be an improvement but is not required for correctness or coherence.
+
+        Choose remedies in this order: delete an unnecessary path, consolidate duplicated authority, reuse the closest existing seam, make the smallest local correction, then add new behavior only when the earlier options cannot satisfy the invariant.
+        For an additive remedy, explain why deletion, consolidation, or reuse is insufficient and identify any new state, branch, configuration, public surface, authority, or test-maintenance burden it introduces.
+        Carry resolved and dismissed decisions into incremental reviews; reopen them only when new code or concrete evidence changes the risk.
         Flag concrete cases where code can be deleted or simplified.
         Flag tests that duplicate existing coverage, assert implementation details, or do not protect observable behavior.
         Do not suggest speculative refactors or alternatives without a concrete correctness or maintenance benefit.
@@ -29,6 +38,11 @@ reviews:
     3. Whether it is the smallest coherent solution and any added complexity is necessary.
     4. What code or tests, if any, can be deleted or simplified without weakening behavior or regression coverage.
     5. The concrete risks and validation performed.
+
+    Include a section named "Complexity delta":
+    - State what authorities, states, branches, configuration, public surface, and test-maintenance burden the PR adds and removes.
+    - Conclude whether total maintenance complexity decreases, stays justified, or increases without enough evidence.
+    - Treat optional and follow-up findings as non-blocking; they are not implementation requests for the current PR.
 
     End with a section named "Review-relevant risks":
     - Identify, with concrete evidence from the current diff, any apparent effect on user-visible behavior, public contracts, security, licensing, releases, or governance.
@@ -64,4 +78,5 @@ reviews:
 
   auto_review:
     enabled: true
+    auto_incremental_review: true
     drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,7 @@ reviews:
         Review the diff adversarially against the problem it claims to solve.
         Determine whether it is the smallest coherent solution at the existing source of truth.
         Treat the reported problem and the proposed remedy as separate decisions.
-        Report only concrete, reproducible correctness or maintenance risks, and give each finding one disposition:
+        Report only concrete, reproducible risks, and give each finding one disposition:
         - fix-now: the current PR violates its stated behavior or an existing invariant;
         - follow-up: the risk is real but pre-existing or outside the PR's goal;
         - optional: the change would be an improvement but is not required for correctness or coherence.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,10 @@
+[review_agent]
+comments_location_policy = "both"
+inline_comments_severity_threshold = 3
+issues_user_guidelines = """
+Review all changed code and report concrete, reproducible correctness, security, contract, or maintenance risks. Separate the issue from its remedy. Give each finding one disposition: fix-now when this PR violates stated behavior or an existing invariant; follow-up when the risk is real but pre-existing or outside the PR goal; optional when it is an improvement rather than a correctness or coherence requirement.
+
+Choose remedies in this order: delete an unnecessary path; consolidate duplicated authority; reuse the closest existing seam; make the smallest local correction; add new behavior only when the earlier options cannot satisfy the invariant. For any additive recommendation, explain why deletion, consolidation, or reuse is insufficient and identify the new state, branch, configuration, public surface, authority, or test-maintenance burden introduced.
+
+Carry resolved and dismissed decisions into later review runs. Reopen them only when new code or concrete evidence changes the risk. Present follow-up and optional findings as non-blocking, not as implementation requests for the current PR.
+"""


### PR DESCRIPTION
## Summary

- version the same deletion-first review policy for CodeRabbit and Qodo
- separate concrete findings from their proposed remedies and classify them as fix-now, follow-up, or optional
- require additive remedies to justify why deletion, consolidation, or reuse is insufficient
- keep automatic incremental reviews enabled while routing only Qodo action-required findings inline

## Qodo operational settings

The Qodo Portal remains the authority for controls that are not reliably repository-scoped:

- Review every push: enabled
- High findings: inline and summary
- Medium and Low findings: summary only
- Suggest committable fixes: disabled

The repository-level `.pr_agent.toml` becomes effective for new PRs after merge and owns the Qodo review guidance and inline severity threshold.

## Verification

- `git diff --check`
- parsed `.coderabbit.yaml` with Ruby YAML
- parsed `.pr_agent.toml` with Python `tomllib`
- confirmed the configured fields against the current CodeRabbit and Qodo documentation
- reloaded Qodo Portal and verified the saved workflow, routing, remediation, and prompt values
- product tests were not run because this changes review configuration only

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex researched the supported review controls and authored the CodeRabbit and Qodo review guidance in this PR. Both commits include the required `Generated-by: Codex` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

## Review focus

Please verify that both tools preserve full review coverage while making deletion, consolidation, and reuse the default remediation order. The human contributor owns the final diff, configuration policy, and merge decision.