### PR TITLE
fix(runtime-host): drop unread scheduled-task backend persistence

### DIFF
--- a/packages/core/src/__tests__/scheduled-task.test.ts
+++ b/packages/core/src/__tests__/scheduled-task.test.ts
@@ -147,36 +147,6 @@ describe('scheduled-task catalog', () => {
     assert.deepEqual(result, { ok: false, message: 'Schedule must fire before expiresAt' });
   });
 
-  it('refuses to create an Automation on the retired backend', () => {
-    // #3211: this is create/update input, not a decoder — stored Automations
-    // are read back with JSON.parse and never reach here. Accepting `'fake'`
-    // would let a brand new Automation be written that can only fail later at
-    // activation.
-    const now = Date.UTC(2026, 0, 5, 8, 0, 0);
-    const execution = {
-      cwd: '/tmp/project',
-      llmConnectionSlug: 'anthropic',
-      model: 'claude-sonnet-4-5-20250929',
-      permissionMode: 'ask',
-      collaborationMode: 'agent',
-      orchestrationMode: 'default',
-    };
-    const create = (backend: string) =>
-      normalizeCreateScheduledTaskInput(
-        {
-          title: 'Nightly run',
-          intentBody: 'do the thing',
-          schedule: { kind: 'once', runAt: now + 60_000 },
-          effect: { kind: 'agent_run', execution: { ...execution, backend } },
-          createdBy: { kind: 'user' },
-        },
-        now,
-      );
-
-    assert.deepEqual(create('fake'), { ok: false, message: 'execution.backend is invalid' });
-    assert.equal(create('ai-sdk').ok, true);
-  });
-
   it('rejects future recurrence anchors outside the scheduling horizon', () => {
     const now = Date.UTC(2026, 0, 5, 8, 0, 0);
     for (const schedule of [

--- a/packages/core/src/scheduled-task.ts
+++ b/packages/core/src/scheduled-task.ts
@@ -11,7 +11,6 @@ import { isOrchestrationMode, type OrchestrationMode } from './orchestration.js'
 import { isThinkingLevel, type ThinkingLevel } from './model-thinking.js';
 import { isPermissionMode, type PermissionMode } from './permission.js';
 import { isBotDeliveryProvider, type BotProvider } from './bot-chat-settings.js';
-import type { PersistedBackendKind } from './session.js';
 
 export const SCHEDULED_TASK_TITLE_MAX_CHARS = 120;
 export const SCHEDULED_TASK_INTENT_MAX_CHARS = 8_000;
@@ -52,7 +51,6 @@ export type ScheduledTaskEffect =
 export interface ScheduledTaskExecutionTemplate {
   readonly cwd: string;
   readonly projectId?: string | null;
-  readonly backend: PersistedBackendKind;
   readonly llmConnectionSlug: string;
   readonly model: string;
   readonly thinkingLevel?: ThinkingLevel;
@@ -488,14 +486,6 @@ function normalizeExecution(
 ): ScheduledTaskNormalizeResult<ScheduledTaskExecutionTemplate> {
   if (!isObject(value)) return fail('agent_run requires execution template');
   if (typeof value.cwd !== 'string' || !value.cwd.trim()) return fail('execution.cwd is required');
-  if (typeof value.backend !== 'string') return fail('execution.backend is required');
-  // Create/update input, not a decoder: stored Automations are read back with
-  // `JSON.parse` in scheduled-task-store.ts and never pass through here. So the
-  // retired `'fake'` is refused (#3211) — accepting it would let a brand new
-  // Automation be written that can only fail later at activation.
-  if (value.backend !== 'ai-sdk') {
-    return fail('execution.backend is invalid');
-  }
   if (typeof value.llmConnectionSlug !== 'string' || !value.llmConnectionSlug.trim()) {
     return fail('execution.llmConnectionSlug is required');
   }
@@ -527,7 +517,6 @@ function normalizeExecution(
     value: {
       cwd: value.cwd.trim(),
       ...(projectId === undefined ? {} : { projectId }),
-      backend: value.backend,
       llmConnectionSlug: value.llmConnectionSlug.trim(),
       model: value.model.trim(),
       ...(value.thinkingLevel === undefined ? {} : { thinkingLevel: value.thinkingLevel }),

--- a/packages/runtime-host/src/__tests__/scheduled-task-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/scheduled-task-protocol.test.ts
@@ -12,7 +12,6 @@ import {
   authorizeRuntimeHostOperation,
   createRuntimeHostConnectionAuthority,
 } from '../server/connection-authority.js';
-import { decodeScheduledTask, decodeScheduledTaskMutateInput } from '../protocol/scheduled-task.js';
 
 describe('ScheduledTask protocol', () => {
   test('requires Host-path authority only when a mutation submits a Host path', () => {
@@ -32,39 +31,6 @@ describe('ScheduledTask protocol', () => {
       for (const frame of [createMutationFrame(projectId), updateMutationFrame(projectId)]) {
         assert.equal(authorizeRuntimeHostOperation(authority, frame), false);
       }
-    }
-  });
-
-  test('a retired backend decodes on the way out but not on the way in', () => {
-    // #3211: the same execution decoder serves both directions, and they carry
-    // different backend invariants. A stored Automation frozen by a build that
-    // shipped FakeBackend must stay readable; a live create/update may not
-    // introduce the retired value.
-    const retired = (effect: ScheduledTaskEffect): ScheduledTaskEffect =>
-      effect.kind === 'agent_run'
-        ? { ...effect, execution: { ...effect.execution, backend: 'fake' } }
-        : effect;
-
-    const stored = { ...scheduledTask('task-1'), effect: retired(agentRunEffect('project-1')) };
-    assert.equal(decodeScheduledTask(stored).effect.kind, 'agent_run');
-
-    for (const input of [
-      {
-        kind: 'create' as const,
-        input: {
-          title: 'Inspect workspace',
-          intentBody: 'Summarize the workspace.',
-          schedule: { kind: 'once' as const, runAt: 1 },
-          effect: retired(agentRunEffect('project-1')),
-        },
-      },
-      {
-        kind: 'update' as const,
-        taskId: 'task-1',
-        patch: { effect: retired(agentRunEffect('project-1')) },
-      },
-    ]) {
-      assert.throws(() => decodeScheduledTaskMutateInput(input), /Invalid ScheduledTask backend/);
     }
   });
 
@@ -104,6 +70,40 @@ describe('ScheduledTask protocol', () => {
       /byte limit/,
     );
   });
+
+  test('tolerates the legacy backend key on agent_run execution templates', () => {
+    // Older builds persisted `ScheduledTaskExecutionTemplate.backend`. The field
+    // is dropped from new writes, but stored records that still carry it must
+    // keep decoding, and the decoded template must not resurrect the field.
+    const template = {
+      cwd: '/workspace',
+      backend: 'fake',
+      llmConnectionSlug: 'openai',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+    };
+    const decoded = decodeScheduledTaskQueryResult({
+      kind: 'task',
+      task: {
+        ...scheduledTask('legacy-backend'),
+        effect: { kind: 'agent_run', execution: template },
+      },
+    });
+    assert.equal(decoded.kind, 'task');
+    assert.ok(decoded.task !== null);
+    if (decoded.task.effect.kind !== 'agent_run') assert.fail('expected agent_run effect');
+    assert.deepEqual(decoded.task.effect.execution, {
+      cwd: '/workspace',
+      llmConnectionSlug: 'openai',
+      model: 'gpt-5',
+      permissionMode: 'ask',
+      collaborationMode: 'agent',
+      orchestrationMode: 'default',
+    });
+    assert.equal('backend' in decoded.task.effect.execution, false);
+  });
 });
 
 function createMutationFrame(projectId: string | null | undefined): RequestFrame {
@@ -140,7 +140,6 @@ function agentRunEffect(projectId: string | null | undefined): ScheduledTaskEffe
     execution: {
       cwd: '/workspace',
       ...(projectId === undefined ? {} : { projectId }),
-      backend: 'ai-sdk',
       llmConnectionSlug: 'openai',
       model: 'gpt-5',
       permissionMode: 'ask',

--- a/packages/runtime-host/src/protocol/scheduled-task.ts
+++ b/packages/runtime-host/src/protocol/scheduled-task.ts
@@ -24,7 +24,6 @@ import {
   type UpdateScheduledTaskInput,
 } from '@maka/core/scheduled-task';
 import { isThinkingLevel } from '@maka/core/model-thinking';
-import type { PersistedBackendKind } from '@maka/core/session';
 import {
   requireCount,
   requireEncodedByteLimit,
@@ -304,7 +303,7 @@ export function decodeScheduledTask(value: unknown): ScheduledTask {
       body: boundedText(intent.body, 'ScheduledTask intent body', SCHEDULED_TASK_INTENT_MAX_CHARS),
     },
     schedule: decodeSchedule(task.schedule),
-    effect: decodeEffect(task.effect, 'stored'),
+    effect: decodeEffect(task.effect),
     status: task.status,
     nextFireAt: nullableCount(task.nextFireAt, 'ScheduledTask nextFireAt'),
     lastFireAt: nullableCount(task.lastFireAt, 'ScheduledTask lastFireAt'),
@@ -341,7 +340,7 @@ function decodeCreateInput(value: unknown): Omit<CreateScheduledTaskInput, 'crea
       SCHEDULED_TASK_INTENT_MAX_CHARS,
     ),
     schedule: decodeSchedule(input.schedule),
-    effect: decodeEffect(input.effect, 'mutation'),
+    effect: decodeEffect(input.effect),
     ...(Object.hasOwn(input, 'maxFires')
       ? { maxFires: nullablePositiveCount(input.maxFires, 'ScheduledTask maxFires') }
       : {}),
@@ -380,7 +379,7 @@ function decodeUpdateInput(value: unknown): UpdateScheduledTaskInput {
         }
       : {}),
     ...(Object.hasOwn(patch, 'schedule') ? { schedule: decodeSchedule(patch.schedule) } : {}),
-    ...(Object.hasOwn(patch, 'effect') ? { effect: decodeEffect(patch.effect, 'mutation') } : {}),
+    ...(Object.hasOwn(patch, 'effect') ? { effect: decodeEffect(patch.effect) } : {}),
     ...(Object.hasOwn(patch, 'maxFires')
       ? { maxFires: nullablePositiveCount(patch.maxFires, 'ScheduledTask maxFires') }
       : {}),
@@ -454,7 +453,7 @@ function decodeSchedule(value: unknown): ScheduledTaskSchedule {
   throw invalidProtocolFrame('Invalid ScheduledTask schedule');
 }
 
-function decodeEffect(value: unknown, origin: BackendOrigin): ScheduledTaskEffect {
+function decodeEffect(value: unknown): ScheduledTaskEffect {
   const effect = requireRecord(value, 'ScheduledTask effect');
   if (effect.kind === 'notify') {
     if (effect.channel === 'local') {
@@ -490,7 +489,7 @@ function decodeEffect(value: unknown, origin: BackendOrigin): ScheduledTaskEffec
       'kind',
       'execution',
     ]);
-    return { kind: 'agent_run', execution: decodeExecution(exact.execution, origin) };
+    return { kind: 'agent_run', execution: decodeExecution(exact.execution) };
   }
   if (effect.kind === 'session_resume') {
     const exact = requireExactRecord(effect, 'ScheduledTask Session resume effect', [
@@ -510,23 +509,20 @@ function decodeEffect(value: unknown, origin: BackendOrigin): ScheduledTaskEffec
   throw invalidProtocolFrame('Invalid ScheduledTask effect');
 }
 
-function decodeExecution(value: unknown, origin: BackendOrigin): ScheduledTaskExecutionTemplate {
+function decodeExecution(value: unknown): ScheduledTaskExecutionTemplate {
   const execution = requireShapedRecord(
     value,
     'ScheduledTask execution template',
     [
       'cwd',
-      'backend',
       'llmConnectionSlug',
       'model',
       'permissionMode',
       'collaborationMode',
       'orchestrationMode',
     ],
-    ['projectId', 'thinkingLevel'],
+    ['projectId', 'thinkingLevel', 'backend'],
   );
-  if (!isBackendFor(origin, execution.backend))
-    throw invalidProtocolFrame('Invalid ScheduledTask backend');
   if (!isPermissionMode(execution.permissionMode)) {
     throw invalidProtocolFrame('Invalid ScheduledTask permission mode');
   }
@@ -551,7 +547,6 @@ function decodeExecution(value: unknown, origin: BackendOrigin): ScheduledTaskEx
     ...(Object.hasOwn(execution, 'projectId')
       ? { projectId: execution.projectId as string | null }
       : {}),
-    backend: execution.backend,
     llmConnectionSlug: boundedText(
       execution.llmConnectionSlug,
       'ScheduledTask connection slug',
@@ -633,18 +628,4 @@ function nullablePositiveCount(value: unknown, label: string): number | null {
   const count = requireCount(value, label);
   if (count === 0) throw invalidProtocolFrame(`Invalid ${label}`);
   return count;
-}
-
-/**
- * Which direction an execution template is crossing the protocol.
- *
- * The same decoder serves both, but they carry different backend invariants:
- * a `'stored'` template is durable data that may have been frozen by a build
- * shipping FakeBackend and must stay decodable, while a `'mutation'` template
- * is a live write and may not introduce the retired value (#3211).
- */
-type BackendOrigin = 'stored' | 'mutation';
-
-function isBackendFor(origin: BackendOrigin, value: unknown): value is PersistedBackendKind {
-  return value === 'ai-sdk' || (origin === 'stored' && value === 'fake');
 }

--- a/packages/runtime-host/src/server/scheduled-task-coordinator.ts
+++ b/packages/runtime-host/src/server/scheduled-task-coordinator.ts
@@ -781,7 +781,6 @@ function executionTemplateFromHeader(header: SessionHeader): ScheduledTaskExecut
   return {
     cwd: header.cwd,
     ...(header.projectId === undefined ? {} : { projectId: header.projectId }),
-    backend: header.backend,
     llmConnectionSlug: header.llmConnectionSlug,
     model: header.model,
     ...(header.thinkingLevel === undefined ? {} : { thinkingLevel: header.thinkingLevel }),


### PR DESCRIPTION
## Summary

Remove the unused `backend` field from scheduled-task execution templates so the protocol and write path stop carrying stale session backend state.

This keeps old stored records readable while preventing new scheduled tasks from persisting a field that nothing consumes.

Fixes #3306

## Verification

- `npm install`
- `npm --workspace @maka/core test`
- `npm --workspace @maka/runtime-host test` (full suite started; the targeted scheduled-task protocol test also passed directly)
- `npm run typecheck --workspace @maka/storage`
- `npm run typecheck --workspace @maka/runtime`
- `npm run typecheck --workspace @maka/runtime-host`
- `npx biome format packages/core/src/scheduled-task.ts packages/runtime-host/src/protocol/scheduled-task.ts packages/runtime-host/src/server/scheduled-task-coordinator.ts packages/runtime-host/src/__tests__/scheduled-task-protocol.test.ts`
- `npx biome lint packages/core/src/scheduled-task.ts packages/runtime-host/src/protocol/scheduled-task.ts packages/runtime-host/src/server/scheduled-task-coordinator.ts packages/runtime-host/src/__tests__/scheduled-task-protocol.test.ts`
- `node --test dist/__tests__/scheduled-task-protocol.test.js` in `packages/runtime-host`

## AI use

- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex contributed to issue discovery, repository analysis, implementation, validation, and PR preparation.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — old stored scheduled-task records remain readable, while new writes stop persisting an unused field