### PR TITLE
fix(runtime): avoid implicit computer-use images

### DIFF
--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -19,11 +19,12 @@
 
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { CuAction } from '@maka/core/computer-use';
+import { CU_TOOL_ACTION_TYPES, type CuAction } from '@maka/core/computer-use';
 import { zodSchema } from 'ai';
 import {
   adaptToCuAction,
   buildComputerUseTools,
+  COMPUTER_USE_MODEL_SCREENSHOT_POLICY,
   snapshotComputerParams,
   type CuDispatchBackend,
   type CuObservation,
@@ -2611,27 +2612,55 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
 
   test('keeps PiP-only screenshots out of semantic action model output', () => {
     const [tool] = buildComputerUseTools({ backend: fakeBackend() });
-    const output = {
+    const output = (includeScreenshotInModelOutput: boolean) => ({
       text: 'persisted result',
       modelText: 'fresh semantic observation',
       screenshot: { base64: 'AA==', mimeType: 'image/png' },
-    };
-    const project = (input: unknown) =>
+      includeScreenshotInModelOutput,
+    });
+    const project = (includeScreenshotInModelOutput: boolean) =>
       tool.toModelOutput?.({
+        toolCallId: 'tool-1',
+        input: {},
+        output: output(includeScreenshotInModelOutput),
+      }) as { value: Array<{ type: string }> };
+
+    assert.deepEqual(project(false).value, [{ type: 'text', text: 'fresh semantic observation' }]);
+    assert.equal(project(true).value[1]?.type, 'file');
+  });
+
+  test('classifies every canonical action for model-visible screenshots', () => {
+    assert.deepEqual(Object.keys(COMPUTER_USE_MODEL_SCREENSHOT_POLICY), [...CU_TOOL_ACTION_TYPES]);
+  });
+
+  test('binds model-visible screenshots to the immutable executed invocation', async () => {
+    const projectAfterMutation = async (
+      includeScreenshot: boolean,
+      mutatedIncludeScreenshot: boolean,
+    ) => {
+      const backend = fakeBackend() as CuDispatchBackend & {
+        observeApp: NonNullable<CuDispatchBackend['observeApp']>;
+      };
+      backend.observeApp = async () => observation();
+      const [tool] = buildComputerUseTools({ backend });
+      const input = {
+        action: 'observe' as const,
+        app: 'Fixture',
+        include_screenshot: includeScreenshot,
+      };
+      const output = await tool.impl(input, ctx());
+      input.include_screenshot = mutatedIncludeScreenshot;
+      return tool.toModelOutput?.({
         toolCallId: 'tool-1',
         input,
         output,
       }) as { value: Array<{ type: string }> };
+    };
 
-    assert.deepEqual(project({ action: 'element_sequence' }).value, [
-      { type: 'text', text: 'fresh semantic observation' },
-    ]);
-    assert.deepEqual(project({ action: 'observe', include_screenshot: false }).value, [
-      { type: 'text', text: 'fresh semantic observation' },
-    ]);
-    assert.equal(project({ action: 'observe', include_screenshot: true }).value[1]?.type, 'file');
-    assert.equal(project({ action: 'screenshot' }).value[1]?.type, 'file');
-    assert.equal(project({ action: 'left_click' }).value[1]?.type, 'file');
+    assert.equal((await projectAfterMutation(true, false)).value[1]?.type, 'file');
+    const nonVisual = await projectAfterMutation(false, true);
+    assert.equal(nonVisual.value.length, 1);
+    assert.equal(nonVisual.value[0]?.type, 'text');
   });
 
   test('S18: an already-aborted signal short-circuits before any dispatch', async () => {

--- a/packages/runtime/src/__tests__/computer-use-tools.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-tools.test.ts
@@ -2609,6 +2609,31 @@ describe('buildComputerUseTools — the `maka_computer` MakaTool', () => {
     assert.doesNotMatch(output.value[0]?.text ?? '', /super-secret-value/);
   });
 
+  test('keeps PiP-only screenshots out of semantic action model output', () => {
+    const [tool] = buildComputerUseTools({ backend: fakeBackend() });
+    const output = {
+      text: 'persisted result',
+      modelText: 'fresh semantic observation',
+      screenshot: { base64: 'AA==', mimeType: 'image/png' },
+    };
+    const project = (input: unknown) =>
+      tool.toModelOutput?.({
+        toolCallId: 'tool-1',
+        input,
+        output,
+      }) as { value: Array<{ type: string }> };
+
+    assert.deepEqual(project({ action: 'element_sequence' }).value, [
+      { type: 'text', text: 'fresh semantic observation' },
+    ]);
+    assert.deepEqual(project({ action: 'observe', include_screenshot: false }).value, [
+      { type: 'text', text: 'fresh semantic observation' },
+    ]);
+    assert.equal(project({ action: 'observe', include_screenshot: true }).value[1]?.type, 'file');
+    assert.equal(project({ action: 'screenshot' }).value[1]?.type, 'file');
+    assert.equal(project({ action: 'left_click' }).value[1]?.type, 'file');
+  });
+
   test('S18: an already-aborted signal short-circuits before any dispatch', async () => {
     const ac = new AbortController();
     ac.abort();

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -35,6 +35,7 @@ import {
   isCuObservingAction,
   type CuAction,
   type CuPoint,
+  type CuToolActionType,
   type ComputerUseErrorCode,
   type ComputerUseWindowIdentity,
 } from '@maka/core/computer-use';
@@ -340,31 +341,46 @@ interface ComputerToolResult {
   error?: ComputerUseErrorCode;
   failureClass?: 'ambiguous_target';
   screenshot?: { base64: string; mimeType: string };
+  includeScreenshotInModelOutput?: boolean;
 }
 
-const MODEL_SCREENSHOT_ACTIONS: ReadonlySet<string> = new Set([
-  'screenshot',
-  'zoom',
-  'mouse_move',
-  'left_click',
-  'right_click',
-  'middle_click',
-  'double_click',
-  'triple_click',
-  'left_mouse_down',
-  'left_mouse_up',
-  'left_click_drag',
-  'type',
-  'key',
-  'hold_key',
-  'scroll',
-]);
+export const COMPUTER_USE_MODEL_SCREENSHOT_POLICY = {
+  list_apps: 'never',
+  launch_app: 'never',
+  observe: 'explicit',
+  click_element: 'never',
+  set_value: 'never',
+  select_text: 'never',
+  secondary_action: 'never',
+  scroll_element: 'never',
+  window_action: 'never',
+  element_sequence: 'never',
+  press_key: 'never',
+  screenshot: 'always',
+  cursor_position: 'never',
+  mouse_move: 'always',
+  left_click: 'always',
+  right_click: 'always',
+  middle_click: 'always',
+  double_click: 'always',
+  triple_click: 'always',
+  left_mouse_down: 'always',
+  left_mouse_up: 'always',
+  left_click_drag: 'always',
+  type: 'always',
+  key: 'always',
+  hold_key: 'always',
+  scroll: 'always',
+  wait: 'never',
+  zoom: 'always',
+} as const satisfies Record<CuToolActionType, 'always' | 'explicit' | 'never'>;
 
-function shouldSendScreenshotToModel(input: unknown): boolean {
-  if (!input || typeof input !== 'object') return false;
-  const record = input as { action?: unknown; include_screenshot?: unknown };
-  if (record.action === 'observe') return record.include_screenshot === true;
-  return typeof record.action === 'string' && MODEL_SCREENSHOT_ACTIONS.has(record.action);
+function shouldSendScreenshotToModel(input: ComputerParams): boolean {
+  const policy = COMPUTER_USE_MODEL_SCREENSHOT_POLICY[input.action];
+  return (
+    policy === 'always' ||
+    (policy === 'explicit' && input.action === 'observe' && input.include_screenshot === true)
+  );
 }
 
 export interface ComputerUseToolSet extends Array<MakaTool> {
@@ -1010,6 +1026,7 @@ export function buildComputerUseTools(deps: {
   function deliveredWithoutFreshObservation(
     action: ComputerSummaryAction,
     result: CuRunResult,
+    includeScreenshotInModelOutput = false,
   ): ComputerToolResult {
     const evidence = summarizeEvidence(result.outcome.evidence);
     const hostEvidence = summarizeEvidence(result.outcome.evidence, 'host');
@@ -1034,6 +1051,7 @@ export function buildComputerUseTools(deps: {
               base64: screenshot.base64,
               mimeType: screenshot.mimeType,
             },
+            includeScreenshotInModelOutput,
           }
         : {}),
     };
@@ -1622,6 +1640,7 @@ export function buildComputerUseTools(deps: {
     ): Promise<ComputerToolResult> => {
       if (abortSignal.aborted) return { text: 'computer aborted before start' };
       const input = snapshotComputerParams(computerParams.parse(args));
+      const includeScreenshotInModelOutput = shouldSendScreenshotToModel(input);
       // Before anything is claimed against a frame or dispatched: an argument
       // holding one of this host's own withheld-value placeholders is a replay
       // of the record, not a value, and every path below would have typed it.
@@ -1630,7 +1649,7 @@ export function buildComputerUseTools(deps: {
       const invocationGeneration = presentationGenerations.get(sessionId) ?? 0;
       const releasePendingInvocation = trackPendingInvocation(sessionId, turnId);
       try {
-        return await withInvocationQueue(sessionId, abortSignal, async () => {
+        return await withInvocationQueue<ComputerToolResult>(sessionId, abortSignal, async () => {
           if ((presentationGenerations.get(sessionId) ?? 0) !== invocationGeneration) {
             return sessionFailure('user_stopped');
           }
@@ -2301,6 +2320,7 @@ export function buildComputerUseTools(deps: {
                   text: persistedObservationText(observation),
                   modelText: observationText({ ...observation, screenshot }),
                   screenshot: { base64: screenshot.base64, mimeType: screenshot.mimeType },
+                  includeScreenshotInModelOutput,
                 }
               : {
                   text: persistedObservationText(observation),
@@ -2366,6 +2386,7 @@ export function buildComputerUseTools(deps: {
                 base64: screenshotObservation.screenshot.base64,
                 mimeType: screenshotObservation.screenshot.mimeType,
               },
+              includeScreenshotInModelOutput,
             };
           }
           if (
@@ -2767,11 +2788,19 @@ export function buildComputerUseTools(deps: {
                   : undefined;
             } catch {
               presentation?.finish(result);
-              return deliveredWithoutFreshObservation(modelAction, result);
+              return deliveredWithoutFreshObservation(
+                modelAction,
+                result,
+                includeScreenshotInModelOutput,
+              );
             }
             if (actionLease && result.outcome.ok && !freshObservation) {
               presentation?.finish(result);
-              return deliveredWithoutFreshObservation(modelAction, result);
+              return deliveredWithoutFreshObservation(
+                modelAction,
+                result,
+                includeScreenshotInModelOutput,
+              );
             }
             presentation?.finish(withMirrorFrame(result, freshObservation));
             const modelRefresh = freshObservation
@@ -2798,6 +2827,7 @@ export function buildComputerUseTools(deps: {
                   ...(!result.outcome.ok ? { error: result.outcome.error } : {}),
                   ...(failureClass ? { failureClass } : {}),
                   screenshot: { base64: screenshot.base64, mimeType: screenshot.mimeType },
+                  includeScreenshotInModelOutput,
                 }
               : {
                   text,
@@ -2815,7 +2845,7 @@ export function buildComputerUseTools(deps: {
     // return a fresh accessibility observation, so their automatically captured
     // PiP frame stays local. Explicit visual requests and legacy coordinate
     // actions still receive the native image block.
-    toModelOutput: ({ input, output }) => {
+    toModelOutput: ({ output }) => {
       const o = (output ?? {}) as Partial<ComputerToolResult> & { error?: unknown };
       const text =
         typeof o.modelText === 'string'
@@ -2829,7 +2859,7 @@ export function buildComputerUseTools(deps: {
         type: 'content',
         value: [
           { type: 'text', text },
-          ...(o.screenshot && shouldSendScreenshotToModel(input)
+          ...(o.screenshot && o.includeScreenshotInModelOutput === true
             ? [
                 {
                   type: 'file' as const,

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -330,8 +330,9 @@ export const computerWireParams = z
  * Raw result of the `computer` tool. `text` is the S16-safe summary the runtime
  * records to session history (via coerceResultContent's text-only projection:
  * this object has no `kind`, so only `text` survives). `screenshot`, when
- * present, rides along ONLY to feed `toModelOutput` — it never enters `text`, so
- * the bounded frame base64 stays out of session history.
+ * present, feeds the local presentation layer and, only for explicitly visual
+ * actions, `toModelOutput`. It never enters `text`, so the bounded frame base64
+ * stays out of session history.
  */
 interface ComputerToolResult {
   text: string;
@@ -339,6 +340,31 @@ interface ComputerToolResult {
   error?: ComputerUseErrorCode;
   failureClass?: 'ambiguous_target';
   screenshot?: { base64: string; mimeType: string };
+}
+
+const MODEL_SCREENSHOT_ACTIONS: ReadonlySet<string> = new Set([
+  'screenshot',
+  'zoom',
+  'mouse_move',
+  'left_click',
+  'right_click',
+  'middle_click',
+  'double_click',
+  'triple_click',
+  'left_mouse_down',
+  'left_mouse_up',
+  'left_click_drag',
+  'type',
+  'key',
+  'hold_key',
+  'scroll',
+]);
+
+function shouldSendScreenshotToModel(input: unknown): boolean {
+  if (!input || typeof input !== 'object') return false;
+  const record = input as { action?: unknown; include_screenshot?: unknown };
+  if (record.action === 'observe') return record.include_screenshot === true;
+  return typeof record.action === 'string' && MODEL_SCREENSHOT_ACTIONS.has(record.action);
 }
 
 export interface ComputerUseToolSet extends Array<MakaTool> {
@@ -2711,11 +2737,11 @@ export function buildComputerUseTools(deps: {
                 state.reobserveRequired();
               }
             }
-            // Carry the screenshot base64 on the raw result (which becomes the ai-sdk
-            // tool `output`) so `toModelOutput` below can hand the vision model an image
-            // block. Kept OFF `text`: coerceResultContent projects this object to a
-            // text-only session-log entry (no `kind` ⇒ only `text` survives), so the
-            // bounded frame never bloats history.
+            // Carry the screenshot base64 on the raw result for the local mirror.
+            // `toModelOutput` below sends it to the provider only for actions that
+            // explicitly need pixels. Kept OFF `text`: coerceResultContent projects
+            // this object to a text-only session-log entry (no `kind` => only `text`
+            // survives), so the bounded frame never bloats durable history.
             let bindingResult: BindingFailureReason | undefined;
             if (boundAction) bindingResult = consumeBoundAction(record, boundAction);
             if (bindingResult && !hasUncertainDeliveredOutcome(result)) {
@@ -2785,11 +2811,11 @@ export function buildComputerUseTools(deps: {
         releasePendingInvocation();
       }
     },
-    // Map the raw result into model-visible content: the summary as text, plus the
-    // screenshot as a native file block when present. Robust to the runtime's synthetic
-    // failure return shape ({ error }) from permission/loop-gate blocks, which
-    // reaches here as `output` too.
-    toModelOutput: ({ output }) => {
+    // Map the raw result into model-visible content. Semantic actions already
+    // return a fresh accessibility observation, so their automatically captured
+    // PiP frame stays local. Explicit visual requests and legacy coordinate
+    // actions still receive the native image block.
+    toModelOutput: ({ input, output }) => {
       const o = (output ?? {}) as Partial<ComputerToolResult> & { error?: unknown };
       const text =
         typeof o.modelText === 'string'
@@ -2803,7 +2829,7 @@ export function buildComputerUseTools(deps: {
         type: 'content',
         value: [
           { type: 'text', text },
-          ...(o.screenshot
+          ...(o.screenshot && shouldSendScreenshotToModel(input)
             ? [
                 {
                   type: 'file' as const,


### PR DESCRIPTION
## Summary

- keep automatically captured Computer Use frames available to the local PiP without sending them to the model for semantic actions
- include model-visible image blocks only for explicit visual requests and legacy coordinate actions
- preserve fresh accessibility observations for semantic actions such as `element_sequence`
- bind the provider-image decision to the immutable invocation that actually executed
- classify every canonical Computer Use action through an exhaustive typed screenshot policy

## Root cause

Mutating Computer Use actions attach a final screenshot for the desktop PiP. `toModelOutput` previously projected every attached screenshot into the next provider request, so a semantic `element_sequence` result carried an unnecessary base64 PNG even though it already returned a fresh accessibility observation. The first revision also evaluated the image gate from settlement-time caller input and represented the action catalogue as an untyped parallel set. The current revision derives the decision from the frozen executed input and carries it on the result, while an exhaustive `Record<CuToolActionType, ...>` makes every action an explicit policy choice.

## Measured result

A real Calculator run using `element_sequence` completed successfully. The final provider request dropped from 156,262 bytes to 73,727 bytes, contained no base64 string over 10 KB, and reduced the post-action input-token increase from 1,575 to 1,056 tokens.

## Verification

- built `@maka/core`, `@maka/storage`, and `@maka/mcp` in dependency order
- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/computer-use-tools.test.js packages/runtime/dist/__tests__/computer-use-schema-parity.test.js` (89 passed)
- `npx biome check packages/runtime/src/computer-use-tools.ts packages/runtime/src/__tests__/computer-use-tools.test.ts`
- `git diff --check origin/main...HEAD`
- real Electron Computer Use run against Calculator with a 12-step semantic `element_sequence`

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex contributed implementation, tests, review follow-up, and verification. Both affected commits include `Generated-by: Codex` trailers.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
