### PR TITLE
feat(desktop): expose Computer Use activity progress

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-native-capabilities.test.ts
@@ -48,6 +48,7 @@ test('publishes self-described session-affine Browser and Computer Use offers', 
       affinity: offer.affinity,
       toolNames: offer.tools.map((descriptor) => descriptor.name),
       serverIds: offer.tools.map((descriptor) => descriptor.serverId),
+      activityKinds: offer.tools.map((descriptor) => descriptor.activityKind),
     })),
     [
       {
@@ -56,6 +57,7 @@ test('publishes self-described session-affine Browser and Computer Use offers', 
         affinity: 'session',
         toolNames: ['browser_snapshot'],
         serverIds: ['desktop_browser'],
+        activityKinds: [undefined],
       },
       {
         offerId: 'desktop_computer_use',
@@ -63,6 +65,7 @@ test('publishes self-described session-affine Browser and Computer Use offers', 
         affinity: 'session',
         toolNames: ['maka_computer'],
         serverIds: ['desktop_computer_use'],
+        activityKinds: ['computer'],
       },
     ],
   );
@@ -566,6 +569,7 @@ function computerTools(
     ? [
         {
           ...tool('maka_computer', z.object({ wait: z.boolean().optional() }), impl),
+          activityKind: 'computer' as const,
           toModelOutput: ({ output }: { output: unknown }) => {
             const result = output as {
               text: string;

--- a/apps/desktop/src/main/runtime-host-native-capabilities.ts
+++ b/apps/desktop/src/main/runtime-host-native-capabilities.ts
@@ -349,6 +349,7 @@ async function invokeNativeTool(
     toolCallId: frame.toolCallId,
     abortSignal: signal,
     emitOutput() {},
+    ...(options.progress ? { emitProgress: options.progress } : {}),
   });
   return projectToolResult(binding.tool, frame.toolCallId, args, output);
 }
@@ -387,6 +388,7 @@ function capabilityOffer(
           name: tool.name,
           description: tool.description,
           inputSchema: toolInputSchema(tool),
+          ...(tool.activityKind ? { activityKind: tool.activityKind } : {}),
           ...(tool.displayName
             ? { annotations: Object.freeze({ title: tool.displayName }) }
             : {}),

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -571,6 +571,65 @@ export const RunningStatusDuringToolRun: Story = {
   ),
 };
 
+// Real path: Desktop Computer Use is exposed through the Runtime Host Client
+// Capability bridge. The settled observation establishes the confirmed target;
+// the following sequence inherits it while live progress replaces the generic
+// working phrase at the bottom of the turn.
+export const ComputerUseObservability: Story = {
+  render: () => (
+    <ComposedShell
+      session={{ status: 'running', streaming: true }}
+      chat={{
+        runningStatus: true,
+        messages: [
+          user('msg-cu-1', 'turn-cu', 2, '在计算器里完成这组输入，并确认结果。'),
+          {
+            type: 'turn_state',
+            id: 'state-cu',
+            turnId: 'turn-cu',
+            ts: NOW - 40_000,
+            status: 'running',
+            partialOutputRetained: false,
+          },
+        ],
+        liveTurn: {
+          turnId: 'turn-cu',
+          phase: 'streamed',
+          steps: [{
+            stepId: 'msg-assistant-cu',
+            tools: [
+              {
+                toolUseId: 'tool-cu-observe',
+                toolName: 'mcp__desktop_computer_use__maka_computer',
+                activityKind: 'computer',
+                displayName: 'Maka Computer',
+                status: 'completed',
+                args: { action: 'observe', app: '计算器', window_id: 7 },
+                durationMs: 728,
+              },
+              {
+                toolUseId: 'tool-cu-sequence',
+                toolName: 'mcp__desktop_computer_use__maka_computer',
+                activityKind: 'computer',
+                displayName: 'Maka Computer',
+                status: 'running',
+                args: {
+                  action: 'element_sequence',
+                  observation_id: '00000000-0000-0000-0000-000000000001',
+                  steps: Array.from({ length: 11 }, (_, index) => ({
+                    label: `<text:${String(index).length}>`,
+                  })),
+                },
+                progress: { current: 7, total: 11 },
+              },
+            ],
+          }],
+        },
+      }}
+    />
+  ),
+};
+
 // Real path: the agent calls a tool that needs approval → session enters
 // waiting_for_user and the permission-mode picker is locked with a reason.
 //

--- a/packages/core/src/__tests__/events.test.ts
+++ b/packages/core/src/__tests__/events.test.ts
@@ -19,7 +19,11 @@
 
 import { test } from 'node:test';
 import { expect } from './test-helpers.js';
-import { aggregateMessageContents } from '../events.js';
+import {
+  aggregateMessageContents,
+  decodeToolStepProgress,
+  encodeToolStepProgress,
+} from '../events.js';
 
 test('aggregates inline references against the combined display text', () => {
   expect(
@@ -50,4 +54,46 @@ test('preserves an explicit empty inline-reference marker while aggregating', ()
     text: 'plain',
     inlineReferences: [],
   });
+});
+
+test('round-trips bounded tool step progress through the shared wire codec', () => {
+  const encoded = encodeToolStepProgress({ current: 1, total: 2 });
+
+  expect(encoded).toBe('steps:1/2');
+  expect(decodeToolStepProgress(encoded!)).toEqual({ current: 1, total: 2 });
+  expect(
+    decodeToolStepProgress(
+      encodeToolStepProgress({
+        current: Number.MAX_SAFE_INTEGER,
+        total: Number.MAX_SAFE_INTEGER,
+      })!,
+    ),
+  ).toEqual({
+    current: Number.MAX_SAFE_INTEGER,
+    total: Number.MAX_SAFE_INTEGER,
+  });
+});
+
+test('rejects invalid tool step progress at both codec boundaries', () => {
+  for (const progress of [
+    { current: -1, total: 2 },
+    { current: 1, total: 0 },
+    { current: 3, total: 2 },
+    { current: 0.5, total: 2 },
+    { current: Number.MAX_SAFE_INTEGER + 1, total: Number.MAX_SAFE_INTEGER + 1 },
+  ]) {
+    expect(encodeToolStepProgress(progress)).toBe(undefined);
+  }
+
+  for (const chunk of [
+    'working',
+    'steps:-1/2',
+    'steps:1/0',
+    'steps:3/2',
+    'steps:0.5/2',
+    'steps:9007199254740992/9007199254740992',
+  ]) {
+    expect(decodeToolStepProgress(chunk)).toBe(undefined);
+  }
+  expect(decodeToolStepProgress({ kind: 'stdout', text: 'steps:1/2' })).toBe(undefined);
 });

--- a/packages/core/src/computer-use.ts
+++ b/packages/core/src/computer-use.ts
@@ -478,6 +478,9 @@ export interface ComputerUseModelCallArgs {
   window_id?: number;
   observation_id?: string;
   element_id?: string;
+  menu?: string;
+  window_action?: string;
+  steps?: readonly ComputerUseModelCallStep[];
   /** Every other argument the call carried, values reduced to their shape. */
   [key: string]:
     | string

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -580,6 +580,39 @@ export interface ToolProgressEvent extends BaseEvent, ToolActivityIdentity {
   chunk: string | { kind: 'stdout' | 'stderr'; text: string };
 }
 
+export interface ToolStepProgress {
+  current: number;
+  total: number;
+}
+
+const TOOL_STEP_PROGRESS_PATTERN = /^steps:(\d+)\/(\d+)$/;
+
+export function encodeToolStepProgress(progress: ToolStepProgress): string | undefined {
+  return isValidToolStepProgress(progress)
+    ? `steps:${progress.current}/${progress.total}`
+    : undefined;
+}
+
+export function decodeToolStepProgress(
+  chunk: ToolProgressEvent['chunk'],
+): ToolStepProgress | undefined {
+  if (typeof chunk !== 'string') return undefined;
+  const match = TOOL_STEP_PROGRESS_PATTERN.exec(chunk);
+  if (!match) return undefined;
+  const progress = { current: Number(match[1]), total: Number(match[2]) };
+  return isValidToolStepProgress(progress) ? progress : undefined;
+}
+
+function isValidToolStepProgress(progress: ToolStepProgress): boolean {
+  return (
+    Number.isSafeInteger(progress.current) &&
+    Number.isSafeInteger(progress.total) &&
+    progress.current >= 0 &&
+    progress.total >= 1 &&
+    progress.current <= progress.total
+  );
+}
+
 /**
  * Live-only open-facts for a tool that is still running (e.g. agent_spawn child ready).
  * Not a durable transcript commit and not model-visible function_response.

--- a/packages/runtime-host/src/__tests__/client-capability-channel.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-channel.test.ts
@@ -210,3 +210,82 @@ test('Client Capability channel rejects Host paths before invoking a path-isolat
   ]);
   channel.close(new Error('test complete'));
 });
+
+test('Client Capability channel forwards admitted tool progress before the result', async () => {
+  let registrationId = '';
+  const written: unknown[] = [];
+  let channel!: ClientCapabilityChannel;
+  const provider: ClientCapabilityProvider = {
+    offers: () => [{
+      offerId: 'fixture',
+      version: '0',
+      affinity: 'call',
+      hostPathAccess: 'cwd',
+      label: 'Fixture',
+      tools: [{ serverId: 'fixture', name: 'sequence', inputSchema: { type: 'object' } }],
+    }],
+    call: async (_frame, options) => {
+      await options.accept();
+      options.progress?.(1, 3);
+      options.progress?.(2, 3);
+      return { content: [] };
+    },
+  };
+  channel = new ClientCapabilityChannel({
+    write: async (frame) => {
+      written.push(frame);
+      if (frame.kind === 'client.capability.accepted') {
+        queueMicrotask(() => channel.accept({
+          kind: 'client.capability.admitted',
+          invocationId: frame.invocationId,
+        }));
+      }
+    },
+    replace: async (input) => {
+      registrationId = input.registrationId;
+      return { registrationId, revision: 1 };
+    },
+    unregister: async (input) => ({ registrationId: input.registrationId, revision: 2 }),
+    onFailure: (error) => {
+      throw error;
+    },
+  });
+
+  await channel.replace(provider, 1_000);
+  channel.accept({
+    kind: 'client.capability.call',
+    invocationId: 'progress-invocation',
+    registrationId,
+    offerId: 'fixture',
+    serverId: 'fixture',
+    toolName: 'sequence',
+    arguments: {},
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    toolCallId: 'tool-1',
+    cwd: '/tmp',
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(written, [
+    { kind: 'client.capability.accepted', invocationId: 'progress-invocation' },
+    {
+      kind: 'client.capability.progress',
+      invocationId: 'progress-invocation',
+      current: 1,
+      total: 3,
+    },
+    {
+      kind: 'client.capability.progress',
+      invocationId: 'progress-invocation',
+      current: 2,
+      total: 3,
+    },
+    {
+      kind: 'client.capability.result',
+      invocationId: 'progress-invocation',
+      result: { content: [] },
+    },
+  ]);
+  channel.close(new Error('test complete'));
+});

--- a/packages/runtime-host/src/__tests__/client-capability-channel.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-channel.test.ts
@@ -216,14 +216,16 @@ test('Client Capability channel forwards admitted tool progress before the resul
   const written: unknown[] = [];
   let channel!: ClientCapabilityChannel;
   const provider: ClientCapabilityProvider = {
-    offers: () => [{
-      offerId: 'fixture',
-      version: '0',
-      affinity: 'call',
-      hostPathAccess: 'cwd',
-      label: 'Fixture',
-      tools: [{ serverId: 'fixture', name: 'sequence', inputSchema: { type: 'object' } }],
-    }],
+    offers: () => [
+      {
+        offerId: 'fixture',
+        version: '0',
+        affinity: 'call',
+        hostPathAccess: 'cwd',
+        label: 'Fixture',
+        tools: [{ serverId: 'fixture', name: 'sequence', inputSchema: { type: 'object' } }],
+      },
+    ],
     call: async (_frame, options) => {
       await options.accept();
       options.progress?.(1, 3);
@@ -235,10 +237,12 @@ test('Client Capability channel forwards admitted tool progress before the resul
     write: async (frame) => {
       written.push(frame);
       if (frame.kind === 'client.capability.accepted') {
-        queueMicrotask(() => channel.accept({
-          kind: 'client.capability.admitted',
-          invocationId: frame.invocationId,
-        }));
+        queueMicrotask(() =>
+          channel.accept({
+            kind: 'client.capability.admitted',
+            invocationId: frame.invocationId,
+          }),
+        );
       }
     },
     replace: async (input) => {

--- a/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/client-capability-coordinator.test.ts
@@ -152,6 +152,7 @@ describe('Host Client Capability coordinator', () => {
                 serverId: 'remote',
                 name: 'inspect',
                 inputSchema: { type: 'object' },
+                activityKind: 'computer',
               },
             ],
           },
@@ -164,6 +165,7 @@ describe('Host Client Capability coordinator', () => {
     const snapshot = coordinator.snapshotForSession('session-a');
     assert.ok(snapshot);
     assert.equal(snapshot.tools[0]?.categoryHint, 'client_capability');
+    assert.equal(snapshot.tools[0]?.activityKind, 'tool');
     await invoke(snapshot.tools[0]);
     assert.ok(isRecord(observedCall));
     assert.equal(Object.hasOwn(observedCall, 'cwd'), false);
@@ -213,6 +215,7 @@ describe('Host Client Capability coordinator', () => {
               serverId: 'remote',
               name: 'inspect',
               inputSchema: { type: 'object' },
+              activityKind: 'computer',
             },
           ],
         },
@@ -228,6 +231,7 @@ describe('Host Client Capability coordinator', () => {
     assert.ok(snapshot);
     const tool = snapshot.tools[0] ?? assert.fail('Expected trusted provider tool');
     assert.equal(tool.categoryHint, 'custom_tool');
+    assert.equal(tool.activityKind, 'computer');
     const result = await tool.impl(
       {},
       {

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -1458,19 +1458,23 @@ describe('Runtime Host bootstrap protocol', () => {
 test('Client Capability tool descriptors preserve only known activity kinds', () => {
   const input = {
     registrationId: 'registration-1',
-    offers: [{
-      offerId: 'desktop_computer_use',
-      version: '0',
-      affinity: 'session',
-      hostPathAccess: 'cwd',
-      label: 'Computer Use',
-      tools: [{
-        serverId: 'desktop_computer_use',
-        name: 'maka_computer',
-        inputSchema: { type: 'object' },
-        activityKind: 'computer',
-      }],
-    }],
+    offers: [
+      {
+        offerId: 'desktop_computer_use',
+        version: '0',
+        affinity: 'session',
+        hostPathAccess: 'cwd',
+        label: 'Computer Use',
+        tools: [
+          {
+            serverId: 'desktop_computer_use',
+            name: 'maka_computer',
+            inputSchema: { type: 'object' },
+            activityKind: 'computer',
+          },
+        ],
+      },
+    ],
   };
 
   assert.equal(
@@ -1478,13 +1482,16 @@ test('Client Capability tool descriptors preserve only known activity kinds', ()
     'computer',
   );
   assert.throws(
-    () => decodeClientCapabilityReplaceInput({
-      ...input,
-      offers: [{
-        ...input.offers[0],
-        tools: [{ ...input.offers[0]!.tools[0], activityKind: 'desktop' }],
-      }],
-    }),
+    () =>
+      decodeClientCapabilityReplaceInput({
+        ...input,
+        offers: [
+          {
+            ...input.offers[0],
+            tools: [{ ...input.offers[0]!.tools[0], activityKind: 'desktop' }],
+          },
+        ],
+      }),
     isInvalidFrame,
   );
 });
@@ -1505,21 +1512,23 @@ test('Client Capability progress frames require bounded monotonic coordinates', 
     },
   );
   assert.throws(
-    () => decodeClientFrame({
-      kind: 'client.capability.progress',
-      invocationId: 'invocation-1',
-      current: 12,
-      total: 11,
-    }),
+    () =>
+      decodeClientFrame({
+        kind: 'client.capability.progress',
+        invocationId: 'invocation-1',
+        current: 12,
+        total: 11,
+      }),
     isInvalidFrame,
   );
   assert.throws(
-    () => decodeClientFrame({
-      kind: 'client.capability.progress',
-      invocationId: 'invocation-1',
-      current: 1,
-      total: 1_025,
-    }),
+    () =>
+      decodeClientFrame({
+        kind: 'client.capability.progress',
+        invocationId: 'invocation-1',
+        current: 1,
+        total: 1_025,
+      }),
     isInvalidFrame,
   );
 });

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -23,6 +23,7 @@ import { describe, test } from 'node:test';
 import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_COUNT } from '@maka/core/attachments';
 import { TOOL_OUTPUT_DELTA_MAX_CHARS } from '@maka/core/events';
 import {
+  decodeClientCapabilityReplaceInput,
   decodeClientFrame,
   decodeHostFrame,
   decodeHostRegistration,
@@ -155,6 +156,12 @@ describe('Runtime Host bootstrap protocol', () => {
     // Epoch 37 still speaks `execute`. Frame decoders now reject it, so such a
     // peer would fail mid-Session rather than at connect.
     assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 37);
+  });
+
+  test('publishes a new compatibility epoch for Client Capability progress', () => {
+    // Epoch 38 peers reject the additional tool descriptor field and progress
+    // frame, so the capability must be negotiated at a newer epoch.
+    assert.ok(RUNTIME_HOST_COMPATIBILITY_EPOCH > 38);
   });
 
   test('selects the highest mutually supported protocol and rejects a gap', () => {
@@ -1446,6 +1453,75 @@ describe('Runtime Host bootstrap protocol', () => {
         error instanceof RuntimeHostProtocolError && error.code === 'frame_too_large',
     );
   });
+});
+
+test('Client Capability tool descriptors preserve only known activity kinds', () => {
+  const input = {
+    registrationId: 'registration-1',
+    offers: [{
+      offerId: 'desktop_computer_use',
+      version: '0',
+      affinity: 'session',
+      hostPathAccess: 'cwd',
+      label: 'Computer Use',
+      tools: [{
+        serverId: 'desktop_computer_use',
+        name: 'maka_computer',
+        inputSchema: { type: 'object' },
+        activityKind: 'computer',
+      }],
+    }],
+  };
+
+  assert.equal(
+    decodeClientCapabilityReplaceInput(input).offers[0]?.tools[0]?.activityKind,
+    'computer',
+  );
+  assert.throws(
+    () => decodeClientCapabilityReplaceInput({
+      ...input,
+      offers: [{
+        ...input.offers[0],
+        tools: [{ ...input.offers[0]!.tools[0], activityKind: 'desktop' }],
+      }],
+    }),
+    isInvalidFrame,
+  );
+});
+
+test('Client Capability progress frames require bounded monotonic coordinates', () => {
+  assert.deepEqual(
+    decodeClientFrame({
+      kind: 'client.capability.progress',
+      invocationId: 'invocation-1',
+      current: 7,
+      total: 11,
+    }),
+    {
+      kind: 'client.capability.progress',
+      invocationId: 'invocation-1',
+      current: 7,
+      total: 11,
+    },
+  );
+  assert.throws(
+    () => decodeClientFrame({
+      kind: 'client.capability.progress',
+      invocationId: 'invocation-1',
+      current: 12,
+      total: 11,
+    }),
+    isInvalidFrame,
+  );
+  assert.throws(
+    () => decodeClientFrame({
+      kind: 'client.capability.progress',
+      invocationId: 'invocation-1',
+      current: 1,
+      total: 1_025,
+    }),
+    isInvalidFrame,
+  );
 });
 
 function isInvalidFrame(error: unknown): boolean {

--- a/packages/runtime-host/src/client/client-capability-channel.ts
+++ b/packages/runtime-host/src/client/client-capability-channel.ts
@@ -283,6 +283,7 @@ export class ClientCapabilityChannel {
     execute: (options: {
       readonly signal: AbortSignal;
       accept(): Promise<void>;
+      progress(current: number, total: number): void;
     }) => Promise<ReturnType<typeof decodeClientCapabilityResult>>,
   ): Promise<void> {
     let accepted = false;
@@ -305,10 +306,30 @@ export class ClientCapabilityChannel {
       return accepting;
     };
     try {
+      const progress = (current: number, total: number): void => {
+        if (
+          !accepted ||
+          invocation.released ||
+          !Number.isInteger(current) ||
+          !Number.isInteger(total) ||
+          current < 0 ||
+          total < 1 ||
+          current > total
+        ) {
+          return;
+        }
+        void this.#options.write({
+          kind: 'client.capability.progress',
+          invocationId,
+          current,
+          total,
+        }).catch((error: unknown) => this.#options.onFailure(asError(error)));
+      };
       const result = decodeClientCapabilityResult(
         await execute({
           signal: invocation.controller.signal,
           accept,
+          progress,
         }),
       );
       if (invocation.released) return;

--- a/packages/runtime-host/src/client/client-capability-channel.ts
+++ b/packages/runtime-host/src/client/client-capability-channel.ts
@@ -318,12 +318,14 @@ export class ClientCapabilityChannel {
         ) {
           return;
         }
-        void this.#options.write({
-          kind: 'client.capability.progress',
-          invocationId,
-          current,
-          total,
-        }).catch((error: unknown) => this.#options.onFailure(asError(error)));
+        void this.#options
+          .write({
+            kind: 'client.capability.progress',
+            invocationId,
+            current,
+            total,
+          })
+          .catch((error: unknown) => this.#options.onFailure(asError(error)));
       };
       const result = decodeClientCapabilityResult(
         await execute({

--- a/packages/runtime-host/src/client/client-capability.ts
+++ b/packages/runtime-host/src/client/client-capability.ts
@@ -35,6 +35,8 @@ export interface ClientCapabilityProvider {
       readonly signal: AbortSignal;
       /** Await immediately before crossing the provider's irreversible admission cut. */
       accept(): Promise<void>;
+      /** Publish bounded live progress after admission. */
+      progress?(current: number, total: number): void;
     },
   ): Promise<ClientCapabilityCallResult>;
   callService?(

--- a/packages/runtime-host/src/protocol/client-capability.ts
+++ b/packages/runtime-host/src/protocol/client-capability.ts
@@ -18,6 +18,10 @@
  */
 
 import {
+  TOOL_ACTIVITY_KINDS,
+  type ToolActivityKind,
+} from '@maka/core/events';
+import {
   assertExactKeys,
   requireCount,
   requireEntityId,
@@ -42,6 +46,7 @@ export interface ClientCapabilityToolDescriptor {
   readonly description?: string;
   readonly inputSchema: Record<string, unknown>;
   readonly annotations?: ClientCapabilityToolAnnotations;
+  readonly activityKind?: ToolActivityKind;
 }
 
 export type ClientCapabilityContentBlock =
@@ -79,6 +84,7 @@ export const CLIENT_CAPABILITY_MAX_TOOLS = 256;
 export const CLIENT_CAPABILITY_MAX_MANIFEST_BYTES = 56 * 1024;
 export const CLIENT_CAPABILITY_MAX_RESULT_BYTES = 24 * 1024 * 1024;
 export const CLIENT_CAPABILITY_RESULT_CHUNK_MAX_BYTES = 36 * 1024;
+export const CLIENT_CAPABILITY_MAX_PROGRESS_TOTAL = 1_024;
 export const CLIENT_CAPABILITY_MAX_RESULT_CHUNKS = Math.ceil(
   CLIENT_CAPABILITY_MAX_RESULT_BYTES / CLIENT_CAPABILITY_RESULT_CHUNK_MAX_BYTES,
 );
@@ -199,6 +205,13 @@ export interface ClientCapabilityFailedFrame {
   readonly message: string;
 }
 
+export interface ClientCapabilityProgressFrame {
+  readonly kind: 'client.capability.progress';
+  readonly invocationId: string;
+  readonly current: number;
+  readonly total: number;
+}
+
 export interface ClientCapabilityResultFrame {
   readonly kind: 'client.capability.result';
   readonly invocationId: string;
@@ -223,6 +236,7 @@ export type ClientCapabilityClientFrame =
   | ClientCapabilityAcceptedFrame
   | ClientCapabilityRejectedFrame
   | ClientCapabilityFailedFrame
+  | ClientCapabilityProgressFrame
   | ClientCapabilityResultFrame
   | ClientCapabilityResultStartFrame
   | ClientCapabilityResultChunkFrame;
@@ -388,6 +402,29 @@ export function decodeClientCapabilityClientFrame(value: unknown): ClientCapabil
         invocationId: requireEntityId(frame.invocationId, 'invocationId'),
         message: requireString(frame.message, 'message', 4_096),
       };
+    case 'client.capability.progress': {
+      assertExactKeys(frame, 'Client Capability progress frame', [
+        'kind',
+        'invocationId',
+        'current',
+        'total',
+      ]);
+      const current = requireCount(frame.current, 'current');
+      const total = requireCount(frame.total, 'total');
+      if (
+        total === 0 ||
+        total > CLIENT_CAPABILITY_MAX_PROGRESS_TOTAL ||
+        current > total
+      ) {
+        throw invalidProtocolFrame('Invalid Client Capability progress bounds');
+      }
+      return {
+        kind: frame.kind,
+        invocationId: requireEntityId(frame.invocationId, 'invocationId'),
+        current,
+        total,
+      };
+    }
     case 'client.capability.result':
       assertExactKeys(frame, 'Client Capability result frame', ['kind', 'invocationId', 'result']);
       if (jsonByteLength(frame.result) > CLIENT_CAPABILITY_INLINE_RESULT_MAX_BYTES) {
@@ -612,7 +649,7 @@ function decodeToolDescriptor(value: unknown): ClientCapabilityToolDescriptor {
     record,
     'Client Capability tool',
     ['serverId', 'name', 'inputSchema'],
-    ['description', 'annotations'],
+    ['description', 'annotations', 'activityKind'],
   );
   const inputSchema = decodeJsonRecord(record.inputSchema, 'inputSchema');
   if (jsonByteLength(inputSchema) > 32 * 1024) {
@@ -632,10 +669,23 @@ function decodeToolDescriptor(value: unknown): ClientCapabilityToolDescriptor {
           ),
         }),
     inputSchema,
+    ...(record.activityKind === undefined
+      ? {}
+      : { activityKind: decodeToolActivityKind(record.activityKind) }),
     ...(record.annotations === undefined
       ? {}
       : { annotations: decodeToolAnnotations(record.annotations) }),
   };
+}
+
+function decodeToolActivityKind(value: unknown): ToolActivityKind {
+  if (
+    typeof value === 'string' &&
+    (TOOL_ACTIVITY_KINDS as readonly string[]).includes(value)
+  ) {
+    return value as ToolActivityKind;
+  }
+  throw invalidProtocolFrame('Invalid Client Capability tool activity kind');
 }
 
 const CLIENT_CAPABILITY_SCHEMA_TYPES = new Set([
@@ -1058,6 +1108,7 @@ const CLIENT_CAPABILITY_CLIENT_FRAME_KINDS = new Set<ClientCapabilityClientFrame
   'client.capability.accepted',
   'client.capability.rejected',
   'client.capability.failed',
+  'client.capability.progress',
   'client.capability.result',
   'client.capability.result_start',
   'client.capability.result_chunk',

--- a/packages/runtime-host/src/protocol/client-capability.ts
+++ b/packages/runtime-host/src/protocol/client-capability.ts
@@ -17,10 +17,7 @@
  * under the License.
  */
 
-import {
-  TOOL_ACTIVITY_KINDS,
-  type ToolActivityKind,
-} from '@maka/core/events';
+import { TOOL_ACTIVITY_KINDS, type ToolActivityKind } from '@maka/core/events';
 import {
   assertExactKeys,
   requireCount,
@@ -411,11 +408,7 @@ export function decodeClientCapabilityClientFrame(value: unknown): ClientCapabil
       ]);
       const current = requireCount(frame.current, 'current');
       const total = requireCount(frame.total, 'total');
-      if (
-        total === 0 ||
-        total > CLIENT_CAPABILITY_MAX_PROGRESS_TOTAL ||
-        current > total
-      ) {
+      if (total === 0 || total > CLIENT_CAPABILITY_MAX_PROGRESS_TOTAL || current > total) {
         throw invalidProtocolFrame('Invalid Client Capability progress bounds');
       }
       return {
@@ -679,10 +672,7 @@ function decodeToolDescriptor(value: unknown): ClientCapabilityToolDescriptor {
 }
 
 function decodeToolActivityKind(value: unknown): ToolActivityKind {
-  if (
-    typeof value === 'string' &&
-    (TOOL_ACTIVITY_KINDS as readonly string[]).includes(value)
-  ) {
+  if (typeof value === 'string' && (TOOL_ACTIVITY_KINDS as readonly string[]).includes(value)) {
     return value as ToolActivityKind;
   }
   throw invalidProtocolFrame('Invalid Client Capability tool activity kind');

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -91,7 +91,9 @@ export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;
 // Increment when the same protocol version no longer guarantees safe Client-Host
 // interoperability. Mismatches are rejected before domain commands are admitted.
-export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 38 as const;
+export const RUNTIME_HOST_COMPATIBILITY_EPOCH = 39 as const;
+// 39: Client Capability tool descriptors carry trusted activity semantics and
+// invocations can stream bounded progress frames.
 // 38: `execute` is no longer a permission mode. Frame decoders reject it, so a
 // peer that still sends it would fail mid-Session rather than at connect.
 // 37: External Session catalog queries carry a search term.

--- a/packages/runtime-host/src/server/client-capability-coordinator.ts
+++ b/packages/runtime-host/src/server/client-capability-coordinator.ts
@@ -518,6 +518,8 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
         categoryHint: 'custom_tool',
         recoveryMode: 'outcome_unknown',
         executionLocation: 'remote',
+        activityKindForDescriptor: (descriptor) =>
+          trustedClientToolActivityKind(descriptor),
       }),
     ];
     const groups = selected.map(({ offer: binding }) => ({
@@ -957,6 +959,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
           options.context,
           options.signal,
           options.timeoutMs ?? DEFAULT_CALL_TIMEOUT_MS,
+          options.emitProgress,
         );
       },
     };
@@ -1184,6 +1187,12 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
     }
     return false;
   }
+}
+
+function trustedClientToolActivityKind(
+  descriptor: ClientCapabilityToolDescriptor,
+): MakaTool['activityKind'] {
+  return descriptor.activityKind;
 }
 
 function freezeRegistration(

--- a/packages/runtime-host/src/server/client-capability-coordinator.ts
+++ b/packages/runtime-host/src/server/client-capability-coordinator.ts
@@ -518,8 +518,7 @@ export class HostClientCapabilityCoordinator implements ClientCapabilityService 
         categoryHint: 'custom_tool',
         recoveryMode: 'outcome_unknown',
         executionLocation: 'remote',
-        activityKindForDescriptor: (descriptor) =>
-          trustedClientToolActivityKind(descriptor),
+        activityKindForDescriptor: (descriptor) => trustedClientToolActivityKind(descriptor),
       }),
     ];
     const groups = selected.map(({ offer: binding }) => ({

--- a/packages/runtime-host/src/server/client-capability-invocation-broker.ts
+++ b/packages/runtime-host/src/server/client-capability-invocation-broker.ts
@@ -323,10 +323,7 @@ export class ClientCapabilityInvocationBroker<
         }
         if (
           invocation.progress &&
-          (
-            frame.total !== invocation.progress.total ||
-            frame.current < invocation.progress.current
-          )
+          (frame.total !== invocation.progress.total || frame.current < invocation.progress.current)
         ) {
           throw new Error('Client Capability progress moved backwards or changed total');
         }

--- a/packages/runtime-host/src/server/client-capability-invocation-broker.ts
+++ b/packages/runtime-host/src/server/client-capability-invocation-broker.ts
@@ -77,8 +77,10 @@ interface InvocationState<Registration extends ClientCapabilityInvocationRegistr
   readonly reject: (error: Error) => void;
   readonly signal?: AbortSignal;
   readonly onAbort?: () => void;
+  readonly onProgress?: (current: number, total: number) => void;
   readonly timer: NodeJS.Timeout;
   phase: 'dispatched' | 'accepted' | 'chunks';
+  progress?: { current: number; total: number };
   chunks?: {
     readonly byteLength: number;
     readonly chunkCount: number;
@@ -114,8 +116,9 @@ export class ClientCapabilityInvocationBroker<
     context: ClientCapabilityInvocationContext,
     signal: AbortSignal | undefined,
     timeoutMs: number,
+    onProgress?: (current: number, total: number) => void,
   ): Promise<ClientCapabilityCallResult> {
-    return this.#invoke(registration, signal, timeoutMs, (invocationId) => ({
+    return this.#invoke(registration, signal, timeoutMs, onProgress, (invocationId) => ({
       kind: 'client.capability.call',
       invocationId,
       registrationId: registration.registrationId,
@@ -139,7 +142,7 @@ export class ClientCapabilityInvocationBroker<
     signal: AbortSignal | undefined,
     timeoutMs: number,
   ): Promise<ClientCapabilityCallResult> {
-    return this.#invoke(registration, signal, timeoutMs, (invocationId) => ({
+    return this.#invoke(registration, signal, timeoutMs, undefined, (invocationId) => ({
       kind: 'client.capability.service_call',
       invocationId,
       registrationId: registration.registrationId,
@@ -154,6 +157,7 @@ export class ClientCapabilityInvocationBroker<
     registration: Registration,
     signal: AbortSignal | undefined,
     timeoutMs: number,
+    onProgress: ((current: number, total: number) => void) | undefined,
     frameFor: (invocationId: string) => ClientCapabilityHostFrame,
   ): Promise<ClientCapabilityCallResult> {
     const sender = this.#senderFor(registration.connectionId);
@@ -222,6 +226,7 @@ export class ClientCapabilityInvocationBroker<
         reject,
         signal,
         onAbort,
+        onProgress,
         timer,
         phase: 'dispatched',
       };
@@ -311,6 +316,23 @@ export class ClientCapabilityInvocationBroker<
           new ClientCapabilityInvocationError('provider_failed', frame.message),
           true,
         );
+        return;
+      case 'client.capability.progress':
+        if (invocation.phase !== 'accepted' && invocation.phase !== 'chunks') {
+          throw new Error('Client Capability progress arrived before acceptance');
+        }
+        if (
+          invocation.progress &&
+          (
+            frame.total !== invocation.progress.total ||
+            frame.current < invocation.progress.current
+          )
+        ) {
+          throw new Error('Client Capability progress moved backwards or changed total');
+        }
+        if (frame.current === invocation.progress?.current) return;
+        invocation.progress = { current: frame.current, total: frame.total };
+        invocation.onProgress?.(frame.current, frame.total);
         return;
       case 'client.capability.result':
         if (invocation.phase !== 'accepted') {

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -1004,6 +1004,7 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     // press, so the host can take a step, look again with its own eyes, and
     // take the next.
     const dispatched: string[] = [];
+    const progress: Array<[number, number]> = [];
     let captures = 0;
     const backend = fakeBackend() as CuDispatchBackend & {
       observeApp: NonNullable<CuDispatchBackend['observeApp']>;
@@ -1042,13 +1043,17 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
         observation_id: JSON.parse(observed.text).observation_id,
         steps: [{ label: '7' }, { label: '×' }, { label: '8' }, { label: '=' }],
       } as never,
-      ctx(undefined, { toolCallId: 'sequence' }),
+      ctx(undefined, {
+        toolCallId: 'sequence',
+        emitProgress: (current, total) => progress.push([current, total]),
+      }),
     )) as { text: string; modelText?: string };
 
     assert.deepEqual(dispatched, ['1', '2', '3', '4']);
     // Three re-observations between the four steps, plus the closing one.
     assert.equal(captures, 4);
     assert.match(result.text, /ok \(4 of 4 steps\)/);
