### PR TITLE
docs: correct the multi-agent orchestration documents

### DIFF
--- a/docs/agent-swarm.md
+++ b/docs/agent-swarm.md
@@ -29,13 +29,20 @@ There is no `agent_swarm` tool. A synchronous fan-out tool of that name existed
 until #2384, which removed it in favour of asynchronous supervision over the
 graph. `agent_swarm` survives only as a tool-result kind on historical records.
 
-Swarm adds no execution machinery of its own:
+Swarm adds no execution machinery of its own. There is one scheduler, one
+ledger, and one control plane, and they are the graph's:
 
 - items are ordinary child Sessions and their `AgentRun`s, scheduled as graph work;
-- durable schedule, admission, and wake state live in the SQLite graph control plane;
+- durable schedule, admission, and wake state are stored in the SQLite graph
+  control plane;
 - `agent_swarm_status` is a compact projection over the same graph snapshot —
   its `swarmId` is the `graphId`;
 - there is no `SwarmRun`, second event ledger, or background owner.
+
+What the mode does add is supervision policy over that machinery: which tools
+are guaranteed, what the Agent is told to do with them, why the mode was
+authorized, and when a checkpoint is worth waking the Agent for. Those four are
+described below.
 
 For the mechanism underneath, see
 [Graph Is a Schedule, Not a Second Runtime](./architecture/agent-graph-stream-scheduling-draft.md).
@@ -68,9 +75,11 @@ from it:
    `AgentRun` header as `session_mode` (the Session is in swarm mode),
    `turn_override` (one `/swarm <task>` turn), or `none`. It records why swarm
    was authorized, not merely that it was.
-4. **Wake policy.** `isSwarmCheckpointTransition` gives the mode its own
-   supervisor-wake rule: wake when the swarm first reaches `settled`, or when the
-   set of `blocked` / `failed` / `aborted` / `cancelled` items changes.
+4. **Wake policy.** Wake *state* is stored by the graph control plane like any
+   other graph wake, but the *trigger* is mode-specific:
+   `isSwarmCheckpointTransition` wakes the supervisor when the swarm first
+   reaches `settled`, or when the set of `blocked` / `failed` / `aborted` /
+   `cancelled` items changes.
 
 ## What the prompt instructs
 

--- a/docs/agent-swarm.md
+++ b/docs/agent-swarm.md
@@ -17,235 +17,170 @@
   under the License.
 -->
 
+
 # Agent Swarm
 
-Agent Swarm is Maka's bounded foreground fan-out for independent child work. The
-main Agent plans the batch, calls `agent_swarm` once, waits for every settled
-item, and remains responsible for semantic synthesis.
+Agent Swarm is an orchestration mode, not a tool. When a Session runs in swarm
+mode, the main Agent is instructed to prefer the durable asynchronous Agent
+Graph whenever a request splits into independent work, and to supervise that
+graph asynchronously instead of blocking on it.
 
-It is intentionally a structured-concurrency convenience over existing child
-`AgentRun`s, not a workflow runtime:
+There is no `agent_swarm` tool. A synchronous fan-out tool of that name existed
+until #2384, which removed it in favour of asynchronous supervision over the
+graph. `agent_swarm` survives only as a tool-result kind on historical records.
 
