### PR TITLE
fix(desktop): use a supported macOS bundle icon size

### DIFF
--- a/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
@@ -314,7 +314,16 @@ describe('app bundle resolution for the drag', () => {
     });
     assert.equal(icon, null);
     assert.equal(calls, 0, 'unpackaged development must not call app.getFileIcon()');
-    assert.equal(await loadNativeBundleIcon(true, async () => 'icon'), 'icon');
+  });
+
+  it('uses the macOS-supported normal icon size for a packaged app', async () => {
+    let received: unknown;
+    const icon = await loadNativeBundleIcon(true, async (options) => {
+      received = options;
+      return 'icon';
+    });
+    assert.equal(icon, 'icon');
+    assert.deepEqual(received, { size: 'normal' });
   });
 
   it('walks three levels up from the executable to the .app', () => {

--- a/apps/desktop/src/main/permission-overlay/app-bundle.ts
+++ b/apps/desktop/src/main/permission-overlay/app-bundle.ts
@@ -34,6 +34,15 @@ export interface ResolveAppBundleDeps {
   exists(path: string): boolean;
 }
 
+interface NativeBundleIconOptions {
+  size: 'normal';
+}
+
+// Electron's `large` file-icon size is unsupported on macOS and can terminate
+// the packaged process before the promise settles. Both packaged icon reads
+// must use `normal`; callers may resize the decorative image afterwards.
+const NATIVE_BUNDLE_ICON_OPTIONS: NativeBundleIconOptions = { size: 'normal' };
+
 /**
  * Reading a bundle icon is presentation-only. The original unpackaged npm
  * Electron runtime could terminate natively while macOS resolved its bundle
@@ -43,11 +52,11 @@ export interface ResolveAppBundleDeps {
  */
 export async function loadNativeBundleIcon<T>(
   isPackaged: boolean,
-  load: () => Promise<T>,
+  load: (options: NativeBundleIconOptions) => Promise<T>,
 ): Promise<T | null> {
   if (!isPackaged) return null;
   try {
-    return await load();
+    return await load(NATIVE_BUNDLE_ICON_OPTIONS);
   } catch {
     return null;
   }

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
@@ -76,8 +76,8 @@ export function createPermissionOverlayMain(
 
   async function resolveAppIconDataUrl(bundlePath: string | null): Promise<string | null> {
     if (!bundlePath) return null;
-    const icon = await loadNativeBundleIcon(app.isPackaged, () =>
-      app.getFileIcon(bundlePath, { size: 'large' }),
+    const icon = await loadNativeBundleIcon(app.isPackaged, (options) =>
+      app.getFileIcon(bundlePath, options),
     );
     if (!icon || icon.isEmpty()) return null;
     // nativeImage.createFromPath does not decode .icns reliably. Asking
@@ -273,8 +273,8 @@ function attachCardGestures(win: import('electron').BrowserWindow): void {
       if (!fromRenderer.isEmpty()) icon = fromRenderer;
     }
     if (icon.isEmpty()) {
-      const fallback = await loadNativeBundleIcon(app.isPackaged, () =>
-        app.getFileIcon(resolved.bundlePath, { size: 'large' }),
+      const fallback = await loadNativeBundleIcon(app.isPackaged, (options) =>
+        app.getFileIcon(resolved.bundlePath, options),
       );
       if (fallback && !fallback.isEmpty()) icon = fallback.resize({ width: 64, height: 64 });
       // The file drag still works without a decorative drag image.


### PR DESCRIPTION
## Summary

Use Electron's macOS-supported `normal` file-icon size for the packaged permission overlay. Both native bundle-icon reads now share the same option, while unpackaged development continues to skip native icon loading.

Add a regression test covering the unpackaged bypass and the packaged `normal` option.

Fixes #3352
Refs #1919
Refs #1920

## Verification

Passed locally:

- `corepack npm --workspace @maka/desktop test` — 979 passed
- `corepack npm --workspace @maka/desktop run e2e` — 34 passed, 1 skipped
- `corepack npm run lint` — passed
- `corepack npm run format:check` — passed
- `corepack npm run build` — passed
- `corepack npm run typecheck` — passed
- `corepack npm exec -- knip --workspace apps/desktop` — passed
- `corepack npm exec -- knip --workspace packages/ui` — passed
- `corepack npm run astryx:theme -- --check` — passed
- `node scripts/audit-alignment.mjs` — passed
- `node --test --test-concurrency=1 scripts/ci-test-plan.test.mjs` — 21 passed
- `corepack npm run windows:inventory` — passed
- `git diff --check` — passed

`corepack npm test` was also attempted, but was not green on this machine for failures outside this Desktop change:

- Eval's Harbor Python test requires Python 3.10+; this host has Python 3.9.6.
- One Storage child-process test treats Node's SQLite experimental warning on stderr as a failure; that test file passes 5/5 with `NODE_NO_WARNINGS=1`.
- Runtime and MCP passed when rerun separately (Runtime: 2968 passed, 13 skipped; MCP: 115 passed).

Not run:

- Manual smoke test of the fix in a signed/notarized macOS package; release signing/notarization credentials are unavailable.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

OpenAI Codex assisted with crash-log analysis, implementation, the regression test, local verification, and drafting this description. I reviewed the final diff and test results.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No