### PR TITLE
feat(cli): degrade status-line ctx segment to ?/window when usage is unavailable (#3371)

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -118,6 +118,55 @@ describe('Maka Pi TUI transcript', () => {
     assert.doesNotMatch(stripAnsi(renderMakaPiStatusLine({ ...meta(), goal: null }, 120)), /goal/);
   });
 
+  test('status line degrades to ctx ?/window when the window is known but usage is not (#3371)', () => {
+    // No usage object at all: the window is known, so degrade explicitly.
+    assert.match(
+      stripAnsi(renderMakaPiStatusLine({ ...meta(), modelContextWindow: 500_000 }, 120)),
+      /ctx \?\/500k/,
+    );
+
+    // Usage exists but contextRemaining has not been reported yet.
+    assert.match(
+      stripAnsi(
+        renderMakaPiStatusLine(
+          {
+            ...meta(),
+            modelContextWindow: 500_000,
+            usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 },
+          },
+          120,
+        ),
+      ),
+      /ctx \?\/500k/,
+    );
+
+    // Window unknown: the segment stays hidden, even with usage present.
+    assert.doesNotMatch(
+      stripAnsi(
+        renderMakaPiStatusLine(
+          { ...meta(), usage: { costUsd: 0.01, cacheHitInput: 0, cacheMissInput: 0 } },
+          120,
+        ),
+      ),
+      /ctx/,
+    );
+
+    // contextRemaining present: the measured segment is unchanged.
+    assert.match(
+      stripAnsi(
+        renderMakaPiStatusLine(
+          {
+            ...meta(),
+            modelContextWindow: 500_000,
+            usage: { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0, contextRemaining: 480_000 },
+          },
+          120,
+        ),
+      ),
+      /ctx 20k\/500k 4%/,
+    );
+  });
+
   test('keeps assistant text after a tool call visible after the tool block', () => {
     const state = createMakaPiTranscriptState();
     appendUserPrompt(state, 'inspect the package');

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1359,22 +1359,29 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
     );
   }
   const usage = metadata.usage;
+  // ctx segment: only show "used" when contextRemaining is available, since
+  // token_usage.input is a billing-cumulative sum across tool-loop steps,
+  // not the last request's context size. Using it as a proxy for "used"
+  // would produce misleading percentages (potentially >100%).
+  const contextRemaining = usage?.contextRemaining;
+  if (metadata.modelContextWindow !== undefined && contextRemaining !== undefined) {
+    const used = Math.max(0, metadata.modelContextWindow - contextRemaining);
+    const pct = Math.round((used / metadata.modelContextWindow) * 100);
+    // #1064: color warning — yellow >80%, red >95%, dim otherwise.
+    const ctxColor = pct > 95 ? ansi.red : pct > 80 ? ansi.yellow : ansi.dim;
+    parts.push(
+      ctxColor(
+        `ctx ${formatTokenCount(used)}/${formatTokenCount(metadata.modelContextWindow)} ${pct}%`,
+      ),
+    );
+  } else if (metadata.modelContextWindow !== undefined) {
+    // #3371: the window is known but no usage has arrived yet (fresh session,
+    // or the provider doesn't report per-step input tokens). Degrade
+    // explicitly, pi-style, instead of hiding the segment silently — the user
+    // can then tell "not measured yet" apart from "window unknown".
+    parts.push(ansi.dim(`ctx ?/${formatTokenCount(metadata.modelContextWindow)}`));
+  }
   if (usage) {
-    // ctx segment: only show when contextRemaining is available, since
-    // token_usage.input is a billing-cumulative sum across tool-loop steps,
-    // not the last request's context size. Using it as a proxy for "used"
-    // would produce misleading percentages (potentially >100%).
-    if (metadata.modelContextWindow !== undefined && usage.contextRemaining !== undefined) {
-      const used = Math.max(0, metadata.modelContextWindow - usage.contextRemaining);
-      const pct = Math.round((used / metadata.modelContextWindow) * 100);
-      // #1064: color warning — yellow >80%, red >95%, dim otherwise.
-      const ctxColor = pct > 95 ? ansi.red : pct > 80 ? ansi.yellow : ansi.dim;
-      parts.push(
-        ctxColor(
-          `ctx ${formatTokenCount(used)}/${formatTokenCount(metadata.modelContextWindow)} ${pct}%`,
-        ),
-      );
-    }
     if (usage.costUsd > 0) {
       parts.push(ansi.dim(`$${formatCost(usage.costUsd)}`));
     }


### PR DESCRIPTION
## Summary

The TUI status-line ctx segment (#1067) only rendered when **both** the model context window and a `token_usage` `contextRemaining` were present. On connections whose provider does not report per-step input tokens (e.g. `opencode-go`), the status line shows no context indicator at all — the user cannot distinguish "provider doesn't report usage" from "not measured yet" from "window unknown".

In `renderMakaPiStatusLine` (packages/cli/src/pi-transcript.ts), the ctx segment is lifted out of the `if (usage)` block:

- window known + `contextRemaining` available → unchanged: `ctx 20k/500k 4%` with the existing 80%/95% color thresholds
- window known + no usage yet → **new**: dim `ctx ?/500k` fallback, following pi-mono's footer design (`?/200k` when context usage is unknown)
- window unknown → unchanged: no segment

The follow-up from the issue — verifying whether the opencode-go relay reports per-step input tokens — is not in scope here.

Fixes #3371

## Verification

- pi-transcript.test.js 59/59 (new unit test covering all four combinations: no usage / usage without contextRemaining / unknown window stays hidden / measured rendering unchanged)
- pi-tui-runner.test.js 119/119 (including the existing `ctx 20k/500k 4%` integration assertion)
- biome format clean; full dependency chain + cli build (typecheck) pass

## AI use

- [x] Generative tooling made a substantive contribution
- [ ] No generative tool made a substantive contribution

Tool(s) and scope: Maka (AI coding agent) authored the design, implementation, and tests; the diff was human-reviewed before push. `Generated-by: Maka` trailer is present on the commit and retained on this branch.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No