### PR TITLE
fix(ci): add missing ASF headers to session status files

### DIFF
--- a/packages/cli/src/__tests__/tui-session-status.test.ts
+++ b/packages/cli/src/__tests__/tui-session-status.test.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { SessionSummary } from '@maka/core/session';

--- a/packages/cli/src/tui-session-status.ts
+++ b/packages/cli/src/tui-session-status.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import type { SessionSummary } from '@maka/core/session';
 import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
 


### PR DESCRIPTION
## Summary

- add the required ASF license header to the two session-status files introduced by #3441
- restore the source-header gate on current `main`
- make no runtime or test behavior changes

## Verification

- `npm run check:asf-headers`
- `git diff --check`

## Scope

Exactly two TypeScript files changed; no documentation or Java test sources are included.