### PR TITLE
fix(release): resume draft CLI releases by ID

### DIFF
--- a/.github/workflows/release-cli-finalize.yml
+++ b/.github/workflows/release-cli-finalize.yml
@@ -194,7 +194,6 @@ jobs:
             exit 1
           fi
 
-          release_endpoint="repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG"
           release_json="$RUNNER_TEMP/github-release.json"
           release_assets=(
             "$RELEASE_DIRECTORY/$RELEASE_TARBALL_NAME"
@@ -203,7 +202,12 @@ jobs:
             "$RELEASE_DIRECTORY/release.json"
           )
 
-          if ! gh api "$release_endpoint" > "$release_json" 2>/dev/null; then
+          # The REST release-by-tag endpoint does not return drafts. Resolve both draft and
+          # published releases through gh, then use the immutable API URL for exact reads.
+          if ! release_api_url="$(gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json apiUrl \
+            --jq .apiUrl 2>/dev/null)"; then
             if ! gh release create "$RELEASE_TAG" \
               --repo "$GITHUB_REPOSITORY" \
               --verify-tag \
@@ -213,8 +217,16 @@ jobs:
               --notes-file "$RELEASE_DIRECTORY/release-notes.md"; then
               echo "GitHub Release creation did not confirm success; inspecting remote state" >&2
             fi
-            gh api "$release_endpoint" > "$release_json"
+            release_api_url="$(gh release view "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json apiUrl \
+              --jq .apiUrl)"
           fi
+          if [[ ! "$release_api_url" =~ ^https://api\.github\.com/repos/$GITHUB_REPOSITORY/releases/[1-9][0-9]*$ ]]; then
+            echo "GitHub Release API URL is not bound to the expected repository: $release_api_url" >&2
+            exit 1
+          fi
+          gh api "$release_api_url" > "$release_json"
 
           release_draft="$(RELEASE_JSON="$release_json" node -e '
             const fs = require("node:fs");
@@ -243,7 +255,7 @@ jobs:
               --notes-file "$RELEASE_DIRECTORY/release-notes.md"
           fi
 
-          gh api "$release_endpoint" > "$release_json"
+          gh api "$release_api_url" > "$release_json"
           node scripts/release-cli-publication.mjs validate-github-release \
             "$RELEASE_DIRECTORY" \
             "$release_json"

--- a/scripts/release-cli-workflow-policy.test.mjs
+++ b/scripts/release-cli-workflow-policy.test.mjs
@@ -84,6 +84,9 @@ test('finalize propagates verified artifacts and idempotently publishes an exact
   assert.match(publish, /gh release create[\s\S]*?--draft/u);
   assert.match(publish, /gh release upload[\s\S]*?--clobber/u);
   assert.match(publish, /gh release edit[\s\S]*?--draft=false/u);
+  assert.match(publish, /gh release view[\s\S]*?--json apiUrl/u);
+  assert.match(publish, /gh api "\$release_api_url"/u);
+  assert.doesNotMatch(publish, /releases\/tags\/\$RELEASE_TAG/u);
   assert.match(publish, /--prerelease/u);
   assert.match(publish, /--latest=false/u);
   assert.match(publish, /validate-github-release/u);


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Resume a partially created CLI GitHub Release by resolving its stable API ID through `gh release
view`. GitHub's release-by-tag REST endpoint returns 404 for drafts, which caused Finalize run
[`32125339803`](https://github.com/maka-agent/maka-agent/actions/runs/32125339803) to fail immediately
after successfully creating the draft.

The existing exact tag and draft remain the recovery state; rerunning Finalize after this fix will
upload, verify, and publish that draft.

</details>

<details>
<summary>简体中文</summary>

通过 `gh release view` 解析稳定的 Release API ID，从而继续处理部分创建完成的 CLI GitHub
Release。GitHub 的 release-by-tag REST endpoint 对 draft 返回 404，导致 Finalize run
[`32125339803`](https://github.com/maka-agent/maka-agent/actions/runs/32125339803) 在成功创建 draft
后立即失败。

现有精确 tag 和 draft 会保留为恢复状态；合并本修复后重新运行 Finalize，即可继续上传、验证并
发布该 draft。

</details>

## Verification

- `npx --yes npm@11.19.0 run check:release` — 27 tests passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/release-cli-finalize.yml`
- Bash syntax check for the Finalize publish step
- `npx biome check scripts/release-cli-workflow-policy.test.mjs`
- Read-only lookup of the existing draft resolved Release ID `372253908`
- Full repository typecheck was not run; the change is limited to workflow shell and its policy test

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the Actions failure, implemented the workflow fix, and added the
regression assertion. M4n5ter is the human contributor of record and reviews the final change.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
