### PR TITLE
chore: record the ASF header sweep in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,5 +12,5 @@
 # style: apply Biome format baseline outside the UI surface (#415)
 # -> squash-commit hash added in a follow-up immediately after this PR lands.
 
-# chore: apply the ASF license header to every covered source file (#3397)
-# -> squash-commit hash added in a follow-up immediately after this PR lands.
+# chore: add ASF source headers and a release header audit gate (#3397)
+c633ea5b2524d9463228e01f8d369ef9166c3f05


### PR DESCRIPTION
## Summary

`.git-blame-ignore-revs` documents its own convention: a reformat PR adds its landed hash here in a follow-up right after the squash, because an entry naming a hash the clone has never seen makes `git blame` error out with `cannot find revision ... to ignore` rather than degrading. #3397 left the placeholder in place, as its commit message said it would. This fills it in with `c633ea5b2524d9463228e01f8d369ef9166c3f05`, the squash commit that landed on `main`.

Without the entry, all 2679 files the header sweep touched blame to that commit, even though it changed no line of their content.

Refs #3397

## Verification

- `c633ea5b2524d9463228e01f8d369ef9166c3f05` confirmed present on `main` (`git log -1` resolves it), which is the precondition the file itself states.
- `node scripts/asf-license-headers.mjs check` on this branch: 2681 covered, 114 excluded, clean. Unrelated to this change, but it is the gate #3397 introduced and this branch is the first thing on top of it.
- No test covers this: the file is consumed by `git blame` and by GitHub's blame view, not by anything in the build. Nothing to run beyond confirming the hash resolves.

## Review focus

One thing worth a maintainer's call, not addressed here: the `# style: apply Biome format baseline outside the UI surface (#415)` entry above still carries its own unfilled placeholder, so that sweep is not actually being ignored either. Filling it needs the landed hash for #415, which is a separate lookup and a separate intent — happy to do it in another PR if you want it.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — wrote the change and this description. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
