### PR TITLE
test(computer-use): await disposal cleanup

### DIFF
--- a/packages/computer-use/src/__tests__/maka-cu-service.test.ts
+++ b/packages/computer-use/src/__tests__/maka-cu-service.test.ts
@@ -153,6 +153,16 @@ async function waitForRecord(
   }
 }
 
+async function waitForPathRemoval(path: string, deadlineMs = 2000): Promise<void> {
+  const startedAt = Date.now();
+  while (existsSync(path)) {
+    if (Date.now() - startedAt >= deadlineMs) {
+      assert.fail(`${path} still exists after ${deadlineMs}ms`);
+    }
+    await delay(10);
+  }
+}
+
 function makeService(
   opts: {
     limits?: Partial<MakaCuLimits>;
@@ -494,7 +504,6 @@ describe('maka-cu supervisor: shutdown', () => {
     void starting.catch(() => {});
     service.dispose();
     await starting.catch(() => {});
-    await delay(150);
-    assert.equal(existsSync(imageDir), false, `${imageDir} must not survive dispose()`);
+    await waitForPathRemoval(imageDir);
   });
 });


### PR DESCRIPTION
## Summary

Replace the fixed 150 ms sleep in the Computer Use startup-disposal regression with a condition-based, bounded wait for the Host-owned image directory to disappear.

The existing production cleanup is asynchronous by contract. Under a loaded CI workspace, the cleanup can finish after 150 ms even though it succeeds; this produced the unrelated `test_workspaces` failure observed on #2521. The test now retains a 2-second failure bound while completing as soon as the cleanup condition is true.

## Verification

- Full repository build passed.
- `@maka/computer-use` tests: 118/118 passed.
- Biome check passed for the changed test.
- Diff check passed.
- The failing #2521 exact head passed the original focused test 10/10 on local reruns, confirming this is a timing-sensitive baseline test rather than a product-code regression.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex (Maka) diagnosed the CI log, implemented the bounded condition wait, and ran local verification. The author reviewed the final diff and test evidence. The commit includes `Generated-by: Maka`; please retain it in the final squash commit.

## Checklist

- [x] Tests cover the change and fail without it under the observed loaded-CI timing
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No