### PR TITLE
fix(core): recognize DeepSeek V4 Flash Vision image input

### DIFF
--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -174,3 +174,34 @@ test('Alibaba Token Plan catalogs the formal Qwen3.8 model instead of its retire
     assert.equal(model?.canUseAsChatDefault, true, providerType);
   }
 });
+
+test('DeepSeek catalogs the V4 vision model display metadata from a bare provider id', () => {
+  const modelId = 'deepseek-v4-flash-vision-exp';
+  const [model] = buildConnectionModelCatalogEntries({
+    connection: {
+      slug: 'deepseek',
+      providerType: 'deepseek',
+      defaultModel: modelId,
+      models: [{ id: modelId }],
+      modelSource: 'fetched',
+    },
+  });
+
+  assert.equal(model?.displayName, 'DeepSeek-V4-Flash-Vision-Exp');
+  assert.equal(
+    model?.description,
+    'Experimental DeepSeek V4 Flash model for image understanding and multimodal agent tasks',
+  );
+  assert.equal(model?.docsUrl, 'https://api-docs.deepseek.com/guides/vision/');
+  assert.equal(model?.contextWindow, 1_000_000);
+  assert.equal(model?.maxOutputTokens, 384_000);
+  assert.equal(model?.structuredOutput, true);
+  assert.equal(model?.lastUpdated, '2026-08-21');
+  assert.deepEqual(model?.capabilities, {
+    reasoning: true,
+    functionCalling: true,
+    vision: true,
+  });
+  assert.deepEqual(model?.modalities, { input: ['text', 'image'], output: ['text'] });
+  assert.equal(model?.canUseAsChatDefault, true);
+});

