### PR TITLE
refactor(storage): centralize root writer lifecycle

### DIFF
--- a/packages/runtime-host/src/server/daily-review-coordinator.ts
+++ b/packages/runtime-host/src/server/daily-review-coordinator.ts
@@ -142,7 +142,6 @@ export class HostDailyReviewCoordinator {
     this.#closeTask ??= (async () => {
       this.beginDrain();
       await Promise.allSettled([...this.#inFlight.values()].map((entry) => entry.promise));
-      this.#store.close();
     })();
     return this.#closeTask;
   }

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -48,37 +48,16 @@ import {
 } from '@maka/runtime/shell-detect';
 import { type MakaTool } from '@maka/runtime/tool-runtime';
 import { type RuntimeHostedRootAuthority } from '@maka/runtime/message-authority';
-import {
-  openInteractiveProjectCatalogForWrite,
-  type InteractiveProjectCatalogWriter,
-} from '@maka/storage';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import {
   createArtifactAttachmentResourceReader,
   createReadImageSnapshotter,
-  openInteractiveArtifactStoreForWrite,
 } from '@maka/storage/artifact-stores';
-import { openInteractiveScheduledTaskStoreForWrite } from '@maka/storage/scheduled-task-store';
-import { openInteractiveDeepResearchStoreForWrite } from '@maka/storage/deep-research-authority';
-import { openInteractiveDailyReviewAuthorityForWrite } from '@maka/storage/daily-review-authority';
-import { openInteractiveGoalAuthorityForWrite } from '@maka/storage/goal-authority';
-import { openInteractivePlanStoreForWrite } from '@maka/storage/plan-authority';
-import {
-  isSessionNotFoundError,
-  openInteractiveExecutionStoresForWrite,
-} from '@maka/storage/execution-stores';
+import { isSessionNotFoundError } from '@maka/storage/execution-stores';
 import { createExternalSessionAdapterRegistry } from '@maka/storage/external-sessions';
 import { createGitWorktreeChildExecutor } from '@maka/storage/git-worktree-child-executor';
-import {
-  type InteractiveLongTermMemoryWriter,
-  openInteractiveLongTermMemoryStoreForWrite,
-} from '@maka/storage/long-term-memory-store';
-import { openInteractiveMemoryBundleStoreForWrite } from '@maka/storage/memory-bundle-store';
 import { runWithStorageRootLease } from '@maka/storage/root-authority';
