### PR TITLE
fix(storage): clear obsolete onboarding intent

### DIFF
--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -3372,6 +3372,16 @@ describe('runtime policy stores', () => {
       } finally {
         await successor.close();
       }
+
+      const reopened = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(reopened);
+      if (!reopened) return;
+      try {
+        await openInteractiveRuntimePolicyStoresForWrite(reopened.lease);
+        assert.equal(existsSync(join(root, 'runtime-policy-onboarding.json')), false);
+      } finally {
+        await reopened.close();
+      }
     });
   });
 

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -3331,6 +3331,50 @@ describe('runtime policy stores', () => {
     });
   });
 
+  test('clears a stale onboarding intent when its connection id conflicts with the catalog', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      try {
+        const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+        const connection = await createConnection(
+          stores,
+          0,
+          connectionDraft('openai', 'openai', 'Stale onboarding'),
+        );
+        await writeFile(
+          join(root, 'runtime-policy-onboarding.json'),
+          `${JSON.stringify({
+            schemaVersion: 1,
+            connectionId: '11111111-1111-4111-8111-111111111111',
+            providerType: connection.providerType,
+            suppliedSecret: null,
+            enabledModelIds: connection.enabledModelIds,
+            discovery: {
+              models: [{ id: 'gpt-5' }],
+              source: 'fetched',
+              fetchedAt: 1_800_000_000_000,
+            },
+            invalidateLastTest: false,
+          })}\n`,
+        );
+      } finally {
+        await owner.close();
+      }
+
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successor);
+      if (!successor) return;
+      try {
+        await openInteractiveRuntimePolicyStoresForWrite(successor.lease);
+        assert.equal(existsSync(join(root, 'runtime-policy-onboarding.json')), false);
+      } finally {
+        await successor.close();
+      }
+    });
+  });
+
   test('interactive OAuth login commits only against its frozen connection and credential basis', async () => {
     await withInteractiveOwner(async ({ root, stores }) => {
       const claude = await createConnection(

--- a/packages/storage/src/runtime-policy/coordinator.ts
+++ b/packages/storage/src/runtime-policy/coordinator.ts
@@ -1326,6 +1326,11 @@ export class RuntimePolicyCoordinator {
       await clearConnectionOnboardingIntent(root);
       this.onboardingRecoveryRequired = false;
     } catch (error) {
+      if (isObsoleteConnectionOnboardingIntent(error)) {
+        await clearConnectionOnboardingIntent(root);
+        this.onboardingRecoveryRequired = false;
+        return;
+      }
       if (isCommitOutcomeUnknown(error)) throw error;
       throw commitOutcomeUnknown('Connection onboarding recovery did not converge', error);
     }
@@ -1389,6 +1394,14 @@ export class RuntimePolicyCoordinator {
 
 function isCommitOutcomeUnknown(error: unknown): error is RuntimePolicyStoreError {
   return error instanceof RuntimePolicyStoreError && error.code === 'commit_outcome_unknown';
+}
+
+function isObsoleteConnectionOnboardingIntent(error: unknown): boolean {
+  return (
+    error instanceof RuntimePolicyStoreError &&
+    error.code === 'invalid_document' &&
+    error.message === 'Onboarding intent conflicts with the connection id'
+  );
 }
 
 function commonSemanticConnectionBasis(


### PR DESCRIPTION
## Issue
Fixes #3566.

## Background
A stale connection-onboarding journal can become permanently unreplayable when the catalog contains the same provider slug with a different connection ID. Every subsequent interactive runtime-policy store open then fails.

## Changes
- Treat the exact connection-id conflict as an obsolete onboarding intent.
- Clear that intent and allow the store to open.
- Preserve fail-closed recovery for all other errors.
- Add a regression test covering reopen success and journal cleanup.

## Compatibility
Only stale intents with the explicit identity conflict are discarded. I/O failures, malformed journals, vault failures, and other recovery errors retain their existing fail-closed behavior.

## Verification
- `npm --workspace @maka/core run build` — passed
- `npm --workspace @maka/storage run build` — passed
- `node --test packages/storage/dist/__tests__/runtime-policy-stores.test.js` — 47 passed, 6 skipped
- `npx biome check packages/storage/src/runtime-policy/coordinator.ts packages/storage/src/__tests__/runtime-policy-stores.test.ts` — passed

## Notes
The skipped tests require POSIX permissions or symlink support unavailable in the Windows environment. Full repository build/lint were not run because this change is scoped to the storage workspace and its focused checks were sufficient for the affected path.

Generated-by: Codex