### PR TITLE
docs: turn the Simplified Chinese README link into a 中文文档 badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 </p>
 
 <p align="center">
-  <sub><a href="./README.zh-CN.md">简体中文</a></sub>
+  <a href="./README.zh-CN.md"><img src="https://img.shields.io/badge/%E4%B8%AD%E6%96%87%E6%96%87%E6%A1%A3-4C8DFF?style=flat" alt="中文文档" /></a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,7 +33,7 @@
 </p>
 
 <p align="center">
-  <sub><a href="./README.md">English</a></sub>
+  <a href="./README.md"><img src="https://img.shields.io/badge/English-4C8DFF?style=flat" alt="English" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
The English README linked to `README.zh-CN.md` with a small subscript `简体中文` text link. Make that a shields.io badge whose label is **中文文档**, matching the other header badges.

The Chinese README gets the same treatment for `English`, so the language switch looks the same from both sides.

## Test plan
- [x] shields.io returns SVG with aria-label/title `中文文档`
- [ ] GitHub renders the badge on this PR's README preview
- [ ] Clicking the badge opens `README.zh-CN.md` (and `English` opens `README.md`)

Do not merge unless asked.