### PR TITLE
docs(cli): document npm install and release operations

### DIFF
--- a/.github/workflows/release-cli-finalize.yml
+++ b/.github/workflows/release-cli-finalize.yml
@@ -143,6 +143,11 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Check out the current release finalizer
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
       - name: Download the verified public release
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -182,17 +187,74 @@ jobs:
           release_flags=(--latest=false)
           if [[ "$RELEASE_DIST_TAG" == "next" ]]; then
             release_flags+=(--prerelease)
-          elif [[ "$RELEASE_DIST_TAG" != "latest" ]]; then
+          elif [[ "$RELEASE_DIST_TAG" == "latest" ]]; then
+            release_flags+=(--prerelease=false)
+          else
             echo "Unsupported CLI release dist-tag: $RELEASE_DIST_TAG" >&2
             exit 1
           fi
-          gh release create "$RELEASE_TAG" \
-            "$RELEASE_DIRECTORY/$RELEASE_TARBALL_NAME" \
-            "$RELEASE_DIRECTORY/$RELEASE_TARBALL_NAME.sha256" \
-            "$RELEASE_DIRECTORY/$RELEASE_TARBALL_NAME.files.json" \
-            "$RELEASE_DIRECTORY/release.json" \
-            --repo "$GITHUB_REPOSITORY" \
-            --verify-tag \
-            "${release_flags[@]}" \
-            --title "Maka CLI $RELEASE_VERSION" \
-            --notes-file "$RELEASE_DIRECTORY/release-notes.md"
+
+          release_endpoint="repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"
+          release_json="$RUNNER_TEMP/github-release.json"
+          release_assets=(
+            "$RELEASE_DIRECTORY/$RELEASE_TARBALL_NAME"
+            "$RELEASE_DIRECTORY/$RELEASE_TARBALL_NAME.sha256"
+            "$RELEASE_DIRECTORY/$RELEASE_TARBALL_NAME.files.json"
+            "$RELEASE_DIRECTORY/release.json"
+          )
+
+          if ! gh api "$release_endpoint" > "$release_json" 2>/dev/null; then
+            if ! gh release create "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --draft \
+              "${release_flags[@]}" \
+              --title "Maka CLI $RELEASE_VERSION" \
+              --notes-file "$RELEASE_DIRECTORY/release-notes.md"; then
+              echo "GitHub Release creation did not confirm success; inspecting remote state" >&2
+            fi
+            gh api "$release_endpoint" > "$release_json"
+          fi
+
+          release_draft="$(RELEASE_JSON="$release_json" node -e '
+            const fs = require("node:fs");
+            const release = JSON.parse(fs.readFileSync(process.env.RELEASE_JSON, "utf8"));
+            if (typeof release.draft !== "boolean") throw new Error("GitHub Release draft state is invalid");
+            process.stdout.write(String(release.draft));
+          ')"
+          if [[ "$release_draft" == "true" ]]; then
+            gh release edit "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --draft=true \
+              "${release_flags[@]}" \
+              --title "Maka CLI $RELEASE_VERSION" \
+              --notes-file "$RELEASE_DIRECTORY/release-notes.md"
+            gh release upload "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --clobber \
+              "${release_assets[@]}"
+            gh release edit "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --verify-tag \
+              --draft=false \
+              "${release_flags[@]}" \
+              --title "Maka CLI $RELEASE_VERSION" \
+              --notes-file "$RELEASE_DIRECTORY/release-notes.md"
+          fi
+
+          gh api "$release_endpoint" > "$release_json"
+          node scripts/release-cli-publication.mjs validate-github-release \
+            "$RELEASE_DIRECTORY" \
+            "$release_json"
+
+          latest_json="$RUNNER_TEMP/latest-release.json"
+          if gh api "repos/$GITHUB_REPOSITORY/releases/latest" > "$latest_json" 2>/dev/null; then
+            LATEST_JSON="$latest_json" node -e '
+              const fs = require("node:fs");
+              const latest = JSON.parse(fs.readFileSync(process.env.LATEST_JSON, "utf8"));
+              if (latest.tag_name === process.env.RELEASE_TAG) {
+                throw new Error("CLI release must not become the repository GitHub Latest release");
+              }
+            '
+          fi

--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ The app distinguishes configured, send-ready, and experimental connection states
 
 ## Terminal entry points
 
+For the public npm package, see the [CLI installation and usage guide](./packages/cli/README.md).
+The commands below run the development CLI from a source checkout.
+
 Build the workspaces first:
 
 ```sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -114,6 +114,9 @@ Maka 不内置共享模型账号。第一次打开时：
 
 ## 使用终端入口
 
+公共 npm 包的安装和使用方式请查看 [CLI 中文指南](./packages/cli/README.zh-CN.md)。下面的命令
+用于从源码 checkout 运行开发版 CLI。
+
 先构建 workspace：
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,10 @@ This page is the authority map for Maka documentation. Code and contract tests r
 - [Frontend CSS governance](./frontend-css-governance.md) ([中文](./frontend-css-governance.zh-CN.md))
 - [Windows support baseline](./windows-support.md)
 
+### Release operations
+
+- [CLI npm release](./cli-npm-release.md) ([中文](./cli-npm-release.zh-CN.md))
+
 ### Security and privacy
 
 - [Workspace privacy context](./workspace-privacy-context.md)

--- a/docs/cli-npm-release.md
+++ b/docs/cli-npm-release.md
@@ -92,7 +92,8 @@ Do not approve anything on npm if the Stage workflow did not finish successfully
 
 ## Inspect and approve on npm
 
-Use npm 11.15 or newer. The repository pins the reviewed release toolchain in `packageManager`.
+Use Node.js 22.19.0 or newer and the npm version pinned in the repository's `packageManager`
+(currently npm 11.19.0). These are the reviewed release toolchain versions.
 
 ```sh
 npm stage list maka-agent --registry https://registry.npmjs.org/
@@ -176,8 +177,11 @@ The npm version is already immutable. Do not publish or approve it again. Preser
 attempt, version, and artifacts. If the package bytes and provenance are valid, fix the current
 Finalize verifier on `main` and rerun Finalize against that same successful Stage identity.
 
-If an existing `cli-v<version>` tag points anywhere other than the recorded Stage source commit,
-stop and investigate. Do not move or delete it to make the workflow pass.
+Finalize is idempotent across partial GitHub Release creation: it resumes an exact draft and accepts
+an already-published release only after verifying its metadata and asset digests. If an existing
+`cli-v<version>` tag points anywhere other than the recorded Stage source commit, or an existing
+published release differs from the verified candidate, stop and investigate. Do not move or delete
+it to make the workflow pass.
 
 ### The public version is defective
 
@@ -189,12 +193,14 @@ npm dist-tag add "maka-agent@$known_good" next
 # For a stable release incident, use latest instead of next.
 ```
 
-Then deprecate only the defective version with an actionable replacement message:
+Then deprecate only the defective version and direct users to the recovered dist-tag, which already
+points to the verified version:
 
 ```sh
 bad_version=0.1.0-beta.2
