### PR TITLE
feat(goal): let the user arm a Goal from the composer

### DIFF
--- a/apps/desktop/e2e/goal-dialog-budget.spec.ts
+++ b/apps/desktop/e2e/goal-dialog-budget.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect, COMPOSER_INPUT } from './fixtures';
+
+/**
+ * Arming a Goal starts unattended token spending, and the two budgets in this
+ * dialog are what stops it. A budget the form shows but does not send is
+ * therefore the one failure this dialog must not have — most sharply when the
+ * value is dropped rather than altered, because an absent token budget is not
+ * a smaller ceiling but no ceiling at all.
+ *
+ * The assertions read the Goal back from the Host rather than watching the
+ * bridge call, so they answer what was actually armed.
+ */
+test('an unsendable budget blocks Start instead of arming a different one', async ({
+  window: page,
+}) => {
+  // The ＋ menu only offers a Goal for a Session that exists, so seed one and
+  // let its Turn settle first — a live Turn disables the entry too.
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('seed session');
+  await composer.press('Enter');
+  await expect(page.getByRole('log').getByText(/Fake backend received: seed session/)).toBeVisible();
+  await expect(page.getByRole('button', { name: '重新生成' })).toHaveCount(1, { timeout: 20_000 });
+
+  const sessionId = await page.evaluate(async () => (await window.maka.sessions.list())[0]?.id);
+  expect(sessionId).toBeTruthy();
+  const armedGoal = () =>
+    page.evaluate(async (id: string) => await window.maka.goal.get(id), sessionId as string);
+
+  await page.getByRole('button', { name: '添加上下文' }).click();
+  await page.getByRole('menuitem', { name: '设定 Goal…' }).click();
+
+  const dialog = page.getByRole('dialog');
+  await dialog.getByLabel(/达成条件/).fill('所有测试通过');
+  const start = dialog.getByRole('button', { name: '开始' });
+  await expect(start).toBeEnabled();
+
+  // Below the Host's own minimum. The field this replaced kept such text to
+  // itself and left the sent budget null, so Start stayed enabled and armed no
+  // ceiling at all.
+  await dialog.getByLabel(/Token 预算/).fill('500');
+  await expect(start).toBeDisabled();
+  await expect(dialog.getByText(/请填不小于 1000 的整数/)).toBeVisible();
+
+  await dialog.getByLabel(/Token 预算/).fill('5000');
+  await expect(start).toBeEnabled();
+
+  // Above the Host's ceiling on turns; the same rule from the other side.
+  await dialog.getByLabel(/最多轮数/).fill('250');
+  await expect(start).toBeDisabled();
+  await expect(await armedGoal()).toBeNull();
+
+  await dialog.getByLabel(/最多轮数/).fill('25');
+  await expect(start).toBeEnabled();
+  await start.click();
+
+  await expect
+    .poll(async () => {
+      const goal = await armedGoal();
+      return goal && {
+        condition: goal.condition,
+        maxIterations: goal.maxIterations,
+        tokenBudget: goal.tokenBudget,
+      };
+    })
+    .toEqual({ condition: '所有测试通过', maxIterations: 25, tokenBudget: 5000 });
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-client-operations.test.ts
@@ -754,6 +754,52 @@ test('controlGoalWithRetry rethrows a status refusal instead of retrying it away
   );
 });
 
