### PR TITLE
chore: add ASF headers to session status files

### DIFF
--- a/packages/cli/src/__tests__/tui-session-status.test.ts
+++ b/packages/cli/src/__tests__/tui-session-status.test.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import type { SessionSummary } from '@maka/core/session';

--- a/packages/cli/src/tui-session-status.ts
+++ b/packages/cli/src/tui-session-status.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import type { SessionSummary } from '@maka/core/session';
 import type { UiCatalog, UiLocale } from '@maka/core/ui-locale';
 


### PR DESCRIPTION
## Problem

`main` is currently red: `npm run check:asf-headers` fails with

```
2 file(s) are missing the ASF license header:
  packages/cli/src/__tests__/tui-session-status.test.ts
  packages/cli/src/tui-session-status.ts
```

Both files were introduced by #3441. Its CI ran at 2026-08-22T05:55Z, while the ASF source header gate landed later the same day in c633ea5b2 (2026-08-22T13:48Z), so the PR's green predates the gate and the files merged without headers.

## What changes

Headers added by the repository's own tool, `npm run write:asf-headers`. Nothing else is touched.

## Note

This is repair for a merge I performed on a stale green check. Flagging the process gap rather than just the file fix: a check that is green on the exact head can still predate a gate that landed on the base afterwards, so exact-head green needs a freshness dimension too, not only a commit-identity one.