### PR TITLE
fix(runtime-host): preserve Windows startup diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "release:cli:eval": "node scripts/release-cli-eval-package.mjs",
     "generate:windows-cargo-notices": "node scripts/generate-windows-cargo-notices.mjs",
     "check:windows-cargo-notices": "node scripts/generate-windows-cargo-notices.mjs --check",
-    "check:release": "npm run check:stale && npm run check:third-party-notices && npm run check:cli-third-party-notices && node --test scripts/release-cli-file-policy.test.mjs scripts/release-cli-artifact-policy.test.mjs scripts/release-cli-eval-support.test.mjs scripts/release-cli-publication.test.mjs scripts/release-cli-workflow-policy.test.mjs",
+    "check:release": "npm run check:stale && npm run check:third-party-notices && npm run check:cli-third-party-notices && node --test scripts/release-cli-file-policy.test.mjs scripts/release-cli-artifact-policy.test.mjs scripts/release-cli-eval-support.test.mjs scripts/release-cli-publication.test.mjs scripts/release-cli-runtime-host-diagnostics.test.mjs scripts/release-cli-workflow-policy.test.mjs",
     "package:macos-arm64": "node scripts/package-macos-arm64.mjs",
     "verify:macos-arm64": "node scripts/verify-macos-arm64-dmg.mjs",
     "package:windows-x64": "node scripts/package-windows-x64.mjs",

--- a/packages/runtime-host/src/__tests__/candidate-cli.test.ts
+++ b/packages/runtime-host/src/__tests__/candidate-cli.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import { parseInteractiveRuntimeHostCandidateArguments } from '../candidate-cli.js';
 
 const ROOT_ID = 'a'.repeat(64);