+test('arms a Goal in one request and reports a conflicting Goal instead of retrying', async () => {
+  const armed = goalProjection(0);
+  const { client, requests } = clientWithResponses([
+    { sessionId: 'session-1', goal: armed },
+  ]);
+
+  const result = await client.armGoal({
+    sessionId: 'session-1',
+    condition: 'All tests pass',
+    maxIterations: 20,
+    tokenBudget: null,
+  });
+
+  assert.deepEqual(result, { sessionId: 'session-1', goal: armed });
+  assert.deepEqual(
+    requests.filter(({ operation }) => operation === 'goal.arm').map(({ input }) => input),
+    [
+      {
+        sessionId: 'session-1',
+        condition: 'All tests pass',
+        maxIterations: 20,
+        tokenBudget: null,
+      },
+    ],
+  );
+
+  // Arming names no revision, so a conflict is an answer for the user — the
+  // Session already has a Goal — not a stale read to refresh and re-send.
+  const conflicted = clientWithResponses([
+    new RuntimeHostOperationError('goal.arm', 'operation_conflict', 'Goal already set'),
+  ]);
+  await assert.rejects(
+    conflicted.client.armGoal({
+      sessionId: 'session-1',
+      condition: 'All tests pass',
+      maxIterations: null,
+      tokenBudget: null,
+    }),
+    /Goal already set/,
+  );
+  assert.equal(
+    conflicted.requests.filter(({ operation }) => operation === 'goal.arm').length,
+    1,
+  );
+});
+
 test('rejects an invalid sidecar continuation without misclassifying it as revision churn', async () => {
   const revision = catalogRevision('7');
   const { client, requests } = clientWithResponses([

--- a/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
@@ -17,7 +17,7 @@ import {
 
 type DomainClient = RuntimeHostSessionDomainsIpcDeps['client'];
 
-test('goal:arm takes the Session from the scoped channel, not the renderer frame', async () => {
+test('goal:arm takes the Session from the scoped channel and refuses any other key', async () => {
   const armed: unknown[] = [];
   const client = domainClient({
     armGoal: async (input) => {
@@ -29,8 +29,6 @@ test('goal:arm takes the Session from the scoped channel, not the renderer frame
   registerDomainsIpc({ client, emitModeChanged() {} }, ipc);
 
   const goal = await ipc.invoke('goal:arm', 'session-1', {
-    // A renderer-side Session id in the frame must not redirect the operation.
-    sessionId: 'session-somewhere-else',
     condition: 'Finish the adapter',
     maxIterations: 20,
     tokenBudget: 1_000,
@@ -59,6 +57,23 @@ test('goal:arm takes the Session from the scoped channel, not the renderer frame
     ipc.invoke('goal:arm', 'session-1', { condition: 'Finish', maxIterations: 0 }),
   );
   await assert.rejects(ipc.invoke('goal:arm', 'session-1', 'not-an-object'));
+
+  // Any key this frame does not carry is a caller mistake. Dropping it would
+  // send the Host a frame the caller did not write, so it is refused instead.
+  await assert.rejects(
+    ipc.invoke('goal:arm', 'session-1', { condition: 'Finish', blockCap: 5 }),
+    /Invalid Goal arm input/,
+  );
+  // The Session is one of those keys: it comes from the scoped channel, so a
+  // renderer-side Session id cannot redirect the operation even by matching.
+  await assert.rejects(
+    ipc.invoke('goal:arm', 'session-1', {
+      sessionId: 'session-somewhere-else',
+      condition: 'Finish',
+    }),
+    /Invalid Goal arm input/,
+  );
+  assert.equal(armed.length, 2);
 });
 
 test('adapts Host Goal, Task, Deep Research, and Resource projections', async () => {

--- a/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-domains-ipc-main.test.ts
@@ -17,6 +17,50 @@ import {
 
 type DomainClient = RuntimeHostSessionDomainsIpcDeps['client'];
 
+test('goal:arm takes the Session from the scoped channel, not the renderer frame', async () => {
+  const armed: unknown[] = [];
+  const client = domainClient({
+    armGoal: async (input) => {
+      armed.push(input);
+      return { sessionId: input.sessionId, goal: goalProjection() };
+    },
+  });
+  const ipc = ipcHarness();
+  registerDomainsIpc({ client, emitModeChanged() {} }, ipc);
+
+  const goal = await ipc.invoke('goal:arm', 'session-1', {
+    // A renderer-side Session id in the frame must not redirect the operation.
+    sessionId: 'session-somewhere-else',
+    condition: 'Finish the adapter',
+    maxIterations: 20,
+    tokenBudget: 1_000,
+  });
+  assert.deepEqual(armed, [
+    {
+      sessionId: 'session-1',
+      condition: 'Finish the adapter',
+      maxIterations: 20,
+      tokenBudget: 1_000,
+    },
+  ]);
+  assert.equal((goal as { id: string }).id, 'goal-1');
+
+  // Omitted budgets are "not chosen", which the Host reads as its defaults.
+  await ipc.invoke('goal:arm', 'session-1', { condition: 'Finish the adapter' });
+  assert.deepEqual(armed[1], {
+    sessionId: 'session-1',
+    condition: 'Finish the adapter',
+    maxIterations: null,
+    tokenBudget: null,
+  });
+
+  await assert.rejects(ipc.invoke('goal:arm', 'session-1', { condition: '   ' }));
+  await assert.rejects(
+    ipc.invoke('goal:arm', 'session-1', { condition: 'Finish', maxIterations: 0 }),
+  );
+  await assert.rejects(ipc.invoke('goal:arm', 'session-1', 'not-an-object'));
+});
+
 test('adapts Host Goal, Task, Deep Research, and Resource projections', async () => {
   const controls: unknown[] = [];
   const client = domainClient({
@@ -720,6 +764,7 @@ function domainClient(overrides: Partial<DomainClient>): DomainClient {
     throw new Error('Unexpected domain operation');
   };
   return {
+    armGoal: unavailable,
     clearGoal: unavailable,
     acquireRuntimeResourceController: unavailable,
     controlPlan: unavailable,

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1189,12 +1189,7 @@ export class DesktopRuntimeHostClient {
    * that already has an unfinished Goal fails with `operation_conflict`, and
    * that is an answer for the user, not a race to re-run.
    */
-  armGoal(input: {
-    sessionId: string;
-    condition: string;
-    maxIterations: number | null;
-    tokenBudget: number | null;
-  }): Promise<OperationOutput<"goal.arm">> {
+  armGoal(input: OperationInput<"goal.arm">): Promise<OperationOutput<"goal.arm">> {
     return this.request("goal.arm", input);
   }
 

--- a/apps/desktop/src/main/runtime-host-client.ts
+++ b/apps/desktop/src/main/runtime-host-client.ts
@@ -1183,6 +1183,21 @@ export class DesktopRuntimeHostClient {
     return this.request("goal.query", { sessionId });
   }
 
+  /**
+   * Arm a Goal the user asked for. No optimistic retry loop like `clearGoal`:
+   * arming names no revision, so there is no stale one to refresh — a Session
+   * that already has an unfinished Goal fails with `operation_conflict`, and
+   * that is an answer for the user, not a race to re-run.
+   */
+  armGoal(input: {
+    sessionId: string;
+    condition: string;
+    maxIterations: number | null;
+    tokenBudget: number | null;
+  }): Promise<OperationOutput<"goal.arm">> {
+    return this.request("goal.arm", input);
+  }
+
   controlGoal(
     goal: Pick<GoalProjection, "sessionId" | "goalId" | "revision">,
     action: GoalControlAction,

--- a/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
@@ -27,6 +27,7 @@ import {
 type RuntimeHostSessionDomainClient = RuntimeHostShellRunsClient &
   Pick<
     DesktopRuntimeHostClient,
+    | 'armGoal'
     | 'clearGoal'
   | 'controlGoalWithRetry'
   | 'controlPlan'
@@ -99,6 +100,13 @@ export function registerRuntimeHostSessionDomainsIpc(
   });
   ipcMain.handle('goal:resume', async (_event, sessionId: unknown) => {
     await deps.client.controlGoalWithRetry(requiredId(sessionId, 'Session'), 'resume');
+  });
+  ipcMain.handle('goal:arm', async (_event, sessionId: unknown, input: unknown) => {
+    const result = await deps.client.armGoal({
+      sessionId: requiredId(sessionId, 'Session'),
+      ...requireGoalArmBudgets(input),
+    });
+    return toDesktopGoal(result.goal);
   });
 
   handleReconnectableRead(ipcMain, 'plan-mode:getState', (_event, sessionId: unknown) =>
@@ -300,6 +308,41 @@ async function refreshRuntimeResources(
       deps.onError?.(error);
     }
   }
+}
+
+/**
+ * The renderer sends what the user typed; the Host owns every bound. This only
+ * gets the frame into the shape the protocol decodes — numbers stay numbers,
+ * "not chosen" stays null — so an out-of-range budget is refused once, by the
+ * Host, instead of being clamped here into something the user did not ask for.
+ * The Session comes from the scoped IPC argument, not from this frame, so a
+ * renderer-side Session id can never redirect the operation.
+ */
+function requireGoalArmBudgets(value: unknown): {
+  condition: string;
+  maxIterations: number | null;
+  tokenBudget: number | null;
+} {
+  if (typeof value !== 'object' || value === null) {
+    throw new TypeError('Goal arm input must be an object');
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.condition !== 'string' || record.condition.trim().length === 0) {
+    throw new TypeError('Goal condition is required');
+  }
+  return {
+    condition: record.condition,
+    maxIterations: optionalCount(record.maxIterations, 'Goal maxIterations'),
+    tokenBudget: optionalCount(record.tokenBudget, 'Goal tokenBudget'),
+  };
+}
+
+function optionalCount(value: unknown, label: string): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+    throw new TypeError(`${label} must be a positive integer`);
+  }
+  return value;
 }
 
 function toDesktopGoal(goal: GoalProjection): GoalState {

--- a/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-session-domains-ipc-main.ts
@@ -14,6 +14,7 @@ import type {
 import type { AgentGraphEpochDirectory } from '@maka/runtime-host/client';
 import type { DesktopRuntimeHostClient } from './runtime-host-client.js';
 import type { RuntimeHostSessionObserver } from './runtime-host-session-observer.js';
+import { GOAL_ARM_REQUEST_KEYS } from '../shared/goal-arm.js';
 import { projectHostedDeepResearch } from './deep-research-desktop-projection.js';
 import {
   handleReconnectableRead,
@@ -327,6 +328,9 @@ function requireGoalArmBudgets(value: unknown): {
     throw new TypeError('Goal arm input must be an object');
   }
   const record = value as Record<string, unknown>;
+  if (Object.keys(record).some((key) => !GOAL_ARM_REQUEST_KEYS.includes(key as never))) {
+    throw new TypeError('Invalid Goal arm input');
+  }
   if (typeof record.condition !== 'string' || record.condition.trim().length === 0) {
     throw new TypeError('Goal condition is required');
   }

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -724,6 +724,17 @@ export interface MakaBridge {
   goal: {
     /** The session's current goal (null when none is set). */
     get(sessionId: string): Promise<import('@maka/runtime/goal-state').GoalState | null>;
+    /**
+     * Arm a goal for this session. It drives the session from the next turn
+     * on; arming alone starts nothing. Rejects when the session already has an
+     * unfinished goal.
+     */
+    arm(input: {
+      sessionId: string;
+      condition: string;
+      maxIterations?: number | null;
+      tokenBudget?: number | null;
+    }): Promise<import('@maka/runtime/goal-state').GoalState>;
     /** Clear the active goal, stopping autonomous continuation. */
     clear(sessionId: string): Promise<void>;
     /** Pause the active goal without spending a model turn. */

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -729,12 +729,10 @@ export interface MakaBridge {
      * on; arming alone starts nothing. Rejects when the session already has an
      * unfinished goal.
      */
-    arm(input: {
-      sessionId: string;
-      condition: string;
-      maxIterations?: number | null;
-      tokenBudget?: number | null;
-    }): Promise<import('@maka/runtime/goal-state').GoalState>;
+    arm(
+      sessionId: string,
+      goal: import('../shared/goal-arm').GoalArmRequest,
+    ): Promise<import('@maka/runtime/goal-state').GoalState>;
     /** Clear the active goal, stopping autonomous continuation. */
     clear(sessionId: string): Promise<void>;
     /** Pause the active goal without spending a model turn. */

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -170,6 +170,7 @@ import {
   requireDesktopTargetScope,
   type DesktopTargetScope,
 } from '../shared/runtime-host-identity.js';
+import type { GoalArmRequest } from '../shared/goal-arm.js';
 import {
   projectDesktopAttachmentRefs,
   projectDesktopDailyReviewSummary,
@@ -1910,13 +1911,8 @@ const makaBridge = {
     get(sessionId: string): Promise<GoalState | null> {
       return invokeProjectedSessionRuntimeHost('goal:get', sessionId);
     },
-    arm(input: {
-      sessionId: string;
-      condition: string;
-      maxIterations?: number | null;
-      tokenBudget?: number | null;
-    }): Promise<GoalState> {
-      return invokeProjectedSessionRuntimeHost('goal:arm', input.sessionId, input);
+    arm(sessionId: string, goal: GoalArmRequest): Promise<GoalState> {
+      return invokeProjectedSessionRuntimeHost('goal:arm', sessionId, goal);
     },
     clear(sessionId: string): Promise<void> {
       return invokeSessionRuntimeHost('goal:clear', sessionId);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1910,6 +1910,14 @@ const makaBridge = {
     get(sessionId: string): Promise<GoalState | null> {
       return invokeProjectedSessionRuntimeHost('goal:get', sessionId);
     },
+    arm(input: {
+      sessionId: string;
+      condition: string;
+      maxIterations?: number | null;
+      tokenBudget?: number | null;
+    }): Promise<GoalState> {
+      return invokeProjectedSessionRuntimeHost('goal:arm', input.sessionId, input);
+    },
     clear(sessionId: string): Promise<void> {
       return invokeSessionRuntimeHost('goal:clear', sessionId);
     },

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -227,6 +227,7 @@ function rebaseWorkspaceFileReferences(
 
 import { useSettingsModal } from './use-settings-modal';
 import { RemoteProjectDirectoryDialog } from './remote-project-directory-dialog';
+import { GoalDialog } from './goal-dialog.js';
 import { useSystemUiLocale } from './use-system-ui-locale';
 import {
   isSessionWorkspaceUnavailableError,
@@ -776,6 +777,12 @@ function AppShellContent({
     },
     [],
   );
+  /**
+   * The Session the Goal dialog is arming, or `undefined` when it is closed.
+   * Keyed by Session rather than a boolean so switching Sessions while the
+   * dialog is open can never arm the wrong one.
+   */
+  const [goalDialogSessionId, setGoalDialogSessionId] = useState<string>();
   // Set of session ids whose backend / connection is no longer usable —
   // drives the sidebar "已过期" pill (PR108g, paired with the PR108e chat
   // header banner). Derivation is pure (see `stale-sessions.ts`) so the
@@ -3271,6 +3278,17 @@ function AppShellContent({
                   onOrchestrationModeChange={(mode) => {
                     void setOrchestrationMode(mode);
                   }}
+                  onSetGoal={
+                    activeId && activeBoundarySurface.localInteractionAvailable
+                      ? () => setGoalDialogSessionId(activeId)
+                      : undefined
+                  }
+                  goalActive={activeGoal !== null}
+                  goalDisabledReason={
+                    activeStreamingLive || (activeId && turnActive)
+                      ? shellCopy.goalTurnActive
+                      : undefined
+                  }
                     />
                   </>
                 }
@@ -3586,6 +3604,10 @@ function AppShellContent({
         }}
       />
 
+      <GoalDialog
+        {...(goalDialogSessionId ? { sessionId: goalDialogSessionId } : {})}
+        onClose={() => setGoalDialogSessionId(undefined)}
+      />
       <RuntimeHostSshTerminalDialog />
 
       <RemoteProjectDirectoryDialog

--- a/apps/desktop/src/renderer/goal-dialog.tsx
+++ b/apps/desktop/src/renderer/goal-dialog.tsx
@@ -19,7 +19,11 @@ import { NumberInput } from '@astryxdesign/core/NumberInput';
 import { Text } from '@astryxdesign/core/Text';
 import { TextArea } from '@astryxdesign/core/TextArea';
 import { useUiLocale } from '@maka/ui';
-import { GOAL_CONDITION_TEXT_LIMIT, GOAL_MAX_ITERATIONS_LIMIT } from '@maka/core/goal';
+import {
+  GOAL_CONDITION_TEXT_LIMIT,
+  GOAL_MAX_ITERATIONS_LIMIT,
+  GOAL_TOKEN_BUDGET_MINIMUM,
+} from '@maka/core/goal';
 import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy.js';
 
 export function GoalDialog(props: {
@@ -54,8 +58,7 @@ export function GoalDialog(props: {
     setArming(true);
     setError(undefined);
     try {
-      await window.maka.goal.arm({
-        sessionId,
+      await window.maka.goal.arm(sessionId, {
         condition: condition.trim(),
         maxIterations,
         tokenBudget,
@@ -115,7 +118,7 @@ export function GoalDialog(props: {
                   description={copy.tokenBudgetDescription}
                   value={tokenBudget}
                   onChange={setTokenBudget}
-                  min={1_000}
+                  min={GOAL_TOKEN_BUDGET_MINIMUM}
                   step={1_000}
                   isOptional
                   isDisabled={arming}

--- a/apps/desktop/src/renderer/goal-dialog.tsx
+++ b/apps/desktop/src/renderer/goal-dialog.tsx
@@ -1,0 +1,149 @@
+/**
+ * The form behind the ＋ menu's "Set a goal…" entry.
+ *
+ * A Goal is the one control here that keeps spending tokens after the user
+ * stops typing, so it is a dialog rather than a menu row: the condition needs
+ * a sentence, and the two budgets that stop it should be visible while it is
+ * being armed, not discovered afterwards.
+ *
+ * Bounds are the Host's. This sends what the user chose and reports what the
+ * Host answers; it does not clamp a rejected number into an accepted one,
+ * because the Goal that then runs would not be the one they asked for.
+ */
+import { useEffect, useState } from 'react';
+import { Button } from '@astryxdesign/core/Button';
+import { Dialog, DialogHeader } from '@astryxdesign/core/Dialog';
+import { Layout, LayoutContent, LayoutFooter } from '@astryxdesign/core/Layout';
+import { HStack, VStack } from '@astryxdesign/core/Stack';
+import { NumberInput } from '@astryxdesign/core/NumberInput';
+import { Text } from '@astryxdesign/core/Text';
+import { TextArea } from '@astryxdesign/core/TextArea';
+import { useUiLocale } from '@maka/ui';
+import { GOAL_CONDITION_TEXT_LIMIT, GOAL_MAX_ITERATIONS_LIMIT } from '@maka/core/goal';
+import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy.js';
+
+export function GoalDialog(props: {
+  /** The Session to arm. `undefined` closes the dialog. */
+  sessionId?: string;
+  onClose(): void;
+}) {
+  const locale = useUiLocale();
+  const copy = getShellCopy(locale).goalDialog;
+  const [condition, setCondition] = useState('');
+  const [maxIterations, setMaxIterations] = useState<number | null>(null);
+  const [tokenBudget, setTokenBudget] = useState<number | null>(null);
+  const [arming, setArming] = useState(false);
+  const [error, setError] = useState<string>();
+
+  // Each opening starts from empty: the previous Session's condition is not a
+  // useful default for this one, and a stale error would outlive its cause.
+  useEffect(() => {
+    if (props.sessionId === undefined) return;
+    setCondition('');
+    setMaxIterations(null);
+    setTokenBudget(null);
+    setError(undefined);
+    setArming(false);
+  }, [props.sessionId]);
+
+  const sessionId = props.sessionId;
+  const canSubmit = condition.trim().length > 0 && !arming;
+
+  async function arm(): Promise<void> {
+    if (!sessionId || !canSubmit) return;
+    setArming(true);
+    setError(undefined);
+    try {
+      await window.maka.goal.arm({
+        sessionId,
+        condition: condition.trim(),
+        maxIterations,
+        tokenBudget,
+      });
+      props.onClose();
+    } catch (cause) {
+      setError(localizedShellErrorMessage(cause, copy.failedFallback, locale));
+    } finally {
+      setArming(false);
+    }
+  }
+
+  return (
+    <Dialog
+      isOpen={sessionId !== undefined}
+      onOpenChange={(open) => {
+        if (!open && !arming) props.onClose();
+      }}
+      purpose="form"
+      width={520}
+      className="goalDialog"
+    >
+      <Layout
+        header={<DialogHeader title={copy.title} onOpenChange={(open) => {
+          if (!open && !arming) props.onClose();
+        }} />}
+        content={
+          <LayoutContent padding={4}>
+            <VStack gap={4}>
+              <Text type="body" color="secondary">{copy.description}</Text>
+              <TextArea
+                label={copy.conditionLabel}
+                description={copy.conditionDescription}
+                placeholder={copy.conditionPlaceholder}
+                value={condition}
+                onChange={setCondition}
+                rows={3}
+                maxLength={GOAL_CONDITION_TEXT_LIMIT.codeUnits}
+                isRequired
+                isDisabled={arming}
+                hasAutoFocus
+                {...(error ? { status: { type: 'error' as const, message: error } } : {})}
+              />
+              <HStack gap={3}>
+                <NumberInput
+                  label={copy.maxIterationsLabel}
+                  description={copy.maxIterationsDescription}
+                  value={maxIterations}
+                  onChange={setMaxIterations}
+                  min={1}
+                  max={GOAL_MAX_ITERATIONS_LIMIT}
+                  isOptional
+                  isDisabled={arming}
+                />
+                <NumberInput
+                  label={copy.tokenBudgetLabel}
+                  description={copy.tokenBudgetDescription}
+                  value={tokenBudget}
+                  onChange={setTokenBudget}
+                  min={1_000}
+                  step={1_000}
+                  isOptional
+                  isDisabled={arming}
+                />
+              </HStack>
+            </VStack>
+          </LayoutContent>
+        }
+        footer={
+          <LayoutFooter hasDivider>
+            <HStack gap={2} hAlign="end">
+              <Button
+                variant="ghost"
+                label={copy.cancel}
+                isDisabled={arming}
+                onClick={props.onClose}
+              />
+              <Button
+                variant="primary"
+                label={copy.submit}
+                isDisabled={!canSubmit}
+                isLoading={arming}
+                onClick={() => void arm()}
+              />
+            </HStack>
+          </LayoutFooter>
+        }
+      />
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/renderer/goal-dialog.tsx
+++ b/apps/desktop/src/renderer/goal-dialog.tsx
@@ -8,16 +8,20 @@
  *
  * Bounds are the Host's. This sends what the user chose and reports what the
  * Host answers; it does not clamp a rejected number into an accepted one,
- * because the Goal that then runs would not be the one they asked for.
+ * because the Goal that then runs would not be the one they asked for. For the
+ * same reason the budget fields hold the user's own text rather than a parsed
+ * number: a field that quietly keeps the last value it could parse can arm a
+ * budget the form is no longer showing, and a field that quietly keeps nothing
+ * can arm no budget at all where the user asked for a tight one.
  */
 import { useEffect, useState } from 'react';
 import { Button } from '@astryxdesign/core/Button';
 import { Dialog, DialogHeader } from '@astryxdesign/core/Dialog';
 import { Layout, LayoutContent, LayoutFooter } from '@astryxdesign/core/Layout';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
-import { NumberInput } from '@astryxdesign/core/NumberInput';
 import { Text } from '@astryxdesign/core/Text';
 import { TextArea } from '@astryxdesign/core/TextArea';
+import { TextInput } from '@astryxdesign/core/TextInput';
 import { useUiLocale } from '@maka/ui';
 import {
   GOAL_CONDITION_TEXT_LIMIT,
@@ -25,6 +29,29 @@ import {
   GOAL_TOKEN_BUDGET_MINIMUM,
 } from '@maka/core/goal';
 import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy.js';
+
+type BudgetReading =
+  | { readonly kind: 'empty' }
+  | { readonly kind: 'value'; readonly value: number }
+  | { readonly kind: 'invalid' };
+
+/**
+ * Read one budget field, refusing anything the Host would not take.
+ *
+ * `min`/`max` repeat the operation's own bounds so the refusal can be shown
+ * beside the field instead of arriving as a rejected frame; the numbers
+ * themselves come from the shared Goal limits, so there is still one authority
+ * for what they are.
+ */
+function readGoalBudget(text: string, min: number, max?: number): BudgetReading {
+  const trimmed = text.trim();
+  if (!trimmed) return { kind: 'empty' };
+  if (!/^\d+$/.test(trimmed)) return { kind: 'invalid' };
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value) || value < min) return { kind: 'invalid' };
+  if (max !== undefined && value > max) return { kind: 'invalid' };
+  return { kind: 'value', value };
+}
 
 export function GoalDialog(props: {
   /** The Session to arm. `undefined` closes the dialog. */
@@ -34,8 +61,8 @@ export function GoalDialog(props: {
   const locale = useUiLocale();
   const copy = getShellCopy(locale).goalDialog;
   const [condition, setCondition] = useState('');
-  const [maxIterations, setMaxIterations] = useState<number | null>(null);
-  const [tokenBudget, setTokenBudget] = useState<number | null>(null);
+  const [maxIterationsText, setMaxIterationsText] = useState('');
+  const [tokenBudgetText, setTokenBudgetText] = useState('');
   const [arming, setArming] = useState(false);
   const [error, setError] = useState<string>();
 
@@ -44,14 +71,20 @@ export function GoalDialog(props: {
   useEffect(() => {
     if (props.sessionId === undefined) return;
     setCondition('');
-    setMaxIterations(null);
-    setTokenBudget(null);
+    setMaxIterationsText('');
+    setTokenBudgetText('');
     setError(undefined);
     setArming(false);
   }, [props.sessionId]);
 
   const sessionId = props.sessionId;
-  const canSubmit = condition.trim().length > 0 && !arming;
+  const maxIterations = readGoalBudget(maxIterationsText, 1, GOAL_MAX_ITERATIONS_LIMIT);
+  const tokenBudget = readGoalBudget(tokenBudgetText, GOAL_TOKEN_BUDGET_MINIMUM);
+  const canSubmit =
+    condition.trim().length > 0 &&
+    maxIterations.kind !== 'invalid' &&
+    tokenBudget.kind !== 'invalid' &&
+    !arming;
 
   async function arm(): Promise<void> {
     if (!sessionId || !canSubmit) return;
@@ -60,8 +93,8 @@ export function GoalDialog(props: {
     try {
       await window.maka.goal.arm(sessionId, {
         condition: condition.trim(),
-        maxIterations,
-        tokenBudget,
+        maxIterations: maxIterations.kind === 'value' ? maxIterations.value : null,
+        tokenBudget: tokenBudget.kind === 'value' ? tokenBudget.value : null,
       });
       props.onClose();
     } catch (cause) {
@@ -103,25 +136,27 @@ export function GoalDialog(props: {
                 {...(error ? { status: { type: 'error' as const, message: error } } : {})}
               />
               <HStack gap={3}>
-                <NumberInput
+                <TextInput
                   label={copy.maxIterationsLabel}
                   description={copy.maxIterationsDescription}
-                  value={maxIterations}
-                  onChange={setMaxIterations}
-                  min={1}
-                  max={GOAL_MAX_ITERATIONS_LIMIT}
+                  value={maxIterationsText}
+                  onChange={setMaxIterationsText}
                   isOptional
                   isDisabled={arming}
+                  {...(maxIterations.kind === 'invalid'
+                    ? { status: { type: 'error' as const, message: copy.maxIterationsInvalid(GOAL_MAX_ITERATIONS_LIMIT) } }
+                    : {})}
                 />
-                <NumberInput
+                <TextInput
                   label={copy.tokenBudgetLabel}
                   description={copy.tokenBudgetDescription}
-                  value={tokenBudget}
-                  onChange={setTokenBudget}
-                  min={GOAL_TOKEN_BUDGET_MINIMUM}
-                  step={1_000}
+                  value={tokenBudgetText}
+                  onChange={setTokenBudgetText}
                   isOptional
                   isDisabled={arming}
+                  {...(tokenBudget.kind === 'invalid'
+                    ? { status: { type: 'error' as const, message: copy.tokenBudgetInvalid(GOAL_TOKEN_BUDGET_MINIMUM) } }
+                    : {})}
                 />
               </HStack>
             </VStack>

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -332,8 +332,10 @@ type ShellCopy = {
     conditionPlaceholder: string;
     maxIterationsLabel: string;
     maxIterationsDescription: string;
+    maxIterationsInvalid(max: number): string;
     tokenBudgetLabel: string;
     tokenBudgetDescription: string;
+    tokenBudgetInvalid(min: number): string;
     cancel: string;
     submit: string;
     failedFallback: string;
@@ -985,8 +987,10 @@ const SHELL_COPY_BY_LOCALE = {
       conditionPlaceholder: '例如：所有测试通过，且 lint 无告警',
       maxIterationsLabel: '最多轮数',
       maxIterationsDescription: '留空使用默认值。',
+      maxIterationsInvalid: (max) => `请填 1 到 ${max} 之间的整数，或留空。`,
       tokenBudgetLabel: 'Token 预算',
       tokenBudgetDescription: '留空表示不设 token 上限。',
+      tokenBudgetInvalid: (min) => `请填不小于 ${min} 的整数，或留空。`,
       cancel: '取消',
       submit: '开始',
       failedFallback: '无法设定 Goal，请稍后重试。',
@@ -1485,8 +1489,10 @@ const SHELL_COPY_BY_LOCALE = {
       conditionPlaceholder: 'e.g. all tests pass and lint reports no warnings',
       maxIterationsLabel: 'Maximum turns',
       maxIterationsDescription: 'Leave empty to use the default.',
+      maxIterationsInvalid: (max) => `Enter a whole number from 1 to ${max}, or leave it empty.`,
       tokenBudgetLabel: 'Token budget',
       tokenBudgetDescription: 'Leave empty for no token ceiling.',
+      tokenBudgetInvalid: (min) => `Enter a whole number of at least ${min}, or leave it empty.`,
       cancel: 'Cancel',
       submit: 'Start',
       failedFallback: 'The goal could not be set. Try again.',

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -319,6 +319,25 @@ type ShellCopy = {
     thinkingFailedTitle: string;
     thinkingFallback: string;
   };
+  /**
+   * The Goal dialog. A Goal spends tokens without further prompting, so the
+   * wording states what it does and names the two budgets that stop it —
+   * silence here reads as "nothing happens until I press something else".
+   */
+  goalDialog: {
+    title: string;
+    description: string;
+    conditionLabel: string;
+    conditionDescription: string;
+    conditionPlaceholder: string;
+    maxIterationsLabel: string;
+    maxIterationsDescription: string;
+    tokenBudgetLabel: string;
+    tokenBudgetDescription: string;
+    cancel: string;
+    submit: string;
+    failedFallback: string;
+  };
   errorBoundary: {
     copyPending: string;
     copied: string;
@@ -443,6 +462,12 @@ type ShellCopy = {
     modeChangeStreaming: string;
     modeChangeRunning: string;
     modeChangeWaiting: string;
+    /**
+     * Why the ＋ menu's Goal entry is unavailable right now. A Goal takes hold
+     * on the next Turn, so arming one mid-Turn would look like it did nothing;
+     * saying so is better than letting the user find that out afterwards.
+     */
+    goalTurnActive: string;
     planModeFailedTitle: string;
     planModeFallback: string;
     orchestrationModeFailedTitle: string;
@@ -952,6 +977,20 @@ const SHELL_COPY_BY_LOCALE = {
       thinkingFailedTitle: '切换思考级别失败',
       thinkingFallback: '思考级别暂时无法切换，请稍后重试。',
     },
+    goalDialog: {
+      title: '设定 Goal',
+      description: 'Goal 会在每轮结束后自动续行，直到达成、判定不可行，或触及下面的预算。随时可在输入框上方停止。',
+      conditionLabel: '达成条件',
+      conditionDescription: '用一句话说明什么算做完；Maka 每轮都据此判断。',
+      conditionPlaceholder: '例如：所有测试通过，且 lint 无告警',
+      maxIterationsLabel: '最多轮数',
+      maxIterationsDescription: '留空使用默认值。',
+      tokenBudgetLabel: 'Token 预算',
+      tokenBudgetDescription: '留空表示不设 token 上限。',
+      cancel: '取消',
+      submit: '开始',
+      failedFallback: '无法设定 Goal，请稍后重试。',
+    },
     errorBoundary: {
       copyPending: '复制中…',
       copied: '已复制',
@@ -1143,6 +1182,7 @@ const SHELL_COPY_BY_LOCALE = {
       modeChangeStreaming: '当前任务正在流式输出，等结束后再切换模式。',
       modeChangeRunning: '当前任务正在运行，等结束后再切换模式。',
       modeChangeWaiting: '当前有工具调用正在等待确认，处理后再切换模式。',
+      goalTurnActive: 'Goal 从下一轮开始生效。等当前这一轮结束后再设定。',
       planModeFailedTitle: '切换 Plan 模式失败',
       planModeFallback: 'Plan 模式暂时无法切换，请稍后重试。',
       orchestrationModeFailedTitle: '切换编排模式失败',
@@ -1437,6 +1477,20 @@ const SHELL_COPY_BY_LOCALE = {
       thinkingFailedTitle: 'Could not change thinking level',
       thinkingFallback: 'The thinking level could not be changed. Try again later.',
     },
+    goalDialog: {
+      title: 'Set a goal',
+      description: 'Maka continues on its own after each turn until the goal is met, judged impossible, or a budget below is reached. You can stop it any time from above the composer.',
+      conditionLabel: 'Completion condition',
+      conditionDescription: 'One sentence for what counts as done; Maka checks it after every turn.',
+      conditionPlaceholder: 'e.g. all tests pass and lint reports no warnings',
+      maxIterationsLabel: 'Maximum turns',
+      maxIterationsDescription: 'Leave empty to use the default.',
+      tokenBudgetLabel: 'Token budget',
+      tokenBudgetDescription: 'Leave empty for no token ceiling.',
+      cancel: 'Cancel',
+      submit: 'Start',
+      failedFallback: 'The goal could not be set. Try again.',
+    },
     errorBoundary: {
       copyPending: 'Copying…',
       copied: 'Copied',
@@ -1670,6 +1724,8 @@ const SHELL_COPY_BY_LOCALE = {
       modeChangeStreaming: 'This task is streaming. Wait for it to finish before changing the mode.',
       modeChangeRunning: 'This task is running. Wait for it to finish before changing the mode.',
       modeChangeWaiting: 'A tool call is waiting for confirmation. Respond before changing the mode.',
+      goalTurnActive:
+        'A goal takes hold on the next turn. Wait for this one to finish before setting one.',
       planModeFailedTitle: 'Could not change Plan mode',
       planModeFallback: 'Plan mode could not be changed. Try again later.',
       orchestrationModeFailedTitle: 'Could not change the orchestration mode',

--- a/apps/desktop/src/renderer/use-session-goal.ts
+++ b/apps/desktop/src/renderer/use-session-goal.ts
@@ -37,6 +37,9 @@ export function useSessionGoal(sessionId: string | undefined): LiveGoalState | n
       setGoal(null);
       return;
     }
+    // The previous Session's Goal is not an answer for this one, so it goes
+    // before the first fetch resolves rather than after.
+    setGoal(null);
     let cancelled = false;
     let refreshSequence = 0;
     const refresh = (): void => {

--- a/apps/desktop/src/shared/goal-arm.ts
+++ b/apps/desktop/src/shared/goal-arm.ts
@@ -1,0 +1,19 @@
+/**
+ * What the renderer sends to arm a Goal.
+ *
+ * The Session is not here: it travels as the scoped IPC argument, so a
+ * renderer-side Session id can never redirect the operation. Preload declares
+ * this shape and the IPC validator refuses anything outside it, so both read
+ * the one declaration instead of each keeping its own copy.
+ */
+export interface GoalArmRequest {
+  readonly condition: string;
+  readonly maxIterations?: number | null;
+  readonly tokenBudget?: number | null;
+}
+
+export const GOAL_ARM_REQUEST_KEYS: readonly (keyof GoalArmRequest)[] = Object.freeze([
+  'condition',
+  'maxIterations',
+  'tokenBudget',
+]);

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -19,6 +19,7 @@ import { deriveBranchBanner } from '../src/renderer/branch-banner';
 import { deriveSessionRevisionNavigation } from '../src/renderer/session-revisions';
 import { deriveSessionRail } from '../src/renderer/session-rail';
 import { AppShell as AstryxAppShell } from '@astryxdesign/core/AppShell';
+import { GoalDialog } from '../src/renderer/goal-dialog';
 
 const NOW = Date.UTC(2026, 6, 1, 9, 30, 0);
 
@@ -229,6 +230,9 @@ const baseComposerProps: ComposerProps = {
   onPlanModeChange: noop,
   orchestrationMode: 'default',
   onOrchestrationModeChange: noop,
+  // Production wires this for every Session it can interact with locally
+  // (app-shell.tsx), so the ＋ menu always carries the Goal entry.
+  onSetGoal: noop,
   // Thinking is a separate right-footer Selector when levels are offered.
   activeThinkingLevels: ['off', 'low', 'medium', 'high', 'xhigh'],
   activeThinkingLevel: 'medium',
@@ -1026,5 +1030,25 @@ export const ModeOnWithPendingAttachments: Story = {
         onRemoveAttachment: noop,
       }}
     />
+  ),
+};
+
+// Real path: this Session already has a running Goal, which the composer shows
+// above the input. Arming refuses a second one, so the ＋ menu's Goal entry
+// says why instead of opening a dialog that would fail on submit.
+export const GoalAlreadySet: Story = {
+  render: () => <ComposedShell composer={{ goalActive: true }} />,
+};
+
+// Real path: composer ＋ → 设定 Goal…, on a Session with no Goal running and no
+// Turn in flight — app-shell mounts this dialog at the top level, over the
+// shell, exactly as composed here. It is the only place the two budgets that
+// stop a Goal are visible before one starts.
+export const GoalDialogOpen: Story = {
+  render: () => (
+    <>
+      <ComposedShell />
+      <GoalDialog sessionId="session-1" onClose={noop} />
+    </>
   ),
 };

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -5,7 +5,7 @@ Each row is one on-disk product surface file. Regenerated inventory must stay in
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 188 files — blocker 0, polish 0, aligned 188.
+**Totals:** 189 files — blocker 0, polish 0, aligned 189.
 
 ## Exclusions (explicit)
 
@@ -43,6 +43,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/command-palette.tsx` | dialog-overlay | EmptyState | aligned — uses Astryx (EmptyState) | aligned |
 | `apps/desktop/src/renderer/custom-pet-companion.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/error-boundary.tsx` | other | Button, Card | aligned — uses Astryx (Button, Card) | aligned |
+| `apps/desktop/src/renderer/goal-dialog.tsx` | dialog-overlay | Button, Dialog, DialogHeader, HStack, Layout, LayoutContent, Text, VStack | aligned — uses Astryx (Button, Dialog, DialogHeader, HStack, Layout, LayoutContent, Text, VStack) | aligned |
 | `apps/desktop/src/renderer/keyboard-help.tsx` | dialog-overlay | Dialog, DialogHeader, Heading, Layout, LayoutContent | aligned — uses Astryx (Dialog, DialogHeader, Heading, Layout, LayoutContent) | aligned |
 | `apps/desktop/src/renderer/live-turn-reconciler.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/maka-tokens.css` | styles | n/a (css) | aligned — no off-rhythm control heights flagged | aligned |

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -43,7 +43,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/command-palette.tsx` | dialog-overlay | EmptyState | aligned — uses Astryx (EmptyState) | aligned |
 | `apps/desktop/src/renderer/custom-pet-companion.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/error-boundary.tsx` | other | Button, Card | aligned — uses Astryx (Button, Card) | aligned |
-| `apps/desktop/src/renderer/goal-dialog.tsx` | dialog-overlay | Button, Dialog, DialogHeader, HStack, Layout, LayoutContent, Text, VStack | aligned — uses Astryx (Button, Dialog, DialogHeader, HStack, Layout, LayoutContent, Text, VStack) | aligned |
+| `apps/desktop/src/renderer/goal-dialog.tsx` | dialog-overlay | Button, Dialog, DialogHeader, HStack, Layout, LayoutContent, Text, TextInput, VStack | aligned — uses Astryx (Button, Dialog, DialogHeader, HStack, Layout, LayoutContent, Text, TextInput) | aligned |
 | `apps/desktop/src/renderer/keyboard-help.tsx` | dialog-overlay | Dialog, DialogHeader, Heading, Layout, LayoutContent | aligned — uses Astryx (Dialog, DialogHeader, Heading, Layout, LayoutContent) | aligned |
 | `apps/desktop/src/renderer/live-turn-reconciler.tsx` | other | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/maka-tokens.css` | styles | n/a (css) | aligned — no off-rhythm control heights flagged | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -15,6 +15,7 @@ apps/desktop/src/renderer/chat-workbar.tsx
 apps/desktop/src/renderer/command-palette.tsx
 apps/desktop/src/renderer/custom-pet-companion.tsx
 apps/desktop/src/renderer/error-boundary.tsx
+apps/desktop/src/renderer/goal-dialog.tsx
 apps/desktop/src/renderer/keyboard-help.tsx
 apps/desktop/src/renderer/live-turn-reconciler.tsx
 apps/desktop/src/renderer/maka-tokens.css

--- a/packages/core/src/goal.ts
+++ b/packages/core/src/goal.ts
@@ -43,6 +43,19 @@ export interface GoalState {
   readonly pausedAt?: number;
 }
 
+/**
+ * Whether any Turn has ever carried this Goal to a settlement.
+ *
+ * `iterations` is only ever raised by a Turn that settled while bound to the
+ * Goal, so it doubles as the record of that having happened — a Goal at zero
+ * exists but has never driven, or been driven by, a Turn. Recovery reads this
+ * rather than `status`, because `active` alone cannot tell a Goal waiting for
+ * its first Turn from one waiting between continuations.
+ */
+export function hasCarriedTurn(goal: Pick<GoalState, 'iterations'>): boolean {
+  return goal.iterations > 0;
+}
+
 export interface GoalCheckpoint {
   readonly goalId: string;
   readonly revision: number;

--- a/packages/core/src/goal.ts
+++ b/packages/core/src/goal.ts
@@ -266,6 +266,18 @@ export const GOAL_CONDITION_TEXT_LIMIT: GoalTextLimit = Object.freeze({
   utf8Bytes: 1_500,
 });
 
+/**
+ * Shared ceilings for the two Goal budgets a caller may choose.
+ *
+ * They were literals inside the GoalSet tool's schema until the Host grew an
+ * operation that arms a Goal too — two callers validating the same field
+ * against two copies of a number is how the copies drift apart.
+ */
+export const GOAL_MAX_ITERATIONS_LIMIT = 200;
+export const GOAL_BLOCK_CAP_LIMIT = 50;
+/** Below this a budget stops the Goal before it can do anything with it. */
+export const GOAL_TOKEN_BUDGET_MINIMUM = 1_000;
+
 /** Shared boundary for evaluator and lifecycle diagnostics. */
 export const GOAL_REASON_TEXT_LIMIT: GoalTextLimit = Object.freeze({
   codeUnits: 500,

--- a/packages/core/src/goal.ts
+++ b/packages/core/src/goal.ts
@@ -42,31 +42,32 @@ export interface GoalState {
   readonly achievedAt?: number;
   readonly pausedAt?: number;
   /**
-   * When `goal.arm` created this Goal, and absent when the model did.
+   * When `goal.arm` created this Goal, and absent once the Goal drives itself.
    *
-   * A Goal is born into one of two situations and nothing else records which.
-   * The model sets a Goal from inside a Turn, so that Turn is already bound to
-   * it and will settle into the Goal's first continuation. Arming happens
-   * outside every Turn and deliberately starts nothing, so the Goal waits for
-   * a Turn to take hold of it. Both look identical at `iterations: 0`, and a
-   * restart or a resume has to tell them apart. Stamped once at birth and
-   * never cleared: it says how the Goal began, not where it is now.
+   * A Goal the model sets drives from the moment it exists: the Turn that set
+   * it is already bound to it and settles into its first continuation. Arming
+   * happens outside every Turn and deliberately starts nothing, so an armed
+   * Goal waits — for a Turn to carry it into a continuation, or for the user
+   * to resume it — and this records that wait. Both events clear it, so its
+   * absence is the whole fact `isDrivingGoal` reads. Absence is also what
+   * every Goal written before arming existed carries, which is what those
+   * Goals mean.
    */
   readonly armedAt?: number;
 }
 
 /**
- * Whether this Goal is in a continuation loop that a restart or a resume
- * should put back.
+ * Whether this Goal admits its own continuation Turns, which a restart or a
+ * resume has to put back.
  *
- * A Goal the model set is in one from the moment it exists. An armed Goal is
- * not, until a Turn settles while bound to it — which is the only event that
- * raises `iterations`. Reading `status` cannot answer this: `active` covers
- * both a Goal waiting for its first Turn and one waiting between
- * continuations.
+ * `status` cannot answer this: `active` covers both a Goal between
+ * continuations and an armed one still waiting for its first Turn. Neither
+ * can `iterations`, which only rises once a carried Turn settles into an
+ * evaluation — leaving the whole first Turn, and any pause taken during it,
+ * indistinguishable from a Goal nothing ever took hold of.
  */
-export function isDrivingGoal(goal: Pick<GoalState, 'iterations' | 'armedAt'>): boolean {
-  return goal.armedAt === undefined || goal.iterations > 0;
+export function isDrivingGoal(goal: Pick<GoalState, 'armedAt'>): boolean {
+  return goal.armedAt === undefined;
 }
 
 export interface GoalCheckpoint {

--- a/packages/core/src/goal.ts
+++ b/packages/core/src/goal.ts
@@ -41,19 +41,32 @@ export interface GoalState {
   readonly lastReason?: string;
   readonly achievedAt?: number;
   readonly pausedAt?: number;
+  /**
+   * When `goal.arm` created this Goal, and absent when the model did.
+   *
+   * A Goal is born into one of two situations and nothing else records which.
+   * The model sets a Goal from inside a Turn, so that Turn is already bound to
+   * it and will settle into the Goal's first continuation. Arming happens
+   * outside every Turn and deliberately starts nothing, so the Goal waits for
+   * a Turn to take hold of it. Both look identical at `iterations: 0`, and a
+   * restart or a resume has to tell them apart. Stamped once at birth and
+   * never cleared: it says how the Goal began, not where it is now.
+   */
+  readonly armedAt?: number;
 }
 
 /**
- * Whether any Turn has ever carried this Goal to a settlement.
+ * Whether this Goal is in a continuation loop that a restart or a resume
+ * should put back.
  *
- * `iterations` is only ever raised by a Turn that settled while bound to the
- * Goal, so it doubles as the record of that having happened — a Goal at zero
- * exists but has never driven, or been driven by, a Turn. Recovery reads this
- * rather than `status`, because `active` alone cannot tell a Goal waiting for
- * its first Turn from one waiting between continuations.
+ * A Goal the model set is in one from the moment it exists. An armed Goal is
+ * not, until a Turn settles while bound to it — which is the only event that
+ * raises `iterations`. Reading `status` cannot answer this: `active` covers
+ * both a Goal waiting for its first Turn and one waiting between
+ * continuations.
  */
-export function hasCarriedTurn(goal: Pick<GoalState, 'iterations'>): boolean {
-  return goal.iterations > 0;
+export function isDrivingGoal(goal: Pick<GoalState, 'iterations' | 'armedAt'>): boolean {
+  return goal.armedAt === undefined || goal.iterations > 0;
 }
 
 export interface GoalCheckpoint {
@@ -109,7 +122,7 @@ const GOAL_STATE_SHAPE = defineObjectShape<GoalState>()(
     'tokensNow',
     'tokensBaselinePending',
   ],
-  ['tokenBudget', 'lastReason', 'achievedAt', 'pausedAt'],
+  ['tokenBudget', 'lastReason', 'achievedAt', 'pausedAt', 'armedAt'],
 );
 const GOAL_CONTROL_LEASE_SHAPE = defineObjectShape<GoalControlLease>()(
   ['goalId', 'generation'],
@@ -175,7 +188,8 @@ function decodeGoalState(value: unknown): GoalState {
     typeof value.tokensBaselinePending !== 'boolean' ||
     !isOptionalBoundedReason(value.lastReason) ||
     !isOptionalNonnegativeInteger(value.achievedAt) ||
-    !isOptionalNonnegativeInteger(value.pausedAt)
+    !isOptionalNonnegativeInteger(value.pausedAt) ||
+    !isOptionalNonnegativeInteger(value.armedAt)
   ) {
     throw new TypeError('Invalid Goal state');
   }

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -740,7 +740,7 @@ test('a Goal armed but never carried by a Turn does not start itself after a res
   }
 });
 
-test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a loop', async () => {
+test('resuming an armed Goal drives it, and a restart puts that drive back', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-armed-resume-'));
   const capability = await resolveStorageRoot({
     path: join(base, 'root'),
@@ -759,8 +759,8 @@ test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    let admitted = false;
-    let evaluated = false;
+    let admitted = 0;
+    let evaluated = 0;
     const host = new HostGoalCoordinator({
       store: goalStore,
       stores,
@@ -771,14 +771,17 @@ test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a
       sessionAdmission: new SessionAdmissionGate(),
       evaluator: {
         evaluate: async () => {
-          evaluated = true;
+          evaluated += 1;
           return '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"x"}';
         },
         close: async () => {},
       },
+      // Busy leaves the Goal exactly where resume put it: driving, with no
+      // execution recorded. Any other admission would write durable state and
+      // hide what the restart below has to rebuild from the Goal alone.
       admitTurn: () => {
-        admitted = true;
-        return { kind: 'unavailable', reason: 'Resume assertion only' };
+        admitted += 1;
+        return { kind: 'busy', whenIdle: new Promise<void>(() => {}) };
       },
       listActionableTaskKeys: async () => [],
       acquireResidency: () => ({ release: () => {} }),
@@ -798,6 +801,8 @@ test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a
     );
     assert.ok(armed.ok);
     if (!armed.ok) return;
+    for (let tick = 0; tick < 20; tick += 1) await new Promise((r) => setImmediate(r));
+    assert.equal(admitted, 0, 'arming alone must start nothing');
 
     const paused = await host.handlers['goal.control'](
       {
@@ -811,9 +816,9 @@ test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a
     assert.ok(paused.ok && paused.result.goal.status === 'paused');
     if (!paused.ok) return;
 
-    // Pause stopped nothing, so resume starts nothing. A Goal no Turn has
-    // carried has no loop to put back: it goes on waiting for the Turn that
-    // arming left it to, exactly as it was before the pause.
+    // Resume is the user saying go, and the control that sends it promises
+    // continuation starts immediately. From here the Goal drives itself,
+    // whether or not a Turn ever carried it.
     const resumed = await host.handlers['goal.control'](
       {
         sessionId: session.id,
@@ -824,30 +829,43 @@ test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a
       operationContext('connection-1'),
     );
     assert.ok(resumed.ok && resumed.result.goal.status === 'active');
+    if (!resumed.ok) return;
     for (let tick = 0; tick < 20; tick += 1) await new Promise((r) => setImmediate(r));
-    assert.equal(admitted, false, 'resume admitted a Turn for a Goal no Turn had carried');
-    assert.equal(evaluated, false, 'resume evaluated a Goal no Turn had carried');
-    await waitForAsync(async () => (await goalStore.read(session.id)) !== null);
+    assert.equal(admitted, 1, 'resume promised continuation and started none');
+    assert.equal(evaluated, 0, 'resume drives the next Turn without evaluating one');
+    await waitForAsync(
+      async () =>
+        (await goalStore.read(session.id))?.record.goal.revision === resumed.result.goal.revision,
+    );
+    assert.equal(
+      (await goalStore.read(session.id))?.record.currentExecution,
+      null,
+      'a busy admission records no execution, so only the Goal carries the drive',
+    );
     await host.close();
 
-    // And because resume promised nothing, a restart has nothing to lose: the
-    // Goal comes back active and still waiting for its first Turn.
-    let admittedAfterRestart = false;
+    // The resume outlived the process that took it: nothing else is left to
+    // say the user asked for continuation.
+    let admittedAfterRestart = 0;
+    let evaluatedAfterRestart = 0;
     const restarted = new HostGoalCoordinator({
       store: goalStore,
       stores,
       executions: {
-        reconcile: async () => assert.fail('An armed Goal has no execution to recover'),
+        reconcile: async () => assert.fail('A busy admission left no execution to recover'),
         subscribe: () => () => undefined,
       },
       sessionAdmission: new SessionAdmissionGate(),
       evaluator: {
-        evaluate: async () => assert.fail('A resumed but never carried Goal must not evaluate'),
+        evaluate: async () => {
+          evaluatedAfterRestart += 1;
+          return '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"x"}';
+        },
         close: async () => {},
       },
       admitTurn: () => {
-        admittedAfterRestart = true;
-        return { kind: 'unavailable', reason: 'Recovery assertion only' };
+        admittedAfterRestart += 1;
+        return { kind: 'busy', whenIdle: new Promise<void>(() => {}) };
       },
       listActionableTaskKeys: async () => [],
       acquireResidency: () => ({ release: () => {} }),
@@ -857,10 +875,8 @@ test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a
     await restarted.prepareRecovery();
     await restarted.recover();
     for (let tick = 0; tick < 20; tick += 1) await new Promise((r) => setImmediate(r));
-    assert.equal(admittedAfterRestart, false, 'the restart drove a Goal no Turn had carried');
-    const goal = restarted.readProjection(session.id);
-    assert.equal(goal?.status, 'active');
-    assert.equal(goal?.iterations, 0);
+    assert.equal(admittedAfterRestart, 1, 'the restart dropped a resume the user had already made');
+    assert.equal(evaluatedAfterRestart, 0, 'recovery drives the next Turn without evaluating one');
     await restarted.close();
   } finally {
     await goalStore.close();

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -540,7 +540,6 @@ test('goal.arm creates one Goal per Session and refuses a second while it is unf
   try {
     const session = await stores.sessionStore.create({
       cwd: capability.canonicalPath,
-      backend: 'fake',
       llmConnectionSlug: 'fake',
       model: 'fake-model',
       permissionMode: 'ask',
@@ -655,7 +654,6 @@ test('a Goal armed but never carried by a Turn does not start itself after a res
   try {
     const session = await stores.sessionStore.create({
       cwd: capability.canonicalPath,
-      backend: 'fake',
       llmConnectionSlug: 'fake',
       model: 'fake-model',
       permissionMode: 'ask',
@@ -757,7 +755,6 @@ test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a
   try {
     const session = await stores.sessionStore.create({
       cwd: capability.canonicalPath,
-      backend: 'fake',
       llmConnectionSlug: 'fake',
       model: 'fake-model',
       permissionMode: 'ask',
@@ -887,7 +884,6 @@ test('an arm admitted before the drain creates no Goal after it', async () => {
   try {
     const session = await stores.sessionStore.create({
       cwd: capability.canonicalPath,
-      backend: 'fake',
       llmConnectionSlug: 'fake',
       model: 'fake-model',
       permissionMode: 'ask',

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -525,6 +525,121 @@ function activeGoalRecord(
   };
 }
 
+test('goal.arm creates one Goal per Session and refuses a second while it is unfinished', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-arm-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+
+  const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  const goalStore = await openInteractiveGoalAuthorityForWrite(owner.lease);
+  try {
+    const session = await stores.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    const coordinator = new HostGoalCoordinator({
+      store: goalStore,
+      stores,
+      executions: {
+        reconcile: async () => assert.fail('Arming alone has no execution to recover'),
+        subscribe: () => () => undefined,
+      },
+      sessionAdmission: new SessionAdmissionGate(),
+      evaluator: {
+        evaluate: async () => assert.fail('Arming alone must not evaluate the Goal'),
+        close: async () => {},
+      },
+      // Arming schedules nothing: the Goal takes hold on the next Turn.
+      admitTurn: () => assert.fail('Arming must not admit a continuation Turn'),
+      listActionableTaskKeys: async () => [],
+      acquireResidency: () => ({ release: () => {} }),
+      onProjectionChanged: () => {},
+      requestDrain: () => {},
+      newId: () => 'goal-armed',
+      now: () => 10,
+    });
+    await coordinator.prepareRecovery();
+
+    const armed = await coordinator.handlers['goal.arm'](
+      {
+        sessionId: session.id,
+        condition: 'All tests pass',
+        maxIterations: 20,
+        tokenBudget: 50_000,
+      },
+      operationContext('connection-1'),
+    );
+    assert.equal(armed.ok, true);
+    if (!armed.ok) return;
+    assert.equal(armed.result.goal.goalId, 'goal-armed');
+    assert.equal(armed.result.goal.status, 'active');
+    assert.equal(armed.result.goal.maxIterations, 20);
+    assert.equal(armed.result.goal.tokenBudget, 50_000);
+    assert.deepEqual(
+      await coordinator.handlers['goal.query'](
+        { sessionId: session.id },
+        operationContext('connection-2'),
+      ),
+      armed,
+      'every client reads the Goal the Host just armed',
+    );
+    await waitForAsync(async () => (await goalStore.read(session.id)) !== null);
+
+    const second = await coordinator.handlers['goal.arm'](
+      {
+        sessionId: session.id,
+        condition: 'Something else',
+        maxIterations: null,
+        tokenBudget: null,
+      },
+      operationContext('connection-1'),
+    );
+    assert.equal(second.ok, false);
+    assert.equal(second.ok === false && second.error.code, 'operation_conflict');
+
+    const missing = await coordinator.handlers['goal.arm'](
+      {
+        sessionId: 'session-that-never-existed',
+        condition: 'All tests pass',
+        maxIterations: null,
+        tokenBudget: null,
+      },
+      operationContext('connection-1'),
+    );
+    assert.equal(missing.ok === false && missing.error.code, 'not_found');
+
+    const header = await stores.sessionStore.readHeaderRecordSnapshot(session.id);
+    await stores.sessionStore.setSessionsArchivedVersioned(
+      [{ sessionId: session.id, expectedVersion: header.revision }],
+      true,
+    );
+    const archived = await coordinator.handlers['goal.arm'](
+      {
+        sessionId: session.id,
+        condition: 'All tests pass',
+        maxIterations: null,
+        tokenBudget: null,
+      },
+      operationContext('connection-1'),
+    );
+    assert.equal(archived.ok === false && archived.error.code, 'session_archived');
+
+    await coordinator.close();
+  } finally {
+    await goalStore.close();
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 function operationContext(connectionId: string) {
   return {
     hostEpoch: 'epoch-1',

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -742,6 +742,136 @@ test('a Goal armed but never carried by a Turn does not start itself after a res
   }
 });
 
+test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a loop', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-armed-resume-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+
+  const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  const goalStore = await openInteractiveGoalAuthorityForWrite(owner.lease);
+  try {
+    const session = await stores.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    let admitted = false;
+    let evaluated = false;
+    const host = new HostGoalCoordinator({
+      store: goalStore,
+      stores,
+      executions: {
+        reconcile: async () => assert.fail('Arming alone has no execution to recover'),
+        subscribe: () => () => undefined,
+      },
+      sessionAdmission: new SessionAdmissionGate(),
+      evaluator: {
+        evaluate: async () => {
+          evaluated = true;
+          return '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"x"}';
+        },
+        close: async () => {},
+      },
+      admitTurn: () => {
+        admitted = true;
+        return { kind: 'unavailable', reason: 'Resume assertion only' };
+      },
+      listActionableTaskKeys: async () => [],
+      acquireResidency: () => ({ release: () => {} }),
+      onProjectionChanged: () => {},
+      requestDrain: () => {},
+      newId: () => 'goal-armed-and-resumed',
+    });
+    await host.prepareRecovery();
+    const armed = await host.handlers['goal.arm'](
+      {
+        sessionId: session.id,
+        condition: 'All tests pass',
+        maxIterations: null,
+        tokenBudget: null,
+      },
+      operationContext('connection-1'),
+    );
+    assert.ok(armed.ok);
+    if (!armed.ok) return;
+
+    const paused = await host.handlers['goal.control'](
+      {
+        sessionId: session.id,
+        goalId: armed.result.goal.goalId,
+        expectedRevision: armed.result.goal.revision,
+        action: 'pause',
+      },
+      operationContext('connection-1'),
+    );
+    assert.ok(paused.ok && paused.result.goal.status === 'paused');
+    if (!paused.ok) return;
+
+    // Pause stopped nothing, so resume starts nothing. A Goal no Turn has
+    // carried has no loop to put back: it goes on waiting for the Turn that
+    // arming left it to, exactly as it was before the pause.
+    const resumed = await host.handlers['goal.control'](
+      {
+        sessionId: session.id,
+        goalId: paused.result.goal.goalId,
+        expectedRevision: paused.result.goal.revision,
+        action: 'resume',
+      },
+      operationContext('connection-1'),
+    );
+    assert.ok(resumed.ok && resumed.result.goal.status === 'active');
+    for (let tick = 0; tick < 20; tick += 1) await new Promise((r) => setImmediate(r));
+    assert.equal(admitted, false, 'resume admitted a Turn for a Goal no Turn had carried');
+    assert.equal(evaluated, false, 'resume evaluated a Goal no Turn had carried');
+    await waitForAsync(async () => (await goalStore.read(session.id)) !== null);
+    await host.close();
+
+    // And because resume promised nothing, a restart has nothing to lose: the
+    // Goal comes back active and still waiting for its first Turn.
+    let admittedAfterRestart = false;
+    const restarted = new HostGoalCoordinator({
+      store: goalStore,
+      stores,
+      executions: {
+        reconcile: async () => assert.fail('An armed Goal has no execution to recover'),
+        subscribe: () => () => undefined,
+      },
+      sessionAdmission: new SessionAdmissionGate(),
+      evaluator: {
+        evaluate: async () => assert.fail('A resumed but never carried Goal must not evaluate'),
+        close: async () => {},
+      },
+      admitTurn: () => {
+        admittedAfterRestart = true;
+        return { kind: 'unavailable', reason: 'Recovery assertion only' };
+      },
+      listActionableTaskKeys: async () => [],
+      acquireResidency: () => ({ release: () => {} }),
+      onProjectionChanged: () => {},
+      requestDrain: () => {},
+    });
+    await restarted.prepareRecovery();
+    await restarted.recover();
+    for (let tick = 0; tick < 20; tick += 1) await new Promise((r) => setImmediate(r));
+    assert.equal(admittedAfterRestart, false, 'the restart drove a Goal no Turn had carried');
+    const goal = restarted.readProjection(session.id);
+    assert.equal(goal?.status, 'active');
+    assert.equal(goal?.iterations, 0);
+    await restarted.close();
+  } finally {
+    await goalStore.close();
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 function operationContext(connectionId: string) {
   return {
     hostEpoch: 'epoch-1',

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -640,6 +640,108 @@ test('goal.arm creates one Goal per Session and refuses a second while it is unf
   }
 });
 
+test('a Goal armed but never carried by a Turn does not start itself after a restart', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-armed-restart-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+
+  const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  const goalStore = await openInteractiveGoalAuthorityForWrite(owner.lease);
+  try {
+    const session = await stores.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    const armingHost = new HostGoalCoordinator({
+      store: goalStore,
+      stores,
+      executions: {
+        reconcile: async () => assert.fail('Arming alone has no execution to recover'),
+        subscribe: () => () => undefined,
+      },
+      sessionAdmission: new SessionAdmissionGate(),
+      evaluator: {
+        evaluate: async () => assert.fail('Arming alone must not evaluate the Goal'),
+        close: async () => {},
+      },
+      admitTurn: () => assert.fail('Arming must not admit a continuation Turn'),
+      listActionableTaskKeys: async () => [],
+      acquireResidency: () => ({ release: () => {} }),
+      onProjectionChanged: () => {},
+      requestDrain: () => {},
+      newId: () => 'goal-armed-across-restart',
+    });
+    await armingHost.prepareRecovery();
+    const armed = await armingHost.handlers['goal.arm'](
+      {
+        sessionId: session.id,
+        condition: 'All tests pass',
+        maxIterations: null,
+        tokenBudget: null,
+      },
+      operationContext('connection-1'),
+    );
+    assert.equal(armed.ok, true);
+    await waitForAsync(async () => (await goalStore.read(session.id)) !== null);
+    await armingHost.close();
+
+    // The Host that comes back up reads the same durable Goal. Arming started
+    // nothing before the restart, so it must start nothing because of one.
+    // Both hooks record rather than throw: a throw inside admission is caught
+    // by the drain and only surfaces as a paused Goal, which names the wrong
+    // failure.
+    let evaluated = false;
+    let admitted = false;
+    const restarted = new HostGoalCoordinator({
+      store: goalStore,
+      stores,
+      executions: {
+        reconcile: async () => assert.fail('An armed Goal has no execution to recover'),
+        subscribe: () => () => undefined,
+      },
+      sessionAdmission: new SessionAdmissionGate(),
+      evaluator: {
+        evaluate: async () => {
+          evaluated = true;
+          return '{"met":false,"impossible":false,"progress":true,"waiting":false,"reason":"x"}';
+        },
+        close: async () => {},
+      },
+      admitTurn: () => {
+        admitted = true;
+        return { kind: 'unavailable', reason: 'Recovery assertion only' };
+      },
+      listActionableTaskKeys: async () => [],
+      acquireResidency: () => ({ release: () => {} }),
+      onProjectionChanged: () => {},
+      requestDrain: () => {},
+    });
+    await restarted.prepareRecovery();
+    await restarted.recover();
+    // Settle every microtask a scheduled continuation would have needed.
+    for (let tick = 0; tick < 20; tick += 1) await new Promise((r) => setImmediate(r));
+
+    assert.equal(admitted, false, 'the restart admitted a Turn for a Goal no Turn had carried');
+    assert.equal(evaluated, false, 'the restart evaluated a Goal no Turn had carried');
+    const goal = restarted.readProjection(session.id);
+    assert.equal(goal?.status, 'active', 'the armed Goal survives the restart untouched');
+    assert.equal(goal?.iterations, 0, 'and no Turn ran for it');
+    await restarted.close();
+  } finally {
+    await goalStore.close();
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 function operationContext(connectionId: string) {
   return {
     hostEpoch: 'epoch-1',

--- a/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-coordinator.test.ts
@@ -872,6 +872,87 @@ test('resuming a Goal no Turn has carried leaves it for the next Turn, not for a
   }
 });
 
+test('an arm admitted before the drain creates no Goal after it', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-host-goal-arm-drain-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+
+  const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  const goalStore = await openInteractiveGoalAuthorityForWrite(owner.lease);
+  try {
+    const session = await stores.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    const sessionAdmission = new SessionAdmissionGate();
+    const host = new HostGoalCoordinator({
+      store: goalStore,
+      stores,
+      executions: {
+        reconcile: async () => assert.fail('A refused arm has no execution'),
+        subscribe: () => () => undefined,
+      },
+      sessionAdmission,
+      evaluator: {
+        evaluate: async () => assert.fail('A refused arm must not evaluate a Goal'),
+        close: async () => {},
+      },
+      admitTurn: () => assert.fail('A refused arm must not admit a Turn'),
+      listActionableTaskKeys: async () => [],
+      acquireResidency: () => ({ release: () => {} }),
+      onProjectionChanged: () => {},
+      requestDrain: () => {},
+      newId: () => 'goal-arm-after-drain',
+    });
+    await host.prepareRecovery();
+
+    // Hold this Session's admission so the arm is admitted but still queued
+    // when the composition begins to drain — the one window in which the
+    // Goal manager is already cleared and the callback has yet to run.
+    let releaseHolder = () => {};
+    const holder = sessionAdmission.run(
+      session.id,
+      () =>
+        new Promise<void>((resolve) => {
+          releaseHolder = () => resolve();
+        }),
+    );
+    const arming = host.handlers['goal.arm'](
+      {
+        sessionId: session.id,
+        condition: 'All tests pass',
+        maxIterations: null,
+        tokenBudget: null,
+      },
+      operationContext('connection-1'),
+    );
+    for (let tick = 0; tick < 5; tick += 1) await new Promise((r) => setImmediate(r));
+    host.beginDrain();
+    releaseHolder();
+    await holder;
+
+    const outcome = await arming;
+    assert.equal(outcome.ok, false, 'a draining Host answered an arm with success');
+    assert.equal(outcome.ok === false && outcome.error.code, 'host_draining');
+    assert.equal(host.readProjection(session.id), null, 'the drained Host holds a new Goal');
+    for (let tick = 0; tick < 20; tick += 1) await new Promise((r) => setImmediate(r));
+    assert.equal(await goalStore.read(session.id), null, 'the drain persisted a new Goal');
+    await host.close();
+  } finally {
+    await goalStore.close();
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
 function operationContext(connectionId: string) {
   return {
     hostEpoch: 'epoch-1',

--- a/packages/runtime-host/src/__tests__/goal-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/goal-protocol.test.ts
@@ -6,6 +6,7 @@ import {
   decodeResponseFrame,
   decodeSessionContinuitySnapshot,
   HOST_OPERATION_SPECS,
+  REMOTE_OWNER_OPERATION_GRANTS,
   SESSION_CONTINUITY_SCHEMA_VERSION,
 } from '../protocol/index.js';
 
@@ -119,4 +120,80 @@ test('Goal projection rejects unknown fields and text beyond the shared UTF-8 bo
   assert.throws(() => decodeGoalProjection({ ...goal, extra: true }));
   assert.throws(() => decodeGoalProjection({ ...goal, condition: '界'.repeat(501) }));
   assert.throws(() => decodeGoalProjection({ ...goal, lastReason: '界'.repeat(501) }));
+});
+
+test('goal.arm carries an exact frame and refuses budgets outside the shared bounds', () => {
+  const input = {
+    sessionId: 'session-1',
+    condition: 'All tests pass',
+    maxIterations: 20,
+    tokenBudget: 50_000,
+  };
+  assert.deepEqual(decodeRequestFrame({ requestId: 'request-arm', operation: 'goal.arm', input }), {
+    requestId: 'request-arm',
+    operation: 'goal.arm',
+    input,
+  });
+  // "Not chosen" travels as null, so the key set stays exact either way.
+  assert.deepEqual(
+    decodeRequestFrame({
+      requestId: 'request-arm-defaults',
+      operation: 'goal.arm',
+      input: { ...input, maxIterations: null, tokenBudget: null },
+    }).input,
+    { ...input, maxIterations: null, tokenBudget: null },
+  );
+  const decode = (patch: Record<string, unknown>): unknown =>
+    decodeRequestFrame({
+      requestId: 'request-arm',
+      operation: 'goal.arm',
+      input: { ...input, ...patch },
+    });
+  assert.throws(() => decode({ condition: '   ' }));
+  assert.throws(() => decode({ condition: '界'.repeat(501) }));
+  assert.throws(() => decode({ maxIterations: 201 }));
+  assert.throws(() => decode({ maxIterations: 0 }));
+  assert.throws(() => decode({ tokenBudget: 999 }));
+  assert.throws(() => decode({ blockCap: 8 }), 'goal.arm takes no unknown field');
+});
+
+test('goal.arm answers with a Goal from the Session it was asked about', () => {
+  const result = { sessionId: 'session-1', goal };
+  assert.deepEqual(
+    decodeResponseFrame({
+      requestId: 'request-arm',
+      operation: 'goal.arm',
+      ok: true,
+      result,
+    }),
+    { requestId: 'request-arm', operation: 'goal.arm', ok: true, result },
+  );
+  assert.throws(() =>
+    decodeResponseFrame({
+      requestId: 'request-arm',
+      operation: 'goal.arm',
+      ok: true,
+      result: { sessionId: 'session-2', goal },
+    }),
+  );
+  assert.throws(() =>
+    HOST_OPERATION_SPECS['goal.arm'].assertOutputForInput?.(
+      {
+        sessionId: 'session-2',
+        condition: 'All tests pass',
+        maxIterations: null,
+        tokenBudget: null,
+      },
+      result,
+    ),
+  );
+});
+
+test('a remote owner may arm a Goal, because it can already cause one', () => {
+  // Withholding goal.arm would withhold nothing: a remote owner sends Turns,
+  // and the model arms its own Goal with the GoalSet tool inside one. The only
+  // thing a refusal here removes is the explicit path the user can see and
+  // stop, so the grant sits at the same tier as goal.control.
+  assert.equal(REMOTE_OWNER_OPERATION_GRANTS.includes('goal.arm'), true);
+  assert.equal(REMOTE_OWNER_OPERATION_GRANTS.includes('goal.control'), true);
 });

--- a/packages/runtime-host/src/protocol/goal.ts
+++ b/packages/runtime-host/src/protocol/goal.ts
@@ -1,6 +1,8 @@
 import {
   GOAL_CONDITION_TEXT_LIMIT,
+  GOAL_MAX_ITERATIONS_LIMIT,
   GOAL_REASON_TEXT_LIMIT,
+  GOAL_TOKEN_BUDGET_MINIMUM,
   isGoalStatus,
   type GoalStatus,
 } from '@maka/core/goal';
@@ -24,6 +26,7 @@ const QUERY_ERRORS = [
   'internal_failure',
 ] as const;
 const CONTROL_ERRORS = [...QUERY_ERRORS, 'session_archived', 'operation_conflict'] as const;
+const ARM_ERRORS = CONTROL_ERRORS;
 
 export type GoalControlAction = 'pause' | 'resume' | 'clear';
 
@@ -54,6 +57,31 @@ export interface GoalQueryResult {
   readonly goal: GoalProjection | null;
 }
 
+/**
+ * Arm a Goal for a Session from outside a Turn.
+ *
+ * The model arms its own Goal with the GoalSet tool, inside the Turn that owns
+ * the control lease. A user arming one has no Turn to speak from, so this is
+ * the Host's own entry point for it — same authority, same durable record, no
+ * second implementation of what a Goal is.
+ *
+ * `maxIterations` and `tokenBudget` are nullable rather than optional: the
+ * frame carries an exact key set, and "the caller did not choose" has to be a
+ * value on the wire rather than an absent field. Null means the Goal takes the
+ * Runtime default (and, for the budget, no budget at all).
+ */
+export interface GoalArmInput {
+  readonly sessionId: string;
+  readonly condition: string;
+  readonly maxIterations: number | null;
+  readonly tokenBudget: number | null;
+}
+
+export interface GoalArmResult {
+  readonly sessionId: string;
+  readonly goal: GoalProjection;
+}
+
 export interface GoalControlInput {
   readonly sessionId: string;
   readonly goalId: string;
@@ -76,6 +104,18 @@ export const GOAL_OPERATION_SPECS = {
     assertOutputForInput(input, output) {
       if (input.sessionId !== output.sessionId) {
         throw invalidProtocolFrame('Goal query result belongs to a different Session');
+      }
+    },
+  }),
+  'goal.arm': defineOperation({
+    mode: 'control',
+    availability: 'ready',
+    errors: ARM_ERRORS,
+    decodeInput: decodeGoalArmInput,
+    decodeOutput: decodeGoalArmResult,
+    assertOutputForInput(input, output) {
+      if (input.sessionId !== output.sessionId) {
+        throw invalidProtocolFrame('Goal arm result belongs to a different Session');
       }
     },
   }),
@@ -151,6 +191,48 @@ function decodeGoalQueryResult(value: unknown): GoalQueryResult {
   const goal = record.goal === null ? null : decodeGoalProjection(record.goal);
   if (goal && goal.sessionId !== sessionId) {
     throw invalidProtocolFrame('Goal query result contains a Goal from another Session');
+  }
+  return { sessionId, goal };
+}
+
+function decodeGoalArmInput(value: unknown): GoalArmInput {
+  const record = requireExactRecord(value, 'goal.arm input', [
+    'sessionId',
+    'condition',
+    'maxIterations',
+    'tokenBudget',
+  ]);
+  const condition = requireUtf8String(
+    record.condition,
+    'Goal condition',
+    GOAL_CONDITION_TEXT_LIMIT.utf8Bytes,
+  );
+  if (!condition.trim() || condition.length > GOAL_CONDITION_TEXT_LIMIT.codeUnits) {
+    throw invalidProtocolFrame('Invalid Goal condition');
+  }
+  const maxIterations = requireNullablePositiveCount(record.maxIterations, 'Goal maxIterations');
+  if (maxIterations !== null && maxIterations > GOAL_MAX_ITERATIONS_LIMIT) {
+    throw invalidProtocolFrame('Goal maxIterations exceeds its limit');
+  }
+  const tokenBudget = requireNullablePositiveCount(record.tokenBudget, 'Goal tokenBudget');
+  if (tokenBudget !== null && tokenBudget < GOAL_TOKEN_BUDGET_MINIMUM) {
+    throw invalidProtocolFrame('Goal tokenBudget is below its minimum');
+  }
+  return {
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    condition,
+    maxIterations,
+    tokenBudget,
+  };
+}
+
+function decodeGoalArmResult(value: unknown): GoalArmResult {
+  requireEncodedByteLimit(value, 'Goal arm result', GOAL_RESULT_MAX_BYTES);
+  const record = requireExactRecord(value, 'goal.arm result', ['sessionId', 'goal']);
+  const sessionId = requireEntityId(record.sessionId, 'sessionId');
+  const goal = decodeGoalProjection(record.goal);
+  if (goal.sessionId !== sessionId) {
+    throw invalidProtocolFrame('Goal arm result contains a Goal from another Session');
   }
   return { sessionId, goal };
 }

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -72,7 +72,9 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 28 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 29 as const;
+// 29: `goal.arm` is a new wire operation. An older Host decodes it as unknown
+// and tears the connection down, so the pair must be refused up front.
 // 28: Relay model profiles carry the Fast service-tier declaration. Older
 // peers cannot safely preserve that Runtime Policy field.
 // 27: Runtime Policy carries the Host-owned shell preference used by tool,

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -234,6 +234,7 @@ export const REMOTE_OWNER_OPERATION_GRANTS = Object.freeze([
   'external-session.catalog.query',
   'external-session.import',
   'external-session.source.query',
+  'goal.arm',
   'goal.control',
   'goal.query',
   'host.diagnostics.query',

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -102,11 +102,11 @@ export class HostGoalCoordinator {
   readonly #executions: Pick<HostedExecutionAuthority, 'reconcile' | 'subscribe'>;
   readonly #authorityBySession = new Map<string, GoalAuthoritySnapshot>();
   /**
-   * Token count per Session as of the last continuation read. It is the
-   * baseline a new Goal starts from, and `#arm` reads the same cache the
-   * GoalSet tool does — a second source would let the two paths disagree about
-   * what a Goal has spent. An empty entry means no evaluation has read this
-   * Session yet, which is what `tokensBaselinePending` on the Goal is for.
+   * Token count per Session as of the last continuation read, which is what a
+   * settling Turn reports so the Goal can measure its budget. It is not a
+   * baseline for a new Goal: only an evaluation writes here, so a Session that
+   * has never run one has no entry, and `tokensBaselinePending` on the Goal is
+   * what carries that until the first Turn carrying it settles.
    */
   readonly #tokenCache = new Map<string, number>();
   readonly #recoveryWaits = new Set<Promise<void>>();
@@ -161,7 +161,6 @@ export class HostGoalCoordinator {
       buildGoalTools({
         goalManager: this.manager,
         goalContinuation: this.continuation,
-        getTokenCount: (sessionId) => tokenCache.get(sessionId) ?? 0,
         isAvailable: () => !this.#draining,
         flush: (sessionId) => this.#flushGoalState(sessionId),
         now,
@@ -361,7 +360,6 @@ export class HostGoalCoordinator {
       const created = this.manager.create(input.sessionId, input.condition, {
         ...(input.maxIterations === null ? {} : { maxIterations: input.maxIterations }),
         ...(input.tokenBudget === null ? {} : { tokenBudget: input.tokenBudget }),
-        tokensAtStart: this.#tokenCache.get(input.sessionId) ?? 0,
       });
       if (created.kind === 'unfinished') {
         return operationConflict(

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import {
+  hasCarriedTurn,
   sameGoalControlLease,
   type GoalAuthorityRecord,
   type GoalControlLease as DurableGoalControlLease,
@@ -193,12 +194,24 @@ export class HostGoalCoordinator {
     this.#prepared = true;
   }
 
+  /**
+   * Resume the Goal loop where the last Host epoch left it.
+   *
+   * A durable Goal with no execution of its own is either between
+   * continuations or has never run at all, and `status` cannot tell those
+   * apart: `goal.arm` persists an `active` Goal that takes hold on the user's
+   * next Turn, and arming alone starts nothing. Recovery therefore asks
+   * whether a Turn has ever carried the Goal, and leaves the ones that have
+   * not for `beginObservedTurn` to bind exactly as it would have before the
+   * restart. An execution that was in flight is its own proof of carrying, so
+   * that branch keeps recovering unconditionally.
+   */
   async recover(): Promise<void> {
     if (!this.#prepared) throw new Error('Goal recovery was not prepared');
     for (const snapshot of this.#authorityBySession.values()) {
       if (snapshot.record.currentExecution) {
         await this.#recoverCurrentExecution(snapshot.record.currentExecution);
-      } else {
+      } else if (hasCarriedTurn(snapshot.record.goal)) {
         this.continuation.recoverActiveGoal(snapshot.record.goal.sessionId);
       }
     }

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -33,7 +33,12 @@ import {
   type GoalAuthoritySnapshot,
   type InteractiveGoalAuthorityWriter,
 } from '@maka/storage/goal-authority';
-import type { GoalControlInput, GoalProjection, OperationOutcome } from '../protocol/index.js';
+import type {
+  GoalArmInput,
+  GoalControlInput,
+  GoalProjection,
+  OperationOutcome,
+} from '../protocol/index.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
 import type { GoalOperationHandlerMap } from './operation-dispatcher.js';
 import { projectGoalState } from './goal-projection.js';
@@ -78,6 +83,7 @@ export interface HostGoalSessionRetirement {
 export class HostGoalCoordinator {
   readonly handlers: GoalOperationHandlerMap = {
     'goal.query': (input) => this.#query(input.sessionId),
+    'goal.arm': (input) => this.#arm(input),
     'goal.control': (input) => this.#control(input),
   };
 
@@ -94,6 +100,14 @@ export class HostGoalCoordinator {
   readonly #acquireResidency: () => RuntimeHostResidency;
   readonly #executions: Pick<HostedExecutionAuthority, 'reconcile' | 'subscribe'>;
   readonly #authorityBySession = new Map<string, GoalAuthoritySnapshot>();
+  /**
+   * Token count per Session as of the last continuation read. It is the
+   * baseline a new Goal starts from, and `#arm` reads the same cache the
+   * GoalSet tool does — a second source would let the two paths disagree about
+   * what a Goal has spent. An empty entry means no evaluation has read this
+   * Session yet, which is what `tokensBaselinePending` on the Goal is for.
+   */
+  readonly #tokenCache = new Map<string, number>();
   readonly #recoveryWaits = new Set<Promise<void>>();
   readonly #recoveryAbort = new AbortController();
   #persistenceLane: Promise<void> = Promise.resolve();
@@ -120,7 +134,7 @@ export class HostGoalCoordinator {
         this.#onProjectionChanged(goal.sessionId);
       },
     });
-    const tokenCache = new Map<string, number>();
+    const tokenCache = this.#tokenCache;
     this.continuation = new GoalContinuationCoordinator({
       goalManager: this.manager,
       evaluator: options.evaluator,
@@ -302,6 +316,49 @@ export class HostGoalCoordinator {
       return {
         ok: true,
         result: { sessionId, goal: this.readProjection(sessionId) },
+      };
+    });
+  }
+
+  /**
+   * Arm a Goal from outside a Turn — the Host's own entry point for a user who
+   * asked for one, next to the GoalSet tool the model uses from inside a Turn.
+   *
+   * It creates the Goal and nothing else. There is deliberately no continuation
+   * scheduled here: a Goal armed with no Turn running takes effect on the next
+   * Turn, which `beginObservedTurn` binds to the live control lease, and the
+   * loop starts when that Turn settles. Arming does not itself start spending.
+   *
+   * A Turn already in flight keeps the standing it registered with — it was
+   * bound before this Goal existed, so it settles outside the Goal, and the one
+   * after it is the first the Goal drives.
+   */
+  #arm(input: GoalArmInput): Promise<OperationOutcome<'goal.arm'>> {
+    return this.#sessionAdmission.run(input.sessionId, async () => {
+      let header;
+      try {
+        header = await this.#stores.sessionStore.readHeaderSnapshot(input.sessionId);
+      } catch (error) {
+        if (isSessionNotFoundError(error)) return notFound('Session does not exist');
+        throw error;
+      }
+      if (header.isArchived) {
+        return sessionArchived('Archived Session cannot be given a Goal');
+      }
+      const created = this.manager.create(input.sessionId, input.condition, {
+        ...(input.maxIterations === null ? {} : { maxIterations: input.maxIterations }),
+        ...(input.tokenBudget === null ? {} : { tokenBudget: input.tokenBudget }),
+        tokensAtStart: this.#tokenCache.get(input.sessionId) ?? 0,
+      });
+      if (created.kind === 'unfinished') {
+        return operationConflict(
+          `Session already has an unfinished Goal in status ${created.goal.status}`,
+        );
+      }
+      await this.#flushGoalState(input.sessionId);
+      return {
+        ok: true,
+        result: { sessionId: input.sessionId, goal: projectGoalState(created.goal) },
       };
     });
   }

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -348,6 +348,12 @@ export class HostGoalCoordinator {
    */
   #arm(input: GoalArmInput): Promise<OperationOutcome<'goal.arm'>> {
     return this.#sessionAdmission.run(input.sessionId, async () => {
+      // Admission is a queue, and the composition begins to drain without
+      // waiting for it to empty. An arm let through before that can still be
+      // waiting behind another operation when the Goal manager is disposed,
+      // and it is the one operation here that would answer by creating state:
+      // the others read a manager that no longer holds anything and say so.
+      if (this.#draining) return hostDraining();
       let header;
       try {
         header = await this.#stores.sessionStore.readHeaderSnapshot(input.sessionId);
@@ -634,6 +640,13 @@ function operationConflict(message: string) {
   return {
     ok: false as const,
     error: { code: 'operation_conflict' as const, message },
+  };
+}
+
+function hostDraining() {
+  return {
+    ok: false as const,
+    error: { code: 'host_draining' as const, message: 'Runtime Host is draining' },
   };
 }
 

--- a/packages/runtime-host/src/server/goal-coordinator.ts
+++ b/packages/runtime-host/src/server/goal-coordinator.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto';
 import {
-  hasCarriedTurn,
   sameGoalControlLease,
   type GoalAuthorityRecord,
   type GoalControlLease as DurableGoalControlLease,
@@ -199,18 +198,20 @@ export class HostGoalCoordinator {
    * A durable Goal with no execution of its own is either between
    * continuations or has never run at all, and `status` cannot tell those
    * apart: `goal.arm` persists an `active` Goal that takes hold on the user's
-   * next Turn, and arming alone starts nothing. Recovery therefore asks
-   * whether a Turn has ever carried the Goal, and leaves the ones that have
-   * not for `beginObservedTurn` to bind exactly as it would have before the
-   * restart. An execution that was in flight is its own proof of carrying, so
-   * that branch keeps recovering unconditionally.
+   * next Turn, and arming alone starts nothing. Telling them apart is the
+   * continuation's own rule — only a settled Turn ever starts a Goal driving,
+   * so only a Goal a Turn has carried has a drive to restore — and
+   * `recoverActiveGoal` holds it for every caller. Recovery hands it each
+   * Goal and lets it decide, rather than keeping a second copy of the rule
+   * here that a later change could contradict. An execution that was in
+   * flight is its own proof of carrying, so that branch recovers directly.
    */
   async recover(): Promise<void> {
     if (!this.#prepared) throw new Error('Goal recovery was not prepared');
     for (const snapshot of this.#authorityBySession.values()) {
       if (snapshot.record.currentExecution) {
         await this.#recoverCurrentExecution(snapshot.record.currentExecution);
-      } else if (hasCarriedTurn(snapshot.record.goal)) {
+      } else {
         this.continuation.recoverActiveGoal(snapshot.record.goal.sessionId);
       }
     }
@@ -358,6 +359,7 @@ export class HostGoalCoordinator {
         return sessionArchived('Archived Session cannot be given a Goal');
       }
       const created = this.manager.create(input.sessionId, input.condition, {
+        armed: true,
         ...(input.maxIterations === null ? {} : { maxIterations: input.maxIterations }),
         ...(input.tokenBudget === null ? {} : { tokenBudget: input.tokenBudget }),
       });

--- a/packages/runtime/src/__tests__/goal-state.test.ts
+++ b/packages/runtime/src/__tests__/goal-state.test.ts
@@ -108,6 +108,11 @@ describe('GoalManager creation and lifecycle', () => {
     assert.equal(defaultGoal.blockCap, 8);
   });
 
+  test('stores the condition trimmed, whichever caller set it', () => {
+    const { mgr } = createManager();
+    assert.equal(createGoal(mgr, '  ship it\n').condition, 'ship it');
+  });
+
   test('rejects active and paused Goal replacement without mutating either snapshot', () => {
     const { mgr, events } = createManager();
     const original = createGoal(mgr, 'first');

--- a/packages/runtime/src/__tests__/goal-state.test.ts
+++ b/packages/runtime/src/__tests__/goal-state.test.ts
@@ -91,7 +91,6 @@ describe('GoalManager creation and lifecycle', () => {
       maxIterations: 10,
       blockCap: 3,
       tokenBudget: 5000,
-      tokensAtStart: 100,
     });
 
     assert.equal(goal.revision, 0);
@@ -99,7 +98,7 @@ describe('GoalManager creation and lifecycle', () => {
     assert.equal(goal.maxIterations, 10);
     assert.equal(goal.blockCap, 3);
     assert.equal(goal.tokenBudget, 5000);
-    assert.equal(goal.tokensAtStart, 100);
+    assert.equal(goal.tokensAtStart, 0);
     assert.ok(Object.isFrozen(goal));
 
     const { mgr: defaults } = createManager();
@@ -206,10 +205,31 @@ describe('GoalManager creation and lifecycle', () => {
   });
 });
 
+describe('GoalManager token budget baseline', () => {
+  test('measures the budget from the first carried Turn, whoever set the Goal', () => {
+    const { mgr } = createManager();
+    createGoal(mgr, 'ship it', { tokenBudget: 1_000 });
+
+    // The Session had already spent 40k before anything carried this Goal.
+    // That settlement establishes the baseline instead of being charged to it.
+    const first = settle(mgr, { madeProgress: true, tokensNow: 40_000 });
+    assert.equal(first?.status, 'active');
+    assert.equal(first?.tokensAtStart, 40_000);
+    assert.equal(first?.tokensBaselinePending, false);
+
+    // Everything the Goal drives from there is measured against the budget.
+    const second = settle(mgr, { madeProgress: true, tokensNow: 40_500 });
+    assert.equal(second?.status, 'active', '500 of a 1,000 budget leaves it running');
+
+    const third = settle(mgr, { madeProgress: true, tokensNow: 41_000 });
+    assert.equal(third?.status, 'budget_limited');
+  });
+});
+
 describe('GoalManager atomic turn settlement', () => {
   test('commits token, iteration, progress, reason, revision, and one event atomically', () => {
     const { mgr, events } = createManager();
-    const before = createGoal(mgr, 'x', { tokensAtStart: 0 });
+    const before = createGoal(mgr, 'x');
     const result = settle(mgr, {
       madeProgress: false,
       tokensNow: 50_000,

--- a/packages/runtime/src/__tests__/goal-state.test.ts
+++ b/packages/runtime/src/__tests__/goal-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
+import { isDrivingGoal } from '@maka/core/goal';
 import { GoalManager, goalCheckpoint, type GoalState } from '../goal-state.js';
 
 const SESSION = 'sess-1';
@@ -223,6 +224,31 @@ describe('GoalManager token budget baseline', () => {
 
     const third = settle(mgr, { madeProgress: true, tokensNow: 41_000 });
     assert.equal(third?.status, 'budget_limited');
+  });
+});
+
+describe('GoalManager arming', () => {
+  test('a Goal the model set drives from the moment it exists', () => {
+    const { mgr } = createManager();
+    assert.equal(isDrivingGoal(createGoal(mgr, 'x')), true);
+  });
+
+  test('an armed Goal drives once a carried Turn settles it into a continuation', () => {
+    const { mgr } = createManager();
+    assert.equal(isDrivingGoal(createGoal(mgr, 'x', { armed: true })), false);
+    const settled = settle(mgr);
+    assert.ok(settled);
+    assert.equal(isDrivingGoal(settled), true);
+  });
+
+  test('resume drives an armed Goal no Turn ever carried', () => {
+    const { mgr } = createManager();
+    const armed = createGoal(mgr, 'x', { armed: true });
+    const paused = mgr.pause(SESSION, { checkpoint: goalCheckpoint(armed) });
+    assert.ok(paused);
+    const resumed = mgr.resume(SESSION, goalCheckpoint(paused));
+    assert.ok(resumed);
+    assert.equal(isDrivingGoal(resumed), true);
   });
 });
 

--- a/packages/runtime/src/__tests__/goal-tools.test.ts
+++ b/packages/runtime/src/__tests__/goal-tools.test.ts
@@ -29,7 +29,7 @@ function findTool(tools: MakaTool[], name: string): MakaTool {
   return t!;
 }
 
-function makeTools(getTokenCount?: (s: string) => number) {
+function makeTools() {
   const mgr = new GoalManager({ generateId: () => 'g-1', now: () => 5000 });
   const goalContinuation = new GoalContinuationCoordinator({
     goalManager: mgr,
@@ -42,18 +42,21 @@ function makeTools(getTokenCount?: (s: string) => number) {
   const tools = buildGoalTools({
     goalManager: mgr,
     goalContinuation,
-    getTokenCount,
     now: () => 5000,
   });
   return { mgr, tools, goalContinuation };
 }
 
 describe('goal tools', () => {
-  test('GoalSet captures the token baseline', async () => {
-    const { mgr, tools } = makeTools(() => 1234);
+  test('GoalSet leaves the token baseline for the first carried Turn to settle', async () => {
+    const { mgr, tools } = makeTools();
     const set = findTool(tools, GOAL_SET_TOOL_NAME);
     await set.impl({ condition: 'x' }, ctx());
-    assert.equal(mgr.get(SESSION)?.tokensAtStart, 1234);
+    const goal = mgr.get(SESSION);
+    // The Turn holding this tool call has already spent tokens the Goal did
+    // not cause, so there is no honest baseline to record yet.
+    assert.equal(goal?.tokensBaselinePending, true);
+    assert.equal(goal?.tokensAtStart, 0);
   });
 
   test('GoalSet reports an unfinished Goal instead of replacing it', async () => {

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -404,13 +404,15 @@ export class GoalContinuationCoordinator {
   }
 
   /**
-   * Put back a loop this Goal is already in, and only that.
+   * Put back the drive this Goal already has, and only that.
    *
-   * Recovery and resume both restore a continuation rather than start one, so
-   * both must refuse a Goal that is not in a loop to begin with — an armed
-   * Goal no Turn has taken hold of, which `goal.arm` deliberately left for the
-   * user's next Turn. Two callers must obey that and a third would inherit it,
-   * so the rule is stated once here rather than at each door.
+   * Neither caller may start a loop the Goal is not in: a restart would
+   * otherwise begin one for an armed Goal that `goal.arm` deliberately left
+   * for the user's next Turn. Resume is not an exception to that rule but a
+   * satisfier of it — resuming is the user asking for continuation, so the
+   * Goal is already driving by the time it arrives here. Two callers must obey
+   * this and a third would inherit it, so it is stated once here rather than
+   * at each door.
    */
   private restoreDrive(
     lane: SessionLane,

--- a/packages/runtime/src/goal-continuation.ts
+++ b/packages/runtime/src/goal-continuation.ts
@@ -27,6 +27,7 @@ import {
 import { GoalTaskGatePolicy, type GoalTaskGateDeps } from './goal-task-gate-policy.js';
 import type { GoalTurnOutcome } from './goal-turn-lifecycle.js';
 import {
+  isDrivingGoal,
   sameGoalControlLease,
   type GoalCurrentExecution,
   type GoalExecutionRef,
@@ -402,6 +403,26 @@ export class GoalContinuationCoordinator {
     };
   }
 
+  /**
+   * Put back a loop this Goal is already in, and only that.
+   *
+   * Recovery and resume both restore a continuation rather than start one, so
+   * both must refuse a Goal that is not in a loop to begin with — an armed
+   * Goal no Turn has taken hold of, which `goal.arm` deliberately left for the
+   * user's next Turn. Two callers must obey that and a third would inherit it,
+   * so the rule is stated once here rather than at each door.
+   */
+  private restoreDrive(
+    lane: SessionLane,
+    goal: GoalState,
+    controlLease: GoalControlLease,
+    evaluation: GoalEvaluation,
+  ): void {
+    if (!isDrivingGoal(goal)) return;
+    lane.intent = { checkpoint: goalCheckpoint(goal), controlLease, evaluation };
+    this.scheduleDrain(lane);
+  }
+
   recoverActiveGoal(sessionId: string): void {
     if (this.disposed || this.sessionCloseFence.isClosed(sessionId)) return;
     const goal = this.deps.goalManager.get(sessionId);
@@ -409,19 +430,14 @@ export class GoalContinuationCoordinator {
     if (!goal || !controlLease || (goal.status !== 'active' && goal.status !== 'waiting')) return;
     const lane = this.laneFor(sessionId);
     if (lane.intent || lane.turns.size > 0) return;
-    lane.intent = {
-      checkpoint: goalCheckpoint(goal),
-      controlLease,
-      evaluation: {
-        met: false,
-        impossible: false,
-        progress: false,
-        waiting: goal.status === 'waiting',
-        evaluatorFailed: true,
-        reason: goal.lastReason ?? 'Goal continuation recovered after Host restart.',
-      },
-    };
-    this.scheduleDrain(lane);
+    this.restoreDrive(lane, goal, controlLease, {
+      met: false,
+      impossible: false,
+      progress: false,
+      waiting: goal.status === 'waiting',
+      evaluatorFailed: true,
+      reason: goal.lastReason ?? 'Goal continuation recovered after Host restart.',
+    });
   }
 
   /** Resume an exact paused Goal generation from Host control without a model-owned Turn. */
@@ -432,22 +448,17 @@ export class GoalContinuationCoordinator {
     const controlLease = this.deps.goalManager.getControlLease(sessionId);
     if (!controlLease) return undefined;
     const lane = this.laneFor(sessionId);
-    lane.intent = {
-      checkpoint: goalCheckpoint(resumed),
-      controlLease,
-      evaluation: {
-        met: false,
-        impossible: false,
-        progress: false,
-        waiting: false,
-        evaluatorFailed: false,
-        reason: 'Goal resumed by a connected client.',
-      },
-    };
     lane.busyWake = undefined;
     this.clearWaitingTimer(lane);
     this.resetWaitingBackoff(lane);
-    this.scheduleDrain(lane);
+    this.restoreDrive(lane, resumed, controlLease, {
+      met: false,
+      impossible: false,
+      progress: false,
+      waiting: false,
+      evaluatorFailed: false,
+      reason: 'Goal resumed by a connected client.',
+    });
     return resumed;
   }
 

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -189,7 +189,10 @@ export class GoalManager {
       tokensAtStart?: number;
     },
   ): GoalCreateResult {
-    if (!condition.trim() || !isGoalTextWithinLimit(condition, GOAL_CONDITION_TEXT_LIMIT)) {
+    // Every caller reaches the Goal through here, so the stored condition is
+    // trimmed once here rather than by each caller in its own way.
+    const trimmed = condition.trim();
+    if (!trimmed || !isGoalTextWithinLimit(trimmed, GOAL_CONDITION_TEXT_LIMIT)) {
       throw new RangeError('Goal condition exceeds its shared text limit');
     }
     const existing = this.goals.get(sessionId)?.state;
@@ -202,7 +205,7 @@ export class GoalManager {
       id: this.deps.generateId(),
       revision: 0,
       sessionId,
-      condition,
+      condition: trimmed,
       status: 'active',
       setAt: this.deps.now(),
       iterations: 0,

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -186,7 +186,6 @@ export class GoalManager {
       maxIterations?: number;
       blockCap?: number;
       tokenBudget?: number;
-      tokensAtStart?: number;
     },
   ): GoalCreateResult {
     // Every caller reaches the Goal through here, so the stored condition is
@@ -200,7 +199,12 @@ export class GoalManager {
       return { kind: 'unfinished', goal: existing };
     }
 
-    const start = opts?.tokensAtStart ?? 0;
+    // The token baseline is not knowable here. `GoalSet` runs inside a Turn
+    // whose own spend predates the Goal, and `goal.arm` runs outside every
+    // Turn, so neither caller can name the count the budget should measure
+    // from. Both start at zero and `settleTurn` writes the real baseline when
+    // the first Turn carrying the Goal settles: the budget bounds what the
+    // Goal goes on to drive, not the Turn it was born beside.
     const goal: GoalState = Object.freeze({
       id: this.deps.generateId(),
       revision: 0,
@@ -213,8 +217,8 @@ export class GoalManager {
       consecutiveNoProgress: 0,
       blockCap: opts?.blockCap ?? DEFAULT_BLOCK_CAP,
       tokenBudget: opts?.tokenBudget,
-      tokensAtStart: start,
-      tokensNow: start,
+      tokensAtStart: 0,
+      tokensNow: 0,
       tokensBaselinePending: true,
     });
     const goalRecord: GoalRecord = {

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -29,8 +29,11 @@ import {
 } from '@maka/core/goal';
 
 export {
+  GOAL_BLOCK_CAP_LIMIT,
   GOAL_CONDITION_TEXT_LIMIT,
+  GOAL_MAX_ITERATIONS_LIMIT,
   GOAL_REASON_TEXT_LIMIT,
+  GOAL_TOKEN_BUDGET_MINIMUM,
   type GoalCheckpoint,
   type GoalControlLease,
   type GoalState,

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -370,6 +370,9 @@ export class GoalManager {
         tokensNow,
         tokensBaselinePending,
         lastReason,
+        // A Turn carried this Goal all the way into a continuation, so
+        // whatever it was armed to wait for has happened.
+        armedAt: undefined,
       };
     }
 
@@ -399,7 +402,10 @@ export class GoalManager {
     if (checkpoint && !this.matches(sessionId, checkpoint)) return undefined;
     return this.commit(
       record,
-      { status: 'active', pausedAt: undefined },
+      // Resume is a request for continuation, not a return to whatever the
+      // Goal was doing before. A Goal armed and never carried has been waiting
+      // for a Turn to take hold of it; this is one.
+      { status: 'active', pausedAt: undefined, armedAt: undefined },
       { renewControlLease: true },
     );
   }

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -144,6 +144,7 @@ type GoalStatePatch = Partial<
 
 export class GoalManager {
   private goals = new Map<string, GoalRecord>();
+  private disposed = false;
 
   constructor(private readonly deps: GoalManagerDeps) {}
 
@@ -194,6 +195,12 @@ export class GoalManager {
       armed?: boolean;
     },
   ): GoalCreateResult {
+    // A disposed manager has no Goals, which is not the same as being able to
+    // start one. Reads after disposal answer honestly by finding nothing;
+    // this is the only entry that would answer by conjuring a Goal into a
+    // composition that is already shutting down, so it refuses instead of
+    // repopulating the map its owner just emptied.
+    if (this.disposed) throw new Error('Goal manager is disposed');
     // Every caller reaches the Goal through here, so the stored condition is
     // trimmed once here rather than by each caller in its own way.
     const trimmed = condition.trim();
@@ -416,6 +423,7 @@ export class GoalManager {
   }
 
   dispose(): void {
+    this.disposed = true;
     this.goals.clear();
   }
 }

--- a/packages/runtime/src/goal-state.ts
+++ b/packages/runtime/src/goal-state.ts
@@ -186,6 +186,12 @@ export class GoalManager {
       maxIterations?: number;
       blockCap?: number;
       tokenBudget?: number;
+      /**
+       * Whether this Goal is being armed from outside a Turn rather than set
+       * by the model inside one. Recorded on the Goal because nothing else
+       * survives a restart to say which of the two it was.
+       */
+      armed?: boolean;
     },
   ): GoalCreateResult {
     // Every caller reaches the Goal through here, so the stored condition is
@@ -205,13 +211,15 @@ export class GoalManager {
     // from. Both start at zero and `settleTurn` writes the real baseline when
     // the first Turn carrying the Goal settles: the budget bounds what the
     // Goal goes on to drive, not the Turn it was born beside.
+    const setAt = this.deps.now();
     const goal: GoalState = Object.freeze({
       id: this.deps.generateId(),
       revision: 0,
       sessionId,
       condition: trimmed,
       status: 'active',
-      setAt: this.deps.now(),
+      setAt,
+      ...(opts?.armed ? { armedAt: setAt } : {}),
       iterations: 0,
       maxIterations: opts?.maxIterations ?? DEFAULT_MAX_ITERATIONS,
       consecutiveNoProgress: 0,

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -126,8 +126,6 @@ export interface GoalToolsDeps {
     GoalContinuationCoordinator,
     'activateGoal' | 'mutateGoal' | 'activationStanding' | 'mutationStanding'
   >;
-  /** Current cumulative token count for a session (baseline for budget). */
-  getTokenCount?: (sessionId: string) => number;
   /**
    * Reject new model-owned mutations while the enclosing authority drains.
    *
@@ -212,13 +210,11 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
           'Clear or complete it before setting another goal.'
         );
       }
-      const tokensAtStart = deps.getTokenCount?.(ctx.sessionId) ?? 0;
       const goal = deps.goalContinuation.activateGoal(ctx.sessionId, ctx.turnId, () => {
         return deps.goalManager.create(ctx.sessionId, input.condition, {
           maxIterations: input.max_iterations,
           blockCap: input.block_cap,
           tokenBudget: input.token_budget,
-          tokensAtStart,
         }).goal;
       });
       if (!goal) {

--- a/packages/runtime/src/goal-tools.ts
+++ b/packages/runtime/src/goal-tools.ts
@@ -9,7 +9,10 @@
 import { z } from 'zod';
 import type { MakaTool } from './tool-runtime.js';
 import {
+  GOAL_BLOCK_CAP_LIMIT,
   GOAL_CONDITION_TEXT_LIMIT,
+  GOAL_MAX_ITERATIONS_LIMIT,
+  GOAL_TOKEN_BUDGET_MINIMUM,
   isGoalTextWithinLimit,
   TERMINAL_GOAL_STATUSES,
   type GoalManager,
@@ -179,14 +182,14 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
         .number()
         .int()
         .min(1)
-        .max(200)
+        .max(GOAL_MAX_ITERATIONS_LIMIT)
         .optional()
         .describe('Absolute ceiling on total turns before giving up. Defaults to 50.'),
       block_cap: z
         .number()
         .int()
         .min(1)
-        .max(50)
+        .max(GOAL_BLOCK_CAP_LIMIT)
         .optional()
         .describe(
           'Stop after this many consecutive turns with no progress (stall detection). Defaults to 8.',
@@ -194,7 +197,7 @@ function buildGoalSetTool(deps: GoalToolsDeps): MakaTool<
       token_budget: z
         .number()
         .int()
-        .min(1000)
+        .min(GOAL_TOKEN_BUDGET_MINIMUM)
         .optional()
         .describe(
           'Optional token budget; the goal stops (budget_limited) once this many tokens are spent working toward it.',

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -23,6 +23,7 @@ import {
   Plus,
   Square,
   Sparkles,
+  Target,
   Upload,
   Workflow,
 } from './icons.js';
@@ -368,6 +369,24 @@ export const Composer = forwardRef<
     orchestrationModePending?: boolean;
     orchestrationModeDisabledReason?: string;
     onOrchestrationModeChange?(mode: OrchestrationMode): void | Promise<void>;
+    /**
+     * Open the host's Goal dialog. The composer offers the entry and nothing
+     * else: a Goal names a condition and two budgets, which is a form, and the
+     * ＋ menu is a menu. Absent handler, no entry — the same rule the other
+     * ＋ entries follow.
+     */
+    onSetGoal?(): void | Promise<void>;
+    /**
+     * A Goal is already running here. Arming refuses a second one, so the
+     * entry says so up front instead of spending the user's click on an error.
+     */
+    goalActive?: boolean;
+    /**
+     * Why a Goal cannot be set right now — a running Turn, typically. A Goal
+     * takes hold on the Turn after it is armed, so arming during one reads as
+     * having done nothing; the host names the reason and the entry shows it.
+     */
+    goalDisabledReason?: string;
     /**
      * Composer mention popups. Both are optional and the whole feature no-ops
      * when absent (SSR contracts render Composer with minimal props):
@@ -1412,7 +1431,9 @@ export const Composer = forwardRef<
    * groups, so with nothing above it there is nothing to separate — a host
    * that wires only the mode controls would open the menu on a rule.
    */
-  const hasPlusMenuActions = Boolean(props.onPickAttachments || props.mentionSkills);
+  const hasPlusMenuActions = Boolean(
+    props.onPickAttachments || props.mentionSkills || props.onSetGoal,
+  );
   const hasPlusMenuModes = Boolean(props.onPlanModeChange || props.onOrchestrationModeChange);
   const showPlusMenu = Boolean(hasPlusMenuActions || hasPlusMenuModes);
 
@@ -1666,6 +1687,25 @@ export const Composer = forwardRef<
                           props.mentionSkills.length === 0 ? copy.noSkillsAvailable : undefined
                         }
                         onClick={openSkillMenu}
+                      />
+                    ) : null}
+                    {props.onSetGoal ? (
+                      <DropdownMenuItem
+                        label={copy.setGoal}
+                        icon={<Target size={ICON_SIZE.control} aria-hidden="true" />}
+                        isDisabled={
+                          props.disabled
+                          || props.goalActive === true
+                          || Boolean(props.goalDisabledReason)
+                        }
+                        description={
+                          props.goalActive === true
+                            ? copy.goalAlreadySet
+                            : props.goalDisabledReason
+                        }
+                        onClick={() => {
+                          void props.onSetGoal?.();
+                        }}
                       />
                     ) : null}
                     {hasPlusMenuModes ? (

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -111,6 +111,10 @@ export interface ConversationCopy {
     chooseSkill: string;
     /** Why that entry is unavailable: the catalog is empty. */
     noSkillsAvailable: string;
+    /** The ＋ menu entry that opens the Goal dialog. */
+    setGoal: string;
+    /** Why that entry is unavailable: this Session already has an unfinished Goal. */
+    goalAlreadySet: string;
     switchDisabledStreaming: string;
     switchDisabledRunning: string;
     switchDisabledPermission: string;
@@ -385,6 +389,7 @@ const CONVERSATION_COPY = {
       interruptHint: '或点停止中断', addContext: '添加上下文', stagedContext: '附加内容',
       selectModel: '选择模型', dropToImport: '松开以导入文件内容', addingAttachment: '正在添加附件', addFileOrDirectory: '添加文件或目录',
       chooseSkill: '选择技能', noSkillsAvailable: '当前没有可用技能',
+      setGoal: '设定 Goal…', goalAlreadySet: '当前会话已有进行中的 Goal',
       switchDisabledStreaming: '当前任务正在流式输出，等结束后再切换模型。', switchDisabledRunning: '当前任务正在运行，等结束后再切换模型。', switchDisabledPermission: '当前有工具调用正在等待确认，处理后再切换模型。',
       thinkingDisabledStreaming: '当前任务正在流式输出，等结束后再切换思考级别。', thinkingDisabledRunning: '当前任务正在运行，等结束后再切换思考级别。', thinkingDisabledPermission: '当前有工具调用正在等待确认，处理后再切换思考级别。',
       orchestrationModeAriaLabel: '编排模式',
@@ -525,6 +530,7 @@ const CONVERSATION_COPY = {
       interruptHint: 'or click Stop to interrupt', addContext: 'Add context', stagedContext: 'staged items',
       selectModel: 'Choose model', dropToImport: 'Drop to import file contents', addingAttachment: 'Adding attachment', addFileOrDirectory: 'Add file or directory',
       chooseSkill: 'Choose skills', noSkillsAvailable: 'No skills available',
+      setGoal: 'Set a goal…', goalAlreadySet: 'This session already has a goal in progress',
       switchDisabledStreaming: 'Wait for the current response to finish before switching models.', switchDisabledRunning: 'Wait for the current run to finish before switching models.', switchDisabledPermission: 'Resolve the pending tool permission before switching models.',
       thinkingDisabledStreaming: 'Wait for the current response to finish before changing the thinking level.', thinkingDisabledRunning: 'Wait for the current run to finish before changing the thinking level.', thinkingDisabledPermission: 'Resolve the pending tool permission before changing the thinking level.',
       orchestrationModeAriaLabel: 'Orchestration mode',


### PR DESCRIPTION
## Summary

A Goal could only be armed by the model, from inside a Turn, with the GoalSet tool. There was no Host operation for it, no bridge method, and no control anywhere in the product — the user could stop a Goal but never start one.

This adds `goal.arm` as a real Host operation, next to `goal.query` and `goal.control`, and carries it out to the ＋ menu:

- **`HostGoalCoordinator#arm`** creates the Goal through the same `GoalManager` the tool uses, under the same Session admission gate, with the same durable record. It schedules nothing: a Goal armed outside a Turn takes hold on the next one, which `beginObservedTurn` binds to the live control lease. A Session that already has an unfinished Goal gets `operation_conflict`.
- **One authority for the bounds.** The two budget ceilings and the token floor move to `@maka/core/goal`, so the protocol codec and the GoalSet tool schema validate against one number instead of two copies of it.
- **Remote owners are granted `goal.arm`**, at the same tier as `goal.control`. Withholding it would withhold nothing: a remote owner sends Turns, and the model arms its own Goal inside one. The only thing a refusal removes is the explicit path the user can see and stop.
- **The IPC handler takes the Session from the scoped channel**, never from the renderer's frame, and normalizes the budgets without clamping them — an out-of-range value is refused once, by the Host, rather than quietly becoming a Goal the user did not ask for.
- **The ＋ menu gains one "设定 Goal…" row** in its action group, at the same 28px rhythm as the rest, and app-shell opens a dialog that collects the condition and the two budgets. The row explains itself when a Goal is already running (arming would conflict) or a Turn is in flight (the Goal would only take hold on the next one).

> **Stacked on #3198.** That PR restructured the same menu, and this row belongs in the action group it establishes. Both branches live on the same fork, so GitHub cannot base this one on that branch directly — it is opened against `main` and its diff therefore contains #3198's commit as well. **Review only the second commit** (`feat(goal): let the user arm a Goal from the composer`), and merge #3198 first.

### What it looks like

Shot live in Storybook, same viewport, each surface cropped to its own bounds and composited at 1:1 pixel scale. (The mode rows below the divider are #3198's doing, not this PR's.)

<img width="2937" height="1575" alt="image" src="https://github.com/user-attachments/assets/1cc8259e-23e7-40e4-bb3f-81eb01cda059" />

Left: 设定 Goal… joins 添加文件或目录 and 选择技能 in the action group — the same 28px row, no new component kind in the panel. Middle: arming refuses a second Goal, so the row says why instead of opening a dialog that would fail on submit; it is the same mechanism the Skills row already uses for an empty catalog, and the only row that grows past 28px is the one carrying an explanation. Right: the two budgets that stop a Goal are visible while it is being armed, the condition counter is the shared `GOAL_CONDITION_TEXT_LIMIT`, and 开始 stays disabled until there is a condition.

## Verification

- `packages/runtime-host`: `goal-protocol.test.ts` (+3 tests — exact frame, budget bounds, remote-owner grant) and `goal-coordinator.test.ts` (+1 — arm, conflict, not-found, archived) pass.
- `apps/desktop`: `runtime-host-client-operations.test.ts` (+1 — one request, no retry on conflict) and `runtime-host-session-domains-ipc-main.test.ts` (+1 — scoped Session wins over the frame's, budget normalization) pass.
- `packages/runtime` `goal-tools.test.ts` / `goal-state.test.ts` and `packages/core` `goal-authority.test.ts` pass unchanged, confirming the constant move is behaviour-preserving.
- Typecheck: `@maka/core`, `@maka/runtime`, `@maka/runtime-host`, `@maka/ui`, and all four `apps/desktop` tsconfig projects. `npm run format:check` and `biome lint` clean.
- Storybook: `GoalDialogOpen` and `GoalAlreadySet` added. Measured live — the seven ＋ rows stay 28px, and the disabled Goal row grows to 48px only because it carries its explanation, the same way the Skills row already does with an empty catalog.
- Not run: repository-wide suites (left to CI); no E2E added.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Opus) wrote the diff, the tests, and the commit message. The decision to add a real Host operation rather than route the user through the model is the human contributor's. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above

### Review focus

Runtime Host is the sole execution authority, and this adds an operation to it. Two things deserve the attention:

1. **`#arm` schedules nothing.** A Goal armed while a Turn is in flight does not drive that Turn — it registered before the Goal existed, and `activateGoal` declines exactly that case (`goal_not_observed`). The UI disables the entry during a Turn so this is never a silent no-op, but the Host accepts it either way; the Goal simply starts from the next Turn.
2. **The remote-owner grant.** `REMOTE_OWNER_OPERATION_GRANTS` is fail-closed by design, and this PR opens one entry in it. The reasoning is in the test that asserts it; if you disagree, the grant is the one line to revert.


