### PR TITLE
test(runtime): make node-pty lifecycle regression deterministic

### DIFF
--- a/packages/runtime/src/__tests__/node-pty-write-lifecycle.test.ts
+++ b/packages/runtime/src/__tests__/node-pty-write-lifecycle.test.ts
@@ -3,32 +3,27 @@ import { spawnSync } from 'node:child_process';
 import { test } from 'node:test';
 
 const CHILD_SOURCE = String.raw`
-  import { spawn as spawnPty } from 'node-pty';
-  import { execFileSync } from 'node:child_process';
+  import { createRequire } from 'node:module';
   import {
     closeSync,
     constants,
     fstatSync,
     mkdtempSync,
-    open,
     openSync,
     rmSync,
-    stat,
   } from 'node:fs';
   import { tmpdir } from 'node:os';
   import { join } from 'node:path';
-  import { promisify } from 'node:util';
 
-  const delay = promisify(setTimeout);
+  const require = createRequire(import.meta.url);
+  const fs = require('node:fs');
+  const { spawn: spawnPty } = await import('node-pty');
   const root = mkdtempSync(join(tmpdir(), 'maka-node-pty-write-lifecycle-'));
-  const fifo = join(root, 'worker-blocker');
   const sentinelPath = join(root, 'sentinel');
-  let readerFd;
-  let sentinelFd;
+  const sentinelFds = [];
   let terminal;
 
   try {
-    execFileSync('mkfifo', [fifo]);
     terminal = spawnPty(
       process.execPath,
       ['-e', 'process.stdin.pause(); setInterval(() => {}, 1000)'],
@@ -36,64 +31,63 @@ const CHILD_SOURCE = String.raw`
     );
     const terminalFd = terminal.fd;
 
-    const reader = new Promise((resolve, reject) => {
-      open(fifo, constants.O_RDONLY, (error, fd) => {
-        if (error) reject(error);
-        else {
-          readerFd = fd;
-          resolve();
-        }
-      });
-    });
-    let probeCompleted = false;
-    const blockedPoolProbe = new Promise((resolve, reject) => {
-      stat(root, (error) => {
-        if (error) reject(error);
-        else {
-          probeCompleted = true;
-          resolve();
-        }
-      });
-    });
-    await delay(50);
-    if (probeCompleted) throw new Error('FIFO did not occupy the libuv worker');
+    // Hold the unpatched writer at its raw-fd submission boundary. Replaying that
+    // request only after fd reuse models the dangerous libuv schedule without
+    // coupling PTY teardown to starvation of the process-wide worker pool.
+    const originalWrite = fs.write;
+    let deferredRawWrite;
+    fs.write = (...args) => {
+      if (deferredRawWrite !== undefined) {
+        throw new Error('Expected at most one raw PTY write before the lifecycle fence');
+      }
+      deferredRawWrite = args;
+    };
+    try {
+      terminal.write('R'.repeat(4 * 1024 * 1024));
+    } finally {
+      fs.write = originalWrite;
+    }
 
-    terminal.write('R'.repeat(4 * 1024 * 1024));
     setTimeout(() => terminal.kill('SIGKILL'), 5);
     await new Promise((resolve) => terminal.onExit(resolve));
 
