### PR TITLE
fix(runtime-host): fence State Root before service retirement

### DIFF
--- a/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
+++ b/packages/cli/src/__tests__/runtime-host-service-manager.test.ts
@@ -888,6 +888,7 @@ describe('managed Runtime Host service', () => {
     let startingPid: number | null = null;
     let stops = 0;
     let observedStartingFence = false;
+    let publishPidlessSuccessor = false;
     const backend: RuntimeHostServiceBackend = {
       ...createReadyBackend(),
       status: async () => ({
@@ -930,6 +931,10 @@ describe('managed Runtime Host service', () => {
         allow: boolean,
       ) => {
         assert.equal(expectedPid, 42);
+        if (publishPidlessSuccessor) {
+          serviceState = 'starting';
+          startingPid = null;
+        }
         return allow
           ? ({ kind: 'prepared', hostEpoch: 'host-1', pid: 42 } as const)
           : ({ kind: 'active_tasks' } as const);
@@ -1018,6 +1023,26 @@ describe('managed Runtime Host service', () => {
       pid: 42,
     });
     assert.equal(serviceState, 'stopped');
+
+    serviceState = 'running';
+    publishPidlessSuccessor = true;
+    const stopsBeforeSuccessor = stops;
+    await assert.rejects(
+      manageRuntimeHostService(
+        {
+          ...common,
+          action: 'retire',
+          expectedTarget,
+          allowInterruptActiveTasks: true,
+        },
+        backend,
+        deps,
+      ),
+      (error: unknown) =>
+        error instanceof RuntimeHostServiceManagerError && error.code === 'retirement_failed',
+    );
+    assert.equal(stops, stopsBeforeSuccessor);
+    assert.equal(serviceState, 'starting');
   });
 
   it('fails closed without stopping a successor that won the State Root', async (t) => {

--- a/packages/cli/src/runtime-host-service-manager.ts
+++ b/packages/cli/src/runtime-host-service-manager.ts
@@ -958,7 +958,10 @@ async function acquirePreparedRuntimeHostRootRetirementFence(
   while (Date.now() < deadline) {
     const owner = await tryAcquireInteractiveRootOwner(root);
     const status = await backend.status();
-    if (status.pid !== null && status.pid !== expectedPid) {
+    if (
+      status.pid !== expectedPid &&
+      !(status.pid === null && !status.active && status.state === 'stopped')
+    ) {
       await owner?.close().catch(() => undefined);
       throw new RuntimeHostServiceManagerError(
         'retirement_failed',


### PR DESCRIPTION
## Summary

`host.upgrade.prepare` only starts the Runtime Host's asynchronous drain. Before
this change, the PID-known retirement path called `backend.stop()` immediately
after preparation.

If the prepared Host exited unexpectedly, systemd could restart the same service
unit with a successor Host. Stopping the unit at that point could stop the
successor instead of the prepared Host.

This change:

- waits for the prepared Host to release the State Root;
- acquires a retirement fence before calling `backend.stop()`;
- rechecks the service PID while the fence is unavailable;
- fails closed when the Host identity changes or the fence deadline expires;
- keeps the post-stop State Root check as a cleanup verification, rather than
  treating it as proof of continuous Host identity.

Fixes #3594

## Verification

- `npm run build:test` — passed.
- `npm --workspace @maka/core run build` — passed.
- `npm --workspace maka-agent run build` — passed.
- `npm --workspace maka-agent run typecheck` — passed.
- `npx biome check packages/cli/src/runtime-host-service-manager.ts packages/cli/src/__tests__/runtime-host-service-manager.test.ts` — passed.
- `git diff --check` — passed.
- Regression test for successor replacement — passed.
- Regression test for normal Host draining and State Root fencing — passed.
- The complete service-manager test file still has unrelated Windows `fsync`
  and symlink `EPERM` failures.
- Linux/systemd runtime verification has not been performed yet.

## Review focus

The important safety property is that `backend.stop()` is not called until the
retirement process owns the State Root fence. If a successor has already
acquired the State Root, retirement fails without stopping the service unit.

## AI use

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope:

Codex was used for repository analysis, implementation design, production code,
regression tests, verification, and PR description drafting.

## Checklist

- [x] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — managed Runtime Host retirement now fails closed when Host identity
  or State Root ownership cannot be safely fenced.
- [ ] No