### PR TITLE
fix(runtime-host): gate Windows Local Owner authority

### DIFF
--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Build test artifacts
         run: npm.cmd run build:test
 
+      - name: Verify Runtime Host Local IPC trust boundary
+        shell: pwsh
+        run: ./scripts/windows-runtime-host-local-ipc-trust.ps1
+
       - name: Verify SQLite crash recovery
         shell: pwsh
         run: |

--- a/docs/architecture/runtime-host-architecture.md
+++ b/docs/architecture/runtime-host-architecture.md
@@ -283,6 +283,7 @@ Runtime Host does not promise that an arbitrary external side effect happens exa
 
 - Protocol messages use closed schemas that reject unknown fields, explicit size and count limits, and stable error codes.
 - Authentication completes before protocol connection admission.
+- Local IPC grants Local Owner authority only after its OS endpoint establishes a same-user trust boundary.
 - Authentication fixes the principal, allowed operations, and path or capability access for the lifetime of a connection.
 - Client Capability offers and reverse calls remain authenticated, size-limited, and tied to that connection.
 - Adding a protocol operation does not expand an existing credential grant.

--- a/docs/architecture/runtime-host-architecture.zh-CN.md
+++ b/docs/architecture/runtime-host-architecture.zh-CN.md
@@ -283,6 +283,7 @@ Runtime Host 不保证任意 external side effect 恰好发生一次。如果 co
 
 - Protocol message 使用拒绝未知字段的 closed schema、明确的大小与数量限制，以及稳定的 error code。
 - Authentication 在 protocol connection admission 前完成。
+- Local IPC 只有在操作系统 endpoint 建立 same-user 信任边界后，才能授予 Local Owner authority。
 - Authentication 会在 connection 的整个生命周期内固定 principal、允许的 operations，以及 path 或 capability access。
 - Client Capability offers 与 reverse calls 必须经过认证、带大小限制，并绑定到该 connection。
 - 新增 protocol operation 不会扩张既有 credential grant。

--- a/packages/runtime-host/src/__tests__/fixtures/windows-local-ipc-trust-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/windows-local-ipc-trust-host.ts
@@ -1,0 +1,27 @@
+import { once } from 'node:events';
+import { startLocalIpcRuntimeHostListener } from '../../server/local-ipc-listener.js';
+
+if (process.platform !== 'win32') {
+  throw new Error('Windows Local IPC trust fixture must run on Windows');
+}
+
+const listener = await startLocalIpcRuntimeHostListener({
+  rootId: 'ab'.repeat(32),
+  hostEpoch: `trust-${process.pid}`,
+  accept(connection) {
+    process.stdout.write(
+      `${JSON.stringify({
+        type: 'accepted',
+        principalKind: connection.authority.principalKind,
+      })}\n`,
+    );
+    connection.transport.abort();
+  },
+});
+
+process.stdout.write(`${JSON.stringify({ type: 'ready', endpoint: listener.endpoint })}\n`);
+process.stdin.resume();
+await once(process.stdin, 'data');
+process.stdin.pause();
+await listener.closeAdmission();
+await listener.cleanup();

--- a/packages/runtime-host/src/control/endpoint.ts
+++ b/packages/runtime-host/src/control/endpoint.ts
@@ -36,7 +36,10 @@ export async function prepareRuntimeHostEndpoint(
     const path = `\\\\.\\pipe\\maka-runtime-host-${input.rootId.slice(0, 16)}-${input.hostEpoch}`;
     return {
       path,
-      async prepareAfterListen() {},
+      async prepareAfterListen() {
+        // Node creates the pipe with the process token's default DACL. The
+        // blocking cross-user CI pins that a foreign user cannot open it duplex.
+      },
       async cleanup() {},
     };
   }

--- a/packages/runtime-host/src/server/local-ipc-listener.ts
+++ b/packages/runtime-host/src/server/local-ipc-listener.ts
@@ -19,22 +19,29 @@ export async function startLocalIpcRuntimeHostListener(
   });
   const startupTransports = new Set<FramedTransport>();
   let starting = true;
