### PR TITLE
fix(desktop): preserve live turns across session refreshes

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-session-catalog-running-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-catalog-running-turns.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { SessionCatalogProjection } from '@maka/runtime-host/protocol';
+import type { IpcHandler } from '../ipc-reconnect-policy.js';
+import { registerRuntimeHostSessionCatalogIpc } from '../runtime-host-session-catalog-ipc-main.js';
+
+test('projects observed running Turn identities into renderer Session lists', async () => {
+  const handlers = new Map<string, IpcHandler>();
+  registerRuntimeHostSessionCatalogIpc(
+    {
+      client: {
+        listSessions: async () => [session('running'), session('idle')],
+      } as never,
+      runningTurnIds: (sessionId) =>
+        sessionId === 'running' ? ['turn-live'] : [],
+      resolveCreateProject: async () => ({ kind: 'host_path', path: '/workspace' }),
+      emitSessionsChanged() {},
+      releaseSessionResources() {},
+      sessionCopyCleanup: {
+        recover: async () => ({ failed: [] }),
+      } as never,
+    },
+    {
+      handle: (channel, listener) => handlers.set(channel, listener),
+      handleReconnectableRead: (channel, listener) => handlers.set(channel, listener),
+    },
+  );
+
+  const list = handlers.get('sessions:list');
+  assert.ok(list);
+  const projected = await list({} as never) as Array<{ id: string; runningTurnIds?: string[] }>;
+
+  assert.deepEqual(projected.find(({ id }) => id === 'running')?.runningTurnIds, ['turn-live']);
+  assert.equal(
+    Object.hasOwn(projected.find(({ id }) => id === 'idle') ?? {}, 'runningTurnIds'),
+    false,
+  );
+});
+
+function session(id: string): SessionCatalogProjection {
+  return {
+    id,
+    revision: 1,
+    workspace: {
+      target: { kind: 'host_path', path: '/workspace' },
+      hostCwd: '/workspace',
+    },
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: id,
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    connectionLocked: true,
+    model: 'fake-model',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  };
+}