+const STARTUP_ATTEMPT_ID = '00000000-0000-4000-8000-000000000001';
 
 test('parses the production candidate flags without a desktop E2E override', () => {
   const parsed = parseInteractiveRuntimeHostCandidateArguments([
@@ -10,11 +11,14 @@ test('parses the production candidate flags without a desktop E2E override', () 
     '/tmp/workspace',
     '--expected-root-id',
     ROOT_ID,
+    '--startup-attempt-id',
+    STARTUP_ATTEMPT_ID,
     '--idle-grace-ms',
     '10000',
   ]);
   assert.equal(parsed.rootPath, '/tmp/workspace');
   assert.equal(parsed.expectedRootId, ROOT_ID);
+  assert.equal(parsed.startupAttemptId, STARTUP_ATTEMPT_ID);
   assert.equal(parsed.idleGraceMs, 10_000);
   assert.equal(parsed.desktopE2e, undefined);
 });
@@ -25,6 +29,8 @@ test('parses the desktop E2E composition flag', () => {
     '/tmp/workspace',
     '--expected-root-id',
     ROOT_ID,
+    '--startup-attempt-id',
+    STARTUP_ATTEMPT_ID,
     '--desktop-e2e',
     '1',
   ]);
@@ -39,6 +45,8 @@ test('rejects an unknown desktop E2E flag value', () => {
         '/tmp/workspace',
         '--expected-root-id',
         ROOT_ID,
+        '--startup-attempt-id',
+        STARTUP_ATTEMPT_ID,
         '--desktop-e2e',
         'true',
       ]),

--- a/packages/runtime-host/src/__tests__/candidate-startup-failure.test.ts
+++ b/packages/runtime-host/src/__tests__/candidate-startup-failure.test.ts
@@ -4,6 +4,7 @@ import {
   candidateStartupFailureExitCode,
   candidateStartupFailureForExitCode,
   classifyCandidateStartupFailure,
+  isPermanentCandidateStartupFailure,
 } from '../candidate-startup-failure.js';
 
 test('preserves the primary startup classification through cleanup aggregation', () => {
@@ -61,6 +62,25 @@ test('does not infer workspace ownership from a generic filesystem error', () =>
   assert.deepEqual(classifyCandidateStartupFailure(resourceError), {
     reason: 'internal_startup_failure',
   });
+});
+
+test('preserves a retryable Local IPC security failure across the Candidate boundary', () => {
+  const endpointError = Object.assign(new Error('private Windows ACL detail'), {
+    code: 'insecure_endpoint_directory',
+  });
+  const failure = classifyCandidateStartupFailure(
+    new AggregateError([endpointError, new Error('cleanup failed')], 'startup failed', {
+      cause: endpointError,
+    }),
+  );
+
+  assert.deepEqual(failure, { reason: 'local_ipc_security_failed' });
+  assert.deepEqual(
+    candidateStartupFailureForExitCode(candidateStartupFailureExitCode(failure)),
+    failure,
+  );
+  assert.equal(isPermanentCandidateStartupFailure(failure), false);
+  assert.equal(JSON.stringify(failure).includes('private'), false);
 });
 
 test('classifies unknown startup failures without serializing their message', () => {

--- a/packages/runtime-host/src/__tests__/control-endpoint.test.ts
+++ b/packages/runtime-host/src/__tests__/control-endpoint.test.ts
@@ -7,6 +7,7 @@ import {
   prepareRuntimeHostEndpoint,
   RuntimeHostEndpointError,
   windowsPipeAclFailure,
+  windowsPipeAclFailureDiagnostic,
 } from '../control/endpoint.js';
 import { removePosixEndpointDirectories } from './fixtures/endpoint-hygiene.js';
 
@@ -20,6 +21,37 @@ function execFileException(overrides: Partial<ExecFileException>): ExecFileExcep
     ...overrides,
   });
 }
+
+test('bounds Windows pipe ACL helper diagnostics without serializing the command', () => {
+  const error = Object.assign(new Error('helper failed'), {
+    code: 1,
+    signal: 'SIGTERM',
+    killed: true,
+    cmd: 'private PowerShell command',
+  });
+  const diagnostic = windowsPipeAclFailureDiagnostic(error, `ACL failure ${'x'.repeat(8_192)}`);
+  const parsed = JSON.parse(diagnostic);
+
+  assert.deepEqual(
+    {
+      schemaVersion: parsed.schemaVersion,
+      helper: parsed.helper,
+      exitCode: parsed.exitCode,
+      signal: parsed.signal,
+      killed: parsed.killed,
+    },
+    {
+      schemaVersion: 1,
+      helper: 'windows_pipe_acl',
+      exitCode: 1,
+      signal: 'SIGTERM',
+      killed: true,
+    },
+  );
+  assert.equal(typeof parsed.stderr, 'string');
+  assert.ok(Buffer.byteLength(parsed.stderr, 'utf8') <= 4 * 1024);
+  assert.equal(diagnostic.includes('private PowerShell command'), false);
+});
 
 function rootTag(): string {
   return Buffer.from(ROOT_ID, 'hex').toString('base64url');

--- a/packages/runtime-host/src/__tests__/execution-candidate-main.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-candidate-main.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -15,6 +16,7 @@ const CANDIDATE_ENTRYPOINT = fileURLToPath(
   new URL('../execution-candidate-main.js', import.meta.url),
 );
 const ROOT_ID = 'a'.repeat(64);
+const STARTUP_ATTEMPT_ID = '00000000-0000-4000-8000-000000000001';
 
 test('classifies invalid candidate arguments as an internal startup failure', () => {
   const result = spawnSync(
@@ -25,6 +27,8 @@ test('classifies invalid candidate arguments as an internal startup failure', ()
       '/tmp/workspace',
       '--expected-root-id',
       ROOT_ID,
+      '--startup-attempt-id',
+      STARTUP_ATTEMPT_ID,
       '--desktop-e2e',
       'true',
     ],
@@ -38,23 +42,33 @@ test('classifies invalid candidate arguments as an internal startup failure', ()
 
 test('preserves a valid Candidate invocation failure across the detached stderr boundary', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-candidate-diagnostic-'));
-  const mismatchedRootId = 'b'.repeat(64);
-  const diagnosticPath = resolveCandidateStartupDiagnosticPath(mismatchedRootId);
+  const mismatchedRootId = createHash('sha256').update(randomUUID()).digest('hex');
+  const startupAttemptId = randomUUID();
+  const diagnosticPath = resolveCandidateStartupDiagnosticPath(mismatchedRootId, startupAttemptId);
   const controlDirectory = dirname(diagnosticPath);
   try {
     await resolveStorageRoot({ path: root, kind: 'interactive' });
     await mkdir(controlDirectory, { recursive: true, mode: 0o700 });
     const result = spawnSync(
       process.execPath,
-      [CANDIDATE_ENTRYPOINT, '--root', root, '--expected-root-id', mismatchedRootId],
+      [
+        CANDIDATE_ENTRYPOINT,
+        '--root',
+        root,
+        '--expected-root-id',
+        mismatchedRootId,
+        '--startup-attempt-id',
+        startupAttemptId,
+      ],
       { encoding: 'utf8', timeout: 10_000 },
     );
 
     assert.equal(result.status, 70, result.stderr);
-    const diagnostic = await readCandidateStartupDiagnostic(mismatchedRootId);
+    const diagnostic = await readCandidateStartupDiagnostic(mismatchedRootId, startupAttemptId);
     assert.ok(diagnostic);
     assert.equal(diagnostic.reason, 'internal_startup_failure');
-    assert.ok(diagnostic.logs.some((entry) => entry.includes('startup failed')));
+    assert.equal(diagnostic.startupAttemptId, startupAttemptId);
+    assert.ok(diagnostic.logs.every((entry) => !entry.includes('startup failed')));
     assert.ok(diagnostic.errorChain.some((entry) => entry.code === 'root_identity_changed'));
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/runtime-host/src/__tests__/execution-candidate-main.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-candidate-main.test.ts
@@ -1,7 +1,15 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
+import { resolveStorageRoot } from '@maka/storage/root-authority';
+import {
+  readCandidateStartupDiagnostic,
+  resolveCandidateStartupDiagnosticPath,
+} from '../control/startup-diagnostic.js';
 
 const CANDIDATE_ENTRYPOINT = fileURLToPath(
   new URL('../execution-candidate-main.js', import.meta.url),
@@ -26,4 +34,30 @@ test('classifies invalid candidate arguments as an internal startup failure', ()
   assert.equal(result.status, 70, result.stderr);
   assert.match(result.stderr, /\[runtime-host\] startup failed:/);
   assert.match(result.stderr, /Invalid --desktop-e2e/);
+});
+
+test('preserves a valid Candidate invocation failure across the detached stderr boundary', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-candidate-diagnostic-'));
+  const mismatchedRootId = 'b'.repeat(64);
+  const diagnosticPath = resolveCandidateStartupDiagnosticPath(mismatchedRootId);
+  const controlDirectory = dirname(diagnosticPath);
+  try {
+    await resolveStorageRoot({ path: root, kind: 'interactive' });
+    await mkdir(controlDirectory, { recursive: true, mode: 0o700 });
+    const result = spawnSync(
+      process.execPath,
+      [CANDIDATE_ENTRYPOINT, '--root', root, '--expected-root-id', mismatchedRootId],
+      { encoding: 'utf8', timeout: 10_000 },
+    );
+
+    assert.equal(result.status, 70, result.stderr);
+    const diagnostic = await readCandidateStartupDiagnostic(mismatchedRootId);
+    assert.ok(diagnostic);
+    assert.equal(diagnostic.reason, 'internal_startup_failure');
+    assert.ok(diagnostic.logs.some((entry) => entry.includes('startup failed')));
+    assert.ok(diagnostic.errorChain.some((entry) => entry.code === 'root_identity_changed'));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(controlDirectory, { recursive: true, force: true });
+  }
 });

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -36,6 +36,10 @@ import {
   type DetachedCandidateInput,
 } from '../client/launcher.js';
 import { readHostRegistration } from '../control/registration.js';
+import {
+  readCandidateStartupDiagnostic,
+  writeCandidateStartupDiagnostic,
+} from '../control/startup-diagnostic.js';
 import { removePosixEndpointDirectories } from './fixtures/endpoint-hygiene.js';
 import {
   decodeHostFrame,
@@ -81,6 +85,8 @@ const CURRENT_PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 const LEGACY_PROTOCOL = { min: 1, max: 1 } as const;
+const STARTUP_ATTEMPT_A = '00000000-0000-4000-8000-000000000001';
+const STARTUP_ATTEMPT_B = '00000000-0000-4000-8000-000000000002';
 const KERNEL_CANDIDATE_ENTRYPOINT = new URL('./fixtures/kernel-candidate.js', import.meta.url);
 const KERNEL_COMPOSITION = defineInteractiveRuntimeHostComposition(async () => ({
   handlers: createUnavailableDomainOperationHandlers(),
@@ -162,6 +168,7 @@ describe('non-serving Runtime Host kernel', () => {
                 pid: process.pid,
                 startupFailure: Promise.resolve({
                   reason: 'operational_state_migration_blocked' as const,
+                  startupAttemptId: STARTUP_ATTEMPT_A,
                 }),
               }),
             };
@@ -200,11 +207,64 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
+  test('publishes the diagnostic from the Candidate failure selected by the election', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      let launches = 0;
+      const result = await connectOrSpawnRuntimeHostWithDependencies(
+        {
+          rootPath: paths.root,
+          surface: 'desktop',
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          electionDeadlineMs: 800,
+        },
+        {
+          random: () => 0.5,
+          launchCandidate: () => {
+            launches += 1;
+            if (launches > 2) return { spawned: new Promise(() => undefined) };
+            const startupAttemptId = launches === 1 ? STARTUP_ATTEMPT_A : STARTUP_ATTEMPT_B;
+            const reason =
+              launches === 1
+                ? ('local_ipc_security_failed' as const)
+                : ('internal_startup_failure' as const);
+            return {
+              spawned: writeCandidateStartupDiagnostic({
+                rootId: capability.rootId,
+                startupAttemptId,
+                failure: { reason },
+                error: new Error(`Candidate ${launches} failed`),
+              }).then(() => ({
+                pid: process.pid,
+                startupFailure: Promise.resolve({ reason, startupAttemptId }),
+              })),
+            };
+          },
+        },
+      );
+
+      assert.deepEqual(result, { kind: 'failed', reason: 'local_ipc_security_failed' });
+      assert.equal(
+        (await readCandidateStartupDiagnostic(capability.rootId))?.startupAttemptId,
+        STARTUP_ATTEMPT_A,
+      );
+      assert.equal(
+        await readCandidateStartupDiagnostic(capability.rootId, STARTUP_ATTEMPT_B),
+        undefined,
+      );
+    });
+  });
+
   test('accepts a ready successor launched before a migration blocker is observed', async () => {
     await withHostPaths(async (paths) => {
       let launches = 0;
       let reportBlocker:
-        | ((failure: { reason: 'operational_state_migration_blocked' }) => void)
+        | ((failure: {
+            reason: 'operational_state_migration_blocked';
+            startupAttemptId: string;
+          }) => void)
         | undefined;
       const result = await connectOrSpawnRuntimeHostWithDependencies(
         {
@@ -229,7 +289,10 @@ describe('non-serving Runtime Host kernel', () => {
                 }),
               };
             }
-            reportBlocker?.({ reason: 'operational_state_migration_blocked' });
+            reportBlocker?.({
+              reason: 'operational_state_migration_blocked',
+              startupAttemptId: STARTUP_ATTEMPT_A,
+            });
             return launchTestRuntimeHostCandidate(paths, {
               ...input,
             });

--- a/packages/runtime-host/src/__tests__/startup-diagnostic.test.ts
+++ b/packages/runtime-host/src/__tests__/startup-diagnostic.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, rm, stat } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import test from 'node:test';
+import {
+  clearCandidateStartupDiagnostic,
+  readCandidateStartupDiagnostic,
+  resolveCandidateStartupDiagnosticPath,
+  writeCandidateStartupDiagnostic,
+} from '../control/startup-diagnostic.js';
+
+test('preserves a bounded redacted Candidate startup diagnostic in the private control root', async () => {
+  const rootId = createHash('sha256').update(randomUUID()).digest('hex');
+  const path = resolveCandidateStartupDiagnosticPath(rootId);
+  const controlDirectory = dirname(path);
+  await mkdir(controlDirectory, { recursive: true, mode: 0o700 });
+  try {
+    const helperDiagnostic = JSON.stringify({
+      schemaVersion: 1,
+      helper: 'windows_pipe_acl',
+      stderr: JSON.stringify({ stage: 'acl_apply', hresult: -2_147_024_891 }),
+    });
+    await writeCandidateStartupDiagnostic({
+      rootId,
+      failure: { reason: 'local_ipc_security_failed' },
+      error: new Error('Unable to secure endpoint', { cause: new Error(helperDiagnostic) }),
+      logs: [`startup token=sk-${'a'.repeat(24)}`, 'endpoint setup failed'],
+    });
+
+    const diagnostic = await readCandidateStartupDiagnostic(rootId);
+    assert.ok(diagnostic);
+    assert.equal(diagnostic.rootId, rootId);
+    assert.equal(diagnostic.reason, 'local_ipc_security_failed');
+    assert.match(diagnostic.errorChain[1]?.message ?? '', /windows_pipe_acl/u);
+    assert.match(diagnostic.errorChain[1]?.message ?? '', /acl_apply/u);
+    assert.deepEqual(diagnostic.logs, ['startup token=[redacted]', 'endpoint setup failed']);
+    assert.equal((await stat(path)).mode & 0o077, 0);
+
+    await clearCandidateStartupDiagnostic(rootId);
+    assert.equal(await readCandidateStartupDiagnostic(rootId), undefined);
+  } finally {
+    await rm(controlDirectory, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime-host/src/__tests__/startup-diagnostic.test.ts
+++ b/packages/runtime-host/src/__tests__/startup-diagnostic.test.ts
@@ -1,19 +1,24 @@
 import assert from 'node:assert/strict';
 import { createHash, randomUUID } from 'node:crypto';
-import { mkdir, rm, stat } from 'node:fs/promises';
+import { mkdir, rm, stat, utimes } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import test from 'node:test';
 import {
   clearCandidateStartupDiagnostic,
+  clearSelectedCandidateStartupDiagnostic,
   readCandidateStartupDiagnostic,
   resolveCandidateStartupDiagnosticPath,
+  selectCandidateStartupDiagnostic,
   writeCandidateStartupDiagnostic,
 } from '../control/startup-diagnostic.js';
 
 test('preserves a bounded redacted Candidate startup diagnostic in the private control root', async () => {
   const rootId = createHash('sha256').update(randomUUID()).digest('hex');
-  const path = resolveCandidateStartupDiagnosticPath(rootId);
-  const controlDirectory = dirname(path);
+  const selectedAttemptId = randomUUID();
+  const otherAttemptId = randomUUID();
+  const attemptPath = resolveCandidateStartupDiagnosticPath(rootId, selectedAttemptId);
+  const selectedPath = resolveCandidateStartupDiagnosticPath(rootId);
+  const controlDirectory = dirname(attemptPath);
   await mkdir(controlDirectory, { recursive: true, mode: 0o700 });
   try {
     const helperDiagnostic = JSON.stringify({
@@ -23,21 +28,50 @@ test('preserves a bounded redacted Candidate startup diagnostic in the private c
     });
     await writeCandidateStartupDiagnostic({
       rootId,
+      startupAttemptId: selectedAttemptId,
       failure: { reason: 'local_ipc_security_failed' },
       error: new Error('Unable to secure endpoint', { cause: new Error(helperDiagnostic) }),
       logs: [`startup token=sk-${'a'.repeat(24)}`, 'endpoint setup failed'],
     });
 
+    await writeCandidateStartupDiagnostic({
+      rootId,
+      startupAttemptId: otherAttemptId,
+      failure: { reason: 'internal_startup_failure' },
+      error: new Error('Different Candidate failure'),
+    });
+    await selectCandidateStartupDiagnostic(rootId, selectedAttemptId);
+
     const diagnostic = await readCandidateStartupDiagnostic(rootId);
     assert.ok(diagnostic);
     assert.equal(diagnostic.rootId, rootId);
+    assert.equal(diagnostic.startupAttemptId, selectedAttemptId);
     assert.equal(diagnostic.reason, 'local_ipc_security_failed');
     assert.match(diagnostic.errorChain[1]?.message ?? '', /windows_pipe_acl/u);
     assert.match(diagnostic.errorChain[1]?.message ?? '', /acl_apply/u);
     assert.deepEqual(diagnostic.logs, ['startup token=[redacted]', 'endpoint setup failed']);
-    assert.equal((await stat(path)).mode & 0o077, 0);
+    assert.equal((await stat(selectedPath)).mode & 0o077, 0);
 
-    await clearCandidateStartupDiagnostic(rootId);
+    const otherDiagnostic = await readCandidateStartupDiagnostic(rootId, otherAttemptId);
+    assert.equal(otherDiagnostic?.reason, 'internal_startup_failure');
+
+    await utimes(
+      resolveCandidateStartupDiagnosticPath(rootId, otherAttemptId),
+      new Date(0),
+      new Date(0),
+    );
+    const freshAttemptId = randomUUID();
+    await writeCandidateStartupDiagnostic({
+      rootId,
+      startupAttemptId: freshAttemptId,
+      failure: { reason: 'internal_startup_failure' },
+      error: new Error('Fresh Candidate failure'),
+    });
+    assert.equal(await readCandidateStartupDiagnostic(rootId, otherAttemptId), undefined);
+
+    assert.equal(await clearSelectedCandidateStartupDiagnostic(rootId, otherAttemptId), false);
+    assert.equal(await clearSelectedCandidateStartupDiagnostic(rootId, selectedAttemptId), true);
+    await clearCandidateStartupDiagnostic(rootId, freshAttemptId);
     assert.equal(await readCandidateStartupDiagnostic(rootId), undefined);
   } finally {
     await rm(controlDirectory, { recursive: true, force: true });

--- a/packages/runtime-host/src/__tests__/startup-error.test.ts
+++ b/packages/runtime-host/src/__tests__/startup-error.test.ts
@@ -27,3 +27,9 @@ test('keeps internal startup failures retryable', () => {
   const error = runtimeHostStartupError('internal_startup_failure');
   assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
 });
+
+test('presents Local IPC security failures distinctly without making them permanent', () => {
+  const error = runtimeHostStartupError('local_ipc_security_failed');
+  assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
+  assert.match(error.message, /LOCAL_IPC_SECURITY_FAILED/u);
+});

--- a/packages/runtime-host/src/candidate-cli.ts
+++ b/packages/runtime-host/src/candidate-cli.ts
@@ -1,7 +1,9 @@
 import type { InteractiveRuntimeHostCandidateOptions } from './server/candidate.js';
+import { isCandidateStartupAttemptId } from './candidate-startup-failure.js';
 
 export interface ParsedInteractiveRuntimeHostCandidateArguments
   extends InteractiveRuntimeHostCandidateOptions {
+  readonly startupAttemptId: string;
   readonly desktopE2e?: true;
 }
 
@@ -11,6 +13,7 @@ export function parseInteractiveRuntimeHostCandidateArguments(
   const allowedKeys = new Set([
     'root',
     'expected-root-id',
+    'startup-attempt-id',
     'initial-connection-timeout-ms',
     'idle-grace-ms',
     'handshake-timeout-ms',
@@ -36,9 +39,14 @@ export function parseInteractiveRuntimeHostCandidateArguments(
   if (!expectedRootId || !/^[a-f0-9]{64}$/.test(expectedRootId)) {
     throw new Error('Runtime Host candidate requires a valid --expected-root-id');
   }
+  const startupAttemptId = values.get('startup-attempt-id');
+  if (!isCandidateStartupAttemptId(startupAttemptId)) {
+    throw new Error('Runtime Host candidate requires a valid --startup-attempt-id');
+  }
   return {
     rootPath,
     expectedRootId,
+    startupAttemptId,
     initialConnectionTimeoutMs: readOptionalInteger(values, 'initial-connection-timeout-ms'),
     idleGraceMs: readOptionalInteger(values, 'idle-grace-ms'),
     handshakeTimeoutMs: readOptionalInteger(values, 'handshake-timeout-ms'),

--- a/packages/runtime-host/src/candidate-startup-failure.ts
+++ b/packages/runtime-host/src/candidate-startup-failure.ts
@@ -8,6 +8,13 @@ export interface CandidateStartupFailure {
   readonly reason: CandidateStartupFailureReason;
 }
 
+export interface CandidateStartupFailureReport extends CandidateStartupFailure {
+  readonly startupAttemptId: string;
+}
+
+const STARTUP_ATTEMPT_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+
 const EXIT_CODE_BY_REASON: Readonly<Record<CandidateStartupFailureReason, number>> = {
   stored_data_incompatible: 65,
   operational_state_migration_blocked: 78,
@@ -51,6 +58,10 @@ export function candidateStartupFailureForExitCode(
     if (exitCode === code) return { reason: reason as CandidateStartupFailureReason };
   }
   return undefined;
+}
+
+export function isCandidateStartupAttemptId(value: unknown): value is string {
+  return typeof value === 'string' && STARTUP_ATTEMPT_ID_PATTERN.test(value);
 }
 
 function primaryErrorChain(root: unknown): unknown[] {

--- a/packages/runtime-host/src/candidate-startup-failure.ts
+++ b/packages/runtime-host/src/candidate-startup-failure.ts
@@ -1,6 +1,7 @@
 export type CandidateStartupFailureReason =
   | 'stored_data_incompatible'
   | 'operational_state_migration_blocked'
+  | 'local_ipc_security_failed'
   | 'internal_startup_failure';
 
 export interface CandidateStartupFailure {
@@ -10,6 +11,7 @@ export interface CandidateStartupFailure {
 const EXIT_CODE_BY_REASON: Readonly<Record<CandidateStartupFailureReason, number>> = {
   stored_data_incompatible: 65,
   operational_state_migration_blocked: 78,
+  local_ipc_security_failed: 77,
   internal_startup_failure: 70,
 };
 
@@ -21,15 +23,21 @@ export function classifyCandidateStartupFailure(error: unknown): CandidateStartu
   if (errors.some((candidate) => errorCode(candidate) === 'operational_state_migration_blocked')) {
     return { reason: 'operational_state_migration_blocked' };
   }
+  if (errors.some((candidate) => errorCode(candidate) === 'insecure_endpoint_directory')) {
+    return { reason: 'local_ipc_security_failed' };
+  }
   return { reason: 'internal_startup_failure' };
 }
 
 export function isPermanentCandidateStartupFailure(
   failure: CandidateStartupFailure | undefined,
 ): failure is CandidateStartupFailure & {
-  readonly reason: Exclude<CandidateStartupFailureReason, 'internal_startup_failure'>;
+  readonly reason: 'stored_data_incompatible' | 'operational_state_migration_blocked';
 } {
-  return failure !== undefined && failure.reason !== 'internal_startup_failure';
+  return (
+    failure?.reason === 'stored_data_incompatible' ||
+    failure?.reason === 'operational_state_migration_blocked'
+  );
 }
 
 export function candidateStartupFailureExitCode(failure: CandidateStartupFailure): number {

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -27,7 +27,12 @@ import {
 import {
   isPermanentCandidateStartupFailure,
   type CandidateStartupFailure,
+  type CandidateStartupFailureReport,
 } from '../candidate-startup-failure.js';
+import {
+  clearCandidateStartupDiagnostic,
+  selectCandidateStartupDiagnostic,
+} from '../control/startup-diagnostic.js';
 import { abortable, waitForRuntimeHostReady } from './wait-for-ready.js';
 
 const DEFAULT_ELECTION_DEADLINE_MS = 45_000;
@@ -181,116 +186,163 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
   let nextCandidateAt = startedAt;
   let backoffMs = DEFAULT_BACKOFF_MIN_MS;
   let sawUnresponsiveEndpoint = false;
-  let startupFailure: CandidateStartupFailure | undefined;
+  let startupFailure: CandidateStartupFailureReport | undefined;
   let pendingCandidateReports = 0;
+  let electionSettled = false;
 
-  while (performance.now() < deadline) {
-    input.signal?.throwIfAborted();
-    const result = await connectResolvedRuntimeHost({
-      capability,
-      controlDirectory,
-      surface: input.surface,
-      protocol: input.protocol,
-      compositionId: input.compositionId,
-      ...(input.generation === undefined ? {} : { generation: input.generation }),
-      ...(input.takeoverHostEpoch === undefined
-        ? {}
-        : { takeoverHostEpoch: input.takeoverHostEpoch }),
-      clientInstanceId,
-      connectTimeoutMs: input.connectTimeoutMs,
-      handshakeTimeoutMs: input.handshakeTimeoutMs,
-      electionDeadline: deadline,
-    });
-    if (result.kind === 'election_deadline_elapsed') {
-      if (result.endpointConnected) sawUnresponsiveEndpoint = true;
-      break;
-    }
-    if (result.kind === 'connected') {
-      const remaining = deadline - performance.now();
-      if (remaining <= 0) {
-        await result.connection.close().catch(() => undefined);
+  try {
+    while (performance.now() < deadline) {
+      input.signal?.throwIfAborted();
+      const result = await connectResolvedRuntimeHost({
+        capability,
+        controlDirectory,
+        surface: input.surface,
+        protocol: input.protocol,
+        compositionId: input.compositionId,
+        ...(input.generation === undefined ? {} : { generation: input.generation }),
+        ...(input.takeoverHostEpoch === undefined
+          ? {}
+          : { takeoverHostEpoch: input.takeoverHostEpoch }),
+        clientInstanceId,
+        connectTimeoutMs: input.connectTimeoutMs,
+        handshakeTimeoutMs: input.handshakeTimeoutMs,
+        electionDeadline: deadline,
+      });
+      if (result.kind === 'election_deadline_elapsed') {
+        if (result.endpointConnected) sawUnresponsiveEndpoint = true;
         break;
       }
-      try {
-        await waitForRuntimeHostReady(
-          result.connection,
-          Math.max(1, Math.ceil(remaining)),
-          input.signal,
-        );
-        return result;
-      } catch {
-        await result.connection.close().catch(() => undefined);
-      }
-      input.signal?.throwIfAborted();
-      sawUnresponsiveEndpoint = true;
-    }
-    if (result.kind === 'upgrade_required') return result;
-    if (result.kind === 'unavailable' && result.reason === 'handshake_failed') {
-      sawUnresponsiveEndpoint = true;
-    }
-    if (isBlockingIncompatibility(result)) {
-      return result;
-    }
-    if (isPermanentCandidateStartupFailure(startupFailure) && pendingCandidateReports === 0) {
-      return { kind: 'failed', reason: startupFailure.reason };
-    }
-
-    const now = performance.now();
-    if (
-      shouldLaunchCandidate(result) &&
-      !isPermanentCandidateStartupFailure(startupFailure) &&
-      now >= nextCandidateAt
-    ) {
-      try {
+      if (result.kind === 'connected') {
         const remaining = deadline - performance.now();
-        if (remaining <= 0) break;
-        const launch = dependencies.launchCandidate({
-          rootPath: capability.canonicalPath,
-          expectedRootId: capability.rootId,
-          entrypoint: input.candidateEntrypoint,
-          initialConnectionTimeoutMs: Math.ceil(remaining),
-          ...(input.generation === undefined ? {} : { generation: input.generation }),
-          ...(input.desktopE2e ? { desktopE2e: true } : {}),
-        });
-        const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);
-        if (attempt.startupFailure) {
-          pendingCandidateReports += 1;
-          void attempt.startupFailure
-            .then(
-              (failure) => {
-                if (
-                  failure &&
-                  (!startupFailure ||
-                    (!isPermanentCandidateStartupFailure(startupFailure) &&
-                      isPermanentCandidateStartupFailure(failure)))
-                ) {
-                  startupFailure = failure;
-                }
-              },
-              () => undefined,
-            )
-            .finally(() => {
-              pendingCandidateReports -= 1;
-            });
+        if (remaining <= 0) {
+          await result.connection.close().catch(() => undefined);
+          break;
         }
-      } catch {
-        // A failed Candidate attempt is ordinary election evidence; discovery continues.
+        try {
+          await waitForRuntimeHostReady(
+            result.connection,
+            Math.max(1, Math.ceil(remaining)),
+            input.signal,
+          );
+          electionSettled = true;
+          await retireCandidateStartupDiagnostic(capability.rootId, startupFailure);
+          return result;
+        } catch {
+          await result.connection.close().catch(() => undefined);
+        }
+        input.signal?.throwIfAborted();
+        sawUnresponsiveEndpoint = true;
       }
-      nextCandidateAt = now + MIN_CANDIDATE_INTERVAL_MS;
-    }
+      if (result.kind === 'upgrade_required') return result;
+      if (result.kind === 'unavailable' && result.reason === 'handshake_failed') {
+        sawUnresponsiveEndpoint = true;
+      }
+      if (isBlockingIncompatibility(result)) {
+        return result;
+      }
+      if (isPermanentCandidateStartupFailure(startupFailure) && pendingCandidateReports === 0) {
+        const selectedFailure = startupFailure;
+        electionSettled = true;
+        await selectCandidateStartupDiagnostic(
+          capability.rootId,
+          selectedFailure.startupAttemptId,
+        ).catch(() => undefined);
+        return { kind: 'failed', reason: selectedFailure.reason };
+      }
 
-    const remaining = deadline - performance.now();
-    if (remaining <= 0) break;
-    const random = dependencies.random();
-    const jitter = 0.75 + Math.min(1, Math.max(0, Number.isFinite(random) ? random : 0.5)) * 0.5;
-    await sleep(Math.min(remaining, Math.max(1, Math.round(backoffMs * jitter))), input.signal);
-    backoffMs = Math.min(DEFAULT_BACKOFF_MAX_MS, backoffMs * 2);
+      const now = performance.now();
+      if (
+        shouldLaunchCandidate(result) &&
+        !isPermanentCandidateStartupFailure(startupFailure) &&
+        now >= nextCandidateAt
+      ) {
+        try {
+          const remaining = deadline - performance.now();
+          if (remaining <= 0) break;
+          const launch = dependencies.launchCandidate({
+            rootPath: capability.canonicalPath,
+            expectedRootId: capability.rootId,
+            entrypoint: input.candidateEntrypoint,
+            initialConnectionTimeoutMs: Math.ceil(remaining),
+            ...(input.generation === undefined ? {} : { generation: input.generation }),
+            ...(input.desktopE2e ? { desktopE2e: true } : {}),
+          });
+          const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);
+          if (attempt.startupFailure) {
+            pendingCandidateReports += 1;
+            void attempt.startupFailure
+              .then(
+                (failure) => {
+                  if (!failure) return;
+                  if (electionSettled) {
+                    void clearCandidateStartupDiagnostic(
+                      capability.rootId,
+                      failure.startupAttemptId,
+                    ).catch(() => undefined);
+                    return;
+                  }
+                  const replace =
+                    !startupFailure ||
+                    (!isPermanentCandidateStartupFailure(startupFailure) &&
+                      isPermanentCandidateStartupFailure(failure));
+                  const obsolete = replace ? startupFailure : failure;
+                  if (replace) {
+                    startupFailure = failure;
+                  }
+                  if (obsolete) {
+                    void clearCandidateStartupDiagnostic(
+                      capability.rootId,
+                      obsolete.startupAttemptId,
+                    ).catch(() => undefined);
+                  }
+                },
+                () => undefined,
+              )
+              .finally(() => {
+                pendingCandidateReports -= 1;
+              });
+          }
+        } catch {
+          // A failed Candidate attempt is ordinary election evidence; discovery continues.
+        }
+        nextCandidateAt = now + MIN_CANDIDATE_INTERVAL_MS;
+      }
+
+      const remaining = deadline - performance.now();
+      if (remaining <= 0) break;
+      const random = dependencies.random();
+      const jitter = 0.75 + Math.min(1, Math.max(0, Number.isFinite(random) ? random : 0.5)) * 0.5;
+      await sleep(Math.min(remaining, Math.max(1, Math.round(backoffMs * jitter))), input.signal);
+      backoffMs = Math.min(DEFAULT_BACKOFF_MAX_MS, backoffMs * 2);
+    }
+    if (startupFailure) {
+      const selectedFailure = startupFailure;
+      electionSettled = true;
+      await selectCandidateStartupDiagnostic(
+        capability.rootId,
+        selectedFailure.startupAttemptId,
+      ).catch(() => undefined);
+      return { kind: 'failed', reason: selectedFailure.reason };
+    }
+    return {
+      kind: 'failed',
+      reason: sawUnresponsiveEndpoint ? 'host_unresponsive' : 'startup_timeout',
+    };
+  } finally {
+    electionSettled = true;
   }
-  if (startupFailure) return { kind: 'failed', reason: startupFailure.reason };
-  return {
-    kind: 'failed',
-    reason: sawUnresponsiveEndpoint ? 'host_unresponsive' : 'startup_timeout',
-  };
+}
+
+async function retireCandidateStartupDiagnostic(
+  rootId: string,
+  startupFailure: CandidateStartupFailureReport | undefined,
+): Promise<void> {
+  await Promise.all([
+    clearCandidateStartupDiagnostic(rootId),
+    ...(startupFailure
+      ? [clearCandidateStartupDiagnostic(rootId, startupFailure.startupAttemptId)]
+      : []),
+  ]).catch(() => undefined);
 }
 
 function isBlockingIncompatibility(

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -1,9 +1,10 @@
 import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { dirname, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
   candidateStartupFailureForExitCode,
-  type CandidateStartupFailure,
+  type CandidateStartupFailureReport,
 } from '../candidate-startup-failure.js';
 
 export interface DetachedCandidateInput {
@@ -21,7 +22,7 @@ export interface DetachedCandidateInput {
 
 export interface DetachedCandidateAttempt {
   pid: number;
-  startupFailure?: Promise<CandidateStartupFailure | undefined>;
+  startupFailure?: Promise<CandidateStartupFailureReport | undefined>;
 }
 
 export interface OwnedCandidateAttempt extends DetachedCandidateAttempt {
@@ -38,8 +39,9 @@ export type CandidateLauncher = (input: DetachedCandidateInput) => DetachedCandi
 export function launchDetachedRuntimeHostCandidate(
   input: DetachedCandidateInput,
 ): DetachedCandidateLaunch {
-  const child = spawnCandidate(input, true);
-  const startupFailure = readStartupFailure(child);
+  const startupAttemptId = randomUUID();
+  const child = spawnCandidate(input, true, startupAttemptId);
+  const startupFailure = readStartupFailure(child, startupAttemptId);
   const spawned = spawnedPid(child).then(({ pid }) => {
     child.unref();
     return { pid, startupFailure };
@@ -50,8 +52,9 @@ export function launchDetachedRuntimeHostCandidate(
 export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): {
   readonly spawned: Promise<OwnedCandidateAttempt>;
 } {
-  const child = spawnCandidate(input, false);
-  const startupFailure = readStartupFailure(child);
+  const startupAttemptId = randomUUID();
+  const child = spawnCandidate(input, false, startupAttemptId);
+  const startupFailure = readStartupFailure(child, startupAttemptId);
   const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
     child.once('exit', (code, signal) => resolve({ code, signal }));
   });
@@ -73,7 +76,11 @@ export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): 
   };
 }
 
-function spawnCandidate(input: DetachedCandidateInput, detached: boolean) {
+function spawnCandidate(
+  input: DetachedCandidateInput,
+  detached: boolean,
+  startupAttemptId: string,
+) {
   const executable = input.executable ?? process.execPath;
   const args = [
     typeof input.entrypoint === 'string' ? input.entrypoint : fileURLToPath(input.entrypoint),
@@ -81,6 +88,8 @@ function spawnCandidate(input: DetachedCandidateInput, detached: boolean) {
     input.rootPath,
     '--expected-root-id',
     input.expectedRootId,
+    '--startup-attempt-id',
+    startupAttemptId,
   ];
   appendArgument(args, '--initial-connection-timeout-ms', input.initialConnectionTimeoutMs);
   appendArgument(args, '--idle-grace-ms', input.idleGraceMs);
@@ -125,9 +134,13 @@ function spawnedPid(child: ReturnType<typeof spawn>): Promise<{ pid: number }> {
 
 function readStartupFailure(
   child: ReturnType<typeof spawn>,
-): Promise<CandidateStartupFailure | undefined> {
+  startupAttemptId: string,
+): Promise<CandidateStartupFailureReport | undefined> {
   return new Promise((resolve) => {
-    child.once('exit', (code) => resolve(candidateStartupFailureForExitCode(code)));
+    child.once('exit', (code) => {
+      const failure = candidateStartupFailureForExitCode(code);
+      resolve(failure ? { ...failure, startupAttemptId } : undefined);
+    });
     child.once('error', () => resolve(undefined));
   });
 }

--- a/packages/runtime-host/src/client/startup-error.ts
+++ b/packages/runtime-host/src/client/startup-error.ts
@@ -37,6 +37,10 @@ export function runtimeHostStartupError(reason: RuntimeHostStartupFailureReason)
       return new Error(
         'Runtime Host failed while recovering this workspace. Try again; if the problem persists, report diagnostic code INTERNAL_STARTUP_FAILURE.',
       );
+    case 'local_ipc_security_failed':
+      return new Error(
+        'Runtime Host could not secure its Local IPC endpoint. Try again; if the problem persists, report diagnostic code LOCAL_IPC_SECURITY_FAILED.',
+      );
     case 'composition_mismatch':
       return new RuntimeHostStartupError(
         reason,

--- a/packages/runtime-host/src/control/endpoint.ts
+++ b/packages/runtime-host/src/control/endpoint.ts
@@ -2,6 +2,7 @@ import { execFile, type ExecFileException } from 'node:child_process';
 import { chmod, lstat, mkdtemp, readdir, rm, rmdir, unlink } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { truncateUtf8 } from '@maka/core/diagnostic-log';
 
 const FALLBACK_ENDPOINT_ROOT = '/tmp';
 const PORTABLE_UNIX_SOCKET_PATH_LIMIT = 100;
@@ -20,18 +21,43 @@ const WINDOWS_PIPE_PATH_ENV = 'MAKA_RUNTIME_HOST_PIPE_PATH';
 // it: scripts/windows-runtime-host-local-ipc-trust.ps1 and client/wait-for-ready.ts.
 const WINDOWS_PIPE_ACL_TIMEOUT_MS = 30_000;
 const WINDOWS_PIPE_ACL_DIAGNOSTIC_LIMIT = 1_000;
+const WINDOWS_PIPE_ACL_STDERR_MAX_BYTES = 4 * 1024;
 const WINDOWS_PIPE_ACL_SCRIPT = String.raw`
 $ErrorActionPreference = 'Stop'
-$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
-$security = [System.Security.AccessControl.FileSecurity]::new()
-$security.SetAccessRuleProtection($true, $false)
-$rights = [System.Security.AccessControl.FileSystemRights]::FullControl
-$allow = [System.Security.AccessControl.AccessControlType]::Allow
-$security.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($identity.User, $rights, $allow))
-$system = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18')
-$security.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($system, $rights, $allow))
-$pipe = Get-Item -LiteralPath $env:${WINDOWS_PIPE_PATH_ENV}
-$pipe.SetAccessControl($security)
+$stage = 'identity'
+$currentSid = $null
+try {
+  $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+  $currentSid = $identity.User.Value
+  $stage = 'security_descriptor'
+  $security = [System.Security.AccessControl.FileSecurity]::new()
+  $security.SetAccessRuleProtection($true, $false)
+  $rights = [System.Security.AccessControl.FileSystemRights]::FullControl
+  $allow = [System.Security.AccessControl.AccessControlType]::Allow
+  $security.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($identity.User, $rights, $allow))
+  $system = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-18')
+  $security.AddAccessRule([System.Security.AccessControl.FileSystemAccessRule]::new($system, $rights, $allow))
+  $stage = 'pipe_lookup'
+  $pipe = Get-Item -LiteralPath $env:${WINDOWS_PIPE_PATH_ENV}
+  $stage = 'acl_apply'
+  $pipe.SetAccessControl($security)
+} catch {
+  $exception = $_.Exception
+  $nativeErrorCode = $null
+  if ($null -ne $exception.PSObject.Properties['NativeErrorCode']) {
+    $nativeErrorCode = $exception.NativeErrorCode
+  }
+  [Console]::Error.WriteLine((@{
+    schemaVersion = 1
+    stage = $stage
+    currentSid = $currentSid
+    exceptionType = $exception.GetType().FullName
+    hresult = $exception.HResult
+    nativeErrorCode = $nativeErrorCode
+    message = $exception.Message
+  } | ConvertTo-Json -Compress))
+  exit 1
+}
 `;
 
 export interface RuntimeHostEndpointInput {
@@ -49,10 +75,33 @@ export class RuntimeHostEndpointError extends Error {
   constructor(
     readonly code: 'insecure_endpoint_directory' | 'endpoint_path_too_long',
     message: string,
+    options?: ErrorOptions,
   ) {
-    super(message);
+    super(message, options);
     this.name = 'RuntimeHostEndpointError';
   }
+}
+
+export function windowsPipeAclFailureDiagnostic(error: unknown, stderr: string): string {
+  const details: Record<string, unknown> = {
+    schemaVersion: 1,
+    helper: 'windows_pipe_acl',
+  };
+  if (typeof error === 'object' && error !== null) {
+    const candidate = error as { code?: unknown; signal?: unknown; killed?: unknown };
+    if (typeof candidate.code === 'number' || typeof candidate.code === 'string') {
+      details.exitCode = candidate.code;
+    }
+    if (typeof candidate.signal === 'string') details.signal = candidate.signal;
+    if (typeof candidate.killed === 'boolean') details.killed = candidate.killed;
+  }
+  const boundedStderr = truncateUtf8(
+    stderr.trim(),
+    WINDOWS_PIPE_ACL_STDERR_MAX_BYTES,
+    '\n<stderr truncated>',
+  );
+  if (boundedStderr) details.stderr = boundedStderr;
+  return JSON.stringify(details);
 }
 
 export async function prepareRuntimeHostEndpoint(
@@ -132,6 +181,7 @@ function secureWindowsNamedPipe(path: string): Promise<void> {
       ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', WINDOWS_PIPE_ACL_SCRIPT],
       {
         env: { ...process.env, [WINDOWS_PIPE_PATH_ENV]: path },
+        encoding: 'utf8',
         timeout: WINDOWS_PIPE_ACL_TIMEOUT_MS,
         windowsHide: true,
       },
@@ -158,15 +208,18 @@ export function windowsPipeAclFailure(
   stderr: string,
 ): RuntimeHostEndpointError {
   const diagnostic = powershellDiagnostic(stdout, stderr);
+  const options = { cause: new Error(windowsPipeAclFailureDiagnostic(error, stderr)) };
   if (error.killed === true) {
     return new RuntimeHostEndpointError(
       'insecure_endpoint_directory',
       `Runtime Host could not confirm its Windows Local IPC endpoint restriction within ${WINDOWS_PIPE_ACL_TIMEOUT_MS}ms and refused the endpoint: ${path} (powershell killed with ${error.signal ?? 'no signal'})${diagnostic}`,
+      options,
     );
   }
   return new RuntimeHostEndpointError(
     'insecure_endpoint_directory',
     `Runtime Host could not restrict its Windows Local IPC endpoint to the current user: ${path} (${describeExecFileFailure(error)})${diagnostic}`,
+    options,
   );
 }
 

--- a/packages/runtime-host/src/control/startup-diagnostic.ts
+++ b/packages/runtime-host/src/control/startup-diagnostic.ts
@@ -1,11 +1,14 @@
 import { randomUUID } from 'node:crypto';
-import { chmod, lstat, open, readFile, rename, unlink } from 'node:fs/promises';
+import { chmod, lstat, open, readFile, readdir, rename, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { truncateUtf8 } from '@maka/core/diagnostic-log';
 import { redactSecrets } from '@maka/core/redaction';
 import { resolveRootControlNamespace } from '@maka/storage/root-authority';
 import { z } from 'zod';
-import type { CandidateStartupFailure } from '../candidate-startup-failure.js';
+import {
+  isCandidateStartupAttemptId,
+  type CandidateStartupFailure,
+} from '../candidate-startup-failure.js';
 
 export const RUNTIME_HOST_STARTUP_DIAGNOSTIC_FILE = 'startup-diagnostic.json';
 
@@ -16,6 +19,8 @@ const MAX_ERROR_TEXT_BYTES = 1_024;
 const MAX_LOG_ENTRIES = 4;
 const MAX_LOG_TEXT_BYTES = 1_536;
 const MAX_LABEL_BYTES = 128;
+const MAX_RETAINED_ATTEMPT_DIAGNOSTICS = 32;
+const ATTEMPT_DIAGNOSTIC_RETENTION_MS = 24 * 60 * 60 * 1_000;
 
 const boundedStringSchema = (maximumBytes: number) =>
   z.string().refine((value) => Buffer.byteLength(value, 'utf8') <= maximumBytes);
@@ -30,6 +35,7 @@ const candidateStartupDiagnosticSchema = z
   .object({
     schemaVersion: z.literal(STARTUP_DIAGNOSTIC_SCHEMA_VERSION),
     rootId: z.string().regex(/^[a-f0-9]{64}$/u),
+    startupAttemptId: z.string().refine(isCandidateStartupAttemptId),
     candidatePid: z.number().int().positive().safe(),
     capturedAt: boundedStringSchema(MAX_LABEL_BYTES).refine((value) =>
       Number.isFinite(Date.parse(value)),
@@ -58,21 +64,30 @@ export class CandidateStartupDiagnosticError extends Error {
   }
 }
 
-export function resolveCandidateStartupDiagnosticPath(rootId: string): string {
+export function resolveCandidateStartupDiagnosticPath(
+  rootId: string,
+  startupAttemptId?: string,
+): string {
   assertRootId(rootId);
-  return join(resolveRootControlNamespace(), rootId, RUNTIME_HOST_STARTUP_DIAGNOSTIC_FILE);
+  if (startupAttemptId !== undefined) assertStartupAttemptId(startupAttemptId);
+  const filename = startupAttemptId
+    ? `startup-diagnostic.${startupAttemptId}.json`
+    : RUNTIME_HOST_STARTUP_DIAGNOSTIC_FILE;
+  return join(resolveRootControlNamespace(), rootId, filename);
 }
 
 export async function writeCandidateStartupDiagnostic(input: {
   readonly rootId: string;
+  readonly startupAttemptId: string;
   readonly failure: CandidateStartupFailure;
   readonly error: unknown;
   readonly logs?: readonly string[];
 }): Promise<void> {
-  const path = resolveCandidateStartupDiagnosticPath(input.rootId);
+  const path = resolveCandidateStartupDiagnosticPath(input.rootId, input.startupAttemptId);
   const document: CandidateStartupDiagnostic = {
     schemaVersion: STARTUP_DIAGNOSTIC_SCHEMA_VERSION,
     rootId: input.rootId,
+    startupAttemptId: input.startupAttemptId,
     candidatePid: process.pid,
     capturedAt: new Date().toISOString(),
     reason: input.failure.reason,
@@ -113,12 +128,16 @@ export async function writeCandidateStartupDiagnostic(input: {
   } finally {
     if (!replaced) await unlink(temporaryPath).catch(() => undefined);
   }
+  await pruneCandidateStartupDiagnostics(input.rootId, input.startupAttemptId).catch(
+    () => undefined,
+  );
 }
 
 export async function readCandidateStartupDiagnostic(
   rootId: string,
+  startupAttemptId?: string,
 ): Promise<CandidateStartupDiagnostic | undefined> {
-  const path = resolveCandidateStartupDiagnosticPath(rootId);
+  const path = resolveCandidateStartupDiagnosticPath(rootId, startupAttemptId);
   let contents: string;
   try {
     const diagnosticStat = await lstat(path);
@@ -139,7 +158,11 @@ export async function readCandidateStartupDiagnostic(
     );
   }
   try {
-    return decodeCandidateStartupDiagnostic(JSON.parse(contents) as unknown, rootId);
+    return decodeCandidateStartupDiagnostic(
+      JSON.parse(contents) as unknown,
+      rootId,
+      startupAttemptId,
+    );
   } catch (error) {
     if (error instanceof CandidateStartupDiagnosticError) throw error;
     throw new CandidateStartupDiagnosticError(
@@ -150,22 +173,65 @@ export async function readCandidateStartupDiagnostic(
   }
 }
 
-export async function clearCandidateStartupDiagnostic(rootId: string): Promise<void> {
-  const path = resolveCandidateStartupDiagnosticPath(rootId);
+export async function selectCandidateStartupDiagnostic(
+  rootId: string,
+  startupAttemptId: string,
+): Promise<void> {
+  const attemptPath = resolveCandidateStartupDiagnosticPath(rootId, startupAttemptId);
+  const selectedPath = resolveCandidateStartupDiagnosticPath(rootId);
+  await readCandidateStartupDiagnostic(rootId, startupAttemptId);
+  try {
+    await rename(attemptPath, selectedPath);
+    await syncDirectory(dirname(selectedPath));
+  } catch (error) {
+    throw new CandidateStartupDiagnosticError(
+      'startup_diagnostic_io_failed',
+      'Unable to select the Runtime Host startup diagnostic',
+      { cause: error },
+    );
+  }
+}
+
+export async function clearCandidateStartupDiagnostic(
+  rootId: string,
+  startupAttemptId?: string,
+): Promise<void> {
+  const path = resolveCandidateStartupDiagnosticPath(rootId, startupAttemptId);
   await unlink(path).catch((error: unknown) => {
     if (!isNodeError(error, 'ENOENT')) throw error;
   });
 }
 
+export async function clearSelectedCandidateStartupDiagnostic(
+  rootId: string,
+  expectedStartupAttemptId: string,
+): Promise<boolean> {
+  assertStartupAttemptId(expectedStartupAttemptId);
+  const diagnostic = await readCandidateStartupDiagnostic(rootId);
+  if (!diagnostic || diagnostic.startupAttemptId !== expectedStartupAttemptId) return false;
+  await clearCandidateStartupDiagnostic(rootId);
+  return true;
+}
+
 function decodeCandidateStartupDiagnostic(
   value: unknown,
   expectedRootId: string,
+  expectedStartupAttemptId?: string,
 ): CandidateStartupDiagnostic {
   const diagnostic = candidateStartupDiagnosticSchema.parse(value);
   if (diagnostic.rootId !== expectedRootId) {
     throw new CandidateStartupDiagnosticError(
       'invalid_startup_diagnostic',
       'Runtime Host startup diagnostic belongs to a different storage root',
+    );
+  }
+  if (
+    expectedStartupAttemptId !== undefined &&
+    diagnostic.startupAttemptId !== expectedStartupAttemptId
+  ) {
+    throw new CandidateStartupDiagnosticError(
+      'invalid_startup_diagnostic',
+      'Runtime Host startup diagnostic belongs to a different Candidate attempt',
     );
   }
   return diagnostic;
@@ -229,6 +295,54 @@ function assertRootId(rootId: string): void {
   if (!/^[a-f0-9]{64}$/u.test(rootId)) {
     throw new TypeError('Runtime Host startup diagnostic requires a valid root id');
   }
+}
+
+function assertStartupAttemptId(startupAttemptId: string): void {
+  if (!isCandidateStartupAttemptId(startupAttemptId)) {
+    throw new TypeError('Runtime Host startup diagnostic requires a valid attempt id');
+  }
+}
+
+async function pruneCandidateStartupDiagnostics(
+  rootId: string,
+  retainedAttemptId: string,
+): Promise<void> {
+  const controlDirectory = dirname(resolveCandidateStartupDiagnosticPath(rootId));
+  const entries = await readdir(controlDirectory, { withFileTypes: true });
+  const attempts = await Promise.all(
+    entries.flatMap((entry) => {
+      if (!entry.isFile()) return [];
+      const startupAttemptId = startupAttemptIdFromFilename(entry.name);
+      if (!startupAttemptId) return [];
+      const path = join(controlDirectory, entry.name);
+      return [
+        lstat(path).then((fileStat) => ({
+          startupAttemptId,
+          path,
+          mtimeMs: fileStat.mtimeMs,
+        })),
+      ];
+    }),
+  );
+  attempts.sort((left, right) => right.mtimeMs - left.mtimeMs);
+  const expiredBefore = Date.now() - ATTEMPT_DIAGNOSTIC_RETENTION_MS;
+  await Promise.all(
+    attempts.map(async (attempt, index) => {
+      if (attempt.startupAttemptId === retainedAttemptId) return;
+      if (index < MAX_RETAINED_ATTEMPT_DIAGNOSTICS && attempt.mtimeMs >= expiredBefore) return;
+      await unlink(attempt.path).catch((error: unknown) => {
+        if (!isNodeError(error, 'ENOENT')) throw error;
+      });
+    }),
+  );
+}
+
+function startupAttemptIdFromFilename(filename: string): string | undefined {
+  const prefix = 'startup-diagnostic.';
+  const suffix = '.json';
+  if (!filename.startsWith(prefix) || !filename.endsWith(suffix)) return undefined;
+  const startupAttemptId = filename.slice(prefix.length, -suffix.length);
+  return isCandidateStartupAttemptId(startupAttemptId) ? startupAttemptId : undefined;
 }
 
 async function syncDirectory(path: string): Promise<void> {

--- a/packages/runtime-host/src/control/startup-diagnostic.ts
+++ b/packages/runtime-host/src/control/startup-diagnostic.ts
@@ -1,0 +1,252 @@
+import { randomUUID } from 'node:crypto';
+import { chmod, lstat, open, readFile, rename, unlink } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { truncateUtf8 } from '@maka/core/diagnostic-log';
+import { redactSecrets } from '@maka/core/redaction';
+import { resolveRootControlNamespace } from '@maka/storage/root-authority';
+import { z } from 'zod';
+import type { CandidateStartupFailure } from '../candidate-startup-failure.js';
+
+export const RUNTIME_HOST_STARTUP_DIAGNOSTIC_FILE = 'startup-diagnostic.json';
+
+const STARTUP_DIAGNOSTIC_SCHEMA_VERSION = 1 as const;
+const MAX_STARTUP_DIAGNOSTIC_BYTES = 16 * 1024;
+const MAX_ERROR_CHAIN_ENTRIES = 4;
+const MAX_ERROR_TEXT_BYTES = 1_024;
+const MAX_LOG_ENTRIES = 4;
+const MAX_LOG_TEXT_BYTES = 1_536;
+const MAX_LABEL_BYTES = 128;
+
+const boundedStringSchema = (maximumBytes: number) =>
+  z.string().refine((value) => Buffer.byteLength(value, 'utf8') <= maximumBytes);
+const candidateStartupErrorSummarySchema = z
+  .object({
+    name: boundedStringSchema(MAX_LABEL_BYTES).optional(),
+    code: z.union([boundedStringSchema(MAX_LABEL_BYTES), z.number().finite()]).optional(),
+    message: boundedStringSchema(MAX_ERROR_TEXT_BYTES),
+  })
+  .strict();
+const candidateStartupDiagnosticSchema = z
+  .object({
+    schemaVersion: z.literal(STARTUP_DIAGNOSTIC_SCHEMA_VERSION),
+    rootId: z.string().regex(/^[a-f0-9]{64}$/u),
+    candidatePid: z.number().int().positive().safe(),
+    capturedAt: boundedStringSchema(MAX_LABEL_BYTES).refine((value) =>
+      Number.isFinite(Date.parse(value)),
+    ),
+    reason: z.enum([
+      'stored_data_incompatible',
+      'operational_state_migration_blocked',
+      'local_ipc_security_failed',
+      'internal_startup_failure',
+    ]),
+    errorChain: z.array(candidateStartupErrorSummarySchema).min(1).max(MAX_ERROR_CHAIN_ENTRIES),
+    logs: z.array(boundedStringSchema(MAX_LOG_TEXT_BYTES)).max(MAX_LOG_ENTRIES),
+  })
+  .strict();
+
+export type CandidateStartupDiagnostic = z.infer<typeof candidateStartupDiagnosticSchema>;
+
+export class CandidateStartupDiagnosticError extends Error {
+  constructor(
+    readonly code: 'invalid_startup_diagnostic' | 'startup_diagnostic_io_failed',
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'CandidateStartupDiagnosticError';
+  }
+}
+
+export function resolveCandidateStartupDiagnosticPath(rootId: string): string {
+  assertRootId(rootId);
+  return join(resolveRootControlNamespace(), rootId, RUNTIME_HOST_STARTUP_DIAGNOSTIC_FILE);
+}
+
+export async function writeCandidateStartupDiagnostic(input: {
+  readonly rootId: string;
+  readonly failure: CandidateStartupFailure;
+  readonly error: unknown;
+  readonly logs?: readonly string[];
+}): Promise<void> {
+  const path = resolveCandidateStartupDiagnosticPath(input.rootId);
+  const document: CandidateStartupDiagnostic = {
+    schemaVersion: STARTUP_DIAGNOSTIC_SCHEMA_VERSION,
+    rootId: input.rootId,
+    candidatePid: process.pid,
+    capturedAt: new Date().toISOString(),
+    reason: input.failure.reason,
+    errorChain: summarizeErrorChain(input.error),
+    logs: (input.logs ?? [])
+      .slice(-MAX_LOG_ENTRIES)
+      .map((entry) => boundedDiagnosticText(entry, MAX_LOG_TEXT_BYTES)),
+  };
+  const contents = `${JSON.stringify(document)}\n`;
+  if (Buffer.byteLength(contents, 'utf8') > MAX_STARTUP_DIAGNOSTIC_BYTES) {
+    throw new CandidateStartupDiagnosticError(
+      'invalid_startup_diagnostic',
+      'Runtime Host startup diagnostic exceeded its size limit',
+    );
+  }
+
+  const temporaryPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  let replaced = false;
+  try {
+    const handle = await open(temporaryPath, 'wx', 0o600);
+    try {
+      await handle.writeFile(contents, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    if (process.platform !== 'win32') await chmod(temporaryPath, 0o600);
+    await rename(temporaryPath, path);
+    replaced = true;
+    await syncDirectory(dirname(path));
+  } catch (error) {
+    if (error instanceof CandidateStartupDiagnosticError) throw error;
+    throw new CandidateStartupDiagnosticError(
+      'startup_diagnostic_io_failed',
+      'Unable to preserve the Runtime Host startup diagnostic',
+      { cause: error },
+    );
+  } finally {
+    if (!replaced) await unlink(temporaryPath).catch(() => undefined);
+  }
+}
+
+export async function readCandidateStartupDiagnostic(
+  rootId: string,
+): Promise<CandidateStartupDiagnostic | undefined> {
+  const path = resolveCandidateStartupDiagnosticPath(rootId);
+  let contents: string;
+  try {
+    const diagnosticStat = await lstat(path);
+    if (!diagnosticStat.isFile() || diagnosticStat.size > MAX_STARTUP_DIAGNOSTIC_BYTES) {
+      throw new CandidateStartupDiagnosticError(
+        'invalid_startup_diagnostic',
+        'Runtime Host startup diagnostic must be a bounded regular file',
+      );
+    }
+    contents = await readFile(path, 'utf8');
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) return undefined;
+    if (error instanceof CandidateStartupDiagnosticError) throw error;
+    throw new CandidateStartupDiagnosticError(
+      'startup_diagnostic_io_failed',
+      'Unable to read the Runtime Host startup diagnostic',
+      { cause: error },
+    );
+  }
+  try {
+    return decodeCandidateStartupDiagnostic(JSON.parse(contents) as unknown, rootId);
+  } catch (error) {
+    if (error instanceof CandidateStartupDiagnosticError) throw error;
+    throw new CandidateStartupDiagnosticError(
+      'invalid_startup_diagnostic',
+      'Runtime Host startup diagnostic is invalid',
+      { cause: error },
+    );
+  }
+}
+
+export async function clearCandidateStartupDiagnostic(rootId: string): Promise<void> {
+  const path = resolveCandidateStartupDiagnosticPath(rootId);
+  await unlink(path).catch((error: unknown) => {
+    if (!isNodeError(error, 'ENOENT')) throw error;
+  });
+}
+
+function decodeCandidateStartupDiagnostic(
+  value: unknown,
+  expectedRootId: string,
+): CandidateStartupDiagnostic {
+  const diagnostic = candidateStartupDiagnosticSchema.parse(value);
+  if (diagnostic.rootId !== expectedRootId) {
+    throw new CandidateStartupDiagnosticError(
+      'invalid_startup_diagnostic',
+      'Runtime Host startup diagnostic belongs to a different storage root',
+    );
+  }
+  return diagnostic;
+}
+
+function summarizeErrorChain(error: unknown): z.infer<typeof candidateStartupErrorSummarySchema>[] {
+  const summaries: z.infer<typeof candidateStartupErrorSummarySchema>[] = [];
+  const visited = new Set<object>();
+  let current: unknown = error;
+  while (summaries.length < MAX_ERROR_CHAIN_ENTRIES) {
+    if (typeof current !== 'object' || current === null || visited.has(current)) {
+      if (summaries.length === 0) {
+        summaries.push({ message: boundedDiagnosticText(String(current), MAX_ERROR_TEXT_BYTES) });
+      }
+      break;
+    }
+    visited.add(current);
+    const candidate = current as {
+      name?: unknown;
+      code?: unknown;
+      message?: unknown;
+      cause?: unknown;
+      errors?: unknown;
+    };
+    summaries.push({
+      ...(typeof candidate.name === 'string'
+        ? { name: boundedDiagnosticText(candidate.name, MAX_LABEL_BYTES) }
+        : {}),
+      ...(typeof candidate.code === 'string' ||
+      (typeof candidate.code === 'number' && Number.isFinite(candidate.code))
+        ? {
+            code:
+              typeof candidate.code === 'string'
+                ? boundedDiagnosticText(candidate.code, MAX_LABEL_BYTES)
+                : candidate.code,
+          }
+        : {}),
+      message: boundedDiagnosticText(
+        typeof candidate.message === 'string' ? candidate.message : String(current),
+        MAX_ERROR_TEXT_BYTES,
+      ),
+    });
+    if (candidate.cause !== undefined) {
+      current = candidate.cause;
+      continue;
+    }
+    if (current instanceof AggregateError && current.errors.length > 0) {
+      [current] = current.errors;
+      continue;
+    }
+    break;
+  }
+  return summaries;
+}
+
+function boundedDiagnosticText(value: string, maximumBytes: number): string {
+  return truncateUtf8(redactSecrets(value), maximumBytes, '\n<diagnostic truncated>');
+}
+
+function assertRootId(rootId: string): void {
+  if (!/^[a-f0-9]{64}$/u.test(rootId)) {
+    throw new TypeError('Runtime Host startup diagnostic requires a valid root id');
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await open(path, 'r').catch(() => undefined);
+  if (!handle) return;
+  try {
+    await handle.sync().catch(() => undefined);
+  } finally {
+    await handle.close();
+  }
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === code
+  );
+}

--- a/packages/runtime-host/src/execution-candidate-main.ts
+++ b/packages/runtime-host/src/execution-candidate-main.ts
@@ -12,20 +12,23 @@ import {
   candidateStartupFailureExitCode,
   classifyCandidateStartupFailure,
 } from './candidate-startup-failure.js';
-import {
-  clearCandidateStartupDiagnostic,
-  writeCandidateStartupDiagnostic,
-} from './control/startup-diagnostic.js';
+import { writeCandidateStartupDiagnostic } from './control/startup-diagnostic.js';
 
 installRuntimeHostLogCapture();
 
 let result: Awaited<ReturnType<typeof startExecutionRuntimeHostCandidate>>;
 let desktopE2e: true | undefined;
 let rootId: string | undefined;
+let startupAttemptId: string | undefined;
 try {
   const parsed = parseInteractiveRuntimeHostCandidateArguments(process.argv.slice(2));
   rootId = parsed.expectedRootId;
-  const { desktopE2e: parsedDesktopE2e, ...parsedOptions } = parsed;
+  const {
+    desktopE2e: parsedDesktopE2e,
+    startupAttemptId: parsedStartupAttemptId,
+    ...parsedOptions
+  } = parsed;
+  startupAttemptId = parsedStartupAttemptId;
   desktopE2e = parsedDesktopE2e;
   const options = desktopE2e
     ? { ...parsedOptions, idleGraceMs: DESKTOP_E2E_IDLE_GRACE_MS }
@@ -36,20 +39,20 @@ try {
   );
 } catch (error) {
   const failure = classifyCandidateStartupFailure(error);
+  const logs = runtimeHostLogBuffer.snapshot();
   console.error('[runtime-host] startup failed:', error);
-  if (rootId) {
+  if (rootId && startupAttemptId) {
     await writeCandidateStartupDiagnostic({
       rootId,
+      startupAttemptId,
       failure,
       error,
-      logs: runtimeHostLogBuffer.snapshot(),
+      logs,
     }).catch(() => undefined);
   }
   process.exit(candidateStartupFailureExitCode(failure));
 }
 if (result.kind === 'loser') process.exit(2);
-// A loser may overlap the active owner's failure; only the ready winner can retire that evidence.
-if (rootId) await clearCandidateStartupDiagnostic(rootId).catch(() => undefined);
 
 const stopParentWatch = desktopE2e
   ? watchDesktopE2eParentProcess(() => result.host.close())

--- a/packages/runtime-host/src/execution-candidate-main.ts
+++ b/packages/runtime-host/src/execution-candidate-main.ts
@@ -7,18 +7,24 @@ import {
 } from './desktop-e2e-execution.js';
 import { startExecutionRuntimeHostCandidate } from './server/execution-candidate.js';
 import { runRuntimeHostProcessLifecycle } from './server/process-lifecycle.js';
-import { installRuntimeHostLogCapture } from './process-diagnostics.js';
+import { installRuntimeHostLogCapture, runtimeHostLogBuffer } from './process-diagnostics.js';
 import {
   candidateStartupFailureExitCode,
   classifyCandidateStartupFailure,
 } from './candidate-startup-failure.js';
+import {
+  clearCandidateStartupDiagnostic,
+  writeCandidateStartupDiagnostic,
+} from './control/startup-diagnostic.js';
 
 installRuntimeHostLogCapture();
 
 let result: Awaited<ReturnType<typeof startExecutionRuntimeHostCandidate>>;
 let desktopE2e: true | undefined;
+let rootId: string | undefined;
 try {
   const parsed = parseInteractiveRuntimeHostCandidateArguments(process.argv.slice(2));
+  rootId = parsed.expectedRootId;
   const { desktopE2e: parsedDesktopE2e, ...parsedOptions } = parsed;
   desktopE2e = parsedDesktopE2e;
   const options = desktopE2e
@@ -29,10 +35,21 @@ try {
     desktopE2e ? createDesktopE2eExecutionCandidateDependencies() : {},
   );
 } catch (error) {
+  const failure = classifyCandidateStartupFailure(error);
   console.error('[runtime-host] startup failed:', error);
-  process.exit(candidateStartupFailureExitCode(classifyCandidateStartupFailure(error)));
+  if (rootId) {
+    await writeCandidateStartupDiagnostic({
+      rootId,
+      failure,
+      error,
+      logs: runtimeHostLogBuffer.snapshot(),
+    }).catch(() => undefined);
+  }
+  process.exit(candidateStartupFailureExitCode(failure));
 }
 if (result.kind === 'loser') process.exit(2);
+// A loser may overlap the active owner's failure; only the ready winner can retire that evidence.
+if (rootId) await clearCandidateStartupDiagnostic(rootId).catch(() => undefined);
 
 const stopParentWatch = desktopE2e
   ? watchDesktopE2eParentProcess(() => result.host.close())

--- a/scripts/release-cli-runtime-host-diagnostics.mjs
+++ b/scripts/release-cli-runtime-host-diagnostics.mjs
@@ -6,14 +6,39 @@ import { pathToFileURL } from 'node:url';
 const RUNTIME_HOST_DIAGNOSTIC_MAX_BYTES = 32 * 1024;
 const WINDOWS_SECURITY_TEXT_MAX_CHARS = 4 * 1024;
 const DIAGNOSTIC_TEXT_MAX_CHARS = 2 * 1024;
-const WINDOWS_DIAGNOSTIC_PATH_ENV = 'MAKA_RUNTIME_HOST_DIAGNOSTIC_PATH';
+const WINDOWS_PATH_SECURITY_TIMEOUT_MS = 30_000;
+const WINDOWS_DIAGNOSTIC_PATHS_ENV = 'MAKA_RUNTIME_HOST_DIAGNOSTIC_PATHS';
 const WINDOWS_PATH_SECURITY_SCRIPT = `
 $ErrorActionPreference = 'Stop'
-$acl = Get-Acl -LiteralPath $env:${WINDOWS_DIAGNOSTIC_PATH_ENV}
-[Console]::Out.Write((@{
-  owner = $acl.Owner
-  sddl = $acl.Sddl
-} | ConvertTo-Json -Compress))
+$paths = ConvertFrom-Json -InputObject $env:${WINDOWS_DIAGNOSTIC_PATHS_ENV}
+$results = @()
+foreach ($path in @($paths)) {
+  try {
+    $acl = Get-Acl -LiteralPath $path
+    $results += [ordered]@{
+      state = 'present'
+      owner = $acl.Owner
+      sddl = $acl.Sddl
+    }
+  } catch {
+    $exception = $_.Exception
+    $nativeErrorCode = $null
+    if ($null -ne $exception.PSObject.Properties['NativeErrorCode']) {
+      $nativeErrorCode = $exception.NativeErrorCode
+    }
+    $results += [ordered]@{
+      state = 'unavailable'
+      error = [ordered]@{
+        name = $exception.GetType().FullName
+        hresult = $exception.HResult
+        nativeErrorCode = $nativeErrorCode
+        message = $exception.Message
+      }
+    }
+  }
+}
+$response = [ordered]@{ results = @($results) }
+[Console]::Out.Write((ConvertTo-Json -InputObject $response -Compress -Depth 5))
 `;
 
 const STORAGE_AUTHORITY_MODULE = 'node_modules/@maka/storage/dist/root-authority.js';
@@ -25,11 +50,11 @@ export async function collectRuntimeHostFailureDiagnostic(packageRoot, rootPath,
   const platform = options.platform ?? process.platform;
   const environment = options.environment ?? process.env;
   const loadInstalled = options.loadInstalled ?? importInstalled;
-  const readPathSecurity =
-    options.readPathSecurity ??
+  const readPathSecurityBatch =
+    options.readPathSecurityBatch ??
     (platform === 'win32'
-      ? (path) => readWindowsPathSecurity(path, environment)
-      : async () => undefined);
+      ? (paths) => readWindowsPathSecurityBatch(paths, environment)
+      : undefined);
   const diagnostic = {
     schemaVersion: 1,
     platform,
@@ -43,22 +68,27 @@ export async function collectRuntimeHostFailureDiagnostic(packageRoot, rootPath,
     paths: [],
   };
 
-  await addPathEvidence(diagnostic.paths, 'root', rootPath, readPathSecurity, true);
+  addPathEvidence(diagnostic.paths, 'root', rootPath);
+
+  const finish = async () => {
+    if (readPathSecurityBatch) {
+      await addPathSecurityEvidence(diagnostic.paths, readPathSecurityBatch);
+    }
+    return diagnostic;
+  };
 
   let authority;
   try {
     authority = await loadInstalled(packageRoot, STORAGE_AUTHORITY_MODULE);
   } catch (error) {
     diagnostic.storageAuthority = { state: 'unavailable', error: summarizeDiagnosticError(error) };
-    return diagnostic;
+    return finish();
   }
 
-  await addPathEvidence(
+  addPathEvidence(
     diagnostic.paths,
     'root_marker',
     join(rootPath, authority.STORAGE_ROOT_MARKER_FILE),
-    readPathSecurity,
-    false,
   );
 
   let capability;
@@ -72,23 +102,17 @@ export async function collectRuntimeHostFailureDiagnostic(packageRoot, rootPath,
   let controlRoot;
   try {
     controlRoot = authority.resolveRootControlNamespace();
-    await addPathEvidence(diagnostic.paths, 'control_root', controlRoot, readPathSecurity, true);
+    addPathEvidence(diagnostic.paths, 'control_root', controlRoot);
   } catch (error) {
     diagnostic.controlNamespace = {
       state: 'unavailable',
       error: summarizeDiagnosticError(error),
     };
   }
-  if (!capability || !controlRoot) return diagnostic;
+  if (!capability || !controlRoot) return finish();
 
   const controlDirectory = join(controlRoot, capability.rootId);
-  await addPathEvidence(
-    diagnostic.paths,
-    'control_directory',
-    controlDirectory,
-    readPathSecurity,
-    true,
-  );
+  addPathEvidence(diagnostic.paths, 'control_directory', controlDirectory);
 
   try {
     const registrationAuthority = await loadInstalled(packageRoot, REGISTRATION_MODULE);
@@ -96,13 +120,7 @@ export async function collectRuntimeHostFailureDiagnostic(packageRoot, rootPath,
       controlDirectory,
       registrationAuthority.RUNTIME_HOST_REGISTRATION_FILE,
     );
-    await addPathEvidence(
-      diagnostic.paths,
-      'registration',
-      registrationPath,
-      readPathSecurity,
-      false,
-    );
+    addPathEvidence(diagnostic.paths, 'registration', registrationPath);
     const registration = await registrationAuthority.readHostRegistration(controlDirectory);
     diagnostic.registration = registration
       ? summarizeRegistration(registration, capability.rootId)
@@ -117,20 +135,14 @@ export async function collectRuntimeHostFailureDiagnostic(packageRoot, rootPath,
       controlDirectory,
       startupAuthority.RUNTIME_HOST_STARTUP_DIAGNOSTIC_FILE,
     );
-    await addPathEvidence(
-      diagnostic.paths,
-      'startup_diagnostic',
-      startupPath,
-      readPathSecurity,
-      false,
-    );
+    addPathEvidence(diagnostic.paths, 'startup_diagnostic', startupPath);
     const startup = await startupAuthority.readCandidateStartupDiagnostic(capability.rootId);
     diagnostic.startup = startup ? { state: 'present', diagnostic: startup } : { state: 'absent' };
   } catch (error) {
     diagnostic.startup = { state: 'unavailable', error: summarizeDiagnosticError(error) };
   }
 
-  return diagnostic;
+  return finish();
 }
 
 export function renderRuntimeHostFailureDiagnostic(diagnostic) {
@@ -141,16 +153,44 @@ export function renderRuntimeHostFailureDiagnostic(diagnostic) {
   );
 }
 
-async function addPathEvidence(paths, role, path, readPathSecurity, includeSecurity) {
-  const evidence = inspectDiagnosticPath(role, path);
-  if (includeSecurity && evidence.state === 'present') {
-    try {
-      evidence.security = await readPathSecurity(path);
-    } catch (error) {
-      evidence.security = { state: 'unavailable', error: summarizeDiagnosticError(error) };
+export async function retireCollectedRuntimeHostStartupDiagnostic(
+  packageRoot,
+  diagnostic,
+  options = {},
+) {
+  const startupAttemptId = diagnostic.startup?.diagnostic?.startupAttemptId;
+  const rootId = diagnostic.storageAuthority?.rootId;
+  if (typeof rootId !== 'string' || typeof startupAttemptId !== 'string') return false;
+  const loadInstalled = options.loadInstalled ?? importInstalled;
+  const startupAuthority = await loadInstalled(packageRoot, STARTUP_DIAGNOSTIC_MODULE);
+  return startupAuthority.clearSelectedCandidateStartupDiagnostic(rootId, startupAttemptId);
+}
+
+function addPathEvidence(paths, role, path) {
+  paths.push(inspectDiagnosticPath(role, path));
+}
+
+async function addPathSecurityEvidence(paths, readPathSecurityBatch) {
+  const evidence = paths.filter(
+    (entry) =>
+      entry.state === 'present' &&
+      (entry.role === 'root' ||
+        entry.role === 'control_root' ||
+        entry.role === 'control_directory'),
+  );
+  if (evidence.length === 0) return;
+  try {
+    const results = await readPathSecurityBatch(evidence.map(({ path }) => path));
+    if (!Array.isArray(results) || results.length !== evidence.length) {
+      throw new Error('Windows path security probe returned an invalid result count');
     }
+    for (let index = 0; index < evidence.length; index += 1) {
+      evidence[index].security = results[index];
+    }
+  } catch (error) {
+    const unavailable = { state: 'unavailable', error: summarizeDiagnosticError(error) };
+    for (const entry of evidence) entry.security = unavailable;
   }
-  paths.push(evidence);
 }
 
 function inspectDiagnosticPath(role, path) {
@@ -169,7 +209,7 @@ function inspectDiagnosticPath(role, path) {
   }
 }
 
-function readWindowsPathSecurity(path, environment) {
+function readWindowsPathSecurityBatch(paths, environment) {
   const systemRoot = environment.SystemRoot;
   if (!systemRoot) throw new Error('SystemRoot is unavailable');
   const output = execFileSync(
@@ -177,8 +217,8 @@ function readWindowsPathSecurity(path, environment) {
     ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', WINDOWS_PATH_SECURITY_SCRIPT],
     {
       encoding: 'utf8',
-      env: { ...environment, [WINDOWS_DIAGNOSTIC_PATH_ENV]: path },
-      timeout: 10_000,
+      env: { ...environment, [WINDOWS_DIAGNOSTIC_PATHS_ENV]: JSON.stringify(paths) },
+      timeout: WINDOWS_PATH_SECURITY_TIMEOUT_MS,
       windowsHide: true,
     },
   );
@@ -186,16 +226,52 @@ function readWindowsPathSecurity(path, environment) {
   if (
     typeof parsed !== 'object' ||
     parsed === null ||
-    typeof parsed.owner !== 'string' ||
-    typeof parsed.sddl !== 'string'
+    !Array.isArray(parsed.results) ||
+    parsed.results.length !== paths.length
   ) {
     throw new Error('Windows path security probe returned an invalid response');
   }
-  return {
-    state: 'present',
-    owner: parsed.owner.slice(0, WINDOWS_SECURITY_TEXT_MAX_CHARS),
-    sddl: parsed.sddl.slice(0, WINDOWS_SECURITY_TEXT_MAX_CHARS),
-  };
+  return parsed.results.map(decodeWindowsPathSecurity);
+}
+
+function decodeWindowsPathSecurity(value) {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    value.state === 'present' &&
+    typeof value.owner === 'string' &&
+    typeof value.sddl === 'string'
+  ) {
+    return {
+      state: 'present',
+      owner: value.owner.slice(0, WINDOWS_SECURITY_TEXT_MAX_CHARS),
+      sddl: value.sddl.slice(0, WINDOWS_SECURITY_TEXT_MAX_CHARS),
+    };
+  }
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    value.state === 'unavailable' &&
+    typeof value.error === 'object' &&
+    value.error !== null &&
+    typeof value.error.message === 'string'
+  ) {
+    return {
+      state: 'unavailable',
+      error: compactObject({
+        name:
+          typeof value.error.name === 'string'
+            ? boundedDiagnosticString(value.error.name)
+            : undefined,
+        hresult: Number.isSafeInteger(value.error.hresult) ? value.error.hresult : undefined,
+        nativeErrorCode: Number.isSafeInteger(value.error.nativeErrorCode)
+          ? value.error.nativeErrorCode
+          : undefined,
+        message: boundedDiagnosticString(value.error.message),
+      }),
+    };
+  }
+  throw new Error('Windows path security probe returned an invalid path result');
 }
 
 function summarizeRegistration(registration, expectedRootId) {

--- a/scripts/release-cli-runtime-host-diagnostics.mjs
+++ b/scripts/release-cli-runtime-host-diagnostics.mjs
@@ -1,0 +1,255 @@
+import { execFileSync } from 'node:child_process';
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const RUNTIME_HOST_DIAGNOSTIC_MAX_BYTES = 32 * 1024;
+const WINDOWS_SECURITY_TEXT_MAX_CHARS = 4 * 1024;
+const DIAGNOSTIC_TEXT_MAX_CHARS = 2 * 1024;
+const WINDOWS_DIAGNOSTIC_PATH_ENV = 'MAKA_RUNTIME_HOST_DIAGNOSTIC_PATH';
+const WINDOWS_PATH_SECURITY_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+$acl = Get-Acl -LiteralPath $env:${WINDOWS_DIAGNOSTIC_PATH_ENV}
+[Console]::Out.Write((@{
+  owner = $acl.Owner
+  sddl = $acl.Sddl
+} | ConvertTo-Json -Compress))
+`;
+
+const STORAGE_AUTHORITY_MODULE = 'node_modules/@maka/storage/dist/root-authority.js';
+const REGISTRATION_MODULE = 'node_modules/@maka/runtime-host/dist/control/registration.js';
+const STARTUP_DIAGNOSTIC_MODULE =
+  'node_modules/@maka/runtime-host/dist/control/startup-diagnostic.js';
+
+export async function collectRuntimeHostFailureDiagnostic(packageRoot, rootPath, options = {}) {
+  const platform = options.platform ?? process.platform;
+  const environment = options.environment ?? process.env;
+  const loadInstalled = options.loadInstalled ?? importInstalled;
+  const readPathSecurity =
+    options.readPathSecurity ??
+    (platform === 'win32'
+      ? (path) => readWindowsPathSecurity(path, environment)
+      : async () => undefined);
+  const diagnostic = {
+    schemaVersion: 1,
+    platform,
+    architecture: options.architecture ?? process.arch,
+    runner: compactObject({
+      imageOS: boundedOptionalString(environment.ImageOS),
+      imageVersion: boundedOptionalString(environment.ImageVersion),
+      name: boundedOptionalString(environment.RUNNER_NAME),
+      environment: boundedOptionalString(environment.RUNNER_ENVIRONMENT),
+    }),
+    paths: [],
+  };
+
+  await addPathEvidence(diagnostic.paths, 'root', rootPath, readPathSecurity, true);
+
+  let authority;
+  try {
+    authority = await loadInstalled(packageRoot, STORAGE_AUTHORITY_MODULE);
+  } catch (error) {
+    diagnostic.storageAuthority = { state: 'unavailable', error: summarizeDiagnosticError(error) };
+    return diagnostic;
+  }
+
+  await addPathEvidence(
+    diagnostic.paths,
+    'root_marker',
+    join(rootPath, authority.STORAGE_ROOT_MARKER_FILE),
+    readPathSecurity,
+    false,
+  );
+
+  let capability;
+  try {
+    capability = await authority.discoverMarkedStorageRoot({ path: rootPath });
+    diagnostic.storageAuthority = { state: 'valid', rootId: capability.rootId };
+  } catch (error) {
+    diagnostic.storageAuthority = { state: 'invalid', error: summarizeDiagnosticError(error) };
+  }
+
+  let controlRoot;
+  try {
+    controlRoot = authority.resolveRootControlNamespace();
+    await addPathEvidence(diagnostic.paths, 'control_root', controlRoot, readPathSecurity, true);
+  } catch (error) {
+    diagnostic.controlNamespace = {
+      state: 'unavailable',
+      error: summarizeDiagnosticError(error),
+    };
+  }
+  if (!capability || !controlRoot) return diagnostic;
+
+  const controlDirectory = join(controlRoot, capability.rootId);
+  await addPathEvidence(
+    diagnostic.paths,
+    'control_directory',
+    controlDirectory,
+    readPathSecurity,
+    true,
+  );
+
+  try {
+    const registrationAuthority = await loadInstalled(packageRoot, REGISTRATION_MODULE);
+    const registrationPath = join(
+      controlDirectory,
+      registrationAuthority.RUNTIME_HOST_REGISTRATION_FILE,
+    );
+    await addPathEvidence(
+      diagnostic.paths,
+      'registration',
+      registrationPath,
+      readPathSecurity,
+      false,
+    );
+    const registration = await registrationAuthority.readHostRegistration(controlDirectory);
+    diagnostic.registration = registration
+      ? summarizeRegistration(registration, capability.rootId)
+      : { state: 'absent' };
+  } catch (error) {
+    diagnostic.registration = { state: 'unavailable', error: summarizeDiagnosticError(error) };
+  }
+
+  try {
+    const startupAuthority = await loadInstalled(packageRoot, STARTUP_DIAGNOSTIC_MODULE);
+    const startupPath = join(
+      controlDirectory,
+      startupAuthority.RUNTIME_HOST_STARTUP_DIAGNOSTIC_FILE,
+    );
+    await addPathEvidence(
+      diagnostic.paths,
+      'startup_diagnostic',
+      startupPath,
+      readPathSecurity,
+      false,
+    );
+    const startup = await startupAuthority.readCandidateStartupDiagnostic(capability.rootId);
+    diagnostic.startup = startup ? { state: 'present', diagnostic: startup } : { state: 'absent' };
+  } catch (error) {
+    diagnostic.startup = { state: 'unavailable', error: summarizeDiagnosticError(error) };
+  }
+
+  return diagnostic;
+}
+
+export function renderRuntimeHostFailureDiagnostic(diagnostic) {
+  return truncateUtf8Text(
+    JSON.stringify(diagnostic),
+    RUNTIME_HOST_DIAGNOSTIC_MAX_BYTES,
+    '<diagnostic truncated>',
+  );
+}
+
+async function addPathEvidence(paths, role, path, readPathSecurity, includeSecurity) {
+  const evidence = inspectDiagnosticPath(role, path);
+  if (includeSecurity && evidence.state === 'present') {
+    try {
+      evidence.security = await readPathSecurity(path);
+    } catch (error) {
+      evidence.security = { state: 'unavailable', error: summarizeDiagnosticError(error) };
+    }
+  }
+  paths.push(evidence);
+}
+
+function inspectDiagnosticPath(role, path) {
+  try {
+    const pathStat = statSync(path);
+    return {
+      role,
+      path,
+      state: 'present',
+      kind: pathStat.isDirectory() ? 'directory' : pathStat.isFile() ? 'file' : 'other',
+      size: pathStat.size,
+      mode: pathStat.mode,
+    };
+  } catch (error) {
+    return { role, path, state: 'unavailable', error: summarizeDiagnosticError(error) };
+  }
+}
+
+function readWindowsPathSecurity(path, environment) {
+  const systemRoot = environment.SystemRoot;
+  if (!systemRoot) throw new Error('SystemRoot is unavailable');
+  const output = execFileSync(
+    join(systemRoot, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'),
+    ['-NoLogo', '-NoProfile', '-NonInteractive', '-Command', WINDOWS_PATH_SECURITY_SCRIPT],
+    {
+      encoding: 'utf8',
+      env: { ...environment, [WINDOWS_DIAGNOSTIC_PATH_ENV]: path },
+      timeout: 10_000,
+      windowsHide: true,
+    },
+  );
+  const parsed = JSON.parse(output);
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof parsed.owner !== 'string' ||
+    typeof parsed.sddl !== 'string'
+  ) {
+    throw new Error('Windows path security probe returned an invalid response');
+  }
+  return {
+    state: 'present',
+    owner: parsed.owner.slice(0, WINDOWS_SECURITY_TEXT_MAX_CHARS),
+    sddl: parsed.sddl.slice(0, WINDOWS_SECURITY_TEXT_MAX_CHARS),
+  };
+}
+
+function summarizeRegistration(registration, expectedRootId) {
+  return compactObject({
+    state: 'present',
+    schemaVersion: registration.schemaVersion,
+    rootIdMatches: registration.rootId === expectedRootId,
+    hostEpoch: registration.hostEpoch,
+    lifecycleState: registration.state,
+    lifecycleMode: registration.lifecycleMode,
+    pid: registration.pid,
+    endpointKind:
+      typeof registration.endpoint === 'string' && registration.endpoint.startsWith('\\\\.\\pipe\\')
+        ? 'windows_named_pipe'
+        : 'other',
+  });
+}
+
+function summarizeDiagnosticError(error, depth = 0) {
+  if (!(error instanceof Error)) return { message: boundedDiagnosticString(String(error)) };
+  return compactObject({
+    name: boundedDiagnosticString(error.name),
+    code: typeof error.code === 'string' || typeof error.code === 'number' ? error.code : undefined,
+    message: boundedDiagnosticString(error.message),
+    cause:
+      depth < 3 && error.cause !== undefined
+        ? summarizeDiagnosticError(error.cause, depth + 1)
+        : undefined,
+  });
+}
+
+function compactObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function boundedOptionalString(value) {
+  return typeof value === 'string' ? boundedDiagnosticString(value) : undefined;
+}
+
+function boundedDiagnosticString(value) {
+  return value.slice(0, DIAGNOSTIC_TEXT_MAX_CHARS);
+}
+
+function truncateUtf8Text(value, maximumBytes, marker) {
+  const encoded = Buffer.from(value, 'utf8');
+  if (encoded.byteLength <= maximumBytes) return value;
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  const prefix = encoded
+    .subarray(0, Math.max(0, maximumBytes - markerBytes))
+    .toString('utf8')
+    .replace(/\uFFFD$/u, '');
+  return `${prefix}${marker}`;
+}
+
+function importInstalled(packageRoot, relativePath) {
+  return import(pathToFileURL(join(packageRoot, relativePath)).href);
+}

--- a/scripts/release-cli-runtime-host-diagnostics.test.mjs
+++ b/scripts/release-cli-runtime-host-diagnostics.test.mjs
@@ -3,9 +3,13 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { collectRuntimeHostFailureDiagnostic } from './release-cli-runtime-host-diagnostics.mjs';
+import {
+  collectRuntimeHostFailureDiagnostic,
+  retireCollectedRuntimeHostStartupDiagnostic,
+} from './release-cli-runtime-host-diagnostics.mjs';
 
 const ROOT_ID = 'a'.repeat(64);
+const STARTUP_ATTEMPT_ID = '00000000-0000-4000-8000-000000000001';
 
 test('collects canonical Runtime Host evidence without invoking mutating storage authority', async () => {
   const fixture = createFixture();
@@ -13,6 +17,7 @@ test('collects canonical Runtime Host evidence without invoking mutating storage
     const startupDiagnostic = {
       schemaVersion: 1,
       rootId: ROOT_ID,
+      startupAttemptId: STARTUP_ATTEMPT_ID,
       candidatePid: 123,
       capturedAt: '2026-08-19T00:00:00.000Z',
       reason: 'local_ipc_security_failed',
@@ -59,9 +64,13 @@ test('collects canonical Runtime Host evidence without invoking mutating storage
         }
         throw new Error(`Unexpected installed module: ${relativePath}`);
       },
-      readPathSecurity: async (path) => {
-        securityCalls.push(path);
-        return { state: 'present', owner: 'runner\\user', sddl: 'O:SYD:P' };
+      readPathSecurityBatch: async (paths) => {
+        securityCalls.push(paths);
+        return paths.map(() => ({
+          state: 'present',
+          owner: 'runner\\user',
+          sddl: 'O:SYD:P',
+        }));
       },
     });
 
@@ -76,12 +85,31 @@ test('collects canonical Runtime Host evidence without invoking mutating storage
         'startup_diagnostic',
       ],
     );
-    assert.deepEqual(securityCalls, [fixture.root, fixture.controlRoot, fixture.controlDirectory]);
+    assert.deepEqual(securityCalls, [
+      [fixture.root, fixture.controlRoot, fixture.controlDirectory],
+    ]);
     assert.equal(diagnostic.paths[0].security.owner, 'runner\\user');
     assert.equal(diagnostic.storageAuthority.state, 'valid');
     assert.equal(diagnostic.registration.rootIdMatches, true);
     assert.deepEqual(diagnostic.startup, { state: 'present', diagnostic: startupDiagnostic });
     assert.equal(diagnostic.runner.architecture, undefined);
+
+    let retired;
+    assert.equal(
+      await retireCollectedRuntimeHostStartupDiagnostic('/installed', diagnostic, {
+        loadInstalled: async (_packageRoot, relativePath) => {
+          assert.match(relativePath, /startup-diagnostic\.js$/u);
+          return {
+            clearSelectedCandidateStartupDiagnostic: async (rootId, startupAttemptId) => {
+              retired = { rootId, startupAttemptId };
+              return true;
+            },
+          };
+        },
+      }),
+      true,
+    );
+    assert.deepEqual(retired, { rootId: ROOT_ID, startupAttemptId: STARTUP_ATTEMPT_ID });
   } finally {
     fixture.cleanup();
   }
@@ -106,15 +134,22 @@ test('keeps read-only path evidence when root authority validation fails', async
           resolveRootControlNamespace: () => fixture.controlRoot,
         };
       },
-      readPathSecurity: async (path) => {
-        if (path === fixture.root) throw Object.assign(new Error('ACL lookup failed'), { code: 5 });
-        return { state: 'present', owner: 'runner\\user', sddl: 'O:SYD:P' };
+      readPathSecurityBatch: async (paths) => {
+        return paths.map((path) =>
+          path === fixture.root
+            ? {
+                state: 'unavailable',
+                error: { name: 'UnauthorizedAccessException', nativeErrorCode: 5 },
+              }
+            : { state: 'present', owner: 'runner\\user', sddl: 'O:SYD:P' },
+        );
       },
     });
 
     assert.equal(diagnostic.storageAuthority.state, 'invalid');
     assert.equal(diagnostic.storageAuthority.error.cause.code, 'EACCES');
     assert.equal(diagnostic.paths[0].security.state, 'unavailable');
+    assert.equal(diagnostic.paths[0].security.error.nativeErrorCode, 5);
     assert.deepEqual(
       diagnostic.paths.map(({ role }) => role),
       ['root', 'root_marker', 'control_root'],

--- a/scripts/release-cli-runtime-host-diagnostics.test.mjs
+++ b/scripts/release-cli-runtime-host-diagnostics.test.mjs
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { collectRuntimeHostFailureDiagnostic } from './release-cli-runtime-host-diagnostics.mjs';
+
+const ROOT_ID = 'a'.repeat(64);
+
+test('collects canonical Runtime Host evidence without invoking mutating storage authority', async () => {
+  const fixture = createFixture();
+  try {
+    const startupDiagnostic = {
+      schemaVersion: 1,
+      rootId: ROOT_ID,
+      candidatePid: 123,
+      capturedAt: '2026-08-19T00:00:00.000Z',
+      reason: 'local_ipc_security_failed',
+      errorChain: [{ message: '{"stage":"acl_apply"}' }],
+      logs: ['endpoint setup failed'],
+    };
+    const securityCalls = [];
+    const diagnostic = await collectRuntimeHostFailureDiagnostic('/installed', fixture.root, {
+      platform: 'win32',
+      architecture: 'x64',
+      environment: {
+        ImageOS: 'win25',
+        ImageVersion: '20260817.1',
+        RUNNER_NAME: 'hosted-runner',
+        RUNNER_ENVIRONMENT: 'github-hosted',
+      },
+      loadInstalled: async (_packageRoot, relativePath) => {
+        if (relativePath.endsWith('/root-authority.js')) {
+          return {
+            STORAGE_ROOT_MARKER_FILE: '.maka-storage-root.json',
+            discoverMarkedStorageRoot: async () => ({ rootId: ROOT_ID }),
+            resolveRootControlNamespace: () => fixture.controlRoot,
+          };
+        }
+        if (relativePath.endsWith('/registration.js')) {
+          return {
+            RUNTIME_HOST_REGISTRATION_FILE: 'registration.json',
+            readHostRegistration: async () => ({
+              schemaVersion: 1,
+              rootId: ROOT_ID,
+              hostEpoch: 'host-epoch',
+              state: 'recovering',
+              lifecycleMode: 'interactive',
+              pid: 123,
+              endpoint: '\\\\.\\pipe\\maka-runtime-host',
+            }),
+          };
+        }
+        if (relativePath.endsWith('/startup-diagnostic.js')) {
+          return {
+            RUNTIME_HOST_STARTUP_DIAGNOSTIC_FILE: 'startup-diagnostic.json',
+            readCandidateStartupDiagnostic: async () => startupDiagnostic,
+          };
+        }
+        throw new Error(`Unexpected installed module: ${relativePath}`);
+      },
+      readPathSecurity: async (path) => {
+        securityCalls.push(path);
+        return { state: 'present', owner: 'runner\\user', sddl: 'O:SYD:P' };
+      },
+    });
+
+    assert.deepEqual(
+      diagnostic.paths.map(({ role }) => role),
+      [
+        'root',
+        'root_marker',
+        'control_root',
+        'control_directory',
+        'registration',
+        'startup_diagnostic',
+      ],
+    );
+    assert.deepEqual(securityCalls, [fixture.root, fixture.controlRoot, fixture.controlDirectory]);
+    assert.equal(diagnostic.paths[0].security.owner, 'runner\\user');
+    assert.equal(diagnostic.storageAuthority.state, 'valid');
+    assert.equal(diagnostic.registration.rootIdMatches, true);
+    assert.deepEqual(diagnostic.startup, { state: 'present', diagnostic: startupDiagnostic });
+    assert.equal(diagnostic.runner.architecture, undefined);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+test('keeps read-only path evidence when root authority validation fails', async () => {
+  const fixture = createFixture({ createControlDirectory: false });
+  try {
+    const diagnostic = await collectRuntimeHostFailureDiagnostic('/installed', fixture.root, {
+      platform: 'win32',
+      loadInstalled: async (_packageRoot, relativePath) => {
+        if (!relativePath.endsWith('/root-authority.js')) {
+          throw new Error(`Unexpected installed module: ${relativePath}`);
+        }
+        return {
+          STORAGE_ROOT_MARKER_FILE: '.maka-storage-root.json',
+          discoverMarkedStorageRoot: async () => {
+            throw new Error('marker validation failed', {
+              cause: Object.assign(new Error('Access is denied'), { code: 'EACCES' }),
+            });
+          },
+          resolveRootControlNamespace: () => fixture.controlRoot,
+        };
+      },
+      readPathSecurity: async (path) => {
+        if (path === fixture.root) throw Object.assign(new Error('ACL lookup failed'), { code: 5 });
+        return { state: 'present', owner: 'runner\\user', sddl: 'O:SYD:P' };
+      },
+    });
+
+    assert.equal(diagnostic.storageAuthority.state, 'invalid');
+    assert.equal(diagnostic.storageAuthority.error.cause.code, 'EACCES');
+    assert.equal(diagnostic.paths[0].security.state, 'unavailable');
+    assert.deepEqual(
+      diagnostic.paths.map(({ role }) => role),
+      ['root', 'root_marker', 'control_root'],
+    );
+    assert.equal(existsSync(fixture.controlDirectory), false);
+  } finally {
+    fixture.cleanup();
+  }
+});
+
+function createFixture({ createControlDirectory = true } = {}) {
+  const base = mkdtempSync(join(tmpdir(), 'maka-runtime-host-diagnostic-test-'));
+  const root = join(base, 'root');
+  const controlRoot = join(base, 'control');
+  const controlDirectory = join(controlRoot, ROOT_ID);
+  const registrationPath = join(controlDirectory, 'registration.json');
+  const startupPath = join(controlDirectory, 'startup-diagnostic.json');
+  mkdirSync(root, { recursive: true });
+  mkdirSync(controlRoot, { recursive: true });
+  writeFileSync(join(root, '.maka-storage-root.json'), '{}\n');
+  if (createControlDirectory) {
+    mkdirSync(controlDirectory, { recursive: true });
+    writeFileSync(registrationPath, '{}\n');
+    writeFileSync(startupPath, '{}\n');
+  }
+  return {
+    root,
+    controlRoot,
+    controlDirectory,
+    registrationPath,
+    startupPath,
+    cleanup: () => rmSync(base, { recursive: true, force: true }),
+  };
+}

--- a/scripts/smoke-release-cli-package.mjs
+++ b/scripts/smoke-release-cli-package.mjs
@@ -17,13 +17,15 @@ import { tmpdir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { validateCliReleaseArtifactMetrics } from './release-cli-artifact-policy.mjs';
+import {
+  collectRuntimeHostFailureDiagnostic,
+  renderRuntimeHostFailureDiagnostic,
+} from './release-cli-runtime-host-diagnostics.mjs';
 import { npmSpawnOptions } from './npm-spawn.mjs';
 
 const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 const PROCESS_TIMEOUT_MS = 90_000;
 const RUNTIME_HOST_SHUTDOWN_TIMEOUT_MS = 45_000;
-const RUNTIME_HOST_DIAGNOSTIC_MAX_BYTES = 32 * 1024;
-const WINDOWS_ACL_DIAGNOSTIC_MAX_CHARS = 8 * 1024;
 const MODEL_ID = 'maka-release-smoke-model';
 const CONNECTION_SLUG = 'maka-release-smoke';
 const API_KEY = 'maka-release-smoke-key';
@@ -805,135 +807,9 @@ async function settleRuntimeHost(packageRoot, rootPath, requireNaturalShutdown) 
 
 async function reportRuntimeHostFailureDiagnostics(packageRoot, rootPath) {
   if (process.platform !== 'win32') return;
-  const diagnostic = {
-    schemaVersion: 1,
-    platform: process.platform,
-    architecture: process.arch,
-    runner: compactObject({
-      imageOS: process.env.ImageOS,
-      imageVersion: process.env.ImageVersion,
-      name: process.env.RUNNER_NAME,
-      architecture: process.env.RUNNER_ARCH,
-      environment: process.env.RUNNER_ENVIRONMENT,
-    }),
-    rootPath,
-  };
-  try {
-    const authority = await importInstalled(
-      packageRoot,
-      'node_modules/@maka/storage/dist/root-authority.js',
-    );
-    const capability = await authority.resolveStorageRoot({ path: rootPath, kind: 'interactive' });
-    const { controlRoot, controlDirectory } =
-      await authority.prepareStorageRootControlDirectory(capability);
-    const registrationPath = join(controlDirectory, 'registration.json');
-    Object.assign(diagnostic, {
-      rootId: capability.rootId,
-      controlRoot,
-      controlDirectory,
-      registration: readSafeRegistrationSummary(registrationPath, capability.rootId),
-      paths: [rootPath, controlRoot, controlDirectory, registrationPath].map(inspectDiagnosticPath),
-      accessControl: [rootPath, controlRoot, controlDirectory]
-        .filter((path) => existsSync(path))
-        .map(readWindowsAccessControl),
-    });
-  } catch (error) {
-    diagnostic.diagnosticError = summarizeDiagnosticError(error);
-  }
-  const rendered = truncateUtf8Text(
-    JSON.stringify(diagnostic),
-    RUNTIME_HOST_DIAGNOSTIC_MAX_BYTES,
-    '<diagnostic truncated>',
-  );
+  const diagnostic = await collectRuntimeHostFailureDiagnostic(packageRoot, rootPath);
+  const rendered = renderRuntimeHostFailureDiagnostic(diagnostic);
   writeSync(2, `[release-cli-validation] Runtime Host failure diagnostics: ${rendered}\n`);
-}
-
-function readSafeRegistrationSummary(path, expectedRootId) {
-  if (!existsSync(path)) return { state: 'absent' };
-  try {
-    const registration = JSON.parse(readFileSync(path, 'utf8'));
-    return compactObject({
-      state: 'present',
-      schemaVersion: registration.schemaVersion,
-      rootIdMatches: registration.rootId === expectedRootId,
-      hostEpoch: registration.hostEpoch,
-      lifecycleState: registration.state,
-      lifecycleMode: registration.lifecycleMode,
-      pid: registration.pid,
-      endpointKind:
-        typeof registration.endpoint === 'string' &&
-        registration.endpoint.startsWith('\\\\.\\pipe\\')
-          ? 'windows_named_pipe'
-          : 'other',
-    });
-  } catch (error) {
-    return { state: 'unreadable', error: summarizeDiagnosticError(error) };
-  }
-}
-
-function inspectDiagnosticPath(path) {
-  try {
-    const pathStat = statSync(path);
-    return {
-      path,
-      state: 'present',
-      kind: pathStat.isDirectory() ? 'directory' : pathStat.isFile() ? 'file' : 'other',
-      size: pathStat.size,
-      mode: pathStat.mode,
-    };
-  } catch (error) {
-    return { path, state: 'unavailable', error: summarizeDiagnosticError(error) };
-  }
-}
-
-function readWindowsAccessControl(path) {
-  const systemRoot = process.env.SystemRoot;
-  if (!systemRoot) return { path, error: { message: 'SystemRoot is unavailable' } };
-  try {
-    const output = execFileSync(join(systemRoot, 'System32', 'icacls.exe'), [path], {
-      encoding: 'utf8',
-      timeout: 10_000,
-      windowsHide: true,
-    });
-    return { path, output: output.slice(0, WINDOWS_ACL_DIAGNOSTIC_MAX_CHARS).trim() };
-  } catch (error) {
-    return {
-      path,
-      error: summarizeDiagnosticError(error),
-      stdout:
-        typeof error?.stdout === 'string'
-          ? error.stdout.slice(0, WINDOWS_ACL_DIAGNOSTIC_MAX_CHARS).trim()
-          : undefined,
-      stderr:
-        typeof error?.stderr === 'string'
-          ? error.stderr.slice(0, WINDOWS_ACL_DIAGNOSTIC_MAX_CHARS).trim()
-          : undefined,
-    };
-  }
-}
-
-function compactObject(value) {
-  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
-}
-
-function summarizeDiagnosticError(error) {
-  if (!(error instanceof Error)) return { message: String(error) };
-  return compactObject({
-    name: error.name,
-    code: error.code,
-    message: error.message,
-  });
-}
-
-function truncateUtf8Text(value, maximumBytes, marker) {
-  const encoded = Buffer.from(value, 'utf8');
-  if (encoded.byteLength <= maximumBytes) return value;
-  const markerBytes = Buffer.byteLength(marker, 'utf8');
-  const prefix = encoded
-    .subarray(0, Math.max(0, maximumBytes - markerBytes))
-    .toString('utf8')
-    .replace(/\uFFFD$/u, '');
-  return `${prefix}${marker}`;
 }
 
 async function terminateRegisteredProcess(pid) {

--- a/scripts/smoke-release-cli-package.mjs
+++ b/scripts/smoke-release-cli-package.mjs
@@ -22,6 +22,8 @@ import { npmSpawnOptions } from './npm-spawn.mjs';
 const MAX_OUTPUT_BYTES = 16 * 1024 * 1024;
 const PROCESS_TIMEOUT_MS = 90_000;
 const RUNTIME_HOST_SHUTDOWN_TIMEOUT_MS = 45_000;
+const RUNTIME_HOST_DIAGNOSTIC_MAX_BYTES = 32 * 1024;
+const WINDOWS_ACL_DIAGNOSTIC_MAX_CHARS = 8 * 1024;
 const MODEL_ID = 'maka-release-smoke-model';
 const CONNECTION_SLUG = 'maka-release-smoke';
 const API_KEY = 'maka-release-smoke-key';
@@ -758,6 +760,9 @@ async function runCleanupSteps(steps) {
 }
 
 async function settleRuntimeHost(packageRoot, rootPath, requireNaturalShutdown) {
+  if (!requireNaturalShutdown) {
+    await reportRuntimeHostFailureDiagnostics(packageRoot, rootPath).catch(() => undefined);
+  }
   let naturalShutdownError;
   try {
     await waitForRuntimeHostShutdown(packageRoot, rootPath);
@@ -796,6 +801,139 @@ async function settleRuntimeHost(packageRoot, rootPath, requireNaturalShutdown) 
   }
   if (forcedCleanupError) throw forcedCleanupError;
   if (requireNaturalShutdown) throw naturalShutdownError;
+}
+
+async function reportRuntimeHostFailureDiagnostics(packageRoot, rootPath) {
+  if (process.platform !== 'win32') return;
+  const diagnostic = {
+    schemaVersion: 1,
+    platform: process.platform,
+    architecture: process.arch,
+    runner: compactObject({
+      imageOS: process.env.ImageOS,
+      imageVersion: process.env.ImageVersion,
+      name: process.env.RUNNER_NAME,
+      architecture: process.env.RUNNER_ARCH,
+      environment: process.env.RUNNER_ENVIRONMENT,
+    }),
+    rootPath,
+  };
+  try {
+    const authority = await importInstalled(
+      packageRoot,
+      'node_modules/@maka/storage/dist/root-authority.js',
+    );
+    const capability = await authority.resolveStorageRoot({ path: rootPath, kind: 'interactive' });
+    const { controlRoot, controlDirectory } =
+      await authority.prepareStorageRootControlDirectory(capability);
+    const registrationPath = join(controlDirectory, 'registration.json');
+    Object.assign(diagnostic, {
+      rootId: capability.rootId,
+      controlRoot,
+      controlDirectory,
+      registration: readSafeRegistrationSummary(registrationPath, capability.rootId),
+      paths: [rootPath, controlRoot, controlDirectory, registrationPath].map(inspectDiagnosticPath),
+      accessControl: [rootPath, controlRoot, controlDirectory]
+        .filter((path) => existsSync(path))
+        .map(readWindowsAccessControl),
+    });
+  } catch (error) {
+    diagnostic.diagnosticError = summarizeDiagnosticError(error);
+  }
+  const rendered = truncateUtf8Text(
+    JSON.stringify(diagnostic),
+    RUNTIME_HOST_DIAGNOSTIC_MAX_BYTES,
+    '<diagnostic truncated>',
+  );
+  writeSync(2, `[release-cli-validation] Runtime Host failure diagnostics: ${rendered}\n`);
+}
+
+function readSafeRegistrationSummary(path, expectedRootId) {
+  if (!existsSync(path)) return { state: 'absent' };
+  try {
+    const registration = JSON.parse(readFileSync(path, 'utf8'));
+    return compactObject({
+      state: 'present',
+      schemaVersion: registration.schemaVersion,
+      rootIdMatches: registration.rootId === expectedRootId,
+      hostEpoch: registration.hostEpoch,
+      lifecycleState: registration.state,
+      lifecycleMode: registration.lifecycleMode,
+      pid: registration.pid,
+      endpointKind:
+        typeof registration.endpoint === 'string' &&
+        registration.endpoint.startsWith('\\\\.\\pipe\\')
+          ? 'windows_named_pipe'
+          : 'other',
+    });
+  } catch (error) {
+    return { state: 'unreadable', error: summarizeDiagnosticError(error) };
+  }
+}
+
+function inspectDiagnosticPath(path) {
+  try {
+    const pathStat = statSync(path);
+    return {
+      path,
+      state: 'present',
+      kind: pathStat.isDirectory() ? 'directory' : pathStat.isFile() ? 'file' : 'other',
+      size: pathStat.size,
+      mode: pathStat.mode,
+    };
+  } catch (error) {
+    return { path, state: 'unavailable', error: summarizeDiagnosticError(error) };
+  }
+}
+
+function readWindowsAccessControl(path) {
+  const systemRoot = process.env.SystemRoot;
+  if (!systemRoot) return { path, error: { message: 'SystemRoot is unavailable' } };
+  try {
+    const output = execFileSync(join(systemRoot, 'System32', 'icacls.exe'), [path], {
+      encoding: 'utf8',
+      timeout: 10_000,
+      windowsHide: true,
+    });
+    return { path, output: output.slice(0, WINDOWS_ACL_DIAGNOSTIC_MAX_CHARS).trim() };
+  } catch (error) {
+    return {
+      path,
+      error: summarizeDiagnosticError(error),
+      stdout:
+        typeof error?.stdout === 'string'
+          ? error.stdout.slice(0, WINDOWS_ACL_DIAGNOSTIC_MAX_CHARS).trim()
+          : undefined,
+      stderr:
+        typeof error?.stderr === 'string'
+          ? error.stderr.slice(0, WINDOWS_ACL_DIAGNOSTIC_MAX_CHARS).trim()
+          : undefined,
+    };
+  }
+}
+
+function compactObject(value) {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function summarizeDiagnosticError(error) {
+  if (!(error instanceof Error)) return { message: String(error) };
+  return compactObject({
+    name: error.name,
+    code: error.code,
+    message: error.message,
+  });
+}
+
+function truncateUtf8Text(value, maximumBytes, marker) {
+  const encoded = Buffer.from(value, 'utf8');
+  if (encoded.byteLength <= maximumBytes) return value;
+  const markerBytes = Buffer.byteLength(marker, 'utf8');
+  const prefix = encoded
+    .subarray(0, Math.max(0, maximumBytes - markerBytes))
+    .toString('utf8')
+    .replace(/\uFFFD$/u, '');
+  return `${prefix}${marker}`;
 }
 
 async function terminateRegisteredProcess(pid) {

--- a/scripts/smoke-release-cli-package.mjs
+++ b/scripts/smoke-release-cli-package.mjs
@@ -20,6 +20,7 @@ import { validateCliReleaseArtifactMetrics } from './release-cli-artifact-policy
 import {
   collectRuntimeHostFailureDiagnostic,
   renderRuntimeHostFailureDiagnostic,
+  retireCollectedRuntimeHostStartupDiagnostic,
 } from './release-cli-runtime-host-diagnostics.mjs';
 import { npmSpawnOptions } from './npm-spawn.mjs';
 
@@ -810,6 +811,7 @@ async function reportRuntimeHostFailureDiagnostics(packageRoot, rootPath) {
   const diagnostic = await collectRuntimeHostFailureDiagnostic(packageRoot, rootPath);
   const rendered = renderRuntimeHostFailureDiagnostic(diagnostic);
   writeSync(2, `[release-cli-validation] Runtime Host failure diagnostics: ${rendered}\n`);
+  await retireCollectedRuntimeHostStartupDiagnostic(packageRoot, diagnostic);
 }
 
 async function terminateRegisteredProcess(pid) {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Preserve actionable evidence when Windows Runtime Host startup fails:

- carry Local IPC security failures across the detached Candidate boundary as a distinct, retryable diagnostic code;
- retain bounded PowerShell stage, SID, exit, and exception evidence for direct Local IPC failures;
- print a bounded Runtime Host root, registration, and ACL snapshot before installed CLI validation cleans up its isolated state.

Fixes #3237

## Verification

- Runtime Host typecheck and build
- 23 focused startup, endpoint, and owned-Candidate tests
- 46 Host-kernel tests
- Biome, `node --check`, and `git diff --check`

The full Runtime Host suite reached 980/982; its two process-timing failures pass in isolation and are tracked in #3190 and #3239. The Windows workflows remain the authoritative platform validation for this draft.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with implementation, tests, and validation. M4n5ter is the contributor of record.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>中文</summary>

## 摘要

在 Windows Runtime Host 启动失败时保留可定位的证据：

- 将 Local IPC 安全失败以独立且可重试的诊断码带过 detached Candidate 边界；
- 为直接 Local IPC 失败保留有界的 PowerShell 阶段、SID、退出状态和异常证据；
- 在已安装 CLI 验收清理隔离状态前，输出有界的 Runtime Host 根目录、注册和 ACL 快照。

修复 #3237

## 验证

- Runtime Host typecheck 与 build
- 23 项启动、endpoint 和 owned-Candidate 定向测试
- 46 项 Host-kernel 测试
- Biome、`node --check` 与 `git diff --check`

Runtime Host 全量套件通过 980/982；两项进程时序失败均可在独立运行时通过，并已由 #3190 和 #3239 跟踪。此 Draft PR 的 Windows workflow 是权威平台验证。

## AI 使用

- [ ] 没有生成式工具作出实质贡献
- [x] 生成式工具作出了实质贡献

工具与范围：OpenAI Codex 协助实现、测试和验证。M4n5ter 是记录在案的贡献者。

## 检查清单

- [x] 测试覆盖本次变更，并会在缺少变更时失败
- [x] lint、format、typecheck 和受影响测试在本地通过

本 PR 是否改变行为？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
