### PR TITLE
fix(desktop): hide workbar chrome behind settings

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -19,3 +19,31 @@ test('opening settings commits an active titlebar rename', async ({ window: page
 
   await expect(identity).toContainText('renamed before settings');
 });
+
+test('settings hides expanded workbar chrome and restores it on close', async ({
+  window: page,
+}) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('create a session with an expanded workbar');
+  await composer.press('Enter');
+
+  await page.getByRole('button', { name: '展开任务工作栏' }).click();
+  const workbar = page.locator('.maka-session-workbar[data-placement="right"]');
+  const workbarToolbar = workbar.getByRole('toolbar', { name: '任务工作栏标签' });
+  await expect(workbarToolbar).toBeVisible();
+  await expect(workbarToolbar.getByRole('button', { name: '打开工作栏标签' })).toBeVisible();
+  await expect(workbarToolbar.getByRole('button', { name: '收起任务工作栏' })).toBeVisible();
+  await page
+    .getByRole('button', { name: /待办.*查看和维护这个任务的待办台账/ })
+    .click();
+  const taskTab = workbarToolbar.getByRole('tab', { name: '待办' });
+  await expect(taskTab).toBeVisible();
+
+  await page.getByRole('button', { name: '设置' }).click();
+  await expect(page.getByRole('main', { name: '设置内容' })).toBeVisible();
+  await expect(workbar).not.toBeVisible();
+
+  await page.keyboard.press('Escape');
+  await expect(workbarToolbar).toBeVisible();
+  await expect(taskTab).toBeVisible();
+});

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -703,7 +703,8 @@ export function SessionWorkbar(props: {
         const activeTab = panel.tabs.find((tab) => tab.id === panel.activeTabId);
         const showingLauncher = panel.launcherOpen || !activeTab;
         const visible =
-          placement === 'right' ? !props.rightCollapsed : props.bottomOpen;
+          !props.hidden &&
+          (placement === 'right' ? !props.rightCollapsed : props.bottomOpen);
         return (
           <Card
             key={placement}


### PR DESCRIPTION
## Summary

Hide the complete session Workbar while Settings owns the window, including its tabs, add button, and right-panel toggle. Closing Settings restores the previously expanded Workbar and its active tabs.

`ChatWorkbar` already forwards the shell's obscured state as `hidden`, but `SessionWorkbar` only applied it to panel content. Its titlebar-level toolbar remained visible whenever the right Workbar was expanded. Folding `hidden` into the placement visibility condition removes the whole Workbar frame without unmounting its state.

This fixes the residual Workbar-owned toolbar leak after #2617. It is related to #2628, but that PR plans AppShell titlebar actions and does not hide the tab strip rendered inside `SessionWorkbar`.

## Verification

- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:with-deps`
- `npx playwright test e2e/settings.spec.ts --config e2e/playwright.config.ts` — 2 passed
- `npm run lint` — 2,446 files checked
- `npm run format:check` — 1,539 files checked
- `git diff --check`

The regression test opens a real Workbar tab, opens Settings, asserts the entire right Workbar is hidden, then closes Settings and asserts the prior tab is restored.

## Visual evidence

| Before — Workbar chrome leaks above Settings | After — Settings owns the full window |
| --- | --- |
| <img width="640" alt="Before: the Workbar tab, add button, and right-panel toggle remain visible above Settings" src="https://github.com/user-attachments/assets/c4f1131f-0e72-4706-a795-1fa8c4f702d5" /> | <img width="640" alt="After: Settings is shown without any Workbar chrome" src="https://github.com/user-attachments/assets/bd0d3054-7c82-4c85-81c8-b75949736dbb" /> |

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex (OpenAI) — root-cause analysis, implementation, regression test, and validation. The contributor reviewed the result and owns the final submission. The affected commit carries a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
