### PR TITLE
feat(release): verify Windows automatic updates end to end

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -25,7 +25,7 @@ jobs:
             runner: windows-2025
     runs-on: ${{ matrix.runner }}
     environment: release
-    timeout-minutes: 45
+    timeout-minutes: 60
     defaults:
       run:
         # Windows runners default to pwsh; the release steps are written once,
@@ -152,6 +152,19 @@ jobs:
           npm run verify:windows-installer -- \
             "${{ steps.release.outputs.exe }}" \
             "${{ steps.previous.outputs.exe }}"
+
+      - name: Build the version-bumped autoupdate installer
+        if: matrix.platform == 'windows'
+        run: npm run package:windows-autoupdate-next
+
+      # The fake-versioned artifacts live outside apps/desktop/release, so the
+      # upload globs below can never pick them up.
+      - name: Verify automatic update end to end
+        if: matrix.platform == 'windows'
+        run: |
+          npm run verify:windows-autoupdate -- \
+            "${{ steps.release.outputs.exe }}" \
+            apps/desktop/release-autoupdate-next
 
       - name: Upload the verified release assets
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -23,8 +23,10 @@ on:
       - 'scripts/verify-windows-installer-lifecycle.mjs'
       - 'scripts/verify-windows-autoupdate.mjs'
       - 'scripts/package-windows-autoupdate-next.mjs'
-      # The packaged updater's feed behavior is only observable on this path.
+      # The packaged updater's feed behavior — and the boot wiring that hands
+      # MAKA_UPDATE_TEST_FEED to it — is only observable on this path.
       - 'apps/desktop/src/main/app-update-service.ts'
+      - 'apps/desktop/src/main/runtime-host-boot.ts'
       - 'scripts/prepare-windows-upgrade-baseline.mjs'
       - 'scripts/windows-upgrade-baseline.json'
       - 'scripts/verify-packaged-app.mjs'

--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -21,6 +21,10 @@ on:
       - 'scripts/verify-windows-x64.mjs'
       - 'scripts/verify-windows-sandbox-e2e.mjs'
       - 'scripts/verify-windows-installer-lifecycle.mjs'
+      - 'scripts/verify-windows-autoupdate.mjs'
+      - 'scripts/package-windows-autoupdate-next.mjs'
+      # The packaged updater's feed behavior is only observable on this path.
+      - 'apps/desktop/src/main/app-update-service.ts'
       - 'scripts/prepare-windows-upgrade-baseline.mjs'
       - 'scripts/windows-upgrade-baseline.json'
       - 'scripts/verify-packaged-app.mjs'
@@ -47,7 +51,7 @@ concurrency:
 jobs:
   package:
     runs-on: windows-2025
-    timeout-minutes: 60
+    timeout-minutes: 75
     defaults:
       run:
         shell: bash
@@ -89,3 +93,13 @@ jobs:
           npm run verify:windows-installer -- \
             "apps/desktop/release/Maka-${version}-win-x64.exe" \
             "${{ steps.previous.outputs.exe }}"
+
+      - name: Build the version-bumped autoupdate installer
+        run: npm run package:windows-autoupdate-next
+
+      - name: Verify automatic update end to end
+        run: |
+          version="$(node -p "require('./apps/desktop/package.json').version")"
+          npm run verify:windows-autoupdate -- \
+            "apps/desktop/release/Maka-${version}-win-x64.exe" \
+            apps/desktop/release-autoupdate-next

--- a/apps/desktop/src/main/__tests__/app-update-service.test.ts
+++ b/apps/desktop/src/main/__tests__/app-update-service.test.ts
@@ -4,6 +4,7 @@ import { describe, test } from 'node:test';
 import type { AppUpdater } from 'electron-updater';
 import {
   createAppUpdateService,
+  resolveUpdateFeedOverride,
   type AppUpdateInstallRequest,
   type AppUpdateStatus,
 } from '../app-update-service.js';
@@ -106,6 +107,7 @@ function createHarness(input: {
   >;
   mockLatestVersion?: string;
   mockState?: 'available' | 'downloading' | 'downloaded';
+  testFeedUrl?: string;
 } = {}) {
   const updater = input.updater ?? new FakeUpdater();
   const clock = input.clock ?? new FakeClock();
@@ -121,6 +123,7 @@ function createHarness(input: {
         : { kind: 'prepared', rollback() {} }),
     mockLatestVersion: input.mockLatestVersion,
     mockState: input.mockState,
+    testFeedUrl: input.testFeedUrl,
   });
   return { clock, service, updater };
 }
