### PR TITLE
chore: remove explicit commit email notification

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -79,7 +79,6 @@ github:
             type: branch
 
 notifications:
-  commits:      commits@maka.apache.org
   discussions:  dev@maka.apache.org 
   issues:       commits@maka.apache.org
   pullrequests: commits@maka.apache.org


### PR DESCRIPTION
## Summary

Remove the explicit raw commit email target from `.asf.yaml` while preserving the existing notification routes for GitHub Discussions, Issues, and Pull Requests.

## Verification

- `git diff --check`
- Parsed `.asf.yaml` with Ruby's YAML parser and verified that `notifications.commits` is absent while the Issue and Pull Request routes remain unchanged.
- Repository-wide tests were not run because this is a one-line ASF notification configuration change with no local execution seam for GitBox email delivery.

## Operational follow-up

ASF's `.asf.yaml` documentation says a missing notification target falls back to the repository's legacy target. After merge, verify whether raw commit emails stop. If they continue, ask ASF Infra to disable the legacy commit notification target for `apache/maka`.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex analyzed the ASF notification behavior, applied the configuration edit, ran the focused validation, and drafted this pull request.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
