### PR TITLE
chore(deps): normalize locked npm registry sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1167,8 +1167,8 @@
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha1-O0ICvWuzcKBzD2c0hneFkZvqxq8=",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -1179,8 +1179,8 @@
     },
     "node_modules/@dnd-kit/core": {
       "version": "6.3.1",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha1-TDZAamLHuqxJlyb4mZNfk/Dm0AM=",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
@@ -1194,8 +1194,8 @@
     },
     "node_modules/@dnd-kit/sortable": {
       "version": "10.0.0",
-      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
-      "integrity": "sha1-H5OCuQ2DXNXGXZKCT6na+3jEw+g=",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
@@ -1208,8 +1208,8 @@
     },
     "node_modules/@dnd-kit/utilities": {
       "version": "3.2.2",
-      "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha1-WjK2rzVtxfdNYbN9b3EppAQM7Xs=",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -4895,8 +4895,8 @@
     },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
-      "integrity": "sha1-ukd4tp/MkESgYMIXa74HdlfXs34=",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-unicode11": {
@@ -4916,8 +4916,8 @@
     },
     "node_modules/@xterm/xterm": {
       "version": "6.0.0",
-      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@xterm/xterm/-/xterm-6.0.0.tgz",
-      "integrity": "sha1-k2N7Dy7jpwcYtXRqJ8nFBq8WdFs=",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
       "license": "MIT",
       "workspaces": [
         "addons/*"


### PR DESCRIPTION
## Summary

Replace six stale Microsoft 1ES proxy resolutions with their canonical npm registry tarballs. Package names and versions remain unchanged; integrity metadata is refreshed to npm-published SHA-512 digests.

Fixes #3356

## Verification

- `npx --yes npm@11.19.0 ci --ignore-scripts`
- `npm query ':type(remote)' --json`
- Confirmed every HTTP(S) package resolution in `package-lock.json` uses `registry.npmjs.org`
- `git diff --check`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted the dependency-source analysis and prepared the mechanical lockfile update. The human contributor will review the change and remains responsible for it.

## Checklist

- [ ] Tests cover the change and fail without it — not applicable to a resolution-metadata-only change
- [x] Lint, format, typecheck and the affected suites pass locally — clean installation and lockfile checks pass; source checks are unaffected

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
