### PR TITLE
feat(cli): manage Linux Runtime Host services

### DIFF
--- a/docs/runtime-host-remote-access.md
+++ b/docs/runtime-host-remote-access.md
@@ -37,6 +37,22 @@ npm --workspace maka-agent exec -- maka runtime-host access issue \
 
 Use `terminal-client` for TUI or CLI. The command prints the credential once.
 
+On Linux with a systemd user manager, the released CLI can keep the loopback Host running after the
+SSH session ends:
+
+```sh
+maka runtime-host service install \
+  --root /srv/maka \
+  --project-root projects=/srv/projects
+maka runtime-host service status --json
+```
+
+The install command persists the current exact Node and Maka CLI paths. Re-running it updates the
+same service; an omitted WebSocket port preserves the existing port. Before uninstalling the npm
+package, remove the service with `maka runtime-host service uninstall`. Service uninstall keeps the
+State Root and Project data. Installation reports an actionable error instead of claiming persistence
+when systemd user lingering is disabled.
+
 ## Choose a connection method
 
 ### Direct TLS

--- a/docs/runtime-host-remote-access.md
+++ b/docs/runtime-host-remote-access.md
@@ -51,7 +51,9 @@ The install command persists the current exact Node and Maka CLI paths. Re-runni
 same service; an omitted WebSocket port preserves the existing port. Before uninstalling the npm
 package, remove the service with `maka runtime-host service uninstall`. Service uninstall keeps the
 State Root and Project data. Installation reports an actionable error instead of claiming persistence
-when systemd user lingering is disabled.
+when systemd user lingering is disabled. Run service installation from a persistent global Maka
+installation, not `npx`. A replacement is committed only after the new Runtime Host is ready; failure
+restores the previous service.
 
 ## Choose a connection method
 

--- a/docs/runtime-host-remote-access.zh-CN.md
+++ b/docs/runtime-host-remote-access.zh-CN.md
@@ -50,7 +50,9 @@ maka runtime-host service status --json
 安装命令会持久保存当前精确的 Node 与 Maka CLI 路径。重复执行会更新同一个 service；未指定
 WebSocket port 时会保留现有端口。卸载 npm 包前，应先执行
 `maka runtime-host service uninstall`。卸载 service 会保留 State Root 与 Project 数据。如果
-systemd user lingering 未启用，安装会给出可操作的错误，不会声称服务能够持久运行。
+systemd user lingering 未启用，安装会给出可操作的错误，不会声称服务能够持久运行。Service
+必须从持久的全局 Maka 安装中安装，不能使用 `npx`。替换操作只会在新的 Runtime Host ready
+之后提交；失败时会恢复之前的 service。
 
 ## 选择连接方式
 

--- a/docs/runtime-host-remote-access.zh-CN.md
+++ b/docs/runtime-host-remote-access.zh-CN.md
@@ -37,6 +37,21 @@ npm --workspace maka-agent exec -- maka runtime-host access issue \
 
 TUI 或 CLI 使用 `terminal-client`。命令只显示 credential 一次。
 
+在使用 systemd user manager 的 Linux 上，发布版 CLI 可以让 loopback Host 在 SSH 会话结束后
+继续运行：
+
+```sh
+maka runtime-host service install \
+  --root /srv/maka \
+  --project-root projects=/srv/projects
+maka runtime-host service status --json
+```
+
+安装命令会持久保存当前精确的 Node 与 Maka CLI 路径。重复执行会更新同一个 service；未指定
+WebSocket port 时会保留现有端口。卸载 npm 包前，应先执行
+`maka runtime-host service uninstall`。卸载 service 会保留 State Root 与 Project 数据。如果
+systemd user lingering 未启用，安装会给出可操作的错误，不会声称服务能够持久运行。
+
 ## 选择连接方式
 
 ### Direct TLS

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -86,10 +86,14 @@ with `npm install --global maka-agent@latest`.
 ## Uninstall
 
 ```sh
+# Linux only, when a managed Runtime Host service was installed
+maka runtime-host service uninstall
+
 npm uninstall --global maka-agent
 ```
 
-Uninstalling the package does not delete model connections, credentials, sessions, or artifacts.
+Remove the managed service before removing the package so systemd does not retain a unit pointing to
+the deleted CLI. Neither command deletes model connections, credentials, sessions, or artifacts.
 Those remain in the profile shared by the released CLI and Desktop app:
 
 | Platform | Profile directory |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -38,7 +38,8 @@ maka --help
 ```
 
 `maka-agent` is an alias for `maka`. For a one-off invocation, use
-`npx --yes maka-agent@next`; the unrelated `maka` package on npm is not this project.
+`npx --yes maka-agent@next`; the unrelated `maka` package on npm is not this project. A managed
+Runtime Host service requires the persistent global installation above.
 
 ## First run
 

--- a/packages/cli/README.zh-CN.md
+++ b/packages/cli/README.zh-CN.md
@@ -36,7 +36,7 @@ maka --help
 ```
 
 `maka-agent` 是 `maka` 的别名。一次性运行请使用 `npx --yes maka-agent@next`；npm 上与本项目
-无关的 `maka` 包不是本项目。
+无关的 `maka` 包不是本项目。Managed Runtime Host service 必须使用上面的持久全局安装。
 
 ## 第一次运行
 

--- a/packages/cli/README.zh-CN.md
+++ b/packages/cli/README.zh-CN.md
@@ -81,10 +81,14 @@ Beta 升级不要使用不带 tag 的 `npm update --global maka-agent`：npm 的
 ## 卸载
 
 ```sh
+# 仅限安装过 managed Runtime Host service 的 Linux
+maka runtime-host service uninstall
+
 npm uninstall --global maka-agent
 ```
 
