### PR TITLE
fix(ui): give transcript paragraphs a full block step

### DIFF
--- a/packages/ui/src/__tests__/markdown-rhythm-contract.test.tsx
+++ b/packages/ui/src/__tests__/markdown-rhythm-contract.test.tsx
@@ -26,25 +26,22 @@
  * measures. Same for the adjacent-sibling gap form, the `hr` rung, and the two
  * heading size tiers: those are how the table is written, not what it
  * promises.
+ *
+ * Also not pinned, and deliberately not testable from here: WHICH surfaces
+ * ask for compact. That set spans workspaces — `chat-turn.tsx` here and
+ * Artifact Preview in `apps/desktop` — so asserting it would mean a library
+ * test reading application source, which is the dependency backwards. It is
+ * documented where it is decided instead, next to the heading rules in
+ * styles.css that the sharing actually matters for.
  */
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { readdir, readFile } from 'node:fs/promises';
-import { join, relative, resolve } from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { MarkdownBody } from '../markdown-body.js';
 
 const UI_SRC = resolve(import.meta.dirname, '..', '..', 'src');
-
-async function tsxFiles(dir: string): Promise<string[]> {
-  const out: string[] = [];
-  for (const entry of await readdir(dir, { withFileTypes: true })) {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory()) out.push(...(await tsxFiles(path)));
-    else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.')) out.push(path);
-  }
-  return out;
-}
 
 const SAMPLE = ['## Heading two', '', 'A paragraph.', '', '1. First item', '2. Second item'].join('\n');
 
