### PR TITLE
fix(cli,runtime): enforce --max-steps on maka run turns

### DIFF
--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -19,7 +19,9 @@
 
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { parseMakaRunArgs } from '../run-command-core.js';
+import type { UserMessageInput } from '@maka/core/runtime-inputs';
+import type { SessionSummary } from '@maka/core/session';
+import { parseMakaRunArgs, runMakaTextCliCore, type MakaRunAdapter } from '../run-command-core.js';
 
 describe('maka run argument parsing', () => {
   test('recognizes stdin prompt mode and rejects malformed limits', () => {
@@ -70,4 +72,79 @@ describe('maka run argument parsing', () => {
       'error',
     );
   });
+
+  test('forwards --max-steps to local and Graph turn inputs', async () => {
+    for (const graph of [false, true]) {
+      const messages: UserMessageInput[] = [];
+      const adapter: MakaRunAdapter = {
+        listSessions: async () => [],
+        createContext: async (input) => ({
+          runtime: {
+            createSession: async () => sessionSummary(),
+            readExecutionBoundary: async () => ({
+              kind: 'managed',
+              access: 'writable',
+              revision: 0,
+            }),
+            sendMessage: async function* (_sessionId, message) {
+              messages.push(message);
+              await input.runOutcomeObserver?.({
+                outcomeId: message.turnId,
+                status: 'completed',
+                finalOutput: 'done',
+                sandboxBoundary: 'none',
+              });
+            },
+            respondToSandboxBoundary: async () => {},
+            stopSession: async () => {},
+            setExecutionBoundaryKind: async () => {},
+          },
+          target: { connection: { slug: 'test' }, model: 'test' },
+          agentGraph: {
+            reserveActivity: () => ({ release: () => {} }),
+            waitForCompletion: async () => {},
+          },
+          close: async () => {},
+        }),
+      };
+
+      const exitCode = await runMakaTextCliCore(
+        ['answer once', '--max-steps', '2', ...(graph ? ['--graph'] : [])],
+        adapter,
+        {
+          workspaceRoot: () => process.cwd(),
+          processCwd: () => process.cwd(),
+          stdinIsTTY: () => true,
+          writeStdout: () => {},
+          writeStderr: () => {},
+          onSigint: () => () => {},
+          newId: () => 'turn-1',
+        },
+      );
+
+      assert.equal(exitCode, 0);
+      assert.equal(messages.length, 1);
+      assert.equal(messages[0]?.maxSteps, 2);
+    }
+  });
 });
+
+function sessionSummary(): SessionSummary {
+  return {
+    id: 'session-1',
+    cwd: process.cwd(),
+    name: 'Run once',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'test',
+    connectionLocked: true,
+    model: 'test',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  };
+}

--- a/packages/cli/src/run-command-core.ts
+++ b/packages/cli/src/run-command-core.ts
@@ -397,6 +397,7 @@ export async function runMakaTextCliCore(
     for await (const event of context.runtime.sendMessage(session.id, {
       turnId: deps.newId(),
       text: prompt,
+      ...(parsed.options.maxSteps !== undefined ? { maxSteps: parsed.options.maxSteps } : {}),
       ...(parsed.options.graph
         ? { turnOrchestration: { mode: 'graph' as const, source: 'host_api' as const } }
         : {}),

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -154,6 +154,60 @@ test('prepares a fresh Agent Graph epoch before durable external Turn admission'
   }
 });
 
+test('turn.start enforces the admitted step cap at the backend boundary', async () => {
+  let backend: StepCapProbeBackend | undefined;
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => {
+      backends.register('ai-sdk', (context) => {
+        backend = new StepCapProbeBackend(context.sessionId);
+        return backend;
+      });
+    },
+  });
+  try {
+    const turnId = 'turn-step-cap';
+    const started = await fixture.interactiveTurns.handlers['turn.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId,
+        content: { text: 'Keep calling Read.' },
+        maxSteps: 1,
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assertStartedTurn(started);
+    await fixture.coordinator.whenIdle(fixture.sessionId);
+
+    const admission = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      turnId,
+    );
+    assert.equal(
+      admission?.execution.kind === 'external_message' ? admission.execution.maxSteps : undefined,
+      1,
+    );
+    assert.equal(backend?.sendInputs[0]?.maxSteps, 1);
+    assert.equal(backend?.providerSteps, 1);
+
+    const runtimeEvents = await fixture.stores.runtimeEventStore.readRuntimeEvents(
+      fixture.sessionId,
+      started.result.turn.runId,
+    );
+    assert.equal(
+      runtimeEvents.filter((event) => event.content?.kind === 'function_call').length,
+      1,
+    );
+    assert.deepEqual(runtimeEvents.at(-1)?.actions?.stateDelta, {
+      stopReason: 'step_limit',
+      failureClass: 'tool_step_cap_reached',
+    });
+  } finally {
+    await fixture.coordinator.close();
+    await fixture.messages.close();
+    await fixture.dispose();
+  }
+});
+
 test('does not advance a finished graph for an ordinary default Turn', async () => {
   let cutovers = 0;
   const fixture = await createFailureFixture({
@@ -5077,6 +5131,52 @@ class LinkedChildAuthorityBackend implements AgentBackend {
   async dispose(): Promise<void> {
     this.releaseWait?.();
   }
+}
+
+class StepCapProbeBackend implements AgentBackend {
+  readonly kind = 'ai-sdk' as const;
+  readonly sendInputs: BackendSendInput[] = [];
+  providerSteps = 0;
+
+  constructor(readonly sessionId: string) {}
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.sendInputs.push(input);
+    const stepLimit = input.maxSteps ?? 3;
+    for (let step = 1; step <= stepLimit; step += 1) {
+      this.providerSteps += 1;
+      const toolUseId = `tool-${step}`;
+      yield {
+        type: 'tool_start',
+        id: randomUUID(),
+        turnId: input.turnId,
+        ts: Date.now(),
+        toolUseId,
+        toolName: 'Read',
+        args: { path: `notes-${step}.md` },
+      };
+      yield {
+        type: 'tool_result',
+        id: randomUUID(),
+        turnId: input.turnId,
+        ts: Date.now(),
+        toolUseId,
+        isError: false,
+        content: { kind: 'text', text: 'ok' },
+      };
+    }
+    yield {
+      type: 'complete',
+      id: randomUUID(),
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'step_limit',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToSandboxBoundary(): Promise<void> {}
+  async dispose(): Promise<void> {}
 }
 
 class BlockingRootBackend implements AgentBackend {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -5531,6 +5531,92 @@ describe('SessionManager permission mode updates', () => {
     expect(runtimeEvents[2]?.status).toBe('completed');
   });
 
+  test('RuntimeKernel preserves the per-turn step cap through RuntimeRunner', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    let providerSteps = 0;
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        providerSteps += 1;
+        return {
+          stream: simulateReadableStream({
+            chunks: [
+              { type: 'stream-start', warnings: [] },
+              {
+                type: 'tool-call',
+                toolCallId: `tool-${providerSteps}`,
+                toolName: 'Read',
+                input: JSON.stringify({ path: `notes-${providerSteps}.md` }),
+              },
+              {
+                type: 'finish',
+                finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
+                usage: {
+                  inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+                  outputTokens: { total: 1, text: 1, reasoning: 0 },
+                },
+              },
+            ] as LanguageModelV4StreamPart[],
+            initialDelayInMs: null,
+            chunkDelayInMs: null,
+          }),
+        };
+      },
+    });
+    backends.register('ai-sdk', (ctx) =>
+      createTestAiSdkBackend({
+        sessionId: ctx.sessionId,
+        header: ctx.header,
+        appendMessage: ctx.appendMessage ?? (async () => {}),
+        connection: {
+          slug: 'mock-main',
+          providerType: 'anthropic',
+          defaultModel: 'mock-model-id',
+        },
+        apiKey: 'sk-test',
+        modelId: 'mock-model-id',
+        modelFactory: () => model,
+        tools: [
+          {
+            name: 'Read',
+            description: 'Read a file',
+            parameters: z.object({ path: z.string() }),
+            impl: async () => ({ ok: true }),
+          },
+        ],
+        maxSteps: 3,
+        ...(ctx.loadTurnRuntimeEvents ? { loadTurnRuntimeEvents: ctx.loadTurnRuntimeEvents } : {}),
+        newId: nextId(),
+        now: nextNow(1),
+      }),
+    );
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_525),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'bypass' }));
+
+    const events = await collectSessionEvents(
+      manager.sendMessage(session.id, {
+        turnId: 'turn-step-cap',
+        text: 'Keep calling Read.',
+        maxSteps: 1,
+      }),
+    );
+
+    expect(providerSteps).toBe(1);
+    expect(
+      events.find((event) => event.type === 'token_usage' && event.runtimeSteps !== undefined),
+    ).toMatchObject({ type: 'token_usage', runtimeSteps: 1 });
+    expect(events.at(-1)).toMatchObject({ type: 'complete', stopReason: 'step_limit' });
+  });
+
   test('executes an approved continuation after a path move without another user message', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -1687,6 +1687,9 @@ export class RuntimeKernel implements RuntimeKernelLike {
           ? { orchestration: begin.backendInput.orchestration }
           : {}),
         ...(begin.backendInput.toolMode ? { toolMode: begin.backendInput.toolMode } : {}),
+        ...(begin.backendInput.maxSteps !== undefined
+          ? { maxSteps: begin.backendInput.maxSteps }
+          : {}),
         text: input.text,
         ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
         ...(begin.backendInput.quotes ? { quotes: begin.backendInput.quotes } : {}),


### PR DESCRIPTION
## Summary

`maka run --max-steps N` was parsed and then ignored. Two handoffs dropped the value:

- `runMakaTextCliCore` left it out of the `UserMessageInput` that starts the turn.
- `RuntimeKernel` left it out of the `RuntimeRunner` invocation it builds from `AgentRun.backendInput`, so `AiSdkBackend` never received a per-turn cap. The Runtime Host path carried the cap as far as turn admission and lost it at the same place.

This forwards the cap at both boundaries. The backend's step accounting and `step_limit` outcome are unchanged: with `--max-steps 1`, the first provider step completes and settles its tool call, and no second provider request starts. The turn then ends through the existing `tool_step_cap_reached` failure: empty stdout, `maka run: Turn failed: tool_step_cap_reached` on stderr, exit 1. A step is one completed provider request; parallel tool calls in one response still count as one step.

Fixes #3553

## Verification

Each regression test ran red with the forwarding removed and green with it restored:

- CLI boundary (`run-command.test.ts`): `undefined !== 2`
- Runtime loop (`session-manager.test.ts`, mock provider that always returns a tool call): `3 !== 1`
- Runtime Host seam (`root-turn-coordinator.test.ts`, admission to backend input): `undefined !== 1`

Affected suites:

```sh
npm --workspace maka-agent test          # tests 383, pass 383, fail 0
npm --workspace @maka/runtime test       # tests 3085, pass 3072, skipped 13, fail 0
npm --workspace @maka/runtime-host test  # tests 1080, pass 1080, fail 0
```

`npm run typecheck` passed in all three workspaces. `biome lint` and `biome format` on the five changed files reported no fixes.

Live runs against an OpenAI-compatible relay, same fixture and prompt as the issue, on the fixed build:

| Path | Exit | stdout | stderr beyond the SQLite warning | Tool calls | `runtimeSteps` | `stopReason` |
|---|---:|---|---|---:|---:|---|
| Local profile | 1 | empty | `maka run: Turn failed: tool_step_cap_reached` | 1 | 1 | `step_limit` |
| Runtime Host, fresh loopback Host from this build | 1 | empty | `maka run: Turn failed: tool_step_cap_reached` | 1 | 1 | `step_limit` |

Unfixed, both paths ran 3 tool calls, `runtimeSteps: 4`, `end_turn`, exit 0.

Not run: the full monorepo `npm test`, root-wide typecheck, lint and format, Windows or Linux, other provider families.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: pi (gpt-5.6-sol) wrote the regression tests, both forwarding changes, the live verification harness, and the first draft of this description. Claude Code reviewed the diff, re-ran the three suites, and edited this text. Both commits carry the trailer.

Generated-by: pi (gpt-5.6-sol)

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
