### PR TITLE
chore: add the ASF header to the renderer-loss recovery files

### DIFF
--- a/apps/desktop/src/main/__tests__/main-renderer-process-gone.test.ts
+++ b/apps/desktop/src/main/__tests__/main-renderer-process-gone.test.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
 import { test } from 'node:test';

--- a/apps/desktop/src/main/main-renderer-process-gone.ts
+++ b/apps/desktop/src/main/main-renderer-process-gone.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import type { RenderProcessGoneDetails } from 'electron';
 
 interface RenderProcessGoneSource {


### PR DESCRIPTION
## Summary

#3495 branched before #3397 landed, so its two new files arrived without the ASF header, and its CI run predates the `audit` job that #3397 added. `check:asf-headers` runs in `ci.yml`, so `main` is currently failing that check and every open PR inherits the failure until this lands.

`npm run write:asf-headers` produced this commit. Nothing else was touched.

Refs #3495, #3397

## Verification

- `node scripts/asf-license-headers.mjs check` on `main` before this change: 2 files missing (`apps/desktop/src/main/main-renderer-process-gone.ts` and its test).
- Same command on this branch: clean.
- No behavior to test: both files gain a leading license comment and nothing else.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — ran the header writer and wrote this description. The commit carries a `Generated-by: Claude Code` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
