### PR TITLE
fix(storage): stop a credential deletion from bumping a retired connection

### DIFF
--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -845,6 +845,106 @@ describe('runtime policy stores', () => {
     });
   });
 
+  test('deleting a retained retired credential leaves its row byte-stable', async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      // Deleting the credential is the one write a tombstone must still accept
+      // — it is how a user removes the retained token. The deletion itself was
+      // never the problem: it invalidated the row's verification on the way
+      // out, bumping the revision of a row nothing may rewrite. The global
+      // sweep was taught to skip retired rows; this single-connection path is
+      // the same invariant reached one connection at a time.
+      const retired = await seedRetiredConnection(
+        root,
+        stores,
+        'delete-claude',
+        '88888888-8888-4888-8888-888888888888',
+        { status: 'verified', checkedAt: '2026-08-01T00:00:00.000Z' },
+      );
+      assert.ok(retired.lastTest, 'the seeded retired row must carry a verification');
+
+      // Seeded the same way the row is: a retired connection's credential
+      // cannot be written through the API that now refuses it.
+      const locator = {
+        scope: 'connection' as const,
+        connectionId: retired.connectionId,
+        kind: 'oauth_token' as const,
+      };
+      await writeFile(
+        join(root, 'credential-vault.json'),
+        `${JSON.stringify({
+          schemaVersion: 1,
+          revision: 1,
+          entries: [
+            {
+              locator,
+              credentialId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+              revision: 1,
+              secret: JSON.stringify({
+                access_token: 'legacy',
+                expires_at: Number.MAX_SAFE_INTEGER,
+              }),
+              updatedAt: 1,
+            },
+          ],
+        })}\n`,
+        'utf8',
+      );
+      const seeded = await getCredentialStatus(stores.credentialVault, locator);
+      assert.equal(credentialBasis(seeded).revision, 1);
+
+      const deleted = await stores.credentialVault.delete({
+        expected: credentialBasis(seeded),
+      });
+      assert.equal(deleted.kind, 'committed');
+
+      const after = await stores.connectionCatalog.getSnapshot();
+      const row = after.connections.find((item) => item.slug === 'delete-claude');
+      // The credential is gone and the row is exactly as it was — same
+      // revision, same verification. A concurrent deletion of the row itself
+      // must not have been made stale by removing its credential.
+      assert.equal(row?.revision, retired.revision);
+      assert.deepEqual(row?.lastTest, retired.lastTest);
+
+      // Control: the same deletion against a live connection must still
+      // invalidate it. Without this the test would pass just as well if the
+      // guard stopped every invalidation rather than only the retired one.
+      const live = await createConnection(
+        stores,
+        after.revision,
+        connectionDraft('delete-live', 'openai', 'Delete Live'),
+      );
+      const liveLocator = connectionCredential(live, 'api_key');
+      await stores.credentialVault.set({
+        locator: liveLocator,
+        expected: null,
+        secret: 'live-key',
+      });
+      const ticket = await stores.operations.beginConnectionTest(live.connectionId, 'gpt-5');
+      assert.equal(ticket.kind, 'ready');
+      if (ticket.kind !== 'ready') return;
+      await stores.operations.completeConnectionTest(ticket.ticket, {
+        status: 'verified',
+        checkedAt: '2026-08-03T00:00:00.000Z',
+      });
+      const liveBefore = (await stores.connectionCatalog.getSnapshot()).connections.find(
+        (item) => item.slug === 'delete-live',
+      );
+      assert.ok(liveBefore?.lastTest, 'the live row must be verified before its credential goes');
+
+      const liveStatus = await getCredentialStatus(stores.credentialVault, liveLocator);
+      const liveDeleted = await stores.credentialVault.delete({
+        expected: credentialBasis(liveStatus),
+      });
+      assert.equal(liveDeleted.kind, 'committed');
+
+      const liveAfter = (await stores.connectionCatalog.getSnapshot()).connections.find(
+        (item) => item.slug === 'delete-live',
+      );
+      assert.equal(liveAfter?.lastTest, undefined);
+      assert.equal(liveAfter?.revision, liveBefore.revision + 1);
+    });
+  });
+
   test('a global proxy change leaves a retained retired row byte-stable', async () => {
     await withInteractiveOwner(async ({ root, stores }) => {
       // Refusing direct writes was not enough: an indirect one reached the

--- a/packages/storage/src/runtime-policy/connection-catalog-document.ts
+++ b/packages/storage/src/runtime-policy/connection-catalog-document.ts
@@ -566,7 +566,14 @@ export class ConnectionCatalogDocumentOwner {
     if (!previous) {
       throw codecError('invalid_document', 'Coordinator admitted an unknown connection');
     }
-    if (previous.lastTest === undefined) return false;
+    // Same tombstone rule the global sweep follows, reached one connection at
+    // a time: deleting a retained retired credential is a write the row must
+    // still accept, and invalidating its verification on the way out would
+    // bump the revision of a row nothing may rewrite — enough to make a
+    // deletion started elsewhere fail as stale. Its `lastTest` describes a
+    // provider that can no longer be tested, so there is nothing to
+    // invalidate.
+    if (previous.lastTest === undefined || isRetiredProvider(previous.providerType)) return false;
     const { lastTest: _lastTest, ...withoutLastTest } = previous;
     await this.writePatchedResult(root, current, index, {
       ...withoutLastTest,


### PR DESCRIPTION
## Summary

A retained retired connection is a tombstone: readable, queryable, deletable, and byte-stable until it is deleted. #3183 established that against direct writes and against the global verification sweep, and left one path open.

Deleting the credential is the write a tombstone must still accept — it is how a user removes the token that retirement deliberately kept. The deletion itself was never the problem. On its way out it invalidated the connection's verification through `clearConnectionLastTest`, which rewrote the row and advanced its revision.

Reproduced: revision `1` becomes `2` for removing a credential.

That bump is not cosmetic. A revision is what a concurrent deletion of the row itself compares against, so removing the credential could make deleting the connection fail as stale — and those two are the same user action, one after the other.

## The fix

`clearAllConnectionLastTests` already skips retired rows. This is the same invariant reached one connection at a time rather than all of them at once, so it gets the same predicate rather than a second rule:

```ts
if (previous.lastTest === undefined || isRetiredProvider(previous.providerType)) return false;
```

One line of behaviour. The asymmetry it removes is the whole bug: the global sweep was taught the rule and the single-connection path was not.

## Verification

The test asserts the tombstone is untouched — revision and `lastTest` both — and carries a live connection as a **control**: the same deletion against it must still clear the verification and bump the revision. Without that half, the test would pass just as well if the guard stopped every invalidation instead of only the retired one.

Verified in both directions rather than only the passing one:

- with the guard reverted, the test fails on exactly the revision it was written for (`actual: 2, expected: 1`)
- with the guard in place, it passes, and so does the control

Gates: `build`, `lint`, `format:check`, `typecheck`, `check:stale`, `check:release` (32), `check:asf-source` (9), `windows:inventory`, the CI planner tests (53, including the pre-`npm ci` case), knip on both workspaces, and the Astryx inventory and theme checks. Suites: storage 849 (848 + this one), core 576, runtime-host 1045, desktop 1023 — all green.

No wire contract changes, so no `RUNTIME_HOST_COMPATIBILITY_EPOCH` bump.

## Review focus

Whether the tombstone invariant is the right frame for this path at all. The alternative reading is that deleting a credential *should* invalidate verification unconditionally, and that a retired row's revision moving is acceptable because nothing will test it again. I do not think so — deletability is part of what the invariant promises, and a revision bump is exactly what breaks it — but that is the judgement worth a second opinion.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — reproduced the defect, wrote the test and its control, made the one-line fix, and ran the verification above. Reviewed and submitted by the contributor of record.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
