### PR TITLE
test(storage): stop leaking control directories into the user cache

### DIFF
--- a/packages/storage/src/__tests__/artifact-stores.test.ts
+++ b/packages/storage/src/__tests__/artifact-stores.test.ts
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, test } from 'node:test';
+import { after, describe, test } from 'node:test';
 import {
   authenticateInteractiveArtifactStoreWriter,
   openInteractiveArtifactStoreForWrite,
@@ -34,6 +34,14 @@ import {
   tryAcquireInteractiveRootOwner,
   type StorageRootLease,
 } from '../root-authority.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 describe('interactive artifact store authority', () => {
   test('requires authentic leases and writer facades', async () => {
@@ -95,7 +103,9 @@ describe('interactive artifact store authority', () => {
 
   test('root close revokes new facade operations after draining an in-flight write', async () => {
     await withTemporaryRoot('interactive', async (root, track) => {
-      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const capability = trackControlDirectory(
+        await resolveStorageRoot({ path: root, kind: 'interactive' }),
+      );
       const owner = await tryAcquireInteractiveRootOwner(capability);
       assert.ok(owner);
       const writer = track(await openInteractiveArtifactStoreForWrite(owner.lease));
@@ -167,7 +177,9 @@ async function withInteractiveOwner(
   ) => Promise<void>,
 ): Promise<void> {
   await withTemporaryRoot('interactive', async (root, track) => {
-    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     try {

--- a/packages/storage/src/__tests__/artifact-writer-lock.test.ts
+++ b/packages/storage/src/__tests__/artifact-writer-lock.test.ts
@@ -34,7 +34,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
-import { test } from 'node:test';
+import { after, test } from 'node:test';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import {
   openInteractiveArtifactStoreForWrite as openInteractiveArtifactStoreForWriteRaw,
@@ -53,6 +53,14 @@ import {
 } from '../root-authority.js';
 import { exportSessionBundleState } from '../session-bundle-policy.js';
 import { createSessionStore } from '../session-store.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 const TEST_TIMEOUT_MS = 15_000;
 const OPERATION_TIMEOUT_MS = 5_000;
@@ -168,7 +176,9 @@ test('public Store mutations share the rootId writer lock used by lease-bound au
   await withTemporaryDirectory(async (root) => {
     const stateRoot = join(root, 'state');
     await mkdir(stateRoot);
-    const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: stateRoot, kind: 'interactive' }),
+    );
     const holder = await spawnAuthorityLockHolder(stateRoot, capability.rootId);
     try {
       const mutation = createArtifactStore(stateRoot).create(artifactInput('public-marked-root'));
@@ -204,7 +214,7 @@ test('mutations spanning initial root marking remain serialized by the bootstrap
       );
       await assertPending(firstMutation, 'public mutation started before root marking');
 
-      await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+      trackControlDirectory(await resolveStorageRoot({ path: stateRoot, kind: 'interactive' }));
       const secondMutation = createArtifactStore(stateRoot).create(
         artifactInput('after-root-marking', undefined, 2),
       );
@@ -275,7 +285,9 @@ test('public mutation through a retargeted alias stays bound to its verified can
     const alias = join(root, 'state-alias');
     await Promise.all([mkdir(stateRoot), mkdir(replacementRoot)]);
     await writeFile(join(replacementRoot, 'replacement-sentinel'), 'replacement');
-    const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: stateRoot, kind: 'interactive' }),
+    );
     await createArtifactStore(stateRoot).create(artifactInput('seed'));
     await symlink(stateRoot, alias, process.platform === 'win32' ? 'junction' : 'dir');
     const store = createArtifactStore(alias);
@@ -313,7 +325,9 @@ test('admitted lease-bound mutations reject a replacement root without modifying
   await withTemporaryDirectory(async (root) => {
     const stateRoot = join(root, 'state');
     await mkdir(stateRoot);
-    const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: stateRoot, kind: 'interactive' }),
+    );
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     const firstStore = await openInteractiveArtifactStoreForWrite(owner.lease);
@@ -356,7 +370,9 @@ test('lease-bound mutation does not rebuild a root deleted while waiting for the
   await withTemporaryDirectory(async (root) => {
     const stateRoot = join(root, 'state');
     await mkdir(stateRoot);
-    const capability = await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: stateRoot, kind: 'interactive' }),
+    );
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     const store = await openInteractiveArtifactStoreForWrite(owner.lease);

--- a/packages/storage/src/__tests__/daily-review-authority.test.ts
+++ b/packages/storage/src/__tests__/daily-review-authority.test.ts
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { test } from 'node:test';
+import { after, test } from 'node:test';
 import type { DailyReviewArchive } from '@maka/core/daily-review';
 import {
   authenticateInteractiveDailyReviewAuthorityWriter,
@@ -32,6 +32,14 @@ import {
   StorageRootAuthorityError,
   tryAcquireInteractiveRootOwner,
 } from '../root-authority.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 test('Daily Review authority serializes config revisions and preserves archives', async () => {
   await withInteractiveRoot(async ({ capability }) => {
@@ -179,10 +187,9 @@ async function withInteractiveRoot(
 ): Promise<void> {
   const base = await mkdtemp(join(tmpdir(), 'maka-daily-review-authority-'));
   try {
-    const capability = await resolveStorageRoot({
-      path: join(base, 'interactive'),
-      kind: 'interactive',
-    });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: join(base, 'interactive'), kind: 'interactive' }),
+    );
     await run({ capability });
   } finally {
     await rm(base, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/fixtures/control-directory-hygiene.ts
+++ b/packages/storage/src/__tests__/fixtures/control-directory-hygiene.ts
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { resolveRootControlNamespace, STORAGE_ROOT_MARKER_FILE } from '../../root-authority.js';
+
+// A storage root's control directory lives under the real OS account home, not
+// inside the temporary root a test creates, so removing the temporary directory
+// leaves the control directory behind. `resolveRootControlNamespace` reads
+// `userInfo().homedir` on purpose — the directory carries `owner.lock`, which
+// decides who may write a State Root, and an environment variable must not be
+// able to move that trust boundary. Tests therefore have to remove what they
+// created, and these helpers are the one place that knows how.
+
+/** Removes the control directory for a rootId. Safe to call when none exists. */
+export async function removeControlDirectory(rootId: string): Promise<void> {
+  if (rootId.length === 0) return;
+  await rm(join(resolveRootControlNamespace(), rootId), { recursive: true, force: true });
+}
+
+/**
+ * Removes the control directory belonging to a storage root path, reading the
+ * rootId from the root's own marker file.
+ *
+ * Only usable while the root still exists. A test that removes or quarantines
+ * its root before teardown has already destroyed the marker that names the
+ * control directory, so such tests must record the rootId at resolution time
+ * with `trackControlDirectory` instead.
+ */
+export async function removeControlDirectoryForRootPath(rootPath: string): Promise<void> {
+  const marker = await readFile(join(rootPath, STORAGE_ROOT_MARKER_FILE), 'utf8').catch(
+    () => undefined,
+  );
+  if (marker === undefined) return;
+  let rootId: unknown;
+  try {
+    rootId = (JSON.parse(marker) as { rootId?: unknown }).rootId;
+  } catch {
+    return;
+  }
+  if (typeof rootId !== 'string') return;
+  await removeControlDirectory(rootId);
+}
+
+const trackedRootIds = new Set<string>();
+
+/**
+ * Records a resolved root's control directory for teardown and returns the
+ * capability unchanged, so it can wrap a `resolveStorageRoot` call in place.
+ * The record survives the root itself, which is what teardown needs. Node's
+ * test runner gives each file its own process, so the set is per-file state.
+ */
+export function trackControlDirectory<Capability extends { readonly rootId: string }>(
+  capability: Capability,
+): Capability {
+  trackedRootIds.add(capability.rootId);
+  return capability;
+}
+
+/** Removes every control directory recorded by `trackControlDirectory` so far. */
+export async function removeTrackedControlDirectories(): Promise<void> {
+  const rootIds = [...trackedRootIds];
+  trackedRootIds.clear();
+  await Promise.all(rootIds.map(removeControlDirectory));
+}

--- a/packages/storage/src/__tests__/goal-authority.test.ts
+++ b/packages/storage/src/__tests__/goal-authority.test.ts
@@ -21,18 +21,25 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { test } from 'node:test';
+import { after, test } from 'node:test';
 import type { GoalAuthorityRecord } from '@maka/core/goal';
 import { openInteractiveExecutionStoresForWrite } from '../execution-stores.js';
 import { openInteractiveGoalAuthorityForWrite } from '../goal-authority.js';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 test('Goal authority commits one revisioned record and preserves its execution reference', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-goal-authority-'));
-  const capability = await resolveStorageRoot({
-    path: join(base, 'interactive'),
-    kind: 'interactive',
-  });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: join(base, 'interactive'), kind: 'interactive' }),
+  );
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner);
   if (!owner) return;
@@ -84,10 +91,9 @@ test('Goal authority commits one revisioned record and preserves its execution r
 
 test('Goal authority close lets an admitted commit finish before releasing storage', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-goal-authority-close-'));
-  const capability = await resolveStorageRoot({
-    path: join(base, 'interactive'),
-    kind: 'interactive',
-  });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: join(base, 'interactive'), kind: 'interactive' }),
+  );
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner);
   if (!owner) return;
@@ -122,10 +128,9 @@ test('Goal authority close lets an admitted commit finish before releasing stora
 
 test('Session retirement atomically removes its Goal authority', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-goal-authority-retirement-'));
-  const capability = await resolveStorageRoot({
-    path: join(base, 'interactive'),
-    kind: 'interactive',
-  });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: join(base, 'interactive'), kind: 'interactive' }),
+  );
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner);
   if (!owner) return;

--- a/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-baseline.test.ts
@@ -51,6 +51,10 @@ import {
   tryAcquireInteractiveRootOwner,
 } from '../root-authority.js';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
 
 const execFileAsync = promisify(execFile);
 const cleanup: string[] = [];
@@ -87,7 +91,9 @@ test('does not expose artifact-only workspace creation through the public storag
   assert.equal('inspectManagedWorkspaceExecutionScopeInternal' in publicStorage, false);
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   try {
@@ -107,14 +113,23 @@ test('does not expose artifact-only workspace creation through the public storag
 });
 
 afterEach(async () => {
-  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  await Promise.all(
+    cleanup.splice(0).map(async (path) => {
+      await rm(path, { recursive: true, force: true });
+    }),
+  );
+  // Control directories live outside the temporary roots, so they outlive the
+  // removal above and have to be reclaimed from the recorded rootIds.
+  await removeTrackedControlDirectories();
 });
 
 test('opens one canonical baseline from a durable verified Git receipt', async () => {
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -231,7 +246,9 @@ test('reuses an orphan receipt after interruption before SQLite acceptance', asy
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -278,7 +295,9 @@ test('rejects a receipt read through a replaced instance-root symlink before par
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -320,7 +339,9 @@ test('serializes concurrent baseline opens under the same managed workspace owne
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -354,7 +375,9 @@ test('rejects a leased authority database whose real root differs from its claim
   const actualRoot = join(root, 'actual-storage');
   const claimedRoot = join(root, 'claimed-storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: claimedRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: claimedRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const databaseLease = acquireOperationalStateDatabase(actualRoot);
@@ -385,7 +408,9 @@ test('rejects a leased authority database whose real root differs from its claim
 test('rejects a non-canonical SQLite file in the authenticated storage root', async () => {
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'other.sqlite'));
@@ -413,7 +438,9 @@ test('rejects a non-canonical SQLite file in the authenticated storage root', as
 test('rejects an in-memory SQLite authority store', async () => {
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(':memory:');
@@ -448,7 +475,9 @@ test('rejects a cross-root hard link to the canonical SQLite authority database'
   sourceStore.close();
   await link(sourceDatabasePath, join(claimedStorageRoot, 'runtime.sqlite'));
 
-  const capability = await resolveStorageRoot({ path: claimedStorageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: claimedStorageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(claimedStorageRoot, 'runtime.sqlite'));
@@ -479,10 +508,9 @@ test('rejects a canonical SQLite database copied from a different durable storag
   const claimedStorageRoot = join(root, 'storage-b');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
   const request = openRequest(sourceRoot);
-  const sourceCapability = await resolveStorageRoot({
-    path: sourceStorageRoot,
-    kind: 'interactive',
-  });
+  const sourceCapability = trackControlDirectory(
+    await resolveStorageRoot({ path: sourceStorageRoot, kind: 'interactive' }),
+  );
   const sourceRootOwner = await tryAcquireInteractiveRootOwner(sourceCapability);
   assert.ok(sourceRootOwner);
   const sourceStore = createSqliteRuntimeStore(join(sourceStorageRoot, 'runtime.sqlite'));
@@ -501,10 +529,9 @@ test('rejects a canonical SQLite database copied from a different durable storag
     await sourceRootOwner.close();
   }
 
-  const claimedCapability = await resolveStorageRoot({
-    path: claimedStorageRoot,
-    kind: 'interactive',
-  });
+  const claimedCapability = trackControlDirectory(
+    await resolveStorageRoot({ path: claimedStorageRoot, kind: 'interactive' }),
+  );
   await copyFile(
     join(sourceStorageRoot, 'runtime.sqlite'),
     join(claimedStorageRoot, 'runtime.sqlite'),
@@ -535,10 +562,9 @@ test('preserves the durable database root binding across formal whole-root impor
   const root = await temporaryRoot();
   const sourceStorageRoot = join(root, 'storage-a');
   const importedStorageRoot = join(root, 'storage-imported');
-  const sourceCapability = await resolveStorageRoot({
-    path: sourceStorageRoot,
-    kind: 'interactive',
-  });
+  const sourceCapability = trackControlDirectory(
+    await resolveStorageRoot({ path: sourceStorageRoot, kind: 'interactive' }),
+  );
   const sourceRootOwner = await tryAcquireInteractiveRootOwner(sourceCapability);
   assert.ok(sourceRootOwner);
   const sourceStore = createSqliteRuntimeStore(join(sourceStorageRoot, 'runtime.sqlite'));
@@ -598,7 +624,9 @@ test('preserves the durable database root binding across formal whole-root impor
 test('rejects an authenticated owner after its durable root marker id is replaced', async () => {
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -633,7 +661,9 @@ test('rejects final admission when the root marker changes after post-commit art
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
   const request = openRequest(sourceRoot);
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -677,7 +707,9 @@ test('rejects an authority database whose file identity changes after registrati
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const databasePath = join(storageRoot, 'runtime.sqlite');
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(databasePath);
@@ -713,7 +745,9 @@ test('does not return an accepted baseline when runtime.sqlite is replaced after
   const databasePath = join(storageRoot, 'runtime.sqlite');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
   const request = openRequest(sourceRoot);
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(databasePath);
@@ -781,7 +815,9 @@ test('rejects runtime.sqlite when the canonical database path is a symlink', asy
     throw error;
   }
 
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -810,7 +846,9 @@ test('keeps an orphan receipt across SQLite rollback and accepts it on retry', a
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   let interruptOnce = true;
@@ -884,7 +922,9 @@ test('accepts the same durable receipt after a real process crash before SQLite 
     child.kill('SIGKILL');
     await waitForExit(child);
 
-    const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+    );
     const rootOwner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(rootOwner);
     const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -945,7 +985,9 @@ test('reopens the exact accepted baseline after a real crash before post-commit 
     child.kill('SIGKILL');
     await waitForExit(child);
 
-    const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+    );
     const rootOwner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(rootOwner);
     const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -1004,7 +1046,9 @@ test('reissues execution authority after a real process crash during admission v
     child.kill('SIGKILL');
     await waitForExit(child);
 
-    const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+    );
     const rootOwner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(rootOwner);
     const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -1048,7 +1092,9 @@ test('rejects a source tree containing a non-UTF-8 Git path', {
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
   await commitInvalidUtf8Path(sourceRoot);
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));

--- a/packages/storage/src/__tests__/managed-workspace-owner.test.ts
+++ b/packages/storage/src/__tests__/managed-workspace-owner.test.ts
@@ -39,6 +39,10 @@ import {
 } from '../managed-workspace-execution-authority-internal.js';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
 
 const execFileAsync = promisify(execFile);
 const cleanup: string[] = [];
@@ -55,12 +59,21 @@ before(async () => {
 });
 
 afterEach(async () => {
-  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  await Promise.all(
+    cleanup.splice(0).map(async (path) => {
+      await rm(path, { recursive: true, force: true });
+    }),
+  );
+  // Control directories live outside the temporary roots, so they outlive the
+  // removal above and have to be reclaimed from the recorded rootIds.
+  await removeTrackedControlDirectories();
 });
 
 test('admits exactly one managed workspace owner for an interactive root owner', async () => {
   const storageRoot = await temporaryRoot();
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   try {
@@ -91,7 +104,9 @@ test('admits exactly one managed workspace owner for an interactive root owner',
 
 test('releases a partial owner claim when pinned Git initialization fails', async () => {
   const storageRoot = await temporaryRoot();
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   try {
@@ -124,7 +139,9 @@ test('creates an accepted managed baseline only through the active owner', async
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -160,7 +177,9 @@ test('publishes only a revocable execution scope through its accepted handle', a
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -231,7 +250,9 @@ test('does not let caller-mutated head state or a shadowed public reader forge e
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -280,7 +301,9 @@ test('quarantines drift introduced after execution artifact verification before 
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -341,7 +364,9 @@ test('rejects execution when runtime.sqlite detaches from its canonical path aft
   const storageRoot = join(root, 'storage');
   const databasePath = join(storageRoot, 'runtime.sqlite');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(databasePath);
@@ -386,7 +411,9 @@ test('rejects execution when runtime.sqlite detaches from its canonical path aft
 
 test('rejects a forged execution handle before invoking the tool callback', async () => {
   const storageRoot = await temporaryRoot();
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   let callbackCalled = false;
@@ -421,14 +448,12 @@ test('rejects a forged execution handle before invoking the tool callback', asyn
 test('rejects an execution handle issued by another managed workspace owner', async () => {
   const root = await temporaryRoot();
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const leftCapability = await resolveStorageRoot({
-    path: join(root, 'left-storage'),
-    kind: 'interactive',
-  });
-  const rightCapability = await resolveStorageRoot({
-    path: join(root, 'right-storage'),
-    kind: 'interactive',
-  });
+  const leftCapability = trackControlDirectory(
+    await resolveStorageRoot({ path: join(root, 'left-storage'), kind: 'interactive' }),
+  );
+  const rightCapability = trackControlDirectory(
+    await resolveStorageRoot({ path: join(root, 'right-storage'), kind: 'interactive' }),
+  );
   const leftRootOwner = await tryAcquireInteractiveRootOwner(leftCapability);
   const rightRootOwner = await tryAcquireInteractiveRootOwner(rightCapability);
   assert.ok(leftRootOwner);
@@ -472,7 +497,9 @@ test('drains an admitted managed execution before owner close completes', async 
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -534,7 +561,9 @@ test('routes read-only execution through the owner-bound worker bridge', async (
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -582,7 +611,9 @@ test('revokes the scope and releases owner residency when the filesystem worker 
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -634,7 +665,9 @@ test('rejects owner close reentrancy from an active execution callback', async (
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -675,7 +708,9 @@ test('allows concurrent read-only scopes for one handle and close drains both', 
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -749,7 +784,9 @@ test('expires the execution scope and releases owner residency when its callback
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -792,7 +829,9 @@ test('drains an admitted workspace operation before closing and rejects new work
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));
@@ -868,7 +907,9 @@ test('rejects external drift instead of reopening a non-ready workspace', async 
   const root = await temporaryRoot();
   const storageRoot = join(root, 'storage');
   const sourceRoot = await createEligibleSource(join(root, 'source'));
-  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: storageRoot, kind: 'interactive' }),
+  );
   const rootOwner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(rootOwner);
   const runtimeStore = createSqliteRuntimeStore(join(storageRoot, 'runtime.sqlite'));

--- a/packages/storage/src/__tests__/memory-bundle-store.test.ts
+++ b/packages/storage/src/__tests__/memory-bundle-store.test.ts
@@ -43,6 +43,7 @@ import {
   type InteractiveRootOwner,
   type StorageRootCapability,
 } from '../root-authority.js';
+import { removeControlDirectory } from './fixtures/control-directory-hygiene.js';
 
 const MEMORY_DIRECTORY = 'memory';
 const TRANSACTION_DIRECTORY = '.memory-bundle-transaction';
@@ -752,7 +753,11 @@ async function withInteractiveRoot(
   const root = await mkdtemp(join(tmpdir(), 'maka-memory-bundle-store-'));
   try {
     const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
-    await run({ root, capability });
+    try {
+      await run({ root, capability });
+    } finally {
+      await removeControlDirectory(capability.rootId);
+    }
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/storage/src/__tests__/project-catalog-authority.test.ts
+++ b/packages/storage/src/__tests__/project-catalog-authority.test.ts
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { test } from 'node:test';
+import { after, test } from 'node:test';
 import {
   authenticateInteractiveProjectCatalogWriter,
   openInteractiveProjectCatalogForWrite,
@@ -31,13 +31,23 @@ import {
   StorageRootAuthorityError,
   tryAcquireInteractiveRootOwner,
 } from '../root-authority.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 test('Project Catalog writes require one live interactive root owner', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-project-catalog-authority-'));
   const dataRoot = join(base, 'data');
   const projectRoot = join(base, 'project');
   await mkdir(projectRoot);
-  const capability = await resolveStorageRoot({ path: dataRoot, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: dataRoot, kind: 'interactive' }),
+  );
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner);
   if (!owner) return;

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -51,6 +51,7 @@ import {
   openInteractiveRuntimePolicyStoresForWrite,
   RuntimePolicyStoreError,
 } from '../runtime-policy-stores.js';
+import { removeControlDirectory } from './fixtures/control-directory-hygiene.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -3596,7 +3597,11 @@ async function withInteractiveRoot(
   await withTempDir(async (base) => {
     const root = join(base, 'interactive');
     const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
-    await run({ root, capability });
+    try {
+      await run({ root, capability });
+    } finally {
+      await removeControlDirectory(capability.rootId);
+    }
   });
 }
 

--- a/packages/storage/src/__tests__/shell-run-authority.test.ts
+++ b/packages/storage/src/__tests__/shell-run-authority.test.ts
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, test } from 'node:test';
+import { after, describe, test } from 'node:test';
 import type { ShellRunRecord } from '@maka/core/shell-run';
 import {
   authenticateInteractiveShellRunWriter,
@@ -34,6 +34,14 @@ import {
   tryAcquireInteractiveRootOwner,
   type StorageRootLease,
 } from '../root-authority.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 describe('interactive ShellRun authority', () => {
   test('single-flights one authentic writer and preserves durable lifecycle state', async () => {
@@ -156,10 +164,9 @@ async function withInteractiveRoot(
   }) => Promise<void>,
 ): Promise<void> {
   await withTempDir(async (base) => {
-    const capability = await resolveStorageRoot({
-      path: join(base, 'interactive'),
-      kind: 'interactive',
-    });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: join(base, 'interactive'), kind: 'interactive' }),
+    );
     await run({ capability });
   });
 }

--- a/packages/storage/src/__tests__/sqlite-core-execution-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-core-execution-store.test.ts
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, test } from 'node:test';
+import { after, describe, test } from 'node:test';
 import { DatabaseSync } from 'node:sqlite';
 import type { AgentRunHeader, EmittedAgentRunEvent } from '@maka/core/agent-run';
 import {
@@ -40,6 +40,14 @@ import {
 import { createSqliteMessageReceiptStore } from '../message-receipt-store.js';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
 import { createSqliteShellRunStore } from '../shell-run-store.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 describe('SQLite core execution stores', () => {
   test('persists AgentRun header and events', async () => {
@@ -343,7 +351,9 @@ describe('SQLite core execution stores', () => {
 
   test('persists interaction request and outcome', async () => {
     await withRoot(async (root) => {
-      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const capability = trackControlDirectory(
+        await resolveStorageRoot({ path: root, kind: 'interactive' }),
+      );
       const owner = await tryAcquireInteractiveRootOwner(capability);
       assert.ok(owner);
       if (!owner) return;

--- a/packages/storage/src/__tests__/sqlite-long-term-memory-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-long-term-memory-store.test.ts
@@ -22,7 +22,7 @@ import { createRequire } from 'node:module';
 import { chmod, link, mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, test } from 'node:test';
+import { after, describe, test } from 'node:test';
 import { Worker } from 'node:worker_threads';
 import {
   MemoryItemStoreConflictError,
@@ -44,6 +44,14 @@ import {
   SqliteMemoryItemStore,
   type SqliteMemoryItemStoreFailpoint,
 } from '../sqlite-long-term-memory-store.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 const require = createRequire(import.meta.url);
 
@@ -1544,7 +1552,9 @@ describe('long-term memory Storage Root authority', () => {
 
   test('snapshots mutation input before crossing the authority boundary', async () => {
     await withTempRoot(async (root) => {
-      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const capability = trackControlDirectory(
+        await resolveStorageRoot({ path: root, kind: 'interactive' }),
+      );
       const owner = await tryAcquireInteractiveRootOwner(capability);
       assert.ok(owner);
       if (!owner) return;
@@ -1583,7 +1593,9 @@ describe('long-term memory Storage Root authority', () => {
 
   test('rejects operations after the durable root identity changes', async () => {
     await withTempRoot(async (root) => {
-      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const capability = trackControlDirectory(
+        await resolveStorageRoot({ path: root, kind: 'interactive' }),
+      );
       const owner = await tryAcquireInteractiveRootOwner(capability);
       assert.ok(owner);
       if (!owner) return;
@@ -1605,7 +1617,9 @@ describe('long-term memory Storage Root authority', () => {
 
   test('single-flights an Interactive writer and closes it explicitly', async () => {
     await withTempRoot(async (root) => {
-      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const capability = trackControlDirectory(
+        await resolveStorageRoot({ path: root, kind: 'interactive' }),
+      );
       const owner = await tryAcquireInteractiveRootOwner(capability);
       assert.ok(owner);
       if (!owner) return;

--- a/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
@@ -21,12 +21,20 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, test } from 'node:test';
+import { after, describe, test } from 'node:test';
 import { createSqliteDeepResearchStore } from '../deep-research-store.js';
 import { openInteractiveScheduledTaskStoreForWrite } from '../scheduled-task-store.js';
 import { createSqlitePlanStore } from '../plan-store.js';
 import { createSqliteTaskLedgerStore } from '../task-ledger-store.js';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 const SESSION_ID = 'session-workflow';
 
@@ -427,7 +435,9 @@ describe('SQLite workflow stores', () => {
 });
 
 async function scheduledTaskStoreRoot(root: string) {
-  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const capability = trackControlDirectory(
+    await resolveStorageRoot({ path: root, kind: 'interactive' }),
+  );
   const owner = await tryAcquireInteractiveRootOwner(capability);
   assert.ok(owner);
   if (!owner) throw new Error('Unable to acquire the ScheduledTask test root');

--- a/packages/storage/src/__tests__/state-root-composition.test.ts
+++ b/packages/storage/src/__tests__/state-root-composition.test.ts
@@ -21,18 +21,28 @@ import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { test } from 'node:test';
+import { after, test } from 'node:test';
 import { resolveStorageRoot, tryAcquireStateRootOwner } from '../root-authority.js';
 import {
   bindStateRootComposition,
   STATE_ROOT_COMPOSITION_FILE,
   StateRootCompositionError,
 } from '../state-root-composition.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 test('State Root composition binding is durable, idempotent, and exclusive', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-state-root-composition-'));
   try {
-    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
     const owner = await tryAcquireStateRootOwner(capability);
     assert.ok(owner);
     try {
@@ -56,7 +66,9 @@ test('State Root composition binding is durable, idempotent, and exclusive', asy
 test('State Root composition binding rejects a corrupt existing authority record', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-state-root-composition-corrupt-'));
   try {
-    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
     const owner = await tryAcquireStateRootOwner(capability);
     assert.ok(owner);
     try {

--- a/packages/storage/src/__tests__/storage-writer-composition.test.ts
+++ b/packages/storage/src/__tests__/storage-writer-composition.test.ts
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { test } from 'node:test';
+import { after, test } from 'node:test';
 import { acquireOperationalStateDatabase } from '../operational-state-store.js';
 import { openStorageWriterComposition } from '../storage-writer-composition.js';
 import {
@@ -29,11 +29,21 @@ import {
   runWithStorageRootLease,
   tryAcquireInteractiveRootOwner,
 } from '../root-authority.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 test('storage writer composition rejects reuse until close completes', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-storage-composition-'));
   try {
-    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     try {
@@ -58,7 +68,9 @@ test('storage writer composition rejects reuse until close completes', async () 
 test('opening a second storage writer composition creates a usable lifecycle', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-storage-composition-failure-'));
   try {
-    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     try {
@@ -79,7 +91,9 @@ test('opening a second storage writer composition creates a usable lifecycle', a
 test('a failed close keeps the lease unavailable', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-storage-composition-close-failure-'));
   try {
-    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     try {
@@ -108,7 +122,9 @@ test('a failed close keeps the lease unavailable', async () => {
 test('a failed runtime-policy hook rolls back before reopening', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-storage-composition-hook-failure-'));
   try {
-    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     try {

--- a/packages/storage/src/__tests__/task-ledger-authority.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-authority.test.ts
@@ -21,7 +21,7 @@ import assert from 'node:assert/strict';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { describe, test } from 'node:test';
+import { after, describe, test } from 'node:test';
 import {
   authenticateInteractiveTaskLedgerWriter,
   openInteractiveTaskLedgerStoreForWrite,
@@ -33,6 +33,14 @@ import {
   tryAcquireInteractiveRootOwner,
   type StorageRootLease,
 } from '../root-authority.js';
+import {
+  removeTrackedControlDirectories,
+  trackControlDirectory,
+} from './fixtures/control-directory-hygiene.js';
+
+// The control directory of each resolved root lives outside that root, so a
+// temporary root's removal leaves it behind; reclaim the recorded rootIds here.
+after(removeTrackedControlDirectories);
 
 const SESSION_ID = 'authority-session';
 
@@ -135,7 +143,9 @@ async function withInteractiveRoot(
 ): Promise<void> {
   await withTempDir(async (base) => {
     const root = join(base, 'interactive');
-    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const capability = trackControlDirectory(
+      await resolveStorageRoot({ path: root, kind: 'interactive' }),
+    );
     await run({ root, capability });
   });
 }

--- a/packages/storage/src/__tests__/usage-stores.test.ts
+++ b/packages/storage/src/__tests__/usage-stores.test.ts
@@ -52,6 +52,7 @@ import {
   openInteractiveUsageStoresForWrite,
 } from '../usage-stores.js';
 import { acquireOperationalStateDatabase } from '../operational-state-store.js';
+import { removeControlDirectory } from './fixtures/control-directory-hygiene.js';
 
 describe('InteractiveUsageStores', () => {
   test('classifies facade failures without exposing concrete errors to callers', () => {
@@ -466,7 +467,11 @@ async function withInteractiveRoot(
   try {
     const root = join(base, 'interactive');
     const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
-    await run({ root, capability });
+    try {
+      await run({ root, capability });
+    } finally {
+      await removeControlDirectory(capability.rootId);
+    }
   } finally {
     await rm(base, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

A clean run of the `@maka/storage` suite left 159 directories behind in `~/Library/Caches/Maka/runtime-hosts`. Nothing failed, so nothing surfaced it — the machine this was found on had accumulated 27,740.

A storage root's control directory is keyed by rootId under the real OS account home, deliberately outside the root itself. `resolveRootControlNamespace()` reads `userInfo().homedir` so that no environment variable can move a boundary `owner.lock` enforces. The consequence is that `rm(temporaryRoot)` does not reclaim it, and seventeen test files removed only their temporary root.

This adds `packages/storage/src/__tests__/fixtures/control-directory-hygiene.ts` and calls it from every file that resolves a temporary root:

- `trackControlDirectory(capability)` records the rootId at resolution and returns the capability unchanged, so it wraps a `resolveStorageRoot` call in place;
- `removeTrackedControlDirectories()` reclaims them in teardown.

The trust boundary is untouched; the tests simply clean up what they created.

**Recording at resolution rather than teardown is required, not stylistic.** The first attempt read the rootId from the root's marker file during teardown. Instrumenting it showed the marker was already gone for 14 of the 15 leaks in `managed-workspace-owner`, because those tests remove or quarantine the root as part of what they exercise. The recorded id outlives the root; the marker does not. `removeControlDirectoryForRootPath` is kept for teardown that still has the root on disk, with that precondition documented.

Fixes #3590

## Verification

Counted `~/Library/Caches/Maka/runtime-hosts` before and after each run.

Whole suite:

```
$ node --test --test-concurrency=2 "packages/storage/dist/__tests__/*.test.js"
ℹ tests 912
ℹ pass 898
ℹ fail 0
before 28126 → after 28126     (+159 before this change)
```

The five largest sources, measured individually, all pass and all now leak nothing:

| File | Before | After | Tests |
|---|---|---|---|
| `runtime-policy-stores` | +54 | 0 | 52 pass, 0 fail |
| `managed-workspace-baseline` | +22 | 0 | 22 pass, 0 fail |
| `managed-workspace-owner` | +18 | 0 | 17 pass, 0 fail |
| `memory-bundle-store` | +16 | 0 | 16 pass, 0 fail |
| `usage-stores` | +15 | 0 | 13 pass, 0 fail |

The remaining twelve files (+1 to +5 each) are covered by the same change and are included in the whole-suite result above.

`@maka/runtime-host` was measured the same way and does not leak — its shared `ExecutionFixture.close()` already removes the control directory, the endpoint directories and the base — so nothing there is changed.

Repository checks:

```
npm run format:check   Checked 1599 files. No fixes applied.
npx biome lint packages/storage/src/__tests__/   Checked 96 files. No fixes applied.
npm --workspace @maka/storage run build          clean
```

## Out of scope

Reclaiming control directories that are already stale needs a definition of "stale" that is safe against a live `owner.lock`. That is tracked in #3590 and deliberately not attempted here.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Claude Opus 5 via Claude Code — measured the leak, attributed it per file by running each test file in isolation, wrote the fixture and the call-site changes, and re-measured. Every number in this description came from running the command shown. The commit carries a `Generated-by` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

The coverage here is the measurement itself rather than a new assertion: before this change the suite leaves 159 directories behind, after it leaves none, with the same 912 tests passing. A test that asserts on the developer's real cache directory would be worse than the measurement — it would either be racy under `--test-concurrency` or would itself have to write there.

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No
