### PR TITLE
fix(runtime): collapse duplicate workspace instruction files in one directory

### DIFF
--- a/packages/runtime/src/__tests__/workspace-instructions.test.ts
+++ b/packages/runtime/src/__tests__/workspace-instructions.test.ts
@@ -124,7 +124,79 @@ describe('workspace instructions prompt fragment', () => {
       assert.doesNotMatch(prompt, /PROJECT_SHOULD_BE_SQUEEZED/);
     });
   });
+
+  it('collapses a CLAUDE.md symlinked to AGENTS.md into one block', async () => {
+    // Sharing one instruction file across agent CLIs by symlinking the names
+    // each of them reads is the documented way to do it, so the same bytes
+    // arriving twice must not be injected twice.
+    await withWorkspaceAndHome(async ({ workspaceRoot, homeDir }) => {
+      await writeFile(join(workspaceRoot, 'AGENTS.md'), 'SHARED_RULE\n', 'utf8');
+      await symlink(join(workspaceRoot, 'AGENTS.md'), join(workspaceRoot, 'CLAUDE.md'));
+
+      const prompt = await buildWorkspaceInstructionsPromptFragment(workspaceRoot, { homeDir });
+
+      assert.ok(prompt);
+      assert.equal(countBlocks(prompt), 1);
+      assert.equal(occurrences(prompt, 'SHARED_RULE'), 1);
+      assert.match(prompt, /file="AGENTS\.md"/);
+    });
+  });
+
+  it('collapses byte-identical instruction files that are not links', async () => {
+    // Copying rather than linking is the other common way to share one set of
+    // rules; it is the same redundancy and deserves the same treatment.
+    await withWorkspaceAndHome(async ({ workspaceRoot, homeDir }) => {
+      await writeFile(join(workspaceRoot, 'AGENTS.md'), 'COPIED_RULE\n', 'utf8');
+      await writeFile(join(workspaceRoot, 'CLAUDE.md'), 'COPIED_RULE\n', 'utf8');
+
+      const prompt = await buildWorkspaceInstructionsPromptFragment(workspaceRoot, { homeDir });
+
+      assert.ok(prompt);
+      assert.equal(countBlocks(prompt), 1);
+      assert.equal(occurrences(prompt, 'COPIED_RULE'), 1);
+    });
+  });
+
+  it('keeps instruction files in one directory that genuinely differ', async () => {
+    await withWorkspaceAndHome(async ({ workspaceRoot, homeDir }) => {
+      await writeFile(join(workspaceRoot, 'AGENTS.md'), 'SHARED_RULE\n', 'utf8');
+      await writeFile(join(workspaceRoot, 'CLAUDE.md'), 'CLAUDE_ONLY_RULE\n', 'utf8');
+
+      const prompt = await buildWorkspaceInstructionsPromptFragment(workspaceRoot, { homeDir });
+
+      assert.ok(prompt);
+      assert.equal(countBlocks(prompt), 2);
+      assert.match(prompt, /SHARED_RULE/);
+      assert.match(prompt, /CLAUDE_ONLY_RULE/);
+    });
+  });
+
+  it('keeps identical instructions that live in different scopes', async () => {
+    // Global and project files are a deliberate layering. Identical bytes in
+    // both is a user saying the same thing at two scopes, not a duplicate.
+    await withWorkspaceAndHome(async ({ workspaceRoot, homeDir }) => {
+      const makaDir = join(homeDir, '.maka');
+      await mkdir(makaDir, { recursive: true });
+      await writeFile(join(makaDir, 'AGENTS.md'), 'SAME_TEXT\n', 'utf8');
+      await writeFile(join(workspaceRoot, 'AGENTS.md'), 'SAME_TEXT\n', 'utf8');
+
+      const prompt = await buildWorkspaceInstructionsPromptFragment(workspaceRoot, { homeDir });
+
+      assert.ok(prompt);
+      assert.equal(countBlocks(prompt), 2);
+      assert.match(prompt, /scope="global"/);
+      assert.match(prompt, /scope="project"/);
+    });
+  });
 });
