### PR TITLE
fix(desktop): skip idle Host restart prompt

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -603,7 +603,7 @@ test('stops reconnecting when the replacement Host is incompatible', async () =>
   await owner.close();
 });
 
-test('restarts a generation-aware Host through its exact takeover handshake', async () => {
+test('restarts an idle generation-aware Host without prompting', async () => {
   const replacement = candidateHarness();
   const starts: DesktopRuntimeHostCandidateStartInput[] = [];
   const conflict = upgradeRequired(true);
@@ -613,13 +613,53 @@ test('restarts a generation-aware Host through its exact takeover handshake', as
       return starts.length === 1 ? conflict : ready(replacement.candidate);
     },
     upgradePrompts: {
-      restartable: async () => 'restart',
+      restartable: async () => assert.fail('idle Host must not prompt before restart'),
       waitOnly: async () => assert.fail('restartable conflict used wait-only prompt'),
     },
   });
 
   assert.equal(starts.length, 2);
   assert.equal(starts[1]?.takeoverHostEpoch, conflict.registration.hostEpoch);
+  await owner.close();
+});
+
+test('prompts before restarting a generation-aware Host with active work', async () => {
+  const replacement = candidateHarness();
+  const conflict = upgradeRequired(true, 1);
+  let prompts = 0;
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) =>
+      input.takeoverHostEpoch ? ready(replacement.candidate) : conflict,
+    upgradePrompts: {
+      restartable: async () => {
+        prompts += 1;
+        return 'restart';
+      },
+      waitOnly: async () => assert.fail('restartable conflict used wait-only prompt'),
+    },
+  });
+
+  assert.equal(prompts, 1);
+  await owner.close();
+});
+
+test('prompts before restarting a generation-aware Host with a residency', async () => {
+  const replacement = candidateHarness();
+  const conflict = upgradeRequired(true, 0, [{ label: 'goal', count: 1 }]);
+  let prompts = 0;
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) =>
+      input.takeoverHostEpoch ? ready(replacement.candidate) : conflict,
+    upgradePrompts: {
+      restartable: async () => {
+        prompts += 1;
+        return 'restart';
+      },
+      waitOnly: async () => assert.fail('restartable conflict used wait-only prompt'),
+    },
+  });
+
+  assert.equal(prompts, 1);
   await owner.close();
 });
 
