### PR TITLE
fix(core): scope the missing-default-model health warning to the workspace default

### DIFF
--- a/apps/desktop/src/main/runtime-host-permissions-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-permissions-ipc-main.ts
@@ -22,6 +22,7 @@ import {
   healthSignalFromCapability,
   healthSignalFromConnection,
   healthSignalFromConnectionRuntime,
+  workspaceHasDefaultModelTarget,
 } from '@maka/core/health';
 import { type AppSettings } from '@maka/core/settings';
 import { type LlmConnection } from '@maka/core/llm-connections';
@@ -94,10 +95,10 @@ export function registerRuntimeHostPermissionsIpc(
     // The catalog projects `defaultModel` onto exactly one connection (the
     // default target): with a default configured somewhere, other enabled
     // connections carry an empty `defaultModel` by construction, and their
-    // signal must say "not the default source", not "misconfigured".
-    const workspaceHasDefaultTarget = connections.some((connection) =>
-      Boolean(connection.defaultModel),
-    );
+    // signal must say "not the default source", not "misconfigured". The
+    // derivation (which requires the holder to be ENABLED — a disabled
+    // holder cannot serve a new chat) lives in core beside the signal.
+    const workspaceHasDefaultTarget = workspaceHasDefaultModelTarget(connections);
     const connectionSignals = (
       await Promise.all(
         connections.map(async (connection) => [

--- a/apps/desktop/src/main/runtime-host-permissions-ipc-main.ts
+++ b/apps/desktop/src/main/runtime-host-permissions-ipc-main.ts
@@ -91,10 +91,17 @@ export function registerRuntimeHostPermissionsIpc(
       computerUse: deps.getComputerUseCapabilityInput(),
       now,
     });
+    // The catalog projects `defaultModel` onto exactly one connection (the
+    // default target): with a default configured somewhere, other enabled
+    // connections carry an empty `defaultModel` by construction, and their
+    // signal must say "not the default source", not "misconfigured".
+    const workspaceHasDefaultTarget = connections.some((connection) =>
+      Boolean(connection.defaultModel),
+    );
     const connectionSignals = (
       await Promise.all(
         connections.map(async (connection) => [
-          healthSignalFromConnection(connection, now),
+          healthSignalFromConnection(connection, now, { workspaceHasDefaultTarget }),
           healthSignalFromConnectionRuntime(
             connection,
             await latestRuntimeProbe(deps.client, connection),

--- a/apps/desktop/src/renderer/locales/settings-health-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-health-copy.ts
@@ -128,7 +128,20 @@ function englishSignalLabel(signal: HealthSignal): string {
 
 function englishSignalMessage(signal: HealthSignal): string {
   if (signal.scope === 'llm_connection') {
-    if (signal.layer === 'configuration') return signal.status === 'info' ? 'Connection is disabled.' : 'Select a default model.';
+    if (signal.layer === 'configuration') {
+      // Three-way split matching the producer's configuration states
+      // (packages/core/src/health.ts) — the message string is the anchor,
+      // the same way the runtime_probe branch below parses the producer's
+      // detail. Falling back on status alone described an enabled
+      // non-default connection as disabled.
+      if (signal.message === '不是工作区的默认模型来源。') {
+        return 'Not the workspace default model source.';
+      }
+      if (signal.message === '没有启用任何模型。') {
+        return 'No models are enabled on this connection.';
+      }
+      return signal.status === 'info' ? 'Connection is disabled.' : 'Select a default model.';
+    }
     if (signal.layer === 'runtime_probe') {
       return { ok: 'The latest send completed.', info: 'The latest send was stopped by the user.', warning: 'The latest send failed.', error: 'The latest send failed.', unknown: 'Waiting for a send-path runtime probe.' }[signal.status];
     }
@@ -151,6 +164,14 @@ function englishSignalDetail(signal: HealthSignal): string | undefined {
     const errorClass = signal.detail.match(/错误类型=([^·]+)/)?.[1]?.trim();
     const parts = [model && `Model=${model}`, latency && `Latency=${latency}`, errorClass && `Error type=${errorClass}`].filter(Boolean);
     return parts.length > 0 ? parts.join(' · ') : 'Runtime details are available in Usage settings.';
+  }
+  if (signal.scope === 'llm_connection' && signal.layer === 'configuration') {
+    if (signal.message === '不是工作区的默认模型来源。') {
+      return 'Models on this connection stay usable when selected explicitly in a task; the default model for new chats lives in Settings · General.';
+    }
+    if (signal.message === '没有启用任何模型。') {
+      return "Enable at least one model in this connection's detail view under Settings · Models.";
+    }
   }
   return 'See the corresponding settings page for details.';
 }

--- a/packages/core/src/__tests__/health.test.ts
+++ b/packages/core/src/__tests__/health.test.ts
@@ -43,6 +43,59 @@ describe('HealthSignal contract', () => {
     expect(result.source).toBe('connection_test');
   });
 
+  test('a missing default model warns only when the workspace has no default target', () => {
+    // The catalog projects `defaultModel` onto exactly one connection (the
+    // default target). With a default configured elsewhere, an enabled
+    // connection with an empty `defaultModel` is the documented normal
+    // state — informational, never send-blocking, and never a prompt to
+    // find a per-connection setting that deliberately does not exist.
+    const nonDefault = healthSignalFromConnection(
+      connection({ defaultModel: '', enabledModelIds: ['glm-4.7'] }),
+      20,
+      { workspaceHasDefaultTarget: true },
+    );
+    expect(nonDefault.status).toBe('info');
+    expect(nonDefault.blocksSend).toBe(false);
+
+    // With NO default anywhere, a new chat cannot start: that is the
+    // actionable, send-blocking configuration gap.
+    const noDefaultAnywhere = healthSignalFromConnection(
+      connection({ defaultModel: '' }),
+      20,
+      { workspaceHasDefaultTarget: false },
+    );
+    expect(noDefaultAnywhere.status).toBe('warning');
+    expect(noDefaultAnywhere.blocksSend).toBe(true);
+
+    // The informational note must not paper over real per-connection
+    // blockers: failing validation still wins on a non-default connection…
+    const reauth = healthSignalFromConnection(
+      connection({ defaultModel: '', enabledModelIds: ['glm-4.7'], lastTestStatus: 'needs_reauth' }),
+      20,
+      { workspaceHasDefaultTarget: true },
+    );
+    expect(reauth.status).toBe('error');
+    expect(reauth.blocksSend).toBe(true);
+
+    // …and a connection with no enabled models cannot claim that explicit
+    // selection works — there is nothing to select.
+    const emptyInventory = healthSignalFromConnection(
+      connection({ defaultModel: '', enabledModelIds: [] }),
+      20,
+      { workspaceHasDefaultTarget: true },
+    );
+    expect(emptyInventory.status).toBe('warning');
+    expect(emptyInventory.blocksSend).toBe(false);
+
+    // The default target itself keeps its validation-layer signals.
+    const configured = healthSignalFromConnection(
+      connection({ lastTestStatus: 'verified', lastTestAt: '2026-05-22T07:30:00.000Z' }),
+      20,
+      { workspaceHasDefaultTarget: true },
+    );
+    expect(configured.status).toBe('ok');
+  });
+
   test('LLM runtime probe is separate from credential validation', () => {
     const unknown = healthSignalFromConnectionRuntime(
       connection({ lastTestStatus: 'verified' }),

--- a/packages/core/src/__tests__/health.test.ts
+++ b/packages/core/src/__tests__/health.test.ts
@@ -23,6 +23,7 @@ import {
   buildHealthSnapshot,
   healthSignalFromCapability,
   healthSignalFromConnection,
+  workspaceHasDefaultModelTarget,
   healthSignalFromConnectionRuntime,
 } from '../health.js';
 import type { CapabilitySnapshot } from '../capabilities.js';
@@ -96,6 +97,25 @@ describe('HealthSignal contract', () => {
       { workspaceHasDefaultTarget: true },
     );
     expect(configured.status).toBe('ok');
+  });
+
+  test('a disabled default holder does not count as a workspace default', () => {
+    // Disabling the connection that holds the default target (ordinary UI,
+    // nothing clears defaultTarget) leaves its projected defaultModel in
+    // place. Counting it would show an all-clear health page in exactly
+    // the state where sends fail with connection_disabled.
+    const disabledHolder = connection({ enabled: false }); // defaultModel: 'glm-4.7'
+    const other = connection({ slug: 'other', defaultModel: '', enabledModelIds: ['m'] });
+    expect(workspaceHasDefaultModelTarget([disabledHolder, other])).toBe(false);
+    expect(workspaceHasDefaultModelTarget([connection({}), other])).toBe(true);
+
+    // With the holder disabled, the OTHER enabled connections escalate back
+    // to the send-blocking warning — the workspace genuinely has no default.
+    const signal = healthSignalFromConnection(other, 20, {
+      workspaceHasDefaultTarget: workspaceHasDefaultModelTarget([disabledHolder, other]),
+    });
+    expect(signal.status).toBe('warning');
+    expect(signal.blocksSend).toBe(true);
   });
 
   test('LLM runtime probe is separate from credential validation', () => {

--- a/packages/core/src/__tests__/health.test.ts
+++ b/packages/core/src/__tests__/health.test.ts
@@ -59,18 +59,20 @@ describe('HealthSignal contract', () => {
 
     // With NO default anywhere, a new chat cannot start: that is the
     // actionable, send-blocking configuration gap.
-    const noDefaultAnywhere = healthSignalFromConnection(
-      connection({ defaultModel: '' }),
-      20,
-      { workspaceHasDefaultTarget: false },
-    );
+    const noDefaultAnywhere = healthSignalFromConnection(connection({ defaultModel: '' }), 20, {
+      workspaceHasDefaultTarget: false,
+    });
     expect(noDefaultAnywhere.status).toBe('warning');
     expect(noDefaultAnywhere.blocksSend).toBe(true);
 
     // The informational note must not paper over real per-connection
     // blockers: failing validation still wins on a non-default connection…
     const reauth = healthSignalFromConnection(
-      connection({ defaultModel: '', enabledModelIds: ['glm-4.7'], lastTestStatus: 'needs_reauth' }),
+      connection({
+        defaultModel: '',
+        enabledModelIds: ['glm-4.7'],
+        lastTestStatus: 'needs_reauth',
+      }),
       20,
       { workspaceHasDefaultTarget: true },
     );

--- a/packages/core/src/health.ts
+++ b/packages/core/src/health.ts
@@ -18,7 +18,7 @@
  */
 
 import type { CapabilityId, CapabilityReadinessState, CapabilitySnapshot } from './capabilities.js';
-import type { LlmConnection } from './llm-connections.js';
+import { connectionEnabledModelIds, type LlmConnection } from './llm-connections.js';
 import type { UsageLogRow } from './usage-stats/types.js';
 
 export const HEALTH_SIGNAL_STATUSES = ['ok', 'info', 'warning', 'error', 'unknown'] as const;
@@ -114,6 +114,20 @@ export function healthSignalFromCapability(capability: CapabilitySnapshot): Heal
 export function healthSignalFromConnection(
   connection: LlmConnection,
   checkedAt: number,
+  options: {
+    /** Whether SOME connection in the workspace carries the default model
+     * target. The catalog projects `defaultModel` onto exactly one
+     * connection — the default target — so with a default configured,
+     * every OTHER enabled connection has an empty `defaultModel` BY
+     * CONSTRUCTION. That is the connection model's documented normal state
+     * (设置 · 通用 is the one control for which model a new chat starts
+     * on; see reconcileConnectionAfterEnabledModelsChange), not a
+     * configuration gap — warning on it sent users hunting for a
+     * per-connection setting that deliberately does not exist. Only when
+     * NO default exists anywhere is a missing model an actionable,
+     * send-blocking problem. */
+    workspaceHasDefaultTarget?: boolean;
+  } = {},
 ): HealthSignal {
   const configured = Boolean(connection.defaultModel);
   if (!connection.enabled) {
@@ -130,7 +144,7 @@ export function healthSignalFromConnection(
     };
   }
 
-  if (!configured) {
+  if (!configured && !options.workspaceHasDefaultTarget) {
     return {
       id: `connection:${connection.slug}`,
       label: connection.name,
@@ -186,6 +200,40 @@ export function healthSignalFromConnection(
       message: '上次连接验证失败。',
       detail: connection.lastTestMessage,
       blocksSend: true,
+    };
+  }
+
+  if (!configured) {
+    // A non-default connection reaches here only with nothing above firing:
+    // enabled, workspace default lives elsewhere, no failing validation.
+    // Ordered AFTER the validation branches on purpose — a needs_reauth or
+    // failed test on a non-default connection is a real blocker and must
+    // not be papered over by the "not the default source" note.
+    if (connectionEnabledModelIds(connection).length === 0) {
+      return {
+        id: `connection:${connection.slug}`,
+        label: connection.name,
+        scope: 'llm_connection',
+        layer: 'configuration',
+        status: 'warning',
+        source: 'settings',
+        checkedAt,
+        message: '没有启用任何模型。',
+        detail: '在 设置 · 模型 的连接详情里启用至少一个模型后才能使用该连接。',
+        blocksSend: false,
+      };
+    }
+    return {
+      id: `connection:${connection.slug}`,
+      label: connection.name,
+      scope: 'llm_connection',
+      layer: 'configuration',
+      status: 'info',
+      source: 'settings',
+      checkedAt,
+      message: '不是工作区的默认模型来源。',
+      detail: '在任务中显式选择该连接的模型即可正常使用;新对话的默认模型在 设置 · 通用 配置。',
+      blocksSend: false,
     };
   }
 

--- a/packages/core/src/health.ts
+++ b/packages/core/src/health.ts
@@ -111,6 +111,18 @@ export function healthSignalFromCapability(capability: CapabilitySnapshot): Heal
   };
 }
 
+/** Whether some ENABLED connection holds the workspace's default model
+ * target. The catalog projects `defaultModel` purely from the default
+ * target's connection id — a DISABLED holder keeps its projected value,
+ * but cannot serve a new chat: counting it would show an all-clear health
+ * page in exactly the state where sends fail with connection_disabled.
+ * The one derivation, exported so the caller and the tests cannot drift. */
+export function workspaceHasDefaultModelTarget(
+  connections: readonly Pick<LlmConnection, 'defaultModel' | 'enabled'>[],
+): boolean {
+  return connections.some((connection) => Boolean(connection.defaultModel) && connection.enabled);
+}
+
 export function healthSignalFromConnection(
   connection: LlmConnection,
   checkedAt: number,


### PR DESCRIPTION

<img width="920" height="526" alt="image" src="https://github.com/user-attachments/assets/8c9aee23-272d-4f55-b8a2-1c67c7186258" />


## Symptom

The 健康 tab shows `等待选择默认模型` (warning, **阻塞发送**) for every enabled LLM connection that is not the workspace default — three at once in the report that surfaced this (Openrouter / Codex OAuth / Moonshot). The user then goes hunting in the provider detail page for a per-connection default-model setting… which deliberately does not exist.

*(Before-screenshot to follow in a comment — the original capture is being re-attached.)*

## Root cause — the signal contradicts the connection model's own doctrine

`projectHostConnections` projects `defaultModel` onto exactly **one** connection — the catalog's default target. Every other enabled connection carries an empty `defaultModel` **by construction**. That is the documented normal state: `reconcileConnectionAfterEnabledModelsChange` says which model a new chat starts on is 设置 · 通用's one control, and explicitly declines to offer a per-connection picker elsewhere ("the connection is then simply not the workspace default … which is what it is").

`healthSignalFromConnection` predates that doctrine: it treats any enabled connection with an empty `defaultModel` as a per-connection configuration gap — warning + `blocksSend` — so with N enabled connections the health page permanently shows N−1 unresolvable warnings.

## Fix

`healthSignalFromConnection` now takes `{ workspaceHasDefaultTarget }` (the caller derives it from the same projected list — exactly one connection carries a non-empty `defaultModel`):

- default target exists elsewhere → the connection reports an **informational** `不是工作区的默认模型来源` with a detail pointing at explicit per-task model selection and 设置 · 通用, and never blocks send;
- **no** default anywhere → the send-blocking `等待选择默认模型` warning remains on every enabled connection — the one state where a new chat genuinely cannot start;
- disabled connections and the validation-layer signals for the configured target are unchanged.

## Regression

`health.test.ts`: non-default connection with a workspace default → info, non-blocking; no default anywhere → warning, blocking; configured target keeps its validation signal.

Suites: core 606, desktop 1150 — green; biome clean.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01TMwYxgNEbz2RFmuK6AXGcj