### PR TITLE
fix(desktop): center compact appearance choices

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -19,6 +19,23 @@
 
 import { test, expect, COMPOSER_INPUT } from './fixtures';
 
+async function choiceContentGeometry(card: import('@playwright/test').Locator) {
+  return card.evaluate((element) => {
+    const content = Array.from(element.children).find((child) => child.tagName !== 'INPUT');
+    if (!(content instanceof HTMLElement)) {
+      throw new Error('SelectableCard content is missing');
+    }
+    const cardRect = element.getBoundingClientRect();
+    const contentRect = content.getBoundingClientRect();
+    return {
+      cardHeight: cardRect.height,
+      contentHeight: contentRect.height,
+      topGap: contentRect.top - cardRect.top,
+      bottomGap: cardRect.bottom - contentRect.bottom,
+    };
+  });
+}
+
 test('opening settings commits an active titlebar rename', async ({ window: page }) => {
   const composer = page.locator(COMPOSER_INPUT);
   await composer.fill('create a session for settings rename');
@@ -103,4 +120,24 @@ test('wide settings gutters scroll the whole main pane', async ({ window: page }
   await page.mouse.wheel(0, 600);
   await expect.poll(() => pane.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
   await expect(content).toBeVisible();
+});
+
+test('appearance choice content stays vertically centered in stretched grid rows', async ({ window: page }) => {
+  await page.evaluate(async () => {
+    await window.maka.settings.update({ personalization: { uiLocale: 'en' } });
+  });
+  await page.reload();
+  await page.waitForSelector(COMPOSER_INPUT);
+  await page.setViewportSize({ width: 1650, height: 992 });
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await page.getByRole('button', { name: 'Appearance', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'App icon' })).toBeVisible();
+
+  for (const name of ['Azure', 'Classic']) {
+    const card = page.getByRole('checkbox', { name, exact: true }).locator('..');
+    await expect(card).toBeVisible();
+    const geometry = await choiceContentGeometry(card);
+    expect(geometry.cardHeight).toBeGreaterThan(geometry.contentHeight);
+    expect(Math.abs(geometry.topGap - geometry.bottomGap)).toBeLessThanOrEqual(1);
+  }
 });

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -373,7 +373,7 @@ export function AppearanceSettingsPage(props: {
                   onChange={() => void setPalette(palette)}
                   padding={2}
                 >
-                  <HStack gap={2} align="center">
+                  <HStack gap={2} align="center" height="100%">
                     <span
                       className={`settingsPaletteSwatch settingsPaletteSwatch-${palette}`}
                       aria-hidden="true"
@@ -429,7 +429,7 @@ export function AppearanceSettingsPage(props: {
                       onChange={() => void setAppIcon(option.id)}
                       padding={2}
                     >
-                      <HStack gap={2} align="center">
+                      <HStack gap={2} align="center" height="100%">
                         {/* Decorative: the tile's own label already names the icon. */}
                         <img className="settingsAppIconPreview" src={option.dataUrl} alt="" width={48} height={48} />
                         <VStack gap={0.5}>


### PR DESCRIPTION
## Summary

- vertically center compact palette and app-icon choices when their grid row stretches to fit wrapped content
- keep media-led theme cards top-aligned and leave the shared SelectableCard primitive unchanged
- add geometry-based Electron coverage for the palette and app-icon regressions

## Root cause

Astryx Grid stretches cards to the tallest item in each row, while the compact choice HStack kept its natural height. Shorter content therefore remained pinned to the card padding-top instead of sharing the extra vertical space.

## Before / after

| Before | After |
| --- | --- |
| ![Before: compact appearance choices align to the top of stretched cards](https://raw.githubusercontent.com/ARE404/maka-agent/codex/pr-assets-3564/pr-assets/3564/before.png) | ![After: compact appearance choices are vertically centered](https://raw.githubusercontent.com/ARE404/maka-agent/codex/pr-assets-3564/pr-assets/3564/after.png) |

## Testing

- `npm run build:renderer` (desktop workspace)
- `npm run typecheck`
- `npx playwright test e2e/settings.spec.ts --config e2e/playwright.config.ts --workers=1` (4 passed)
- spacing detector scan (clean)