### PR TITLE
fix(runtime): classify provider server errors

### DIFF
--- a/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-presentation.test.ts
@@ -19,7 +19,10 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { deriveFailedTurnRecovery } from '../../renderer/session-status-presentation.js';
+import {
+  deriveFailedTurnRecovery,
+  describeTurnErrorClass,
+} from '../../renderer/session-status-presentation.js';
 
 const outputFreeFailure = {
   partialOutputRetained: false,
@@ -28,6 +31,11 @@ const outputFreeFailure = {
 };
 
 describe('failed turn recovery presentation', () => {
+  it('presents persisted provider server errors as provider failures', () => {
+    assert.equal(describeTurnErrorClass('server_error', 'zh'), '模型服务返回错误');
+    assert.equal(describeTurnErrorClass('server_error', 'en'), 'Model service error');
+  });
+
   it('does not recommend a byte-identical retry after context overflow', () => {
     assert.deepEqual(
       deriveFailedTurnRecovery({ ...outputFreeFailure, errorClass: 'context_overflow' }, 'zh'),

--- a/apps/desktop/src/renderer/session-status-presentation.ts
+++ b/apps/desktop/src/renderer/session-status-presentation.ts
@@ -143,7 +143,12 @@ export function describeTurnErrorClass(errorClass: string | undefined, locale: U
   if (lower === 'network' || lower.includes('network') || lower.includes('fetch') || lower.includes('econn')) {
     return copy.network;
   }
-  if (lower === 'provider_unavailable' || /\b5\d\d\b/.test(lower)) return copy.provider;
+  if (
+    lower === 'provider_unavailable' ||
+    lower === 'server_error' ||
+    /\b5\d\d\b/.test(lower)
+  )
+    return copy.provider;
   if (lower === 'tool_step_cap_reached') return copy.stepCap;
   if (lower === 'tool_failed' || lower.includes('tool')) return copy.tool;
   if (lower === 'permission_required' || lower.includes('permission')) return copy.permission;

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -223,6 +223,31 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(shaped.message, 'Rate limit exceeded');
   });
 
+  test('normalizes a status-less provider server_error into a retryable outage', () => {
+    const adapter = newAdapter();
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
+    const [event] = adapter.translateChunk({
+      type: 'error',
+      error: {
+        type: 'server_error',
+        code: 'server_error',
+        message:
+          'Streaming response failed: [502] Upstream error from Nvidia: Service temporarily overloaded',
+      },
+    } as Chunk);
+
+    assert.deepEqual(event, {
+      kind: 'error',
+      failure: {
+        type: 'model_failure',
+        kind: 'provider_unavailable',
+        code: 'server_error',
+        message: 'Provider returned an error',
+        retryable: true,
+      },
+    });
+  });
+
   test('preserves an explicit empty reasoning delta without inventing one for absent text', () => {
     const adapter = newAdapter();
     type Chunk = Parameters<typeof adapter.translateChunk>[0];

--- a/packages/runtime/src/__tests__/provider-error-classification.test.ts
+++ b/packages/runtime/src/__tests__/provider-error-classification.test.ts
@@ -155,6 +155,25 @@ describe('Provider error classification', () => {
     assert.deepEqual(providerRetryMetadata(missingContinuation), { retryable: true });
   });
 
+  test('treats a status-less provider server_error as temporarily unavailable', () => {
+    const failure = {
+      type: 'model_failure',
+      kind: 'unknown',
+      retryable: false,
+      message:
+        'Streaming response failed: [502] Upstream error from Nvidia: Service temporarily overloaded',
+      code: 'server_error',
+    };
+
+    assert.equal(classifyError(failure), 'ProviderUnavailable');
+    assert.deepEqual(providerRetryMetadata(failure), { retryable: true });
+    assert.deepEqual(providerFailureDiagnostic(failure), {
+      errorClass: 'ProviderUnavailable',
+      providerCode: 'server_error',
+      retryable: true,
+    });
+  });
+
   test('retries a rate limit only when the provider names a retry delay', () => {
     const bareRateLimit = Object.assign(new Error('Rate limit exceeded'), {
       name: 'AI_APICallError',

--- a/packages/runtime/src/provider-error-classification.ts
+++ b/packages/runtime/src/provider-error-classification.ts
@@ -32,6 +32,10 @@ const CONTEXT_OVERFLOW_PROVIDER_CODES: ReadonlySet<string> = new Set([
   'request_too_large', // Anthropic byte-size overflow (HTTP 413): error.type
 ]);
 
+const PROVIDER_UNAVAILABLE_PROVIDER_CODES: ReadonlySet<string> = new Set([
+  'server_error', // OpenAI-compatible stream errors can omit the HTTP status.
+]);
+
 /**
  * A provider failure normalized into classification evidence. classifyError's
  * real input domain is NOT just Error instances: a request-level failure is
@@ -144,6 +148,7 @@ export function providerRetryMetadata(error: unknown): ProviderRetryMetadata {
   }
   const retryable =
     errorClass === 'Network' ||
+    errorClass === 'ProviderUnavailable' ||
     status === 408 ||
     status === 409 ||
     (status >= 500 && status <= 599);
@@ -612,6 +617,8 @@ function classifyProviderFacts(facts: ProviderErrorFacts): string {
   if (statusCode === '413' || code === '413') return 'ContextLength';
   // Free-text overflow relations on the composite text, veto-first inside.
   if (isContextOverflowErrorText(text)) return 'ContextLength';
+  if (structuredCodes.some((c) => PROVIDER_UNAVAILABLE_PROVIDER_CODES.has(c)))
+    return 'ProviderUnavailable';
   if (/^5\d\d$/.test(statusCode) || /^5\d\d$/.test(code)) return 'ProviderUnavailable';
   // Weak word heuristics, last: they only catch errors that carried no
   // stronger evidence for any other class. `rate` must be word-shaped


### PR DESCRIPTION
## Summary

- classify structured `server_error` provider failures as `ProviderUnavailable` even when the stream omits an HTTP status
- make those transient provider failures retryable through the existing runtime retry path
- render persisted `server_error` failures as a model service error instead of an unknown error

## Root cause

OpenAI-compatible streaming errors can carry `code: server_error` without preserving the upstream HTTP status. The classifier only recognized numeric 5xx codes, so Maka normalized the failure to `kind: unknown`, disabled retry, and displayed the failed turn as an unknown error.

## Validation

- `node --test packages/runtime/dist/__tests__/provider-error-classification.test.js packages/runtime/dist/__tests__/model-adapter.test.js` (39 passed)
- `node --test apps/desktop/dist/main/__tests__/session-status-presentation.test.js` (4 passed)
- Biome check on all changed files
- `git diff --check`

The full runtime suite completed with 3,059 passing tests and 9 unrelated existing failures in `model-factory-tool-call-index.test.js` and `node-pty-write-lifecycle.test.js`; the focused suites covering this change pass.