### PR TITLE
fix(eval): make install preflight path test portable on macOS

### DIFF
--- a/packages/eval/src/__tests__/install-preflight.test.ts
+++ b/packages/eval/src/__tests__/install-preflight.test.ts
@@ -13,11 +13,13 @@ test('preflights the pinned Python framework and Docker before execution', async
   t.after(() => rm(root, { recursive: true, force: true }));
   const trials = join(root, 'trials');
   const mount = join(root, 'mount');
+  const egressTarget = join(root, 'egress-target');
   const egress = join(root, 'egress');
-  await Promise.all([mkdir(trials), mkdir(mount), mkdir(egress)]);
+  await Promise.all([mkdir(trials), mkdir(mount), mkdir(egressTarget)]);
+  await symlink(egressTarget, egress, process.platform === 'win32' ? 'junction' : 'dir');
   await Promise.all([
-    writeFile(join(egress, 'compose.yaml'), 'services: {}\n'),
-    writeFile(join(egress, 'network-policy.json'), '{}\n'),
+    writeFile(join(egressTarget, 'compose.yaml'), 'services: {}\n'),
+    writeFile(join(egressTarget, 'network-policy.json'), '{}\n'),
   ]);
   const restore = setMachinePaths({
     MAKA_TEST_PREFLIGHT_PYTHON: process.execPath,
@@ -46,10 +48,10 @@ test('preflights the pinned Python framework and Docker before execution', async
   assert.equal(calls[0]?.environment.MAKA_TEST_PREFLIGHT_SECRET, undefined);
   assert.equal(calls[0]?.environment.MAKA_EVAL_EGRESS_REQUIRED, '1');
   assert.equal(calls[0]?.environment.MAKA_EVAL_EGRESS_ALLOWED_HOST, 'api.example.test');
-  assert.equal(
-    calls[0]?.environment.MAKA_EVAL_NETWORK_POLICY_PATH,
-    await realpath(join(egress, 'network-policy.json')),
-  );
+  const networkPolicyPath = join(egress, 'network-policy.json');
+  const canonicalNetworkPolicyPath = await realpath(networkPolicyPath);
+  assert.notEqual(canonicalNetworkPolicyPath, networkPolicyPath);
+  assert.equal(calls[0]?.environment.MAKA_EVAL_NETWORK_POLICY_PATH, canonicalNetworkPolicyPath);
   assert.deepEqual(calls[1], {
     command: 'docker',
     args: ['version', '--format', '{{.Server.Version}}'],

--- a/packages/eval/src/__tests__/install-preflight.test.ts
+++ b/packages/eval/src/__tests__/install-preflight.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -48,7 +48,7 @@ test('preflights the pinned Python framework and Docker before execution', async
   assert.equal(calls[0]?.environment.MAKA_EVAL_EGRESS_ALLOWED_HOST, 'api.example.test');
   assert.equal(
     calls[0]?.environment.MAKA_EVAL_NETWORK_POLICY_PATH,
-    join(egress, 'network-policy.json'),
+    await realpath(join(egress, 'network-policy.json')),
   );
   assert.deepEqual(calls[1], {
     command: 'docker',


### PR DESCRIPTION
## Summary

Fix the Eval install preflight test on macOS by comparing the propagated network policy path with its canonical filesystem path.

On macOS, `os.tmpdir()` can return `/var/folders/...`, while `realpath()` resolves the same location as `/private/var/folders/...`. Production intentionally returns the canonical path to support symlink-containment checks, so the test now reflects that contract instead of expecting the original path spelling.

## Verification

- `npm run build:test` — passed
- `node --test packages/eval/dist/__tests__/install-preflight.test.js` — 8 passed, 0 failed
- Eval Node test suite — 75 passed, 0 failed
- `git diff --check` — passed
- The remaining Python checks from `test:dist` were not run successfully because the local Python 3.9.6 interpreter does not support the suite's `int | None` syntax.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the macOS path canonicalization mismatch, updated the test expectation, and ran the relevant build and test checks.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No