-import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
-import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
-import { openInteractiveShellRunStoreForWrite } from '@maka/storage/shell-run-authority';
-import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
+import { openStorageWriterComposition } from '@maka/storage';
 import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import {
   openManagedWorkspaceOwner,
@@ -214,27 +193,22 @@ export async function createExecutionRuntimeHostComposition(
   options: CreateExecutionRuntimeHostCompositionOptions = {},
   dependencies: ExecutionRuntimeHostCompositionDependencies = {},
 ): Promise<ExecutionRuntimeHostComposition> {
-  const stores = await openInteractiveExecutionStoresForWrite(context.owner.lease);
-  await stores.sessionStore.ready();
+  const storage = await openStorageWriterComposition(context.owner.lease, {
+    afterRuntimePolicyOpened: async (stores) => {
+      if (options.bootstrapRuntimePolicy !== false) {
+        await ensureBootstrapRuntimePolicy({
+          workspaceRoot: context.owner.capability.canonicalPath,
+          stores,
+          onDeferredError: (error) =>
+            console.error(
+              `[runtime-host] optional bootstrap target could not be configured: ${generalizedErrorMessage(error)}`,
+            ),
+        });
+      }
+    },
+  });
+  const stores = storage.execution;
   let graphControlStore: ReturnType<typeof createAgentGraphControlStore> | undefined;
-  let taskLedgerStore:
-    | Awaited<ReturnType<typeof openInteractiveTaskLedgerStoreForWrite>>
-    | undefined;
-  let usageStores: Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>> | undefined;
-  let artifactStore: Awaited<ReturnType<typeof openInteractiveArtifactStoreForWrite>> | undefined;
-  let shellRunStore: Awaited<ReturnType<typeof openInteractiveShellRunStoreForWrite>> | undefined;
-  let longTermMemoryStore: InteractiveLongTermMemoryWriter | undefined;
-  let scheduledTaskStore:
-    | Awaited<ReturnType<typeof openInteractiveScheduledTaskStoreForWrite>>
-    | undefined;
-  let planStore: Awaited<ReturnType<typeof openInteractivePlanStoreForWrite>> | undefined;
-  let deepResearchStore:
-    | Awaited<ReturnType<typeof openInteractiveDeepResearchStoreForWrite>>
-    | undefined;
-  let dailyReviewStore:
-    | Awaited<ReturnType<typeof openInteractiveDailyReviewAuthorityForWrite>>
-    | undefined;
-  let goalStore: Awaited<ReturnType<typeof openInteractiveGoalAuthorityForWrite>> | undefined;
   let graphClient: HostAgentGraphCoordinator | undefined;
   let sessionEffects: HostSessionEffectCoordinator | undefined;
   let memoryExtraction: HostMemoryExtractionCoordinator | undefined;
@@ -242,50 +216,22 @@ export async function createExecutionRuntimeHostComposition(
   let unsubscribeTranscriptChanges: (() => void) | undefined;
   let managedWorkspaceOwner: ManagedWorkspaceOwner | undefined;
   let workspaceExecution: RuntimeHostWorkspaceExecutionComposition | undefined;
-  let projectCatalog: InteractiveProjectCatalogWriter | undefined;
   let goalExecutions: HostGoalExecutionCoordinator | undefined;
   try {
-    const openedProjectCatalog = await openInteractiveProjectCatalogForWrite(context.owner.lease);
-    projectCatalog = openedProjectCatalog;
-    const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
-      context.owner.lease,
-    );
-    if (options.bootstrapRuntimePolicy !== false) {
-      await ensureBootstrapRuntimePolicy({
-        workspaceRoot: context.owner.capability.canonicalPath,
-        stores: runtimePolicyStores,
-        onDeferredError: (error) =>
-          console.error(
-            `[runtime-host] optional bootstrap target could not be configured: ${generalizedErrorMessage(error)}`,
-          ),
-      });
-    }
+    const openedProjectCatalog = storage.projectCatalog;
+    const runtimePolicyStores = storage.runtimePolicy;
     const oauthCredentials = new HostOAuthExecutionAuthority(runtimePolicyStores);
-    const openedScheduledTaskStore = await openInteractiveScheduledTaskStoreForWrite(
-      context.owner.lease,
-    );
-    scheduledTaskStore = openedScheduledTaskStore;
-    const openedPlanStore = await openInteractivePlanStoreForWrite(context.owner.lease);
-    planStore = openedPlanStore;
-    const openedDeepResearchStore = await openInteractiveDeepResearchStoreForWrite(
-      context.owner.lease,
-    );
-    deepResearchStore = openedDeepResearchStore;
-    const openedDailyReviewStore = await openInteractiveDailyReviewAuthorityForWrite(
-      context.owner.lease,
-    );
-    dailyReviewStore = openedDailyReviewStore;
-    const openedGoalStore = await openInteractiveGoalAuthorityForWrite(context.owner.lease);
-    goalStore = openedGoalStore;
-    const memoryStore = await openInteractiveMemoryBundleStoreForWrite(context.owner.lease);
-    longTermMemoryStore = await openInteractiveLongTermMemoryStoreForWrite(context.owner.lease);
-    taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
-    const openedArtifactStore = await openInteractiveArtifactStoreForWrite(context.owner.lease);
-    artifactStore = openedArtifactStore;
-    const openedUsageStores = await openInteractiveUsageStoresForWrite(context.owner.lease);
-    usageStores = openedUsageStores;
-    const openedShellRunStore = await openInteractiveShellRunStoreForWrite(context.owner.lease);
-    shellRunStore = openedShellRunStore;
+    const openedScheduledTaskStore = storage.scheduledTasks;
+    const openedPlanStore = storage.plan;
+    const openedDeepResearchStore = storage.deepResearch;
+    const openedDailyReviewStore = storage.dailyReview;
+    const openedGoalStore = storage.goal;
+    const memoryStore = storage.memoryBundle;
+    const longTermMemoryStore = storage.longTermMemory;
+    const taskLedgerStore = storage.taskLedger;
+    const openedArtifactStore = storage.artifacts;
+    const openedUsageStores = storage.usage;
+    const openedShellRunStore = storage.shellRuns;
     const worktreeChildExecutor = createGitWorktreeChildExecutor({
       storageRoot: context.owner.capability.canonicalPath,
     });
@@ -1398,11 +1344,7 @@ export async function createExecutionRuntimeHostComposition(
           state: () => requireMemory(memory).recover(),
         },
         drain: [() => memoryExtraction?.beginDrain(), () => memory?.beginDrain()],
-        close: [
-          () => memoryExtraction?.close(),
-          () => memory?.close(),
-          () => longTermMemoryStore?.close(),
-        ],
+        close: [() => memoryExtraction?.close(), () => memory?.close()],
         releaseConnection: [
           (connectionId) => requireMemory(memory).releaseConnection(connectionId),
         ],
@@ -1410,12 +1352,10 @@ export async function createExecutionRuntimeHostComposition(
       createRuntimeHostDomainModule({
         id: 'plan',
         handlers: [plans.handlers],
-        close: [() => openedPlanStore.close()],
       }),
       createRuntimeHostDomainModule({
         id: 'project-catalog',
         handlers: [projects.handlers],
-        close: [() => openedProjectCatalog.close()],
       }),
       createRuntimeHostDomainModule({
         id: 'session',
@@ -1437,7 +1377,6 @@ export async function createExecutionRuntimeHostComposition(
             }
           },
         },
-        close: [() => stores.sessionStore.close?.()],
       }),
       createRuntimeHostDomainModule({
         id: 'configuration',
@@ -1469,14 +1408,10 @@ export async function createExecutionRuntimeHostComposition(
           () => (backendInvalidationPoisoned ? undefined : manager.refreshIdleBackends()),
           () => skills.close(),
           () => oauth?.close(),
-          () => openedUsageStores.close(),
-          () => openedArtifactStore.close(),
           () => {
             unsubscribeTranscriptChanges?.();
             unsubscribeTaskLedger?.();
-            taskLedgerStore?.close();
           },
-          () => shellRunStore?.close(),
         ],
         releaseConnection: [(connectionId) => artifacts.releaseConnection(connectionId)],
       }),
@@ -1497,7 +1432,7 @@ export async function createExecutionRuntimeHostComposition(
       createRuntimeHostDomainModule({
         id: 'deep-research',
         handlers: [requireDeepResearch(deepResearch).handlers],
-        close: [() => deepResearch?.close(), () => openedDeepResearchStore.close()],
+        close: [() => deepResearch?.close()],
       }),
       createRuntimeHostDomainModule({
         id: 'daily-review',
@@ -1596,7 +1531,7 @@ export async function createExecutionRuntimeHostComposition(
           domains: () => requireGoal(goal).recover(),
         },
         drain: [() => goalExecutions?.beginDrain(), () => goal?.beginDrain()],
-        close: [() => requireGoal(goal).close(), () => openedGoalStore.close()],
+        close: [() => requireGoal(goal).close()],
       }),
       createRuntimeHostDomainModule({
         id: 'session-retirement',
@@ -1630,6 +1565,11 @@ export async function createExecutionRuntimeHostComposition(
         }
         try {
           await closeRuntimeHostDomainModules(domainModules);
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          await storage.close();
         } catch (error) {
           errors.push(error);
         }
@@ -1669,16 +1609,6 @@ export async function createExecutionRuntimeHostComposition(
       errors.push(closeError);
     }
     try {
-      dailyReviewStore?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
-      deepResearchStore?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
       graphClient?.close();
     } catch (closeError) {
       errors.push(closeError);
@@ -1689,24 +1619,8 @@ export async function createExecutionRuntimeHostComposition(
       errors.push(closeError);
     }
     try {
-      await usageStores?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
-      artifactStore?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
       unsubscribeTranscriptChanges?.();
       unsubscribeTaskLedger?.();
-      taskLedgerStore?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
-      shellRunStore?.close();
     } catch (closeError) {
       errors.push(closeError);
     }
@@ -1716,32 +1630,7 @@ export async function createExecutionRuntimeHostComposition(
       errors.push(closeError);
     }
     try {
-      longTermMemoryStore?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
-      scheduledTaskStore?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
-      await goalStore?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
-      planStore?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
-      projectCatalog?.close();
-    } catch (closeError) {
-      errors.push(closeError);
-    }
-    try {
-      await stores.sessionStore.close?.();
+      await storage.close();
     } catch (closeError) {
       errors.push(closeError);
     }

--- a/packages/runtime-host/src/server/scheduled-task-coordinator.ts
+++ b/packages/runtime-host/src/server/scheduled-task-coordinator.ts
@@ -212,7 +212,6 @@ export class HostScheduledTaskCoordinator implements ScheduledTaskToolAuthority 
     this.beginDrain();
     await this.#lane;
     this.#closed = true;
-    this.#store.close();
   }
 
   async create(input: {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -29,6 +29,7 @@
     "./pet-pack-store": "./dist/pet-pack-store.js",
     "./root-authority": "./dist/root-authority.js",
     "./state-root-composition": "./dist/state-root-composition.js",
+    "./storage-writer-composition": "./dist/storage-writer-composition.js",
     "./runtime-policy-stores": "./dist/runtime-policy-stores.js",
     "./scheduled-task-store": "./dist/scheduled-task-store.js",
     "./settings-store": "./dist/settings-store.js",

--- a/packages/storage/src/__tests__/storage-writer-composition.test.ts
+++ b/packages/storage/src/__tests__/storage-writer-composition.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { acquireOperationalStateDatabase } from '../operational-state-store.js';
+import { openStorageWriterComposition } from '../storage-writer-composition.js';
+import {
+  resolveStorageRoot,
+  runWithStorageRootLease,
+  tryAcquireInteractiveRootOwner,
+} from '../root-authority.js';
+
+test('storage writer composition rejects reuse until close completes', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-storage-composition-'));
+  try {
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    try {
+      const first = await openStorageWriterComposition(owner.lease);
+      await assert.rejects(openStorageWriterComposition(owner.lease));
+
+      const closing = first.close();
+      await assert.rejects(openStorageWriterComposition(owner.lease));
+      await closing;
+
+      const reopened = await openStorageWriterComposition(owner.lease);
+      await reopened.execution.sessionStore.list();
+      await reopened.close();
+    } finally {
+      await owner.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('opening a second storage writer composition creates a usable lifecycle', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-storage-composition-failure-'));
+  try {
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    try {
+      const first = await openStorageWriterComposition(owner.lease);
+      await first.close();
+      const second = await openStorageWriterComposition(owner.lease);
+      await second.execution.sessionStore.list();
+      await second.usage.telemetry.logs({ range: 'all' }, 0, 1);
+      await second.close();
+    } finally {
+      await owner.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('a failed close keeps the lease unavailable', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-storage-composition-close-failure-'));
+  try {
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    try {
+      const composition = await openStorageWriterComposition(owner.lease);
+      const operationalState = await runWithStorageRootLease(
+        owner.lease,
+        'interactive',
+        'write',
+        async (storageRoot) => acquireOperationalStateDatabase(storageRoot),
+      );
+      operationalState.database.close();
+      operationalState.close();
+
+      await assert.rejects(composition.close(), AggregateError);
+      const [reopen] = await Promise.allSettled([openStorageWriterComposition(owner.lease)]);
+      if (reopen.status === 'fulfilled') await reopen.value.close();
+      assert.equal(reopen.status, 'rejected');
+    } finally {
+      await owner.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('a failed runtime-policy hook rolls back before reopening', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-storage-composition-hook-failure-'));
+  try {
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    try {
+      const failure = new Error('runtime-policy hook failed');
+      await assert.rejects(
+        openStorageWriterComposition(owner.lease, {
+          afterRuntimePolicyOpened: () => {
+            throw failure;
+          },
+        }),
+        (error) => error === failure,
+      );
+
+      const reopened = await openStorageWriterComposition(owner.lease);
+      await reopened.execution.sessionStore.list();
+      await reopened.projectCatalog.list();
+      await reopened.close();
+    } finally {
+      await owner.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -312,6 +312,7 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
   });
   const run = <T>(operation: () => Promise<T>) =>
     runWithStorageRootLease(lease, kind, 'write', operation);
+  let closeTask: Promise<void> | undefined;
 
   const stores: ExecutionStoresWriterBase<K> & E = {
     ...extension,
@@ -421,12 +422,17 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
       completeSessionRetirementCleanup: (sessionId) =>
         run(() => sessionStore.completeSessionRetirementCleanup(sessionId)),
       close: () =>
-        closeExecutionStorePersistence(sessionStore, runtimePersistence, {
-          agentRunStore,
-          conversationOperationalStateStore,
-          messageReceiptStore,
-          interactionStore,
-        }),
+        (closeTask ??= (async () => {
+          if (executionStoresWritersByLease.get(lease) === stores) {
+            executionStoresWritersByLease.delete(lease);
+          }
+          await closeExecutionStorePersistence(sessionStore, runtimePersistence, {
+            agentRunStore,
+            conversationOperationalStateStore,
+            messageReceiptStore,
+            interactionStore,
+          });
+        })()),
     },
     agentRunStore: {
       createRun: (header, options) => run(() => agentRunStore.createRun(header, options)),

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -142,6 +142,7 @@ export * from './operational-state-backup.js';
 export * from './mcp-config-store.js';
 export * from './workspace-identity.js';
 export * from './memory-bundle-store.js';
+export * from './storage-writer-composition.js';
 export * from './long-term-memory-store.js';
 export * from './project-catalog.js';
 export * from './project-catalog-authority.js';

--- a/packages/storage/src/storage-writer-composition.ts
+++ b/packages/storage/src/storage-writer-composition.ts
@@ -1,0 +1,176 @@
+import { openInteractiveArtifactStoreForWrite } from './artifact-stores.js';
+import { openInteractiveDailyReviewAuthorityForWrite } from './daily-review-authority.js';
+import { openInteractiveDeepResearchStoreForWrite } from './deep-research-authority.js';
+import { openInteractiveExecutionStoresForWrite } from './execution-stores.js';
+import { openInteractiveGoalAuthorityForWrite } from './goal-authority.js';
+import { openInteractiveLongTermMemoryStoreForWrite } from './long-term-memory-store.js';
+import { openInteractiveMemoryBundleStoreForWrite } from './memory-bundle-store.js';
+import { openInteractivePlanStoreForWrite } from './plan-authority.js';
+import { openInteractiveProjectCatalogForWrite } from './project-catalog-authority.js';
+import { assertStorageRootLease, type StorageRootLease } from './root-authority.js';
+import { openInteractiveRuntimePolicyStoresForWrite } from './runtime-policy-stores.js';
+import { openInteractiveScheduledTaskStoreForWrite } from './scheduled-task-store.js';
+import { openInteractiveShellRunStoreForWrite } from './shell-run-authority.js';
+import { openInteractiveTaskLedgerStoreForWrite } from './task-ledger-authority.js';
+import { openInteractiveUsageStoresForWrite } from './usage-stores.js';
+
+export interface OpenStorageWriterCompositionOptions {
+  /** Runs after the runtime-policy stores open and before the remaining writers open. */
+  afterRuntimePolicyOpened?: (
+    stores: Awaited<ReturnType<typeof openInteractiveRuntimePolicyStoresForWrite>>,
+  ) => void | Promise<void>;
+}
+
+export interface StorageWriterComposition {
+  readonly execution: Awaited<ReturnType<typeof openInteractiveExecutionStoresForWrite>>;
+  readonly projectCatalog: Awaited<ReturnType<typeof openInteractiveProjectCatalogForWrite>>;
+  readonly runtimePolicy: Awaited<ReturnType<typeof openInteractiveRuntimePolicyStoresForWrite>>;
+  readonly scheduledTasks: Awaited<ReturnType<typeof openInteractiveScheduledTaskStoreForWrite>>;
+  readonly plan: Awaited<ReturnType<typeof openInteractivePlanStoreForWrite>>;
+  readonly deepResearch: Awaited<ReturnType<typeof openInteractiveDeepResearchStoreForWrite>>;
+  readonly dailyReview: Awaited<ReturnType<typeof openInteractiveDailyReviewAuthorityForWrite>>;
+  readonly goal: Awaited<ReturnType<typeof openInteractiveGoalAuthorityForWrite>>;
+  readonly memoryBundle: Awaited<ReturnType<typeof openInteractiveMemoryBundleStoreForWrite>>;
+  readonly longTermMemory: Awaited<ReturnType<typeof openInteractiveLongTermMemoryStoreForWrite>>;
+  readonly taskLedger: Awaited<ReturnType<typeof openInteractiveTaskLedgerStoreForWrite>>;
+  readonly artifacts: Awaited<ReturnType<typeof openInteractiveArtifactStoreForWrite>>;
+  readonly usage: Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>>;
+  readonly shellRuns: Awaited<ReturnType<typeof openInteractiveShellRunStoreForWrite>>;
+  close(): Promise<void>;
+}
+
+const activeCompositions = new WeakSet<object>();
+
+export async function openStorageWriterComposition(
+  lease: StorageRootLease<'interactive', 'write'>,
+  options: OpenStorageWriterCompositionOptions = {},
+): Promise<StorageWriterComposition> {
+  if (activeCompositions.has(lease)) {
+    throw new Error('Storage writer composition is already active for this lease');
+  }
+  await assertStorageRootLease(lease, 'interactive', 'write');
+  if (activeCompositions.has(lease)) {
+    throw new Error('Storage writer composition is already active for this lease');
+  }
+  activeCompositions.add(lease);
+  return createComposition(lease, options);
+}
+
+async function createComposition(
+  lease: StorageRootLease<'interactive', 'write'>,
+  options: OpenStorageWriterCompositionOptions,
+): Promise<StorageWriterComposition> {
+  const closes: Array<() => void | Promise<void>> = [];
+  let closeTask: Promise<void> | undefined;
+  const close = () =>
+    (closeTask ??= closeInReverse(closes).then(() => {
+      // A failed close may leave a writer handle open, so keep this lease unavailable.
+      activeCompositions.delete(lease);
+    }));
+  const failOpen = async (error: unknown): Promise<never> => {
+    try {
+      await close();
+    } catch (closeError) {
+      throw new AggregateError([error, closeError], 'Unable to open storage composition');
+    }
+    throw error;
+  };
+  const openWriter = async <T>(
+    operation: () => Promise<T>,
+    closeWriter?: (writer: T) => void | Promise<void>,
+  ): Promise<T> => {
+    try {
+      const writer = await operation();
+      if (closeWriter) closes.push(() => closeWriter(writer));
+      return writer;
+    } catch (error) {
+      return failOpen(error);
+    }
+  };
+
+  const execution = await openWriter(
+    () => openInteractiveExecutionStoresForWrite(lease),
+    (writer) => writer.sessionStore.close?.(),
+  );
+  try {
+    await execution.sessionStore.ready();
+  } catch (error) {
+    await failOpen(error);
+  }
+  const projectCatalog = await openWriter(
+    () => openInteractiveProjectCatalogForWrite(lease),
+    closeWriter,
+  );
+  const runtimePolicy = await openWriter(() => openInteractiveRuntimePolicyStoresForWrite(lease));
+  try {
+    await options.afterRuntimePolicyOpened?.(runtimePolicy);
+  } catch (error) {
+    await failOpen(error);
+  }
+  const scheduledTasks = await openWriter(
+    () => openInteractiveScheduledTaskStoreForWrite(lease),
+    closeWriter,
+  );
+  const plan = await openWriter(() => openInteractivePlanStoreForWrite(lease), closeWriter);
+  const deepResearch = await openWriter(
+    () => openInteractiveDeepResearchStoreForWrite(lease),
+    closeWriter,
+  );
+  const dailyReview = await openWriter(
+    () => openInteractiveDailyReviewAuthorityForWrite(lease),
+    closeWriter,
+  );
+  const goal = await openWriter(() => openInteractiveGoalAuthorityForWrite(lease), closeWriter);
+  const memoryBundle = await openWriter(() => openInteractiveMemoryBundleStoreForWrite(lease));
+  const longTermMemory = await openWriter(
+    () => openInteractiveLongTermMemoryStoreForWrite(lease),
+    closeWriter,
+  );
+  const taskLedger = await openWriter(
+    () => openInteractiveTaskLedgerStoreForWrite(lease),
+    closeWriter,
+  );
+  const artifacts = await openWriter(
+    () => openInteractiveArtifactStoreForWrite(lease),
+    closeWriter,
+  );
+  const usage = await openWriter(() => openInteractiveUsageStoresForWrite(lease), closeWriter);
+  const shellRuns = await openWriter(
+    () => openInteractiveShellRunStoreForWrite(lease),
+    closeWriter,
+  );
+  return Object.freeze({
+    execution,
+    projectCatalog,
+    runtimePolicy,
+    scheduledTasks,
+    plan,
+    deepResearch,
+    dailyReview,
+    goal,
+    memoryBundle,
+    longTermMemory,
+    taskLedger,
+    artifacts,
+    usage,
+    shellRuns,
+    close,
+  });
+}
+
+function closeWriter(writer: { close(): void | Promise<void> }): void | Promise<void> {
+  return writer.close();
+}
+
+async function closeInReverse(closes: Array<() => void | Promise<void>>): Promise<void> {
+  const errors: unknown[] = [];
+  for (const close of closes.reverse()) {
+    try {
+      await close();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  closes.length = 0;
+  if (errors.length) throw new AggregateError(errors, 'Unable to close storage composition');
+}

--- a/packages/storage/src/usage-stores.ts
+++ b/packages/storage/src/usage-stores.ts
@@ -369,6 +369,8 @@ function createWriterFacade(
   const close = (): Promise<void> => {
     if (closePromise) return closePromise;
     state = 'draining';
+    if (writerByLease.get(lease) === stores) writerByLease.delete(lease);
+    writers.delete(stores);
     const accepted = barrier;
     closePromise = accepted
       .then(async () => {


### PR DESCRIPTION
## Summary

Add a storage writer composition that owns the Runtime Host writer lifecycle.

The composition now:

- validates the root lease before opening writers
- permits only one active composition per root lease and rejects overlapping opens
- opens existing domain writers in one defined order
- closes opened writers in reverse order after partial initialization failures
- keeps the lease unavailable if any writer fails to close
- makes `close()` idempotent
- removes writer lifecycle management from Runtime Host domain coordinators

Domain writer interfaces, authorization checks, and persistence behavior remain unchanged. This PR does not introduce a repository framework or merge domain interfaces.

The Runtime Host still bootstraps runtime policy immediately after opening its stores and before opening the remaining writers.

## Verification

- `npm --workspace @maka/storage run typecheck` — passed
- `npm --workspace @maka/runtime-host run typecheck` — passed
- targeted storage composition and usage-store tests — 12 passed
- Biome format check for changed files — passed
- `git diff --check` — passed
- full storage suite — not rerun after the review fixes; the earlier run passed 832 tests and had 3 unrelated environment or fixture failures

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the storage writer lifecycle refactor, drafted its tests, and addressed code-review feedback. The human contributor reviewed the final diff and owns the decision to submit it. The commit carries a `Generated-by: Codex` trailer.
