### PR TITLE
fix(core): stop offering deprecated models in fallback lists

### DIFF
--- a/packages/core/src/__tests__/provider-catalog-contract.test.ts
+++ b/packages/core/src/__tests__/provider-catalog-contract.test.ts
@@ -145,13 +145,15 @@ describe('retired provider contract', () => {
 });
 
 // A deprecated id in `fallbackModels` is offered as a usable choice: the
-// catalog marks whatever the list contains available and default-capable, and
-// `fallbackModels[0]` is what a new connection defaults to and what the
-// connection test probes. `toolCallingModelIds` filters on tool-calling
-// capability only, so each derivation drops deprecated ids at its call site;
-// `openai` writes its list by hand. Removal is from the offer only — an id a
-// user already chose still sends, and live discovery still returns whatever
-// the endpoint serves (#3355).
+// catalog marks the list available and default-capable, and `fallbackModels[0]`
+// is the new-connection default and the connection-test probe. (For the eight
+// providers with a `CURATED_CATALOG_FALLBACK_MODELS` entry that curated list
+// replaces this one in the catalog, so theirs reaches CLI onboarding and the
+// probe candidates instead.) `toolCallingModelIds` filters on tool-calling
+// capability only, so a derivation that needs it drops deprecated ids at its
+// own call site, and `openai` writes its list by hand. Removal is from the
+// offer only — an id a user already chose still sends, and live discovery
+// still returns whatever the endpoint serves (#3355).
 // Not every catalog provider has a models.dev snapshot (custom and
 // compatible-endpoint types have none), so the lookup is widened rather than
 // keyed on the registry's own union.

--- a/packages/core/src/__tests__/provider-catalog-contract.test.ts
+++ b/packages/core/src/__tests__/provider-catalog-contract.test.ts
@@ -144,14 +144,14 @@ describe('retired provider contract', () => {
   });
 });
 
-// Discovery keeps only the fallback set, and the catalog marks whatever it
-// returns available and default-capable, so a deprecated id in `fallbackModels`
-// is offered as a usable choice. Six providers still carry such ids on main —
-// `openai` writes its list by hand, the rest build it through
-// `toolCallingModelIds`, which does not filter lifecycle. Converging all of
-// them changes which models users are offered and is tracked in #3355; this
-// list is the recorded boundary, so a provider that regresses into it fails
-// here rather than passing unnoticed.
+// A deprecated id in `fallbackModels` is offered as a usable choice: the
+// catalog marks whatever the list contains available and default-capable, and
+// `fallbackModels[0]` is what a new connection defaults to and what the
+// connection test probes. `toolCallingModelIds` filters on tool-calling
+// capability only, so each derivation drops deprecated ids at its call site;
+// `openai` writes its list by hand. Removal is from the offer only — an id a
+// user already chose still sends, and live discovery still returns whatever
+// the endpoint serves (#3355).
 // Not every catalog provider has a models.dev snapshot (custom and
 // compatible-endpoint types have none), so the lookup is widened rather than
 // keyed on the registry's own union.
@@ -163,15 +163,6 @@ const snapshotFor = (type: string) =>
     >
   )[type];
 
