### PR TITLE
fix(desktop): recover from main Renderer loss

### DIFF
--- a/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
@@ -10,6 +10,7 @@ describe('app quit coordinator', () => {
       cleanup: async () => {},
       focusOrCreateWindow: () => {},
       onCleanupError: () => {},
+      onWindowCreationError: () => {},
       resumeQuit: () => {
         resumeQuitCount += 1;
       },
@@ -50,6 +51,7 @@ describe('app quit coordinator', () => {
         focusOrCreateCount += 1;
       },
       onCleanupError: () => {},
+      onWindowCreationError: () => {},
       resumeQuit: () => {
         resumeQuitCount += 1;
       },
@@ -85,22 +87,44 @@ describe('app quit coordinator', () => {
 
   it('does not reopen the main window after quit cleanup starts', () => {
     let focusOrCreateCount = 0;
+    let windowCreationSignal: AbortSignal | undefined;
     const coordinator = createAppQuitCoordinator({
       cleanup: () => new Promise<void>(() => {}),
-      focusOrCreateWindow: () => {
+      focusOrCreateWindow: (signal) => {
         focusOrCreateCount += 1;
+        windowCreationSignal = signal;
       },
       onCleanupError: () => {},
+      onWindowCreationError: () => {},
       resumeQuit: () => {},
     });
-    const windowCreationSignal = coordinator.getWindowCreationSignal();
 
+    coordinator.focusOrCreateWindow();
     coordinator.handleBeforeQuit({ preventDefault: () => {} });
     coordinator.focusOrCreateWindow();
 
-    assert.equal(focusOrCreateCount, 0);
+    assert.equal(focusOrCreateCount, 1);
     assert.equal(windowCreationSignal?.aborted, true);
-    assert.equal(coordinator.getWindowCreationSignal(), undefined);
+  });
+
+  it('reports window creation failure without leaking an unhandled rejection', async () => {
+    const failure = new Error('window load failed');
+    const reportedErrors: unknown[] = [];
+    const coordinator = createAppQuitCoordinator({
+      cleanup: async () => {},
+      focusOrCreateWindow: async () => {
+        throw failure;
+      },
+      onCleanupError: () => {},
+      onWindowCreationError: (error) => reportedErrors.push(error),
+      resumeQuit: () => {},
+    });
+
+    coordinator.focusOrCreateWindow();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.deepEqual(reportedErrors, [failure]);
   });
 
   it('reports cleanup failure without leaking an unhandled rejection', async () => {
@@ -118,6 +142,7 @@ describe('app quit coordinator', () => {
       onCleanupError: (error: unknown) => {
         reportedErrors.push(error);
       },
+      onWindowCreationError: () => {},
       resumeQuit: () => {
         resumeQuitCount += 1;
       },
@@ -139,6 +164,5 @@ describe('app quit coordinator', () => {
     assert.equal(focusOrCreateCount, 0);
     assert.equal(resumeQuitCount, 1);
     assert.equal(secondQuitPrevented, false);
-    assert.equal(coordinator.getWindowCreationSignal(), undefined);
   });
 });

--- a/apps/desktop/src/main/__tests__/main-renderer-process-gone.test.ts
+++ b/apps/desktop/src/main/__tests__/main-renderer-process-gone.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { shouldReportMainRendererProcessGone } from '../main-renderer-process-gone.js';
+
+test('reports only an unexpected main Renderer exit while the app is running', () => {
+  for (const scenario of [
+    { aborted: false, reason: 'clean-exit' as const, expected: false },
+    { aborted: true, reason: 'killed' as const, expected: false },
+    { aborted: false, reason: 'crashed' as const, expected: true },
+  ]) {
+    const abort = new AbortController();
+    if (scenario.aborted) abort.abort();
+    assert.equal(
+      shouldReportMainRendererProcessGone(
+        { reason: scenario.reason, exitCode: scenario.reason === 'clean-exit' ? 0 : 1 },
+        abort.signal,
+      ),
+      scenario.expected,
+    );
+  }
+});

--- a/apps/desktop/src/main/__tests__/main-renderer-process-gone.test.ts
+++ b/apps/desktop/src/main/__tests__/main-renderer-process-gone.test.ts
@@ -1,21 +1,42 @@
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import { test } from 'node:test';
-import { shouldReportMainRendererProcessGone } from '../main-renderer-process-gone.js';
+import type { RenderProcessGoneDetails } from 'electron';
+import { observeMainRendererProcessGone } from '../main-renderer-process-gone.js';
 
-test('reports only an unexpected main Renderer exit while the app is running', () => {
+test('observes one unexpected main Renderer exit while the app is running', () => {
+  const source = new EventEmitter();
+  const observed: RenderProcessGoneDetails[] = [];
+  observeMainRendererProcessGone({
+    source,
+    shutdownSignal: new AbortController().signal,
+    onUnexpectedExit: (details) => observed.push(details),
+  });
+
+  source.emit('render-process-gone', {}, { reason: 'oom', exitCode: 137 });
+  source.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 11 });
+
+  assert.deepEqual(observed, [{ reason: 'oom', exitCode: 137 }]);
+});
+
+test('ignores clean exits and app shutdown', () => {
   for (const scenario of [
-    { aborted: false, reason: 'clean-exit' as const, expected: false },
-    { aborted: true, reason: 'killed' as const, expected: false },
-    { aborted: false, reason: 'crashed' as const, expected: true },
+    { aborted: false, details: { reason: 'clean-exit', exitCode: 0 } as const },
+    { aborted: true, details: { reason: 'killed', exitCode: 9 } as const },
   ]) {
+    const source = new EventEmitter();
     const abort = new AbortController();
     if (scenario.aborted) abort.abort();
-    assert.equal(
-      shouldReportMainRendererProcessGone(
-        { reason: scenario.reason, exitCode: scenario.reason === 'clean-exit' ? 0 : 1 },
-        abort.signal,
-      ),
-      scenario.expected,
-    );
+    let observed = false;
+    observeMainRendererProcessGone({
+      source,
+      shutdownSignal: abort.signal,
+      onUnexpectedExit: () => {
+        observed = true;
+      },
+    });
+
+    source.emit('render-process-gone', {}, scenario.details);
+    assert.equal(observed, false);
   }
 });

--- a/apps/desktop/src/main/__tests__/main-renderer-process-gone.test.ts
+++ b/apps/desktop/src/main/__tests__/main-renderer-process-gone.test.ts
@@ -26,7 +26,6 @@ test('ignores clean exits and app shutdown', () => {
   ]) {
     const source = new EventEmitter();
     const abort = new AbortController();
-    if (scenario.aborted) abort.abort();
     let observed = false;
     observeMainRendererProcessGone({
       source,
@@ -35,6 +34,7 @@ test('ignores clean exits and app shutdown', () => {
         observed = true;
       },
     });
+    if (scenario.aborted) abort.abort();
 
     source.emit('render-process-gone', {}, scenario.details);
     assert.equal(observed, false);

--- a/apps/desktop/src/main/__tests__/native-diagnostic-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/native-diagnostic-dialog.test.ts
@@ -1,7 +1,27 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import type { MessageBoxOptions, MessageBoxReturnValue } from 'electron';
-import { showFatalStartupError, showMessageBoxWithDiagnostics } from '../native-diagnostic-dialog.js';
+import {
+  showFatalStartupError,
+  showMainRendererProcessGoneDialog,
+  showMessageBoxWithDiagnostics,
+} from '../native-diagnostic-dialog.js';
+
+const diagnosticEnvironment = () => ({
+  appVersion: '0.1.8',
+  buildMode: 'packaged' as const,
+  buildCommit: null,
+  electronVersion: '38.0.0',
+  nodeVersion: '22.0.0',
+  chromeVersion: '140.0.0',
+  platform: 'linux' as const,
+  arch: 'x64',
+  osRelease: '6.6.0',
+  locale: 'en-US',
+  workspacePath: '/home/tester/.local/share/maka/workspaces/default',
+  homePath: '/home/tester',
+  processUptimeSeconds: 3,
+});
 
 test('copies diagnostics as an auxiliary native-dialog action', async () => {
   const shown: MessageBoxOptions[] = [];
@@ -43,21 +63,7 @@ test('fatal startup errors remain copyable without a renderer or BrowserWindow',
 
   await showFatalStartupError(new Error('Authorization: Bearer very-secret-token'), {
     locale: 'en',
-    environment: () => ({
-      appVersion: '0.1.8',
-      buildMode: 'packaged',
-      buildCommit: null,
-      electronVersion: '38.0.0',
-      nodeVersion: '22.0.0',
-      chromeVersion: '140.0.0',
-      platform: 'linux',
-      arch: 'x64',
-      osRelease: '6.6.0',
-      locale: 'en-US',
-      workspacePath: '/home/tester/.local/share/maka/workspaces/default',
-      homePath: '/home/tester',
-      processUptimeSeconds: 3,
-    }),
+    environment: diagnosticEnvironment,
     mainLogs: () => ['startup failed with Authorization: Bearer very-secret-token'],
     writeClipboard: (value) => {
       clipboard = value;
@@ -72,6 +78,37 @@ test('fatal startup errors remain copyable without a renderer or BrowserWindow',
   assert.deepEqual(shown[1]?.buttons, ['Exit', 'Copy Again']);
   assert.match(shown[1]?.detail ?? '', /Diagnostics copied/);
   assert.match(clipboard, /Surface: startup/);
+  assert.match(clipboard, /Recent main-process logs \(1\)/);
+  assert.doesNotMatch(clipboard, /very-secret-token/);
+});
+
+test('main Renderer loss keeps Copy Diagnostics auxiliary to recovery', async () => {
+  const shown: MessageBoxOptions[] = [];
+  const responses = [2, 0];
+  let clipboard = '';
+
+  const decision = await showMainRendererProcessGoneDialog(
+    { reason: 'oom', exitCode: 137 },
+    {
+      locale: 'en',
+      environment: diagnosticEnvironment,
+      mainLogs: () => ['renderer stopped with api_key=very-secret-token'],
+      writeClipboard: (value) => {
+        clipboard = value;
+      },
+      showMessageBox: async (options): Promise<MessageBoxReturnValue> => {
+        shown.push(options);
+        return { response: responses.shift() ?? 1, checkboxChecked: false };
+      },
+    },
+  );
+
+  assert.equal(decision, 'relaunch');
+  assert.deepEqual(shown[0]?.buttons, ['Relaunch', 'Exit', 'Copy Diagnostics']);
+  assert.deepEqual(shown[1]?.buttons, ['Relaunch', 'Exit', 'Copy Again']);
+  assert.match(clipboard, /Surface: renderer_process_gone/);
+  assert.match(clipboard, /Reason: oom/);
+  assert.match(clipboard, /Exit code: 137/);
   assert.match(clipboard, /Recent main-process logs \(1\)/);
   assert.doesNotMatch(clipboard, /very-secret-token/);
 });

--- a/apps/desktop/src/main/__tests__/native-diagnostic-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/native-diagnostic-dialog.test.ts
@@ -2,6 +2,10 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import type { MessageBoxOptions, MessageBoxReturnValue } from 'electron';
 import {
+  copyDesktopDiagnosticReport,
+  createDesktopMainRendererDiagnosticInput,
+} from '../main-process-diagnostics.js';
+import {
   showFatalStartupError,
   showMainRendererProcessGoneDialog,
   showMessageBoxWithDiagnostics,
@@ -86,22 +90,36 @@ test('main Renderer loss keeps Copy Diagnostics auxiliary to recovery', async ()
   const shown: MessageBoxOptions[] = [];
   const responses = [2, 0];
   let clipboard = '';
+  const diagnosticInput = createDesktopMainRendererDiagnosticInput({
+    title: 'Maka main Renderer process exited unexpectedly',
+    description: 'Reason: oom',
+    details: 'Exit code: 137',
+  });
 
-  const decision = await showMainRendererProcessGoneDialog(
-    { reason: 'oom', exitCode: 137 },
-    {
-      locale: 'en',
-      environment: diagnosticEnvironment,
-      mainLogs: () => ['renderer stopped with api_key=very-secret-token'],
-      writeClipboard: (value) => {
-        clipboard = value;
-      },
-      showMessageBox: async (options): Promise<MessageBoxReturnValue> => {
-        shown.push(options);
-        return { response: responses.shift() ?? 1, checkboxChecked: false };
-      },
+  const decision = await showMainRendererProcessGoneDialog({
+    locale: 'en',
+    copyDiagnostics: () =>
+      copyDesktopDiagnosticReport(
+        {
+          environment: diagnosticEnvironment,
+          mainLogs: () => ['renderer stopped with api_key=very-secret-token'],
+          resolveActiveRuntimeHost: () => {
+            throw new Error('Renderer-loss diagnostics must remain Desktop-only');
+          },
+          resolveRuntimeHost: () => {
+            throw new Error('Renderer-loss diagnostics must not resolve a task Host');
+          },
+          writeClipboard: (value) => {
+            clipboard = value;
+          },
+        },
+        diagnosticInput,
+      ),
+    showMessageBox: async (options): Promise<MessageBoxReturnValue> => {
+      shown.push(options);
+      return { response: responses.shift() ?? 1, checkboxChecked: false };
     },
-  );
+  });
 
   assert.equal(decision, 'relaunch');
   assert.deepEqual(shown[0]?.buttons, ['Relaunch', 'Exit', 'Copy Diagnostics']);

--- a/apps/desktop/src/main/app-quit-coordinator.ts
+++ b/apps/desktop/src/main/app-quit-coordinator.ts
@@ -4,14 +4,14 @@ export interface AppQuitEvent {
 
 export interface AppQuitCoordinator {
   focusOrCreateWindow(): void;
-  getWindowCreationSignal(): AbortSignal | undefined;
   handleBeforeQuit(event: AppQuitEvent): void;
 }
 
 export interface AppQuitCoordinatorDeps {
   cleanup(): Promise<void>;
-  focusOrCreateWindow(signal: AbortSignal): void;
+  focusOrCreateWindow(signal: AbortSignal): void | Promise<void>;
   onCleanupError(error: unknown): void;
+  onWindowCreationError(error: unknown): void;
   resumeQuit(): void;
 }
 
@@ -24,10 +24,13 @@ export function createAppQuitCoordinator(deps: AppQuitCoordinatorDeps): AppQuitC
   return {
     focusOrCreateWindow(): void {
       if (phase !== 'running') return;
-      deps.focusOrCreateWindow(windowCreationAbort.signal);
-    },
-    getWindowCreationSignal(): AbortSignal | undefined {
-      return phase === 'running' ? windowCreationAbort.signal : undefined;
+      try {
+        void Promise.resolve(deps.focusOrCreateWindow(windowCreationAbort.signal)).catch(
+          deps.onWindowCreationError,
+        );
+      } catch (error) {
+        deps.onWindowCreationError(error);
+      }
     },
     handleBeforeQuit(event): void {
       if (phase === 'ready-to-exit') return;

--- a/apps/desktop/src/main/main-process-diagnostics.ts
+++ b/apps/desktop/src/main/main-process-diagnostics.ts
@@ -56,9 +56,18 @@ export interface DesktopStartupDiagnosticInput {
   readonly hostTarget: 'none';
 }
 
+export interface DesktopMainRendererDiagnosticInput {
+  readonly surface: 'renderer_process_gone';
+  readonly title: string;
+  readonly description?: string;
+  readonly details?: string;
+  readonly hostTarget: 'none';
+}
+
 export type DesktopDiagnosticReportInput =
   | DesktopDiagnosticWireInput
-  | DesktopStartupDiagnosticInput;
+  | DesktopStartupDiagnosticInput
+  | DesktopMainRendererDiagnosticInput;
 
 export type RuntimeHostDiagnosticRead =
   | { readonly ok: true; readonly value: HostDiagnosticsResult }
@@ -120,6 +129,27 @@ export function createDesktopStartupDiagnosticInput(input: {
 }): DesktopStartupDiagnosticInput {
   return {
     surface: 'startup',
+    ...createDesktopNativeDiagnosticFields(input),
+  };
+}
+
+export function createDesktopMainRendererDiagnosticInput(input: {
+  readonly title: string;
+  readonly description?: string;
+  readonly details?: string;
+}): DesktopMainRendererDiagnosticInput {
+  return {
+    surface: 'renderer_process_gone',
+    ...createDesktopNativeDiagnosticFields(input),
+  };
+}
+
+function createDesktopNativeDiagnosticFields(input: {
+  readonly title: string;
+  readonly description?: string;
+  readonly details?: string;
+}): Omit<DesktopStartupDiagnosticInput, 'surface'> {
+  return {
     hostTarget: 'none',
     title: requireDiagnosticString(input.title, 'title', INPUT_LIMITS.title),
     ...(input.description
@@ -308,7 +338,12 @@ export function formatDesktopDiagnosticReport(
   capturedAt = new Date(),
 ): string {
   const lines = ['Maka Desktop diagnostic report', `Captured at: ${capturedAt.toISOString()}`];
-  const rendererContext = input.surface === 'startup' ? undefined : input;
+  const rendererContext =
+    input.surface === 'manual' ||
+    input.surface === 'toast' ||
+    input.surface === 'renderer_crash'
+      ? input
+      : undefined;
   if (input.surface === 'manual') {
     lines.push('', 'Capture', 'Surface: manual');
   } else {

--- a/apps/desktop/src/main/main-renderer-process-gone.ts
+++ b/apps/desktop/src/main/main-renderer-process-gone.ts
@@ -1,8 +1,19 @@
 import type { RenderProcessGoneDetails } from 'electron';
 
-export function shouldReportMainRendererProcessGone(
-  details: RenderProcessGoneDetails,
-  shutdownSignal: AbortSignal,
-): boolean {
-  return !shutdownSignal.aborted && details.reason !== 'clean-exit';
+interface RenderProcessGoneSource {
+  once(
+    event: 'render-process-gone',
+    listener: (event: unknown, details: RenderProcessGoneDetails) => void,
+  ): void;
+}
+
+export function observeMainRendererProcessGone(deps: {
+  readonly source: RenderProcessGoneSource;
+  readonly shutdownSignal: AbortSignal;
+  readonly onUnexpectedExit: (details: RenderProcessGoneDetails) => void;
+}): void {
+  deps.source.once('render-process-gone', (_event, details) => {
+    if (deps.shutdownSignal.aborted || details.reason === 'clean-exit') return;
+    deps.onUnexpectedExit(details);
+  });
 }

--- a/apps/desktop/src/main/main-renderer-process-gone.ts
+++ b/apps/desktop/src/main/main-renderer-process-gone.ts
@@ -1,0 +1,8 @@
+import type { RenderProcessGoneDetails } from 'electron';
+
+export function shouldReportMainRendererProcessGone(
+  details: RenderProcessGoneDetails,
+  shutdownSignal: AbortSignal,
+): boolean {
+  return !shutdownSignal.aborted && details.reason !== 'clean-exit';
+}

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -10,6 +10,7 @@ import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
 import type { E2eFixture } from './e2e-fixture.js';
 import { installMainWindowPermissionPolicy } from './main-window-permission-policy.js';
+import { shouldReportMainRendererProcessGone } from './main-renderer-process-gone.js';
 import { isThemePreference, toNativeThemeSource } from './theme-source.js';
 import { createWindowRevealGate } from './window-reveal.js';
 import {
@@ -66,6 +67,7 @@ interface MainWindowControllerDeps {
   // and the fake backend, so main-window.ts owns no env policy of its own.
   startHidden: boolean;
   onClose?: () => void;
+  onRendererProcessGone: (details: Electron.RenderProcessGoneDetails) => void | Promise<void>;
 }
 
 let mainWindow: BrowserWindow | null = null;
@@ -347,6 +349,18 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         webSecurity: true,         // enforce CSP / same-origin policy
         allowRunningInsecureContent: false,
       },
+    });
+    mainWindow.webContents.once('render-process-gone', (_event, details) => {
+      if (!shouldReportMainRendererProcessGone(details, signal)) return;
+      console.error(
+        `[renderer] main Renderer process exited unexpectedly: reason=${details.reason} exitCode=${details.exitCode}`,
+      );
+      void Promise.resolve()
+        .then(() => deps.onRendererProcessGone(details))
+        .catch((error) => {
+          console.error('[renderer] failed to handle main Renderer process exit:', error);
+          app.quit();
+        });
     });
     installMainWindowPermissionPolicy(mainWindow.webContents, rendererEntryUrl);
 

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -10,7 +10,7 @@ import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
 import type { E2eFixture } from './e2e-fixture.js';
 import { installMainWindowPermissionPolicy } from './main-window-permission-policy.js';
-import { shouldReportMainRendererProcessGone } from './main-renderer-process-gone.js';
+import { observeMainRendererProcessGone } from './main-renderer-process-gone.js';
 import { isThemePreference, toNativeThemeSource } from './theme-source.js';
 import { createWindowRevealGate } from './window-reveal.js';
 import {
@@ -350,17 +350,20 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         allowRunningInsecureContent: false,
       },
     });
-    mainWindow.webContents.once('render-process-gone', (_event, details) => {
-      if (!shouldReportMainRendererProcessGone(details, signal)) return;
-      console.error(
-        `[renderer] main Renderer process exited unexpectedly: reason=${details.reason} exitCode=${details.exitCode}`,
-      );
-      void Promise.resolve()
-        .then(() => deps.onRendererProcessGone(details))
-        .catch((error) => {
-          console.error('[renderer] failed to handle main Renderer process exit:', error);
-          app.quit();
-        });
+    observeMainRendererProcessGone({
+      source: mainWindow.webContents,
+      shutdownSignal: signal,
+      onUnexpectedExit: (details) => {
+        console.error(
+          `[renderer] main Renderer process exited unexpectedly: reason=${details.reason} exitCode=${details.exitCode}`,
+        );
+        void Promise.resolve()
+          .then(() => deps.onRendererProcessGone(details))
+          .catch((error) => {
+            console.error('[renderer] failed to handle main Renderer process exit:', error);
+            app.quit();
+          });
+      },
     });
     installMainWindowPermissionPolicy(mainWindow.webContents, rendererEntryUrl);
 

--- a/apps/desktop/src/main/native-diagnostic-dialog.ts
+++ b/apps/desktop/src/main/native-diagnostic-dialog.ts
@@ -2,17 +2,21 @@ import type { UiLocale } from '@maka/core/ui-locale';
 import type {
   MessageBoxOptions,
   MessageBoxReturnValue,
-  RenderProcessGoneDetails,
 } from 'electron';
 import {
-  createDesktopMainRendererDiagnosticInput,
   createDesktopStartupDiagnosticInput,
   formatDesktopDiagnosticReport,
   type DesktopDiagnosticEnvironment,
 } from './main-process-diagnostics.js';
 import { whileAwaitingPerson } from './startup-step.js';
 
-interface NativeDiagnosticDialogDeps {
+interface DiagnosticDialogDeps {
+  readonly locale: UiLocale;
+  readonly copyDiagnostics: () => void | Promise<void>;
+  readonly showMessageBox: (options: MessageBoxOptions) => Promise<MessageBoxReturnValue>;
+}
+
+interface FatalStartupDiagnosticDialogDeps {
   readonly locale: UiLocale;
   readonly environment: () => DesktopDiagnosticEnvironment;
   readonly mainLogs: () => readonly string[];
@@ -22,11 +26,7 @@ interface NativeDiagnosticDialogDeps {
 
 export async function showMessageBoxWithDiagnostics(
   options: MessageBoxOptions,
-  deps: {
-    readonly locale: UiLocale;
-    readonly copyDiagnostics: () => void | Promise<void>;
-    readonly showMessageBox: (options: MessageBoxOptions) => Promise<MessageBoxReturnValue>;
-  },
+  deps: DiagnosticDialogDeps,
 ): Promise<MessageBoxReturnValue> {
   let status: string | undefined;
   for (;;) {
@@ -39,7 +39,7 @@ export async function showMessageBoxWithDiagnostics(
 
 export async function showFatalStartupError(
   error: unknown,
-  deps: NativeDiagnosticDialogDeps,
+  deps: FatalStartupDiagnosticDialogDeps,
 ): Promise<void> {
   const copy = FATAL_STARTUP_COPY[deps.locale];
   const message = error instanceof Error ? error.message : String(error);
@@ -76,15 +76,9 @@ export async function showFatalStartupError(
 }
 
 export async function showMainRendererProcessGoneDialog(
-  details: RenderProcessGoneDetails,
-  deps: NativeDiagnosticDialogDeps,
+  deps: DiagnosticDialogDeps,
 ): Promise<'relaunch' | 'exit'> {
   const copy = MAIN_RENDERER_GONE_COPY[deps.locale];
-  const input = createDesktopMainRendererDiagnosticInput({
-    title: 'Maka main Renderer process exited unexpectedly',
-    description: `Reason: ${details.reason}`,
-    details: `Exit code: ${details.exitCode}`,
-  });
   const result = await showMessageBoxWithDiagnostics(
     {
       type: 'error',
@@ -96,19 +90,7 @@ export async function showMainRendererProcessGoneDialog(
       cancelId: 1,
       noLink: true,
     },
-    {
-      locale: deps.locale,
-      showMessageBox: deps.showMessageBox,
-      copyDiagnostics: () =>
-        deps.writeClipboard(
-          formatDesktopDiagnosticReport(
-            input,
-            deps.environment(),
-            deps.mainLogs(),
-            { ok: false, error: 'No Runtime Host authority was associated with this error' },
-          ),
-        ),
-    },
+    deps,
   );
   return result.response === 0 ? 'relaunch' : 'exit';
 }

--- a/apps/desktop/src/main/native-diagnostic-dialog.ts
+++ b/apps/desktop/src/main/native-diagnostic-dialog.ts
@@ -1,11 +1,24 @@
 import type { UiLocale } from '@maka/core/ui-locale';
-import type { MessageBoxOptions, MessageBoxReturnValue } from 'electron';
+import type {
+  MessageBoxOptions,
+  MessageBoxReturnValue,
+  RenderProcessGoneDetails,
+} from 'electron';
 import {
+  createDesktopMainRendererDiagnosticInput,
   createDesktopStartupDiagnosticInput,
   formatDesktopDiagnosticReport,
   type DesktopDiagnosticEnvironment,
 } from './main-process-diagnostics.js';
 import { whileAwaitingPerson } from './startup-step.js';
+
+interface NativeDiagnosticDialogDeps {
+  readonly locale: UiLocale;
+  readonly environment: () => DesktopDiagnosticEnvironment;
+  readonly mainLogs: () => readonly string[];
+  readonly writeClipboard: (value: string) => void;
+  readonly showMessageBox: (options: MessageBoxOptions) => Promise<MessageBoxReturnValue>;
+}
 
 export async function showMessageBoxWithDiagnostics(
   options: MessageBoxOptions,
@@ -26,13 +39,7 @@ export async function showMessageBoxWithDiagnostics(
 
 export async function showFatalStartupError(
   error: unknown,
-  deps: {
-    readonly locale: UiLocale;
-    readonly environment: () => DesktopDiagnosticEnvironment;
-    readonly mainLogs: () => readonly string[];
-    readonly writeClipboard: (value: string) => void;
-    readonly showMessageBox: (options: MessageBoxOptions) => Promise<MessageBoxReturnValue>;
-  },
+  deps: NativeDiagnosticDialogDeps,
 ): Promise<void> {
   const copy = FATAL_STARTUP_COPY[deps.locale];
   const message = error instanceof Error ? error.message : String(error);
@@ -66,6 +73,44 @@ export async function showFatalStartupError(
         ),
     },
   );
+}
+
+export async function showMainRendererProcessGoneDialog(
+  details: RenderProcessGoneDetails,
+  deps: NativeDiagnosticDialogDeps,
+): Promise<'relaunch' | 'exit'> {
+  const copy = MAIN_RENDERER_GONE_COPY[deps.locale];
+  const input = createDesktopMainRendererDiagnosticInput({
+    title: 'Maka main Renderer process exited unexpectedly',
+    description: `Reason: ${details.reason}`,
+    details: `Exit code: ${details.exitCode}`,
+  });
+  const result = await showMessageBoxWithDiagnostics(
+    {
+      type: 'error',
+      title: copy.title,
+      message: copy.message,
+      detail: copy.detail,
+      buttons: [copy.relaunch, copy.exit],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+    },
+    {
+      locale: deps.locale,
+      showMessageBox: deps.showMessageBox,
+      copyDiagnostics: () =>
+        deps.writeClipboard(
+          formatDesktopDiagnosticReport(
+            input,
+            deps.environment(),
+            deps.mainLogs(),
+            { ok: false, error: 'No Runtime Host authority was associated with this error' },
+          ),
+        ),
+    },
+  );
+  return result.response === 0 ? 'relaunch' : 'exit';
 }
 
 async function copyDiagnostics(
@@ -129,6 +174,23 @@ const FATAL_STARTUP_COPY = {
     title: 'Maka 启动失败',
     message: 'Maka 无法完成启动。',
     unknownError: '启动时发生未知错误。',
+    exit: '退出',
+  },
+} as const;
+
+const MAIN_RENDERER_GONE_COPY = {
+  en: {
+    title: 'Maka needs to recover',
+    message: "Maka's interface stopped unexpectedly.",
+    detail: 'Relaunch Maka to continue, or exit and reopen it later.',
+    relaunch: 'Relaunch',
+    exit: 'Exit',
+  },
+  zh: {
+    title: 'Maka 需要恢复',
+    message: 'Maka 界面意外停止运行。',
+    detail: '重新启动 Maka 以继续，或退出后稍后再打开。',
+    relaunch: '重新启动',
     exit: '退出',
   },
 } as const;

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -78,7 +78,10 @@ import {
   mainProcessLogBuffer,
   type DesktopDiagnosticsDeps,
 } from "./main-process-diagnostics.js";
-import { showMessageBoxWithDiagnostics } from "./native-diagnostic-dialog.js";
+import {
+  showMainRendererProcessGoneDialog,
+  showMessageBoxWithDiagnostics,
+} from "./native-diagnostic-dialog.js";
 import {
   resolveDesktopSessionWorkspace,
 } from "./new-session-project.js";
@@ -323,6 +326,17 @@ const mainWindowController = createMainWindowController({
   settingsStore,
   startHidden,
   onClose: () => onMainWindowClose(),
+  onRendererProcessGone: async (details) => {
+    const decision = await showMainRendererProcessGoneDialog(details, {
+      locale: desktopLocale.current(),
+      environment: desktopDiagnostics.environment,
+      mainLogs: desktopDiagnostics.mainLogs,
+      writeClipboard: desktopDiagnostics.writeClipboard,
+      showMessageBox: (options) => dialog.showMessageBox(options),
+    });
+    if (decision === "relaunch") app.relaunch();
+    app.quit();
+  },
 });
 const runtimeHostSshTerminal = createDesktopRuntimeHostSshTerminal({
   ipcMain,

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -1435,10 +1435,12 @@ function wireLifecycle(): void {
     cleanup: closeRuntimeHostDesktop,
     focusOrCreateWindow: (signal) => {
       if (mainWindowController.hasOpenWindows()) mainWindowController.focus();
-      else void mainWindowController.createWindow(signal);
+      else return mainWindowController.createWindow(signal);
     },
     onCleanupError: (error) =>
       console.error("[runtime-host] shutdown failed:", error),
+    onWindowCreationError: (error) =>
+      console.error("[window] creation failed:", error),
     resumeQuit: () => app.quit(),
   });
   installDesktopShellPresentation({
@@ -1459,8 +1461,7 @@ function wireLifecycle(): void {
     if (process.platform !== "darwin") app.quit();
   });
   app.on("before-quit", quitCoordinator.handleBeforeQuit);
-  const initialWindowSignal = quitCoordinator.getWindowCreationSignal();
-  if (initialWindowSignal) void mainWindowController.createWindow(initialWindowSignal);
+  quitCoordinator.focusOrCreateWindow();
 }
 
 async function closeRuntimeHostDesktop(): Promise<void> {

--- a/apps/desktop/src/main/runtime-host-boot.ts
+++ b/apps/desktop/src/main/runtime-host-boot.ts
@@ -74,6 +74,7 @@ import { createMainWindowController } from "./main-window.js";
 import {
   captureDesktopDiagnosticEnvironment,
   copyDesktopDiagnosticReport,
+  createDesktopMainRendererDiagnosticInput,
   createDesktopStartupDiagnosticInput,
   mainProcessLogBuffer,
   type DesktopDiagnosticsDeps,
@@ -327,11 +328,15 @@ const mainWindowController = createMainWindowController({
   startHidden,
   onClose: () => onMainWindowClose(),
   onRendererProcessGone: async (details) => {
-    const decision = await showMainRendererProcessGoneDialog(details, {
+    const diagnosticInput = createDesktopMainRendererDiagnosticInput({
+      title: "Maka main Renderer process exited unexpectedly",
+      description: `Reason: ${details.reason}`,
+      details: `Exit code: ${details.exitCode}`,
+    });
+    const decision = await showMainRendererProcessGoneDialog({
       locale: desktopLocale.current(),
-      environment: desktopDiagnostics.environment,
-      mainLogs: desktopDiagnostics.mainLogs,
-      writeClipboard: desktopDiagnostics.writeClipboard,
+      copyDiagnostics: () =>
+        copyDesktopDiagnosticReport(desktopDiagnostics, diagnosticInput),
       showMessageBox: (options) => dialog.showMessageBox(options),
     });
     if (decision === "relaunch") app.relaunch();


### PR DESCRIPTION
## Summary

<details open>
<summary>English</summary>

Detect unexpected termination of the main BrowserWindow Renderer while the Electron main process remains alive.

- Ignore clean exits and app shutdown.
- Capture the bounded reason and exit code in existing main-process diagnostics.
- Present a native recovery dialog where Copy Diagnostics remains auxiliary to Relaunch or Exit.
- Keep the report Desktop-only instead of inferring Runtime Host authority.

</details>

<details>
<summary>中文</summary>

当 Electron 主进程仍存活、主 BrowserWindow 的 Renderer 意外终止时提供可恢复的诊断入口。

- 忽略正常退出和应用关闭流程。
- 将限长后的退出原因与退出码记录到既有主进程诊断中。
- 通过原生恢复弹窗提供复制诊断信息，同时保留重新启动或退出决策。
- 报告仅归因于 Desktop，不推断 Runtime Host。

</details>

Fixes #3490
Refs #3463

## Verification

<details open>
<summary>English</summary>

- `npm --workspace @maka/desktop test` — 1152 passed
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `npx knip --workspace apps/desktop`

Focused tests cover the actual `render-process-gone` observation boundary, shutdown filtering, rejected window loads, and the Copy Diagnostics → Relaunch decision path.

</details>

<details>
<summary>中文</summary>

上述检查均通过；聚焦测试覆盖真实的 `render-process-gone` 事件边界、关闭流程过滤、窗口加载失败，以及“复制诊断信息后仍可重新启动”的决策路径。

</details>

## Review focus

<details open>
<summary>English</summary>

Please verify that the lifecycle filter reports only unexpected loss of the main Renderer and that the native report remains within the existing Desktop diagnostic authority.

</details>

<details>
<summary>中文</summary>

请重点确认生命周期过滤仅报告主 Renderer 的意外终止，并且原生报告仍遵循既有 Desktop 诊断权限边界。

</details>

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented and validated the change under human direction. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
