### PR TITLE
fix(runtime-host): remove stale surface inputs

### DIFF
--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -76,7 +76,6 @@ test('owned connect returns a missed election without waiting for a late candida
     const result = await connectOwnedRuntimeHostWithDependencies(
       {
         rootPath,
-        surface: 'run',
         protocol: {
           min: RUNTIME_HOST_PROTOCOL_VERSION,
           max: RUNTIME_HOST_PROTOCOL_VERSION,
@@ -132,7 +131,6 @@ test('a late owned candidate stays alive after another client adopts it', {
     const missed = await connectOwnedRuntimeHostWithDependencies(
       {
         rootPath,
-        surface: 'run',
         protocol: {
           min: RUNTIME_HOST_PROTOCOL_VERSION,
           max: RUNTIME_HOST_PROTOCOL_VERSION,
@@ -165,7 +163,6 @@ test('a late owned candidate stays alive after another client adopts it', {
     const adopted = await connectOrSpawnRuntimeHostWithDependencies(
       {
         rootPath,
-        surface: 'run',
         protocol: {
           min: RUNTIME_HOST_PROTOCOL_VERSION,
           max: RUNTIME_HOST_PROTOCOL_VERSION,


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Remove three obsolete `surface` inputs from the owned-candidate regression tests so the merged `main` tree builds from a clean source archive again.

#3277 retired client surface identity from Runtime Host connection inputs. #3221 was developed against an older base and later restored the retired field in three newly added test calls without producing a textual merge conflict. The tests retain their election and late-candidate coverage; only the invalid input is removed.

Closes #3331

## Verification

- `npm run build` — passed
- `npm run typecheck` — passed
- `npm --workspace @maka/runtime-host test` — 1,029 passed, 0 failed
- `git diff --check` — passed

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex diagnosed the merged-tree regression, implemented the minimal fix, and ran the listed verification.

## Checklist

- [x] Existing tests cover the affected behavior and the clean build fails without this fix
- [x] Typecheck and the affected suite pass locally; the three-line deletion requires no formatting or lint changes

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

</details>

<details>
<summary>中文</summary>

## 摘要

从 owned-candidate 回归测试中删除 3 个已经失效的 `surface` 输入，使合并后的 `main` 再次能够从干净源码归档完成构建。

#3277 已从 Runtime Host 连接输入中移除客户端 surface identity。#3221 基于更早的基线开发，随后在 3 处新增测试调用中重新带入了该字段，且合并时没有产生文本冲突。本 PR 只删除无效输入，完整保留 election 与 late-candidate 行为覆盖。

Closes #3331

## 验证

- `npm run build`：通过
- `npm run typecheck`：通过
- `npm --workspace @maka/runtime-host test`：1,029 项通过，0 项失败
- `git diff --check`：通过

## AI 使用

OpenAI Codex 协助定位合并树回归、实现最小修复并执行上述验证。具体声明以英文区为准。

## 检查清单

- [x] 现有测试覆盖受影响行为，且没有本修复时干净构建会失败
- [x] 类型检查和受影响测试套件均在本地通过；三行删除不需要额外格式化或 lint 变更

本 PR 是否改变行为？

- [ ] 是——已在摘要中说明
- [x] 否

</details>
