### PR TITLE
fix(eval): close metering admission at child exit

### DIFF
--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -324,11 +324,21 @@ test('a request arriving while the proxy drains is refused, not counted', async 
     `import { readFileSync, writeFileSync } from 'node:fs';
 const [, , baseUrl, outcomePath, childExitedPath] = process.argv;
 const held = fetch(\`\${baseUrl}/responses\`, { method: 'POST', body: '{}' }).catch(() => undefined);
-for (;;) {
+const deadline = Date.now() + 5_000;
+let sawChildExit = false;
+while (Date.now() < deadline) {
   try {
-    if (JSON.parse(readFileSync(childExitedPath, 'utf8')).phase === 'child_exited') break;
+    if (JSON.parse(readFileSync(childExitedPath, 'utf8')).phase === 'child_exited') {
+      sawChildExit = true;
+      break;
+    }
   } catch {}
   await new Promise((resolve) => setTimeout(resolve, 10));
+}
+if (!sawChildExit) {
+  await held;
+  writeFileSync(outcomePath, JSON.stringify({ status: -2 }));
+  process.exit(2);
 }
 let status = 0;
 try {

--- a/packages/eval/src/__tests__/provider-admission-integration.test.ts
+++ b/packages/eval/src/__tests__/provider-admission-integration.test.ts
@@ -314,14 +314,22 @@ test('a request arriving while the proxy drains is refused, not counted', async 
   assert.ok(address && typeof address !== 'string');
   const child = join(root, 'child.mjs');
   const straggler = join(root, 'straggler.mjs');
-  // Outlives its parent, holds one request open across the subject's exit, then
-  // starts another -- the shape of a background service the agent left running.
+  const childExited = join(root, 'logs/agent/opencode.wrapper-state.json');
+  // Outlives its parent and holds the child's stdout pipe open, keeping the
+  // wrapper inside runChild until the exit callback publishes its barrier.
+  // The second request therefore cannot race ahead of that callback, while a
+  // report-time-only admission cut deadlocks instead of satisfying the test.
   await writeFile(
     straggler,
-    `import { writeFileSync } from 'node:fs';
-const [, , baseUrl, outcomePath] = process.argv;
+    `import { readFileSync, writeFileSync } from 'node:fs';
+const [, , baseUrl, outcomePath, childExitedPath] = process.argv;
 const held = fetch(\`\${baseUrl}/responses\`, { method: 'POST', body: '{}' }).catch(() => undefined);
-await new Promise((resolve) => setTimeout(resolve, 300));
+for (;;) {
+  try {
+    if (JSON.parse(readFileSync(childExitedPath, 'utf8')).phase === 'child_exited') break;
+  } catch {}
+  await new Promise((resolve) => setTimeout(resolve, 10));
+}
 let status = 0;
 try {
   status = (await fetch(\`\${baseUrl}/responses\`, { method: 'POST', body: '{}' })).status;
@@ -336,9 +344,9 @@ await held;
     child,
     `import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
-spawn(process.execPath, [${JSON.stringify(straggler)}, process.env.DEEPSEEK_BASE_URL, ${JSON.stringify(outcome)}], {
+spawn(process.execPath, [${JSON.stringify(straggler)}, process.env.DEEPSEEK_BASE_URL, ${JSON.stringify(outcome)}, ${JSON.stringify(childExited)}], {
   detached: true,
-  stdio: 'ignore',
+  stdio: ['ignore', 'inherit', 'ignore'],
 }).unref();
 // Exits only once the proxy has a request to drain, so what follows is the
 // drain window rather than a race against it.

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -365,9 +365,11 @@ try {
     const prepared = await prepareProfile(profile, proxy.baseUrl, systemRoot, args);
     credentialPath = prepared.credentialPath;
     if (profile === 'claude-code') prepareClaudeWorkspace(systemRoot, prepared.home);
-    const result = await runChild(command, args, prepared.env, profile, proxy.stopAccepting);
+    const result = await runChild(command, args, prepared.env, profile, async (exitCode) => {
+      proxy.stopAccepting();
+      if (exitCode !== undefined) await writeState('child_exited', { exitCode });
+    });
     child = undefined;
-    await writeState('child_exited', { exitCode: result.exitCode });
     const metering = await proxy.report();
     const derived = deriveMetering(metering);
     usage = metering.usage;
@@ -459,7 +461,7 @@ async function runChild(
   executableArgs: string[],
   env: NodeJS.ProcessEnv,
   selected: Profile,
-  onExit: () => void,
+  onExit: (exitCode?: number) => Promise<void>,
 ): Promise<{ exitCode: number; stdout: ClassifiedStream; stderr: StreamDiagnostic }> {
   const running = spawn(executable, executableArgs, {
     env,
@@ -469,13 +471,17 @@ async function runChild(
   const stdout = classifyStream(running.stdout, selected);
   const stderr = captureStreamDiagnostic(running.stderr);
   const exitCode = await new Promise<number>((resolveExit, reject) => {
+    let settled = false;
     running.once('error', (error) => {
-      onExit();
-      reject(error);
+      if (settled) return;
+      settled = true;
+      void onExit().then(() => reject(error), reject);
     });
     running.once('exit', (code) => {
-      onExit();
-      resolveExit(code ?? 1);
+      if (settled) return;
+      settled = true;
+      const exitCode = code ?? 1;
+      void onExit(exitCode).then(() => resolveExit(exitCode), reject);
     });
   });
   const [stdoutResult, stderrResult] = await Promise.all([stdout, stderr]);

--- a/packages/eval/src/harbor-external-subject.ts
+++ b/packages/eval/src/harbor-external-subject.ts
@@ -365,7 +365,7 @@ try {
     const prepared = await prepareProfile(profile, proxy.baseUrl, systemRoot, args);
     credentialPath = prepared.credentialPath;
     if (profile === 'claude-code') prepareClaudeWorkspace(systemRoot, prepared.home);
-    const result = await runChild(command, args, prepared.env, profile);
+    const result = await runChild(command, args, prepared.env, profile, proxy.stopAccepting);
     child = undefined;
     await writeState('child_exited', { exitCode: result.exitCode });
     const metering = await proxy.report();
@@ -459,6 +459,7 @@ async function runChild(
   executableArgs: string[],
   env: NodeJS.ProcessEnv,
   selected: Profile,
+  onExit: () => void,
 ): Promise<{ exitCode: number; stdout: ClassifiedStream; stderr: StreamDiagnostic }> {
   const running = spawn(executable, executableArgs, {
     env,
@@ -468,8 +469,14 @@ async function runChild(
   const stdout = classifyStream(running.stdout, selected);
   const stderr = captureStreamDiagnostic(running.stderr);
   const exitCode = await new Promise<number>((resolveExit, reject) => {
-    running.once('error', reject);
-    running.once('exit', (code) => resolveExit(code ?? 1));
+    running.once('error', (error) => {
+      onExit();
+      reject(error);
+    });
+    running.once('exit', (code) => {
+      onExit();
+      resolveExit(code ?? 1);
+    });
   });
   const [stdoutResult, stderrResult] = await Promise.all([stdout, stderr]);
   return { exitCode, stdout: stdoutResult, stderr: stderrResult };
@@ -661,6 +668,7 @@ async function startMeteringProxy(
   // Metering is only readable as one settled snapshot: a request still in
   // flight when the child exits would otherwise be missing from the counts that
   // decide admission, usage, and cost.
+  stopAccepting(): void;
   report(): Promise<ProviderMeteringCounts>;
   close(): Promise<void>;
 }> {
@@ -722,6 +730,9 @@ async function startMeteringProxy(
     : new Agent(timeouts);
   const active = new Set<Promise<void>>();
   let accepting = true;
+  const stopAccepting = () => {
+    accepting = false;
+  };
   const server = createServer((request, response) => {
     // Refused rather than counted: a request the proxy declined was never
     // admitted by the provider and never billed, so it is not part of what
@@ -824,6 +835,7 @@ async function startMeteringProxy(
   if (!address || typeof address === 'string') throw new Error('provider proxy did not bind');
   return {
     baseUrl: `http://127.0.0.1:${address.port}`,
+    stopAccepting,
     report: async () => {
       // Admission closes before anything is drained, so settlement is made
       // true rather than asserted about a moment. The subject's own process has
@@ -833,7 +845,7 @@ async function startMeteringProxy(
       // with work in flight. Closing the socket would not do this: it stops new
       // connections while leaving established ones free to send another
       // request, and it waits on idle keep-alive sockets that may never close.
-      accepting = false;
+      stopAccepting();
       await Promise.allSettled([...active]);
       // Settlement is something this process observes; it is not recoverable
       // from the counts. A checkpoint whose last successful write happened
@@ -844,6 +856,7 @@ async function startMeteringProxy(
       return snapshot();
     },
     close: async () => {
+      stopAccepting();
       await Promise.allSettled([...active]);
       await checkpointWrites;
       await closeServer(server);


### PR DESCRIPTION
## Summary

The external-subject metering proxy stayed open for new admissions after the child process had exited while `runChild()` was still draining stdout and stderr. A leftover descendant or established keep-alive connection could issue another provider request in that window, so the supposedly post-exit request was counted instead of refused.

This closes proxy admission synchronously from the child `exit`/`error` boundary. `report()` and `close()` reuse the same idempotent transition, then drain only requests admitted before that cut.

The failure is reproducible on current `main`; PR #3208's otherwise unrelated workspace lane failed this exact regression with `2 !== 1`.

## Verification

- focused provider-admission regression: 50/50 consecutive passes
- `npm --workspace @maka/eval run build`
- `npm --workspace @maka/eval run test:dist` — 75/75 Node tests; all Python Harbor suites pass (4 environment-dependent cases skipped as expected)
- `npx biome check packages/eval/src/harbor-external-subject.ts`
- `git diff --check`
- `simplify-audit`: no P0-P3 candidates; `accepting` remains the single admission authority

AI disclosure: Codex implemented and verified this change under me2seeks's direction and review.
