### PR TITLE
test(desktop): isolate side-chat slash dispatch

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -109,7 +109,7 @@ test('offers commands only for the first token and keeps explicit Skill queries 
   await expect(inlineMenu.getByRole('group', { name: '命令' })).toHaveCount(0);
 });
 
-test('dispatches a staged slash command instead of steering it into a running turn', async ({
+test('dispatches /side instead of steering it into a running turn', async ({
   invocableSkillsWindow: page,
 }) => {
   const composer = page.locator(COMPOSER_INPUT);
@@ -119,14 +119,6 @@ test('dispatches a staged slash command instead of steering it into a running tu
   await expect(page.locator('.maka-user-message', { hasText: runningPrompt })).toBeVisible();
   await expect(page.getByRole('button', { name: '停止' })).toBeVisible();
 
-  await composer.fill('/compact explain');
-  await expect(page.getByRole('button', { name: '插入消息' })).toBeVisible();
-  await composer.press('Enter');
-
-  // After the steering send the composer remounts. `fill('/')` can land
-  // before the contentEditable is focused, so the `/` trigger never
-  // populates. An empty command group then makes `/compact` look absent
-  // and the `/side` click waits out the timeout.
   await composer.click();
   await composer.pressSequentially('/');
   const menu = page.getByRole('listbox', { name: '命令和技能' });
@@ -142,6 +134,5 @@ test('dispatches a staged slash command instead of steering it into a running tu
   await composer.press('Enter');
 
   await expect(page.locator('.maka-quote-workbar-panel')).toHaveCount(1);
-  await expect(page.getByText(/Acknowledged steering: \/compact explain/)).toBeVisible();
   await page.getByRole('button', { name: '停止' }).click();
 });


### PR DESCRIPTION
## Summary

- remove the unrelated steering submission from the `/side` slash-command E2E
- keep the scenario focused on the running-turn command-dispatch contract
- rely on the existing streaming-remount E2E for Desktop steering coverage

Fixes #2916.

## Root cause

The test chained two asynchronous submissions. Under CI load, the second slash-menu interaction could begin while the steering submission still owned the previous draft, producing `/compact explain/` instead of `/` and leaving no `/side` option to select. The same failure appeared on unrelated PRs #3242 and #3278.

The steering behavior is already covered by `streaming-remount.spec.ts`, so removing that duplicate prelude eliminates the race without adding another timing fence or product state solely for a test.

## Verification

- targeted `/side` E2E repeated 10 times: 10/10 passed
- `/side` dispatch and the independent live-turn steering E2E: 2/2 passed
- Biome check and `git diff --check` passed
