### PR TITLE
feat(core): search the External Session catalog by title and path

### DIFF
--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1807,6 +1807,7 @@ const makaBridge = {
       adapterId: string;
       includeArchived?: boolean;
       cursor?: string;
+      text?: string;
     }, host?: DesktopRuntimeHostRef): Promise<{
       sessions: DesktopExternalSessionCatalogItem[];
       nextCursor: string | null;

--- a/apps/desktop/src/renderer/locales/external-session-import-copy.ts
+++ b/apps/desktop/src/renderer/locales/external-session-import-copy.ts
@@ -14,6 +14,10 @@ type ExternalSessionImportCopy = {
    *  itself, which is legible enough to ship and obvious enough to fix. */
   sourceNames: Readonly<Record<string, string>>;
   includeArchived: string;
+  searchLabel: string;
+  searchHelp: string;
+  searchPlaceholder: string;
+  searchEmpty: (term: string) => string;
   loading: string;
   listAria: string;
   emptyTitle: string;
@@ -63,6 +67,10 @@ const COPY = {
     sourceLabel: '来源',
     sourceNames: { codex: 'Codex', 'claude-code': 'Claude Code' },
     includeArchived: '包含已归档的对话',
+    searchLabel: '搜索',
+    searchHelp: '匹配对话标题与项目路径。留空显示全部。',
+    searchPlaceholder: '标题或路径的一部分',
+    searchEmpty: (term) => `没有标题或路径包含「${term}」的对话。`,
     loading: '正在读取外部对话…',
     listAria: '可导入的对话',
     emptyTitle: '没有可导入的对话',
@@ -106,6 +114,10 @@ const COPY = {
     sourceLabel: 'Source',
     sourceNames: { codex: 'Codex', 'claude-code': 'Claude Code' },
     includeArchived: 'Include archived conversations',
+    searchLabel: 'Search',
+    searchHelp: 'Matches the conversation title and the project path. Empty shows everything.',
+    searchPlaceholder: 'Part of a title or path',
+    searchEmpty: (term) => `No conversation has "${term}" in its title or path.`,
     loading: 'Reading external conversations…',
     listAria: 'Conversations available to import',
     emptyTitle: 'No conversations to import',

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -5,6 +5,7 @@ import { CheckboxInput } from '@astryxdesign/core/CheckboxInput';
 import { EmptyState } from '@astryxdesign/core/EmptyState';
 import { List, ListItem } from '@astryxdesign/core/List';
 import { SegmentedControl, SegmentedControlItem } from '@astryxdesign/core/SegmentedControl';
+import { TextInput } from '@astryxdesign/core/TextInput';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
 import { uiLocaleToIntlLocale } from '@maka/core/ui-locale';
 import type {
@@ -34,6 +35,7 @@ type CatalogWindow = CatalogState & {
 async function readCatalogWindow(input: {
   adapterId: string;
   includeArchived: boolean;
+  text: string;
   minimumItemCount: number;
   targetSourceSessionId?: string;
   host?: DesktopRuntimeHostRef;
@@ -49,6 +51,7 @@ async function readCatalogWindow(input: {
       {
         adapterId: input.adapterId,
         includeArchived: input.includeArchived,
+        ...(input.text ? { text: input.text } : {}),
         ...(cursor === undefined ? {} : { cursor }),
       },
       input.host,
@@ -87,6 +90,7 @@ type ImportAttempt = {
   sourceSessionId: string;
   name: string;
   includeArchived: boolean;
+  text: string;
   importedCountBefore: number;
   latestImportedSessionIdBefore: string | undefined;
   loadedCatalogItemCountBefore: number;
@@ -140,6 +144,11 @@ export function ImportTasksSettingsPage(props: {
   const [adapterIds, setAdapterIds] = useState<string[]>([]);
   const [adapterId, setAdapterId] = useState<string | null>(null);
   const [includeArchived, setIncludeArchived] = useState(false);
+  // Two states, not one: `searchDraft` is what the box shows, `search` is what
+  // has been asked of the Host. Typing must not put a request on the wire per
+  // keystroke against a source with a thousand sessions.
+  const [searchDraft, setSearchDraft] = useState('');
+  const [search, setSearch] = useState('');
   const [catalog, setCatalog] = useState<CatalogState>(EMPTY_CATALOG);
   const [sourceLoading, setSourceLoading] = useState(false);
   const [sourceResolved, setSourceResolved] = useState(false);
@@ -170,17 +179,28 @@ export function ImportTasksSettingsPage(props: {
   // source's rows under the new source's label.
   const requestGeneration = useRef(0);
   const recoveryGeneration = useRef(0);
-  const catalogSelectionRef = useRef({ adapterId, includeArchived, generation: 0 });
+  const catalogSelectionRef = useRef({ adapterId, includeArchived, search, generation: 0 });
   if (
     catalogSelectionRef.current.adapterId !== adapterId ||
-    catalogSelectionRef.current.includeArchived !== includeArchived
+    catalogSelectionRef.current.includeArchived !== includeArchived ||
+    catalogSelectionRef.current.search !== search
   ) {
     catalogSelectionRef.current = {
       adapterId,
       includeArchived,
+      search,
       generation: catalogSelectionRef.current.generation + 1,
     };
   }
+
+  // 250ms after typing stops, not per keystroke. The term reaches the adapter,
+  // which walks every transcript on the source, so a request per character
+  // would queue a thousand-file scan behind each one.
+  useEffect(() => {
+    if (searchDraft === search) return;
+    const timer = setTimeout(() => setSearch(searchDraft), 250);
+    return () => clearTimeout(timer);
+  }, [searchDraft, search]);
 
   const loadSources = useCallback(async () => {
     const generation = ++requestGeneration.current;
@@ -224,6 +244,7 @@ export function ImportTasksSettingsPage(props: {
         const result = await window.maka.externalSessions.list({
           adapterId: sourceId,
           includeArchived,
+          ...(search ? { text: search } : {}),
           ...(cursor === undefined ? {} : { cursor }),
         }, host);
         if (generation !== requestGeneration.current) return;
@@ -241,7 +262,7 @@ export function ImportTasksSettingsPage(props: {
         }
       }
     },
-    [copy.loadFailedFallback, host, includeArchived, locale],
+    [copy.loadFailedFallback, host, includeArchived, locale, search],
   );
 
   const refreshLoadedCatalog = useCallback(
@@ -251,6 +272,7 @@ export function ImportTasksSettingsPage(props: {
         const result = await readCatalogWindow({
           adapterId: sourceId,
           includeArchived,
+          text: search,
           minimumItemCount: loadedItemCount,
           host,
           isCurrent: () => mountedRef.current && generation === requestGeneration.current,
@@ -261,7 +283,7 @@ export function ImportTasksSettingsPage(props: {
         // visible and retry rather than replacing it with a transient error.
       }
     },
-    [host, includeArchived, mountedRef],
+    [host, includeArchived, mountedRef, search],
   );
 
   useEffect(() => {
@@ -271,7 +293,7 @@ export function ImportTasksSettingsPage(props: {
   useEffect(() => {
     if (adapterId === null) return;
     void loadCatalog(adapterId);
-  }, [adapterId, includeArchived, loadCatalog]);
+  }, [adapterId, includeArchived, search, loadCatalog]);
 
   const hasCatalogImportInFlight = catalog.sessions.some(
     (session) => session.importState.isImporting,
@@ -321,6 +343,7 @@ export function ImportTasksSettingsPage(props: {
         const result = await readCatalogWindow({
           adapterId: attempt.adapterId,
           includeArchived: attempt.includeArchived,
+          text: attempt.text,
           minimumItemCount: attempt.loadedCatalogItemCountBefore,
           targetSourceSessionId: attempt.sourceSessionId,
           host,
@@ -391,6 +414,10 @@ export function ImportTasksSettingsPage(props: {
         sourceSessionId: session.id,
         name: session.name,
         includeArchived,
+        // The search term is part of the attempt for the same reason the
+        // archived filter is: recovery re-reads the catalog window this row
+        // came from, and a cleared box would look at a different list.
+        text: search,
         importedCountBefore: session.importState.importedCount,
         latestImportedSessionIdBefore: session.importState.importedSessionIds[0],
         loadedCatalogItemCountBefore: catalog.sessions.length,
@@ -432,6 +459,7 @@ export function ImportTasksSettingsPage(props: {
       props,
       recoverUnknownImport,
       includeArchived,
+      search,
     ],
   );
 
@@ -507,6 +535,14 @@ export function ImportTasksSettingsPage(props: {
               ))}
             </SegmentedControl>
           )}
+          <TextInput
+            label={copy.searchLabel}
+            description={copy.searchHelp}
+            placeholder={copy.searchPlaceholder}
+            value={searchDraft}
+            onChange={setSearchDraft}
+            hasClear
+          />
           <CheckboxInput
             label={copy.includeArchived}
             value={includeArchived}
@@ -609,7 +645,14 @@ export function ImportTasksSettingsPage(props: {
             </div>
           )}
 
-          {catalogEmpty && (
+          {/* A search that found nothing is not the same as a source with
+              nothing in it. Reusing the "no conversations" copy would tell a
+              user their transcripts are missing when the term is simply
+              wrong, and hide the one control that would fix it. */}
+          {catalogEmpty && search !== '' && (
+            <EmptyState isCompact title={copy.searchLabel} description={copy.searchEmpty(search)} />
+          )}
+          {catalogEmpty && search === '' && (
             <EmptyState isCompact title={copy.emptyTitle} description={copy.emptyDescription} />
           )}
 

--- a/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx
@@ -7,6 +7,7 @@ import { List, ListItem } from '@astryxdesign/core/List';
 import { SegmentedControl, SegmentedControlItem } from '@astryxdesign/core/SegmentedControl';
 import { TextInput } from '@astryxdesign/core/TextInput';
 import { HStack, VStack } from '@astryxdesign/core/Stack';
+import { normalizeExternalSessionQueryText } from '@maka/core/external-session';
 import { uiLocaleToIntlLocale } from '@maka/core/ui-locale';
 import type {
   DesktopRuntimeHostRef,
@@ -466,6 +467,9 @@ export function ImportTasksSettingsPage(props: {
   const noSource = sourceResolved && !sourceLoading && !sourceError && adapterIds.length === 0;
   const catalogEmpty =
     adapterId !== null && !catalogLoading && !catalogError && catalog.sessions.length === 0;
+  // The shared normalizer decides what counts as a filter, so the empty-state
+  // copy and the matcher cannot disagree about a whitespace-only box.
+  const activeSearch = normalizeExternalSessionQueryText(search);
 
   if (sourceLoading) {
     return (
@@ -649,10 +653,18 @@ export function ImportTasksSettingsPage(props: {
               nothing in it. Reusing the "no conversations" copy would tell a
               user their transcripts are missing when the term is simply
               wrong, and hide the one control that would fix it. */}
-          {catalogEmpty && search !== '' && (
-            <EmptyState isCompact title={copy.searchLabel} description={copy.searchEmpty(search)} />
+          {/* Keyed on the normalized term, the same value the matcher uses.
+              Comparing the raw string would call a box holding only spaces an
+              active search and answer `No conversation has "   "` on a source
+              that is simply empty. */}
+          {catalogEmpty && activeSearch !== undefined && (
+            <EmptyState
+              isCompact
+              title={copy.searchLabel}
+              description={copy.searchEmpty(search.trim())}
+            />
           )}
-          {catalogEmpty && search === '' && (
+          {catalogEmpty && activeSearch === undefined && (
             <EmptyState isCompact title={copy.emptyTitle} description={copy.emptyDescription} />
           )}
 

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 import { ToastProvider, useToast } from '@maka/ui';
 import type {
   AppSettings,
@@ -704,9 +704,17 @@ const makaBridge = {
   // judge.
   externalSessions: {
     listSources: async () => ({ adapterIds: ['codex'] }),
-    list: async (input: { includeArchived?: boolean; cursor?: string }) => {
+    list: async (input: { includeArchived?: boolean; cursor?: string; text?: string }) => {
+      // The stub honours `text` because the real Host applies it before
+      // paging. A stub that ignored it would render a search box that looks
+      // wired and is not, and the story would certify that.
+      const term = input.text?.trim().toLowerCase();
       const visible = externalConversations.filter(
-        (conversation) => input.includeArchived || !conversation.archived,
+        (conversation) =>
+          (input.includeArchived || !conversation.archived) &&
+          (!term ||
+            conversation.name.toLowerCase().includes(term) ||
+            conversation.cwd.toLowerCase().includes(term)),
       );
       const start = input.cursor === EXTERNAL_SECOND_PAGE ? EXTERNAL_PAGE_SIZE : 0;
       const end = start + EXTERNAL_PAGE_SIZE;
@@ -1419,6 +1427,32 @@ export const ArchivedTasks: Story = {
 export const ImportTasks: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="import-tasks" />,
+};
+
+// Real path: 设置 → 导入任务 → type into 搜索. The catalog pages 16 at a time
+// over a source that can hold a thousand sessions, so the term is the only way
+// to reach one by name. Typing here proves the box reaches the query rather
+// than filtering the page already on screen.
+export const ImportTasksSearch: Story = {
+  decorators: [withSettingsBridge],
+  render: () => <SettingsStory section="import-tasks" />,
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    const search = await body.findByRole('textbox', { name: '搜索' });
+    // `worktree` appears in exactly one fixture title, so a working search
+    // narrows three rows to one. Filtering the assembled page would too — the
+    // difference is that this term reaches the query, which is what the
+    // stub asserts by honouring it.
+    await userEvent.type(search, 'worktree');
+    // Debounced, so the list settles a moment after the last keystroke.
+    await waitFor(async () => {
+      const rows = body.queryAllByRole('listitem');
+      await expect(rows).toHaveLength(1);
+    });
+    await expect(
+      await body.findByText('Trace the flaky worktree teardown in CI'),
+    ).toBeInTheDocument();
+  },
 };
 
 function importOutcomeRecoveryBridge(): Record<string, unknown> {

--- a/docs/astryx-surface-file-inventory.md
+++ b/docs/astryx-surface-file-inventory.md
@@ -71,7 +71,7 @@ Wiki bar: Design Conventions · API Use-the-System · Theming · Container Paddi
 | `apps/desktop/src/renderer/settings/data-settings-page.tsx` | settings-page | Banner, Button | aligned — uses Astryx (Banner, Button) | aligned |
 | `apps/desktop/src/renderer/settings/general-settings-page.tsx` | settings-page | Banner, Button | aligned — uses Astryx (Banner, Button) | aligned |
 | `apps/desktop/src/renderer/settings/health-center-page.tsx` | settings-page | Banner, Button, Text, VStack | aligned — uses Astryx (Banner, Button, Text, VStack) | aligned |
-| `apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx` | settings-page | Banner, Button, CheckboxInput, EmptyState, HStack, List, ListItem, SegmentedControl, SegmentedControlItem, Spinner, VStack | aligned — uses Astryx (Banner, Button, CheckboxInput, EmptyState, HStack, List, ListItem, SegmentedControl) | aligned |
+| `apps/desktop/src/renderer/settings/import-tasks-settings-page.tsx` | settings-page | Banner, Button, CheckboxInput, EmptyState, HStack, List, ListItem, SegmentedControl, SegmentedControlItem, Spinner, TextInput, VStack | aligned — uses Astryx (Banner, Button, CheckboxInput, EmptyState, HStack, List, ListItem, SegmentedControl) | aligned |
 | `apps/desktop/src/renderer/settings/memory-entry-list.tsx` | settings-module | Button, EmptyState | aligned — uses Astryx (Button, EmptyState) | aligned |
 | `apps/desktop/src/renderer/settings/memory-settings-page.tsx` | settings-page | Banner, Button, EmptyState | aligned — uses Astryx (Banner, Button, EmptyState) | aligned |
 | `apps/desktop/src/renderer/settings/memory-settings-sections.tsx` | settings-module | Button | aligned — uses Astryx (Button) | aligned |

--- a/packages/core/src/__tests__/external-session-query.test.ts
+++ b/packages/core/src/__tests__/external-session-query.test.ts
@@ -144,6 +144,33 @@ describe('sameExternalSessionPath', () => {
     assert.equal(sameExternalSessionPath('/Repo', '/repo'), false);
   });
 
+  test('the POSIX root is not the same as an unknown cwd', () => {
+    // Stripping trailing separators unconditionally folded `/` and `''` to the
+    // same value, so a workspace at filesystem root matched every session
+    // whose cwd the adapter could not determine. The root IS its separator.
+    assert.equal(sameExternalSessionPath('/', ''), false);
+    assert.equal(sameExternalSessionPath('/', '/'), true);
+    assert.equal(sameExternalSessionPath('//', '/'), true);
+    assert.equal(sameExternalSessionPath('', ''), true);
+    assert.equal(sameExternalSessionPath('/', '/repo'), false);
+  });
+
+  test('a term with a trailing separator still names the project', () => {
+    // Windows Explorer copies `C:\\Repo\\App\\`, trailing backslash included.
+    const backslash = String.fromCharCode(92);
+    const win = summary({ name: 'untitled', cwd: 'C:/Repo/App' });
+    assert.equal(
+      externalSessionMatchesQuery(win, {
+        text: `C:${backslash}Repo${backslash}App${backslash}`,
+      }),
+      true,
+    );
+    assert.equal(
+      externalSessionMatchesQuery(summary({ cwd: '/repo/app' }), { text: '/repo/app/' }),
+      true,
+    );
+  });
+
   test('different projects stay different', () => {
     assert.equal(sameExternalSessionPath('/repo/app', '/repo/other'), false);
     assert.equal(sameExternalSessionPath('/repo/app', '/repo/app-2'), false);

--- a/packages/core/src/__tests__/external-session-query.test.ts
+++ b/packages/core/src/__tests__/external-session-query.test.ts
@@ -55,6 +55,36 @@ describe('externalSessionMatchesQuery', () => {
     assert.equal(normalized?.length, EXTERNAL_SESSION_QUERY_TEXT_MAX_CHARS);
   });
 
+  test('a term pasted from a Windows path finds a forward-slash summary', () => {
+    // `sameExternalSessionPath` already calls these the same project. Before
+    // the shared normalizer, the text match disagreed with the cwd filter
+    // about the same two strings.
+    const win = summary({ cwd: 'C:/Repo/App' });
+    assert.equal(
+      externalSessionMatchesQuery(win, {
+        text: 'C:' + String.fromCharCode(92) + 'Repo' + String.fromCharCode(92) + 'App',
+      }),
+      true,
+    );
+    assert.equal(externalSessionMatchesQuery(win, { text: 'c:/repo/app' }), true);
+    // A summary recorded with backslashes is reachable from either spelling.
+    const stored = summary({
+      cwd: 'C:' + String.fromCharCode(92) + 'Repo' + String.fromCharCode(92) + 'App',
+    });
+    assert.equal(externalSessionMatchesQuery(stored, { text: 'C:/Repo/App' }), true);
+  });
+
+  test('composed and decomposed Unicode name the same conversation', () => {
+    // macOS records decomposed filenames, so the same visible title arrives
+    // in NFC or NFD depending on where it was typed.
+    const nfc = 'caf\u00e9-notes';
+    const nfd = 'cafe\u0301-notes';
+    assert.notEqual(nfc, nfd, 'fixture must actually differ by normalization form');
+    assert.equal(externalSessionMatchesQuery(summary({ name: nfc }), { text: nfd }), true);
+    assert.equal(externalSessionMatchesQuery(summary({ name: nfd }), { text: nfc }), true);
+    assert.equal(sameExternalSessionPath('/repo/' + nfc, '/repo/' + nfd), true);
+  });
+
   test('archived rows stay hidden unless asked for, term or no term', () => {
     const archived = summary({ archived: true });
     assert.equal(externalSessionMatchesQuery(archived, {}), false);

--- a/packages/core/src/__tests__/external-session-query.test.ts
+++ b/packages/core/src/__tests__/external-session-query.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  EXTERNAL_SESSION_QUERY_TEXT_MAX_CHARS,
+  externalSessionMatchesQuery,
+  normalizeExternalSessionQueryText,
+  sameExternalSessionPath,
+  type ExternalSessionSummary,
+} from '../external-session.js';
+
+function summary(over: Partial<ExternalSessionSummary> = {}): ExternalSessionSummary {
+  return { id: 'sess-1', name: 'Fix the parser', cwd: '/Users/z/maka-agent', ...over };
+}
+
+describe('externalSessionMatchesQuery', () => {
+  test('an absent term selects everything', () => {
+    assert.equal(externalSessionMatchesQuery(summary()), true);
+    assert.equal(externalSessionMatchesQuery(summary(), {}), true);
+  });
+
+  test('a term matches the title, case-insensitively', () => {
+    assert.equal(externalSessionMatchesQuery(summary(), { text: 'parser' }), true);
+    assert.equal(externalSessionMatchesQuery(summary(), { text: 'PARSER' }), true);
+    assert.equal(externalSessionMatchesQuery(summary(), { text: 'Fix the' }), true);
+  });
+
+  test('a term matches the project path', () => {
+    // The other half of "the session I half remember": people navigate by
+    // where the work happened as often as by what it was called.
+    assert.equal(externalSessionMatchesQuery(summary(), { text: 'maka-agent' }), true);
+    assert.equal(externalSessionMatchesQuery(summary(), { text: '/Users/z' }), true);
+  });
+
+  test('a term that matches neither excludes the row', () => {
+    assert.equal(externalSessionMatchesQuery(summary(), { text: 'kubernetes' }), false);
+  });
+
+  test('a blank box is not a filter', () => {
+    // A stray space must not hide every session. `''` and `'   '` both mean
+    // "no term", which is why the term is normalized rather than truthiness-
+    // checked at each call site.
+    for (const text of ['', '   ', '\t\n']) {
+      assert.equal(externalSessionMatchesQuery(summary(), { text }), true, JSON.stringify(text));
+    }
+    assert.equal(normalizeExternalSessionQueryText('   '), undefined);
+    assert.equal(normalizeExternalSessionQueryText(undefined), undefined);
+    assert.equal(normalizeExternalSessionQueryText('  Parser '), 'parser');
+  });
+
+  test('an over-long term is truncated rather than refused', () => {
+    // Bounded because the term reaches every adapter. Truncating keeps a long
+    // paste working on its prefix instead of throwing at the user.
+    const term = 'a'.repeat(EXTERNAL_SESSION_QUERY_TEXT_MAX_CHARS + 50);
+    const normalized = normalizeExternalSessionQueryText(term);
+    assert.equal(normalized?.length, EXTERNAL_SESSION_QUERY_TEXT_MAX_CHARS);
+  });
+
+  test('archived rows stay hidden unless asked for, term or no term', () => {
+    const archived = summary({ archived: true });
+    assert.equal(externalSessionMatchesQuery(archived, {}), false);
+    assert.equal(externalSessionMatchesQuery(archived, { text: 'parser' }), false);
+    assert.equal(externalSessionMatchesQuery(archived, { includeArchived: true }), true);
+    assert.equal(
+      externalSessionMatchesQuery(archived, { includeArchived: true, text: 'parser' }),
+      true,
+    );
+  });
+
+  test('cwd and text both apply, not either', () => {
+    const query = { cwd: '/Users/z/maka-agent', text: 'parser' };
+    assert.equal(externalSessionMatchesQuery(summary(), query), true);
+    assert.equal(externalSessionMatchesQuery(summary({ cwd: '/elsewhere' }), query), false);
+    assert.equal(externalSessionMatchesQuery(summary({ name: 'unrelated' }), query), false);
+  });
+
+  test('a term matching one field is enough', () => {
+    assert.equal(
+      externalSessionMatchesQuery(summary({ name: 'untitled' }), { text: 'maka-agent' }),
+      true,
+    );
+    assert.equal(externalSessionMatchesQuery(summary({ cwd: '/tmp' }), { text: 'parser' }), true);
+  });
+});
+
+describe('sameExternalSessionPath', () => {
+  test('separators and a trailing slash do not change the project', () => {
+    // The Claude Code adapter compared raw strings, so the same project
+    // reached through a different separator answered "no such project".
+    assert.equal(sameExternalSessionPath('C:/Repo/App', 'C:\\Repo\\App'), true);
+    assert.equal(sameExternalSessionPath('/repo/app/', '/repo/app'), true);
+    assert.equal(sameExternalSessionPath('/repo/app', '/repo/app'), true);
+  });
+
+  test('a Windows drive letter is case-insensitive, a POSIX path is not', () => {
+    assert.equal(sameExternalSessionPath('C:/Repo', 'c:/repo'), true);
+    // Two different directories on a case-sensitive filesystem.
+    assert.equal(sameExternalSessionPath('/Repo', '/repo'), false);
+  });
+
+  test('different projects stay different', () => {
+    assert.equal(sameExternalSessionPath('/repo/app', '/repo/other'), false);
+    assert.equal(sameExternalSessionPath('/repo/app', '/repo/app-2'), false);
+  });
+});

--- a/packages/core/src/__tests__/external-session-query.test.ts
+++ b/packages/core/src/__tests__/external-session-query.test.ts
@@ -74,6 +74,23 @@ describe('externalSessionMatchesQuery', () => {
     assert.equal(externalSessionMatchesQuery(stored, { text: 'C:/Repo/App' }), true);
   });
 
+  test('separator folding stays on the path pair and off the title', () => {
+    // Folding a title would make `/n` match a title holding a literal
+    // backslash-n; folding the term but not the title would stop the term
+    // that names it from finding it. Both directions are checked because a
+    // one-sided fold trades one bug for the other.
+    const backslash = String.fromCharCode(92);
+    const title = summary({ name: `regex: ${backslash}n handling`, cwd: '/repo' });
+    assert.equal(externalSessionMatchesQuery(title, { text: `${backslash}n` }), true);
+    assert.equal(externalSessionMatchesQuery(title, { text: '/n' }), false);
+    // The path pair still folds, which is what makes a pasted Windows path work.
+    const win = summary({ name: 'untitled', cwd: 'C:/Repo/App' });
+    assert.equal(
+      externalSessionMatchesQuery(win, { text: `C:${backslash}Repo${backslash}App` }),
+      true,
+    );
+  });
+
   test('composed and decomposed Unicode name the same conversation', () => {
     // macOS records decomposed filenames, so the same visible title arrives
     // in NFC or NFD depending on where it was typed.

--- a/packages/core/src/external-session.ts
+++ b/packages/core/src/external-session.ts
@@ -55,9 +55,16 @@ export function externalSessionMatchesQuery(
   // pasted from a Windows path missed a stored forward-slash path that
   // `sameExternalSessionPath` already calls the same project, and a title
   // typed in NFC missed one macOS recorded in NFD.
+  // Separator folding is applied to the path pair only, never to the title.
+  // Folding a title would make a search for `/n` match a title containing a
+  // literal backslash-n, and folding the term without the title would stop
+  // `\\n` from finding the very title it names. The path pair has no such
+  // ambiguity: a separator there is a separator.
   return (
     normalizeExternalSessionMatchText(summary.name).includes(text) ||
-    normalizeExternalSessionMatchText(summary.cwd).includes(text)
+    foldExternalSessionPathSeparators(normalizeExternalSessionMatchText(summary.cwd)).includes(
+      foldExternalSessionPathSeparators(text),
+    )
   );
 }
 
@@ -79,7 +86,16 @@ export function externalSessionMatchesQuery(
  * rather than two rules free to drift.
  */
 function normalizeExternalSessionMatchText(value: string): string {
-  return value.normalize('NFC').toLowerCase().split(String.fromCharCode(92)).join('/');
+  return value.normalize('NFC').toLowerCase();
+}
+
+/**
+ * Windows separators folded to the POSIX form, so a term pasted from one
+ * spelling of a path finds the project the summary stored in the other. The
+ * same equivalence `sameExternalSessionPath` applies to the `cwd` filter.
+ */
+function foldExternalSessionPathSeparators(value: string): string {
+  return value.split(String.fromCharCode(92)).join('/');
 }
 
 /**

--- a/packages/core/src/external-session.ts
+++ b/packages/core/src/external-session.ts
@@ -3,9 +3,20 @@ import type { StoredMessage } from './session.js';
 /** Stable identifier for one external Agent integration, for example `codex`. */
 export type ExternalAgentId = string;
 
+/** A search term longer than this is refused rather than matched. */
+export const EXTERNAL_SESSION_QUERY_TEXT_MAX_CHARS = 200;
+
 export interface ExternalSessionQuery {
   cwd?: string;
   includeArchived?: boolean;
+  /**
+   * Free text matched against a summary's title and cwd.
+   *
+   * Applied by the adapter, before paging. Filtering an assembled page would
+   * search only the rows already fetched, which on a 1128-session source is
+   * worse than offering no search at all.
+   */
+  text?: string;
 }
 
 /** Lightweight source-native identity used by session pickers and import commands. */
@@ -16,6 +27,58 @@ export interface ExternalSessionSummary {
   createdAt?: number;
   updatedAt?: number;
   archived?: boolean;
+}
+
+/**
+ * Whether one summary answers a query.
+ *
+ * Shared by every adapter on purpose. The catalog is one surface over several
+ * sources, so a filter that quietly worked for Codex and not for Claude Code
+ * would be worse than no filter — the user cannot see which source dropped
+ * their term. Keeping the decision here means a new adapter inherits the
+ * behaviour instead of reimplementing it.
+ */
+export function externalSessionMatchesQuery(
+  summary: ExternalSessionSummary,
+  query: ExternalSessionQuery = {},
+): boolean {
+  if (!query.includeArchived && summary.archived) return false;
+  if (query.cwd !== undefined && !sameExternalSessionPath(summary.cwd, query.cwd)) return false;
+  const text = normalizeExternalSessionQueryText(query.text);
+  if (text === undefined) return true;
+  // Title and path, because those are the two things a user remembers about a
+  // conversation they are looking for. Both already sit on the summary, so
+  // matching costs no extra reads. Message content is deliberately excluded:
+  // it would mean opening every transcript on every keystroke.
+  return summary.name.toLowerCase().includes(text) || summary.cwd.toLowerCase().includes(text);
+}
+
+/**
+ * The comparable form of a search term, or `undefined` when it selects
+ * nothing — an empty or whitespace-only box is not a filter, and treating it
+ * as one would hide every session behind a stray space.
+ */
+export function normalizeExternalSessionQueryText(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim().slice(0, EXTERNAL_SESSION_QUERY_TEXT_MAX_CHARS);
+  return trimmed.length > 0 ? trimmed.toLowerCase() : undefined;
+}
+
+/**
+ * Path equality across the shapes different sources record.
+ *
+ * Codex normalizes separators and lowercases a Windows drive prefix before
+ * comparing; the Claude Code adapter compared raw strings, so the same project
+ * reached through a different separator answered "no such project". One rule
+ * for both.
+ */
+export function sameExternalSessionPath(left: string, right: string): boolean {
+  return normalizeExternalSessionPath(left) === normalizeExternalSessionPath(right);
+}
+
+function normalizeExternalSessionPath(value: string): string {
+  const normalized = value.replaceAll('\\', '/').replace(/\/+$/u, '');
+  return /^[A-Za-z]:\//u.test(normalized) ? normalized.toLowerCase() : normalized;
 }
 
 /**

--- a/packages/core/src/external-session.ts
+++ b/packages/core/src/external-session.ts
@@ -50,7 +50,36 @@ export function externalSessionMatchesQuery(
   // conversation they are looking for. Both already sit on the summary, so
   // matching costs no extra reads. Message content is deliberately excluded:
   // it would mean opening every transcript on every keystroke.
-  return summary.name.toLowerCase().includes(text) || summary.cwd.toLowerCase().includes(text);
+  //
+  // Candidate and term pass through the same normalizer. Without it a term
+  // pasted from a Windows path missed a stored forward-slash path that
+  // `sameExternalSessionPath` already calls the same project, and a title
+  // typed in NFC missed one macOS recorded in NFD.
+  return (
+    normalizeExternalSessionMatchText(summary.name).includes(text) ||
+    normalizeExternalSessionMatchText(summary.cwd).includes(text)
+  );
+}
+
+/**
+ * The comparable form of one side of a text match.
+ *
+ * Three normalizations, each for a difference that is not a difference to the
+ * person searching:
+ *
+ * - **NFC** — macOS records decomposed filenames, so the same visible name can
+ *   arrive composed or decomposed depending on where it was typed.
+ * - **case** — nobody searching for a project remembers its capitalisation.
+ * - **separators** — a term pasted from a Windows path should still find the
+ *   project the summary stored with forward slashes, matching the equivalence
+ *   `sameExternalSessionPath` already applies to the `cwd` filter.
+ *
+ * Applied to the title as well as the path. A title rarely holds a separator,
+ * but running one normalizer over both is what keeps this a single authority
+ * rather than two rules free to drift.
+ */
+function normalizeExternalSessionMatchText(value: string): string {
+  return value.normalize('NFC').toLowerCase().split(String.fromCharCode(92)).join('/');
 }
 
 /**
@@ -61,7 +90,7 @@ export function externalSessionMatchesQuery(
 export function normalizeExternalSessionQueryText(value: string | undefined): string | undefined {
   if (value === undefined) return undefined;
   const trimmed = value.trim().slice(0, EXTERNAL_SESSION_QUERY_TEXT_MAX_CHARS);
-  return trimmed.length > 0 ? trimmed.toLowerCase() : undefined;
+  return trimmed.length > 0 ? normalizeExternalSessionMatchText(trimmed) : undefined;
 }
 
 /**
@@ -77,7 +106,7 @@ export function sameExternalSessionPath(left: string, right: string): boolean {
 }
 
 function normalizeExternalSessionPath(value: string): string {
-  const normalized = value.replaceAll('\\', '/').replace(/\/+$/u, '');
+  const normalized = value.normalize('NFC').replaceAll('\\', '/').replace(/\/+$/u, '');
   return /^[A-Za-z]:\//u.test(normalized) ? normalized.toLowerCase() : normalized;
 }
 

--- a/packages/core/src/external-session.ts
+++ b/packages/core/src/external-session.ts
@@ -95,7 +95,7 @@ function normalizeExternalSessionMatchText(value: string): string {
  * same equivalence `sameExternalSessionPath` applies to the `cwd` filter.
  */
 function foldExternalSessionPathSeparators(value: string): string {
-  return value.split(String.fromCharCode(92)).join('/');
+  return normalizeExternalSessionPath(value);
 }
 
 /**
@@ -122,8 +122,16 @@ export function sameExternalSessionPath(left: string, right: string): boolean {
 }
 
 function normalizeExternalSessionPath(value: string): string {
-  const normalized = value.normalize('NFC').replaceAll('\\', '/').replace(/\/+$/u, '');
-  return /^[A-Za-z]:\//u.test(normalized) ? normalized.toLowerCase() : normalized;
+  const folded = value.normalize('NFC').replaceAll('\\', '/');
+  // Trailing separators are noise — Windows Explorer copies `C:\\Repo\\App\\`
+  // — but the POSIX root IS its separator. Stripping unconditionally folded
+  // `/` and `''` to the same value, so a workspace at filesystem root matched
+  // every session whose cwd was simply unknown.
+  const stripped = folded.replace(/\/+$/u, '');
+  // `''` after stripping means the input was nothing but separators, so it was
+  // the POSIX root — `/`, `//` and `///` all name the same directory.
+  const trimmed = stripped.length > 0 ? stripped : folded.length > 0 ? '/' : '';
+  return /^[A-Za-z]:\//u.test(trimmed) ? trimmed.toLowerCase() : trimmed;
 }
 
 /**

--- a/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/external-session-protocol.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import {
   decodeClientFrame,
+  decodeExternalSessionCatalogQueryInput,
   decodeExternalSessionCatalogQueryResult,
   decodeExternalSessionSourceQueryResult,
   EXTERNAL_SESSION_IMPORTED_SESSION_IDS_MAX_ITEMS,
@@ -252,3 +253,37 @@ describe('external Session protocol', () => {
 function isProtocolError(error: unknown): boolean {
   return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
 }
+
+describe('external Session catalog query text', () => {
+  test('a term is accepted and carried through', () => {
+    assert.deepEqual(
+      decodeExternalSessionCatalogQueryInput({ adapterId: 'claude-code', text: 'parser' }),
+      { adapterId: 'claude-code', text: 'parser' },
+    );
+  });
+
+  test('an absent term stays absent rather than becoming an empty filter', () => {
+    assert.deepEqual(decodeExternalSessionCatalogQueryInput({ adapterId: 'codex' }), {
+      adapterId: 'codex',
+    });
+  });
+
+  test('a term that is not a bounded string is refused at the frame', () => {
+    // The term reaches every adapter, so an unbounded or wrong-typed value
+    // must not get past the protocol edge.
+    for (const text of [42, null, {}, '', 'x'.repeat(1_000)]) {
+      assert.throws(
+        () => decodeExternalSessionCatalogQueryInput({ adapterId: 'codex', text }),
+        RuntimeHostProtocolError,
+        `text=${JSON.stringify(text)?.slice(0, 24)}`,
+      );
+    }
+  });
+
+  test('an unknown field is still refused', () => {
+    assert.throws(
+      () => decodeExternalSessionCatalogQueryInput({ adapterId: 'codex', query: 'parser' }),
+      RuntimeHostProtocolError,
+    );
+  });
+});

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -113,8 +113,8 @@ describe('Runtime Host bootstrap protocol', () => {
     assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 34);
   });
 
-  test('publishes a new compatibility epoch for TraceTotals removal', () => {
-    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 36);
+  test('publishes a new compatibility epoch for the catalog search term', () => {
+    assert.equal(RUNTIME_HOST_COMPATIBILITY_EPOCH, 37);
   });
 
   test('selects the highest mutually supported protocol and rejects a gap', () => {

--- a/packages/runtime-host/src/protocol/external-session.ts
+++ b/packages/runtime-host/src/protocol/external-session.ts
@@ -12,6 +12,11 @@ import { decodeSessionCatalogItem, type SessionCatalogItem } from './session-cat
 import { decodeWorkspaceTarget, type WorkspaceTarget } from './workspace.js';
 
 export const EXTERNAL_SESSION_PAGE_MAX_ITEMS = 16;
+
+/** Byte bound for a catalog search term. The 200-char contract in
+ *  `@maka/core/external-session` at 4 bytes per character, so a term the core
+ *  matcher would accept can always reach it. */
+export const EXTERNAL_SESSION_QUERY_TEXT_MAX_BYTES = 800;
 export const EXTERNAL_SESSION_RESULT_MAX_BYTES = 72 * 1024;
 export const EXTERNAL_SESSION_CWD_MAX_BYTES = 4 * 1024;
 export const EXTERNAL_SESSION_NAME_MAX_BYTES = 320;
@@ -46,6 +51,8 @@ export interface ExternalSessionCatalogQueryInput {
   readonly includeArchived?: boolean;
   readonly workspace?: WorkspaceTarget;
   readonly cursor?: string;
+  /** Free text matched against a session's title and cwd, applied before paging. */
+  readonly text?: string;
 }
 
 export interface ExternalSessionCatalogQueryResult {
@@ -148,7 +155,7 @@ export function decodeExternalSessionCatalogQueryInput(
     value,
     'external Session catalog query input',
     ['adapterId'],
-    ['includeArchived', 'workspace', 'cursor'],
+    ['includeArchived', 'workspace', 'cursor', 'text'],
   );
   return {
     adapterId: adapterId(input.adapterId),
@@ -159,6 +166,7 @@ export function decodeExternalSessionCatalogQueryInput(
       ? { workspace: decodeWorkspaceTarget(input.workspace) }
       : {}),
     ...(Object.hasOwn(input, 'cursor') ? { cursor: cursor(input.cursor) } : {}),
+    ...(Object.hasOwn(input, 'text') ? { text: catalogQueryText(input.text) } : {}),
   };
 }
 
@@ -276,6 +284,19 @@ function decodeExternalSessionImportState(
 
 function adapterId(value: unknown): string {
   return requireEntityId(value, 'external Session adapter id');
+}
+
+/**
+ * A bounded search term. Bounded rather than free-form because it reaches the
+ * adapters, and an unbounded string from a client would be matched against
+ * every summary on every source.
+ */
+function catalogQueryText(value: unknown): string {
+  return requireUtf8String(
+    value,
+    'external Session catalog query text',
+    EXTERNAL_SESSION_QUERY_TEXT_MAX_BYTES,
+  );
 }
 
 function cursor(value: unknown): string {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -72,7 +72,7 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 36 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 37 as const;
 // 36: Session trace inspection no longer transports aggregate TraceTotals.
 // 35: Session trace inspection uses cursor pages and Session usage has its own
 // invalidation domain. Older peers cannot safely exchange those frames.

--- a/packages/runtime-host/src/server/external-session-coordinator.ts
+++ b/packages/runtime-host/src/server/external-session-coordinator.ts
@@ -149,16 +149,21 @@ export class HostExternalSessionCoordinator {
         ? (await this.#workspaceResolver.resolve(input.workspace)).cwd
         : undefined;
       const offset = input.cursor === undefined ? 0 : Number(input.cursor);
-      const sessions = (
-        await adapter.listSessions({
-          ...(cwd === undefined ? {} : { cwd }),
-          ...(input.includeArchived === undefined
-            ? {}
-            : { includeArchived: input.includeArchived }),
-        })
-      )
-        .map(toWireSummary)
-        .filter((summary): summary is ExternalSessionCatalogItem => summary !== undefined);
+      const sessions =
+        // The term reaches the adapter rather than being applied to the page
+        // below: paging happens after this call, so filtering afterwards would
+        // search the 16 rows already fetched instead of the source.
+        (
+          await adapter.listSessions({
+            ...(cwd === undefined ? {} : { cwd }),
+            ...(input.includeArchived === undefined
+              ? {}
+              : { includeArchived: input.includeArchived }),
+            ...(input.text === undefined ? {} : { text: input.text }),
+          })
+        )
+          .map(toWireSummary)
+          .filter((summary): summary is ExternalSessionCatalogItem => summary !== undefined);
       const candidates = sessions.slice(offset, offset + EXTERNAL_SESSION_PAGE_MAX_ITEMS);
       const imports = await this.#sessions.lookupExternalSessionImports(
         input.adapterId,

--- a/packages/storage/src/__tests__/claude-code-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/claude-code-session-adapter.test.ts
@@ -295,6 +295,37 @@ describe('ClaudeCodeSessionAdapter', () => {
     });
   });
 
+  test('a rewritten transcript is re-read, a deleted one drops out', async () => {
+    // Listing parses every transcript, and the catalog is listed once per
+    // search term — so summaries are cached against the file's own mtime and
+    // size. The risk a cache carries is serving a stale answer, so both
+    // directions are pinned: an appended transcript must be re-read, and a
+    // removed one must not survive in the map.
+    await withClaudeHome(async (home) => {
+      const id = 'aaaaaaaa-0000-4000-8000-000000000033';
+      await seed(home, id, [
+        userRecord('first title'),
+        assistantRecord({ text: 'ok', stopReason: 'end_turn' }),
+      ]);
+      const adapter = new ClaudeCodeSessionAdapter({ claudeHome: home });
+      assert.equal((await adapter.listSessions())[0]?.name, 'first title');
+
+      // Rewritten with a different title. Same path, new content.
+      await seed(home, id, [
+        userRecord('second title'),
+        assistantRecord({ text: 'ok', stopReason: 'end_turn' }),
+      ]);
+      assert.equal(
+        (await adapter.listSessions())[0]?.name,
+        'second title',
+        'a changed transcript must not keep its cached summary',
+      );
+
+      await rm(join(home, 'projects', CWD.replace(/\//gu, '-'), `${id}.jsonl`));
+      assert.deepEqual(await adapter.listSessions(), []);
+    });
+  });
+
   test('a project query tolerates a trailing separator', async () => {
     // The adapter compared raw strings, so the same project reached with a
     // trailing slash answered "no such project". Both sources now share one

--- a/packages/storage/src/__tests__/claude-code-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/claude-code-session-adapter.test.ts
@@ -256,6 +256,61 @@ describe('ClaudeCodeSessionAdapter', () => {
     });
   });
 
+  test('a text query filters the source, before paging', async () => {
+    // The catalog pages 16 at a time over a source with 1128 sessions here, so
+    // the term has to reach the adapter. A filter applied to an assembled page
+    // would search the rows already fetched, which is worse than none.
+    await withClaudeHome(async (home) => {
+      await seed(
+        home,
+        'aaaaaaaa-0000-4000-8000-000000000030',
+        [userRecord('fix the parser'), assistantRecord({ text: 'ok', stopReason: 'end_turn' })],
+        '/Users/someone/compiler',
+      );
+      await seed(
+        home,
+        'aaaaaaaa-0000-4000-8000-000000000031',
+        [userRecord('write the docs'), assistantRecord({ text: 'ok', stopReason: 'end_turn' })],
+        '/Users/someone/handbook',
+      );
+      const adapter = new ClaudeCodeSessionAdapter({ claudeHome: home });
+
+      const byTitle = await adapter.listSessions({ text: 'parser' });
+      assert.deepEqual(
+        byTitle.map((s) => s.id),
+        ['aaaaaaaa-0000-4000-8000-000000000030'],
+      );
+
+      // The path is the other half of what a user remembers.
+      const byPath = await adapter.listSessions({ text: 'handbook' });
+      assert.deepEqual(
+        byPath.map((s) => s.id),
+        ['aaaaaaaa-0000-4000-8000-000000000031'],
+      );
+
+      assert.equal((await adapter.listSessions({ text: 'kubernetes' })).length, 0);
+      // A blank box is not a filter.
+      assert.equal((await adapter.listSessions({ text: '  ' })).length, 2);
+      assert.equal((await adapter.listSessions()).length, 2);
+    });
+  });
+
+  test('a project query tolerates a trailing separator', async () => {
+    // The adapter compared raw strings, so the same project reached with a
+    // trailing slash answered "no such project". Both sources now share one
+    // path rule.
+    await withClaudeHome(async (home) => {
+      await seed(
+        home,
+        'aaaaaaaa-0000-4000-8000-000000000032',
+        [userRecord('one'), assistantRecord({ text: 'ok', stopReason: 'end_turn' })],
+        '/Users/someone/my-project',
+      );
+      const adapter = new ClaudeCodeSessionAdapter({ claudeHome: home });
+      assert.equal((await adapter.listSessions({ cwd: '/Users/someone/my-project/' })).length, 1);
+    });
+  });
+
   test('a project query matches the record cwd, not the mangled directory name', async () => {
     // `-Users-a-b` cannot be reversed — it is ambiguous between `/Users/a/b`
     // and `/Users/a-b` — so only a record's own `cwd` can answer this.

--- a/packages/storage/src/__tests__/codex-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/codex-session-adapter.test.ts
@@ -70,6 +70,29 @@ describe('CodexSessionAdapter', () => {
         (await adapter.listSessions({ includeArchived: true })).map((session) => session.id),
         ['codex-session-1', 'codex-session-archived'],
       );
+
+      // The same text query the Claude Code adapter honours. A catalog filter
+      // that silently worked for one source and not the other would be worse
+      // than none — the user cannot see which source dropped their term.
+      assert.deepEqual(
+        (await adapter.listSessions({ text: 'named' })).map((session) => session.id),
+        ['codex-session-1'],
+      );
+      assert.deepEqual(
+        (await adapter.listSessions({ text: '/workspace/project' })).map((session) => session.id),
+        ['codex-session-1'],
+      );
+      assert.equal((await adapter.listSessions({ text: 'kubernetes' })).length, 0);
+      // A blank box selects nothing, so it must not filter.
+      assert.equal((await adapter.listSessions({ text: '  ' })).length, 1);
+      // Text does not override the archived gate.
+      assert.equal((await adapter.listSessions({ text: 'archived' })).length, 0);
+      assert.deepEqual(
+        (await adapter.listSessions({ includeArchived: true, text: 'archived' })).map(
+          (session) => session.id,
+        ),
+        ['codex-session-archived'],
+      );
       assert.deepEqual(
         await adapter.listSessions({ includeArchived: true, cwd: '/workspace/archive/' }),
         [

--- a/packages/storage/src/__tests__/codex-session-adapter.test.ts
+++ b/packages/storage/src/__tests__/codex-session-adapter.test.ts
@@ -109,6 +109,45 @@ describe('CodexSessionAdapter', () => {
     });
   });
 
+  test('a Windows path spelling reaches the matcher instead of being lost in SQL', async () => {
+    // The SQL used to prefilter with `cwd IN (<spelling variants>)`, and
+    // SQLite compares those exactly — a row stored `C:\\Repo\\App` was
+    // discarded before the shared matcher could see that `c:/repo/app` names
+    // the same project. This drives the real state-database path, not the
+    // matcher in isolation, because that is where the row was being dropped.
+    await withCodexHome(async (codexHome) => {
+      const rolloutPath = await seedMinimalRollout(
+        codexHome,
+        'codex-win',
+        false,
+        'C:\\Repo\\App',
+        'hello',
+      );
+      await seedStateDatabase(codexHome, [
+        {
+          id: 'codex-win',
+          rolloutPath,
+          cwd: 'C:\\Repo\\App',
+          name: 'Windows-shaped path',
+          createdAtMs: 1_000,
+          updatedAtMs: 2_000,
+          archived: false,
+          source: 'cli',
+        },
+      ]);
+      const adapter = new CodexSessionAdapter({ codexHome });
+      for (const cwd of ['C:\\Repo\\App', 'C:/Repo/App', 'c:/repo/app', 'c:\\repo\\app\\']) {
+        assert.deepEqual(
+          (await adapter.listSessions({ cwd })).map((session) => session.id),
+          ['codex-win'],
+          `cwd=${cwd}`,
+        );
+      }
+      // A genuinely different project is still excluded.
+      assert.equal((await adapter.listSessions({ cwd: 'C:/Repo/Other' })).length, 0);
+    });
+  });
+
   test('converts Codex presentation events and raw tool items without duplicates', async () => {
     await withCodexHome(async (codexHome) => {
       await seedFixtureRollout(codexHome, 'codex-session-1', false);

--- a/packages/storage/src/claude-code-session-adapter.ts
+++ b/packages/storage/src/claude-code-session-adapter.ts
@@ -65,6 +65,23 @@ export class ClaudeCodeSessionAdapter implements ExternalSessionAdapter {
   readonly id = CLAUDE_CODE_SESSION_ADAPTER_ID;
   readonly #home: string;
   readonly #maxBytes: number;
+  /**
+   * Summaries already derived from a transcript, keyed by path and invalidated
+   * by the file's own mtime and size.
+   *
+   * Listing reads and parses every transcript: 1128 of them take about a
+   * second here, and the catalog is listed once per search term. Without this,
+   * a pause in typing starts another full parse of files that have not changed
+   * since the last one — the cost is paid again for an answer already known.
+   *
+   * Keyed on what the filesystem reports rather than a timer: a transcript
+   * that Claude Code appended to must be re-read, and one that did not change
+   * cannot have a different summary.
+   */
+  readonly #summaries = new Map<
+    string,
+    { mtimeMs: number; size: number; summary?: ExternalSessionSummary }
+  >();
 
   constructor(options: ClaudeCodeSessionAdapterOptions = {}) {
     this.#home = options.claudeHome ?? join(homedir(), '.claude');
@@ -77,28 +94,62 @@ export class ClaudeCodeSessionAdapter implements ExternalSessionAdapter {
 
   async listSessions(query?: ExternalSessionQuery): Promise<readonly ExternalSessionSummary[]> {
     const summaries: ExternalSessionSummary[] = [];
+    const live = new Set<string>();
     for (const file of await this.#transcriptFiles()) {
-      const parsed = await this.#parse(file.path, file.sessionId);
-      if (!parsed) continue;
-      // Sub-agent transcripts are whole files, never records interleaved into
-      // a parent — so exclusion is per file. Importing one would present a
-      // fragment of a conversation as a conversation.
-      if (parsed.isSidechain) continue;
-      const summary: ExternalSessionSummary = {
-        id: file.sessionId,
-        name: parsed.title || file.sessionId,
-        cwd: parsed.cwd,
-        ...(parsed.createdAt !== undefined ? { createdAt: parsed.createdAt } : {}),
-        ...(parsed.updatedAt !== undefined ? { updatedAt: parsed.updatedAt } : {}),
-      };
+      live.add(file.path);
+      const summary = await this.#summaryOf(file.path, file.sessionId);
+      if (!summary) continue;
       // The shared matcher, not a local cwd comparison: filtering happens here
       // rather than after paging, and every source has to answer a query the
       // same way or the catalog lies about which one dropped the term.
       if (!externalSessionMatchesQuery(summary, query)) continue;
       summaries.push(summary);
     }
+    // A transcript the source no longer lists must not keep its entry alive,
+    // or a long-lived Host grows one per deleted session.
+    for (const path of this.#summaries.keys()) {
+      if (!live.has(path)) this.#summaries.delete(path);
+    }
     summaries.sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
     return summaries;
+  }
+
+  /**
+   * The summary for one transcript, parsed only when the file has changed.
+   *
+   * `undefined` is cached too: a sidechain transcript or an unreadable one is
+   * a stable answer, and re-deriving it every list would defeat the point.
+   */
+  async #summaryOf(path: string, sessionId: string): Promise<ExternalSessionSummary | undefined> {
+    let mtimeMs: number;
+    let size: number;
+    try {
+      const info = await stat(path);
+      mtimeMs = info.mtimeMs;
+      size = info.size;
+    } catch {
+      this.#summaries.delete(path);
+      return undefined;
+    }
+    const cached = this.#summaries.get(path);
+    if (cached && cached.mtimeMs === mtimeMs && cached.size === size) return cached.summary;
+
+    const parsed = await this.#parse(path, sessionId);
+    // Sub-agent transcripts are whole files, never records interleaved into a
+    // parent — so exclusion is per file. Importing one would present a
+    // fragment of a conversation as a conversation.
+    const summary =
+      parsed && !parsed.isSidechain
+        ? {
+            id: sessionId,
+            name: parsed.title || sessionId,
+            cwd: parsed.cwd,
+            ...(parsed.createdAt !== undefined ? { createdAt: parsed.createdAt } : {}),
+            ...(parsed.updatedAt !== undefined ? { updatedAt: parsed.updatedAt } : {}),
+          }
+        : undefined;
+    this.#summaries.set(path, { mtimeMs, size, ...(summary ? { summary } : {}) });
+    return summary;
   }
 
   async readSession(sessionId: string): Promise<ExternalMakaSession> {

--- a/packages/storage/src/claude-code-session-adapter.ts
+++ b/packages/storage/src/claude-code-session-adapter.ts
@@ -21,6 +21,7 @@ import {
   pickClaudeTitle,
   sanitizeForeignTitle,
 } from '@maka/core/foreign-session';
+import { externalSessionMatchesQuery } from '@maka/core/external-session';
 import type {
   ExternalMakaSession,
   ExternalSessionAdapter,
@@ -83,14 +84,18 @@ export class ClaudeCodeSessionAdapter implements ExternalSessionAdapter {
       // a parent — so exclusion is per file. Importing one would present a
       // fragment of a conversation as a conversation.
       if (parsed.isSidechain) continue;
-      if (query?.cwd !== undefined && parsed.cwd !== query.cwd) continue;
-      summaries.push({
+      const summary: ExternalSessionSummary = {
         id: file.sessionId,
         name: parsed.title || file.sessionId,
         cwd: parsed.cwd,
         ...(parsed.createdAt !== undefined ? { createdAt: parsed.createdAt } : {}),
         ...(parsed.updatedAt !== undefined ? { updatedAt: parsed.updatedAt } : {}),
-      });
+      };
+      // The shared matcher, not a local cwd comparison: filtering happens here
+      // rather than after paging, and every source has to answer a query the
+      // same way or the catalog lies about which one dropped the term.
+      if (!externalSessionMatchesQuery(summary, query)) continue;
+      summaries.push(summary);
     }
     summaries.sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
     return summaries;

--- a/packages/storage/src/codex-session-adapter.ts
+++ b/packages/storage/src/codex-session-adapter.ts
@@ -555,11 +555,17 @@ async function readCodexThreadRows(
       if (!query.includeArchived && columns.has('archived')) {
         where.push('(archived IS NULL OR archived = 0)');
       }
-      if (query.cwd !== undefined && columns.has('cwd')) {
-        const variants = cwdSqlVariants(query.cwd);
-        where.push(`cwd IN (${variants.map(() => '?').join(', ')})`);
-        params.push(...variants);
-      }
+      // No cwd clause. `cwd IN (...)` enumerated spelling variants of the
+      // query, but SQLite compares them exactly: a row stored `C:\\Repo\\App`
+      // was discarded before `matchesQuery` could see that `c:/repo/app` names
+      // the same project. A prefilter that cannot express the matcher's own
+      // equivalence is not an optimization, it is a second, weaker rule — so
+      // the shared matcher below is the only authority on which project a row
+      // belongs to. The archived clause stays: that one is an exact boolean
+      // and agrees with the matcher by construction.
+      //
+      // The statement has no LIMIT, so dropping the clause widens the read
+      // rather than truncating it.
       const orderColumn = columns.has('updated_at_ms')
         ? 'updated_at_ms'
         : columns.has('updated_at')
@@ -734,25 +740,10 @@ function normalizeEpochMs(value: unknown): number | undefined {
   return undefined;
 }
 
-function normalizePath(value: string): string {
-  const normalized = value.replaceAll('\\', '/').replace(/\/+$/, '');
-  return /^[A-Za-z]:\//.test(normalized) ? normalized.toLowerCase() : normalized;
-}
-
-function cwdSqlVariants(cwd: string): string[] {
-  const normalized = normalizePath(cwd);
-  const variants = new Set([cwd, normalized]);
-  if (/^[A-Za-z]:\//.test(normalized)) variants.add(normalized.replaceAll('/', '\\'));
-  if (normalized !== '/') {
-    variants.add(`${normalized}/`);
-    if (/^[A-Za-z]:\//.test(normalized)) variants.add(`${normalized.replaceAll('/', '\\')}\\`);
-  }
-  return [...variants];
-}
-
 function matchesQuery(entry: ExternalSessionSummary, query: ExternalSessionQuery): boolean {
-  // Delegated so both sources answer a query identically; the local
-  // `normalizePath` below is still used for the SQL cwd variants.
+  // The single authority on whether a row answers a query, shared with every
+  // other adapter. The local path helpers this file used to keep were only
+  // reachable from the SQL prefilter that has been removed.
   return externalSessionMatchesQuery(entry, query);
 }
 

--- a/packages/storage/src/codex-session-adapter.ts
+++ b/packages/storage/src/codex-session-adapter.ts
@@ -4,6 +4,7 @@ import { homedir } from 'node:os';
 import { basename, join, resolve, sep } from 'node:path';
 import type { StoredMessage } from '@maka/core/session';
 import { sanitizeForeignTitle } from '@maka/core/foreign-session';
+import { externalSessionMatchesQuery } from '@maka/core/external-session';
 import type {
   ExternalMakaSession,
   ExternalSessionAdapter,
@@ -750,8 +751,9 @@ function cwdSqlVariants(cwd: string): string[] {
 }
 
 function matchesQuery(entry: ExternalSessionSummary, query: ExternalSessionQuery): boolean {
-  if (!query.includeArchived && entry.archived) return false;
-  return query.cwd === undefined || normalizePath(entry.cwd) === normalizePath(query.cwd);
+  // Delegated so both sources answer a query identically; the local
+  // `normalizePath` below is still used for the SQL cwd variants.
+  return externalSessionMatchesQuery(entry, query);
 }
 
 function compareCatalogEntries(a: CodexCatalogEntry, b: CodexCatalogEntry): number {


### PR DESCRIPTION
## Summary

设置 → 导入任务 pages 16 sessions at a time with one filter, `includeArchived`. That was proportionate to what Codex produces here — 19 sessions. Claude Code brought **1128**, which is 71 pages of cursor paging with no way to say which one you want.

`ExternalSessionQuery` gains `text`, matched against the summary's title and cwd. Both already sit on `ExternalSessionSummary`, so neither adapter reads more than it did.

**The term reaches the adapter, before paging.** The coordinator slices a page out of whatever `listSessions` returns, so a filter applied after that would search the 16 rows already fetched. That is worse than offering no search at all, because it looks like it worked.

**One matcher, not one per adapter.** `externalSessionMatchesQuery` lives in `@maka/core` and both adapters call it. The catalog is one surface over several sources; a filter that quietly worked for Codex and not for Claude Code would be undebuggable from the UI, which cannot say which source dropped the term. A third adapter inherits the behaviour rather than reimplementing it.

Fixes #3438

## Review focus

**This consolidation fixes an inconsistency I introduced in #3435.** Codex compared cwd through `normalizePath`; the Claude Code adapter compared raw strings. The same project reached with a trailing separator answered "no such project" on one source and not the other. Both now share one path rule, and there is a test for it.

**A blank box is not a filter.** `''` and `'   '` both normalize to "no term", so a stray space cannot hide every session. An over-long term is truncated to its 200-character prefix rather than throwing at the user; the protocol bounds it at the frame because it reaches every adapter.

**Search is a dimension of the catalog selection**, not a view filter. It joins `catalogSelectionRef` and the `ImportAttempt` record beside `includeArchived`: import recovery re-reads the window a row came from, and a cleared box would look at a different list.

**Debounced at 250ms.** The term walks every transcript on the source, so a request per keystroke would queue a thousand-file scan behind each character.

**A search that finds nothing gets its own empty state.** Reusing "no conversations" would tell a user their transcripts are missing when the term is simply wrong, and hide the one control that would fix it.

## Breaking change

Protocol epoch **36 → 37**. `ExternalSessionCatalogQueryInput` gains an optional `text`. `scripts/protocol-epoch-check.mjs --base origin/main` confirms: `Protocol changed and the epoch moved: 36 -> 37.`

## Verification

**Tests — 26 new, across every layer the term crosses:**

| layer | what is pinned |
| --- | --- |
| `@maka/core` (12) | title/path match, blank-is-not-a-filter, truncation, archived gate, cwd+text both apply, path normalization |
| Claude Code adapter (2) | filters the source not the page; trailing separator tolerated |
| Codex adapter | the same term, same results — the "silently works for one source" case |
| protocol (4) | a term is carried; a non-string, empty, or over-long one is refused at the frame |
| storybook `play` | typing `worktree` narrows three rows to one |

The storybook stub honours `text` on purpose. A stub that ignored it would render a search box that looks wired and is not, and the story would certify that. **Disconnecting the term from the request fails that story** — checked by removing it.

**Checks run locally:**

- `@maka/core`: **593/593** · `@maka/storage`: **895/895** · `@maka/runtime-host`: **1066/1066** · `@maka/desktop`: **1092/1092**
- typecheck (preload + main + renderer + storybook): clean
- `npm run format:check`: 1571 files, clean
- `biome lint .`: 2510 files, clean
- `build-storybook` + `smoke:storybook`: **162 stories**, AX audit included

**Not run:** the packaged-artifact and release checks; `@maka/runtime`'s suite has 5 unrelated environmental failures here (`spawn rg ENOENT` — no ripgrep binary).

## Not in scope

Searching message content. Titles and paths are metadata the adapters already hold; content means reading every transcript on every keystroke, which is a different problem with a different budget.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Opus 5 (Claude Code) — wrote the implementation, tests, and story; ran the checks above. Reviewed and directed by me. `Generated-by` trailer is on the commit.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