-const PROVIDERS_WITH_DEPRECATED_FALLBACKS = new Set([
-  'openai',
-  'xiaomi',
-  'mistral',
-  'togetherai',
-  'nvidia',
-  'deepinfra',
-]);
-
 describe('provider catalog contract — fallback lifecycle', () => {
   it('keeps deprecated snapshot models out of fallback lists', () => {
     const regressed = [];
@@ -181,25 +172,10 @@ describe('provider catalog contract — fallback lifecycle', () => {
       const deprecated = (PROVIDER_REGISTRY[type].fallbackModels ?? []).filter(
         (id) => snapshot[id]?.lifecycle === 'deprecated',
       );
-      if (deprecated.length > 0 && !PROVIDERS_WITH_DEPRECATED_FALLBACKS.has(type)) {
+      if (deprecated.length > 0) {
         regressed.push(`${type}: ${deprecated.join(', ')}`);
       }
     }
     assert.deepEqual(regressed, []);
-  });
-
-  it('holds the recorded boundary to exactly the providers that predate it', () => {
-    const offenders = CATALOG_PROVIDER_TYPES.filter((type) => {
-      const snapshot = snapshotFor(type);
-      return (
-        snapshot !== undefined &&
-        (PROVIDER_REGISTRY[type].fallbackModels ?? []).some(
-          (id) => snapshot[id]?.lifecycle === 'deprecated',
-        )
-      );
-    });
-    // Fails when a listed provider is cleaned up and the entry is left behind,
-    // so the boundary shrinks as the tracked work lands instead of going stale.
-    assert.deepEqual([...offenders].sort(), [...PROVIDERS_WITH_DEPRECATED_FALLBACKS].sort());
   });
 });

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -129,7 +129,7 @@ if (xiaomi.id !== 'xiaomi' || !xiaomi.api) {
 }
 const xiaomiModelIds = toolCallingModelIds('Xiaomi', GENERATED_MODELS_DEV_METADATA.xiaomi, [
   'mimo-v2.5',
-]);
+]).filter((id) => GENERATED_MODELS_DEV_METADATA.xiaomi[id]?.lifecycle !== 'deprecated');
 // Keep the bootstrap snapshot limited to the two documented MiMo chat models. The remote
 // /models response becomes authoritative as soon as the user saves a working plan credential.
 const xiaomiTokenPlanModelIds = ['mimo-v2.5-pro', 'mimo-v2.5'] as const;
@@ -181,14 +181,14 @@ if (nvidia.id !== 'nvidia')
 if (!nvidia.api) throw new Error('models.dev NVIDIA provider facts are missing api');
 const nvidiaModelIds = toolCallingModelIds('NVIDIA', GENERATED_MODELS_DEV_METADATA.nvidia, [
   'nvidia/nemotron-3-super-120b-a12b',
-]);
+]).filter((id) => GENERATED_MODELS_DEV_METADATA.nvidia[id]?.lifecycle !== 'deprecated');
 
 const mistral = GENERATED_MODELS_DEV_PROVIDER_FACTS.mistral;
 if (mistral.id !== 'mistral')
   throw new Error('models.dev Mistral provider facts are missing stable id mistral');
 const mistralModelIds = toolCallingModelIds('Mistral', GENERATED_MODELS_DEV_METADATA.mistral, [
   'mistral-large-latest',
-]);
+]).filter((id) => GENERATED_MODELS_DEV_METADATA.mistral[id]?.lifecycle !== 'deprecated');
 const cohere = GENERATED_MODELS_DEV_PROVIDER_FACTS.cohere;
 if (cohere.id !== 'cohere')
   throw new Error('models.dev Cohere provider facts are missing stable id cohere');