-- every started item is an ordinary child `AgentRun`;
-- the parent tool result is an ordered projection over those child facts;
-- there is no `SwarmRun`, second event ledger, checkpoint, or background owner;
-- child toolsets exclude `agent_swarm`, so batches cannot nest.
+Swarm adds no execution machinery of its own:
+
+- items are ordinary child Sessions and their `AgentRun`s, scheduled as graph work;
+- durable schedule, admission, and wake state live in the SQLite graph control plane;
+- `agent_swarm_status` is a compact projection over the same graph snapshot —
+  its `swarmId` is the `graphId`;
+- there is no `SwarmRun`, second event ledger, or background owner.
+
+For the mechanism underneath, see
+[Graph Is a Schedule, Not a Second Runtime](./architecture/agent-graph-stream-scheduling-draft.md).
+
+## Enabling the mode
+
+`/swarm` is parsed by `parseSwarmCommand` in `packages/core/src/swarm-command.ts`:
+
+| Input | Effect |
+| --- | --- |
+| `/swarm on` | Set the Session orchestration mode to `swarm` |
+| `/swarm off` | Set the Session orchestration mode back to `default` |
+| `/swarm` or `/swarm status` | Report the current mode |
+| `/swarm <task>` | Run one task in swarm mode without changing the Session mode |
+
+`ORCHESTRATION_MODES` is `['default', 'swarm', 'graph']`.
+
+## What the mode changes
+
+Swarm mode is mostly instruction, but not only instruction. Four things follow
+from it:
+
+1. **System prompt.** `AiSdkBackend` appends `renderSwarmModePrompt()`.
+2. **Guaranteed tools.** The mode forces `agent_list`, `update_agent_graph`,
+   `yield_agent_graph`, `agent_swarm_status` and `agent_output` into the turn's
+   tool catalog. Graph mode requires the same set plus `view_agent_graph`; swarm
+   deliberately omits it, matching the instruction to read compact status rather
+   than the whole graph.
+3. **Durable authorization.** `agentSwarmAuthorization` is recorded on the
+   `AgentRun` header as `session_mode` (the Session is in swarm mode),
+   `turn_override` (one `/swarm <task>` turn), or `none`. It records why swarm
+   was authorized, not merely that it was.
+4. **Wake policy.** `isSwarmCheckpointTransition` gives the mode its own
+   supervisor-wake rule: wake when the swarm first reaches `settled`, or when the
+   set of `blocked` / `failed` / `aborted` / `cancelled` items changes.
+
+## What the prompt instructs
+
+`packages/runtime/src/swarm-mode.ts` is the entire feature: one function
+returning an `<orchestration_mode>` block. It asks the main Agent to:
+
+1. decide first whether parallel delegation would materially improve speed,
+   quality, coverage, or independent verification, and to continue directly when
+   the request is small, conversational, latency-sensitive, or indivisible;
+2. keep exploration light, and make every item bounded and self-contained with an
+   explicit scope, expected output, and constraints;
+3. avoid overlapping writes, preferring read-only investigation unless isolated
+   workspaces are available;
+4. call `agent_list`, then schedule all independent items together with
+   `update_agent_graph` using `target_kind=new_preset` and a user-approved
+   `subagent_id`;
+5. call `yield_agent_graph`, and **not** poll, sleep, watch child logs, or wait
+   synchronously — the host wakes the Agent only when work needs attention or the
+   whole swarm has settled;
+6. on wake, read `agent_swarm_status` for compact statuses, and reach for
+   `agent_output view=result` only for completed final results or narrow
+   diagnosis of a failed item;
+7. replace failed work with `update_agent_graph` using `replaces=<failed work id>`
+   and `replacement_mode=replace`, so a failed item stops holding the swarm in
+   `needs_attention`;
+8. finish the graph once useful work has settled, then deduplicate, verify, and
+   semantically synthesize.
+
+The prompt also states the limit explicitly: do not manufacture parallelism or
+create duplicate busywork merely because swarm mode is enabled.
 
 ## Choosing the execution model
 
 | Need | Prefer | Why |
 | --- | --- | --- |
 | One small task or tightly coupled reasoning | Main Agent directly | Delegation overhead would exceed the useful parallelism. |
-| One specialist result, or the next task depends on the previous result | `agent_spawn` sequentially | The dependency is explicit and each result can refine the next prompt. |
-| Several finite, independent items with one final synthesis | `agent_swarm` | Bounded worker-pool execution, stable ordered results, and isolated failures. |
-| Durable ownership, task claiming, or worker communication | Agent Team | Members have roles, mailbox collaboration, and Task Ledger coordination. |
-| Dynamic dependent Agent work supervised from the root conversation | Agent Graph | Child Sessions are operators, committed RuntimeEvents are records, and SQLite owns durable schedule and admission state. |
+| One specialist result, or the next task depends on the previous one | `agent_spawn` | The dependency is explicit and each result can refine the next prompt. |
+| Several independent items with one final synthesis | Swarm mode | The Agent schedules them as graph work and supervises asynchronously. |
+| Dynamic dependent Agent work supervised from the root conversation | Agent Graph directly | Same machinery; the graph tools are used without the swarm prompt. |
 | Explicit workflow steps, arbitrary workflow resume, or distributed execution | Rive | Workflow state and recovery need a dedicated workflow authority. |
 
