### PR TITLE
fix(desktop): let the whole Settings pane scroll

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -47,3 +47,41 @@ test('settings hides expanded workbar chrome and restores it on close', async ({
   await expect(workbarToolbar).toBeVisible();
   await expect(taskTab).toBeVisible();
 });
+
+test('wide settings gutters scroll the whole main pane', async ({ window: page }) => {
+  await page.setViewportSize({ width: 1600, height: 520 });
+  await page.getByRole('button', { name: '设置' }).click();
+  await page.getByRole('button', { name: '通用', exact: true }).click();
+  await expect(page.getByRole('textbox', { name: '助手语气偏好' })).toBeEnabled();
+
+  const pane = page.locator('.settingsMainPane');
+  const content = pane.locator('.settingsPageStack').first();
+  const geometry = await pane.evaluate((element) => {
+    const paneRect = element.getBoundingClientRect();
+    const contentElement = element.querySelector('.settingsPageStack');
+    const contentRect = contentElement?.getBoundingClientRect();
+    const layoutContent = element.querySelector('.astryx-layout-content');
+    if (!contentRect || !layoutContent) throw new Error('Settings layout is incomplete');
+    return {
+      blankRight: paneRect.right - contentRect.right,
+      clientHeight: element.clientHeight,
+      contentOverflowY: getComputedStyle(layoutContent).overflowY,
+      paneOverflowY: getComputedStyle(element).overflowY,
+      scrollHeight: element.scrollHeight,
+      wheelPoint: {
+        x: Math.floor((contentRect.right + paneRect.right) / 2),
+        y: Math.floor(Math.min(contentRect.top + 120, paneRect.bottom - 40)),
+      },
+    };
+  });
+
+  expect(geometry.blankRight).toBeGreaterThan(40);
+  expect(geometry.scrollHeight).toBeGreaterThan(geometry.clientHeight);
+  expect(geometry.contentOverflowY).not.toBe('auto');
+  expect(geometry.paneOverflowY).toBe('auto');
+
+  await page.mouse.move(geometry.wheelPoint.x, geometry.wheelPoint.y);
+  await page.mouse.wheel(0, 600);
+  await expect.poll(() => pane.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+  await expect(content).toBeVisible();
+});

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -674,7 +674,10 @@ export function SettingsSurface(props: {
             aria-label={copy.contentLabel}
           >
             <Layout
-              height="fill"
+              /* The rounded main pane owns page scrolling. Keeping scroll on
+                 the centered LayoutContent made the wide gutters inert and
+                 parked the scrollbar beside the 920px content column. */
+              height="auto"
               padding={0}
               /* One column width for EVERY section. Usage used to get 920
                  while the rest sat in a 640 column, so switching pages
@@ -709,7 +712,7 @@ export function SettingsSurface(props: {
                 </LayoutHeader>
               )}
               content={(
-                <LayoutContent padding={6}>
+                <LayoutContent padding={6} isScrollable={false}>
                   {loading ? (
                     <SettingsSkeleton />
                   ) : requiresRuntimeHost && runtimeHostContentStatus === 'error' ? (

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -44,7 +44,11 @@
   border: 0;
   border-radius: var(--radius-modal);
   background: var(--agents-content-area-bg);
-  overflow: hidden;
+  /* The pane, not the centered 920px column, is the page scroll owner. This
+     lets wheel input from either wide gutter scroll and keeps the native
+     scrollbar against the pane's outer edge. */
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .settingsPageHeader {

--- a/apps/desktop/stories/settings/provider-settings.stories.tsx
+++ b/apps/desktop/stories/settings/provider-settings.stories.tsx
@@ -330,7 +330,7 @@ function ProviderStoryFrame(props: {
               window's width and hides exactly the layout question a page-level
               form raises. */}
           <Layout
-            height="fill"
+            height="auto"
             padding={0}
             contentWidth={920}
             header={(
@@ -343,7 +343,7 @@ function ProviderStoryFrame(props: {
               </LayoutHeader>
             )}
             content={(
-              <LayoutContent padding={6}>
+              <LayoutContent padding={6} isScrollable={false}>
                 <SettingsPage className="settingsModelsPage">
                   <ProvidersPanel bridge={props.bridge} />
                 </SettingsPage>


### PR DESCRIPTION
## Summary

- Move vertical scroll ownership from the centered Settings content column to the whole rounded main pane.
- Let wheel input over either wide gutter scroll the page and keep the native scrollbar at the pane's outer edge.
- Preserve the existing 920px content width and mirror the production scroll structure in Storybook.
- Add Electron E2E coverage for wide-gutter wheel scrolling and scroll ownership.

## Before / after

https://github.com/user-attachments/assets/edf6b42f-01b4-4b2d-8d7f-80d7df60207d


https://github.com/user-attachments/assets/a63f069d-7709-4152-a8da-59eb4e27ec8b



## Draft status

- [ ] Add the before/after visual evidence above.
- [ ] Rebase after #3450 merges and retain both Settings E2E tests.

The current three-way merge against #3450 auto-merges the production TSX/CSS changes. Only `apps/desktop/e2e/settings.spec.ts` conflicts because both branches append a test at the end of the file; resolving it means keeping both tests.

## Verification

- `npx biome check apps/desktop/e2e/settings.spec.ts apps/desktop/src/renderer/settings/settings-surface.tsx apps/desktop/src/renderer/styles/settings/nav-sidebar.css apps/desktop/stories/settings/provider-settings.stories.tsx`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run e2e -- e2e/settings.spec.ts` — 3/3 passed
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook` — 160/160 stories passed
- `git diff --check`

Manual/native visual acceptance and screenshots were intentionally skipped for this draft.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

OpenAI Codex — investigated the scroll owner, implemented the renderer/CSS/Storybook changes, added Electron E2E coverage, verified the branch, checked overlap with #3450, and prepared this Draft PR. The human contributor reviewed the intended behavior and authorized publication.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
