### PR TITLE
fix(desktop): keep Settings stable during Runtime Host refresh

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -141,3 +141,69 @@ test('appearance choice content stays vertically centered in stretched grid rows
     expect(Math.abs(geometry.topGap - geometry.bottomGap)).toBeLessThanOrEqual(1);
   }
 });
+
+test('reopening settings keeps the last-ready General page stable while refreshing', async ({
+  window: page,
+}) => {
+  await page.getByRole('button', { name: '设置' }).click();
+  const settings = page.locator('.settingsSurface');
+  await page.getByRole('button', { name: '通用', exact: true }).click();
+  await expect(settings.getByRole('textbox', { name: '助手语气偏好' })).toBeEnabled();
+  await expect(settings.getByRole('button', { name: '默认模型' })).toBeEnabled();
+
+  await page.keyboard.press('Escape');
+  await expect(settings).toHaveCount(0);
+  await expect(page.getByRole('button', { name: '设置' })).toBeVisible();
+
+  await page.evaluate(() => {
+    const state = {
+      sawLoadingWarning: false,
+      sawGeneralWithoutReadyHostControls: false,
+    };
+    const inspect = () => {
+      const surface = document.querySelector('.settingsSurface');
+      const main = surface?.querySelector('main, [role="main"]');
+      if (!surface || !main) return;
+      state.sawLoadingWarning ||= Array.from(
+        surface.querySelectorAll('[role="alert"]'),
+      ).some((banner) => banner.textContent?.includes('正在加载设置') === true);
+      const defaultModelReady = Array.from(main.querySelectorAll('*')).some(
+        (element) =>
+          element.children.length === 0 &&
+          element.textContent?.trim() === '默认模型' &&
+          Boolean(element.closest('.astryx-item')?.querySelector('button')),
+      );
+      state.sawGeneralWithoutReadyHostControls ||=
+        main.querySelector('textarea') === null || !defaultModelReady;
+    };
+    const observer = new MutationObserver(inspect);
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    Object.assign(window, {
+      __makaSettingsReopenProbe: {
+        finish() {
+          inspect();
+          observer.disconnect();
+          return state;
+        },
+      },
+    });
+  });
+
+  await page.getByRole('button', { name: '设置' }).click();
+  await expect(settings.getByRole('textbox', { name: '助手语气偏好' })).toBeEnabled();
+  await expect(settings.getByRole('button', { name: '默认模型' })).toBeEnabled();
+
+  const probe = await page.evaluate(() => {
+    const target = window as typeof window & {
+      __makaSettingsReopenProbe: {
+        finish(): {
+          sawLoadingWarning: boolean;
+          sawGeneralWithoutReadyHostControls: boolean;
+        };
+      };
+    };
+    return target.__makaSettingsReopenProbe.finish();
+  });
+  expect(probe.sawLoadingWarning).toBe(false);
+  expect(probe.sawGeneralWithoutReadyHostControls).toBe(false);
+});

--- a/apps/desktop/src/main/__tests__/runtime-host-settings-generation.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-settings-generation.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { act, createElement, Fragment, useEffect } from 'react';
+import { teardownPendingAuthorization } from '../../renderer/settings/oauth-login-flow-guard.js';
+import {
+  RuntimeHostSettingsGenerationBoundary,
+  RuntimeHostSettingsTarget,
+} from '../../renderer/settings/runtime-host-settings-target.js';
+import { cleanupFakeDom, installReactRenderer } from './fake-dom.js';
+
+test('retires only Host-owned controllers when a same-key Host enters a new generation', async () => {
+  const { root } = installReactRenderer();
+  const lifecycle: string[] = [];
+  const cancelled: string[] = [];
+
+  function StableSettingsState() {
+    useEffect(() => {
+      lifecycle.push('stable:mount');
+      return () => {
+        lifecycle.push('stable:unmount');
+      };
+    }, []);
+    return null;
+  }
+
+  function HostOwnedOAuthController() {
+    useEffect(() => {
+      const pendingAuthorization = { current: 'authorization-from-current-generation' };
+      lifecycle.push('oauth:mount');
+      return () => {
+        lifecycle.push('oauth:unmount');
+        teardownPendingAuthorization(pendingAuthorization, (id) => cancelled.push(id));
+      };
+    }, []);
+    return null;
+  }
+
+  function render(generation: string) {
+    root.render(createElement(RuntimeHostSettingsTarget, {
+      host: { profileId: 'local', hostId: 'same-host-id' },
+      generation,
+      children: createElement(Fragment, {
+        children: [
+          createElement(StableSettingsState, { key: 'stable' }),
+          createElement(RuntimeHostSettingsGenerationBoundary, {
+            key: 'host-owned',
+            children: createElement(HostOwnedOAuthController),
+          }),
+        ],
+      }),
+    }));
+  }
+
+  await act(async () => render('epoch-1'));
+  assert.deepEqual(lifecycle, ['stable:mount', 'oauth:mount']);
+
+  await act(async () => render('epoch-1'));
+  assert.deepEqual(lifecycle, ['stable:mount', 'oauth:mount'], 'the same generation remains mounted');
+
+  await act(async () => render('epoch-2'));
+  assert.deepEqual(lifecycle, [
+    'stable:mount',
+    'oauth:mount',
+    'oauth:unmount',
+    'oauth:mount',
+  ]);
+  assert.deepEqual(cancelled, ['authorization-from-current-generation']);
+});
+
+afterEach(() => {
+  cleanupFakeDom();
+});

