### PR TITLE
test(desktop): fence active turn state in streaming-remount e2e

### DIFF
--- a/apps/desktop/e2e/streaming-remount.spec.ts
+++ b/apps/desktop/e2e/streaming-remount.spec.ts
@@ -124,14 +124,21 @@ test('keeps a completed reply after an interrupted turn and conversation remount
     ), originalSessionId!),
     { timeout: 20_000 },
   ).toBe(0);
-  await composer.fill(FAKE_WAIT_FOR_STEERING_LARGE_RESPONSE_PROMPT);
   await expect(page.getByRole('button', { name: '发送' })).toBeEnabled({
     timeout: 20_000,
   });
+  await composer.fill(FAKE_WAIT_FOR_STEERING_LARGE_RESPONSE_PROMPT);
   await composer.press('Enter');
   await expect(page.locator('.maka-user-message', {
     hasText: FAKE_WAIT_FOR_STEERING_LARGE_RESPONSE_PROMPT,
   })).toBeVisible();
+  await expect.poll(
+    () => page.evaluate(async (sessionId) => (
+      (await window.maka.sessions.list()).find((session) => session.id === sessionId)
+        ?.runningTurnIds?.length ?? 0
+    ), originalSessionId!),
+    { timeout: 20_000 },
+  ).toBeGreaterThan(0);
   await expect(page.getByRole('button', { name: '停止' })).toBeVisible({
     timeout: 20_000,
   });


### PR DESCRIPTION
### What changed
- Re-ordered composer readiness check (`getByRole('button', { name: '发送' }).toBeEnabled()`) to precede `composer.fill(...)` in `apps/desktop/e2e/streaming-remount.spec.ts` so React state transitions after an interrupted turn settle before filling text.
- Added an `expect.poll` fence verifying `runningTurnIds.length > 0` on the session before expecting the Stop button to be rendered, ensuring active Turn state is fenced in durable session state.

Addresses #3177

---
Generated from a bounded immutable repository snapshot by PARS-Agent using Gemini 3.6 Flash. Tests listed above are recommendations unless GitHub checks report otherwise.
