### PR TITLE
fix(desktop): preserve completed SSH management results

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-ssh-terminal.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-ssh-terminal.test.ts
@@ -271,6 +271,43 @@ test('reads a framed service result without projecting it into the SSH terminal'
   await harness.terminal.close();
 });
 
+test('keeps a received management result when SSH teardown times out', async () => {
+  const harness = createHarness('pending', { managementTimeoutMs: 1 });
+  harness.pty.deferKill = true;
+  harness.pty.exitOnForceKill = true;
+  const management = harness.terminal.runServiceManagement({
+    destination: 'operator@example.com',
+    operatorPath: '/home/operator/.local/share/maka/operator',
+    action: 'status',
+    expectedTarget: {
+      serviceId: 'b'.repeat(64),
+      rootPath: '/srv/maka',
+      rootId: 'a'.repeat(64),
+    },
+  });
+  harness.pty.emitData(
+    encodeRuntimeHostServiceManagementFrame({
+      schemaVersion: 1,
+      kind: 'result',
+      action: 'status',
+      service: {
+        platform: 'linux',
+        arch: 'x64',
+        osRelease: '6.8.0',
+        state: 'running',
+        pid: 42,
+        lastExitCode: 0,
+        installedVersion: '1.2.3',
+        projectDirectoryRoots: [],
+      },
+    }),
+  );
+
+  assert.equal((await management).kind, 'result');
+  assert.deepEqual(harness.pty.killSignals, ['SIGTERM', 'SIGKILL']);
+  await harness.terminal.close();
+});
+
 test('keeps a prepared access credential out of the SSH terminal projection', async () => {
   const harness = createHarness('pending');
   const credential = 'maka_rh_secret-replacement';
@@ -455,7 +492,10 @@ test('uploads a development release archive before running the same remote setup
   await assert.rejects(setup, /exited with code 255/u);
 });
 
-function createHarness(mode: 'pending' | 'exit') {
+function createHarness(
+  mode: 'pending' | 'exit',
+  options: { readonly managementTimeoutMs?: number } = {},
+) {
   const handlers = new Map<string, (...args: unknown[]) => unknown>();
   const events: Array<{ kind: string }> = [];
   const pty = new FakePty();
@@ -476,6 +516,7 @@ function createHarness(mode: 'pending' | 'exit') {
       return pty as unknown as IPty;
     }) as typeof import('node-pty').spawn,
     revealDelayMs: 0,
+    ...options,
     processStopGraceMs: 1,
     openSshTunnel: async (input, overrides) => {
       const spawnProcess = overrides?.spawnProcess as RuntimeHostSshProcessFactory;

--- a/apps/desktop/src/main/runtime-host-ssh-terminal.ts
+++ b/apps/desktop/src/main/runtime-host-ssh-terminal.ts
@@ -140,6 +140,7 @@ export function createDesktopRuntimeHostSshTerminal(input: {
   readonly spawnPty?: typeof spawnPty;
   readonly openSshTunnel?: typeof openRuntimeHostSshTunnel;
   readonly revealDelayMs?: number;
+  readonly managementTimeoutMs?: number;
   readonly processStopGraceMs?: number;
 }): {
   openSshTunnel(input: RuntimeHostSshTunnelInput): Promise<RuntimeHostSshTunnel>;
@@ -402,10 +403,9 @@ export function createDesktopRuntimeHostSshTerminal(input: {
     );
     activeTerminal = terminal;
     if (frame) completePresentation(terminal);
-    const result = await waitForTerminalProcess(process, {
+    const wait = await waitForTerminalProcess(process, {
       signal: options.signal,
-      timeoutMs: MANAGEMENT_TIMEOUT_MS,
-      timeoutMessage: `${options.label} timed out`,
+      timeoutMs: input.managementTimeoutMs ?? MANAGEMENT_TIMEOUT_MS,
       stopGraceMs: input.processStopGraceMs,
       onAbort: () => dismissPresentation(terminal),
     });
@@ -413,9 +413,11 @@ export function createDesktopRuntimeHostSshTerminal(input: {
     if (failure) throw failure;
     if (!frame) {
       throw new Error(
-        result.code === 0
+        wait.timedOut
+          ? `${options.label} timed out`
+          : wait.exit.code === 0
           ? `${options.label} ended without a result`
-          : `${options.label} exited with code ${String(result.code)}`,
+          : `${options.label} exited with code ${String(wait.exit.code)}`,
       );
     }
     completePresentation(terminal);
@@ -483,10 +485,9 @@ export function createDesktopRuntimeHostSshTerminal(input: {
         );
         setupTerminal = terminal;
         if (complete) completePresentation(terminal);
-        const result = await waitForTerminalProcess(process, {
+        const wait = await waitForTerminalProcess(process, {
           signal: cancellation.signal,
           timeoutMs: SETUP_TIMEOUT_MS,
-          timeoutMessage: 'Remote Maka setup timed out',
           stopGraceMs: input.processStopGraceMs,
           onAbort: () => dismissPresentation(terminal),
         });
@@ -494,11 +495,13 @@ export function createDesktopRuntimeHostSshTerminal(input: {
         if (setupFailure) throw setupFailure;
         if (!complete) {
           throw new Error(
-            result.code === 0
+            wait.timedOut
+              ? 'Remote Maka setup timed out'
+              : wait.exit.code === 0
               ? 'Remote Maka setup ended without a completion result'
-              : result.code === 2
+              : wait.exit.code === 2
                 ? 'The released Maka CLI on this channel does not support automated Runtime Host setup'
-                : `Remote Maka setup exited with code ${String(result.code)}`,
+                : `Remote Maka setup exited with code ${String(wait.exit.code)}`,
           );
         }
         completePresentation(terminal);
@@ -546,16 +549,18 @@ export function createDesktopRuntimeHostSshTerminal(input: {
         undefined,
         true,
       );
-      const result = await waitForTerminalProcess(process, {
+      const wait = await waitForTerminalProcess(process, {
         signal: cleanupInput.signal,
-        timeoutMs: MANAGEMENT_TIMEOUT_MS,
-        timeoutMessage: 'Remote Runtime Host deployment cleanup timed out',
+        timeoutMs: input.managementTimeoutMs ?? MANAGEMENT_TIMEOUT_MS,
         stopGraceMs: input.processStopGraceMs,
         onAbort: () => dismissPresentation(terminal),
       });
-      if (result.code !== 0) {
+      if (wait.timedOut) {
+        throw new Error('Remote Runtime Host deployment cleanup timed out');
+      }
+      if (wait.exit.code !== 0) {
         throw new Error(
-          `Remote Runtime Host deployment cleanup exited with code ${String(result.code)}`,
+          `Remote Runtime Host deployment cleanup exited with code ${String(wait.exit.code)}`,
         );
       }
       completePresentation(terminal);
@@ -723,16 +728,18 @@ async function prepareSetupPackage(
     archive,
     `${destination}:${remoteArchive}`,
   ], undefined, true);
-  const result = await waitForTerminalProcess(process, {
+  const wait = await waitForTerminalProcess(process, {
     signal,
     timeoutMs: SETUP_TIMEOUT_MS,
-    timeoutMessage: 'Uploading the Runtime Host development package timed out',
     stopGraceMs,
     onAbort: () => dismissPresentation(terminal),
   });
-  if (result.code !== 0) {
+  if (wait.timedOut) {
+    throw new Error('Uploading the Runtime Host development package timed out');
+  }
+  if (wait.exit.code !== 0) {
     throw new Error(
-      `Uploading the Runtime Host development package exited with code ${String(result.code)}`,
+      `Uploading the Runtime Host development package exited with code ${String(wait.exit.code)}`,
     );
   }
   return { specifier: remoteArchive, removeAfterSetup: remoteArchive };
@@ -749,11 +756,13 @@ async function waitForTerminalProcess(
   input: {
     readonly signal?: AbortSignal;
     readonly timeoutMs: number;
-    readonly timeoutMessage: string;
     readonly stopGraceMs?: number;
     readonly onAbort?: () => void;
   },
-): Promise<Awaited<RuntimeHostSshProcess['exited']>> {
+): Promise<{
+  readonly exit: Awaited<RuntimeHostSshProcess['exited']>;
+  readonly timedOut: boolean;
+}> {
   let requestStop!: (reason: 'aborted' | 'timeout') => void;
   let stopReason: 'aborted' | 'timeout' | undefined;
   const stopRequested = new Promise<'aborted' | 'timeout'>((resolve) => {
@@ -777,8 +786,7 @@ async function waitForTerminalProcess(
       }),
     ]);
     input.signal?.throwIfAborted();
-    if (stopReason === 'timeout') throw new Error(input.timeoutMessage);
-    return result;
+    return { exit: result, timedOut: stopReason === 'timeout' };
   } finally {
     clearTimeout(timeout);
     input.signal?.removeEventListener('abort', onAbort);


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Preserve a fully decoded Runtime Host setup or management frame when the SSH process misses its exit deadline. The SSH process is still terminated and reaped within the existing bounds; only the already-known remote operation outcome stops being replaced by a transport timeout.

Unframed upload and deployment-cleanup operations, malformed frames, and calls that time out before receiving a complete frame continue to fail.

Fixes #3546

## Verification

- `npm --workspace @maka/desktop test` — 1193 tests passed
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:asf-headers`
- `npx knip --workspace apps/desktop`

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex implemented and verified the SSH management timeout fix under maintainer direction

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 摘要

当 Runtime Host setup 或 management frame 已完整解码后，即使 SSH 进程未能在退出期限内结束，也保留该远端操作结果。SSH 进程仍会按现有边界被终止并回收；本 PR 只防止已知的远端结果被传输收尾超时覆盖。

没有 frame 的上传与 deployment cleanup、畸形 frame，以及在收到完整 frame 前发生的超时仍然失败。

修复 #3546

## 验证

- `npm --workspace @maka/desktop test` — 1193 项测试通过
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- `npm run check:asf-headers`
- `npx knip --workspace apps/desktop`

## AI 使用

Codex 在维护者指导下实现并验证了 SSH management timeout 修复

## 检查清单

- 测试覆盖该变更，且在修复前会失败
- lint、format、typecheck 与相关测试套件均已在本地通过
- 本 PR 包含行为变更，已在摘要中说明

</details>
