### PR TITLE
fix(desktop): guard Host projections and fallback reports

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-project-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-project-actions.test.ts
@@ -115,19 +115,16 @@ test('Project errors preserve the Host authority of the failed operation', async
   }
 });
 
-test('an old Host mutation cannot refresh the current default Host presentation', async () => {
+test('a Project mutation refresh stays bound to the operation Host', async () => {
   const actionsModule = await importProjectActions();
   const previousWindow = globalThis.window;
-  const hosts = [
-    { profileId: 'profile-a', hostId: 'host-a' },
-    { profileId: 'profile-b', hostId: 'host-b' },
-  ];
+  const host = { profileId: 'profile-a', hostId: 'host-a' };
   let renamedOnHost: unknown;
-  let refreshCalls = 0;
+  let refreshedHost: unknown;
   globalThis.window = {
     maka: {
       runtimeHostProfiles: {
-        getDefaultHost: async () => hosts.shift() ?? { profileId: 'profile-b', hostId: 'host-b' },
+        getDefaultHost: async () => host,
       },
       projects: {
         rename: async (_projectId: string, _name: string, host: unknown) => {
@@ -139,16 +136,16 @@ test('an old Host mutation cannot refresh the current default Host presentation'
 
   try {
     const actions = createTestProjectActions(actionsModule, {
-      refreshDefaultProjectState: async () => {
-        refreshCalls += 1;
+      refreshDefaultProjectState: async (operationHost) => {
+        refreshedHost = operationHost;
         return [];
       },
     });
 
     await actions.renameProject('project-1', 'Renamed');
 
-    assert.deepEqual(renamedOnHost, { profileId: 'profile-a', hostId: 'host-a' });
-    assert.equal(refreshCalls, 0);
+    assert.deepEqual(renamedOnHost, host);
+    assert.deepEqual(refreshedHost, host);
   } finally {
     globalThis.window = previousWindow;
   }

--- a/apps/desktop/src/main/__tests__/default-runtime-host-operation.test.ts
+++ b/apps/desktop/src/main/__tests__/default-runtime-host-operation.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { afterEach, test } from 'node:test';
 import {
   defaultRuntimeHostDiagnosticTarget,
+  runIfDefaultRuntimeHostCurrent,
   runOnDefaultRuntimeHost,
 } from '../../renderer/default-runtime-host-operation.js';
 
@@ -44,4 +45,49 @@ test('does not invent Host authority when resolving the default Host fails', asy
   );
 
   assert.equal(defaultRuntimeHostDiagnosticTarget(error), undefined);
+});
+
+test('discards a projection completion from a Host that is no longer the default', async () => {
+  const hostA = { profileId: 'profile-a', hostId: 'host-a' };
+  const hostB = { profileId: 'profile-b', hostId: 'host-b' };
+  let defaultHost = hostA;
+  (globalThis as { window?: unknown }).window = {
+    maka: {
+      runtimeHostProfiles: {
+        getDefaultHost: async () => defaultHost,
+      },
+    },
+  };
+  let markAStarted!: () => void;
+  const aStarted = new Promise<void>((resolve) => {
+    markAStarted = resolve;
+  });
+  let resolveA!: (value: string) => void;
+  const aResult = new Promise<string>((resolve) => {
+    resolveA = resolve;
+  });
+  const committed: string[] = [];
+
+  const pendingA = runOnDefaultRuntimeHost(async () => {
+    markAStarted();
+    return aResult;
+  }).then((result) =>
+    runIfDefaultRuntimeHostCurrent(result.host, () => {
+      committed.push(result.value);
+    }),
+  );
+  await aStarted;
+
+  defaultHost = hostB;
+  const resultB = await runOnDefaultRuntimeHost(async () => 'Host B');
+  assert.equal(
+    await runIfDefaultRuntimeHostCurrent(resultB.host, () => {
+      committed.push(resultB.value);
+    }),
+    true,
+  );
+
+  resolveA('Host A');
+  assert.equal(await pendingA, false);
+  assert.deepEqual(committed, ['Host B']);
 });

--- a/apps/desktop/src/main/__tests__/renderer-error-report.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-error-report.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { formatRendererErrorReport, RENDERER_ERROR_REPORT_MAX_BYTES } from '../../renderer/error-boundary.js';
+
+const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  if (originalNavigator) {
+    Object.defineProperty(globalThis, 'navigator', originalNavigator);
+  } else {
+    delete (globalThis as { navigator?: unknown }).navigator;
+  }
+});
+
+test('bounds and redacts the browser-only renderer error report', () => {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { userAgent: `browser/${'u'.repeat(8 * 1024)}` },
+  });
+  (globalThis as { window?: unknown }).window = {
+    location: {
+      href: `data:text/plain,?token=sk-locationsecret123&payload=${'🚀'.repeat(16 * 1024)}`,
+    },
+  };
+  const error = new Error(`api_key=sk-messagesecret123 ${'故障'.repeat(16 * 1024)}`);
+  error.stack = `Error: token=sk-stacksecret123\n${'stack frame\n'.repeat(8 * 1024)}`;
+
+  const report = formatRendererErrorReport(error, {
+    componentStack: `\n${'component\n'.repeat(8 * 1024)}`,
+  });
+
+  assert.ok(Buffer.byteLength(report, 'utf8') <= RENDERER_ERROR_REPORT_MAX_BYTES);
+  assert.match(report, /<renderer diagnostic (?:field|report) truncated>/);
+  assert.match(report, /(?:<redacted>|\[redacted\])/);
+  assert.doesNotMatch(report, /sk-(?:location|message|stack)secret123/);
+  assert.match(report, /^Maka renderer error report/);
+});

--- a/apps/desktop/src/main/__tests__/use-project-context.test.ts
+++ b/apps/desktop/src/main/__tests__/use-project-context.test.ts
@@ -1,0 +1,128 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, test } from 'node:test';
+import { act, createElement } from 'react';
+import { build } from 'esbuild';
+import type { ProjectRecord } from '@maka/core/project';
+import type * as ProjectContext from '../../renderer/use-project-context.js';
+import { cleanupFakeDom, installReactRenderer } from './fake-dom.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+const NO_PROJECT_CAPABILITIES = {
+  chooseClientDirectory: false,
+  chooseHostDirectory: false,
+  selectNoProject: false,
+  setLocalDefault: false,
+  viewClientPath: false,
+} as const;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+test('discards a pending Project projection after the default Host changes', async () => {
+  const projectContext = await importProjectContext();
+  const { root } = installReactRenderer();
+  const hostA = { profileId: 'profile-a', hostId: 'host-a' };
+  const hostB = { profileId: 'profile-b', hostId: 'host-b' };
+  let defaultHost = hostA;
+  let defaultHostReads = 0;
+  const contextStarted = deferred<void>();
+  const commitGuardChecked = deferred<void>();
+  const pendingContext = deferred<{
+    snapshot: { projects: ProjectRecord[]; capabilities: typeof NO_PROJECT_CAPABILITIES };
+    info: {
+      projectId: string;
+      projectPath: string;
+      projectGit: { isGitRepo: boolean };
+    };
+  }>();
+  (globalThis.window as unknown as { maka: unknown }).maka = {
+    runtimeHostProfiles: {
+      getDefaultHost: async () => {
+        defaultHostReads += 1;
+        if (defaultHostReads === 2) commitGuardChecked.resolve();
+        return defaultHost;
+      },
+    },
+    projects: {
+      getDefaultContext: async (host: unknown) => {
+        assert.deepEqual(host, hostA);
+        contextStarted.resolve();
+        return pendingContext.promise;
+      },
+      subscribeChanges: () => () => {},
+      getLocalSnapshot: async () => ({
+        projects: [],
+        capabilities: NO_PROJECT_CAPABILITIES,
+      }),
+      subscribeLocalChanges: () => () => {},
+    },
+  };
+  let projects: ProjectRecord[] = [];
+  let selectedProjectId: string | null | undefined;
+
+  function Probe() {
+    const context = projectContext.useAppShellProjectContext({
+      uiLocale: 'en',
+      rendererMountedRef: { current: true },
+      onProjectSelected: () => {},
+      toastApi: { success: () => {}, error: () => {} },
+    });
+    projects = context.projects;
+    selectedProjectId = context.selectedProjectId;
+    return null;
+  }
+
+  await act(async () => {
+    root.render(createElement(Probe));
+  });
+  await contextStarted.promise;
+
+  defaultHost = hostB;
+  await act(async () => {
+    pendingContext.resolve({
+      snapshot: {
+        projects: [{ id: 'project-a', name: 'Project A', locations: [], available: true }],
+        capabilities: NO_PROJECT_CAPABILITIES,
+      },
+      info: {
+        projectId: 'project-a',
+        projectPath: '/host-a/project',
+        projectGit: { isGitRepo: false },
+      },
+    });
+    await commitGuardChecked.promise;
+  });
+
+  assert.deepEqual(projects, []);
+  assert.equal(selectedProjectId, undefined);
+});
+
+afterEach(() => {
+  cleanupFakeDom();
+});
+
+async function importProjectContext(): Promise<typeof ProjectContext> {
+  const outdir = await mkdtemp(resolve(REPO_ROOT, 'apps/desktop/dist/main/__tests__/project-context-'));
+  const outfile = resolve(outdir, 'use-project-context.mjs');
+  await mkdir(dirname(outfile), { recursive: true });
+  await build({
+    entryPoints: [resolve(REPO_ROOT, 'apps/desktop/src/renderer/use-project-context.ts')],
+    outfile,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    external: ['react'],
+    logLevel: 'silent',
+  });
+  return (await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`)) as typeof ProjectContext;
+}

--- a/apps/desktop/src/renderer/app-shell-project-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-project-actions.ts
@@ -11,7 +11,6 @@ import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy.j
 import { isSessionWorkspaceUnavailableError, showSessionWorkspaceUnavailableToast } from './session-workspace-errors';
 import {
   defaultRuntimeHostDiagnosticTarget,
-  runIfDefaultRuntimeHostCurrent,
   runOnDefaultRuntimeHost,
 } from './default-runtime-host-operation.js';
 
@@ -59,7 +58,7 @@ export function createAppShellProjectActions(deps: {
   projectPickerRequestRef: RefBox<number>;
   rendererMountedRef: RefBox<boolean>;
   setProjectPickerPending: Dispatch<SetStateAction<boolean>>;
-  refreshDefaultProjectState(host?: DesktopRuntimeHostRef): Promise<ProjectRecord[]>;
+  refreshDefaultProjectState(host: DesktopRuntimeHostRef): Promise<ProjectRecord[]>;
   selectedProjectId: string | null | undefined;
   projects: readonly ProjectRecord[];
   projectCapabilities: DesktopProjectCapabilities;
@@ -95,10 +94,6 @@ export function createAppShellProjectActions(deps: {
     toastApi.error(title, description, undefined, sessionDiagnosticTarget);
   };
 
-  async function refreshDefaultProjectPresentation(host: DesktopRuntimeHostRef): Promise<void> {
-    await runIfDefaultRuntimeHostCurrent(host, () => refreshDefaultProjectState(host));
-  }
-
   async function refreshProjects(): Promise<ProjectRecord[]> {
     return (
       await runOnDefaultRuntimeHost((host) => refreshDefaultProjectState(host))
@@ -115,7 +110,7 @@ export function createAppShellProjectActions(deps: {
       const info = await window.maka.app.resolveProjectGitInfo(path, host);
       if (!info.ok) throw new Error(copy.selectedPathUnreadable);
     }
-    await refreshDefaultProjectPresentation(host);
+    await refreshDefaultProjectState(host);
     if (notify) {
       onProjectSelected(sessionId);
       toastApi.success(copy.directorySwitchedTitle, project.name);
@@ -188,7 +183,7 @@ export function createAppShellProjectActions(deps: {
     try {
       await runOnDefaultRuntimeHost(async (host) => {
         await window.maka.projects.select(null, host);
-        await refreshDefaultProjectPresentation(host);
+        await refreshDefaultProjectState(host);
         onProjectSelected(sessionId);
       });
     } catch (error) {
@@ -230,7 +225,7 @@ export function createAppShellProjectActions(deps: {
           if (project) return selectProjectRecord(project, false, host);
           if (!projectCapabilities.selectNoProject) return false;
           await window.maka.projects.select(null, host);
-          await refreshDefaultProjectPresentation(host);
+          await refreshDefaultProjectState(host);
           onProjectSelected(sessionId);
           return true;
         })
@@ -253,7 +248,7 @@ export function createAppShellProjectActions(deps: {
           const result = await window.maka.projects.relink(projectId, host);
           if (!result.ok) return null;
           if (selectAfter) await selectProjectRecord(result.project, true, host);
-          else await refreshDefaultProjectPresentation(host);
+          else await refreshDefaultProjectState(host);
           return result.project;
         })
       ).value;
@@ -267,7 +262,7 @@ export function createAppShellProjectActions(deps: {
     try {
       await runOnDefaultRuntimeHost(async (host) => {
         await window.maka.projects.rename(projectId, name, host);
-        await refreshDefaultProjectPresentation(host);
+        await refreshDefaultProjectState(host);
       });
     } catch (error) {
       showDefaultProjectError(
@@ -282,7 +277,7 @@ export function createAppShellProjectActions(deps: {
     try {
       await runOnDefaultRuntimeHost(async (host) => {
         await window.maka.projects.archive(projectId, host);
-        await refreshDefaultProjectPresentation(host);
+        await refreshDefaultProjectState(host);
       });
     } catch (error) {
       showDefaultProjectError(
@@ -297,7 +292,7 @@ export function createAppShellProjectActions(deps: {
     try {
       await runOnDefaultRuntimeHost(async (host) => {
         await window.maka.projects.restore(projectId, host);
-        await refreshDefaultProjectPresentation(host);
+        await refreshDefaultProjectState(host);
       });
     } catch (error) {
       showDefaultProjectError(

--- a/apps/desktop/src/renderer/app-shell-project-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-project-actions.ts
@@ -11,6 +11,7 @@ import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy.j
 import { isSessionWorkspaceUnavailableError, showSessionWorkspaceUnavailableToast } from './session-workspace-errors';
 import {
   defaultRuntimeHostDiagnosticTarget,
+  runIfDefaultRuntimeHostCurrent,
   runOnDefaultRuntimeHost,
 } from './default-runtime-host-operation.js';
 
@@ -95,14 +96,7 @@ export function createAppShellProjectActions(deps: {
   };
 
   async function refreshDefaultProjectPresentation(host: DesktopRuntimeHostRef): Promise<void> {
-    let currentHost: DesktopRuntimeHostRef;
-    try {
-      currentHost = await window.maka.runtimeHostProfiles.getDefaultHost();
-    } catch {
-      return;
-    }
-    if (currentHost.profileId !== host.profileId || currentHost.hostId !== host.hostId) return;
-    await refreshDefaultProjectState(host);
+    await runIfDefaultRuntimeHostCurrent(host, () => refreshDefaultProjectState(host));
   }
 
   async function refreshProjects(): Promise<ProjectRecord[]> {

--- a/apps/desktop/src/renderer/app-shell-scheduled-task-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-scheduled-task-actions.ts
@@ -6,6 +6,7 @@ import { localizedShellErrorMessage } from "./locales/shell-copy.js";
 import type { DesktopRuntimeHostRef } from '../preload/bridge-contract.js';
 import {
   defaultRuntimeHostDiagnosticTarget,
+  runIfDefaultRuntimeHostCurrent,
   runOnDefaultRuntimeHost,
 } from './default-runtime-host-operation.js';
 
@@ -64,7 +65,7 @@ export function createAppShellScheduledTaskActions(deps: {
       const next = await runOnDefaultRuntimeHost((host) =>
         window.maka.scheduledTasks.list(host),
       );
-      setScheduledTasks(next.value);
+      await runIfDefaultRuntimeHostCurrent(next.host, () => setScheduledTasks(next.value));
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         toastApi.error(

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -10,6 +10,7 @@ import { openSkillFailureCopy } from './app-shell-copy';
 import { createOpenSkillAction } from './app-shell-open-skill-action';
 import {
   defaultRuntimeHostDiagnosticTarget,
+  runIfDefaultRuntimeHostCurrent,
   runOnDefaultRuntimeHost,
 } from './default-runtime-host-operation.js';
 import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy.js';
@@ -84,7 +85,7 @@ export function createAppShellSkillActions(deps: {
   async function refreshSkills(options: { shouldShowError?: () => boolean } = {}) {
     try {
       const next = await runOnDefaultRuntimeHost((host) => window.maka.skills.list(host));
-      setSkills(next.value);
+      await runIfDefaultRuntimeHostCurrent(next.host, () => setSkills(next.value));
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshSkillsFailedTitle, copy.refreshSkillsFallback, error);
@@ -95,7 +96,7 @@ export function createAppShellSkillActions(deps: {
   async function refreshManagedSkillSources(options: { shouldShowError?: () => boolean } = {}) {
     try {
       const next = await runOnDefaultRuntimeHost((host) => window.maka.skills.sources.list(host));
-      setManagedSkillSources(next.value);
+      await runIfDefaultRuntimeHostCurrent(next.host, () => setManagedSkillSources(next.value));
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshSourcesFailedTitle, copy.refreshSourcesFallback, error);
@@ -106,7 +107,7 @@ export function createAppShellSkillActions(deps: {
   async function refreshBundledSkillCatalog(options: { shouldShowError?: () => boolean } = {}) {
     try {
       const next = await runOnDefaultRuntimeHost((host) => window.maka.skills.catalog.list(host));
-      setBundledSkillCatalog(next.value);
+      await runIfDefaultRuntimeHostCurrent(next.host, () => setBundledSkillCatalog(next.value));
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshBundledFailedTitle, copy.refreshBundledFallback, error);

--- a/apps/desktop/src/renderer/default-runtime-host-operation.ts
+++ b/apps/desktop/src/renderer/default-runtime-host-operation.ts
@@ -14,14 +14,35 @@ class DefaultRuntimeHostOperationError extends Error {
 
 export async function runOnDefaultRuntimeHost<T>(
   operation: (host: DesktopRuntimeHostRef) => Promise<T>,
-): Promise<{ readonly value: T; readonly diagnosticTarget: DefaultRuntimeHostDiagnosticTarget }> {
+): Promise<{
+  readonly value: T;
+  readonly host: DesktopRuntimeHostRef;
+  readonly diagnosticTarget: DefaultRuntimeHostDiagnosticTarget;
+}> {
   const host = await window.maka.runtimeHostProfiles.getDefaultHost();
   const diagnosticTarget = { profileId: host.profileId };
   try {
-    return { value: await operation(host), diagnosticTarget };
+    return { value: await operation(host), host, diagnosticTarget };
   } catch (error) {
     throw new DefaultRuntimeHostOperationError(error, diagnosticTarget);
   }
+}
+
+export async function runIfDefaultRuntimeHostCurrent(
+  host: DesktopRuntimeHostRef,
+  operation: () => unknown | Promise<unknown>,
+): Promise<boolean> {
+  let currentHost: DesktopRuntimeHostRef;
+  try {
+    currentHost = await window.maka.runtimeHostProfiles.getDefaultHost();
+  } catch {
+    return false;
+  }
+  if (currentHost.profileId !== host.profileId || currentHost.hostId !== host.hostId) {
+    return false;
+  }
+  await operation();
+  return true;
 }
 
 export function defaultRuntimeHostDiagnosticTarget(

--- a/apps/desktop/src/renderer/error-boundary.tsx
+++ b/apps/desktop/src/renderer/error-boundary.tsx
@@ -7,6 +7,7 @@
 // crashed early just left the user staring at an empty viewport).
 
 import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { truncateUtf8 } from '@maka/core/diagnostic-log';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { ICON_SIZE, AlertTriangle, Check, Clipboard, RotateCw } from '@maka/ui/icons';
 import { Button as UiButton, Card, redactSecrets } from '@maka/ui';
@@ -18,20 +19,36 @@ type State = {
   copyState: 'idle' | 'pending' | 'copied' | 'failed';
 };
 
+const RENDERER_ERROR_DETAILS_MAX_BYTES = 24 * 1024;
+const RENDERER_USER_AGENT_MAX_BYTES = 2 * 1024;
+const RENDERER_LOCATION_MAX_BYTES = 8 * 1024;
+export const RENDERER_ERROR_REPORT_MAX_BYTES = 32 * 1024;
+const RENDERER_FIELD_TRUNCATION_MARKER = '\n<renderer diagnostic field truncated>';
+const RENDERER_REPORT_TRUNCATION_MARKER = '\n<renderer diagnostic report truncated>';
+
 export function formatRendererErrorReport(error: Error, info?: ErrorInfo | null): string {
   const lines = [
     'Maka renderer error report',
     `Captured at: ${new Date().toISOString()}`,
     '',
-    formatRendererErrorDetails(error, info),
+    boundedRendererField(formatRendererErrorDetails(error, info), RENDERER_ERROR_DETAILS_MAX_BYTES),
   ];
   if (typeof navigator !== 'undefined' && navigator.userAgent) {
-    lines.push('', `User agent: ${navigator.userAgent}`);
+    lines.push(
+      '',
+      `User agent: ${boundedRendererField(navigator.userAgent, RENDERER_USER_AGENT_MAX_BYTES)}`,
+    );
   }
   if (typeof window !== 'undefined' && window.location?.href) {
-    lines.push(`Location: ${window.location.href}`);
+    lines.push(
+      `Location: ${boundedRendererField(window.location.href, RENDERER_LOCATION_MAX_BYTES)}`,
+    );
   }
-  return redactSecrets(lines.join('\n'));
+  return truncateUtf8(
+    redactSecrets(lines.join('\n')),
+    RENDERER_ERROR_REPORT_MAX_BYTES,
+    RENDERER_REPORT_TRUNCATION_MARKER,
+  );
 }
 
 export class ErrorBoundary extends Component<{ children: ReactNode; locale: UiLocale }, State> {
@@ -168,4 +185,8 @@ function formatRendererErrorDetails(error: Error, info?: ErrorInfo | null): stri
     lines.push('', 'React component stack:', info.componentStack.trim());
   }
   return redactSecrets(lines.join('\n'));
+}
+
+function boundedRendererField(value: string, maximumBytes: number): string {
+  return truncateUtf8(redactSecrets(value), maximumBytes, RENDERER_FIELD_TRUNCATION_MARKER);
 }

--- a/apps/desktop/src/renderer/use-project-context.ts
+++ b/apps/desktop/src/renderer/use-project-context.ts
@@ -11,6 +11,10 @@ import {
   type RendererAppInfo,
   type SessionProjectInfoState,
 } from './app-shell-project-actions';
+import {
+  runIfDefaultRuntimeHostCurrent,
+  runOnDefaultRuntimeHost,
+} from './default-runtime-host-operation.js';
 
 type RefBox<T> = { current: T };
 
@@ -89,7 +93,7 @@ export function useAppShellProjectContext(options: {
   const defaultRefreshGenerationRef = useRef(0);
 
   const refreshDefaultProjectState = async (
-    host?: DesktopRuntimeHostRef,
+    host: DesktopRuntimeHostRef,
   ): Promise<ProjectRecord[]> => {
     const generation = ++defaultRefreshGenerationRef.current;
     const { snapshot, info } = await window.maka.projects.getDefaultContext(host);
@@ -100,21 +104,32 @@ export function useAppShellProjectContext(options: {
       return [];
     }
     const nextProjects = [...snapshot.projects];
-    setProjects(nextProjects);
-    setProjectCapabilities(snapshot.capabilities);
-    setAppInfo({
-      projectId: info.projectId,
-      projectPath: info.projectPath,
-      projectGit: info.projectGit,
+    let committed = false;
+    await runIfDefaultRuntimeHostCurrent(host, () => {
+      if (
+        !rendererMountedRef.current ||
+        generation !== defaultRefreshGenerationRef.current
+      ) {
+        return;
+      }
+      setProjects(nextProjects);
+      setProjectCapabilities(snapshot.capabilities);
+      setAppInfo({
+        projectId: info.projectId,
+        projectPath: info.projectPath,
+        projectGit: info.projectGit,
+      });
+      setSelectedProjectId(info.projectId);
+      committed = true;
     });
-    setSelectedProjectId(info.projectId);
-    return nextProjects;
+    return committed ? nextProjects : [];
   };
 
   useEffect(() => {
-    const refresh = () => void refreshDefaultProjectState().catch(() => {
-      // Project management failures surface at the next user action.
-    });
+    const refresh = () =>
+      void runOnDefaultRuntimeHost((host) => refreshDefaultProjectState(host)).catch(() => {
+        // Project management failures surface at the next user action.
+      });
     const unsubscribe = window.maka.projects.subscribeChanges(refresh);
     refresh();
     return () => {


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Prevent a completed read from an old default Runtime Host from overwriting Skills, managed-source, bundled-catalog, scheduled-task, or Project presentation after the default changes.
- Make the existing Host-identity completion check a shared renderer boundary instead of duplicating it across projections.
- Bound the browser-only Renderer crash report to explicit UTF-8 budgets: 24 KiB details, 2 KiB user agent, 8 KiB location, and 32 KiB overall, with redaction before truncation.
- Keep the Electron path unchanged: main remains its collection, validation, and formatting authority.

Refs #3463

## Review focus

The Host guard owns only completion-time presentation authority; it does not cancel operations or change their diagnostic target. The browser formatter is used only when the Electron diagnostics bridge is unavailable and does not add storage, telemetry, or another report pipeline.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 1063 passed
- Focused default-Host ordering and oversized browser-report tests — 5 passed

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with implementation, tests, scope review, verification, and pull request drafting; the human contributor remains responsible for the change.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 默认 Runtime Host 切换后，旧 Host 已完成的读取结果不再覆盖 Skills、managed source、bundled catalog、scheduled task 或 Project 的当前展示状态。
- 将已有的 Host identity 完成检查收敛为 Renderer 共享边界，不在各 projection 中重复实现。
- 为纯浏览器 Renderer 崩溃报告增加明确的 UTF-8 预算：details 24 KiB、user agent 2 KiB、location 8 KiB、最终报告 32 KiB，并在截断前脱敏。
- Electron 路径保持不变：main 仍是采集、验证和格式化 authority。

关联 #3463

## 审查重点

Host guard 只负责完成时的展示 authority，不取消操作，也不改变其诊断目标。Browser formatter 仅在 Electron diagnostics bridge 不可用时使用，不增加存储、遥测或第二条报告链路。

## 验证

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 1063 项通过
- 默认 Host 时序及超长 browser report 定向测试 — 5 项通过

## AI 使用

OpenAI Codex 协助了实现、测试、范围复核、验证和 PR 文案；贡献者本人仍对本次变更负责。AI 使用选项已在英文部分勾选。

## 检查清单

- 测试覆盖本次变更，并会在缺少实现时失败。
- lint、format、typecheck 和受影响测试均已在本地通过。
- 本 PR 包含行为变化，已在概要中说明。

</details>