### PR TITLE
fix(desktop): indent project session rows

### DIFF
--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -34,6 +34,8 @@ test('project navigation and actions remain adjacent keyboard controls', async (
   const controlledGroup = page.locator(`[id="${controlledGroupId}"]`);
   const firstSessionControl = controlledGroup.locator('[data-session-id] button').first();
 
+  await expect(navigation).toBeVisible();
+  await expect(firstSessionControl).toBeVisible();
   const [projectNavigationBox, firstSessionBox] = await Promise.all([
     navigation.boundingBox(),
     firstSessionControl.boundingBox(),

--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -34,6 +34,14 @@ test('project navigation and actions remain adjacent keyboard controls', async (
   const controlledGroup = page.locator(`[id="${controlledGroupId}"]`);
   const firstSessionControl = controlledGroup.locator('[data-session-id] button').first();
 
+  const [projectNavigationBox, firstSessionBox] = await Promise.all([
+    navigation.boundingBox(),
+    firstSessionControl.boundingBox(),
+  ]);
+  expect(projectNavigationBox).not.toBeNull();
+  expect(firstSessionBox).not.toBeNull();
+  expect(firstSessionBox!.x - projectNavigationBox!.x).toBeGreaterThanOrEqual(20);
+
   await expect(projectRow.locator('button button')).toHaveCount(0);
   await expect(navigation).toHaveAttribute('aria-expanded', 'true');
 

--- a/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+const sidebarCssUrl = [
+  new URL('../../renderer/styles/sidebar.css', import.meta.url),
+  new URL('../../../src/renderer/styles/sidebar.css', import.meta.url),
+].find((candidate) => existsSync(candidate));
+
+if (!sidebarCssUrl) throw new Error('Could not locate renderer/styles/sidebar.css');
+
+const sidebarCss = readFileSync(sidebarCssUrl, 'utf8');
+
+describe('project-grouped session hierarchy', () => {
+  it('visually indents session rows beneath their project', () => {
+    const projectChildrenRule = sidebarCss.match(
+      /\.maka-project-row\s*>\s*div\s*>\s*\[role=["']group["']\]\s*>\s*div\s*\{([^}]*)\}/,
+    );
+
+    assert.ok(projectChildrenRule, 'project children must have an explicit hierarchy rule');
+    assert.match(
+      projectChildrenRule[1] ?? '',
+      /padding-inline-start:\s*var\(--spacing-6\)\s*!important;/,
+      'project sessions must keep one SideNav nesting step (24px)',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -226,17 +226,18 @@
 }
 
 /*
- * Project groups are a section label + peer sessions, not a deep tree.
- * Astryx SideNavItem always pads children with spacing-6 (24px); that is the
- * shell-side-nav workspace pattern, but it wastes a full icon column in a
- * narrow session rail. Zero only the project item's own nest so sessions share
- * the time-sort left edge. Child combinator only — do not use a descendant
- * selector that would punch deeper nest levels if any appear later.
+ * Project groups are a real parent-child hierarchy. Keep Astryx's standard
+ * SideNav nesting step (spacing-6 / 24px) so session rows visibly belong to
+ * the project above them instead of sharing the project's left edge. Pin the
+ * value here because StyleX owns the unlayered default and this relationship
+ * is part of the task rail's visual contract. Child combinator only — do not
+ * use a descendant selector that would indent deeper nest levels twice if any
+ * appear later.
  * DOM: .maka-project-row > SideNavItem root > [role=group] > childrenInner
  */
 .maka-project-row > div > [role="group"] > div {
   /* !important: StyleX childrenInner paddingInlineStart is unlayered. */
-  padding-inline-start: 0 !important;
+  padding-inline-start: var(--spacing-6) !important;
 }
 
 .maka-session-row-end,

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -345,7 +345,7 @@ function ProjectNavRow(props: {
           />
         }
       >
-        {/* Nest indent zeroed one level in sidebar.css (time-sort left edge). */}
+        {/* sidebar.css preserves one SideNav nesting step for project hierarchy. */}
         {hasSessions ? (
           <VStack gap={0.5}>{props.sessions.map((session) => props.renderSession(session))}</VStack>
         ) : undefined}


### PR DESCRIPTION
## Summary

Restore the standard `spacing-6` (24px) SideNav nesting step for sessions rendered under a project. The CSS contract test pins the hierarchy, and the Electron test verifies the visible indentation after waiting for both measured controls to become visible.

## Verification

- `npx biome check apps/desktop/src/renderer/styles/sidebar.css packages/ui/src/session-history-list.tsx apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts apps/desktop/e2e/sidebar-project-row.spec.ts` — passed
- `node --test apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts` — 1 passed
- `npx playwright test --config e2e/playwright.config.ts e2e/sidebar-project-row.spec.ts` — 3 passed
- Desktop build and focused compiled contract tests passed before review

## Review focus

The implementation restores the existing design-system spacing token rather than introducing a new value. The geometry assertion waits for the project and first-session controls to be visible before reading `boundingBox()`, addressing the review reliability concern.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex audited the sidebar hierarchy, implemented and tested the CSS/E2E fix, incorporated review feedback, and drafted this description. The human contributor reviewed the work, chose to submit it, and remains responsible for its accuracy, provenance, and licensing.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
