### PR TITLE
fix(desktop): reload usage stats when the persisted range arrives

### DIFF
--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -575,8 +575,18 @@ export function SettingsSurface(props: {
   }, [connectionsBridge, selectedRuntimeHost]);
 
   useEffect(() => {
-    if (section === 'usage') void reloadUsage();
-  }, [section]);
+    // Keyed on the EFFECTIVE range, not just the section: usage is
+    // client-owned (settings-ownership.ts), and the persisted range rides
+    // in with the async getClient() load — which lands after this effect
+    // first fires when a Settings window is restored directly onto
+    // 使用统计. The initial fetch then used the '24h' default while the
+    // chip showed the persisted range, and nothing refetched — every
+    // metric read 0 until a manual refresh or a tab round-trip. With the
+    // range in the deps, the truth's arrival (or any later range change,
+    // including the page's own persisted range clicks) is the trigger, and
+    // this effect is the single owner of range-driven fetches.
+    if (section === 'usage') void reloadUsage(settings.usage.range);
+  }, [section, settings.usage.range]);
 
   // PR-SETTINGS-HEADER-COPY-MAP-0 (U1): the page header derives its title
   // and description from the section→copy map keyed by the active section,

--- a/apps/desktop/src/renderer/settings/usage-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/usage-settings-page.tsx
@@ -89,9 +89,10 @@ export function UsageSettingsPage(props: {
   };
 
   async function setRange(range: UsageRange) {
-    const saved = await updateUsage({ range });
-    if (!saved || !usagePageMountedRef.current) return;
-    await props.onReload(range);
+    // Persist only: the surface refetches when the persisted range lands
+    // (the same trigger that reloads a Settings window restored directly
+    // onto this page), so a second fetch here would just race it.
+    await updateUsage({ range });
   }
 
   function updateUsage(patch: Partial<AppSettings['usage']>): Promise<boolean> {

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -8,6 +8,7 @@ import type {
   ThemePalette,
   ThemePreference,
   UpdateAppSettingsResult,
+  UsageRange,
   UsageStats,
 } from '@maka/core/settings';
 import type {
@@ -1292,6 +1293,51 @@ export const UsageLongTail: Story = {
 export const UsageNarrow: Story = {
   ...UsageLongTail,
   parameters: { viewport: { defaultViewport: 'mobile2' } },
+};
+
+/** The persisted range lands with the async CLIENT settings load — usage
+ * is client-owned (settings-ownership.ts), so getClient() is the channel
+ * that carries it — after the section effect's first fetch already ran
+ * with the '24h' default. A Settings window restored directly onto
+ * 使用统计 must refetch when the persisted range arrives — without that,
+ * the page shows the default range's (empty) numbers under the persisted
+ * range's selected chip until a manual refresh. The bridge makes the race
+ * explicit: stats exist only for the persisted 'all' range, and the
+ * client settings resolve a beat late. */
+const withUsagePersistedRangeBridge = (() => {
+  const clientSettings = mergeSettings(createDefaultSettings(), { usage: { range: 'all' } });
+  return withScopedMakaBridge({
+    ...makaBridge,
+    settings: {
+      ...makaBridge.settings,
+      getClient: async () => {
+        await new Promise((resolve) => globalThis.setTimeout(resolve, 30));
+        return clientSettings;
+      },
+      updateClient: async (
+        patch: Parameters<typeof window.maka.settings.updateClient>[0],
+      ): Promise<UpdateAppSettingsResult> => ({
+        settings: mergeSettings(clientSettings, patch),
+      }),
+      usageStats: async (range?: UsageRange): Promise<UsageStats> =>
+        range === 'all' ? usageStats : emptyUsageStats,
+    },
+  } satisfies Record<string, unknown>);
+})();
+
+// Real path: 设置 remembers 使用统计 as the last-open page and restores
+// straight onto it, with 全部 as the persisted range.
+export const UsagePersistedRangeRestore: Story = {
+  decorators: [withUsagePersistedRangeBridge],
+  render: () => <SettingsStory section="usage" />,
+  play: async ({ canvasElement }) => {
+    // The totals must come from the PERSISTED range's dataset, not the
+    // '24h' default the section effect first fired with.
+    await waitForStoryCondition(
+      () => (canvasElement.textContent ?? '').includes('420'),
+      'Usage totals for the persisted range did not render',
+    );
+  },
 };
 /**
  * #1364: entry list (long title / content / tag set), archived group, and


### PR DESCRIPTION
## Symptom

Settings remembers the last-open page. When a Settings window is restored **directly onto 使用统计**, every metric reads **0** under a correct-looking range chip (typically 全部) — until a manual refresh, or navigating away and back:

![usage page restored with all metrics at zero](https://raw.githubusercontent.com/GabrielDrapor/maka-agent/pr-assets/usage-restore-zeros-before.png)

## Root cause

The section-change effect fetched usage stats exactly once:

```ts
useEffect(() => {
  if (section === 'usage') void reloadUsage();
}, [section]);
```

`reloadUsage()` defaults its range to `settings.usage.range` — but when the window restores straight onto this page, the Runtime Host settings are still loading, so `settings` is `createDefaultSettings()` and the fetch runs with the **`'24h'` default**. The persisted range then lands and moves the selected chip (e.g. to 全部), but nothing refetches: the page shows the default range's (often empty) dataset under the persisted range's chip. A manual refresh uses the live draft range and a tab round-trip re-fires the effect after settings are ready — which is why both "fix" it.

## Fix

- The section effect is keyed on the **effective range** and passes it explicitly — the persisted range's arrival (or any later range change) triggers the reload, and the effect is the single owner of range-driven fetches.
- The page's range chips now only persist; the surface refetches when the persisted value lands, instead of racing a second fetch against it.

## Regression

New story `UsagePersistedRangeRestore`: the bridge resolves `settings.get()` a beat late and serves stats **only** for the persisted `'all'` range; the story renders `SettingsStory section="usage"` (the restore path) and the play function asserts the totals come from the persisted range's dataset. Under the previous code the play times out — the mount-time `'24h'` fetch was the only one.

Verified: renderer + storybook tsconfigs compile; Desktop suite 1092 green; biome clean.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01TMwYxgNEbz2RFmuK6AXGcj