### PR TITLE
fix(runtime-host): bind managed retirement to one service generation

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -1020,6 +1020,73 @@ describe('managed Runtime Host service', () => {
     assert.equal(serviceState, 'stopped');
   });
 
+  it('fails closed without stopping a successor that won the State Root', async (t) => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-retirement-generation-'));
+    t.after(() => rm(base, { recursive: true, force: true }));
+    const clientDataRoot = join(base, 'config');
+    const root = await resolveStorageRoot({ path: join(base, 'state'), kind: 'interactive' });
+    const cliPath = join(base, 'cli.js');
+    await writeFile(cliPath, '#!/usr/bin/env node\n', 'utf8');
+    let serviceState: 'running' | 'stopped' = 'running';
+    let servicePid: number | null = 42;
+    let stops = 0;
+    let successor: Awaited<ReturnType<typeof tryAcquireInteractiveRootOwner>>;
+    const backend: RuntimeHostServiceBackend = {
+      ...createReadyBackend(),
+      status: async () => ({
+        manager: 'systemd_user',
+        installed: true,
+        enabled: true,
+        active: serviceState === 'running',
+        state: serviceState,
+        pid: serviceState === 'running' ? servicePid : null,
+        lastExitCode: 0,
+      }),
+      stop: async () => {
+        stops += 1;
+        serviceState = 'stopped';
+        servicePid = null;
+      },
+    };
+    const common = {
+      clientDataRoot,
+      defaultRootPath: root.canonicalPath,
+      nodePath: process.execPath,
+      cliPath,
+    } as const;
+    await manageRuntimeHostService({ ...common, action: 'install' }, backend, {
+      waitForReady: async () => undefined,
+    });
+    const expectedTarget = {
+      serviceId: resolveRuntimeHostManagedServiceId(clientDataRoot),
+      rootPath: root.canonicalPath,
+      rootId: root.rootId,
+    } as const;
+    await assert.rejects(
+      manageRuntimeHostService(
+        { ...common, action: 'retire', expectedTarget, allowInterruptActiveTasks: true },
+        backend,
+        {
+          prepareRetirement: async (
+            _config: RuntimeHostManagedServiceConfig,
+            expectedPid: number,
+          ) => {
+            assert.equal(expectedPid, 42);
+            successor = await tryAcquireInteractiveRootOwner(root);
+            assert.ok(successor);
+            servicePid = 43;
+            return { kind: 'prepared', hostEpoch: 'host-a', pid: expectedPid } as const;
+          },
+        },
+      ),
+      (error: unknown) =>
+        error instanceof RuntimeHostServiceManagerError && error.code === 'retirement_failed',
+    );
+    assert.equal(stops, 0);
+    assert.equal(servicePid, 43);
+    await successor?.close();
+  });
+
   it('restores the deployed service when the replacement never becomes ready', async (t) => {
     const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-service-rollback-'));
     t.after(() => rm(base, { recursive: true, force: true }));

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -387,6 +387,7 @@ async function manageRuntimeHostServiceLocked(
         return { schemaVersion: 1, action: input.action, service, retirement };
       }
       prepared = retirement;
+      rootFence = await acquirePreparedRuntimeHostRootRetirementFence(root, prepared.pid, backend);
     } else if (service.active) {
       throw new RuntimeHostServiceManagerError(
         'retirement_failed',
@@ -946,6 +947,31 @@ async function acquireRuntimeHostRootRetirementFence(
       { cause: error },
     );
   }
+}
+
+async function acquirePreparedRuntimeHostRootRetirementFence(
+  root: StorageRootCapability<'interactive'>,
+  expectedPid: number,
+  backend: RuntimeHostServiceBackend,
+): Promise<InteractiveRootOwner> {
+  const deadline = Date.now() + SERVICE_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const owner = await tryAcquireInteractiveRootOwner(root);
+    const status = await backend.status();
+    if (status.pid !== null && status.pid !== expectedPid) {
+      await owner?.close().catch(() => undefined);
+      throw new RuntimeHostServiceManagerError(
+        'retirement_failed',
+        'Runtime Host service identity changed before retirement could stop the prepared Host',
+      );
+    }
+    if (owner) return owner;
+    await new Promise<void>((resolveWait) => setTimeout(resolveWait, SERVICE_READY_POLL_MS));
+  }
+  throw new RuntimeHostServiceManagerError(
+    'retirement_failed',
+    'The prepared Runtime Host did not release the State Root writer before retirement timed out',
+  );
 }
 
 async function releaseRuntimeHostRootRetirementFence(owner: InteractiveRootOwner): Promise<void> {


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

Fix the managed Runtime Host retirement identity gap from #3583.

After an exact Host passes `host.upgrade.prepare`, the CLI now waits for that Host to release the State Root writer, verifies that the managed service PID has not changed, and holds the writer fence across `backend.stop()` and the stable-stopped check. If a successor changes the service identity or wins the State Root first, retirement fails closed before calling `stop`, instead of stopping the successor as if it were the prepared Host.

The existing PID-less/startup fence path and normal retirement tests remain unchanged. The new regression models Host A crashing, Host B acquiring the State Root, and verifies that `stop` is not called.

Fixes #3583

## Verification

- `node --test packages/cli/dist/__tests__/runtime-host-service-manager.test.js` — 17 passed, including the new successor-generation regression.
- `npx biome check packages/cli/src/runtime-host-service-manager.ts packages/cli/src/__tests__/runtime-host-service-manager.test.ts` — passed.
- `git diff --check` — passed.
- The current-main CLI typecheck is blocked by two existing errors in `packages/cli/src/pi-transcript.ts:512,515` (`CompleteEvent.contextCompactionOutcome` is missing); neither changed file contributes an error.
- The repository `npm run build:test` is likewise not a clean baseline on this head: it reaches unrelated current-main UI type errors in `packages/ui`.

## Root cause

The previous PID-known retirement path validated Host A before `prepare`, but did not carry generation authority through service stop. A crash after prepare could let `Restart=always` start Host B, after which `systemctl stop` stopped B while the result still reported A as retired.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: OpenAI Codex contributed substantively to the bounded runtime-host implementation and regression test under human direction. The human contributor owns review and submission. The commit retains the `Generated-by: Codex` trailer.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally — typecheck remains blocked by the unrelated current-main errors listed above.

Does this PR entail a change in behavior?

- [x] Yes — managed retirement now fails closed on a service-generation or State Root identity change instead of stopping a successor.
- [ ] No

</details>

<details>
<summary>简体中文</summary>

## 概要

修复 #3583 中 managed Runtime Host 退场时的 service generation identity gap。

精确 Host 通过 `host.upgrade.prepare` 后，CLI 现在会等待该 Host 释放 State Root writer，确认 managed service PID 没有变化，并在 `backend.stop()` 与稳定 stopped 检查期间持有 writer fence。如果 successor 改变 service identity 或先取得 State Root，退场会在调用 `stop` 前 fail closed，而不会把 successor 当成原先准备退场的 Host 停掉。

现有的 PID-less/startup fence 路径与正常退场测试保持不变。新增回归测试模拟 Host A 异常退出、Host B 取得 State Root，并确认不会调用 `stop`。

修复 #3583

## 验证

- `node --test packages/cli/dist/__tests__/runtime-host-service-manager.test.js`：17 项通过，包含 successor generation 回归测试。
- 两个变更文件的 `npx biome check`：通过。
- `git diff --check`：通过。
- 当前 main 的 CLI typecheck 被 `packages/cli/src/pi-transcript.ts:512,515` 的两个既有错误阻塞（`CompleteEvent.contextCompactionOutcome` 缺失）；两个变更文件没有产生 typecheck 错误。
- `npm run build:test` 同样被当前 main 中无关的 `packages/ui` 类型错误阻塞。

## 根因

原 PID-known 退场路径只在 `prepare` 前验证 Host A，没有把 generation authority 延续到 service stop。如果 A 在 prepare 后异常退出，`Restart=always` 可能启动 Host B；之后 `systemctl stop` 实际停止 B，但结果仍会报告 A 已退场。

## AI 使用

- [ ] 无生成式工具实质参与
- [x] 生成式工具有实质参与

工具与范围：OpenAI Codex 在人工指导下实质参与了限定范围的 runtime-host 实现与回归测试。人工贡献者负责 review 与提交。commit 保留 `Generated-by: Codex` trailer。

## 检查清单

- [x] 测试覆盖该变更，且缺少该变更时会失败
- [ ] lint、format、typecheck 与受影响测试套件均已在本地通过——typecheck 仍被上述无关的 current-main 错误阻塞。

本 PR 是否改变行为？

- [x] 是——managed retirement 在 service generation 或 State Root identity 变化时 fail closed，不再误停 successor。
- [ ] 否

</details>
