### PR TITLE
test: fix the two intermittent CI lane failures at their causes

### DIFF
--- a/apps/desktop/e2e/slash-command-menu.spec.ts
+++ b/apps/desktop/e2e/slash-command-menu.spec.ts
@@ -78,7 +78,14 @@ test('compacts the active session', async ({
   await expect.poll(() => composer.textContent()).toBe('');
   await expect(page.getByText('压缩失败')).toHaveCount(0);
 
-  await composer.fill('after compact');
+  // After the compact completes the composer clears and can remount. `fill()`
+  // can land before the contentEditable is focused again, so the draft never
+  // populates and Enter submits nothing — the flake in issue #3289. Type
+  // through the focused element and require the draft to have settled before
+  // dispatching, mirroring the running-turn spec below.
+  await composer.click();
+  await composer.pressSequentially('after compact');
+  await expect.poll(() => composer.textContent()).toBe('after compact');
   await composer.press('Enter');
   await expect(page.getByText('Fake backend received: after compact')).toBeVisible();
   await expect(page.getByText('Fake backend received: /compact')).toHaveCount(0);

--- a/packages/computer-use/src/__tests__/maka-cu-service.test.ts
+++ b/packages/computer-use/src/__tests__/maka-cu-service.test.ts
@@ -113,6 +113,7 @@ process.stdin.on('data', function (chunk) {
 let workDir = '';
 let mockPath = '';
 const services: MakaCuService[] = [];
+const imageDirs: string[] = [];
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -197,6 +198,7 @@ function makeService(
   };
   const service = new MakaCuService(options);
   services.push(service);
+  imageDirs.push(imageDir);
   return { service, logPath, imageDir };
 }
 
@@ -215,7 +217,24 @@ after(async () => {
       // A disposed service disposing again is not a test failure.
     }
   }
-  if (workDir) await rm(workDir, { recursive: true, force: true });
+  // `dispose()` is deliberately fire-and-forget: it SIGTERMs the child and
+  // schedules an asynchronous image-directory purge on child exit (or on the
+  // shutdown-grace SIGKILL, at most `shutdownGraceMs` = 3s later). Deleting
+  // `workDir` while those purges — and a child still flushing its ndjson log —
+  // are in flight races `rm` against concurrent writers and fails with
+  // ENOTEMPTY (issue #3290). Every `makeService` image directory is purged by
+  // its `dispose()`, so waiting for them to vanish is a "children exited and
+  // purges finished" barrier. The wait is tolerant rather than asserting —
+  // purge failures are permitted by contract ("the next spawn purges it
+  // again") and are not what this teardown tests — and the retrying `rm`
+  // backstop then only absorbs stragglers, not an unbounded race.
+  const purgeDeadline = Date.now() + 10_000;
+  while (imageDirs.some((imageDir) => existsSync(imageDir)) && Date.now() < purgeDeadline) {
+    await delay(25);
+  }
+  if (workDir) {
+    await rm(workDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  }
 });
 
 describe('maka-cu supervisor: what the child may put on stdout', () => {


### PR DESCRIPTION
## Summary

Fixes the two intermittent CI lane failures tracked in #3289 and #3290, each at its cause. No assertion is weakened and no timeout is raised.

Since the Apache migration a single flaked lane costs a full CI cycle plus a re-review round (`gh run rerun` needs admin; the only contributor recovery is an empty-commit push that cancels in-flight lanes and re-triggers every bot), which is why these two are worth fixing at the source rather than retrying around.

## #3290 — computer-use `ENOTEMPTY` teardown race

`maka-cu-service.test.ts`'s `after()` disposed every service and immediately `rm -r`'d the shared work directory. `dispose()` is deliberately fire-and-forget: it SIGTERMs the child and schedules an **asynchronous** image-directory purge on child exit (or on the 3s shutdown-grace SIGKILL), plus one more purge when an in-flight `start()` settles. The recursive `rm` therefore raced concurrent purges — and a child still flushing its ndjson log — and failed with `ENOTEMPTY` (`maka-cu-service.ts` `dispose()`, the purge closure).

Fix (test-side only; the production fire-and-forget contract is intentional and untouched):
- `makeService` now records each per-service image directory.
- `after()` waits (bounded, 10s; grace is 3s) for every image directory to vanish — each one is deleted by its service's own purge, so this is a deterministic "children exited and purges finished" barrier. The wait is tolerant rather than asserting, because purge failure is explicitly permitted by the production contract ("the next spawn purges it again") and is not what this teardown tests.
- The final `rm(workDir)` gets `maxRetries: 10, retryDelay: 100` as a backstop for same-tree stragglers (e.g. a final log flush).

## #3289 — slash-command e2e `toBeVisible` 10s timeouts

dd4b2d0b4 (#3291) already fixed the `/side` spec by removing the racy steering chain and documented the underlying race: *after the composer remounts, `fill()` can land before the contentEditable is focused, so the draft never populates.*

The remaining flaky spec, `compacts the active session`, hits the same race one step later: right after the compact completes (composer clears/remounts), it did `fill('after compact')` + `Enter` — if the fill lands before focus returns, Enter submits nothing and `Fake backend received: after compact` never appears. That is exactly the pinned failure: run 32157698387 attempt 1 fails at **line 83** on `getByText('Fake backend received: after compact')`, 10s `element(s) not found`, after all preceding compact assertions passed.

Fix mirrors dd4b2d0b4 in the same file: `click()` + `pressSequentially('after compact')` + `expect.poll(textContent).toBe('after compact')` before pressing Enter — the dispatch only happens once the draft has demonstrably settled.

## Verification

- **L2 (local, Windows dev machine)**: `@maka/computer-use` builds (`tsc`) and the service test file runs its new teardown cleanly; pass/fail counts are byte-identical to unmodified `main` (4 pass / 13 fail, all pre-existing environmental `spawn EFTYPE` — Windows cannot spawn the `.cjs` mock directly; the Linux `test` lane is the authoritative runner for this suite). Desktop typecheck and biome pass. 
- **L3 (authoritative, CI)**: the Linux `test` and `e2e` lanes on this PR execute both changed suites for real. Local Playwright execution was attempted and is not possible on this machine (Electron `firstWindow` timeout at fixture level, before any test body, for all specs including unmodified ones).
- The flake is intermittent, so a single green lane proves non-regression, not the absence of the race; the determinism argument above is the actual fix rationale.

Closes #3289
Closes #3290
