### PR TITLE
fix(desktop): preserve Runtime Host exit diagnostics

### DIFF
--- a/apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-diagnostics.test.ts
@@ -244,6 +244,9 @@ test('copies Desktop diagnostics while Runtime Host is unavailable', async () =>
     },
     environment: () => environment,
     mainLogs: () => ['main remained available'],
+    runtimeHostProcessLogs: () => [
+      '[2026-08-20T00:00:00.000Z] ERROR [runtime-host] local Host child exited: pid=42 code=23 signal=none',
+    ],
     resolveActiveRuntimeHost: () => undefined,
     resolveRuntimeHost: () => ({
       getDiagnostics: async () => {
@@ -265,6 +268,10 @@ test('copies Desktop diagnostics while Runtime Host is unavailable', async () =>
   );
 
   assert.match(clipboard, /Recent main-process logs \(1\)\nmain remained available/);
+  assert.match(
+    clipboard,
+    /Recent local Runtime Host process exits \(1\)[\s\S]*pid=42 code=23 signal=none/,
+  );
   assert.match(clipboard, /Diagnostics unavailable: Runtime Host disconnected/);
 });
 

--- a/apps/desktop/src/main/__tests__/native-diagnostic-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/native-diagnostic-dialog.test.ts
@@ -180,6 +180,7 @@ test('previous main-process evidence remains copyable before a Renderer exists',
         {
           environment: diagnosticEnvironment,
           mainLogs: () => ['current main log'],
+          runtimeHostProcessLogs: () => ['current Runtime Host exit'],
           resolveActiveRuntimeHost: () => {
             throw new Error('Previous-run diagnostics must remain Desktop-only');
           },
@@ -204,5 +205,5 @@ test('previous main-process evidence remains copyable before a Renderer exists',
   assert.match(clipboard, /clean shutdown was not observed/);
   assert.match(clipboard, /Maka: 0\.1\.10/);
   assert.match(clipboard, /Recent previous main-process logs \(1\)/);
-  assert.doesNotMatch(clipboard, /current main log|very-secret-token/);
+  assert.doesNotMatch(clipboard, /current main log|current Runtime Host exit|very-secret-token/);
 });

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-candidate.test.ts
@@ -43,6 +43,7 @@ import { z } from 'zod';
 import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
 import {
   createDesktopRuntimeHostCandidate as createCandidate,
+  formatLocalRuntimeHostProcessExitDiagnostic,
   startDesktopRuntimeHostCandidate,
   type DesktopRuntimeHostCandidateControls,
   type DesktopRuntimeHostCandidateDeps,
@@ -77,6 +78,60 @@ test('uses the manager-owned launch barrier for local candidate startup', async 
 
   assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
   assert.equal(connectedRoot, 'C:\\workspace');
+});
+
+test('formats bounded local Host exit evidence without leaking stderr secrets', () => {
+  const diagnostic = formatLocalRuntimeHostProcessExitDiagnostic(42, {
+    code: 23,
+    signal: null,
+    stderr: 'partial record\nstartup failed: token=fixture-secret',
+    stderrTruncated: true,
+  });
+
+  assert.match(diagnostic, /pid=42 code=23 signal=none/);
+  assert.match(diagnostic, /token=\[redacted\]/);
+  assert.match(diagnostic, /stderr truncated; showing final 4096 bytes/);
+  assert.doesNotMatch(diagnostic, /fixture-secret/);
+});
+
+test('drops a partial secret record retained across the stderr tail boundary', () => {
+  const secret = 'boundary-secret-value';
+  const fullStderr = `apiKey=${secret}\n${'x'.repeat(4_079)}`;
+  const stderrTail = Buffer.from(fullStderr).subarray(-4 * 1024).toString('utf8');
+  assert.match(stderrTail, /secret-value/);
+
+  const diagnostic = formatLocalRuntimeHostProcessExitDiagnostic(42, {
+    code: 1,
+    signal: null,
+    stderr: stderrTail,
+    stderrTruncated: true,
+  });
+
+  assert.doesNotMatch(diagnostic, /secret-value/);
+  assert.match(diagnostic, /stderr truncated; showing final 4096 bytes/);
+});
+
+test('redacts a compact JSON secret embedded in local Host stderr', () => {
+  const diagnostic = formatLocalRuntimeHostProcessExitDiagnostic(42, {
+    code: 1,
+    signal: null,
+    stderr: 'provider failed: {"apiKey":12345}',
+    stderrTruncated: false,
+  });
+
+  assert.match(diagnostic, /"apiKey":"\[redacted\]"/);
+  assert.doesNotMatch(diagnostic, /12345/);
+});
+
+test('does not claim a blank local Host stderr tail was truncated', () => {
+  const diagnostic = formatLocalRuntimeHostProcessExitDiagnostic(42, {
+    code: 1,
+    signal: null,
+    stderr: ' \r\n\t',
+    stderrTruncated: true,
+  });
+
+  assert.doesNotMatch(diagnostic, /stderr:|stderr truncated/);
 });
 
 function createDesktopRuntimeHostCandidate(

--- a/apps/desktop/src/main/main-process-diagnostics.ts
+++ b/apps/desktop/src/main/main-process-diagnostics.ts
@@ -119,6 +119,7 @@ type RuntimeHostDiagnosticsClient = {
 export interface DesktopDiagnosticsDeps {
   readonly environment: () => DesktopDiagnosticEnvironment;
   readonly mainLogs: () => readonly string[];
+  readonly runtimeHostProcessLogs?: () => readonly string[];
   readonly resolveActiveRuntimeHost: () => RuntimeHostDiagnosticsClient | undefined;
   readonly resolveRuntimeHost: (scope: DesktopTargetScope) => RuntimeHostDiagnosticsClient | undefined;
   readonly writeClipboard: (value: string) => void;
@@ -126,6 +127,10 @@ export interface DesktopDiagnosticsDeps {
 
 export const mainProcessLogBuffer = new DiagnosticLogBuffer({
   maxBytes: MAIN_PROCESS_DIAGNOSTIC_LOG_MAX_BYTES,
+});
+export const runtimeHostProcessLogBuffer = new DiagnosticLogBuffer({
+  maxBytes: 16 * 1024,
+  maxEntries: 4,
 });
 
 let logCaptureInstalled = false;
@@ -372,6 +377,8 @@ export async function copyDesktopDiagnosticReport(
       deps.mainLogs(),
       runtimeHost,
       runtimeExecution,
+      undefined,
+      deps.runtimeHostProcessLogs?.() ?? [],
     ),
   );
 }
@@ -383,6 +390,7 @@ export function formatDesktopDiagnosticReport(
   runtimeHost: RuntimeHostDiagnosticRead,
   runtimeExecution: RuntimeHostExecutionDiagnosticRead | undefined = undefined,
   capturedAt = new Date(),
+  runtimeHostProcessLogs: readonly string[] = [],
 ): string {
   const lines = ['Maka Desktop diagnostic report', `Captured at: ${capturedAt.toISOString()}`];
   const rendererContext =
@@ -435,6 +443,11 @@ export function formatDesktopDiagnosticReport(
       '',
       `Recent main-process logs (${mainLogs.length})`,
       ...(mainLogs.length > 0 ? mainLogs : ['<none captured>']),
+      '',
+      `Recent local Runtime Host process exits (${runtimeHostProcessLogs.length})`,
+      ...(runtimeHostProcessLogs.length > 0
+        ? runtimeHostProcessLogs
+        : ['<none captured>']),
     );
   }
 

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -100,6 +100,7 @@ import {
   createDesktopMainRendererDiagnosticInput,
   createDesktopStartupDiagnosticInput,
   mainProcessLogBuffer,
+  runtimeHostProcessLogBuffer,
   type DesktopDiagnosticsDeps,
 } from "./main-process-diagnostics.js";
 import {
@@ -250,6 +251,7 @@ const desktopDiagnostics: DesktopDiagnosticsDeps = {
       workspacePath: workspaceRoot,
     }),
   mainLogs: () => mainProcessLogBuffer.snapshot(),
+  runtimeHostProcessLogs: () => runtimeHostProcessLogBuffer.snapshot(),
   resolveActiveRuntimeHost: () => {
     const scope = activeRuntimeHostRef();
     return scope ? resolveRuntimeHostDiagnostics(scope) : undefined;

--- a/apps/desktop/src/main/runtime-host-desktop-candidate.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-candidate.ts
@@ -20,6 +20,7 @@
 import { randomUUID } from "node:crypto";
 import type { IpcMain } from "electron";
 import type { ActiveInteractionRequestEvent } from '@maka/core/events';
+import { redactSecrets } from '@maka/core/redaction';
 import type { CreateSessionRequestInput } from '@maka/core/runtime-inputs';
 import type { SessionChangedEvent, SessionChangedReason } from '@maka/core/session';
 import type { BotRegistry } from '@maka/runtime/bots';
@@ -33,6 +34,7 @@ import {
   type ConnectOrSpawnRuntimeHostResult,
   type RuntimeHostConnection,
   type RuntimeHostCandidateLaunchBarrier,
+  type RuntimeHostSpawnedProcess,
   type RemoteRuntimeHostProfile,
 } from "@maka/runtime-host/client";
 import {
@@ -76,6 +78,7 @@ import type {
   ReconnectableReadIpcMain,
 } from "./ipc-reconnect-policy.js";
 import type { RuntimeHostTargetIpcMain } from "./runtime-host-reconnecting-ipc-main.js";
+import { runtimeHostProcessLogBuffer } from './main-process-diagnostics.js';
 import {
   desktopSessionResourceKey,
   requireDesktopTargetScope,
@@ -288,6 +291,7 @@ export async function startDesktopRuntimeHostCandidate(
     ? await input.candidateLaunchBarrier.connect(connectInput(input))
     : await connectOrSpawnRuntimeHost(connectInput(input));
   if (connection.kind !== "connected") return connection;
+  observeLocalRuntimeHostProcess(connection.spawnedProcess);
   try {
     return {
       kind: "ready",
@@ -303,6 +307,52 @@ export async function startDesktopRuntimeHostCandidate(
     await connection.connection.close().catch(() => undefined);
     throw error;
   }
+}
+
+function observeLocalRuntimeHostProcess(spawnedProcess: RuntimeHostSpawnedProcess | undefined): void {
+  if (!spawnedProcess) return;
+  void spawnedProcess.exited.then(
+    (exit) =>
+      logLocalRuntimeHostProcessDiagnostic(
+        formatLocalRuntimeHostProcessExitDiagnostic(spawnedProcess.pid, exit),
+      ),
+    () =>
+      logLocalRuntimeHostProcessDiagnostic(
+        `[runtime-host] local Host child exit could not be observed: pid=${spawnedProcess.pid}`,
+      ),
+  );
+}
+
+function logLocalRuntimeHostProcessDiagnostic(diagnostic: string): void {
+  runtimeHostProcessLogBuffer.append('error', diagnostic);
+  console.error(diagnostic);
+}
+
+export function formatLocalRuntimeHostProcessExitDiagnostic(
+  pid: number,
+  exit: Awaited<RuntimeHostSpawnedProcess['exited']>,
+): string {
+  const status = `pid=${pid} code=${exit.code ?? 'null'} signal=${exit.signal ?? 'none'}`;
+  const stderr = redactRuntimeHostStderr(
+    exit.stderrTruncated ? discardLeadingPartialStderrRecord(exit.stderr) : exit.stderr,
+  );
+  if (!stderr) return `[runtime-host] local Host child exited: ${status}`;
+  const truncation = exit.stderrTruncated
+    ? '\n<stderr truncated; showing final 4096 bytes>'
+    : '';
+  return `[runtime-host] local Host child exited: ${status}\nstderr:\n${stderr}${truncation}`;
+}
+
+function discardLeadingPartialStderrRecord(stderr: string): string {
+  const separator = stderr.search(/[\r\n]/u);
+  return separator === -1 ? '' : stderr.slice(separator + 1);
+}
+
+function redactRuntimeHostStderr(stderr: string): string {
+  const redacted = redactSecrets(stderr.trim());
+  // The full stderr blob normally takes text redaction. Rechecking each
+  // compact token also applies structured JSON redaction to embedded payloads.
+  return redacted.replace(/\S+/gu, (token) => redactSecrets(token));
 }
 
 async function startRemoteDesktopRuntimeHostCandidate(

--- a/packages/runtime-host/src/__tests__/fixtures/candidate-stderr-exit.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/candidate-stderr-exit.ts
@@ -17,24 +17,10 @@
  * under the License.
  */
 
-import { launchDetachedRuntimeHostCandidate } from '../../client/launcher.js';
-
-const [rootPath, expectedRootId, stderrMarkerPath] = process.argv.slice(2);
-if (!rootPath || !expectedRootId) {
-  throw new Error('usage: detached-launcher <root> <expected-root-id>');
+if (process.env.MAKA_TEST_STDERR_EXACT_LIMIT === '1') {
+  process.stderr.write('x'.repeat(4 * 1024));
+  process.exitCode = 24;
+} else {
+  process.stderr.write(`${'x'.repeat(5_000)}\ntoken=fixture-secret\n`);
+  process.exitCode = 23;
 }
-const candidateEntrypoint = new URL(
-  stderrMarkerPath ? './stderr-after-launcher-exit.js' : './kernel-candidate.js',
-  import.meta.url,
-);
-
-const attempt = await launchDetachedRuntimeHostCandidate({
-  rootPath,
-  expectedRootId,
-  entrypoint: candidateEntrypoint,
-  idleGraceMs: 10_000,
-  ...(stderrMarkerPath
-    ? { env: { MAKA_TEST_STDERR_AFTER_PARENT_EXIT_MARKER: stderrMarkerPath } }
-    : {}),
-}).spawned;
-process.send?.({ type: 'launched', pid: attempt.pid });

--- a/packages/runtime-host/src/__tests__/fixtures/stderr-after-launcher-exit.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/stderr-after-launcher-exit.ts
@@ -17,24 +17,21 @@
  * under the License.
  */
 
-import { launchDetachedRuntimeHostCandidate } from '../../client/launcher.js';
+import { randomUUID } from 'node:crypto';
+import { rename, writeFile } from 'node:fs/promises';
+import { installRuntimeHostLogCapture } from '../../process-diagnostics.js';
 
-const [rootPath, expectedRootId, stderrMarkerPath] = process.argv.slice(2);
-if (!rootPath || !expectedRootId) {
-  throw new Error('usage: detached-launcher <root> <expected-root-id>');
-}
-const candidateEntrypoint = new URL(
-  stderrMarkerPath ? './stderr-after-launcher-exit.js' : './kernel-candidate.js',
-  import.meta.url,
-);
+const markerPath = process.env.MAKA_TEST_STDERR_AFTER_PARENT_EXIT_MARKER;
+if (!markerPath) throw new Error('stderr survival marker path is required');
 
-const attempt = await launchDetachedRuntimeHostCandidate({
-  rootPath,
-  expectedRootId,
-  entrypoint: candidateEntrypoint,
-  idleGraceMs: 10_000,
-  ...(stderrMarkerPath
-    ? { env: { MAKA_TEST_STDERR_AFTER_PARENT_EXIT_MARKER: stderrMarkerPath } }
-    : {}),
-}).spawned;
-process.send?.({ type: 'launched', pid: attempt.pid });
+installRuntimeHostLogCapture();
+setTimeout(() => {
+  console.error('[runtime-host] stderr after launcher exit');
+  const temporaryMarkerPath = `${markerPath}.${process.pid}.${randomUUID()}.tmp`;
+  void writeFile(temporaryMarkerPath, 'alive')
+    .then(() => rename(temporaryMarkerPath, markerPath))
+    .catch(() => {
+      process.exitCode = 1;
+    });
+}, 500);
+setInterval(() => undefined, 1_000);

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -522,7 +522,16 @@ describe('non-serving Runtime Host kernel', () => {
                 exited:
                   launches === 1
                     ? new Promise((resolve) => {
-                        setTimeout(() => resolve({ code: 2, signal: null }), 25);
+                        setTimeout(
+                          () =>
+                            resolve({
+                              code: 2,
+                              signal: null,
+                              stderr: '',
+                              stderrTruncated: false,
+                            }),
+                          25,
+                        );
                       })
                     : new Promise<never>(() => undefined),
               }),
@@ -648,7 +657,12 @@ describe('non-serving Runtime Host kernel', () => {
               return {
                 spawned: Promise.resolve({
                   pid: process.pid,
-                  exited: Promise.resolve({ code: 2, signal: null }),
+                  exited: Promise.resolve({
+                    code: 2,
+                    signal: null,
+                    stderr: '',
+                    stderrTruncated: false,
+                  }),
                   startupFailure: new Promise((resolve) => {
                     reportBlocker = resolve;
                   }),
@@ -668,7 +682,10 @@ describe('non-serving Runtime Host kernel', () => {
 
       assert.equal(result.kind, 'connected');
       assert.ok(launches >= 2);
-      if (result.kind === 'connected') await result.connection.close();
+      if (result.kind === 'connected') {
+        assert.equal(result.spawnedProcess?.pid, result.registration.pid);
+        await result.connection.close();
+      }
     });
   });
 
@@ -1650,6 +1667,28 @@ describe('non-serving Runtime Host kernel', () => {
       } finally {
         await rm(callerCwd, { recursive: true, force: true });
       }
+    });
+  });
+
+  test('a detached Candidate survives writing stderr after its launcher exits', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const markerPath = join(paths.base, 'stderr-after-launcher-exit');
+      const launcher = paths.resources.trackChild(
+        fork(
+          new URL('./fixtures/detached-launcher.js', import.meta.url),
+          [paths.root, capability.rootId, markerPath],
+          { stdio: ['ignore', 'ignore', 'inherit', 'ipc'] },
+        ),
+      );
+      const launchedPid = paths.resources.trackPid(await waitForLaunch(launcher));
+      await waitForExit(launcher);
+
+      assert.equal(await waitForFileText(markerPath), 'alive');
+      assert.equal(isProcessAlive(launchedPid), true);
+      terminateProcess(launchedPid);
+      await waitForProcessExit(launchedPid);
+      paths.resources.forgetPid(launchedPid);
     });
   });
 
@@ -2732,8 +2771,50 @@ describe('non-serving Runtime Host kernel', () => {
       assert.ok(attempt.exited);
       assert.deepEqual(
         await withTimeout(attempt.exited, 2_000, 'detached Candidate did not exit'),
-        { code: 1, signal: null },
+        { code: 1, signal: null, stderr: '', stderrTruncated: false },
       );
+    });
+  });
+
+  test('detached launcher preserves a bounded stderr tail with process exit evidence', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const attempt = await launchDetachedRuntimeHostCandidate({
+        rootPath: paths.root,
+        expectedRootId: capability.rootId,
+        entrypoint: new URL('./fixtures/candidate-stderr-exit.js', import.meta.url),
+      }).spawned;
+      paths.resources.trackPid(attempt.pid);
+      assert.ok(attempt.exited);
+
+      const exit = await withTimeout(attempt.exited, 2_000, 'Candidate exit was not observed');
+      paths.resources.forgetPid(attempt.pid);
+      assert.equal(exit.code, 23);
+      assert.equal(exit.signal, null);
+      assert.equal(exit.stderrTruncated, true);
+      assert.ok(Buffer.byteLength(exit.stderr, 'utf8') <= 4 * 1024);
+      assert.match(exit.stderr, /token=fixture-secret/);
+    });
+  });
+
+  test('detached launcher does not mark an exact-limit stderr payload as truncated', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const attempt = await launchDetachedRuntimeHostCandidate({
+        rootPath: paths.root,
+        expectedRootId: capability.rootId,
+        entrypoint: new URL('./fixtures/candidate-stderr-exit.js', import.meta.url),
+        env: { MAKA_TEST_STDERR_EXACT_LIMIT: '1' },
+      }).spawned;
+      paths.resources.trackPid(attempt.pid);
+      assert.ok(attempt.exited);
+
+      const exit = await withTimeout(attempt.exited, 2_000, 'Candidate exit was not observed');
+      paths.resources.forgetPid(attempt.pid);
+      assert.equal(exit.code, 24);
+      assert.equal(exit.signal, null);
+      assert.equal(exit.stderrTruncated, false);
+      assert.equal(Buffer.byteLength(exit.stderr, 'utf8'), 4 * 1024);
     });
   });
 
