### PR TITLE
fix(ui): show one spinner throughout live turns

### DIFF
--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -167,7 +167,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `packages/ui/src/chat-empty-hero.tsx` | shell-chrome-or-panel | Item | aligned — uses Astryx (Item) | aligned |
 | `packages/ui/src/chat-model-switcher.tsx` | shell-chrome-or-panel | Button | aligned — uses Astryx (Button) | aligned |
 | `packages/ui/src/chat-surface-layout.tsx` | shell-chrome-or-panel | ChatLayout | aligned — uses Astryx (ChatLayout) | aligned |
-| `packages/ui/src/chat-turn.tsx` | shell-chrome-or-panel | Badge, Banner, Button, HStack, IconButton, Token, Tooltip | aligned — uses Astryx (Badge, Banner, Button, HStack, IconButton, Token, Tooltip) | aligned |
+| `packages/ui/src/chat-turn.tsx` | shell-chrome-or-panel | Badge, Banner, Button, HStack, IconButton, Spinner, Token, Tooltip | aligned — uses Astryx (Badge, Banner, Button, HStack, IconButton, Spinner, Token, Tooltip) | aligned |
 | `packages/ui/src/chat-view.tsx` | shell-chrome-or-panel | Button, EmptyState, Spinner | aligned — uses Astryx (Button, EmptyState, Spinner) | aligned |
 | `packages/ui/src/components.tsx` | ui-composition | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `packages/ui/src/composer.tsx` | shell-chrome-or-panel | Button, ChatComposer, IconButton, Lightbox, Token, Tooltip | aligned — uses Astryx (Button, ChatComposer, IconButton, Lightbox, Token, Tooltip) | aligned |

