### PR TITLE
fix(cli): align TUI input and transcript flow

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -178,6 +178,33 @@ describe('Maka Pi TUI transcript', () => {
     );
   });
 
+  test('uses a shared message gutter and trims trailing block rows', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'text_delta',
+        messageId: 'message-1',
+        text: 'I will run it.\n\n',
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'tool_start',
+        toolUseId: 'tool-1',
+        toolName: 'Bash',
+        args: { command: 'true' },
+      }),
+    );
+
+    const lines = renderMakaPiTranscript(state, meta(), 40).map(stripAnsi);
+    assert.equal(lines[0], '');
+    assert.equal(lines[2], '');
+    assert.match(lines[1] ?? '', /^ I will run it\.\s+$/);
+    assert.match(lines[3] ?? '', /^ ● Bash  \$ true \(running\)$/);
+  });
+
   test('treats text_complete as the authoritative assistant text', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1,4 +1,4 @@
-import { Markdown } from '@earendil-works/pi-tui';
+import { Markdown, visibleWidth } from '@earendil-works/pi-tui';
 import type {
   ProviderRetryEvent,
   SandboxBoundaryRequestEvent,
@@ -1253,22 +1253,42 @@ function renderTranscriptEntryMemoized(
 }
 
 function renderTranscriptEntryBlock(entry: MakaPiTranscriptEntry, width: number): string[] {
-  switch (entry.kind) {
-    case 'user':
-      return renderUserBlock(entry.text, width);
-    case 'legacy_automation':
-      return renderLegacyAutomationBlock(entry.text, width);
-    case 'goal_continuation':
-      return renderGoalContinuationBlock(entry.text, width);
-    case 'assistant':
-      return renderAssistantBlock(entry.text, width);
-    case 'thinking':
-      return renderThinkingBlock(entry, width, entry.expanded);
-    case 'tool':
-      return renderToolBlock(entry, width, entry.expanded);
-    case 'notice':
-      return renderNotice(entry, width);
-  }
+  // Keep the conversation stream inside a one-cell gutter. The editor owns
+  // the full terminal width, so this makes the two surfaces align without
+  // changing any of the individual block renderers' internal prefixes.
+  const contentWidth = Math.max(1, width - 2);
+  const lines = (() => {
+    switch (entry.kind) {
+      case 'user':
+        return renderUserBlock(entry.text, contentWidth);
+      case 'legacy_automation':
+        return renderLegacyAutomationBlock(entry.text, contentWidth);
+      case 'goal_continuation':
+        return renderGoalContinuationBlock(entry.text, contentWidth);
+      case 'assistant':
+        return renderAssistantBlock(entry.text, contentWidth);
+      case 'thinking':
+        return renderThinkingBlock(entry, contentWidth, entry.expanded);
+      case 'tool':
+        return renderToolBlock(entry, contentWidth, entry.expanded);
+      case 'notice':
+        return renderNotice(entry, contentWidth);
+    }
+  })();
+
+  // Markdown preserves a final blank paragraph. It should not become part of
+  // the block's vertical footprint because renderMakaPiTranscript already
+  // inserts the single separator row between entries.
+  let end = lines.length;
+  while (end > 0 && isBlankTranscriptLine(lines[end - 1]!)) end -= 1;
+  return lines.slice(0, end).map((line) => {
+    if (isBlankTranscriptLine(line)) return '';
+    return fitLine(` ${line}`, width);
+  });
+}
+
+function isBlankTranscriptLine(line: string): boolean {
+  return line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '').trim().length === 0;
 }
 
 function transcriptEntrySignature(entry: MakaPiTranscriptEntry, width: number): string {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -421,7 +421,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // Show the whole slash-command set at once — discoverability is the point of
   // the menu. Keep a little headroom above the current command count.
   const editor = new MakaSkillHighlightEditor(tui, editorTheme(), {
-    paddingX: 1,
+    paddingX: 0,
     autocompleteMaxVisible: EDITOR_AUTOCOMPLETE_MAX_VISIBLE,
   });
   let refreshEditorCwd: ((cwd: string) => void) | undefined;


### PR DESCRIPTION
## Summary

Fixes #3361

Align the TUI input with the terminal edge, add a consistent one-cell gutter around transcript entries, and trim trailing blank rows before applying the transcript separator. This keeps tool stacks evenly spaced after assistant Markdown ends with a blank paragraph.

## Verification

- `node --test packages/cli/dist/__tests__/pi-transcript.test.js`
- `npx biome check packages/cli/src/pi-transcript.ts packages/cli/src/pi-tui-runner.ts packages/cli/src/__tests__/pi-transcript.test.ts`
- `npm --workspace maka-agent test` ran the full CLI suite. The new transcript regression passed; 8 pre-existing Windows-environment failures remain: two SIGTERM expectations and six Runtime Host service cases blocked by `fsync`/symlink permissions.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex (GPT-5) implemented the focused TUI layout and transcript-spacing changes, added the regression test, and ran verification. The commit includes `Generated-by: Codex (GPT-5)`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
## Screenshots

### Before

<img width="490" height="116" alt="image" src="https://github.com/user-attachments/assets/c9c85948-fc88-4e53-8101-c0a774d10b03" />

<img width="906" height="278" alt="image" src="https://github.com/user-attachments/assets/c58b5da7-bf7d-41c4-af2d-1e2c75ed27dc" />

### After

<img width="557" height="109" alt="image" src="https://github.com/user-attachments/assets/19d68e8a-c265-45c7-aefe-9befe0faf601" />

<img width="991" height="297" alt="image" src="https://github.com/user-attachments/assets/b3fa7122-8299-4f68-b3c5-bc7ac343406f" />