### PR TITLE
fix(desktop): show the Codex device sign-in code on connection-detail re-login

### DIFF
--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -1101,7 +1101,8 @@ function OAuthReloginNoticeForCurrentGeneration(props: {
   hasSecret: CredentialPresenceStatus;
   onRelogin(): Promise<void>;
 }) {
-  const copy = getProviderSettingsCopy(useUiLocale()).detail;
+  const providerCopy = getProviderSettingsCopy(useUiLocale());
+  const copy = providerCopy.detail;
   const flow = useOAuthLoginFlow({
     bridge: props.service.bridge,
     display: props.service.display,
@@ -1125,11 +1126,18 @@ function OAuthReloginNoticeForCurrentGeneration(props: {
       : errored
         ? copy.oauthUnknownDetail
         : copy.oauthStartDetail;
+  // Codex's device page has no code in its URL — the user must type the
+  // code shown here, so hiding it makes the re-login impossible to finish.
+  const deviceCode = props.service.showsDeviceCode ? flow.stateHint : null;
   return (
     <Banner
       status="info"
       title={title}
-      description={detail}
+      description={deviceCode ? (
+        <>
+          {detail} {providerCopy.oauthSection.deviceCode} <code>{deviceCode}</code>
+        </>
+      ) : detail}
       endContent={!loading ? (
           <Button
             variant="primary"

--- a/apps/desktop/src/renderer/settings/use-connection-detail.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-detail.ts
@@ -72,6 +72,11 @@ import { runtimeHostOAuthLoginBridge } from './runtime-host-settings-bridge.js';
 export interface OAuthLoginService {
   bridge: OAuthLoginFlowBridge;
   display: { name: string; shortName: string };
+  // Codex's device-authorization page requires the user to type the code the
+  // flow surfaces as `stateHint` — the verification URL does not embed it, so
+  // the notice must show it or the login cannot be completed. xAI's page
+  // needs no manual code, mirroring the catalog panel's `!isXai` guard.
+  showsDeviceCode: boolean;
 }
 
 export function oauthLoginServiceFor(
@@ -83,11 +88,13 @@ export function oauthLoginServiceFor(
       return {
         bridge: runtimeHostOAuthLoginBridge(window.maka.openAiCodex, host),
         display: { name: 'OpenAI Codex', shortName: 'Codex' },
+        showsDeviceCode: true,
       };
     case 'xai-oauth':
       return {
         bridge: runtimeHostOAuthLoginBridge(window.maka.xaiOAuth, host),
         display: { name: 'xAI Grok', shortName: 'SuperGrok / X Premium' },
+        showsDeviceCode: false,
       };
     default:
       return null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,8 +1224,8 @@
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha1-O0ICvWuzcKBzD2c0hneFkZvqxq8=",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1237,8 +1237,8 @@
     },
     "node_modules/@dnd-kit/core": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha1-TDZAamLHuqxJlyb4mZNfk/Dm0AM=",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1253,8 +1253,8 @@
     },
     "node_modules/@dnd-kit/sortable": {
       "version": "10.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
-      "integrity": "sha1-H5OCuQ2DXNXGXZKCT6na+3jEw+g=",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1268,8 +1268,8 @@
     },
     "node_modules/@dnd-kit/utilities": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha1-WjK2rzVtxfdNYbN9b3EppAQM7Xs=",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5080,8 +5080,8 @@
     },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
-      "integrity": "sha1-ukd4tp/MkESgYMIXa74HdlfXs34=",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
       "dev": true,
       "license": "MIT"
     },
@@ -5102,8 +5102,8 @@
     },
     "node_modules/@xterm/xterm": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@xterm/xterm/-/xterm-6.0.0.tgz",
-      "integrity": "sha1-k2N7Dy7jpwcYtXRqJ8nFBq8WdFs=",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
       "dev": true,
       "license": "MIT",
       "workspaces": [


### PR DESCRIPTION
## Summary

The connection detail sheet's re-login notice (`OAuthReloginNotice`) drives the same browser-assisted OAuth flow as the provider catalog panel, but never rendered the flow's `stateHint`. For Codex that hint is the 9-character device user code the authorization page requires — the verification URL is the static device page and does not embed the code — so a re-login started from the notice could never be completed: the browser asked for a code the app never showed.

- `OAuthLoginService` gains a `showsDeviceCode` flag: `true` for Codex, `false` for xAI, whose authorization page needs no manual code (mirroring the catalog panel's existing `!isXai` guard). The mapping stays in `use-connection-detail.ts` so the legacy AppShell closure gains no file and no dependency under the renderer architecture ratchet.
- `OAuthReloginNotice` appends the sign-in code to the banner description while authorization is pending, reusing the catalog panel's `deviceCode` copy so both entry points speak the same words.

The second commit re-applies #3381 (normalize locked npm registry sources). That fix was reverted on `main` by #3148's lockfile regeneration six hours after it merged, so `npm ci` under `allow-remote=none` fails again on `main`; it is included here so the branch installs cleanly. Happy to drop it if the maintainers prefer a separate PR.

Fixes #3357

## Verification

- `npm run lint`, `npm run format:check`, `npm run check:asf-headers` — clean
- `npm run typecheck` (desktop) — clean
- `npm run check:architecture -- --base <main>` — passed
- `npm --workspace @maka/desktop test` — 1695 passed, 0 failed
- `npx knip --workspace apps/desktop` — clean
- Manual: launched the dev app, opened the Codex connection detail, clicked re-login — the 9-character sign-in code now appears in the banner while the browser shows the device page.

**Before (en)** — no code while authorization is pending
<img width="900" alt="before-en" src="https://github.com/user-attachments/assets/d2db62a6-10b4-45cc-9661-d8a0624c43d7" />

**After (en)** — `Sign-in code: …` shown in the banner
<img width="900" alt="after-en" src="https://github.com/user-attachments/assets/a716e8e5-7b34-4b50-ac6e-196279fddae1" />

**After (zh)** — `登录码：…` shown in the banner
<img width="900" alt="after-zh" src="https://github.com/user-attachments/assets/95ce2321-ffd7-4352-bc87-6e559c2960d7" />

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Fable 5) performed the diagnosis, implementation, and verification. The human contributor reviewed and manually verified the result and authorized submission. Commits carry a Generated-by trailer.

## Checklist

- [ ] Tests cover the change and fail without it — see Verification
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)