@@ -148,6 +151,56 @@ describe('AppUpdateService', () => {
 
     service.dispose();
     assert.equal(clock.pending().length, 0);
+  });
+
+  test('routes the feed to a loopback generic provider when the test override is set', () => {
+    const { updater } = createHarness({ testFeedUrl: 'http://127.0.0.1:8443/feed' });
+    assert.deepEqual(updater.feed, {
+      provider: 'generic',
+      url: 'http://127.0.0.1:8443/feed',
+    });
+  });
+
+  test('rejects a non-loopback test feed instead of falling back to production', () => {
+    // A mistyped override must never silently install from the real GitHub
+    // feed: construction fails closed.
+    assert.throws(
+      () => createHarness({ testFeedUrl: 'https://evil.example/feed' }),
+      TypeError,
+    );
+  });
+
+  test('resolveUpdateFeedOverride accepts exactly loopback http URLs', () => {
+    assert.equal(resolveUpdateFeedOverride(undefined), undefined);
+    assert.equal(resolveUpdateFeedOverride(''), undefined);
+    assert.deepEqual(resolveUpdateFeedOverride('http://127.0.0.1:1'), {
+      provider: 'generic',
+      url: 'http://127.0.0.1:1/',
+    });
+    assert.deepEqual(resolveUpdateFeedOverride('http://127.0.0.1:65535/updates'), {
+      provider: 'generic',
+      url: 'http://127.0.0.1:65535/updates',
+    });
+    const rejected = [
+      'not-a-url',
+      'file:///C:/feed',
+      'https://127.0.0.1:1', // https is not loopback-harness shaped
+      'http://localhost:1', // alias resolution is not identity
+      'http://127.0.0.2:1', // other loopback addresses stay rejected
+      'http://[::1]:1', // IPv6 loopback stays rejected: one accepted shape only
+      'http://127.0.0.1', // no port: cannot be an ephemeral harness server
+      'http://u:p@127.0.0.1:1', // userinfo confusion
+      'http://127.0.0.1.evil.example:1', // hostname prefix confusion
+      'http://127.0.0.1:1/x?y=1', // query smuggling
+      'http://127.0.0.1:1/x#frag',
+    ];
+    for (const raw of rejected) {
+      assert.throws(
+        () => resolveUpdateFeedOverride(raw),
+        TypeError,
+        `expected rejection: ${raw}`,
+      );
+    }
   });
 
   test('does not overlap checks and cannot re-arm after disposal', async () => {

--- a/apps/desktop/src/main/app-update-service.ts
+++ b/apps/desktop/src/main/app-update-service.ts
@@ -67,6 +67,11 @@ interface AppUpdateServiceDeps {
   currentVersion: string;
   isPackaged: boolean;
   updater?: AppUpdater;
+  /**
+   * Harness-only feed override (`MAKA_UPDATE_TEST_FEED`); see
+   * {@link resolveUpdateFeedOverride} for the exact accepted shape.
+   */
+  testFeedUrl?: string;
   mockLatestVersion?: string;
   mockState?: 'available' | 'downloading' | 'downloaded';
   onStatusChange?: (status: AppUpdateStatus) => void;
@@ -92,6 +97,58 @@ const UPDATE_CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
  * four-hour timer stays as the floor for a window that is never refocused.
  */
 const UPDATE_CHECK_ON_FOCUS_MIN_INTERVAL_MS = 15 * 60 * 1000;
+
+/**
+ * Harness-only override for the update feed (`MAKA_UPDATE_TEST_FEED`).
+ *
+ * Accepts exactly `http://127.0.0.1:<port>[/path]` and maps it to a generic
+ * provider so the end-to-end Windows auto-update verification can serve a
+ * candidate installer plus `latest.yml` from a loopback HTTP server. Anything
+ * else set — a remote host, `localhost`, another loopback alias, HTTPS,
+ * userinfo, a query string, or a malformed URL — throws: a mistyped override
+ * must never silently fall back to the production GitHub feed, because a test
+ * run quietly installing a real release is exactly the failure this shape
+ * exists to prevent.
+ *
+ * Security posture (this is not an update-hijack vector): setting an
+ * environment variable on the app's process already requires code execution
+ * as the same user, and the per-user NSIS install model means that user can
+ * rewrite the installation directory directly — the override grants no
+ * capability across any privilege boundary. Loopback-only keeps even that
+ * same-user surface minimal: the feed must be a process listening on this
+ * machine. With the variable unset the feed configuration is byte-identical
+ * to production, and update signature verification (once a certificate
+ * exists) applies to overridden feeds exactly as it does to the GitHub feed —
+ * nothing here relaxes it.
+ */
+export function resolveUpdateFeedOverride(
+  raw: string | undefined,
+): { provider: 'generic'; url: string } | undefined {
+  if (raw === undefined || raw === '') return undefined;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new TypeError(
+      `MAKA_UPDATE_TEST_FEED is not a URL: ${JSON.stringify(raw)}`,
+    );
+  }
+  if (
+    url.protocol !== 'http:' ||
+    url.hostname !== '127.0.0.1' ||
+    url.port === '' ||
+    url.username !== '' ||
+    url.password !== '' ||
+    url.search !== '' ||
+    url.hash !== ''
+  ) {
+    throw new TypeError(
+      'MAKA_UPDATE_TEST_FEED must be http://127.0.0.1:<port>[/path] ' +
+        `(got ${JSON.stringify(raw)})`,
+    );
+  }
+  return { provider: 'generic', url: url.toString() };
+}
 
 function normalizeVersion(version: string): string {
   return version.trim().replace(/^v/i, '');
@@ -241,11 +298,16 @@ export function createAppUpdateService(deps: AppUpdateServiceDeps): AppUpdateSer
   updater.autoInstallOnAppQuit = false;
   updater.allowPrerelease = false;
   updater.logger = null;
-  updater.setFeedURL({
-    provider: 'github',
-    owner: 'Maka-Agent',
-    repo: 'maka-agent',
-  });
+  // The override changes the feed URL and nothing else: every other updater
+  // setting and the whole status machine behave identically under it, so what
+  // the loopback harness verifies is what production runs.
+  updater.setFeedURL(
+    resolveUpdateFeedOverride(deps.testFeedUrl) ?? {
+      provider: 'github',
+      owner: 'Maka-Agent',
+      repo: 'maka-agent',
+    },
+  );
 
   updater.on('checking-for-update', () => {
     publish({ state: 'checking', currentVersion: deps.currentVersion });

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -420,6 +420,7 @@ const updateMockState =
 const updateService = createAppUpdateService({
   currentVersion: app.getVersion(),
   isPackaged: app.isPackaged,
+  testFeedUrl: process.env.MAKA_UPDATE_TEST_FEED,
   mockLatestVersion: process.env.MAKA_UPDATE_MOCK_VERSION,
   mockState: updateMockState,
   onStatusChange: (status) =>

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -28,8 +28,9 @@ the candidate, fully smokes the candidate, waits for installed processes to exit
 uninstaller. A second gate proves the automatic, running-app upgrade path: the installed candidate,
 running, discovers a newer build through its packaged electron-updater against a loopback test feed,
 downloads it in the background, hands off to the NSIS installer, relaunches as the new version, and
-passes the full packaged smoke — with the feed requests, every updater state, and the final version
-asserted individually. What is still not proven: update signature verification (no Authenticode
+passes the full packaged smoke — with the feed requests (including the differential-download probe),
+the `downloaded` state and its exact version pair, and the final installed version asserted
+individually; transient states such as `checking` and `downloading` are not individually asserted. What is still not proven: update signature verification (no Authenticode
 certificate yet — the feed configuration for the production GitHub channel is pinned by unit tests
 and exercised routinely on real releases instead), persisted business-data migration, and rollback
 after a mid-install failure.
@@ -59,7 +60,8 @@ workspace data first; the preview does not yet claim installer rollback or migra
 发布门禁会安装固定的 v0.1.9、执行完整 smoke、在同一目录升级候选版本、再次完整 smoke、等待安装目录内
 进程退出，并运行真实卸载器。另一个门禁证明**运行中的自动更新路径**：已安装且正在运行的候选版本通过打包的
 electron-updater 从 loopback 测试 feed 发现新版本、后台下载、交接给 NSIS 安装器、以新版本自动重启并通过
-完整打包 smoke——feed 请求、每个 updater 状态与最终版本均逐项断言。仍未证明的是：更新签名校验（尚无
+完整打包 smoke——feed 请求（含差量下载探测）、`downloaded` 状态及其精确版本对、最终安装版本均逐项断言；
+`checking`/`downloading` 等瞬态不逐项断言。仍未证明的是：更新签名校验（尚无
 Authenticode 证书；生产 GitHub 通道的 feed 配置由单测钉死，并在每次真实 release 中例行使用）、业务数据
 迁移，以及安装中途失败后的 rollback。
 

--- a/docs/windows-support.md
+++ b/docs/windows-support.md
@@ -1,6 +1,6 @@
 # Windows support baseline
 
-Windows is an active enablement target, not a fully supported Maka platform yet. The CLI and Electron desktop application can run from source, and release workflows produce a verified unsigned Windows x64 preview. The x64 package includes an AppContainer sandbox for restricted managed execution; signing, the complete adversarial sandbox matrix, automatic updates, and computer-use guarantees remain incomplete. Progress is tracked in [GitHub issue #2142](https://github.com/maka-agent/maka-agent/issues/2142).
+Windows is an active enablement target, not a fully supported Maka platform yet. The CLI and Electron desktop application can run from source, and release workflows produce a verified unsigned Windows x64 preview. The x64 package includes an AppContainer sandbox for restricted managed execution, and automatic updates are verified end to end in CI on the unsigned preview channel; signing, the complete adversarial sandbox matrix, and computer-use guarantees remain incomplete. Progress is tracked in [GitHub issue #2142](https://github.com/maka-agent/maka-agent/issues/2142).
 
 ## Install the Windows x64 preview
 
@@ -25,8 +25,14 @@ Only use Windows assets attached to a Maka GitHub Release. The NSIS installer is
 
 The release gate installs a pinned v0.1.9 build, fully smokes it, upgrades the same installation to
 the candidate, fully smokes the candidate, waits for installed processes to exit, and runs the real
-uninstaller. This proves a closed-app upgrade and uninstall path. It does not prove automatic update,
-running-app upgrade, persisted business-data migration, or rollback after a mid-install failure.
+uninstaller. A second gate proves the automatic, running-app upgrade path: the installed candidate,
+running, discovers a newer build through its packaged electron-updater against a loopback test feed,
+downloads it in the background, hands off to the NSIS installer, relaunches as the new version, and
+passes the full packaged smoke — with the feed requests, every updater state, and the final version
+asserted individually. What is still not proven: update signature verification (no Authenticode
+certificate yet — the feed configuration for the production GitHub channel is pinned by unit tests
+and exercised routinely on real releases instead), persisted business-data migration, and rollback
+after a mid-install failure.
 
 To uninstall, use **Settings → Apps → Installed apps → Maka → Uninstall**. Back up any important
 workspace data first; the preview does not yet claim installer rollback or migration guarantees.
@@ -51,8 +57,11 @@ workspace data first; the preview does not yet claim installer rollback or migra
    `winget install BurntSushi.ripgrep.MSVC`，并在 `PATH` 更新后重启 Maka。
 
 发布门禁会安装固定的 v0.1.9、执行完整 smoke、在同一目录升级候选版本、再次完整 smoke、等待安装目录内
-进程退出，并运行真实卸载器。这证明关闭应用后的升级与卸载路径，不证明自动更新、运行中升级、业务数据迁移，
-也不证明安装中途失败后的 rollback。
+进程退出，并运行真实卸载器。另一个门禁证明**运行中的自动更新路径**：已安装且正在运行的候选版本通过打包的
+electron-updater 从 loopback 测试 feed 发现新版本、后台下载、交接给 NSIS 安装器、以新版本自动重启并通过
+完整打包 smoke——feed 请求、每个 updater 状态与最终版本均逐项断言。仍未证明的是：更新签名校验（尚无
+Authenticode 证书；生产 GitHub 通道的 feed 配置由单测钉死，并在每次真实 release 中例行使用）、业务数据
+迁移，以及安装中途失败后的 rollback。
 
 卸载入口为 **设置 → 应用 → 已安装的应用 → Maka → 卸载**。预览版尚未承诺安装器 rollback 或数据迁移，
 请先备份重要 workspace 数据。
@@ -69,7 +78,7 @@ The initial target is a native Windows 11 x64 development environment with:
 - WebView/runtime components installed by a current Windows 11 installation;
 - Windows Developer Mode or elevation only for tests that create file symlinks. Normal CLI and desktop startup must not require either.
 
-Windows 10, Windows on Arm, automatic updates, the final sandbox support declaration, and computer-use are not covered by the current support target. Packaged installation is available only as the unsigned Windows 11 x64 preview described above.
+Windows 10, Windows on Arm, signed automatic updates, the final sandbox support declaration, and computer-use are not covered by the current support target. Packaged installation is available only as the unsigned Windows 11 x64 preview described above; its automatic-update path is CI-verified but unsigned.
 
 ## Reproducible checks
 
@@ -148,6 +157,9 @@ The root test timeout is tracked separately from individual test failures. Phase
 - Restricted managed profiles use the packaged AppContainer broker when available and fail closed
   when the native capability or requested policy is unavailable.
 - Computer-use has no Windows backend.
-- The Windows x64 NSIS installer is unsigned and there is no supported automatic-update channel.
+- The Windows x64 NSIS installer is unsigned. The in-app automatic-update path (electron-updater →
+  NSIS handoff → relaunch) is verified end to end in CI against a loopback feed; the production
+  GitHub feed configuration is pinned by unit tests. Updates are not signature-verified until an
+  Authenticode certificate lands.
 
 Do not describe Windows as released or fully supported until the support criteria in issue #2142 are complete for the claimed support tier.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "package:windows-x64": "node scripts/package-windows-x64.mjs",
     "verify:windows-x64": "node scripts/verify-windows-x64.mjs",
     "verify:windows-installer": "node scripts/verify-windows-installer-lifecycle.mjs",
+    "package:windows-autoupdate-next": "node scripts/package-windows-autoupdate-next.mjs",
+    "verify:windows-autoupdate": "node scripts/verify-windows-autoupdate.mjs",
     "astryx:theme": "node scripts/build-astryx-theme.mjs",
     "astryx:surface-inventory": "node scripts/check-astryx-surface-inventory.mjs",
     "astryx:surface-inventory:write": "node scripts/generate-astryx-surface-inventory.mjs",

--- a/scripts/package-windows-autoupdate-next.mjs
+++ b/scripts/package-windows-autoupdate-next.mjs
@@ -1,0 +1,124 @@
+import { createHash } from 'node:crypto';
+import { access, readFile, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { runCommand } from './package-windows-x64.mjs';
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const desktopRoot = join(repoRoot, 'apps', 'desktop');
+
+/**
+ * The version the auto-update harness serves as "newer than the candidate".
+ * A plain patch bump keeps the artifact name matching the release regex and
+ * avoids every channel/prerelease ambiguity: `allowPrerelease` only affects
+ * the GitHub provider, but a stable version never depends on that behavior.
+ */
+export function bumpedAutoupdateVersion(candidateVersion) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(candidateVersion);
+  if (!match) {
+    throw new Error(
+      `Cannot bump a non-stable x.y.z candidate version: ${JSON.stringify(candidateVersion)}`,
+    );
+  }
+  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
+}
+
+/**
+ * Minimal parser for the handful of flat keys the assertions need. electron-
+ * builder writes plain `key: value` lines for these; a format drift makes the
+ * assertions below fail loudly rather than letting a malformed feed pass.
+ */
+function readFlatYamlValue(source, key) {
+  const match = new RegExp(`^${key}:\\s*(.+)\\s*$`, 'm').exec(source);
+  return match ? match[1].trim() : undefined;
+}
+
+/**
+ * Build the version-bumped NSIS installer the auto-update harness serves as
+ * the "next" release.
+ *
+ * Runs only after a full `package:windows-x64`: it reuses the existing
+ * workspace build (`apps/desktop/dist`) and injects the bumped version via
+ * electron-builder's `extraMetadata`, which rewrites the packaged
+ * `package.json` so the upgraded app really reports the new version through
+ * `app.getVersion()`. Output goes to a dedicated directory outside
+ * `apps/desktop/release`, so the release upload globs can never pick up the
+ * fake-versioned artifacts.
+ */
+export async function packageWindowsAutoupdateNext({
+  platform = process.platform,
+  arch = process.arch,
+  run = runCommand,
+} = {}) {
+  if (platform !== 'win32' || arch !== 'x64') {
+    throw new Error('The auto-update installer build requires a Windows x64 host.');
+  }
+
+  const manifest = JSON.parse(await readFile(join(desktopRoot, 'package.json'), 'utf8'));
+  const nextVersion = bumpedAutoupdateVersion(manifest.version);
+  const outputDirectory = join(desktopRoot, 'release-autoupdate-next');
+  const exeName = `Maka-${nextVersion}-win-x64.exe`;
+  const exePath = join(outputDirectory, exeName);
+  const latestYmlPath = join(outputDirectory, 'latest.yml');
+  const blockmapPath = join(outputDirectory, `${exeName}.blockmap`);
+
+  // Prerequisites from the full packaging run; failing here beats a confusing
+  // electron-builder error half-way through.
+  await access(join(desktopRoot, 'dist'));
+  await access(join(desktopRoot, 'release', 'win-unpacked'));
+
+  await rm(outputDirectory, { recursive: true, force: true });
+  await run('npm', [
+    '--workspace',
+    '@maka/desktop',
+    'exec',
+    '--',
+    'electron-builder',
+    '--config',
+    'electron-builder.config.mjs',
+    '--win',
+    'nsis',
+    '--x64',
+    '--publish',
+    'never',
+    `-c.extraMetadata.version=${nextVersion}`,
+    '-c.directories.output=release-autoupdate-next',
+  ]);
+
+  // Assert the properties the harness depends on, not just process exit 0.
+  await access(exePath);
+  await access(blockmapPath);
+  const latestYml = await readFile(latestYmlPath, 'utf8');
+  const feedVersion = readFlatYamlValue(latestYml, 'version');
+  if (feedVersion !== nextVersion) {
+    throw new Error(
+      `latest.yml advertises version ${JSON.stringify(feedVersion)}, expected ${nextVersion}`,
+    );
+  }
+  const feedPath = readFlatYamlValue(latestYml, 'path');
+  if (feedPath !== exeName) {
+    throw new Error(`latest.yml path points at ${JSON.stringify(feedPath)}, expected ${exeName}`);
+  }
+  const feedSha512 = readFlatYamlValue(latestYml, 'sha512');
+  const actualSha512 = createHash('sha512')
+    .update(await readFile(exePath))
+    .digest('base64');
+  if (feedSha512 !== actualSha512) {
+    throw new Error(
+      'latest.yml sha512 does not match the built installer; the feed would fail integrity checks',
+    );
+  }
+
+  return { version: nextVersion, exePath, latestYmlPath, blockmapPath, directory: outputDirectory };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await packageWindowsAutoupdateNext();
+  console.log(
+    JSON.stringify({
+      version: result.version,
+      exePath: result.exePath,
+      directory: result.directory,
+    }),
+  );
+}

--- a/scripts/verify-packaged-app.mjs
+++ b/scripts/verify-packaged-app.mjs
@@ -74,7 +74,7 @@ export async function assertMissing(path) {
   throw new Error(`Forbidden release resource exists: ${path}`);
 }
 
-async function reserveTcpPort() {
+export async function reserveTcpPort() {
   const server = createServer();
   await new Promise((resolvePromise, reject) => {
     server.once('error', reject);
@@ -97,7 +97,7 @@ function delay(milliseconds) {
   });
 }
 
-async function findRendererTarget(port, child) {
+export async function findRendererTarget(port, child) {
   const deadline = Date.now() + 30_000;
   let lastError;
   while (Date.now() < deadline) {
@@ -125,7 +125,17 @@ async function findRendererTarget(port, child) {
   );
 }
 
-async function evaluateRenderer(webSocketDebuggerUrl) {
+/**
+ * Evaluate one expression in a renderer over CDP and return its
+ * `returnByValue` result. `awaitPromise` resolves a returned promise before
+ * reporting, which is how the auto-update harness drives `window.maka.app`
+ * calls; the plain smoke below keeps its original synchronous expression.
+ */
+export async function evaluateInRenderer(
+  webSocketDebuggerUrl,
+  expression,
+  { awaitPromise = false, timeoutMs = 10_000 } = {},
+) {
   if (typeof WebSocket !== 'function') {
     throw new Error('The release verifier requires Node.js WebSocket support.');
   }
@@ -139,13 +149,23 @@ async function evaluateRenderer(webSocketDebuggerUrl) {
     return await new Promise((resolvePromise, reject) => {
       const timeout = setTimeout(() => {
         reject(new Error('CDP renderer evaluation timed out.'));
-      }, 10_000);
+      }, timeoutMs);
       socket.addEventListener('message', (event) => {
         const message = JSON.parse(String(event.data));
         if (message.id !== 1) return;
         clearTimeout(timeout);
         if (message.error) {
           reject(new Error(message.error.message));
+          return;
+        }
+        if (message.result?.exceptionDetails) {
+          reject(
+            new Error(
+              message.result.exceptionDetails.exception?.description ??
+                message.result.exceptionDetails.text ??
+                'Renderer evaluation threw.',
+            ),
+          );
           return;
         }
         resolvePromise(message.result?.result?.value);
@@ -155,14 +175,9 @@ async function evaluateRenderer(webSocketDebuggerUrl) {
           id: 1,
           method: 'Runtime.evaluate',
           params: {
-            expression: `({
-              readyState: document.readyState,
-              hasBridge: Boolean(window.maka),
-              hasRoot: Boolean(document.querySelector('#root')),
-              hasPreloadSkeleton: Boolean(document.querySelector('#root > .maka-preload')),
-              hasAppShell: Boolean(document.querySelector('#root [data-agents-page]'))
-            })`,
+            expression,
             returnByValue: true,
+            awaitPromise,
           },
         }),
       );
@@ -172,7 +187,19 @@ async function evaluateRenderer(webSocketDebuggerUrl) {
   }
 }
 
-function isPackagedRendererUsable(rendererState) {
+export const RENDERER_STATE_EXPRESSION = `({
+  readyState: document.readyState,
+  hasBridge: Boolean(window.maka),
+  hasRoot: Boolean(document.querySelector('#root')),
+  hasPreloadSkeleton: Boolean(document.querySelector('#root > .maka-preload')),
+  hasAppShell: Boolean(document.querySelector('#root [data-agents-page]'))
+})`;
+
+function evaluateRenderer(webSocketDebuggerUrl) {
+  return evaluateInRenderer(webSocketDebuggerUrl, RENDERER_STATE_EXPRESSION);
+}
+
+export function isPackagedRendererUsable(rendererState) {
   return (
     rendererState?.readyState === 'complete' &&
     rendererState.hasBridge === true &&
@@ -182,7 +209,7 @@ function isPackagedRendererUsable(rendererState) {
   );
 }
 
-async function stopChild(child) {
+export async function stopChild(child) {
   if (child.exitCode !== null) return;
   child.kill('SIGTERM');
   const exited = await Promise.race([

--- a/scripts/verify-windows-autoupdate.mjs
+++ b/scripts/verify-windows-autoupdate.mjs
@@ -47,13 +47,16 @@ function compareStableVersions(left, right) {
 }
 
 /**
- * Loopback static file server for the update feed. Serves exactly the allowed
- * basenames from `directory`; anything else is 404 and counted, and the
- * verification fails if any unexpected request arrived — a wrong request shape
- * must surface, not be absorbed. Supports single-range GETs because
- * electron-updater uses ranged requests for differential downloads.
+ * Loopback static file server for the update feed. Serves exactly the mapped
+ * basenames; anything else is 404 and counted, and the verification fails if
+ * any unexpected request arrived — a wrong request shape must surface, not be
+ * absorbed. A mapped name whose file is absent 404s without counting: the
+ * updater legitimately probes the *previous* version's blockmap for a
+ * differential download and falls back to the full installer when the feed
+ * does not have it. Supports single-range GETs because differential downloads
+ * use ranged requests.
  */
-async function startFeedServer(directory, allowedNames) {
+async function startFeedServer(files) {
   const requests = [];
   let unexpectedRequests = 0;
   const server = createServer(async (request, response) => {
@@ -62,7 +65,7 @@ async function startFeedServer(directory, allowedNames) {
     const name = basename(pathName);
     const record = { method, path: pathName, status: 0 };
     requests.push(record);
-    if ((method !== 'GET' && method !== 'HEAD') || !allowedNames.has(name)) {
+    if ((method !== 'GET' && method !== 'HEAD') || !files.has(name)) {
       unexpectedRequests += 1;
       record.status = 404;
       response.writeHead(404).end();
@@ -70,9 +73,9 @@ async function startFeedServer(directory, allowedNames) {
     }
     let body;
     try {
-      body = await readFile(join(directory, name));
+      body = await readFile(files.get(name));
     } catch {
-      unexpectedRequests += 1;
+      // Known name, absent file: the expected 404 shape (previous blockmap).
       record.status = 404;
       response.writeHead(404).end();
       return;
@@ -191,9 +194,18 @@ export async function verifyWindowsAutoupdate(
 
   try {
     step('starting the loopback update feed');
+    // The candidate's own blockmap is served too, exactly as a GitHub release
+    // hosts the previous version's assets: the updater requests it to attempt
+    // a differential download. If the file is missing next to the candidate
+    // installer, the mapped-but-absent 404 makes the updater fall back to the
+    // full download — both are valid production shapes.
     feed = await startFeedServer(
-      nextDirectory,
-      new Set(['latest.yml', nextInstallerName, `${nextInstallerName}.blockmap`]),
+      new Map([
+        ['latest.yml', join(nextDirectory, 'latest.yml')],
+        [nextInstallerName, join(nextDirectory, nextInstallerName)],
+        [`${nextInstallerName}.blockmap`, join(nextDirectory, `${nextInstallerName}.blockmap`)],
+        [`${basename(candidateInstaller)}.blockmap`, `${candidateInstaller}.blockmap`],
+      ]),
     );
 
     step(`installing candidate ${candidateVersion} into ${installDirectory}`);

--- a/scripts/verify-windows-autoupdate.mjs
+++ b/scripts/verify-windows-autoupdate.mjs
@@ -72,11 +72,15 @@ async function startFeedServer(files) {
   }
   const server = createServer((request, response) => {
     const method = request.method ?? 'GET';
-    // The raw request target is matched, before any decoding and including
-    // any query: `/%6catest.yml` or `/latest.yml?cache=1` must count as
-    // unexpected, or "exact root-level paths" would be an overclaim.
-    const pathName = request.url ?? '/';
-    const record = { method, path: pathName, status: 0 };
+    // The raw path segment is matched without decoding, so `/%6catest.yml`
+    // cannot alias `/latest.yml`. The query is allowed and recorded, not
+    // matched: electron-updater cache-busts its channel request with
+    // `?noCache=<id>`, so rejecting queries rejects the updater's own
+    // documented request shape (the first live run proved exactly that).
+    const target = request.url ?? '/';
+    const queryIndex = target.indexOf('?');
+    const pathName = queryIndex === -1 ? target : target.slice(0, queryIndex);
+    const record = { method, path: pathName, target, status: 0 };
     requests.push(record);
     const known = [...files.keys()].some((name) => `/${name}` === pathName);
     if ((method !== 'GET' && method !== 'HEAD') || !known) {

--- a/scripts/verify-windows-autoupdate.mjs
+++ b/scripts/verify-windows-autoupdate.mjs
@@ -1,0 +1,510 @@
+import { spawn } from 'node:child_process';
+import { access, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  evaluateInRenderer,
+  findRendererTarget,
+  isPackagedRendererUsable,
+  isolatedUserEnv,
+  RENDERER_STATE_EXPRESSION,
+  reserveTcpPort,
+  runCommand,
+  stopChild,
+} from './verify-packaged-app.mjs';
+import {
+  installerVersion,
+  listInstalledProcesses,
+  waitForInstalledProcessesToExit,
+  waitUntilMissing,
+} from './verify-windows-installer-lifecycle.mjs';
+import {
+  assertWindowsProductVersion,
+  powerShellLiteral,
+  verifyPackagedWindowsApp,
+} from './verify-windows-x64.mjs';
+
+const uninstallExecutableName = 'Uninstall Maka.exe';
+const executableName = 'Maka.exe';
+
+function delay(milliseconds) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, milliseconds));
+}
+
+function step(label) {
+  console.log(`[verify-windows-autoupdate] ${label}`);
+}
+
+function compareStableVersions(left, right) {
+  const parse = (value) => value.split('.').map(Number);
+  const [lMaj, lMin, lPat] = parse(left);
+  const [rMaj, rMin, rPat] = parse(right);
+  if (lMaj !== rMaj) return lMaj - rMaj;
+  if (lMin !== rMin) return lMin - rMin;
+  return lPat - rPat;
+}
+
+/**
+ * Loopback static file server for the update feed. Serves exactly the allowed
+ * basenames from `directory`; anything else is 404 and counted, and the
+ * verification fails if any unexpected request arrived — a wrong request shape
+ * must surface, not be absorbed. Supports single-range GETs because
+ * electron-updater uses ranged requests for differential downloads.
+ */
+async function startFeedServer(directory, allowedNames) {
+  const requests = [];
+  let unexpectedRequests = 0;
+  const server = createServer(async (request, response) => {
+    const method = request.method ?? 'GET';
+    const pathName = decodeURIComponent(new URL(request.url ?? '/', 'http://127.0.0.1').pathname);
+    const name = basename(pathName);
+    const record = { method, path: pathName, status: 0 };
+    requests.push(record);
+    if ((method !== 'GET' && method !== 'HEAD') || !allowedNames.has(name)) {
+      unexpectedRequests += 1;
+      record.status = 404;
+      response.writeHead(404).end();
+      return;
+    }
+    let body;
+    try {
+      body = await readFile(join(directory, name));
+    } catch {
+      unexpectedRequests += 1;
+      record.status = 404;
+      response.writeHead(404).end();
+      return;
+    }
+    const range = /^bytes=(\d+)-(\d*)$/.exec(request.headers.range ?? '');
+    if (range) {
+      const start = Number(range[1]);
+      const end = range[2] === '' ? body.length - 1 : Math.min(Number(range[2]), body.length - 1);
+      if (start > end || start >= body.length) {
+        record.status = 416;
+        response.writeHead(416, { 'Content-Range': `bytes */${body.length}` }).end();
+        return;
+      }
+      record.status = 206;
+      response.writeHead(206, {
+        'Content-Type': 'application/octet-stream',
+        'Content-Range': `bytes ${start}-${end}/${body.length}`,
+        'Content-Length': end - start + 1,
+        'Accept-Ranges': 'bytes',
+      });
+      response.end(method === 'HEAD' ? undefined : body.subarray(start, end + 1));
+      return;
+    }
+    record.status = 200;
+    response.writeHead(200, {
+      'Content-Type': 'application/octet-stream',
+      'Content-Length': body.length,
+      'Accept-Ranges': 'bytes',
+    });
+    response.end(method === 'HEAD' ? undefined : body);
+  });
+  await new Promise((resolvePromise, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolvePromise);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Could not start the loopback update feed.');
+  }
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    unexpectedCount: () => unexpectedRequests,
+    close: () =>
+      new Promise((resolvePromise) => {
+        server.close(() => resolvePromise());
+        server.closeAllConnections?.();
+      }),
+  };
+}
+
+async function readInstalledProductVersion(executablePath, { run = runCommand } = {}) {
+  const script = `(Get-Item ${powerShellLiteral(executablePath)}).VersionInfo.ProductVersion`;
+  const { stdout } = await run('powershell', ['-NoProfile', '-NonInteractive', '-Command', script]);
+  return stdout;
+}
+
+/**
+ * End-to-end Windows automatic-update verification.
+ *
+ * Installs the candidate build, points its packaged updater at a loopback feed
+ * serving a version-bumped installer, and asserts the complete in-app path:
+ * check → background download (feed request log) → `downloaded` status →
+ * `installUpdate` handoff → old process exit → NSIS upgrade → automatic
+ * relaunch as the new version → full packaged smoke of the upgraded install →
+ * silent uninstall. Every stage has its own deadline and named failure; the
+ * overall shape fails closed rather than reporting a partial success.
+ */
+export async function verifyWindowsAutoupdate(
+  candidateInputPath,
+  nextDirectoryInput,
+  {
+    platform = process.platform,
+    makeTemporaryDirectory = () => mkdtemp(join(tmpdir(), 'maka-autoupdate-')),
+    run = runCommand,
+  } = {},
+) {
+  if (platform !== 'win32') {
+    throw new Error('Windows auto-update verification requires Windows.');
+  }
+  if (!candidateInputPath || !nextDirectoryInput) {
+    throw new Error(
+      'Usage: npm run verify:windows-autoupdate -- <candidate-exe> <next-release-directory>',
+    );
+  }
+
+  const candidateInstaller = resolve(candidateInputPath);
+  const nextDirectory = resolve(nextDirectoryInput);
+  const candidateVersion = installerVersion(candidateInstaller);
+  await access(candidateInstaller);
+  const latestYml = await readFile(join(nextDirectory, 'latest.yml'), 'utf8');
+  const nextVersion = /^version:\s*(.+)\s*$/m.exec(latestYml)?.[1]?.trim();
+  if (!nextVersion) {
+    throw new Error(`latest.yml in ${nextDirectory} does not advertise a version.`);
+  }
+  if (compareStableVersions(nextVersion, candidateVersion) <= 0) {
+    throw new Error(
+      `The served version ${nextVersion} must be newer than the candidate ${candidateVersion}.`,
+    );
+  }
+  const nextInstallerName = `Maka-${nextVersion}-win-x64.exe`;
+  installerVersion(join(nextDirectory, nextInstallerName));
+  await access(join(nextDirectory, nextInstallerName));
+  await access(join(nextDirectory, `${nextInstallerName}.blockmap`));
+
+  const temporaryDirectory = await makeTemporaryDirectory();
+  const installDirectory = join(temporaryDirectory, 'installed');
+  const uninstaller = join(installDirectory, uninstallExecutableName);
+  const installedExecutable = join(installDirectory, executableName);
+  let installationStarted = false;
+  let uninstallCompleted = false;
+  let feed;
+  let child;
+  let primaryError;
+
+  try {
+    step('starting the loopback update feed');
+    feed = await startFeedServer(
+      nextDirectory,
+      new Set(['latest.yml', nextInstallerName, `${nextInstallerName}.blockmap`]),
+    );
+
+    step(`installing candidate ${candidateVersion} into ${installDirectory}`);
+    installationStarted = true;
+    await run(candidateInstaller, ['/S', `/D=${installDirectory}`], { timeoutMs: 120_000 });
+    await access(uninstaller);
+
+    step('launching the installed candidate against the loopback feed');
+    const cdpPort = await reserveTcpPort();
+    const home = join(temporaryDirectory, 'home');
+    const userData = join(temporaryDirectory, 'user-data');
+    const userEnv = isolatedUserEnv(home);
+    await mkdir(home, { recursive: true });
+    await mkdir(userData, { recursive: true });
+    await mkdir(userEnv.APPDATA, { recursive: true });
+    await mkdir(userEnv.LOCALAPPDATA, { recursive: true });
+    const childEnv = {
+      ...process.env,
+      MAKA_SKIP_SHELL_ENV: '1',
+      ...userEnv,
+      MAKA_UPDATE_TEST_FEED: feed.url,
+    };
+    // The mocks short-circuit before the real updater; leaking them from the
+    // caller's environment would turn this into a fixture test.
+    delete childEnv.MAKA_UPDATE_MOCK_VERSION;
+    delete childEnv.MAKA_UPDATE_MOCK_STATE;
+    child = spawn(
+      installedExecutable,
+      [
+        `--remote-debugging-port=${cdpPort}`,
+        `--user-data-dir=${userData}`,
+        '--enable-logging=stderr',
+      ],
+      { cwd: temporaryDirectory, env: childEnv, stdio: ['ignore', 'ignore', 'pipe'] },
+    );
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (chunk) => {
+      stderr = `${stderr}${chunk}`.slice(-16_384);
+    });
+
+    const target = await findRendererTarget(cdpPort, child);
+    const rendererDeadline = Date.now() + 30_000;
+    for (;;) {
+      const state = await evaluateInRenderer(
+        target.webSocketDebuggerUrl,
+        RENDERER_STATE_EXPRESSION,
+      );
+      if (isPackagedRendererUsable(state)) break;
+      if (child.exitCode !== null) {
+        throw new Error(`Candidate exited before its renderer became usable.\n${stderr.trim()}`);
+      }
+      if (Date.now() >= rendererDeadline) {
+        throw new Error(`Candidate renderer did not become usable: ${JSON.stringify(state)}`);
+      }
+      await delay(250);
+    }
+
+    step('driving an update check through the renderer bridge');
+    await evaluateInRenderer(target.webSocketDebuggerUrl, 'window.maka.app.checkForUpdates()', {
+      awaitPromise: true,
+      timeoutMs: 30_000,
+    });
+
+    step('waiting for the update to reach the downloaded state');
+    const downloadDeadline = Date.now() + 180_000;
+    let status;
+    for (;;) {
+      status = await evaluateInRenderer(
+        target.webSocketDebuggerUrl,
+        'window.maka.app.updateStatus()',
+        {
+          awaitPromise: true,
+        },
+      );
+      if (status?.state === 'error') {
+        throw new Error(
+          `Update ${status.operation ?? 'flow'} failed: ${status.message ?? '<no message>'}`,
+        );
+      }
+      if (status?.state === 'downloaded') break;
+      if (child.exitCode !== null) {
+        throw new Error(`Candidate exited while downloading the update.\n${stderr.trim()}`);
+      }
+      if (Date.now() >= downloadDeadline) {
+        throw new Error(`Update never reached 'downloaded': ${JSON.stringify(status)}`);
+      }
+      await delay(500);
+    }
+    if (status.currentVersion !== candidateVersion || status.latestVersion !== nextVersion) {
+      throw new Error(
+        `Downloaded update advertises ${status.currentVersion} -> ${status.latestVersion}, ` +
+          `expected ${candidateVersion} -> ${nextVersion}.`,
+      );
+    }
+
+    step('asserting the download really came from the loopback feed');
+    const served = (name) =>
+      feed.requests.some(
+        (request) =>
+          request.method === 'GET' &&
+          basename(request.path) === name &&
+          (request.status === 200 || request.status === 206),
+      );
+    if (!served('latest.yml')) {
+      throw new Error(
+        `The app never fetched latest.yml from the loopback feed: ${JSON.stringify(feed.requests)}`,
+      );
+    }
+    if (!served(nextInstallerName)) {
+      throw new Error(
+        `The app never downloaded the installer from the loopback feed: ${JSON.stringify(feed.requests)}`,
+      );
+    }
+    if (feed.unexpectedCount() > 0) {
+      throw new Error(`The app requested unexpected feed paths: ${JSON.stringify(feed.requests)}`);
+    }
+
+    step('handing off to the installer via installUpdate');
+    let installResult;
+    try {
+      installResult = await evaluateInRenderer(
+        target.webSocketDebuggerUrl,
+        'window.maka.app.installUpdate({ allowInterruptActiveTasks: true })',
+        { awaitPromise: true, timeoutMs: 30_000 },
+      );
+    } catch (error) {
+      // The evaluation races the app quitting for the installer handoff; a
+      // dropped socket here is the expected shape of success. A structured
+      // failure is not.
+      installResult = { racedAppExit: true, message: error.message };
+    }
+    if (installResult && installResult.ok === false) {
+      throw new Error(`installUpdate refused: ${JSON.stringify(installResult)}`);
+    }
+
+    step('waiting for the candidate process to exit for the installer');
+    await new Promise((resolvePromise, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('Candidate did not exit for the installer within 60s.')),
+        60_000,
+      );
+      if (child.exitCode !== null) {
+        clearTimeout(timeout);
+        resolvePromise();
+        return;
+      }
+      child.once('exit', () => {
+        clearTimeout(timeout);
+        resolvePromise();
+      });
+    });
+
+    step('waiting for the upgraded app to relaunch automatically');
+    const relaunchDeadline = Date.now() + 120_000;
+    let relaunched = [];
+    for (;;) {
+      relaunched = (await listInstalledProcesses(installDirectory)).filter(
+        (processInfo) => basename(processInfo.path).toLowerCase() === executableName.toLowerCase(),
+      );
+      if (relaunched.length > 0) break;
+      if (Date.now() >= relaunchDeadline) {
+        throw new Error('The installer did not relaunch the upgraded app within 120s.');
+      }
+      await delay(1_000);
+    }
+    const productVersion = await readInstalledProductVersion(installedExecutable, { run });
+    assertWindowsProductVersion(productVersion, nextVersion);
+
+    step('stopping the relaunched instance');
+    // isForceRunAfter relaunches without our CDP/user-data arguments, so the
+    // instance is observed (it exists, and the image on disk is the new
+    // version) and then stopped before it can touch further state; the
+    // environment it inherited still points at the isolated home.
+    for (const processInfo of relaunched) {
+      await run('taskkill', ['/PID', String(processInfo.processId), '/T', '/F'], {
+        timeoutMs: 30_000,
+      });
+    }
+    await waitForInstalledProcessesToExit(installDirectory);
+
+    step('running the full packaged smoke against the upgraded install');
+    const upgradedStatusExpression = 'window.maka.app.updateStatus()';
+    await verifyPackagedWindowsApp(installDirectory, {
+      workingDirectory: join(temporaryDirectory, 'smoke'),
+      expectedVersion: nextVersion,
+      smokeRenderer: async (executable, { workingDirectory }) => {
+        const smokePort = await reserveTcpPort();
+        const smokeHome = join(workingDirectory, 'home');
+        const smokeUserData = join(workingDirectory, 'user-data');
+        const smokeEnv = isolatedUserEnv(smokeHome);
+        await mkdir(smokeHome, { recursive: true });
+        await mkdir(smokeUserData, { recursive: true });
+        await mkdir(smokeEnv.APPDATA, { recursive: true });
+        await mkdir(smokeEnv.LOCALAPPDATA, { recursive: true });
+        const smokeChild = spawn(
+          executable,
+          [
+            `--remote-debugging-port=${smokePort}`,
+            `--user-data-dir=${smokeUserData}`,
+            '--enable-logging=stderr',
+          ],
+          {
+            cwd: workingDirectory,
+            env: { ...process.env, MAKA_SKIP_SHELL_ENV: '1', ...smokeEnv },
+            stdio: ['ignore', 'ignore', 'ignore'],
+          },
+        );
+        try {
+          const smokeTarget = await findRendererTarget(smokePort, smokeChild);
+          const deadline = Date.now() + 30_000;
+          for (;;) {
+            const state = await evaluateInRenderer(
+              smokeTarget.webSocketDebuggerUrl,
+              RENDERER_STATE_EXPRESSION,
+            );
+            if (isPackagedRendererUsable(state)) break;
+            if (smokeChild.exitCode !== null || Date.now() >= deadline) {
+              throw new Error(`Upgraded renderer did not become usable: ${JSON.stringify(state)}`);
+            }
+            await delay(250);
+          }
+          const upgradedStatus = await evaluateInRenderer(
+            smokeTarget.webSocketDebuggerUrl,
+            upgradedStatusExpression,
+            { awaitPromise: true },
+          );
+          if (upgradedStatus?.currentVersion !== nextVersion) {
+            throw new Error(
+              `Upgraded app reports version ${upgradedStatus?.currentVersion}, expected ${nextVersion}.`,
+            );
+          }
+        } finally {
+          await stopChild(smokeChild);
+        }
+      },
+    });
+    await waitForInstalledProcessesToExit(installDirectory);
+
+    step('uninstalling the upgraded application');
+    await run(uninstaller, ['/S'], { timeoutMs: 120_000 });
+    await waitUntilMissing(installDirectory);
+    uninstallCompleted = true;
+    step(`verified automatic update ${candidateVersion} -> ${nextVersion}`);
+    return { candidateVersion, nextVersion, installDirectory };
+  } catch (error) {
+    primaryError = error;
+    throw error;
+  } finally {
+    const cleanupErrors = [];
+    if (child) {
+      try {
+        await stopChild(child);
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+    if (feed) {
+      try {
+        await feed.close();
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+    }
+    if (installationStarted && !uninstallCompleted) {
+      let exited = false;
+      try {
+        const leftover = await listInstalledProcesses(installDirectory);
+        for (const processInfo of leftover) {
+          await run('taskkill', ['/PID', String(processInfo.processId), '/T', '/F'], {
+            timeoutMs: 30_000,
+          });
+        }
+        await waitForInstalledProcessesToExit(installDirectory);
+        exited = true;
+      } catch (error) {
+        cleanupErrors.push(error);
+      }
+      if (exited) {
+        try {
+          await access(uninstaller);
+          await run(uninstaller, ['/S'], { timeoutMs: 120_000 });
+        } catch (error) {
+          cleanupErrors.push(error);
+        }
+      }
+    }
+    try {
+      await rm(temporaryDirectory, {
+        recursive: true,
+        force: true,
+        maxRetries: 20,
+        retryDelay: 250,
+      });
+    } catch (error) {
+      cleanupErrors.push(error);
+    }
+    if (cleanupErrors.length > 0) {
+      const cleanupFailure = new AggregateError(
+        cleanupErrors,
+        'Auto-update verifier cleanup failed.',
+      );
+      if (!primaryError) throw cleanupFailure;
+      if (primaryError instanceof Error && primaryError.cause === undefined) {
+        primaryError.cause = cleanupFailure;
+      }
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const result = await verifyWindowsAutoupdate(process.argv[2], process.argv[3]);
+  console.log(`Verified automatic update ${result.candidateVersion} -> ${result.nextVersion}`);
+}

--- a/scripts/verify-windows-autoupdate.mjs
+++ b/scripts/verify-windows-autoupdate.mjs
@@ -72,7 +72,10 @@ async function startFeedServer(files) {
   }
   const server = createServer((request, response) => {
     const method = request.method ?? 'GET';
-    const pathName = decodeURIComponent(new URL(request.url ?? '/', 'http://127.0.0.1').pathname);
+    // The raw request target is matched, before any decoding and including
+    // any query: `/%6catest.yml` or `/latest.yml?cache=1` must count as
+    // unexpected, or "exact root-level paths" would be an overclaim.
+    const pathName = request.url ?? '/';
     const record = { method, path: pathName, status: 0 };
     requests.push(record);
     const known = [...files.keys()].some((name) => `/${name}` === pathName);
@@ -333,8 +336,9 @@ export async function verifyWindowsAutoupdate(
     // The differential probe is a deterministic part of the flow: the updater
     // asks for the running version's blockmap before deciding between a
     // differential and a full download. Both outcomes are valid production
-    // shapes; the probe itself must have happened, and which path was taken is
-    // logged as evidence.
+    // shapes; the probe itself must have happened. The mode is reported from
+    // the installer transfer responses themselves — a served previous blockmap
+    // alone proves nothing about which download the updater then performed.
     const oldBlockmapProbe = feed.requests.find(
       (request) => request.path === `/${basename(candidateInstaller)}.blockmap`,
     );
@@ -343,10 +347,13 @@ export async function verifyWindowsAutoupdate(
         `The updater never probed the previous blockmap for a differential download: ${JSON.stringify(feed.requests)}`,
       );
     }
+    const installerResponses = feed.requests
+      .filter((request) => request.method === 'GET' && request.path === `/${nextInstallerName}`)
+      .map((request) => request.status);
     step(
-      oldBlockmapProbe.status === 200
-        ? 'differential download path exercised (previous blockmap served)'
-        : 'full-download fallback exercised (previous blockmap absent)',
+      `installer transfer observed: previous blockmap ${oldBlockmapProbe.status}, ` +
+        `installer responses [${installerResponses.join(', ')}] ` +
+        `(${installerResponses.includes(206) ? 'ranged/differential transfer' : 'single full download'})`,
     );
     if (feed.unexpectedCount() > 0) {
       throw new Error(`The app requested unexpected feed paths: ${JSON.stringify(feed.requests)}`);
@@ -416,9 +423,14 @@ export async function verifyWindowsAutoupdate(
     await waitForInstalledProcessesToExit(installDirectory);
 
     step('running the full packaged smoke against the upgraded install');
+    // The sandbox probe writes its manifest into workingDirectory before the
+    // renderer smoke would have created any subdirectories, so the directory
+    // must exist first.
+    const smokeDirectory = join(temporaryDirectory, 'smoke');
+    await mkdir(smokeDirectory, { recursive: true });
     const upgradedStatusExpression = 'window.maka.app.updateStatus()';
     await verifyPackagedWindowsApp(installDirectory, {
-      workingDirectory: join(temporaryDirectory, 'smoke'),
+      workingDirectory: smokeDirectory,
       expectedVersion: nextVersion,
       // The upgraded install is a current build (only its version is bumped),
       // so it gets the full sandbox and disclaimer verification a released

--- a/scripts/verify-windows-autoupdate.mjs
+++ b/scripts/verify-windows-autoupdate.mjs
@@ -48,34 +48,43 @@ function compareStableVersions(left, right) {
 
 /**
  * Loopback static file server for the update feed. Serves exactly the mapped
- * basenames; anything else is 404 and counted, and the verification fails if
- * any unexpected request arrived — a wrong request shape must surface, not be
- * absorbed. A mapped name whose file is absent 404s without counting: the
- * updater legitimately probes the *previous* version's blockmap for a
- * differential download and falls back to the full installer when the feed
- * does not have it. Supports single-range GETs because differential downloads
- * use ranged requests.
+ * root-level paths (`/latest.yml`, `/<installer>`, …) — the *full* request
+ * path is matched, so a nested `/x/latest.yml` counts as unexpected; a wrong
+ * updater request shape must surface, not be absorbed. A mapped path whose
+ * file is absent 404s without counting: the updater legitimately probes the
+ * *previous* version's blockmap for a differential download and falls back to
+ * the full installer when the feed does not have it. Bodies are read once at
+ * startup — electron-updater issues many ranged requests against the
+ * multi-hundred-megabyte installer, and re-reading it per request could push
+ * the download stage past its deadline. Supports single-range GETs because
+ * differential downloads use ranged requests.
  */
 async function startFeedServer(files) {
   const requests = [];
   let unexpectedRequests = 0;
-  const server = createServer(async (request, response) => {
+  const bodies = new Map();
+  for (const [name, filePath] of files) {
+    try {
+      bodies.set(`/${name}`, await readFile(filePath));
+    } catch {
+      // Mapped but absent (the previous blockmap): served as an expected 404.
+    }
+  }
+  const server = createServer((request, response) => {
     const method = request.method ?? 'GET';
     const pathName = decodeURIComponent(new URL(request.url ?? '/', 'http://127.0.0.1').pathname);
-    const name = basename(pathName);
     const record = { method, path: pathName, status: 0 };
     requests.push(record);
-    if ((method !== 'GET' && method !== 'HEAD') || !files.has(name)) {
+    const known = [...files.keys()].some((name) => `/${name}` === pathName);
+    if ((method !== 'GET' && method !== 'HEAD') || !known) {
       unexpectedRequests += 1;
       record.status = 404;
       response.writeHead(404).end();
       return;
     }
-    let body;
-    try {
-      body = await readFile(files.get(name));
-    } catch {
-      // Known name, absent file: the expected 404 shape (previous blockmap).
+    const body = bodies.get(pathName);
+    if (body === undefined) {
+      // Known path, absent file: the expected 404 shape (previous blockmap).
       record.status = 404;
       response.writeHead(404).end();
       return;
@@ -303,11 +312,12 @@ export async function verifyWindowsAutoupdate(
     }
 
     step('asserting the download really came from the loopback feed');
+    // Exact root-level paths, matching the server's own allowlist shape.
     const served = (name) =>
       feed.requests.some(
         (request) =>
           request.method === 'GET' &&
-          basename(request.path) === name &&
+          request.path === `/${name}` &&
           (request.status === 200 || request.status === 206),
       );
     if (!served('latest.yml')) {
@@ -320,6 +330,24 @@ export async function verifyWindowsAutoupdate(
         `The app never downloaded the installer from the loopback feed: ${JSON.stringify(feed.requests)}`,
       );
     }
+    // The differential probe is a deterministic part of the flow: the updater
+    // asks for the running version's blockmap before deciding between a
+    // differential and a full download. Both outcomes are valid production
+    // shapes; the probe itself must have happened, and which path was taken is
+    // logged as evidence.
+    const oldBlockmapProbe = feed.requests.find(
+      (request) => request.path === `/${basename(candidateInstaller)}.blockmap`,
+    );
+    if (!oldBlockmapProbe) {
+      throw new Error(
+        `The updater never probed the previous blockmap for a differential download: ${JSON.stringify(feed.requests)}`,
+      );
+    }
+    step(
+      oldBlockmapProbe.status === 200
+        ? 'differential download path exercised (previous blockmap served)'
+        : 'full-download fallback exercised (previous blockmap absent)',
+    );
     if (feed.unexpectedCount() > 0) {
       throw new Error(`The app requested unexpected feed paths: ${JSON.stringify(feed.requests)}`);
     }
@@ -392,6 +420,11 @@ export async function verifyWindowsAutoupdate(
     await verifyPackagedWindowsApp(installDirectory, {
       workingDirectory: join(temporaryDirectory, 'smoke'),
       expectedVersion: nextVersion,
+      // The upgraded install is a current build (only its version is bumped),
+      // so it gets the full sandbox and disclaimer verification a released
+      // baseline would be exempt from.
+      requireWindowsSandbox: true,
+      requireDisclaimer: true,
       smokeRenderer: async (executable, { workingDirectory }) => {
         const smokePort = await reserveTcpPort();
         const smokeHome = join(workingDirectory, 'home');

--- a/scripts/verify-windows-x64.mjs
+++ b/scripts/verify-windows-x64.mjs
@@ -93,9 +93,12 @@ export async function verifyPackagedWindowsApp(
     // which cannot be required to carry resources added after it shipped. A
     // caller verifying a *current* build under a different version (the
     // auto-update gate's upgraded install) overrides these to true so the
-    // sandbox and disclaimer checks are not silently skipped.
-    requireWindowsSandbox = expectedVersion === undefined,
-    requireDisclaimer = expectedVersion === undefined,
+    // sandbox and disclaimer checks are not silently skipped. `== null`
+    // matches the `expectedVersion ?? desktopManifest.version` fallback below,
+    // so a `null` cannot disable these checks while also meaning "no expected
+    // version".
+    requireWindowsSandbox = expectedVersion == null,
+    requireDisclaimer = expectedVersion == null,
   } = {},
 ) {
   const desktopManifest = JSON.parse(await readFile(join(desktopRoot, 'package.json'), 'utf8'));

--- a/scripts/verify-windows-x64.mjs
+++ b/scripts/verify-windows-x64.mjs
@@ -89,6 +89,13 @@ export async function verifyPackagedWindowsApp(
     smokeRenderer = smokePackagedRenderer,
     workingDirectory = appDirectory,
     expectedVersion,
+    // An expectedVersion historically marks a previously released baseline,
+    // which cannot be required to carry resources added after it shipped. A
+    // caller verifying a *current* build under a different version (the
+    // auto-update gate's upgraded install) overrides these to true so the
+    // sandbox and disclaimer checks are not silently skipped.
+    requireWindowsSandbox = expectedVersion === undefined,
+    requireDisclaimer = expectedVersion === undefined,
   } = {},
 ) {
   const desktopManifest = JSON.parse(await readFile(join(desktopRoot, 'package.json'), 'utf8'));
@@ -96,10 +103,6 @@ export async function verifyPackagedWindowsApp(
   const executable = join(appDirectory, executableName);
   const appAsar = join(resources, 'app.asar');
   const sandboxExecutable = join(resources, 'windows-sandbox', 'maka-windows-sandbox.exe');
-  const requireWindowsSandbox = expectedVersion === undefined;
-  // Same reason as the sandbox above: a packaged resource added after the
-  // baseline release cannot be required of that baseline.
-  const requireDisclaimer = expectedVersion === undefined;
 
   step('checking packaged resources');
   await requirePath(executable);


### PR DESCRIPTION
## What & why

Closes the **automatic updates** item of #2142 Phase 3 (distribution): the update service, `latest.yml` production, and the closed-app NSIS upgrade gate all existed, but no evidence ever exercised the actual in-app path — a running packaged app discovering, downloading, and installing a newer build through its own electron-updater. This PR adds that evidence end to end on the unsigned Windows x64 preview channel.

## What this does

**1. Loopback-only test feed override (`apps/desktop/src/main/app-update-service.ts`).** `MAKA_UPDATE_TEST_FEED` is resolved by an exported pure function that accepts exactly `http://127.0.0.1:<port>[/path]` and maps it to a generic provider. Any other value — remote host, `localhost`, another loopback alias, HTTPS, userinfo, query, malformed — **throws at construction**: a mistyped override must never silently fall back to the production GitHub feed. The override changes the feed URL and nothing else; with the variable unset the configuration is byte-identical to production (pinned by the existing unit test). Security posture: setting an env var on the app's process already requires same-user code execution, which under the per-user NSIS install model can rewrite the install directory directly — the hook crosses no privilege boundary, and update signature verification (once a certificate exists) applies to overridden feeds unchanged. Unit tests pin two accepted forms and eleven rejected confusion shapes.

**2. Version-bumped installer builder (`scripts/package-windows-autoupdate-next.mjs`).** Reuses the workspace build from a full `package:windows-x64` run and repackages NSIS-only with `extraMetadata.version` = patch+1, so the upgraded app genuinely reports the new version via `app.getVersion()`. Output goes to `apps/desktop/release-autoupdate-next`, **outside the release upload globs**, so fake-versioned artifacts can never reach a draft release. Asserts properties, not exit codes: exe/latest.yml/blockmap exist, latest.yml advertises exactly the bumped version and installer name, and its sha512 matches the installer byte for byte.

**3. End-to-end harness (`scripts/verify-windows-autoupdate.mjs`).** Installs the candidate, launches it against a loopback feed serving the bumped build, and asserts stage by stage with individual deadlines and named failures:

- renderer-driven `checkForUpdates` via CDP (`window.maka.app`), polled to the `downloaded` status with the exact `current → latest` version pair;
- feed request log: `latest.yml` and the installer were actually fetched (200/206), zero unexpected paths;
- `installUpdate` handoff (an evaluation dropped by the app quitting is the expected success shape; a structured refusal fails);
- old process exits; NSIS upgrades; **automatic relaunch is observed** and the on-disk image carries the new `ProductVersion`;
- the relaunched instance (spawned by NSIS without our CDP/user-data flags) is stopped promptly, then the full packaged smoke runs against the upgraded install with an added renderer-bridge assertion that `app.getVersion()` reports the bumped version;
- clean silent uninstall; cleanup mirrors the installer-lifecycle verifier (straggler kill, best-effort uninstall, AggregateError cause chaining).

`verify-packaged-app.mjs` generalizes its CDP internals into exported `evaluateInRenderer` / `findRendererTarget` / `reserveTcpPort` / `stopChild`; the existing smoke's assertions are unchanged.

**4. CI wiring.** Both `release-windows-check.yml` (PR gate; paths filter extended to the new scripts and `app-update-service.ts`) and `release-desktop.yml` (before asset upload, so a failure blocks the release) build the bumped installer and run the verification; timeouts raised 60→75 and 45→60 to absorb the ~8–10 minute addition.

**5. Docs.** `docs/windows-support.md` (EN + zh) now records what the gate proves and keeps the unproven remainder explicit: signature verification awaits an Authenticode certificate, business-data migration and mid-install rollback stay uncovered.

## Verification

- `npm --workspace @maka/desktop run typecheck` clean; desktop unit tests: the update-service suites pass 19/19 including the new feed-override tests (the workspace run shows 22 pre-existing local-environment failures — `EBUSY` SQLite cleanup and `EPERM` symlink — unrelated to this change and present on `main` locally).
- Pure pieces exercised directly: version-bump function (accept/reject shapes), platform guard, export surface, biome clean.
- **The full packaged end-to-end run could not be executed on the development machine** — it lacks Visual Studio Build Tools, which electron-builder needs to rebuild `node-pty` for Electron (and a pre-existing local `EBUSY` flake in `release-cli-eval-support.test.mjs` blocks `check:release` there as well). The authoritative end-to-end evidence is this PR's own `windows_sandbox`-style gate: `release-windows-check` runs the complete package → verify → **autoupdate** chain on `windows-2025`. Treat that lane's result as the verification for this PR; I will iterate on it if it surfaces harness issues.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Fable 5 (Anthropic), driven by the human contributor of record, authored the feed-override hook and tests, the bumped-installer builder, the end-to-end harness, the CI wiring, and the documentation updates, all under human review. Commits carry `Generated-by: Claude Fable 5` trailers; the final squash commit must retain them.
