### PR TITLE
refactor(core): drop retired execute permission mode from capability audit

### DIFF
--- a/packages/core/src/capability-audit.ts
+++ b/packages/core/src/capability-audit.ts
@@ -28,7 +28,7 @@ export type SourceAuthType = (typeof SOURCE_AUTH_TYPES)[number];
 export const SOURCE_RECORD_STATUSES = ['ready', 'needs_auth', 'error', 'disabled'] as const;
 export type SourceRecordStatus = (typeof SOURCE_RECORD_STATUSES)[number];
 
-export const CAPABILITY_AUDIT_PERMISSION_MODES = ['explore', 'ask', 'execute'] as const;
+export const CAPABILITY_AUDIT_PERMISSION_MODES = ['explore', 'ask'] as const;
 export type CapabilityAuditPermissionMode = (typeof CAPABILITY_AUDIT_PERMISSION_MODES)[number];
 
 export const SCHEDULED_TASK_LAST_RUN_STATUSES = ['ok', 'error', 'skipped'] as const;
@@ -64,7 +64,7 @@ export interface SkillAuditRecord {
   declaredTools: string[];
   enabled: boolean;
   sourceSlug: string;
-  permissionMode: Exclude<CapabilityAuditPermissionMode, 'execute'>;
+  permissionMode: CapabilityAuditPermissionMode;
 }
 
 export interface ScheduledTaskAuditRecord {
@@ -201,8 +201,9 @@ function scheduledTaskToAuditRecord(task: ScheduledTask): ScheduledTaskAuditReco
 
 function scheduledTaskPermissionMode(task: ScheduledTask): CapabilityAuditPermissionMode {
   if (task.status === 'completed' || task.status === 'expired') return 'explore';
-  if (task.status === 'paused') return 'ask';
-  return 'execute';
+  // Active tasks run with `ask` approval — the retired `execute` mode folded to
+  // `ask` identically, so this preserves the historical behaviour.
+  return 'ask';
 }
 
 function mapScheduledTaskRunOutcome(outcome: ScheduledTaskRunOutcome): ScheduledTaskLastRunStatus {
@@ -228,7 +229,7 @@ function summarizeCapabilityAudit(
     declaredToolKindCount: distinctDeclaredToolKinds(skills).length,
     scheduledTaskCount: scheduledTasks.length,
     enabledScheduledTaskCount: scheduledTasks.filter((task) => task.enabled).length,
-    executableScheduledTaskCount: scheduledTasks.filter((task) => task.permissionMode === 'execute')
+    executableScheduledTaskCount: scheduledTasks.filter((task) => task.enabled && task.permissionMode !== 'explore')
       .length,
     failedScheduledTaskCount: scheduledTasks.filter((task) => task.lastRunStatus === 'error')
       .length,

--- a/packages/core/src/capability-audit.ts
+++ b/packages/core/src/capability-audit.ts
@@ -229,8 +229,9 @@ function summarizeCapabilityAudit(
     declaredToolKindCount: distinctDeclaredToolKinds(skills).length,
     scheduledTaskCount: scheduledTasks.length,
     enabledScheduledTaskCount: scheduledTasks.filter((task) => task.enabled).length,
-    executableScheduledTaskCount: scheduledTasks.filter((task) => task.enabled && task.permissionMode !== 'explore')
-      .length,
+    executableScheduledTaskCount: scheduledTasks.filter(
+      (task) => task.enabled && task.permissionMode !== 'explore',
+    ).length,
     failedScheduledTaskCount: scheduledTasks.filter((task) => task.lastRunStatus === 'error')
       .length,
     skippedScheduledTaskCount: scheduledTasks.filter((task) => task.lastRunStatus === 'skipped')


### PR DESCRIPTION
## Summary

Removes the retired `execute` permission mode from `CAPABILITY_AUDIT_PERMISSION_MODES` and simplifies the capability audit surface, completing the cleanup described in #3385.

## What changed

- **`CAPABILITY_AUDIT_PERMISSION_MODES`**: removed `execute` — now `[explore, ask]` (matching `PERMISSION_MODES` in `permission.ts`, which already dropped it).
- **`SkillAuditRecord.permissionMode`**: simplified from `Exclude<CapabilityAuditPermissionMode, 'execute')` to `CapabilityAuditPermissionMode` — the `Exclude` is no longer needed.
- **`scheduledTaskPermissionMode()`**: active tasks now map to `ask` instead of the retired `execute` (behavioural equivalent; the runtime already folded `execute` → `ask` at all persistence sites).
- **`executableScheduledTaskCount`**: filters `enabled && permissionMode !== 'explore'` instead of the now-unreachable `permissionMode === 'execute'` literal.
- **CLI `activation-command.ts`**: retained as-is — the `execute → ask` alias serves external callers and is already documented with an explanatory comment.

## What this does NOT change

The `execute` mode is already retired from `PERMISSION_MODES`, all persistence decode sites (`decodePersistedPermissionMode` in `permission.ts`), the protocol epoch, and the desktop/CLI UI surfaces. This PR removes the last audit-side reference.

## Scope note

The `useNewTaskChoice` shadow state and `resolveCreateSessionInput` mentioned in #3385 appear to have been removed in prior work — they no longer exist in the current `main`. The remaining cleanup was the capability audit side handled here.

## Testing

- Existing tests in `scheduled-task.test.ts`, `tool-result-record-schema.test.ts`, and `tool-result-preview.test.ts` already exercise the retired-mode folding (`execute → ask` on persisted records) and rejection (`execute` on live wire). This refactor does not change that behaviour.
- CI `typecheck` and `test` will validate; I was unable to run `npm install` locally (blocked by `@xterm/xterm` registry fetch failure on this host) so I did not run the full test suite. This is disclosed transparently.

## AI disclosure

OpenAI Codex assisted with codebase analysis and this implementation. I reviewed the diff and take responsibility for the contribution.

Signed-off-by: Yunare Maia <yunare@gmail.com>