--- a/apps/desktop/src/main/__tests__/settings-resource-state.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-resource-state.test.ts
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { createDefaultSettings } from '@maka/core/settings';
+import {
+  beginSettingsResourceLoad,
+  completeSettingsResourceLoad,
+  createSettingsResourceState,
+  failSettingsResourceLoad,
+  reconcileRuntimeHostProfileSelection,
+  settingsResourceSnapshot,
+  settingsResourceStatus,
+} from '../../renderer/settings/settings-resource-state.js';
+import {
+  createSettingsSnapshotCache,
+  settingsSnapshotCacheFor,
+} from '../../renderer/settings/settings-snapshot-cache.js';
+import type { DesktopRuntimeHostProfileSnapshot } from '../../preload/bridge-contract.js';
+import { createSettingsRequestAuthority } from '../../renderer/settings/settings-request-authority.js';
+
+const LOCAL_KEY = 'local:host-local-1';
+const REMOTE_KEY = 'remote:host-remote-1';
+
+function catalog(entries: DesktopRuntimeHostProfileSnapshot['entries']): DesktopRuntimeHostProfileSnapshot {
+  return {
+    defaultProfileId: 'local',
+    entries,
+  };
+}
+
+describe('Settings resource state', () => {
+  it('keeps a last-ready snapshot visible while it revalidates', () => {
+    const snapshot = { value: 'ready' };
+    const ready = completeSettingsResourceLoad(LOCAL_KEY, snapshot);
+
+    const loading = beginSettingsResourceLoad(ready, LOCAL_KEY);
+
+    assert.equal(loading.phase, 'loading');
+    assert.equal(settingsResourceSnapshot(loading, LOCAL_KEY), snapshot);
+    assert.deepEqual(settingsResourceStatus(loading, LOCAL_KEY), {
+      phase: 'loading',
+      hasSnapshot: true,
+      isVerified: true,
+      message: undefined,
+    });
+  });
+
+  it('retains the snapshot and records a failed refresh', () => {
+    const snapshot = { value: 'ready' };
+    const loading = beginSettingsResourceLoad(
+      completeSettingsResourceLoad(LOCAL_KEY, snapshot),
+      LOCAL_KEY,
+    );
+
+    const failed = failSettingsResourceLoad(loading, LOCAL_KEY, 'offline');
+
+    assert.equal(settingsResourceSnapshot(failed, LOCAL_KEY), snapshot);
+    assert.deepEqual(settingsResourceStatus(failed, LOCAL_KEY), {
+      phase: 'error',
+      hasSnapshot: true,
+      isVerified: true,
+      message: 'offline',
+    });
+  });
+
+  it('never exposes one Runtime Host snapshot through another Host key', () => {
+    const local = completeSettingsResourceLoad(LOCAL_KEY, { value: 'local' });
+
+    assert.equal(settingsResourceSnapshot(local, REMOTE_KEY), undefined);
+    assert.deepEqual(settingsResourceStatus(local, REMOTE_KEY), {
+      phase: 'idle',
+      hasSnapshot: false,
+      isVerified: false,
+    });
+  });
+
+  it('seeds a cold load from a matching cached snapshot', () => {
+    const cached = { value: 'cached' };
+
+    const loading = beginSettingsResourceLoad(
+      createSettingsResourceState(),
+      LOCAL_KEY,
+      cached,
+    );
+
+    assert.equal(settingsResourceSnapshot(loading, LOCAL_KEY), cached);
+    assert.equal(settingsResourceStatus(loading, LOCAL_KEY).hasSnapshot, true);
+    assert.equal(settingsResourceStatus(loading, LOCAL_KEY).isVerified, false);
+  });
+
+  it('keeps an initially cached snapshot read-only when validation fails', () => {
+    const cached = { value: 'cached' };
+    const loading = beginSettingsResourceLoad(
+      createSettingsResourceState(LOCAL_KEY, cached),
+      LOCAL_KEY,
+      cached,
+    );
+
+    const failed = failSettingsResourceLoad(loading, LOCAL_KEY, 'offline', cached);
+
+    assert.equal(settingsResourceSnapshot(failed, LOCAL_KEY), cached);
+    assert.deepEqual(settingsResourceStatus(failed, LOCAL_KEY), {
+      phase: 'error',
+      hasSnapshot: true,
+      isVerified: false,
+      message: 'offline',
+    });
+  });
+
+  it('uses a fresh default over a cached bootstrap selection', () => {
+    assert.equal(
+      reconcileRuntimeHostProfileSelection({
+        currentProfileId: 'cached-default',
+        defaultProfileId: 'fresh-default',
+        enabledProfileIds: ['cached-default', 'fresh-default'],
+        preserveCurrentSelection: false,
+      }),
+      'fresh-default',
+    );
+  });
+
+  it('preserves an explicit valid selection after hydration', () => {
+    assert.equal(
+      reconcileRuntimeHostProfileSelection({
+        currentProfileId: 'remote',
+        defaultProfileId: 'local',
+        enabledProfileIds: ['local', 'remote'],
+        preserveCurrentSelection: true,
+      }),
+      'remote',
+    );
+  });
+});
+
+describe('Settings snapshot cache', () => {
+  it('reuses masked read snapshots for the same renderer bridge identity only', () => {
+    const firstBridge = {};
+    const secondBridge = {};
+    const clientSettings = createDefaultSettings();
+
+    settingsSnapshotCacheFor(firstBridge).commitClientRead(clientSettings);
+
+    assert.equal(settingsSnapshotCacheFor(firstBridge).readClient(), clientSettings);
+    assert.equal(settingsSnapshotCacheFor(secondBridge).readClient(), undefined);
+  });
+
+  it('isolates settings and connections by Runtime Host epoch', () => {
+    const cache = createSettingsSnapshotCache();
+    const localSettings = createDefaultSettings();
+    const remoteSettings = {
+      ...createDefaultSettings(),
+      personalization: {
+        ...createDefaultSettings().personalization,
+        displayName: 'Remote Host',
+      },
+    };
+    const localConnections = { connections: [], defaultSlug: 'local-default' };
+
+    cache.commitRuntimeHostSettingsRead(LOCAL_KEY, localSettings);
+    cache.commitRuntimeHostSettingsRead(REMOTE_KEY, remoteSettings);
+    cache.commitRuntimeHostConnectionsRead(LOCAL_KEY, localConnections);
+
+    assert.equal(cache.readRuntimeHostSettings(LOCAL_KEY), localSettings);
+    assert.equal(cache.readRuntimeHostSettings(REMOTE_KEY), remoteSettings);
+    assert.equal(cache.readRuntimeHostConnections(LOCAL_KEY), localConnections);
+    assert.equal(cache.readRuntimeHostConnections(REMOTE_KEY), undefined);
+  });
+
+  it('prunes snapshots when a profile reconnects with a new host id', () => {
+    const cache = createSettingsSnapshotCache();
+    cache.commitRuntimeHostSettingsRead(LOCAL_KEY, createDefaultSettings());
+    cache.commitRuntimeHostConnectionsRead(LOCAL_KEY, {
+      connections: [],
+      defaultSlug: null,
+    });
+
+    cache.commitRuntimeHostCatalogRead(catalog([
+      {
+        profile: { id: 'local', name: 'Local', kind: 'local' },
+        enabled: true,
+        isDefault: true,
+        readiness: 'ready',
+        hostId: 'host-local-2',
+      },
+    ]));
+
+    assert.equal(cache.readRuntimeHostSettings(LOCAL_KEY), undefined);
+    assert.equal(cache.readRuntimeHostConnections(LOCAL_KEY), undefined);
+  });
+
+  it('stores settings and connection reads independently', () => {
+    const cache = createSettingsSnapshotCache();
+    const settings = createDefaultSettings();
+    cache.commitRuntimeHostSettingsRead(LOCAL_KEY, settings);
+
+    assert.equal(cache.readRuntimeHostSettings(LOCAL_KEY), settings);
+    assert.equal(cache.readRuntimeHostConnections(LOCAL_KEY), undefined);
+
+    const connections = { connections: [], defaultSlug: null };
+    cache.commitRuntimeHostConnectionsRead(LOCAL_KEY, connections);
+
+    assert.equal(cache.readRuntimeHostSettings(LOCAL_KEY), settings);
+    assert.equal(cache.readRuntimeHostConnections(LOCAL_KEY), connections);
+  });
+});
+
+describe('Settings Runtime Host request authority', () => {
+  it('invalidates reads without discarding a same-Host mutation', () => {
+    const authority = createSettingsRequestAuthority(LOCAL_KEY);
+    const settingsRead = authority.beginSettingsRead(LOCAL_KEY);
+    const connectionsRead = authority.beginConnectionsRead(LOCAL_KEY);
+    const settingsWrite = authority.beginSettingsWrite(LOCAL_KEY);
+    assert.ok(settingsRead);
+    assert.ok(connectionsRead);
+    assert.ok(settingsWrite);
+
+    authority.invalidateReads();
+
+    assert.equal(authority.acceptsSettingsRead(settingsRead), false);
+    assert.equal(authority.acceptsConnectionsRead(connectionsRead), false);
+    assert.equal(authority.acceptsSettingsWrite(settingsWrite), true);
+  });
+
+  it('rejects every in-flight operation synchronously when the Host epoch changes', () => {
+    const authority = createSettingsRequestAuthority(LOCAL_KEY);
+    const settingsRead = authority.beginSettingsRead(LOCAL_KEY);
+    const connectionsRead = authority.beginConnectionsRead(LOCAL_KEY);
+    const settingsWrite = authority.beginSettingsWrite(LOCAL_KEY);
+    assert.ok(settingsRead);
+    assert.ok(connectionsRead);
+    assert.ok(settingsWrite);
+
+    authority.selectTarget(REMOTE_KEY);
+
+    assert.equal(authority.acceptsSettingsRead(settingsRead), false);
+    assert.equal(authority.acceptsConnectionsRead(connectionsRead), false);
+    assert.equal(authority.acceptsSettingsWrite(settingsWrite), false);
+  });
+
+  it('keeps only the latest mutation for one Host', () => {
+    const authority = createSettingsRequestAuthority(LOCAL_KEY);
+    const first = authority.beginSettingsWrite(LOCAL_KEY);
+    const second = authority.beginSettingsWrite(LOCAL_KEY);
+    assert.ok(first);
+    assert.ok(second);
+
+    assert.equal(authority.acceptsSettingsWrite(first), false);
+    assert.equal(authority.acceptsSettingsWrite(second), true);
+  });
+
+  it('refuses to start a delayed mutation for a no-longer-selected Host', () => {
+    const authority = createSettingsRequestAuthority(LOCAL_KEY);
+
+    authority.selectTarget(REMOTE_KEY);
+
+    assert.equal(authority.beginSettingsWrite(LOCAL_KEY), undefined);
+    assert.notEqual(authority.beginSettingsWrite(REMOTE_KEY), undefined);
+  });
+
+  it('does not let a delayed old-Host read invalidate the current Host reads', () => {
+    const authority = createSettingsRequestAuthority(LOCAL_KEY);
+    authority.selectTarget(REMOTE_KEY);
+    const settingsRead = authority.beginSettingsRead(REMOTE_KEY);
+    const connectionsRead = authority.beginConnectionsRead(REMOTE_KEY);
+    assert.ok(settingsRead);
+    assert.ok(connectionsRead);
+
+    assert.equal(authority.beginSettingsRead(LOCAL_KEY), undefined);
+    assert.equal(authority.beginConnectionsRead(LOCAL_KEY), undefined);
+    assert.equal(authority.acceptsSettingsRead(settingsRead), true);
+    assert.equal(authority.acceptsConnectionsRead(connectionsRead), true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/settings-resource-state.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-resource-state.test.ts
@@ -25,6 +25,7 @@ import {
   completeSettingsResourceLoad,
   createSettingsResourceState,
   failSettingsResourceLoad,
+  invalidateSettingsResourceGeneration,
   reconcileRuntimeHostProfileSelection,
   settingsResourceSnapshot,
   settingsResourceStatus,
@@ -79,6 +80,29 @@ describe('Settings resource state', () => {
       isVerified: true,
       message: 'offline',
     });
+  });
+
+  it('keeps a previous-generation snapshot visible without keeping its authority', () => {
+    const snapshot = { value: 'ready' };
+    const invalidated = invalidateSettingsResourceGeneration(
+      completeSettingsResourceLoad(LOCAL_KEY, snapshot),
+    );
+
+    assert.equal(settingsResourceSnapshot(invalidated, LOCAL_KEY), snapshot);
+    assert.deepEqual(settingsResourceStatus(invalidated, LOCAL_KEY), {
+      phase: 'loading',
+      hasSnapshot: true,
+      isVerified: false,
+      message: undefined,
+    });
+
+    const failed = failSettingsResourceLoad(
+      beginSettingsResourceLoad(invalidated, LOCAL_KEY),
+      LOCAL_KEY,
+      'replacement offline',
+    );
+    assert.equal(settingsResourceSnapshot(failed, LOCAL_KEY), snapshot);
+    assert.equal(settingsResourceStatus(failed, LOCAL_KEY).isVerified, false);
   });
 
   it('never exposes one Runtime Host snapshot through another Host key', () => {
@@ -162,7 +186,7 @@ describe('Settings snapshot cache', () => {
     assert.equal(settingsSnapshotCacheFor(secondBridge).readClient(), undefined);
   });
 
-  it('isolates settings and connections by Runtime Host epoch', () => {
+  it('isolates settings and connections by selected Runtime Host key', () => {
     const cache = createSettingsSnapshotCache();
     const localSettings = createDefaultSettings();
     const remoteSettings = {
@@ -239,7 +263,7 @@ describe('Settings Runtime Host request authority', () => {
     assert.equal(authority.acceptsSettingsWrite(settingsWrite), true);
   });
 
-  it('rejects every in-flight operation synchronously when the Host epoch changes', () => {
+  it('rejects every in-flight operation synchronously when the selected Host changes', () => {
     const authority = createSettingsRequestAuthority(LOCAL_KEY);
     const settingsRead = authority.beginSettingsRead(LOCAL_KEY);
     const connectionsRead = authority.beginConnectionsRead(LOCAL_KEY);
@@ -253,6 +277,47 @@ describe('Settings Runtime Host request authority', () => {
     assert.equal(authority.acceptsSettingsRead(settingsRead), false);
     assert.equal(authority.acceptsConnectionsRead(connectionsRead), false);
     assert.equal(authority.acceptsSettingsWrite(settingsWrite), false);
+  });
+
+  it('rejects every in-flight operation when the same Host key enters a new epoch', () => {
+    const authority = createSettingsRequestAuthority(LOCAL_KEY, 'epoch-1');
+    const settingsRead = authority.beginSettingsRead(LOCAL_KEY);
+    const connectionsRead = authority.beginConnectionsRead(LOCAL_KEY);
+    const settingsWrite = authority.beginSettingsWrite(LOCAL_KEY);
+    assert.ok(settingsRead);
+    assert.ok(connectionsRead);
+    assert.ok(settingsWrite);
+
+    assert.equal(authority.selectTarget(LOCAL_KEY, 'epoch-2'), true);
+
+    assert.equal(authority.acceptsSettingsRead(settingsRead), false);
+    assert.equal(authority.acceptsConnectionsRead(connectionsRead), false);
+    assert.equal(authority.acceptsSettingsWrite(settingsWrite), false);
+    assert.equal(authority.isCurrentTarget(settingsWrite), false);
+  });
+
+  it('does not revoke tickets for a repeated observation of the same Host epoch', () => {
+    const authority = createSettingsRequestAuthority(LOCAL_KEY, 'epoch-1');
+    const settingsRead = authority.beginSettingsRead(LOCAL_KEY);
+    const settingsWrite = authority.beginSettingsWrite(LOCAL_KEY);
+    assert.ok(settingsRead);
+    assert.ok(settingsWrite);
+
+    assert.equal(authority.selectTarget(LOCAL_KEY, 'epoch-1'), false);
+
+    assert.equal(authority.acceptsSettingsRead(settingsRead), true);
+    assert.equal(authority.acceptsSettingsWrite(settingsWrite), true);
+  });
+
+  it('rejects an in-flight write while the same Host epoch reconnects', () => {
+    const authority = createSettingsRequestAuthority(LOCAL_KEY, 'epoch-1');
+    const settingsWrite = authority.beginSettingsWrite(LOCAL_KEY);
+    assert.ok(settingsWrite);
+
+    assert.equal(authority.selectTarget(undefined, 'epoch-1'), true);
+
+    assert.equal(authority.acceptsSettingsWrite(settingsWrite), false);
+    assert.equal(authority.isCurrentTarget(settingsWrite), false);
   });
 
   it('keeps only the latest mutation for one Host', () => {

--- a/apps/desktop/src/renderer/settings/data-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/data-settings-page.tsx
@@ -57,6 +57,8 @@ function summarizeImportResult(result: ConfigImportResult, copy: DataSettingsCop
 
 export function DataSettingsPage(props: {
   runtimeHostStatus: 'loading' | 'ready' | 'unavailable' | 'error';
+  runtimeHostTargetVerified: boolean;
+  runtimeHostErrorMessage?: string;
   onRetryRuntimeHost(): Promise<void>;
 }) {
   const host = useOptionalRuntimeHostSettingsTarget();
@@ -74,11 +76,11 @@ export function DataSettingsPage(props: {
   );
   const [importStrategy, setImportStrategy] = useState<'skip' | 'overwrite'>('skip');
   const [configBusy, setConfigBusy] = useState<null | 'export' | 'import'>(null);
-  const runtimeHostAvailable = host !== undefined && props.runtimeHostStatus === 'ready';
+  const runtimeHostAvailable = host !== undefined;
   const diagnosticTarget = host ? { profileId: host.profileId } : undefined;
 
   useEffect(() => {
-    if (!host) {
+    if (!host || !props.runtimeHostTargetVerified) {
       setInfo(null);
       setInfoError(null);
       return;
@@ -99,7 +101,7 @@ export function DataSettingsPage(props: {
     return () => {
       cancelled = true;
     };
-  }, [host, locale, toast]);
+  }, [host, locale, props.runtimeHostTargetVerified, toast]);
 
   async function runDataAction(action: string, run: () => Promise<void>) {
     if (!dataActionGuard.begin(action)) return;
@@ -118,7 +120,7 @@ export function DataSettingsPage(props: {
   const dataActionDisabled = Boolean(pendingDataAction);
 
   async function openWorkspace() {
-    if (!info) return;
+    if (!props.runtimeHostTargetVerified || !info || !host) return;
     await runDataAction('workspace:open', async () => {
       try {
         const result = await window.maka.app.openPath('workspace', undefined, host);
@@ -145,7 +147,7 @@ export function DataSettingsPage(props: {
   }
 
   async function copyPath() {
-    if (!info) return;
+    if (!props.runtimeHostTargetVerified || !info || !host) return;
     await runDataAction('workspace:path:copy', async () => {
       try {
         await navigator.clipboard.writeText(info.workspacePath);
@@ -179,7 +181,7 @@ export function DataSettingsPage(props: {
   }
 
   async function exportConfig() {
-    if (configBusy || !host) return;
+    if (!props.runtimeHostTargetVerified || configBusy || !host) return;
     const categories = [...selectedCategories];
     if (categories.length === 0) {
       toast.error(copy.selectCategory);
@@ -211,7 +213,7 @@ export function DataSettingsPage(props: {
   }
 
   async function importConfig() {
-    if (configBusy || !host) return;
+    if (!props.runtimeHostTargetVerified || configBusy || !host) return;
     setConfigBusy('import');
     try {
       const res = await window.maka.config.import({ strategy: importStrategy }, host);
@@ -237,12 +239,16 @@ export function DataSettingsPage(props: {
 
   return (
     <SettingsPage>
-      {!runtimeHostAvailable ? (
+      {props.runtimeHostStatus === 'error' ||
+      (!runtimeHostAvailable && props.runtimeHostStatus === 'unavailable') ? (
         <Banner
           status={props.runtimeHostStatus === 'error' ? 'error' : 'warning'}
-          title={props.runtimeHostStatus === 'loading'
-            ? sharedCopy.loading
+          title={props.runtimeHostStatus === 'error'
+            ? sharedCopy.settingsLoadFailed
             : sharedCopy.runtimeHostUnavailable}
+          description={props.runtimeHostStatus === 'error'
+            ? props.runtimeHostErrorMessage
+            : undefined}
           endContent={props.runtimeHostStatus === 'error' ? (
             <Button
               variant="secondary"
@@ -284,13 +290,13 @@ export function DataSettingsPage(props: {
         <Button
           variant="secondary"
           onClick={() => void openWorkspace()}
-          isDisabled={!info || dataActionDisabled}
+          isDisabled={!props.runtimeHostTargetVerified || !info || dataActionDisabled}
           label={isDataActionPending('workspace:open') ? copy.opening : copy.openWorkspace}
         />
         <Button
           variant="secondary"
           onClick={() => void copyPath()}
-          isDisabled={!info || dataActionDisabled}
+          isDisabled={!props.runtimeHostTargetVerified || !info || dataActionDisabled}
           label={isDataActionPending('workspace:path:copy') ? copy.copying : copy.copyPath}
         />
         <Button
@@ -369,11 +375,21 @@ export function DataSettingsPage(props: {
               screen reader had to re-read the button to notice. `configBusy`
               stays because it is the *cross-button* rule (one config operation
               at a time), which is not a thing a single control can know. */}
-          <Button variant="primary" isDisabled={configBusy !== null} clickAction={() => exportConfig()} label={copy.exportConfig} />
+          <Button
+            variant="primary"
+            isDisabled={!props.runtimeHostTargetVerified || configBusy !== null}
+            clickAction={() => exportConfig()}
+            label={copy.exportConfig}
+          />
           {/* One primary per action row: export is the action this section
               is titled after; import is the inverse operation and reads
               secondary. Two filled buttons recommended neither. */}
-          <Button variant="secondary" isDisabled={configBusy !== null} clickAction={() => importConfig()} label={copy.importConfig} />
+          <Button
+            variant="secondary"
+            isDisabled={!props.runtimeHostTargetVerified || configBusy !== null}
+            clickAction={() => importConfig()}
+            label={copy.importConfig}
+          />
         </SettingsActions>
       </SettingsSection> : null}
     </SettingsPage>

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -69,13 +69,19 @@ import {
   useOptionalRuntimeHostSettingsTarget,
   useRuntimeHostSettingsTarget,
 } from './runtime-host-settings-target.js';
+import type { SettingsResourceStatus } from './settings-resource-state.js';
+import { SettingsRowSkeleton } from './settings-skeleton.js';
 
 export function GeneralSettingsPage(props: {
   settings: AppSettings;
   connections: readonly LlmConnection[];
   defaultSlug: string | null;
   connectionsBridge: Pick<RuntimeHostSettingsConnectionsBridge, 'setDefaultModel'> | undefined;
-  runtimeHostStatus: 'loading' | 'ready' | 'unavailable' | 'error';
+  runtimeHostAvailabilityStatus: 'loading' | 'ready' | 'unavailable' | 'error';
+  runtimeHostCatalogStatus: SettingsResourceStatus;
+  runtimeHostSettingsStatus: SettingsResourceStatus;
+  runtimeHostConnectionsStatus: SettingsResourceStatus;
+  runtimeHostErrorMessage?: string;
   testNetworkProxy?(input: TestProxyInput): Promise<import('@maka/core/settings').SettingsTestResult>;
   onUpdate(
     patch: Parameters<typeof window.maka.settings.update>[0],
@@ -90,42 +96,94 @@ export function GeneralSettingsPage(props: {
   const sharedCopy = getSettingsSharedCopy(locale);
   const toast = useToast();
   const hostDiagnosticTarget = host ? { profileId: host.profileId } : undefined;
-  const runtimeHostAvailable =
-    host !== undefined &&
-    props.runtimeHostStatus === 'ready' &&
-    props.connectionsBridge !== undefined &&
-    props.testNetworkProxy !== undefined;
+  const runtimeHostSettingsAvailable =
+    props.runtimeHostSettingsStatus.hasSnapshot && props.testNetworkProxy !== undefined;
+  const runtimeHostConnectionsAvailable =
+    props.runtimeHostConnectionsStatus.hasSnapshot && props.connectionsBridge !== undefined;
+  const runtimeHostTargetVerified =
+    props.runtimeHostAvailabilityStatus === 'ready' &&
+    props.runtimeHostCatalogStatus.isVerified;
+  const runtimeHostSettingsInteractive =
+    runtimeHostSettingsAvailable &&
+    runtimeHostTargetVerified &&
+    props.runtimeHostSettingsStatus.isVerified;
+  const runtimeHostConnectionsInteractive =
+    runtimeHostConnectionsAvailable &&
+    runtimeHostTargetVerified &&
+    props.runtimeHostConnectionsStatus.isVerified;
+  const runtimeHostError =
+    props.runtimeHostCatalogStatus.phase === 'error' ||
+    props.runtimeHostSettingsStatus.phase === 'error' ||
+    props.runtimeHostConnectionsStatus.phase === 'error';
+  const runtimeHostLoading =
+    !runtimeHostError &&
+    props.runtimeHostAvailabilityStatus !== 'unavailable' &&
+    (props.runtimeHostAvailabilityStatus === 'loading' ||
+      !runtimeHostSettingsAvailable ||
+      !runtimeHostConnectionsAvailable ||
+      !props.runtimeHostCatalogStatus.isVerified ||
+      !props.runtimeHostSettingsStatus.isVerified ||
+      !props.runtimeHostConnectionsStatus.isVerified);
+  const showRuntimeHostContent =
+    props.runtimeHostAvailabilityStatus !== 'unavailable' &&
+    (props.runtimeHostAvailabilityStatus === 'loading' ||
+      props.runtimeHostAvailabilityStatus === 'ready' ||
+      runtimeHostSettingsAvailable ||
+      runtimeHostConnectionsAvailable);
+  const showRuntimeHostSettingsPlaceholder =
+    showRuntimeHostContent &&
+    !runtimeHostSettingsAvailable &&
+    (props.runtimeHostSettingsStatus.phase === 'idle' ||
+      props.runtimeHostSettingsStatus.phase === 'loading');
+  const showRuntimeHostConnectionsPlaceholder =
+    showRuntimeHostContent &&
+    !runtimeHostConnectionsAvailable &&
+    (props.runtimeHostConnectionsStatus.phase === 'idle' ||
+      props.runtimeHostConnectionsStatus.phase === 'loading');
+  const showRuntimeHostDefaults =
+    runtimeHostSettingsAvailable ||
+    runtimeHostConnectionsAvailable ||
+    showRuntimeHostSettingsPlaceholder ||
+    showRuntimeHostConnectionsPlaceholder;
   return (
     <SettingsPage>
-      {!runtimeHostAvailable ? (
+      {runtimeHostError ? (
         <Banner
-          status={props.runtimeHostStatus === 'error' ? 'error' : 'warning'}
-          title={props.runtimeHostStatus === 'loading'
-            ? sharedCopy.loading
-            : sharedCopy.runtimeHostUnavailable}
-          endContent={props.runtimeHostStatus === 'error' ? (
+          status="error"
+          title={sharedCopy.settingsLoadFailed}
+          description={props.runtimeHostErrorMessage}
+          endContent={(
             <Button
               variant="secondary"
               size="sm"
               label={sharedCopy.retry}
               onClick={() => void props.onRetryRuntimeHost()}
             />
-          ) : undefined}
+          )}
         />
+      ) : props.runtimeHostAvailabilityStatus === 'unavailable' ? (
+        <Banner status="warning" title={sharedCopy.runtimeHostUnavailable} />
+      ) : null}
+      {runtimeHostLoading && !runtimeHostError ? (
+        <span className="maka-visually-hidden" role="status" aria-live="polite">
+          {sharedCopy.loading}
+        </span>
       ) : null}
       {/* Designer audit P2-13: identity fields (显示名称/界面语言/语气偏好)
           moved here from the 外观 page — they configure who you are to the
           app, not how the app looks. The component keeps its save flow. */}
       <PersonalizationSettingsSection
         settings={props.settings}
-        runtimeHostAvailable={runtimeHostAvailable}
+        runtimeHostSettingsAvailable={runtimeHostSettingsAvailable}
+        runtimeHostSettingsInteractive={runtimeHostSettingsInteractive}
+        showRuntimeHostSettingsPlaceholder={showRuntimeHostSettingsPlaceholder}
         onUpdate={props.onUpdate}
       />
       <SettingsSection
         title={sections.privacy}
         description={sections.privacyHelp}
       >
-        {runtimeHostAvailable ? <SettingsRow
+        {runtimeHostSettingsAvailable ? <SettingsRow
           label={copy.incognito}
           description={copy.incognitoHelp}
           end={
@@ -133,6 +191,7 @@ export function GeneralSettingsPage(props: {
               label={copy.enableIncognito}
               isLabelHidden
               value={props.settings.privacy.incognitoActive}
+              isDisabled={!runtimeHostSettingsInteractive}
               changeAction={async (incognitoActive) => {
                 try {
                   await props.onUpdate({ privacy: { incognitoActive } });
@@ -147,7 +206,13 @@ export function GeneralSettingsPage(props: {
               }}
             />
           }
-        /> : null}
+        /> : showRuntimeHostSettingsPlaceholder ? (
+          <SettingsRowSkeleton
+            label={copy.incognito}
+            description={copy.incognitoHelp}
+            width="2.5rem"
+          />
+        ) : null}
         <SettingsRow
           label={copy.notifications}
           description={copy.notificationsHelp}
@@ -169,7 +234,7 @@ export function GeneralSettingsPage(props: {
             />
           }
         />
-        {runtimeHostAvailable ? <SettingsRow
+        {runtimeHostSettingsAvailable ? <SettingsRow
           label={copy.workspaceInstructions}
           description={copy.workspaceInstructionsHelp}
           end={
@@ -177,6 +242,7 @@ export function GeneralSettingsPage(props: {
               label={copy.workspaceInstructions}
               isLabelHidden
               value={props.settings.workspaceInstructions.enabled}
+              isDisabled={!runtimeHostSettingsInteractive}
               changeAction={async (enabled) => {
                 try {
                   await props.onUpdate({ workspaceInstructions: { enabled } });
@@ -191,7 +257,13 @@ export function GeneralSettingsPage(props: {
               }}
             />
           }
-        /> : null}
+        /> : showRuntimeHostSettingsPlaceholder ? (
+          <SettingsRowSkeleton
+            label={copy.workspaceInstructions}
+            description={copy.workspaceInstructionsHelp}
+            width="2.5rem"
+          />
+        ) : null}
         <SettingsRow
           label={copy.workHub}
           description={copy.workHubHelp}
@@ -211,26 +283,56 @@ export function GeneralSettingsPage(props: {
           }
         />
       </SettingsSection>
-      {runtimeHostAvailable ? (
+      {showRuntimeHostDefaults ? (
+        <GeneralDefaultsCard
+          connections={props.connections}
+          defaultSlug={props.defaultSlug}
+          connectionsBridge={props.connectionsBridge}
+          connectionsAvailable={runtimeHostConnectionsAvailable}
+          connectionsInteractive={runtimeHostConnectionsInteractive}
+          showConnectionsPlaceholder={showRuntimeHostConnectionsPlaceholder}
+          settingsAvailable={runtimeHostSettingsAvailable}
+          settingsInteractive={runtimeHostSettingsInteractive}
+          showSettingsPlaceholder={showRuntimeHostSettingsPlaceholder}
+          onRefresh={props.onRefreshConnections}
+          permissionMode={props.settings.chatDefaults.permissionMode}
+          thinkingLevel={props.settings.chatDefaults.thinkingLevel}
+          onUpdate={props.onUpdate}
+        />
+      ) : null}
+      {runtimeHostSettingsAvailable ? (
         <>
-          <GeneralDefaultsCard
-            connections={props.connections}
-            defaultSlug={props.defaultSlug}
-            connectionsBridge={props.connectionsBridge!}
-            onRefresh={props.onRefreshConnections}
-            permissionMode={props.settings.chatDefaults.permissionMode}
-            thinkingLevel={props.settings.chatDefaults.thinkingLevel}
+          <ShellSettingsSection
+            settings={props.settings}
+            isInteractive={runtimeHostSettingsInteractive}
             onUpdate={props.onUpdate}
           />
-          <ShellSettingsSection settings={props.settings} onUpdate={props.onUpdate} />
           <SettingsSection
             title={sections.network}
             description={sections.networkHelp}
           >
             <NetworkProxySection
               settings={props.settings}
+              isInteractive={runtimeHostSettingsInteractive}
               onUpdate={props.onUpdate}
               testNetworkProxy={props.testNetworkProxy!}
+            />
+          </SettingsSection>
+        </>
+      ) : showRuntimeHostSettingsPlaceholder ? (
+        <>
+          <SettingsSection title={sections.shell} description={sections.shellHelp}>
+            <SettingsRowSkeleton
+              label={copy.shellPreference}
+              description={copy.shellPreferenceHelp}
+              width="6rem"
+            />
+          </SettingsSection>
+          <SettingsSection title={sections.network} description={sections.networkHelp}>
+            <SettingsRowSkeleton
+              label={copy.proxy}
+              description={copy.proxyHelp}
+              width="6rem"
             />
           </SettingsSection>
         </>
@@ -243,6 +345,7 @@ const DEFAULT_GIT_BASH_EXECUTABLE = "C:\\Program Files\\Git\\bin\\bash.exe";
 
 function ShellSettingsSection(props: {
   settings: AppSettings;
+  isInteractive: boolean;
   onUpdate(
     patch: Parameters<typeof window.maka.settings.update>[0],
   ): Promise<UpdateAppSettingsResult>;
@@ -273,6 +376,7 @@ function ShellSettingsSection(props: {
     dirty && !saving && (preference === "auto" || normalizedExecutable.length > 0);
 
   async function save(): Promise<void> {
+    if (!props.isInteractive) return;
     if (!saveGuard.begin("save-shell")) return;
     setSaving(true);
     try {
@@ -310,7 +414,7 @@ function ShellSettingsSection(props: {
               { value: "auto", label: copy.shellAuto },
               { value: "git_bash", label: copy.shellGitBash },
             ]}
-            isDisabled={saving}
+            isDisabled={saving || !props.isInteractive}
             onChange={(value) => {
               const next = value as ShellPreference;
               setPreference(next);
@@ -330,14 +434,14 @@ function ShellSettingsSection(props: {
             description={copy.shellExecutableHelp}
             placeholder={DEFAULT_GIT_BASH_EXECUTABLE}
             width="100%"
-            isDisabled={saving}
+            isDisabled={saving || !props.isInteractive}
           />
         </SettingsField>
       ) : null}
       <SettingsActions>
         <Button
           variant="primary"
-          isDisabled={!canSave}
+          isDisabled={!canSave || !props.isInteractive}
           isLoading={saving}
           onClick={() => void save()}
           label={saving ? copy.savingShell : dirty ? copy.saveShell : copy.shellSaved}
@@ -380,7 +484,13 @@ const THINKING_LEVELS: readonly ThinkingLevel[] = ["off", "minimal", "low", "med
 function GeneralDefaultsCard(props: {
   connections: readonly LlmConnection[];
   defaultSlug: string | null;
-  connectionsBridge: Pick<RuntimeHostSettingsConnectionsBridge, 'setDefaultModel'>;
+  connectionsBridge: Pick<RuntimeHostSettingsConnectionsBridge, 'setDefaultModel'> | undefined;
+  connectionsAvailable: boolean;
+  connectionsInteractive: boolean;
+  showConnectionsPlaceholder: boolean;
+  settingsAvailable: boolean;
+  settingsInteractive: boolean;
+  showSettingsPlaceholder: boolean;
   onRefresh(): Promise<void>;
   permissionMode: ChatDefaultPermissionMode;
   thinkingLevel?: ThinkingLevel;
@@ -428,6 +538,7 @@ function GeneralDefaultsCard(props: {
       : "";
   }, [modelChoices, props.connections, props.defaultSlug]);
   async function persistDefault(nextValue: string) {
+    if (!props.connectionsBridge || !props.connectionsInteractive) return;
     const releaseSave = persistGuard.begin("default-model");
     if (!releaseSave) return;
     setSaving(true);
@@ -459,6 +570,7 @@ function GeneralDefaultsCard(props: {
   }
 
   async function persistPermissionMode(nextMode: ChatDefaultPermissionMode) {
+    if (!props.settingsInteractive) return;
     // Same re-entrancy guard as persistDefault above: the disabled trigger
     // alone can't fully prevent overlapping saves (React disables it a tick
     // after the click), and overlapping settings.update calls have no
@@ -509,6 +621,7 @@ function GeneralDefaultsCard(props: {
   }
 
   async function persistThinkingLevel(next: ThinkingLevel | undefined) {
+    if (!props.settingsInteractive) return;
     const releaseSave = persistGuard.begin("thinking-level");
     if (!releaseSave) return;
     setSavingThinkingLevel(true);
@@ -534,72 +647,97 @@ function GeneralDefaultsCard(props: {
       title={sections.chatDefaults}
       description={sections.chatDefaultsHelp}
     >
-      <SettingsRow
-        label={copy.defaultModel}
-        description={copy.defaultModelHelp}
-        end={
-          <ModelPicker
-            groups={modelGroups}
-            value={selectedValue}
-            leadingOption={{ value: "", label: copy.notSet }}
-            renderProviderMark={(type) => <ProviderBrandMark type={type} />}
-            ariaLabel={copy.defaultModel}
-            disabled={saving}
-            loading={saving}
-            triggerClassName="settingsModelPickerTrigger"
-            onValueChange={persistDefault}
-          />
-        }
-      />
-      <SettingsRow
-        label={copy.defaultPermission}
-        description={copy.defaultPermissionHelp}
-        end={
-          <PermissionModeSelect
-            activeMode={props.permissionMode}
-            onSelect={(mode) => {
-              void persistPermissionMode(mode);
-            }}
-            align="end"
-            disabled={savingPermissionMode}
-            ariaLabel={copy.defaultPermission}
-          />
-        }
-      />
+      {props.connectionsAvailable ? (
+        <SettingsRow
+          label={copy.defaultModel}
+          description={copy.defaultModelHelp}
+          end={
+            <ModelPicker
+              groups={modelGroups}
+              value={selectedValue}
+              leadingOption={{ value: "", label: copy.notSet }}
+              renderProviderMark={(type) => <ProviderBrandMark type={type} />}
+              ariaLabel={copy.defaultModel}
+              disabled={saving || !props.connectionsInteractive}
+              loading={saving}
+              triggerClassName="settingsModelPickerTrigger"
+              onValueChange={persistDefault}
+            />
+          }
+        />
+      ) : props.showConnectionsPlaceholder ? (
+        <SettingsRowSkeleton
+          label={copy.defaultModel}
+          description={copy.defaultModelHelp}
+          width="8rem"
+        />
+      ) : null}
+      {props.settingsAvailable ? (
+        <SettingsRow
+          label={copy.defaultPermission}
+          description={copy.defaultPermissionHelp}
+          end={
+            <PermissionModeSelect
+              activeMode={props.permissionMode}
+              onSelect={(mode) => {
+                void persistPermissionMode(mode);
+              }}
+              align="end"
+              disabled={savingPermissionMode || !props.settingsInteractive}
+              ariaLabel={copy.defaultPermission}
+            />
+          }
+        />
+      ) : props.showSettingsPlaceholder ? (
+        <SettingsRowSkeleton
+          label={copy.defaultPermission}
+          description={copy.defaultPermissionHelp}
+          width="7rem"
+        />
+      ) : null}
       {/* The absent option is first and means exactly that: no preference, so
           each model uses its own. It is not a level, which is why the composer
           menu now calls that same state 模型默认 rather than 默认 — the old
           wording promised a knob that did not exist anywhere. */}
-      <SettingsRow
-        label={copy.defaultThinking}
-        description={copy.defaultThinkingHelp}
-        end={
-          <Selector
-            label={copy.defaultThinking}
-            isLabelHidden
-            value={props.thinkingLevel ?? FOLLOW_MODEL_DEFAULT}
-            onChange={(value) => {
-              void persistThinkingLevel(
-                value === FOLLOW_MODEL_DEFAULT ? undefined : (value as ThinkingLevel),
-              );
-            }}
-            options={[
-              { value: FOLLOW_MODEL_DEFAULT, label: copy.followModelDefault },
-              ...THINKING_LEVELS.map((level) => ({
-                value: level,
-                label: conversationCopy.model.level[level],
-              })),
-            ]}
-            isDisabled={savingThinkingLevel}
-          />
-        }
-      />
+      {props.settingsAvailable ? (
+        <SettingsRow
+          label={copy.defaultThinking}
+          description={copy.defaultThinkingHelp}
+          end={
+            <Selector
+              label={copy.defaultThinking}
+              isLabelHidden
+              value={props.thinkingLevel ?? FOLLOW_MODEL_DEFAULT}
+              onChange={(value) => {
+                void persistThinkingLevel(
+                  value === FOLLOW_MODEL_DEFAULT ? undefined : (value as ThinkingLevel),
+                );
+              }}
+              options={[
+                { value: FOLLOW_MODEL_DEFAULT, label: copy.followModelDefault },
+                ...THINKING_LEVELS.map((level) => ({
+                  value: level,
+                  label: conversationCopy.model.level[level],
+                })),
+              ]}
+              isDisabled={savingThinkingLevel || !props.settingsInteractive}
+            />
+          }
+        />
+      ) : props.showSettingsPlaceholder ? (
+        <SettingsRowSkeleton
+          label={copy.defaultThinking}
+          description={copy.defaultThinkingHelp}
+          width="7rem"
+        />
+      ) : null}
     </SettingsSection>
   );
 }
 
 function NetworkProxySection(props: {
   settings: AppSettings;
+  isInteractive: boolean;
   testNetworkProxy(input: TestProxyInput): Promise<import('@maka/core/settings').SettingsTestResult>;
   onUpdate(
     patch: Parameters<typeof window.maka.settings.update>[0],
@@ -635,10 +773,12 @@ function NetworkProxySection(props: {
   );
 
   function updateProxy(patch: Partial<NetworkProxySettings>) {
+    if (!props.isInteractive) return Promise.resolve();
     return update(patch);
   }
 
   async function testProxy() {
+    if (!props.isInteractive) return;
     if (!proxyTestGuard.begin("test")) return;
     setTesting(true);
     try {
@@ -683,6 +823,7 @@ function NetworkProxySection(props: {
             label={copy.enableProxy}
             isLabelHidden
             value={proxyDraft.enabled}
+            isDisabled={!props.isInteractive}
             onChange={(enabled) => void updateProxy({ enabled })}
           />
         }
@@ -700,6 +841,7 @@ function NetworkProxySection(props: {
                   { value: "socks5", label: "SOCKS5" },
                 ]}
                 width="100%"
+                isDisabled={!props.isInteractive}
                 onChange={(protocol) =>
                   void updateProxy({
                     protocol: protocol as NetworkProxySettings["protocol"],
@@ -711,6 +853,7 @@ function NetworkProxySection(props: {
                 onChange={(value) => void updateProxy({ host: value })}
                 placeholder="127.0.0.1"
                 label={copy.serverAddress}
+                isDisabled={!props.isInteractive}
               />
               <NumberInput
                 label={copy.port}
@@ -718,6 +861,7 @@ function NetworkProxySection(props: {
                 isIntegerOnly
                 onChange={(value) => void updateProxy({ port: value ?? 0 })}
                 placeholder="7890"
+                isDisabled={!props.isInteractive}
               />
             </FormLayout>
           </SettingsField>
@@ -730,6 +874,7 @@ function NetworkProxySection(props: {
                 label={copy.enableProxyAuth}
                 isLabelHidden
                 value={proxyDraft.authEnabled}
+                isDisabled={!props.isInteractive}
                 onChange={(authEnabled) => void updateProxy({ authEnabled })}
               />
             }
@@ -742,11 +887,13 @@ function NetworkProxySection(props: {
                   value={proxyDraft.username}
                   onChange={(value) => void updateProxy({ username: value })}
                   label={copy.username}
+                  isDisabled={!props.isInteractive}
                 />
                 <PasswordInput
                   value={proxyDraft.password}
                   onChange={(next) => void updateProxy({ password: next })}
                   label={copy.password}
+                  isDisabled={!props.isInteractive}
                 />
               </FormLayout>
             </SettingsField>
@@ -762,6 +909,7 @@ function NetworkProxySection(props: {
               label={copy.bypassList}
               description={copy.bypassHelp}
               width="100%"
+              isDisabled={!props.isInteractive}
             />
           </SettingsField>
 
@@ -776,6 +924,7 @@ function NetworkProxySection(props: {
             <Button
               variant="primary"
               isLoading={testing}
+              isDisabled={!props.isInteractive}
               onClick={() => void testProxy()}
               label={copy.testCurrent}
             />

--- a/apps/desktop/src/renderer/settings/general-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/general-settings-page.tsx
@@ -498,7 +498,7 @@ function GeneralDefaultsCard(props: {
     patch: Parameters<typeof window.maka.settings.update>[0],
   ): Promise<UpdateAppSettingsResult>;
 }) {
-  const host = useRuntimeHostSettingsTarget();
+  const host = useOptionalRuntimeHostSettingsTarget();
   const locale = useUiLocale();
   const copy = getSettingsPreferencesCopy(locale).general;
   // Level names come from the composer's own map — one vocabulary for the
@@ -560,7 +560,7 @@ function GeneralDefaultsCard(props: {
           copy.saveDefaultModelFailed,
           settingsActionErrorMessage(error, locale),
           undefined,
-          { profileId: host.profileId },
+          host ? { profileId: host.profileId } : undefined,
         );
       }
     } finally {
@@ -611,7 +611,7 @@ function GeneralDefaultsCard(props: {
           copy.saveDefaultPermissionFailed,
           settingsActionErrorMessage(error, locale),
           undefined,
-          { profileId: host.profileId },
+          host ? { profileId: host.profileId } : undefined,
         );
       }
     } finally {
@@ -633,7 +633,7 @@ function GeneralDefaultsCard(props: {
           copy.saveDefaultThinkingFailed,
           settingsActionErrorMessage(error, locale),
           undefined,
-          { profileId: host.profileId },
+          host ? { profileId: host.profileId } : undefined,
         );
       }
     } finally {

--- a/apps/desktop/src/renderer/settings/personalization-settings-section.tsx
+++ b/apps/desktop/src/renderer/settings/personalization-settings-section.tsx
@@ -38,6 +38,7 @@ import { TextArea, TextInput, useMountedRef, useToast, useUiLocale } from '@maka
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { getSettingsPreferencesCopy } from '../locales/settings-preferences-copy.js';
 import { useOptionalRuntimeHostSettingsTarget } from './runtime-host-settings-target.js';
+import { SettingsRowSkeleton } from './settings-skeleton.js';
 
 // PR-TONE-AUTOSAVE-0: the personalization block used to be the page's ONLY
 // control with an explicit 保存 button + helper line — every neighboring row
@@ -50,7 +51,9 @@ import { useOptionalRuntimeHostSettingsTarget } from './runtime-host-settings-ta
 
 export function PersonalizationSettingsSection(props: {
   settings: AppSettings;
-  runtimeHostAvailable: boolean;
+  runtimeHostSettingsAvailable: boolean;
+  runtimeHostSettingsInteractive: boolean;
+  showRuntimeHostSettingsPlaceholder: boolean;
   onUpdate(patch: Parameters<typeof window.maka.settings.update>[0]): Promise<UpdateAppSettingsResult>;
 }) {
   const host = useOptionalRuntimeHostSettingsTarget();
@@ -116,6 +119,9 @@ export function PersonalizationSettingsSection(props: {
   // know, or a failed write collapses the row onto the old value and drops
   // the draft with only a toast to show for it.
   async function persistPersonalization(patch: Partial<PersonalizationSettings>): Promise<boolean> {
+    const updatesRuntimeHost =
+      patch.displayName !== undefined || patch.assistantTone !== undefined;
+    if (updatesRuntimeHost && !props.runtimeHostSettingsInteractive) return false;
     const ticket = ++persistTicketRef.current;
     const localeTicket = patch.uiLocale === undefined ? null : ++localePersistTicketRef.current;
     persistPendingCountRef.current += 1;
@@ -181,13 +187,14 @@ export function PersonalizationSettingsSection(props: {
           the user to fill in something already filled in, and its blur-save
           gave them no way to back out of a change. The row reports the
           settled value and opens on demand; Cancel puts the draft back. */}
-      {props.runtimeHostAvailable ? (
+      {props.runtimeHostSettingsAvailable ? (
         <SettingsExpandableRow
           label={copy.displayName}
           value={value.displayName || copy.displayNameUnset}
           actionLabel={value.displayName ? copy.displayNameChange : copy.displayNameSet}
           isEditing={expandedRow === 'displayName'}
           canSave={displayName.trim() !== value.displayName}
+          isDisabled={!props.runtimeHostSettingsInteractive}
           saveLabel={sharedCopy.save}
           cancelLabel={sharedCopy.cancel}
           onEdit={() => {
@@ -213,8 +220,15 @@ export function PersonalizationSettingsSection(props: {
             description={copy.displayNameHelp}
             isLabelHidden
             width="100%"
+            isDisabled={!props.runtimeHostSettingsInteractive}
           />
         </SettingsExpandableRow>
+      ) : props.showRuntimeHostSettingsPlaceholder ? (
+        <SettingsRowSkeleton
+          label={copy.displayName}
+          description={copy.displayNameHelp}
+          width="7rem"
+        />
       ) : null}
       {/*
         PR-LANG-PREF-0 (WAWQAQ msg `edc9cb41` + kenji `7e532892`
@@ -235,7 +249,7 @@ export function PersonalizationSettingsSection(props: {
           ))}
         </SegmentedControl>}
       />
-      {props.runtimeHostAvailable ? <SettingsField>
+      {props.runtimeHostSettingsAvailable ? <SettingsField>
         {/* No fixed height style: it lands as inline style on the wrapper,
             which pins the visible box while the inner textarea keeps its
             native `resize: vertical` — dragging then moves only the grip.
@@ -255,8 +269,16 @@ export function PersonalizationSettingsSection(props: {
           label={copy.assistantTone}
           description={copy.assistantToneHelp}
           width="100%"
+          isDisabled={!props.runtimeHostSettingsInteractive}
         />
-      </SettingsField> : null}
+      </SettingsField> : props.showRuntimeHostSettingsPlaceholder ? (
+        <SettingsRowSkeleton
+          label={copy.assistantTone}
+          description={copy.assistantToneHelp}
+          width="10rem"
+          height={42}
+        />
+      ) : null}
     </SettingsSection>
   );
 }

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -194,6 +194,12 @@ export function ProjectsSettingsPage(props: {
     await props.onUpdate({ projects: { defaultProjectId: projectId } });
   }
 
+  // `runtimeHostStatus` describes the selected target's current read/feedback
+  // state; it is not the write-authority predicate. A same-generation refresh
+  // may fail while the already verified target remains safe to use. Every
+  // project read and mutation is therefore fenced by
+  // `runtimeHostTargetVerified`, with the Host-owned subtree below providing
+  // the matching inert, busy, and muted presentation while authority is absent.
   if (!host) {
     return (
       <SettingsPage as="section" aria-label={copy.section}>

--- a/apps/desktop/src/renderer/settings/projects-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/projects-settings-page.tsx
@@ -43,6 +43,7 @@ import { useKeyedActionGuard } from './use-action-guard';
 import { useOptionalRuntimeHostSettingsTarget } from './runtime-host-settings-target.js';
 import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';
 import { RemoteProjectDirectoryDialog } from '../remote-project-directory-dialog.js';
+import { RuntimeHostInteractionBoundary } from './runtime-host-interaction-boundary.js';
 
 const NO_PROJECT_CAPABILITIES: DesktopProjectCapabilities = {
   chooseClientDirectory: false,
@@ -69,6 +70,8 @@ const NO_PROJECT_CAPABILITIES: DesktopProjectCapabilities = {
 export function ProjectsSettingsPage(props: {
   settings: AppSettings;
   runtimeHostStatus: 'loading' | 'ready' | 'unavailable' | 'error';
+  runtimeHostTargetVerified: boolean;
+  runtimeHostErrorMessage?: string;
   onUpdate(
     patch: Parameters<typeof window.maka.settings.update>[0],
   ): Promise<UpdateAppSettingsResult>;
@@ -93,17 +96,18 @@ export function ProjectsSettingsPage(props: {
   const reloadGeneration = useRef(0);
 
   const reload = useCallback(async () => {
-    if (!host) return;
+    if (!host || !props.runtimeHostTargetVerified) return;
     const generation = ++reloadGeneration.current;
     const snapshot = await window.maka.projects.getSnapshot(undefined, host);
     if (mountedRef.current && generation === reloadGeneration.current) {
       setProjects([...snapshot.projects]);
       setCapabilities(snapshot.capabilities);
     }
-  }, [host, mountedRef]);
+  }, [host, mountedRef, props.runtimeHostTargetVerified]);
 
   useEffect(() => {
-    if (!host) {
+    if (!host || !props.runtimeHostTargetVerified) {
+      reloadGeneration.current += 1;
       setProjects([]);
       setCapabilities(NO_PROJECT_CAPABILITIES);
       setHomePath(undefined);
@@ -151,6 +155,7 @@ export function ProjectsSettingsPage(props: {
     action: () => Promise<void>,
     failure: string,
   ) {
+    if (!props.runtimeHostTargetVerified) return;
     const release = actionGuard.begin(key);
     if (!release) return;
     try {
@@ -185,6 +190,7 @@ export function ProjectsSettingsPage(props: {
   }
 
   async function setDefault(projectId: string | undefined) {
+    if (!props.runtimeHostTargetVerified) return;
     await props.onUpdate({ projects: { defaultProjectId: projectId } });
   }
 
@@ -192,51 +198,75 @@ export function ProjectsSettingsPage(props: {
     return (
       <SettingsPage as="section" aria-label={copy.section}>
         <RuntimeHostProfilesSection onRemoteHostAdded={props.onRemoteHostAdded} />
-        <Banner
-          status={props.runtimeHostStatus === 'error' ? 'error' : 'warning'}
-          title={props.runtimeHostStatus === 'loading'
-            ? sharedCopy.loading
-            : sharedCopy.runtimeHostUnavailable}
-          endContent={props.runtimeHostStatus === 'error' ? (
-            <Button
-              variant="secondary"
-              size="sm"
-              label={sharedCopy.retry}
-              onClick={() => void props.onRetryRuntimeHost()}
-            />
-          ) : undefined}
-        />
+        {props.runtimeHostStatus !== 'loading' ? (
+          <Banner
+            status={props.runtimeHostStatus === 'error' ? 'error' : 'warning'}
+            title={props.runtimeHostStatus === 'error'
+              ? sharedCopy.settingsLoadFailed
+              : sharedCopy.runtimeHostUnavailable}
+            description={props.runtimeHostStatus === 'error'
+              ? props.runtimeHostErrorMessage
+              : undefined}
+            endContent={props.runtimeHostStatus === 'error' ? (
+              <Button
+                variant="secondary"
+                size="sm"
+                label={sharedCopy.retry}
+                onClick={() => void props.onRetryRuntimeHost()}
+              />
+            ) : undefined}
+          />
+        ) : null}
       </SettingsPage>
     );
   }
   return (
     <SettingsPage as="section" aria-label={copy.section}>
       <RuntimeHostProfilesSection onRemoteHostAdded={props.onRemoteHostAdded} />
-      {/* No section title: the page header already says 项目, and repeating it
-          straight above the rows is the same duplicate-heading noise we
-          removed from the skills page. The rule this page exists for lives in
-          the page subtitle; the section keeps only its action. */}
-      <SettingsSection
-        description={
-          defaultProjectId !== undefined && !defaultResolves
-            ? `${copy.sectionHelp} ${copy.defaultUnavailable}`
-            : copy.sectionHelp
-        }
-        action={capabilities.chooseClientDirectory || capabilities.chooseHostDirectory ? (
-          <Button
-            ref={directoryPickerTriggerRef}
-            variant="secondary"
-            size="sm"
-            label={copy.addProject}
-            clickAction={capabilities.chooseHostDirectory
-              ? () => setDirectoryPickerOpen(true)
-              : async () => {
-                  const result = await window.maka.projects.add(host);
-                  if (result.ok) await reload();
-                }}
-          />
-        ) : undefined}
-      >
+      {props.runtimeHostStatus === 'error' ? (
+        <Banner
+          status="error"
+          title={sharedCopy.settingsLoadFailed}
+          description={props.runtimeHostErrorMessage}
+          endContent={(
+            <Button
+              variant="secondary"
+              size="sm"
+              label={sharedCopy.retry}
+              onClick={() => void props.onRetryRuntimeHost()}
+            />
+          )}
+        />
+      ) : null}
+      <RuntimeHostInteractionBoundary isInteractive={props.runtimeHostTargetVerified}>
+        {/* No section title: the page header already says 项目, and repeating it
+            straight above the rows is the same duplicate-heading noise we
+            removed from the skills page. The rule this page exists for lives in
+            the page subtitle; the section keeps only its action. */}
+        <SettingsSection
+          description={
+            defaultProjectId !== undefined && !defaultResolves
+              ? `${copy.sectionHelp} ${copy.defaultUnavailable}`
+              : copy.sectionHelp
+          }
+          action={capabilities.chooseClientDirectory || capabilities.chooseHostDirectory ? (
+            <Button
+              ref={directoryPickerTriggerRef}
+              variant="secondary"
+              size="sm"
+              label={copy.addProject}
+              clickAction={capabilities.chooseHostDirectory
+                ? () => {
+                    if (props.runtimeHostTargetVerified) setDirectoryPickerOpen(true);
+                  }
+                : async () => {
+                    if (!props.runtimeHostTargetVerified) return;
+                    const result = await window.maka.projects.add(host);
+                    if (result.ok) await reload();
+                  }}
+            />
+          ) : undefined}
+        >
         {listed.length === 0 ? (
           <EmptyState icon={<FolderOpen size={ICON_SIZE.empty} />} title={copy.emptyTitle} description={copy.emptyBody} />
         ) : (
@@ -334,7 +364,7 @@ export function ProjectsSettingsPage(props: {
                                     cancelLabel: copy.removeCancel,
                                     destructive: true,
                                   });
-                                  if (!ok) return;
+                                  if (!ok || !mountedRef.current) return;
                                   await window.maka.projects.archive(project.id, host);
                                   // Removing the default leaves the preference
                                   // pointing at nothing; clear it in the same
@@ -447,16 +477,17 @@ export function ProjectsSettingsPage(props: {
             })}
           </List>)
         )}
-      </SettingsSection>
-      <RemoteProjectDirectoryDialog
-        host={directoryPickerOpen ? host : undefined}
-        returnFocusTo={directoryPickerTriggerRef.current}
-        onClose={() => setDirectoryPickerOpen(false)}
-        onRegistered={() => {
-          setDirectoryPickerOpen(false);
-          void reload();
-        }}
-      />
+        </SettingsSection>
+        <RemoteProjectDirectoryDialog
+          host={directoryPickerOpen && props.runtimeHostTargetVerified ? host : undefined}
+          returnFocusTo={directoryPickerTriggerRef.current}
+          onClose={() => setDirectoryPickerOpen(false)}
+          onRegistered={() => {
+            setDirectoryPickerOpen(false);
+            void reload();
+          }}
+        />
+      </RuntimeHostInteractionBoundary>
     </SettingsPage>
   );
 }

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -57,6 +57,7 @@ import { AddModelDialog } from './provider-add-model-dialog';
 import { EnabledModelManager } from './provider-enabled-model-manager';
 import { useActionGuard } from './use-action-guard';
 import {
+  RuntimeHostSettingsGenerationBoundary,
   useRuntimeHostSettingsErrorReporter,
   useRuntimeHostSettingsTarget,
 } from './runtime-host-settings-target.js';
@@ -994,6 +995,18 @@ function GitHubCopilotReloginNotice(props: {
 // token still reads hasSecret===true, so it must not hide behind
 // hasSecret===false.
 function OAuthReloginNotice(props: {
+  service: OAuthLoginService;
+  hasSecret: CredentialPresenceStatus;
+  onRelogin(): Promise<void>;
+}) {
+  return (
+    <RuntimeHostSettingsGenerationBoundary>
+      <OAuthReloginNoticeForCurrentGeneration {...props} />
+    </RuntimeHostSettingsGenerationBoundary>
+  );
+}
+
+function OAuthReloginNoticeForCurrentGeneration(props: {
   service: OAuthLoginService;
   hasSecret: CredentialPresenceStatus;
   onRelogin(): Promise<void>;

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -943,6 +943,17 @@ function GitHubCopilotReloginNotice(props: {
   hasSecret: CredentialPresenceStatus;
   onRelogin(): Promise<void>;
 }) {
+  return (
+    <RuntimeHostSettingsGenerationBoundary>
+      <GitHubCopilotReloginNoticeForCurrentGeneration {...props} />
+    </RuntimeHostSettingsGenerationBoundary>
+  );
+}
+
+function GitHubCopilotReloginNoticeForCurrentGeneration(props: {
+  hasSecret: CredentialPresenceStatus;
+  onRelogin(): Promise<void>;
+}) {
   const host = useRuntimeHostSettingsTarget();
   const locale = useUiLocale();
   const copy = getProviderSettingsCopy(locale).detail;
@@ -960,6 +971,10 @@ function GitHubCopilotReloginNotice(props: {
     if (!connectGuard.begin('connect')) return;
     try {
       const result = await window.maka.githubCopilotSubscription.connectExistingLogin(host);
+      // A same-key Runtime Host replacement remounts this controller through
+      // the generation boundary above. The old import cannot report into, or
+      // refresh, the connection detail now owned by the replacement Host.
+      if (!mountedRef.current) return;
       if (!result.ok) {
         reportHostError(copy.copilotImportFailed, result.message);
         return;

--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -35,7 +35,11 @@ import {
   type OAuthLoginFlowBridge,
   type SubscriptionSnapshot,
 } from './use-oauth-login-flow';
-import { useRuntimeHostSettingsTarget } from './runtime-host-settings-target.js';
+import {
+  RuntimeHostSettingsGenerationBoundary,
+  useRuntimeHostSettingsGenerationKey,
+  useRuntimeHostSettingsTarget,
+} from './runtime-host-settings-target.js';
 import { runtimeHostOAuthLoginBridge } from './runtime-host-settings-bridge.js';
 
 export type OAuthCardId = 'codex' | 'github-copilot' | 'xai';
@@ -49,6 +53,14 @@ export interface OAuthCard {
   /** A meaningful account state; routine availability stays in the description. */
   status?: string;
   isLoggedIn: boolean;
+}
+
+function emptyOAuthCardStates(): Record<OAuthCardId, SubscriptionSnapshot | null> {
+  return {
+    codex: null,
+    'github-copilot': null,
+    xai: null,
+  };
 }
 
 /**
@@ -66,6 +78,7 @@ export interface OAuthCard {
  */
 export function useOAuthCards(props: { query?: string }) {
   const host = useRuntimeHostSettingsTarget();
+  const generationKey = useRuntimeHostSettingsGenerationKey();
   const locale = useUiLocale();
   const copy = getProviderSettingsCopy(locale).oauthSection;
   const cards = modelOAuthCards(copy);
@@ -77,11 +90,7 @@ export function useOAuthCards(props: { query?: string }) {
   // carries a runtimeState + email so its row can show the account email inline,
   // re-fetched whenever a login step closes (success OR
   // cancel — the user may have signed out from inside it).
-  const [cardStates, setCardStates] = useState<Record<OAuthCardId, SubscriptionSnapshot | null>>({
-    codex: null,
-    'github-copilot': null,
-    xai: null,
-  });
+  const [cardStates, setCardStates] = useState(emptyOAuthCardStates);
   const [refreshError, setRefreshError] = useState<string | null>(null);
   const normalizedQuery = props.query?.trim().toLocaleLowerCase() ?? '';
 
@@ -130,11 +139,17 @@ export function useOAuthCards(props: { query?: string }) {
   }
 
   useEffect(() => {
+    // A same-key Host replacement keeps the catalog mounted to preserve its
+    // route, query, scroll, and focus. Retire only the account snapshots: the
+    // outer Settings fence may lift before these independent OAuth reads do,
+    // so the previous generation must never remain visible as current state.
+    setCardStates(emptyOAuthCardStates());
+    setRefreshError(null);
     void refreshAllCards();
     return () => {
       refreshTicketRef.current += 1;
     };
-  }, []);
+  }, [generationKey]);
 
   const visibleCards: OAuthCard[] = cards
     .filter(matchesQuery)
@@ -165,6 +180,17 @@ export function useOAuthCards(props: { query?: string }) {
  * level, the same ones the catalog and the connection detail use.
  */
 export function OAuthLoginPanel(props: { cardId: OAuthCardId; onLoginSuccess(): void | Promise<void> }) {
+  return (
+    <RuntimeHostSettingsGenerationBoundary>
+      <OAuthLoginPanelForCurrentGeneration {...props} />
+    </RuntimeHostSettingsGenerationBoundary>
+  );
+}
+
+function OAuthLoginPanelForCurrentGeneration(props: {
+  cardId: OAuthCardId;
+  onLoginSuccess(): void | Promise<void>;
+}) {
   if (props.cardId === 'github-copilot') {
     return <GitHubCopilotLoginPanel onLoginSuccess={props.onLoginSuccess} />;
   }

--- a/apps/desktop/src/renderer/settings/providers-panel.tsx
+++ b/apps/desktop/src/renderer/settings/providers-panel.tsx
@@ -87,7 +87,7 @@ function backTarget(route: PanelRoute): PanelRoute {
   return { kind: 'list' };
 }
 
-export function ProvidersPanel({ bridge, initialPage = 'connections', initialConnectionSlug, initialCreateProviderType, onInitialCreateProviderConsumed }: {
+export function ProvidersPanel({ bridge, initialPage = 'connections', initialConnectionSlug, initialCreateProviderType, onInitialCatalogConsumed, onInitialCreateProviderConsumed }: {
   bridge: ConnectionsBridge;
   initialPage?: 'connections' | 'catalog';
   /**
@@ -100,6 +100,8 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
    * onInitialCreateProviderConsumed.
    */
   initialCreateProviderType?: ProviderType;
+  /** Called once the catalog level has consumed the one-shot landing intent. */
+  onInitialCatalogConsumed?: () => void;
   /** Called once the setup level has been entered. */
   onInitialCreateProviderConsumed?: () => void;
 }) {
@@ -159,7 +161,8 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
     if (loading || initialPage !== 'catalog' || initialCatalogOpenedRef.current) return;
     initialCatalogOpenedRef.current = true;
     setRoute({ kind: 'catalog' });
-  }, [initialPage, loading]);
+    onInitialCatalogConsumed?.();
+  }, [initialPage, loading, onInitialCatalogConsumed]);
 
   const initialConnectionDetailOpenedRef = useRef(false);
   useEffect(() => {

--- a/apps/desktop/src/renderer/settings/runtime-host-interaction-boundary.tsx
+++ b/apps/desktop/src/renderer/settings/runtime-host-interaction-boundary.tsx
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ReactNode } from 'react';
+
+/**
+ * Keeps a last-known Runtime Host snapshot visible while preventing writes
+ * until the current Settings mount has verified that Host authority.
+ *
+ * `display: contents` makes this an interaction boundary only; it must not
+ * become a layout owner for the settings page it protects.
+ */
+export function RuntimeHostInteractionBoundary(props: {
+  isInteractive: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className="settingsRuntimeHostInteractionBoundary"
+      inert={props.isInteractive ? undefined : true}
+      aria-busy={props.isInteractive ? undefined : true}
+    >
+      {props.children}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/settings/runtime-host-settings-target.tsx
+++ b/apps/desktop/src/renderer/settings/runtime-host-settings-target.tsx
@@ -17,32 +17,76 @@
  * under the License.
  */
 
-import { createContext, useCallback, useContext, type ReactNode } from "react";
+import {
+  createContext,
+  Fragment,
+  useCallback,
+  useContext,
+  useMemo,
+  type ReactNode,
+} from "react";
 import { useToast } from "@maka/ui";
 import type { DesktopRuntimeHostRef } from "../../preload/bridge-contract.js";
 
+interface RuntimeHostSettingsTargetValue {
+  readonly host: DesktopRuntimeHostRef;
+  /**
+   * Changes when Desktop replaces the selected Host without changing its
+   * renderer-facing profileId:hostId pair. Host-owned sub-authorities use this
+   * key to retire their own async work without remounting the Settings page.
+   */
+  readonly generationKey: string;
+}
+
 const RuntimeHostSettingsTargetContext =
-  createContext<DesktopRuntimeHostRef | null>(null);
+  createContext<RuntimeHostSettingsTargetValue | null>(null);
 
 export function RuntimeHostSettingsTarget(props: {
   readonly host?: DesktopRuntimeHostRef;
+  readonly generation?: string;
   readonly children: ReactNode;
 }) {
+  const value = useMemo<RuntimeHostSettingsTargetValue | null>(() => {
+    if (!props.host) return null;
+    return {
+      host: props.host,
+      generationKey:
+        `${props.host.profileId}:${props.host.hostId}@${props.generation ?? "unversioned"}`,
+    };
+  }, [props.generation, props.host]);
   return (
-    <RuntimeHostSettingsTargetContext.Provider value={props.host ?? null}>
+    <RuntimeHostSettingsTargetContext.Provider value={value}>
       {props.children}
     </RuntimeHostSettingsTargetContext.Provider>
   );
 }
 
 export function useRuntimeHostSettingsTarget(): DesktopRuntimeHostRef {
-  const host = useContext(RuntimeHostSettingsTargetContext);
-  if (!host) throw new Error("Runtime Host Settings target is unavailable");
-  return host;
+  const target = useContext(RuntimeHostSettingsTargetContext);
+  if (!target) throw new Error("Runtime Host Settings target is unavailable");
+  return target.host;
 }
 
 export function useOptionalRuntimeHostSettingsTarget(): DesktopRuntimeHostRef | undefined {
-  return useContext(RuntimeHostSettingsTargetContext) ?? undefined;
+  return useContext(RuntimeHostSettingsTargetContext)?.host;
+}
+
+export function useRuntimeHostSettingsGenerationKey(): string {
+  const target = useContext(RuntimeHostSettingsTargetContext);
+  if (!target) throw new Error("Runtime Host Settings target is unavailable");
+  return target.generationKey;
+}
+
+/**
+ * Retires only the Host-owned controller below this boundary when the selected
+ * Runtime Host enters a new lifecycle generation. Parent route, draft, scroll,
+ * and focus state remain owned by their existing Settings components.
+ */
+export function RuntimeHostSettingsGenerationBoundary(props: {
+  readonly children: ReactNode;
+}) {
+  const generationKey = useRuntimeHostSettingsGenerationKey();
+  return <Fragment key={generationKey}>{props.children}</Fragment>;
 }
 
 export function useRuntimeHostSettingsErrorReporter() {

--- a/apps/desktop/src/renderer/settings/settings-request-authority.ts
+++ b/apps/desktop/src/renderer/settings/settings-request-authority.ts
@@ -19,31 +19,52 @@
 
 interface SettingsRequestTicket {
   readonly key: string;
-  readonly generation: number;
+  readonly targetEpoch: string | undefined;
+  readonly targetRevision: number;
+  readonly requestGeneration: number;
 }
 
 /**
  * Separates Runtime Host read refreshes from mutations while fencing both to
- * the currently selected Host epoch. Catalog refreshes may invalidate reads
- * without discarding a same-Host mutation that has already reached Desktop.
+ * the currently selected Host generation. Catalog refreshes may invalidate
+ * reads without discarding a same-generation mutation that has already reached
+ * Desktop, while a lifecycle epoch change invalidates every outstanding ticket
+ * even when the renderer-facing `profileId:hostId` key stays the same.
  */
-export function createSettingsRequestAuthority(initialKey?: string) {
+export function createSettingsRequestAuthority(
+  initialKey?: string,
+  initialTargetEpoch?: string,
+) {
   let targetKey = initialKey;
+  let targetEpoch = initialTargetEpoch;
+  let targetRevision = 0;
   let settingsReadGeneration = 0;
   let connectionsReadGeneration = 0;
   let settingsWriteGeneration = 0;
 
-  function ticket(key: string, generation: number): SettingsRequestTicket {
-    return { key, generation };
+  function ticket(key: string, requestGeneration: number): SettingsRequestTicket {
+    return { key, targetEpoch, targetRevision, requestGeneration };
+  }
+
+  function isCurrentTarget(candidate: SettingsRequestTicket): boolean {
+    return candidate.key === targetKey &&
+      candidate.targetEpoch === targetEpoch &&
+      candidate.targetRevision === targetRevision;
   }
 
   return {
-    selectTarget(nextKey: string | undefined): void {
-      if (targetKey === nextKey) return;
+    selectTarget(
+      nextKey: string | undefined,
+      nextTargetEpoch?: string,
+    ): boolean {
+      if (targetKey === nextKey && targetEpoch === nextTargetEpoch) return false;
       targetKey = nextKey;
+      targetEpoch = nextTargetEpoch;
+      targetRevision += 1;
       settingsReadGeneration += 1;
       connectionsReadGeneration += 1;
       settingsWriteGeneration += 1;
+      return true;
     },
 
     invalidateReads(): void {
@@ -58,8 +79,8 @@ export function createSettingsRequestAuthority(initialKey?: string) {
     },
 
     acceptsSettingsRead(candidate: SettingsRequestTicket): boolean {
-      return candidate.key === targetKey &&
-        candidate.generation === settingsReadGeneration;
+      return isCurrentTarget(candidate) &&
+        candidate.requestGeneration === settingsReadGeneration;
     },
 
     beginConnectionsRead(key: string): SettingsRequestTicket | undefined {
@@ -69,8 +90,8 @@ export function createSettingsRequestAuthority(initialKey?: string) {
     },
 
     acceptsConnectionsRead(candidate: SettingsRequestTicket): boolean {
-      return candidate.key === targetKey &&
-        candidate.generation === connectionsReadGeneration;
+      return isCurrentTarget(candidate) &&
+        candidate.requestGeneration === connectionsReadGeneration;
     },
 
     beginSettingsWrite(key: string): SettingsRequestTicket | undefined {
@@ -80,8 +101,10 @@ export function createSettingsRequestAuthority(initialKey?: string) {
     },
 
     acceptsSettingsWrite(candidate: SettingsRequestTicket): boolean {
-      return candidate.key === targetKey &&
-        candidate.generation === settingsWriteGeneration;
+      return isCurrentTarget(candidate) &&
+        candidate.requestGeneration === settingsWriteGeneration;
     },
+
+    isCurrentTarget,
   };
 }

--- a/apps/desktop/src/renderer/settings/settings-request-authority.ts
+++ b/apps/desktop/src/renderer/settings/settings-request-authority.ts
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+interface SettingsRequestTicket {
+  readonly key: string;
+  readonly generation: number;
+}
+
+/**
+ * Separates Runtime Host read refreshes from mutations while fencing both to
+ * the currently selected Host epoch. Catalog refreshes may invalidate reads
+ * without discarding a same-Host mutation that has already reached Desktop.
+ */
+export function createSettingsRequestAuthority(initialKey?: string) {
+  let targetKey = initialKey;
+  let settingsReadGeneration = 0;
+  let connectionsReadGeneration = 0;
+  let settingsWriteGeneration = 0;
+
+  function ticket(key: string, generation: number): SettingsRequestTicket {
+    return { key, generation };
+  }
+
+  return {
+    selectTarget(nextKey: string | undefined): void {
+      if (targetKey === nextKey) return;
+      targetKey = nextKey;
+      settingsReadGeneration += 1;
+      connectionsReadGeneration += 1;
+      settingsWriteGeneration += 1;
+    },
+
+    invalidateReads(): void {
+      settingsReadGeneration += 1;
+      connectionsReadGeneration += 1;
+    },
+
+    beginSettingsRead(key: string): SettingsRequestTicket | undefined {
+      if (key !== targetKey) return undefined;
+      settingsReadGeneration += 1;
+      return ticket(key, settingsReadGeneration);
+    },
+
+    acceptsSettingsRead(candidate: SettingsRequestTicket): boolean {
+      return candidate.key === targetKey &&
+        candidate.generation === settingsReadGeneration;
+    },
+
+    beginConnectionsRead(key: string): SettingsRequestTicket | undefined {
+      if (key !== targetKey) return undefined;
+      connectionsReadGeneration += 1;
+      return ticket(key, connectionsReadGeneration);
+    },
+
+    acceptsConnectionsRead(candidate: SettingsRequestTicket): boolean {
+      return candidate.key === targetKey &&
+        candidate.generation === connectionsReadGeneration;
+    },
+
+    beginSettingsWrite(key: string): SettingsRequestTicket | undefined {
+      if (key !== targetKey) return undefined;
+      settingsWriteGeneration += 1;
+      return ticket(key, settingsWriteGeneration);
+    },
+
+    acceptsSettingsWrite(candidate: SettingsRequestTicket): boolean {
+      return candidate.key === targetKey &&
+        candidate.generation === settingsWriteGeneration;
+    },
+  };
+}

--- a/apps/desktop/src/renderer/settings/settings-resource-state.ts
+++ b/apps/desktop/src/renderer/settings/settings-resource-state.ts
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type SettingsResourcePhase = 'idle' | 'loading' | 'ready' | 'error';
+
+/**
+ * A resource can keep a last-ready snapshot while a newer read is in flight
+ * or has failed. Keeping availability separate from the request phase lets
+ * Settings revalidate without replacing known values with defaults.
+ */
+export interface SettingsResourceState<T> {
+  readonly key?: string;
+  readonly snapshot?: T;
+  readonly phase: SettingsResourcePhase;
+  /** The current modal has confirmed this key with a successful read. */
+  readonly isVerified: boolean;
+  readonly message?: string;
+}
+
+export interface SettingsResourceStatus {
+  readonly phase: SettingsResourcePhase;
+  readonly hasSnapshot: boolean;
+  readonly isVerified: boolean;
+  readonly message?: string;
+}
+
+export function createSettingsResourceState<T>(
+  key?: string,
+  snapshot?: T,
+): SettingsResourceState<T> {
+  return {
+    key,
+    snapshot,
+    phase: snapshot === undefined ? 'idle' : 'loading',
+    isVerified: false,
+  };
+}
+
+export function beginSettingsResourceLoad<T>(
+  current: SettingsResourceState<T>,
+  key: string,
+  cachedSnapshot?: T,
+): SettingsResourceState<T> {
+  return {
+    key,
+    snapshot: current.key === key ? current.snapshot ?? cachedSnapshot : cachedSnapshot,
+    phase: 'loading',
+    isVerified: current.key === key && current.isVerified,
+  };
+}
+
+export function completeSettingsResourceLoad<T>(
+  key: string,
+  snapshot: T,
+): SettingsResourceState<T> {
+  return { key, snapshot, phase: 'ready', isVerified: true };
+}
+
+export function failSettingsResourceLoad<T>(
+  current: SettingsResourceState<T>,
+  key: string,
+  message: string,
+  cachedSnapshot?: T,
+): SettingsResourceState<T> {
+  return {
+    key,
+    snapshot: current.key === key ? current.snapshot ?? cachedSnapshot : cachedSnapshot,
+    phase: 'error',
+    isVerified: current.key === key && current.isVerified,
+    message,
+  };
+}
+
+export function settingsResourceSnapshot<T>(
+  state: SettingsResourceState<T>,
+  key: string | undefined,
+): T | undefined {
+  return key !== undefined && state.key === key ? state.snapshot : undefined;
+}
+
+export function settingsResourceStatus<T>(
+  state: SettingsResourceState<T>,
+  key: string | undefined,
+): SettingsResourceStatus {
+  if (key === undefined || state.key !== key) {
+    return { phase: 'idle', hasSnapshot: false, isVerified: false };
+  }
+  return {
+    phase: state.phase,
+    hasSnapshot: state.snapshot !== undefined,
+    isVerified: state.isVerified,
+    message: state.message,
+  };
+}
+
+export function reconcileRuntimeHostProfileSelection(options: {
+  currentProfileId: string | undefined;
+  defaultProfileId: string;
+  enabledProfileIds: readonly string[];
+  preserveCurrentSelection: boolean;
+}): string {
+  return options.preserveCurrentSelection &&
+    options.currentProfileId !== undefined &&
+    options.enabledProfileIds.includes(options.currentProfileId)
+    ? options.currentProfileId
+    : options.defaultProfileId;
+}

--- a/apps/desktop/src/renderer/settings/settings-resource-state.ts
+++ b/apps/desktop/src/renderer/settings/settings-resource-state.ts
@@ -52,6 +52,17 @@ export function createSettingsResourceState<T>(
   };
 }
 
+/**
+ * Keeps the last snapshot visible while revoking the authority established by
+ * an older Runtime Host generation. Ordinary same-generation refreshes use
+ * `beginSettingsResourceLoad` instead so they retain verified SWR semantics.
+ */
+export function invalidateSettingsResourceGeneration<T>(
+  current: SettingsResourceState<T>,
+): SettingsResourceState<T> {
+  return createSettingsResourceState(current.key, current.snapshot);
+}
+
 export function beginSettingsResourceLoad<T>(
   current: SettingsResourceState<T>,
   key: string,

--- a/apps/desktop/src/renderer/settings/settings-skeleton.tsx
+++ b/apps/desktop/src/renderer/settings/settings-skeleton.tsx
@@ -20,6 +20,8 @@
 import { Skeleton } from '@astryxdesign/core';
 import { useUiLocale } from '@maka/ui';
 import { getSettingsSharedCopy } from '../locales/settings-shared-copy.js';
+import type { ReactNode } from 'react';
+import { SettingsRow } from './settings-section.js';
 
 type SkeletonLine = { width: string; size?: 'lg' | 'sm' };
 
@@ -67,5 +69,33 @@ export function SettingsSkeleton() {
         <Skeleton width="48%" height={12} radius="rounded" index={5} />
       </div>
     </div>
+  );
+}
+
+/**
+ * Keeps a mixed-ownership page's row topology stable while one authority is
+ * still hydrating. The row copy remains readable; only the unknown control is
+ * represented by a neutral, non-interactive placeholder.
+ */
+export function SettingsRowSkeleton(props: {
+  label: ReactNode;
+  description?: ReactNode;
+  width?: string;
+  height?: number;
+}) {
+  return (
+    <SettingsRow
+      label={props.label}
+      description={props.description}
+      end={(
+        <span aria-hidden="true">
+          <Skeleton
+            width={props.width ?? '5.5rem'}
+            height={props.height ?? 28}
+            radius="rounded"
+          />
+        </span>
+      )}
+    />
   );
 }

--- a/apps/desktop/src/renderer/settings/settings-snapshot-cache.ts
+++ b/apps/desktop/src/renderer/settings/settings-snapshot-cache.ts
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { AppSettings } from '@maka/core/settings';
+import type { LlmConnection } from '@maka/core/llm-connections';
+import type {
+  DesktopRuntimeHostProfileSnapshot,
+  DesktopRuntimeHostRef,
+} from '../../preload/bridge-contract.js';
+
+export interface RuntimeHostConnectionsSnapshot {
+  readonly connections: LlmConnection[];
+  readonly defaultSlug: string | null;
+}
+
+export interface SettingsSnapshotCache {
+  readClient(): AppSettings | undefined;
+  commitClientRead(snapshot: AppSettings): void;
+
+  readRuntimeHostCatalog(): DesktopRuntimeHostProfileSnapshot | undefined;
+  commitRuntimeHostCatalogRead(snapshot: DesktopRuntimeHostProfileSnapshot): void;
+
+  readRuntimeHostSettings(key: string): AppSettings | undefined;
+  commitRuntimeHostSettingsRead(key: string, snapshot: AppSettings): void;
+
+  readRuntimeHostConnections(key: string): RuntimeHostConnectionsSnapshot | undefined;
+  commitRuntimeHostConnectionsRead(
+    key: string,
+    snapshot: RuntimeHostConnectionsSnapshot,
+  ): void;
+}
+
+export function runtimeHostSettingsKey(host: DesktopRuntimeHostRef): string {
+  return `${host.profileId}:${host.hostId}`;
+}
+
+/**
+ * Renderer-memory cache for masked read snapshots. It deliberately has no
+ * method that accepts a settings mutation response: update responses may
+ * reveal the just-submitted secret, while subsequent GETs are masked again.
+ */
+export function createSettingsSnapshotCache(): SettingsSnapshotCache {
+  let client: AppSettings | undefined;
+  let runtimeHostCatalog: DesktopRuntimeHostProfileSnapshot | undefined;
+  const runtimeHostSettings = new Map<string, AppSettings>();
+  const runtimeHostConnections = new Map<string, RuntimeHostConnectionsSnapshot>();
+
+  return {
+    readClient: () => client,
+    commitClientRead: (snapshot) => {
+      client = snapshot;
+    },
+    readRuntimeHostCatalog: () => runtimeHostCatalog,
+    commitRuntimeHostCatalogRead: (snapshot) => {
+      runtimeHostCatalog = snapshot;
+      const currentHostKeys = new Set(
+        snapshot.entries.flatMap((entry) =>
+          entry.hostId
+            ? [runtimeHostSettingsKey({ profileId: entry.profile.id, hostId: entry.hostId })]
+            : [],
+        ),
+      );
+      for (const key of runtimeHostSettings.keys()) {
+        if (!currentHostKeys.has(key)) runtimeHostSettings.delete(key);
+      }
+      for (const key of runtimeHostConnections.keys()) {
+        if (!currentHostKeys.has(key)) runtimeHostConnections.delete(key);
+      }
+    },
+    readRuntimeHostSettings: (key) => runtimeHostSettings.get(key),
+    commitRuntimeHostSettingsRead: (key, snapshot) => {
+      runtimeHostSettings.set(key, snapshot);
+    },
+    readRuntimeHostConnections: (key) => runtimeHostConnections.get(key),
+    commitRuntimeHostConnectionsRead: (key, snapshot) => {
+      runtimeHostConnections.set(key, snapshot);
+    },
+  };
+}
+
+const settingsSnapshotCaches = new WeakMap<object, SettingsSnapshotCache>();
+
+/**
+ * One cache per bridge identity survives Settings modal unmounts without
+ * moving Settings data into AppShell. Storybook and tests get isolated caches
+ * by installing distinct bridge objects.
+ */
+export function settingsSnapshotCacheFor(owner: object): SettingsSnapshotCache {
+  const existing = settingsSnapshotCaches.get(owner);
+  if (existing) return existing;
+  const cache = createSettingsSnapshotCache();
+  settingsSnapshotCaches.set(owner, cache);
+  return cache;
+}

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -17,7 +17,14 @@
  * under the License.
  */
 
-import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import {
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
 import {
   Badge,
   Button,
@@ -44,6 +51,7 @@ import type {
 } from '@maka/core/settings';
 import type { LlmConnection, ProviderType } from '@maka/core/llm-connections';
 import type {
+  DesktopRuntimeHostProfileChangedEvent,
   DesktopRuntimeHostProfileSnapshot,
   DesktopRuntimeHostRef,
   DesktopSessionSummary,
@@ -96,6 +104,7 @@ import {
   completeSettingsResourceLoad,
   createSettingsResourceState,
   failSettingsResourceLoad,
+  invalidateSettingsResourceGeneration,
   reconcileRuntimeHostProfileSelection,
   settingsResourceSnapshot,
   settingsResourceStatus,
@@ -119,9 +128,19 @@ type RuntimeHostAvailabilityStatus = 'loading' | 'ready' | 'unavailable' | 'erro
 function readyRuntimeHost(
   snapshot: DesktopRuntimeHostProfileSnapshot | undefined,
   profileId: string | undefined,
+  lifecycle?: DesktopRuntimeHostProfileChangedEvent,
 ): DesktopRuntimeHostRef | undefined {
   const entry = snapshot?.entries.find((candidate) => candidate.profile.id === profileId);
   if (entry?.readiness !== 'ready' || !entry.hostId) return undefined;
+  if (
+    lifecycle &&
+    (
+      lifecycle.removed === true ||
+      lifecycle.readiness !== 'ready' ||
+      !lifecycle.hostId ||
+      lifecycle.hostId !== entry.hostId
+    )
+  ) return undefined;
   return { profileId: entry.profile.id, hostId: entry.hostId };
 }
 
@@ -286,6 +305,12 @@ export function SettingsSurface(props: {
   const runtimeHostReloadTicketRef = useRef(0);
   const runtimeHostCatalogHydratedRef = useRef(false);
   const selectedProfileChangedByUserRef = useRef(false);
+  const runtimeHostLifecycleByProfileRef = useRef(
+    new Map<string, DesktopRuntimeHostProfileChangedEvent>(),
+  );
+  const [runtimeHostLifecycleByProfile, setRuntimeHostLifecycleByProfile] = useState(
+    runtimeHostLifecycleByProfileRef.current,
+  );
   const toast = useToast();
 
   const runtimeHosts = settingsResourceSnapshot(
@@ -301,8 +326,14 @@ export function SettingsSurface(props: {
     (entry) => entry.profile.id === selectedProfileId,
   );
   const selectedRuntimeHost = useMemo(
-    () => readyRuntimeHost(runtimeHosts, selectedProfileId),
-    [runtimeHosts, selectedProfileId],
+    () => readyRuntimeHost(
+      runtimeHosts,
+      selectedProfileId,
+      selectedProfileId
+        ? runtimeHostLifecycleByProfile.get(selectedProfileId)
+        : undefined,
+    ),
+    [runtimeHostLifecycleByProfile, runtimeHosts, selectedProfileId],
   );
   const connectionsBridge = useMemo(
     () => selectedRuntimeHost
@@ -317,11 +348,15 @@ export function SettingsSurface(props: {
     profileId: string,
     snapshot = runtimeHosts,
   ): void {
-    const nextHost = readyRuntimeHost(snapshot, profileId);
+    const lifecycle = runtimeHostLifecycleByProfileRef.current.get(profileId);
+    const nextHost = readyRuntimeHost(snapshot, profileId, lifecycle);
     const nextKey = nextHost ? runtimeHostSettingsKey(nextHost) : undefined;
     // Reject old-Host reads and writes synchronously with the authority
     // change, before React renders the newly selected profile.
-    runtimeHostRequestAuthority.selectTarget(nextKey);
+    runtimeHostRequestAuthority.selectTarget(
+      nextKey,
+      lifecycle?.epoch,
+    );
     selectedProfileIdRef.current = profileId;
     setSelectedProfileId(profileId);
   }
@@ -529,6 +564,9 @@ export function SettingsSurface(props: {
       const result = host
         ? await window.maka.settings.update(patch, host)
         : await window.maka.settings.updateClient(patch);
+      if (hostTicket && !runtimeHostRequestAuthority.isCurrentTarget(hostTicket)) {
+        throw new Error(copy.runtimeHostUnavailable);
+      }
       props.uiLocaleUpdateGate.commit(
         uiLocaleTicket,
         result.settings.personalization.uiLocale,
@@ -623,11 +661,41 @@ export function SettingsSurface(props: {
     }
   }
 
+  const handleRuntimeHostProfileChange = useEffectEvent(
+    (event: DesktopRuntimeHostProfileChangedEvent) => {
+      // Retain removed/unavailable events as tombstones until a newer event for
+      // the profile arrives. Otherwise selecting that profile while the
+      // catalog refresh is pending could revive its last-ready snapshot.
+      const nextLifecycleByProfile = new Map(
+        runtimeHostLifecycleByProfileRef.current,
+      );
+      nextLifecycleByProfile.set(event.profileId, event);
+      runtimeHostLifecycleByProfileRef.current = nextLifecycleByProfile;
+      setRuntimeHostLifecycleByProfile(nextLifecycleByProfile);
+      if (selectedProfileIdRef.current === event.profileId) {
+        const nextHost = readyRuntimeHost(runtimeHosts, event.profileId, event);
+        const targetChanged = runtimeHostRequestAuthority.selectTarget(
+          nextHost ? runtimeHostSettingsKey(nextHost) : undefined,
+          event.epoch,
+        );
+        if (targetChanged) {
+          // Fence synchronously, before the catalog refresh can resolve. The
+          // previous generation's snapshots stay visible but no Host-backed
+          // control may treat them as current write authority.
+          setRuntimeHostCatalog(invalidateSettingsResourceGeneration);
+          setRuntimeHostSettings(invalidateSettingsResourceGeneration);
+          setRuntimeHostConnections(invalidateSettingsResourceGeneration);
+        }
+      }
+      void reloadRuntimeHosts().catch(() => undefined);
+    },
+  );
+
   useEffect(() => {
     let disposed = false;
-    const unsubscribe = window.maka.runtimeHostProfiles.subscribeChanges(() => {
-      void reloadRuntimeHosts().catch(() => undefined);
-    });
+    const unsubscribe = window.maka.runtimeHostProfiles.subscribeChanges(
+      handleRuntimeHostProfileChange,
+    );
     void reloadRuntimeHosts().catch((error) => {
       if (!disposed) {
         toast.error(copy.settingsLoadFailed, settingsActionErrorMessage(error, locale));

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -91,38 +91,38 @@ import {
   projectClientOwnedSettings,
 } from '../../shared/settings-ownership.js';
 import { RuntimeHostSettingsTarget } from './runtime-host-settings-target.js';
+import {
+  beginSettingsResourceLoad,
+  completeSettingsResourceLoad,
+  createSettingsResourceState,
+  failSettingsResourceLoad,
+  reconcileRuntimeHostProfileSelection,
+  settingsResourceSnapshot,
+  settingsResourceStatus,
+  type SettingsResourceState,
+  type SettingsResourceStatus,
+} from './settings-resource-state.js';
+import {
+  runtimeHostSettingsKey,
+  settingsSnapshotCacheFor,
+  type RuntimeHostConnectionsSnapshot,
+  type SettingsSnapshotCache,
+} from './settings-snapshot-cache.js';
+import { RuntimeHostInteractionBoundary } from './runtime-host-interaction-boundary.js';
+import { createSettingsRequestAuthority } from './settings-request-authority.js';
 
 const NARROW_SETTINGS_QUERY = '(max-width: 760px)';
+const RUNTIME_HOST_CATALOG_KEY = 'runtime-host-catalog';
 
-type ResourceState<T> =
-  | { status: 'idle' }
-  | { status: 'loading'; key: string }
-  | { status: 'ready'; key: string; value: T }
-  | { status: 'error'; key: string; message: string };
+type RuntimeHostAvailabilityStatus = 'loading' | 'ready' | 'unavailable' | 'error';
 
-type RuntimeHostCatalogState =
-  | { status: 'loading' }
-  | { status: 'ready'; snapshot: DesktopRuntimeHostProfileSnapshot }
-  | { status: 'error'; message: string };
-
-function beginResourceLoad<T>(current: ResourceState<T>, key: string): ResourceState<T> {
-  return current.status === 'ready' && current.key === key
-    ? current
-    : { status: 'loading', key };
-}
-
-function failResourceLoad<T>(
-  current: ResourceState<T>,
-  key: string,
-  message: string,
-): ResourceState<T> {
-  return current.status === 'ready' && current.key === key
-    ? current
-    : { status: 'error', key, message };
-}
-
-function runtimeHostKey(host: DesktopRuntimeHostRef): string {
-  return `${host.profileId}:${host.hostId}`;
+function readyRuntimeHost(
+  snapshot: DesktopRuntimeHostProfileSnapshot | undefined,
+  profileId: string | undefined,
+): DesktopRuntimeHostRef | undefined {
+  const entry = snapshot?.entries.find((candidate) => candidate.profile.id === profileId);
+  if (entry?.readiness !== 'ready' || !entry.hostId) return undefined;
+  return { profileId: entry.profile.id, hostId: entry.hostId };
 }
 
 export function SettingsSurface(props: {
@@ -147,6 +147,7 @@ export function SettingsSurface(props: {
   onTaskImported(session: DesktopSessionSummary): void;
   onRemoteHostAdded(profileId: string): void;
   onSelectedRuntimeHostProfileIdChange(profileId: string | undefined): void;
+  snapshotCache?: SettingsSnapshotCache;
 }) {
   const locale = useUiLocale();
   const copy = getSettingsSharedCopy(locale);
@@ -220,48 +221,89 @@ export function SettingsSurface(props: {
     safeLocalStorageSet('maka-settings-section-v1', section);
   }, [section]);
   const defaultSettings = useMemo(() => createDefaultSettings(), []);
-  const [clientSettings, setClientSettings] = useState(defaultSettings);
-  const [runtimeHostSettings, setRuntimeHostSettings] = useState<ResourceState<AppSettings>>({
-    status: 'idle',
-  });
+  const snapshotCache = useMemo(
+    () => props.snapshotCache ?? settingsSnapshotCacheFor(window.maka),
+    [props.snapshotCache],
+  );
+  const initialClientSettings = useMemo(
+    () => snapshotCache.readClient(),
+    [snapshotCache],
+  );
+  const initialRuntimeHostCatalog = useMemo(
+    () => snapshotCache.readRuntimeHostCatalog(),
+    [snapshotCache],
+  );
+  const initialRuntimeHost = useMemo(
+    () => readyRuntimeHost(
+      initialRuntimeHostCatalog,
+      initialRuntimeHostCatalog?.defaultProfileId,
+    ),
+    [initialRuntimeHostCatalog],
+  );
+  const initialRuntimeHostKey = initialRuntimeHost
+    ? runtimeHostSettingsKey(initialRuntimeHost)
+    : undefined;
+  const [clientSettings, setClientSettings] = useState(
+    initialClientSettings ?? defaultSettings,
+  );
+  const [runtimeHostSettings, setRuntimeHostSettings] = useState<
+    SettingsResourceState<AppSettings>
+  >(() => createSettingsResourceState(
+    initialRuntimeHostKey,
+    initialRuntimeHostKey
+      ? snapshotCache.readRuntimeHostSettings(initialRuntimeHostKey)
+      : undefined,
+  ));
   const [runtimeHostConnections, setRuntimeHostConnections] = useState<
-    ResourceState<{ connections: LlmConnection[]; defaultSlug: string | null }>
-  >({ status: 'idle' });
-  const [runtimeHostCatalog, setRuntimeHostCatalog] = useState<RuntimeHostCatalogState>({
-    status: 'loading',
-  });
-  const [selectedProfileId, setSelectedProfileId] = useState<string>();
+    SettingsResourceState<RuntimeHostConnectionsSnapshot>
+  >(() => createSettingsResourceState(
+    initialRuntimeHostKey,
+    initialRuntimeHostKey
+      ? snapshotCache.readRuntimeHostConnections(initialRuntimeHostKey)
+      : undefined,
+  ));
+  const [runtimeHostCatalog, setRuntimeHostCatalog] = useState<
+    SettingsResourceState<DesktopRuntimeHostProfileSnapshot>
+  >(() => createSettingsResourceState(
+    RUNTIME_HOST_CATALOG_KEY,
+    initialRuntimeHostCatalog,
+  ));
+  const [selectedProfileId, setSelectedProfileId] = useState<string | undefined>(
+    initialRuntimeHostCatalog?.defaultProfileId,
+  );
+  const selectedProfileIdRef = useRef(selectedProfileId);
+  const defaultRuntimeHostProfileIdRef = useRef(
+    initialRuntimeHostCatalog?.defaultProfileId,
+  );
   const [usageStats, setUsageStats] = useState<UsageStats | null>(null);
-  const [clientLoading, setClientLoading] = useState(true);
+  const [clientLoading, setClientLoading] = useState(initialClientSettings === undefined);
   const settingsModalMountedRef = useMountedRef();
   const clientSettingsTicketRef = useRef(0);
-  const runtimeHostSettingsTicketRef = useRef(0);
-  const runtimeHostConnectionsTicketRef = useRef(0);
+  const [runtimeHostRequestAuthority] = useState(
+    () => createSettingsRequestAuthority(initialRuntimeHostKey),
+  );
   const usageReloadTicketRef = useRef(0);
   const runtimeHostReloadTicketRef = useRef(0);
+  const runtimeHostCatalogHydratedRef = useRef(false);
+  const selectedProfileChangedByUserRef = useRef(false);
   const toast = useToast();
 
-  const runtimeHosts = runtimeHostCatalog.status === 'ready'
-    ? runtimeHostCatalog.snapshot
-    : undefined;
+  const runtimeHosts = settingsResourceSnapshot(
+    runtimeHostCatalog,
+    RUNTIME_HOST_CATALOG_KEY,
+  );
+  const runtimeHostCatalogStatus = settingsResourceStatus(
+    runtimeHostCatalog,
+    RUNTIME_HOST_CATALOG_KEY,
+  );
 
   const selectedRuntimeHostEntry = runtimeHosts?.entries.find(
     (entry) => entry.profile.id === selectedProfileId,
   );
-  const selectedRuntimeHost = useMemo<DesktopRuntimeHostRef | undefined>(() => {
-    if (
-      selectedRuntimeHostEntry?.readiness !== 'ready' ||
-      !selectedRuntimeHostEntry.hostId
-    ) return undefined;
-    return {
-      profileId: selectedRuntimeHostEntry.profile.id,
-      hostId: selectedRuntimeHostEntry.hostId,
-    };
-  }, [
-    selectedRuntimeHostEntry?.hostId,
-    selectedRuntimeHostEntry?.profile.id,
-    selectedRuntimeHostEntry?.readiness,
-  ]);
+  const selectedRuntimeHost = useMemo(
+    () => readyRuntimeHost(runtimeHosts, selectedProfileId),
+    [runtimeHosts, selectedProfileId],
+  );
   const connectionsBridge = useMemo(
     () => selectedRuntimeHost
       ? runtimeHostConnectionsBridge(selectedRuntimeHost)
@@ -269,22 +311,36 @@ export function SettingsSurface(props: {
     [selectedRuntimeHost],
   );
   const selectedRuntimeHostKey = selectedRuntimeHost
-    ? runtimeHostKey(selectedRuntimeHost)
+    ? runtimeHostSettingsKey(selectedRuntimeHost)
     : undefined;
-  const selectedRuntimeHostKeyRef = useRef(selectedRuntimeHostKey);
-  selectedRuntimeHostKeyRef.current = selectedRuntimeHostKey;
-  const selectedRuntimeHostSettings =
-    selectedRuntimeHostKey &&
-    runtimeHostSettings.status === 'ready' &&
-    runtimeHostSettings.key === selectedRuntimeHostKey
-      ? runtimeHostSettings.value
-      : undefined;
-  const selectedConnections =
-    selectedRuntimeHostKey &&
-    runtimeHostConnections.status === 'ready' &&
-    runtimeHostConnections.key === selectedRuntimeHostKey
-      ? runtimeHostConnections.value
-      : undefined;
+  function commitSelectedRuntimeHostProfile(
+    profileId: string,
+    snapshot = runtimeHosts,
+  ): void {
+    const nextHost = readyRuntimeHost(snapshot, profileId);
+    const nextKey = nextHost ? runtimeHostSettingsKey(nextHost) : undefined;
+    // Reject old-Host reads and writes synchronously with the authority
+    // change, before React renders the newly selected profile.
+    runtimeHostRequestAuthority.selectTarget(nextKey);
+    selectedProfileIdRef.current = profileId;
+    setSelectedProfileId(profileId);
+  }
+  const selectedRuntimeHostSettings = settingsResourceSnapshot(
+    runtimeHostSettings,
+    selectedRuntimeHostKey,
+  );
+  const selectedConnections = settingsResourceSnapshot(
+    runtimeHostConnections,
+    selectedRuntimeHostKey,
+  );
+  const selectedRuntimeHostSettingsStatus = settingsResourceStatus(
+    runtimeHostSettings,
+    selectedRuntimeHostKey,
+  );
+  const selectedRuntimeHostConnectionsStatus = settingsResourceStatus(
+    runtimeHostConnections,
+    selectedRuntimeHostKey,
+  );
   const settings = useMemo(
     () => projectClientOwnedSettings(
       selectedRuntimeHostSettings ?? defaultSettings,
@@ -303,86 +359,94 @@ export function SettingsSurface(props: {
     );
     return () => props.onSelectedRuntimeHostProfileIdChange(undefined);
   }, [props.onSelectedRuntimeHostProfileIdChange, selectedProfileId, showsRuntimeHost]);
-  const runtimeHostCatalogFailed = runtimeHostCatalog.status === 'error';
-  const runtimeHostSettingsLoading = Boolean(
-    selectedRuntimeHostKey &&
-    !(
-      (runtimeHostSettings.status === 'ready' || runtimeHostSettings.status === 'error') &&
-      runtimeHostSettings.key === selectedRuntimeHostKey
-    ),
-  );
-  const runtimeHostConnectionsLoading = Boolean(
-    selectedRuntimeHostKey &&
-    !(
-      (runtimeHostConnections.status === 'ready' ||
-        runtimeHostConnections.status === 'error') &&
-      runtimeHostConnections.key === selectedRuntimeHostKey
-    ),
-  );
   const sectionNeedsSettings = ['general', 'subagents', 'memory', 'search'].includes(section);
   const sectionNeedsConnections = ['general', 'subagents', 'daily-review'].includes(section);
+  const runtimeHostAvailabilityStatus: RuntimeHostAvailabilityStatus =
+    selectedRuntimeHost
+      ? 'ready'
+      : runtimeHostCatalogStatus.phase === 'error'
+        ? 'error'
+        : runtimeHostCatalogStatus.phase === 'idle' ||
+            runtimeHostCatalogStatus.phase === 'loading' ||
+            selectedRuntimeHostEntry?.readiness === 'connecting' ||
+            selectedRuntimeHostEntry?.readiness === 'reconnecting'
+          ? 'loading'
+          : 'unavailable';
   const runtimeHostDataLoading =
-    (sectionNeedsSettings && runtimeHostSettingsLoading) ||
-    (sectionNeedsConnections && runtimeHostConnectionsLoading);
-  const runtimeHostDataFailed = Boolean(
-    selectedRuntimeHostKey &&
-    ((sectionNeedsSettings &&
-      runtimeHostSettings.status === 'error' &&
-      runtimeHostSettings.key === selectedRuntimeHostKey) ||
-      (sectionNeedsConnections &&
-        runtimeHostConnections.status === 'error' &&
-        runtimeHostConnections.key === selectedRuntimeHostKey)),
-  );
+    (sectionNeedsSettings && !selectedRuntimeHostSettingsStatus.hasSnapshot) ||
+    (sectionNeedsConnections && !selectedRuntimeHostConnectionsStatus.hasSnapshot);
+  const runtimeHostDataFailed =
+    (sectionNeedsSettings && selectedRuntimeHostSettingsStatus.phase === 'error') ||
+    (sectionNeedsConnections && selectedRuntimeHostConnectionsStatus.phase === 'error');
   const runtimeHostContentReady = Boolean(
     selectedRuntimeHost &&
     (!sectionNeedsSettings || selectedRuntimeHostSettings) &&
     (!sectionNeedsConnections || selectedConnections),
   );
   const runtimeHostContentStatus: 'loading' | 'ready' | 'unavailable' | 'error' =
-    runtimeHostCatalog.status === 'loading'
-      ? 'loading'
-      : runtimeHostCatalogFailed || runtimeHostDataFailed
+    runtimeHostCatalogStatus.phase === 'error' || runtimeHostDataFailed
       ? 'error'
-      : !selectedRuntimeHost
-        ? selectedRuntimeHostEntry?.readiness === 'connecting' ||
-          selectedRuntimeHostEntry?.readiness === 'reconnecting'
-          ? 'loading'
-          : 'unavailable'
+      : runtimeHostAvailabilityStatus !== 'ready'
+        ? runtimeHostAvailabilityStatus
         : runtimeHostDataLoading || !runtimeHostContentReady
           ? 'loading'
           : 'ready';
+  const runtimeHostContentVerified =
+    runtimeHostCatalogStatus.isVerified &&
+    (!sectionNeedsSettings || selectedRuntimeHostSettingsStatus.isVerified) &&
+    (!sectionNeedsConnections || selectedRuntimeHostConnectionsStatus.isVerified);
+  const runtimeHostTargetVerified = Boolean(
+    selectedRuntimeHost && runtimeHostCatalogStatus.isVerified,
+  );
+  const runtimeHostTargetStatus: RuntimeHostAvailabilityStatus =
+    runtimeHostCatalogStatus.phase === 'error'
+      ? 'error'
+      : !selectedRuntimeHost
+        ? runtimeHostAvailabilityStatus
+        : runtimeHostTargetVerified
+          ? 'ready'
+          : 'loading';
+  const runtimeHostErrorMessage =
+    runtimeHostCatalogStatus.message ??
+    selectedRuntimeHostSettingsStatus.message ??
+    selectedRuntimeHostConnectionsStatus.message;
   const loading =
     clientLoading ||
-    (requiresRuntimeHost && runtimeHostContentStatus === 'loading');
-
-  useEffect(() => {
-    if (!loading && section === 'models' && providerCatalogRequested) {
-      setProviderCatalogRequested(false);
-    }
-  }, [loading, providerCatalogRequested, section]);
+    (requiresRuntimeHost &&
+      !runtimeHostContentReady &&
+      runtimeHostContentStatus === 'loading');
 
   async function reloadRuntimeHostSettings(host = selectedRuntimeHost) {
     if (!host) return;
-    const key = runtimeHostKey(host);
-    const ticket = ++runtimeHostSettingsTicketRef.current;
-    setRuntimeHostSettings((current) => beginResourceLoad(current, key));
+    const key = runtimeHostSettingsKey(host);
+    const ticket = runtimeHostRequestAuthority.beginSettingsRead(key);
+    if (!ticket) return;
+    setRuntimeHostSettings((current) => beginSettingsResourceLoad(
+      current,
+      key,
+      snapshotCache.readRuntimeHostSettings(key),
+    ));
     try {
       const next = await window.maka.settings.get(host);
       if (
         settingsModalMountedRef.current &&
-        ticket === runtimeHostSettingsTicketRef.current &&
-        selectedRuntimeHostKeyRef.current === key
+        runtimeHostRequestAuthority.acceptsSettingsRead(ticket)
       ) {
-        setRuntimeHostSettings({ status: 'ready', key, value: next });
+        snapshotCache.commitRuntimeHostSettingsRead(key, next);
+        setRuntimeHostSettings(completeSettingsResourceLoad(key, next));
       }
     } catch (error) {
       if (
         settingsModalMountedRef.current &&
-        ticket === runtimeHostSettingsTicketRef.current &&
-        selectedRuntimeHostKeyRef.current === key
+        runtimeHostRequestAuthority.acceptsSettingsRead(ticket)
       ) {
         const message = settingsActionErrorMessage(error, locale);
-        setRuntimeHostSettings((current) => failResourceLoad(current, key, message));
+        setRuntimeHostSettings((current) => failSettingsResourceLoad(
+          current,
+          key,
+          message,
+          snapshotCache.readRuntimeHostSettings(key),
+        ));
       }
     }
   }
@@ -392,6 +456,7 @@ export function SettingsSurface(props: {
     try {
       const next = await window.maka.settings.getClient();
       if (!settingsModalMountedRef.current || ticket !== clientSettingsTicketRef.current) return;
+      snapshotCache.commitClientRead(next);
       setClientSettings(next);
     } finally {
       if (settingsModalMountedRef.current && ticket === clientSettingsTicketRef.current) {
@@ -405,32 +470,38 @@ export function SettingsSurface(props: {
     host = selectedRuntimeHost,
   ): Promise<void> {
     if (!bridge || !host) return;
-    const key = runtimeHostKey(host);
-    const ticket = ++runtimeHostConnectionsTicketRef.current;
-    setRuntimeHostConnections((current) => beginResourceLoad(current, key));
+    const key = runtimeHostSettingsKey(host);
+    const ticket = runtimeHostRequestAuthority.beginConnectionsRead(key);
+    if (!ticket) return;
+    setRuntimeHostConnections((current) => beginSettingsResourceLoad(
+      current,
+      key,
+      snapshotCache.readRuntimeHostConnections(key),
+    ));
     try {
       const snapshot = await bridge.getSnapshot();
       if (
         !settingsModalMountedRef.current ||
-        ticket !== runtimeHostConnectionsTicketRef.current ||
-        selectedRuntimeHostKeyRef.current !== key
+        !runtimeHostRequestAuthority.acceptsConnectionsRead(ticket)
       ) return;
-      setRuntimeHostConnections({
-        status: 'ready',
-        key,
-        value: {
-          connections: snapshot.connections,
-          defaultSlug: snapshot.defaultConnection,
-        },
-      });
+      const next = {
+        connections: snapshot.connections,
+        defaultSlug: snapshot.defaultConnection,
+      };
+      snapshotCache.commitRuntimeHostConnectionsRead(key, next);
+      setRuntimeHostConnections(completeSettingsResourceLoad(key, next));
     } catch (error) {
       if (
         settingsModalMountedRef.current &&
-        ticket === runtimeHostConnectionsTicketRef.current &&
-        selectedRuntimeHostKeyRef.current === key
+        runtimeHostRequestAuthority.acceptsConnectionsRead(ticket)
       ) {
         const message = settingsActionErrorMessage(error, locale);
-        setRuntimeHostConnections((current) => failResourceLoad(current, key, message));
+        setRuntimeHostConnections((current) => failSettingsResourceLoad(
+          current,
+          key,
+          message,
+          snapshotCache.readRuntimeHostConnections(key),
+        ));
       }
     }
   }
@@ -445,10 +516,13 @@ export function SettingsSurface(props: {
         throw new Error(copy.runtimeHostUnavailable);
       }
       const host = updatesRuntimeHost ? selectedRuntimeHost : undefined;
-      const hostKey = host ? runtimeHostKey(host) : undefined;
-      const hostTicket = host
-        ? ++runtimeHostSettingsTicketRef.current
+      const hostKey = host ? runtimeHostSettingsKey(host) : undefined;
+      const hostTicket = hostKey
+        ? runtimeHostRequestAuthority.beginSettingsWrite(hostKey)
         : undefined;
+      if (hostKey && !hostTicket) {
+        throw new Error(copy.runtimeHostUnavailable);
+      }
       const clientTicket = updatesRuntimeHost
         ? undefined
         : ++clientSettingsTicketRef.current;
@@ -461,11 +535,10 @@ export function SettingsSurface(props: {
         props.onUiLocalePreferenceChange,
       );
       const acceptedHostUpdate = Boolean(
-        hostKey &&
-        hostTicket === runtimeHostSettingsTicketRef.current &&
-        selectedRuntimeHostKeyRef.current === hostKey,
+        hostTicket &&
+        runtimeHostRequestAuthority.acceptsSettingsWrite(hostTicket),
       );
-      if (acceptedHostUpdate && selectedProfileId === runtimeHosts?.defaultProfileId) {
+      if (acceptedHostUpdate && host?.profileId === defaultRuntimeHostProfileIdRef.current) {
         if (patch.chatDefaults?.permissionMode !== undefined) {
           props.onDefaultPermissionModeChange(result.settings.chatDefaults.permissionMode);
         }
@@ -475,12 +548,14 @@ export function SettingsSurface(props: {
         return result;
       }
       if (acceptedHostUpdate && hostKey) {
-        setRuntimeHostSettings({ status: 'ready', key: hostKey, value: result.settings });
+        setRuntimeHostSettings(completeSettingsResourceLoad(hostKey, result.settings));
+        void reloadRuntimeHostSettings(host);
       } else if (
         clientTicket !== undefined &&
         clientTicket === clientSettingsTicketRef.current
       ) {
         setClientSettings(result.settings);
+        void reloadClientSettings();
       }
       return result;
     } catch (error) {
@@ -506,32 +581,43 @@ export function SettingsSurface(props: {
 
   async function reloadRuntimeHosts(): Promise<void> {
     const ticket = ++runtimeHostReloadTicketRef.current;
-    setRuntimeHostCatalog((current) =>
-      current.status === 'ready' ? current : { status: 'loading' });
+    setRuntimeHostCatalog((current) => beginSettingsResourceLoad(
+      current,
+      RUNTIME_HOST_CATALOG_KEY,
+      snapshotCache.readRuntimeHostCatalog(),
+    ));
     try {
       const next = await window.maka.runtimeHostProfiles.getSnapshot();
       if (!settingsModalMountedRef.current || ticket !== runtimeHostReloadTicketRef.current) {
         return;
       }
-      setRuntimeHostCatalog({ status: 'ready', snapshot: next });
-      setSelectedProfileId((current) => {
-        if (
-          current &&
-          next.entries.some((entry) => entry.profile.id === current && entry.enabled)
-        ) {
-          return current;
-        }
-        return next.defaultProfileId;
+      // A catalog snapshot is the authority for Host identity. Invalidate any
+      // reads started against the previous catalog before pruning its epochs;
+      // otherwise a late response could repopulate a key that was just removed.
+      runtimeHostRequestAuthority.invalidateReads();
+      snapshotCache.commitRuntimeHostCatalogRead(next);
+      defaultRuntimeHostProfileIdRef.current = next.defaultProfileId;
+      setRuntimeHostCatalog(completeSettingsResourceLoad(RUNTIME_HOST_CATALOG_KEY, next));
+      const preserveCurrentSelection =
+        runtimeHostCatalogHydratedRef.current || selectedProfileChangedByUserRef.current;
+      runtimeHostCatalogHydratedRef.current = true;
+      const nextProfileId = reconcileRuntimeHostProfileSelection({
+        currentProfileId: selectedProfileIdRef.current,
+        defaultProfileId: next.defaultProfileId,
+        enabledProfileIds: next.entries
+          .filter((entry) => entry.enabled)
+          .map((entry) => entry.profile.id),
+        preserveCurrentSelection,
       });
+      commitSelectedRuntimeHostProfile(nextProfileId, next);
     } catch (error) {
       if (settingsModalMountedRef.current && ticket === runtimeHostReloadTicketRef.current) {
-        setRuntimeHostCatalog((current) =>
-          current.status === 'ready'
-            ? current
-            : {
-                status: 'error',
-                message: settingsActionErrorMessage(error, locale),
-              });
+        setRuntimeHostCatalog((current) => failSettingsResourceLoad(
+          current,
+          RUNTIME_HOST_CATALOG_KEY,
+          settingsActionErrorMessage(error, locale),
+          snapshotCache.readRuntimeHostCatalog(),
+        ));
       }
       throw error;
     }
@@ -569,11 +655,10 @@ export function SettingsSurface(props: {
   }, [copy.settingsLoadFailed, locale, toast]);
 
   useEffect(() => {
-    runtimeHostSettingsTicketRef.current += 1;
-    runtimeHostConnectionsTicketRef.current += 1;
+    runtimeHostRequestAuthority.invalidateReads();
     if (!selectedRuntimeHost || !connectionsBridge) {
-      setRuntimeHostSettings({ status: 'idle' });
-      setRuntimeHostConnections({ status: 'idle' });
+      setRuntimeHostSettings(createSettingsResourceState());
+      setRuntimeHostConnections(createSettingsResourceState());
       return;
     }
     void Promise.all([
@@ -626,7 +711,7 @@ export function SettingsSurface(props: {
   async function retryRuntimeHostContent(): Promise<void> {
     let diagnosticTarget: { profileId: string } | undefined;
     try {
-      if (runtimeHostCatalog.status === 'error') {
+      if (runtimeHostCatalogStatus.phase === 'error') {
         await reloadRuntimeHosts();
         return;
       }
@@ -747,7 +832,10 @@ export function SettingsSurface(props: {
                           options={runtimeHostOptions}
                           isDisabled={!runtimeHosts}
                           width={220}
-                          onChange={setSelectedProfileId}
+                          onChange={(profileId) => {
+                            selectedProfileChangedByUserRef.current = true;
+                            commitSelectedRuntimeHostProfile(profileId);
+                          }}
                         />
                       </div>
                     ) : null}
@@ -758,19 +846,13 @@ export function SettingsSurface(props: {
                 <LayoutContent padding={6} isScrollable={false}>
                   {loading ? (
                     <SettingsSkeleton />
-                  ) : requiresRuntimeHost && runtimeHostContentStatus === 'error' ? (
+                  ) : requiresRuntimeHost &&
+                    !runtimeHostContentReady &&
+                    runtimeHostContentStatus === 'error' ? (
                     <Banner
                       status="error"
                       title={copy.settingsLoadFailed}
-                      description={
-                        runtimeHostCatalog.status === 'error'
-                          ? runtimeHostCatalog.message
-                          : runtimeHostSettings.status === 'error'
-                            ? runtimeHostSettings.message
-                            : runtimeHostConnections.status === 'error'
-                              ? runtimeHostConnections.message
-                              : undefined
-                      }
+                      description={runtimeHostErrorMessage}
                       endContent={(
                         <Button
                           variant="secondary"
@@ -783,43 +865,75 @@ export function SettingsSurface(props: {
                   ) : requiresRuntimeHost && !runtimeHostContentReady ? (
                     <Banner status="warning" title={copy.runtimeHostUnavailable} />
                   ) : (
-                    <RuntimeHostSettingsTarget
-                      key={selectedRuntimeHost
-                        ? `${selectedRuntimeHost.profileId}:${selectedRuntimeHost.hostId}`
-                        : 'client'}
-                      host={selectedRuntimeHost}
-                    >
-                      <SettingsPageBody
-                        section={section}
-                        settings={settings}
-                        usageStats={usageStats}
-                        connections={connections}
-                        connectionsBridge={connectionsBridge}
-                        defaultSlug={defaultSlug}
-                        runtimeHost={selectedRuntimeHost}
-                        runtimeHostStatus={runtimeHostContentStatus}
-                        themePref={props.themePref}
-                        themePalette={props.themePalette}
-                        onRefreshConnections={reloadConnections}
-                        onUpdateSettings={updateSettings}
-                        onReloadSettings={reloadRuntimeHostSettings}
-                        onReloadClientSettings={reloadClientSettings}
-                        onRetryRuntimeHost={retryRuntimeHostContent}
-                        onReloadUsage={reloadUsage}
-                        onThemeChange={props.onThemeChange}
-                        onThemePaletteChange={props.onThemePaletteChange}
-                        onOpenDailyReview={props.onOpenDailyReview}
-                        onOpenKeyboardHelp={props.onOpenKeyboardHelp}
-                        onOpenSession={props.onOpenSession}
-                        archivedTasks={props.archivedTasks}
-                        onTaskImported={props.onTaskImported}
-                        onRemoteHostAdded={props.onRemoteHostAdded}
-                        openProviderCatalog={providerCatalogRequested}
-                        initialConnectionSlug={props.initialConnectionSlug}
-                        initialCreateProviderType={createProviderRequest}
-                        onInitialCreateProviderConsumed={() => setCreateProviderRequest(undefined)}
-                      />
-                    </RuntimeHostSettingsTarget>
+                    <>
+                      {requiresRuntimeHost && runtimeHostContentStatus === 'error' ? (
+                        <Banner
+                          status="error"
+                          title={copy.settingsLoadFailed}
+                          description={runtimeHostErrorMessage}
+                          endContent={(
+                            <Button
+                              variant="secondary"
+                              size="sm"
+                              label={copy.retry}
+                              onClick={() => void retryRuntimeHostContent()}
+                            />
+                          )}
+                        />
+                      ) : null}
+                      <RuntimeHostSettingsTarget
+                        key={selectedRuntimeHost
+                          ? `${selectedRuntimeHost.profileId}:${selectedRuntimeHost.hostId}`
+                          : 'client'}
+                        host={selectedRuntimeHost}
+                      >
+                        <RuntimeHostInteractionBoundary
+                          isInteractive={!requiresRuntimeHost || runtimeHostContentVerified}
+                        >
+                          <SettingsPageBody
+                            section={section}
+                            settings={settings}
+                            usageStats={usageStats}
+                            connections={connections}
+                            connectionsBridge={connectionsBridge}
+                            defaultSlug={defaultSlug}
+                            runtimeHost={selectedRuntimeHost}
+                            runtimeHostAvailabilityStatus={runtimeHostAvailabilityStatus}
+                            runtimeHostCatalogStatus={runtimeHostCatalogStatus}
+                            runtimeHostSettingsStatus={selectedRuntimeHostSettingsStatus}
+                            runtimeHostConnectionsStatus={selectedRuntimeHostConnectionsStatus}
+                            runtimeHostTargetVerified={runtimeHostTargetVerified}
+                            runtimeHostTargetStatus={runtimeHostTargetStatus}
+                            runtimeHostErrorMessage={runtimeHostErrorMessage}
+                            themePref={props.themePref}
+                            themePalette={props.themePalette}
+                            onRefreshConnections={reloadConnections}
+                            onUpdateSettings={updateSettings}
+                            onReloadSettings={reloadRuntimeHostSettings}
+                            onReloadClientSettings={reloadClientSettings}
+                            onRetryRuntimeHost={retryRuntimeHostContent}
+                            onReloadUsage={reloadUsage}
+                            onThemeChange={props.onThemeChange}
+                            onThemePaletteChange={props.onThemePaletteChange}
+                            onOpenDailyReview={props.onOpenDailyReview}
+                            onOpenKeyboardHelp={props.onOpenKeyboardHelp}
+                            onOpenSession={props.onOpenSession}
+                            archivedTasks={props.archivedTasks}
+                            onTaskImported={props.onTaskImported}
+                            onRemoteHostAdded={props.onRemoteHostAdded}
+                            openProviderCatalog={providerCatalogRequested}
+                            initialConnectionSlug={props.initialConnectionSlug}
+                            initialCreateProviderType={createProviderRequest}
+                            onInitialCreateProviderConsumed={() => {
+                              setCreateProviderRequest(undefined);
+                            }}
+                            onInitialProviderCatalogConsumed={() => {
+                              setProviderCatalogRequested(false);
+                            }}
+                          />
+                        </RuntimeHostInteractionBoundary>
+                      </RuntimeHostSettingsTarget>
+                    </>
                   )}
                 </LayoutContent>
               )}
@@ -839,7 +953,13 @@ function SettingsPageBody(props: {
   connectionsBridge: RuntimeHostSettingsConnectionsBridge | undefined;
   defaultSlug: string | null;
   runtimeHost: DesktopRuntimeHostRef | undefined;
-  runtimeHostStatus: 'loading' | 'ready' | 'unavailable' | 'error';
+  runtimeHostAvailabilityStatus: RuntimeHostAvailabilityStatus;
+  runtimeHostCatalogStatus: SettingsResourceStatus;
+  runtimeHostSettingsStatus: SettingsResourceStatus;
+  runtimeHostConnectionsStatus: SettingsResourceStatus;
+  runtimeHostTargetVerified: boolean;
+  runtimeHostTargetStatus: RuntimeHostAvailabilityStatus;
+  runtimeHostErrorMessage?: string;
   themePref: ThemePreference;
   themePalette: ThemePalette;
   onRefreshConnections(): Promise<void>;
@@ -860,6 +980,7 @@ function SettingsPageBody(props: {
   initialConnectionSlug?: string;
   initialCreateProviderType?: ProviderType;
   onInitialCreateProviderConsumed?(): void;
+  onInitialProviderCatalogConsumed?(): void;
 }) {
   const locale = useUiLocale();
   const copy = getSettingsSharedCopy(locale);
@@ -880,6 +1001,7 @@ function SettingsPageBody(props: {
             initialConnectionSlug={props.initialConnectionSlug}
             initialCreateProviderType={props.initialCreateProviderType}
             onInitialCreateProviderConsumed={props.onInitialCreateProviderConsumed}
+            onInitialCatalogConsumed={props.onInitialProviderCatalogConsumed}
           />
         </SettingsPage>
       );
@@ -918,7 +1040,11 @@ function SettingsPageBody(props: {
           connections={props.connections}
           defaultSlug={props.defaultSlug}
           connectionsBridge={props.connectionsBridge}
-          runtimeHostStatus={props.runtimeHostStatus}
+          runtimeHostAvailabilityStatus={props.runtimeHostAvailabilityStatus}
+          runtimeHostCatalogStatus={props.runtimeHostCatalogStatus}
+          runtimeHostSettingsStatus={props.runtimeHostSettingsStatus}
+          runtimeHostConnectionsStatus={props.runtimeHostConnectionsStatus}
+          runtimeHostErrorMessage={props.runtimeHostErrorMessage}
           testNetworkProxy={props.runtimeHost
             ? (input) => window.maka.settings.testNetworkProxy(input, props.runtimeHost)
             : undefined}
@@ -931,7 +1057,9 @@ function SettingsPageBody(props: {
       return (
         <ProjectsSettingsPage
           settings={props.settings}
-          runtimeHostStatus={props.runtimeHostStatus}
+          runtimeHostStatus={props.runtimeHostTargetStatus}
+          runtimeHostTargetVerified={props.runtimeHostTargetVerified}
+          runtimeHostErrorMessage={props.runtimeHostErrorMessage}
           onUpdate={props.onUpdateSettings}
           onRetryRuntimeHost={props.onRetryRuntimeHost}
           onRemoteHostAdded={props.onRemoteHostAdded}
@@ -960,7 +1088,9 @@ function SettingsPageBody(props: {
     case 'data':
       return (
         <DataSettingsPage
-          runtimeHostStatus={props.runtimeHostStatus}
+          runtimeHostStatus={props.runtimeHostTargetStatus}
+          runtimeHostTargetVerified={props.runtimeHostTargetVerified}
+          runtimeHostErrorMessage={props.runtimeHostErrorMessage}
           onRetryRuntimeHost={props.onRetryRuntimeHost}
         />
       );

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -395,7 +395,7 @@ export function SettingsSurface(props: {
     return () => props.onSelectedRuntimeHostProfileIdChange(undefined);
   }, [props.onSelectedRuntimeHostProfileIdChange, selectedProfileId, showsRuntimeHost]);
   const sectionNeedsSettings = ['general', 'subagents', 'memory', 'search'].includes(section);
-  const sectionNeedsConnections = ['general', 'subagents', 'daily-review'].includes(section);
+  const sectionNeedsConnections = ['general', 'models', 'subagents', 'daily-review'].includes(section);
   const runtimeHostAvailabilityStatus: RuntimeHostAvailabilityStatus =
     selectedRuntimeHost
       ? 'ready'

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -954,6 +954,9 @@ export function SettingsSurface(props: {
                           ? `${selectedRuntimeHost.profileId}:${selectedRuntimeHost.hostId}`
                           : 'client'}
                         host={selectedRuntimeHost}
+                        generation={selectedProfileId
+                          ? runtimeHostLifecycleByProfile.get(selectedProfileId)?.epoch
+                          : undefined}
                       >
                         <RuntimeHostInteractionBoundary
                           isInteractive={!requiresRuntimeHost || runtimeHostContentVerified}

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -153,6 +153,20 @@
   background: transparent;
 }
 
+/* Renderer-memory snapshots keep a Runtime Host page visually stable while
+   its authority is revalidated. `inert` fences every Host mutation during
+   that first verification; display: contents keeps the page grid unchanged. */
+.settingsRuntimeHostInteractionBoundary {
+  display: contents;
+}
+
+/* `inert` is an interaction contract, not a visual state. Cached Host pages
+   otherwise look fully actionable while their fresh authority is still being
+   verified, so mute the existing page without adding layout or a flash banner. */
+.settingsRuntimeHostInteractionBoundary[inert] > * {
+  opacity: var(--opacity-disabled);
+}
+
 /* Nested `.settingsPageStack` (merged pages like 外观 stack two
    sub-pages, each wrapping in their own SettingsPage):
    the inner one just passes through. */

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -933,6 +933,7 @@ const withGeneralCachedRevalidationBridge = withScopedMakaBridge({
 
 let generationStoryCatalogPending = false;
 let generationStoryRuntimeHostProfiles = runtimeHostProfiles;
+let generationStoryConnectionsPending = false;
 let generationStoryCodexEmail = 'old-generation@example.com';
 let generationStoryCodexAccountReads = 0;
 let generationStoryOpenedAuthIds: string[] = [];
@@ -951,6 +952,7 @@ function resetGenerationStoryBridge(
 ): void {
   generationStoryCatalogPending = false;
   generationStoryRuntimeHostProfiles = snapshot;
+  generationStoryConnectionsPending = false;
   generationStoryCodexEmail = 'old-generation@example.com';
   generationStoryCodexAccountReads = 0;
   generationStoryOpenedAuthIds = [];
@@ -1002,6 +1004,17 @@ const withModelsOAuthGenerationRevalidationBridge = withScopedMakaBridge({
         plan: 'Plus',
       };
     },
+  },
+} satisfies Record<string, unknown>);
+
+const withModelsConnectionsGenerationRevalidationBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: generationStoryRuntimeHostProfilesBridge,
+  connections: {
+    ...connectionsBridge,
+    getSnapshot: () => generationStoryConnectionsPending
+      ? pendingForever()
+      : connectionsBridge.getSnapshot(),
   },
 } satisfies Record<string, unknown>);
 
@@ -2111,6 +2124,55 @@ export const ModelsCachedHostRevalidation: Story = {
     }
     await expect(Number.parseFloat(getComputedStyle(mutedPage).opacity)).toBeLessThan(1);
     await expect(within(canvasElement).queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+
+// A same-key Host replacement can verify the profile catalog before its
+// connection catalog has arrived. Keep the last-ready rows visible, but do not
+// let Models make them writable until the new generation verifies connections.
+export const ModelsConnectionsHostGenerationRevalidation: Story = {
+  decorators: [withModelsConnectionsGenerationRevalidationBridge],
+  render: () => {
+    resetGenerationStoryBridge();
+    return (
+      <SettingsStory
+        section="models"
+        seedSnapshotCache={seedGeneralSnapshotCache}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const oldConnection = await canvas.findByText('Z.AI Live');
+    const boundary = canvasElement.querySelector<HTMLElement>(
+      '.settingsRuntimeHostInteractionBoundary',
+    );
+    if (!boundary) throw new Error('Runtime Host interaction boundary did not render');
+    await waitForStoryCondition(
+      () => !boundary.hasAttribute('inert'),
+      'Initial Runtime Host generation did not become interactive',
+    );
+
+    generationStoryConnectionsPending = true;
+    generationStoryRuntimeHostProfiles = runtimeHostProfilesWithRemote;
+    const listener = generationStoryProfileListener;
+    if (!listener) throw new Error('Runtime Host generation listener did not subscribe');
+    listener({
+      epoch: 'storybook-generation-2',
+      profileId: 'local',
+      profileName: 'Local',
+      profileKind: 'local',
+      readiness: 'ready',
+      hostId: 'storybook-local-host',
+      isDefault: true,
+    });
+
+    await userEvent.click(canvas.getByRole('combobox', { name: 'Runtime Host' }));
+    await within(document.body).findByRole('option', { name: 'Remote' });
+    await userEvent.keyboard('{Escape}');
+    await expect(boundary).toHaveAttribute('inert');
+    await expect(oldConnection).toBeInTheDocument();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
   },
 };
 

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -57,6 +57,7 @@ import type { ConnectionsBridge } from '../../src/renderer/settings/providers-pa
 import type { ProjectRecord } from '@maka/core/project';
 import type { ArchivedTasksBridge } from '../../src/renderer/settings/tasks-settings-page';
 import type {
+  DesktopRuntimeHostProfileChangedEvent,
   DesktopRuntimeHostProfileSnapshot,
   DesktopSessionSummary,
 } from '../../src/preload/bridge-contract.js';
@@ -619,6 +620,31 @@ const runtimeHostProfiles: DesktopRuntimeHostProfileSnapshot = {
   ],
 };
 
+const runtimeHostProfilesWithRemote: DesktopRuntimeHostProfileSnapshot = {
+  defaultProfileId: 'local',
+  entries: [
+    ...runtimeHostProfiles.entries,
+    {
+      profile: {
+        id: 'remote',
+        name: 'Remote',
+        kind: 'remote',
+        rootId: 'storybook-remote-root',
+        transport: {
+          kind: 'ssh',
+          destination: 'storybook.example.test',
+          remotePort: 43123,
+          websocketPath: '/runtime-host',
+        },
+      },
+      enabled: true,
+      isDefault: false,
+      readiness: 'ready',
+      hostId: 'storybook-remote-host',
+    },
+  ],
+};
+
 const unavailableRuntimeHostProfiles: DesktopRuntimeHostProfileSnapshot = {
   defaultProfileId: 'local',
   entries: [
@@ -643,6 +669,11 @@ function seedGeneralSnapshotCache(cache: SettingsSnapshotCache): void {
     connections,
     defaultSlug: 'zai-live',
   });
+}
+
+function seedGeneralTwoHostSnapshotCache(cache: SettingsSnapshotCache): void {
+  seedGeneralSnapshotCache(cache);
+  cache.commitRuntimeHostCatalogRead(runtimeHostProfilesWithRemote);
 }
 
 let storyClientSettings = createDefaultSettings();
@@ -855,6 +886,46 @@ const withGeneralCachedRevalidationBridge = withScopedMakaBridge({
   connections: {
     ...connectionsBridge,
     getSnapshot: () => pendingForever(),
+  },
+} satisfies Record<string, unknown>);
+
+let generationStoryCatalogPending = false;
+let generationStoryRuntimeHostProfiles = runtimeHostProfiles;
+let generationStoryProfileListener:
+  | ((event: DesktopRuntimeHostProfileChangedEvent) => void)
+  | undefined;
+
+function resetGenerationStoryBridge(
+  snapshot: DesktopRuntimeHostProfileSnapshot = runtimeHostProfiles,
+): void {
+  generationStoryCatalogPending = false;
+  generationStoryRuntimeHostProfiles = snapshot;
+  generationStoryProfileListener = undefined;
+}
+
+const withGeneralHostGenerationRevalidationBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: {
+    ...makaBridge.runtimeHostProfiles,
+    getSnapshot: () => {
+      return generationStoryCatalogPending
+        ? pendingForever()
+        : Promise.resolve({
+            ...generationStoryRuntimeHostProfiles,
+            // IPC returns a fresh structured clone. Reusing the cache's exact
+            // object identity would suppress the selected-Host effect after
+            // catalog hydration and make this fake less faithful than Desktop.
+            entries: [...generationStoryRuntimeHostProfiles.entries],
+          });
+    },
+    subscribeChanges: (handler: (event: DesktopRuntimeHostProfileChangedEvent) => void) => {
+      generationStoryProfileListener = handler;
+      return () => {
+        if (generationStoryProfileListener === handler) {
+          generationStoryProfileListener = undefined;
+        }
+      };
+    },
   },
 } satisfies Record<string, unknown>);
 
@@ -1510,8 +1581,127 @@ export const GeneralCachedRevalidation: Story = {
     await expect(
       canvas.getByRole('switch', { name: '完成时发送系统通知' }),
     ).toBeEnabled();
+    await expect(canvas.getByRole('radio', { name: '中文' })).toBeEnabled();
+    const mixedBoundary = canvasElement.querySelector<HTMLElement>(
+      '.settingsRuntimeHostInteractionBoundary',
+    );
+    if (!mixedBoundary) throw new Error('General mixed-ownership boundary did not render');
+    await expect(mixedBoundary).not.toHaveAttribute('inert');
     await canvas.findByText('正在加载设置');
     await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+// A Runtime Host can be replaced without changing its renderer-facing
+// profileId:hostId key. The lifecycle epoch is the generation boundary: keep
+// cached Host values visible, revoke their write authority immediately, and
+// leave Desktop-owned controls usable while the new generation verifies.
+export const GeneralHostGenerationRevalidation: Story = {
+  decorators: [withGeneralHostGenerationRevalidationBridge],
+  render: () => {
+    resetGenerationStoryBridge();
+    return (
+      <SettingsStory
+        section="general"
+        seedSnapshotCache={seedGeneralSnapshotCache}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tone = await canvas.findByRole('textbox', { name: '助手语气偏好' });
+    const defaultModel = await canvas.findByRole('button', { name: '默认模型' });
+    await waitForStoryCondition(
+      () => !tone.matches(':disabled') && !defaultModel.matches(':disabled'),
+      'Initial Runtime Host generation did not become interactive',
+    );
+    const listener = generationStoryProfileListener;
+    if (!listener) throw new Error('Runtime Host generation listener did not subscribe');
+
+    generationStoryCatalogPending = true;
+    listener({
+      epoch: 'storybook-generation-2',
+      profileId: 'local',
+      profileName: 'Local',
+      profileKind: 'local',
+      readiness: 'ready',
+      hostId: 'storybook-local-host',
+      isDefault: true,
+    });
+
+    await waitForStoryCondition(
+      () => tone.matches(':disabled') && defaultModel.matches(':disabled'),
+      'Previous Runtime Host generation remained writable',
+    );
+    await expect(tone).toBeDisabled();
+    await expect(defaultModel).toBeDisabled();
+    await expect(
+      canvas.getByRole('switch', { name: '完成时发送系统通知' }),
+    ).toBeEnabled();
+    await expect(canvas.getByRole('radio', { name: '中文' })).toBeEnabled();
+    const mixedBoundary = canvasElement.querySelector<HTMLElement>(
+      '.settingsRuntimeHostInteractionBoundary',
+    );
+    if (!mixedBoundary) throw new Error('General mixed-ownership boundary did not render');
+    await expect(mixedBoundary).not.toHaveAttribute('inert');
+  },
+};
+// A lifecycle event is newer than the cached catalog even when its profile is
+// not selected yet. Switching to that profile must respect the event's
+// reconnecting tombstone instead of reviving the catalog's last-ready Host.
+export const GeneralBackgroundHostReconnectThenSelect: Story = {
+  decorators: [withGeneralHostGenerationRevalidationBridge],
+  render: () => {
+    resetGenerationStoryBridge(runtimeHostProfilesWithRemote);
+    return (
+      <SettingsStory
+        section="general"
+        seedSnapshotCache={seedGeneralTwoHostSnapshotCache}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tone = await canvas.findByRole('textbox', { name: '助手语气偏好' });
+    await waitForStoryCondition(
+      () => !tone.matches(':disabled'),
+      'Initial Runtime Host did not become interactive',
+    );
+    const listener = generationStoryProfileListener;
+    if (!listener) throw new Error('Runtime Host generation listener did not subscribe');
+
+    generationStoryCatalogPending = true;
+    listener({
+      epoch: 'storybook-remote-generation-2',
+      profileId: 'remote',
+      profileName: 'Remote',
+      profileKind: 'remote',
+      readiness: 'reconnecting',
+      hostId: 'storybook-remote-host',
+      isDefault: false,
+    });
+
+    await userEvent.click(canvas.getByRole('combobox', { name: 'Runtime Host' }));
+    await userEvent.click(
+      await within(document.body).findByRole('option', { name: 'Remote' }),
+    );
+    await waitForStoryCondition(
+      () => {
+        const currentTone = canvas.queryByRole('textbox', {
+          name: '助手语气偏好',
+        });
+        return currentTone === null || currentTone.matches(':disabled');
+      },
+      'The reconnecting background Host was revived from the stale catalog',
+    );
+    await expect(canvas.getByRole('combobox', { name: 'Runtime Host' }))
+      .toHaveTextContent('Remote');
+    await canvas.findByText('助手语气偏好');
+    const currentTone = canvas.queryByRole('textbox', { name: '助手语气偏好' });
+    if (currentTone) await expect(currentTone).toBeDisabled();
+    await expect(
+      canvas.getByRole('switch', { name: '完成时发送系统通知' }),
+    ).toBeEnabled();
+    await expect(canvas.getByRole('radio', { name: '中文' })).toBeEnabled();
   },
 };
 // Error is a real signal rather than a loading state. Desktop-owned controls

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -1766,6 +1766,14 @@ export const ProjectsCachedHostRevalidation: Story = {
       ) !== null,
       'Project Host interaction boundary did not remain inert',
     );
+    const boundary = canvasElement.querySelector<HTMLElement>(
+      '.settingsRuntimeHostInteractionBoundary[inert][aria-busy="true"]',
+    );
+    const mutedProjectContent = boundary?.firstElementChild;
+    if (!(mutedProjectContent instanceof HTMLElement)) {
+      throw new Error('Project Host interaction boundary did not contain visible content');
+    }
+    await expect(getComputedStyle(mutedProjectContent).opacity).toBe('0.5');
     await expect(cachedProjectsSnapshotRead).not.toHaveBeenCalled();
     await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
   },

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -121,6 +121,16 @@ const connections: LlmConnection[] = [
   makeConnection({ slug: 'ollama-local', name: 'Ollama Local', providerType: 'ollama' }),
 ];
 
+const generationStoryCopilotConnection = makeConnection({
+  slug: 'github-copilot-generation',
+  name: 'GitHub Copilot',
+  providerType: 'github-copilot',
+});
+const generationStoryConnections = [
+  ...connections,
+  generationStoryCopilotConnection,
+];
+
 const connectionsBridge: ConnectionsBridge = {
   async getSnapshot() {
     return {
@@ -671,6 +681,14 @@ function seedGeneralSnapshotCache(cache: SettingsSnapshotCache): void {
   });
 }
 
+function seedCopilotGenerationSnapshotCache(cache: SettingsSnapshotCache): void {
+  seedGeneralSnapshotCache(cache);
+  cache.commitRuntimeHostConnectionsRead(STORY_RUNTIME_HOST_KEY, {
+    connections: generationStoryConnections,
+    defaultSlug: 'zai-live',
+  });
+}
+
 function seedGeneralTwoHostSnapshotCache(cache: SettingsSnapshotCache): void {
   seedGeneralSnapshotCache(cache);
   cache.commitRuntimeHostCatalogRead(runtimeHostProfilesWithRemote);
@@ -688,6 +706,30 @@ const makaBridge = {
     setEnabled: async () => runtimeHostProfiles,
     setDefault: async () => runtimeHostProfiles,
     subscribeChanges: () => () => undefined,
+  },
+  // Projects always mounts the Runtime Host management dialog shell, even
+  // before a remote profile is selected. Keep the shared Settings fixture in
+  // sync with the full preload surface so mount-time subscriptions stay real.
+  runtimeHostManagement: {
+    run: async (
+      _profileId: string,
+      action: Parameters<typeof window.maka.runtimeHostManagement.run>[1],
+    ) => ({
+      schemaVersion: 1 as const,
+      kind: 'error' as const,
+      action,
+      error: { code: 'storybook_unavailable', message: 'Not configured in this story.' },
+    }),
+    update: async () => ({
+      schemaVersion: 1 as const,
+      kind: 'error' as const,
+      action: 'update' as const,
+      error: { code: 'storybook_unavailable', message: 'Not configured in this story.' },
+    }),
+    subscribeProgress: () => () => undefined,
+    listCredentials: async () => ({ canRotate: false, credentials: [] }),
+    rotateCredential: async () => ({ canRotate: false, credentials: [] }),
+    revokeCredential: async () => ({ canRotate: false, credentials: [] }),
   },
   settings: {
     getClient: async () => storyClientSettings,
@@ -895,6 +937,11 @@ let generationStoryCodexEmail = 'old-generation@example.com';
 let generationStoryCodexAccountReads = 0;
 let generationStoryOpenedAuthIds: string[] = [];
 let generationStoryCancelledAuthIds: string[] = [];
+let generationStoryCopilotImportAttempts = 0;
+let generationStoryCopilotSecretReads = 0;
+let generationStoryCopilotImportResolve:
+  | ((result: { ok: true }) => void)
+  | undefined;
 let generationStoryProfileListener:
   | ((event: DesktopRuntimeHostProfileChangedEvent) => void)
   | undefined;
@@ -908,6 +955,9 @@ function resetGenerationStoryBridge(
   generationStoryCodexAccountReads = 0;
   generationStoryOpenedAuthIds = [];
   generationStoryCancelledAuthIds = [];
+  generationStoryCopilotImportAttempts = 0;
+  generationStoryCopilotSecretReads = 0;
+  generationStoryCopilotImportResolve = undefined;
   generationStoryProfileListener = undefined;
 }
 
@@ -975,6 +1025,35 @@ const withModelsOAuthAuthorizationGenerationBridge = withScopedMakaBridge({
       return { ok: true as const };
     },
     logout: async () => ({ ok: true as const }),
+  },
+} satisfies Record<string, unknown>);
+
+const withModelsCopilotReimportGenerationBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: generationStoryRuntimeHostProfilesBridge,
+  connections: {
+    ...connectionsBridge,
+    getSnapshot: async () => ({
+      connections: generationStoryConnections,
+      defaultConnection: 'zai-live',
+      chatModelChoices: buildChatModelChoices(generationStoryConnections),
+    }),
+    hasSecret: async () => {
+      generationStoryCopilotSecretReads += 1;
+      return true;
+    },
+  },
+  githubCopilotSubscription: {
+    ...makaBridge.githubCopilotSubscription,
+    connectExistingLogin: () => {
+      generationStoryCopilotImportAttempts += 1;
+      if (generationStoryCopilotImportAttempts > 1) {
+        return Promise.resolve({ ok: true as const });
+      }
+      return new Promise<{ ok: true }>((resolve) => {
+        generationStoryCopilotImportResolve = resolve;
+      });
+    },
   },
 } satisfies Record<string, unknown>);
 
@@ -1430,6 +1509,7 @@ type SettingsStoryProps = {
   connections?: LlmConnection[];
   defaultSlug?: string | null;
   openProviderCatalog?: boolean;
+  initialConnectionSlug?: string;
   /** Seeds 已归档任务. Empty for every story that is not about that page. */
   archivedTaskSessions?: readonly SessionSummary[];
   seedSnapshotCache?(cache: SettingsSnapshotCache): void;
@@ -1491,6 +1571,7 @@ function SettingsStoryFrame(props: SettingsStoryProps) {
           onDefaultPermissionModeChange={noop}
           requestedSection={props.section}
           openProviderCatalog={props.openProviderCatalog}
+          initialConnectionSlug={props.initialConnectionSlug}
           initialFocusRef={initialFocusRef}
           onOpenDailyReview={noop}
           onOpenSession={noop}
@@ -2125,6 +2206,67 @@ export const ModelsOAuthAuthorizationHostGenerationRevalidation: Story = {
     await expect(generationStoryCancelledAuthIds).toEqual([
       'authorization-from-generation-1',
     ]);
+  },
+};
+
+// The connection-detail Copilot import owns an action guard and a late
+// success callback independently of the catalog login panel. A same-key Host
+// replacement retires that controller without throwing away the detail route
+// or its surrounding Settings state.
+export const ModelsCopilotReimportHostGenerationRevalidation: Story = {
+  decorators: [withModelsCopilotReimportGenerationBridge],
+  render: () => {
+    resetGenerationStoryBridge();
+    return (
+      <SettingsStory
+        section="models"
+        initialConnectionSlug="github-copilot-generation"
+        seedSnapshotCache={seedCopilotGenerationSnapshotCache}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const firstImport = await canvas.findByRole('button', { name: '重新导入' });
+    await userEvent.click(firstImport);
+    await waitForStoryCondition(
+      () => generationStoryCopilotImportAttempts === 1,
+      'GitHub Copilot reimport did not start',
+    );
+
+    const listener = generationStoryProfileListener;
+    if (!listener) throw new Error('Runtime Host generation listener did not subscribe');
+    listener({
+      epoch: 'storybook-generation-2',
+      profileId: 'local',
+      profileName: 'Local',
+      profileKind: 'local',
+      readiness: 'ready',
+      hostId: 'storybook-local-host',
+      isDefault: true,
+    });
+
+    await waitForStoryCondition(
+      () => canvas.queryByRole('button', { name: '重新导入' })?.hasAttribute('disabled') === false,
+      'Replacement Host kept the previous generation import guard',
+    );
+    const readsAfterReplacement = generationStoryCopilotSecretReads;
+    generationStoryCopilotImportResolve?.({ ok: true });
+    await new Promise((resolve) => globalThis.setTimeout(resolve, 50));
+    await expect(generationStoryCopilotSecretReads).toBe(readsAfterReplacement);
+
+    await userEvent.click(canvas.getByRole('button', { name: '重新导入' }));
+    await waitForStoryCondition(
+      () => generationStoryCopilotImportAttempts === 2,
+      'Replacement Host could not start a fresh GitHub Copilot reimport',
+    );
+    await waitForStoryCondition(
+      () => generationStoryCopilotSecretReads > readsAfterReplacement,
+      'Replacement Host reimport did not refresh the current credential state',
+    );
+    await expect(
+      canvasElement.querySelector('[data-maka-contract="connection-detail"]'),
+    ).toBeInTheDocument();
   },
 };
 

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -891,6 +891,10 @@ const withGeneralCachedRevalidationBridge = withScopedMakaBridge({
 
 let generationStoryCatalogPending = false;
 let generationStoryRuntimeHostProfiles = runtimeHostProfiles;
+let generationStoryCodexEmail = 'old-generation@example.com';
+let generationStoryCodexAccountReads = 0;
+let generationStoryOpenedAuthIds: string[] = [];
+let generationStoryCancelledAuthIds: string[] = [];
 let generationStoryProfileListener:
   | ((event: DesktopRuntimeHostProfileChangedEvent) => void)
   | undefined;
@@ -900,32 +904,77 @@ function resetGenerationStoryBridge(
 ): void {
   generationStoryCatalogPending = false;
   generationStoryRuntimeHostProfiles = snapshot;
+  generationStoryCodexEmail = 'old-generation@example.com';
+  generationStoryCodexAccountReads = 0;
+  generationStoryOpenedAuthIds = [];
+  generationStoryCancelledAuthIds = [];
   generationStoryProfileListener = undefined;
 }
 
+const generationStoryRuntimeHostProfilesBridge = {
+  ...makaBridge.runtimeHostProfiles,
+  getSnapshot: () => {
+    return generationStoryCatalogPending
+      ? pendingForever()
+      : Promise.resolve({
+          ...generationStoryRuntimeHostProfiles,
+          // IPC returns a fresh structured clone. Reusing the cache's exact
+          // object identity would suppress the selected-Host effect after
+          // catalog hydration and make this fake less faithful than Desktop.
+          entries: [...generationStoryRuntimeHostProfiles.entries],
+        });
+  },
+  subscribeChanges: (handler: (event: DesktopRuntimeHostProfileChangedEvent) => void) => {
+    generationStoryProfileListener = handler;
+    return () => {
+      if (generationStoryProfileListener === handler) {
+        generationStoryProfileListener = undefined;
+      }
+    };
+  },
+};
+
 const withGeneralHostGenerationRevalidationBridge = withScopedMakaBridge({
   ...makaBridge,
-  runtimeHostProfiles: {
-    ...makaBridge.runtimeHostProfiles,
-    getSnapshot: () => {
-      return generationStoryCatalogPending
-        ? pendingForever()
-        : Promise.resolve({
-            ...generationStoryRuntimeHostProfiles,
-            // IPC returns a fresh structured clone. Reusing the cache's exact
-            // object identity would suppress the selected-Host effect after
-            // catalog hydration and make this fake less faithful than Desktop.
-            entries: [...generationStoryRuntimeHostProfiles.entries],
-          });
-    },
-    subscribeChanges: (handler: (event: DesktopRuntimeHostProfileChangedEvent) => void) => {
-      generationStoryProfileListener = handler;
-      return () => {
-        if (generationStoryProfileListener === handler) {
-          generationStoryProfileListener = undefined;
-        }
+  runtimeHostProfiles: generationStoryRuntimeHostProfilesBridge,
+} satisfies Record<string, unknown>);
+
+const withModelsOAuthGenerationRevalidationBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: generationStoryRuntimeHostProfilesBridge,
+  openAiCodex: {
+    ...makaBridge.openAiCodex,
+    getAccountState: async () => {
+      generationStoryCodexAccountReads += 1;
+      return {
+        runtimeState: 'authenticated' as const,
+        email: generationStoryCodexEmail,
+        plan: 'Plus',
       };
     },
+  },
+} satisfies Record<string, unknown>);
+
+const withModelsOAuthAuthorizationGenerationBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: generationStoryRuntimeHostProfilesBridge,
+  openAiCodex: {
+    ...makaBridge.openAiCodex,
+    getAccountState: async () => ({ runtimeState: 'not_logged_in' as const }),
+    getAuthUrl: async () => ({
+      authRequestId: 'authorization-from-generation-1',
+      stateHint: 'GEN1-CODE',
+    }),
+    openAuthUrl: async (authRequestId: string) => {
+      generationStoryOpenedAuthIds.push(authRequestId);
+      return pendingForever<{ ok: true }>();
+    },
+    completeAuthorization: () => pendingForever<{ ok: true }>(),
+    cancelAuthorization: async (authRequestId?: string) => {
+      if (authRequestId) generationStoryCancelledAuthIds.push(authRequestId);
+      return { ok: true as const };
+    },
+    logout: async () => ({ ok: true as const }),
   },
 } satisfies Record<string, unknown>);
 
@@ -1981,6 +2030,101 @@ export const ModelsCachedHostRevalidation: Story = {
     }
     await expect(Number.parseFloat(getComputedStyle(mutedPage).opacity)).toBeLessThan(1);
     await expect(within(canvasElement).queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+
+// A ready event can replace the Runtime Host without changing
+// profileId:hostId. The catalog route stays mounted, but its OAuth account
+// snapshot belongs to the Host generation and must be read again before the
+// previous account can be presented as current.
+export const ModelsOAuthHostGenerationRevalidation: Story = {
+  decorators: [withModelsOAuthGenerationRevalidationBridge],
+  render: () => {
+    resetGenerationStoryBridge();
+    return (
+      <SettingsStory
+        section="models"
+        openProviderCatalog
+        seedSnapshotCache={seedGeneralSnapshotCache}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('old-generation@example.com');
+    const readsBeforeReplacement = generationStoryCodexAccountReads;
+    const listener = generationStoryProfileListener;
+    if (!listener) throw new Error('Runtime Host generation listener did not subscribe');
+
+    generationStoryCodexEmail = 'new-generation@example.com';
+    listener({
+      epoch: 'storybook-generation-2',
+      profileId: 'local',
+      profileName: 'Local',
+      profileKind: 'local',
+      readiness: 'ready',
+      hostId: 'storybook-local-host',
+      isDefault: true,
+    });
+
+    await canvas.findByText('new-generation@example.com');
+    await expect(canvas.queryByText('old-generation@example.com')).not.toBeInTheDocument();
+    await expect(generationStoryCodexAccountReads).toBeGreaterThan(readsBeforeReplacement);
+    await expect(
+      canvasElement.querySelector('[data-maka-contract="provider-catalog"]'),
+    ).toBeInTheDocument();
+  },
+};
+
+// Browser authorization is an active Host-owned controller, not durable
+// Settings route state. Replacing a same-key Host cancels the old generation's
+// request while leaving the user on the same provider setup route.
+export const ModelsOAuthAuthorizationHostGenerationRevalidation: Story = {
+  decorators: [withModelsOAuthAuthorizationGenerationBridge],
+  render: () => {
+    resetGenerationStoryBridge();
+    return (
+      <SettingsStory
+        section="models"
+        openProviderCatalog
+        seedSnapshotCache={seedGeneralSnapshotCache}
+      />
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole('button', {
+      name: /打开 OAuth 登录：OpenAI Codex/,
+    }));
+    await userEvent.click(await canvas.findByRole('button', { name: '登录 Codex' }));
+    await waitForStoryCondition(
+      () => generationStoryOpenedAuthIds.includes('authorization-from-generation-1'),
+      'OAuth authorization did not reach the browser handoff',
+    );
+    const listener = generationStoryProfileListener;
+    if (!listener) throw new Error('Runtime Host generation listener did not subscribe');
+
+    listener({
+      epoch: 'storybook-generation-2',
+      profileId: 'local',
+      profileName: 'Local',
+      profileKind: 'local',
+      readiness: 'ready',
+      hostId: 'storybook-local-host',
+      isDefault: true,
+    });
+
+    await waitForStoryCondition(
+      () => generationStoryCancelledAuthIds.includes('authorization-from-generation-1'),
+      'Previous Runtime Host generation authorization was not cancelled',
+    );
+    await expect(
+      canvasElement.querySelector('[data-maka-contract="provider-setup"]'),
+    ).toBeInTheDocument();
+    await expect(await canvas.findByRole('button', { name: '登录 Codex' })).toBeEnabled();
+    await expect(generationStoryCancelledAuthIds).toEqual([
+      'authorization-from-generation-1',
+    ]);
   },
 };
 

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -19,7 +19,7 @@
 
 import { useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import { ToastProvider, useToast } from '@maka/ui';
 import type {
   AppSettings,
@@ -49,6 +49,10 @@ import { createDefaultSettings, mergeSettings } from '@maka/core/settings';
 import { DEFAULT_DAILY_REVIEW_CONFIG } from '@maka/core/daily-review';
 import { SettingsSurface } from '../../src/renderer/settings/settings-surface';
 import { createUiLocaleUpdateGate } from '../../src/renderer/settings/ui-locale-update-gate';
+import {
+  createSettingsSnapshotCache,
+  type SettingsSnapshotCache,
+} from '../../src/renderer/settings/settings-snapshot-cache';
 import type { ConnectionsBridge } from '../../src/renderer/settings/providers-panel';
 import type { ProjectRecord } from '@maka/core/project';
 import type { ArchivedTasksBridge } from '../../src/renderer/settings/tasks-settings-page';
@@ -615,6 +619,32 @@ const runtimeHostProfiles: DesktopRuntimeHostProfileSnapshot = {
   ],
 };
 
+const unavailableRuntimeHostProfiles: DesktopRuntimeHostProfileSnapshot = {
+  defaultProfileId: 'local',
+  entries: [
+    {
+      profile: { id: 'local', name: 'Local', kind: 'local' },
+      enabled: true,
+      isDefault: true,
+      readiness: 'unavailable',
+      message: 'Runtime Host is offline in this story.',
+    },
+  ],
+};
+
+const STORY_RUNTIME_HOST_KEY = 'local:storybook-local-host';
+
+function seedGeneralSnapshotCache(cache: SettingsSnapshotCache): void {
+  const settings = createDefaultSettings();
+  cache.commitClientRead(settings);
+  cache.commitRuntimeHostCatalogRead(runtimeHostProfiles);
+  cache.commitRuntimeHostSettingsRead(STORY_RUNTIME_HOST_KEY, settings);
+  cache.commitRuntimeHostConnectionsRead(STORY_RUNTIME_HOST_KEY, {
+    connections,
+    defaultSlug: 'zai-live',
+  });
+}
+
 let storyClientSettings = createDefaultSettings();
 let storyRuntimeHostSettings = createDefaultSettings();
 
@@ -791,6 +821,106 @@ const makaBridge = {
 } satisfies Record<string, unknown>;
 
 const withSettingsBridge = withScopedMakaBridge(makaBridge);
+
+function pendingForever<T>(): Promise<T> {
+  return new Promise(() => undefined);
+}
+
+const withGeneralHostSettingsLoadingBridge = withScopedMakaBridge({
+  ...makaBridge,
+  settings: {
+    ...makaBridge.settings,
+    get: () => pendingForever(),
+  },
+} satisfies Record<string, unknown>);
+
+const withGeneralConnectionsLoadingBridge = withScopedMakaBridge({
+  ...makaBridge,
+  connections: {
+    ...connectionsBridge,
+    getSnapshot: () => pendingForever(),
+  },
+} satisfies Record<string, unknown>);
+
+const withGeneralCachedRevalidationBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: {
+    ...makaBridge.runtimeHostProfiles,
+    getSnapshot: () => pendingForever(),
+  },
+  settings: {
+    ...makaBridge.settings,
+    get: () => pendingForever(),
+  },
+  connections: {
+    ...connectionsBridge,
+    getSnapshot: () => pendingForever(),
+  },
+} satisfies Record<string, unknown>);
+
+const withProviderCatalogIntentRevalidationBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: {
+    ...makaBridge.runtimeHostProfiles,
+    getSnapshot: () => pendingForever(),
+  },
+  settings: {
+    ...makaBridge.settings,
+    get: () => pendingForever(),
+  },
+  connections: {
+    ...connectionsBridge,
+    getSnapshot: async () => {
+      await new Promise((resolve) => globalThis.setTimeout(resolve, 100));
+      return {
+        connections,
+        defaultConnection: 'zai-live',
+        chatModelChoices: buildChatModelChoices(connections),
+      };
+    },
+  },
+} satisfies Record<string, unknown>);
+
+const cachedProjectsSnapshotRead = fn(async () => ({
+  projects: [],
+  capabilities: {
+    chooseClientDirectory: false,
+    chooseHostDirectory: false,
+    selectNoProject: false,
+    setLocalDefault: false,
+    viewClientPath: false,
+  },
+}));
+
+const withProjectsCachedRevalidationBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: {
+    ...makaBridge.runtimeHostProfiles,
+    getSnapshot: () => pendingForever(),
+  },
+  projects: {
+    getSnapshot: cachedProjectsSnapshotRead,
+    subscribeChanges: () => () => undefined,
+  },
+} satisfies Record<string, unknown>);
+
+const withGeneralHostSettingsErrorBridge = withScopedMakaBridge({
+  ...makaBridge,
+  settings: {
+    ...makaBridge.settings,
+    get: async () => {
+      throw new Error('Runtime Host settings read failed in this story.');
+    },
+  },
+} satisfies Record<string, unknown>);
+
+const withGeneralUnavailableBridge = withScopedMakaBridge({
+  ...makaBridge,
+  runtimeHostProfiles: {
+    ...makaBridge.runtimeHostProfiles,
+    getSnapshot: async () => unavailableRuntimeHostProfiles,
+  },
+} satisfies Record<string, unknown>);
 
 // 已归档任务 renders the shell's catalog, so its fixture is sessions +
 // projects rather than a settings patch. The set is chosen to exercise the
@@ -1179,8 +1309,10 @@ type SettingsStoryProps = {
   section: SettingsSection;
   connections?: LlmConnection[];
   defaultSlug?: string | null;
+  openProviderCatalog?: boolean;
   /** Seeds 已归档任务. Empty for every story that is not about that page. */
   archivedTaskSessions?: readonly SessionSummary[];
+  seedSnapshotCache?(cache: SettingsSnapshotCache): void;
 };
 
 /**
@@ -1200,6 +1332,11 @@ function SettingsStoryFrame(props: SettingsStoryProps) {
   const archivedTasks = useArchivedTasksStoryBridge(props.archivedTaskSessions ?? []);
   const initialFocusRef = useRef<HTMLButtonElement>(null);
   const [uiLocaleUpdateGate] = useState(createUiLocaleUpdateGate);
+  const [snapshotCache] = useState(() => {
+    const cache = createSettingsSnapshotCache();
+    props.seedSnapshotCache?.(cache);
+    return cache;
+  });
   // Fidelity: the theme and palette pickers are the 外观 page's whole content,
   // and with static props + noop handlers the selection could never move — the
   // story showed a picker that looked interactive and wasn't. The real app
@@ -1233,6 +1370,7 @@ function SettingsStoryFrame(props: SettingsStoryProps) {
           uiLocaleUpdateGate={uiLocaleUpdateGate}
           onDefaultPermissionModeChange={noop}
           requestedSection={props.section}
+          openProviderCatalog={props.openProviderCatalog}
           initialFocusRef={initialFocusRef}
           onOpenDailyReview={noop}
           onOpenSession={noop}
@@ -1240,6 +1378,7 @@ function SettingsStoryFrame(props: SettingsStoryProps) {
           onTaskImported={noop}
           onRemoteHostAdded={noop}
           onSelectedRuntimeHostProfileIdChange={noop}
+          snapshotCache={snapshotCache}
         />
       </div>
     </>
@@ -1315,6 +1454,131 @@ export const SubagentEditor: Story = {
 export const General: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="general" />,
+};
+// Cold path: Desktop-owned preferences are ready while the selected Runtime
+// Host settings read is still pending. The complete page topology stays
+// visible as neutral row placeholders, without treating hydration as a warning.
+export const GeneralHostSettingsLoading: Story = {
+  decorators: [withGeneralHostSettingsLoadingBridge],
+  render: () => <SettingsStory section="general" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByText('显示名称');
+    await canvas.findByRole('switch', { name: '完成时发送系统通知' });
+    await expect(
+      await canvas.findByRole('button', { name: '默认模型' }),
+    ).toBeEnabled();
+    await expect(
+      canvas.queryByRole('textbox', { name: '助手语气偏好' }),
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+// Independent resource path: Host settings are usable, but the model
+// connection catalog is still loading. Only 默认模型 remains a placeholder.
+export const GeneralConnectionsLoading: Story = {
+  decorators: [withGeneralConnectionsLoadingBridge],
+  render: () => <SettingsStory section="general" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tone = await canvas.findByRole('textbox', { name: '助手语气偏好' });
+    await expect(tone).toBeEnabled();
+    await canvas.findByText('默认模型');
+    await expect(
+      canvas.queryByRole('button', { name: '默认模型' }),
+    ).not.toBeInTheDocument();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+// Warm path: renderer-memory snapshots render the complete General page on
+// the first commit, but Host-owned mutations remain fenced until this modal
+// verifies the catalog and both resource authorities.
+export const GeneralCachedRevalidation: Story = {
+  decorators: [withGeneralCachedRevalidationBridge],
+  render: () => (
+    <SettingsStory
+      section="general"
+      seedSnapshotCache={seedGeneralSnapshotCache}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tone = await canvas.findByRole('textbox', { name: '助手语气偏好' });
+    const defaultModel = await canvas.findByRole('button', { name: '默认模型' });
+    await expect(tone).toBeDisabled();
+    await expect(defaultModel).toBeDisabled();
+    await expect(
+      canvas.getByRole('switch', { name: '完成时发送系统通知' }),
+    ).toBeEnabled();
+    await canvas.findByText('正在加载设置');
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+// Error is a real signal rather than a loading state. Desktop-owned controls
+// and independently loaded connections remain usable; unknown Host settings
+// are not represented as a perpetual shimmer.
+export const GeneralHostSettingsError: Story = {
+  decorators: [withGeneralHostSettingsErrorBridge],
+  render: () => <SettingsStory section="general" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('载入设置失败');
+    await canvas.findByRole('button', { name: '重试' });
+    await expect(
+      canvas.getByRole('switch', { name: '完成时发送系统通知' }),
+    ).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: '默认模型' })).toBeEnabled();
+    await expect(canvas.queryByText('显示名称')).not.toBeInTheDocument();
+    await expect(
+      canvas.queryByRole('textbox', { name: '助手语气偏好' }),
+    ).not.toBeInTheDocument();
+  },
+};
+// An unavailable Host is not still loading: keep Client preferences usable,
+// show one warning, and omit Host controls/placeholders until a target exists.
+export const GeneralRuntimeHostUnavailable: Story = {
+  decorators: [withGeneralUnavailableBridge],
+  render: () => <SettingsStory section="general" />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = await canvas.findByRole('alert');
+    await expect(alert).toHaveTextContent('Runtime Host');
+    await expect(
+      canvas.getByRole('switch', { name: '完成时发送系统通知' }),
+    ).toBeEnabled();
+    await expect(
+      Array.from(canvasElement.querySelectorAll('[role="status"]')).some(
+        (status) => status.textContent?.includes('正在加载设置') === true,
+      ),
+    ).toBe(false);
+    await expect(canvas.queryByText('显示名称')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('默认模型')).not.toBeInTheDocument();
+  },
+};
+// Mixed authority path: Runtime Host profile management remains available,
+// while project-catalog reads and writes wait for this modal to confirm the
+// cached selected Host.
+export const ProjectsCachedHostRevalidation: Story = {
+  decorators: [withProjectsCachedRevalidationBridge],
+  render: () => (
+    <SettingsStory
+      section="projects"
+      seedSnapshotCache={seedGeneralSnapshotCache}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('button', { name: '添加电脑' })).toBeEnabled();
+    await waitForStoryCondition(
+      () => canvasElement.querySelector(
+        '.settingsRuntimeHostInteractionBoundary[inert][aria-busy="true"]',
+      ) !== null,
+      'Project Host interaction boundary did not remain inert',
+    );
+    await expect(cachedProjectsSnapshotRead).not.toHaveBeenCalled();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
 };
 // Real path: 设置 → 通用, after selecting Git Bash for the current Runtime Host.
 export const GeneralGitBash: Story = {
@@ -1468,6 +1732,94 @@ export const DailyReviewModelSelectorOpen: Story = {
 export const Data: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="data" />,
+};
+// Mixed authority path: local input-history and export-draft controls remain
+// available, but operations that address the cached Host are disabled until
+// the fresh catalog confirms that target.
+export const DataCachedHostRevalidation: Story = {
+  decorators: [withGeneralCachedRevalidationBridge],
+  render: () => (
+    <SettingsStory
+      section="data"
+      seedSnapshotCache={seedGeneralSnapshotCache}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByRole('button', { name: '清空输入历史' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: '打开工作区文件夹' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: '复制路径' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: '导出配置…' })).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: '导入配置…' })).toBeDisabled();
+    await expect(canvas.getByRole('switch', { name: '模型连接' })).toBeEnabled();
+    await expect(
+      canvas.getByRole('combobox', { name: '导入时同名连接的处理方式' }),
+    ).toBeEnabled();
+    await expect(canvas.queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+// Runtime-Host-only pages share one mutation fence while a cached Host target
+// is being confirmed. The wrapper is layout-transparent but interaction-inert.
+export const ModelsCachedHostRevalidation: Story = {
+  decorators: [withGeneralCachedRevalidationBridge],
+  render: () => (
+    <SettingsStory
+      section="models"
+      seedSnapshotCache={seedGeneralSnapshotCache}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    await waitForStoryCondition(
+      () => canvasElement.querySelector('.settingsRuntimeHostInteractionBoundary') !== null,
+      'Runtime Host interaction boundary did not render',
+    );
+    const boundary = canvasElement.querySelector<HTMLElement>(
+      '.settingsRuntimeHostInteractionBoundary',
+    );
+    await expect(boundary).toHaveAttribute('inert');
+    const mutedPage = boundary?.firstElementChild;
+    if (!(mutedPage instanceof HTMLElement)) {
+      throw new Error('Runtime Host interaction boundary did not contain a visible page');
+    }
+    await expect(Number.parseFloat(getComputedStyle(mutedPage).opacity)).toBeLessThan(1);
+    await expect(within(canvasElement).queryByRole('alert')).not.toBeInTheDocument();
+  },
+};
+
+// Warm cache makes SettingsSurface ready before ProvidersPanel finishes its
+// own connection read. The catalog landing intent belongs to the child and is
+// retired only after that child has actually entered the catalog route.
+export const ModelsCatalogIntentDuringWarmRevalidation: Story = {
+  decorators: [withProviderCatalogIntentRevalidationBridge],
+  render: () => (
+    <SettingsStory
+      section="models"
+      openProviderCatalog
+      seedSnapshotCache={seedGeneralSnapshotCache}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitForStoryCondition(
+      () => canvasElement.querySelector('[data-maka-contract="provider-catalog"]') !== null,
+      'Provider catalog intent was retired before ProvidersPanel consumed it',
+    );
+
+    await userEvent.click(canvas.getByRole('button', { name: /^外观$/ }));
+    await userEvent.click(canvas.getByRole('button', { name: /^模型$/ }));
+    await waitForStoryCondition(
+      () => canvasElement.querySelector(
+        '[data-maka-contract="providers-panel"]:not([aria-busy="true"])',
+      ) !== null,
+      'ProvidersPanel did not finish loading after remount',
+    );
+    await expect(
+      canvasElement.querySelector('[data-maka-contract="provider-catalog"]'),
+    ).not.toBeInTheDocument();
+    await expect(
+      canvasElement.querySelector('button[data-maka-contract="add-connection"]'),
+    ).toBeInTheDocument();
+  },
 };
 /**
  * The expanded state, not the collapsed one the page opens in: the capability layers grid

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -5,7 +5,7 @@ Each row is one on-disk product surface file. Regenerated inventory must stay in
 
 Wiki bar: Design Conventions · API Use-the-System · Theming · Container Padding.
 
-**Totals:** 206 files — blocker 0, polish 0, aligned 206.
+**Totals:** 207 files — blocker 0, polish 0, aligned 207.
 
 ## Exclusions (explicit)
 
@@ -94,6 +94,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/settings/provider-oauth-section.tsx` | settings-module | Banner, Button, HStack, Text, VStack | aligned — uses Astryx (Banner, Button, HStack, Text, VStack) | aligned |
 | `apps/desktop/src/renderer/settings/providers-panel.tsx` | settings-module | Badge, Banner, Button, EmptyState, HStack, Heading, List, ListItem, Text, VStack | aligned — uses Astryx (Badge, Banner, Button, EmptyState, HStack, Heading, List, ListItem) | aligned |
 | `apps/desktop/src/renderer/settings/request-customization-editor.tsx` | settings-module | Button, HStack, IconButton, Text, VStack | aligned — uses Astryx (Button, HStack, IconButton, Text, VStack) | aligned |
+| `apps/desktop/src/renderer/settings/runtime-host-interaction-boundary.tsx` | settings-module | none | aligned — no raw controls; no Astryx JSX usage | aligned |
 | `apps/desktop/src/renderer/settings/runtime-host-management-dialog.tsx` | settings-module | Badge, Banner, Button, Dialog, DialogHeader, Layout, LayoutContent, Spinner, Text | aligned — uses Astryx (Badge, Banner, Button, Dialog, DialogHeader, Layout, LayoutContent, Spinner) | aligned |
 | `apps/desktop/src/renderer/settings/runtime-host-onboarding-dialog.tsx` | settings-module | Banner, Button, Dialog, DialogHeader, Layout, LayoutContent, Spinner, Text | aligned — uses Astryx (Banner, Button, Dialog, DialogHeader, Layout, LayoutContent, Spinner, Text) | aligned |
 | `apps/desktop/src/renderer/settings/runtime-host-profiles-section.tsx` | settings-module | Badge, Banner, Button, HStack, List, ListItem, SegmentedControl, SegmentedControlItem, Selector, Switch | aligned — uses Astryx (Badge, Banner, Button, HStack, List, ListItem, SegmentedControl, SegmentedControlItem) | aligned |

--- a/docs/astryx-surface-file-inventory.paths
+++ b/docs/astryx-surface-file-inventory.paths
@@ -66,6 +66,7 @@ apps/desktop/src/renderer/settings/provider-enabled-model-manager.tsx
 apps/desktop/src/renderer/settings/provider-oauth-section.tsx
 apps/desktop/src/renderer/settings/providers-panel.tsx
 apps/desktop/src/renderer/settings/request-customization-editor.tsx
+apps/desktop/src/renderer/settings/runtime-host-interaction-boundary.tsx
 apps/desktop/src/renderer/settings/runtime-host-management-dialog.tsx
 apps/desktop/src/renderer/settings/runtime-host-onboarding-dialog.tsx
 apps/desktop/src/renderer/settings/runtime-host-profiles-section.tsx


### PR DESCRIPTION
## Summary

- Keep last-ready masked Settings snapshots in renderer memory so reopening Settings does not flash a warning or collapse Runtime Host-owned rows during revalidation.
- Bind Runtime Host settings, connections, and mutation authority to the selected Host key and lifecycle epoch, so reconnect or same-key replacement cannot retain stale write authority.
- Keep Desktop-owned preferences available while Host-owned controls remain visible but inert until the current Runtime Host generation is verified.
- Retire one-shot provider catalog navigation only after `ProvidersPanel` consumes it, and visibly mute cached Host pages while their authority fence is active.
- Preserve error and unavailable feedback without changing IPC contracts or persistent storage.

## Behaviour

Before fixing, the yellow banner flashes each time the settings page is opened.

https://github.com/user-attachments/assets/d8cb6212-d0f5-447c-9814-3caa16df68f8

After fixing, no yellow banner was ever shown.

https://github.com/user-attachments/assets/054a9905-43ea-42ac-90ce-9fe0a8d6e394

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm run typecheck`
- `npm --workspace @maka/desktop test` — 1118/1118 passed
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook` — 172/172 passed
- `npx knip --workspace apps/desktop`
- `npx knip --workspace packages/ui`
- `npm run astryx:surface-inventory` — 191 files, 1 documented exclusion
- Settings cases in the full Electron run — 4/4 passed
- `npm --workspace @maka/desktop run e2e` — 41 passed, 1 skipped

## Review focus

- Runtime Host epoch changes and stale read/write fencing
- masked snapshot caching and secret lifetime
- mixed ownership boundaries on General, Projects, and Data
- one-shot provider catalog intent ownership across warm-cache loading

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex — implementation, race analysis, unit/Storybook/Electron
E2E coverage, regression verification, and pull request preparation. The human
contributor reviewed the contribution and accepts responsibility for it.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