@@ -422,7 +422,7 @@ const togetherModelIds = toolCallingModelIds(
   'Together AI',
   GENERATED_MODELS_DEV_METADATA.togetherai,
   ['MiniMaxAI/MiniMax-M3'],
-);
+).filter((id) => GENERATED_MODELS_DEV_METADATA.togetherai[id]?.lifecycle !== 'deprecated');
 const deepinfra = GENERATED_MODELS_DEV_PROVIDER_FACTS.deepinfra;
 if (deepinfra.id !== 'deepinfra') {
   throw new Error('models.dev DeepInfra provider facts are missing stable id deepinfra');
@@ -431,7 +431,7 @@ const deepinfraModelIds = toolCallingModelIds(
   'DeepInfra',
   GENERATED_MODELS_DEV_METADATA.deepinfra,
   ['moonshotai/Kimi-K2.7-Code', 'moonshotai/Kimi-K2.6'],
-);
+).filter((id) => GENERATED_MODELS_DEV_METADATA.deepinfra[id]?.lifecycle !== 'deprecated');
 const groq = GENERATED_MODELS_DEV_PROVIDER_FACTS.groq;
 if (groq.id !== 'groq') {
   throw new Error('models.dev Groq provider facts are missing stable id groq');
@@ -827,7 +827,7 @@ const providerRegistry = {
     baseUrl: 'https://api.openai.com/v1',
     authKind: 'api_key',
     backendKind: 'ai-sdk',
-    fallbackModels: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo', 'gpt-5'],
+    fallbackModels: ['gpt-4o-mini', 'gpt-4o', 'gpt-5'],
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai', applyPatchProtocol: 'openai-structured' },


### PR DESCRIPTION
## Summary

`fallbackModels` is a recommendation, not an inventory: everything in it lands in the catalog as available and default-capable, and its head is what a new connection defaults to and what the connection test probes. `toolCallingModelIds` filters on tool-calling capability only, so six providers still offered 28 models their vendors have deprecated.

This applies the call-site lifecycle filter #3324 established for ZenMux to xiaomi, nvidia, mistral, togetherai and deepinfra, and drops the one deprecated id from openai's hand-written list. That empties `PROVIDERS_WITH_DEPRECATED_FALLBACKS`, so the recorded boundary goes away with it and the remaining assertion becomes the unconditional invariant — which is what its comment says it was built to do.

Removal is from the offer only. An id a user already chose still sends (`authorizeConnectionModel` never reads this list), and all six do `kind: 'protocol'` discovery, so the endpoint's own catalog returns on the first `/models` fetch. Every list head is unchanged, so no connection default or connection-test probe model moves.

Reasoning for the offer-policy question the issue poses, and the measurements behind the notes below, are in https://github.com/apache/maka/issues/3355#issuecomment-5380472230.

Fixes #3355

## Review focus

- **Two corrections to the issue body.** The 28 is right as a registry count, but only **27 are user-visible**: `CURATED_CATALOG_FALLBACK_MODELS.openai` shadows the registry list at `model-catalog.ts:239`, so `gpt-4-turbo` is in no picker today — removing it is hygiene for the non-catalog consumers (connection test, onboarding verify, CLI projection) and for the contract test, which reads the registry directly. And "discovery keeps only the fallback set" is the `kind: 'fallback'` branch; none of these six is on it, which is why the exclusion costs no reachability.
- **Two product judgments worth naming.** mistral loses its whole devstral line from the pre-credential list (all eight deprecated ids are devstral plus `open-mistral-nemo`), and xiaomi is the largest proportional cut, 6 → 3. Both come straight back from live discovery.
- **The clause now sits at 13 call sites**, so a new provider is wrong by default. Folding it into `toolCallingModelIds` would be a no-op today — of 46 snapshots, the only ones carrying a tool-capable deprecated id are the nine now filtered at their call site plus openai, google and the three xiaomi-token-plan entries, which all use hand-written lists that never reach the helper. Happy to roll that in here or leave it as a follow-up; the wrinkle is placement, since ollama-cloud's pre-filter is what makes a deprecated *recommended* id throw at module load rather than vanish.
- **Known limit, pre-existing:** the invariant sweeps `CATALOG_PROVIDER_TYPES`, which is 55 of 59 registry entries. `xai-oauth`, `github-copilot`, `claude-subscription` and `openai-codex` sit outside it; I checked and none carries a deprecated id today.

## Verification

- Red state: with the registry change reverted, `keeps deprecated snapshot models out of fallback lists` fails naming all six providers and all 28 ids (togetherai 11, mistral 8, xiaomi 3, deepinfra 3, nvidia 2, openai 1)
- `@maka/core` 588 pass; `@maka/storage` 895 pass; `@maka/runtime` 3066 pass with one environment failure (`claude-subscription-usage` cannot reach the OAuth token endpoint in my sandbox — fails identically on unmodified `main`)
- Root `lint`, `format:check` and `typecheck` all pass
- Post-fix list sizes, zero deprecated remaining in each, heads unchanged: togetherai 19, mistral 22, xiaomi 3, deepinfra 56, nvidia 59, openai 3
- No protocol files touched, so `RUNTIME_HOST_COMPATIBILITY_EPOCH` stays put. `model-pricing.generated.ts` still carries rows for the removed ids and is deliberately untouched — it is generated and keyed independently.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code (Opus 5) — implementation, tests and the supporting measurements, under my direction and review. The commit carries a Generated-by trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — a connection created after this change sees a shorter pre-discovery model list; described under Summary above
- [ ] No