-  const server = createServer({ allowHalfOpen: true }, (socket) => {
-    const transport = new FramedTransport(socket);
-    if (starting) {
-      startupTransports.add(transport);
-      void transport.closed.then(() => startupTransports.delete(transport));
-    }
+  const acceptTransport = (transport: FramedTransport) => {
     try {
       options.accept({ transport, authority: LOCAL_OWNER_CONNECTION_AUTHORITY });
     } catch (error) {
       transport.abort(asError(error));
     }
+  };
+  const server = createServer({ allowHalfOpen: true }, (socket) => {
+    const transport = new FramedTransport(socket);
+    if (starting) {
+      startupTransports.add(transport);
+      void transport.closed.then(() => startupTransports.delete(transport));
+      return;
+    }
+    acceptTransport(transport);
   });
   try {
     await listen(server, endpoint.path);
     await endpoint.prepareAfterListen();
     starting = false;
+    // A connection opened before the endpoint trust boundary was verified
+    // must not inherit Local Owner authority after verification completes.
+    for (const transport of startupTransports) transport.abort();
     startupTransports.clear();
     return new LocalIpcRuntimeHostListener(server, endpoint);
   } catch (error) {

--- a/scripts/windows-runtime-host-local-ipc-trust.ps1
+++ b/scripts/windows-runtime-host-local-ipc-trust.ps1
@@ -1,0 +1,188 @@
+$ErrorActionPreference = 'Stop'
+
+if ($env:OS -ne 'Windows_NT') {
+  throw 'Windows Runtime Host Local IPC trust verification must run on Windows'
+}
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$fixturePath = Join-Path $repositoryRoot 'packages/runtime-host/dist/__tests__/fixtures/windows-local-ipc-trust-host.js'
+if (-not (Test-Path $fixturePath)) {
+  throw "Missing Runtime Host trust fixture: $fixturePath"
+}
+
+Add-Type -TypeDefinition @'
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Security.Principal;
+using Microsoft.Win32.SafeHandles;
+
+public static class MakaWindowsPipeTrustProbe
+{
+    [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+    private static extern bool LogonUser(
+        string username,
+        string domain,
+        string password,
+        int logonType,
+        int logonProvider,
+        out SafeAccessTokenHandle token);
+
+    public static string TryOpenAsUser(
+        string username,
+        string domain,
+        string password,
+        string pipeName)
+    {
+        SafeAccessTokenHandle token;
+        if (!LogonUser(username, domain, password, 2, 0, out token))
+        {
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "LogonUser failed");
+        }
+
+        using (token)
+        {
+            return WindowsIdentity.RunImpersonated(token, () => TryOpen(pipeName));
+        }
+    }
+
+    private static string TryOpen(string pipeName)
+    {
+        try
+        {
+            using (var client = new NamedPipeClientStream(
+                ".",
+                pipeName,
+                PipeDirection.InOut,
+                PipeOptions.None,
+                TokenImpersonationLevel.Identification))
+            {
+                client.Connect(3000);
+                return "connected";
+            }
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return "access_denied";
+        }
+        catch (IOException error)
+        {
+            var win32Code = error.HResult & 0xffff;
+            return win32Code == 5 ? "access_denied" : "io_error:" + win32Code;
+        }
+        catch (TimeoutException)
+        {
+            return "timeout";
+        }
+    }
+}
+'@
+
+function Read-ProcessLine {
+  param(
+    [Parameter(Mandatory = $true)]
+    [System.Diagnostics.Process]$Process,
+    [Parameter(Mandatory = $true)]
+    [int]$TimeoutMilliseconds
+  )
+
+  $readTask = $Process.StandardOutput.ReadLineAsync()
+  if (-not $readTask.Wait($TimeoutMilliseconds)) {
+    throw "Timed out waiting for Runtime Host trust fixture output"
+  }
+  $line = $readTask.Result
+  if ($null -eq $line) {
+    $stderr = $Process.StandardError.ReadToEnd()
+    throw "Runtime Host trust fixture exited before producing output: $stderr"
+  }
+  return $line
+}
+
+$userName = "MakaIpc$(([Guid]::NewGuid().ToString('N')).Substring(0, 8))"
+$password = "Maka-Ipc!$([Guid]::NewGuid().ToString('N'))aA1"
+$securePassword = ConvertTo-SecureString $password -AsPlainText -Force
+$fixture = $null
+$createdUser = $false
+
+try {
+  New-LocalUser `
+    -Name $userName `
+    -Password $securePassword `
+    -AccountNeverExpires `
+    -PasswordNeverExpires | Out-Null
+  $createdUser = $true
+
+  $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+  $startInfo.FileName = (Get-Command node.exe).Source
+  $startInfo.ArgumentList.Add($fixturePath)
+  $startInfo.WorkingDirectory = $repositoryRoot
+  $startInfo.UseShellExecute = $false
+  $startInfo.RedirectStandardInput = $true
+  $startInfo.RedirectStandardOutput = $true
+  $startInfo.RedirectStandardError = $true
+  $startInfo.CreateNoWindow = $true
+
+  $fixture = [System.Diagnostics.Process]::new()
+  $fixture.StartInfo = $startInfo
+  if (-not $fixture.Start()) {
+    throw 'Unable to start Runtime Host trust fixture'
+  }
+
+  $ready = Read-ProcessLine -Process $fixture -TimeoutMilliseconds 10000 | ConvertFrom-Json
+  if ($ready.type -ne 'ready' -or $ready.endpoint -notmatch '^\\\\\.\\pipe\\(.+)$') {
+    throw "Invalid Runtime Host trust fixture readiness: $($ready | ConvertTo-Json -Compress)"
+  }
+  $pipeName = $Matches[1]
+
+  $currentUserClient = [System.IO.Pipes.NamedPipeClientStream]::new(
+    '.',
+    $pipeName,
+    [System.IO.Pipes.PipeDirection]::InOut,
+    [System.IO.Pipes.PipeOptions]::None,
+    [System.Security.Principal.TokenImpersonationLevel]::Identification
+  )
+  try {
+    $currentUserClient.Connect(5000)
+  } finally {
+    $currentUserClient.Dispose()
+  }
+
+  $accepted = Read-ProcessLine -Process $fixture -TimeoutMilliseconds 5000 | ConvertFrom-Json
+  if ($accepted.type -ne 'accepted' -or $accepted.principalKind -ne 'local_owner') {
+    throw "Current-user connection did not receive Local Owner authority"
+  }
+
+  $foreignResult = [MakaWindowsPipeTrustProbe]::TryOpenAsUser(
+    $userName,
+    $env:COMPUTERNAME,
+    $password,
+    $pipeName
+  )
+  if ($foreignResult -ne 'access_denied') {
+    throw "Foreign Windows user unexpectedly reached the Local IPC listener: $foreignResult"
+  }
+
+  Write-Output 'Runtime Host Windows Local IPC admitted the current user and denied a foreign user.'
+} finally {
+  if ($null -ne $fixture) {
+    if (-not $fixture.HasExited) {
+      $fixture.StandardInput.WriteLine('close')
+      $fixture.StandardInput.Flush()
+      if (-not $fixture.WaitForExit(5000)) {
+        $fixture.Kill($true)
+        $fixture.WaitForExit()
+      }
+    }
+    if ($fixture.ExitCode -ne 0) {
+      $stderr = $fixture.StandardError.ReadToEnd()
+      Write-Warning "Runtime Host trust fixture exited with $($fixture.ExitCode): $stderr"
+    }
+    $fixture.Dispose()
+  }
+  if ($createdUser) {
+    Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
+  }
+}
+


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Local IPC no longer grants Local Owner authority to connections opened before the endpoint trust boundary is established. Runtime Host changes now also run a blocking Windows check that admits the current user and attempts the same duplex named-pipe connection under a separate standard-user token.

The real Windows check confirms that the platform boundary denies a foreign standard user, so no native helper or additional authentication state is required.

</details>

<details>
<summary>简体中文</summary>

Local IPC 不再向 endpoint 信任边界建立前打开的连接授予 Local Owner authority。Runtime Host 变更现在还会运行 blocking Windows 检查：确认当前用户可以连接，并使用独立标准用户 token 尝试相同的双向 named-pipe 连接。

真实 Windows 检查已确认平台边界会拒绝其他标准用户，因此不需要 native helper 或额外认证状态。

</details>

Refs #2522

## Verification

<details open>
<summary>English</summary>

- `npm run build:test`
- `npm --workspace @maka/runtime-host run typecheck`
- `npm --workspace @maka/runtime-host run test:dist` — 962 passed
- Biome check and `git diff --check`
- [Windows cross-user admission](https://github.com/maka-agent/maka-agent/actions/runs/32090917105/job/95572743352) — passed

</details>

<details>
<summary>简体中文</summary>

- `npm run build:test`
- `npm --workspace @maka/runtime-host run typecheck`
- `npm --workspace @maka/runtime-host run test:dist` — 962 passed
- Biome check 与 `git diff --check`
- [Windows 跨用户 admission](https://github.com/maka-agent/maka-agent/actions/runs/32090917105/job/95572743352) — passed

</details>

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the listener gate, Windows trust harness, CI wiring, and concise architecture updates under maintainer direction.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No