@@ -699,6 +739,8 @@ function incompatibleHost(
 
 function upgradeRequired(
   restartable: boolean,
+  activeOperations = 0,
+  residencies: readonly { readonly label: string; readonly count: number }[] = [],
 ): Extract<DesktopRuntimeHostCandidateStartResult, { kind: 'upgrade_required' }> {
   const registration = hostRegistration(
     restartable ? { lifecycleMode: 'ephemeral' } : {},
@@ -723,9 +765,9 @@ function upgradeRequired(
       replacement: 'blocked_by_residency',
       activity: {
         connections: 0,
-        activeOperations: 0,
+        activeOperations,
         processUptimeSeconds: 60,
-        residencies: [],
+        residencies,
       },
     },
   };

--- a/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-desktop-manager.test.ts
@@ -663,6 +663,46 @@ test('prompts before restarting a generation-aware Host with a residency', async
   await owner.close();
 });
 
+test('prompts before restarting a generation-aware Host with connections', async () => {
+  const replacement = candidateHarness();
+  const conflict = upgradeRequired(true, 0, [], 1);
+  let prompts = 0;
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) =>
+      input.takeoverHostEpoch ? ready(replacement.candidate) : conflict,
+    upgradePrompts: {
+      restartable: async () => {
+        prompts += 1;
+        return 'restart';
+      },
+      waitOnly: async () => assert.fail('restartable conflict used wait-only prompt'),
+    },
+  });
+
+  assert.equal(prompts, 1);
+  await owner.close();
+});
+
+test('prompts when a restartable Host has no activity snapshot', async () => {
+  const replacement = candidateHarness();
+  const conflict = upgradeRequired(true, 0, [], 0, false);
+  let prompts = 0;
+  const owner = await startRuntimeHostDesktopManager({} as DesktopRuntimeHostCandidateStartInput, {
+    startCandidate: async (input) =>
+      input.takeoverHostEpoch ? ready(replacement.candidate) : conflict,
+    upgradePrompts: {
+      restartable: async () => {
+        prompts += 1;
+        return 'restart';
+      },
+      waitOnly: async () => assert.fail('restartable conflict used wait-only prompt'),
+    },
+  });
+
+  assert.equal(prompts, 1);
+  await owner.close();
+});
+
 test('waits passively for a Host that cannot be taken over', async () => {
   const conflict = upgradeRequired(false);
   let starts = 0;
@@ -741,6 +781,8 @@ function upgradeRequired(
   restartable: boolean,
   activeOperations = 0,
   residencies: readonly { readonly label: string; readonly count: number }[] = [],
+  connections = 0,
+  includeActivity = true,
 ): Extract<DesktopRuntimeHostCandidateStartResult, { kind: 'upgrade_required' }> {
   const registration = hostRegistration(
     restartable ? { lifecycleMode: 'ephemeral' } : {},
@@ -763,12 +805,16 @@ function upgradeRequired(
       generation: 'desktop-old',
       state: 'ready',
       replacement: 'blocked_by_residency',
-      activity: {
-        connections: 0,
-        activeOperations,
-        processUptimeSeconds: 60,
-        residencies,
-      },
+      ...(includeActivity
+        ? {
+            activity: {
+              connections,
+              activeOperations,
+              processUptimeSeconds: 60,
+              residencies,
+            },
+          }
+        : {}),
     },
   };
 }

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -582,7 +582,11 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         return result.candidate;
       }
       if (result.kind === 'upgrade_required' && result.restartable) {
-        const decision = await this.#resolveRestartable(result);
+        const activity = result.handshake?.activity;
+        const decision =
+          activity && activity.activeOperations === 0 && activity.residencies.length === 0
+            ? 'restart'
+            : await this.#resolveRestartable(result);
         if (decision === 'cancel') {
           throw new RuntimeHostUpgradeCancelledError();
         }

--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -584,7 +584,10 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
       if (result.kind === 'upgrade_required' && result.restartable) {
         const activity = result.handshake?.activity;
         const decision =
-          activity && activity.activeOperations === 0 && activity.residencies.length === 0
+          activity &&
+          activity.connections === 0 &&
+          activity.activeOperations === 0 &&
+          activity.residencies.length === 0
             ? 'restart'
             : await this.#resolveRestartable(result);
         if (decision === 'cancel') {

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -724,6 +724,98 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
+  test('does not take over an idle-looking Host with a residency acquired after discovery', async () => {
+    await withHostPaths(async (paths) => {
+      let context: RuntimeHostCompositionContext | undefined;
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      const host = await RuntimeHostKernel.start({
+        owner,
+        generation: 'desktop-old',
+        idleGraceMs: 10_000,
+        composition: defineInteractiveRuntimeHostComposition(async (value) => {
+          context = value;
+          return testComposition();
+        }),
+      });
+
+      const discovered = await connectRuntimeHost({
+        rootPath: paths.root,
+        protocol: CURRENT_PROTOCOL,
+        generation: 'desktop-new',
+      });
+      assert.equal(discovered.kind, 'upgrade_required');
+      if (discovered.kind !== 'upgrade_required') return;
+      assert.equal(discovered.restartable, true);
+
+      const residency = context?.acquireResidency('late-activity');
+      assert.ok(residency);
+      const takeover = await connectRuntimeHost({
+        rootPath: paths.root,
+        protocol: CURRENT_PROTOCOL,
+        generation: 'desktop-new',
+        takeoverHostEpoch: host.hostEpoch,
+      });
+      assert.equal(takeover.kind, 'upgrade_required');
+      if (takeover.kind === 'upgrade_required') {
+        assert.equal(takeover.restartable, false);
+        assert.equal(takeover.handshake?.activity?.residencies.length, 1);
+      }
+      assert.equal(host.state, 'ready');
+      residency?.release();
+      await host.close();
+    });
+  });
+
+  test('does not take over a generation-mismatched Host before it is ready', async () => {
+    await withHostPaths(async (paths) => {
+      let releaseRecovery!: () => void;
+      const recovery = new Promise<void>((resolve) => {
+        releaseRecovery = resolve;
+      });
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      const hostPromise = RuntimeHostKernel.start({
+        owner,
+        generation: 'desktop-old',
+        idleGraceMs: 10_000,
+        composition: defineInteractiveRuntimeHostComposition(async () => ({
+          ...testComposition(),
+          async recover() {
+            await recovery;
+          },
+        })),
+      });
+
+      let takeover = await connectRuntimeHost({
+        rootPath: paths.root,
+        protocol: CURRENT_PROTOCOL,
+        generation: 'desktop-new',
+      });
+      while (takeover.kind === 'unavailable' && takeover.reason === 'not_registered') {
+        await sleep(10);
+        takeover = await connectRuntimeHost({
+          rootPath: paths.root,
+          protocol: CURRENT_PROTOCOL,
+          generation: 'desktop-new',
+        });
+      }
+      assert.equal(takeover.kind, 'upgrade_required');
+      if (takeover.kind === 'upgrade_required') {
+        assert.equal(takeover.restartable, false);
+        assert.equal(takeover.handshake?.state, 'recovering');
+      }
+      releaseRecovery();
+      const host = await hostPromise;
+      await host.close();
+      await sleep(100);
+    });
+  });
+
   test('process-exit retention closes admission before requiring termination without releasing ownership', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -1330,8 +1330,11 @@ export async function connectResolvedRuntimeHost(
       result.handshake.generation !== generation
     ) {
       return registration.lifecycleMode === 'ephemeral' &&
+        result.handshake.state === 'ready' &&
         result.handshake.activity !== undefined &&
-        result.handshake.activity.connections === 0
+        result.handshake.activity.connections === 0 &&
+        result.handshake.activity.activeOperations === 0 &&
+        result.handshake.activity.residencies.length === 0
         ? {
             kind: 'upgrade_required',
             registration,

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -416,7 +416,7 @@ export class RuntimeHostKernel {
       hello.generation !== undefined &&
       hello.generation !== this.#options.generation;
     if (generationMismatch && hello.takeover?.expectedHostEpoch === this.hostEpoch) {
-      if (authority.principalKind === 'local_owner' && this.#acceptedTransports.size === 0) {
+      if (authority.principalKind === 'local_owner' && this.#isTrueIdle()) {
         this.#requestDrain();
         return {
           kind: 'draining',


### PR DESCRIPTION
## Summary

When Maka restarts immediately after the Desktop client exits, an idle Runtime Host can still be within its idle grace period. The new client currently opens the restart prompt even though the Host has no active work.

This change restarts a generation-aware Host automatically when:

- `activeOperations === 0`
- `residencies.length === 0`

Hosts with active operations or residencies still use the existing restart prompt.

## Verification

- [x] `npm --workspace @maka/desktop run build:main`
- [x] `node --test apps/desktop/dist/main/__tests__/runtime-host-desktop-manager.test.js`
  - 24 tests passed
- [x] `git diff --check`
- [x] Manual Electron restart-cycle verification was run in this environment

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Codex assisted with root-cause analysis, implementation, test updates, and verification.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — idle Runtime Hosts restart without showing a prompt
- [ ] No
