### PR TITLE
fix(desktop): keep module refreshes latest-wins

### DIFF
--- a/apps/desktop/src/main/__tests__/use-module-data.test.ts
+++ b/apps/desktop/src/main/__tests__/use-module-data.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, test } from 'node:test';
+import { act, createElement } from 'react';
+import { build } from 'esbuild';
+import type * as ModuleData from '../../renderer/use-module-data.js';
+import { cleanupFakeDom, installReactRenderer } from './fake-dom.js';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+test('keeps the newest same-Host module projection refresh', async () => {
+  const moduleData = await importModuleData();
+  const { root } = installReactRenderer();
+  const host = { profileId: 'profile-a', hostId: 'host-a' };
+  type Projection = 'skills' | 'managedSkillSources' | 'bundledSkillCatalog' | 'scheduledTasks';
+  let activeRead: {
+    projection: Projection;
+    calls: number;
+    started: ReturnType<typeof deferred<void>>;
+    pending: ReturnType<typeof deferred<Array<{ id: string }>>>;
+  } | undefined;
+  const read = async (projection: Projection, operationHost: unknown) => {
+    assert.deepEqual(operationHost, host);
+    assert.equal(activeRead?.projection, projection);
+    if (!activeRead) throw new Error('No projection read is active');
+    activeRead.calls += 1;
+    if (activeRead.calls === 1) {
+      activeRead.started.resolve();
+      return activeRead.pending.promise;
+    }
+    return [{ id: `${projection}-new` }];
+  };
+  (globalThis.window as unknown as { maka: unknown }).maka = {
+    runtimeHostProfiles: {
+      getDefaultHost: async () => host,
+    },
+    skills: {
+      list: (operationHost: unknown) => read('skills', operationHost),
+      sources: {
+        list: (operationHost: unknown) => read('managedSkillSources', operationHost),
+      },
+      catalog: {
+        list: (operationHost: unknown) => read('bundledSkillCatalog', operationHost),
+      },
+    },
+    scheduledTasks: {
+      list: (operationHost: unknown) => read('scheduledTasks', operationHost),
+    },
+  };
+  let current: ReturnType<typeof moduleData.useAppShellModuleData> | undefined;
+  let renderRevision = 0;
+
+  function Probe(_props: { revision: number }) {
+    current = moduleData.useAppShellModuleData({
+      uiLocale: 'en',
+      isSkillsSurfaceActive: () => true,
+      isScheduledTasksSurfaceActive: () => true,
+      toastApi: {
+        success: () => {},
+        error: () => {},
+        confirm: async () => true,
+      },
+    });
+    return null;
+  }
+
+  await act(async () => {
+    root.render(createElement(Probe, { revision: 0 }));
+  });
+
+  const projections: Array<{
+    projection: Projection;
+    refresh(value: NonNullable<typeof current>): Promise<void>;
+    values(value: NonNullable<typeof current>): readonly { id: string }[];
+  }> = [
+    {
+      projection: 'skills',
+      refresh: (value) => value.refreshSkills(),
+      values: (value) => value.skills,
+    },
+    {
+      projection: 'managedSkillSources',
+      refresh: (value) => value.refreshManagedSkillSources(),
+      values: (value) => value.managedSkillSources,
+    },
+    {
+      projection: 'bundledSkillCatalog',
+      refresh: (value) => value.refreshBundledSkillCatalog(),
+      values: (value) => value.bundledSkillCatalog,
+    },
+    {
+      projection: 'scheduledTasks',
+      refresh: (value) => value.refreshScheduledTasks(),
+      values: (value) => value.scheduledTasks,
+    },
+  ];
+
+  for (const { projection, refresh, values } of projections) {
+    const started = deferred<void>();
+    const pending = deferred<Array<{ id: string }>>();
+    activeRead = { projection, calls: 0, started, pending };
+    const staleRefresh = refresh(current!);
+    await started.promise;
+
+    await act(async () => {
+      root.render(createElement(Probe, { revision: ++renderRevision }));
+    });
+    await act(async () => {
+      await refresh(current!);
+    });
+    assert.deepEqual(values(current!).map(({ id }) => id), [`${projection}-new`]);
+
+    await act(async () => {
+      pending.resolve([{ id: `${projection}-old` }]);
+      await staleRefresh;
+    });
+    assert.deepEqual(values(current!).map(({ id }) => id), [`${projection}-new`]);
+    assert.equal(activeRead.calls, 2);
+  }
+});
+
+afterEach(() => {
+  cleanupFakeDom();
+});
+
+async function importModuleData(): Promise<typeof ModuleData> {
+  const outdir = await mkdtemp(resolve(REPO_ROOT, 'apps/desktop/dist/main/__tests__/module-data-'));
+  const outfile = resolve(outdir, 'use-module-data.mjs');
+  await mkdir(dirname(outfile), { recursive: true });
+  await build({
+    entryPoints: [resolve(REPO_ROOT, 'apps/desktop/src/renderer/use-module-data.ts')],
+    outfile,
+    bundle: true,
+    platform: 'node',
+    format: 'esm',
+    target: 'node20',
+    external: ['react'],
+    logLevel: 'silent',
+  });
+  return (await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`)) as typeof ModuleData;
+}

--- a/apps/desktop/src/renderer/app-shell-scheduled-task-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-scheduled-task-actions.ts
@@ -28,6 +28,7 @@ type ToastApi = {
 };
 
 type ScheduledTaskCreateInput = Omit<CreateScheduledTaskInput, "createdBy">;
+type RefBox<T> = { current: T };
 
 export interface AppShellScheduledTaskActions {
   refreshScheduledTasks(options?: {
@@ -46,6 +47,7 @@ export function createAppShellScheduledTaskActions(deps: {
   uiLocale: UiLocale;
   getScheduledTasks: () => readonly ScheduledTask[];
   isScheduledTasksSurfaceActive: () => boolean;
+  refreshGenerationsRef: RefBox<{ scheduledTasks: number }>;
   setScheduledTasks: Dispatch<SetStateAction<ScheduledTask[]>>;
   toastApi: ToastApi;
 }): AppShellScheduledTaskActions {
@@ -53,6 +55,7 @@ export function createAppShellScheduledTaskActions(deps: {
     uiLocale,
     getScheduledTasks,
     isScheduledTasksSurfaceActive,
+    refreshGenerationsRef,
     setScheduledTasks,
     toastApi,
   } = deps;
@@ -61,11 +64,16 @@ export function createAppShellScheduledTaskActions(deps: {
   async function refreshScheduledTasks(
     options: { shouldShowError?: () => boolean } = {},
   ) {
+    const generation = ++refreshGenerationsRef.current.scheduledTasks;
     try {
       const next = await runOnDefaultRuntimeHost((host) =>
         window.maka.scheduledTasks.list(host),
       );
-      await runIfDefaultRuntimeHostCurrent(next.host, () => setScheduledTasks(next.value));
+      await runIfDefaultRuntimeHostCurrent(next.host, () => {
+        if (generation === refreshGenerationsRef.current.scheduledTasks) {
+          setScheduledTasks(next.value);
+        }
+      });
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         toastApi.error(

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -25,6 +25,8 @@ type ToastApi = {
   ): void;
 };
 
+type RefBox<T> = { current: T };
+
 export interface AppShellSkillActions {
   refreshSkills(options?: { shouldShowError?: () => boolean }): Promise<void>;
   refreshManagedSkillSources(options?: { shouldShowError?: () => boolean }): Promise<void>;
@@ -50,6 +52,11 @@ export interface AppShellSkillActions {
 export function createAppShellSkillActions(deps: {
   uiLocale: UiLocale;
   isSkillsSurfaceActive: () => boolean;
+  refreshGenerationsRef: RefBox<{
+    skills: number;
+    managedSkillSources: number;
+    bundledSkillCatalog: number;
+  }>;
   setSkills: Dispatch<SetStateAction<SkillEntry[]>>;
   setManagedSkillSources: Dispatch<SetStateAction<ManagedSkillSourceEntry[]>>;
   setBundledSkillCatalog: Dispatch<SetStateAction<BundledSkillCatalogEntry[]>>;
@@ -58,6 +65,7 @@ export function createAppShellSkillActions(deps: {
   const {
     uiLocale,
     isSkillsSurfaceActive,
+    refreshGenerationsRef,
     setBundledSkillCatalog,
     setManagedSkillSources,
     setSkills,
@@ -83,9 +91,12 @@ export function createAppShellSkillActions(deps: {
   });
 
   async function refreshSkills(options: { shouldShowError?: () => boolean } = {}) {
+    const generation = ++refreshGenerationsRef.current.skills;
     try {
       const next = await runOnDefaultRuntimeHost((host) => window.maka.skills.list(host));
-      await runIfDefaultRuntimeHostCurrent(next.host, () => setSkills(next.value));
+      await runIfDefaultRuntimeHostCurrent(next.host, () => {
+        if (generation === refreshGenerationsRef.current.skills) setSkills(next.value);
+      });
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshSkillsFailedTitle, copy.refreshSkillsFallback, error);
@@ -94,9 +105,14 @@ export function createAppShellSkillActions(deps: {
   }
 
   async function refreshManagedSkillSources(options: { shouldShowError?: () => boolean } = {}) {
+    const generation = ++refreshGenerationsRef.current.managedSkillSources;
     try {
       const next = await runOnDefaultRuntimeHost((host) => window.maka.skills.sources.list(host));
-      await runIfDefaultRuntimeHostCurrent(next.host, () => setManagedSkillSources(next.value));
+      await runIfDefaultRuntimeHostCurrent(next.host, () => {
+        if (generation === refreshGenerationsRef.current.managedSkillSources) {
+          setManagedSkillSources(next.value);
+        }
+      });
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshSourcesFailedTitle, copy.refreshSourcesFallback, error);
@@ -105,9 +121,14 @@ export function createAppShellSkillActions(deps: {
   }
 
   async function refreshBundledSkillCatalog(options: { shouldShowError?: () => boolean } = {}) {
+    const generation = ++refreshGenerationsRef.current.bundledSkillCatalog;
     try {
       const next = await runOnDefaultRuntimeHost((host) => window.maka.skills.catalog.list(host));
-      await runIfDefaultRuntimeHostCurrent(next.host, () => setBundledSkillCatalog(next.value));
+      await runIfDefaultRuntimeHostCurrent(next.host, () => {
+        if (generation === refreshGenerationsRef.current.bundledSkillCatalog) {
+          setBundledSkillCatalog(next.value);
+        }
+      });
     } catch (error) {
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshBundledFailedTitle, copy.refreshBundledFallback, error);

--- a/apps/desktop/src/renderer/use-module-data.ts
+++ b/apps/desktop/src/renderer/use-module-data.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import type { ScheduledTask } from '@maka/core/scheduled-task';
 import type { UiLocale } from '@maka/core/ui-locale';
 import type { BundledSkillCatalogEntry, ManagedSkillSourceEntry, SkillEntry } from '@maka/ui';
@@ -56,11 +56,18 @@ export function useAppShellModuleData(options: {
   const [managedSkillSources, setManagedSkillSources] = useState<ManagedSkillSourceEntry[]>([]);
   const [bundledSkillCatalog, setBundledSkillCatalog] = useState<BundledSkillCatalogEntry[]>([]);
   const [scheduledTasks, setScheduledTasks] = useState<ScheduledTask[]>([]);
+  const refreshGenerationsRef = useRef({
+    skills: 0,
+    managedSkillSources: 0,
+    bundledSkillCatalog: 0,
+    scheduledTasks: 0,
+  });
 
   const scheduledTaskActions = createAppShellScheduledTaskActions({
     uiLocale,
     getScheduledTasks: () => scheduledTasks,
     isScheduledTasksSurfaceActive,
+    refreshGenerationsRef,
     setScheduledTasks,
     toastApi,
   });
@@ -68,6 +75,7 @@ export function useAppShellModuleData(options: {
   const skillActions = createAppShellSkillActions({
     uiLocale,
     isSkillsSurfaceActive,
+    refreshGenerationsRef,
     setSkills,
     setManagedSkillSources,
     setBundledSkillCatalog,


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

- Keep only the latest-started same-Host refresh authoritative for Skills, managed skill sources, bundled skill catalog, and scheduled tasks.
- Store four independent refresh generations with the module-data hook so ordering survives renderer re-renders.
- Preserve the existing default-Host identity guard and all mutation, error, and diagnostic behavior.

Fixes #3477

## Review focus

Now that #3465 has merged, this PR is based directly on `main`. The generation state owns request ordering only; it does not cancel requests or become another Host authority.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 1099 passed
- Focused same-Host ordering coverage exercises all four projections and forces a renderer re-render between the stale and current refreshes.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with implementation, tests, verification, scope review, and pull request drafting; the human contributor remains responsible for the change.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

- 对 Skills、managed skill source、bundled skill catalog 和 scheduled task，仅允许同一 Host 上最后启动的刷新提交展示状态。
- 四个 projection 的 refresh generation 由 module-data hook 独立持有，因此 Renderer re-render 不会重置排序 authority。
- 保留现有默认 Host identity guard，不改变 mutation、错误反馈或诊断行为。

修复 #3477。

## 审查重点

#3465 已合并，因此本 PR 现在直接基于 `main`。Generation 只负责请求排序，不取消请求，也不成为新的 Host authority。

## 验证

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 1099 项通过
- 同一 Host 排序覆盖四个 projection，并在旧刷新与当前刷新之间强制 Renderer re-render。

## AI 使用

OpenAI Codex 协助了实现、测试、验证、范围复核和 PR 文案；贡献者本人仍对本次变更负责。AI 使用选项已在英文部分勾选。

## 检查清单

- 测试覆盖本次变更，并会在缺少实现时失败。
- lint、format、typecheck 和受影响测试均已在本地通过。
- 本 PR 包含行为变化，已在概要中说明。

</details>