### PR TITLE
test(runtime-host): attribute Windows startup stalls

### DIFF
--- a/apps/desktop/src/main/runtime-host-desktop-manager.ts
+++ b/apps/desktop/src/main/runtime-host-desktop-manager.ts
@@ -623,7 +623,7 @@ class RuntimeHostDesktopManagerImpl implements RuntimeHostDesktopManager {
         await this.waitForHostRetirement(result.registration, signal);
         continue;
       }
-      throw runtimeHostStartupError(result.reason);
+      throw runtimeHostStartupError(result.reason, result.diagnostic);
     }
   }
 

--- a/packages/cli/src/runtime-host-cli-context.ts
+++ b/packages/cli/src/runtime-host-cli-context.ts
@@ -161,7 +161,7 @@ export async function connectRuntimeHostCli(
       );
     }
     if (connected.kind === 'failed') {
-      throw runtimeHostStartupError(connected.reason);
+      throw runtimeHostStartupError(connected.reason, connected.diagnostic);
     }
     return connected.connection;
   };

--- a/packages/runtime-host/src/__tests__/handshake-compatibility.test.ts
+++ b/packages/runtime-host/src/__tests__/handshake-compatibility.test.ts
@@ -29,7 +29,7 @@ import {
   STORAGE_ROOT_MARKER_FILE,
   STORAGE_ROOT_MARKER_SCHEMA_VERSION,
 } from '@maka/storage/root-authority';
-import { connectResolvedRuntimeHost, type ConnectRuntimeHostResult } from '../client/connection.js';
+import { connectResolvedRuntimeHost } from '../client/connection.js';
 import { prepareRuntimeHostEndpoint } from '../control/endpoint.js';
 import { removeHostRegistration, writeHostRegistration } from '../control/registration.js';
 import {
@@ -143,6 +143,52 @@ test('rejects an epoch-23 Host before any domain command', async () => {
     },
   );
   assert.equal(admittedRequest, undefined);
+});
+
+test('records a registration root mismatch before connecting the endpoint', async () => {
+  await withForgedHandshakePeer(
+    async () => {
+      assert.fail('registration mismatch must not connect to the endpoint');
+    },
+    async (result) => {
+      assert.equal(result.kind, 'unavailable');
+      if (result.kind !== 'unavailable') return;
+      assert.equal(result.reason, 'root_mismatch');
+      assert.equal(result.endpointConnected, false);
+    },
+    {
+      registrationRootId: randomBytes(32).toString('hex'),
+      expectConnection: false,
+    },
+  );
+});
+
+test('records a root mismatch returned after connecting and handshaking', async () => {
+  await withForgedHandshakePeer(
+    async (transport, hostEpoch) => {
+      const hello = decodeClientFrame(await transport.read(2_000));
+      assert.ok('kind' in hello && hello.kind === 'hello');
+      await writeProtocolFrame(transport, {
+        kind: 'accepted',
+        rootId: randomBytes(32).toString('hex'),
+        hostEpoch,
+        connectionId: 'forged-root-mismatch-connection',
+        selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+        compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+        compositionId: 'maka.interactive',
+        compositionRevision: '1',
+        state: 'ready',
+      });
+      await transport.closed;
+    },
+    async (result) => {
+      assert.equal(result.kind, 'unavailable');
+      if (result.kind !== 'unavailable') return;
+      assert.equal(result.reason, 'root_mismatch');
+      assert.equal(result.endpointConnected, true);
+    },
+    { prepareAfterListen: false },
+  );
 });
 
 interface V0_1_11ClientHello {
@@ -268,10 +314,20 @@ function requireString(value: unknown, label: string): string {
   return value;
 }
 
+type ResolvedConnectRuntimeHostResult = Exclude<
+  Awaited<ReturnType<typeof connectResolvedRuntimeHost>>,
+  { kind: 'election_deadline_elapsed' }
+>;
+
 async function withForgedHandshakePeer(
   serve: (transport: FramedTransport, hostEpoch: string, rootId: string) => Promise<void>,
-  run: (result: ConnectRuntimeHostResult) => Promise<void>,
-  options: { readonly registrationCompatibilityEpoch?: number } = {},
+  run: (result: ResolvedConnectRuntimeHostResult) => Promise<void>,
+  options: {
+    readonly registrationCompatibilityEpoch?: number;
+    readonly registrationRootId?: string;
+    readonly expectConnection?: boolean;
+    readonly prepareAfterListen?: boolean;
+  } = {},
 ): Promise<void> {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-handshake-'));
   const rootPath = join(base, 'root');
@@ -308,12 +364,14 @@ async function withForgedHandshakePeer(
     );
   });
   try {
-    await listen(server, endpoint.path);
-    await endpoint.prepareAfterListen();
+    if (options.expectConnection !== false) {
+      await listen(server, endpoint.path);
+      if (options.prepareAfterListen !== false) await endpoint.prepareAfterListen();
+    }
     await writeHostRegistration(controlDirectory, {
       kind: 'maka-runtime-host',
       schemaVersion: RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
-      rootId: capability.rootId,
+      rootId: options.registrationRootId ?? capability.rootId,
       hostEpoch,
       endpoint: endpoint.path,
       protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
@@ -341,7 +399,7 @@ async function withForgedHandshakePeer(
     } finally {
       if (result.kind === 'connected') await result.connection.close();
     }
-    await serverTask.promise;
+    if (options.expectConnection !== false) await serverTask.promise;
   } finally {
     await closeServer(server);
     await removeHostRegistration(controlDirectory, hostEpoch).catch(() => undefined);

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -217,7 +217,103 @@ describe('non-serving Runtime Host kernel', () => {
         },
       );
 
-      assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
+      assert.equal(result.kind, 'failed');
+      if (result.kind !== 'failed') return;
+      assert.equal(result.reason, 'startup_timeout');
+      assert.ok(result.diagnostic);
+      assert.equal(result.diagnostic.candidateLaunches, 1);
+    });
+  });
+
+  test('attributes an unresponsive endpoint to the exact running Candidate attempt', async () => {
+    await withHostPaths(async (paths) => {
+      let connectCalls = 0;
+      const result = await connectOrSpawnRuntimeHostWithDependencies(
+        {
+          rootPath: paths.root,
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          electionDeadlineMs: 500,
+        },
+        {
+          random: () => 0.5,
+          connectHost: async () => {
+            connectCalls += 1;
+            return connectCalls === 1
+              ? { kind: 'unavailable' as const, reason: 'not_registered' as const }
+              : { kind: 'election_deadline_elapsed' as const, endpointConnected: true };
+          },
+          launchCandidate: () => ({
+            spawned: Promise.resolve({
+              pid: 4242,
+              startupAttemptId: STARTUP_ATTEMPT_A,
+              exited: new Promise<never>(() => undefined),
+              startupFailure: new Promise<never>(() => undefined),
+            }),
+          }),
+        },
+      );
+
+      assert.equal(result.kind, 'failed');
+      if (result.kind !== 'failed') return;
+      assert.equal(result.reason, 'host_unresponsive');
+      assert.ok(result.diagnostic);
+      assert.equal(result.diagnostic.candidateLaunches, 1);
+      assert.equal(result.diagnostic.sawEndpointConnected, true);
+      assert.deepEqual(result.diagnostic.observations, {
+        notRegistered: 1,
+        connectFailed: 0,
+        handshakeFailed: 0,
+        connected: 0,
+        readyWaitFailed: 0,
+        deadlineElapsed: 1,
+      });
+      assert.deepEqual(result.diagnostic.latestCandidate, {
+        pid: 4242,
+        startupAttemptId: STARTUP_ATTEMPT_A,
+        state: 'running',
+      });
+    });
+  });
+
+  test('counts a coalesced Candidate launch only once across repeated election requests', async () => {
+    await withHostPaths(async (paths) => {
+      let launchRequests = 0;
+      const launch = {
+        spawned: Promise.resolve({
+          pid: 4242,
+          startupAttemptId: STARTUP_ATTEMPT_A,
+          exited: new Promise<never>(() => undefined),
+          startupFailure: new Promise<never>(() => undefined),
+        }),
+      };
+      const result = await connectOrSpawnRuntimeHostWithDependencies(
+        {
+          rootPath: paths.root,
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          electionDeadlineMs: 800,
+        },
+        {
+          random: () => 0,
+          connectHost: async () => ({
+            kind: 'unavailable' as const,
+            reason: 'not_registered' as const,
+          }),
+          launchCandidate: () => {
+            launchRequests += 1;
+            return launch;
+          },
+        },
+      );
+
+      assert.ok(launchRequests > 1);
+      assert.equal(result.kind, 'failed');
+      if (result.kind !== 'failed') return;
+      assert.equal(result.reason, 'startup_timeout');
+      assert.equal(result.diagnostic?.candidateLaunches, 1);
     });
   });
 
