### PR TITLE
feat(runtime): add Markdown response guidance

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -1623,6 +1623,7 @@ test('production Host executes a durable runnable child with an exact tool ceili
     // agent-permission tools cannot be the thing that decides whether the child
     // can read back a result the runtime itself pruned.
     assert.deepEqual(toolNames(requests[2]?.body), ['ArchiveRead', 'Glob', 'Grep', 'Read']);
+    assert.doesNotMatch(JSON.stringify(requests[2]?.body), /## Response format/u);
     assert.ok(toolNames(requests[3]?.body).includes('agent_spawn'));
 
     const sessions = await execution.sessionStore.listForRecovery();
@@ -2573,6 +2574,18 @@ test('one turn shares one canonical Skill inventory across prompt and lazy tools
   assert.match(nextPrompt ?? '', /NEW_DESCRIPTION/);
   assert.doesNotMatch(nextPrompt ?? '', /OLD_DESCRIPTION/);
   assert.equal(inventoryReads, 2);
+
+  for (const prompt of [firstPrompt, nextPrompt]) {
+    assert.match(prompt ?? '', /^## Response format$/mu);
+    assert.equal(prompt?.match(/Use GitHub-Flavored Markdown for responses\./gmu)?.length, 1);
+    assert.match(
+      prompt ?? '',
+      /Keep simple answers simple; do not add headings or lists to simple answers\./u,
+    );
+    assert.match(prompt ?? '', /Use short headings and flat lists to organize longer answers\./u);
+    assert.match(prompt ?? '', /inline commands/u);
+    assert.match(prompt ?? '', /descriptive link text/u);
+  }
 });
 
 test('one composer freezes Runtime Policy while each Run freezes its remaining prompt sources', async () => {

--- a/packages/runtime/src/system-prompt/main-session-prompt.ts
+++ b/packages/runtime/src/system-prompt/main-session-prompt.ts
@@ -6,17 +6,18 @@
  * product identity. This closes that gap while leaving sub-agent identities to
  * the agent catalog.
  *
- * The assembler is deliberately order-agnostic: it only prepends the identity,
- * drops empty fragments, and joins. It does NOT impose a fixed fragment order,
- * because several fragments are position-semantic and must stay where the host
- * put them — e.g. the Side Chat isolation boundary and the Deep Research mode
- * contract are trailing assertions that constrain everything before them, so
- * moving them earlier weakens them. Each host keeps its existing fragment order.
+ * The assembler is deliberately order-agnostic: it only prepends the shared
+ * defaults, drops empty fragments, and joins. It does NOT impose a fixed
+ * fragment order, because several fragments are position-semantic and must stay
+ * where the host put them — e.g. the Side Chat isolation boundary and the Deep
+ * Research mode contract are trailing assertions that constrain everything
+ * before them, so moving them earlier weakens them. Each host keeps its existing
+ * fragment order.
  *
- * The identity line is pure static text: constant across turns, so it never
- * churns the systemPromptHash / prefix-cache (see request-shape.ts). It is
- * intentionally NOT injected into sub-agent (childInstruction) paths, which
- * already carry their own role identities.
+ * The identity and response-format guidance are pure static text: constant
+ * across turns, so they never churn the systemPromptHash / prefix-cache (see
+ * request-shape.ts). They are intentionally NOT injected into sub-agent
+ * (childInstruction) paths, which already carry their own role identities.
  */
 
 /** Product identity line, prepended by the main-session assembler. */
@@ -24,32 +25,21 @@ function buildIdentityPromptFragment(): string {
   return "You are Maka, an AI agent operating on the user's machine. You help by reading files, running commands, editing code, and answering questions.";
 }
 
-export interface AssembleMainSessionSystemPromptOptions {
-  /**
-   * Lead with the product identity. Default true (main session). Set false for
-   * paths that already carry their own identity, e.g. the desktop
-   * child-instruction path reuses this assembly but must NOT inject the
-   * main-session identity (#2352).
-   */
-  identity?: boolean;
+function buildResponseFormatPromptFragment(): string {
+  return `## Response format
+
+Use GitHub-Flavored Markdown for responses.
+Keep simple answers simple; do not add headings or lists to simple answers.
+Use short headings and flat lists to organize longer answers.
+Use fenced code blocks for multiline code and backticks for inline commands, paths, identifiers, and literal values.
+Prefer descriptive link text for external sources when it is available.
+Follow a more specific format requested by the user or task.`;
 }
 
-/**
- * Prepend the product identity (unless `identity: false`) to a host-supplied
- * fragment list, drop empty/blank fragments, and join with a blank-line
- * separator. The fragment order is the host's responsibility.
- *
- * Pure policy: identity text + filtering. Sub-agent (childInstruction)
- * assembly reuses this helper only on Desktop where the same fragments are
- * shared; it passes `identity: false` so the main-session identity is not
- * injected into a child.
- */
 export function assembleMainSessionSystemPrompt(
   fragments: readonly (string | undefined)[],
-  options: AssembleMainSessionSystemPromptOptions = {},
 ): string {
-  const includeIdentity = options.identity !== false;
-  return [includeIdentity ? buildIdentityPromptFragment() : undefined, ...fragments]
+  return [buildIdentityPromptFragment(), buildResponseFormatPromptFragment(), ...fragments]
     .filter((fragment): fragment is string => Boolean(fragment?.trim()))
     .join('\n\n');
 }


### PR DESCRIPTION
## Summary

Main-chat responses do not have shared formatting guidance, so their presentation depends on each model's defaults. This is most visible with weaker models and source-heavy answers, which can return raw URLs instead of readable Markdown links.

This change adds one static response-format fragment to the shared main-session assembler. The guidance:

- uses GitHub-Flavored Markdown as the default response format;
- keeps simple answers free of unnecessary headings and lists;
- uses short headings and flat lists to organize longer answers;
- formats multiline code and inline commands, paths, identifiers, and literal values consistently;
- prefers descriptive text for external links; and
- allows more specific user or task formats to take priority.

The fragment applies only to regular main-session prompts. Child prompts and frozen execution profiles keep their existing prompts. Output rendering and link safety are unchanged.

The unused exported identity opt-out is removed because interactive main chat is the assembler's only remaining consumer.

Fixes #3392

## Verification

- `npm --workspace @maka/runtime test` — 3,003 passed, 11 skipped
- `npm --workspace @maka/runtime-host run build`
- `node --test packages/runtime-host/dist/__tests__/execution-model-composition.test.js` — 24 passed
- scoped Biome check for the two changed files
- the focused Host test failed before the prompt update because the shared rules were absent, then passed after the update

### Model behavior

I ran one-time controlled checks with `gpt-5.4-mini`. Each comparison used the same input and runtime path. The response-format fragment was disabled for the Before run and enabled for the After run.

| Scenario | Before | After |
| --- | --- | --- |
| Simple answer | Returned `4` without extra structure | Returned `4` without extra structure |
| Longer explanation | Already used a flat numbered list | Used short paragraphs for the 180-word prompt; a longer variant used headings but still produced nested lists |
| Multiline code | Already used a fenced `javascript` block | Used a fenced `js` block and backticks for identifiers |
| External source | Returned the source as a raw URL | Returned a descriptive Markdown link |

In a longer API-comparison prompt, the baseline produced five Markdown headings. The guided run used short paragraphs and flat lists. Both runs already formatted code, commands, and paths correctly. Neither repeated the supplied documentation URLs because the prompt did not request a source list.

The comparison does not show improvement in every formatting dimension because the model already handled some Markdown cases well. It shows that the guidance preserves simple answers, can reduce unnecessary structure, and improves the source-link case from the issue.

These model calls are one-time PR evidence rather than automated tests because model output is nondeterministic and provider-dependent.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the prompt guidance and tests, reviewed the change, ran the model comparisons, and prepared this PR description. The commit includes `Generated-by: Codex`.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
