### PR TITLE
fix(runtime-host): restrict Windows Local IPC ACL

### DIFF
--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -35,7 +35,9 @@ jobs:
 
       - name: Verify Runtime Host Local IPC trust boundary
         shell: pwsh
-        run: ./scripts/windows-runtime-host-local-ipc-trust.ps1
+        run: |
+          node.exe --test packages/runtime-host/dist/__tests__/control-endpoint.test.js
+          ./scripts/windows-runtime-host-local-ipc-trust.ps1
 
       - name: Verify SQLite crash recovery
         shell: pwsh

--- a/packages/runtime-host/src/__tests__/control-endpoint.test.ts
+++ b/packages/runtime-host/src/__tests__/control-endpoint.test.ts
@@ -22,10 +22,9 @@ function legacyPrefix(): string {
 }
 
 describe('runtime host Windows named-pipe endpoint', { skip: process.platform !== 'win32' }, () => {
-  test('derives a stable pipe name and has idempotent lifecycle hooks', async () => {
+  test('derives a stable pipe name and has idempotent cleanup', async () => {
     const endpoint = await prepareRuntimeHostEndpoint({ rootId: ROOT_ID, hostEpoch: 'epoch-1' });
     assert.equal(endpoint.path, `\\\\.\\pipe\\maka-runtime-host-${ROOT_ID.slice(0, 16)}-epoch-1`);
-    await endpoint.prepareAfterListen();
     await endpoint.cleanup();
     await endpoint.cleanup();
   });

--- a/packages/runtime-host/src/__tests__/fixtures/windows-local-ipc-trust-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/windows-local-ipc-trust-host.ts
@@ -1,21 +1,24 @@
 import { once } from 'node:events';
 import { startLocalIpcRuntimeHostListener } from '../../server/local-ipc-listener.js';
+import type { RuntimeHostMessageTransport } from '../../transport/message-transport.js';
 
 if (process.platform !== 'win32') {
   throw new Error('Windows Local IPC trust fixture must run on Windows');
 }
 
+const transports = new Set<RuntimeHostMessageTransport>();
 const listener = await startLocalIpcRuntimeHostListener({
   rootId: 'ab'.repeat(32),
   hostEpoch: `trust-${process.pid}`,
   accept(connection) {
+    transports.add(connection.transport);
+    void connection.transport.closed.then(() => transports.delete(connection.transport));
     process.stdout.write(
       `${JSON.stringify({
         type: 'accepted',
         principalKind: connection.authority.principalKind,
       })}\n`,
     );
-    connection.transport.abort();
   },
 });
 
@@ -23,5 +26,11 @@ process.stdout.write(`${JSON.stringify({ type: 'ready', endpoint: listener.endpo
 process.stdin.resume();
 await once(process.stdin, 'data');
 process.stdin.pause();
+await Promise.all(
+  [...transports].map((transport) => {
+    transport.abort();
+    return transport.closed;
+  }),
+);
 await listener.closeAdmission();
 await listener.cleanup();

--- a/packages/runtime-host/src/control/endpoint.ts
+++ b/packages/runtime-host/src/control/endpoint.ts
@@ -1,3 +1,4 @@
+import { execFile } from 'node:child_process';
 import { chmod, lstat, mkdtemp, readdir, rm, rmdir, unlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,6 +7,20 @@ const FALLBACK_ENDPOINT_ROOT = '/tmp';
 const PORTABLE_UNIX_SOCKET_PATH_LIMIT = 100;
 const ENDPOINT_SOCKET_NAME = 'h.sock';
 const MKDTEMP_SUFFIX_LENGTH = 6;
+const WINDOWS_PIPE_PATH_ENV = 'MAKA_RUNTIME_HOST_PIPE_PATH';
+const WINDOWS_PIPE_ACL_SCRIPT = String.raw`
+$ErrorActionPreference = 'Stop'
+$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$security = [System.Security.AccessControl.FileSecurity]::new()
+$security.SetAccessRuleProtection($true, $false)
+$rights = [System.Security.AccessControl.FileSystemRights]::FullControl
+$allow = [System.Security.AccessControl.AccessControlType]::Allow
+$security.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($identity.User, $rights, $allow))
+$system = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18')
+$security.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($system, $rights, $allow))
+$pipe = Get-Item -LiteralPath $env:${WINDOWS_PIPE_PATH_ENV}
+$pipe.SetAccessControl($security)
+`;
 
 export interface RuntimeHostEndpointInput {
   rootId: string;
@@ -37,8 +52,7 @@ export async function prepareRuntimeHostEndpoint(
     return {
       path,
       async prepareAfterListen() {
-        // Node creates the pipe with the process token's default DACL. The
-        // blocking cross-user CI pins that a foreign user cannot open it duplex.
+        await secureWindowsNamedPipe(path);
       },
       async cleanup() {},
     };
@@ -87,6 +101,42 @@ export async function prepareRuntimeHostEndpoint(
     await rm(directory, { recursive: true, force: true }).catch(() => undefined);
     throw error;
   }
+}
+
+function secureWindowsNamedPipe(path: string): Promise<void> {
+  const systemRoot = process.env.SystemRoot;
+  if (!systemRoot) {
+    return Promise.reject(
+      new RuntimeHostEndpointError(
+        'insecure_endpoint_directory',
+        'Runtime Host cannot locate Windows PowerShell to secure its Local IPC endpoint',
+      ),
+    );
+  }
+  const powershell = join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe');
+  return new Promise((resolve, reject) => {
+    execFile(
+      powershell,
+      ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', WINDOWS_PIPE_ACL_SCRIPT],
+      {
+        env: { ...process.env, [WINDOWS_PIPE_PATH_ENV]: path },
+        timeout: 10_000,
+        windowsHide: true,
+      },
+      (error) => {
+        if (!error) {
+          resolve();
+          return;
+        }
+        reject(
+          new RuntimeHostEndpointError(
+            'insecure_endpoint_directory',
+            'Runtime Host could not restrict its Windows Local IPC endpoint to the current user',
+          ),
+        );
+      },
+    );
+  });
 }
 
 // Honor TMPDIR via os.tmpdir(), but never at the cost of a socket path over

--- a/scripts/windows-runtime-host-local-ipc-trust.ps1
+++ b/scripts/windows-runtime-host-local-ipc-trust.ps1
@@ -34,7 +34,8 @@ public static class MakaWindowsPipeTrustProbe
         string username,
         string domain,
         string password,
-        string pipeName)
+        string pipeName,
+        PipeDirection direction)
     {
         SafeAccessTokenHandle token;
         if (!LogonUser(username, domain, password, 2, 0, out token))
@@ -44,18 +45,18 @@ public static class MakaWindowsPipeTrustProbe
 
         using (token)
         {
-            return WindowsIdentity.RunImpersonated(token, () => TryOpen(pipeName));
+            return WindowsIdentity.RunImpersonated(token, () => TryOpen(pipeName, direction));
         }
     }
 
-    private static string TryOpen(string pipeName)
+    private static string TryOpen(string pipeName, PipeDirection direction)
     {
         try
         {
             using (var client = new NamedPipeClientStream(
                 ".",
                 pipeName,
-                PipeDirection.InOut,
+                direction,
                 PipeOptions.None,
                 TokenImpersonationLevel.Identification))
             {
@@ -104,6 +105,7 @@ $userName = "MakaIpc$(([Guid]::NewGuid().ToString('N')).Substring(0, 8))"
 $password = "Maka-Ipc!$([Guid]::NewGuid().ToString('N'))aA1"
 $securePassword = ConvertTo-SecureString $password -AsPlainText -Force
 $fixture = $null
+$currentUserClients = @()
 $createdUser = $false
 
 try {
@@ -124,11 +126,17 @@ try {
   $startInfo.RedirectStandardError = $true
   $startInfo.CreateNoWindow = $true
 
-  $fixture = [System.Diagnostics.Process]::new()
-  $fixture.StartInfo = $startInfo
-  if (-not $fixture.Start()) {
-    throw 'Unable to start Runtime Host trust fixture'
+  $candidateFixture = [System.Diagnostics.Process]::new()
+  $candidateFixture.StartInfo = $startInfo
+  try {
+    if (-not $candidateFixture.Start()) {
+      throw 'Unable to start Runtime Host trust fixture'
+    }
+  } catch {
+    $candidateFixture.Dispose()
+    throw
   }
+  $fixture = $candidateFixture
 
   $ready = Read-ProcessLine -Process $fixture -TimeoutMilliseconds 10000 | ConvertFrom-Json
   if ($ready.type -ne 'ready' -or $ready.endpoint -notmatch '^\\\\\.\\pipe\\(.+)$') {
@@ -136,53 +144,79 @@ try {
   }
   $pipeName = $Matches[1]
 
-  $currentUserClient = [System.IO.Pipes.NamedPipeClientStream]::new(
-    '.',
-    $pipeName,
-    [System.IO.Pipes.PipeDirection]::InOut,
-    [System.IO.Pipes.PipeOptions]::None,
-    [System.Security.Principal.TokenImpersonationLevel]::Identification
-  )
-  try {
-    $currentUserClient.Connect(5000)
-  } finally {
-    $currentUserClient.Dispose()
+  # Keep enough owner connections open to consume libuv's initial pending pipe
+  # instances and force replacement instances before probing the foreign user.
+  for ($index = 0; $index -lt 8; $index += 1) {
+    $currentUserClient = [System.IO.Pipes.NamedPipeClientStream]::new(
+      '.',
+      $pipeName,
+      [System.IO.Pipes.PipeDirection]::InOut,
+      [System.IO.Pipes.PipeOptions]::None,
+      [System.Security.Principal.TokenImpersonationLevel]::Identification
+    )
+    try {
+      $currentUserClient.Connect(5000)
+      $currentUserClients += $currentUserClient
+    } catch {
+      $currentUserClient.Dispose()
+      throw
+    }
+
+    $accepted = Read-ProcessLine -Process $fixture -TimeoutMilliseconds 5000 | ConvertFrom-Json
+    if ($accepted.type -ne 'accepted' -or $accepted.principalKind -ne 'local_owner') {
+      throw "Current-user connection did not receive Local Owner authority"
+    }
   }
 
-  $accepted = Read-ProcessLine -Process $fixture -TimeoutMilliseconds 5000 | ConvertFrom-Json
-  if ($accepted.type -ne 'accepted' -or $accepted.principalKind -ne 'local_owner') {
-    throw "Current-user connection did not receive Local Owner authority"
-  }
-
-  $foreignResult = [MakaWindowsPipeTrustProbe]::TryOpenAsUser(
-    $userName,
-    $env:COMPUTERNAME,
-    $password,
-    $pipeName
-  )
-  if ($foreignResult -ne 'access_denied') {
-    throw "Foreign Windows user unexpectedly reached the Local IPC listener: $foreignResult"
+  foreach ($direction in @(
+    [System.IO.Pipes.PipeDirection]::In,
+    [System.IO.Pipes.PipeDirection]::Out,
+    [System.IO.Pipes.PipeDirection]::InOut
+  )) {
+    $foreignResult = [MakaWindowsPipeTrustProbe]::TryOpenAsUser(
+      $userName,
+      $env:COMPUTERNAME,
+      $password,
+      $pipeName,
+      $direction
+    )
+    if ($foreignResult -ne 'access_denied') {
+      throw "Foreign Windows user unexpectedly opened the Local IPC listener ($direction): $foreignResult"
+    }
   }
 
   Write-Output 'Runtime Host Windows Local IPC admitted the current user and denied a foreign user.'
 } finally {
-  if ($null -ne $fixture) {
-    if (-not $fixture.HasExited) {
-      $fixture.StandardInput.WriteLine('close')
-      $fixture.StandardInput.Flush()
-      if (-not $fixture.WaitForExit(5000)) {
-        $fixture.Kill($true)
-        $fixture.WaitForExit()
+  try {
+    try {
+      foreach ($client in $currentUserClients) {
+        $client.Dispose()
+      }
+    } finally {
+      if ($null -ne $fixture) {
+        if (-not $fixture.HasExited) {
+          $fixture.StandardInput.WriteLine('close')
+          $fixture.StandardInput.Flush()
+          if (-not $fixture.WaitForExit(5000)) {
+            $fixture.Kill($true)
+            $fixture.WaitForExit()
+          }
+        }
+        if ($fixture.ExitCode -ne 0) {
+          $stderr = $fixture.StandardError.ReadToEnd()
+          throw "Runtime Host trust fixture exited with $($fixture.ExitCode): $stderr"
+        }
       }
     }
-    if ($fixture.ExitCode -ne 0) {
-      $stderr = $fixture.StandardError.ReadToEnd()
-      Write-Warning "Runtime Host trust fixture exited with $($fixture.ExitCode): $stderr"
+  } finally {
+    try {
+      if ($null -ne $fixture) {
+        $fixture.Dispose()
+      }
+    } finally {
+      if ($createdUser) {
+        Remove-LocalUser -Name $userName -ErrorAction Stop
+      }
     }
-    $fixture.Dispose()
-  }
-  if ($createdUser) {
-    Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
   }
 }
-


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Windows Local IPC now applies a protected DACL for the current user and SYSTEM before granting Local Owner authority. After forcing replacement pipe instances, the Windows trust check covers read-only, write-only, and duplex access from a separate standard user.

The test harness keeps temporary-account deletion independent from fixture startup and cleanup failures, and reports a deletion failure instead of silently leaving the account behind.

</details>

<details>
<summary>简体中文</summary>

Windows Local IPC 现在会在授予 Local Owner authority 前，为当前用户和 SYSTEM 设置受保护的 DACL。Windows 信任检查会先迫使 listener 创建 replacement pipe instances，再使用独立标准用户验证只读、只写和双向访问。

测试工具会独立执行临时账户删除，不受 fixture 启动或清理失败影响；账户删除失败也会被明确报告，不再静默遗留账户。

</details>

Follow-up to #3179

## Verification

<details open>
<summary>English</summary>

- `npm run build:test`
- `npm --workspace @maka/runtime-host run typecheck`
- `npm --workspace @maka/runtime-host run test:dist` — 962 passed
- Biome check and `git diff --check`
- [Real Windows cross-user verification](https://github.com/maka-agent/maka-agent/actions/runs/32093739119/job/95580956491) — passed

</details>

<details>
<summary>简体中文</summary>

- `npm run build:test`
- `npm --workspace @maka/runtime-host run typecheck`
- `npm --workspace @maka/runtime-host run test:dist` — 962 passed
- Biome check 与 `git diff --check`
- [真实 Windows 跨用户验证](https://github.com/maka-agent/maka-agent/actions/runs/32093739119/job/95580956491) — passed

</details>

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the Windows endpoint ACL and expanded trust harness under maintainer direction.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
