### PR TITLE
docs: use the new Ä mark in the README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 -->
 
 <h1 align="center">
-  <img src="apps/desktop/assets/icon.png" alt="Maka" width="72" valign="middle" /> Apache Maka (Incubating)
+  <img src="apps/desktop/assets/app-icons/sky.png" alt="Maka" width="72" valign="middle" /> Apache Maka (Incubating)
 </h1>
 
 <p align="center"><sub>Incubating at The Apache Software Foundation</sub></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,7 +18,7 @@
 -->
 
 <h1 align="center">
-  <img src="apps/desktop/assets/icon.png" alt="Maka" width="72" valign="middle" /> Apache Maka (Incubating)
+  <img src="apps/desktop/assets/app-icons/sky.png" alt="Maka" width="72" valign="middle" /> Apache Maka (Incubating)
 </h1>
 
 <p align="center"><sub>正在 Apache 软件基金会孵化</sub></p>


### PR DESCRIPTION
## Summary
Both READMEs still showed `apps/desktop/assets/icon.png` (the character mascot) next to the title. The icon set that landed in #3431 is the geometric Ä mark under `apps/desktop/assets/app-icons/`. Point the header at `sky.png`.

Hero banners are unchanged. Packaging/window default is still `assets/icon.png`; this PR is docs-only.

## Test plan
- [ ] GitHub renders `app-icons/sky.png` in README.md and README.zh-CN.md
- [ ] Character mascot no longer appears in the README title row