-卸载 npm 包不会删除模型连接、凭证、会话或 Artifact。它们仍保留在发布版 CLI 与 Desktop
+先删除 managed service，再卸载 npm 包，避免 systemd 留下指向已删除 CLI 的 unit。这两个命令
+都不会删除模型连接、凭证、会话或 Artifact。它们仍保留在发布版 CLI 与 Desktop
 共用的 profile 中：
 
 | 平台 | Profile 目录 |

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -77,7 +77,10 @@ describe('managed Runtime Host service', () => {
       defaultRootPath: rootPath,
       nodePath: process.execPath,
       cliPath,
-      packageVersion: '0.1.0-beta.1',
+    } as const;
+    const managerDeps = {
+      allocateLoopbackPort: async () => 49_999,
+      waitForReady: async () => undefined,
     } as const;
 
     const installed = await manageRuntimeHostService(
@@ -88,28 +91,29 @@ describe('managed Runtime Host service', () => {
         websocketPort: 47_777,
       },
       backend(),
-      {
-        allocateLoopbackPort: async () => 49_999,
-      },
+      managerDeps,
     );
     assert.equal(installed.service.active, true);
-    assert.equal(installed.service.configured, true);
+    assert.notEqual(installed.service.config, null);
     assert.equal(installed.service.enabled, true);
     assert.equal(installed.service.config?.websocket.port, 47_777);
     assert.match(await readFile(unitPath, 'utf8'), /ExecStart=.*runtime-host.*serve/u);
     assert.deepEqual(systemd.calls.slice(0, 4), [
       ['show-environment'],
+      [
+        'show',
+        'maka-runtime-host.service',
+        '--property=LoadState,ActiveState,SubState,UnitFileState,MainPID,ExecMainStatus',
+        '--no-pager',
+      ],
       ['daemon-reload'],
       ['enable', 'maka-runtime-host.service'],
-      ['restart', 'maka-runtime-host.service'],
     ]);
 
     const reinstalled = await manageRuntimeHostService(
       { ...common, action: 'install' },
       backend(),
-      {
-        allocateLoopbackPort: async () => 49_999,
-      },
+      managerDeps,
     );
     assert.equal(reinstalled.service.config?.websocket.port, 47_777);
     assert.deepEqual(reinstalled.service.config?.projectDirectoryRoots, [
@@ -122,7 +126,7 @@ describe('managed Runtime Host service', () => {
       backend(),
     );
     assert.equal(uninstalled.service.installed, false);
-    assert.equal(uninstalled.service.configured, false);
+    assert.equal(uninstalled.service.config, null);
     assert.equal(uninstalled.service.state, 'not_installed');
     assert.equal(uninstalled.retainedStateRoot, await realpath(rootPath));
     await access(rootPath);
@@ -148,7 +152,6 @@ describe('managed Runtime Host service', () => {
       launch: {
         nodePath: '/opt/Node 24/bin/node',
         cliPath: '/opt/Maka/current/cli.js',
-        packageVersion: '0.1.0-beta.1',
       },
     };
     const unit = renderSystemdUnit(config);
@@ -166,7 +169,6 @@ describe('managed Runtime Host service', () => {
         defaultRootPath: '/config/Maka/workspaces/default',
         nodePath: '/usr/bin/node',
         cliPath: '/opt/maka/cli.js',
-        packageVersion: '0.1.0-beta.1',
       },
       {
         manage: async () => {
@@ -192,10 +194,175 @@ describe('managed Runtime Host service', () => {
       },
     });
   });
+
+  it('restores the deployed service when the replacement never becomes ready', async (t) => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-service-rollback-'));
+    t.after(() => rm(base, { recursive: true, force: true }));
+    const clientDataRoot = join(base, 'config');
+    const stateRoot = join(base, 'state');
+    const cliPath = join(base, 'cli.js');
+    const unitPath = join(base, 'systemd', 'user', 'maka-runtime-host.service');
+    await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
+    const systemd = createFakeSystemd(unitPath);
+    const backend = () =>
+      createSystemdUserRuntimeHostService({
+        env: { XDG_CONFIG_HOME: base },
+        homeDir: base,
+        uid: 1000,
+        runSystemctl: systemd.run,
+        runLoginctl: async () => success('yes\n'),
+      });
+    const input = {
+      action: 'install' as const,
+      clientDataRoot,
+      defaultRootPath: stateRoot,
+      nodePath: process.execPath,
+      cliPath,
+    };
+
+    const first = await manageRuntimeHostService({ ...input, websocketPort: 41_001 }, backend(), {
+      waitForReady: async () => undefined,
+    });
+    assert.equal(first.service.config?.websocket.port, 41_001);
+
+    await assert.rejects(
+      manageRuntimeHostService({ ...input, websocketPort: 41_002 }, backend(), {
+        waitForReady: async () => {
+          throw new RuntimeHostServiceManagerError(
+            'service_manager_operation_failed',
+            'candidate failed readiness',
+          );
+        },
+      }),
+      /candidate failed readiness/u,
+    );
+    const status = await manageRuntimeHostService({ ...input, action: 'status' }, backend());
+    assert.equal(status.service.config?.websocket.port, 41_001);
+    assert.match(await readFile(unitPath, 'utf8'), /--websocket-port" "41001"/u);
+    assert.equal(status.service.active, true);
+
+    systemd.failNext('restart');
+    await assert.rejects(
+      manageRuntimeHostService({ ...input, websocketPort: 41_003 }, backend(), {
+        waitForReady: async () => undefined,
+      }),
+      /Starting the Runtime Host service failed/u,
+    );
+    assert.match(await readFile(unitPath, 'utf8'), /--websocket-port" "41001"/u);
+  });
+
+  it('rejects invalid Project roots and temporary npx launch paths before deployment', async (t) => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-service-input-'));
+    t.after(() => rm(base, { recursive: true, force: true }));
+    const cliPath = join(base, 'cli.js');
+    const fileRoot = join(base, 'not-a-directory');
+    const directoryRoot = join(base, 'directory');
+    const npxCliPath = join(base, '.npm', '_npx', 'temporary', 'cli.js');
+    await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
+    await mkdir(join(base, '.npm', '_npx', 'temporary'), { recursive: true });
+    await writeFile(npxCliPath, '#!/usr/bin/env node\n', 'utf8');
+    await writeFile(fileRoot, '', 'utf8');
+    await mkdir(directoryRoot);
+    const input = {
+      action: 'install' as const,
+      clientDataRoot: join(base, 'config'),
+      defaultRootPath: join(base, 'state'),
+      nodePath: process.execPath,
+      cliPath,
+    };
+    const backend = createPreparedUnusedBackend(join(base, 'service'));
+
+    await assert.rejects(
+      manageRuntimeHostService(
+        { ...input, projectDirectoryRoots: [{ label: 'file', path: fileRoot }] },
+        backend,
+      ),
+      (error: unknown) =>
+        error instanceof RuntimeHostServiceManagerError && error.code === 'invalid_config',
+    );
+    await assert.rejects(
+      manageRuntimeHostService(
+        {
+          ...input,
+          projectDirectoryRoots: [
+            { label: 'first', path: directoryRoot },
+            { label: 'second', path: directoryRoot },
+          ],
+        },
+        backend,
+      ),
+      (error: unknown) =>
+        error instanceof RuntimeHostServiceManagerError && error.code === 'invalid_config',
+    );
+    await assert.rejects(
+      manageRuntimeHostService({ ...input, cliPath: npxCliPath }, backend, { homeDir: base }),
+      (error: unknown) =>
+        error instanceof RuntimeHostServiceManagerError && error.code === 'invalid_launch',
+    );
+  });
+
+  it('reports an unavailable systemd manager instead of not installed', async () => {
+    const backend = createSystemdUserRuntimeHostService({
+      runSystemctl: async () => ({
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Failed to connect to bus',
+      }),
+    });
+    await assert.rejects(
+      backend.status(),
+      (error: unknown) =>
+        error instanceof RuntimeHostServiceManagerError &&
+        error.code === 'service_manager_operation_failed',
+    );
+  });
+
+  it('serializes status behind an in-flight deployment', async (t) => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-service-lock-'));
+    t.after(() => rm(base, { recursive: true, force: true }));
+    const cliPath = join(base, 'cli.js');
+    await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      releaseReady = resolve;
+    });
+    let markInstallStarted!: () => void;
+    const installStarted = new Promise<void>((resolve) => {
+      markInstallStarted = resolve;
+    });
+    const backend: RuntimeHostServiceBackend = {
+      ...createReadyBackend(join(base, 'service')),
+      install: async () => {
+        markInstallStarted();
+        return { rollback: async () => undefined };
+      },
+    };
+    const input = {
+      clientDataRoot: join(base, 'config'),
+      defaultRootPath: join(base, 'state'),
+      nodePath: process.execPath,
+      cliPath,
+    } as const;
+    const installing = manageRuntimeHostService({ ...input, action: 'install' }, backend, {
+      waitForReady: () => ready,
+    });
+    await installStarted;
+    let statusSettled = false;
+    const status = manageRuntimeHostService({ ...input, action: 'status' }, backend).finally(() => {
+      statusSettled = true;
+    });
+    await new Promise<void>((resolveWait) => setTimeout(resolveWait, 10));
+    assert.equal(statusSettled, false);
+
+    releaseReady();
+    await installing;
+    assert.notEqual((await status).service.config, null);
+  });
 });
 
 function createFakeSystemd(unitPath: string): {
   readonly calls: string[][];
+  readonly failNext: (command: string) => void;
   readonly run: (args: readonly string[]) => Promise<{
     exitCode: number;
     stdout: string;
@@ -206,10 +373,18 @@ function createFakeSystemd(unitPath: string): {
   let loaded = false;
   let enabled = false;
   let active = false;
+  let failureCommand: string | undefined;
   return {
     calls,
+    failNext: (command) => {
+      failureCommand = command;
+    },
     run: async (args) => {
       calls.push([...args]);
+      if (args[0] === failureCommand) {
+        failureCommand = undefined;
+        return { exitCode: 1, stdout: '', stderr: `${args[0]} failed` };
+      }
       if (args[0] === 'show-environment') return success('PATH=/usr/bin\n');
       if (args[0] === 'daemon-reload') {
         loaded = await access(unitPath).then(
@@ -261,6 +436,7 @@ function createUnusedBackend(): RuntimeHostServiceBackend {
     throw new Error('Backend should not be used by this test');
   };
   return {
+    operationLockPath: '/unused/maka-runtime-host.service',
     preflightInstall: unexpected,
     install: unexpected,
     status: unexpected,
@@ -268,6 +444,36 @@ function createUnusedBackend(): RuntimeHostServiceBackend {
     stop: unexpected,
     restart: unexpected,
     uninstall: unexpected,
+  };
+}
+
+function createPreparedUnusedBackend(operationLockPath: string): RuntimeHostServiceBackend {
+  return {
+    ...createUnusedBackend(),
+    operationLockPath,
+    preflightInstall: async () => undefined,
+  };
+}
+
+function createReadyBackend(operationLockPath: string): RuntimeHostServiceBackend {
+  const status = async () => ({
+    manager: 'systemd_user' as const,
+    installed: true,
+    enabled: true,
+    active: true,
+    state: 'running' as const,
+    pid: 42,
+    lastExitCode: 0,
+  });
+  return {
+    operationLockPath,
+    preflightInstall: async () => undefined,
+    install: async () => ({ rollback: async () => undefined }),
+    status,
+    start: async () => undefined,
+    stop: async () => undefined,
+    restart: async () => undefined,
+    uninstall: async () => undefined,
   };
 }
 

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -1,0 +1,276 @@
+import assert from 'node:assert/strict';
+import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { parseRuntimeHostCommand } from '../runtime-host-cli.js';
+import { runManagedRuntimeHostServiceCli } from '../runtime-host-service-management-command.js';
+import {
+  manageRuntimeHostService,
+  resolveRuntimeHostManagedServiceConfigPath,
+  RuntimeHostServiceManagerError,
+  type RuntimeHostManagedServiceConfig,
+  type RuntimeHostServiceBackend,
+} from '../runtime-host-service-manager.js';
+import {
+  createSystemdUserRuntimeHostService,
+  renderSystemdUnit,
+  resolveSystemdUserRuntimeHostServicePath,
+} from '../runtime-host-systemd-service.js';
+
+describe('managed Runtime Host service', () => {
+  it('parses the bounded Linux service command surface', () => {
+    assert.deepEqual(
+      parseRuntimeHostCommand([
+        'service',
+        'install',
+        '--root',
+        '/srv/maka',
+        '--project-root',
+        'Home=/home/ada',
+        '--websocket-port',
+        '7443',
+        '--json',
+      ]),
+      {
+        kind: 'runtime-host-service-manage',
+        action: 'install',
+        json: true,
+        rootPath: '/srv/maka',
+        projectDirectoryRoots: [{ label: 'Home', path: '/home/ada' }],
+        websocketPort: 7443,
+      },
+    );
+    assert.deepEqual(parseRuntimeHostCommand(['service', 'uninstall', '--json']), {
+      kind: 'runtime-host-service-manage',
+      action: 'uninstall',
+      json: true,
+    });
+    assert.equal(parseRuntimeHostCommand(['service', 'status', '--root', '/tmp']).kind, 'error');
+  });
+
+  it('installs, reports, and cleanly uninstalls while retaining the State Root', async (t) => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-service-'));
+    t.after(() => rm(base, { recursive: true, force: true }));
+    const homeDir = join(base, 'home');
+    const clientDataRoot = join(base, 'config', 'Maka');
+    const rootPath = join(base, 'state root');
+    const projectPath = join(base, 'projects');
+    const cliPath = join(base, 'maka cli.js');
+    await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
+    await writeFile(join(base, 'placeholder'), '', 'utf8');
+    await mkdir(projectPath, { recursive: true });
+    const env = { XDG_CONFIG_HOME: join(base, 'xdg-config') };
+    const configPath = resolveRuntimeHostManagedServiceConfigPath(clientDataRoot);
+    const unitPath = resolveSystemdUserRuntimeHostServicePath(env, homeDir);
+    const systemd = createFakeSystemd(unitPath);
+    const backend = () =>
+      createSystemdUserRuntimeHostService({
+        env,
+        homeDir,
+        uid: 1000,
+        runSystemctl: systemd.run,
+        runLoginctl: async () => success('yes\n'),
+      });
+    const common = {
+      clientDataRoot,
+      defaultRootPath: rootPath,
+      nodePath: process.execPath,
+      cliPath,
+      packageVersion: '0.1.0-beta.1',
+    } as const;
+
+    const installed = await manageRuntimeHostService(
+      {
+        ...common,
+        action: 'install',
+        projectDirectoryRoots: [{ label: 'Projects', path: projectPath }],
+        websocketPort: 47_777,
+      },
+      backend(),
+      {
+        allocateLoopbackPort: async () => 49_999,
+      },
+    );
+    assert.equal(installed.service.active, true);
+    assert.equal(installed.service.configured, true);
+    assert.equal(installed.service.enabled, true);
+    assert.equal(installed.service.config?.websocket.port, 47_777);
+    assert.match(await readFile(unitPath, 'utf8'), /ExecStart=.*runtime-host.*serve/u);
+    assert.deepEqual(systemd.calls.slice(0, 4), [
+      ['show-environment'],
+      ['daemon-reload'],
+      ['enable', 'maka-runtime-host.service'],
+      ['restart', 'maka-runtime-host.service'],
+    ]);
+
+    const reinstalled = await manageRuntimeHostService(
+      { ...common, action: 'install' },
+      backend(),
+      {
+        allocateLoopbackPort: async () => 49_999,
+      },
+    );
+    assert.equal(reinstalled.service.config?.websocket.port, 47_777);
+    assert.deepEqual(reinstalled.service.config?.projectDirectoryRoots, [
+      { label: 'Projects', path: await realpath(projectPath) },
+    ]);
+    assert.equal(reinstalled.service.lastExitCode, 0);
+
+    const uninstalled = await manageRuntimeHostService(
+      { ...common, action: 'uninstall' },
+      backend(),
+    );
+    assert.equal(uninstalled.service.installed, false);
+    assert.equal(uninstalled.service.configured, false);
+    assert.equal(uninstalled.service.state, 'not_installed');
+    assert.equal(uninstalled.retainedStateRoot, await realpath(rootPath));
+    await access(rootPath);
+    await assert.rejects(access(configPath));
+    await assert.rejects(access(unitPath));
+
+    const repeated = await manageRuntimeHostService({ ...common, action: 'uninstall' }, backend());
+    assert.equal(repeated.service.installed, false);
+
+    await mkdir(join(clientDataRoot), { recursive: true });
+    await writeFile(configPath, '{not-json', 'utf8');
+    const repaired = await manageRuntimeHostService({ ...common, action: 'uninstall' }, backend());
+    assert.equal(repaired.service.installed, false);
+    await assert.rejects(access(configPath));
+  });
+
+  it('quotes systemd arguments without exposing specifier or environment expansion', () => {
+    const config: RuntimeHostManagedServiceConfig = {
+      schemaVersion: 1,
+      rootPath: '/srv/Maka 100%',
+      projectDirectoryRoots: [{ label: 'Cash$', path: '/home/ada/My Projects' }],
+      websocket: { host: '127.0.0.1', port: 7443, path: '/runtime-host' },
+      launch: {
+        nodePath: '/opt/Node 24/bin/node',
+        cliPath: '/opt/Maka/current/cli.js',
+        packageVersion: '0.1.0-beta.1',
+      },
+    };
+    const unit = renderSystemdUnit(config);
+    assert.match(unit, /"\/srv\/Maka 100%%"/u);
+    assert.match(unit, /"Cash\$\$=\/home\/ada\/My Projects"/u);
+  });
+
+  it('emits one stable machine error for an unmet service prerequisite', async () => {
+    let output = '';
+    const exitCode = await runManagedRuntimeHostServiceCli(
+      {
+        action: 'install',
+        json: true,
+        clientDataRoot: '/config/Maka',
+        defaultRootPath: '/config/Maka/workspaces/default',
+        nodePath: '/usr/bin/node',
+        cliPath: '/opt/maka/cli.js',
+        packageVersion: '0.1.0-beta.1',
+      },
+      {
+        manage: async () => {
+          throw new RuntimeHostServiceManagerError(
+            'linger_disabled',
+            'Persistent user services are disabled',
+          );
+        },
+        createBackend: createUnusedBackend,
+        writeOutput: (value) => {
+          output += value;
+        },
+      },
+    );
+    assert.equal(exitCode, 1);
+    assert.deepEqual(JSON.parse(output), {
+      schemaVersion: 1,
+      ok: false,
+      action: 'install',
+      error: {
+        code: 'linger_disabled',
+        message: 'Persistent user services are disabled',
+      },
+    });
+  });
+});
+
+function createFakeSystemd(unitPath: string): {
+  readonly calls: string[][];
+  readonly run: (args: readonly string[]) => Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }>;
+} {
+  const calls: string[][] = [];
+  let loaded = false;
+  let enabled = false;
+  let active = false;
+  return {
+    calls,
+    run: async (args) => {
+      calls.push([...args]);
+      if (args[0] === 'show-environment') return success('PATH=/usr/bin\n');
+      if (args[0] === 'daemon-reload') {
+        loaded = await access(unitPath).then(
+          () => true,
+          () => false,
+        );
+        return success();
+      }
+      if (args[0] === 'enable') {
+        enabled = true;
+        return success();
+      }
+      if (args[0] === 'disable') {
+        enabled = false;
+        return success();
+      }
+      if (args[0] === 'start' || args[0] === 'restart') {
+        active = true;
+        loaded = true;
+        return success();
+      }
+      if (args[0] === 'stop') {
+        active = false;
+        return success();
+      }
+      if (args[0] === 'reset-failed') return success();
+      if (args[0] === 'show') {
+        return {
+          exitCode: loaded ? 0 : 4,
+          stdout: [
+            `LoadState=${loaded ? 'loaded' : 'not-found'}`,
+            `ActiveState=${active ? 'active' : 'inactive'}`,
+            `SubState=${active ? 'running' : 'dead'}`,
+            `UnitFileState=${enabled ? 'enabled' : 'disabled'}`,
+            `MainPID=${active ? '4242' : '0'}`,
+            'ExecMainStatus=0',
+            '',
+          ].join('\n'),
+          stderr: '',
+        };
+      }
+      throw new Error(`Unexpected systemctl call: ${args.join(' ')}`);
+    },
+  };
+}
+
+function createUnusedBackend(): RuntimeHostServiceBackend {
+  const unexpected = async (): Promise<never> => {
+    throw new Error('Backend should not be used by this test');
+  };
+  return {
+    preflightInstall: unexpected,
+    install: unexpected,
+    status: unexpected,
+    start: unexpected,
+    stop: unexpected,
+    restart: unexpected,
+    uninstall: unexpected,
+  };
+}
+
+function success(stdout = ''): { exitCode: number; stdout: string; stderr: string } {
+  return { exitCode: 0, stdout, stderr: '' };
+}

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -1,13 +1,14 @@
 import assert from 'node:assert/strict';
 import { access, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { describe, it } from 'node:test';
 import { parseRuntimeHostCommand } from '../runtime-host-cli.js';
 import { runManagedRuntimeHostServiceCli } from '../runtime-host-service-management-command.js';
 import {
   manageRuntimeHostService,
   resolveRuntimeHostManagedServiceConfigPath,
+  resolveRuntimeHostManagedServiceId,
   RuntimeHostServiceManagerError,
   type RuntimeHostManagedServiceConfig,
   type RuntimeHostServiceBackend,
@@ -62,10 +63,11 @@ describe('managed Runtime Host service', () => {
     await mkdir(projectPath, { recursive: true });
     const env = { XDG_CONFIG_HOME: join(base, 'xdg-config') };
     const configPath = resolveRuntimeHostManagedServiceConfigPath(clientDataRoot);
-    const unitPath = resolveSystemdUserRuntimeHostServicePath(env, homeDir);
+    const serviceId = resolveRuntimeHostManagedServiceId(clientDataRoot);
+    const unitPath = resolveSystemdUserRuntimeHostServicePath(serviceId, env, homeDir);
     const systemd = createFakeSystemd(unitPath);
     const backend = () =>
-      createSystemdUserRuntimeHostService({
+      createSystemdUserRuntimeHostService(serviceId, {
         env,
         homeDir,
         uid: 1000,
@@ -98,17 +100,6 @@ describe('managed Runtime Host service', () => {
     assert.equal(installed.service.enabled, true);
     assert.equal(installed.service.config?.websocket.port, 47_777);
     assert.match(await readFile(unitPath, 'utf8'), /ExecStart=.*runtime-host.*serve/u);
-    assert.deepEqual(systemd.calls.slice(0, 4), [
-      ['show-environment'],
-      [
-        'show',
-        'maka-runtime-host.service',
-        '--property=LoadState,ActiveState,SubState,UnitFileState,MainPID,ExecMainStatus',
-        '--no-pager',
-      ],
-      ['daemon-reload'],
-      ['enable', 'maka-runtime-host.service'],
-    ]);
 
     const reinstalled = await manageRuntimeHostService(
       { ...common, action: 'install' },
@@ -141,6 +132,74 @@ describe('managed Runtime Host service', () => {
     const repaired = await manageRuntimeHostService({ ...common, action: 'uninstall' }, backend());
     assert.equal(repaired.service.installed, false);
     await assert.rejects(access(configPath));
+  });
+
+  it('isolates managed services by Client Data Root without mutating on status', async (t) => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-service-profile-'));
+    t.after(() => rm(base, { recursive: true, force: true }));
+    const homeDir = join(base, 'home');
+    const env = { XDG_CONFIG_HOME: join(base, 'xdg-config') };
+    const cliPath = join(base, 'cli.js');
+    const releaseRoot = join(base, 'profiles', 'Maka');
+    const developmentRoot = join(base, 'profiles', 'Maka Dev');
+    await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
+
+    const createProfile = (clientDataRoot: string) => {
+      const serviceId = resolveRuntimeHostManagedServiceId(clientDataRoot);
+      const unitPath = resolveSystemdUserRuntimeHostServicePath(serviceId, env, homeDir);
+      const systemd = createFakeSystemd(unitPath);
+      return {
+        unitPath,
+        backend: createSystemdUserRuntimeHostService(serviceId, {
+          env,
+          homeDir,
+          uid: 1000,
+          runSystemctl: systemd.run,
+          runLoginctl: async () => success('yes\n'),
+        }),
+      };
+    };
+    const release = createProfile(releaseRoot);
+    const development = createProfile(developmentRoot);
+    assert.notEqual(release.unitPath, development.unitPath);
+
+    const input = (clientDataRoot: string) => ({
+      clientDataRoot,
+      defaultRootPath: join(clientDataRoot, 'workspaces', 'default'),
+      nodePath: process.execPath,
+      cliPath,
+    });
+    const status = await manageRuntimeHostService(
+      { ...input(releaseRoot), action: 'status' },
+      release.backend,
+    );
+    assert.equal(status.service.installed, false);
+    await assert.rejects(access(releaseRoot));
+    await assert.rejects(access(dirname(release.unitPath)));
+
+    const ready = { waitForReady: async () => undefined } as const;
+    await manageRuntimeHostService(
+      { ...input(releaseRoot), action: 'install' },
+      release.backend,
+      ready,
+    );
+    await manageRuntimeHostService(
+      { ...input(developmentRoot), action: 'install' },
+      development.backend,
+      ready,
+    );
+    await manageRuntimeHostService(
+      { ...input(developmentRoot), action: 'uninstall' },
+      development.backend,
+    );
+
+    await access(release.unitPath);
+    await access(resolveRuntimeHostManagedServiceConfigPath(releaseRoot));
+    assert.equal(
+      (await manageRuntimeHostService({ ...input(releaseRoot), action: 'status' }, release.backend))
+        .service.active,
+      true,
+    );
   });
 
   it('quotes systemd arguments without exposing specifier or environment expansion', () => {
@@ -201,11 +260,14 @@ describe('managed Runtime Host service', () => {
     const clientDataRoot = join(base, 'config');
     const stateRoot = join(base, 'state');
     const cliPath = join(base, 'cli.js');
-    const unitPath = join(base, 'systemd', 'user', 'maka-runtime-host.service');
+    const serviceId = resolveRuntimeHostManagedServiceId(clientDataRoot);
+    const unitPath = resolveSystemdUserRuntimeHostServicePath(serviceId, {
+      XDG_CONFIG_HOME: base,
+    });
     await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
     const systemd = createFakeSystemd(unitPath);
     const backend = () =>
-      createSystemdUserRuntimeHostService({
+      createSystemdUserRuntimeHostService(serviceId, {
         env: { XDG_CONFIG_HOME: base },
         homeDir: base,
         uid: 1000,
@@ -270,7 +332,7 @@ describe('managed Runtime Host service', () => {
       nodePath: process.execPath,
       cliPath,
     };
-    const backend = createPreparedUnusedBackend(join(base, 'service'));
+    const backend = createPreparedUnusedBackend();
 
     await assert.rejects(
       manageRuntimeHostService(
@@ -302,13 +364,16 @@ describe('managed Runtime Host service', () => {
   });
 
   it('reports an unavailable systemd manager instead of not installed', async () => {
-    const backend = createSystemdUserRuntimeHostService({
-      runSystemctl: async () => ({
-        exitCode: 1,
-        stdout: '',
-        stderr: 'Failed to connect to bus',
-      }),
-    });
+    const backend = createSystemdUserRuntimeHostService(
+      resolveRuntimeHostManagedServiceId('/config/Maka'),
+      {
+        runSystemctl: async () => ({
+          exitCode: 1,
+          stdout: '',
+          stderr: 'Failed to connect to bus',
+        }),
+      },
+    );
     await assert.rejects(
       backend.status(),
       (error: unknown) =>
@@ -331,7 +396,7 @@ describe('managed Runtime Host service', () => {
       markInstallStarted = resolve;
     });
     const backend: RuntimeHostServiceBackend = {
-      ...createReadyBackend(join(base, 'service')),
+      ...createReadyBackend(),
       install: async () => {
         markInstallStarted();
         return { rollback: async () => undefined };
@@ -361,7 +426,6 @@ describe('managed Runtime Host service', () => {
 });
 
 function createFakeSystemd(unitPath: string): {
-  readonly calls: string[][];
   readonly failNext: (command: string) => void;
   readonly run: (args: readonly string[]) => Promise<{
     exitCode: number;
@@ -369,18 +433,22 @@ function createFakeSystemd(unitPath: string): {
     stderr: string;
   }>;
 } {
-  const calls: string[][] = [];
   let loaded = false;
   let enabled = false;
   let active = false;
   let failureCommand: string | undefined;
   return {
-    calls,
     failNext: (command) => {
       failureCommand = command;
     },
     run: async (args) => {
-      calls.push([...args]);
+      if (
+        ['show', 'enable', 'disable', 'start', 'restart', 'stop', 'reset-failed'].includes(
+          args[0] ?? '',
+        )
+      ) {
+        assert.equal(args[1], basename(unitPath));
+      }
       if (args[0] === failureCommand) {
         failureCommand = undefined;
         return { exitCode: 1, stdout: '', stderr: `${args[0]} failed` };
@@ -436,7 +504,6 @@ function createUnusedBackend(): RuntimeHostServiceBackend {
     throw new Error('Backend should not be used by this test');
   };
   return {
-    operationLockPath: '/unused/maka-runtime-host.service',
     preflightInstall: unexpected,
     install: unexpected,
     status: unexpected,
@@ -447,15 +514,14 @@ function createUnusedBackend(): RuntimeHostServiceBackend {
   };
 }
 
-function createPreparedUnusedBackend(operationLockPath: string): RuntimeHostServiceBackend {
+function createPreparedUnusedBackend(): RuntimeHostServiceBackend {
   return {
     ...createUnusedBackend(),
-    operationLockPath,
     preflightInstall: async () => undefined,
   };
 }
 
-function createReadyBackend(operationLockPath: string): RuntimeHostServiceBackend {
+function createReadyBackend(): RuntimeHostServiceBackend {
   const status = async () => ({
     manager: 'systemd_user' as const,
     installed: true,
@@ -466,7 +532,6 @@ function createReadyBackend(operationLockPath: string): RuntimeHostServiceBacken
     lastExitCode: 0,
   });
   return {
-    operationLockPath,
     preflightInstall: async () => undefined,
     install: async () => ({ rollback: async () => undefined }),
     status,

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -215,7 +215,6 @@ export async function runMakaCli(
         json: command.json,
         clientDataRoot: dataRoots.clientDataRoot,
         defaultRootPath: dataRoots.workspaceRoot,
-        packageVersion: version,
         nodePath: process.execPath,
         cliPath: process.argv[1] ?? '',
         ...(command.rootPath ? { rootPath: command.rootPath } : {}),

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -100,6 +100,8 @@ function helpText(cliCommand: string): string {
     `  ${cliCommand} -p ...       Alias for ${cliCommand} run`,
     `  ${cliCommand} eval ...     Run one declarative multi-arm experiment`,
     `  ${cliCommand} runtime-host serve [options]  Run a Runtime Host service`,
+    `  ${cliCommand} runtime-host service install [options]`,
+    `  ${cliCommand} runtime-host service status|start|stop|restart|uninstall [--json]`,
     `  ${cliCommand} runtime-host access issue --principal <id> --grant <operation>`,
     `  ${cliCommand} runtime-host access issue --principal <id> --preset <desktop-client|terminal-client>`,
     `  ${cliCommand} runtime-host access issue --kind capability-provider --principal <id>`,
@@ -122,7 +124,7 @@ function helpText(cliCommand: string): string {
     '  --project <project-id>  Select an existing Project on a remote Host',
     '  MAKA_RUNTIME_HOST_ACCESS_CREDENTIAL  Access credential used by runtime-host profile set',
     '',
-    'Runtime Host service options:',
+    'Runtime Host serve options:',
     '  --root <path>                 Select the canonical data root',
     '  --project-root <label>=<path> Publish an absolute project directory root (repeatable)',
     '  --websocket-port <port>       Enable an authenticated WebSocket listener',
@@ -133,6 +135,13 @@ function helpText(cliCommand: string): string {
     '  --allow-insecure-remote       Allow plaintext WebSocket access beyond loopback',
     '  --allow-origin <origin>       Allow one browser Origin (repeatable)',
     '  --json                        Emit one machine-readable ready event',
+    '',
+    'Managed Runtime Host service install options (Linux):',
+    '  --root <path>                 Select the canonical data root',
+    '  --project-root <label>=<path> Publish an absolute directory root (repeatable)',
+    '  --websocket-port <port>       Persist a loopback port (chosen automatically by default)',
+    '  --websocket-path <path>       Persist the upgrade path (default: /runtime-host)',
+    '  --json                        Emit a machine-readable result',
     '',
     'Runtime Host access issue options:',
     '  --root <path>                 Select the canonical data root',
@@ -195,6 +204,26 @@ export async function runMakaCli(
           ? { projectDirectoryRoots: command.projectDirectoryRoots }
           : {}),
         ...(command.websocket ? { websocket: command.websocket } : {}),
+      });
+    }
+    case 'runtime-host-service-manage': {
+      const { runManagedRuntimeHostServiceCli } = await import(
+        './runtime-host-service-management-command.js'
+      );
+      return runManagedRuntimeHostServiceCli({
+        action: command.action,
+        json: command.json,
+        clientDataRoot: dataRoots.clientDataRoot,
+        defaultRootPath: dataRoots.workspaceRoot,
+        packageVersion: version,
+        nodePath: process.execPath,
+        cliPath: process.argv[1] ?? '',
+        ...(command.rootPath ? { rootPath: command.rootPath } : {}),
+        ...(command.projectDirectoryRoots
+          ? { projectDirectoryRoots: command.projectDirectoryRoots }
+          : {}),
+        ...(command.websocketPort === undefined ? {} : { websocketPort: command.websocketPort }),
+        ...(command.websocketPath ? { websocketPath: command.websocketPath } : {}),
       });
     }
     case 'runtime-host-access-issue': {

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -23,6 +23,15 @@ export type RuntimeHostCliCommand =
       };
     }
   | {
+      kind: 'runtime-host-service-manage';
+      action: 'install' | 'status' | 'start' | 'stop' | 'restart' | 'uninstall';
+      json: boolean;
+      rootPath?: string;
+      projectDirectoryRoots?: { label: string; path: string }[];
+      websocketPort?: number;
+      websocketPath?: string;
+    }
+  | {
       kind: 'runtime-host-access-issue';
       rootPath?: string;
       principalKind: 'remote_owner' | 'capability_provider';
@@ -70,6 +79,7 @@ export type RuntimeHostCliCommand =
 
 export function parseRuntimeHostCommand(argv: string[]): RuntimeHostCliCommand {
   if (argv[0] === 'serve') return parseServeCommand(argv.slice(1));
+  if (argv[0] === 'service') return parseServiceManagementCommand(argv.slice(1));
   if (argv[0] === 'access') return parseAccessCommand(argv.slice(1));
   if (argv[0] === 'project') return parseProjectCommand(argv.slice(1));
   if (argv[0] === 'capability-provider') {
@@ -79,8 +89,92 @@ export function parseRuntimeHostCommand(argv: string[]): RuntimeHostCliCommand {
   return error(
     argv[0]
       ? `Unexpected runtime-host command: ${argv[0]}`
-      : 'runtime-host requires the serve, access, project, profile, or capability-provider command',
+      : 'runtime-host requires the serve, service, access, project, profile, or capability-provider command',
   );
+}
+
+function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
+  const action = argv[0];
+  if (
+    action !== 'install' &&
+    action !== 'status' &&
+    action !== 'start' &&
+    action !== 'stop' &&
+    action !== 'restart' &&
+    action !== 'uninstall'
+  ) {
+    return error(
+      action
+        ? `Unexpected runtime-host service command: ${action}`
+        : 'runtime-host service requires install, status, start, stop, restart, or uninstall',
+    );
+  }
+
+  let json = false;
+  let rootPath: string | undefined;
+  let websocketPort: number | undefined;
+  let websocketPath: string | undefined;
+  const projectDirectoryRoots: { label: string; path: string }[] = [];
+  for (let index = 1; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--json') {
+      json = true;
+      continue;
+    }
+    if (action !== 'install') {
+      return error(`Unexpected argument: ${argument ?? ''}`);
+    }
+    if (
+      argument === '--root' ||
+      argument === '--websocket-port' ||
+      argument === '--websocket-path'
+    ) {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      if (argument === '--root') rootPath = parsed;
+      if (argument === '--websocket-port') websocketPort = Number(parsed);
+      if (argument === '--websocket-path') websocketPath = parsed;
+      index += 1;
+      continue;
+    }
+    if (argument === '--project-root') {
+      const parsed = optionValue(argv, index, argument);
+      if (typeof parsed !== 'string') return parsed;
+      const root = parseProjectRoot(parsed);
+      if ('kind' in root) return root;
+      if (projectDirectoryRoots.length >= PROJECT_DIRECTORY_MAX_ROOTS) {
+        return error(`--project-root may be provided at most ${PROJECT_DIRECTORY_MAX_ROOTS} times`);
+      }
+      if (projectDirectoryRoots.some((candidate) => candidate.label === root.label)) {
+        return error(`Duplicate --project-root label: ${root.label}`);
+      }
+      projectDirectoryRoots.push(root);
+      index += 1;
+      continue;
+    }
+    return error(`Unexpected argument: ${argument ?? ''}`);
+  }
+  if (
+    websocketPort !== undefined &&
+    (!Number.isInteger(websocketPort) || websocketPort < 1 || websocketPort > 65_535)
+  ) {
+    return error('--websocket-port must be an integer between 1 and 65535');
+  }
+  if (
+    websocketPath !== undefined &&
+    (!websocketPath.startsWith('/') || websocketPath.includes('?') || websocketPath.includes('#'))
+  ) {
+    return error('--websocket-path must be an absolute URL path without a query or fragment');
+  }
+  return {
+    kind: 'runtime-host-service-manage',
+    action,
+    json,
+    ...(rootPath ? { rootPath } : {}),
+    ...(projectDirectoryRoots.length > 0 ? { projectDirectoryRoots } : {}),
+    ...(websocketPort === undefined ? {} : { websocketPort }),
+    ...(websocketPath === undefined ? {} : { websocketPath }),
+  };
 }
 
 function parseProjectCommand(argv: string[]): RuntimeHostCliCommand {

--- a/packages/cli/src/runtime-host-service-management-command.ts
+++ b/packages/cli/src/runtime-host-service-management-command.ts
@@ -1,0 +1,86 @@
+import {
+  manageRuntimeHostService,
+  RuntimeHostServiceManagerError,
+  type RuntimeHostManagedServiceInput,
+  type RuntimeHostManagedServiceResult,
+  type RuntimeHostServiceBackend,
+} from './runtime-host-service-manager.js';
+import { createSystemdUserRuntimeHostService } from './runtime-host-systemd-service.js';
+
+export interface RuntimeHostServiceManagementCliOptions extends RuntimeHostManagedServiceInput {
+  readonly json: boolean;
+}
+
+export interface RuntimeHostServiceManagementCliDeps {
+  readonly manage: typeof manageRuntimeHostService;
+  readonly createBackend: () => RuntimeHostServiceBackend;
+  readonly writeOutput: (value: string) => unknown;
+  readonly writeError: (value: string) => unknown;
+}
+
+export async function runManagedRuntimeHostServiceCli(
+  options: RuntimeHostServiceManagementCliOptions,
+  overrides: Partial<RuntimeHostServiceManagementCliDeps> = {},
+): Promise<number> {
+  const deps: RuntimeHostServiceManagementCliDeps = {
+    manage: manageRuntimeHostService,
+    createBackend: createPlatformServiceBackend,
+    writeOutput: (value) => process.stdout.write(value),
+    writeError: (value) => process.stderr.write(value),
+    ...overrides,
+  };
+  try {
+    const { json: _json, ...input } = options;
+    const result = await deps.manage(input, deps.createBackend());
+    deps.writeOutput(
+      options.json ? `${JSON.stringify({ ...result, ok: true })}\n` : formatHumanResult(result),
+    );
+    return 0;
+  } catch (error) {
+    const code =
+      error instanceof RuntimeHostServiceManagerError ? error.code : 'internal_service_error';
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.json) {
+      deps.writeOutput(
+        `${JSON.stringify({ schemaVersion: 1, ok: false, action: options.action, error: { code, message } })}\n`,
+      );
+    } else {
+      deps.writeError(`${message}\n`);
+    }
+    return 1;
+  }
+}
+
+function formatHumanResult(result: RuntimeHostManagedServiceResult): string {
+  const service = result.service;
+  if (result.action === 'uninstall') {
+    return result.retainedStateRoot
+      ? `Runtime Host service is uninstalled. Data was retained at ${result.retainedStateRoot}\n`
+      : 'Runtime Host service is uninstalled.\n';
+  }
+  if (result.action === 'install') {
+    return service.active
+      ? `Runtime Host service is installed and running at ${websocketUrl(service)}\n`
+      : 'Runtime Host service is installed but is not running. Check its status and journal.\n';
+  }
+  if (result.action === 'status') {
+    if (!service.installed) return 'Runtime Host service is not installed.\n';
+    return `Runtime Host service is ${service.state} at ${websocketUrl(service)}\n`;
+  }
+  return `Runtime Host service is ${service.state}.\n`;
+}
+
+function createPlatformServiceBackend(): RuntimeHostServiceBackend {
+  if (process.platform === 'linux') return createSystemdUserRuntimeHostService();
+  throw new RuntimeHostServiceManagerError(
+    'unsupported_platform',
+    'Managed Runtime Host services currently require Linux',
+  );
+}
+
+function websocketUrl(service: RuntimeHostManagedServiceResult['service']): string {
+  const websocket = service.config?.websocket;
+  return websocket
+    ? `ws://${websocket.host}:${websocket.port}${websocket.path}`
+    : 'an unknown endpoint';
+}

--- a/packages/cli/src/runtime-host-service-management-command.ts
+++ b/packages/cli/src/runtime-host-service-management-command.ts
@@ -1,5 +1,6 @@
 import {
   manageRuntimeHostService,
+  resolveRuntimeHostManagedServiceId,
   RuntimeHostServiceManagerError,
   type RuntimeHostManagedServiceInput,
   type RuntimeHostManagedServiceResult,
@@ -13,7 +14,7 @@ export interface RuntimeHostServiceManagementCliOptions extends RuntimeHostManag
 
 export interface RuntimeHostServiceManagementCliDeps {
   readonly manage: typeof manageRuntimeHostService;
-  readonly createBackend: () => RuntimeHostServiceBackend;
+  readonly createBackend: (serviceId: string) => RuntimeHostServiceBackend;
   readonly writeOutput: (value: string) => unknown;
   readonly writeError: (value: string) => unknown;
 }
@@ -31,7 +32,8 @@ export async function runManagedRuntimeHostServiceCli(
   };
   try {
     const { json: _json, ...input } = options;
-    const result = await deps.manage(input, deps.createBackend());
+    const serviceId = resolveRuntimeHostManagedServiceId(options.clientDataRoot);
+    const result = await deps.manage(input, deps.createBackend(serviceId));
     deps.writeOutput(
       options.json ? `${JSON.stringify({ ...result, ok: true })}\n` : formatHumanResult(result),
     );
@@ -70,8 +72,8 @@ function formatHumanResult(result: RuntimeHostManagedServiceResult): string {
   return `Runtime Host service is ${service.state}.\n`;
 }
 
-function createPlatformServiceBackend(): RuntimeHostServiceBackend {
-  if (process.platform === 'linux') return createSystemdUserRuntimeHostService();
+function createPlatformServiceBackend(serviceId: string): RuntimeHostServiceBackend {
+  if (process.platform === 'linux') return createSystemdUserRuntimeHostService(serviceId);
   throw new RuntimeHostServiceManagerError(
     'unsupported_platform',
     'Managed Runtime Host services currently require Linux',

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -1,14 +1,21 @@
 import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:net';
-import { mkdir, open, readFile, realpath, rename, rm } from 'node:fs/promises';
-import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { mkdir, open, readFile, realpath, rename, rm, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import {
   PROJECT_DIRECTORY_MAX_ROOTS,
   PROJECT_DIRECTORY_ROOT_LABEL_MAX_BYTES,
+  RUNTIME_HOST_PROTOCOL_VERSION,
 } from '@maka/runtime-host/protocol';
+import { connectExistingRuntimeHost } from '@maka/runtime-host/client';
+import { withFileUpdateLock } from '@maka/storage/file-update-lock';
 
 const SERVICE_CONFIG_FILE = 'runtime-host-service.json';
 const DEFAULT_WEBSOCKET_PATH = '/runtime-host';
+const SERVICE_OPERATION_LOCK_TIMEOUT_MS = 60_000;
+const SERVICE_READY_TIMEOUT_MS = 45_000;
+const SERVICE_READY_POLL_MS = 50;
 
 export interface RuntimeHostManagedServiceConfig {
   readonly schemaVersion: 1;
@@ -25,7 +32,6 @@ export interface RuntimeHostManagedServiceConfig {
   readonly launch: {
     readonly nodePath: string;
     readonly cliPath: string;
-    readonly packageVersion: string;
   };
 }
 
@@ -47,8 +53,9 @@ export interface RuntimeHostServiceBackendStatus {
 }
 
 export interface RuntimeHostServiceBackend {
+  readonly operationLockPath: string;
   preflightInstall(): Promise<void>;
-  install(config: RuntimeHostManagedServiceConfig): Promise<void>;
+  install(config: RuntimeHostManagedServiceConfig): Promise<RuntimeHostServiceDeployment>;
   status(): Promise<RuntimeHostServiceBackendStatus>;
   start(): Promise<void>;
   stop(): Promise<void>;
@@ -56,8 +63,11 @@ export interface RuntimeHostServiceBackend {
   uninstall(): Promise<void>;
 }
 
+export interface RuntimeHostServiceDeployment {
+  rollback(): Promise<void>;
+}
+
 export interface RuntimeHostManagedServiceStatus extends RuntimeHostServiceBackendStatus {
-  readonly configured: boolean;
   readonly config: RuntimeHostManagedServiceConfig | null;
 }
 
@@ -86,11 +96,16 @@ export interface RuntimeHostManagedServiceInput {
   readonly websocketPath?: string;
   readonly nodePath: string;
   readonly cliPath: string;
-  readonly packageVersion: string;
 }
 
 interface RuntimeHostServiceManagerDeps {
   readonly allocateLoopbackPort: () => Promise<number>;
+  readonly waitForReady: (
+    config: RuntimeHostManagedServiceConfig,
+    backend: RuntimeHostServiceBackend,
+  ) => Promise<void>;
+  readonly environment: NodeJS.ProcessEnv;
+  readonly homeDir: string;
 }
 
 export class RuntimeHostServiceManagerError extends Error {
@@ -119,16 +134,47 @@ export async function manageRuntimeHostService(
 ): Promise<RuntimeHostManagedServiceResult> {
   const deps: RuntimeHostServiceManagerDeps = {
     allocateLoopbackPort,
+    waitForReady: waitForManagedRuntimeHostReady,
+    environment: process.env,
+    homeDir: homedir(),
     ...overrides,
   };
   const configPath = resolveRuntimeHostManagedServiceConfigPath(input.clientDataRoot);
+  await Promise.all([
+    mkdir(dirname(configPath), { recursive: true, mode: 0o700 }),
+    mkdir(dirname(backend.operationLockPath), { recursive: true, mode: 0o700 }),
+  ]);
 
+  return withFileUpdateLock(
+    backend.operationLockPath,
+    () => manageRuntimeHostServiceLocked(input, backend, deps, configPath),
+    SERVICE_OPERATION_LOCK_TIMEOUT_MS,
+  );
+}
+
+async function manageRuntimeHostServiceLocked(
+  input: RuntimeHostManagedServiceInput,
+  backend: RuntimeHostServiceBackend,
+  deps: RuntimeHostServiceManagerDeps,
+  configPath: string,
+): Promise<RuntimeHostManagedServiceResult> {
   if (input.action === 'install') {
     await backend.preflightInstall();
     const previous = await readServiceConfigForRepair(configPath);
     const config = await prepareServiceConfig(input, previous, deps);
-    await writeRuntimeHostServiceFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 0o600);
-    await backend.install(config);
+    const deployment = await backend.install(config);
+    let configWriteStarted = false;
+    try {
+      await deps.waitForReady(config, backend);
+      configWriteStarted = true;
+      await writeRuntimeHostServiceFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 0o600);
+    } catch (error) {
+      await rollbackDeployment(
+        deployment,
+        configWriteStarted ? { configPath, previous } : null,
+        error,
+      );
+    }
     return result(input.action, await readServiceStatus(configPath, backend));
   }
 
@@ -141,7 +187,7 @@ export async function manageRuntimeHostService(
     await backend.uninstall();
     await removeRuntimeHostServiceFile(configPath, 'service config');
     const service = await readServiceStatus(configPath, backend);
-    if (service.installed || service.active || service.enabled || service.configured) {
+    if (service.installed || service.active || service.enabled || service.config !== null) {
       throw new RuntimeHostServiceManagerError(
         'uninstall_incomplete',
         `Runtime Host service still has managed state: ${service.state}`,
@@ -158,6 +204,14 @@ export async function manageRuntimeHostService(
     );
   }
   await backend[input.action]();
+  if (input.action === 'start' || input.action === 'restart') {
+    try {
+      await deps.waitForReady(config, backend);
+    } catch (error) {
+      await backend.stop().catch(() => undefined);
+      throw error;
+    }
+  }
   return result(input.action, await readServiceStatus(configPath, backend));
 }
 
@@ -217,10 +271,8 @@ async function prepareServiceConfig(
     );
   }
   const requestedRoot = resolve(input.rootPath ?? previous?.rootPath ?? input.defaultRootPath);
-  const projectDirectoryRoots = await Promise.all(
-    (input.projectDirectoryRoots ?? previous?.projectDirectoryRoots ?? []).map(
-      async ({ label, path }) => ({ label, path: await realpath(path) }),
-    ),
+  const projectDirectoryRoots = await normalizeProjectDirectoryRoots(
+    input.projectDirectoryRoots ?? previous?.projectDirectoryRoots ?? [],
   );
   const [nodePath, cliPath] = await Promise.all([
     realpath(input.nodePath),
@@ -232,8 +284,8 @@ async function prepareServiceConfig(
       { cause: error },
     );
   });
-  await mkdir(requestedRoot, { recursive: true, mode: 0o700 });
-  const rootPath = await realpath(requestedRoot);
+  await assertPersistentCliInstallation(cliPath, deps.environment, deps.homeDir);
+  const rootPath = await normalizeStateRoot(requestedRoot);
   const port =
     input.websocketPort ?? previous?.websocket.port ?? (await deps.allocateLoopbackPort());
   const websocketPath = input.websocketPath ?? previous?.websocket.path ?? DEFAULT_WEBSOCKET_PATH;
@@ -242,7 +294,7 @@ async function prepareServiceConfig(
     rootPath,
     projectDirectoryRoots,
     websocket: { host: '127.0.0.1', port, path: websocketPath },
-    launch: { nodePath, cliPath, packageVersion: input.packageVersion },
+    launch: { nodePath, cliPath },
   };
   validateServiceConfig(config);
   return config;
@@ -256,7 +308,7 @@ async function readServiceStatus(
     readServiceConfig(configPath),
     backend.status(),
   ]);
-  return { ...backendStatus, configured: config !== null, config };
+  return { ...backendStatus, config };
 }
 
 async function readServiceConfig(path: string): Promise<RuntimeHostManagedServiceConfig | null> {
@@ -340,13 +392,169 @@ function validateServiceConfig(value: unknown): asserts value is RuntimeHostMana
   if (
     !isRecord(launch) ||
     !isSafeAbsolutePath(launch.nodePath) ||
-    !isSafeAbsolutePath(launch.cliPath) ||
-    typeof launch.packageVersion !== 'string' ||
-    launch.packageVersion.length === 0 ||
-    hasControlCharacters(launch.packageVersion)
+    !isSafeAbsolutePath(launch.cliPath)
   ) {
     throw new TypeError('Invalid launch config');
   }
+}
+
+async function normalizeStateRoot(requestedRoot: string): Promise<string> {
+  try {
+    await mkdir(requestedRoot, { recursive: true, mode: 0o700 });
+    const canonical = await realpath(requestedRoot);
+    if (!(await stat(canonical)).isDirectory()) throw new Error('State Root is not a directory');
+    return canonical;
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'invalid_config',
+      `Invalid Runtime Host State Root: ${requestedRoot}`,
+      { cause: error },
+    );
+  }
+}
+
+async function normalizeProjectDirectoryRoots(
+  roots: readonly { readonly label: string; readonly path: string }[],
+): Promise<readonly { readonly label: string; readonly path: string }[]> {
+  let canonicalRoots: readonly { readonly label: string; readonly path: string }[];
+  try {
+    canonicalRoots = await Promise.all(
+      roots.map(async ({ label, path }) => {
+        const canonical = await realpath(path);
+        if (!(await stat(canonical)).isDirectory()) {
+          throw new Error(`Project root is not a directory: ${path}`);
+        }
+        return { label, path: canonical };
+      }),
+    );
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'invalid_config',
+      'A configured Project root is unavailable or is not a directory',
+      { cause: error },
+    );
+  }
+  if (new Set(canonicalRoots.map(({ path }) => path)).size !== canonicalRoots.length) {
+    throw new RuntimeHostServiceManagerError(
+      'invalid_config',
+      'Configured Project roots must resolve to distinct directories',
+    );
+  }
+  return canonicalRoots;
+}
+
+async function assertPersistentCliInstallation(
+  cliPath: string,
+  environment: NodeJS.ProcessEnv,
+  homeDir: string,
+): Promise<void> {
+  const invokedByNpx =
+    environment.npm_command === 'exec' || environment.npm_lifecycle_event === 'npx';
+  const cacheRoots = await Promise.all(
+    [environment.npm_config_cache, join(homeDir, '.npm')].flatMap((root) =>
+      root ? [realpath(resolve(root, '_npx')).catch(() => resolve(root, '_npx'))] : [],
+    ),
+  );
+  if (invokedByNpx || cacheRoots.some((root) => isWithin(root, cliPath))) {
+    throw new RuntimeHostServiceManagerError(
+      'invalid_launch',
+      'A persistent Runtime Host service cannot use a temporary npx installation; install Maka globally and retry',
+    );
+  }
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const pathFromRoot = relative(root, candidate);
+  return (
+    pathFromRoot === '' ||
+    (pathFromRoot !== '..' && !pathFromRoot.startsWith(`..${sep}`) && !isAbsolute(pathFromRoot))
+  );
+}
+
+async function waitForManagedRuntimeHostReady(
+  config: RuntimeHostManagedServiceConfig,
+  backend: RuntimeHostServiceBackend,
+): Promise<void> {
+  const deadline = Date.now() + SERVICE_READY_TIMEOUT_MS;
+  let lastFailure = 'not available';
+  while (Date.now() < deadline) {
+    const remaining = deadline - Date.now();
+    const connected = await connectExistingRuntimeHost({
+      rootPath: config.rootPath,
+      surface: 'run',
+      protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
+      connectTimeoutMs: Math.max(1, Math.min(500, remaining)),
+      handshakeTimeoutMs: Math.max(1, Math.min(500, remaining)),
+    }).catch((error: unknown) => {
+      lastFailure = error instanceof Error ? error.message : String(error);
+      return undefined;
+    });
+    if (connected?.kind === 'connected') {
+      try {
+        const status = await connected.connection.status(Math.max(1, remaining));
+        if (status.state === 'ready') {
+          const [diagnostics, service] = await Promise.all([
+            connected.connection.queryHostDiagnostics(),
+            backend.status(),
+          ]);
+          if (service.active && service.pid !== null && diagnostics.pid === service.pid) return;
+          lastFailure = 'ready Host does not belong to the managed service process';
+        } else {
+          lastFailure = `Host state is ${status.state}`;
+        }
+      } catch (error) {
+        lastFailure = error instanceof Error ? error.message : String(error);
+      } finally {
+        await connected.connection.close().catch(() => undefined);
+      }
+    } else if (connected) {
+      lastFailure = connected.kind;
+    }
+    await new Promise<void>((resolveWait) => setTimeout(resolveWait, SERVICE_READY_POLL_MS));
+  }
+  throw new RuntimeHostServiceManagerError(
+    'service_manager_operation_failed',
+    `Runtime Host service did not become ready: ${lastFailure}`,
+  );
+}
+
+async function rollbackDeployment(
+  deployment: RuntimeHostServiceDeployment,
+  configRollback: {
+    readonly configPath: string;
+    readonly previous: RuntimeHostManagedServiceConfig | null;
+  } | null,
+  originalError: unknown,
+): Promise<never> {
+  const rollbackErrors: unknown[] = [];
+  try {
+    await deployment.rollback();
+  } catch (rollbackError) {
+    rollbackErrors.push(rollbackError);
+  }
+  if (configRollback) {
+    try {
+      if (configRollback.previous) {
+        await writeRuntimeHostServiceFile(
+          configRollback.configPath,
+          `${JSON.stringify(configRollback.previous, null, 2)}\n`,
+          0o600,
+        );
+      } else {
+        await removeRuntimeHostServiceFile(configRollback.configPath, 'service config');
+      }
+    } catch (rollbackError) {
+      rollbackErrors.push(rollbackError);
+    }
+  }
+  if (rollbackErrors.length > 0) {
+    throw new RuntimeHostServiceManagerError(
+      'service_manager_operation_failed',
+      'Runtime Host service deployment failed and the previous deployment could not be restored',
+      { cause: new AggregateError([originalError, ...rollbackErrors]) },
+    );
+  }
+  throw originalError;
 }
 
 async function allocateLoopbackPort(): Promise<number> {

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { createServer } from 'node:net';
 import { mkdir, open, readFile, realpath, rename, rm, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
@@ -53,7 +53,6 @@ export interface RuntimeHostServiceBackendStatus {
 }
 
 export interface RuntimeHostServiceBackend {
-  readonly operationLockPath: string;
   preflightInstall(): Promise<void>;
   install(config: RuntimeHostManagedServiceConfig): Promise<RuntimeHostServiceDeployment>;
   status(): Promise<RuntimeHostServiceBackendStatus>;
@@ -140,13 +139,14 @@ export async function manageRuntimeHostService(
     ...overrides,
   };
   const configPath = resolveRuntimeHostManagedServiceConfigPath(input.clientDataRoot);
-  await Promise.all([
-    mkdir(dirname(configPath), { recursive: true, mode: 0o700 }),
-    mkdir(dirname(backend.operationLockPath), { recursive: true, mode: 0o700 }),
-  ]);
+  const configDirectory = dirname(configPath);
+  if (input.action === 'status' && !(await isExistingDirectory(configDirectory))) {
+    return manageRuntimeHostServiceLocked(input, backend, deps, configPath);
+  }
+  await mkdir(configDirectory, { recursive: true, mode: 0o700 });
 
   return withFileUpdateLock(
-    backend.operationLockPath,
+    configPath,
     () => manageRuntimeHostServiceLocked(input, backend, deps, configPath),
     SERVICE_OPERATION_LOCK_TIMEOUT_MS,
   );
@@ -217,6 +217,10 @@ async function manageRuntimeHostServiceLocked(
 
 export function resolveRuntimeHostManagedServiceConfigPath(clientDataRoot: string): string {
   return join(clientDataRoot, SERVICE_CONFIG_FILE);
+}
+
+export function resolveRuntimeHostManagedServiceId(clientDataRoot: string): string {
+  return createHash('sha256').update(resolve(clientDataRoot)).digest('hex');
 }
 
 export async function writeRuntimeHostServiceFile(
@@ -601,4 +605,13 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error && error.code === code;
+}
+
+async function isExistingDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) return false;
+    throw error;
+  }
 }

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -1,0 +1,396 @@
+import { randomUUID } from 'node:crypto';
+import { createServer } from 'node:net';
+import { mkdir, open, readFile, realpath, rename, rm } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import {
+  PROJECT_DIRECTORY_MAX_ROOTS,
+  PROJECT_DIRECTORY_ROOT_LABEL_MAX_BYTES,
+} from '@maka/runtime-host/protocol';
+
+const SERVICE_CONFIG_FILE = 'runtime-host-service.json';
+const DEFAULT_WEBSOCKET_PATH = '/runtime-host';
+
+export interface RuntimeHostManagedServiceConfig {
+  readonly schemaVersion: 1;
+  readonly rootPath: string;
+  readonly projectDirectoryRoots: readonly {
+    readonly label: string;
+    readonly path: string;
+  }[];
+  readonly websocket: {
+    readonly host: '127.0.0.1';
+    readonly port: number;
+    readonly path: string;
+  };
+  readonly launch: {
+    readonly nodePath: string;
+    readonly cliPath: string;
+    readonly packageVersion: string;
+  };
+}
+
+export type RuntimeHostServiceState =
+  | 'not_installed'
+  | 'stopped'
+  | 'starting'
+  | 'running'
+  | 'failed';
+
+export interface RuntimeHostServiceBackendStatus {
+  readonly manager: 'systemd_user' | 'launch_agent';
+  readonly installed: boolean;
+  readonly enabled: boolean;
+  readonly active: boolean;
+  readonly state: RuntimeHostServiceState;
+  readonly pid: number | null;
+  readonly lastExitCode: number | null;
+}
+
+export interface RuntimeHostServiceBackend {
+  preflightInstall(): Promise<void>;
+  install(config: RuntimeHostManagedServiceConfig): Promise<void>;
+  status(): Promise<RuntimeHostServiceBackendStatus>;
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  restart(): Promise<void>;
+  uninstall(): Promise<void>;
+}
+
+export interface RuntimeHostManagedServiceStatus extends RuntimeHostServiceBackendStatus {
+  readonly configured: boolean;
+  readonly config: RuntimeHostManagedServiceConfig | null;
+}
+
+export type RuntimeHostManagedServiceAction =
+  | 'install'
+  | 'status'
+  | 'start'
+  | 'stop'
+  | 'restart'
+  | 'uninstall';
+
+export interface RuntimeHostManagedServiceResult {
+  readonly schemaVersion: 1;
+  readonly action: RuntimeHostManagedServiceAction;
+  readonly service: RuntimeHostManagedServiceStatus;
+  readonly retainedStateRoot?: string;
+}
+
+export interface RuntimeHostManagedServiceInput {
+  readonly action: RuntimeHostManagedServiceAction;
+  readonly clientDataRoot: string;
+  readonly defaultRootPath: string;
+  readonly rootPath?: string;
+  readonly projectDirectoryRoots?: readonly { readonly label: string; readonly path: string }[];
+  readonly websocketPort?: number;
+  readonly websocketPath?: string;
+  readonly nodePath: string;
+  readonly cliPath: string;
+  readonly packageVersion: string;
+}
+
+interface RuntimeHostServiceManagerDeps {
+  readonly allocateLoopbackPort: () => Promise<number>;
+}
+
+export class RuntimeHostServiceManagerError extends Error {
+  constructor(
+    readonly code:
+      | 'unsupported_platform'
+      | 'service_manager_unavailable'
+      | 'linger_disabled'
+      | 'not_installed'
+      | 'invalid_config'
+      | 'invalid_launch'
+      | 'service_manager_operation_failed'
+      | 'uninstall_incomplete',
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'RuntimeHostServiceManagerError';
+  }
+}
+
+export async function manageRuntimeHostService(
+  input: RuntimeHostManagedServiceInput,
+  backend: RuntimeHostServiceBackend,
+  overrides: Partial<RuntimeHostServiceManagerDeps> = {},
+): Promise<RuntimeHostManagedServiceResult> {
+  const deps: RuntimeHostServiceManagerDeps = {
+    allocateLoopbackPort,
+    ...overrides,
+  };
+  const configPath = resolveRuntimeHostManagedServiceConfigPath(input.clientDataRoot);
+
+  if (input.action === 'install') {
+    await backend.preflightInstall();
+    const previous = await readServiceConfigForRepair(configPath);
+    const config = await prepareServiceConfig(input, previous, deps);
+    await writeRuntimeHostServiceFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 0o600);
+    await backend.install(config);
+    return result(input.action, await readServiceStatus(configPath, backend));
+  }
+
+  if (input.action === 'status') {
+    return result(input.action, await readServiceStatus(configPath, backend));
+  }
+
+  if (input.action === 'uninstall') {
+    const before = await readServiceConfigForRepair(configPath);
+    await backend.uninstall();
+    await removeRuntimeHostServiceFile(configPath, 'service config');
+    const service = await readServiceStatus(configPath, backend);
+    if (service.installed || service.active || service.enabled || service.configured) {
+      throw new RuntimeHostServiceManagerError(
+        'uninstall_incomplete',
+        `Runtime Host service still has managed state: ${service.state}`,
+      );
+    }
+    return result(input.action, service, before?.rootPath);
+  }
+
+  const config = await readServiceConfig(configPath);
+  if (!config) {
+    throw new RuntimeHostServiceManagerError(
+      'not_installed',
+      'Runtime Host service is not installed',
+    );
+  }
+  await backend[input.action]();
+  return result(input.action, await readServiceStatus(configPath, backend));
+}
+
+export function resolveRuntimeHostManagedServiceConfigPath(clientDataRoot: string): string {
+  return join(clientDataRoot, SERVICE_CONFIG_FILE);
+}
+
+export async function writeRuntimeHostServiceFile(
+  path: string,
+  contents: string,
+  mode: number,
+): Promise<void> {
+  const directory = dirname(path);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  try {
+    const file = await open(temporaryPath, 'wx', mode);
+    try {
+      await file.writeFile(contents, 'utf8');
+      await file.sync();
+    } finally {
+      await file.close();
+    }
+    await rename(temporaryPath, path);
+    const parent = await open(directory, 'r');
+    try {
+      await parent.sync();
+    } finally {
+      await parent.close();
+    }
+  } finally {
+    await rm(temporaryPath, { force: true });
+  }
+}
+
+export async function removeRuntimeHostServiceFile(path: string, label: string): Promise<void> {
+  try {
+    await rm(path, { force: true });
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'uninstall_incomplete',
+      `Unable to remove Runtime Host ${label} at ${path}`,
+      { cause: error },
+    );
+  }
+}
+
+async function prepareServiceConfig(
+  input: RuntimeHostManagedServiceInput,
+  previous: RuntimeHostManagedServiceConfig | null,
+  deps: RuntimeHostServiceManagerDeps,
+): Promise<RuntimeHostManagedServiceConfig> {
+  if (!input.cliPath) {
+    throw new RuntimeHostServiceManagerError(
+      'invalid_launch',
+      'The current Maka CLI entry point could not be resolved',
+    );
+  }
+  const requestedRoot = resolve(input.rootPath ?? previous?.rootPath ?? input.defaultRootPath);
+  const projectDirectoryRoots = await Promise.all(
+    (input.projectDirectoryRoots ?? previous?.projectDirectoryRoots ?? []).map(
+      async ({ label, path }) => ({ label, path: await realpath(path) }),
+    ),
+  );
+  const [nodePath, cliPath] = await Promise.all([
+    realpath(input.nodePath),
+    realpath(input.cliPath),
+  ]).catch((error) => {
+    throw new RuntimeHostServiceManagerError(
+      'invalid_launch',
+      'The current Node.js or Maka CLI installation is unavailable',
+      { cause: error },
+    );
+  });
+  await mkdir(requestedRoot, { recursive: true, mode: 0o700 });
+  const rootPath = await realpath(requestedRoot);
+  const port =
+    input.websocketPort ?? previous?.websocket.port ?? (await deps.allocateLoopbackPort());
+  const websocketPath = input.websocketPath ?? previous?.websocket.path ?? DEFAULT_WEBSOCKET_PATH;
+  const config: RuntimeHostManagedServiceConfig = {
+    schemaVersion: 1,
+    rootPath,
+    projectDirectoryRoots,
+    websocket: { host: '127.0.0.1', port, path: websocketPath },
+    launch: { nodePath, cliPath, packageVersion: input.packageVersion },
+  };
+  validateServiceConfig(config);
+  return config;
+}
+
+async function readServiceStatus(
+  configPath: string,
+  backend: RuntimeHostServiceBackend,
+): Promise<RuntimeHostManagedServiceStatus> {
+  const [config, backendStatus] = await Promise.all([
+    readServiceConfig(configPath),
+    backend.status(),
+  ]);
+  return { ...backendStatus, configured: config !== null, config };
+}
+
+async function readServiceConfig(path: string): Promise<RuntimeHostManagedServiceConfig | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) return null;
+    throw error;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    validateServiceConfig(parsed);
+    return parsed;
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'invalid_config',
+      `Invalid Runtime Host service config at ${path}`,
+      { cause: error },
+    );
+  }
+}
+
+async function readServiceConfigForRepair(
+  path: string,
+): Promise<RuntimeHostManagedServiceConfig | null> {
+  try {
+    return await readServiceConfig(path);
+  } catch (error) {
+    if (error instanceof RuntimeHostServiceManagerError && error.code === 'invalid_config') {
+      return null;
+    }
+    throw error;
+  }
+}
+
+function validateServiceConfig(value: unknown): asserts value is RuntimeHostManagedServiceConfig {
+  if (!isRecord(value) || value.schemaVersion !== 1) throw new TypeError('Invalid schemaVersion');
+  if (!isSafeAbsolutePath(value.rootPath)) throw new TypeError('Invalid rootPath');
+  if (
+    !Array.isArray(value.projectDirectoryRoots) ||
+    value.projectDirectoryRoots.length > PROJECT_DIRECTORY_MAX_ROOTS
+  ) {
+    throw new TypeError('Invalid projectDirectoryRoots');
+  }
+  for (const root of value.projectDirectoryRoots) {
+    if (
+      !isRecord(root) ||
+      typeof root.label !== 'string' ||
+      root.label.length === 0 ||
+      Buffer.byteLength(root.label, 'utf8') > PROJECT_DIRECTORY_ROOT_LABEL_MAX_BYTES ||
+      hasControlCharacters(root.label) ||
+      !isSafeAbsolutePath(root.path)
+    ) {
+      throw new TypeError('Invalid project directory root');
+    }
+  }
+  if (
+    new Set(value.projectDirectoryRoots.map(({ label }) => label)).size !==
+    value.projectDirectoryRoots.length
+  ) {
+    throw new TypeError('Duplicate project directory root label');
+  }
+  const websocket = value.websocket;
+  if (
+    !isRecord(websocket) ||
+    websocket.host !== '127.0.0.1' ||
+    typeof websocket.port !== 'number' ||
+    !Number.isInteger(websocket.port) ||
+    websocket.port < 1 ||
+    websocket.port > 65_535 ||
+    typeof websocket.path !== 'string' ||
+    !websocket.path.startsWith('/') ||
+    websocket.path.includes('?') ||
+    websocket.path.includes('#') ||
+    hasControlCharacters(websocket.path)
+  ) {
+    throw new TypeError('Invalid websocket config');
+  }
+  const launch = value.launch;
+  if (
+    !isRecord(launch) ||
+    !isSafeAbsolutePath(launch.nodePath) ||
+    !isSafeAbsolutePath(launch.cliPath) ||
+    typeof launch.packageVersion !== 'string' ||
+    launch.packageVersion.length === 0 ||
+    hasControlCharacters(launch.packageVersion)
+  ) {
+    throw new TypeError('Invalid launch config');
+  }
+}
+
+async function allocateLoopbackPort(): Promise<number> {
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.unref();
+    server.once('error', reject);
+    server.listen({ host: '127.0.0.1', port: 0, exclusive: true }, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Unable to allocate a loopback port'));
+        return;
+      }
+      server.close((error) => (error ? reject(error) : resolvePort(address.port)));
+    });
+  });
+}
+
+function result(
+  action: RuntimeHostManagedServiceAction,
+  service: RuntimeHostManagedServiceStatus,
+  retainedStateRoot?: string,
+): RuntimeHostManagedServiceResult {
+  return {
+    schemaVersion: 1,
+    action,
+    service,
+    ...(retainedStateRoot ? { retainedStateRoot } : {}),
+  };
+}
+
+function isSafeAbsolutePath(value: unknown): value is string {
+  return typeof value === 'string' && isAbsolute(value) && !hasControlCharacters(value);
+}
+
+function hasControlCharacters(value: string): boolean {
+  return /[\u0000-\u001f\u007f]/u.test(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === code;
+}

--- a/packages/cli/src/runtime-host-systemd-service.ts
+++ b/packages/cli/src/runtime-host-systemd-service.ts
@@ -14,13 +14,18 @@ import {
   writeRuntimeHostServiceFile,
 } from './runtime-host-service-manager.js';
 
-const SYSTEMD_UNIT_NAME = 'maka-runtime-host.service';
 const SERVICE_MANAGER_COMMAND_TIMEOUT_MS = 30_000;
 
 interface CommandResult {
   readonly exitCode: number;
   readonly stdout: string;
   readonly stderr: string;
+}
+
+interface SystemdUnitContext {
+  readonly unitName: string;
+  readonly unitPath: string;
+  readonly runSystemctl: (args: readonly string[]) => Promise<CommandResult>;
 }
 
 export interface SystemdUserServiceOptions {
@@ -32,17 +37,22 @@ export interface SystemdUserServiceOptions {
 }
 
 export function createSystemdUserRuntimeHostService(
+  serviceId: string,
   options: SystemdUserServiceOptions = {},
 ): RuntimeHostServiceBackend {
   const env = options.env ?? process.env;
   const homeDir = options.homeDir ?? homedir();
-  const unitPath = resolveSystemdUserRuntimeHostServicePath(env, homeDir);
   const runSystemctl = options.runSystemctl ?? defaultRunSystemctl;
+  const context: SystemdUnitContext = {
+    unitName: resolveSystemdUserRuntimeHostServiceName(serviceId),
+    unitPath: resolveSystemdUserRuntimeHostServicePath(serviceId, env, homeDir),
+    runSystemctl,
+  };
   const runLoginctl = options.runLoginctl ?? defaultRunLoginctl;
   const uid = options.uid ?? process.getuid?.();
 
   const readStatus = async (): Promise<RuntimeHostServiceBackendStatus> => {
-    const raw = await readSystemdStatus(runSystemctl);
+    const raw = await readSystemdStatus(context);
     return {
       manager: 'systemd_user',
       installed: raw.loadState !== 'not-found',
@@ -55,38 +65,37 @@ export function createSystemdUserRuntimeHostService(
   };
 
   return {
-    operationLockPath: unitPath,
     preflightInstall: async () => {
       await assertUserSystemd(runSystemctl);
       await assertUserLinger(uid, runLoginctl);
     },
     install: async (config) => {
       await validateLaunchFiles(config);
-      const previous = await captureSystemdDeployment(unitPath, readStatus);
+      const previous = await captureSystemdDeployment(context.unitPath, readStatus);
       try {
-        await applySystemdDeployment(unitPath, config, runSystemctl);
+        await applySystemdDeployment(context, config);
       } catch (error) {
-        await restoreFailedSystemdDeployment(previous, unitPath, runSystemctl, error);
+        await restoreFailedSystemdDeployment(previous, context, error);
       }
       let rolledBack = false;
       return {
         rollback: async () => {
           if (rolledBack) return;
           rolledBack = true;
-          await restoreSystemdDeployment(previous, unitPath, runSystemctl);
+          await restoreSystemdDeployment(previous, context);
         },
       } satisfies RuntimeHostServiceDeployment;
     },
     status: readStatus,
-    start: () => runLifecycleAction(runSystemctl, 'start'),
-    stop: () => runLifecycleAction(runSystemctl, 'stop'),
-    restart: () => runLifecycleAction(runSystemctl, 'restart'),
+    start: () => runLifecycleAction(context, 'start'),
+    stop: () => runLifecycleAction(context, 'stop'),
+    restart: () => runLifecycleAction(context, 'restart'),
     uninstall: async () => {
-      const before = await readSystemdStatus(runSystemctl);
+      const before = await readSystemdStatus(context);
       if (before.loadState !== 'not-found') {
         await requireSystemctl(
           runSystemctl,
-          ['stop', SYSTEMD_UNIT_NAME],
+          ['stop', context.unitName],
           'Stopping the Runtime Host service failed',
         );
       }
@@ -97,12 +106,12 @@ export function createSystemdUserRuntimeHostService(
       ) {
         await requireSystemctl(
           runSystemctl,
-          ['disable', SYSTEMD_UNIT_NAME],
+          ['disable', context.unitName],
           'Disabling the Runtime Host service failed',
         );
-        await runSystemctl(['reset-failed', SYSTEMD_UNIT_NAME]);
+        await runSystemctl(['reset-failed', context.unitName]);
       }
-      await removeRuntimeHostServiceFile(unitPath, 'systemd unit');
+      await removeRuntimeHostServiceFile(context.unitPath, 'systemd unit');
       await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
       const after = await readStatus();
       if (after.installed || after.active || after.enabled) {
@@ -116,11 +125,22 @@ export function createSystemdUserRuntimeHostService(
 }
 
 export function resolveSystemdUserRuntimeHostServicePath(
+  serviceId: string,
   env: NodeJS.ProcessEnv = process.env,
   homeDir = homedir(),
 ): string {
   const systemdConfigRoot = resolveXdgConfigHome(env, homeDir);
-  return join(systemdConfigRoot, 'systemd', 'user', SYSTEMD_UNIT_NAME);
+  return join(
+    systemdConfigRoot,
+    'systemd',
+    'user',
+    resolveSystemdUserRuntimeHostServiceName(serviceId),
+  );
+}
+
+function resolveSystemdUserRuntimeHostServiceName(serviceId: string): string {
+  if (!/^[0-9a-f]{64}$/u.test(serviceId)) throw new TypeError('Invalid Runtime Host service ID');
+  return `maka-runtime-host-${serviceId}.service`;
 }
 
 export function renderSystemdUnit(config: RuntimeHostManagedServiceConfig): string {
@@ -191,32 +211,30 @@ async function captureSystemdDeployment(
 }
 
 async function applySystemdDeployment(
-  unitPath: string,
+  context: SystemdUnitContext,
   config: RuntimeHostManagedServiceConfig,
-  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
 ): Promise<void> {
-  await writeRuntimeHostServiceFile(unitPath, renderSystemdUnit(config), 0o600);
-  await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
+  await writeRuntimeHostServiceFile(context.unitPath, renderSystemdUnit(config), 0o600);
+  await requireSystemctl(context.runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
   await requireSystemctl(
-    runSystemctl,
-    ['enable', SYSTEMD_UNIT_NAME],
+    context.runSystemctl,
+    ['enable', context.unitName],
     'Enabling the Runtime Host service failed',
   );
   await requireSystemctl(
-    runSystemctl,
-    ['restart', SYSTEMD_UNIT_NAME],
+    context.runSystemctl,
+    ['restart', context.unitName],
     'Starting the Runtime Host service failed',
   );
 }
 
 async function restoreFailedSystemdDeployment(
   snapshot: SystemdDeploymentSnapshot,
-  unitPath: string,
-  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+  context: SystemdUnitContext,
   originalError: unknown,
 ): Promise<never> {
   try {
-    await restoreSystemdDeployment(snapshot, unitPath, runSystemctl);
+    await restoreSystemdDeployment(snapshot, context);
   } catch (rollbackError) {
     throw new RuntimeHostServiceManagerError(
       'service_manager_operation_failed',
@@ -229,57 +247,54 @@ async function restoreFailedSystemdDeployment(
 
 async function restoreSystemdDeployment(
   snapshot: SystemdDeploymentSnapshot,
-  unitPath: string,
-  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+  context: SystemdUnitContext,
 ): Promise<void> {
   if (snapshot.unit === null) {
     let current: SystemdStatus;
     try {
-      current = await readSystemdStatus(runSystemctl);
+      current = await readSystemdStatus(context);
     } catch (error) {
-      await removeRuntimeHostServiceFile(unitPath, 'systemd unit');
+      await removeRuntimeHostServiceFile(context.unitPath, 'systemd unit');
       throw error;
     }
     if (current.loadState !== 'not-found') {
       await requireSystemctl(
-        runSystemctl,
-        ['stop', SYSTEMD_UNIT_NAME],
+        context.runSystemctl,
+        ['stop', context.unitName],
         'Stopping the replacement Runtime Host service failed',
       );
       await requireSystemctl(
-        runSystemctl,
-        ['disable', SYSTEMD_UNIT_NAME],
+        context.runSystemctl,
+        ['disable', context.unitName],
         'Disabling the replacement Runtime Host service failed',
       );
     }
-    await removeRuntimeHostServiceFile(unitPath, 'systemd unit');
-    await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
-    await runSystemctl(['reset-failed', SYSTEMD_UNIT_NAME]);
+    await removeRuntimeHostServiceFile(context.unitPath, 'systemd unit');
+    await requireSystemctl(context.runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
+    await context.runSystemctl(['reset-failed', context.unitName]);
     return;
   }
 
-  await writeRuntimeHostServiceFile(unitPath, snapshot.unit, 0o600);
-  await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
+  await writeRuntimeHostServiceFile(context.unitPath, snapshot.unit, 0o600);
+  await requireSystemctl(context.runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
   await requireSystemctl(
-    runSystemctl,
-    [snapshot.status.enabled ? 'enable' : 'disable', SYSTEMD_UNIT_NAME],
+    context.runSystemctl,
+    [snapshot.status.enabled ? 'enable' : 'disable', context.unitName],
     'Restoring the Runtime Host service enablement failed',
   );
   await requireSystemctl(
-    runSystemctl,
-    [snapshot.status.active ? 'restart' : 'stop', SYSTEMD_UNIT_NAME],
+    context.runSystemctl,
+    [snapshot.status.active ? 'restart' : 'stop', context.unitName],
     'Restoring the Runtime Host service state failed',
   );
 }
 
-async function readSystemdStatus(
-  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
-): Promise<SystemdStatus> {
+async function readSystemdStatus(context: SystemdUnitContext): Promise<SystemdStatus> {
   let result: CommandResult;
   try {
-    result = await runSystemctl([
+    result = await context.runSystemctl([
       'show',
-      SYSTEMD_UNIT_NAME,
+      context.unitName,
       '--property=LoadState,ActiveState,SubState,UnitFileState,MainPID,ExecMainStatus',
       '--no-pager',
     ]);
@@ -291,14 +306,10 @@ async function readSystemdStatus(
     );
   }
   const properties = parseProperties(result.stdout);
-  const reportedLoadState = properties.get('LoadState');
-  if (
-    (result.exitCode !== 0 && reportedLoadState !== 'not-found') ||
-    reportedLoadState === undefined
-  ) {
+  const loadState = properties.get('LoadState');
+  if (loadState === undefined || (result.exitCode !== 0 && loadState !== 'not-found')) {
     throw managerError('Reading Runtime Host service status failed', result);
   }
-  const loadState = reportedLoadState ?? 'loaded';
   return {
     loadState,
     activeState: properties.get('ActiveState') ?? 'inactive',
@@ -381,12 +392,12 @@ async function assertUserLinger(
 }
 
 async function runLifecycleAction(
-  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+  context: SystemdUnitContext,
   action: 'start' | 'stop' | 'restart',
 ): Promise<void> {
   await requireSystemctl(
-    runSystemctl,
-    [action, SYSTEMD_UNIT_NAME],
+    context.runSystemctl,
+    [action, context.unitName],
     `${actionPresentParticiple(action)} the Runtime Host service failed`,
   );
 }

--- a/packages/cli/src/runtime-host-systemd-service.ts
+++ b/packages/cli/src/runtime-host-systemd-service.ts
@@ -1,18 +1,21 @@
 import { spawn } from 'node:child_process';
 import { constants } from 'node:fs';
-import { access, realpath, stat } from 'node:fs/promises';
+import { access, readFile, realpath, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { resolveXdgConfigHome } from '@maka/storage';
 import {
   removeRuntimeHostServiceFile,
   RuntimeHostServiceManagerError,
   type RuntimeHostManagedServiceConfig,
   type RuntimeHostServiceBackend,
   type RuntimeHostServiceBackendStatus,
+  type RuntimeHostServiceDeployment,
   writeRuntimeHostServiceFile,
 } from './runtime-host-service-manager.js';
 
 const SYSTEMD_UNIT_NAME = 'maka-runtime-host.service';
+const SERVICE_MANAGER_COMMAND_TIMEOUT_MS = 30_000;
 
 interface CommandResult {
   readonly exitCode: number;
@@ -52,24 +55,27 @@ export function createSystemdUserRuntimeHostService(
   };
 
   return {
+    operationLockPath: unitPath,
     preflightInstall: async () => {
       await assertUserSystemd(runSystemctl);
       await assertUserLinger(uid, runLoginctl);
     },
     install: async (config) => {
       await validateLaunchFiles(config);
-      await writeRuntimeHostServiceFile(unitPath, renderSystemdUnit(config), 0o600);
-      await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
-      await requireSystemctl(
-        runSystemctl,
-        ['enable', SYSTEMD_UNIT_NAME],
-        'Enabling the Runtime Host service failed',
-      );
-      await requireSystemctl(
-        runSystemctl,
-        ['restart', SYSTEMD_UNIT_NAME],
-        'Starting the Runtime Host service failed',
-      );
+      const previous = await captureSystemdDeployment(unitPath, readStatus);
+      try {
+        await applySystemdDeployment(unitPath, config, runSystemctl);
+      } catch (error) {
+        await restoreFailedSystemdDeployment(previous, unitPath, runSystemctl, error);
+      }
+      let rolledBack = false;
+      return {
+        rollback: async () => {
+          if (rolledBack) return;
+          rolledBack = true;
+          await restoreSystemdDeployment(previous, unitPath, runSystemctl);
+        },
+      } satisfies RuntimeHostServiceDeployment;
     },
     status: readStatus,
     start: () => runLifecycleAction(runSystemctl, 'start'),
@@ -113,7 +119,7 @@ export function resolveSystemdUserRuntimeHostServicePath(
   env: NodeJS.ProcessEnv = process.env,
   homeDir = homedir(),
 ): string {
-  const systemdConfigRoot = env.XDG_CONFIG_HOME ?? join(homeDir, '.config');
+  const systemdConfigRoot = resolveXdgConfigHome(env, homeDir);
   return join(systemdConfigRoot, 'systemd', 'user', SYSTEMD_UNIT_NAME);
 }
 
@@ -165,20 +171,134 @@ interface SystemdStatus {
   readonly execMainStatus?: string;
 }
 
+interface SystemdDeploymentSnapshot {
+  readonly unit: string | null;
+  readonly status: RuntimeHostServiceBackendStatus;
+}
+
+async function captureSystemdDeployment(
+  unitPath: string,
+  readStatus: () => Promise<RuntimeHostServiceBackendStatus>,
+): Promise<SystemdDeploymentSnapshot> {
+  const [unit, status] = await Promise.all([
+    readFile(unitPath, 'utf8').catch((error: unknown) => {
+      if (isNodeError(error, 'ENOENT')) return null;
+      throw error;
+    }),
+    readStatus(),
+  ]);
+  return { unit, status };
+}
+
+async function applySystemdDeployment(
+  unitPath: string,
+  config: RuntimeHostManagedServiceConfig,
+  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+): Promise<void> {
+  await writeRuntimeHostServiceFile(unitPath, renderSystemdUnit(config), 0o600);
+  await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
+  await requireSystemctl(
+    runSystemctl,
+    ['enable', SYSTEMD_UNIT_NAME],
+    'Enabling the Runtime Host service failed',
+  );
+  await requireSystemctl(
+    runSystemctl,
+    ['restart', SYSTEMD_UNIT_NAME],
+    'Starting the Runtime Host service failed',
+  );
+}
+
+async function restoreFailedSystemdDeployment(
+  snapshot: SystemdDeploymentSnapshot,
+  unitPath: string,
+  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+  originalError: unknown,
+): Promise<never> {
+  try {
+    await restoreSystemdDeployment(snapshot, unitPath, runSystemctl);
+  } catch (rollbackError) {
+    throw new RuntimeHostServiceManagerError(
+      'service_manager_operation_failed',
+      'Updating the Runtime Host service failed and the previous systemd deployment could not be restored',
+      { cause: new AggregateError([originalError, rollbackError]) },
+    );
+  }
+  throw originalError;
+}
+
+async function restoreSystemdDeployment(
+  snapshot: SystemdDeploymentSnapshot,
+  unitPath: string,
+  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+): Promise<void> {
+  if (snapshot.unit === null) {
+    let current: SystemdStatus;
+    try {
+      current = await readSystemdStatus(runSystemctl);
+    } catch (error) {
+      await removeRuntimeHostServiceFile(unitPath, 'systemd unit');
+      throw error;
+    }
+    if (current.loadState !== 'not-found') {
+      await requireSystemctl(
+        runSystemctl,
+        ['stop', SYSTEMD_UNIT_NAME],
+        'Stopping the replacement Runtime Host service failed',
+      );
+      await requireSystemctl(
+        runSystemctl,
+        ['disable', SYSTEMD_UNIT_NAME],
+        'Disabling the replacement Runtime Host service failed',
+      );
+    }
+    await removeRuntimeHostServiceFile(unitPath, 'systemd unit');
+    await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
+    await runSystemctl(['reset-failed', SYSTEMD_UNIT_NAME]);
+    return;
+  }
+
+  await writeRuntimeHostServiceFile(unitPath, snapshot.unit, 0o600);
+  await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
+  await requireSystemctl(
+    runSystemctl,
+    [snapshot.status.enabled ? 'enable' : 'disable', SYSTEMD_UNIT_NAME],
+    'Restoring the Runtime Host service enablement failed',
+  );
+  await requireSystemctl(
+    runSystemctl,
+    [snapshot.status.active ? 'restart' : 'stop', SYSTEMD_UNIT_NAME],
+    'Restoring the Runtime Host service state failed',
+  );
+}
+
 async function readSystemdStatus(
   runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
 ): Promise<SystemdStatus> {
-  const result = await runSystemctl([
-    'show',
-    SYSTEMD_UNIT_NAME,
-    '--property=LoadState,ActiveState,SubState,UnitFileState,MainPID,ExecMainStatus',
-    '--no-pager',
-  ]);
+  let result: CommandResult;
+  try {
+    result = await runSystemctl([
+      'show',
+      SYSTEMD_UNIT_NAME,
+      '--property=LoadState,ActiveState,SubState,UnitFileState,MainPID,ExecMainStatus',
+      '--no-pager',
+    ]);
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'service_manager_unavailable',
+      'Unable to query the systemd user service manager',
+      { cause: error },
+    );
+  }
   const properties = parseProperties(result.stdout);
-  const loadState = properties.get('LoadState') ?? (result.exitCode === 0 ? 'loaded' : 'not-found');
-  if (result.exitCode !== 0 && loadState !== 'not-found') {
+  const reportedLoadState = properties.get('LoadState');
+  if (
+    (result.exitCode !== 0 && reportedLoadState !== 'not-found') ||
+    reportedLoadState === undefined
+  ) {
     throw managerError('Reading Runtime Host service status failed', result);
   }
+  const loadState = reportedLoadState ?? 'loaded';
   return {
     loadState,
     activeState: properties.get('ActiveState') ?? 'inactive',
@@ -276,7 +396,14 @@ async function requireSystemctl(
   args: readonly string[],
   message: string,
 ): Promise<void> {
-  const result = await runSystemctl(args);
+  let result: CommandResult;
+  try {
+    result = await runSystemctl(args);
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError('service_manager_unavailable', message, {
+      cause: error,
+    });
+  }
   if (result.exitCode !== 0) throw managerError(message, result);
 }
 
@@ -301,6 +428,8 @@ async function runCommand(command: string, args: readonly string[]): Promise<Com
     const child = spawn(command, args, {
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
+      timeout: SERVICE_MANAGER_COMMAND_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
     let stdout = '';
     let stderr = '';
@@ -317,6 +446,10 @@ async function runCommand(command: string, args: readonly string[]): Promise<Com
       resolveResult({ exitCode: exitCode ?? 1, stdout, stderr });
     });
   });
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error && error.code === code;
 }
 
 function parseProperties(output: string): Map<string, string> {

--- a/packages/cli/src/runtime-host-systemd-service.ts
+++ b/packages/cli/src/runtime-host-systemd-service.ts
@@ -1,0 +1,364 @@
+import { spawn } from 'node:child_process';
+import { constants } from 'node:fs';
+import { access, realpath, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  removeRuntimeHostServiceFile,
+  RuntimeHostServiceManagerError,
+  type RuntimeHostManagedServiceConfig,
+  type RuntimeHostServiceBackend,
+  type RuntimeHostServiceBackendStatus,
+  writeRuntimeHostServiceFile,
+} from './runtime-host-service-manager.js';
+
+const SYSTEMD_UNIT_NAME = 'maka-runtime-host.service';
+
+interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export interface SystemdUserServiceOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly homeDir?: string;
+  readonly uid?: number;
+  readonly runSystemctl?: (args: readonly string[]) => Promise<CommandResult>;
+  readonly runLoginctl?: (args: readonly string[]) => Promise<CommandResult>;
+}
+
+export function createSystemdUserRuntimeHostService(
+  options: SystemdUserServiceOptions = {},
+): RuntimeHostServiceBackend {
+  const env = options.env ?? process.env;
+  const homeDir = options.homeDir ?? homedir();
+  const unitPath = resolveSystemdUserRuntimeHostServicePath(env, homeDir);
+  const runSystemctl = options.runSystemctl ?? defaultRunSystemctl;
+  const runLoginctl = options.runLoginctl ?? defaultRunLoginctl;
+  const uid = options.uid ?? process.getuid?.();
+
+  const readStatus = async (): Promise<RuntimeHostServiceBackendStatus> => {
+    const raw = await readSystemdStatus(runSystemctl);
+    return {
+      manager: 'systemd_user',
+      installed: raw.loadState !== 'not-found',
+      enabled: raw.unitFileState === 'enabled' || raw.unitFileState === 'enabled-runtime',
+      active: raw.activeState === 'active',
+      state: systemdServiceState(raw.loadState, raw.activeState),
+      pid: positiveInteger(raw.mainPid),
+      lastExitCode: nonNegativeInteger(raw.execMainStatus),
+    };
+  };
+
+  return {
+    preflightInstall: async () => {
+      await assertUserSystemd(runSystemctl);
+      await assertUserLinger(uid, runLoginctl);
+    },
+    install: async (config) => {
+      await validateLaunchFiles(config);
+      await writeRuntimeHostServiceFile(unitPath, renderSystemdUnit(config), 0o600);
+      await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
+      await requireSystemctl(
+        runSystemctl,
+        ['enable', SYSTEMD_UNIT_NAME],
+        'Enabling the Runtime Host service failed',
+      );
+      await requireSystemctl(
+        runSystemctl,
+        ['restart', SYSTEMD_UNIT_NAME],
+        'Starting the Runtime Host service failed',
+      );
+    },
+    status: readStatus,
+    start: () => runLifecycleAction(runSystemctl, 'start'),
+    stop: () => runLifecycleAction(runSystemctl, 'stop'),
+    restart: () => runLifecycleAction(runSystemctl, 'restart'),
+    uninstall: async () => {
+      const before = await readSystemdStatus(runSystemctl);
+      if (before.loadState !== 'not-found') {
+        await requireSystemctl(
+          runSystemctl,
+          ['stop', SYSTEMD_UNIT_NAME],
+          'Stopping the Runtime Host service failed',
+        );
+      }
+      if (
+        before.loadState !== 'not-found' ||
+        before.unitFileState === 'enabled' ||
+        before.unitFileState === 'enabled-runtime'
+      ) {
+        await requireSystemctl(
+          runSystemctl,
+          ['disable', SYSTEMD_UNIT_NAME],
+          'Disabling the Runtime Host service failed',
+        );
+        await runSystemctl(['reset-failed', SYSTEMD_UNIT_NAME]);
+      }
+      await removeRuntimeHostServiceFile(unitPath, 'systemd unit');
+      await requireSystemctl(runSystemctl, ['daemon-reload'], 'Reloading systemd failed');
+      const after = await readStatus();
+      if (after.installed || after.active || after.enabled) {
+        throw new RuntimeHostServiceManagerError(
+          'uninstall_incomplete',
+          `Runtime Host systemd service still has managed state: ${after.state}`,
+        );
+      }
+    },
+  };
+}
+
+export function resolveSystemdUserRuntimeHostServicePath(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir = homedir(),
+): string {
+  const systemdConfigRoot = env.XDG_CONFIG_HOME ?? join(homeDir, '.config');
+  return join(systemdConfigRoot, 'systemd', 'user', SYSTEMD_UNIT_NAME);
+}
+
+export function renderSystemdUnit(config: RuntimeHostManagedServiceConfig): string {
+  const args = [
+    config.launch.nodePath,
+    config.launch.cliPath,
+    'runtime-host',
+    'serve',
+    '--root',
+    config.rootPath,
+    ...config.projectDirectoryRoots.flatMap(({ label, path }) => [
+      '--project-root',
+      `${label}=${path}`,
+    ]),
+    '--websocket-host',
+    config.websocket.host,
+    '--websocket-port',
+    String(config.websocket.port),
+    '--websocket-path',
+    config.websocket.path,
+    '--json',
+  ];
+  return [
+    '[Unit]',
+    'Description=Maka Runtime Host',
+    'After=network.target',
+    '',
+    '[Service]',
+    'Type=simple',
+    `ExecStart=${args.map(quoteSystemdArgument).join(' ')}`,
+    'Restart=on-failure',
+    'RestartSec=2s',
+    'KillMode=mixed',
+    'TimeoutStopSec=45s',
+    'UMask=0077',
+    '',
+    '[Install]',
+    'WantedBy=default.target',
+    '',
+  ].join('\n');
+}
+
+interface SystemdStatus {
+  readonly loadState: string;
+  readonly activeState: string;
+  readonly unitFileState: string;
+  readonly mainPid?: string;
+  readonly execMainStatus?: string;
+}
+
+async function readSystemdStatus(
+  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+): Promise<SystemdStatus> {
+  const result = await runSystemctl([
+    'show',
+    SYSTEMD_UNIT_NAME,
+    '--property=LoadState,ActiveState,SubState,UnitFileState,MainPID,ExecMainStatus',
+    '--no-pager',
+  ]);
+  const properties = parseProperties(result.stdout);
+  const loadState = properties.get('LoadState') ?? (result.exitCode === 0 ? 'loaded' : 'not-found');
+  if (result.exitCode !== 0 && loadState !== 'not-found') {
+    throw managerError('Reading Runtime Host service status failed', result);
+  }
+  return {
+    loadState,
+    activeState: properties.get('ActiveState') ?? 'inactive',
+    unitFileState: properties.get('UnitFileState') ?? 'disabled',
+    mainPid: properties.get('MainPID'),
+    execMainStatus: properties.get('ExecMainStatus'),
+  };
+}
+
+async function validateLaunchFiles(config: RuntimeHostManagedServiceConfig): Promise<void> {
+  try {
+    const [nodePath, cliPath] = await Promise.all([
+      realpath(config.launch.nodePath),
+      realpath(config.launch.cliPath),
+    ]);
+    const [node, cli] = await Promise.all([stat(nodePath), stat(cliPath)]);
+    if (!node.isFile() || !cli.isFile()) throw new Error('Launch path is not a file');
+    await Promise.all([access(nodePath, constants.X_OK), access(cliPath, constants.R_OK)]);
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'invalid_launch',
+      'The configured Node.js or Maka CLI installation is unavailable',
+      { cause: error },
+    );
+  }
+}
+
+async function assertUserSystemd(
+  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+): Promise<void> {
+  let result: CommandResult;
+  try {
+    result = await runSystemctl(['show-environment']);
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'service_manager_unavailable',
+      'systemd --user is unavailable',
+      { cause: error },
+    );
+  }
+  if (result.exitCode === 0) return;
+  throw new RuntimeHostServiceManagerError(
+    'service_manager_unavailable',
+    `systemd --user is unavailable${result.stderr.trim() ? `: ${result.stderr.trim()}` : ''}`,
+  );
+}
+
+async function assertUserLinger(
+  uid: number | undefined,
+  runLoginctl: (args: readonly string[]) => Promise<CommandResult>,
+): Promise<void> {
+  if (uid === undefined) {
+    throw new RuntimeHostServiceManagerError(
+      'service_manager_unavailable',
+      'The current Linux user identity could not be determined',
+    );
+  }
+  let result: CommandResult;
+  try {
+    result = await runLoginctl(['show-user', String(uid), '--property=Linger', '--value']);
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'service_manager_unavailable',
+      'Unable to verify systemd user lingering',
+      { cause: error },
+    );
+  }
+  if (result.exitCode !== 0) {
+    throw new RuntimeHostServiceManagerError(
+      'service_manager_unavailable',
+      `Unable to verify systemd user lingering${result.stderr.trim() ? `: ${result.stderr.trim()}` : ''}`,
+    );
+  }
+  if (result.stdout.trim() !== 'yes') {
+    throw new RuntimeHostServiceManagerError(
+      'linger_disabled',
+      `Persistent user services are disabled. Enable lingering for user ${uid} and retry`,
+    );
+  }
+}
+
+async function runLifecycleAction(
+  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+  action: 'start' | 'stop' | 'restart',
+): Promise<void> {
+  await requireSystemctl(
+    runSystemctl,
+    [action, SYSTEMD_UNIT_NAME],
+    `${actionPresentParticiple(action)} the Runtime Host service failed`,
+  );
+}
+
+async function requireSystemctl(
+  runSystemctl: (args: readonly string[]) => Promise<CommandResult>,
+  args: readonly string[],
+  message: string,
+): Promise<void> {
+  const result = await runSystemctl(args);
+  if (result.exitCode !== 0) throw managerError(message, result);
+}
+
+function managerError(message: string, result: CommandResult): RuntimeHostServiceManagerError {
+  const detail = result.stderr.trim() || result.stdout.trim();
+  return new RuntimeHostServiceManagerError(
+    'service_manager_operation_failed',
+    detail ? `${message}: ${detail}` : message,
+  );
+}
+
+async function defaultRunSystemctl(args: readonly string[]): Promise<CommandResult> {
+  return runCommand('systemctl', ['--user', ...args]);
+}
+
+async function defaultRunLoginctl(args: readonly string[]): Promise<CommandResult> {
+  return runCommand('loginctl', args);
+}
+
+async function runCommand(command: string, args: readonly string[]): Promise<CommandResult> {
+  return new Promise((resolveResult, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk;
+    });
+    child.once('error', reject);
+    child.once('close', (exitCode) => {
+      resolveResult({ exitCode: exitCode ?? 1, stdout, stderr });
+    });
+  });
+}
+
+function parseProperties(output: string): Map<string, string> {
+  const properties = new Map<string, string>();
+  for (const line of output.split('\n')) {
+    const separator = line.indexOf('=');
+    if (separator > 0) properties.set(line.slice(0, separator), line.slice(separator + 1));
+  }
+  return properties;
+}
+
+function systemdServiceState(loadState: string, activeState: string) {
+  if (loadState === 'not-found') return 'not_installed' as const;
+  if (activeState === 'active') return 'running' as const;
+  if (activeState === 'activating' || activeState === 'reloading') return 'starting' as const;
+  if (activeState === 'failed') return 'failed' as const;
+  return 'stopped' as const;
+}
+
+function positiveInteger(value: string | undefined): number | null {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function nonNegativeInteger(value: string | undefined): number | null {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function quoteSystemdArgument(value: string): string {
+  if (/[\u0000-\u001f\u007f]/u.test(value)) {
+    throw new TypeError('systemd arguments cannot contain control characters');
+  }
+  return `"${value
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"')
+    .replaceAll('%', '%%')
+    .replaceAll('$', '$$$$')}"`;
+}
+
+function actionPresentParticiple(action: 'start' | 'stop' | 'restart'): string {
+  if (action === 'start') return 'Starting';
+  if (action === 'stop') return 'Stopping';
+  return 'Restarting';
+}

--- a/packages/storage/src/__tests__/workspace-root.test.ts
+++ b/packages/storage/src/__tests__/workspace-root.test.ts
@@ -66,6 +66,16 @@ describe('Maka workspace root resolver', () => {
       }),
       '/var/config/ada/Maka Dev',
     );
+    for (const XDG_CONFIG_HOME of ['', 'relative/config']) {
+      assert.equal(
+        resolveMakaClientDataRoot({
+          platform: 'linux',
+          homeDir: '/home/ada',
+          env: { XDG_CONFIG_HOME },
+        }),
+        '/home/ada/.config/Maka',
+      );
+    }
     assert.equal(
       resolveMakaClientDataRoot({
         platform: 'win32',

--- a/packages/storage/src/workspace-root.ts
+++ b/packages/storage/src/workspace-root.ts
@@ -66,7 +66,15 @@ function resolveElectronUserDataRoot(
   if (platform === 'win32') {
     return win32.join(env.APPDATA || win32.join(home, 'AppData', 'Roaming'), profileName);
   }
-  return posix.join(env.XDG_CONFIG_HOME || posix.join(home, '.config'), profileName);
+  return posix.join(resolveXdgConfigHome(env, home), profileName);
+}
+
+export function resolveXdgConfigHome(
+  env: NodeJS.ProcessEnv = process.env,
+  homeDir: string = homedir(),
+): string {
+  const configured = env.XDG_CONFIG_HOME;
+  return configured && posix.isAbsolute(configured) ? configured : posix.join(homeDir, '.config');
 }
 
 function assertMakaProfileName(profileName: string): void {


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Add a managed Runtime Host service lifecycle to the CLI so a Linux Host can remain available after its SSH session ends.

The lifecycle contract, persisted configuration, normalized status, and clean-uninstall behavior are platform-neutral. Linux supplies a systemd user backend; a future macOS LaunchAgent backend can reuse the same CLI and lifecycle semantics. Installation pins the exact Node.js and Maka CLI paths, binds the WebSocket listener to loopback, and preserves the existing port and project roots on reinstall. Uninstall removes the managed unit and configuration while retaining the State Root and user data.

Refs #2522

</details>

<details>
<summary>中文</summary>

为 CLI 增加 managed Runtime Host service lifecycle，使 Linux Host 能在 SSH 会话结束后继续运行。

Lifecycle contract、持久配置、归一化状态和 clean uninstall 均保持平台无关；Linux 仅提供 systemd user backend，未来 macOS LaunchAgent backend 可以复用相同的 CLI 与 lifecycle 语义。安装会固定精确的 Node.js 与 Maka CLI 路径、只监听 loopback，并在重复安装时保留已有端口和 Project roots。卸载会移除托管 unit 与配置，同时保留 State Root 和用户数据。

Refs #2522

</details>

## Verification

<details open>
<summary>English</summary>

- `npm --workspace maka-agent test` — 269 tests passed
- `npm run build` — passed
- `npm run typecheck` — all workspaces passed after a clean dependency install and build
- `npm run lint` and `npm run format:check` — passed
- CLI release pack and offline smoke validation — passed
- Packaged CLI installed, restarted, inspected, and cleanly uninstalled a real systemd user service; the service survived the setup SSH session and uninstall retained the State Root

</details>

<details>
<summary>中文</summary>

- `npm --workspace maka-agent test` — 269 项测试通过
- `npm run build` — 通过
- `npm run typecheck` — 干净安装依赖并构建后，所有 workspace 通过
- `npm run lint` 与 `npm run format:check` — 通过
- CLI release pack 与离线 smoke validation — 通过
- 使用发布形态 CLI 在真实 systemd user 环境完成安装、重启、状态查询和干净卸载；service 不依赖 setup SSH 会话存活，卸载后 State Root 保留

</details>

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex assisted with implementation, tests, documentation, and validation under maintainer direction. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
