### PR TITLE
test(core): keep timestamp refresh delays within the scheduler bound

### DIFF
--- a/packages/core/src/__tests__/relative-time.test.ts
+++ b/packages/core/src/__tests__/relative-time.test.ts
@@ -58,7 +58,7 @@ describe('relative timestamp labels', () => {
     assert.equal(formatCompactTimestamp(futureTs, NOW, 'en'), 'just now');
   });
 
-  it('keeps finite timestamp refresh delays within the scheduler bound', () => {
+  it('keeps timestamp refresh delays within the scheduler bound', () => {
     for (const ts of [
       NOW - 60_000,
       NOW - 60 * 60_000,


### PR DESCRIPTION
Fixes #3364 follow-up P3: test name said finite but covered Infinity/NaN. Rename to neutral.\n\nGenerated-by: Muse Spark