### PR TITLE
ci(cli): validate npm tarball across platforms

### DIFF
--- a/.github/workflows/cli-package-validation.yml
+++ b/.github/workflows/cli-package-validation.yml
@@ -1,0 +1,146 @@
+name: CLI package validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/cli-package-validation.yml'
+      - '.gitattributes'
+      - '.npmrc'
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'patches/**'
+      - 'packages/cli/**'
+      - 'packages/code-mode/**'
+      - 'packages/core/**'
+      - 'packages/eval/**'
+      - 'packages/mcp/**'
+      - 'packages/runtime/**'
+      - 'packages/runtime-host/**'
+      - 'packages/storage/**'
+      - 'scripts/apply-dependency-patches.mjs'
+      - 'scripts/clean-paths.mjs'
+      - 'scripts/generate-third-party-notices.mjs'
+      - 'scripts/install-electron-with-retry.mjs'
+      - 'scripts/npm-spawn.mjs'
+      - 'scripts/release-cli-*.mjs'
+      - 'scripts/smoke-release-cli-package.mjs'
+      - 'tsconfig*.json'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/cli-package-validation.yml'
+      - '.gitattributes'
+      - '.npmrc'
+      - 'LICENSE'
+      - 'NOTICE'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'patches/**'
+      - 'packages/cli/**'
+      - 'packages/code-mode/**'
+      - 'packages/core/**'
+      - 'packages/eval/**'
+      - 'packages/mcp/**'
+      - 'packages/runtime/**'
+      - 'packages/runtime-host/**'
+      - 'packages/storage/**'
+      - 'scripts/apply-dependency-patches.mjs'
+      - 'scripts/clean-paths.mjs'
+      - 'scripts/generate-third-party-notices.mjs'
+      - 'scripts/install-electron-with-retry.mjs'
+      - 'scripts/npm-spawn.mjs'
+      - 'scripts/release-cli-*.mjs'
+      - 'scripts/smoke-release-cli-package.mjs'
+      - 'tsconfig*.json'
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cli-package-validation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: Build immutable tarball
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.19.0'
+          cache: npm
+      - name: Select the release npm toolchain
+        run: npm install --global --no-audit --no-fund npm@11.12.1
+      - name: Build the release tarball once
+        run: npm run release:cli:pack
+      - name: Upload the immutable release candidate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cli-release-candidate
+          path: |
+            packages/cli/release/*.tgz
+            packages/cli/release/*.tgz.sha256
+            packages/cli/release/*.tgz.files.json
+          if-no-files-found: error
+          retention-days: 7
+
+  smoke:
+    name: Smoke ${{ matrix.name }}
+    needs: build
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Linux x64 / Node 22.19
+            runner: ubuntu-24.04
+            node: '22.19.0'
+            platform: linux
+            arch: x64
+          - name: Linux x64 / Node 24
+            runner: ubuntu-24.04
+            node: '24'
+            platform: linux
+            arch: x64
+          - name: macOS arm64 / Node 24
+            runner: macos-15
+            node: '24'
+            platform: darwin
+            arch: arm64
+          - name: Windows x64 / Node 24
+            runner: windows-2025
+            node: '24'
+            platform: win32
+            arch: x64
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Select the release npm toolchain
+        run: npm install --global --no-audit --no-fund npm@11.12.1
+      - name: Assert the runner architecture
+        env:
+          EXPECTED_PLATFORM: ${{ matrix.platform }}
+          EXPECTED_ARCH: ${{ matrix.arch }}
+        run: |
+          node -e "if (process.platform !== process.env.EXPECTED_PLATFORM || process.arch !== process.env.EXPECTED_ARCH) throw new Error('Expected ' + process.env.EXPECTED_PLATFORM + '/' + process.env.EXPECTED_ARCH + ', found ' + process.platform + '/' + process.arch)"
+      - name: Download the release candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: cli-release-candidate
+          path: packages/cli/release
+      - name: Smoke the installed tarball
+        run: node scripts/smoke-release-cli-package.mjs

--- a/.github/workflows/cli-package-validation.yml
+++ b/.github/workflows/cli-package-validation.yml
@@ -94,7 +94,7 @@ jobs:
           retention-days: 7
 
   smoke:
-    name: Smoke ${{ matrix.name }}
+    name: Validate installed CLI ${{ matrix.name }}
     needs: build
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 15
@@ -142,5 +142,5 @@ jobs:
         with:
           name: cli-release-candidate
           path: packages/cli/release
-      - name: Smoke the installed tarball
+      - name: Validate the installed tarball
         run: node scripts/smoke-release-cli-package.mjs

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "release:cli:smoke": "node scripts/smoke-release-cli-package.mjs",
     "generate:windows-cargo-notices": "node scripts/generate-windows-cargo-notices.mjs",
     "check:windows-cargo-notices": "node scripts/generate-windows-cargo-notices.mjs --check",
-    "check:release": "npm run check:stale && npm run check:third-party-notices && npm run check:cli-third-party-notices && node --test scripts/release-cli-file-policy.test.mjs",
+    "check:release": "npm run check:stale && npm run check:third-party-notices && npm run check:cli-third-party-notices && node --test scripts/release-cli-file-policy.test.mjs scripts/release-cli-artifact-policy.test.mjs",
     "package:macos-arm64": "node scripts/package-macos-arm64.mjs",
     "verify:macos-arm64": "node scripts/verify-macos-arm64-dmg.mjs",
     "package:windows-x64": "node scripts/package-windows-x64.mjs",

--- a/scripts/release-cli-artifact-policy.mjs
+++ b/scripts/release-cli-artifact-policy.mjs
@@ -1,0 +1,22 @@
+// The first installable proof tarball was 15,005,877 compressed bytes,
+// 77,684,229 unpacked bytes, and 7,511 entries. These ceilings preserve
+// deliberate headroom while making an accidental dependency/content spike a
+// reviewed release change instead of silently shipping it.
+export const CLI_RELEASE_ARTIFACT_LIMITS = Object.freeze({
+  compressedBytes: 18 * 1024 * 1024,
+  unpackedBytes: 90 * 1024 * 1024,
+  entryCount: 9_000,
+});
+
+export function validateCliReleaseArtifactMetrics(metrics) {
+  for (const key of ['compressedBytes', 'unpackedBytes', 'entryCount']) {
+    const value = metrics[key];
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`CLI release artifact ${key} must be a non-negative safe integer`);
+    }
+    const limit = CLI_RELEASE_ARTIFACT_LIMITS[key];
+    if (value > limit) {
+      throw new Error(`CLI release artifact ${key} is ${value}; limit is ${limit}`);
+    }
+  }
+}

--- a/scripts/release-cli-artifact-policy.test.mjs
+++ b/scripts/release-cli-artifact-policy.test.mjs
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  CLI_RELEASE_ARTIFACT_LIMITS,
+  validateCliReleaseArtifactMetrics,
+} from './release-cli-artifact-policy.mjs';
+
+describe('CLI release artifact policy', () => {
+  test('accepts the established proof-tarball baseline', () => {
+    assert.doesNotThrow(() =>
+      validateCliReleaseArtifactMetrics({
+        compressedBytes: 15_005_877,
+        unpackedBytes: 77_684_229,
+        entryCount: 7_511,
+      }),
+    );
+  });
+
+  test('rejects each metric above its reviewed ceiling', () => {
+    for (const key of Object.keys(CLI_RELEASE_ARTIFACT_LIMITS)) {
+      const metrics = {
+        ...CLI_RELEASE_ARTIFACT_LIMITS,
+        [key]: CLI_RELEASE_ARTIFACT_LIMITS[key] + 1,
+      };
+      assert.throws(() => validateCliReleaseArtifactMetrics(metrics), new RegExp(key));
+    }
+  });
+
+  test('rejects malformed metrics instead of coercing them', () => {
+    assert.throws(
+      () =>
+        validateCliReleaseArtifactMetrics({
+          compressedBytes: Number.NaN,
+          unpackedBytes: 1,
+          entryCount: 1,
+        }),
+      /compressedBytes/,
+    );
+  });
+});

--- a/scripts/release-cli-package.mjs
+++ b/scripts/release-cli-package.mjs
@@ -18,6 +18,7 @@ import {
 import { tmpdir } from 'node:os';
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { npmSpawnOptions } from './npm-spawn.mjs';
+import { validateCliReleaseArtifactMetrics } from './release-cli-artifact-policy.mjs';
 import {
   isMakaDevelopmentArtifact,
   isThirdPartyDevelopmentArtifact,
@@ -123,6 +124,11 @@ function main() {
   if (!pack?.filename || !Array.isArray(pack.files)) {
     throw new Error('npm pack did not return one JSON package result');
   }
+  validateCliReleaseArtifactMetrics({
+    compressedBytes: pack.size,
+    unpackedBytes: pack.unpackedSize,
+    entryCount: pack.entryCount,
+  });
   const tarballPath = join(releaseRoot, pack.filename);
   validatePackedFiles(pack.files, expectedDependencyManifests);
   const sha256 = digestFile(tarballPath);

--- a/scripts/smoke-release-cli-package.mjs
+++ b/scripts/smoke-release-cli-package.mjs
@@ -11,6 +11,7 @@ import {
   rmSync,
   statSync,
   writeFileSync,
+  writeSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
@@ -26,6 +27,7 @@ const CONNECTION_SLUG = 'maka-release-smoke';
 const API_KEY = 'maka-release-smoke-key';
 const FILE_SENTINEL = 'MAKA_RELEASE_FILESYSTEM_WORKER_OK';
 const RESPONSE_SENTINEL = 'MAKA_RELEASE_SMOKE_OK';
+const INSTALLED_ROOT_ENV = 'MAKA_CLI_RELEASE_INSTALLED_ROOT';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const cliVersion = JSON.parse(
@@ -35,18 +37,19 @@ const tarballPath = resolve(
   process.argv[2] ?? join(repoRoot, `packages/cli/release/maka-agent-${cliVersion}.tgz`),
 );
 
-await main();
-// ConPTY may retain its native event-loop handle after every PTY child has
-// emitted onExit. All product processes and temporary state are settled above,
-// so terminate the verifier explicitly only on that platform.
-if (process.platform === 'win32') process.exit(0);
+const installedRoot = process.env[INSTALLED_ROOT_ENV];
+if (installedRoot) await runInstalledVerifier(resolve(installedRoot));
+else await main();
 
 async function main() {
   validateReleaseArtifact(tarballPath);
   const root = mkdtempSync(join(tmpdir(), 'maka-cli-tarball-smoke-'));
+  let primaryError;
+  let cleanupError;
   try {
     const prefix = join(root, 'prefix');
     const cache = join(root, 'empty-npm-cache');
+    logStep('installing the immutable tarball with an empty offline npm cache');
     execFileSync(
       'npm',
       [
@@ -67,58 +70,112 @@ async function main() {
         stdio: 'inherit',
       }),
     );
-
-    const packageRoot =
-      process.platform === 'win32'
-        ? join(prefix, 'node_modules/maka-agent')
-        : join(prefix, 'lib/node_modules/maka-agent');
-    const baseEnvironment = isolatedEnvironment(join(root, 'home'));
-    const maka = process.platform === 'win32' ? join(prefix, 'maka.cmd') : join(prefix, 'bin/maka');
-    const makaAgent =
-      process.platform === 'win32'
-        ? join(prefix, 'maka-agent.cmd')
-        : join(prefix, 'bin/maka-agent');
-    const cliEntrypoint = join(packageRoot, 'dist/cli.js');
-    const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
-
-    const version = runSync(maka, ['--version'], baseEnvironment, root).trim();
-    if (version !== manifest.version) {
-      throw new Error(`Installed CLI reports ${version}; package manifest is ${manifest.version}`);
-    }
-    assertOutput(runSync(maka, ['--help'], baseEnvironment, root), 'Usage: maka');
-    assertOutput(runSync(makaAgent, ['--help'], baseEnvironment, root), 'Usage: maka');
-    assertOutput(runSync(maka, ['eval', '--help'], baseEnvironment, root), 'usage: maka eval run');
-    validateInstalledRuntimeFiles(packageRoot);
-
-    const nodePty = await importInstalled(packageRoot, 'node_modules/node-pty/lib/index.js');
-    const ptySpawn = nodePty.spawn ?? nodePty.default?.spawn;
-    if (typeof ptySpawn !== 'function') throw new Error('Installed node-pty has no spawn function');
-    await smokePty(ptySpawn, baseEnvironment, root);
-    await smokeNativeFileLock(packageRoot, root);
-    await smokeInteractiveTui({
-      packageRoot,
-      cliEntrypoint,
-      ptySpawn,
-      root: join(root, 'first-run'),
+    logStep('validating the installed product in an isolated verifier process');
+    execFileSync(process.execPath, [process.argv[1], tarballPath], {
+      cwd: repoRoot,
+      env: { ...process.env, [INSTALLED_ROOT_ENV]: root },
+      stdio: 'inherit',
     });
-    await smokeRuntimeHostService({
-      packageRoot,
-      cliEntrypoint,
-      ptySpawn,
-      root: join(root, 'runtime-host-service'),
-    });
-    await smokeControlledRun({
-      packageRoot,
-      cliEntrypoint,
-      root: join(root, 'controlled-run'),
-    });
-
-    console.log(
-      `[release-cli-smoke] OK — installed ${basename(tarballPath)} offline as ${version}`,
-    );
+  } catch (error) {
+    primaryError = error;
   } finally {
-    rmSync(root, { recursive: true, force: true });
+    logStep('removing the isolated installation');
+    try {
+      rmSync(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    } catch (error) {
+      cleanupError = error;
+    }
   }
+  if (primaryError && cleanupError) {
+    throw new AggregateError(
+      [primaryError, cleanupError],
+      'Installed CLI validation and isolated-install cleanup both failed',
+    );
+  }
+  if (primaryError) throw primaryError;
+  if (cleanupError) throw cleanupError;
+}
+
+async function runInstalledVerifier(root) {
+  try {
+    await validateInstalledProduct(root);
+    // Native PTY libraries can retain an event-loop handle after their product
+    // processes settle. This child owns those libraries, so exiting here both
+    // unloads them and gives the parent a reliable cleanup boundary.
+    process.exit(0);
+  } catch (error) {
+    writeSync(2, `${formatError(error)}\n`);
+    process.exit(1);
+  }
+}
+
+async function validateInstalledProduct(root) {
+  const prefix = join(root, 'prefix');
+  const packageRoot =
+    process.platform === 'win32'
+      ? join(prefix, 'node_modules/maka-agent')
+      : join(prefix, 'lib/node_modules/maka-agent');
+  const baseEnvironment = isolatedEnvironment(join(root, 'home'));
+  const maka = process.platform === 'win32' ? join(prefix, 'maka.cmd') : join(prefix, 'bin/maka');
+  const makaAgent =
+    process.platform === 'win32' ? join(prefix, 'maka-agent.cmd') : join(prefix, 'bin/maka-agent');
+  const cliEntrypoint = join(packageRoot, 'dist/cli.js');
+  const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+  const crossSpawnModule = await importInstalled(packageRoot, 'node_modules/cross-spawn/index.js');
+  const crossSpawn = crossSpawnModule.default ?? crossSpawnModule;
+  if (typeof crossSpawn.sync !== 'function') {
+    throw new Error('Installed cross-spawn sync API is unavailable');
+  }
+
+  logStep('checking bins, Eval assets, and patched runtime files');
+  const version = runSync(crossSpawn.sync, maka, ['--version'], baseEnvironment, root).trim();
+  if (version !== manifest.version) {
+    throw new Error(`Installed CLI reports ${version}; package manifest is ${manifest.version}`);
+  }
+  assertOutput(runSync(crossSpawn.sync, maka, ['--help'], baseEnvironment, root), 'Usage: maka');
+  assertOutput(
+    runSync(crossSpawn.sync, makaAgent, ['--help'], baseEnvironment, root),
+    'Usage: maka',
+  );
+  assertOutput(
+    runSync(crossSpawn.sync, maka, ['eval', '--help'], baseEnvironment, root),
+    'usage: maka eval run',
+  );
+  validateInstalledRuntimeFiles(packageRoot);
+
+  logStep('checking installed native PTY and file-lock modules');
+  const nodePty = await importInstalled(packageRoot, 'node_modules/node-pty/lib/index.js');
+  const ptySpawn = nodePty.spawn ?? nodePty.default?.spawn;
+  if (typeof ptySpawn !== 'function') throw new Error('Installed node-pty has no spawn function');
+  await smokePty(ptySpawn, baseEnvironment, root);
+  await smokeNativeFileLock(packageRoot, root);
+
+  logStep('checking the interactive TUI setup path');
+  await smokeInteractiveTui({
+    packageRoot,
+    cliEntrypoint,
+    ptySpawn,
+    root: join(root, 'first-run'),
+  });
+
+  logStep('checking the managed Runtime Host lifecycle');
+  await smokeRuntimeHostService({
+    packageRoot,
+    cliEntrypoint,
+    ptySpawn,
+    root: join(root, 'runtime-host-service'),
+  });
+
+  logStep('checking a filesystem-backed controlled model turn');
+  await smokeControlledRun({
+    packageRoot,
+    cliEntrypoint,
+    root: join(root, 'controlled-run'),
+  });
+
+  console.log(
+    `[release-cli-validation] OK — installed ${basename(tarballPath)} offline as ${version}`,
+  );
 }
 
 function validateReleaseArtifact(path) {
@@ -209,72 +266,70 @@ async function smokeInteractiveTui({ packageRoot, cliEntrypoint, ptySpawn, root 
   mkdirSync(workspace, { recursive: true });
   const environment = isolatedEnvironment(home);
   const dataRoots = await resolveInstalledDataRoots(packageRoot, environment, home);
-  let completed = false;
-  try {
-    const result = await runPtyScenario({
-      ptySpawn,
-      command: process.execPath,
-      args: [cliEntrypoint],
-      cwd: workspace,
-      environment,
-      marker: 'Set Up Provider',
-      onOutput: (terminal, output) => {
-        if (!output.includes('/setup    配置模型提供商')) return false;
-        terminal.write('/setup\r');
-        return true;
-      },
-      onMarker: (terminal) => {
-        terminal.write('\x03');
-        setTimeout(() => terminal.write('\x04'), 250);
-      },
-      timeoutMs: PROCESS_TIMEOUT_MS,
-    });
-    if (result.exitCode !== 0) throw new Error(`Interactive TUI exited with ${result.exitCode}`);
-    completed = true;
-  } finally {
-    await settleRuntimeHost(packageRoot, dataRoots.workspaceRoot, completed);
-  }
+  await withCleanup(
+    async () => {
+      const result = await runPtyScenario({
+        ptySpawn,
+        command: process.execPath,
+        args: [cliEntrypoint],
+        cwd: workspace,
+        environment,
+        marker: 'Set Up Provider',
+        onOutput: (terminal, output) => {
+          if (!output.includes('/setup')) return false;
+          terminal.write('/setup\r');
+          return true;
+        },
+        onMarker: (terminal) => {
+          terminal.write('\x03');
+          setTimeout(() => terminal.write('\x04'), 250);
+        },
+        timeoutMs: PROCESS_TIMEOUT_MS,
+      });
+      if (result.exitCode !== 0) throw new Error(`Interactive TUI exited with ${result.exitCode}`);
+    },
+    (completed) => settleRuntimeHost(packageRoot, dataRoots.workspaceRoot, completed),
+  );
 }
 
 async function smokeRuntimeHostService({ packageRoot, cliEntrypoint, ptySpawn, root }) {
   mkdirSync(root, { recursive: true });
   const environment = isolatedEnvironment(join(root, 'home'));
   let ready;
-  let completed = false;
-  try {
-    const result = await runPtyScenario({
-      ptySpawn,
-      command: process.execPath,
-      args: [cliEntrypoint, 'runtime-host', 'serve', '--root', root, '--json'],
-      cwd: root,
-      environment,
-      marker: '"event":"runtime_host_ready"',
-      onMarker: (terminal, output) => {
-        const line = output
-          .split(/\r?\n/u)
-          .map((candidate) => candidate.trim())
-          .find((candidate) => candidate.includes('"event":"runtime_host_ready"'));
-        ready = line ? JSON.parse(line) : undefined;
-        terminal.write('\x03');
-      },
-      timeoutMs: PROCESS_TIMEOUT_MS,
-    });
-    if (result.exitCode !== 0) {
-      throw new Error(`Runtime Host service exited with ${result.exitCode}`);
-    }
-    if (
-      ready?.schemaVersion !== 1 ||
-      ready.protocol?.version === undefined ||
-      !ready.hostEpoch ||
-      !ready.rootId ||
-      !ready.listeners?.some((listener) => listener.kind === 'local_ipc')
-    ) {
-      throw new Error('Runtime Host ready event is incomplete');
-    }
-    completed = true;
-  } finally {
-    await settleRuntimeHost(packageRoot, root, completed);
-  }
+  await withCleanup(
+    async () => {
+      const result = await runPtyScenario({
+        ptySpawn,
+        command: process.execPath,
+        args: [cliEntrypoint, 'runtime-host', 'serve', '--root', root, '--json'],
+        cwd: root,
+        environment,
+        marker: '"event":"runtime_host_ready"',
+        onMarker: (terminal, output) => {
+          const line = output
+            .split(/\r?\n/u)
+            .map((candidate) => candidate.trim())
+            .find((candidate) => candidate.includes('"event":"runtime_host_ready"'));
+          ready = line ? parseTerminalJsonObject(line) : undefined;
+          terminal.write('\x03');
+        },
+        timeoutMs: PROCESS_TIMEOUT_MS,
+      });
+      if (result.exitCode !== 0) {
+        throw new Error(`Runtime Host service exited with ${result.exitCode}`);
+      }
+      if (
+        ready?.schemaVersion !== 1 ||
+        ready.protocol?.version === undefined ||
+        !ready.hostEpoch ||
+        !ready.rootId ||
+        !ready.listeners?.some((listener) => listener.kind === 'local_ipc')
+      ) {
+        throw new Error('Runtime Host ready event is incomplete');
+      }
+    },
+    (completed) => settleRuntimeHost(packageRoot, root, completed),
+  );
 }
 
 async function smokeControlledRun({ packageRoot, cliEntrypoint, root }) {
@@ -286,46 +341,48 @@ async function smokeControlledRun({ packageRoot, cliEntrypoint, root }) {
   const environment = isolatedEnvironment(home);
   const dataRoots = await resolveInstalledDataRoots(packageRoot, environment, home);
   const provider = await startProvider();
-  let behaviorCompleted = false;
-  try {
-    await configureRuntimePolicy(packageRoot, dataRoots.workspaceRoot, provider.baseUrl);
-    const result = await runProcess(
-      process.execPath,
-      [
-        cliEntrypoint,
-        'run',
-        'Read smoke.txt, then report the exact release-smoke result.',
-        '--cwd',
-        workspace,
-        '--connection',
-        CONNECTION_SLUG,
-        '--model',
-        MODEL_ID,
-        '--timeout',
-        '45',
-        '--max-steps',
-        '4',
-        '--yolo',
-      ],
-      {
-        cwd: workspace,
-        environment,
-        timeoutMs: PROCESS_TIMEOUT_MS,
-      },
-    );
-    if (result.exitCode !== 0) {
-      throw new Error(`Controlled maka run exited with ${result.exitCode}: ${result.stderr}`);
-    }
-    assertOutput(result.stdout, RESPONSE_SENTINEL);
-    if (!provider.sawReadTool || !provider.sawFileSentinel) {
-      throw new Error('Controlled maka run did not execute the installed filesystem worker');
-    }
-    if (provider.error) throw provider.error;
-    behaviorCompleted = true;
-  } finally {
-    await provider.close();
-    await settleRuntimeHost(packageRoot, dataRoots.workspaceRoot, behaviorCompleted);
-  }
+  await withCleanup(
+    async () => {
+      await configureRuntimePolicy(packageRoot, dataRoots.workspaceRoot, provider.baseUrl);
+      const result = await runProcess(
+        process.execPath,
+        [
+          cliEntrypoint,
+          'run',
+          'Read smoke.txt, then report the exact release-smoke result.',
+          '--cwd',
+          workspace,
+          '--connection',
+          CONNECTION_SLUG,
+          '--model',
+          MODEL_ID,
+          '--timeout',
+          '45',
+          '--max-steps',
+          '4',
+          '--yolo',
+        ],
+        {
+          cwd: workspace,
+          environment,
+          timeoutMs: PROCESS_TIMEOUT_MS,
+        },
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(`Controlled maka run exited with ${result.exitCode}: ${result.stderr}`);
+      }
+      if (provider.error) throw provider.error;
+      assertOutput(result.stdout, RESPONSE_SENTINEL);
+      if (!provider.sawReadTool || !provider.sawFileSentinel) {
+        throw new Error('Controlled maka run did not execute the installed filesystem worker');
+      }
+    },
+    (completed) =>
+      runCleanupSteps([
+        () => provider.close(),
+        () => settleRuntimeHost(packageRoot, dataRoots.workspaceRoot, completed),
+      ]),
+  );
 }
 
 async function configureRuntimePolicy(packageRoot, rootPath, baseUrl) {
@@ -589,42 +646,97 @@ async function waitForRuntimeHostShutdown(packageRoot, rootPath) {
   throw new Error(`Runtime Host did not release its root: ${rootPath}`);
 }
 
+async function withCleanup(action, cleanup) {
+  let primaryError;
+  let cleanupError;
+  try {
+    await action();
+  } catch (error) {
+    primaryError = error;
+  }
+  try {
+    await cleanup(primaryError === undefined);
+  } catch (error) {
+    cleanupError = error;
+  }
+  if (primaryError && cleanupError) {
+    throw new AggregateError([primaryError, cleanupError], 'Validation and cleanup both failed');
+  }
+  if (primaryError) throw primaryError;
+  if (cleanupError) throw cleanupError;
+}
+
+async function runCleanupSteps(steps) {
+  const errors = [];
+  for (const step of steps) {
+    try {
+      await step();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) throw new AggregateError(errors, 'Multiple cleanup steps failed');
+}
+
 async function settleRuntimeHost(packageRoot, rootPath, requireNaturalShutdown) {
+  let naturalShutdownError;
   try {
     await waitForRuntimeHostShutdown(packageRoot, rootPath);
     return;
   } catch (error) {
-    if (requireNaturalShutdown) throw error;
+    naturalShutdownError = error;
   }
-  const authority = await importInstalled(
-    packageRoot,
-    'node_modules/@maka/storage/dist/root-authority.js',
-  );
-  const capability = await authority.resolveStorageRoot({ path: rootPath, kind: 'interactive' });
-  const { controlDirectory } = await authority.prepareStorageRootControlDirectory(capability);
-  const registrationPath = join(controlDirectory, 'registration.json');
-  if (!existsSync(registrationPath)) return;
-  const registration = JSON.parse(readFileSync(registrationPath, 'utf8'));
-  if (
-    registration.rootId !== capability.rootId ||
-    !Number.isSafeInteger(registration.pid) ||
-    registration.pid <= 0
-  ) {
-    throw new Error('Refusing to clean up a Runtime Host with an unexpected registration');
-  }
+  let forcedCleanupError;
   try {
-    process.kill(registration.pid, 'SIGTERM');
+    const authority = await importInstalled(
+      packageRoot,
+      'node_modules/@maka/storage/dist/root-authority.js',
+    );
+    const capability = await authority.resolveStorageRoot({ path: rootPath, kind: 'interactive' });
+    const { controlDirectory } = await authority.prepareStorageRootControlDirectory(capability);
+    const registrationPath = join(controlDirectory, 'registration.json');
+    if (existsSync(registrationPath)) {
+      const registration = JSON.parse(readFileSync(registrationPath, 'utf8'));
+      if (
+        registration.rootId !== capability.rootId ||
+        !Number.isSafeInteger(registration.pid) ||
+        registration.pid <= 0
+      ) {
+        throw new Error('Refusing to clean up a Runtime Host with an unexpected registration');
+      }
+      await terminateRegisteredProcess(registration.pid);
+    }
+  } catch (error) {
+    forcedCleanupError = error;
+  }
+  if (naturalShutdownError && forcedCleanupError) {
+    throw new AggregateError(
+      [naturalShutdownError, forcedCleanupError],
+      'Runtime Host did not stop naturally and forced cleanup failed',
+    );
+  }
+  if (forcedCleanupError) throw forcedCleanupError;
+  if (requireNaturalShutdown) throw naturalShutdownError;
+}
+
+async function terminateRegisteredProcess(pid) {
+  try {
+    process.kill(pid, 'SIGTERM');
   } catch (error) {
     if (error?.code !== 'ESRCH') throw error;
   }
-  const deadline = Date.now() + 5_000;
-  while (Date.now() < deadline && processExists(registration.pid)) await delay(100);
-  if (processExists(registration.pid)) {
+  let deadline = Date.now() + 5_000;
+  while (Date.now() < deadline && processExists(pid)) await delay(100);
+  if (processExists(pid)) {
     try {
-      process.kill(registration.pid, 'SIGKILL');
+      process.kill(pid, 'SIGKILL');
     } catch (error) {
       if (error?.code !== 'ESRCH') throw error;
     }
+    deadline = Date.now() + 5_000;
+    while (Date.now() < deadline && processExists(pid)) await delay(100);
+    if (processExists(pid)) throw new Error(`Runtime Host process ${pid} did not exit`);
   }
 }
 
@@ -791,15 +903,21 @@ function importInstalled(packageRoot, relativePath) {
   return import(pathToFileURL(join(packageRoot, relativePath)).href);
 }
 
-function runSync(command, args, environment, cwd) {
-  return execFileSync(command, args, {
+function runSync(spawnSync, command, args, environment, cwd) {
+  const result = spawnSync(command, args, {
     cwd,
     env: environment,
     encoding: 'utf8',
     timeout: 30_000,
     maxBuffer: MAX_OUTPUT_BYTES,
-    shell: process.platform === 'win32' && command.toLowerCase().endsWith('.cmd'),
   });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(
+      `Installed command exited with ${result.status ?? result.signal}: ${result.stderr}`,
+    );
+  }
+  return result.stdout;
 }
 
 function appendBounded(previous, chunk) {
@@ -810,10 +928,27 @@ function appendBounded(previous, chunk) {
   return next;
 }
 
+function parseTerminalJsonObject(line) {
+  const start = line.indexOf('{');
+  const end = line.lastIndexOf('}');
+  if (start < 0 || end < start) throw new Error('Terminal output did not contain a JSON object');
+  return JSON.parse(line.slice(start, end + 1));
+}
+
 function assertOutput(output, marker) {
   if (!output.includes(marker)) {
     throw new Error(`Expected output to contain ${JSON.stringify(marker)}`);
   }
+}
+
+function logStep(message) {
+  console.log(`[release-cli-validation] ${message}`);
+}
+
+function formatError(error) {
+  const rendered = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  if (!(error instanceof AggregateError)) return rendered;
+  return [rendered, ...error.errors.map((cause) => `Caused by:\n${formatError(cause)}`)].join('\n');
 }
 
 function delay(ms) {
@@ -826,6 +961,7 @@ function processExists(pid) {
     return true;
   } catch (error) {
     if (error?.code === 'ESRCH') return false;
+    if (error?.code === 'EPERM') return true;
     throw error;
   }
 }

--- a/scripts/smoke-release-cli-package.mjs
+++ b/scripts/smoke-release-cli-package.mjs
@@ -1,9 +1,31 @@
-import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync, spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createServer } from 'node:http';
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { validateCliReleaseArtifactMetrics } from './release-cli-artifact-policy.mjs';
 import { npmSpawnOptions } from './npm-spawn.mjs';
+
+const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
+const PROCESS_TIMEOUT_MS = 90_000;
+const RUNTIME_HOST_SHUTDOWN_TIMEOUT_MS = 45_000;
+const MODEL_ID = 'maka-release-smoke-model';
+const CONNECTION_SLUG = 'maka-release-smoke';
+const API_KEY = 'maka-release-smoke-key';
+const FILE_SENTINEL = 'MAKA_RELEASE_FILESYSTEM_WORKER_OK';
+const RESPONSE_SENTINEL = 'MAKA_RELEASE_SMOKE_OK';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 const cliVersion = JSON.parse(
@@ -12,93 +34,124 @@ const cliVersion = JSON.parse(
 const tarballPath = resolve(
   process.argv[2] ?? join(repoRoot, `packages/cli/release/maka-agent-${cliVersion}.tgz`),
 );
-if (!existsSync(tarballPath)) {
-  throw new Error(`Release tarball does not exist: ${tarballPath}`);
+
+await main();
+// ConPTY may retain its native event-loop handle after every PTY child has
+// emitted onExit. All product processes and temporary state are settled above,
+// so terminate the verifier explicitly only on that platform.
+if (process.platform === 'win32') process.exit(0);
+
+async function main() {
+  validateReleaseArtifact(tarballPath);
+  const root = mkdtempSync(join(tmpdir(), 'maka-cli-tarball-smoke-'));
+  try {
+    const prefix = join(root, 'prefix');
+    const cache = join(root, 'empty-npm-cache');
+    execFileSync(
+      'npm',
+      [
+        'install',
+        '--global',
+        '--prefix',
+        prefix,
+        '--cache',
+        cache,
+        '--offline',
+        '--no-audit',
+        '--no-fund',
+        tarballPath,
+      ],
+      npmSpawnOptions({
+        cwd: root,
+        env: { ...process.env, npm_config_registry: 'http://127.0.0.1:9/' },
+        stdio: 'inherit',
+      }),
+    );
+
+    const packageRoot =
+      process.platform === 'win32'
+        ? join(prefix, 'node_modules/maka-agent')
+        : join(prefix, 'lib/node_modules/maka-agent');
+    const baseEnvironment = isolatedEnvironment(join(root, 'home'));
+    const maka = process.platform === 'win32' ? join(prefix, 'maka.cmd') : join(prefix, 'bin/maka');
+    const makaAgent =
+      process.platform === 'win32'
+        ? join(prefix, 'maka-agent.cmd')
+        : join(prefix, 'bin/maka-agent');
+    const cliEntrypoint = join(packageRoot, 'dist/cli.js');
+    const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
+
+    const version = runSync(maka, ['--version'], baseEnvironment, root).trim();
+    if (version !== manifest.version) {
+      throw new Error(`Installed CLI reports ${version}; package manifest is ${manifest.version}`);
+    }
+    assertOutput(runSync(maka, ['--help'], baseEnvironment, root), 'Usage: maka');
+    assertOutput(runSync(makaAgent, ['--help'], baseEnvironment, root), 'Usage: maka');
+    assertOutput(runSync(maka, ['eval', '--help'], baseEnvironment, root), 'usage: maka eval run');
+    validateInstalledRuntimeFiles(packageRoot);
+
+    const nodePty = await importInstalled(packageRoot, 'node_modules/node-pty/lib/index.js');
+    const ptySpawn = nodePty.spawn ?? nodePty.default?.spawn;
+    if (typeof ptySpawn !== 'function') throw new Error('Installed node-pty has no spawn function');
+    await smokePty(ptySpawn, baseEnvironment, root);
+    await smokeNativeFileLock(packageRoot, root);
+    await smokeInteractiveTui({
+      packageRoot,
+      cliEntrypoint,
+      ptySpawn,
+      root: join(root, 'first-run'),
+    });
+    await smokeRuntimeHostService({
+      packageRoot,
+      cliEntrypoint,
+      ptySpawn,
+      root: join(root, 'runtime-host-service'),
+    });
+    await smokeControlledRun({
+      packageRoot,
+      cliEntrypoint,
+      root: join(root, 'controlled-run'),
+    });
+
+    console.log(
+      `[release-cli-smoke] OK — installed ${basename(tarballPath)} offline as ${version}`,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 }
 
-const root = mkdtempSync(join(tmpdir(), 'maka-cli-tarball-smoke-'));
-try {
-  const prefix = join(root, 'prefix');
-  const cache = join(root, 'empty-npm-cache');
-  const home = join(root, 'home');
-  execFileSync(
-    'npm',
-    [
-      'install',
-      '--global',
-      '--prefix',
-      prefix,
-      '--cache',
-      cache,
-      '--offline',
-      '--no-audit',
-      '--no-fund',
-      tarballPath,
-    ],
-    npmSpawnOptions({ cwd: root, stdio: 'inherit' }),
-  );
-
-  const packageRoot =
-    process.platform === 'win32'
-      ? join(prefix, 'node_modules/maka-agent')
-      : join(prefix, 'lib/node_modules/maka-agent');
-  const environment = {
-    ...process.env,
-    HOME: home,
-    USERPROFILE: home,
-    XDG_CONFIG_HOME: join(home, '.config'),
-  };
-  const maka = process.platform === 'win32' ? join(prefix, 'maka.cmd') : join(prefix, 'bin/maka');
-  const makaAgent =
-    process.platform === 'win32' ? join(prefix, 'maka-agent.cmd') : join(prefix, 'bin/maka-agent');
-  const version = run(maka, ['--version'], environment).trim();
-  const manifest = JSON.parse(readFileSync(join(packageRoot, 'package.json'), 'utf8'));
-  if (version !== manifest.version) {
-    throw new Error(`Installed CLI reports ${version}; package manifest is ${manifest.version}`);
+function validateReleaseArtifact(path) {
+  if (!existsSync(path)) throw new Error(`Release tarball does not exist: ${path}`);
+  const checksumPath = `${path}.sha256`;
+  const inventoryPath = `${path}.files.json`;
+  if (!existsSync(checksumPath) || !existsSync(inventoryPath)) {
+    throw new Error('Release tarball checksum or file inventory is missing');
   }
-  assertOutput(run(maka, ['--help'], environment), 'Usage: maka');
-  assertOutput(run(makaAgent, ['--help'], environment), 'Usage: maka');
-  assertOutput(run(maka, ['eval', '--help'], environment), 'usage: maka eval run');
-  const nodePtyUrl = pathToFileURL(join(packageRoot, 'node_modules/node-pty/lib/index.js')).href;
-  assertOutput(
-    run(
-      process.execPath,
-      [
-        '--input-type=module',
-        '-e',
-        `
-          const { spawn } = await import(${JSON.stringify(nodePtyUrl)});
-          const terminal = spawn(process.execPath, ['-e', 'process.stdout.write("maka-pty-ok")']);
-          let output = '';
-          terminal.onData((chunk) => { output += chunk; });
-          await new Promise((resolve) => terminal.onExit(resolve));
-          process.stdout.write(output);
-        `,
-      ],
-      environment,
-    ),
-    'maka-pty-ok',
-  );
-  const fsNativeUrl = pathToFileURL(
-    join(packageRoot, 'node_modules/fs-native-extensions/index.js'),
-  ).href;
-  assertOutput(
-    run(
-      process.execPath,
-      [
-        '--input-type=module',
-        '-e',
-        `
-          const native = await import(${JSON.stringify(fsNativeUrl)});
-          if (typeof native.default?.tryLock !== 'function') process.exit(1);
-          process.stdout.write('maka-fs-native-ok');
-        `,
-      ],
-      environment,
-    ),
-    'maka-fs-native-ok',
-  );
+  const checksum = readFileSync(checksumPath, 'utf8').trim().split(/\s+/u);
+  if (checksum.length !== 2 || checksum[1] !== basename(path)) {
+    throw new Error('Release tarball checksum sidecar is malformed');
+  }
+  const actual = createHash('sha256').update(readFileSync(path)).digest('hex');
+  if (checksum[0] !== actual) throw new Error('Release tarball checksum does not match');
 
+  const files = JSON.parse(readFileSync(inventoryPath, 'utf8'));
+  if (!Array.isArray(files)) throw new Error('Release tarball file inventory must be an array');
+  let unpackedBytes = 0;
+  for (const file of files) {
+    if (!Number.isSafeInteger(file?.size) || file.size < 0 || typeof file.path !== 'string') {
+      throw new Error('Release tarball file inventory contains an invalid entry');
+    }
+    unpackedBytes += file.size;
+  }
+  validateCliReleaseArtifactMetrics({
+    compressedBytes: statSync(path).size,
+    unpackedBytes,
+    entryCount: files.length,
+  });
+}
+
+function validateInstalledRuntimeFiles(packageRoot) {
   for (const path of [
     'node_modules/@maka/runtime/dist/workers/filesystem-worker.js',
     'node_modules/@maka/runtime-host/dist/execution-candidate-main.js',
@@ -106,8 +159,9 @@ try {
     'packages/eval/harbor/relay_agent.py',
     'packages/eval/harbor/egress-proxy/network-policy',
   ]) {
-    if (!existsSync(join(packageRoot, path)))
+    if (!existsSync(join(packageRoot, path))) {
       throw new Error(`Installed runtime file is missing: ${path}`);
+    }
   }
   assertOutput(
     readFileSync(join(packageRoot, 'node_modules/node-pty/lib/unixTerminal.js'), 'utf8'),
@@ -117,24 +171,661 @@ try {
     readFileSync(join(packageRoot, 'node_modules/@ai-sdk/provider-utils/dist/index.js'), 'utf8'),
     'function absentIfBlank',
   );
-
-  console.log(`[release-cli-smoke] OK — installed ${basename(tarballPath)} offline as ${version}`);
-} finally {
-  rmSync(root, { recursive: true, force: true });
 }
 
-function run(command, args, env) {
+async function smokePty(ptySpawn, environment, cwd) {
+  const result = await runPtyScenario({
+    ptySpawn,
+    command: process.execPath,
+    args: ['-e', 'process.stdout.write("maka-pty-ok")'],
+    cwd,
+    environment,
+    marker: 'maka-pty-ok',
+    timeoutMs: 30_000,
+  });
+  if (result.exitCode !== 0) throw new Error(`Installed PTY exited with ${result.exitCode}`);
+}
+
+async function smokeNativeFileLock(packageRoot, root) {
+  const imported = await importInstalled(packageRoot, 'node_modules/fs-native-extensions/index.js');
+  const native = imported.default ?? imported;
+  if (typeof native.tryLock !== 'function' || typeof native.unlock !== 'function') {
+    throw new Error('Installed fs-native-extensions lock API is unavailable');
+  }
+  const lockPath = join(root, 'native-lock');
+  const handle = openSync(lockPath, 'a+');
+  try {
+    if (native.tryLock(handle) !== true) throw new Error('Native file lock was not granted');
+    native.unlock(handle);
+  } finally {
+    closeSync(handle);
+  }
+}
+
+async function smokeInteractiveTui({ packageRoot, cliEntrypoint, ptySpawn, root }) {
+  mkdirSync(root, { recursive: true });
+  const home = join(root, 'home');
+  const workspace = join(root, 'workspace');
+  mkdirSync(workspace, { recursive: true });
+  const environment = isolatedEnvironment(home);
+  const dataRoots = await resolveInstalledDataRoots(packageRoot, environment, home);
+  let completed = false;
+  try {
+    const result = await runPtyScenario({
+      ptySpawn,
+      command: process.execPath,
+      args: [cliEntrypoint],
+      cwd: workspace,
+      environment,
+      marker: 'Set Up Provider',
+      onOutput: (terminal, output) => {
+        if (!output.includes('/setup    配置模型提供商')) return false;
+        terminal.write('/setup\r');
+        return true;
+      },
+      onMarker: (terminal) => {
+        terminal.write('\x03');
+        setTimeout(() => terminal.write('\x04'), 250);
+      },
+      timeoutMs: PROCESS_TIMEOUT_MS,
+    });
+    if (result.exitCode !== 0) throw new Error(`Interactive TUI exited with ${result.exitCode}`);
+    completed = true;
+  } finally {
+    await settleRuntimeHost(packageRoot, dataRoots.workspaceRoot, completed);
+  }
+}
+
+async function smokeRuntimeHostService({ packageRoot, cliEntrypoint, ptySpawn, root }) {
+  mkdirSync(root, { recursive: true });
+  const environment = isolatedEnvironment(join(root, 'home'));
+  let ready;
+  let completed = false;
+  try {
+    const result = await runPtyScenario({
+      ptySpawn,
+      command: process.execPath,
+      args: [cliEntrypoint, 'runtime-host', 'serve', '--root', root, '--json'],
+      cwd: root,
+      environment,
+      marker: '"event":"runtime_host_ready"',
+      onMarker: (terminal, output) => {
+        const line = output
+          .split(/\r?\n/u)
+          .map((candidate) => candidate.trim())
+          .find((candidate) => candidate.includes('"event":"runtime_host_ready"'));
+        ready = line ? JSON.parse(line) : undefined;
+        terminal.write('\x03');
+      },
+      timeoutMs: PROCESS_TIMEOUT_MS,
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(`Runtime Host service exited with ${result.exitCode}`);
+    }
+    if (
+      ready?.schemaVersion !== 1 ||
+      ready.protocol?.version === undefined ||
+      !ready.hostEpoch ||
+      !ready.rootId ||
+      !ready.listeners?.some((listener) => listener.kind === 'local_ipc')
+    ) {
+      throw new Error('Runtime Host ready event is incomplete');
+    }
+    completed = true;
+  } finally {
+    await settleRuntimeHost(packageRoot, root, completed);
+  }
+}
+
+async function smokeControlledRun({ packageRoot, cliEntrypoint, root }) {
+  mkdirSync(root, { recursive: true });
+  const home = join(root, 'home');
+  const workspace = join(root, 'workspace');
+  mkdirSync(workspace, { recursive: true });
+  writeFileSync(join(workspace, 'smoke.txt'), `${FILE_SENTINEL}\n`, 'utf8');
+  const environment = isolatedEnvironment(home);
+  const dataRoots = await resolveInstalledDataRoots(packageRoot, environment, home);
+  const provider = await startProvider();
+  let behaviorCompleted = false;
+  try {
+    await configureRuntimePolicy(packageRoot, dataRoots.workspaceRoot, provider.baseUrl);
+    const result = await runProcess(
+      process.execPath,
+      [
+        cliEntrypoint,
+        'run',
+        'Read smoke.txt, then report the exact release-smoke result.',
+        '--cwd',
+        workspace,
+        '--connection',
+        CONNECTION_SLUG,
+        '--model',
+        MODEL_ID,
+        '--timeout',
+        '45',
+        '--max-steps',
+        '4',
+        '--yolo',
+      ],
+      {
+        cwd: workspace,
+        environment,
+        timeoutMs: PROCESS_TIMEOUT_MS,
+      },
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`Controlled maka run exited with ${result.exitCode}: ${result.stderr}`);
+    }
+    assertOutput(result.stdout, RESPONSE_SENTINEL);
+    if (!provider.sawReadTool || !provider.sawFileSentinel) {
+      throw new Error('Controlled maka run did not execute the installed filesystem worker');
+    }
+    if (provider.error) throw provider.error;
+    behaviorCompleted = true;
+  } finally {
+    await provider.close();
+    await settleRuntimeHost(packageRoot, dataRoots.workspaceRoot, behaviorCompleted);
+  }
+}
+
+async function configureRuntimePolicy(packageRoot, rootPath, baseUrl) {
+  const authority = await importInstalled(
+    packageRoot,
+    'node_modules/@maka/storage/dist/root-authority.js',
+  );
+  const policyModule = await importInstalled(
+    packageRoot,
+    'node_modules/@maka/storage/dist/runtime-policy-stores.js',
+  );
+  const capability = await authority.resolveStorageRoot({ path: rootPath, kind: 'interactive' });
+  const owner = await authority.tryAcquireInteractiveRootOwner(capability);
+  if (!owner) throw new Error('Unable to acquire the controlled-run Runtime Host root');
+  try {
+    const policy = await policyModule.openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    const initial = await policy.connectionCatalog.getSnapshot();
+    const created = await policy.connectionCatalog.create({
+      expectedCatalogRevision: initial.revision,
+      connection: {
+        slug: CONNECTION_SLUG,
+        name: 'Maka release smoke',
+        providerType: 'moonshot',
+        baseUrl,
+        enabled: true,
+        enabledModelIds: [MODEL_ID],
+      },
+    });
+    if (created.kind !== 'committed') throw new Error(`Connection setup failed: ${created.kind}`);
+    const connection = created.snapshot.connections.find(
+      (candidate) => candidate.slug === CONNECTION_SLUG,
+    );
+    if (!connection) throw new Error('Connection setup omitted the controlled connection');
+    const credential = await policy.credentialVault.set({
+      locator: {
+        scope: 'connection',
+        connectionId: connection.connectionId,
+        kind: 'api_key',
+      },
+      expected: null,
+      secret: API_KEY,
+    });
+    if (credential.kind !== 'committed') {
+      throw new Error(`Credential setup failed: ${credential.kind}`);
+    }
+    const fetch = await policy.operations.beginModelFetch(connection.connectionId);
+    if (fetch.kind !== 'ready') throw new Error(`Model setup failed: ${fetch.kind}`);
+    const discovered = await policy.operations.completeModelFetch(fetch.ticket, {
+      models: [
+        {
+          id: MODEL_ID,
+          capabilities: { chat: true, functionCalling: true },
+          contextWindow: 8_192,
+          maxOutputTokens: 256,
+        },
+      ],
+      source: 'fetched',
+      fetchedAt: Date.now(),
+    });
+    if (discovered.kind !== 'committed') {
+      throw new Error(`Model setup commit failed: ${discovered.kind}`);
+    }
+    const defaulted = await policy.connectionCatalog.setDefaultTarget({
+      expectedCatalogRevision: discovered.snapshot.revision,
+      target: { connectionId: connection.connectionId, modelId: MODEL_ID },
+    });
+    if (defaulted.kind !== 'committed') {
+      throw new Error(`Default model setup failed: ${defaulted.kind}`);
+    }
+  } finally {
+    await owner.close();
+  }
+}
+
+async function startProvider() {
+  let streamRequestCount = 0;
+  let sawReadTool = false;
+  let sawFileSentinel = false;
+  let providerError;
+  const server = createServer((request, response) => {
+    void handleRequest(request, response).catch((error) => {
+      providerError ??= error instanceof Error ? error : new Error(String(error));
+      response.writeHead(500, { 'content-type': 'text/plain' });
+      response.end('release smoke provider failure');
+    });
+  });
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Provider did not bind TCP');
+
+  async function handleRequest(request, response) {
+    if (request.method === 'GET' && request.url?.endsWith('/models')) {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ object: 'list', data: [{ id: MODEL_ID, object: 'model' }] }));
+      return;
+    }
+    if (request.method !== 'POST') throw new Error(`Unexpected provider method: ${request.method}`);
+    if (request.headers.authorization !== `Bearer ${API_KEY}`) {
+      throw new Error('Controlled provider received the wrong authorization header');
+    }
+    const body = JSON.parse(await readRequestBody(request));
+    if (body.stream !== true) {
+      respondNonStreaming(response);
+      return;
+    }
+    const toolNames = (body.tools ?? []).map((tool) => tool.function?.name ?? tool.name);
+    if (toolNames.includes('Read')) {
+      streamRequestCount += 1;
+      if (streamRequestCount === 1) {
+        sawReadTool = true;
+        respondToolCall(response, 'Read', { path: 'smoke.txt' });
+        return;
+      }
+      sawFileSentinel ||= JSON.stringify(body).includes(FILE_SENTINEL);
+      if (!sawFileSentinel) throw new Error('Read tool result did not contain the smoke file');
+    }
+    respondText(response, RESPONSE_SENTINEL);
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    get sawReadTool() {
+      return sawReadTool;
+    },
+    get sawFileSentinel() {
+      return sawFileSentinel;
+    },
+    get error() {
+      return providerError;
+    },
+    close: () =>
+      new Promise((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+function respondToolCall(response, name, args) {
+  respondSse(response, [
+    {
+      id: 'chatcmpl-release-smoke-tool',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: MODEL_ID,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: 'assistant',
+            tool_calls: [
+              {
+                index: 0,
+                id: 'release-smoke-read',
+                type: 'function',
+                function: { name, arguments: JSON.stringify(args) },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    },
+    {
+      id: 'chatcmpl-release-smoke-tool',
+      object: 'chat.completion.chunk',
+      created: 1,
+      model: MODEL_ID,
+      choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  ]);
+}
+
+function respondText(response, text) {
+  respondSse(response, [
+    {
+      id: 'chatcmpl-release-smoke-text',
+      object: 'chat.completion.chunk',
+      created: 2,
+      model: MODEL_ID,
+      choices: [{ index: 0, delta: { role: 'assistant', content: text }, finish_reason: null }],
+    },
+    {
+      id: 'chatcmpl-release-smoke-text',
+      object: 'chat.completion.chunk',
+      created: 2,
+      model: MODEL_ID,
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+    },
+  ]);
+}
+
+function respondSse(response, events) {
+  response.writeHead(200, { 'content-type': 'text/event-stream' });
+  for (const event of events) response.write(`data: ${JSON.stringify(event)}\n\n`);
+  response.end('data: [DONE]\n\n');
+}
+
+function respondNonStreaming(response) {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(
+    JSON.stringify({
+      id: 'chatcmpl-release-smoke-summary',
+      object: 'chat.completion',
+      created: 3,
+      model: MODEL_ID,
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: RESPONSE_SENTINEL },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+  );
+}
+
+async function readRequestBody(request) {
+  let body = '';
+  request.setEncoding('utf8');
+  for await (const chunk of request) {
+    body += chunk;
+    if (Buffer.byteLength(body) > MAX_OUTPUT_BYTES)
+      throw new Error('Provider request is too large');
+  }
+  return body;
+}
+
+async function resolveInstalledDataRoots(packageRoot, environment, home) {
+  const storage = await importInstalled(packageRoot, 'node_modules/@maka/storage/dist/index.js');
+  return storage.resolveMakaDataRoots({ env: environment, homeDir: home, profileName: 'Maka' });
+}
+
+async function waitForRuntimeHostShutdown(packageRoot, rootPath) {
+  const authority = await importInstalled(
+    packageRoot,
+    'node_modules/@maka/storage/dist/root-authority.js',
+  );
+  const capability = await authority.resolveStorageRoot({ path: rootPath, kind: 'interactive' });
+  const { controlDirectory } = await authority.prepareStorageRootControlDirectory(capability);
+  const registrationPath = join(controlDirectory, 'registration.json');
+  const deadline = Date.now() + RUNTIME_HOST_SHUTDOWN_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (!existsSync(registrationPath)) {
+      const owner = await authority.tryAcquireInteractiveRootOwner(capability);
+      if (owner) {
+        await owner.close();
+        return;
+      }
+    }
+    await delay(100);
+  }
+  throw new Error(`Runtime Host did not release its root: ${rootPath}`);
+}
+
+async function settleRuntimeHost(packageRoot, rootPath, requireNaturalShutdown) {
+  try {
+    await waitForRuntimeHostShutdown(packageRoot, rootPath);
+    return;
+  } catch (error) {
+    if (requireNaturalShutdown) throw error;
+  }
+  const authority = await importInstalled(
+    packageRoot,
+    'node_modules/@maka/storage/dist/root-authority.js',
+  );
+  const capability = await authority.resolveStorageRoot({ path: rootPath, kind: 'interactive' });
+  const { controlDirectory } = await authority.prepareStorageRootControlDirectory(capability);
+  const registrationPath = join(controlDirectory, 'registration.json');
+  if (!existsSync(registrationPath)) return;
+  const registration = JSON.parse(readFileSync(registrationPath, 'utf8'));
+  if (
+    registration.rootId !== capability.rootId ||
+    !Number.isSafeInteger(registration.pid) ||
+    registration.pid <= 0
+  ) {
+    throw new Error('Refusing to clean up a Runtime Host with an unexpected registration');
+  }
+  try {
+    process.kill(registration.pid, 'SIGTERM');
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
+  }
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline && processExists(registration.pid)) await delay(100);
+  if (processExists(registration.pid)) {
+    try {
+      process.kill(registration.pid, 'SIGKILL');
+    } catch (error) {
+      if (error?.code !== 'ESRCH') throw error;
+    }
+  }
+}
+
+function runPtyScenario({
+  ptySpawn,
+  command,
+  args,
+  cwd,
+  environment,
+  marker,
+  onOutput,
+  onMarker,
+  timeoutMs,
+}) {
+  return new Promise((resolvePromise, reject) => {
+    let output = '';
+    let markerSeen = false;
+    let outputActionApplied = false;
+    let settled = false;
+    const terminal = ptySpawn(command, args, {
+      cwd,
+      env: environment,
+      name: 'xterm-256color',
+      cols: 100,
+      rows: 30,
+    });
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      terminal.kill();
+      reject(
+        new Error(
+          `PTY command timed out waiting for ${JSON.stringify(marker)}: ${output.slice(-4_000)}`,
+        ),
+      );
+    }, timeoutMs);
+    terminal.onData((chunk) => {
+      if (settled) return;
+      try {
+        output = appendBounded(output, chunk);
+      } catch (error) {
+        settled = true;
+        clearTimeout(timer);
+        terminal.kill();
+        reject(error);
+        return;
+      }
+      if (!outputActionApplied && onOutput) {
+        try {
+          outputActionApplied = onOutput(terminal, output) === true;
+        } catch (error) {
+          settled = true;
+          clearTimeout(timer);
+          terminal.kill();
+          reject(error);
+          return;
+        }
+      }
+      if (!markerSeen && output.includes(marker)) {
+        markerSeen = true;
+        try {
+          onMarker?.(terminal, output);
+        } catch (error) {
+          settled = true;
+          clearTimeout(timer);
+          terminal.kill();
+          reject(error);
+        }
+      }
+    });
+    terminal.onExit(({ exitCode, signal }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (!markerSeen) {
+        reject(new Error(`PTY command exited before ${JSON.stringify(marker)}: ${output}`));
+        return;
+      }
+      resolvePromise({ exitCode, signal, output });
+    });
+  });
+}
+
+function runProcess(command, args, { cwd, environment, timeoutMs }) {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: environment,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let settled = false;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill('SIGKILL');
+      reject(error);
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, timeoutMs);
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      try {
+        stdout = appendBounded(stdout, chunk);
+      } catch (error) {
+        fail(error);
+      }
+    });
+    child.stderr.on('data', (chunk) => {
+      try {
+        stderr = appendBounded(stderr, chunk);
+      } catch (error) {
+        fail(error);
+      }
+    });
+    child.once('error', (error) => {
+      fail(error);
+    });
+    child.once('exit', (exitCode, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (timedOut) {
+        reject(new Error(`Command timed out after ${timeoutMs}ms: ${command}`));
+        return;
+      }
+      resolvePromise({ exitCode, signal, stdout, stderr });
+    });
+  });
+}
+
+function isolatedEnvironment(home) {
+  const appData = join(home, 'AppData', 'Roaming');
+  const localAppData = join(home, 'AppData', 'Local');
+  const temporaryDirectory = join(home, 'tmp');
+  for (const path of [home, appData, localAppData, join(home, '.config'), temporaryDirectory]) {
+    mkdirSync(path, { recursive: true });
+  }
+  return {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: join(home, '.config'),
+    APPDATA: appData,
+    LOCALAPPDATA: localAppData,
+    TMPDIR: temporaryDirectory,
+    TEMP: temporaryDirectory,
+    TMP: temporaryDirectory,
+    NODE_PATH: '',
+    TERM: 'xterm-256color',
+    NO_PROXY: '127.0.0.1,localhost',
+    no_proxy: '127.0.0.1,localhost',
+  };
+}
+
+function importInstalled(packageRoot, relativePath) {
+  return import(pathToFileURL(join(packageRoot, relativePath)).href);
+}
+
+function runSync(command, args, environment, cwd) {
   return execFileSync(command, args, {
-    cwd: root,
-    env,
+    cwd,
+    env: environment,
     encoding: 'utf8',
     timeout: 30_000,
-    maxBuffer: 16 * 1024 * 1024,
+    maxBuffer: MAX_OUTPUT_BYTES,
     shell: process.platform === 'win32' && command.toLowerCase().endsWith('.cmd'),
   });
 }
 
+function appendBounded(previous, chunk) {
+  const next = previous + chunk;
+  if (Buffer.byteLength(next) > MAX_OUTPUT_BYTES) {
+    throw new Error(`Command output exceeded ${MAX_OUTPUT_BYTES} bytes`);
+  }
+  return next;
+}
+
 function assertOutput(output, marker) {
-  if (!output.includes(marker))
+  if (!output.includes(marker)) {
     throw new Error(`Expected output to contain ${JSON.stringify(marker)}`);
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ESRCH') return false;
+    throw error;
+  }
 }


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Adds a read-only release gate for the npm CLI artifact introduced by #3173. The workflow builds one tarball, then tests that exact artifact on Linux (minimum and current Node), macOS arm64, and Windows x64.

The installed-product smoke runs outside the repository with an empty offline npm cache and covers both bins, Eval assets, PTY and native locks, TUI setup, Runtime Host lifecycle, and a filesystem-backed model turn. It also fails packaging when the artifact exceeds reviewed size or file-count limits.

Refs #3166

## Verification

- Release tarball pack and full installed-product smoke passed locally.
- Release policy tests, lint, format, CLI typecheck, notice checks, and actionlint passed.
- The aggregate `check:release` stopped on a local pre-existing `@maka/ui` stale-build timestamp; its affected checks were run individually.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex implemented the workflow, artifact policy, installed-product smoke, and tests under human direction and review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概要

为 #3173 引入的 npm CLI 产物增加只读发布门禁。工作流只构建一次 tarball，并在 Linux（最低及当前 Node）、macOS arm64 和 Windows x64 上验证同一个产物。

安装态冒烟测试在仓库外、空离线 npm 缓存中运行，覆盖两个 bin、Eval 资源、PTY 和原生文件锁、TUI 配置、Runtime Host 生命周期，以及通过文件系统 worker 完成的受控模型回合。打包产物超过已审定的体积或文件数上限时也会失败。

Refs #3166

## 验证

- 本地通过 release tarball 打包及完整安装态冒烟测试。
- release policy 测试、lint、format、CLI typecheck、notice 检查及 actionlint 均通过。
- 聚合命令 `check:release` 因本地已有的 `@maka/ui` 构建时间戳陈旧而停止；其受影响检查已分别通过。

## AI 使用

请且仅选择一项：

- [ ] 没有生成式工具作出实质性贡献
- [x] 生成式工具作出了实质性贡献

工具及范围：OpenAI Codex 在人工指导与审核下实现了工作流、产物策略、安装态冒烟测试及相关测试。

## 检查清单

- [x] 测试覆盖此变更，且在缺少该变更时会失败
- [x] lint、format、typecheck 和受影响测试套件已在本地通过

本 PR 是否包含行为变更？

- [x] 是——已在上方概要中说明
- [ ] 否

</details>
