### PR TITLE
fix(cli): label /model choices by catalog display name

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -2839,6 +2839,66 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('/model labels choices by catalog display name and searches it', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      // Same trick as the search test above: a current model absent from the
+      // choices, so raw ids can only reach the screen through picker labels.
+      model: 'legacy-curated-out',
+      connectionSlug: 'ghost',
+      providerType: 'openai',
+      modelChoices: [
+        {
+          connectionSlug: 'alpha',
+          connectionName: 'Aurora',
+          providerType: 'openai',
+          model: 'gpt-5.5',
+          displayName: 'GPT-5.5 Mini',
+          isDefaultConnection: true,
+        },
+        {
+          connectionSlug: 'beta',
+          connectionName: 'Boreal',
+          providerType: 'zai',
+          model: 'glm-max',
+          isDefaultConnection: false,
+        },
+      ],
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    await waitForTuiPaint(terminal);
+    terminal.input('/model');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Select Model'));
+    // The labeled choice renders its display name instead of the raw id; the
+    // choice without one falls back to the id like desktop does.
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('GPT-5.5 Mini') && !out.includes('gpt-5.5') && out.includes('glm-max');
+    });
+
+    // Searching by the friendly name finds the model (#3482).
+    terminal.input('mini');
+    await waitFor(() => {
+      const out = plainTerminalOutput(terminal.screenOutput());
+      return out.includes('GPT-5.5 Mini') && !out.includes('glm-max');
+    });
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(CLOSE_BUDGET_MS).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('switches models in a fresh conversation without a cache warning', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();

--- a/packages/cli/src/__tests__/runtime-host-onboarding.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-onboarding.test.ts
@@ -52,4 +52,23 @@ describe('projectRuntimeHostModelChoices', () => {
       ['openai'],
     );
   });
+
+  test('projects the catalog display name so the picker can label like desktop', () => {
+    const choices = projectRuntimeHostModelChoices(
+      catalog([
+        {
+          ...live,
+          enabledModelIds: ['gpt-5-mini', 'gpt-5.2-codex'],
+          models: [{ id: 'gpt-5-mini', displayName: 'GPT-5 mini' }, { id: 'gpt-5.2-codex' }],
+        },
+      ]),
+    );
+    assert.deepEqual(
+      choices.map(({ model, displayName }) => ({ model, displayName })),
+      [
+        { model: 'gpt-5-mini', displayName: 'GPT-5 mini' },
+        { model: 'gpt-5.2-codex', displayName: undefined },
+      ],
+    );
+  });
 });

--- a/packages/cli/src/pi-tui-contracts.ts
+++ b/packages/cli/src/pi-tui-contracts.ts
@@ -8,6 +8,13 @@ export interface ModelChoice {
   connectionName: string;
   providerType: ProviderType;
   model: string;
+  /**
+   * Human-readable model name from the connection catalog, mirroring the
+   * desktop label rule (`displayName?.trim() || model`). Optional so
+   * hand-written choice literals and ids-only minimal hosts stay valid —
+   * consumers must fall back to `model`.
+   */
+  displayName?: string;
   isDefaultConnection: boolean;
   /** Maximum context tokens for this model, resolved from the connection or provider catalog. */
   contextWindow?: number;

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -566,8 +566,10 @@ export function modelPickerItems(
 /**
  * `/model` items across every ready connection. The value is the choice's index
  * (models can repeat across connections, so no id is unique on its own); the
- * caller maps it back to the {@link ModelChoice}. The description carries the
- * owning connection so identical model ids on different providers are readable.
+ * caller maps it back to the {@link ModelChoice}. Items prefer the catalog
+ * display name and fall back to the model id — the same rule desktop uses —
+ * while the description carries the owning connection so identical models on
+ * different providers are readable.
  */
 function modelChoicePickerItems(
   choices: readonly ModelChoice[],
@@ -579,18 +581,19 @@ function modelChoicePickerItems(
     const tags = [choice.connectionName || choice.connectionSlug];
     if (isCurrent) tags.push('current');
     else if (choice.isDefaultConnection) tags.push('default');
-    return { value: String(index), label: choice.model, description: tags.join(' · ') };
+    const label = choice.displayName?.trim() || choice.model;
+    return { value: String(index), label, description: tags.join(' · ') };
   });
 }
 
 /**
  * Case-insensitive substring match for the `/model` search field, against every
- * criterion the issue names: model id, provider label/type, and connection
- * name/slug. `ModelChoice` carries no display name, so the model id is the only
- * model-side match target; a display-name enrichment would slot in here.
+ * criterion the issue names: model display name (when the catalog supplies
+ * one), model id, provider label/type, and connection name/slug.
  */
 function matchesModelChoice(choice: ModelChoice, query: string): boolean {
   if (choice.model.toLowerCase().includes(query)) return true;
+  if (choice.displayName?.toLowerCase().includes(query)) return true;
   if (choice.connectionName.toLowerCase().includes(query)) return true;
   if (choice.connectionSlug.toLowerCase().includes(query)) return true;
   if (choice.providerType.toLowerCase().includes(query)) return true;

--- a/packages/cli/src/runtime-host-onboarding.ts
+++ b/packages/cli/src/runtime-host-onboarding.ts
@@ -73,6 +73,7 @@ export function projectRuntimeHostModelChoices(catalog: ConnectionCatalogSnapsho
         connectionName: connection.name,
         providerType: connection.providerType,
         model,
+        displayName: modelsById.get(model)?.displayName,
         isDefaultConnection: catalog.defaultTarget?.connectionId === connection.connectionId,
         contextWindow: modelsById.get(model)?.contextWindow,
       });


### PR DESCRIPTION
Fixes #3482

## Problem

The TUI `/model` picker rendered raw model ids as item labels, while Desktop labels the same underlying choices by catalog display name (`entry.displayName?.trim() || entry.id` in `chat-model-choice.ts`). The same model showed as `Claude Opus 4.5` on Desktop but as its raw id in the TUI, and the TUI search field could not match by the friendly name.

## Change

- `pi-tui-contracts.ts` — add optional `displayName` to `ModelChoice`, documented with the fallback contract.
- `runtime-host-onboarding.ts` — project it from the connection catalog via the existing `modelsById` lookup (the same lookup that already resolves `contextWindow`; no new data source or protocol change).
- `pi-tui-pickers.ts` — items render `displayName?.trim() || model` (desktop's rule), and `matchesModelChoice` matches queries against the display name; stale doc comments updated.

The ids-only `modelPickerItems` fallback for minimal hosts is intentionally unchanged, as scoped in the issue.

## Testing

- `packages/cli`: typecheck clean; biome lint/format clean on all touched files.
- `node --test dist/__tests__/runtime-host-onboarding.test.js` — 3/3 pass, incl. new projection test.
- `node --test dist/__tests__/pi-tui-runner.test.js` — 120/120 pass, incl. new integration test asserting the picker shows the display name (raw id absent when one exists), falls back to the id otherwise, and search-by-friendly-name isolates the choice.

## Note / follow-up candidate

The one-expression label rule now exists on both surfaces (core for Desktop, cli for TUI) with cross-referencing comments. Folding the cli projection into a shared core type is a separate consolidation candidate and is deliberately not mixed into this bugfix.