--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -3,11 +3,43 @@ import { describe, it } from 'node:test';
 import {
   lookupModelMetadata,
   openAiAdapterApiProtocol,
+  resolveModelInputModalities,
   resolveModelVisionSupport,
 } from '../model-metadata.js';
 import type { ModelInfo, ProviderType } from '../llm-connections.js';
 
 describe('model-metadata vision capability', () => {
+  it('recognizes the DeepSeek V4 vision model from a bare discovered id', () => {
+    const modelId = 'deepseek-v4-flash-vision-exp';
+    const discovered: ModelInfo[] = [{ id: modelId }];
+    const metadata = lookupModelMetadata('deepseek', modelId);
+
+    assert.equal(metadata.displayName, 'DeepSeek-V4-Flash-Vision-Exp');
+    assert.equal(
+      metadata.description,
+      'Experimental DeepSeek V4 Flash model for image understanding and multimodal agent tasks',
+    );
+    assert.equal(metadata.docsUrl, 'https://api-docs.deepseek.com/guides/vision/');
+    assert.equal(metadata.contextWindow, 1_000_000);
+    assert.equal(metadata.maxOutputTokens, 384_000);
+    assert.equal(metadata.structuredOutput, true);
+    assert.equal(metadata.lastUpdated, '2026-08-21');
+    assert.deepEqual(metadata.thinkingOptions, {
+      efforts: ['low', 'high', 'max'],
+      toggle: true,
+    });
+    assert.equal(metadata.capabilities?.vision, true);
+    assert.deepEqual(resolveModelInputModalities('deepseek', discovered, modelId), [
+      'text',
+      'image',
+    ]);
+    assert.equal(resolveModelVisionSupport('deepseek', discovered, modelId), true);
+    assert.equal(
+      resolveModelVisionSupport('deepseek', [{ id: 'deepseek-v4-flash' }], 'deepseek-v4-flash'),
+      false,
+    );
+  });
+
   it('treats a Claude newer than the generated snapshot as able to read images', () => {
     assert.deepEqual(lookupModelMetadata('anthropic', 'claude-opus-6'), {});
     assert.equal(resolveModelVisionSupport('anthropic', undefined, 'claude-opus-6'), true);

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -395,6 +395,21 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
   },
   'ollama-cloud': ollamaCloudThinkingModels,
   deepseek: {
+    // The first-party model inventory currently returns this new model as a bare id.
+    // Keep its official metadata explicit until the generated catalog includes it.
+    'deepseek-v4-flash-vision-exp': {
+      displayName: 'DeepSeek-V4-Flash-Vision-Exp',
+      description:
+        'Experimental DeepSeek V4 Flash model for image understanding and multimodal agent tasks',
+      docsUrl: 'https://api-docs.deepseek.com/guides/vision/',
+      contextWindow: 1_000_000,
+      maxOutputTokens: 384_000,
+      structuredOutput: true,
+      lastUpdated: '2026-08-21',
+      capabilities: { ...REASONING_FUNCTION_CALLING, vision: true },
+      modalities: { input: ['text', 'image'], output: ['text'] },
+      thinkingOptions: { efforts: ['low', 'high', 'max'], toggle: true },
+    },
     'deepseek-v4-flash': {
       capabilities: { ...REASONING_FUNCTION_CALLING, webSearch: true },
       thinkingOptions: { efforts: ['high', 'max'], toggle: true },


### PR DESCRIPTION
Generated-by: OpenAI Codex

## Summary

DeepSeek's first-party inventory returns `deepseek-v4-flash-vision-exp` as a bare ID. Without a catalog entry, Maka classifies it as text-only, filters image attachments, and displays only the raw model ID.

Add explicit static metadata from DeepSeek's [Vision guide](https://api-docs.deepseek.com/guides/vision/) and [model details](https://api-docs.deepseek.com/quick_start/pricing/), including text-and-image input, friendly display metadata, documented context/output limits, structured output, tool calling, and reasoning controls. Keep this entry local to the first-party DeepSeek provider until the generated models.dev catalog catches up.

Add focused coverage for metadata and modality resolution, catalog projection from a bare provider ID, and the adjacent non-vision `deepseek-v4-flash` model.

Fixes #3417

## Root cause

The first-party `/models` response supplies no modality facts for the new model, and Maka's generated metadata snapshot predates the 2026-08-21 release. `resolveModelVisionSupport()` therefore finds no provider or static vision signal and resolves to `false`.

## Verification

- `npm --workspace @maka/core test` — 578 passed, 0 failed
- `npm run lint` — passed
- `npm run format:check` — passed
- `npm run build` — passed
- `npm run typecheck` — passed
- `./node_modules/.bin/knip --workspace apps/desktop` — passed
- `./node_modules/.bin/knip --workspace packages/ui` — passed
- Desktop smoke test — selected `deepseek-v4-flash-vision-exp`, attached an image, and received an image-grounded response

Before: Maka classifies the model as text-only and filters the attached image.

<img width="894" height="615" alt="Before: Maka filters the image as unsupported" src="https://github.com/user-attachments/assets/d02b569c-f3b9-4885-b51a-52233a9a5e2b" />

After: Maka recognizes the model as multimodal, sends the same image, and receives an image-grounded response.

<img width="864" height="673" alt="After: Maka sends the image to DeepSeek V4 Flash Vision" src="https://github.com/user-attachments/assets/4da9567e-712d-4ef2-9754-9fcb1257e6e4" />

Full `npm test` was not completed locally: an earlier run stalled in `packages/eval/dist/__tests__/provider-admission-integration.test.js` and was interrupted. The affected Core suite completed without failures, and required CI will exercise the remaining workspaces.

## Scope

- The generated models.dev snapshot is unchanged; this is an explicit static entry until the upstream catalog includes the model.
- No lifecycle is assigned because DeepSeek calls the model `experimental`, while Maka has no exact matching lifecycle value.
- Protocol selection is unchanged; the model continues to use Chat Completions, whose image input path DeepSeek documents and the Desktop smoke test verified.
- The model is not added to the offline fallback list.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

OpenAI Codex assisted with official-documentation review, diagnosis, implementation, regression tests, local verification, and drafting this description. I reproduced the issue, reviewed the final diff and test results, and performed the manual smoke test.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No