### PR TITLE
test(runtime): stabilize proxied body deadline coverage

### DIFF
--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -180,7 +180,9 @@ describe('connection effect network transport', () => {
       const response = await fetchForConnectionEffect(
         undefined,
         `http://127.0.0.1:${port}/models`,
-        { timeoutMs: 50 },
+        // Leave enough time for the production proxy to establish the response;
+        // the assertion is that its deadline remains armed while the body stalls.
+        { timeoutMs: 250 },
       );
       await assert.rejects(
         response.readJson(),

--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -180,8 +180,8 @@ describe('connection effect network transport', () => {
       const response = await fetchForConnectionEffect(
         undefined,
         `http://127.0.0.1:${port}/models`,
-        // Leave enough time for the production proxy to establish the response;
-        // the assertion is that its deadline remains armed while the body stalls.
+        // Leave enough time for the default production proxiedFetch path to
+        // receive the response; its deadline must remain armed while the body stalls.
         { timeoutMs: 250 },
       );
       await assert.rejects(


### PR DESCRIPTION
## Summary

The default production `proxiedFetch` body-deadline test uses one timeout for both response setup and the intentionally stalled body read. At 50 ms, loaded runners can expire before response headers arrive, so the test fails at `fetchForConnectionEffect()` instead of exercising the body-read deadline it is meant to cover.

On current `main`, the unchanged test passed only 13/20 isolated runs; the #2684 worktree passed 16/20, confirming this is a baseline timing flake rather than a shell-selection regression.

This raises only the default production `proxiedFetch` test budget to 250 ms. The explicitly constructed direct-transport body-deadline test remains at 50 ms, preserving its tighter coverage.

The test does not install an active proxy: with the module default of `proxy = null`, this production wrapper reaches the response through direct Undici.

## Verification

- focused default `proxiedFetch` regression: 50/50 consecutive passes
- `npm --workspace @maka/runtime test` — 2877 total / 2871 pass / 0 fail / 6 skip
- `npx biome check packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts`
- `git diff --check`
- `simplify-audit`: no P0-P3 candidates; the two timeout values intentionally cover different setup boundaries

AI disclosure: Codex implemented and verified this test stabilization under me2seeks's direction and review.
