### PR TITLE
fix(cli): declare the transcript viewer's mid-turn disposition

### DIFF
--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -2876,6 +2876,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     transcript: {
       description: primaryGuidance.commands.transcript,
+      // The viewer is a full-screen overlay over the same TUI the turn paints
+      // into, so it is exactly the picker case 'refuse' exists for.
+      midTurn: 'refuse',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({


### PR DESCRIPTION
## Summary

`main` does not typecheck. `MakaSlashCommand.midTurn` became required so every handler has to state whether it is safe to run while a turn is in flight; `/transcript` (#2999) landed in parallel and never got an answer:

```
packages/cli/src/pi-tui-runner.ts(2877,5): error TS2741: Property 'midTurn' is missing in type
'{ description: string; run: (parts: string[]) => void; }' but required in type
'Omit<MakaSlashCommand, "aliases" | "name">'.
```

Neither PR was wrong on its own — the conflict is semantic, so both merged green and `main` broke. The viewer is a full-screen overlay over the same TUI the running turn paints into, which is the picker case `'refuse'` exists for, so that is its declared answer.

Refs #2999

## Verification

- `npm run build` — passes with this change, fails on `main` without it
- `npm run format:check` — clean
- `npm test --workspace maka-agent` — 371 pass, 0 fail

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code diagnosed the cross-PR type break and wrote the one-line declaration and its comment. The human contributor reviewed the diff and the disposition choice.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

The compiler is the test: `main` fails to build without this change.

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

`/transcript` is now refused mid-turn instead of opening over a running turn.