### PR TITLE
fix(runtime): route OpenCode Go Muse Spark through Responses

### DIFF
--- a/packages/core/src/__tests__/model-metadata.test.ts
+++ b/packages/core/src/__tests__/model-metadata.test.ts
@@ -95,4 +95,13 @@ describe('openAiAdapterApiProtocol', () => {
     assert.equal(openAiAdapterApiProtocol('deepseek-v4-pro', 'deepseek'), 'openai-responses');
     assert.equal(openAiAdapterApiProtocol('deepseek-chat', 'deepseek'), 'openai-chat');
   });
+
+  it('routes only OpenCode Go Muse Spark through its supported Responses wire', () => {
+    assert.equal(
+      openAiAdapterApiProtocol('muse-spark-1.2-contributor', 'opencode-go'),
+      'openai-responses',
+    );
+    assert.equal(openAiAdapterApiProtocol('muse-spark-1.2-contributor', 'opencode'), 'openai-chat');
+    assert.equal(openAiAdapterApiProtocol('minimax-m3', 'opencode-go'), 'openai-chat');
+  });
 });

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -137,6 +137,7 @@ export function openAiAdapterApiProtocol(
 ): 'openai-responses' | 'openai-chat' {
   const id = modelId.trim();
   return (providerType === 'deepseek' && deepSeekModelSupportsResponses(id)) ||
+    (providerType === 'opencode-go' && id === 'muse-spark-1.2-contributor') ||
     /^gpt-5/i.test(id) ||
     ((providerType === 'xai' || providerType === 'xai-oauth') && id === 'grok-4.5')
     ? 'openai-responses'

--- a/packages/runtime/src/__tests__/responses-wire-contract.test.ts
+++ b/packages/runtime/src/__tests__/responses-wire-contract.test.ts
@@ -68,6 +68,32 @@ describe('responses wire contract', () => {
     );
   });
 
+  test('routes OpenCode Go Muse Spark through the Responses endpoint', async () => {
+    const urls: string[] = [];
+    const fetch = (async (url: string | URL | Request) => {
+      urls.push(String(url));
+      return Response.json({
+        id: 'r',
+        object: 'response',
+        status: 'completed',
+        output: [],
+        usage: { input_tokens: 1, output_tokens: 1 },
+      });
+    }) as typeof globalThis.fetch;
+    const model = getAIModel({
+      connection: conn('opencode-go'),
+      apiKey: '[redacted]',
+      modelId: 'muse-spark-1.2-contributor',
+      fetch,
+    });
+
+    await model.doGenerate({
+      prompt: [{ role: 'user', content: [{ type: 'text', text: 'ping' }] }],
+    });
+
+    assert.deepEqual(urls, ['https://opencode.ai/zen/go/v1/responses']);
+  });
+
   test('normalizes the upstream Open Responses endpoint exactly once', () => {
     assert.equal(
       openResponsesUrl('https://api.deepseek.com/v1'),


### PR DESCRIPTION
## Summary

`opencode-go/muse-spark-1.2-contributor` failed in Maka because the model resolved to the native OpenAI adapter but defaulted to the Chat Completions wire. That endpoint returns content without a reliable terminal `finish_reason`, so Maka's strict stream settlement correctly reports the ambiguous EOF as truncated.

Route this exact provider/model pair through the OpenAI Responses API instead. The Responses endpoint provides an explicit terminal response event, so no EOF inference or relaxation of Maka's truncation and tool-safety checks is needed.

This matches the model-specific routing correction merged in [can1357/oh-my-pi#8980](https://github.com/can1357/oh-my-pi/pull/8980).

Fixes #3548

## Verification

- `packages/core`
  - build passed
  - `model-metadata.test.js`: 10 passed
- `packages/runtime`
  - build passed
  - `responses-wire-contract.test.js`: 13 passed
  - verifies the final request URL is `https://opencode.ai/zen/go/v1/responses`
- `biome check` on all changed files: passed
- Live sandboxed verification against OpenCode Go:
  - a text-only turn completed successfully
  - a turn requiring the `Read` tool completed successfully and returned the expected package name

Not run: full-repository suite, Desktop, Playwright.

## Review focus

The override is scoped to `opencode-go/muse-spark-1.2-contributor`, the only affected model currently exposed by Maka's OpenCode Go catalog. Other OpenCode providers and models keep their existing protocol selection.

This change does not modify stream parsing, finish-reason settlement, retry behavior, or tool-call authorization. Ambiguous Chat Completions EOFs remain fail-closed.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tools and scope:

- Claude Code — initial investigation and first implementation.
- OpenAI Codex — corrected root-cause investigation, final implementation and tests, live verification, and PR rewrite.

The final commit carries a `Generated-by: OpenAI Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — the affected OpenCode Go model now uses the Responses API
- [ ] No