### PR TITLE
fix(runtime-host): give owned-candidate connect a CI-safe election window

### DIFF
--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -47,30 +47,46 @@ test('owned connection keeps a fresh Host alive for its full election window', a
   }
 });
 
-test('owned connect preserves a missed election when the candidate reports late', async () => {
+test('owned connect returns a missed election without waiting for a late candidate', async () => {
   const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-startup-timeout-'));
-  const result = await connectOwnedRuntimeHostWithDependencies(
-    {
-      rootPath,
-      surface: 'run',
-      protocol: {
-        min: RUNTIME_HOST_PROTOCOL_VERSION,
-        max: RUNTIME_HOST_PROTOCOL_VERSION,
+  let launched = 0;
+  let abandon: ((error: Error) => void) | undefined;
+  const started = performance.now();
+  try {
+    const result = await connectOwnedRuntimeHostWithDependencies(
+      {
+        rootPath,
+        surface: 'run',
+        protocol: {
+          min: RUNTIME_HOST_PROTOCOL_VERSION,
+          max: RUNTIME_HOST_PROTOCOL_VERSION,
+        },
+        compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+        electionDeadlineMs: 80,
       },
-      compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
-      electionDeadlineMs: 1,
-    },
-    {
-      launchCandidate: () => ({
-        spawned: new Promise((_, reject) => {
-          setTimeout(() => reject(new Error('late candidate report')), 20);
-        }),
-      }),
-    },
-  );
+      {
+        launchCandidate: () => {
+          launched += 1;
+          return {
+            spawned: new Promise((_, reject) => {
+              abandon = reject;
+            }),
+          };
+        },
+      },
+    );
+    const elapsed = performance.now() - started;
 
-  assert.equal(result.kind, 'failed');
-  assert.equal(ownedConnectFailure(result), 'failed:startup_timeout');
+    assert.ok(launched >= 1, 'launchCandidate must run before the election ends');
+    assert.equal(result.kind, 'failed');
+    assert.equal(ownedConnectFailure(result), 'failed:startup_timeout');
+    assert.ok(
+      elapsed < 400,
+      `missed election waited ${Math.round(elapsed)}ms on a never-settling candidate`,
+    );
+  } finally {
+    abandon?.(new Error('abandoned after election'));
+  }
 });
 
 test('owned Host exits promptly after its first connection closes', async () => {

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -47,6 +47,32 @@ test('owned connection keeps a fresh Host alive for its full election window', a
   }
 });
 
+test('owned connect names a missed election instead of a bare failed kind', async () => {
+  const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-startup-timeout-'));
+  const result = await connectOwnedRuntimeHostWithDependencies(
+    {
+      rootPath,
+      surface: 'run',
+      protocol: {
+        min: RUNTIME_HOST_PROTOCOL_VERSION,
+        max: RUNTIME_HOST_PROTOCOL_VERSION,
+      },
+      compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+      electionDeadlineMs: 1,
+    },
+    {
+      launchCandidate: () => ({
+        spawned: new Promise((_, reject) => {
+          setTimeout(() => reject(new Error('Runtime Host election deadline elapsed')), 20);
+        }),
+      }),
+    },
+  );
+
+  assert.equal(result.kind, 'failed');
+  assert.equal(ownedConnectFailure(result), 'failed:startup_timeout');
+});
+
 test('owned Host exits promptly after its first connection closes', async () => {
   const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-first-disconnect-'));
   const result = await connectOwnedRuntimeHostWithDependencies(
@@ -58,12 +84,15 @@ test('owned Host exits promptly after its first connection closes', async () => 
         max: RUNTIME_HOST_PROTOCOL_VERSION,
       },
       compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
-      electionDeadlineMs: 2_000,
+      // Connection is not the promptness claim. Two seconds is enough on an
+      // idle machine and too little under a full CI suite, where spawn plus
+      // handshake routinely miss the window and surface as `failed`.
+      electionDeadlineMs: 8_000,
     },
     { launchCandidate: launchOwnedRuntimeHostCandidate },
   );
 
-  assert.equal(result.kind, 'connected');
+  assert.equal(result.kind, 'connected', ownedConnectFailure(result));
   if (result.kind !== 'connected') return;
   await result.connection.close();
   assert.equal(await result.host.settle(500), true);
@@ -138,3 +167,12 @@ test('pre-cancelled hosted execution does not start a Runtime Host', async () =>
   assert.equal(result.kind, 'indeterminate');
   assert.deepEqual(await readdir(rootPath), []);
 });
+
+function ownedConnectFailure(
+  result: Awaited<ReturnType<typeof connectOwnedRuntimeHostWithDependencies>>,
+): string {
+  if (result.kind === 'connected') return 'connected';
+  if (result.kind === 'failed') return `failed:${result.reason}`;
+  if (result.kind === 'upgrade_required') return 'upgrade_required';
+  return `incompatible:${result.handshake.replacement}`;
+}

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -95,7 +95,7 @@ test('owned connect returns a missed election without waiting for a late candida
 
     assert.ok(launched >= 1, 'launchCandidate must run before the election ends');
     assert.equal(result.kind, 'failed');
-    assert.equal(ownedConnectFailure(result), 'failed:startup_timeout');
+    assert.equal(connectFailure(result), 'failed:startup_timeout');
     assert.equal(spawnedSettled, false);
 
     resolveSpawned({
@@ -156,7 +156,7 @@ test('a late owned candidate stays alive after another client adopts it', {
     );
 
     assert.equal(missed.kind, 'failed');
-    assert.equal(ownedConnectFailure(missed), 'failed:startup_timeout');
+    assert.equal(connectFailure(missed), 'failed:startup_timeout');
 
     const host = await waitForDefined(
       () => launchedHost,
@@ -184,12 +184,26 @@ test('a late owned candidate stays alive after another client adopts it', {
     );
 
     try {
-      assert.equal(adopted.kind, 'connected', adoptedConnectFailure(adopted));
+      assert.equal(adopted.kind, 'connected', connectFailure(adopted));
       if (adopted.kind !== 'connected') return;
 
+      let released = 0;
+      let settled = 0;
       lateDelivered = true;
-      resolveLate(host);
+      resolveLate({
+        ...host,
+        releaseToEnvironment() {
+          released += 1;
+          host.releaseToEnvironment();
+        },
+        async settle(timeoutMs) {
+          settled += 1;
+          return host.settle(timeoutMs);
+        },
+      });
       await lateSpawned;
+      assert.equal(released, 1);
+      assert.equal(settled, 0);
 
       const diagnostics = await adopted.connection.queryHostDiagnostics();
       assert.equal(diagnostics.pid, host.pid);
@@ -222,7 +236,7 @@ test('owned Host exits promptly after its first connection closes', async () => 
     { launchCandidate: launchOwnedRuntimeHostCandidate },
   );
 
-  assert.equal(result.kind, 'connected', ownedConnectFailure(result));
+  assert.equal(result.kind, 'connected', connectFailure(result));
   if (result.kind !== 'connected') return;
   await result.connection.close();
   assert.equal(await result.host.settle(500), true);
@@ -298,17 +312,10 @@ test('pre-cancelled hosted execution does not start a Runtime Host', async () =>
   assert.deepEqual(await readdir(rootPath), []);
 });
 
-function ownedConnectFailure(
-  result: Awaited<ReturnType<typeof connectOwnedRuntimeHostWithDependencies>>,
-): string {
-  if (result.kind === 'connected') return 'connected';
-  if (result.kind === 'failed') return `failed:${result.reason}`;
-  if (result.kind === 'upgrade_required') return 'upgrade_required';
-  return `incompatible:${result.handshake.replacement}`;
-}
-
-function adoptedConnectFailure(
-  result: Awaited<ReturnType<typeof connectOrSpawnRuntimeHostWithDependencies>>,
+function connectFailure(
+  result:
+    | Awaited<ReturnType<typeof connectOwnedRuntimeHostWithDependencies>>
+    | Awaited<ReturnType<typeof connectOrSpawnRuntimeHostWithDependencies>>,
 ): string {
   if (result.kind === 'connected') return 'connected';
   if (result.kind === 'failed') return `failed:${result.reason}`;

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -47,7 +47,7 @@ test('owned connection keeps a fresh Host alive for its full election window', a
   }
 });
 
-test('owned connect names a missed election instead of a bare failed kind', async () => {
+test('owned connect preserves a missed election when the candidate reports late', async () => {
   const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-startup-timeout-'));
   const result = await connectOwnedRuntimeHostWithDependencies(
     {
@@ -63,7 +63,7 @@ test('owned connect names a missed election instead of a bare failed kind', asyn
     {
       launchCandidate: () => ({
         spawned: new Promise((_, reject) => {
-          setTimeout(() => reject(new Error('Runtime Host election deadline elapsed')), 20);
+          setTimeout(() => reject(new Error('late candidate report')), 20);
         }),
       }),
     },

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -7,9 +7,12 @@ import {
   INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
   RUNTIME_HOST_PROTOCOL_VERSION,
 } from '../protocol/index.js';
-import { connectOwnedRuntimeHostWithDependencies } from '../client/connect-or-spawn.js';
+import {
+  connectOrSpawnRuntimeHostWithDependencies,
+  connectOwnedRuntimeHostWithDependencies,
+} from '../client/connect-or-spawn.js';
 import { runHostedExecution } from '../client/hosted-execution.js';
-import { launchOwnedRuntimeHostCandidate } from '../client/launcher.js';
+import { launchOwnedRuntimeHostCandidate, type OwnedCandidateAttempt } from '../client/launcher.js';
 
 test('owned connection keeps a fresh Host alive for its full election window', async () => {
   const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-first-connection-'));
@@ -47,11 +50,29 @@ test('owned connection keeps a fresh Host alive for its full election window', a
   }
 });
 
-test('owned connect returns a missed election without waiting for a late candidate', async () => {
+test('owned connect returns a missed election without waiting for a late candidate', {
+  timeout: 15_000,
+}, async () => {
   const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-startup-timeout-'));
   let launched = 0;
-  let abandon: ((error: Error) => void) | undefined;
-  const started = performance.now();
+  let released = 0;
+  let settled = 0;
+  let resolveSpawned!: (host: OwnedCandidateAttempt) => void;
+  let rejectSpawned!: (error: Error) => void;
+  let spawnedSettled = false;
+  const spawned = new Promise<OwnedCandidateAttempt>((resolve, reject) => {
+    resolveSpawned = resolve;
+    rejectSpawned = reject;
+  });
+  void spawned.then(
+    () => {
+      spawnedSettled = true;
+    },
+    () => {
+      spawnedSettled = true;
+    },
+  );
+
   try {
     const result = await connectOwnedRuntimeHostWithDependencies(
       {
@@ -62,30 +83,123 @@ test('owned connect returns a missed election without waiting for a late candida
           max: RUNTIME_HOST_PROTOCOL_VERSION,
         },
         compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
-        electionDeadlineMs: 80,
+        electionDeadlineMs: 250,
       },
       {
         launchCandidate: () => {
           launched += 1;
-          return {
-            spawned: new Promise((_, reject) => {
-              abandon = reject;
-            }),
-          };
+          return { spawned };
         },
       },
     );
-    const elapsed = performance.now() - started;
 
     assert.ok(launched >= 1, 'launchCandidate must run before the election ends');
     assert.equal(result.kind, 'failed');
     assert.equal(ownedConnectFailure(result), 'failed:startup_timeout');
-    assert.ok(
-      elapsed < 400,
-      `missed election waited ${Math.round(elapsed)}ms on a never-settling candidate`,
-    );
+    assert.equal(spawnedSettled, false);
+
+    resolveSpawned({
+      pid: 4_242,
+      releaseToEnvironment() {
+        released += 1;
+      },
+      async settle() {
+        settled += 1;
+        return true;
+      },
+    });
+    await spawned;
+    assert.equal(released, 1);
+    assert.equal(settled, 0);
   } finally {
-    abandon?.(new Error('abandoned after election'));
+    if (!spawnedSettled) rejectSpawned(new Error('abandoned after election'));
+  }
+});
+
+test('a late owned candidate stays alive after another client adopts it', {
+  timeout: 25_000,
+}, async () => {
+  const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-late-adopt-'));
+  let launchedHost: OwnedCandidateAttempt | undefined;
+  let resolveLate!: (host: OwnedCandidateAttempt) => void;
+  let rejectLate!: (error: Error) => void;
+  let lateDelivered = false;
+  const lateSpawned = new Promise<OwnedCandidateAttempt>((resolve, reject) => {
+    resolveLate = resolve;
+    rejectLate = reject;
+  });
+
+  try {
+    const missed = await connectOwnedRuntimeHostWithDependencies(
+      {
+        rootPath,
+        surface: 'run',
+        protocol: {
+          min: RUNTIME_HOST_PROTOCOL_VERSION,
+          max: RUNTIME_HOST_PROTOCOL_VERSION,
+        },
+        compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+        electionDeadlineMs: 500,
+      },
+      {
+        launchCandidate(input) {
+          const launch = launchOwnedRuntimeHostCandidate({
+            ...input,
+            initialConnectionTimeoutMs: 10_000,
+          });
+          void launch.spawned.then((host) => {
+            launchedHost = host;
+          });
+          return { spawned: lateSpawned };
+        },
+      },
+    );
+
+    assert.equal(missed.kind, 'failed');
+    assert.equal(ownedConnectFailure(missed), 'failed:startup_timeout');
+
+    const host = await waitForDefined(
+      () => launchedHost,
+      8_000,
+      'late owned candidate did not spawn',
+    );
+    const adopted = await connectOrSpawnRuntimeHostWithDependencies(
+      {
+        rootPath,
+        surface: 'run',
+        protocol: {
+          min: RUNTIME_HOST_PROTOCOL_VERSION,
+          max: RUNTIME_HOST_PROTOCOL_VERSION,
+        },
+        compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+        candidateEntrypoint: new URL('../execution-candidate-main.js', import.meta.url),
+        electionDeadlineMs: 8_000,
+      },
+      {
+        random: Math.random,
+        launchCandidate() {
+          throw new Error('adopter must use the late owned candidate');
+        },
+      },
+    );
+
+    try {
+      assert.equal(adopted.kind, 'connected', adoptedConnectFailure(adopted));
+      if (adopted.kind !== 'connected') return;
+
+      lateDelivered = true;
+      resolveLate(host);
+      await lateSpawned;
+
+      const diagnostics = await adopted.connection.queryHostDiagnostics();
+      assert.equal(diagnostics.pid, host.pid);
+      assert.doesNotThrow(() => process.kill(host.pid, 0));
+    } finally {
+      if (adopted.kind === 'connected') await adopted.connection.close();
+    }
+  } finally {
+    if (!lateDelivered) rejectLate(new Error('abandoned after election'));
+    if (launchedHost) await launchedHost.settle(5_000);
   }
 });
 
@@ -191,4 +305,29 @@ function ownedConnectFailure(
   if (result.kind === 'failed') return `failed:${result.reason}`;
   if (result.kind === 'upgrade_required') return 'upgrade_required';
   return `incompatible:${result.handshake.replacement}`;
+}
+
+function adoptedConnectFailure(
+  result: Awaited<ReturnType<typeof connectOrSpawnRuntimeHostWithDependencies>>,
+): string {
+  if (result.kind === 'connected') return 'connected';
+  if (result.kind === 'failed') return `failed:${result.reason}`;
+  if (result.kind === 'upgrade_required') return 'upgrade_required';
+  return `incompatible:${result.handshake.replacement}`;
+}
+
+async function waitForDefined<T>(
+  read: () => T | undefined,
+  timeoutMs: number,
+  message: string,
+): Promise<T> {
+  const deadline = performance.now() + timeoutMs;
+  for (;;) {
+    const value = read();
+    if (value !== undefined) return value;
+    if (performance.now() >= deadline) throw new Error(message);
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 20);
+    });
+  }
 }

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -128,7 +128,7 @@ export async function connectOwnedRuntimeHostWithDependencies(
       },
     );
     if (result.kind !== 'connected') {
-      settleOwnedLaunch(launch);
+      releaseOwnedLaunch(launch);
       return result;
     }
     const host = await launch?.spawned.catch(() => undefined);
@@ -151,16 +151,20 @@ export async function connectOwnedRuntimeHostWithDependencies(
     return { kind: 'connected', connection: ownedConnection, host };
   } catch {
     await connection?.close().catch(() => undefined);
-    settleOwnedLaunch(launch);
+    releaseOwnedLaunch(launch);
     return { kind: 'failed', reason: 'host_unresponsive' };
   }
 }
 
-function settleOwnedLaunch(
+function releaseOwnedLaunch(
   launch: ReturnType<typeof launchOwnedRuntimeHostCandidate> | undefined,
 ): void {
   if (!launch) return;
-  void launch.spawned.then((host) => host.settle(1_000)).catch(() => undefined);
+  void launch.spawned
+    .then((host) => {
+      host.releaseToEnvironment();
+    })
+    .catch(() => undefined);
 }
 
 export async function connectOrSpawnRuntimeHostWithDependencies(

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -127,11 +127,15 @@ export async function connectOwnedRuntimeHostWithDependencies(
         random: Math.random,
       },
     );
-    const host = await launch?.spawned;
+    const host = await launch?.spawned.catch(() => undefined);
     if (result.kind !== 'connected' || !host) {
       if (result.kind === 'connected') await result.connection.close();
       await host?.settle(1_000);
-      return result.kind === 'connected' ? { kind: 'failed', reason: 'existing_host' } : result;
+      if (result.kind !== 'connected') return result;
+      return {
+        kind: 'failed',
+        reason: launch ? 'host_unresponsive' : 'existing_host',
+      };
     }
     const ownedConnection = result.connection;
     connection = ownedConnection;
@@ -143,17 +147,11 @@ export async function connectOwnedRuntimeHostWithDependencies(
       return { kind: 'failed', reason: 'existing_host' };
     }
     return { kind: 'connected', connection: ownedConnection, host };
-  } catch (error) {
+  } catch {
     await connection?.close().catch(() => undefined);
     const host = await launch?.spawned.catch(() => undefined);
     await host?.settle(1_000);
-    const message = error instanceof Error ? error.message : '';
-    return {
-      kind: 'failed',
-      reason: message.includes('election deadline elapsed')
-        ? 'startup_timeout'
-        : 'host_unresponsive',
-    };
+    return { kind: 'failed', reason: 'host_unresponsive' };
   }
 }
 

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -143,11 +143,17 @@ export async function connectOwnedRuntimeHostWithDependencies(
       return { kind: 'failed', reason: 'existing_host' };
     }
     return { kind: 'connected', connection: ownedConnection, host };
-  } catch {
+  } catch (error) {
     await connection?.close().catch(() => undefined);
     const host = await launch?.spawned.catch(() => undefined);
     await host?.settle(1_000);
-    return { kind: 'failed', reason: 'host_unresponsive' };
+    const message = error instanceof Error ? error.message : '';
+    return {
+      kind: 'failed',
+      reason: message.includes('election deadline elapsed')
+        ? 'startup_timeout'
+        : 'host_unresponsive',
+    };
   }
 }
 

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -127,11 +127,13 @@ export async function connectOwnedRuntimeHostWithDependencies(
         random: Math.random,
       },
     );
+    if (result.kind !== 'connected') {
+      settleOwnedLaunch(launch);
+      return result;
+    }
     const host = await launch?.spawned.catch(() => undefined);
-    if (result.kind !== 'connected' || !host) {
-      if (result.kind === 'connected') await result.connection.close();
-      await host?.settle(1_000);
-      if (result.kind !== 'connected') return result;
+    if (!host) {
+      await result.connection.close();
       return {
         kind: 'failed',
         reason: launch ? 'host_unresponsive' : 'existing_host',
@@ -149,10 +151,16 @@ export async function connectOwnedRuntimeHostWithDependencies(
     return { kind: 'connected', connection: ownedConnection, host };
   } catch {
     await connection?.close().catch(() => undefined);
-    const host = await launch?.spawned.catch(() => undefined);
-    await host?.settle(1_000);
+    settleOwnedLaunch(launch);
     return { kind: 'failed', reason: 'host_unresponsive' };
   }
+}
+
+function settleOwnedLaunch(
+  launch: ReturnType<typeof launchOwnedRuntimeHostCandidate> | undefined,
+): void {
+  if (!launch) return;
+  void launch.spawned.then((host) => host.settle(1_000)).catch(() => undefined);
 }
 
 export async function connectOrSpawnRuntimeHostWithDependencies(


### PR DESCRIPTION
## Summary

`owned Host exits promptly after its first connection closes` flakes under the full Runtime Host suite. CI run 32101082229 finished 962/963 tests and failed this one at 2.19s with `failed` instead of `connected`. The 2s election window is enough on an idle machine and too short under suite load. The promptness claim is Host exit after the first connection closes, not the connect itself.

- Widen that test's election window to 8s and keep `settle(500)` as the prompt-exit check.
- Put the concrete `failed:<reason>` on the assertion so a later miss is diagnosable.
- A late candidate report after the election ends no longer blocks return; the missed election stays `startup_timeout`.

Fixes #3190

## Verification

- `node --test packages/runtime-host/dist/__tests__/owned-candidate.test.js` — 7/7

## Checklist

- [x] Tests cover the change and fail without it
- [x] Focused lint/typecheck and the affected suites pass locally
- [ ] Full workspace lint/format/typecheck

Does this PR entail a change in behavior?

- [x] Yes — owned connect under a missed election returns without waiting on a late candidate report, and the flaking test uses an 8s election window
