### PR TITLE
fix(cli): reconcile tool results while turns are live

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-session-driver.test.ts
@@ -1323,6 +1323,40 @@ describe('Runtime Host Maka Session driver', () => {
     assert.deepEqual(await replacement.promise, durableMessages);
   });
 
+  test('publishes only the newest live tool-result transcript refresh', async () => {
+    const attached = new FakeSubscription(continuitySnapshot(), Promise.resolve([]));
+    const firstRefresh = new FakeSubscription(
+      continuitySnapshot(),
+      new Promise<StoredMessage[]>(() => undefined),
+      'subscription-2',
+    );
+    const secondMessages = [userMessage('turn-1', 'Run it'), assistantMessage('turn-1', 'Done')];
+    const secondRefresh = new FakeSubscription(
+      continuitySnapshot(),
+      Promise.resolve(secondMessages),
+      'subscription-3',
+    );
+    const connection = new FakeConnection([attached, firstRefresh, secondRefresh]);
+    const driver = createRuntimeHostMakaSessionDriver({
+      connection: connection.value,
+      cwd: '/tmp',
+      llmConnectionSlug: 'openai-main',
+      model: 'gpt-5',
+    });
+    await driver.switchSession('session-1');
+    const replacements: StoredMessage[][] = [];
+    driver.subscribeTranscriptReplacements!((_sessionId, _turnId, messages, reason) => {
+      assert.equal(reason, 'tool_result');
+      replacements.push(messages);
+    });
+
+    attached.push(toolResultFrame(1));
+    attached.push(toolResultFrame(2));
+    await waitFor(() => connection.openedSubscriptions === 3);
+    await waitFor(() => replacements.length === 1);
+    assert.deepEqual(replacements, [secondMessages]);
+  });
+
   test('resnapshots an active Session after reconnect and continues its live stream', async () => {
     const initial = new FakeSubscription(
       continuitySnapshot(),

--- a/packages/cli/src/runtime-host-session-channel.ts
+++ b/packages/cli/src/runtime-host-session-channel.ts
@@ -66,6 +66,7 @@ export interface RuntimeHostSessionChannelOptions {
   onInteractionPending: (pending: InteractionPendingSnapshot) => void;
   onInteractionResolved: (pending: InteractionPendingSnapshot) => void;
   onTurnTerminal: (turn: TerminalTurnSnapshot) => void;
+  onToolResult?: (turnId: string) => void;
   onTranscriptReplaced: (turnId: string, messages: readonly StoredMessage[]) => void;
   /**
    * Fired when the folded session projection's goal changes (set / settle /
@@ -88,6 +89,7 @@ export class RuntimeHostSessionChannel {
   readonly #onInteractionPending: (pending: InteractionPendingSnapshot) => void;
   readonly #onInteractionResolved: (pending: InteractionPendingSnapshot) => void;
   readonly #onTurnTerminal: (turn: TerminalTurnSnapshot) => void;
+  readonly #onToolResult: ((turnId: string) => void) | undefined;
   readonly #onTranscriptReplaced: (turnId: string, messages: readonly StoredMessage[]) => void;
   readonly #onGoalChanged: (goal: GoalProjection | null) => void;
   readonly #onRecovered: () => void;
@@ -127,6 +129,7 @@ export class RuntimeHostSessionChannel {
     this.#onInteractionPending = options.onInteractionPending;
     this.#onInteractionResolved = options.onInteractionResolved;
     this.#onTurnTerminal = options.onTurnTerminal;
+    this.#onToolResult = options.onToolResult;
     this.#onTranscriptReplaced = options.onTranscriptReplaced;
     this.#onGoalChanged = options.onGoalChanged;
     this.#onRecovered = options.onRecovered;
@@ -628,6 +631,7 @@ export class RuntimeHostSessionChannel {
   }
 
   #emit(event: SessionEvent): void {
+    if (event.type === 'tool_result') this.#onToolResult?.(event.turnId);
     this.#queue(event.turnId).push(event);
   }
 

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -1028,6 +1028,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       },
       onInteractionResolved: (pending) => this.#resolveExternalInteraction(pending),
       onTurnTerminal: (turn) => this.#refreshTerminalTranscript(turn),
+      onToolResult: (turnId) => this.#refreshLiveTranscript(sessionId, turnId),
       onTranscriptReplaced: (turnId, messages) =>
         this.#publishTranscriptReplacement(sessionId, turnId, messages, 'reconnect'),
       onGoalChanged: (goal) => {
@@ -1075,6 +1076,15 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       .then((messages) => {
         if (this.#sessionId !== turn.sessionId) return;
         this.#publishTranscriptReplacement(turn.sessionId, turn.turnId, messages, 'terminal');
+      })
+      .catch(() => undefined);
+  }
+
+  #refreshLiveTranscript(sessionId: string, turnId: string): void {
+    void loadCurrentMessages(this.#connection, sessionId)
+      .then((messages) => {
+        if (this.#sessionId !== sessionId) return;
+        this.#publishTranscriptReplacement(sessionId, turnId, messages, 'tool_result');
       })
       .catch(() => undefined);
   }

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -1029,8 +1029,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       },
       onInteractionResolved: (pending) => this.#resolveExternalInteraction(pending),
       onTurnTerminal: (turn) => this.#refreshTerminalTranscript(turn),
-      onToolResult: (turnId) =>
-        this.#refreshLiveTranscript(sessionId, sessionGeneration, turnId),
+      onToolResult: (turnId) => this.#refreshLiveTranscript(sessionId, sessionGeneration, turnId),
       onTranscriptReplaced: (turnId, messages) =>
         this.#publishTranscriptReplacement(sessionId, turnId, messages, 'reconnect'),
       onGoalChanged: (goal) => {

--- a/packages/cli/src/runtime-host-session-driver.ts
+++ b/packages/cli/src/runtime-host-session-driver.ts
@@ -176,6 +176,7 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
   readonly #startedTurnReattachTails = new Map<number, Promise<void>>();
   #sessionGeneration = 0;
   #channelGeneration = 0;
+  #liveTranscriptRefreshSequence = 0;
   readonly #startedTurnListeners = new Set<(turn: MakaAttachedSessionTurn) => void>();
   readonly #goalListeners = new Set<(goal: GoalProjection | null) => void>();
   readonly #pendingInteractionListeners = new Set<(pending: InteractionPendingSnapshot) => void>();
@@ -1028,7 +1029,8 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       },
       onInteractionResolved: (pending) => this.#resolveExternalInteraction(pending),
       onTurnTerminal: (turn) => this.#refreshTerminalTranscript(turn),
-      onToolResult: (turnId) => this.#refreshLiveTranscript(sessionId, turnId),
+      onToolResult: (turnId) =>
+        this.#refreshLiveTranscript(sessionId, sessionGeneration, turnId),
       onTranscriptReplaced: (turnId, messages) =>
         this.#publishTranscriptReplacement(sessionId, turnId, messages, 'reconnect'),
       onGoalChanged: (goal) => {
@@ -1080,10 +1082,17 @@ class RuntimeHostMakaSessionDriverImpl implements RuntimeHostMakaSessionDriver {
       .catch(() => undefined);
   }
 
-  #refreshLiveTranscript(sessionId: string, turnId: string): void {
+  #refreshLiveTranscript(sessionId: string, sessionGeneration: number, turnId: string): void {
+    const refreshSequence = ++this.#liveTranscriptRefreshSequence;
     void loadCurrentMessages(this.#connection, sessionId)
       .then((messages) => {
-        if (this.#sessionId !== sessionId) return;
+        if (
+          this.#sessionId !== sessionId ||
+          this.#sessionGeneration !== sessionGeneration ||
+          refreshSequence !== this.#liveTranscriptRefreshSequence
+        ) {
+          return;
+        }
         this.#publishTranscriptReplacement(sessionId, turnId, messages, 'tool_result');
       })
       .catch(() => undefined);

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -176,7 +176,7 @@ export type CreateSessionRequest = Omit<CreateSessionInput, 'permissionMode'> & 
   permissionMode?: PermissionMode;
 };
 
-export type MakaTranscriptReplacementReason = 'terminal' | 'reconnect';
+export type MakaTranscriptReplacementReason = 'terminal' | 'reconnect' | 'tool_result';
 
 export type SessionResumeAvailability = { available: true } | { available: false; reason: string };
 


### PR DESCRIPTION
## Summary

Fixes #3521.

Runtime Host live `tool_result` events intentionally omit durable content. The CLI previously reconciled those details only when a turn terminated, so cards that scrolled into terminal scrollback could remain stuck at `(no output)`. This change refreshes the durable transcript when each live tool result settles and reuses the existing transcript replacement/reconciliation path.

## Compatibility

No protocol or persisted-message changes. The live event contract remains unchanged; this only adds a CLI-side durable transcript refresh.

## Verification

- `npm install` — passed; repository dependency patches applied.
- `npm run build` — passed.
- `npm --workspace maka-agent run typecheck` — passed.
- `npm --workspace maka-agent test` — 359 passed, 12 failed in existing Windows managed-setup environment tests unrelated to this change; 1 skipped.
- `git diff --check` — passed.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex investigated Issue #3521, implemented the CLI change, and prepared the regression fix. The commit includes the required `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the existing reconciliation behavior and build/type checks pass
- [ ] Full CLI suite passes locally (12 unrelated Windows managed-setup failures noted above)

Does this PR entail a change in behavior?

- [x] Yes — live tool cards now receive durable results before turn termination
- [ ] No