### PR TITLE
fix(cli): give rewind selections visible feedback and preserve mid-switch input

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -3928,9 +3928,62 @@ describe('Maka Pi TUI runner', () => {
     // The notice wraps across screen lines at 80 columns, so match against a
     // whitespace-collapsed copy instead of the raw output.
     const collapsedOutput = () => plainTerminalOutput(terminal.output()).replace(/\s+/g, '');
-    await waitFor(() => collapsedOutput().includes('未回填该轮prompt'));
+    await waitFor(() => collapsedOutput().includes('未覆盖'));
     await waitFor(() => editorInputText(terminal) === 'my draft');
     assert.equal(plainTerminalOutput(terminal.output()).includes('refilled: turn-1'), false);
+    // The ↑ recovery promise must hold even though nothing was submitted in
+    // this TUI process (a resumed session has no live-path history entry):
+    // the rewound prompt is recorded explicitly on completion (#3475 review).
+    // The first ↑ only jumps to line start while the cursor sits at col > 0;
+    // the second one then enters history recall.
+    terminal.input('\x1b[A');
+    terminal.input('\x1b[A');
+    await waitFor(() => editorInputText(terminal) === 'refilled: turn-1');
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('lets a bracketed paste still being buffered win over the prompt refill', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredRewindDriver([{ turnId: 'turn-1', label: 'first question' }]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/rewind');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('first question'));
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('正在回退到该轮之前'));
+
+    // A bracketed paste starts while the branch switch is in flight and its end
+    // marker has not arrived: getText() still reports empty, but the buffered
+    // bytes are newer user input and must win over the refill (#3475 review).
+    terminal.input('\x1b[200~pasted half');
+
+    driver.gate.resolve();
+    // The completion notice wraps across screen lines at 80 columns, so match a
+    // whitespace-collapsed copy.
+    await waitFor(() =>
+      plainTerminalOutput(terminal.output()).replace(/\s+/g, '').includes('未覆盖'),
+    );
+
+    // Only now does the paste complete — after the refill decision was made.
+    terminal.input(' rest\x1b[201~');
+    await waitFor(() => editorInputText(terminal)?.includes('pasted half rest') ?? false);
+    assert.equal(editorInputText(terminal)?.includes('refilled'), false);
 
     exitMaka(terminal);
     await Promise.race([

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -3851,6 +3851,135 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('shows an in-progress notice while the rewind branch is being created', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredRewindDriver(
+      [{ turnId: 'turn-1', label: 'first question' }],
+      [
+        storedUserMessage('user-0', 'turn-0', 'earlier question'),
+        storedAssistantMessage('assistant-0', 'turn-0', 'earlier answer'),
+      ],
+    );
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/rewind');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('first question'));
+
+    terminal.input('\r');
+    // The branch switch is still in flight, but the selection must already be
+    // visibly accepted — control-busy otherwise renders nothing (#3383).
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('正在回退到该轮之前'));
+    assert.deepEqual(driver.rewound, []);
+
+    driver.gate.resolve();
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('已回退到该轮之前'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('refilled: turn-1'));
+    // The in-progress notice is wiped together with the transcript it announced.
+    await waitFor(
+      () => plainTerminalOutput(terminal.screenOutput()).includes('正在回退到该轮之前') === false,
+    );
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('keeps a draft typed while the rewind is in flight instead of overwriting it', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredRewindDriver([{ turnId: 'turn-1', label: 'first question' }]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/rewind');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('first question'));
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('正在回退到该轮之前'));
+
+    // Typed while the branch switch is in flight: this is newer user work and
+    // must win over the prompt refill (#3383). Enter stays swallowed by
+    // disableSubmit, so the draft never becomes a turn.
+    terminal.input('my draft');
+    await waitFor(() => editorInputText(terminal) === 'my draft');
+    terminal.input('\r');
+    assert.deepEqual(driver.prompts, []);
+
+    driver.gate.resolve();
+    // The notice wraps across screen lines at 80 columns, so match against a
+    // whitespace-collapsed copy instead of the raw output.
+    const collapsedOutput = () => plainTerminalOutput(terminal.output()).replace(/\s+/g, '');
+    await waitFor(() => collapsedOutput().includes('未回填该轮prompt'));
+    await waitFor(() => editorInputText(terminal) === 'my draft');
+    assert.equal(plainTerminalOutput(terminal.output()).includes('refilled: turn-1'), false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('refuses a rewind selection with a notice when another action claimed busy', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new BusyAfterPickerOpenDriver([{ turnId: 'turn-1', label: 'first question' }]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/rewind');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('first question'));
+
+    // A Host-started turn claims busy while the picker is open (the same way a
+    // Goal auto-continuation would). Selecting a target must then surface a
+    // refusal instead of runControl's silent early return (#3383).
+    driver.startBlockingTurn();
+    await waitFor(() => terminal.progressStates.at(-1) === true);
+
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('无法回退'));
+    assert.deepEqual(driver.rewound, []);
+
+    driver.turnGate.resolve();
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('marks an inherited running Bash card detached after rewind', async () => {
     const terminal = new FakeTerminal();
     const ref = 'maka://runtime/background-tasks/bg-1';
@@ -7317,6 +7446,55 @@ class RewindDriver extends SlashCommandDriver {
       ...switchResult(this.branchSummary, [...this.branchMessages]),
       prompt: `refilled: ${turnId}`,
     };
+  }
+}
+
+class DeferredRewindDriver extends RewindDriver {
+  readonly gate = deferred<void>();
+
+  override async rewindToTurn(turnId: string): Promise<MakaSessionRewindResult> {
+    await this.gate.promise;
+    return super.rewindToTurn(turnId);
+  }
+}
+
+/**
+ * Holds `busy` from underneath an open picker: publishSuccessor-style, a
+ * Host-started turn begins (and blocks on `turnGate`) while the rewind picker
+ * is already open, so a selection lands on runControl's busy early return.
+ */
+class BusyAfterPickerOpenDriver extends RewindDriver {
+  readonly turnGate = deferred<void>();
+  #startedTurnListener: ((turn: MakaAttachedSessionTurn) => void) | undefined;
+
+  subscribeStartedTurns(listener: (turn: MakaAttachedSessionTurn) => void): () => void {
+    this.#startedTurnListener = listener;
+    return () => {
+      if (this.#startedTurnListener === listener) this.#startedTurnListener = undefined;
+    };
+  }
+
+  startBlockingTurn(): void {
+    const gate = this.turnGate;
+    this.#startedTurnListener?.({
+      sessionId: this.getSessionId()!,
+      turnId: 'turn-host',
+      messages: [
+        storedUserMessage('user-host', 'turn-host', 'host question'),
+        storedAssistantMessage('assistant-host', 'turn-host', 'host answer'),
+      ],
+      summary: fakeSessionSummary(this.getSessionId()!),
+      events: (async function* () {
+        await gate.promise;
+        yield {
+          type: 'complete',
+          id: 'complete-host',
+          turnId: 'turn-host',
+          ts: 3,
+          stopReason: 'end_turn',
+        } satisfies SessionEvent;
+      })(),
+    });
   }
 }
 

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -1504,18 +1504,41 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // non-destructive and inherits the branch's resume guarantees.
   const rewindToTurn = async (turnId: string) => {
     resolvedInteractionIds.clear();
-    const result = await input.driver.rewindToTurn(turnId);
-    await applySwitchResult(result);
-    // Refill the editor with the discarded turn's prompt so the user can edit
-    // and resend it. The picker only arms when the editor is neutral (empty
-    // draft, no autocomplete), so overwriting the text loses no in-progress work.
-    editor.setText(result.prompt);
-    state.entries.push({
+    // Synchronous feedback before the first await: branching + switching takes
+    // several serialized runtime-host round trips, and control-busy renders
+    // nothing in the TUI body, so without this notice the picker's Enter looks
+    // dead until the branch lands (#3383). replaceTranscript wipes it on
+    // success; the catch removes it on failure so only the error stays.
+    const pendingNotice: (typeof state.entries)[number] = {
       kind: 'notice',
       level: 'info',
-      text: '已回退到该轮之前（分支为新任务，原任务保留），该轮 prompt 已回填输入框，可修改后重新发送。',
-    });
+      text: '正在回退到该轮之前…',
+    };
+    state.entries.push(pendingNotice);
     requestRender();
+    try {
+      const result = await input.driver.rewindToTurn(turnId);
+      await applySwitchResult(result);
+      // Refill the editor with the discarded turn's prompt so the user can edit
+      // and resend it — unless the user typed into the editor while the switch
+      // was in flight. The picker's neutral-editor guarantee only holds at open
+      // time, so a non-empty draft here is newer user work and wins; the prompt
+      // stays recoverable from the editor history (submitPrompt added it).
+      const refill = editor.getText().trim().length === 0;
+      if (refill) editor.setText(result.prompt);
+      state.entries.push({
+        kind: 'notice',
+        level: 'info',
+        text: refill
+          ? '已回退到该轮之前（分支为新任务，原任务保留），该轮 prompt 已回填输入框，可修改后重新发送。'
+          : '已回退到该轮之前（分支为新任务，原任务保留）。输入框已有未发送内容，未回填该轮 prompt（可按 ↑ 从输入历史找回）。',
+      });
+      requestRender();
+    } catch (error) {
+      const index = state.entries.indexOf(pendingNotice);
+      if (index >= 0) state.entries.splice(index, 1);
+      throw error;
+    }
   };
 
   const showBottomPicker = (picker: Component): OverlayHandle =>
@@ -2088,6 +2111,19 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       'Rewind',
       items,
       (item) => {
+        // runControl drops the action silently when busy is already held (e.g.
+        // a Goal auto-continuation started while the picker was open). The
+        // overlay is already closed at this point, so say so instead of
+        // leaving a dead Enter — same contract as /goal's busy guard.
+        if (busy) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: '无法回退：当前有正在进行的操作 — 请等待其完成，或中断（Esc）后重试。',
+          });
+          requestRender();
+          return;
+        }
         void runControl(() => rewindToTurn(item.value));
       },
       {

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -331,6 +331,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let lastTurnEscapeAt = 0;
   let lastIdleEscapeAt = 0;
   let lastIdleCtrlCAt = 0;
+  // Mirrors the editor's bracketed-paste buffering at the input seam: between a
+  // paste start marker and its end marker the editor holds incoming bytes in an
+  // internal buffer and getText() stays empty, so "editor is empty" must not
+  // treat that in-flight paste as absent user input (#3475 review). The marker
+  // matching deliberately mirrors the editor's own per-chunk includes() checks,
+  // so this flag agrees with what the editor will buffer.
+  let editorPastePending = false;
   type AttachedTurnContext =
     | { readonly kind: 'adopted'; readonly turn: MakaPreparedSessionTurn }
     | { readonly kind: 'external'; readonly turn: MakaAttachedSessionTurn };
@@ -1519,19 +1526,26 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     try {
       const result = await input.driver.rewindToTurn(turnId);
       await applySwitchResult(result);
-      // Refill the editor with the discarded turn's prompt so the user can edit
-      // and resend it — unless the user typed into the editor while the switch
-      // was in flight. The picker's neutral-editor guarantee only holds at open
-      // time, so a non-empty draft here is newer user work and wins; the prompt
-      // stays recoverable from the editor history (submitPrompt added it).
-      const refill = editor.getText().trim().length === 0;
+      // Record the discarded turn's prompt in the editor history before
+      // deciding on the refill: prompts submitted in this TUI process are
+      // already there (addToHistory dedupes consecutive duplicates), but a
+      // session entered via startup resume or /resume has no entry yet, and
+      // the notice below promises ↑ recovery (#3475 review).
+      editor.addToHistory(result.prompt);
+      // Refill the editor with that prompt so the user can edit and resend it
+      // — unless newer user input arrived while the switch was in flight. The
+      // picker's neutral-editor guarantee only holds at open time, so this
+      // covers both a typed draft and a bracketed paste still being buffered
+      // (getText() stays empty until its end marker); either wins over the
+      // refill.
+      const refill = editor.getText().trim().length === 0 && !editorPastePending;
       if (refill) editor.setText(result.prompt);
       state.entries.push({
         kind: 'notice',
         level: 'info',
         text: refill
           ? '已回退到该轮之前（分支为新任务，原任务保留），该轮 prompt 已回填输入框，可修改后重新发送。'
-          : '已回退到该轮之前（分支为新任务，原任务保留）。输入框已有未发送内容，未回填该轮 prompt（可按 ↑ 从输入历史找回）。',
+          : '已回退到该轮之前（分支为新任务，原任务保留）。输入框已有未发送内容，未覆盖；该轮 prompt 已存入输入历史，可按 ↑ 找回。',
       });
       requestRender();
     } catch (error) {
@@ -3010,6 +3024,18 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   refreshEditorCwd(cwd);
 
   tui.addInputListener((data) => {
+    // Track bracketed pastes before any consuming branch: this must observe
+    // every chunk the editor could buffer, regardless of what the rest of the
+    // listener decides (#3475 review).
+    if (data.includes('\x1b[200~')) {
+      // A paste begins; it is only complete when the end marker follows, here
+      // or in a later chunk.
+      editorPastePending = !data.slice(data.indexOf('\x1b[200~') + 6).includes('\x1b[201~');
+    } else if (editorPastePending && data.includes('\x1b[201~')) {
+      // The paste ends; bytes after the end marker may start another paste.
+      const remainder = data.slice(data.indexOf('\x1b[201~') + 6);
+      editorPastePending = remainder.includes('\x1b[200~');
+    }
     // Once closing has begun, swallow any buffered input that reaches the
     // listener while the terminal is being torn down.
     if (closed) return { consume: true };


### PR DESCRIPTION
Closes #3383.

## Problem

Selecting a turn in the Esc-Esc Rewind picker closed the overlay and then stayed silent for the whole branch-and-switch chain (~6–8 serialized runtime-host round trips), while control-busy renders nothing in the TUI body. In that window Enter was silently swallowed (`disableSubmit`), typed text / ↑ history recall accumulated in the editor — and were then clobbered by `editor.setText(result.prompt)` when the rewind landed. If busy was claimed while the picker was open (e.g. a Goal auto-continuation starting a turn), `runControl`'s early return dropped the rewind with no notice at all. Net effect: "nothing happened", or it happened a beat later with my input gone (#3383).

## Changes (`packages/cli/src/pi-tui-runner.ts`)

1. **In-progress feedback on selection.** `rewindToTurn` pushes a `正在回退到该轮之前…` notice synchronously before its first await, so the Enter keypress is visibly accepted immediately. On success the transcript replacement wipes it; on failure the catch splices it out so only the error notice remains.
2. **Draft wins over refill.** The refill now checks the editor at completion time: a non-empty draft (typed during the window) is newer user work and is kept; the rewound prompt stays recoverable from editor history (`submitPrompt` added it). The completion notice says which variant happened.
3. **Audible busy refusal.** The picker's `onSelect` refuses with an error notice when `busy` is already held — same contract as `/goal`'s guard at the former `runControl` silent early return.

## Tests (`packages/cli/src/__tests__/pi-tui-runner.test.ts`)

- `shows an in-progress notice while the rewind branch is being created` — deferred driver gate proves the notice renders while the switch is still in flight, and disappears once the branch lands;
- `keeps a draft typed while the rewind is in flight instead of overwriting it` — draft survives completion, Enter stays swallowed (`driver.prompts` stays empty), no refill happens;
- `refuses a rewind selection with a notice when another action claimed busy` — a Host-started turn claims busy under the open picker (the Goal-continuation shape); selection surfaces the refusal and `rewound` stays empty.

## Verification

- `packages/cli`: full suite green — **340/340 pass** (includes all 8 rewind tests);
- `tsc -p packages/cli` clean; `biome check` clean on both touched files.

## Out of scope (noted in the issue)

- Reusing the messages `listRewindTargets` already loaded to avoid the re-fetch inside `rewindToTurn` (perf-only follow-up).
- Rendering control-busy in the activity strip generally; this PR fixes the rewind path's feedback specifically.

## AI use

- [x] Generative tooling made a substantive contribution
- [ ] No generative tool made a substantive contribution

Tool(s) and scope: Maka (AI coding agent) authored the implementation and tests; the diff was human-reviewed before push. `Generated-by: Maka` trailers are present on the branch commits.
