### PR TITLE
fix(desktop): suppress superseded refresh errors

### DIFF
--- a/apps/desktop/src/main/__tests__/use-module-data.test.ts
+++ b/apps/desktop/src/main/__tests__/use-module-data.test.ts
@@ -12,13 +12,15 @@ const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((settle) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((settle, fail) => {
     resolve = settle;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
-test('keeps the newest same-Host module projection refresh', async () => {
+test('keeps stale same-Host module refreshes from changing state or reporting errors', async () => {
   const moduleData = await importModuleData();
   const { root } = installReactRenderer();
   const host = { profileId: 'profile-a', hostId: 'host-a' };
@@ -59,6 +61,7 @@ test('keeps the newest same-Host module projection refresh', async () => {
   };
   let current: ReturnType<typeof moduleData.useAppShellModuleData> | undefined;
   let renderRevision = 0;
+  const errors: string[] = [];
 
   function Probe(_props: { revision: number }) {
     current = moduleData.useAppShellModuleData({
@@ -67,7 +70,7 @@ test('keeps the newest same-Host module projection refresh', async () => {
       isScheduledTasksSurfaceActive: () => true,
       toastApi: {
         success: () => {},
-        error: () => {},
+        error: (title) => errors.push(title),
         confirm: async () => true,
       },
     });
@@ -125,6 +128,26 @@ test('keeps the newest same-Host module projection refresh', async () => {
       await staleRefresh;
     });
     assert.deepEqual(values(current!).map(({ id }) => id), [`${projection}-new`]);
+    assert.equal(activeRead.calls, 2);
+
+    const errorStarted = deferred<void>();
+    const pendingError = deferred<Array<{ id: string }>>();
+    activeRead = {
+      projection,
+      calls: 0,
+      started: errorStarted,
+      pending: pendingError,
+    };
+    const staleErrorRefresh = refresh(current!);
+    await errorStarted.promise;
+    await act(async () => {
+      await refresh(current!);
+    });
+    await act(async () => {
+      pendingError.reject(new Error(`${projection} stale failure`));
+      await staleErrorRefresh;
+    });
+    assert.deepEqual(errors, []);
     assert.equal(activeRead.calls, 2);
   }
 });

--- a/apps/desktop/src/renderer/app-shell-scheduled-task-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-scheduled-task-actions.ts
@@ -75,6 +75,7 @@ export function createAppShellScheduledTaskActions(deps: {
         }
       });
     } catch (error) {
+      if (generation !== refreshGenerationsRef.current.scheduledTasks) return;
       if (options.shouldShowError?.() ?? true) {
         toastApi.error(
           copy.refreshFailed,

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -98,6 +98,7 @@ export function createAppShellSkillActions(deps: {
         if (generation === refreshGenerationsRef.current.skills) setSkills(next.value);
       });
     } catch (error) {
+      if (generation !== refreshGenerationsRef.current.skills) return;
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshSkillsFailedTitle, copy.refreshSkillsFallback, error);
       }
@@ -114,6 +115,7 @@ export function createAppShellSkillActions(deps: {
         }
       });
     } catch (error) {
+      if (generation !== refreshGenerationsRef.current.managedSkillSources) return;
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshSourcesFailedTitle, copy.refreshSourcesFallback, error);
       }
@@ -130,6 +132,7 @@ export function createAppShellSkillActions(deps: {
         }
       });
     } catch (error) {
+      if (generation !== refreshGenerationsRef.current.bundledSkillCatalog) return;
       if (options.shouldShowError?.() ?? true) {
         reportRuntimeHostError(copy.refreshBundledFailedTitle, copy.refreshBundledFallback, error);
       }


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

Suppress error toasts from module refreshes that a newer request has already superseded. This applies the existing latest-started ordering rule to Skills, managed skill sources, the bundled skill catalog, and scheduled tasks; failures from the current refresh remain visible.

Follow-up to #3478 and https://github.com/apache/maka/pull/3478#discussion_r3835859471.

## Verification

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` (1148 passed)

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with implementation, tests, verification, and PR drafting. Human review is required before merge, and the human contributor remains responsible for the merged result.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary><strong>中文</strong></summary>

## 摘要

不再显示已被较新请求取代的模块刷新错误提示。该变更将现有的“最后发起的请求优先”规则同时应用到 Skills、托管 Skill 来源、内置 Skill 目录和定时任务的错误反馈；当前刷新请求的真实错误仍会正常显示。

这是 #3478 及 https://github.com/apache/maka/pull/3478#discussion_r3835859471 的后续修复。

## 验证

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test`（1148 项通过）

## AI 使用

- [ ] 没有生成式工具作出实质性贡献
- [x] 生成式工具作出了实质性贡献

工具及范围：OpenAI Codex 协助了实现、测试、验证和 PR 文案起草。合并前仍需人工审核，人工贡献者对最终合并结果负责。

## 检查清单

- [x] 测试覆盖该变更，并会在缺少修复时失败
- [x] lint、格式检查、类型检查及受影响测试均已在本地通过

该 PR 是否包含行为变更？

- [x] 是——已在摘要中说明
- [ ] 否

</details>