+    assert.deepEqual(progress, [[0, 4], [1, 4], [2, 4], [3, 4], [4, 4]]);
   });
 
   test('a sequence stops at the step it cannot resolve, and says which', async () => {

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -1053,7 +1053,13 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     // Three re-observations between the four steps, plus the closing one.
     assert.equal(captures, 4);
     assert.match(result.text, /ok \(4 of 4 steps\)/);
-    assert.deepEqual(progress, [[0, 4], [1, 4], [2, 4], [3, 4], [4, 4]]);
+    assert.deepEqual(progress, [
+      [0, 4],
+      [1, 4],
+      [2, 4],
+      [3, 4],
+      [4, 4],
+    ]);
   });
 
   test('a sequence stops at the step it cannot resolve, and says which', async () => {

--- a/packages/runtime/src/__tests__/mcp-tools.test.ts
+++ b/packages/runtime/src/__tests__/mcp-tools.test.ts
@@ -243,6 +243,20 @@ test('a trusted composition can apply the Client Capability permission floor and
   });
 });
 
+test('a trusted composition can preserve provider-owned activity semantics', () => {
+  const [tool] = buildMcpTools(
+    fakeProvider(
+      [boundTool(
+        descriptor('desktop_computer_use', 'maka_computer'),
+        binding('desktop-computer-binding'),
+      )],
+      async () => ({ content: [{ type: 'text', text: 'ok' }] }),
+    ),
+    { activityKindForDescriptor: () => 'computer' },
+  );
+  assert.equal(tool?.activityKind, 'computer');
+});
+
 test('mcpProxyToolName is stable, provider-safe, and bounded to 64 chars', () => {
   const first = mcpProxyToolName('服 务/'.repeat(20), 'tool.with punctuation '.repeat(20));
   const second = mcpProxyToolName('服 务/'.repeat(20), 'tool.with punctuation '.repeat(20));

--- a/packages/runtime/src/__tests__/mcp-tools.test.ts
+++ b/packages/runtime/src/__tests__/mcp-tools.test.ts
@@ -246,10 +246,12 @@ test('a trusted composition can apply the Client Capability permission floor and
 test('a trusted composition can preserve provider-owned activity semantics', () => {
   const [tool] = buildMcpTools(
     fakeProvider(
-      [boundTool(
-        descriptor('desktop_computer_use', 'maka_computer'),
-        binding('desktop-computer-binding'),
-      )],
+      [
+        boundTool(
+          descriptor('desktop_computer_use', 'maka_computer'),
+          binding('desktop-computer-binding'),
+        ),
+      ],
       async () => ({ content: [{ type: 'text', text: 'ok' }] }),
     ),
     { activityKindForDescriptor: () => 'computer' },

--- a/packages/runtime/src/__tests__/tool-runtime-progress.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-progress.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { decodeToolStepProgress, type SessionEvent } from '@maka/core/events';
+import type { LlmConnection } from '@maka/core/llm-connections';
+import type { SessionHeader } from '@maka/core/session';
+
+import { createTestToolRuntime } from './execution-boundary-test-helpers.js';
+import type { MakaTool } from '../tool-runtime.js';
+
+test('ToolRuntime emits only valid progress through the shared codec', async () => {
+  const events: SessionEvent[] = [];
+  const runtime = createTestToolRuntime({
+    sessionId: 'session-1',
+    header: testHeader(),
+    connection: testConnection(),
+    modelId: 'test-model',
+    appendMessage: async () => {},
+    newId: nextId(),
+    now: () => 1,
+    getPermissionPauseTarget: () => null,
+  });
+  const tool: MakaTool = {
+    name: 'ProgressTool',
+    description: 'Report bounded progress',
+    parameters: {},
+    impl: async (_args, context) => {
+      context.emitProgress?.(0, 2);
+      context.emitProgress?.(1, 2);
+      context.emitProgress?.(3, 2);
+      return { ok: true };
+    },
+  };
+
+  await runtime.settleToolCall({
+    tool,
+    turnId: 'turn-1',
+    toolCallId: 'tool-1',
+    input: {},
+    abortSignal: new AbortController().signal,
+    eventSink: {
+      push: (event) => events.push(event),
+      pushAndWaitUntilConsumed: async (event) => {
+        events.push(event);
+      },
+    },
+  });
+
+  const progress = events.flatMap((event) =>
+    event.type === 'tool_progress' ? [decodeToolStepProgress(event.chunk)] : [],
+  );
+  assert.deepEqual(progress, [
+    { current: 0, total: 2 },
+    { current: 1, total: 2 },
+  ]);
+});
+
+function testHeader(): SessionHeader {
+  return {
+    id: 'session-1',
+    workspaceRoot: '/tmp/maka',
+    cwd: '/tmp/maka',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Test',
+    titleIsManual: true,
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test',
+    connectionLocked: true,
+    model: 'test-model',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+}
+
+function testConnection(): LlmConnection {
+  return {
+    slug: 'test',
+    name: 'Test',
+    providerType: 'anthropic',
+    defaultModel: 'test-model',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function nextId(): () => string {
+  let id = 0;
+  return () => `id-${++id}`;
+}

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -1592,7 +1592,7 @@ export function buildComputerUseTools(deps: {
     },
     impl: async (
       args,
-      { abortSignal, sessionId, turnId, toolCallId },
+      { abortSignal, sessionId, turnId, toolCallId, emitProgress },
     ): Promise<ComputerToolResult> => {
       if (abortSignal.aborted) return { text: 'computer aborted before start' };
       const input = snapshotComputerParams(computerParams.parse(args));
@@ -1702,6 +1702,7 @@ export function buildComputerUseTools(deps: {
               : undefined;
             const done: Array<{ step: number; label: string; ok: boolean; detail?: string }> = [];
             let stopped: string | undefined;
+            emitProgress?.(0, input.steps.length);
             for (const [index, step] of input.steps.entries()) {
               // Every step after the first looks again first. The host is the
               // one holding the frame here, and it is a frame it captured a
@@ -1754,6 +1755,7 @@ export function buildComputerUseTools(deps: {
                   ok: false,
                   detail: 'no control with that label',
                 });
+                emitProgress?.(done.length, input.steps.length);
                 break;
               }
               if (matches.length > 1) {
@@ -1764,6 +1766,7 @@ export function buildComputerUseTools(deps: {
                   ok: false,
                   detail: `${matches.length} controls share that label; add a role`,
                 });
+                emitProgress?.(done.length, input.steps.length);
                 break;
               }
               const element = matches[0]!;
@@ -1827,9 +1830,11 @@ export function buildComputerUseTools(deps: {
                     ? stepResult.outcome.error
                     : 'capture_failed';
                 done.push({ step: index + 1, label: step.label, ok: false });
+                emitProgress?.(done.length, input.steps.length);
                 break;
               }
               done.push({ step: index + 1, label: step.label, ok: true });
+              emitProgress?.(done.length, input.steps.length);
             }
             // One observation at the end, whatever happened: the model needs a
             // current frame either to carry on or to work out what went wrong.

--- a/packages/runtime/src/mcp-tools.ts
+++ b/packages/runtime/src/mcp-tools.ts
@@ -19,7 +19,13 @@
 
 import { createHash } from 'node:crypto';
 import { jsonSchema } from 'ai';
-import type { McpCallResult, McpToolBinding, McpToolSnapshot } from '@maka/core/mcp';
+import type { ToolActivityKind } from '@maka/core/events';
+import type {
+  McpCallResult,
+  McpToolBinding,
+  McpToolDescriptor,
+  McpToolSnapshot,
+} from '@maka/core/mcp';
 import type { ToolCategory } from '@maka/core/permission';
 import type { ToolRecoveryMode } from '@maka/core/runtime-event';
 import type { ToolResultContentPart, ToolResultOutput } from './model-protocol.js';
@@ -46,6 +52,7 @@ export interface McpToolCallOptions {
   readonly signal?: AbortSignal;
   readonly timeoutMs?: number;
   readonly context: McpToolInvocationContext;
+  readonly emitProgress?: (current: number, total: number) => void;
 }
 
 export interface McpToolInvocationContext {
@@ -60,6 +67,9 @@ export interface BuildMcpToolsOptions {
   categoryHint?: ToolCategory;
   recoveryMode?: ToolRecoveryMode;
   executionLocation?: 'host' | 'remote';
+  activityKindForDescriptor?: (
+    descriptor: McpToolDescriptor,
+  ) => ToolActivityKind | undefined;
 }
 
 export function buildMcpTools(
@@ -82,7 +92,7 @@ export function buildMcpTools(
         descriptor.description?.trim() ||
         `MCP tool ${descriptor.name} provided by ${descriptor.serverId}`,
       displayName: descriptor.annotations?.title?.trim() || descriptor.name,
-      activityKind: 'tool',
+      activityKind: options.activityKindForDescriptor?.(descriptor) ?? 'tool',
       // MCP annotations are advisory provider claims, not a security boundary.
       // The trusted composition may select a stricter open-world category;
       // ordinary MCP servers retain the side-effecting network default.
@@ -116,6 +126,7 @@ export function buildMcpTools(
             toolCallId: context.toolCallId,
             cwd: context.cwd,
           },
+          ...(context.emitProgress ? { emitProgress: context.emitProgress } : {}),
         });
       },
       toModelOutput: ({ output }) => mcpResultToModelOutput(output),

--- a/packages/runtime/src/mcp-tools.ts
+++ b/packages/runtime/src/mcp-tools.ts
@@ -67,9 +67,7 @@ export interface BuildMcpToolsOptions {
   categoryHint?: ToolCategory;
   recoveryMode?: ToolRecoveryMode;
   executionLocation?: 'host' | 'remote';
-  activityKindForDescriptor?: (
-    descriptor: McpToolDescriptor,
-  ) => ToolActivityKind | undefined;
+  activityKindForDescriptor?: (descriptor: McpToolDescriptor) => ToolActivityKind | undefined;
 }
 
 export function buildMcpTools(

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -30,7 +30,7 @@ import {
   type SettleSandboxBoundaryRequest,
 } from '@maka/core/sandbox-boundary';
 import { serializedByteLength } from '@maka/core/serialized-byte-length';
-import { ToolOutcomeUnknownError } from '@maka/core/events';
+import { encodeToolStepProgress, ToolOutcomeUnknownError } from '@maka/core/events';
 import type {
   SandboxBoundaryDecisionAckEvent,
   SandboxBoundaryRequestEvent,
@@ -1340,22 +1340,15 @@ export class ToolRuntime {
           abortSignal: ctx.abortSignal,
           emitOutput: output.emit,
           emitProgress: (current, total) => {
-            if (
-              !Number.isInteger(current) ||
-              !Number.isInteger(total) ||
-              current < 0 ||
-              total < 1 ||
-              current > total
-            ) {
-              return;
-            }
+            const chunk = encodeToolStepProgress({ current, total });
+            if (!chunk) return;
             queue.push({
               type: 'tool_progress',
               id: this.input.newId(),
               turnId,
               ts: this.input.now(),
               toolUseId,
-              chunk: `steps:${current}/${total}`,
+              chunk,
               ...activityIdentity,
             });
           },

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -192,6 +192,8 @@ export interface MakaToolContext {
   operationId?: string;
   abortSignal: AbortSignal;
   emitOutput: (stream: ToolOutputStream, chunk: string) => void;
+  /** Live-only bounded progress for multi-step tools. */
+  emitProgress?: (current: number, total: number) => void;
   /** Diagnostic-only trace projection. It must never affect tool execution. */
   emitRunTrace?: (
     type:
@@ -1337,6 +1339,26 @@ export class ToolRuntime {
           ...(pushedCallEvent?.operationId ? { operationId: pushedCallEvent.operationId } : {}),
           abortSignal: ctx.abortSignal,
           emitOutput: output.emit,
+          emitProgress: (current, total) => {
+            if (
+              !Number.isInteger(current) ||
+              !Number.isInteger(total) ||
+              current < 0 ||
+              total < 1 ||
+              current > total
+            ) {
+              return;
+            }
+            queue.push({
+              type: 'tool_progress',
+              id: this.input.newId(),
+              turnId,
+              ts: this.input.now(),
+              toolUseId,
+              chunk: `steps:${current}/${total}`,
+              ...activityIdentity,
+            });
+          },
           ...(trace
             ? {
                 emitRunTrace: (

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -19,6 +19,7 @@
 
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
+import { encodeToolStepProgress } from '@maka/core/events';
 import {
   applyLiveTurnEvent,
   armLiveTurn,
@@ -397,12 +398,33 @@ describe('applyLiveTurnEvent', () => {
       id: 'event-2',
       turnId: 'turn-1',
       toolUseId: 'tool-1',
-      chunk: 'steps:1/2',
+      chunk: encodeToolStepProgress({ current: 1, total: 2 })!,
       ts: 101,
     });
 
     assert.deepEqual(projection.steps[0]?.tools[0]?.progress, { current: 1, total: 2 });
     assert.equal(projection.steps[0]?.tools[0]?.status, 'running');
+  });
+
+  it('ignores invalid step progress without clearing the last valid value', () => {
+    const valid = applyLiveTurnEvent(undefined, {
+      type: 'tool_progress',
+      id: 'event-1',
+      turnId: 'turn-1',
+      toolUseId: 'tool-1',
+      chunk: encodeToolStepProgress({ current: 1, total: 2 })!,
+      ts: 100,
+    });
+    const invalid = applyLiveTurnEvent(valid, {
+      type: 'tool_progress',
+      id: 'event-2',
+      turnId: 'turn-1',
+      toolUseId: 'tool-1',
+      chunk: 'steps:3/2',
+      ts: 101,
+    });
+
+    assert.deepEqual(invalid.steps[0]?.tools[0]?.progress, { current: 1, total: 2 });
   });
 
   it('preserves steering positions when an output-first tool receives its real step', () => {

--- a/packages/ui/src/__tests__/live-turn-projection.test.ts
+++ b/packages/ui/src/__tests__/live-turn-projection.test.ts
@@ -377,6 +377,34 @@ describe('applyLiveTurnEvent', () => {
     }]);
   });
 
+  it('projects bounded multi-step tool progress onto the running row', () => {
+    const started = applyLiveTurnEvent(undefined, {
+      type: 'tool_start',
+      id: 'event-1',
+      turnId: 'turn-1',
+      stepId: 'step-1',
+      toolUseId: 'tool-1',
+      toolName: 'mcp__desktop_computer_use__maka_computer',
+      activityKind: 'computer',
+      args: {
+        action: 'element_sequence',
+        steps: [{ label: '<text:1>' }, { label: '<text:1>' }],
+      },
+      ts: 100,
+    });
+    const projection = applyLiveTurnEvent(started, {
+      type: 'tool_progress',
+      id: 'event-2',
+      turnId: 'turn-1',
+      toolUseId: 'tool-1',
+      chunk: 'steps:1/2',
+      ts: 101,
+    });
+
+    assert.deepEqual(projection.steps[0]?.tools[0]?.progress, { current: 1, total: 2 });
+    assert.equal(projection.steps[0]?.tools[0]?.status, 'running');
+  });
+
   it('preserves steering positions when an output-first tool receives its real step', () => {
     const firstSteer = applyLiveTurnEvent(undefined, {
       type: 'steering_message', id: 'steer-event-1', messageId: 'steer-1',

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -21,9 +21,15 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createElement, type ReactNode } from 'react';
 import { renderToStaticMarkup as renderReactToStaticMarkup } from 'react-dom/server';
-import { ToolCallDetail } from '../tool-activity.js';
+import { computerUseModelCallArgs } from '@maka/core/computer-use';
+import { ToolCallDetail, ToolTrow } from '../tool-activity.js';
 import type { ToolActivityItem } from '../materialize.js';
 import { LocaleProvider } from '../locale-context.js';
+import {
+  computerActionLabel,
+  computerRunningLabel,
+  isComputerTool,
+} from '../tool-activity/computer-action-label.js';
 
 function renderToStaticMarkup(node: ReactNode, locale: 'zh' | 'en' = 'zh'): string {
   return renderReactToStaticMarkup(createElement(LocaleProvider, {
@@ -33,6 +39,66 @@ function renderToStaticMarkup(node: ReactNode, locale: 'zh' | 'en' = 'zh'): stri
 }
 
 describe('tool activity presentation', () => {
+  it('describes Computer Use proxy calls by action instead of the generic tool name', () => {
+    const item: ToolActivityItem = {
+      toolUseId: 'computer-observe',
+      toolName: 'mcp__desktop_computer_use__maka_computer',
+      displayName: 'Maka Computer',
+      activityKind: 'tool',
+      status: 'completed',
+      args: computerUseModelCallArgs({
+        action: 'observe',
+        app: '计算器',
+        window_id: 7,
+      }),
+    };
+
+    assert.equal(isComputerTool(item), true);
+    assert.equal(computerActionLabel(item, 'zh'), '观察「计算器」窗口');
+    const markup = renderToStaticMarkup(
+      createElement(ToolTrow, { items: [item] }),
+    );
+    assert.match(markup, /观察「计算器」窗口/);
+    assert.doesNotMatch(markup, /Maka Computer/);
+  });
+
+  it('inherits the confirmed target and exposes live sequence progress', () => {
+    const observed: ToolActivityItem = {
+      toolUseId: 'computer-observe',
+      toolName: 'maka_computer',
+      activityKind: 'computer',
+      status: 'completed',
+      args: computerUseModelCallArgs({
+        action: 'observe',
+        app: '计算器',
+        window_id: 7,
+      }),
+    };
+    const sequence: ToolActivityItem = {
+      toolUseId: 'computer-sequence',
+      toolName: 'maka_computer',
+      activityKind: 'computer',
+      status: 'running',
+      args: computerUseModelCallArgs({
+        action: 'element_sequence',
+        observation_id: '00000000-0000-0000-0000-000000000001',
+        steps: Array.from({ length: 11 }, (_, index) => ({ label: String(index) })),
+      }),
+      progress: { current: 7, total: 11 },
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(ToolTrow, { items: [observed, sequence] }),
+    );
+    assert.match(markup, /连续操作 11 个控件/);
+    assert.match(markup, /「计算器」窗口/);
+    assert.match(markup, />7\/11</);
+    assert.equal(
+      computerRunningLabel([observed, sequence], 'zh'),
+      '正在操作「计算器」窗口 · 连续操作第 7/11 步',
+    );
+  });
+
   it('contains a malformed persisted terminal result instead of crashing the renderer', () => {
     const malformed = {
       kind: 'terminal',

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -29,6 +29,7 @@ import {
 } from './chat-display-helpers.js';
 import { redactSecrets } from './redact.js';
 import { isProgressiveStreamingEnabled, isTimeDrivenMotionEnabled } from './streaming-presentation.js';
+import { computerRunningLabel } from './tool-activity/computer-action-label.js';
 import {
   Badge,
   Banner,
@@ -452,6 +453,7 @@ export const TurnView = memo(function TurnView(props: {
   // flat timeline. Settled turn identities are stable (memoized projections),
   // so this only recomputes for the turn whose timeline actually changed.
   const foldedTimeline = useMemo(() => foldTimeline(turn.timeline), [turn.timeline]);
+  const runningToolLabel = computerRunningLabel(turn.tools, locale);
   const conversationSegments = useMemo(
     () => splitTimelineAtUserMessages(foldedTimeline, showAssistantMessage),
     [foldedTimeline, showAssistantMessage],
@@ -684,6 +686,7 @@ export const TurnView = memo(function TurnView(props: {
                       <TurnRunningStatus
                         startedAt={turn.startedAt}
                         showSpinner={!toolSurfaceOwnsSpinner}
+                        activityLabel={runningToolLabel}
                       />
                     )
                   )}
@@ -974,7 +977,11 @@ const ELAPSED_TICK_MS = 1_000;
  * rare fallback path where streaming beat the user turn into the transcript;
  * the phrase then stands alone.
  */
-export function TurnRunningStatus(props: { startedAt?: number; showSpinner?: boolean }) {
+export function TurnRunningStatus(props: {
+  startedAt?: number;
+  showSpinner?: boolean;
+  activityLabel?: string;
+}) {
   const copy = getConversationCopy(useUiLocale()).messages;
   const phrases = copy.workingPhrases;
   const { startedAt } = props;
@@ -1016,7 +1023,12 @@ export function TurnRunningStatus(props: { startedAt?: number; showSpinner?: boo
   }, [phrases.length]);
 
   return (
-    <div className="maka-turn-processing" role="status" aria-label={copy.processing} ref={rootRef}>
+    <div
+      className="maka-turn-processing"
+      role="status"
+      aria-label={props.activityLabel ?? copy.processing}
+      ref={rootRef}
+    >
       {props.showSpinner !== false && (
         <Spinner size="md" shade="subtle" aria-hidden="true" />
       )}
@@ -1025,7 +1037,7 @@ export function TurnRunningStatus(props: { startedAt?: number; showSpinner?: boo
           its whole accessible name and the text is decoration. */}
       <span className="maka-turn-indicator-text" aria-hidden="true">
         <span className="maka-turn-working-phrase" data-fading={phraseFading || undefined}>
-          {phrases[phraseIndex] ?? copy.processing}
+          {props.activityLabel ?? phrases[phraseIndex] ?? copy.processing}
         </span>
         {elapsedMs !== undefined && (
           <>

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -17,7 +17,12 @@
  * under the License.
  */
 
-import type { MessageContent, ProviderRetryEvent, SessionEvent } from '@maka/core/events';
+import {
+  decodeToolStepProgress,
+  type MessageContent,
+  type ProviderRetryEvent,
+  type SessionEvent,
+} from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import type { UiLocale } from '@maka/core/ui-locale';
 import { materializeToolResultPreviewForActivity } from '@maka/core/tool-result-preview';
@@ -400,7 +405,7 @@ export function applyLiveTurnEvent(
     const base: ToolActivityItem = toolIndex >= 0
       ? step.tools[toolIndex]!
       : { toolUseId: event.toolUseId, toolName: 'Tool', status: 'running', args: undefined };
-    const progress = parseStepProgress(event.chunk);
+    const progress = decodeToolStepProgress(event.chunk);
     const tool: ToolActivityItem = {
       ...base,
       ...projectToolActivityIdentity(event),
@@ -511,20 +516,6 @@ function liveSteeringMessages(current: LiveTurnProjection): LiveSteeringProjecti
     ...(current.pendingSteering ?? []),
     ...current.steps.flatMap((step) => step.leadingSteering ?? []),
   ];
-}
-
-function parseStepProgress(
-  chunk: Extract<SessionEvent, { type: 'tool_progress' }>['chunk'],
-): ToolActivityItem['progress'] | undefined {
-  if (typeof chunk !== 'string') return undefined;
-  const match = /^steps:(\d+)\/(\d+)$/.exec(chunk);
-  if (!match) return undefined;
-  const current = Number(match[1]);
-  const total = Number(match[2]);
-  if (!Number.isInteger(current) || !Number.isInteger(total) || total < 1 || current > total) {
-    return undefined;
-  }
-  return { current, total };
 }
 
 function replaySafeDelta(

--- a/packages/ui/src/live-turn-projection.ts
+++ b/packages/ui/src/live-turn-projection.ts
@@ -30,7 +30,7 @@ import { applyThinkingComplete, applyThinkingDelta } from './thinking-stream.js'
 import type { StreamingDisplayRedactionState } from './streaming-display-redaction.js';
 import { applyToolOutputChunk } from './tool-output-stream.js';
 
-type LiveTurnContentEvent = Extract<SessionEvent, { type: 'thinking_delta' | 'thinking_complete' | 'text_delta' | 'text_complete' | 'tool_start' | 'tool_output_delta' | 'tool_result_preview' | 'tool_result' }>;
+type LiveTurnContentEvent = Extract<SessionEvent, { type: 'thinking_delta' | 'thinking_complete' | 'text_delta' | 'text_complete' | 'tool_start' | 'tool_output_delta' | 'tool_progress' | 'tool_result_preview' | 'tool_result' }>;
 
 export interface LiveThinkingProjection {
   text: string;
@@ -236,6 +236,7 @@ export function applyLiveTurnEvent(
     && event.type !== 'text_complete'
     && event.type !== 'tool_start'
     && event.type !== 'tool_output_delta'
+    && event.type !== 'tool_progress'
     && event.type !== 'tool_result_preview'
     && event.type !== 'tool_result'
   ) {
@@ -251,6 +252,7 @@ export function applyLiveTurnEvent(
     || event.type === 'text_complete';
   const existingToolStep = event.type === 'tool_start'
     || event.type === 'tool_output_delta'
+    || event.type === 'tool_progress'
     || event.type === 'tool_result_preview'
     || event.type === 'tool_result'
     ? prior.steps.find((candidate) => candidate.tools.some((tool) => tool.toolUseId === event.toolUseId))
@@ -393,6 +395,24 @@ export function applyLiveTurnEvent(
         ? step.tools.map((candidate, index) => index === toolIndex ? tool : candidate)
         : [...step.tools, tool],
     };
+  } else if (event.type === 'tool_progress') {
+    const toolIndex = step.tools.findIndex((candidate) => candidate.toolUseId === event.toolUseId);
+    const base: ToolActivityItem = toolIndex >= 0
+      ? step.tools[toolIndex]!
+      : { toolUseId: event.toolUseId, toolName: 'Tool', status: 'running', args: undefined };
+    const progress = parseStepProgress(event.chunk);
+    const tool: ToolActivityItem = {
+      ...base,
+      ...projectToolActivityIdentity(event),
+      status: isInFlightToolStatus(base.status) ? 'running' : base.status,
+      ...(progress ? { progress } : {}),
+    };
+    nextStep = {
+      ...step,
+      tools: toolIndex >= 0
+        ? step.tools.map((candidate, index) => index === toolIndex ? tool : candidate)
+        : [...step.tools, tool],
+    };
   } else if (event.type === 'tool_result_preview') {
     // Live-only open-facts: materialize into activity.result with empty bulk
     // so ToolTrow can Open without dual storage.
@@ -491,6 +511,20 @@ function liveSteeringMessages(current: LiveTurnProjection): LiveSteeringProjecti
     ...(current.pendingSteering ?? []),
     ...current.steps.flatMap((step) => step.leadingSteering ?? []),
   ];
+}
+
+function parseStepProgress(
+  chunk: Extract<SessionEvent, { type: 'tool_progress' }>['chunk'],
+): ToolActivityItem['progress'] | undefined {
+  if (typeof chunk !== 'string') return undefined;
+  const match = /^steps:(\d+)\/(\d+)$/.exec(chunk);
+  if (!match) return undefined;
+  const current = Number(match[1]);
+  const total = Number(match[2]);
+  if (!Number.isInteger(current) || !Number.isInteger(total) || total < 1 || current > total) {
+    return undefined;
+  }
+  return { current, total };
 }
 
 function replaySafeDelta(

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -34,6 +34,7 @@ import type {
   ShellRunUpdate,
   ToolActivityKind,
   ToolResultContent,
+  ToolStepProgress,
 } from '@maka/core/events';
 import type { ToolActivityStatus } from '@maka/core/tool-result-status';
 import type { ShellRunToolResult } from '@maka/core/shell-run-result';
@@ -99,7 +100,7 @@ export interface ToolActivityItem {
   result?: ToolResultContent;
   durationMs?: number;
   /** Live-only progress for a bounded multi-step tool invocation. */
-  progress?: { current: number; total: number };
+  progress?: ToolStepProgress;
   /**
    * Live streamed output buffer (PR-UI-12). Append-only from the
    * renderer's perspective — runtime side already enforces the

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -98,6 +98,8 @@ export interface ToolActivityItem {
   args: unknown;
   result?: ToolResultContent;
   durationMs?: number;
+  /** Live-only progress for a bounded multi-step tool invocation. */
+  progress?: { current: number; total: number };
   /**
    * Live streamed output buffer (PR-UI-12). Append-only from the
    * renderer's perspective — runtime side already enforces the

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -33,7 +33,12 @@ import { useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { useUiLocale } from './locale-context.js';
 import { type ToolActivityItem, type ToolOutputChunk } from './materialize.js';
 import { isConnectorTool, resolveToolDisplayName } from './tool-activity/display-name.js';
-import { computerActionLabel } from './tool-activity/computer-action-label.js';
+import {
+  computerActionLabel,
+  computerActionLabelIncludesTarget,
+  computerActionTarget,
+  isComputerTool,
+} from './tool-activity/computer-action-label.js';
 import {
   extractErrorText,
   isCancelledToolResult,
@@ -314,6 +319,7 @@ type ToolTrowSegment =
 
 function toolTrowSegments(items: ToolActivityItem[], locale: UiLocale): ToolTrowSegment[] {
   const segments: ToolTrowSegment[] = [];
+  let computerTarget: string | undefined;
   for (const item of items) {
     const rows = linkedAgentRows(item, locale);
     const previous = segments.at(-1);
@@ -322,7 +328,15 @@ function toolTrowSegments(items: ToolActivityItem[], locale: UiLocale): ToolTrow
       else segments.push({ kind: 'agents', key: item.toolUseId, rows });
       continue;
     }
-    const call = standardToolCall(item, locale);
+    const ownComputerTarget = computerActionTarget(item, locale);
+    if (ownComputerTarget) computerTarget = ownComputerTarget;
+    const call = standardToolCall(
+      item,
+      locale,
+      isComputerTool(item) && !computerActionLabelIncludesTarget(item)
+        ? computerTarget
+        : undefined,
+    );
     if (previous?.kind === 'tools') previous.calls.push(call);
     else segments.push({ kind: 'tools', key: item.toolUseId, calls: [call] });
   }
@@ -386,7 +400,11 @@ function LinkedAgentList(props: {
   );
 }
 
-function standardToolCall(item: ToolActivityItem, locale: UiLocale): ChatToolCallItem {
+function standardToolCall(
+  item: ToolActivityItem,
+  locale: UiLocale,
+  inferredTarget?: string,
+): ChatToolCallItem {
   return {
     key: item.toolUseId,
     // The name is what a person reads to tell one call from the next, and for
@@ -395,10 +413,12 @@ function standardToolCall(item: ToolActivityItem, locale: UiLocale): ChatToolCal
     // arguments says what happened instead.
     name: computerActionLabel(item, locale) ?? resolveToolDisplayName(item, locale),
     status: astryxToolStatus(item),
-    target: item.intent ? formatToolIntent(item.intent) : undefined,
+    target: item.intent ? formatToolIntent(item.intent) : inferredTarget,
     duration: formatDuration(item.durationMs) ?? undefined,
     errorMessage: toolCallErrorMessage(item, locale),
-    stats: outcomeWord(item, locale),
+    stats: item.progress && isInFlightToolStatus(item.status)
+      ? `${item.progress.current}/${item.progress.total}`
+      : outcomeWord(item, locale),
     ...diffStats(itemDiffs(item)),
     resultDetail: (
       <ToolDetailReveal>

--- a/packages/ui/src/tool-activity/computer-action-label.ts
+++ b/packages/ui/src/tool-activity/computer-action-label.ts
@@ -79,7 +79,11 @@ import { getToolActivityCopy, type ToolActivityCopy } from './copy.js';
 
 /** True for a row produced by the Computer Use tool. */
 export function isComputerTool(item: ToolActivityItem): boolean {
-  return item.toolName === 'maka_computer' || item.activityKind === 'computer';
+  return (
+    item.toolName === 'maka_computer' ||
+    item.toolName.endsWith('__maka_computer') ||
+    item.activityKind === 'computer'
+  );
 }
 
 /**
@@ -99,15 +103,64 @@ export function computerActionLabel(
   return describeAction(args, copy) ?? copy.fallback;
 }
 
+export function computerActionTarget(
+  item: ToolActivityItem,
+  locale: UiLocale,
+): string | undefined {
+  if (!isComputerTool(item)) return undefined;
+  const args = asRecord(item.args);
+  if (!args) return undefined;
+  const copy = getToolActivityCopy(locale).computer;
+  const app = displayable(str(args, 'app'));
+  if (app !== undefined) return copy.targetApp(app);
+  const windowId = int(args, 'window_id');
+  return windowId === undefined ? undefined : copy.targetWindow(windowId);
+}
+
+export function computerActionLabelIncludesTarget(item: ToolActivityItem): boolean {
+  const args = asRecord(item.args);
+  const action = str(args ?? {}, 'action');
+  return (
+    action === 'launch_app' ||
+    action === 'screenshot' ||
+    (action === 'observe' && str(args ?? {}, 'menu') === undefined)
+  );
+}
+
+export function computerRunningLabel(
+  items: readonly ToolActivityItem[],
+  locale: UiLocale,
+): string | undefined {
+  let target: string | undefined;
+  let active: ToolActivityItem | undefined;
+  for (const item of items) {
+    if (!isComputerTool(item)) continue;
+    target = computerActionTarget(item, locale) ?? target;
+    if (item.status === 'pending' || item.status === 'running') active = item;
+  }
+  if (!active) return undefined;
+  const copy = getToolActivityCopy(locale).computer;
+  const args = asRecord(active.args);
+  const actionName = str(args ?? {}, 'action');
+  if (actionName === 'element_sequence' && active.progress) {
+    return copy.runningSequence(active.progress.current, active.progress.total, target);
+  }
+  const action = computerActionLabel(active, locale) ?? copy.fallback;
+  return copy.runningAction(
+    action,
+    computerActionLabelIncludesTarget(active) ? undefined : target,
+  );
+}
+
 /**
  * The keys the projection declares by name, and the only ones read below.
  *
  * Not `keyof ComputerUseModelCallArgs`: that interface carries an index
  * signature for every other argument the model sent, so `keyof` widens to
- * `string | number` and the stale `windowId` this file used to read would type
- * check again. Filtering the index signature back out leaves the five names the
- * projection spells out, so renaming one there is a build error here rather
- * than a row that quietly reads "点击该元素".
+ * `string | number` and a stale camelCase name would type check again.
+ * Filtering the index signature back out leaves only names the projection
+ * spells out, so renaming one there is a build error here rather than a row
+ * that quietly loses its target.
  */
 type DeclaredArg<T> = keyof {
   [K in keyof T as string extends K ? never : number extends K ? never : K]: unknown;
@@ -123,12 +176,19 @@ function describeAction(
   const windowId = int(args, 'window_id');
   const elementId = identifier(str(args, 'element_id'));
   const element = elementId ? copy.element(elementId) : copy.elementUnknown;
+  const menu = displayable(str(args, 'menu'));
+  const sequenceSteps = Array.isArray(args.steps) ? args.steps.length : undefined;
+  const windowAction = str(args, 'window_action');
 
   switch (action) {
     case 'list_apps':
       return copy.listApps;
+    case 'launch_app':
+      return app !== undefined ? copy.launchApp(app) : copy.launchAppUnknown;
     case 'observe':
-      return app !== undefined
+      return menu !== undefined
+        ? copy.observeMenu(menu)
+        : app !== undefined
         ? copy.observeApp(app)
         : windowId !== undefined
           ? copy.observeWindow(windowId)
@@ -147,6 +207,20 @@ function describeAction(
       return copy.selectText(element);
     case 'secondary_action':
       return copy.secondaryAction(element);
+    case 'scroll_element':
+      return copy.scrollElement(element);
+    case 'element_sequence':
+      return sequenceSteps !== undefined
+        ? copy.elementSequence(sequenceSteps)
+        : copy.elementSequenceUnknown;
+    case 'window_action':
+      return windowAction === 'move'
+        ? copy.windowMove
+        : windowAction === 'resize'
+          ? copy.windowResize
+          : windowAction === 'minimize'
+            ? copy.windowMinimize
+            : copy.windowAction;
     case 'press_key':
     case 'key':
       return copy.pressKey;

--- a/packages/ui/src/tool-activity/copy.ts
+++ b/packages/ui/src/tool-activity/copy.ts
@@ -60,9 +60,12 @@ export interface ToolActivityCopy {
   computer: {
     fallback: string;
     listApps: string;
+    launchApp: (app: string) => string;
+    launchAppUnknown: string;
     observe: string;
     observeApp: (app: string) => string;
     observeWindow: (windowId: number) => string;
+    observeMenu: (menu: string) => string;
     screenshot: string;
     screenshotApp: (app: string) => string;
     screenshotWindow: (windowId: number) => string;
@@ -72,6 +75,17 @@ export interface ToolActivityCopy {
     setValue: (element: string) => string;
     selectText: (element: string) => string;
     secondaryAction: (element: string) => string;
+    scrollElement: (element: string) => string;
+    elementSequence: (count: number) => string;
+    elementSequenceUnknown: string;
+    windowAction: string;
+    windowMove: string;
+    windowResize: string;
+    windowMinimize: string;
+    targetApp: (app: string) => string;
+    targetWindow: (windowId: number) => string;
+    runningAction: (action: string, target?: string) => string;
+    runningSequence: (current: number, total: number, target?: string) => string;
     scroll: string;
     pressKey: string;
     type: string;
@@ -186,9 +200,12 @@ const TOOL_ACTIVITY_COPY = {
     computer: {
       fallback: '操作电脑',
       listApps: '列出打开的应用',
+      launchApp: (app) => `打开「${app}」`,
+      launchAppUnknown: '打开应用',
       observe: '观察当前窗口',
       observeApp: (app) => `观察「${app}」窗口`,
       observeWindow: (windowId) => `观察窗口 ${windowId}`,
+      observeMenu: (menu) => `查看「${menu}」菜单`,
       screenshot: '截图当前窗口',
       screenshotApp: (app) => `截图「${app}」窗口`,
       screenshotWindow: (windowId) => `截图窗口 ${windowId}`,
@@ -201,6 +218,20 @@ const TOOL_ACTIVITY_COPY = {
       setValue: (element) => `设置值：${element}`,
       selectText: (element) => `选择文本：${element}`,
       secondaryAction: (element) => `次要操作：${element}`,
+      scrollElement: (element) => `滚动${element}`,
+      elementSequence: (count) => `连续操作 ${count} 个控件`,
+      elementSequenceUnknown: '连续操作多个控件',
+      windowAction: '操作窗口',
+      windowMove: '移动窗口',
+      windowResize: '调整窗口大小',
+      windowMinimize: '最小化窗口',
+      targetApp: (app) => `「${app}」窗口`,
+      targetWindow: (windowId) => `窗口 ${windowId}`,
+      runningAction: (action, target) => target ? `正在${action} · ${target}` : `正在${action}`,
+      runningSequence: (current, total, target) =>
+        target
+          ? `正在操作${target} · 连续操作第 ${current}/${total} 步`
+          : `正在连续操作第 ${current}/${total} 步`,
       scroll: '滚动',
       pressKey: '按下按键',
       type: '输入文本',
@@ -252,9 +283,12 @@ const TOOL_ACTIVITY_COPY = {
     computer: {
       fallback: 'Use the computer',
       listApps: 'List open apps',
+      launchApp: (app) => `Open “${app}”`,
+      launchAppUnknown: 'Open an app',
       observe: 'Observe the current window',
       observeApp: (app) => `Observe the “${app}” window`,
       observeWindow: (windowId) => `Observe window ${windowId}`,
+      observeMenu: (menu) => `Inspect the “${menu}” menu`,
       screenshot: 'Screenshot the current window',
       screenshotApp: (app) => `Screenshot the “${app}” window`,
       screenshotWindow: (windowId) => `Screenshot window ${windowId}`,
@@ -264,6 +298,20 @@ const TOOL_ACTIVITY_COPY = {
       setValue: (element) => `Set the value of ${element}`,
       selectText: (element) => `Select text in ${element}`,
       secondaryAction: (element) => `Run a secondary action on ${element}`,
+      scrollElement: (element) => `Scroll ${element}`,
+      elementSequence: (count) => `Operate ${count} controls`,
+      elementSequenceUnknown: 'Operate multiple controls',
+      windowAction: 'Operate the window',
+      windowMove: 'Move the window',
+      windowResize: 'Resize the window',
+      windowMinimize: 'Minimize the window',
+      targetApp: (app) => `“${app}” window`,
+      targetWindow: (windowId) => `Window ${windowId}`,
+      runningAction: (action, target) => target ? `${action} · ${target}` : action,
+      runningSequence: (current, total, target) =>
+        target
+          ? `Operating ${target} · step ${current}/${total}`
+          : `Operating controls · step ${current}/${total}`,
       scroll: 'Scroll',
       pressKey: 'Press a key',
       type: 'Type text',


### PR DESCRIPTION
## Summary

- preserve trusted Computer Use activity semantics across the Client Capability bridge
- stream bounded multi-step progress from Desktop through Runtime Host into the live turn projection
- replace generic Computer Use rows and running text with action, target, and step-aware labels
- add a Storybook state covering a running 7/11 element sequence

## Verification

- `npm --workspace @maka/runtime-host test` (1071 passed)
- targeted runtime tests for Computer Use and MCP projection (89 passed)
- `npm --workspace @maka/ui test` (204 passed)
- Desktop native capability tests (13 passed)
- `npm --workspace @maka/desktop run typecheck`
- visually checked the Computer Use observability Storybook story at 1200x768