### PR TITLE
fix(cli): declare the transcript command's mid-turn disposition

### DIFF
--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -2876,6 +2876,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     transcript: {
       description: primaryGuidance.commands.transcript,
+      // Read-only overlay over the in-memory transcript: showTranscriptViewer
+      // only calls tui.showOverlay and never enters runControl, so it stays
+      // usable mid-turn — which is exactly when looking back is most useful.
+      midTurn: 'local',
       run: (parts: string[]) => {
         if (parts.length !== 1) {
           state.entries.push({


### PR DESCRIPTION
## Summary

`main` is red: the `test` job fails at Build.

```
src/pi-tui-runner.ts(2877,5): error TS2741:
  Property 'midTurn' is missing in type '{ description; run }'
  but required in type 'Omit<MakaSlashCommand, "aliases"|"name">'
src/pi-tui-runner.ts(3015,9): error TS2322: ... not assignable to type 'MakaSlashCommand[]'
```

#2999 added `/transcript`; the change making `midTurn` required on `MakaSlashCommand` landed separately. Each was green on its own branch — the break exists only where they meet, and the intermediate `main` runs were each cancelled by the next push, so no complete run reported it until now.

`'local'` rather than the more obvious `'refuse'`: `'refuse'` is documented as the safe default for anything that mutates session state or opens a picker the turn would race, and `/transcript` does neither. `showTranscriptViewer` (`pi-tui-runner.ts:2184`) only calls `tui.showOverlay` with a read-only viewer over the in-memory transcript, never entering `runControl` — which is precisely what `'local'` requires. It also matters for behaviour: mid-turn is when reading back the transcript is most useful, and the viewer was built to be open while a turn runs, so `'refuse'` would compile while removing the command's main value.

Refs #2999

## Verification

- `npm run build --workspace @maka/core`, then `tsc -p packages/cli --noEmit` — clean.
- `npm run build --workspace @maka/ui`, then `tsc -p apps/desktop --noEmit` — 0 errors.

The desktop check is worth stating: a report suggested `ToastDiagnosticTarget` was a second break in `main`. It isn't. That type is a discriminated union in which `{ sessionId }` alone is a valid member; desktop only appeared broken because the CLI build failed before reaching it.

No test accompanies this change — see Review focus.

## Review focus

The disposition value is the whole change, so it's worth a second opinion on `'local'` vs `'refuse'` rather than just on whether it compiles.

No test is added. `midTurn` is a required field enforced by the compiler, so the type system already fails without the fix and a test asserting the literal would restate the declaration rather than pin behaviour. If you'd prefer coverage that `/transcript` stays usable mid-turn, that's a behavioural test worth having on its own terms — say so and I'll add it here.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Opus 5 (Claude Code) — diagnosed the failure, chose the disposition value, and wrote the change and this description. Reviewed by a human before submission. The commit carries a `Generated-by` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