-The main Agent should call Swarm deliberately. The runtime does not infer that a
-request is parallelizable and does not automatically fan work out.
+Swarm mode and graph mode differ only in instruction, not in mechanism. Swarm
+mode biases the Agent toward fan-out for every new request; graph mode leaves
+the decision to the Agent.
 
-For the deeper boundary between foreground fan-out and durable dynamic
-scheduling, see [Graph Is a Schedule, Not a Second Runtime](./architecture/agent-graph-stream-scheduling-draft.md).
+## Status projection
 
-## Contract
-
-One call accepts `1..32` items. Local concurrency defaults to `3` and is capped
-at `32`. The entire input is validated before any child starts. Results retain
-input order even when children finish out of order.
-
-New work has two mutually exclusive forms. Callers may provide the explicit
-structured items shown below, or use a homogeneous template batch with one
-shared selector, a `prompt_template` containing `{{item}}`, and string
-`items`. Template batches replace every placeholder occurrence, reject
-duplicate expanded tasks, generate stable ordered IDs (`item-1`, `item-2`,
-...), and then enter the same preflight and execution path as explicit items.
-They are input shorthand, not a separate scheduler.
-
-### Configurable subagent model routes
-
-Settings → Models can define multiple user-approved subagent presets. Each
-preset has a stable `subagent_id`, a capability `profile`, and its own model
-connection/model pair. The main Agent discovers these routes with `agent_list`
-and selects one by `subagent_id`; it cannot supply an arbitrary provider or
-model in a tool call.
-
-The runtime resolves the id against the host-owned catalog and freezes the
-resolved connection, model, thinking level, and profile into the new child
-Session. Editing or deleting a preset therefore affects future spawns only;
-resume and retry continue to use the child Session's durable target. The
-legacy `profile` selector remains supported and inherits the parent target.
-
-For a configured route, replace `profile` with `subagent_id` in either an
-explicit item or a template batch:
+`agent_swarm_status` takes no parameters and returns a bounded snapshot
+(`packages/runtime/src/agent-swarm-status-tool.ts`):
 
 ```ts
-agent_swarm({
-  prompt_template: "Review {{item}} and return concrete evidence.",
-  subagent_id: "fast-reader",
-  items: ["runtime", "desktop", "tests"],
-  max_concurrency: 3
-})
+interface AgentSwarmStatusResult {
+  kind: 'agent_swarm_status';
+  swarmId: string;                                   // the graphId
+  status: 'running' | 'needs_attention' | 'settled';
+  counts: Record<AgentSwarmItemStatus, number>;
+  items: AgentSwarmStatusItem[];
+}
+
+interface AgentSwarmStatusItem {
+  workId: string;
+  status: AgentSwarmItemStatus;
+  operatorId?: string;
+  childSessionId?: string;
+  runId?: string;
+  failurePhase?: 'schedule' | 'topology' | 'stop' | 'render' | 'dispatch';
+  failureReason?: string;
+}
 ```
 
-Either form may also include `resume_run_ids`, a map from an existing child
-`runId` to the new prompt that should continue it. A call may contain only
-resumes. Resume entries count toward the same 32-item bound, are presented
-before new items in map insertion order, and use the same local and shared
-concurrency limits as newly spawned children.
+Item status is one of `queued`, `running`, `blocked`, `completed`, `failed`,
+`aborted`, `cancelled`, `stopped`, `superseded`. The terminal set is everything
+except `queued`, `running`, and `blocked`.
 
-## Resuming child runs
+The three swarm-level values are derived, not stored:
 
-Resume creates a fresh child `AgentRun` whose durable lineage names the source
-in `resumedFromRunId`. It replays the complete RuntimeEvent history of that
-source and its resume ancestors, then sends the new prompt. It does not mutate
-or restart the original run, and it does not approximate continuation by
-concatenating a summary into a fresh prompt.
+- `running` — work remains and nothing needs the supervisor;
+- `needs_attention` — at least one item is `blocked`, `failed`, `aborted`, or `cancelled`;
+- `settled` — every item reached a terminal status.
 
