### PR TITLE
chore(ui): show signed-in mark in model provider list

### DIFF
--- a/apps/desktop/src/renderer/settings/claude-subscription-card.tsx
+++ b/apps/desktop/src/renderer/settings/claude-subscription-card.tsx
@@ -31,7 +31,7 @@ import { useRuntimeHostSettingsTarget } from './runtime-host-settings-target.js'
  * `useOAuthLoginFlow` — Claude deliberately keeps its own card because it
  * needs the manual authorization-code step and the experimental gate.
  */
-export function ClaudeSubscriptionCard() {
+export function ClaudeSubscriptionCard(props: { onLoginSuccess(): void | Promise<void> }) {
   const host = useRuntimeHostSettingsTarget();
   const locale = useUiLocale();
   const copy = getProviderSettingsCopy(locale).claude;
@@ -229,6 +229,7 @@ export function ClaudeSubscriptionCard() {
         setStateHint(null);
         setPasteValue('');
         await refresh();
+        await props.onLoginSuccess();
       } else {
         setPasteError(subscriptionResultMessage(result.message, copy.submitFailedRetry, locale));
       }

--- a/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
+++ b/apps/desktop/src/renderer/settings/provider-catalog-page.tsx
@@ -8,7 +8,7 @@ import {
   Selector,
   VStack,
 } from '@astryxdesign/core';
-import { ICON_SIZE, ChevronRight, Search } from '@maka/ui/icons';
+import { ICON_SIZE, Check, ChevronRight, Search } from '@maka/ui/icons';
 import {
   CATALOG_PROVIDER_TYPES,
   RECOMMENDED_PROVIDER_TYPES,
@@ -144,7 +144,17 @@ export function ProviderCatalogPage(props: {
               startContent={<ProviderLogo type={card.providerType} />}
               label={/* a11y-allow: this label names the ROW, not the span. Astryx's Item puts consumer props on its outer wrapper and renders a separate invisible <button> for the click target, so an aria-label on the Item never reaches that button — measured. The button is named from its content, and this span is how the status reaches that name. Removing it drops the runtime error from the row's accessible name (settings.spec:226).*/ <span aria-label={providerCopy.oauthSection.cardAria(card.name, card.status, card.description)}>{card.name}</span>}
               description={card.description}
-              endContent={<ChevronRight size={ICON_SIZE.chrome} aria-hidden="true" />}
+              endContent={(
+                <HStack gap={2} vAlign="center">
+                  {card.isLoggedIn && (
+                    <span className="settingsStatus" aria-hidden="true">
+                      <Check size={ICON_SIZE.chrome} />
+                      <span>{providerCopy.oauthSection.signedIn}</span>
+                    </span>
+                  )}
+                  <ChevronRight size={ICON_SIZE.chrome} aria-hidden="true" />
+                </HStack>
+              )}
               onClick={() => props.onPick({
                 method: 'account',
                 cardId: card.id,

--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -169,8 +169,12 @@ export function useOAuthCards(props: { query?: string }) {
  * level, the same ones the catalog and the connection detail use.
  */
 export function OAuthLoginPanel(props: { cardId: OAuthCardId; onLoginSuccess(): void | Promise<void> }) {
-  if (props.cardId === 'claude') return <ClaudeSubscriptionCard />;
-  if (props.cardId === 'github-copilot') return <GitHubCopilotLoginPanel />;
+  if (props.cardId === 'claude') {
+    return <ClaudeSubscriptionCard onLoginSuccess={props.onLoginSuccess} />;
+  }
+  if (props.cardId === 'github-copilot') {
+    return <GitHubCopilotLoginPanel onLoginSuccess={props.onLoginSuccess} />;
+  }
   return <SubscriptionLoginPanel service={props.cardId} onLoginSuccess={props.onLoginSuccess} />;
 }
 
@@ -253,7 +257,7 @@ function SubscriptionLoginPanel(props: {
   );
 }
 
-function GitHubCopilotLoginPanel() {
+function GitHubCopilotLoginPanel(props: { onLoginSuccess(): void | Promise<void> }) {
   const host = useRuntimeHostSettingsTarget();
   const copy = getProviderSettingsCopy(useUiLocale()).oauthSection;
   // The shared login-flow controller owns the snapshot refresh, the
@@ -267,6 +271,7 @@ function GitHubCopilotLoginPanel() {
       logout: () => window.maka.githubCopilotSubscription.logout(host),
     } as OAuthLoginFlowBridge,
     display: { name: 'GitHub Copilot', shortName: 'GitHub Copilot' },
+    onLoginSuccess: props.onLoginSuccess,
     direct: {
       login: () => window.maka.githubCopilotSubscription.connectExistingLogin(host),
       refreshTokens: () => window.maka.githubCopilotSubscription.refreshTokens(host),


### PR DESCRIPTION
In model list, after signed in a provider, there is no indidcator to mark it as signed in.

this pr add a mark to show it.

Before:
<img width="938" height="390" alt="image" src="https://github.com/user-attachments/assets/8ec8069a-5f82-4cd4-a211-4eb30fbd81e9" />

After:
<img width="969" height="467" alt="image" src="https://github.com/user-attachments/assets/afed53e5-a60c-444c-a994-31d127384daf" />
