### PR TITLE
fix(cli): stop steering known slash commands into a running turn

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -4930,6 +4930,159 @@ describe('Maka Pi TUI runner', () => {
     });
   });
 
+  describe('slash commands during a running turn', () => {
+    test('/recap answers locally instead of steering into the model', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new SteeringTurnDriver();
+      driver.rewindTargets = [{ turnId: 'turn-1', label: 'first' }];
+      let calls = 0;
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'm',
+        connectionSlug: 'c',
+        permissionMode: 'bypass',
+        terminal,
+        recap: {
+          generate: async () => {
+            calls += 1;
+            return { ok: true, text: 'mid-turn recap', raw: 'mid-turn recap' };
+          },
+        },
+      });
+
+      terminal.input('start the work');
+      terminal.input('\r');
+      await waitFor(() => terminal.progressStates.at(-1) === true);
+
+      // The recap uses the independent session.recap.generate call behind its
+      // own in-flight lock, so it can answer while the turn is running;
+      // steering "/recap" into the model would read as a confused instruction.
+      terminal.input('/recap');
+      terminal.input('\r');
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes('Recap: mid-turn recap'));
+      assert.equal(calls, 1);
+      assert.deepEqual(driver.steered, []);
+
+      terminal.input('\x1b');
+      terminal.input('\x1b');
+      await waitFor(() => terminal.progressStates.at(-1) === false);
+      // Interrupt refills the editor with the cleared queue; clear it before /exit.
+      terminal.input('\x03');
+      terminal.input('/exit');
+      terminal.input('\r');
+      await run;
+    });
+
+    test('/resume refuses with a clear message instead of steering into the model', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new SteeringTurnDriver();
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'm',
+        connectionSlug: 'c',
+        permissionMode: 'bypass',
+        terminal,
+      });
+
+      terminal.input('start the work');
+      terminal.input('\r');
+      await waitFor(() => terminal.progressStates.at(-1) === true);
+
+      // A safe-boundary resume mutates the session behind the turn's back; it
+      // must be refused loudly, never steered into the model as "/resume".
+      terminal.input('/resume');
+      terminal.input('\r');
+      await waitFor(() =>
+        plainTerminalOutput(terminal.output()).includes(
+          'Cannot run /resume while a turn is running',
+        ),
+      );
+      assert.deepEqual(driver.steered, []);
+
+      terminal.input('\x1b');
+      terminal.input('\x1b');
+      await waitFor(() => terminal.progressStates.at(-1) === false);
+      terminal.input('\x03');
+      terminal.input('/exit');
+      terminal.input('\r');
+      await run;
+    });
+
+    test('/model refuses instead of opening the picker behind the running turn', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new SteeringTurnDriver();
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'm',
+        connectionSlug: 'c',
+        permissionMode: 'bypass',
+        terminal,
+      });
+
+      terminal.input('start the work');
+      terminal.input('\r');
+      await waitFor(() => terminal.progressStates.at(-1) === true);
+
+      terminal.input('/model');
+      terminal.input('\r');
+      await waitFor(() =>
+        plainTerminalOutput(terminal.output()).includes(
+          'Cannot run /model while a turn is running',
+        ),
+      );
+      assert.deepEqual(driver.steered, []);
+
+      terminal.input('\x1b');
+      terminal.input('\x1b');
+      await waitFor(() => terminal.progressStates.at(-1) === false);
+      terminal.input('\x03');
+      terminal.input('/exit');
+      terminal.input('\r');
+      await run;
+    });
+
+    test('unknown slash-prefixed text still steers into the running turn', async () => {
+      const terminal = new FakeTerminal();
+      const driver = new SteeringTurnDriver();
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'm',
+        connectionSlug: 'c',
+        permissionMode: 'bypass',
+        terminal,
+      });
+
+      terminal.input('start the work');
+      terminal.input('\r');
+      await waitFor(() => terminal.progressStates.at(-1) === true);
+
+      // `/skill:<name>` is not a catalog command; mid-turn it stays prompt
+      // text for the running turn, exactly like any other steered message.
+      terminal.input('/skill:review');
+      terminal.input('\r');
+      await waitFor(() =>
+        plainTerminalOutput(terminal.screenOutput()).includes('Steering: /skill:review'),
+      );
+      assert.deepEqual(driver.steered, ['/skill:review']);
+
+      terminal.input('\x1b');
+      terminal.input('\x1b');
+      await waitFor(() => terminal.progressStates.at(-1) === false);
+      terminal.input('\x03');
+      terminal.input('/exit');
+      terminal.input('\r');
+      await run;
+    });
+  });
+
   describe('/goal command', () => {
     const armedGoal: GoalProjection = {
       goalId: 'goal-1',
@@ -5817,6 +5970,7 @@ class SteeringTurnDriver implements MakaSessionDriver {
   readonly queuedMessages: string[] = [];
   readonly turnOrchestrations: Array<MakaPreparePromptOptions['turnOrchestration']> = [];
   retractCalls = 0;
+  rewindTargets: RewindTarget[] = [];
   private steering: string[] = [];
   private followup: string[] = [];
   private pendingEvents: SessionEvent[] = [];
@@ -5932,7 +6086,7 @@ class SteeringTurnDriver implements MakaSessionDriver {
     return switchResult(fakeSessionSummary(sessionId));
   }
   async listRewindTargets(): Promise<RewindTarget[]> {
-    return [];
+    return this.rewindTargets;
   }
   async rewindToTurn(): Promise<MakaSessionRewindResult> {
     throw new Error('rewind not supported in this fake');

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -1084,13 +1084,34 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         }
         return;
       }
-      // Read-only status commands answer locally even mid-turn instead of
-      // steering into the model as prompt text: an autonomous goal loop keeps
-      // a turn running almost by definition, and that is exactly when the
-      // user reaches for `/goal` (review finding on turnRunning routing).
-      if (prompt.trim().split(/\s+/, 1)[0] === '/goal') {
+      // Known slash commands typed mid-turn must not steer into the model as
+      // prompt text (review finding on turnRunning routing). `/goal` and
+      // `/recap` answer locally: both are independent of the running turn —
+      // `/goal` is read-only status, and `/recap` uses the separate
+      // session.recap.generate call behind its own in-flight lock. Every other
+      // known command either mutates session state behind the turn's back or
+      // opens a picker the turn would race (and would silently no-op on the
+      // runControl busy gate even if it ran), so refuse it with a clear
+      // message. Unknown slash-prefixed text still steers: it may be intended
+      // prompt text (a skill invocation such as `/skill:<name>`, or a path).
+      const commandToken = prompt.trim().split(/\s+/, 1)[0] ?? '';
+      const knownCommand = slashCommands.find(
+        (candidate) =>
+          `/${candidate.name}` === commandToken ||
+          candidate.aliases?.some((alias) => `/${alias}` === commandToken),
+      );
+      if (knownCommand) {
         editor.addToHistory(prompt);
-        handleSlashCommand(prompt, 0);
+        if (knownCommand.name === 'goal' || knownCommand.name === 'recap') {
+          handleSlashCommand(prompt, 0);
+        } else {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: `Cannot run /${knownCommand.name} while a turn is running — interrupt it (Esc) or wait for it to finish.`,
+          });
+          requestRender();
+        }
         return;
       }
       steerRunningTurn(prompt);


### PR DESCRIPTION
## Summary

Typing `/recap` or `/resume` in the TUI while a turn is running never ran the command: `editor.onSubmit` only special-cased exit forms, `/swarm`, `/graph`, and `/goal`, so every other input — including known slash commands — went to `steerRunningTurn()` and the model received the literal text (`Steering: /resume`) as a user message. Whether the command executed at all depended on whether the turn was still alive when the enqueue landed (the `fallback` path re-routes through `submitPrompt`).

Mid-turn submissions of known slash commands now route explicitly: `/goal` and `/recap` answer locally (both are independent of the running turn — recap uses the separate `session.recap.generate` call behind its own in-flight lock); every other known command is refused with a clear message ("Cannot run /X while a turn is running — interrupt it (Esc) or wait for it to finish.") instead of being steered or silently no-opping on the `runControl` busy gate; unknown slash-prefixed text (skill invocations like `/skill:<name>`, paths) still steers unchanged.

Fixes #3308

## Verification

- `npm --workspace maka-agent test`: 320 pass / 0 fail, including 4 new tests under `slash commands during a running turn` (`/recap` answers locally, `/resume` and `/model` refuse with a message, unknown slash text still steers).
- The new tests fail without the fix: reverting `pi-tui-runner.ts` and rebuilding makes the `/recap`, `/resume`, and `/model` tests fail while the unknown-slash test still passes.
- `npm run lint`, `npm run format:check`, `npm run typecheck`: pass.
- Not run: desktop e2e (no desktop change).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka (AI agent) located the routing defect, implemented the fix and tests, and ran the verification; the commit carries the `Generated-by: Maka` trailer. Human contributor of record reviewed the diagnosis and the routing design and decided to submit.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No