--- a/apps/desktop/src/main/__tests__/session-read-state.test.ts
+++ b/apps/desktop/src/main/__tests__/session-read-state.test.ts
@@ -76,6 +76,7 @@ describe('renderer session read state', () => {
     let listCalls = 0;
     let currentSessions: SessionSummary[] = [];
     const refresher = createSessionListRefresher({
+      captureRequestContext: () => undefined,
       listSessions: async () => {
         const result = listResults[listCalls];
         listCalls += 1;
@@ -113,6 +114,7 @@ describe('renderer session read state', () => {
     const errors: unknown[] = [];
     let currentSessions = original;
     const refresher = createSessionListRefresher({
+      captureRequestContext: () => undefined,
       listSessions: async () => {
         throw new Error('list failed');
       },
@@ -131,6 +133,29 @@ describe('renderer session read state', () => {
     assert.equal(result, original);
     assert.equal(currentSessions, original);
     assert.equal(errors.length, 1);
+  });
+
+  it('commits the renderer context captured before the accepted authority read', async () => {
+    const listed = deferred<SessionSummary[]>();
+    let requestContext = 'before';
+    let committedContext: string | undefined;
+    const refresher = createSessionListRefresher({
+      captureRequestContext: () => requestContext,
+      listSessions: () => listed.promise,
+      readBoundaries: () => ({}),
+      currentSessions: () => [],
+      commitSessions: (_sessions, context) => {
+        committedContext = context;
+      },
+      onError: () => {},
+    });
+
+    const refresh = refresher.refresh();
+    requestContext = 'after';
+    listed.resolve([]);
+    await refresh;
+
+    assert.equal(committedContext, 'before');
   });
 });
 

--- a/apps/desktop/src/main/__tests__/settled-session-transient-reconcile.test.ts
+++ b/apps/desktop/src/main/__tests__/settled-session-transient-reconcile.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { SessionSummary } from '@maka/core/session';
+import { armLiveTurn } from '@maka/ui';
+import { createAppShellSessionUiStateController } from '../../renderer/app-shell-session-ui-state.js';
+import { reconcileSettledSessionTransients } from '../../renderer/settled-session-transients.js';
+
+test('does not let a session snapshot retire a turn confirmed while its list request was in flight', () => {
+  const sessionId = 'session-a';
+  const turnId = 'turn-a';
+  const controller = createAppShellSessionUiStateController();
+  controller.setLiveTurnBySession(() => ({
+    [sessionId]: armLiveTurn(turnId),
+  }));
+  const observedLiveTurnBySession = controller.liveTurnBySessionRef.current;
+
+  controller.confirmLiveTurn(sessionId, turnId);
+  reconcileSettledSessionTransients({
+    activeId: sessionId,
+    sessions: [settledSession(sessionId)],
+    observedLiveTurnBySession,
+    clearTurnTransientStateIfCurrent: controller.clearTurnTransientStateIfCurrent,
+  });
+
+  assert.equal(controller.getState().liveTurnBySession[sessionId]?.turnId, turnId);
+  assert.equal(controller.getState().liveTurnBySession[sessionId]?.unconfirmed, undefined);
+});
+
+test('does not let an older session snapshot clear a replacement live turn', () => {
+  const sessionId = 'session-a';
+  const controller = createAppShellSessionUiStateController();
+  controller.setLiveTurnBySession(() => ({
+    [sessionId]: armLiveTurn('turn-a'),
+  }));
+  controller.confirmLiveTurn(sessionId, 'turn-a');
+  const observedLiveTurnBySession = controller.liveTurnBySessionRef.current;
+
+  controller.setLiveTurnBySession(() => ({
+    [sessionId]: armLiveTurn('turn-b'),
+  }));
+  reconcileSettledSessionTransients({
+    activeId: sessionId,
+    sessions: [settledSession(sessionId)],
+    observedLiveTurnBySession,
+    clearTurnTransientStateIfCurrent: controller.clearTurnTransientStateIfCurrent,
+  });
+
+  assert.equal(controller.getState().liveTurnBySession[sessionId]?.turnId, 'turn-b');
+});
+
+test('clears a confirmed live turn when the accepted authority snapshot says it settled', () => {
+  const sessionId = 'session-a';
+  const controller = createAppShellSessionUiStateController();
+  controller.setLiveTurnBySession(() => ({
+    [sessionId]: armLiveTurn('turn-a'),
+  }));
+  controller.confirmLiveTurn(sessionId, 'turn-a');
+  const observedLiveTurnBySession = controller.liveTurnBySessionRef.current;
+
+  reconcileSettledSessionTransients({
+    activeId: sessionId,
+    sessions: [settledSession(sessionId)],
+    observedLiveTurnBySession,
+    clearTurnTransientStateIfCurrent: controller.clearTurnTransientStateIfCurrent,
+  });
+
+  assert.equal(controller.getState().liveTurnBySession[sessionId], undefined);
+});
+
+function settledSession(id: string): SessionSummary {
+  return {
+    id,
+    name: 'Session A',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    runningTurnIds: [],
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    connectionLocked: true,
+    model: 'fake-model',
+    permissionMode: 'ask',
+  };
+}

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -586,6 +586,7 @@ export async function createDesktopRuntimeHostCandidate(
     registerRuntimeHostSessionCatalogIpc(
       {
         client,
+        runningTurnIds: (sessionId) => sessionObserver.observedRunningTurnIds(sessionId),
         resolveCreateProject: (input) => deps.resolveSessionCreateProject(input, target),
         emitSessionsChanged,
         releaseSessionResources: releaseNativeSession,

--- a/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-catalog-ipc-main.ts
@@ -44,6 +44,8 @@ export interface DesktopHostSessionSummary extends SessionSummary {
 
 export interface RuntimeHostSessionCatalogIpcDeps {
   client: RuntimeHostSessionCatalogClient;
+  /** Live execution identity is observer-owned and must not be inferred from the durable header. */
+  runningTurnIds: (sessionId: string) => readonly string[];
   resolveCreateProject: (
     input: Pick<CreateSessionRequestInput, 'cwd' | 'projectId'>,
   ) => Promise<WorkspaceTarget>;
@@ -76,7 +78,9 @@ export function registerRuntimeHostSessionCatalogIpc(
       .filter((session) =>
         parentSessionId === undefined ? true : session.subagent?.parentSessionId === parentSessionId,
       )
-      .map(toDesktopHostSessionSummary);
+      .map((session) =>
+        toDesktopHostSessionListSummary(session, deps.runningTurnIds(session.id)),
+      );
   };
   const actionIds = (sessionId: string, options: unknown) =>
     resolveSessionActionIds(() => listSessions(), sessionId, options);
@@ -343,4 +347,14 @@ export function toDesktopHostSessionSummary(
     collaborationMode: session.collaborationMode,
     orchestrationMode: session.orchestrationMode,
   };
+}
+
+function toDesktopHostSessionListSummary(
+  session: SessionCatalogProjection,
+  runningTurnIds: readonly string[],
+): DesktopHostSessionSummary {
+  const summary = toDesktopHostSessionSummary(session);
+  return runningTurnIds.length === 0
+    ? summary
+    : { ...summary, runningTurnIds: [...runningTurnIds] };
 }

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -445,6 +445,11 @@ export class RuntimeHostSessionObserver {
     void this.#closeIfIdle(state);
   }
 
+  observedRunningTurnIds(sessionId: string): string[] {
+    const root = this.#states.get(sessionId)?.snapshot?.rootTurn;
+    return root && !isTerminalTurn(root) ? [root.turnId] : [];
+  }
+
   activeInteraction(
     sessionId: string,
     interactionId: string,

--- a/apps/desktop/src/renderer/app-shell-effects.ts
+++ b/apps/desktop/src/renderer/app-shell-effects.ts
@@ -24,7 +24,6 @@ import {
   recordSessionEventStreamChange,
   recordSessionEventStreamEvent,
 } from './session-event-health';
-import { settledSessionTransientIds } from './settled-session-transients.js';
 import {
   persistableSessionWorkbarPanels,
   type SessionWorkbarPanelsState,
@@ -726,51 +725,4 @@ export function useSessionEventHealthPolling(options: {
       document.removeEventListener('visibilitychange', onVisibilityChange);
     };
   }, [activeId, activeSession?.status, activeStreamingLive, hasInFlightLiveTools, activeInteraction?.requestId]);
-}
-
-// #646: transient live state is only
-// advanced and cleared by the ACTIVE session's SessionEvent stream (subscribeEvents
-// follows activeId only, with no replay of missed events). So any session that
-// reaches a terminal status while backgrounded — or whose terminal status only
-// lands after the user has switched back — leaves that transient frozen mid-turn,
-// surfacing a stuck Stop (via the ungated `activeStreamingLive`) and a half-streamed
-// bubble. Heal it against the authoritative status, not against an event or a switch
-// (both fire before the terminal status is known): whenever the sessions list
-// settles, drop the turn transient of every session that is no longer running /
-// waiting_for_user. Because it keys off the status landing in `sessions`, it closes
-// the hole regardless of which path or timing delivers that status.
-//
-// Except while a send is still awaiting its answer: an arm carries `unconfirmed`
-// until a `sessions:changed` names its turn back, and the pre-send status is
-// indistinguishable from the post-turn one. Reading a list refreshed in that
-// window as a settle would drop the arm the send just created
-// (settled-session-transients.ts).
-//
-// An active terminal projection is left to its text handoff callback, so this
-// reconcile cannot cut in front of the committed message landing. Background
-// terminal projections have no mounted streaming renderer and are safe to clear.
-// It drops ONLY the turn transient (`clearTurnTransientState`), never the
-// independently-scoped message-load-error / retry / pending-toggle / permission /
-// health state — those survive a mere settle. The clear is idempotent (referentially
-// stable when there's nothing to drop), so the common "terminal session with no
-// transient" case triggers no re-render.
-export function useSettledSessionTransientReconcile(options: {
-  activeId?: string;
-  sessions: readonly SessionSummary[];
-  liveTurnBySessionRef: RefBox<Record<string, LiveTurnProjection>>;
-  clearTurnTransientState: (sessionId: string) => void;
-}) {
-  const reconcile = useEffectEvent(() => {
-    const sessionIds = settledSessionTransientIds({
-      activeId: options.activeId,
-      sessions: options.sessions,
-      liveTurnBySession: options.liveTurnBySessionRef.current,
-    });
-    for (const sessionId of sessionIds) {
-      options.clearTurnTransientState(sessionId);
-    }
-  });
-  useEffect(() => {
-    reconcile();
-  }, [options.activeId, options.sessions]);
 }

--- a/apps/desktop/src/renderer/app-shell-session-ui-state.ts
+++ b/apps/desktop/src/renderer/app-shell-session-ui-state.ts
@@ -33,7 +33,7 @@ type MissingSessionUiMapKey = Exclude<AppShellSessionUiStateMapKey, typeof SESSI
 const allSessionUiMapsAreListed: Record<MissingSessionUiMapKey, never> = {};
 void allSessionUiMapsAreListed;
 
-// `useSettledSessionTransientReconcile` heals a session whose turn ended while
+// An authoritative session-list refresh heals a session whose turn ended while
 // its SessionEvent stream wasn't being followed, and must drop only the live
 // projection. The independently-scoped maps (message load error / retry, pending
 // permission-mode / model toggles, the permission queue, stop-pending) each have
@@ -177,7 +177,11 @@ export function createAppShellSessionUiStateController(
       );
       replaceState(clearAppShellSessionUiStateForSession(currentState, sessionId));
     },
-    clearTurnTransientState: (sessionId: string) => {
+    clearTurnTransientStateIfCurrent: (
+      sessionId: string,
+      expected: LiveTurnProjection | undefined,
+    ) => {
+      if (currentState.liveTurnBySession[sessionId] !== expected) return;
       replaceState(clearAppShellTurnTransientForSession(currentState, sessionId));
     },
   };
@@ -215,6 +219,6 @@ export function useAppShellSessionUiState() {
     setPendingSessionModelBySession: controller.setPendingSessionModelBySession,
     confirmLiveTurn: controller.confirmLiveTurn,
     clearSessionUiState: controller.clearSessionUiState,
-    clearTurnTransientState: controller.clearTurnTransientState,
+    clearTurnTransientStateIfCurrent: controller.clearTurnTransientStateIfCurrent,
   };
 }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -183,7 +183,6 @@ import {
   useAppShellNavRefSync,
   useSessionEventHealthPolling,
   useShellRunUpdates,
-  useSettledSessionTransientReconcile,
 } from './app-shell-effects';
 import {
   EMPTY_LIVE_CONTENT_SEED,
@@ -391,7 +390,6 @@ function AppShellContent({
     setSessionEventHealthBySession,
     setPendingPermissionModeBySession,
     setPendingSessionModelBySession,
-    clearTurnTransientState,
   } = useAppShellSessionWorkspace(toastApi);
   const interactionHydrationEpochRef = useRef(new Map<string, number>());
   const markInteractionChanged = useCallback((sessionId: string) => {
@@ -2600,13 +2598,6 @@ function AppShellContent({
     sessionEventHealthBySessionRef,
     setSessionEventHealthBySession,
   });
-  useSettledSessionTransientReconcile({
-    activeId,
-    sessions,
-    liveTurnBySessionRef,
-    clearTurnTransientState,
-  });
-
   function captureComposerImportOwner(): ComposerImportOwner {
     return {
       sessionId: activeIdRef.current,

--- a/apps/desktop/src/renderer/session-read-state.ts
+++ b/apps/desktop/src/renderer/session-read-state.ts
@@ -6,11 +6,13 @@ export interface SessionListRefresher<T extends SessionSummary = SessionSummary>
   refresh(): Promise<T[]>;
 }
 
-export interface SessionListRefresherOptions<T extends SessionSummary = SessionSummary> {
+export interface SessionListRefresherOptions<T extends SessionSummary, TRequestContext> {
+  /** Capture renderer-owned state before the authority read it must be compared with. */
+  captureRequestContext: () => TRequestContext;
   listSessions: () => Promise<T[]>;
   readBoundaries: () => Readonly<SessionReadBoundaries>;
   currentSessions: () => T[];
-  commitSessions: (sessions: T[]) => void;
+  commitSessions: (sessions: T[], requestContext: TRequestContext) => void;
   onError: (error: unknown) => void;
 }
 
@@ -49,8 +51,8 @@ export function applyLocalSessionRead<T extends SessionSummary>(
   return applySessionReadOverrides(sessions, boundaries);
 }
 
-export function createSessionListRefresher<T extends SessionSummary>(
-  options: SessionListRefresherOptions<T>,
+export function createSessionListRefresher<T extends SessionSummary, TRequestContext>(
+  options: SessionListRefresherOptions<T, TRequestContext>,
 ): SessionListRefresher<T> {
   let requestedGeneration = 0;
   let completedGeneration = 0;
@@ -62,11 +64,12 @@ export function createSessionListRefresher<T extends SessionSummary>(
       // Session events can arrive in bursts (especially while spawning a swarm). Keep one
       // list IPC in flight and collapse everything that arrived during it into one trailing read.
       const generation = requestedGeneration;
+      const requestContext = options.captureRequestContext();
       try {
         const listed = await options.listSessions();
         if (generation === requestedGeneration) {
           result = applySessionReadOverrides(listed, options.readBoundaries());
-          options.commitSessions(result);
+          options.commitSessions(result, requestContext);
         } else {
           result = options.currentSessions();
         }

--- a/apps/desktop/src/renderer/settled-session-transients.ts
+++ b/apps/desktop/src/renderer/settled-session-transients.ts
@@ -39,3 +39,31 @@ export function settledSessionTransientIds(options: {
     return [session.id];
   });
 }
+
+/**
+ * Reconcile one accepted authority read against the exact live projections
+ * observed before that read began. The conditional clear is a compare-and-swap:
+ * a Turn confirmed, replaced, or otherwise advanced while the read was in
+ * flight cannot be retired by that older catalog snapshot.
+ */
+export function reconcileSettledSessionTransients(options: {
+  activeId?: string;
+  sessions: readonly SessionSummary[];
+  observedLiveTurnBySession: Readonly<Record<string, LiveTurnProjection>>;
+  clearTurnTransientStateIfCurrent: (
+    sessionId: string,
+    expected: LiveTurnProjection | undefined,
+  ) => void;
+}): void {
+  const sessionIds = settledSessionTransientIds({
+    activeId: options.activeId,
+    sessions: options.sessions,
+    liveTurnBySession: options.observedLiveTurnBySession,
+  });
+  for (const sessionId of sessionIds) {
+    options.clearTurnTransientStateIfCurrent(
+      sessionId,
+      options.observedLiveTurnBySession[sessionId],
+    );
+  }
+}

--- a/apps/desktop/src/renderer/use-app-shell-session-list.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-list.ts
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import type { StoredMessage } from '@maka/core/session';
-import { useUiLocale } from '@maka/ui';
+import { type LiveTurnProjection, useUiLocale } from '@maka/ui';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import { localizedShellErrorMessage } from './locales/shell-copy.js';
 import { normalizeSessionSummaryForDisplay } from './session-status-presentation';
@@ -11,13 +11,26 @@ import {
   type SessionListRefresher,
   type SessionReadBoundaries,
 } from './session-read-state';
+import { reconcileSettledSessionTransients } from './settled-session-transients.js';
 import type { DesktopSessionSummary } from '../preload/bridge-contract.js';
 
 type ToastApi = {
   error(title: string, description?: string): void;
 };
 
-export function useAppShellSessionList(toastApi: ToastApi) {
+type RefBox<T> = { current: T };
+
+export function useAppShellSessionList(
+  toastApi: ToastApi,
+  options: {
+    activeIdRef: RefBox<string | undefined>;
+    liveTurnBySessionRef: RefBox<Record<string, LiveTurnProjection>>;
+    clearTurnTransientStateIfCurrent: (
+      sessionId: string,
+      expected: LiveTurnProjection | undefined,
+    ) => void;
+  },
+) {
   const uiLocale = useUiLocale();
   const uiLocaleRef = useRef(uiLocale);
   uiLocaleRef.current = uiLocale;
@@ -45,11 +58,18 @@ export function useAppShellSessionList(toastApi: ToastApi) {
 
   if (!refresherRef.current) {
     refresherRef.current = createSessionListRefresher({
+      captureRequestContext: () => options.liveTurnBySessionRef.current,
       listSessions: () => window.maka.sessions.list(),
       readBoundaries: () => sessionReadBoundariesRef.current,
       currentSessions: () => sessionsRef.current,
-      commitSessions: (next) => {
+      commitSessions: (next, observedLiveTurnBySession) => {
         const normalized = next.map(normalizeSessionSummaryForDisplay);
+        reconcileSettledSessionTransients({
+          activeId: options.activeIdRef.current,
+          sessions: normalized,
+          observedLiveTurnBySession,
+          clearTurnTransientStateIfCurrent: options.clearTurnTransientStateIfCurrent,
+        });
         commitSessions(normalized);
         setAuthoritativeSessionIds(new Set(normalized.map(({ id }) => id)));
       },

--- a/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-workspace.ts
@@ -15,10 +15,14 @@ type ToastApi = {
 };
 
 export function useAppShellSessionWorkspace(toastApi: ToastApi) {
-  const sessionList = useAppShellSessionList(toastApi);
-  const sessionUi = useAppShellSessionUiState();
   const [activeId, setActiveIdState] = useState<string | undefined>();
   const activeIdRef = useRef<string | undefined>(undefined);
+  const sessionUi = useAppShellSessionUiState();
+  const sessionList = useAppShellSessionList(toastApi, {
+    activeIdRef,
+    liveTurnBySessionRef: sessionUi.liveTurnBySessionRef,
+    clearTurnTransientStateIfCurrent: sessionUi.clearTurnTransientStateIfCurrent,
+  });
   const selectionRevisionRef = useRef(0);
   const bootstrapSelectionLeaseRef = useRef<ReturnType<typeof createBootstrapSelectionLease> | null>(null);
   const [messages, setMessages] = useState<StoredMessage[]>([]);
@@ -91,6 +95,5 @@ export function useAppShellSessionWorkspace(toastApi: ToastApi) {
     setPendingPermissionModeBySession: sessionUi.setPendingPermissionModeBySession,
     setPendingSessionModelBySession: sessionUi.setPendingSessionModelBySession,
     confirmLiveTurn: sessionUi.confirmLiveTurn,
-    clearTurnTransientState: sessionUi.clearTurnTransientState,
   };
 }

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -723,12 +723,10 @@ interface SessionRowSignal {
  * with unread text drew the same accent dot as one that is running. Now it
  * draws its own neutral dot and unread is still in the list behind it.
  *
- * `streaming` is the only live-run source the rail actually has. It knows only
- * about turns THIS renderer sent, which is a real limit — a task running under
- * a bot channel or a second window reads as idle here. The fix for that is a
- * live-run projection from Runtime Host, which is not in this change; there is
- * no `runningTurnIds` on a `SessionSummary` that reaches Desktop, so reading it
- * would be reading a field nothing populates.
+ * `streaming` is the live-run source the Desktop shell selected for the rail.
+ * Desktop summaries can also carry observer-projected `runningTurnIds` to keep
+ * active-turn identity across catalog refreshes, but this shared presentational
+ * component does not arbitrate those sources itself.
  */
 function sessionRowSignals(
   session: SessionSummary,


### PR DESCRIPTION
## Summary

- bind transient settlement to the accepted authoritative session-list read and the exact live projections observed before that read began
- clear only an unchanged per-session projection with an identity compare-and-swap, so a concurrent confirmation, replacement, or content advance cannot be retired by an older catalog snapshot
- merge observer-owned nonterminal root Turn identities into Desktop session-list summaries without persisting them or changing Runtime Host wire data

Fixes #3177

## Root cause

Settlement previously combined two independently versioned inputs: a React `sessions` state snapshot and whatever live-Turn projection happened to be current when an effect ran. Changing the effect phase could narrow one scheduling window, but it could not establish causality. A list result could already be queued, a `sessions:changed` notification could then confirm or replace the Turn, and React could commit the older list afterward; reconciliation would treat that older catalog state as evidence about the newer projection and clear the Stop witness.

Runtime Host-backed Desktop lists also omitted the observer's current running Turn identity, so later catalog refreshes could not preserve a live Turn when the durable header lagged or was stale.

## Design

`createSessionListRefresher` now captures renderer context immediately before each authority read and passes it only with the accepted generation. Settlement runs at that acceptance boundary, before the list enters React state. The state controller conditionally clears a projection only when it is still the same object captured for that read. Superseded responses discard both their catalog result and their context, while a trailing read captures a fresh context.

This removes the React effect and adds no persisted state, protocol field, or renderer epoch. `SessionSummary.runningTurnIds` remains an ephemeral list projection sourced from the existing Runtime Host observer.

## Verification

- compiled Desktop test suite — 904/904 passed
- focused causal reconciliation, request-context, and Runtime Host observer tests — 45/45 passed
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm --workspace @maka/desktop run build`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- independent correctness and design reviews found no actionable findings
- scoped simplification audit found no deletion candidate, deletion probe, or architecture decision gate

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex investigated the race, implemented the fix, and added regression coverage under M4n5ter's direction and review. M4n5ter accepts responsibility for the result.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
