### PR TITLE
fix(storybook): fill the app shell viewport

### DIFF
--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -280,7 +280,6 @@ function ShellFrame(props: {
       data-sidebar-state={props.sidebarCollapsed ? 'collapsed' : 'expanded'}
       style={
         {
-          height: '100%',
           minHeight: 640,
           /* Same publication point as production, for the same reason as
              `data-sidebar-state` above: the titlebar's first grid track is a


### PR DESCRIPTION
## Summary

- remove the inline percentage height that overrides the production `100dvh` app-frame rule
- let AppShell stories fill the Storybook iframe instead of ending at the 640px minimum and leaving a white band

## Verification

- `npm --workspace @maka/desktop run typecheck:stories`
- visually checked the default AppShell story at 1200x768; the shell now fills the full viewport with no bottom white band