### PR TITLE
docs: update repository URLs to apache/maka in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Maka
 
-[![CI](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml)
+[![CI](https://github.com/apache/maka/actions/workflows/ci.yml/badge.svg)](https://github.com/apache/maka/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![docs](https://img.shields.io/badge/docs-%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-blue?logo=googletranslate&logoColor=white)](./README.zh-CN.md)
 
@@ -57,7 +57,7 @@ Read [Maka Backend Architecture](./ARCHITECTURE.md) for the complete design.
 
 ### Download Desktop for macOS
 
-The signed and notarized Desktop app is available from [GitHub Releases](https://github.com/Maka-Agent/maka-agent/releases/latest) for Apple Silicon Macs only (`arm64`).
+The signed and notarized Desktop app is available from [GitHub Releases](https://github.com/apache/maka/releases/latest) for Apple Silicon Macs only (`arm64`).
 
 1. Download `Maka-<version>-mac-arm64.dmg`;
 2. Open the DMG and drag Maka to Applications;
@@ -84,8 +84,8 @@ published with the same release.
 ### Start Desktop
 
 ```sh
-git clone https://github.com/Maka-Agent/maka-agent.git
-cd maka-agent
+git clone https://github.com/apache/maka.git
+cd maka
 npm ci
 npm run dev
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # Maka
 
-[![CI](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml)
+[![CI](https://github.com/apache/maka/actions/workflows/ci.yml/badge.svg)](https://github.com/apache/maka/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![docs](https://img.shields.io/badge/docs-English-blue?logo=googletranslate&logoColor=white)](./README.md)
 
@@ -57,7 +57,7 @@ Maka 不只回答问题。它可以在受控权限下阅读项目、执行工具
 
 ### 下载 macOS 桌面版
 
-已签名并完成 Apple 公证的桌面应用可从 [GitHub Releases](https://github.com/Maka-Agent/maka-agent/releases/latest) 下载，目前仅支持 Apple Silicon Mac（`arm64`）。
+已签名并完成 Apple 公证的桌面应用可从 [GitHub Releases](https://github.com/apache/maka/releases/latest) 下载，目前仅支持 Apple Silicon Mac（`arm64`）。
 
 1. 下载 `Maka-<version>-mac-arm64.dmg`；
 2. 打开 DMG，将 Maka 拖入“应用程序”；
@@ -83,8 +83,8 @@ Windows 目前仍是未签名预览版，不属于正式支持的平台。当某
 ### 启动 Desktop
 
 ```sh
-git clone https://github.com/Maka-Agent/maka-agent.git
-cd maka-agent
+git clone https://github.com/apache/maka.git
+cd maka
 npm ci
 npm run dev
 ```

--- a/docs/architecture/mcp-runtime-architecture-draft.zh-CN.md
+++ b/docs/architecture/mcp-runtime-architecture-draft.zh-CN.md
@@ -2,7 +2,7 @@
 
 状态：remote dual-era V2 implemented（2026-08-11）
 
-跟踪：[MCP 2026-07-28 dual-era rollout #1650](https://github.com/Maka-Agent/maka-agent/issues/1650)
+跟踪：[MCP 2026-07-28 dual-era rollout #1650](https://github.com/apache/maka/issues/1650)
 
 ## 1. 目标与边界
 


### PR DESCRIPTION
Both READMEs still pointed readers at the old `Maka-Agent/maka-agent` org after the repository moved to `apache/maka`: the CI badge linked to the old Actions page, the Desktop download link went to the old Releases, and the Quick Start cloned the old URL and `cd`'d into a directory name that no longer matches the checkout.

## Summary

<!-- The problem this solves and the outcome it produces. If the approach
is not the obvious one, say why. -->

Update every stale repository URL to `apache/maka`:

- CI badge image and link (`actions/workflows/ci.yml`);
- GitHub Releases download link for the macOS Desktop build;
- `git clone https://github.com/apache/maka.git`;
- follow-up `cd maka-agent` corrected to `cd maka` so it matches the directory the new clone URL produces;
- the issue reference at `docs/architecture/mcp-runtime-architecture-draft.zh-CN.md:5` (review feedback).

<!-- Delete the line above if this PR closes no issue. Use "Refs #N" instead
when an issue is context only. -->

## Verification

<!-- The checks you actually ran and their results. Name relevant checks
you did not run. For user-visible changes, attach the lightest evidence
that demonstrates the behavior (screenshot, recording, or command output). -->

- `git grep -n 'Maka-Agent' HEAD -- '*.md'` returns no matches in the tracked tree after the change.
- `git diff --check` clean.

Not run: lint, typecheck, and test suites — the change touches Markdown documentation only, with no code or build inputs affected.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

<!-- If the second option applies, name the tool(s) and briefly describe their
scope. If AI authored material contribution content, add Generated-by trailers
to the affected commits and ensure the final squash commit retains the trailer. -->

Tool(s) and scope: Claude (pi coding agent) — located the stale URLs across both READMEs, applied the edits, and authored the commit; commit carries a `Generated-by` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