-The runtime preflights every resume entry before any resumed or new child
-starts. Resume fails closed unless all of these invariants hold:
+`settled` is a statement about the current items, not about the user's task.
+Closing the graph is still the supervisor's explicit `finish` decision.
 
-- the source and every resume ancestor are built-in child runs in this session;
-- every run has the same Agent profile and current backend, connection, model,
-  working directory, and child permission mode;
-- every RuntimeEvent ledger has a valid terminal fact and a user-anchored,
-  model-replayable history with no indeterminate tool boundary;
-- the immediate source does not already have a resume successor.
+The result carries identity, not payload: `childSessionId` and `runId` are
+references into the authoritative Runtime read path. Child output is read with
+`agent_output` only when it is actually needed, which is what keeps a large
+fan-out from consuming the main Agent's context.
 
-Completed, failed, and cancelled child runs may be continued. Each source has
-at most one direct successor, while that successor may itself be resumed to
-form an auditable linear chain. The API deliberately uses `resume_run_ids`
-rather than `resume_agent_ids`: built-in `agentId`s identify reusable profiles
-such as `local-read`, while `runId`s identify the unique execution and history
-being continued.
+## Example
 
-```ts
-agent_swarm({
-  resume_run_ids: {
-    "child-run-123": "Re-check the failing assertion and propose the smallest fix.",
-    "child-run-456": "Continue from your findings and inspect the UI projection."
-  },
-  items: [
-    {
-      item_id: "fresh-review",
-      profile: "local_read",
-      task: "Independently review the updated cancellation invariant."
-    }
-  ],
-  max_concurrency: 3
-})
+```text
+User:    /swarm on
+User:    Review the three packages and report concrete evidence.
+
+Agent:   agent_list
+         update_agent_graph  target_kind=new_preset  subagent_id=reviewer  (x3)
+         yield_agent_graph
+
+         ... host wakes the Agent ...
+
+Agent:   agent_swarm_status
+         -> status=needs_attention, 2 completed, 1 failed
+         agent_output view=result   (failed item only)
+         update_agent_graph  replaces=<failed work id>  replacement_mode=replace
+         yield_agent_graph
+
+         ... host wakes the Agent ...
+
+Agent:   agent_swarm_status
+         -> status=settled, 3 completed
+         agent_output view=result   (each completed item)
+         finish, deduplicate, verify, synthesize
 ```
-
-Three separate concurrency boundaries remain observable:
-
-1. **Subagent tool admission** limits how many subagent tool calls the model may
-   open in one turn.
-2. **Local Swarm concurrency** limits workers claimed inside one batch.
-3. **Shared child-run permits** cap real child executions across
-   `agent_spawn` and `agent_swarm`.
-
-Partial child failure does not erase successful siblings. Parent cancellation
-signals active children, prevents locally queued items from starting, joins
-active work, and returns explicit cancelled rows for both started and
-never-started items.
-
-## Provider backpressure
-
-Swarm uses Kimi-compatible, batch-local rate-limit handling after the backend's
-ordinary request retry policy is exhausted:
-
-- launch up to five initial items, then admit one additional pending item every
-  700 ms;
-- when a child settles with `failureClass: RateLimit`, suspend that item and
-  requeue it at the front with a 3 s, 6 s, 12 s, ... retry delay;
-- reduce the batch's effective capacity by one (never below one), at most once
-  every 2 s;
-- after three minutes without another rate limit, recover capacity one slot at
-  a time;
-- if the rate-limited item is the only unfinished item, fail it instead of
-  leaving the foreground tool suspended indefinitely.
-
-A retry is a fresh child `AgentRun` linked through `retriedFromRunId`. It
-replays the safely materialized RuntimeEvent history and sends no second user
-prompt. This keeps each attempt inspectable while preventing duplicated task
-instructions. Artifacts from all attempts are retained in the final ordered
-item result, and parent cancellation still covers queued retries and active
-retry runs through the shared child-run permit pool.
-
-This mechanism is deliberately reactive and local to one Swarm call. It is not
-a provider-global RPM/TPM admission controller and does not coordinate capacity
-between independent sessions or processes.
-
-## Presentation and evidence
-
-Desktop and CLI project the same settled `agent_swarm` result:
-
-- aggregate status and completed/failed/cancelled counts;
-- bounded per-item summaries;
-- child status, profile, duration, failure class, and artifact count;
-- real child `runId` and `turnId` references for inspection.
-
-The presentation never copies child prompts, tool arguments, or raw child tool
-output. Desktop summaries are bounded per row, the card is scroll-bounded, and
-CLI output has per-item and aggregate character caps.
-
-Tool telemetry stores only a bounded result summary: result kind/status, item
-counts, started count, and artifact count. Run trace events reuse the existing
-parent `AgentRun` diagnostic stream and identify these boundaries with stable
-data fields:
-
-| Evidence | Trace data |
-| --- | --- |
-| Tool-call admission rejection | `boundary: subagent_tool_admission` |
-| Local item queued or started | `swarmStage: item_queued` / `item_started`, `boundary: local_swarm_concurrency` |
-| Provider-limited item suspended | `swarmStage: item_suspended`, `failureClass: RateLimit`, plus attempt and retry delay |
-| Adaptive batch capacity | `swarmStage: capacity_changed`, direction, and effective capacity |
-| Waiting for shared capacity | `boundary: shared_child_run_permit`, `stage: waiting` |
-| Real child execution | `boundary: child_run_execution`, `stage: started` / `completed` |
-| Settled batch | `swarmStage: batch_completed` plus the aggregate projection |
-
-These are diagnostic projections only. Child `AgentRun`s and their artifact
-references remain the lifecycle and evidence authority.
-
-## Example: review fan-out and synthesis
-
-For a cross-cutting change, the main Agent can create independent review items:
-
-```ts
-agent_swarm({
-  items: [
-    {
-      item_id: "runtime",
-      profile: "local_read",
-      task: "Review concurrency and cancellation invariants."
-    },
-    {
-      item_id: "presentation",
-      profile: "local_read",
-      task: "Review bounded UI and CLI result presentation."
-    },
-    {
-      item_id: "tests",
-      profile: "local_read",
-      task: "Review regression coverage and identify missing cases."
-    }
-  ],
-  max_concurrency: 3
-})
-```
-
-The same read-only batch can use Kimi-compatible single-placeholder expansion:
-
-```ts
-agent_swarm({
-  prompt_template: "Review {{item}} and report concrete file or symbol evidence.",
-  profile: "local_read",
-  items: ["runtime concurrency and cancellation", "UI and CLI presentation", "regression coverage"],
-  max_concurrency: 3
-})
-```
-
-After the batch settles, the main Agent should compare the three summaries,
-inspect referenced child runs when evidence conflicts, deduplicate overlapping
-findings, rank them by severity, and produce one coherent review. Swarm owns
-finite execution and settlement; the main Agent owns judgment.

--- a/docs/architecture/agent-graph-stream-scheduling-draft.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.md
@@ -7,7 +7,7 @@ counterpart: ./agent-graph-stream-scheduling-draft.zh-CN.md
 implementation_status: current
 document_status: draft
 translation_status: synced
-last_verified: 2026-07-28
+last_verified: 2026-08-23
 owners:
   - maka-backend
 ---
@@ -36,7 +36,7 @@ owners:
 
 This chapter builds directly on Chapter 1. The Runtime Event Log remains the semantic authority for what an Agent did. Graph adds identities and projections that answer different questions: which child Session is one operator, which committed records flow to another operator, which work the supervisor requested, which intent was admitted exactly once, and when the root Agent should be woken to inspect a stable checkpoint.
 
-It is written for engineers changing Graph contracts, child Sessions, scheduling, recovery, or Desktop integration. It describes the implementation verified on 2026-07-28. The chapter does not describe arbitrary cyclic workflows, distributed execution, graph-wide resource optimization, or a visual workflow authoring system.
+It is written for engineers changing Graph contracts, child Sessions, scheduling, recovery, or Desktop integration. It describes the implementation verified on 2026-08-23. The chapter does not describe arbitrary cyclic workflows, distributed execution, graph-wide resource optimization, or a visual workflow authoring system.
 
 ## Start with work that changes shape while it runs
 
@@ -561,15 +561,14 @@ The current Graph should not be mistaken for a general distributed stream proces
 
 These are deliberate boundaries. They keep Graph useful without moving workflow semantics, resource management, or product presentation into the Agent runtime.
 
-## Graph, Swarm, Agent Team, and Rive
+## Graph, Swarm, agent_spawn, and Rive
 
 The four mechanisms solve different coordination problems.
 
 | Need | Mechanism | Ownership model |
 |---|---|---|
-| Finite independent fan-out followed by one synthesis | Agent Swarm | One foreground tool call owns a bounded worker pool |
+| Finite independent fan-out followed by one synthesis | Swarm mode | The main Agent schedules independent items into one Graph and supervises them asynchronously |
 | One linked specialist execution or follow-up | `agent_spawn` / child Session | Parent Agent owns explicit delegation |
-| Roles, mailbox collaboration, and Task Ledger coordination | Agent Team | Team members own durable collaboration state |
 | Dynamic dependent Agent work supervised from a root conversation | Agent Graph | SQLite schedule/control plane over child Sessions and Runtime records |
 | Explicit workflow steps, arbitrary resume policy, or distributed workflow authority | Rive | Workflow runtime owns workflow state |
 
@@ -594,7 +593,7 @@ Read the implementation in this order:
 13. `packages/runtime/src/agent-graph-timeline.ts`: reference-only control/data-plane reconstruction, stable order, coverage, and pagination.
 14. `packages/runtime/src/agent-graph-supervisor-wake.ts`: durable return path to the root Agent.
 15. `packages/storage/src/sqlite-session-metadata-schema.ts` and `sqlite-session-metadata-store.ts`: Graph control-plane transactions and timeline metadata snapshot.
-16. `apps/desktop/src/main/main.ts`, `agent-graph-ipc-main.ts`, and `apps/desktop/src/renderer/agent-graph-panel.tsx`: product composition and bounded UI.
+16. `apps/desktop/src/main/main.ts`, `runtime-host-session-domains-ipc-main.ts`, and `apps/desktop/src/renderer/agent-graph-panel.tsx`: product composition and bounded UI. Graph change events travel through the generic session-domains bridge as `agentGraphChanged`; there is no Graph-specific main-process IPC module.
 
 The most relevant contract tests are colocated under:
 
@@ -604,7 +603,6 @@ The most relevant contract tests are colocated under:
 - `packages/runtime/src/__tests__/session-manager.test.ts`
 - `packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts`
 - `packages/storage/src/__tests__/agent-graph-timeline-metadata.test.ts`
-- `apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts`
 
 ## Summary
 

--- a/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
@@ -7,7 +7,7 @@ counterpart: ./agent-graph-stream-scheduling-draft.md
 implementation_status: current
 document_status: draft
 translation_status: synced
-last_verified: 2026-07-28
+last_verified: 2026-08-23
 owners:
   - maka-backend
 ---
@@ -36,7 +36,7 @@ owners:
 
 本章直接建立在第一章之上。Runtime Event Log 仍然是“Agent 实际做了什么”的语义 authority。Graph 只是增加了一组 identity 和 projection，用来回答另外几类问题：哪个 child Session 是一个 operator、哪些已提交 record 会流向另一个 operator、supervisor 请求了哪些 work、哪个 intent 被精确 admission 一次，以及何时应该唤醒 root Agent 检查一个稳定 checkpoint。
 
-本文面向修改 Graph contract、child Session、调度、恢复或 Desktop 接线的工程师，描述截至 2026-07-28 已验证的实现。它不描述任意有环 workflow、分布式执行、图级资源优化，也不把当前实现说成可视化 workflow authoring system。
+本文面向修改 Graph contract、child Session、调度、恢复或 Desktop 接线的工程师，描述截至 2026-08-23 已验证的实现。它不描述任意有环 workflow、分布式执行、图级资源优化，也不把当前实现说成可视化 workflow authoring system。
 
 ## 从运行中才逐渐显形的工作开始
 
@@ -558,15 +558,14 @@ sequenceDiagram
 
 这些都是有意保留的边界。它们让 Graph 有用，同时不把 workflow semantic、resource management 或 product presentation 塞进 Agent runtime。
 
-## Graph、Swarm、Agent Team 与 Rive
+## Graph、Swarm、agent_spawn 与 Rive
 
 四种机制解决不同的协调问题。
 
 | 需求 | 机制 | Ownership model |
 |---|---|---|
-| 有限独立 fan-out，随后一次 synthesis | Agent Swarm | 一个 foreground tool call 拥有有界 worker pool |
+| 有限独立 fan-out，随后一次 synthesis | Swarm 模式 | 主 Agent 把独立 item 排进同一张 Graph，并异步监督 |
 | 一次 linked specialist execution 或 follow-up | `agent_spawn` / child Session | Parent Agent 显式拥有 delegation |
-| Role、mailbox collaboration 与 Task Ledger coordination | Agent Team | Team member 拥有持久 collaboration state |
 | 从 root conversation 监督动态依赖 Agent work | Agent Graph | Child Session 与 Runtime record 之上的 SQLite schedule/control plane |
 | 显式 workflow step、任意 resume policy 或分布式 workflow authority | Rive | Workflow runtime 拥有 workflow state |
 
@@ -591,7 +590,7 @@ Graph 位于 foreground fan-out 与独立 workflow runtime 之间：足够动态
 13. `packages/runtime/src/agent-graph-timeline.ts`：reference-only control/data-plane reconstruction、stable order、coverage 与 pagination。
 14. `packages/runtime/src/agent-graph-supervisor-wake.ts`：回到 root Agent 的持久路径。
 15. `packages/storage/src/sqlite-session-metadata-schema.ts` 与 `sqlite-session-metadata-store.ts`：Graph control-plane transaction 与 timeline metadata snapshot。
-16. `apps/desktop/src/main/main.ts`、`agent-graph-ipc-main.ts` 与 `apps/desktop/src/renderer/agent-graph-panel.tsx`：产品组合与 bounded UI。
+16. `apps/desktop/src/main/main.ts`、`runtime-host-session-domains-ipc-main.ts` 与 `apps/desktop/src/renderer/agent-graph-panel.tsx`：产品组合与 bounded UI。Graph 变更事件走通用 session-domains 桥接的 `agentGraphChanged`，没有 Graph 专属的主进程 IPC 模块。
 
 最相关的 contract tests 位于：
 
@@ -601,7 +600,6 @@ Graph 位于 foreground fan-out 与独立 workflow runtime 之间：足够动态
 - `packages/runtime/src/__tests__/session-manager.test.ts`
 - `packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts`
 - `packages/storage/src/__tests__/agent-graph-timeline-metadata.test.ts`
-- `apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts`
 
 ## 总结
 


### PR DESCRIPTION
## Summary

The Multi-agent orchestration group from #3522. Four documents were audited; three needed changes.

**`docs/agent-swarm.md` documented a tool that no longer exists.** The whole document was built around an `agent_swarm` tool taking `items`, a `prompt_template` and `resume_run_ids`. #2384 deleted `packages/runtime/src/agent-swarm-tools.ts` — where `AGENT_SWARM_TOOL_NAME = 'agent_swarm'` was defined — along with `adaptive-swarm.ts`, and replaced synchronous fan-out with asynchronous supervision over the Agent Graph. `agent_swarm` survives only as a tool-result kind on historical records, so a reader following this document would call a tool that is not in the catalog.

Rewritten around what swarm actually is now: an orchestration mode, not a tool. It is entered with `/swarm on|off|status|<task>` and changes four things — the system prompt, a guaranteed tool set that deliberately omits `view_agent_graph`, the durable `agentSwarmAuthorization` field on the Run header, and its own supervisor-wake rule. Items are ordinary child Sessions scheduled as graph work, and `agent_swarm_status` projects the same graph snapshot, where `swarmId` is the `graphId`.

Two questions a reader may reasonably ask, answered here so the diff does not have to carry them:

*Was the tool deleted, or renamed and moved?* Deleted. The file that defined it declared exactly one tool, the current catalog of 47 tools contains no `agent_swarm`, no tool anywhere accepts a batch `items` array, and every surviving mention is the result-kind type — nothing constructs one. `agent_swarm_status` is a different tool, not a rename: it takes no parameters and only projects a graph snapshot. The *capability* did move, onto the graph tools.

*Is swarm now just a compatibility shell over graph?* No. The execution machinery is entirely the graph — one scheduler, one ledger, one control plane. But swarm is a live mode over it, with its own guaranteed tool set, durable authorization record, and supervisor-wake trigger. Only the `agent_swarm` result kind is pure legacy, kept so old records stay readable.

**The Agent Graph chapter had four smaller defects**, corrected in both languages so `translation_status: synced` stays true:

- `apps/desktop/src/main/agent-graph-ipc-main.ts` does not exist. Graph change events travel through `runtime-host-session-domains-ipc-main.ts` as `agentGraphChanged`, and `agent-graph-panel.tsx` imports its types straight from `@maka/runtime-host/client` and `@maka/runtime-host/protocol`.
- `apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts` was deleted and has no successor.
- The comparison table described Agent Swarm as "one foreground tool call owns a bounded worker pool" — the removed synchronous model.
- The same table listed Agent Team beside four real mechanisms, but `AgentTeam`, `agent_team` and `mailbox` appear nowhere in the code. The row was removed and the section heading updated to match the rows that remain.

**`docs/side-conversation.md` needs no change.** Its unresolved symbols (`excludeTurns`, `moveTabTo`, `receiveMovedTab`, `preserveOnClose`, `onBeforeClose`) all sit inside the Codex Reference and Desktop Architecture Snapshot sections, which describe OpenAI Codex and carry their own inspection date.

Refs #3522

## Verification

Claims in the rewritten document, each checked against the code:

| Claim | Check | Result |
|---|---|---|
| `agent_swarm` tool existed and was deleted | `git show 08b745028^:packages/runtime/src/agent-swarm-tools.ts \| grep TOOL_NAME` | `AGENT_SWARM_TOOL_NAME = 'agent_swarm'`; file deleted by that commit |
| no `agent_swarm` tool today | `grep -n "name: 'agent" packages/core/src/tool-catalog.ts` | `agent_spawn`, `agent_list`, `agent_output`, `agent_swarm_status` |
| `/swarm` grammar | `packages/core/src/swarm-command.ts` | `status` / `on` / `off` / `run_once` |
| prompt injection | `packages/runtime/src/ai-sdk-backend.ts:1734` | appended when `mode === 'swarm'` |
| guaranteed tool set | `packages/runtime/src/ai-sdk-backend.ts:1670-1687` | swarm set omits `view_agent_graph`; graph set includes it |
| durable authorization | `packages/core/src/orchestration.ts:84,91`, `agent-run.ts:165` | `session_mode` / `turn_override` / `none` |
| swarm wake rule | `packages/runtime/src/stream-graph-coordinator.ts:1715` | `isSwarmCheckpointTransition` |
| `swarmId` is `graphId` | `packages/runtime/src/agent-swarm-status-tool.ts:79` | `swarmId: snapshot.graphId` |
| status enums | same file, lines 28-70 | 9 item statuses; attention set is blocked/failed/aborted/cancelled |
| the missing IPC file | `ls apps/desktop/src/main/agent-graph-ipc-main.ts` | No such file |
| the missing test | `find . -name 'graph-mode-host-contract*'` | no matches |
| Agent Team absent | `grep -rn "AgentTeam\|agent_team\|mailbox" packages/ apps/` | no matches outside docs |

Every `packages/...` and `apps/...` path in both reading maps was re-checked after the edit; all resolve.

Repository checks:

```
npm run format:check    Checked 1597 files. No fixes applied.
npm run check:asf-source  fail 0
```

No test covers prose and this PR changes no code, so no suite was added. `npm test` was not run.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Opus 5 via Claude Code — audited the four documents against the code, traced the swarm removal through `git show`, drafted the rewrite and the bilingual corrections. Every row in the table above was produced by running the listed command. The commit carries a `Generated-by` trailer.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No

