### PR TITLE
test(windows): verify packaged sandbox client cancellation

### DIFF
--- a/scripts/verify-windows-sandbox-e2e.mjs
+++ b/scripts/verify-windows-sandbox-e2e.mjs
@@ -17,13 +17,17 @@
  * under the License.
  */
 
+import { execFile } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { basename, dirname, join, resolve } from 'node:path';
+import { promisify } from 'node:util';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const execFileAsync = promisify(execFile);
 
 function assertCondition(condition, message) {
   if (!condition) throw new Error(message);
@@ -154,6 +158,21 @@ export async function verifyWindowsSandboxWorkerE2E(appDirectoryPath) {
       'Sandboxed read did not return the written content.',
     );
 
+    console.log('[verify-windows-sandbox] cancelling an active packaged AppContainer worker');
+    await verifyPackagedClientCancellation({
+      FilesystemWorkerClient,
+      FilesystemWorkerClientError,
+      SandboxManager,
+      WindowsBrokerSandboxBackend,
+      createWindowsBrokerManifestWriter,
+      client,
+      launchSpec: launchSpec.spec,
+      sandboxExecutable,
+      workspace,
+      targetPath: insidePath,
+    });
+    console.log('[verify-windows-sandbox] packaged client cancellation and recovery verified');
+
     const sourceDirectory = join(workspace, 'src');
     await mkdir(sourceDirectory, { recursive: true });
     await writeFile(join(sourceDirectory, 'health.ts'), 'export const healthSignal = true;\n');
@@ -205,6 +224,213 @@ export async function verifyWindowsSandboxWorkerE2E(appDirectoryPath) {
       await rm(path, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
     }
   }
+}
+
+async function verifyPackagedClientCancellation({
+  FilesystemWorkerClient,
+  FilesystemWorkerClientError,
+  SandboxManager,
+  WindowsBrokerSandboxBackend,
+  createWindowsBrokerManifestWriter,
+  client,
+  launchSpec,
+  sandboxExecutable,
+  workspace,
+  targetPath,
+}) {
+  const requestId = `packaged-client-cancel-${process.pid}-${randomBytes(4).toString('hex')}`;
+  const launchRequestId = `${requestId}-launch`;
+  const sleepSeconds = 47;
+  assertCondition(
+    (await listCancellationProcesses(sandboxExecutable)).length === 0,
+    'Client-cancel evidence started with an existing sandbox process.',
+  );
+  const controller = new AbortController();
+  const cancelClient = new FilesystemWorkerClient({
+    sandboxManager: new SandboxManager([
+      new WindowsBrokerSandboxBackend({
+        clientPath: sandboxExecutable,
+        writeManifest: createWindowsBrokerManifestWriter(),
+        requestId: () => requestId,
+      }),
+    ]),
+    platform: 'win32',
+    newId: () => `${requestId}-operation`,
+    timeoutMs: 60_000,
+    getLaunchSpec: async () => ({
+      ok: true,
+      spec: {
+        ...launchSpec,
+        program: sandboxExecutable,
+        args: ['--stdio-probe', '--sleep', String(sleepSeconds)],
+      },
+    }),
+  });
+
+  let cancellationError;
+  let cancellationSettled = false;
+  const cancellation = cancelClient
+    .execute({
+      operation: { kind: 'read', path: targetPath },
+      cwd: workspace,
+      mode: 'ask',
+      abortSignal: controller.signal,
+    })
+    .then(
+      () => {
+        cancellationSettled = true;
+      },
+      (error) => {
+        cancellationError = error;
+        cancellationSettled = true;
+      },
+    );
+
+  let primaryError;
+  try {
+    await waitForObservation({
+      description: 'packaged client-cancel AppContainer child',
+      probe: (remainingMs) => listCancellationProcesses(sandboxExecutable, remainingMs),
+      accept: (processes) => processes.length >= 2,
+      settledEarly: () => cancellationSettled,
+    });
+
+    controller.abort();
+    await cancellation;
+    assertCondition(
+      cancellationError instanceof FilesystemWorkerClientError &&
+        cancellationError.reason === 'aborted' &&
+        cancellationError.stage === 'launch' &&
+        cancellationError.dispatched === true,
+      `Client cancellation did not report an unknown dispatched outcome: ${renderError(
+        cancellationError,
+      )}`,
+    );
+
+    await waitForObservation({
+      description: 'packaged client-cancel AppContainer child exit',
+      probe: (remainingMs) => listCancellationProcesses(sandboxExecutable, remainingMs),
+      accept: (processes) => processes.length === 0,
+    });
+
+    // The process runner terminates the one-shot broker. Its kill-on-close Job
+    // tears down the AppContainer child. The next ordinary launch owns any
+    // stale-ledger replay before it establishes its own grants; a future
+    // graceful-cancel path is also valid if it already cleaned the ledger.
+    await client.execute({
+      operation: { kind: 'read', path: targetPath },
+      cwd: workspace,
+      mode: 'ask',
+    });
+    assertCondition(
+      (await findRecoveryRecord(launchRequestId)) === undefined,
+      'Normal packaged launch did not remove the client-cancel recovery ledger.',
+    );
+  } catch (error) {
+    primaryError = error;
+  } finally {
+    controller.abort();
+    await cancellation;
+    if (primaryError) {
+      try {
+        await client.execute({
+          operation: { kind: 'read', path: targetPath },
+          cwd: workspace,
+          mode: 'ask',
+        });
+      } catch (cleanupError) {
+        throw new AggregateError(
+          [primaryError, cleanupError],
+          'Client-cancel evidence failed and its recovery launch also failed.',
+        );
+      }
+    }
+  }
+  if (primaryError) throw primaryError;
+}
+
+async function listCancellationProcesses(sandboxExecutable, timeoutMs = 10_000) {
+  const script = String.raw`
+$imageName = [IO.Path]::GetFileName($env:MAKA_CANCEL_SANDBOX)
+$matches = @(
+  Get-CimInstance Win32_Process | ForEach-Object {
+    if ($_.Name -eq $imageName) {
+      [PSCustomObject]@{
+        processId = $_.ProcessId
+        commandLine = [string]$_.CommandLine
+      }
+    }
+  }
+)
+@($matches) | ConvertTo-Json -Compress
+`;
+  const { stdout } = await execFileAsync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-Command', script],
+    {
+      env: {
+        ...process.env,
+        MAKA_CANCEL_SANDBOX: sandboxExecutable,
+      },
+      timeout: Math.min(timeoutMs, 10_000),
+      windowsHide: true,
+    },
+  );
+  if (!stdout.trim()) return [];
+  const parsed = JSON.parse(stdout);
+  return Array.isArray(parsed) ? parsed : [parsed];
+}
+
+async function findRecoveryRecord(requestId) {
+  const ledgerRoot = join(tmpdir(), 'maka-sandbox-acl-ledgers');
+  const entries = await readdir(ledgerRoot, { withFileTypes: true }).catch((error) => {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  });
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const path = join(ledgerRoot, entry.name);
+    const contents = await readFile(path, 'utf8').catch(() => undefined);
+    if (contents?.includes(`"requestId":"${requestId}"`)) return path;
+  }
+  return undefined;
+}
+
+async function waitForObservation({
+  description,
+  probe,
+  accept,
+  settledEarly = () => false,
+  timeoutMs = 30_000,
+}) {
+  const deadline = Date.now() + timeoutMs;
+  let lastObservation;
+  let lastError;
+  while (Date.now() < deadline) {
+    if (settledEarly()) {
+      throw new Error(`${description} settled before the expected state was observed.`);
+    }
+    try {
+      lastObservation = await probe(Math.max(1, deadline - Date.now()));
+      lastError = undefined;
+      if (accept(lastObservation)) return lastObservation;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 100));
+  }
+  throw new Error(
+    `${description} was not observed within ${timeoutMs}ms.` +
+      `${lastObservation === undefined ? '' : ` Last observation: ${JSON.stringify(lastObservation)}.`}` +
+      `${lastError ? ` Last probe error: ${renderError(lastError)}.` : ''}`,
+  );
+}
+
+function renderError(error) {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  return JSON.stringify(error);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {


### PR DESCRIPTION
## Summary

Adds explicit client-initiated cancellation evidence to the existing packaged Windows filesystem-worker E2E.

The scenario uses `FilesystemWorkerClient.abortSignal` against a deterministic long-running AppContainer child provided by the already-packaged broker's `--stdio-probe --sleep` command. It proves the one-shot broker and AppContainer child are active before abort, then requires:

- `FilesystemWorkerClientError` with `reason: aborted`, `stage: launch`, and `dispatched: true`;
- the broker plus AppContainer child process count to return to zero;
- a normal packaged worker read to succeed afterward;
- no recovery ledger or quarantine record for the cancelled request after that recovery launch.

The WMI probe is bounded by the remaining outer deadline. A unique request identity prevents ledger collisions. Failure cleanup aborts the probe and runs one recovery launch; simultaneous evidence and cleanup failures are reported together. Both an immediately clean cancellation and stale-ledger replay are accepted, so the test pins the security outcome rather than the current cleanup mechanism.

This is test/release evidence only. It does not change Runtime behavior, the worker protocol, broker behavior, timeout policy, cancellation classification, ACL semantics, or lifecycle ownership.

Refs #2142

## Scope

This is the explicit client-cancel slice left open by Phase 4. It does not claim to close the whole lifecycle checkbox. Runtime Host death mid-launch, sustained concurrency soak, unsettled-state recovery/quarantine, the adversarial matrix, and independent human security review remain separate work.

It is independent of #3558 at the code level: this PR changes only the existing packaged worker E2E consumed by `verify:windows-x64`; #3558 promotes the broader existing lifecycle smokes through a different four-file diff.

## Verification

Exact head `bbbb6b4f19a64f6a1047defba962382321914d47`; the branch started from `main` `9de05e266`, and fresh GitHub checks passed against the merged result at base `dc9d2f0dd`:

- local real-Electron L2 passed three times using the current Runtime worker bundle and a current-source debug broker in a `win-unpacked`-shaped temporary directory;
- after local runs: 0 sandbox processes and 0 matching cancel recovery records;
- `npm run rebuild` passed;
- `biome lint .`: 2,611 files, no findings;
- `biome format .`: 1,600 files, no changes;
- ASF header audit: 2,745 covered / 130 reviewed exclusions;
- CI planner + Windows harness: 61 passed, 0 failed, 1 privilege-dependent symlink skip;
- packaged dependency-closure tests: 18 passed;
- unified release workflow contract: 1 passed;
- Windows inventory: 3 passed; 63 declarations current;
- JavaScript syntax and `git diff --check` passed.

Local limitations:

- local Cargo initially lacked `dlltool.exe`; the L2 broker was built from the exact current sources by placing the installed LLVM `llvm-dlltool.exe` under the expected temporary tool name and adding only that temporary directory to PATH;
- the full release suite retains two pre-existing local Windows failures outside this one-file diff: the temporary Bash launcher exits `0xffffffff`, and one Git fixture cleanup hits `EBUSY`; the changed release ownership and packaged-closure tests pass directly;
- local L2 uses the real Electron runtime and current artifacts but not electron-builder's final `win-unpacked` output. The authoritative packaged evidence is below.

L3 on the exact head:

- [Core CI 32630825242](https://github.com/apache/maka/actions/runs/32630825242) passed in 15m02s.
- [Release Windows check 32630825228](https://github.com/apache/maka/actions/runs/32630825228) passed in 16m25s.
- The packaged cancellation/recovery stage passed three times in that run: the initial `win-unpacked` app, the pinned-upgrade result, and the automatic-update result.
- Automatic update and the full #3265 Abort-path rollback gate completed afterward, demonstrating that cancellation left no process or recovery-state contamination in the release job.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Codex designed and implemented the bounded packaged client-cancel evidence, ran the local quality gate and real-Electron L2, and performed an author-side adversarial review. The commit includes a `Generated-by: Codex` trailer. AI review is not independent human security review.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, syntax, build, and affected local suites pass
- [x] Fresh packaged Windows L3 passes on this exact head

Does this PR entail a change in behavior?

- [ ] Yes
- [x] No - test and release evidence only