### PR TITLE
refactor(cli): move the mid-turn slash disposition onto the command spec

### DIFF
--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -250,7 +250,26 @@ export interface MakaSlashCommandMetadata {
   description: string;
 }
 
+/**
+ * How the TUI treats a slash command submitted while a turn is running:
+ * 'local' answers it immediately, 'refuse' rejects it with a notice, and
+ * 'intercepted' commands are claimed by dedicated checks ahead of generic
+ * slash routing (/exit, /swarm, /graph). Only an unrecognized form — e.g.
+ * /exit with arguments, which isExitPrompt does not match — can still reach
+ * the disposition, where it falls through to 'refuse'.
+ */
+export type SlashCommandMidTurnDisposition = 'local' | 'refuse' | 'intercepted';
+
 export interface MakaSlashCommand extends MakaSlashCommandMetadata {
+  /**
+   * Mid-turn disposition. 'local' requires the handler to be independent of
+   * the running turn — it must not enter runControl, whose busy gate would
+   * silently no-op. 'refuse' is the safe default for anything that mutates
+   * session state or opens a picker the turn would race. Declared on every
+   * handler so a newly added command must state its answer instead of
+   * inheriting one from the routing call site.
+   */
+  midTurn: SlashCommandMidTurnDisposition;
   run(parts: string[], rawTail: string | undefined, context: { idleMs: number }): void;
   /** Alternate names that dispatch to this command without appearing in
    *  completion or the /help menu (e.g. /quit as an alias of /exit). */

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -1084,16 +1084,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         }
         return;
       }
