### PR TITLE
fix(desktop): preserve side chat composer elevation

### DIFF
--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -68,6 +68,8 @@ test('narrow right workbar keeps launcher shortcuts and side-chat send button in
   await setRightWorkbarWidth(page, 320);
 
   const composerCard = companion.locator('.maka-composer-astryx');
+  // Keep ChatComposer's inner elevation visible.
+  await expect(composerCard).toHaveCSS('overflow', 'visible');
   // Match the long model-label pressure from the reported side-chat screenshot
   // without coupling the fixture's globally useful default model to this test.
   await companion.locator('.maka-composer-model-chip-text').evaluate((element) => {

--- a/apps/desktop/src/renderer/styles/quote-side-panel.css
+++ b/apps/desktop/src/renderer/styles/quote-side-panel.css
@@ -83,9 +83,8 @@
   .maka-composer-astryx {
   --_chat-composer-radius: var(--radius-surface);
 
-  overflow: hidden;
-  border-radius: var(--radius-surface);
-  /* Leave elevation to ChatComposer; product shadow overrode hover/focus lift. */
+  /* Let ChatComposer paint its own radius and elevation. Clipping this wrapper
+     hides the body's hover/focus shadow against the white side panel. */
 }
 
 .maka-session-workbar-panel[data-placement="right"]


### PR DESCRIPTION
## Summary

The right-side Side Chat composer clipped the elevation painted by Astryx's
inner `ChatComposer` body, leaving the white composer visually unbounded against
the white workbar surface.

This change removes the side-only wrapper clipping and redundant wrapper radius
while preserving the compact Side Chat radius token. It also adds an Electron
E2E assertion for the overflow contract that keeps the inner elevation visible.

## Visual evidence

### Before

<img width="1894" height="232" alt="before" src="https://github.com/user-attachments/assets/2156eb43-51a0-4053-a649-bf34824d5c8f" />


### After

<img width="1003" height="289" alt="after" src="https://github.com/user-attachments/assets/2c703a38-4145-4199-a4db-eba045e60889" />


## Verification

- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- `npm --workspace @maka/desktop run e2e -- session-workbar.spec.ts` (3 passed)
- `git diff --check`


## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed and implemented the scoped CSS fix, added the
regression assertion, ran validation, and prepared this pull request.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
