### PR TITLE
fix(desktop): synchronize session row metadata with menu state

### DIFF
--- a/apps/desktop/e2e/sidebar-project-row.spec.ts
+++ b/apps/desktop/e2e/sidebar-project-row.spec.ts
@@ -100,11 +100,28 @@ test('task row action menu accepts pointer selection', async ({
   await expect(page.locator('[data-maka-contract="search-modal"]')).not.toBeVisible();
 
   const sidebar = page.getByRole('navigation', { name: '任务列表' });
-  const taskRow = sessionRow(sidebar, `${LONG_SIDEBAR_SESSION_PREFIX}00`);
+  const taskSessionId = `${LONG_SIDEBAR_SESSION_PREFIX}00`;
+  const taskRow = sessionRow(sidebar, taskSessionId);
+  const actionMenu = taskRow.locator(':scope > .maka-session-row-action');
+  const timestamp = taskRow.locator('.maka-session-row-time');
+  await expect(timestamp).toHaveCSS('visibility', 'visible');
   await taskRow.hover();
   await taskRow.getByRole('button', { name: /任务操作$/ }).click();
 
   const rename = page.getByRole('menuitem', { name: '重命名', exact: true });
+  await expect(rename).toBeVisible();
+  await expect(actionMenu).toHaveAttribute('data-menu-open', 'true');
+  await rename.hover();
+  await expect.poll(() => taskRow.evaluate((row) => row.matches(':hover'))).toBe(false);
+  await expect(timestamp).toHaveCSS('visibility', 'hidden');
+
+  await page.mouse.click(4, 4);
+  await expect(rename).not.toBeVisible();
+  await expect(actionMenu).not.toHaveAttribute('data-menu-open', 'true');
+
+  await taskRow.hover();
+  await taskRow.getByRole('button', { name: /任务操作$/ }).focus();
+  await page.keyboard.press('Enter');
   await expect(rename).toBeVisible();
   await rename.click();
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -359,13 +359,14 @@
 
 .maka-session-row:hover > .maka-session-row-action,
 .maka-session-row:focus-within > .maka-session-row-action,
-.maka-session-row > .maka-session-row-action:has([popover]:popover-open) {
+.maka-session-row > .maka-session-row-action[data-menu-open="true"] {
   opacity: 1;
   pointer-events: auto;
 }
 
 .maka-session-row:hover .maka-session-row-time,
-.maka-session-row:focus-within .maka-session-row-time {
+.maka-session-row:focus-within .maka-session-row-time,
+.maka-session-row:has(> .maka-session-row-action[data-menu-open="true"]) .maka-session-row-time {
   visibility: hidden;
 }
 

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -644,6 +644,7 @@ function SessionItemActions(props: {
   return (
     <span
       className="maka-session-row-action"
+      data-menu-open={menuOpen ? 'true' : undefined}
       ref={trailingRef}
       onKeyDown={(event) => event.stopPropagation()}
     >


### PR DESCRIPTION
## Summary

- Prevent the sidebar session timestamp from overlapping or flickering with its action trigger during menu dismissal.
- Mirror the controlled menu-open state onto the session action wrapper.
- Use the same hover, focus, and menu-open conditions for both action visibility and timestamp hiding, so they switch together.
- Extend Electron regression coverage for hover loss, outside dismissal, reopening, and pointer menu selection.

before:
<img width="230" height="140" alt="Screenshot 2026-08-22 at 2 38 50 PM" src="https://github.com/user-attachments/assets/32bdda59-2db2-4447-baf3-d2cf931435cc" />

after: 
<img width="183" height="117" alt="Screenshot 2026-08-22 at 3 24 32 PM" src="https://github.com/user-attachments/assets/6723e4a6-4bb6-4283-af9d-c64c48ab2249" />


## Verification

- `npm run build:with-deps` from `apps/desktop`
- `npm --workspace @maka/desktop run typecheck`
- `npx biome check apps/desktop/e2e/sidebar-project-row.spec.ts apps/desktop/src/renderer/styles/sidebar.css packages/ui/src/session-history-list.tsx`
- `npx playwright test --config e2e/playwright.config.ts e2e/sidebar-project-row.spec.ts` — 3 passed
- `git diff --check`

The focused regression failed before the controlled menu-state wiring was added.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex analyzed the popover/focus timing, implemented the controlled-state CSS fix, and extended Electron E2E coverage.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No