-replacement=0.1.0-beta.3
-npm deprecate "maka-agent@$bad_version" "Known issue; install maka-agent@$replacement."
+recovery_tag=next
+# For a stable release incident, use latest instead of next.
+npm deprecate "maka-agent@$bad_version" "Known issue; install maka-agent@$recovery_tag."
 ```
 
 Verify the tags, fix the defect, and release a new version through the complete Stage and Finalize

--- a/docs/cli-npm-release.md
+++ b/docs/cli-npm-release.md
@@ -1,0 +1,229 @@
+# Maka CLI npm release operations
+
+[简体中文](./cli-npm-release.zh-CN.md)
+
+This runbook is the operational authority for publishing `maka-agent`. The package version is
+independent of the Desktop release line. Every public version must come from the exact tarball
+validated by the Stage workflow.
+
+## Release invariants
+
+- Dispatch release workflows only from `main`.
+- Publish prereleases under `next` and stable versions under `latest`.
+- Use the Git tag `cli-v<version>`; CLI releases never replace the Desktop GitHub Latest release.
+- Do not run `npm publish`. GitHub Actions may only run `npm stage publish`; a human package
+  maintainer approves the staged package with npm 2FA.
+- Do not rebuild between validation, staging, approval, and finalization.
+- Never reuse a public version. Fixes require a new prerelease, patch, minor, or major version.
+
+The two workflow boundaries are:
+
+1. [Stage CLI npm release](../.github/workflows/release-cli-stage.yml) builds and validates one
+   immutable tarball, records its source identity, enters the protected `npm-release` Environment,
+   and submits it to npm staging through OIDC.
+2. [Finalize CLI npm release](../.github/workflows/release-cli-finalize.yml) accepts only the exact
+   successful Stage run and attempt, verifies the public registry bytes, signature, provenance, and
+   dist-tag, then creates the exact Git tag and a non-Latest GitHub Release.
+
+## One-time control-plane configuration
+
+### GitHub Environment
+
+Create an Environment named `npm-release` with:
+
+- `main` as the only allowed deployment branch;
+- the active CLI release maintainer as a required reviewer;
+- self-review allowed while one person is the sole release maintainer;
+- administrator bypass disabled where repository policy permits it;
+- no environment secrets or variables.
+
+Repository administration permission is required to configure the Environment. The workflow itself
+uses GitHub OIDC and does not read an npm token.
+
+### npm Trusted Publisher
+
+In the `maka-agent` package settings, configure one GitHub Actions trusted publisher:
+
+| Field | Value |
+| --- | --- |
+| Organization or user | `maka-agent` |
+| Repository | `maka-agent` |
+| Workflow filename | `release-cli-stage.yml` |
+| Environment name | `npm-release` |
+| Allowed actions | `npm stage publish` only |
+
+The workflow filename is case-sensitive and contains no `.github/workflows/` prefix. Keep
+`npm publish` disabled for this trust relationship.
+
+After the first OIDC Stage succeeds, set package publishing access to **Require two-factor
+authentication and disallow tokens**, then revoke obsolete publish tokens. Do not remove the human
+package owner or recovery access as part of that change.
+
+## Prepare a release
+
+1. Merge all intended package, documentation, and release changes to `main`.
+2. Set `packages/cli/package.json` to the unused target version and merge that change. The release
+   tool maps prerelease versions to `next` and stable versions to `latest`.
+3. Confirm the target version is absent from both public and staged package state:
+
+   ```sh
+   version=0.1.0-beta.1
+   npm view "maka-agent@$version" version --registry https://registry.npmjs.org/
+   npm stage list maka-agent --registry https://registry.npmjs.org/
+   ```
+
+   The first command should report that the target version is not present. Resolve any existing
+   stage instead of submitting the same version again.
+4. Confirm the `npm-release` Environment and Trusted Publisher still match the values above and the
+   approving npm account has 2FA enabled.
+
+## Stage the candidate
+
+1. Open **Actions → Stage CLI npm release → Run workflow**.
+2. Select `main` and enter the exact version from `packages/cli/package.json`.
+3. Wait for the reusable package validation jobs to pass. They build one tarball and validate the
+   installed CLI on Linux x64, macOS arm64, and Windows x64, plus real Harbor and Pier Docker cells
+   on Linux x64.
+4. Review and approve the `npm-release` Environment deployment.
+5. Record the successful Stage workflow run ID, run attempt, source commit, version, and staged
+   artifact checksum from the run summary and `cli-staged-release-<attempt>` artifact.
+
+Do not approve anything on npm if the Stage workflow did not finish successfully.
+
+## Inspect and approve on npm
+
+Use npm 11.15 or newer. The repository pins the reviewed release toolchain in `packageManager`.
+
+```sh
+npm stage list maka-agent --registry https://registry.npmjs.org/
+stage_id=replace-with-reviewed-stage-id
+npm stage view "$stage_id" --registry https://registry.npmjs.org/
+npm stage download "$stage_id" --registry https://registry.npmjs.org/
+```
+
+Before approval:
+
+- require the package name, version, dist-tag, provenance, and source repository to match the Stage
+  run;
+- compare the downloaded staged tarball's SHA-256 with the workflow artifact's `.tgz.sha256`;
+- inspect the file inventory and the packaged `README.md`;
+- confirm the tarball belongs to the recorded Stage run and source commit.
+
+Approve only that stage ID. npm requires 2FA and makes the package public as part of approval:
+
+```sh
+npm stage approve "$stage_id" --registry https://registry.npmjs.org/
+```
+
+The same review and approval can be performed from the package's **Staged Packages** page on
+npmjs.com.
+
+## Finalize the public release
+
+After npm reports the version as public:
+
+1. Open **Actions → Finalize CLI npm release → Run workflow** on `main`.
+2. Enter the successful Stage run ID, its exact run attempt, and the version.
+3. Let the inspection job verify the public tarball bytes, checksum, inventory, dist-tag, npm
+   signature, and Trusted Publishing provenance.
+4. Review and approve the `npm-release` Environment deployment for the Git tag and GitHub Release.
+5. Confirm the workflow created `cli-v<version>` at the Stage source commit. A prerelease must be
+   marked prerelease; no CLI release may become the repository's GitHub Latest release.
+
+Check the resulting registry state:
+
+```sh
+version=0.1.0-beta.1
+npm view "maka-agent@$version" version dist.tarball dist.integrity --json
+npm view maka-agent dist-tags --json
+```
+
+Finally, install the exact public version on each release platform and complete one real TUI/model
+turn. On the supported Eval host, complete at least one real experiment cell and inspect score,
+usage, cost, and artifacts.
+
+## Failure recovery
+
+### Before npm staging
+
+If validation or Environment approval fails before `npm stage publish`, fix the problem on `main`
+and start a new Stage run. No npm version has been consumed.
+
+### Stage workflow failed but npm contains a stage
+
+The submission is the Stage workflow's final business step, so a lost response can leave npm with a
+stage even when the workflow is not successful. Do not approve that orphan: Finalize accepts only a
+successful Stage run attempt.
+
+Inspect it, then reject the exact stage ID with 2FA before starting a new Stage run:
+
+```sh
+stage_id=replace-with-reviewed-stage-id
+npm stage view "$stage_id" --registry https://registry.npmjs.org/
+npm stage reject "$stage_id" --registry https://registry.npmjs.org/
+```
+
+Never reject a stage based only on version text; bind the action to the inspected stage ID.
+
+### Stage succeeded but review found a problem
+
+Reject the stage, fix the problem on `main`, and stage again. Do not approve a candidate merely to
+clear the staging area.
+
+### npm approval succeeded but Finalize failed
+
+The npm version is already immutable. Do not publish or approve it again. Preserve the Stage run ID,
+attempt, version, and artifacts. If the package bytes and provenance are valid, fix the current
+Finalize verifier on `main` and rerun Finalize against that same successful Stage identity.
+
+If an existing `cli-v<version>` tag points anywhere other than the recorded Stage source commit,
+stop and investigate. Do not move or delete it to make the workflow pass.
+
+### The public version is defective
+
+First move the affected dist-tag back to a previously verified version:
+
+```sh
+known_good=0.1.0-beta.1
+npm dist-tag add "maka-agent@$known_good" next
+# For a stable release incident, use latest instead of next.
+```
+
+Then deprecate only the defective version with an actionable replacement message:
+
+```sh
+bad_version=0.1.0-beta.2
+replacement=0.1.0-beta.3
+npm deprecate "maka-agent@$bad_version" "Known issue; install maka-agent@$replacement."
+```
+
+Verify the tags, fix the defect, and release a new version through the complete Stage and Finalize
+flow. Do not use `npm unpublish` as routine rollback: removing immutable dependency bytes can break
+existing installations and does not restore the reviewed release chain.
+
+## Ownership and emergency recovery
+
+- GitHub repository admins own the `npm-release` Environment configuration. The release maintainer
+  owns dispatch, Environment review, staged-package inspection, npm 2FA approval, and final
+  acceptance.
+- npm package owners own Trusted Publisher, publishing-access, maintainer, and dist-tag recovery.
+- Keep at least one 2FA-protected human owner while trusted publishing is active. Before removing the
+  current direct owner, add the intended npm organization publishing team and another direct human
+  recovery maintainer, then verify both paths.
+- The workflows must not gain a long-lived npm token. If OIDC, the Environment, or the trust
+  relationship is broken, pause releases and repair that control plane instead of bypassing staging
+  with `npm publish`.
+- If an npm account is lost, use its account recovery methods or another verified package owner.
+  Until a second owner is established, recovery depends on the current owner's npm recovery
+  credentials; treat completing that ownership follow-up as operational debt.
+- If repository or npm publisher settings change unexpectedly, remove or disable the trust
+  relationship, preserve workflow and npm audit evidence, restore the reviewed configuration, and
+  use a new version for any candidate whose integrity is uncertain.
+
+## References
+
+- [npm staged publishing](https://docs.npmjs.com/staged-publishing/)
+- [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/)
+- [npm dist-tags](https://docs.npmjs.com/cli/dist-tag/)
+- [npm deprecation](https://docs.npmjs.com/cli/v11/commands/npm-deprecate/)
+- [GitHub deployment environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)

--- a/docs/cli-npm-release.md
+++ b/docs/cli-npm-release.md
@@ -92,8 +92,7 @@ Do not approve anything on npm if the Stage workflow did not finish successfully
 
 ## Inspect and approve on npm
 
-Use Node.js 22.19.0 or newer and the npm version pinned in the repository's `packageManager`
-(currently npm 11.19.0). These are the reviewed release toolchain versions.
+Use Node.js 22.14.0 or newer and npm 11.15.0 or newer for the inspection and approval commands below. The Stage workflow uses its own reviewed toolchain: the Node.js version pinned in the workflow and the exact npm version pinned in the repository's `packageManager`.
 
 ```sh
 npm stage list maka-agent --registry https://registry.npmjs.org/

