### PR TITLE
test(mcp): stabilize refresh budget synchronization

### DIFF
--- a/packages/mcp/src/__tests__/manager.test.ts
+++ b/packages/mcp/src/__tests__/manager.test.ts
@@ -749,7 +749,9 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
       );
     });
 
-    test('gives spaced list-changed notifications independent refresh budgets', async () => {
+    test('gives spaced list-changed notifications independent refresh budgets', {
+      timeout: 30_000,
+    }, async () => {
       const fixture = await createRemoteFixture('sse');
       let now = 0;
       const manager = createManager({ now: () => now });
@@ -757,8 +759,23 @@ describe('McpClientManager E2E', { concurrency: false }, () => {
 
       for (let change = 1; change <= 4; change += 1) {
         now += 1_000;
+        const refreshCompleted = new Promise<void>((resolve) => {
+          const unsubscribe = manager.onChange((status) => {
+            if (
+              status.serverId !== 'remote' ||
+              status.state !== 'connected' ||
+              status.updatedAt !== now ||
+              status.error !== undefined
+            ) {
+              return;
+            }
+            unsubscribe();
+            resolve();
+          });
+        });
         await fixture.notifyToolListChanged();
-        await waitFor(() => countProtocolMethod(fixture, 'tools/list') === change + 1);
+        await refreshCompleted;
+        assert.equal(countProtocolMethod(fixture, 'tools/list'), change + 1);
       }
 
       assert.equal(manager.status('remote')?.error, undefined);


### PR DESCRIPTION
## Summary

Make the spaced `list-changed` refresh-budget E2E test wait for the manager's successful refresh publication instead of polling `tools/list` requests against a one-second wall-clock deadline. This keeps the production refresh behavior unchanged while retaining a bounded whole-test timeout for genuine non-convergence.

Fixes #3307

## Verification

- `npm run lint` — passed (2,623 files)
- `npm run format:check` — passed (1,603 files)
- `npm --workspace @maka/mcp run typecheck` — passed
- `npm --workspace @maka/mcp run test:dist` — passed (171 tests)
- Targeted refresh-budget test repetitions — passed (20/20 on the latest base; 50/50 before the final rebase)
- `npm run build` — Core, Storage, and MCP passed; the full command stopped in unrelated `@maka/runtime` compilation because the shared local dependency tree lacks `@slack/web-api` / `@slack/socket-mode` and exposes a mismatched `HttpsProxyAgent` type
- `npm run typecheck` — affected MCP workspace passed; the aggregate command reported the same unrelated local `@maka/runtime` dependency errors above

The pre-change failure is load-sensitive rather than deterministic on every local run; the linked issue records the failing CI run and a code-identical successful rerun.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex assisted with diagnosis, the test synchronization change, verification, and PR preparation. The commit carries `Generated-by: Codex`; CuSO41108 is the human contributor of record.

## Checklist

- [x] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [ ] Yes — described under Summary above
- [x] No