### PR TITLE
fix(ui): stop overriding Astryx's chat bubble radius

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -126,11 +126,12 @@ Nothing interactive is square. One ladder, assigned monotonically by box height:
 | Radius | Maka tier | Astryx tier | Assign to |
 |---|---|---|---|
 | 6px | control | inner | chips, keycaps, nested inlays, and product-drawn compact controls |
-| 10px | card | element | cards, rows-as-cards, list containers, chat bubbles; Astryx `Button`, `Input`, `SegmentedControl` |
+| 10px | card | element | cards, rows-as-cards, list containers; Astryx `Button`, `Input`, `SegmentedControl` |
 | 12px | container | container | modals, panels, portal surfaces; Astryx `Card`, `Dialog`, `DropdownMenu` |
+| 28px | chat | chat | the conversation surface as one shape: user bubble, assistant bubble, composer dock. Sourced from Astryx's `--radius-chat` by `ChatMessageBubble` and `ChatComposer` themselves; product CSS never restates it |
 | full | pill (999px) | full (9999px) | badges, pills, circular controls |
 
-- **The Two-Name Rule.** These are one ladder under two vocabularies, and the names never line up: Maka's `control` is Astryx's `inner`, Maka's `card` is Astryx's `element`, Maka's `modal` is Astryx's `container`. Resolve a tier from the box, never from the token name that sounds right. The paired values agree *today* but are independent literals, not aliases — an Astryx upgrade can move one side silently, so a mismatch is a real failure mode rather than an impossibility. Astryx's `--radius-page` (28px) has no Maka tier and no product consumer; anything reaching for a page-level radius is inventing a rung.
+- **The Two-Name Rule.** These are one ladder under two vocabularies, and the names never line up: Maka's `control` is Astryx's `inner`, Maka's `card` is Astryx's `element`, Maka's `modal` is Astryx's `container`. Resolve a tier from the box, never from the token name that sounds right. The paired values agree *today* but are independent literals, not aliases — an Astryx upgrade can move one side silently, so a mismatch is a real failure mode rather than an impossibility. The chat rung is the one tier the product does not assign: `ChatMessageBubble` and `ChatComposer` both resolve `--radius-chat` on their own, which is why the bubble and the dock round together, and why setting a bubble radius or a non-default `density` in product code silently breaks the pair. Astryx's `--radius-page` carries the same 28px literal but is a different token with no Maka tier and no product consumer; reaching for it to match the chat surface is inventing a rung.
 - **The Full-Bleed Rule.** `border-radius: 0` is legal only on true full-bleed rows — an element flush with its container on both sides. Radius and gap move together: if it has breathing room, it has corners.
 - **Proportional marks.** Product-drawn icon plates use ratio-owned radius (~25–27% of the box edge), recorded in prose because Stitch accepts only absolute units.
 

--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -70,6 +70,32 @@ test('narrow right workbar keeps launcher shortcuts and side-chat send button in
   const composerCard = companion.locator('.maka-composer-astryx');
   // Keep ChatComposer's inner elevation visible.
   await expect(composerCard).toHaveCSS('overflow', 'visible');
+
+  // #3452: Side Chat is a branch of the main conversation, not a second
+  // conversation surface, so its dock rounds like the main dock. Both resolve
+  // Astryx's `--radius-chat`, the same token `ChatMessageBubble` defaults to —
+  // a side-only `--_chat-composer-radius` split the bubble from the dock the
+  // moment the bubbles moved back to that default. Compared against the main
+  // composer rather than a literal so an upstream token change moves both or
+  // fails here.
+  const composerRadii = await page.evaluate(() => {
+    const wrappers = [...document.querySelectorAll('.maka-composer-astryx')];
+    const inCompanion = (element: Element) => element.closest('.maka-quote-companion') !== null;
+    const effectiveRadius = (element: Element | undefined) => {
+      if (!element) return null;
+      const styles = getComputedStyle(element);
+      return (
+        styles.getPropertyValue('--_chat-composer-radius').trim() ||
+        styles.getPropertyValue('--radius-chat').trim()
+      );
+    };
+    return {
+      side: effectiveRadius(wrappers.find(inCompanion)),
+      main: effectiveRadius(wrappers.find((element) => !inCompanion(element))),
+    };
+  });
+  expect(composerRadii.side).toBeTruthy();
+  expect(composerRadii.side).toBe(composerRadii.main);
   // Match the long model-label pressure from the reported side-chat screenshot
   // without coupling the fixture's globally useful default model to this test.
   await companion.locator('.maka-composer-model-chip-text').evaluate((element) => {

--- a/apps/desktop/src/renderer/styles/chat-message.css
+++ b/apps/desktop/src/renderer/styles/chat-message.css
@@ -62,26 +62,23 @@
   font: var(--maka-text-body);
 }
 
-/* Padding and max-width belong to ChatMessageBubble; re-declaring those here
-   only forks the primitive. What stays is the product tint, the verbatim-text
-   rule (Maka renders user input as typed, which the primitive has no opinion
-   about) — and, since Visual System 2.0 (T3), the radius TIER.
+/* Padding, max-width and radius belong to ChatMessageBubble; re-declaring any
+   of them here only forks the primitive. What stays is the product tint and the
+   verbatim-text rule (Maka renders user input as typed, which the primitive has
+   no opinion about).
 
-   The primitive resolves `--radius-container` (12px). DESIGN.md §6 assigns
-   radius by box height, and container is scoped to "modals, panels, portal
-   surfaces" — a message bubble is none of those. Measured in the chat fixture
-   the filled user bubble is 44px tall, which lands it in the card tier (10px,
-   "cards, rows-as-cards, list containers"). Astryx publishes no radius prop on
-   this component (only `variant`), so the tier is expressed on Maka's own
-   class rather than by reaching into the primitive's internals.
+   Radius is absent on purpose. The primitive resolves `--radius-chat` (28px),
+   the same token `ChatComposer` reads through `--_chat-composer-radius`, so the
+   bubble and the dock round together as one conversation surface — DESIGN.md §6
+   records that as the chat rung. Astryx publishes no radius prop on this
+   component (only `variant`), so a product radius could only fight the
+   primitive, never configure it.
 
    Scoped to the filled bubble on purpose: the assistant bubble is `ghost` (no
-   fill, measured transparent), so it has no corner to round and inherits
-   nothing it needs to override. */
+   fill, measured transparent), so it carries no tint to override. */
 .maka-chat-message-bubble-user {
   background: var(--chat-user-bg);
   color: var(--chat-user-foreground, var(--foreground));
-  border-radius: var(--radius-surface);
   white-space: pre-wrap;
 }
 

--- a/apps/desktop/src/renderer/styles/quote-side-panel.css
+++ b/apps/desktop/src/renderer/styles/quote-side-panel.css
@@ -78,14 +78,13 @@
   padding-bottom: var(--space-2);
 }
 