@@ -3248,6 +3329,16 @@ function waitForChildExitResult(
 function waitForExit(child: ChildProcess): Promise<void> {
   if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
   return new Promise((resolve) => child.once('exit', () => resolve()));
+}
+
+async function waitForFileText(path: string, timeoutMs = 5_000): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await readFile(path, 'utf8').catch(() => undefined);
+    if (value !== undefined) return value;
+    await sleep(20);
+  }
+  throw new Error(`File was not written before timeout: ${path}`);
 }
 
 function waitForSuccessfulExit(child: ChildProcess, label: string): Promise<void> {

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -327,7 +327,12 @@ test('owned candidate settlement requires a clean process exit', async () => {
   assert.ok(candidate.exited);
   const exited = candidate.exited;
   assert.equal(await candidate.settle(2_000), false);
-  assert.deepEqual(await exited, { code: 1, signal: null });
+  assert.deepEqual(await exited, {
+    code: 1,
+    signal: null,
+    stderr: '',
+    stderrTruncated: false,
+  });
 });
 
 test('owned candidate can be released to the enclosing environment without termination', async () => {

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -116,6 +116,7 @@ export type ConnectOrSpawnRuntimeHostResult =
       kind: 'connected';
       connection: RuntimeHostConnection;
       registration: Extract<ConnectRuntimeHostResult, { kind: 'connected' }>['registration'];
+      spawnedProcess?: RuntimeHostSpawnedProcess;
     }
   | Extract<ConnectRuntimeHostResult, { kind: 'upgrade_required' }>
   | Extract<ConnectRuntimeHostResult, { kind: 'incompatible' }>
@@ -175,6 +176,11 @@ interface MutableElectionObservations {
 interface ObservedCandidateAttempt {
   readonly attempt: DetachedCandidateAttempt;
   exit?: CandidateProcessExit;
+}
+
+export interface RuntimeHostSpawnedProcess {
+  readonly pid: number;
+  readonly exited: Promise<CandidateProcessExit>;
 }
 
 export async function connectOrSpawnRuntimeHost(
@@ -357,7 +363,12 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
           );
           electionSettled = true;
           await retireCandidateStartupDiagnostic(capability.rootId, startupFailure);
-          return result;
+          const selected = latestCandidate?.attempt;
+          const spawnedProcess =
+            selected?.pid === result.registration.pid && selected.exited
+              ? { pid: selected.pid, exited: selected.exited }
+              : undefined;
+          return spawnedProcess ? { ...result, spawnedProcess } : result;
         } catch {
           observations.readyWaitFailed += 1;
           await result.connection.close().catch(() => undefined);
@@ -410,7 +421,9 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
                 candidate.exit = exit;
                 candidateInFlight = false;
               },
-              () => undefined,
+              () => {
+                candidateInFlight = false;
+              },
             );
           }
           if (attempt.startupFailure) {

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -93,6 +93,7 @@ export {
   type ConnectOrSpawnRuntimeHostInput,
   type ConnectOrSpawnRuntimeHostResult,
   type RuntimeHostElectionDiagnostic,
+  type RuntimeHostSpawnedProcess,
 } from './connect-or-spawn.js';
 export {
   createRuntimeHostCandidateLaunchBarrier,

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { dirname, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -25,6 +25,9 @@ import {
   candidateStartupFailureForExitCode,
   type CandidateStartupFailureReport,
 } from '../candidate-startup-failure.js';
+import { RUNTIME_HOST_STDERR_PIPE_ENV } from '../process-diagnostics.js';
+
+const CANDIDATE_STDERR_MAX_BYTES = 4 * 1024;
 
 export interface DetachedCandidateInput {
   rootPath: string;
@@ -48,6 +51,8 @@ export interface DetachedCandidateAttempt {
 export interface CandidateProcessExit {
   readonly code: number | null;
   readonly signal: NodeJS.Signals | null;
+  readonly stderr: string;
+  readonly stderrTruncated: boolean;
 }
 
 export interface OwnedCandidateAttempt extends DetachedCandidateAttempt {
@@ -66,8 +71,8 @@ export function launchDetachedRuntimeHostCandidate(
 ): DetachedCandidateLaunch {
   const startupAttemptId = randomUUID();
   const child = spawnCandidate(input, true, startupAttemptId);
-  const exited = candidateExit(child);
-  const startupFailure = readStartupFailure(child, exited, startupAttemptId);
+  const exited = observeCandidateExit(child);
+  const startupFailure = readStartupFailure(exited, startupAttemptId);
   const spawned = spawnedPid(child).then(({ pid }) => {
     child.unref();
     return { pid, startupAttemptId, exited, startupFailure };
@@ -80,8 +85,8 @@ export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): 
 } {
   const startupAttemptId = randomUUID();
   const child = spawnCandidate(input, false, startupAttemptId);
-  const exited = candidateExit(child);
-  const startupFailure = readStartupFailure(child, exited, startupAttemptId);
+  const exited = observeCandidateExit(child);
+  const startupFailure = readStartupFailure(exited, startupAttemptId);
   return {
     spawned: spawnedPid(child).then(({ pid }) => ({
       pid,
@@ -106,7 +111,7 @@ function spawnCandidate(
   input: DetachedCandidateInput,
   detached: boolean,
   startupAttemptId: string,
-) {
+): ChildProcess {
   const executable = input.executable ?? process.execPath;
   const args = [
     typeof input.entrypoint === 'string' ? input.entrypoint : fileURLToPath(input.entrypoint),
@@ -126,14 +131,17 @@ function spawnCandidate(
   const child = spawn(executable, args, {
     cwd: dirname(isAbsolute(executable) ? executable : process.execPath),
     detached,
-    stdio: 'ignore',
+    stdio: ['ignore', 'ignore', 'pipe'],
     windowsHide: true,
     env: {
       ...process.env,
       ...(process.versions.electron ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
       ...input.env,
+      [RUNTIME_HOST_STDERR_PIPE_ENV]: '1',
     },
   });
+  const stderr = child.stderr as (NodeJS.ReadableStream & { unref?: () => void }) | null;
+  stderr?.unref?.();
   return child;
 }
 
@@ -158,22 +166,42 @@ function spawnedPid(child: ReturnType<typeof spawn>): Promise<{ pid: number }> {
 }
 
 function readStartupFailure(
-  child: ReturnType<typeof spawn>,
   exited: Promise<CandidateProcessExit>,
   startupAttemptId: string,
 ): Promise<CandidateStartupFailureReport | undefined> {
-  return new Promise((resolve) => {
-    void exited.then(({ code }) => {
-      const failure = candidateStartupFailureForExitCode(code);
-      resolve(failure ? { ...failure, startupAttemptId } : undefined);
-    });
-    child.once('error', () => resolve(undefined));
+  return exited.then(({ code }) => {
+    const failure = candidateStartupFailureForExitCode(code);
+    return failure ? { ...failure, startupAttemptId } : undefined;
   });
 }
 
-function candidateExit(child: ReturnType<typeof spawn>): Promise<CandidateProcessExit> {
+function observeCandidateExit(child: ChildProcess): Promise<CandidateProcessExit> {
+  let stderr: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+  let stderrTruncated = false;
+  child.stderr?.on('data', (value: Buffer | string) => {
+    const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+    if (chunk.length > CANDIDATE_STDERR_MAX_BYTES) {
+      stderr = chunk.subarray(chunk.length - CANDIDATE_STDERR_MAX_BYTES);
+      stderrTruncated = true;
+      return;
+    }
+    const combined = Buffer.concat([stderr, chunk]);
+    if (combined.length > CANDIDATE_STDERR_MAX_BYTES) {
+      stderr = combined.subarray(combined.length - CANDIDATE_STDERR_MAX_BYTES);
+      stderrTruncated = true;
+    } else {
+      stderr = combined;
+    }
+  });
   return new Promise((resolve) => {
-    child.once('exit', (code, signal) => resolve({ code, signal }));
+    child.once('close', (code, signal) => {
+      resolve({
+        code,
+        signal,
+        stderr: stderr.toString('utf8'),
+        stderrTruncated,
+      });
+    });
   });
 }
 

--- a/packages/runtime-host/src/process-diagnostics.ts
+++ b/packages/runtime-host/src/process-diagnostics.ts
@@ -25,6 +25,7 @@ import {
 } from './protocol/host-status.js';
 
 export const RUNTIME_HOST_DIAGNOSTIC_LOG_MAX_BYTES = 64 * 1024;
+export const RUNTIME_HOST_STDERR_PIPE_ENV = 'MAKA_RUNTIME_HOST_STDERR_PIPE';
 
 export const runtimeHostLogBuffer = new DiagnosticLogBuffer({
   maxBytes: RUNTIME_HOST_DIAGNOSTIC_LOG_MAX_BYTES,
@@ -33,9 +34,25 @@ export const runtimeHostLogBuffer = new DiagnosticLogBuffer({
 });
 
 let logCaptureInstalled = false;
+let stderrPipeGuardInstalled = false;
 
 export function installRuntimeHostLogCapture(buffer = runtimeHostLogBuffer): void {
+  installRuntimeHostStderrPipeGuard();
   if (logCaptureInstalled) return;
   logCaptureInstalled = true;
   installConsoleDiagnosticLogCapture(buffer);
+}
+
+function installRuntimeHostStderrPipeGuard(): void {
+  if (stderrPipeGuardInstalled || process.env[RUNTIME_HOST_STDERR_PIPE_ENV] !== '1') {
+    return;
+  }
+  stderrPipeGuardInstalled = true;
+  process.stderr.on('error', (error: NodeJS.ErrnoException) => {
+    // A detached Host intentionally outlives the Client that owns this pipe.
+    // Once that Client exits, later diagnostics must be dropped rather than
+    // turning the expected pipe closure into a fatal Host error.
+    if (error.code === 'EPIPE') return;
+    throw error;
+  });
 }


### PR DESCRIPTION
## Summary

The detached local Runtime Host was launched with ignored stdio, so after its
transport reached EOF Desktop had no process exit code, signal, or Host stderr
to include in the diagnostic report.

This change captures a bounded 4 KiB stderr tail and exit status while
preserving detached-process behavior, associates that evidence only with the
spawned PID selected by the final Host registration, and records a redacted
diagnostic in both the main-process log and a dedicated bounded process-exit
buffer. Copied Desktop diagnostics retain the last four local Host exits even
when repeated transport errors fill the ordinary log buffer and the Host is no
longer available.

Fixes #3333

## Verification

- `npx biome check <13 changed files>`
- `npm run build`
- `npm run typecheck`
- `git diff --check`
- 4 targeted Runtime Host tests passed, covering selected-PID association,
  detached stderr after launcher exit, bounded stderr, and the exact 4096-byte
  boundary
- 36 targeted Desktop tests passed, covering stderr redaction and process-exit
  evidence in copied diagnostics

The full Desktop suite was also run on Windows: 955 tests passed, 17 unrelated
existing environment-dependent tests failed, and 7 were skipped. The failures
were Windows symlink `EPERM`, SQLite cleanup `EBUSY`, and Rive CLI fixture
failures. All tests added or changed by this PR pass.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with root-cause analysis,
implementation, regression tests, local verification, and PR drafting. The
contributor will review the final diff and accepts responsibility for the contribution.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Lint, formatting, typechecks, builds, and targeted affected tests pass. The
full Desktop suite has the unrelated Windows failures listed under Verification.

Does this PR entail a change in behavior?

- [x] Yes - described under Summary above
- [ ] No