### PR TITLE
fix(win): invalidate stale rollback backup authority

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -616,8 +616,8 @@ FunctionEnd
   # Success tail: the upgrade completed, so the backup and any aside residue
   # are redundant. Invalidate the completeness marker before the best-effort
   # tree removal: if a scanner holds an application file, RMDir may leave the
-  # old backup behind, and a later upgrade must not mistake that residue for a
-  # live recovery source from the newly installed version.
+  # old backup behind. Its old-version marker would make a later upgrade
+  # reject the healthy current installation as mismatched recovery state.
   ClearErrors
   Delete "$makaBackupDir\${MAKA_BACKUP_MARKER}"
   Delete "$makaBackupDir\${MAKA_RECOVERY_README}"

--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -614,8 +614,13 @@ FunctionEnd
 
 !macro customInstall
   # Success tail: the upgrade completed, so the backup and any aside residue
-  # are redundant. Best effort -- a held handle must not fail a completed
-  # install.
+  # are redundant. Invalidate the completeness marker before the best-effort
+  # tree removal: if a scanner holds an application file, RMDir may leave the
+  # old backup behind, and a later upgrade must not mistake that residue for a
+  # live recovery source from the newly installed version.
+  ClearErrors
+  Delete "$makaBackupDir\${MAKA_BACKUP_MARKER}"
+  Delete "$makaBackupDir\${MAKA_RECOVERY_README}"
   ClearErrors
   ${If} ${FileExists} "$makaBackupDir\*.*"
     RMDir /r "$makaBackupDir"

--- a/scripts/product-release.test.mjs
+++ b/scripts/product-release.test.mjs
@@ -194,6 +194,24 @@ test('Desktop packaging does not distribute the retired bundled Git runtime', ()
   );
 });
 
+test('a successful Windows upgrade invalidates backup authority before best-effort cleanup', async () => {
+  const source = await readFile(
+    join(repoRoot, 'apps', 'desktop', 'build', 'installer.nsh'),
+    'utf8',
+  );
+  const macroStart = source.indexOf('!macro customInstall');
+  const macroEnd = source.indexOf('!macroend', macroStart);
+  assert.ok(macroStart >= 0 && macroEnd > macroStart);
+  const cleanup = source.slice(macroStart, macroEnd);
+  const markerInvalidation = cleanup.indexOf('Delete "$makaBackupDir\\${MAKA_BACKUP_MARKER}"');
+  const backupRemoval = cleanup.indexOf('RMDir /r "$makaBackupDir"');
+  const snapshotRemoval = cleanup.indexOf('DeleteRegKey SHELL_CONTEXT "${MAKA_SNAPSHOT_REG_KEY}"');
+
+  assert.ok(markerInvalidation >= 0);
+  assert.ok(backupRemoval > markerInvalidation);
+  assert.ok(snapshotRemoval > markerInvalidation);
+});
+
 test('platform package verifiers keep Git checks out of current artifacts', async () => {
   const windowsSource = await readFile(join(repoRoot, 'scripts', 'verify-windows-x64.mjs'), 'utf8');
   assert.match(

--- a/scripts/product-release.test.mjs
+++ b/scripts/product-release.test.mjs
@@ -194,7 +194,7 @@ test('Desktop packaging does not distribute the retired bundled Git runtime', ()
   );
 });
 
-test('a successful Windows upgrade invalidates backup authority before best-effort cleanup', async () => {
+test('a successful Windows upgrade invalidates stale backup authority before best-effort cleanup', async () => {
   const source = await readFile(
     join(repoRoot, 'apps', 'desktop', 'build', 'installer.nsh'),
     'utf8',


### PR DESCRIPTION
## Summary

- revoke the Windows pre-upgrade backup completeness marker before best-effort successful-install cleanup
- prevent a residual old-version marker from blocking later upgrades when `RMDir /r` is interrupted by a held file
- pin the authority-before-cleanup ordering with a product release policy test

## Why

The successful upgrade tail intentionally treats backup removal as best effort. On Windows, antivirus or indexing can keep an application file open, so `RMDir /r` may partially delete the backup and leave its completeness marker behind. After the successful install, the registry identifies the new version, while that marker still identifies the old backup version. The next installer sees the stale authority, detects the version mismatch, and refuses an otherwise healthy upgrade with exit 101.

Deleting the marker first makes any cleanup residue inert before recursive tree removal begins. The completed install remains successful even when cleanup cannot finish.

## Verification

- `npm run build`
- `npm run test:product-release` (32/32)
- `npx biome check scripts/product-release.test.mjs`
- `git diff --check`
- mutation: deleting the production marker invalidation makes the new targeted test fail
