### PR TITLE
ci: reduce pull request runner usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,105 +5,71 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
-  changes:
+  # Planning and every selected Linux surface share one runner, so the core
+  # workflow consumes one automatic job without dropping affected coverage.
+  test:
     runs-on: ubuntu-latest
-    outputs:
-      astryx_surface: ${{ steps.plan.outputs.astryx_surface }}
-      code: ${{ steps.plan.outputs.code }}
-      e2e: ${{ steps.plan.outputs.e2e }}
-      runtime_host: ${{ steps.plan.outputs.runtime_host }}
-      runtime_sandbox: ${{ steps.plan.outputs.runtime_sandbox }}
-      standard_workspaces: ${{ steps.plan.outputs.standard_workspaces }}
-      storage_stress: ${{ steps.plan.outputs.storage_stress }}
-      storybook: ${{ steps.plan.outputs.storybook }}
-      unit: ${{ steps.plan.outputs.unit }}
-      workspaces: ${{ steps.plan.outputs.workspaces }}
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
+
       - id: plan
         name: Select affected test surfaces
         env:
           BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
         run: |
-          # A merged PR has already been tested by impact. Re-run the same
-          # affected surfaces for the exact main-branch delta instead of
-          # turning every push (including docs-only pushes) into a full suite.
-          # New branches and unavailable history still fail safe to full.
-          if [[ "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "${BASE_SHA}^{commit}"; then
+          # PR checks may predate later main changes, so the single core job also
+          # validates the exact merged delta. Dispatches and unavailable history
+          # fail safe to every surface.
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || [[ "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "${BASE_SHA}^{commit}"; then
             node scripts/ci-test-plan.mjs --full >> "$GITHUB_OUTPUT"
           else
             node scripts/ci-test-plan.mjs --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_OUTPUT"
           fi
 
-  astryx_surface:
-    needs: changes
-    if: needs.changes.outputs.astryx_surface == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-      - name: Astryx surface inventory
-        run: npm run astryx:surface-inventory
+      - name: Test CI planner
+        run: node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs
 
-  typecheck:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.plan.outputs.code == 'true' || steps.plan.outputs.astryx_surface == 'true' || steps.plan.outputs.cli_package == 'true'
         with:
           node-version: '24'
           cache: npm
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run format:check
-      - run: npm run build
-      - run: npm run typecheck
-      # Generated-artifact governance. astryx-theme/maka.{css,js} are built
-      # from makaTheme.ts, which is now the renderer's type-scale authority —
-      # editing the scale without regenerating would leave the authority and
-      # the shipped ladder disagreeing, and nothing else would notice.
-      - name: Astryx theme drift
-        run: npm run astryx:theme -- --check
-      # Dead-code / dependency governance. Entry points and reasoned ignores
-      # live in knip.json; both workspaces must stay at zero findings.
-      - name: Knip (apps/desktop)
-        run: npx knip --workspace apps/desktop
-      - name: Knip (packages/ui)
-        run: npx knip --workspace packages/ui
-  test_workspaces:
-    needs: changes
-    if: needs.changes.outputs.standard_workspaces != ''
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+
+      - name: Select the release npm toolchain
+        if: steps.plan.outputs.cli_package == 'true'
+        run: npm install --global --no-audit --no-fund "$(node -p 'require("./package.json").packageManager')"
+
+      - name: Restore Electron artifact cache
+        if: steps.plan.outputs.code == 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          node-version: '24'
-          cache: npm
+          path: ~/.cache/electron
+          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: electron-${{ runner.os }}-
+
       - name: Install Linux runtime dependencies
-        if: needs.changes.outputs.runtime_sandbox == 'true'
+        if: steps.plan.outputs.runtime_sandbox == 'true'
         run: sudo apt-get update && sudo apt-get install -y ripgrep bubblewrap
+
       # Ubuntu 24.04 hosted runners gate unprivileged user namespaces through
       # AppArmor, which otherwise makes bwrap fail while configuring loopback.
       - name: Enable bubblewrap user namespaces
-        if: needs.changes.outputs.runtime_sandbox == 'true'
+        if: steps.plan.outputs.runtime_sandbox == 'true'
         run: |
           if [[ -e /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]]; then
             sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
@@ -111,133 +77,96 @@ jobs:
           if [[ -e /proc/sys/kernel/unprivileged_userns_clone ]]; then
             sudo sysctl -w kernel.unprivileged_userns_clone=1
           fi
-      - run: npm ci
-      # build:test skips the renderer bundle (vite); test:dist only consumes
-      # tsc outputs (dist/main + dist/renderer side-files), never the vite
-      # bundle. e2e builds its own renderer in a separate job.
-      - run: npm run build:test
+
+      - name: Install dependencies
+        if: steps.plan.outputs.code == 'true' || steps.plan.outputs.cli_package == 'true'
+        run: npm ci
+
+      - name: Lint
+        if: steps.plan.outputs.code == 'true'
+        run: npm run lint
+
+      - name: Check formatting
+        if: steps.plan.outputs.code == 'true'
+        run: npm run format:check
+
+      - name: Check Windows test inventory
+        continue-on-error: true
+        run: npm run windows:inventory
+
+      - name: Build
+        if: steps.plan.outputs.code == 'true'
+        run: npm run build
+
+      - name: Typecheck
+        if: steps.plan.outputs.code == 'true'
+        run: npm run typecheck
+
+      - name: Astryx surface inventory
+        if: steps.plan.outputs.astryx_surface == 'true'
+        run: npm run astryx:surface-inventory
+
+      - name: Astryx theme drift
+        if: steps.plan.outputs.code == 'true'
+        run: npm run astryx:theme -- --check
+
+      - name: Knip (apps/desktop)
+        if: steps.plan.outputs.code == 'true'
+        run: npx knip --workspace apps/desktop
+
+      - name: Knip (packages/ui)
+        if: steps.plan.outputs.code == 'true'
+        run: npx knip --workspace packages/ui
+
       - name: Linux sandbox smoke
-        if: needs.changes.outputs.runtime_sandbox == 'true'
+        if: steps.plan.outputs.runtime_sandbox == 'true'
         env:
           MAKA_REQUIRE_LINUX_SANDBOX_SMOKE: '1'
         run: npm exec -w @maka/runtime -- node --test dist/__tests__/linux-sandbox-smoke.test.js
-      # Workspaces consume the dist built above. Selection includes reverse
-      # dependencies, while bounded concurrency avoids both the old serial
-      # critical path and an unbounded process stampede on two-core runners.
+
       - name: Run affected standard workspace tests
-        if: needs.changes.outputs.standard_workspaces != ''
+        if: steps.plan.outputs.standard_workspaces != ''
         env:
-          STORAGE_STRESS: ${{ needs.changes.outputs.storage_stress }}
-          WORKSPACES: ${{ needs.changes.outputs.standard_workspaces }}
+          STORAGE_STRESS: ${{ steps.plan.outputs.storage_stress }}
+          WORKSPACES: ${{ steps.plan.outputs.standard_workspaces }}
         run: |
           if [[ "$STORAGE_STRESS" == "true" ]]; then
             export MAKA_STORAGE_STRESS=1
           fi
           node scripts/run-workspace-tests-parallel.mjs --concurrency=3 --workspaces="$WORKSPACES"
 
-  test_runtime_host:
-    needs: changes
-    if: needs.changes.outputs.runtime_host == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-          cache: npm
-      - run: npm ci
-      - run: npm run build:test
       - name: Run Runtime Host tests
+        if: steps.plan.outputs.runtime_host == 'true'
         run: npm --workspace @maka/runtime-host run test:dist
 
-  # Preserve one stable required check while letting independent heavy suites
-  # occupy their own runners. The aggregator waits for every selected lane.
-  test:
-    needs: [changes, test_workspaces, test_runtime_host]
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require successful test lanes
-        env:
-          CHANGES_RESULT: ${{ needs.changes.result }}
-          RUNTIME_HOST_RESULT: ${{ needs.test_runtime_host.result }}
-          RUNTIME_HOST_SELECTED: ${{ needs.changes.outputs.runtime_host }}
-          STANDARD_WORKSPACES: ${{ needs.changes.outputs.standard_workspaces }}
-          WORKSPACES_RESULT: ${{ needs.test_workspaces.result }}
-        run: |
-          if [[ "$CHANGES_RESULT" != "success" ]]; then
-            echo "changes failed: $CHANGES_RESULT" >&2
-            exit 1
-          fi
-          require_lane() {
-            local name="$1"
-            local selected="$2"
-            local result="$3"
-            local expected="skipped"
-            if [[ "$selected" == "true" ]]; then
-              expected="success"
-            fi
-            if [[ "$result" != "$expected" ]]; then
-              echo "$name expected $expected but was $result" >&2
-              exit 1
-            fi
-          }
-          workspaces_selected="false"
-          if [[ -n "$STANDARD_WORKSPACES" ]]; then
-            workspaces_selected="true"
-          fi
-          require_lane "workspace tests" "$workspaces_selected" "$WORKSPACES_RESULT"
-          require_lane "Runtime Host tests" "$RUNTIME_HOST_SELECTED" "$RUNTIME_HOST_RESULT"
-
-  # One Electron job: install once, run the (now small) e2e suite, then the
-  # CDP alignment audit against the same built renderer. Dual shards plus a
-  # separate audit job each paid full npm ci + cold build after the suite
-  # slash; that was pure wall-clock and runner waste.
-  e2e:
-    needs: changes
-    if: needs.changes.outputs.e2e == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-          cache: npm
-      - name: Restore Electron artifact cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/electron
-          key: electron-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: electron-${{ runner.os }}-
-      - run: npm ci
       - name: Ensure xvfb
+        if: steps.plan.outputs.e2e == 'true'
         run: command -v xvfb-run >/dev/null 2>&1 || { sudo apt-get update && sudo apt-get install -y xvfb; }
+
       - name: Desktop e2e
-        run: xvfb-run -a npm --workspace @maka/desktop run e2e
+        if: steps.plan.outputs.e2e == 'true'
+        run: xvfb-run -a npm exec -w @maka/desktop -- playwright test --config e2e/playwright.config.ts
+
       - name: Alignment audit
+        if: steps.plan.outputs.e2e == 'true'
         run: xvfb-run -a node scripts/audit-alignment.mjs
-  # Storybook build + initial render smoke. Embedded mode disables every play
-  # function, so this lane never duplicates desktop interaction or layout E2E.
-  # It launches Chromium only to catch catalog runtime errors. See FIDELITY.md.
-  storybook:
-    needs: changes
-    if: needs.changes.outputs.storybook == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: '24'
-          cache: npm
-      - run: npm ci
-      # Stories import @maka/core / @maka/ui package exports (dist/). The old
-      # e2e job paid for this via `build:with-deps`; the split job must too.
-      - name: Build workspace packages
-        run: npm --workspace @maka/desktop run build:workspace-deps
-      # The smoke calls `chromium.launch()`; Electron's binary is irrelevant.
+
       - name: Install Playwright Chromium
+        if: steps.plan.outputs.storybook == 'true'
         run: npx playwright install --with-deps chromium
+
       - name: Build Storybook
+        if: steps.plan.outputs.storybook == 'true'
         run: npm --workspace @maka/desktop run build-storybook
+
       - name: Storybook smoke
+        if: steps.plan.outputs.storybook == 'true'
         run: npm --workspace @maka/desktop run smoke:storybook
+
+      - name: Build CLI release candidate
+        if: steps.plan.outputs.cli_package == 'true'
+        run: npm run release:cli:pack
+
+      - name: Validate installed CLI release candidate
+        if: steps.plan.outputs.cli_package == 'true'
+        run: npm run release:cli:smoke

--- a/.github/workflows/cli-package-validation.yml
+++ b/.github/workflows/cli-package-validation.yml
@@ -1,64 +1,6 @@
 name: CLI package validation
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - '.github/workflows/cli-package-validation.yml'
-      - '.github/workflows/release-cli-*.yml'
-      - '.gitattributes'
-      - '.npmrc'
-      - 'LICENSE'
-      - 'NOTICE'
-      - 'DISCLAIMER-WIP'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - 'packages/cli/**'
-      - 'packages/code-mode/**'
-      - 'packages/core/**'
-      - 'packages/eval/**'
-      - 'packages/mcp/**'
-      - 'packages/runtime/**'
-      - 'packages/runtime-host/**'
-      - 'packages/storage/**'
-      - 'scripts/apply-dependency-patches.mjs'
-      - 'scripts/clean-paths.mjs'
-      - 'scripts/generate-third-party-notices.mjs'
-      - 'scripts/install-electron-with-retry.mjs'
-      - 'scripts/npm-spawn.mjs'
-      - 'scripts/release-cli-*.mjs'
-      - 'scripts/smoke-release-cli-package.mjs'
-      - 'tsconfig*.json'
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/cli-package-validation.yml'
-      - '.github/workflows/release-cli-*.yml'
-      - '.gitattributes'
-      - '.npmrc'
-      - 'LICENSE'
-      - 'NOTICE'
-      - 'DISCLAIMER-WIP'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'patches/**'
-      - 'packages/cli/**'
-      - 'packages/code-mode/**'
-      - 'packages/core/**'
-      - 'packages/eval/**'
-      - 'packages/mcp/**'
-      - 'packages/runtime/**'
-      - 'packages/runtime-host/**'
-      - 'packages/storage/**'
-      - 'scripts/apply-dependency-patches.mjs'
-      - 'scripts/clean-paths.mjs'
-      - 'scripts/generate-third-party-notices.mjs'
-      - 'scripts/install-electron-with-retry.mjs'
-      - 'scripts/npm-spawn.mjs'
-      - 'scripts/release-cli-*.mjs'
-      - 'scripts/smoke-release-cli-package.mjs'
-      - 'tsconfig*.json'
   workflow_call:
     outputs:
       release_candidate_artifact_id:
@@ -71,7 +13,6 @@ permissions:
 
 concurrency:
   group: cli-package-validation-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/windows-baseline.yml
+++ b/.github/workflows/windows-baseline.yml
@@ -1,11 +1,6 @@
 name: Windows baseline
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
-  # Nightly full storage suite (PR/push keep curated OS-sensitive gates only).
   schedule:
     - cron: '17 6 * * *'
   workflow_dispatch:
@@ -17,53 +12,12 @@ on:
 
 concurrency:
   group: windows-baseline-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      windows: ${{ steps.plan.outputs.windows }}
-      windows_runtime: ${{ steps.plan.outputs.windows_runtime }}
-      windows_storage: ${{ steps.plan.outputs.windows_storage }}
-      # Full suite is never selected by path plan — only schedule / dispatch.
-      windows_storage_full: ${{ steps.full.outputs.windows_storage_full }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-      - id: plan
-        name: Select affected Windows surfaces
-        env:
-          BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event_name == 'push' && github.sha || github.event.pull_request.head.sha }}
-        run: |
-          # schedule / manual dispatch have no meaningful PR base; use full
-          # surface selection so the job still runs install+smoke+gates.
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            node scripts/ci-test-plan.mjs --full >> "$GITHUB_OUTPUT"
-          elif [[ "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "${BASE_SHA}^{commit}"; then
-            node scripts/ci-test-plan.mjs --full >> "$GITHUB_OUTPUT"
-          else
-            node scripts/ci-test-plan.mjs --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_OUTPUT"
-          fi
-      - id: full
-        name: Decide full storage suite
-        run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "windows_storage_full=true" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.full_storage }}" == "true" ]]; then
-            echo "windows_storage_full=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "windows_storage_full=false" >> "$GITHUB_OUTPUT"
-          fi
-
   windows_baseline:
-    needs: changes
-    if: needs.changes.outputs.windows == 'true'
     name: windows_baseline (non-blocking)
     runs-on: windows-latest
     timeout-minutes: 45
@@ -125,17 +79,6 @@ jobs:
           Get-Content "$env:WINDOWS_BASELINE_LOG_DIR/build.log"
           exit $exitCode
 
-      - id: inventory
-        name: Check Windows skip inventory
-        if: always() && steps.install.outcome == 'success'
-        continue-on-error: true
-        shell: pwsh
-        run: |
-          npm.cmd run windows:inventory *> "$env:WINDOWS_BASELINE_LOG_DIR/inventory.log"
-          $exitCode = $LASTEXITCODE
-          Get-Content "$env:WINDOWS_BASELINE_LOG_DIR/inventory.log"
-          exit $exitCode
-
       - id: smoke
         name: Run CLI and Electron startup smoke
         if: always() && steps.build.outcome == 'success'
@@ -153,7 +96,7 @@ jobs:
 
       - id: runtime_pty_input
         name: Run Runtime PTY input gates
-        if: always() && steps.build.outcome == 'success' && needs.changes.outputs.windows_runtime == 'true'
+        if: always() && steps.build.outcome == 'success'
         continue-on-error: true
         timeout-minutes: 5
         shell: pwsh
@@ -170,7 +113,7 @@ jobs:
 
       - id: runtime_powershell_encoding
         name: Run Runtime PowerShell UTF-8 gates
-        if: always() && steps.build.outcome == 'success' && needs.changes.outputs.windows_runtime == 'true'
+        if: always() && steps.build.outcome == 'success'
         continue-on-error: true
         timeout-minutes: 5
         shell: pwsh
@@ -193,7 +136,7 @@ jobs:
       # fight for disk under high fan-out.
       - id: storage
         name: Run Windows storage path and lock gates
-        if: always() && steps.build.outcome == 'success' && needs.changes.outputs.windows_storage == 'true'
+        if: always() && steps.build.outcome == 'success'
         continue-on-error: true
         timeout-minutes: 12
         shell: pwsh
@@ -213,12 +156,12 @@ jobs:
             2>&1 | Tee-Object -FilePath "$env:WINDOWS_BASELINE_LOG_DIR/storage.log"
           exit $LASTEXITCODE
 
-      # Full suite is evidence-only: nightly + manual dispatch. Do not run on
-      # ordinary PRs — Linux unit already covers the package, and the full
-      # Windows wall clock is ~10 minutes.
+      # Full suite is evidence-only and requires an explicit manual opt-in.
+      # Linux unit already covers the package, while the full Windows wall
+      # clock is ~10 minutes.
       - id: storage_full
         name: Capture full storage suite baseline
-        if: always() && steps.build.outcome == 'success' && needs.changes.outputs.windows_storage_full == 'true'
+        if: always() && steps.build.outcome == 'success' && (github.event_name == 'schedule' || inputs.full_storage)
         continue-on-error: true
         timeout-minutes: 25
         shell: pwsh
@@ -326,12 +269,11 @@ jobs:
           |---|---|
           | Install | ${{ steps.install.outcome }} |
           | Build | ${{ steps.build.outcome }} |
-          | Skip inventory | ${{ steps.inventory.outcome }} |
           | CLI / Electron smoke | ${{ steps.smoke.outcome }} |
           | Storage path/lock gates | ${{ steps.storage.outcome }} |
           | Runtime PTY input | ${{ steps.runtime_pty_input.outcome }} |
           | Runtime PowerShell UTF-8 | ${{ steps.runtime_powershell_encoding.outcome }} |
-          | Full storage suite (nightly/manual) | ${{ steps.storage_full.outcome }} |
+          | Full storage suite (nightly or manual opt-in) | ${{ steps.storage_full.outcome }} |
           | Residual processes | ${{ steps.processes.outcome }} |
 
           Download the `windows-baseline` artifact for complete logs.

--- a/.github/workflows/windows-recovery.yml
+++ b/.github/workflows/windows-recovery.yml
@@ -1,15 +1,10 @@
 name: Windows recovery
 
 on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:
   group: windows-recovery-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,8 +152,8 @@ npx knip --workspace apps/desktop
 npx knip --workspace packages/ui
 ```
 
-The CI job named `typecheck` runs all of them under `bash -e`, so the first
-failure aborts the rest — read which step failed, not the job name.
+The CI job named `test` runs all of them as separate steps, so read which step
+failed rather than relying on the job name.
 
 ## Branch naming
 

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -145,7 +145,7 @@ npx knip --workspace apps/desktop
 npx knip --workspace packages/ui
 ```
 
-CI 里名为 `typecheck` 的 job 会在 `bash -e` 下跑完上面全部命令，第一个失败会中止其余——要看是哪个 step 失败，别看 job 名字。
+CI 里名为 `test` 的 job 会把上面这些命令作为独立 step 依次执行，第一个失败会中止其余——要看是哪个 step 失败，别看 job 名字。
 
 ## 分支命名
 

--- a/scripts/ci-test-plan.mjs
+++ b/scripts/ci-test-plan.mjs
@@ -24,25 +24,40 @@ const TYPECHECK_ONLY_FILES = new Set([
   'tsconfig.lib.json',
 ]);
 
-const WINDOWS_BASELINE_FILES = new Set([
-  '.github/workflows/windows-baseline.yml',
-  'scripts/windows-process-identity.ps1',
-  'scripts/windows-smoke.mjs',
+const CLI_PACKAGE_FILES = new Set([
+  '.gitattributes',
+  '.npmrc',
+  'DISCLAIMER-WIP',
+  'LICENSE',
+  'NOTICE',
+  'package-lock.json',
+  'package.json',
+  'scripts/apply-dependency-patches.mjs',
+  'scripts/clean-paths.mjs',
+  'scripts/generate-third-party-notices.mjs',
+  'scripts/install-electron-with-retry.mjs',
+  'scripts/npm-spawn.mjs',
+  'scripts/smoke-release-cli-package.mjs',
 ]);
 
-/**
- * Storage seams that exercise Windows-specific path, lock, crash, or NTFS
- * behavior. Catalog/session SQLite unit changes stay on Linux; only these
- * paths open the Windows storage gate lane.
- */
-const WINDOWS_STORAGE_SENSITIVE_PATH =
-  /(^|\/)(root-authority|managed-dependency-environment|managed-workspace|git-workspace-service|git-worktree|workspace-root|workspace-identity|marker-file|write-queue|artifact-writer-lock|sqlite-recovery-concurrency|sqlite-runtime-crash|sqlite-long-term-memory-crash)([./_-]|$)/u;
+const CLI_PACKAGE_WORKSPACES = [
+  'packages/cli',
+  'packages/code-mode',
+  'packages/core',
+  'packages/eval',
+  'packages/mcp',
+  'packages/runtime',
+  'packages/runtime-host',
+  'packages/storage',
+];
 
-export function isWindowsStorageSensitivePath(path) {
-  const normalized = normalizePath(path);
-  if (normalized === 'packages/storage/package.json') return true;
-  if (!normalized.startsWith('packages/storage/')) return false;
-  return WINDOWS_STORAGE_SENSITIVE_PATH.test(normalized);
+function isCliPackagePath(path) {
+  if (CLI_PACKAGE_FILES.has(path) || path.startsWith('patches/')) return true;
+  if (path.startsWith('scripts/release-cli-')) return true;
+  if (path.startsWith('tsconfig') && path.endsWith('.json')) return true;
+  return CLI_PACKAGE_WORKSPACES.some(
+    (workspace) => path === workspace || path.startsWith(`${workspace}/`),
+  );
 }
 
 const DEDICATED_WORKSPACE_LANES = new Set(['packages/runtime-host']);
@@ -230,6 +245,7 @@ export function planTests(changedFiles, options = {}) {
     const workspaces = [...graph.dirs];
     return {
       astryxSurface: true,
+      cliPackage: true,
       code: true,
       e2e: true,
       full: true,
@@ -240,9 +256,6 @@ export function planTests(changedFiles, options = {}) {
       // every unrelated merge into a 10K-chunk pressure run.
       storageStress: false,
       storybook: true,
-      windows: true,
-      windowsRuntime: true,
-      windowsStorage: true,
       workspaces,
       ...workspaceLanes(workspaces, graph),
     };
@@ -290,17 +303,10 @@ export function planTests(changedFiles, options = {}) {
 
   const workspaces = reverseDependencyClosure(directWorkspaces, graph);
   const storageStress = files.some((path) => STORAGE_STRESS_FILES.has(path));
-  const windowsBaselineChanged = files.includes('.github/workflows/windows-baseline.yml');
-  const windows = code || files.some((path) => WINDOWS_BASELINE_FILES.has(path));
-  const windowsRuntime = windowsBaselineChanged || workspaces.includes('packages/runtime');
-  // Not every packages/storage edit needs Windows: reverse-dep closure would
-  // also open this lane for any desktop/runtime consumer of storage. Gate on
-  // path/lock/crash-sensitive files only.
-  const windowsStorage =
-    windowsBaselineChanged || files.some((path) => isWindowsStorageSensitivePath(path));
 
   return {
     astryxSurface: files.some((path) => isAstryxSurfaceInventoryPath(path)),
+    cliPackage: files.some((path) => isCliPackagePath(path)),
     code,
     // Electron E2E + alignment audit (same job). Product desktop/ui sources and
     // e2e drivers only — a storage/runtime change must not drag cold Electron
@@ -317,9 +323,6 @@ export function planTests(changedFiles, options = {}) {
     // PR — product ship gates are typecheck, unit, and Electron e2e. See
     // isStorybookPath.
     storybook: files.some((path) => isStorybookPath(path)),
-    windows,
-    windowsRuntime,
-    windowsStorage,
     workspaces,
     ...workspaceLanes(workspaces, graph),
   };
@@ -328,19 +331,14 @@ export function planTests(changedFiles, options = {}) {
 export function formatGitHubOutputs(plan) {
   return [
     `astryx_surface=${plan.astryxSurface}`,
+    `cli_package=${plan.cliPackage}`,
     `code=${plan.code}`,
     `e2e=${plan.e2e}`,
-    `full=${plan.full}`,
     `runtime_host=${plan.runtimeHost}`,
     `runtime_sandbox=${plan.runtimeSandbox}`,
     `storage_stress=${plan.storageStress}`,
     `storybook=${plan.storybook}`,
-    `unit=${plan.workspaces.length > 0}`,
-    `windows=${plan.windows}`,
-    `windows_runtime=${plan.windowsRuntime}`,
-    `windows_storage=${plan.windowsStorage}`,
     `standard_workspaces=${plan.standardWorkspaces.join(',')}`,
-    `workspaces=${plan.workspaces.join(',')}`,
   ].join('\n');
 }
 

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+
+import { formatGitHubOutputs, planTests } from './ci-test-plan.mjs';
+
+const dirs = [
+  'packages/core',
+  'packages/storage',
+  'packages/runtime',
+  'packages/runtime-host',
+  'packages/cli',
+  'packages/ui',
+  'apps/desktop',
+];
+
+const graph = {
+  dirs,
+  dependents: new Map([
+    ['packages/core', new Set(['packages/storage', 'packages/runtime'])],
+    ['packages/storage', new Set(['packages/runtime', 'packages/runtime-host'])],
+    ['packages/runtime', new Set(['packages/runtime-host', 'packages/cli', 'apps/desktop'])],
+    ['packages/runtime-host', new Set(['packages/cli', 'apps/desktop'])],
+    ['packages/cli', new Set()],
+    ['packages/ui', new Set(['apps/desktop'])],
+    ['apps/desktop', new Set()],
+  ]),
+  testDirs: new Set(dirs),
+};
+
+test('documentation-only changes do not select code validation', () => {
+  const plan = planTests(['docs/ci.md'], { graph });
+
+  assert.equal(plan.code, false);
+  assert.equal(plan.astryxSurface, false);
+  assert.deepEqual(plan.workspaces, []);
+});
+
+test('the Astryx inventory can run without selecting the code suite', () => {
+  const plan = planTests(['docs/astryx-surface-file-inventory.md'], { graph });
+
+  assert.equal(plan.code, false);
+  assert.equal(plan.astryxSurface, true);
+});
+
+test('desktop renderer changes retain Electron and Storybook coverage', () => {
+  const plan = planTests(['apps/desktop/src/renderer/app.tsx'], { graph });
+
+  assert.equal(plan.code, true);
+  assert.equal(plan.e2e, true);
+  assert.equal(plan.storybook, true);
+  assert.equal(plan.astryxSurface, true);
+  assert.deepEqual(plan.standardWorkspaces, ['apps/desktop']);
+});
+
+test('Storybook catalog changes avoid real-window E2E and workspace tests', () => {
+  const plan = planTests(['apps/desktop/stories/settings.stories.tsx'], { graph });
+
+  assert.equal(plan.code, true);
+  assert.equal(plan.e2e, false);
+  assert.equal(plan.storybook, true);
+  assert.deepEqual(plan.workspaces, []);
+});
+
+test('runtime changes retain the dedicated Runtime Host lane', () => {
+  const plan = planTests(['packages/runtime/src/runtime.ts'], { graph });
+
+  assert.equal(plan.runtimeHost, true);
+  assert.equal(plan.runtimeSandbox, true);
+  assert.deepEqual(plan.standardWorkspaces, ['packages/runtime', 'packages/cli', 'apps/desktop']);
+});
+
+test('CLI release inputs select installed-package validation', () => {
+  const plan = planTests(['packages/runtime/src/runtime.ts'], { graph });
+
+  assert.equal(plan.cliPackage, true);
+});
+
+test('release metadata selects installed-package validation', () => {
+  assert.equal(planTests(['LICENSE'], { graph }).cliPackage, true);
+});
+
+test('desktop-only changes skip installed-package validation', () => {
+  assert.equal(planTests(['apps/desktop/src/main.ts'], { graph }).cliPackage, false);
+});
+
+test('full selection covers every live surface', () => {
+  const plan = planTests([], { graph, forceFull: true });
+
+  assert.equal(plan.full, true);
+  assert.equal(plan.cliPackage, true);
+  assert.equal(plan.code, true);
+  assert.equal(plan.e2e, true);
+  assert.equal(plan.storybook, true);
+  assert.equal(plan.runtimeHost, true);
+  assert.deepEqual(plan.workspaces, dirs);
+});
+
+test('unknown top-level code fails safe to full selection', () => {
+  assert.equal(planTests(['unknown.config'], { graph }).full, true);
+});
+
+test('full-suite authority files select every surface', () => {
+  for (const path of ['package-lock.json', '.github/workflows/ci.yml']) {
+    assert.equal(planTests([path], { graph }).full, true, path);
+  }
+});
+
+test('GitHub output matches the selections consumed by CI', () => {
+  const output = formatGitHubOutputs(planTests([], { graph, forceFull: true }));
+  const outputKeys = new Set(output.split('\n').map((line) => line.split('=', 1)[0]));
+  const workflow = readWorkflow('ci.yml');
+  const consumedKeys = new Set(
+    [...workflow.matchAll(/steps\.plan\.outputs\.([a-z0-9_]+)/gu)].map((match) => match[1]),
+  );
+
+  assert.deepEqual(outputKeys, consumedKeys);
+});
+
+test('core CI validates pull requests and the resulting main branch state', () => {
+  const workflow = readWorkflow('ci.yml');
+
+  assert.match(workflow, /pull_request:\n\s+branches: \[main\]/u);
+  assert.match(workflow, /push:\n\s+branches: \[main\]/u);
+  assert.match(
+    workflow,
+    /BASE_SHA: \$\{\{ github\.event_name == 'push' && github\.event\.before \|\| github\.event\.pull_request\.base\.sha \}\}/u,
+  );
+  assert.match(
+    workflow,
+    /HEAD_SHA: \$\{\{ github\.event_name == 'push' && github\.sha \|\| github\.event\.pull_request\.head\.sha \}\}/u,
+  );
+  assert.match(workflow, /\[\[ "\$BASE_SHA" =~ \^0\+\$ \]\]/u);
+});
+
+test('core CI uses the Windows inventory package-script authority', () => {
+  const workflow = readWorkflow('ci.yml');
+
+  assert.match(workflow, /run: npm run windows:inventory/u);
+  assert.doesNotMatch(workflow, /run: node scripts\/windows-test-inventory\.mjs --check/u);
+});
+
+test('CI planner contracts run before dependency setup on every change', () => {
+  const workflow = readWorkflow('ci.yml');
+  const testStepStart = workflow.indexOf('      - name: Test CI planner\n');
+  const setupNodeStart = workflow.indexOf('      - uses: actions/setup-node@');
+  const testStepEnd = workflow.indexOf('\n      - ', testStepStart + 1);
+
+  assert.ok(testStepStart >= 0);
+  assert.ok(testStepStart < setupNodeStart);
+  assert.doesNotMatch(workflow.slice(testStepStart, testStepEnd), /\n\s+if:/u);
+});
+
+test('core CI validates affected installed CLI packages on its existing runner', () => {
+  const workflow = readWorkflow('ci.yml');
+  const toolchain = workflow.indexOf(
+    'npm install --global --no-audit --no-fund "$(node -p \'require("./package.json").packageManager\')"',
+  );
+  const pack = workflow.indexOf('run: npm run release:cli:pack');
+
+  assert.match(workflow, /if: steps\.plan\.outputs\.cli_package == 'true'/u);
+  assert.ok(toolchain >= 0);
+  assert.ok(toolchain < pack);
+  assert.match(workflow, /run: npm run release:cli:smoke/u);
+});
+
+test('specialized platform workflows never create pull request jobs', () => {
+  const cli = readWorkflow('cli-package-validation.yml');
+  const baseline = readWorkflow('windows-baseline.yml');
+  const recovery = readWorkflow('windows-recovery.yml');
+
+  for (const workflow of [cli, baseline, recovery]) {
+    assert.doesNotMatch(workflow, /\n  pull_request:/u);
+    assert.match(workflow, /\n  workflow_dispatch:/u);
+  }
+  assert.match(cli, /\n  workflow_call:/u);
+  assert.match(baseline, /\n  schedule:/u);
+});
+
+function readWorkflow(name) {
+  return readFileSync(new URL(`../.github/workflows/${name}`, import.meta.url), 'utf8');
+}


### PR DESCRIPTION
## Summary

Reduce automatic pull request runner starts to one stable core gate.

- Run planning, planner contract tests, lint/format, build/typecheck, affected workspace tests, Runtime Host tests, Electron E2E/alignment, and Storybook as selected steps in one Ubuntu `test` job.
- For changes that can affect the published CLI, build and validate an installed Linux/Node 24 tarball in that same job. The planner is the single authority for selecting this check.
- Keep the full CLI matrix, including macOS, Windows, Node 22, and real Harbor/Pier validation, available through manual dispatch and the release `workflow_call`; it no longer starts automatically for pull requests.
- Keep Windows baseline on its existing nightly schedule and manual dispatch. Keep Windows recovery on manual dispatch. Neither starts automatically for pull requests.
- Run the core job for pull requests and `main` pushes. The `main` run validates the exact merged delta because this repository does not currently require pull requests to stay up to date with the base branch.

For this PR's own CI-sensitive diff, the automatic path changes from nine jobs to `CI / test` only. The tradeoff is less platform evidence on every pull request and less lane-level parallelism; the retained installed-package smoke covers the common CLI packaging failure mode without another runner.

This does not add a new daily or weekly tier. The existing Windows nightly remains in place.

Fixes #3259

## Verification

- `node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs scripts/release-cli-workflow-policy.test.mjs` (22 tests)
- `npm run windows:inventory` (3 tests; generated inventory current)
- `actionlint .github/workflows/ci.yml .github/workflows/windows-baseline.yml .github/workflows/windows-recovery.yml .github/workflows/cli-package-validation.yml`
- `npm run format:check`
- `git diff --check`
- `npm --userconfig=/dev/null run release:cli:pack && npm --userconfig=/dev/null run release:cli:smoke` (clean isolated build, offline installed-package validation passed)

Repository-wide tests and the Electron E2E suite were not run locally. The changed workflow will provide the selected CI evidence.

## Discussion and rollout

The `dev@maka.apache.org` discussion remains open, and this PR is ready for concrete review. Do not merge while there are unresolved objections. If there are no objections after the stated 72-hour window, it can proceed under lazy consensus after human review of the final diff.

The stable required check remains `CI / test`. Live verification found no branch protection or repository ruleset that requires the removed platform job names.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex analyzed runner usage, implemented and validated the workflow changes, and performed independent deep reviews. Claude Opus performed separate adversarial reviews. I reviewed the final diff, the validation evidence, and each accepted or rejected finding.

## Checklist

- [x] Tests cover the planner and workflow contract
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes, described under Summary above
- [ ] No
