### PR TITLE
fix(desktop): align project session titles with the project name

### DIFF
--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -42,7 +42,10 @@ test('project navigation and actions follow their visual keyboard order', async 
   ]);
   expect(projectNavigationBox).not.toBeNull();
   expect(firstSessionBox).not.toBeNull();
-  expect(firstSessionBox!.x - projectNavigationBox!.x).toBeGreaterThanOrEqual(20);
+  // Remaining nest after StatusDot occupies 8px of Astryx's 24px icon column.
+  const sessionInset = firstSessionBox!.x - projectNavigationBox!.x;
+  expect(sessionInset).toBeGreaterThanOrEqual(6);
+  expect(sessionInset).toBeLessThan(16);
 
   await expect(projectRow.locator('button button')).toHaveCount(0);
   await expect(navigation).toHaveAttribute('aria-expanded', 'true');

--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -36,16 +36,27 @@ test('project navigation and actions follow their visual keyboard order', async 
 
   await expect(navigation).toBeVisible();
   await expect(firstSessionControl).toBeVisible();
-  const [projectNavigationBox, firstSessionBox] = await Promise.all([
+  const projectTitle = navigation.getByText(LONG_SIDEBAR_PROJECT_NAME, { exact: true });
+  const sessionTitle = firstSessionControl.getByText('任务 00', { exact: true });
+  await expect(projectTitle).toBeVisible();
+  await expect(sessionTitle).toBeVisible();
+  const [projectNavigationBox, firstSessionBox, projectTitleBox, sessionTitleBox] = await Promise.all([
     navigation.boundingBox(),
     firstSessionControl.boundingBox(),
+    projectTitle.boundingBox(),
+    sessionTitle.boundingBox(),
   ]);
   expect(projectNavigationBox).not.toBeNull();
   expect(firstSessionBox).not.toBeNull();
-  // Remaining nest after StatusDot occupies 8px of Astryx's 24px icon column.
+  expect(projectTitleBox).not.toBeNull();
+  expect(sessionTitleBox).not.toBeNull();
+  // Hierarchy is the session button sitting inside the project button. Title
+  // alignment is the product contract: leading content widths differ, so the
+  // inset is not the same as the title column.
   const sessionInset = firstSessionBox!.x - projectNavigationBox!.x;
   expect(sessionInset).toBeGreaterThanOrEqual(6);
   expect(sessionInset).toBeLessThan(16);
+  expect(Math.abs(projectTitleBox!.x - sessionTitleBox!.x)).toBeLessThanOrEqual(2);
 
   await expect(projectRow.locator('button button')).toHaveCount(0);
   await expect(navigation).toHaveAttribute('aria-expanded', 'true');

--- a/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
@@ -18,13 +18,12 @@ describe('project-grouped session hierarchy', () => {
     );
 
     assert.ok(projectChildrenRule, 'project children must have an explicit hierarchy rule');
-    // Astryx nests icon-less children by spacing-6 (24px) so their text meets a
-    // parent title after a 16px icon + 8px gap. Session rows already spend 8px
-    // on StatusDot in that slot, so the remaining nest is spacing-2.
+    // Product contract: 8px nest so session titles share the project title's x.
+    // SideNav's default spacing-6 is a fixed child inset, not that alignment.
     assert.match(
       projectChildrenRule[1] ?? '',
       /padding-inline-start:\s*var\(--spacing-2\)\s*!important;/,
-      'project sessions must nest by the unused 8px of the SideNav icon column',
+      'project sessions must keep an 8px hierarchical nest',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts
@@ -12,16 +12,19 @@ if (!sidebarCssUrl) throw new Error('Could not locate renderer/styles/sidebar.cs
 const sidebarCss = readFileSync(sidebarCssUrl, 'utf8');
 
 describe('project-grouped session hierarchy', () => {
-  it('visually indents session rows beneath their project', () => {
+  it('aligns session titles with the project name', () => {
     const projectChildrenRule = sidebarCss.match(
       /\.maka-project-row\s*>\s*div\s*>\s*\[role=["']group["']\]\s*>\s*div\s*\{([^}]*)\}/,
     );
 
     assert.ok(projectChildrenRule, 'project children must have an explicit hierarchy rule');
+    // Astryx nests icon-less children by spacing-6 (24px) so their text meets a
+    // parent title after a 16px icon + 8px gap. Session rows already spend 8px
+    // on StatusDot in that slot, so the remaining nest is spacing-2.
     assert.match(
       projectChildrenRule[1] ?? '',
-      /padding-inline-start:\s*var\(--spacing-6\)\s*!important;/,
-      'project sessions must keep one SideNav nesting step (24px)',
+      /padding-inline-start:\s*var\(--spacing-2\)\s*!important;/,
+      'project sessions must nest by the unused 8px of the SideNav icon column',
     );
   });
 });

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -226,12 +226,14 @@
 }
 
 /*
- * Project groups are a real parent-child hierarchy. Astryx nests icon-less
- * children by spacing-6 (24px) so their text meets a parent title after a
- * 16px icon + 8px gap. Session rows already spend 8px on StatusDot in that
- * slot, so the remaining nest is spacing-2: titles share one x, and the row
- * still sits inside the project. Pin the value because StyleX owns the
- * unlayered default. Child combinator only — do not use a descendant
+ * Project groups are a parent-child hierarchy. SideNav always nests children
+ * by spacing-6; that is a fixed inset, not a title-alignment rule. Project
+ * rows lead with a 16px folder, session rows with an 8px StatusDot, so the
+ * default 24px inset puts session titles 16px right of the project name.
+ * Product intent: keep an 8px hierarchical inset (spacing-2) so titles share
+ * one x. The whole session button, including hover/selected fill, moves with
+ * that inset; the right edge stays on the rail. Pin the value because StyleX
+ * owns the unlayered default. Child combinator only — do not use a descendant
  * selector that would indent deeper nest levels twice if any appear later.
  * DOM: .maka-project-row > SideNavItem root > [role=group] > childrenInner
  */

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -226,18 +226,18 @@
 }
 
 /*
- * Project groups are a real parent-child hierarchy. Keep Astryx's standard
- * SideNav nesting step (spacing-6 / 24px) so session rows visibly belong to
- * the project above them instead of sharing the project's left edge. Pin the
- * value here because StyleX owns the unlayered default and this relationship
- * is part of the task rail's visual contract. Child combinator only — do not
- * use a descendant selector that would indent deeper nest levels twice if any
- * appear later.
+ * Project groups are a real parent-child hierarchy. Astryx nests icon-less
+ * children by spacing-6 (24px) so their text meets a parent title after a
+ * 16px icon + 8px gap. Session rows already spend 8px on StatusDot in that
+ * slot, so the remaining nest is spacing-2: titles share one x, and the row
+ * still sits inside the project. Pin the value because StyleX owns the
+ * unlayered default. Child combinator only — do not use a descendant
+ * selector that would indent deeper nest levels twice if any appear later.
  * DOM: .maka-project-row > SideNavItem root > [role=group] > childrenInner
  */
 .maka-project-row > div > [role="group"] > div {
   /* !important: StyleX childrenInner paddingInlineStart is unlayered. */
-  padding-inline-start: var(--spacing-6) !important;
+  padding-inline-start: var(--spacing-2) !important;
 }
 
 .maka-session-row-end,

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -346,7 +346,7 @@ function ProjectNavRow(props: {
           ) : undefined
         }
       >
-        {/* sidebar.css preserves one SideNav nesting step for project hierarchy. */}
+        {/* sidebar.css nests by the unused 8px of the SideNav icon column. */}
         {hasSessions ? (
           <VStack gap={0.5}>{props.sessions.map((session) => props.renderSession(session))}</VStack>
         ) : undefined}

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -346,7 +346,7 @@ function ProjectNavRow(props: {
           ) : undefined
         }
       >
-        {/* sidebar.css nests by the unused 8px of the SideNav icon column. */}
+        {/* sidebar.css keeps an 8px nest so session titles share the project x. */}
         {hasSessions ? (
           <VStack gap={0.5}>{props.sessions.map((session) => props.renderSession(session))}</VStack>
         ) : undefined}

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -343,8 +343,8 @@ export const PinnedAndRecentSections: Story = {
   ),
 };
 
-// Real path: group-by-project — collapsible project rows, sessions flush under
-// the project (zero nest padding), worktree mark + count badge.
+// Real path: group-by-project — collapsible project rows, sessions nested 8px
+// under the project so titles share one x, worktree mark + count badge.
 export const ProjectGroups: Story = {
   render: () => {
     const maka = makeProject({


### PR DESCRIPTION
## Summary

Project-grouped session rows were nested a full Astryx SideNav step (24px). That step is for icon-less children so their text meets a parent title after a 16px icon + 8px gap. Session rows already spend 8px on StatusDot in that slot, so the extra 24px pushed titles too far right of the project name.

<img width="1048" height="896" alt="image" src="https://github.com/user-attachments/assets/6674fad3-37cf-4f8e-9679-11a5ea580573" />

Keep the remaining 8px nest (`--spacing-2`) so titles share one x and the row still sits inside the project.

## Verification

- Ran `node --experimental-strip-types --test apps/desktop/src/main/__tests__/session-project-hierarchy-contract.test.ts` in the worktree (pass).
- Did not run Playwright locally: the geometry spec opens a visible Electron window and would steal focus from an active `maka dev` session. Leave `sidebar-project-row.spec.ts` to CI.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Maka diagnosed the indent, chose the 8px remaining nest, and authored the CSS, contract test, e2e assertion, and commit.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No