--- a/docs/cli-npm-release.zh-CN.md
+++ b/docs/cli-npm-release.zh-CN.md
@@ -1,0 +1,219 @@
+# Maka CLI npm 发布操作手册
+
+[English](./cli-npm-release.md)
+
+本文档是发布 `maka-agent` 的操作权威。CLI 包版本独立于 Desktop 发布线。每个公开版本都必须
+来自 Stage workflow 验证过的同一个精确 tarball。
+
+## 发布不变量
+
+- 只从 `main` dispatch 发布 workflow；
+- 预发布版本使用 `next`，稳定版本使用 `latest`；
+- Git tag 使用 `cli-v<version>`；CLI release 不得替换 Desktop 的 GitHub Latest release；
+- 不运行 `npm publish`。GitHub Actions 只能运行 `npm stage publish`，由人工 package
+  maintainer 使用 npm 2FA 批准 staged package；
+- validation、staging、approval 和 finalization 之间不得重新构建；
+- 已公开的版本不得复用。修复必须使用新的 prerelease、patch、minor 或 major 版本。
+
+两个 workflow 边界分别是：
+
+1. [Stage CLI npm release](../.github/workflows/release-cli-stage.yml) 构建并验证一个 immutable
+   tarball，记录其 source identity，进入受保护的 `npm-release` Environment，然后通过 OIDC
+   提交到 npm staging；
+2. [Finalize CLI npm release](../.github/workflows/release-cli-finalize.yml) 只接受精确的成功
+   Stage run 和 attempt，验证公共 registry 字节、signature、provenance 和 dist-tag，然后创建
+   精确 Git tag 和非 Latest 的 GitHub Release。
+
+## 一次性控制面配置
+
+### GitHub Environment
+
+创建名为 `npm-release` 的 Environment，并设置：
+
+- 只允许 `main` 部署；
+- 将当前 CLI 发布维护者设为 required reviewer；
+- 只有一名发布维护者期间允许 self-review；
+- 仓库策略允许时禁用 administrator bypass；
+- 不配置 environment secret 或 variable。
+
+配置 Environment 需要仓库 administration 权限。workflow 使用 GitHub OIDC，不读取 npm
+token。
+
+### npm Trusted Publisher
+
+在 `maka-agent` package settings 中配置一个 GitHub Actions trusted publisher：
+
+| 字段 | 值 |
+| --- | --- |
+| Organization or user | `maka-agent` |
+| Repository | `maka-agent` |
+| Workflow filename | `release-cli-stage.yml` |
+| Environment name | `npm-release` |
+| Allowed actions | 仅 `npm stage publish` |
+
+Workflow filename 区分大小写，并且不包含 `.github/workflows/` 前缀。这个 trust relationship
+不得启用 `npm publish`。
+
+第一次 OIDC Stage 成功后，将 package publishing access 设置为 **Require two-factor
+authentication and disallow tokens**，然后撤销不再使用的 publish token。不要在这一步移除
+人工 package owner 或恢复权限。
+
+## 准备发布
+
+1. 将本次包、文档和发布变更全部合并到 `main`；
+2. 把 `packages/cli/package.json` 更新为尚未使用的目标版本并合并。release tool 会把
+   prerelease 映射到 `next`，stable 映射到 `latest`；
+3. 确认目标版本既不在公共 registry，也不在 staged package 中：
+
+   ```sh
+   version=0.1.0-beta.1
+   npm view "maka-agent@$version" version --registry https://registry.npmjs.org/
+   npm stage list maka-agent --registry https://registry.npmjs.org/
+   ```
+
+   第一个命令应报告目标版本不存在。如果已经存在同版本 stage，先处理它，不要再次提交；
+4. 确认 `npm-release` Environment 和 Trusted Publisher 仍与上面的值一致，并确认负责批准的
+   npm 账号已经启用 2FA。
+
+## Stage 候选包
+
+1. 打开 **Actions → Stage CLI npm release → Run workflow**；
+2. 选择 `main`，输入 `packages/cli/package.json` 中的精确版本；
+3. 等待可复用 package validation jobs 全部通过。它们只构建一个 tarball，并在 Linux x64、
+   macOS arm64、Windows x64 上验证安装态 CLI，在 Linux x64 上运行真实 Harbor 和 Pier
+   Docker cell；
+4. 审查并批准 `npm-release` Environment deployment；
+5. 从 run summary 和 `cli-staged-release-<attempt>` artifact 记录成功 Stage workflow 的 run
+   ID、run attempt、source commit、version 和 staged artifact checksum。
+
+Stage workflow 没有成功结束时，不得在 npm 上批准任何内容。
+
+## 在 npm 上检查并批准
+
+使用 npm 11.15 或更高版本。仓库通过 `packageManager` 固定经过审查的 release toolchain。
+
+```sh
+npm stage list maka-agent --registry https://registry.npmjs.org/
+stage_id=replace-with-reviewed-stage-id
+npm stage view "$stage_id" --registry https://registry.npmjs.org/
+npm stage download "$stage_id" --registry https://registry.npmjs.org/
+```
+
+批准前必须：
+
+- 确认 package name、version、dist-tag、provenance 和 source repository 与 Stage run 一致；
+- 将下载的 staged tarball SHA-256 与 workflow artifact 的 `.tgz.sha256` 比较；
+- 检查文件清单和包内 `README.md`；
+- 确认 tarball 属于所记录的 Stage run 和 source commit。
+
+只批准这个 stage ID。npm 会要求 2FA，并在批准时将 package 公开：
+
+```sh
+npm stage approve "$stage_id" --registry https://registry.npmjs.org/
+```
+
+也可以在 npmjs.com package 的 **Staged Packages** 页面完成相同的检查和批准。
+
+## Finalize 公共发布
+
+npm 显示该版本已经公开后：
+
+1. 在 `main` 上打开 **Actions → Finalize CLI npm release → Run workflow**；
+2. 输入成功 Stage 的 run ID、精确 run attempt 和 version；
+3. 让 inspection job 验证公共 tarball 字节、checksum、inventory、dist-tag、npm signature 和
+   Trusted Publishing provenance；
+4. 审查并批准用于 Git tag 和 GitHub Release 的 `npm-release` Environment deployment；
+5. 确认 workflow 在 Stage source commit 上创建了 `cli-v<version>`。预发布版本必须标记为
+   prerelease；任何 CLI release 都不得成为仓库的 GitHub Latest release。
+
+检查最终 registry 状态：
+
+```sh
+version=0.1.0-beta.1
+npm view "maka-agent@$version" version dist.tarball dist.integrity --json
+npm view maka-agent dist-tags --json
+```
+
+最后，在每个发布平台安装精确的公共版本，并完成一次真实的 TUI/model turn。在支持的 Eval
+host 上完成至少一个真实 experiment cell，检查 score、usage、cost 和 artifacts。
+
+## 失败恢复
+
+### npm staging 之前失败
+
+如果 validation 或 Environment approval 在 `npm stage publish` 前失败，在 `main` 修复后启动
+新的 Stage run。此时没有消耗 npm 版本。
+
+### Stage workflow 失败，但 npm 中存在 stage
+
+提交是 Stage workflow 的最后一个业务步骤，因此响应丢失可能导致 workflow 未成功但 npm
+已经存在 stage。不要批准这个 orphan：Finalize 只接受成功的 Stage run attempt。
+
+检查后，先用 2FA 拒绝精确的 stage ID，再启动新的 Stage run：
+
+```sh
+stage_id=replace-with-reviewed-stage-id
+npm stage view "$stage_id" --registry https://registry.npmjs.org/
+npm stage reject "$stage_id" --registry https://registry.npmjs.org/
+```
+
+不要只根据 version 文本拒绝 stage；操作必须绑定到已经检查的 stage ID。
+
+### Stage 成功，但人工检查发现问题
+
+拒绝该 stage，在 `main` 修复后重新 Stage。不要为了清空 staging area 而批准有问题的候选。
+
+### npm approval 成功，但 Finalize 失败
+
+npm 版本此时已经 immutable，不要再次 publish 或 approve。保留 Stage run ID、attempt、version
+和 artifacts。如果 package 字节与 provenance 有效，在 `main` 修复当前 Finalize verifier，
+然后针对同一个成功 Stage identity 重新运行 Finalize。
+
+如果已经存在的 `cli-v<version>` 指向的不是记录的 Stage source commit，立即停止并调查。
+不要通过移动或删除 tag 让 workflow 通过。
+
+### 公共版本存在缺陷
+
+先把受影响的 dist-tag 指回先前验证过的版本：
+
+```sh
+known_good=0.1.0-beta.1
+npm dist-tag add "maka-agent@$known_good" next
+# 稳定版事故使用 latest，而不是 next。
+```
+
+然后只 deprecate 有缺陷的版本，并提供可操作的替代版本信息：
+
+```sh
+bad_version=0.1.0-beta.2
+replacement=0.1.0-beta.3
+npm deprecate "maka-agent@$bad_version" "Known issue; install maka-agent@$replacement."
+```
+
+验证 dist-tags、修复缺陷，然后通过完整 Stage 和 Finalize 流程发布新版本。不要把
+`npm unpublish` 当作常规回滚：删除 immutable dependency bytes 会破坏现有安装，也不能恢复
+经过审查的发布链。
+
+## 所有权和紧急恢复
+
+- GitHub repository admin 负责 `npm-release` Environment 配置；release maintainer 负责
+  dispatch、Environment review、staged-package 检查、npm 2FA approval 和最终验收；
+- npm package owner 负责 Trusted Publisher、publishing access、maintainer 和 dist-tag 恢复；
+- trusted publishing 启用期间，至少保留一个启用 2FA 的人工 owner。移除当前 direct owner
+  前，先加入预期的 npm organization publishing team 和另一名人工 direct recovery
+  maintainer，并验证两条恢复路径；
+- workflow 不得获得长期 npm token。OIDC、Environment 或 trust relationship 损坏时，暂停
+  发布并修复控制面，不要使用 `npm publish` 绕过 staging；
+- npm 账号丢失时，使用该账号的恢复方式或另一名已经验证的 package owner。在建立第二名
+  owner 之前，恢复依赖当前 owner 的 npm recovery credential；完成所有权 follow-up 属于
+  明确的运维债务；
+- repository 或 npm publisher 设置出现意外变更时，移除或禁用 trust relationship，保留
+  workflow 与 npm audit 证据，恢复经过审查的配置，并为 integrity 存疑的候选使用新版本。
+
+## 参考资料
+
+- [npm staged publishing](https://docs.npmjs.com/staged-publishing/)
+- [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/)
+- [npm dist-tags](https://docs.npmjs.com/cli/dist-tag/)
+- [npm deprecation](https://docs.npmjs.com/cli/v11/commands/npm-deprecate/)
+- [GitHub deployment environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)

--- a/docs/cli-npm-release.zh-CN.md
+++ b/docs/cli-npm-release.zh-CN.md
@@ -90,8 +90,7 @@ Stage workflow 没有成功结束时，不得在 npm 上批准任何内容。
 
 ## 在 npm 上检查并批准
 
-使用 Node.js 22.19.0 或更高版本，并使用仓库 `packageManager` 固定的 npm 版本
-（当前为 npm 11.19.0）。这是经过审查的 release toolchain 版本。
+执行下面的检查和审批命令需使用 Node.js 22.14.0 或更高版本和 npm 11.15.0 或更高版本。Stage workflow 使用自身经过审查的工具链：workflow 固定的 Node.js 版本，以及仓库 `packageManager` 固定的精确 npm 版本。
 
 ```sh
 npm stage list maka-agent --registry https://registry.npmjs.org/

--- a/docs/cli-npm-release.zh-CN.md
+++ b/docs/cli-npm-release.zh-CN.md
@@ -90,7 +90,8 @@ Stage workflow 没有成功结束时，不得在 npm 上批准任何内容。
 
 ## 在 npm 上检查并批准
 
-使用 npm 11.15 或更高版本。仓库通过 `packageManager` 固定经过审查的 release toolchain。
+使用 Node.js 22.19.0 或更高版本，并使用仓库 `packageManager` 固定的 npm 版本
+（当前为 npm 11.19.0）。这是经过审查的 release toolchain 版本。
 
 ```sh
 npm stage list maka-agent --registry https://registry.npmjs.org/
@@ -169,8 +170,10 @@ npm 版本此时已经 immutable，不要再次 publish 或 approve。保留 Sta
 和 artifacts。如果 package 字节与 provenance 有效，在 `main` 修复当前 Finalize verifier，
 然后针对同一个成功 Stage identity 重新运行 Finalize。
 
-如果已经存在的 `cli-v<version>` 指向的不是记录的 Stage source commit，立即停止并调查。
-不要通过移动或删除 tag 让 workflow 通过。
+Finalize 可以幂等地恢复部分完成的 GitHub Release 创建：它会继续处理精确匹配的
+draft，并且只会在验证 metadata 和 asset digest 后接受已经发布的 release。如果已经
+存在的 `cli-v<version>` 指向的不是记录的 Stage source commit，或已经发布的 release
+与验证过的 candidate 不一致，立即停止并调查。不要通过移动或删除 tag 让 workflow 通过。
 
 ### 公共版本存在缺陷
 
@@ -182,12 +185,13 @@ npm dist-tag add "maka-agent@$known_good" next
 # 稳定版事故使用 latest，而不是 next。
 ```
 
-然后只 deprecate 有缺陷的版本，并提供可操作的替代版本信息：
+然后只 deprecate 有缺陷的版本，并引导用户使用已经指向验证版本的恢复 dist-tag：
 
 ```sh
 bad_version=0.1.0-beta.2
-replacement=0.1.0-beta.3
-npm deprecate "maka-agent@$bad_version" "Known issue; install maka-agent@$replacement."
+recovery_tag=next
+# 稳定版事故使用 latest，而不是 next。
+npm deprecate "maka-agent@$bad_version" "Known issue; install maka-agent@$recovery_tag."
 ```
 
 验证 dist-tags、修复缺陷，然后通过完整 Stage 和 Finalize 流程发布新版本。不要把

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,26 +1,166 @@
 # Maka CLI
 
-Maka is a local-first agent workspace for terminal and desktop workflows. This package installs
-the interactive terminal UI and non-interactive CLI.
+[简体中文](https://github.com/maka-agent/maka-agent/blob/main/packages/cli/README.zh-CN.md)
 
-> **Beta:** the CLI is under active development. Commands and local data formats may change before
+Maka is a local-first agent workspace. The `maka-agent` npm package installs the interactive
+terminal UI, the non-interactive CLI, Runtime Host tooling, and the Eval command.
+
+> **Beta:** The CLI is under active development. Commands and local data formats may change before
 > the stable release.
+
+## Requirements
+
+- Node.js 22.19.0 or newer;
+- a terminal with interactive input for the TUI;
+- a configured model connection for agent turns; first-run setup currently supports API-key
+  providers.
+
+The release gate validates the following installed-package matrix:
+
+| Platform | Architecture | Node.js | TUI, CLI, Runtime Host | Real Harbor/Pier Eval |
+| --- | --- | --- | --- | --- |
+| Linux | x64 | 22.19 | Validated | Preflight only |
+| Linux | x64 | 24 | Validated | Validated |
+| macOS | arm64 | 24 | Validated | Preflight only |
+| Windows | x64 | 24 | Validated | Preflight only |
+
+Other combinations that satisfy the Node.js minimum may work, but are not part of the current
+release gate. Real Eval executor validation currently runs on Linux x64 with Node.js 24.
 
 ## Install
 
-```bash
+Install the current beta explicitly from the `next` dist-tag:
+
+```sh
 npm install --global maka-agent@next
+maka --version
+maka --help
+```
+
+`maka-agent` is an alias for `maka`. For a one-off invocation, use
+`npx --yes maka-agent@next`; the unrelated `maka` package on npm is not this project.
+
+## First run
+
+Start Maka from the project directory the agent should work in:
+
+```sh
+cd path/to/project
 maka
 ```
 
-`maka-agent` is an alias for `maka`. Node.js 22.19.0 or newer is required.
+If no model connection exists, Maka opens the provider setup flow. Select a provider, enter its API
+key, choose the enabled models, and save. Run `/setup` later to add or update a provider and `/model`
+to switch models.
 
-Use `maka --help` for the supported command surface. `maka eval` additionally requires the
-executor environment declared by the selected experiment, such as Docker and Harbor or Pier; the
-npm package includes Maka's Eval runtime but does not install those external systems.
+API keys and workspace state stay in the local `Maka` profile. The current credential vault is a
+local plaintext file protected by the operating-system account boundary; on POSIX systems Maka
+enforces owner-only directory and file modes. It is not an OS keychain. See the repository
+[security policy](https://github.com/maka-agent/maka-agent/blob/main/SECURITY.md) for the current
+boundary.
+
+Run one non-interactive turn with:
+
+```sh
+maka run "Summarize this project and identify its highest-risk area"
+maka run --help
+```
+
+Maka asks before privileged tool operations by default. `maka run --yolo` grants the task full file
+and network access and should only be used in an environment you are prepared to let the task
+modify.
+
+## Upgrade
+
+While using prereleases, keep the `next` tag explicit:
+
+```sh
+npm install --global maka-agent@next
+maka --version
+```
+
+Do not use a bare `npm update --global maka-agent` for beta upgrades: global npm updates follow the
+`latest` tag and may select a different release line. After a stable release is available, install it
+with `npm install --global maka-agent@latest`.
+
+## Uninstall
+
+```sh
+npm uninstall --global maka-agent
+```
+
+Uninstalling the package does not delete model connections, credentials, sessions, or artifacts.
+Those remain in the profile shared by the released CLI and Desktop app:
+
+| Platform | Profile directory |
+| --- | --- |
+| macOS | `~/Library/Application Support/Maka` |
+| Linux | `$XDG_CONFIG_HOME/Maka`, or `~/.config/Maka` when unset |
+| Windows | `%APPDATA%\Maka` |
+
+Back up and remove that directory separately only when you intend to delete all local Maka data.
+Close the CLI and Desktop app first.
+
+## Eval
+
+Run a declarative experiment with:
+
+```sh
+maka eval run experiment.json --out .maka-eval/run-001
+```
+
+The npm package includes Maka's Eval runtime, relay, wrapper, and container policy assets. It does
+not install the executor's external software or machine-local benchmark data. Before starting any
+trial, Eval checks the exact prerequisites declared by the spec and fails without running a cell if
+one is missing.
+
+For Docker-based Harbor or Pier specs, provide:
+
+- a reachable Docker CLI and daemon;
+- a dedicated Python environment containing the exact framework version declared by
+  `executor.config.frameworkVersion`;
+- an executable interpreter through the environment variable named by `pythonPathEnv`;
+- writable trial storage through `trialsRootEnv`;
+- for Pier, the task directory named by `tasksRootEnv`;
+- every machine path and subject credential environment variable declared by the spec.
+
+Harbor and Pier must use separate Python environments. The currently validated versions are:
+
+```sh
+python3.12 -m venv ~/.venvs/maka-harbor-0.20.0
+~/.venvs/maka-harbor-0.20.0/bin/python -m pip install 'harbor==0.20.0'
+
+python3.12 -m venv ~/.venvs/maka-pier-0.3.0
+~/.venvs/maka-pier-0.3.0/bin/python -m pip install 'datacurve-pier==0.3.0'
+```
+
+Set the spec's `pythonPathEnv` to the corresponding `bin/python` path. Do not reuse one environment
+for both frameworks: their dependency and trial contracts differ. Advanced experiment and
+toolchain details live in the
+[Eval documentation](https://github.com/maka-agent/maka-agent/tree/main/packages/eval).
+
+## Troubleshooting
+
+Start by recording the installed versions:
+
+```sh
+node --version
+npm --version
+maka --version
+```
+
+- If `maka` is not found after a global install, ensure npm's global executable directory is on
+  `PATH`.
+- If no model is available, start the TUI and run `/setup`.
+- If Eval refuses to start, follow the reported environment-variable name and expected framework
+  version; it does not install or silently substitute missing prerequisites.
+- When reporting a problem, include the three versions above, the operating system and
+  architecture, the command, and the complete error with credentials removed.
+
+Report issues at <https://github.com/maka-agent/maka-agent/issues>.
 
 ## Links
 
 - [Repository](https://github.com/maka-agent/maka-agent)
-- [Issues](https://github.com/maka-agent/maka-agent/issues)
+- [Release operations](https://github.com/maka-agent/maka-agent/blob/main/docs/cli-npm-release.md)
 - [License](https://github.com/maka-agent/maka-agent/blob/main/LICENSE)

--- a/packages/cli/README.zh-CN.md
+++ b/packages/cli/README.zh-CN.md
@@ -1,0 +1,157 @@
+# Maka CLI
+
+[English](./README.md)
+
+Maka 是一个本地优先的 Agent 工作空间。`maka-agent` npm 包包含交互式终端界面、非交互
+CLI、Runtime Host 工具和 Eval 命令。
+
+> **Beta：**CLI 仍在积极开发中，稳定版发布前，命令和本地数据格式可能发生变化。
+
+## 环境要求
+
+- Node.js 22.19.0 或更高版本；
+- 使用 TUI 时需要支持交互输入的终端；
+- 执行 Agent Turn 时需要已经配置的模型连接；首次设置目前支持使用 API Key 的供应商。
+
+发布门禁会验证以下安装态矩阵：
+
+| 平台 | 架构 | Node.js | TUI、CLI、Runtime Host | 真实 Harbor/Pier Eval |
+| --- | --- | --- | --- | --- |
+| Linux | x64 | 22.19 | 已验证 | 仅验证 preflight |
+| Linux | x64 | 24 | 已验证 | 已验证 |
+| macOS | arm64 | 24 | 已验证 | 仅验证 preflight |
+| Windows | x64 | 24 | 已验证 | 仅验证 preflight |
+
+满足 Node.js 最低版本的其他组合也可能可用，但不属于当前发布门禁。真实 Eval executor
+目前只在 Linux x64 和 Node.js 24 上验证。
+
+## 安装
+
+Beta 阶段请明确从 `next` dist-tag 安装：
+
+```sh
+npm install --global maka-agent@next
+maka --version
+maka --help
+```
+
+`maka-agent` 是 `maka` 的别名。一次性运行请使用 `npx --yes maka-agent@next`；npm 上与本项目
+无关的 `maka` 包不是本项目。
+
+## 第一次运行
+
+进入希望 Agent 工作的项目目录，然后启动 Maka：
+
+```sh
+cd path/to/project
+maka
+```
+
+如果还没有模型连接，Maka 会自动打开供应商设置流程。选择供应商、输入 API Key、选择要
+启用的模型并保存。之后可以运行 `/setup` 添加或更新供应商，使用 `/model` 切换模型。
+
+API Key 和工作空间状态保存在本机的 `Maka` profile 中。当前 credential vault 是受操作系统
+账号边界保护的本地明文文件；在 POSIX 系统上，Maka 会强制使用仅 owner 可访问的目录和文件
+权限。它不是操作系统 Keychain。当前边界详见仓库的
+[安全策略](https://github.com/maka-agent/maka-agent/blob/main/SECURITY.md)。
+
+执行一次非交互 Turn：
+
+```sh
+maka run "总结这个项目并指出风险最高的部分"
+maka run --help
+```
+
+Maka 默认会在执行高权限工具操作前询问。`maka run --yolo` 会授予该任务完整的文件和网络
+权限，只应在你允许任务修改的环境中使用。
+
+## 升级
+
+使用预发布版本时，请继续明确指定 `next`：
+
+```sh
+npm install --global maka-agent@next
+maka --version
+```
+
+Beta 升级不要使用不带 tag 的 `npm update --global maka-agent`：npm 的全局更新会跟随
+`latest`，可能选中不同的发布线。稳定版发布后，使用
+`npm install --global maka-agent@latest` 安装。
+
+## 卸载
+
+```sh
+npm uninstall --global maka-agent
+```
+
+卸载 npm 包不会删除模型连接、凭证、会话或 Artifact。它们仍保留在发布版 CLI 与 Desktop
+共用的 profile 中：
+
+| 平台 | Profile 目录 |
+| --- | --- |
+| macOS | `~/Library/Application Support/Maka` |
+| Linux | `$XDG_CONFIG_HOME/Maka`；未设置时为 `~/.config/Maka` |
+| Windows | `%APPDATA%\Maka` |
+
+只有在确实要删除全部本地 Maka 数据时，才应单独备份并删除该目录。操作前先关闭 CLI 和
+Desktop 应用。
+
+## Eval
+
+运行声明式实验：
+
+```sh
+maka eval run experiment.json --out .maka-eval/run-001
+```
+
+npm 包包含 Maka 自有的 Eval runtime、relay、wrapper 和容器策略资源，但不会安装 executor
+所需的外部软件或机器本地 benchmark 数据。Eval 会在启动任何 trial 前检查 spec 声明的精确
+前置条件；缺少任意一项时会在不运行 cell 的情况下失败。
+
+运行基于 Docker 的 Harbor 或 Pier spec 时，需要提供：
+
+- 可访问的 Docker CLI 和 daemon；
+- 包含 `executor.config.frameworkVersion` 所声明精确版本的独立 Python 环境；
+- 通过 `pythonPathEnv` 所命名的环境变量提供可执行的解释器；
+- 通过 `trialsRootEnv` 提供可写的 trial 目录；
+- Pier 还需要通过 `tasksRootEnv` 提供 task 目录；
+- spec 声明的所有机器路径和 subject 凭证环境变量。
+
+Harbor 和 Pier 必须使用不同的 Python 环境。当前验证过的版本为：
+
+```sh
+python3.12 -m venv ~/.venvs/maka-harbor-0.20.0
+~/.venvs/maka-harbor-0.20.0/bin/python -m pip install 'harbor==0.20.0'
+
+python3.12 -m venv ~/.venvs/maka-pier-0.3.0
+~/.venvs/maka-pier-0.3.0/bin/python -m pip install 'datacurve-pier==0.3.0'
+```
+
+把 spec 的 `pythonPathEnv` 指向相应的 `bin/python`。不要让两个 framework 复用一个环境：
+它们的依赖和 trial contract 不同。高级实验和 toolchain 说明位于
+[Eval 文档](https://github.com/maka-agent/maka-agent/tree/main/packages/eval)。
+
+## 故障排查
+
+先记录实际安装版本：
+
+```sh
+node --version
+npm --version
+maka --version
+```
+
+- 全局安装后找不到 `maka` 时，确认 npm 的全局可执行目录已经加入 `PATH`；
+- 没有可用模型时，启动 TUI 并运行 `/setup`；
+- Eval 拒绝启动时，根据错误中给出的环境变量名和预期 framework 版本修复环境；Eval 不会
+  自动安装或静默替换缺失的前置条件；
+- 报告问题时，请提供以上三个版本、操作系统和架构、执行的命令，以及移除凭证后的完整
+  错误信息。
+
+请在 <https://github.com/maka-agent/maka-agent/issues> 报告问题。
+
+## 链接
+
+- [代码仓库](https://github.com/maka-agent/maka-agent)
+- [发布操作手册](https://github.com/maka-agent/maka-agent/blob/main/docs/cli-npm-release.zh-CN.md)
+- [许可证](https://github.com/maka-agent/maka-agent/blob/main/LICENSE)

--- a/scripts/release-cli-package.mjs
+++ b/scripts/release-cli-package.mjs
@@ -443,6 +443,7 @@ function copyEvalMirror() {
 
 function copyReleaseDocuments() {
   copyFileSync(join(cliSource, 'README.md'), join(stageRoot, 'README.md'));
+  copyFileSync(join(cliSource, 'README.zh-CN.md'), join(stageRoot, 'README.zh-CN.md'));
   copyFileSync(join(repoRoot, 'LICENSE'), join(stageRoot, 'LICENSE'));
   copyFileSync(join(repoRoot, 'NOTICE'), join(stageRoot, 'NOTICE'));
   copyFileSync(
@@ -489,7 +490,15 @@ function writeReleaseManifest(cli, publishable) {
           registry: 'http://127.0.0.1:9/',
           tag: 'development',
         },
-    files: ['dist', 'packages/eval', 'README.md', 'LICENSE', 'NOTICE', 'THIRD_PARTY_NOTICES.txt'],
+    files: [
+      'dist',
+      'packages/eval',
+      'README.md',
+      'README.zh-CN.md',
+      'LICENSE',
+      'NOTICE',
+      'THIRD_PARTY_NOTICES.txt',
+    ],
     dependencies,
     bundledDependencies: Object.keys(dependencies).sort(),
     ...(!publishable ? { private: true } : {}),
@@ -500,6 +509,7 @@ function writeReleaseManifest(cli, publishable) {
 function validateStaging() {
   const required = [
     'dist/cli.js',
+    'README.zh-CN.md',
     'node_modules/@maka/runtime/dist/workers/filesystem-worker.js',
     'node_modules/@maka/runtime-host/dist/execution-candidate-main.js',
     'packages/eval/dist/harbor-external-subject.js',

--- a/scripts/release-cli-publication.mjs
+++ b/scripts/release-cli-publication.mjs
@@ -184,6 +184,37 @@ export function validateSignatureAudit({ releaseDirectory, audit }) {
   return record;
 }
 
+export function validateGitHubRelease({ releaseDirectory, release }) {
+  const record = loadReleaseRecord(releaseDirectory);
+  const expectedAssets = [record.tarball, record.checksum, record.inventory, 'release.json'];
+  const expectedPrerelease = record.distTag === 'next';
+  if (
+    release?.tag_name !== record.gitTag ||
+    release.name !== `Maka CLI ${record.version}` ||
+    release.body !== readFileSync(join(releaseDirectory, 'release-notes.md'), 'utf8') ||
+    release.draft !== false ||
+    release.prerelease !== expectedPrerelease ||
+    !Array.isArray(release.assets) ||
+    release.assets.length !== expectedAssets.length
+  ) {
+    throw new Error('GitHub Release metadata does not match the verified CLI release');
+  }
+
+  const assets = new Map(release.assets.map((asset) => [asset?.name, asset]));
+  for (const name of expectedAssets) {
+    const bytes = readFileSync(join(releaseDirectory, name));
+    const asset = assets.get(name);
+    if (
+      asset?.state !== 'uploaded' ||
+      asset.size !== bytes.length ||
+      asset.digest !== `sha256:${digest('sha256', bytes, 'hex')}`
+    ) {
+      throw new Error(`GitHub Release asset does not match the verified file: ${name}`);
+    }
+  }
+  return record;
+}
+
 export function prepareSignatureAuditTree({ releaseDirectory, auditDirectory }) {
   const record = loadReleaseRecord(releaseDirectory);
   const packageDirectory = join(auditDirectory, 'node_modules', PACKAGE_NAME);
@@ -448,8 +479,16 @@ async function main() {
     });
     return;
   }
+  if (command === 'validate-github-release' && args.length === 2) {
+    const [releaseDirectory, releasePath] = args;
+    validateGitHubRelease({
+      releaseDirectory: resolve(releaseDirectory),
+      release: readJson(resolve(releasePath), 'GitHub Release'),
+    });
+    return;
+  }
   throw new Error(
-    `Usage: release-cli-publication.mjs <prepare-stage|prepare-audit|validate-stage-run|fetch-registry|validate-audit> ...`,
+    `Usage: release-cli-publication.mjs <prepare-stage|prepare-audit|validate-stage-run|fetch-registry|validate-audit|validate-github-release> ...`,
   );
 }
 

--- a/scripts/release-cli-publication.test.mjs
+++ b/scripts/release-cli-publication.test.mjs
@@ -10,6 +10,7 @@ import {
   parseCliReleaseVersion,
   prepareSignatureAuditTree,
   prepareStageRelease,
+  validateGitHubRelease,
   validateSignatureAudit,
   validateStageRun,
 } from './release-cli-publication.mjs';
@@ -247,6 +248,42 @@ test('signature audit tree exposes only the top-level registry package', () => {
   );
 });
 
+test('GitHub finalization accepts only the exact published metadata and asset digests', async () => {
+  const fixture = createPreparedCandidate();
+  const registryDirectory = mkdtempSync(join(tmpdir(), 'maka-cli-github-release-'));
+  await fetchRegistryRelease({
+    releaseDirectory: fixture.releaseDirectory,
+    registryDirectory,
+    fetchImpl: registryFetch({ fixture }),
+  });
+  const release = createGitHubReleaseFixture(fixture, registryDirectory);
+
+  assert.doesNotThrow(() =>
+    validateGitHubRelease({ releaseDirectory: registryDirectory, release }),
+  );
+  assert.throws(
+    () =>
+      validateGitHubRelease({
+        releaseDirectory: registryDirectory,
+        release: { ...release, draft: true },
+      }),
+    /metadata does not match/u,
+  );
+  assert.throws(
+    () =>
+      validateGitHubRelease({
+        releaseDirectory: registryDirectory,
+        release: {
+          ...release,
+          assets: release.assets.map((asset, index) =>
+            index === 0 ? { ...asset, digest: `sha256:${'0'.repeat(64)}` } : asset,
+          ),
+        },
+      }),
+    /asset does not match/u,
+  );
+});
+
 test('prepare-stage CLI emits only consumed GitHub Actions outputs', () => {
   const fixture = createCandidate();
   const output = join(fixture.root, 'github-output.txt');
@@ -370,6 +407,31 @@ function registryFetch({ fixture, bytes = fixture.bytes }) {
     }
     if (url === tarballUrl) return new Response(bytes);
     return new Response('not found', { status: 404 });
+  };
+}
+
+function createGitHubReleaseFixture(fixture, releaseDirectory) {
+  const names = [
+    fixture.tarball,
+    `${fixture.tarball}.sha256`,
+    `${fixture.tarball}.files.json`,
+    'release.json',
+  ];
+  return {
+    tag_name: `cli-v${fixture.version}`,
+    name: `Maka CLI ${fixture.version}`,
+    body: readFileSync(join(releaseDirectory, 'release-notes.md'), 'utf8'),
+    draft: false,
+    prerelease: true,
+    assets: names.map((name) => {
+      const bytes = readFileSync(join(releaseDirectory, name));
+      return {
+        name,
+        state: 'uploaded',
+        size: bytes.length,
+        digest: `sha256:${digest('sha256', bytes, 'hex')}`,
+      };
+    }),
   };
 }
 

--- a/scripts/release-cli-workflow-policy.test.mjs
+++ b/scripts/release-cli-workflow-policy.test.mjs
@@ -67,7 +67,7 @@ test('finalize validates one exact stage attempt before running the current veri
   assert.doesNotMatch(checkout, /steps\.stage-run\.outputs\.source_sha/u);
 });
 
-test('finalize propagates verified artifacts and creates a non-latest exact-tag release', () => {
+test('finalize propagates verified artifacts and idempotently publishes an exact-tag release', () => {
   const workflow = readWorkflow('release-cli-finalize.yml');
   assert.match(
     workflow,
@@ -81,9 +81,15 @@ test('finalize propagates verified artifacts and creates a non-latest exact-tag 
     /artifact-ids: \$\{\{ needs\.inspect\.outputs\.public_release_artifact_id \}\}/u,
   );
   assert.match(publish, /--verify-tag/u);
+  assert.match(publish, /gh release create[\s\S]*?--draft/u);
+  assert.match(publish, /gh release upload[\s\S]*?--clobber/u);
+  assert.match(publish, /gh release edit[\s\S]*?--draft=false/u);
   assert.match(publish, /--prerelease/u);
   assert.match(publish, /--latest=false/u);
-  assert.doesNotMatch(publish, /actions\/checkout@/u);
+  assert.match(publish, /validate-github-release/u);
+  const checkout = namedStep(workflowSteps(publish), 'Check out the current release finalizer');
+  assert.match(checkout, /ref: \$\{\{ github\.sha \}\}/u);
+  assert.match(checkout, /persist-credentials: false/u);
 });
 
 test('release workflows select npm from the root packageManager authority', () => {


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

- Document npm installation, first-run provider setup, upgrades, uninstall behavior, local data, the validated platform matrix, and Eval prerequisites.
- Add the maintainer runbook for protected staging, npm 2FA approval, finalization, failure recovery, dist-tag rollback, and ownership recovery.
- Provide matching Simplified Chinese guides and ship the versioned Chinese CLI guide in the npm tarball.

Refs #3166

</details>

<details>
<summary>简体中文</summary>

- 补全 npm 安装、首次供应商配置、升级、卸载、本地数据、已验证平台矩阵和 Eval 前置条件说明。
- 增加受保护 Stage、npm 2FA 审批、Finalize、失败恢复、dist-tag 回滚和所有权恢复手册。
- 提供对应的简体中文文档，并将版本匹配的 CLI 中文指南收入 npm tarball。

关联 #3166

</details>

## Verification

<details open>
<summary>English</summary>

- `npx --yes npm@11.19.0 run rebuild`
- `npx --yes npm@11.19.0 run check:release`
- `npx --yes npm@11.19.0 run release:cli:pack`
- `npx --yes npm@11.19.0 run release:cli:smoke`
- Verified both packaged READMEs are byte-identical to their source documents and checked all changed relative Markdown links.

</details>

<details>
<summary>简体中文</summary>

- 完整构建、release 检查、clean-tree CLI pack 和安装态 smoke 均通过。
- 已确认 tarball 内的中英文 README 与源码逐字节一致，并检查了所有变更文档的相对链接。

</details>

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex drafted the bilingual documentation, updated the release document whitelist, and ran the reported validation.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
