### PR TITLE
fix(runtime-host): escalate reconnect delay while a Host never stabilizes

### DIFF
--- a/packages/runtime-host/src/__tests__/reconnecting-connection.test.ts
+++ b/packages/runtime-host/src/__tests__/reconnecting-connection.test.ts
@@ -320,6 +320,142 @@ test('reconnect lifecycle quiescence suppresses replacement until it is resumed'
   await lifecycle.close();
 });
 
+test('reconnect delay escalates past maxMs while the Host never stabilizes', async () => {
+  const first = connectionHarness('first', () => undefined);
+  const delays: number[] = [];
+  let attempts = 0;
+  const lifecycle = await startRuntimeHostReconnectLifecycle({
+    initial: first.connection,
+    connect: async () => {
+      attempts += 1;
+      throw new Error('connect failed');
+    },
+    backoff: {
+      minMs: 1,
+      maxMs: 2,
+      unstableMaxMs: 20,
+      random: () => 0.5,
+      wait: async (delayMs) => {
+        await yieldToEventLoop();
+        delays.push(delayMs);
+      },
+    },
+  });
+  try {
+    first.disconnect();
+    await waitForCondition(() => attempts >= 8);
+    assert.deepEqual(delays.slice(0, 3), [1, 2, 4]);
+    assert.ok(Math.max(...delays) > 2);
+    assert.equal(Math.max(...delays), 20);
+  } finally {
+    await lifecycle.close();
+  }
+});
+
+test('a stabilized connection restarts the reconnect delay ladder', async () => {
+  let clock = 1_000_000;
+  const first = connectionHarness('first', () => undefined);
+  const second = connectionHarness('second', () => undefined);
+  const reconnected = deferred();
+  const delays: number[] = [];
+  let attempts = 0;
+  const lifecycle = await startRuntimeHostReconnectLifecycle({
+    initial: first.connection,
+    connect: async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        reconnected.resolve();
+        return second.connection;
+      }
+      throw new Error('connect failed');
+    },
+    backoff: {
+      minMs: 3,
+      maxMs: 5,
+      unstableMaxMs: 40,
+      stableConnectionMs: 50,
+      now: () => clock,
+      random: () => 0.5,
+      wait: async (delayMs) => {
+        await yieldToEventLoop();
+        clock += delayMs;
+        delays.push(delayMs);
+      },
+    },
+  });
+  try {
+    first.disconnect();
+    await reconnected.promise;
+    clock += 60;
+    second.disconnect();
+    await waitForCondition(() => delays.length >= 2);
+    assert.deepEqual(delays.slice(0, 2), [3, 6]);
+  } finally {
+    await lifecycle.close();
+  }
+});
+
+test('reconnect backoff rejects an unstable ceiling below maxMs', async () => {
+  const first = connectionHarness('first', () => undefined);
+  await assert.rejects(
+    startRuntimeHostReconnectLifecycle({
+      initial: first.connection,
+      connect: async () => first.connection,
+      backoff: { minMs: 1, maxMs: 10, unstableMaxMs: 5 },
+    }),
+    (error: unknown) => error instanceof RangeError && /unstableMaxMs/u.test(error.message),
+  );
+});
+
+test('an omitted unstableMaxMs stays compatible with a large maxMs', async () => {
+  // Pre-escalation callers could legally set maxMs above the 60s default
+  // ceiling; omitting the new field must derive the ceiling from maxMs rather
+  // than reject a previously valid configuration.
+  const first = connectionHarness('first', () => undefined);
+  const delays: number[] = [];
+  let attempts = 0;
+  const lifecycle = await startRuntimeHostReconnectLifecycle({
+    initial: first.connection,
+    connect: async () => {
+      attempts += 1;
+      throw new Error('connect failed');
+    },
+    backoff: {
+      minMs: 100,
+      maxMs: 90_000,
+      random: () => 0.5,
+      wait: async (delayMs) => {
+        await yieldToEventLoop();
+        delays.push(delayMs);
+      },
+    },
+  });
+  try {
+    first.disconnect();
+    // 100ms doubling reaches the derived 90s ceiling on the 11th attempt.
+    await waitForCondition(() => attempts >= 12);
+    assert.ok(delays.every((delay) => delay >= 100));
+    // The derived ceiling is max(60_000, 90_000) = 90_000, not the 60s default.
+    assert.equal(Math.max(...delays), 90_000);
+    assert.ok(delays.slice(-1)[0]! >= 90_000);
+  } finally {
+    await lifecycle.close();
+  }
+});
+
+function waitForCondition(condition: () => boolean): Promise<void> {
+  return (async () => {
+    for (let i = 0; i < 1_000 && !condition(); i += 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    assert.ok(condition());
+  })();
+}
+
+function yieldToEventLoop(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
 function connectionHarness(
   id: string,
   request: (operation: DirectRequestOperationKey, input: unknown) => unknown,

--- a/packages/runtime-host/src/__tests__/reconnecting-connection.test.ts
+++ b/packages/runtime-host/src/__tests__/reconnecting-connection.test.ts
@@ -388,8 +388,11 @@ test('a stabilized connection restarts the reconnect delay ladder', async () => 
     await reconnected.promise;
     clock += 60;
     second.disconnect();
-    await waitForCondition(() => delays.length >= 2);
-    assert.deepEqual(delays.slice(0, 2), [3, 6]);
+    await waitForCondition(() => delays.length >= 3);
+    // The regular ladder clamps at maxMs (5) before the never-stabilized
+    // escalation engages on the next doubling.
+    assert.deepEqual(delays.slice(0, 2), [3, 5]);
+    assert.ok(delays[2]! > 5);
   } finally {
     await lifecycle.close();
   }

--- a/packages/runtime-host/src/client/reconnect-lifecycle.ts
+++ b/packages/runtime-host/src/client/reconnect-lifecycle.ts
@@ -354,8 +354,11 @@ function reconnectDelayMs(
   unstableMaxMs: number,
 ): number {
   if (attempt <= 0 || minMs === 0) return 0;
-  const ceiling = Math.max(maxMs, unstableMaxMs);
-  const exponential = Math.min(ceiling, minMs * 2 ** Math.min(attempt - 1, 30));
+  const exponential = minMs * 2 ** Math.min(attempt - 1, 30);
+  // maxMs keeps binding until the natural doubling leaves the ceiling band;
+  // only a streak that saturates the regular ladder escalates toward
+  // unstableMaxMs.
+  const ceiling = exponential >= 2 * maxMs ? unstableMaxMs : maxMs;
   const sample = random();
   const bounded = Number.isFinite(sample) ? Math.min(1, Math.max(0, sample)) : 0.5;
   return Math.min(ceiling, Math.max(1, Math.round(exponential * (0.8 + bounded * 0.4))));

--- a/packages/runtime-host/src/client/reconnect-lifecycle.ts
+++ b/packages/runtime-host/src/client/reconnect-lifecycle.ts
@@ -20,6 +20,7 @@
 const DEFAULT_BACKOFF_MIN_MS = 100;
 const DEFAULT_BACKOFF_MAX_MS = 5_000;
 const DEFAULT_STABLE_CONNECTION_MS = 10_000;
+const DEFAULT_UNSTABLE_MAX_MS = 60_000;
 
 export interface RuntimeHostReconnectResource {
   readonly closed: Promise<void>;
@@ -30,6 +31,14 @@ export interface RuntimeHostReconnectBackoff {
   readonly minMs?: number;
   readonly maxMs?: number;
   readonly stableConnectionMs?: number;
+  /**
+   * Ceiling applied once a connection keeps failing without ever stabilizing.
+   * After the jittered delay has saturated at maxMs, the failure streak keeps
+   * doubling up to this bound so a persistently dying Host cannot force a
+   * regeneration attempt every maxMs indefinitely. Defaults to 60_000; set it
+   * equal to maxMs to keep the flat ceiling.
+   */
+  readonly unstableMaxMs?: number;
   readonly random?: () => number;
   readonly now?: () => number;
   readonly wait?: (delayMs: number, signal: AbortSignal) => Promise<void>;
@@ -88,6 +97,7 @@ class RuntimeHostReconnectLifecycleImpl<T extends RuntimeHostReconnectResource>
   readonly #minMs: number;
   readonly #maxMs: number;
   readonly #stableConnectionMs: number;
+  readonly #unstableMaxMs: number;
   readonly #random: () => number;
   readonly #now: () => number;
   readonly #wait: (delayMs: number, signal: AbortSignal) => Promise<void>;
@@ -118,12 +128,19 @@ class RuntimeHostReconnectLifecycleImpl<T extends RuntimeHostReconnectResource>
     this.#onFatalError = input.onFatalError;
     this.#minMs = requireDelay(input.backoff?.minMs ?? DEFAULT_BACKOFF_MIN_MS, 'minMs');
     this.#maxMs = requireDelay(input.backoff?.maxMs ?? DEFAULT_BACKOFF_MAX_MS, 'maxMs');
-    if (this.#maxMs < this.#minMs)
-      throw new RangeError('maxMs must be greater than or equal to minMs');
     this.#stableConnectionMs = requireDelay(
       input.backoff?.stableConnectionMs ?? DEFAULT_STABLE_CONNECTION_MS,
       'stableConnectionMs',
     );
+    this.#unstableMaxMs = requireDelay(
+      input.backoff?.unstableMaxMs ?? Math.max(DEFAULT_UNSTABLE_MAX_MS, this.#maxMs),
+      'unstableMaxMs',
+    );
+    if (this.#maxMs < this.#minMs)
+      throw new RangeError('maxMs must be greater than or equal to minMs');
+    if (this.#unstableMaxMs < this.#maxMs) {
+      throw new RangeError('unstableMaxMs must be greater than or equal to maxMs');
+    }
     this.#random = input.backoff?.random ?? Math.random;
     this.#now = input.backoff?.now ?? Date.now;
     this.#wait = input.backoff?.wait ?? waitForDelay;
@@ -264,6 +281,7 @@ class RuntimeHostReconnectLifecycleImpl<T extends RuntimeHostReconnectResource>
         this.#minMs,
         this.#maxMs,
         this.#random,
+        this.#unstableMaxMs,
       );
       try {
         if (delayMs > 0) await this.#wait(delayMs, this.#abort.signal);
@@ -333,12 +351,14 @@ function reconnectDelayMs(
   minMs: number,
   maxMs: number,
   random: () => number,
+  unstableMaxMs: number,
 ): number {
   if (attempt <= 0 || minMs === 0) return 0;
-  const exponential = Math.min(maxMs, minMs * 2 ** Math.min(attempt - 1, 30));
+  const ceiling = Math.max(maxMs, unstableMaxMs);
+  const exponential = Math.min(ceiling, minMs * 2 ** Math.min(attempt - 1, 30));
   const sample = random();
   const bounded = Number.isFinite(sample) ? Math.min(1, Math.max(0, sample)) : 0.5;
-  return Math.min(maxMs, Math.max(1, Math.round(exponential * (0.8 + bounded * 0.4))));
+  return Math.min(ceiling, Math.max(1, Math.round(exponential * (0.8 + bounded * 0.4))));
 }
 
 function waitForDelay(delayMs: number, signal: AbortSignal): Promise<void> {


### PR DESCRIPTION
Mitigates #3458

## Problem

When a Runtime Host dies immediately after spawn (transport `read_eof` on every attempt), the reconnect lifecycle retried roughly every `maxMs` (5s by default) **forever**. Each retry re-ran the full desktop registration stack — new candidate process, IPC handlers, subscriptions, capability publisher bind. ~12 hours of this churn produced hundreds of candidate generations and ended in an Electron main-process OOM (heap pinned at ~3.6 GB), with the log dominated by repeated `MCP capability alignment failed` errors.

## Change (mitigation, not the OOM root fix)

This change bounds the *churn* that amplifies the OOM; it does not fix the retained root behind it.

`RuntimeHostReconnectBackoff` gains an optional `unstableMaxMs` ceiling (default 60s, validated `>= maxMs`; when omitted it derives from `max(60s, maxMs)` so a previously valid large `maxMs` keeps working). While the failure streak persists (no connection stays installed for `stableConnectionMs`, which already resets the streak), the jittered delay now keeps doubling past `maxMs` up to that ceiling instead of saturating at `maxMs`. As soon as a connection stabilizes, the ladder restarts from `minMs`.

- Worst-case regeneration cadence during a persistent startup-death loop drops from ~every 5s to ~every 60s (~12x less churn of processes and desktop-side registration).
- Callers that need the old flat ceiling can set `unstableMaxMs` equal to `maxMs`; callers with `minMs: 0` are unaffected.
- Backwards compatibility: configurations without `unstableMaxMs` but with `maxMs > 60s` are preserved — the ceiling derives from `maxMs` instead of rejecting them.
- No behavior change for short transient outages: escalation only engages after the exponential ladder would have saturated anyway.

## What this deliberately does not do

The retention root behind the OOM still needs a heap snapshot under reproduction. If cross-generation retention persists, this patch delays the same OOM rather than bounding it — the escalation reduces regeneration frequency ~12x, which converts an hours-scale OOM into a days-scale one at worst. A real bounded/circuit-breaking ownership rule or the retained-root fix should land as a follow-up before #3458 closes.

## Testing

- New tests in `reconnecting-connection.test.ts`: delay escalates past `maxMs` and saturates at `unstableMaxMs`; a stabilized connection restarts the ladder; `unstableMaxMs < maxMs` is rejected; **an omitted `unstableMaxMs` stays compatible with a large `maxMs`** (the compatibility case from review).
- Full `@maka/runtime-host` suite green on the rebased head.

## Follow-ups (not in this PR)

- Heap snapshot under reproduction to find and fix the retained root (the actual #3458 close).
- Circuit-breaking / bounded ownership rule if retention proves unavoidable during flapping.
- Surface diagnostics when candidates die at startup so the flapping root cause (`read_eof` origin) is observable.

## AI use

- [x] Generative tooling made a substantive contribution
- [ ] No generative tool made a substantive contribution

Tool(s) and scope: Maka (AI coding agent) authored the implementation and tests; the diff was human-reviewed before push. `Generated-by: Maka` trailers are present on the branch commits (the tip commit was missing its trailer on the previously reviewed head — now added).

<details>
<summary>中文说明</summary>

本 PR 是对 #3458 的**缓解**而非根因修复：持续启动即死的 Host 触发的重建风暴从约每 5 秒一次降级到最多每 60 秒一次（新增 `unstableMaxMs` 上限，默认 60s 且省略时从 `max(60s, maxMs)` 派生，保证旧的大 `maxMs` 配置兼容）。OOM 的保留根因仍需堆快照定位；若保留仍在，此补丁只是把小时级 OOM 推迟到天级，#3458 的关闭需要后续的边界/熔断修复。已按 review 意见补充 maxMs 兼容回归测试，tip commit 补上 `Generated-by: Maka` trailer。

</details>
