### PR TITLE
fix(desktop): align sidebar chrome actions

### DIFF
--- a/apps/desktop/e2e/sidebar-titlebar-actions.spec.ts
+++ b/apps/desktop/e2e/sidebar-titlebar-actions.spec.ts
@@ -19,10 +19,13 @@
 
 import { expect, test } from './fixtures';
 
-test('search and sidebar controls align to the sidebar right edge', async ({ window }) => {
+test('expanded sidebar chrome follows Astryx toolbar geometry', async ({ window }) => {
   const sidebar = window.getByRole('navigation', { name: '任务列表' });
   const actions = window.locator('[data-maka-contract="shell-topbar-rail"]');
+  const expandSidebar = window.getByRole('button', { name: '展开侧边栏' });
 
+  if (await expandSidebar.isVisible()) await expandSidebar.click();
+  await expect(window.getByRole('button', { name: '收起侧边栏' })).toBeVisible();
   await expect(sidebar).toBeVisible();
   await expect(actions).toBeVisible();
 
@@ -34,4 +37,5 @@ test('search and sidebar controls align to the sidebar right edge', async ({ win
   const trailingInset = sidebarBox!.x + sidebarBox!.width - (actionsBox!.x + actionsBox!.width);
   expect(trailingInset).toBeGreaterThanOrEqual(0);
   expect(trailingInset).toBeLessThanOrEqual(16);
+  await expect(actions).toHaveCSS('column-gap', '4px');
 });

--- a/apps/desktop/e2e/sidebar-titlebar-actions.spec.ts
+++ b/apps/desktop/e2e/sidebar-titlebar-actions.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, test } from './fixtures';
+
+test('search and sidebar controls align to the sidebar right edge', async ({ window }) => {
+  const sidebar = window.getByRole('navigation', { name: '任务列表' });
+  const actions = window.locator('[data-maka-contract="shell-topbar-rail"]');
+
+  await expect(sidebar).toBeVisible();
+  await expect(actions).toBeVisible();
+
+  const sidebarBox = await sidebar.boundingBox();
+  const actionsBox = await actions.boundingBox();
+  expect(sidebarBox).not.toBeNull();
+  expect(actionsBox).not.toBeNull();
+
+  const trailingInset = sidebarBox!.x + sidebarBox!.width - (actionsBox!.x + actionsBox!.width);
+  expect(trailingInset).toBeGreaterThanOrEqual(0);
+  expect(trailingInset).toBeLessThanOrEqual(16);
+});

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -324,7 +324,8 @@ dialog:modal {
   justify-self: end;
   display: flex;
   align-items: center;
-  gap: var(--space-2);
+  /* Astryx Toolbar spaces independent actions by spacing-1 (4px). */
+  gap: var(--space-1);
   opacity: 1;
   pointer-events: auto;
   transform: translateX(0);

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -317,7 +317,11 @@ dialog:modal {
 
 .maka-shell-topbar-rail {
   grid-column: 1;
-  justify-self: start;
+  /* These controls operate on the sidebar, so their anchor is its trailing
+     edge — not the platform-safe area's leading edge beside the traffic
+     lights. The first titlebar grid track already ends one gap before the
+     sidebar seam and follows the user-resized sidebar width. */
+  justify-self: end;
   display: flex;
   align-items: center;
   gap: var(--space-2);


### PR DESCRIPTION
## Summary

Move the search and sidebar-toggle controls from the leading edge of the titlebar to the sidebar's trailing edge. The controls now follow the resizable sidebar width, no longer sit beside the macOS traffic lights, and use Astryx Toolbar's standard 4px spacing for independent actions.

Refs #3343

## Screenshot

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/21069654-49ce-4734-b3f0-99cb71a42291" />

## Verification

- `npm --workspace @maka/desktop run build:with-deps`
- `npx biome check apps/desktop/src/renderer/styles/shell-layout.css apps/desktop/e2e/sidebar-titlebar-actions.spec.ts`
- Storybook geometry check at 1200×800: trailing inset `8px`, action-group gap `4px`
- Added `sidebar-titlebar-actions.spec.ts` to guard expanded-sidebar alignment and Astryx spacing. The focused Electron run was not completed locally because the app fixture timed out during launch in this environment; CI exposed that its fixture starts collapsed, and the test now establishes its expanded-state premise before measuring.

## AI use

Select exactly one:

- [ ] No generative tool made a substantive contribution
- [x] Generative tooling made a substantive contribution

Tool(s) and scope: Maka inspected the existing titlebar layout, implemented the CSS alignment change, added the geometry regression test, and prepared the Storybook evidence and PR text. The contributor should verify the final diff, screenshot, and claims before merge.

## Checklist

- [ ] Tests cover the change and fail without it
- [ ] Lint, format, typecheck and the affected suites pass locally

Does this PR entail a change in behavior?

- [x] Yes — described under Summary above
- [ ] No


