### PR TITLE
fix(runtime-host): keep one candidate in flight

### DIFF
--- a/.github/workflows/release-windows-check.yml
+++ b/.github/workflows/release-windows-check.yml
@@ -43,6 +43,8 @@ on:
       # MAKA_UPDATE_TEST_FEED to it — is only observable on this path.
       - 'apps/desktop/src/main/app-update-service.ts'
       - 'apps/desktop/src/main/runtime-host-boot.ts'
+      - 'packages/runtime-host/src/client/connect-or-spawn.ts'
+      - 'packages/runtime-host/src/client/launcher.ts'
       - 'scripts/prepare-windows-upgrade-baseline.mjs'
       - 'scripts/windows-upgrade-baseline.json'
       - 'scripts/verify-packaged-app.mjs'

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -221,6 +221,103 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
+  test('keeps one live Candidate in flight for the whole election', async () => {
+    await withHostPaths(async (paths) => {
+      let launches = 0;
+      const result = await connectOrSpawnRuntimeHostWithDependencies(
+        {
+          rootPath: paths.root,
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          electionDeadlineMs: 500,
+        },
+        {
+          random: () => 0,
+          launchCandidate: () => {
+            launches += 1;
+            return {
+              spawned: Promise.resolve({
+                pid: 4242,
+                exited: new Promise<never>(() => undefined),
+              }),
+            };
+          },
+        },
+      );
+
+      assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
+      assert.equal(launches, 1);
+    });
+  });
+
+  test('launches one successor after the exact in-flight Candidate exits', async () => {
+    await withHostPaths(async (paths) => {
+      let launches = 0;
+      const result = await connectOrSpawnRuntimeHostWithDependencies(
+        {
+          rootPath: paths.root,
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          electionDeadlineMs: 700,
+        },
+        {
+          random: () => 0,
+          launchCandidate: () => {
+            launches += 1;
+            return {
+              spawned: Promise.resolve({
+                pid: 4241 + launches,
+                exited:
+                  launches === 1
+                    ? new Promise((resolve) => {
+                        setTimeout(() => resolve({ code: 2, signal: null }), 25);
+                      })
+                    : new Promise<never>(() => undefined),
+              }),
+            };
+          },
+        },
+      );
+
+      assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
+      assert.equal(launches, 2);
+    });
+  });
+
+  test('retries after a Candidate spawn is rejected before an attempt exists', async () => {
+    await withHostPaths(async (paths) => {
+      let launches = 0;
+      const result = await connectOrSpawnRuntimeHostWithDependencies(
+        {
+          rootPath: paths.root,
+          protocol: CURRENT_PROTOCOL,
+          compositionId: KERNEL_COMPOSITION.descriptor.id,
+          candidateEntrypoint: KERNEL_CANDIDATE_ENTRYPOINT,
+          electionDeadlineMs: 700,
+        },
+        {
+          random: () => 0,
+          launchCandidate: () => {
+            launches += 1;
+            return launches === 1
+              ? { spawned: Promise.reject(new Error('spawn refused')) }
+              : {
+                  spawned: Promise.resolve({
+                    pid: 4242,
+                    exited: new Promise<never>(() => undefined),
+                  }),
+                };
+          },
+        },
+      );
+
+      assert.deepEqual(result, { kind: 'failed', reason: 'startup_timeout' });
+      assert.equal(launches, 2);
+    });
+  });
+
   test('publishes the diagnostic from the Candidate failure selected by the election', async () => {
     await withHostPaths(async (paths) => {
       const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
@@ -295,6 +392,7 @@ describe('non-serving Runtime Host kernel', () => {
               return {
                 spawned: Promise.resolve({
                   pid: process.pid,
+                  exited: Promise.resolve({ code: 2, signal: null }),
                   startupFailure: new Promise((resolve) => {
                     reportBlocker = resolve;
                   }),
@@ -1310,12 +1408,7 @@ describe('non-serving Runtime Host kernel', () => {
         paths.resources.trackPid(pid),
       );
       await waitForSuccessfulExit(parent, 'Electron connect parent');
-      assert.ok(launched.candidatePids.includes(launched.pid));
-      for (const pid of launched.candidatePids) {
-        if (pid === launched.pid) continue;
-        await waitForProcessExit(pid);
-        paths.resources.forgetPid(pid);
-      }
+      assert.deepEqual(launched.candidatePids, [launched.pid]);
 
       const connected = await retryConnect(paths, CURRENT_PROTOCOL);
       assert.equal(connected.kind, 'connected');
@@ -2349,6 +2442,24 @@ describe('non-serving Runtime Host kernel', () => {
           error instanceof Error &&
           'code' in error &&
           (error as NodeJS.ErrnoException).code === 'ENOENT',
+      );
+    });
+  });
+
+  test('detached launcher exposes exact Candidate process settlement', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const attempt = await launchDetachedRuntimeHostCandidate({
+        rootPath: paths.root,
+        expectedRootId: capability.rootId,
+        entrypoint: new URL('./fixtures/owned-candidate-exit.js', import.meta.url),
+        env: { MAKA_TEST_EXIT_CODE: '1' },
+      }).spawned;
+
+      assert.ok(attempt.exited);
+      assert.deepEqual(
+        await withTimeout(attempt.exited, 2_000, 'detached Candidate did not exit'),
+        { code: 1, signal: null },
       );
     });
   });

--- a/packages/runtime-host/src/__tests__/owned-candidate.test.ts
+++ b/packages/runtime-host/src/__tests__/owned-candidate.test.ts
@@ -18,7 +18,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mkdtemp, readdir } from 'node:fs/promises';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -254,6 +254,60 @@ test('owned Host exits promptly after its first connection closes', async () => 
   if (result.kind !== 'connected') return;
   await result.connection.close();
   assert.equal(await result.host.settle(500), true);
+});
+
+test('an exited owned Candidate permits one real successor in the same election', {
+  timeout: 25_000,
+}, async () => {
+  const rootPath = await mkdtemp(join(tmpdir(), 'maka-owned-successor-'));
+  const attempts: OwnedCandidateAttempt[] = [];
+  let launches = 0;
+  let connection: Awaited<ReturnType<typeof connectOrSpawnRuntimeHostWithDependencies>> | undefined;
+  try {
+    connection = await connectOrSpawnRuntimeHostWithDependencies(
+      {
+        rootPath,
+        protocol: {
+          min: RUNTIME_HOST_PROTOCOL_VERSION,
+          max: RUNTIME_HOST_PROTOCOL_VERSION,
+        },
+        compositionId: INTERACTIVE_RUNTIME_HOST_COMPOSITION_ID,
+        candidateEntrypoint: new URL('../execution-candidate-main.js', import.meta.url),
+        // This proves successor admission, not startup promptness. A full Windows
+        // suite can spend several seconds loading the real execution composition.
+        electionDeadlineMs: 15_000,
+      },
+      {
+        random: () => 0,
+        launchCandidate(input) {
+          launches += 1;
+          const launch = launchOwnedRuntimeHostCandidate(
+            launches === 1
+              ? {
+                  ...input,
+                  entrypoint: new URL('./fixtures/owned-candidate-exit.js', import.meta.url),
+                  env: { MAKA_TEST_EXIT_CODE: '2' },
+                }
+              : { ...input, idleGraceMs: 0 },
+          );
+          void launch.spawned.then((attempt) => attempts.push(attempt));
+          return launch;
+        },
+      },
+    );
+
+    assert.equal(connection.kind, 'connected', connectFailure(connection));
+    assert.equal(launches, 2);
+    assert.equal(attempts.length, 2);
+    if (connection.kind === 'connected') await connection.connection.close();
+    assert.equal(await attempts[0]?.settle(2_000), false);
+    assert.equal(await attempts[1]?.settle(5_000), true);
+  } finally {
+    if (connection?.kind === 'connected')
+      await connection.connection.close().catch(() => undefined);
+    await Promise.allSettled(attempts.map((attempt) => attempt.settle(2_000)));
+    await rm(rootPath, { recursive: true, force: true });
+  }
 });
 
 test('owned candidate settlement requires a clean process exit', async () => {

--- a/packages/runtime-host/src/client/connect-or-spawn.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn.ts
@@ -249,6 +249,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
   let startupFailure: CandidateStartupFailureReport | undefined;
   let pendingCandidateReports = 0;
   let electionSettled = false;
+  let candidateInFlight = false;
 
   try {
     while (performance.now() < deadline) {
@@ -313,6 +314,7 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
       if (
         shouldLaunchCandidate(result) &&
         !isPermanentCandidateStartupFailure(startupFailure) &&
+        !candidateInFlight &&
         now >= nextCandidateAt
       ) {
         try {
@@ -326,6 +328,15 @@ export async function connectOrSpawnRuntimeHostWithDependencies(
             ...(input.generation === undefined ? {} : { generation: input.generation }),
           });
           const attempt = await settleBeforeDeadline(launch.spawned, deadline, input.signal);
+          candidateInFlight = true;
+          if (attempt.exited) {
+            void attempt.exited.then(
+              () => {
+                candidateInFlight = false;
+              },
+              () => undefined,
+            );
+          }
           if (attempt.startupFailure) {
             pendingCandidateReports += 1;
             void attempt.startupFailure

--- a/packages/runtime-host/src/client/launcher.ts
+++ b/packages/runtime-host/src/client/launcher.ts
@@ -40,7 +40,13 @@ export interface DetachedCandidateInput {
 
 export interface DetachedCandidateAttempt {
   pid: number;
+  exited?: Promise<CandidateProcessExit>;
   startupFailure?: Promise<CandidateStartupFailureReport | undefined>;
+}
+
+export interface CandidateProcessExit {
+  readonly code: number | null;
+  readonly signal: NodeJS.Signals | null;
 }
 
 export interface OwnedCandidateAttempt extends DetachedCandidateAttempt {
@@ -59,10 +65,11 @@ export function launchDetachedRuntimeHostCandidate(
 ): DetachedCandidateLaunch {
   const startupAttemptId = randomUUID();
   const child = spawnCandidate(input, true, startupAttemptId);
-  const startupFailure = readStartupFailure(child, startupAttemptId);
+  const exited = candidateExit(child);
+  const startupFailure = readStartupFailure(child, exited, startupAttemptId);
   const spawned = spawnedPid(child).then(({ pid }) => {
     child.unref();
-    return { pid, startupFailure };
+    return { pid, exited, startupFailure };
   });
   return { spawned };
 }
@@ -72,13 +79,12 @@ export function launchOwnedRuntimeHostCandidate(input: DetachedCandidateInput): 
 } {
   const startupAttemptId = randomUUID();
   const child = spawnCandidate(input, false, startupAttemptId);
-  const startupFailure = readStartupFailure(child, startupAttemptId);
-  const exited = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve) => {
-    child.once('exit', (code, signal) => resolve({ code, signal }));
-  });
+  const exited = candidateExit(child);
+  const startupFailure = readStartupFailure(child, exited, startupAttemptId);
   return {
     spawned: spawnedPid(child).then(({ pid }) => ({
       pid,
+      exited,
       startupFailure,
       releaseToEnvironment(): void {
         child.unref();
@@ -151,14 +157,21 @@ function spawnedPid(child: ReturnType<typeof spawn>): Promise<{ pid: number }> {
 
 function readStartupFailure(
   child: ReturnType<typeof spawn>,
+  exited: Promise<CandidateProcessExit>,
   startupAttemptId: string,
 ): Promise<CandidateStartupFailureReport | undefined> {
   return new Promise((resolve) => {
-    child.once('exit', (code) => {
+    void exited.then(({ code }) => {
       const failure = candidateStartupFailureForExitCode(code);
       resolve(failure ? { ...failure, startupAttemptId } : undefined);
     });
     child.once('error', () => resolve(undefined));
+  });
+}
+
+function candidateExit(child: ReturnType<typeof spawn>): Promise<CandidateProcessExit> {
+  return new Promise((resolve) => {
+    child.once('exit', (code, signal) => resolve({ code, signal }));
   });
 }
 

--- a/scripts/ci-test-plan.test.mjs
+++ b/scripts/ci-test-plan.test.mjs
@@ -322,6 +322,13 @@ test('the sandbox lane pairs its path filter with a nightly run', () => {
   assert.match(workflow, /\n {2}schedule:/u);
 });
 
+test('the packaged Windows gate owns Runtime Host candidate election changes', () => {
+  const workflow = readWorkflow('release-windows-check.yml');
+
+  assert.match(workflow, /'packages\/runtime-host\/src\/client\/connect-or-spawn\.ts'/u);
+  assert.match(workflow, /'packages\/runtime-host\/src\/client\/launcher\.ts'/u);
+});
+
 test('specialized platform workflows stay reachable without pull requests', () => {
   const cli = readWorkflow('cli-package-validation.yml');
   const baseline = readWorkflow('windows-baseline.yml');


### PR DESCRIPTION
## Summary

Prevents one Runtime Host election from spawning another Candidate while its current Candidate process is still alive.

#3454 classified the intermittent Windows startup failure in #3279: one packaged automatic-update startup made 69 distinct Candidate launches while observing `not_registered` 73 times, then connected once and timed out with the Host still `recovering`. Repeated process creation under load works against election convergence rather than helping it.

This PR makes Candidate process settlement explicit for both detached and owned launchers, and keeps a per-election in-flight gate closed until that exact process exits. A spawn rejection still permits a later attempt because no process exists. A process whose exit cannot be observed remains fail-closed for that election.

Refs #3279. This PR should land before #3454; the diagnostic PR can then rebase without combining behavior and evidence changes.

## Boundary

- The production 45-second election deadline is unchanged.
- Failure classification, endpoint handling, readiness polling, startup-failure selection, and cleanup ownership are unchanged.
- This is per-election single-flight, not global or cross-client launch coalescing.
- A sequential successor is allowed only after the prior Candidate exits.
- Full LaunchLease, cross-client coordination, retry-policy redesign, and #3454 diagnostic counters remain deferred to their existing #2142/#3454 scopes.

## Mechanism

Both `launchDetachedRuntimeHostCandidate` and `launchOwnedRuntimeHostCandidate` now return the same child-bound `exited` promise. `connectOrSpawnRuntimeHostWithDependencies` marks a Candidate in flight only after `spawned` resolves and clears the gate only when `exited` fulfills. A rejected spawn never sets the gate; a missing or rejected exit signal leaves it closed.

`Release Windows check` now owns changes to the two Candidate-election source files so this behavior cannot merge on Node-only evidence.

## Verification

L1/L2 on exact head `814d95f663c74fb6bd804de5eed3ae37d2eae482`:

- `npm run build` passed
- `npm run typecheck` passed across all workspaces
- `npm run lint`: 2,551 files, 0 errors
- `npm run format:check`: 1,590 files, 0 changes
- CI planner + Windows harness: 60 passed, 0 failed, 1 privilege-dependent symlink skip
- Windows inventory: 3 passed; 63 declarations current
- single-flight/live/exit/spawn-reject/detached settlement: 4 passed
- Candidate barrier + deadline contracts: 8 passed
- real owned exit-to-successor paths: 2 passed
- real Electron Client: exactly one Candidate PID, 1 passed
- independent author-gate review: no unresolved P0-P2 findings
- `git diff --check` passed

Real local fresh-root evidence:

- one detached Candidate launch
- connection succeeded
- Candidate exited with code 0 and no signal
- exact PID exited and the temporary root was removed

The real owned-successor test uses a 15-second election budget and 25-second test timeout only to tolerate execution-composition startup under local load. Production remains at 45 seconds.

Local limitations:

- a serial Runtime Host run reached at least 149 passing tests, but the tool session did not return a final summary, so it is not claimed as a full-suite pass
- `check:release` was attempted; three unrelated Windows-local failures were in existing standalone Bash/temp-directory cleanup paths (two `EBUSY`), outside this diff
- authoritative full-suite and packaged evidence comes from this PR's CI

## L3 gate

- [Core CI 32581049491](https://github.com/apache/maka/actions/runs/32581049491) passed in 6m09s, including the full Runtime Host suite, Desktop E2E, Storybook, and installed CLI validation.
- [Release Windows check 32581049489](https://github.com/apache/maka/actions/runs/32581049489) passed in 12m16s, including packaging, packaged smoke, pinned upgrade/uninstall, and automatic update end to end.
- Dependency audit did not run because this PR changes no dependency inputs.

Fresh exact-head core and packaged Windows evidence is green. The PR is ready for review.
## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented the per-election gate and process-settlement contract, added focused Node/Electron/owned-process regression evidence, ran local validation, and used independent review agents for the author gate. The commit includes a `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary and Boundary above
- [ ] No