### PR TITLE
fix(runtime): give a late steer an injection point in the turn it was aimed at

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -13984,6 +13984,82 @@ describe('AiSdkBackend steering durability and identity', () => {
     }
   };
 
+  test('injects a steer that arrives after the turn last tool-call boundary', async () => {
+    // A tool-free turn runs exactly one provider step, and the top-of-loop
+    // drain happens before the model has said anything — so a steer typed
+    // while the answer streams has no boundary left to land on. Whether
+    // "Steer" works at all must not depend on the model happening to call a
+    // tool afterwards (#3529).
+    const model = textCompletionModel('done');
+    const backend = steeringBackend(model);
+    const acked: string[] = [];
+    const nacked: string[] = [];
+    let pulls = 0;
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({
+      turnId: 'turn-1',
+      text: 'start',
+      context: [],
+      pullSteering: () => {
+        pulls += 1;
+        // Nothing to take before the model speaks; the interjection lands
+        // while the first (and only) step is streaming.
+        if (pulls !== 2) return [];
+        return [{ id: 'lease-late', messageId: 'message-late', content: { text: 'late steer' } }];
+      },
+      ackSteering: (leaseIds) => acked.push(...leaseIds),
+      nackSteering: (leaseIds) => nacked.push(...leaseIds),
+    })) {
+      events.push(event);
+    }
+
+    const steering = events.filter((event) => event.type === 'steering_message');
+    assert.equal(steering.length, 1);
+    assert.deepEqual(acked, ['lease-late']);
+    assert.deepEqual(nacked, []);
+    // Echoing the message is not the point — the model has to be asked again
+    // with it. Draining without taking another step would satisfy every
+    // assertion above while the user still never gets an answer.
+    assert.equal(model.doStreamCalls.length, 2);
+    assert.match(JSON.stringify(model.doStreamCalls[1]?.prompt), /late steer/);
+  });
+
+  test('a stop that lands during the final drain wins over the injected steer', async () => {
+    // The final drain awaits a durable push, so an `after_step` stop can arrive
+    // while it is in flight. Deciding to take another step from flags read
+    // BEFORE that await would spend a provider step the user already stopped —
+    // which is precisely what `after_step` exists to prevent.
+    const model = textCompletionModel('done');
+    const backend = steeringBackend(model);
+    let pulls = 0;
+    const iterator = backend
+      .send({
+        turnId: 'turn-1',
+        text: 'start',
+        context: [],
+        pullSteering: () => {
+          pulls += 1;
+          if (pulls !== 2) return [];
+          return [{ id: 'lease-late', messageId: 'message-late', content: { text: 'late steer' } }];
+        },
+        ackSteering: () => {},
+      })
+      [Symbol.asyncIterator]();
+
+    for (;;) {
+      const next = await iterator.next();
+      if (next.done) break;
+      const event = next.value as SessionEvent;
+      // Consuming the echo is what resolves the drain's push, so the stop lands
+      // in the window between that resolution and the post-drain decision.
+      if (event.type === 'steering_message') await backend.stop('user_stop', 'after_step');
+    }
+
+    // The steer was still delivered — it is durable and the Host will carry it
+    // into the next Turn — but no further provider step was dispatched.
+    assert.equal(model.doStreamCalls.length, 1);
+  });
+
   test('holds the provider request until the steering event is durably consumed', async () => {
     // Persist-before-include: the initial user message is durable before the
     // backend is invoked, and a steered message holds the same line via the

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -13946,7 +13946,9 @@ function archiveGatedTurnEvents(suffix: 'a' | 'b', path: string, result: unknown
 describe('AiSdkBackend steering durability and identity', () => {
   const steeringBackend = (
     model: MockLanguageModelV4,
-    options: Partial<Pick<AiSdkBackendInput, 'supportsVision' | 'readAttachmentBytes'>> = {},
+    options: Partial<
+      Pick<AiSdkBackendInput, 'supportsVision' | 'readAttachmentBytes' | 'loadTurnRuntimeEvents'>
+    > = {},
   ): AiSdkBackend =>
     createTestAiSdkBackend({
       sessionId: 'session-1',
@@ -13990,28 +13992,32 @@ describe('AiSdkBackend steering durability and identity', () => {
     // while the answer streams has no boundary left to land on. Whether
     // "Steer" works at all must not depend on the model happening to call a
     // tool afterwards (#3529).
-    const model = textCompletionModel('done');
-    const backend = steeringBackend(model);
+    const model = textCompletionModel('the first answer');
+    const durable = durableTurnHarness('turn-1', 'start');
+    const backend = steeringBackend(model, {
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+    });
     const acked: string[] = [];
     const nacked: string[] = [];
     let pulls = 0;
-    const events: SessionEvent[] = [];
-    for await (const event of backend.send({
-      turnId: 'turn-1',
-      text: 'start',
-      context: [],
-      pullSteering: () => {
-        pulls += 1;
-        // Nothing to take before the model speaks; the interjection lands
-        // while the first (and only) step is streaming.
-        if (pulls !== 2) return [];
-        return [{ id: 'lease-late', messageId: 'message-late', content: { text: 'late steer' } }];
-      },
-      ackSteering: (leaseIds) => acked.push(...leaseIds),
-      nackSteering: (leaseIds) => nacked.push(...leaseIds),
-    })) {
-      events.push(event);
-    }
+    const events = await drainDurably(
+      backend.send(
+        durable.input({
+          pullSteering: () => {
+            pulls += 1;
+            // Nothing to take before the model speaks; the interjection lands
+            // while the first (and only) step is streaming.
+            if (pulls !== 2) return [];
+            return [
+              { id: 'lease-late', messageId: 'message-late', content: { text: 'late steer' } },
+            ];
+          },
+          ackSteering: (leaseIds: readonly string[]) => acked.push(...leaseIds),
+          nackSteering: (leaseIds: readonly string[]) => nacked.push(...leaseIds),
+        }),
+      ),
+      durable,
+    );
 
     const steering = events.filter((event) => event.type === 'steering_message');
     assert.equal(steering.length, 1);
@@ -14021,7 +14027,42 @@ describe('AiSdkBackend steering durability and identity', () => {
     // with it. Draining without taking another step would satisfy every
     // assertion above while the user still never gets an answer.
     assert.equal(model.doStreamCalls.length, 2);
-    assert.match(JSON.stringify(model.doStreamCalls[1]?.prompt), /late steer/);
+    const secondPrompt = JSON.stringify(model.doStreamCalls[1]?.prompt);
+    assert.match(secondPrompt, /late steer/);
+    // …and it has to carry what the model just said, or the correction lands on
+    // work the model cannot see.
+    assert.match(secondPrompt, /the first answer/);
+  });
+
+  test('the late-steer edge is skipped without a durable current-run reader', async () => {
+    // The no-reader projection at the top of the loop appends steering alone —
+    // it never appends the assistant output of the step just finished. Taking
+    // the continuation edge there would ask the model to redirect work it
+    // cannot see, so the edge requires the reader the way the tool-call edge
+    // does. The turn still completes; the Host folds the message into the next
+    // Turn, which is the behaviour before #3529.
+    const model = textCompletionModel('the first answer');
+    const backend = steeringBackend(model);
+    const acked: string[] = [];
+    let pulls = 0;
+    const events: SessionEvent[] = [];
+    for await (const event of backend.send({
+      turnId: 'turn-1',
+      text: 'start',
+      context: [],
+      pullSteering: () => {
+        pulls += 1;
+        if (pulls !== 2) return [];
+        return [{ id: 'lease-late', messageId: 'message-late', content: { text: 'late steer' } }];
+      },
+      ackSteering: (leaseIds) => acked.push(...leaseIds),
+    })) {
+      events.push(event);
+    }
+
+    assert.equal(model.doStreamCalls.length, 1);
+    assert.equal(events.filter((event) => event.type === 'steering_message').length, 0);
+    assert.deepEqual(acked, []);
   });
 
   test('a stop that lands during the final drain wins over the injected steer', async () => {
@@ -14030,26 +14071,33 @@ describe('AiSdkBackend steering durability and identity', () => {
     // BEFORE that await would spend a provider step the user already stopped —
     // which is precisely what `after_step` exists to prevent.
     const model = textCompletionModel('done');
-    const backend = steeringBackend(model);
+    const durable = durableTurnHarness('turn-1', 'start');
+    // The reader has to be present, or the edge is skipped for that reason
+    // instead and this test would pass while exercising nothing.
+    const backend = steeringBackend(model, {
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+    });
     let pulls = 0;
     const iterator = backend
-      .send({
-        turnId: 'turn-1',
-        text: 'start',
-        context: [],
-        pullSteering: () => {
-          pulls += 1;
-          if (pulls !== 2) return [];
-          return [{ id: 'lease-late', messageId: 'message-late', content: { text: 'late steer' } }];
-        },
-        ackSteering: () => {},
-      })
+      .send(
+        durable.input({
+          pullSteering: () => {
+            pulls += 1;
+            if (pulls !== 2) return [];
+            return [
+              { id: 'lease-late', messageId: 'message-late', content: { text: 'late steer' } },
+            ];
+          },
+          ackSteering: () => {},
+        }),
+      )
       [Symbol.asyncIterator]();
 
     for (;;) {
       const next = await iterator.next();
       if (next.done) break;
       const event = next.value as SessionEvent;
+      durable.record(event);
       // Consuming the echo is what resolves the drain's push, so the stop lands
       // in the window between that resolution and the post-drain decision.
       if (event.type === 'steering_message') await backend.stop('user_stop', 'after_step');

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2791,7 +2791,15 @@ export class AiSdkBackend implements AgentBackend {
             currentStepMessageId = this.newId();
             continue agentLoop;
           }
-          if (mayTakeAnotherStep) {
+          // Continuing the turn needs the durable current-run reader, for the
+          // same reason the tool-call edge above demands it: the next request
+          // has to carry the assistant output this step just produced, and only
+          // the ledger projection has it. The no-reader fallback at the top of
+          // the loop appends steering alone, which would ask the model to
+          // redirect work it cannot see. Without a reader this edge is skipped
+          // rather than throwing — the turn still completes and the Host folds
+          // the message into the next Turn, which is today's behaviour.
+          if (mayTakeAnotherStep && this.input.loadTurnRuntimeEvents) {
             // Last chance for a steer that landed after this turn's final
             // tool-call boundary — including the only boundary a tool-free
             // turn has, which precedes the model's first token. Without it the

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2785,14 +2785,34 @@ export class AiSdkBackend implements AgentBackend {
             ...(providerStepUsage ? { usage: providerStepUsage } : {}),
           });
           const stepLimitReached = maxSteps !== undefined && runtimeSteps >= maxSteps;
-          if (
-            returnedToolCalls.length > 0 &&
-            !stepLimitReached &&
-            !scope.loopStopRequested &&
-            !scope.aborted
-          ) {
+          const mayTakeAnotherStep =
+            !stepLimitReached && !scope.loopStopRequested && !scope.aborted;
+          if (returnedToolCalls.length > 0 && mayTakeAnotherStep) {
             currentStepMessageId = this.newId();
             continue agentLoop;
+          }
+          if (mayTakeAnotherStep) {
+            // Last chance for a steer that landed after this turn's final
+            // tool-call boundary — including the only boundary a tool-free
+            // turn has, which precedes the model's first token. Without it the
+            // message is never pulled at all, and whether Steer works would
+            // depend on the model happening to call a tool afterwards (#3529).
+            // A step-limited turn deliberately skips this: its budget is spent,
+            // and the Host folds the message into the next Turn instead.
+            const injectedBefore = scope.injectedSteeringMessages.length;
+            await this.drainSteeringInto(scope, input, queue);
+            // Re-read the stop flags: the drain awaits a durable push, so an
+            // `after_step` stop or an abort can land while it is in flight, and
+            // `mayTakeAnotherStep` is stale by now. Stop wins — the message is
+            // already durable, so the Host folds it into the next Turn.
+            if (
+              scope.injectedSteeringMessages.length > injectedBefore &&
+              !scope.loopStopRequested &&
+              !scope.aborted
+            ) {
+              currentStepMessageId = this.newId();
+              continue agentLoop;
+            }
           }
           break agentLoop;
         }


### PR DESCRIPTION
## Summary

`drainSteeringInto` runs only at the top of an `agentLoop` iteration, and the loop only iterates again when the step returned tool calls. A tool-free turn therefore has exactly one drain, and it happens before the model's first token — so a steer typed while the answer streams is never pulled. Whether "Steer" works at all depended on whether the model happened to call a tool afterwards, which the user cannot know when they press Enter.

This drains once more before leaving the loop and takes another step when something was injected, so the message lands in the turn the user aimed it at. A step-limited, stopped, or aborted turn deliberately skips it — the budget is spent or the turn is ending on purpose, and the Host folds the message into the next Turn instead.

No protocol change: `drainSteeringInto` already owns pull, injection and ack, and `scope.injectedSteeringMessages` already tells the caller whether anything landed. `pullSteering` is a lease, so it cannot be used as a probe — draining and then continuing is what keeps the lease honest.

Fixes #3529

## Verification

New test `injects a steer that arrives after the turn last tool-call boundary`: a `pullSteering` that is empty on the first call and yields a message on the second — the real timing of pressing Enter after streaming starts — against a text-only model.

It asserts the model is actually asked again with the steer, not just that the echo was emitted:

```
assert.equal(model.doStreamCalls.length, 2);
assert.match(JSON.stringify(model.doStreamCalls[1]?.prompt), /late steer/);
```

Checked against both weaker builds, per the repo's habit of proving a guard bites:

- without the fix: `steering_message` count `expected: 1, actual: 0`
- with a drain that does **not** take another step: `doStreamCalls expected: 2, actual: 1` — the echo and the ack both happen, and the user still never gets an answer

Ran: `ai-sdk-backend` (205), `fake-backend` (4), `overflow-reactive-recovery` (43) — all green; `message-coordinator` and `execution-host-message` in `runtime-host` (34) — green; `biome check` on both changed files; `tsc -p packages/runtime`.

`agent-run-steering-recovery` fails 8/8 here, all `EBUSY: resource busy or locked, unlink ...runtime.sqlite` on teardown. Verified pre-existing: identical 8/8 against a clean `origin/main` build. Windows-only fixture problem, unrelated to the change.

Not run: Desktop and Playwright.

## Review focus

The fake backend already drains between chunks *and* once after the last chunk, commented "Final stranded drain (grok-build safety): a steer that landed after the last boundary still lands in this turn instead of being lost". That safety net is why the suites were green while the real backend lost the message — this change gives `AiSdkBackend` the boundary the fake has always assumed.

Independent of #3530: that one fixes what happens to a message that still ends up folded (step limit, stop, abort). Both are needed; neither subsumes the other.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — investigation, root-cause tracing, the test, and the fix.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
