### PR TITLE
chore(release): prepare 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,35 @@
 
 ## Unreleased
 
+## 0.1.11 - 2026-08-18
+
+### Highlights
+
+- Expanded Runtime Host from a local execution service into the shared authority for multiple connected Hosts, remote project registration, live run state, and archived session lifecycle (#3097, #3145, #3079, #3074, #3151).
+- Added the installable Maka CLI package and its protected staged npm release pipeline, including cross-platform artifact and Eval validation (#3169, #3173, #3185, #3188, #3192, #3197, #3200, #3201).
+- Added brokered Windows AppContainer sandbox support and tightened local IPC ownership and ACL enforcement (#2961, #3179, #3182).
+- Added Work Board storage foundations, Host-scoped task creation, prompt-history completion, and first-run viewport containment (#3028, #3122, #1874, #3195).
+- Added native Desktop and TUI locale authorities and Qwen3.8 Max Token Plan support (#2686, #2691, #3157).
+
+### Reliability and developer experience
+
+- Preserved live turns across refresh and projected authoritative live execution state through Runtime Host (#3189, #3079).
+- Kept restored tasks safe from concurrent removal, queued busy-raced sends as steering, bounded summarizer inputs, and retired obsolete compact and compatibility paths (#3056, #3032, #3113, #3128, #2742).
+- Hardened MCP rediscovery, provider failure diagnostics, rate-limit handling, session stream completion, and scheduled-task ownership (#2989, #2675, #3115, #2682, #2655).
+- Added fair multi-arm Eval infrastructure and the DeepSeek Harness benchmark arm, while isolating subject metering from framework accounting (#2668, #2971, #3176).
+- Strengthened Windows installer, crash-recovery, remote service restart, and release artifact coverage (#2650, #2562, #3186, #2941).
+
 ### Fixed
 
 - Disabled TUI taskbar-progress keepalives by default on native Windows and
   Windows Terminal sessions, where repeated OSC 9;4 updates can make Explorer's
   taskbar unresponsive. `MAKA_TASKBAR_PROGRESS=1` restores the prior behavior,
   while `MAKA_TASKBAR_PROGRESS=0` disables it explicitly.
+
+### Distribution
+
+- Ships for Apple Silicon macOS as a signed and notarized DMG and ZIP, and for Windows x64 as an unsigned NSIS installer and ZIP, built and verified in the same release run.
+- The bundled Computer Use skill ships with the app, but the Computer Use executor remains excluded from this release.
 
 ## 0.1.10 - 2026-08-10
 

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@maka/desktop",
   "productName": "Maka",
   "description": "A local-first agent workspace built for real work.",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "author": "The Maka Authors",
   "license": "Apache-2.0",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maka",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maka",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -39,7 +39,7 @@
     },
     "apps/desktop": {
       "name": "@maka/desktop",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@astryxdesign/core": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maka",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "license": "Apache-2.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Summary

- bump the root and Desktop release identity from 0.1.10 to 0.1.11
- promote the accumulated unreleased changes into a 0.1.11 changelog using the established Highlights, Reliability and developer experience, Fixed, and Distribution structure
- reserve the exact v0.1.10..release range for final GitHub release notes containing every merged PR and contributor

## Verification

- npm ci
- npm run rebuild
- npm audit --omit=dev --audit-level=moderate: 0 vulnerabilities
- npm run check:release: 28 tests pass; dist and both third-party notice inventories are current
- git diff --check

## Release review

The current pre-release inventory contains 374 merged PRs. The final GitHub release notes will be generated from the exact v0.1.10..release-commit range so they also include this release PR and name every PR author. The Release desktop workflow will create a draft only; the draft assets and notes must be verified before publication.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex prepared the version bump, drafted the curated changelog section, validated the release boundary, and will mechanically generate the complete PR and contributor inventory. The commit carries a Generated-by: Codex trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No