@@ -1305,7 +1401,11 @@ describe('non-serving Runtime Host kernel', () => {
               },
             },
           );
-          assert.deepEqual(staleDiscovery, { kind: 'failed', reason: 'startup_timeout' });
+          assert.equal(staleDiscovery.kind, 'failed');
+          if (staleDiscovery.kind !== 'failed') return;
+          assert.equal(staleDiscovery.reason, 'startup_timeout');
+          assert.ok(staleDiscovery.diagnostic);
+          assert.equal(staleDiscovery.diagnostic.candidateLaunches, staleLaunchAttempts);
           assert.ok(staleLaunchAttempts > 0);
 
           const successor = await connectOrSpawnRuntimeHostWithDependencies(
@@ -1681,7 +1781,10 @@ describe('non-serving Runtime Host kernel', () => {
         candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
         electionDeadlineMs: 100,
       });
-      assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
+      assert.equal(result.kind, 'failed');
+      if (result.kind !== 'failed') return;
+      assert.equal(result.reason, 'startup_timeout');
+      assert.ok(result.diagnostic);
       assert.equal(await tryAcquireInteractiveRootOwner(capability), undefined);
       await owner?.close();
     });
@@ -1788,7 +1891,17 @@ describe('non-serving Runtime Host kernel', () => {
           1_000,
           'election exceeded its total deadline',
         );
-        assert.deepEqual(result, { kind: 'failed', reason: 'host_unresponsive' });
+        assert.equal(result.kind, 'failed');
+        if (result.kind !== 'failed') return;
+        assert.equal(result.reason, 'host_unresponsive');
+        assert.ok(result.diagnostic);
+        assert.equal(result.diagnostic.deadlineMs, 50);
+        assert.ok(result.diagnostic.elapsedMs >= 40);
+        assert.equal(result.diagnostic.candidateLaunches, 0);
+        assert.equal(result.diagnostic.sawEndpointConnected, true);
+        assert.ok(result.diagnostic.observations.deadlineElapsed >= 1);
+        assert.equal(result.diagnostic.lastRegistration?.pid, attempt.pid);
+        assert.equal(result.diagnostic.lastRegistration?.state, 'ready');
         assert.equal(launchCount, 0);
       } finally {
         if (stopped) process.kill(attempt.pid, 'SIGCONT');

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -66,6 +66,7 @@ import {
   RUNTIME_HOST_COMPATIBILITY_EPOCH,
   RUNTIME_HOST_MAX_MESSAGE_BYTES,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
   type ClientFrame,
 } from '../protocol/index.js';
 import {
@@ -135,6 +136,25 @@ export type GenericRuntimeHostCompositionFactory = RuntimeHostCompositionFactory
 export type GenericRuntimeHostCompositionSource = RuntimeHostCompositionSource<'interactive'>;
 // @ts-expect-error Runtime Host kernel options are concretely interactive.
 export type GenericRuntimeHostKernelOptions = RuntimeHostKernelOptions<'interactive'>;
+
+function diagnosticRegistration(state: 'ready' | 'draining') {
+  return {
+    kind: 'maka-runtime-host',
+    schemaVersion: RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
+    rootId: '00000000-0000-4000-8000-000000000003',
+    hostEpoch: '00000000-0000-4000-8000-000000000004',
+    endpoint: '\\\\.\\pipe\\maka-runtime-host-diagnostic',
+    protocolMin: CURRENT_PROTOCOL.min,
+    protocolMax: CURRENT_PROTOCOL.max,
+    compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+    compositionId: KERNEL_COMPOSITION.descriptor.id,
+    compositionRevision: KERNEL_COMPOSITION.descriptor.revision,
+    lifecycleMode: 'ephemeral',
+    state,
+    pid: 4242,
+    createdAt: '2026-08-22T00:00:00.000Z',
+  } as const;
+}
 
 describe('non-serving Runtime Host kernel', () => {
   test('reports a recovery failure when the election produces no ready Host', async () => {
@@ -241,7 +261,11 @@ describe('non-serving Runtime Host kernel', () => {
           connectHost: async () => {
             connectCalls += 1;
             return connectCalls === 1
-              ? { kind: 'unavailable' as const, reason: 'not_registered' as const }
+              ? {
+                  kind: 'unavailable' as const,
+                  reason: 'not_registered' as const,
+                  endpointConnected: false,
+                }
               : { kind: 'election_deadline_elapsed' as const, endpointConnected: true };
           },
           launchCandidate: () => ({
@@ -262,12 +286,14 @@ describe('non-serving Runtime Host kernel', () => {
       assert.equal(result.diagnostic.candidateLaunches, 1);
       assert.equal(result.diagnostic.sawEndpointConnected, true);
       assert.deepEqual(result.diagnostic.observations, {
+        totalResults: 2,
         notRegistered: 1,
         connectFailed: 0,
         handshakeFailed: 0,
         connected: 0,
         readyWaitFailed: 0,
         deadlineElapsed: 1,
+        otherResults: 0,
       });
       assert.deepEqual(result.diagnostic.latestCandidate, {
         pid: 4242,
@@ -277,45 +303,170 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
-  test('counts a coalesced Candidate launch only once across repeated election requests', async () => {
+  test('keeps diagnostic observation buckets reconcilable for unclassified results', async () => {
     await withHostPaths(async (paths) => {
-      let launchRequests = 0;
-      const launch = {
-        spawned: Promise.resolve({
-          pid: 4242,
-          startupAttemptId: STARTUP_ATTEMPT_A,
-          exited: new Promise<never>(() => undefined),
-          startupFailure: new Promise<never>(() => undefined),
-        }),
-      };
+      let connectCalls = 0;
       const result = await connectOrSpawnRuntimeHostWithDependencies(
         {
           rootPath: paths.root,
           protocol: CURRENT_PROTOCOL,
           compositionId: KERNEL_COMPOSITION.descriptor.id,
           candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
-          electionDeadlineMs: 800,
+          electionDeadlineMs: 500,
         },
         {
           random: () => 0,
-          connectHost: async () => ({
-            kind: 'unavailable' as const,
-            reason: 'not_registered' as const,
-          }),
-          launchCandidate: () => {
-            launchRequests += 1;
-            return launch;
+          connectHost: async () => {
+            connectCalls += 1;
+            if (connectCalls === 1) {
+              return {
+                kind: 'draining' as const,
+                registration: diagnosticRegistration('draining'),
+              };
+            }
+            if (connectCalls === 2) {
+              return {
+                kind: 'unavailable' as const,
+                reason: 'invalid_registration' as const,
+                endpointConnected: false,
+              };
+            }
+            return { kind: 'election_deadline_elapsed' as const, endpointConnected: true };
           },
+          launchCandidate: () => ({ spawned: Promise.resolve({ pid: process.pid }) }),
         },
       );
 
-      assert.ok(launchRequests > 1);
       assert.equal(result.kind, 'failed');
       if (result.kind !== 'failed') return;
-      assert.equal(result.reason, 'startup_timeout');
-      assert.equal(result.diagnostic?.candidateLaunches, 1);
+      assert.equal(result.reason, 'host_unresponsive');
+      assert.deepEqual(result.diagnostic?.observations, {
+        totalResults: 3,
+        notRegistered: 0,
+        connectFailed: 0,
+        handshakeFailed: 0,
+        connected: 0,
+        readyWaitFailed: 0,
+        deadlineElapsed: 1,
+        otherResults: 2,
+      });
+      const observations = result.diagnostic?.observations;
+      assert.equal(
+        observations?.totalResults,
+        (observations?.notRegistered ?? 0) +
+          (observations?.connectFailed ?? 0) +
+          (observations?.handshakeFailed ?? 0) +
+          (observations?.connected ?? 0) +
+          (observations?.deadlineElapsed ?? 0) +
+          (observations?.otherResults ?? 0),
+      );
     });
   });
+
+  for (const handshakeResult of [
+    {
+      name: 'draining',
+      result: {
+        kind: 'draining' as const,
+        registration: diagnosticRegistration('draining'),
+      },
+    },
+    {
+      name: 'non-blocking incompatible',
+      result: {
+        kind: 'incompatible' as const,
+        registration: diagnosticRegistration('ready'),
+        handshake: {
+          kind: 'incompatible' as const,
+          hostEpoch: '00000000-0000-4000-8000-000000000004',
+          protocolMin: CURRENT_PROTOCOL.min,
+          protocolMax: CURRENT_PROTOCOL.max,
+          compatibilityEpoch: RUNTIME_HOST_COMPATIBILITY_EPOCH,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          compositionRevision: KERNEL_COMPOSITION.descriptor.revision,
+          state: 'ready' as const,
+          replacement: 'wait_for_idle_exit' as const,
+        },
+      },
+    },
+    {
+      name: 'registration root mismatch',
+      result: {
+        kind: 'unavailable' as const,
+        reason: 'root_mismatch' as const,
+        endpointConnected: false,
+        registration: diagnosticRegistration('ready'),
+      },
+      expectedEndpointConnected: false,
+    },
+    {
+      name: 'handshake root mismatch',
+      result: {
+        kind: 'unavailable' as const,
+        reason: 'root_mismatch' as const,
+        endpointConnected: true,
+        registration: diagnosticRegistration('ready'),
+      },
+      expectedEndpointConnected: true,
+    },
+    {
+      name: 'epoch mismatch',
+      result: {
+        kind: 'unavailable' as const,
+        reason: 'epoch_mismatch' as const,
+        endpointConnected: true,
+        registration: diagnosticRegistration('ready'),
+      },
+      expectedEndpointConnected: true,
+    },
+    {
+      name: 'composition mismatch',
+      result: {
+        kind: 'unavailable' as const,
+        reason: 'composition_mismatch' as const,
+        endpointConnected: true,
+        registration: diagnosticRegistration('ready'),
+      },
+      expectedEndpointConnected: true,
+    },
+  ]) {
+    test(`records ${handshakeResult.name} endpoint evidence exactly`, async () => {
+      await withHostPaths(async (paths) => {
+        const launch = {
+          spawned: Promise.resolve({
+            pid: 4242,
+            startupAttemptId: STARTUP_ATTEMPT_A,
+            exited: new Promise<never>(() => undefined),
+            startupFailure: new Promise<never>(() => undefined),
+          }),
+        };
+        const result = await connectOrSpawnRuntimeHostWithDependencies(
+          {
+            rootPath: paths.root,
+            protocol: CURRENT_PROTOCOL,
+            compositionId: KERNEL_COMPOSITION.descriptor.id,
+            candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+            electionDeadlineMs: 300,
+          },
+          {
+            random: () => 0,
+            connectHost: async () => handshakeResult.result,
+            launchCandidate: () => launch,
+          },
+        );
+
+        assert.equal(result.kind, 'failed');
+        if (result.kind !== 'failed') return;
+        assert.equal(result.reason, 'startup_timeout');
+        assert.equal(
+          result.diagnostic?.sawEndpointConnected,
+          'expectedEndpointConnected' in handshakeResult
+            ? handshakeResult.expectedEndpointConnected
+            : true,
+        );
+      });
+    });
+  }
 
   test('keeps one live Candidate in flight for the whole election', async () => {
     await withHostPaths(async (paths) => {
@@ -342,7 +493,10 @@ describe('non-serving Runtime Host kernel', () => {
         },
       );
 
-      assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
+      assert.equal(result.kind, 'failed');
+      if (result.kind !== 'failed') return;
+      assert.equal(result.reason, 'startup_timeout');
+      assert.equal(result.diagnostic?.candidateLaunches, 1);
       assert.equal(launches, 1);
     });
   });
@@ -377,7 +531,10 @@ describe('non-serving Runtime Host kernel', () => {
         },
       );
 
-      assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
+      assert.equal(result.kind, 'failed');
+      if (result.kind !== 'failed') return;
+      assert.equal(result.reason, 'startup_timeout');
+      assert.equal(result.diagnostic?.candidateLaunches, 2);
       assert.equal(launches, 2);
     });
   });
@@ -409,7 +566,10 @@ describe('non-serving Runtime Host kernel', () => {
         },
       );
 
-      assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
+      assert.equal(result.kind, 'failed');
+      if (result.kind !== 'failed') return;
+      assert.equal(result.reason, 'startup_timeout');
+      assert.equal(result.diagnostic?.candidateLaunches, 2);
       assert.equal(launches, 2);
     });
   });

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -320,7 +320,14 @@ test('owned candidate settlement requires a clean process exit', async () => {
   });
 
   const candidate = await launch.spawned;
+  assert.match(
+    candidate.startupAttemptId ?? '',
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+  );
+  assert.ok(candidate.exited);
+  const exited = candidate.exited;
   assert.equal(await candidate.settle(2_000), false);
+  assert.deepEqual(await exited, { code: 1, signal: null });
 });
 
 test('owned candidate can be released to the enclosing environment without termination', async () => {

--- a/packages/runtime-host/src/__tests__/startup-error.test.ts
+++ b/packages/runtime-host/src/__tests__/startup-error.test.ts
@@ -43,12 +43,14 @@ test('keeps an unresponsive Host retryable and includes bounded diagnostics', ()
     candidateLaunches: 1,
     sawEndpointConnected: true,
     observations: {
+      totalResults: 6,
       notRegistered: 1,
       connectFailed: 0,
       handshakeFailed: 2,
       connected: 1,
       readyWaitFailed: 1,
       deadlineElapsed: 1,
+      otherResults: 1,
     },
     lastRegistration: {
       pid: 42,
@@ -63,7 +65,9 @@ test('keeps an unresponsive Host retryable and includes bounded diagnostics', ()
     },
   });
   assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
-  assert.match(error.message, /stopped responding/u);
+  assert.match(error.message, /did not become ready before the startup deadline/u);
+  assert.match(error.message, /retrying/u);
+  assert.match(error.message, /MAKA_RUNTIME_HOST_ELECTION_DEADLINE_MS/u);
   assert.match(error.message, /election diagnostic/u);
   assert.match(error.message, /"state":"recovering"/u);
   assert.match(error.message, /"startupAttemptId":"00000000/u);
@@ -76,12 +80,14 @@ test('includes bounded election evidence when startup times out before an endpoi
     candidateLaunches: 1,
     sawEndpointConnected: false,
     observations: {
+      totalResults: 4,
       notRegistered: 4,
       connectFailed: 0,
       handshakeFailed: 0,
       connected: 0,
       readyWaitFailed: 0,
       deadlineElapsed: 0,
+      otherResults: 0,
     },
     latestCandidate: {
       pid: 42,
@@ -90,7 +96,8 @@ test('includes bounded election evidence when startup times out before an endpoi
     },
   });
 
-  assert.match(error.message, /did not become ready/u);
+  assert.match(error.message, /became ready/u);
+  assert.match(error.message, /MAKA_RUNTIME_HOST_ELECTION_DEADLINE_MS/u);
   assert.match(error.message, /"sawEndpointConnected":false/u);
   assert.match(error.message, /"candidateLaunches":1/u);
 });

--- a/packages/runtime-host/src/__tests__/startup-error.test.ts
+++ b/packages/runtime-host/src/__tests__/startup-error.test.ts
@@ -36,21 +36,63 @@ test('presents migration blockers with a permanent previous-release recovery pat
   assert.match(error.message, /OPERATIONAL_STATE_MIGRATION_BLOCKED/u);
 });
 
-test('keeps an unresponsive Host retryable', () => {
-  const error = runtimeHostStartupError('host_unresponsive');
+test('keeps an unresponsive Host retryable and includes bounded diagnostics', () => {
+  const error = runtimeHostStartupError('host_unresponsive', {
+    deadlineMs: 45_000,
+    elapsedMs: 45_001,
+    candidateLaunches: 1,
+    sawEndpointConnected: true,
+    observations: {
+      notRegistered: 1,
+      connectFailed: 0,
+      handshakeFailed: 2,
+      connected: 1,
+      readyWaitFailed: 1,
+      deadlineElapsed: 1,
+    },
+    lastRegistration: {
+      pid: 42,
+      state: 'recovering',
+      lifecycleMode: 'ephemeral',
+      generation: '0.1.11',
+    },
+    latestCandidate: {
+      pid: 42,
+      startupAttemptId: '00000000-0000-4000-8000-000000000001',
+      state: 'running',
+    },
+  });
   assert.equal(error instanceof RuntimeHostPermanentReconnectError, false);
-  assert.match(error.message, /did not become ready before the startup deadline/u);
+  assert.match(error.message, /stopped responding/u);
+  assert.match(error.message, /election diagnostic/u);
+  assert.match(error.message, /"state":"recovering"/u);
+  assert.match(error.message, /"startupAttemptId":"00000000/u);
 });
 
-test('tells both timeout reasons how to widen the election window', () => {
-  assert.match(
-    runtimeHostStartupError('host_unresponsive').message,
-    /MAKA_RUNTIME_HOST_ELECTION_DEADLINE_MS/u,
-  );
-  assert.match(
-    runtimeHostStartupError('startup_timeout').message,
-    /MAKA_RUNTIME_HOST_ELECTION_DEADLINE_MS/u,
-  );
+test('includes bounded election evidence when startup times out before an endpoint appears', () => {
+  const error = runtimeHostStartupError('startup_timeout', {
+    deadlineMs: 12_000,
+    elapsedMs: 12_001,
+    candidateLaunches: 1,
+    sawEndpointConnected: false,
+    observations: {
+      notRegistered: 4,
+      connectFailed: 0,
+      handshakeFailed: 0,
+      connected: 0,
+      readyWaitFailed: 0,
+      deadlineElapsed: 0,
+    },
+    latestCandidate: {
+      pid: 42,
+      startupAttemptId: '00000000-0000-4000-8000-000000000001',
+      state: 'running',
+    },
+  });
+
+  assert.match(error.message, /did not become ready/u);
+  assert.match(error.message, /"sawEndpointConnected":false/u);
+  assert.match(error.message, /"candidateLaunches":1/u);
 });
 
 test('keeps internal startup failures retryable', () => {

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { randomUUID } from 'node:crypto';
 import {
   prepareStorageRootControlDirectory,
@@ -72,6 +91,13 @@ const defaultDependencies: ConnectOrSpawnRuntimeHostDependencies = {
   random: Math.random,
 };
 
+/**
+ * Resolves the operator override for the client election deadline. Large
+ * workspaces can legitimately take longer than the default window on their
+ * first start after an upgrade, so the deadline must be raisable without a
+ * code change. Invalid values fail closed: a silently ignored typo would
+ * leave the operator believing they widened the window when they did not.
+ */
 export function electionDeadlineMsFromEnvironment(
   rawValue: string | undefined,
 ): number | undefined {
@@ -111,12 +137,14 @@ export interface RuntimeHostElectionDiagnostic {
   readonly candidateLaunches: number;
   readonly sawEndpointConnected: boolean;
   readonly observations: {
+    readonly totalResults: number;
     readonly notRegistered: number;
     readonly connectFailed: number;
     readonly handshakeFailed: number;
     readonly connected: number;
     readonly readyWaitFailed: number;
     readonly deadlineElapsed: number;
+    readonly otherResults: number;
   };
   readonly lastRegistration?: {
     readonly pid: number;
@@ -134,12 +162,14 @@ export interface RuntimeHostElectionDiagnostic {
 }
 
 interface MutableElectionObservations {
+  totalResults: number;
   notRegistered: number;
   connectFailed: number;
   handshakeFailed: number;
   connected: number;
   readyWaitFailed: number;
   deadlineElapsed: number;
+  otherResults: number;
 }
 
 interface ObservedCandidateAttempt {
@@ -273,17 +303,20 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
   let startupFailure: CandidateStartupFailureReport | undefined;
   let pendingCandidateReports = 0;
   let electionSettled = false;
+  let candidateInFlight = false;
   const candidateLaunches = new Set<ReturnType<CandidateLauncher>>();
   let sawEndpointConnected = false;
   let lastRegistration: HostRegistration | undefined;
   let latestCandidate: ObservedCandidateAttempt | undefined;
   const observations: MutableElectionObservations = {
+    totalResults: 0,
     notRegistered: 0,
     connectFailed: 0,
     handshakeFailed: 0,
     connected: 0,
     readyWaitFailed: 0,
     deadlineElapsed: 0,
+    otherResults: 0,
   };
 
   try {
@@ -353,6 +386,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
       if (
         shouldLaunchCandidate(result) &&
         !isPermanentCandidateStartupFailure(startupFailure) &&
+        !candidateInFlight &&
         now >= nextCandidateAt
       ) {
         try {
@@ -367,12 +401,17 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
           });
           candidateLaunches.add(launch);
           const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);
+          candidateInFlight = true;
           const candidate: ObservedCandidateAttempt = { attempt };
           latestCandidate = candidate;
           if (attempt.exited) {
-            void attempt.exited.then((exit) => {
-              candidate.exit = exit;
-            });
+            void attempt.exited.then(
+              (exit) => {
+                candidate.exit = exit;
+                candidateInFlight = false;
+              },
+              () => undefined,
+            );
           }
           if (attempt.startupFailure) {
             pendingCandidateReports += 1;
@@ -452,6 +491,7 @@ function recordElectionResult(
   result: ElectionConnectionResult,
   observations: MutableElectionObservations,
 ): { readonly endpointConnected: boolean; readonly registration?: HostRegistration } {
+  observations.totalResults += 1;
   const registration = 'registration' in result ? result.registration : undefined;
   if (result.kind === 'election_deadline_elapsed') {
     observations.deadlineElapsed += 1;
@@ -465,7 +505,11 @@ function recordElectionResult(
     return { endpointConnected: true, registration };
   }
   if (result.kind !== 'unavailable') {
-    return { endpointConnected: false, ...(registration ? { registration } : {}) };
+    observations.otherResults += 1;
+    return {
+      endpointConnected: electionResultReachedEndpoint(result),
+      ...(registration ? { registration } : {}),
+    };
   }
   switch (result.reason) {
     case 'not_registered':
@@ -477,11 +521,28 @@ function recordElectionResult(
     case 'handshake_failed':
       observations.handshakeFailed += 1;
       break;
+    default:
+      observations.otherResults += 1;
+      break;
   }
   return {
-    endpointConnected: result.reason === 'handshake_failed',
+    endpointConnected: electionResultReachedEndpoint(result),
     ...(registration ? { registration } : {}),
   };
+}
+
+function electionResultReachedEndpoint(
+  result: Exclude<ElectionConnectionResult, { kind: 'election_deadline_elapsed' }>,
+): boolean {
+  switch (result.kind) {
+    case 'connected':
+    case 'draining':
+    case 'incompatible':
+    case 'upgrade_required':
+      return true;
+    case 'unavailable':
+      return result.endpointConnected;
+  }
 }
 
 function createElectionDiagnostic(input: {

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import { randomUUID } from 'node:crypto';
 import {
   prepareStorageRootControlDirectory,
@@ -28,6 +9,7 @@ import {
   requireClientInstanceId,
   requireHostCompositionId,
   validateProtocolRange,
+  type HostRegistration,
   type HostIncompatible,
   type ProtocolRange,
 } from '../protocol/index.js';
@@ -39,7 +21,9 @@ import {
 import {
   launchDetachedRuntimeHostCandidate,
   launchOwnedRuntimeHostCandidate,
+  type CandidateProcessExit,
   type CandidateLauncher,
+  type DetachedCandidateAttempt,
   type OwnedCandidateAttempt,
 } from './launcher.js';
 import {
@@ -78,20 +62,16 @@ interface ConnectOrSpawnRuntimeHostDependencies {
   random(): number;
   /** Defaults to `process.env`; injected so tests never mutate the real environment. */
   env?: NodeJS.ProcessEnv;
+  connectHost?: typeof connectResolvedRuntimeHost;
 }
+
+type ElectionConnectionResult = Awaited<ReturnType<typeof connectResolvedRuntimeHost>>;
 
 const defaultDependencies: ConnectOrSpawnRuntimeHostDependencies = {
   launchCandidate: launchDetachedRuntimeHostCandidate,
   random: Math.random,
 };
 
-/**
- * Resolves the operator override for the client election deadline. Large
- * workspaces can legitimately take longer than the default window on their
- * first start after an upgrade, so the deadline must be raisable without a
- * code change. Invalid values fail closed: a silently ignored typo would leave
- * the operator believing they widened the window when they did not.
- */
 export function electionDeadlineMsFromEnvironment(
   rawValue: string | undefined,
 ): number | undefined {
@@ -117,11 +97,55 @@ export type ConnectOrSpawnRuntimeHostResult =
       kind: 'failed';
       reason: 'composition_mismatch';
       requiredCompositionId: string;
+      diagnostic?: RuntimeHostElectionDiagnostic;
     }
   | {
       kind: 'failed';
       reason: CandidateStartupFailure['reason'] | 'startup_timeout' | 'host_unresponsive';
+      diagnostic?: RuntimeHostElectionDiagnostic;
     };
+
+export interface RuntimeHostElectionDiagnostic {
+  readonly deadlineMs: number;
+  readonly elapsedMs: number;
+  readonly candidateLaunches: number;
+  readonly sawEndpointConnected: boolean;
+  readonly observations: {
+    readonly notRegistered: number;
+    readonly connectFailed: number;
+    readonly handshakeFailed: number;
+    readonly connected: number;
+    readonly readyWaitFailed: number;
+    readonly deadlineElapsed: number;
+  };
+  readonly lastRegistration?: {
+    readonly pid: number;
+    readonly state: HostRegistration['state'];
+    readonly lifecycleMode: HostRegistration['lifecycleMode'];
+    readonly generation?: string;
+  };
+  readonly latestCandidate?: {
+    readonly pid: number;
+    readonly startupAttemptId?: string;
+    readonly state: 'running' | 'exited' | 'unknown';
+    readonly exitCode?: number | null;
+    readonly signal?: NodeJS.Signals | null;
+  };
+}
+
+interface MutableElectionObservations {
+  notRegistered: number;
+  connectFailed: number;
+  handshakeFailed: number;
+  connected: number;
+  readyWaitFailed: number;
+  deadlineElapsed: number;
+}
+
+interface ObservedCandidateAttempt {
+  readonly attempt: DetachedCandidateAttempt;
+  exit?: CandidateProcessExit;
+}
 
 export async function connectOrSpawnRuntimeHost(
   input: ConnectOrSpawnRuntimeHostInput,
@@ -249,12 +273,23 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
   let startupFailure: CandidateStartupFailureReport | undefined;
   let pendingCandidateReports = 0;
   let electionSettled = false;
-  let candidateInFlight = false;
+  const candidateLaunches = new Set<ReturnType<CandidateLauncher>>();
+  let sawEndpointConnected = false;
+  let lastRegistration: HostRegistration | undefined;
+  let latestCandidate: ObservedCandidateAttempt | undefined;
+  const observations: MutableElectionObservations = {
+    notRegistered: 0,
+    connectFailed: 0,
+    handshakeFailed: 0,
+    connected: 0,
+    readyWaitFailed: 0,
+    deadlineElapsed: 0,
+  };
 
   try {
     while (performance.now() < deadline) {
       input.signal?.throwIfAborted();
-      const result = await connectResolvedRuntimeHost({
+      const result = await (dependencies.connectHost ?? connectResolvedRuntimeHost)({
         capability,
         controlDirectory,
         protocol: input.protocol,
@@ -268,6 +303,9 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
         handshakeTimeoutMs: input.handshakeTimeoutMs,
         electionDeadline: deadline,
       });
+      const observed = recordElectionResult(result, observations);
+      if (observed.registration) lastRegistration = observed.registration;
+      if (observed.endpointConnected) sawEndpointConnected = true;
       if (result.kind === 'election_deadline_elapsed') {
         if (result.endpointConnected) sawUnresponsiveEndpoint = true;
         break;
@@ -288,6 +326,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
           await retireCandidateStartupDiagnostic(capability.rootId, startupFailure);
           return result;
         } catch {
+          observations.readyWaitFailed += 1;
           await result.connection.close().catch(() => undefined);
         }
         input.signal?.throwIfAborted();
@@ -314,7 +353,6 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
       if (
         shouldLaunchCandidate(result) &&
         !isPermanentCandidateStartupFailure(startupFailure) &&
-        !candidateInFlight &&
         now >= nextCandidateAt
       ) {
         try {
@@ -327,15 +365,14 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
             initialConnectionTimeoutMs: Math.ceil(remaining),
             ...(input.generation === undefined ? {} : { generation: input.generation }),
           });
+          candidateLaunches.add(launch);
           const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);
-          candidateInFlight = true;
+          const candidate: ObservedCandidateAttempt = { attempt };
+          latestCandidate = candidate;
           if (attempt.exited) {
-            void attempt.exited.then(
-              () => {
-                candidateInFlight = false;
-              },
-              () => undefined,
-            );
+            void attempt.exited.then((exit) => {
+              candidate.exit = exit;
+            });
           }
           if (attempt.startupFailure) {
             pendingCandidateReports += 1;
@@ -396,10 +433,100 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
     return {
       kind: 'failed',
       reason: sawUnresponsiveEndpoint ? 'host_unresponsive' : 'startup_timeout',
+      diagnostic: createElectionDiagnostic({
+        deadlineMs,
+        startedAt,
+        candidateLaunches: candidateLaunches.size,
+        sawEndpointConnected,
+        observations,
+        lastRegistration,
+        latestCandidate,
+      }),
     };
   } finally {
     electionSettled = true;
   }
+}
+
+function recordElectionResult(
+  result: ElectionConnectionResult,
+  observations: MutableElectionObservations,
+): { readonly endpointConnected: boolean; readonly registration?: HostRegistration } {
+  const registration = 'registration' in result ? result.registration : undefined;
+  if (result.kind === 'election_deadline_elapsed') {
+    observations.deadlineElapsed += 1;
+    return {
+      endpointConnected: result.endpointConnected,
+      ...(result.registration ? { registration: result.registration } : {}),
+    };
+  }
+  if (result.kind === 'connected') {
+    observations.connected += 1;
+    return { endpointConnected: true, registration };
+  }
+  if (result.kind !== 'unavailable') {
+    return { endpointConnected: false, ...(registration ? { registration } : {}) };
+  }
+  switch (result.reason) {
+    case 'not_registered':
+      observations.notRegistered += 1;
+      break;
+    case 'connect_failed':
+      observations.connectFailed += 1;
+      break;
+    case 'handshake_failed':
+      observations.handshakeFailed += 1;
+      break;
+  }
+  return {
+    endpointConnected: result.reason === 'handshake_failed',
+    ...(registration ? { registration } : {}),
+  };
+}
+
+function createElectionDiagnostic(input: {
+  readonly deadlineMs: number;
+  readonly startedAt: number;
+  readonly candidateLaunches: number;
+  readonly sawEndpointConnected: boolean;
+  readonly observations: MutableElectionObservations;
+  readonly lastRegistration: HostRegistration | undefined;
+  readonly latestCandidate: ObservedCandidateAttempt | undefined;
+}): RuntimeHostElectionDiagnostic {
+  const candidate = input.latestCandidate;
+  return {
+    deadlineMs: input.deadlineMs,
+    elapsedMs: Math.max(0, Math.round(performance.now() - input.startedAt)),
+    candidateLaunches: input.candidateLaunches,
+    sawEndpointConnected: input.sawEndpointConnected,
+    observations: { ...input.observations },
+    ...(input.lastRegistration
+      ? {
+          lastRegistration: {
+            pid: input.lastRegistration.pid,
+            state: input.lastRegistration.state,
+            lifecycleMode: input.lastRegistration.lifecycleMode,
+            ...(input.lastRegistration.generation === undefined
+              ? {}
+              : { generation: input.lastRegistration.generation }),
+          },
+        }
+      : {}),
+    ...(candidate
+      ? {
+          latestCandidate: {
+            pid: candidate.attempt.pid,
+            ...(candidate.attempt.startupAttemptId === undefined
+              ? {}
+              : { startupAttemptId: candidate.attempt.startupAttemptId }),
+            state: candidate.exit ? 'exited' : candidate.attempt.exited ? 'running' : 'unknown',
+            ...(candidate.exit
+              ? { exitCode: candidate.exit.code, signal: candidate.exit.signal }
+              : {}),
+          },
+        }
+      : {}),
+  };
 }
 
 async function retireCandidateStartupDiagnostic(

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -221,6 +221,7 @@ type ConnectResolvedRuntimeHostResult =
   | {
       kind: 'election_deadline_elapsed';
       endpointConnected: boolean;
+      registration?: HostRegistration;
     };
 
 class ElectionDeadlineElapsedError extends Error {
@@ -1254,7 +1255,7 @@ export async function connectResolvedRuntimeHost(
     );
   } catch (error) {
     if (error instanceof ElectionDeadlineElapsedError) {
-      return { kind: 'election_deadline_elapsed', endpointConnected: false };
+      return { kind: 'election_deadline_elapsed', endpointConnected: false, registration };
     }
     if (error instanceof RuntimeHostRegistrationError && error.code === 'invalid_registration') {
       return { kind: 'unavailable', reason: 'invalid_registration' };
@@ -1269,7 +1270,7 @@ export async function connectResolvedRuntimeHost(
   const connectBudget = remainingTimeout(connectDeadline.at);
   if (connectBudget === undefined) {
     if (connectDeadline.exhaustsElection) {
-      return { kind: 'election_deadline_elapsed', endpointConnected: false };
+      return { kind: 'election_deadline_elapsed', endpointConnected: false, registration };
     }
     return { kind: 'unavailable', reason: 'connect_failed', registration };
   }
@@ -1282,7 +1283,7 @@ export async function connectResolvedRuntimeHost(
     );
   } catch (error) {
     if (error instanceof ElectionDeadlineElapsedError) {
-      return { kind: 'election_deadline_elapsed', endpointConnected: false };
+      return { kind: 'election_deadline_elapsed', endpointConnected: false, registration };
     }
     return { kind: 'unavailable', reason: 'connect_failed', registration };
   }
@@ -1291,7 +1292,7 @@ export async function connectResolvedRuntimeHost(
   if (handshakeBudget === undefined) {
     transport.abort();
     if (handshakeDeadline.exhaustsElection) {
-      return { kind: 'election_deadline_elapsed', endpointConnected: true };
+      return { kind: 'election_deadline_elapsed', endpointConnected: true, registration };
     }
     return { kind: 'unavailable', reason: 'handshake_failed', registration };
   }
@@ -1380,7 +1381,7 @@ export async function connectResolvedRuntimeHost(
       return { kind: 'unavailable', reason: 'composition_mismatch', registration };
     }
     if (failure instanceof ElectionDeadlineElapsedError) {
-      return { kind: 'election_deadline_elapsed', endpointConnected: true };
+      return { kind: 'election_deadline_elapsed', endpointConnected: true, registration };
     }
     return { kind: 'unavailable', reason: 'handshake_failed', registration };
   } finally {

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -217,7 +217,10 @@ export type ConnectRemoteRuntimeHostResult =
     };
 
 type ConnectResolvedRuntimeHostResult =
-  | ConnectRuntimeHostResult
+  | Exclude<ConnectRuntimeHostResult, { kind: 'unavailable' }>
+  | (Extract<ConnectRuntimeHostResult, { kind: 'unavailable' }> & {
+      endpointConnected: boolean;
+    })
   | {
       kind: 'election_deadline_elapsed';
       endpointConnected: boolean;
@@ -1216,6 +1219,13 @@ function finalizeConnectRuntimeHostResult(
       reason: result.endpointConnected ? 'handshake_failed' : 'connect_failed',
     };
   }
+  if (result.kind === 'unavailable') {
+    return {
+      kind: 'unavailable',
+      reason: result.reason,
+      ...(result.registration ? { registration: result.registration } : {}),
+    };
+  }
   return result;
 }
 
@@ -1258,13 +1268,20 @@ export async function connectResolvedRuntimeHost(
       return { kind: 'election_deadline_elapsed', endpointConnected: false, registration };
     }
     if (error instanceof RuntimeHostRegistrationError && error.code === 'invalid_registration') {
-      return { kind: 'unavailable', reason: 'invalid_registration' };
+      return { kind: 'unavailable', reason: 'invalid_registration', endpointConnected: false };
     }
-    return { kind: 'unavailable', reason: 'connect_failed' };
+    return { kind: 'unavailable', reason: 'connect_failed', endpointConnected: false };
   }
-  if (!registration) return { kind: 'unavailable', reason: 'not_registered' };
+  if (!registration) {
+    return { kind: 'unavailable', reason: 'not_registered', endpointConnected: false };
+  }
   if (registration.rootId !== input.capability.rootId) {
-    return { kind: 'unavailable', reason: 'root_mismatch', registration };
+    return {
+      kind: 'unavailable',
+      reason: 'root_mismatch',
+      endpointConnected: false,
+      registration,
+    };
   }
   const connectDeadline = phaseDeadline(connectTimeoutMs, input.electionDeadline);
   const connectBudget = remainingTimeout(connectDeadline.at);
@@ -1272,7 +1289,12 @@ export async function connectResolvedRuntimeHost(
     if (connectDeadline.exhaustsElection) {
       return { kind: 'election_deadline_elapsed', endpointConnected: false, registration };
     }
-    return { kind: 'unavailable', reason: 'connect_failed', registration };
+    return {
+      kind: 'unavailable',
+      reason: 'connect_failed',
+      endpointConnected: false,
+      registration,
+    };
   }
   let transport: FramedTransport;
   try {
@@ -1285,7 +1307,12 @@ export async function connectResolvedRuntimeHost(
     if (error instanceof ElectionDeadlineElapsedError) {
       return { kind: 'election_deadline_elapsed', endpointConnected: false, registration };
     }
-    return { kind: 'unavailable', reason: 'connect_failed', registration };
+    return {
+      kind: 'unavailable',
+      reason: 'connect_failed',
+      endpointConnected: false,
+      registration,
+    };
   }
   const handshakeDeadline = phaseDeadline(handshakeTimeoutMs, input.electionDeadline);
   const handshakeBudget = remainingTimeout(handshakeDeadline.at);
@@ -1294,7 +1321,12 @@ export async function connectResolvedRuntimeHost(
     if (handshakeDeadline.exhaustsElection) {
       return { kind: 'election_deadline_elapsed', endpointConnected: true, registration };
     }
-    return { kind: 'unavailable', reason: 'handshake_failed', registration };
+    return {
+      kind: 'unavailable',
+      reason: 'handshake_failed',
+      endpointConnected: true,
+      registration,
+    };
   }
   let handshakeTimeoutError: Error | undefined;
   const handshakeTimer = setTimeout(() => {
@@ -1372,18 +1404,38 @@ export async function connectResolvedRuntimeHost(
     transport.abort();
     const failure = handshakeTimeoutError ?? error;
     if (failure instanceof RuntimeHostEpochMismatchError) {
-      return { kind: 'unavailable', reason: 'epoch_mismatch', registration };
+      return {
+        kind: 'unavailable',
+        reason: 'epoch_mismatch',
+        endpointConnected: true,
+        registration,
+      };
     }
     if (failure instanceof RuntimeHostRootMismatchError) {
-      return { kind: 'unavailable', reason: 'root_mismatch', registration };
+      return {
+        kind: 'unavailable',
+        reason: 'root_mismatch',
+        endpointConnected: true,
+        registration,
+      };
     }
     if (failure instanceof RuntimeHostCompositionMismatchError) {
-      return { kind: 'unavailable', reason: 'composition_mismatch', registration };
+      return {
+        kind: 'unavailable',
+        reason: 'composition_mismatch',
+        endpointConnected: true,
+        registration,
+      };
     }
     if (failure instanceof ElectionDeadlineElapsedError) {
       return { kind: 'election_deadline_elapsed', endpointConnected: true, registration };
     }
-    return { kind: 'unavailable', reason: 'handshake_failed', registration };
+    return {
+      kind: 'unavailable',
+      reason: 'handshake_failed',
+      endpointConnected: true,
+      registration,
+    };
   } finally {
     clearTimeout(handshakeTimer);
   }

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -92,6 +92,7 @@ export {
   connectOrSpawnRuntimeHost,
   type ConnectOrSpawnRuntimeHostInput,
   type ConnectOrSpawnRuntimeHostResult,
+  type RuntimeHostElectionDiagnostic,
 } from './connect-or-spawn.js';
 export {
   createRuntimeHostCandidateLaunchBarrier,

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { dirname, isAbsolute } from 'node:path';

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { dirname, isAbsolute } from 'node:path';
@@ -40,6 +21,7 @@ export interface DetachedCandidateInput {
 
 export interface DetachedCandidateAttempt {
   pid: number;
+  startupAttemptId?: string;
   exited?: Promise<CandidateProcessExit>;
   startupFailure?: Promise<CandidateStartupFailureReport | undefined>;
 }
@@ -69,7 +51,7 @@ export function launchDetachedRuntimeHostCandidate(
   const startupFailure = readStartupFailure(child, exited, startupAttemptId);
   const spawned = spawnedPid(child).then(({ pid }) => {
     child.unref();
-    return { pid, exited, startupFailure };
+    return { pid, startupAttemptId, exited, startupFailure };
   });
   return { spawned };
 }
@@ -84,6 +66,7 @@ export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): 
   return {
     spawned: spawnedPid(child).then(({ pid }) => ({
       pid,
+      startupAttemptId,
       exited,
       startupFailure,
       releaseToEnvironment(): void {

--- a/packages/runtime-host/src/client/startup-error.ts
+++ b/packages/runtime-host/src/client/startup-error.ts
@@ -71,11 +71,11 @@ export function runtimeHostStartupError(
       );
     case 'startup_timeout':
       return new Error(
-        `Runtime Host did not become ready before the startup deadline${electionDiagnosticSuffix(diagnostic)}`,
+        `No Runtime Host became ready before the startup deadline elapsed${electionDiagnosticSuffix(diagnostic)}. Retry; if this workspace needs longer to open (large workspaces can after an upgrade), set MAKA_RUNTIME_HOST_ELECTION_DEADLINE_MS to allow more time.`,
       );
     case 'host_unresponsive':
       return new Error(
-        `Runtime Host stopped responding during startup${electionDiagnosticSuffix(diagnostic)}`,
+        `A Runtime Host was found but did not become ready before the startup deadline elapsed${electionDiagnosticSuffix(diagnostic)}. It may still be opening this workspace (large workspaces can need longer right after an upgrade); retrying once it settles usually succeeds, or set MAKA_RUNTIME_HOST_ELECTION_DEADLINE_MS to allow more time.`,
       );
   }
 }

--- a/packages/runtime-host/src/client/startup-error.ts
+++ b/packages/runtime-host/src/client/startup-error.ts
@@ -18,6 +18,7 @@
  */
 
 import type { CandidateStartupFailureReason } from '../candidate-startup-failure.js';
+import type { RuntimeHostElectionDiagnostic } from './connect-or-spawn.js';
 import { RuntimeHostPermanentReconnectError } from './reconnect-lifecycle.js';
 
 export type RuntimeHostStartupFailureReason =
@@ -40,7 +41,10 @@ export class RuntimeHostStartupError extends RuntimeHostPermanentReconnectError 
   }
 }
 
-export function runtimeHostStartupError(reason: RuntimeHostStartupFailureReason): Error {
+export function runtimeHostStartupError(
+  reason: RuntimeHostStartupFailureReason,
+  diagnostic?: RuntimeHostElectionDiagnostic,
+): Error {
   switch (reason) {
     case 'stored_data_incompatible':
       return new RuntimeHostStartupError(
@@ -67,11 +71,15 @@ export function runtimeHostStartupError(reason: RuntimeHostStartupFailureReason)
       );
     case 'startup_timeout':
       return new Error(
-        'No Runtime Host became ready before the startup deadline elapsed. Retry; if this workspace needs longer to open (large workspaces can after an upgrade), set MAKA_RUNTIME_HOST_ELECTION_DEADLINE_MS to allow more time.',
+        `Runtime Host did not become ready before the startup deadline${electionDiagnosticSuffix(diagnostic)}`,
       );
     case 'host_unresponsive':
       return new Error(
-        'A Runtime Host was found but did not become ready before the startup deadline elapsed. It may still be opening this workspace (large workspaces can need longer right after an upgrade); retrying once it settles usually succeeds, or set MAKA_RUNTIME_HOST_ELECTION_DEADLINE_MS to allow more time.',
+        `Runtime Host stopped responding during startup${electionDiagnosticSuffix(diagnostic)}`,
       );
   }
+}
+
+function electionDiagnosticSuffix(diagnostic: RuntimeHostElectionDiagnostic | undefined): string {
+  return diagnostic ? `; election diagnostic: ${JSON.stringify(diagnostic)}` : '';
 }


### PR DESCRIPTION
## Summary

Preserves bounded structured evidence for Runtime Host election timeout failures.

The diagnostic records the observed startup cut with the exact Candidate PID/attempt identity and exit state, final election elapsed time, endpoint-connected observation, reconcilable election result counters, and the last safe registration summary. Desktop and CLI startup errors include the same bounded JSON.

This PR is diagnostic-only. The Candidate single-flight behavior fix from #3512 is already merged into `main`; this PR does not change that behavior, the 45-second election deadline, retry/respawn policy, candidate backoff, endpoint behavior, public wire protocol, failure classification, or cleanup ownership.

Refs #3279.

## Diagnostic contract

- Endpoint evidence is written at the connection phase: registration/read/connect failures record `false`; draining, incompatible, and post-connect handshake failures record `true`. The internal phase field is stripped from the existing public connection result.
- `totalResults` is reconciled by `notRegistered + connectFailed + handshakeFailed + connected + deadlineElapsed + otherResults`. `readyWaitFailed` is a separate post-connection phase counter and is intentionally outside that sum.
- Candidate PID and startup attempt identity are preserved; the latest attempt is reported as running, exited, or unknown with bounded exit code/signal data.
- The diagnostic never includes the runtime root path or endpoint value.
- Candidate stderr remains outside this PR because detached launch I/O and lifecycle ownership are unchanged.
- No Node stress harness is shipped. Packaged Electron evidence remains owned by the existing `Release Windows check` lane.

## Scope decisions

The merged #3512 behavior fix owns per-election Candidate single-flight. This PR retains only its diagnostic observation and regression evidence; it does not reimplement or broaden the behavior fix. Cross-client coalescing, full LaunchLease architecture, detailed phase timestamps, and retry/deadline policy changes remain deferred to #2142 or #3279 follow-up work.

## Verification

Exact head `8a5a275926f7abef0109b496acd84dc86cae535a`, rebased onto `main` `f19eede03a829c226be39f001b2684860a3aa1d5`:

- Runtime Host build and typecheck passed.
- Maka CLI build passed.
- `npm run lint`: 2,583 files, 0 errors.
- `npm run format:check`: 1,591 files, 0 changes.
- ASF header gate: 2,717 covered / 114 excluded.
- CI planner + Windows harness: 60 passed, 0 failed, 1 privilege-dependent symlink skip.
- Windows inventory: 3 passed; 63 declarations current.
- Counter reconciliation and endpoint phase tests passed.
- Startup-error tests: 6 passed.
- CLI Runtime Host context: 31 passed.
- Desktop Runtime Host manager: 22 passed.
- `git diff --check` passed.
- Independent exact-head author-gate: no introduced P0-P2 findings.

Local limitations:

- The full Runtime Host suite was not claimed as a complete local pass: it reached at least 149 passing tests before the known local execution-composition hang/no-output condition.
- A few forged-handshake tests still show the machine's known Windows endpoint-probe `read_eof` timing noise; the new root-mismatch writer tests pass 2/2.
- One existing owned-candidate startup test and two existing host-kernel tests are load/permission-sensitive locally. These are not introduced by this diagnostic diff; authoritative evidence is fresh CI.

## L3 gate

- [x] [Core CI 32607957602](https://github.com/apache/maka/actions/runs/32607957602) passed in 11m45s, including the full Runtime Host suite and merged-result checks.
- [x] [Release Windows check 32607957610](https://github.com/apache/maka/actions/runs/32607957610) passed in 11m38s, including packaging, packaged smoke, pinned upgrade/uninstall, and automatic update end to end without a Candidate storm.

Fresh exact-head L3 evidence is green. The remaining gate is normal human review.
## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the bounded diagnostic, addressed review findings, rebased it after the #3512 behavior fix, removed the exploratory Node stress harness, ran local validation, and used independent author-gate reviews. The commits include `Generated-by: Codex` trailers.

## Checklist

- [x] Tests cover the diagnostic boundaries and fail without them
- [x] Lint, format, typecheck and affected suites pass where locally runnable

Does this PR entail a change in behavior?

- [x] Yes — startup errors now carry bounded diagnostic evidence
- [ ] No