-    sentinelFd = openSync(
-      sentinelPath,
-      constants.O_RDWR | constants.O_CREAT | constants.O_TRUNC,
-      0o600,
-    );
-    if (sentinelFd !== terminalFd) {
-      throw new Error(
-        'Expected retired PTY fd ' + terminalFd + ' to be reused, received ' + sentinelFd,
+    // Retain any lower-numbered descriptors until the retired PTY fd is reused.
+    let sentinelFd;
+    for (let attempt = 0; attempt < 64; attempt += 1) {
+      const fd = openSync(
+        sentinelPath,
+        constants.O_RDWR |
+          constants.O_CREAT |
+          (sentinelFds.length === 0 ? constants.O_TRUNC : 0),
+        0o600,
       );
+      sentinelFds.push(fd);
+      if (fd === terminalFd) {
+        sentinelFd = fd;
+        break;
+      }
+      if (fd > terminalFd) break;
+    }
+    if (sentinelFd === undefined) {
+      throw new Error('Could not reuse retired PTY fd ' + terminalFd);
     }
 
-    const writerFd = openSync(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
-    closeSync(writerFd);
-    const writeCompletionBarrier = new Promise((resolve, reject) => {
-      stat(root, (error) => (error ? reject(error) : resolve()));
-    });
-    await Promise.all([reader, blockedPoolProbe, writeCompletionBarrier]);
-    closeSync(readerFd);
-    readerFd = undefined;
+    if (deferredRawWrite !== undefined) {
+      const [fd, buffer, offset] = deferredRawWrite;
+      await new Promise((resolve, reject) => {
+        originalWrite(fd, buffer, offset, (error) => (error ? reject(error) : resolve()));
+      });
+    }
 
     if (fstatSync(sentinelFd).size !== 0) {
       throw new Error('Queued PTY input reached the reused sentinel fd');
     }
-    closeSync(sentinelFd);
-    sentinelFd = undefined;
     console.log('sentinel-ok');
   } finally {
     try {
       terminal?.kill('SIGKILL');
     } catch {}
-    if (readerFd !== undefined) closeSync(readerFd);
-    if (sentinelFd !== undefined) closeSync(sentinelFd);
+    for (const fd of sentinelFds) closeSync(fd);
     rmSync(root, { recursive: true, force: true });
   }
 `;
@@ -104,7 +98,6 @@ test('does not carry queued Unix PTY writes past native exit', {
   const result = spawnSync(process.execPath, ['--input-type=module', '--eval', CHILD_SOURCE], {
     cwd: process.cwd(),
     encoding: 'utf8',
-    env: { ...process.env, UV_THREADPOOL_SIZE: '1' },
     timeout: 10_000,
   });
 


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- replace the FIFO / single-worker scheduling harness with an explicit raw-fd write boundary
- remove a cleanup gap that turned any intermediate child failure into an opaque outer timeout
- retain the exact regression proof by replaying an unpatched pending write only after the PTY fd has been reused

## Root cause

The confirmed root cause of the opaque 10-second `ETIMEDOUT` is the old harness's cleanup model. It set `UV_THREADPOOL_SIZE=1`, occupied that sole worker with a blocking FIFO read, and released the request only on the success path after PTY exit and exact fd reuse. If any earlier phase or assertion failed, `finally` had no writer or cancellation path for the pending FIFO open. That live request kept the child process alive, so the parent reported its `spawnSync` timeout instead of the original error.

The available macOS evidence does not identify which phase failed first; it is therefore not sufficient to attribute the initial failure specifically to PTY teardown or a Node/libuv change. The replacement removes both the process-wide worker starvation and the failure-masking cleanup path, so any remaining lifecycle failure will surface directly.

The new test controls the dangerous schedule explicitly: it captures the unpatched `fs.write` request when node-pty submits it, allows the PTY to exit normally, reuses the exact retired descriptor, and then replays the captured write. The patched synchronous writer leaves no pending raw-fd request and the sentinel remains empty; the unpatched writer deterministically corrupts it.

The regression remains worth keeping because it protects a high-impact dependency patch against arbitrary-file corruption. The scheduling machinery around it was the disposable part.

Fixes #3395

## Verification

- `npm run build:test`
- `npm --workspace @maka/runtime run test:dist` — 3,006 tests, 0 failures
- targeted regression passes on Node 22.19.0, 24.18.0, and 26.3.1
- temporarily reversed dependency patch: the test fails in ~0.1s with `Queued PTY input reached the reused sentinel fd`; restored patch: the test passes
- patched Node 26 targeted regression: 100 consecutive passes
- `npx biome check packages/runtime/src/__tests__/node-pty-write-lifecycle.test.ts`
- `git diff --check`

macOS arm64 was not available in this workspace. The OS-sensitive worker-pool dependency has been removed rather than retimed; one run on the original Apple M4 / Node 24.18 environment remains useful target-platform confirmation.

AI disclosure: Codex prepared this change with direction from M4n5ter; M4n5ter is the contributor of record and will review the result.

</details>

<details>
<summary>简体中文</summary>

## 概要

- 用显式的 raw-fd write 控制边界替换 FIFO / 单 worker 调度 harness
- 删除会把任何子进程中间失败变成不透明外层 timeout 的 cleanup 缺口
- 仅在 PTY fd 被精确复用后重放未打补丁实现的 pending write，保留原回归的完整证明

## 根因

目前能够确认的 10 秒 `ETIMEDOUT` 根因是旧 harness 的 cleanup 模型。它把 `UV_THREADPOOL_SIZE` 设为 `1`，再用阻塞的 FIFO read 占住这个唯一 worker，并且只在 PTY 退出、fd 精确复用之后的成功路径释放该请求。如果此前任何阶段或断言失败，`finally` 没有 writer 或 cancellation path 可以结束 pending FIFO open。这个存活请求会阻止子进程退出，导致父进程只报告 `spawnSync` timeout，而不是最初的错误。

现有 macOS 证据不足以判断最先失败的是哪个阶段，因此不能把初始失败确定归因于 PTY teardown 或某项 Node/libuv 变更。新的测试同时删除进程级 worker starvation 和掩盖失败的 cleanup path；如果仍有生命周期错误，它会被直接报告。

新测试直接控制危险调度：在 node-pty 提交未打补丁的 `fs.write` 请求时将其捕获，让 PTY 正常退出，精确复用已退役的描述符，然后重放该请求。应用补丁的同步 writer 不会留下 pending raw-fd request，sentinel 保持为空；未打补丁的 writer 则会确定性地污染 sentinel。

这项回归仍值得保留，因为它保护的是会导致任意文件损坏的高影响依赖补丁。可以删除的是围绕它构造的调度机制，而不是这条行为证据。

Fixes #3395

## 验证

- `npm run build:test`
- `npm --workspace @maka/runtime run test:dist` — 3,006 tests，0 failures
- 定向回归在 Node 22.19.0、24.18.0 和 26.3.1 上通过
- 临时撤销 dependency patch：测试会在约 0.1 秒内以 `Queued PTY input reached the reused sentinel fd` 失败；恢复补丁后通过
- patched Node 26 定向回归连续运行 100 次全部通过
- `npx biome check packages/runtime/src/__tests__/node-pty-write-lifecycle.test.ts`
- `git diff --check`

当前工作区没有 macOS arm64 环境。本次修改删除了 OS-sensitive 的 worker-pool 依赖，而不是调整 timeout；仍建议在最初报告问题的 Apple M4 / Node 24.18 环境运行一次，补齐目标平台确认。

AI disclosure：Codex 在 M4n5ter 的指导下准备了本次修改；M4n5ter 是记录中的贡献者，并会审阅最终结果。

</details>
