### PR TITLE
fix(storage): retire completed legacy migration metadata

### DIFF
--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -82,6 +82,122 @@ test('atomically reapplies current owner schema without republishing its registr
   }
 });
 
+test('retires completed released migration metadata during schema convergence', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-retirement-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    const metadata = createSqliteSessionMetadataStore(databasePath, {
+      databaseLease: acquireOperationalStateDatabase(root),
+    });
+    await metadata.create(sessionHeader());
+    metadata.close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyCutoverJournal(legacy);
+    createLegacyImportSourceTables(legacy);
+    legacy
+      .prepare(`
+        INSERT INTO cutover_journal(
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at,
+          completed_at,
+          validation_json
+        ) VALUES (?, ?, ?, 'completed', ?, ?, ?)
+      `)
+      .run(
+        'session_metadata',
+        join(root, 'sessions.sqlite'),
+        'sha256:released-source',
+        10,
+        20,
+        JSON.stringify({ session_metadata: 4, session_metadata_labels: 0 }),
+      );
+    legacy
+      .prepare(`
+        INSERT INTO runtime_import_sources(source_path, fingerprint, imported_at)
+        VALUES (?, ?, ?)
+      `)
+      .run(join(root, 'runtime-events.jsonl'), 'sha256:released-events', 20);
+    legacy
+      .prepare(`
+        INSERT INTO session_metadata_import_sources(
+          source_path,
+          fingerprint,
+          session_id,
+          imported_at
+        ) VALUES (?, ?, ?, ?)
+      `)
+      .run(join(root, 'sessions.json'), 'sha256:released-session', 'session-1', 20);
+    legacy.close();
+
+    const migrated = acquireOperationalStateDatabase(root);
+    assert.equal(
+      migrated.database
+        .prepare(`
+          SELECT 1
+          FROM sqlite_schema
+          WHERE type = 'table'
+            AND name IN (
+              'cutover_journal',
+              'runtime_import_sources',
+              'session_metadata_import_sources'
+            )
+          LIMIT 1
+        `)
+        .get(),
+      undefined,
+    );
+    migrated.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves an interrupted released cutover journal and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-interrupted-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyCutoverJournal(legacy);
+    legacy
+      .prepare(`
+        INSERT INTO cutover_journal(
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at
+        ) VALUES (?, ?, ?, 'started', ?)
+      `)
+      .run('session_metadata', join(root, 'sessions.sqlite'), 'sha256:released-source', 10);
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /cutover journal is incomplete or invalid/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.deepEqual(
+      {
+        ...(preserved.prepare('SELECT store_name, state FROM cutover_journal').get() as Record<
+          string,
+          unknown
+        >),
+      },
+      { store_name: 'session_metadata', state: 'started' },
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test('rolls back every scope when migration publication fails', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-operational-rollback-'));
   const databasePath = join(root, 'runtime.sqlite');
@@ -765,6 +881,38 @@ test('rejects an invalid registered schema version before migrating', async () =
 function rewindRuntimeSchema(database: DatabaseSync): void {
   database.exec('DROP TABLE runtime_session_event_ordinals');
   database.exec(`PRAGMA user_version = ${SQLITE_RUNTIME_SCHEMA_VERSION - 1}`);
+}
+
+function createLegacyCutoverJournal(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE cutover_journal (
+      store_name TEXT PRIMARY KEY,
+      source_path TEXT NOT NULL,
+      source_fingerprint TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('started', 'completed')),
+      started_at INTEGER NOT NULL CHECK (started_at >= 0),
+      completed_at INTEGER,
+      validation_json TEXT
+    )
+  `);
+}
+
+function createLegacyImportSourceTables(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE runtime_import_sources (
+      source_path TEXT PRIMARY KEY,
+      fingerprint TEXT NOT NULL,
+      imported_at INTEGER NOT NULL
+    );
+
+    CREATE TABLE session_metadata_import_sources (
+      source_path TEXT PRIMARY KEY,
+      fingerprint TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      imported_at INTEGER NOT NULL,
+      FOREIGN KEY(session_id) REFERENCES session_metadata(session_id) ON DELETE CASCADE
+    )
+  `);
 }
 
 async function copyV016Database(databasePath: string): Promise<void> {

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -112,7 +112,7 @@ test('retires completed released migration metadata during schema convergence', 
         'sha256:released-source',
         10,
         20,
-        JSON.stringify({ session_metadata: 4, session_metadata_labels: 0 }),
+        JSON.stringify(releasedSessionMetadataValidation()),
       );
     legacy
       .prepare(`
@@ -430,6 +430,163 @@ test('preserves a cutover journal naming an unknown store and fails closed', asy
       (preserved.prepare('SELECT store_name FROM cutover_journal').get() as { store_name: string })
         .store_name,
       'future_store',
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a completed row carrying an unfamiliar validation key and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-extra-key-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyCutoverJournal(legacy);
+    // A known store, released shape, well-formed counts — but one key beyond the
+    // set the released writer emitted. No released writer produced this contract,
+    // so the journal must be preserved rather than retired.
+    legacy
+      .prepare(`
+        INSERT INTO cutover_journal(
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at,
+          completed_at,
+          validation_json
+        ) VALUES (?, ?, ?, 'completed', ?, ?, ?)
+      `)
+      .run(
+        'session_metadata',
+        join(root, 'sessions.sqlite'),
+        'sha256:released-source',
+        10,
+        20,
+        JSON.stringify({ ...releasedSessionMetadataValidation(), unexpected_evidence: 0 }),
+      );
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /invalid validation evidence/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.equal(
+      (preserved.prepare('SELECT store_name FROM cutover_journal').get() as { store_name: string })
+        .store_name,
+      'session_metadata',
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a completed row missing a released validation key and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-missing-key-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyCutoverJournal(legacy);
+    const incomplete = releasedSessionMetadataValidation();
+    delete incomplete.sandbox_boundary_log;
+    legacy
+      .prepare(`
+        INSERT INTO cutover_journal(
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at,
+          completed_at,
+          validation_json
+        ) VALUES (?, ?, ?, 'completed', ?, ?, ?)
+      `)
+      .run(
+        'session_metadata',
+        join(root, 'sessions.sqlite'),
+        'sha256:released-source',
+        10,
+        20,
+        JSON.stringify(incomplete),
+      );
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /invalid validation evidence/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.equal(
+      (
+        preserved.prepare('SELECT COUNT(*) AS count FROM cutover_journal').get() as {
+          count: number;
+        }
+      ).count,
+      1,
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a completed row whose completion precedes its start and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-timeorder-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyCutoverJournal(legacy);
+    // Both timestamps are non-negative integers, but completed_at < started_at:
+    // internally inconsistent evidence must fail closed, not be retired.
+    legacy
+      .prepare(`
+        INSERT INTO cutover_journal(
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at,
+          completed_at,
+          validation_json
+        ) VALUES (?, ?, ?, 'completed', ?, ?, ?)
+      `)
+      .run(
+        'session_metadata',
+        join(root, 'sessions.sqlite'),
+        'sha256:released-source',
+        20,
+        10,
+        JSON.stringify(releasedSessionMetadataValidation()),
+      );
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /cutover journal is incomplete or invalid/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.equal(
+      (
+        preserved.prepare('SELECT COUNT(*) AS count FROM cutover_journal').get() as {
+          count: number;
+        }
+      ).count,
+      1,
     );
     preserved.close();
   } finally {
@@ -1215,6 +1372,31 @@ function createLegacyCutoverJournal(database: DatabaseSync): void {
       validation_json TEXT
     )
   `);
+}
+
+// The exact validation-evidence key set the released session_metadata cutover
+// writer emitted (commit 1caea265c^): one row count per copied session-metadata
+// table. Kept as an explicit fixture so a drift from the source contract in
+// operational-state-store.ts turns this suite red rather than silently
+// accepting a narrower shape.
+function releasedSessionMetadataValidation(): Record<string, number> {
+  return {
+    session_metadata: 4,
+    session_metadata_labels: 0,
+    session_metadata_import_sources: 1,
+    session_metadata_tombstones: 0,
+    subagent_spawns: 0,
+    agent_graph_intent_claims: 0,
+    agent_graph_schedule_updates: 0,
+    agent_graph_operator_provisions: 0,
+    agent_graph_client_projections: 0,
+    agent_graph_client_operator_projections: 0,
+    agent_graph_client_terminal_activity: 0,
+    agent_graph_client_applied_records: 0,
+    agent_graph_supervisor_wakes: 0,
+    agent_graph_supervisor_wake_attempts: 0,
+    sandbox_boundary_log: 0,
+  };
 }
 
 function createLegacyImportSourceTables(database: DatabaseSync): void {

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -149,6 +149,33 @@ test('retires completed released migration metadata during schema convergence', 
         .get(),
       undefined,
     );
+    // Retirement must not touch legitimate data or half-apply schema convergence.
+    assert.equal(
+      (
+        migrated.database
+          .prepare("SELECT COUNT(*) AS count FROM session_metadata WHERE session_id = 'session-1'")
+          .get() as { count: number }
+      ).count,
+      1,
+    );
+    assert.equal(
+      (
+        migrated.database
+          .prepare("SELECT version FROM operational_schema_migrations WHERE scope = 'runtime'")
+          .get() as { version?: number } | undefined
+      )?.version,
+      SQLITE_RUNTIME_SCHEMA_VERSION,
+    );
+    assert.equal(
+      (
+        migrated.database
+          .prepare(
+            "SELECT version FROM operational_schema_migrations WHERE scope = 'session_metadata'",
+          )
+          .get() as { version?: number } | undefined
+      )?.version,
+      SQLITE_SESSION_METADATA_SCHEMA_VERSION,
+    );
     migrated.close();
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -191,6 +218,149 @@ test('preserves an interrupted released cutover journal and fails closed', async
         >),
       },
       { store_name: 'session_metadata', state: 'started' },
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a cutover journal with an unfamiliar column shape and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-shape-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    legacy.exec(`
+      CREATE TABLE cutover_journal (
+        store_name TEXT PRIMARY KEY,
+        source_path TEXT NOT NULL,
+        source_fingerprint TEXT NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('started', 'completed')),
+        started_at INTEGER NOT NULL CHECK (started_at >= 0),
+        completed_at INTEGER,
+        validation_json TEXT,
+        unexpected_column TEXT
+      )
+    `);
+    legacy
+      .prepare(`
+        INSERT INTO cutover_journal(
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at,
+          completed_at,
+          validation_json
+        ) VALUES (?, ?, ?, 'completed', ?, ?, ?)
+      `)
+      .run(
+        'session_metadata',
+        join(root, 'sessions.sqlite'),
+        'sha256:released-source',
+        10,
+        20,
+        JSON.stringify({ session_metadata: 4 }),
+      );
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /unfamiliar schema/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.equal(
+      (
+        preserved.prepare('SELECT COUNT(*) AS count FROM cutover_journal').get() as {
+          count: number;
+        }
+      ).count,
+      1,
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a malformed released import source and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-import-malformed-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyImportSourceTables(legacy);
+    legacy
+      .prepare(`
+        INSERT INTO runtime_import_sources(source_path, fingerprint, imported_at)
+        VALUES (?, ?, ?)
+      `)
+      .run(join(root, 'runtime-events.jsonl'), '', 20);
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /import source is incomplete or invalid/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.equal(
+      (
+        preserved.prepare('SELECT COUNT(*) AS count FROM runtime_import_sources').get() as {
+          count: number;
+        }
+      ).count,
+      1,
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a session import source with a missing session and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-import-missing-session-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyImportSourceTables(legacy);
+    // node:sqlite enforces foreign keys by default; disable them only to plant
+    // the orphaned import row this defensive branch must reject.
+    legacy.exec('PRAGMA foreign_keys = OFF');
+    legacy
+      .prepare(`
+        INSERT INTO session_metadata_import_sources(
+          source_path,
+          fingerprint,
+          session_id,
+          imported_at
+        ) VALUES (?, ?, ?, ?)
+      `)
+      .run(join(root, 'sessions.json'), 'sha256:released-session', 'missing-session', 20);
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /session import source is incomplete or invalid/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.equal(
+      (
+        preserved
+          .prepare('SELECT COUNT(*) AS count FROM session_metadata_import_sources')
+          .get() as { count: number }
+      ).count,
+      1,
     );
     preserved.close();
   } finally {

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -270,7 +270,7 @@ test('preserves a cutover journal with an unfamiliar column shape and fails clos
       (error: unknown) =>
         error instanceof Error &&
         (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
-        /unfamiliar schema/u.test(error.message),
+        /unfamiliar released shape/u.test(error.message),
     );
     const preserved = new DatabaseSync(databasePath, { readOnly: true });
     assert.equal(
@@ -280,6 +280,156 @@ test('preserves a cutover journal with an unfamiliar column shape and fails clos
         }
       ).count,
       1,
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a cutover journal with an altered constraint and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-constraint-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    // Released columns/types verbatim, but a loosened CHECK bound. A column-only
+    // gate would accept and DROP this; the full-signature gate must not.
+    legacy.exec(`
+      CREATE TABLE cutover_journal (
+        store_name TEXT PRIMARY KEY,
+        source_path TEXT NOT NULL,
+        source_fingerprint TEXT NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('started', 'completed')),
+        started_at INTEGER NOT NULL CHECK (started_at >= -1),
+        completed_at INTEGER,
+        validation_json TEXT
+      )
+    `);
+    legacy
+      .prepare(`
+        INSERT INTO cutover_journal(
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at,
+          completed_at,
+          validation_json
+        ) VALUES (?, ?, ?, 'completed', ?, ?, ?)
+      `)
+      .run(
+        'session_metadata',
+        join(root, 'sessions.sqlite'),
+        'sha256:released-source',
+        10,
+        20,
+        JSON.stringify({ session_metadata: 4 }),
+      );
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /unfamiliar released shape/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.equal(
+      (
+        preserved.prepare('SELECT COUNT(*) AS count FROM cutover_journal').get() as {
+          count: number;
+        }
+      ).count,
+      1,
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a cutover journal carrying an extra trigger and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-trigger-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyCutoverJournal(legacy);
+    // An extra schema object grafted onto the released table: retirement must
+    // refuse to DROP a table whose full object set it cannot recognize.
+    legacy.exec(`
+      CREATE TRIGGER cutover_journal_guard
+      AFTER INSERT ON cutover_journal
+      BEGIN
+        DELETE FROM cutover_journal WHERE store_name = NEW.store_name;
+      END;
+    `);
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /carries an unexpected object/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.ok(
+      preserved
+        .prepare("SELECT 1 FROM sqlite_schema WHERE type = 'table' AND name = 'cutover_journal'")
+        .get(),
+    );
+    preserved.close();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('preserves a cutover journal naming an unknown store and fails closed', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-unknown-store-'));
+  const databasePath = join(root, 'runtime.sqlite');
+  try {
+    acquireOperationalStateDatabase(root).close();
+    const legacy = new DatabaseSync(databasePath);
+    createLegacyCutoverJournal(legacy);
+    // Released shape and internally well-formed, but names a store no released
+    // writer ever emitted — unrecognized evidence must fail closed, not drop.
+    legacy
+      .prepare(`
+        INSERT INTO cutover_journal(
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at,
+          completed_at,
+          validation_json
+        ) VALUES (?, ?, ?, 'completed', ?, ?, ?)
+      `)
+      .run(
+        'future_store',
+        join(root, 'future.sqlite'),
+        'sha256:released-source',
+        10,
+        20,
+        JSON.stringify({ future_store: 1 }),
+      );
+    legacy.close();
+
+    assert.throws(
+      () => acquireOperationalStateDatabase(root),
+      (error: unknown) =>
+        error instanceof Error &&
+        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
+        /cutover journal is incomplete or invalid/u.test(error.message),
+    );
+    const preserved = new DatabaseSync(databasePath, { readOnly: true });
+    assert.equal(
+      (preserved.prepare('SELECT store_name FROM cutover_journal').get() as { store_name: string })
+        .store_name,
+      'future_store',
     );
     preserved.close();
   } finally {

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -541,59 +541,6 @@ test('preserves a completed row missing a released validation key and fails clos
   }
 });
 
-test('preserves a completed row whose completion precedes its start and fails closed', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'maka-operational-cutover-timeorder-'));
-  const databasePath = join(root, 'runtime.sqlite');
-  try {
-    acquireOperationalStateDatabase(root).close();
-    const legacy = new DatabaseSync(databasePath);
-    createLegacyCutoverJournal(legacy);
-    // Both timestamps are non-negative integers, but completed_at < started_at:
-    // internally inconsistent evidence must fail closed, not be retired.
-    legacy
-      .prepare(`
-        INSERT INTO cutover_journal(
-          store_name,
-          source_path,
-          source_fingerprint,
-          state,
-          started_at,
-          completed_at,
-          validation_json
-        ) VALUES (?, ?, ?, 'completed', ?, ?, ?)
-      `)
-      .run(
-        'session_metadata',
-        join(root, 'sessions.sqlite'),
-        'sha256:released-source',
-        20,
-        10,
-        JSON.stringify(releasedSessionMetadataValidation()),
-      );
-    legacy.close();
-
-    assert.throws(
-      () => acquireOperationalStateDatabase(root),
-      (error: unknown) =>
-        error instanceof Error &&
-        (error as { code?: unknown }).code === 'operational_state_migration_blocked' &&
-        /cutover journal is incomplete or invalid/u.test(error.message),
-    );
-    const preserved = new DatabaseSync(databasePath, { readOnly: true });
-    assert.equal(
-      (
-        preserved.prepare('SELECT COUNT(*) AS count FROM cutover_journal').get() as {
-          count: number;
-        }
-      ).count,
-      1,
-    );
-    preserved.close();
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-});
-
 test('preserves a malformed released import source and fails closed', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-operational-import-malformed-'));
   const databasePath = join(root, 'runtime.sqlite');

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -58,6 +58,26 @@ const OPERATIONAL_SCHEMA_VERSIONS: ReadonlyMap<string, number> = new Map([
 const REMOVED_OPERATIONAL_SCHEMA_VERSIONS: ReadonlyMap<string, number> = new Map([
   ['automation', 2],
 ]);
+const LEGACY_CUTOVER_JOURNAL_COLUMNS = [
+  { name: 'store_name', type: 'TEXT', notNull: 0, primaryKey: 1 },
+  { name: 'source_path', type: 'TEXT', notNull: 1, primaryKey: 0 },
+  { name: 'source_fingerprint', type: 'TEXT', notNull: 1, primaryKey: 0 },
+  { name: 'state', type: 'TEXT', notNull: 1, primaryKey: 0 },
+  { name: 'started_at', type: 'INTEGER', notNull: 1, primaryKey: 0 },
+  { name: 'completed_at', type: 'INTEGER', notNull: 0, primaryKey: 0 },
+  { name: 'validation_json', type: 'TEXT', notNull: 0, primaryKey: 0 },
+] as const;
+const LEGACY_RUNTIME_IMPORT_SOURCE_COLUMNS = [
+  { name: 'source_path', type: 'TEXT', notNull: 0, primaryKey: 1 },
+  { name: 'fingerprint', type: 'TEXT', notNull: 1, primaryKey: 0 },
+  { name: 'imported_at', type: 'INTEGER', notNull: 1, primaryKey: 0 },
+] as const;
+const LEGACY_SESSION_IMPORT_SOURCE_COLUMNS = [
+  { name: 'source_path', type: 'TEXT', notNull: 0, primaryKey: 1 },
+  { name: 'fingerprint', type: 'TEXT', notNull: 1, primaryKey: 0 },
+  { name: 'session_id', type: 'TEXT', notNull: 1, primaryKey: 0 },
+  { name: 'imported_at', type: 'INTEGER', notNull: 1, primaryKey: 0 },
+] as const;
 
 const require = createRequire(import.meta.url);
 const owners = new Map<string, OperationalStateDatabaseOwner>();
@@ -365,6 +385,7 @@ export function migrateOperationalStateDatabaseInternal(db: DatabaseSync, now: (
       DROP TABLE IF EXISTS automation_authority_state;
       DELETE FROM operational_schema_migrations WHERE scope = 'automation';
     `);
+    retireCompletedLegacyMigrationMetadata(db);
     assertCurrentOperationalTargetSchema(db);
     for (const [scope, version] of OPERATIONAL_SCHEMA_VERSIONS) {
       registerSchema(db, scope, version, appliedAt);
@@ -374,6 +395,158 @@ export function migrateOperationalStateDatabaseInternal(db: DatabaseSync, now: (
     rollback(db);
     throw error;
   }
+}
+
+/**
+ * Retire import and cutover evidence written before SQLite became the sole
+ * operational authority. Only exact released tables with internally valid,
+ * completed rows may be removed; interrupted or unfamiliar state stays
+ * fail-closed and the surrounding migration transaction rolls back unchanged.
+ */
+function retireCompletedLegacyMigrationMetadata(db: DatabaseSync): void {
+  if (hasTable(db, 'cutover_journal')) {
+    assertReleasedLegacyTableShape(db, 'cutover_journal', LEGACY_CUTOVER_JOURNAL_COLUMNS);
+    const rows = db
+      .prepare(`
+        SELECT
+          store_name,
+          source_path,
+          source_fingerprint,
+          state,
+          started_at,
+          completed_at,
+          validation_json
+        FROM cutover_journal
+        ORDER BY store_name
+      `)
+      .all() as Array<Record<string, unknown>>;
+    for (const row of rows) assertCompletedLegacyCutoverJournalRow(row);
+  }
+  if (hasTable(db, 'runtime_import_sources')) {
+    assertReleasedLegacyTableShape(
+      db,
+      'runtime_import_sources',
+      LEGACY_RUNTIME_IMPORT_SOURCE_COLUMNS,
+    );
+    const rows = db
+      .prepare(`
+        SELECT source_path, fingerprint, imported_at
+        FROM runtime_import_sources
+        ORDER BY source_path
+      `)
+      .all() as Array<Record<string, unknown>>;
+    for (const row of rows) assertLegacyImportSourceRow(row);
+  }
+  if (hasTable(db, 'session_metadata_import_sources')) {
+    assertReleasedLegacyTableShape(
+      db,
+      'session_metadata_import_sources',
+      LEGACY_SESSION_IMPORT_SOURCE_COLUMNS,
+    );
+    const rows = db
+      .prepare(`
+        SELECT source_path, fingerprint, session_id, imported_at
+        FROM session_metadata_import_sources
+        ORDER BY source_path
+      `)
+      .all() as Array<Record<string, unknown>>;
+    const sessionExists = db.prepare('SELECT 1 FROM session_metadata WHERE session_id = ?');
+    for (const row of rows) {
+      assertLegacyImportSourceRow(row);
+      if (
+        typeof row.session_id !== 'string' ||
+        row.session_id.length === 0 ||
+        !sessionExists.get(row.session_id)
+      ) {
+        throw new Error('Legacy session import source is incomplete or invalid');
+      }
+    }
+  }
+
+  db.exec(`
+    DROP TABLE IF EXISTS session_metadata_import_sources;
+    DROP TABLE IF EXISTS runtime_import_sources;
+    DROP TABLE IF EXISTS cutover_journal;
+  `);
+}
+
+function assertReleasedLegacyTableShape(
+  db: DatabaseSync,
+  table: string,
+  expectedColumns: ReadonlyArray<{
+    readonly name: string;
+    readonly type: string;
+    readonly notNull: number;
+    readonly primaryKey: number;
+  }>,
+): void {
+  const columns = db
+    .prepare(`
+      SELECT name, type, "notnull" AS not_null, pk
+      FROM pragma_table_info(?)
+      ORDER BY cid
+    `)
+    .all(table) as Array<{ name?: unknown; type?: unknown; not_null?: unknown; pk?: unknown }>;
+  const releasedShape = columns.every((column, index) => {
+    const expected = expectedColumns[index];
+    return (
+      expected !== undefined &&
+      column.name === expected.name &&
+      column.type === expected.type &&
+      column.not_null === expected.notNull &&
+      column.pk === expected.primaryKey
+    );
+  });
+  if (columns.length !== expectedColumns.length || !releasedShape) {
+    throw new Error(`Legacy operational metadata table ${table} has an unfamiliar schema`);
+  }
+}
+
+function assertCompletedLegacyCutoverJournalRow(row: Record<string, unknown>): void {
+  if (
+    typeof row.store_name !== 'string' ||
+    row.store_name.length === 0 ||
+    typeof row.source_path !== 'string' ||
+    row.source_path.length === 0 ||
+    typeof row.source_fingerprint !== 'string' ||
+    row.source_fingerprint.length === 0 ||
+    row.state !== 'completed' ||
+    !isNonnegativeInteger(row.started_at) ||
+    !isNonnegativeInteger(row.completed_at) ||
+    typeof row.validation_json !== 'string'
+  ) {
+    throw new Error('Legacy operational cutover journal is incomplete or invalid');
+  }
+  let validation: unknown;
+  try {
+    validation = JSON.parse(row.validation_json);
+  } catch {
+    throw new Error('Legacy operational cutover journal has invalid validation evidence');
+  }
+  if (
+    typeof validation !== 'object' ||
+    validation === null ||
+    Array.isArray(validation) ||
+    !Object.values(validation).every(isNonnegativeInteger)
+  ) {
+    throw new Error('Legacy operational cutover journal has invalid validation evidence');
+  }
+}
+
+function assertLegacyImportSourceRow(row: Record<string, unknown>): void {
+  if (
+    typeof row.source_path !== 'string' ||
+    row.source_path.length === 0 ||
+    typeof row.fingerprint !== 'string' ||
+    row.fingerprint.length === 0 ||
+    !isNonnegativeInteger(row.imported_at)
+  ) {
+    throw new Error('Legacy operational import source is incomplete or invalid');
+  }
+}
+
+function isNonnegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
 }
 
 function registerSchema(db: DatabaseSync, scope: string, version: number, appliedAt: number): void {

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -520,9 +520,6 @@ function assertCompletedLegacyCutoverJournalRow(row: Record<string, unknown>): v
     row.state !== 'completed' ||
     !isNonnegativeInteger(row.started_at) ||
     !isNonnegativeInteger(row.completed_at) ||
-    // A completed row whose finish precedes its start is internally
-    // inconsistent evidence, not a row this build ever wrote.
-    row.completed_at < row.started_at ||
     typeof row.validation_json !== 'string'
   ) {
     throw new Error('Legacy operational cutover journal is incomplete or invalid');

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -34,6 +34,7 @@ import {
 } from './sqlite-legacy-scheduling.js';
 import {
   assertCurrentOperationalTargetSchema,
+  assertReleasedLegacyRetirementShape,
   ensureOperationalSchemaRegistry,
   isCurrentOperationalTargetSchema,
 } from './operational-target-schema.js';
@@ -58,26 +59,27 @@ const OPERATIONAL_SCHEMA_VERSIONS: ReadonlyMap<string, number> = new Map([
 const REMOVED_OPERATIONAL_SCHEMA_VERSIONS: ReadonlyMap<string, number> = new Map([
   ['automation', 2],
 ]);
-const LEGACY_CUTOVER_JOURNAL_COLUMNS = [
-  { name: 'store_name', type: 'TEXT', notNull: 0, primaryKey: 1 },
-  { name: 'source_path', type: 'TEXT', notNull: 1, primaryKey: 0 },
-  { name: 'source_fingerprint', type: 'TEXT', notNull: 1, primaryKey: 0 },
-  { name: 'state', type: 'TEXT', notNull: 1, primaryKey: 0 },
-  { name: 'started_at', type: 'INTEGER', notNull: 1, primaryKey: 0 },
-  { name: 'completed_at', type: 'INTEGER', notNull: 0, primaryKey: 0 },
-  { name: 'validation_json', type: 'TEXT', notNull: 0, primaryKey: 0 },
-] as const;
-const LEGACY_RUNTIME_IMPORT_SOURCE_COLUMNS = [
-  { name: 'source_path', type: 'TEXT', notNull: 0, primaryKey: 1 },
-  { name: 'fingerprint', type: 'TEXT', notNull: 1, primaryKey: 0 },
-  { name: 'imported_at', type: 'INTEGER', notNull: 1, primaryKey: 0 },
-] as const;
-const LEGACY_SESSION_IMPORT_SOURCE_COLUMNS = [
-  { name: 'source_path', type: 'TEXT', notNull: 0, primaryKey: 1 },
-  { name: 'fingerprint', type: 'TEXT', notNull: 1, primaryKey: 0 },
-  { name: 'session_id', type: 'TEXT', notNull: 1, primaryKey: 0 },
-  { name: 'imported_at', type: 'INTEGER', notNull: 1, primaryKey: 0 },
-] as const;
+/**
+ * Store names actually emitted into `cutover_journal` by the released cutover
+ * writers (commit 1caea265c^): `session_metadata` from the dedicated session
+ * cutover plus every `completeOperationalStoreCutover({ storeName })` caller. A
+ * completed row naming anything outside this set is unrecognized evidence, so
+ * retirement fails closed rather than dropping it.
+ */
+const RELEASED_CUTOVER_STORE_NAMES: ReadonlySet<string> = new Set([
+  'agent_runs',
+  'artifact_metadata',
+  'automations',
+  'interactions',
+  'message_receipts',
+  'session_metadata',
+  'shell_runs',
+  'usage_pricing',
+  'workflow_deep_research',
+  'workflow_plan',
+  'workflow_plan_reminders',
+  'workflow_task_ledger',
+]);
 
 const require = createRequire(import.meta.url);
 const owners = new Map<string, OperationalStateDatabaseOwner>();
@@ -399,16 +401,16 @@ export function migrateOperationalStateDatabaseInternal(db: DatabaseSync, now: (
 
 /**
  * Retire import and cutover evidence written before SQLite became the sole
- * operational authority. Only tables whose column shape (name/type/notNull/pk)
- * matches the released layout and whose rows are internally valid and completed
- * may be removed; any interrupted, malformed, or column-shape-mismatched state
- * stays fail-closed and the surrounding migration transaction rolls back
- * unchanged. Column-shape validation does not inspect CHECK/FK constraints or
- * indexes; row-level validation below is the authoritative content gate.
+ * operational authority. A table is only removed when its full released schema
+ * signature is recognized (columns *and* CHECK/FK constraints, with no extra
+ * index/trigger — see {@link assertReleasedLegacyRetirementShape}), it names only
+ * a released store contract, and every row is internally valid and completed. Any
+ * interrupted, malformed, unrecognized-shape, or unknown-store state stays
+ * fail-closed and the surrounding migration transaction rolls back unchanged.
  */
 function retireCompletedLegacyMigrationMetadata(db: DatabaseSync): void {
   if (hasTable(db, 'cutover_journal')) {
-    assertReleasedLegacyTableShape(db, 'cutover_journal', LEGACY_CUTOVER_JOURNAL_COLUMNS);
+    assertReleasedLegacyRetirementShape(db, 'cutover_journal');
     const rows = db
       .prepare(`
         SELECT
@@ -426,11 +428,7 @@ function retireCompletedLegacyMigrationMetadata(db: DatabaseSync): void {
     for (const row of rows) assertCompletedLegacyCutoverJournalRow(row);
   }
   if (hasTable(db, 'runtime_import_sources')) {
-    assertReleasedLegacyTableShape(
-      db,
-      'runtime_import_sources',
-      LEGACY_RUNTIME_IMPORT_SOURCE_COLUMNS,
-    );
+    assertReleasedLegacyRetirementShape(db, 'runtime_import_sources');
     const rows = db
       .prepare(`
         SELECT source_path, fingerprint, imported_at
@@ -441,11 +439,7 @@ function retireCompletedLegacyMigrationMetadata(db: DatabaseSync): void {
     for (const row of rows) assertLegacyImportSourceRow(row);
   }
   if (hasTable(db, 'session_metadata_import_sources')) {
-    assertReleasedLegacyTableShape(
-      db,
-      'session_metadata_import_sources',
-      LEGACY_SESSION_IMPORT_SOURCE_COLUMNS,
-    );
+    assertReleasedLegacyRetirementShape(db, 'session_metadata_import_sources');
     const rows = db
       .prepare(`
         SELECT source_path, fingerprint, session_id, imported_at
@@ -473,42 +467,11 @@ function retireCompletedLegacyMigrationMetadata(db: DatabaseSync): void {
   `);
 }
 
-function assertReleasedLegacyTableShape(
-  db: DatabaseSync,
-  table: string,
-  expectedColumns: ReadonlyArray<{
-    readonly name: string;
-    readonly type: string;
-    readonly notNull: number;
-    readonly primaryKey: number;
-  }>,
-): void {
-  const columns = db
-    .prepare(`
-      SELECT name, type, "notnull" AS not_null, pk
-      FROM pragma_table_info(?)
-      ORDER BY cid
-    `)
-    .all(table) as Array<{ name?: unknown; type?: unknown; not_null?: unknown; pk?: unknown }>;
-  const releasedShape = columns.every((column, index) => {
-    const expected = expectedColumns[index];
-    return (
-      expected !== undefined &&
-      column.name === expected.name &&
-      column.type === expected.type &&
-      column.not_null === expected.notNull &&
-      column.pk === expected.primaryKey
-    );
-  });
-  if (columns.length !== expectedColumns.length || !releasedShape) {
-    throw new Error(`Legacy operational metadata table ${table} has an unfamiliar schema`);
-  }
-}
-
 function assertCompletedLegacyCutoverJournalRow(row: Record<string, unknown>): void {
   if (
     typeof row.store_name !== 'string' ||
     row.store_name.length === 0 ||
+    !RELEASED_CUTOVER_STORE_NAMES.has(row.store_name) ||
     typeof row.source_path !== 'string' ||
     row.source_path.length === 0 ||
     typeof row.source_fingerprint !== 'string' ||

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -60,25 +60,62 @@ const REMOVED_OPERATIONAL_SCHEMA_VERSIONS: ReadonlyMap<string, number> = new Map
   ['automation', 2],
 ]);
 /**
- * Store names actually emitted into `cutover_journal` by the released cutover
- * writers (commit 1caea265c^): `session_metadata` from the dedicated session
- * cutover plus every `completeOperationalStoreCutover({ storeName })` caller. A
- * completed row naming anything outside this set is unrecognized evidence, so
- * retirement fails closed rather than dropping it.
+ * Exact validation-evidence contract emitted into `cutover_journal` by the
+ * released cutover writers (commit 1caea265c^, removed in #1994). Each entry
+ * maps a released `store_name` to the precise key set its `importAndValidate`
+ * returned as `validation_json`: `session_metadata` reports one row count per
+ * copied session-metadata table, and every other store reports its own fixed
+ * evidence keys. A completed row whose store name is absent here, or whose
+ * validation keys are not *exactly* this set, is
+ * evidence this build never wrote — retirement fails closed and preserves it
+ * rather than dropping unrecognized migration state.
+ *
+ * The contract is pinned to the final writer generation (1caea265c^); a
+ * workspace whose cutover ran under an earlier writer whose key set differed
+ * fails closed here (preserved, startup still blocked) — non-regressive versus
+ * today and deliberately safer than dropping evidence we do not recognize.
  */
-const RELEASED_CUTOVER_STORE_NAMES: ReadonlySet<string> = new Set([
-  'agent_runs',
-  'artifact_metadata',
-  'automations',
-  'interactions',
-  'message_receipts',
-  'session_metadata',
-  'shell_runs',
-  'usage_pricing',
-  'workflow_deep_research',
-  'workflow_plan',
-  'workflow_plan_reminders',
-  'workflow_task_ledger',
+const RELEASED_CUTOVER_STORE_VALIDATION_KEYS: ReadonlyMap<string, ReadonlySet<string>> = new Map([
+  [
+    'agent_runs',
+    new Set([
+      'agent_runs',
+      'agent_run_events',
+      'agent_run_projections',
+      'root_turn_admissions',
+      'root_source_message_proofs',
+    ]),
+  ],
+  ['artifact_metadata', new Set(['records'])],
+  ['automations', new Set(['automations'])],
+  ['interactions', new Set(['interaction_requests', 'interaction_outcomes'])],
+  ['message_receipts', new Set(['host_epochs', 'message_receipts'])],
+  [
+    'session_metadata',
+    new Set([
+      'session_metadata',
+      'session_metadata_labels',
+      'session_metadata_import_sources',
+      'session_metadata_tombstones',
+      'subagent_spawns',
+      'agent_graph_intent_claims',
+      'agent_graph_schedule_updates',
+      'agent_graph_operator_provisions',
+      'agent_graph_client_projections',
+      'agent_graph_client_operator_projections',
+      'agent_graph_client_terminal_activity',
+      'agent_graph_client_applied_records',
+      'agent_graph_supervisor_wakes',
+      'agent_graph_supervisor_wake_attempts',
+      'sandbox_boundary_log',
+    ]),
+  ],
+  ['shell_runs', new Set(['shell_runs'])],
+  ['usage_pricing', new Set(['llm', 'tools', 'pricing'])],
+  ['workflow_deep_research', new Set(['sessions', 'events'])],
+  ['workflow_plan', new Set(['sessions', 'events'])],
+  ['workflow_plan_reminders', new Set(['reminders'])],
+  ['workflow_task_ledger', new Set(['sessions', 'events'])],
 ]);
 
 const require = createRequire(import.meta.url);
@@ -468,10 +505,14 @@ function retireCompletedLegacyMigrationMetadata(db: DatabaseSync): void {
 }
 
 function assertCompletedLegacyCutoverJournalRow(row: Record<string, unknown>): void {
+  // A store name absent from the released contract yields `undefined` here,
+  // which fails closed below — an empty or non-string name lands the same way.
+  const expectedValidationKeys =
+    typeof row.store_name === 'string'
+      ? RELEASED_CUTOVER_STORE_VALIDATION_KEYS.get(row.store_name)
+      : undefined;
   if (
-    typeof row.store_name !== 'string' ||
-    row.store_name.length === 0 ||
-    !RELEASED_CUTOVER_STORE_NAMES.has(row.store_name) ||
+    expectedValidationKeys === undefined ||
     typeof row.source_path !== 'string' ||
     row.source_path.length === 0 ||
     typeof row.source_fingerprint !== 'string' ||
@@ -479,6 +520,9 @@ function assertCompletedLegacyCutoverJournalRow(row: Record<string, unknown>): v
     row.state !== 'completed' ||
     !isNonnegativeInteger(row.started_at) ||
     !isNonnegativeInteger(row.completed_at) ||
+    // A completed row whose finish precedes its start is internally
+    // inconsistent evidence, not a row this build ever wrote.
+    row.completed_at < row.started_at ||
     typeof row.validation_json !== 'string'
   ) {
     throw new Error('Legacy operational cutover journal is incomplete or invalid');
@@ -493,11 +537,22 @@ function assertCompletedLegacyCutoverJournalRow(row: Record<string, unknown>): v
     typeof validation !== 'object' ||
     validation === null ||
     Array.isArray(validation) ||
-    Object.keys(validation).length === 0 ||
-    !Object.values(validation).every(isNonnegativeInteger)
+    !Object.values(validation).every(isNonnegativeInteger) ||
+    // The evidence keys must be exactly the set the released writer emitted for
+    // this store: a missing, extra, or renamed key is a contract this build
+    // never produced, so the journal is preserved rather than retired.
+    !hasExactValidationKeys(validation as Record<string, unknown>, expectedValidationKeys)
   ) {
     throw new Error('Legacy operational cutover journal has invalid validation evidence');
   }
+}
+
+function hasExactValidationKeys(
+  validation: Record<string, unknown>,
+  expected: ReadonlySet<string>,
+): boolean {
+  const keys = Object.keys(validation);
+  return keys.length === expected.size && keys.every((key) => expected.has(key));
 }
 
 function assertLegacyImportSourceRow(row: Record<string, unknown>): void {

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -399,9 +399,12 @@ export function migrateOperationalStateDatabaseInternal(db: DatabaseSync, now: (
 
 /**
  * Retire import and cutover evidence written before SQLite became the sole
- * operational authority. Only exact released tables with internally valid,
- * completed rows may be removed; interrupted or unfamiliar state stays
- * fail-closed and the surrounding migration transaction rolls back unchanged.
+ * operational authority. Only tables whose column shape (name/type/notNull/pk)
+ * matches the released layout and whose rows are internally valid and completed
+ * may be removed; any interrupted, malformed, or column-shape-mismatched state
+ * stays fail-closed and the surrounding migration transaction rolls back
+ * unchanged. Column-shape validation does not inspect CHECK/FK constraints or
+ * indexes; row-level validation below is the authoritative content gate.
  */
 function retireCompletedLegacyMigrationMetadata(db: DatabaseSync): void {
   if (hasTable(db, 'cutover_journal')) {
@@ -527,6 +530,7 @@ function assertCompletedLegacyCutoverJournalRow(row: Record<string, unknown>): v
     typeof validation !== 'object' ||
     validation === null ||
     Array.isArray(validation) ||
+    Object.keys(validation).length === 0 ||
     !Object.values(validation).every(isNonnegativeInteger)
   ) {
     throw new Error('Legacy operational cutover journal has invalid validation evidence');

--- a/packages/storage/src/operational-target-schema.ts
+++ b/packages/storage/src/operational-target-schema.ts
@@ -61,6 +61,12 @@ function buildOperationalTargetSchema(): ReadonlyMap<string, string> {
 }
 
 function readSchema(database: DatabaseSync): ReadonlyMap<string, string> {
+  return new Map(readSchemaObjects(database).map((object) => [object.key, object.signature]));
+}
+
+function readSchemaObjects(
+  database: DatabaseSync,
+): Array<{ key: string; tableName: string; signature: string }> {
   const rows = database
     .prepare(`
       SELECT type, name, tbl_name, sql
@@ -69,12 +75,109 @@ function readSchema(database: DatabaseSync): ReadonlyMap<string, string> {
       ORDER BY type, name
     `)
     .all() as Array<{ type: string; name: string; tbl_name: string; sql: string }>;
-  return new Map(
-    rows.map(({ type, name, tbl_name, sql }) => [
-      `${type}:${name}`,
-      normalizeReleasedSchemaException(name, `${type}:${tbl_name}:${normalizeSql(sql)}`),
-    ]),
-  );
+  return rows.map(({ type, name, tbl_name, sql }) => ({
+    key: `${type}:${name}`,
+    tableName: tbl_name,
+    signature: normalizeReleasedSchemaException(name, `${type}:${tbl_name}:${normalizeSql(sql)}`),
+  }));
+}
+
+/**
+ * Released DDL for the pre-authority migration metadata tables, verbatim from
+ * commit 1caea265c^ (before SQLite became the sole operational authority). These
+ * strings are only ever read back through {@link readSchemaObjects} in a throwaway
+ * database, so their exact whitespace/case is irrelevant — the normalized
+ * `type:tbl_name:sql` signature (including CHECK/FK constraints and any attached
+ * index/trigger) is what the retirement gate recognizes.
+ */
+const RELEASED_LEGACY_RETIREMENT_DDL: ReadonlyMap<string, string> = new Map([
+  [
+    'cutover_journal',
+    `CREATE TABLE IF NOT EXISTS cutover_journal (
+      store_name TEXT PRIMARY KEY,
+      source_path TEXT NOT NULL,
+      source_fingerprint TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('started', 'completed')),
+      started_at INTEGER NOT NULL CHECK (started_at >= 0),
+      completed_at INTEGER,
+      validation_json TEXT
+    )`,
+  ],
+  [
+    'runtime_import_sources',
+    `CREATE TABLE runtime_import_sources (
+      source_path TEXT PRIMARY KEY,
+      fingerprint TEXT NOT NULL,
+      imported_at INTEGER NOT NULL
+    )`,
+  ],
+  [
+    'session_metadata_import_sources',
+    `CREATE TABLE session_metadata_import_sources (
+      source_path TEXT PRIMARY KEY,
+      fingerprint TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      imported_at INTEGER NOT NULL,
+      FOREIGN KEY(session_id) REFERENCES session_metadata(session_id) ON DELETE CASCADE
+    )`,
+  ],
+]);
+
+let cachedLegacyRetirementSchema: ReadonlyMap<string, ReadonlyMap<string, string>> | undefined;
+
+function buildLegacyRetirementSchema(): ReadonlyMap<string, ReadonlyMap<string, string>> {
+  const database = new DatabaseSync(':memory:');
+  try {
+    database.exec('PRAGMA foreign_keys = OFF');
+    for (const ddl of RELEASED_LEGACY_RETIREMENT_DDL.values()) database.exec(ddl);
+    const byTable = new Map<string, Map<string, string>>();
+    for (const object of readSchemaObjects(database)) {
+      const bucket = byTable.get(object.tableName) ?? new Map<string, string>();
+      bucket.set(object.key, object.signature);
+      byTable.set(object.tableName, bucket);
+    }
+    return byTable;
+  } finally {
+    database.close();
+  }
+}
+
+/**
+ * Fail closed unless every schema object attached to a legacy metadata table
+ * (`tableName`) matches the released layout down to CHECK/FK constraints and has
+ * no extra index/trigger grafted on. Unlike a column-only comparison this rejects
+ * a table that shares the released column names/types but carries altered
+ * constraints or additional objects — the destructive retirement below must only
+ * DROP shapes it can positively recognize.
+ */
+export function assertReleasedLegacyRetirementShape(
+  database: DatabaseSync,
+  tableName: string,
+): void {
+  const canonical = (cachedLegacyRetirementSchema ??= buildLegacyRetirementSchema()).get(tableName);
+  if (canonical === undefined) {
+    throw new Error(`No released legacy retirement signature is registered for ${tableName}`);
+  }
+  const observed = new Map<string, string>();
+  for (const object of readSchemaObjects(database)) {
+    if (object.tableName === tableName) observed.set(object.key, object.signature);
+  }
+  for (const [key, signature] of canonical) {
+    const actual = observed.get(key);
+    if (actual === undefined) {
+      throw new Error(`Legacy operational metadata object ${key} is missing its released shape`);
+    }
+    if (actual !== signature) {
+      throw new Error(`Legacy operational metadata object ${key} has an unfamiliar released shape`);
+    }
+  }
+  for (const key of observed.keys()) {
+    if (!canonical.has(key)) {
+      throw new Error(
+        `Legacy operational metadata table ${tableName} carries an unexpected object ${key}`,
+      );
+    }
+  }
 }
 
 function normalizeReleasedSchemaException(name: string, signature: string): string {


### PR DESCRIPTION
## Summary

- retire the released `cutover_journal`, `runtime_import_sources`, and `session_metadata_import_sources` tables during the existing atomic operational-state migration
- validate the released column shapes (name/type/notNull/pk) and row-level migration evidence before removing obsolete metadata; column-shape validation does not inspect CHECK/FK constraints, and row validation is the authoritative content gate
- require every cutover row to be completed and internally valid
- preserve interrupted, malformed, or unfamiliar migration state unchanged and fail closed

## Root cause

Released workspaces can still contain migration bookkeeping created before SQLite became the sole operational authority. The old readers and writers were removed, but their tables were not retired. Current schema convergence therefore upgrades the real application tables, then rejects the otherwise valid database because strict target-schema validation sees `cutover_journal` (followed by the two import-source tables) as unexpected objects.

This presents as `OPERATIONAL_STATE_MIGRATION_BLOCKED` on startup even though SQLite integrity is healthy.

## Verification

- `npm run clean --workspace @maka/storage`
- `npm run build --workspace @maka/storage`
- operational-state suite under the packaged Electron Node 24 runtime: **29 pass / 0 fail**
- Biome 2.5.6 check for both changed source files
- `git diff --check`
- replayed the migration against a copy of the affected released workspace database:
  - migration completed
  - `PRAGMA quick_check` returned `ok`
  - schema versions converged to runtime 12, session metadata 27, workflow 9, operational 2
  - all three retired metadata tables were absent afterward

The full storage suite was also attempted locally, but unrelated tests that load `fs-native-extensions` cannot start because this checkout lacks its Darwin prebuilt addon. The focused suite and real-database-copy replay do not load that optional native path; CI remains authoritative for the complete package suite.

The real workspace database was never modified; all migration replay used temporary copies.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex and Claude Code contributed to the implementation, regression tests, historical writer-contract analysis, and review-response changes. The human contributor reviewed the final diff, owns the submission, and owns the merge decision.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Affected package build, formatting, and focused tests pass
- [x] `git diff --check` passes

Generated-by: Codex



