### PR TITLE
fix(runtime-host): keep folded steering entries decodable in the followup queue

### DIFF
--- a/packages/runtime-host/src/__tests__/message-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/message-coordinator.test.ts
@@ -29,6 +29,7 @@ import type {
 import {
   MESSAGE_OPERATION_RESULT_MAX_BYTES,
   MESSAGE_QUEUE_PROJECTION_MAX_BYTES,
+  decodeSessionMessageQueueProjection,
   type SessionMessageQueueProjection,
   type TurnSnapshot,
 } from '../protocol/index.js';
@@ -1860,3 +1861,41 @@ function deferred<T>() {
   });
   return { promise, resolve };
 }
+
+test('a lone folded steering entry leaves the queue projection decodable', async () => {
+  // A steer the run never pulls is folded into `followup` at the terminal
+  // transition. It has to arrive there as a followup entry: the wire decoder
+  // requires `next_turn`, and an undecodable projection takes down the whole
+  // Host by way of the session continuity snapshot (#3530).
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  const submitted = await submitContent(
+    fixture,
+    'lone-steer',
+    { text: 'late steer', displayText: 'late steer' },
+    'current_turn',
+  );
+  assert.equal(submitted.ok, true, JSON.stringify(submitted));
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+
+  const projection = fixture.coordinator.projection(ROOT.sessionId);
+  assert.deepEqual(projection.steering, []);
+  assert.equal(projection.followup.length, 1);
+  assert.equal(projection.followup[0]?.placement, 'next_turn');
+  assert.doesNotThrow(() => decodeSessionMessageQueueProjection(projection));
+
+  // Durable provenance is unchanged: the source still records where the
+  // message was aimed, which is what makes the fold auditable.
+  assert.equal(batch.sources.length, 1);
+  assert.equal(batch.sources[0]?.placement, 'current_turn');
+  assert.equal(batch.sources[0]?.disposition, 'steering');
+
+  fixture.coordinator.commitNextRoot(batch, {
+    sessionId: ROOT.sessionId,
+    turnId: 'turn-2',
+    runId: 'run-2',
+  });
+});

--- a/packages/runtime-host/src/server/message-coordinator.ts
+++ b/packages/runtime-host/src/server/message-coordinator.ts
@@ -1347,7 +1347,7 @@ export class HostMessageCoordinator implements RuntimeMessageAuthority {
         ...[...state.inFlight.values()].map(inFlightSnapshot),
         ...steering.map(queuedSteeringSnapshot),
       ],
-      followup: followup.map(queuedSnapshot),
+      followup: followup.map(queuedFollowupSnapshot),
     };
   }
 
@@ -1475,6 +1475,19 @@ function queuedSteeringSnapshot(entry: LiveEntry): SteeringMessageSnapshot {
     throw new RuntimeMessageAuthorityInvariantError('Steering entry lost current-turn placement');
   }
   return { ...queuedSnapshot(entry), placement: 'current_turn' };
+}
+
+/**
+ * Queue position, not origin: an entry in the followup queue is a next-turn
+ * message by definition, including a steering entry the run never pulled and
+ * the terminal transition folded ahead of the followups. Where the message was
+ * originally aimed stays on `disposition` and on the durable
+ * {@link sourceFromEntry} record. Reporting a folded entry as `current_turn`
+ * here makes the projection fail its own wire decode, which takes the Host
+ * down through the session continuity snapshot (#3530).
+ */
+function queuedFollowupSnapshot(entry: LiveEntry): QueuedMessageSnapshot {
+  return { ...queuedSnapshot(entry), placement: 'next_turn' };
 }
 
 function inFlightSnapshot(entry: LiveEntry): SteeringMessageSnapshot {


### PR DESCRIPTION
## Summary

A steering message the run never pulls is folded into `followup` at the terminal transition, but the fold only resets `state` — the entry keeps `placement: 'current_turn'`. The followup queue projection then fails `decodeFollowupMessages`, which requires `next_turn`. That throw surfaces inside `createSessionContinuitySnapshot`, so `completeTerminalTransition` fails before `commitNextRoot`, `drainTurn`'s `finally` falls through to `abandonRootReservation`, the still-live entry trips `#failStop()`, and the Host drains mid-turn.

The fix projects followup entries by queue position: an entry in the followup queue is a next-turn message, whatever it was submitted as. Where the message was originally aimed already lives on `disposition` and on the durable `sourceFromEntry` record — which the existing fold test pins, and which this change deliberately leaves alone.

`queuedSnapshot` itself is unchanged because `retractedSnapshot` also builds on it, and a retracted steering entry legitimately carries `current_turn`.

Fixes #3530

## Verification

New unit test `a lone folded steering entry leaves the queue projection decodable` folds a lone unpulled steer and round-trips the projection through `decodeSessionMessageQueueProjection`. Without the fix it fails on `expected: 'next_turn' / actual: 'current_turn'`.

End-to-end, against a real Host with the fake backend's two steering drains temporarily disabled (they are what hides this today — see the "Final stranded drain" comment in `fake-backend.ts`), polling `queryTurn` every 500 ms:

```
before  t=500ms  running
before  t=1000ms RuntimeHostOperationError: Runtime Host is draining

after   t=500ms  running
after   t=1000ms completed
```

`after` matches a no-steer control exactly. That scaffolding is not part of this PR; #3529 covers why the steer is never pulled in the first place.

Ran: `message-coordinator` (31), `session-projector` (5), `execution-host-message` (4) — all green; `biome check` on both changed files; `npm run check:asf-headers`; `tsc -p packages/runtime-host`.

`canonical-session-projection` fails 7/7 here, all `EBUSY: resource busy or locked, unlink ...runtime.sqlite` on teardown. Verified pre-existing: identical 7/7 against a clean `origin/main` build of the same file. This is a Windows-only SQLite unlink problem in the fixture, unrelated to the change.

Not run: the rest of the `runtime-host` suite, Desktop, and Playwright — this change is confined to the Host queue projection.

## Root cause

The asymmetry that allowed it: `queuedSteeringSnapshot` already asserts its own placement invariant (`Steering entry lost current-turn placement`), and `inFlightSnapshot` does the same. The followup side had no guard, so a wrong placement reached the wire instead of failing loudly next to the code that produced it.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — investigation, root-cause tracing, the test, and the fix.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
