### PR TITLE
feat(runtime-host): add managed Host retirement

### DIFF
--- a/apps/desktop/src/main/__tests__/runtime-host-management.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-host-management.test.ts
@@ -19,7 +19,10 @@
 
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { runtimeHostAccessCredentialFingerprint } from '@maka/runtime-host/operator';
+import {
+  runtimeHostAccessCredentialFingerprint,
+  type RuntimeHostServiceManagementFrame,
+} from '@maka/runtime-host/operator';
 import { createDesktopRuntimeHostManagement } from '../runtime-host-management.js';
 import type {
   DesktopRuntimeHostSshAccessInput,
@@ -438,11 +441,10 @@ test('rechecks uninstall intent before retrying the remote service', async () =>
 function serviceResult(
   action: DesktopRuntimeHostSshManagementInput['action'],
   operatorAccess = false,
-) {
-  return {
+): Extract<RuntimeHostServiceManagementFrame, { kind: 'result' }> {
+  const result = {
     schemaVersion: 1 as const,
     kind: 'result' as const,
-    action,
     ...(operatorAccess
       ? { operatorCapabilities: ['access-management-v1' as const] }
       : {}),
@@ -457,6 +459,9 @@ function serviceResult(
       projectDirectoryRoots: [],
     },
   };
+  return action === 'retire'
+    ? { ...result, action, retirement: { kind: 'stopped' } }
+    : { ...result, action };
 }
 
 function accessCredential(

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -887,6 +887,7 @@ describe('managed Runtime Host service', () => {
     let serviceState: 'running' | 'starting' | 'stopped' = 'running';
     let startingPid: number | null = null;
     let stops = 0;
+    let observedStartingFence = false;
     const backend: RuntimeHostServiceBackend = {
       ...createReadyBackend(),
       status: async () => ({
@@ -900,6 +901,11 @@ describe('managed Runtime Host service', () => {
       }),
       stop: async () => {
         stops += 1;
+        if (serviceState === 'starting' && startingPid === null) {
+          const contender = await tryAcquireInteractiveRootOwner(root);
+          observedStartingFence = contender === undefined;
+          await contender?.close();
+        }
         serviceState = 'stopped';
       },
     };
@@ -972,6 +978,19 @@ describe('managed Runtime Host service', () => {
     );
     assert.deepEqual(starting.retirement, { kind: 'stopped' });
     assert.equal(serviceState, 'stopped');
+    assert.equal(observedStartingFence, true);
+
+    serviceState = 'starting';
+    const competingStarter = await tryAcquireInteractiveRootOwner(root);
+    assert.ok(competingStarter);
+    const stopsBeforeConflict = stops;
+    await assert.rejects(
+      manageRuntimeHostService({ ...common, action: 'retire', expectedTarget }, backend, deps),
+      (error: unknown) =>
+        error instanceof RuntimeHostServiceManagerError && error.code === 'retirement_failed',
+    );
+    assert.equal(stops, stopsBeforeConflict);
+    await competingStarter.close();
 
     serviceState = 'starting';
     startingPid = 42;

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -37,6 +37,7 @@ import {
   RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY,
   RUNTIME_HOST_OPERATOR_CAPABILITY_REQUEST_ENV,
 } from '@maka/runtime-host/operator';
+import { RUNTIME_HOST_RETIREMENT_EXIT_CODE } from '@maka/runtime-host/server';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import { parseRuntimeHostCommand } from '../runtime-host-cli.js';
 import {
@@ -549,6 +550,10 @@ describe('managed Runtime Host service', () => {
     assert.match(unit, /"Cash\$\$=\/home\/\$\$ada\/My Projects"/u);
     assert.match(unit, /"\/opt\/\$\$Node 24\/bin\/node"/u);
     assert.match(unit, /"\/opt\/Maka\/\$\$current\/cli\.js"/u);
+    assert.ok(unit.includes(`SuccessExitStatus=${String(RUNTIME_HOST_RETIREMENT_EXIT_CODE)}\n`));
+    assert.ok(
+      unit.includes(`RestartPreventExitStatus=${String(RUNTIME_HOST_RETIREMENT_EXIT_CODE)}\n`),
+    );
     assert.match(unit, /^Restart=always$/mu);
     assert.match(unit, /^StartLimitIntervalSec=60s$/mu);
     assert.match(unit, /^StartLimitBurst=5$/mu);
@@ -648,6 +653,66 @@ describe('managed Runtime Host service', () => {
         hostEpoch: 'host-1',
         pid: 42,
       },
+    );
+  });
+
+  it('reports active work as a blocked retirement result', async () => {
+    const service = {
+      manager: 'systemd_user',
+      installed: true,
+      enabled: true,
+      active: true,
+      state: 'running',
+      pid: 42,
+      lastExitCode: 0,
+      installedVersion: '1.2.3',
+      config: null,
+    } as const;
+    const run = async (framed: boolean) => {
+      let output = '';
+      const exitCode = await runManagedRuntimeHostServiceCli(
+        {
+          action: 'retire',
+          json: !framed,
+          framed,
+          clientDataRoot: '/config/Maka',
+          defaultRootPath: '/config/Maka/workspaces/default',
+          nodePath: '/usr/bin/node',
+          cliPath: '/opt/maka/cli.js',
+        },
+        {
+          manage: async () => ({
+            schemaVersion: 1,
+            action: 'retire',
+            service,
+            retirement: { kind: 'active_tasks' },
+          }),
+          withLifecycleLock: async (_root, operation) => operation(),
+          createBackend: createUnusedBackend,
+          writeOutput: (value) => {
+            output += value;
+          },
+        },
+      );
+      return { exitCode, output };
+    };
+
+    const json = await run(false);
+    assert.equal(json.exitCode, 1);
+    assert.deepEqual(JSON.parse(json.output), {
+      schemaVersion: 1,
+      action: 'retire',
+      service,
+      retirement: { kind: 'active_tasks' },
+      ok: false,
+    });
+
+    const framed = await run(true);
+    assert.equal(framed.exitCode, 1);
+    const frame = decodeRuntimeHostServiceManagementFrame(framed.output);
+    assert.deepEqual(
+      frame?.kind === 'result' && frame.action === 'retire' ? frame.retirement : null,
+      { kind: 'active_tasks' },
     );
   });
 
@@ -820,6 +885,7 @@ describe('managed Runtime Host service', () => {
     const cliPath = join(base, 'cli.js');
     await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
     let serviceState: 'running' | 'starting' | 'stopped' = 'running';
+    let startingPid: number | null = null;
     let stops = 0;
     const backend: RuntimeHostServiceBackend = {
       ...createReadyBackend(),
@@ -829,7 +895,7 @@ describe('managed Runtime Host service', () => {
         enabled: true,
         active: serviceState === 'running',
         state: serviceState,
-        pid: serviceState === 'running' ? 42 : null,
+        pid: serviceState === 'running' ? 42 : serviceState === 'starting' ? startingPid : null,
         lastExitCode: 0,
       }),
       stop: async () => {
@@ -905,6 +971,33 @@ describe('managed Runtime Host service', () => {
       deps,
     );
     assert.deepEqual(starting.retirement, { kind: 'stopped' });
+    assert.equal(serviceState, 'stopped');
+
+    serviceState = 'starting';
+    startingPid = 42;
+    const startingBlocked = await manageRuntimeHostService(
+      { ...common, action: 'retire', expectedTarget },
+      backend,
+      deps,
+    );
+    assert.deepEqual(startingBlocked.retirement, { kind: 'active_tasks' });
+    assert.equal(serviceState, 'starting');
+
+    const startingRetired = await manageRuntimeHostService(
+      {
+        ...common,
+        action: 'retire',
+        expectedTarget,
+        allowInterruptActiveTasks: true,
+      },
+      backend,
+      deps,
+    );
+    assert.deepEqual(startingRetired.retirement, {
+      kind: 'retired',
+      hostEpoch: 'host-1',
+      pid: 42,
+    });
     assert.equal(serviceState, 'stopped');
   });
 

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -37,7 +37,7 @@ import {
   RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY,
   RUNTIME_HOST_OPERATOR_CAPABILITY_REQUEST_ENV,
 } from '@maka/runtime-host/operator';
-import { resolveStorageRoot } from '@maka/storage/root-authority';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import { parseRuntimeHostCommand } from '../runtime-host-cli.js';
 import {
   removeRuntimeHostManagedDeployment,
@@ -128,6 +128,33 @@ describe('managed Runtime Host service', () => {
         retainManagedDeployment: true,
       },
     );
+    assert.deepEqual(
+      parseRuntimeHostCommand([
+        'service',
+        'retire',
+        '--framed',
+        '--allow-interrupt-active-tasks',
+        '--expected-service-id',
+        'b'.repeat(64),
+        '--expected-root-path',
+        '/srv/maka',
+        '--expected-root-id',
+        'a'.repeat(64),
+      ]),
+      {
+        kind: 'runtime-host-service-manage',
+        action: 'retire',
+        json: false,
+        framed: true,
+        allowInterruptActiveTasks: true,
+        expectedTarget: {
+          serviceId: 'b'.repeat(64),
+          rootPath: '/srv/maka',
+          rootId: 'a'.repeat(64),
+        },
+      },
+    );
+    assert.equal(parseRuntimeHostCommand(['service', 'retire', '--framed']).kind, 'error');
     assert.deepEqual(
       parseRuntimeHostCommand([
         'service',
@@ -563,6 +590,51 @@ describe('managed Runtime Host service', () => {
     });
   });
 
+  it('emits bounded retirement facts in framed output', async () => {
+    let output = '';
+    const exitCode = await runManagedRuntimeHostServiceCli(
+      {
+        action: 'retire',
+        json: false,
+        framed: true,
+        clientDataRoot: '/config/Maka',
+        defaultRootPath: '/config/Maka/workspaces/default',
+        nodePath: '/usr/bin/node',
+        cliPath: '/opt/maka/cli.js',
+      },
+      {
+        manage: async () => ({
+          schemaVersion: 1,
+          action: 'retire',
+          service: {
+            manager: 'systemd_user',
+            installed: true,
+            enabled: true,
+            active: false,
+            state: 'stopped',
+            pid: null,
+            lastExitCode: 0,
+            installedVersion: '1.2.3',
+            config: null,
+          },
+          retirement: { kind: 'retired', hostEpoch: 'host-1', pid: 42 },
+        }),
+        createBackend: createUnusedBackend,
+        writeOutput: (value) => {
+          output += value;
+        },
+      },
+    );
+    assert.equal(exitCode, 0);
+    const frame = decodeRuntimeHostServiceManagementFrame(output);
+    assert.equal(frame?.kind, 'result');
+    assert.deepEqual(frame?.kind === 'result' ? frame.retirement : undefined, {
+      kind: 'retired',
+      hostEpoch: 'host-1',
+      pid: 42,
+    });
+  });
+
   it('projects requested operator capabilities without launch configuration', async (t) => {
     const previousCapabilityRequest = process.env[RUNTIME_HOST_OPERATOR_CAPABILITY_REQUEST_ENV];
     delete process.env[RUNTIME_HOST_OPERATOR_CAPABILITY_REQUEST_ENV];
@@ -722,6 +794,115 @@ describe('managed Runtime Host service', () => {
       { waitForReady: async () => undefined },
     );
     assert.equal(repaired.service.config?.rootPath, root.canonicalPath);
+  });
+
+  it('retires the exact managed Host only after active work is authorized', async (t) => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-retirement-'));
+    t.after(() => rm(base, { recursive: true, force: true }));
+    const clientDataRoot = join(base, 'config');
+    const root = await resolveStorageRoot({ path: join(base, 'state'), kind: 'interactive' });
+    const cliPath = join(base, 'cli.js');
+    await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
+    let active = true;
+    let stops = 0;
+    const backend: RuntimeHostServiceBackend = {
+      ...createReadyBackend(),
+      status: async () => ({
+        manager: 'systemd_user',
+        installed: true,
+        enabled: true,
+        active,
+        state: active ? ('running' as const) : ('stopped' as const),
+        pid: active ? 42 : null,
+        lastExitCode: 0,
+      }),
+      stop: async () => {
+        stops += 1;
+        active = false;
+      },
+    };
+    const common = {
+      clientDataRoot,
+      defaultRootPath: root.canonicalPath,
+      nodePath: process.execPath,
+      cliPath,
+    } as const;
+    await manageRuntimeHostService({ ...common, action: 'install' }, backend, {
+      waitForReady: async () => undefined,
+    });
+    const expectedTarget = {
+      serviceId: resolveRuntimeHostManagedServiceId(clientDataRoot),
+      rootPath: root.canonicalPath,
+      rootId: root.rootId,
+    } as const;
+    let preparations = 0;
+    const deps = {
+      prepareRetirement: async (_config: RuntimeHostManagedServiceConfig, allow: boolean) => {
+        preparations += 1;
+        return allow
+          ? ({ kind: 'prepared', hostEpoch: 'host-1', pid: 42 } as const)
+          : ({
+              kind: 'active_tasks',
+              blockers: {
+                activeOperations: 0,
+                residencies: [{ label: 'scheduled-task', count: 1 }],
+              },
+            } as const);
+      },
+    } as const;
+
+    const blocked = await manageRuntimeHostService(
+      { ...common, action: 'retire', expectedTarget },
+      backend,
+      deps,
+    );
+    assert.deepEqual(blocked.retirement, {
+      kind: 'active_tasks',
+      blockers: {
+        activeOperations: 0,
+        residencies: [{ label: 'scheduled-task', count: 1 }],
+      },
+    });
+    assert.equal(stops, 0);
+
+    const retired = await manageRuntimeHostService(
+      {
+        ...common,
+        action: 'retire',
+        expectedTarget,
+        allowInterruptActiveTasks: true,
+      },
+      backend,
+      deps,
+    );
+    assert.deepEqual(retired.retirement, {
+      kind: 'retired',
+      hostEpoch: 'host-1',
+      pid: 42,
+    });
+    assert.equal(stops, 1);
+
+    const conflictingOwner = await tryAcquireInteractiveRootOwner(root);
+    assert.ok(conflictingOwner);
+    await assert.rejects(
+      manageRuntimeHostService({ ...common, action: 'retire', expectedTarget }, backend, deps),
+      (error: unknown) =>
+        error instanceof RuntimeHostServiceManagerError && error.code === 'retirement_failed',
+    );
+    await conflictingOwner.close();
+
+    const repeated = await manageRuntimeHostService(
+      { ...common, action: 'retire', expectedTarget },
+      backend,
+      deps,
+    );
+    assert.deepEqual(repeated.retirement, {
+      kind: 'retired',
+      hostEpoch: null,
+      pid: null,
+    });
+    assert.equal(preparations, 2);
+    assert.equal(stops, 1);
   });
 
   it('restores the deployed service when the replacement never becomes ready', async (t) => {

--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -572,6 +572,7 @@ describe('managed Runtime Host service', () => {
             'Persistent user services are disabled',
           );
         },
+        withLifecycleLock: async (_root, operation) => operation(),
         createBackend: createUnusedBackend,
         writeOutput: (value) => {
           output += value;
@@ -592,6 +593,7 @@ describe('managed Runtime Host service', () => {
 
   it('emits bounded retirement facts in framed output', async () => {
     let output = '';
+    let lifecycleLocked = false;
     const exitCode = await runManagedRuntimeHostServiceCli(
       {
         action: 'retire',
@@ -603,22 +605,33 @@ describe('managed Runtime Host service', () => {
         cliPath: '/opt/maka/cli.js',
       },
       {
-        manage: async () => ({
-          schemaVersion: 1,
-          action: 'retire',
-          service: {
-            manager: 'systemd_user',
-            installed: true,
-            enabled: true,
-            active: false,
-            state: 'stopped',
-            pid: null,
-            lastExitCode: 0,
-            installedVersion: '1.2.3',
-            config: null,
-          },
-          retirement: { kind: 'retired', hostEpoch: 'host-1', pid: 42 },
-        }),
+        manage: async () => {
+          assert.equal(lifecycleLocked, true);
+          return {
+            schemaVersion: 1,
+            action: 'retire',
+            service: {
+              manager: 'systemd_user',
+              installed: true,
+              enabled: true,
+              active: false,
+              state: 'stopped',
+              pid: null,
+              lastExitCode: 0,
+              installedVersion: '1.2.3',
+              config: null,
+            },
+            retirement: { kind: 'retired', hostEpoch: 'host-1', pid: 42 },
+          };
+        },
+        withLifecycleLock: async (_root, operation) => {
+          lifecycleLocked = true;
+          try {
+            return await operation();
+          } finally {
+            lifecycleLocked = false;
+          }
+        },
         createBackend: createUnusedBackend,
         writeOutput: (value) => {
           output += value;
@@ -628,11 +641,14 @@ describe('managed Runtime Host service', () => {
     assert.equal(exitCode, 0);
     const frame = decodeRuntimeHostServiceManagementFrame(output);
     assert.equal(frame?.kind, 'result');
-    assert.deepEqual(frame?.kind === 'result' ? frame.retirement : undefined, {
-      kind: 'retired',
-      hostEpoch: 'host-1',
-      pid: 42,
-    });
+    assert.deepEqual(
+      frame?.kind === 'result' && frame.action === 'retire' ? frame.retirement : null,
+      {
+        kind: 'retired',
+        hostEpoch: 'host-1',
+        pid: 42,
+      },
+    );
   });
 
   it('projects requested operator capabilities without launch configuration', async (t) => {
@@ -803,7 +819,7 @@ describe('managed Runtime Host service', () => {
     const root = await resolveStorageRoot({ path: join(base, 'state'), kind: 'interactive' });
     const cliPath = join(base, 'cli.js');
     await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
-    let active = true;
+    let serviceState: 'running' | 'starting' | 'stopped' = 'running';
     let stops = 0;
     const backend: RuntimeHostServiceBackend = {
       ...createReadyBackend(),
@@ -811,14 +827,14 @@ describe('managed Runtime Host service', () => {
         manager: 'systemd_user',
         installed: true,
         enabled: true,
-        active,
-        state: active ? ('running' as const) : ('stopped' as const),
-        pid: active ? 42 : null,
+        active: serviceState === 'running',
+        state: serviceState,
+        pid: serviceState === 'running' ? 42 : null,
         lastExitCode: 0,
       }),
       stop: async () => {
         stops += 1;
-        active = false;
+        serviceState = 'stopped';
       },
     };
     const common = {
@@ -835,19 +851,16 @@ describe('managed Runtime Host service', () => {
       rootPath: root.canonicalPath,
       rootId: root.rootId,
     } as const;
-    let preparations = 0;
     const deps = {
-      prepareRetirement: async (_config: RuntimeHostManagedServiceConfig, allow: boolean) => {
-        preparations += 1;
+      prepareRetirement: async (
+        _config: RuntimeHostManagedServiceConfig,
+        expectedPid: number,
+        allow: boolean,
+      ) => {
+        assert.equal(expectedPid, 42);
         return allow
           ? ({ kind: 'prepared', hostEpoch: 'host-1', pid: 42 } as const)
-          : ({
-              kind: 'active_tasks',
-              blockers: {
-                activeOperations: 0,
-                residencies: [{ label: 'scheduled-task', count: 1 }],
-              },
-            } as const);
+          : ({ kind: 'active_tasks' } as const);
       },
     } as const;
 
@@ -856,13 +869,7 @@ describe('managed Runtime Host service', () => {
       backend,
       deps,
     );
-    assert.deepEqual(blocked.retirement, {
-      kind: 'active_tasks',
-      blockers: {
-        activeOperations: 0,
-        residencies: [{ label: 'scheduled-task', count: 1 }],
-      },
-    });
+    assert.deepEqual(blocked.retirement, { kind: 'active_tasks' });
     assert.equal(stops, 0);
 
     const retired = await manageRuntimeHostService(
@@ -891,18 +898,14 @@ describe('managed Runtime Host service', () => {
     );
     await conflictingOwner.close();
 
-    const repeated = await manageRuntimeHostService(
+    serviceState = 'starting';
+    const starting = await manageRuntimeHostService(
       { ...common, action: 'retire', expectedTarget },
       backend,
       deps,
     );
-    assert.deepEqual(repeated.retirement, {
-      kind: 'retired',
-      hostEpoch: null,
-      pid: null,
-    });
-    assert.equal(preparations, 2);
-    assert.equal(stops, 1);
+    assert.deepEqual(starting.retirement, { kind: 'stopped' });
+    assert.equal(serviceState, 'stopped');
   });
 
   it('restores the deployed service when the replacement never becomes ready', async (t) => {

--- a/packages/cli/src/__tests__/runtime-host-setup.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-setup.test.ts
@@ -439,7 +439,7 @@ async function createReleasePackage(base: string, version: string): Promise<stri
 }
 
 function serviceResult(
-  action: RuntimeHostManagedServiceResult['action'],
+  action: Exclude<RuntimeHostManagedServiceResult['action'], 'retire'>,
   config: RuntimeHostManagedServiceConfig | null,
   installedVersion: string | null,
 ): RuntimeHostManagedServiceResult {

--- a/packages/cli/src/cli-core.ts
+++ b/packages/cli/src/cli-core.ts
@@ -121,6 +121,7 @@ function helpText(cliCommand: string): string {
     `  ${cliCommand} runtime-host setup --principal <id> --preset <desktop-client|terminal-client> [options]`,
     `  ${cliCommand} runtime-host service install [options]`,
     `  ${cliCommand} runtime-host service status|start|stop|restart|logs|uninstall [--json]`,
+    `  ${cliCommand} runtime-host service retire --expected-service-id <id> --expected-root-path <path> --expected-root-id <id> [--allow-interrupt-active-tasks]`,
     `  ${cliCommand} runtime-host access issue --principal <id> --grant <operation>`,
     `  ${cliCommand} runtime-host access issue --principal <id> --preset <desktop-client|terminal-client>`,
     `  ${cliCommand} runtime-host access list`,
@@ -271,6 +272,7 @@ export async function runMakaCli(
         ...(command.websocketPath ? { websocketPath: command.websocketPath } : {}),
         ...(command.expectedTarget ? { expectedTarget: command.expectedTarget } : {}),
         ...(command.retainManagedDeployment ? { retainManagedDeployment: true } : {}),
+        ...(command.allowInterruptActiveTasks ? { allowInterruptActiveTasks: true } : {}),
       });
     }
     case 'runtime-host-managed-deployment-cleanup': {

--- a/packages/cli/src/runtime-host-cli.ts
+++ b/packages/cli/src/runtime-host-cli.ts
@@ -57,7 +57,7 @@ export type RuntimeHostCliCommand =
     }
   | {
       kind: 'runtime-host-service-manage';
-      action: 'install' | 'status' | 'start' | 'stop' | 'restart' | 'logs' | 'uninstall';
+      action: 'install' | 'status' | 'start' | 'stop' | 'restart' | 'retire' | 'logs' | 'uninstall';
       json: boolean;
       framed?: true;
       clientDataRoot?: string;
@@ -67,6 +67,7 @@ export type RuntimeHostCliCommand =
       websocketPath?: string;
       expectedTarget?: RuntimeHostManagedServiceTarget;
       retainManagedDeployment?: true;
+      allowInterruptActiveTasks?: true;
     }
   | {
       kind: 'runtime-host-managed-deployment-cleanup';
@@ -225,18 +226,38 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
     action !== 'start' &&
     action !== 'stop' &&
     action !== 'restart' &&
+    action !== 'retire' &&
     action !== 'logs' &&
     action !== 'uninstall'
   ) {
     return error(
       action
         ? `Unexpected runtime-host service command: ${action}`
-        : 'runtime-host service requires install, status, start, stop, restart, logs, or uninstall',
+        : 'runtime-host service requires install, status, start, stop, restart, retire, logs, or uninstall',
     );
   }
 
   let retainManagedDeployment = false;
+  let allowInterruptActiveTasks = false;
   let clientDataRoot: string | undefined;
+  const flagOptions: Readonly<Record<string, () => void | RuntimeHostCliError>> =
+    action === 'uninstall'
+      ? {
+          '--retain-managed-deployment': () => {
+            if (retainManagedDeployment) return error('Duplicate --retain-managed-deployment');
+            retainManagedDeployment = true;
+          },
+        }
+      : action === 'retire'
+        ? {
+            '--allow-interrupt-active-tasks': () => {
+              if (allowInterruptActiveTasks) {
+                return error('Duplicate --allow-interrupt-active-tasks');
+              }
+              allowInterruptActiveTasks = true;
+            },
+          }
+        : {};
   const options = parseManagedServiceOptions(argv.slice(1), {
     allowConfiguration: action === 'install',
     allowFramed: true,
@@ -247,24 +268,19 @@ function parseServiceManagementCommand(argv: string[]): RuntimeHostCliCommand {
         clientDataRoot = value;
       },
     },
-    ...(action === 'uninstall'
-      ? {
-          flagOptions: {
-            '--retain-managed-deployment': () => {
-              if (retainManagedDeployment) return error('Duplicate --retain-managed-deployment');
-              retainManagedDeployment = true;
-            },
-          },
-        }
-      : {}),
+    flagOptions,
   });
   if ('kind' in options) return options;
+  if (action === 'retire' && !options.expectedTarget) {
+    return error('runtime-host service retire requires an expected target');
+  }
   return {
     kind: 'runtime-host-service-manage',
     action,
     ...options,
     ...(clientDataRoot ? { clientDataRoot } : {}),
     ...(retainManagedDeployment ? { retainManagedDeployment: true } : {}),
+    ...(allowInterruptActiveTasks ? { allowInterruptActiveTasks: true } : {}),
   };
 }
 

--- a/packages/cli/src/runtime-host-service-command.ts
+++ b/packages/cli/src/runtime-host-service-command.ts
@@ -19,6 +19,7 @@
 
 import {
   installRuntimeHostLogCapture,
+  RUNTIME_HOST_RETIREMENT_EXIT_CODE,
   runRuntimeHostProcessLifecycle,
   startExecutionRuntimeHostService,
 } from '@maka/runtime-host/server';
@@ -73,19 +74,24 @@ export async function runRuntimeHostServiceCli(
       : {}),
     ...(websocket ? { websocket } : {}),
   });
-  await runRuntimeHostProcessLifecycle(host, {
-    onReady: () => {
-      if (options.json) {
-        process.stdout.write(`${JSON.stringify(createRuntimeHostServiceReadyEvent(host))}\n`);
-        return;
-      }
-      process.stdout.write(`Runtime Host service is ready at ${host.endpoint}\n`);
-      for (const endpoint of host.websocketEndpoints) {
-        process.stdout.write(`Runtime Host WebSocket is ready at ${endpoint}\n`);
-      }
-    },
-  });
-  return 0;
+  try {
+    await runRuntimeHostProcessLifecycle(host, {
+      onReady: () => {
+        if (options.json) {
+          process.stdout.write(`${JSON.stringify(createRuntimeHostServiceReadyEvent(host))}\n`);
+          return;
+        }
+        process.stdout.write(`Runtime Host service is ready at ${host.endpoint}\n`);
+        for (const endpoint of host.websocketEndpoints) {
+          process.stdout.write(`Runtime Host WebSocket is ready at ${endpoint}\n`);
+        }
+      },
+    });
+  } catch (error) {
+    if (host.shutdownReason !== 'retirement') throw error;
+    console.error('[runtime-host] retirement shutdown did not complete cleanly:', error);
+  }
+  return host.shutdownReason === 'retirement' ? RUNTIME_HOST_RETIREMENT_EXIT_CODE : 0;
 }
 
 export interface RuntimeHostServiceReadyEvent {

--- a/packages/cli/src/runtime-host-service-management-command.ts
+++ b/packages/cli/src/runtime-host-service-management-command.ts
@@ -140,6 +140,11 @@ function formatHumanResult(result: RuntimeHostManagedServiceResult): string {
     if (!service.installed) return 'Runtime Host service is not installed.\n';
     return `Runtime Host service is ${service.state} at ${websocketUrl(service)}\n`;
   }
+  if (result.action === 'retire') {
+    return result.retirement?.kind === 'active_tasks'
+      ? 'Runtime Host service still owns active work. Retry with explicit interruption authority.\n'
+      : 'Runtime Host service is retired and its State Root writer is released.\n';
+  }
   if (result.action === 'logs') return result.logs || 'No Runtime Host service logs were found.\n';
   return `Runtime Host service is ${service.state}.\n`;
 }
@@ -165,6 +170,22 @@ function successFrame(result: RuntimeHostManagedServiceResult): RuntimeHostServi
     ...(process.env[RUNTIME_HOST_OPERATOR_CAPABILITY_REQUEST_ENV] ===
     RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY
       ? { operatorCapabilities: [RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY] }
+      : {}),
+    ...(result.retirement
+      ? {
+          retirement:
+            result.retirement.kind === 'active_tasks'
+              ? {
+                  kind: result.retirement.kind,
+                  blockers: {
+                    activeOperations: result.retirement.blockers.activeOperations,
+                    residencies: result.retirement.blockers.residencies.map((residency) => ({
+                      ...residency,
+                    })),
+                  },
+                }
+              : { ...result.retirement },
+        }
       : {}),
     ...(result.retainedStateRoot ? { retainedStateRoot: result.retainedStateRoot } : {}),
     ...(result.logs !== undefined ? { logs: result.logs } : {}),

--- a/packages/cli/src/runtime-host-service-management-command.ts
+++ b/packages/cli/src/runtime-host-service-management-command.ts
@@ -33,6 +33,7 @@ import {
   manageRuntimeHostService,
   resolveRuntimeHostManagedServiceId,
   RuntimeHostServiceManagerError,
+  withRuntimeHostManagedServiceLifecycleLock,
   type RuntimeHostManagedServiceInput,
   type RuntimeHostManagedServiceResult,
   type RuntimeHostManagedServiceTarget,
@@ -47,6 +48,7 @@ export interface RuntimeHostServiceManagementCliOptions extends RuntimeHostManag
 
 export interface RuntimeHostServiceManagementCliDeps {
   readonly manage: typeof manageRuntimeHostService;
+  readonly withLifecycleLock: typeof withRuntimeHostManagedServiceLifecycleLock;
   readonly createBackend: (serviceId: string) => RuntimeHostServiceBackend;
   readonly writeOutput: (value: string) => unknown;
   readonly writeError: (value: string) => unknown;
@@ -58,6 +60,7 @@ export async function runManagedRuntimeHostServiceCli(
 ): Promise<number> {
   const deps: RuntimeHostServiceManagementCliDeps = {
     manage: manageRuntimeHostService,
+    withLifecycleLock: withRuntimeHostManagedServiceLifecycleLock,
     createBackend: createPlatformRuntimeHostServiceBackend,
     writeOutput: (value) => process.stdout.write(value),
     writeError: (value) => process.stderr.write(value),
@@ -66,7 +69,11 @@ export async function runManagedRuntimeHostServiceCli(
   try {
     const { json: _json, framed: _framed, ...input } = options;
     const serviceId = resolveRuntimeHostManagedServiceId(options.clientDataRoot);
-    const result = await deps.manage(input, deps.createBackend(serviceId));
+    const manage = () => deps.manage(input, deps.createBackend(serviceId));
+    const result =
+      options.action === 'status' || options.action === 'logs'
+        ? await manage()
+        : await deps.withLifecycleLock(options.clientDataRoot, manage);
     if (options.framed) {
       deps.writeOutput(encodeRuntimeHostServiceManagementFrame(successFrame(result)));
     } else {
@@ -141,7 +148,7 @@ function formatHumanResult(result: RuntimeHostManagedServiceResult): string {
     return `Runtime Host service is ${service.state} at ${websocketUrl(service)}\n`;
   }
   if (result.action === 'retire') {
-    return result.retirement?.kind === 'active_tasks'
+    return result.retirement.kind === 'active_tasks'
       ? 'Runtime Host service still owns active work. Retry with explicit interruption authority.\n'
       : 'Runtime Host service is retired and its State Root writer is released.\n';
   }
@@ -162,34 +169,24 @@ function successFrame(result: RuntimeHostManagedServiceResult): RuntimeHostServi
     ...(config ? { stateRoot: config.rootPath } : {}),
     projectDirectoryRoots: [...(config?.projectDirectoryRoots ?? [])],
   };
-  return {
+  const common = {
     schemaVersion: 1,
     kind: 'result',
-    action: result.action,
     service,
     ...(process.env[RUNTIME_HOST_OPERATOR_CAPABILITY_REQUEST_ENV] ===
     RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY
-      ? { operatorCapabilities: [RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY] }
-      : {}),
-    ...(result.retirement
       ? {
-          retirement:
-            result.retirement.kind === 'active_tasks'
-              ? {
-                  kind: result.retirement.kind,
-                  blockers: {
-                    activeOperations: result.retirement.blockers.activeOperations,
-                    residencies: result.retirement.blockers.residencies.map((residency) => ({
-                      ...residency,
-                    })),
-                  },
-                }
-              : { ...result.retirement },
+          operatorCapabilities: [
+            RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY,
+          ] as (typeof RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY)[],
         }
       : {}),
     ...(result.retainedStateRoot ? { retainedStateRoot: result.retainedStateRoot } : {}),
     ...(result.logs !== undefined ? { logs: result.logs } : {}),
-  };
+  } as const;
+  return result.action === 'retire'
+    ? { ...common, action: result.action, retirement: { ...result.retirement } }
+    : { ...common, action: result.action };
 }
 
 export function createPlatformRuntimeHostServiceBackend(

--- a/packages/cli/src/runtime-host-service-management-command.ts
+++ b/packages/cli/src/runtime-host-service-management-command.ts
@@ -74,14 +74,17 @@ export async function runManagedRuntimeHostServiceCli(
       options.action === 'status' || options.action === 'logs'
         ? await manage()
         : await deps.withLifecycleLock(options.clientDataRoot, manage);
+    const blocked = result.action === 'retire' && result.retirement.kind === 'active_tasks';
     if (options.framed) {
       deps.writeOutput(encodeRuntimeHostServiceManagementFrame(successFrame(result)));
+    } else if (options.json) {
+      deps.writeOutput(`${JSON.stringify({ ...result, ok: !blocked })}\n`);
+    } else if (blocked) {
+      deps.writeError(formatHumanResult(result));
     } else {
-      deps.writeOutput(
-        options.json ? `${JSON.stringify({ ...result, ok: true })}\n` : formatHumanResult(result),
-      );
+      deps.writeOutput(formatHumanResult(result));
     }
-    return 0;
+    return blocked ? 1 : 0;
   } catch (error) {
     const code =
       error instanceof RuntimeHostServiceManagerError ? error.code : 'internal_service_error';

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -35,6 +35,7 @@ import { withFileUpdateLock } from '@maka/storage/file-update-lock';
 import {
   resolveExistingStorageRoot,
   tryAcquireInteractiveRootOwner,
+  type InteractiveRootOwner,
   type StorageRootCapability,
 } from '@maka/storage/root-authority';
 import {
@@ -375,6 +376,7 @@ async function manageRuntimeHostServiceLocked(
       );
     }
     let prepared: { readonly hostEpoch: string; readonly pid: number } | undefined;
+    let rootFence: InteractiveRootOwner | undefined;
     if (service.pid !== null) {
       const retirement = await deps.prepareRetirement(
         service.config,
@@ -390,24 +392,35 @@ async function manageRuntimeHostServiceLocked(
         'retirement_failed',
         'Managed Runtime Host service did not report its process identity',
       );
+    } else if (service.state === 'starting') {
+      rootFence = await acquireRuntimeHostRootRetirementFence(root);
     }
-    await backend.stop();
-    const stopped = await readServiceStatus(configPath, backend);
-    if (stopped.active || stopped.state !== 'stopped' || stopped.pid !== null) {
-      throw new RuntimeHostServiceManagerError(
-        'retirement_failed',
-        'Runtime Host service did not reach a stable stopped state after retirement',
-      );
+    try {
+      await backend.stop();
+      const stopped = await readServiceStatus(configPath, backend);
+      if (stopped.active || stopped.state !== 'stopped' || stopped.pid !== null) {
+        throw new RuntimeHostServiceManagerError(
+          'retirement_failed',
+          'Runtime Host service did not reach a stable stopped state after retirement',
+        );
+      }
+      if (rootFence) {
+        await releaseRuntimeHostRootRetirementFence(rootFence);
+        rootFence = undefined;
+      } else {
+        await verifyRuntimeHostRootReleased(root);
+      }
+      return {
+        schemaVersion: 1,
+        action: input.action,
+        service: stopped,
+        retirement: prepared
+          ? { kind: 'retired', hostEpoch: prepared.hostEpoch, pid: prepared.pid }
+          : { kind: 'stopped' },
+      };
+    } finally {
+      await rootFence?.close().catch(() => undefined);
     }
-    await verifyRuntimeHostRootReleased(root);
-    return {
-      schemaVersion: 1,
-      action: input.action,
-      service: stopped,
-      retirement: prepared
-        ? { kind: 'retired', hostEpoch: prepared.hostEpoch, pid: prepared.pid }
-        : { kind: 'stopped' },
-    };
   }
   const config = await readServiceConfig(configPath);
   if (!config) {
@@ -914,6 +927,34 @@ async function verifyRuntimeHostRootReleased(
     throw new RuntimeHostServiceManagerError(
       'retirement_failed',
       'Runtime Host retirement did not release the State Root writer',
+      { cause: error },
+    );
+  }
+}
+
+async function acquireRuntimeHostRootRetirementFence(
+  root: StorageRootCapability<'interactive'>,
+): Promise<InteractiveRootOwner> {
+  try {
+    const owner = await tryAcquireInteractiveRootOwner(root);
+    if (!owner) throw new Error('The State Root writer changed while retirement was starting');
+    return owner;
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'retirement_failed',
+      'The State Root acquired a writer before retirement could stop the Runtime Host service',
+      { cause: error },
+    );
+  }
+}
+
+async function releaseRuntimeHostRootRetirementFence(owner: InteractiveRootOwner): Promise<void> {
+  try {
+    await owner.close();
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'retirement_failed',
+      'Runtime Host retirement did not release the State Root writer fence',
       { cause: error },
     );
   }

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -32,7 +32,10 @@ import {
 import { connectExistingRuntimeHost } from '@maka/runtime-host/client';
 import { RUNTIME_HOST_SERVICE_LOG_MAX_BYTES } from '@maka/runtime-host/operator';
 import { withFileUpdateLock } from '@maka/storage/file-update-lock';
-import { resolveExistingStorageRoot } from '@maka/storage/root-authority';
+import {
+  resolveExistingStorageRoot,
+  tryAcquireInteractiveRootOwner,
+} from '@maka/storage/root-authority';
 import {
   isRuntimeHostManagedDeploymentCli,
   removeRuntimeHostManagedDeployment,
@@ -108,13 +111,28 @@ export type RuntimeHostManagedServiceAction =
   | 'start'
   | 'stop'
   | 'restart'
+  | 'retire'
   | 'logs'
   | 'uninstall';
+
+export type RuntimeHostRetirementResult =
+  | { readonly kind: 'active_tasks'; readonly blockers: RuntimeHostRetirementBlockers }
+  | {
+      readonly kind: 'retired';
+      readonly hostEpoch: string | null;
+      readonly pid: number | null;
+    };
+
+export interface RuntimeHostRetirementBlockers {
+  readonly activeOperations: number;
+  readonly residencies: readonly { readonly label: string; readonly count: number }[];
+}
 
 export interface RuntimeHostManagedServiceResult {
   readonly schemaVersion: 1;
   readonly action: RuntimeHostManagedServiceAction;
   readonly service: RuntimeHostManagedServiceStatus;
+  readonly retirement?: RuntimeHostRetirementResult;
   readonly retainedStateRoot?: string;
   readonly logs?: string;
 }
@@ -131,6 +149,7 @@ export interface RuntimeHostManagedServiceInput {
   readonly nodePath: string;
   readonly cliPath: string;
   readonly expectedTarget?: RuntimeHostManagedServiceTarget;
+  readonly allowInterruptActiveTasks?: boolean;
 }
 
 export interface RuntimeHostManagedServiceTarget {
@@ -151,6 +170,14 @@ interface RuntimeHostServiceManagerDeps {
     config: RuntimeHostManagedServiceConfig,
     backend: RuntimeHostServiceBackend,
   ) => Promise<void>;
+  readonly prepareRetirement: (
+    config: RuntimeHostManagedServiceConfig,
+    allowInterruptActiveTasks: boolean,
+  ) => Promise<
+    | { readonly kind: 'active_tasks'; readonly blockers: RuntimeHostRetirementBlockers }
+    | { readonly kind: 'prepared'; readonly hostEpoch: string; readonly pid: number }
+  >;
+  readonly verifyRootReleased: (rootPath: string, expectedRootId: string) => Promise<void>;
   readonly environment: NodeJS.ProcessEnv;
   readonly homeDir: string;
 }
@@ -165,6 +192,7 @@ export class RuntimeHostServiceManagerError extends Error {
       | 'invalid_config'
       | 'invalid_launch'
       | 'target_mismatch'
+      | 'retirement_failed'
       | 'service_manager_operation_failed'
       | 'uninstall_incomplete',
     message: string,
@@ -183,6 +211,8 @@ export async function manageRuntimeHostService(
   const deps: RuntimeHostServiceManagerDeps = {
     allocateLoopbackPort,
     waitForReady: waitForManagedRuntimeHostReady,
+    prepareRetirement: prepareRuntimeHostRetirement,
+    verifyRootReleased: verifyRuntimeHostRootReleased,
     environment: process.env,
     homeDir: homedir(),
     ...overrides,
@@ -325,6 +355,52 @@ async function manageRuntimeHostServiceLocked(
     await resolveExpectedServiceRoot(service.config, input);
     const logs = truncateUtf8(await backend.logs(), RUNTIME_HOST_SERVICE_LOG_MAX_BYTES);
     return result(input.action, service, undefined, logs);
+  }
+  if (input.action === 'retire') {
+    if (!input.expectedTarget) {
+      throw new RuntimeHostServiceManagerError(
+        'target_mismatch',
+        'Runtime Host retirement requires the expected managed service identity',
+      );
+    }
+    const service = await readServiceStatus(configPath, backend);
+    const rootPath = await resolveExpectedServiceRoot(service.config, input);
+    if (!service.installed || !service.config || !rootPath) {
+      throw new RuntimeHostServiceManagerError(
+        'not_installed',
+        'Runtime Host service is not installed',
+      );
+    }
+    let prepared: { readonly hostEpoch: string; readonly pid: number } | undefined;
+    if (service.active) {
+      const retirement = await deps.prepareRetirement(
+        service.config,
+        input.allowInterruptActiveTasks ?? false,
+      );
+      if (retirement.kind === 'active_tasks') {
+        return { schemaVersion: 1, action: input.action, service, retirement };
+      }
+      prepared = retirement;
+      await backend.stop();
+    }
+    const stopped = await readServiceStatus(configPath, backend);
+    if (stopped.active) {
+      throw new RuntimeHostServiceManagerError(
+        'retirement_failed',
+        'Runtime Host service remained active after retirement',
+      );
+    }
+    await deps.verifyRootReleased(rootPath, input.expectedTarget.rootId);
+    return {
+      schemaVersion: 1,
+      action: input.action,
+      service: stopped,
+      retirement: {
+        kind: 'retired',
+        hostEpoch: prepared?.hostEpoch ?? null,
+        pid: prepared?.pid ?? null,
+      },
+    };
   }
   const config = await readServiceConfig(configPath);
   if (!config) {
@@ -760,6 +836,79 @@ async function waitForManagedRuntimeHostReady(
     'service_manager_operation_failed',
     `Runtime Host service did not become ready: ${lastFailure}`,
   );
+}
+
+async function prepareRuntimeHostRetirement(
+  config: RuntimeHostManagedServiceConfig,
+  allowInterruptActiveTasks: boolean,
+): Promise<
+  | { readonly kind: 'active_tasks'; readonly blockers: RuntimeHostRetirementBlockers }
+  | { readonly kind: 'prepared'; readonly hostEpoch: string; readonly pid: number }
+> {
+  const connected = await connectExistingRuntimeHost({
+    rootPath: config.rootPath,
+    protocol: { min: RUNTIME_HOST_PROTOCOL_VERSION, max: RUNTIME_HOST_PROTOCOL_VERSION },
+  }).catch((error: unknown) => {
+    throw new RuntimeHostServiceManagerError(
+      'retirement_failed',
+      'Unable to connect to the managed Runtime Host before retirement',
+      { cause: error },
+    );
+  });
+  if (connected.kind !== 'connected') {
+    throw new RuntimeHostServiceManagerError(
+      'retirement_failed',
+      `Managed Runtime Host cannot prepare for retirement: ${connected.kind}`,
+    );
+  }
+  const hostEpoch = connected.connection.hostEpoch;
+  try {
+    const diagnostics = await connected.connection.queryHostDiagnostics();
+    const prepared = await connected.connection.request('host.upgrade.prepare', {
+      expectedHostEpoch: hostEpoch,
+      allowInterruptActiveTasks,
+    });
+    if (prepared.kind === 'prepared') return { ...prepared, hostEpoch };
+    return {
+      kind: 'active_tasks',
+      blockers: {
+        activeOperations: Math.max(0, diagnostics.activeOperations - 1),
+        residencies: diagnostics.residencies.filter(({ label }) => label !== 'process-retention'),
+      },
+    };
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'retirement_failed',
+      'Managed Runtime Host could not prepare for retirement',
+      { cause: error },
+    );
+  } finally {
+    await connected.connection.close().catch(() => undefined);
+  }
+}
+
+async function verifyRuntimeHostRootReleased(
+  rootPath: string,
+  expectedRootId: string,
+): Promise<void> {
+  try {
+    const capability = await resolveExistingStorageRoot({
+      path: rootPath,
+      kind: 'interactive',
+      expectedRootId,
+    });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    if (!owner) {
+      throw new Error('The State Root writer is still held');
+    }
+    await owner.close();
+  } catch (error) {
+    throw new RuntimeHostServiceManagerError(
+      'retirement_failed',
+      'Runtime Host retirement did not release the State Root writer',
+      { cause: error },
+    );
+  }
 }
 
 async function rollbackDeployment(

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -375,13 +375,7 @@ async function manageRuntimeHostServiceLocked(
       );
     }
     let prepared: { readonly hostEpoch: string; readonly pid: number } | undefined;
-    if (service.active) {
-      if (service.pid === null) {
-        throw new RuntimeHostServiceManagerError(
-          'retirement_failed',
-          'Managed Runtime Host service did not report its process identity',
-        );
-      }
+    if (service.pid !== null) {
       const retirement = await deps.prepareRetirement(
         service.config,
         service.pid,
@@ -391,6 +385,11 @@ async function manageRuntimeHostServiceLocked(
         return { schemaVersion: 1, action: input.action, service, retirement };
       }
       prepared = retirement;
+    } else if (service.active) {
+      throw new RuntimeHostServiceManagerError(
+        'retirement_failed',
+        'Managed Runtime Host service did not report its process identity',
+      );
     }
     await backend.stop();
     const stopped = await readServiceStatus(configPath, backend);

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -35,6 +35,7 @@ import { withFileUpdateLock } from '@maka/storage/file-update-lock';
 import {
   resolveExistingStorageRoot,
   tryAcquireInteractiveRootOwner,
+  type StorageRootCapability,
 } from '@maka/storage/root-authority';
 import {
   isRuntimeHostManagedDeploymentCli,
@@ -116,26 +117,30 @@ export type RuntimeHostManagedServiceAction =
   | 'uninstall';
 
 export type RuntimeHostRetirementResult =
-  | { readonly kind: 'active_tasks'; readonly blockers: RuntimeHostRetirementBlockers }
+  | { readonly kind: 'active_tasks' }
   | {
       readonly kind: 'retired';
-      readonly hostEpoch: string | null;
-      readonly pid: number | null;
-    };
+      readonly hostEpoch: string;
+      readonly pid: number;
+    }
+  | { readonly kind: 'stopped' };
 
-export interface RuntimeHostRetirementBlockers {
-  readonly activeOperations: number;
-  readonly residencies: readonly { readonly label: string; readonly count: number }[];
-}
-
-export interface RuntimeHostManagedServiceResult {
+interface RuntimeHostManagedServiceResultBase {
   readonly schemaVersion: 1;
-  readonly action: RuntimeHostManagedServiceAction;
   readonly service: RuntimeHostManagedServiceStatus;
-  readonly retirement?: RuntimeHostRetirementResult;
   readonly retainedStateRoot?: string;
   readonly logs?: string;
 }
+
+export type RuntimeHostManagedServiceResult =
+  | (RuntimeHostManagedServiceResultBase & {
+      readonly action: 'retire';
+      readonly retirement: RuntimeHostRetirementResult;
+    })
+  | (RuntimeHostManagedServiceResultBase & {
+      readonly action: Exclude<RuntimeHostManagedServiceAction, 'retire'>;
+      readonly retirement?: never;
+    });
 
 export interface RuntimeHostManagedServiceInput {
   readonly action: RuntimeHostManagedServiceAction;
@@ -172,12 +177,12 @@ interface RuntimeHostServiceManagerDeps {
   ) => Promise<void>;
   readonly prepareRetirement: (
     config: RuntimeHostManagedServiceConfig,
+    expectedPid: number,
     allowInterruptActiveTasks: boolean,
   ) => Promise<
-    | { readonly kind: 'active_tasks'; readonly blockers: RuntimeHostRetirementBlockers }
+    | { readonly kind: 'active_tasks' }
     | { readonly kind: 'prepared'; readonly hostEpoch: string; readonly pid: number }
   >;
-  readonly verifyRootReleased: (rootPath: string, expectedRootId: string) => Promise<void>;
   readonly environment: NodeJS.ProcessEnv;
   readonly homeDir: string;
 }
@@ -212,7 +217,6 @@ export async function manageRuntimeHostService(
     allocateLoopbackPort,
     waitForReady: waitForManagedRuntimeHostReady,
     prepareRetirement: prepareRuntimeHostRetirement,
-    verifyRootReleased: verifyRuntimeHostRootReleased,
     environment: process.env,
     homeDir: homedir(),
     ...overrides,
@@ -287,10 +291,10 @@ async function manageRuntimeHostServiceLocked(
   if (input.expectedTarget) assertExpectedServiceIdentity(serviceId, input.expectedTarget);
   if (input.action === 'install') {
     const previous = await readServiceConfigForRepair(configPath);
-    const expectedRootPath = await resolveExpectedServiceRoot(previous, input);
+    const expectedRoot = await resolveExpectedServiceRoot(previous, input);
     await backend.preflightInstall();
     const config = await prepareServiceConfig(
-      expectedRootPath ? { ...input, rootPath: expectedRootPath } : input,
+      expectedRoot ? { ...input, rootPath: expectedRoot.canonicalPath } : input,
       previous,
       deps,
     );
@@ -319,11 +323,10 @@ async function manageRuntimeHostServiceLocked(
   if (input.action === 'uninstall') {
     const { config: before, invalid: invalidConfig } =
       await readServiceConfigForUninstall(configPath);
-    const serviceStateAlreadyRemoved = before === null && !invalidConfig;
-    const expectedRootPath =
-      serviceStateAlreadyRemoved && input.expectedTarget
+    const retainedStateRoot =
+      before === null && !invalidConfig && input.expectedTarget
         ? input.expectedTarget.rootPath
-        : await resolveExpectedServiceRoot(before, input);
+        : (await resolveExpectedServiceRoot(before, input))?.canonicalPath;
     const managedDeploymentRoot =
       before?.managedDeploymentRoot ??
       resolveRuntimeHostManagedDeploymentForCli(serviceId, input.cliPath);
@@ -347,7 +350,7 @@ async function manageRuntimeHostServiceLocked(
         `Runtime Host service still has managed state: ${service.state}`,
       );
     }
-    return result(input.action, service, before?.rootPath ?? expectedRootPath);
+    return result(input.action, service, before?.rootPath ?? retainedStateRoot);
   }
 
   if (input.action === 'logs') {
@@ -364,8 +367,8 @@ async function manageRuntimeHostServiceLocked(
       );
     }
     const service = await readServiceStatus(configPath, backend);
-    const rootPath = await resolveExpectedServiceRoot(service.config, input);
-    if (!service.installed || !service.config || !rootPath) {
+    const root = await resolveExpectedServiceRoot(service.config, input);
+    if (!service.installed || !service.config || !root) {
       throw new RuntimeHostServiceManagerError(
         'not_installed',
         'Runtime Host service is not installed',
@@ -373,33 +376,38 @@ async function manageRuntimeHostServiceLocked(
     }
     let prepared: { readonly hostEpoch: string; readonly pid: number } | undefined;
     if (service.active) {
+      if (service.pid === null) {
+        throw new RuntimeHostServiceManagerError(
+          'retirement_failed',
+          'Managed Runtime Host service did not report its process identity',
+        );
+      }
       const retirement = await deps.prepareRetirement(
         service.config,
+        service.pid,
         input.allowInterruptActiveTasks ?? false,
       );
       if (retirement.kind === 'active_tasks') {
         return { schemaVersion: 1, action: input.action, service, retirement };
       }
       prepared = retirement;
-      await backend.stop();
     }
+    await backend.stop();
     const stopped = await readServiceStatus(configPath, backend);
-    if (stopped.active) {
+    if (stopped.active || stopped.state !== 'stopped' || stopped.pid !== null) {
       throw new RuntimeHostServiceManagerError(
         'retirement_failed',
-        'Runtime Host service remained active after retirement',
+        'Runtime Host service did not reach a stable stopped state after retirement',
       );
     }
-    await deps.verifyRootReleased(rootPath, input.expectedTarget.rootId);
+    await verifyRuntimeHostRootReleased(root);
     return {
       schemaVersion: 1,
       action: input.action,
       service: stopped,
-      retirement: {
-        kind: 'retired',
-        hostEpoch: prepared?.hostEpoch ?? null,
-        pid: prepared?.pid ?? null,
-      },
+      retirement: prepared
+        ? { kind: 'retired', hostEpoch: prepared.hostEpoch, pid: prepared.pid }
+        : { kind: 'stopped' },
     };
   }
   const config = await readServiceConfig(configPath);
@@ -437,7 +445,7 @@ function assertExpectedServiceIdentity(
 async function resolveExpectedServiceRoot(
   config: RuntimeHostManagedServiceConfig | null,
   input: Pick<RuntimeHostManagedServiceInput, 'expectedTarget'>,
-): Promise<string | undefined> {
+): Promise<StorageRootCapability<'interactive'> | undefined> {
   if (!input.expectedTarget) return undefined;
   try {
     const root = await resolveExistingStorageRoot({
@@ -448,7 +456,7 @@ async function resolveExpectedServiceRoot(
     if (config && resolve(config.rootPath) !== root.canonicalPath) {
       throw new Error('The service config points to a different State Root path');
     }
-    return root.canonicalPath;
+    return root;
   } catch (error) {
     throw new RuntimeHostServiceManagerError(
       'target_mismatch',
@@ -840,9 +848,10 @@ async function waitForManagedRuntimeHostReady(
 
 async function prepareRuntimeHostRetirement(
   config: RuntimeHostManagedServiceConfig,
+  expectedPid: number,
   allowInterruptActiveTasks: boolean,
 ): Promise<
-  | { readonly kind: 'active_tasks'; readonly blockers: RuntimeHostRetirementBlockers }
+  | { readonly kind: 'active_tasks' }
   | { readonly kind: 'prepared'; readonly hostEpoch: string; readonly pid: number }
 > {
   const connected = await connectExistingRuntimeHost({
@@ -864,18 +873,24 @@ async function prepareRuntimeHostRetirement(
   const hostEpoch = connected.connection.hostEpoch;
   try {
     const diagnostics = await connected.connection.queryHostDiagnostics();
+    if (diagnostics.pid !== expectedPid) {
+      throw new RuntimeHostServiceManagerError(
+        'retirement_failed',
+        'The State Root is owned by a different Runtime Host process',
+      );
+    }
     const prepared = await connected.connection.request('host.upgrade.prepare', {
       expectedHostEpoch: hostEpoch,
       allowInterruptActiveTasks,
     });
-    if (prepared.kind === 'prepared') return { ...prepared, hostEpoch };
-    return {
-      kind: 'active_tasks',
-      blockers: {
-        activeOperations: Math.max(0, diagnostics.activeOperations - 1),
-        residencies: diagnostics.residencies.filter(({ label }) => label !== 'process-retention'),
-      },
-    };
+    if (prepared.kind === 'active_tasks') return prepared;
+    if (prepared.pid !== expectedPid) {
+      throw new RuntimeHostServiceManagerError(
+        'retirement_failed',
+        'Runtime Host process identity changed while preparing retirement',
+      );
+    }
+    return { ...prepared, hostEpoch };
   } catch (error) {
     throw new RuntimeHostServiceManagerError(
       'retirement_failed',
@@ -888,16 +903,10 @@ async function prepareRuntimeHostRetirement(
 }
 
 async function verifyRuntimeHostRootReleased(
-  rootPath: string,
-  expectedRootId: string,
+  root: StorageRootCapability<'interactive'>,
 ): Promise<void> {
   try {
-    const capability = await resolveExistingStorageRoot({
-      path: rootPath,
-      kind: 'interactive',
-      expectedRootId,
-    });
-    const owner = await tryAcquireInteractiveRootOwner(capability);
+    const owner = await tryAcquireInteractiveRootOwner(root);
     if (!owner) {
       throw new Error('The State Root writer is still held');
     }
@@ -968,7 +977,7 @@ async function allocateLoopbackPort(): Promise<number> {
 }
 
 function result(
-  action: RuntimeHostManagedServiceAction,
+  action: Exclude<RuntimeHostManagedServiceAction, 'retire'>,
   service: RuntimeHostManagedServiceStatus,
   retainedStateRoot?: string,
   logs?: string,

--- a/packages/cli/src/runtime-host-systemd-service.ts
+++ b/packages/cli/src/runtime-host-systemd-service.ts
@@ -23,6 +23,7 @@ import { access, readFile, realpath, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { resolveXdgConfigHome } from '@maka/storage';
+import { RUNTIME_HOST_RETIREMENT_EXIT_CODE } from '@maka/runtime-host/server';
 import {
   removeRuntimeHostServiceFile,
   RuntimeHostServiceManagerError,
@@ -213,6 +214,8 @@ export function renderSystemdUnit(config: RuntimeHostManagedServiceConfig): stri
     '[Service]',
     'Type=simple',
     `ExecStart=${args.map(quoteSystemdArgument).join(' ')}`,
+    `SuccessExitStatus=${String(RUNTIME_HOST_RETIREMENT_EXIT_CODE)}`,
+    `RestartPreventExitStatus=${String(RUNTIME_HOST_RETIREMENT_EXIT_CODE)}`,
     // A clean idle exit must not silently remove a configured remote Host.
     'Restart=always',
     'RestartSec=2s',

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -731,14 +731,6 @@ describe('non-serving Runtime Host kernel', () => {
       assert.equal(connected.kind, 'connected');
       if (connected.kind !== 'connected') return;
       assert.equal(connected.registration.lifecycleMode, 'service');
-      await assert.rejects(
-        connected.connection.request('host.upgrade.prepare', {
-          expectedHostEpoch: connected.connection.hostEpoch,
-          allowInterruptActiveTasks: false,
-        }),
-        (error: unknown) =>
-          error instanceof RuntimeHostOperationError && error.code === 'operation_unavailable',
-      );
       await connected.connection.close();
 
       const incompatible = await connectOrSpawnRuntimeHost({
@@ -1018,6 +1010,34 @@ describe('non-serving Runtime Host kernel', () => {
         { kind: 'prepared', pid: process.pid },
       );
       activity?.release();
+      await host.closed;
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successor);
+      await successor?.close();
+    });
+  });
+
+  test('local owner can prepare a managed service Host for retirement', async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      const host = await RuntimeHostKernel.start({
+        owner,
+        lifecycleMode: 'service',
+        composition: KERNEL_COMPOSITION,
+      });
+      const connected = await retryConnect(paths, CURRENT_PROTOCOL);
+      assert.equal(connected.kind, 'connected');
+      if (connected.kind !== 'connected') return;
+
+      assert.deepEqual(
+        await connected.connection.request('host.upgrade.prepare', {
+          expectedHostEpoch: host.hostEpoch,
+          allowInterruptActiveTasks: false,
+        }),
+        { kind: 'prepared', pid: process.pid },
+      );
       await host.closed;
       const successor = await tryAcquireInteractiveRootOwner(capability);
       assert.ok(successor);

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -1039,6 +1039,7 @@ describe('non-serving Runtime Host kernel', () => {
         { kind: 'prepared', pid: process.pid },
       );
       await host.closed;
+      assert.equal(host.shutdownReason, 'retirement');
       const successor = await tryAcquireInteractiveRootOwner(capability);
       assert.ok(successor);
       await successor?.close();

--- a/packages/runtime-host/src/operator/service-management-frame.ts
+++ b/packages/runtime-host/src/operator/service-management-frame.ts
@@ -37,6 +37,7 @@ const SERVICE_ACTIONS = [
   'start',
   'stop',
   'restart',
+  'retire',
   'logs',
   'uninstall',
 ] as const;
@@ -50,6 +51,38 @@ const boundedNonEmptyString = (maxBytes: number) =>
     .string()
     .min(1)
     .refine((value) => Buffer.byteLength(value, 'utf8') <= maxBytes);
+
+const RETIREMENT_BLOCKERS_SCHEMA = z
+  .object({
+    activeOperations: z.number().int().nonnegative(),
+    residencies: z
+      .array(
+        z
+          .object({
+            label: boundedNonEmptyString(FIELD_MAX_BYTES),
+            count: z.number().int().positive(),
+          })
+          .strict(),
+      )
+      .max(128),
+  })
+  .strict();
+
+const RETIREMENT_RESULT_SCHEMA = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('active_tasks'),
+      blockers: RETIREMENT_BLOCKERS_SCHEMA,
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('retired'),
+      hostEpoch: boundedNonEmptyString(FIELD_MAX_BYTES).nullable(),
+      pid: z.number().int().positive().nullable(),
+    })
+    .strict(),
+]);
 
 const SERVICE_SUMMARY_SCHEMA = z
   .object({
@@ -82,6 +115,7 @@ const SERVICE_MANAGEMENT_FRAME_SCHEMA = z.discriminatedUnion('kind', [
       action: z.enum(SERVICE_ACTIONS),
       service: SERVICE_SUMMARY_SCHEMA,
       operatorCapabilities: z.array(z.enum(OPERATOR_CAPABILITIES)).max(16).optional(),
+      retirement: RETIREMENT_RESULT_SCHEMA.optional(),
       retainedStateRoot: boundedString(PATH_MAX_BYTES).optional(),
       logs: boundedString(RUNTIME_HOST_SERVICE_LOG_MAX_BYTES).optional(),
     })

--- a/packages/runtime-host/src/operator/service-management-frame.ts
+++ b/packages/runtime-host/src/operator/service-management-frame.ts
@@ -41,6 +41,15 @@ const SERVICE_ACTIONS = [
   'logs',
   'uninstall',
 ] as const;
+const NON_RETIRE_SERVICE_ACTIONS = [
+  'install',
+  'status',
+  'start',
+  'stop',
+  'restart',
+  'logs',
+  'uninstall',
+] as const;
 const SERVICE_STATES = ['not_installed', 'stopped', 'starting', 'running', 'failed'] as const;
 const OPERATOR_CAPABILITIES = [RUNTIME_HOST_OPERATOR_ACCESS_MANAGEMENT_CAPABILITY] as const;
 
@@ -52,36 +61,16 @@ const boundedNonEmptyString = (maxBytes: number) =>
     .min(1)
     .refine((value) => Buffer.byteLength(value, 'utf8') <= maxBytes);
 
-const RETIREMENT_BLOCKERS_SCHEMA = z
-  .object({
-    activeOperations: z.number().int().nonnegative(),
-    residencies: z
-      .array(
-        z
-          .object({
-            label: boundedNonEmptyString(FIELD_MAX_BYTES),
-            count: z.number().int().positive(),
-          })
-          .strict(),
-      )
-      .max(128),
-  })
-  .strict();
-
 const RETIREMENT_RESULT_SCHEMA = z.discriminatedUnion('kind', [
-  z
-    .object({
-      kind: z.literal('active_tasks'),
-      blockers: RETIREMENT_BLOCKERS_SCHEMA,
-    })
-    .strict(),
+  z.object({ kind: z.literal('active_tasks') }).strict(),
   z
     .object({
       kind: z.literal('retired'),
-      hostEpoch: boundedNonEmptyString(FIELD_MAX_BYTES).nullable(),
-      pid: z.number().int().positive().nullable(),
+      hostEpoch: boundedNonEmptyString(FIELD_MAX_BYTES),
+      pid: z.number().int().positive(),
     })
     .strict(),
+  z.object({ kind: z.literal('stopped') }).strict(),
 ]);
 
 const SERVICE_SUMMARY_SCHEMA = z
@@ -107,17 +96,27 @@ const SERVICE_SUMMARY_SCHEMA = z
   })
   .strict();
 
-const SERVICE_MANAGEMENT_FRAME_SCHEMA = z.discriminatedUnion('kind', [
+const SERVICE_RESULT_COMMON = {
+  schemaVersion: z.literal(1),
+  kind: z.literal('result'),
+  service: SERVICE_SUMMARY_SCHEMA,
+  operatorCapabilities: z.array(z.enum(OPERATOR_CAPABILITIES)).max(16).optional(),
+  retainedStateRoot: boundedString(PATH_MAX_BYTES).optional(),
+  logs: boundedString(RUNTIME_HOST_SERVICE_LOG_MAX_BYTES).optional(),
+} as const;
+
+const SERVICE_MANAGEMENT_FRAME_SCHEMA = z.union([
   z
     .object({
-      schemaVersion: z.literal(1),
-      kind: z.literal('result'),
-      action: z.enum(SERVICE_ACTIONS),
-      service: SERVICE_SUMMARY_SCHEMA,
-      operatorCapabilities: z.array(z.enum(OPERATOR_CAPABILITIES)).max(16).optional(),
-      retirement: RETIREMENT_RESULT_SCHEMA.optional(),
-      retainedStateRoot: boundedString(PATH_MAX_BYTES).optional(),
-      logs: boundedString(RUNTIME_HOST_SERVICE_LOG_MAX_BYTES).optional(),
+      ...SERVICE_RESULT_COMMON,
+      action: z.literal('retire'),
+      retirement: RETIREMENT_RESULT_SCHEMA,
+    })
+    .strict(),
+  z
+    .object({
+      ...SERVICE_RESULT_COMMON,
+      action: z.enum(NON_RETIRE_SERVICE_ACTIONS),
     })
     .strict(),
   z

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -623,15 +623,6 @@ export class RuntimeHostKernel {
           },
         }),
         'host.upgrade.prepare': async (input) => {
-          if (this.#lifecycle.kind !== 'ephemeral') {
-            return {
-              ok: false,
-              error: {
-                code: 'operation_unavailable',
-                message: 'Runtime Host service lifecycle cannot be replaced by a Client',
-              },
-            };
-          }
           if (input.expectedHostEpoch !== this.hostEpoch) {
             return {
               ok: false,

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -199,6 +199,7 @@ export class RuntimeHostKernel {
   #initialConnectionDeadline: NodeJS.Timeout | undefined;
   #initialConnectionDeadlineDeferrals = 0;
   #shutdownRequested = false;
+  #shutdownReason: 'retirement' | undefined;
   #shutdownTask: Promise<void> | undefined;
   #shutdownDeadlineTimer: NodeJS.Timeout | undefined;
   #terminationRequired: RuntimeHostProcessTerminationRequiredError | undefined;
@@ -263,6 +264,10 @@ export class RuntimeHostKernel {
 
   get state(): HostLifecycleState {
     return this.#state;
+  }
+
+  get shutdownReason(): 'retirement' | undefined {
+    return this.#shutdownReason;
   }
 
   get endpoint(): string {
@@ -635,6 +640,7 @@ export class RuntimeHostKernel {
           if (!input.allowInterruptActiveTasks && this.#hasUpgradeBlockingActivity()) {
             return { ok: true, result: { kind: 'active_tasks' } };
           }
+          this.#shutdownReason = 'retirement';
           this.#requestDrain();
           return { ok: true, result: { kind: 'prepared', pid: process.pid } };
         },

--- a/packages/runtime-host/src/server/index.ts
+++ b/packages/runtime-host/src/server/index.ts
@@ -24,7 +24,10 @@ export {
 export { defineInteractiveRuntimeHostComposition } from './host-composition.js';
 export { createUnavailableDomainOperationHandlers } from './operation-dispatcher.js';
 export { startExecutionRuntimeHostService } from './execution-service.js';
-export { runRuntimeHostProcessLifecycle } from './process-lifecycle.js';
+export {
+  RUNTIME_HOST_RETIREMENT_EXIT_CODE,
+  runRuntimeHostProcessLifecycle,
+} from './process-lifecycle.js';
 export { installRuntimeHostLogCapture } from '../process-diagnostics.js';
 export {
   readRuntimeHostAccessCredentialMetadata,

--- a/packages/runtime-host/src/server/process-lifecycle.ts
+++ b/packages/runtime-host/src/server/process-lifecycle.ts
@@ -22,13 +22,16 @@ import {
   type RuntimeHostKernel,
 } from './host-kernel.js';
 
+export const RUNTIME_HOST_RETIREMENT_EXIT_CODE = 3;
+
 export interface RuntimeHostProcessLifecycleOptions {
   closeOnDisconnect?: boolean;
   onReady?: () => void;
 }
 
 export async function runRuntimeHostProcessLifecycle(
-  host: Pick<RuntimeHostKernel, 'close' | 'closed'>,
+  host: Pick<RuntimeHostKernel, 'close' | 'closed'> &
+    Partial<Pick<RuntimeHostKernel, 'shutdownReason'>>,
   options: RuntimeHostProcessLifecycleOptions = {},
 ): Promise<void> {
   let closing = false;
@@ -45,7 +48,9 @@ export async function runRuntimeHostProcessLifecycle(
     options.onReady?.();
     await host.closed;
   } catch (error) {
-    if (error instanceof RuntimeHostProcessTerminationRequiredError) process.exit(1);
+    if (error instanceof RuntimeHostProcessTerminationRequiredError) {
+      process.exit(host.shutdownReason === 'retirement' ? RUNTIME_HOST_RETIREMENT_EXIT_CODE : 1);
+    }
     throw error;
   } finally {
     process.off('SIGINT', close);


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Adds the local-operator retirement boundary required before a managed Runtime Host service can be replaced. The CLI now binds the exact live Host to the managed service process, reports when active work blocks retirement unless interruption was explicitly authorized, stops every non-stable service state, prevents intentional retirement from being restarted by the service manager, and verifies that the State Root writer was released. Standalone service mutations are serialized with setup and deployment lifecycle operations.

This reuses the existing exact-Epoch Host prepare contract. Package staging, version switching, replacement startup, and update policy remain outside Runtime Host authority.

Refs #3231
Refs #3228

## Verification

- `npm --workspace @maka/runtime-host test` — 1,086 tests passed
- `npm --workspace maka-agent test` — 393 tests passed
- Desktop Runtime Host management tests — 4 tests passed
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- Disposable Linux systemd user service: install, target-mismatch rejection, retire, idempotent retry, restart, status, uninstall, and cleanup all passed

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex contributed substantively to the implementation and tests under the contributor's direction. The human contributor owns review and submission.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 概要

增加 managed Runtime Host service 在替换前所需的 local-operator 退场边界。CLI 现在会将精确的 live Host 与 managed service 进程绑定；若未明确授权中断，则在存在 active work 时阻止退场；停止所有非稳定状态的 service，阻止 service manager 重启主动退场的进程，并验证 State Root writer 已释放。独立执行的 service mutation 也会与 setup 和 deployment lifecycle 操作串行化。

该实现复用现有的 exact-Epoch Host prepare contract。Package staging、版本切换、replacement 启动和更新策略仍不属于 Runtime Host authority。

关联 #3231
关联 #3228

## 验证

- `npm --workspace @maka/runtime-host test` — 1,086 项测试通过
- `npm --workspace maka-agent test` — 393 项测试通过
- Desktop Runtime Host management — 4 项测试通过
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- 一次性 Linux systemd user service：install、target mismatch 拒绝、retire、幂等重试、restart、status、uninstall 与清理均通过

## AI 使用

- [ ] 无生成式工具实质参与
- [x] 生成式工具有实质参与

工具与范围：OpenAI Codex 在贡献者指导下实质参与实现与测试。人工贡献者负责审查与提交。

## 检查清单

- [x] 测试覆盖该变更，且缺少该变更时会失败
- [x] lint、format、typecheck 与受影响测试套件均已在本地通过

本 PR 是否改变行为？

- [x] 是 — 已在概要中说明
- [ ] 否

</details>

