### PR TITLE
fix(desktop): never request the 'large' file icon that kills packaged macOS builds

### DIFF
--- a/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
@@ -21,6 +21,7 @@ import {
   type PermissionOverlayWindowLike,
 } from '../permission-overlay/permission-overlay-controller.js';
 import {
+  BUNDLE_ICON_OPTIONS,
   loadNativeBundleIcon,
   resolveAppBundle,
 } from '../permission-overlay/app-bundle.js';
@@ -315,6 +316,12 @@ describe('app bundle resolution for the drag', () => {
     assert.equal(icon, null);
     assert.equal(calls, 0, 'unpackaged development must not call app.getFileIcon()');
     assert.equal(await loadNativeBundleIcon(true, async () => 'icon'), 'icon');
+  });
+
+  it('never requests the large icon size that kills packaged macOS builds', () => {
+    // 'large' hits a fatal NOTREACHED inside Chromium's IconLoader on
+    // macOS (SIGTRAP, not a catchable error) — see issue #3352.
+    assert.notEqual(BUNDLE_ICON_OPTIONS.size as string, 'large');
   });
 
   it('walks three levels up from the executable to the .app', () => {

--- a/apps/desktop/src/main/permission-overlay/app-bundle.ts
+++ b/apps/desktop/src/main/permission-overlay/app-bundle.ts
@@ -35,6 +35,15 @@ export interface ResolveAppBundleDeps {
 }
 
 /**
+ * The only size every platform can actually deliver. `'large'` is
+ * unsupported on macOS: Chromium's IconLoader hits a fatal NOTREACHED and
+ * the process dies with SIGTRAP before the promise settles — no JavaScript
+ * error is ever thrown, so the try/catch in `loadNativeBundleIcon` cannot
+ * save the app. Callers upscale the 32x32 result as needed.
+ */
+export const BUNDLE_ICON_OPTIONS = { size: 'normal' } as const;
+
+/**
  * Reading a bundle icon is presentation-only. The original unpackaged npm
  * Electron runtime could terminate natively while macOS resolved its bundle
  * icon, before the returned promise settled. Keep native icon loading for

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
@@ -24,7 +24,7 @@ import { join } from 'node:path';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { resolveOverlayAssetDir } from '../overlay-assets.js';
 import { openSystemPermissionPane, requestPermissionAccess } from '../permissions-actions.js';
-import { loadNativeBundleIcon, resolveAppBundle } from './app-bundle.js';
+import { BUNDLE_ICON_OPTIONS, loadNativeBundleIcon, resolveAppBundle } from './app-bundle.js';
 import { getPermissionOverlayCopy } from './permission-overlay-copy.js';
 import {
   createPermissionOverlayController,
@@ -77,7 +77,7 @@ export function createPermissionOverlayMain(
   async function resolveAppIconDataUrl(bundlePath: string | null): Promise<string | null> {
     if (!bundlePath) return null;
     const icon = await loadNativeBundleIcon(app.isPackaged, () =>
-      app.getFileIcon(bundlePath, { size: 'large' }),
+      app.getFileIcon(bundlePath, BUNDLE_ICON_OPTIONS),
     );
     if (!icon || icon.isEmpty()) return null;
     // nativeImage.createFromPath does not decode .icns reliably. Asking
@@ -274,7 +274,7 @@ function attachCardGestures(win: import('electron').BrowserWindow): void {
     }
     if (icon.isEmpty()) {
       const fallback = await loadNativeBundleIcon(app.isPackaged, () =>
-        app.getFileIcon(resolved.bundlePath, { size: 'large' }),
+        app.getFileIcon(resolved.bundlePath, BUNDLE_ICON_OPTIONS),
       );
       if (fallback && !fallback.isEmpty()) icon = fallback.resize({ width: 64, height: 64 });
       // The file drag still works without a decorative drag image.


### PR DESCRIPTION
## Summary

Packaged macOS builds crash with `EXC_BREAKPOINT (SIGTRAP)` in Chromium's `IconLoader::ReadIcon()` the moment the drag-to-grant permission guide loads the app icon. The trigger is `app.getFileIcon(bundlePath, { size: 'large' })`: Electron documents `'large'` as unsupported on macOS, and in practice it hits a fatal `NOTREACHED` in native code — the process dies before the promise settles, so the `try/catch` inside `loadNativeBundleIcon` never sees an error to catch. Unpackaged builds were spared only because #1920 gates native icon loading on `app.isPackaged` (the #1919 dev-mode crash carried this exact signature: SIGTRAP on `ThreadPoolForegroundWorker` while reading a bundle icon).

The fix requests `{ size: 'normal' }` instead, hoisted into a single exported constant (`BUNDLE_ICON_OPTIONS` in `app-bundle.ts`) shared by both call sites, so the size choice and the reason it must never be `'large'` live in one place. Both call sites are only reachable on macOS (`resolveAppBundle` returns `not_darwin` elsewhere, and the drag IPC handler early-returns off-darwin), and `'normal'` is supported on every platform regardless. The 32×32 result is upscaled to the same 64×64 the code already produced on the platforms where `'large'` silently meant 32×32 (Windows), so no downstream contract changes.

Fixes #3352

## Verification

Empirical reproduction with this repo's Electron 43.2.0 on an Apple silicon Mac (the exact version and hardware class from the report):

- `app.getFileIcon(<.app>, { size: 'large' })` → process exits 133 (`SIGTRAP`), no JavaScript error thrown — matching the crash report's `IconLoader::ReadIcon()` frame.
- `app.getFileIcon(<.app>, { size: 'normal' })` → resolves a 32×32 image.
- The full fixed path (`loadNativeBundleIcon(true, …)` → `getFileIcon` `normal` → `resize({64,64})` → `toDataURL()`) → produces a valid 7 KB PNG data URL, exit 0.

Checks run locally (Node 24.18):

- `npm --workspace @maka/desktop run typecheck` — pass
- `npm --workspace @maka/desktop run test` — 1038 pass / 0 fail (includes the new regression tripwire)
- `biome check` on the changed files — clean; `knip` desktop workspace — clean
- Regression-test validity: reverting `BUNDLE_ICON_OPTIONS` to `'large'` makes the new test fail; restoring the fix makes it pass.

Not run: a full packaged DMG build. The crash and the fix were both demonstrated against the real Electron binary with the production code path mirrored 1:1; the packaged-only aspect is fully explained by the `app.isPackaged` gate in `loadNativeBundleIcon`.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code diagnosed the crash, wrote the fix and test, and ran the reproduction and verification; an independent adversarial review pass (also Claude) probed the fix with fault-injection experiments before submission. I reviewed and verified the result.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
