### PR TITLE
fix(desktop): show the canonical Maka icon in the permission guide

### DIFF
--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -52,10 +52,11 @@ export default {
       to: 'bundled-tools.json',
     },
     {
-      // The app icon is read at runtime by the BrowserWindow `icon` option, and
-      // `files` above does not carry `assets/`. Electron reports the missing
-      // file as an empty image rather than an error, so without this the
-      // packaged app just draws no window icon.
+      // The app icon is read at runtime by the BrowserWindow `icon` option
+      // and by the permission-overlay card, and `files` above does not carry
+      // `assets/`. Electron reports the missing file as an empty image rather
+      // than an error, so without this the packaged app just draws no window
+      // icon; `assertPackagedResources` requires it on current builds.
       from: 'assets',
       to: 'assets',
     },

--- a/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
@@ -20,11 +20,7 @@ import {
   type PermissionOverlayDeps,
   type PermissionOverlayWindowLike,
 } from '../permission-overlay/permission-overlay-controller.js';
-import {
-  BUNDLE_ICON_OPTIONS,
-  loadNativeBundleIcon,
-  resolveAppBundle,
-} from '../permission-overlay/app-bundle.js';
+import { resolveAppBundle } from '../permission-overlay/app-bundle.js';
 
 /** Deterministic timer wheel — no real time passes in these tests. */
 function createClock() {
@@ -307,23 +303,6 @@ describe('drag-to-grant permission overlay', () => {
 });
 
 describe('app bundle resolution for the drag', () => {
-  it('never calls the native icon loader for an unpackaged app', async () => {
-    let calls = 0;
-    const icon = await loadNativeBundleIcon(false, async () => {
-      calls += 1;
-      return 'icon';
-    });
-    assert.equal(icon, null);
-    assert.equal(calls, 0, 'unpackaged development must not call app.getFileIcon()');
-    assert.equal(await loadNativeBundleIcon(true, async () => 'icon'), 'icon');
-  });
-
-  it('never requests the large icon size that kills packaged macOS builds', () => {
-    // 'large' hits a fatal NOTREACHED inside Chromium's IconLoader on
-    // macOS (SIGTRAP, not a catchable error) — see issue #3352.
-    assert.notEqual(BUNDLE_ICON_OPTIONS.size as string, 'large');
-  });
-
   it('walks three levels up from the executable to the .app', () => {
     assert.deepEqual(
       resolveAppBundle({

--- a/apps/desktop/src/main/permission-overlay/app-bundle.ts
+++ b/apps/desktop/src/main/permission-overlay/app-bundle.ts
@@ -34,34 +34,6 @@ export interface ResolveAppBundleDeps {
   exists(path: string): boolean;
 }
 
-/**
- * The only size every platform can actually deliver. `'large'` is
- * unsupported on macOS: Chromium's IconLoader hits a fatal NOTREACHED and
- * the process dies with SIGTRAP before the promise settles — no JavaScript
- * error is ever thrown, so the try/catch in `loadNativeBundleIcon` cannot
- * save the app. Callers upscale the 32x32 result as needed.
- */
-export const BUNDLE_ICON_OPTIONS = { size: 'normal' } as const;
-
-/**
- * Reading a bundle icon is presentation-only. The original unpackaged npm
- * Electron runtime could terminate natively while macOS resolved its bundle
- * icon, before the returned promise settled. Keep native icon loading for
- * packaged Maka.app builds and let the signed Maka Dev workflow use an empty
- * drag image instead.
- */
-export async function loadNativeBundleIcon<T>(
-  isPackaged: boolean,
-  load: () => Promise<T>,
-): Promise<T | null> {
-  if (!isPackaged) return null;
-  try {
-    return await load();
-  } catch {
-    return null;
-  }
-}
-
 export function resolveAppBundle(deps: ResolveAppBundleDeps): AppBundleResult {
   const { executablePath, platform, exists } = deps;
   if (platform !== 'darwin') {

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
@@ -22,9 +22,10 @@ import { createRequire } from 'node:module';
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { UiLocale } from '@maka/core/ui-locale';
+import { desktopAssetPath } from '../desktop-assets.js';
 import { resolveOverlayAssetDir } from '../overlay-assets.js';
 import { openSystemPermissionPane, requestPermissionAccess } from '../permissions-actions.js';
-import { BUNDLE_ICON_OPTIONS, loadNativeBundleIcon, resolveAppBundle } from './app-bundle.js';
+import { resolveAppBundle } from './app-bundle.js';
 import { getPermissionOverlayCopy } from './permission-overlay-copy.js';
 import {
   createPermissionOverlayController,
@@ -64,7 +65,7 @@ export function createPermissionOverlayMain(
   let locale: UiLocale = 'en';
   let iconDataUrl: string | null = null;
   const electron = requireElectron('electron') as Electron;
-  const { BrowserWindow, app, screen, systemPreferences } = electron;
+  const { BrowserWindow, app, nativeImage, screen, systemPreferences } = electron;
 
   function isGranted(id: DragGrantPermissionId): boolean {
     if (process.platform !== 'darwin') return false;
@@ -74,15 +75,21 @@ export function createPermissionOverlayMain(
     return systemPreferences.getMediaAccessStatus('screen') === 'granted';
   }
 
-  async function resolveAppIconDataUrl(bundlePath: string | null): Promise<string | null> {
-    if (!bundlePath) return null;
-    const icon = await loadNativeBundleIcon(app.isPackaged, () =>
-      app.getFileIcon(bundlePath, BUNDLE_ICON_OPTIONS),
+  function resolveAppIconDataUrl(): string | null {
+    // The canonical 1024px icon ships in assets/ — the same PNG
+    // electron-builder stamps onto the bundle. `app.getFileIcon()` is the
+    // wrong source for an identity: macOS reduces the path to its UTType
+    // and returns the generic application icon, never this app's own — and
+    // requesting it at size 'large' killed packaged builds outright with a
+    // fatal NOTREACHED inside Chromium's IconLoader (#3352).
+    const icon = nativeImage.createFromPath(
+      desktopAssetPath(
+        { isPackaged: app.isPackaged, resourcesPath: process.resourcesPath },
+        'assets',
+        'icon.png',
+      ),
     );
-    if (!icon || icon.isEmpty()) return null;
-    // nativeImage.createFromPath does not decode .icns reliably. Asking
-    // macOS for the bundle icon returns the same image Finder and the TCC
-    // list display for packaged Maka builds.
+    if (icon.isEmpty()) return null;
     return icon.resize({ width: 64, height: 64 }).toDataURL();
   }
 
@@ -110,6 +117,10 @@ export function createPermissionOverlayMain(
         exists: existsSync,
       });
       const bundlePath = bundle.ok ? bundle.bundlePath : null;
+      // Resolved here, at the only consumer, so a non-darwin start() never
+      // pays the PNG decode; a null result (asset missing) retries on the
+      // next card rather than caching the failure.
+      iconDataUrl ??= resolveAppIconDataUrl();
       return {
         permission: id,
         appName: app.getName(),
@@ -187,12 +198,6 @@ export function createPermissionOverlayMain(
       } catch (error) {
         console.warn('[permission-overlay] locale lookup failed, keeping', locale, error);
       }
-      const bundle = resolveAppBundle({
-        executablePath: app.getPath('exe'),
-        platform: process.platform,
-        exists: existsSync,
-      });
-      iconDataUrl = await resolveAppIconDataUrl(bundle.ok ? bundle.bundlePath : null);
       return controller.start(id);
     },
   };
@@ -267,17 +272,12 @@ function attachCardGestures(win: import('electron').BrowserWindow): void {
       payload && typeof payload === 'object' && 'iconDataUrl' in payload
         ? (payload as { iconDataUrl?: unknown }).iconDataUrl
         : null;
+    // The file drag still works without a decorative drag image, so a
+    // failed decode degrades to an empty icon rather than a native read.
     let icon = nativeImage.createEmpty();
     if (typeof iconDataUrl === 'string' && iconDataUrl.startsWith('data:image/')) {
       const fromRenderer = nativeImage.createFromDataURL(iconDataUrl);
       if (!fromRenderer.isEmpty()) icon = fromRenderer;
-    }
-    if (icon.isEmpty()) {
-      const fallback = await loadNativeBundleIcon(app.isPackaged, () =>
-        app.getFileIcon(resolved.bundlePath, BUNDLE_ICON_OPTIONS),
-      );
-      if (fallback && !fallback.isEmpty()) icon = fallback.resize({ width: 64, height: 64 });
-      // The file drag still works without a decorative drag image.
     }
 
     if (!win.isDestroyed()) win.webContents.startDrag({ file: resolved.bundlePath, icon });

--- a/scripts/verify-packaged-app.mjs
+++ b/scripts/verify-packaged-app.mjs
@@ -714,6 +714,11 @@ export async function assertPackagedResources(
     // build, which predates the disclaimer being packaged. Requiring it there
     // would fail a release that was correct when it shipped.
     requireDisclaimer = true,
+    // Same shape as the disclaimer: the canonical icon began shipping as an
+    // extra resource with the window-icon fix, and the permission overlay
+    // reads it at runtime, so current builds must carry it — but a
+    // previously released baseline predates it.
+    requireCanonicalIcon = true,
   } = {},
 ) {
   if (bundledGitContract !== 'forbidden' && bundledGitContract !== 'legacy-required') {
@@ -732,6 +737,7 @@ export async function assertPackagedResources(
           join('licenses', 'git', 'NOTICE.txt'),
         ]
       : []),
+    ...(requireCanonicalIcon ? [join('assets', 'icon.png')] : []),
     join('workers', 'filesystem-worker.js'),
     join('licenses', 'maka', 'LICENSE'),
     join('licenses', 'maka', 'NOTICE'),

--- a/scripts/verify-packaged-app.test.mjs
+++ b/scripts/verify-packaged-app.test.mjs
@@ -38,6 +38,7 @@ test('legacy packaged resources require the historical bundled Git contract', as
     forbidPath: async (path) => forbidden.push(path),
     requireWindowsSandbox: false,
     bundledGitContract: 'legacy-required',
+    requireCanonicalIcon: false,
   });
 
   for (const path of [
@@ -302,5 +303,40 @@ describe('assertPackagedDependencyClosure', () => {
         assertPackagedDependencyClosure(withoutLicense, { ...options, collectClosure: closure }),
       /shipped license file for @fontsource-variable\/geist is missing/,
     );
+  });
+});
+
+// The resource list is contract, not implementation: the permission overlay
+// reads `assets/icon.png` at runtime, so a current build that drops it ships
+// a regression the app cannot report. The check is driven through the
+// injectable `requirePath`, so it needs no packaging and no platform.
+describe('assertPackagedResources', () => {
+  const resources = join('fake', 'resources');
+  const iconPath = join(resources, 'assets', 'icon.png');
+  const requirePathMissing = (absent) => async (path) => {
+    if (path === absent) throw new Error(`MISSING ${path}`);
+  };
+  const forbidPath = async () => {};
+
+  test('a current build must carry the canonical icon', async () => {
+    await assert.rejects(
+      () =>
+        assertPackagedResources(resources, {
+          requirePath: requirePathMissing(iconPath),
+          forbidPath,
+          requireWindowsSandbox: false,
+        }),
+      /MISSING .*icon\.png/,
+    );
+  });
+
+  test('a legacy baseline predating the packaged icon is not required to carry it', async () => {
+    await assertPackagedResources(resources, {
+      requirePath: requirePathMissing(iconPath),
+      forbidPath,
+      requireWindowsSandbox: false,
+      requireDisclaimer: false,
+      requireCanonicalIcon: false,
+    });
   });
 });

--- a/scripts/verify-windows-x64.mjs
+++ b/scripts/verify-windows-x64.mjs
@@ -110,6 +110,7 @@ export async function verifyPackagedWindowsApp(
     requireWindowsSandbox: requiresCurrentContract,
     requireDisclaimer: requiresCurrentContract,
     bundledGitContract: requiresCurrentContract ? 'forbidden' : 'legacy-required',
+    requireCanonicalIcon: requiresCurrentContract,
   });
   if (requiresCurrentContract) await assertPackagedDependencyClosure(resources);
   else await requirePath(join(resources, 'git', 'cmd', 'git.exe'));


### PR DESCRIPTION
## Summary

Follow-up agreed in the #3455 review (M4n5ter's request-changes, Astro-Han's P2): the permission guide now shows the canonical Maka icon instead of a macOS file-type icon.

`app.getFileIcon()` was the wrong identity source — macOS reduces the path to its UTType and returns the generic application-bundle icon, never this particular app's own. The guide now loads the canonical 1024×1024 `assets/icon.png` (shipped as an extra resource since #3451, and the same PNG electron-builder stamps onto the bundle) via `desktopAssetPath()` + `nativeImage.createFromPath()`, resolved lazily at the card payload — its only consumer — so a non-darwin `start()` never pays the decode, and a missing asset degrades to the pre-existing no-icon path instead of caching the failure.

This lands the simplify-audit the review outlined: both `app.getFileIcon()` calls, `BUNDLE_ICON_OPTIONS`, `loadNativeBundleIcon()` and its packaged-only gate, the drag-time native fallback, and the unbounded icon await in `start()` are all gone. `resolveAppBundle()` remains solely responsible for the file being dragged. Dev builds now show the icon too, instead of the deliberate blank the #1920 gate imposed.

Since the PNG is now a load-bearing packaged resource, `assertPackagedResources` requires `assets/icon.png` — gated behind `requireCanonicalIcon` (same shape as `requireDisclaimer`) because the Windows upgrade-lifecycle baseline predates #3451; the lifecycle's post-upgrade re-verification still runs under the current contract and does require it.

Refs #3352.

## Verification

Empirical, with this repo's Electron 43.2.0 on an Apple silicon Mac:

- `nativeImage.createFromPath(assets/icon.png)` decodes 1024×1024; `resize({64,64})` → `toDataURL()` yields a valid PNG data URL; a missing path returns an empty image without throwing (degrades to `null`, same as before).
- The built `dist/main/desktop-assets.js` resolves the dev layout to `apps/desktop/assets/icon.png` (exists) and the packaged layout to `<resourcesPath>/assets/icon.png` — the call site is byte-identical to the existing one in `main-window.ts`.
- `webContents.startDrag({ file, icon: nativeImage.createEmpty() })` does not throw — Electron's `'icon' parameter is required` guard fires only on a missing key, so the deleted drag fallback loses nothing.
- `assertPackagedResources` fault-injection: current contract fails on a missing icon; `requireCanonicalIcon: false` (legacy baseline) passes — now pinned as two unit tests driven through the injectable `requirePath` (no packaging, no platform dependence).

Checks run locally (Node 24.18):

- `npm --workspace @maka/desktop run typecheck` — pass
- `npm --workspace @maka/desktop run test` — 1036 pass / 0 fail
- `node --test scripts/verify-packaged-app.test.mjs` — 16 pass / 0 fail
- `biome check` on changed files — clean; `knip` desktop workspace — clean

Not run: a full packaged DMG build (the packaged path split is covered by the existing `desktop-assets` unit tests plus the release verifiers this PR extends).

An independent adversarial review pass probed the change with fault-injection experiments before submission (path resolution from the built layout, `start()` payload regression, caching semantics, drag-fallback deletion, the `assertPackagedResources` caller matrix including the legacy-baseline gate, destructure coherence, comment truthfulness) — no defects; its two suggestions (lazy resolution at the consumer, the `assertPackagedResources` unit tests) are incorporated.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code implemented the maintainer-specified follow-up, ran the Electron-level verification, and wrote the tests; an independent adversarial review pass (also Claude) verified the change with running experiments. I reviewed and verified the result.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