--- a/packages/ui/src/__tests__/turn-running-spinner.test.tsx
+++ b/packages/ui/src/__tests__/turn-running-spinner.test.tsx
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { parseHTML } from 'linkedom';
+import { TurnView } from '../chat-turn.js';
+import { LocaleProvider } from '../locale-context.js';
+import type { TurnViewModel } from '../materialize.js';
+
+function statusHasSpinner(toolStatuses: readonly ('running' | 'completed')[]): boolean {
+  const tools = toolStatuses.map((status, index) => ({
+    toolUseId: `tool-${index + 1}`,
+    toolName: 'Bash',
+    status,
+    args: {},
+  } as const));
+  const turn: TurnViewModel = {
+    turnId: 'turn-1',
+    status: 'running',
+    partialOutputRetained: false,
+    tools,
+    notes: [],
+    startedAt: 1,
+    timeline: [{ kind: 'tools', items: tools }],
+  };
+  const markup = renderToStaticMarkup(
+    <LocaleProvider locale="en">
+      <TurnView turn={turn} liveStreaming={{ runningStatus: true }} />
+    </LocaleProvider>,
+  );
+  const { document } = parseHTML(markup);
+  return document.querySelector('.maka-turn-processing .astryx-spinner') !== null;
+}
+
+test('hands the spinner to the turn status after the tool settles', () => {
+  assert.equal(statusHasSpinner(['running']), false);
+  assert.equal(statusHasSpinner(['completed']), true);
+});
+
+test('keeps the turn spinner when a collapsed group hides the running tool', () => {
+  assert.equal(statusHasSpinner(['running', 'completed']), true);
+});

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -17,6 +17,7 @@ import {
   ChatTokenizedText,
   HStack,
   IconButton as UiIconButton,
+  Spinner,
   Thumbnail,
   Timestamp,
   Token,
@@ -41,7 +42,7 @@ import { foldTimeline, type FoldedTimelineChild, type FoldedTimelineEntry } from
 import { AttachmentKindIcon } from './attachment-kinds.js';
 import { QuoteRefChip } from './quote-ref-chip.js';
 import { Marker, markerVariants } from './primitives/chat.js';
-import { ToolTrow } from './tool-activity.js';
+import { ToolTrow, toolTrowHasVisibleSpinner } from './tool-activity.js';
 import { formatBytes } from './tool-activity/preview-utils.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
@@ -400,6 +401,9 @@ export const TurnView = memo(function TurnView(props: {
     () => splitTimelineAtUserMessages(foldedTimeline, showAssistantMessage),
     [foldedTimeline, showAssistantMessage],
   );
+  const toolSurfaceOwnsSpinner = turn.timeline.some(
+    (item) => item.kind === 'tools' && toolTrowHasVisibleSpinner(item.items),
+  );
   return (
     <section
       className="maka-turn"
@@ -620,7 +624,10 @@ export const TurnView = memo(function TurnView(props: {
                     <ModelProviderRetryIndicator retry={props.liveStreaming.providerRetry} />
                   ) : (
                     props.liveStreaming.runningStatus && (
-                      <TurnRunningStatus startedAt={turn.startedAt} />
+                      <TurnRunningStatus
+                        startedAt={turn.startedAt}
+                        showSpinner={!toolSurfaceOwnsSpinner}
+                      />
                     )
                   )}
                 </>
@@ -901,7 +908,7 @@ const ELAPSED_TICK_MS = 1_000;
  * rare fallback path where streaming beat the user turn into the transcript;
  * the phrase then stands alone.
  */
-export function TurnRunningStatus(props: { startedAt?: number }) {
+export function TurnRunningStatus(props: { startedAt?: number; showSpinner?: boolean }) {
   const copy = getConversationCopy(useUiLocale()).messages;
   const phrases = copy.workingPhrases;
   const { startedAt } = props;
@@ -943,22 +950,14 @@ export function TurnRunningStatus(props: { startedAt?: number }) {
   }, [phrases.length]);
 
   return (
-    /* This row runs no animation of its own. Both idioms above it are already
-       spoken for — a running tool card spins, and `ChatReasoning` shimmers its
-       label while reasoning streams — and Astryx's guidance is not to stack a
-       second instance of either in one view. What moves here is the content:
-       the phrase every 20s, the seconds every second. The seconds are the
-       better proof anyway, because a spinner turns and a shimmer sweeps at the
-       same rate whether or not anything is happening. */
     <div className="maka-turn-processing" role="status" aria-label={copy.processing} ref={rootRef}>
+      {props.showSpinner !== false && (
+        <Spinner size="md" shade="subtle" aria-hidden="true" />
+      )}
       {/* Every visible token here moves on the clock. Announcing either would
           talk over the answer being streamed beside it, so the row's label is
           its whole accessible name and the text is decoration. */}
       <span className="maka-turn-indicator-text" aria-hidden="true">
-        {/* No sweep here. Astryx already owns that idiom: `ChatReasoning`
-            shimmers its own label while reasoning streams, a few pixels above
-            this row. Running a second one, at a second speed, made the two
-            read as competing rather than as one turn working. */}
         <span className="maka-turn-working-phrase" data-fading={phraseFading || undefined}>
           {phrases[phraseIndex] ?? copy.processing}
         </span>

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -246,6 +246,15 @@ export function ToolTrow({
   );
 }
 
+/** Whether a visible, collapsed ChatToolCalls row owns the active spinner. */
+export function toolTrowHasVisibleSpinner(items: readonly ToolActivityItem[]): boolean {
+  return items.some((item, index) =>
+    !isLinkedAgentResult(item.result)
+    && isInFlightToolStatus(item.status)
+    && (index === items.length - 1 || isLinkedAgentResult(items[index + 1]?.result)),
+  );
+}
+
 type LinkedAgentRow = {
   key: string;
   name: string;
@@ -362,6 +371,7 @@ function linkedAgentRows(
   locale: UiLocale,
 ): LinkedAgentRow[] | undefined {
   const result = item.result;
+  if (!isLinkedAgentResult(result)) return undefined;
   if (result?.kind === 'subagent') {
     const name = redactSecrets(result.agentName.trim()) || resolveToolDisplayName(item, locale);
     return [{
@@ -377,8 +387,6 @@ function linkedAgentRows(
       childSessionId: result.childSessionId,
     }];
   }
-  if (result?.kind !== 'agent_swarm') return undefined;
-  if (result.items.length === 0) return undefined;
   return result.items.map((child) => {
     const name = redactSecrets((child.agentName || child.itemId).trim()) || child.profile;
     return {
@@ -392,6 +400,13 @@ function linkedAgentRows(
       childSessionId: child.childSessionId,
     } satisfies LinkedAgentRow;
   });
+}
+
+function isLinkedAgentResult(
+  result: ToolActivityItem['result'],
+): result is Extract<ToolResultContent, { kind: 'subagent' | 'agent_swarm' }> {
+  return result?.kind === 'subagent'
+    || (result?.kind === 'agent_swarm' && result.items.length > 0);
 }
 
 type LinkedAgentStatus = Extract<ToolResultContent, { kind: 'subagent' }>['status'];


### PR DESCRIPTION
## Summary

During a live turn, a completed tool row could appear above the working status while no animated indicator showed that output was still in progress.

The expected behavior is one active spinner—not zero or two—throughout a live turn.

| Live-turn phase | Tool row | Turn status | Spinner owner |
|---|---|---|---|
| The model works before or between tool calls | No running tool | Shows the working phrase, elapsed time, and spinner | Turn status |
| A tool call runs | Shows its running state and spinner | Keeps the working phrase and elapsed time | Tool row |
| The tool settles and the model continues | Shows its completed state | Resumes the spinner with the working phrase and elapsed time | Turn status |

When the turn reaches a terminal state, the running status disappears and no spinner remains.

The previous implementation removed the spinner from `TurnRunningStatus` to prevent duplicate animation during tool calls. This also removed the only animated indicator between tool calls.

This change detects in-flight tools with the shared `isInFlightToolStatus` helper. The turn status renders the existing Astryx `Spinner` only when no tool owns the active spinner.

The working copy, elapsed timer, timeline folding, and tool-row behavior remain unchanged. The spinner is decorative for assistive technology, while the status row keeps its accessible name.

| Before | After | 
|---|---|
|<img width="398" height="166" alt="image" src="https://github.com/user-attachments/assets/e758e911-d553-45d5-87fb-31bfa676fda1" />|<img width="422" height="188" alt="image" src="https://github.com/user-attachments/assets/a0084eea-e97f-47fd-8b49-65cafe8f2e33" />|


## Verification

- `npm --workspace @maka/ui test` — 184 tests passed
- The new regression test failed before the production change and passed after it
- `git diff --cached --check` — passed
- Real-window visual verification was not run

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex diagnosed the missing activity state, implemented conditional spinner ownership, added regression coverage, and drafted this pull request.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
