### PR TITLE
test(runtime-host): verify remote service restart

### DIFF
--- a/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
+++ b/packages/runtime-host/src/__tests__/authenticated-websocket.test.ts
@@ -7,12 +7,15 @@ import { test } from 'node:test';
 import { resolveRootControlNamespace, resolveStorageRoot } from '@maka/storage/root-authority';
 import { classifyRemoteRuntimeHostConnectFailure } from '../client/connection.js';
 import {
+  connectRemoteRuntimeHostProfile,
   connectRemoteRuntimeHost,
   connectRuntimeHost,
   consumeAccessCredentialDelivery,
+  createRuntimeHostReconnectingConnection,
   RuntimeHostOperationError,
   type RuntimeHostConnection,
 } from '../client/index.js';
+import { RUNTIME_HOST_PLAINTEXT_ACKNOWLEDGEMENT } from '../client/host-profile.js';
 import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
   RUNTIME_HOST_PROTOCOL_VERSION,
@@ -372,6 +375,103 @@ test('classifies safe remote connection failures without exposing raw errors', (
     classifyRemoteRuntimeHostConnectFailure(new Error('unexpected sensitive detail')),
     'connect_failed',
   );
+});
+
+test('an authenticated WebSocket Client reconnects after service restart to canonical state', {
+  timeout: 120_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-authenticated-websocket-restart-'));
+  const root = join(base, 'root');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  let host: Awaited<ReturnType<typeof startExecutionRuntimeHostService>> | undefined =
+    await startExecutionRuntimeHostService({
+      rootPath: root,
+      websocket: { host: '127.0.0.1', port: 0 },
+    });
+  let local: RuntimeHostConnection | undefined;
+  let remote: Awaited<ReturnType<typeof createRuntimeHostReconnectingConnection>> | undefined;
+  try {
+    local = requireConnection(
+      await connectRuntimeHost({ rootPath: root, surface: 'desktop', protocol: PROTOCOL }),
+    );
+    const issued = await local.request('access.credential.issue', {
+      principalKind: 'remote_owner',
+      principalId: 'restart-client',
+      operationGrants: ['host.status', 'session.catalog.query'],
+      canPublishClientCapabilities: false,
+      canUseHostPaths: false,
+    });
+    const credential = await consumeAccessCredentialDelivery(
+      root,
+      issued.deliveryId,
+      issued.credentialId,
+    );
+    const created = await local.request('session.create', {
+      sessionId: 'session-before-restart',
+      workspace: { kind: 'host_path', path: root },
+      name: 'Created before restart',
+      modelTarget: { kind: 'default' },
+    });
+    assert.ok(!('kind' in created));
+
+    const url = host.websocketEndpoints[0];
+    assert.ok(url);
+    const port = Number(new URL(url).port);
+    const profile = {
+      id: 'restart-host',
+      name: 'Restart Host',
+      kind: 'remote',
+      transport: {
+        kind: 'plaintext',
+        url,
+        acknowledgement: RUNTIME_HOST_PLAINTEXT_ACKNOWLEDGEMENT,
+      },
+      rootId: capability.rootId,
+    } as const;
+    const connectRemote = (signal?: AbortSignal) =>
+      connectRemoteRuntimeHostProfile({
+        profile,
+        credential,
+        surface: 'tui',
+        clientInstanceId: 'restart-client-instance',
+        ...(signal ? { signal } : {}),
+        connectTimeoutMs: 1_000,
+        readyTimeoutMs: 5_000,
+      });
+    const initialRemote = await connectRemote();
+    const firstHostEpoch = initialRemote.hostEpoch;
+    remote = await createRuntimeHostReconnectingConnection({
+      initialConnection: initialRemote,
+      connect: connectRemote,
+      backoff: { minMs: 10, maxMs: 25 },
+    });
+
+    await host.close();
+    await Promise.all([initialRemote.closed, local.closed]);
+    host = undefined;
+    local = undefined;
+
+    const recovered = remote.request(
+      'session.catalog.query',
+      { kind: 'get', sessionId: 'session-before-restart' },
+      20_000,
+    );
+    host = await startExecutionRuntimeHostService({
+      rootPath: root,
+      websocket: { host: '127.0.0.1', port },
+    });
+
+    assert.deepEqual(await recovered, { kind: 'session', session: created });
+    assert.notEqual(remote.hostEpoch, firstHostEpoch);
+  } finally {
+    await Promise.allSettled([remote?.close(), local?.close()]);
+    await host?.close().catch(() => undefined);
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
 });
 
 test('access credentials persist only as hashes and stay revoked after reload', async () => {


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Adds one service-level integration journey for the remaining Runtime Host production-hardening gap. An authenticated remote profile now proves it can reconnect after the real WebSocket service restarts with a new Host epoch and read the canonical Session created before restart.

This is a test-only change. It composes the existing profile connector, credential authority, reconnect lifecycle, Root identity, and durable Session state without duplicating Domain behavior suites per transport.

</details>

<details>
<summary>简体中文</summary>

为 Runtime Host 剩余的生产强化缺口增加一条 service-level 集成 journey。经过认证的远程 profile 会在真实 WebSocket service 以新 Host epoch 重启后重新连接，并读取重启前创建的 canonical Session。

本 PR 只修改测试。它组合验证现有 profile connector、credential authority、reconnect lifecycle、Root identity 与持久 Session 状态，不会按 transport 重复 Domain 行为测试。

</details>

Fixes #2522

## Verification

<details open>
<summary>English</summary>

- Runtime Host full suite: 963 passed
- New restart journey: 8 parallel repetitions passed
- Runtime Host typecheck
- Biome check and `git diff --check`
- Required CI, including Windows recovery and baseline

</details>

<details>
<summary>简体中文</summary>

- Runtime Host 全量测试：963 passed
- 新增重启 journey：8 路并行重复验证通过
- Runtime Host typecheck
- Biome check 与 `git diff --check`
- Required CI，包括 Windows recovery 与 baseline

</details>

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex audited the remaining hardening evidence and added the focused lifecycle test under maintainer direction.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
