### PR TITLE
docs: identify the project as Apache Maka (Incubating) in both READMEs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,6 +35,7 @@ github:
     - typescript
     - cli
     - apache
+    - incubator
     - maka
   features:
     issues: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Maka
+# Apache Maka (Incubating)
 
 [![CI](https://github.com/apache/maka/actions/workflows/ci.yml/badge.svg)](https://github.com/apache/maka/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
@@ -9,6 +9,9 @@
 **A local-first Agent workspace built for real work.**
 
 Maka does more than answer questions. With controlled permissions, it can inspect projects, execute tools, produce artifacts, and preserve model messages and tool calls as recoverable execution facts. Desktop, the terminal TUI, the non-interactive CLI, and Maka evaluation subjects all execute through Runtime Host.
+
+> [!NOTE]
+> Apache Maka (Incubating) is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision-making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF. [DISCLAIMER-WIP](./DISCLAIMER-WIP) records the issues the project is currently aware of.
 
 > [!IMPORTANT]
 > Maka is under active development. The macOS Apple Silicon desktop build is an early public release; data formats, CLI commands, and experimental capabilities may still change.
@@ -54,6 +57,12 @@ Read [Maka Backend Architecture](./ARCHITECTURE.md) for the complete design.
 - Maka subjects execute only through Runtime Host; external competitors use generic external subject adapters.
 
 ## Quick start
+
+### Releases and downloads
+
+Apache Maka has not made an Apache release yet. Everything currently published from this repository or from a package registry was produced before or during incubation, is not an Apache Software Foundation release, and has not been reviewed or voted on by the Incubator PMC.
+
+Once Apache releases exist, the official release is the source release published by the ASF and approved by the podling PPMC and the Incubator PMC. A package built from that source and distributed elsewhere, for example through a package registry or as a Desktop installer, is a convenience artifact rather than the release itself, and it is valid only when it is built from an approved source release. [`.github/ASF_SOURCE_RELEASE.md`](./.github/ASF_SOURCE_RELEASE.md) holds the candidate contract, signing path, and verification steps.
 
 ### Download Desktop for macOS
 
@@ -288,3 +297,5 @@ Before submitting code, run typecheck, build, and focused tests proportionate to
 Maka is licensed under the [Apache License 2.0](./LICENSE). See
 [NOTICE](./NOTICE) for attribution information. Third-party components remain
 subject to their respective licenses and notices.
+
+Apache Maka, Maka, Apache, the Apache feather, and the Apache Maka project logo are either registered trademarks or trademarks of The Apache Software Foundation.

--- a/README.md
+++ b/README.md
@@ -64,24 +64,7 @@ Apache Maka has not made an Apache release yet. Everything currently published f
 
 Once Apache releases exist, the official release is the source release published by the ASF and approved by the podling PPMC and the Incubator PMC. A package built from that source and distributed elsewhere, for example through a package registry or as a Desktop installer, is a convenience artifact rather than the release itself, and it is valid only when it is built from an approved source release. [`.github/ASF_SOURCE_RELEASE.md`](./.github/ASF_SOURCE_RELEASE.md) holds the candidate contract, signing path, and verification steps.
 
-### Download Desktop for macOS
-
-The signed and notarized Desktop app is available from [GitHub Releases](https://github.com/apache/maka/releases/latest) for Apple Silicon Macs only (`arm64`).
-
-1. Download `Maka-<version>-mac-arm64.dmg`;
-2. Open the DMG and drag Maka to Applications;
-3. Install `ripgrep` with `brew install ripgrep` to enable Runtime's `Grep` tool;
-4. Launch Maka and configure your own model connection under `Settings → Models`.
-
-Computer Use is not included in this first public build. Intel Macs, Windows, and Linux packages are not supported yet.
-
-### Windows x64 preview
-
-Windows is still an unsigned preview, not a supported release tier. When a release includes Windows
-assets, follow the [Windows preview installation and verification guide](docs/windows-support.md#install-the-windows-x64-preview)
-before running `Maka-<version>-win-x64.exe`. SmartScreen will identify the installer as coming from
-an unknown publisher; do not bypass that warning unless the downloaded SHA-256 matches the checksum
-published with the same release.
+Until an approved source release exists, this README recommends no prebuilt download. Build and run Maka from source as described below. Desktop currently targets Apple Silicon Macs (`arm64`); Intel Macs, Windows, and Linux are not supported yet, and [Windows support](docs/windows-support.md) remains an unsigned preview rather than a supported release tier.
 
 ### Requirements
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-# Maka
+# Apache Maka (Incubating)
 
 [![CI](https://github.com/apache/maka/actions/workflows/ci.yml/badge.svg)](https://github.com/apache/maka/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
@@ -9,6 +9,9 @@
 **一个为真实工作而生的本地优先 Agent 工作台。**
 
 Maka 不只回答问题。它可以在受控权限下阅读项目、执行工具、生成产物，并把模型消息和工具调用保存为可恢复的运行事实。桌面应用、终端 TUI、非交互 CLI 和 Maka 评测 subject 都通过 Runtime Host 执行。
+
+> [!NOTE]
+> Apache Maka (Incubating) 是一个正在 Apache 软件基金会（ASF）孵化的项目，由 Apache Incubator PMC 提供 sponsor。所有新接受的项目都必须经过孵化，直到进一步审查表明其基础设施、沟通方式和决策流程已经稳定到与其他成功的 ASF 项目一致的程度。孵化状态并不必然反映代码的完成度或稳定性，但它确实表明该项目尚未得到 ASF 的完全认可。项目当前已知的问题记录在 [DISCLAIMER-WIP](./DISCLAIMER-WIP)（以英文原文为准）。
 
 > [!IMPORTANT]
 > Maka 仍在活跃开发中。macOS Apple Silicon 桌面版是首个早期公开版本，数据格式、CLI 和实验能力仍可能变化。
@@ -54,6 +57,12 @@ Maka 不只回答问题。它可以在受控权限下阅读项目、执行工具
 - Maka subject 只通过 Runtime Host 执行，外部竞品使用 generic external subject adapter。
 
 ## 快速开始
+
+### Release 与下载
+
+Apache Maka 目前还没有发布过 Apache release。当前从本仓库或包管理器分发的一切内容，都是在进入孵化器之前或孵化期间产生的，不是 Apache 软件基金会的 release，也没有经过 Incubator PMC 审查和投票。
+
+在 Apache release 出现之后，官方 release 指的是由 ASF 发布、并经 podling PPMC 和 Incubator PMC 批准的源码 release。由该源码构建并通过其他渠道分发的包，例如包管理器中的包或 Desktop 安装程序，属于 convenience artifact，本身不是 release，并且只有在由获批源码 release 构建时才有效。候选契约、签名路径和验包步骤见 [`.github/ASF_SOURCE_RELEASE.md`](./.github/ASF_SOURCE_RELEASE.md)。
 
 ### 下载 macOS 桌面版
 
@@ -281,3 +290,5 @@ npm --workspace @maka/desktop run smoke:real-window
 
 Maka 使用 [Apache License 2.0](./LICENSE) 开源，归属信息见
 [NOTICE](./NOTICE)。第三方组件仍分别适用其自身的许可证与声明。
+
+Apache Maka、Maka、Apache、Apache 羽毛标志和 Apache Maka 项目标志是 Apache 软件基金会的注册商标或商标。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,23 +64,7 @@ Apache Maka 目前还没有发布过 Apache release。当前从本仓库或包�
 
 在 Apache release 出现之后，官方 release 指的是由 ASF 发布、并经 podling PPMC 和 Incubator PMC 批准的源码 release。由该源码构建并通过其他渠道分发的包，例如包管理器中的包或 Desktop 安装程序，属于 convenience artifact，本身不是 release，并且只有在由获批源码 release 构建时才有效。候选契约、签名路径和验包步骤见 [`.github/ASF_SOURCE_RELEASE.md`](./.github/ASF_SOURCE_RELEASE.md)。
 
-### 下载 macOS 桌面版
-
-已签名并完成 Apple 公证的桌面应用可从 [GitHub Releases](https://github.com/apache/maka/releases/latest) 下载，目前仅支持 Apple Silicon Mac（`arm64`）。
-
-1. 下载 `Maka-<version>-mac-arm64.dmg`；
-2. 打开 DMG，将 Maka 拖入“应用程序”；
-3. 执行 `brew install ripgrep`，启用 Runtime 的 `Grep` 工具；
-4. 启动 Maka，在`设置 → 模型`中配置自己的模型连接。
-
-首个公开版本不包含 Computer Use，暂不支持 Intel Mac、Windows 和 Linux 安装包。
-
-### Windows x64 预览版
-
-Windows 目前仍是未签名预览版，不属于正式支持的平台。当某个 release 包含 Windows 资产时，
-请先阅读 [Windows 预览版安装与校验指南](docs/windows-support.md#安装-windows-x64-预览版)，再运行
-`Maka-<version>-win-x64.exe`。SmartScreen 会将安装包显示为未知发布者；只有从同一 release 下载
-并确认 SHA-256 与发布的校验文件一致后，才应选择绕过该提示。
+在获批源码 release 出现之前，本 README 不推荐任何预构建下载，请按下文从源码构建并运行 Maka。Desktop 目前面向 Apple Silicon Mac（`arm64`），暂不支持 Intel Mac、Windows 和 Linux，[Windows 支持](docs/windows-support.md)仍属于未签名预览，不是正式支持的平台。
 
 ### 环境要求
 


### PR DESCRIPTION
## Summary

The root READMEs opened as "Maka", with no incubation status and no link from the repository front page to `DISCLAIMER-WIP`. This applies Incubator branding to the two surfaces whose wording does not depend on the undecided first-release scope.

Refs #3272

- Both README titles become `Apache Maka (Incubating)`, and each file carries the standard ASF incubation disclaimer text near the top with a link to [`DISCLAIMER-WIP`](../blob/main/DISCLAIMER-WIP).
- A new "Releases and downloads" section sits ahead of the existing download instructions. It states that no Apache release exists yet, that what is published today is not an ASF release and has not been through an Incubator PMC vote, and that once Apache releases exist the ASF-published source release is *the* release while packages built from it and distributed elsewhere are convenience artifacts. It links [`.github/ASF_SOURCE_RELEASE.md`](../blob/main/.github/ASF_SOURCE_RELEASE.md) from #3269 / #3278 for the candidate contract and verification path.
- The license section of each README gains the ASF trademark attribution, using the wording [Apache OpenDAL carries in its site footer](https://github.com/apache/opendal/blob/main/website/docusaurus.config.js).
- `.asf.yaml` gains the `incubator` topic, extending the metadata #3262 established. The description there already carries the incubating name; the topic list carried `apache` but not `incubator`.

### Scope: why this is not `Fixes #3272`

Four of the seven exit criteria in #3272 depend on decisions that are not mine to make, so this PR deliberately stops short of them.

| #3272 exit criterion | This PR |
|---|---|
| Root English and Chinese READMEs first identify Apache Maka and its incubating status and link the disclaimer | Satisfied |
| Repository description and metadata use Apache Incubator branding | Satisfied — description landed in #3262, topic added here |
| `maka.apache.org` serves the reviewed project website rather than 404 | Not attempted — needs Infra configuration and PPMC review of website content; see "Follow-up" below |
| The website provides an ASF-compliant source download path and points to `KEYS` and verification instructions | Not attempted — depends on the website existing |
| npm package README/version page displays the full disclaimer and links the approved source release | Not attempted — depends on whether npm is in first-release scope (#2974, #3275) |
| GitHub release surfaces distinguish ASF releases from historical or non-ASF product releases | Not attempted — overlaps the pending mentor decision in #3274 |
| The release announcement and download page use the approved project name | Not attempted — no release candidate exists yet |

The README wording states the source-versus-convenience-artifact distinction in general terms and does **not** assert that npm or Desktop artifacts are part of the first release. That remains a PPMC and mentor decision under #2974.

## Prior art

Wording and structure follow Apache OpenDAL. The trademark line is OpenDAL's site-footer sentence with the project name substituted. The source-versus-convenience-artifact framing matches [OpenDAL's download page](https://github.com/apache/opendal/blob/main/website/src/pages/download.mdx), which states that official releases are provided as source artifacts and keeps verification against `KEYS`, GPG, and SHA-512 next to the download links.

The Chinese README marks `DISCLAIMER-WIP` as authoritative in English rather than translating the disclaimer as a substitute for it.

## Verification

- `npm run format` — clean, no fixes applied.
- `.asf.yaml` round-tripped through the `strictyaml` check from #3262 (`dirty_load` → `as_yaml()` → `dirty_load`): prints `184 184 OK`, so the folded description scalar is unpolluted, and the parsed label list contains the new `incubator` topic.
- Verified against `gh api repos/apache/maka` that the live description already carries the incubating name and that `incubator` is genuinely absent from the current topics.
- Checked that no script or test asserts README content: the matches under `scripts/` are release-packaging code and `asf-source-release.test.mjs` fixtures that write their own `README.md`.
- Not run: typecheck, build, and the workspace suites. This PR touches two Markdown files and `.asf.yaml`; none of those suites cover them.
- `.asf.yaml` label reconciliation itself can only be verified after merge, when asfyaml processes the change.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code drafted the README changes, the `.asf.yaml` topic, this description, and ran the verification above. The human contributor reviews the final diff and owns the decision to submit it. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint and format pass locally; typecheck and the test suites do not cover Markdown or `.asf.yaml` and were not run

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
