### PR TITLE
chore(release): set product version to 0.2.0

### DIFF
--- a/.github/ASF_NPM_RELEASE.md
+++ b/.github/ASF_NPM_RELEASE.md
@@ -53,7 +53,7 @@ Dispatch **Validate ASF npm package from source RC** from the exact source
 candidate tag:
 
 ```sh
-version=0.1.11
+version="$(node -p 'require("./package.json").version')"
 rc=1
 source_reference_tag="v${version}-incubating-rc${rc}"
 gh workflow run asf-npm-candidate.yml --ref "$source_reference_tag"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ## Unreleased
 
+## 0.2.0 - Unreleased
+
 ### Added
 
 - Added `/transcript` to browse long TUI sessions without depending on terminal

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@maka/desktop",
   "productName": "Maka",
   "description": "A local-first agent workspace built for real work.",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "author": "The Maka Authors",
   "license": "Apache-2.0",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maka",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maka",
-      "version": "0.1.11",
+      "version": "0.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
@@ -39,7 +39,7 @@
     },
     "apps/desktop": {
       "name": "@maka/desktop",
-      "version": "0.1.11",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@jackwener/opencli": "1.8.6",
@@ -13506,7 +13506,7 @@
     },
     "packages/cli": {
       "name": "maka-agent",
-      "version": "0.1.11",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-tui": "0.83.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maka",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "private": true,
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maka-agent",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Set the first Apache Maka product release version to `0.2.0`.

The root `package.json` remains the single product-version authority. The Desktop and CLI manifests are synchronized mirrors enforced by the release identity checks, and `package-lock.json` is updated mechanically for those three package entries. The ASF npm runbook now reads the root manifest instead of hard-coding another version value.

The current release notes are assigned to `## 0.2.0 - Unreleased`; the placeholder will be replaced with the real release date when the release is completed. Historical changelog entries, compatibility fixtures, and private workspace `0.1.0` versions remain unchanged.

This does not publish an npm package, create a release tag, or move a dist-tag.

Refs #3275

## Verification

- `node --test --test-concurrency=4 scripts/product-release.test.mjs scripts/asf-source-release.test.mjs scripts/release-cli-publication.test.mjs scripts/release-cli-workflow-policy.test.mjs` (54/54 passed)
- `npm run check:product-release-identity`
- `npm run test:product-release` (31/31 passed after the changelog update)
- `npx biome format package.json apps/desktop/package.json packages/cli/package.json package-lock.json`
- `SOURCE_REFERENCE_TAG=v0.2.0-incubating-rc1 EXPECTED_PRODUCT_VERSION=0.2.0 node scripts/product-release-identity.mjs`
- `SOURCE_REFERENCE_TAG=v0.2.0-incubating-rc1 node scripts/product-release-artifacts.mjs list`
- `npm run release:cli:pack` produced `maka-agent-0.2.0.tgz` from an isolated committed source tree; SHA-256 `49290db67b96d13001e8d22126f13ec070d96987308cc52cf4ec113b0e1a4e79`

## Review focus

Please verify that the root manifest remains the only product-version authority, that the synchronized Desktop, CLI, lockfile, and runbook changes introduce no parallel version source, and that the changelog now assigns the release notes to 0.2.0 without inventing a release date before the vote completes.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex traced the existing release identity consumers, applied the manifest/lockfile/runbook/changelog update, and ran the focused release validation. The human contributor remains responsible for the final diff and release decision.

## Checklist

- [ ] Tests cover the change and fail without it
- [x] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No
