### PR TITLE
fix(providers): add GLM-5.3 to Agent Plan catalog

### DIFF
--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -132,27 +132,6 @@ test('connection catalogs preserve user-choice provenance without inventing avai
   assert.deepEqual(entries[2]?.provenance.sources?.userChoice, ['session_model']);
 });
 
-test('Volcengine Agent Plan offers GLM-5.3 with its published model limits', () => {
-  const entries = buildConnectionModelCatalogEntries({
-    connection: {
-      slug: 'volcengine-agent-plan',
-      providerType: 'volcengine-agent-plan',
-      defaultModel: 'glm-5.3',
-      modelSource: 'fallback',
-    },
-  });
-
-  const model = entries.find((entry) => entry.id === 'glm-5.3');
-  assert.equal(PROVIDER_DEFAULTS['volcengine-agent-plan'].fallbackModels.includes('glm-5.3'), true);
-  assert.equal(model?.displayName, 'GLM-5.3');
-  assert.equal(model?.contextWindow, 1_000_000);
-  assert.equal(model?.maxOutputTokens, 131_072);
-  assert.deepEqual(model?.capabilities, {
-    reasoning: true,
-    functionCalling: true,
-  });
-});
-
 test('unknown persisted provider ids return an empty catalog', () => {
   assert.deepEqual(
     buildConnectionModelCatalogEntries({

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -132,6 +132,27 @@ test('connection catalogs preserve user-choice provenance without inventing avai
   assert.deepEqual(entries[2]?.provenance.sources?.userChoice, ['session_model']);
 });
 
+test('Volcengine Agent Plan offers GLM-5.3 with its published model limits', () => {
+  const entries = buildConnectionModelCatalogEntries({
+    connection: {
+      slug: 'volcengine-agent-plan',
+      providerType: 'volcengine-agent-plan',
+      defaultModel: 'glm-5.3',
+      modelSource: 'fallback',
+    },
+  });
+
+  const model = entries.find((entry) => entry.id === 'glm-5.3');
+  assert.equal(PROVIDER_DEFAULTS['volcengine-agent-plan'].fallbackModels.includes('glm-5.3'), true);
+  assert.equal(model?.displayName, 'GLM-5.3');
+  assert.equal(model?.contextWindow, 1_000_000);
+  assert.equal(model?.maxOutputTokens, 131_072);
+  assert.deepEqual(model?.capabilities, {
+    reasoning: true,
+    functionCalling: true,
+  });
+});
+
 test('unknown persisted provider ids return an empty catalog', () => {
   assert.deepEqual(
     buildConnectionModelCatalogEntries({

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -254,6 +254,9 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
 };
 const VOLCENGINE_AGENT_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'ark-code-latest': agentPlanModel('Ark Code Latest', 256_000, 32_000, { vision: true }),
+  // Agent Plan currently exposes GLM-5.3 in its ark-code-latest routing catalog.
+  // The underlying model's published limits are 1M context and 128K output.
+  'glm-5.3': agentPlanModel('GLM-5.3', 1_000_000, 131_072),
   'doubao-seed-2.0-mini': agentPlanModel('Doubao Seed 2.0 Mini', 256_000, 128_000, {
     vision: true,
   }),

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -290,6 +290,7 @@ const volcengineCodingPlanModelIds = [
 ] as const;
 const volcengineAgentPlanModelIds = [
   'ark-code-latest',
+  'glm-5.3',
   'doubao-seed-2.0-mini',
   'doubao-seed-2.0-lite',
   'deepseek-v4-flash',


### PR DESCRIPTION
## Summary

Adds `glm-5.3` to Maka's built-in Volcengine Ark Agent Plan fallback catalog, including its published 1M-token context window and 128K maximum output.

Agent Plan's dedicated inference API key has no usable runtime model-list endpoint, so this intentionally preserves fallback-based discovery rather than adding a `/models` refresh request.

Refs #1584

Sources:

- [Volcengine Ark model list](https://console.volcengine.com/ark/region:cn-beijing/docs/82379/1330310?lang=zh)
- Official Agent Plan console: `glm-5.3` is present in the `ark-code-latest` routing catalog.

## Verification

- `npm --workspace @maka/core test` — passed (564 tests) before the targeted assertion was removed at maintainer feedback.
- `npx biome lint packages/core/src/__tests__/model-catalog.test.ts` — passed after the test removal.
- `git diff --check` — passed before committing the removal.
- Not run: full repository test suite, format check, or typecheck.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka prepared the catalog and metadata change, and this PR description. The human contributor reviewed the scope and authorized submission. The commits include `Generated-by: Maka` trailers.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
