### PR TITLE
refactor(desktop): align browser panel with Astryx

### DIFF
--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -89,6 +89,38 @@ test('narrow right workbar keeps launcher shortcuts and side-chat send button in
   );
 });
 
+// #2188: the address field, not the nav buttons, absorbs the column's free
+// width. The rule reaches into Astryx Toolbar's slot div, which nothing else
+// pins — an upstream slot-wrapper change would silently regress it.
+test('browser address field tracks the workbar column width', async ({ window: page }) => {
+  const composer = page.locator(COMPOSER_INPUT);
+  await composer.fill('create browser session');
+  await composer.press('Enter');
+  await expect(page.getByText(/Fake backend received: create browser session/)).toBeVisible();
+  await page.getByRole('button', { name: '展开任务工作栏' }).click();
+  await expect(page.getByRole('list', { name: '打开工具' })).toBeVisible();
+  await page.getByRole('button', { name: /浏览器.*打开内置浏览器/ }).click();
+  await expect(page.getByRole('region', { name: '嵌入式浏览器' })).toBeVisible();
+
+  const addressInput = page.getByRole('textbox', { name: '浏览器地址' });
+  const inputWidth = async () => (await addressInput.boundingBox())!.width;
+  // The tab's content lives in the overlay panel next to the workbar frame,
+  // so the width override must land there, not on `.maka-session-workbar`.
+  const setPanelWidth = async (width: number) => {
+    const panel = page.locator('.maka-session-workbar-panel[data-overlay][data-placement="right"]');
+    await panel.evaluate((element, nextWidth) => {
+      (element as HTMLElement).style.setProperty('--maka-session-workbar-width', `${nextWidth}px`);
+    }, width);
+    await expect.poll(async () => (await panel.boundingBox())?.width).toBeCloseTo(width, 0);
+  };
+  await setPanelWidth(480);
+  await expect.poll(inputWidth).toBeGreaterThan(250);
+  await setPanelWidth(320);
+  // Fails at a flat width without the slot rule: 480 and 320 would measure the same.
+  await expect.poll(inputWidth).toBeLessThan(220);
+  await expect.poll(inputWidth).toBeGreaterThan(100);
+});
+
 test('titlebar workbar action restores an existing tool instead of the picker', async ({
   gitReviewWindow,
 }) => {

--- a/apps/desktop/src/main/__tests__/browser-logic.test.ts
+++ b/apps/desktop/src/main/__tests__/browser-logic.test.ts
@@ -65,7 +65,7 @@ describe('browser logic', () => {
   });
 
   it('deriveBrowserState computes hasPage and secure', () => {
-    const base = { title: '', canGoBack: false, canGoForward: false, loading: false, favicon: null };
+    const base = { title: '', canGoBack: false, canGoForward: false, loading: false };
     assert.equal(deriveBrowserState({ ...base, url: '' }).hasPage, false);
     assert.equal(deriveBrowserState({ ...base, url: 'about:blank' }).hasPage, false);
     const loaded = deriveBrowserState({ ...base, url: 'https://x.com/' });

--- a/apps/desktop/src/main/browser/controller.ts
+++ b/apps/desktop/src/main/browser/controller.ts
@@ -35,7 +35,6 @@ const VIEWPORT_RESTORE_POLL_MS = 16;
 export class BrowserViewController {
   private readonly view: WebContentsView;
   private destroyed = false;
-  private favicon: string | null = null;
   /** True while the view holds real on-screen bounds (last setViewport painted it). */
   private shownWithBounds = false;
   private automation: CdpBridge | null = null;
@@ -60,16 +59,9 @@ export class BrowserViewController {
     const wc = this.wc;
     wc.on('did-start-loading', () => this.emitState());
     wc.on('did-stop-loading', () => this.emitState());
-    wc.on('did-navigate', () => {
-      this.favicon = null;
-      this.emitState();
-    });
+    wc.on('did-navigate', () => this.emitState());
     wc.on('did-navigate-in-page', () => this.emitState());
     wc.on('page-title-updated', () => this.emitState());
-    wc.on('page-favicon-updated', (_event, favicons: string[]) => {
-      this.favicon = favicons[0] ?? null;
-      this.emitState();
-    });
     wc.on('did-fail-load', () => this.emitState());
 
     // Single-view browser: keep http(s) "open in new window" links in-place and
@@ -123,7 +115,7 @@ export class BrowserViewController {
 
   state(): BrowserState {
     if (this.destroyed || this.wc.isDestroyed()) {
-      return deriveBrowserState({ url: '', title: '', canGoBack: false, canGoForward: false, loading: false, favicon: null });
+      return deriveBrowserState({ url: '', title: '', canGoBack: false, canGoForward: false, loading: false });
     }
     const wc = this.wc;
     return deriveBrowserState({
@@ -132,7 +124,6 @@ export class BrowserViewController {
       canGoBack: wc.navigationHistory.canGoBack(),
       canGoForward: wc.navigationHistory.canGoForward(),
       loading: wc.isLoading(),
-      favicon: this.favicon,
     });
   }
 
@@ -256,7 +247,7 @@ export class BrowserViewController {
     // this it would keep showing stale hasPage/url for a page that is gone.
     this.onState(
       this.sessionId,
-      deriveBrowserState({ url: '', title: '', canGoBack: false, canGoForward: false, loading: false, favicon: null }),
+      deriveBrowserState({ url: '', title: '', canGoBack: false, canGoForward: false, loading: false }),
     );
     // Tear down the ws bridge; the debugger detaches with the wc.close() below.
     // Each step guarded so a half-gone window (during quit) can't strand the rest.

--- a/apps/desktop/src/main/browser/logic.ts
+++ b/apps/desktop/src/main/browser/logic.ts
@@ -82,7 +82,6 @@ export interface BrowserStateSnapshot {
   canGoBack: boolean;
   canGoForward: boolean;
   loading: boolean;
-  favicon: string | null;
 }
 
 /**
@@ -97,7 +96,6 @@ export function deriveBrowserState(snapshot: BrowserStateSnapshot): BrowserState
     canGoBack: snapshot.canGoBack,
     canGoForward: snapshot.canGoForward,
     loading: snapshot.loading,
-    favicon: snapshot.favicon,
     secure: /^https:\/\//i.test(snapshot.url),
     hasPage: snapshot.url !== '' && !snapshot.url.startsWith('about:'),
   };

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -32,6 +32,7 @@ import { usageStatsSessions } from './e2e-fixture/scenarios-usage.js';
 const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   'settings-models',
   'turn-narrative',
+  'turn-narrative-browser',
   'chat-prompt-rail',
   'settings-data',
   'settings-bots-onboarding',
@@ -140,6 +141,8 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'models' };
     case 'turn-narrative':
       return { ...state, activeSessionId: TURN_SESSION_ID, workbarCollapsed: false, workbarTab: 'tasks' };
+    case 'turn-narrative-browser':
+      return { ...state, activeSessionId: TURN_SESSION_ID, workbarCollapsed: false, workbarTab: 'browser' };
     case 'chat-prompt-rail':
       // Workbar collapsed: the rail lives on the chat scrollport's right edge,
       // and the panel would take the width the measurements are about. Whether

--- a/apps/desktop/src/renderer/browser-panel.tsx
+++ b/apps/desktop/src/renderer/browser-panel.tsx
@@ -97,8 +97,11 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
   // per frame is negligible and the IPC only fires when the rect changes.
   const showView = !hidden && state.hasPage;
   useEffect(() => {
+    // Captured because this passive cleanup can run after a bridge host
+    // (Storybook's scoped decorator) has already torn `window.maka` down.
+    const { browser } = window.maka;
     if (!showView) {
-      window.maka.browser.setViewport({ sessionId, rect: null });
+      browser.setViewport({ sessionId, rect: null });
       return;
     }
     const el = stripRef.current;
@@ -116,14 +119,14 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
       const key = `${rect.x},${rect.y},${rect.width},${rect.height}`;
       if (key !== last) {
         last = key;
-        window.maka.browser.setViewport({ sessionId, rect });
+        browser.setViewport({ sessionId, rect });
       }
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
     return () => {
       cancelAnimationFrame(raf);
-      window.maka.browser.setViewport({ sessionId, rect: null });
+      browser.setViewport({ sessionId, rect: null });
     };
   }, [sessionId, showView]);
 

--- a/apps/desktop/src/renderer/browser-panel.tsx
+++ b/apps/desktop/src/renderer/browser-panel.tsx
@@ -34,7 +34,6 @@ const EMPTY_STATE: BrowserState = {
   canGoBack: false,
   canGoForward: false,
   loading: false,
-  favicon: null,
   secure: false,
   hasPage: false,
 };
@@ -145,13 +144,17 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
   }, [address, copy, isBrowserPanelSessionCurrent, sessionId, toast]);
 
   return (
-    <div className="maka-browser-panel" role="region" aria-label={copy.panelAria}>
+    <div
+      className="maka-browser-panel"
+      role="region"
+      aria-label={state.title ? copy.panelAriaWithTitle(state.title) : copy.panelAria}
+    >
       <Toolbar
         className="maka-browser-toolbar"
         label={copy.panelAria}
         size="sm"
         startContent={(
-          <div className="maka-browser-toolbar-start">
+          <>
             <Tooltip content={copy.back}>
               <IconButton
                 label={copy.backAria}
@@ -191,6 +194,8 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
                 isLabelHidden
                 width="100%"
                 placeholder={copy.addressPlaceholder}
+                status={state.hasPage && !state.secure ? { type: 'warning', message: copy.insecure } : undefined}
+                statusVariant="tooltip"
                 value={address}
                 onChange={setAddress}
                 onFocus={() => {
@@ -208,7 +213,7 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
                 }}
               />
             </div>
-          </div>
+          </>
         )}
         endContent={(
           <Tooltip content={copy.close}>
@@ -225,7 +230,6 @@ export function BrowserPanel(props: { sessionId: string; hidden: boolean }) {
       <div className="maka-browser-strip" ref={stripRef}>
         {!state.hasPage && (
           <EmptyState
-            className="maka-browser-empty"
             icon={<Globe size={ICON_SIZE.empty} aria-hidden="true" />}
             title={copy.title}
             description={copy.description}

--- a/apps/desktop/src/renderer/locales/browser-copy.ts
+++ b/apps/desktop/src/renderer/locales/browser-copy.ts
@@ -7,6 +7,8 @@ export type BrowserCopy = {
   navigationFailed: string;
   navigationFailedDetail: string;
   panelAria: string;
+  panelAriaWithTitle: (title: string) => string;
+  insecure: string;
   backAria: string;
   back: string;
   forwardAria: string;
@@ -31,6 +33,8 @@ const BROWSER_COPY = {
     navigationFailed: '浏览器导航失败',
     navigationFailedDetail: '页面暂时无法打开，请稍后重试。',
     panelAria: '嵌入式浏览器',
+    panelAriaWithTitle: (title) => `嵌入式浏览器：${title}`,
+    insecure: '这个站点用 HTTP 传输，连接未加密。',
     backAria: '浏览器后退',
     back: '后退',
     forwardAria: '浏览器前进',
@@ -53,6 +57,8 @@ const BROWSER_COPY = {
     navigationFailed: 'Browser navigation failed',
     navigationFailedDetail: 'The page could not be opened. Try again later.',
     panelAria: 'Embedded browser',
+    panelAriaWithTitle: (title) => `Embedded browser: ${title}`,
+    insecure: 'This site is served over HTTP, so the connection is not encrypted.',
     backAria: 'Go back in browser',
     back: 'Back',
     forwardAria: 'Go forward in browser',

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -930,12 +930,11 @@
   border-bottom: var(--border-width-hairline) solid var(--border);
 }
 
-.maka-browser-toolbar-start {
-  display: flex;
-  min-width: 0;
+/* Astryx sizes its toolbar slots to content; only the product knows the address
+   field, not the nav buttons, should eat the free width. */
+.maka-browser-toolbar div:has(> .maka-browser-address-field) {
   flex: 1 1 auto;
-  align-items: center;
-  gap: var(--space-1);
+  min-width: 0;
 }
 
 .maka-browser-address-field {
@@ -944,20 +943,9 @@
 }
 
 .maka-browser-strip {
-  position: relative;
   flex: 1 1 auto;
   min-height: 0;
-}
-
-.maka-browser-empty {
-  position: absolute;
-  inset: 0;
-  padding-block: 32px;
-  color: var(--muted-foreground);
-}
-
-@media (min-width: 768px) {
-  .maka-browser-empty { padding-block: 39px; }
+  display: grid;
 }
 
 .maka-artifact-pane {

--- a/apps/desktop/stories/session-workbar.stories.tsx
+++ b/apps/desktop/stories/session-workbar.stories.tsx
@@ -1,5 +1,7 @@
+import type { CSSProperties } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ArtifactRecord } from '@maka/core/artifacts';
+import type { BrowserState } from '@maka/core/browser';
 import type { GitReviewSnapshot } from '@maka/core/git-review';
 import type { SessionSummary } from '@maka/core/session';
 import type { Task } from '@maka/core/task-ledger';
@@ -37,7 +39,31 @@ import { withScopedMakaBridge } from './maka-bridge';
 // 1280, above it.
 
 const SESSION_ID = 'session-workbar';
+const STACKED_WINDOW_VIEWPORT = {
+  makaStackedWindow: {
+    name: 'Maka window below the 990px stack point',
+    styles: { width: '900px', height: '900px' },
+    type: 'desktop' as const,
+  },
+};
 const NOW = Date.UTC(2026, 6, 31, 10, 30, 0);
+const EMPTY_BROWSER_STATE: BrowserState = {
+  url: '',
+  title: '',
+  canGoBack: false,
+  canGoForward: false,
+  loading: false,
+  secure: false,
+  hasPage: false,
+};
+const LOADED_BROWSER_STATE: BrowserState = {
+  ...EMPTY_BROWSER_STATE,
+  url: 'https://maka.apache.org/docs/getting-started',
+  title: 'Getting started — Apache Maka',
+  canGoBack: true,
+  secure: true,
+  hasPage: true,
+};
 const TOOL_PICKER_SOURCE_SESSION: SessionSummary = {
   id: SESSION_ID,
   name: '工作栏组件审查',
@@ -515,7 +541,9 @@ function bridge(options: {
   /** The context snapshot the composition block reads (#2323). */
   context?: ContextDiagnosticsResult;
   recordFilePath?: string;
+  browserState?: BrowserState;
 } = {}) {
+  const browserState = options.browserState ?? EMPTY_BROWSER_STATE;
   return withScopedMakaBridge({
     tasks: {
       list: async () => {
@@ -558,22 +586,47 @@ function bridge(options: {
         snapshot: gitReviewSnapshot,
       }),
     },
+    browser: {
+      getState: async () => browserState,
+      onState: unsubscribe,
+      setViewport: noop,
+      navigate: async () => undefined,
+      back: async () => undefined,
+      forward: async () => undefined,
+      reload: async () => undefined,
+      stop: async () => undefined,
+      close: async () => undefined,
+    },
     sessions: { subscribeEvents: unsubscribe },
   });
 }
 
-/** The column AppShell hands the workbar, at the width it restores by default. */
+/**
+ * The AppShell grid the workbar really lives in, with an empty conversation
+ * column. Its 990px media query is what stacks the column in narrow windows.
+ */
 function Workbar(props: {
-  tab?: 'review' | 'tasks' | 'files' | 'inspector';
+  tab?: 'review' | 'tasks' | 'browser' | 'files' | 'inspector';
   sourceSession?: SessionSummary;
+  /** Overrides the restored column width, the way the resize handle does. */
+  width?: number;
 }) {
   const emptyTabsState = createSessionWorkbarTabsState();
   const tabsState = props.tab
     ? openStaticSessionWorkbarTab(emptyTabsState, props.tab)
     : emptyTabsState;
   return (
-    <div style={{ height: 720, display: 'flex', justifyContent: 'flex-end' }}>
-      <ToastProvider>
+    <ToastProvider>
+      <div
+        className="maka-detail-with-artifacts"
+        style={{
+          // Fill the preview viewport like AppShell fills the window; a fixed
+          // height pushes the stacked workbar below the fold in short windows.
+          height: '100dvh',
+          ...(props.width ? { '--maka-session-workbar-width': `${props.width}px` } : {}),
+        } as CSSProperties}
+      >
+        <div className="mainColumn" />
         <SessionWorkbar
           sessionId={SESSION_ID}
           hidden={false}
@@ -592,8 +645,8 @@ function Workbar(props: {
           onRequestOpenTab={noop}
           sourceSession={props.sourceSession}
         />
-      </ToastProvider>
-    </div>
+      </div>
+    </ToastProvider>
   );
 }
 
@@ -639,6 +692,56 @@ export const TasksEmpty: Story = {
 export const TasksLoadFailed: Story = {
   decorators: [bridge({ tasksFail: true })],
   render: () => <Workbar tab="tasks" />,
+};
+
+// Storybook cannot host the native WebContentsView, so these pin what the panel
+// itself draws — chrome and empty state — inside the real workbar shell.
+export const BrowserEmpty: Story = {
+  decorators: [bridge()],
+  render: () => <Workbar tab="browser" />,
+};
+
+// The first navigation: hasPage is derived from the URL, still empty until the
+// page commits, so the empty state and a live 停止 control share a frame.
+export const BrowserLoading: Story = {
+  decorators: [bridge({ browserState: { ...EMPTY_BROWSER_STATE, loading: true } })],
+  render: () => <Workbar tab="browser" />,
+};
+
+// A committed page. The strip below the toolbar is blank here because the native
+// view owns that rect in the app.
+export const BrowserLoaded: Story = {
+  decorators: [bridge({ browserState: LOADED_BROWSER_STATE })],
+  render: () => <Workbar tab="browser" />,
+};
+
+// An http page, where `secure` turns into Astryx's warning status on the field.
+export const BrowserInsecure: Story = {
+  decorators: [bridge({
+    browserState: { ...LOADED_BROWSER_STATE, url: 'http://192.168.1.10:8080/dashboard', title: 'Local dashboard', secure: false },
+  })],
+  render: () => <Workbar tab="browser" />,
+};
+
+// The column's 320px floor — the least room the toolbar row ever gets.
+export const BrowserAtColumnFloor: Story = {
+  decorators: [bridge({ browserState: LOADED_BROWSER_STATE })],
+  render: () => <Workbar tab="browser" width={320} />,
+};
+
+// The width the resize handle lands on most often, between the floor and default.
+export const BrowserAt400: Story = {
+  decorators: [bridge({ browserState: LOADED_BROWSER_STATE })],
+  render: () => <Workbar tab="browser" width={400} />,
+};
+
+// Below 990px the grid stacks the same right-placement column under the
+// conversation: full width, capped at 42dvh.
+export const BrowserStacked: Story = {
+  parameters: { viewport: { options: STACKED_WINDOW_VIEWPORT } },
+  globals: { viewport: { value: 'makaStackedWindow', isRotated: false } },
+  decorators: [bridge({ browserState: LOADED_BROWSER_STATE })],
+  render: () => <Workbar tab="browser" />,
 };
 
 // Real path: 任务工作栏 → 文件, on a session whose agent wrote artifacts. The

--- a/apps/desktop/stories/session-workbar.stories.tsx
+++ b/apps/desktop/stories/session-workbar.stories.tsx
@@ -736,7 +736,8 @@ export const BrowserAt400: Story = {
 };
 
 // Below 990px the grid stacks the same right-placement column under the
-// conversation: full width, capped at 42dvh.
+// conversation: full width, capped at 42dvh. Storybook-UI only: the smoke lane
+// loads iframes at 1280px, above the stack point, so it renders wide there.
 export const BrowserStacked: Story = {
   parameters: { viewport: { options: STACKED_WINDOW_VIEWPORT } },
   globals: { viewport: { value: 'makaStackedWindow', isRotated: false } },

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -11,7 +11,6 @@ export interface BrowserState {
   canGoBack: boolean;
   canGoForward: boolean;
   loading: boolean;
-  favicon: string | null;
   /** https origin. */
   secure: boolean;
   /** A real page is loaded (not blank / about:) — gates the DOM empty state. */

--- a/packages/core/src/e2e-fixture.ts
+++ b/packages/core/src/e2e-fixture.ts
@@ -6,6 +6,7 @@ import type { UiLocale } from './ui-locale.js';
 export type E2eFixtureScenario =
   | 'settings-models'
   | 'turn-narrative'
+  | 'turn-narrative-browser'
   | 'chat-prompt-rail'
   | 'settings-data'
   | 'settings-bots-onboarding'

--- a/scripts/audit-alignment.mjs
+++ b/scripts/audit-alignment.mjs
@@ -34,6 +34,8 @@ const FIXTURES = [
   // tables now sit under the alignment auditor's watch.
   ['settings-usage', '.settingsSurface'],
   ['turn-narrative', '.maka-session-workbar'],
+  // #2188: the browser toolbar's four-control-plus-input row.
+  ['turn-narrative-browser', '.maka-browser-panel'],
   ['settings-permissions', '.settingsSurface'],
   // #1233 deferral: bot QR-onboarding modal in its deterministic waiting state.
   ['settings-bots-onboarding', '.settingsSurface'],


### PR DESCRIPTION
## Summary

Refs #2188

First panel interior from the #2188 list. Auditing the browser chrome against the design system found three defects, fixed as one pass:

- The address bar never stretched (~154px at every width): the flex rule targeted the panel's own wrapper, not the Astryx Toolbar slot.
- The empty state restated `EmptyState` defaults as magic numbers (32px/39px, a 768px breakpoint used nowhere else). Deleted.
- `favicon`/`secure`/`title` crossed IPC with no consumer. `favicon` is removed end to end (the renderer CSP can never load it); `secure` now shows a warning status on http pages; `title` feeds the panel's `aria-label`.

New stories pin every state the E2E fixture cannot reach — empty, loading, loaded, insecure — at the 320px floor, 400px, and the sub-990px stacked layout, mounted in the real AppShell grid.

Behavior change: the http warning and the title-bearing accessible name above; the empty-state Globe icon also moves from `--muted-foreground` to the inherited foreground, converging with the terminal/artifacts empty states.

## Verification

lint · format:check · build · typecheck · knip (desktop, ui) pass; browser main-process tests 34/34; Storybook render smoke 143 stories; `session-workbar.spec.ts` (4/4) including a new width-tracking assertion verified to fail with the slot rule removed; `audit-alignment.mjs` clean including the new `turn-narrative-browser` fixture.

```
before  browser-loaded          addressInput: 154
before  browser-at-400          addressInput: 154
before  browser-at-column-floor addressInput: 154

after   browser-loaded          addressInput: 310
after   browser-at-400          addressInput: 230
after   browser-at-column-floor addressInput: 150
```

|  | before | after |
| --- | --- | --- |
| 480px column | <img alt="before-browser-loaded" width="380" src="https://github.com/user-attachments/assets/2f793c35-fcba-4256-86a8-da25eba87257" /> | <img alt="after-browser-loaded" width="380" src="https://github.com/user-attachments/assets/a78c58cc-f159-4659-a0ae-99f0990b0378" /> |
| http page | <img alt="before-browser-insecure" width="380" src="https://github.com/user-attachments/assets/81b39742-e5f0-4754-bb7a-53c31ee3f0b6" /> | <img alt="after-browser-insecure" width="380" src="https://github.com/user-attachments/assets/cc62e2f8-013c-4580-a4cd-d2b29f518daf" /> |
| 400px | <img alt="before-browser-at-400" width="340" src="https://github.com/user-attachments/assets/e779c020-802d-4718-a4c2-641127aea838" /> | <img alt="after-browser-at-400" width="340" src="https://github.com/user-attachments/assets/c86c080d-f26c-4474-b659-fc23d420285c" /> |

At the 320px floor the field yields to the four controls either way (154px → 150px), so before/after are visually identical there by design.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Opus) — panel/CSS changes and stories, human-directed and reviewed.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No