-      // Known slash commands typed mid-turn must not steer into the model as
-      // prompt text (review finding on turnRunning routing). `/goal` and
-      // `/recap` answer locally: both are independent of the running turn —
-      // `/goal` is read-only status, and `/recap` uses the separate
-      // session.recap.generate call behind its own in-flight lock. Every other
-      // known command either mutates session state behind the turn's back or
-      // opens a picker the turn would race (and would silently no-op on the
-      // runControl busy gate even if it ran), so refuse it with a clear
-      // message. Unknown slash-prefixed text still steers: it may be intended
-      // prompt text (a skill invocation such as `/skill:<name>`, or a path).
+      // Known slash commands typed mid-turn follow the disposition declared on
+      // the command itself (`midTurn`, review finding on turnRunning routing):
+      // 'local' commands answer immediately because their handler is
+      // independent of the running turn; every other known command is refused
+      // with a clear message, since it would either mutate session state
+      // behind the turn's back, open a picker the turn would race, or silently
+      // no-op on the runControl busy gate. ('intercepted' commands — /exit,
+      // /swarm, /graph — were claimed by their dedicated checks above and
+      // reaching the refusal here only means an unrecognized form.) Unknown
+      // slash-prefixed text still steers: it may be intended prompt text (a
+      // skill invocation such as `/skill:<name>`, or a path).
       const commandToken = prompt.trim().split(/\s+/, 1)[0] ?? '';
       const knownCommand = slashCommands.find(
         (candidate) =>
@@ -1102,7 +1103,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       );
       if (knownCommand) {
         editor.addToHistory(prompt);
-        if (knownCommand.name === 'goal' || knownCommand.name === 'recap') {
+        if (knownCommand.midTurn === 'local') {
           handleSlashCommand(prompt, 0);
         } else {
           state.entries.push({
@@ -2641,6 +2642,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const slashCommandHandlers = {
     context: {
       description: primaryGuidance.commands.context,
+      // Read-only diagnostics, but runControl-gated: mid-turn it would
+      // silently no-op on the busy gate, so refuse loudly instead.
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2666,6 +2670,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     compact: {
       description: primaryGuidance.commands.compact,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2681,12 +2686,18 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     exit: {
       description: primaryGuidance.commands.exit,
+      // isExitPrompt (which also matches bare "quit"/"exit" without a slash)
+      // closes the TUI ahead of generic slash routing.
+      midTurn: 'intercepted',
       run: () => {
         beginGracefulClose();
       },
     },
     goal: {
       description: primaryGuidance.commands.goal,
+      // Read-only status answers locally; control actions carry their own
+      // busy notice inside the handler, so neither path no-ops silently.
+      midTurn: 'local',
       run: (parts: string[]) => {
         if (parts.length === 1) {
           // Read-only, so no runControl busy gate: an autonomous loop keeps
@@ -2725,18 +2736,21 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     help: {
       description: primaryGuidance.commands.help,
+      midTurn: 'refuse',
       run: () => {
         void runControl(async () => showHelp());
       },
     },
     new: {
       description: primaryGuidance.commands.new,
+      midTurn: 'refuse',
       run: () => {
         void runControl(async () => newSession());
       },
     },
     skill: {
       description: primaryGuidance.commands.skill,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2752,6 +2766,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     setup: {
       description: primaryGuidance.commands.setup,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2767,6 +2782,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     model: {
       description: primaryGuidance.commands.model,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length === 1) {
           showModelList();
@@ -2787,6 +2803,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     move: {
       description: primaryGuidance.commands.move,
+      midTurn: 'refuse',
       run: (parts: string[], rawTail?: string) => {
         const targetCwd = (rawTail ?? parts.slice(1).join(' ')).trim();
         if (targetCwd) {
@@ -2798,6 +2815,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     thinking: {
       description: primaryGuidance.commands.thinking,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length === 1) {
           if (thinkingLevels.length === 0) {
@@ -2836,6 +2854,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     permissions: {
       description: primaryGuidance.commands.permissions,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length === 1) {
           showPermissionModeList();
@@ -2856,12 +2875,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     recap: {
       description: primaryGuidance.commands.recap,
+      // Independent of the running turn: runRecap goes straight to the
+      // separate session.recap.generate call behind its own in-flight lock
+      // and never enters runControl.
+      midTurn: 'local',
       run: () => {
         void runRecap('manual');
       },
     },
     rename: {
       description: primaryGuidance.commands.rename,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         const name = parts.slice(1).join(' ').trim();
         if (!name) {
@@ -2887,6 +2911,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     resume: {
       description: primaryGuidance.commands.resume,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({
@@ -2902,12 +2927,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     rewind: {
       description: primaryGuidance.commands.rewind,
+      midTurn: 'refuse',
       run: () => {
         void runControl(showRewindPicker);
       },
     },
     session: {
       description: primaryGuidance.commands.session,
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length === 1) {
           void runControl(showSessionList);
@@ -2928,6 +2955,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     graph: {
       description: primaryGuidance.commands.graph,
+      // parseGraphCommand answers status and refuses changes ahead of generic
+      // slash routing.
+      midTurn: 'intercepted',
       run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
         const parsed = parseGraphCommand(`/graph${rawTail ? ` ${rawTail}` : ''}`);
         if (parsed) runGraphCommand(parsed, context.idleMs);
@@ -2935,6 +2965,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     swarm: {
       description: primaryGuidance.commands.swarm,
+      // parseSwarmCommand answers status and refuses changes ahead of generic
+      // slash routing.
+      midTurn: 'intercepted',
       run: (_parts: string[], rawTail: string | undefined, context: { idleMs: number }) => {
         const parsed = parseSwarmCommand(`/swarm${rawTail ? ` ${rawTail}` : ''}`);
         if (parsed) runSwarmCommand(parsed, context.idleMs);


### PR DESCRIPTION
## Summary

Follow-up to #3310, per the review seam observation: the routing call site in `editor.onSubmit` matched command names (`'goal' || 'recap'`) to decide which slash commands answer locally while a turn is running. That knowledge now lives on `MakaSlashCommand` as a required `midTurn` field declared next to each handler:

- `'local'` (`/goal`, `/recap`) — answers immediately; the handler must be independent of the running turn and never enter `runControl`, whose busy gate would silently no-op.
- `'refuse'` (everything else that reaches generic routing) — rejected with the notice introduced in #3310. Safe default for anything that mutates session state or opens a picker the turn would race.
- `'intercepted'` (`/exit`, `/swarm`, `/graph`) — documents that dedicated checks claim these ahead of generic routing; the disposition is never consulted for them.

Because `slashCommandHandlers` is a `satisfies Record<TuiSlashCommandId, …>` and the field is required, a newly added command must state its mid-turn answer — omitting it is a compile error, instead of silently inheriting the call site's default.

Behavior is unchanged; the mid-turn routing tests from #3310 pin it.

Refs #3308

## Verification

- `npm --workspace maka-agent test`: 337 pass / 0 fail, including the four `slash commands during a running turn` tests from #3310 unchanged.
- Compile-time enforcement verified: removing one handler's `midTurn` fails with `TS2741: Property 'midTurn' is missing … but required in type 'Omit<MakaSlashCommand, "aliases" | "name">'`; restored and `tsc` is clean again.
- `npm run lint`, `npm run format:check`, `npm run typecheck`: pass.
- Not run: desktop e2e (no desktop change).

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka (AI agent) implemented the refactor and ran the verification; the commit carries the `Generated-by: Maka` trailer. Human contributor of record reviewed the disposition assignment per command and decided to submit.

## Checklist

- [x] Tests cover the change and fail without it — behavior is pinned by the #3310 mid-turn routing tests; the type-level guarantee was verified by removing a declaration and observing the compile error
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No