### PR TITLE
fix(cli): show model display names in picker

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2912,6 +2912,7 @@ describe('Maka Pi TUI runner', () => {
       { query: 'alpha', keep: 'GPT 5.5 Preview', drop: ['GLM Max', 'text-unicorn'] },
       { query: 'zai', keep: 'GLM Max', drop: ['GPT 5.5 Preview', 'text-unicorn'] },
       { query: 'gemini', keep: 'text-unicorn', drop: ['GPT 5.5 Preview', 'GLM Max'] },
+      { query: 'glm-max', keep: 'GLM Max', drop: ['GPT 5.5 Preview', 'text-unicorn'] },
     ];
     for (const c of cases) {
       terminal.input(c.query);

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2786,7 +2786,7 @@ describe('Maka Pi TUI runner', () => {
           connectionName: 'OpenAI',
           providerType: 'openai',
           model: 'gpt-5.5',
-          displayName: 'GPT Standard',
+          displayName: 'GPT 5.5 Preview',
           isDefaultConnection: true,
         },
         {
@@ -2859,7 +2859,7 @@ describe('Maka Pi TUI runner', () => {
           connectionName: 'Aurora',
           providerType: 'openai',
           model: 'gpt-5.5',
-          displayName: 'GPT Standard',
+          displayName: 'GPT 5.5 Preview',
           isDefaultConnection: true,
         },
         {
@@ -2889,7 +2889,7 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => {
       const out = plainTerminalOutput(terminal.screenOutput());
       return (
-        out.includes('GPT Standard') && out.includes('GLM Max') && out.includes('text-unicorn')
+        out.includes('GPT 5.5 Preview') && out.includes('GLM Max') && out.includes('text-unicorn')
       );
     });
     assert.doesNotMatch(
@@ -2907,11 +2907,11 @@ describe('Maka Pi TUI runner', () => {
     // clears the search field in one event so the next criterion starts from
     // the full list again.
     const cases = [
-      { query: 'standard', keep: 'GPT Standard', drop: ['GLM Max', 'text-unicorn'] },
-      { query: 'aurora', keep: 'GPT Standard', drop: ['GLM Max', 'text-unicorn'] },
-      { query: 'alpha', keep: 'GPT Standard', drop: ['GLM Max', 'text-unicorn'] },
-      { query: 'zai', keep: 'GLM Max', drop: ['GPT Standard', 'text-unicorn'] },
-      { query: 'gemini', keep: 'text-unicorn', drop: ['GPT Standard', 'GLM Max'] },
+      { query: 'preview', keep: 'GPT 5.5 Preview', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'aurora', keep: 'GPT 5.5 Preview', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'alpha', keep: 'GPT 5.5 Preview', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'zai', keep: 'GLM Max', drop: ['GPT 5.5 Preview', 'text-unicorn'] },
+      { query: 'gemini', keep: 'text-unicorn', drop: ['GPT 5.5 Preview', 'GLM Max'] },
     ];
     for (const c of cases) {
       terminal.input(c.query);
@@ -2923,7 +2923,7 @@ describe('Maka Pi TUI runner', () => {
       await waitFor(() => {
         const out = plainTerminalOutput(terminal.screenOutput());
         return (
-          out.includes('GPT Standard') && out.includes('GLM Max') && out.includes('text-unicorn')
+          out.includes('GPT 5.5 Preview') && out.includes('GLM Max') && out.includes('text-unicorn')
         );
       });
     }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2786,7 +2786,7 @@ describe('Maka Pi TUI runner', () => {
           connectionName: 'OpenAI',
           providerType: 'openai',
           model: 'gpt-5.5',
-          displayName: 'GPT 5.5',
+          displayName: 'GPT Standard',
           isDefaultConnection: true,
         },
         {
@@ -2859,7 +2859,7 @@ describe('Maka Pi TUI runner', () => {
           connectionName: 'Aurora',
           providerType: 'openai',
           model: 'gpt-5.5',
-          displayName: 'GPT 5.5',
+          displayName: 'GPT Standard',
           isDefaultConnection: true,
         },
         {
@@ -2888,7 +2888,9 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => terminal.output().includes('Select Model'));
     await waitFor(() => {
       const out = plainTerminalOutput(terminal.screenOutput());
-      return out.includes('GPT 5.5') && out.includes('GLM Max') && out.includes('text-unicorn');
+      return (
+        out.includes('GPT Standard') && out.includes('GLM Max') && out.includes('text-unicorn')
+      );
     });
     assert.doesNotMatch(
       plainTerminalOutput(terminal.screenOutput()),
@@ -2905,11 +2907,11 @@ describe('Maka Pi TUI runner', () => {
     // clears the search field in one event so the next criterion starts from
     // the full list again.
     const cases = [
-      { query: 'gpt', keep: 'GPT 5.5', drop: ['GLM Max', 'text-unicorn'] },
-      { query: 'aurora', keep: 'GPT 5.5', drop: ['GLM Max', 'text-unicorn'] },
-      { query: 'alpha', keep: 'GPT 5.5', drop: ['GLM Max', 'text-unicorn'] },
-      { query: 'zai', keep: 'GLM Max', drop: ['GPT 5.5', 'text-unicorn'] },
-      { query: 'gemini', keep: 'text-unicorn', drop: ['GPT 5.5', 'GLM Max'] },
+      { query: 'standard', keep: 'GPT Standard', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'aurora', keep: 'GPT Standard', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'alpha', keep: 'GPT Standard', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'zai', keep: 'GLM Max', drop: ['GPT Standard', 'text-unicorn'] },
+      { query: 'gemini', keep: 'text-unicorn', drop: ['GPT Standard', 'GLM Max'] },
     ];
     for (const c of cases) {
       terminal.input(c.query);
@@ -2920,7 +2922,9 @@ describe('Maka Pi TUI runner', () => {
       terminal.input('\x15');
       await waitFor(() => {
         const out = plainTerminalOutput(terminal.screenOutput());
-        return out.includes('GPT 5.5') && out.includes('GLM Max') && out.includes('text-unicorn');
+        return (
+          out.includes('GPT Standard') && out.includes('GLM Max') && out.includes('text-unicorn')
+        );
       });
     }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2786,6 +2786,7 @@ describe('Maka Pi TUI runner', () => {
           connectionName: 'OpenAI',
           providerType: 'openai',
           model: 'gpt-5.5',
+          displayName: 'GPT 5.5',
           isDefaultConnection: true,
         },
         {
@@ -2793,6 +2794,7 @@ describe('Maka Pi TUI runner', () => {
           connectionName: 'Z.ai',
           providerType: 'openai',
           model: 'glm-5.2',
+          displayName: 'GLM 5.2',
           isDefaultConnection: false,
         },
       ],
@@ -2807,7 +2809,7 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('\r');
 
     await waitFor(() => terminal.output().includes('Select Model'));
-    await waitFor(() => terminal.output().includes('glm-5.2'));
+    await waitFor(() => terminal.output().includes('GLM 5.2'));
     assert.match(
       plainTerminalOutput(terminal.screenOutput()),
       /切换模型可能需要重建提示缓存；下一次请求可能更慢或成本更高/,
@@ -2857,6 +2859,7 @@ describe('Maka Pi TUI runner', () => {
           connectionName: 'Aurora',
           providerType: 'openai',
           model: 'gpt-5.5',
+          displayName: 'GPT 5.5',
           isDefaultConnection: true,
         },
         {
@@ -2864,6 +2867,7 @@ describe('Maka Pi TUI runner', () => {
           connectionName: 'Boreal',
           providerType: 'zai',
           model: 'glm-max',
+          displayName: 'GLM Max',
           isDefaultConnection: false,
         },
         {
@@ -2884,7 +2888,7 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => terminal.output().includes('Select Model'));
     await waitFor(() => {
       const out = plainTerminalOutput(terminal.screenOutput());
-      return out.includes('gpt-5.5') && out.includes('glm-max') && out.includes('text-unicorn');
+      return out.includes('GPT 5.5') && out.includes('GLM Max') && out.includes('text-unicorn');
     });
     assert.doesNotMatch(
       plainTerminalOutput(terminal.screenOutput()),
@@ -2901,11 +2905,11 @@ describe('Maka Pi TUI runner', () => {
     // clears the search field in one event so the next criterion starts from
     // the full list again.
     const cases = [
-      { query: 'gpt', keep: 'gpt-5.5', drop: ['glm-max', 'text-unicorn'] },
-      { query: 'aurora', keep: 'gpt-5.5', drop: ['glm-max', 'text-unicorn'] },
-      { query: 'alpha', keep: 'gpt-5.5', drop: ['glm-max', 'text-unicorn'] },
-      { query: 'zai', keep: 'glm-max', drop: ['gpt-5.5', 'text-unicorn'] },
-      { query: 'gemini', keep: 'text-unicorn', drop: ['gpt-5.5', 'glm-max'] },
+      { query: 'gpt', keep: 'GPT 5.5', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'aurora', keep: 'GPT 5.5', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'alpha', keep: 'GPT 5.5', drop: ['GLM Max', 'text-unicorn'] },
+      { query: 'zai', keep: 'GLM Max', drop: ['GPT 5.5', 'text-unicorn'] },
+      { query: 'gemini', keep: 'text-unicorn', drop: ['GPT 5.5', 'GLM Max'] },
     ];
     for (const c of cases) {
       terminal.input(c.query);
@@ -2916,7 +2920,7 @@ describe('Maka Pi TUI runner', () => {
       terminal.input('\x15');
       await waitFor(() => {
         const out = plainTerminalOutput(terminal.screenOutput());
-        return out.includes('gpt-5.5') && out.includes('glm-max') && out.includes('text-unicorn');
+        return out.includes('GPT 5.5') && out.includes('GLM Max') && out.includes('text-unicorn');
       });
     }
 

--- a/packages/cli/src/__tests__/runtime-host-onboarding.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-onboarding.test.ts
@@ -15,7 +15,7 @@ const live = {
   providerType: 'openai',
   enabled: true,
   enabledModelIds: ['gpt-5-mini'],
-  models: [{ id: 'gpt-5-mini' }],
+  models: [{ id: 'gpt-5-mini', displayName: 'GPT-5 Mini' }],
 } as const;
 
 describe('projectRuntimeHostModelChoices', () => {
@@ -51,5 +51,11 @@ describe('projectRuntimeHostModelChoices', () => {
       choices.map(({ connectionSlug }) => connectionSlug),
       ['openai'],
     );
+  });
+
+  test('projects the catalog display name onto each model choice', () => {
+    const choices = projectRuntimeHostModelChoices(catalog([live]));
+
+    assert.equal(choices[0]?.displayName, 'GPT-5 Mini');
   });
 });

--- a/packages/cli/src/pi-tui-contracts.ts
+++ b/packages/cli/src/pi-tui-contracts.ts
@@ -8,6 +8,8 @@ export interface ModelChoice {
   connectionName: string;
   providerType: ProviderType;
   model: string;
+  /** Human-readable model name from the provider catalog, when available. */
+  displayName?: string;
   isDefaultConnection: boolean;
   /** Maximum context tokens for this model, resolved from the connection or provider catalog. */
   contextWindow?: number;

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -579,18 +579,22 @@ function modelChoicePickerItems(
     const tags = [choice.connectionName || choice.connectionSlug];
     if (isCurrent) tags.push('current');
     else if (choice.isDefaultConnection) tags.push('default');
-    return { value: String(index), label: choice.model, description: tags.join(' · ') };
+    return {
+      value: String(index),
+      label: choice.displayName?.trim() || choice.model,
+      description: tags.join(' · '),
+    };
   });
 }
 
 /**
  * Case-insensitive substring match for the `/model` search field, against every
  * criterion the issue names: model id, provider label/type, and connection
- * name/slug. `ModelChoice` carries no display name, so the model id is the only
- * model-side match target; a display-name enrichment would slot in here.
+ * name/slug. Model ids and display names are both model-side match targets.
  */
 function matchesModelChoice(choice: ModelChoice, query: string): boolean {
   if (choice.model.toLowerCase().includes(query)) return true;
+  if (choice.displayName?.toLowerCase().includes(query)) return true;
   if (choice.connectionName.toLowerCase().includes(query)) return true;
   if (choice.connectionSlug.toLowerCase().includes(query)) return true;
   if (choice.providerType.toLowerCase().includes(query)) return true;

--- a/packages/cli/src/runtime-host-onboarding.ts
+++ b/packages/cli/src/runtime-host-onboarding.ts
@@ -73,6 +73,7 @@ export function projectRuntimeHostModelChoices(catalog: ConnectionCatalogSnapsho
         connectionName: connection.name,
         providerType: connection.providerType,
         model,
+        displayName: modelsById.get(model)?.displayName,
         isDefaultConnection: catalog.defaultTarget?.connectionId === connection.connectionId,
         contextWindow: modelsById.get(model)?.contextWindow,
       });


### PR DESCRIPTION
## Summary

The cross-connection TUI `/model` picker now prefers each catalog model’s human-readable `displayName`, while retaining the raw model id when no display name is available. Search matches both model ids and display names.

Fixes #3482

## Verification

- `npm --workspace maka-agent test` (372 tests passed)
- `npm --workspace maka-agent run typecheck`
- `npx biome lint packages/cli/src/pi-tui-contracts.ts packages/cli/src/runtime-host-onboarding.ts packages/cli/src/pi-tui-pickers.ts packages/cli/src/__tests__/runtime-host-onboarding.test.ts packages/cli/src/__tests__/pi-tui-runner.test.ts`
- `npx biome format packages/cli/src/pi-tui-contracts.ts packages/cli/src/runtime-host-onboarding.ts packages/cli/src/pi-tui-pickers.ts packages/cli/src/__tests__/runtime-host-onboarding.test.ts packages/cli/src/__tests__/pi-tui-runner.test.ts`

The TUI runner test covers display-name rendering, id fallback, and searching by the displayed model name.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenCode made the code and test changes, reviewed the implementation, and ran the verification commands.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No