-.maka-session-workbar-panel[data-placement="right"]
-  .maka-quote-companion
-  .maka-composer-astryx {
-  --_chat-composer-radius: var(--radius-surface);
-
-  /* Let ChatComposer paint its own radius and elevation. Clipping this wrapper
-     hides the body's hover/focus shadow against the white side panel. */
-}
+/* `.maka-composer-astryx` is deliberately unstyled on this surface. Side Chat is
+   a branch of the main conversation, not a second one, so the composer resolves
+   `--radius-chat` here exactly as it does at full width and pairs with the
+   bubble; a side-only radius token forked the pair the moment the bubbles moved
+   to the primitive's default. The wrapper is also left unclipped — `overflow:
+   hidden` here would hide the body's hover/focus shadow against the white side
+   panel, and `session-workbar.spec.ts` asserts `overflow: visible`. */
 
 .maka-session-workbar-panel[data-placement="right"]
   .maka-quote-companion

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -483,7 +483,6 @@ export function ChatView(props: {
             owns. */}
         <ChatMessageList
           className="maka-chat-message-list maka-chatContent"
-          gap={4}
           emptyState={conversationItems.length === 0 ? emptyContent : undefined}
         >
           {conversationItems.length > 0 ? (
@@ -588,7 +587,6 @@ export function ChatView(props: {
         <ChatMessageList
           className="maka-chat-message-list maka-chatContent"
           data-turn-source-count={turns.length}
-          gap={4}
           isStreaming={streamingActive}
           emptyState={showEmptyState ? emptyContent : undefined}
         >

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -483,7 +483,6 @@ export function ChatView(props: {
             owns. */}
         <ChatMessageList
           className="maka-chat-message-list maka-chatContent"
-          density="compact"
           gap={4}
           emptyState={conversationItems.length === 0 ? emptyContent : undefined}
         >
@@ -589,7 +588,6 @@ export function ChatView(props: {
         <ChatMessageList
           className="maka-chat-message-list maka-chatContent"
           data-turn-source-count={turns.length}
-          density="compact"
           gap={4}
           isStreaming={streamingActive}
           emptyState={showEmptyState ? emptyContent : undefined}


### PR DESCRIPTION
## Summary

The bubble and the composer are designed to share one radius token. `ChatMessageBubble` defaults to `var(--radius-chat)` (28px); `ChatComposer` reads the same token via `--_chat-composer-radius`. The product overrode the bubble twice — `density="compact"` dropped it to 12px, then `.maka-chat-message-bubble-user` pushed it to 10px — and left the main composer alone.

<img width="4816" height="1736" alt="image" src="https://github.com/user-attachments/assets/4be36291-7a52-4f3a-9b59-9e2724e653c7" />

<img width="4816" height="1736" alt="image" src="https://github.com/user-attachments/assets/1bb30a37-2842-4a5a-943c-b2cb7130df7f" />

*Full view, light (top) then dark (bottom). Story `product-shell-official-appshell--native-conversation`, 1180×788 @2x, scrolled to top.*

<img width="3130" height="801" alt="image" src="https://github.com/user-attachments/assets/570fd722-c867-4f6a-807a-09facce30544" />

<img width="3130" height="801" alt="image" src="https://github.com/user-attachments/assets/6a0ad0eb-175d-414b-89e6-febacbe32391" />

*Corner zoom on the bubble/dock join, light (top) then dark (bottom). Same story and conditions. The AFTER bubble sits ~32px lower: the balanced tier lengthens the transcript.*

Deletions only, no new value. 28px is what the component picks on its own once the overrides are gone.

Side Chat is covered by the same rule. `quote-side-panel.css` pinned the side composer to `--radius-surface` (10px), which paired with the bubble only because product CSS forced the bubble to 10px as well; that override goes too. Side Chat is a branch of the main conversation, not a second conversation surface, so it resolves the same token rather than carrying its own interaction language.

<img width="1396" height="1286" alt="image" src="https://github.com/user-attachments/assets/7786963e-d8a7-463a-b95a-992b6fbd4709" />

*Side Chat (quote companion) at the 320px workbar floor, real cascade with no harness overrides.*

`density` is a spacing tier, so dropping it also moves `ChatMessage`'s children gap 2px → 4px and the transcript reads looser — bundled with the tier, intended. Bubble padding is *not* affected: Astryx's `paddingCompact` and `paddingBalanced` resolve to the same StyleX atoms. `gap={4}` is removed from both call sites: under `balanced` the tier already selects the identical `--spacing-4` atom (`x18g69wz`), so the prop restated what it was reading.

`DESIGN.md` §6 moves in the same PR: chat bubbles leave the 10px card row, a 28px chat rung records what `--radius-chat` governs, and the Two-Name Rule no longer claims nothing in the product renders at 28px — `ChatComposer` already did, on `main`.

Refs #3446 — same root as its F1 finding, separate intent, none of its other work folded in.

## Verification

Playwright computed-style sweeps against a live Storybook dev server, before and after, same branch and same server. Page pinned, `scrollTop` 0, identical framing. **Light and dark — identical results in both.**

Main conversation:

| | before | after |
|---|---|---|
| user bubble | `10px` | `28px` |
| assistant bubble | `12px` | `28px` (ghost, transparent) |
| user bubble padding | `12px 16px` | `12px 16px` |
| composer drawer | `28px 28px 0 0` | `28px 28px 0 0` |
| list density | `compact` | `balanced` |

Side Chat (quote companion), measured at the 320px workbar floor and at 600px, harness carrying no CSS overrides:

| | on `main` | first push | now |
|---|---|---|---|
| user / assistant bubble | `10px` | `28px` | `28px` |
| composer drawer | `10px` | `10px` | `28px` |
| `--_chat-composer-radius` | `10px` | `10px` | unset → `--radius-chat` |

The middle column is the regression M4n5ter caught: the first push fixed the main conversation and split Side Chat. Both widths and both colour schemes agree.

Full-page sweep of every visible element's radius, font-size/line-height, colour and gap on the main story. Everything that moved is accounted for, nothing else:

- radius `10px` ×35→32, `12px` ×3→1, `28px` ×1→6 — distinct radii stay at 10, no new value in the ladder
- gap `2px` ×11→5, `4px` ×22→27 — `ChatMessage`'s `childrenGap`, the tier's own spacing
- 435→431 visible elements — signature diff shows every other element is the same element with `compact` renamed to `balanced`; the four that leave are the last message's tail, pushed below the fold as `scrollHeight` grows 1473→1505px
- removing `gap={4}` changed nothing: the sweep is byte-identical with and without it, in both schemes

`density="compact"` on `<Markdown>` (`chat-turn.tsx:1107`) is left alone — a different density axis with its own `[data-density="compact"]` contract.

Ran: `npm run format` (no fixes), `@maka/ui` tsc build (clean), focused tests `chat-turn-answer-identity` / `chat-turn-steering-order` / `chat-conversation-items` / `transcript-projection` (23 pass, 0 fail). Not run: repo-wide suite (CI), Electron E2E.

## Review focus

No Storybook story renders Side Chat, which is why the first push's sweep missed it. The measurements above come from a scratch story kept out of the commit. The natural permanent seam is `apps/desktop/e2e/session-workbar.spec.ts`, which already asserts `overflow` on `.maka-composer-astryx` — adding a radius assertion there would pin the pairing. Say the word and I will add it here rather than in a follow-up.

`packages/ui/src/chat-surface-layout.tsx:35` says `chat-surface-layout.test.tsx` holds the balanced density value. That file does not exist in the repo — the `ChatLayout` density default is unguarded. Pre-existing, out of scope.

`DESIGN.md` §6 is a deliberate revision of the design authority, written as a rule rather than an exception. Please review that wording as policy.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — the deletions, the DESIGN.md §6 revision, the CSS comment rewrites, the Playwright measurement harnesses, and this body. Every number above comes from those harnesses against a live server, not from reasoning about the cascade. Commits carry a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