+
+function countBlocks(prompt: string): number {
+  return occurrences(prompt, '<workspace-instructions ');
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
 
 async function withWorkspaceAndHome(
   fn: (dirs: { workspaceRoot: string; homeDir: string }) => Promise<void>,

--- a/packages/runtime/src/system-prompt/workspace-instructions.ts
+++ b/packages/runtime/src/system-prompt/workspace-instructions.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import { createHash } from 'node:crypto';
 import { readFile, realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -107,6 +108,16 @@ async function readWorkspaceInstructions(
   }
 
   const out: WorkspaceInstruction[] = [];
+  // Content already accepted from this directory. Sharing one instruction file
+  // across the names different agent CLIs read — Claude Code reads CLAUDE.md,
+  // Codex reads AGENTS.md, Gemini CLI reads GEMINI.md — is the documented way
+  // to do it, whether by symlink or by copy, so identical bytes arriving under
+  // two names here are redundancy rather than two instructions. Digesting the
+  // cleaned text catches both forms; `realpath` alone would miss the copy.
+  // Scoped to one directory on purpose: the same text at global and project
+  // scope is a user repeating themselves deliberately, and collapsing that
+  // would silently drop a layer.
+  const seenDigests = new Set<string>();
   for (const file of WORKSPACE_INSTRUCTION_FILES) {
     const candidate = join(root, file);
     let resolved: string;
@@ -120,6 +131,11 @@ async function readWorkspaceInstructions(
       const raw = await readFile(resolved, 'utf8');
       const cleaned = cleanPromptText(raw.trim());
       if (!cleaned) continue;
+      // Digest before truncation: two files that diverge only past the cap are
+      // still different instructions.
+      const digest = createHash('sha256').update(cleaned).digest('hex');
+      if (seenDigests.has(digest)) continue;
+      seenDigests.add(digest);
       const chars = Array.from(cleaned).length;
       out.push({
         file,


### PR DESCRIPTION
## Summary

`readWorkspaceInstructions` reads every candidate name in a directory and appends each result, so a repository that shares one instruction file across the names different agent CLIs read gets it injected twice. That sharing is the documented way to do it — Claude Code's docs recommend `ln -s AGENTS.md CLAUDE.md`, and `apache/airflow` and `deepseek-ai/deepseek-harness` both ship that link — and the duplicate then consumes most of the 14000-character workspace-instruction budget, squeezing out whatever genuinely different file sits beside it.

Deduplicate on the digest of the cleaned text, scoped to one directory. Digesting rather than comparing `realpath` catches a byte-identical copy as well as a link, which is the other common way people share these files. Directories stay independent, because the same text at global and project scope is a user repeating themselves on purpose and collapsing it would silently drop a layer. The digest is taken before truncation, so two files that diverge only past the per-file cap still count as different.

Fixes #3577

## Verification

Four new tests in `workspace-instructions.test.ts`: a symlinked `CLAUDE.md` collapses, a byte-identical copy collapses, files in one directory that genuinely differ are both kept, and identical text at global and project scope is kept at both scopes. The first two fail on `main` with `expected: 1, actual: 2`; the last two pass either way and are there so the fix cannot over-collapse.

End-to-end against a directory holding a real `AGENTS.md`, in both duplicate forms:

```
before   blocks = project/AGENTS.md, project/CLAUDE.md
after    blocks = project/AGENTS.md
```

Ran: `workspace-instructions` (9) and `ai-sdk-backend` (204) green; `biome check` on both changed files; `npm run check:asf-headers`.

`packages/runtime` typecheck reports one error in `responses-wire-contract.test.ts` about an `alibaba-cn` provider literal. Verified pre-existing — the same error appears on a clean `origin/main` build, and this change touches neither file.

Not run: the rest of the runtime suite, Desktop, Playwright.

## Notes

`@AGENTS.md` — the import form Claude Code's docs also suggest — is not addressed here. Maka does not expand imports, so a one-line `CLAUDE.md` containing `@AGENTS.md` is injected as that literal text. It is small and harmless rather than wasteful, but it is also an instruction that means nothing; worth a separate decision about whether to expand or ignore it.

For reference, the three strategies other agents use: read a single filename (Claude Code, Codex CLI, Gemini CLI), first-match-wins across a candidate list (opencode, Pi), or content deduplication (deepseek-harness). First-match-wins would be simpler here, but it discards a `CLAUDE.md` that genuinely differs from `AGENTS.md`, which is a supported thing to have.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Code — investigation, comparison of other agents' loaders, the tests, and the fix.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
