### PR TITLE
ci: bind the release deployment environment to main

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -63,6 +63,21 @@ github:
         contexts:
           - test
 
+  environments:
+    # release holds the Apple notarization and code signing credentials used by
+    # .github/workflows/release-desktop.yml. That workflow's own branch guard
+    # sits inside the file it is meant to protect, so this policy is the only
+    # boundary GitHub enforces from outside the workflow.
+    #
+    # Naming an environment here replaces its settings wholesale, so restate
+    # its full configuration when adding one. npm-release carries a required
+    # reviewer and a branch policy that live only on GitHub.
+    release:
+      deployment_branch_policy:
+        policies:
+          - name: main
+            type: branch
+
 notifications:
   commits:      commits@maka.apache.org
   discussions:  dev@maka.apache.org 


### PR DESCRIPTION
## Summary

The `release` GitHub Environment holds the Apple notarization and code signing credentials that `.github/workflows/release-desktop.yml` consumes, and it currently has no protection rules at all. Nothing outside the workflow constrains which ref may deploy with those credentials.

The workflow does carry a job-level branch condition, but that condition lives in the same file it is meant to protect, so it cannot serve as the boundary for the environment's secrets. The boundary that holds regardless of the workflow file is the environment's own deployment branch policy, which GitHub evaluates before a job that requests the environment starts.

This declares that policy in `.asf.yaml`, restricting `release` to `main`. `npm-release` already carries the same kind of policy, so this reuses an established pattern in this repository rather than introducing a new one.

`npm-release` is deliberately left undeclared. The asfyaml directive only visits the environments it is given, so `npm-release` and `copilot` are untouched — but the underlying API call replaces an environment's settings wholesale, so naming `npm-release` here without restating its existing reviewer and branch policy would clear them. The `.asf.yaml` comment records that constraint where the next editor will see it.

## Verification

Validated against the upstream asfyaml implementation at `apache/infrastructure-asfyaml@main`, not against documentation. All of the below was re-run after the final wording of the `.asf.yaml` comment:

- `asfyaml.cli:validate` on this branch's checkout — reports the file as valid. Negative control: renaming `deployment_branch_policy` to a key not in the schema makes the same run fail with `unexpected key not in schema`, confirming the new block actually reaches `ASFGitHubFeature.schema`. Note for anyone tempted to wire this into CI: `validate()` prints the error but still exits 0, so it would need an explicit output check to work as a gate.
- `_validate_environment_configs` from `asfyaml/feature/github/deployment_environments.py` on the parsed `environments` map — no errors. The parsed value is exactly `{"release": {"deployment_branch_policy": {"policies": [{"name": "main", "type": "branch"}], "protected_branches": false}}}`.
- Reproduced asfyaml's two-stage parse (`dirty_load` of the whole file, then `dirty_load` of `github.as_yaml()`) to confirm the comment block does not pollute the folded `description` scalar: 184 characters before and after the round trip, identical. `yaml.safe_load` does not exercise this path.
- Confirmed the existing `protected_branches.main.required_status_checks.contexts` still parses as `['test']` after the round trip.

Not run: repository test suites, lint and typecheck. This change touches only `.asf.yaml`, which no workspace suite covers and which Biome does not format.

## Rollout

ASF Infrastructure applies `.asf.yaml` on push to the default branch, so the policy takes effect on merge. Applying it issues a full environment update for `release`, which also writes asfyaml's defaults of `wait_timer: 0` and `prevent_self_review: true`. The environment currently has no reviewers, no wait timer and no branch policy, so nothing existing is cleared and `prevent_self_review` is a no-op until a reviewer is ever added. Environment secrets live on a separate endpoint and are not affected. In-flight runs are not affected.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Opus 5) read the upstream asfyaml source to confirm the schema and directive semantics, wrote the `.asf.yaml` change, ran the validation described above, and drafted this description. A second pass by Claude Code (Fable 5) adversarially reviewed the change and independently reproduced each verification step above; its findings corrected the comment wording and prompted the scope section. Both are AI review and neither substitutes for independent human review. The commit carries a `Generated-by` trailer. A human contributor reviews the final diff and owns the merge decision.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Neither applies: there is no test hook for `.asf.yaml`, and Biome does not cover YAML. Validation against the upstream schema and directive is described above.

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

This is a security hardening change to a protected area, so it is not a self-merge candidate and needs independent human review.
