### PR TITLE
fix(desktop): ship assets/ so the packaged window icon resolves

### DIFF
--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -60,6 +60,14 @@ export default {
       to: 'bundled-tools.json',
     },
     {
+      // The app icon is read at runtime by the BrowserWindow `icon` option, and
+      // `files` above does not carry `assets/`. Electron reports the missing
+      // file as an empty image rather than an error, so without this the
+      // packaged app just draws no window icon.
+      from: 'assets',
+      to: 'assets',
+    },
+    {
       // Menu bar status item art. Without this the packaged app resolves an
       // empty NativeImage and Electron silently shows no icon at all.
       from: 'resources/status',

--- a/apps/desktop/src/main/__tests__/desktop-assets.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-assets.test.ts
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { desktopAssetPath, desktopAssetRoot } from '../desktop-assets.js';
+
+test('a packaged build reads assets from the copy beside the app', () => {
+  const resourcesPath = join('/Applications', 'Maka.app', 'Contents', 'Resources');
+  assert.equal(desktopAssetRoot({ isPackaged: true, resourcesPath }), resourcesPath);
+  assert.equal(
+    desktopAssetPath({ isPackaged: true, resourcesPath }, 'assets', 'icon.png'),
+    join(resourcesPath, 'assets', 'icon.png'),
+  );
+});
+
+test('a dev run keeps resolving the repo layout, not the resources path', () => {
+  const root = desktopAssetRoot({ isPackaged: false, resourcesPath: '/unused' });
+  assert.ok(root.endsWith(join('apps', 'desktop')), `${root} should point at apps/desktop`);
+});

--- a/apps/desktop/src/main/desktop-assets.ts
+++ b/apps/desktop/src/main/desktop-assets.ts
@@ -1,0 +1,28 @@
+import { join } from 'node:path';
+
+/**
+ * Root that `apps/desktop/assets` hangs off at runtime.
+ *
+ * Dev resolves the repo layout: two levels up from the built main bundle in
+ * `dist/main/` lands on `apps/desktop`. A packaged app has no such tree —
+ * `files` in the builder config carries `dist/`, `dist-renderer/` and
+ * `package.json`, and nothing else — so the assets ride along as an extra
+ * resource and the same segments hang off `process.resourcesPath` instead.
+ *
+ * Resolving the dev path in a packaged build fails silently: Electron reports
+ * an unreadable file as an EMPTY NativeImage rather than as an error, and the
+ * BrowserWindow `icon` option simply draws nothing.
+ */
+export function desktopAssetRoot(runtime: {
+  readonly isPackaged: boolean;
+  readonly resourcesPath: string;
+}): string {
+  return runtime.isPackaged ? runtime.resourcesPath : join(import.meta.dirname, '..', '..');
+}
+
+export function desktopAssetPath(
+  runtime: { readonly isPackaged: boolean; readonly resourcesPath: string },
+  ...segments: readonly string[]
+): string {
+  return join(desktopAssetRoot(runtime), ...segments);
+}

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -3,6 +3,7 @@ import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import type { AppSettings } from '@maka/core/settings';
+import { desktopAssetPath } from './desktop-assets.js';
 import { isExternalUrl } from './external-link-guard.js';
 import { readSavedBounds, writeSavedBounds, SAFE_MIN_HEIGHT, SAFE_MIN_WIDTH, type SavedBounds } from './window-state.js';
 import { BrowserViewController } from './browser/controller.js';
@@ -268,7 +269,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
       // / window title bar; .icns / .ico packaging will come with the
       // installer build pass. The asset path resolves from the built
       // dist/main/main.js (two levels up to apps/desktop, then assets).
-      icon: join(import.meta.dirname, '..', '..', 'assets', 'icon.png'),
+      icon: desktopAssetPath({ isPackaged: app.isPackaged, resourcesPath: process.resourcesPath }, 'assets', 'icon.png'),
       // PR-WINDOW-TITLEBAR-0: hide the native title bar so the renderer
       // chrome can extend to the top edge on every platform. macOS keeps
       // `hiddenInset` + traffic-light buttons (top-left); Windows uses


### PR DESCRIPTION
## The bug

`createWindow` resolves the window icon out of `apps/desktop/assets`:

```ts
icon: join(import.meta.dirname, '..', '..', 'assets', 'icon.png'),
```

`files` in `electron-builder.config.mjs` carries `dist/**`, `dist-renderer/**`
and `package.json`. It does not carry `assets/`, and `assets/` is not in
`extraResources` either — so in a packaged app that path does not exist.

It fails silently: `nativeImage` reports an unreadable file as an **empty**
image rather than raising, and `BrowserWindow` then draws no icon at all. The
same trap the `resources/status` entry in that file already documents.

macOS hides it, because the dock uses the bundle icon electron-builder
generates at build time from `icon: 'assets/icon.png'`. Linux has no such
fallback for the window icon.

## The fix

- copy `assets/` beside the app, the way `resources/status` already is
- resolve the root against `process.resourcesPath` when packaged

The dev path is unchanged: two levels up from `dist/main/` still lands on
`apps/desktop`.

## Notes

- `desktop-assets.ts` is a pure helper so the packaged branch is testable
  without booting Electron; both branches are covered.
- Found while working on #3431, but it predates that branch and stands alone —
  #3431 builds on this commit.

## Verification

- `tsc -p apps/desktop/tsconfig.main.json --noEmit` clean
- `node --test dist/main/__tests__/desktop-assets.test.js` — 2/2

I could not verify a packaged build end to end: this machine cannot start an
Electron GUI (it hangs during GUI init), so the dock/window icon was not
observed directly. The path resolution itself is covered by the tests.