### PR TITLE
fix(desktop): fence stale transcript range failures

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -460,6 +460,86 @@ test('restores transcript consumers across Host replacement', async () => {
   await observations.close();
 });
 
+test('fences transcript range failures to the current registration and Host source', async () => {
+  const observations = new RuntimeHostSessionObservationRegistry();
+  const target: RuntimeHostTranscriptTarget = {
+    id: 19,
+    send() {},
+    once() {},
+    off() {},
+  };
+  const pendingFailure = () => {
+    let reject!: (error: Error) => void;
+    const promise = new Promise<void>((_resolve, rejectPromise) => {
+      reject = rejectPromise;
+    });
+    return { promise, reject };
+  };
+  const source = (
+    generation: string,
+    loadTranscriptBefore: () => Promise<void>,
+  ) => ({
+    async observe() {},
+    async unobserve() {},
+    async openTranscript(sessionId: string) {
+      return {
+        sessionId,
+        generation,
+        hostEpoch: `host-${generation}`,
+        readThroughMessageId: null,
+      };
+    },
+    loadTranscriptBefore,
+    async loadTranscriptAround() {},
+    async closeTranscript() {},
+  });
+  const request = (consumerId: string, generation: string) => ({
+    consumerId,
+    generation,
+    anchorSequence: null,
+    maxBytes: DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
+  });
+
+  const closedFailure = pendingFailure();
+  const first = source('first', () => closedFailure.promise);
+  await observations.attach(first);
+  await observations.openTranscript('session-1', 'consumer-closed', target);
+  const closedRange = observations.loadTranscriptBefore(
+    request('consumer-closed', 'first'),
+    target.id,
+  );
+  await observations.closeTranscript('consumer-closed', target.id);
+  closedFailure.reject(new Error('closed source rejected its range'));
+  await assert.doesNotReject(closedRange);
+  observations.detach(first);
+
+  const replacedFailure = pendingFailure();
+  const second = source('second', () => replacedFailure.promise);
+  await observations.attach(second);
+  await observations.openTranscript('session-1', 'consumer-replaced', target);
+  const replacedRange = observations.loadTranscriptBefore(
+    request('consumer-replaced', 'second'),
+    target.id,
+  );
+  observations.detach(second);
+
+  const currentFailure = new Error('current source failed its range');
+  const third = source('third', async () => {
+    throw currentFailure;
+  });
+  await observations.attach(third);
+  replacedFailure.reject(new Error('replaced source rejected its range'));
+  await assert.doesNotReject(replacedRange);
+  await assert.rejects(
+    observations.loadTranscriptBefore(
+      request('consumer-replaced', 'third'),
+      target.id,
+    ),
+    (error) => error === currentFailure,
+  );
+  await observations.close();
+});
+
 test('cancels a transcript consumer while its replica is still preparing', async () => {
   const transcript = deferred<StoredMessage[]>();
   const events = new AsyncFrameQueue();

--- a/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-session-observer.test.ts
@@ -6,6 +6,7 @@ import type { StoredMessage } from '@maka/core/session';
 import {
   SESSION_CONTINUITY_SCHEMA_VERSION,
   type SessionContinuitySnapshot,
+  type SessionTranscriptPage,
   type SubscriptionFrame,
 } from "@maka/runtime-host/protocol";
 import { RuntimeHostSubscriptionError } from "@maka/runtime-host/client";
@@ -468,13 +469,6 @@ test('fences transcript range failures to the current registration and Host sour
     once() {},
     off() {},
   };
-  const pendingFailure = () => {
-    let reject!: (error: Error) => void;
-    const promise = new Promise<void>((_resolve, rejectPromise) => {
-      reject = rejectPromise;
-    });
-    return { promise, reject };
-  };
   const source = (
     generation: string,
     loadTranscriptBefore: () => Promise<void>,
@@ -500,7 +494,7 @@ test('fences transcript range failures to the current registration and Host sour
     maxBytes: DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
   });
 
-  const closedFailure = pendingFailure();
+  const closedFailure = deferred<void>();
   const first = source('first', () => closedFailure.promise);
   await observations.attach(first);
   await observations.openTranscript('session-1', 'consumer-closed', target);
@@ -513,7 +507,7 @@ test('fences transcript range failures to the current registration and Host sour
   await assert.doesNotReject(closedRange);
   observations.detach(first);
 
-  const replacedFailure = pendingFailure();
+  const replacedFailure = deferred<void>();
   const second = source('second', () => replacedFailure.promise);
   await observations.attach(second);
   await observations.openTranscript('session-1', 'consumer-replaced', target);
@@ -538,6 +532,117 @@ test('fences transcript range failures to the current registration and Host sour
     (error) => error === currentFailure,
   );
   await observations.close();
+});
+
+test('fences transcript range failures across same-source replica recovery', async () => {
+  const firstEvents = new AsyncFrameQueue();
+  const secondEvents = new AsyncFrameQueue();
+  const staleRange = deferred<SessionTranscriptPage>();
+  const currentFailure = new Error('current replica failed its range');
+  const message: StoredMessage = {
+    type: 'assistant',
+    id: 'assistant-1',
+    turnId: 'turn-1',
+    ts: 1,
+    text: 'current',
+    modelId: 'test-model',
+  };
+  let opens = 0;
+  let staleRangeStarted = false;
+  const observer = new RuntimeHostSessionObserver({
+    client: {
+      openSession: async () => {
+        opens += 1;
+        const first = opens === 1;
+        const events = first ? firstEvents : secondEvents;
+        const bootstrap: SessionTranscriptPage = {
+          kind: 'page',
+          sessionId: 'session-1',
+          source: 'durable',
+          direction: 'older',
+          throughSequence: 1,
+          rawBytes: 1,
+          fragments: [],
+          nextCursor: 'older',
+        };
+        return runtimeHostSessionFixture({
+          snapshot: continuitySnapshot(),
+          transcript: Promise.resolve([]),
+          events,
+          transcriptBootstrap: {
+            throughSequence: 1,
+            overlayMessageCount: 0,
+            durable: bootstrap,
+            overlay: { ...bootstrap, source: 'overlay', nextCursor: null },
+          },
+          decodeTranscriptPage: async (page) => ({
+            messages: page === bootstrap ? [{ identity: 1, message }] : [],
+            nextCursor: page === bootstrap ? 'older' : null,
+          }),
+          loadTranscriptPage: first
+            ? () => {
+                staleRangeStarted = true;
+                return staleRange.promise;
+              }
+            : async () => {
+                throw currentFailure;
+              },
+          async close() {
+            events.end();
+          },
+        });
+      },
+    },
+    emitSessionsChanged() {},
+  });
+  const observations = new RuntimeHostSessionObservationRegistry();
+  const batches: DesktopTranscriptBatch[] = [];
+  const consumerId = 'consumer-replica-recovery';
+  const request = (generation: string) => ({
+    consumerId,
+    generation,
+    anchorSequence: 1,
+    maxBytes: DESKTOP_TRANSCRIPT_FRAGMENT_MAX_BYTES,
+  });
+  const target: RuntimeHostTranscriptTarget = {
+    id: 20,
+    send(_channel, batch) {
+      batches.push(batch);
+      queueMicrotask(() =>
+        observations.acknowledgeTranscript(
+          consumerId,
+          batch.generation,
+          batch.deliverySequence,
+          20,
+        ),
+      );
+    },
+    once() {},
+    off() {},
+  };
+  await observations.attach(observer);
+  const opened = await observations.openTranscript('session-1', consumerId, target);
+  const staleLoad = observations.loadTranscriptBefore(request(opened.generation), target.id);
+  await waitFor(() => staleRangeStarted);
+
+  firstEvents.push({
+    kind: 'subscription.closed',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-session-1',
+    sequence: 1,
+    reason: 'slow_consumer',
+  });
+  await waitFor(() => batches.at(-1)?.generation !== opened.generation);
+  staleRange.reject(new Error('stale replica rejected its range'));
+  await assert.doesNotReject(staleLoad);
+
+  const generation = batches.at(-1)!.generation;
+  await assert.rejects(
+    observations.loadTranscriptBefore(request(generation), target.id),
+    (error) => error === currentFailure,
+  );
+  await observations.close();
+  await observer.close();
 });
 
 test('cancels a transcript consumer while its replica is still preparing', async () => {
@@ -2476,12 +2581,15 @@ class AsyncFrameQueue implements AsyncIterable<SubscriptionFrame> {
 function deferred<T>(): {
   promise: Promise<T>;
   resolve(value: T): void;
+  reject(error: Error): void;
 } {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((settle) => {
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((settle, rejectPromise) => {
     resolve = settle;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/apps/desktop/src/main/runtime-host-session-observation-registry.ts
+++ b/apps/desktop/src/main/runtime-host-session-observation-registry.ts
@@ -300,17 +300,21 @@ export class RuntimeHostSessionObservationRegistry {
     return registration.ready.promise;
   }
 
-  loadTranscriptBefore(request: DesktopTranscriptRangeRequest, targetId?: number): Promise<void> {
-    return requireTranscriptSource(this.#transcriptSource(request.consumerId)).loadTranscriptBefore(
-      request,
-      targetId,
+  async loadTranscriptBefore(
+    request: DesktopTranscriptRangeRequest,
+    targetId?: number,
+  ): Promise<void> {
+    await this.#runTranscriptOperation(request.consumerId, (source) =>
+      source.loadTranscriptBefore(request, targetId),
     );
   }
 
-  loadTranscriptAround(request: DesktopTranscriptRangeRequest, targetId?: number): Promise<void> {
-    return requireTranscriptSource(this.#transcriptSource(request.consumerId)).loadTranscriptAround(
-      request,
-      targetId,
+  async loadTranscriptAround(
+    request: DesktopTranscriptRangeRequest,
+    targetId?: number,
+  ): Promise<void> {
+    await this.#runTranscriptOperation(request.consumerId, (source) =>
+      source.loadTranscriptAround(request, targetId),
     );
   }
 
@@ -395,12 +399,28 @@ export class RuntimeHostSessionObservationRegistry {
     );
   }
 
-  #transcriptSource(consumerId: string): SessionObservationSource {
-    if (!this.#transcripts.has(consumerId)) {
+  async #runTranscriptOperation(
+    consumerId: string,
+    operation: (source: SessionObservationSource & TranscriptSource) => Promise<void>,
+  ): Promise<void> {
+    const registration = this.#transcripts.get(consumerId);
+    if (!registration) {
       throw new Error('Desktop transcript consumer does not exist');
     }
-    if (!this.#source) throw new Error('Runtime Host transcript source is unavailable');
-    return this.#source;
+    const source = requireTranscriptSource(this.#source);
+    try {
+      await operation(source);
+    } catch (error) {
+      // Once either owner changes, this rejection belongs to stale work and
+      // must not escape as a failure of the current renderer intent.
+      if (
+        this.#source !== source ||
+        this.#transcripts.get(consumerId) !== registration
+      ) {
+        return;
+      }
+      throw error;
+    }
   }
 
   #deleteTranscript(consumerId: string, registration: TranscriptRegistration): void {

--- a/apps/desktop/src/main/runtime-host-session-observer.ts
+++ b/apps/desktop/src/main/runtime-host-session-observer.ts
@@ -310,26 +310,48 @@ export class RuntimeHostSessionObserver {
     request: DesktopTranscriptRangeRequest,
     targetId?: number,
   ): Promise<void> {
-    const { state, replica, consumer } = this.#requireTranscriptConsumer(request, targetId);
-    await replica.loadBefore(request.anchorSequence, requireTranscriptRangeBytes(request.maxBytes));
-    await consumer.deliveryTask;
-    this.#touchReplica(state);
+    await this.#runTranscriptRangeOperation(request, targetId, (replica) =>
+      replica.loadBefore(
+        request.anchorSequence,
+        requireTranscriptRangeBytes(request.maxBytes),
+      ),
+    );
   }
 
   async loadTranscriptAround(
     request: DesktopTranscriptRangeRequest,
     targetId?: number,
   ): Promise<void> {
+    await this.#runTranscriptRangeOperation(request, targetId, (replica) => {
+      if (request.anchorSequence === null) {
+        throw new Error('Desktop transcript around request requires an anchor');
+      }
+      return replica.loadAround(
+        request.anchorSequence,
+        requireTranscriptRangeBytes(request.maxBytes),
+      );
+    });
+  }
+
+  async #runTranscriptRangeOperation(
+    request: DesktopTranscriptRangeRequest,
+    targetId: number | undefined,
+    operation: (replica: DesktopTranscriptReplica) => Promise<void>,
+  ): Promise<void> {
     const { state, replica, consumer } = this.#requireTranscriptConsumer(request, targetId);
-    if (request.anchorSequence === null) {
-      throw new Error('Desktop transcript around request requires an anchor');
+    const isCurrent = () =>
+      state.replica === replica &&
+      state.transcriptConsumers.get(request.consumerId) === consumer &&
+      consumer.generation === request.generation;
+    const task = operation(replica);
+    try {
+      await task;
+      await consumer.deliveryTask;
+    } catch (error) {
+      if (!isCurrent()) return;
+      throw error;
     }
-    await replica.loadAround(
-      request.anchorSequence,
-      requireTranscriptRangeBytes(request.maxBytes),
-    );
-    await consumer.deliveryTask;
-    this.#touchReplica(state);
+    if (isCurrent()) this.#touchReplica(state);
   }
 
   async closeTranscript(consumerId: string, targetId?: number): Promise<void> {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2823,6 +2823,12 @@ function AppShellContent({
         await controller.loadLatest();
       }
     } catch (error) {
+      if (
+        activeIdRef.current !== sessionId ||
+        transcriptRangeRef.current !== controller
+      ) {
+        return;
+      }
       toastApi.error(
         desktopConversationCopy.actions.messageReadFailedTitle,
         localizedShellErrorMessage(


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Fence Desktop transcript range reads to the exact renderer registration and Runtime Host source generation that started them. Closing a session or replacing its Host now cancels stale range failures at the registry boundary, while failures from the current registration and source still propagate normally. Same-source subscription recovery is fenced independently by the exact consumer, replica, and generation owned by the observer.

Also prevent an obsolete transcript controller from presenting a history-load error after the user has moved to another session or returned through an A → B → A navigation.

This keeps teardown immediate and preserves delivery ACK/backpressure semantics; it does not add consumer reuse, request replay, string-matched cancellation, or a second lifecycle state machine.

Fixes #3394

## Verification

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 1,019 tests passed
- Added deterministic lifecycle regressions covering consumer close, Runtime Host source replacement, same-source replica recovery, and real failures from the current owner.
- Not run: Windows Electron real-window smoke. There is no visual change; the reported race is covered at the owning lifecycle boundary.

## Root cause

`RuntimeHostSessionObservationRegistry` already fenced transcript open/restore work by registration and source identity, but `loadTranscriptBefore` and `loadTranscriptAround` returned the physical observer promises directly. A close or Host replacement could therefore reject an operation that no longer belonged to the current logical consumer, leaking it through Electron IPC and the renderer toast path. Same-source subscription recovery can also replace the observer replica without changing the outer Registry identities, so the Observer now fences range completion by consumer, replica, and generation.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex investigated the lifecycle race, developed the registration/source fencing design, implemented the change and regression coverage, and prepared this draft PR. The human contributor remains responsible for review and submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — stale transcript operations are cancelled instead of surfacing as current-session failures
- [ ] No

</details>

<details>
<summary>中文</summary>

## 概述

将 Desktop transcript range read 绑定到发起它的精确 renderer registration 和 Runtime Host source generation。会话关闭或 Host replacement 后，Registry 会在生命周期边界取消旧 range operation 的失败；当前 registration 和 source 的真实错误仍然正常传播。同一 source 内部发生 subscription recovery 时，Observer 也会用精确 consumer、replica 和 generation 独立 fence 旧操作。

同时，过期 transcript controller 在用户切换会话或经历 A → B → A 后，不再有权提交历史读取错误。

该方案保持 teardown 立即执行，也保留 delivery ACK/backpressure 语义；不增加 consumer 复用、请求重放、错误字符串匹配或第二套生命周期状态机。

对应并关闭 #3394。

## 验证

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 1,019 项测试通过
- 新增确定性生命周期回归测试，覆盖 consumer close、Runtime Host source replacement、同一 source 内的 replica recovery，以及当前 owner 的真实失败。
- 未运行 Windows Electron real-window smoke。本次没有视觉变更；报告中的竞态已在拥有该生命周期的边界完成覆盖。

## 根因

`RuntimeHostSessionObservationRegistry` 已经用 registration/source identity fence 保护 transcript open 和 restore，但 `loadTranscriptBefore`、`loadTranscriptAround` 直接返回物理 observer Promise。因此 close 或 Host replacement 可以拒绝一个已经不属于当前逻辑 consumer 的 operation，最终通过 Electron IPC 和 renderer toast 泄漏为当前错误。同一 source 内部的 subscription recovery 也可以在不改变 Registry 外层 identity 的情况下替换 observer replica，因此 Observer 现在按 consumer、replica 和 generation fence range completion。

## AI 使用

- [ ] 没有生成式工具作出实质贡献
- [x] 生成式工具作出了实质贡献

工具和范围：Codex 排查生命周期竞态、设计 registration/source fencing、实施修改与回归覆盖，并准备本 draft PR。最终审查与提交责任仍由人类贡献者承担。

## Checklist

- [x] 测试覆盖本次变更，并会在修复前失败
- [x] 本地 lint、format、typecheck 和受影响测试套件均已通过

本 PR 是否改变行为？

- [x] 是——过期 transcript operation 会被取消，不再作为当前会话错误呈现
- [ ] 否

</details>