@@ -121,45 +118,6 @@ describe('transcript markdown rhythm', () => {
       'ListItem block padding is no longer zeroed on the compact surface, so the real ' +
         'list-item gap is padding + gap and the declared ladder is not the spacing you get. ' +
         `Found: { ${rule[1].trim()} }`,
-    );
-  });
-
-  /**
-   * The rhythm table carries the transcript's heading TYPOGRAPHY, not just its
-   * spacing, and keys both on `density`. That is a deliberate bet, and it is a
-   * bet: Astryx's density RFC (facebook/astryx#839) draws the line at "density
-   * shifts heights and spacing, not typography", so the key is honest only
-   * while `compact` and "transcript" name the same set. They do today — the
-   * transcript is the only caller asking for compact, and the Daily Review
-   * renders a document at the default.
-   *
-   * A separate surface attribute would decouple them, but nothing needs it yet
-   * and it would add a prop to a public component for a caller that does not
-   * exist. Guard the assumption instead: the moment a second surface asks for
-   * compact markdown it silently inherits transcript heading sizes and dimmed
-   * deep headings, and this is what tells whoever adds it that they have to
-   * choose — inherit deliberately, or split the key then.
-   */
-  it('keeps compact markdown a transcript-only surface', async () => {
-    const callers: string[] = [];
-    for (const file of await tsxFiles(UI_SRC)) {
-      const source = await readFile(file, 'utf8');
-      // `<Markdown …>` opening tags only — not MarkdownBody's internal plumbing
-      // and not the density Maka hands its own code-block renderers.
-      for (const tag of source.matchAll(/<Markdown\s[^>]*?\/?>/gs)) {
-        if (/density=(["'])compact\1/.test(tag[0])) callers.push(relative(UI_SRC, file));
-      }
-    }
-
-    assert.deepEqual(
-      [...new Set(callers)].sort(),
-      ['chat-turn.tsx'],
-      'a new caller renders markdown at compact density. The rhythm table treats ' +
-        '`density="compact"` as "this is a transcript" and gives it flattened heading sizes ' +
-        'plus secondary-colour h4-h6 — typography, which Astryx\'s density is explicitly not ' +
-        'supposed to carry (facebook/astryx#839). Either that is what the new surface wants, ' +
-        'and this list grows, or the typography rules need their own key. ' +
-        `Found: ${JSON.stringify([...new Set(callers)].sort())}`,
     );
   });
 });

--- a/packages/ui/src/__tests__/markdown-rhythm-contract.test.tsx
+++ b/packages/ui/src/__tests__/markdown-rhythm-contract.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Transcript markdown rhythm contract.
+ *
+ * Two failure modes, both SILENT — no error, no failing check, just spacing
+ * that quietly stops being what the table declares. That is the whole reason
+ * this file exists; a CSS selector that matches nothing never complains.
+ *
+ * 1. The table selects entirely on DOM Astryx generates at runtime —
+ *    `data-density`, `astryx-markdown-heading` + `data-level`,
+ *    `astryx-list-item`. Those names have a single upstream owner and appear
+ *    in Maka only inside selectors, so an Astryx rename kills every rule at
+ *    once. Astryx is bumped regularly (0.4.0 in #2983, 0.4.3 in flight, plus
+ *    the Dependabot minor group), so this is a recurring event rather than a
+ *    hypothetical.
+ *
+ * 2. Astryx's ListItem carries CONTROL row padding that `density` cannot reach
+ *    from outside. That padding is what inverted the ladder in the first place
+ *    (#2348: list items ~10px apart against 4px paragraphs, so same-level
+ *    items read as further apart than separate paragraphs), and one rule
+ *    neutralizes it. Lose that rule and the original defect returns.
+ *
+ * Deliberately NOT pinned: the ladder's declared VALUES and their order. A
+ * reversed ladder has to be typed on purpose into four adjacent lines under a
+ * comment that explains the order, and it is visible the moment anyone looks
+ * at a transcript — unlike the two above, which are invisible until someone
+ * measures. Same for the adjacent-sibling gap form, the `hr` rung, and the two
+ * heading size tiers: those are how the table is written, not what it
+ * promises.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readdir, readFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MarkdownBody } from '../markdown-body.js';
+
+const UI_SRC = resolve(import.meta.dirname, '..', '..', 'src');
+
+async function tsxFiles(dir: string): Promise<string[]> {
+  const out: string[] = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await tsxFiles(path)));
+    else if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.')) out.push(path);
+  }
+  return out;
+}
+
+const SAMPLE = ['## Heading two', '', 'A paragraph.', '', '1. First item', '2. Second item'].join('\n');
+
+function compactMarkup(): string {
+  return renderToStaticMarkup(<MarkdownBody text={SAMPLE} density="compact" />);
+}
+
+describe('transcript markdown rhythm', () => {
+  it('emits the DOM hooks the rhythm table selects on', () => {
+    const markup = compactMarkup();
+    // Every rule in the table is prefixed with this, so it is the one hook
+    // whose two halves — selector prefix and runtime attribute — nothing else
+    // joins. Rename it and all compact spacing dies silently.
+    assert.match(
+      markup,
+      /data-maka-contract="markdown"/,
+      'the `data-maka-contract="markdown"` wrapper is gone. Every rule in the rhythm table ' +
+        'is scoped on it, so all compact prose spacing and the heading scale are now dead.',
+    );
+    assert.match(
+      markup,
+      /<div[^>]*role="document"[^>]*data-density="compact"|<div[^>]*data-density="compact"[^>]*role="document"/,
+      'the document root no longer carries `data-density="compact"`. Every rule in the ' +
+        'rhythm table is scoped on it, so all compact prose spacing is now dead.',
+    );
+    assert.match(
+      markup,
+      /class="[^"]*\bastryx-markdown\b/,
+      'the document root no longer carries the `astryx-markdown` class the table selects on',
+    );
+    assert.match(
+      markup,
+      /<h2[^>]*class="[^"]*\bastryx-markdown-heading\b/,
+      'headings no longer carry `astryx-markdown-heading`; the transcript heading scale is dead',
+    );
+    assert.match(
+      markup,
+      /<h2[^>]*data-level="2"/,
+      'headings no longer carry `data-level`. The table splits h1/h2 from h3-h6 on it, so ' +
+        'without it every heading collapses to one tier — the exact defect #2348 replaced.',
+    );
+    assert.match(
+      markup,
+      /class="[^"]*\bastryx-list-item\b/,
+      'list rows no longer carry `astryx-list-item`, so the rule below cannot reach them. ' +
+        'If markdown lists stopped rendering through Astryx `List` that is good news, but ' +
+        'the list rhythm needs re-measuring rather than silently inheriting whatever ' +
+        'replaced it.',
+    );
+  });
+
+  /**
+   * The other half of the join above: the class is emitted AND something
+   * spends its control padding. Markdown hands its list a hardcoded
+   * `density="compact"` in both modes, so the row keeps a control's block
+   * padding no matter what the caller asks for — the real list-item gap is
+   * `padding + gap`, and only zeroing the padding makes `--md-gap-list` the
+   * whole distance between two items.
+   */
+  it('neutralizes the ListItem control padding the ladder inverted on', async () => {
+    const css = (await readFile(join(UI_SRC, 'styles.css'), 'utf8')).replace(/\/\*[\s\S]*?\*\//g, '');
+    const rule = new RegExp(
+      String.raw`\.astryx-markdown\[data-density="compact"\][^{]*\.astryx-list-item\s*\{([^}]*)\}`,
+    ).exec(css);
+    assert.ok(
+      rule,
+      'the compact surface no longer neutralizes `.astryx-list-item` padding. Astryx spaces ' +
+        'a markdown list as a clickable row, which is what made same-level items read as ' +
+        'further apart than separate paragraphs (#2348).',
+    );
+    assert.match(
+      rule[1],
+      /padding-block\s*:\s*0/,
+      'ListItem block padding is no longer zeroed on the compact surface, so the real ' +
+        'list-item gap is padding + gap and the declared ladder is not the spacing you get. ' +
+        `Found: { ${rule[1].trim()} }`,
+    );
+  });
+
+  /**
+   * The rhythm table carries the transcript's heading TYPOGRAPHY, not just its
+   * spacing, and keys both on `density`. That is a deliberate bet, and it is a
+   * bet: Astryx's density RFC (facebook/astryx#839) draws the line at "density
+   * shifts heights and spacing, not typography", so the key is honest only
+   * while `compact` and "transcript" name the same set. They do today — the
+   * transcript is the only caller asking for compact, and the Daily Review
+   * renders a document at the default.
+   *
+   * A separate surface attribute would decouple them, but nothing needs it yet
+   * and it would add a prop to a public component for a caller that does not
+   * exist. Guard the assumption instead: the moment a second surface asks for
+   * compact markdown it silently inherits transcript heading sizes and dimmed
+   * deep headings, and this is what tells whoever adds it that they have to
+   * choose — inherit deliberately, or split the key then.
+   */
+  it('keeps compact markdown a transcript-only surface', async () => {
+    const callers: string[] = [];
+    for (const file of await tsxFiles(UI_SRC)) {
+      const source = await readFile(file, 'utf8');
+      // `<Markdown …>` opening tags only — not MarkdownBody's internal plumbing
+      // and not the density Maka hands its own code-block renderers.
+      for (const tag of source.matchAll(/<Markdown\s[^>]*?\/?>/gs)) {
+        if (/density=(["'])compact\1/.test(tag[0])) callers.push(relative(UI_SRC, file));
+      }
+    }
+
+    assert.deepEqual(
+      [...new Set(callers)].sort(),
+      ['chat-turn.tsx'],
+      'a new caller renders markdown at compact density. The rhythm table treats ' +
+        '`density="compact"` as "this is a transcript" and gives it flattened heading sizes ' +
+        'plus secondary-colour h4-h6 — typography, which Astryx\'s density is explicitly not ' +
+        'supposed to carry (facebook/astryx#839). Either that is what the new surface wants, ' +
+        'and this list grows, or the typography rules need their own key. ' +
+        `Found: ${JSON.stringify([...new Set(callers)].sort())}`,
+    );
+  });
+});

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -1104,13 +1104,16 @@ const AssistantAnswerBubble = memo(function AssistantAnswerBubble(props: Assista
         text={props.text}
         streaming={props.phase === 'streaming'}
         settledText={settledText}
-        // Names the surface; it does NOT set this turn's block spacing. Every
-        // top-level gap in a transcript turn comes from the rhythm table in
-        // styles.css, which keys on the `data-density="compact"` this prop
-        // reflects and overrides Astryx's own margins outright. So `compact`
-        // still buys the transcript heading scale and the tighter rhythm
-        // inside a list item or a quote, and reading it as "paragraphs are
-        // squeezed here" is the wrong file — retune `--md-gap-block` instead.
+        // Names the surface, and not exclusively: the desktop Artifact
+        // Preview asks for compact too and takes the same rules, so retuning
+        // them here is retuning them there. What this prop does NOT do is set
+        // this turn's block spacing. Every top-level gap in a transcript turn
+        // comes from the rhythm table in styles.css, which keys on the
+        // `data-density="compact"` this prop reflects and overrides Astryx's
+        // own margins outright. So `compact` still buys the transcript
+        // heading scale and the tighter rhythm inside a list item or a quote,
+        // and reading it as "paragraphs are squeezed here" is the wrong
+        // file — retune `--md-gap-block` instead.
         density="compact"
       />
       {truncated && (

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -1104,6 +1104,13 @@ const AssistantAnswerBubble = memo(function AssistantAnswerBubble(props: Assista
         text={props.text}
         streaming={props.phase === 'streaming'}
         settledText={settledText}
+        // Names the surface; it does NOT set this turn's block spacing. Every
+        // top-level gap in a transcript turn comes from the rhythm table in
+        // styles.css, which keys on the `data-density="compact"` this prop
+        // reflects and overrides Astryx's own margins outright. So `compact`
+        // still buys the transcript heading scale and the tighter rhythm
+        // inside a list item or a quote, and reading it as "paragraphs are
+        // squeezed here" is the wrong file — retune `--md-gap-block` instead.
         density="compact"
       />
       {truncated && (

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -229,7 +229,12 @@
    - Only `[data-density="compact"]`. The document mode is not broken (its
      lists sit 10px apart against 12px paragraphs, which is already in order),
      and the Daily Review renders through it. Fixing only the broken half keeps
-     that surface out of the blast radius.
+     that surface out of the blast radius. Compact is not the transcript
+     alone, though — the desktop Artifact Preview asks for it too, so it takes
+     these gaps as well. For the block rung that is the point rather than a
+     cost: 12px IS the document rhythm, so the preview moves toward Astryx's
+     default rather than further from it. The heading rules below are the ones
+     where sharing is arguable, and they say so.
    - Scoped to Astryx's own `data-density`, not to a `.maka-turn` ancestor.
      `themeProps()` reflects every visual prop as a data attribute for exactly
      this ("consumers target stable data-attribute selectors"), so the rhythm
@@ -317,14 +322,28 @@
    rather than spacing, and Astryx's density RFC (facebook/astryx#839) draws
    the line at "density shifts heights and spacing, not typography". Keying
    them on `data-density` is honest only while `compact` and "transcript" name
-   the same set — true today, since the transcript is the only caller asking
-   for compact and the Daily Review renders a document at the default. A
-   second compact surface would silently inherit transcript heading sizes and
-   dimmed deep headings. Giving typography its own surface attribute would
-   decouple them, but nothing needs it yet; the assumption is held by a test
-   instead (__tests__/markdown-rhythm-contract.test.tsx, "keeps compact
-   markdown a transcript-only surface"), which fails the moment the sets
-   diverge and says what the choice is. */
+   the same set, and they DO NOT. Two surfaces ask for compact: the transcript
+   (chat-turn.tsx) and the desktop Artifact Preview
+   (apps/desktop/src/renderer/artifact-preview.tsx, since #2506), so the
+   preview pane has been rendering `.md` files at transcript heading sizes
+   with dimmed h4-h6 ever since. Nothing scopes it out: the
+   `[data-maka-contract="markdown"]` prefix is on every MarkdownBody, so
+   `density` is the whole key.
+
+   Left shared on purpose, not by omission. The preview is a narrow side pane
+   showing a document a few lines at a time, which is the shape the flattening
+   was designed for, and no report has called it wrong. Splitting the key —
+   moving these three rules onto a surface attribute the transcript sets and
+   the preview does not — is a visible change to the preview's typography and
+   belongs in its own change, argued and looked at on that surface rather
+   than smuggled in under a spacing token.
+
+   So: a THIRD compact surface inherits transcript typography silently, and
+   nothing catches it. That is unguarded, and it stays unguarded knowingly —
+   the caller set spans workspaces, so the only test that could hold it is a
+   library test grepping application source. One was written and it was wrong
+   on its first commit, passing while already false. A comment that is checked
+   when these rules are read beats an assertion that lies. */
 [data-maka-contract="markdown"] .astryx-markdown[data-density="compact"] .astryx-markdown-heading:is([data-level="1"], [data-level="2"]) {
   font: var(--maka-text-heading-3);
 }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -193,9 +193,26 @@
    by owning every compact prose gap in one place:
 
      4px  list items   (same level)
-     8px  blocks       (paragraph, list, quote, table, code)
+     12px blocks       (paragraph, list, quote, table, code)
      16px section      (h3-h6, and either side of an `hr`)
      24px chapter      (h1, h2)
+
+   Why the block rung is 12px and not the 8px this table first shipped: 8px
+   restored the ORDER the table exists to fix, but never argued its value.
+   Body leading here is 20px, so 8px put two paragraphs 0.4 of a line apart —
+   a paragraph break narrower than the line break inside a paragraph, which is
+   the one distance a reader already knows. 12px is Astryx's own paragraph
+   rhythm at document density (spacingParagraphDefault, `--spacing-3`), so this
+   is the block step returning to the design system rather than a Maka number:
+   the transcript keeps its own HEADING scale and its own list rung, and only
+   stops being denser than the design system between two paragraphs. Measured
+   in Storybook (Product/Markdown → TranscriptTurn) rather than estimated.
+
+   It costs contrast at the top of the ladder — the section step falls from 2x
+   the block gap to 1.33x, so a heading now separates mainly on weight, size
+   and colour rather than on space. That is the price of leaving the heading
+   rungs alone, which is deliberate: heading spacing is what #1857 and this
+   table already decided, and this change is about paragraphs only.
 
    Three deliberate choices:
 
@@ -211,11 +228,11 @@
      old ancestor-scoped rules could not.
    - Top level only. `>` keeps every gap on the document's own children, so
      blocks nested inside a list item or a blockquote keep Astryx's own compact
-     4px instead of the 8px block gap. That tier difference is the point, not
-     an oversight: a list item should read as one unit, so two paragraphs
-     inside it belong closer together than two paragraphs in the transcript.
-     The ladder extends downward (4px nested < 8px block) rather than
-     inverting, which is the invariant that matters.
+     4px instead of the block gap. That tier difference is the point, not an
+     oversight: a list item should read as one unit, so two paragraphs inside
+     it belong closer together than two paragraphs in the transcript. The
+     ladder extends downward (4px nested < 12px block) rather than inverting,
+     which is the invariant that matters.
 
    A gap is a relation BETWEEN two blocks, so every gap rule is an adjacent
    sibling rule. Two consequences, both load-bearing:
@@ -232,7 +249,7 @@
      two blocks is the value declared here. */
 [data-maka-contract="markdown"] .astryx-markdown[data-density="compact"] {
   --md-gap-list: var(--space-1);
-  --md-gap-block: var(--space-2);
+  --md-gap-block: var(--space-3);
   --md-gap-section: var(--space-4);
   --md-gap-chapter: var(--space-6);
 }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -214,6 +214,16 @@
    rungs alone, which is deliberate: heading spacing is what #1857 and this
    table already decided, and this change is about paragraphs only.
 
+   What holds this: __tests__/markdown-rhythm-contract.test.tsx, and it pins
+   only the two ways this table can break SILENTLY — the runtime hooks these
+   selectors need still being emitted (an Astryx rename kills every rule at
+   once, and a selector that matches nothing never complains), and the
+   ListItem control padding still being neutralized (the mechanism that
+   inverted the ladder in the first place). The values below are NOT pinned,
+   deliberately: a wrong number is visible the moment anyone looks at a
+   transcript, so it does not need a test to be noticed — which is not true of
+   either of the other two.
+
    Three deliberate choices:
 
    - Only `[data-density="compact"]`. The document mode is not broken (its
@@ -312,9 +322,9 @@
    second compact surface would silently inherit transcript heading sizes and
    dimmed deep headings. Giving typography its own surface attribute would
    decouple them, but nothing needs it yet; the assumption is held by a test
-   instead (packages/ui/src/__tests__/markdown-rhythm-dom-contract.test.tsx,
-   "keeps compact markdown a transcript-only surface"), which fails the moment
-   the sets diverge and says what the choice is. */
+   instead (__tests__/markdown-rhythm-contract.test.tsx, "keeps compact
+   markdown a transcript-only surface"), which fails the moment the sets
+   diverge and says what the choice is. */
 [data-maka-contract="markdown"] .astryx-markdown[data-density="compact"] .astryx-markdown-heading:is([data-level="1"], [data-level="2"]) {
   font: var(--maka-text-heading-3);
 }


### PR DESCRIPTION
## Summary

Two paragraphs in a chat turn sat 8px apart against 20px body leading — a paragraph break narrower than the line break inside a paragraph, so a long answer read as one slab. The block rung goes to 12px, Astryx's own paragraph rhythm at document density.

Not where it looks like it belongs: `density="compact"` on the transcript's `<Markdown>` has not owned block spacing since #2348. The rhythm table in `styles.css` zeroes Astryx's margins and declares the four gaps itself in `@layer components`, so a Markdown density token — or a `makaTheme.ts` override — lands in an earlier layer and is inert. `--md-gap-block` is the only authority; the call site now says so.

Code blocks and blockquotes ride the same rung and move with it. The heading rungs stay put, which is #1857's and #2348's decision, and the cost is accepted: the section step falls from 2x the block gap to 1.33x. 12px is the largest step that keeps the ladder ordered without moving a heading rung — at 16px a paragraph break would be indistinguishable from the space before a section heading.

**Second commit.** `styles.css` cited a test as holding the "compact == transcript" assumption; that file was deleted in #2462 and its sibling in #2425, so nothing would have caught a bad value here. The restored test pins only what a reader cannot notice on sight — an Astryx rename (the table selects entirely on runtime Astryx DOM, and a selector matching nothing never complains) and losing the ListItem padding reset (the actual cause of #2348's inversion) — plus the single-caller assumption the comment names. The ladder's values are deliberately left unpinned: a wrong number is visible the moment anyone looks at a transcript.

Refs #1857, #2348, #2425, #2462

## Verification

<img width="2848" height="972" alt="image" src="https://github.com/user-attachments/assets/3572be76-e5f0-43c6-a328-00184859f090" />

| rung | before | after |
| --- | --- | --- |
| list rows | 4px | 4px |
| blocks (paragraph, list, quote, code) | 8px | **12px** |
| section (h3–h6) | 16px | 16px |
| chapter (h1, h2) | 24px | 24px |

Live computed styles in Storybook (`Product/Markdown → TranscriptTurn`, `Product/Shell Official AppShell → Native Conversation`). Daily Review renders at `density="default"`, outside the selector — unchanged.

The contract test was mutation-tested: six mutations (delete / un-zero / comment-out the ListItem reset, rename the contract wrapper, cut `density` before Astryx, add a second compact caller), each verified to fail the assertion that describes it. Also run: the new suite (3/3), `@maka/ui` typecheck, `npm run lint`, `npm run format:check`, `npm run astryx:theme -- --check`. Full repository suite left to CI.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — found the real spacing authority, made the change, found the dangling test citation, wrote the test and comments, and ran the measurements and mutation sweep. The 12px value, leaving the heading rungs alone, and the restore-vs-drop scope call were reviewed by the human contributor.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
