### PR TITLE
fix(cli): explain residency-blocked host conflicts

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-cli-context.test.ts
@@ -15,7 +15,11 @@ import {
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
 } from '@maka/runtime-host/protocol';
-import { connectRuntimeHostCli, RuntimeHostCliConflictError } from '../runtime-host-cli-context.js';
+import {
+  connectRuntimeHostCli,
+  RuntimeHostCliConflictError,
+  shouldRetryRuntimeHostConflict,
+} from '../runtime-host-cli-context.js';
 
 test('CLI Runtime Host bootstrap launches the execution composition', async () => {
   let candidateEntrypoint: string | URL | undefined;
@@ -94,10 +98,63 @@ test('non-interactive CLI reports how to retire an incompatible Runtime Host', a
     (error: unknown) => {
       assert.ok(error instanceof RuntimeHostCliConflictError);
       assert.equal(error.code, 'RUNTIME_HOST_RESTART_REQUIRED');
-      assert.match(error.message, /Stop the previous Maka Desktop or CLI process/);
+      assert.match(
+        error.message,
+        new RegExp(
+          `PID 42; lifecycle ephemeral; compatibility epoch ${RUNTIME_HOST_COMPATIBILITY_EPOCH - 1}`,
+        ),
+      );
+      assert.match(
+        error.message,
+        /ephemeral Host is not currently idle and cannot be replaced by this Client/,
+      );
+      assert.match(error.message, /previous compatible Maka build/);
       return true;
     },
   );
+});
+
+test('CLI explains a service Host without inventing resident work', async () => {
+  await assert.rejects(
+    connectRuntimeHostCli(
+      { rootPath: '/runtime-host-root', surface: 'run' },
+      {
+        connectOrSpawn: async () => ({
+          kind: 'incompatible',
+          registration: hostRegistration({ lifecycleMode: 'service' }),
+          handshake: {
+            kind: 'incompatible',
+            hostEpoch: 'host-old',
+            protocolMin: 0,
+            protocolMax: 0,
+            compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH - 1,
+            compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+            compositionRevision: 'legacy',
+            state: 'ready',
+            replacement: 'blocked_by_residency',
+          },
+        }),
+      },
+    ),
+    (error: unknown) => {
+      assert.ok(error instanceof RuntimeHostCliConflictError);
+      assert.match(error.message, /service Host is managed by its operator/);
+      assert.match(error.message, /service operator to inspect or upgrade/);
+      assert.doesNotMatch(error.message, /not idle/);
+      return true;
+    },
+  );
+});
+
+test('Runtime Host conflict waits only after an explicit wait answer', () => {
+  assert.equal(shouldRetryRuntimeHostConflict('w'), true);
+  assert.equal(shouldRetryRuntimeHostConflict(' wait '), true);
+  assert.equal(shouldRetryRuntimeHostConflict(' W '), true);
+  assert.equal(shouldRetryRuntimeHostConflict('WAIT'), true);
+  assert.equal(shouldRetryRuntimeHostConflict(''), false);
+  assert.equal(shouldRetryRuntimeHostConflict('c'), false);
+  assert.equal(shouldRetryRuntimeHostConflict('cancel'), false);
+  assert.equal(shouldRetryRuntimeHostConflict('unexpected'), false);
 });
 
 test('CLI reports an actionable stored-data startup failure', async () => {
@@ -253,7 +310,12 @@ test('remote CLI profile state and Client identity use the explicit Client Data 
   await context.close();
 });
 
-function hostRegistration(overrides: Partial<{ compatibilityEpoch: number }> = {}) {
+function hostRegistration(
+  overrides: Partial<{
+    compatibilityEpoch: number;
+    lifecycleMode: 'ephemeral' | 'service';
+  }> = {},
+) {
   return {
     kind: 'maka-runtime-host' as const,
     schemaVersion: RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
@@ -265,6 +327,7 @@ function hostRegistration(overrides: Partial<{ compatibilityEpoch: number }> = {
     compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
     compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
     compositionRevision: 'legacy',
+    lifecycleMode: 'ephemeral' as const,
     state: 'ready' as const,
     pid: 42,
     createdAt: '2026-08-10T00:00:00.000Z',

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -21,6 +21,7 @@ import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  type HostRegistration,
   type ClientSurface,
   type HostIncompatible,
 } from '@maka/runtime-host/protocol';
@@ -29,8 +30,11 @@ import { resolveMakaClientDataRoot } from '@maka/storage';
 export class RuntimeHostCliConflictError extends RuntimeHostPermanentReconnectError {
   readonly code = 'RUNTIME_HOST_RESTART_REQUIRED';
 
-  constructor(readonly handshake: HostIncompatible) {
-    super(formatRuntimeHostCliConflict(handshake));
+  constructor(
+    readonly handshake: HostIncompatible,
+    registration: HostRegistration,
+  ) {
+    super(formatRuntimeHostCliConflict(handshake, registration));
     this.name = 'RuntimeHostCliConflictError';
   }
 }
@@ -110,7 +114,7 @@ export async function connectRuntimeHostCli(
       ...(signal ? { signal } : {}),
     });
     if (connected.kind === 'incompatible') {
-      throw new RuntimeHostCliConflictError(connected.handshake);
+      throw new RuntimeHostCliConflictError(connected.handshake, connected.registration);
     }
     if (connected.kind === 'upgrade_required') {
       throw new RuntimeHostPermanentReconnectError(
@@ -155,13 +159,28 @@ async function resolveHostProfile(
   return catalog.resolve(input.profileId);
 }
 
-function formatRuntimeHostCliConflict(handshake: HostIncompatible): string {
+function formatRuntimeHostCliConflict(
+  handshake: HostIncompatible,
+  registration: HostRegistration,
+): string {
   const lines = [
     'RUNTIME_HOST_RESTART_REQUIRED: An older Runtime Host is still running and cannot accept this client.',
+    `Local Runtime Host: PID ${registration.pid}; lifecycle ${registration.lifecycleMode ?? 'unknown'}; compatibility epoch ${registration.compatibilityEpoch}.`,
   ];
+  if (registration.lifecycleMode === 'ephemeral') {
+    lines.push('The ephemeral Host is not currently idle and cannot be replaced by this Client.');
+  } else if (registration.lifecycleMode === 'service') {
+    lines.push(
+      'This service Host is managed by its operator and cannot be replaced by this Client.',
+    );
+  } else {
+    lines.push('This Host cannot be replaced by this Client.');
+  }
   if (handshake.compatibilityEpoch < RUNTIME_HOST_COMPATIBILITY_EPOCH) {
     lines.push(
-      'Stop the previous Maka Desktop or CLI process, or wait for it to exit, then try again.',
+      registration.lifecycleMode === 'service'
+        ? 'Use the service operator to inspect or upgrade the Host.'
+        : 'Use a previous compatible Maka build to inspect the Host and finish or clear any retained work. Stop the Host only after deciding that interruption is safe.',
     );
   } else {
     lines.push(
@@ -169,6 +188,11 @@ function formatRuntimeHostCliConflict(handshake: HostIncompatible): string {
     );
   }
   return lines.join('\n');
+}
+
+export function shouldRetryRuntimeHostConflict(answer: string): boolean {
+  const normalized = answer.trim().toLowerCase();
+  return normalized === 'w' || normalized === 'wait';
 }
 
 export function resolveRuntimeHostCliTarget(

--- a/packages/cli/src/runtime-host-tui-command.ts
+++ b/packages/cli/src/runtime-host-tui-command.ts
@@ -5,7 +5,11 @@ import { SessionActivityRegistry } from '@maka/runtime/goal-turn-lifecycle';
 import { readRuntimeHostConnectionCatalog } from '@maka/runtime-host/client';
 import { createForeignSessionStore } from '@maka/storage';
 import { formatMakaResumeHint } from './cli-invocation.js';
-import { connectRuntimeHostCli, RuntimeHostCliConflictError } from './runtime-host-cli-context.js';
+import {
+  connectRuntimeHostCli,
+  RuntimeHostCliConflictError,
+  shouldRetryRuntimeHostConflict,
+} from './runtime-host-cli-context.js';
 import { createRuntimeHostOnboardingSurface } from './runtime-host-onboarding.js';
 import type { MakaPiTuiTurnActivitySurface } from './pi-tui-contracts.js';
 import { runMakaPiTui } from './pi-tui-runner.js';
@@ -101,24 +105,18 @@ export async function runRuntimeHostTui(input: RunRuntimeHostTuiInput): Promise<
 async function createTuiContextWithHostConflictPrompt(
   input: Parameters<typeof createRuntimeHostTuiContext>[0],
 ): Promise<Awaited<ReturnType<typeof createRuntimeHostTuiContext>> | null> {
-  let waitingForHost = false;
   while (true) {
     try {
       return await createRuntimeHostTuiContext(input);
     } catch (error) {
       if (!(error instanceof RuntimeHostCliConflictError) || !process.stdin.isTTY) throw error;
-      if (waitingForHost) {
-        await waitForHostRetry();
-        continue;
-      }
       process.stderr.write(`${error.message}\n`);
       const readline = createInterface({ input: process.stdin, output: process.stderr });
       try {
-        const answer = (await readline.question('Wait and try again, or cancel? [W/c] '))
-          .trim()
-          .toLowerCase();
-        if (answer === 'c' || answer === 'cancel') return null;
-        waitingForHost = true;
+        const answer = await readline.question(
+          'Wait only if the existing Host is expected to become idle, or cancel? [w/C] ',
+        );
+        if (!shouldRetryRuntimeHostConflict(answer)) return null;
       } finally {
         readline.close();
       }


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Explain local Runtime Host compatibility conflicts when an older ephemeral Host is retained by resident work.

The CLI now projects safe registration facts—PID, lifecycle mode, and compatibility epoch—and explains that retrying cannot itself retire resident work. The TUI still permits an explicit wait when another compatible Client is expected to finish work, but re-prompts after each failed retry instead of entering a silent loop.

This does not alter Goal durability, Host admission, or the one-Host-per-State-Root authority model.

Fixes #3207

</details>

<details>
<summary>中文</summary>

改进本地 Runtime Host 兼容冲突的诊断：展示 PID、lifecycle 和 compatibility epoch，并明确仅重试不会让 resident work 自动结束。

TUI 仍允许用户在预期其他兼容 Client 会完成工作时选择等待，但每次失败后都会重新展示状态与取消选项，不再静默循环。

本修复不改变 Goal durability、Host admission 或一个 State Root 只有一个 Host authority 的约束。

</details>

## Verification

<details open>
<summary>English</summary>

- `node --test --test-name-pattern='non-interactive CLI reports how to retire an incompatible Runtime Host' packages/cli/dist/__tests__/runtime-host-cli-context.test.js`
- `npm --workspace maka-agent run typecheck`
- `npm run lint`
- `npm run format:check`
- Manual TTY regression against a real epoch-23 local Host retained by paused Goals

</details>

<details>
<summary>中文</summary>

- 定向 CLI 测试、typecheck、lint 与 format 检查通过。
- 使用真实 epoch-23、本地 paused Goal 留存的 Host 完成 TTY 回归。

</details>

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex investigated the lifecycle behavior, implemented the CLI/TUI projection, and ran local verification. The commit includes the required `Generated-by: Codex` trailer.

## Visual evidence

The representative TUI conflict state shows the projected Host identity/lifecycle facts and makes the explicit wait (`w`) versus default cancel (`C`) choice visible.

![Runtime Host compatibility conflict with wait or cancel choices](https://raw.githubusercontent.com/me2seeks/maka-agent/00827401079cfa38f2eb91809995e5185b11440a/pr-3208-host-conflict.png)